### PR TITLE
Update README with missing environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ To get the project up and running on your local machine, follow these steps:
     - `CLICKHOUSE_HOST`: ClickHouse host, for example `http://localhost:8123`
     - `CLICKHOUSE_USER`: ClickHouse user with permission to query the `system` database.
     - `CLICKHOUSE_PASSWORD`: ClickHouse password for the specified user.
+    - `CLICKHOUSE_TIMEOUT`: Timeout for ClickHouse queries in milliseconds. Default is `100000`.
 4. Run the development server with `npm run dev` or `yarn dev`
 5. Open [http://localhost:3000](http://localhost:3000) in your browser to see the dashboard.
 


### PR DESCRIPTION
Related to #225

Updates the `README.md` file to enhance the project's setup and deployment documentation.

- Adds the `CLICKHOUSE_TIMEOUT` environment variable to the "Getting Started" section, including a brief description and default value, ensuring users are aware of how to configure timeout settings for ClickHouse queries.
- No changes were made to the "Deployment" section regarding the `NODE_ENV` environment variable as initially planned.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/duyet/clickhouse-monitoring/issues/225?shareId=418f5057-da71-4053-ae83-a932b0afc092).