### PR TITLE
Add 30-minute refresh interval option

### DIFF
--- a/components/reload-button.tsx
+++ b/components/reload-button.tsx
@@ -87,6 +87,9 @@ export function ReloadButton({ className }: ReloadButtonProps) {
         <DropdownMenuItem onClick={() => setReloadInterval(10 * 60 * 1000)}>
           10m
         </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setReloadInterval(1800000)}>
+          30m
+        </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={() => setReloadInterval(null)}>
           Disable Auto


### PR DESCRIPTION
Related to #227

Adds a new 30-minute refresh interval option to the `ReloadButton` component in `components/reload-button.tsx`.
- Introduces a `DropdownMenuItem` for a 30-minute (1800000 milliseconds) refresh interval, allowing users to select this new option for auto-refreshing the page.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/duyet/clickhouse-monitoring/issues/227?shareId=347b7ae3-b3ef-49fe-ac0b-f4cbdd9bcf2c).