### PR TITLE
Add chart for ZooKeeper metrics

### DIFF
--- a/app/[query]/more/zookeeper.ts
+++ b/app/[query]/more/zookeeper.ts
@@ -36,4 +36,14 @@ export const zookeeperConfig: QueryConfig = {
     updated_at: ColumnFormat.RelatedTime,
   },
   defaultParams: { path: '/' },
+  relatedCharts: [
+    [
+      'ZooKeeperRequestsChart',
+      {
+        title: 'ZooKeeper Requests Over Time',
+        interval: 'toStartOfHour',
+        lastHours: 24 * 7,
+      },
+    ],
+  ],
 }

--- a/components/charts/zookeeper-requests.tsx
+++ b/components/charts/zookeeper-requests.tsx
@@ -1,0 +1,44 @@
+import { ChartCard } from '@/components/chart-card'
+import { AreaChart } from '@/components/tremor/area'
+import { fetchData } from '@/lib/clickhouse'
+import { type ChartProps } from './chart-props'
+
+const ZooKeeperRequestsChart = async ({
+  title = 'ZooKeeper Requests Over Time',
+  interval = 'toStartOfHour',
+  lastHours = 24 * 7,
+  className,
+}: ChartProps) => {
+  const query = `
+    SELECT
+      ${interval}(event_time) AS event_time,
+      SUM(CurrentMetric_ZooKeeperRequest) AS requests
+    FROM system.metric_log
+    WHERE event_time >= now() - INTERVAL ${lastHours} HOUR
+    GROUP BY event_time
+    ORDER BY event_time
+  `
+
+  const data = await fetchData<
+    {
+      event_time: string
+      requests: number
+    }[]
+  >({
+    query,
+    format: 'JSONEachRow',
+  })
+
+  return (
+    <ChartCard title={title} sql={query} className={className}>
+      <AreaChart
+        data={data}
+        index="event_time"
+        categories={['requests']}
+        className="h-52"
+      />
+    </ChartCard>
+  )
+}
+
+export default ZooKeeperRequestsChart


### PR DESCRIPTION
Resolved #231

This pull request introduces a new chart for visualizing ZooKeeper request metrics over time on the `/zookeeper` table, enhancing the monitoring capabilities of the Clickhouse monitoring tool.

- **Adds a new chart component**: Implements `ZooKeeperRequestsChart` in `components/charts/zookeeper-requests.tsx` to display the `CurrentMetric_ZooKeeperRequest` metric using an area chart. This component fetches data from `system.metric_log` and visualizes the number of ZooKeeper requests over a configurable time interval.
- **Updates the ZooKeeper query configuration**: Modifies `app/[query]/more/zookeeper.ts` to include a reference to the new `ZooKeeperRequestsChart` component in the `relatedCharts` property of the `zookeeperConfig` object. This addition ensures the new chart is displayed alongside the existing data table on the `/zookeeper` page.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/duyet/clickhouse-monitoring/issues/231?shareId=169b8c99-baa0-4962-a4f3-702f919ffcae).