### PR TITLE
feat: add /projection

### DIFF
--- a/app/[query]/clickhouse-queries.ts
+++ b/app/[query]/clickhouse-queries.ts
@@ -22,6 +22,7 @@ import { queryCacheConfig } from './queries/query-cache'
 import { runningQueriesConfig } from './queries/running-queries'
 import { detachedPartsConfig } from './tables/detached-parts'
 import { distributedDdlQueueConfig } from './tables/distributed-ddl-queue'
+import { projectionsConfig } from './tables/projections'
 import { readOnlyTablesConfig } from './tables/readonly-tables'
 import { replicasConfig } from './tables/replicas'
 import { replicationQueueConfig } from './tables/replication-queue'
@@ -35,6 +36,7 @@ export const queries: Array<QueryConfig> = [
   replicationQueueConfig,
   readOnlyTablesConfig,
   detachedPartsConfig,
+  projectionsConfig,
 
   // Queries
   queryCacheConfig,

--- a/app/[query]/tables/projections.ts
+++ b/app/[query]/tables/projections.ts
@@ -1,0 +1,54 @@
+import { ColumnFormat } from '@/lib/types/column-format'
+import { type QueryConfig } from '@/lib/types/query-config'
+
+export const projectionsConfig: QueryConfig = {
+  name: 'projections',
+  description: `Projection size. https://clickhouse.com/docs/en/sql-reference/statements/alter/projection`,
+  sql: `
+      SELECT
+          database,
+          table,
+          name,
+          (sum(data_compressed_bytes) AS size) AS compressed,
+          (sum(data_uncompressed_bytes) AS usize) AS uncompressed,
+          formatReadableSize(compressed) AS readable_compressed,
+          formatReadableSize(uncompressed) AS readable_uncompressed,
+          round(100 * compressed / max(compressed) OVER ()) AS pct_compressed,
+          round(100 * uncompressed / max(uncompressed) OVER ()) AS pct_uncompressed,
+          round(uncompressed / compressed, 2) AS compr_rate,
+          round(100 * compr_rate / max(compr_rate) OVER ()) AS pct_compr_rate,
+          sum(rows) AS rows,
+          formatReadableQuantity(rows) AS readable_rows,
+          round(100 * rows / max(rows) OVER ()) AS pct_rows,
+          count() AS part_count,
+          round(100 * part_count / max(part_count) OVER ()) AS pct_part_count
+      FROM system.projection_parts
+      WHERE active
+      GROUP BY
+          database,
+          table,
+          name
+      ORDER BY compressed DESC
+  `,
+  columns: [
+    'database',
+    'table',
+    'name',
+    'readable_compressed',
+    'readable_uncompressed',
+    'compr_rate',
+    'readable_rows',
+    'part_count',
+  ],
+  columnFormats: {
+    readable_compressed: ColumnFormat.BackgroundBar,
+    readable_uncompressed: ColumnFormat.BackgroundBar,
+    compr_rate: ColumnFormat.BackgroundBar,
+    readable_rows: ColumnFormat.BackgroundBar,
+    part_count: ColumnFormat.BackgroundBar,
+  },
+  defaultParams: {
+    table: 'default.default',
+  },
+  relatedCharts: [],
+}

--- a/menu.ts
+++ b/menu.ts
@@ -86,8 +86,15 @@ export const menuItemsConfig: MenuItem[] = [
       {
         title: 'Top Usage Tables',
         href: '/top-usage-tables',
-        description: 'Most usage tables, ignore system tables (top 50)',
+        description: 'Most used tables, excluding system tables',
         icon: TextAlignBottomIcon,
+      },
+      {
+        title: 'Projections',
+        href: '/projections',
+        description:
+          'Projections store data in a format that optimizes query execution',
+        icon: DatabaseZapIcon,
       },
     ],
   },


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new 'Projection' feature, including a menu item and a query configuration for displaying projection size data from ClickHouse. Additionally, it updates the description of the 'Top Usage Tables' menu item for better clarity.

- **New Features**:
    - Added a new menu item 'Projection' with a description and icon.
    - Introduced a new query configuration 'projectionConfig' for fetching and displaying projection size data from ClickHouse.
- **Enhancements**:
    - Updated the description of the 'Top Usage Tables' menu item for clarity.

<!-- Generated by sourcery-ai[bot]: end summary -->