### PR TITLE
feat: /database page redirect invalid database to the first one existing

### DIFF
--- a/app/database/queries.ts
+++ b/app/database/queries.ts
@@ -6,11 +6,10 @@ export const listDatabases = `
         engine
     FROM system.tables
   )
-
   SELECT d.name as name,
          countDistinct(t.table) as count
   FROM system.databases AS d
-  LEFT JOIN tables_from_tables AS t USING database
+  JOIN tables_from_tables AS t USING database
   WHERE d.engine != 'Memory'
   GROUP BY d.name
 `


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a feature that redirects users to the first existing database if the specified database is invalid on the /database page. Additionally, it enhances the database query by changing the join type from left join to inner join for improved accuracy in fetching database names and table counts.

- **New Features**:
    - Added a redirect to the first existing database if the current database is invalid on the /database page.
- **Enhancements**:
    - Updated the database query to use an inner join instead of a left join for fetching database names and table counts.

<!-- Generated by sourcery-ai[bot]: end summary -->