### PR TITLE
feat: link from `/tables-overview` to `/tables/[database]/[table]`

### DIFF
--- a/app/[query]/tables/tables-overview.ts
+++ b/app/[query]/tables/tables-overview.ts
@@ -4,50 +4,51 @@ import { type QueryConfig } from '@/types/query-config'
 export const tablesOverviewConfig: QueryConfig = {
   name: 'tables-overview',
   sql: `
-      WITH detached_parts AS (
-        SELECT
-          format('{}.{}', database, table) AS table,
-          count() AS detached_parts_count,
-          sum(bytes_on_disk) AS detached_bytes_on_disk,
-          formatReadableSize(detached_bytes_on_disk) AS readable_detached_bytes_on_disk
-        FROM system.detached_parts
-        GROUP BY table
-      ),
-
-      parts AS (
-          SELECT
-            format('{}.{}', database, table) AS table,
-            sum(rows) AS total_rows,
-            formatReadableQuantity(total_rows) AS readable_total_rows,
-            round(100 * total_rows / max(total_rows) OVER ()) AS pct_total_rows,
-            max(modification_time) AS latest_modification,
-
-            sum(data_compressed_bytes) as compressed,
-            sum(data_uncompressed_bytes) AS uncompressed,
-            round(uncompressed / compressed, 2) AS compr_rate,
-            formatReadableSize(compressed) AS readable_compressed,
-            formatReadableSize(uncompressed) AS readable_uncompressed,
-            round(100 * compressed / max(compressed) OVER ()) AS pct_compressed,
-            round(100 * uncompressed / max(uncompressed) OVER ()) AS pct_uncompressed,
-            round(100 * compr_rate / max(compr_rate) OVER ()) AS pct_compr_rate,
-
-            sum(primary_key_bytes_in_memory) AS primary_keys_size,
-            formatReadableSize(primary_keys_size) AS readable_primary_keys_size,
-            round(100 * primary_keys_size / max(primary_keys_size) OVER ()) AS pct_primary_keys_size,
-            any(engine) AS engine,
-            count() AS parts_count,
-            round(100 * parts_count / max(parts_count) OVER ()) AS pct_parts_count
-
-          FROM system.parts parts
-          WHERE active
-          GROUP BY 1
-         ORDER BY compressed DESC
-      )
-
-      SELECT parts.*, detached_parts.*
+      WITH
+        detached_parts AS
+        (
+            SELECT
+                format('{}.{}', database, \`table\`) AS \`table\`,
+                count() AS detached_parts_count,
+                sum(bytes_on_disk) AS detached_bytes_on_disk,
+                formatReadableSize(detached_bytes_on_disk) AS readable_detached_bytes_on_disk
+            FROM system.detached_parts
+            GROUP BY 1
+        ),
+        parts AS
+        (
+            SELECT
+                format('{}.{}', database, \`table\`) AS \`table\`,
+                sum(rows) AS total_rows,
+                formatReadableQuantity(total_rows) AS readable_total_rows,
+                round((100 * total_rows) / max(total_rows) OVER ()) AS pct_total_rows,
+                max(modification_time) AS latest_modification,
+                sum(data_compressed_bytes) AS compressed,
+                sum(data_uncompressed_bytes) AS uncompressed,
+                round(uncompressed / compressed, 2) AS compr_rate,
+                formatReadableSize(compressed) AS readable_compressed,
+                formatReadableSize(uncompressed) AS readable_uncompressed,
+                round((100 * compressed) / max(compressed) OVER ()) AS pct_compressed,
+                round((100 * uncompressed) / max(uncompressed) OVER ()) AS pct_uncompressed,
+                round((100 * compr_rate) / max(compr_rate) OVER ()) AS pct_compr_rate,
+                sum(primary_key_bytes_in_memory) AS primary_keys_size,
+                formatReadableSize(primary_keys_size) AS readable_primary_keys_size,
+                round((100 * primary_keys_size) / max(primary_keys_size) OVER ()) AS pct_primary_keys_size,
+                any(engine) AS engine,
+                count() AS parts_count,
+                round((100 * parts_count) / max(parts_count) OVER ()) AS pct_parts_count
+            FROM system.parts AS parts
+            WHERE active
+            GROUP BY 1
+            ORDER BY compressed DESC
+        )
+      SELECT
+        parts.*,
+        detached_parts.*,
+        splitByChar('.', parts.table)[1] AS _database,
+        splitByChar('.', parts.table)[2] AS _table
       FROM parts
-      LEFT JOIN detached_parts USING table
-
+      LEFT JOIN detached_parts USING (\`table\`)
     `,
   columns: [
     'table',
@@ -62,6 +63,7 @@ export const tablesOverviewConfig: QueryConfig = {
     'readable_detached_bytes_on_disk',
   ],
   columnFormats: {
+    table: [ColumnFormat.Link, { href: '/tables/[_database]/[_table]' }],
     engine: ColumnFormat.ColoredBadge,
     readable_total_rows: ColumnFormat.BackgroundBar,
     readable_compressed: ColumnFormat.BackgroundBar,
@@ -69,5 +71,8 @@ export const tablesOverviewConfig: QueryConfig = {
     readable_primary_keys_size: ColumnFormat.BackgroundBar,
     compr_rate: ColumnFormat.BackgroundBar,
     parts_count: ColumnFormat.BackgroundBar,
+  },
+  clickhouseSettings: {
+    allow_experimental_analyzer: 0,
   },
 }

--- a/components/data-table/cells/link-format.tsx
+++ b/components/data-table/cells/link-format.tsx
@@ -1,17 +1,26 @@
 import { ArrowRightIcon } from '@radix-ui/react-icons'
+import { Row, RowData } from '@tanstack/react-table'
 import Link, { LinkProps } from 'next/link'
 
-interface LinkFormatProps {
-  row: any
+interface LinkFormatProps<TData extends RowData, TValue> {
+  row: Row<TData>
+  data: TData[]
   value: any
   options?: LinkProps
 }
 
-export function LinkFormat({ row, value, options }: LinkFormatProps) {
+export function LinkFormat<TData extends RowData, TValue>({
+  row,
+  data,
+  value,
+  options,
+}: LinkFormatProps<TData, TValue>) {
   const link = options as LinkProps
   let href = link.href as string
 
   if (!href) return value
+
+  const originalRow = data[row.index] as Record<string, string | undefined>
 
   // Href contains placeholders, e.g. /tables/[database]/[table]
   // Replace placeholders with values from the row
@@ -20,7 +29,7 @@ export function LinkFormat({ row, value, options }: LinkFormatProps) {
     if (matches) {
       matches.forEach((match) => {
         const key = match.replace('[', '').replace(']', '').trim()
-        href = href.replace(match, row.getValue(key))
+        href = href.replace(match, originalRow[key] ?? '')
       })
     }
   }

--- a/components/data-table/column-defs.tsx
+++ b/components/data-table/column-defs.tsx
@@ -33,7 +33,8 @@ export const normalizeColumnName = (column: string) => {
  * @returns {ColumnDef<ColumnType>[]} - An array of column definitions.
  */
 export const getColumnDefs = <TData extends RowData, TValue>(
-  config: QueryConfig
+  config: QueryConfig,
+  data: TData[]
 ): ColumnDef<TData, TValue>[] => {
   const configColumns = config.columns || []
 
@@ -87,6 +88,7 @@ export const getColumnDefs = <TData extends RowData, TValue>(
         const value = getValue()
         const formatted = formatCell<TData, TValue>(
           table,
+          data,
           row,
           value,
           column,

--- a/components/data-table/data-table.tsx
+++ b/components/data-table/data-table.tsx
@@ -72,7 +72,7 @@ export function DataTable<TData extends RowData, TValue>({
   const configuredColumns = config.columns.map(normalizeColumnName)
 
   // Column definitions for the table
-  const columnDefs = getColumnDefs<TData, TValue>(config) as ColumnDef<
+  const columnDefs = getColumnDefs<TData, TValue>(config, data) as ColumnDef<
     TData,
     TValue
   >[]

--- a/components/data-table/format-cell.tsx
+++ b/components/data-table/format-cell.tsx
@@ -18,6 +18,7 @@ import { RelatedTimeFormat } from './cells/related-time-format'
 
 export const formatCell = <TData extends RowData, TValue>(
   table: Table<TData>,
+  data: TData[],
   row: Row<TData>,
   value: TValue,
   columnName: string,
@@ -75,6 +76,7 @@ export const formatCell = <TData extends RowData, TValue>(
       return (
         <LinkFormat
           row={row}
+          data={data}
           value={value}
           options={columnFormatOptions as LinkProps}
         />


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a feature that adds links from the tables overview page to individual table pages. It also includes enhancements to the SQL query and the `LinkFormat` component to support the new URL format.

- **New Features**:
    - Added links from the tables overview page to individual table pages using the new URL format `/tables/[database]/[table]`.
- **Enhancements**:
    - Updated SQL query in `tables-overview.ts` to include `_database` and `_table` fields for better URL generation.
    - Enhanced `LinkFormat` component to replace placeholders in URLs with actual values from the row data.

<!-- Generated by sourcery-ai[bot]: end summary -->