### PR TITLE
feat(ci): test on multiple clickhouse version

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -20,9 +20,14 @@ jobs:
   job:
     name: ${{ inputs.job-type }}
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        clickhouse: [24.5, 24.6]
+
     services:
       clickhouse:
-        image: ghcr.io/duyet/docker-images:clickhouse_testing
+        image: ghcr.io/duyet/docker-images:clickhouse_${{ matrix.clickhouse}}
         ports:
           - 8123:8123
           - 9000:9000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,11 @@ jobs:
       matrix:
         containers: [1]
         browser: [chrome, firefox, edge]
+        clickhouse: [24.5, 24.6]
 
     services:
       clickhouse:
-        image: ghcr.io/duyet/docker-images:clickhouse_testing
+        image: ghcr.io/duyet/docker-images:clickhouse_${{ matrix.clickhouse}}
         ports:
           - 8123:8123
           - 9000:9000
@@ -84,10 +85,11 @@ jobs:
       matrix:
         node: [20, 21]
         browser: [chrome, firefox]
+        clickhouse: [24.5, 24.6]
 
     services:
       clickhouse:
-        image: ghcr.io/duyet/docker-images:clickhouse_testing
+        image: ghcr.io/duyet/docker-images:clickhouse_${{ matrix.clickhouse }}
         ports:
           - 8123:8123
           - 9000:9000


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the CI workflows to test the project against multiple versions of ClickHouse (24.5 and 24.6) by adding a matrix strategy to the configuration.

- **CI**:
    - Updated CI workflows to test against multiple ClickHouse versions (24.5 and 24.6) by introducing a matrix strategy.

<!-- Generated by sourcery-ai[bot]: end summary -->