### PR TITLE
chore(ci): remove clickhouse serice for component test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,20 +96,6 @@ jobs:
       matrix:
         node: [20, 21]
         browser: [chrome, firefox]
-        clickhouse: [24.5, 24.6]
-
-    services:
-      clickhouse:
-        image: ghcr.io/duyet/docker-images:clickhouse_${{ matrix.clickhouse }}
-        ports:
-          - 8123:8123
-          - 9000:9000
-        options: >-
-          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:8123/?query=SELECT%201 || exit 1"
-          --health-interval 30s
-          --health-timeout 10s
-          --health-retries 5
-          --health-start-period 30s
 
     steps:
       - name: Checkout


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request removes the ClickHouse service configuration from the CI workflow for component tests, simplifying the test setup.

- **CI**:
    - Removed ClickHouse service configuration from the CI workflow for component tests.

<!-- Generated by sourcery-ai[bot]: end summary -->