### PR TITLE
feat: add radial bar chart

### DIFF
--- a/components/generic-charts/radial.cy.tsx
+++ b/components/generic-charts/radial.cy.tsx
@@ -1,0 +1,88 @@
+import { RadialChart } from './radial'
+
+describe('<RadialChart />', () => {
+  const data = [
+    { browser: 'chrome', visitors: 275, fill: 'var(--color-chrome)' },
+    { browser: 'safari', visitors: 200, fill: 'var(--color-safari)' },
+    { browser: 'firefox', visitors: 187, fill: 'var(--color-firefox)' },
+    { browser: 'edge', visitors: 173, fill: 'var(--color-edge)' },
+    { browser: 'other', visitors: 90, fill: 'var(--color-other)' },
+  ]
+
+  it('renders with default props', () => {
+    cy.mount(<RadialChart data={data} nameKey="browser" dataKey="visitors" />)
+    cy.screenshot()
+
+    // Render as svg
+    cy.get('svg:first').as('chart').should('be.visible')
+
+    // Have bar sectors (circle)
+    cy.get('.recharts-radial-bar-sector').should('be.visible')
+  })
+
+  it('renders with single data point', () => {
+    cy.mount(
+      <RadialChart data={[data[0]]} nameKey="browser" dataKey="visitors" />
+    )
+    cy.screenshot()
+
+    // Render as svg
+    cy.get('svg:first').as('chart').should('be.visible')
+
+    // Have bar sectors (circle)
+    cy.get('.recharts-radial-bar-sector').as('bar').should('be.visible')
+
+    // Hover over the first sector
+    cy.get('@bar').trigger('mouseover')
+    // cy.contains(data[0].browser)
+  })
+
+  it('renders and hover to show tooltip', () => {
+    cy.mount(<RadialChart data={data} nameKey="browser" dataKey="visitors" />)
+    cy.screenshot()
+
+    // Render as svg
+    cy.get('svg:first').as('chart').should('be.visible')
+
+    // Hover to show tooltip
+    cy.get('.recharts-radial-bar-sector')
+      .last()
+      .trigger('mouseover', { force: true })
+    cy.contains(data[data.length - 1].browser)
+  })
+
+  it('renders with showLegend', () => {
+    cy.mount(
+      <RadialChart
+        data={data}
+        nameKey="browser"
+        dataKey="visitors"
+        showLegend
+      />
+    )
+    cy.screenshot()
+
+    // Render as svg
+    cy.get('svg:first').as('chart').should('be.visible')
+    cy.get('.recharts-legend-wrapper').should('be.visible')
+  })
+
+  it('renders with onClick', () => {
+    const onClick = cy.stub().as('onClick')
+
+    cy.mount(
+      <RadialChart
+        data={data}
+        nameKey="browser"
+        dataKey="visitors"
+        onClick={onClick}
+      />
+    )
+
+    // Click on a sector
+    cy.get('.recharts-radial-bar-sector').first().click()
+
+    // Check if onClick was called
+    cy.get('@onClick').should('have.been.calledOnce')
+  })
+})

--- a/components/generic-charts/radial.tsx
+++ b/components/generic-charts/radial.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart'
+import { cn } from '@/lib/utils'
+import { type RadialChartProps } from '@/types/charts'
+import { LabelList, RadialBar, RadialBarChart } from 'recharts'
+
+export function RadialChart({
+  data,
+  nameKey,
+  dataKey,
+  showLegend = false,
+  showLabel = false,
+  colors,
+  colorLabel,
+  onClick,
+  className,
+}: RadialChartProps) {
+  const chartConfig = data
+    .map((row) => row[nameKey])
+    .reduce(
+      (acc, category, index) => {
+        acc[category] = {
+          label: category,
+          color: colors
+            ? `hsl(var(${colors[index]}))`
+            : `hsl(var(--chart-${index + 1}))`,
+        }
+
+        return acc
+      },
+      {
+        label: {
+          color: colorLabel
+            ? `hsl(var(${colorLabel}))`
+            : 'hsl(var(--background))',
+        },
+      } as ChartConfig
+    )
+
+  return (
+    <ChartContainer
+      config={chartConfig}
+      className={cn('mx-auto aspect-square max-h-[250px]', className)}
+    >
+      <RadialBarChart
+        accessibilityLayer
+        data={data}
+        innerRadius={30}
+        outerRadius={110}
+        barSize={25}
+      >
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent hideLabel nameKey={nameKey} />}
+        />
+
+        <RadialBar dataKey={dataKey} onClick={onClick} background>
+          {showLabel && (
+            <LabelList
+              position="insideStart"
+              dataKey={dataKey}
+              className="fill-white capitalize mix-blend-luminosity"
+              fontSize={11}
+            />
+          )}
+        </RadialBar>
+
+        {showLegend && <ChartLegend content={<ChartLegendContent />} />}
+      </RadialBarChart>
+    </ChartContainer>
+  )
+}

--- a/types/charts.ts
+++ b/types/charts.ts
@@ -70,8 +70,6 @@ export interface BaseChartProps
   extends BaseAnimationTimingProps,
     React.HTMLAttributes<HTMLDivElement> {
   data: any[]
-  categories: string[]
-  index: string
   labelPosition?: LabelPosition
   labelAngle?: number
   colors?: Color[]
@@ -106,6 +104,8 @@ export interface BaseChartProps
 }
 
 export interface BarChartProps extends BaseChartProps {
+  categories: string[]
+  index?: string
   layout?: 'vertical' | 'horizontal'
   stack?: boolean
   relative?: boolean
@@ -116,6 +116,8 @@ export interface BarChartProps extends BaseChartProps {
 }
 
 export interface AreaChartProps extends BaseChartProps {
+  categories: string[]
+  index?: string
   type?: string
   stack?: boolean
   relative?: boolean
@@ -126,4 +128,11 @@ export interface AreaChartProps extends BaseChartProps {
   breakdown?: string
   readableColumn?: string
   readableColumns?: string[]
+}
+
+export interface RadialChartProps extends BaseChartProps {
+  data: Record<string, string | number>[]
+  nameKey: string
+  dataKey: string
+  onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 }


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds support for radial bar charts by introducing a new RadialChart component and updating the BarChartProps and AreaChartProps interfaces to include additional properties.

- **New Features**:
    - Introduced a new RadialChart component to support radial bar charts, including properties for data, nameKey, dataKey, and optional onClick event handling.
- **Enhancements**:
    - Updated BarChartProps and AreaChartProps interfaces to include categories and optional index properties.

<!-- Generated by sourcery-ai[bot]: end summary -->