### PR TITLE
chore: count-across-replicas link to table detail, `<ErrorAlert />` add toggle to open detailed query, add number chart

### DIFF
--- a/app/[query]/tables/replicas.ts
+++ b/app/[query]/tables/replicas.ts
@@ -44,7 +44,10 @@ export const replicasConfig: QueryConfig = {
     'zookeeper_exception',
   ],
   columnFormats: {
-    database_table: [ColumnFormat.Link, { href: '/tables/[database]/[table]' }],
+    database_table: [
+      ColumnFormat.Link,
+      { href: '/database/[database]/[table]' },
+    ],
     engine: ColumnFormat.ColoredBadge,
     is_leader: ColumnFormat.Boolean,
     can_become_leader: ColumnFormat.Boolean,

--- a/components/data-table/cells/link-format.cy.tsx
+++ b/components/data-table/cells/link-format.cy.tsx
@@ -6,14 +6,14 @@ describe('<LinkFormat />', () => {
     const row = { index: 0 } as Row<any>
     const data = [{ database: 'testDB', table: 'testTable' }]
     const value = 'Test Link'
-    const options = { href: '/tables/[database]/[table]' }
+    const options = { href: '/database/[database]/[table]' }
 
     cy.mount(
       <LinkFormat row={row} data={data} value={value} options={options} />
     )
 
     cy.get('a')
-      .should('have.attr', 'href', '/tables/testDB/testTable')
+      .should('have.attr', 'href', '/database/testDB/testTable')
       .and('contain.text', 'Test Link')
   })
 

--- a/components/data-table/cells/link-format.tsx
+++ b/components/data-table/cells/link-format.tsx
@@ -29,7 +29,7 @@ export function LinkFormat<
 
   const originalRow = data[row.index] as Record<string, string | undefined>
 
-  // Href contains placeholders, e.g. /tables/[database]/[table]
+  // Href contains placeholders, e.g. /database/[database]/[table]
   // Replace placeholders with values from the row
   let hrefBinding = href
   if (href.includes('[') && href.includes(']')) {

--- a/components/error-alert.cy.tsx
+++ b/components/error-alert.cy.tsx
@@ -64,6 +64,9 @@ describe('<ErrorAlert />', () => {
         query="SELECT 1"
       />
     )
+
+    cy.get('button[role="open-query"]').should('be.visible')
+    cy.get('button[role="open-query"]').click()
     cy.contains('SELECT 1').should('be.visible')
   })
 
@@ -77,6 +80,9 @@ describe('<ErrorAlert />', () => {
     )
     cy.contains('Something went wrong').should('be.visible')
     cy.get('div').should('have.class', 'bg-green-300')
+
+    cy.get('button[role="open-query"]').should('be.visible')
+    cy.get('button[role="open-query"]').click()
     cy.contains('SELECT 1').should('be.visible')
   })
 })

--- a/components/error-alert.tsx
+++ b/components/error-alert.tsx
@@ -1,5 +1,11 @@
 'use client'
 
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import React, { useEffect, useState } from 'react'
@@ -48,12 +54,24 @@ export function ErrorAlert({
     </div>
   )
 
+  const renderAccordion = (
+    title: string,
+    content: string | React.ReactNode
+  ) => (
+    <Accordion type="single" collapsible className="w-full">
+      <AccordionItem className="border-none" value="item-1">
+        <AccordionTrigger role="open-query">{title}</AccordionTrigger>
+        <AccordionContent>{content}</AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  )
+
   return (
     <Alert className={className}>
       <AlertTitle className="text-lg">{title}</AlertTitle>
       <AlertDescription>
         {renderContent(message)}
-        {query && renderContent(query)}
+        {query && renderAccordion('View Full Query Details', query)}
         {reset && (
           <Button variant="outline" onClick={() => reset()}>
             Try again {countdown >= 0 && `(${countdown}s)`}

--- a/components/error-alert.tsx
+++ b/components/error-alert.tsx
@@ -19,7 +19,7 @@ export function ErrorAlert({
   reset,
   className,
 }: ErrorAlertProps) {
-  const [countdown, setCountdown] = useState(3)
+  const [countdown, setCountdown] = useState(10)
 
   useEffect(() => {
     if (!reset) return
@@ -29,7 +29,7 @@ export function ErrorAlert({
         if (prev <= 1) {
           clearInterval(timer)
           reset()
-          return 3
+          return 0
         }
         return prev - 1
       })

--- a/components/generic-charts/number.cy.tsx
+++ b/components/generic-charts/number.cy.tsx
@@ -1,0 +1,75 @@
+import { NumberChart } from './number'
+
+describe('<NumberChart />', () => {
+  const mockData = [
+    {
+      value: 100,
+      name: 'Test Name',
+    },
+  ]
+
+  it('renders correctly with data', () => {
+    cy.mount(<NumberChart data={mockData} nameKey="name" dataKey="value" />)
+    cy.get('div').contains('100').should('be.visible')
+    cy.get('div').contains('Test Name').should('not.exist')
+  })
+
+  it('renders without legend when showLabel is false', () => {
+    cy.mount(
+      <NumberChart
+        data={mockData}
+        nameKey="name"
+        dataKey="value"
+        showLabel={false}
+      />
+    )
+    cy.get('div').contains('Test Name').should('not.exist')
+  })
+
+  it('renders with showLabel ', () => {
+    cy.mount(
+      <NumberChart data={mockData} nameKey="name" dataKey="value" showLabel />
+    )
+    cy.get('div').contains('Test Name').should('be.visible')
+  })
+
+  it('handles empty data gracefully', () => {
+    cy.mount(<NumberChart data={[]} nameKey="name" dataKey="value" />)
+    cy.contains('No data').should('be.visible')
+  })
+
+  it('renders without data', () => {
+    cy.mount(<NumberChart data={[]} dataKey="value" nameKey="name" />)
+    cy.contains('No data').should('be.visible')
+  })
+
+  it('renders with title', () => {
+    cy.mount(
+      <NumberChart
+        data={mockData}
+        dataKey="value"
+        nameKey="name"
+        showLabel
+        title="Walking Distance"
+        className="max-w-[300px] rounded border"
+      />
+    )
+    cy.get('[role="title"]').should('be.visible')
+  })
+
+  it('renders with title and description', () => {
+    cy.mount(
+      <NumberChart
+        data={mockData}
+        dataKey="value"
+        nameKey="name"
+        showLabel
+        title="Walking Distance"
+        description="Over the last 7 days, your distance walked and run was 12.5 miles per day."
+        className="max-w-[300px] rounded border"
+      />
+    )
+    cy.get('[role="title"]').should('be.visible')
+    cy.get('[role="description"]').should('be.visible')
+  })
+})

--- a/components/generic-charts/number.tsx
+++ b/components/generic-charts/number.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+import { NumberChartProps } from '@/types/charts'
+
+export function NumberChart({
+  data,
+  nameKey,
+  dataKey,
+  title,
+  description,
+  showLabel = false,
+  className,
+}: NumberChartProps) {
+  if (!data || data.length === 0) {
+    return (
+      <div
+        className={cn(
+          'p-6 text-center text-xs text-muted-foreground',
+          className
+        )}
+      >
+        No data
+      </div>
+    )
+  }
+
+  const chartData = data[0]
+
+  return (
+    <div className={cn(className)}>
+      {title || description ? (
+        <header className="flex flex-col space-y-1.5 p-4 pb-0">
+          <h3
+            className="text-2xl font-semibold leading-none tracking-tight"
+            role="title"
+          >
+            {title}
+          </h3>
+          <p className="text-sm text-muted-foreground" role="description">
+            {description}
+          </p>
+        </header>
+      ) : null}
+      <div
+        className={cn(
+          'flex items-baseline gap-1 p-6',
+          title || description ? 'flex-row' : 'flex-col'
+        )}
+      >
+        <div className="text-center text-3xl font-bold tabular-nums">
+          {chartData[dataKey] || ''}
+        </div>
+        {showLabel && (
+          <div className="text-center text-xs text-muted-foreground">
+            {chartData[nameKey] || ''}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/skeleton.tsx
+++ b/components/skeleton.tsx
@@ -26,7 +26,7 @@ export function TableSkeleton({
   className?: string
 }) {
   return (
-    <div className={cn('mb-5 flex flex-col gap-3', className)}>
+    <div className={cn('mb-5 flex w-fit flex-col gap-3', className)}>
       {Array.from({ length: rows }).map((_, i) => (
         <div key={`row-${i}`} className="flex flex-row items-center gap-3">
           {Array.from({ length: cols }).map((_, j) => (

--- a/types/charts.ts
+++ b/types/charts.ts
@@ -122,10 +122,10 @@ export interface AreaChartProps extends BaseChartProps {
   stack?: boolean
   relative?: boolean
   opacity?: number
+  breakdown?: string
 
   // TODO: support these features
   readable?: string
-  breakdown?: string
   readableColumn?: string
   readableColumns?: string[]
 }
@@ -135,4 +135,12 @@ export interface RadialChartProps extends BaseChartProps {
   nameKey: string
   dataKey: string
   onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
+}
+
+export interface NumberChartProps extends BaseChartProps {
+  data: Record<string, string | number>[]
+  nameKey: string
+  dataKey: string
+  title?: string
+  description?: string
 }


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new `NumberChart` component, enhances the `ErrorAlert` component with an accordion for detailed query views, and updates the `count-across-replicas` page to link database tables to their detailed views. Additionally, it includes updates to the `TableSkeleton` component for better width flexibility and adds corresponding tests for the new features.

- **New Features**:
    - Introduced a new `NumberChart` component for displaying numerical data in a chart format.
- **Enhancements**:
    - Updated `ErrorAlert` component to include an accordion for viewing detailed query information.
    - Modified the `count-across-replicas` page to link database tables to their detailed views.
    - Enhanced the `TableSkeleton` component to have a more flexible width.
- **Tests**:
    - Added tests for the new accordion feature in the `ErrorAlert` component.
    - Updated tests for the `LinkFormat` component to reflect the new URL structure.

<!-- Generated by sourcery-ai[bot]: end summary -->