### PR TITLE
feat: area chart support breakdown

### DIFF
--- a/app/[query]/queries/expensive-queries.ts
+++ b/app/[query]/queries/expensive-queries.ts
@@ -7,7 +7,7 @@ export const expensiveQueriesConfig: QueryConfig = {
   sql: `
       SELECT
           normalized_query_hash,
-          replace(substr(argMax(query, utime), 1, 200), '\n', ' ') AS query,
+          replace(substr(argMax(query, utime), 1, 500), '\n', ' ') AS query,
           count() AS cnt,
           sum(query_duration_ms) / 1000 AS queries_duration,
           sum(ProfileEvents.Values[indexOf(ProfileEvents.Names, 'RealTimeMicroseconds')]) / 1000000 AS real_time,
@@ -59,6 +59,7 @@ export const expensiveQueriesConfig: QueryConfig = {
     'result_bytes',
   ],
   columnFormats: {
+    query: ColumnFormat.CodeDialog,
     queries_duration: ColumnFormat.Duration,
     real_time: ColumnFormat.Duration,
     user_time: ColumnFormat.Duration,

--- a/components/generic-charts/area.cy.tsx
+++ b/components/generic-charts/area.cy.tsx
@@ -209,4 +209,78 @@ describe('<AreaChart />', () => {
     // Should have two layer
     cy.get('.recharts-area').should('have.length', 2)
   })
+
+  const dataWithBreakdown = [
+    {
+      date: '2025-01-01',
+      query_count: 1000,
+      query_duration: 1000,
+      breakdown: [
+        ['select', '500'],
+        ['insert', '500'],
+      ],
+    },
+    {
+      date: '2025-01-02',
+      query_count: 2000,
+      query_duration: 2000,
+      breakdown: [
+        ['select', '1000'],
+        ['insert', '1000'],
+      ],
+    },
+  ]
+
+  it('renders with breakdown', () => {
+    cy.mount(
+      <AreaChart
+        data={dataWithBreakdown}
+        categories={['query_count']}
+        index="date"
+        showLegend
+        breakdown="breakdown"
+        tooltipActive={true /* always show tooltip for test/debugging */}
+      />
+    )
+    cy.screenshot()
+
+    // Render as svg
+    cy.get('svg:first').as('chart').should('be.visible')
+
+    // Hover to show tooltip
+    cy.get('@chart').trigger('mouseover')
+
+    // Show breakdown in tooltip
+    cy.get('.recharts-tooltip-wrapper [role="breakdown"]').should(
+      'contain',
+      'Breakdown'
+    )
+    cy.get('[role="breakdown"] [role="row"]').should(
+      'have.length',
+      dataWithBreakdown[0].breakdown.length
+    )
+  })
+
+  it('renders with breakdown custom breakdownLabel', () => {
+    const breakdownLabel = 'Custom breakdown'
+
+    cy.mount(
+      <AreaChart
+        data={dataWithBreakdown}
+        categories={['query_count']}
+        index="date"
+        showLegend
+        breakdown="breakdown"
+        breakdownLabel={breakdownLabel}
+        tooltipActive={true /* always show tooltip for test/debugging */}
+      />
+    )
+    cy.screenshot()
+
+    // Show breakdown in tooltip
+    cy.get('.recharts-tooltip-wrapper [role="breakdown"]').should(
+      'contain',
+      breakdownLabel
+    )
+  })
 })

--- a/types/charts.ts
+++ b/types/charts.ts
@@ -123,6 +123,8 @@ export interface AreaChartProps extends BaseChartProps {
   relative?: boolean
   opacity?: number
   breakdown?: string
+  breakdownLabel?: string
+  tooltipActive?: boolean
 
   // TODO: support these features
   readable?: string


### PR DESCRIPTION
<img width="418" alt="image" src="https://github.com/user-attachments/assets/7631902f-05ae-4ff4-a859-ec90b8d55bde">

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces support for breakdowns in area charts, enhancing the tooltip functionality to display detailed breakdowns. It also extends the query string length in the expensive queries configuration and adds new tests to ensure the correct rendering of the new features.

- **New Features**:
    - Added support for breakdown in area charts, allowing detailed breakdowns to be displayed in tooltips.
    - Introduced new props `breakdown`, `breakdownLabel`, and `tooltipActive` to the AreaChart component.
- **Enhancements**:
    - Extended the maximum length of the query string in the expensive queries configuration from 200 to 500 characters.
    - Added `ColumnFormat.CodeDialog` format to the `query` column in the expensive queries configuration.
- **Tests**:
    - Added tests to verify the rendering of area charts with breakdown data.
    - Included tests for custom breakdown labels in area charts.

<!-- Generated by sourcery-ai[bot]: end summary -->