### PR TITLE
chore: support single user/pass for multiple hosts

### DIFF
--- a/lib/clickhouse.ts
+++ b/lib/clickhouse.ts
@@ -47,11 +47,22 @@ export const getClickHouseConfigs = (): ClickHouseConfig[] => {
   const customLabels = splitByComma(process.env.CLICKHOUSE_NAME || '')
 
   return hosts.map((host, index) => {
+    // User and password fallback to the first value,
+    // supporting multiple hosts with the same user/password
+    let user, password
+    if (users.length === 1 && passwords.length === 1) {
+      user = users[0]
+      password = passwords[0]
+    } else {
+      user = users[index] || 'default'
+      password = passwords[index] || ''
+    }
+
     return {
       id: index,
       host,
-      user: users[index] || 'default',
-      password: passwords[index] || '',
+      user,
+      password,
       customName: customLabels[index],
     }
   })


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the ClickHouse configuration to allow a single user and password to be used across multiple hosts by defaulting to the first user and password when only one set is provided.

Enhancements:
- Support using a single user and password for multiple ClickHouse hosts by falling back to the first user and password when only one set is provided.

<!-- Generated by sourcery-ai[bot]: end summary -->