### PR TITLE
chore: update LinkCount ignore system database, fix skeleton

### DIFF
--- a/app/[host]/overview/overview-charts.tsx
+++ b/app/[host]/overview/overview-charts.tsx
@@ -104,23 +104,23 @@ export async function DatabaseTableCount({
       )}
     >
       <CardContent className="flex flex-col content-center p-2 pt-2">
-        <Suspense fallback={<SingleLineSkeleton className='w-full' />}>
+        <Suspense fallback={<SingleLineSkeleton className="w-full" />}>
           <LinkCount
-            query="SELECT countDistinct(database) as count FROM system.tables"
+            query="SELECT countDistinct(database) as count FROM system.tables WHERE database != 'system'"
             icon={<Database className="opacity-70 hover:opacity-100" />}
             label="database(s)"
             href={getScopedLink('/database')}
           />
         </Suspense>
-        <Suspense fallback={<SingleLineSkeleton className='w-full' />}>
+        <Suspense fallback={<SingleLineSkeleton className="w-full" />}>
           <LinkCount
-            query="SELECT countDistinct(format('{}.{}', database, table)) as count FROM system.tables"
+            query="SELECT countDistinct(format('{}.{}', database, table)) as count FROM system.tables WHERE database != 'system'"
             icon={<Database className="opacity-70 hover:opacity-100" />}
             label="table(s)"
             href={getScopedLink('/database')}
           />
         </Suspense>
-        <Suspense fallback={<SingleLineSkeleton className='w-full' />}>
+        <Suspense fallback={<SingleLineSkeleton className="w-full" />}>
           <LinkCount
             query="SELECT countDistinct(format('{}.{}', database, table)) as count FROM system.replicas WHERE is_readonly = 1"
             icon={<CircleAlert className="opacity-70 hover:opacity-100" />}

--- a/app/[host]/overview/overview-charts.tsx
+++ b/app/[host]/overview/overview-charts.tsx
@@ -104,7 +104,7 @@ export async function DatabaseTableCount({
       )}
     >
       <CardContent className="flex flex-col content-center p-2 pt-2">
-        <Suspense fallback={<SingleLineSkeleton />}>
+        <Suspense fallback={<SingleLineSkeleton className='w-full' />}>
           <LinkCount
             query="SELECT countDistinct(database) as count FROM system.tables"
             icon={<Database className="opacity-70 hover:opacity-100" />}
@@ -112,7 +112,7 @@ export async function DatabaseTableCount({
             href={getScopedLink('/database')}
           />
         </Suspense>
-        <Suspense fallback={<SingleLineSkeleton />}>
+        <Suspense fallback={<SingleLineSkeleton className='w-full' />}>
           <LinkCount
             query="SELECT countDistinct(format('{}.{}', database, table)) as count FROM system.tables"
             icon={<Database className="opacity-70 hover:opacity-100" />}
@@ -120,7 +120,7 @@ export async function DatabaseTableCount({
             href={getScopedLink('/database')}
           />
         </Suspense>
-        <Suspense fallback={<SingleLineSkeleton />}>
+        <Suspense fallback={<SingleLineSkeleton className='w-full' />}>
           <LinkCount
             query="SELECT countDistinct(format('{}.{}', database, table)) as count FROM system.replicas WHERE is_readonly = 1"
             icon={<CircleAlert className="opacity-70 hover:opacity-100" />}


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the skeleton width of the LinkCount component to ensure it spans the full width in the fallback of the Suspense component.

Bug Fixes:
- Fix the skeleton width of the LinkCount component by setting it to full width in the fallback of the Suspense component.

<!-- Generated by sourcery-ai[bot]: end summary -->