### PR TITLE
fix(ui): dropdown filter cannot scroll down

### DIFF
--- a/components/data-table/buttons/column-visibility.tsx
+++ b/components/data-table/buttons/column-visibility.tsx
@@ -17,7 +17,7 @@ export function ColumnVisibilityButton<TData>({
   table,
 }: ColumnVisibilityButtonProps<TData>) {
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <Button
           variant="outline"
@@ -28,7 +28,7 @@ export function ColumnVisibilityButton<TData>({
           <MixerHorizontalIcon className="size-4" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent align="end" className="overflow-x-auto">
         {table
           .getAllColumns()
           .filter((column) => column.getCanHide())


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue where the dropdown filter could not scroll down by making the DropdownMenu non-modal and allowing horizontal overflow.

Bug Fixes:
- Fix dropdown filter scrolling issue by setting the DropdownMenu to non-modal and adding horizontal overflow handling.

<!-- Generated by sourcery-ai[bot]: end summary -->

Resolved https://github.com/duyet/clickhouse-monitoring/issues/364