### PR TITLE
feat: add chart to track KEEPER_EXCEPTION error

### DIFF
--- a/app/[host]/[query]/more/zookeeper.ts
+++ b/app/[host]/[query]/more/zookeeper.ts
@@ -30,7 +30,7 @@ export const zookeeperConfig: QueryConfig = {
     'num_child_changes',
   ],
   columnFormats: {
-    _path: [ColumnFormat.Link, { href: `/zookeeper?path=[_path]` }],
+    _path: [ColumnFormat.Link, { href: `?path=[_path]` }],
     value: ColumnFormat.CodeToggle,
     created_at: ColumnFormat.RelatedTime,
     updated_at: ColumnFormat.RelatedTime,
@@ -57,7 +57,7 @@ export const zookeeperConfig: QueryConfig = {
     'break',
     'zookeeper-uptime',
     'zookeeper-summary-table',
-    ['zookeeper-error', {}],
+    ['zookeeper-exception', {}],
     'break',
   ],
 }

--- a/app/[host]/overview/page.tsx
+++ b/app/[host]/overview/page.tsx
@@ -9,6 +9,7 @@ import { ChartMergeCount } from '@/components/charts/merge-count'
 import { ChartNewPartsCreated } from '@/components/charts/new-parts-created'
 import { ChartQueryCountByUser } from '@/components/charts/query-count-by-user'
 import { ChartTopTableSize } from '@/components/charts/top-table-size'
+import ChartKeeperException from '@/components/charts/zookeeper-exception'
 import { ServerComponentLazy } from '@/components/server-component-lazy'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { OverviewCharts } from './overview-charts'
@@ -28,6 +29,7 @@ export default async function Overview() {
         <div className="flex items-center justify-between space-y-2">
           <TabsList>
             <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="errors">Errors</TabsTrigger>
             <TabsTrigger value="disks">Disks</TabsTrigger>
             <TabsTrigger value="backups">Backups</TabsTrigger>
           </TabsList>
@@ -97,6 +99,14 @@ export default async function Overview() {
                 interval="toStartOfHour"
                 lastHours={24 * 7}
               />
+            </ServerComponentLazy>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="errors" className="space-y-4">
+          <div className="grid grid-cols-1 items-stretch gap-5 md:grid-cols-2">
+            <ServerComponentLazy>
+              <ChartKeeperException className="w-full p-5" />
             </ServerComponentLazy>
           </div>
         </TabsContent>

--- a/lib/clickhouse-query.test.ts
+++ b/lib/clickhouse-query.test.ts
@@ -72,7 +72,7 @@ describe('fillStep', () => {
 
   it('returns undefined for invalid interval', () => {
     // @ts-expect-error: Testing with invalid input
-    expect(fillStep('invalidInterval')).toBeUndefined()
+    expect(fillStep('invalidInterval')).toBe('')
   })
 })
 
@@ -101,6 +101,6 @@ describe('nowOrToday', () => {
 
   it('returns undefined for invalid interval', () => {
     // @ts-expect-error: Testing with invalid input
-    expect(nowOrToday('invalidInterval')).toBeUndefined()
+    expect(nowOrToday('invalidInterval')).toBe('')
   })
 })

--- a/lib/clickhouse-query.test.ts
+++ b/lib/clickhouse-query.test.ts
@@ -1,24 +1,106 @@
-import { expect } from '@jest/globals'
-import { applyInterval } from './clickhouse-query'
+import type { ClickHouseInterval } from '@/types/clickhouse-interval'
+import { expect, test } from '@jest/globals'
+import { applyInterval, fillStep, nowOrToday } from './clickhouse-query'
 
 describe('applyInterval', () => {
-  it('should apply toStartOfDay for toStartOfDay interval', () => {
-    const result = applyInterval('toStartOfDay', 'myColumn', 'myAlias')
-    expect(result).toEqual('toDate(toStartOfDay(myColumn)) AS myAlias') // Change to toEqual
+  const testCases: [ClickHouseInterval, string, string | undefined, string][] =
+    [
+      [
+        'toStartOfDay',
+        'myColumn',
+        'myAlias',
+        'toDate(toStartOfDay(myColumn)) AS myAlias',
+      ],
+      [
+        'toStartOfWeek',
+        'myColumn',
+        undefined,
+        'toDate(toStartOfWeek(myColumn)) AS myColumn',
+      ],
+      [
+        'toStartOfMonth',
+        'myColumn',
+        'myAlias',
+        'toDate(toStartOfMonth(myColumn)) AS myAlias',
+      ],
+      [
+        'toStartOfHour',
+        'myColumn',
+        'myAlias',
+        'toStartOfHour(myColumn) AS myAlias',
+      ],
+      [
+        'toStartOfMinute',
+        'myColumn',
+        'myAlias',
+        'toStartOfMinute(myColumn) AS myAlias',
+      ],
+    ]
+
+  test.each(testCases)(
+    'applies %s correctly',
+    (interval, column, alias, expected) => {
+      const result = applyInterval(interval, column, alias)
+      expect(result).toEqual(expected)
+    }
+  )
+
+  it('should use column name as alias if no alias is provided', () => {
+    const result = applyInterval('toStartOfDay', 'myColumn')
+    expect(result).toEqual('toDate(toStartOfDay(myColumn)) AS myColumn')
+  })
+})
+
+describe('fillStep', () => {
+  const testCases: [ClickHouseInterval, string][] = [
+    ['toStartOfMinute', 'toIntervalMinute(1)'],
+    ['toStartOfFiveMinutes', 'toIntervalMinute(5)'],
+    ['toStartOfTenMinutes', 'toIntervalMinute(10)'],
+    ['toStartOfFifteenMinutes', 'toIntervalMinute(15)'],
+    ['toStartOfHour', 'toIntervalHour(1)'],
+    ['toStartOfDay', 'toIntervalDay(1)'],
+    ['toStartOfWeek', 'toIntervalDay(7)'],
+    ['toStartOfMonth', 'toIntervalMonth(1)'],
+  ]
+
+  test.each(testCases)(
+    'returns correct interval for %s',
+    (input: ClickHouseInterval, expected: string) => {
+      expect(fillStep(input)).toBe(expected)
+    }
+  )
+
+  it('returns undefined for invalid interval', () => {
+    // @ts-expect-error: Testing with invalid input
+    expect(fillStep('invalidInterval')).toBeUndefined()
+  })
+})
+
+describe('nowOrToday', () => {
+  const nowCases: ClickHouseInterval[] = [
+    'toStartOfMinute',
+    'toStartOfFiveMinutes',
+    'toStartOfTenMinutes',
+    'toStartOfFifteenMinutes',
+    'toStartOfHour',
+  ]
+
+  const todayCases: ClickHouseInterval[] = [
+    'toStartOfDay',
+    'toStartOfWeek',
+    'toStartOfMonth',
+  ]
+
+  test.each(nowCases)('returns "now()" for %s', (interval) => {
+    expect(nowOrToday(interval)).toBe('now()')
   })
 
-  it('should apply toStartOfWeek for toStartOfWeek interval', () => {
-    const result = applyInterval('toStartOfWeek', 'myColumn')
-    expect(result).toEqual('toDate(toStartOfWeek(myColumn)) AS myColumn') // Change to toEqual
+  test.each(todayCases)('returns "today()" for %s', (interval) => {
+    expect(nowOrToday(interval)).toBe('today()')
   })
 
-  it('should apply toStartOfMonth for toStartOfMonth interval', () => {
-    const result = applyInterval('toStartOfMonth', 'myColumn', 'myAlias')
-    expect(result).toEqual('toDate(toStartOfMonth(myColumn)) AS myAlias') // Change to toEqual
-  })
-
-  it('should apply toStartOfHour for other intervals', () => {
-    const result = applyInterval('toStartOfHour', 'myColumn', 'myAlias')
-    expect(result).toEqual('toStartOfHour(myColumn) AS myAlias') // Change to toEqual
+  it('returns undefined for invalid interval', () => {
+    // @ts-expect-error: Testing with invalid input
+    expect(nowOrToday('invalidInterval')).toBeUndefined()
   })
 })

--- a/lib/clickhouse-query.ts
+++ b/lib/clickhouse-query.ts
@@ -16,38 +16,22 @@ export function applyInterval(
   return `${interval}(${column}) AS ${alias || column}`
 }
 
-export function fillStep(interval: ClickHouseInterval) {
-  switch (interval) {
-    case 'toStartOfMinute':
-      return 'toIntervalMinute(1)'
-    case 'toStartOfFiveMinutes':
-      return 'toIntervalMinute(5)'
-    case 'toStartOfTenMinutes':
-      return 'toIntervalMinute(10)'
-    case 'toStartOfFifteenMinutes':
-      return 'toIntervalMinute(15)'
-    case 'toStartOfHour':
-      return 'toIntervalHour(1)'
-    case 'toStartOfDay':
-      return 'toIntervalDay(1)'
-    case 'toStartOfWeek':
-      return 'toIntervalDay(7)'
-    case 'toStartOfMonth':
-      return 'toIntervalMonth(1)'
-  }
+// prettier-ignore
+const intervalMap = new Map<ClickHouseInterval, { fillStep: string; nowOrToday: string }>([
+  ['toStartOfMinute',        { fillStep: 'toIntervalMinute(1)',  nowOrToday: 'now()' }],
+  ['toStartOfFiveMinutes',   { fillStep: 'toIntervalMinute(5)',  nowOrToday: 'now()' }],
+  ['toStartOfTenMinutes',    { fillStep: 'toIntervalMinute(10)', nowOrToday: 'now()' }],
+  ['toStartOfFifteenMinutes',{ fillStep: 'toIntervalMinute(15)', nowOrToday: 'now()' }],
+  ['toStartOfHour',          { fillStep: 'toIntervalHour(1)',    nowOrToday: 'now()' }],
+  ['toStartOfDay',           { fillStep: 'toIntervalDay(1)',     nowOrToday: 'today()' }],
+  ['toStartOfWeek',          { fillStep: 'toIntervalDay(7)',     nowOrToday: 'today()' }],
+  ['toStartOfMonth',         { fillStep: 'toIntervalMonth(1)',   nowOrToday: 'today()' }],
+])
+
+export function fillStep(interval: ClickHouseInterval): string {
+  return intervalMap.get(interval)?.fillStep ?? ''
 }
 
-export function nowOrToday(interval: ClickHouseInterval) {
-  switch (interval) {
-    case 'toStartOfMinute':
-    case 'toStartOfFiveMinutes':
-    case 'toStartOfTenMinutes':
-    case 'toStartOfFifteenMinutes':
-    case 'toStartOfHour':
-      return 'now()'
-    case 'toStartOfDay':
-    case 'toStartOfWeek':
-    case 'toStartOfMonth':
-      return 'today()'
-  }
+export function nowOrToday(interval: ClickHouseInterval): string {
+  return intervalMap.get(interval)?.nowOrToday ?? ''
 }

--- a/lib/clickhouse-query.ts
+++ b/lib/clickhouse-query.ts
@@ -15,3 +15,39 @@ export function applyInterval(
 
   return `${interval}(${column}) AS ${alias || column}`
 }
+
+export function fillStep(interval: ClickHouseInterval) {
+  switch (interval) {
+    case 'toStartOfMinute':
+      return 'toIntervalMinute(1)'
+    case 'toStartOfFiveMinutes':
+      return 'toIntervalMinute(5)'
+    case 'toStartOfTenMinutes':
+      return 'toIntervalMinute(10)'
+    case 'toStartOfFifteenMinutes':
+      return 'toIntervalMinute(15)'
+    case 'toStartOfHour':
+      return 'toIntervalHour(1)'
+    case 'toStartOfDay':
+      return 'toIntervalDay(1)'
+    case 'toStartOfWeek':
+      return 'toIntervalDay(7)'
+    case 'toStartOfMonth':
+      return 'toIntervalMonth(1)'
+  }
+}
+
+export function nowOrToday(interval: ClickHouseInterval) {
+  switch (interval) {
+    case 'toStartOfMinute':
+    case 'toStartOfFiveMinutes':
+    case 'toStartOfTenMinutes':
+    case 'toStartOfFifteenMinutes':
+    case 'toStartOfHour':
+      return 'now()'
+    case 'toStartOfDay':
+    case 'toStartOfWeek':
+    case 'toStartOfMonth':
+      return 'today()'
+  }
+}

--- a/menu.ts
+++ b/menu.ts
@@ -28,6 +28,7 @@ import {
   Grid2x2CheckIcon,
   HardDriveIcon,
   RollerCoasterIcon,
+  ShieldAlertIcon,
   UngroupIcon,
   UnplugIcon,
 } from 'lucide-react'
@@ -274,6 +275,12 @@ export const menuItemsConfig: MenuItem[] = [
         href: '/charts/connections-http,connections-interserver',
         description: 'Number of connections over time',
         icon: UnplugIcon,
+      },
+      {
+        title: 'Errors',
+        href: '/charts/zookeeper-exception',
+        description: 'History of error values from table system.errors',
+        icon: ShieldAlertIcon,
       },
     ],
   },

--- a/menu.ts
+++ b/menu.ts
@@ -279,7 +279,7 @@ export const menuItemsConfig: MenuItem[] = [
       {
         title: 'Errors',
         href: '/charts/zookeeper-exception',
-        description: 'History of error values from table system.errors',
+        description: 'System error logs and history',
         icon: ShieldAlertIcon,
       },
     ],


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new chart to track KEEPER_EXCEPTION errors, including changes to the query logic and UI components to support this feature. Update the menu and overview page to include the new errors tab and chart.

New Features:
- Introduce a new chart to track KEEPER_EXCEPTION errors over the last 7 days, providing a visual representation of error occurrences.

Enhancements:
- Add a new function `fillStep` to determine the interval step for filling data in ClickHouse queries.
- Add a new function `nowOrToday` to decide between using 'now()' or 'today()' based on the interval in ClickHouse queries.

<!-- Generated by sourcery-ai[bot]: end summary -->