### PR TITLE
feat(ci): e2e test against v24.7, v24.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         containers: [1]
         browser: [chrome, firefox, edge]
-        clickhouse: [24.5, 24.6]
+        clickhouse: [24.5, 24.6, 24.7, 24.8]
 
     services:
       clickhouse:


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Expand the CI testing matrix to include ClickHouse versions 24.7 and 24.8 for end-to-end tests.

CI:
- Update the CI workflow to include end-to-end tests against ClickHouse versions 24.7 and 24.8.

<!-- Generated by sourcery-ai[bot]: end summary -->