### PR TITLE
fix: correct the calculation of the 'expires_in' field in the query cache

### DIFF
--- a/app/[host]/[query]/queries/query-cache.ts
+++ b/app/[host]/[query]/queries/query-cache.ts
@@ -13,7 +13,7 @@ export const queryCacheConfig: QueryConfig = {
           shared,
           compressed,
           expires_at,
-          (now() - expires_at) AS expires_in,
+          (expires_at - now()) AS expires_in,
           key_hash
       FROM system.query_cache
       ORDER BY expires_at DESC


### PR DESCRIPTION
## Summary by Sourcery

Fix the calculation of the 'expires_in' field in the query cache configuration to ensure it correctly represents the time remaining until expiration.

Bug Fixes:
- Correct the calculation of the 'expires_in' field in the query cache configuration by subtracting the current time from 'expires_at'.