### PR TITLE
fix: database table explorer overflow

### DIFF
--- a/app/[host]/database/[database]/layout.tsx
+++ b/app/[host]/database/[database]/layout.tsx
@@ -23,7 +23,7 @@ export default async function TableListPage({ nav, children }: TableListProps) {
   return (
     <ResizablePanelGroup
       direction="horizontal"
-      className="h-full max-h-[800px] items-stretch gap-4"
+      className="h-full min-h-screen items-stretch gap-4"
     >
       <ResizablePanel
         defaultSize={10}


### PR DESCRIPTION
Fix https://github.com/duyet/clickhouse-monitoring/issues/412

## Summary by Sourcery

Bug Fixes:
- Fix data explorer overflow by adjusting the panel height to a minimum of the screen height.