### PR TITLE
feat: add ColumnFormat.Text column format to the data table component

### DIFF
--- a/app/[host]/database/[database]/page.tsx
+++ b/app/[host]/database/[database]/page.tsx
@@ -51,6 +51,12 @@ export default async function TableListPage({ params }: TableListProps) {
       readable_total_rows: ColumnFormat.BackgroundBar,
       readable_avg_part_size: ColumnFormat.BackgroundBar,
       compr_rate: ColumnFormat.BackgroundBar,
+      comment: [
+        ColumnFormat.Text,
+        {
+          className: 'line-clamp-1	hover:text-nowrap',
+        },
+      ],
       action: [ColumnFormat.Action, ['optimize']],
     },
   }

--- a/components/data-table/cells/text-format.cy.tsx
+++ b/components/data-table/cells/text-format.cy.tsx
@@ -1,0 +1,46 @@
+import { TextFormat } from './text-format'
+
+describe('<TextFormat />', () => {
+  it('renders basic text value', () => {
+    cy.mount(<TextFormat value="Hello World" />)
+    cy.contains('Hello World').should('be.visible')
+  })
+
+  it('applies default classes', () => {
+    cy.mount(<TextFormat value="Test" />)
+    cy.get('span').should('have.class', 'truncate')
+    cy.get('span').should('have.class', 'text-wrap')
+  })
+
+  it('applies custom className from options', () => {
+    cy.mount(
+      <TextFormat
+        value="Custom Class"
+        options={{ className: 'text-red-500' }}
+      />
+    )
+    cy.get('span')
+      .should('have.class', 'text-red-500')
+      .and('have.class', 'truncate')
+      .and('have.class', 'text-wrap')
+  })
+
+  it('handles non-string values', () => {
+    cy.mount(<TextFormat value={123} />)
+    cy.contains('123').should('be.visible')
+
+    cy.mount(<TextFormat value={true} />)
+    cy.contains('true').should('be.visible')
+  })
+
+  it('handles empty or null values', () => {
+    cy.mount(<TextFormat value={null} />)
+    cy.get('span').should('be.empty')
+
+    cy.mount(<TextFormat value={undefined} />)
+    cy.get('span').should('be.empty')
+
+    cy.mount(<TextFormat value="" />)
+    cy.get('span').should('be.empty')
+  })
+})

--- a/components/data-table/cells/text-format.tsx
+++ b/components/data-table/cells/text-format.tsx
@@ -1,0 +1,18 @@
+import { cn } from '@/lib/utils'
+
+export interface TextFormatOptions {
+  className?: string
+}
+
+interface TextFormatProps {
+  value: any
+  options?: TextFormatOptions
+}
+
+export function TextFormat({ value, options }: TextFormatProps) {
+  return (
+    <span className={cn('truncate text-wrap', options?.className)}>
+      {`${!!value ? value : ''}`}
+    </span>
+  )
+}

--- a/components/data-table/column-defs.tsx
+++ b/components/data-table/column-defs.tsx
@@ -72,6 +72,7 @@ export const getColumnDefs = <
         <Button
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+          className="truncate"
         >
           {formatHeader(name, columnFormat, config.columnIcons?.[name])}
 

--- a/components/data-table/format-cell.tsx
+++ b/components/data-table/format-cell.tsx
@@ -28,6 +28,7 @@ import {
 } from './cells/hover-card-format'
 import { LinkFormat } from './cells/link-format'
 import { RelatedTimeFormat } from './cells/related-time-format'
+import { TextFormat, type TextFormatOptions } from './cells/text-format'
 
 export const formatCell = <
   TData extends RowData,
@@ -117,6 +118,14 @@ export const formatCell = <
         />
       )
 
+    case ColumnFormat.Text:
+      return (
+        <TextFormat
+          value={value}
+          options={columnFormatOptions as TextFormatOptions}
+        />
+      )
+
     case ColumnFormat.HoverCard:
       return (
         <HoverCardFormat
@@ -127,6 +136,6 @@ export const formatCell = <
       )
 
     default:
-      return <span className="text-nowrap text-center">{value as string}</span>
+      return <span className="truncate text-wrap">{value as string}</span>
   }
 }

--- a/types/column-format.ts
+++ b/types/column-format.ts
@@ -5,6 +5,7 @@ import { type BackgroundBarOptions } from '@/components/data-table/cells/backgro
 import { type CodeDialogOptions } from '@/components/data-table/cells/code-dialog-format'
 import { type CodeToggleOptions } from '@/components/data-table/cells/code-toggle-format'
 import { type HoverCardOptions } from '@/components/data-table/cells/hover-card-format'
+import { type TextFormatOptions } from '@/components/data-table/cells/text-format'
 
 export enum ColumnFormat {
   BackgroundBar = 'background-bar',
@@ -21,12 +22,14 @@ export enum ColumnFormat {
   Badge = 'badge',
   Code = 'code',
   Link = 'link',
+  Text = 'text',
   None = 'none',
 }
 
 export type ColumnFormatWithArgs =
   | [ColumnFormat.Action, Action[]]
   | [ColumnFormat.Link, LinkProps]
+  | [ColumnFormat.Text, TextFormatOptions]
   | [ColumnFormat.HoverCard, HoverCardOptions]
   | [ColumnFormat.CodeDialog, CodeDialogOptions]
   | [ColumnFormat.CodeToggle, CodeToggleOptions]


### PR DESCRIPTION
Example config:

```ts
  columnFormats: {
    comment: [
      ColumnFormat.Text,
      {
         className: 'line-clamp-1 hover:text-nowrap',
       },
    ],
    // ...
  }
```

## Summary by Sourcery

Add a new 'Text' column format to the data table component, enabling text values to be formatted with custom options. Update the default text display to improve text handling with truncation and wrapping.

New Features:
- Introduce a new column format 'Text' in the data table component, allowing text values to be displayed with specific formatting options.

Enhancements:
- Modify the default text display in the data table to use 'truncate' and 'text-wrap' classes for better text handling.