### PR TITLE
feat: add view refreshes configuration and menu item

### DIFF
--- a/app/[host]/[query]/clickhouse-queries.ts
+++ b/app/[host]/[query]/clickhouse-queries.ts
@@ -29,6 +29,7 @@ import { readOnlyTablesConfig } from './tables/readonly-tables'
 import { replicasConfig } from './tables/replicas'
 import { replicationQueueConfig } from './tables/replication-queue'
 import { tablesOverviewConfig } from './tables/tables-overview'
+import { viewRefreshesConfig } from './tables/view-refreshes'
 
 export const queries: Array<QueryConfig> = [
   // Tables
@@ -39,6 +40,7 @@ export const queries: Array<QueryConfig> = [
   readOnlyTablesConfig,
   detachedPartsConfig,
   projectionsConfig,
+  viewRefreshesConfig,
 
   // Queries
   queryCacheConfig,

--- a/app/[host]/[query]/tables/view-refreshes.ts
+++ b/app/[host]/[query]/tables/view-refreshes.ts
@@ -1,0 +1,42 @@
+import { ColumnFormat } from '@/types/column-format'
+import { type QueryConfig } from '@/types/query-config'
+
+export const viewRefreshesConfig: QueryConfig = {
+  name: 'view-refreshes',
+  description: `Contains information about refresh operations for materialized views using the REFRESH keyword. https://clickhouse.com/docs/operations/system-tables/view_refreshes`,
+  sql: `
+    SELECT *
+    FROM system.view_refreshes
+    ORDER BY next_refresh_time DESC
+  `,
+  columns: [
+    'database',
+    'view',
+    'last_success_time',
+    'last_refresh_time',
+    'next_refresh_time',
+    'progress',
+    'status',
+    'retry',
+    'last_success_duration_ms',
+    'total_rows',
+    'read_rows',
+    'written_rows',
+    'exception',
+  ],
+  columnFormats: {
+    last_refresh_time: ColumnFormat.RelatedTime,
+    next_refresh_time: ColumnFormat.RelatedTime,
+    database: ColumnFormat.Text,
+    view: [
+      ColumnFormat.Link,
+      { href: '/[ctx.hostId]/database/[database]/[view]' },
+    ],
+    status: ColumnFormat.ColoredBadge,
+    total_rows: ColumnFormat.Number,
+    read_rows: ColumnFormat.Number,
+    written_rows: ColumnFormat.Number,
+    exception: ColumnFormat.Text,
+  },
+  relatedCharts: [],
+}

--- a/components/data-table/cells/related-time-format.tsx
+++ b/components/data-table/cells/related-time-format.tsx
@@ -4,7 +4,8 @@ interface RelatedTimeFormatProps {
   value: any
 }
 
-const CLICKHOUSE_TZ: string = process.env.CLICKHOUSE_TZ || ''
+const CLICKHOUSE_TZ: string =
+  process.env.NEXT_PUBLIC_CLICKHOUSE_TZ || process.env.CLICKHOUSE_TZ || ''
 
 export function RelatedTimeFormat({ value }: RelatedTimeFormatProps) {
   let fromNow

--- a/menu.ts
+++ b/menu.ts
@@ -104,6 +104,14 @@ export const menuItemsConfig: MenuItem[] = [
           'Projections store data in a format that optimizes query execution',
         icon: DatabaseZapIcon,
       },
+      {
+        title: 'View Refreshes',
+        href: '/view-refreshes',
+        description:
+          "Information about Refreshable Materialized Views. Contains all refreshable materialized views, regardless of whether there's a refresh in progress or not.",
+        countSql: `SELECT COUNT() FROM system.view_refreshes`,
+        icon: UpdateIcon,
+      },
     ],
   },
   {


### PR DESCRIPTION
Resolved https://github.com/duyet/clickhouse-monitoring/issues/481

## Summary by Sourcery

Adds a new page to display information about ClickHouse View Refreshes, including a menu item and a table view.

New Features:
- Adds a new "View Refreshes" menu item to the monitoring interface, providing access to information about refreshable materialized views.
- Implements a table view displaying data from the `system.view_refreshes` table, including details like database, view, refresh times, progress, and status.