### PR TITLE
chore: add maxDuration for `/query/<id>`

### DIFF
--- a/app/[host]/query/[query_id]/page.tsx
+++ b/app/[host]/query/[query_id]/page.tsx
@@ -8,7 +8,8 @@ import { QueryDetail } from './query-detail'
 import { PageProps } from './types'
 
 export const dynamic = 'force-dynamic'
-export const revalidate = 300
+export const revalidate = 3600
+export const maxDuration = 30
 
 export default async function Page({ params, searchParams }: PageProps) {
   const { query_id } = await params


### PR DESCRIPTION
## Summary by Sourcery

Modify page revalidation and add maximum duration for query page rendering

Chores:
- Increase page revalidation time from 5 minutes to 1 hour
- Set a maximum duration of 30 seconds for the query page rendering