### PR TITLE
feat(part-info): add part info page

### DIFF
--- a/app/[host]/[query]/tables/tables-overview.ts
+++ b/app/[host]/[query]/tables/tables-overview.ts
@@ -95,7 +95,10 @@ export const tablesOverviewConfig: QueryConfig = {
     readable_avg_part_size_uncompressed: ColumnFormat.BackgroundBar,
     readable_primary_keys_size: ColumnFormat.BackgroundBar,
     compr_rate: ColumnFormat.BackgroundBar,
-    parts_count: ColumnFormat.BackgroundBar,
+    parts_count: [
+      ColumnFormat.Link,
+      { href: '/[ctx.hostId]/part-info/[_database]/[_table]' },
+    ],
     readable_max_part_size_compressed: ColumnFormat.BackgroundBar,
     readable_max_part_size_uncompressed: ColumnFormat.BackgroundBar,
   },

--- a/app/[host]/database/[database]/page.tsx
+++ b/app/[host]/database/[database]/page.tsx
@@ -1,8 +1,9 @@
+import { type RowData } from '@tanstack/react-table'
+
 import { DataTable } from '@/components/data-table/data-table'
 import { fetchData } from '@/lib/clickhouse'
 import { ColumnFormat } from '@/types/column-format'
 import { type QueryConfig } from '@/types/query-config'
-import { type RowData } from '@tanstack/react-table'
 
 import { listTables } from '../queries'
 import { Toolbar } from './toolbar'

--- a/app/[host]/database/[database]/toolbar.tsx
+++ b/app/[host]/database/[database]/toolbar.tsx
@@ -1,7 +1,8 @@
-import { Button } from '@/components/ui/button'
-import { getScopedLink } from '@/lib/scoped-link'
 import { TextAlignBottomIcon } from '@radix-ui/react-icons'
 import Link from 'next/link'
+
+import { Button } from '@/components/ui/button'
+import { getScopedLink } from '@/lib/scoped-link'
 
 export const Toolbar = async ({ database }: { database: string }) => (
   <Link href={await getScopedLink(`/top-usage-tables?database=${database}`)}>

--- a/app/[host]/part-info/[database]/[table]/loading.tsx
+++ b/app/[host]/part-info/[database]/[table]/loading.tsx
@@ -1,0 +1,10 @@
+import { TableSkeleton } from '@/components/skeleton'
+
+export default function Loading() {
+  return (
+    <div className="flex flex-col gap-4">
+      <TableSkeleton />
+      <TableSkeleton />
+    </div>
+  )
+}

--- a/app/[host]/part-info/[database]/[table]/page.tsx
+++ b/app/[host]/part-info/[database]/[table]/page.tsx
@@ -1,0 +1,54 @@
+import { Suspense } from 'react'
+
+import {
+  levelCountConfig,
+  partitionCountConfig,
+} from '@/app/[host]/part-info/part-info-configs'
+import { TableSkeleton } from '@/components/skeleton'
+import { Table } from '@/components/table'
+
+interface PageProps {
+  params: Promise<{
+    host: string
+    database: string
+    table: string
+  }>
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 300
+
+export default async function Page({ params, searchParams }: PageProps) {
+  const { host, database, table } = await params
+  const searchParamsResolved = await searchParams
+
+  const paramsForTable = {
+    hostId: host,
+    database,
+    table,
+    ...searchParamsResolved,
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <Suspense fallback={<TableSkeleton />}>
+        <Table
+          title={`Partition Count`}
+          description={`Partition Count for ${database}.${table}`}
+          queryConfig={partitionCountConfig}
+          searchParams={paramsForTable}
+        />
+      </Suspense>
+
+      <Suspense fallback={<TableSkeleton />}>
+        <Table
+          title={`Level Count`}
+          description={`Level Count for ${database}.${table}`}
+          queryConfig={levelCountConfig}
+          searchParams={paramsForTable}
+        />
+      </Suspense>
+    </div>
+  )
+}

--- a/app/[host]/part-info/[database]/page.tsx
+++ b/app/[host]/part-info/[database]/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from 'next/navigation'
+
+import { getDefaultTable } from '@/app/[host]/part-info/get-database-tables'
+
+export default async function PartInfoRootPage({
+  params,
+}: {
+  params: Promise<{ host: string; database: string }>
+}) {
+  const { host, database } = await params
+  const defaultTable = await getDefaultTable(host, database)
+
+  if (!defaultTable) {
+    return <div>No default table found</div>
+  }
+
+  redirect(`/${host}/part-info/${database}/${defaultTable}`)
+}

--- a/app/[host]/part-info/get-database-tables.ts
+++ b/app/[host]/part-info/get-database-tables.ts
@@ -1,0 +1,50 @@
+import { fetchData } from '@/lib/clickhouse'
+
+export const getDefaultDatabase = async (host: string) => {
+  const databases = await getDatabases(host)
+  return databases?.[0] || ''
+}
+
+export const getDefaultTable = async (host: string, database: string) => {
+  const tables = await getTables(host, database)
+  return tables?.[0] || ''
+}
+
+export const getDatabases = async (host: string): Promise<string[]> => {
+  const items = await getDatabaseTables(host)
+  return items
+    .map((item) => item.database)
+    .reduce((acc, curr) => {
+      if (!acc.includes(curr)) {
+        acc.push(curr)
+      }
+      return acc
+    }, [] as string[])
+}
+
+export const getTables = async (
+  host: string,
+  database: string
+): Promise<string[]> => {
+  const items = await getDatabaseTables(host)
+  return items
+    .filter((item) => item.database === database)
+    .map((item) => item.table)
+}
+
+export const getDatabaseTables = async (host: string) => {
+  const { data } = await fetchData<{ database: string; table: string }[]>({
+    query:
+      "SELECT DISTINCT database, table FROM system.parts WHERE active AND lower(database) NOT IN ('system', 'information_schema')",
+    query_params: {},
+    clickhouse_settings: {
+      use_query_cache: 1,
+    },
+    hostId: host,
+  })
+
+  return data.map((table: { database: string; table: string }) => ({
+    database: table.database,
+    table: table.table,
+  }))
+}

--- a/app/[host]/part-info/layout.tsx
+++ b/app/[host]/part-info/layout.tsx
@@ -1,0 +1,30 @@
+import { Suspense } from 'react'
+import { getDatabases, getDatabaseTables } from './get-database-tables'
+import { DatabaseSelector, TableSelector } from './selectors'
+
+export default async function PartInfoLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ host: string; database?: string; table?: string }>
+}) {
+  const { host, database, table } = await params
+
+  const databaseTables = await getDatabaseTables(host)
+  const databases = await getDatabases(host)
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex gap-2">
+        <Suspense fallback={<div>Loading Databases...</div>}>
+          <DatabaseSelector host={host} databases={databases} />
+        </Suspense>
+        <Suspense fallback={<div>Loading Tables...</div>}>
+          <TableSelector host={host} databaseTables={databaseTables} />
+        </Suspense>
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/app/[host]/part-info/page.tsx
+++ b/app/[host]/part-info/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from 'next/navigation'
+
+import { getDefaultDatabase } from './get-database-tables'
+
+export default async function PartInfoRootPage({
+  params,
+}: {
+  params: Promise<{ host: string }>
+}) {
+  const { host } = await params
+  const defaultDatabase = await getDefaultDatabase(host)
+
+  if (!defaultDatabase) {
+    return <div>No default database found</div>
+  }
+
+  redirect(`/${host}/part-info/${defaultDatabase}`)
+}

--- a/app/[host]/part-info/part-info-configs.ts
+++ b/app/[host]/part-info/part-info-configs.ts
@@ -1,0 +1,65 @@
+import { ColumnFormat } from '@/types/column-format'
+import { type QueryConfig } from '@/types/query-config'
+
+export const partitionCountConfig: QueryConfig = {
+  name: 'partition-count',
+  sql: `
+    WITH partition_info AS (
+      SELECT
+        partition,
+        level,
+        rows
+      FROM system.parts
+      WHERE database = {database:String} AND \`table\` = {table:String} AND active
+    )
+    SELECT
+      partition,
+      count() AS count,
+      round(100 * count() / max(count()) OVER ()) AS pct_count
+    FROM partition_info
+    GROUP BY 1
+    ORDER BY 1 DESC
+    LIMIT {limit:UInt64}
+  `,
+  columns: ['partition', 'count'],
+  columnFormats: {
+    count: ColumnFormat.BackgroundBar,
+  },
+  defaultParams: {
+    database: 'default',
+    table: '',
+    limit: 100,
+  },
+}
+
+export const levelCountConfig: QueryConfig = {
+  name: 'level-count',
+  sql: `
+    WITH part_info AS (
+      SELECT
+        name,
+        level,
+        rows
+      FROM system.parts
+      WHERE database = {database:String} AND \`table\` = {table:String} AND active
+      ORDER BY name ASC
+    )
+    SELECT
+      level,
+      count() AS count,
+      round(100 * count() / max(count()) OVER ()) AS pct_count
+    FROM part_info
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT {limit:UInt64}
+  `,
+  columns: ['level', 'count'],
+  columnFormats: {
+    count: ColumnFormat.BackgroundBar,
+  },
+  defaultParams: {
+    database: 'default',
+    table: '',
+    limit: 100,
+  },
+}

--- a/app/[host]/part-info/selectors.tsx
+++ b/app/[host]/part-info/selectors.tsx
@@ -1,0 +1,77 @@
+'use client'
+import { redirect, useParams } from 'next/navigation'
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+export function DatabaseSelector({
+  host,
+  databases,
+}: {
+  host: string
+  databases: string[]
+}) {
+  const params = useParams()
+
+  const currentDatabase = params.database as string
+
+  const handleSelect = (newDatabase: string) => {
+    redirect(`/${host}/part-info/${newDatabase}`)
+  }
+
+  return (
+    <Select value={currentDatabase} onValueChange={handleSelect}>
+      <SelectTrigger className="w-[180px]">
+        <SelectValue placeholder="Select Database" />
+      </SelectTrigger>
+      <SelectContent>
+        {databases.map((db) => (
+          <SelectItem key={db} value={db}>
+            {db}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+export function TableSelector({
+  host,
+  databaseTables,
+}: {
+  host: string
+  databaseTables: { database: string; table: string }[]
+}) {
+  const params = useParams()
+
+  const currentDatabase = params.database as string
+  const currentTable = params.table as string
+
+  const handleSelect = (newTable: string) => {
+    redirect(`/${host}/part-info/${currentDatabase}/${newTable}`)
+  }
+
+  return (
+    <Select value={currentTable} onValueChange={handleSelect}>
+      <SelectTrigger className="w-[180px]">
+        <SelectValue placeholder="Select Table" />
+      </SelectTrigger>
+      <SelectContent>
+        {databaseTables
+          .filter(
+            (item) => item.database === currentDatabase || !currentDatabase
+          )
+          .map((tbl) => (
+            <SelectItem key={tbl.table} value={tbl.table}>
+              {tbl.table}
+            </SelectItem>
+          ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/menu.ts
+++ b/menu.ts
@@ -112,6 +112,13 @@ export const menuItemsConfig: MenuItem[] = [
         countSql: `SELECT COUNT() FROM system.view_refreshes`,
         icon: UpdateIcon,
       },
+      {
+        title: 'Part Info',
+        href: '/part-info',
+        description:
+          'Information about currently table active parts and levels',
+        icon: DatabaseZapIcon,
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary by Sourcery

Add a new Part Info page to provide detailed information about active table parts and levels

New Features:
- Introduce a new '/part-info' route that allows users to explore partition and level details for database tables
- Add dynamic selectors for databases and tables to navigate part information
- Implement part count and level count views with interactive selection

Enhancements:
- Modify tables overview to add a link to part info page for parts count
- Create reusable selectors for database and table navigation