### PR TITLE
chore(ci): using kimi-k2 via openrouter

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,9 +33,30 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Prepare Environment
+        run: |
+          curl -fsSL https://bun.sh/install | bash
+          mkdir -p $HOME/.claude-code-router
+          cat << 'EOF' > $HOME/.claude-code-router/config.json
+          {
+            "log": true,
+            "OPENAI_API_KEY": "${{ secrets.OPENROUTER_API_KEY }}",
+            "OPENAI_BASE_URL": "https://openrouter.ai/api/v1",
+            "OPENAI_MODEL": "moonshotai/kimi-k2:free"
+          }
+          EOF
+        shell: bash
+
+      - name: Start Claude Code Router
+        run: |
+          nohup ~/.bun/bin/bunx @musistudio/claude-code-router@1.0.8 start &
+        shell: bash
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@beta
+        env:
+          ANTHROPIC_BASE_URL: http://localhost:3456
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,9 +30,30 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Prepare Environment
+        run: |
+          curl -fsSL https://bun.sh/install | bash
+          mkdir -p $HOME/.claude-code-router
+          cat << 'EOF' > $HOME/.claude-code-router/config.json
+          {
+            "log": true,
+            "OPENAI_API_KEY": "${{ secrets.OPENROUTER_API_KEY }}",
+            "OPENAI_BASE_URL": "https://openrouter.ai/api/v1",
+            "OPENAI_MODEL": "moonshotai/kimi-k2:free"
+          }
+          EOF
+        shell: bash
+
+      - name: Start Claude Code Router
+        run: |
+          nohup ~/.bun/bin/bunx @musistudio/claude-code-router@1.0.8 start &
+        shell: bash
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@beta
+        env:
+          ANTHROPIC_BASE_URL: http://localhost:3456
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary by Sourcery

Configure the CI workflow to route Claude code review through a local Claude Code Router using the Kimi-K2 model via OpenRouter

CI:
- Install bun and set up the Claude Code Router with OpenRouter API key, base URL, and model
- Start the local Claude Code Router service before running the review
- Set ANTHROPIC_BASE_URL to localhost for the anthropic/claude-code-action