### PR TITLE
fix(menu): fix countVariant prop and text overflow in navigation menu

### DIFF
--- a/components/menu/menu-navigation-style.tsx
+++ b/components/menu/menu-navigation-style.tsx
@@ -112,7 +112,7 @@ function HasChildItems({ item }: { item: MenuItem }) {
                     >
                       <CountBadge
                         sql={childItem.countSql}
-                        variant={item.countVariant}
+                        variant={childItem.countVariant}
                       />
                     </ServerComponentLazy>
                   ) : null}
@@ -160,8 +160,10 @@ function ListItem({
             )}
             {...props}
           >
-            <div className="text-sm leading-none font-medium">{title}</div>
-            <p className="text-muted-foreground line-clamp-2 text-sm leading-snug">
+            <div className="text-sm leading-none font-medium overflow-hidden text-ellipsis">
+              {title}
+            </div>
+            <p className="text-muted-foreground line-clamp-2 text-sm leading-snug break-words">
               {description}
             </p>
           </div>


### PR DESCRIPTION
## Summary

Fixes two issues in the navigation menu component:

1. **Fixed incorrect countVariant prop** - Menu items were using parent `item.countVariant` instead of `childItem.countVariant`, causing incorrect badge styling
2. **Fixed text overflow** - Added proper overflow handling to prevent text from breaking menu layout:
   - Menu item titles now use `overflow-hidden` and `text-ellipsis` 
   - Menu item descriptions now use `break-words` for better text wrapping

## Changes

- `components/menu/menu-navigation-style.tsx`:
  - Line 115: Changed `variant={item.countVariant}` to `variant={childItem.countVariant}`
  - Line 163: Added `overflow-hidden text-ellipsis` to title div
  - Line 166: Added `break-words` to description paragraph

## Test plan

- [x] Linting passes (`pnpm lint`)
- [ ] Visual testing: Verify menu items render correctly without blank spaces
- [ ] Visual testing: Verify text overflow is handled properly
- [ ] Visual testing: Verify count badges have correct styling

## Related Issue

Fixes the blank menu item issue reported in the screenshot.

Co-Authored-By: duyetbot <duyetbot@users.noreply.github.com>

## Summary by Sourcery

Fix badge variant propagation and prevent text overflow in navigation menu items.

Bug Fixes:
- Use childItem.countVariant instead of parent item.countVariant for count badges

Enhancements:
- Add overflow-hidden and text-ellipsis to menu titles to handle overflow
- Add break-words to menu descriptions for improved text wrapping