### PR TITLE
fix: update cluster page routing and badge count

### DIFF
--- a/app/clusters/replicas-status/page.tsx
+++ b/app/clusters/replicas-status/page.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { Suspense } from 'react'
+import { TableSkeleton } from '@/components/skeletons'
+import { TableClient } from '@/components/tables/table-client'
+import { clustersReplicasStatusConfig } from '@/lib/query-config/system/replicas-status'
+import { useHostId } from '@/lib/swr'
+
+function ReplicasStatusContent() {
+  const searchParams = useSearchParams()
+  const hostId = useHostId()
+  const cluster = searchParams.get('cluster')
+
+  const clustersUrl = `/clusters?host=${hostId}`
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Breadcrumb and cluster info */}
+      <div className="bg-card flex items-center justify-between gap-4 rounded-lg border p-4">
+        <div className="flex items-center gap-2">
+          <Link
+            href={clustersUrl}
+            className="text-muted-foreground hover:text-foreground text-sm transition-colors"
+          >
+            Clusters
+          </Link>
+          <span className="text-muted-foreground">/</span>
+          <span className="font-medium">{cluster || 'Select a cluster'}</span>
+        </div>
+      </div>
+
+      {/* Table Content */}
+      {cluster ? (
+        <Suspense fallback={<TableSkeleton />}>
+          <TableClient
+            title={`Replicas Status: ${cluster}`}
+            description={clustersReplicasStatusConfig.description}
+            queryConfig={clustersReplicasStatusConfig}
+            searchParams={{ cluster }}
+          />
+        </Suspense>
+      ) : (
+        <div className="bg-card flex h-96 items-center justify-center rounded-lg border">
+          <p className="text-muted-foreground text-sm">
+            Select a cluster from the{' '}
+            <Link href={clustersUrl} className="text-primary hover:underline">
+              clusters list
+            </Link>{' '}
+            to view replicas status.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function ClusterReplicasStatusPage() {
+  return (
+    <Suspense fallback={<TableSkeleton />}>
+      <ReplicasStatusContent />
+    </Suspense>
+  )
+}

--- a/lib/api/clusters-api.ts
+++ b/lib/api/clusters-api.ts
@@ -24,13 +24,9 @@ export const queryConfig: QueryConfig = {
   `,
   columns: ['cluster', 'shard_count', 'replica_count', 'replica_status'],
   columnFormats: {
-    cluster: [
-      ColumnFormat.Link,
-      { href: `/clusters/[cluster]?host=[ctx.hostId]` },
-    ],
     replica_status: [
       ColumnFormat.Link,
-      { href: `/clusters/[cluster]/replicas-status?host=[ctx.hostId]` },
+      { href: `/clusters/replicas-status?cluster=[cluster]&host=[ctx.hostId]` },
     ],
   },
 }

--- a/lib/api/menu-count-registry.ts
+++ b/lib/api/menu-count-registry.ts
@@ -67,7 +67,7 @@ export const menuCountRegistry: Record<string, MenuCountQuery> = {
     query: `SELECT COUNT() as count FROM system.merge_tree_settings`,
   },
   clusters: {
-    query: `SELECT COUNT() as count FROM system.clusters`,
+    query: `SELECT COUNT(DISTINCT cluster) as count FROM system.clusters`,
   },
   backups: {
     query: `SELECT COUNT() as count FROM system.backup_log WHERE status = 'BACKUP_CREATED'`,

--- a/lib/query-config/system/clusters.ts
+++ b/lib/query-config/system/clusters.ts
@@ -24,10 +24,9 @@ export const clustersConfig: QueryConfig = {
   `,
   columns: ['cluster', 'shard_count', 'replica_count', 'replica_status'],
   columnFormats: {
-    cluster: [ColumnFormat.Link, { href: `/clusters/[cluster]` }],
     replica_status: [
       ColumnFormat.Link,
-      { href: `/clusters/[cluster]/replicas-status` },
+      { href: `/clusters/replicas-status?cluster=[cluster]&host=[ctx.hostId]` },
     ],
   },
 }


### PR DESCRIPTION
- Fix menu badge count to show distinct clusters instead of all rows
- Create /clusters/replicas-status static page with cluster query param
- Update cluster links to use static routing pattern (?cluster=xxx&host=0)
- Remove broken dynamic route links (/clusters/[cluster])

## Summary by Sourcery

Adjust cluster navigation and counts to use a static replicas status page with query parameters and correct menu badge totals.

New Features:
- Add a static /clusters/replicas-status page that displays replica status for a selected cluster via query parameters.

Bug Fixes:
- Fix the clusters menu badge to count distinct clusters instead of all rows in system.clusters.
- Update replica status links to point to the new static replicas-status page with cluster and host query parameters instead of broken dynamic routes.