### PR TITLE
fix: fix logo in dark mode

### DIFF
--- a/components/header/header-brand.tsx
+++ b/components/header/header-brand.tsx
@@ -24,7 +24,7 @@ export const HeaderBrand = memo(function HeaderBrand({
         aria-label="Go to overview"
         className="flex items-center transition-opacity hover:opacity-80"
       >
-        <ClickHouseLogo width={24} height={24} className="h-6 w-6" />
+        <ClickHouseLogo width={24} height={24} className="h-6 w-6 text-foreground dark:text-white" />
       </Link>
 
       {/* Title and Host Selector */}

--- a/components/icons/clickhouse-logo.tsx
+++ b/components/icons/clickhouse-logo.tsx
@@ -19,7 +19,7 @@ export const ClickHouseLogo = memo(function ClickHouseLogo({
       className={className}
     >
       <title>ClickHouse</title>
-      <path d="M21.333 10H24v4h-2.667ZM16 1.335h2.667v21.33H16Zm-5.333 0h2.666v21.33h-2.666ZM0 22.665V1.335h2.667v21.33zm5.333-21.33H8v21.33H5.333Z" />
+      <path fill="currentColor" d="M21.333 10H24v4h-2.667ZM16 1.335h2.667v21.33H16Zm-5.333 0h2.666v21.33h-2.666ZM0 22.665V1.335h2.667v21.33zm5.333-21.33H8v21.33H5.333Z" />
     </svg>
   )
 })


### PR DESCRIPTION
- Add fill="currentColor" to SVG path for proper color inheritance
- Add text color classes to logo element for light/dark mode support

## Summary by Sourcery

Ensure the header logo correctly adapts to light and dark themes by inheriting the current text color.

Enhancements:
- Update the header brand logo component to use theme-aware text color classes for light and dark mode.
- Adjust the ClickHouse logo SVG to inherit its color from the surrounding context via currentColor.