### PR TITLE
feat(agents): add schema migration assistant tools

### DIFF
--- a/lib/ai/agent/prompts/clickhouse-instructions.ts
+++ b/lib/ai/agent/prompts/clickhouse-instructions.ts
@@ -37,7 +37,7 @@ When queries fail due to missing columns:
 2. Suggest version-compatible alternatives
 3. Recommend upgrading if relevant features are unavailable
 
-## Available Tools (41 tools across 14 categories)
+## Available Tools (42 tools across 15 categories)
 
 ### Schema & Exploration
 - **query**: Execute read-only SQL queries (SELECT, WITH/CTE, DESCRIBE). Supports \`hostId\`, \`format\`.
@@ -104,6 +104,10 @@ When queries fail due to missing columns:
 
 ### Capacity Planning
 - **forecast_capacity**: Forecast storage and resource capacity based on 30-day trends. Analyzes storage growth, query volume, and disk state. Returns projections for days until disk full. Optional \`forecastDays\` (default: 90), supports \`hostId\`.
+
+### Schema Migration
+- **analyze_schema_change**: Analyze impact of a proposed ALTER TABLE before execution. Shows table state, parts, mutations, replication, and classifies change risk (LOW/HIGH). Required \`database\`, \`table\`, \`alterStatement\`. Supports \`hostId\`.
+- **get_column_usage**: Find queries referencing a column in query_log. Assesses blast radius of dropping/renaming columns. Required \`database\`, \`table\`, \`column\`. Optional \`lastDays\` (default: 7). Supports \`hostId\`.
 
 ### System
 - **get_zookeeper_info**: ZooKeeper/Keeper node data (optional table). Optional \`path\`, supports \`hostId\`.

--- a/lib/ai/agent/tools/index.ts
+++ b/lib/ai/agent/tools/index.ts
@@ -17,6 +17,7 @@ import { createHealthTools } from './health-tools'
 import { createIncidentTools } from './incident-tools'
 import { createLogTools } from './log-tools'
 import { createMergeTools } from './merge-tools'
+import { createMigrationTools } from './migration-tools'
 import { createOptimizerTools } from './optimizer-tools'
 import { createQueryTools } from './query-tools'
 import { createReplicationTools } from './replication-tools'
@@ -93,5 +94,8 @@ export function createAllTools(hostId: number) {
 
     // Incident response
     ...createIncidentTools(hostId),
+
+    // Schema migration
+    ...createMigrationTools(hostId),
   }
 }

--- a/lib/ai/agent/tools/migration-tools.ts
+++ b/lib/ai/agent/tools/migration-tools.ts
@@ -1,0 +1,254 @@
+/**
+ * Schema Migration Assistant Tools
+ *
+ * Tools to analyze the impact of schema changes and assess column usage
+ * before executing DDL operations on production tables.
+ */
+
+import { readOnlyQuery, resolveHostId } from './helpers'
+import { dynamicTool } from 'ai'
+import { z } from 'zod/v3'
+
+export function createMigrationTools(hostId: number) {
+  return {
+    analyze_schema_change: dynamicTool({
+      description:
+        'Analyze the impact of a proposed ALTER TABLE before executing it. Returns table state, active parts, running mutations, replication status, and classifies whether the change requires a data rewrite. Use before any DDL operation on production tables.',
+      inputSchema: z.object({
+        database: z.string().describe('Database name'),
+        table: z.string().describe('Table name'),
+        alterStatement: z
+          .string()
+          .describe(
+            'The ALTER TABLE statement to analyze (will NOT be executed)'
+          ),
+        hostId: z.number().int().optional().describe('Host ID override'),
+      }),
+      execute: async (input: unknown) => {
+        const {
+          database,
+          table,
+          alterStatement,
+          hostId: toolHostId,
+        } = input as {
+          database: string
+          table: string
+          alterStatement: string
+          hostId?: number
+        }
+        const resolved = resolveHostId(toolHostId, hostId)
+
+        const [tableInfo, parts, mutations, replication, columns] =
+          await Promise.all([
+            readOnlyQuery({
+              query: `SELECT engine, sorting_key, primary_key, partition_key, total_rows, total_bytes, formatReadableSize(total_bytes) as readable_size, create_table_query FROM system.tables WHERE database = {db:String} AND name = {tbl:String}`,
+              query_params: { db: database, tbl: table },
+              hostId: resolved,
+            }).catch((e: Error) => ({ error: e.message })),
+
+            readOnlyQuery({
+              query: `SELECT count() as active_parts, formatReadableSize(sum(bytes_on_disk)) as total_size, min(modification_time) as oldest_part, max(modification_time) as newest_part FROM system.parts WHERE database = {db:String} AND table = {tbl:String} AND active`,
+              query_params: { db: database, tbl: table },
+              hostId: resolved,
+            }).catch((e: Error) => ({ error: e.message })),
+
+            readOnlyQuery({
+              query: `SELECT mutation_id, command, create_time, parts_to_do, is_done FROM system.mutations WHERE database = {db:String} AND table = {tbl:String} ORDER BY create_time DESC LIMIT 5`,
+              query_params: { db: database, tbl: table },
+              hostId: resolved,
+            }).catch((e: Error) => ({ error: e.message })),
+
+            readOnlyQuery({
+              query: `SELECT is_leader, is_readonly, absolute_delay, queue_size, inserts_in_queue, merges_in_queue FROM system.replicas WHERE database = {db:String} AND table = {tbl:String}`,
+              query_params: { db: database, tbl: table },
+              hostId: resolved,
+            }).catch((e: Error) => ({ error: e.message })),
+
+            readOnlyQuery({
+              query: `SELECT name, type, default_kind, default_expression FROM system.columns WHERE database = {db:String} AND table = {tbl:String} ORDER BY position`,
+              query_params: { db: database, tbl: table },
+              hostId: resolved,
+            }).catch((e: Error) => ({ error: e.message })),
+          ])
+
+        // Classify the ALTER type
+        const alterLower = alterStatement.toLowerCase()
+        const { changeType, requiresRewrite } =
+          classifyAlterStatement(alterLower)
+
+        const warnings: string[] = []
+
+        if (requiresRewrite) {
+          warnings.push(
+            'This change requires rewriting all data parts. Schedule during low-traffic periods.'
+          )
+        }
+
+        if (
+          Array.isArray(mutations) &&
+          mutations.some((m: Record<string, unknown>) => !m.is_done)
+        ) {
+          warnings.push(
+            'There are pending mutations on this table. Wait for them to complete before adding more.'
+          )
+        }
+
+        return {
+          table: `${database}.${table}`,
+          proposed_change: alterStatement,
+          change_classification: {
+            type: changeType,
+            requires_data_rewrite: requiresRewrite,
+            risk_level: requiresRewrite ? 'HIGH' : 'LOW',
+          },
+          current_state: {
+            table_info: tableInfo,
+            parts,
+            pending_mutations: mutations,
+            replication,
+            columns,
+          },
+          warnings,
+        }
+      },
+    }),
+
+    get_column_usage: dynamicTool({
+      description:
+        'Analyze query_log to find which queries reference a specific column. Helps assess the blast radius of dropping or renaming a column. Returns query count, affected users, and sample queries.',
+      inputSchema: z.object({
+        database: z.string().describe('Database name'),
+        table: z.string().describe('Table name'),
+        column: z.string().describe('Column name to search for'),
+        lastDays: z
+          .number()
+          .int()
+          .min(1)
+          .max(30)
+          .optional()
+          .default(7)
+          .describe('Days of query history to search (default: 7)'),
+        hostId: z.number().int().optional().describe('Host ID override'),
+      }),
+      execute: async (input: unknown) => {
+        const {
+          database,
+          table,
+          column,
+          lastDays = 7,
+          hostId: toolHostId,
+        } = input as {
+          database: string
+          table: string
+          column: string
+          lastDays?: number
+          hostId?: number
+        }
+        const resolved = resolveHostId(toolHostId, hostId)
+        const safeDays = Math.floor(Math.max(1, Math.min(30, lastDays)))
+
+        const [usage, users] = await Promise.all([
+          readOnlyQuery({
+            query: `
+              SELECT
+                count() as query_count,
+                countDistinct(user) as unique_users,
+                min(event_time) as first_seen,
+                max(event_time) as last_seen
+              FROM system.query_log
+              WHERE type = 'QueryFinish'
+                AND event_time > now() - INTERVAL {days:UInt32} DAY
+                AND query LIKE {pattern:String}
+                AND has(tables, {fullTable:String})
+            `,
+            query_params: {
+              days: safeDays.toString(),
+              pattern: `%${column}%`,
+              fullTable: `${database}.${table}`,
+            },
+            hostId: resolved,
+          }).catch((e: Error) => ({ error: e.message })),
+
+          readOnlyQuery({
+            query: `
+              SELECT
+                user,
+                count() as query_count,
+                any(substring(query, 1, 300)) as sample_query
+              FROM system.query_log
+              WHERE type = 'QueryFinish'
+                AND event_time > now() - INTERVAL {days:UInt32} DAY
+                AND query LIKE {pattern:String}
+                AND has(tables, {fullTable:String})
+              GROUP BY user
+              ORDER BY query_count DESC
+              LIMIT 10
+            `,
+            query_params: {
+              days: safeDays.toString(),
+              pattern: `%${column}%`,
+              fullTable: `${database}.${table}`,
+            },
+            hostId: resolved,
+          }).catch((e: Error) => ({ error: e.message })),
+        ])
+
+        return {
+          column: `${database}.${table}.${column}`,
+          time_window_days: safeDays,
+          usage_summary: usage,
+          users_affected: users,
+          recommendation:
+            'Review the users and query patterns before proceeding with schema changes. Contact affected users if dropping the column.',
+        }
+      },
+    }),
+  }
+}
+
+/**
+ * Classify an ALTER TABLE statement to determine its type and whether
+ * it requires a data rewrite.
+ */
+function classifyAlterStatement(alterLower: string): {
+  changeType: string
+  requiresRewrite: boolean
+} {
+  if (alterLower.includes('add column')) {
+    return { changeType: 'add_column', requiresRewrite: false }
+  }
+  if (alterLower.includes('drop column')) {
+    return { changeType: 'drop_column', requiresRewrite: false }
+  }
+  if (
+    alterLower.includes('modify column') ||
+    alterLower.includes('alter column')
+  ) {
+    return { changeType: 'modify_column', requiresRewrite: true }
+  }
+  if (alterLower.includes('rename column')) {
+    return { changeType: 'rename_column', requiresRewrite: false }
+  }
+  if (alterLower.includes('drop index')) {
+    return { changeType: 'index_change', requiresRewrite: false }
+  }
+  if (alterLower.includes('add index')) {
+    return { changeType: 'index_change', requiresRewrite: true }
+  }
+  if (
+    alterLower.includes('modify order by') ||
+    alterLower.includes('modify sorting key')
+  ) {
+    return { changeType: 'sorting_key_change', requiresRewrite: true }
+  }
+  if (alterLower.includes('drop projection')) {
+    return { changeType: 'projection_change', requiresRewrite: false }
+  }
+  if (alterLower.includes('add projection')) {
+    return { changeType: 'projection_change', requiresRewrite: true }
+  }
+  if (alterLower.includes('modify ttl')) {
+    return { changeType: 'ttl_change', requiresRewrite: false }
+  }
+  return { changeType: 'unknown', requiresRewrite: false }
+}


### PR DESCRIPTION
## Summary
- Add `analyze_schema_change` tool that inspects table state, active parts, pending mutations, and replication status before DDL execution, classifying changes as LOW/HIGH risk based on whether a data rewrite is required
- Add `get_column_usage` tool that searches query_log to find queries referencing a specific column, helping assess the blast radius of dropping or renaming columns
- Register both tools in the agent tool index and document them in the ClickHouse agent instructions

## Test plan
- [x] TypeScript type check passes (`bun run type-check`)
- [x] All 1303 unit tests pass (`bun run test`)
- [ ] Manual: ask the agent "analyze this schema change: ALTER TABLE default.events ADD COLUMN new_col String" and verify structured response
- [ ] Manual: ask the agent "who uses the user_id column in default.events?" and verify query_log analysis

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce schema migration assistant tools for analyzing ClickHouse schema changes and column usage.

New Features:
- Add an analyze_schema_change tool to inspect table state, parts, mutations, replication, and classify ALTER TABLE risk before execution.
- Add a get_column_usage tool that analyzes query_log to identify queries and users referencing a specific column over a recent time window.
- Expose the new schema migration tools in the ClickHouse agent tool index and documentation.