### PR TITLE
feat(agents): wire AgentVisualization and AgentDataSources into tool output renderer

### DIFF
--- a/components/agents/agent-visualization.tsx
+++ b/components/agents/agent-visualization.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+export interface AgentVisualizationProps {
+  title?: string
+  sql: string
+  rows: Record<string, unknown>[]
+  columns: string[]
+  rowCount: number
+  viz: {
+    chartType: 'bar' | 'line' | 'area' | 'pie' | 'number' | 'table'
+    xKey: string
+    yKeys: string[]
+    sortBy?: string
+    sortOrder?: 'asc' | 'desc'
+    readable?: 'bytes' | 'duration' | 'number' | 'quantity'
+  }
+}
+
+export function AgentVisualization({
+  title,
+  rows,
+  rowCount,
+  viz,
+}: AgentVisualizationProps) {
+  return (
+    <div className="rounded-md border p-4">
+      <div className="text-sm font-medium">{title || 'Query Results'}</div>
+      <div className="text-xs text-muted-foreground mt-1">
+        {rowCount} rows · {viz.chartType} chart
+      </div>
+      <pre className="text-xs mt-2 max-h-48 overflow-auto">
+        {JSON.stringify(rows.slice(0, 5), null, 2)}
+      </pre>
+    </div>
+  )
+}

--- a/components/agents/agents-chat-area.tsx
+++ b/components/agents/agents-chat-area.tsx
@@ -44,12 +44,16 @@ import rehypeHighlight from 'rehype-highlight'
 import remarkGfm from 'remark-gfm'
 import './markdown-code.css'
 
+import type { AgentDataSourcesProps } from '@/components/agents/agent-data-sources'
+import type { AgentVisualizationProps } from '@/components/agents/agent-visualization'
 import type { Conversation } from '@/lib/ai/agent/conversation-utils'
 import type { QueryConfig } from '@/types/query-config'
 
 import { AgentChartRenderer } from '@/components/agents/agent-chart-renderer'
+import { AgentDataSources } from '@/components/agents/agent-data-sources'
 import { AgentErrorDisplay } from '@/components/agents/agent-error-display'
 import { AgentInsightCards } from '@/components/agents/agent-insight-cards'
+import { AgentVisualization } from '@/components/agents/agent-visualization'
 import {
   AskUserWidget,
   isAskUserOutput,
@@ -503,6 +507,32 @@ function ExpandTableButton({
 function renderToolOutput(output: unknown) {
   if (output == null) return null
 
+  const outputObj = output as Record<string, unknown>
+
+  // Visualization tool output (query_and_visualize)
+  if (outputObj.type === 'visualization' && Array.isArray(outputObj.rows)) {
+    return (
+      <AgentVisualization
+        title={outputObj.title as string | undefined}
+        sql={outputObj.sql as string}
+        rows={outputObj.rows as Record<string, unknown>[]}
+        columns={outputObj.columns as string[]}
+        rowCount={outputObj.rowCount as number}
+        viz={outputObj.viz as AgentVisualizationProps['viz']}
+      />
+    )
+  }
+
+  // Data source discovery output (discover_data_sources)
+  if (outputObj.type === 'data_sources' && Array.isArray(outputObj.sources)) {
+    return (
+      <AgentDataSources
+        searchTerm={outputObj.searchTerm as string}
+        sources={outputObj.sources as AgentDataSourcesProps['sources']}
+      />
+    )
+  }
+
   // Handle direct array output (e.g., list_databases, list_tables, get_table_schema)
   if (Array.isArray(output) && output.length > 0) {
     const firstItem = output[0] as Record<string, unknown>
@@ -510,8 +540,6 @@ function renderToolOutput(output: unknown) {
       return <ResultTable rows={output as unknown[]} maxRows={100} />
     }
   }
-
-  const outputObj = output as Record<string, unknown>
 
   // Check if output has chart data
   if (


### PR DESCRIPTION
## Summary

- Add stub components `AgentVisualization` and `AgentDataSources` with typed interfaces for TypeScript compilation
- Connect both into `renderToolOutput` in `agents-chat-area.tsx`, dispatching on `output.type === 'visualization'` and `output.type === 'data_sources'` before existing array/chartData checks
- Move `outputObj` cast above the array check so it's available for the new type guards

## Test plan

- [x] `bun run build` passes with zero TypeScript errors (Biome + tsc pre-commit checks passed)
- [ ] Full implementations from Unit 2 (AgentVisualization) and Unit 3 (AgentDataSources) will replace the stubs when those PRs are merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Wire new agent tool output types into the chat tool output renderer.

New Features:
- Add stub AgentVisualization component to display structured visualization tool output.
- Add stub AgentDataSources component to summarize discovered data source results in the UI.

Enhancements:
- Extend renderToolOutput to handle visualization and data_sources output types before existing array and chart handling logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Query results now display with visualization configuration, supporting multiple chart types including bar, line, area, pie, number, and table formats
- Agent tool outputs render dedicated components for query visualizations and data sources
- Result metadata displays row count and selected chart type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->