### PR TITLE
fix(agents): default to openrouter/free + simplify sidebar borders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,12 +54,19 @@ LLM_API_BASE=https://openrouter.ai/api/v1
 # Model to use for agent inference
 # Anthropic: claude-3-5-sonnet-20241022, claude-3-opus-20240229
 # OpenAI: gpt-4, gpt-4-turbo, gpt-3.5-turbo
-# OpenRouter free tier options (default: stepfun/step-3.5-flash:free)
-# - stepfun/step-3.5-flash:free (recommended, fast and reliable)
-# - nvidia/nemotron-3-super-120b-a12b:free (large model)
-# - google/gemma-3-27b-it:free (Google model)
-# - meta-llama/llama-3.1-8b-instruct:free (Meta model)
-LLM_MODEL=stepfun/step-3.5-flash:free
+# Default: openrouter/free — a meta-router that auto-selects a working free,
+# tool-capable model per request. Survives individual model deprecations.
+# Other OpenRouter options (all support tool use):
+# - openrouter/auto (auto-router, best quality, paid)
+# - z-ai/glm-4.5-air:free (verified reliable free)
+# - arcee-ai/trinity-large-preview:free (verified reliable free)
+# - qwen/qwen3-coder:free (1M context)
+# - qwen/qwen3-next-80b-a3b-instruct:free (262K context)
+# - openai/gpt-oss-120b:free / openai/gpt-oss-20b:free
+# - meta-llama/llama-3.3-70b-instruct:free
+# - google/gemma-4-31b-it:free
+# Some free providers require opting-in at https://openrouter.ai/settings/privacy
+LLM_MODEL=openrouter/free
 
 # Optional: Maximum tokens for LLM responses
 # LLM_MAX_TOKENS=4096

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -645,7 +645,7 @@ Add to `.env.local`:
 # LangGraph Agent Configuration
 LLM_API_KEY=your-openrouter-api-key
 LLM_API_BASE=https://openrouter.ai/api/v1  # OpenRouter supports multiple providers
-LLM_MODEL=stepfun/step-3.5-flash:free      # Free tier (recommended)
+LLM_MODEL=openrouter/free                   # Auto-routes to a working free model
 ```
 
 ### Agent Architecture

--- a/app/api/v1/agent/route.ts
+++ b/app/api/v1/agent/route.ts
@@ -95,8 +95,7 @@ export async function POST(request: Request) {
   }
 
   const hostId = typeof body.hostId === 'number' ? body.hostId : 0
-  const model =
-    body.model || process.env.LLM_MODEL || 'stepfun/step-3.5-flash:free'
+  const model = body.model || process.env.LLM_MODEL || 'openrouter/free'
   const disabledTools = Array.isArray(body.disabledTools)
     ? body.disabledTools.filter((t) => typeof t === 'string')
     : []

--- a/components/agents/agents-sidebar.tsx
+++ b/components/agents/agents-sidebar.tsx
@@ -148,8 +148,8 @@ function HostSelector({ hostId }: { readonly hostId: number }) {
 }
 
 function getProviderFromModelId(modelId: string): string {
+  if (modelId.startsWith('openrouter/')) return 'openrouter'
   if (modelId.startsWith('nvidia/')) return 'nvidia'
-  if (modelId.startsWith('stepfun/')) return 'openai'
   if (modelId.startsWith('z-ai/')) return 'zai'
   if (modelId.startsWith('google/') || modelId.startsWith('google-'))
     return 'google'
@@ -157,6 +157,9 @@ function getProviderFromModelId(modelId: string): string {
   if (modelId.startsWith('anthropic/')) return 'anthropic'
   if (modelId.startsWith('mistral/')) return 'mistral'
   if (modelId.startsWith('deepseek/')) return 'deepseek'
+  if (modelId.startsWith('qwen/')) return 'qwen'
+  if (modelId.startsWith('minimax/')) return 'minimax'
+  if (modelId.startsWith('arcee-ai/')) return 'arcee'
   if (modelId.startsWith('openai/')) return 'openai'
   return 'openrouter'
 }
@@ -336,7 +339,7 @@ function McpToolRow({
   return (
     <div
       className={cn(
-        'rounded-lg border border-border/60 bg-background/70 p-2.5 transition-colors',
+        'rounded-lg bg-muted/20 p-2.5 transition-colors',
         !enabled && 'opacity-80'
       )}
     >
@@ -371,14 +374,12 @@ function McpToolRow({
             </div>
           ) : null}
         </div>
-        <div className="rounded-full border border-border/60 bg-muted/20 p-0.5">
-          <Switch
-            checked={enabled}
-            onCheckedChange={onToggle}
-            className="h-5 w-9 border border-border/60 bg-muted-foreground/15 shadow-none data-[state=checked]:bg-primary [&>span]:bg-background"
-            aria-label={`${enabled ? 'Disable' : 'Enable'} ${tool.name}`}
-          />
-        </div>
+        <Switch
+          checked={enabled}
+          onCheckedChange={onToggle}
+          className="h-5 w-9 bg-muted-foreground/20 shadow-none data-[state=checked]:bg-primary [&>span]:bg-background"
+          aria-label={`${enabled ? 'Disable' : 'Enable'} ${tool.name}`}
+        />
       </div>
     </div>
   )
@@ -498,7 +499,7 @@ function McpToolsSection() {
           open={openSections.has('server')}
           onOpenChange={() => toggleSection('server')}
         >
-          <CollapsibleTrigger className="flex w-full items-center gap-3 rounded-lg border border-border/60 bg-background/70 px-3 py-2.5 text-left transition-colors hover:bg-muted/30">
+          <CollapsibleTrigger className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-muted/30">
             <TreeTriggerIcon open={openSections.has('server')} />
             <div className="flex min-w-0 flex-1 items-center gap-2">
               <DatabaseIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -630,7 +631,7 @@ function SkillsSection() {
         }
       >
         <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-          <CollapsibleTrigger className="flex w-full items-center gap-3 rounded-lg border border-border/60 bg-background/70 px-3 py-2.5 text-left transition-colors hover:bg-muted/30">
+          <CollapsibleTrigger className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-muted/30">
             <TreeTriggerIcon open={isOpen} />
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2 text-sm font-medium text-foreground">
@@ -650,9 +651,9 @@ function SkillsSection() {
                 key={skill.name}
                 type="button"
                 onClick={() => setShowTree(true)}
-                className="flex w-full items-start gap-3 rounded-lg border border-border/60 bg-muted/10 px-3 py-2.5 text-left transition-colors hover:bg-muted/25"
+                className="flex w-full items-start gap-3 rounded-lg bg-muted/15 px-3 py-2.5 text-left transition-colors hover:bg-muted/30"
               >
-                <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border bg-background text-muted-foreground">
+                <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-background text-muted-foreground">
                   <BookOpenIcon className="h-4 w-4" />
                 </span>
                 <div className="min-w-0 flex-1">
@@ -691,7 +692,7 @@ function SuggestedPromptsSection() {
         {SUGGESTED_PROMPTS.map((prompt) => (
           <li
             key={prompt}
-            className="rounded-lg border border-border/60 bg-muted/10 px-3 py-2.5 text-xs leading-5 text-muted-foreground transition-colors hover:bg-muted/25 hover:text-foreground"
+            className="rounded-lg bg-muted/15 px-3 py-2.5 text-xs leading-5 text-muted-foreground transition-colors hover:bg-muted/30 hover:text-foreground"
           >
             {prompt}
           </li>

--- a/docs/agents/api-reference.md
+++ b/docs/agents/api-reference.md
@@ -43,17 +43,25 @@ LLM_MODEL=gpt-4o-mini
 
 # Alternative: OpenRouter (supports multiple providers)
 LLM_API_BASE=https://openrouter.ai/api/v1
-LLM_MODEL=stepfun/step-3.5-flash:free
+LLM_MODEL=openrouter/free
 ```
 
 ### Model Options
 
+All free OpenRouter options listed below support tool use (required by the agent).
+
 | Model | Provider | Cost | Notes |
 |-------|----------|------|-------|
-| `stepfun/step-3.5-flash:free` | OpenRouter | Free | Fast & reliable (recommended) |
-| `nvidia/nemotron-3-super-120b-a12b:free` | OpenRouter | Free | Large 120B model |
-| `google/gemma-3-27b-it:free` | OpenRouter | Free | Google 27B model |
-| `meta-llama/llama-3.1-8b-instruct:free` | OpenRouter | Free | Meta 8B model |
+| `openrouter/free` | OpenRouter | Free | Auto-routes to a working free tool-capable model (default) |
+| `openrouter/auto` | OpenRouter | Paid | Auto-routes to best available model |
+| `z-ai/glm-4.5-air:free` | OpenRouter | Free | Reliable free, tool-capable |
+| `openai/gpt-oss-120b:free` | OpenRouter | Free | OpenAI 120B open-source |
+| `openai/gpt-oss-20b:free` | OpenRouter | Free | OpenAI 20B open-source |
+| `qwen/qwen3-coder:free` | OpenRouter | Free | 1M context window |
+| `qwen/qwen3-next-80b-a3b-instruct:free` | OpenRouter | Free | 262K context |
+| `meta-llama/llama-3.3-70b-instruct:free` | OpenRouter | Free | Meta 70B instruct |
+| `google/gemma-4-31b-it:free` | OpenRouter | Free | Google 31B instruct |
+| `arcee-ai/trinity-large-preview:free` | OpenRouter | Free | Arcee preview |
 | `gpt-4o-mini` | OpenAI | Paid | Best quality |
 | `anthropic/claude-3-haiku` | Anthropic | Paid | Fast & accurate |
 
@@ -66,7 +74,7 @@ import { createClickHouseAgent } from '@/lib/ai/agent'
 
 const agent = createClickHouseAgent({
   hostId: 0,
-  model: 'stepfun/step-3.5-flash:free',
+  model: 'openrouter/free',
   apiKey: process.env.LLM_API_KEY,
   baseURL: process.env.LLM_API_BASE,
 })
@@ -77,7 +85,7 @@ const agent = createClickHouseAgent({
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
 | `hostId` | `number` | Yes | - | ClickHouse host ID |
-| `model` | `string` | No | `'stepfun/step-3.5-flash:free'` | LLM model identifier |
+| `model` | `string` | No | `'openrouter/free'` | LLM model identifier |
 | `apiKey` | `string` | No | `process.env.LLM_API_KEY` | LLM API key |
 | `baseURL` | `string` | No | `process.env.LLM_API_BASE` | LLM API base URL |
 | `maxSteps` | `number` | No | `30` | Max tool execution steps |
@@ -229,7 +237,7 @@ export function ChatComponent() {
   const { messages, sendMessage, status } = useChat({
     transport: new DefaultChatTransport({
       api: '/api/v1/agent',
-      body: { hostId: 0, model: 'stepfun/step-3.5-flash:free' },
+      body: { hostId: 0, model: 'openrouter/free' },
     }),
   })
 

--- a/docs/agents/feature-guide.md
+++ b/docs/agents/feature-guide.md
@@ -19,14 +19,14 @@ Add the following environment variables to your `.env.local`:
 # LangGraph Agent Configuration - OpenRouter (Free Model)
 LLM_API_KEY=your-openrouter-api-key
 LLM_API_BASE=https://openrouter.ai/api/v1
-LLM_MODEL=stepfun/step-3.5-flash:free
+LLM_MODEL=openrouter/free
 ```
 
 **Supported Providers:**
 
 | Provider | Base URL | Models |
 |----------|----------|--------|
-| **OpenRouter** (Free tier) | `https://openrouter.ai/api/v1` | `stepfun/step-3.5-flash:free`, `nvidia/nemotron-3-super-120b-a12b:free`, `anthropic/claude-3.5-sonnet`, `openai/gpt-4` |
+| **OpenRouter** (Free tier) | `https://openrouter.ai/api/v1` | `openrouter/free` (auto-router), `z-ai/glm-4.5-air:free`, `qwen/qwen3-coder:free`, `meta-llama/llama-3.3-70b-instruct:free` |
 | Anthropic | `https://api.anthropic.com` | `claude-3-5-sonnet-20241022`, `claude-3-opus-20240229` |
 | OpenAI | `https://api.openai.com` | `gpt-4`, `gpt-4-turbo`, `gpt-3.5-turbo` |
 | Azure OpenAI | `https://your-resource.openai.azure.com` | `gpt-4` |

--- a/lib/ai/agent/__tests__/clickhouse-agent.test.ts
+++ b/lib/ai/agent/__tests__/clickhouse-agent.test.ts
@@ -75,7 +75,7 @@ describe('createClickHouseAgent', () => {
   test('creates agent with all custom options', () => {
     const agent = createClickHouseAgent({
       hostId: 1,
-      model: 'stepfun/step-3.5-flash:free',
+      model: 'openrouter/free',
       apiKey: 'custom-key',
       baseURL: 'https://openrouter.ai/api/v1',
       maxSteps: 20,

--- a/lib/ai/agent/analytics.ts
+++ b/lib/ai/agent/analytics.ts
@@ -42,12 +42,17 @@ export interface AgentUsageStats {
  * Prices are approximate — update as providers change rates.
  */
 export const MODEL_PRICING: Record<string, [number, number]> = {
-  // Free tier models
-  'stepfun/step-3.5-flash:free': [0, 0],
+  // OpenRouter meta-routers
+  'openrouter/free': [0, 0],
+  // Free tier models (OpenRouter, tool-use capable)
+  'z-ai/glm-4.5-air:free': [0, 0],
+  'openai/gpt-oss-120b:free': [0, 0],
+  'openai/gpt-oss-20b:free': [0, 0],
+  'qwen/qwen3-coder:free': [0, 0],
+  'qwen/qwen3-next-80b-a3b-instruct:free': [0, 0],
   'meta-llama/llama-3.3-70b-instruct:free': [0, 0],
-  'mistralai/mistral-7b-instruct:free': [0, 0],
-  'google/gemma-2-9b-it:free': [0, 0],
-  'qwen/qwen-2.5-7b-instruct:free': [0, 0],
+  'google/gemma-4-31b-it:free': [0, 0],
+  'arcee-ai/trinity-large-preview:free': [0, 0],
 
   // OpenAI models (via OpenRouter)
   'openai/gpt-4o': [2.5, 10],

--- a/lib/ai/agent/clickhouse-agent.ts
+++ b/lib/ai/agent/clickhouse-agent.ts
@@ -30,9 +30,9 @@ function filterTools<T extends Record<string, unknown>>(
 
 /**
  * Default model configuration
- * Falls back to stepfun/step-3.5-flash:free if LLM_MODEL env var is not set
+ * Falls back to openrouter/free if LLM_MODEL env var is not set
  */
-const DEFAULT_MODEL = process.env.LLM_MODEL || 'stepfun/step-3.5-flash:free'
+const DEFAULT_MODEL = process.env.LLM_MODEL || 'openrouter/free'
 
 /**
  * Returns true for Anthropic/Claude models routed via OpenRouter.
@@ -51,7 +51,8 @@ const DEFAULT_MAX_STEPS = 30
  */
 export function createClickHouseAgent(options: {
   /**
-   * The model to use for the agent (e.g., 'stepfun/step-3.5-flash:free')
+   * The model to use for the agent (e.g., 'openrouter/free')
+   * Defaults to 'openrouter/free' which auto-routes to a working free tool-capable model.
    */
   model?: string
 

--- a/lib/hooks/use-agent-model.ts
+++ b/lib/hooks/use-agent-model.ts
@@ -13,7 +13,7 @@ import { formatCompactNumber } from '@/lib/format-number'
  */
 const MODEL_STORAGE_KEY = 'clickhouse-monitor-agent-model'
 
-const DEFAULT_MODEL = 'qwen/qwen3.6-plus:free'
+const DEFAULT_MODEL = 'openrouter/free'
 
 /**
  * Format a token count to a compact human-readable string.
@@ -30,58 +30,65 @@ export function formatTokenCount(count: number): string {
  * the exact provider/model identifier chosen by the user.
  */
 export const AGENT_MODELS = {
-  'qwen/qwen3.6-plus:free': {
-    name: 'qwen/qwen3.6-plus:free',
-    description: 'Qwen model available by default',
-    contextLength: 128000,
+  'openrouter/free': {
+    name: 'openrouter/free',
+    description:
+      'OpenRouter auto-router: picks a working free tool-capable model (default)',
+    contextLength: 200000,
   },
-  'stepfun/step-3.5-flash:free': {
-    name: 'stepfun/step-3.5-flash:free',
-    description: 'StepFun model available by default',
-    contextLength: 128000,
+  'openrouter/auto': {
+    name: 'openrouter/auto',
+    description: 'OpenRouter auto-router: picks the best model (paid)',
+    contextLength: 2000000,
   },
   'z-ai/glm-4.5-air:free': {
     name: 'z-ai/glm-4.5-air:free',
-    description: 'Z.AI model available by default',
-    contextLength: 128000,
+    description: 'Z.AI GLM 4.5 Air, free tier',
+    contextLength: 131072,
   },
-  'nvidia/nemotron-3-nano-30b-a3b:free': {
-    name: 'nvidia/nemotron-3-nano-30b-a3b:free',
-    description: 'Compact NVIDIA model available by default',
-    contextLength: 128000,
+  'arcee-ai/trinity-large-preview:free': {
+    name: 'arcee-ai/trinity-large-preview:free',
+    description: 'Arcee Trinity Large Preview, free tier',
+    contextLength: 131000,
   },
-  'minimax/minimax-m2.5:free': {
-    name: 'minimax/minimax-m2.5:free',
-    description: 'MiniMax free tier model',
-    contextLength: 128000,
+  'qwen/qwen3-coder:free': {
+    name: 'qwen/qwen3-coder:free',
+    description: 'Qwen3 Coder, free tier, 1M context',
+    contextLength: 1048576,
+  },
+  'qwen/qwen3-next-80b-a3b-instruct:free': {
+    name: 'qwen/qwen3-next-80b-a3b-instruct:free',
+    description: 'Qwen3 Next 80B Instruct, free tier',
+    contextLength: 262144,
+  },
+  'openai/gpt-oss-120b:free': {
+    name: 'openai/gpt-oss-120b:free',
+    description: 'OpenAI GPT-OSS 120B, free tier',
+    contextLength: 131072,
+  },
+  'openai/gpt-oss-20b:free': {
+    name: 'openai/gpt-oss-20b:free',
+    description: 'OpenAI GPT-OSS 20B, free tier',
+    contextLength: 131072,
+  },
+  'meta-llama/llama-3.3-70b-instruct:free': {
+    name: 'meta-llama/llama-3.3-70b-instruct:free',
+    description: 'Meta Llama 3.3 70B Instruct, free tier',
+    contextLength: 131072,
+  },
+  'google/gemma-4-31b-it:free': {
+    name: 'google/gemma-4-31b-it:free',
+    description: 'Google Gemma 4 31B Instruct, free tier',
+    contextLength: 262144,
   },
   'minimax/minimax-m2.7': {
     name: 'minimax/minimax-m2.7',
-    description: 'MiniMax production model',
-    contextLength: 128000,
+    description: 'MiniMax production model (paid)',
+    contextLength: 200000,
     pricing: {
       inputPerMillion: 0.5,
       outputPerMillion: 1.5,
     },
-  },
-  'openai/gpt-5.4-nano': {
-    name: 'openai/gpt-5.4-nano',
-    description: 'OpenAI nano model',
-    contextLength: 128000,
-    pricing: {
-      inputPerMillion: 0.15,
-      outputPerMillion: 0.6,
-    },
-  },
-  'google/gemma-3-27b-it:free': {
-    name: 'google/gemma-3-27b-it:free',
-    description: 'Google, free tier, Gemma instruct model',
-    contextLength: 128000,
-  },
-  'meta-llama/llama-3.1-8b-instruct:free': {
-    name: 'meta-llama/llama-3.1-8b-instruct:free',
-    description: 'Meta, free tier, compact instruct model',
-    contextLength: 128000,
   },
 } as const
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -85,7 +85,7 @@ id = "78782c1fcf4141d9b6f26f2046f50ceb"
 #   - CLICKHOUSE_NAME: Comma-separated list of custom names for hosts (optional)
 #   - CLICKHOUSE_TZ: Timezone for ClickHouse queries (optional)
 #   - CLOUDFLARE_WORKERS: Set to "1" when running in Workers environment
-#   - LLM_MODEL: Model identifier for AI agent (default: stepfun/step-3.5-flash:free)
+#   - LLM_MODEL: Model identifier for AI agent (default: openrouter/free)
 #   - LLM_API_BASE: Base URL for LLM API (default: https://openrouter.ai/api/v1)
 #   - OPENROUTER_REFERER: App URL for OpenRouter attribution (optional)
 #   - OPENROUTER_APP_NAME: App display name for OpenRouter (optional)
@@ -150,7 +150,7 @@ CLICKHOUSE_USER = "duyet,default,duyet,duyet"
 CLICKHOUSE_NAME = "Duet Homelab,ClickHouse Playground,Tunnel,Docker"
 CLICKHOUSE_MAX_EXECUTION_TIME = "60"
 CLOUDFLARE_WORKERS = "1"
-LLM_MODEL = "stepfun/step-3.5-flash:free"
+LLM_MODEL = "openrouter/free"
 OPENROUTER_REFERER = "https://clickhouse.duyet.net"
 OPENROUTER_APP_NAME = "ClickHouse Monitoring"
 


### PR DESCRIPTION
## Summary

- **Root cause**: The default model `qwen/qwen3.6-plus:free` and several other listed options return `No endpoints found that support tool use` or guardrail errors on OpenRouter, breaking the agent page at `/agents?host=0`.
- **Fix**: Switch default to `openrouter/free`, OpenRouter's meta-router that auto-picks a working free tool-capable model per request — resilient to individual model deprecations.
- **Bonus**: Simplify nested borders in the agents sidebar per UX feedback.

## Model list changes

**Default**: `qwen/qwen3.6-plus:free` → `openrouter/free`

**Added** (all verified free + tool-use capable on OpenRouter as of today):
- `openrouter/free` — meta-router, always works
- `openrouter/auto` — best-model router (paid)
- `qwen/qwen3-coder:free` (1M context)
- `qwen/qwen3-next-80b-a3b-instruct:free` (262K)
- `openai/gpt-oss-120b:free`, `openai/gpt-oss-20b:free`
- `meta-llama/llama-3.3-70b-instruct:free`
- `google/gemma-4-31b-it:free`
- `arcee-ai/trinity-large-preview:free`

**Removed** (deprecated, region-blocked, or no tool-use support):
- `stepfun/step-3.5-flash:free` — deprecated
- `qwen/qwen3.6-plus:free` — free tier removed, paid only
- `nvidia/nemotron-3-nano-30b-a3b:free` — guardrail issues
- `minimax/minimax-m2.5:free` — guardrail issues
- `openai/gpt-5.4-nano` — region blocked
- `google/gemma-3-27b-it:free` — no tool-use
- `meta-llama/llama-3.1-8b-instruct:free` — no longer tool-capable on free tier

**Kept**: `z-ai/glm-4.5-air:free` (verified working), `minimax/minimax-m2.7` (paid).

## UI simplification

- Drop redundant inner borders (CollapsibleTriggers, McpToolRow, skill buttons, suggested prompt items) — the outer `SidebarSection` border already groups content.
- Replace stacked strokes with background-shade hierarchy (`bg-muted/15 → /20 → /30` on hover).
- Keep the tree-guide `border-l` (semantic) and outer section borders.

## Verification

- ✅ `bun run type-check` — passes
- ✅ `bun test lib/ai/agent/__tests__/` — 33/33 pass
- ✅ Live-tested `openrouter/free` against OpenRouter API — routes to `z-ai/glm-4.5-air:free` and returns proper `tool_calls`
- ✅ Live-tested `z-ai/glm-4.5-air:free` and `arcee-ai/trinity-large-preview:free` — both emit `tool_calls` correctly

## Test plan

- [ ] Open `/agents?host=0` in preview — agent chat responds without "No endpoints found" error
- [ ] Open model selector — dropdown lists the new models with the `openrouter/free` default on top
- [ ] Send a query like "how many rows in system.tables" — tool call executes
- [ ] Switch to `openrouter/auto` or a specific free model — still works
- [ ] Verify agents sidebar looks cleaner — fewer nested borders, background-based hierarchy

Fixes the errors reported from https://clickhouse-monitor-preview.duyet.workers.dev/agents?host=0

Co-Authored-By: duyetbot <duyetbot@users.noreply.github.com>

## Summary by Sourcery

Default the agents feature to the OpenRouter meta-router and refresh supported model options while simplifying the agents sidebar UI styling.

New Features:
- Add OpenRouter meta-router options (`openrouter/free` and `openrouter/auto`) and several new free, tool-capable OpenRouter models to the agent model list.

Bug Fixes:
- Switch the default agent model to `openrouter/free` and propagate this default across server, docs, config, and tests to avoid OpenRouter tool-use and endpoint errors on the agents page.

Enhancements:
- Update provider detection and analytics pricing mappings for the new OpenRouter, Qwen, MiniMax, and Arcee models.
- Simplify agents sidebar styling by removing redundant inner borders and relying on background shading for hierarchy.

Build:
- Update environment and deployment configuration defaults to use `openrouter/free` for the agent model.

Documentation:
- Revise agent documentation and examples to use `openrouter/free` as the default model and document the new OpenRouter model options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded available free model options for AI agents, including OpenRouter's auto-routing capability.

* **Improvements**
  * Updated default AI model configuration for enhanced availability and reliability.
  * Refined provider detection logic for better model identification.
  * Enhanced sidebar UI styling for improved visual consistency.

* **Chores**
  * Updated configuration defaults across development and deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->