### PR TITLE
fix(agents): require tool-capable endpoints on OpenRouter

### DIFF
--- a/lib/ai/agent/clickhouse-agent.ts
+++ b/lib/ai/agent/clickhouse-agent.ts
@@ -129,19 +129,22 @@ export function createClickHouseAgent(options: {
         `[Agent] Prompt caching enabled for Anthropic model: ${modelId}`
       )
     }
+    // Get tools for this host, filtering out disabled tools
+    const allTools = createMcpTools(hostId)
+    const tools = filterTools(allTools, disabledTools)
+    const hasTools = Object.keys(tools).length > 0
+
     // require_parameters: true forces OpenRouter to only route to endpoints
     // that support every parameter in the request — including `tools`. This
     // keeps meta-routers like `openrouter/free` from picking a free model
     // without tool-calling support, which otherwise fails with
-    // "No endpoints found that support tool use".
+    // "No endpoints found that support tool use". Skip the constraint when
+    // the user has disabled every tool, since a tool-less request has no
+    // reason to narrow the provider pool.
     const modelInstance = openrouter.chat(modelId, {
-      provider: { require_parameters: true },
+      ...(hasTools && { provider: { require_parameters: true } }),
       ...(usePromptCache && { cache_control: { type: 'ephemeral' } }),
     })
-
-    // Get tools for this host, filtering out disabled tools
-    const allTools = createMcpTools(hostId)
-    const tools = filterTools(allTools, disabledTools)
 
     // Create the agent
     const agent = new ToolLoopAgent({

--- a/lib/ai/agent/clickhouse-agent.ts
+++ b/lib/ai/agent/clickhouse-agent.ts
@@ -129,10 +129,15 @@ export function createClickHouseAgent(options: {
         `[Agent] Prompt caching enabled for Anthropic model: ${modelId}`
       )
     }
-    const modelInstance = openrouter.chat(
-      modelId,
-      usePromptCache ? { cache_control: { type: 'ephemeral' } } : undefined
-    )
+    // require_parameters: true forces OpenRouter to only route to endpoints
+    // that support every parameter in the request — including `tools`. This
+    // keeps meta-routers like `openrouter/free` from picking a free model
+    // without tool-calling support, which otherwise fails with
+    // "No endpoints found that support tool use".
+    const modelInstance = openrouter.chat(modelId, {
+      provider: { require_parameters: true },
+      ...(usePromptCache && { cache_control: { type: 'ephemeral' } }),
+    })
 
     // Get tools for this host, filtering out disabled tools
     const allTools = createMcpTools(hostId)


### PR DESCRIPTION
## Summary

- Sets `provider.require_parameters: true` on the OpenRouter chat settings so meta-routers like `openrouter/free` (the default) only pick endpoints that support every parameter in the request — including `tools`.
- Fixes the runtime error `"No endpoints found that support tool use. Try disabling 'query'"` that surfaced on https://clickhouse.duyet.net/agents?host=0 when the auto-router landed on a free model without tool-calling support.
- Merges the new `provider` field into the same `OpenRouterChatSettings` object that already holds `cache_control` — no `extraBody` escape hatch needed (see `OpenRouterChatSettings` in `@openrouter/ai-sdk-provider`).

## Why `require_parameters`?

Per [OpenRouter provider routing](https://openrouter.ai/docs/guides/routing/provider-selection#require-parameters), when `require_parameters: true` the router only dispatches to providers that support every parameter in the request. Because our agent always sends a `tools` array, this effectively filters the free pool down to tool-capable free endpoints only.

Non-OpenRouter paths are untouched.

## Test plan

- [x] `bun run type-check` passes locally
- [x] Biome/lint-staged pre-commit hook passes
- [ ] CI: unit tests (the known-flaky `unit-tests` job may still hang — that is pre-existing)
- [ ] Manual: visit `/agents?host=0` with `LLM_MODEL=openrouter/free` and confirm tool-calling no longer errors with "No endpoints found that support tool use"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: duyetbot <duyetbot@users.noreply.github.com>

## Summary by Sourcery

Ensure OpenRouter-routed agents only use tool-capable endpoints and continue to support optional prompt caching.

Bug Fixes:
- Prevent OpenRouter meta-router configurations like `openrouter/free` from selecting models without tool-calling support, which previously caused runtime errors when tools were requested.

Enhancements:
- Always configure OpenRouter chat calls with `provider.require_parameters: true` while preserving optional ephemeral prompt caching settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OpenRouter model routing configuration to ensure better compatibility with requested parameters and improve model selection reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->