### PR TITLE
fix(agent): harden OpenRouter free-model tool routing

### DIFF
--- a/lib/ai/agent/__tests__/clickhouse-agent-openrouter.test.ts
+++ b/lib/ai/agent/__tests__/clickhouse-agent-openrouter.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+const openRouterChatMock = mock(() => ({ provider: 'openrouter-chat-model' }))
+
+mock.module('server-only', () => ({}))
+mock.module('@/lib/ai/agent/mcp-tool-adapter', () => ({
+  createMcpTools: () => ({
+    get_running_queries: { description: 'Mock tool' },
+  }),
+}))
+mock.module('@openrouter/ai-sdk-provider', () => ({
+  createOpenRouter: () => ({
+    chat: openRouterChatMock,
+  }),
+}))
+mock.module('@ai-sdk/openai', () => ({
+  createOpenAI: () => ({
+    chat: () => ({ provider: 'openai-chat-model' }),
+  }),
+}))
+mock.module('ai', () => ({
+  ToolLoopAgent: class ToolLoopAgent {
+    id: string
+    model: unknown
+    tools: Record<string, unknown>
+    constructor(config: {
+      id: string
+      model: unknown
+      tools: Record<string, unknown>
+    }) {
+      this.id = config.id
+      this.model = config.model
+      this.tools = config.tools
+    }
+  },
+  stepCountIs: (n: number) => n,
+}))
+
+describe('createClickHouseAgent OpenRouter model resolution', () => {
+  const originalFallback = process.env.OPENROUTER_FREE_FALLBACK_MODEL
+
+  beforeEach(() => {
+    openRouterChatMock.mockClear()
+  })
+
+  afterEach(() => {
+    if (originalFallback) {
+      process.env.OPENROUTER_FREE_FALLBACK_MODEL = originalFallback
+    } else {
+      delete process.env.OPENROUTER_FREE_FALLBACK_MODEL
+    }
+  })
+
+  test('maps openrouter/free to fallback tool-capable model', async () => {
+    process.env.OPENROUTER_FREE_FALLBACK_MODEL = 'openai/gpt-oss-20b:free'
+    const { createClickHouseAgent } = await import('../clickhouse-agent')
+
+    createClickHouseAgent({
+      hostId: 0,
+      model: 'openrouter/free',
+      baseURL: 'https://openrouter.ai/api/v1',
+      apiKey: 'test-key',
+    })
+
+    expect(openRouterChatMock).toHaveBeenCalledWith(
+      'openai/gpt-oss-20b:free',
+      expect.any(Object)
+    )
+  })
+})

--- a/lib/ai/agent/clickhouse-agent.ts
+++ b/lib/ai/agent/clickhouse-agent.ts
@@ -33,6 +33,8 @@ function filterTools<T extends Record<string, unknown>>(
  * Falls back to openrouter/free if LLM_MODEL env var is not set
  */
 const DEFAULT_MODEL = process.env.LLM_MODEL || 'openrouter/free'
+const OPENROUTER_FREE_FALLBACK_MODEL =
+  process.env.OPENROUTER_FREE_FALLBACK_MODEL || 'qwen/qwen3-coder:free'
 
 /**
  * Returns true for Anthropic/Claude models routed via OpenRouter.
@@ -116,10 +118,23 @@ export function createClickHouseAgent(options: {
       },
     })
 
-    // For OpenRouter, use .chat() method and strip 'openrouter/' prefix if present
-    const modelId = model.startsWith('openrouter/')
+    // For OpenRouter, use .chat() method and strip 'openrouter/' prefix if present.
+    // The `openrouter/free` meta-router can intermittently return:
+    // "No endpoints found that support tool use".
+    // To keep the agent reliable, map `openrouter/free` to a concrete free
+    // model that supports tool calling by default.
+    const normalizedModelId = model.startsWith('openrouter/')
       ? model.replace('openrouter/', '')
       : model
+    const modelId =
+      normalizedModelId === 'free'
+        ? OPENROUTER_FREE_FALLBACK_MODEL
+        : normalizedModelId
+    if (normalizedModelId === 'free') {
+      console.warn(
+        `[Agent] openrouter/free resolved to fallback tool model: ${modelId}`
+      )
+    }
 
     // Prompt caching: static system instructions (~400 tokens) are ideal cache
     // candidates. Only Anthropic models support this via OpenRouter's cache_control.


### PR DESCRIPTION
### Motivation
- The `openrouter/free` meta-router can intermittently fail tool-enabled requests with `No endpoints found that support tool use`, causing agent calls that use tools to error. 

### Description
- Map `openrouter/free` to a concrete fallback tool-capable model via a new `OPENROUTER_FREE_FALLBACK_MODEL` (default: `qwen/qwen3-coder:free`) in `createClickHouseAgent` so tool calls avoid unstable meta-router routing.  
- Normalize the OpenRouter model id and apply the fallback when the normalized id is `free`, and emit a `console.warn` when the fallback mapping is applied.  
- Add a focused unit test `lib/ai/agent/__tests__/clickhouse-agent-openrouter.test.ts` to verify the `openrouter/free` → fallback resolution.  

### Testing
- Ran `bun test lib/ai/agent/__tests__/clickhouse-agent-openrouter.test.ts`, which passed.  
- Installed deps via `bun install` and ran `bun run build`, which completed successfully.  
- Pre-commit checks and TypeScript type check (`tsc --noEmit`) passed during commit hooks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3f7dbf188332ab887ef96d0f9af1)

## Summary by Sourcery

Ensure OpenRouter-based ClickHouse agents avoid the unstable `openrouter/free` meta-router by mapping it to a concrete, tool-capable fallback model.

New Features:
- Introduce an `OPENROUTER_FREE_FALLBACK_MODEL` configuration (defaulting to `qwen/qwen3-coder:free`) to control the concrete model used when `openrouter/free` is requested.

Enhancements:
- Normalize OpenRouter model IDs and transparently remap `openrouter/free` to the configured fallback model while emitting a console warning when this mapping occurs.

Tests:
- Add a unit test to verify that `createClickHouseAgent` resolves `openrouter/free` to the configured fallback model when using the OpenRouter chat provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for OpenRouter free model resolution behavior to ensure proper fallback mechanism validation and correct model routing across all agent implementations.

* **Bug Fixes**
  * Improved OpenRouter free model selection logic to properly normalize and resolve free-tier model requests, with automatic fallback to appropriate default models based on environment-specific configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->