### PR TITLE
Update agent docs and model capability UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,9 +69,11 @@ See `.claude/skills/clickhouse-query-config.md` for full patterns.
 
 ### Testing
 
-- `bun run test` - Run Jest unit tests with coverage
-- `bun run jest` - Run Jest tests (excludes query-config tests)
-- `bun run test-queries-config` - Run query config specific tests
+- `bun run test` - Run Bun unit tests (single concurrency)
+- `bun run test:unit` - Run focused unit test suites
+- `bun run test:query-config` - Run query config specific tests
+- `bun run test:coverage` - Run tests with coverage
+- `bun run test:watch` - Run tests in watch mode
 - `bun run component` - Open Cypress component tests
 - `bun run component:headless` - Run Cypress component tests headless
 - `bun run e2e` - Open Cypress e2e tests
@@ -477,13 +479,9 @@ export const backupsConfig: QueryConfig = {
 
 #### Testing Strategy
 
-- **Jest** for unit tests and utilities
-  - **Known Issue**: Jest hangs indefinitely in current environment, even with minimal configuration
-  - Issue persists with default settings, no ts-jest, no coverage, and bare minimum config
-  - Alternative test files (test-without-jest.js) work fine, indicating Node.js environment is functional
-  - **CI Workaround**: Jest tests temporarily disabled in GitHub Actions with 5-minute timeout
-  - Temporary workaround: Use Cypress for testing until Jest hanging issue is resolved
+- **Bun test** for unit tests and utilities (`bun test --max-concurrency=1` in CI)
 - **Cypress** for component and e2e tests
+- **Query-config tests** run with `bun run test:query-config` against ClickHouse service containers in CI
 - Component tests include visual regression testing
 - Test files are co-located with components (`.cy.tsx` files)
 

--- a/app/api/v1/agents/models/route.ts
+++ b/app/api/v1/agents/models/route.ts
@@ -1,0 +1,145 @@
+/**
+ * Agent Models Endpoint
+ *
+ * GET /api/v1/agents/models
+ *
+ * Returns available models with capability indicators fetched from OpenRouter.
+ * Used by the frontend to show which models support tools, streaming, etc.
+ *
+ * Caches the OpenRouter response for 5 minutes to avoid rate limiting.
+ */
+
+import { NextResponse } from 'next/server'
+import { AGENT_MODELS, type OpenAIModel } from '@/lib/hooks/use-agent-model'
+
+const OPENROUTER_MODELS_API = 'https://openrouter.ai/api/v1/models'
+const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
+interface ModelCapability {
+  id: OpenAIModel
+  name: string
+  description: string
+  contextLength: number
+  formattedContextLength: string
+  isFree: boolean
+  supportsTools: boolean
+  supportsStreaming: boolean
+  supportsVision: boolean
+  pricing?: {
+    inputPerMillion: number
+    outputPerMillion: number
+  }
+}
+
+let cachedModels: ModelCapability[] | null = null
+let cacheTime = 0
+
+/**
+ * Fetch models from OpenRouter and merge with our static AGENT_MODELS metadata.
+ */
+async function fetchOpenRouterModels(): Promise<ModelCapability[]> {
+  const response = await fetch(OPENROUTER_MODELS_API, {
+    headers: {
+      // OpenRouter requires identification
+      'HTTP-Referer': 'https://clickhouse.duyet.net',
+      'X-OpenRouter-Title': 'ClickHouse Monitor',
+    },
+    next: { revalidate: CACHE_TTL / 1000 },
+  })
+
+  if (!response.ok) {
+    throw new Error(`OpenRouter API error: ${response.status}`)
+  }
+
+  const data = (await response.json()) as {
+    data: Array<{
+      id: string
+      name: string
+      description?: string
+      context_length: number
+      pricing?: {
+        prompt: string
+        completion: string
+      }
+      architecture?: {
+        modality: string[]
+      }
+    }>
+  }
+
+  // Build a map of OpenRouter models by ID for quick lookup
+  const orModels = new Map(
+    data.data.map((m) => [
+      m.id,
+      {
+        name: m.name,
+        description: m.description,
+        contextLength: m.context_length,
+        pricing: m.pricing,
+        architecture: m.architecture,
+      },
+    ])
+  )
+
+  // Merge our static model list with OpenRouter's capability data
+  return Object.entries(AGENT_MODELS).map(([id, info]): ModelCapability => {
+    const orData = orModels.get(id)
+    const isFree = id.endsWith(':free') || !('pricing' in info)
+
+    // Determine capabilities from OpenRouter data or defaults
+    // Most modern models support streaming; tools support is more selective
+    const supportsStreaming =
+      orData?.architecture?.modality?.includes('text') ?? true
+    const supportsTools =
+      orData?.architecture?.modality?.includes('text+tool_calling') ?? false
+    const supportsVision =
+      orData?.architecture?.modality?.includes('image') ?? false
+
+    const result: ModelCapability = {
+      id: id as OpenAIModel,
+      name: info.name,
+      description: info.description,
+      contextLength: info.contextLength,
+      formattedContextLength: info.contextLength.toLocaleString(),
+      isFree,
+      supportsTools,
+      supportsStreaming,
+      supportsVision,
+    }
+
+    // Only include pricing if defined
+    if ('pricing' in info && info.pricing) {
+      result.pricing = info.pricing
+    }
+
+    return result
+  })
+}
+
+/**
+ * Handle GET requests for models with capabilities
+ */
+export async function GET() {
+  try {
+    // Check cache
+    const now = Date.now()
+    if (cachedModels && now - cacheTime < CACHE_TTL) {
+      return NextResponse.json({ models: cachedModels })
+    }
+
+    // Fetch from OpenRouter
+    const models = await fetchOpenRouterModels()
+
+    // Update cache
+    cachedModels = models
+    cacheTime = now
+
+    return NextResponse.json({ models })
+  } catch (error) {
+    console.error('Failed to fetch models from OpenRouter:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch model capabilities', models: [] },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/v1/agents/models/route.ts
+++ b/app/api/v1/agents/models/route.ts
@@ -13,6 +13,7 @@ import { NextResponse } from 'next/server'
 import {
   AGENT_MODELS,
   formatTokenCount,
+  isFreeAgentModel,
   type OpenAIModel,
 } from '@/lib/ai/agent-models'
 
@@ -91,7 +92,7 @@ async function fetchOpenRouterModels(): Promise<ModelCapability[]> {
   // Merge our static model list with OpenRouter's capability data
   return Object.entries(AGENT_MODELS).map(([id, info]): ModelCapability => {
     const orData = orModels.get(id)
-    const isFree = id.endsWith(':free')
+    const isFree = isFreeAgentModel(id)
 
     const inputModalities = [
       ...(orData?.architecture?.input_modalities ?? []),

--- a/app/api/v1/agents/models/route.ts
+++ b/app/api/v1/agents/models/route.ts
@@ -19,10 +19,8 @@ import {
 const OPENROUTER_MODELS_API =
   process.env.OPENROUTER_MODELS_API || 'https://openrouter.ai/api/v1/models'
 const CACHE_TTL_SECONDS = 5 * 60
-const OPENROUTER_REFERER =
-  process.env.OPENROUTER_REFERER || 'https://clickhouse.duyet.net'
-const OPENROUTER_APP_NAME =
-  process.env.OPENROUTER_APP_NAME || 'ClickHouse Monitor'
+const OPENROUTER_REFERER = process.env.OPENROUTER_REFERER
+const OPENROUTER_APP_NAME = process.env.OPENROUTER_APP_NAME
 
 interface ModelCapability {
   id: OpenAIModel
@@ -46,8 +44,8 @@ interface ModelCapability {
 async function fetchOpenRouterModels(): Promise<ModelCapability[]> {
   const response = await fetch(OPENROUTER_MODELS_API, {
     headers: {
-      'HTTP-Referer': OPENROUTER_REFERER,
-      'X-OpenRouter-Title': OPENROUTER_APP_NAME,
+      ...(OPENROUTER_REFERER && { 'HTTP-Referer': OPENROUTER_REFERER }),
+      ...(OPENROUTER_APP_NAME && { 'X-OpenRouter-Title': OPENROUTER_APP_NAME }),
     },
     next: { revalidate: CACHE_TTL_SECONDS },
   })
@@ -93,7 +91,7 @@ async function fetchOpenRouterModels(): Promise<ModelCapability[]> {
   // Merge our static model list with OpenRouter's capability data
   return Object.entries(AGENT_MODELS).map(([id, info]): ModelCapability => {
     const orData = orModels.get(id)
-    const isFree = id.endsWith(':free') || !('pricing' in info)
+    const isFree = id.endsWith(':free')
 
     const inputModalities = [
       ...(orData?.architecture?.input_modalities ?? []),

--- a/app/api/v1/agents/models/route.ts
+++ b/app/api/v1/agents/models/route.ts
@@ -93,30 +93,33 @@ async function fetchOpenRouterModels(): Promise<ModelCapability[]> {
   return Object.entries(AGENT_MODELS).map(([id, info]): ModelCapability => {
     const orData = orModels.get(id)
     const isFree = isFreeAgentModel(id)
-
+    const rawModality = orData?.architecture?.modality
+    const modalityList = Array.isArray(rawModality)
+      ? rawModality
+      : rawModality
+        ? [rawModality]
+        : []
     const inputModalities = [
       ...(orData?.architecture?.input_modalities ?? []),
-      ...(Array.isArray(orData?.architecture?.modality)
-        ? (orData?.architecture?.modality ?? [])
-        : orData?.architecture?.modality
-          ? [orData.architecture.modality]
-          : []),
-    ]
+      ...modalityList.map((modality) => modality.split('->')[0] ?? ''),
+    ].map((modality) => modality.trim().toLowerCase())
     const supportedParameters = orData?.supportedParameters ?? []
     const supportsTools =
       supportedParameters.includes('tools') ||
       supportedParameters.includes('tool_choice')
-    const supportsStreaming = true
+    const supportsStreaming =
+      orData?.architecture?.output_modalities?.includes('text') ?? false
     const supportsVision = inputModalities.some((modality) =>
-      modality.toLowerCase().includes('image')
+      modality.includes('image')
     )
+    const contextLength = orData?.contextLength ?? info.contextLength
 
     const result: ModelCapability = {
       id: id as OpenAIModel,
       name: info.name,
       description: info.description,
-      contextLength: info.contextLength,
-      formattedContextLength: formatTokenCount(info.contextLength),
+      contextLength,
+      formattedContextLength: formatTokenCount(contextLength),
       isFree,
       supportsTools,
       supportsStreaming,

--- a/components/agents/agent-settings.tsx
+++ b/components/agents/agent-settings.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Badge } from '@/components/ui/badge'
 import {
   Select,
   SelectContent,
@@ -22,7 +23,7 @@ export interface AgentSettingsProps {
  *
  * Features:
  * - Model selection dropdown with free tier models
- * - Capability badges (Streaming, Tools, Context, Fast)
+ * - Capability badges (Tools, Streaming, Vision)
  * - Human-readable model names
  * - Auto-saves to localStorage
  *
@@ -55,18 +56,57 @@ export function AgentSettings({ onModelChange }: AgentSettingsProps) {
         <SelectContent>
           {models.map((m) => (
             <SelectItem key={m.id} value={m.id} className="text-xs">
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 flex-wrap">
                 <span>{m.name}</span>
+                {m.supportsTools && (
+                  <Badge variant="outline" className="text-[10px] px-1">
+                    Tools
+                  </Badge>
+                )}
+                {m.supportsStreaming && (
+                  <Badge variant="outline" className="text-[10px] px-1">
+                    Stream
+                  </Badge>
+                )}
+                {m.supportsVision && (
+                  <Badge variant="outline" className="text-[10px] px-1">
+                    Vision
+                  </Badge>
+                )}
+                {m.isFree && (
+                  <Badge variant="secondary" className="text-[10px] px-1">
+                    Free
+                  </Badge>
+                )}
               </div>
             </SelectItem>
           ))}
         </SelectContent>
       </Select>
 
-      {/* Model info */}
+      {/* Model info with capabilities */}
       {currentModelData && (
-        <div className="text-xs text-muted-foreground">
-          {currentModelData.description}
+        <div className="flex flex-col gap-1">
+          <div className="text-xs text-muted-foreground">
+            {currentModelData.description}
+          </div>
+          <div className="flex items-center gap-1 flex-wrap">
+            {currentModelData.supportsTools && (
+              <Badge variant="default" className="text-[10px]">
+                ✓ Tools
+              </Badge>
+            )}
+            {currentModelData.supportsStreaming && (
+              <Badge variant="default" className="text-[10px]">
+                ✓ Streaming
+              </Badge>
+            )}
+            {currentModelData.supportsVision && (
+              <Badge variant="default" className="text-[10px]">
+                ✓ Vision
+              </Badge>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -67,7 +67,7 @@ export function NavUser({
       className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
       data-testid="nav-user-trigger"
     >
-      <Avatar className="h-8 w-8 rounded-lg">
+      <Avatar className="avatar h-8 w-8 rounded-lg">
         <AvatarImage src={user.avatar} alt={user.name} />
         <AvatarFallback className="rounded-lg">G</AvatarFallback>
       </Avatar>
@@ -88,7 +88,7 @@ export function NavUser({
       <SidebarMenu>
         <SidebarMenuItem>
           <ClientOnly fallback={userButton}>
-            <DropdownMenu>
+            <DropdownMenu modal={false}>
               <DropdownMenuTrigger asChild>{userButton}</DropdownMenuTrigger>
               <DropdownMenuContent
                 className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
@@ -98,7 +98,7 @@ export function NavUser({
               >
                 <DropdownMenuLabel className="p-0 font-normal">
                   <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                    <Avatar className="h-8 w-8 rounded-lg">
+                    <Avatar className="avatar h-8 w-8 rounded-lg">
                       <AvatarImage src={user.avatar} alt={user.name} />
                       <AvatarFallback className="rounded-lg">G</AvatarFallback>
                     </Avatar>
@@ -132,8 +132,7 @@ export function NavUser({
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     className="flex items-center gap-2"
-                    onSelect={(e) => {
-                      e.preventDefault()
+                    onSelect={() => {
                       setSettingsOpen(true)
                     }}
                     data-testid="nav-user-settings"

--- a/components/nav-user/clerk-nav.tsx
+++ b/components/nav-user/clerk-nav.tsx
@@ -71,7 +71,7 @@ export function ClerkNavWrapper() {
                 className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
                 data-testid="nav-user-trigger"
               >
-                <Avatar className="h-8 w-8 rounded-lg">
+                <Avatar className="avatar h-8 w-8 rounded-lg">
                   <AvatarFallback className="rounded-lg bg-primary/10 text-primary">
                     <UserIcon className="h-4 w-4" />
                   </AvatarFallback>
@@ -88,14 +88,14 @@ export function ClerkNavWrapper() {
 
           {/* Signed in - show user menu with avatar */}
           {isSignedIn && (
-            <DropdownMenu>
+            <DropdownMenu modal={false}>
               <DropdownMenuTrigger asChild>
                 <SidebarMenuButton
                   size="lg"
                   className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
                   data-testid="nav-user-trigger"
                 >
-                  <Avatar className="h-8 w-8 rounded-lg">
+                  <Avatar className="avatar h-8 w-8 rounded-lg">
                     <AvatarImage
                       src={user?.imageUrl}
                       alt={user?.fullName ?? 'User'}
@@ -129,7 +129,7 @@ export function ClerkNavWrapper() {
               >
                 <DropdownMenuLabel className="p-0 font-normal">
                   <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                    <Avatar className="h-8 w-8 rounded-lg">
+                    <Avatar className="avatar h-8 w-8 rounded-lg">
                       <AvatarImage
                         src={user?.imageUrl}
                         alt={user?.fullName ?? 'User'}
@@ -183,8 +183,7 @@ export function ClerkNavWrapper() {
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     className="flex items-center gap-2"
-                    onSelect={(e) => {
-                      e.preventDefault()
+                    onSelect={() => {
                       setSettingsOpen(true)
                     }}
                     data-testid="nav-user-settings"

--- a/components/settings/settings-dialog.tsx
+++ b/components/settings/settings-dialog.tsx
@@ -46,7 +46,7 @@ export function SettingsDialog({
           )}
         </DialogTrigger>
       )}
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md" data-testid="settings-dialog">
         <DialogHeader>
           <DialogTitle>Settings</DialogTitle>
         </DialogHeader>

--- a/cypress/e2e/authentication.cy.ts
+++ b/cypress/e2e/authentication.cy.ts
@@ -136,8 +136,9 @@ describe('Authentication', () => {
       cy.get('[data-testid="nav-user-trigger"]').click()
       cy.get('[data-testid="nav-user-about"]').should('be.visible')
 
-      // Click outside the menu (on the main content area)
-      cy.get('main').click()
+      // Click outside the menu at a stable viewport coordinate. Clicking the
+      // center of <main> is brittle because chart content can cover that point.
+      cy.get('body').click(10, 10)
 
       // Menu should close (DropdownMenu handles this automatically via Radix)
       cy.get('[data-testid="nav-user-about"]').should('not.exist')

--- a/lib/ai/agent-models.test.ts
+++ b/lib/ai/agent-models.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test'
+import { isFreeAgentModel } from './agent-models'
+
+describe('isFreeAgentModel', () => {
+  test('recognizes OpenRouter free router and explicit free suffixes', () => {
+    expect(isFreeAgentModel('openrouter/free')).toBe(true)
+    expect(isFreeAgentModel('qwen/qwen3-coder:free')).toBe(true)
+  })
+
+  test('does not treat unknown pricing as free', () => {
+    expect(isFreeAgentModel('openrouter/auto')).toBe(false)
+    expect(isFreeAgentModel('minimax/minimax-m2.7')).toBe(false)
+  })
+})

--- a/lib/ai/agent-models.ts
+++ b/lib/ai/agent-models.ts
@@ -83,6 +83,10 @@ export function formatTokenCount(count: number): string {
   return formatCompactNumber(count)
 }
 
+export function isFreeAgentModel(model: string): boolean {
+  return model === 'openrouter/free' || model.endsWith(':free')
+}
+
 export function isKnownModel(
   model: string
 ): model is keyof typeof AGENT_MODELS {

--- a/lib/ai/agent-models.ts
+++ b/lib/ai/agent-models.ts
@@ -83,6 +83,13 @@ export function formatTokenCount(count: number): string {
   return formatCompactNumber(count)
 }
 
+/**
+ * Returns true for OpenRouter free-tier model IDs.
+ *
+ * Matches the free auto-router (`openrouter/free`) and explicit `:free`
+ * suffixes. `openrouter/free` needs the exact match because it does not use the
+ * suffix convention.
+ */
 export function isFreeAgentModel(model: string): boolean {
   return model === 'openrouter/free' || model.endsWith(':free')
 }

--- a/lib/hooks/use-agent-model.ts
+++ b/lib/hooks/use-agent-model.ts
@@ -114,7 +114,7 @@ export interface UseAgentModelResult {
  */
 function getStaticModels(): ModelDisplayInfo[] {
   return Object.entries(AGENT_MODELS).map(([id, info]): ModelDisplayInfo => {
-    const isFree = id.endsWith(':free') || !('pricing' in info)
+    const isFree = id.endsWith(':free')
     const pricing =
       'pricing' in info ? (info.pricing as ModelPricing) : undefined
 
@@ -175,7 +175,20 @@ export function useAgentModel(): UseAgentModelResult {
 
   // Fetch models on mount
   useEffect(() => {
-    fetchModelsWithCapabilities().then(setModels)
+    let cancelled = false
+
+    async function loadModels() {
+      const nextModels = await fetchModelsWithCapabilities()
+      if (!cancelled && nextModels.length > 0) {
+        setModels(nextModels)
+      }
+    }
+
+    loadModels()
+
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   // Update model selection

--- a/lib/hooks/use-agent-model.ts
+++ b/lib/hooks/use-agent-model.ts
@@ -5,7 +5,7 @@
  * Persists selection to localStorage and provides model metadata.
  */
 
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { formatCompactNumber } from '@/lib/format-number'
 
 /**
@@ -158,7 +158,7 @@ export interface ModelPricing {
 }
 
 /**
- * Model display metadata
+ * Model display metadata with capability indicators
  */
 export interface ModelDisplayInfo {
   /** Model ID */
@@ -175,6 +175,12 @@ export interface ModelDisplayInfo {
   isFree: boolean
   /** Pricing info for paid models */
   pricing?: ModelPricing
+  /** Whether the model supports tool/function calling */
+  supportsTools?: boolean
+  /** Whether the model supports streaming responses */
+  supportsStreaming?: boolean
+  /** Whether the model supports vision/image input */
+  supportsVision?: boolean
 }
 
 /**
@@ -192,10 +198,42 @@ export interface UseAgentModelResult {
 }
 
 /**
+ * Fetch models with capability indicators from the API
+ */
+async function fetchModelsWithCapabilities(): Promise<ModelDisplayInfo[]> {
+  try {
+    const response = await fetch('/api/v1/agents/models')
+    if (!response.ok) {
+      throw new Error('Failed to fetch models')
+    }
+    const data = (await response.json()) as { models: ModelDisplayInfo[] }
+    return data.models
+  } catch {
+    // Fallback to static models without capabilities
+    return Object.entries(AGENT_MODELS).map(([id, info]): ModelDisplayInfo => {
+      const isFree = id.endsWith(':free') || !('pricing' in info)
+      const pricing =
+        'pricing' in info ? (info.pricing as ModelPricing) : undefined
+
+      return {
+        id,
+        name: info.name,
+        description: info.description,
+        contextLength: info.contextLength,
+        formattedContextLength: formatTokenCount(info.contextLength),
+        isFree,
+        pricing,
+      }
+    })
+  }
+}
+
+/**
  * Hook for managing agent model selection
  *
  * Provides model selection state with localStorage persistence
- * and model metadata for UI rendering.
+ * and model metadata for UI rendering. Fetches capability indicators
+ * from OpenRouter via the API.
  *
  * @returns Model selection state and actions
  *
@@ -214,23 +252,12 @@ export function useAgentModel(): UseAgentModelResult {
   // Get current model (uses saved value or default)
   const model = useMemo(() => getSavedModel(), [])
 
-  // Get all available models
-  const models = useMemo(() => {
-    return Object.entries(AGENT_MODELS).map(([id, info]): ModelDisplayInfo => {
-      const isFree = id.endsWith(':free') || !('pricing' in info)
-      const pricing =
-        'pricing' in info ? (info.pricing as ModelPricing) : undefined
+  // Get all available models with capabilities
+  const [models, setModels] = useState<ModelDisplayInfo[]>([])
 
-      return {
-        id,
-        name: info.name,
-        description: info.description,
-        contextLength: info.contextLength,
-        formattedContextLength: formatTokenCount(info.contextLength),
-        isFree,
-        pricing,
-      }
-    })
+  // Fetch models on mount
+  useEffect(() => {
+    fetchModelsWithCapabilities().then(setModels)
   }, [])
 
   // Update model selection

--- a/lib/hooks/use-agent-model.ts
+++ b/lib/hooks/use-agent-model.ts
@@ -11,6 +11,7 @@ import { useEffect, useMemo, useState } from 'react'
 import {
   AGENT_MODELS,
   formatTokenCount,
+  isFreeAgentModel,
   type ModelPricing,
   type OpenAIModel,
 } from '@/lib/ai/agent-models'
@@ -114,7 +115,7 @@ export interface UseAgentModelResult {
  */
 function getStaticModels(): ModelDisplayInfo[] {
   return Object.entries(AGENT_MODELS).map(([id, info]): ModelDisplayInfo => {
-    const isFree = id.endsWith(':free')
+    const isFree = isFreeAgentModel(id)
     const pricing =
       'pricing' in info ? (info.pricing as ModelPricing) : undefined
 


### PR DESCRIPTION
## Summary
- Sync `CLAUDE.md`/`AGENTS.md` testing docs with current Bun and Cypress scripts
- Add the new agent models API and surface OpenRouter capability badges in the UI
- Update the agent model hook to load capability metadata from the API with a static fallback

## Testing
- Not run (not requested)

## Summary by Sourcery

Integrate agent model capabilities from OpenRouter into the agents UI and sync testing documentation with the current Bun-based test setup.

New Features:
- Expose an API endpoint to fetch agent models with capability metadata from OpenRouter and cache responses.
- Load agent model listings in the frontend from the new API with capability indicators and a static fallback when the API fails.
- Display capability badges (tools, streaming, vision, free) in the agent settings UI for each model.

Enhancements:
- Extend agent model metadata types to include capability flags for tools, streaming, and vision support.
- Update agent settings UI copy to reflect the new capability badge set.

Documentation:
- Refresh CLAUDE.md testing documentation to describe the Bun-based test commands, coverage options, and query-config testing in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenRouter endpoint and identification headers configurable via environment variables.
  * Faster initial model list rendering using static metadata while capabilities load.

* **Bug Fixes**
  * Switched to platform fetch revalidation for model responses; more reliable and consistent capability detection (tools, streaming, vision, free models).
  * Avatar styling and dropdown behavior refined for more consistent UI interactions.

* **Tests**
  * Expanded mocks and test coverage for model pricing and runtime behaviors; e2e click behavior made more reliable.

* **Documentation**
  * Clarified test command description and CI testing note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->