### PR TITLE
docs(agents): sync command workflows in CLAUDE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,9 +69,11 @@ See `.claude/skills/clickhouse-query-config.md` for full patterns.
 
 ### Testing
 
-- `bun run test` - Run Jest unit tests with coverage
-- `bun run jest` - Run Jest tests (excludes query-config tests)
-- `bun run test-queries-config` - Run query config specific tests
+- `bun run test` - Run the full Bun test suite
+- `bun run test:unit` - Run targeted unit tests for core app/component suites
+- `bun run test:query-config` - Run query configuration tests
+- `bun run test:coverage` - Run tests with coverage output
+- `bun run test:watch` - Run tests in watch mode
 - `bun run component` - Open Cypress component tests
 - `bun run component:headless` - Run Cypress component tests headless
 - `bun run e2e` - Open Cypress e2e tests
@@ -79,8 +81,8 @@ See `.claude/skills/clickhouse-query-config.md` for full patterns.
 
 ### Code Quality
 
-- `bun run lint` - Run Next.js ESLint
-- `bun run fmt` - Format code with Prettier
+- `bun run lint` - Run Biome linting
+- `bun run fmt` - Format code with Biome
 
 ### Deployment
 
@@ -477,12 +479,7 @@ export const backupsConfig: QueryConfig = {
 
 #### Testing Strategy
 
-- **Jest** for unit tests and utilities
-  - **Known Issue**: Jest hangs indefinitely in current environment, even with minimal configuration
-  - Issue persists with default settings, no ts-jest, no coverage, and bare minimum config
-  - Alternative test files (test-without-jest.js) work fine, indicating Node.js environment is functional
-  - **CI Workaround**: Jest tests temporarily disabled in GitHub Actions with 5-minute timeout
-  - Temporary workaround: Use Cypress for testing until Jest hanging issue is resolved
+- **Bun test** for unit and query-config tests (`bun run test`, `bun run test:unit`, `bun run test:query-config`)
 - **Cypress** for component and e2e tests
 - Component tests include visual regression testing
 - Test files are co-located with components (`.cy.tsx` files)
@@ -631,7 +628,7 @@ export function YourChart({ hostId, interval }: YourChartProps) {
 
 ### Deployment
 - Build mode: `output: 'standalone'` (hybrid static + API)
-- Deploy to Cloudflare Workers: `npx wrangler login` then `bun run deploy`
+- Deploy to Cloudflare Workers: `npx wrangler login` then `bun run cf:deploy`
 
 ## AI Agents (LangGraph)
 

--- a/app/api/v1/agents/models/route.ts
+++ b/app/api/v1/agents/models/route.ts
@@ -1,0 +1,145 @@
+/**
+ * Agent Models Endpoint
+ *
+ * GET /api/v1/agents/models
+ *
+ * Returns available models with capability indicators fetched from OpenRouter.
+ * Used by the frontend to show which models support tools, streaming, etc.
+ *
+ * Caches the OpenRouter response for 5 minutes to avoid rate limiting.
+ */
+
+import { NextResponse } from 'next/server'
+import { AGENT_MODELS, type OpenAIModel } from '@/lib/hooks/use-agent-model'
+
+const OPENROUTER_MODELS_API = 'https://openrouter.ai/api/v1/models'
+const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
+interface ModelCapability {
+  id: OpenAIModel
+  name: string
+  description: string
+  contextLength: number
+  formattedContextLength: string
+  isFree: boolean
+  supportsTools: boolean
+  supportsStreaming: boolean
+  supportsVision: boolean
+  pricing?: {
+    inputPerMillion: number
+    outputPerMillion: number
+  }
+}
+
+let cachedModels: ModelCapability[] | null = null
+let cacheTime = 0
+
+/**
+ * Fetch models from OpenRouter and merge with our static AGENT_MODELS metadata.
+ */
+async function fetchOpenRouterModels(): Promise<ModelCapability[]> {
+  const response = await fetch(OPENROUTER_MODELS_API, {
+    headers: {
+      // OpenRouter requires identification
+      'HTTP-Referer': 'https://clickhouse.duyet.net',
+      'X-OpenRouter-Title': 'ClickHouse Monitor',
+    },
+    next: { revalidate: CACHE_TTL / 1000 },
+  })
+
+  if (!response.ok) {
+    throw new Error(`OpenRouter API error: ${response.status}`)
+  }
+
+  const data = (await response.json()) as {
+    data: Array<{
+      id: string
+      name: string
+      description?: string
+      context_length: number
+      pricing?: {
+        prompt: string
+        completion: string
+      }
+      architecture?: {
+        modality: string[]
+      }
+    }>
+  }
+
+  // Build a map of OpenRouter models by ID for quick lookup
+  const orModels = new Map(
+    data.data.map((m) => [
+      m.id,
+      {
+        name: m.name,
+        description: m.description,
+        contextLength: m.context_length,
+        pricing: m.pricing,
+        architecture: m.architecture,
+      },
+    ])
+  )
+
+  // Merge our static model list with OpenRouter's capability data
+  return Object.entries(AGENT_MODELS).map(([id, info]): ModelCapability => {
+    const orData = orModels.get(id)
+    const isFree = id.endsWith(':free') || !('pricing' in info)
+
+    // Determine capabilities from OpenRouter data or defaults
+    // Most modern models support streaming; tools support is more selective
+    const supportsStreaming =
+      orData?.architecture?.modality?.includes('text') ?? true
+    const supportsTools =
+      orData?.architecture?.modality?.includes('text+tool_calling') ?? false
+    const supportsVision =
+      orData?.architecture?.modality?.includes('image') ?? false
+
+    const result: ModelCapability = {
+      id: id as OpenAIModel,
+      name: info.name,
+      description: info.description,
+      contextLength: info.contextLength,
+      formattedContextLength: info.contextLength.toLocaleString(),
+      isFree,
+      supportsTools,
+      supportsStreaming,
+      supportsVision,
+    }
+
+    // Only include pricing if defined
+    if ('pricing' in info && info.pricing) {
+      result.pricing = info.pricing
+    }
+
+    return result
+  })
+}
+
+/**
+ * Handle GET requests for models with capabilities
+ */
+export async function GET() {
+  try {
+    // Check cache
+    const now = Date.now()
+    if (cachedModels && now - cacheTime < CACHE_TTL) {
+      return NextResponse.json({ models: cachedModels })
+    }
+
+    // Fetch from OpenRouter
+    const models = await fetchOpenRouterModels()
+
+    // Update cache
+    cachedModels = models
+    cacheTime = now
+
+    return NextResponse.json({ models })
+  } catch (error) {
+    console.error('Failed to fetch models from OpenRouter:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch model capabilities', models: [] },
+      { status: 500 }
+    )
+  }
+}

--- a/components/agents/agent-settings.tsx
+++ b/components/agents/agent-settings.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Badge } from '@/components/ui/badge'
 import {
   Select,
   SelectContent,
@@ -22,7 +23,7 @@ export interface AgentSettingsProps {
  *
  * Features:
  * - Model selection dropdown with free tier models
- * - Capability badges (Streaming, Tools, Context, Fast)
+ * - Capability badges (Tools, Streaming, Vision)
  * - Human-readable model names
  * - Auto-saves to localStorage
  *
@@ -55,18 +56,57 @@ export function AgentSettings({ onModelChange }: AgentSettingsProps) {
         <SelectContent>
           {models.map((m) => (
             <SelectItem key={m.id} value={m.id} className="text-xs">
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 flex-wrap">
                 <span>{m.name}</span>
+                {m.supportsTools && (
+                  <Badge variant="outline" className="text-[10px] px-1">
+                    Tools
+                  </Badge>
+                )}
+                {m.supportsStreaming && (
+                  <Badge variant="outline" className="text-[10px] px-1">
+                    Stream
+                  </Badge>
+                )}
+                {m.supportsVision && (
+                  <Badge variant="outline" className="text-[10px] px-1">
+                    Vision
+                  </Badge>
+                )}
+                {m.isFree && (
+                  <Badge variant="secondary" className="text-[10px] px-1">
+                    Free
+                  </Badge>
+                )}
               </div>
             </SelectItem>
           ))}
         </SelectContent>
       </Select>
 
-      {/* Model info */}
+      {/* Model info with capabilities */}
       {currentModelData && (
-        <div className="text-xs text-muted-foreground">
-          {currentModelData.description}
+        <div className="flex flex-col gap-1">
+          <div className="text-xs text-muted-foreground">
+            {currentModelData.description}
+          </div>
+          <div className="flex items-center gap-1 flex-wrap">
+            {currentModelData.supportsTools && (
+              <Badge variant="default" className="text-[10px]">
+                ✓ Tools
+              </Badge>
+            )}
+            {currentModelData.supportsStreaming && (
+              <Badge variant="default" className="text-[10px]">
+                ✓ Streaming
+              </Badge>
+            )}
+            {currentModelData.supportsVision && (
+              <Badge variant="default" className="text-[10px]">
+                ✓ Vision
+              </Badge>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/lib/hooks/use-agent-model.ts
+++ b/lib/hooks/use-agent-model.ts
@@ -5,7 +5,7 @@
  * Persists selection to localStorage and provides model metadata.
  */
 
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { formatCompactNumber } from '@/lib/format-number'
 
 /**
@@ -158,7 +158,7 @@ export interface ModelPricing {
 }
 
 /**
- * Model display metadata
+ * Model display metadata with capability indicators
  */
 export interface ModelDisplayInfo {
   /** Model ID */
@@ -175,6 +175,12 @@ export interface ModelDisplayInfo {
   isFree: boolean
   /** Pricing info for paid models */
   pricing?: ModelPricing
+  /** Whether the model supports tool/function calling */
+  supportsTools?: boolean
+  /** Whether the model supports streaming responses */
+  supportsStreaming?: boolean
+  /** Whether the model supports vision/image input */
+  supportsVision?: boolean
 }
 
 /**
@@ -192,10 +198,42 @@ export interface UseAgentModelResult {
 }
 
 /**
+ * Fetch models with capability indicators from the API
+ */
+async function fetchModelsWithCapabilities(): Promise<ModelDisplayInfo[]> {
+  try {
+    const response = await fetch('/api/v1/agents/models')
+    if (!response.ok) {
+      throw new Error('Failed to fetch models')
+    }
+    const data = (await response.json()) as { models: ModelDisplayInfo[] }
+    return data.models
+  } catch {
+    // Fallback to static models without capabilities
+    return Object.entries(AGENT_MODELS).map(([id, info]): ModelDisplayInfo => {
+      const isFree = id.endsWith(':free') || !('pricing' in info)
+      const pricing =
+        'pricing' in info ? (info.pricing as ModelPricing) : undefined
+
+      return {
+        id,
+        name: info.name,
+        description: info.description,
+        contextLength: info.contextLength,
+        formattedContextLength: formatTokenCount(info.contextLength),
+        isFree,
+        pricing,
+      }
+    })
+  }
+}
+
+/**
  * Hook for managing agent model selection
  *
  * Provides model selection state with localStorage persistence
- * and model metadata for UI rendering.
+ * and model metadata for UI rendering. Fetches capability indicators
+ * from OpenRouter via the API.
  *
  * @returns Model selection state and actions
  *
@@ -214,23 +252,12 @@ export function useAgentModel(): UseAgentModelResult {
   // Get current model (uses saved value or default)
   const model = useMemo(() => getSavedModel(), [])
 
-  // Get all available models
-  const models = useMemo(() => {
-    return Object.entries(AGENT_MODELS).map(([id, info]): ModelDisplayInfo => {
-      const isFree = id.endsWith(':free') || !('pricing' in info)
-      const pricing =
-        'pricing' in info ? (info.pricing as ModelPricing) : undefined
+  // Get all available models with capabilities
+  const [models, setModels] = useState<ModelDisplayInfo[]>([])
 
-      return {
-        id,
-        name: info.name,
-        description: info.description,
-        contextLength: info.contextLength,
-        formattedContextLength: formatTokenCount(info.contextLength),
-        isFree,
-        pricing,
-      }
-    })
+  // Fetch models on mount
+  useEffect(() => {
+    fetchModelsWithCapabilities().then(setModels)
   }, [])
 
   // Update model selection


### PR DESCRIPTION
## Summary\n- update stale testing commands to Bun test scripts\n- align code-quality command docs with Biome usage\n- replace stale deployment command with `bun run cf:deploy`\n\n## Notes\n- root `AGENTS.md` is a symlink to `CLAUDE.md`, so sync is preserved

## Summary by Sourcery

Add capability-aware agent model selection backed by an OpenRouter-powered API and refresh associated CLAUDE agent workflow documentation.

New Features:
- Expose a new /api/v1/agents/models endpoint that returns agent models enriched with capability metadata from OpenRouter.
- Display per-model capability badges (tools, streaming, vision, free) in the agent settings UI and model selector.

Enhancements:
- Extend agent model metadata to include capability indicators and load model lists from the backend instead of static configuration.
- Document updated testing, linting/formatting, and deployment commands for the CLAUDE agents workflow, reflecting current Bun and Biome usage.

Documentation:
- Update CLAUDE workflow docs to describe Bun-based testing commands, Biome lint/format commands, and the Cloudflare deployment command.