### PR TITLE
docs(agents): remove non-existent migrate commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ Both deployment methods provide:
 - `bun run cf:typegen` - Regenerate Cloudflare environment typings
 - `bun run cf:setup-conversations` - Provision the D1 database and update `wrangler.toml`
 - `bun run cf:migrate-conversations` / `bun run cf:migrate-conversations:local` - Apply conversation DB migrations remotely or locally
-- `bun run migrate`, `bun run migrate:status`, `bun run migrate:dry-run`, `bun run migrate up`, `bun run migrate rollback` - Use the local migration runner for non-Cloudflare targets
+- `bun run migrate`, `bun run migrate:status`, `bun run migrate:dry-run` - Use the local migration runner for non-Cloudflare targets
 - `bun run docker:health` / `bun run cf:health` - Check Docker or deployed health endpoints
 
 **Docs workspace**: The `docs/` app uses `pnpm` instead of `bun`.


### PR DESCRIPTION
## Summary
- remove `bun run migrate up` and `bun run migrate rollback` from `CLAUDE.md` additional workflows
- keep AGENTS/CLAUDE in sync via existing symlink

## Why
These commands are not present in `package.json` scripts, so this keeps command docs accurate and repo-grounded.

## Verification
- compared `CLAUDE.md` workflow command list with `package.json` scripts
- confirmed only stale command references were updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified migration command documentation by removing outdated command entries for non-Cloudflare migration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->