### PR TITLE
fix(agent): isolate model metadata from client hooks

### DIFF
--- a/app/api/v1/agents/models/route.ts
+++ b/app/api/v1/agents/models/route.ts
@@ -10,7 +10,7 @@
  */
 
 import { NextResponse } from 'next/server'
-import { AGENT_MODELS, type OpenAIModel } from '@/lib/hooks/use-agent-model'
+import { AGENT_MODELS, type OpenAIModel } from '@/lib/ai/agent-models'
 
 const OPENROUTER_MODELS_API = 'https://openrouter.ai/api/v1/models'
 const CACHE_TTL = 5 * 60 * 1000 // 5 minutes

--- a/lib/ai/agent-models.ts
+++ b/lib/ai/agent-models.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared agent model metadata for both client and server code.
+ */
+
+export const AGENT_MODELS = {
+  'openrouter/free': {
+    name: 'openrouter/free',
+    description:
+      'OpenRouter auto-router: picks a working free tool-capable model (default)',
+    contextLength: 200000,
+  },
+  'openrouter/auto': {
+    name: 'openrouter/auto',
+    description: 'OpenRouter auto-router: picks the best model (paid)',
+    contextLength: 2000000,
+  },
+  'z-ai/glm-4.5-air:free': {
+    name: 'z-ai/glm-4.5-air:free',
+    description: 'Z.AI GLM 4.5 Air, free tier',
+    contextLength: 131072,
+  },
+  'arcee-ai/trinity-large-preview:free': {
+    name: 'arcee-ai/trinity-large-preview:free',
+    description: 'Arcee Trinity Large Preview, free tier',
+    contextLength: 131000,
+  },
+  'qwen/qwen3-coder:free': {
+    name: 'qwen/qwen3-coder:free',
+    description: 'Qwen3 Coder, free tier, 1M context',
+    contextLength: 1048576,
+  },
+  'qwen/qwen3-next-80b-a3b-instruct:free': {
+    name: 'qwen/qwen3-next-80b-a3b-instruct:free',
+    description: 'Qwen3 Next 80B Instruct, free tier',
+    contextLength: 262144,
+  },
+  'openai/gpt-oss-120b:free': {
+    name: 'openai/gpt-oss-120b:free',
+    description: 'OpenAI GPT-OSS 120B, free tier',
+    contextLength: 131072,
+  },
+  'openai/gpt-oss-20b:free': {
+    name: 'openai/gpt-oss-20b:free',
+    description: 'OpenAI GPT-OSS 20B, free tier',
+    contextLength: 131072,
+  },
+  'meta-llama/llama-3.3-70b-instruct:free': {
+    name: 'meta-llama/llama-3.3-70b-instruct:free',
+    description: 'Meta Llama 3.3 70B Instruct, free tier',
+    contextLength: 131072,
+  },
+  'google/gemma-4-31b-it:free': {
+    name: 'google/gemma-4-31b-it:free',
+    description: 'Google Gemma 4 31B Instruct, free tier',
+    contextLength: 262144,
+  },
+  'minimax/minimax-m2.7': {
+    name: 'minimax/minimax-m2.7',
+    description: 'MiniMax production model (paid)',
+    contextLength: 200000,
+    pricing: {
+      inputPerMillion: 0.5,
+      outputPerMillion: 1.5,
+    },
+  },
+} as const
+
+/** OpenAI-compatible model identifier. */
+export type OpenAIModel = string
+
+export interface ModelPricing {
+  inputPerMillion: number
+  outputPerMillion: number
+}
+
+export function isKnownModel(
+  model: string
+): model is keyof typeof AGENT_MODELS {
+  return model in AGENT_MODELS
+}

--- a/lib/ai/agent/clickhouse-agent.ts
+++ b/lib/ai/agent/clickhouse-agent.ts
@@ -33,8 +33,10 @@ function filterTools<T extends Record<string, unknown>>(
  * Falls back to openrouter/free if LLM_MODEL env var is not set
  */
 const DEFAULT_MODEL = process.env.LLM_MODEL || 'openrouter/free'
-const OPENROUTER_FREE_FALLBACK_MODEL =
-  process.env.OPENROUTER_FREE_FALLBACK_MODEL || 'qwen/qwen3-coder:free'
+
+function getOpenRouterFreeFallbackModel(): string {
+  return process.env.OPENROUTER_FREE_FALLBACK_MODEL || 'qwen/qwen3-coder:free'
+}
 
 /**
  * Returns true for Anthropic/Claude models routed via OpenRouter.
@@ -128,7 +130,7 @@ export function createClickHouseAgent(options: {
       : model
     const modelId =
       normalizedModelId === 'free'
-        ? OPENROUTER_FREE_FALLBACK_MODEL
+        ? getOpenRouterFreeFallbackModel()
         : normalizedModelId
     if (normalizedModelId === 'free') {
       console.warn(

--- a/lib/hooks/use-agent-model.ts
+++ b/lib/hooks/use-agent-model.ts
@@ -1,3 +1,5 @@
+'use client'
+
 /**
  * useAgentModel Hook
  *
@@ -6,7 +8,15 @@
  */
 
 import { useEffect, useMemo, useState } from 'react'
+import {
+  AGENT_MODELS,
+  isKnownModel,
+  type ModelPricing,
+  type OpenAIModel,
+} from '@/lib/ai/agent-models'
 import { formatCompactNumber } from '@/lib/format-number'
+
+export type { OpenAIModel } from '@/lib/ai/agent-models'
 
 /**
  * LocalStorage key for model selection
@@ -21,87 +31,6 @@ const DEFAULT_MODEL = 'openrouter/free'
  */
 export function formatTokenCount(count: number): string {
   return formatCompactNumber(count)
-}
-
-/**
- * Available agent models.
- *
- * Keep `name` identical to the model code so the UI always shows
- * the exact provider/model identifier chosen by the user.
- */
-export const AGENT_MODELS = {
-  'openrouter/free': {
-    name: 'openrouter/free',
-    description:
-      'OpenRouter auto-router: picks a working free tool-capable model (default)',
-    contextLength: 200000,
-  },
-  'openrouter/auto': {
-    name: 'openrouter/auto',
-    description: 'OpenRouter auto-router: picks the best model (paid)',
-    contextLength: 2000000,
-  },
-  'z-ai/glm-4.5-air:free': {
-    name: 'z-ai/glm-4.5-air:free',
-    description: 'Z.AI GLM 4.5 Air, free tier',
-    contextLength: 131072,
-  },
-  'arcee-ai/trinity-large-preview:free': {
-    name: 'arcee-ai/trinity-large-preview:free',
-    description: 'Arcee Trinity Large Preview, free tier',
-    contextLength: 131000,
-  },
-  'qwen/qwen3-coder:free': {
-    name: 'qwen/qwen3-coder:free',
-    description: 'Qwen3 Coder, free tier, 1M context',
-    contextLength: 1048576,
-  },
-  'qwen/qwen3-next-80b-a3b-instruct:free': {
-    name: 'qwen/qwen3-next-80b-a3b-instruct:free',
-    description: 'Qwen3 Next 80B Instruct, free tier',
-    contextLength: 262144,
-  },
-  'openai/gpt-oss-120b:free': {
-    name: 'openai/gpt-oss-120b:free',
-    description: 'OpenAI GPT-OSS 120B, free tier',
-    contextLength: 131072,
-  },
-  'openai/gpt-oss-20b:free': {
-    name: 'openai/gpt-oss-20b:free',
-    description: 'OpenAI GPT-OSS 20B, free tier',
-    contextLength: 131072,
-  },
-  'meta-llama/llama-3.3-70b-instruct:free': {
-    name: 'meta-llama/llama-3.3-70b-instruct:free',
-    description: 'Meta Llama 3.3 70B Instruct, free tier',
-    contextLength: 131072,
-  },
-  'google/gemma-4-31b-it:free': {
-    name: 'google/gemma-4-31b-it:free',
-    description: 'Google Gemma 4 31B Instruct, free tier',
-    contextLength: 262144,
-  },
-  'minimax/minimax-m2.7': {
-    name: 'minimax/minimax-m2.7',
-    description: 'MiniMax production model (paid)',
-    contextLength: 200000,
-    pricing: {
-      inputPerMillion: 0.5,
-      outputPerMillion: 1.5,
-    },
-  },
-} as const
-
-/** OpenAI-compatible model identifier — any string is valid (custom models supported) */
-export type OpenAIModel = string
-
-/**
- * Check whether a model ID is in the known AGENT_MODELS list
- */
-export function isKnownModel(
-  model: string
-): model is keyof typeof AGENT_MODELS {
-  return model in AGENT_MODELS
 }
 
 /**
@@ -147,14 +76,6 @@ function saveModel(model: OpenAIModel): void {
   } catch {
     // localStorage may be disabled
   }
-}
-
-/**
- * Pricing information for a model (USD per 1M tokens)
- */
-export interface ModelPricing {
-  inputPerMillion: number
-  outputPerMillion: number
 }
 
 /**


### PR DESCRIPTION
## Summary
- move shared agent model metadata into a non-hook module so the server route stops importing React hooks
- read `OPENROUTER_FREE_FALLBACK_MODEL` at agent creation time so the fallback test is stable across the full suite
- keep the change scoped to the current agent model regressions

## Evidence
- main run `24913936549` failed Cloudflare build on commit `34f0ee62ddd6074a39193f01769f3908da31a9de`
- failing file path: `lib/hooks/use-agent-model.ts` imported from `app/api/v1/agents/models/route.ts`
- exact build error: Next reported `useEffect` and `useState` can only be used in a Client Component
- main run `24913936588` failed `unit-tests` with `createClickHouseAgent OpenRouter model resolution > maps openrouter/free to fallback tool-capable model`

## Verification
- `bun test ./lib/ai/agent/__tests__/clickhouse-agent-openrouter.test.ts`
- `bun run build` could not be completed locally in this sandbox because `bun install` cannot write to the tempdir here; GitHub Actions should validate the full build path

## Summary by Sourcery

Extract shared agent model metadata into a dedicated non-hook module and update consumers to use it, while stabilizing OpenRouter fallback model resolution for the ClickHouse agent.

Enhancements:
- Create a shared lib/ai/agent-models module for agent model metadata and type utilities, and update both client hooks and the agents models API route to consume it.
- Mark the use-agent-model hook file as a client component while re-exporting model types from the new shared module.
- Change ClickHouse agent OpenRouter fallback model resolution to read the fallback model from the environment at call time via a helper function.