### PR TITLE
fix(deps): bump root postcss

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -131,7 +131,7 @@
         "cypress-real-events": "^1.15.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.10",
         "react-is": "^19.2.4",
         "shadcn": "^4.0.0",
         "start-server-and-test": "^3.0.0",
@@ -2471,7 +2471,7 @@
 
     "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
-    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,7 +140,7 @@
         "jest": "^29.7.0",
         "jest-junit": "^16.0.0",
         "lint-staged": "^16.2.7",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.10",
         "react-is": "^19.2.4",
         "shadcn": "^4.0.0",
         "start-server-and-test": "^2.1.3",
@@ -22578,7 +22578,7 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
+      "version": "8.5.10",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "cypress-real-events": "^1.15.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
-    "postcss": "^8.5.6",
+    "postcss": "^8.5.10",
     "react-is": "^19.2.4",
     "shadcn": "^4.0.0",
     "start-server-and-test": "^3.0.0",


### PR DESCRIPTION
## Evidence
- Recent main run `24922730213` failed in Dependabot security updates for root `postcss` after merge commit `f18ac7967686939760b7b62d624907003e991d89`.
- The log reports `dependency_file_not_supported` while trying to update root `postcss`, and root `package.json` / `bun.lock` / `package-lock.json` still pinned the direct root package at `8.5.6`.
- PR #1002 only updated `docs/postcss` to `8.5.10`, leaving the root vulnerable direct dependency behind.

## Fix
- Bump root `postcss` from `^8.5.6` to `^8.5.10`.
- Update the matching root entries in `bun.lock` and `package-lock.json`.

## Verification
- `git diff --check`
- `npm audit --json` still reports a separate nested `next` PostCSS finding, so this PR stays scoped to the concrete root Dependabot failure.

## Summary by Sourcery

Update the root postcss dependency to address a Dependabot-reported security issue and align lockfiles with the new version.

Bug Fixes:
- Resolve Dependabot failure caused by the outdated and vulnerable root postcss dependency version.

Chores:
- Bump root postcss from ^8.5.6 to ^8.5.10 and update corresponding entries in bun.lock and package-lock.json.