### PR TITLE
docs(agents): sync Next.js version in AGENTS and CLAUDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this project are documented in this file.
   - Enables independent data refresh on host switching without full page reload
 
 #### Framework & Build Updates
-- **Next.js 16 with React 19** and Turbopack
+- **Next.js 15 with React 19** and Turbopack
 - **Migrated to Bun** as the primary package manager
   - Better performance and compatibility with modern JavaScript ecosystem
   - Replaced PNPM with Bun (`bun install`, `bun run dev`, etc.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Use semantic commit format with consistent scope for commit messages and PR titl
 
 ## Project Overview
 
-This is a Next.js 16 (React 19) ClickHouse monitoring dashboard that provides real-time insights into ClickHouse clusters through system tables. The application connects to ClickHouse instances and displays metrics, query performance, table information, and cluster health.
+This is a Next.js 15 (React 19) ClickHouse monitoring dashboard that provides real-time insights into ClickHouse clusters through system tables. The application connects to ClickHouse instances and displays metrics, query performance, table information, and cluster health.
 
 ## Claude Skills
 
@@ -148,7 +148,7 @@ Both deployment methods provide:
 
 ### Core Technologies
 
-- **Next.js 16** with App Router and Turbopack
+- **Next.js 15** with App Router and Turbopack
 - **React 19** with TypeScript
 - **SWR** for client-side data fetching with caching
 - **ClickHouse clients** (@clickhouse/client and @clickhouse/client-web)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build and Test](https://github.com/duyet/clickhouse-monitoring/actions/workflows/ci.yml/badge.svg)](https://github.com/duyet/clickhouse-monitoring/actions/workflows/ci.yml)
 [![All-time uptime](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fduyet%2Fuptime%2FHEAD%2Fapi%2Fclickhouse-monitoring-vercel-app%2Fuptime.json)](https://duyet.github.io/uptime/history/clickhouse-monitoring-vercel-app)
 
-A modern Next.js 16 dashboard that provides real-time insights into ClickHouse clusters through system tables. Features static site generation with client-side data fetching for optimal performance and CDN caching.
+A modern Next.js 15 dashboard that provides real-time insights into ClickHouse clusters through system tables. Features static site generation with client-side data fetching for optimal performance and CDN caching.
 
 **Features:**
 
@@ -61,7 +61,7 @@ bun run cf:deploy
 
 **Important Notes:**
 - Build uses **Webpack** (not Turbopack) due to Cloudflare Workers compatibility
-- Next.js version pinned to **16.0.7** (React 19) for stability
+- Next.js version pinned to **15.5.x** (React 19) for stability
 - Static pages are pre-rendered at edge for optimal performance
 - API routes run on Workers using Fetch API
 - Supports multi-host monitoring with query parameter routing (`?host=0`)


### PR DESCRIPTION
## Summary
- sync Next.js version references in `CLAUDE.md` (and `AGENTS.md` via symlink)
- keep docs aligned with current `package.json` (`next@15.x`)

## Verification
- verified `AGENTS.md` is a symlink to `CLAUDE.md`
- verified `package.json` uses `next@^15.5.14`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated framework version information from Next.js 16 to Next.js 15 in project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->