### PR TITLE
fix(agents): preserve unknown model capabilities

### DIFF
--- a/app/api/v1/agents/models/__tests__/route.test.ts
+++ b/app/api/v1/agents/models/__tests__/route.test.ts
@@ -1,0 +1,44 @@
+import { GET } from '../route'
+import { afterEach, describe, expect, test } from 'bun:test'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('GET /api/v1/agents/models', () => {
+  test('leaves capabilities unknown when OpenRouter omits a curated model', async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              id: 'openrouter/free',
+              name: 'OpenRouter Free',
+              context_length: 200000,
+              supported_parameters: ['tools', 'tool_choice'],
+              architecture: {
+                input_modalities: ['text'],
+                output_modalities: ['text'],
+                modality: 'text->text',
+              },
+            },
+          ],
+        }),
+        { status: 200 }
+      )
+
+    const response = await GET()
+    const body = await response.json()
+    const omittedModel = body.models.find(
+      (model: { id: string }) =>
+        model.id === 'arcee-ai/trinity-large-preview:free'
+    )
+
+    expect(omittedModel).toBeDefined()
+    expect(omittedModel).not.toHaveProperty('supportsTools')
+    expect(omittedModel).not.toHaveProperty('supportsStreaming')
+    expect(omittedModel).not.toHaveProperty('supportsVision')
+  })
+})

--- a/app/api/v1/agents/models/route.ts
+++ b/app/api/v1/agents/models/route.ts
@@ -30,9 +30,9 @@ interface ModelCapability {
   contextLength: number
   formattedContextLength: string
   isFree: boolean
-  supportsTools: boolean
-  supportsStreaming: boolean
-  supportsVision: boolean
+  supportsTools?: boolean
+  supportsStreaming?: boolean
+  supportsVision?: boolean
   pricing?: {
     inputPerMillion: number
     outputPerMillion: number
@@ -93,6 +93,27 @@ async function fetchOpenRouterModels(): Promise<ModelCapability[]> {
   return Object.entries(AGENT_MODELS).map(([id, info]): ModelCapability => {
     const orData = orModels.get(id)
     const isFree = isFreeAgentModel(id)
+    const contextLength = orData?.contextLength ?? info.contextLength
+
+    const result: ModelCapability = {
+      id: id as OpenAIModel,
+      name: info.name,
+      description: info.description,
+      contextLength,
+      formattedContextLength: formatTokenCount(contextLength),
+      isFree,
+    }
+
+    // If OpenRouter omits a curated model, keep capabilities unknown rather
+    // than reporting false support from absent metadata.
+    if (!orData) {
+      if ('pricing' in info && info.pricing) {
+        result.pricing = info.pricing
+      }
+
+      return result
+    }
+
     const rawModality = orData?.architecture?.modality
     const modalityList = Array.isArray(rawModality)
       ? rawModality
@@ -112,19 +133,10 @@ async function fetchOpenRouterModels(): Promise<ModelCapability[]> {
     const supportsVision = inputModalities.some((modality) =>
       modality.includes('image')
     )
-    const contextLength = orData?.contextLength ?? info.contextLength
 
-    const result: ModelCapability = {
-      id: id as OpenAIModel,
-      name: info.name,
-      description: info.description,
-      contextLength,
-      formattedContextLength: formatTokenCount(contextLength),
-      isFree,
-      supportsTools,
-      supportsStreaming,
-      supportsVision,
-    }
+    result.supportsTools = supportsTools
+    result.supportsStreaming = supportsStreaming
+    result.supportsVision = supportsVision
 
     // Only include pricing if defined
     if ('pricing' in info && info.pricing) {


### PR DESCRIPTION
## Summary
- keep model capability fields undefined when OpenRouter omits a curated `AGENT_MODELS` entry
- add a route test for the omitted-model fallback path

## Evidence
- Daily scan window: commits merged after `2026-04-25T23:00:53Z`
- Recent PR: #996 added `/api/v1/agents/models` capability derivation
- Live OpenRouter check during scan returned no entry for `arcee-ai/trinity-large-preview:free`
- Current main converted that absent metadata into `supportsTools: false`, `supportsStreaming: false`, and `supportsVision: false`

## Verification
- `bun test app/api/v1/agents/models/__tests__/route.test.ts`
- `bunx biome check app/api/v1/agents/models/route.ts app/api/v1/agents/models/__tests__/route.test.ts`
- `git diff --check`
- `bun run type-check`
- `bun run build`

Note: `bun run check` is not clean on current main because of unrelated existing findings in `lib/ai/agent/errors.ts` and `components/agents/agents-chat-area.tsx`; changed files pass targeted Biome check.
