### PR TITLE
refactor(nav): share settings shortcut handler

### DIFF
--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -2,8 +2,9 @@
 
 import { ChevronsUpDown, ExternalLink, Info, Settings } from 'lucide-react'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { ClientOnly } from '@/components/client-only'
+import { useSettingsShortcut } from '@/components/nav-user/use-settings-shortcut'
 import { SettingsDialog } from '@/components/settings'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import {
@@ -39,20 +40,8 @@ export function NavUser({
 }) {
   const { isMobile } = useSidebar()
   const [settingsOpen, setSettingsOpen] = useState(false)
-
-  // Keyboard shortcut for settings (Cmd/Ctrl + ,)
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      // Cmd+, or Ctrl+, to open settings (standard for Settings/Preferences)
-      if ((event.metaKey || event.ctrlKey) && event.key === ',') {
-        event.preventDefault()
-        setSettingsOpen(true)
-      }
-    }
-
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [])
+  const openSettings = useCallback(() => setSettingsOpen(true), [])
+  useSettingsShortcut(openSettings)
 
   // If Clerk is enabled, use Clerk navigation
   if (isClerkEnabled() && ClerkNavWrapper) {

--- a/components/nav-user/clerk-nav.tsx
+++ b/components/nav-user/clerk-nav.tsx
@@ -10,7 +10,8 @@ import {
 } from 'lucide-react'
 
 import { SignInButton, SignOutButton, useUser } from '@clerk/nextjs'
-import { useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
+import { useSettingsShortcut } from '@/components/nav-user/use-settings-shortcut'
 import { SettingsDialog } from '@/components/settings'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import {
@@ -40,19 +41,8 @@ export function ClerkNavWrapper() {
   const { user, isLoaded, isSignedIn } = useUser()
   const { isMobile } = useSidebar()
   const [settingsOpen, setSettingsOpen] = useState(false)
-
-  // Keyboard shortcut for settings (Cmd/Ctrl + ,)
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key === ',') {
-        event.preventDefault()
-        setSettingsOpen(true)
-      }
-    }
-
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [])
+  const openSettings = useCallback(() => setSettingsOpen(true), [])
+  useSettingsShortcut(openSettings)
 
   // Loading state - show skeleton
   if (!isLoaded) {

--- a/components/nav-user/use-settings-shortcut.ts
+++ b/components/nav-user/use-settings-shortcut.ts
@@ -1,0 +1,17 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export function useSettingsShortcut(openSettings: () => void) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === ',') {
+        event.preventDefault()
+        openSettings()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [openSettings])
+}


### PR DESCRIPTION
## Summary
- Extract the duplicated Cmd/Ctrl+, settings shortcut into a shared nav-user hook.
- Reuse the hook from both guest and Clerk nav user components.

## Findings fixed
- Warning: duplicated settings keyboard shortcut handler in `components/nav-user.tsx` and `components/nav-user/clerk-nav.tsx`. Evidence: both recently changed files registered the same `keydown` listener and opened the same settings dialog.

## Dead code review
- No confident dead-code candidates were removed in the recent-change window. Repo-wide grep showed remaining candidates have references or are route/component entry points.

## Verification
- `bun run type-check`
- `bun run build`

Note: repo label `codex-automation` is not available, so only `codex` was applied.

## Summary by Sourcery

Deduplicate the settings keyboard shortcut handling between guest and Clerk navigation user components by introducing a shared hook.

Enhancements:
- Introduce a shared useSettingsShortcut hook to centralize the Cmd/Ctrl+, settings keyboard shortcut behavior.
- Update both guest and Clerk nav user components to use the shared settings shortcut hook instead of duplicating the listener logic.