### PR TITLE
docs(claude): add local CI parity command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ Both deployment methods provide:
 - `bun run cf:migrate-conversations` / `bun run cf:migrate-conversations:local` - Apply conversation DB migrations remotely or locally
 - `bun run migrate`, `bun run migrate:status`, `bun run migrate:dry-run` - Use the local migration runner for non-Cloudflare targets
 - `bun run docker:health` / `bun run cf:health` - Check Docker or deployed health endpoints
+- `bun run lint && bun run build` - Quick local CI parity check (matches core lint/build workflow jobs)
 
 **Docs workspace**: The `docs/` app uses `pnpm` instead of `bun`.
 


### PR DESCRIPTION
## Summary\n- add one verified command note for local CI parity\n- keep AGENTS.md and CLAUDE.md synced via existing symlink\n\n## Validation\n- pre-commit type-check (tsc --noEmit)\n- pre-push biome check\n

## Summary by Sourcery

Documentation:
- Describe the `bun run lint && bun run build` command as a local CI parity check aligned with core lint/build workflow jobs in CLAUDE.md.