### PR TITLE
fix(history-queries): apply URL filter params

### DIFF
--- a/app/history-queries/page.tsx
+++ b/app/history-queries/page.tsx
@@ -2,19 +2,35 @@
 
 export const dynamic = 'force-static'
 
-import { Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { Suspense, useMemo } from 'react'
 import { QueryFiltersBar } from '@/components/history-queries/filter-bar'
 import { PageLayout } from '@/components/layout/query-page'
 import { ChartSkeleton } from '@/components/skeletons'
 import { historyQueriesConfig } from '@/lib/query-config/queries/history-queries'
 
 function HistoryQueriesPageContent() {
+  const searchParams = useSearchParams()
+  const tableSearchParams = useMemo(() => {
+    const params: Record<string, string> = {}
+
+    Object.keys(historyQueriesConfig.defaultParams || {}).forEach((key) => {
+      const value = searchParams.get(key)
+      if (value) {
+        params[key] = value
+      }
+    })
+
+    return params
+  }, [searchParams])
+
   return (
     <PageLayout
       queryConfig={historyQueriesConfig}
       title="History Queries"
       defaultPageSize={100}
       maxTableHeight="calc(100vh - 320px)"
+      searchParams={tableSearchParams}
       headerContent={<QueryFiltersBar queryConfig={historyQueriesConfig} />}
     />
   )

--- a/lib/query-config/__tests__/query-config.test.ts
+++ b/lib/query-config/__tests__/query-config.test.ts
@@ -350,4 +350,38 @@ describe('Query Config Validation', () => {
       })
     })
   })
+
+  describe('History query filter params', () => {
+    const historyQueriesConfig = queries.find(
+      (config) => config.name === 'history-queries'
+    )
+
+    it('should define defaults for every history query preset key', () => {
+      expect(historyQueriesConfig).toBeDefined()
+
+      const defaultParams = historyQueriesConfig?.defaultParams || {}
+      const presetKeys =
+        historyQueriesConfig?.filterParamPresets?.map((preset) => preset.key) ||
+        []
+
+      presetKeys.forEach((key) => {
+        expect(defaultParams).toHaveProperty(key)
+      })
+    })
+
+    it('should apply visible time and duration filter params in SQL', () => {
+      expect(historyQueriesConfig).toBeDefined()
+
+      const sqlVariants = Array.isArray(historyQueriesConfig?.sql)
+        ? historyQueriesConfig.sql.map((variant) => variant.sql)
+        : [historyQueriesConfig?.sql || '']
+
+      sqlVariants.forEach((sql) => {
+        expect(sql).toContain('{min_duration_s: String}')
+        expect(sql).toContain('{min_duration_s:UInt64}')
+        expect(sql).toContain('{last_hours: String}')
+        expect(sql).toContain('{last_hours:UInt64}')
+      })
+    })
+  })
 })

--- a/lib/query-config/queries/history-queries.ts
+++ b/lib/query-config/queries/history-queries.ts
@@ -40,6 +40,8 @@ export const historyQueriesConfig: QueryConfig = {
           WHERE
             if ({type: String} != '', type = {type: String}, type != 'QueryStart')
             AND if ({duration_1m: String} = '1', query_duration >= 60, true)
+            AND if ({min_duration_s: String} != '', query_duration >= {min_duration_s:UInt64}, true)
+            AND if ({last_hours: String} != '', event_time > now() - interval {last_hours:UInt64} hour, true)
             AND if (notEmpty({event_time: String}), toDate(event_time) = {event_time: String}, true)
             AND if ({database: String} != '' AND {table: String} != '', has(tables, format('{}.{}', {database: String}, {table: String})), true)
             AND if ({user: String} != '', user = {user: String}, true)
@@ -84,6 +86,8 @@ export const historyQueriesConfig: QueryConfig = {
           WHERE
             if ({type: String} != '', type = {type: String}, type != 'QueryStart')
             AND if ({duration_1m: String} = '1', query_duration >= 60, true)
+            AND if ({min_duration_s: String} != '', query_duration >= {min_duration_s:UInt64}, true)
+            AND if ({last_hours: String} != '', event_time > now() - interval {last_hours:UInt64} hour, true)
             AND if (notEmpty({event_time: String}), toDate(event_time) = {event_time: String}, true)
             AND if ({database: String} != '' AND {table: String} != '', has(tables, format('{}.{}', {database: String}, {table: String})), true)
             AND if ({user: String} != '', user = {user: String}, true)
@@ -159,6 +163,8 @@ export const historyQueriesConfig: QueryConfig = {
   defaultParams: {
     type: '',
     duration_1m: '',
+    min_duration_s: '',
+    last_hours: '',
     event_time: '',
     database: '',
     table: '',


### PR DESCRIPTION
## Summary
- pass recognized history-query URL filters into the table data request
- add SQL/default-param support for the visible time-window and duration chips
- add regression coverage for history-query preset param wiring

## Verification
- BUN_INSTALL_CACHE_DIR=/tmp/bun-cache XDG_CACHE_HOME=/tmp/bun-cache CYPRESS_CACHE_FOLDER=/tmp/cypress-cache TMPDIR=/tmp bun run test:query-config
- BUN_INSTALL_CACHE_DIR=/tmp/bun-cache XDG_CACHE_HOME=/tmp/bun-cache CYPRESS_CACHE_FOLDER=/tmp/cypress-cache TMPDIR=/tmp bun run lint
- BUN_INSTALL_CACHE_DIR=/tmp/bun-cache XDG_CACHE_HOME=/tmp/bun-cache CYPRESS_CACHE_FOLDER=/tmp/cypress-cache TMPDIR=/tmp bun run build

## Summary by Sourcery

Ensure history query URL filter parameters correctly drive history-queries table data and SQL filters.

Bug Fixes:
- Wire recognized history-queries URL filter parameters through to the table request via PageLayout searchParams.

Enhancements:
- Extend history-queries SQL to respect visible time-window and minimum duration filter parameters across all SQL variants.
- Add validation tests to guarantee default params exist for all history query preset keys and that SQL includes the new filter parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filter for minimum query duration to refine query history results.
  * Added time-range filter to display queries from the last N hours.
  * Improved query parameter handling to preserve filter selections in URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->