### PR TITLE
fix(history-queries): parse empty numeric filters

### DIFF
--- a/lib/query-config/__tests__/query-config.test.ts
+++ b/lib/query-config/__tests__/query-config.test.ts
@@ -378,9 +378,13 @@ describe('Query Config Validation', () => {
 
       sqlVariants.forEach((sql) => {
         expect(sql).toContain('{min_duration_s: String}')
-        expect(sql).toContain('{min_duration_s:UInt64}')
+        expect(sql).toContain('toUInt64OrZero({min_duration_s: String})')
         expect(sql).toContain('{last_hours: String}')
-        expect(sql).toContain('{last_hours:UInt64}')
+        expect(sql).toContain(
+          'toIntervalHour(toUInt64OrZero({last_hours: String}))'
+        )
+        expect(sql).not.toContain('{min_duration_s:UInt64}')
+        expect(sql).not.toContain('{last_hours:UInt64}')
       })
     })
   })

--- a/lib/query-config/queries/history-queries.ts
+++ b/lib/query-config/queries/history-queries.ts
@@ -40,16 +40,16 @@ export const historyQueriesConfig: QueryConfig = {
           WHERE
             if ({type: String} != '', type = {type: String}, type != 'QueryStart')
             AND if ({duration_1m: String} = '1', query_duration >= 60, true)
-            AND if ({min_duration_s: String} != '', query_duration >= {min_duration_s:UInt64}, true)
-            AND if ({last_hours: String} != '', event_time > now() - interval {last_hours:UInt64} hour, true)
+            AND if ({min_duration_s: String} != '', query_duration >= toUInt64OrZero({min_duration_s: String}), true)
+            AND if ({last_hours: String} != '', event_time > now() - toIntervalHour(toUInt64OrZero({last_hours: String})), true)
             AND if (notEmpty({event_time: String}), toDate(event_time) = {event_time: String}, true)
             AND if ({database: String} != '' AND {table: String} != '', has(tables, format('{}.{}', {database: String}, {table: String})), true)
             AND if ({user: String} != '', user = {user: String}, true)
             AND if ({excluded_users: String} != '', not(has(splitByChar(',', {excluded_users: String}), user)), true)
             AND if ({query_text: String} != '', positionCaseInsensitiveUTF8(query, {query_text: String}) > 0, true)
             AND if ({query_id: String} != '', query_id = {query_id: String}, true)
-            AND if ({min_memory_mb: String} != '', memory_usage > {min_memory_mb:UInt64} * 1024 * 1024, true)
-            AND if ({min_read_rows: String} != '', read_rows > {min_read_rows:UInt64}, true)
+            AND if ({min_memory_mb: String} != '', memory_usage > toUInt64OrZero({min_memory_mb: String}) * 1024 * 1024, true)
+            AND if ({min_read_rows: String} != '', read_rows > toUInt64OrZero({min_read_rows: String}), true)
             AND if ({query_kind: String} != '', query_kind = {query_kind: String}, true)
           ORDER BY event_time DESC
           LIMIT 100
@@ -86,16 +86,16 @@ export const historyQueriesConfig: QueryConfig = {
           WHERE
             if ({type: String} != '', type = {type: String}, type != 'QueryStart')
             AND if ({duration_1m: String} = '1', query_duration >= 60, true)
-            AND if ({min_duration_s: String} != '', query_duration >= {min_duration_s:UInt64}, true)
-            AND if ({last_hours: String} != '', event_time > now() - interval {last_hours:UInt64} hour, true)
+            AND if ({min_duration_s: String} != '', query_duration >= toUInt64OrZero({min_duration_s: String}), true)
+            AND if ({last_hours: String} != '', event_time > now() - toIntervalHour(toUInt64OrZero({last_hours: String})), true)
             AND if (notEmpty({event_time: String}), toDate(event_time) = {event_time: String}, true)
             AND if ({database: String} != '' AND {table: String} != '', has(tables, format('{}.{}', {database: String}, {table: String})), true)
             AND if ({user: String} != '', user = {user: String}, true)
             AND if ({excluded_users: String} != '', not(has(splitByChar(',', {excluded_users: String}), user)), true)
             AND if ({query_text: String} != '', positionCaseInsensitiveUTF8(query, {query_text: String}) > 0, true)
             AND if ({query_id: String} != '', query_id = {query_id: String}, true)
-            AND if ({min_memory_mb: String} != '', memory_usage > {min_memory_mb:UInt64} * 1024 * 1024, true)
-            AND if ({min_read_rows: String} != '', read_rows > {min_read_rows:UInt64}, true)
+            AND if ({min_memory_mb: String} != '', memory_usage > toUInt64OrZero({min_memory_mb: String}) * 1024 * 1024, true)
+            AND if ({min_read_rows: String} != '', read_rows > toUInt64OrZero({min_read_rows: String}), true)
             AND if ({query_kind: String} != '', query_kind = {query_kind: String}, true)
           ORDER BY event_time DESC
           LIMIT 100


### PR DESCRIPTION
## Summary
- avoid binding empty history-query numeric filters as UInt64 params
- convert optional numeric filter strings with ClickHouse safe numeric conversion
- update query-config coverage for empty duration/time filter params

## Verification
- bun run test:query-config
- bun run lint
- bun run build

## Summary by Sourcery

Handle history query numeric filters safely when optional filter values are empty.

Bug Fixes:
- Prevent binding empty numeric history query filters as UInt64 parameters by using safe ClickHouse conversions for optional numeric filter strings.

Tests:
- Expand query-config tests to cover handling of empty duration and time filter parameters in history queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated query filter validation test expectations for parameter handling.

* **Refactor**
  * Improved internal parameter conversion for duration and time-based query filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->