### PR TITLE
refactor(history-queries): share filter predicates

### DIFF
--- a/docs/reviews/code-smell-dead-code-2026-04-30.md
+++ b/docs/reviews/code-smell-dead-code-2026-04-30.md
@@ -1,0 +1,41 @@
+# Code Smell and Dead Code Review - 2026-04-30
+
+Scope: recent changes since the last handled repo scan, focused on
+`ca2328c3` and `e8675d72`.
+
+## Findings
+
+### Warning: duplicated history query filter predicates
+
+- File: `lib/query-config/queries/history-queries.ts:40` and
+  `lib/query-config/queries/history-queries.ts:86`
+- Severity: warning
+- Evidence:
+  - Both versioned SQL variants repeated the same `WHERE`, `ORDER BY`, and
+    `LIMIT` block.
+  - Recent fixes changed optional URL filters in both blocks:
+    `min_duration_s`, `last_hours`, `min_memory_mb`, and `min_read_rows`.
+- Fix:
+  - Extracted the shared predicate block to `historyQueryFilters` so later
+    filter changes have one source.
+- Behavior:
+  - No intended SQL behavior change. The selected columns stay versioned, and
+    only the shared filter block moved.
+
+## Dead Code Check
+
+No confident dead-code removals were found.
+
+- `rg -n "historyQueriesConfig" --glob '!**/*.test.*' --glob '!**/*.cy.*'`
+  shows live references from the registry and history queries page.
+- `rg -n "QueryFiltersBar" --glob '!**/*.test.*' --glob '!**/*.cy.*'`
+  shows the filter bar is used by `app/history-queries/page.tsx`.
+- `rg -n "duration_1m" --glob '!**/*.test.*' --glob '!**/*.cy.*'`
+  shows the legacy parameter is still present in SQL/default params. Removing
+  it could change URL compatibility, so it was not treated as dead code.
+
+## ClickHouse Rules Checked
+
+- `query-index-skipping-indices`: no action. The reviewed query targets
+  `system.query_log`; adding table indices is outside this app config and would
+  change database setup, not just maintainability.

--- a/lib/query-config/queries/history-queries.ts
+++ b/lib/query-config/queries/history-queries.ts
@@ -3,6 +3,24 @@ import type { QueryConfig } from '@/types/query-config'
 import { QUERY_LOG } from '@/lib/table-notes'
 import { ColumnFormat } from '@/types/column-format'
 
+const historyQueryFilters = `
+          WHERE
+            if ({type: String} != '', type = {type: String}, type != 'QueryStart')
+            AND if ({duration_1m: String} = '1', query_duration >= 60, true)
+            AND if ({min_duration_s: String} != '', query_duration >= toUInt64OrZero({min_duration_s: String}), true)
+            AND if ({last_hours: String} != '', event_time > now() - toIntervalHour(toUInt64OrZero({last_hours: String})), true)
+            AND if (notEmpty({event_time: String}), toDate(event_time) = {event_time: String}, true)
+            AND if ({database: String} != '' AND {table: String} != '', has(tables, format('{}.{}', {database: String}, {table: String})), true)
+            AND if ({user: String} != '', user = {user: String}, true)
+            AND if ({excluded_users: String} != '', not(has(splitByChar(',', {excluded_users: String}), user)), true)
+            AND if ({query_text: String} != '', positionCaseInsensitiveUTF8(query, {query_text: String}) > 0, true)
+            AND if ({query_id: String} != '', query_id = {query_id: String}, true)
+            AND if ({min_memory_mb: String} != '', memory_usage > toUInt64OrZero({min_memory_mb: String}) * 1024 * 1024, true)
+            AND if ({min_read_rows: String} != '', read_rows > toUInt64OrZero({min_read_rows: String}), true)
+            AND if ({query_kind: String} != '', query_kind = {query_kind: String}, true)
+          ORDER BY event_time DESC
+          LIMIT 100`
+
 export const historyQueriesConfig: QueryConfig = {
   name: 'history-queries',
   description:
@@ -37,22 +55,7 @@ export const historyQueriesConfig: QueryConfig = {
               query_kind,
               client_name
           FROM system.query_log
-          WHERE
-            if ({type: String} != '', type = {type: String}, type != 'QueryStart')
-            AND if ({duration_1m: String} = '1', query_duration >= 60, true)
-            AND if ({min_duration_s: String} != '', query_duration >= toUInt64OrZero({min_duration_s: String}), true)
-            AND if ({last_hours: String} != '', event_time > now() - toIntervalHour(toUInt64OrZero({last_hours: String})), true)
-            AND if (notEmpty({event_time: String}), toDate(event_time) = {event_time: String}, true)
-            AND if ({database: String} != '' AND {table: String} != '', has(tables, format('{}.{}', {database: String}, {table: String})), true)
-            AND if ({user: String} != '', user = {user: String}, true)
-            AND if ({excluded_users: String} != '', not(has(splitByChar(',', {excluded_users: String}), user)), true)
-            AND if ({query_text: String} != '', positionCaseInsensitiveUTF8(query, {query_text: String}) > 0, true)
-            AND if ({query_id: String} != '', query_id = {query_id: String}, true)
-            AND if ({min_memory_mb: String} != '', memory_usage > toUInt64OrZero({min_memory_mb: String}) * 1024 * 1024, true)
-            AND if ({min_read_rows: String} != '', read_rows > toUInt64OrZero({min_read_rows: String}), true)
-            AND if ({query_kind: String} != '', query_kind = {query_kind: String}, true)
-          ORDER BY event_time DESC
-          LIMIT 100
+${historyQueryFilters}
       `,
     },
     {
@@ -83,22 +86,7 @@ export const historyQueriesConfig: QueryConfig = {
               query_cache_usage,
               client_name
           FROM system.query_log
-          WHERE
-            if ({type: String} != '', type = {type: String}, type != 'QueryStart')
-            AND if ({duration_1m: String} = '1', query_duration >= 60, true)
-            AND if ({min_duration_s: String} != '', query_duration >= toUInt64OrZero({min_duration_s: String}), true)
-            AND if ({last_hours: String} != '', event_time > now() - toIntervalHour(toUInt64OrZero({last_hours: String})), true)
-            AND if (notEmpty({event_time: String}), toDate(event_time) = {event_time: String}, true)
-            AND if ({database: String} != '' AND {table: String} != '', has(tables, format('{}.{}', {database: String}, {table: String})), true)
-            AND if ({user: String} != '', user = {user: String}, true)
-            AND if ({excluded_users: String} != '', not(has(splitByChar(',', {excluded_users: String}), user)), true)
-            AND if ({query_text: String} != '', positionCaseInsensitiveUTF8(query, {query_text: String}) > 0, true)
-            AND if ({query_id: String} != '', query_id = {query_id: String}, true)
-            AND if ({min_memory_mb: String} != '', memory_usage > toUInt64OrZero({min_memory_mb: String}) * 1024 * 1024, true)
-            AND if ({min_read_rows: String} != '', read_rows > toUInt64OrZero({min_read_rows: String}), true)
-            AND if ({query_kind: String} != '', query_kind = {query_kind: String}, true)
-          ORDER BY event_time DESC
-          LIMIT 100
+${historyQueryFilters}
       `,
     },
   ],


### PR DESCRIPTION
## Summary
- Extract the shared history-query filter block used by both ClickHouse SQL variants.
- Add the 2026-04-30 code smell/dead-code scan report with search evidence.

## Verification
- bun test lib/query-config/__tests__/query-config.test.ts
- bun run lint
- bun run build
- bun run type-check

Note: the first type-check attempt ran before Next regenerated .next/types and failed on missing generated files; after build refreshed them, type-check passed.

## Summary by Sourcery

Refactor history query configuration to share common ClickHouse filter predicates and document the associated code smell/dead-code review findings.

Enhancements:
- Extract a shared SQL filter, ordering, and limit block for history queries used by both ClickHouse query variants to remove duplication and centralize future filter changes.

Documentation:
- Add a code smell and dead code review report for the 2026-04-30 scan, documenting duplicated history query predicates and confirming no dead-code removals.