### PR TITLE
docs(claude): note code-smell maintenance workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,8 @@ Both deployment methods provide:
 - `bun run migrate`, `bun run migrate:status`, `bun run migrate:dry-run` - Use the local migration runner for non-Cloudflare targets
 - `bun run docker:health` / `bun run cf:health` - Check Docker or deployed health endpoints
 - `bun run lint && bun run build` - Quick local CI parity check (matches core lint/build workflow jobs)
+- Code-smell/dead-code maintenance notes are tracked in `docs/reviews/code-smell-dead-code-YYYY-MM-DD.md`
+- TODO: Add a dedicated command for the code-smell scan workflow (currently run manually)
 
 **Docs workspace**: The `docs/` app uses `pnpm` instead of `bun`.
 


### PR DESCRIPTION
## Summary
- add the newly used code-smell review artifact workflow to command/workflow docs
- add a TODO noting the workflow is currently manual and needs a dedicated command

## Notes
- AGENTS.md is a symlink to CLAUDE.md, so one edit keeps both in sync
- minimal docs-only change

## Summary by Sourcery

Document the new code-smell/dead-code maintenance workflow and note the need for a future dedicated command in the Claude/agents documentation.

Documentation:
- Add a reference to the code-smell/dead-code review artifact file in the Claude workflow docs.
- Document a TODO indicating the current manual nature of the code-smell scan workflow and the intent to add a dedicated command.