### PR TITLE
fix(history-queries): preserve zero filter params

### DIFF
--- a/app/history-queries/page.tsx
+++ b/app/history-queries/page.tsx
@@ -5,6 +5,7 @@ export const dynamic = 'force-static'
 import { useSearchParams } from 'next/navigation'
 import { Suspense, useMemo } from 'react'
 import { QueryFiltersBar } from '@/components/history-queries/filter-bar'
+import { getHistoryQuerySearchParams } from '@/components/history-queries/search-params'
 import { PageLayout } from '@/components/layout/query-page'
 import { ChartSkeleton } from '@/components/skeletons'
 import { historyQueriesConfig } from '@/lib/query-config/queries/history-queries'
@@ -12,16 +13,10 @@ import { historyQueriesConfig } from '@/lib/query-config/queries/history-queries
 function HistoryQueriesPageContent() {
   const searchParams = useSearchParams()
   const tableSearchParams = useMemo(() => {
-    const params: Record<string, string> = {}
-
-    Object.keys(historyQueriesConfig.defaultParams || {}).forEach((key) => {
-      const value = searchParams.get(key)
-      if (value) {
-        params[key] = value
-      }
-    })
-
-    return params
+    return getHistoryQuerySearchParams(
+      searchParams,
+      historyQueriesConfig.defaultParams
+    )
   }, [searchParams])
 
   return (

--- a/components/history-queries/search-params.test.ts
+++ b/components/history-queries/search-params.test.ts
@@ -27,4 +27,16 @@ describe('getHistoryQuerySearchParams', () => {
       })
     ).toEqual({})
   })
+
+  it('omits empty-string params', () => {
+    const searchParams = new URLSearchParams({
+      last_hours: '',
+    })
+
+    expect(
+      getHistoryQuerySearchParams(searchParams, {
+        last_hours: '',
+      })
+    ).toEqual({})
+  })
 })

--- a/components/history-queries/search-params.test.ts
+++ b/components/history-queries/search-params.test.ts
@@ -1,0 +1,30 @@
+import { getHistoryQuerySearchParams } from './search-params'
+import { describe, expect, it } from 'bun:test'
+
+describe('getHistoryQuerySearchParams', () => {
+  it('keeps present zero-valued params', () => {
+    const searchParams = new URLSearchParams({
+      last_hours: '0',
+      min_duration_s: '0',
+      unknown: 'ignored',
+    })
+
+    expect(
+      getHistoryQuerySearchParams(searchParams, {
+        last_hours: '',
+        min_duration_s: '',
+      })
+    ).toEqual({
+      last_hours: '0',
+      min_duration_s: '0',
+    })
+  })
+
+  it('omits params that are not present', () => {
+    expect(
+      getHistoryQuerySearchParams(new URLSearchParams(), {
+        last_hours: '',
+      })
+    ).toEqual({})
+  })
+})

--- a/components/history-queries/search-params.ts
+++ b/components/history-queries/search-params.ts
@@ -1,12 +1,16 @@
 export function getHistoryQuerySearchParams(
   searchParams: Pick<URLSearchParams, 'get'>,
-  defaultParams: Record<string, unknown> | undefined
-) {
+  defaultParams: Record<string, string | number | boolean> | undefined
+): Record<string, string> {
   const params: Record<string, string> = {}
 
-  Object.keys(defaultParams || {}).forEach((key) => {
+  if (!defaultParams) {
+    return params
+  }
+
+  Object.keys(defaultParams).forEach((key) => {
     const value = searchParams.get(key)
-    if (value !== null) {
+    if (value !== null && value !== '') {
       params[key] = value
     }
   })

--- a/components/history-queries/search-params.ts
+++ b/components/history-queries/search-params.ts
@@ -1,0 +1,15 @@
+export function getHistoryQuerySearchParams(
+  searchParams: Pick<URLSearchParams, 'get'>,
+  defaultParams: Record<string, unknown> | undefined
+) {
+  const params: Record<string, string> = {}
+
+  Object.keys(defaultParams || {}).forEach((key) => {
+    const value = searchParams.get(key)
+    if (value !== null) {
+      params[key] = value
+    }
+  })
+
+  return params
+}


### PR DESCRIPTION
## Summary
- preserve present history-query URL params even when the value is `0`
- move configured-param extraction into a focused helper with regression coverage

## Evidence
- Recent PR #1011 added history-query URL param forwarding and Sourcery flagged that truthy filtering drops valid `0` values.
- Current main still had `if (value)` in `app/history-queries/page.tsx`, so `last_hours=0` and `min_duration_s=0` were omitted before reaching `PageLayout`.

## Verification
- `bun test --max-concurrency=1 components/history-queries/search-params.test.ts`
- `bun test --max-concurrency=1 lib/query-config/__tests__/query-config.test.ts components/history-queries/search-params.test.ts`
- `bun run lint`
- `bun run build`

## Summary by Sourcery

Preserve history query URL parameters with zero values and centralize their extraction into a reusable helper with regression tests.

Bug Fixes:
- Ensure history query URL parameters are preserved even when their values are zero or otherwise falsy.

Enhancements:
- Extract history query search-parameter handling into a dedicated helper for reuse and clarity.

Tests:
- Add unit tests covering history query search-parameter extraction behavior, including zero-valued parameters.