### PR TITLE
refactor(agents): split chat area components

### DIFF
--- a/components/agents/agents-chat-area.tsx
+++ b/components/agents/agents-chat-area.tsx
@@ -116,6 +116,9 @@ export const AgentsChatArea = forwardRef<
   const prevStatusRef = useRef<string>(status)
   const lastSavedMessagesRef = useRef<UIMessage[]>([])
   const saveTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
+  const regenerateTimeoutRef = useRef<
+    ReturnType<typeof setTimeout> | undefined
+  >(undefined)
   const prevConversationIdRef = useRef<string | undefined>(undefined)
   const initialQuerySentRef = useRef<string | null>(null)
   const [responseDurations, setResponseDurations] = useState<
@@ -157,6 +160,11 @@ export const AgentsChatArea = forwardRef<
     if (!currentConversationId) return
     if (currentConversationId === prevConversationIdRef.current) return
 
+    if (regenerateTimeoutRef.current) {
+      clearTimeout(regenerateTimeoutRef.current)
+      regenerateTimeoutRef.current = undefined
+    }
+
     const conversation = conversations.find(
       (item: Conversation) => item.id === currentConversationId
     )
@@ -192,6 +200,14 @@ export const AgentsChatArea = forwardRef<
     }
   }, [messages, currentConversationId, updateMessages, status])
 
+  useEffect(() => {
+    return () => {
+      if (regenerateTimeoutRef.current) {
+        clearTimeout(regenerateTimeoutRef.current)
+      }
+    }
+  }, [])
+
   const submitPrompt = useCallback(
     (text: string) => {
       const trimmed = text.trim()
@@ -217,6 +233,10 @@ export const AgentsChatArea = forwardRef<
     if (saveTimeoutRef.current) {
       clearTimeout(saveTimeoutRef.current)
       saveTimeoutRef.current = undefined
+    }
+    if (regenerateTimeoutRef.current) {
+      clearTimeout(regenerateTimeoutRef.current)
+      regenerateTimeoutRef.current = undefined
     }
 
     setMessages([])
@@ -270,10 +290,15 @@ export const AgentsChatArea = forwardRef<
     )
     setMessages(messagesWithoutLastExchange)
 
-    setTimeout(() => {
+    if (regenerateTimeoutRef.current) {
+      clearTimeout(regenerateTimeoutRef.current)
+    }
+
+    regenerateTimeoutRef.current = setTimeout(() => {
       sendMessage({
         parts: [{ type: 'text', text: textPart.text }],
       })
+      regenerateTimeoutRef.current = undefined
     }, 100)
   }, [messages, stop, sendMessage, setMessages])
 

--- a/components/agents/agents-chat-area.tsx
+++ b/components/agents/agents-chat-area.tsx
@@ -2,29 +2,10 @@
 
 'use no memo'
 
-import {
-  ActivityIcon,
-  AlertCircleIcon,
-  ChevronDownIcon,
-  ChevronRightIcon,
-  ClockIcon,
-  DatabaseIcon,
-  HardDriveIcon,
-  Loader2Icon,
-  Maximize2Icon,
-  MergeIcon,
-  PanelRightClose,
-  PanelRightOpen,
-  RefreshCwIcon,
-  SparklesIcon,
-  SquareIcon,
-  TableIcon,
-  TrashIcon,
-  UserIcon,
-  ZapIcon,
-} from 'lucide-react'
+import { RefreshCwIcon, SquareIcon } from 'lucide-react'
 
 import type { UIMessage } from 'ai'
+import type { Conversation } from '@/lib/ai/agent/conversation-utils'
 
 import { useChat } from '@ai-sdk/react'
 import { DefaultChatTransport } from 'ai'
@@ -38,76 +19,27 @@ import {
   useRef,
   useState,
 } from 'react'
-import ReactMarkdown from 'react-markdown'
-import rehypeHighlight from 'rehype-highlight'
-import remarkGfm from 'remark-gfm'
-import './markdown-code.css'
-
-import type { AgentDataSourcesProps } from '@/components/agents/agent-data-sources'
-import type { AgentVisualizationProps } from '@/components/agents/agent-visualization'
-import type { Conversation } from '@/lib/ai/agent/conversation-utils'
-import type { QueryConfig } from '@/types/query-config'
-
-import { AgentChartRenderer } from '@/components/agents/agent-chart-renderer'
-import { AgentDataSources } from '@/components/agents/agent-data-sources'
 import { AgentErrorDisplay } from '@/components/agents/agent-error-display'
-import { AgentInsightCards } from '@/components/agents/agent-insight-cards'
-import { AgentVisualization } from '@/components/agents/agent-visualization'
 import {
-  AskUserWidget,
-  isAskUserOutput,
-} from '@/components/agents/ask-user-widget'
+  AgentChatCompactControls,
+  AgentChatHeader,
+} from '@/components/agents/chat/controls'
+import { AgentChatEmptyState } from '@/components/agents/chat/empty-state'
+import {
+  ChatMessage,
+  StreamingTypingIndicator,
+} from '@/components/agents/chat/message'
 import { PromptInputTextareaWithMentions } from '@/components/agents/mentions'
 import {
   ConversationContent,
   ConversationEmptyState,
   Conversation as ConversationUI,
 } from '@/components/ai-elements/conversation'
-import {
-  Message,
-  MessageContent,
-  MessageResponse,
-} from '@/components/ai-elements/message'
-import {
-  Reasoning,
-  ReasoningContent,
-  ReasoningTrigger,
-} from '@/components/ai-elements/reasoning'
-import { Suggestion, Suggestions } from '@/components/ai-elements/suggestion'
-import {
-  Task,
-  TaskContent,
-  TaskItem,
-  TaskTrigger,
-} from '@/components/ai-elements/task'
-import { DataTable } from '@/components/data-table/data-table'
-import { getToolMetadata } from '@/components/mcp/mcp-tools-data'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog'
 import { useConversationContext } from '@/lib/ai/agent/conversation-context'
 import { getSavedModel } from '@/lib/hooks/use-agent-model'
-import { getMessageStats } from '@/lib/hooks/use-agent-session-stats'
 import { useToolConfig } from '@/lib/hooks/use-tool-config'
 import { useHostId } from '@/lib/swr'
-import { cn, formatDuration } from '@/lib/utils'
-
-// ============================================================================
-// Types
-// ============================================================================
 
 export interface AgentsChatAreaRef {
   handleClear: () => void
@@ -121,1016 +53,29 @@ interface AgentsChatAreaProps {
   readonly initialQuery?: string | null
 }
 
-// Note: Chat state is managed internally by useChat when props are not provided.
-// For external state management, messages are passed via props but types need to match exactly.
+function findLastAssistantMessage(messages: readonly UIMessage[]) {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index].role === 'assistant') return messages[index]
+  }
+  return undefined
+}
 
-// ============================================================================
-// Sub-components
-// ============================================================================
+function findLastUserMessage(messages: readonly UIMessage[]) {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index].role === 'user') return messages[index]
+  }
+  return undefined
+}
 
-/**
- * Animated typing indicator with three bouncing dots
- */
-function TypingIndicator() {
-  return (
-    <Message from="assistant">
-      <MessageContent>
-        <div className="flex items-center gap-1 py-2">
-          <span className="flex gap-0.5">
-            <span className="h-1.5 w-1.5 rounded-full bg-foreground/60 animate-bounce [animation-delay:-0.3s]" />
-            <span className="h-1.5 w-1.5 rounded-full bg-foreground/60 animate-bounce [animation-delay:-0.15s]" />
-            <span className="h-1.5 w-1.5 rounded-full bg-foreground/60 animate-bounce" />
-          </span>
-        </div>
-      </MessageContent>
-    </Message>
+function getTextPart(message: UIMessage) {
+  return message.parts.find(
+    (part): part is { type: 'text'; text: string } =>
+      typeof part === 'object' &&
+      part !== null &&
+      'type' in part &&
+      part.type === 'text'
   )
 }
-
-/**
- * Enhanced result table using the full-featured DataTable component.
- * Supports sorting, pagination, column filtering, and virtualization for large datasets.
- */
-function ResultTable({
-  rows,
-  maxRows = 100,
-}: {
-  readonly rows: readonly unknown[]
-  readonly maxRows?: number
-}) {
-  const displayRows = rows.slice(0, maxRows) as Record<string, unknown>[]
-
-  // Extract column names from first row
-  const columns = useMemo(() => {
-    if (displayRows.length === 0) return []
-    return Object.keys(displayRows[0])
-  }, [displayRows])
-
-  // Dynamically build QueryConfig for the DataTable
-  const queryConfig = useMemo<QueryConfig<string[]>>(
-    () => ({
-      name: 'agent-query-result',
-      description: 'Query results from AI agent',
-      sql: 'SELECT * FROM agent_result',
-      columns: columns as string[],
-    }),
-    [columns]
-  )
-
-  if (columns.length === 0) {
-    return (
-      <div className="text-center text-muted-foreground py-4 text-sm">
-        No columns to display
-      </div>
-    )
-  }
-
-  const footnote =
-    rows.length > maxRows ? `Showing ${maxRows} of ${rows.length} rows` : ' '
-
-  return (
-    <DataTable
-      data={displayRows}
-      queryConfig={queryConfig}
-      context={{}}
-      defaultPageSize={Math.min(displayRows.length, 25)}
-      showSQL={false}
-      enableColumnFilters={false}
-      enableColumnReordering={false}
-      compact
-      footnote={footnote}
-    />
-  )
-}
-
-/**
- * Renders a single tool invocation part from the AI SDK UIMessage
- * with toggleable content for cleaner UI
- */
-function ToolCallPart({
-  part,
-  onToolResult,
-}: {
-  readonly part: {
-    type: string
-    toolCallId: string
-    toolName?: string
-    state: string
-    input?: unknown
-    output?: unknown
-    errorText?: string
-    title?: string
-  }
-  readonly onToolResult?: (toolCallId: string, result: string) => void
-}) {
-  const toolName = part.toolName || part.type.replace('tool-', '')
-
-  // Determine state
-  const isStarting =
-    part.state === 'input-streaming' || part.state === 'input-available'
-  const isStreaming = part.state === 'output-streaming'
-  const hasOutput = part.state === 'output-available'
-  const hasError = part.state === 'output-error'
-
-  // Track expanded state directly, auto-expand during streaming/error
-  const shouldAutoExpand = isStreaming || hasError || isStarting
-  const [isExpanded, setIsExpanded] = useState(shouldAutoExpand)
-
-  // Auto-expand when tool starts streaming or errors
-  useEffect(() => {
-    if (shouldAutoExpand) setIsExpanded(true)
-  }, [shouldAutoExpand])
-
-  const toggleExpanded = () => setIsExpanded((prev) => !prev)
-
-  // Format input parameters as muted inline text (e.g., "hostId=0")
-  const inputParams = useMemo(() => {
-    if (!part.input || typeof part.input !== 'object') return null
-
-    const inputObj = part.input as Record<string, unknown>
-    const entries = Object.entries(inputObj)
-
-    // For single param like hostId, show "hostId=0"
-    // For multiple params, join with ", "
-    const params = entries
-      .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
-      .join(', ')
-
-    return params
-  }, [part.input])
-
-  // Get tool parameter info for optional display
-  const toolParams = useMemo(() => {
-    const tool = getToolMetadata(toolName)
-    return tool?.params || []
-  }, [toolName])
-
-  // Extract rows from output for the expand button in the header
-  const { outputRows, outputQueryConfig } = useMemo(() => {
-    if (!hasOutput || !part.output)
-      return {
-        outputRows: [] as Record<string, unknown>[],
-        outputQueryConfig: null,
-      }
-
-    let rows: Record<string, unknown>[] = []
-
-    // Direct array output
-    if (Array.isArray(part.output) && part.output.length > 0) {
-      const first = part.output[0]
-      if (typeof first === 'object' && first !== null) {
-        rows = part.output as Record<string, unknown>[]
-      }
-    }
-
-    // Object with rows property
-    const obj = part.output as Record<string, unknown>
-    if (Array.isArray(obj.rows) && obj.rows.length > 0) {
-      rows = obj.rows as Record<string, unknown>[]
-    }
-
-    if (rows.length === 0)
-      return {
-        outputRows: [] as Record<string, unknown>[],
-        outputQueryConfig: null,
-      }
-
-    const columns = Object.keys(rows[0])
-    const qc: QueryConfig<string[]> = {
-      name: 'agent-query-result',
-      description: 'Query results from AI agent',
-      sql: 'SELECT * FROM agent_result',
-      columns,
-    }
-    return { outputRows: rows, outputQueryConfig: qc }
-  }, [hasOutput, part.output])
-
-  // Check if the tool output is a "promoted" type (visualization or data sources)
-  // that should render outside the collapsible, always visible
-  const promotedOutput = useMemo(() => {
-    if (!hasOutput || part.output == null) return null
-    const outputObj = part.output as Record<string, unknown>
-    if (outputObj.type === 'visualization' && Array.isArray(outputObj.rows)) {
-      return 'visualization' as const
-    }
-    if (outputObj.type === 'data_sources' && Array.isArray(outputObj.sources)) {
-      return 'data_sources' as const
-    }
-    return null
-  }, [hasOutput, part.output])
-
-  return (
-    <div className="my-2">
-      <div className="overflow-hidden rounded-md border border-border/60 bg-muted/20">
-        {/* Tool header - clickable to toggle */}
-        <button
-          onClick={toggleExpanded}
-          className="flex w-full items-center gap-2 px-2.5 py-2 text-left transition-colors hover:bg-muted/30"
-        >
-          {/* Expand/collapse icon */}
-          <span className="shrink-0 text-muted-foreground">
-            {isExpanded ? (
-              <ChevronDownIcon className="h-3.5 w-3.5" />
-            ) : (
-              <ChevronRightIcon className="h-3.5 w-3.5" />
-            )}
-          </span>
-
-          {/* Status indicator */}
-          <div
-            className={cn(
-              'h-2 w-2 rounded-full shrink-0',
-              isStarting && 'bg-yellow-500 animate-pulse',
-              isStreaming && 'bg-yellow-400 animate-ping',
-              hasOutput && 'bg-green-500',
-              hasError && 'bg-red-500'
-            )}
-          />
-
-          {/* Tool name with muted input params */}
-          <div className="flex items-center gap-1.5 min-w-0">
-            <span className="text-xs font-medium font-mono">{toolName}</span>
-            {inputParams && (
-              <span className="text-xs text-muted-foreground/70 font-mono truncate">
-                {inputParams}
-              </span>
-            )}
-          </div>
-
-          {/* Status badge + expand button */}
-          <div className="ml-auto flex items-center gap-1.5">
-            {isStreaming && (
-              <Badge
-                variant="outline"
-                className="text-[10px] text-yellow-600 shrink-0"
-              >
-                Executing...
-              </Badge>
-            )}
-            {hasOutput && (
-              <Badge
-                variant="outline"
-                className="text-[10px] text-green-600 shrink-0"
-              >
-                ✓ Done
-              </Badge>
-            )}
-            {hasError && (
-              <Badge
-                variant="outline"
-                className="text-[10px] text-red-600 shrink-0"
-              >
-                ✗ Failed
-              </Badge>
-            )}
-            {hasOutput && outputRows.length > 0 && outputQueryConfig && (
-              <ExpandTableButton
-                rows={outputRows}
-                queryConfig={outputQueryConfig}
-              />
-            )}
-          </div>
-        </button>
-
-        {/* Collapsible content */}
-        {isExpanded ? (
-          <div className="bg-background/50">
-            {/* Streaming state */}
-            {isStreaming ? (
-              <div className="px-2.5 py-2.5">
-                <div className="flex items-center gap-2">
-                  <Loader2Icon className="h-4 w-4 animate-spin text-yellow-500" />
-                  <span className="text-xs text-muted-foreground">
-                    Executing {toolName}...
-                  </span>
-                </div>
-              </div>
-            ) : null}
-
-            {/* Tool output — ask_user gets interactive widget; promoted types render below */}
-            {hasOutput && part.output != null && !promotedOutput ? (
-              <div className="px-1 py-1">
-                {isAskUserOutput(part.output) && onToolResult ? (
-                  <AskUserWidget
-                    output={part.output}
-                    toolCallId={part.toolCallId}
-                    onSubmit={onToolResult}
-                  />
-                ) : (
-                  renderToolOutput(part.output)
-                )}
-              </div>
-            ) : null}
-
-            {/* Tool error */}
-            {hasError && Boolean(part.errorText) ? (
-              <div className="px-3 py-2 text-sm text-destructive">
-                {String(part.errorText)}
-              </div>
-            ) : null}
-
-            {/* Input parameters with optional indicators */}
-            {part.input && typeof part.input === 'object' ? (
-              <div className="border-t border-border/60 bg-muted/10 px-2.5 py-2">
-                <div className="text-[10px] font-medium text-muted-foreground mb-1.5 uppercase tracking-wider">
-                  Parameters
-                </div>
-                <div className="space-y-1">
-                  {Object.entries(part.input as Record<string, unknown>).map(
-                    ([key, value]) => {
-                      const paramDef = toolParams.find((p) => p.name === key)
-                      const isOptional = paramDef?.required === false
-                      return (
-                        <div
-                          key={key}
-                          className="flex items-center gap-2 text-xs"
-                        >
-                          <span
-                            className={cn(
-                              'font-mono',
-                              isOptional
-                                ? 'text-muted-foreground'
-                                : 'text-foreground font-medium'
-                            )}
-                          >
-                            {key}
-                          </span>
-                          <span className="text-muted-foreground">:</span>
-                          <span className="font-mono text-muted-foreground">
-                            {JSON.stringify(value)}
-                          </span>
-                          {isOptional ? (
-                            <span className="text-[10px] text-muted-foreground/60">
-                              (optional)
-                            </span>
-                          ) : null}
-                        </div>
-                      )
-                    }
-                  )}
-                </div>
-              </div>
-            ) : null}
-          </div>
-        ) : null}
-      </div>
-
-      {/* Promoted output — rendered outside the collapsible, always visible */}
-      {hasOutput && promotedOutput && part.output != null ? (
-        <div className="mt-2">{renderToolOutput(part.output)}</div>
-      ) : null}
-    </div>
-  )
-}
-
-/**
- * Expand button for result tables — opens a full-screen dialog with the data
- */
-function ExpandTableButton({
-  rows,
-  queryConfig,
-}: {
-  readonly rows: Record<string, unknown>[]
-  readonly queryConfig: QueryConfig<string[]>
-}) {
-  return (
-    <Dialog>
-      <DialogTrigger asChild>
-        <button
-          className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
-          title="Expand table"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <Maximize2Icon className="h-3 w-3" />
-        </button>
-      </DialogTrigger>
-      <DialogContent className="flex max-h-[90vh] max-w-[95vw] flex-col">
-        <DialogHeader>
-          <DialogTitle>Query Results ({rows.length} rows)</DialogTitle>
-        </DialogHeader>
-        <div className="flex-1 overflow-auto min-h-0">
-          <DataTable
-            data={rows}
-            queryConfig={queryConfig}
-            context={{}}
-            defaultPageSize={50}
-            showSQL={false}
-            enableColumnFilters={true}
-            enableColumnReordering={false}
-          />
-        </div>
-      </DialogContent>
-    </Dialog>
-  )
-}
-
-function renderToolOutput(output: unknown) {
-  if (output == null) return null
-
-  const outputObj = output as Record<string, unknown>
-
-  // Visualization tool output (query_and_visualize)
-  if (outputObj.type === 'visualization' && Array.isArray(outputObj.rows)) {
-    return (
-      <AgentVisualization
-        title={outputObj.title as string | undefined}
-        sql={outputObj.sql as string}
-        rows={outputObj.rows as Record<string, unknown>[]}
-        columns={outputObj.columns as string[]}
-        rowCount={outputObj.rowCount as number}
-        viz={outputObj.viz as AgentVisualizationProps['viz']}
-      />
-    )
-  }
-
-  // Data source discovery output (discover_data_sources)
-  if (outputObj.type === 'data_sources' && Array.isArray(outputObj.sources)) {
-    return (
-      <AgentDataSources
-        searchTerm={outputObj.searchTerm as string}
-        sources={outputObj.sources as AgentDataSourcesProps['sources']}
-      />
-    )
-  }
-
-  // Handle direct array output (e.g., list_databases, list_tables, get_table_schema)
-  if (Array.isArray(output) && output.length > 0) {
-    const firstItem = output[0] as Record<string, unknown>
-    if (typeof firstItem === 'object' && firstItem !== null) {
-      return <ResultTable rows={output as unknown[]} maxRows={100} />
-    }
-  }
-
-  // Check if output has chart data
-  if (
-    outputObj.chartData &&
-    Array.isArray(outputObj.chartData) &&
-    outputObj.chartData.length > 0
-  ) {
-    return (
-      <AgentChartRenderer
-        type={
-          (outputObj.chartType as 'area' | 'bar' | 'donut' | undefined) || 'bar'
-        }
-        data={outputObj.chartData as readonly Record<string, unknown>[]}
-        title={outputObj.chartTitle as string | undefined}
-        xKey={outputObj.xKey as string | undefined}
-        yKey={outputObj.yKey as string | undefined}
-        categories={outputObj.categories as string[] | undefined}
-        readable={
-          outputObj.readable as
-            | 'bytes'
-            | 'duration'
-            | 'number'
-            | 'quantity'
-            | undefined
-        }
-      />
-    )
-  }
-
-  // Check if output has rows (query result)
-  if (Array.isArray(outputObj.rows) && outputObj.rows.length > 0) {
-    return <ResultTable rows={outputObj.rows as unknown[]} maxRows={100} />
-  }
-
-  // Default: render as JSON
-  return (
-    <pre className="text-xs whitespace-pre-wrap break-all max-h-48 overflow-auto font-mono text-muted-foreground">
-      {typeof output === 'string' ? output : JSON.stringify(output, null, 2)}
-    </pre>
-  )
-}
-
-/**
- * Checks if an assistant message has meaningful content (text with actual characters)
- */
-function hasMeaningfulContent(message: UIMessage): boolean {
-  if (message.role !== 'assistant') return false
-
-  // Find text parts and check if any have meaningful content
-  const textParts = message.parts.filter(
-    (p): p is { type: 'text'; text: string } =>
-      typeof p === 'object' && p !== null && 'type' in p && p.type === 'text'
-  )
-
-  return textParts.some((part) => {
-    // Clean markdown and check for actual content
-    const cleaned = part.text
-      .replace(/```[\w]*\n?[\s\S]*?```/g, '') // Remove code blocks
-      .replace(/#{1,6}\s/g, '') // Remove headers
-      .replace(/\*\*/g, '') // Remove bold
-      .replace(/\*/g, '') // Remove italic
-      .replace(/`/g, '') // Remove inline code
-      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // Remove links
-      .replace(/\n+/g, ' ') // Replace newlines
-      .trim()
-
-    return cleaned.length > 10 // Consider meaningful if more than 10 chars
-  })
-}
-
-/**
- * Shows typing indicator during streaming when assistant response is minimal
- * Shows for both cases:
- * 1. User just sent a message (last message is from user, waiting for assistant)
- * 2. Assistant started streaming but hasn't produced meaningful content yet
- */
-function StreamingTypingIndicator({
-  messages,
-}: {
-  readonly messages: readonly UIMessage[]
-}) {
-  const lastMessage = messages[messages.length - 1]
-
-  // Show typing indicator if:
-  // 1. Last message is from user (waiting for assistant to start)
-  // 2. Last message is from assistant but has no meaningful content yet
-  const shouldShowTyping =
-    !lastMessage ||
-    lastMessage.role === 'user' ||
-    (lastMessage.role === 'assistant' && !hasMeaningfulContent(lastMessage))
-
-  if (!shouldShowTyping) return null
-
-  return <TypingIndicator />
-}
-
-/**
- * Generates a stable key for a message part to avoid React remounting during streaming
- * Using message.id + part type + index ensures keys don't shift when parts are added
- */
-function getStablePartKey(
-  messageId: string,
-  part: unknown,
-  index: number
-): string {
-  const p = part as Record<string, unknown>
-
-  // Tool parts have stable toolCallId
-  if (
-    p.type === 'dynamic-tool' ||
-    (typeof p.type === 'string' && p.type.startsWith('tool-'))
-  ) {
-    return `msg-${messageId}-tool-${p.toolCallId as string}`
-  }
-
-  // Text parts: include index to ensure uniqueness across multiple text parts
-  // This is necessary because incremental updates can add/remove text parts
-  if (p.type === 'text') {
-    return `msg-${messageId}-text-${index}`
-  }
-
-  // Step parts: use index (they're separators so position matters)
-  if (p.type === 'step-start') {
-    return `msg-${messageId}-step-${index}`
-  }
-
-  // Reasoning parts
-  if (p.type === 'reasoning') {
-    return `msg-${messageId}-reasoning-${index}`
-  }
-
-  // Fallback
-  return `msg-${messageId}-part-${index}`
-}
-
-/**
- * Displays per-message statistics (tool calls, durations) at the bottom of assistant messages.
- * Only shown for completed assistant messages (not during streaming).
- */
-function MessageStatsFooter({
-  message,
-  responseDurationMs,
-}: {
-  readonly message: UIMessage
-  readonly responseDurationMs?: number
-}) {
-  const stats = useMemo(() => getMessageStats(message), [message])
-
-  // Only show footer when there were actual tool calls
-  if (stats.toolCallCount === 0) return null
-
-  const parts: string[] = []
-
-  if (responseDurationMs && responseDurationMs > 0) {
-    parts.push(formatDuration(responseDurationMs))
-  }
-
-  parts.push(
-    `${stats.toolCallCount} tool ${stats.toolCallCount === 1 ? 'call' : 'calls'}`
-  )
-
-  if (stats.totalToolDurationMs > 0) {
-    parts.push(`${formatDuration(stats.totalToolDurationMs)} in tools`)
-  }
-
-  return (
-    <div className="mt-2 pt-1.5 text-[11px] text-muted-foreground/60 select-none">
-      {parts.join(' · ')}
-    </div>
-  )
-}
-
-/**
- * Renders a single UIMessage with its parts (text, tool calls, etc.)
- * Includes follow-up suggestions for assistant messages
- */
-function ChatMessage({
-  message,
-  allMessages,
-  isLastUserMessage,
-  isStreaming,
-  responseDurationMs,
-  onRegenerate,
-  onSuggestionClick,
-  onToolResult,
-}: {
-  readonly message: UIMessage
-  readonly allMessages: readonly UIMessage[]
-  readonly isLastUserMessage?: boolean
-  readonly isStreaming?: boolean
-  readonly responseDurationMs?: number
-  readonly onRegenerate?: () => void
-  readonly onSuggestionClick?: (suggestion: string) => void
-  readonly onToolResult?: (toolCallId: string, result: string) => void
-}) {
-  const isUser = message.role === 'user'
-  const isAssistant = message.role === 'assistant'
-
-  // Generate follow-up suggestions for assistant messages with tool calls
-  const followUpSuggestions = useMemo(() => {
-    if (!isAssistant) return []
-    return generateFollowUpSuggestions(message, allMessages)
-  }, [message, allMessages, isAssistant])
-
-  return (
-    <Message from={isUser ? 'user' : 'assistant'}>
-      <MessageContent>
-        <div
-          className={cn(
-            'relative group',
-            isLastUserMessage && isUser && onRegenerate && 'pr-8'
-          )}
-        >
-          {message.parts.map((part, i) => {
-            const stableKey = getStablePartKey(message.id, part, i)
-
-            // Text part - render as markdown for assistant messages
-            if (part.type === 'text') {
-              // For user messages, use MessageResponse (plain text)
-              if (isUser) {
-                return (
-                  <MessageResponse key={stableKey}>{part.text}</MessageResponse>
-                )
-              }
-
-              // For assistant messages, check for task list pattern first
-              const taskItems = extractTaskItems(part.text)
-              if (taskItems.length > 0) {
-                return (
-                  <div key={stableKey} className="my-2">
-                    <Task>
-                      <TaskTrigger title="Tasks" />
-                      <TaskContent>
-                        {taskItems.map((item, idx) => (
-                          <TaskItem key={idx}>{item}</TaskItem>
-                        ))}
-                      </TaskContent>
-                    </Task>
-                  </div>
-                )
-              }
-
-              // For assistant messages, use markdown rendering
-              return (
-                <div key={stableKey} className="markdown-content">
-                  <ReactMarkdown
-                    remarkPlugins={[remarkGfm]}
-                    rehypePlugins={[rehypeHighlight]}
-                    components={{
-                      // Custom table styling
-                      table: ({ children }) => (
-                        <div className="overflow-x-auto my-2">
-                          <table className="min-w-full border-collapse border border-border">
-                            {children}
-                          </table>
-                        </div>
-                      ),
-                      thead: ({ children }) => (
-                        <thead className="bg-muted">{children}</thead>
-                      ),
-                      th: ({ children }) => (
-                        <th className="border border-border px-3 py-2 text-left text-sm font-medium">
-                          {children}
-                        </th>
-                      ),
-                      td: ({ children }) => (
-                        <td className="border border-border px-3 py-2 text-sm">
-                          {children}
-                        </td>
-                      ),
-                      // Code block styling
-                      pre: ({ children }) => (
-                        <pre className="bg-muted rounded-md p-3 my-2 overflow-x-auto">
-                          {children}
-                        </pre>
-                      ),
-                      code: ({ className, children }) => {
-                        // Check if this is inline code (no language class)
-                        const isInline = !className || className === 'language-'
-                        return isInline ? (
-                          <code className="bg-muted px-1 py-0.5 rounded text-sm">
-                            {children}
-                          </code>
-                        ) : (
-                          <code className={className}>{children}</code>
-                        )
-                      },
-                    }}
-                  >
-                    {part.text}
-                  </ReactMarkdown>
-                </div>
-              )
-            }
-
-            // Reasoning part — display with the Reasoning collapsible component
-            if (part.type === 'reasoning') {
-              // AI SDK v6: ReasoningUIPart has { type: 'reasoning', text: string }
-              const reasoningText = (
-                part as unknown as { type: 'reasoning'; text: string }
-              ).text
-              return (
-                <Reasoning key={stableKey} isStreaming={false}>
-                  <ReasoningTrigger />
-                  <ReasoningContent>{reasoningText}</ReasoningContent>
-                </Reasoning>
-              )
-            }
-
-            // Tool call part (dynamic tool - from our custom agent)
-            if (part.type === 'dynamic-tool') {
-              return (
-                <ToolCallPart
-                  key={stableKey}
-                  part={part as any}
-                  onToolResult={onToolResult}
-                />
-              )
-            }
-
-            // Static typed tool call part (type starts with 'tool-')
-            if (
-              typeof part.type === 'string' &&
-              part.type.startsWith('tool-')
-            ) {
-              return (
-                <ToolCallPart
-                  key={stableKey}
-                  part={part as any}
-                  onToolResult={onToolResult}
-                />
-              )
-            }
-
-            // Step start part
-            if (part.type === 'step-start') {
-              return (
-                <div
-                  key={stableKey}
-                  className="border-t border-muted/30 my-2"
-                />
-              )
-            }
-
-            return null
-          })}
-
-          {/* Refresh icon button - shown on hover for last user message */}
-          {isLastUserMessage && isUser && onRegenerate && (
-            <button
-              onClick={onRegenerate}
-              className="absolute right-0 top-0 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-muted rounded"
-              title="Regenerate response"
-            >
-              <RefreshCwIcon className="h-3.5 w-3.5 text-muted-foreground hover:text-foreground" />
-            </button>
-          )}
-        </div>
-
-        {/* Per-message stats footer for completed assistant messages */}
-        {isAssistant && !isStreaming && (
-          <MessageStatsFooter
-            message={message}
-            responseDurationMs={responseDurationMs}
-          />
-        )}
-
-        {/* Follow-up suggestions for assistant messages */}
-        {isAssistant && followUpSuggestions.length > 0 && (
-          <div className="mt-3 pt-3 border-t border-muted/30">
-            <Suggestions>
-              {followUpSuggestions.map((suggestion) => (
-                <Suggestion
-                  key={suggestion}
-                  suggestion={suggestion}
-                  onClick={onSuggestionClick}
-                />
-              ))}
-            </Suggestions>
-          </div>
-        )}
-      </MessageContent>
-    </Message>
-  )
-}
-
-// ============================================================================
-// Task List Extraction
-// ============================================================================
-
-/**
- * Extract task items from markdown-style task lists.
- * Returns non-empty array only when the text is *primarily* a task list
- * (3+ items, >50% of non-empty lines are task list entries).
- */
-function extractTaskItems(text: string): string[] {
-  const taskPattern = /^[\s]*-\s+\[[ xX]\]\s+(.+)$/gm
-  const matches = [...text.matchAll(taskPattern)]
-  if (matches.length < 3) return []
-
-  // Require majority of content to be task items
-  const nonEmptyLines = text.split('\n').filter((l) => l.trim().length > 0)
-  if (matches.length < nonEmptyLines.length * 0.5) return []
-
-  return matches.map((m) => m[1].trim())
-}
-
-// ============================================================================
-// Follow-up Suggestions
-// ============================================================================
-
-/**
- * Generates contextual follow-up suggestions based on the assistant message
- * Analyzes tool outputs and conversation context to provide relevant next actions
- */
-function generateFollowUpSuggestions(
-  message: UIMessage,
-  _allMessages: readonly UIMessage[]
-): string[] {
-  const suggestions: string[] = []
-
-  // Get tool names that were used in this message
-  const toolNames: string[] = []
-  for (const part of message.parts) {
-    if (typeof part === 'object' && part !== null) {
-      if ('type' in part) {
-        const partType = (part as { type: string }).type
-        if (partType === 'dynamic-tool') {
-          const toolName = (part as { toolName?: string }).toolName
-          if (toolName) toolNames.push(toolName)
-        } else if (
-          typeof partType === 'string' &&
-          partType.startsWith('tool-')
-        ) {
-          toolNames.push(partType.replace(/^tool-/, ''))
-        }
-      }
-    }
-  }
-
-  // Generate suggestions based on tools used
-  if (toolNames.includes('query')) {
-    suggestions.push('Explain the query results in more detail')
-    suggestions.push('Export this data to CSV')
-    suggestions.push('Create a chart from this data')
-  }
-
-  if (toolNames.includes('list_tables')) {
-    suggestions.push('Show me the schema of a specific table')
-    suggestions.push('What are the largest tables by disk usage?')
-    suggestions.push('Which tables have the most rows?')
-  }
-
-  if (toolNames.includes('list_databases')) {
-    suggestions.push('Show tables in a specific database')
-    suggestions.push('Which database has the most tables?')
-    suggestions.push('What is the total size of all databases?')
-  }
-
-  if (toolNames.includes('get_slow_queries')) {
-    suggestions.push('Show me the query patterns for slow queries')
-    suggestions.push('What are the most common slow query types?')
-    suggestions.push('Are there any queries that should be optimized?')
-  }
-
-  if (toolNames.includes('get_running_queries')) {
-    suggestions.push('Which queries are using the most memory?')
-    suggestions.push('Kill a specific long-running query')
-    suggestions.push('Show query execution progress')
-  }
-
-  if (toolNames.includes('get_table_schema')) {
-    suggestions.push('Show sample data from this table')
-    suggestions.push('What indexes exist on this table?')
-    suggestions.push('Who is querying this table?')
-  }
-
-  if (toolNames.includes('get_metrics')) {
-    suggestions.push('Show me the historical metrics trend')
-    suggestions.push('What is the memory usage breakdown?')
-    suggestions.push('Are there any performance anomalies?')
-  }
-
-  if (toolNames.includes('get_merge_status')) {
-    suggestions.push('Which tables have the largest merged parts?')
-    suggestions.push('Show merge performance over time')
-    suggestions.push('Are there any stuck merges?')
-  }
-
-  // Add general follow-up if no specific suggestions
-  if (suggestions.length === 0) {
-    suggestions.push('Tell me more about this')
-    suggestions.push('What are the key insights?')
-  }
-
-  // Return top 3-4 suggestions
-  return suggestions.slice(0, 4)
-}
-
-// ============================================================================
-// Default suggestions
-// ============================================================================
-
-interface DefaultSuggestion {
-  text: string
-  category: string
-  icon: React.ReactNode
-}
-
-const DEFAULT_SUGGESTIONS: DefaultSuggestion[] = [
-  {
-    text: 'What databases are available and which ones have the most tables?',
-    category: 'Schema',
-    icon: <DatabaseIcon className="h-3.5 w-3.5" />,
-  },
-  {
-    text: 'Show me the 10 largest tables and their disk usage',
-    category: 'Storage',
-    icon: <HardDriveIcon className="h-3.5 w-3.5" />,
-  },
-  {
-    text: 'Which queries are running right now and how long have they been executing?',
-    category: 'Querying',
-    icon: <ActivityIcon className="h-3.5 w-3.5" />,
-  },
-  {
-    text: 'What are the slowest queries from the past 24 hours?',
-    category: 'Performance',
-    icon: <ClockIcon className="h-3.5 w-3.5" />,
-  },
-  {
-    text: 'How is the merge queue performing? Are there any large merges stuck?',
-    category: 'Merges',
-    icon: <MergeIcon className="h-3.5 w-3.5" />,
-  },
-  {
-    text: 'What is the current CPU, memory, and disk usage of this server?',
-    category: 'System',
-    icon: <ZapIcon className="h-3.5 w-3.5" />,
-  },
-  {
-    text: 'Show me replication lag across all replica tables',
-    category: 'Replication',
-    icon: <AlertCircleIcon className="h-3.5 w-3.5" />,
-  },
-  {
-    text: 'Which users are consuming the most resources?',
-    category: 'Access',
-    icon: <UserIcon className="h-3.5 w-3.5" />,
-  },
-  {
-    text: 'Are there any long-running queries that should be killed?',
-    category: 'Operations',
-    icon: <SquareIcon className="h-3.5 w-3.5" />,
-  },
-  {
-    text: 'What are the most frequently accessed tables recently?',
-    category: 'Usage',
-    icon: <TableIcon className="h-3.5 w-3.5" />,
-  },
-]
-
-const GETTING_STARTED_FEATURES = [
-  'Live metrics',
-  'Read-only analysis',
-  'One-click prompts',
-] as const
-
-// ============================================================================
-// Main Component
-// ============================================================================
 
 export const AgentsChatArea = forwardRef<
   AgentsChatAreaRef,
@@ -1145,18 +90,11 @@ export const AgentsChatArea = forwardRef<
   }: AgentsChatAreaProps,
   ref
 ) {
-  // Get hostId from URL query params
   const hostId = useHostId()
   const router = useRouter()
-
-  // Get conversation context for loading/saving messages
   const { conversations, currentConversationId, updateMessages } =
     useConversationContext()
-
-  // Get the selected model from localStorage
   const model = useMemo(() => getSavedModel(), [])
-
-  // Get disabled tools so the API can filter them out
   const { disabledTools } = useToolConfig()
 
   const {
@@ -1174,94 +112,78 @@ export const AgentsChatArea = forwardRef<
     }),
   })
 
-  // Response timing: track when user sends a message and compute duration when streaming ends
   const sendTimestampRef = useRef<number>(0)
+  const prevStatusRef = useRef<string>(status)
+  const lastSavedMessagesRef = useRef<UIMessage[]>([])
+  const saveTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
+  const prevConversationIdRef = useRef<string | undefined>(undefined)
+  const initialQuerySentRef = useRef<string | null>(null)
   const [responseDurations, setResponseDurations] = useState<
     Record<string, number>
   >({})
-  const prevStatusRef = useRef<string>(status)
 
-  // Capture send timestamp when status transitions to streaming
+  const isLoading = status === 'streaming' || status === 'submitted'
+  const isEmpty = messages.length === 0
+
   useEffect(() => {
-    const prev = prevStatusRef.current
+    const previousStatus = prevStatusRef.current
     prevStatusRef.current = status
 
-    // User just sent a message → mark start time
     if (
-      prev === 'ready' &&
+      previousStatus === 'ready' &&
       (status === 'submitted' || status === 'streaming')
     ) {
       sendTimestampRef.current = Date.now()
     }
 
-    // Streaming finished → compute duration for last assistant message
-    if ((prev === 'streaming' || prev === 'submitted') && status === 'ready') {
-      if (sendTimestampRef.current > 0 && messages.length > 0) {
-        let lastAssistant: UIMessage | undefined
-        for (let i = messages.length - 1; i >= 0; i--) {
-          if (messages[i].role === 'assistant') {
-            lastAssistant = messages[i]
-            break
-          }
-        }
-        if (lastAssistant) {
-          const duration = Date.now() - sendTimestampRef.current
-          const id = lastAssistant.id
-          setResponseDurations((prev) => ({ ...prev, [id]: duration }))
-          sendTimestampRef.current = 0
-        }
-      }
+    if (
+      (previousStatus === 'streaming' || previousStatus === 'submitted') &&
+      status === 'ready' &&
+      sendTimestampRef.current > 0
+    ) {
+      const lastAssistantMessage = findLastAssistantMessage(messages)
+      if (!lastAssistantMessage) return
+
+      const duration = Date.now() - sendTimestampRef.current
+      setResponseDurations((previous) => ({
+        ...previous,
+        [lastAssistantMessage.id]: duration,
+      }))
+      sendTimestampRef.current = 0
     }
   }, [status, messages])
 
-  // Ref to track last saved messages to avoid infinite loops
-  const lastSavedMessagesRef = useRef<UIMessage[]>([])
-  const saveTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
-
-  // Track previous conversation ID to detect conversation switches
-  const prevConversationIdRef = useRef<string | undefined>(undefined)
-
-  // Load messages ONLY when conversation ID changes (not on every message update)
   useEffect(() => {
-    // Skip if no conversation or same conversation (not a switch)
     if (!currentConversationId) return
     if (currentConversationId === prevConversationIdRef.current) return
 
     const conversation = conversations.find(
-      (c: Conversation) => c.id === currentConversationId
+      (item: Conversation) => item.id === currentConversationId
     )
-    if (conversation) {
-      const storedMsgs = conversation.messages
-      // Load messages from storage when switching conversations
-      setMessages(storedMsgs)
-      setResponseDurations({})
-      lastSavedMessagesRef.current = storedMsgs
-    }
+    if (!conversation) return
 
-    // Update previous conversation ID
+    setMessages(conversation.messages)
+    setResponseDurations({})
+    lastSavedMessagesRef.current = conversation.messages
     prevConversationIdRef.current = currentConversationId
   }, [currentConversationId, conversations, setMessages])
 
-  // Save messages to conversation when they change (debounced)
   useEffect(() => {
     if (!currentConversationId) return
 
-    // Clear existing timeout
     if (saveTimeoutRef.current) {
       clearTimeout(saveTimeoutRef.current)
     }
 
-    // Check if messages actually changed (reference check)
     if (messages === lastSavedMessagesRef.current) return
 
-    // Debounce save: wait 1s after last message change (or 100ms during streaming)
-    const isStreaming = status === 'streaming'
-    const debounceMs = isStreaming ? 100 : 1000
-
-    saveTimeoutRef.current = setTimeout(() => {
-      lastSavedMessagesRef.current = messages
-      updateMessages(currentConversationId, messages)
-    }, debounceMs)
+    saveTimeoutRef.current = setTimeout(
+      () => {
+        lastSavedMessagesRef.current = messages
+        updateMessages(currentConversationId, messages)
+      },
+      status === 'streaming' ? 100 : 1000
+    )
 
     return () => {
       if (saveTimeoutRef.current) {
@@ -1270,31 +192,18 @@ export const AgentsChatArea = forwardRef<
     }
   }, [messages, currentConversationId, updateMessages, status])
 
-  const isLoading = status === 'streaming' || status === 'submitted'
-  const isEmpty = messages.length === 0
+  const submitPrompt = useCallback(
+    (text: string) => {
+      const trimmed = text.trim()
+      if (!trimmed || isLoading) return
 
-  const handleSubmit = useCallback(
-    ({ text }: { text: string; files?: unknown[] }) => {
-      if (!text.trim() || isLoading) return
       sendMessage({
-        parts: [{ type: 'text', text: text.trim() }],
+        parts: [{ type: 'text', text: trimmed }],
       })
     },
     [isLoading, sendMessage]
   )
 
-  // Handler for mentions-enabled textarea (receives pre-resolved text with context)
-  const handleMentionSubmit = useCallback(
-    (resolvedText: string) => {
-      if (!resolvedText.trim() || isLoading) return
-      sendMessage({
-        parts: [{ type: 'text', text: resolvedText.trim() }],
-      })
-    },
-    [isLoading, sendMessage]
-  )
-
-  // Handle ask_user tool results — submit user response back to the agent
   const handleToolResult = useCallback(
     (toolCallId: string, result: string) => {
       addToolResult({ toolCallId, tool: 'ask_user', output: result })
@@ -1303,294 +212,107 @@ export const AgentsChatArea = forwardRef<
   )
 
   const handleClear = useCallback(() => {
-    // Stop any active streaming first
     stop()
 
-    // Cancel any pending debounced saves
     if (saveTimeoutRef.current) {
       clearTimeout(saveTimeoutRef.current)
       saveTimeoutRef.current = undefined
     }
 
-    // Clear messages state
     setMessages([])
     setResponseDurations({})
 
-    // Clear messages in current conversation too
     if (currentConversationId) {
       updateMessages(currentConversationId, [])
       lastSavedMessagesRef.current = []
     }
   }, [stop, setMessages, currentConversationId, updateMessages])
 
-  // Expose handleClear to parent via ref
   useImperativeHandle(ref, () => ({ handleClear }), [handleClear])
 
-  const handleSuggestionClick = useCallback(
-    (suggestion: string) => {
-      handleSubmit({ text: suggestion })
-    },
-    [handleSubmit]
-  )
-
-  // Auto-send initial query from URL param (e.g., /agents?query=SELECT...)
-  // Track which query was sent (not just boolean) so re-navigation works
-  const initialQuerySentRef = useRef<string | null>(null)
   useEffect(() => {
     const cleaned = initialQuery?.trim()
     if (
-      cleaned &&
-      cleaned !== initialQuerySentRef.current &&
-      status === 'ready'
+      !cleaned ||
+      cleaned === initialQuerySentRef.current ||
+      status !== 'ready'
     ) {
-      initialQuerySentRef.current = cleaned
-      sendMessage({
-        parts: [
-          {
-            type: 'text',
-            text: `Analyze this ClickHouse query:\n\n\`\`\`sql\n${cleaned}\n\`\`\``,
-          },
-        ],
-      })
-      // Clear query param to prevent re-send on refresh, preserve host param
-      const url = new URL(window.location.href)
-      url.searchParams.delete('query')
-      router.replace(url.pathname + url.search, { scroll: false })
+      return
     }
+
+    initialQuerySentRef.current = cleaned
+    sendMessage({
+      parts: [
+        {
+          type: 'text',
+          text: `Analyze this ClickHouse query:\n\n\`\`\`sql\n${cleaned}\n\`\`\``,
+        },
+      ],
+    })
+
+    const url = new URL(window.location.href)
+    url.searchParams.delete('query')
+    router.replace(url.pathname + url.search, { scroll: false })
   }, [initialQuery, status, sendMessage, router])
 
   const handleRegenerate = useCallback(() => {
-    // Stop current generation
     stop()
 
-    // Find the last user message using a backward loop (avoids copying the array)
-    let lastUserMessage: UIMessage | undefined
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].role === 'user') {
-        lastUserMessage = messages[i]
-        break
-      }
-    }
+    const lastUserMessage = findLastUserMessage(messages)
+    if (!lastUserMessage) return
 
-    if (lastUserMessage) {
-      // Get text from the last user message
-      const textPart = lastUserMessage.parts.find(
-        (p): p is { type: 'text'; text: string } =>
-          typeof p === 'object' &&
-          p !== null &&
-          'type' in p &&
-          p.type === 'text'
-      )
+    const textPart = getTextPart(lastUserMessage)
+    if (!textPart) return
 
-      if (textPart) {
-        // Remove the last assistant response and user message, then resend
-        const messagesWithoutLastExchange = messages.slice(
-          0,
-          messages.lastIndexOf(lastUserMessage)
-        )
-        setMessages(messagesWithoutLastExchange)
+    const messagesWithoutLastExchange = messages.slice(
+      0,
+      messages.lastIndexOf(lastUserMessage)
+    )
+    setMessages(messagesWithoutLastExchange)
 
-        // Resend the user message
-        setTimeout(() => {
-          sendMessage({
-            parts: [{ type: 'text', text: textPart.text }],
-          })
-        }, 100)
-      }
-    }
+    setTimeout(() => {
+      sendMessage({
+        parts: [{ type: 'text', text: textPart.text }],
+      })
+    }, 100)
   }, [messages, stop, sendMessage, setMessages])
 
+  const lastUserMessageIndex = useMemo(
+    () => messages.findLastIndex((message) => message.role === 'user'),
+    [messages]
+  )
+
   return (
-    <div className="flex flex-col h-full min-h-0">
-      {/* Header (hidden when in page-level layout) */}
+    <div className="flex h-full min-h-0 flex-col">
       {!hideHeader && (
-        <div className="flex items-center justify-between border-b px-3 sm:px-4 py-3 shrink-0">
-          {/* Left: Toggle button */}
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onMenuClick}
-            className="h-8 w-8 shrink-0"
-            title={isSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
-          >
-            {isSidebarOpen ? (
-              <PanelRightClose className="h-4 w-4" />
-            ) : (
-              <PanelRightOpen className="h-4 w-4" />
-            )}
-          </Button>
-
-          {/* Center: AI Agent title */}
-          <div className="flex items-center gap-2 min-w-0">
-            <SparklesIcon className="h-5 w-5 text-primary shrink-0" />
-            <h2 className="font-semibold truncate text-sm sm:text-base">
-              AI Agent
-            </h2>
-          </div>
-
-          {/* Right: Stop (when loading) and Clear */}
-          <div className="flex items-center gap-1 shrink-0">
-            {isLoading && (
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={stop}
-                className="h-8 w-8"
-                title="Stop generation"
-              >
-                <SquareIcon className="h-4 w-4" />
-              </Button>
-            )}
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={handleClear}
-              className="h-8 w-8"
-              title="Clear conversation"
-            >
-              <TrashIcon className="h-4 w-4" />
-            </Button>
-          </div>
-        </div>
+        <AgentChatHeader
+          isSidebarOpen={isSidebarOpen}
+          isLoading={isLoading}
+          onClear={handleClear}
+          onMenuClick={onMenuClick}
+          onStop={stop}
+        />
       )}
 
-      {/* Compact controls bar (shown when header is hidden and not hidden by parent) */}
       {hideHeader &&
         !hideCompactControls &&
         (isLoading || messages.length > 0) && (
-          <div className="flex items-center justify-end gap-1 px-3 py-2 border-b shrink-0">
-            {isLoading && (
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={stop}
-                className="h-8 w-8"
-                title="Stop generation"
-              >
-                <SquareIcon className="h-4 w-4" />
-              </Button>
-            )}
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={handleClear}
-              className="h-8 w-8"
-              title="Clear conversation"
-            >
-              <TrashIcon className="h-4 w-4" />
-            </Button>
-          </div>
+          <AgentChatCompactControls
+            isLoading={isLoading}
+            onClear={handleClear}
+            onStop={stop}
+          />
         )}
 
-      {/* Messages Area */}
       <ConversationUI>
         <ConversationContent className="gap-4">
           {isEmpty ? (
             <ConversationEmptyState className="justify-start px-0 py-6 text-left sm:py-8">
-              <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 px-4 sm:px-6">
-                <Card className="overflow-hidden border-border/60 bg-gradient-to-br from-background via-background to-muted/30">
-                  <CardContent className="p-4 sm:p-5">
-                    <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-                      <div className="space-y-3">
-                        <Badge
-                          variant="outline"
-                          className="rounded-full border-border/60 bg-background/80 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground"
-                        >
-                          Agent workspace
-                        </Badge>
-                        <div className="flex items-start gap-3">
-                          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-border/60 bg-card">
-                            <SparklesIcon className="h-4.5 w-4.5 text-primary" />
-                          </div>
-                          <div className="space-y-2">
-                            <h2 className="text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
-                              Inspect your ClickHouse cluster
-                            </h2>
-                            <p className="max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
-                              Start with a live health signal or launch one of
-                              the ready-made prompts below. Every card and
-                              question sends directly to the agent.
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:w-[320px]">
-                        {GETTING_STARTED_FEATURES.map((item) => (
-                          <div
-                            key={item}
-                            className="rounded-lg border border-border/60 bg-background/70 px-2.5 py-2 text-xs font-medium text-muted-foreground"
-                          >
-                            {item}
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-
-                <section className="space-y-3">
-                  <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
-                    <div>
-                      <h3 className="text-base font-semibold tracking-tight text-foreground sm:text-lg">
-                        Live cluster snapshot
-                      </h3>
-                      <p className="text-sm text-muted-foreground">
-                        These values are fetched from the current host and open
-                        the matching investigation when clicked.
-                      </p>
-                    </div>
-                  </div>
-                  <AgentInsightCards onQuestionClick={handleSuggestionClick} />
-                </section>
-
-                <Card className="border-border/60 bg-muted/10">
-                  <CardHeader className="space-y-2 p-4 sm:p-5">
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                      <div className="space-y-1">
-                        <CardTitle className="text-base tracking-tight sm:text-lg">
-                          Suggested questions
-                        </CardTitle>
-                        <CardDescription className="max-w-2xl text-sm leading-6">
-                          Use a starter prompt for schemas, storage, query
-                          performance, and system health. You can keep iterating
-                          from there.
-                        </CardDescription>
-                      </div>
-                    </div>
-                  </CardHeader>
-                  <CardContent className="p-4 pt-0 sm:p-5 sm:pt-0">
-                    <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
-                      {DEFAULT_SUGGESTIONS.map((suggestion) => (
-                        <button
-                          key={suggestion.text}
-                          onClick={() => handleSuggestionClick(suggestion.text)}
-                          className="group flex items-center gap-2.5 rounded-lg border border-border/60 bg-background/80 px-3 py-2 text-left transition-all hover:border-border hover:bg-accent/20"
-                        >
-                          <span className="shrink-0 text-muted-foreground">
-                            {suggestion.icon}
-                          </span>
-                          <span className="min-w-0 flex-1 text-sm text-foreground">
-                            {suggestion.text}
-                          </span>
-                          <ChevronRightIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50 transition-transform group-hover:translate-x-0.5" />
-                        </button>
-                      ))}
-                    </div>
-                  </CardContent>
-                </Card>
-              </div>
+              <AgentChatEmptyState onSubmitPrompt={submitPrompt} />
             </ConversationEmptyState>
           ) : (
             <>
               {messages.map((message, index) => {
-                // Find the last user message index
-                const lastUserMessageIndex = messages.findLastIndex(
-                  (m) => m.role === 'user'
-                )
-                const isLastUserMessage = index === lastUserMessageIndex
-
-                // Check if this specific message is currently streaming
-                // (last assistant message while status is streaming)
                 const isMessageStreaming =
                   isLoading &&
                   message.role === 'assistant' &&
@@ -1601,25 +323,25 @@ export const AgentsChatArea = forwardRef<
                     key={message.id}
                     message={message}
                     allMessages={messages}
-                    isLastUserMessage={isLastUserMessage}
+                    isLastUserMessage={index === lastUserMessageIndex}
                     isStreaming={isMessageStreaming}
                     responseDurationMs={responseDurations[message.id]}
                     onRegenerate={
-                      isLastUserMessage ? handleRegenerate : undefined
+                      index === lastUserMessageIndex
+                        ? handleRegenerate
+                        : undefined
                     }
-                    onSuggestionClick={handleSuggestionClick}
+                    onSuggestionClick={submitPrompt}
                     onToolResult={handleToolResult}
                   />
                 )
               })}
-              {/* Show typing indicator during streaming/submitted when assistant message is minimal */}
               {isLoading && <StreamingTypingIndicator messages={messages} />}
             </>
           )}
         </ConversationContent>
       </ConversationUI>
 
-      {/* Error display */}
       {error && (
         <AgentErrorDisplay
           error={error}
@@ -1628,22 +350,20 @@ export const AgentsChatArea = forwardRef<
         />
       )}
 
-      {/* Input Area */}
-      <div className="border-t p-3 sm:p-4 shrink-0">
+      <div className="shrink-0 border-t p-3 sm:p-4">
         <PromptInputTextareaWithMentions
           disabled={isLoading}
-          onResolvedSubmit={handleMentionSubmit}
+          onResolvedSubmit={submitPrompt}
         />
-        {/* Regenerate button during streaming */}
         {isLoading && messages.length > 0 && (
-          <div className="flex items-center gap-2 mt-2">
+          <div className="mt-2 flex items-center gap-2">
             <Button
               variant="ghost"
               size="sm"
               onClick={handleRegenerate}
               className="h-7 text-xs"
             >
-              <RefreshCwIcon className="h-3 w-3 mr-1" />
+              <RefreshCwIcon className="mr-1 h-3 w-3" />
               Regenerate
             </Button>
             <span className="text-xs text-muted-foreground">or</span>
@@ -1653,7 +373,7 @@ export const AgentsChatArea = forwardRef<
               onClick={stop}
               className="h-7 text-xs"
             >
-              <SquareIcon className="h-3 w-3 mr-1" />
+              <SquareIcon className="mr-1 h-3 w-3" />
               Stop
             </Button>
           </div>

--- a/components/agents/chat/controls.tsx
+++ b/components/agents/chat/controls.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import {
+  PanelRightClose,
+  PanelRightOpen,
+  SparklesIcon,
+  SquareIcon,
+  TrashIcon,
+} from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+interface AgentChatControlsProps {
+  readonly isLoading: boolean
+  readonly onClear: () => void
+  readonly onStop: () => void
+}
+
+interface AgentChatHeaderProps extends AgentChatControlsProps {
+  readonly isSidebarOpen: boolean
+  readonly onMenuClick: () => void
+}
+
+export function AgentChatHeader({
+  isSidebarOpen,
+  isLoading,
+  onClear,
+  onMenuClick,
+  onStop,
+}: AgentChatHeaderProps) {
+  return (
+    <div className="flex shrink-0 items-center justify-between border-b px-3 py-3 sm:px-4">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onMenuClick}
+        className="h-8 w-8 shrink-0"
+        title={isSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+      >
+        {isSidebarOpen ? (
+          <PanelRightClose className="h-4 w-4" />
+        ) : (
+          <PanelRightOpen className="h-4 w-4" />
+        )}
+      </Button>
+
+      <div className="flex min-w-0 items-center gap-2">
+        <SparklesIcon className="h-5 w-5 shrink-0 text-primary" />
+        <h2 className="truncate text-sm font-semibold sm:text-base">
+          AI Agent
+        </h2>
+      </div>
+
+      <AgentChatActions
+        isLoading={isLoading}
+        onClear={onClear}
+        onStop={onStop}
+      />
+    </div>
+  )
+}
+
+export function AgentChatCompactControls({
+  isLoading,
+  onClear,
+  onStop,
+}: AgentChatControlsProps) {
+  return (
+    <div className="flex shrink-0 items-center justify-end gap-1 border-b px-3 py-2">
+      <AgentChatActions
+        isLoading={isLoading}
+        onClear={onClear}
+        onStop={onStop}
+      />
+    </div>
+  )
+}
+
+function AgentChatActions({
+  isLoading,
+  onClear,
+  onStop,
+}: AgentChatControlsProps) {
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      {isLoading && (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onStop}
+          className="h-8 w-8"
+          title="Stop generation"
+        >
+          <SquareIcon className="h-4 w-4" />
+        </Button>
+      )}
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onClear}
+        className="h-8 w-8"
+        title="Clear conversation"
+      >
+        <TrashIcon className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}

--- a/components/agents/chat/controls.tsx
+++ b/components/agents/chat/controls.tsx
@@ -35,6 +35,7 @@ export function AgentChatHeader({
         size="icon"
         onClick={onMenuClick}
         className="h-8 w-8 shrink-0"
+        aria-label={isSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
         title={isSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
       >
         {isSidebarOpen ? (
@@ -89,6 +90,7 @@ function AgentChatActions({
           size="icon"
           onClick={onStop}
           className="h-8 w-8"
+          aria-label="Stop generation"
           title="Stop generation"
         >
           <SquareIcon className="h-4 w-4" />
@@ -99,6 +101,7 @@ function AgentChatActions({
         size="icon"
         onClick={onClear}
         className="h-8 w-8"
+        aria-label="Clear conversation"
         title="Clear conversation"
       >
         <TrashIcon className="h-4 w-4" />

--- a/components/agents/chat/empty-state.tsx
+++ b/components/agents/chat/empty-state.tsx
@@ -1,0 +1,195 @@
+'use client'
+
+import {
+  ActivityIcon,
+  AlertCircleIcon,
+  ChevronRightIcon,
+  ClockIcon,
+  DatabaseIcon,
+  HardDriveIcon,
+  MergeIcon,
+  SparklesIcon,
+  SquareIcon,
+  TableIcon,
+  UserIcon,
+  ZapIcon,
+} from 'lucide-react'
+
+import type { ReactNode } from 'react'
+
+import { AgentInsightCards } from '@/components/agents/agent-insight-cards'
+import { Badge } from '@/components/ui/badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+
+interface DefaultSuggestion {
+  readonly text: string
+  readonly category: string
+  readonly icon: ReactNode
+}
+
+const DEFAULT_SUGGESTIONS: DefaultSuggestion[] = [
+  {
+    text: 'What databases are available and which ones have the most tables?',
+    category: 'Schema',
+    icon: <DatabaseIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    text: 'Show me the 10 largest tables and their disk usage',
+    category: 'Storage',
+    icon: <HardDriveIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    text: 'Which queries are running right now and how long have they been executing?',
+    category: 'Querying',
+    icon: <ActivityIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    text: 'What are the slowest queries from the past 24 hours?',
+    category: 'Performance',
+    icon: <ClockIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    text: 'How is the merge queue performing? Are there any large merges stuck?',
+    category: 'Merges',
+    icon: <MergeIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    text: 'What is the current CPU, memory, and disk usage of this server?',
+    category: 'System',
+    icon: <ZapIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    text: 'Show me replication lag across all replica tables',
+    category: 'Replication',
+    icon: <AlertCircleIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    text: 'Which users are consuming the most resources?',
+    category: 'Access',
+    icon: <UserIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    text: 'Are there any long-running queries that should be killed?',
+    category: 'Operations',
+    icon: <SquareIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    text: 'What are the most frequently accessed tables recently?',
+    category: 'Usage',
+    icon: <TableIcon className="h-3.5 w-3.5" />,
+  },
+]
+
+const GETTING_STARTED_FEATURES = [
+  'Live metrics',
+  'Read-only analysis',
+  'One-click prompts',
+] as const
+
+interface AgentChatEmptyStateProps {
+  readonly onSubmitPrompt: (prompt: string) => void
+}
+
+export function AgentChatEmptyState({
+  onSubmitPrompt,
+}: AgentChatEmptyStateProps) {
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 px-4 sm:px-6">
+      <Card className="overflow-hidden border-border/60 bg-gradient-to-br from-background via-background to-muted/30">
+        <CardContent className="p-4 sm:p-5">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-3">
+              <Badge
+                variant="outline"
+                className="rounded-full border-border/60 bg-background/80 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground"
+              >
+                Agent workspace
+              </Badge>
+              <div className="flex items-start gap-3">
+                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-border/60 bg-card">
+                  <SparklesIcon className="h-4.5 w-4.5 text-primary" />
+                </div>
+                <div className="space-y-2">
+                  <h2 className="text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+                    Inspect your ClickHouse cluster
+                  </h2>
+                  <p className="max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
+                    Start with a live health signal or launch one of the
+                    ready-made prompts below. Every card and question sends
+                    directly to the agent.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:w-[320px]">
+              {GETTING_STARTED_FEATURES.map((item) => (
+                <div
+                  key={item}
+                  className="rounded-lg border border-border/60 bg-background/70 px-2.5 py-2 text-xs font-medium text-muted-foreground"
+                >
+                  {item}
+                </div>
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <section className="space-y-3">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h3 className="text-base font-semibold tracking-tight text-foreground sm:text-lg">
+              Live cluster snapshot
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              These values are fetched from the current host and open the
+              matching investigation when clicked.
+            </p>
+          </div>
+        </div>
+        <AgentInsightCards onQuestionClick={onSubmitPrompt} />
+      </section>
+
+      <Card className="border-border/60 bg-muted/10">
+        <CardHeader className="space-y-2 p-4 sm:p-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-1">
+              <CardTitle className="text-base tracking-tight sm:text-lg">
+                Suggested questions
+              </CardTitle>
+              <CardDescription className="max-w-2xl text-sm leading-6">
+                Use a starter prompt for schemas, storage, query performance,
+                and system health. You can keep iterating from there.
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="p-4 pt-0 sm:p-5 sm:pt-0">
+          <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
+            {DEFAULT_SUGGESTIONS.map((suggestion) => (
+              <button
+                key={suggestion.text}
+                onClick={() => onSubmitPrompt(suggestion.text)}
+                className="group flex items-center gap-2.5 rounded-lg border border-border/60 bg-background/80 px-3 py-2 text-left transition-all hover:border-border hover:bg-accent/20"
+              >
+                <span className="shrink-0 text-muted-foreground">
+                  {suggestion.icon}
+                </span>
+                <span className="min-w-0 flex-1 text-sm text-foreground">
+                  {suggestion.text}
+                </span>
+                <ChevronRightIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50 transition-transform group-hover:translate-x-0.5" />
+              </button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/agents/chat/message.tsx
+++ b/components/agents/chat/message.tsx
@@ -148,7 +148,7 @@ function MessageStatsFooter({
 
   return (
     <div className="mt-2 select-none pt-1.5 text-[11px] text-muted-foreground/60">
-      {parts.join(' | ')}
+      {parts.join(' · ')}
     </div>
   )
 }
@@ -161,7 +161,7 @@ function extractTaskItems(text: string): string[] {
   const nonEmptyLines = text
     .split('\n')
     .filter((line) => line.trim().length > 0)
-  if (matches.length < nonEmptyLines.length * 0.5) return []
+  if (matches.length !== nonEmptyLines.length) return []
 
   return matches.map((match) => match[1].trim())
 }
@@ -239,8 +239,8 @@ function MarkdownMessage({ text }: { readonly text: string }) {
         <Task>
           <TaskTrigger title="Tasks" />
           <TaskContent>
-            {taskItems.map((item) => (
-              <TaskItem key={item}>{item}</TaskItem>
+            {taskItems.map((item, index) => (
+              <TaskItem key={index}>{item}</TaskItem>
             ))}
           </TaskContent>
         </Task>

--- a/components/agents/chat/message.tsx
+++ b/components/agents/chat/message.tsx
@@ -1,0 +1,411 @@
+'use client'
+
+'use no memo'
+
+import { RefreshCwIcon } from 'lucide-react'
+
+import type { UIMessage } from 'ai'
+
+import { useMemo } from 'react'
+import ReactMarkdown from 'react-markdown'
+import rehypeHighlight from 'rehype-highlight'
+import remarkGfm from 'remark-gfm'
+import {
+  Message,
+  MessageContent,
+  MessageResponse,
+} from '@/components/ai-elements/message'
+import {
+  Reasoning,
+  ReasoningContent,
+  ReasoningTrigger,
+} from '@/components/ai-elements/reasoning'
+import { Suggestion, Suggestions } from '@/components/ai-elements/suggestion'
+import {
+  Task,
+  TaskContent,
+  TaskItem,
+  TaskTrigger,
+} from '@/components/ai-elements/task'
+import { getMessageStats } from '@/lib/hooks/use-agent-session-stats'
+import { cn, formatDuration } from '@/lib/utils'
+
+import '../markdown-code.css'
+
+import { type AgentToolPart, ToolCallPart } from './tool-output'
+
+interface ChatMessageProps {
+  readonly message: UIMessage
+  readonly allMessages: readonly UIMessage[]
+  readonly isLastUserMessage?: boolean
+  readonly isStreaming?: boolean
+  readonly responseDurationMs?: number
+  readonly onRegenerate?: () => void
+  readonly onSuggestionClick?: (suggestion: string) => void
+  readonly onToolResult?: (toolCallId: string, result: string) => void
+}
+
+export function hasMeaningfulContent(message: UIMessage): boolean {
+  if (message.role !== 'assistant') return false
+
+  const textParts = message.parts.filter(
+    (part): part is { type: 'text'; text: string } =>
+      typeof part === 'object' &&
+      part !== null &&
+      'type' in part &&
+      part.type === 'text'
+  )
+
+  return textParts.some((part) => {
+    const cleaned = part.text
+      .replace(/```[\w]*\n?[\s\S]*?```/g, '')
+      .replace(/#{1,6}\s/g, '')
+      .replace(/\*\*/g, '')
+      .replace(/\*/g, '')
+      .replace(/`/g, '')
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+      .replace(/\n+/g, ' ')
+      .trim()
+
+    return cleaned.length > 10
+  })
+}
+
+export function TypingIndicator() {
+  return (
+    <Message from="assistant">
+      <MessageContent>
+        <div className="flex items-center gap-1 py-2">
+          <span className="flex gap-0.5">
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-foreground/60 [animation-delay:-0.3s]" />
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-foreground/60 [animation-delay:-0.15s]" />
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-foreground/60" />
+          </span>
+        </div>
+      </MessageContent>
+    </Message>
+  )
+}
+
+export function StreamingTypingIndicator({
+  messages,
+}: {
+  readonly messages: readonly UIMessage[]
+}) {
+  const lastMessage = messages[messages.length - 1]
+  const shouldShowTyping =
+    !lastMessage ||
+    lastMessage.role === 'user' ||
+    (lastMessage.role === 'assistant' && !hasMeaningfulContent(lastMessage))
+
+  if (!shouldShowTyping) return null
+
+  return <TypingIndicator />
+}
+
+function getStablePartKey(
+  messageId: string,
+  part: unknown,
+  index: number
+): string {
+  const p = part as Record<string, unknown>
+
+  if (
+    p.type === 'dynamic-tool' ||
+    (typeof p.type === 'string' && p.type.startsWith('tool-'))
+  ) {
+    return `msg-${messageId}-tool-${p.toolCallId as string}`
+  }
+
+  if (p.type === 'text') return `msg-${messageId}-text-${index}`
+  if (p.type === 'step-start') return `msg-${messageId}-step-${index}`
+  if (p.type === 'reasoning') return `msg-${messageId}-reasoning-${index}`
+
+  return `msg-${messageId}-part-${index}`
+}
+
+function MessageStatsFooter({
+  message,
+  responseDurationMs,
+}: {
+  readonly message: UIMessage
+  readonly responseDurationMs?: number
+}) {
+  const stats = useMemo(() => getMessageStats(message), [message])
+
+  if (stats.toolCallCount === 0) return null
+
+  const parts: string[] = []
+  if (responseDurationMs && responseDurationMs > 0) {
+    parts.push(formatDuration(responseDurationMs))
+  }
+  parts.push(
+    `${stats.toolCallCount} tool ${stats.toolCallCount === 1 ? 'call' : 'calls'}`
+  )
+  if (stats.totalToolDurationMs > 0) {
+    parts.push(`${formatDuration(stats.totalToolDurationMs)} in tools`)
+  }
+
+  return (
+    <div className="mt-2 select-none pt-1.5 text-[11px] text-muted-foreground/60">
+      {parts.join(' | ')}
+    </div>
+  )
+}
+
+function extractTaskItems(text: string): string[] {
+  const taskPattern = /^[\s]*-\s+\[[ xX]\]\s+(.+)$/gm
+  const matches = [...text.matchAll(taskPattern)]
+  if (matches.length < 3) return []
+
+  const nonEmptyLines = text
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+  if (matches.length < nonEmptyLines.length * 0.5) return []
+
+  return matches.map((match) => match[1].trim())
+}
+
+function generateFollowUpSuggestions(message: UIMessage): string[] {
+  const suggestions: string[] = []
+  const toolNames: string[] = []
+
+  for (const part of message.parts) {
+    if (typeof part !== 'object' || part === null || !('type' in part)) continue
+
+    const partType = (part as { type: string }).type
+    if (partType === 'dynamic-tool') {
+      const toolName = (part as { toolName?: string }).toolName
+      if (toolName) toolNames.push(toolName)
+    } else if (typeof partType === 'string' && partType.startsWith('tool-')) {
+      toolNames.push(partType.replace(/^tool-/, ''))
+    }
+  }
+
+  if (toolNames.includes('query')) {
+    suggestions.push('Explain the query results in more detail')
+    suggestions.push('Export this data to CSV')
+    suggestions.push('Create a chart from this data')
+  }
+  if (toolNames.includes('list_tables')) {
+    suggestions.push('Show me the schema of a specific table')
+    suggestions.push('What are the largest tables by disk usage?')
+    suggestions.push('Which tables have the most rows?')
+  }
+  if (toolNames.includes('list_databases')) {
+    suggestions.push('Show tables in a specific database')
+    suggestions.push('Which database has the most tables?')
+    suggestions.push('What is the total size of all databases?')
+  }
+  if (toolNames.includes('get_slow_queries')) {
+    suggestions.push('Show me the query patterns for slow queries')
+    suggestions.push('What are the most common slow query types?')
+    suggestions.push('Are there any queries that should be optimized?')
+  }
+  if (toolNames.includes('get_running_queries')) {
+    suggestions.push('Which queries are using the most memory?')
+    suggestions.push('Kill a specific long-running query')
+    suggestions.push('Show query execution progress')
+  }
+  if (toolNames.includes('get_table_schema')) {
+    suggestions.push('Show sample data from this table')
+    suggestions.push('What indexes exist on this table?')
+    suggestions.push('Who is querying this table?')
+  }
+  if (toolNames.includes('get_metrics')) {
+    suggestions.push('Show me the historical metrics trend')
+    suggestions.push('What is the memory usage breakdown?')
+    suggestions.push('Are there any performance anomalies?')
+  }
+  if (toolNames.includes('get_merge_status')) {
+    suggestions.push('Which tables have the largest merged parts?')
+    suggestions.push('Show merge performance over time')
+    suggestions.push('Are there any stuck merges?')
+  }
+  if (suggestions.length === 0) {
+    suggestions.push('Tell me more about this')
+    suggestions.push('What are the key insights?')
+  }
+
+  return suggestions.slice(0, 4)
+}
+
+function MarkdownMessage({ text }: { readonly text: string }) {
+  const taskItems = extractTaskItems(text)
+
+  if (taskItems.length > 0) {
+    return (
+      <div className="my-2">
+        <Task>
+          <TaskTrigger title="Tasks" />
+          <TaskContent>
+            {taskItems.map((item) => (
+              <TaskItem key={item}>{item}</TaskItem>
+            ))}
+          </TaskContent>
+        </Task>
+      </div>
+    )
+  }
+
+  return (
+    <div className="markdown-content">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeHighlight]}
+        components={{
+          table: ({ children }) => (
+            <div className="my-2 overflow-x-auto">
+              <table className="min-w-full border-collapse border border-border">
+                {children}
+              </table>
+            </div>
+          ),
+          thead: ({ children }) => (
+            <thead className="bg-muted">{children}</thead>
+          ),
+          th: ({ children }) => (
+            <th className="border border-border px-3 py-2 text-left text-sm font-medium">
+              {children}
+            </th>
+          ),
+          td: ({ children }) => (
+            <td className="border border-border px-3 py-2 text-sm">
+              {children}
+            </td>
+          ),
+          pre: ({ children }) => (
+            <pre className="my-2 overflow-x-auto rounded-md bg-muted p-3">
+              {children}
+            </pre>
+          ),
+          code: ({ className, children }) => {
+            const isInline = !className || className === 'language-'
+            return isInline ? (
+              <code className="rounded bg-muted px-1 py-0.5 text-sm">
+                {children}
+              </code>
+            ) : (
+              <code className={className}>{children}</code>
+            )
+          },
+        }}
+      >
+        {text}
+      </ReactMarkdown>
+    </div>
+  )
+}
+
+export function ChatMessage({
+  message,
+  allMessages: _allMessages,
+  isLastUserMessage,
+  isStreaming,
+  responseDurationMs,
+  onRegenerate,
+  onSuggestionClick,
+  onToolResult,
+}: ChatMessageProps) {
+  const isUser = message.role === 'user'
+  const isAssistant = message.role === 'assistant'
+
+  const followUpSuggestions = useMemo(() => {
+    if (!isAssistant) return []
+    return generateFollowUpSuggestions(message)
+  }, [message, isAssistant])
+
+  return (
+    <Message from={isUser ? 'user' : 'assistant'}>
+      <MessageContent>
+        <div
+          className={cn(
+            'group relative',
+            isLastUserMessage && isUser && onRegenerate && 'pr-8'
+          )}
+        >
+          {message.parts.map((part, index) => {
+            const stableKey = getStablePartKey(message.id, part, index)
+
+            if (part.type === 'text') {
+              if (isUser) {
+                return (
+                  <MessageResponse key={stableKey}>{part.text}</MessageResponse>
+                )
+              }
+
+              return <MarkdownMessage key={stableKey} text={part.text} />
+            }
+
+            if (part.type === 'reasoning') {
+              const reasoningText = (
+                part as unknown as { type: 'reasoning'; text: string }
+              ).text
+              return (
+                <Reasoning key={stableKey} isStreaming={false}>
+                  <ReasoningTrigger />
+                  <ReasoningContent>{reasoningText}</ReasoningContent>
+                </Reasoning>
+              )
+            }
+
+            if (
+              part.type === 'dynamic-tool' ||
+              (typeof part.type === 'string' && part.type.startsWith('tool-'))
+            ) {
+              return (
+                <ToolCallPart
+                  key={stableKey}
+                  part={part as AgentToolPart}
+                  onToolResult={onToolResult}
+                />
+              )
+            }
+
+            if (part.type === 'step-start') {
+              return (
+                <div
+                  key={stableKey}
+                  className="my-2 border-t border-muted/30"
+                />
+              )
+            }
+
+            return null
+          })}
+
+          {isLastUserMessage && isUser && onRegenerate && (
+            <button
+              onClick={onRegenerate}
+              className="absolute right-0 top-0 rounded p-1 opacity-0 transition-opacity hover:bg-muted group-hover:opacity-100"
+              title="Regenerate response"
+            >
+              <RefreshCwIcon className="h-3.5 w-3.5 text-muted-foreground hover:text-foreground" />
+            </button>
+          )}
+        </div>
+
+        {isAssistant && !isStreaming && (
+          <MessageStatsFooter
+            message={message}
+            responseDurationMs={responseDurationMs}
+          />
+        )}
+
+        {isAssistant && followUpSuggestions.length > 0 && (
+          <div className="mt-3 border-t border-muted/30 pt-3">
+            <Suggestions>
+              {followUpSuggestions.map((suggestion) => (
+                <Suggestion
+                  key={suggestion}
+                  suggestion={suggestion}
+                  onClick={onSuggestionClick}
+                />
+              ))}
+            </Suggestions>
+          </div>
+        )}
+      </MessageContent>
+    </Message>
+  )
+}

--- a/components/agents/chat/message.tsx
+++ b/components/agents/chat/message.tsx
@@ -153,17 +153,53 @@ function MessageStatsFooter({
   )
 }
 
-function extractTaskItems(text: string): string[] {
-  const taskPattern = /^[\s]*-\s+\[[ xX]\]\s+(.+)$/gm
-  const matches = [...text.matchAll(taskPattern)]
-  if (matches.length < 3) return []
+type MessageSection =
+  | { readonly type: 'markdown'; readonly text: string }
+  | { readonly type: 'tasks'; readonly items: readonly string[] }
 
-  const nonEmptyLines = text
-    .split('\n')
-    .filter((line) => line.trim().length > 0)
-  if (matches.length !== nonEmptyLines.length) return []
+function getTaskItem(line: string): string | null {
+  const match = /^[\s]*-\s+\[[ xX]\]\s+(.+)$/.exec(line)
+  return match ? match[1].trim() : null
+}
 
-  return matches.map((match) => match[1].trim())
+function extractMessageSections(text: string): MessageSection[] | null {
+  const lines = text.split('\n')
+  const nonEmptyLines = lines.filter((line) => line.trim().length > 0)
+  const taskCount = nonEmptyLines.filter((line) => getTaskItem(line)).length
+  if (taskCount < 3 || taskCount < nonEmptyLines.length * 0.5) return null
+
+  const sections: MessageSection[] = []
+  let markdownLines: string[] = []
+  let taskItems: string[] = []
+
+  const flushMarkdown = () => {
+    const markdown = markdownLines.join('\n').trim()
+    if (markdown) sections.push({ type: 'markdown', text: markdown })
+    markdownLines = []
+  }
+
+  const flushTasks = () => {
+    if (taskItems.length > 0) {
+      sections.push({ type: 'tasks', items: taskItems })
+    }
+    taskItems = []
+  }
+
+  for (const line of lines) {
+    const taskItem = getTaskItem(line)
+    if (taskItem) {
+      flushMarkdown()
+      taskItems.push(taskItem)
+    } else {
+      flushTasks()
+      markdownLines.push(line)
+    }
+  }
+
+  flushTasks()
+  flushMarkdown()
+
+  return sections
 }
 
 function generateFollowUpSuggestions(message: UIMessage): string[] {
@@ -230,24 +266,42 @@ function generateFollowUpSuggestions(message: UIMessage): string[] {
   return suggestions.slice(0, 4)
 }
 
-function MarkdownMessage({ text }: { readonly text: string }) {
-  const taskItems = extractTaskItems(text)
+function TaskSection({ items }: { readonly items: readonly string[] }) {
+  return (
+    <div className="my-2">
+      <Task>
+        <TaskTrigger title="Tasks" />
+        <TaskContent>
+          {items.map((item, index) => (
+            <TaskItem key={index}>{item}</TaskItem>
+          ))}
+        </TaskContent>
+      </Task>
+    </div>
+  )
+}
 
-  if (taskItems.length > 0) {
+function MarkdownMessage({ text }: { readonly text: string }) {
+  const sections = extractMessageSections(text)
+
+  if (sections) {
     return (
-      <div className="my-2">
-        <Task>
-          <TaskTrigger title="Tasks" />
-          <TaskContent>
-            {taskItems.map((item, index) => (
-              <TaskItem key={index}>{item}</TaskItem>
-            ))}
-          </TaskContent>
-        </Task>
-      </div>
+      <>
+        {sections.map((section, index) =>
+          section.type === 'tasks' ? (
+            <TaskSection key={index} items={section.items} />
+          ) : (
+            <MarkdownContent key={index} text={section.text} />
+          )
+        )}
+      </>
     )
   }
 
+  return <MarkdownContent text={text} />
+}
+
+function MarkdownContent({ text }: { readonly text: string }) {
   return (
     <div className="markdown-content">
       <ReactMarkdown

--- a/components/agents/chat/tool-output.tsx
+++ b/components/agents/chat/tool-output.tsx
@@ -1,0 +1,435 @@
+'use client'
+
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  Loader2Icon,
+  Maximize2Icon,
+} from 'lucide-react'
+
+import type { AgentDataSourcesProps } from '@/components/agents/agent-data-sources'
+import type { AgentVisualizationProps } from '@/components/agents/agent-visualization'
+import type { QueryConfig } from '@/types/query-config'
+
+import { useEffect, useMemo, useState } from 'react'
+import { AgentChartRenderer } from '@/components/agents/agent-chart-renderer'
+import { AgentDataSources } from '@/components/agents/agent-data-sources'
+import { AgentVisualization } from '@/components/agents/agent-visualization'
+import {
+  AskUserWidget,
+  isAskUserOutput,
+} from '@/components/agents/ask-user-widget'
+import { DataTable } from '@/components/data-table/data-table'
+import { getToolMetadata } from '@/components/mcp/mcp-tools-data'
+import { Badge } from '@/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+
+export interface AgentToolPart {
+  readonly type: string
+  readonly toolCallId: string
+  readonly toolName?: string
+  readonly state: string
+  readonly input?: unknown
+  readonly output?: unknown
+  readonly errorText?: string
+  readonly title?: string
+}
+
+interface ToolCallPartProps {
+  readonly part: AgentToolPart
+  readonly onToolResult?: (toolCallId: string, result: string) => void
+}
+
+function createResultQueryConfig(columns: string[]): QueryConfig<string[]> {
+  return {
+    name: 'agent-query-result',
+    description: 'Query results from AI agent',
+    sql: 'SELECT * FROM agent_result',
+    columns,
+  }
+}
+
+function getRowsFromOutput(output: unknown): Record<string, unknown>[] {
+  if (Array.isArray(output) && output.length > 0) {
+    const first = output[0]
+    if (typeof first === 'object' && first !== null) {
+      return output as Record<string, unknown>[]
+    }
+  }
+
+  if (typeof output === 'object' && output !== null) {
+    const obj = output as Record<string, unknown>
+    if (Array.isArray(obj.rows) && obj.rows.length > 0) {
+      return obj.rows as Record<string, unknown>[]
+    }
+  }
+
+  return []
+}
+
+function getPromotedOutputType(output: unknown) {
+  if (typeof output !== 'object' || output === null) return null
+
+  const outputObj = output as Record<string, unknown>
+  if (outputObj.type === 'visualization' && Array.isArray(outputObj.rows)) {
+    return 'visualization' as const
+  }
+  if (outputObj.type === 'data_sources' && Array.isArray(outputObj.sources)) {
+    return 'data_sources' as const
+  }
+
+  return null
+}
+
+export function ResultTable({
+  rows,
+  maxRows = 100,
+}: {
+  readonly rows: readonly unknown[]
+  readonly maxRows?: number
+}) {
+  const displayRows = rows.slice(0, maxRows) as Record<string, unknown>[]
+
+  const columns = useMemo(() => {
+    if (displayRows.length === 0) return []
+    return Object.keys(displayRows[0])
+  }, [displayRows])
+
+  const queryConfig = useMemo(() => createResultQueryConfig(columns), [columns])
+
+  if (columns.length === 0) {
+    return (
+      <div className="py-4 text-center text-sm text-muted-foreground">
+        No columns to display
+      </div>
+    )
+  }
+
+  const footnote =
+    rows.length > maxRows ? `Showing ${maxRows} of ${rows.length} rows` : ' '
+
+  return (
+    <DataTable
+      data={displayRows}
+      queryConfig={queryConfig}
+      context={{}}
+      defaultPageSize={Math.min(displayRows.length, 25)}
+      showSQL={false}
+      enableColumnFilters={false}
+      enableColumnReordering={false}
+      compact
+      footnote={footnote}
+    />
+  )
+}
+
+function ExpandTableButton({
+  rows,
+  queryConfig,
+}: {
+  readonly rows: Record<string, unknown>[]
+  readonly queryConfig: QueryConfig<string[]>
+}) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
+          title="Expand table"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <Maximize2Icon className="h-3 w-3" />
+        </button>
+      </DialogTrigger>
+      <DialogContent className="flex max-h-[90vh] max-w-[95vw] flex-col">
+        <DialogHeader>
+          <DialogTitle>Query Results ({rows.length} rows)</DialogTitle>
+        </DialogHeader>
+        <div className="min-h-0 flex-1 overflow-auto">
+          <DataTable
+            data={rows}
+            queryConfig={queryConfig}
+            context={{}}
+            defaultPageSize={50}
+            showSQL={false}
+            enableColumnFilters={true}
+            enableColumnReordering={false}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function renderToolOutput(output: unknown) {
+  if (output == null) return null
+
+  const outputObj = output as Record<string, unknown>
+
+  if (outputObj.type === 'visualization' && Array.isArray(outputObj.rows)) {
+    return (
+      <AgentVisualization
+        title={outputObj.title as string | undefined}
+        sql={outputObj.sql as string}
+        rows={outputObj.rows as Record<string, unknown>[]}
+        columns={outputObj.columns as string[]}
+        rowCount={outputObj.rowCount as number}
+        viz={outputObj.viz as AgentVisualizationProps['viz']}
+      />
+    )
+  }
+
+  if (outputObj.type === 'data_sources' && Array.isArray(outputObj.sources)) {
+    return (
+      <AgentDataSources
+        searchTerm={outputObj.searchTerm as string}
+        sources={outputObj.sources as AgentDataSourcesProps['sources']}
+      />
+    )
+  }
+
+  if (Array.isArray(output) && output.length > 0) {
+    const firstItem = output[0]
+    if (typeof firstItem === 'object' && firstItem !== null) {
+      return <ResultTable rows={output} maxRows={100} />
+    }
+  }
+
+  if (
+    outputObj.chartData &&
+    Array.isArray(outputObj.chartData) &&
+    outputObj.chartData.length > 0
+  ) {
+    return (
+      <AgentChartRenderer
+        type={
+          (outputObj.chartType as 'area' | 'bar' | 'donut' | undefined) || 'bar'
+        }
+        data={outputObj.chartData as readonly Record<string, unknown>[]}
+        title={outputObj.chartTitle as string | undefined}
+        xKey={outputObj.xKey as string | undefined}
+        yKey={outputObj.yKey as string | undefined}
+        categories={outputObj.categories as string[] | undefined}
+        readable={
+          outputObj.readable as
+            | 'bytes'
+            | 'duration'
+            | 'number'
+            | 'quantity'
+            | undefined
+        }
+      />
+    )
+  }
+
+  if (Array.isArray(outputObj.rows) && outputObj.rows.length > 0) {
+    return <ResultTable rows={outputObj.rows as unknown[]} maxRows={100} />
+  }
+
+  return (
+    <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all font-mono text-xs text-muted-foreground">
+      {typeof output === 'string' ? output : JSON.stringify(output, null, 2)}
+    </pre>
+  )
+}
+
+export function ToolCallPart({ part, onToolResult }: ToolCallPartProps) {
+  const toolName = part.toolName || part.type.replace('tool-', '')
+  const isStarting =
+    part.state === 'input-streaming' || part.state === 'input-available'
+  const isStreaming = part.state === 'output-streaming'
+  const hasOutput = part.state === 'output-available'
+  const hasError = part.state === 'output-error'
+  const shouldAutoExpand = isStreaming || hasError || isStarting
+  const [isExpanded, setIsExpanded] = useState(shouldAutoExpand)
+
+  useEffect(() => {
+    if (shouldAutoExpand) setIsExpanded(true)
+  }, [shouldAutoExpand])
+
+  const inputParams = useMemo(() => {
+    if (!part.input || typeof part.input !== 'object') return null
+    return Object.entries(part.input as Record<string, unknown>)
+      .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+      .join(', ')
+  }, [part.input])
+
+  const toolParams = useMemo(() => {
+    const tool = getToolMetadata(toolName)
+    return tool?.params || []
+  }, [toolName])
+
+  const outputRows = useMemo(() => {
+    if (!hasOutput || !part.output) return []
+    return getRowsFromOutput(part.output)
+  }, [hasOutput, part.output])
+
+  const outputQueryConfig = useMemo(() => {
+    if (outputRows.length === 0) return null
+    return createResultQueryConfig(Object.keys(outputRows[0]))
+  }, [outputRows])
+
+  const promotedOutput = useMemo(() => {
+    if (!hasOutput || part.output == null) return null
+    return getPromotedOutputType(part.output)
+  }, [hasOutput, part.output])
+
+  return (
+    <div className="my-2">
+      <div className="overflow-hidden rounded-md border border-border/60 bg-muted/20">
+        <button
+          onClick={() => setIsExpanded((previous) => !previous)}
+          className="flex w-full items-center gap-2 px-2.5 py-2 text-left transition-colors hover:bg-muted/30"
+        >
+          <span className="shrink-0 text-muted-foreground">
+            {isExpanded ? (
+              <ChevronDownIcon className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronRightIcon className="h-3.5 w-3.5" />
+            )}
+          </span>
+
+          <div
+            className={cn(
+              'h-2 w-2 shrink-0 rounded-full',
+              isStarting && 'animate-pulse bg-yellow-500',
+              isStreaming && 'animate-ping bg-yellow-400',
+              hasOutput && 'bg-green-500',
+              hasError && 'bg-red-500'
+            )}
+          />
+
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span className="font-mono text-xs font-medium">{toolName}</span>
+            {inputParams && (
+              <span className="truncate font-mono text-xs text-muted-foreground/70">
+                {inputParams}
+              </span>
+            )}
+          </div>
+
+          <div className="ml-auto flex items-center gap-1.5">
+            {isStreaming && (
+              <Badge
+                variant="outline"
+                className="shrink-0 text-[10px] text-yellow-600"
+              >
+                Executing...
+              </Badge>
+            )}
+            {hasOutput && (
+              <Badge
+                variant="outline"
+                className="shrink-0 text-[10px] text-green-600"
+              >
+                Done
+              </Badge>
+            )}
+            {hasError && (
+              <Badge
+                variant="outline"
+                className="shrink-0 text-[10px] text-red-600"
+              >
+                Failed
+              </Badge>
+            )}
+            {hasOutput && outputRows.length > 0 && outputQueryConfig && (
+              <ExpandTableButton
+                rows={outputRows}
+                queryConfig={outputQueryConfig}
+              />
+            )}
+          </div>
+        </button>
+
+        {isExpanded ? (
+          <div className="bg-background/50">
+            {isStreaming ? (
+              <div className="px-2.5 py-2.5">
+                <div className="flex items-center gap-2">
+                  <Loader2Icon className="h-4 w-4 animate-spin text-yellow-500" />
+                  <span className="text-xs text-muted-foreground">
+                    Executing {toolName}...
+                  </span>
+                </div>
+              </div>
+            ) : null}
+
+            {hasOutput && part.output != null && !promotedOutput ? (
+              <div className="px-1 py-1">
+                {isAskUserOutput(part.output) && onToolResult ? (
+                  <AskUserWidget
+                    output={part.output}
+                    toolCallId={part.toolCallId}
+                    onSubmit={onToolResult}
+                  />
+                ) : (
+                  renderToolOutput(part.output)
+                )}
+              </div>
+            ) : null}
+
+            {hasError && Boolean(part.errorText) ? (
+              <div className="px-3 py-2 text-sm text-destructive">
+                {String(part.errorText)}
+              </div>
+            ) : null}
+
+            {part.input && typeof part.input === 'object' ? (
+              <div className="border-t border-border/60 bg-muted/10 px-2.5 py-2">
+                <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                  Parameters
+                </div>
+                <div className="space-y-1">
+                  {Object.entries(part.input as Record<string, unknown>).map(
+                    ([key, value]) => {
+                      const paramDef = toolParams.find((p) => p.name === key)
+                      const isOptional = paramDef?.required === false
+                      return (
+                        <div
+                          key={key}
+                          className="flex items-center gap-2 text-xs"
+                        >
+                          <span
+                            className={cn(
+                              'font-mono',
+                              isOptional
+                                ? 'text-muted-foreground'
+                                : 'font-medium text-foreground'
+                            )}
+                          >
+                            {key}
+                          </span>
+                          <span className="text-muted-foreground">:</span>
+                          <span className="font-mono text-muted-foreground">
+                            {JSON.stringify(value)}
+                          </span>
+                          {isOptional ? (
+                            <span className="text-[10px] text-muted-foreground/60">
+                              (optional)
+                            </span>
+                          ) : null}
+                        </div>
+                      )
+                    }
+                  )}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      {hasOutput && promotedOutput && part.output != null ? (
+        <div className="mt-2">{renderToolOutput(part.output)}</div>
+      ) : null}
+    </div>
+  )
+}

--- a/components/agents/chat/tool-output.tsx
+++ b/components/agents/chat/tool-output.tsx
@@ -142,6 +142,7 @@ function ExpandTableButton({
       <DialogTrigger asChild>
         <button
           className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
+          aria-label="Expand table"
           title="Expand table"
           onClick={(event) => event.stopPropagation()}
         >
@@ -284,70 +285,76 @@ export function ToolCallPart({ part, onToolResult }: ToolCallPartProps) {
   return (
     <div className="my-2">
       <div className="overflow-hidden rounded-md border border-border/60 bg-muted/20">
-        <button
-          onClick={() => setIsExpanded((previous) => !previous)}
-          className="flex w-full items-center gap-2 px-2.5 py-2 text-left transition-colors hover:bg-muted/30"
-        >
-          <span className="shrink-0 text-muted-foreground">
-            {isExpanded ? (
-              <ChevronDownIcon className="h-3.5 w-3.5" />
-            ) : (
-              <ChevronRightIcon className="h-3.5 w-3.5" />
-            )}
-          </span>
+        <div className="flex w-full items-center transition-colors hover:bg-muted/30">
+          <button
+            onClick={() => setIsExpanded((previous) => !previous)}
+            className="flex min-w-0 flex-1 items-center gap-2 px-2.5 py-2 text-left"
+            aria-expanded={isExpanded}
+          >
+            <span className="shrink-0 text-muted-foreground">
+              {isExpanded ? (
+                <ChevronDownIcon className="h-3.5 w-3.5" />
+              ) : (
+                <ChevronRightIcon className="h-3.5 w-3.5" />
+              )}
+            </span>
 
-          <div
-            className={cn(
-              'h-2 w-2 shrink-0 rounded-full',
-              isStarting && 'animate-pulse bg-yellow-500',
-              isStreaming && 'animate-ping bg-yellow-400',
-              hasOutput && 'bg-green-500',
-              hasError && 'bg-red-500'
-            )}
-          />
+            <div
+              className={cn(
+                'h-2 w-2 shrink-0 rounded-full',
+                isStarting && 'animate-pulse bg-yellow-500',
+                isStreaming && 'animate-ping bg-yellow-400',
+                hasOutput && 'bg-green-500',
+                hasError && 'bg-red-500'
+              )}
+            />
 
-          <div className="flex min-w-0 items-center gap-1.5">
-            <span className="font-mono text-xs font-medium">{toolName}</span>
-            {inputParams && (
-              <span className="truncate font-mono text-xs text-muted-foreground/70">
-                {inputParams}
-              </span>
-            )}
-          </div>
+            <div className="flex min-w-0 items-center gap-1.5">
+              <span className="font-mono text-xs font-medium">{toolName}</span>
+              {inputParams && (
+                <span className="truncate font-mono text-xs text-muted-foreground/70">
+                  {inputParams}
+                </span>
+              )}
+            </div>
 
-          <div className="ml-auto flex items-center gap-1.5">
-            {isStreaming && (
-              <Badge
-                variant="outline"
-                className="shrink-0 text-[10px] text-yellow-600"
-              >
-                Executing...
-              </Badge>
-            )}
-            {hasOutput && (
-              <Badge
-                variant="outline"
-                className="shrink-0 text-[10px] text-green-600"
-              >
-                Done
-              </Badge>
-            )}
-            {hasError && (
-              <Badge
-                variant="outline"
-                className="shrink-0 text-[10px] text-red-600"
-              >
-                Failed
-              </Badge>
-            )}
-            {hasOutput && outputRows.length > 0 && outputQueryConfig && (
+            <div className="ml-auto flex items-center gap-1.5">
+              {isStreaming && (
+                <Badge
+                  variant="outline"
+                  className="shrink-0 text-[10px] text-yellow-600"
+                >
+                  Executing...
+                </Badge>
+              )}
+              {hasOutput && (
+                <Badge
+                  variant="outline"
+                  className="shrink-0 text-[10px] text-green-600"
+                >
+                  ✓ Done
+                </Badge>
+              )}
+              {hasError && (
+                <Badge
+                  variant="outline"
+                  className="shrink-0 text-[10px] text-red-600"
+                >
+                  ✗ Failed
+                </Badge>
+              )}
+            </div>
+          </button>
+
+          {hasOutput && outputRows.length > 0 && outputQueryConfig && (
+            <div className="shrink-0 pr-2">
               <ExpandTableButton
                 rows={outputRows}
                 queryConfig={outputQueryConfig}
               />
-            )}
-          </div>
-        </button>
+            </div>
+          )}
+        </div>
 
         {isExpanded ? (
           <div className="bg-background/50">


### PR DESCRIPTION
## Summary
- Split the large agent chat area into focused chat modules for controls, empty state, message rendering, and tool output.
- Kept `AgentsChatArea` focused on chat transport, conversation persistence, timing, and input orchestration.
- Normalized callback prop names in extracted components (`onClear`, `onStop`, `onSubmitPrompt`) to match intent.

## Verification
- `bunx biome check components/agents/agents-chat-area.tsx components/agents/chat/controls.tsx components/agents/chat/empty-state.tsx components/agents/chat/message.tsx components/agents/chat/tool-output.tsx`
- `bun run type-check`
- `bun run lint`
- `bun run build`
- `bun run test` (1327 pass)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced chat message display with improved markdown rendering, syntax highlighting, and support for tables and task items.
  * Added suggested questions in the empty state and auto-generated follow-up suggestions after responses.
  * Introduced regenerate message button and typing indicator feedback.
  * Improved tool output visualization with expandable sections and structured data display.
  * Added response duration statistics display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->