### PR TITLE
test(wasm): fix monitor core mock exports

### DIFF
--- a/lib/clickhouse/__tests__/clickhouse-fetch.test.ts
+++ b/lib/clickhouse/__tests__/clickhouse-fetch.test.ts
@@ -39,23 +39,36 @@ const mockTransformClickHouseJsonEachRowWasmJson = mock((input: string) => {
     .filter((line) => line.trim().length > 0)
     .map((line) => JSON.parse(line))
 
-  for (const row of rows) {
-    for (const [key, value] of Object.entries(row)) {
-      if (
-        typeof value === 'string' &&
-        /^-?\d+(\.\d+)?([eE][+-]?\d+)?$/.test(value)
-      ) {
-        const number = Number(value)
-        row[key] =
-          Number.isInteger(number) && Math.abs(number) > Number.MAX_SAFE_INTEGER
-            ? value
-            : number
-      }
-    }
+  return Promise.resolve(JSON.stringify(normalizeNumericStrings(rows)))
+})
+
+function normalizeNumericStrings(value: unknown): unknown {
+  if (
+    typeof value === 'string' &&
+    /^-?\d+(\.\d+)?([eE][+-]?\d+)?$/.test(value)
+  ) {
+    const number = Number(value)
+    return Number.isInteger(number) &&
+      Math.abs(number) > Number.MAX_SAFE_INTEGER
+      ? value
+      : number
   }
 
-  return Promise.resolve(JSON.stringify(rows))
-})
+  if (Array.isArray(value)) {
+    return value.map(normalizeNumericStrings)
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        normalizeNumericStrings(item),
+      ])
+    )
+  }
+
+  return value
+}
 
 // Mock specifiers MUST match the import specifiers in clickhouse-fetch.ts.
 // On Linux CI, bun's mock.module only intercepts imports with matching specifiers.
@@ -74,6 +87,8 @@ mock.module('@/lib/table-validator', () => ({
 mock.module('@/lib/wasm/monitor-core', () => ({
   transformClickHouseJsonEachRowWasmJson:
     mockTransformClickHouseJsonEachRowWasmJson,
+  transformClickHouseJsonEachRowWasm: async (input: string) =>
+    JSON.parse(await mockTransformClickHouseJsonEachRowWasmJson(input)),
 }))
 
 // Clean up all module mocks after tests complete


### PR DESCRIPTION
## Summary
- Fix the ClickHouse fetch test monitor-core mock to expose both WASM helper exports.
- Make the mock normalization recurse through nested objects and arrays, matching the real helper contract.

## Evidence
- Recent commit 014bb7dc renamed the WASM binding test to run as a Bun test.
- Before this patch, this order failed because the ClickHouse test mock shadowed `transformClickHouseJsonEachRowWasm`:
  `bun test ./lib/clickhouse/__tests__/clickhouse-fetch.test.ts ./lib/wasm/monitor-core.wasm.test.ts`

## Verification
- `bun test ./lib/clickhouse/__tests__/clickhouse-fetch.test.ts ./lib/wasm/monitor-core.wasm.test.ts`
- `bunx biome check lib/clickhouse/__tests__/clickhouse-fetch.test.ts`
- `bun run type-check`
- pre-push `biome check .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test mock implementations to improve validation of JSON data normalization and transformation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->