### PR TITLE
test(clickhouse): remove empty cleanup hook

### DIFF
--- a/lib/clickhouse/__tests__/clickhouse-fetch.test.ts
+++ b/lib/clickhouse/__tests__/clickhouse-fetch.test.ts
@@ -4,15 +4,7 @@
 
 import type { QueryConfig } from '@/types/query-config'
 
-import {
-  afterAll,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-} from 'bun:test'
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
 
 // Mock dependencies — all mock.module calls are hoisted by bun before imports.
 // We use dynamic import (await import) instead of static import to guarantee
@@ -154,10 +146,6 @@ describe('clickhouse-fetch', () => {
     mockResultSetJson.mockResolvedValue([{ result: 'data' }])
     mockResultSetText.mockResolvedValue('{"result":"1"}\n{"result":"2"}\n')
     mockClientQuery.mockResolvedValue(mockResultSet as never)
-  })
-
-  afterEach(() => {
-    // Cleanup happens automatically with mockReset in beforeEach
   })
 
   describe('fetchData', () => {


### PR DESCRIPTION
## Summary
- remove the empty `afterEach` hook from `lib/clickhouse/__tests__/clickhouse-fetch.test.ts`
- keep cleanup in the existing `beforeEach` reset block and `afterAll` mock restore

## Code smell scan
- warning: `lib/clickhouse/__tests__/clickhouse-fetch.test.ts:9` imported `afterEach` only for an empty hook.
- warning: `lib/clickhouse/__tests__/clickhouse-fetch.test.ts:159` registered a no-op cleanup hook even though the reset work happens in `beforeEach`.

## Dead code scan
- no production dead-code candidates were removed. The only candidate was in a test file, and test files are excluded by this automation's dead-code rules.

## Verification
- `bun test ./lib/clickhouse/__tests__/clickhouse-fetch.test.ts`
- `bunx biome check lib/clickhouse/__tests__/clickhouse-fetch.test.ts`

## Summary by Sourcery

Tests:
- Delete an empty afterEach hook from clickhouse-fetch tests, relying on existing beforeEach and afterAll cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined test cleanup by consolidating imports and removing redundant cleanup callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->