### PR TITLE
Use timing-safe API key check and reduce agent production logging; add security scan report

### DIFF
--- a/app/api/v1/agent/route.ts
+++ b/app/api/v1/agent/route.ts
@@ -21,6 +21,8 @@ import { classifyError } from '@/lib/ai/agent/errors'
 // This route is dynamic and should not be statically exported
 export const dynamic = 'force-dynamic'
 
+const AGENT_DEBUG_LOGS = process.env.NODE_ENV !== 'production'
+
 /**
  * Handle POST requests for agent processing with streaming
  */
@@ -37,25 +39,10 @@ export async function POST(request: Request) {
     disabledTools?: string[] // Tools the user has disabled in the sidebar
   }
 
-  // Debug logging
-  console.log('[Agent API] Request body keys:', Object.keys(body))
-  console.log('[Agent API] Messages count:', body.messages?.length)
-  console.log(
-    '[Agent API] Messages sample:',
-    body.messages?.slice(-2).map((m) => ({
-      role: m.role,
-      hasParts: 'parts' in m,
-      partsCount: 'parts' in m ? m.parts?.length : 0,
-      hasContent: 'content' in m,
-      id: 'id' in m ? m.id : undefined,
-    }))
-  )
-  // Log full first message structure for deep debugging
-  if (body.messages && body.messages.length > 0) {
-    console.log(
-      '[Agent API] First message structure:',
-      JSON.stringify(body.messages[0], null, 2)
-    )
+  // Debug logging (disabled in production to avoid sensitive prompt leakage)
+  if (AGENT_DEBUG_LOGS) {
+    console.log('[Agent API] Request body keys:', Object.keys(body))
+    console.log('[Agent API] Messages count:', body.messages?.length)
   }
 
   // Support both direct `message` and AI SDK's UIMessage format with parts array
@@ -151,13 +138,11 @@ export async function POST(request: Request) {
     })
   }
 
-  // Debug logging
-  console.log(
-    '[Agent API] uiMessages being sent:',
-    JSON.stringify(uiMessages, null, 2)
-  )
-  console.log('[Agent API] Model being used:', model)
-  console.log('[Agent API] OpenAI baseURL:', process.env.LLM_API_BASE)
+  if (AGENT_DEBUG_LOGS) {
+    // Keep logs minimal: avoid logging full message contents
+    console.log('[Agent API] uiMessages count:', uiMessages.length)
+    console.log('[Agent API] Model being used:', model)
+  }
 
   // Collect usage from each step for analytics aggregation
   const usageSteps: LanguageModelUsage[] = []

--- a/app/api/v1/auth/api-key/route.ts
+++ b/app/api/v1/auth/api-key/route.ts
@@ -8,6 +8,19 @@ function getSecret(): string | null {
   return process.env.CHM_API_KEY_SECRET ?? null
 }
 
+function timingSafeEqualString(a: string, b: string): boolean {
+  const aBytes = new TextEncoder().encode(a)
+  const bBytes = new TextEncoder().encode(b)
+  if (aBytes.length !== bBytes.length) return false
+
+  let diff = 0
+  for (let index = 0; index < aBytes.length; index += 1) {
+    diff |= aBytes[index] ^ bBytes[index]
+  }
+
+  return diff === 0
+}
+
 export async function POST(request: Request) {
   const secret = getSecret()
   if (!secret) {
@@ -19,7 +32,7 @@ export async function POST(request: Request) {
 
   // Require the CHM_API_KEY_SECRET itself to mint keys
   const token = getBearerToken(request.headers.get('authorization'))
-  if (!token || token !== secret) {
+  if (!token || !timingSafeEqualString(token, secret)) {
     return NextResponse.json(
       { error: 'Unauthorized: provide CHM_API_KEY_SECRET as Bearer token' },
       { status: 401 }

--- a/docs/reviews/security-scan-2026-05-04.md
+++ b/docs/reviews/security-scan-2026-05-04.md
@@ -1,0 +1,38 @@
+# Security Scan Report — 2026-05-04
+
+## Scope
+- Repository: `clickhouse-monitoring`
+- Date: 2026-05-04 (UTC)
+- Focus: API routes and auth flows with potential data exposure or authentication side-channel risk.
+
+## Scan Method
+- Pattern scan for insecure constructs in `app/`, `components/`, `lib/`, `scripts/`.
+- Manual review of API-key minting endpoint and agent streaming endpoint.
+
+## Risks Found and Fixed
+
+### 1) Timing side-channel in API-key mint authorization
+- **Location**: `app/api/v1/auth/api-key/route.ts`
+- **Risk**: Authorization compared bearer token to `CHM_API_KEY_SECRET` using direct string equality.
+- **Impact**: In theory, direct equality can leak timing differences versus constant-time comparison.
+- **Fix**:
+  - Added `timingSafeEqualString()` using byte-wise XOR over equal-length encoded strings.
+  - Replaced `token !== secret` with constant-time compare function.
+
+### 2) Prompt/data leakage through production logs in Agent API
+- **Location**: `app/api/v1/agent/route.ts`
+- **Risk**: Route logged message payload structure and serialized messages, which may include sensitive user prompts or operational details.
+- **Impact**: Sensitive data could be exposed in production log pipelines.
+- **Fix**:
+  - Added `AGENT_DEBUG_LOGS` guard (`NODE_ENV !== 'production'`).
+  - Disabled verbose payload logs in production.
+  - Reduced remaining debug output to metadata only (message count and selected model).
+
+## Commands Executed
+- `rg -n "dangerouslySetInnerHTML|eval\(|new Function|child_process|exec\(|spawn\(|http://|target=\"_blank\"|process\.env" app components lib scripts`
+- `bun run lint app/api/v1/auth/api-key/route.ts app/api/v1/agent/route.ts`
+- `bun run build`
+
+## Result
+- High-priority risks identified in request handling/logging were fixed in code.
+- Lint/build checks passed after remediation.


### PR DESCRIPTION
### Motivation
- Prevent a potential timing side-channel when minting API keys by avoiding direct string equality on the `CHM_API_KEY_SECRET` Bearer token.
- Prevent sensitive prompt or message data from being emitted to production logs by gating verbose debug output in the agent streaming endpoint.
- Document the findings and remediation of the scan in a repository-accessible report.

### Description
- Added a `timingSafeEqualString()` helper that performs a constant-time byte-wise comparison and replaced `token !== secret` with `!timingSafeEqualString(token, secret)` in `app/api/v1/auth/api-key/route.ts`.
- Introduced `AGENT_DEBUG_LOGS` (`process.env.NODE_ENV !== 'production'`) to `app/api/v1/agent/route.ts` and guarded verbose `console.log` statements to avoid logging full message contents in production, reducing logs to metadata like `uiMessages` count and model.
- Added `docs/reviews/security-scan-2026-05-04.md` that summarizes the scan scope, findings (timing side-channel and log exposure), fixes, and the commands run.

### Testing
- Ran lint on the updated files with `bun run lint` and the checks passed.
- Performed a local build with `bun run build`, which succeeded.
- Executed the scan and verification commands listed in `docs/reviews/security-scan-2026-05-04.md` and observed no remaining lint/build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f80b3f423883328fa7fcf07197757a)

## Summary by Sourcery

Harden API authentication and agent logging while documenting recent security scan findings.

Bug Fixes:
- Eliminate a potential timing side-channel in API key minting by using a constant-time comparison for the authorization secret.
- Prevent leakage of sensitive agent prompts by disabling verbose debug logs in production and limiting remaining logs to high-level metadata.

Documentation:
- Add a security scan report documenting identified risks, fixes applied, and verification commands run.