### PR TITLE
fix(charts): guard chart render callbacks

### DIFF
--- a/components/charts/chart-container.cy.tsx
+++ b/components/charts/chart-container.cy.tsx
@@ -11,7 +11,6 @@ describe('<ChartContainer />', () => {
   ) => <div data-testid="chart-content">Chart Content</div>
 
   it('renders skeleton when loading', () => {
-    const children = cy.stub().as('children')
     const swr = {
       data: undefined,
       isLoading: true,
@@ -22,17 +21,15 @@ describe('<ChartContainer />', () => {
 
     cy.mount(
       <ChartContainer swr={swr} title="Test Chart">
-        {children}
+        {mockChildren}
       </ChartContainer>
     )
 
     cy.contains('Test Chart').should('exist')
     cy.get('[role="status"][aria-label*="Loading"]').should('exist')
-    cy.get('@children').should('not.have.been.called')
   })
 
   it('renders error state when error exists', () => {
-    const children = cy.stub().as('children')
     const swr = {
       data: undefined,
       isLoading: false,
@@ -43,7 +40,7 @@ describe('<ChartContainer />', () => {
 
     cy.mount(
       <ChartContainer swr={swr} title="Test Chart">
-        {children}
+        {mockChildren}
       </ChartContainer>
     )
 
@@ -51,11 +48,9 @@ describe('<ChartContainer />', () => {
     cy.get('[data-testid="chart-content"]').should('not.exist')
     // Title is shown in error state
     cy.contains('Test Chart').should('exist')
-    cy.get('@children').should('not.have.been.called')
   })
 
   it('renders empty state when no data', () => {
-    const children = cy.stub().as('children')
     const swr = {
       data: [],
       isLoading: false,
@@ -66,14 +61,13 @@ describe('<ChartContainer />', () => {
 
     cy.mount(
       <ChartContainer swr={swr} title="Test Chart">
-        {children}
+        {mockChildren}
       </ChartContainer>
     )
 
     // EmptyState with no-data variant shows "No data available"
     cy.contains('No data available').should('exist')
     cy.contains('Test Chart').should('exist')
-    cy.get('@children').should('not.have.been.called')
   })
 
   it('renders children when data exists', () => {

--- a/components/charts/chart-container.cy.tsx
+++ b/components/charts/chart-container.cy.tsx
@@ -1,7 +1,6 @@
 import { ChartContainer } from './chart-container'
 
 describe('<ChartContainer />', () => {
-  // Regular function (not cy.stub) since tests don't need to spy on children calls
   const mockChildren = (
     _data: unknown[],
     _sql: string | undefined,
@@ -9,6 +8,10 @@ describe('<ChartContainer />', () => {
     _staleError: unknown,
     _mutate: unknown
   ) => <div data-testid="chart-content">Chart Content</div>
+
+  const guardedChildren = () => {
+    throw new Error('ChartContainer should not render children for this state')
+  }
 
   it('renders skeleton when loading', () => {
     const swr = {
@@ -21,7 +24,7 @@ describe('<ChartContainer />', () => {
 
     cy.mount(
       <ChartContainer swr={swr} title="Test Chart">
-        {mockChildren}
+        {guardedChildren}
       </ChartContainer>
     )
 
@@ -40,7 +43,7 @@ describe('<ChartContainer />', () => {
 
     cy.mount(
       <ChartContainer swr={swr} title="Test Chart">
-        {mockChildren}
+        {guardedChildren}
       </ChartContainer>
     )
 
@@ -61,12 +64,12 @@ describe('<ChartContainer />', () => {
 
     cy.mount(
       <ChartContainer swr={swr} title="Test Chart">
-        {mockChildren}
+        {guardedChildren}
       </ChartContainer>
     )
 
-    // EmptyState with no-data variant shows "No data available"
-    cy.contains('No data available').should('exist')
+    // Titled empty states include the chart title in the visible message.
+    cy.contains('Test Chart - No data').should('exist')
     cy.contains('Test Chart').should('exist')
   })
 

--- a/components/charts/chart-container.cy.tsx
+++ b/components/charts/chart-container.cy.tsx
@@ -11,6 +11,7 @@ describe('<ChartContainer />', () => {
   ) => <div data-testid="chart-content">Chart Content</div>
 
   it('renders skeleton when loading', () => {
+    const children = cy.stub().as('children')
     const swr = {
       data: undefined,
       isLoading: true,
@@ -21,15 +22,17 @@ describe('<ChartContainer />', () => {
 
     cy.mount(
       <ChartContainer swr={swr} title="Test Chart">
-        {mockChildren}
+        {children}
       </ChartContainer>
     )
 
     cy.contains('Test Chart').should('exist')
     cy.get('[role="status"][aria-label*="Loading"]').should('exist')
+    cy.get('@children').should('not.have.been.called')
   })
 
   it('renders error state when error exists', () => {
+    const children = cy.stub().as('children')
     const swr = {
       data: undefined,
       isLoading: false,
@@ -40,7 +43,7 @@ describe('<ChartContainer />', () => {
 
     cy.mount(
       <ChartContainer swr={swr} title="Test Chart">
-        {mockChildren}
+        {children}
       </ChartContainer>
     )
 
@@ -48,9 +51,11 @@ describe('<ChartContainer />', () => {
     cy.get('[data-testid="chart-content"]').should('not.exist')
     // Title is shown in error state
     cy.contains('Test Chart').should('exist')
+    cy.get('@children').should('not.have.been.called')
   })
 
   it('renders empty state when no data', () => {
+    const children = cy.stub().as('children')
     const swr = {
       data: [],
       isLoading: false,
@@ -61,13 +66,14 @@ describe('<ChartContainer />', () => {
 
     cy.mount(
       <ChartContainer swr={swr} title="Test Chart">
-        {mockChildren}
+        {children}
       </ChartContainer>
     )
 
     // EmptyState with no-data variant shows "No data available"
     cy.contains('No data available').should('exist')
     cy.contains('Test Chart').should('exist')
+    cy.get('@children').should('not.have.been.called')
   })
 
   it('renders children when data exists', () => {

--- a/components/charts/chart-container.tsx
+++ b/components/charts/chart-container.tsx
@@ -9,7 +9,7 @@ import type { ChartDataPoint } from '@/types/chart-data'
 import { ChartEmpty } from './chart-empty'
 import { ChartError } from './chart-error'
 import { ChartZoomButton, ChartZoomDialog } from './chart-zoom-dialog'
-import { cloneElement, isValidElement, useMemo, useState } from 'react'
+import { cloneElement, isValidElement, useState } from 'react'
 import { ChartSkeleton } from '@/components/skeletons'
 import { FadeIn } from '@/components/ui/fade-in'
 import { cn } from '@/lib/utils'
@@ -94,12 +94,6 @@ export function ChartContainer<TData extends ChartDataPoint = ChartDataPoint>({
     ? { ...metadata }
     : undefined
 
-  // Render chart content memoize callback to avoid cloneElement on every render
-  const chartContent = useMemo(
-    () => children(data ?? [], sql, toolbarMetadata, staleError, mutate),
-    [data, sql, toolbarMetadata, staleError, mutate, children]
-  )
-
   // Loading state
   if (isLoading) {
     return <ChartSkeleton title={title} className={className} />
@@ -123,6 +117,8 @@ export function ChartContainer<TData extends ChartDataPoint = ChartDataPoint>({
       />
     )
   }
+
+  const chartContent = children(data, sql, toolbarMetadata, staleError, mutate)
 
   // If children returns a valid element, inject zoomButton prop if it's a ChartCard
   const enhancedContent =


### PR DESCRIPTION
## Summary
- restore ChartContainer so chart render callbacks run only after loading/error/empty guards pass

## Evidence
- Recent commit a9f86e1e moved ChartContainer children(data ?? []) before guards.
- Existing charts such as components/charts/query/query-cache.tsx and components/charts/system/disk-size.tsx dereference dataArray[0] in their render callbacks.

## Verification
- bun run type-check
- bunx biome check components/charts/chart-container.tsx
- git diff --check

## Not run
- bunx cypress run --component --spec components/charts/chart-container.cy.tsx exits before specs with Cypress SIGABRT on local macOS.