### PR TITLE
chore(code-quality): add 2026-05-07 smell scan report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ Both deployment methods provide:
 - `bun run docker:health` / `bun run cf:health` - Check Docker or deployed health endpoints
 - `bun run lint && bun run build` - Quick local CI parity check (matches core lint/build workflow jobs)
 - Code-smell/dead-code maintenance notes are tracked in `docs/reviews/code-smell-dead-code-YYYY-MM-DD.md`
+- Since-last-run scan scope command: `git log --since='<ISO_TIME>' --name-only --pretty=format: | sed '/^$/d' | sort -u`
 - TODO: Add a dedicated command for the code-smell scan workflow (currently run manually)
 
 **Docs workspace**: The `docs/` app uses `pnpm` instead of `bun`.

--- a/docs/reviews/code-smell-dead-code-2026-05-07.md
+++ b/docs/reviews/code-smell-dead-code-2026-05-07.md
@@ -1,0 +1,39 @@
+# Code Smell and Dead Code Review - 2026-05-07
+
+Scope:
+- Since last automation run timestamp in prompt: `2026-05-05T21:01:49.337Z`
+- Commits scanned: `1af14f7c049952d69b699c83296d02162b1f4c50`
+- Files changed in scope:
+  - `lib/api/shared/status-code-mapper.ts`
+  - `lib/api/shared/index.ts`
+  - `components/charts/chart-error.tsx`
+  - `CLAUDE.md`
+  - `docs/reviews/code-smell-dead-code-2026-05-06.md`
+
+## Findings
+
+### Critical
+- None.
+
+### Warning
+- None in the changed-code scope.
+
+### Info
+- No new dead code candidates found in recently modified non-test files.
+- Reference evidence:
+  - `mapErrorTypeToStatusCode` is referenced by API routes:
+    - `app/api/v1/data/route.ts:26`
+    - `app/api/v1/explain/route.ts:24`
+  - Shared export retained in `lib/api/shared/index.ts:17`.
+
+## Potential Bugs Since Last Run
+- No concrete new bug signals found in the scoped commit diff.
+- No failing CI signal tied to post-run commits in this window.
+
+## Performance Regression Audit
+- No performance regression evidence found in the scoped commit.
+- Uncertainty: no fresh perf traces/benchmarks were added in this window.
+- If needed next run: compare `bun run bench:wasm` and chart render timings on a fixed dataset before/after commit SHA.
+
+## Notes
+- Workspace lint still reports pre-existing warnings in `components/charts/chart-empty.tsx` (unused import and parameter), but that file is outside this run's changed-file scope.


### PR DESCRIPTION
## Summary
- add the 2026-05-07 code-smell/dead-code review report for the since-last-run window
- add one documented command in CLAUDE/AGENTS for scoping files since a given timestamp

## Evidence
- scoped commit since prompt timestamp: `1af14f7c049952d69b699c83296d02162b1f4c50`
- no new critical/warning findings in changed-code scope

## Verification
- documentation-only change

## Summary by Sourcery

Document the latest code-smell/dead-code review run and add guidance for scoping scans to recent changes.

Documentation:
- Add the 2026-05-07 code-smell and dead-code review report covering changes since the last automation run.
- Document a git command in CLAUDE.md for generating a since-last-run file scope for smell scans.