### PR TITLE
ci(docker): extend arm64 build timeout

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -26,6 +26,10 @@ on:
       image-tag:
         type: string
         description: 'Custom Docker image tag override'
+      timeout-minutes:
+        type: number
+        description: 'Job timeout in minutes'
+        default: 60
 
     outputs:
       tags:
@@ -49,7 +53,7 @@ jobs:
   job:
     name: ${{ inputs.job-type }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       first_tag: ${{ steps.first_tag.outputs.tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
       clickhouse-versions: '["25.1"]'
       platforms: linux/arm64
       push-image: true
+      timeout-minutes: 120
 
   # Merge multi-arch manifests
   docker-manifest:


### PR DESCRIPTION
## Summary
- add a timeout override input to the reusable CI base workflow
- set the main arm64 Docker publish job to 120 minutes after the previous main run was cancelled at 60 minutes while still building

## Verification
- bun run check

Co-Authored-By: duyetbot <duyetbot@users.noreply.github.com>

## Summary by Sourcery

Make the reusable Docker CI workflow configurable for job timeouts and extend the arm64 Docker publish job timeout.

CI:
- Add a timeout-minutes input to the base reusable workflow and wire it to the job timeout configuration.
- Increase the main arm64 Docker publish job timeout to 120 minutes using the new configurable timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow timeout configuration to be configurable with a default 60-minute limit
  * Extended timeout for ARM64 Docker builds to 120 minutes to improve build reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->