### PR TITLE
feat(skills): enrich cluster-operations SKILL.md

### DIFF
--- a/.agents/skills/cluster-operations/SKILL.md
+++ b/.agents/skills/cluster-operations/SKILL.md
@@ -1,42 +1,54 @@
 ---
 name: cluster-operations
-description: "Distributed table management, resharding, node addition/removal, and cluster topology operations."
+description: "Cluster management: distributed tables, ON CLUSTER DDL, node lifecycle, resharding, load balancing, and Keeper migration."
 ---
 
 # Cluster Operations
 
-## When to use this skill
-Load when users ask about cluster management, distributed tables, or scaling.
-
 ## Distributed Tables
 - `CREATE TABLE dist ENGINE = Distributed(cluster, db, local_table, sharding_key)`
 - Sharding key: `rand()` for even distribution, `cityHash64(user_id)` for user affinity
-- Reads: query all shards in parallel
-- Writes: can route to correct shard or write locally
+- Reads: query all shards in parallel; Writes: route to correct shard or write locally
+
+## ON CLUSTER DDL
+- `ALTER TABLE t ON CLUSTER '{cluster}' ADD COLUMN col Type` — propagate schema to all replicas
+- `CREATE TABLE t ON CLUSTER '{cluster}' AS template_db.template_table` — clone across shards
+- `distributed_ddl_output_mode`: `throw` (fail on error), `null` (ignore), `none`, `active`
+- Check status: `SELECT * FROM system.distributed_ddl_queue`
+
+## Load Balancing and Read Routing
+- `load_balancing`: `random`, `in_order`, `first_or_random`, `nearest_hostname`
+- `max_replica_delay_for_distributed_queries` — skip lagging replicas
+- `fallback_to_stale_replicas_for_distributed_queries=1` — use stale when all delayed
 
 ## Adding Nodes
 1. Install ClickHouse on new node
 2. Configure Keeper/ZooKeeper connection
 3. Update cluster config (`remote_servers`) on all nodes
 4. Create local tables on new node
-5. For ReplicatedMergeTree: data syncs automatically
-6. For non-replicated: manually copy data or re-insert
+5. ReplicatedMergeTree: data syncs automatically; non-replicated: copy or re-insert
 
 ## Removing Nodes
-1. Stop writes to the node
-2. Wait for replication queue to drain
-3. `SYSTEM DROP REPLICA` for replicated tables
-4. Remove from cluster config
-5. Restart remaining nodes to pick up config
+1. Stop writes, wait for replication queue to drain
+2. `SYSTEM DROP REPLICA` for replicated tables
+3. Remove from cluster config, restart remaining nodes
 
 ## Resharding
-- ClickHouse doesn't support online resharding natively
-- Strategy: create new distributed table with new sharding scheme
-- Use `INSERT INTO new_dist SELECT * FROM old_dist` to migrate
-- Or use `clickhouse-copier` for large-scale migrations
+- No native online resharding — create new distributed table with new sharding scheme
+- `INSERT INTO new_dist SELECT * FROM old_dist` or `clickhouse-copier` for large migrations
+
+## Cluster Recovery
+- `SYSTEM RESTART REPLICA ON CLUSTER '{cluster}'` — restart replication across all nodes
+- `SYSTEM SYNC REPLICA ON CLUSTER '{cluster}'` — force sync from ZooKeeper
+- `SYSTEM FETCH PARTS ON CLUSTER '{cluster}'` — pull missing parts from other replicas
 
 ## Monitoring Clusters
-- `system.clusters` — topology view
-- `system.distributed_ddl_queue` — DDL operation status
-- `system.replicas` — per-table replication status
+- `system.clusters` — topology; `system.distributed_ddl_queue` — DDL status; `system.replicas` — replication
 - Cross-shard queries: use Distributed table or `remote()` function
+
+## Keeper Migration (ZooKeeper to ClickHouse Keeper)
+1. Deploy ClickHouse Keeper alongside ZooKeeper
+2. Snapshot data: `clickhouse-keeper-converter` or `zk-dump.sh`
+3. Configure Keeper with converted snapshot
+4. Update `zookeeper` config, restart one node at a time
+5. Verify replication recovers, then remove ZooKeeper


### PR DESCRIPTION
## Summary
- Add ON CLUSTER DDL syntax (`ALTER TABLE`, `CREATE TABLE ... AS`) and `distributed_ddl_output_mode` settings
- Add load balancing settings (`load_balancing`, `max_replica_delay_for_distributed_queries`, `fallback_to_stale_replicas`)
- Add cluster recovery commands (`SYSTEM RESTART/SYNC/FETCH REPLICA ON CLUSTER`)
- Add Keeper migration checklist (ZooKeeper to ClickHouse Keeper)
- Remove "When to use this skill" section per format standardization
- Update frontmatter description to cover all new topics

## Test plan
- [x] Unit tests pass (`bun test` — 1296 pass, 0 fail)
- [x] Markdown well-formed (no lint issues)
- [x] No "When to use this skill" section present
- [x] Frontmatter description is quoted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the cluster-operations skill documentation to cover broader cluster management topics, including ON CLUSTER DDL, load balancing, cluster recovery, and Keeper migration.

Documentation:
- Document ON CLUSTER DDL usage and related distributed_ddl_output_mode settings for cluster-wide schema changes.
- Document load balancing and read routing settings for distributed queries, including replica delay handling and stale replica fallback.
- Add guidance for cluster recovery operations using SYSTEM RESTART/SYNC/FETCH REPLICA ON CLUSTER commands.
- Add a Keeper migration checklist for transitioning from ZooKeeper to ClickHouse Keeper.
- Revise and condense existing cluster operations guidance (adding/removing nodes, resharding, monitoring) and remove the non-standard 'When to use this skill' section.
- Expand the frontmatter description to reflect the full scope of cluster operations covered by the skill.