### PR TITLE
fix(skills): standardize format for 3 remaining skills

### DIFF
--- a/.agents/skills/replication-guide/SKILL.md
+++ b/.agents/skills/replication-guide/SKILL.md
@@ -5,9 +5,6 @@ description: "ReplicatedMergeTree operations, failover procedures, lag diagnosis
 
 # Replication Guide
 
-## When to use this skill
-Load when users ask about replication setup, lag, failover, or Keeper/ZooKeeper.
-
 ## ReplicatedMergeTree Basics
 - Engine: `ReplicatedMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}')`
 - Requires ZooKeeper or ClickHouse Keeper
@@ -28,6 +25,7 @@ Load when users ask about replication setup, lag, failover, or Keeper/ZooKeeper.
 2. Verify Keeper connectivity: `SELECT * FROM system.zookeeper WHERE path = '/'`
 3. If replica is readonly due to Keeper disconnect, it auto-recovers when connection restores
 4. For permanent failures: `SYSTEM DROP REPLICA 'replica_name' FROM TABLE db.table`
+5. Corrupted metadata: `SYSTEM RESTORE REPLICA db.table`
 
 ## Quorum Writes
 - `SET insert_quorum = 2` — wait for N replicas to confirm
@@ -46,3 +44,4 @@ Load when users ask about replication setup, lag, failover, or Keeper/ZooKeeper.
 - **Readonly replica**: Lost Keeper session — check network, Keeper logs
 - **Queue buildup**: Slow fetches — check network bandwidth, disk I/O
 - **Diverged replicas**: `SYSTEM SYNC REPLICA db.table` to force sync
+- Load the `troubleshooting` skill for OOM-related replica failures and disk-full scenarios.

--- a/.agents/skills/security-hardening/SKILL.md
+++ b/.agents/skills/security-hardening/SKILL.md
@@ -5,15 +5,14 @@ description: "RBAC configuration, row policies, quotas, network security, audit 
 
 # Security Hardening
 
-## When to use this skill
-Load when users ask about access control, security, auditing, or user management.
-
 ## RBAC (Role-Based Access Control)
 - Create roles: `CREATE ROLE analyst`
 - Grant permissions: `GRANT SELECT ON db.* TO analyst`
 - Assign to users: `GRANT analyst TO user1`
 - Hierarchical: roles can inherit from other roles
 - Check grants: `SHOW GRANTS FOR user1`
+- Inspect user: `SHOW CREATE USER username`
+- Password rotation: `ALTER USER username IDENTIFIED BY 'new_password'`
 
 ## Row Policies
 - Restrict row access per user: `CREATE ROW POLICY p ON db.table FOR SELECT USING tenant_id = currentUser()`

--- a/.agents/skills/storage-optimization/SKILL.md
+++ b/.agents/skills/storage-optimization/SKILL.md
@@ -5,9 +5,6 @@ description: "Compression codecs, TTL policies, tiered storage, part management,
 
 # Storage Optimization
 
-## When to use this skill
-Load when users ask about disk usage, compression, TTL, or storage tiers.
-
 ## Compression Codecs
 - Default: LZ4 — fast, moderate compression
 - `ZSTD(level)` — better compression, slower. Level 1-22 (3 is good default)
@@ -16,6 +13,7 @@ Load when users ask about disk usage, compression, TTL, or storage tiers.
 - `Gorilla` — optimized for floating-point gauge metrics
 - `T64` — for integer columns with small range
 - Per-column: `ALTER TABLE t MODIFY COLUMN col TYPE UInt32 CODEC(Delta, ZSTD(3))`
+- In-place codec change: `ALTER TABLE t MODIFY COLUMN col CODEC(Delta, ZSTD(3))`
 
 ## TTL Policies
 - Table-level: `ALTER TABLE t MODIFY TTL event_time + INTERVAL 90 DAY`
@@ -34,7 +32,6 @@ Load when users ask about disk usage, compression, TTL, or storage tiers.
 ## Part Management
 - Monitor part count: `SELECT count() FROM system.parts WHERE active AND database = 'db' AND table = 't'`
 - Too many parts (>300 per partition) = degraded performance
-- Force merge: `OPTIMIZE TABLE t FINAL` (expensive)
 - Detached parts: check `system.detached_parts`, clean with `DROP DETACHED PART`
 - Part size target: 1-10GB per part for optimal performance
 
@@ -43,3 +40,4 @@ Load when users ask about disk usage, compression, TTL, or storage tiers.
 - `TRUNCATE TABLE` for full table cleanup
 - Check for orphaned data: detached parts, temporary files
 - System tables can grow large — set TTL on query_log, trace_log, etc.
+- Load the `troubleshooting` skill for disk-full recovery procedures.


### PR DESCRIPTION
## Summary
- Remove "When to use this skill" sections from storage-optimization, security-hardening, and replication-guide skills
- Ensure all frontmatter descriptions are quoted per format standard
- Add targeted content: in-place codec changes, user inspection/password rotation, SYSTEM RESTORE REPLICA
- Remove redundant `OPTIMIZE TABLE t FINAL` from storage-optimization (covered by troubleshooting skill)
- Add cross-references to `troubleshooting` skill in storage-optimization and replication-guide

## Test plan
- [x] Verified all 3 files have quoted descriptions
- [x] Verified no "When to use this skill" headers remain
- [x] Verified cross-references name valid skills (`troubleshooting` exists)
- [x] `bun test` passes (1296 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Standardize formatting and content across the storage-optimization, replication-guide, and security-hardening skills.

New Features:
- Document in-place compression codec changes in the storage-optimization skill.
- Add guidance for inspecting users and rotating passwords in the security-hardening skill.
- Document SYSTEM RESTORE REPLICA usage for corrupted metadata in the replication-guide skill.
- Add cross-references from storage-optimization and replication-guide skills to the troubleshooting skill for related recovery scenarios.

Enhancements:
- Remove redundant and obsolete guidance, including the generic "When to use this skill" sections and an OPTIMIZE TABLE example now covered elsewhere.
- Ensure skill frontmatter descriptions follow the quoted format standard.