### PR TITLE
fix(skills): add missing export and strip quotes from descriptions in skills registry

### DIFF
--- a/lib/ai/agent/skills/registry.ts
+++ b/lib/ai/agent/skills/registry.ts
@@ -11,7 +11,7 @@ export const SKILLS: readonly Skill[] = [
   {
     name: 'replication-guide',
     description:
-      '"ReplicatedMergeTree operations, failover procedures, lag diagnosis, quorum writes, and Keeper management."',
+      'ReplicatedMergeTree operations, failover procedures, lag diagnosis, quorum writes, and Keeper management.',
     content: `# Replication Guide
 
 ## When to use this skill
@@ -59,7 +59,7 @@ Load when users ask about replication setup, lag, failover, or Keeper/ZooKeeper.
   {
     name: 'query-optimization',
     description:
-      '"Query optimization strategies: PREWHERE, JOIN patterns, materialized views, EXPLAIN analysis, index usage, and query profiling."',
+      'Query optimization strategies: PREWHERE, JOIN patterns, materialized views, EXPLAIN analysis, index usage, and query profiling.',
     content: `# Query Optimization
 
 ## When to use this skill
@@ -118,7 +118,7 @@ Load when users ask about slow queries, optimization strategies, or query perfor
   {
     name: 'cluster-operations',
     description:
-      '"Distributed table management, resharding, node addition/removal, and cluster topology operations."',
+      'Distributed table management, resharding, node addition/removal, and cluster topology operations.',
     content: `# Cluster Operations
 
 ## When to use this skill
@@ -160,7 +160,7 @@ Load when users ask about cluster management, distributed tables, or scaling.
   {
     name: 'troubleshooting',
     description:
-      '"Diagnose and resolve common ClickHouse issues: OOM, slow merges, replication lag, disk full, stuck mutations, and query failures."',
+      'Diagnose and resolve common ClickHouse issues: OOM, slow merges, replication lag, disk full, stuck mutations, and query failures.',
     content: `# Troubleshooting Guide
 
 ## When to use this skill
@@ -246,7 +246,7 @@ Load when users report errors, performance issues, or system problems.
   {
     name: 'security-hardening',
     description:
-      '"RBAC configuration, row policies, quotas, network security, audit logging, and access control best practices."',
+      'RBAC configuration, row policies, quotas, network security, audit logging, and access control best practices.',
     content: `# Security Hardening
 
 ## When to use this skill
@@ -294,7 +294,7 @@ Load when users ask about access control, security, auditing, or user management
   {
     name: 'migration-patterns',
     description:
-      '"Schema migrations, ALTER patterns, engine changes, data backfill, and zero-downtime migration strategies."',
+      'Schema migrations, ALTER patterns, engine changes, data backfill, and zero-downtime migration strategies.',
     content: `# Migration Patterns
 
 ## When to use this skill
@@ -344,7 +344,7 @@ RENAME TABLE t_old TO t_backup, t_new TO t_old;
   {
     name: 'storage-optimization',
     description:
-      '"Compression codecs, TTL policies, tiered storage, part management, and disk space optimization."',
+      'Compression codecs, TTL policies, tiered storage, part management, and disk space optimization.',
     content: `# Storage Optimization
 
 ## When to use this skill

--- a/scripts/build-skills-registry.ts
+++ b/scripts/build-skills-registry.ts
@@ -35,7 +35,7 @@ function parseFrontmatter(raw: string): {
 
   return {
     name: nameMatch[1].trim(),
-    description: descMatch[1].trim(),
+    description: descMatch[1].trim().replace(/^["']|["']$/g, ''),
     body,
   }
 }
@@ -98,7 +98,7 @@ async function main() {
 
 import type { Skill } from './types'
 
-const SKILLS: readonly Skill[] = [
+export const SKILLS: readonly Skill[] = [
 ${skillEntries}
 ]
 


### PR DESCRIPTION
## Summary
- Add missing `export` keyword to `SKILLS` constant in the generated registry template (`scripts/build-skills-registry.ts`), so `dynamic-loader.ts` can import it
- Strip surrounding quotes from YAML `description` values captured by the frontmatter regex, fixing 7 of 8 skills that had embedded quotes

## Test plan
- [x] `bun run build:skills` regenerates registry with correct output
- [x] `grep 'export const SKILLS' lib/ai/agent/skills/registry.ts` confirms export
- [x] Descriptions verified clean (no embedded quote marks)
- [x] `bun test` passes (1296 tests, 0 failures)
- [x] Pre-commit hooks pass (Biome lint + TypeScript type-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix skills registry generation so skills are correctly exported and descriptions no longer include extraneous quote characters.

Bug Fixes:
- Strip surrounding quote characters from parsed skill descriptions when building the skills registry.
- Export the generated SKILLS constant from the skills registry template so it can be imported by consumers.