### PR TITLE
feat(skills): enrich migration-patterns SKILL.md

### DIFF
--- a/.agents/skills/migration-patterns/SKILL.md
+++ b/.agents/skills/migration-patterns/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: migration-patterns
-description: "Schema migrations, ALTER patterns, engine changes, data backfill, and zero-downtime migration strategies."
+description: "Schema migrations: ALTER patterns, engine changes, zero-downtime swaps, clickhouse-local offline migrations, and lightweight UPDATE/DELETE strategies."
 ---
 
 # Migration Patterns
-
-## When to use this skill
-Load when users ask about schema changes, migrations, or engine upgrades.
 
 ## ALTER TABLE Operations
 - Add column: `ALTER TABLE t ADD COLUMN col Type [DEFAULT expr] [AFTER existing_col]`
@@ -24,6 +21,11 @@ RENAME TABLE t_old TO t_backup, t_new TO t_old;
 ```
 - For large tables: use `INSERT INTO ... SELECT` with batching
 
+## EXCHANGE TABLES (v22.5+)
+- Atomic swap without RENAME chain: `EXCHANGE TABLES t_old AND t_new`
+- Simpler and safer than `RENAME TABLE t_old TO t_backup, t_new TO t_old`
+- Both tables must exist and be in the same database
+
 ## Zero-Downtime Migrations
 1. Create new table with desired schema
 2. Create materialized view to capture new inserts: `CREATE MATERIALIZED VIEW mv TO t_new AS SELECT ... FROM t_old`
@@ -38,6 +40,33 @@ RENAME TABLE t_old TO t_backup, t_new TO t_old;
 - Monitor with `system.processes` and `system.merges`
 - Verify row counts match after backfill
 
+## Lightweight Mutations
+- `ALTER TABLE t UPDATE col = expr WHERE condition` — async by default (`mutations_sync = 0`)
+- Track progress: `SELECT * FROM system.mutations WHERE table = 't'`
+- `ALTER TABLE t DELETE WHERE condition` — rewrites affected parts
+- Throttle impact: set `max_rows_per_mutation` to limit rows per mutation batch
+- Always schedule heavy mutations off-peak; monitor `system.mutations` for completion
+
+## Cross-Server Migration
+- Use `remote()` table function to copy between servers:
+```sql
+INSERT INTO local_db.t SELECT * FROM remote('source_host:9000', 'db', 't', 'user', 'pass')
+```
+- For large tables, batch by partition or use `clickhouse-local` offline approach
+
+## clickhouse-local Offline Migrations
+- Run migrations without a running server: `clickhouse-local --file migration.sql`
+- Useful for schema changes on cold data or CI/CD validation
+- Can operate directly on data files: `clickhouse-local -S 'col1 Type1, col2 Type2' --input-format Native < data.bin`
+
+## Schema Migration Versioning
+- Track applied migrations with a dedicated table:
+```sql
+CREATE TABLE _schema_migrations (name String, applied_at DateTime DEFAULT now()) ENGINE = TinyLog;
+```
+- Insert a row after each successful migration; check before applying
+- Integrate with deployment scripts for idempotent migration runs
+
 ## Partition Operations
 - `ALTER TABLE t ATTACH PARTITION id FROM other_table` — zero-copy if same structure
 - `ALTER TABLE t REPLACE PARTITION id FROM other_table` — atomic swap
@@ -48,3 +77,4 @@ RENAME TABLE t_old TO t_backup, t_new TO t_old;
 - Changing ORDER BY requires table recreation
 - Mutations (UPDATE/DELETE) rewrite all parts — schedule off-peak
 - Test migrations on staging with production data volumes
+- `EXCHANGE TABLES` fails if either table is replicated with different replica paths


### PR DESCRIPTION
## Summary
- Add 6 new sections: EXCHANGE TABLES (v22.5+), Lightweight Mutations, Cross-Server Migration, clickhouse-local Offline Migrations, Schema Migration Versioning, and replicated table pitfall
- Remove "When to use this skill" section per format standardization
- Update frontmatter description to reflect expanded scope

## Test plan
- [ ] Verify markdown is well-formed (no broken syntax)
- [ ] Verify no "When to use this skill" header remains
- [ ] Verify frontmatter description is quoted
- [x] Unit tests pass (1296/1296)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Broaden the migration-patterns SKILL.md description and content to include EXCHANGE TABLES, lightweight mutations, cross-server and clickhouse-local offline migrations, schema versioning, and replicated table pitfalls while aligning with current skill formatting standards.