### PR TITLE
feat: add SVG favicon

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F7DF1E"/>
+      <stop offset="100%" stop-color="#E6B800"/>
+    </linearGradient>
+  </defs>
+  <!-- Database cylinder body -->
+  <path d="M12 20 C12 16 16 14 32 14 C48 14 52 16 52 20 L52 44 C52 48 48 50 32 50 C16 50 12 48 12 44 Z" fill="#1A1A2E" stroke="#F7DF1E" stroke-width="2.5"/>
+  <!-- Cylinder ellipses -->
+  <ellipse cx="32" cy="20" rx="20" ry="6" fill="url(#g)" opacity="0.15"/>
+  <ellipse cx="32" cy="44" rx="20" ry="6" fill="url(#g)" opacity="0.1"/>
+  <!-- Monitor/gauge overlay -->
+  <circle cx="32" cy="32" r="8" fill="none" stroke="#F7DF1E" stroke-width="1.8"/>
+  <path d="M32 26 L32 32 L37 35" fill="none" stroke="#F7DF1E" stroke-width="1.8" stroke-linecap="round"/>
+  <circle cx="32" cy="32" r="1.5" fill="#F7DF1E"/>
+  <!-- Bottom highlight -->
+  <ellipse cx="32" cy="44" rx="14" ry="3" fill="url(#g)" opacity="0.08"/>
+</svg>


### PR DESCRIPTION
## Summary

Add an SVG favicon to the application with a database cylinder icon featuring a gauge overlay, styled in the app's yellow-on-dark color scheme.

Next.js 15 auto-detects `app/icon.svg` — no manual link tag needed.

## Summary by Sourcery

Enhancements:
- Introduce an SVG favicon matching the app’s visual style for use as the site icon.