### PR TITLE
fix(agent): require bearer auth for agent API

### DIFF
--- a/app/api/v1/agent/__tests__/route.test.ts
+++ b/app/api/v1/agent/__tests__/route.test.ts
@@ -64,10 +64,11 @@ describe('POST /api/v1/agent', () => {
   let POST: (request: Request) => Promise<Response>
 
   beforeAll(async () => {
+    process.env.AGENT_API_TOKEN = AGENT_API_TOKEN
+
     // Import after mocks are set up
     const route = await import('../route')
     POST = route.POST
-    process.env.AGENT_API_TOKEN = AGENT_API_TOKEN
   })
 
   describe('UIMessage format handling', () => {

--- a/app/api/v1/agent/__tests__/route.test.ts
+++ b/app/api/v1/agent/__tests__/route.test.ts
@@ -48,6 +48,18 @@ mock.module('ai', () => ({
 }))
 
 describe('POST /api/v1/agent', () => {
+  const AGENT_API_TOKEN = 'test-agent-token'
+
+  const createAgentRequest = (init: RequestInit) => {
+    const headers = new Headers(init.headers)
+    headers.set('authorization', `Bearer ${AGENT_API_TOKEN}`)
+
+    return new Request('http://localhost:3000/api/v1/agent', {
+      ...init,
+      headers,
+    })
+  }
+
   // We need to dynamically import the route handler after mocking
   let POST: (request: Request) => Promise<Response>
 
@@ -55,11 +67,12 @@ describe('POST /api/v1/agent', () => {
     // Import after mocks are set up
     const route = await import('../route')
     POST = route.POST
+    process.env.AGENT_API_TOKEN = AGENT_API_TOKEN
   })
 
   describe('UIMessage format handling', () => {
     test('accepts UIMessage format with id and parts', async () => {
-      const request = new Request('http://localhost:3000/api/v1/agent', {
+      const request = createAgentRequest({
         method: 'POST',
         body: JSON.stringify({
           messages: [
@@ -82,7 +95,7 @@ describe('POST /api/v1/agent', () => {
     })
 
     test('accepts backward compatible message format', async () => {
-      const request = new Request('http://localhost:3000/api/v1/agent', {
+      const request = createAgentRequest({
         method: 'POST',
         body: JSON.stringify({
           message: 'Show me all databases',
@@ -96,7 +109,7 @@ describe('POST /api/v1/agent', () => {
     })
 
     test('handles both message and messages formats', async () => {
-      const request = new Request('http://localhost:3000/api/v1/agent', {
+      const request = createAgentRequest({
         method: 'POST',
         body: JSON.stringify({
           message: 'Test',
@@ -118,8 +131,23 @@ describe('POST /api/v1/agent', () => {
   })
 
   describe('validation', () => {
-    test('returns 400 when message is missing', async () => {
+    test('returns 401 when Authorization header is missing', async () => {
       const request = new Request('http://localhost:3000/api/v1/agent', {
+        method: 'POST',
+        body: JSON.stringify({
+          message: 'Show me all databases',
+          hostId: 0,
+        }),
+      })
+
+      const response = await POST(request)
+
+      expect(response.status).toBe(401)
+      expect(response.headers.get('www-authenticate')).toBe('Bearer')
+    })
+
+    test('returns 400 when message is missing', async () => {
+      const request = createAgentRequest({
         method: 'POST',
         body: JSON.stringify({
           messages: [],
@@ -135,7 +163,7 @@ describe('POST /api/v1/agent', () => {
     })
 
     test('returns 400 when message is not a string', async () => {
-      const request = new Request('http://localhost:3000/api/v1/agent', {
+      const request = createAgentRequest({
         method: 'POST',
         body: JSON.stringify({
           message: 123,
@@ -151,7 +179,7 @@ describe('POST /api/v1/agent', () => {
     })
 
     test('returns 400 when message is empty string', async () => {
-      const request = new Request('http://localhost:3000/api/v1/agent', {
+      const request = createAgentRequest({
         method: 'POST',
         body: JSON.stringify({
           message: '   ',
@@ -167,7 +195,7 @@ describe('POST /api/v1/agent', () => {
 
   describe('hostId handling', () => {
     test('uses provided hostId', async () => {
-      const request = new Request('http://localhost:3000/api/v1/agent', {
+      const request = createAgentRequest({
         method: 'POST',
         body: JSON.stringify({
           message: 'Test',
@@ -181,7 +209,7 @@ describe('POST /api/v1/agent', () => {
     })
 
     test('defaults to hostId 0 when not provided', async () => {
-      const request = new Request('http://localhost:3000/api/v1/agent', {
+      const request = createAgentRequest({
         method: 'POST',
         body: JSON.stringify({
           message: 'Test',
@@ -194,7 +222,7 @@ describe('POST /api/v1/agent', () => {
     })
 
     test('handles non-number hostId by defaulting to 0', async () => {
-      const request = new Request('http://localhost:3000/api/v1/agent', {
+      const request = createAgentRequest({
         method: 'POST',
         body: JSON.stringify({
           message: 'Test',
@@ -210,7 +238,7 @@ describe('POST /api/v1/agent', () => {
 
   describe('model configuration', () => {
     test('passes model to agent factory', async () => {
-      const request = new Request('http://localhost:3000/api/v1/agent', {
+      const request = createAgentRequest({
         method: 'POST',
         body: JSON.stringify({
           message: 'Test',
@@ -227,7 +255,7 @@ describe('POST /api/v1/agent', () => {
 
   describe('response format', () => {
     test('returns SSE stream with correct headers', async () => {
-      const request = new Request('http://localhost:3000/api/v1/agent', {
+      const request = createAgentRequest({
         method: 'POST',
         body: JSON.stringify({
           messages: [
@@ -251,7 +279,7 @@ describe('POST /api/v1/agent', () => {
     })
 
     test('returns JSON error response for validation failures', async () => {
-      const request = new Request('http://localhost:3000/api/v1/agent', {
+      const request = createAgentRequest({
         method: 'POST',
         body: JSON.stringify({
           message: '',
@@ -267,7 +295,7 @@ describe('POST /api/v1/agent', () => {
 
   describe('error handling', () => {
     test('handles malformed JSON', async () => {
-      const request = new Request('http://localhost:3000/api/v1/agent', {
+      const request = createAgentRequest({
         method: 'POST',
         body: 'invalid json',
       })
@@ -279,7 +307,7 @@ describe('POST /api/v1/agent', () => {
 
   describe('UIMessage parts extraction', () => {
     test('extracts text from parts array', async () => {
-      const request = new Request('http://localhost:3000/api/v1/agent', {
+      const request = createAgentRequest({
         method: 'POST',
         body: JSON.stringify({
           messages: [
@@ -302,7 +330,7 @@ describe('POST /api/v1/agent', () => {
     })
 
     test('handles missing text part in parts array', async () => {
-      const request = new Request('http://localhost:3000/api/v1/agent', {
+      const request = createAgentRequest({
         method: 'POST',
         body: JSON.stringify({
           messages: [

--- a/app/api/v1/agent/__tests__/route.test.ts
+++ b/app/api/v1/agent/__tests__/route.test.ts
@@ -146,6 +146,21 @@ describe('POST /api/v1/agent', () => {
       expect(response.headers.get('www-authenticate')).toBe('Bearer')
     })
 
+    test('accepts lowercase bearer token scheme', async () => {
+      const request = new Request('http://localhost:3000/api/v1/agent', {
+        method: 'POST',
+        headers: { authorization: 'bearer test-agent-token' },
+        body: JSON.stringify({
+          message: 'Show me all databases',
+          hostId: 0,
+        }),
+      })
+
+      const response = await POST(request)
+
+      expect(response.status).toBe(200)
+    })
+
     test('returns 400 when message is missing', async () => {
       const request = createAgentRequest({
         method: 'POST',

--- a/app/api/v1/agent/route.ts
+++ b/app/api/v1/agent/route.ts
@@ -24,6 +24,11 @@ export const dynamic = 'force-dynamic'
 
 const AGENT_DEBUG_LOGS = process.env.NODE_ENV !== 'production'
 
+/**
+ * Validate the request's Authorization header against `AGENT_API_TOKEN` using a
+ * constant-time comparison. Returns `false` when env token, scheme, or token
+ * format is missing or mismatched.
+ */
 function isAuthorized(request: Request): boolean {
   const expectedToken = process.env.AGENT_API_TOKEN
   if (!expectedToken) {
@@ -31,11 +36,16 @@ function isAuthorized(request: Request): boolean {
   }
 
   const authHeader = request.headers.get('authorization')
-  if (!authHeader?.startsWith('Bearer ')) {
+  const parts = authHeader?.split(/\s+/)
+  if (
+    !parts ||
+    parts.length < 2 ||
+    parts[0]?.toLowerCase() !== 'bearer'
+  ) {
     return false
   }
 
-  const providedToken = authHeader.slice('Bearer '.length)
+  const providedToken = parts.slice(1).join(' ')
   const expectedBuffer = Buffer.from(expectedToken, 'utf8')
   const providedBuffer = Buffer.from(providedToken, 'utf8')
 

--- a/app/api/v1/agent/route.ts
+++ b/app/api/v1/agent/route.ts
@@ -12,6 +12,7 @@
  */
 
 import type { LanguageModelUsage } from 'ai'
+import { timingSafeEqual } from 'node:crypto'
 
 import { createAgentUIStreamResponse } from 'ai'
 import { createClickHouseAgent } from '@/lib/ai/agent'
@@ -23,10 +24,47 @@ export const dynamic = 'force-dynamic'
 
 const AGENT_DEBUG_LOGS = process.env.NODE_ENV !== 'production'
 
+function isAuthorized(request: Request): boolean {
+  const expectedToken = process.env.AGENT_API_TOKEN
+  if (!expectedToken) {
+    return false
+  }
+
+  const authHeader = request.headers.get('authorization')
+  if (!authHeader?.startsWith('Bearer ')) {
+    return false
+  }
+
+  const providedToken = authHeader.slice('Bearer '.length)
+  const expectedBuffer = Buffer.from(expectedToken, 'utf8')
+  const providedBuffer = Buffer.from(providedToken, 'utf8')
+
+  if (expectedBuffer.length !== providedBuffer.length) {
+    return false
+  }
+
+  return timingSafeEqual(expectedBuffer, providedBuffer)
+}
+
 /**
  * Handle POST requests for agent processing with streaming
  */
 export async function POST(request: Request) {
+  if (!isAuthorized(request)) {
+    return new Response(
+      JSON.stringify({
+        error: { message: 'Unauthorized' },
+      }),
+      {
+        status: 401,
+        headers: {
+          'content-type': 'application/json',
+          'www-authenticate': 'Bearer',
+        },
+      }
+    )
+  }
+
   // Parse request body
   const body = (await request.json()) as {
     message?: string

--- a/app/api/v1/agent/route.ts
+++ b/app/api/v1/agent/route.ts
@@ -12,7 +12,7 @@
  */
 
 import type { LanguageModelUsage } from 'ai'
-import { timingSafeEqual } from 'node:crypto'
+import { createHash, timingSafeEqual } from 'node:crypto'
 
 import { createAgentUIStreamResponse } from 'ai'
 import { createClickHouseAgent } from '@/lib/ai/agent'
@@ -23,15 +23,23 @@ import { classifyError } from '@/lib/ai/agent/errors'
 export const dynamic = 'force-dynamic'
 
 const AGENT_DEBUG_LOGS = process.env.NODE_ENV !== 'production'
+const EXPECTED_TOKEN_HASH = process.env.AGENT_API_TOKEN
+  ? createHash('sha256').update(process.env.AGENT_API_TOKEN).digest()
+  : null
 
 /**
- * Validate the request's Authorization header against `AGENT_API_TOKEN` using a
- * constant-time comparison. Returns `false` when env token, scheme, or token
- * format is missing or mismatched.
+ * Validate the request's Authorization header against `AGENT_API_TOKEN`.
+ *
+ * @param request - Incoming HTTP request containing an Authorization header.
+ * @returns `true` when `request` contains a valid Bearer token matching
+ * `AGENT_API_TOKEN`, otherwise `false`.
+ *
+ * Uses SHA-256 + `timingSafeEqual` to keep response timing consistent for
+ * token comparisons and avoid leaking raw token length differences.
+ * Returns `false` when the token is missing, malformed, or mismatched.
  */
 function isAuthorized(request: Request): boolean {
-  const expectedToken = process.env.AGENT_API_TOKEN
-  if (!expectedToken) {
+  if (!EXPECTED_TOKEN_HASH) {
     return false
   }
 
@@ -46,14 +54,11 @@ function isAuthorized(request: Request): boolean {
   }
 
   const providedToken = parts.slice(1).join(' ')
-  const expectedBuffer = Buffer.from(expectedToken, 'utf8')
-  const providedBuffer = Buffer.from(providedToken, 'utf8')
+  const providedTokenHash = createHash('sha256')
+    .update(providedToken)
+    .digest()
 
-  if (expectedBuffer.length !== providedBuffer.length) {
-    return false
-  }
-
-  return timingSafeEqual(expectedBuffer, providedBuffer)
+  return timingSafeEqual(EXPECTED_TOKEN_HASH, providedTokenHash)
 }
 
 /**

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -33,6 +33,8 @@ export default defineConfig({
 
       // The config object must be returned for Cypress to pick up
       // any changed environment variables
+      config.env ??= {}
+      config.env.AGENT_API_TOKEN = process.env.AGENT_API_TOKEN ?? ''
       return config
     },
   },

--- a/cypress/e2e/agent-api.cy.ts
+++ b/cypress/e2e/agent-api.cy.ts
@@ -190,22 +190,19 @@ describe('Agent Chat API E2E Tests', () => {
     cy.request({
       url: AGENT_API_URL,
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: getAuthHeaders(),
       body: {
         hostId: 0,
       },
       failOnStatusCode: false,
     }).then((response) => {
-      if (hasAgentApiToken) {
-        expect(response.status).to.eq(400)
-      } else {
-        expect(response.status).to.eq(401)
-      }
+      expectAuthAwareStatus(response.status)
       expect(response.body).to.have.property('error')
       expect(response.body.error).to.have.property('message')
-      expect(response.body.error.message).to.include('Message is required')
+
+      if (response.status === 400) {
+        expect(response.body.error.message).to.include('Message is required')
+      }
     })
   })
 

--- a/cypress/e2e/agent-api.cy.ts
+++ b/cypress/e2e/agent-api.cy.ts
@@ -5,6 +5,30 @@
 
 describe('Agent Chat API E2E Tests', () => {
   const AGENT_API_URL = '/api/v1/agent'
+  const AGENT_API_TOKEN = Cypress.env('AGENT_API_TOKEN')
+  const hasAgentApiToken = Boolean(AGENT_API_TOKEN)
+
+  const getAuthHeaders = () => {
+    if (!hasAgentApiToken) {
+      return {
+        'Content-Type': 'application/json',
+      }
+    }
+
+    return {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${AGENT_API_TOKEN}`,
+    }
+  }
+
+  const expectAuthAwareStatus = (status: number) => {
+    if (hasAgentApiToken) {
+      expect(status).to.not.eq(400)
+      return
+    }
+
+    expect(status).to.eq(401)
+  }
 
   /**
    * Test: Basic message format validation
@@ -16,9 +40,7 @@ describe('Agent Chat API E2E Tests', () => {
     cy.request({
       url: AGENT_API_URL,
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: getAuthHeaders(),
       body: {
         message: testMessage,
         hostId: 0,
@@ -26,9 +48,7 @@ describe('Agent Chat API E2E Tests', () => {
       // Don't fail on 4xx/5xx - we want to assert on response
       failOnStatusCode: false,
     }).then((response) => {
-      // Response should be successful (or at least not a 400 format error)
-      // Note: If LLM is not configured, we might get a 500, but NOT a 400 format error
-      expect(response.status).to.not.eq(400)
+      expectAuthAwareStatus(response.status)
 
       // If we get a success response, validate headers
       if (response.status === 200) {
@@ -61,9 +81,7 @@ describe('Agent Chat API E2E Tests', () => {
     cy.request({
       url: AGENT_API_URL,
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: getAuthHeaders(),
       body: {
         messages: [
           {
@@ -82,7 +100,7 @@ describe('Agent Chat API E2E Tests', () => {
       failOnStatusCode: false,
     }).then((response) => {
       // Should not get 400 format error
-      expect(response.status).to.not.eq(400)
+      expectAuthAwareStatus(response.status)
 
       // Validate no format-specific errors
       if (response.body?.error) {
@@ -105,9 +123,7 @@ describe('Agent Chat API E2E Tests', () => {
     cy.request({
       url: AGENT_API_URL,
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: getAuthHeaders(),
       body: {
         messages: [
           {
@@ -131,7 +147,7 @@ describe('Agent Chat API E2E Tests', () => {
       failOnStatusCode: false,
     }).then((response) => {
       // Should not get 400 format error
-      expect(response.status).to.not.eq(400)
+      expectAuthAwareStatus(response.status)
 
       // Validate no format-specific errors
       if (response.body?.error) {
@@ -150,9 +166,7 @@ describe('Agent Chat API E2E Tests', () => {
     cy.request({
       url: AGENT_API_URL,
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: getAuthHeaders(),
       body: {
         messages: [
           {
@@ -165,7 +179,7 @@ describe('Agent Chat API E2E Tests', () => {
       failOnStatusCode: false,
     }).then((response) => {
       // Should not get 400 format error
-      expect(response.status).to.not.eq(400)
+      expectAuthAwareStatus(response.status)
     })
   })
 
@@ -184,7 +198,11 @@ describe('Agent Chat API E2E Tests', () => {
       },
       failOnStatusCode: false,
     }).then((response) => {
-      expect(response.status).to.eq(400)
+      if (hasAgentApiToken) {
+        expect(response.status).to.eq(400)
+      } else {
+        expect(response.status).to.eq(401)
+      }
       expect(response.body).to.have.property('error')
       expect(response.body.error).to.have.property('message')
       expect(response.body.error.message).to.include('Message is required')
@@ -206,12 +224,10 @@ describe('Agent Chat API E2E Tests', () => {
       cy.request({
         url: AGENT_API_URL,
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: {
-          message: 'test',
-          hostId: 0,
+      headers: getAuthHeaders(),
+      body: {
+        message: 'test',
+        hostId: 0,
         },
         failOnStatusCode: false,
       }).then((response) => {


### PR DESCRIPTION
### Motivation
- The agent API at `POST /api/v1/agent` could construct server-side ClickHouse tools (including read-only and destructive control tools) and was reachable without any in-route authentication, which makes it possible for a remote attacker to misuse server ClickHouse credentials.
- The change is a minimal remediation to prevent unauthorized creation and execution of the agent/tool graph while preserving the existing agent behavior for authorized callers.

### Description
- Added an `isAuthorized(request: Request)` gate in `app/api/v1/agent/route.ts` which requires a bearer token stored in the `AGENT_API_TOKEN` environment variable. 
- The implementation uses `timingSafeEqual` from `node:crypto` for constant-time token comparison to reduce timing side-channel risk. 
- The route now returns `401 Unauthorized` with `WWW-Authenticate: Bearer` when the bearer token is missing or invalid, and this check occurs before any agent creation or processing. 
- Changes are limited to `app/api/v1/agent/route.ts` and do not modify the agent/tool implementation or feature surface.

### Testing
- Attempted to run the repository build with `bun run build`, but the build failed in this environment due to missing `next` script errors (`error: Script not found "next"`), so a full automated build could not be completed here. 
- No unit or e2e test suites were runnable in this environment; automated tests were therefore not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00abd3eb308332b6c3919baaa2a70c)

## Summary by Sourcery

Require authenticated access to the v1 agent API endpoint to prevent unauthorized agent creation and execution.

Bug Fixes:
- Protect the POST /api/v1/agent endpoint with bearer token authentication backed by an AGENT_API_TOKEN environment variable.
- Return a 401 Unauthorized response with a WWW-Authenticate: Bearer header when requests lack a valid bearer token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent API now requires bearer-token authentication; unauthenticated requests receive 401 with authentication guidance.

* **Bug Fixes / Validation**
  * Improved input validation: missing, non-string, or empty messages return 400. Lowercase "bearer" scheme accepted.

* **Tests**
  * Updated unit and E2E tests to cover authentication, validation, streaming headers, and error responses.

* **Chores**
  * Test runner configured to propagate the agent token into test environment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1066)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->