### PR TITLE
fix(auth): enforce Clerk auth on actions API

### DIFF
--- a/app/api/v1/actions/route.ts
+++ b/app/api/v1/actions/route.ts
@@ -5,6 +5,7 @@ import {
 } from '@/lib/api/error-handler'
 import { type Action, ActionSchema } from '@/lib/api/schemas'
 import { fetchData } from '@/lib/clickhouse'
+import { GUEST_USER_ID, resolveUserId } from '@/lib/conversation-store/auth'
 import { ErrorLogger, generateRequestId, log } from '@/lib/logger'
 
 export const dynamic = 'force-dynamic'
@@ -135,6 +136,22 @@ async function handleQuerySettings(
 export const POST = withApiHandler(async (request: Request) => {
   // Generate request ID for correlation and tracing
   const requestId = generateRequestId()
+
+  // Enforce server-side authentication when Clerk is configured.
+  if (process.env.CLERK_SECRET_KEY) {
+    const userId = await resolveUserId()
+    if (userId === GUEST_USER_ID) {
+      return Response.json(
+        { success: false, message: 'Unauthorized' },
+        {
+          status: 401,
+          headers: {
+            'X-Request-ID': requestId,
+          },
+        }
+      )
+    }
+  }
 
   const { searchParams } = new URL(request.url)
   const hostId = getHostIdFromParams(searchParams, ROUTE_CONTEXT)


### PR DESCRIPTION
### Motivation
- The actions API executed sensitive ClickHouse operations without server-side authentication, while the UI added Clerk sign-in buttons — creating a mismatch that allowed unauthenticated attackers to call operational endpoints directly.

### Description
- Add a server-side auth gate to `POST /api/v1/actions` by importing `resolveUserId` and `GUEST_USER_ID` from `lib/conversation-store/auth` and returning `401` when `process.env.CLERK_SECRET_KEY` is set and the resolved user is the guest user, preserving guest-mode when Clerk is not configured.
- Change implemented in `app/api/v1/actions/route.ts` with minimal logic to fail-fast before any action handlers run.

### Testing
- Attempted `bun run build` in the environment, but the build failed here with `error: Script not found "next"` after the wasm build step, so a full build/test could not be completed.
- No automated tests were added or run as part of this change; manual verification was done by static inspection to ensure the auth check executes before action handlers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00aea20a808332bce020c1f6d2934a)

## Summary by Sourcery

Bug Fixes:
- Guard POST /api/v1/actions with a server-side Clerk-based auth check that rejects guest users with 401 when Clerk is enabled, while preserving guest behavior when Clerk is not configured.