### PR TITLE
fix(ci): disable PR-triggered cloudflare deploy workflow

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -6,8 +6,6 @@ on:
       - main
     tags:
       - 'v*'
-  pull_request:
-    types: [opened, synchronize, reopened]
   release:
     types: [published]
   workflow_dispatch:
@@ -23,7 +21,8 @@ permissions:
 
 jobs:
   # ──────────────────────────────────────────────────────────────────────────
-  # Preview: deploy on every PR so reviewers can test changes live
+  # Preview: disabled for pull_request events to avoid exposing secrets
+  # in public preview environments.
   # ──────────────────────────────────────────────────────────────────────────
   preview:
     name: preview


### PR DESCRIPTION
### Motivation
- Prevent public PR preview deployments from receiving and exposing live ClickHouse credentials and secrets by removing the GitHub Actions trigger that previously deployed previews on `pull_request` events.

### Description
- Removed the `pull_request` trigger from `.github/workflows/cloudflare.yml` and added an inline comment clarifying that PR preview deployment is intentionally disabled to avoid secret exposure.
- This is a minimal CI-only remediation that leaves production deploy paths and application code unchanged.

### Testing
- Verified the workflow diff with `git diff -- .github/workflows/cloudflare.yml` and confirmed the `pull_request` trigger removal (success).
- Committed the change using `git commit` and inspected the file head with `nl -ba .github/workflows/cloudflare.yml | sed -n '1,40p'` to confirm the update (success).
- No runtime/unit tests were executed because this change only modifies CI configuration and does not affect application code or test suites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b7dadcfc8332bb55fd805d9dfc67)

## Summary by Sourcery

Disable Cloudflare preview deployments from running on pull request events to prevent secret exposure while keeping production deployment behavior unchanged.

CI:
- Remove the pull_request trigger from the Cloudflare GitHub Actions workflow so PRs no longer deploy preview environments.
- Document in the workflow that PR-based preview deployments are intentionally disabled due to secret exposure risk.