### PR TITLE
fix(ci): disable automatic PR preview deploy trigger

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -6,8 +6,6 @@ on:
       - main
     tags:
       - 'v*'
-  pull_request:
-    types: [opened, synchronize, reopened]
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
### Motivation
- Remove the `pull_request` trigger from the Cloudflare deployment workflow to prevent unreviewed PR code from being auto-deployed to the public preview Worker and exposing runtime ClickHouse secrets or admin endpoints.

### Description
- Removed the `pull_request` event from `.github/workflows/cloudflare.yml`, preserving existing production triggers (`push` to `main`, tags, `release`, and `workflow_dispatch`) and keeping the preview job guard intact; the commit message is `fix(ci): disable automatic PR preview deploy trigger` and includes the required co-author trailer `Co-Authored-By: duyetbot <duyetbot@users.noreply.github.com>`.

### Testing
- Ran `bun install` which completed successfully.
- Ran `bun run build` which completed successfully and produced a successful Next.js build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b7ac70608332b3c69fd720ed55cc)

## Summary by Sourcery

CI:
- Remove the pull_request event trigger from the Cloudflare deployment workflow so PRs no longer auto-deploy to the preview environment.