### PR TITLE
fix(api): enforce query allowlist for GET /api/v1/data

### DIFF
--- a/app/api/v1/data/route.ts
+++ b/app/api/v1/data/route.ts
@@ -107,6 +107,23 @@ export const GET = withApiHandler(async (request: Request) => {
     timezone,
   })
 
+  // SECURITY: Validate GET query against dashboard allowlist to prevent
+  // arbitrary SQL execution through query-string requests.
+  const validationResult = await validateDashboardQuery(query, hostId)
+  if (!validationResult.valid) {
+    error('[GET /api/v1/data] Security: Query not found in dashboard tables', {
+      queryPreview: query.substring(0, 100),
+    })
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.PermissionError,
+        message: validationResult.error?.message || 'Query validation failed',
+      },
+      403,
+      { ...ROUTE_CONTEXT, method: 'GET', hostId }
+    )
+  }
+
   // Execute the query
   const result = await fetchData({
     query,


### PR DESCRIPTION
### Motivation
- Close a security gap where `GET /api/v1/data` accepted arbitrary read queries via `sql`/`query` URL params despite POST requests requiring an allowlist, which could expose sensitive data.

### Description
- Add server-side allowlist validation by calling `validateDashboardQuery(query, hostId)` in the `GET /api/v1/data` handler and reject non-allowlisted queries with a `403` `PermissionError` response.
- Emit structured security logging for rejected GET queries including a `queryPreview` and preserve existing SQL pattern validation and `hostId` validation before execution.
- Changes made in `app/api/v1/data/route.ts` to apply the same dashboard-query allowlist flow used by the `POST` handler and to use `createApiErrorResponse` / `ApiErrorType.PermissionError` for consistent error semantics.

### Testing
- Ran `bun install` successfully to install dependencies and set up the repo.
- Built the project with `bun run build`, which completed a full Next.js production build and TypeScript type-check with no errors.
- Pre-commit checks (Biome linting and `tsc`) ran as part of the commit pipeline and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d09e3aa48332a9c0716981c8d097)

## Summary by Sourcery

Enforce dashboard query allowlist validation for GET /api/v1/data requests to close a security gap allowing arbitrary read queries.

Bug Fixes:
- Block execution of non-allowlisted queries on GET /api/v1/data by validating against the dashboard query allowlist and returning a 403 permission error when validation fails.

Enhancements:
- Add structured security logging for rejected GET /api/v1/data queries and align error responses with existing API error semantics.