### PR TITLE
fix(auth): remove browser-exposed api key flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,10 +27,7 @@ CLICKHOUSE_MAX_EXECUTION_TIME=60
 
 # Optional API-key gate for /api/v1 routes.
 # Set CHM_API_KEY_SECRET to enable middleware validation.
-# Set NEXT_PUBLIC_CHM_API_KEY to a minted key when the browser dashboard should
-# call protected API routes. This value is visible to browser users.
 CHM_API_KEY_SECRET=
-NEXT_PUBLIC_CHM_API_KEY=
 
 # ===========================================
 # Caching & Performance

--- a/README.md
+++ b/README.md
@@ -55,10 +55,7 @@ Optional API-key protection for `/api/v1/*` routes:
 
 ```bash
 CHM_API_KEY_SECRET=your-signing-secret
-NEXT_PUBLIC_CHM_API_KEY=your-minted-dashboard-key
 ```
-
-`NEXT_PUBLIC_CHM_API_KEY` is only needed when the browser dashboard should call protected API routes. It is visible to browser users.
 
 3. Deploy to Cloudflare Workers:
 ```bash

--- a/lib/swr/api-fetch.ts
+++ b/lib/swr/api-fetch.ts
@@ -1,47 +1,11 @@
 'use client'
 
-const dashboardApiKey = process.env.NEXT_PUBLIC_CHM_API_KEY
-
-function isFirstPartyApiRequest(input: RequestInfo | URL): boolean {
-  const rawUrl =
-    typeof Request !== 'undefined' && input instanceof Request
-      ? input.url
-      : input.toString()
-
-  if (rawUrl.startsWith('/api/v1/')) return true
-
-  if (typeof window === 'undefined') return false
-
-  try {
-    const url = new URL(rawUrl, window.location.origin)
-    return (
-      url.origin === window.location.origin &&
-      url.pathname.startsWith('/api/v1/')
-    )
-  } catch {
-    return false
-  }
-}
-
 /**
  * Fetch wrapper for first-party dashboard API calls.
  *
- * When API-key protection is enabled with CHM_API_KEY_SECRET, static dashboard
- * clients can set NEXT_PUBLIC_CHM_API_KEY to a minted key so browser fetches
- * include auth without relying on spoofable request-origin headers.
+ * Authentication headers must be supplied by trusted runtime context
+ * (for example, server-to-server requests), not embedded in browser bundles.
  */
 export function apiFetch(input: RequestInfo | URL, init?: RequestInit) {
-  if (!dashboardApiKey || !isFirstPartyApiRequest(input)) {
-    return init === undefined ? fetch(input) : fetch(input, init)
-  }
-
-  const headers = new Headers(init?.headers)
-  if (!headers.has('authorization') && !headers.has('x-api-key')) {
-    headers.set('x-api-key', dashboardApiKey)
-  }
-
-  return fetch(input, {
-    ...init,
-    headers,
-  })
+  return init === undefined ? fetch(input) : fetch(input, init)
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -11,9 +11,7 @@ export async function middleware(request: Request) {
     return NextResponse.next()
   }
 
-  const headerToken =
-    getBearerToken(request.headers.get('authorization')) ||
-    request.headers.get('x-api-key')
+  const headerToken = getBearerToken(request.headers.get('authorization'))
 
   if (!headerToken) {
     return NextResponse.json({ error: 'API key required' }, { status: 401 })


### PR DESCRIPTION
### Motivation
- Prevent a deployed dashboard from leaking a public `NEXT_PUBLIC_CHM_API_KEY` that could be reused to authenticate to all `/api/v1/*` routes and perform sensitive data queries or operational actions.
- Ensure authentication headers are supplied by a trusted runtime and not embedded into browser bundles.

### Description
- Remove automatic client-side `x-api-key` injection by replacing the `apiFetch` helper in `lib/swr/api-fetch.ts` with a no-op wrapper that does not read `NEXT_PUBLIC_CHM_API_KEY` or attach auth headers.
- Tighten middleware in `middleware.ts` to parse only `Authorization: Bearer ...` via `getBearerToken(...)` and no longer accept `x-api-key` from arbitrary requests for `/api/v1/*` routes.
- Update docs (`README.md`) and `.env.example` to remove guidance that recommends `NEXT_PUBLIC_CHM_API_KEY` for browser dashboard calls and to keep only server-side `CHM_API_KEY_SECRET` for the API-key gate.
- Keep server-side key issuance and verification logic unchanged so existing server workflows remain intact while removing the insecure browser-auth path.

### Testing
- Ran `bun install` to install dependencies and then `bun run build`, which completed successfully and includes TypeScript type checking (`tsc`).
- Pre-commit checks (Biome + `tsc`) passed during the commit process.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00a2649b648332b35e7bcb2cd01075)

## Summary by Sourcery

Remove browser-based API key authentication for dashboard API calls and require bearer tokens from trusted runtimes for protected routes.

Bug Fixes:
- Eliminate automatic client-side injection of the public NEXT_PUBLIC_CHM_API_KEY into dashboard API requests.
- Stop accepting x-api-key headers for /api/v1/* middleware authentication to prevent reuse of leaked browser keys.

Documentation:
- Update README and example environment configuration to remove guidance around using NEXT_PUBLIC_CHM_API_KEY from browser dashboards and document server-side API key usage only.