### PR TITLE
fix(ci): validate and sanitize release tag handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,14 @@ jobs:
 
       - name: Extract release metadata
         id: release_meta
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ github.event.release.tag_name || inputs.tag || github.ref_name }}"
+          TAG="$RELEASE_TAG"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release tag: $TAG" >&2
+            exit 1
+          fi
           VERSION="${TAG#v}"
           MAJOR="${VERSION%%.*}"
           MINOR="$(echo "$VERSION" | cut -d. -f1,2)"
@@ -126,8 +132,14 @@ jobs:
 
       - name: Extract release metadata
         id: meta
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ github.event.release.tag_name || inputs.tag || github.ref_name }}"
+          TAG="$RELEASE_TAG"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release tag: $TAG" >&2
+            exit 1
+          fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "RELEASE_TAG=$TAG" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
### Motivation
- Prevent command-injection risk in the release pipeline where attacker-controlled tag names or `workflow_dispatch` inputs were interpolated directly into shell `run` blocks in `.github/workflows/release.yml`.

### Description
- Replace direct `${{ ... }}` interpolation in `run` steps with an environment variable `RELEASE_TAG` and set `TAG="$RELEASE_TAG"` inside the script, and add a strict semver-style validation `^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$` that exits on invalid tags, applied to both the docker `release_meta` step and the assets `meta` step while preserving the existing metadata outputs (`tag`, `version`, `major`, `minor`, `RELEASE_TAG`).

### Testing
- Verified the fix by running `git diff -- .github/workflows/release.yml` and inspecting the modified lines with `nl -ba .github/workflows/release.yml | sed -n '34,70p;120,152p'`, which confirmed the env-backed tag assignment and validation were added successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00a385850c833296f2da67a7ff8f10)

## Summary by Sourcery

Harden release workflow tag handling to avoid unsafe shell interpolation and enforce valid release tag formats.

CI:
- Add environment-provided RELEASE_TAG variable for release workflows instead of interpolating expressions directly into shell commands.
- Validate release tags against a strict semver-like pattern in metadata extraction steps, failing the job on invalid tags while preserving existing metadata outputs.