### PR TITLE
fix(agents): sanitize chart config keys in style vars

### DIFF
--- a/components/agents/agent-visualization.tsx
+++ b/components/agents/agent-visualization.tsx
@@ -24,6 +24,7 @@ import { Button } from '@/components/ui/button'
 import {
   type ChartConfig,
   ChartContainer,
+  sanitizeChartConfigKey,
   ChartTooltip,
   ChartTooltipContent,
 } from '@/components/ui/chart'
@@ -460,7 +461,7 @@ function BarChartView({
           <Bar
             key={key}
             dataKey={key}
-            fill={`var(--color-${key})`}
+            fill={`var(--color-${sanitizeChartConfigKey(key)})`}
             radius={[2, 2, 0, 0]}
             stackId={stacked ? 'stack' : undefined}
           />
@@ -539,7 +540,7 @@ function ComboChartView({
             key={key}
             yAxisId="left"
             dataKey={key}
-            fill={`var(--color-${key})`}
+            fill={`var(--color-${sanitizeChartConfigKey(key)})`}
             radius={[2, 2, 0, 0]}
           />
         ))}
@@ -549,7 +550,7 @@ function ComboChartView({
             yAxisId="right"
             type="monotone"
             dataKey={key}
-            stroke={`var(--color-${key})`}
+            stroke={`var(--color-${sanitizeChartConfigKey(key)})`}
             strokeWidth={2}
             dot={false}
           />

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -71,6 +71,17 @@ const ChartContainer = React.forwardRef<
 })
 ChartContainer.displayName = 'Chart'
 
+
+export function sanitizeChartConfigKey(key: string): string {
+  return (
+    key
+      .replace(/[()[\]{}]/g, '')
+      .replace(/[^a-zA-Z0-9_-]/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .replace(/-+/g, '-') || 'unnamed'
+  )
+}
+
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
   const colorConfig = Object.entries(config).filter(
     ([, config]) => config.theme || config.color
@@ -92,7 +103,8 @@ ${colorConfig
     const color =
       itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
       itemConfig.color
-    return color ? `  --color-${key}: ${color};` : null
+    const safeKey = sanitizeChartConfigKey(key)
+    return color ? `  --color-${safeKey}: ${color};` : null
   })
   .join('\n')}
 }


### PR DESCRIPTION
### Motivation

- The agent visualization path previously allowed untrusted LLM/tool-provided series/category names to be interpolated into a `<style>` block via `dangerouslySetInnerHTML`, enabling a CSS/HTML breakout XSS when chart keys contained sequences like `</style>`.
- The change aims to mitigate that XSS by ensuring any ChartConfig keys used to build CSS custom properties are mapped to safe identifiers before being injected.

### Description

- Add a reusable `sanitizeChartConfigKey` helper in `components/ui/chart.tsx` that normalizes arbitrary keys to a safe CSS-identifier-friendly string and export it for reuse.
- Update `ChartStyle` (the `ChartContainer` style sink) to use `sanitizeChartConfigKey(key)` when emitting `--color-<key>` custom properties so untrusted keys cannot break out of the style block.
- Update agent visualization chart primitives in `components/agents/agent-visualization.tsx` to reference color CSS variables using `sanitizeChartConfigKey(key)` for `fill`/`stroke` so runtime series mapping remains consistent with the sanitized names.

### Testing

- Attempted a full build with `bun run build`; the build attempt was run but it fails in this environment due to missing/hosted `next` script/dependency issues, so a full TypeScript/Next build could not be completed here.
- Verified changes via static inspection and local source searches to ensure `sanitizeChartConfigKey` is used at the style sink and in the agent visualization fill/stroke usages; no unit test runs were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00a90478a883329a841aa16511a7e1)