### PR TITLE
fix(security): pin init events table to system database

### DIFF
--- a/lib/app-tables.ts
+++ b/lib/app-tables.ts
@@ -24,7 +24,7 @@ export const DASHBOARD_SETTINGS_TABLE_SHORT =
 
 // Fully-qualified "database.table" names used in SQL.
 export const EVENTS_TABLE =
-  process.env.EVENTS_TABLE_NAME || `${APP_DATABASE}.${EVENTS_TABLE_SHORT}`
+  process.env.EVENTS_TABLE_NAME || `system.${EVENTS_TABLE_SHORT}`
 
 export const DASHBOARD_CHARTS_TABLE = `${APP_DATABASE}.${DASHBOARD_CHARTS_TABLE_SHORT}`
 


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated `/api/init` from potentially dropping an arbitrary application table when `CLICKHOUSE_DATABASE` is set by removing the default that targeted `${CLICKHOUSE_DATABASE}.monitoring_events`.

### Description
- Change the `EVENTS_TABLE` default in `lib/app-tables.ts` to `system.monitoring_events` while preserving the explicit override via `EVENTS_TABLE_NAME` so the tracking initializer only targets the system database by default.

### Testing
- Ran `bun install` and `bun run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00a7a25b2883329c783b6929c49111)