### PR TITLE
fix(agents): remove query-param auto-submit flow

### DIFF
--- a/components/agents/agents-chat-area.tsx
+++ b/components/agents/agents-chat-area.tsx
@@ -9,7 +9,6 @@ import type { Conversation } from '@/lib/ai/agent/conversation-utils'
 
 import { useChat } from '@ai-sdk/react'
 import { DefaultChatTransport } from 'ai'
-import { useRouter } from 'next/navigation'
 import {
   forwardRef,
   useCallback,
@@ -51,7 +50,6 @@ interface AgentsChatAreaProps {
   readonly onMenuClick: () => void
   readonly hideHeader?: boolean
   readonly hideCompactControls?: boolean
-  readonly initialQuery?: string | null
 }
 
 function findLastAssistantMessage(messages: readonly UIMessage[]) {
@@ -87,12 +85,10 @@ export const AgentsChatArea = forwardRef<
     onMenuClick,
     hideHeader = false,
     hideCompactControls = false,
-    initialQuery,
   }: AgentsChatAreaProps,
   ref
 ) {
   const hostId = useHostId()
-  const router = useRouter()
   const { conversations, currentConversationId, updateMessages } =
     useConversationContext()
   const model = useMemo(() => getSavedModel(), [])
@@ -122,7 +118,6 @@ export const AgentsChatArea = forwardRef<
     ReturnType<typeof setTimeout> | undefined
   >(undefined)
   const prevConversationIdRef = useRef<string | undefined>(undefined)
-  const initialQuerySentRef = useRef<string | null>(null)
   const [responseDurations, setResponseDurations] = useState<
     Record<string, number>
   >({})
@@ -251,31 +246,6 @@ export const AgentsChatArea = forwardRef<
   }, [stop, setMessages, currentConversationId, updateMessages])
 
   useImperativeHandle(ref, () => ({ handleClear }), [handleClear])
-
-  useEffect(() => {
-    const cleaned = initialQuery?.trim()
-    if (
-      !cleaned ||
-      cleaned === initialQuerySentRef.current ||
-      status !== 'ready'
-    ) {
-      return
-    }
-
-    initialQuerySentRef.current = cleaned
-    sendMessage({
-      parts: [
-        {
-          type: 'text',
-          text: `Analyze this ClickHouse query:\n\n\`\`\`sql\n${cleaned}\n\`\`\``,
-        },
-      ],
-    })
-
-    const url = new URL(window.location.href)
-    url.searchParams.delete('query')
-    router.replace(url.pathname + url.search, { scroll: false })
-  }, [initialQuery, status, sendMessage, router])
 
   const handleRegenerate = useCallback(() => {
     stop()

--- a/components/agents/agents-layout.tsx
+++ b/components/agents/agents-layout.tsx
@@ -8,7 +8,6 @@ import { AgentConfigGuidance } from './agent-config-guidance'
 import { AgentsChatArea } from './agents-chat-area'
 import { AgentsSidebar } from './agents-sidebar'
 import { ConversationSwitcher } from './conversation-switcher'
-import { useSearchParams } from 'next/navigation'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { useIsMobile } from '@/hooks/use-mobile'
@@ -19,8 +18,6 @@ import { useHostId } from '@/lib/swr'
 export function AgentsLayout() {
   const hostId = useHostId()
   const isMobile = useIsMobile()
-  const searchParams = useSearchParams()
-  const initialQuery = searchParams.get('query')
 
   // Track if user manually toggled sidebar (to prevent auto-closing on resize)
   const userToggledRef = useRef(false)
@@ -128,7 +125,6 @@ export function AgentsLayout() {
           onMenuClick={() => setIsSidebarOpen(!isSidebarOpen)}
           hideHeader={true}
           hideCompactControls={true}
-          initialQuery={initialQuery}
         />
       </div>
 

--- a/components/data-table/cells/actions/action-item.tsx
+++ b/components/data-table/cells/actions/action-item.tsx
@@ -69,15 +69,7 @@ export function ActionItem<TData extends RowData, TValue>({
     },
     'analyze-with-ai': {
       label: 'Analyze with AI',
-      handler: async () => {
-        const query = String(
-          row.getValue('query') || row.getValue('normalized_query') || ''
-        )
-        return {
-          success: true,
-          message: `/agents?query=${encodeURIComponent(query)}&host=${hostId}`,
-        }
-      },
+      handler: async () => ({ success: true, message: `/agents?host=${hostId}` }),
     },
     optimize: {
       label: 'Optimize Table',

--- a/components/data-table/cells/actions/inline-actions.tsx
+++ b/components/data-table/cells/actions/inline-actions.tsx
@@ -110,7 +110,7 @@ export function InlineActions<TData extends RowData>({
           } else if (action === 'explain-query') {
             href = `/explain?query=${encodeURIComponent(getQuery())}`
           } else if (action === 'analyze-with-ai') {
-            href = `/agents?query=${encodeURIComponent(getQuery())}&host=${hostId}`
+            href = `/agents?host=${hostId}`
           }
 
           return (


### PR DESCRIPTION
### Motivation
- The agents page previously accepted untrusted `/agents?query=...` input and auto-submitted it to the AI agent, enabling prompt-injection and link-triggered destructive actions via default-enabled control tools.
- Embedding raw SQL in the browser URL exposed sensitive queries in history, referrers, and logs and allowed attackers to craft links that submit malicious prompts without user confirmation.

### Description
- Removed URL query ingestion plumbing by stopping `AgentsLayout` from reading `?query` and no longer passing an `initialQuery` prop into `AgentsChatArea`.
- Removed the auto-send effect from `AgentsChatArea` that automatically called `sendMessage` with the URL-provided SQL and cleaned up router-based query param deletion and related imports.
- Updated both inline and dropdown "Analyze with AI" actions to navigate to `/agents?host=<id>` only, eliminating SQL-in-URL generation and preserving manual chat submission.

### Testing
- Ran pre-commit checks and TypeScript type-checks which passed during the commit operation.
- Performed `bun install` successfully to restore dependencies.
- Executed `bun run build` which completed successfully and produced the application build without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00a85322788332b5ba73f788e76aae)