### PR TITLE
fix(mcp): require api key auth for mcp endpoint

### DIFF
--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -1,9 +1,27 @@
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+import { getBearerToken } from '@/lib/auth/bearer-token'
+import { verifyApiKey } from '@/lib/api-key'
 import { createMcpServer } from '@/lib/mcp/server'
 
 export const dynamic = 'force-dynamic'
 
 async function handleMcpRequest(req: Request) {
+  const authHeader = req.headers.get('authorization')
+  const bearerToken = getBearerToken(authHeader)
+  const apiKeyHeader = req.headers.get('x-api-key')
+  const token = bearerToken ?? apiKeyHeader
+
+  if (process.env.CHM_API_KEY_SECRET) {
+    if (!token) {
+      return new Response('Unauthorized', { status: 401 })
+    }
+
+    const result = await verifyApiKey(token)
+    if (!result.valid) {
+      return new Response('Unauthorized', { status: 401 })
+    }
+  }
+
   const server = createMcpServer()
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined,


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated access to MCP resources which could disclose ClickHouse schema and operational metadata via the existing `/api/mcp` endpoint.

### Description
- Add header parsing with `getBearerToken` and `x-api-key`, validate the token with `verifyApiKey` when `CHM_API_KEY_SECRET` is configured, and return HTTP `401` for missing or invalid keys while preserving current behavior when the secret is not set.

### Testing
- Ran pre-commit checks (Biome) and TypeScript type-check (`tsc`), then executed `bun install` followed by `bun run build`, and all steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00a86269c88332bee895b88421c13d)