### PR TITLE
fix(auth): fail closed for conversation db user resolution

### DIFF
--- a/lib/conversation-store/auth.ts
+++ b/lib/conversation-store/auth.ts
@@ -1,10 +1,9 @@
 /**
  * Authentication utilities for conversation store.
- *
- * Handles user ID resolution with graceful fallback to guest mode.
  */
 
 import { auth } from '@clerk/nextjs/server'
+import { ConversationStoreError } from './types'
 
 /**
  * Guest user ID constant for unauthenticated users.
@@ -19,39 +18,43 @@ const CLERK_SECRET_KEY = 'CLERK_SECRET_KEY'
 /**
  * Resolves the current user ID from Clerk authentication.
  *
- * Falls back to guest mode if:
- * - Clerk is not configured (missing CLERK_SECRET_KEY)
- * - No authenticated user session
- * - Authentication service throws an error
- *
- * @returns Promise resolving to userId string or GUEST_USER_ID
- *
- * @example
- * ```ts
- * const userId = await resolveUserId()
- * if (userId === GUEST_USER_ID) {
- *   // Handle guest user
- * }
- * ```
+ * Conversation DB endpoints must be authenticated to guarantee user isolation.
+ * This function fails closed when Clerk is unavailable, missing a session,
+ * or returns an auth error.
  */
 export async function resolveUserId(): Promise<string> {
-  // Check if Clerk is configured
   if (!process.env[CLERK_SECRET_KEY]) {
-    return GUEST_USER_ID
+    throw new ConversationStoreError(
+      'Authentication is required for conversation storage.',
+      'UNAUTHORIZED'
+    )
   }
 
   try {
     const authResult = await auth()
     const userId = authResult?.userId
 
-    return userId || GUEST_USER_ID
+    if (!userId) {
+      throw new ConversationStoreError(
+        'Authentication is required for conversation storage.',
+        'UNAUTHORIZED'
+      )
+    }
+
+    return userId
   } catch (error) {
-    // Log error in development, but fail silently in production
+    if (error instanceof ConversationStoreError) {
+      throw error
+    }
+
     if (process.env.NODE_ENV === 'development') {
       console.error('Auth resolution failed:', error)
     }
 
-    // Fallback to guest mode on any auth error
-    return GUEST_USER_ID
+    throw new ConversationStoreError(
+      'Failed to validate authentication for conversation storage.',
+      'UNAUTHORIZED',
+      error
+    )
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent a fail-open fallback that returned a shared `guest` user and allowed unauthenticated callers to read/modify/delete other users' persisted conversations.

### Description
- Change `resolveUserId()` in `lib/conversation-store/auth.ts` to throw `ConversationStoreError('UNAUTHORIZED')` when Clerk is not configured, no session is present, or an auth error occurs instead of returning the shared `guest` ID.
- Import `ConversationStoreError` and update the function to require a validated Clerk `userId` (fail-closed) so existing store APIs continue to receive errors they can map to permission failures.

### Testing
- Ran the build check with `bun run build`; the run completed wasm steps but failed in this environment with `error: Script not found "next"`, so a full app build/type-check could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ac29e04c8332a06e4e8c9c824854)