### PR TITLE
fix(agent): disable destructive control tools by default

### DIFF
--- a/lib/ai/agent/tools/index.ts
+++ b/lib/ai/agent/tools/index.ts
@@ -37,6 +37,8 @@ import { createZookeeperTools } from './zookeeper-tools'
  * Returns a flat object of all tools across all categories.
  */
 export function createAllTools(hostId: number) {
+  const enableControlTools = process.env.AGENT_ENABLE_CONTROL_TOOLS === 'true'
+
   return {
     // Schema & exploration
     ...createSchemaTools(hostId),
@@ -63,7 +65,7 @@ export function createAllTools(hostId: number) {
     ...createClusterTools(hostId),
 
     // Control actions (destructive)
-    ...createControlTools(hostId),
+    ...(enableControlTools ? createControlTools(hostId) : {}),
 
     // Dashboard navigation
     ...createDashboardTools(),


### PR DESCRIPTION
### Motivation
- The agent registered destructive ClickHouse control tools (e.g., `kill_query`, `optimize_table`, `kill_mutation`) unconditionally, which allows the ToolLoopAgent to execute write/control statements without a server-side approval or authorization gate, creating a prompt-injection / confused-deputy risk.

### Description
- Gate inclusion of the control tools behind an explicit server-side opt-in by checking `process.env.AGENT_ENABLE_CONTROL_TOOLS === 'true'` in `createAllTools`.
- When the env flag is not set the control tools are excluded from the returned tool set, preserving all non-destructive tools and behavior.
- Change implemented in `lib/ai/agent/tools/index.ts` by conditionally spreading `createControlTools(hostId)` only when `AGENT_ENABLE_CONTROL_TOOLS` is `true`.

### Testing
- Attempted a full build with `bun run build` to validate the change, but the environment build failed here with `error: Script not found "next"` after the WASM build step, so a full compile could not be completed in this environment (build failure unrelated to the small code change).
- Verified the repository diff and committed the change locally; the change is syntactic and minimal and does not alter other runtime paths when the env flag is unset.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ab15893083329d6bbc2af8be16f4)