### PR TITLE
fix(agents): disable runtime skill registration endpoint

### DIFF
--- a/app/api/v1/agent/skills/route.ts
+++ b/app/api/v1/agent/skills/route.ts
@@ -1,7 +1,4 @@
-import {
-  getAllSkills,
-  registerSkill,
-} from '@/lib/ai/agent/skills/dynamic-loader'
+import { getAllSkills } from '@/lib/ai/agent/skills/dynamic-loader'
 
 export async function GET() {
   const skills = getAllSkills().map(({ name, description, source }) => ({
@@ -12,42 +9,9 @@ export async function GET() {
   return Response.json({ data: skills })
 }
 
-export async function POST(request: Request) {
-  let body: unknown
-
-  try {
-    body = await request.json()
-  } catch {
-    return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
-  }
-
-  const b = body as Record<string, unknown>
-  if (
-    typeof body !== 'object' ||
-    body === null ||
-    typeof b.name !== 'string' ||
-    typeof b.description !== 'string' ||
-    typeof b.content !== 'string'
-  ) {
-    return Response.json(
-      {
-        error:
-          'Request body must include: name (string), description (string), content (string)',
-      },
-      { status: 400 }
-    )
-  }
-
-  const { name, description, content } = b as {
-    name: string
-    description: string
-    content: string
-  }
-
-  registerSkill({ name, description, content, source: 'remote' })
-
+export async function POST() {
   return Response.json(
-    { data: { name, description, source: 'remote' } },
-    { status: 201 }
+    { error: 'Runtime skill registration is disabled for security reasons' },
+    { status: 403 }
   )
 }


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated runtime registration of agent skills via `POST /api/v1/agent/skills` which allowed persistent prompt-poisoning and unbounded in-memory skill registration that could override trusted builtins.

### Description
- Disable the runtime registration path by returning `403` from the `POST /api/v1/agent/skills` handler and remove the `registerSkill` usage while leaving `GET` (metadata reads via `getAllSkills()`) unchanged.

### Testing
- Ran `bun install`, `bun run build`, and the repository pre-commit/type checks (lint-staged and `tsc --noEmit`) which all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00a653e1308332b262f7ed4bbe3382)