### PR TITLE
fix(ci): add explicit release types to fix startup_failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     tags:
       - 'v*'
   release:
+    types: [published]
   pull_request:
   workflow_dispatch:
 

--- a/components/agents/chat/message.tsx
+++ b/components/agents/chat/message.tsx
@@ -42,13 +42,13 @@ import '../markdown-code.css'
 
 import { MermaidRenderer } from './mermaid-renderer'
 import { type AgentToolPart, ToolCallPart } from './tool-output'
-import { AGENT_JSON_RENDER_CATALOG } from '@/lib/ai/agent/json-render-catalog-with-schema'
 import {
   AGENT_JSON_RENDER_MAX_ELEMENT_COUNT,
   AGENT_JSON_RENDER_MAX_SPEC_BYTES,
   AGENT_JSON_RENDER_MAX_SPEC_PART_BYTES,
   AGENT_JSON_RENDER_MAX_SPEC_PARTS,
 } from '@/lib/ai/agent/json-render-catalog'
+import { AGENT_JSON_RENDER_CATALOG } from '@/lib/ai/agent/json-render-catalog-with-schema'
 import { AGENT_JSON_RENDER_REGISTRY } from '@/lib/ai/agent/json-render-registry'
 
 const jsonRenderTextEncoder = new TextEncoder()

--- a/lib/ai/agent/json-render-catalog-with-schema.ts
+++ b/lib/ai/agent/json-render-catalog-with-schema.ts
@@ -1,8 +1,8 @@
+import type { AGENT_JSON_RENDER_COMPONENT_NAMES } from './json-render-catalog'
+
 import { defineCatalog } from '@json-render/core'
 import { schema as reactSchema } from '@json-render/react'
 import { shadcnComponentDefinitions } from '@json-render/shadcn/catalog'
-
-import { AGENT_JSON_RENDER_COMPONENT_NAMES } from './json-render-catalog'
 
 const AGENT_JSON_RENDER_COMPONENTS = {
   Card: shadcnComponentDefinitions.Card,


### PR DESCRIPTION
## Summary
- Add `types: [published]` to `release:` event trigger in `ci.yml`
- Fix pre-existing lint issues (import ordering) from recent merge

The bare `release:` trigger without `types:` causes GitHub Actions to fail with `startup_failure` and 0 jobs created.

## Test plan
- [ ] Verify "Image build and Push" workflow initializes correctly on this PR
- [ ] Verify `lint` and `build` jobs run successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD configuration for release workflows
  * Refactored internal code organization and import statements

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1086)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->