### PR TITLE
fix(ci): remove invalid job-level permissions escalation

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -47,7 +47,7 @@ env:
 permissions:
   contents: read
   id-token: write
-  packages: read
+  packages: write
 
 jobs:
   job:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
 permissions:
   contents: read
   id-token: write
-  packages: read
+  packages: write
 
 env:
   REGISTRY: ghcr.io
@@ -53,9 +53,6 @@ jobs:
   build-docker-amd64:
     name: build-docker-amd64
     if: github.event_name != 'pull_request'
-    permissions:
-      contents: read
-      packages: write
     uses: ./.github/workflows/base.yml
     with:
       job-type: docker
@@ -66,9 +63,6 @@ jobs:
   build-docker-arm64:
     name: build-docker-arm64
     if: github.event_name != 'pull_request'
-    permissions:
-      contents: read
-      packages: write
     uses: ./.github/workflows/base.yml
     with:
       job-type: docker


### PR DESCRIPTION
## Summary
- Remove job-level `permissions:` blocks from `build-docker-amd64` and `build-docker-arm64` jobs in ci.yml — these are invalid when calling reusable workflows via `uses:`
- Restore `packages: write` at top-level in both ci.yml and base.yml (reverted from PR #1073)

## Root Cause
PR #1073 set top-level `packages: read` in ci.yml, then tried to escalate to `packages: write` at the job level for specific jobs. GitHub Actions does not allow job-level permissions to exceed the top-level scope when calling reusable workflows. This caused `startup_failure` on every CI run since that merge.

## Why PRs are still safe
- PR docker jobs use `push-image: false`, so the login and push steps are skipped entirely
- The `if` conditions on both the login step and the push step check `inputs.push-image`

## Test plan
- [ ] CI workflow initializes successfully (no more startup_failure)
- [ ] PR builds run without pushing images
- [ ] Merge to main pushes multi-arch images to GHCR