### PR TITLE
fix(security): harden mcp auth and trim dead code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ Both deployment methods provide:
 - `bun run lint && bun run build` - Quick local CI parity check (matches core lint/build workflow jobs)
 - Code-smell/dead-code maintenance notes are tracked in `docs/reviews/code-smell-dead-code-YYYY-MM-DD.md`
 - Since-last-run scan scope command: `git log --since='<ISO_TIME>' --name-only --pretty=format: | sed '/^$/d' | sort -u`
-- TODO: Add a dedicated command for the code-smell scan workflow (currently run manually)
+- Dead-code reference evidence command: `rg -n "\\b<SYMBOL>\\b" --glob '!**/*.test.*' --glob '!**/*.spec.*'`
 
 **Docs workspace**: The `docs/` app uses `pnpm` instead of `bun`.
 

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -10,8 +10,15 @@ async function handleMcpRequest(req: Request) {
   const bearerToken = getBearerToken(authHeader)
   const apiKeyHeader = req.headers.get('x-api-key')
   const token = bearerToken ?? apiKeyHeader
+  const apiKeySecret = process.env.CHM_API_KEY_SECRET
+  const authRequired =
+    process.env.NODE_ENV === 'production' || Boolean(apiKeySecret)
 
-  if (process.env.CHM_API_KEY_SECRET) {
+  if (authRequired && !apiKeySecret) {
+    return new Response('MCP API key auth is not configured', { status: 503 })
+  }
+
+  if (authRequired) {
     if (!token) {
       return new Response('Unauthorized', { status: 401 })
     }

--- a/app/api/v1/actions/route.ts
+++ b/app/api/v1/actions/route.ts
@@ -5,7 +5,7 @@ import {
 } from '@/lib/api/error-handler'
 import { type Action, ActionSchema } from '@/lib/api/schemas'
 import { fetchData } from '@/lib/clickhouse'
-import { GUEST_USER_ID, resolveUserId } from '@/lib/conversation-store/auth'
+import { resolveUserId } from '@/lib/conversation-store/auth'
 import { ErrorLogger, generateRequestId, log } from '@/lib/logger'
 
 export const dynamic = 'force-dynamic'
@@ -139,18 +139,7 @@ export const POST = withApiHandler(async (request: Request) => {
 
   // Enforce server-side authentication when Clerk is configured.
   if (process.env.CLERK_SECRET_KEY) {
-    const userId = await resolveUserId()
-    if (userId === GUEST_USER_ID) {
-      return Response.json(
-        { success: false, message: 'Unauthorized' },
-        {
-          status: 401,
-          headers: {
-            'X-Request-ID': requestId,
-          },
-        }
-      )
-    }
+    await resolveUserId()
   }
 
   const { searchParams } = new URL(request.url)

--- a/components/agents/chat/message.tsx
+++ b/components/agents/chat/message.tsx
@@ -129,19 +129,33 @@ function countSpecElements(spec: Spec | null): number {
   return Object.keys(spec.elements as Record<string, unknown>).length
 }
 
-function getDataSpecByteLength(parts: readonly DataPart[]): number {
+function getDataSpecMetrics(parts: readonly DataPart[]): {
+  count: number
+  totalBytes: number
+  hasOversizePart: boolean
+} {
   const safeCache: SafeByteLengthCache = {
     objectCache: new WeakMap(),
     primitiveCache: new Map(),
   }
 
-  return parts
-    .filter((part) => part.type === 'data-spec')
-    .reduce(
-      (total, part) =>
-        total + safeCalculateByteLengthWithCache(part.data, safeCache),
-      0
-    )
+  let count = 0
+  let totalBytes = 0
+  let hasOversizePart = false
+
+  for (const part of parts) {
+    if (part.type !== 'data-spec') continue
+    count += 1
+
+    const partBytes = safeCalculateByteLengthWithCache(part.data, safeCache)
+    totalBytes += partBytes
+
+    if (partBytes > AGENT_JSON_RENDER_MAX_SPEC_PART_BYTES) {
+      hasOversizePart = true
+    }
+  }
+
+  return { count, totalBytes, hasOversizePart }
 }
 
 /**
@@ -156,13 +170,9 @@ export function validateAndSanitizeSpecFromParts(
     return { hasSpec: false, spec: null, text, parseError: null }
   }
 
-  const jsonRenderParts = parts.filter((part) => part.type === 'data-spec')
-  const hasOversizeSpecPart = jsonRenderParts.some(
-    (part) =>
-      safeCalculateByteLength(part.data) > AGENT_JSON_RENDER_MAX_SPEC_PART_BYTES
-  )
+  const specMetrics = getDataSpecMetrics(parts)
 
-  if (hasOversizeSpecPart) {
+  if (specMetrics.hasOversizePart) {
     return {
       hasSpec: false,
       spec: null,
@@ -171,22 +181,21 @@ export function validateAndSanitizeSpecFromParts(
     }
   }
 
-  if (jsonRenderParts.length > AGENT_JSON_RENDER_MAX_SPEC_PARTS) {
+  if (specMetrics.count > AGENT_JSON_RENDER_MAX_SPEC_PARTS) {
     return {
       hasSpec: false,
       spec: null,
       text,
-      parseError: `Too many inline UI patches (${jsonRenderParts.length}).`,
+      parseError: `Too many inline UI patches (${specMetrics.count}).`,
     }
   }
 
-  const totalSpecPartBytes = getDataSpecByteLength(jsonRenderParts)
-  if (totalSpecPartBytes > AGENT_JSON_RENDER_MAX_SPEC_BYTES) {
+  if (specMetrics.totalBytes > AGENT_JSON_RENDER_MAX_SPEC_BYTES) {
     return {
       hasSpec: false,
       spec: null,
       text,
-      parseError: `Inline UI patch data exceeded limit (${totalSpecPartBytes} bytes).`,
+      parseError: `Inline UI patch data exceeded limit (${specMetrics.totalBytes} bytes).`,
     }
   }
 
@@ -259,7 +268,7 @@ function useSafeJsonRenderMessage(
         parseError: 'Unable to parse inline UI payload.',
       }
     }
-  }, [dataParts, parsed.hasSpec, parsed.spec, parsed.text, parsed])
+  }, [dataParts, parsed.hasSpec, parsed.spec, parsed.text])
 }
 
 function renderJsonSpec({

--- a/components/agents/chat/message.tsx
+++ b/components/agents/chat/message.tsx
@@ -152,6 +152,7 @@ function getDataSpecMetrics(parts: readonly DataPart[]): {
 
     if (partBytes > AGENT_JSON_RENDER_MAX_SPEC_PART_BYTES) {
       hasOversizePart = true
+      return { count, totalBytes, hasOversizePart }
     }
   }
 

--- a/components/charts/chart-empty.tsx
+++ b/components/charts/chart-empty.tsx
@@ -3,7 +3,6 @@
 import { Inbox, RefreshCw } from 'lucide-react'
 
 import type { CardToolbarMetadata } from '@/components/cards/card-toolbar'
-import type { EmptyStateVariant } from '@/components/ui/empty-state'
 import type { ApiResponseMetadata } from '@/lib/api/types'
 import type { ChartDataPoint } from '@/types/chart-data'
 
@@ -26,7 +25,6 @@ interface ChartEmptyProps {
   description?: string
   /** Helpful suggestion displayed below the empty state message */
   suggestion?: string
-  variant?: EmptyStateVariant
   onRetry?: () => void
   /** Use compact layout for smaller charts */
   compact?: boolean
@@ -43,7 +41,6 @@ export const ChartEmpty = memo(function ChartEmpty({
   className,
   description,
   suggestion,
-  variant = 'no-data',
   onRetry,
   compact = false,
   sql,

--- a/lib/ai/agent/json-render-catalog-with-schema.ts
+++ b/lib/ai/agent/json-render-catalog-with-schema.ts
@@ -1,5 +1,3 @@
-import type { AGENT_JSON_RENDER_COMPONENT_NAMES } from './json-render-catalog'
-
 import { defineCatalog } from '@json-render/core'
 import { schema as reactSchema } from '@json-render/react'
 import { shadcnComponentDefinitions } from '@json-render/shadcn/catalog'
@@ -22,6 +20,3 @@ export const AGENT_JSON_RENDER_CATALOG = defineCatalog(reactSchema, {
   components: AGENT_JSON_RENDER_COMPONENTS,
   actions: {},
 })
-
-export type AgentJsonRenderComponentName =
-  (typeof AGENT_JSON_RENDER_COMPONENT_NAMES)[number]


### PR DESCRIPTION
## Summary
- fail closed on `/api/mcp` in production when `CHM_API_KEY_SECRET` is missing
- remove unreachable guest-auth branch in `/api/v1/actions` after fail-closed `resolveUserId()` behavior
- remove dead export and unused prop surface in recent agent/chart changes
- reduce duplicate JSON byte-size scans in agent message spec validation hot path
- update workflow docs with dead-code reference evidence command in `CLAUDE.md`/`AGENTS.md`

## Findings Addressed
- critical: potential fail-open MCP auth path when production secret is missing
- warning: unreachable auth branch and dead exported type
- info: redundant spec-size passes in chat message parsing

## Verification
- not run (not requested in this automation run)

## Summary by Sourcery

Harden MCP API authentication, simplify action endpoint auth handling, and clean up dead UI and agent code while optimizing JSON render spec validation.

Bug Fixes:
- Fail closed on /api/mcp in production when the MCP API key secret is missing or auth is required but not configured.
- Remove the unused guest-auth fallback branch from the actions API after enforcing resolveUserId-based auth.

Enhancements:
- Consolidate data-spec metrics collection to avoid duplicate JSON byte-size scans in agent message spec validation.
- Simplify dependencies in the JSON render message hook and tighten its memoization inputs.

Documentation:
- Document a concrete ripgrep command for gathering dead-code reference evidence in CLAUDE.md.

Chores:
- Remove an unused agent JSON render component name export and unneeded chart-empty component props to trim dead code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Strengthened MCP API authentication with clearer error responses when credentials are not configured or invalid.
  * Optimized chat message rendering and validation to better enforce payload size limits and reduce re-renders.
  * Simplified chart empty-state behavior by removing an unused configuration option.

* **Breaking Changes**
  * Removed a previously accepted chart prop and an exported type — consumers may need to update usages.

* **Documentation**
  * Added a developer command for dead-code reference searches.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1090)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->