### PR TITLE
fix(agents): resolve chat memo dependency warning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ Both deployment methods provide:
 - `bun run lint && bun run build` - Quick local CI parity check (matches core lint/build workflow jobs)
 - Code-smell/dead-code maintenance notes are tracked in `docs/reviews/code-smell-dead-code-YYYY-MM-DD.md`
 - Since-last-run scan scope command: `git log --since='<ISO_TIME>' --name-only --pretty=format: | sed '/^$/d' | sort -u`
+- Fallback scan scope when no new commits: `git log --since='24 hours ago' --name-only --pretty=format: | sed '/^$/d' | sort -u`
 - Dead-code reference evidence command: `rg -n "\\b<SYMBOL>\\b" --glob '!**/*.test.*' --glob '!**/*.spec.*'`
 
 **Docs workspace**: The `docs/` app uses `pnpm` instead of `bun`.

--- a/components/agents/chat/message.tsx
+++ b/components/agents/chat/message.tsx
@@ -257,10 +257,15 @@ function useSafeJsonRenderMessage(
 ): SafeJsonRenderResult {
   const dataParts = useMemo(() => getSafeJsonRenderMessageParts(parts), [parts])
   const parsed = useJsonRenderMessage(dataParts)
+  const { hasSpec, spec, text } = parsed
 
   return useMemo(() => {
     try {
-      return validateAndSanitizeSpecFromParts(dataParts, parsed)
+      return validateAndSanitizeSpecFromParts(dataParts, {
+        hasSpec,
+        spec,
+        text,
+      })
     } catch (_error) {
       return {
         hasSpec: false,
@@ -269,7 +274,7 @@ function useSafeJsonRenderMessage(
         parseError: 'Unable to parse inline UI payload.',
       }
     }
-  }, [dataParts, parsed])
+  }, [dataParts, hasSpec, spec, text])
 }
 
 function renderJsonSpec({

--- a/components/agents/chat/message.tsx
+++ b/components/agents/chat/message.tsx
@@ -269,7 +269,7 @@ function useSafeJsonRenderMessage(
         parseError: 'Unable to parse inline UI payload.',
       }
     }
-  }, [dataParts, parsed.hasSpec, parsed.spec, parsed.text])
+  }, [dataParts, parsed])
 }
 
 function renderJsonSpec({


### PR DESCRIPTION
## Summary
- fix the `useMemo` dependency list in `components/agents/chat/message.tsx` to include the captured `parsed` object and remove stale-closure risk
- add a documented scan fallback command in `CLAUDE.md` and `AGENTS.md` for runs where there are no new commits since the last run

## Why
- lint surfaced a concrete warning in recently changed code (`useExhaustiveDependencies`)
- automation workflow now explicitly documents the fallback command used in this run

## Verification
- `bun run lint` (passes; only existing Biome schema-version info remains)
- `bun run test -- components/agents/chat/message.test.ts` (fails in this sandbox: missing `react/jsx-dev-runtime` because dependencies are not installable here)
- `bun run type-check` (fails in this sandbox: `tsc` unavailable without dependencies)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a documented fallback scan scope command for use when no new commits are found.

* **Refactor**
  * Improved dependency tracking in message rendering to reduce unnecessary recomputation and improve performance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1091)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->