### PR TITLE
chore(docs): add core automation memory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,17 +144,15 @@ Both deployment methods provide:
 - `bun run migrate`, `bun run migrate:status`, `bun run migrate:dry-run` - Use the local migration runner for non-Cloudflare targets
 - `bun run docker:health` / `bun run cf:health` - Check Docker or deployed health endpoints
 - `bun run lint && bun run build` - Quick local CI parity check (matches core lint/build workflow jobs)
-- Code-smell/dead-code maintenance notes are tracked in `docs/reviews/code-smell-dead-code-YYYY-MM-DD.md`
+- Code-smell/dead-code automation memory lives in `docs/knowledge/core-memory.md` (single durable note; do not create dated `docs/reviews/code-smell-dead-code-*.md` files)
 - Since-last-run scan scope command: `git log --since='<ISO_TIME>' --name-only --pretty=format: | sed '/^$/d' | sort -u`
 - Fallback scan scope when no new commits: `git log --since='24 hours ago' --name-only --pretty=format: | sed '/^$/d' | sort -u`
 - Dead-code reference evidence command: `rg -n "\\b<SYMBOL>\\b" --glob '!**/*.test.*' --glob '!**/*.spec.*'`
 
-**Docs workspace**: The `docs/` app uses `pnpm` instead of `bun`.
+**Docs content workflow**: `/docs` pages are rendered by the main app and read source files from `docs/content`.
 
-- `cd docs && pnpm dev` - Start the docs site
-- `cd docs && pnpm build` - Build docs and generate the Pagefind search index
-- `cd docs && pnpm start` - Serve the built docs site
-- `cd docs && pnpm lint` - Run Next.js linting
+- `bun run dev` then open `/docs` - Preview docs through the main app shell
+- `DOCS_CONTENT_ROOT=<path> bun run dev` - Override docs source root for local validation
 
 ## Architecture
 

--- a/app/(docs)/docs/_lib/docs.ts
+++ b/app/(docs)/docs/_lib/docs.ts
@@ -1,6 +1,7 @@
 import { rewriteDocsHref, slugify } from './shared'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
+import { cache } from 'react'
 
 export type DocsNavItem = {
   title: string
@@ -66,16 +67,12 @@ export const docsNav: DocsNavSection[] = [
   },
 ]
 
-export function getDocsSlugs() {
-  return docsNav.flatMap((section) => section.items.map((item) => item.slug))
-}
-
 /**
  * Loads a docs page from docs/content by route slug.
  *
  * Returns null only when the source MDX file is missing.
  */
-export async function getDocsPage(slug: string): Promise<DocsPage | null> {
+export const getDocsPage = cache(async (slug: string): Promise<DocsPage | null> => {
   const normalizedSlug = normalizeSlug(slug)
   const source = await readDocsSource(normalizedSlug)
 
@@ -93,7 +90,7 @@ export async function getDocsPage(slug: string): Promise<DocsPage | null> {
     markdown,
     headings,
   }
-}
+})
 
 export function normalizeSlug(slug: string) {
   return slug

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -8,6 +8,7 @@ tags:
   - ai-agent
   - knowledge-graph
 related:
+  - automation-core-memory
   - rust-wasm-performance
   - component-ci-stability
 source_pr: 1021
@@ -23,6 +24,7 @@ context that should survive a compacted chat or a handoff.
 
 - [Rust and WASM Performance](./rust-wasm-performance.md)
 - [Component CI Stability](./component-ci-stability.md)
+- [Automation Core Memory](./core-memory.md)
 
 ## Graph Convention
 

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -1,0 +1,38 @@
+---
+id: automation-core-memory
+title: Automation Core Memory
+type: workflow
+status: active
+updated: 2026-05-13
+tags:
+  - automation
+  - code-smell
+  - dead-code
+  - docs
+related:
+  - knowledge-index
+artifacts:
+  - CLAUDE.md
+  - app/(docs)/docs/_lib/docs.ts
+---
+
+# Automation Core Memory
+
+Use this note for durable code-smell/dead-code automation memory in this repo.
+Do not create dated files under `docs/reviews/code-smell-dead-code-*.md`.
+
+## Commands
+
+- Since last run: `git log --since='<ISO_TIME>' --name-only --pretty=format: | sed '/^$/d' | sort -u`
+- Fallback window: `git log --since='24 hours ago' --name-only --pretty=format: | sed '/^$/d' | sort -u`
+- Dead-code evidence: `rg -n "\\b<SYMBOL>\\b" --glob '!**/*.test.*' --glob '!**/*.spec.*'`
+
+## Repo Notes
+
+- `AGENTS.md` is a symlink to `CLAUDE.md`; edit `CLAUDE.md` to keep both in sync.
+- `/docs` route reads source files from `docs/content` through `app/(docs)/docs/_lib/docs.ts`.
+- Verify dead-code claims with zero non-test references before deleting symbols.
+
+## Latest Update
+
+- 2026-05-13: removed unused `getDocsSlugs` and memoized `getDocsPage` with React `cache` to avoid repeated docs file read/parse work for the same slug during server render and metadata generation.


### PR DESCRIPTION
## Summary
- add a durable  note for code-smell/dead-code automation memory
- update / guidance to reference the durable knowledge note and current docs-content workflow
- remove dead  export and memoize  to avoid duplicate docs file read/parse work for repeated slug requests

## Verification
- Checked 1090 files in 323ms. No fixes applied.
- Formatted 0 files in 2ms. No fixes applied.
   ▲ Next.js 15.5.14
   - Environments: .env.local, .env

   Creating an optimized production build ...

   Linting and checking validity of types ...
   Collecting page data ...
   Generating static pages (0/86) ...
   Generating static pages (21/86) 
   Generating static pages (42/86) 
   Generating static pages (64/86) 
 ✓ Generating static pages (86/86)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                                 Size  First Load JS
┌ ○ /                                      406 B         106 kB
├ ○ /_not-found                             1 kB         107 kB
├ ○ /about                               6.66 kB         121 kB
├ ○ /agents                              2.76 kB         109 kB
├ ○ /ai-chat                               397 B         106 kB
├ ƒ /api/clean                             242 B         106 kB
├ ƒ /api/health                            242 B         106 kB
├ ƒ /api/healthz                           242 B         106 kB
├ ƒ /api/init                              242 B         106 kB
├ ƒ /api/mcp                               242 B         106 kB
├ ƒ /api/pageview                          242 B         106 kB
├ ƒ /api/timezone                          242 B         106 kB
├ ƒ /api/v1/actions                        242 B         106 kB
├ ƒ /api/v1/agent                          242 B         106 kB
├ ƒ /api/v1/agent/skills                   242 B         106 kB
├ ƒ /api/v1/agents/config-check            242 B         106 kB
├ ƒ /api/v1/agents/models                  242 B         106 kB
├ ƒ /api/v1/auth/api-key                   242 B         106 kB
├ ƒ /api/v1/browser-connections/proxy      242 B         106 kB
├ ƒ /api/v1/browser-connections/test       242 B         106 kB
├ ƒ /api/v1/charts/[name]                  242 B         106 kB
├ ƒ /api/v1/cluster-counts/[key]           242 B         106 kB
├ ƒ /api/v1/conversations                  242 B         106 kB
├ ƒ /api/v1/conversations/[id]             242 B         106 kB
├ ƒ /api/v1/dashboard/settings             242 B         106 kB
├ ƒ /api/v1/data                           242 B         106 kB
├ ƒ /api/v1/explain                        242 B         106 kB
├ ƒ /api/v1/explorer/columns               242 B         106 kB
├ ƒ /api/v1/explorer/databases             242 B         106 kB
├ ƒ /api/v1/explorer/ddl                   242 B         106 kB
├ ƒ /api/v1/explorer/dependencies          242 B         106 kB
├ ƒ /api/v1/explorer/indexes               242 B         106 kB
├ ƒ /api/v1/explorer/preview               242 B         106 kB
├ ƒ /api/v1/explorer/projections           242 B         106 kB
├ ƒ /api/v1/explorer/query                 242 B         106 kB
├ ƒ /api/v1/explorer/skip-indexes          242 B         106 kB
├ ƒ /api/v1/explorer/tables                242 B         106 kB
├ ƒ /api/v1/host-status                    242 B         106 kB
├ ƒ /api/v1/hosts                          242 B         106 kB
├ ƒ /api/v1/mcp/info                       242 B         106 kB
├ ƒ /api/v1/menu-counts/[key]              242 B         106 kB
├ ƒ /api/v1/notifications                  242 B         106 kB
├ ƒ /api/v1/overview                       242 B         106 kB
├ ƒ /api/v1/tables/[name]                  242 B         106 kB
├ ƒ /api/version                           242 B         106 kB
├ ○ /asynchronous-metrics                  639 B         391 kB
├ ○ /backups                             1.24 kB         391 kB
├ ○ /charts                                939 B         132 kB
├ ○ /cluster                             11.9 kB         544 kB
├ ○ /clusters                            3.22 kB         386 kB
├ ○ /clusters/replicas-status            5.14 kB         388 kB
├ ○ /common-errors                         848 B         391 kB
├ ○ /dashboard                           6.03 kB         179 kB
├ ○ /detached-parts                        768 B         391 kB
├ ○ /dictionaries                         1.3 kB         392 kB
├ ○ /disks                               1.09 kB         391 kB
├ ○ /distributed-ddl-queue               1.04 kB         391 kB
├ ● /docs/[[...slug]]                    48.3 kB         210 kB
├   ├ /docs
├   ├ /docs/getting-started
├   ├ /docs/getting-started/local
├   └ [+11 more paths]
├ ƒ /docs/assets/[...path]                 242 B         106 kB
├ ○ /errors                                975 B         391 kB
├ ○ /expensive-queries                   2.26 kB         392 kB
├ ○ /expensive-queries-by-memory         1.42 kB         392 kB
├ ○ /explain                             9.71 kB         161 kB
├ ○ /explorer                            2.41 kB         116 kB
├ ○ /failed-queries                      2.06 kB         392 kB
├ ○ /health                              2.43 kB         130 kB
├ ƒ /healthz                               242 B         106 kB
├ ○ /history-queries                     5.34 kB         396 kB
├ ○ /icon.svg                                0 B            0 B
├ ○ /insights                            14.8 kB         545 kB
├ ƒ /llms.txt                              242 B         106 kB
├ ○ /logs/crashes                          967 B         391 kB
├ ○ /logs/stack-traces                     903 B         391 kB
├ ○ /logs/text-log                       1.04 kB         391 kB
├ ○ /mcp                                 12.8 kB         157 kB
├ ○ /merge-performance                   1.37 kB         392 kB
├ ○ /merges                              1.03 kB         391 kB
├ ○ /mergetree-settings                    655 B         391 kB
├ ○ /metrics                               598 B         391 kB
├ ○ /mutations                           1.13 kB         391 kB
├ ○ /overview                            23.9 kB         556 kB
├ ○ /page-views                            940 B         391 kB
├ ○ /part-info                           4.95 kB         387 kB
├ ○ /profiler                              971 B         391 kB
├ ○ /projections                           908 B         391 kB
├ ○ /queries/parallelization               980 B         391 kB
├ ○ /queries/thread-analysis               965 B         391 kB
├ ○ /query                               4.28 kB         387 kB
├ ○ /query-cache                         1.28 kB         392 kB
├ ○ /query-views-log                     1.24 kB         391 kB
├ ○ /readonly-tables                       946 B         391 kB
├ ○ /replicas                            1.02 kB         391 kB
├ ○ /replication-queue                   1.03 kB         391 kB
├ ○ /roles                                 532 B         391 kB
├ ○ /running-queries                     1.75 kB         392 kB
├ ○ /security/audit-log                    851 B         391 kB
├ ○ /security/login-attempts               919 B         391 kB
├ ○ /security/sessions                     850 B         391 kB
├ ○ /settings                              668 B         391 kB
├ ○ /slow-queries                        1.79 kB         392 kB
├ ○ /table                               1.49 kB         115 kB
├ ○ /tables                                405 B         106 kB
├ ○ /tables-overview                     1.42 kB         392 kB
├ ○ /top-usage-columns                   1.32 kB         392 kB
├ ○ /top-usage-tables                    1.43 kB         392 kB
├ ○ /users                                 589 B         391 kB
├ ○ /view-refreshes                      1.08 kB         391 kB
└ ○ /zookeeper                           1.31 kB         392 kB
+ First Load JS shared by all             106 kB
  ├ chunks/1255-aab1fab69a431920.js      45.8 kB
  ├ chunks/4bd1b696-182b6b13bdad92e3.js  54.4 kB
  └ other shared chunks (total)          5.65 kB


ƒ Middleware                             33.8 kB

○  (Static)   prerendered as static content
●  (SSG)      prerendered as static HTML (uses generateStaticParams)
ƒ  (Dynamic)  server-rendered on demand
- bun test v1.3.13 (bf2e2cec)
⏭️  Skipping ClickHouse integration tests - database not available
   To run these tests, ensure ClickHouse is running on localhost:8123
   and CLICKHOUSE_HOST environment variable is set
ℹ️  CLICKHOUSE_HOST not set - integration tests will be skipped

📚 Integration Test Guidance:
   1. Start ClickHouse server locally: docker run -p 8123:8123 clickhouse/clickhouse-server
   2. Set environment variables: export CLICKHOUSE_HOST=http://localhost:8123
   3. Run integration tests: pnpm test-queries-config
   4. Or run all tests: pnpm test

📝 Notes:
   • Integration tests are automatically skipped in CI environments
   • Tests are skipped when ClickHouse is not available locally
   • Use Docker for consistent local testing environment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined repository guidance by consolidating automation tracking into a centralized memory note.
  * Clarified documentation workflow, explaining how docs content is rendered by the main application.
  * Added comprehensive core automation memory documentation for repository management.

* **Refactor**
  * Optimized docs loading performance through caching to minimize repeated file parsing operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1094)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->