### PR TITLE
fix(ci): use Node 22 for Cloudflare deploy

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.22.1'
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
@@ -230,6 +235,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.22.1'
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary
- Install Node 22 in the Cloudflare workflow before Wrangler 4 runs
- Cover both preview and production jobs so direct `npx wrangler@4` calls use the same runtime

## Verification
- `git diff --check`
- pre-commit `tsc --noEmit`
- pre-push `biome check .`

## Summary by Sourcery

CI:
- Add Node.js 22 setup to both preview and production Cloudflare GitHub Actions jobs to align the runtime with Wrangler 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js configuration in preview and production deployment pipelines to ensure consistent runtime environment setup across all deployment stages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1100)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->