### PR TITLE
fix(ci): keep Cloudflare deploy on Wrangler

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -333,6 +333,8 @@ jobs:
       - name: Deploy to Cloudflare Workers
         id: deploy
         uses: cloudflare/wrangler-action@v3
+        env:
+          OPEN_NEXT_DEPLOY: "true"
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- keep the production Cloudflare deploy on the Wrangler action path
- set `OPEN_NEXT_DEPLOY=true` so Wrangler 4.90 does not auto-delegate to `opennextjs-cloudflare deploy`
- avoid the new D1 cache population failure seen after the Node 22 workflow fix

## Verification
- `git diff --check`
- pre-commit `tsc --noEmit`
- pre-push `biome check .`

## Summary by Sourcery

CI:
- Configure the Cloudflare Workers deployment job to set OPEN_NEXT_DEPLOY=true when running the Wrangler action to avoid automatic delegation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cloudflare Workers production deployment configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1101)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->