### PR TITLE
fix(security): harden browser fetch DNS pinning

### DIFF
--- a/lib/browser-connections/host-url.test.ts
+++ b/lib/browser-connections/host-url.test.ts
@@ -172,4 +172,61 @@ describe('validateHostUrl', () => {
       globalThis.fetch = previousFetch
     }
   })
+
+  test('rejects hostname fetches in Cloudflare Workers because DNS pinning is unavailable', async () => {
+    const previousFetch = globalThis.fetch
+    const previousFlag = process.env.CLOUDFLARE_WORKERS
+    const fetchMock = mock(
+      async (_input: Parameters<typeof fetch>[0], _init?: RequestInit) =>
+        new Response('{}', { status: 200 })
+    )
+    globalThis.fetch = fetchMock
+    process.env.CLOUDFLARE_WORKERS = '1'
+
+    try {
+      const guardedFetch = createHostValidationFetch(async () => [
+        '203.0.113.10',
+      ])
+
+      await expect(guardedFetch('https://safe.example:8443')).rejects.toThrow(
+        'Node.js DNS pinning'
+      )
+      expect(fetchMock).not.toHaveBeenCalled()
+    } finally {
+      globalThis.fetch = previousFetch
+      if (previousFlag === undefined) {
+        delete process.env.CLOUDFLARE_WORKERS
+      } else {
+        process.env.CLOUDFLARE_WORKERS = previousFlag
+      }
+    }
+  })
+
+  test('allows IP literal fetches in Cloudflare Workers after validation', async () => {
+    const previousFetch = globalThis.fetch
+    const previousFlag = process.env.CLOUDFLARE_WORKERS
+    const fetchMock = mock(
+      async (_input: Parameters<typeof fetch>[0], _init?: RequestInit) =>
+        new Response('{}', { status: 200 })
+    )
+    globalThis.fetch = fetchMock
+    process.env.CLOUDFLARE_WORKERS = '1'
+
+    try {
+      const guardedFetch = createHostValidationFetch()
+
+      const response = await guardedFetch('https://203.0.113.10:8443')
+
+      expect(response.status).toBe(200)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(fetchMock.mock.calls[0][1]).not.toHaveProperty('dispatcher')
+    } finally {
+      globalThis.fetch = previousFetch
+      if (previousFlag === undefined) {
+        delete process.env.CLOUDFLARE_WORKERS
+      } else {
+        process.env.CLOUDFLARE_WORKERS = previousFlag
+      }
+    }
+  })
 })

--- a/lib/browser-connections/host-url.test.ts
+++ b/lib/browser-connections/host-url.test.ts
@@ -184,14 +184,14 @@ describe('validateHostUrl', () => {
     process.env.CLOUDFLARE_WORKERS = '1'
 
     try {
-      const guardedFetch = createHostValidationFetch(async () => [
-        '203.0.113.10',
-      ])
+      const resolver = mock(async () => ['203.0.113.10'])
+      const guardedFetch = createHostValidationFetch(resolver)
 
       await expect(guardedFetch('https://safe.example:8443')).rejects.toThrow(
         'Node.js DNS pinning'
       )
       expect(fetchMock).not.toHaveBeenCalled()
+      expect(resolver).not.toHaveBeenCalled()
     } finally {
       globalThis.fetch = previousFetch
       if (previousFlag === undefined) {

--- a/lib/browser-connections/host-url.ts
+++ b/lib/browser-connections/host-url.ts
@@ -90,20 +90,22 @@ export function createHostValidationFetch(
   resolveHostAddresses: ResolveHostAddresses = resolveDnsAddresses
 ): typeof fetch {
   return async (input, init) => {
-    const result = await resolveValidatedHostUrl(
-      getFetchUrl(input),
-      resolveHostAddresses
-    )
+    const fetchUrl = getFetchUrl(input)
+
+    if (isCloudflareWorkers()) {
+      const url = parseHttpUrl(fetchUrl)
+      if (url && !isIpLiteral(getNormalizedHostname(url))) {
+        throw new Error(WORKER_DNS_PINNING_ERROR)
+      }
+    }
+
+    const result = await resolveValidatedHostUrl(fetchUrl, resolveHostAddresses)
 
     if (typeof result === 'string') {
       throw new Error(result)
     }
 
     if (isCloudflareWorkers()) {
-      if (!isIpLiteral(getNormalizedHostname(result.url))) {
-        throw new Error(WORKER_DNS_PINNING_ERROR)
-      }
-
       return fetch(input, init)
     }
 
@@ -202,6 +204,15 @@ function getFetchUrl(input: Parameters<typeof fetch>[0]) {
     : input instanceof URL
       ? input.toString()
       : input.url
+}
+
+function parseHttpUrl(host: string) {
+  try {
+    const url = new URL(host)
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url : null
+  } catch {
+    return null
+  }
 }
 
 async function createPinnedDispatcher(address: string) {

--- a/lib/browser-connections/host-url.ts
+++ b/lib/browser-connections/host-url.ts
@@ -1,11 +1,16 @@
 import type { Dispatcher, Agent as UndiciAgent } from 'undici'
 
 import { Address4, Address6 } from 'ip-address'
+import { isCloudflareWorkers } from '@/lib/runtime/cloudflare-workers'
 
 const INTERNAL_ADDRESS_ERROR =
   'Connections to internal addresses are not allowed.'
 const DNS_RESOLUTION_ERROR = 'Unable to resolve host safely.'
+const WORKER_DNS_PINNING_ERROR =
+  'Browser connection hostnames require Node.js DNS pinning. Use an IP literal or run this endpoint in a Node.js runtime.'
 const DNS_LOOKUP_TIMEOUT_MS = 3000
+// Keep Undici out of the Cloudflare Worker bundle; Next tracing includes it for Node standalone.
+const UNDICI_PACKAGE = ['und', 'ici'].join('')
 
 type FetchInitWithDispatcher = RequestInit & { dispatcher: Dispatcher }
 type ClosableDispatcher = Dispatcher & {
@@ -94,6 +99,14 @@ export function createHostValidationFetch(
       throw new Error(result)
     }
 
+    if (isCloudflareWorkers()) {
+      if (!isIpLiteral(getNormalizedHostname(result.url))) {
+        throw new Error(WORKER_DNS_PINNING_ERROR)
+      }
+
+      return fetch(input, init)
+    }
+
     return fetchPinnedToValidatedAddresses(input, init, result.addresses)
   }
 }
@@ -109,14 +122,14 @@ async function fetchPinnedToValidatedAddresses(
     : addresses.slice(0, 1)
 
   for (const address of addressesToTry) {
-    const dispatcher = await createPinnedDispatcher(address)
-    const pinnedInit = { dispatcher } satisfies FetchInitWithDispatcher
-    const undiciFetch = fetch as unknown as (
-      input: Parameters<typeof fetch>[0],
-      init: FetchInitWithDispatcher
-    ) => Promise<Response>
-
+    let dispatcher: Dispatcher | undefined
     try {
+      dispatcher = await createPinnedDispatcher(address)
+      const pinnedInit = { dispatcher } satisfies FetchInitWithDispatcher
+      const undiciFetch = fetch as unknown as (
+        input: Parameters<typeof fetch>[0],
+        init: FetchInitWithDispatcher
+      ) => Promise<Response>
       const response =
         input instanceof Request
           ? await undiciFetch(new Request(input, init), pinnedInit)
@@ -127,7 +140,9 @@ async function fetchPinnedToValidatedAddresses(
 
       return wrapResponseWithDispatcherCleanup(response, dispatcher)
     } catch (error) {
-      closeDispatcher(dispatcher)
+      if (dispatcher) {
+        closeDispatcher(dispatcher)
+      }
       lastError = error
     }
   }
@@ -209,13 +224,8 @@ async function loadUndici() {
 }
 
 async function importUndici() {
-  const dynamicImport = new Function(
-    'specifier',
-    'return import(specifier)'
-  ) as (specifier: string) => Promise<UndiciModule>
-
   try {
-    return await dynamicImport('undici')
+    return (await import(UNDICI_PACKAGE)) as UndiciModule
   } catch (error) {
     throw new Error('Unable to load Node fetch dispatcher for DNS pinning.', {
       cause: error,
@@ -248,6 +258,10 @@ function withTimeout<T>(promise: Promise<T>) {
 
 function isIpLiteral(hostname: string) {
   return isAddress4(hostname) || isAddress6(hostname)
+}
+
+function getNormalizedHostname(url: URL) {
+  return url.hostname.toLowerCase().replace(/^\[|\]$/g, '')
 }
 
 function isAddress4(hostname: string) {

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,7 +16,10 @@ const nextConfig: NextConfig = {
   // Automatically bundle external packages in the Pages Router:
   bundlePagesRouterDependencies: true,
   // Opt specific packages out of bundling for both App and Pages Router:
-  // serverExternalPackages: [],
+  serverExternalPackages: ['undici'],
+  outputFileTracingIncludes: {
+    '/api/v1/browser-connections/*': ['node_modules/undici/**/*'],
+  },
 
   images: {
     unoptimized: true,


### PR DESCRIPTION
## Summary

Addresses still-valid automated review feedback from the merged browser-connection hardening PRs.

- removes runtime `new Function` from the Undici loader
- keeps Undici available to Node standalone output through explicit tracing config
- fails closed for hostname-based browser connections on Cloudflare Workers, where DNS-pinned Undici dispatchers are unavailable
- preserves IP-literal browser connections on Workers after SSRF validation
- catches dispatcher creation failures inside the address fallback loop

## Verification

- `bun test --max-concurrency=1 lib/browser-connections/host-url.test.ts`
- `bun run type-check`
- `bun run lint`
- `bun run cf:build` passes with the existing SWR top-level-await warnings and one intentional expression-import warning for the non-static Undici package name
- `bunx wrangler deploy --dry-run --minify` reports gzip `2997.39 KiB`, under the Cloudflare Worker limit that failed before

## Review Notes

The expression import is intentional. A static `import('undici')` or `webpackIgnore` variant pulls Undici into the OpenNext Worker bundle and pushes gzip size back over the Cloudflare limit. `outputFileTracingIncludes` keeps the package present for Node standalone deployments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced host validation for Cloudflare Workers environments with improved error handling for DNS-based operations.

* **Chores**
  * Updated configuration to ensure proper dependency packaging in serverless deployment contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1106)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->