### PR TITLE
fix(auth): inline NEXT_PUBLIC_AUTH_PROVIDER at build time

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -85,6 +85,7 @@ jobs:
           NEXT_PUBLIC_GIT_REF: ${{ steps.meta.outputs.git_ref }}
           NEXT_PUBLIC_BUILD_TIMESTAMP: ${{ steps.meta.outputs.build_timestamp }}
           NEXT_PUBLIC_CI: "true"
+          NEXT_PUBLIC_AUTH_PROVIDER: "clerk"
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY_TEST }}
         run: |
           # Update wrangler.toml with the test public key for preview environment
@@ -295,6 +296,7 @@ jobs:
           NEXT_PUBLIC_GIT_REF: ${{ steps.meta.outputs.git_ref }}
           NEXT_PUBLIC_BUILD_TIMESTAMP: ${{ steps.meta.outputs.build_timestamp }}
           NEXT_PUBLIC_CI: "true"
+          NEXT_PUBLIC_AUTH_PROVIDER: "clerk"
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
         run: |
           echo "Building with metadata:"

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -3,6 +3,7 @@
  * GET /api/health - Returns system health and memory usage statistics
  */
 
+import { getAuthProvider, isAuthProviderConfigError } from '@/lib/auth/provider'
 import {
   getHealthMetrics,
   isMemoryCritical,
@@ -11,6 +12,28 @@ import {
 
 // This route is dynamic and should not be statically exported
 export const dynamic = 'force-dynamic'
+
+function getDeploymentInfo() {
+  let authProvider: string
+  try {
+    authProvider = getAuthProvider()
+  } catch (err) {
+    authProvider = isAuthProviderConfigError(err) ? 'invalid' : 'unknown'
+  }
+
+  return {
+    gitSha: process.env.NEXT_PUBLIC_GIT_SHA ?? null,
+    gitRef: process.env.NEXT_PUBLIC_GIT_REF ?? null,
+    buildTimestamp: process.env.NEXT_PUBLIC_BUILD_TIMESTAMP ?? null,
+    ci: process.env.NEXT_PUBLIC_CI === 'true',
+    runtime: process.env.CLOUDFLARE_WORKERS === '1' ? 'cloudflare' : 'node',
+    authProvider,
+    clientAuthProvider: process.env.NEXT_PUBLIC_AUTH_PROVIDER ?? null,
+    agentAccess: process.env.CHM_FEATURE_AGENT_ACCESS ?? 'public',
+    clerkPublishableKeyPrefix:
+      process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?.slice(0, 8) ?? null,
+  }
+}
 
 export async function GET() {
   try {
@@ -22,6 +45,7 @@ export async function GET() {
       {
         status: critical ? 'critical' : warning ? 'warning' : 'ok',
         timestamp: new Date().toISOString(),
+        deployment: getDeploymentInfo(),
         metrics,
         alerts: {
           memoryWarning: warning,


### PR DESCRIPTION
## Summary

- Fix login button missing on chmonitor.dev — client bundle was falling back to guest mode despite Clerk being configured.
- Extend `/api/health` with a `deployment` block so a single curl reveals which build is live and whether auth env vars are wired.

## Root cause

`NEXT_PUBLIC_*` env vars are inlined by Next.js **at build time**. `wrangler.toml [vars]` only affects server-side handlers. The CI build step passed `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` but not `NEXT_PUBLIC_AUTH_PROVIDER`, so the browser saw `getAuthProvider() === 'none'` → `isClerkEnabled()` returned `false` → `nav-user.tsx:54` rendered the guest dropdown.

## Changes

- `.github/workflows/cloudflare.yml`: add `NEXT_PUBLIC_AUTH_PROVIDER: "clerk"` to preview and production build envs.
- `app/api/health/route.ts`: add `deployment` block (`gitSha`, `gitRef`, `buildTimestamp`, `runtime`, `authProvider`, `clientAuthProvider`, `agentAccess`, `clerkPublishableKeyPrefix`). `authProvider` vs `clientAuthProvider` lets ops diagnose runtime/bundle skew exactly like this incident.

## Test plan

- [ ] CI build green
- [ ] After production deploy, `curl https://chmonitor.dev/api/health` shows `deployment.clientAuthProvider === "clerk"` and `clerkPublishableKeyPrefix === "pk_live_"`
- [ ] Visit chmonitor.dev — sign-in button appears instead of "Guest / guest@local"
- [ ] Preview deploy (`pk_test_`) still works for PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health check endpoint now returns detailed deployment metadata including build timestamps, git information, runtime details, and authentication configuration for improved monitoring and diagnostics.

* **Chores**
  * Updated deployment configuration to specify authentication provider during the build process for preview and production environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1107)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->