### PR TITLE
feat(agents): user tracking for OpenRouter analytics

### DIFF
--- a/app/api/v1/agent/route.ts
+++ b/app/api/v1/agent/route.ts
@@ -29,6 +29,7 @@ import { classifyError } from '@/lib/ai/agent/errors'
 import { AGENT_JSON_RENDER_INLINE_PROMPT } from '@/lib/ai/agent/json-render-inline-prompt'
 import { createJsonRenderPatchGuardStream } from '@/lib/ai/agent/json-render-patch-guard'
 import { authorizeAgentApiRequest } from '@/lib/auth/agent-api-auth'
+import { isClerkAuthProvider } from '@/lib/auth/provider'
 
 // This route is dynamic and should not be statically exported
 export const dynamic = 'force-dynamic'
@@ -391,14 +392,16 @@ export async function POST(request: Request) {
       ? body.sessionId
       : crypto.randomUUID()
 
-  // Resolve Clerk user ID for OpenRouter user tracking
+  // Resolve user ID for OpenRouter user tracking
   let userId = 'guest'
-  try {
-    const { auth } = await import('@clerk/nextjs/server')
-    const authResult = await auth()
-    if (authResult?.userId) userId = authResult.userId
-  } catch {
-    // Bearer token auth or Clerk unavailable
+  if (isClerkAuthProvider()) {
+    try {
+      const { auth } = await import('@clerk/nextjs/server')
+      const authResult = await auth()
+      if (authResult?.userId) userId = authResult.userId
+    } catch {
+      // Clerk session unavailable
+    }
   }
   const openRouterUser = `${userId}/${sessionId}`
 


### PR DESCRIPTION
## Summary
- Track Clerk user ID + session ID via OpenRouter `user` parameter for per-user analytics
- Frontend generates `sessionId` (UUID), sends in every API request, resets on chat clear
- Server resolves Clerk `userId` (falls back to `guest`), formats as `{userId}/{sessionId}`
- Skips Clerk import when auth provider is not Clerk (`auth=none`)

## Test plan
- [ ] Type check passes (`bun run type-check`)
- [ ] Agent tests pass (`bun test lib/ai/agent/`)
- [ ] With Clerk auth: check server logs show `user_2xxx/session-uuid`
- [ ] With `auth=none`: check server logs show `guest/session-uuid`
- [ ] Clear chat: verify new session ID is generated

## Summary by Sourcery

New Features:
- Introduce provider-aware resolution of user IDs for OpenRouter user tracking, defaulting to guest when Clerk auth is not in use.