### PR TITLE
feat(agents): unify app attribution headers across providers

### DIFF
--- a/lib/ai/agent/clickhouse-agent.ts
+++ b/lib/ai/agent/clickhouse-agent.ts
@@ -43,8 +43,10 @@ function isAnthropicModel(model: string): boolean {
 
 const DEFAULT_MAX_STEPS = 30
 
-export const DEFAULT_OPENROUTER_REFERER = 'https://chmonitor.dev'
-export const DEFAULT_OPENROUTER_APP_NAME = 'ClickHouse Monitoring'
+export const DEFAULT_APP_REFERER = 'https://chmonitor.dev'
+export const DEFAULT_APP_NAME = 'ClickHouse Monitoring'
+export const DEFAULT_APP_CATEGORY = 'programming-app'
+export const DEFAULT_APP_VERSION = '0.2.0'
 
 export function createClickHouseAgent(options: {
   /** Model ID in `provider:model` format (e.g., `openrouter:openrouter/free`) */
@@ -93,10 +95,26 @@ export function createClickHouseAgent(options: {
     tools,
     systemPrompt,
     maxSteps,
+    referer,
   })
 }
 
 type ToolSet = ReturnType<typeof createMcpTools>
+
+function buildProviderHeaders(
+  providerId: string,
+  referer?: string
+): Record<string, string> | undefined {
+  if (providerId === 'anyrouter') {
+    return {
+      'X-AnyRouter-Title': process.env.APP_NAME || DEFAULT_APP_NAME,
+      'X-AnyRouter-Source': process.env.APP_CATEGORY || DEFAULT_APP_CATEGORY,
+      'X-AnyRouter-Version': process.env.APP_VERSION || DEFAULT_APP_VERSION,
+      'HTTP-Referer': referer || process.env.APP_REFERER || DEFAULT_APP_REFERER,
+    }
+  }
+  return undefined
+}
 
 function createOpenRouterAgent(opts: {
   resolved: ReturnType<typeof resolveProvider>
@@ -119,16 +137,16 @@ function createOpenRouterAgent(opts: {
     referer,
   } = opts
 
-  const openRouterReferer =
-    referer || process.env.OPENROUTER_REFERER || DEFAULT_OPENROUTER_REFERER
-  const openRouterAppName =
-    process.env.OPENROUTER_APP_NAME || DEFAULT_OPENROUTER_APP_NAME
+  const appReferer = referer || process.env.APP_REFERER || DEFAULT_APP_REFERER
+  const appName = process.env.APP_NAME || DEFAULT_APP_NAME
+  const appCategory = process.env.APP_CATEGORY || DEFAULT_APP_CATEGORY
 
   const openrouter = createOpenRouter({
     apiKey: resolved.apiKey,
     headers: {
-      'HTTP-Referer': openRouterReferer,
-      'X-OpenRouter-Title': openRouterAppName,
+      'HTTP-Referer': appReferer,
+      'X-OpenRouter-Title': appName,
+      ...(appCategory && { 'X-OpenRouter-Categories': appCategory }),
     },
   })
 
@@ -175,13 +193,17 @@ function createOpenAIAgent(opts: {
   tools: ToolSet
   systemPrompt: string
   maxSteps: number
+  referer?: string
 }) {
-  const { resolved, modelId, tools, systemPrompt, maxSteps } = opts
+  const { resolved, modelId, tools, systemPrompt, maxSteps, referer } = opts
+
+  const headers = buildProviderHeaders(resolved.providerId, referer)
 
   const openai = createOpenAI({
     apiKey: resolved.apiKey,
     baseURL: resolved.baseURL,
     name: resolved.providerId,
+    ...(headers && { headers }),
   })
 
   return new ToolLoopAgent({

--- a/lib/ai/agent/clickhouse-agent.ts
+++ b/lib/ai/agent/clickhouse-agent.ts
@@ -101,16 +101,38 @@ export function createClickHouseAgent(options: {
 
 type ToolSet = ReturnType<typeof createMcpTools>
 
+/**
+ * Resolve app attribution metadata from env + defaults.
+ * `APP_*` is the canonical name; `OPENROUTER_*` is supported as a fallback
+ * so existing deployments that set the older vars keep working.
+ */
+function getAppMetadata(referer?: string) {
+  return {
+    referer:
+      referer ||
+      process.env.APP_REFERER ||
+      process.env.OPENROUTER_REFERER ||
+      DEFAULT_APP_REFERER,
+    name:
+      process.env.APP_NAME ||
+      process.env.OPENROUTER_APP_NAME ||
+      DEFAULT_APP_NAME,
+    category: process.env.APP_CATEGORY || DEFAULT_APP_CATEGORY,
+    version: process.env.APP_VERSION || DEFAULT_APP_VERSION,
+  }
+}
+
 function buildProviderHeaders(
   providerId: string,
   referer?: string
 ): Record<string, string> | undefined {
   if (providerId === 'anyrouter') {
+    const meta = getAppMetadata(referer)
     return {
-      'X-AnyRouter-Title': process.env.APP_NAME || DEFAULT_APP_NAME,
-      'X-AnyRouter-Source': process.env.APP_CATEGORY || DEFAULT_APP_CATEGORY,
-      'X-AnyRouter-Version': process.env.APP_VERSION || DEFAULT_APP_VERSION,
-      'HTTP-Referer': referer || process.env.APP_REFERER || DEFAULT_APP_REFERER,
+      'X-AnyRouter-Title': meta.name,
+      'X-AnyRouter-Source': meta.category,
+      'X-AnyRouter-Version': meta.version,
+      'HTTP-Referer': meta.referer,
     }
   }
   return undefined
@@ -137,16 +159,14 @@ function createOpenRouterAgent(opts: {
     referer,
   } = opts
 
-  const appReferer = referer || process.env.APP_REFERER || DEFAULT_APP_REFERER
-  const appName = process.env.APP_NAME || DEFAULT_APP_NAME
-  const appCategory = process.env.APP_CATEGORY || DEFAULT_APP_CATEGORY
+  const meta = getAppMetadata(referer)
 
   const openrouter = createOpenRouter({
     apiKey: resolved.apiKey,
     headers: {
-      'HTTP-Referer': appReferer,
-      'X-OpenRouter-Title': appName,
-      ...(appCategory && { 'X-OpenRouter-Categories': appCategory }),
+      'HTTP-Referer': meta.referer,
+      'X-OpenRouter-Title': meta.name,
+      'X-OpenRouter-Categories': meta.category,
     },
   })
 


### PR DESCRIPTION
## Summary
- OpenRouter requests now include `X-OpenRouter-Categories` alongside the existing `HTTP-Referer` and `X-OpenRouter-Title` so chmonitor.dev shows up in OpenRouter's marketplace rankings.
- AnyRouter requests now include the required attribution pair (`X-AnyRouter-Title`, `X-AnyRouter-Source`) plus optional `X-AnyRouter-Version` and `HTTP-Referer`, enabling AnyRouter rankings and analytics.
- Both providers share one set of env vars + defaults (`APP_REFERER`, `APP_NAME`, `APP_CATEGORY`, `APP_VERSION`), so updates land in both places at once. Per-request origin (from the request) still overrides for `HTTP-Referer`.
- NVIDIA path unchanged — `buildProviderHeaders` returns `undefined` for non-AnyRouter OpenAI-SDK providers.

## Test plan
- [x] `bun run type-check` — clean
- [x] `bun test lib/ai/agent/__tests__/` — 62 pass
- [ ] After merge: confirm chmonitor.dev appears in OpenRouter + AnyRouter rankings within ~24h

## Summary by Sourcery

Unify application attribution headers and configuration across OpenRouter and AnyRouter providers while leaving other providers unchanged.

New Features:
- Add shared application metadata defaults (referer, name, category, version) for provider attribution headers.
- Include OpenRouter category attribution via the X-OpenRouter-Categories header driven by shared app configuration.
- Add AnyRouter-specific attribution headers, including title, source, version, and referer, when using the OpenAI-based provider path.

Enhancements:
- Refactor provider header construction into a reusable helper for OpenAI-based providers, returning headers only for AnyRouter.