### PR TITLE
fix(ci): avoid bun prepare during docker install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM base AS deps
 ENV NODE_ENV=production
 RUN apk add --no-cache libc6-compat
 COPY package.json bun.lock ./
-RUN HUSKY=0 bun install --frozen-lockfile --production
+RUN bun install --frozen-lockfile --production --ignore-scripts
 
 # Rebuild the source code only when needed
 FROM base AS builder

--- a/app/api/v1/agent/__tests__/route.test.ts
+++ b/app/api/v1/agent/__tests__/route.test.ts
@@ -80,6 +80,7 @@ mock.module('ai', () => {
         merge: (value: unknown) => {
           record.mergedChunk = value
         },
+        write: (_value: unknown) => {},
       }
 
       capturedAIArgs.push(record)

--- a/app/api/v1/agent/__tests__/route.test.ts
+++ b/app/api/v1/agent/__tests__/route.test.ts
@@ -144,6 +144,8 @@ describe('POST /api/v1/agent', () => {
     mockClerkUserId = null
     process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'clerk'
     delete process.env.CHM_FEATURE_AGENT_ACCESS
+    process.env.LLM_API_KEY = 'test-llm-key'
+    process.env.LLM_MODEL = 'openrouter:openrouter/auto'
     process.env.OPENROUTER_API_KEY = 'test-openrouter-key'
   })
 

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -40,3 +40,4 @@ Durable code-smell/dead-code automation memory. Do not create dated files under 
 - 2026-05-13: removed unused `getDocsSlugs` and memoized `getDocsPage` with React `cache`
 - 2026-05-14: removed four zero-reference dead-code candidates from recent auth/deploy changes (`HeaderClient`, `getClerkPublishableKey`, `SemverRange`, `QueryConfigNoName`)
 - 2026-05-15: fixed Docker CI break by skipping Husky in production install (`HUSKY=0 bun install --production`) and removed global SQL validator mock from `helpers.test.ts` to avoid cross-suite pollution
+- 2026-05-15: follow-up Docker fix uses `bun install --production --ignore-scripts` because Bun still executes root `prepare`; agent route tests now set `LLM_API_KEY`/`LLM_MODEL` in `beforeEach` to avoid provider-preflight `503` from ambient CI env


### PR DESCRIPTION
## Summary
- switch Docker deps install to `bun install --frozen-lockfile --production --ignore-scripts`
- keep agent route tests deterministic by setting `LLM_API_KEY` and `LLM_MODEL` in `beforeEach`
- append this follow-up CI lesson to durable `docs/knowledge/core-memory.md`

## Why
- main workflow `Image build and Push` failed on merge commit `b497d6a3...` because Bun still executed root `prepare` (`husky`) during production install despite `HUSKY=0`.
- main workflow `Test` reported repeated `503` failures in `app/api/v1/agent/__tests__/route.test.ts` when provider preflight read ambient CI env.

## Validation
- `bun run lint` (passes with one pre-existing warning in `components/agents/agent-settings.tsx`)

## Summary by Sourcery

Adjust Docker dependency installation and test env setup to stabilize CI builds and agent route tests.

Bug Fixes:
- Prevent Docker image builds from running Bun prepare scripts during production dependency installation.
- Stabilize agent route tests by isolating LLM configuration from ambient CI environment variables.

Documentation:
- Add a durable core-memory entry documenting the Docker install change and agent route test environment fix.