### PR TITLE
fix(ci): restore docker deps for cloudflare build import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,7 @@ Both deployment methods provide:
 - Dead-code evidence: `rg -n "\b<SYMBOL>\b" --glob '!**/__tests__/**' --glob '!**/*.test.*' --glob '!**/*.spec.*'`
 - Main CI status check: `gh run list --branch main --limit 10 --json workflowName,status,conclusion,headSha,url`
 - Failed-job logs in restricted cache environments: `XDG_CACHE_HOME=/private/tmp/gh-cache gh run view <RUN_ID> --job <JOB_ID> --log-failed`
+- Docker deps-stage parity check: `bun install --frozen-lockfile --ignore-scripts && bun run build` (`lib/platform/adapters/cloudflare.ts` imports `@opennextjs/cloudflare` during build)
 - Cloudflare worker size dry-run: `bun wrangler deploy --minify --dry-run`
 
 **Docs content workflow**: `/docs` pages are rendered by the main app and read source files from `docs/content`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM base AS deps
 ENV NODE_ENV=production
 RUN apk add --no-cache libc6-compat
 COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile --production --ignore-scripts
+RUN bun install --frozen-lockfile --ignore-scripts
 
 # Rebuild the source code only when needed
 FROM base AS builder

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -3,7 +3,7 @@ id: core-memory
 title: Automation Core Memory
 type: workflow
 status: active
-updated: 2026-05-15
+updated: 2026-05-16
 tags:
   - automation
   - code-smell
@@ -33,6 +33,7 @@ Durable code-smell/dead-code automation memory. Do not create dated files under 
 - `AGENTS.md` is a symlink to `CLAUDE.md`; edit `CLAUDE.md` to keep both in sync
 - `/docs` route reads source files from `docs/content` through `app/(docs)/docs/_lib/docs.ts`
 - Verify dead-code claims with zero non-test references before deleting symbols
+- Docker build must install full deps (`bun install --frozen-lockfile --ignore-scripts`) because `lib/platform/adapters/cloudflare.ts` imports `@opennextjs/cloudflare` during `bun run build`
 
 ## Latest Update
 
@@ -41,3 +42,4 @@ Durable code-smell/dead-code automation memory. Do not create dated files under 
 - 2026-05-14: removed four zero-reference dead-code candidates from recent auth/deploy changes (`HeaderClient`, `getClerkPublishableKey`, `SemverRange`, `QueryConfigNoName`)
 - 2026-05-15: fixed Docker CI break by skipping Husky in production install (`HUSKY=0 bun install --production`) and removed global SQL validator mock from `helpers.test.ts` to avoid cross-suite pollution
 - 2026-05-15: follow-up Docker fix uses `bun install --production --ignore-scripts` because Bun still executes root `prepare`; agent route tests now set `LLM_API_KEY`/`LLM_MODEL` in `beforeEach` to avoid provider-preflight `503` from ambient CI env
+- 2026-05-16: fixed `Image build and Push` failures on main (`Module not found: Can't resolve '@opennextjs/cloudflare'`) by removing Docker `--production` install in the deps stage while keeping `--ignore-scripts`


### PR DESCRIPTION
## Summary
- restore Docker deps-stage install to `bun install --frozen-lockfile --ignore-scripts` (remove `--production`)
- document the CI workflow rule in `docs/knowledge/core-memory.md`
- sync the same command note in `CLAUDE.md` (`AGENTS.md` is symlinked)

## Evidence
- Main run failures on commit `c9f73281fecec0b3d7758161d210973a5d206373`:
  - `Image build and Push` run: https://github.com/duyet/clickhouse-monitoring/actions/runs/25924910395
  - failed jobs: `build-docker-amd64 / docker` and `build-docker-arm64 / docker`
  - error: `Module not found: Can't resolve '@opennextjs/cloudflare'` from `lib/platform/adapters/cloudflare.ts`

## Verification
- `TMPDIR=/private/var/folders/h0/jc2125dj0kd4q7ppyqdn399h0000gn/T BUN_INSTALL_CACHE_DIR=/private/tmp/bun-cache bun install --frozen-lockfile --ignore-scripts && TMPDIR=/private/var/folders/h0/jc2125dj0kd4q7ppyqdn399h0000gn/T BUN_INSTALL_CACHE_DIR=/private/tmp/bun-cache bun run build`

## Summary by Sourcery

Restore full dependency installation in the Docker deps stage to fix Cloudflare build imports and update internal documentation to record the workflow rule and parity check command.

Bug Fixes:
- Fix Docker image build failures by installing all dependencies (without production-only filtering) in the deps stage so Cloudflare adapter imports resolve during build.

Documentation:
- Document the Docker dependency installation requirement for Cloudflare builds in the core memory workflow doc.
- Add a Docker deps-stage parity check command to CLAUDE.md to guide local verification of the CI build behavior.