### PR TITLE
fix(auth): default agent and actions features to authenticated

### DIFF
--- a/lib/feature-permissions/permissions.ts
+++ b/lib/feature-permissions/permissions.ts
@@ -2,10 +2,12 @@ import type { FeaturePermission } from './types'
 
 export const AGENT_FEATURE_PERMISSION = {
   feature: 'agent',
+  defaultAccess: 'authenticated',
 } satisfies FeaturePermission
 
 export const ACTIONS_FEATURE_PERMISSION = {
   feature: 'actions',
+  defaultAccess: 'authenticated',
 } satisfies FeaturePermission
 
 export const OVERVIEW_FEATURE_PERMISSION = {


### PR DESCRIPTION
### Motivation
- Sensitive endpoints (`/api/v1/agent`, `/api/v1/actions`) unintentionally inherited a global `public` default which could bypass existing `AGENT_API_TOKEN`/Clerk protections, so features should be secure-by-default.

### Description
- Set `defaultAccess: 'authenticated'` for `AGENT_FEATURE_PERMISSION` and `ACTIONS_FEATURE_PERMISSION` in `lib/feature-permissions/permissions.ts` to require authentication unless explicitly overridden.

### Testing
- Attempted targeted unit tests `bun run test` for agent/feature-permission suites which failed in this environment due to missing runtime/test deps (e.g. `@clerk/nextjs/server`, `next/server`, `@json-render/core`); tests could not be validated here.
- Attempted `bun run build` which failed in this environment because the `next` build script/binary was not available, so a full build verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b77597188332804f3cc2d8800356)

## Summary by Sourcery

Set agent and actions feature permissions to require authenticated access by default to secure sensitive endpoints.

Bug Fixes:
- Ensure agent-related features default to authenticated access instead of inheriting a public default.
- Ensure actions-related features default to authenticated access instead of inheriting a public default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default authentication requirements for agent and actions features to require authenticated access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->