### PR TITLE
chore(automation): remove dead export and refine scan commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,7 @@ Both deployment methods provide:
 - `bun run lint && bun run build` - Quick local CI parity check (matches core lint/build workflow jobs)
 - Code-smell/dead-code automation: see [docs/knowledge/core-memory.md](docs/knowledge/core-memory.md)
 - Since-last-run scan scope: `git log --since='<ISO_TIME>' --name-only --pretty=format: | sed '/^$/d' | sort -u`
+- Since-last-run scan scope (source commits only): `git log --since='<ISO_TIME>' --no-merges --name-only --pretty=format: | sed '/^$/d' | sort -u`
 - Fallback scan (24h): `git log --since='24 hours ago' --name-only --pretty=format: | sed '/^$/d' | sort -u`
 - Fallback scan (7d): `git log --since='7 days ago' --name-only --pretty=format: | sed '/^$/d' | sort -u`
 - Empty-window rule: if since-last-run has zero commits, run 24h then 7d fallback and report no-op when both are empty

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -21,6 +21,7 @@ Durable code-smell/dead-code automation memory. Do not create dated files under 
 ## Commands
 
 - Since last run: `git log --since='<ISO_TIME>' --name-only --pretty=format: | sed '/^$/d' | sort -u`
+- Since last run (source commits only): `git log --since='<ISO_TIME>' --no-merges --name-only --pretty=format: | sed '/^$/d' | sort -u`
 - Fallback window (24h): `git log --since='24 hours ago' --name-only --pretty=format: | sed '/^$/d' | sort -u`
 - Fallback window (7d): `git log --since='7 days ago' --name-only --pretty=format: | sed '/^$/d' | sort -u`
 - Empty-window rule: if since-last-run has zero commits, run 24h then 7d fallback and report no-op when both are empty
@@ -47,3 +48,4 @@ Durable code-smell/dead-code automation memory. Do not create dated files under 
 - 2026-05-16: fixed `Image build and Push` failures on main (`Module not found: Can't resolve '@opennextjs/cloudflare'`) by removing Docker `--production` install in the deps stage while keeping `--ignore-scripts`
 - 2026-05-17: automation run started on detached worktree (`HEAD (no branch)`), so branch/PR work should pivot to `/Users/duet/project/clickhouse-monitor` when git metadata writes fail in `.git/worktrees/...`
 - 2026-05-18: no commits since last run timestamp; 24h fallback was empty, 7d fallback used for evidence-only audit with no new actionable code-smell/dead-code/perf findings
+- 2026-05-19: removed zero-reference `findModelEntry` export from `lib/ai/agent-model-registry.ts`; add `--no-merges` scan variant to reduce merge-only noise in code-smell/dead-code windows

--- a/lib/ai/agent-model-registry.ts
+++ b/lib/ai/agent-model-registry.ts
@@ -96,10 +96,6 @@ export function getAllModelOptions(): string[] {
   return MODEL_REGISTRY.flatMap((m) => m.providers.map((p) => `${p}:${m.id}`))
 }
 
-export function findModelEntry(modelId: string): ModelEntry | undefined {
-  return MODEL_REGISTRY.find((m) => m.id === modelId)
-}
-
 export function isFreeAgentModel(model: string): boolean {
   return model === 'openrouter/free' || model.endsWith(':free')
 }


### PR DESCRIPTION
## Summary
- remove unused `findModelEntry` export from `lib/ai/agent-model-registry.ts` (zero references found)
- add `--no-merges` since-last-run scan variant to automation command docs in `CLAUDE.md`
- append this run to `docs/knowledge/core-memory.md` and keep durable memory flow (no dated review docs)

## Evidence
- scanned commits since last run (2026-05-17T21:01:50Z): `83b7412`, `8edabd2`, `bd0826d`
- dead-code proof: `rg -n "\bfindModelEntry\b"` returns only `lib/ai/agent-model-registry.ts`

## Verification
- pass: `bun test lib/ai/agent-models.test.ts app/api/v1/agent/followups/__tests__/route.test.ts app/api/v1/agents/config-check/__tests__/route.test.ts lib/ai/agent/__tests__/errors.test.ts lib/ai/agent/__tests__/message-metadata.test.ts lib/ai/agent/__tests__/suggested-prompts.test.ts` (run in automation worktree)
- note: the same command fails in the writable PR worktree because that checkout does not have local deps (`next/server`, `zod`)
