### PR TITLE
fix(security): enforce authz boundaries and harden SQL validation

### DIFF
--- a/app/api/clean/route.ts
+++ b/app/api/clean/route.ts
@@ -7,6 +7,8 @@ import { getHostIdFromParams } from '@/lib/api/error-handler'
 import { EVENTS_TABLE } from '@/lib/app-tables'
 import { getClient } from '@/lib/clickhouse'
 import { ErrorLogger } from '@/lib/logger'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
+import { ACTIONS_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
 
 const QUERY_CLEANUP_MAX_DURATION_SECONDS = 10 * 60 // 10 minutes
 const MONITORING_USER = process.env.CLICKHOUSE_USER || ''
@@ -14,13 +16,13 @@ const MONITORING_USER = process.env.CLICKHOUSE_USER || ''
 export const dynamic = 'force-dynamic'
 export const maxDuration = 30
 
-export async function GET(request: Request) {
+export async function POST(request: Request) {
   const searchParams = new URL(request.url).searchParams
   let hostId: number
 
   try {
     const parsedHostId = getHostIdFromParams(searchParams, {
-      route: '/api/clean',
+      route: '/api/clean', method: 'POST',
     })
     hostId =
       typeof parsedHostId === 'string'
@@ -33,6 +35,9 @@ export async function GET(request: Request) {
     )
   }
 
+  const permissionResponse = await authorizeFeatureRequest(ACTIONS_FEATURE_PERMISSION, request)
+  if (permissionResponse) return permissionResponse
+
   try {
     // getClient will auto-detect and use web client for Cloudflare Workers
     const client = await getClient({ hostId })
@@ -41,7 +46,7 @@ export async function GET(request: Request) {
   } catch (error) {
     ErrorLogger.logError(
       error instanceof Error ? error : new Error(String(error)),
-      { route: '/api/clean' }
+      { route: '/api/clean', method: 'POST' }
     )
     return NextResponse.json(
       { status: false, error: `${error}` },
@@ -72,7 +77,7 @@ async function cleanupHangQuery(
   }
 
   ErrorLogger.logDebug('[/api/clean] Starting clean up hang queries', {
-    route: '/api/clean',
+    route: '/api/clean', method: 'POST',
   })
 
   const killQueryResp = await killHangingQueries(client)
@@ -80,7 +85,7 @@ async function cleanupHangQuery(
 
   if (!killQueryResp || killQueryResp.rows === 0) {
     ErrorLogger.logDebug('[/api/clean] Done, nothing to cleanup', {
-      route: '/api/clean',
+      route: '/api/clean', method: 'POST',
     })
     return { lastCleanup, message: 'Nothing to cleanup' }
   }
@@ -111,7 +116,7 @@ async function getLastCleanup(
     const now = new Date(data[0].now)
     ErrorLogger.logDebug(
       `[/api/clean] Last cleanup: ${lastCleanup}, now: ${now}`,
-      { route: '/api/clean' }
+      { route: '/api/clean', method: 'POST' }
     )
     return [lastCleanup, now]
   } catch (error) {
@@ -145,7 +150,7 @@ async function killHangingQueries(
     const killQueryResp = (await resp.json()) as unknown as KillQueryResponse
 
     ErrorLogger.logDebug('[/api/clean] queries found', {
-      route: '/api/clean',
+      route: '/api/clean', method: 'POST',
       queryIds: killQueryResp.data.map((row) => row.query_id).join(', '),
     })
     return killQueryResp
@@ -155,7 +160,7 @@ async function killHangingQueries(
       error.message.includes('Unexpected end of JSON input')
     ) {
       ErrorLogger.logDebug('[/api/clean] Done, nothing to cleanup', {
-        route: '/api/clean',
+        route: '/api/clean', method: 'POST',
       })
       return null
     }
@@ -173,12 +178,12 @@ async function updateLastCleanup(
       format: 'JSONEachRow',
     })
     ErrorLogger.logDebug('[/api/clean] LastCleanup event created', {
-      route: '/api/clean',
+      route: '/api/clean', method: 'POST',
     })
   } catch (error) {
     ErrorLogger.logError(
       error instanceof Error ? error : new Error(String(error)),
-      { route: '/api/clean', event: 'LastCleanup' }
+      { route: '/api/clean', method: 'POST', event: 'LastCleanup' }
     )
     throw new Error(`'LastCleanup' event creating error: ${error}`)
   }
@@ -197,7 +202,7 @@ async function createSystemKillQueryEvent(
       {} as Record<string, number>
     )
     ErrorLogger.logDebug('[/api/clean] Kill status', {
-      route: '/api/clean',
+      route: '/api/clean', method: 'POST',
       killStatus,
     })
 
@@ -217,7 +222,7 @@ async function createSystemKillQueryEvent(
   } catch (error) {
     ErrorLogger.logError(
       error instanceof Error ? error : new Error(String(error)),
-      { route: '/api/clean', event: 'SystemKillQuery' }
+      { route: '/api/clean', method: 'POST', event: 'SystemKillQuery' }
     )
   }
 }

--- a/app/api/init/route.ts
+++ b/app/api/init/route.ts
@@ -2,11 +2,13 @@ import { NextResponse } from 'next/server'
 import { getHostIdFromParams } from '@/lib/api/error-handler'
 import { getClient } from '@/lib/clickhouse'
 import { ErrorLogger } from '@/lib/logger'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
+import { ACTIONS_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
 import { initTrackingTable } from '@/lib/tracking'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET(request: Request) {
+export async function POST(request: Request) {
   const searchParams = new URL(request.url).searchParams
   let hostId: number
 
@@ -24,6 +26,9 @@ export async function GET(request: Request) {
       { status: 400 }
     )
   }
+
+  const permissionResponse = await authorizeFeatureRequest(ACTIONS_FEATURE_PERMISSION, request)
+  if (permissionResponse) return permissionResponse
 
   // getClient will auto-detect and use web client for Cloudflare Workers
   const client = await getClient({ hostId })

--- a/app/api/v1/agent/route.ts
+++ b/app/api/v1/agent/route.ts
@@ -24,6 +24,8 @@ import {
   type UITools,
 } from 'ai'
 import { createClickHouseAgent } from '@/lib/ai/agent'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
+import { ACTIONS_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
 import { aggregateUsageWithCost } from '@/lib/ai/agent/analytics'
 import { classifyError } from '@/lib/ai/agent/errors'
 import { AGENT_JSON_RENDER_INLINE_PROMPT } from '@/lib/ai/agent/json-render-inline-prompt'
@@ -441,6 +443,12 @@ export async function POST(request: Request) {
     console.log('[Agent API] OpenRouter user:', openRouterUser)
   }
 
+  const controlToolsEnabled = process.env.AGENT_ENABLE_CONTROL_TOOLS === 'true'
+  const actionsPermissionResponse = controlToolsEnabled
+    ? await authorizeFeatureRequest(ACTIONS_FEATURE_PERMISSION, request)
+    : null
+  const includeControlTools = controlToolsEnabled && !actionsPermissionResponse
+
   const requestOrigin = request.headers.get('origin') ?? undefined
   const agent = createClickHouseAgent({
     hostId,
@@ -449,6 +457,7 @@ export async function POST(request: Request) {
     systemPrompt: AGENT_JSON_RENDER_INLINE_PROMPT,
     providerOptions: { openrouter: { user: openRouterUser } },
     referer: requestOrigin,
+    includeControlTools,
   })
 
   const uiMessages: Array<{

--- a/app/api/v1/explorer/columns/route.ts
+++ b/app/api/v1/explorer/columns/route.ts
@@ -15,9 +15,15 @@ import {
 import { getTableQuery } from '@/lib/api/table-registry'
 import { ApiErrorType } from '@/lib/api/types'
 import { fetchData } from '@/lib/clickhouse'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 import { debug, error } from '@/lib/logger'
 
 export const dynamic = 'force-dynamic'
+
+const TABLES_FEATURE_PERMISSION = {
+  feature: 'tables',
+  defaultAccess: 'authenticated',
+} as const
 
 const ROUTE_CONTEXT_BASE = { route: '/api/v1/explorer/columns' }
 
@@ -30,6 +36,9 @@ export async function GET(request: Request): Promise<Response> {
     ...ROUTE_CONTEXT_BASE,
     method: 'GET',
   }
+
+  const permissionResponse = await authorizeFeatureRequest(TABLES_FEATURE_PERMISSION, request)
+  if (permissionResponse) return permissionResponse
 
   // Extract and validate hostId
   const hostId = getHostIdFromParams(searchParams, routeContext)

--- a/app/api/v1/explorer/dependencies/route.ts
+++ b/app/api/v1/explorer/dependencies/route.ts
@@ -17,9 +17,15 @@ import {
 import { getTableQuery } from '@/lib/api/table-registry'
 import { ApiErrorType } from '@/lib/api/types'
 import { fetchData } from '@/lib/clickhouse'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 import { debug, error } from '@/lib/logger'
 
 export const dynamic = 'force-dynamic'
+
+const TABLES_FEATURE_PERMISSION = {
+  feature: 'tables',
+  defaultAccess: 'authenticated',
+} as const
 
 const ROUTE_CONTEXT_BASE = { route: '/api/v1/explorer/dependencies' }
 
@@ -32,6 +38,9 @@ export async function GET(request: Request): Promise<Response> {
     ...ROUTE_CONTEXT_BASE,
     method: 'GET',
   }
+
+  const permissionResponse = await authorizeFeatureRequest(TABLES_FEATURE_PERMISSION, request)
+  if (permissionResponse) return permissionResponse
 
   // Extract and validate hostId
   const hostId = getHostIdFromParams(searchParams, routeContext)

--- a/app/api/v1/explorer/preview/route.ts
+++ b/app/api/v1/explorer/preview/route.ts
@@ -14,9 +14,15 @@ import {
 } from '@/lib/api/error-handler'
 import { ApiErrorType } from '@/lib/api/types'
 import { fetchData } from '@/lib/clickhouse'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 import { debug, error } from '@/lib/logger'
 
 export const dynamic = 'force-dynamic'
+
+const TABLES_FEATURE_PERMISSION = {
+  feature: 'tables',
+  defaultAccess: 'authenticated',
+} as const
 
 const ROUTE_CONTEXT_BASE = { route: '/api/v1/explorer/preview' }
 
@@ -32,6 +38,9 @@ export async function GET(request: Request): Promise<Response> {
     ...ROUTE_CONTEXT_BASE,
     method: 'GET',
   }
+
+  const permissionResponse = await authorizeFeatureRequest(TABLES_FEATURE_PERMISSION, request)
+  if (permissionResponse) return permissionResponse
 
   // Extract and validate hostId
   const hostId = getHostIdFromParams(searchParams, routeContext)

--- a/app/api/v1/explorer/query/route.ts
+++ b/app/api/v1/explorer/query/route.ts
@@ -24,9 +24,15 @@ import {
 import { validateSqlQuery } from '@/lib/api/shared/validators/sql'
 import { ApiErrorType } from '@/lib/api/types'
 import { fetchData } from '@/lib/clickhouse'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 import { debug, error } from '@/lib/logger'
 
 export const dynamic = 'force-dynamic'
+
+const TABLES_FEATURE_PERMISSION = {
+  feature: 'tables',
+  defaultAccess: 'authenticated',
+} as const
 
 const ROUTE_CONTEXT_BASE = { route: '/api/v1/explorer/query' }
 
@@ -57,6 +63,7 @@ async function executeQuery(params: {
 }): Promise<Response> {
   const { sql, hostId, format, timezone, routeContext, maxLength } = params
 
+  
   // Validate sql parameter is present
   if (!sql) {
     return createApiErrorResponse(
@@ -178,6 +185,9 @@ export async function GET(request: Request): Promise<Response> {
     method: 'GET',
   }
 
+  const permissionResponse = await authorizeFeatureRequest(TABLES_FEATURE_PERMISSION, request)
+  if (permissionResponse) return permissionResponse
+
   try {
     const hostId = getHostIdFromParams(searchParams, routeContext)
 
@@ -219,7 +229,10 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   try {
-    let body: Record<string, unknown>
+    const permissionResponse = await authorizeFeatureRequest(TABLES_FEATURE_PERMISSION, request)
+  if (permissionResponse) return permissionResponse
+
+  let body: Record<string, unknown>
     try {
       body = (await request.json()) as Record<string, unknown>
     } catch {

--- a/app/api/v1/explorer/tables/route.ts
+++ b/app/api/v1/explorer/tables/route.ts
@@ -15,9 +15,15 @@ import {
 import { getTableQuery } from '@/lib/api/table-registry'
 import { ApiErrorType } from '@/lib/api/types'
 import { fetchData } from '@/lib/clickhouse'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 import { debug, error } from '@/lib/logger'
 
 export const dynamic = 'force-dynamic'
+
+const TABLES_FEATURE_PERMISSION = {
+  feature: 'tables',
+  defaultAccess: 'authenticated',
+} as const
 
 const ROUTE_CONTEXT_BASE = { route: '/api/v1/explorer/tables' }
 
@@ -30,6 +36,9 @@ export async function GET(request: Request): Promise<Response> {
     ...ROUTE_CONTEXT_BASE,
     method: 'GET',
   }
+
+  const permissionResponse = await authorizeFeatureRequest(TABLES_FEATURE_PERMISSION, request)
+  if (permissionResponse) return permissionResponse
 
   // Extract and validate hostId
   const hostId = getHostIdFromParams(searchParams, routeContext)

--- a/app/api/v1/hosts/route.ts
+++ b/app/api/v1/hosts/route.ts
@@ -21,6 +21,19 @@ export const dynamic = 'force-dynamic'
 
 const ROUTE_CONTEXT = { route: '/api/v1/hosts', method: 'GET' }
 
+function sanitizePublicHost(rawHost: string): string {
+  try {
+    const url = new URL(rawHost)
+    url.username = ''
+    url.password = ''
+    url.search = ''
+    url.hash = ''
+    return url.origin
+  } catch {
+    return rawHost
+  }
+}
+
 /**
  * Host information for public API responses
  */
@@ -59,7 +72,7 @@ export async function GET(): Promise<Response> {
     const hosts: HostInfo[] = configs.map((config) => ({
       id: config.id,
       name: config.customName || getHost(config.host) || `Host ${config.id}`,
-      host: config.host,
+      host: sanitizePublicHost(config.host),
       user: config.user,
     }))
 

--- a/app/api/v1/tables/[name]/route.ts
+++ b/app/api/v1/tables/[name]/route.ts
@@ -27,6 +27,10 @@ import { debug, error } from '@/lib/logger'
 export const dynamic = 'force-dynamic'
 
 const ROUTE_CONTEXT_BASE = { route: '/api/v1/tables/[name]' }
+const TABLES_FEATURE_PERMISSION = {
+  feature: 'tables',
+  defaultAccess: 'authenticated',
+} as const
 
 /**
  * Handle GET requests for table data
@@ -95,7 +99,7 @@ export async function GET(
   // Get the original config for optional table checks
   const config = getTableConfig(name)
   const permissionResponse = await authorizeFeatureRequest(
-    config?.permission,
+    config?.permission ?? TABLES_FEATURE_PERMISSION,
     request
   )
   if (permissionResponse) return permissionResponse

--- a/lib/ai/agent/clickhouse-agent.ts
+++ b/lib/ai/agent/clickhouse-agent.ts
@@ -39,6 +39,7 @@ export function createClickHouseAgent(options: {
   providerOptions?: ProviderOptions
   /** Origin of the calling request — passed as OpenRouter HTTP-Referer. */
   referer?: string
+  includeControlTools?: boolean
 }) {
   const {
     model = DEFAULT_MODEL,
@@ -48,9 +49,10 @@ export function createClickHouseAgent(options: {
     systemPrompt = CLICKHOUSE_AGENT_INSTRUCTIONS,
     providerOptions,
     referer,
+    includeControlTools = false,
   } = options
 
-  const allTools = createMcpTools(hostId)
+  const allTools = createMcpTools(hostId, includeControlTools)
   const tools = filterTools(allTools, disabledTools)
   const hasTools = Object.keys(tools).length > 0
   const { model: modelInstance } = resolveAgentChatModel({

--- a/lib/ai/agent/mcp-tool-adapter.ts
+++ b/lib/ai/agent/mcp-tool-adapter.ts
@@ -13,6 +13,6 @@ import { createAllTools } from './tools'
  * Create AI SDK tools from modular tool definitions.
  * Signature unchanged for backward compatibility.
  */
-export function createMcpTools(hostId: number) {
-  return createAllTools(hostId)
+export function createMcpTools(hostId: number, includeControlTools = false) {
+  return createAllTools(hostId, includeControlTools)
 }

--- a/lib/ai/agent/tools/index.ts
+++ b/lib/ai/agent/tools/index.ts
@@ -37,7 +37,7 @@ import { createZookeeperTools } from './zookeeper-tools'
  * Create all agent tools for a given host.
  * Returns a flat object of all tools across all categories.
  */
-export function createAllTools(hostId: number) {
+export function createAllTools(hostId: number, includeControlTools = false) {
   const enableControlTools = process.env.AGENT_ENABLE_CONTROL_TOOLS === 'true'
 
   return {
@@ -69,7 +69,7 @@ export function createAllTools(hostId: number) {
     ...createClusterTools(hostId),
 
     // Control actions (destructive)
-    ...(enableControlTools ? createControlTools(hostId) : {}),
+    ...(enableControlTools && includeControlTools ? createControlTools(hostId) : {}),
 
     // Dashboard navigation
     ...createDashboardTools(),

--- a/lib/ai/agent/tools/query-tools.ts
+++ b/lib/ai/agent/tools/query-tools.ts
@@ -1,6 +1,7 @@
 import { readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
+import { validateSqlQuery } from '@/lib/api/shared/validators/sql'
 
 export function createQueryTools(hostId: number) {
   return {

--- a/lib/ai/agent/tools/query-tools.ts
+++ b/lib/ai/agent/tools/query-tools.ts
@@ -330,7 +330,8 @@ export function createQueryTools(hostId: number) {
         }
         const explainType = typeMap[type]
 
-        // Build EXPLAIN query - EXPLAIN is read-only, no validation needed
+        validateSqlQuery(sql)
+
         const explainQuery = `EXPLAIN ${explainType} ${sql}`
 
         const result = await readOnlyQuery({

--- a/lib/api/shared/validators/sql.ts
+++ b/lib/api/shared/validators/sql.ts
@@ -73,7 +73,7 @@ export const SQL_PATTERNS = {
 
   /** Dangerous ClickHouse table functions that access external resources */
   DANGEROUS_FUNCTIONS:
-    /\b(remote|remoteSecure|url|s3|hdfs|input|jdbc|odbc|mysql|postgresql)\s*\(/i,
+    /\b(remote|remoteSecure|url|urlCluster|s3|s3Cluster|hdfs|input|jdbc|odbc|mysql|postgresql|file|fileCluster|executable|mongodb|redis|azureBlobStorage|gcs)\s*\(/i,
 } as const
 
 /**


### PR DESCRIPTION
### Motivation
- Close multiple high-impact authorization and SSRF vectors where unauthenticated or under-authorized HTTP routes could execute ClickHouse `KILL`, DDL, or arbitrary read-only queries. 
- Prevent agent/tool misuse where destructive control tools could be exposed without the same `actions` permission boundary as the UI actions API. 
- Reduce secret/data exposure from public host responses and tighten SQL validation to block additional ClickHouse external/file/network table-function variants. 

### Description
- Require `ACTIONS_FEATURE_PERMISSION` for the cleanup and init endpoints and convert them from GET to state-changing `POST` handlers (`app/api/clean/route.ts`, `app/api/init/route.ts`).
- Enforce a backend `tables` feature check via `authorizeFeatureRequest` for all explorer endpoints (`columns`, `tables`, `dependencies`, `preview`, and `query`) so UI feature gates cannot be bypassed (`app/api/v1/explorer/*`).
- Fall back to a `TABLES_FEATURE_PERMISSION` when a `QueryConfig` has no explicit `permission`, closing the implicit-open case in `GET /api/v1/tables/[name]` (`app/api/v1/tables/[name]/route.ts`).
- Gate agent control tools behind the same actions permission by adding an `includeControlTools` flag to `createAllTools`/`createMcpTools`/`createClickHouseAgent` and only enabling control tools when `AGENT_ENABLE_CONTROL_TOOLS` is set and the request has `ACTIONS_FEATURE_PERMISSION` (`lib/ai/agent/tools/index.ts`, `lib/ai/agent/mcp-tool-adapter.ts`, `lib/ai/agent/clickhouse-agent.ts`, `app/api/v1/agent/route.ts`).
- Harden SQL validation by expanding the denylist of dangerous ClickHouse table-function variants (cluster/cloud/file/executable/redis/mongodb/etc.) in `validateSqlQuery` and apply validation to agent `explain_query` inputs (`lib/api/shared/validators/sql.ts`, `lib/ai/agent/tools/query-tools.ts`).
- Sanitize public host output returned by `GET /api/v1/hosts` to strip URL userinfo, query, and fragment before exposing the host in API responses (`app/api/v1/hosts/route.ts`).

### Testing
- Ran the TypeScript type check via `bun run type-check` (invokes `tsc --noEmit`) and it failed in this environment due to missing local type dependency definitions for `cypress`, `cypress-real-events`, and `node`, so a clean type-check could not be validated here.  
- No additional automated unit or integration test changes were added in this patch; recommend running `bun run test`, `bun run test:unit`, and `bun run test:query-config` in CI with a complete dev environment to validate behavior and the updated SQL validator rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7b1594ec8332bd16cf3101862621)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Removed usernames and passwords from public API host responses.
  * Expanded SQL function validation to detect additional dangerous operations.

* **New Features**
  * Added permission checks to table explorer, query, and initialization endpoints.
  * Control tools now conditionally available based on feature permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->