### PR TITLE
fix(api): prevent client queryConfig SQL override

### DIFF
--- a/app/api/v1/data/route.ts
+++ b/app/api/v1/data/route.ts
@@ -179,20 +179,38 @@ export const POST = withApiHandler(async (request: Request) => {
     queryParams,
     hostId,
     format = 'JSONEachRow',
-    queryConfig,
+    queryConfigName,
     timezone,
   } = typedBody
 
   debug('[POST /api/v1/data]', {
     hostId,
     format,
-    queryConfig: queryConfig?.name,
+    queryConfigName,
     timezone,
   })
 
-  // SECURITY: If no queryConfig provided, validate the query exists in dashboard tables
+  // SECURITY: Reject client-supplied QueryConfig objects to prevent SQL override attacks.
+  if (
+    typeof body === 'object' &&
+    body !== null &&
+    'queryConfig' in body &&
+    body.queryConfig !== undefined
+  ) {
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message:
+          'queryConfig is not accepted from clients. Use queryConfigName instead.',
+      },
+      400,
+      { ...ROUTE_CONTEXT, method: 'POST', hostId }
+    )
+  }
+
+  // SECURITY: If no queryConfigName provided, validate the query exists in dashboard tables
   // This prevents arbitrary SQL execution from clients
-  if (!queryConfig) {
+  if (!queryConfigName) {
     const validationResult = await validateDashboardQuery(query, Number(hostId))
     if (!validationResult.valid) {
       error(
@@ -212,14 +230,14 @@ export const POST = withApiHandler(async (request: Request) => {
     }
   }
 
-  const serverQueryConfig = queryConfig?.name
-    ? getTableConfig(queryConfig.name)
+  const serverQueryConfig = queryConfigName
+    ? getTableConfig(queryConfigName)
     : undefined
-  if (queryConfig?.name && !serverQueryConfig) {
+  if (queryConfigName && !serverQueryConfig) {
     return createApiErrorResponse(
       {
         type: ApiErrorType.ValidationError,
-        message: `Unknown query config: ${queryConfig.name}`,
+        message: `Unknown query config: ${queryConfigName}`,
       },
       400,
       { ...ROUTE_CONTEXT, method: 'POST', hostId }
@@ -227,7 +245,7 @@ export const POST = withApiHandler(async (request: Request) => {
   }
 
   const permissionResponse = await authorizeFeatureRequest(
-    serverQueryConfig?.permission ?? queryConfig?.permission,
+    serverQueryConfig?.permission,
     request
   )
   if (permissionResponse) return permissionResponse
@@ -241,7 +259,7 @@ export const POST = withApiHandler(async (request: Request) => {
     query_params: queryParams,
     format: dataFormat,
     hostId,
-    queryConfig,
+    queryConfig: serverQueryConfig,
     // Pass timezone to ClickHouse for session-level time conversion
     clickhouse_settings: timezone ? { session_timezone: timezone } : undefined,
   })

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -25,8 +25,6 @@
  * ═══════════════════════════════════════════════════════════════════════════════
  */
 
-import type { QueryConfig } from '@/types/query-config'
-
 /**
  * Error types that can be returned from the API
  */
@@ -145,8 +143,8 @@ export interface ApiRequest {
   readonly hostId: string
   /** Data format for query response (default: JSONEachRow) */
   readonly format?: 'JSONEachRow' | 'JSON' | 'CSV' | 'TSV'
-  /** Optional query configuration with metadata */
-  readonly queryConfig?: QueryConfig
+  /** Server-side query configuration name (resolved from registry on server) */
+  readonly queryConfigName?: string
   /** IANA timezone for ClickHouse session (e.g., "America/Los_Angeles", "UTC") */
   readonly timezone?: string
 }


### PR DESCRIPTION
### Motivation
- Close a SQL allowlist bypass where clients could submit a full `QueryConfig` (including `sql`) and override server-side registry validation, enabling arbitrary ClickHouse SQL execution.

### Description
- Reject client-supplied `queryConfig` objects in `POST /api/v1/data` and require clients to send only `queryConfigName` instead. (app/api/v1/data/route.ts)
- Resolve the query configuration on the server via `getTableConfig(queryConfigName)` and pass only the server-resolved config into `fetchData` and permission checks. (app/api/v1/data/route.ts)
- Remove `queryConfig` from the public API contract and replace it with `queryConfigName` in `ApiRequest` to ensure executable SQL is not accepted from clients. (lib/api/types.ts)
- Ensure permission checks only use the server-resolved config (no merge with client-supplied permission metadata). (app/api/v1/data/route.ts)

### Testing
- Ran `bun install` to populate dependencies and it completed successfully. 
- Built the project with `bun run build` and the build completed successfully (type-check and lint steps ran as part of the build pipeline). 
- Pre-commit checks (Biome + `tsc --noEmit`) ran during development and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7af4d6248332bfa3dde7e63499d4)