### PR TITLE
chore(automation): remove unused overview helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ Both deployment methods provide:
 - Main CI status check: `gh run list --branch main --limit 10 --json workflowName,status,conclusion,headSha,url`
 - Failed-job logs in restricted cache environments: `XDG_CACHE_HOME=/private/tmp/gh-cache gh run view <RUN_ID> --job <JOB_ID> --log-failed`
 - Docker deps-stage parity check: `bun install --frozen-lockfile --ignore-scripts && bun run build` (`lib/platform/adapters/cloudflare.ts` imports `@opennextjs/cloudflare` during build)
-- Worktree fallback for PR operations: if automation checkout is detached (`git status --short --branch` shows `HEAD (no branch)`) or git metadata writes fail (`FETCH_HEAD`/`HEAD.lock`), switch to `/Users/duet/project/clickhouse-monitor` before commit/PR commands
+- Worktree fallback for PR operations: if automation checkout is detached (`git status --short --branch` shows `HEAD (no branch)`) or git metadata writes fail (`FETCH_HEAD`/`HEAD.lock`/`index.lock`), refresh refs through `/Users/duet/project/clickhouse-monitor`; if that checkout is dirty, create a clean worktree under `/private/tmp` for commit/PR commands
 - Cloudflare worker size dry-run: `bun wrangler deploy --minify --dry-run`
 
 **Docs content workflow**: `/docs` pages are rendered by the main app and read source files from `docs/content`.

--- a/app/(dashboard)/overview/__tests__/overview.test.tsx
+++ b/app/(dashboard)/overview/__tests__/overview.test.tsx
@@ -40,9 +40,6 @@ mock.module('@/lib/swr', () => ({
 }))
 
 const {
-  getAllChartIds,
-  getChartsForTab,
-  getTabConfig,
   HEALTH_TAB_CHARTS,
   OPERATIONS_TAB_CHARTS,
   OVERVIEW_TAB_CHARTS,
@@ -232,93 +229,6 @@ describe('charts-config', () => {
     })
   })
 
-  describe('Utility Functions', () => {
-    describe('getTabConfig', () => {
-      it('should return the correct tab configuration', () => {
-        const overviewTab = getTabConfig('overview')
-        expect(overviewTab?.value).toBe('overview')
-        expect(overviewTab?.label).toBe('Overview')
-      })
-
-      it('should return undefined for non-existent tab', () => {
-        const nonExistentTab = getTabConfig('non-existent')
-        expect(nonExistentTab).toBeUndefined()
-      })
-
-      it('should find all tabs by value', () => {
-        OVERVIEW_TABS.forEach((tab) => {
-          const found = getTabConfig(tab.value)
-          expect(found).toBeDefined()
-          expect(found?.value).toBe(tab.value)
-        })
-      })
-    })
-
-    describe('getAllChartIds', () => {
-      it('should return all unique chart IDs', () => {
-        const allIds = getAllChartIds()
-        const uniqueIds = new Set(allIds)
-        // Each chart should have a unique ID
-        expect(allIds.length).toBe(uniqueIds.size)
-      })
-
-      it('should include all chart IDs from all tabs', () => {
-        const allIds = getAllChartIds()
-        const expectedCount =
-          OVERVIEW_TAB_CHARTS.length +
-          QUERIES_TAB_CHARTS.length +
-          STORAGE_TAB_CHARTS.length +
-          OPERATIONS_TAB_CHARTS.length +
-          HEALTH_TAB_CHARTS.length
-        expect(allIds.length).toBe(expectedCount)
-      })
-
-      it('should include specific chart IDs', () => {
-        const allIds = getAllChartIds()
-        expect(allIds).toContain('query-count-24h')
-        expect(allIds).toContain('keeper-exception')
-        expect(allIds).toContain('disk-size')
-        expect(allIds).toContain('backup-size')
-        expect(allIds).toContain('replication-lag')
-        expect(allIds).toContain('query-cache-usage')
-      })
-    })
-
-    describe('getChartsForTab', () => {
-      it('should return charts for the overview tab', () => {
-        const charts = getChartsForTab('overview')
-        expect(charts).toHaveLength(17)
-        expect(charts[0].id).toBe('query-count-24h')
-      })
-
-      it('should return charts for the queries tab', () => {
-        const charts = getChartsForTab('queries')
-        expect(charts).toHaveLength(11)
-        expect(charts[0].id).toBe('query-count-14d')
-      })
-
-      it('should return charts for the storage tab', () => {
-        const charts = getChartsForTab('storage')
-        expect(charts).toHaveLength(12)
-      })
-
-      it('should return charts for the operations tab', () => {
-        const charts = getChartsForTab('operations')
-        expect(charts).toHaveLength(10)
-      })
-
-      it('should return charts for the health tab', () => {
-        const charts = getChartsForTab('health')
-        expect(charts).toHaveLength(12)
-      })
-
-      it('should return empty array for non-existent tab', () => {
-        const charts = getChartsForTab('non-existent')
-        expect(charts).toEqual([])
-      })
-    })
-  })
-
   describe('Chart Types', () => {
     it('should categorize charts by type', () => {
       const allCharts = [
@@ -357,9 +267,11 @@ describe('charts-config', () => {
 
   describe('Grid Layout Classes', () => {
     it('should have proper grid classes for each tab', () => {
-      const overviewTab = getTabConfig('overview')
-      const healthTab = getTabConfig('health')
-      const operationsTab = getTabConfig('operations')
+      const overviewTab = OVERVIEW_TABS.find((tab) => tab.value === 'overview')
+      const healthTab = OVERVIEW_TABS.find((tab) => tab.value === 'health')
+      const operationsTab = OVERVIEW_TABS.find(
+        (tab) => tab.value === 'operations'
+      )
 
       // Overview uses 3-column layout
       expect(overviewTab?.gridClassName).toContain('grid-cols-1')

--- a/app/(dashboard)/overview/charts-config.ts
+++ b/app/(dashboard)/overview/charts-config.ts
@@ -793,29 +793,3 @@ export const OVERVIEW_TABS: OverviewTabConfig[] = [
     charts: HEALTH_TAB_CHARTS,
   },
 ]
-
-// ============================================================================
-// Utilities
-// ============================================================================
-
-/**
- * Get a tab configuration by its value
- */
-export function getTabConfig(value: string): OverviewTabConfig | undefined {
-  return OVERVIEW_TABS.find((tab) => tab.value === value)
-}
-
-/**
- * Get all chart IDs across all tabs
- */
-export function getAllChartIds(): string[] {
-  return OVERVIEW_TABS.flatMap((tab) => tab.charts.map((chart) => chart.id))
-}
-
-/**
- * Get charts for a specific tab
- */
-export function getChartsForTab(tabValue: string): OverviewChartConfig[] {
-  const tab = getTabConfig(tabValue)
-  return tab?.charts ?? []
-}

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -3,7 +3,7 @@ id: core-memory
 title: Automation Core Memory
 type: workflow
 status: active
-updated: 2026-05-18
+updated: 2026-05-21
 tags:
   - automation
   - code-smell
@@ -36,7 +36,7 @@ Durable code-smell/dead-code automation memory. Do not create dated files under 
 - `/docs` route reads source files from `docs/content` through `app/(docs)/docs/_lib/docs.ts`
 - Verify dead-code claims with zero non-test references before deleting symbols
 - Docker build must install full deps (`bun install --frozen-lockfile --ignore-scripts`) because `lib/platform/adapters/cloudflare.ts` imports `@opennextjs/cloudflare` during `bun run build`
-- If automation checkout is detached (`git status --short --branch` shows `HEAD (no branch)`) or `.git/worktrees/...` writes fail (`FETCH_HEAD`/`HEAD.lock`), move commit/PR operations to `/Users/duet/project/clickhouse-monitor`
+- If automation checkout is detached (`git status --short --branch` shows `HEAD (no branch)`) or `.git/worktrees/...` writes fail (`FETCH_HEAD`/`HEAD.lock`/`index.lock`), refresh refs through `/Users/duet/project/clickhouse-monitor`; if that checkout is dirty, create a clean worktree under `/private/tmp` for commit/PR commands
 
 ## Latest Update
 
@@ -49,3 +49,4 @@ Durable code-smell/dead-code automation memory. Do not create dated files under 
 - 2026-05-17: automation run started on detached worktree (`HEAD (no branch)`), so branch/PR work should pivot to `/Users/duet/project/clickhouse-monitor` when git metadata writes fail in `.git/worktrees/...`
 - 2026-05-18: no commits since last run timestamp; 24h fallback was empty, 7d fallback used for evidence-only audit with no new actionable code-smell/dead-code/perf findings
 - 2026-05-19: removed zero-reference `findModelEntry` export from `lib/ai/agent-model-registry.ts`; add `--no-merges` scan variant to reduce merge-only noise in code-smell/dead-code windows
+- 2026-05-21: removed overview chart helper exports that had zero non-test references (`getTabConfig`, `getAllChartIds`, `getChartsForTab`); latest `main` CI was green on `7be1682b`


### PR DESCRIPTION
## Summary
- remove overview chart helper exports with zero non-test references
- trim tests that only covered those unused helpers
- record this automation run and the observed worktree fallback in core memory / CLAUDE.md

## Evidence
- Recent scan window: last 7 days on origin/main, latest main SHA 7be1682b
- Dead-code searches excluding tests found no production refs for getTabConfig, getAllChartIds, getChartsForTab
- Main CI before patch was green on 7be1682b

## Verification
- bun run lint
- bun --smol --env-file=.env.local test --max-concurrency=1 --preload ./.sisyphus/swr-mock-preload.ts 'app/(dashboard)/overview/__tests__/overview.test.tsx'
- bun run type-check
- bun run build

Note: local build kept the existing warning in lib/browser-connections/host-url.ts about an expression dependency; no new build failures.