### PR TITLE
feat(running-queries): add syntax highlighting and beautify to query dialog

### DIFF
--- a/components/data-table/cells/code-dialog-format.cy.tsx
+++ b/components/data-table/cells/code-dialog-format.cy.tsx
@@ -77,4 +77,20 @@ describe('<CodeDialogFormat />', () => {
       cy.get('img').should('not.exist')
     })
   })
+
+  it('does not show SQL controls for plain text content', () => {
+    const plainText =
+      'plain operational message with enough characters to open the dialog'
+
+    cy.mount(
+      <CodeDialogFormat value={plainText} options={{ max_truncate: 20 }} />
+    )
+    cy.get('code.truncated').parent().click()
+
+    cy.get('div[role="dialog"]').within(() => {
+      cy.contains('h2', 'Code content').should('be.visible')
+      cy.contains('Beautify').should('not.exist')
+      cy.contains('Plain text').should('be.visible')
+    })
+  })
 })

--- a/components/data-table/cells/code-dialog-format.cy.tsx
+++ b/components/data-table/cells/code-dialog-format.cy.tsx
@@ -1,6 +1,10 @@
 import { CodeDialogFormat } from './code-dialog-format'
 
 describe('<CodeDialogFormat />', () => {
+  beforeEach(() => {
+    cy.clearLocalStorage()
+  })
+
   it('renders short code without dialog', () => {
     const shortCode = 'SELECT * FROM table'
     cy.mount(<CodeDialogFormat value={shortCode} />)
@@ -57,5 +61,20 @@ describe('<CodeDialogFormat />', () => {
     const options = { hide_query_comment: true, max_truncate: 100 }
     cy.mount(<CodeDialogFormat value={codeWithComment} options={options} />)
     cy.get('code').should('not.contain', '/* This is a comment */')
+  })
+
+  it('escapes HTML-like code in the dialog body', () => {
+    const maliciousCode =
+      "SELECT '<img src=x onerror=alert(1)>' AS payload FROM table WHERE column1 = 'value' AND column2 > 100"
+
+    cy.mount(
+      <CodeDialogFormat value={maliciousCode} options={{ max_truncate: 20 }} />
+    )
+    cy.get('code.truncated').parent().click()
+
+    cy.get('div[role="dialog"]').within(() => {
+      cy.contains('<img src=x onerror=alert(1)>').should('be.visible')
+      cy.get('img').should('not.exist')
+    })
   })
 })

--- a/components/data-table/cells/code-dialog-format.tsx
+++ b/components/data-table/cells/code-dialog-format.tsx
@@ -2,7 +2,15 @@ import { SizeIcon } from '@radix-ui/react-icons'
 import { Check, Copy, ExternalLinkIcon, SparklesIcon } from 'lucide-react'
 
 import dedent from 'dedent'
-import { memo, useCallback, useId, useMemo, useState } from 'react'
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { format } from 'sql-formatter'
 import { highlightCode } from '@/components/ai-elements/code-block'
 import { AppLink as Link } from '@/components/ui/app-link'
@@ -36,6 +44,7 @@ export interface CodeDialogOptions {
 }
 
 const STORAGE_KEY = 'code-dialog-beautify'
+type CodeLanguage = 'sql' | 'json' | 'plaintext'
 
 function getInitialBeautifyState(): boolean {
   if (typeof window === 'undefined') return false
@@ -56,9 +65,12 @@ function saveBeautifyState(value: boolean) {
 }
 
 function looksLikeSql(text: string): boolean {
-  const sqlKeywords =
-    /\b(SELECT|INSERT|CREATE|ALTER|DROP|UPDATE|DELETE|WITH|SHOW|DESCRIBE|EXPLAIN|TRUNCATE|OPTIMIZE|ATTACH|DETACH|BACKUP|RESTORE|SYSTEM|CHECK|GRANT|REVOKE)\b/i
-  return sqlKeywords.test(text)
+  const trimmed = text.trim()
+  const startsWithSql =
+    /^(SELECT|INSERT|CREATE|ALTER|DROP|UPDATE|DELETE|WITH|SHOW|DESCRIBE|EXPLAIN|TRUNCATE|OPTIMIZE|ATTACH|DETACH|BACKUP|RESTORE|SYSTEM|CHECK|GRANT|REVOKE)\b/i
+  const hasSelectFrom = /\bSELECT\b[\s\S]+\bFROM\b/i
+
+  return startsWithSql.test(trimmed) || hasSelectFrom.test(trimmed)
 }
 
 function looksLikeJson(text: string): boolean {
@@ -69,11 +81,11 @@ function looksLikeJson(text: string): boolean {
   )
 }
 
-function detectLanguage(value: string, forceJson?: boolean): string {
+function detectLanguage(value: string, forceJson?: boolean): CodeLanguage {
   if (forceJson) return 'json'
   if (looksLikeSql(value)) return 'sql'
   if (looksLikeJson(value)) return 'json'
-  return 'sql'
+  return 'plaintext'
 }
 
 function escapeHtml(text: string): string {
@@ -123,6 +135,7 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
 }: CodeDialogFormatProps): React.ReactNode {
   const truncate_length = options?.max_truncate || CODE_TRUNCATE_LENGTH
   const beautifyId = useId()
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [open, setOpen] = useState(false)
   const [isBeautified, setIsBeautified] = useState(false)
   const [copied, setCopied] = useState(false)
@@ -132,10 +145,21 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
     [value, options?.json]
   )
   const dialogTitle =
-    options?.dialog_title ?? (language === 'json' ? 'JSON content' : 'SQL code')
+    options?.dialog_title ??
+    (language === 'json'
+      ? 'JSON content'
+      : language === 'sql'
+        ? 'SQL code'
+        : 'Code content')
   const dialogDescription =
     options?.dialog_description ||
     'Code content dialog with syntax highlighting and copy controls'
+  const languageLabel =
+    language === 'sql'
+      ? 'ClickHouse SQL'
+      : language === 'json'
+        ? 'JSON'
+        : 'Plain text'
 
   const formatted = useMemo(() => {
     return formatQuery({
@@ -164,6 +188,7 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
 
     return result
   }, [open, value, isBeautified, language])
+  const lineCount = contentLineCount(content)
 
   const highlightedHtml = useMemo(() => {
     if (!(open && content)) return ''
@@ -174,13 +199,26 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
     }
   }, [open, content, language])
 
-  const handleOpenChange = useCallback((nextOpen: boolean) => {
-    setOpen(nextOpen)
-    if (nextOpen) {
-      setCopied(false)
-      setIsBeautified(getInitialBeautifyState())
+  const clearCopyTimer = useCallback(() => {
+    if (copyTimerRef.current) {
+      clearTimeout(copyTimerRef.current)
+      copyTimerRef.current = null
     }
   }, [])
+
+  useEffect(() => clearCopyTimer, [clearCopyTimer])
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen)
+      clearCopyTimer()
+      if (nextOpen) {
+        setCopied(false)
+        setIsBeautified(getInitialBeautifyState())
+      }
+    },
+    [clearCopyTimer]
+  )
 
   const handleBeautifyToggle = useCallback((checked: boolean) => {
     setIsBeautified(checked)
@@ -189,14 +227,20 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
 
   const handleCopy = useCallback(async () => {
     try {
-      if (!navigator?.clipboard?.writeText) return
+      if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+        return
+      }
       await navigator.clipboard.writeText(content)
       setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      clearCopyTimer()
+      copyTimerRef.current = setTimeout(() => {
+        setCopied(false)
+        copyTimerRef.current = null
+      }, 2000)
     } catch {
       /* noop */
     }
-  }, [content])
+  }, [clearCopyTimer, content])
 
   if (formatted.length < truncate_length) {
     return (
@@ -288,7 +332,7 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
         <div className="relative group/code">
           <ScrollArea className="h-[min(70vh,720px)] rounded-md border bg-muted/40">
             <div
-              className="overflow-auto [&_code]:break-words [&_pre]:whitespace-pre-wrap [&_.hljs-keyword]:text-purple-600 [&_.hljs-string]:text-green-700 [&_.hljs-number]:text-blue-600 [&_.hljs-comment]:text-gray-500 [&_.hljs-built_in]:text-cyan-700 [&_.hljs-title]:text-blue-700 [&_.hljs-attr]:text-orange-600 [&_.hljs-literal]:text-blue-600 dark:[&_.hljs-keyword]:text-purple-400 dark:[&_.hljs-string]:text-green-400 dark:[&_.hljs-number]:text-blue-400 dark:[&_.hljs-comment]:text-gray-400 dark:[&_.hljs-built_in]:text-cyan-400 dark:[&_.hljs-title]:text-blue-400 dark:[&_.hljs-attr]:text-orange-400 dark:[&_.hljs-literal]:text-blue-400"
+              className="[&_code]:break-words [&_pre]:whitespace-pre-wrap [&_.hljs-keyword]:text-purple-600 [&_.hljs-string]:text-green-700 [&_.hljs-number]:text-blue-600 [&_.hljs-comment]:text-gray-500 [&_.hljs-built_in]:text-cyan-700 [&_.hljs-title]:text-blue-700 [&_.hljs-attr]:text-orange-600 [&_.hljs-literal]:text-blue-600 dark:[&_.hljs-keyword]:text-purple-400 dark:[&_.hljs-string]:text-green-400 dark:[&_.hljs-number]:text-blue-400 dark:[&_.hljs-comment]:text-gray-400 dark:[&_.hljs-built_in]:text-cyan-400 dark:[&_.hljs-title]:text-blue-400 dark:[&_.hljs-attr]:text-orange-400 dark:[&_.hljs-literal]:text-blue-400"
               dangerouslySetInnerHTML={{ __html: highlightedHtml }}
             />
           </ScrollArea>
@@ -298,20 +342,20 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
               variant="secondary"
               className="bg-background/80 font-mono text-[10px]"
             >
-              {language.toUpperCase()}
+              {language === 'plaintext' ? 'TEXT' : language.toUpperCase()}
             </Badge>
           </div>
         </div>
 
         <div className="flex items-center justify-between text-[10px] text-muted-foreground px-0.5">
-          <span className="font-medium">
-            {language === 'sql' ? 'ClickHouse SQL' : language.toUpperCase()}
-          </span>
-          <span className="tabular-nums">
-            {content.split('\n').length} lines
-          </span>
+          <span className="font-medium">{languageLabel}</span>
+          <span className="tabular-nums">{lineCount} lines</span>
         </div>
       </DialogContent>
     </Dialog>
   )
 })
+
+function contentLineCount(content: string): number {
+  return content ? content.split('\n').length : 0
+}

--- a/components/data-table/cells/code-dialog-format.tsx
+++ b/components/data-table/cells/code-dialog-format.tsx
@@ -1,19 +1,22 @@
-import { DialogDescription, DialogTitle } from '@radix-ui/react-dialog'
 import { SizeIcon } from '@radix-ui/react-icons'
 import { Check, Copy, ExternalLinkIcon, SparklesIcon } from 'lucide-react'
 
 import dedent from 'dedent'
-import { memo, useCallback, useMemo, useState } from 'react'
+import { memo, useCallback, useId, useMemo, useState } from 'react'
 import { format } from 'sql-formatter'
 import { highlightCode } from '@/components/ai-elements/code-block'
 import { AppLink as Link } from '@/components/ui/app-link'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
+  DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Switch } from '@/components/ui/switch'
 import { buildExplorerQueryUrl } from '@/lib/explorer-url'
@@ -66,11 +69,19 @@ function looksLikeJson(text: string): boolean {
   )
 }
 
-function detectLanguage(value: string, options?: CodeDialogOptions): string {
-  if (options?.json) return 'json'
+function detectLanguage(value: string, forceJson?: boolean): string {
+  if (forceJson) return 'json'
   if (looksLikeSql(value)) return 'sql'
   if (looksLikeJson(value)) return 'json'
   return 'sql'
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
 }
 
 function formatSQL(sql: string): string {
@@ -111,13 +122,20 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
   options,
 }: CodeDialogFormatProps): React.ReactNode {
   const truncate_length = options?.max_truncate || CODE_TRUNCATE_LENGTH
-  const [isBeautified, setIsBeautified] = useState(getInitialBeautifyState)
+  const beautifyId = useId()
+  const [open, setOpen] = useState(false)
+  const [isBeautified, setIsBeautified] = useState(false)
   const [copied, setCopied] = useState(false)
 
   const language = useMemo(
-    () => detectLanguage(value, options),
-    [value, options]
+    () => detectLanguage(value, options?.json),
+    [value, options?.json]
   )
+  const dialogTitle =
+    options?.dialog_title ?? (language === 'json' ? 'JSON content' : 'SQL code')
+  const dialogDescription =
+    options?.dialog_description ||
+    'Code content dialog with syntax highlighting and copy controls'
 
   const formatted = useMemo(() => {
     return formatQuery({
@@ -128,9 +146,11 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
   }, [value, options?.hide_query_comment, truncate_length])
 
   const content = useMemo(() => {
+    if (!open) return ''
+
     let result = value
 
-    if (options?.json) {
+    if (language === 'json') {
       try {
         const json = JSON.parse(value)
         result = JSON.stringify(json, null, 2)
@@ -143,16 +163,24 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
     }
 
     return result
-  }, [value, options?.json, isBeautified, language])
+  }, [open, value, isBeautified, language])
 
   const highlightedHtml = useMemo(() => {
-    if (!content) return ''
+    if (!(open && content)) return ''
     try {
       return highlightCode(content, language, false)
     } catch {
-      return `<pre class="m-0 bg-background! p-4 text-foreground! text-sm"><code class="font-mono text-sm">${content}</code></pre>`
+      return `<pre class="m-0 bg-background! p-4 text-foreground! text-sm"><code class="font-mono text-sm">${escapeHtml(dedent(content))}</code></pre>`
     }
-  }, [content, language])
+  }, [open, content, language])
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (nextOpen) {
+      setCopied(false)
+      setIsBeautified(getInitialBeautifyState())
+    }
+  }, [])
 
   const handleBeautifyToggle = useCallback((checked: boolean) => {
     setIsBeautified(checked)
@@ -161,6 +189,7 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
 
   const handleCopy = useCallback(async () => {
     try {
+      if (!navigator?.clipboard?.writeText) return
       await navigator.clipboard.writeText(content)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
@@ -182,86 +211,95 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
   }
 
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <div
+        <Button
+          type="button"
+          variant="ghost"
           className={cn(
-            'flex max-w-fit cursor-pointer flex-row items-center gap-1.5 line-clamp-1 group/cell',
+            'group/cell h-auto max-w-full justify-start gap-1.5 p-0 text-left font-normal hover:bg-transparent',
             options?.trigger_classname
           )}
         >
-          <code className="font-mono text-xs whitespace-nowrap truncated text-muted-foreground group-hover/cell:text-foreground transition-colors">
+          <code className="min-w-0 truncate font-mono text-xs text-muted-foreground transition-colors group-hover/cell:text-foreground truncated">
             {formatted}
           </code>
-          <SizeIcon className="size-3.5 flex-none shrink-0 text-muted-foreground/60 group-hover/cell:text-muted-foreground transition-colors" />
-        </div>
+          <SizeIcon className="shrink-0 text-muted-foreground/60 transition-colors group-hover/cell:text-muted-foreground" />
+        </Button>
       </DialogTrigger>
       <DialogContent
         className={cn(
-          'max-w-[95vw] md:max-w-[85vw] lg:max-w-[80vw] xl:max-w-[75vw] min-w-80',
+          'w-[min(95vw,1100px)] min-w-0 max-w-none p-4 sm:p-6',
           options?.dialog_classname
         )}
-        aria-describedby={options?.dialog_description}
       >
         <DialogHeader>
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-2">
-              <DialogTitle className="text-base">
-                {options?.dialog_title}
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex min-w-0 items-center gap-2">
+              <DialogTitle className="truncate text-base">
+                {dialogTitle}
               </DialogTitle>
               {(options?.show_explorer_link ||
                 options?.dialog_title === 'Running Query') && (
                 <ExplorerLink query={value} />
               )}
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2 sm:justify-end">
               {language === 'sql' && (
-                <div className="flex items-center gap-1.5">
-                  <SparklesIcon className="size-3 text-muted-foreground" />
+                <Label
+                  htmlFor={beautifyId}
+                  className="gap-1.5 text-xs text-muted-foreground"
+                >
+                  <SparklesIcon data-icon="inline-start" />
                   <span className="text-xs text-muted-foreground">
                     Beautify
                   </span>
                   <Switch
+                    id={beautifyId}
                     checked={isBeautified}
                     onCheckedChange={handleBeautifyToggle}
                     aria-label="Toggle SQL beautification"
                     className="scale-75"
                   />
-                </div>
+                </Label>
               )}
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-6 gap-1 text-xs text-muted-foreground px-2"
+                className="h-6 px-2 text-xs text-muted-foreground"
                 onClick={handleCopy}
               >
                 {copied ? (
-                  <Check className="size-3" strokeWidth={1.5} />
+                  <Check data-icon="inline-start" />
                 ) : (
-                  <Copy className="size-3" strokeWidth={1.5} />
+                  <Copy data-icon="inline-start" />
                 )}
                 {copied ? 'Copied' : 'Copy'}
               </Button>
             </div>
           </div>
-          <DialogDescription className="sr-only">
-            {options?.dialog_description ||
-              'Code content dialog with syntax highlighting'}
+          <DialogDescription
+            className={cn(!options?.dialog_description && 'sr-only')}
+          >
+            {dialogDescription}
           </DialogDescription>
         </DialogHeader>
 
         <div className="relative group/code">
-          <ScrollArea className="max-h-[70vh] rounded-lg border border-border/60 bg-muted/40">
+          <ScrollArea className="h-[min(70vh,720px)] rounded-md border bg-muted/40">
             <div
-              className="overflow-auto [&_.hljs-keyword]:text-purple-600 [&_.hljs-string]:text-green-700 [&_.hljs-number]:text-blue-600 [&_.hljs-comment]:text-gray-500 [&_.hljs-built_in]:text-cyan-700 [&_.hljs-title]:text-blue-700 [&_.hljs-attr]:text-orange-600 [&_.hljs-literal]:text-blue-600 dark:[&_.hljs-keyword]:text-purple-400 dark:[&_.hljs-string]:text-green-400 dark:[&_.hljs-number]:text-blue-400 dark:[&_.hljs-comment]:text-gray-400 dark:[&_.hljs-built_in]:text-cyan-400 dark:[&_.hljs-title]:text-blue-400 dark:[&_.hljs-attr]:text-orange-400 dark:[&_.hljs-literal]:text-blue-400"
+              className="overflow-auto [&_code]:break-words [&_pre]:whitespace-pre-wrap [&_.hljs-keyword]:text-purple-600 [&_.hljs-string]:text-green-700 [&_.hljs-number]:text-blue-600 [&_.hljs-comment]:text-gray-500 [&_.hljs-built_in]:text-cyan-700 [&_.hljs-title]:text-blue-700 [&_.hljs-attr]:text-orange-600 [&_.hljs-literal]:text-blue-600 dark:[&_.hljs-keyword]:text-purple-400 dark:[&_.hljs-string]:text-green-400 dark:[&_.hljs-number]:text-blue-400 dark:[&_.hljs-comment]:text-gray-400 dark:[&_.hljs-built_in]:text-cyan-400 dark:[&_.hljs-title]:text-blue-400 dark:[&_.hljs-attr]:text-orange-400 dark:[&_.hljs-literal]:text-blue-400"
               dangerouslySetInnerHTML={{ __html: highlightedHtml }}
             />
           </ScrollArea>
 
           <div className="absolute top-2 right-2 flex items-center gap-2 opacity-0 group-hover/code:opacity-100 transition-opacity">
-            <span className="text-[10px] text-muted-foreground bg-background/80 px-1.5 py-0.5 rounded">
+            <Badge
+              variant="secondary"
+              className="bg-background/80 font-mono text-[10px]"
+            >
               {language.toUpperCase()}
-            </span>
+            </Badge>
           </div>
         </div>
 

--- a/components/data-table/cells/code-dialog-format.tsx
+++ b/components/data-table/cells/code-dialog-format.tsx
@@ -1,9 +1,11 @@
 import { DialogDescription, DialogTitle } from '@radix-ui/react-dialog'
 import { SizeIcon } from '@radix-ui/react-icons'
-import { ExternalLinkIcon } from 'lucide-react'
+import { Check, Copy, ExternalLinkIcon, SparklesIcon } from 'lucide-react'
 
 import dedent from 'dedent'
-import { memo, useMemo } from 'react'
+import { memo, useCallback, useMemo, useState } from 'react'
+import { format } from 'sql-formatter'
+import { highlightCode } from '@/components/ai-elements/code-block'
 import { AppLink as Link } from '@/components/ui/app-link'
 import { Button } from '@/components/ui/button'
 import {
@@ -12,6 +14,8 @@ import {
   DialogHeader,
   DialogTrigger,
 } from '@/components/ui/dialog'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Switch } from '@/components/ui/switch'
 import { buildExplorerQueryUrl } from '@/lib/explorer-url'
 import { formatQuery } from '@/lib/format-readable'
 import { useHostId } from '@/lib/swr/use-host'
@@ -26,6 +30,61 @@ export interface CodeDialogOptions {
   json?: boolean
   dialog_classname?: string
   show_explorer_link?: boolean
+}
+
+const STORAGE_KEY = 'code-dialog-beautify'
+
+function getInitialBeautifyState(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+function saveBeautifyState(value: boolean) {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(STORAGE_KEY, String(value))
+  } catch {
+    /* noop */
+  }
+}
+
+function looksLikeSql(text: string): boolean {
+  const sqlKeywords =
+    /\b(SELECT|INSERT|CREATE|ALTER|DROP|UPDATE|DELETE|WITH|SHOW|DESCRIBE|EXPLAIN|TRUNCATE|OPTIMIZE|ATTACH|DETACH|BACKUP|RESTORE|SYSTEM|CHECK|GRANT|REVOKE)\b/i
+  return sqlKeywords.test(text)
+}
+
+function looksLikeJson(text: string): boolean {
+  const trimmed = text.trim()
+  return (
+    (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+    (trimmed.startsWith('[') && trimmed.endsWith(']'))
+  )
+}
+
+function detectLanguage(value: string, options?: CodeDialogOptions): string {
+  if (options?.json) return 'json'
+  if (looksLikeSql(value)) return 'sql'
+  if (looksLikeJson(value)) return 'json'
+  return 'sql'
+}
+
+function formatSQL(sql: string): string {
+  try {
+    return format(sql, {
+      language: 'sql',
+      keywordCase: 'upper',
+      identifierCase: 'preserve',
+      tabWidth: 2,
+      linesBetweenQueries: 2,
+    })
+  } catch {
+    return dedent(sql)
+  }
 }
 
 function ExplorerLink({ query }: { query: string }) {
@@ -52,8 +111,14 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
   options,
 }: CodeDialogFormatProps): React.ReactNode {
   const truncate_length = options?.max_truncate || CODE_TRUNCATE_LENGTH
+  const [isBeautified, setIsBeautified] = useState(getInitialBeautifyState)
+  const [copied, setCopied] = useState(false)
 
-  // Memoize query formatting
+  const language = useMemo(
+    () => detectLanguage(value, options),
+    [value, options]
+  )
+
   const formatted = useMemo(() => {
     return formatQuery({
       query: value,
@@ -62,28 +127,58 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
     })
   }, [value, options?.hide_query_comment, truncate_length])
 
-  // Memoize JSON processing for dialog content
   const content = useMemo(() => {
     let result = value
+
     if (options?.json) {
-      let json = result
       try {
-        json = JSON.parse(value)
-      } catch {}
-      try {
+        const json = JSON.parse(value)
         result = JSON.stringify(json, null, 2)
       } catch {}
+      return result
     }
+
+    if (isBeautified && language === 'sql') {
+      return formatSQL(result)
+    }
+
     return result
-  }, [value, options?.json])
+  }, [value, options?.json, isBeautified, language])
+
+  const highlightedHtml = useMemo(() => {
+    if (!content) return ''
+    try {
+      return highlightCode(content, language, false)
+    } catch {
+      return `<pre class="m-0 bg-background! p-4 text-foreground! text-sm"><code class="font-mono text-sm">${content}</code></pre>`
+    }
+  }, [content, language])
+
+  const handleBeautifyToggle = useCallback((checked: boolean) => {
+    setIsBeautified(checked)
+    saveBeautifyState(checked)
+  }, [])
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(content)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      /* noop */
+    }
+  }, [content])
 
   if (formatted.length < truncate_length) {
-    return <code className="whitespace-nowrap">{formatted}</code>
+    return (
+      <code className="whitespace-nowrap font-mono text-xs">{formatted}</code>
+    )
   }
 
-  // If the code is not truncated, show the full code
   if (!formatted.endsWith('...')) {
-    return <code className="whitespace-nowrap">{formatted}</code>
+    return (
+      <code className="whitespace-nowrap font-mono text-xs">{formatted}</code>
+    )
   }
 
   return (
@@ -91,14 +186,14 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
       <DialogTrigger asChild>
         <div
           className={cn(
-            'flex max-w-fit cursor-pointer flex-row items-center gap-1 line-clamp-1',
+            'flex max-w-fit cursor-pointer flex-row items-center gap-1.5 line-clamp-1 group/cell',
             options?.trigger_classname
           )}
         >
-          <code className="font-normal whitespace-nowrap truncated">
+          <code className="font-mono text-xs whitespace-nowrap truncated text-muted-foreground group-hover/cell:text-foreground transition-colors">
             {formatted}
           </code>
-          <SizeIcon className="size-4 flex-none" />
+          <SizeIcon className="size-3.5 flex-none shrink-0 text-muted-foreground/60 group-hover/cell:text-muted-foreground transition-colors" />
         </div>
       </DialogTrigger>
       <DialogContent
@@ -109,26 +204,74 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
         aria-describedby={options?.dialog_description}
       >
         <DialogHeader>
-          <div className="flex items-center gap-2">
-            <DialogTitle>{options?.dialog_title}</DialogTitle>
-            {(options?.show_explorer_link ||
-              options?.dialog_title === 'Running Query') && (
-              <ExplorerLink query={value} />
-            )}
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <DialogTitle className="text-base">
+                {options?.dialog_title}
+              </DialogTitle>
+              {(options?.show_explorer_link ||
+                options?.dialog_title === 'Running Query') && (
+                <ExplorerLink query={value} />
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              {language === 'sql' && (
+                <div className="flex items-center gap-1.5">
+                  <SparklesIcon className="size-3 text-muted-foreground" />
+                  <span className="text-xs text-muted-foreground">
+                    Beautify
+                  </span>
+                  <Switch
+                    checked={isBeautified}
+                    onCheckedChange={handleBeautifyToggle}
+                    aria-label="Toggle SQL beautification"
+                    className="scale-75"
+                  />
+                </div>
+              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 gap-1 text-xs text-muted-foreground px-2"
+                onClick={handleCopy}
+              >
+                {copied ? (
+                  <Check className="size-3" strokeWidth={1.5} />
+                ) : (
+                  <Copy className="size-3" strokeWidth={1.5} />
+                )}
+                {copied ? 'Copied' : 'Copy'}
+              </Button>
+            </div>
           </div>
-          <DialogDescription>{options?.dialog_description}</DialogDescription>
+          <DialogDescription className="sr-only">
+            {options?.dialog_description ||
+              'Code content dialog with syntax highlighting'}
+          </DialogDescription>
         </DialogHeader>
 
-        <div className="max-h-[80vh] overflow-auto">
-          <code className="text-sm text-wrap whitespace-pre-wrap">
-            {typeof content === 'string' ? (
-              <pre className="text-wrap whitespace-pre-wrap">
-                {dedent(content)}
-              </pre>
-            ) : (
-              content
-            )}
-          </code>
+        <div className="relative group/code">
+          <ScrollArea className="max-h-[70vh] rounded-lg border border-border/60 bg-muted/40">
+            <div
+              className="overflow-auto [&_.hljs-keyword]:text-purple-600 [&_.hljs-string]:text-green-700 [&_.hljs-number]:text-blue-600 [&_.hljs-comment]:text-gray-500 [&_.hljs-built_in]:text-cyan-700 [&_.hljs-title]:text-blue-700 [&_.hljs-attr]:text-orange-600 [&_.hljs-literal]:text-blue-600 dark:[&_.hljs-keyword]:text-purple-400 dark:[&_.hljs-string]:text-green-400 dark:[&_.hljs-number]:text-blue-400 dark:[&_.hljs-comment]:text-gray-400 dark:[&_.hljs-built_in]:text-cyan-400 dark:[&_.hljs-title]:text-blue-400 dark:[&_.hljs-attr]:text-orange-400 dark:[&_.hljs-literal]:text-blue-400"
+              dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+            />
+          </ScrollArea>
+
+          <div className="absolute top-2 right-2 flex items-center gap-2 opacity-0 group-hover/code:opacity-100 transition-opacity">
+            <span className="text-[10px] text-muted-foreground bg-background/80 px-1.5 py-0.5 rounded">
+              {language.toUpperCase()}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between text-[10px] text-muted-foreground px-0.5">
+          <span className="font-medium">
+            {language === 'sql' ? 'ClickHouse SQL' : language.toUpperCase()}
+          </span>
+          <span className="tabular-nums">
+            {content.split('\n').length} lines
+          </span>
         </div>
       </DialogContent>
     </Dialog>

--- a/components/data-table/cells/code-dialog-format.tsx
+++ b/components/data-table/cells/code-dialog-format.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { SizeIcon } from '@radix-ui/react-icons'
 import { Check, Copy, ExternalLinkIcon, SparklesIcon } from 'lucide-react'
 

--- a/components/data-table/formatters/index.cy.tsx
+++ b/components/data-table/formatters/index.cy.tsx
@@ -158,14 +158,17 @@ describe('Formatters Module', () => {
       cy.mount(<TestWrapper>{codeDialogFormatter(longCode)}</TestWrapper>)
 
       cy.get('code').should('contain.text', '...')
-      cy.get('code.truncated').parent().should('have.class', 'cursor-pointer')
+      cy.get('code.truncated')
+        .closest('button')
+        .should('have.attr', 'type', 'button')
+        .and('be.enabled')
     })
 
     it('codeDialogFormatter should show dialog trigger for long code', () => {
       const longQuery = 'SELECT * FROM users WHERE id = 1'.repeat(5)
       cy.mount(<TestWrapper>{codeDialogFormatter(longQuery)}</TestWrapper>)
 
-      cy.get('code.truncated').parent().click()
+      cy.get('code.truncated').closest('button').click()
       cy.get('[role="dialog"]').should('exist')
     })
 

--- a/components/data-table/renderers/table-body.tsx
+++ b/components/data-table/renderers/table-body.tsx
@@ -72,7 +72,10 @@ export const VirtualizedTableRow = memo(function VirtualizedTableRow<
         return (
           <TableCell
             key={cell.id}
-            className={cn('text-sm whitespace-nowrap', cellClassName)}
+            className={cn(
+              'text-sm whitespace-nowrap tabular-nums',
+              cellClassName
+            )}
             style={{
               width: 'auto',
               minWidth: 0,
@@ -128,7 +131,10 @@ export const StandardTableRow = memo(function StandardTableRow<
         return (
           <TableCell
             key={cell.id}
-            className={cn('text-sm whitespace-nowrap', cellClassName)}
+            className={cn(
+              'text-sm whitespace-nowrap tabular-nums',
+              cellClassName
+            )}
             style={{
               width: 'auto',
               minWidth: 0,

--- a/lib/query-config/queries/running-queries.ts
+++ b/lib/query-config/queries/running-queries.ts
@@ -75,7 +75,7 @@ export const runningQueriesConfig: QueryConfig = {
     query: [
       ColumnFormat.CodeDialog,
       {
-        max_truncate: 40,
+        max_truncate: 80,
         hide_query_comment: true,
         dialog_title: 'Running Query',
       },


### PR DESCRIPTION
## Changes
- Rewrite `CodeDialogFormat` with **highlight.js syntax highlighting** for SQL/JSON
- Add **sql-formatter beautify toggle** with localStorage persistence
- Add **copy-to-clipboard** button and language auto-detection
- Wrap code in `ScrollArea` with ShowLines count and language badge
- Increase `max_truncate` from **40 → 80** in running-queries for more inline context
- Add `tabular-nums` to all table cells for better number alignment

### Retrofit
All pages using `CodeDialogFormat` (history-queries, failed-queries, slow-queries, expensive-queries, mutations, backups, dictionaries, etc.) automatically get the improved dialog.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Improve the query code dialog with syntax highlighting and formatting controls while refining query truncation and table numeric presentation.

New Features:
- Add syntax-highlighted code dialog content with SQL/JSON language detection and visual language badges.
- Introduce an optional SQL beautify toggle for dialog content with persisted user preference.
- Add a copy-to-clipboard action for dialog code content and display total line count in the footer.

Enhancements:
- Wrap dialog code content in a scrollable, styled container and update inline query typography for better readability.
- Increase the running-queries code truncation limit from 40 to 80 characters to show more inline query context.
- Apply tabular-nums styling to table body cells to improve alignment of numeric values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent, SSR-safe SQL "Beautify" toggle (SQL-only) and JSON pretty-printing in code dialogs
  * Syntax-highlighted, scrollable code view with language badge and line-count
  * Copy-to-clipboard with temporary "Copied" feedback

* **Improvements**
  * Numeric alignment in table cells improved
  * More query text shown before truncation
  * Dialogs safely escape/render HTML-like markup

* **Tests**
  * Tests clear stored settings and verify escaped rendering and plain-text dialog behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->