### PR TITLE
fix(table): allow standard cells to wrap

### DIFF
--- a/components/data-table/renderers/table-body.cy.tsx
+++ b/components/data-table/renderers/table-body.cy.tsx
@@ -95,6 +95,21 @@ describe('TableBody Components', () => {
 
       cy.get('tr').should('have.attr', 'data-state', 'selected')
     })
+
+    it('allows standard cells to wrap long content', () => {
+      cy.mount(
+        <table>
+          <tbody>
+            <StandardTableRow row={mockRow as any} index={0} />
+          </tbody>
+        </table>
+      )
+
+      cy.get('td')
+        .first()
+        .should('have.class', 'break-words')
+        .and('not.have.class', 'whitespace-nowrap')
+    })
   })
 
   describe('VirtualizedTableRow', () => {
@@ -128,6 +143,23 @@ describe('TableBody Components', () => {
       )
 
       cy.get('tr').should('have.class', 'odd:bg-muted/30')
+    })
+
+    it('keeps virtualized cells non-wrapping for stable row heights', () => {
+      const virtualRow = { index: 0, size: 50, start: 0 }
+
+      cy.mount(
+        <table>
+          <tbody>
+            <VirtualizedTableRow row={mockRow as any} virtualRow={virtualRow} />
+          </tbody>
+        </table>
+      )
+
+      cy.get('td')
+        .first()
+        .should('have.class', 'whitespace-nowrap')
+        .and('not.have.class', 'break-words')
     })
   })
 

--- a/components/data-table/renderers/table-body.tsx
+++ b/components/data-table/renderers/table-body.tsx
@@ -18,6 +18,9 @@ import { EmptyState } from '@/components/ui/empty-state'
 import { TableCell, TableRow } from '@/components/ui/table'
 import { cn } from '@/lib/utils'
 
+const VIRTUALIZED_CELL_CLASS = 'text-sm whitespace-nowrap tabular-nums'
+const STANDARD_CELL_CLASS = 'text-sm align-top break-words tabular-nums'
+
 /**
  * Virtual row item from @tanstack/react-virtual
  */
@@ -72,10 +75,7 @@ export const VirtualizedTableRow = memo(function VirtualizedTableRow<
         return (
           <TableCell
             key={cell.id}
-            className={cn(
-              'text-sm whitespace-nowrap tabular-nums',
-              cellClassName
-            )}
+            className={cn(VIRTUALIZED_CELL_CLASS, cellClassName)}
             style={{
               width: 'auto',
               minWidth: 0,
@@ -131,10 +131,7 @@ export const StandardTableRow = memo(function StandardTableRow<
         return (
           <TableCell
             key={cell.id}
-            className={cn(
-              'text-sm whitespace-nowrap tabular-nums',
-              cellClassName
-            )}
+            className={cn(STANDARD_CELL_CLASS, cellClassName)}
             style={{
               width: 'auto',
               minWidth: 0,


### PR DESCRIPTION
## Summary\n- allow non-virtualized table cells to wrap long content on narrow screens\n- keep virtualized cells non-wrapping to preserve stable row heights\n- add component coverage for both row modes\n\n## Verification\n- bunx cypress run --component --spec components/data-table/renderers/table-body.cy.tsx\n- bun run type-check\n- bun run lint\n- bun run build