### PR TITLE
fix(table): stop default polling

### DIFF
--- a/components/tables/table-client.cy.tsx
+++ b/components/tables/table-client.cy.tsx
@@ -15,6 +15,17 @@ function mockTableResponse(body: unknown, statusCode = 200) {
   ).as('fetchTableData')
 }
 
+function mockCountingTableResponse(body: unknown) {
+  let requestCount = 0
+
+  cy.intercept({ method: 'GET', url: '/api/v1/tables/test-tables*' }, (req) => {
+    requestCount += 1
+    req.reply({ statusCode: 200, body })
+  }).as('fetchTableData')
+
+  return () => requestCount
+}
+
 describe('<TableClient />', () => {
   it('renders data table after data loads', () => {
     mockTableResponse({
@@ -107,5 +118,57 @@ describe('<TableClient />', () => {
 
     cy.wait('@fetchTableData')
     cy.contains('All tables in the cluster').should('be.visible')
+  })
+
+  it('does not poll table data by default', () => {
+    cy.clock()
+    const getRequestCount = mockCountingTableResponse({
+      data: [
+        { name: 'users', database: 'default', engine: 'MergeTree', rows: 1000 },
+      ],
+      metadata: {
+        queryId: 'test-query-id',
+        duration: 0.1,
+        rows: 1,
+        host: 'localhost',
+      },
+    })
+
+    cy.mount(<TableClient title="Test Tables" queryConfig={mockQueryConfig} />)
+
+    cy.wait('@fetchTableData')
+    cy.tick(31_000)
+    cy.then(() => {
+      expect(getRequestCount()).to.eq(1)
+    })
+  })
+
+  it('polls table data when the query config opts in', () => {
+    cy.clock()
+    const getRequestCount = mockCountingTableResponse({
+      data: [
+        { name: 'users', database: 'default', engine: 'MergeTree', rows: 1000 },
+      ],
+      metadata: {
+        queryId: 'test-query-id',
+        duration: 0.1,
+        rows: 1,
+        host: 'localhost',
+      },
+    })
+
+    cy.mount(
+      <TableClient
+        title="Test Tables"
+        queryConfig={{ ...mockQueryConfig, refreshInterval: 30_000 }}
+      />
+    )
+
+    cy.wait('@fetchTableData')
+    cy.tick(31_000)
+    cy.wait('@fetchTableData')
+    cy.then(() => {
+      expect(getRequestCount()).to.eq(2)
+    })
   })
 })

--- a/components/tables/table-client.tsx
+++ b/components/tables/table-client.tsx
@@ -71,13 +71,14 @@ export const TableClient = memo(function TableClient({
   enableRowSelection = false,
 }: TableClientProps) {
   const hostId = useHostId()
+  const refreshInterval = queryConfig.refreshInterval ?? 0
 
   const { data, metadata, error, isLoading, isValidating, refresh } =
     useTableData<Record<string, unknown>>(
       queryConfig.name,
       hostId,
       searchParams,
-      30000
+      refreshInterval
     )
 
   // Show skeleton during initial load OR if validating with no existing data

--- a/lib/query-config/merges/merges.ts
+++ b/lib/query-config/merges/merges.ts
@@ -4,6 +4,7 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const mergesConfig: QueryConfig = {
   name: 'merges',
+  refreshInterval: 30_000,
   description:
     'Merges and part mutations currently in process for tables in the MergeTree family',
   sql: `

--- a/lib/query-config/merges/mutations.ts
+++ b/lib/query-config/merges/mutations.ts
@@ -9,6 +9,7 @@ export const LONG_RUNNING_THRESHOLD_SECONDS = 300
 
 export const mutationsConfig: QueryConfig = {
   name: 'mutations',
+  refreshInterval: 30_000,
   description:
     'Information about mutations of MergeTree tables and their progress',
   sql: `

--- a/lib/query-config/queries/running-queries.ts
+++ b/lib/query-config/queries/running-queries.ts
@@ -4,6 +4,7 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const runningQueriesConfig: QueryConfig = {
   name: 'running-queries',
+  refreshInterval: 30_000,
   sql: `
     SELECT *,
       query_id as query_detail,

--- a/lib/query-config/tables/replicas.ts
+++ b/lib/query-config/tables/replicas.ts
@@ -4,6 +4,7 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const replicasConfig: QueryConfig = {
   name: 'replicas',
+  refreshInterval: 30_000,
   description: `Contains information and status for replicated tables residing on the local server`,
   sql: `
       SELECT *, (database || '.' || table) as database_table

--- a/lib/query-config/tables/replication-queue.ts
+++ b/lib/query-config/tables/replication-queue.ts
@@ -4,6 +4,7 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const replicationQueueConfig: QueryConfig = {
   name: 'replication-queue',
+  refreshInterval: 30_000,
   description: `Contains information about tasks from replication queues stored in ClickHouse Keeper, or ZooKeeper, for tables in the ReplicatedMergeTree family`,
   tableCheck: 'system.replication_queue',
   sql: `

--- a/types/query-config.ts
+++ b/types/query-config.ts
@@ -122,6 +122,11 @@ export interface QueryConfig<TColumns extends readonly string[] = string[]> {
   permission?: FeaturePermission
   description?: string
   /**
+   * Auto-refresh interval for table data in milliseconds.
+   * Leave unset to fetch once and rely on manual refresh.
+   */
+  refreshInterval?: number
+  /**
    * Helpful suggestion displayed in empty state when no data is available.
    * Shows below "No data" message with setup examples and documentation links.
    *


### PR DESCRIPTION
## Summary
- make table auto-refresh opt-in through QueryConfig.refreshInterval
- keep 30s refresh on live operational tables: running queries, merges, mutations, replicas, and replication queue
- add component coverage for default no-polling and explicit polling

## Verification
- bunx cypress run --component --spec components/tables/table-client.cy.tsx
- bun run type-check
- bun run lint
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tables now support configurable auto-refresh intervals. Data automatically refreshes at customizable intervals specified through query configuration settings. Most applicable tables are now set to refresh every 30 seconds by default. You can disable auto-refresh entirely by setting the refresh interval to 0, which reverts the table to manual refresh only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->