### PR TITLE
perf(table): avoid row key scans

### DIFF
--- a/components/data-table/data-table.tsx
+++ b/components/data-table/data-table.tsx
@@ -19,6 +19,7 @@ import type { QueryConfig } from '@/types/query-config'
 
 import { arrayMove } from '@dnd-kit/sortable'
 import { useCallback, useMemo, useState } from 'react'
+import { normalizeColumnName } from '@/components/data-table/column-defs'
 import {
   DataTableContent,
   DataTableFooter,
@@ -169,10 +170,7 @@ export function DataTable<
 
   // Determine which columns should be filterable (memoized)
   const configuredColumns = useMemo(
-    () =>
-      queryConfig.columns.map((col) =>
-        col.toLowerCase().replace('readable_', '').trim()
-      ),
+    () => queryConfig.columns.map(normalizeColumnName),
     [queryConfig.columns]
   )
 
@@ -224,10 +222,7 @@ export function DataTable<
   )
 
   // Column calculations and definitions
-  const { columnDefs, initialColumnVisibility } = useTableColumns<
-    TData,
-    TValue
-  >({
+  const { columnDefs } = useTableColumns<TData, TValue>({
     queryConfig,
     context,
     filteredData,
@@ -235,9 +230,10 @@ export function DataTable<
   })
 
   // Column visibility
-  const { columnVisibility, setColumnVisibility } = useColumnVisibility({
-    configuredColumns,
-  })
+  const { columnVisibility, setColumnVisibility, initialColumnVisibility } =
+    useColumnVisibility({
+      configuredColumns,
+    })
 
   // Density mode with localStorage persistence
   const { density, setDensity, cellClassName } = useTableDensity(

--- a/components/data-table/data-table.tsx
+++ b/components/data-table/data-table.tsx
@@ -224,12 +224,11 @@ export function DataTable<
   )
 
   // Column calculations and definitions
-  const { allColumns, columnDefs, initialColumnVisibility } = useTableColumns<
+  const { columnDefs, initialColumnVisibility } = useTableColumns<
     TData,
     TValue
   >({
     queryConfig,
-    data,
     context,
     filteredData,
     filterContext,
@@ -237,7 +236,6 @@ export function DataTable<
 
   // Column visibility
   const { columnVisibility, setColumnVisibility } = useColumnVisibility({
-    allColumns,
     configuredColumns,
   })
 

--- a/components/data-table/hooks/use-column-visibility.ts
+++ b/components/data-table/hooks/use-column-visibility.ts
@@ -3,24 +3,22 @@ import type { VisibilityState } from '@tanstack/react-table'
 import { useMemo, useState } from 'react'
 
 interface UseColumnVisibilityOptions {
-  allColumns: string[]
   configuredColumns: string[]
 }
 
 export function useColumnVisibility({
-  allColumns,
   configuredColumns,
 }: UseColumnVisibilityOptions) {
   const initialColumnVisibility = useMemo(
     () =>
-      allColumns.reduce(
+      configuredColumns.reduce(
         (state, col) => ({
           ...state,
-          [col]: configuredColumns.includes(col),
+          [col]: true,
         }),
         {} as VisibilityState
       ),
-    [allColumns, configuredColumns]
+    [configuredColumns]
   )
 
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(

--- a/components/data-table/hooks/use-column-visibility.ts
+++ b/components/data-table/hooks/use-column-visibility.ts
@@ -6,18 +6,17 @@ interface UseColumnVisibilityOptions {
   configuredColumns: string[]
 }
 
+function createVisibleColumnState(columns: string[]): VisibilityState {
+  return Object.fromEntries(
+    columns.map((col) => [col, true])
+  ) as VisibilityState
+}
+
 export function useColumnVisibility({
   configuredColumns,
 }: UseColumnVisibilityOptions) {
   const initialColumnVisibility = useMemo(
-    () =>
-      configuredColumns.reduce(
-        (state, col) => ({
-          ...state,
-          [col]: true,
-        }),
-        {} as VisibilityState
-      ),
+    () => createVisibleColumnState(configuredColumns),
     [configuredColumns]
   )
 

--- a/components/data-table/hooks/use-table-columns.ts
+++ b/components/data-table/hooks/use-table-columns.ts
@@ -1,12 +1,8 @@
-import type { ColumnDef, RowData, VisibilityState } from '@tanstack/react-table'
+import type { ColumnDef, RowData } from '@tanstack/react-table'
 
 import type { QueryConfig } from '@/types/query-config'
 
-import {
-  type ColumnFilterContext,
-  getColumnDefs,
-  normalizeColumnName,
-} from '../column-defs'
+import { type ColumnFilterContext, getColumnDefs } from '../column-defs'
 import { useMemo } from 'react'
 
 interface UseTableColumnsOptions<TData extends RowData, _TValue> {
@@ -17,10 +13,8 @@ interface UseTableColumnsOptions<TData extends RowData, _TValue> {
 }
 
 interface UseTableColumnsReturn<TData extends RowData, TValue> {
-  configuredColumns: string[]
   contextWithPrefix: Record<string, string>
   columnDefs: ColumnDef<TData, TValue>[]
-  initialColumnVisibility: VisibilityState
 }
 
 export function useTableColumns<
@@ -35,12 +29,6 @@ export function useTableColumns<
   TData,
   TValue
 > {
-  // Configured columns available, normalized
-  const configuredColumns = useMemo(
-    () => queryConfig.columns.map(normalizeColumnName),
-    [queryConfig.columns]
-  )
-
   // Add `ctx.` prefix to all keys (memoized to prevent recalculation)
   const contextWithPrefix = useMemo(
     () =>
@@ -66,23 +54,8 @@ export function useTableColumns<
     [queryConfig, filteredData, contextWithPrefix, filterContext]
   )
 
-  // Initial column visibility state
-  const initialColumnVisibility: VisibilityState = useMemo(
-    () =>
-      configuredColumns.reduce(
-        (state, col) => ({
-          ...state,
-          [col]: true,
-        }),
-        {} as VisibilityState
-      ),
-    [configuredColumns]
-  )
-
   return {
-    configuredColumns,
     contextWithPrefix,
     columnDefs,
-    initialColumnVisibility,
   }
 }

--- a/components/data-table/hooks/use-table-columns.ts
+++ b/components/data-table/hooks/use-table-columns.ts
@@ -8,18 +8,15 @@ import {
   normalizeColumnName,
 } from '../column-defs'
 import { useMemo } from 'react'
-import { uniq } from '@/lib/utils'
 
 interface UseTableColumnsOptions<TData extends RowData, _TValue> {
   queryConfig: QueryConfig
-  data: TData[]
   context: Record<string, string>
   filteredData: TData[]
   filterContext?: ColumnFilterContext
 }
 
 interface UseTableColumnsReturn<TData extends RowData, TValue> {
-  allColumns: string[]
   configuredColumns: string[]
   contextWithPrefix: Record<string, string>
   columnDefs: ColumnDef<TData, TValue>[]
@@ -31,7 +28,6 @@ export function useTableColumns<
   TValue extends React.ReactNode,
 >({
   queryConfig,
-  data,
   context,
   filteredData,
   filterContext,
@@ -39,17 +35,6 @@ export function useTableColumns<
   TData,
   TValue
 > {
-  // Columns available in the data, normalized (memoized to prevent recalculation)
-  const allColumns: string[] = useMemo(
-    () =>
-      uniq(
-        (data.filter((row) => typeof row === 'object') as object[])
-          .flatMap((row) => Object.keys(row))
-          .map(normalizeColumnName)
-      ),
-    [data]
-  )
-
   // Configured columns available, normalized
   const configuredColumns = useMemo(
     () => queryConfig.columns.map(normalizeColumnName),
@@ -84,18 +69,17 @@ export function useTableColumns<
   // Initial column visibility state
   const initialColumnVisibility: VisibilityState = useMemo(
     () =>
-      allColumns.reduce(
+      configuredColumns.reduce(
         (state, col) => ({
           ...state,
-          [col]: configuredColumns.includes(col),
+          [col]: true,
         }),
         {} as VisibilityState
       ),
-    [allColumns, configuredColumns]
+    [configuredColumns]
   )
 
   return {
-    allColumns,
     configuredColumns,
     contextWithPrefix,
     columnDefs,


### PR DESCRIPTION
## Summary
- stop deriving table visibility from every key in every returned row
- initialize table visibility from the configured columns that are actually rendered
- remove the now-unused data scan from the column setup hook

## Verification
- bunx cypress run --component --spec 'components/data-table/data-table.cy.tsx,components/data-table/components/data-table-content.cy.tsx,components/data-table/renderers/table-body.cy.tsx'
- bun run type-check
- bun run lint
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined data table column management by simplifying column visibility initialization logic.
  * Removed unnecessary data processing dependencies to improve overall table performance.
  * Optimized internal column configuration system for more efficient rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->