### PR TITLE
fix(table): keep paginated rows standard

### DIFF
--- a/components/data-table/components/data-table-content.tsx
+++ b/components/data-table/components/data-table-content.tsx
@@ -37,7 +37,7 @@ import { cn } from '@/lib/utils'
  * @param table - TanStack Table instance
  * @param columnDefs - Column definitions for rendering
  * @param tableContainerRef - Ref for the table container (used for virtualization)
- * @param isVirtualized - Whether virtualization is enabled (1000+ rows)
+ * @param isVirtualized - Whether virtualization is enabled
  * @param virtualizer - Virtual row instance from useVirtualRows hook
  * @param activeFilterCount - Number of active column filters
  * @param onAutoFit - Callback when double-clicking column resizer to auto-fit
@@ -58,7 +58,7 @@ export interface DataTableContentProps<
   columnDefs: ColumnDef<TData, TValue>[]
   /** Ref for the table container (used for virtualization) */
   tableContainerRef: React.RefObject<HTMLDivElement | null>
-  /** Whether virtualization is enabled (1000+ rows) */
+  /** Whether virtualization is enabled */
   isVirtualized: boolean
   /** Virtual row instance from useVirtualRows hook */
   virtualizer: ReturnType<
@@ -82,7 +82,7 @@ export interface DataTableContentProps<
  * DataTableContent - Content wrapper with virtualization logic
  *
  * Handles:
- * - Virtual scrolling for large datasets (1000+ rows)
+ * - Virtual scrolling for datasets larger than the standard pagination range
  * - Standard scrolling for smaller datasets
  * - Table header and body rendering
  * - Empty state handling with contextual messaging
@@ -92,7 +92,7 @@ export interface DataTableContentProps<
  * Performance considerations:
  * - Virtualization reduces DOM nodes from thousands to ~100
  * - Memoized to prevent unnecessary re-renders
- * - Auto-enables virtualization at 1000+ rows
+ * - Auto-enables virtualization beyond the standard pagination range
  */
 export const DataTableContent = memo(function DataTableContent<
   TData extends RowData,

--- a/components/data-table/data-table.cy.tsx
+++ b/components/data-table/data-table.cy.tsx
@@ -95,6 +95,27 @@ describe('<DataTable />', () => {
     cy.get('button[aria-label="Go to next page"]').should('be.enabled')
   })
 
+  it('keeps large paginated pages on the standard table path', () => {
+    const data = Array.from({ length: 300 }, (_, index) => ({
+      col1: `val${index}`,
+      col2: `val${index}`,
+    }))
+
+    cy.mount(
+      <DataTable
+        title="Test Table"
+        queryConfig={queryConfig}
+        data={data}
+        context={{}}
+        defaultPageSize={200}
+      />
+    )
+
+    cy.get('[role="region"]').should('not.have.attr', 'style')
+    cy.get('tbody tr').should('have.length', 200)
+    cy.get('div').contains('1–200 of 300 rows')
+  })
+
   it('should adjust column visibility, hide col1', () => {
     // Define some mock data
     const data = [

--- a/components/data-table/data-table.tsx
+++ b/components/data-table/data-table.tsx
@@ -123,7 +123,7 @@ interface DataTableProps<TData extends RowData> {
  * - DataTableFooter: Pagination and footnote
  *
  * Features:
- * - Virtual scrolling for large datasets (auto-enables at 1000+ rows)
+ * - Virtual scrolling for datasets larger than the standard pagination range
  * - Client-side column filtering
  * - URL filter synchronization for shareable links
  * - Custom sorting functions
@@ -412,7 +412,7 @@ export function DataTable<
     },
   })
 
-  // Virtual rows for large datasets (auto-enables at 1000+ rows)
+  // Virtual rows for datasets larger than the standard pagination range
   const rows = table.getRowModel().rows
   const { virtualizer, tableContainerRef, isVirtualized } = useVirtualRows(
     rows.length

--- a/components/data-table/hooks/use-virtual-rows.ts
+++ b/components/data-table/hooks/use-virtual-rows.ts
@@ -4,6 +4,8 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 
 import { type RefObject, useRef } from 'react'
 
+const MAX_PAGINATED_TABLE_ROWS = 1_000
+
 /**
  * Hook for virtualizing table rows to improve performance with large datasets.
  * Automatically enables when row count exceeds threshold.
@@ -29,7 +31,7 @@ export interface UseVirtualRowsOptions {
   estimateSize?: number
   /** Number of rows to render outside viewport (default: 20) */
   overscan?: number
-  /** Row count threshold to enable virtualization (default: 200) */
+  /** Row count threshold to enable virtualization (default: 1001) */
   virtualizeThreshold?: number
 }
 
@@ -49,12 +51,13 @@ export function useVirtualRows(
   const {
     estimateSize = 40,
     overscan = 20,
-    virtualizeThreshold = 200,
+    virtualizeThreshold = MAX_PAGINATED_TABLE_ROWS + 1,
   } = options
 
   const tableContainerRef = useRef<HTMLDivElement>(null)
 
-  // Auto-enable virtualization for large datasets
+  // The table is paginated to at most 1,000 rows. Keep the standard table path
+  // for normal page sizes until the virtual renderer has a proper spacer layout.
   const shouldVirtualize = rowCount >= virtualizeThreshold
 
   const virtualizer = useVirtualizer<HTMLDivElement, Element>({

--- a/components/data-table/renderers/table-body.tsx
+++ b/components/data-table/renderers/table-body.tsx
@@ -48,7 +48,7 @@ export interface VirtualizedTableRowProps<TData extends RowData> {
  * - Zebra striping with odd rows
  * - Hover effects
  *
- * Performance: Optimized for large datasets (1000+ rows), memoized to prevent re-renders
+ * Performance: Optimized for large datasets, memoized to prevent re-renders
  */
 export const VirtualizedTableRow = memo(function VirtualizedTableRow<
   TData extends RowData,
@@ -172,7 +172,7 @@ export interface TableBodyRowsProps<TData extends RowData> {
  * @param virtualizer - Virtual row instance when virtualization is enabled
  *
  * Automatically chooses rendering strategy based on dataset size:
- * - Virtualized rendering for 1000+ rows
+ * - Virtualized rendering for large row sets
  * - Standard rendering for smaller datasets
  *
  * Performance: Virtualization reduces DOM nodes from thousands to ~100, memoized to prevent re-renders


### PR DESCRIPTION
## Summary
- keep normal paginated table pages on the standard table renderer
- raise the virtual-row threshold beyond the table pagination range until the virtual body has a proper spacer layout
- add regression coverage for 200-row pages staying on the standard path

## Verification
- bunx cypress run --component --spec 'components/data-table/data-table.cy.tsx,components/data-table/components/data-table-content.cy.tsx,components/data-table/renderers/table-body.cy.tsx'
- bun run type-check
- bun run lint
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage validating DataTable pagination and row rendering with large datasets.

* **Documentation**
  * Clarified virtualization behavior documentation—virtual scrolling now applies to datasets larger than the standard pagination range.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->