### PR TITLE
perf(table): commit resize on drag end

### DIFF
--- a/components/data-table/data-table.tsx
+++ b/components/data-table/data-table.tsx
@@ -387,7 +387,7 @@ export function DataTable<
     onColumnVisibilityChange: setColumnVisibility,
     // Column resizing
     enableColumnResizing: true,
-    columnResizeMode: 'onChange',
+    columnResizeMode: 'onEnd',
     onColumnSizingChange: setColumnSizing,
     // Column reordering
     onColumnOrderChange: handleColumnOrderChange,


### PR DESCRIPTION
## Summary
- commit table column resize state after the drag gesture ends
- reduce rerenders while resizing large table cells

## Verification
- bunx cypress run --component --spec 'components/data-table/data-table.cy.tsx,components/data-table/components/data-table-content.cy.tsx,components/data-table/renderers/table-body.cy.tsx'
- bun run type-check
- bun run lint
- bun run build

## Summary by Sourcery

Enhancements:
- Adjust table column resize behavior to use end-of-drag commits instead of continuous updates for improved performance during resizing.