### PR TITLE
fix(table): cap API result rows

### DIFF
--- a/app/api/v1/tables/[name]/__tests__/route.test.ts
+++ b/app/api/v1/tables/[name]/__tests__/route.test.ts
@@ -1,0 +1,161 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+const mockQueryConfig = {
+  name: 'tables-overview',
+  sql: 'SELECT 1',
+  columns: ['table'],
+  clickhouseSettings: {
+    allow_experimental_analyzer: 0,
+  },
+}
+
+function getMockQueryConfig(name: string) {
+  if (name === 'metrics') {
+    return {
+      ...mockQueryConfig,
+      name: 'metrics',
+      permission: { feature: 'metrics' as const },
+    }
+  }
+
+  return mockQueryConfig
+}
+
+const mockGetTableConfig = mock((name: string) => getMockQueryConfig(name))
+const mockHasTable = mock(() => true)
+const mockGetAvailableTables = mock(() => ['tables-overview'])
+const mockGetTableQuery = mock(
+  (name: string, params: { searchParams?: Record<string, string> }) => ({
+    query: 'SELECT 1',
+    queryParams:
+      params.searchParams && Object.keys(params.searchParams).length > 0
+        ? params.searchParams
+        : undefined,
+    queryConfig: getMockQueryConfig(name),
+  })
+)
+const mockFetchData = mock(() =>
+  Promise.resolve({
+    data: [{ table: 'system.query_log' }],
+    metadata: {
+      queryId: 'query-1',
+      duration: 0.01,
+      rows: 1,
+      host: 'localhost',
+      clickhouseVersion: '25.1.1.1',
+    },
+  })
+)
+
+mock.module('@/lib/api/table-registry', () => ({
+  getAvailableTables: mockGetAvailableTables,
+  getTableConfig: mockGetTableConfig,
+  getTableQuery: mockGetTableQuery,
+  hasTable: mockHasTable,
+}))
+
+mock.module('@/lib/clickhouse', () => ({
+  fetchData: mockFetchData,
+}))
+
+let GET: (
+  request: Request,
+  context: { params: Promise<{ name: string }> }
+) => Promise<Response>
+
+beforeAll(async () => {
+  const route = await import('../route')
+  GET = route.GET
+})
+
+beforeEach(() => {
+  mockGetTableConfig.mockClear()
+  mockHasTable.mockClear()
+  mockGetAvailableTables.mockClear()
+  mockGetTableQuery.mockClear()
+  mockFetchData.mockClear()
+  mockFetchData.mockResolvedValue({
+    data: [{ table: 'system.query_log' }],
+    metadata: {
+      queryId: 'query-1',
+      duration: 0.01,
+      rows: 1,
+      host: 'localhost',
+      clickhouseVersion: '25.1.1.1',
+    },
+  } as never)
+})
+
+describe('GET /api/v1/tables/[name]', () => {
+  test('passes table result cap with config settings and timezone', async () => {
+    const response = await GET(
+      new Request(
+        'http://localhost:3000/api/v1/tables/tables-overview?hostId=0&timezone=UTC'
+      ),
+      { params: Promise.resolve({ name: 'tables-overview' }) }
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockFetchData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostId: 0,
+        clickhouse_settings: {
+          allow_experimental_analyzer: 0,
+          session_timezone: 'UTC',
+          max_result_rows: '1000',
+          result_overflow_mode: 'break',
+        },
+      })
+    )
+    expect(body.metadata.resultRowLimit).toBe(1000)
+    expect(body.metadata.resultOverflowMode).toBe('break')
+    expect(body.metadata.resultRowsTruncated).toBe(false)
+    expect(body.metadata.timezone).toBe('UTC')
+  })
+
+  test('trims rows above the API result cap', async () => {
+    mockFetchData.mockResolvedValue({
+      data: Array.from({ length: 1002 }, (_, index) => ({ id: index })),
+      metadata: {
+        queryId: 'query-1',
+        duration: 0.01,
+        rows: 1002,
+        host: 'localhost',
+        clickhouseVersion: '25.1.1.1',
+      },
+    } as never)
+
+    const response = await GET(
+      new Request(
+        'http://localhost:3000/api/v1/tables/tables-overview?hostId=0'
+      ),
+      { params: Promise.resolve({ name: 'tables-overview' }) }
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.data).toHaveLength(1000)
+    expect(body.metadata.rows).toBe(1000)
+    expect(body.metadata.resultRowsBeforeCap).toBe(1002)
+    expect(body.metadata.resultRowsTruncated).toBe(true)
+  })
+
+  test('keeps request search params flowing to query params', async () => {
+    await GET(
+      new Request(
+        'http://localhost:3000/api/v1/tables/tables-overview?hostId=0&database=system&table=query_log'
+      ),
+      { params: Promise.resolve({ name: 'tables-overview' }) }
+    )
+
+    expect(mockFetchData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query_params: expect.objectContaining({
+          database: 'system',
+          table: 'query_log',
+        }),
+      })
+    )
+  })
+})

--- a/app/api/v1/tables/[name]/route.ts
+++ b/app/api/v1/tables/[name]/route.ts
@@ -13,6 +13,12 @@ import {
   type RouteContext,
 } from '@/lib/api/error-handler'
 import {
+  capTableResultRows,
+  getTableClickHouseSettings,
+  type TableClickHouseSettings,
+  type TableResultRowCap,
+} from '@/lib/api/table-query-settings'
+import {
   getAvailableTables,
   getTableConfig,
   getTableQuery,
@@ -99,14 +105,15 @@ export async function GET(
     )
   }
 
+  const clickhouseSettings = getTableClickHouseSettings(config, timezone)
+
   // Execute the query - always pass the full config for version selection
   const result = await fetchData({
     query: queryDef.query,
     query_params: queryDef.queryParams,
     hostId,
     format: 'JSONEachRow',
-    // Pass timezone to ClickHouse for session-level time conversion
-    clickhouse_settings: timezone ? { session_timezone: timezone } : undefined,
+    clickhouse_settings: clickhouseSettings,
     // Always pass queryConfig for version-aware SQL selection
     queryConfig: config,
   })
@@ -133,15 +140,22 @@ export async function GET(
     )
   }
 
+  const cappedResult = capTableResultRows(
+    result.data,
+    Number(clickhouseSettings.max_result_rows)
+  )
+
   // Create successful response with SQL and debug info
   return createSuccessResponse(
-    result.data,
+    cappedResult.data,
     result.metadata,
     queryDef.query,
     queryDef.queryParams,
     name,
     searchParams,
-    timezone
+    timezone,
+    clickhouseSettings,
+    cappedResult
   )
 }
 
@@ -172,7 +186,9 @@ function createSuccessResponse<T>(
   queryParams: Record<string, unknown> | undefined,
   tableName: string,
   searchParams: URLSearchParams,
-  timezone?: string
+  timezone: string | undefined,
+  clickhouseSettings: TableClickHouseSettings,
+  rowCap: TableResultRowCap<T>
 ): Response {
   // Build full API URL with query params
   const queryString = searchParams.toString()
@@ -184,7 +200,7 @@ function createSuccessResponse<T>(
     metadata: {
       queryId: String(metadata.queryId || ''),
       duration: Number(metadata.duration || 0),
-      rows: Number(metadata.rows || 0),
+      rows: rowCap.returnedRows ?? Number(metadata.rows || 0),
       host: String(metadata.host || ''),
       clickhouseVersion: String(metadata.clickhouseVersion || 'unknown'),
       // Full API endpoint URL with query params
@@ -198,6 +214,10 @@ function createSuccessResponse<T>(
       params: queryParams || null,
       // IANA timezone used for ClickHouse session
       timezone,
+      resultRowLimit: Number(clickhouseSettings.max_result_rows),
+      resultOverflowMode: String(clickhouseSettings.result_overflow_mode),
+      resultRowsBeforeCap: rowCap.truncated ? rowCap.sourceRows : undefined,
+      resultRowsTruncated: rowCap.truncated,
     },
   }
 

--- a/lib/api/__tests__/table-query-settings.test.ts
+++ b/lib/api/__tests__/table-query-settings.test.ts
@@ -1,0 +1,84 @@
+import type { QueryConfig } from '@/types/query-config'
+
+import { describe, expect, test } from 'bun:test'
+import {
+  capTableResultRows,
+  getTableClickHouseSettings,
+  TABLE_RESULT_OVERFLOW_MODE,
+  TABLE_RESULT_ROW_LIMIT,
+} from '@/lib/api/table-query-settings'
+
+describe('getTableClickHouseSettings', () => {
+  test('adds the table row cap and break overflow mode', () => {
+    expect(getTableClickHouseSettings(undefined, undefined)).toEqual({
+      max_result_rows: String(TABLE_RESULT_ROW_LIMIT),
+      result_overflow_mode: TABLE_RESULT_OVERFLOW_MODE,
+    })
+  })
+
+  test('preserves config settings and applies timezone', () => {
+    const config: QueryConfig = {
+      name: 'tables-overview',
+      sql: 'SELECT 1',
+      columns: ['one'],
+      clickhouseSettings: {
+        allow_experimental_analyzer: 0,
+      },
+    }
+
+    expect(getTableClickHouseSettings(config, 'UTC')).toEqual({
+      allow_experimental_analyzer: 0,
+      session_timezone: 'UTC',
+      max_result_rows: String(TABLE_RESULT_ROW_LIMIT),
+      result_overflow_mode: TABLE_RESULT_OVERFLOW_MODE,
+    })
+  })
+
+  test('does not raise a lower config result limit', () => {
+    const config: QueryConfig = {
+      name: 'small-result',
+      sql: 'SELECT 1',
+      columns: ['one'],
+      clickhouseSettings: {
+        max_result_rows: '25',
+        result_overflow_mode: 'throw',
+      },
+    }
+
+    expect(getTableClickHouseSettings(config, undefined)).toEqual({
+      max_result_rows: '25',
+      result_overflow_mode: TABLE_RESULT_OVERFLOW_MODE,
+    })
+  })
+})
+
+describe('capTableResultRows', () => {
+  test('keeps array data at or below the cap unchanged', () => {
+    const data = [{ id: 1 }, { id: 2 }]
+
+    expect(capTableResultRows(data, 2)).toEqual({
+      data,
+      sourceRows: 2,
+      returnedRows: 2,
+      truncated: false,
+    })
+  })
+
+  test('trims array data above the cap', () => {
+    expect(capTableResultRows([{ id: 1 }, { id: 2 }, { id: 3 }], 2)).toEqual({
+      data: [{ id: 1 }, { id: 2 }],
+      sourceRows: 3,
+      returnedRows: 2,
+      truncated: true,
+    })
+  })
+
+  test('leaves non-array data unchanged', () => {
+    const data = { rows: 10 }
+
+    expect(capTableResultRows(data, 2)).toEqual({
+      data,
+      truncated: false,
+    })
+  })
+})

--- a/lib/api/table-query-settings.ts
+++ b/lib/api/table-query-settings.ts
@@ -1,0 +1,72 @@
+import type { ClickHouseSettings } from '@clickhouse/client'
+
+import type { QueryConfig } from '@/types/query-config'
+
+export const TABLE_RESULT_ROW_LIMIT = 1_000
+export const TABLE_RESULT_OVERFLOW_MODE = 'break'
+
+export type TableResultRowCap<T> = {
+  data: T
+  sourceRows?: number
+  returnedRows?: number
+  truncated: boolean
+}
+
+export type TableClickHouseSettings = ClickHouseSettings & {
+  /** IANA timezone for ClickHouse session time conversion */
+  session_timezone?: string
+}
+
+function resolveResultRowLimit(
+  configuredLimit: ClickHouseSettings['max_result_rows'] | undefined
+): number {
+  const numericLimit = Number(configuredLimit)
+
+  if (Number.isFinite(numericLimit) && numericLimit > 0) {
+    return Math.min(numericLimit, TABLE_RESULT_ROW_LIMIT)
+  }
+
+  return TABLE_RESULT_ROW_LIMIT
+}
+
+export function getTableClickHouseSettings(
+  config: QueryConfig | undefined,
+  timezone: string | undefined
+): TableClickHouseSettings {
+  const configSettings = config?.clickhouseSettings ?? {}
+  const maxResultRows = resolveResultRowLimit(configSettings.max_result_rows)
+
+  return {
+    ...configSettings,
+    ...(timezone ? { session_timezone: timezone } : {}),
+    max_result_rows: String(maxResultRows),
+    result_overflow_mode: TABLE_RESULT_OVERFLOW_MODE,
+  }
+}
+
+export function capTableResultRows<T>(
+  data: T,
+  rowLimit: number
+): TableResultRowCap<T> {
+  if (!Array.isArray(data)) {
+    return { data, truncated: false }
+  }
+
+  const sourceRows = data.length
+
+  if (sourceRows <= rowLimit) {
+    return {
+      data,
+      sourceRows,
+      returnedRows: sourceRows,
+      truncated: false,
+    }
+  }
+
+  return {
+    data: data.slice(0, rowLimit) as T,
+    sourceRows,
+    returnedRows: rowLimit,
+    truncated: true,
+  }
+}

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -115,6 +115,14 @@ export interface ApiResponseMetadata {
   readonly params?: Record<string, unknown> | null
   /** IANA timezone used for ClickHouse session (e.g., "America/Los_Angeles", "UTC") */
   readonly timezone?: string
+  /** Maximum number of table rows the API asks ClickHouse to return */
+  readonly resultRowLimit?: number
+  /** ClickHouse overflow mode used when the result row limit is reached */
+  readonly resultOverflowMode?: string
+  /** Raw rows received from ClickHouse before the API response cap was applied */
+  readonly resultRowsBeforeCap?: number
+  /** Whether the API response data was trimmed to resultRowLimit */
+  readonly resultRowsTruncated?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- cap table API result rows with ClickHouse settings instead of rewriting SQL
- preserve per-query ClickHouse settings and timezone handling
- expose the table result cap in response metadata

## Verification
- bun test lib/api/__tests__/table-query-settings.test.ts 'app/api/v1/tables/[name]/__tests__/route.test.ts'
- bun run test:unit
- bun run type-check
- bun run lint
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API response metadata for table queries now includes result row limits and overflow handling modes.

* **Improvements**
  * Table query requests now properly configure ClickHouse session settings, including timezone information from query parameters.

* **Tests**
  * Added comprehensive test coverage for table query API endpoint and settings configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->