### PR TITLE
feat(table): show capped result state

### DIFF
--- a/components/tables/table-client.cy.tsx
+++ b/components/tables/table-client.cy.tsx
@@ -55,6 +55,31 @@ describe('<TableClient />', () => {
     cy.contains(/2 row\(s\) in 0\.10s/).should('be.visible')
   })
 
+  it('shows capped result metadata when the API trims rows', () => {
+    mockTableResponse({
+      data: [
+        { name: 'users', database: 'default', engine: 'MergeTree', rows: 1000 },
+      ],
+      metadata: {
+        queryId: 'test-query-id',
+        duration: 0.1,
+        rows: 1000,
+        host: 'localhost',
+        resultRowLimit: 1000,
+        resultOverflowMode: 'break',
+        resultRowsBeforeCap: 1002,
+        resultRowsTruncated: true,
+      },
+    })
+
+    cy.mount(<TableClient title="Test Tables" queryConfig={mockQueryConfig} />)
+
+    cy.wait('@fetchTableData')
+    cy.contains('1,000 row(s) in 0.10s').should('be.visible')
+    cy.contains('Capped').should('be.visible')
+    cy.contains('1,002 before cap').should('be.visible')
+  })
+
   it('displays error alert on API error', () => {
     mockTableResponse(
       {

--- a/components/tables/table-client.tsx
+++ b/components/tables/table-client.tsx
@@ -2,12 +2,14 @@
 
 import { RefreshCw } from 'lucide-react'
 
+import type { ApiResponseMetadata } from '@/lib/api/types'
 import type { QueryConfig } from '@/types/query-config'
 
 import { memo } from 'react'
 import { CardToolbar } from '@/components/cards/card-toolbar'
 import { DataTable } from '@/components/data-table/data-table'
 import { TableSkeleton } from '@/components/skeletons'
+import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { EmptyState } from '@/components/ui/empty-state'
 import { SuggestionCard } from '@/components/ui/suggestion-card'
@@ -39,6 +41,33 @@ interface TableClientProps {
   filterableColumns?: string[]
   /** Enable row selection with checkboxes */
   enableRowSelection?: boolean
+}
+
+const tableRowFormatter = new Intl.NumberFormat('en-US')
+
+function TableResultFootnote({ metadata }: { metadata: ApiResponseMetadata }) {
+  const beforeCap =
+    typeof metadata.resultRowsBeforeCap === 'number'
+      ? tableRowFormatter.format(metadata.resultRowsBeforeCap)
+      : null
+  const duration =
+    typeof metadata.duration === 'number'
+      ? metadata.duration.toFixed(2)
+      : '0.00'
+
+  return (
+    <span className="inline-flex flex-wrap items-center gap-2">
+      <span>
+        {tableRowFormatter.format(metadata.rows)} row(s) in {duration}s
+      </span>
+      {metadata.resultRowsTruncated ? (
+        <>
+          <Badge variant="outline">Capped</Badge>
+          {beforeCap ? <span>{beforeCap} before cap</span> : null}
+        </>
+      ) : null}
+    </span>
+  )
 }
 
 /**
@@ -275,9 +304,7 @@ export const TableClient = memo(function TableClient({
       context={{ ...searchParams, hostId: String(hostId) }}
       defaultPageSize={defaultPageSize}
       footnote={
-        metadata
-          ? `${metadata.rows} row(s) in ${metadata.duration?.toFixed(2)}s`
-          : undefined
+        metadata ? <TableResultFootnote metadata={metadata} /> : undefined
       }
       className={className}
       topRightToolbarExtras={topRightToolbarExtras}


### PR DESCRIPTION
## Summary
- Show capped table result metadata in the table footer with a shadcn Badge
- Keep uncapped table footer text unchanged
- Add Cypress component coverage for capped metadata

## Verification
- bun run component:headless -- --spec components/tables/table-client.cy.tsx
- bun run type-check
- bun run lint
- bun run build
- bun run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced table result metadata display with formatted row counts, duration, and capped status indicators.

* **Tests**
  * Added test coverage for result row capping behavior and associated metadata rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->