### PR TITLE
fix(table): stack footer controls on small screens

### DIFF
--- a/components/data-table/components/data-table-footer.cy.tsx
+++ b/components/data-table/components/data-table-footer.cy.tsx
@@ -115,8 +115,8 @@ describe('<DataTableFooter />', () => {
     }))
     cy.mount(<TestDataTableFooter rows={largeData} pageSize={10} />)
 
-    // Check that both elements exist and are in the same container
-    cy.get('.flex.items-center.justify-between').should('be.visible')
+    // Check that both elements exist in the footer
+    cy.get('.flex.shrink-0').should('be.visible')
     cy.contains('0 of 25 row(s) selected').should('be.visible')
     cy.get('[aria-label="Pagination"]').should('be.visible')
   })
@@ -124,7 +124,7 @@ describe('<DataTableFooter />', () => {
   it('applies correct styling classes', () => {
     cy.mount(<TestDataTableFooter />)
 
-    cy.get('.flex.shrink-0.items-center.justify-between').should('be.visible')
+    cy.get('.flex.shrink-0.flex-col').should('be.visible')
   })
 
   it('displays correct page information', () => {
@@ -156,5 +156,33 @@ describe('<DataTableFooter />', () => {
     cy.mount(<TestDataTableFooter rows={largeData} pageSize={10} />)
 
     cy.get('button[aria-label="Go to previous page"]').should('be.disabled')
+  })
+
+  it('stacks footer controls on narrow screens without horizontal overflow', () => {
+    const largeData = Array.from({ length: 25 }, (_, i) => ({
+      col1: `val${i}`,
+      col2: `val${i}`,
+    }))
+
+    cy.viewport(320, 500)
+    cy.mount(
+      <div style={{ width: 305 }}>
+        <TestDataTableFooter rows={largeData} pageSize={10} />
+      </div>
+    )
+
+    cy.contains('0 of 25 row(s) selected').should('be.visible')
+    cy.get('[aria-label="Pagination"]')
+      .should('be.visible')
+      .and('have.class', 'w-full')
+    cy.contains('1/3').should('be.visible')
+    cy.get('.flex.shrink-0.flex-col').then(($footer) => {
+      const footer = $footer[0]
+      expect(footer.scrollWidth).to.be.at.most(footer.clientWidth)
+    })
+    cy.get('[aria-label="Pagination"]').then(($pagination) => {
+      const pagination = $pagination[0]
+      expect(pagination.scrollWidth).to.be.at.most(pagination.clientWidth)
+    })
   })
 })

--- a/components/data-table/components/data-table-footer.tsx
+++ b/components/data-table/components/data-table-footer.tsx
@@ -82,7 +82,7 @@ export const DataTableFooter = memo(function DataTableFooter<
   }
 
   return (
-    <div className="flex shrink-0 items-center justify-between px-2">
+    <div className="flex shrink-0 flex-col gap-2 px-2 py-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3 sm:py-0">
       <Footnote table={table} footnote={footnote} />
       <DataTablePagination table={table} />
     </div>

--- a/components/data-table/footnote.tsx
+++ b/components/data-table/footnote.tsx
@@ -13,7 +13,7 @@ export const Footnote = memo(function Footnote({
   footnote,
 }: FootnoteProps) {
   return (
-    <div className="text-muted-foreground flex-1 text-sm">
+    <div className="min-w-0 flex-1 text-wrap break-words text-sm text-muted-foreground">
       {footnote ? (
         footnote
       ) : (

--- a/components/data-table/pagination.tsx
+++ b/components/data-table/pagination.tsx
@@ -82,11 +82,11 @@ export function DataTablePagination({ table }: DataTablePaginationProps) {
     <div
       aria-label="Pagination"
       className={cn(
-        'flex w-full flex-col items-stretch gap-3 sm:w-auto sm:flex-row sm:items-center sm:gap-6 lg:gap-8',
+        'w-full flex-col items-center gap-3 sm:w-auto sm:flex-row sm:gap-6 lg:gap-8',
         table.getCanPreviousPage() || table.getCanNextPage() ? 'flex' : 'hidden'
       )}
     >
-      <div className="flex items-center justify-between gap-2 sm:justify-start">
+      <div className="flex items-center gap-2">
         <p className="hidden sm:block text-sm font-medium">Rows per page</p>
         <Select
           value={`${table.getState().pagination.pageSize}`}
@@ -106,7 +106,7 @@ export function DataTablePagination({ table }: DataTablePaginationProps) {
         </Select>
       </div>
       <PaginationInfo table={table} />
-      <div className="flex items-center justify-center gap-2">
+      <div className="flex items-center gap-2">
         <Button
           variant="outline"
           className="hidden size-10 sm:size-8 p-0 lg:flex"

--- a/components/data-table/pagination.tsx
+++ b/components/data-table/pagination.tsx
@@ -82,11 +82,11 @@ export function DataTablePagination({ table }: DataTablePaginationProps) {
     <div
       aria-label="Pagination"
       className={cn(
-        'flex flex-col sm:flex-row items-center gap-4 sm:gap-6 lg:gap-8',
+        'flex w-full flex-col items-stretch gap-3 sm:w-auto sm:flex-row sm:items-center sm:gap-6 lg:gap-8',
         table.getCanPreviousPage() || table.getCanNextPage() ? 'flex' : 'hidden'
       )}
     >
-      <div className="flex items-center space-x-2">
+      <div className="flex items-center justify-between gap-2 sm:justify-start">
         <p className="hidden sm:block text-sm font-medium">Rows per page</p>
         <Select
           value={`${table.getState().pagination.pageSize}`}
@@ -106,7 +106,7 @@ export function DataTablePagination({ table }: DataTablePaginationProps) {
         </Select>
       </div>
       <PaginationInfo table={table} />
-      <div className="flex items-center space-x-2">
+      <div className="flex items-center justify-center gap-2">
         <Button
           variant="outline"
           className="hidden size-10 sm:size-8 p-0 lg:flex"


### PR DESCRIPTION
## Summary
- Stack table footnotes and pagination on narrow screens
- Let footnote text wrap without forcing horizontal overflow
- Add a 320px component test for footer pagination layout

## Verification
- bun run component:headless -- --spec components/data-table/components/data-table-footer.cy.tsx
- bun run type-check
- bun run lint
- bun run build
- bun run test

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive layout for data table footer and pagination on mobile and narrow screens.
  * Enhanced text wrapping in footnotes for better readability.
  * Refined spacing and button alignment in pagination controls.

* **Tests**
  * Updated component tests to verify new responsive layout behavior, pagination stacking and page indicator on narrow screens.
  * Added checks to prevent horizontal overflow in footer and pagination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->