### PR TITLE
refactor(table): use button for clear filters

### DIFF
--- a/components/data-table/components/data-table-header.tsx
+++ b/components/data-table/components/data-table-header.tsx
@@ -16,6 +16,7 @@ import { DensityToggle } from '@/components/data-table/buttons/density-toggle'
 import { ResetColumnOrderButton } from '@/components/data-table/buttons/reset-column-order'
 import { BulkActions } from '@/components/data-table/components/bulk-actions'
 import { DataTableToolbar } from '@/components/data-table/data-table-toolbar'
+import { Button } from '@/components/ui/button'
 import { getSqlForDisplay } from '@/types/query-config'
 
 /**
@@ -123,14 +124,17 @@ export const DataTableHeader = memo(function DataTableHeader<
             />
           )}
           {enableColumnFilters && activeFilterCount > 0 && (
-            <button
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
               onClick={clearAllColumnFilters}
-              className="inline-flex items-center gap-1.5 rounded-md bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary hover:bg-primary/20 transition-colors"
+              className="h-7 gap-1.5 px-2.5"
               aria-label={`Clear ${activeFilterCount} active filter${activeFilterCount > 1 ? 's' : ''}`}
             >
-              <X className="h-3 w-3" />
+              <X data-icon="inline-start" />
               Clear {activeFilterCount} filter{activeFilterCount > 1 ? 's' : ''}
-            </button>
+            </Button>
           )}
         </div>
         <p className="text-muted-foreground truncate text-sm">


### PR DESCRIPTION
## Summary
- replace the custom active-filter clear control with the shadcn Button primitive
- keep the existing clear handler, accessible label, and filter-count text

## Verification
- bun run component:headless -- --spec components/data-table/components/data-table-header.cy.tsx
- bun run type-check
- bun run lint
- bun run build
- bun run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to data table component structure.

---

**Note:** This release contains no user-facing changes. Updates are technical improvements to code organization and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->