### PR TITLE
refactor(table): use button for column options

### DIFF
--- a/components/data-table/buttons/column-header-dropdown.cy.tsx
+++ b/components/data-table/buttons/column-header-dropdown.cy.tsx
@@ -1,0 +1,86 @@
+import type { Header } from '@tanstack/react-table'
+
+import { ColumnHeaderDropdown } from './column-header-dropdown'
+
+function createHeader({
+  id = 'query',
+  sorted = false,
+  toggleSorting = cy.stub(),
+  clearSorting = cy.stub(),
+}: {
+  id?: string
+  sorted?: false | 'asc' | 'desc'
+  toggleSorting?: Cypress.Agent<sinon.SinonStub>
+  clearSorting?: Cypress.Agent<sinon.SinonStub>
+} = {}) {
+  return {
+    column: {
+      id,
+      getCanSort: cy.stub().returns(true),
+      getIsSorted: cy.stub().returns(sorted),
+      toggleSorting,
+      clearSorting,
+    },
+  } as unknown as Header<any, unknown>
+}
+
+function mountDropdown(header = createHeader()) {
+  cy.mount(
+    <div className="group p-4">
+      <ColumnHeaderDropdown header={header} />
+    </div>
+  )
+}
+
+describe('<ColumnHeaderDropdown />', () => {
+  it('opens sort and copy actions from the column options button', () => {
+    mountDropdown()
+
+    cy.get('button[aria-label="Column options"]').click({ force: true })
+    cy.contains('[role="menuitem"]', /^A . Z$/).should('be.visible')
+    cy.contains('[role="menuitem"]', /^Z . A$/).should('be.visible')
+    cy.contains('[role="menuitem"]', 'Reset sort').should('be.visible')
+    cy.contains('[role="menuitem"]', 'Copy name').should('be.visible')
+  })
+
+  it('runs ascending sort from the menu', () => {
+    const toggleSorting = cy.stub().as('toggleSorting')
+
+    mountDropdown(createHeader({ toggleSorting }))
+
+    cy.get('button[aria-label="Column options"]').click({ force: true })
+    cy.contains('[role="menuitem"]', /^A . Z$/).click()
+
+    cy.get('@toggleSorting').should('have.been.calledWith', false)
+  })
+
+  it('resets sorting without closing the menu', () => {
+    const clearSorting = cy.stub().as('clearSorting')
+
+    mountDropdown(createHeader({ clearSorting }))
+
+    cy.get('button[aria-label="Column options"]').click({ force: true })
+    cy.contains('[role="menuitem"]', 'Reset sort').click()
+
+    cy.get('@clearSorting').should('have.been.calledOnce')
+    cy.contains('[role="menuitem"]', 'Reset sort').should('be.visible')
+  })
+
+  it('copies the column id', () => {
+    const writeText = cy.stub().as('writeText')
+
+    cy.window().then((win) => {
+      Object.defineProperty(win.navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      })
+    })
+    mountDropdown(createHeader({ id: 'query_id' }))
+
+    cy.get('button[aria-label="Column options"]').click({ force: true })
+    cy.contains('[role="menuitem"]', 'Copy name').click()
+
+    cy.get('@writeText').should('have.been.calledWith', 'query_id')
+    cy.contains('[role="menuitem"]', 'Copied!').should('be.visible')
+  })
+})

--- a/components/data-table/buttons/column-header-dropdown.cy.tsx
+++ b/components/data-table/buttons/column-header-dropdown.cy.tsx
@@ -1,6 +1,6 @@
 import type { Header } from '@tanstack/react-table'
 
-import { ColumnHeaderDropdown } from './column-header-dropdown'
+import { ColumnHeaderDropdown } from '@/components/data-table/buttons/column-header-dropdown'
 
 function createHeader({
   id = 'query',
@@ -36,7 +36,12 @@ describe('<ColumnHeaderDropdown />', () => {
   it('opens sort and copy actions from the column options button', () => {
     mountDropdown()
 
-    cy.get('button[aria-label="Column options"]').click({ force: true })
+    cy.get('button[aria-label="Column options"]').as('trigger').click({
+      force: true,
+    })
+    cy.get('@trigger')
+      .should('have.attr', 'data-state', 'open')
+      .and('have.css', 'opacity', '1')
     cy.contains('[role="menuitem"]', /^A . Z$/).should('be.visible')
     cy.contains('[role="menuitem"]', /^Z . A$/).should('be.visible')
     cy.contains('[role="menuitem"]', 'Reset sort').should('be.visible')

--- a/components/data-table/buttons/column-header-dropdown.tsx
+++ b/components/data-table/buttons/column-header-dropdown.tsx
@@ -2,6 +2,7 @@
 
 import {
   CopyIcon,
+  EllipsisVerticalIcon,
   RotateCcwIcon,
   SortAscIcon,
   SortDescIcon,
@@ -9,6 +10,7 @@ import {
 import type { Header } from '@tanstack/react-table'
 
 import { memo, useCallback, useState } from 'react'
+import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -74,28 +76,20 @@ export const ColumnHeaderDropdown = memo(function ColumnHeaderDropdown({
   return (
     <DropdownMenu open={open} onOpenChange={setOpen} modal={false}>
       <DropdownMenuTrigger asChild>
-        <button
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
           className={cn(
-            'flex items-center justify-center rounded',
-            'w-10 h-10 sm:w-auto sm:h-auto sm:p-0 p-2',
+            'size-10 p-2 sm:h-auto sm:w-auto sm:p-0',
             'opacity-0 group-hover:opacity-40 hover:opacity-100 focus:opacity-100',
-            'focus:outline-none transition-opacity',
+            'transition-opacity',
             'disabled:cursor-default disabled:opacity-50'
           )}
           aria-label="Column options"
         >
-          <svg
-            className="h-3.5 w-3.5"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <circle cx="12" cy="12" r="1" />
-            <circle cx="12" cy="5" r="1" />
-            <circle cx="12" cy="19" r="1" />
-          </svg>
-        </button>
+          <EllipsisVerticalIcon data-icon="inline-start" />
+        </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-40" sticky="always">
         {canSort && (

--- a/components/data-table/buttons/column-header-dropdown.tsx
+++ b/components/data-table/buttons/column-header-dropdown.tsx
@@ -79,12 +79,11 @@ export const ColumnHeaderDropdown = memo(function ColumnHeaderDropdown({
         <Button
           type="button"
           variant="ghost"
-          size="icon"
+          size="icon-sm"
           className={cn(
-            'size-10 p-2 sm:h-auto sm:w-auto sm:p-0',
-            'opacity-0 group-hover:opacity-40 hover:opacity-100 focus:opacity-100',
-            'transition-opacity',
-            'disabled:cursor-default disabled:opacity-50'
+            'size-10 sm:size-7',
+            'opacity-0 group-hover:opacity-40 hover:opacity-100 focus:opacity-100 data-[state=open]:opacity-100',
+            'transition'
           )}
           aria-label="Column options"
         >


### PR DESCRIPTION
## Summary
- replace the custom column options trigger with the shared shadcn Button and lucide icon
- add focused component coverage for opening, sorting, reset, and copy actions

## Verification
- bun run component:headless -- --spec components/data-table/buttons/column-header-dropdown.cy.tsx
- bun run type-check
- bun run lint
- bun run build
- bun run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added component tests covering column header dropdown: sort ascending/descending, reset sort behavior, and copy-column-name with "Copied!" confirmation.

* **Refactor**
  * Unified dropdown trigger to use the shared button/icon UI for improved consistency and styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->