### PR TITLE
refactor(table): use button for expandable cells

### DIFF
--- a/components/data-table/components/expandable-cell.cy.tsx
+++ b/components/data-table/components/expandable-cell.cy.tsx
@@ -1,0 +1,39 @@
+import { ExpandableCell } from '@/components/data-table/components/expandable-cell'
+
+describe('<ExpandableCell />', () => {
+  it('renders short values as plain truncated text', () => {
+    cy.mount(<ExpandableCell value="short query" maxLength={20} />)
+
+    cy.contains('short query').should('be.visible')
+    cy.get('button').should('not.exist')
+  })
+
+  it('opens the full value for long text', () => {
+    const value =
+      'SELECT * FROM system.query_log WHERE query_duration_ms > 1000'
+
+    cy.mount(<ExpandableCell value={value} maxLength={12} />)
+
+    cy.get('button[title="Click to expand"]')
+      .should('have.class', 'truncate')
+      .click()
+
+    cy.contains('pre', value).should('be.visible')
+  })
+
+  it('does not trigger a parent row click when opened', () => {
+    const onRowClick = cy.stub().as('onRowClick')
+    const value = 'A long ClickHouse exception message that should open inline'
+
+    cy.mount(
+      <div onClick={onRowClick}>
+        <ExpandableCell value={value} maxLength={10} />
+      </div>
+    )
+
+    cy.get('button[title="Click to expand"]').click()
+
+    cy.get('@onRowClick').should('not.have.been.called')
+    cy.contains('pre', value).should('be.visible')
+  })
+})

--- a/components/data-table/components/expandable-cell.tsx
+++ b/components/data-table/components/expandable-cell.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { Button } from '@/components/ui/button'
 import {
   Popover,
   PopoverContent,
@@ -39,22 +40,24 @@ export function ExpandableCell({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <button
+        <Button
+          type="button"
+          variant="link"
           className={cn(
-            'max-w-xs truncate cursor-pointer text-left underline decoration-dotted decoration-muted-foreground/40 underline-offset-2 hover:decoration-muted-foreground/80 transition-colors',
+            'block h-auto max-w-xs truncate p-0 text-left font-normal text-foreground',
+            'underline decoration-dotted decoration-muted-foreground/40 underline-offset-2 hover:decoration-muted-foreground/80',
             className
           )}
           title="Click to expand"
           onClick={(e) => {
             e.stopPropagation()
-            setOpen(true)
           }}
         >
           {stringValue.slice(0, maxLength)}…
-        </button>
+        </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-96 max-h-64 overflow-y-auto p-3"
+        className="max-h-64 w-[calc(100vw-2rem)] overflow-y-auto p-3 sm:w-96"
         align="start"
         side="bottom"
         onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## Summary
- replace the expandable long-text trigger with the shared shadcn Button while preserving the inline truncated look
- keep row-click propagation blocked when opening expanded text
- make the expanded popover width fit narrow viewports while preserving the desktop width

## Verification
- bun run component:headless -- --spec components/data-table/components/expandable-cell.cy.tsx
- bun run type-check
- bun run lint
- bun run build
- bun run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive component tests for expandable cell functionality, including validation of expansion behavior and click event handling.

* **Bug Fixes**
  * Fixed click propagation issue preventing accidental triggering of parent element handlers during cell expansion.

* **Style**
  * Enhanced popover responsiveness with improved sizing for mobile and desktop displays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->