### PR TITLE
refactor(table): use button for drag handles

### DIFF
--- a/components/data-table/components/data-table-content.cy.tsx
+++ b/components/data-table/components/data-table-content.cy.tsx
@@ -57,12 +57,16 @@ describe('<DataTableContent />', () => {
     isVirtualized = defaultProps.isVirtualized,
     description = defaultProps.description,
     queryConfig: config = defaultProps.queryConfig,
+    enableColumnReordering = defaultProps.enableColumnReordering,
+    onColumnOrderChange,
   }: {
     rows?: Row[]
     activeFilterCount?: number
     isVirtualized?: boolean
     description?: string
     queryConfig?: QueryConfig
+    enableColumnReordering?: boolean
+    onColumnOrderChange?: (activeId: string, overId: string) => void
   }) {
     const table = useReactTable({
       data: rows,
@@ -75,7 +79,9 @@ describe('<DataTableContent />', () => {
         {...defaultProps}
         activeFilterCount={activeFilterCount}
         description={description}
+        enableColumnReordering={enableColumnReordering}
         isVirtualized={isVirtualized}
+        onColumnOrderChange={onColumnOrderChange}
         queryConfig={config}
         table={table}
       />
@@ -184,5 +190,34 @@ describe('<DataTableContent />', () => {
     )
 
     cy.get('#table-description').should('contain', 'Test Table data table')
+  })
+
+  it('renders column reorder handles as shared icon buttons when enabled', () => {
+    cy.mount(<TestDataTableContent enableColumnReordering={true} />)
+
+    cy.get('button[aria-label="Drag to reorder col1 column"]')
+      .should('have.attr', 'type', 'button')
+      .and('have.class', 'size-10')
+      .and('have.class', 'sm:size-7')
+      .find('[data-icon]')
+      .should('exist')
+    cy.get('button[aria-label="Drag to reorder col2 column"]').should('exist')
+  })
+
+  it('does not reorder columns on a plain drag-handle click', () => {
+    const onColumnOrderChange = cy.stub().as('onColumnOrderChange')
+
+    cy.mount(
+      <TestDataTableContent
+        enableColumnReordering={true}
+        onColumnOrderChange={onColumnOrderChange}
+      />
+    )
+
+    cy.get('button[aria-label="Drag to reorder col1 column"]').click({
+      force: true,
+    })
+
+    cy.get('@onColumnOrderChange').should('not.have.been.called')
   })
 })

--- a/components/data-table/renderers/table-header.tsx
+++ b/components/data-table/renderers/table-header.tsx
@@ -7,6 +7,7 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { memo } from 'react'
 import { ColumnHeaderDropdown } from '@/components/data-table/buttons/column-header-dropdown'
+import { Button } from '@/components/ui/button'
 import { TableHead, TableRow } from '@/components/ui/table'
 import { cn } from '@/lib/utils'
 
@@ -133,14 +134,17 @@ function DraggableTableHeader({
     >
       <div className="group flex items-center">
         {/* Drag handle for column reordering - hidden by default, shown on hover */}
-        <button
+        <Button
           {...attributes}
           {...listeners}
+          type="button"
+          variant="ghost"
+          size="icon-sm"
           className={cn(
-            'mr-1.5 cursor-grab active:cursor-grabbing text-muted-foreground opacity-0',
-            'group-hover:opacity-40 hover:opacity-100 focus:opacity-100',
-            'focus:outline-none',
-            'transition-opacity',
+            'mr-1.5 size-10 cursor-grab text-muted-foreground opacity-0 sm:size-7',
+            'active:cursor-grabbing',
+            'group-hover:opacity-40 hover:opacity-100 focus:opacity-100 focus-visible:opacity-100',
+            'transition',
             'disabled:cursor-default disabled:opacity-50'
           )}
           aria-label={`Drag to reorder ${header.column.id} column`}
@@ -148,8 +152,8 @@ function DraggableTableHeader({
           style={{ touchAction: 'none' }}
           onClick={(e) => e.stopPropagation()} // Prevent drag from triggering sort
         >
-          <GripVertical className="h-3.5 w-3.5" />
-        </button>
+          <GripVertical data-icon className="h-3.5 w-3.5" />
+        </Button>
         <div className="flex-1">
           <div className="group flex items-center gap-1">
             <span className="flex-1">


### PR DESCRIPTION
## Summary
- replace the table column reorder drag handle with the shared Button component
- keep dnd-kit attributes, touch-action behavior, and click isolation intact
- add component coverage for reorder handle rendering and plain-click behavior

## Verification
- bun run component:headless -- --spec components/data-table/components/data-table-content.cy.tsx
- bun run type-check
- bun run lint
- bun run build
- bun run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for column reordering functionality, including drag handle interactions.

* **Improvements**
  * Enhanced visual consistency of the column reorder drag handle in the data table.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->