### PR TITLE
fix: resolve correctness bugs from repository bug scan

### DIFF
--- a/app/api/v1/conversations/route.ts
+++ b/app/api/v1/conversations/route.ts
@@ -75,9 +75,10 @@ export async function GET(request: Request): Promise<Response> {
     const url = new URL(request.url)
     const limitParam = url.searchParams.get('limit')
     const parsedLimit = limitParam ? Number(limitParam) : DEFAULT_LIMIT
+    const normalizedLimit = Math.floor(parsedLimit)
     const limit =
-      Number.isFinite(parsedLimit) && parsedLimit > 0
-        ? Math.min(Math.floor(parsedLimit), 100)
+      Number.isFinite(parsedLimit) && normalizedLimit > 0
+        ? Math.min(normalizedLimit, 100)
         : DEFAULT_LIMIT
 
     // Resolve store and fetch conversations

--- a/app/api/v1/conversations/route.ts
+++ b/app/api/v1/conversations/route.ts
@@ -71,10 +71,14 @@ export async function GET(request: Request): Promise<Response> {
     const userId = await resolveUserId()
     debug('[GET /api/v1/conversations] User resolved', { userId, requestId })
 
-    // Get limit from query params
+    // Get limit from query params (reject non-numeric/negative values)
     const url = new URL(request.url)
     const limitParam = url.searchParams.get('limit')
-    const limit = limitParam ? Math.min(Number(limitParam), 100) : DEFAULT_LIMIT
+    const parsedLimit = limitParam ? Number(limitParam) : DEFAULT_LIMIT
+    const limit =
+      Number.isFinite(parsedLimit) && parsedLimit > 0
+        ? Math.min(Math.floor(parsedLimit), 100)
+        : DEFAULT_LIMIT
 
     // Resolve store and fetch conversations
     const store = await resolveStore()

--- a/app/api/v1/host-status/__tests__/route.test.ts
+++ b/app/api/v1/host-status/__tests__/route.test.ts
@@ -1,0 +1,65 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+const mockFetchData = mock(() =>
+  Promise.resolve({
+    data: [{ version: '25.1.1.1', uptime: '1 day', hostname: 'ch-host-1' }],
+    metadata: {},
+  })
+)
+
+mock.module('@/lib/clickhouse', () => ({
+  fetchData: mockFetchData,
+}))
+
+let GET: (request: Request) => Promise<Response>
+
+beforeAll(async () => {
+  const route = await import('../route')
+  GET = route.GET
+})
+
+beforeEach(() => {
+  mockFetchData.mockClear()
+  mockFetchData.mockResolvedValue({
+    data: [{ version: '25.1.1.1', uptime: '1 day', hostname: 'ch-host-1' }],
+    metadata: {},
+  } as never)
+})
+
+describe('GET /api/v1/host-status', () => {
+  test('returns host status on a successful query', async () => {
+    const response = await GET(
+      new Request('http://localhost:3000/api/v1/host-status?hostId=0')
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data.version).toBe('25.1.1.1')
+    expect(body.data.hostname).toBe('ch-host-1')
+  })
+
+  test('returns an upstream error status when the query fails', async () => {
+    mockFetchData.mockResolvedValue({
+      error: { type: 'network_error', message: 'Connection refused' },
+    } as never)
+
+    const response = await GET(
+      new Request('http://localhost:3000/api/v1/host-status?hostId=0')
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(502)
+    expect(body.success).toBe(false)
+    expect(body.error).toContain('Connection refused')
+  })
+
+  test('rejects a missing hostId with a validation error', async () => {
+    const response = await GET(
+      new Request('http://localhost:3000/api/v1/host-status')
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockFetchData).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/host-status/route.ts
+++ b/app/api/v1/host-status/route.ts
@@ -47,6 +47,17 @@ export async function GET(request: Request) {
 
     debug('[host-status] FetchData result:', result)
 
+    if (result.error) {
+      console.error('Host status API error:', result.error)
+      return NextResponse.json(
+        {
+          success: false,
+          error: result.error.message || 'Failed to fetch host status',
+        },
+        { status: 502 }
+      )
+    }
+
     const data = result.data?.[0]
     const version = data?.version ?? ''
     const uptime = data?.uptime ?? ''

--- a/components/data-table/cells/colored-badge-format.tsx
+++ b/components/data-table/cells/colored-badge-format.tsx
@@ -16,7 +16,7 @@ export const ColoredBadgeFormat = memo(function ColoredBadgeFormat({
 }: ColoredBadgeFormatProps): React.ReactNode {
   // Memoize expensive color calculation - includes dark mode variants
   const pickedColor = useMemo(() => {
-    if (value == null || value === '') return ''
+    if (value == null || value === '' || typeof value === 'boolean') return ''
 
     const colors = [
       'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
@@ -38,7 +38,7 @@ export const ColoredBadgeFormat = memo(function ColoredBadgeFormat({
     ]
   }, [value])
 
-  if (value == null || value === '') {
+  if (value == null || value === '' || typeof value === 'boolean') {
     return null
   }
 

--- a/components/data-table/cells/colored-badge-format.tsx
+++ b/components/data-table/cells/colored-badge-format.tsx
@@ -16,7 +16,7 @@ export const ColoredBadgeFormat = memo(function ColoredBadgeFormat({
 }: ColoredBadgeFormatProps): React.ReactNode {
   // Memoize expensive color calculation - includes dark mode variants
   const pickedColor = useMemo(() => {
-    if (!value || value === '') return ''
+    if (value == null || value === '') return ''
 
     const colors = [
       'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
@@ -38,7 +38,7 @@ export const ColoredBadgeFormat = memo(function ColoredBadgeFormat({
     ]
   }, [value])
 
-  if (!value || value === '') {
+  if (value == null || value === '') {
     return null
   }
 

--- a/lib/clickhouse/clickhouse-fetch.ts
+++ b/lib/clickhouse/clickhouse-fetch.ts
@@ -288,10 +288,10 @@ export const fetchData = async <
       httpStatusCode = parseInt(statusMatch[1], 10)
     }
 
-    // SSL/TLS errors (Cloudflare 525, 526, etc.)
+    // SSL/TLS errors (Cloudflare 525/526 as standalone status codes, not
+    // digits embedded in larger numbers like "525.00 MiB" or "15251")
     if (
-      errorMessage.includes('525') ||
-      errorMessage.includes('526') ||
+      /(?<![\d.])52[56](?![\d.])/.test(errorMessage) ||
       errorMessage.toLowerCase().includes('ssl') ||
       errorMessage.toLowerCase().includes('tls') ||
       errorMessage.toLowerCase().includes('certificate') ||
@@ -552,10 +552,10 @@ export const fetchJsonEachRowAsNormalizedJson = async ({
       httpStatusCode = parseInt(statusMatch[1], 10)
     }
 
-    // SSL/TLS errors (Cloudflare 525, 526, etc.)
+    // SSL/TLS errors (Cloudflare 525/526 as standalone status codes, not
+    // digits embedded in larger numbers like "525.00 MiB" or "15251")
     if (
-      errorMessage.includes('525') ||
-      errorMessage.includes('526') ||
+      /(?<![\d.])52[56](?![\d.])/.test(errorMessage) ||
       errorMessage.toLowerCase().includes('ssl') ||
       errorMessage.toLowerCase().includes('tls') ||
       errorMessage.toLowerCase().includes('certificate') ||

--- a/lib/clickhouse/clickhouse-fetch.ts
+++ b/lib/clickhouse/clickhouse-fetch.ts
@@ -291,7 +291,7 @@ export const fetchData = async <
     // SSL/TLS errors (Cloudflare 525/526 as standalone status codes, not
     // digits embedded in larger numbers like "525.00 MiB" or "15251")
     if (
-      /(?<![\d.])52[56](?![\d.])/.test(errorMessage) ||
+      /(?<![\d.])52[56](?!\d)(?!\.\d)/.test(errorMessage) ||
       errorMessage.toLowerCase().includes('ssl') ||
       errorMessage.toLowerCase().includes('tls') ||
       errorMessage.toLowerCase().includes('certificate') ||
@@ -555,7 +555,7 @@ export const fetchJsonEachRowAsNormalizedJson = async ({
     // SSL/TLS errors (Cloudflare 525/526 as standalone status codes, not
     // digits embedded in larger numbers like "525.00 MiB" or "15251")
     if (
-      /(?<![\d.])52[56](?![\d.])/.test(errorMessage) ||
+      /(?<![\d.])52[56](?!\d)(?!\.\d)/.test(errorMessage) ||
       errorMessage.toLowerCase().includes('ssl') ||
       errorMessage.toLowerCase().includes('tls') ||
       errorMessage.toLowerCase().includes('certificate') ||

--- a/lib/format-readable.test.ts
+++ b/lib/format-readable.test.ts
@@ -41,6 +41,11 @@ describe('formatReadableSize', () => {
     const result = formatReadableSize(1.5e15)
     expect(result).toBe('1.3 PiB')
   })
+
+  it('should format negative sizes with a sign instead of NaN', () => {
+    expect(formatReadableSize(-1024)).toBe('-1 KiB')
+    expect(formatReadableSize(-512)).toBe('-512 Bytes')
+  })
 })
 
 describe('formatReadableQuantity', () => {

--- a/lib/format-readable.ts
+++ b/lib/format-readable.ts
@@ -18,7 +18,10 @@ export function formatReadableSize(bytes: number, decimals = 1) {
 
   const sign = bytes < 0 ? '-' : ''
   const abs = Math.abs(bytes)
-  const i = Math.min(Math.floor(Math.log(abs) / Math.log(k)), sizes.length - 1)
+  const i = Math.max(
+    0,
+    Math.min(Math.floor(Math.log(abs) / Math.log(k)), sizes.length - 1)
+  )
 
   return `${sign}${parseFloat((abs / k ** i).toFixed(dm))} ${sizes[i]}`
 }

--- a/lib/format-readable.ts
+++ b/lib/format-readable.ts
@@ -16,9 +16,11 @@ export function formatReadableSize(bytes: number, decimals = 1) {
     'YiB',
   ]
 
-  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  const sign = bytes < 0 ? '-' : ''
+  const abs = Math.abs(bytes)
+  const i = Math.min(Math.floor(Math.log(abs) / Math.log(k)), sizes.length - 1)
 
-  return `${parseFloat((bytes / k ** i).toFixed(dm))} ${sizes[i]}`
+  return `${sign}${parseFloat((abs / k ** i).toFixed(dm))} ${sizes[i]}`
 }
 
 /**

--- a/lib/query-config/anomaly/anomaly-queries.ts
+++ b/lib/query-config/anomaly/anomaly-queries.ts
@@ -235,7 +235,7 @@ export const diskUsageChangeConfig: QueryConfig = {
   description: 'Disk usage changes over time',
   sql: `
     SELECT
-      toUnixTimestamp(event_time) * 1000 as timestamp,
+      toUnixTimestamp(modification_time) * 1000 as timestamp,
       disk_name,
       database,
       table,
@@ -244,9 +244,9 @@ export const diskUsageChangeConfig: QueryConfig = {
       sum(rows) as total_rows
     FROM system.parts
     WHERE active
-      AND event_time >= now() - INTERVAL {baseline_hours: UInt32} HOUR
-    GROUP BY disk_name, database, table, event_time
-    ORDER BY event_time ASC, total_bytes DESC
+      AND modification_time >= now() - INTERVAL {baseline_hours: UInt32} HOUR
+    GROUP BY disk_name, database, table, modification_time
+    ORDER BY modification_time ASC, total_bytes DESC
   `,
   columns: [
     'timestamp',


### PR DESCRIPTION
## Summary

A repository-wide correctness scan (data layer, API routes, React components, agents/query-config) surfaced several real bugs. This PR fixes the six high-confidence, low-risk ones and adds regression tests.

| Fix | File |
|-----|------|
| `host-status` returned **HTTP 200 `{success:true}` with blank data** when ClickHouse errored (`fetchData` returns an error object, it doesn't throw, so the `try/catch` never caught it). Now returns **502** on upstream failure. | `app/api/v1/host-status/route.ts` |
| `diskUsageChangeConfig` queried `event_time` on `system.parts` — that column does not exist (it is `modification_time`), so the query always failed with `UNKNOWN_IDENTIFIER`. | `lib/query-config/anomaly/anomaly-queries.ts` |
| `formatReadableSize` returned the string `"NaN undefined"` for negative input (`Math.log` of a negative is `NaN`). Now returns a signed value (e.g. `-1 KiB`), consistent with `formatReadableQuantity`. | `lib/format-readable.ts` |
| SSL error detection used `errorMessage.includes('525')` / `'526'`, matching those digits anywhere — a normal error like `"525.00 MiB"` was misclassified as an SSL handshake error. Now matched as standalone status codes. | `lib/clickhouse/clickhouse-fetch.ts` |
| `conversations` API accepted `limit=abc` (→ `NaN` reaching the store) and `limit=-1` (→ unbounded, bypassing the 100 cap). Now validated to a positive integer. | `app/api/v1/conversations/route.ts` |
| `colored-badge` cells used `if (!value)`, so a numeric `0` rendered as a blank cell. Now only `null`/`undefined`/`''` are treated as empty. | `components/data-table/cells/colored-badge-format.tsx` |

### Tests
- New `app/api/v1/host-status/__tests__/route.test.ts` — covers success, upstream-error → 502, and missing-`hostId` → 400.
- New negative-input case in `lib/format-readable.test.ts`.

## Not included (reported, deferred)

The scan also found items that need a design decision or broader changes — left for follow-up:
- `replicationLagBaselineConfig` queries `event_time`/`replication_lag` on `system.replication_queue`; neither exists and that table is a snapshot, so a "24h baseline" can't be salvaged by a rename — needs redesign or removal.
- Non-numeric `hostId` returns HTTP 500 instead of 400 on `charts`/`tables`/`explorer` routes (no early validation).
- `menu-counts`/`cluster-counts` hard-code 500, ignoring `network`/`timeout`/`table_not_found` error types.
- `useAutoFitColumns` measurement cache is unbounded; `useColumnVisibility` ignores later `configuredColumns` changes.

A false positive was also ruled out: `formatReadableSecondDuration` clamping negative values to `0s` is intentional and covered by an existing test.

## Test plan
- [x] `bun run type-check` passes
- [x] `bun run test` — 1,449 tests pass (1,446 existing + 3 new)
- [x] `bun run build` succeeds

Co-Authored-By: duyetbot <bot@duyet.net>

https://claude.ai/code/session_01Tg51YeHMBu3SKNCQoHzk4b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tg51YeHMBu3SKNCQoHzk4b)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and reporting for system status queries, now correctly returns error status when data fetches fail.
  * Fixed formatting of negative byte sizes—previously displayed as NaN, now shows correct values.
  * Enhanced SSL/TLS error detection accuracy to avoid false matches.

* **Improvements**
  * Strengthened API request validation for conversation list pagination parameters.
  * Refined badge display handling for empty or null values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->