### PR TITLE
fix(running-queries): improve mobile query UI

### DIFF
--- a/components/data-table/cells/code-dialog-format.cy.tsx
+++ b/components/data-table/cells/code-dialog-format.cy.tsx
@@ -61,6 +61,43 @@ describe('<CodeDialogFormat />', () => {
     const options = { hide_query_comment: true, max_truncate: 100 }
     cy.mount(<CodeDialogFormat value={codeWithComment} options={options} />)
     cy.get('code').should('not.contain', '/* This is a comment */')
+    cy.get('code').should('have.text', 'SELECT * FROM table')
+  })
+
+  it('keeps running-query dialog content inside the viewport', () => {
+    cy.viewport(390, 844)
+    const longQuery = `/* clickhouse-monitor */ SELECT ${'very_long_identifier_'.repeat(
+      20
+    )} FROM system.processes WHERE query_id = 'abc'`
+
+    cy.mount(
+      <CodeDialogFormat
+        value={longQuery}
+        options={{
+          dialog_title: 'Running Query',
+          hide_query_comment: true,
+          max_truncate: 20,
+          trigger_classname: '-ml-1 w-full min-w-0 sm:-ml-2',
+        }}
+      />
+    )
+
+    cy.get('code.truncated')
+      .invoke('text')
+      .should('match', /^SELECT/)
+      .and('not.contain', 'clickhouse-monitor')
+    cy.get('code.truncated').parent().click()
+
+    cy.get('div[role="dialog"]')
+      .should('be.visible')
+      .then(($dialog) => {
+        const rect = $dialog[0].getBoundingClientRect()
+        expect(rect.width).to.be.lte(390)
+        expect(rect.height).to.be.lte(844)
+      })
+    cy.get('div[role="dialog"] code')
+      .should('contain.text', 'SELECT')
+      .and('not.contain.text', 'clickhouse-monitor')
   })
 
   it('escapes HTML-like code in the dialog body', () => {

--- a/components/data-table/cells/code-dialog-format.tsx
+++ b/components/data-table/cells/code-dialog-format.tsx
@@ -112,6 +112,16 @@ function formatSQL(sql: string): string {
   }
 }
 
+function prepareDialogContent(
+  value: string,
+  hideQueryComment?: boolean
+): string {
+  const withoutComment = hideQueryComment
+    ? value.replace(/\/\*[\s\S]*?\*\//g, '')
+    : value
+  return dedent(withoutComment).trim()
+}
+
 function ExplorerLink({ query }: { query: string }) {
   const hostId = useHostId()
   const href = buildExplorerQueryUrl(query, hostId)
@@ -174,11 +184,11 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
   const content = useMemo(() => {
     if (!open) return ''
 
-    let result = value
+    let result = prepareDialogContent(value, options?.hide_query_comment)
 
     if (language === 'json') {
       try {
-        const json = JSON.parse(value)
+        const json = JSON.parse(result)
         result = JSON.stringify(json, null, 2)
       } catch {}
       return result
@@ -189,7 +199,7 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
     }
 
     return result
-  }, [open, value, isBeautified, language])
+  }, [open, value, options?.hide_query_comment, isBeautified, language])
   const lineCount = contentLineCount(content)
 
   const highlightedHtml = useMemo(() => {
@@ -275,7 +285,7 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
       </DialogTrigger>
       <DialogContent
         className={cn(
-          'w-[min(95vw,1100px)] min-w-0 max-w-none p-4 sm:p-6',
+          'flex max-h-[min(92dvh,900px)] w-[min(95vw,1100px)] min-w-0 max-w-none flex-col overflow-hidden p-4 sm:p-6',
           options?.dialog_classname
         )}
       >
@@ -331,10 +341,10 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="relative group/code">
-          <ScrollArea className="h-[min(70vh,720px)] rounded-md border bg-muted/40">
+        <div className="relative min-h-0 flex flex-1 flex-col group/code">
+          <ScrollArea className="min-h-0 flex-1 rounded-md border bg-muted/40">
             <div
-              className="[&_code]:break-words [&_pre]:whitespace-pre-wrap [&_.hljs-keyword]:text-purple-600 [&_.hljs-string]:text-green-700 [&_.hljs-number]:text-blue-600 [&_.hljs-comment]:text-gray-500 [&_.hljs-built_in]:text-cyan-700 [&_.hljs-title]:text-blue-700 [&_.hljs-attr]:text-orange-600 [&_.hljs-literal]:text-blue-600 dark:[&_.hljs-keyword]:text-purple-400 dark:[&_.hljs-string]:text-green-400 dark:[&_.hljs-number]:text-blue-400 dark:[&_.hljs-comment]:text-gray-400 dark:[&_.hljs-built_in]:text-cyan-400 dark:[&_.hljs-title]:text-blue-400 dark:[&_.hljs-attr]:text-orange-400 dark:[&_.hljs-literal]:text-blue-400"
+              className="[&_code]:break-words [&_pre]:m-0 [&_pre]:max-w-full [&_pre]:whitespace-pre-wrap [&_.hljs-keyword]:text-purple-600 [&_.hljs-string]:text-green-700 [&_.hljs-number]:text-blue-600 [&_.hljs-comment]:text-gray-500 [&_.hljs-built_in]:text-cyan-700 [&_.hljs-title]:text-blue-700 [&_.hljs-attr]:text-orange-600 [&_.hljs-literal]:text-blue-600 dark:[&_.hljs-keyword]:text-purple-400 dark:[&_.hljs-string]:text-green-400 dark:[&_.hljs-number]:text-blue-400 dark:[&_.hljs-comment]:text-gray-400 dark:[&_.hljs-built_in]:text-cyan-400 dark:[&_.hljs-title]:text-blue-400 dark:[&_.hljs-attr]:text-orange-400 dark:[&_.hljs-literal]:text-blue-400"
               dangerouslySetInnerHTML={{ __html: highlightedHtml }}
             />
           </ScrollArea>

--- a/components/navigation/nav-main.cy.tsx
+++ b/components/navigation/nav-main.cy.tsx
@@ -5,7 +5,12 @@ import {
   PathnameContext,
   SearchParamsContext,
 } from 'next/dist/shared/lib/hooks-client-context.shared-runtime'
-import { SidebarProvider } from '@/components/ui/sidebar'
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarProvider,
+  SidebarTrigger,
+} from '@/components/ui/sidebar'
 import { HostProvider } from '@/lib/swr/host-context'
 
 describe('<NavMain />', () => {
@@ -30,6 +35,35 @@ describe('<NavMain />', () => {
         </SearchParamsContext.Provider>
       </PathnameContext.Provider>
     )
+
+  const mountMobileSidebar = (
+    items: MenuItem[],
+    {
+      pathname = '/',
+      searchParams = new URLSearchParams('host=0'),
+    }: {
+      pathname?: string
+      searchParams?: URLSearchParams
+    } = {}
+  ) => {
+    cy.viewport('iphone-x')
+    cy.mount(
+      <PathnameContext.Provider value={pathname}>
+        <SearchParamsContext.Provider value={searchParams}>
+          <HostProvider hostId={Number(searchParams.get('host') ?? 0)}>
+            <SidebarProvider defaultOpen={true}>
+              <SidebarTrigger />
+              <Sidebar collapsible="icon" variant="inset">
+                <SidebarContent>
+                  <NavMain items={items} />
+                </SidebarContent>
+              </Sidebar>
+            </SidebarProvider>
+          </HostProvider>
+        </SearchParamsContext.Provider>
+      </PathnameContext.Provider>
+    )
+  }
 
   const singleItems: MenuItem[] = [
     {
@@ -271,6 +305,28 @@ describe('<NavMain />', () => {
 
       cy.get('[data-sidebar="menu"]').should('be.visible')
       cy.contains('Overview').should('be.visible')
+    })
+
+    it('closes the mobile sidebar after selecting a top-level item', () => {
+      mountMobileSidebar(singleItems)
+
+      cy.get('[data-sidebar="trigger"]').click()
+      cy.get('[data-mobile="true"]').should('be.visible')
+
+      cy.contains('Overview').trigger('click')
+
+      cy.get('[data-mobile="true"]').should('not.exist')
+    })
+
+    it('closes the mobile sidebar after selecting a child item', () => {
+      mountMobileSidebar(collapsibleItems)
+
+      cy.get('[data-sidebar="trigger"]').click()
+      cy.get('[data-mobile="true"]').should('be.visible')
+      cy.contains('Queries').click()
+      cy.contains('Running Queries').trigger('click')
+
+      cy.get('[data-mobile="true"]').should('not.exist')
     })
   })
 

--- a/components/navigation/nav-main/collapsed-submenu.tsx
+++ b/components/navigation/nav-main/collapsed-submenu.tsx
@@ -23,6 +23,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
+import { useSidebar } from '@/components/ui/sidebar'
 import { isMenuItemActive } from '@/lib/menu/breadcrumb'
 import { cn } from '@/lib/utils'
 
@@ -47,6 +48,7 @@ export const CollapsedSubmenu = memo(function CollapsedSubmenu({
   trigger,
 }: CollapsedSubmenuProps) {
   const [open, setOpen] = useState(false)
+  const { isMobile, setOpenMobile } = useSidebar()
   const hasChildren = item.items && item.items.length > 0
 
   if (!hasChildren) {
@@ -85,7 +87,12 @@ export const CollapsedSubmenu = memo(function CollapsedSubmenu({
                 <HostPrefixedLink
                   key={subItem.href}
                   href={subItem.href}
-                  onClick={() => setOpen(false)}
+                  onClick={() => {
+                    setOpen(false)
+                    if (isMobile) {
+                      setOpenMobile(false)
+                    }
+                  }}
                 >
                   <div
                     className={cn(

--- a/components/navigation/nav-main/menu-item.tsx
+++ b/components/navigation/nav-main/menu-item.tsx
@@ -6,7 +6,7 @@ import type { MenuItem as MenuItemType } from '@/components/menu/types'
 import type { MenuItemActiveState, MenuItemProps } from './types'
 
 import { CollapsedSubmenu } from './collapsed-submenu'
-import { lazy, memo, Suspense } from 'react'
+import { lazy, memo, Suspense, useCallback } from 'react'
 import { HostPrefixedLink } from '@/components/menu/link-with-context'
 
 const NewBadge = lazy(() =>
@@ -36,6 +36,19 @@ import {
   useSidebar,
 } from '@/components/ui/sidebar'
 import { isMenuItemActive } from '@/lib/menu/breadcrumb'
+
+function useCloseMobileSidebar() {
+  const { isMobile, setOpenMobile } = useSidebar()
+
+  return useCallback(
+    (event?: React.MouseEvent<HTMLAnchorElement>) => {
+      if (!event?.defaultPrevented && isMobile) {
+        setOpenMobile(false)
+      }
+    },
+    [isMobile, setOpenMobile]
+  )
+}
 
 /**
  * Determines the active state for a menu item
@@ -67,10 +80,16 @@ const SingleMenuItem = memo(function SingleMenuItem({
   item: MenuItemType
   isActive: boolean
 }) {
+  const closeMobileSidebar = useCloseMobileSidebar()
+
   return (
     <SidebarMenuItem>
       <SidebarMenuButton asChild isActive={isActive} tooltip={item.title}>
-        <HostPrefixedLink href={item.href} className="flex w-full items-center">
+        <HostPrefixedLink
+          href={item.href}
+          className="flex w-full items-center"
+          onClick={closeMobileSidebar}
+        >
           {item.icon && <item.icon className="h-4 w-4 shrink-0" />}
           <span className="group-data-[state=collapsed]/sidebar:hidden">
             {item.title}
@@ -113,6 +132,7 @@ const CollapsibleMenuItem = memo(function CollapsibleMenuItem({
   hasActiveChild: boolean
 }) {
   const { state } = useSidebar()
+  const closeMobileSidebar = useCloseMobileSidebar()
   const isCollapsed = state === 'collapsed'
 
   // When collapsed, use Popover submenu
@@ -188,6 +208,7 @@ const CollapsibleMenuItem = memo(function CollapsibleMenuItem({
                   <HostPrefixedLink
                     href={subItem.href}
                     className="flex w-full items-center gap-2"
+                    onClick={closeMobileSidebar}
                   >
                     <span className="group-data-[state=collapsed]/sidebar:hidden min-w-0 truncate">
                       {subItem.title}

--- a/lib/format-readable.test.ts
+++ b/lib/format-readable.test.ts
@@ -143,6 +143,13 @@ describe('formatQuery', () => {
     expect(result).toBe(expected)
   })
 
+  it('should remove leading query comments', () => {
+    const query = '/* clickhouse-monitor */ SELECT * FROM system.processes'
+    const expected = 'SELECT * FROM system.processes'
+    const result = formatQuery({ query, comment_remove: true })
+    expect(result).toBe(expected)
+  })
+
   it('should not remove comments when comment_remove is undefined', () => {
     const query = 'SELECT * FROM table /* This is a comment */'
     const result = formatQuery({ query })

--- a/lib/format-readable.ts
+++ b/lib/format-readable.ts
@@ -76,10 +76,7 @@ export function formatQuery({
   trim?: boolean
 }) {
   let formattedQuery = comment_remove
-    ? query.replace(
-        /\/\*[\s\S]*?\*\//g,
-        query.trim().startsWith('/*') ? '/* ... */' : ''
-      )
+    ? query.replace(/\/\*[\s\S]*?\*\//g, '')
     : query
 
   if (trim) {

--- a/lib/query-config/queries/running-queries.ts
+++ b/lib/query-config/queries/running-queries.ts
@@ -79,6 +79,7 @@ export const runningQueriesConfig: QueryConfig = {
         max_truncate: 80,
         hide_query_comment: true,
         dialog_title: 'Running Query',
+        trigger_classname: '-ml-1 w-full min-w-0 sm:-ml-2',
       },
     ],
     query_detail: [


### PR DESCRIPTION
## Summary
- trim hidden ClickHouse monitor comments from running-query previews and dialogs
- constrain the running-query code dialog to the mobile viewport with internal scrolling
- close the mobile sidebar after top-level and nested menu item selection

## Verification
- bun run component:headless -- --spec components/data-table/cells/code-dialog-format.cy.tsx
- bun run component:headless -- --spec components/navigation/nav-main.cy.tsx
- bun test lib/format-readable.test.ts
- bun run type-check
- bun run lint
- bun run build
- bun run test
- Playwright mobile smoke at 390x844 for dialog bounds and sidebar close behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated mobile sidebar closure with navigation menu interactions.

* **Bug Fixes**
  * Improved code dialog layout handling for better viewport compatibility.
  * Enhanced block comment removal in query formatting to work consistently across all formats.

* **Tests**
  * Added mobile navigation behavior validation.
  * Extended code dialog testing for query formatting edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->