### PR TITLE
refactor(data-table): use checkbox component for row selection

### DIFF
--- a/components/data-table/data-table.cy.tsx
+++ b/components/data-table/data-table.cy.tsx
@@ -116,6 +116,62 @@ describe('<DataTable />', () => {
     cy.get('div').contains('1–200 of 300 rows')
   })
 
+  it('selects rows with accessible checkbox states', () => {
+    const data = [
+      { col1: 'val1', col2: 'val1' },
+      { col1: 'val2', col2: 'val2' },
+      { col1: 'val3', col2: 'val3' },
+    ]
+
+    cy.mount(
+      <DataTable
+        title="Test Table"
+        queryConfig={queryConfig}
+        data={data}
+        context={{}}
+        enableRowSelection
+      />
+    )
+
+    cy.get('[role="checkbox"][aria-label="Select all rows"]')
+      .should('have.attr', 'aria-checked', 'false')
+      .click()
+      .should('have.attr', 'aria-checked', 'true')
+
+    cy.get('[role="checkbox"][aria-label="Select row"]')
+      .should('have.length', 3)
+      .each(($checkbox) => {
+        expect($checkbox).to.have.attr('aria-checked', 'true')
+      })
+
+    cy.get('[role="checkbox"][aria-label="Select row"]').first().click()
+
+    cy.get('[role="checkbox"][aria-label="Select all rows"]').should(
+      'have.attr',
+      'aria-checked',
+      'mixed'
+    )
+  })
+
+  it('notifies consumers when row selection changes', () => {
+    const onRowSelectionChange = cy.stub().as('onRowSelectionChange')
+
+    cy.mount(
+      <DataTable
+        title="Test Table"
+        queryConfig={queryConfig}
+        data={[{ col1: 'val1', col2: 'val1' }]}
+        context={{}}
+        enableRowSelection
+        onRowSelectionChange={onRowSelectionChange}
+      />
+    )
+
+    cy.get('[role="checkbox"][aria-label="Select row"]').click()
+
+    cy.get('@onRowSelectionChange').should('have.been.calledWith', { 0: true })
+  })
+
   it('should adjust column visibility, hide col1', () => {
     // Define some mock data
     const data = [

--- a/components/data-table/data-table.tsx
+++ b/components/data-table/data-table.tsx
@@ -10,6 +10,7 @@ import {
   type RowData,
   type RowSelectionState,
   type SortingState,
+  type Updater,
   useReactTable,
 } from '@tanstack/react-table'
 
@@ -36,6 +37,7 @@ import {
   useVirtualRows,
 } from '@/components/data-table/hooks'
 import { getCustomSortingFns } from '@/components/data-table/sorting-fns'
+import { Checkbox } from '@/components/ui/checkbox'
 
 /**
  * Props for the DataTable component
@@ -159,7 +161,7 @@ export function DataTable<
   isRefreshing = false,
   executedSql,
   enableRowSelection = false,
-  onRowSelectionChange: _onRowSelectionChange,
+  onRowSelectionChange,
   metadata,
   enableColumnReordering = true,
   columnOrderStorageKey,
@@ -298,6 +300,19 @@ export function DataTable<
 
   // Row selection state
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
+  const handleRowSelectionChange = useCallback(
+    (updaterOrValue: Updater<RowSelectionState>) => {
+      setRowSelection((current) => {
+        const next =
+          typeof updaterOrValue === 'function'
+            ? updaterOrValue(current)
+            : updaterOrValue
+        onRowSelectionChange?.(next)
+        return next
+      })
+    },
+    [onRowSelectionChange]
+  )
 
   // Selection column definition using TanStack Table's row selection
   const selectionColumn: ColumnDef<TData, unknown> = useMemo(
@@ -312,15 +327,14 @@ export function DataTable<
             className="flex items-center justify-center"
             onClick={(e) => e.stopPropagation()}
           >
-            <input
-              type="checkbox"
-              className="size-4 cursor-pointer accent-primary"
-              checked={isAllSelected}
-              ref={(el) => {
-                if (el) el.indeterminate = isSomeSelected && !isAllSelected
-              }}
-              onChange={(e) =>
-                table.toggleAllPageRowsSelected(e.target.checked)
+            <Checkbox
+              checked={
+                isSomeSelected && !isAllSelected
+                  ? 'indeterminate'
+                  : isAllSelected
+              }
+              onCheckedChange={(checked) =>
+                table.toggleAllPageRowsSelected(checked === true)
               }
               onClick={(e) => e.stopPropagation()}
               aria-label="Select all rows"
@@ -334,12 +348,10 @@ export function DataTable<
           className="flex items-center justify-center"
           onClick={(e) => e.stopPropagation()}
         >
-          <input
-            type="checkbox"
-            className="size-4 cursor-pointer accent-primary"
+          <Checkbox
             checked={row.getIsSelected()}
             disabled={!row.getCanSelect()}
-            onChange={row.getToggleSelectedHandler()}
+            onCheckedChange={(checked) => row.toggleSelected(checked === true)}
             onClick={(e) => e.stopPropagation()}
             aria-label="Select row"
           />
@@ -394,7 +406,7 @@ export function DataTable<
     // Row selection - pass true to enable for all rows
     enableRowSelection: !!enableRowSelection,
     getRowId,
-    onRowSelectionChange: setRowSelection,
+    onRowSelectionChange: handleRowSelectionChange,
     // Enable sorting (click on header to sort, plus dropdown menu options)
     enableSorting: true,
     state: {


### PR DESCRIPTION
## Summary
- replace raw row-selection inputs with the installed shadcn/Radix Checkbox component
- preserve select-all checked and indeterminate states
- wire the existing onRowSelectionChange prop so consumers receive selection updates

## Verification
- bun run component:headless -- --spec components/data-table/data-table.cy.tsx
- bun run type-check
- bun run lint
- bun run build