### PR TITLE
fix(data-table): virtualize large table pages

### DIFF
--- a/components/data-table/hooks/use-virtual-rows.cy.tsx
+++ b/components/data-table/hooks/use-virtual-rows.cy.tsx
@@ -1,0 +1,41 @@
+import { useVirtualRows } from './use-virtual-rows'
+
+function VirtualRowsProbe({
+  rowCount,
+  virtualizeThreshold,
+}: {
+  rowCount: number
+  virtualizeThreshold?: number
+}) {
+  const { isVirtualized, tableContainerRef } = useVirtualRows(rowCount, {
+    virtualizeThreshold,
+  })
+
+  return (
+    <div
+      ref={tableContainerRef}
+      data-virtualized={String(isVirtualized)}
+      style={{ height: 200, overflow: 'auto' }}
+    />
+  )
+}
+
+describe('useVirtualRows', () => {
+  it('keeps normal page sizes on the standard table path', () => {
+    cy.mount(<VirtualRowsProbe rowCount={249} />)
+
+    cy.get('[data-virtualized="false"]').should('exist')
+  })
+
+  it('enables virtualization for large table pages', () => {
+    cy.mount(<VirtualRowsProbe rowCount={250} />)
+
+    cy.get('[data-virtualized="true"]').should('exist')
+  })
+
+  it('supports a custom virtualization threshold', () => {
+    cy.mount(<VirtualRowsProbe rowCount={20} virtualizeThreshold={10} />)
+
+    cy.get('[data-virtualized="true"]').should('exist')
+  })
+})

--- a/components/data-table/hooks/use-virtual-rows.ts
+++ b/components/data-table/hooks/use-virtual-rows.ts
@@ -4,7 +4,7 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 
 import { type RefObject, useRef } from 'react'
 
-const MAX_PAGINATED_TABLE_ROWS = 1_000
+const DEFAULT_VIRTUALIZE_THRESHOLD = 250
 
 /**
  * Hook for virtualizing table rows to improve performance with large datasets.
@@ -31,7 +31,7 @@ export interface UseVirtualRowsOptions {
   estimateSize?: number
   /** Number of rows to render outside viewport (default: 20) */
   overscan?: number
-  /** Row count threshold to enable virtualization (default: 1001) */
+  /** Row count threshold to enable virtualization (default: 250) */
   virtualizeThreshold?: number
 }
 
@@ -51,13 +51,10 @@ export function useVirtualRows(
   const {
     estimateSize = 40,
     overscan = 20,
-    virtualizeThreshold = MAX_PAGINATED_TABLE_ROWS + 1,
+    virtualizeThreshold = DEFAULT_VIRTUALIZE_THRESHOLD,
   } = options
 
   const tableContainerRef = useRef<HTMLDivElement>(null)
-
-  // The table is paginated to at most 1,000 rows. Keep the standard table path
-  // for normal page sizes until the virtual renderer has a proper spacer layout.
   const shouldVirtualize = rowCount >= virtualizeThreshold
 
   const virtualizer = useVirtualizer<HTMLDivElement, Element>({

--- a/components/data-table/renderers/table-body.cy.tsx
+++ b/components/data-table/renderers/table-body.cy.tsx
@@ -34,6 +34,7 @@ describe('TableBody Components', () => {
   }
 
   const mockTable = {
+    getVisibleLeafColumns: () => [{ id: 'col1' }, { id: 'col2' }],
     getRowModel: () => ({
       rows: [
         mockRow,
@@ -114,7 +115,7 @@ describe('TableBody Components', () => {
 
   describe('VirtualizedTableRow', () => {
     it('renders a virtualized table row with positioning', () => {
-      const virtualRow = { index: 0, size: 50, start: 0 }
+      const virtualRow = { end: 50, index: 0, size: 50, start: 0 }
 
       cy.mount(
         <table>
@@ -126,13 +127,11 @@ describe('TableBody Components', () => {
 
       cy.get('tr').should('have.attr', 'data-index', '0')
       cy.get('tr').should('have.attr', 'style').and('include', 'height: 50px')
-      cy.get('tr')
-        .should('have.attr', 'style')
-        .and('include', 'translateY(0px)')
+      cy.get('tr').should('have.attr', 'style').and('not.include', 'translateY')
     })
 
     it('applies odd row styling for odd virtual row indices', () => {
-      const virtualRow = { index: 1, size: 50, start: 50 }
+      const virtualRow = { end: 100, index: 1, size: 50, start: 50 }
 
       cy.mount(
         <table>
@@ -146,7 +145,7 @@ describe('TableBody Components', () => {
     })
 
     it('keeps virtualized cells non-wrapping for stable row heights', () => {
-      const virtualRow = { index: 0, size: 50, start: 0 }
+      const virtualRow = { end: 50, index: 0, size: 50, start: 0 }
 
       cy.mount(
         <table>
@@ -216,9 +215,10 @@ describe('TableBody Components', () => {
     it('renders virtual rows when virtualized', () => {
       const mockVirtualizer = {
         getVirtualItems: () => [
-          { index: 0, size: 50, start: 0 },
-          { index: 1, size: 50, start: 50 },
+          { end: 50, index: 0, size: 50, start: 0 },
+          { end: 100, index: 1, size: 50, start: 50 },
         ],
+        getTotalSize: () => 150,
       }
 
       cy.mount(
@@ -233,9 +233,49 @@ describe('TableBody Components', () => {
         </table>
       )
 
-      cy.get('tr').should('have.length', 2)
-      cy.get('tr').eq(0).should('have.attr', 'data-index', '0')
-      cy.get('tr').eq(1).should('have.attr', 'data-index', '1')
+      cy.get('tr[data-index]').should('have.length', 2)
+      cy.get('tr[data-index]').eq(0).should('have.attr', 'data-index', '0')
+      cy.get('tr[data-index]').eq(1).should('have.attr', 'data-index', '1')
+      cy.get('[data-virtual-spacer="bottom"] td').should(
+        'have.attr',
+        'style',
+        'height: 50px;'
+      )
+    })
+
+    it('adds top and bottom spacer rows for scrolled virtual windows', () => {
+      const mockVirtualizer = {
+        getVirtualItems: () => [
+          { end: 150, index: 1, size: 50, start: 100 },
+          { end: 200, index: 999, size: 50, start: 150 },
+        ],
+        getTotalSize: () => 500,
+      }
+
+      cy.mount(
+        <table>
+          <tbody>
+            <TableBodyRows
+              table={mockTable as any}
+              isVirtualized={true}
+              virtualizer={mockVirtualizer as any}
+            />
+          </tbody>
+        </table>
+      )
+
+      cy.get('[data-virtual-spacer="top"] td').should(
+        'have.attr',
+        'style',
+        'height: 100px;'
+      )
+      cy.get('tr[data-index]').should('have.length', 1)
+      cy.get('tr[data-index]').should('have.attr', 'data-index', '1')
+      cy.get('[data-virtual-spacer="bottom"] td').should(
+        'have.attr',
+        'style',
+        'height: 300px;'
+      )
     })
   })
 
@@ -279,7 +319,8 @@ describe('TableBody Components', () => {
 
     it('passes virtualization context correctly', () => {
       const mockVirtualizer = {
-        getVirtualItems: () => [{ index: 0, size: 50, start: 0 }],
+        getVirtualItems: () => [{ end: 50, index: 0, size: 50, start: 0 }],
+        getTotalSize: () => 50,
       }
 
       cy.mount(

--- a/components/data-table/renderers/table-body.tsx
+++ b/components/data-table/renderers/table-body.tsx
@@ -25,6 +25,7 @@ const STANDARD_CELL_CLASS = 'text-sm align-top break-words tabular-nums'
  * Virtual row item from @tanstack/react-virtual
  */
 export interface VirtualItem {
+  end: number
   index: number
   size: number
   start: number
@@ -68,7 +69,6 @@ export const VirtualizedTableRow = memo(function VirtualizedTableRow<
       )}
       style={{
         height: `${virtualRow.size}px`,
-        transform: `translateY(${virtualRow.start}px)`,
       }}
     >
       {row.getVisibleCells().map((cell: Cell<TData, unknown>) => {
@@ -152,6 +152,7 @@ export const StandardTableRow = memo(function StandardTableRow<
  */
 export interface Virtualizer {
   getVirtualItems(): VirtualItem[]
+  getTotalSize(): number
 }
 
 /**
@@ -190,10 +191,33 @@ export const TableBodyRows = memo(function TableBodyRows<
   if (isVirtualized && virtualizer) {
     // Virtualized rendering for large datasets
     const virtualRows = virtualizer.getVirtualItems()
+    const firstVirtualRow = virtualRows[0]
+    const lastVirtualRow = virtualRows.at(-1)
+    const paddingTop = firstVirtualRow?.start ?? 0
+    const paddingBottom = lastVirtualRow
+      ? Math.max(virtualizer.getTotalSize() - lastVirtualRow.end, 0)
+      : 0
+    const colSpan = Math.max(table.getVisibleLeafColumns().length, 1)
+
     return (
       <>
+        {paddingTop > 0 && (
+          <TableRow
+            aria-hidden="true"
+            data-virtual-spacer="top"
+            className="border-0 hover:bg-transparent"
+          >
+            <TableCell
+              colSpan={colSpan}
+              className="border-0 p-0"
+              style={{ height: `${paddingTop}px` }}
+            />
+          </TableRow>
+        )}
         {virtualRows.map((virtualRow: VirtualItem) => {
           const row = rows[virtualRow.index]
+          if (!row) return null
+
           return (
             <VirtualizedTableRow<TData>
               key={row.id}
@@ -203,6 +227,19 @@ export const TableBodyRows = memo(function TableBodyRows<
             />
           )
         })}
+        {paddingBottom > 0 && (
+          <TableRow
+            aria-hidden="true"
+            data-virtual-spacer="bottom"
+            className="border-0 hover:bg-transparent"
+          >
+            <TableCell
+              colSpan={colSpan}
+              className="border-0 p-0"
+              style={{ height: `${paddingBottom}px` }}
+            />
+          </TableRow>
+        )}
       </>
     )
   }


### PR DESCRIPTION
## Summary
- lower the default table virtualization threshold so large 500/1000-row pages do not render every row
- add table spacer rows for virtualized windows and skip stale virtual row indexes
- keep virtualized rows at stable fixed heights without transform positioning

## Verification
- bun run component:headless -- --spec "components/data-table/hooks/use-virtual-rows.cy.tsx,components/data-table/renderers/table-body.cy.tsx,components/data-table/components/data-table-content.cy.tsx"
- bun run type-check
- bun run lint
- bun run build
- bun run test