### PR TITLE
refactor(data-table): use shadcn empty state

### DIFF
--- a/components/data-table/renderers/table-body.cy.tsx
+++ b/components/data-table/renderers/table-body.cy.tsx
@@ -177,6 +177,7 @@ describe('TableBody Components', () => {
       )
 
       cy.get('td').should('have.attr', 'colspan', '2')
+      cy.get('[data-slot="empty"]').should('be.visible')
       cy.contains('No results').should('be.visible')
       cy.contains(/no test data found/i).should('be.visible')
     })
@@ -194,6 +195,7 @@ describe('TableBody Components', () => {
         </table>
       )
 
+      cy.get('[data-slot="empty-icon"]').should('be.visible')
       cy.contains(/no test data match your filters/i).should('be.visible')
       cy.contains(/clearing filters/i).should('be.visible')
     })

--- a/components/data-table/renderers/table-body.tsx
+++ b/components/data-table/renderers/table-body.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { SearchX } from 'lucide-react'
 import {
   type Cell,
   type ColumnDef,
@@ -14,7 +15,13 @@ import type { RowClassNameFn } from '@/types/query-config'
 
 import { memo, type ReactNode } from 'react'
 import { useTableDensityContext } from '@/components/data-table/context/table-density-context'
-import { EmptyState } from '@/components/ui/empty-state'
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty'
 import { TableCell, TableRow } from '@/components/ui/table'
 import { cn } from '@/lib/utils'
 
@@ -302,15 +309,19 @@ export const TableBodyEmptyState = memo(function TableBodyEmptyState<
   return (
     <TableRow>
       <TableCell colSpan={columnDefs.length} className="h-64 p-4">
-        <EmptyState
-          variant="no-data"
-          title="No results"
-          description={
-            activeFilterCount > 0
-              ? `No ${title?.toLowerCase() || 'data'} match your filters. Try clearing filters or adjusting your search.`
-              : `No ${title?.toLowerCase() || 'data'} found. Try adjusting your query or check back later.`
-          }
-        />
+        <Empty className="h-full min-h-48 border-0 p-4 md:p-6">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <SearchX className="h-5 w-5" />
+            </EmptyMedia>
+            <EmptyTitle>No results</EmptyTitle>
+            <EmptyDescription>
+              {activeFilterCount > 0
+                ? `No ${title?.toLowerCase() || 'data'} match your filters. Try clearing filters or adjusting your search.`
+                : `No ${title?.toLowerCase() || 'data'} found. Try adjusting your query or check back later.`}
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
       </TableCell>
     </TableRow>
   )

--- a/components/ui/empty.tsx
+++ b/components/ui/empty.tsx
@@ -1,0 +1,104 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+function Empty({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        'flex min-w-0 flex-1 flex-col items-center justify-center gap-6 text-balance rounded-lg border-dashed p-6 text-center md:p-12',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn(
+        'flex max-w-sm flex-col items-center gap-2 text-center',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const emptyMediaVariants = cva(
+  'mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default: 'bg-transparent',
+        icon: "bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-6",
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+)
+
+function EmptyMedia({
+  className,
+  variant = 'default',
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn('text-lg font-medium tracking-tight', className)}
+      {...props}
+    />
+  )
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<'p'>) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        'text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        'flex w-full min-w-0 max-w-sm flex-col items-center gap-4 text-balance text-sm',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+  EmptyMedia,
+}

--- a/components/ui/empty.tsx
+++ b/components/ui/empty.tsx
@@ -58,9 +58,9 @@ function EmptyMedia({
   )
 }
 
-function EmptyTitle({ className, ...props }: React.ComponentProps<'div'>) {
+function EmptyTitle({ className, ...props }: React.ComponentProps<'h3'>) {
   return (
-    <div
+    <h3
       data-slot="empty-title"
       className={cn('text-lg font-medium tracking-tight', className)}
       {...props}
@@ -70,7 +70,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<'div'>) {
 
 function EmptyDescription({ className, ...props }: React.ComponentProps<'p'>) {
   return (
-    <div
+    <p
       data-slot="empty-description"
       className={cn(
         'text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4',


### PR DESCRIPTION
## Summary
- add the official shadcn Empty primitives
- render the data-table no-results row with shadcn Empty components
- keep the existing empty-state copy and table colspan behavior

## Verification
- bun run component:headless -- --spec components/data-table/renderers/table-body.cy.tsx
- bun run type-check
- bun run lint
- bun run test
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned empty state display in data tables with improved visual presentation, now featuring enhanced visual indicators and icons to communicate when no results are available or active filters have been applied.

* **Tests**
  * Enhanced test coverage to verify proper visibility and functionality of all empty state UI elements and associated visual indicators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->