### PR TITLE
feat(running-queries): improve process table layout

### DIFF
--- a/components/data-table/cells/code-dialog-format.tsx
+++ b/components/data-table/cells/code-dialog-format.tsx
@@ -43,6 +43,7 @@ export interface CodeDialogOptions {
   json?: boolean
   dialog_classname?: string
   show_explorer_link?: boolean
+  force_dialog?: boolean
 }
 
 const STORAGE_KEY = 'code-dialog-beautify'
@@ -254,13 +255,13 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
     }
   }, [clearCopyTimer, content])
 
-  if (formatted.length < truncate_length) {
+  if (!options?.force_dialog && formatted.length < truncate_length) {
     return (
       <code className="whitespace-nowrap font-mono text-xs">{formatted}</code>
     )
   }
 
-  if (!formatted.endsWith('...')) {
+  if (!options?.force_dialog && !formatted.endsWith('...')) {
     return (
       <code className="whitespace-nowrap font-mono text-xs">{formatted}</code>
     )

--- a/components/data-table/cells/code-dialog-format.tsx
+++ b/components/data-table/cells/code-dialog-format.tsx
@@ -43,6 +43,7 @@ export interface CodeDialogOptions {
   json?: boolean
   dialog_classname?: string
   show_explorer_link?: boolean
+  /** Force the dialog trigger for short content; defaults to false. */
   force_dialog?: boolean
 }
 

--- a/components/data-table/cells/running-query-summary-format.tsx
+++ b/components/data-table/cells/running-query-summary-format.tsx
@@ -188,10 +188,7 @@ export const RunningQuerySummaryFormat = memo(
     const port = stringValue(record.port)
     const addressLabel = address && port ? `${address}:${port}` : address
     const distributedDepth = numberValue(record.distributed_depth)
-    const isDistributed =
-      distributedDepth !== null && Number.isFinite(distributedDepth)
-        ? distributedDepth > 0
-        : false
+    const isDistributed = (distributedDepth ?? 0) > 0
 
     const queryLink = useMemo(() => {
       if (!queryId) return ''

--- a/components/data-table/cells/running-query-summary-format.tsx
+++ b/components/data-table/cells/running-query-summary-format.tsx
@@ -1,0 +1,354 @@
+'use client'
+
+import type { LucideIcon } from 'lucide-react'
+import {
+  Activity,
+  Clock3,
+  Cpu,
+  Database,
+  Fingerprint,
+  HardDriveDownload,
+  HardDriveUpload,
+  MemoryStick,
+  Monitor,
+  Network,
+  Server,
+  User,
+} from 'lucide-react'
+import type { Row, RowData } from '@tanstack/react-table'
+
+import { memo, useMemo } from 'react'
+import { CodeDialogFormat } from '@/components/data-table/cells/code-dialog-format'
+import { AppLink as Link } from '@/components/ui/app-link'
+import { Badge } from '@/components/ui/badge'
+import {
+  formatReadableQuantity,
+  formatReadableSize,
+} from '@/lib/format-readable'
+import { cn } from '@/lib/utils'
+
+interface RunningQuerySummaryFormatProps<TData extends RowData> {
+  row: Row<TData>
+  value: React.ReactNode
+  context?: Record<string, string>
+}
+
+interface MetricItemProps {
+  icon: LucideIcon
+  label: string
+  value: React.ReactNode
+  subValue?: React.ReactNode
+  tone?: 'default' | 'warning' | 'danger'
+}
+
+interface DetailItemProps {
+  icon: LucideIcon
+  label: string
+  value: React.ReactNode
+  title?: string
+}
+
+const numberFormatter = new Intl.NumberFormat('en-US')
+
+function hasValue(value: unknown): boolean {
+  return value !== undefined && value !== null && String(value) !== ''
+}
+
+function stringValue(value: unknown): string {
+  if (!hasValue(value)) return ''
+  return String(value)
+}
+
+function numberValue(value: unknown): number | null {
+  if (!hasValue(value)) return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function readableSize(value: unknown): string {
+  const parsed = numberValue(value)
+  return parsed === null ? '' : formatReadableSize(parsed)
+}
+
+function readableCount(value: unknown): string {
+  const parsed = numberValue(value)
+  return parsed === null ? '' : formatReadableQuantity(parsed)
+}
+
+function getThreadCount(row: Record<string, unknown>): string {
+  const peakThreads = numberValue(row.peak_threads_usage)
+  if (peakThreads !== null) return numberFormatter.format(peakThreads)
+
+  const threadCount = numberValue(row.thread_count)
+  if (threadCount !== null) return numberFormatter.format(threadCount)
+
+  if (Array.isArray(row.thread_ids)) {
+    return numberFormatter.format(row.thread_ids.length)
+  }
+
+  return ''
+}
+
+function getElapsedTone(elapsed: number | null): MetricItemProps['tone'] {
+  if (elapsed === null) return 'default'
+  if (elapsed > 30) return 'danger'
+  if (elapsed > 5) return 'warning'
+  return 'default'
+}
+
+function MetricItem({
+  icon: Icon,
+  label,
+  value,
+  subValue,
+  tone = 'default',
+}: MetricItemProps) {
+  if (!hasValue(value)) return null
+
+  return (
+    <div
+      className={cn(
+        'min-w-0 rounded-md border bg-background/70 px-2.5 py-2',
+        tone === 'warning' && 'border-amber-300/70 bg-amber-50/70',
+        tone === 'danger' && 'border-red-300/70 bg-red-50/70',
+        tone === 'warning' && 'dark:border-amber-800/70 dark:bg-amber-950/20',
+        tone === 'danger' && 'dark:border-red-800/70 dark:bg-red-950/20'
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
+        <Icon className="size-3.5 shrink-0" aria-hidden="true" />
+        <span className="truncate">{label}</span>
+      </div>
+      <div className="mt-1 min-w-0 truncate text-sm font-semibold tabular-nums text-foreground">
+        {value}
+      </div>
+      {hasValue(subValue) && (
+        <div className="mt-0.5 min-w-0 truncate text-[11px] tabular-nums text-muted-foreground">
+          {subValue}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function DetailItem({ icon: Icon, label, value, title }: DetailItemProps) {
+  if (!hasValue(value)) return null
+
+  return (
+    <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+      <Icon className="size-3.5 shrink-0" aria-hidden="true" />
+      <span className="shrink-0 font-medium text-foreground/70">{label}</span>
+      <span className="min-w-0 truncate font-mono" title={title}>
+        {value}
+      </span>
+    </div>
+  )
+}
+
+export const RunningQuerySummaryFormat = memo(
+  function RunningQuerySummaryFormat<TData extends RowData>({
+    row,
+    value,
+    context,
+  }: RunningQuerySummaryFormatProps<TData>): React.ReactNode {
+    const record = row.original as Record<string, unknown>
+    const hostId = context?.['ctx.hostId'] ?? context?.hostId ?? '0'
+    const query = stringValue(record.query ?? value)
+    const queryId = stringValue(record.query_id ?? record.query_detail)
+    const initialQueryId = stringValue(record.initial_query_id)
+    const normalizedQueryHash = stringValue(record.normalized_query_hash)
+    const elapsed = numberValue(record.elapsed)
+    const elapsedLabel =
+      stringValue(record.readable_elapsed) ||
+      (elapsed === null ? '' : `${elapsed.toFixed(1)} seconds`)
+    const progress = stringValue(record.progress)
+    const memory =
+      stringValue(record.readable_memory_usage) ||
+      readableSize(record.memory_usage)
+    const readRows =
+      stringValue(record.readable_read_rows) || readableCount(record.read_rows)
+    const readBytes =
+      stringValue(record.readable_read_bytes) || readableSize(record.read_bytes)
+    const writtenRows =
+      stringValue(record.readable_written_rows) ||
+      readableCount(record.written_rows)
+    const writtenBytes =
+      stringValue(record.readable_written_bytes) ||
+      readableSize(record.written_bytes)
+    const threadCount = getThreadCount(record)
+    const merges = stringValue(record.launched_merges)
+    const queryKind = stringValue(record.query_kind)
+    const user = stringValue(record.user)
+    const database = stringValue(record.current_database)
+    const interfaceLabel =
+      stringValue(record.interface_label) || stringValue(record.interface)
+    const client = stringValue(record.client_name)
+    const clientHost = stringValue(record.client_hostname)
+    const address = stringValue(record.address)
+    const port = stringValue(record.port)
+    const addressLabel = address && port ? `${address}:${port}` : address
+    const distributedDepth = numberValue(record.distributed_depth)
+    const isDistributed =
+      distributedDepth !== null && Number.isFinite(distributedDepth)
+        ? distributedDepth > 0
+        : false
+
+    const queryLink = useMemo(() => {
+      if (!queryId) return ''
+      return `/query?query_id=${encodeURIComponent(queryId)}&host=${encodeURIComponent(hostId)}`
+    }, [hostId, queryId])
+
+    return (
+      <div data-slot="running-query-summary" className="min-w-0 py-2 pr-2">
+        <div className="grid min-w-0 gap-3 xl:grid-cols-[minmax(0,1fr)_auto]">
+          <div className="min-w-0">
+            <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+              {queryKind && (
+                <Badge
+                  variant="secondary"
+                  className="h-6 shrink-0 rounded-md px-2 font-mono text-[11px] uppercase"
+                >
+                  {queryKind}
+                </Badge>
+              )}
+              {user && (
+                <Badge
+                  variant="outline"
+                  className="h-6 max-w-36 shrink-0 rounded-md px-2 text-[11px]"
+                >
+                  <User className="mr-1 size-3" aria-hidden="true" />
+                  <span className="truncate">{user}</span>
+                </Badge>
+              )}
+              {database && (
+                <Badge
+                  variant="outline"
+                  className="h-6 max-w-44 shrink-0 rounded-md px-2 text-[11px]"
+                >
+                  <Database className="mr-1 size-3" aria-hidden="true" />
+                  <span className="truncate font-mono">{database}</span>
+                </Badge>
+              )}
+              {isDistributed && (
+                <Badge
+                  variant="outline"
+                  className="h-6 shrink-0 rounded-md px-2 text-[11px]"
+                >
+                  Distributed depth {distributedDepth}
+                </Badge>
+              )}
+            </div>
+
+            <div className="mt-2 min-w-0 [&_code]:break-words [&_code]:whitespace-normal">
+              <CodeDialogFormat
+                value={query}
+                options={{
+                  dialog_title: 'Running Query',
+                  hide_query_comment: true,
+                  max_truncate: 320,
+                  force_dialog: true,
+                  trigger_classname:
+                    'w-full min-w-0 justify-start rounded-md border border-transparent bg-muted/30 px-2 py-1.5 hover:border-border hover:bg-muted/60',
+                }}
+              />
+            </div>
+          </div>
+
+          <div className="flex min-w-0 flex-wrap items-start gap-2 xl:max-w-[28rem] xl:justify-end">
+            {queryLink && (
+              <Link
+                href={queryLink}
+                className="inline-flex h-7 max-w-full min-w-0 items-center gap-1.5 rounded-md border bg-background px-2 text-xs font-medium text-foreground transition-colors hover:border-primary/50 hover:text-primary"
+              >
+                <Fingerprint className="size-3.5 shrink-0" aria-hidden="true" />
+                <span className="min-w-0 truncate font-mono">
+                  {queryId.slice(0, 18)}
+                  {queryId.length > 18 ? '...' : ''}
+                </span>
+              </Link>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-3 grid min-w-0 grid-cols-2 gap-2 sm:grid-cols-3 xl:grid-cols-6">
+          <MetricItem
+            icon={Clock3}
+            label="Elapsed"
+            value={elapsedLabel}
+            tone={getElapsedTone(elapsed)}
+          />
+          <MetricItem icon={MemoryStick} label="Memory" value={memory} />
+          <MetricItem
+            icon={Activity}
+            label="Progress"
+            value={progress}
+            subValue={
+              numberValue(record.total_rows_approx) !== null
+                ? `${readRows} of ${readableCount(record.total_rows_approx)} rows`
+                : undefined
+            }
+          />
+          <MetricItem
+            icon={HardDriveDownload}
+            label="Read"
+            value={readRows}
+            subValue={readBytes}
+          />
+          <MetricItem
+            icon={HardDriveUpload}
+            label="Written"
+            value={writtenRows}
+            subValue={writtenBytes}
+          />
+          <MetricItem
+            icon={Cpu}
+            label={
+              hasValue(record.peak_threads_usage) ? 'Peak threads' : 'Threads'
+            }
+            value={threadCount}
+            subValue={
+              hasValue(record.peak_threads_usage)
+                ? 'from system.processes'
+                : undefined
+            }
+          />
+        </div>
+
+        <div className="mt-3 grid min-w-0 grid-cols-1 gap-x-4 gap-y-1.5 sm:grid-cols-2 xl:grid-cols-3">
+          <DetailItem icon={Monitor} label="Client" value={client} />
+          <DetailItem icon={Server} label="Host" value={clientHost} />
+          <DetailItem icon={Network} label="Interface" value={interfaceLabel} />
+          <DetailItem
+            icon={Network}
+            label="Address"
+            value={addressLabel}
+            title={addressLabel}
+          />
+          <DetailItem
+            icon={Fingerprint}
+            label="Initial"
+            value={
+              initialQueryId && initialQueryId !== queryId
+                ? initialQueryId
+                : undefined
+            }
+            title={initialQueryId}
+          />
+          <DetailItem
+            icon={Fingerprint}
+            label="Hash"
+            value={normalizedQueryHash}
+            title={normalizedQueryHash}
+          />
+          <DetailItem
+            icon={Activity}
+            label="Merges"
+            value={merges && merges !== '0' ? merges : undefined}
+          />
+        </div>
+      </div>
+    )
+  }
+) as <TData extends RowData>(
+  props: RunningQuerySummaryFormatProps<TData>
+) => React.ReactNode

--- a/components/data-table/cells/running-query-summary-format.tsx
+++ b/components/data-table/cells/running-query-summary-format.tsx
@@ -25,6 +25,7 @@ import {
   formatReadableQuantity,
   formatReadableSize,
 } from '@/lib/format-readable'
+import { useHostId } from '@/lib/swr/use-host'
 import { cn } from '@/lib/utils'
 
 interface RunningQuerySummaryFormatProps<TData extends RowData> {
@@ -145,14 +146,23 @@ function DetailItem({ icon: Icon, label, value, title }: DetailItemProps) {
   )
 }
 
+/**
+ * Renders a memoized, responsive summary for a `system.processes` row.
+ *
+ * Expects `row.original` to contain running-query fields, tolerates missing
+ * optional columns, and returns a React node for the data-table formatter.
+ *
+ * @param props.row TanStack row whose `original` value is the process record.
+ * @param props.value Fallback query text when `row.original.query` is absent.
+ * @param props.context Formatter context kept for RowContextFormatter shape.
+ */
 export const RunningQuerySummaryFormat = memo(
   function RunningQuerySummaryFormat<TData extends RowData>({
     row,
     value,
-    context,
   }: RunningQuerySummaryFormatProps<TData>): React.ReactNode {
     const record = row.original as Record<string, unknown>
-    const hostId = context?.['ctx.hostId'] ?? context?.hostId ?? '0'
+    const hostId = useHostId()
     const query = stringValue(record.query ?? value)
     const queryId = stringValue(record.query_id ?? record.query_detail)
     const initialQueryId = stringValue(record.initial_query_id)

--- a/components/data-table/formatters/context-formatters.tsx
+++ b/components/data-table/formatters/context-formatters.tsx
@@ -14,7 +14,7 @@ import {
   type HoverCardOptions,
 } from '../cells/hover-card-format'
 import { LinkFormat, type LinkFormatOptions } from '../cells/link-format'
-import { RunningQuerySummaryFormat } from '../cells/running-query-summary-format'
+import { RunningQuerySummaryFormat } from '@/components/data-table/cells/running-query-summary-format'
 import { ColumnFormat } from '@/types/column-format'
 
 /**

--- a/components/data-table/formatters/context-formatters.tsx
+++ b/components/data-table/formatters/context-formatters.tsx
@@ -14,6 +14,7 @@ import {
   type HoverCardOptions,
 } from '../cells/hover-card-format'
 import { LinkFormat, type LinkFormatOptions } from '../cells/link-format'
+import { RunningQuerySummaryFormat } from '../cells/running-query-summary-format'
 import { ColumnFormat } from '@/types/column-format'
 
 /**
@@ -156,6 +157,25 @@ export const hoverCardFormatter: RowContextFormatter = <
 }
 
 /**
+ * Running query summary formatter - renders a responsive process row.
+ */
+export const runningQuerySummaryFormatter: RowContextFormatter = <
+  TData extends RowData,
+  TValue,
+>(
+  props: FormatterProps<TData, TValue>
+): React.ReactNode => {
+  const { row, value, context } = props
+  return (
+    <RunningQuerySummaryFormat
+      row={row}
+      value={value as React.ReactNode}
+      context={context}
+    />
+  )
+}
+
+/**
  * Registry of context formatters
  * These formatters need access to row, table, and context data
  */
@@ -164,7 +184,8 @@ export const CONTEXT_FORMATTERS: Record<
   | ColumnFormat.InlineAction
   | ColumnFormat.BackgroundBar
   | ColumnFormat.HoverCard
-  | ColumnFormat.Link,
+  | ColumnFormat.Link
+  | ColumnFormat.RunningQuerySummary,
   RowContextFormatter
 > = {
   [ColumnFormat.Action]: actionFormatter,
@@ -172,4 +193,5 @@ export const CONTEXT_FORMATTERS: Record<
   [ColumnFormat.BackgroundBar]: backgroundBarFormatter,
   [ColumnFormat.HoverCard]: hoverCardFormatter,
   [ColumnFormat.Link]: linkFormatter,
+  [ColumnFormat.RunningQuerySummary]: runningQuerySummaryFormatter,
 } as const

--- a/components/data-table/formatters/index.cy.tsx
+++ b/components/data-table/formatters/index.cy.tsx
@@ -15,11 +15,22 @@ import {
   runningQuerySummaryFormatter,
   textFormatter,
 } from './index'
+import { HostProvider } from '@/lib/swr/host-context'
 import { ColumnFormat } from '@/types/column-format'
 
 // Test wrapper with required context
-function TestWrapper({ children }: { children: React.ReactNode }) {
-  return <div className="p-4">{children}</div>
+function TestWrapper({
+  children,
+  hostId = 0,
+}: {
+  children: React.ReactNode
+  hostId?: number
+}) {
+  return (
+    <HostProvider hostId={hostId}>
+      <div className="p-4">{children}</div>
+    </HostProvider>
+  )
 }
 
 describe('Formatters Module', () => {
@@ -186,11 +197,10 @@ describe('Formatters Module', () => {
             rowData[key as keyof typeof rowData] as unknown,
         } as unknown as Row<any>,
         data: [rowData],
-        context: { 'ctx.hostId': '2' },
       })
 
       const result = runningQuerySummaryFormatter(props)
-      cy.mount(<TestWrapper>{result}</TestWrapper>)
+      cy.mount(<TestWrapper hostId={2}>{result}</TestWrapper>)
 
       cy.get('[data-slot="running-query-summary"]').should(($summary) => {
         expect($summary[0].scrollWidth).to.be.lte($summary[0].clientWidth + 1)
@@ -201,6 +211,38 @@ describe('Formatters Module', () => {
       cy.contains('8').should('exist')
       cy.get(
         'a[href="/query?query_id=98e83379-9adb-4c1d-9ad3-111111111111&host=2"]'
+      ).should('exist')
+    })
+
+    it('runningQuerySummaryFormatter should render without peak thread data', () => {
+      const rowData = {
+        query_id: '49bc477a-dc31-4c1d-9ad3-222222222222',
+        query: 'SELECT 1',
+        user: 'duyet',
+        readable_elapsed: '1.5 seconds',
+        readable_memory_usage: '12 MiB',
+        thread_count: 3,
+      }
+
+      const props = createMockProps(rowData.query, {
+        row: {
+          original: rowData,
+          index: 0,
+          getValue: (key: string) =>
+            rowData[key as keyof typeof rowData] as unknown,
+        } as unknown as Row<any>,
+        data: [rowData],
+      })
+
+      const result = runningQuerySummaryFormatter(props)
+      cy.mount(<TestWrapper hostId={3}>{result}</TestWrapper>)
+
+      cy.contains('duyet').should('exist')
+      cy.contains('12 MiB').should('exist')
+      cy.contains('Threads').should('exist')
+      cy.contains('Peak threads').should('not.exist')
+      cy.get(
+        'a[href="/query?query_id=49bc477a-dc31-4c1d-9ad3-222222222222&host=3"]'
       ).should('exist')
     })
   })

--- a/components/data-table/formatters/index.cy.tsx
+++ b/components/data-table/formatters/index.cy.tsx
@@ -12,6 +12,7 @@ import {
   markdownFormatter,
   numberFormatter,
   relatedTimeFormatter,
+  runningQuerySummaryFormatter,
   textFormatter,
 } from './index'
 import { ColumnFormat } from '@/types/column-format'
@@ -149,6 +150,58 @@ describe('Formatters Module', () => {
       cy.mount(<TestWrapper>{result}</TestWrapper>)
 
       cy.get('a[href="/details/123"]').should('contain.text', 'Navigate')
+    })
+
+    it('runningQuerySummaryFormatter should render a responsive process summary', () => {
+      cy.viewport(390, 700)
+
+      const rowData = {
+        query_id: '98e83379-9adb-4c1d-9ad3-111111111111',
+        query:
+          'SELECT database, table, count() FROM system.parts WHERE active GROUP BY database, table ORDER BY count() DESC',
+        query_kind: 'Select',
+        user: 'duyet',
+        current_database: 'system',
+        readable_elapsed: '12 seconds',
+        readable_memory_usage: '42 MiB',
+        progress: '64%',
+        readable_read_rows: '12.4M',
+        readable_read_bytes: '3.2 GiB',
+        readable_written_rows: '0',
+        readable_written_bytes: '0 Bytes',
+        peak_threads_usage: 8,
+        client_name: 'ClickHouse',
+        client_hostname: 'workstation',
+        interface_label: 'HTTP',
+        address: '127.0.0.1',
+        port: 8123,
+        normalized_query_hash: '123456789',
+      }
+
+      const props = createMockProps(rowData.query, {
+        row: {
+          original: rowData,
+          index: 0,
+          getValue: (key: string) =>
+            rowData[key as keyof typeof rowData] as unknown,
+        } as unknown as Row<any>,
+        data: [rowData],
+        context: { 'ctx.hostId': '2' },
+      })
+
+      const result = runningQuerySummaryFormatter(props)
+      cy.mount(<TestWrapper>{result}</TestWrapper>)
+
+      cy.get('[data-slot="running-query-summary"]').should(($summary) => {
+        expect($summary[0].scrollWidth).to.be.lte($summary[0].clientWidth + 1)
+      })
+      cy.contains('duyet').should('exist')
+      cy.contains('42 MiB').should('exist')
+      cy.contains('Peak threads').should('exist')
+      cy.contains('8').should('exist')
+      cy.get(
+        'a[href="/query?query_id=98e83379-9adb-4c1d-9ad3-111111111111&host=2"]'
+      ).should('exist')
     })
   })
 

--- a/components/data-table/formatters/index.tsx
+++ b/components/data-table/formatters/index.tsx
@@ -51,6 +51,7 @@ export {
   hoverCardFormatter,
   inlineActionFormatter,
   linkFormatter,
+  runningQuerySummaryFormatter,
 } from './context-formatters'
 // Export core formatting function
 export { formatCell } from './format-cell'

--- a/lib/__tests__/versioned-sql.test.ts
+++ b/lib/__tests__/versioned-sql.test.ts
@@ -129,6 +129,12 @@ describe('Running Queries Version Selection', () => {
     })
 
     it('should configure the compact running-query summary table shape', () => {
+      const sql = selectVersionedSql(
+        runningQueriesConfig.sql,
+        parseVersion('24.1.0.0')
+      )
+
+      expect(sql).toContain('ORDER BY elapsed DESC')
       expect(runningQueriesConfig.columns).toEqual(['action', 'query'])
       expect(runningQueriesConfig.columnFormats?.query).toBe(
         ColumnFormat.RunningQuerySummary

--- a/lib/__tests__/versioned-sql.test.ts
+++ b/lib/__tests__/versioned-sql.test.ts
@@ -65,6 +65,15 @@ describe('Running Queries Version Selection', () => {
 
       // peak_threads_usage is NOT available in ClickHouse 24.x+
       expect(sql).not.toContain('peak_threads_usage')
+      expect(sql).toContain('NULL AS normalized_query_hash')
+    })
+
+    it('should select normalized query hash for ClickHouse 25.3+', () => {
+      const version = parseVersion('25.3.0.0')
+      const sql = selectVersionedSql(runningQueriesConfig.sql, version)
+
+      expect(sql).toContain('normalized_query_hash')
+      expect(sql).not.toContain('NULL AS normalized_query_hash')
     })
 
     it('should fallback to oldest variant when version is null', () => {
@@ -96,7 +105,7 @@ describe('Running Queries Version Selection', () => {
       expect(sql).toContain('ORDER BY elapsed')
     })
 
-    it('both versions should have same base columns (single query now)', () => {
+    it('both versions should have same base projection columns', () => {
       const v23 = selectVersionedSql(
         runningQueriesConfig.sql,
         parseVersion('23.8.0.0')
@@ -108,14 +117,33 @@ describe('Running Queries Version Selection', () => {
 
       // Common columns (same query for all versions now)
       const commonColumns = [
-        'query_id as query_detail',
+        'query_id,',
+        'query,',
+        'query_kind,',
+        'user,',
+        'current_database,',
+        'initial_query_id,',
+        'address,',
+        'port,',
+        'interface,',
+        'client_name,',
+        'client_hostname,',
+        'distributed_depth,',
+        'elapsed,',
+        'read_rows,',
+        'read_bytes,',
+        'total_rows_approx,',
+        'written_rows,',
+        'written_bytes,',
+        'memory_usage,',
+        'peak_memory_usage,',
         'readable_elapsed',
         'readable_read_rows',
         'readable_written_rows',
         'readable_memory_usage',
         'progress',
         'launched_merges',
-        'query_id as action',
+        'query_id AS action',
         'readable_read_bytes',
         'readable_written_bytes',
         'thread_count',
@@ -126,6 +154,16 @@ describe('Running Queries Version Selection', () => {
         expect(v23).toContain(col)
         expect(v24).toContain(col)
       }
+    })
+
+    it('should avoid SELECT star for the frequently refreshed table', () => {
+      const sql = selectVersionedSql(
+        runningQueriesConfig.sql,
+        parseVersion('24.1.0.0')
+      )
+
+      expect(sql).not.toContain('SELECT *')
+      expect(sql).not.toContain('SELECT *,')
     })
 
     it('should configure the compact running-query summary table shape', () => {
@@ -274,21 +312,18 @@ describe('Version Selection Edge Cases', () => {
 })
 
 describe('getSqlForDisplay vs selectVersionedSql', () => {
-  // This test documents the behavior with single (non-versioned) query
-  it('getSqlForDisplay and selectVersionedSql return same query for single query config', () => {
+  it('getSqlForDisplay returns the latest running queries SQL variant', () => {
     const { getSqlForDisplay } = require('@/types/query-config')
 
     const displaySql = getSqlForDisplay(runningQueriesConfig.sql)
     const executionSql = selectVersionedSql(
       runningQueriesConfig.sql,
-      parseVersion('23.8.0.0')
+      parseVersion('25.3.0.0')
     )
 
-    // Both should return the same single query (no versioning)
     expect(displaySql).not.toContain('peak_threads_usage')
     expect(executionSql).not.toContain('peak_threads_usage')
-
-    // Both queries should be identical
+    expect(displaySql).toContain('normalized_query_hash')
     expect(displaySql).toBe(executionSql)
   })
 })

--- a/lib/__tests__/versioned-sql.test.ts
+++ b/lib/__tests__/versioned-sql.test.ts
@@ -10,6 +10,7 @@ import { parseVersion, selectVersionedSql } from '@/lib/clickhouse-version'
 import { queries } from '@/lib/query-config'
 import { queryViewsLogConfig } from '@/lib/query-config/queries/query-views-log'
 import { runningQueriesConfig } from '@/lib/query-config/queries/running-queries'
+import { ColumnFormat } from '@/types/column-format'
 
 describe('Running Queries Version Selection', () => {
   describe('SQL variant selection', () => {
@@ -114,12 +115,25 @@ describe('Running Queries Version Selection', () => {
         'readable_memory_usage',
         'progress',
         'launched_merges',
+        'query_id as action',
+        'readable_read_bytes',
+        'readable_written_bytes',
+        'thread_count',
+        'interface_label',
       ]
 
       for (const col of commonColumns) {
         expect(v23).toContain(col)
         expect(v24).toContain(col)
       }
+    })
+
+    it('should configure the compact running-query summary table shape', () => {
+      expect(runningQueriesConfig.columns).toEqual(['action', 'query'])
+      expect(runningQueriesConfig.columnFormats?.query).toBe(
+        ColumnFormat.RunningQuerySummary
+      )
+      expect(runningQueriesConfig.columnFormats?.action).toBeTruthy()
     })
   })
 })

--- a/lib/__tests__/versioned-sql.test.ts
+++ b/lib/__tests__/versioned-sql.test.ts
@@ -65,15 +65,7 @@ describe('Running Queries Version Selection', () => {
 
       // peak_threads_usage is NOT available in ClickHouse 24.x+
       expect(sql).not.toContain('peak_threads_usage')
-      expect(sql).toContain('NULL AS normalized_query_hash')
-    })
-
-    it('should select normalized query hash for ClickHouse 25.3+', () => {
-      const version = parseVersion('25.3.0.0')
-      const sql = selectVersionedSql(runningQueriesConfig.sql, version)
-
-      expect(sql).toContain('normalized_query_hash')
-      expect(sql).not.toContain('NULL AS normalized_query_hash')
+      expect(sql).not.toContain('normalized_query_hash')
     })
 
     it('should fallback to oldest variant when version is null', () => {
@@ -312,7 +304,7 @@ describe('Version Selection Edge Cases', () => {
 })
 
 describe('getSqlForDisplay vs selectVersionedSql', () => {
-  it('getSqlForDisplay returns the latest running queries SQL variant', () => {
+  it('getSqlForDisplay and selectVersionedSql return same running queries SQL', () => {
     const { getSqlForDisplay } = require('@/types/query-config')
 
     const displaySql = getSqlForDisplay(runningQueriesConfig.sql)
@@ -323,7 +315,7 @@ describe('getSqlForDisplay vs selectVersionedSql', () => {
 
     expect(displaySql).not.toContain('peak_threads_usage')
     expect(executionSql).not.toContain('peak_threads_usage')
-    expect(displaySql).toContain('normalized_query_hash')
+    expect(displaySql).not.toContain('normalized_query_hash')
     expect(displaySql).toBe(executionSql)
   })
 })

--- a/lib/query-config/queries/running-queries.ts
+++ b/lib/query-config/queries/running-queries.ts
@@ -7,14 +7,17 @@ export const runningQueriesConfig: QueryConfig = {
   refreshInterval: 30_000,
   sql: `
     SELECT *,
+      query_id as action,
       query_id as query_detail,
       multiIf (elapsed < 30, format('{} seconds', round(elapsed, 1)),
                elapsed < 90, 'a minute',
                formatReadableTimeDelta(elapsed, 'days', 'minutes')) as readable_elapsed,
       round(100 * elapsed / nullIf(max(elapsed) OVER (), 0)) AS pct_elapsed,
       formatReadableQuantity(read_rows) as readable_read_rows,
+      formatReadableSize(read_bytes) as readable_read_bytes,
       round(100 * read_rows / nullIf(max(read_rows) OVER (), 0)) AS pct_read_rows,
       formatReadableQuantity(written_rows) as readable_written_rows,
+      formatReadableSize(written_bytes) as readable_written_bytes,
       round(100 * written_rows / nullIf(max(written_rows) OVER (), 0)) AS pct_written_rows,
       formatReadableQuantity(total_rows_approx) as readable_total_rows_approx,
       formatReadableSize(peak_memory_usage) as readable_peak_memory_usage,
@@ -34,30 +37,21 @@ export const runningQueriesConfig: QueryConfig = {
       formatReadableTimeDelta(ProfileEvents['PartsLockHoldMicroseconds'] / 1000 / 1000) AS parts_lock_hold,
       ProfileEvents['FileOpen'] AS file_open,
       ProfileEvents['ContextLock'] AS context_lock,
-      ProfileEvents['RWLockAcquiredReadLocks'] AS rw_lock_acquired_read_locks
+      ProfileEvents['RWLockAcquiredReadLocks'] AS rw_lock_acquired_read_locks,
+      length(thread_ids) AS thread_count,
+      multiIf(interface = 1, 'TCP',
+              interface = 2, 'HTTP',
+              interface = 3, 'gRPC',
+              interface = 4, 'MySQL',
+              interface = 5, 'PostgreSQL',
+              interface = 6, 'Local',
+              interface = 7, 'Interserver',
+              toString(interface)) AS interface_label
     FROM system.processes
     WHERE is_cancelled = 0
-    ORDER BY elapsed
+    ORDER BY elapsed DESC
   `,
-  columns: [
-    'action',
-    'query',
-    'query_detail',
-    'user',
-    'readable_memory_usage',
-    'readable_elapsed',
-    'progress',
-    'readable_read_rows',
-    'readable_written_rows',
-    'launched_merges',
-    'rows_before_merge',
-    'bytes_before_merge',
-    'merges_time',
-    'file_open',
-    'parts_lock_hold',
-    'context_lock',
-    'rw_lock_acquired_read_locks',
-  ],
+  columns: ['action', 'query'],
   rowClassName: (row) => {
     // elapsed is in seconds for running queries
     const elapsed = Number(row.elapsed || 0)
@@ -73,31 +67,7 @@ export const runningQueriesConfig: QueryConfig = {
       ColumnFormat.InlineAction,
       ['kill-query', 'analyze-with-ai', 'open-in-explorer'],
     ],
-    query: [
-      ColumnFormat.CodeDialog,
-      {
-        max_truncate: 80,
-        hide_query_comment: true,
-        dialog_title: 'Running Query',
-        trigger_classname: '-ml-1 w-full min-w-0 sm:-ml-2',
-      },
-    ],
-    query_detail: [
-      ColumnFormat.Link,
-      {
-        href: '/query?query_id=[query_id]&host=[ctx.hostId]',
-        className: 'max-w-32 truncate',
-        title: 'Query Detail',
-      },
-    ],
-    user: ColumnFormat.ColoredBadge,
-    estimated_remaining_time: ColumnFormat.Duration,
-    readable_elapsed: ColumnFormat.BackgroundBar,
-    readable_read_rows: ColumnFormat.BackgroundBar,
-    readable_written_rows: ColumnFormat.BackgroundBar,
-    readable_memory_usage: ColumnFormat.BackgroundBar,
-    progress: ColumnFormat.BackgroundBar,
-    file_open: ColumnFormat.Number,
+    query: ColumnFormat.RunningQuerySummary,
   },
   relatedCharts: [
     [

--- a/lib/query-config/queries/running-queries.ts
+++ b/lib/query-config/queries/running-queries.ts
@@ -3,43 +3,55 @@ import type { QueryConfig } from '@/types/query-config'
 import { QUERY_COMMENT } from '@/lib/clickhouse/constants'
 import { ColumnFormat } from '@/types/column-format'
 
-export const runningQueriesConfig: QueryConfig = {
-  name: 'running-queries',
-  refreshInterval: 30_000,
-  sql: `
+function buildRunningQueriesSql({
+  includeNormalizedQueryHash,
+}: {
+  includeNormalizedQueryHash: boolean
+}): string {
+  return `
     ${QUERY_COMMENT}
-    SELECT *,
-      query_id as action,
-      query_id as query_detail,
+    SELECT
+      query_id,
+      query,
+      query_kind,
+      user,
+      current_database,
+      initial_query_id,
+      address,
+      port,
+      interface,
+      client_name,
+      client_hostname,
+      distributed_depth,
+      elapsed,
+      read_rows,
+      read_bytes,
+      total_rows_approx,
+      written_rows,
+      written_bytes,
+      memory_usage,
+      peak_memory_usage,
+      ${
+        includeNormalizedQueryHash
+          ? 'normalized_query_hash'
+          : 'NULL AS normalized_query_hash'
+      },
+      query_id AS action,
       multiIf (elapsed < 30, format('{} seconds', round(elapsed, 1)),
                elapsed < 90, 'a minute',
-               formatReadableTimeDelta(elapsed, 'days', 'minutes')) as readable_elapsed,
-      round(100 * elapsed / nullIf(max(elapsed) OVER (), 0)) AS pct_elapsed,
-      formatReadableQuantity(read_rows) as readable_read_rows,
-      formatReadableSize(read_bytes) as readable_read_bytes,
-      round(100 * read_rows / nullIf(max(read_rows) OVER (), 0)) AS pct_read_rows,
-      formatReadableQuantity(written_rows) as readable_written_rows,
-      formatReadableSize(written_bytes) as readable_written_bytes,
-      round(100 * written_rows / nullIf(max(written_rows) OVER (), 0)) AS pct_written_rows,
-      formatReadableQuantity(total_rows_approx) as readable_total_rows_approx,
-      formatReadableSize(peak_memory_usage) as readable_peak_memory_usage,
+               formatReadableTimeDelta(elapsed, 'days', 'minutes')) AS readable_elapsed,
+      formatReadableQuantity(read_rows) AS readable_read_rows,
+      formatReadableSize(read_bytes) AS readable_read_bytes,
+      formatReadableQuantity(written_rows) AS readable_written_rows,
+      formatReadableSize(written_bytes) AS readable_written_bytes,
+      formatReadableSize(peak_memory_usage) AS readable_peak_memory_usage,
       multiIf (
         memory_usage = 0, formatReadableSize(memory_usage),
         formatReadableSize(memory_usage) = formatReadableSize(peak_memory_usage), formatReadableSize(memory_usage),
         formatReadableSize(memory_usage) || ' (peak ' || readable_peak_memory_usage || ')'
-      ) as readable_memory_usage,
-      round(100 * memory_usage / nullIf(max(memory_usage) OVER (), 0)) AS pct_memory_usage,
+      ) AS readable_memory_usage,
       if(total_rows_approx > 0 AND query_kind = 'Select', toString(round((100 * read_rows) / total_rows_approx, 2)) || '%', '') AS progress,
-      if(total_rows_approx > 0 AND query_kind = 'Select', round((100 * read_rows) / total_rows_approx, 2), 0) AS pct_progress,
-      if(total_rows_approx > 0 AND read_rows > 0, (elapsed / (read_rows / total_rows_approx)) * (1 - (read_rows / total_rows_approx)), NULL) AS estimated_remaining_time,
       formatReadableQuantity(ProfileEvents['Merge']) AS launched_merges,
-      formatReadableQuantity(ProfileEvents['MergedRows']) AS rows_before_merge,
-      formatReadableSize(ProfileEvents['MergedUncompressedBytes']) AS bytes_before_merge,
-      formatReadableTimeDelta(ProfileEvents['MergesTimeMilliseconds'] / 1000, 'days', 'minutes') AS merges_time,
-      formatReadableTimeDelta(ProfileEvents['PartsLockHoldMicroseconds'] / 1000 / 1000) AS parts_lock_hold,
-      ProfileEvents['FileOpen'] AS file_open,
-      ProfileEvents['ContextLock'] AS context_lock,
-      ProfileEvents['RWLockAcquiredReadLocks'] AS rw_lock_acquired_read_locks,
       length(thread_ids) AS thread_count,
       multiIf(interface = 1, 'TCP',
               interface = 2, 'HTTP',
@@ -52,7 +64,24 @@ export const runningQueriesConfig: QueryConfig = {
     FROM system.processes
     WHERE is_cancelled = 0
     ORDER BY elapsed DESC
-  `,
+  `
+}
+
+export const runningQueriesConfig: QueryConfig = {
+  name: 'running-queries',
+  refreshInterval: 30_000,
+  sql: [
+    {
+      since: '23.8',
+      description: 'Base system.processes projection',
+      sql: buildRunningQueriesSql({ includeNormalizedQueryHash: false }),
+    },
+    {
+      since: '25.3',
+      description: 'Includes normalized_query_hash from system.processes',
+      sql: buildRunningQueriesSql({ includeNormalizedQueryHash: true }),
+    },
+  ],
   columns: ['action', 'query'],
   rowClassName: (row) => {
     // elapsed is in seconds for running queries

--- a/lib/query-config/queries/running-queries.ts
+++ b/lib/query-config/queries/running-queries.ts
@@ -1,11 +1,13 @@
 import type { QueryConfig } from '@/types/query-config'
 
+import { QUERY_COMMENT } from '@/lib/clickhouse/constants'
 import { ColumnFormat } from '@/types/column-format'
 
 export const runningQueriesConfig: QueryConfig = {
   name: 'running-queries',
   refreshInterval: 30_000,
   sql: `
+    ${QUERY_COMMENT}
     SELECT *,
       query_id as action,
       query_id as query_detail,

--- a/lib/query-config/queries/running-queries.ts
+++ b/lib/query-config/queries/running-queries.ts
@@ -3,12 +3,10 @@ import type { QueryConfig } from '@/types/query-config'
 import { QUERY_COMMENT } from '@/lib/clickhouse/constants'
 import { ColumnFormat } from '@/types/column-format'
 
-function buildRunningQueriesSql({
-  includeNormalizedQueryHash,
-}: {
-  includeNormalizedQueryHash: boolean
-}): string {
-  return `
+export const runningQueriesConfig: QueryConfig = {
+  name: 'running-queries',
+  refreshInterval: 30_000,
+  sql: `
     ${QUERY_COMMENT}
     SELECT
       query_id,
@@ -31,11 +29,6 @@ function buildRunningQueriesSql({
       written_bytes,
       memory_usage,
       peak_memory_usage,
-      ${
-        includeNormalizedQueryHash
-          ? 'normalized_query_hash'
-          : 'NULL AS normalized_query_hash'
-      },
       query_id AS action,
       multiIf (elapsed < 30, format('{} seconds', round(elapsed, 1)),
                elapsed < 90, 'a minute',
@@ -64,24 +57,7 @@ function buildRunningQueriesSql({
     FROM system.processes
     WHERE is_cancelled = 0
     ORDER BY elapsed DESC
-  `
-}
-
-export const runningQueriesConfig: QueryConfig = {
-  name: 'running-queries',
-  refreshInterval: 30_000,
-  sql: [
-    {
-      since: '23.8',
-      description: 'Base system.processes projection',
-      sql: buildRunningQueriesSql({ includeNormalizedQueryHash: false }),
-    },
-    {
-      since: '25.3',
-      description: 'Includes normalized_query_hash from system.processes',
-      sql: buildRunningQueriesSql({ includeNormalizedQueryHash: true }),
-    },
-  ],
+  `,
   columns: ['action', 'query'],
   rowClassName: (row) => {
     // elapsed is in seconds for running queries

--- a/types/column-format.ts
+++ b/types/column-format.ts
@@ -15,6 +15,7 @@ export enum ColumnFormat {
   NumberShort = 'number-short',
   CodeToggle = 'code-toggle',
   CodeDialog = 'code-dialog',
+  RunningQuerySummary = 'running-query-summary',
   HoverCard = 'hover-card',
   Duration = 'duration',
   Markdown = 'markdown',


### PR DESCRIPTION
## Summary
- Replace the wide Running Queries table with a responsive process summary row.
- Show query text, query id, user/database, elapsed, memory, progress, read/write IO, threads, client, host, interface, address, initial query id, hash, and merges in one row.
- Keep ClickHouse version compatibility by using baseline system.processes fields in SQL and rendering newer fields like peak_threads_usage only when returned by SELECT *.

## Verification
- bunx biome check types/column-format.ts components/data-table/cells/code-dialog-format.tsx components/data-table/cells/running-query-summary-format.tsx components/data-table/formatters/context-formatters.tsx components/data-table/formatters/index.tsx components/data-table/formatters/index.cy.tsx lib/query-config/queries/running-queries.ts lib/__tests__/versioned-sql.test.ts
- bun --smol --env-file=.env.local test --max-concurrency=1 --preload ./.sisyphus/swr-mock-preload.ts lib/__tests__/versioned-sql.test.ts
- bun run type-check
- bunx cypress run --component --spec components/data-table/formatters/index.cy.tsx
- bun run build
- pre-commit: lint-staged Biome + TypeScript type-check
- pre-push: biome check .

## Review
- CodeRabbit CLI completed with 8 findings in files outside this PR diff; skipped as unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned running-queries summary view with badges, metrics, and a card-style detail layout.
  * Option to force the full dialog display for query content regardless of length.

* **Improvements**
  * Compacted running-queries table to a two-column layout (action + query summary).
  * Query list now shows most recent queries first.

* **Tests**
  * Added UI and unit tests covering the new summary formatter and host-aware links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->