### PR TITLE
fix(query): guest visibility for /query + history-queries column overflow

### DIFF
--- a/cypress/e2e/authentication.cy.ts
+++ b/cypress/e2e/authentication.cy.ts
@@ -185,9 +185,11 @@ describe('Authentication', () => {
       cy.get('[data-testid="nav-user-trigger"]').should('have.focus')
 
       // Press Enter to open menu
-        // Keep this force override while the transient overlay cleanup is flaky; it
-        // should be removed once the overlay lifecycle is fully deterministic.
-      cy.get('[data-testid="nav-user-trigger"]').type('{enter}', { force: true })
+      // Keep this force override while the transient overlay cleanup is flaky; it
+      // should be removed once the overlay lifecycle is fully deterministic.
+      cy.get('[data-testid="nav-user-trigger"]').type('{enter}', {
+        force: true,
+      })
       cy.get('[data-testid="nav-user-about"]').should('be.visible')
     })
 

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -14,7 +14,12 @@ describe('Navigation Smoke Tests', () => {
   })
 
   it('should navigate between main pages', () => {
-    const mainPages: string[] = ['/overview', '/dashboard', '/clusters', '/merges']
+    const mainPages: string[] = [
+      '/overview',
+      '/dashboard',
+      '/clusters',
+      '/merges',
+    ]
 
     mainPages.forEach((page) => {
       cy.visit(`${page}?host=0`)

--- a/lib/query-config/queries/history-queries.ts
+++ b/lib/query-config/queries/history-queries.ts
@@ -366,6 +366,7 @@ ${historyQueryTail}
         hide_query_comment: true,
         dialog_title: 'Query',
         trigger_classname: '!max-w-[280px] overflow-hidden',
+        force_dialog: true,
       },
     ],
     event_time: ColumnFormat.RelatedTime,

--- a/lib/query-config/queries/query-detail.ts
+++ b/lib/query-config/queries/query-detail.ts
@@ -7,6 +7,7 @@ export const queryDetailConfig: QueryConfig = {
   name: 'query-detail',
   description: 'Detailed information about a specific query execution',
   docs: QUERY_LOG,
+  permission: { feature: 'queries' },
   tableCheck: 'system.query_log',
   sql: [
     {


### PR DESCRIPTION
## Summary

- **A1**: `/query` detail page now loads for guest users on preview.chmonitor.dev
- **A2**: `query` column in `/history-queries` no longer overflows into neighbouring columns

## A1 — Guest visibility for `/query`

**Root cause**: The `/api/v1/tables/query-detail` endpoint has no explicit `permission` on `queryDetailConfig`, so it falls back to `TABLES_FEATURE_PERMISSION` (`{ feature: 'tables' }`). On preview, `tables` requires authentication. Running-queries and history-queries work for guests because their API routes have separate `queries`-scoped permissions or also fall back to tables — but the page-level `FeatureRouteGate` passes through for `/query` (not in the menu), so only the API call was blocked.

**Option chosen: (a)** — added `permission: { feature: 'queries' }` to `queryDetailConfig`.

Why not (b) or (c): The route group layout and `FeatureRouteGate` are not blocking the page — the gate returns children when the path isn't in the menu. Moving the page out of the dashboard layout would break the sidebar/header. Flipping an existing config would have broader side-effects. Adding the `queries` permission is targeted and correct: the query-detail page is a drill-down from the queries section and should share the same feature gate.

## A2 — `query` column overflow in `/history-queries`

**Root cause**: `CodeDialogFormat` has two rendering paths. When `formatted.length < max_truncate` (100 chars), it renders a plain `<code className="whitespace-nowrap">` with no width cap. Queries shorter than 100 chars but still wide at monospace 12px (e.g., a 90-char SQL ≈ 630px) overflow a 360px column because the `<td>` has no `overflow: hidden`.

**Fix**: Added `force_dialog: true` to the `query` column format options. This routes all values through the dialog-trigger path, which already has `truncate + !max-w-[280px] overflow-hidden` via `trigger_classname`. No component changes needed — this is a column-config-level fix.

## Notes

- The `e2e-test` CI job has a known `timeout-minutes: 25` that the suite deterministically exceeds (no assertion failures, just cancelled). This is a pre-existing issue documented in `memory/chm-redesign-followup.md`. It is not caused by these changes.
- A second commit in this PR (`chore(biome)`) fixes pre-existing Biome format drift in two Cypress test files that were blocking the pre-push hook.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Allow guest access to the query detail page and prevent query text from overflowing in the history queries table.

New Features:
- Enable guest users to access the /query detail page by aligning its permission with other queries features.

Bug Fixes:
- Prevent the query column in /history-queries from overflowing by consistently rendering values through the dialog-based truncated view.

Tests:
- Apply Biome formatting fixes to existing Cypress end-to-end tests without changing their behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reformatted accessibility and navigation test cases for improved readability.

* **Bug Fixes**
  * History queries now consistently display in dialog format for better usability.
  * Query detail view now enforces proper access control requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->