### PR TITLE
fix(auth): restore tables-gated access for query detail

### DIFF
--- a/lib/query-config/queries/query-detail.ts
+++ b/lib/query-config/queries/query-detail.ts
@@ -7,7 +7,6 @@ export const queryDetailConfig: QueryConfig = {
   name: 'query-detail',
   description: 'Detailed information about a specific query execution',
   docs: QUERY_LOG,
-  permission: { feature: 'queries' },
   tableCheck: 'system.query_log',
   sql: [
     {


### PR DESCRIPTION
### Motivation
- Revert the authorization regression that exposed sensitive `system.query_log` rows by removing the per-config `queries` feature permission so the table route falls back to the `tables` gate.

### Description
- Remove `permission: { feature: 'queries' }` from `lib/query-config/queries/query-detail.ts` so `/api/v1/tables/query-detail` uses the `TABLES_FEATURE_PERMISSION` fallback while keeping the same `tableCheck` and SQL output.

### Testing
- Ran `bun run build` in this environment and it failed with `Script not found "next"`, so the change is unbuilt here but is a single-line removal with no functional SQL changes and preserves existing behavior when the `tables` feature is enforced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11170beb18833294733abc81b8d817)