### PR TITLE
fix: running-queries TypeError and history-queries alignment

### DIFF
--- a/components/running-queries/running-queries-table.tsx
+++ b/components/running-queries/running-queries-table.tsx
@@ -211,7 +211,7 @@ function derive(row: RunningQueryRow): DerivedQuery {
     row.address || 'unknown',
     row.port?.toString() || '0',
     queryText.slice(0, 64),
-  ].map((value) => value.trim())
+  ].map((value) => String(value).trim())
 
   const key = queryId || fallbackKeyParts.join('|')
 

--- a/lib/query-config/queries/history-queries.ts
+++ b/lib/query-config/queries/history-queries.ts
@@ -377,7 +377,7 @@ ${historyQueryTail}
       ColumnFormat.Link,
       {
         href: '/query?query_id=[query_id]&host=[ctx.hostId]',
-        className: 'truncate max-w-48 text-wrap',
+        className: 'truncate max-w-48',
         title: 'Query Detail',
       },
     ],


### PR DESCRIPTION
## Summary
- Fix `TypeError: e.trim is not a function` on `/running-queries` — ClickHouse returns `interface` as UInt8, wrapping in `String()` before `.trim()` handles non-string values
- Fix table row alignment on `/history-queries` — remove conflicting `text-wrap` from query_id Link (conflicts with `truncate`'s `white-space: nowrap`)

## Test plan
- [ ] Verify `/running-queries?host=1` loads without TypeError
- [ ] Verify `/history-queries?host=1` table rows have consistent height and alignment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query row key generation to robustly handle various input value types
  * Enhanced query ID column display styling for better text rendering and truncation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->