### PR TITLE
fix(data-table): vertically center cell content

### DIFF
--- a/components/data-table/renderers/table-body.tsx
+++ b/components/data-table/renderers/table-body.tsx
@@ -26,7 +26,7 @@ import { TableCell, TableRow } from '@/components/ui/table'
 import { cn } from '@/lib/utils'
 
 const VIRTUALIZED_CELL_CLASS = 'text-sm whitespace-nowrap tabular-nums'
-const STANDARD_CELL_CLASS = 'text-sm align-top break-words tabular-nums'
+const STANDARD_CELL_CLASS = 'text-sm align-middle break-words tabular-nums'
 const DEFAULT_COLUMN_SIZE = 150
 
 function getCellWidth<TData extends RowData>(cell: Cell<TData, unknown>) {


### PR DESCRIPTION
## Summary
- Change `STANDARD_CELL_CLASS` from `align-top` to `align-middle` so cell content (badges, text, background bars) renders centered vertically within each row

## Test plan
- [ ] All data tables show cell content vertically centered within rows
- [ ] Badges, duration text, and background bars align with row height

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated table cell vertical alignment from top to center for improved visual consistency in data tables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->