### PR TITLE
feat(agent): use @preset/chmonitor as default model

### DIFF
--- a/lib/ai/agent-model-registry.ts
+++ b/lib/ai/agent-model-registry.ts
@@ -18,9 +18,17 @@ export interface ModelEntry {
   providers: string[]
 }
 
-export const DEFAULT_AGENT_MODEL = 'openrouter:openrouter/free'
+export const DEFAULT_AGENT_MODEL = 'anyrouter:@preset/chmonitor'
 
 export const MODEL_REGISTRY: readonly ModelEntry[] = [
+  // ── Presets (auto-routing via AnyRouter) ──
+  {
+    id: '@preset/chmonitor',
+    description: 'Preset: ClickHouse Monitor agent routing',
+    contextLength: 200_000,
+    providers: ['anyrouter'],
+  },
+
   // ── OpenRouter auto-routers ──
   {
     id: 'openrouter/free',

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -122,6 +122,10 @@ CLICKHOUSE_MAX_EXECUTION_TIME = "60"
 # Required because Workers runtime doesn't support Node.js net/tls modules.
 CLOUDFLARE_WORKERS = "1"
 
+# Default model for AI agent — uses the chmonitor preset via AnyRouter
+# Users can override via the UI dropdown at runtime.
+LLM_MODEL = "anyrouter:@preset/chmonitor"
+
 # OpenRouter identification headers for rankings/analytics
 # See: https://openrouter.ai/docs#hosts
 OPENROUTER_REFERER = "https://clickhouse.duyet.net"


### PR DESCRIPTION
## Summary
- Switch default agent model from `openrouter:openrouter/free` to `anyrouter:@preset/chmonitor`
- Add `@preset/chmonitor` entry to the model registry (shown in the UI dropdown)
- Set `LLM_MODEL` in `wrangler.toml` production `[vars]` so Cloudflare Workers uses the preset

## Test plan
- [ ] Agent chat uses `@preset/chmonitor` by default
- [ ] UI dropdown shows the preset as first option
- [ ] Cloudflare Workers deployment has `LLM_MODEL` set correctly