### PR TITLE
fix(agents): polish chat UI and add thread title generation

### DIFF
--- a/components/agents/mentions/prompt-input-with-mentions.tsx
+++ b/components/agents/mentions/prompt-input-with-mentions.tsx
@@ -240,12 +240,12 @@ export function PromptInputTextareaWithMentions({
             disabled={buttonDisabled}
             aria-label={isLoading ? 'Stop response' : 'Send message'}
             className={cn(
-              'rounded-full transition-[transform,background-color,color] active:scale-[0.96]',
+              'rounded-full shadow-sm transition-[transform,background-color,color,box-shadow] active:scale-[0.96]',
               isLoading
                 ? 'bg-foreground text-background hover:bg-foreground/90'
                 : canSubmit
-                  ? 'bg-primary text-primary-foreground hover:bg-primary/90'
-                  : 'bg-muted text-muted-foreground'
+                  ? 'bg-primary text-primary-foreground shadow-md hover:bg-primary/90'
+                  : 'bg-muted text-muted-foreground shadow-none'
             )}
           >
             {isLoading ? (

--- a/components/agents/welcome/composer-toolbar.tsx
+++ b/components/agents/welcome/composer-toolbar.tsx
@@ -101,7 +101,12 @@ export function ComposerToolbar({
             <ChevronDownIcon className="size-2.5 opacity-60" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent align="start" sideOffset={4} className="w-[340px] p-1">
+        <PopoverContent
+          align="start"
+          sideOffset={4}
+          className="w-[340px] p-1"
+          collisionPadding={8}
+        >
           <div className="text-muted-foreground px-2 py-1.5 text-[10px] font-semibold tracking-wider uppercase">
             Skills
           </div>
@@ -183,7 +188,12 @@ export function ComposerToolbar({
             <ChevronDownIcon className="size-2.5 opacity-60" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent align="start" sideOffset={4} className="w-[320px] p-1">
+        <PopoverContent
+          align="start"
+          sideOffset={4}
+          className="w-[320px] p-1"
+          collisionPadding={8}
+        >
           <div className="text-muted-foreground flex items-center justify-between px-2 py-1.5 text-[10px] font-semibold tracking-wider uppercase">
             <span>Tools</span>
             <span className="text-muted-foreground/70 font-normal normal-case tabular-nums">

--- a/components/agents/welcome/recommendations-list.tsx
+++ b/components/agents/welcome/recommendations-list.tsx
@@ -3,13 +3,26 @@
 /**
  * Recommendation prompts shown on the AI Agent welcome screen, replacing the
  * old skills capability grid. Each row pairs a short category tag with a
- * full-text prompt; clicking the row injects the prompt into the composer so
- * the user can hit send (or edit it first).
+ * full-text prompt; clicking the row submits the prompt immediately.
  */
 
 import { ArrowRightIcon } from 'lucide-react'
 
 import { SUGGESTED_PROMPTS } from '@/components/agents/welcome/suggested-prompts'
+import { cn } from '@/lib/utils'
+
+const CATEGORY_COLORS: Record<string, string> = {
+  INSIGHTS:
+    'bg-violet-50 text-violet-700 dark:bg-violet-500/10 dark:text-violet-300',
+  SCHEMA: 'bg-blue-50 text-blue-700 dark:bg-blue-500/10 dark:text-blue-300',
+  STORAGE:
+    'bg-amber-50 text-amber-700 dark:bg-amber-500/10 dark:text-amber-300',
+  QUERIES:
+    'bg-emerald-50 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300',
+  ERRORS: 'bg-red-50 text-red-700 dark:bg-red-500/10 dark:text-red-300',
+  MERGES: 'bg-cyan-50 text-cyan-700 dark:bg-cyan-500/10 dark:text-cyan-300',
+  SYSTEM: 'bg-slate-50 text-slate-700 dark:bg-slate-500/10 dark:text-slate-300',
+}
 
 interface RecommendationsListProps {
   onPickPrompt?: (prompt: string) => void
@@ -32,27 +45,36 @@ export function RecommendationsList({
           Suggested questions
         </h3>
         <p className="text-muted-foreground text-[11.5px]">
-          Pick one to seed the composer — or write your own.
+          Pick one to get started — or write your own.
         </p>
       </div>
 
       <div className="border-border divide-border divide-y rounded-lg border">
-        {prompts.map((entry) => (
-          <button
-            key={entry.title}
-            type="button"
-            onClick={() => onPickPrompt?.(entry.prompt)}
-            className="hover:bg-muted/40 group flex w-full items-start gap-3 px-3 py-2.5 text-left transition-colors first:rounded-t-lg last:rounded-b-lg"
-          >
-            <span className="text-muted-foreground mt-0.5 w-16 shrink-0 text-[9.5px] font-semibold tracking-wider uppercase">
-              {entry.category}
-            </span>
-            <span className="text-foreground/90 flex-1 text-[12.5px] leading-snug">
-              {entry.prompt}
-            </span>
-            <ArrowRightIcon className="text-muted-foreground/60 group-hover:text-foreground mt-1 size-3 shrink-0" />
-          </button>
-        ))}
+        {prompts.map((entry) => {
+          const colorClass =
+            CATEGORY_COLORS[entry.category] ?? 'bg-muted text-muted-foreground'
+          return (
+            <button
+              key={entry.title}
+              type="button"
+              onClick={() => onPickPrompt?.(entry.prompt)}
+              className="hover:bg-muted/40 group flex w-full items-start gap-3 px-3 py-2.5 text-left transition-colors first:rounded-t-lg last:rounded-b-lg"
+            >
+              <span
+                className={cn(
+                  'mt-0.5 inline-flex shrink-0 rounded px-1.5 py-0.5 text-[9px] font-semibold leading-none tracking-wider uppercase',
+                  colorClass
+                )}
+              >
+                {entry.category}
+              </span>
+              <span className="text-foreground/90 flex-1 text-[12.5px] leading-snug">
+                {entry.prompt}
+              </span>
+              <ArrowRightIcon className="text-muted-foreground/60 group-hover:text-foreground mt-1 size-3 shrink-0" />
+            </button>
+          )
+        })}
       </div>
     </section>
   )

--- a/components/assistant-ui/thread.tsx
+++ b/components/assistant-ui/thread.tsx
@@ -33,7 +33,7 @@ import {
   useThread,
   useThreadRuntime,
 } from '@assistant-ui/react'
-import { type FC, useState } from 'react'
+import { type FC, useCallback, useState } from 'react'
 import { PromptInputTextareaWithMentions } from '@/components/agents/mentions'
 import { AgentWelcomeScreen } from '@/components/agents/welcome/agent-welcome-screen'
 import { ComposerToolbar } from '@/components/agents/welcome/composer-toolbar'
@@ -132,7 +132,19 @@ function ThreadWelcome({
   hasClusterIssue,
 }: ThreadWelcomeProps) {
   const { activeToolCount } = useAgentSkills()
-  const [composerValue, setComposerValue] = useState('')
+  const threadRuntime = useThreadRuntime()
+
+  const handlePickPrompt = useCallback(
+    (prompt: string) => {
+      const trimmed = prompt.trim()
+      if (!trimmed) return
+      threadRuntime.append({
+        role: 'user',
+        content: [{ type: 'text', text: trimmed }],
+      })
+    },
+    [threadRuntime]
+  )
 
   return (
     <ThreadPrimitive.Empty>
@@ -141,13 +153,8 @@ function ThreadWelcome({
         clusterName={clusterName}
         hasClusterIssue={hasClusterIssue}
         activeToolCount={activeToolCount}
-        composer={
-          <WelcomeComposer
-            value={composerValue}
-            onValueChange={setComposerValue}
-          />
-        }
-        onPickPrompt={(prompt) => setComposerValue(prompt)}
+        composer={<WelcomeComposer />}
+        onPickPrompt={handlePickPrompt}
       />
     </ThreadPrimitive.Empty>
   )
@@ -158,21 +165,13 @@ function ThreadWelcome({
  * tools · add-context). Wraps the same submission wiring as the in-thread
  * composer below.
  */
-function WelcomeComposer({
-  value,
-  onValueChange,
-}: {
-  value: string
-  onValueChange: (next: string) => void
-}) {
+function WelcomeComposer() {
   const threadRuntime = useThreadRuntime()
   const isRunning = useThread((thread) => thread.isRunning)
 
   return (
     <div className="flex flex-col gap-2">
       <PromptInputTextareaWithMentions
-        value={value}
-        onChange={onValueChange}
         isLoading={isRunning}
         onResolvedSubmit={(text) => {
           const trimmed = text.trim()
@@ -181,7 +180,6 @@ function WelcomeComposer({
             role: 'user',
             content: [{ type: 'text', text: trimmed }],
           })
-          onValueChange('')
         }}
         onStop={() => threadRuntime.cancelRun()}
       />

--- a/lib/conversation-store/adapter/d1-thread-list-adapter.tsx
+++ b/lib/conversation-store/adapter/d1-thread-list-adapter.tsx
@@ -22,6 +22,7 @@ import type {
 import { RuntimeAdapterProvider, useAui } from '@assistant-ui/react'
 import { createAssistantStream } from 'assistant-stream'
 import { type FC, type PropsWithChildren, useMemo } from 'react'
+import { generateTitleFromMessage } from '@/lib/ai/agent/conversation-utils'
 import {
   replaceHistoryItem,
   upsertHistoryItem,
@@ -267,8 +268,28 @@ export function createD1ThreadListAdapter(): RemoteThreadListAdapter {
     },
 
     async generateTitle(remoteId) {
-      void remoteId
-      return createAssistantStream(() => {})
+      const conversation = await apiGet(remoteId)
+      const messages = Array.isArray(conversation?.messages)
+        ? (conversation.messages as Array<Record<string, unknown>>)
+        : []
+      const firstUserMsg = messages.find((m) => m.role === 'user')
+      const text =
+        typeof firstUserMsg?.content === 'string'
+          ? firstUserMsg.content
+          : Array.isArray(firstUserMsg?.content)
+            ? (firstUserMsg.content as Array<{ text?: string }>)
+                .map((p) => p.text ?? '')
+                .join(' ')
+            : ''
+
+      const title = text ? generateTitleFromMessage(text) : 'New Chat'
+
+      // Persist the title server-side
+      await apiPut(remoteId, { title })
+
+      return createAssistantStream((controller) => {
+        controller.appendText(title)
+      })
     },
   }
 }

--- a/lib/conversation-store/adapter/local-thread-list-adapter.tsx
+++ b/lib/conversation-store/adapter/local-thread-list-adapter.tsx
@@ -20,6 +20,7 @@ import type {
 import { RuntimeAdapterProvider, useAui } from '@assistant-ui/react'
 import { createAssistantStream } from 'assistant-stream'
 import { type FC, type PropsWithChildren, useMemo } from 'react'
+import { generateTitleFromMessage } from '@/lib/ai/agent/conversation-utils'
 import {
   replaceHistoryItem,
   upsertHistoryItem,
@@ -196,10 +197,33 @@ export function createLocalThreadListAdapter(): RemoteThreadListAdapter {
     },
 
     async generateTitle(remoteId) {
-      // Title is derived from the first message during persistence; no LLM
-      // round-trip needed. Return an empty stream.
-      void remoteId
-      return createAssistantStream(() => {})
+      // Derive a title from the first user message in the stored conversation.
+      type Msg = { role: string; content?: string | Array<{ text?: string }> }
+      const repo = readJson<{ messages: Msg[] }>(messagesKey(remoteId), {
+        messages: [],
+      })
+      const firstUserMsg = repo.messages.find((m) => m.role === 'user')
+      const text =
+        typeof firstUserMsg?.content === 'string'
+          ? firstUserMsg.content
+          : Array.isArray(firstUserMsg?.content)
+            ? firstUserMsg.content.map((p) => p.text ?? '').join(' ')
+            : ''
+
+      const title = text ? generateTitleFromMessage(text) : 'New Chat'
+
+      // Persist the generated title
+      const threads = loadThreads()
+      const thread = threads.find((item) => item.remoteId === remoteId)
+      if (thread) {
+        thread.title = title
+        saveThreads(threads)
+      }
+
+      // Stream the title back so assistant-ui updates the thread list item
+      return createAssistantStream((controller) => {
+        controller.appendText(title)
+      })
     },
   }
 }


### PR DESCRIPTION
## Summary
- Add shadow to send button (`shadow-md` when active, `shadow-none` when disabled)
- Make suggested questions auto-submit on click (directly appends to thread runtime)
- Add distinct color badges per category: INSIGHTS (violet), SCHEMA (blue), STORAGE (amber), QUERIES (emerald), ERRORS (red), MERGES (cyan), SYSTEM (slate)
- Implement `generateTitle` in both localStorage and D1 thread adapters — derives title from first user message using existing `generateTitleFromMessage` utility
- Add `collisionPadding={8}` to skills/tools popovers to prevent overflow

## Test plan
- [ ] Send button shows shadow when text is entered
- [ ] Clicking a suggested question sends it immediately
- [ ] Category badges show distinct colors
- [ ] New threads auto-generate a title from the first message
- [ ] Skills/tools popovers don't overflow screen edges