### PR TITLE
feat(ui): adopt transitions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -421,3 +421,177 @@
     animation: rq-indeterminate 1.3s ease-in-out infinite;
   }
 }
+
+/* ---------------------------------------------------------------
+ * transitions.dev — copy-paste CSS snippets (https://transitions.dev)
+ *
+ * Source: https://github.com/Jakubantalik/transitions.dev
+ * Patterns: digit pop-in, text swap, success check, error shake.
+ *
+ * The :root custom properties and @keyframes are taken verbatim
+ * from the upstream snippets. The trigger classes are simplified
+ * to fire on element mount (paired with React `key` remount in
+ * usage sites) instead of the upstream is-animating/is-shaking
+ * class-toggle workflow.
+ * --------------------------------------------------------------- */
+
+:root {
+  /* Digit pop-in */
+  --digit-dur: 500ms;
+  --digit-distance: 8px;
+  --digit-blur: 2px;
+  --digit-ease: cubic-bezier(0.34, 1.45, 0.64, 1);
+  --digit-dir-x: 0;
+  --digit-dir-y: 1;
+
+  /* Text swap */
+  --text-swap-dur: 280ms;
+  --text-swap-translate-y: 6px;
+  --text-swap-blur: 4px;
+  --text-swap-ease: cubic-bezier(0.22, 1, 0.36, 1);
+
+  /* Success check */
+  --check-opacity-dur: 550ms;
+  --check-rotate-dur: 550ms;
+  --check-rotate-from: 80deg;
+  --check-bob-dur: 450ms;
+  --check-y-amount: 40px;
+  --check-blur-dur: 500ms;
+  --check-blur-from: 10px;
+  --check-path-dur: 550ms;
+  --check-path-delay: 80ms;
+  --check-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --check-ease-bob: cubic-bezier(0.34, 1.35, 0.64, 1);
+
+  /* Error shake */
+  --shake-distance: 6px;
+  --shake-overshoot: 4px;
+  --shake-dur-a: 80ms;
+  --shake-dur-b: 60ms;
+  --shake-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@layer utilities {
+  /* Digit pop-in: a number that fades + blurs + slides on every change. */
+  @keyframes t-digit-pop-in {
+    0% {
+      transform: translate(
+        calc(var(--digit-distance) * var(--digit-dir-x)),
+        calc(var(--digit-distance) * var(--digit-dir-y))
+      );
+      opacity: 0;
+      filter: blur(var(--digit-blur));
+    }
+    100% {
+      transform: translate(0, 0);
+      opacity: 1;
+      filter: blur(0);
+    }
+  }
+  .t-digit {
+    display: inline-block;
+    will-change: transform, opacity, filter;
+    animation: t-digit-pop-in var(--digit-dur) var(--digit-ease) both;
+  }
+
+  /* Text swap (enter half): blur + slide in when the text changes. */
+  @keyframes t-text-swap-in {
+    0% {
+      transform: translateY(var(--text-swap-translate-y));
+      filter: blur(var(--text-swap-blur));
+      opacity: 0;
+    }
+    100% {
+      transform: translateY(0);
+      filter: blur(0);
+      opacity: 1;
+    }
+  }
+  .t-text-swap {
+    display: inline-block;
+    will-change: transform, filter, opacity;
+    animation: t-text-swap-in var(--text-swap-dur) var(--text-swap-ease) both;
+  }
+
+  /* Success check: fade + rotate + Y-bob + blur on the wrapper, with an
+     SVG stroke draw on the path. Applied to a span wrapping a lucide icon. */
+  @keyframes t-check-fade {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+  @keyframes t-check-rotate {
+    from { transform: rotate(var(--check-rotate-from)); }
+    to { transform: rotate(0deg); }
+  }
+  @keyframes t-check-blur {
+    from { filter: blur(var(--check-blur-from)); }
+    to { filter: blur(0); }
+  }
+  @keyframes t-check-bob {
+    from { translate: 0 var(--check-y-amount); }
+    to { translate: 0 0; }
+  }
+  @keyframes t-check-draw {
+    to { stroke-dashoffset: 0; }
+  }
+  .t-success-check {
+    display: inline-block;
+    transform-origin: center;
+    will-change: transform, opacity, filter;
+    animation:
+      t-check-fade var(--check-opacity-dur) var(--check-ease-out) both,
+      t-check-rotate var(--check-rotate-dur) var(--check-ease-out) both,
+      t-check-blur var(--check-blur-dur) var(--check-ease-out) both,
+      t-check-bob var(--check-bob-dur) var(--check-ease-bob) both;
+  }
+  .t-success-check svg {
+    display: block;
+    overflow: visible;
+  }
+  .t-success-check svg path {
+    stroke-dasharray: 20;
+    stroke-dashoffset: 20;
+    animation: t-check-draw var(--check-path-dur) var(--check-ease-out)
+      var(--check-path-delay) both;
+  }
+
+  /* Error shake: short side-to-side oscillation on validation failure. */
+  @keyframes t-input-shake {
+    0% {
+      transform: translateX(0);
+      animation-timing-function: var(--shake-ease);
+    }
+    28.57% {
+      transform: translateX(var(--shake-distance));
+      animation-timing-function: var(--shake-ease);
+    }
+    57.14% {
+      transform: translateX(calc(var(--shake-distance) * -1));
+      animation-timing-function: var(--shake-ease);
+    }
+    78.57% {
+      transform: translateX(var(--shake-overshoot));
+      animation-timing-function: var(--shake-ease);
+    }
+    100% {
+      transform: translateX(0);
+    }
+  }
+  .t-error-shake {
+    will-change: transform;
+    animation: t-input-shake
+      calc(var(--shake-dur-a) * 2 + var(--shake-dur-b) * 2)
+      linear both;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .t-digit,
+    .t-text-swap,
+    .t-success-check,
+    .t-success-check svg path,
+    .t-error-shake {
+      animation: none !important;
+      transition: none !important;
+    }
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -593,5 +593,11 @@
       animation: none !important;
       transition: none !important;
     }
+    /* Without the draw animation the path would stay clipped at its
+       full stroke-dashoffset and render invisibly. Snap it to the final
+       drawn state so the check still appears for reduced-motion users. */
+    .t-success-check svg path {
+      stroke-dashoffset: 0 !important;
+    }
   }
 }

--- a/components/dashboard/chart-params.tsx
+++ b/components/dashboard/chart-params.tsx
@@ -8,9 +8,9 @@ import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { Button } from '@/components/ui/button'
+import { ShakeFormControl } from '@/components/forms/shake-form-control'
 import {
   Form,
-  FormControl,
   FormField,
   FormItem,
   FormLabel,
@@ -79,9 +79,9 @@ export const ChartParamsForm = ({
             render={({ field }) => (
               <FormItem>
                 <FormLabel>{key}</FormLabel>
-                <FormControl>
+                <ShakeFormControl>
                   <Input {...field} />
-                </FormControl>
+                </ShakeFormControl>
               </FormItem>
             )}
           />

--- a/components/data-table/cells/colored-badge-format.tsx
+++ b/components/data-table/cells/colored-badge-format.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react'
+import { memo, useEffect, useMemo, useRef } from 'react'
 import { cn } from '@/lib/utils'
 
 export interface ColoredBadgeOptions {
@@ -14,6 +14,11 @@ export const ColoredBadgeFormat = memo(function ColoredBadgeFormat({
   value,
   options,
 }: ColoredBadgeFormatProps): React.ReactNode {
+  const isFirstRenderRef = useRef(true)
+  useEffect(() => {
+    isFirstRenderRef.current = false
+  }, [])
+
   // Memoize expensive color calculation - includes dark mode variants
   const pickedColor = useMemo(() => {
     if (value == null || value === '' || typeof value === 'boolean') return ''
@@ -50,7 +55,12 @@ export const ColoredBadgeFormat = memo(function ColoredBadgeFormat({
         options?.className
       )}
     >
-      {value}
+      <span
+        key={String(value)}
+        className={isFirstRenderRef.current ? undefined : 't-text-swap'}
+      >
+        {value}
+      </span>
     </span>
   )
 })

--- a/components/forms/shake-form-control.tsx
+++ b/components/forms/shake-form-control.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import type { Slot } from '@radix-ui/react-slot'
+
+import { useEffect, useState } from 'react'
+import { FormControl, useFormField } from '@/components/ui/form'
+import { cn } from '@/lib/utils'
+
+const SHAKE_DURATION_MS = 320
+
+type ShakeFormControlProps = React.ComponentProps<typeof Slot>
+
+export function ShakeFormControl({
+  className,
+  ...props
+}: ShakeFormControlProps) {
+  const { error } = useFormField()
+  const [shake, setShake] = useState(false)
+
+  useEffect(() => {
+    if (!error) return
+    setShake(true)
+    const timer = setTimeout(() => setShake(false), SHAKE_DURATION_MS)
+    return () => clearTimeout(timer)
+  }, [error])
+
+  return (
+    <FormControl
+      {...props}
+      className={cn(className, shake && 't-error-shake')}
+    />
+  )
+}

--- a/components/forms/shake-form-control.tsx
+++ b/components/forms/shake-form-control.tsx
@@ -1,14 +1,15 @@
 'use client'
 
-import type { Slot } from '@radix-ui/react-slot'
-
 import { useEffect, useState } from 'react'
 import { FormControl, useFormField } from '@/components/ui/form'
 import { cn } from '@/lib/utils'
 
-const SHAKE_DURATION_MS = 320
+// Must stay in sync with the CSS `t-error-shake` animation duration in
+// app/globals.css: calc(var(--shake-dur-a) * 2 + var(--shake-dur-b) * 2)
+// which currently resolves to 280ms.
+const SHAKE_DURATION_MS = 280
 
-type ShakeFormControlProps = React.ComponentProps<typeof Slot>
+type ShakeFormControlProps = React.ComponentProps<typeof FormControl>
 
 export function ShakeFormControl({
   className,
@@ -18,7 +19,10 @@ export function ShakeFormControl({
   const [shake, setShake] = useState(false)
 
   useEffect(() => {
-    if (!error) return
+    if (!error) {
+      setShake(false)
+      return
+    }
     setShake(true)
     const timer = setTimeout(() => setShake(false), SHAKE_DURATION_MS)
     return () => clearTimeout(timer)

--- a/components/mcp/copy-button.tsx
+++ b/components/mcp/copy-button.tsx
@@ -30,7 +30,9 @@ export function CopyButton({ text, className, label }: CopyButtonProps) {
         onClick={handleCopy}
       >
         {copied ? (
-          <Check className="h-3.5 w-3.5 text-green-600" />
+          <span className="t-success-check">
+            <Check className="h-3.5 w-3.5 text-green-600" />
+          </span>
         ) : (
           <Copy className="h-3.5 w-3.5" />
         )}

--- a/components/menu/components/count-badge.tsx
+++ b/components/menu/components/count-badge.tsx
@@ -11,7 +11,7 @@
 import type { BadgeVariant } from '@/types/badge-variant'
 
 import { useMenuCount } from '../hooks/use-menu-count'
-import { memo } from 'react'
+import { memo, useEffect, useRef } from 'react'
 import { formatReadableQuantity } from '@/lib/format-readable'
 import { useHostId } from '@/lib/swr'
 import { cn } from '@/lib/utils'
@@ -29,6 +29,11 @@ export const CountBadge = memo(function CountBadge({
 }: CountBadgeProps) {
   const hostId = useHostId()
   const { count, isLoading } = useMenuCount(countKey, hostId)
+  const isFirstUpdateRef = useRef(true)
+
+  useEffect(() => {
+    isFirstUpdateRef.current = false
+  }, [])
 
   // Don't render if loading, no count, or count is 0
   if (isLoading || count === null || count === 0) {
@@ -50,7 +55,12 @@ export const CountBadge = memo(function CountBadge({
         variantClasses
       )}
     >
-      <span className="shrink-0">{formatReadableQuantity(count, 'short')}</span>
+      <span
+        key={count}
+        className={cn('shrink-0', !isFirstUpdateRef.current && 't-digit')}
+      >
+        {formatReadableQuantity(count, 'short')}
+      </span>
       {countLabel && (
         <span
           className={cn(

--- a/components/menu/components/count-badge.tsx
+++ b/components/menu/components/count-badge.tsx
@@ -29,10 +29,10 @@ export const CountBadge = memo(function CountBadge({
 }: CountBadgeProps) {
   const hostId = useHostId()
   const { count, isLoading } = useMenuCount(countKey, hostId)
-  const isFirstUpdateRef = useRef(true)
+  const isFirstRenderRef = useRef(true)
 
   useEffect(() => {
-    isFirstUpdateRef.current = false
+    isFirstRenderRef.current = false
   }, [])
 
   // Don't render if loading, no count, or count is 0
@@ -57,7 +57,7 @@ export const CountBadge = memo(function CountBadge({
     >
       <span
         key={count}
-        className={cn('shrink-0', !isFirstUpdateRef.current && 't-digit')}
+        className={cn('shrink-0', !isFirstRenderRef.current && 't-digit')}
       >
         {formatReadableQuantity(count, 'short')}
       </span>


### PR DESCRIPTION
## Summary

Adopts four copy-paste CSS patterns from [transitions.dev](https://transitions.dev) (by Jakub Antalik) and wires each into an existing surface that previously changed state silently. All snippets land in `app/globals.css` with their `:root` custom properties and a shared `@media (prefers-reduced-motion: reduce)` guard.

| Pattern (transitions.dev) | Surface | Trigger |
|---|---|---|
| `t-digit` (digit pop-in) | Sidebar `CountBadge` | SWR-driven value change (first mount stays static) |
| `t-text-swap` | `ColoredBadgeFormat` (e.g. query status `QueryStart` → `QueryFinish`) | Value change via `key={String(value)}` remount |
| `t-success-check` | `CopyButton` Check icon (fade + rotate + bob + SVG path draw) | Mounted while `copied === true` |
| `t-error-shake` | `ShakeFormControl` wrapper applied to `chart-params` form | `useFormField().error` becomes truthy |

The form pattern is delivered via a new `components/forms/shake-form-control.tsx` wrapper rather than editing `components/ui/form.tsx`, per the project rule that shadcn primitives stay pristine. Future forms can opt in by swapping `FormControl` for `ShakeFormControl`.

## Files changed

- `app/globals.css` — verbatim `:root` props + keyframes from upstream; trigger classes simplified to fire on mount (paired with React `key` remount at usage sites).
- `components/menu/components/count-badge.tsx` — `key={count}` + first-mount guard via `useRef`.
- `components/data-table/cells/colored-badge-format.tsx` — wraps `{value}` in a `t-text-swap` span keyed on value.
- `components/mcp/copy-button.tsx` — wraps the lucide `Check` in a `t-success-check` span.
- `components/forms/shake-form-control.tsx` — new wrapper; tracks `error`, toggles `t-error-shake` for ~320ms.
- `components/dashboard/chart-params.tsx` — opts into `ShakeFormControl`.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run build` — passes (TypeScript + Next.js production build)
- [x] `bun run test:unit` — 198 pass, 1 pre-existing failure in `lib/__tests__/versioned-sql.test.ts` unrelated to this change (verified by stashing the diff and re-running)
- [ ] Manual: open `/overview?host=0`, watch a sidebar counter with live data — digit should pop on update, not on first reveal
- [ ] Manual: open a query log table — status badge text should blur-swap when a row's status changes
- [ ] Manual: copy SQL via the request-info dialog — check icon should draw in
- [ ] Manual: tighten the `chart-params` zod schema (or any future form), submit with an invalid field — input should shake once and revert
- [ ] Manual: enable OS "Reduce motion" — all four animations should be suppressed

https://claude.ai/code/session_01SDwze6DKWQYrJHt6wVDmwH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDwze6DKWQYrJHt6wVDmwH)_

## Summary by Sourcery

Integrate accessible motion transitions for key UI state changes using transitions.dev patterns across badges, copy feedback, and form validation.

New Features:
- Animate sidebar count badge updates with a digit pop-in effect.
- Animate status badge text changes with a text swap transition.
- Animate the copy success icon with a success check transition.
- Add a reusable shaking form control wrapper to visually indicate validation errors.

Enhancements:
- Centralize transition-related custom properties, keyframes, and utility classes in globals.css with prefers-reduced-motion support.

Tests:
- Rely on existing unit test suite, linting, and build checks to validate the updated components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animated shake feedback for form validation errors
  * Success check animations for copy/confirmation actions
  * Digit pop-in and text-swap transitions for counters and dynamic text
  * Utility classes to apply these transitions across the UI

* **Accessibility**
  * Animations respect prefers-reduced-motion and disable when requested

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->