### PR TITLE
feat(charts): redesign Query Activity Heatmap with KPIs, click-through to history queries

### DIFF
--- a/components/charts/factory/create-custom-chart.tsx
+++ b/components/charts/factory/create-custom-chart.tsx
@@ -63,7 +63,7 @@ export function createCustomChart(
             data-testid={config.dataTestId}
             href={href}
           >
-            {config.render(dataArray, sql, hostId)}
+            {config.render(dataArray, sql, hostId, lastHours)}
           </ChartCard>
         )}
       </ChartContainer>

--- a/components/charts/factory/types.ts
+++ b/components/charts/factory/types.ts
@@ -48,7 +48,8 @@ export interface CustomChartFactoryConfig extends BaseChartFactoryConfig {
   render: (
     data: unknown[],
     sql: string | undefined,
-    hostId: number
+    hostId: number,
+    lastHours: number | undefined
   ) => React.ReactNode
   chartCardClassName?: string
   contentClassName?: string

--- a/components/charts/query/query-count-heatmap.tsx
+++ b/components/charts/query/query-count-heatmap.tsx
@@ -154,14 +154,11 @@ interface DerivedStats {
   avg: number
   activeHours: number
   dayTotals: number[] // index 0..6 → Mon..Sun
-  hourTotals: number[] // index 0..23
   maxDayTotal: number
-  maxHourTotal: number
 }
 
 function deriveStats(data: HeatmapCell[]): DerivedStats {
   const dayTotals = new Array(7).fill(0)
-  const hourTotals = new Array(24).fill(0)
   let total = 0
   let peak: HeatmapCell | null = null
   let quietest: HeatmapCell | null = null
@@ -171,9 +168,6 @@ function deriveStats(data: HeatmapCell[]): DerivedStats {
     total += cell.query_count
     if (cell.day_of_week >= 1 && cell.day_of_week <= 7) {
       dayTotals[cell.day_of_week - 1] += cell.query_count
-    }
-    if (cell.hour_of_day >= 0 && cell.hour_of_day <= 23) {
-      hourTotals[cell.hour_of_day] += cell.query_count
     }
     if (cell.query_count > 0) activeHours++
     if (!peak || cell.query_count > peak.query_count) peak = cell
@@ -192,9 +186,7 @@ function deriveStats(data: HeatmapCell[]): DerivedStats {
     avg: activeHours > 0 ? total / activeHours : 0,
     activeHours,
     dayTotals,
-    hourTotals,
     maxDayTotal: Math.max(...dayTotals, 0),
-    maxHourTotal: Math.max(...hourTotals, 0),
   }
 }
 
@@ -356,15 +348,20 @@ function HeatmapCellLink({
 function HeatmapBody({
   data,
   hostId,
+  lastHours,
 }: {
   data: HeatmapCell[]
   hostId: number
+  lastHours: number | undefined
 }) {
   const { settings } = useUserSettings()
   const timezone =
     settings.timezone ||
     Intl?.DateTimeFormat()?.resolvedOptions()?.timeZone ||
     'UTC'
+  // Drilldown window: bounded by the chart's data window so the resolved
+  // slot is guaranteed to live inside what the user can see.
+  const windowHours = Math.max(1, Math.round(lastHours ?? 24 * 7))
 
   if (data.length === 0) {
     return (
@@ -414,9 +411,6 @@ function HeatmapBody({
     formatCompactNumber(Math.round(t * maxCount))
   )
 
-  // windowHours: matches `defaultLastHours` on the chart definition.
-  const windowHours = 24 * 7
-
   return (
     <TooltipProvider delayDuration={0}>
       <div className="flex h-full flex-col gap-3 px-1 py-1">
@@ -425,7 +419,7 @@ function HeatmapBody({
           <KpiCard
             label="Total queries"
             value={formatCompactNumber(stats.total)}
-            hint={`${stats.activeHours}/168 active hours`}
+            hint={`${stats.activeHours}/${windowHours} active hours`}
           />
           <KpiCard
             label="Peak hour"
@@ -578,8 +572,12 @@ export const ChartQueryCountHeatmap = createCustomChart({
   defaultLastHours: 24 * 7,
   dataTestId: 'query-count-heatmap-chart',
   contentClassName: 'overflow-x-auto',
-  render: (dataArray, _sql, hostId) => (
-    <HeatmapBody data={dataArray as HeatmapCell[]} hostId={hostId} />
+  render: (dataArray, _sql, hostId, lastHours) => (
+    <HeatmapBody
+      data={dataArray as HeatmapCell[]}
+      hostId={hostId}
+      lastHours={lastHours}
+    />
   ),
 })
 

--- a/components/charts/query/query-count-heatmap.tsx
+++ b/components/charts/query/query-count-heatmap.tsx
@@ -12,6 +12,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { formatCompactNumber } from '@/lib/format-readable'
+import { useUserSettings } from '@/lib/hooks/use-user-settings'
 import { cn } from '@/lib/utils'
 
 interface HeatmapCell {
@@ -48,33 +49,85 @@ function getIntensityClass(value: number, max: number): string {
   return INTENSITY_TIERS[0]
 }
 
-/** ClickHouse toDayOfWeek convention (1=Mon..7=Sun) from a JS Date. */
-function jsDateToChDay(d: Date): number {
-  const js = d.getDay()
-  return js === 0 ? 7 : js
+/** ClickHouse toDayOfWeek convention (1=Mon..7=Sun) from a JS day-of-week index. */
+function jsDayToChDay(jsDay: number): number {
+  return jsDay === 0 ? 7 : jsDay
 }
 
-function isCurrentSlot(dayOfWeek: number, hour: number): boolean {
-  const now = new Date()
-  return jsDateToChDay(now) === dayOfWeek && now.getHours() === hour
+/** A wall-clock instant (no timezone). Operations on this object use JS `Date`
+ *  arithmetic, but the components reflect the user's selected timezone. */
+interface WallClock {
+  year: number
+  month: number // 1..12
+  day: number // 1..31
+  hour: number // 0..23
+  jsDayOfWeek: number // 0..6 (Sun=0)
+  asDate: Date // local-time Date whose components match the wall clock
+}
+
+/** Read the current wall clock in the given IANA timezone. */
+function nowInTimezone(timezone: string): WallClock {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    weekday: 'short',
+    hour12: false,
+  }).formatToParts(new Date())
+
+  const pick = (type: string) => parts.find((p) => p.type === type)?.value ?? ''
+  const year = Number(pick('year'))
+  const month = Number(pick('month'))
+  const day = Number(pick('day'))
+  // Intl reports "24" instead of "00" in some runtimes; coerce.
+  const hour = Number(pick('hour')) % 24
+  const weekdayShort = pick('weekday') // e.g. 'Mon'
+  const weekdayMap: Record<string, number> = {
+    Sun: 0,
+    Mon: 1,
+    Tue: 2,
+    Wed: 3,
+    Thu: 4,
+    Fri: 5,
+    Sat: 6,
+  }
+  const jsDayOfWeek = weekdayMap[weekdayShort] ?? 0
+  // Build a "fake-local" Date whose getFullYear/getMonth/... match the wall clock.
+  // This lets us use Date arithmetic (setHours) without bringing the host
+  // timezone into the math.
+  const asDate = new Date(year, month - 1, day, hour, 0, 0)
+  return { year, month, day, hour, jsDayOfWeek, asDate }
+}
+
+function isCurrentSlotIn(
+  timezone: string,
+  dayOfWeek: number,
+  hour: number
+): boolean {
+  const now = nowInTimezone(timezone)
+  return jsDayToChDay(now.jsDayOfWeek) === dayOfWeek && now.hour === hour
 }
 
 /**
- * Find the most-recent absolute Date matching (chDay, hour) within the last
- * `windowHours` hours from now. Returns null when the slot has not occurred
- * within the window.
+ * Find the most-recent wall-clock instant matching (chDay, hour) within the
+ * last `windowHours` hours from the current moment in `timezone`. Returns
+ * null when the slot has not occurred within the window.
  */
 function findMostRecentSlot(
+  timezone: string,
   chDay: number,
   hour: number,
   windowHours: number
 ): Date | null {
-  const now = new Date()
-  const probe = new Date(now)
-  probe.setMinutes(0, 0, 0)
-  // Walk back hour-by-hour until we match. Capped at windowHours iterations.
+  const now = nowInTimezone(timezone)
+  const probe = new Date(now.asDate.getTime())
   for (let i = 0; i <= windowHours; i++) {
-    if (jsDateToChDay(probe) === chDay && probe.getHours() === hour) {
+    const probeChDay = jsDayToChDay(probe.getDay())
+    if (probeChDay === chDay && probe.getHours() === hour) {
       return probe
     }
     probe.setHours(probe.getHours() - 1)
@@ -82,7 +135,7 @@ function findMostRecentSlot(
   return null
 }
 
-/** Format a Date into ClickHouse-friendly `YYYY-MM-DD HH:mm:ss` (local time). */
+/** Format a wall-clock Date as `YYYY-MM-DD HH:mm:ss`. */
 function formatChDateTime(d: Date): string {
   const pad = (n: number) => String(n).padStart(2, '0')
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
@@ -183,6 +236,7 @@ function KpiCard({ label, value, hint, accent = 'default' }: KpiCardProps) {
 
 interface CellLinkProps {
   hostId: number
+  timezone: string
   dayOfWeek: number
   hour: number
   windowHours: number
@@ -196,6 +250,7 @@ interface CellLinkProps {
 
 function HeatmapCellLink({
   hostId,
+  timezone,
   dayOfWeek,
   hour,
   windowHours,
@@ -207,14 +262,17 @@ function HeatmapCellLink({
   isCurrent,
 }: CellLinkProps) {
   const slotDate = useMemo(
-    () => findMostRecentSlot(dayOfWeek, hour, windowHours),
-    [dayOfWeek, hour, windowHours]
+    () => findMostRecentSlot(timezone, dayOfWeek, hour, windowHours),
+    [timezone, dayOfWeek, hour, windowHours]
   )
 
   const href = useMemo(() => {
     if (!slotDate) return null
+    // BETWEEN is inclusive on both ends in ClickHouse — use 59:59 so the
+    // exact next-hour boundary belongs to the next hour's drilldown.
     const end = new Date(slotDate)
     end.setHours(end.getHours() + 1)
+    end.setSeconds(end.getSeconds() - 1)
     const params = new URLSearchParams()
     params.set('host', String(hostId))
     params.set(
@@ -295,207 +353,234 @@ function HeatmapCellLink({
   return inner
 }
 
+function HeatmapBody({
+  data,
+  hostId,
+}: {
+  data: HeatmapCell[]
+  hostId: number
+}) {
+  const { settings } = useUserSettings()
+  const timezone =
+    settings.timezone ||
+    Intl?.DateTimeFormat()?.resolvedOptions()?.timeZone ||
+    'UTC'
+
+  if (data.length === 0) {
+    return (
+      <div className="text-muted-foreground flex h-32 items-center justify-center text-sm">
+        No query data available
+      </div>
+    )
+  }
+
+  // Build lookup: [day][hour] -> cell
+  const grid: Record<number, Record<number, HeatmapCell>> = {}
+  let maxCount = 0
+  for (const cell of data) {
+    if (!grid[cell.day_of_week]) grid[cell.day_of_week] = {}
+    grid[cell.day_of_week][cell.hour_of_day] = cell
+    if (cell.query_count > maxCount) maxCount = cell.query_count
+  }
+
+  const stats = deriveStats(data)
+  // Dense rank: ties share the same rank, next distinct count gets the
+  // sequential rank (1,2,2,3 rather than 1,2,2,4).
+  const sortedByCount = [...data].sort((a, b) => b.query_count - a.query_count)
+  const rankByKey = new Map<string, number>()
+  let denseRank = 0
+  let lastCount = Number.POSITIVE_INFINITY
+  for (const cell of sortedByCount) {
+    if (cell.query_count <= 0) continue
+    if (cell.query_count !== lastCount) {
+      denseRank += 1
+      lastCount = cell.query_count
+    }
+    rankByKey.set(`${cell.day_of_week}-${cell.hour_of_day}`, denseRank)
+  }
+  const totalActiveCells = sortedByCount.filter((c) => c.query_count > 0).length
+
+  const peakLabel = stats.peak
+    ? `${DAY_LABELS[stats.peak.day_of_week - 1]} ${String(stats.peak.hour_of_day).padStart(2, '0')}:00 · ${stats.peak.readable_count}`
+    : '—'
+  const quietestLabel = stats.quietest
+    ? `${DAY_LABELS[stats.quietest.day_of_week - 1]} ${String(stats.quietest.hour_of_day).padStart(2, '0')}:00 · ${stats.quietest.readable_count}`
+    : '—'
+
+  // Bucket boundaries for the legend (rounded). Skip numeric labels when
+  // there is no traffic — all buckets would collapse to "≥ 0".
+  const hasTraffic = maxCount > 0
+  const legendBuckets = TIER_THRESHOLDS.slice(1).map((t) =>
+    formatCompactNumber(Math.round(t * maxCount))
+  )
+
+  // windowHours: matches `defaultLastHours` on the chart definition.
+  const windowHours = 24 * 7
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <div className="flex h-full flex-col gap-3 px-1 py-1">
+        {/* KPI strip */}
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          <KpiCard
+            label="Total queries"
+            value={formatCompactNumber(stats.total)}
+            hint={`${stats.activeHours}/168 active hours`}
+          />
+          <KpiCard
+            label="Peak hour"
+            value={peakLabel}
+            accent="peak"
+            hint={
+              stats.peak && hasTraffic
+                ? `${Math.round(((stats.peak.query_count - stats.avg) * 100) / Math.max(stats.avg, 1))}% above avg`
+                : undefined
+            }
+          />
+          <KpiCard
+            label="Quietest hour"
+            value={quietestLabel}
+            accent="quiet"
+            hint={stats.quietest ? 'lowest non-zero' : undefined}
+          />
+          <KpiCard
+            label="Avg / active hour"
+            value={formatCompactNumber(Math.round(stats.avg))}
+            hint={`across ${stats.activeHours} hours`}
+          />
+        </div>
+
+        {/* Heatmap grid + day-total bars */}
+        <div className="flex min-h-0 flex-1 flex-col gap-1">
+          {/* Hour labels row */}
+          <div className="flex items-end gap-[3px] pl-10 pr-12">
+            {HOUR_LABELS.map((label, hour) => (
+              <div
+                key={hour}
+                className="text-muted-foreground min-w-0 flex-1 text-center text-[10px] leading-none tabular-nums"
+              >
+                {hour % 3 === 0 ? label : ''}
+              </div>
+            ))}
+          </div>
+
+          {/* Grid rows: one per day, with right-margin day total */}
+          <div className="flex flex-1 flex-col gap-[3px]">
+            {DAY_LABELS.map((dayLabel, i) => {
+              const dayOfWeek = i + 1 // 1=Mon .. 7=Sun
+              const isWeekend = dayOfWeek >= 6
+              const dayTotal = stats.dayTotals[i]
+              const dayPct =
+                stats.maxDayTotal > 0 ? (dayTotal * 100) / stats.maxDayTotal : 0
+              return (
+                <div
+                  key={dayOfWeek}
+                  className="flex min-h-0 flex-1 items-stretch gap-[3px]"
+                >
+                  <div
+                    className={cn(
+                      'flex w-9 flex-shrink-0 items-center justify-end pr-1.5 text-[11px] font-medium',
+                      isWeekend
+                        ? 'text-muted-foreground/60'
+                        : 'text-muted-foreground'
+                    )}
+                  >
+                    {dayLabel}
+                  </div>
+                  {Array.from({ length: 24 }, (_, hour) => {
+                    const cell = grid[dayOfWeek]?.[hour]
+                    const count = cell?.query_count ?? 0
+                    const readable = cell?.readable_count ?? '0'
+                    const isCurrent = isCurrentSlotIn(timezone, dayOfWeek, hour)
+                    const rank = rankByKey.get(`${dayOfWeek}-${hour}`) ?? null
+
+                    return (
+                      <HeatmapCellLink
+                        key={hour}
+                        hostId={hostId}
+                        timezone={timezone}
+                        dayOfWeek={dayOfWeek}
+                        hour={hour}
+                        windowHours={windowHours}
+                        count={count}
+                        readable={readable}
+                        maxCount={maxCount}
+                        rank={rank}
+                        totalCells={totalActiveCells}
+                        isCurrent={isCurrent}
+                      />
+                    )
+                  })}
+                  {/* Day-total mini bar */}
+                  <div
+                    className="ml-1 flex w-10 flex-shrink-0 items-center gap-1"
+                    title={`${dayLabel}: ${formatCompactNumber(dayTotal)} queries`}
+                  >
+                    <div className="bg-muted/40 relative h-1.5 flex-1 overflow-hidden rounded-full">
+                      <div
+                        className="bg-chart-2/70 absolute inset-y-0 left-0 rounded-full transition-all"
+                        style={{ width: `${dayPct}%` }}
+                      />
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Footer: legend + helper text */}
+        <div className="flex flex-wrap items-center justify-between gap-2 pt-0.5">
+          <p className="text-muted-foreground text-[10px]">
+            Click any cell to view its queries
+          </p>
+          <div className="flex items-center gap-2">
+            {hasTraffic ? (
+              <span className="text-muted-foreground text-[10px]">0</span>
+            ) : null}
+            <div className="flex items-center gap-[2px]">
+              {INTENSITY_TIERS.map((cls, idx) => (
+                <div
+                  key={cls}
+                  className={cn(
+                    'h-[10px] w-[10px] flex-shrink-0 rounded-[2px]',
+                    cls
+                  )}
+                  title={
+                    !hasTraffic
+                      ? 'No traffic'
+                      : idx === 0
+                        ? '0 queries'
+                        : `≥ ${legendBuckets[idx - 1]} queries`
+                  }
+                />
+              ))}
+            </div>
+            {hasTraffic ? (
+              <span className="text-muted-foreground text-[10px] tabular-nums">
+                {formatCompactNumber(maxCount)}
+              </span>
+            ) : (
+              <span className="text-muted-foreground text-[10px]">
+                no traffic
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </TooltipProvider>
+  )
+}
+
 export const ChartQueryCountHeatmap = createCustomChart({
   chartName: 'query-count-heatmap',
   defaultTitle: 'Query Activity Heatmap',
   defaultLastHours: 24 * 7,
   dataTestId: 'query-count-heatmap-chart',
   contentClassName: 'overflow-x-auto',
-  render: (dataArray, _sql, hostId) => {
-    const data = dataArray as HeatmapCell[]
-
-    if (data.length === 0) {
-      return (
-        <div className="text-muted-foreground flex h-32 items-center justify-center text-sm">
-          No query data available
-        </div>
-      )
-    }
-
-    // Build lookup: [day][hour] -> cell
-    const grid: Record<number, Record<number, HeatmapCell>> = {}
-    let maxCount = 0
-    for (const cell of data) {
-      if (!grid[cell.day_of_week]) grid[cell.day_of_week] = {}
-      grid[cell.day_of_week][cell.hour_of_day] = cell
-      if (cell.query_count > maxCount) maxCount = cell.query_count
-    }
-
-    const stats = deriveStats(data)
-    // Pre-compute rank per cell (descending by count, ties share a slot).
-    const sortedByCount = [...data].sort(
-      (a, b) => b.query_count - a.query_count
-    )
-    const rankByKey = new Map<string, number>()
-    sortedByCount.forEach((cell, idx) => {
-      if (cell.query_count > 0) {
-        rankByKey.set(`${cell.day_of_week}-${cell.hour_of_day}`, idx + 1)
-      }
-    })
-    const totalActiveCells = sortedByCount.filter(
-      (c) => c.query_count > 0
-    ).length
-
-    const peakLabel = stats.peak
-      ? `${DAY_LABELS[stats.peak.day_of_week - 1]} ${String(stats.peak.hour_of_day).padStart(2, '0')}:00 · ${stats.peak.readable_count}`
-      : '—'
-    const quietestLabel = stats.quietest
-      ? `${DAY_LABELS[stats.quietest.day_of_week - 1]} ${String(stats.quietest.hour_of_day).padStart(2, '0')}:00 · ${stats.quietest.readable_count}`
-      : '—'
-
-    // Bucket boundaries for the legend (rounded to nice numbers).
-    const legendBuckets = TIER_THRESHOLDS.slice(1).map((t) =>
-      formatCompactNumber(Math.round(t * maxCount))
-    )
-
-    // windowHours: best-effort from data — fall back to 168.
-    const windowHours = 24 * 7
-
-    return (
-      <TooltipProvider delayDuration={0}>
-        <div className="flex h-full flex-col gap-3 px-1 py-1">
-          {/* KPI strip */}
-          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-            <KpiCard
-              label="Total queries"
-              value={formatCompactNumber(stats.total)}
-              hint={`${stats.activeHours}/168 active hours`}
-            />
-            <KpiCard
-              label="Peak hour"
-              value={peakLabel}
-              accent="peak"
-              hint={
-                stats.peak && maxCount > 0
-                  ? `${Math.round(((stats.peak.query_count - stats.avg) * 100) / Math.max(stats.avg, 1))}% above avg`
-                  : undefined
-              }
-            />
-            <KpiCard
-              label="Quietest hour"
-              value={quietestLabel}
-              accent="quiet"
-              hint={stats.quietest ? 'lowest non-zero' : undefined}
-            />
-            <KpiCard
-              label="Avg / active hour"
-              value={formatCompactNumber(Math.round(stats.avg))}
-              hint={`across ${stats.activeHours} hours`}
-            />
-          </div>
-
-          {/* Heatmap grid + day-total bars */}
-          <div className="flex min-h-0 flex-1 flex-col gap-1">
-            {/* Hour labels row */}
-            <div className="flex items-end gap-[3px] pl-10 pr-12">
-              {HOUR_LABELS.map((label, hour) => (
-                <div
-                  key={hour}
-                  className="text-muted-foreground min-w-0 flex-1 text-center text-[10px] leading-none tabular-nums"
-                >
-                  {hour % 3 === 0 ? label : ''}
-                </div>
-              ))}
-            </div>
-
-            {/* Grid rows: one per day, with right-margin day total */}
-            <div className="flex flex-1 flex-col gap-[3px]">
-              {DAY_LABELS.map((dayLabel, i) => {
-                const dayOfWeek = i + 1 // 1=Mon .. 7=Sun
-                const isWeekend = dayOfWeek >= 6
-                const dayTotal = stats.dayTotals[i]
-                const dayPct =
-                  stats.maxDayTotal > 0
-                    ? (dayTotal * 100) / stats.maxDayTotal
-                    : 0
-                return (
-                  <div
-                    key={dayOfWeek}
-                    className="flex min-h-0 flex-1 items-stretch gap-[3px]"
-                  >
-                    <div
-                      className={cn(
-                        'flex w-9 flex-shrink-0 items-center justify-end pr-1.5 text-[11px] font-medium',
-                        isWeekend
-                          ? 'text-muted-foreground/60'
-                          : 'text-muted-foreground'
-                      )}
-                    >
-                      {dayLabel}
-                    </div>
-                    {Array.from({ length: 24 }, (_, hour) => {
-                      const cell = grid[dayOfWeek]?.[hour]
-                      const count = cell?.query_count ?? 0
-                      const readable = cell?.readable_count ?? '0'
-                      const isCurrent = isCurrentSlot(dayOfWeek, hour)
-                      const rank = rankByKey.get(`${dayOfWeek}-${hour}`) ?? null
-
-                      return (
-                        <HeatmapCellLink
-                          key={hour}
-                          hostId={hostId}
-                          dayOfWeek={dayOfWeek}
-                          hour={hour}
-                          windowHours={windowHours}
-                          count={count}
-                          readable={readable}
-                          maxCount={maxCount}
-                          rank={rank}
-                          totalCells={totalActiveCells}
-                          isCurrent={isCurrent}
-                        />
-                      )
-                    })}
-                    {/* Day-total mini bar */}
-                    <div
-                      className="ml-1 flex w-10 flex-shrink-0 items-center gap-1"
-                      title={`${dayLabel}: ${formatCompactNumber(dayTotal)} queries`}
-                    >
-                      <div className="bg-muted/40 relative h-1.5 flex-1 overflow-hidden rounded-full">
-                        <div
-                          className="bg-chart-2/70 absolute inset-y-0 left-0 rounded-full transition-all"
-                          style={{ width: `${dayPct}%` }}
-                        />
-                      </div>
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-          </div>
-
-          {/* Footer: legend + helper text */}
-          <div className="flex flex-wrap items-center justify-between gap-2 pt-0.5">
-            <p className="text-muted-foreground text-[10px]">
-              Click any cell to view its queries
-            </p>
-            <div className="flex items-center gap-2">
-              <span className="text-muted-foreground text-[10px]">0</span>
-              <div className="flex items-center gap-[2px]">
-                {INTENSITY_TIERS.map((cls, idx) => (
-                  <div
-                    key={cls}
-                    className={cn(
-                      'h-[10px] w-[10px] flex-shrink-0 rounded-[2px]',
-                      cls
-                    )}
-                    title={
-                      idx === 0
-                        ? '0 queries'
-                        : `≥ ${legendBuckets[idx - 1]} queries`
-                    }
-                  />
-                ))}
-              </div>
-              <span className="text-muted-foreground text-[10px] tabular-nums">
-                {formatCompactNumber(maxCount)}
-              </span>
-            </div>
-          </div>
-        </div>
-      </TooltipProvider>
-    )
-  },
+  render: (dataArray, _sql, hostId) => (
+    <HeatmapBody data={dataArray as HeatmapCell[]} hostId={hostId} />
+  ),
 })
 
 export default ChartQueryCountHeatmap

--- a/components/charts/query/query-count-heatmap.tsx
+++ b/components/charts/query/query-count-heatmap.tsx
@@ -1,5 +1,9 @@
 'use client'
 
+import { ArrowUpRightIcon } from 'lucide-react'
+
+import Link from 'next/link'
+import { useMemo } from 'react'
 import { createCustomChart } from '@/components/charts/factory'
 import {
   Tooltip,
@@ -7,6 +11,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { formatCompactNumber } from '@/lib/format-readable'
 import { cn } from '@/lib/utils'
 
 interface HeatmapCell {
@@ -23,32 +28,271 @@ const HOUR_LABELS = Array.from({ length: 24 }, (_, i) =>
 )
 
 const INTENSITY_TIERS = [
-  { threshold: 0, bg: 'bg-muted/60', ring: '' },
-  { threshold: 0.01, bg: 'bg-chart-2/15', ring: '' },
-  { threshold: 0.15, bg: 'bg-chart-2/25', ring: '' },
-  { threshold: 0.3, bg: 'bg-chart-2/40', ring: '' },
-  { threshold: 0.45, bg: 'bg-chart-2/55', ring: '' },
-  { threshold: 0.6, bg: 'bg-chart-2/70', ring: '' },
-  { threshold: 0.75, bg: 'bg-chart-2/85', ring: '' },
-  { threshold: 0.9, bg: 'bg-chart-2', ring: '' },
+  'bg-muted/60',
+  'bg-chart-2/15',
+  'bg-chart-2/25',
+  'bg-chart-2/40',
+  'bg-chart-2/55',
+  'bg-chart-2/70',
+  'bg-chart-2/85',
+  'bg-chart-2',
 ] as const
+const TIER_THRESHOLDS = [0, 0.01, 0.15, 0.3, 0.45, 0.6, 0.75, 0.9]
 
 function getIntensityClass(value: number, max: number): string {
-  if (max === 0 || value === 0) return INTENSITY_TIERS[0].bg
+  if (max === 0 || value === 0) return INTENSITY_TIERS[0]
   const ratio = value / max
-  // Walk tiers in reverse to find the highest matching threshold
-  for (let i = INTENSITY_TIERS.length - 1; i >= 0; i--) {
-    if (ratio >= INTENSITY_TIERS[i].threshold) return INTENSITY_TIERS[i].bg
+  for (let i = TIER_THRESHOLDS.length - 1; i >= 0; i--) {
+    if (ratio >= TIER_THRESHOLDS[i]) return INTENSITY_TIERS[i]
   }
-  return INTENSITY_TIERS[0].bg
+  return INTENSITY_TIERS[0]
+}
+
+/** ClickHouse toDayOfWeek convention (1=Mon..7=Sun) from a JS Date. */
+function jsDateToChDay(d: Date): number {
+  const js = d.getDay()
+  return js === 0 ? 7 : js
 }
 
 function isCurrentSlot(dayOfWeek: number, hour: number): boolean {
   const now = new Date()
-  // JS getDay: 0=Sun, ClickHouse toDayOfWeek: 1=Mon..7=Sun
-  const jsDay = now.getDay()
-  const chDay = jsDay === 0 ? 7 : jsDay
-  return chDay === dayOfWeek && now.getHours() === hour
+  return jsDateToChDay(now) === dayOfWeek && now.getHours() === hour
+}
+
+/**
+ * Find the most-recent absolute Date matching (chDay, hour) within the last
+ * `windowHours` hours from now. Returns null when the slot has not occurred
+ * within the window.
+ */
+function findMostRecentSlot(
+  chDay: number,
+  hour: number,
+  windowHours: number
+): Date | null {
+  const now = new Date()
+  const probe = new Date(now)
+  probe.setMinutes(0, 0, 0)
+  // Walk back hour-by-hour until we match. Capped at windowHours iterations.
+  for (let i = 0; i <= windowHours; i++) {
+    if (jsDateToChDay(probe) === chDay && probe.getHours() === hour) {
+      return probe
+    }
+    probe.setHours(probe.getHours() - 1)
+  }
+  return null
+}
+
+/** Format a Date into ClickHouse-friendly `YYYY-MM-DD HH:mm:ss` (local time). */
+function formatChDateTime(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+}
+
+const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+})
+
+interface DerivedStats {
+  total: number
+  peak: HeatmapCell | null
+  quietest: HeatmapCell | null
+  avg: number
+  activeHours: number
+  dayTotals: number[] // index 0..6 → Mon..Sun
+  hourTotals: number[] // index 0..23
+  maxDayTotal: number
+  maxHourTotal: number
+}
+
+function deriveStats(data: HeatmapCell[]): DerivedStats {
+  const dayTotals = new Array(7).fill(0)
+  const hourTotals = new Array(24).fill(0)
+  let total = 0
+  let peak: HeatmapCell | null = null
+  let quietest: HeatmapCell | null = null
+  let activeHours = 0
+
+  for (const cell of data) {
+    total += cell.query_count
+    if (cell.day_of_week >= 1 && cell.day_of_week <= 7) {
+      dayTotals[cell.day_of_week - 1] += cell.query_count
+    }
+    if (cell.hour_of_day >= 0 && cell.hour_of_day <= 23) {
+      hourTotals[cell.hour_of_day] += cell.query_count
+    }
+    if (cell.query_count > 0) activeHours++
+    if (!peak || cell.query_count > peak.query_count) peak = cell
+    if (
+      cell.query_count > 0 &&
+      (!quietest || cell.query_count < quietest.query_count)
+    ) {
+      quietest = cell
+    }
+  }
+
+  return {
+    total,
+    peak,
+    quietest,
+    avg: activeHours > 0 ? total / activeHours : 0,
+    activeHours,
+    dayTotals,
+    hourTotals,
+    maxDayTotal: Math.max(...dayTotals, 0),
+    maxHourTotal: Math.max(...hourTotals, 0),
+  }
+}
+
+interface KpiCardProps {
+  label: string
+  value: string
+  hint?: string
+  accent?: 'default' | 'peak' | 'quiet'
+}
+
+function KpiCard({ label, value, hint, accent = 'default' }: KpiCardProps) {
+  return (
+    <div
+      className={cn(
+        'flex min-w-0 flex-col gap-0.5 rounded-md border border-border/60 bg-card/40 px-3 py-2',
+        'transition-colors hover:bg-card/70'
+      )}
+    >
+      <span className="text-muted-foreground text-[10px] uppercase tracking-wide">
+        {label}
+      </span>
+      <span
+        className={cn(
+          'truncate text-base font-semibold tabular-nums leading-tight',
+          accent === 'peak' && 'text-chart-2',
+          accent === 'quiet' && 'text-muted-foreground'
+        )}
+      >
+        {value}
+      </span>
+      {hint ? (
+        <span className="text-muted-foreground truncate text-[10px] tabular-nums">
+          {hint}
+        </span>
+      ) : null}
+    </div>
+  )
+}
+
+interface CellLinkProps {
+  hostId: number
+  dayOfWeek: number
+  hour: number
+  windowHours: number
+  count: number
+  readable: string
+  maxCount: number
+  rank: number | null
+  totalCells: number
+  isCurrent: boolean
+}
+
+function HeatmapCellLink({
+  hostId,
+  dayOfWeek,
+  hour,
+  windowHours,
+  count,
+  readable,
+  maxCount,
+  rank,
+  totalCells,
+  isCurrent,
+}: CellLinkProps) {
+  const slotDate = useMemo(
+    () => findMostRecentSlot(dayOfWeek, hour, windowHours),
+    [dayOfWeek, hour, windowHours]
+  )
+
+  const href = useMemo(() => {
+    if (!slotDate) return null
+    const end = new Date(slotDate)
+    end.setHours(end.getHours() + 1)
+    const params = new URLSearchParams()
+    params.set('host', String(hostId))
+    params.set(
+      'event_time',
+      `between:${formatChDateTime(slotDate)},${formatChDateTime(end)}`
+    )
+    return `/history-queries?${params.toString()}`
+  }, [slotDate, hostId])
+
+  const dayLabel = DAY_LABELS[dayOfWeek - 1]
+  const hourLabel = String(hour).padStart(2, '0')
+  const pctOfPeak = maxCount > 0 ? Math.round((count * 100) / maxCount) : 0
+  const intensity = getIntensityClass(count, maxCount)
+
+  const triggerClass = cn(
+    'group/cell relative block min-w-0 flex-1 cursor-pointer rounded-[3px]',
+    'transition-all duration-150',
+    'hover:scale-110 hover:z-10',
+    'hover:ring-2 hover:ring-foreground/30 hover:shadow-sm',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:z-10',
+    intensity,
+    isCurrent &&
+      'ring-2 ring-foreground/50 ring-offset-1 ring-offset-background'
+  )
+
+  const inner = (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {href ? (
+          <Link
+            href={href}
+            className={triggerClass}
+            aria-label={`${readable} queries on ${dayLabel} ${hourLabel}:00`}
+          />
+        ) : (
+          <div
+            role="img"
+            aria-label={`${readable} queries on ${dayLabel} ${hourLabel}:00`}
+            className={cn(triggerClass, 'cursor-default')}
+          />
+        )}
+      </TooltipTrigger>
+      <TooltipContent side="top" className="min-w-[200px] p-0">
+        <div className="flex flex-col gap-2 px-3 py-2">
+          <div className="flex items-baseline justify-between gap-3">
+            <span className="text-sm font-semibold tabular-nums">
+              {readable}
+            </span>
+            <span className="text-muted-foreground text-[10px] tabular-nums">
+              {pctOfPeak}% of peak
+            </span>
+          </div>
+          <div className="flex flex-col gap-0.5">
+            <span className="text-muted-foreground text-[11px]">
+              {slotDate ? DATE_FORMAT.format(slotDate) : dayLabel}
+              {' · '}
+              <span className="tabular-nums">
+                {hourLabel}:00–{hourLabel}:59
+              </span>
+            </span>
+            {rank !== null && totalCells > 0 ? (
+              <span className="text-muted-foreground text-[10px] tabular-nums">
+                Rank #{rank} of {totalCells} hours
+              </span>
+            ) : null}
+          </div>
+          {href ? (
+            <div className="border-border/60 flex items-center gap-1 border-t pt-1.5 text-[10px] text-chart-2">
+              <span>View queries from this hour</span>
+              <ArrowUpRightIcon className="size-3" />
+            </div>
+          ) : null}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+
+  return inner
 }
 
 export const ChartQueryCountHeatmap = createCustomChart({
@@ -57,8 +301,16 @@ export const ChartQueryCountHeatmap = createCustomChart({
   defaultLastHours: 24 * 7,
   dataTestId: 'query-count-heatmap-chart',
   contentClassName: 'overflow-x-auto',
-  render: (dataArray) => {
+  render: (dataArray, _sql, hostId) => {
     const data = dataArray as HeatmapCell[]
+
+    if (data.length === 0) {
+      return (
+        <div className="text-muted-foreground flex h-32 items-center justify-center text-sm">
+          No query data available
+        </div>
+      )
+    }
 
     // Build lookup: [day][hour] -> cell
     const grid: Record<number, Record<number, HeatmapCell>> = {}
@@ -69,106 +321,176 @@ export const ChartQueryCountHeatmap = createCustomChart({
       if (cell.query_count > maxCount) maxCount = cell.query_count
     }
 
-    if (data.length === 0) {
-      return (
-        <div className="text-muted-foreground flex h-32 items-center justify-center text-sm">
-          No query data available
-        </div>
-      )
-    }
+    const stats = deriveStats(data)
+    // Pre-compute rank per cell (descending by count, ties share a slot).
+    const sortedByCount = [...data].sort(
+      (a, b) => b.query_count - a.query_count
+    )
+    const rankByKey = new Map<string, number>()
+    sortedByCount.forEach((cell, idx) => {
+      if (cell.query_count > 0) {
+        rankByKey.set(`${cell.day_of_week}-${cell.hour_of_day}`, idx + 1)
+      }
+    })
+    const totalActiveCells = sortedByCount.filter(
+      (c) => c.query_count > 0
+    ).length
+
+    const peakLabel = stats.peak
+      ? `${DAY_LABELS[stats.peak.day_of_week - 1]} ${String(stats.peak.hour_of_day).padStart(2, '0')}:00 · ${stats.peak.readable_count}`
+      : '—'
+    const quietestLabel = stats.quietest
+      ? `${DAY_LABELS[stats.quietest.day_of_week - 1]} ${String(stats.quietest.hour_of_day).padStart(2, '0')}:00 · ${stats.quietest.readable_count}`
+      : '—'
+
+    // Bucket boundaries for the legend (rounded to nice numbers).
+    const legendBuckets = TIER_THRESHOLDS.slice(1).map((t) =>
+      formatCompactNumber(Math.round(t * maxCount))
+    )
+
+    // windowHours: best-effort from data — fall back to 168.
+    const windowHours = 24 * 7
 
     return (
       <TooltipProvider delayDuration={0}>
-        <div className="flex h-full flex-col justify-between gap-1 px-1 py-1">
-          {/* Hour labels row */}
-          <div className="flex items-end gap-[3px] pl-10">
-            {HOUR_LABELS.map((label, hour) => (
-              <div
-                key={hour}
-                className="text-muted-foreground min-w-0 flex-1 text-center text-[10px] leading-none tabular-nums"
-              >
-                {hour % 3 === 0 ? label : ''}
-              </div>
-            ))}
+        <div className="flex h-full flex-col gap-3 px-1 py-1">
+          {/* KPI strip */}
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+            <KpiCard
+              label="Total queries"
+              value={formatCompactNumber(stats.total)}
+              hint={`${stats.activeHours}/168 active hours`}
+            />
+            <KpiCard
+              label="Peak hour"
+              value={peakLabel}
+              accent="peak"
+              hint={
+                stats.peak && maxCount > 0
+                  ? `${Math.round(((stats.peak.query_count - stats.avg) * 100) / Math.max(stats.avg, 1))}% above avg`
+                  : undefined
+              }
+            />
+            <KpiCard
+              label="Quietest hour"
+              value={quietestLabel}
+              accent="quiet"
+              hint={stats.quietest ? 'lowest non-zero' : undefined}
+            />
+            <KpiCard
+              label="Avg / active hour"
+              value={formatCompactNumber(Math.round(stats.avg))}
+              hint={`across ${stats.activeHours} hours`}
+            />
           </div>
 
-          {/* Grid rows: one per day */}
-          <div className="flex flex-1 flex-col gap-[3px]">
-            {DAY_LABELS.map((dayLabel, i) => {
-              const dayOfWeek = i + 1 // 1=Mon .. 7=Sun
-              const isWeekend = dayOfWeek >= 6
-              return (
+          {/* Heatmap grid + day-total bars */}
+          <div className="flex min-h-0 flex-1 flex-col gap-1">
+            {/* Hour labels row */}
+            <div className="flex items-end gap-[3px] pl-10 pr-12">
+              {HOUR_LABELS.map((label, hour) => (
                 <div
-                  key={dayOfWeek}
-                  className="flex min-h-0 flex-1 items-stretch gap-[3px]"
+                  key={hour}
+                  className="text-muted-foreground min-w-0 flex-1 text-center text-[10px] leading-none tabular-nums"
                 >
-                  <div
-                    className={cn(
-                      'flex w-9 flex-shrink-0 items-center justify-end pr-1.5 text-[11px] font-medium',
-                      isWeekend
-                        ? 'text-muted-foreground/60'
-                        : 'text-muted-foreground'
-                    )}
-                  >
-                    {dayLabel}
-                  </div>
-                  {Array.from({ length: 24 }, (_, hour) => {
-                    const cell = grid[dayOfWeek]?.[hour]
-                    const count = cell?.query_count ?? 0
-                    const readable = cell?.readable_count ?? '0'
-                    const isCurrent = isCurrentSlot(dayOfWeek, hour)
-
-                    return (
-                      <Tooltip key={hour}>
-                        <TooltipTrigger asChild>
-                          <div
-                            className={cn(
-                              'min-w-0 flex-1 cursor-default rounded-[3px] transition-all duration-150',
-                              'hover:scale-110 hover:ring-2 hover:ring-foreground/20 hover:z-10',
-                              getIntensityClass(count, maxCount),
-                              isCurrent &&
-                                'ring-2 ring-foreground/40 ring-offset-1 ring-offset-background'
-                            )}
-                          />
-                        </TooltipTrigger>
-                        <TooltipContent side="top" className="text-xs">
-                          <p className="font-semibold tabular-nums">
-                            {readable} queries
-                          </p>
-                          <p className="text-muted-foreground text-[10px]">
-                            {dayLabel} {String(hour).padStart(2, '0')}:00–
-                            {String(hour).padStart(2, '0')}:59
-                          </p>
-                        </TooltipContent>
-                      </Tooltip>
-                    )
-                  })}
+                  {hour % 3 === 0 ? label : ''}
                 </div>
-              )
-            })}
-          </div>
-
-          {/* Legend row */}
-          <div className="flex items-center justify-end gap-2 pt-0.5">
-            <span className="text-muted-foreground text-[10px]">Less</span>
-            <div className="flex items-center gap-[2px]">
-              {[
-                'bg-muted/60',
-                'bg-chart-2/15',
-                'bg-chart-2/40',
-                'bg-chart-2/70',
-                'bg-chart-2',
-              ].map((cls) => (
-                <div
-                  key={cls}
-                  className={cn(
-                    'h-[10px] w-[10px] flex-shrink-0 rounded-[2px]',
-                    cls
-                  )}
-                />
               ))}
             </div>
-            <span className="text-muted-foreground text-[10px]">More</span>
+
+            {/* Grid rows: one per day, with right-margin day total */}
+            <div className="flex flex-1 flex-col gap-[3px]">
+              {DAY_LABELS.map((dayLabel, i) => {
+                const dayOfWeek = i + 1 // 1=Mon .. 7=Sun
+                const isWeekend = dayOfWeek >= 6
+                const dayTotal = stats.dayTotals[i]
+                const dayPct =
+                  stats.maxDayTotal > 0
+                    ? (dayTotal * 100) / stats.maxDayTotal
+                    : 0
+                return (
+                  <div
+                    key={dayOfWeek}
+                    className="flex min-h-0 flex-1 items-stretch gap-[3px]"
+                  >
+                    <div
+                      className={cn(
+                        'flex w-9 flex-shrink-0 items-center justify-end pr-1.5 text-[11px] font-medium',
+                        isWeekend
+                          ? 'text-muted-foreground/60'
+                          : 'text-muted-foreground'
+                      )}
+                    >
+                      {dayLabel}
+                    </div>
+                    {Array.from({ length: 24 }, (_, hour) => {
+                      const cell = grid[dayOfWeek]?.[hour]
+                      const count = cell?.query_count ?? 0
+                      const readable = cell?.readable_count ?? '0'
+                      const isCurrent = isCurrentSlot(dayOfWeek, hour)
+                      const rank = rankByKey.get(`${dayOfWeek}-${hour}`) ?? null
+
+                      return (
+                        <HeatmapCellLink
+                          key={hour}
+                          hostId={hostId}
+                          dayOfWeek={dayOfWeek}
+                          hour={hour}
+                          windowHours={windowHours}
+                          count={count}
+                          readable={readable}
+                          maxCount={maxCount}
+                          rank={rank}
+                          totalCells={totalActiveCells}
+                          isCurrent={isCurrent}
+                        />
+                      )
+                    })}
+                    {/* Day-total mini bar */}
+                    <div
+                      className="ml-1 flex w-10 flex-shrink-0 items-center gap-1"
+                      title={`${dayLabel}: ${formatCompactNumber(dayTotal)} queries`}
+                    >
+                      <div className="bg-muted/40 relative h-1.5 flex-1 overflow-hidden rounded-full">
+                        <div
+                          className="bg-chart-2/70 absolute inset-y-0 left-0 rounded-full transition-all"
+                          style={{ width: `${dayPct}%` }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+
+          {/* Footer: legend + helper text */}
+          <div className="flex flex-wrap items-center justify-between gap-2 pt-0.5">
+            <p className="text-muted-foreground text-[10px]">
+              Click any cell to view its queries
+            </p>
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground text-[10px]">0</span>
+              <div className="flex items-center gap-[2px]">
+                {INTENSITY_TIERS.map((cls, idx) => (
+                  <div
+                    key={cls}
+                    className={cn(
+                      'h-[10px] w-[10px] flex-shrink-0 rounded-[2px]',
+                      cls
+                    )}
+                    title={
+                      idx === 0
+                        ? '0 queries'
+                        : `≥ ${legendBuckets[idx - 1]} queries`
+                    }
+                  />
+                ))}
+              </div>
+              <span className="text-muted-foreground text-[10px] tabular-nums">
+                {formatCompactNumber(maxCount)}
+              </span>
+            </div>
           </div>
         </div>
       </TooltipProvider>

--- a/components/charts/query/query-count-heatmap.tsx
+++ b/components/charts/query/query-count-heatmap.tsx
@@ -223,11 +223,18 @@ function deriveStats(data: HeatmapCell[]): DerivedStats {
 interface KpiCardProps {
   label: string
   value: string
+  sublabel?: string
   hint?: string
   accent?: 'default' | 'peak' | 'quiet'
 }
 
-function KpiCard({ label, value, hint, accent = 'default' }: KpiCardProps) {
+function KpiCard({
+  label,
+  value,
+  sublabel,
+  hint,
+  accent = 'default',
+}: KpiCardProps) {
   return (
     <div
       className={cn(
@@ -238,15 +245,22 @@ function KpiCard({ label, value, hint, accent = 'default' }: KpiCardProps) {
       <span className="text-muted-foreground text-[10px] uppercase tracking-wide">
         {label}
       </span>
-      <span
-        className={cn(
-          'truncate text-base font-semibold tabular-nums leading-tight',
-          accent === 'peak' && 'text-chart-2',
-          accent === 'quiet' && 'text-muted-foreground'
-        )}
-      >
-        {value}
-      </span>
+      <div className="flex items-baseline gap-1.5 min-w-0">
+        <span
+          className={cn(
+            'truncate text-base font-semibold tabular-nums leading-tight',
+            accent === 'peak' && 'text-chart-2',
+            accent === 'quiet' && 'text-muted-foreground'
+          )}
+        >
+          {value}
+        </span>
+        {sublabel ? (
+          <span className="text-muted-foreground/80 truncate text-[11px] tabular-nums">
+            {sublabel}
+          </span>
+        ) : null}
+      </div>
       {hint ? (
         <span className="text-muted-foreground truncate text-[10px] tabular-nums">
           {hint}
@@ -427,12 +441,14 @@ function HeatmapBody({
   }
   const totalActiveCells = sortedByCount.filter((c) => c.query_count > 0).length
 
-  const peakLabel = stats.peak
-    ? `${DAY_LABELS[stats.peak.day_of_week - 1]} ${String(stats.peak.hour_of_day).padStart(2, '0')}:00 · ${stats.peak.readable_count}`
-    : '—'
-  const quietestLabel = stats.quietest
-    ? `${DAY_LABELS[stats.quietest.day_of_week - 1]} ${String(stats.quietest.hour_of_day).padStart(2, '0')}:00 · ${stats.quietest.readable_count}`
-    : '—'
+  const peakValue = stats.peak ? stats.peak.readable_count : '—'
+  const peakSlot = stats.peak
+    ? `${DAY_LABELS[stats.peak.day_of_week - 1]} ${String(stats.peak.hour_of_day).padStart(2, '0')}:00`
+    : undefined
+  const quietestValue = stats.quietest ? stats.quietest.readable_count : '—'
+  const quietestSlot = stats.quietest
+    ? `${DAY_LABELS[stats.quietest.day_of_week - 1]} ${String(stats.quietest.hour_of_day).padStart(2, '0')}:00`
+    : undefined
 
   // Bucket boundaries for the legend (rounded). Skip numeric labels when
   // there is no traffic — all buckets would collapse to "≥ 0".
@@ -443,7 +459,7 @@ function HeatmapBody({
 
   return (
     <TooltipProvider delayDuration={0}>
-      <div className="flex h-full flex-col gap-3 px-1 py-1">
+      <div className="flex flex-col gap-3 px-1 py-1">
         {/* KPI strip */}
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
           <KpiCard
@@ -453,7 +469,8 @@ function HeatmapBody({
           />
           <KpiCard
             label="Peak hour"
-            value={peakLabel}
+            value={peakValue}
+            sublabel={peakSlot}
             accent="peak"
             hint={
               stats.peak && hasTraffic
@@ -463,7 +480,8 @@ function HeatmapBody({
           />
           <KpiCard
             label="Quietest hour"
-            value={quietestLabel}
+            value={quietestValue}
+            sublabel={quietestSlot}
             accent="quiet"
             hint={stats.quietest ? 'lowest non-zero' : undefined}
           />
@@ -475,9 +493,10 @@ function HeatmapBody({
         </div>
 
         {/* Heatmap grid + day-total bars */}
-        <div className="flex min-h-0 flex-1 flex-col gap-1">
-          {/* Hour labels row */}
-          <div className="flex items-end gap-[3px] pl-10 pr-12">
+        <div className="flex flex-col gap-1.5">
+          {/* Hour labels row — left gutter (40px) and right gutter (56px) match
+              the day-label column and the day-total mini-bar+number column. */}
+          <div className="flex items-end gap-[3px] pl-10 pr-14">
             {HOUR_LABELS.map((label, hour) => (
               <div
                 key={hour}
@@ -488,8 +507,10 @@ function HeatmapBody({
             ))}
           </div>
 
-          {/* Grid rows: one per day, with right-margin day total */}
-          <div className="flex flex-1 flex-col gap-[3px]">
+          {/* Grid rows: one per day, with right-margin day total. Fixed row
+              height (h-5) keeps the card from squeezing rows behind the
+              footer when its container is short. */}
+          <div className="flex flex-col gap-[3px]">
             {DAY_LABELS.map((dayLabel, i) => {
               const dayOfWeek = i + 1 // 1=Mon .. 7=Sun
               const isWeekend = dayOfWeek >= 6
@@ -499,11 +520,11 @@ function HeatmapBody({
               return (
                 <div
                   key={dayOfWeek}
-                  className="flex min-h-0 flex-1 items-stretch gap-[3px]"
+                  className="flex h-5 items-stretch gap-[3px]"
                 >
                   <div
                     className={cn(
-                      'flex w-9 flex-shrink-0 items-center justify-end pr-1.5 text-[11px] font-medium',
+                      'flex w-10 flex-shrink-0 items-center justify-end pr-1.5 text-[11px] font-medium',
                       isWeekend
                         ? 'text-muted-foreground/60'
                         : 'text-muted-foreground'
@@ -535,9 +556,10 @@ function HeatmapBody({
                       />
                     )
                   })}
-                  {/* Day-total mini bar */}
+                  {/* Day-total mini bar + numeric tag. Reserved column width
+                      (w-14) matches the hour-row right gutter. */}
                   <div
-                    className="ml-1 flex w-10 flex-shrink-0 items-center gap-1"
+                    className="ml-1 flex w-14 flex-shrink-0 items-center gap-1.5"
                     title={`${dayLabel}: ${formatCompactNumber(dayTotal)} queries`}
                   >
                     <div className="bg-muted/40 relative h-1.5 flex-1 overflow-hidden rounded-full">
@@ -546,6 +568,16 @@ function HeatmapBody({
                         style={{ width: `${dayPct}%` }}
                       />
                     </div>
+                    <span
+                      className={cn(
+                        'min-w-[1.75rem] text-right text-[10px] tabular-nums leading-none',
+                        isWeekend
+                          ? 'text-muted-foreground/60'
+                          : 'text-muted-foreground'
+                      )}
+                    >
+                      {hasTraffic ? formatCompactNumber(dayTotal) : ''}
+                    </span>
                   </div>
                 </div>
               )

--- a/components/charts/query/query-count-heatmap.tsx
+++ b/components/charts/query/query-count-heatmap.tsx
@@ -112,6 +112,37 @@ function isCurrentSlotIn(
   return jsDayToChDay(now.jsDayOfWeek) === dayOfWeek && now.hour === hour
 }
 
+/** Step a wall clock back by one hour using pure component arithmetic, so the
+ *  walk follows the target timezone's calendar — not the browser's DST rules.
+ *  Day rollover uses a Date at noon to dodge any DST jump zones. */
+function stepBackOneHour(wc: WallClock): WallClock {
+  if (wc.hour > 0) {
+    const hour = wc.hour - 1
+    return {
+      year: wc.year,
+      month: wc.month,
+      day: wc.day,
+      hour,
+      jsDayOfWeek: wc.jsDayOfWeek,
+      asDate: new Date(wc.year, wc.month - 1, wc.day, hour, 0, 0),
+    }
+  }
+  // Roll over to the previous calendar day at hour 23.
+  const prev = new Date(wc.year, wc.month - 1, wc.day - 1, 12)
+  const year = prev.getFullYear()
+  const month = prev.getMonth() + 1
+  const day = prev.getDate()
+  const jsDayOfWeek = prev.getDay()
+  return {
+    year,
+    month,
+    day,
+    hour: 23,
+    jsDayOfWeek,
+    asDate: new Date(year, month - 1, day, 23, 0, 0),
+  }
+}
+
 /**
  * Find the most-recent wall-clock instant matching (chDay, hour) within the
  * last `windowHours` hours from the current moment in `timezone`. Returns
@@ -123,14 +154,12 @@ function findMostRecentSlot(
   hour: number,
   windowHours: number
 ): Date | null {
-  const now = nowInTimezone(timezone)
-  const probe = new Date(now.asDate.getTime())
+  let probe = nowInTimezone(timezone)
   for (let i = 0; i <= windowHours; i++) {
-    const probeChDay = jsDayToChDay(probe.getDay())
-    if (probeChDay === chDay && probe.getHours() === hour) {
-      return probe
+    if (jsDayToChDay(probe.jsDayOfWeek) === chDay && probe.hour === hour) {
+      return probe.asDate
     }
-    probe.setHours(probe.getHours() - 1)
+    probe = stepBackOneHour(probe)
   }
   return null
 }

--- a/components/charts/query/query-count-heatmap.tsx
+++ b/components/charts/query/query-count-heatmap.tsx
@@ -141,11 +141,41 @@ function formatChDateTime(d: Date): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
 }
 
-const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
-  weekday: 'short',
-  month: 'short',
-  day: 'numeric',
-})
+const WEEKDAY_NAMES_SHORT = [
+  'Sun',
+  'Mon',
+  'Tue',
+  'Wed',
+  'Thu',
+  'Fri',
+  'Sat',
+] as const
+const MONTH_NAMES_SHORT = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+] as const
+
+/**
+ * Format a wall-clock Date for display, reading components directly so the
+ * output reflects the user-tz components that were encoded into the Date —
+ * not the browser's interpretation through `Intl`. Going through
+ * `Intl.DateTimeFormat` here would either implicitly use the browser zone
+ * (correct only by coincidence) or, with an explicit `timeZone`, would
+ * double-shift the already-encoded wall clock.
+ */
+function formatDisplayDate(d: Date): string {
+  return `${WEEKDAY_NAMES_SHORT[d.getDay()]}, ${MONTH_NAMES_SHORT[d.getMonth()]} ${d.getDate()}`
+}
 
 interface DerivedStats {
   total: number
@@ -319,7 +349,7 @@ function HeatmapCellLink({
           </div>
           <div className="flex flex-col gap-0.5">
             <span className="text-muted-foreground text-[11px]">
-              {slotDate ? DATE_FORMAT.format(slotDate) : dayLabel}
+              {slotDate ? formatDisplayDate(slotDate) : dayLabel}
               {' · '}
               <span className="tabular-nums">
                 {hourLabel}:00–{hourLabel}:59

--- a/components/dashboard/chart-params.tsx
+++ b/components/dashboard/chart-params.tsx
@@ -7,14 +7,9 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { Button } from '@/components/ui/button'
 import { ShakeFormControl } from '@/components/forms/shake-form-control'
-import {
-  Form,
-  FormField,
-  FormItem,
-  FormLabel,
-} from '@/components/ui/form'
+import { Button } from '@/components/ui/button'
+import { Form, FormField, FormItem, FormLabel } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { updateSettingParams } from '@/lib/api/dashboard-api-client'
 import { ErrorLogger } from '@/lib/logger'


### PR DESCRIPTION
## Summary

Redesigns `components/charts/query/query-count-heatmap.tsx` to be informative, scannable, and actionable.

### What's new

**KPI strip (4 cards above the grid)**
- Total queries (with count of active hours / 168)
- Peak hour with day · hour and % above average
- Quietest non-zero hour
- Average per active hour

**Click-through to filtered queries**
- Each cell becomes a `<Link>` to `/history-queries?host=N&event_time=between:<start>,<end>`
- Host is preserved (uses `hostId` from `createCustomChart` render args)
- Within a 7-day window each (day-of-week, hour-of-day) maps to exactly one real timestamp — the component walks back from `now()` to find it

**Richer hover content**
- Bold readable count
- "% of peak" indicator
- Resolved calendar date (e.g. *Mon, Mar 17 · 14:00–14:59*)
- Rank #N of M active hours
- "View queries from this hour →" hint

**Other polish**
- Day-of-week mini-bars on the right edge of each row (subtle marginal stat)
- Legend now shows numeric bucket thresholds (derived from the actual max), not just *Less / More*
- Focus-visible ring on cells for keyboard navigation
- Empty/no-data states preserved

### Why
The previous heatmap was visually attractive but a dead-end — users could see *when* activity was high but had to manually rebuild a date filter on `/history-queries` to actually look at those queries. KPI + click-through closes that loop.

### Behavior preserved
- Same SQL (`lib/api/charts/query-charts.ts` unchanged)
- Same chart name → registry, overview tests, and skill metadata untouched
- Same `chart-2` color palette and tier ratios

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run type-check` — clean
- [x] `bun run build` — clean
- [x] `bun test app/(dashboard)/overview/__tests__/overview.test.tsx` — 21 pass
- [ ] Manual: hover a cell → tooltip shows full date + click hint
- [ ] Manual: click a cell → lands on `/history-queries?host=…&event_time=between:…` with that hour selected
- [ ] Manual: switch host in URL → cells regenerate links with new host
- [ ] Manual: dark + light mode legibility

Includes one tiny pre-existing import-sort fix in `components/dashboard/chart-params.tsx` (separate commit) — the pre-push lint gate on `main` was failing on that file regardless of this PR.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Redesign the query activity heatmap chart to surface key query volume KPIs and make each cell actionable with click-through to filtered query history, while preserving existing data sources and color scaling.

New Features:
- Add KPI cards summarizing total queries, peak and quietest hours, and average queries per active hour above the heatmap grid.
- Enable each heatmap cell to link directly to the history queries page for the corresponding host and hour window.
- Show richer hover tooltips on heatmap cells with absolute counts, percentage of peak, calendar date, rank among active hours, and a navigation hint.
- Display per-day mini bar charts alongside each row to indicate relative daily query volume and show a more descriptive intensity legend with numeric bucket thresholds.

Enhancements:
- Refine heatmap cell styling for better keyboard focus, hover affordances, and current-slot highlighting, and add an explicit empty-state message when no data is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Heatmap is timezone-aware and highlights the user's current slot.
  * KPI strip added (total queries, peak/quietest non-zero cells, active-hour counts/averages).
  * Heatmap cells link to hour-specific query history when a slot resolves; tooltips show count, percent-of-peak, time range, and rank.
  * Day-total bars and updated legend scale to observed peaks.

* **Style**
  * Minor UI import reordering and formatting cleanup.

* **Chores**
  * Chart rendering now accepts time-range context to enable per-cell drilldowns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->