### PR TITLE
fix(data-table): sort/resize hit areas + dense BackgroundBar

### DIFF
--- a/components/data-table/cells/background-bar-format.tsx
+++ b/components/data-table/cells/background-bar-format.tsx
@@ -48,18 +48,18 @@ export const BackgroundBarFormat = memo(function BackgroundBarFormat({
 
   return (
     <div
-      className="relative flex items-center w-full min-h-[1.75rem] h-full overflow-hidden rounded"
+      className="relative flex items-center w-full h-full overflow-hidden rounded-sm"
       title={`${orgValue} (${pct}%)`}
       aria-label={`${orgValue} (${pct}%)`}
       aria-roledescription="background-bar"
     >
       {/* Background bar - uses inline styles for dynamic color */}
       <div
-        className="absolute inset-y-0 left-0 rounded transition-[width]"
+        className="absolute inset-y-0 left-0 rounded-sm transition-[width]"
         style={{ width: `${pct}%`, ...barStyle }}
         aria-hidden="true"
       />
-      <span className="relative inline-block min-w-0 truncate px-2">
+      <span className="relative inline-block min-w-0 truncate">
         {options?.numberFormat
           ? formatReadableQuantity(value as number, 'long')
           : value}

--- a/components/data-table/column-defs/components/column-header.tsx
+++ b/components/data-table/column-defs/components/column-header.tsx
@@ -49,9 +49,9 @@ function HeaderContent({
   }
 
   return (
-    <span className="inline-flex items-center gap-1 text-muted-foreground">
-      {Icon && <Icon className="size-3" />}
-      {name}
+    <span className="inline-flex flex-1 min-w-0 items-center gap-1 truncate text-muted-foreground">
+      {Icon && <Icon className="size-3 shrink-0" />}
+      <span className="truncate">{name}</span>
     </span>
   )
 }
@@ -83,7 +83,7 @@ export function ColumnHeader<TData extends RowData>({
           }
         }}
         className={cn(
-          'inline-flex items-center gap-0.5 truncate text-xs font-medium uppercase tracking-wider',
+          'flex w-full items-center gap-0.5 truncate text-xs font-medium uppercase tracking-wider select-none',
           canSort && 'cursor-pointer hover:text-foreground'
         )}
       >

--- a/components/data-table/renderers/table-body.tsx
+++ b/components/data-table/renderers/table-body.tsx
@@ -27,7 +27,7 @@ import { cn } from '@/lib/utils'
 
 const VIRTUALIZED_CELL_CLASS = 'text-sm whitespace-nowrap tabular-nums'
 const STANDARD_CELL_CLASS = 'text-sm align-middle break-words tabular-nums'
-const DEFAULT_COLUMN_SIZE = 150
+const DEFAULT_COLUMN_SIZE = 110
 
 function getCellWidth<TData extends RowData>(cell: Cell<TData, unknown>) {
   return (

--- a/components/data-table/renderers/table-header.tsx
+++ b/components/data-table/renderers/table-header.tsx
@@ -55,14 +55,25 @@ function ColumnResizer({ header, onAutoFit }: ColumnResizerProps) {
       role="separator"
       aria-orientation="vertical"
       aria-valuenow={header.column.getSize()}
-      onMouseDown={header.getResizeHandler()}
-      onTouchStart={header.getResizeHandler()}
-      onDoubleClick={handleDoubleClick}
+      onMouseDown={(e) => {
+        e.stopPropagation()
+        header.getResizeHandler()(e)
+      }}
+      onTouchStart={(e) => {
+        e.stopPropagation()
+        header.getResizeHandler()(e)
+      }}
+      onClick={(e) => e.stopPropagation()}
+      onDoubleClick={(e) => {
+        e.stopPropagation()
+        handleDoubleClick()
+      }}
       className={cn(
-        'absolute right-0 top-0 h-full w-1 cursor-col-resize select-none touch-none',
-        'bg-transparent hover:bg-primary/50 active:bg-primary',
-        'transition-colors',
-        header.column.getIsResizing() && 'bg-primary'
+        'absolute right-0 top-0 z-10 h-full w-2 -mr-1 cursor-col-resize select-none touch-none',
+        'after:absolute after:right-1 after:top-0 after:h-full after:w-px',
+        'after:bg-border/40 hover:after:bg-primary active:after:bg-primary',
+        'after:transition-colors',
+        header.column.getIsResizing() && 'after:bg-primary'
       )}
       title={
         onAutoFit

--- a/lib/query-config/tables/tables-overview.ts
+++ b/lib/query-config/tables/tables-overview.ts
@@ -108,6 +108,22 @@ export const tablesOverviewConfig: QueryConfig = {
   clickhouseSettings: {
     allow_experimental_analyzer: 0,
   },
+  columnSizing: {
+    table: { size: 280, minSize: 160 },
+    compressed: { size: 110, minSize: 80 },
+    uncompressed: { size: 110, minSize: 80 },
+    compr_rate: { size: 90, minSize: 70 },
+    avg_part_size_compressed: { size: 110, minSize: 80 },
+    avg_part_size_uncompressed: { size: 110, minSize: 80 },
+    max_part_size_compressed: { size: 110, minSize: 80 },
+    max_part_size_uncompressed: { size: 110, minSize: 80 },
+    total_rows: { size: 110, minSize: 80 },
+    parts_count: { size: 80, minSize: 60 },
+    latest_modification: { size: 150, minSize: 120 },
+    primary_keys_size: { size: 110, minSize: 80 },
+    detached_bytes_on_disk: { size: 110, minSize: 80 },
+    engine: { size: 130, minSize: 90 },
+  },
   sortingFns: {
     compressed: 'sort_column_using_actual_value',
     uncompressed: 'sort_column_using_actual_value',


### PR DESCRIPTION
## Summary

Fixes the issues observed on `/tables-overview`:

- **Sort wasn't reliable** — the header click target was an inline-flex sized to the uppercase label only, so clicks just outside the small text did nothing. Now the clickable region spans the full header cell.
- **Column resize wasn't usable** — the resize handle was only `w-1` (4px) and pointer events bubbled to sort. Widened to a 2px handle with a visible separator and `stopPropagation` so drag never triggers sort.
- **Dense rows still looked tall** — `BackgroundBarFormat` was forcing `min-h-[1.75rem]` and `flex items-center`, which vertically centered content in oversized rows regardless of density. Removed the min-height and inner horizontal padding so the bar respects the active density.
- **Too few columns visible** — `DEFAULT_COLUMN_SIZE` dropped from 150 to 110, and `tables-overview` config now declares per-column sizing so all 14 columns fit on typical desktop widths.

## Test plan

- [x] `bun run type-check` passes
- [x] `bun run test:unit` — only pre-existing unrelated failure (`query-detail` version order) remains
- [ ] Manual: open `/tables-overview?host=0`
  - Click any column header anywhere in the cell → sorts
  - Drag right border of any header → resizes (no sort toggle)
  - Toggle Density → Dense → rows actually compact, bars hug row height
  - More than 4 columns visible without horizontal scroll at 1440+ widths

## Summary by Sourcery

Improve data table header interactions, background bar density behavior, and default column sizing for the tables overview view.

Bug Fixes:
- Make column header sort hit area span the full header cell and avoid interference from resize interactions.
- Ensure column resize uses a wider, visually indicated handle that does not trigger sorting while dragging.
- Align background bar cells with row density by removing fixed minimum height and extra inner padding.

Enhancements:
- Adjust default and per-column widths for the tables overview query so more columns are visible on typical desktop screens.
- Refine header and background bar styling, including truncation and rounding, for better usability and layout in dense tables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined table cell styling and spacing for improved visual layout
  * Enhanced column header display with better content alignment and text truncation support

* **Bug Fixes**
  * Fixed column resizer interaction to prevent accidental triggering of other header controls

* **Chores**
  * Optimized default table column widths for better content display
  * Added column sizing configuration for consistent table layout

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->