### PR TITLE
fix: table resize + agent UI cleanup + longer agent step budget

### DIFF
--- a/app/api/v1/agent/route.ts
+++ b/app/api/v1/agent/route.ts
@@ -45,8 +45,12 @@ export const dynamic = 'force-dynamic'
 const AGENT_DEBUG_LOGS = process.env.NODE_ENV !== 'production'
 
 const AGENT_MAX_REQUEST_SIZE_BYTES = 128 * 1024
-const AGENT_STREAM_TIMEOUT_MS = 30_000
-const AGENT_STREAM_STEP_TIMEOUT_MS = 12_000
+// Free / routed providers can take 20-40s between a tool call and the
+// follow-up summary. The previous 12s step/chunk budget killed the loop
+// after the first tool call on slower models. Give it real room and let
+// stepCountIs(maxSteps) remain the actual termination guard.
+const AGENT_STREAM_TIMEOUT_MS = 120_000
+const AGENT_STREAM_STEP_TIMEOUT_MS = 45_000
 const AGENT_MAX_MESSAGES = 64
 const AGENT_MAX_MESSAGE_PARTS = 64
 const AGENT_MAX_USER_MESSAGE_LENGTH = 8_192

--- a/components/agents/welcome/agent-model-picker.tsx
+++ b/components/agents/welcome/agent-model-picker.tsx
@@ -128,7 +128,6 @@ export function AgentModelPicker({
               <span className="text-muted-foreground">:</span>
               <span className="text-foreground">{selected.name}</span>
             </span>
-            <ChevronDownIcon className="size-2.5 opacity-60" />
           </Button>
         ) : (
           <button

--- a/components/agents/welcome/composer-toolbar.tsx
+++ b/components/agents/welcome/composer-toolbar.tsx
@@ -17,12 +17,7 @@
  * is a sibling that lives in the same outer card.
  */
 
-import {
-  ChevronDownIcon,
-  HashIcon,
-  SparklesIcon,
-  WrenchIcon,
-} from 'lucide-react'
+import { HashIcon, SparklesIcon, WrenchIcon } from 'lucide-react'
 
 import { useMemo, useState } from 'react'
 import { AgentModelPicker } from '@/components/agents/welcome/agent-model-picker'
@@ -98,7 +93,6 @@ export function ComposerToolbar({
               </span>
               <span className="tabular-nums">/{totalSkillCount}</span> skills
             </span>
-            <ChevronDownIcon className="size-2.5 opacity-60" />
           </Button>
         </PopoverTrigger>
         <PopoverContent
@@ -185,7 +179,6 @@ export function ComposerToolbar({
               </span>
               <span className="tabular-nums">/{allTools.length}</span> tools
             </span>
-            <ChevronDownIcon className="size-2.5 opacity-60" />
           </Button>
         </PopoverTrigger>
         <PopoverContent

--- a/components/assistant-ui/thread.tsx
+++ b/components/assistant-ui/thread.tsx
@@ -68,7 +68,7 @@ export function Thread({
       className="aui-root flex h-full flex-col overflow-hidden bg-background"
       style={{ ['--thread-max-width' as string]: '46rem' }}
     >
-      <ThreadPrimitive.Viewport className="relative flex flex-1 flex-col overflow-y-auto scroll-smooth px-4">
+      <ThreadPrimitive.Viewport className="relative flex flex-1 flex-col overflow-y-auto scroll-smooth px-4 pt-14">
         <ThreadWelcome
           firstName={firstName}
           clusterName={clusterName}

--- a/components/data-table/renderers/table-header.tsx
+++ b/components/data-table/renderers/table-header.tsx
@@ -55,7 +55,10 @@ function ColumnResizer({ header, onAutoFit }: ColumnResizerProps) {
       role="separator"
       aria-orientation="vertical"
       aria-valuenow={header.column.getSize()}
-      onMouseDown={(e) => {
+      // PointerSensor (dnd-kit) listens for pointerdown to start a column
+      // drag; stop it here so resize wins. Also block the synthetic click so
+      // the header sort handler doesn't fire on mouseup.
+      onPointerDown={(e) => {
         e.stopPropagation()
         header.getResizeHandler()(e)
       }}
@@ -63,13 +66,14 @@ function ColumnResizer({ header, onAutoFit }: ColumnResizerProps) {
         e.stopPropagation()
         header.getResizeHandler()(e)
       }}
+      onMouseDown={(e) => e.stopPropagation()}
       onClick={(e) => e.stopPropagation()}
       onDoubleClick={(e) => {
         e.stopPropagation()
         handleDoubleClick()
       }}
       className={cn(
-        'absolute right-0 top-0 z-10 h-full w-2 -mr-1 cursor-col-resize select-none touch-none',
+        'absolute right-0 top-0 z-20 h-full w-2 -mr-1 cursor-col-resize select-none touch-none',
         'after:absolute after:right-1 after:top-0 after:h-full after:w-px',
         'after:bg-border/40 hover:after:bg-primary active:after:bg-primary',
         'after:transition-colors',


### PR DESCRIPTION
Bundles four follow-ups from today's review of `/tables-overview` and `/agents`:

## 1. Table column resize finally works
Hover already showed the resize tooltip (#1180), but dragging did nothing. Root cause: dnd-kit's `PointerSensor` listens on `pointerdown` at the document level, and the `TableHead` is registered as sortable via `setNodeRef` — so PointerSensor observed the pointerdown bubbling up from the resize handle and armed a drag before TanStack's `mousedown`-based resize handler ever ran.

Fix: move the resize handler from `onMouseDown` → `onPointerDown` with `stopPropagation`. Pointer events fire first in the event order, so this preempts dnd-kit cleanly. Resizer also bumped to `z-20` to stay above adjacent cell content.

## 2. Agent composer pills
Removed `ChevronDownIcon` from model picker, skills, and tools buttons. Popovers still open on click; the buttons now read as plain pills (consistent with "Add context").

## 3. Chat header overlap
Floating "Conversations" / "Agent settings" buttons (`absolute top-3 …`) were colliding with the first user message bubble. Added `pt-14` to the Thread viewport so message content always clears the toolbar.

## 4. "Model stops after first tool call"
Cause: `AGENT_STREAM_STEP_TIMEOUT_MS = 12s` and `AGENT_STREAM_TIMEOUT_MS = 30s` were too tight for free / routed OpenRouter models, which routinely take 20–40s between the first tool result and the follow-up summary. The loop was being aborted by timeout right after the first tool call — visually identical to "the model gave up." Bumped step → 45s, total → 120s. `stepCountIs(maxSteps)` remains the real termination guard.

## Test plan
- [x] `bun run type-check`
- [ ] `/tables-overview?host=0` — drag any column edge; column actually resizes
- [ ] `/agents` — composer buttons show no chevrons
- [ ] `/agents` — long first user message doesn't sit under "Agent settings"
- [ ] `/agents` — ask a question that triggers a tool call on `openrouter/free`; model returns the follow-up summary instead of stopping

## Summary by Sourcery

Adjust agent timeouts, fix table column resizing, and clean up the agents UI layout and controls.

Bug Fixes:
- Ensure table column resize handles work reliably without conflicting with drag-and-drop sorting.
- Prevent the chat thread header from overlapping the first message in agent conversations.
- Allow agent tool-using conversations to continue past the first tool call by extending stream timeouts.

Enhancements:
- Simplify the appearance of agent composer and model picker buttons by removing dropdown chevrons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended timeout limits for agent operations to prevent premature termination on slower AI providers
  * Improved column resizer interaction to prioritize resize operations over drag-and-drop reordering

* **Style**
  * Removed dropdown indicator icons from model picker and toolbar buttons
  * Adjusted thread viewport spacing for better content visibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->