### PR TITLE
fix(agent): change default model away from broken preset

### DIFF
--- a/lib/ai/agent-model-registry.ts
+++ b/lib/ai/agent-model-registry.ts
@@ -18,7 +18,13 @@ export interface ModelEntry {
   providers: string[]
 }
 
-export const DEFAULT_AGENT_MODEL = 'anyrouter:@preset/chmonitor'
+// NOTE: do not default to `anyrouter:@preset/chmonitor` until the preset
+// is rerouted away from `z-ai/glm-4.7-flash`. That model emits prose that
+// *describes* tool calls instead of producing structured tool_calls, so the
+// agent loop exits after step 1 with no tools ever invoked (verified
+// 2026-05-27 against /api/v1/agent). Gemma 4 26B via AnyRouter completes a
+// full two-step tool loop cleanly and stays effectively free.
+export const DEFAULT_AGENT_MODEL = 'anyrouter:google/gemma-4-26b-a4b-it'
 
 export const MODEL_REGISTRY: readonly ModelEntry[] = [
   // ── Presets (auto-routing via AnyRouter) ──

--- a/lib/ai/agent-models.test.ts
+++ b/lib/ai/agent-models.test.ts
@@ -18,7 +18,7 @@ describe('AnyRouter model registry', () => {
   test('includes the curated AnyRouter models and OpenRouter free default', () => {
     const options = getAllModelOptions()
 
-    expect(DEFAULT_AGENT_MODEL).toBe('openrouter:openrouter/free')
+    expect(DEFAULT_AGENT_MODEL).toBe('anyrouter:google/gemma-4-26b-a4b-it')
     expect(options).toContain('openrouter:openrouter/free')
     expect(options).toContain('anyrouter:z-ai/glm-4.7-flash')
     expect(options).toContain('anyrouter:google/gemini-3.1-flash-lite')


### PR DESCRIPTION
## Why
Verified the AnyRouter→agent loop end-to-end against `/api/v1/agent` today. Four results:

| Model | stepCount | Tool call | Final answer |
|---|---|---|---|
| `anyrouter:@preset/chmonitor` (current default) | 1 | ❌ prose only | never arrives |
| `anyrouter:google/gemini-3.1-flash-lite` | 1 | ✅ once | 400: missing \`thought_signature\` |
| `anyrouter:qwen/qwen3.5-397b-a17b` | 2 | ✅ | ✅ \"There are 14 databases on this host.\" |
| `anyrouter:google/gemma-4-26b-a4b-it` | 2 | ✅ | ✅ proper summary |

The preset currently resolves to `z-ai/glm-4.7-flash`, which emits text *about* using a tool (\`I'll check the databases using the list_databases tool\`) instead of producing structured tool_calls. ToolLoopAgent sees no tool calls, the loop exits at step 1, and the user-visible symptom is exactly what was reported: \"model stops responding after the first tool call.\"

## Change
- `DEFAULT_AGENT_MODEL`: `anyrouter:@preset/chmonitor` → `anyrouter:google/gemma-4-26b-a4b-it`
- Comment explaining the choice (and the fact that the preset itself can be repointed on AnyRouter's dashboard if we want to go back to it)
- Test updated to match

## Test plan
- [x] `bun run type-check`
- [x] `bun test lib/ai/agent-models.test.ts`
- [x] Manual: `POST /api/v1/agent` with no `model` field on a fresh install (no `LLM_MODEL` env) returns a 2-step tool loop with a real answer
- [ ] Note for ops: live deployments that override `LLM_MODEL` in `.env.prod` need to either drop the override or retarget the `@preset/chmonitor` preset on AnyRouter to a tool-capable model before this default takes effect for them

## Summary by Sourcery

Update the default agent model to use a tool-capable AnyRouter model that completes the agent loop successfully.

Enhancements:
- Change the default agent model from an unreliable preset to `anyrouter:google/gemma-4-26b-a4b-it` based on verified tool-loop behavior.

Tests:
- Adjust the AnyRouter model registry test to expect the new default agent model while preserving coverage of other available options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default AI model to improve agent reliability and performance. The new model provides enhanced stability during complex operations with better support for multi-step workflows and consistent tool execution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->