### PR TITLE
fix(data-table): scale heading in compact/dense density modes

### DIFF
--- a/components/assistant-ui/thread.tsx
+++ b/components/assistant-ui/thread.tsx
@@ -66,7 +66,13 @@ export function Thread({
   return (
     <ThreadPrimitive.Root
       className="aui-root flex h-full flex-col overflow-hidden bg-background"
-      style={{ ['--thread-max-width' as string]: '46rem' }}
+      style={{
+        // User messages and composer stay narrow for readability.
+        // Assistant responses (charts, tables, SQL) use the full container width.
+        ['--thread-max-width' as string]: 'min(100%, 56rem)',
+        ['--assistant-max-width' as string]: '100%',
+        ['--user-max-width' as string]: 'min(100%, 46rem)',
+      }}
     >
       <ThreadPrimitive.Viewport className="relative flex flex-1 flex-col overflow-y-auto scroll-smooth px-4 pt-14">
         <ThreadWelcome
@@ -212,7 +218,7 @@ function ThreadComposer() {
 
 const UserMessage: FC = () => {
   return (
-    <MessagePrimitive.Root className="mx-auto w-full max-w-[var(--thread-max-width)] py-3">
+    <MessagePrimitive.Root className="mx-auto w-full max-w-[var(--user-max-width)] py-3">
       <div className="flex flex-col items-end gap-1">
         <UserActionBar />
         <div className="bg-muted text-foreground max-w-[80%] break-words rounded-2xl rounded-br-sm px-4 py-2 text-sm">
@@ -292,7 +298,7 @@ const ReasoningPart: ReasoningMessagePartComponent = ({ text }) => {
  */
 const AssistantMessage: FC = () => {
   return (
-    <MessagePrimitive.Root className="mx-auto w-full max-w-[var(--thread-max-width)] py-3">
+    <MessagePrimitive.Root className="mx-auto w-full max-w-[var(--assistant-max-width)] py-3">
       <div className="text-foreground flex flex-col gap-1.5">
         <MessagePrimitive.Parts
           components={{

--- a/components/cards/card-toolbar.tsx
+++ b/components/cards/card-toolbar.tsx
@@ -110,7 +110,10 @@ function CopyableValue({
   return (
     <button
       onClick={handleCopy}
-      className={`font-mono font-medium text-right truncate min-w-0 hover:text-primary cursor-pointer transition-colors inline-flex items-center gap-1 group/copy ${className}`}
+      className={cn(
+        'font-mono font-medium text-right truncate min-w-0 hover:text-primary cursor-pointer transition-colors inline-flex items-center gap-1 group/copy',
+        className
+      )}
       title={`Click to copy: ${value}`}
     >
       <span className="truncate">{value}</span>

--- a/components/charts/chart-zoom-dialog.tsx
+++ b/components/charts/chart-zoom-dialog.tsx
@@ -90,7 +90,10 @@ function CopyableValue({
       <TooltipTrigger asChild>
         <button
           onClick={handleCopy}
-          className={`font-mono font-medium text-right truncate min-w-0 hover:text-primary cursor-pointer transition-colors inline-flex items-center gap-1 group/copy ${className}`}
+          className={cn(
+            'font-mono font-medium text-right truncate min-w-0 hover:text-primary cursor-pointer transition-colors inline-flex items-center gap-1 group/copy',
+            className
+          )}
         >
           <span className="truncate">{value}</span>
           {copied ? (

--- a/components/charts/primitives/tooltip-color-indicator.tsx
+++ b/components/charts/primitives/tooltip-color-indicator.tsx
@@ -8,6 +8,8 @@
 
 import type { HTMLAttributes } from 'react'
 
+import { cn } from '@/lib/utils'
+
 interface TooltipColorIndicatorProps extends HTMLAttributes<HTMLDivElement> {
   colorVar: string
   size?: 'default' | 'small'
@@ -27,7 +29,11 @@ export function TooltipColorIndicator({
 
   return (
     <div
-      className={`${sizeClass} shrink-0 rounded-[2px] bg-(--color-bg) ${className}`}
+      className={cn(
+        'shrink-0 rounded-[2px] bg-(--color-bg)',
+        sizeClass,
+        className
+      )}
       style={
         {
           '--color-bg': colorVar,

--- a/components/charts/summary-stuck-mutations.tsx
+++ b/components/charts/summary-stuck-mutations.tsx
@@ -10,6 +10,7 @@ import { ChartEmpty } from '@/components/charts/chart-empty'
 import { ChartError } from '@/components/charts/chart-error'
 import { ChartSkeleton } from '@/components/skeletons'
 import { useChartData } from '@/lib/swr'
+import { cn } from '@/lib/utils'
 
 interface MutationMetrics extends ChartDataPoint {
   active: number
@@ -71,7 +72,10 @@ export const ChartSummaryStuckMutations = memo(
                 {METRIC_CONFIGS.map(({ key, label, activeColor }) => (
                   <span key={key}>
                     <span
-                      className={`text-2xl font-bold ${metrics[key] > 0 ? activeColor : ''}`}
+                      className={cn(
+                        'text-2xl font-bold',
+                        metrics[key] > 0 && activeColor
+                      )}
                     >
                       {metrics[key]}
                     </span>{' '}

--- a/components/dashboard/chart-picker.tsx
+++ b/components/dashboard/chart-picker.tsx
@@ -18,6 +18,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
 
 // Category display labels
 const CATEGORY_LABELS: Record<string, string> = {
@@ -81,17 +82,20 @@ export function ChartPicker({ selectedCharts, onChange }: ChartPickerProps) {
                     key={chartName}
                     type="button"
                     onClick={() => toggle(chartName)}
-                    className={`
-                      flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm
-                      hover:bg-accent hover:text-accent-foreground
-                      ${checked ? 'font-medium text-foreground' : 'text-muted-foreground'}
-                    `}
+                    className={cn(
+                      'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground',
+                      checked
+                        ? 'font-medium text-foreground'
+                        : 'text-muted-foreground'
+                    )}
                   >
                     <span
-                      className={`
-                        flex h-4 w-4 shrink-0 items-center justify-center rounded border
-                        ${checked ? 'border-primary bg-primary text-primary-foreground' : 'border-muted'}
-                      `}
+                      className={cn(
+                        'flex h-4 w-4 shrink-0 items-center justify-center rounded border',
+                        checked
+                          ? 'border-primary bg-primary text-primary-foreground'
+                          : 'border-muted'
+                      )}
                     >
                       {checked && (
                         <svg

--- a/components/data-table/cells/badge-format.cy.tsx
+++ b/components/data-table/cells/badge-format.cy.tsx
@@ -15,10 +15,9 @@ describe('<BadgeFormat />', () => {
     const statuses = ['success', 'warning', 'error', 'info']
     const colors = ['green', 'yellow', 'red', 'blue']
     statuses.forEach((status, index) => {
-      cy.mount(
-        <BadgeFormat value={status} className={`bg-${colors[index]}-100`} />
-      )
-      cy.get('span').should('have.class', `bg-${colors[index]}-100`)
+      const colorClass = `bg-${colors[index]}-100`
+      cy.mount(<BadgeFormat value={status} className={colorClass} />)
+      cy.get('span').should('have.class', colorClass)
     })
   })
 

--- a/components/data-table/components/data-table-header.tsx
+++ b/components/data-table/components/data-table-header.tsx
@@ -17,6 +17,7 @@ import { ResetColumnOrderButton } from '@/components/data-table/buttons/reset-co
 import { BulkActions } from '@/components/data-table/components/bulk-actions'
 import { DataTableToolbar } from '@/components/data-table/data-table-toolbar'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 import { getSqlForDisplay } from '@/types/query-config'
 
 /**
@@ -100,12 +101,30 @@ export const DataTableHeader = memo(function DataTableHeader<
 }: DataTableHeaderProps<TData>) {
   // Use executed SQL if provided, otherwise fallback to config SQL
   const displaySql = executedSql || getSqlForDisplay(queryConfig.sql)
+  const isCompact = density === 'compact' || density === 'dense'
   return (
-    <div className="flex min-w-0 shrink-0 flex-col sm:flex-row items-start justify-between gap-2 sm:gap-4 pb-2">
+    <div
+      className={cn(
+        'flex min-w-0 shrink-0 flex-col sm:flex-row items-start justify-between gap-2 sm:gap-4',
+        isCompact ? 'pb-1' : 'pb-2'
+      )}
+    >
       <div className="min-w-0 flex-1">
-        <div className="mb-2 flex flex-wrap items-center gap-1.5 sm:gap-2">
+        <div
+          className={cn(
+            'flex flex-wrap items-center gap-1.5 sm:gap-2',
+            isCompact ? 'mb-0.5' : 'mb-2'
+          )}
+        >
           <div className="flex items-center gap-2">
-            <h1 className="text-muted-foreground flex-none text-xl">{title}</h1>
+            <h1
+              className={cn(
+                'text-muted-foreground flex-none',
+                isCompact ? 'text-sm font-medium' : 'text-xl'
+              )}
+            >
+              {title}
+            </h1>
             {isRefreshing && (
               <Loader2Icon
                 className="text-muted-foreground size-4 animate-spin"
@@ -137,7 +156,12 @@ export const DataTableHeader = memo(function DataTableHeader<
             </Button>
           )}
         </div>
-        <p className="text-muted-foreground truncate text-sm">
+        <p
+          className={cn(
+            'text-muted-foreground truncate',
+            isCompact ? 'text-xs' : 'text-sm'
+          )}
+        >
           {description || queryConfig.description}
         </p>
       </div>

--- a/components/data-table/data-table.tsx
+++ b/components/data-table/data-table.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/components/data-table/hooks'
 import { getCustomSortingFns } from '@/components/data-table/sorting-fns'
 import { Checkbox } from '@/components/ui/checkbox'
+import { cn } from '@/lib/utils'
 
 /**
  * Props for the DataTable component
@@ -484,9 +485,7 @@ export function DataTable<
 
   return (
     <TableDensityProvider value={{ cellClassName }}>
-      <div
-        className={`flex min-w-0 flex-col overflow-hidden ${className || ''}`}
-      >
+      <div className={cn('flex min-w-0 flex-col overflow-hidden', className)}>
         {!compact && (
           <DataTableHeader
             title={title}

--- a/components/dialogs/dialog-sql.tsx
+++ b/components/dialogs/dialog-sql.tsx
@@ -30,7 +30,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { dedent, formatDuration } from '@/lib/utils'
+import { cn, dedent, formatDuration } from '@/lib/utils'
 
 interface ShowSQLButtonProps extends Omit<DialogContentProps, 'content'> {
   sql?: string
@@ -99,7 +99,10 @@ function CopyableValue({
   return (
     <button
       onClick={handleCopy}
-      className={`font-mono font-medium text-right truncate min-w-0 hover:text-primary cursor-pointer transition-colors inline-flex items-center gap-1 group/copy ${className}`}
+      className={cn(
+        'font-mono font-medium text-right truncate min-w-0 hover:text-primary cursor-pointer transition-colors inline-flex items-center gap-1 group/copy',
+        className
+      )}
       title={`Click to copy: ${value}`}
     >
       <span className="truncate">{value}</span>
@@ -402,7 +405,3 @@ export const DialogSQL = memo(function DialogSQL({
     />
   )
 })
-
-function cn(...classes: (string | undefined | false | null)[]) {
-  return classes.filter(Boolean).join(' ')
-}

--- a/components/explorer/explorer-empty-state.tsx
+++ b/components/explorer/explorer-empty-state.tsx
@@ -19,6 +19,7 @@ import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useHostId } from '@/lib/swr'
 import { apiFetch } from '@/lib/swr/api-fetch'
+import { cn } from '@/lib/utils'
 
 interface Database {
   name: string
@@ -164,9 +165,12 @@ export function ExplorerEmptyState() {
                 >
                   <div className="flex items-center gap-3">
                     <div
-                      className={`flex size-9 items-center justify-center rounded-md transition-colors ${bg}`}
+                      className={cn(
+                        'flex size-9 items-center justify-center rounded-md transition-colors',
+                        bg
+                      )}
                     >
-                      <Icon className={`size-4 ${color}`} />
+                      <Icon className={cn('size-4', color)} />
                     </div>
                     <div className="flex-1 min-w-0">
                       <p className="font-medium truncate">{db.name}</p>

--- a/components/feedback/error-alert/variants/compact.tsx
+++ b/components/feedback/error-alert/variants/compact.tsx
@@ -10,6 +10,7 @@ import type React from 'react'
 import type { ErrorAlertVariant } from '../error-alert-variants'
 
 import { getVariantStyles } from '../error-alert-variants'
+import { cn } from '@/lib/utils'
 
 export interface CompactErrorAlertProps {
   title: string
@@ -30,7 +31,11 @@ export function CompactErrorAlert({
 
   return (
     <div
-      className={`${className} ${getVariantStyles(variant)} rounded-lg border p-2`}
+      className={cn(
+        'rounded-lg border p-2',
+        getVariantStyles(variant),
+        className
+      )}
       data-testid="error-message-compact"
       role="alert"
       aria-live="polite"

--- a/components/feedback/error-alert/variants/full.tsx
+++ b/components/feedback/error-alert/variants/full.tsx
@@ -22,6 +22,7 @@ import { getVariantStyles } from '../error-alert-variants'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { getEnvironment, shouldShowDetailedErrors } from '@/lib/env-utils'
+import { cn } from '@/lib/utils'
 
 export interface FullErrorAlertProps {
   title: string
@@ -63,7 +64,11 @@ export function FullErrorAlert({
 
   return (
     <div
-      className={`${className} ${getVariantStyles(variant)} rounded-lg border p-4`}
+      className={cn(
+        'rounded-lg border p-4',
+        getVariantStyles(variant),
+        className
+      )}
       data-testid="error-message-full"
       role="alert"
       aria-live="polite"

--- a/components/host/host-switcher.tsx
+++ b/components/host/host-switcher.tsx
@@ -29,7 +29,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { useHostId } from '@/lib/swr'
 import { useHosts } from '@/lib/swr/use-hosts'
 import { buildUrl } from '@/lib/url/url-builder'
-import { getHost } from '@/lib/utils'
+import { cn, getHost } from '@/lib/utils'
 
 /**
  * Host switcher component for sidebar header.
@@ -65,7 +65,10 @@ export function HostSwitcher() {
         <SidebarMenuItem>
           <SidebarMenuButton size="lg" asChild>
             <div
-              className={`flex gap-2 ${showExpanded ? 'items-center' : 'items-center justify-center'}`}
+              className={cn(
+                'flex gap-2',
+                showExpanded ? 'items-center' : 'items-center justify-center'
+              )}
             >
               <div className="relative">
                 <ClickHouseLogo width={20} height={20} className="size-5" />
@@ -99,7 +102,10 @@ export function HostSwitcher() {
           // Single host: simplified display without dropdown
           <SidebarMenuButton size="lg" asChild>
             <div
-              className={`flex gap-2 ${showExpanded ? 'items-center' : 'items-center justify-center'}`}
+              className={cn(
+                'flex gap-2',
+                showExpanded ? 'items-center' : 'items-center justify-center'
+              )}
             >
               <div className="relative">
                 <ClickHouseLogo width={20} height={20} className="size-5" />
@@ -129,7 +135,12 @@ export function HostSwitcher() {
                 asChild
               >
                 <div
-                  className={`flex gap-2 ${showExpanded ? 'items-center' : 'items-center justify-center'}`}
+                  className={cn(
+                    'flex gap-2',
+                    showExpanded
+                      ? 'items-center'
+                      : 'items-center justify-center'
+                  )}
                 >
                   <div className="relative">
                     <ClickHouseLogo width={20} height={20} className="size-5" />

--- a/docs/anyrouter-bugs.md
+++ b/docs/anyrouter-bugs.md
@@ -1,0 +1,283 @@
+# AnyRouter — two bugs blocking tool-calling agents
+
+Reproduced 2026-05-27 against `https://anyrouter.dev/api/v1` with my own
+API key. Both bugs cause tool-using agent loops to fail at step 2, with
+identical user-facing symptom: "the model stops responding after the
+first tool call." Diagnosed by comparing AnyRouter's response to what
+an OpenAI-compatible client/agent runtime expects.
+
+---
+
+## Bug 1 — `@preset/chmonitor` (and any preset resolving to `z-ai/glm-4.7-flash`) never produces structured tool_calls
+
+### What I see
+The preset currently resolves to `z-ai/glm-4.7-flash` via the `deepinfra`
+backend. Given a tool definition and a prompt that explicitly asks it to
+call the tool, the model returns:
+
+- `choices[0].message.tool_calls: []` (empty)
+- `choices[0].message.content: ""`
+- `choices[0].message.reasoning_content: "..."` — full chain-of-thought
+  text *describing* the tool call ("I need to look for a tool named
+  `list_databases` in my available tools…") instead of producing one
+- `finish_reason: "length"` because the reasoning consumed the budget
+
+So clients see no tool calls, no final answer, and a `finish_reason`
+that's not even `stop` or `tool_calls`. Any agent loop terminates after
+step 1 with nothing useful.
+
+### Minimal repro (direct, bypasses my stack entirely)
+
+```bash
+curl -sS -X POST https://anyrouter.dev/api/v1/chat/completions \
+  -H "Authorization: Bearer $ANYROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "@preset/chmonitor",
+    "messages": [
+      {"role":"user","content":"Call the list_databases tool and tell me how many you see."}
+    ],
+    "tools": [{
+      "type":"function",
+      "function":{
+        "name":"list_databases",
+        "description":"List ClickHouse databases on the connected host",
+        "parameters":{"type":"object","properties":{},"required":[]}
+      }
+    }],
+    "tool_choice": "auto",
+    "max_tokens": 300
+  }'
+```
+
+### Observed response (trimmed)
+
+```json
+{
+  "model": "z-ai/glm-4.7-flash",
+  "choices": [{
+    "message": {
+      "role": "assistant",
+      "content": "",
+      "reasoning_content": "The user wants to know how many databases I see using the `list_databases` tool. 1. Analyze the Request: ...",
+      "tool_calls": []
+    },
+    "finish_reason": "length"
+  }],
+  "provider": "deepinfra",
+  "anyrouter_metadata": {
+    "requestId": "req_dc3ad1c5ccad43e09cdccdf6",
+    "model": "z-ai/glm-4.7-flash",
+    "upstream": { "provider": "deepinfra", "backend": "deepinfra", "latencyMs": 30986 }
+  }
+}
+```
+
+Sample failing requestIds from my tests:
+- `req_dc3ad1c5ccad43e09cdccdf6` (direct, with tools)
+- `req_8787a2e30c4e4c0d9d52476b` (direct, no tools — also went to glm-4.7-flash)
+
+### What should happen
+Either:
+
+1. **Preset routing fix (preferred):** `@preset/chmonitor` should route
+   to a model that actually emits OpenAI-format `tool_calls` when given
+   a `tools` array — e.g. `google/gemma-4-26b-a4b-it` or
+   `qwen/qwen3.5-397b-a17b`, both of which I verified work cleanly via
+   AnyRouter today. Right now the preset is effectively broken for any
+   tool-using workload.
+2. **Model fix (less likely fixable on your side):** the
+   `z-ai/glm-4.7-flash` provider needs to be configured to emit
+   structured tool_calls, not free-form `reasoning_content`. If
+   deepinfra's chat-completions endpoint doesn't support tool emission
+   for this model, the model should not be advertised as tool-capable
+   in your routing.
+
+### Why this is an AnyRouter-side problem, not a client problem
+- The tools array uses the standard OpenAI schema.
+- Other AnyRouter-served models (`google/gemma-4-26b-a4b-it`,
+  `qwen/qwen3.5-397b-a17b`) get the same request and emit proper
+  structured tool_calls in the same response shape.
+- The model that's failing is selected by AnyRouter's preset router,
+  not the client.
+
+---
+
+## Bug 2 — `google/gemini-3.1-flash-lite` via the `cloudflare` backend strips Gemini's `thought_signature`, breaking every follow-up tool turn
+
+### What I see
+Step 1 works: model returns a normal-looking OpenAI `tool_calls` block.
+
+When the client sends the conventional follow-up — the same
+conversation plus an assistant message with the original tool_call and
+a `role: "tool"` message carrying the result — AnyRouter returns 400
+from Cloudflare:
+
+> Upstream provider "cloudflare" returned 400 Bad Request. Model
+> execution failed (User Input Error): Unable to submit request because
+> function call `list_databases` in the 2. content block is missing a
+> `thought_signature`. Learn more:
+> <https://docs.cloud.google.com/vertex-ai/generative-ai/docs/thought-signatures>
+
+This is unrecoverable from the client — Gemini requires an opaque
+`thought_signature` field to be round-tripped from the model's first
+response back into the message history. The signature *exists* on
+Gemini's side (Vertex returns it on the function_call part) but
+**AnyRouter's OpenAI-compatibility shim is not surfacing it** in the
+step-1 response, so the client has nothing to round-trip.
+
+### Minimal repro (step 1)
+
+```bash
+curl -sS -X POST https://anyrouter.dev/api/v1/chat/completions \
+  -H "Authorization: Bearer $ANYROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "google/gemini-3.1-flash-lite",
+    "messages":[{"role":"user","content":"Use the list_databases tool."}],
+    "tools":[{"type":"function","function":{"name":"list_databases","description":"List databases","parameters":{"type":"object","properties":{},"required":[]}}}]
+  }'
+```
+
+### Step-1 response — note the missing thought_signature
+
+```json
+{
+  "model": "google/gemini-3.1-flash-lite",
+  "choices": [{
+    "message": {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [{
+        "index": 0,
+        "id": "call_7ed0a01a82594254bcb40f44",
+        "type": "function",
+        "function": { "name": "list_databases", "arguments": "{}" }
+      }]
+    },
+    "finish_reason": "tool_calls"
+  }],
+  "provider": "cloudflare",
+  "anyrouter_metadata": {
+    "requestId": "req_df10061ed0934cbbb94beeac",
+    "upstream": { "provider": "cloudflare", "backend": "cloudflare", "latencyMs": 6868 }
+  }
+}
+```
+
+There is **no** `thought_signature` field anywhere in the message,
+tool_call, message metadata, or `anyrouter_metadata`. There is no way
+for the client to round-trip it because we never received it.
+
+### Step 2 (the failure)
+
+```bash
+curl -sS -X POST https://anyrouter.dev/api/v1/chat/completions \
+  -H "Authorization: Bearer $ANYROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model":"google/gemini-3.1-flash-lite",
+    "messages":[
+      {"role":"user","content":"Use the list_databases tool."},
+      {"role":"assistant","tool_calls":[{"id":"call_7ed0a01a82594254bcb40f44","type":"function","function":{"name":"list_databases","arguments":"{}"}}]},
+      {"role":"tool","tool_call_id":"call_7ed0a01a82594254bcb40f44","content":"[\"default\",\"system\",\"sentry\"]"}
+    ],
+    "tools":[{"type":"function","function":{"name":"list_databases","description":"List databases","parameters":{"type":"object","properties":{},"required":[]}}}]
+  }'
+```
+
+### Step-2 response
+
+```json
+{
+  "error": {
+    "code": "bad_request",
+    "message": "Upstream provider \"cloudflare\" returned 400 Bad Request. ... Model execution failed (User Input Error): Unable to submit request because function call `list_databases` in the 2. content block is missing a `thought_signature`. Learn more: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/thought-signatures",
+    "metadata": {
+      "upstream_backend": "cloudflare",
+      "upstream_status": 400
+    }
+  },
+  "anyrouter_metadata": {
+    "requestId": "req_dde198eb75d54643a2ae4b1c",
+    "upstream": { "provider": "cloudflare", "backend": "cloudflare", "latencyMs": 1357 },
+    "attempts": [
+      { "backend": "cloudflare", "status": 400, "isFinal": true, "errorCode": "upstream_4xx" }
+    ]
+  }
+}
+```
+
+Sample requestIds:
+- step 1: `req_df10061ed0934cbbb94beeac`
+- step 2 (the 400): `req_dde198eb75d54643a2ae4b1c`
+- another full repro end-to-end through our stack: `req_dde198eb75d54643a2ae4b1c`
+
+### What should happen
+When AnyRouter receives a tool_call from a Gemini-family upstream:
+
+1. **Capture the upstream's `thought_signature`** (Vertex returns it
+   alongside the function_call part).
+2. **Surface it to the client.** The cleanest mapping that stays
+   OpenAI-compatible is to attach it as an extension field on the
+   tool_call object, e.g.:
+
+   ```json
+   "tool_calls":[{
+     "id":"call_…",
+     "type":"function",
+     "function":{ "name":"list_databases", "arguments":"{}" },
+     "anyrouter_thought_signature":"<opaque>"
+   }]
+   ```
+
+3. **Round-trip it on the next request.** When a request comes back
+   with an assistant message containing the same tool_call id, look up
+   the cached signature (or read it from a client-supplied field) and
+   re-attach it to the Vertex `function_call` part you send upstream.
+
+The two practical implementations are: (a) AnyRouter stores
+`{requestId → signature}` keyed by tool_call_id for ~10 minutes and
+re-attaches transparently, or (b) AnyRouter exposes the signature as an
+extension field and asks clients to pass it back. Either eliminates the
+400.
+
+### Why this is an AnyRouter-side problem, not a client problem
+- The Gemini `thought_signature` is **only available** in Gemini's
+  native response format. Clients calling AnyRouter speak
+  OpenAI-compatible JSON — they cannot retrieve a field your shim
+  didn't surface.
+- The 400 explicitly identifies the Vertex / Cloudflare AI Workers
+  pipeline as the requirement source ("docs.cloud.google.com").
+- Anthropic and OpenAI native APIs do not have this concept, so a
+  client SDK like Vercel AI SDK has no portable place to put or read
+  the signature without provider-specific glue. The OpenAI-compat
+  abstraction has to handle it.
+
+---
+
+## Models I verified DO work on AnyRouter (control group)
+
+Same `/chat/completions` endpoint, same tool definition, same key.
+Both completed a full 2-step tool loop and returned a coherent final
+answer:
+
+| Model | Step 1 | Step 2 | Notes |
+|---|---|---|---|
+| `anyrouter:google/gemma-4-26b-a4b-it` | tool_calls populated | normal completion | $0 surfaced cost |
+| `anyrouter:qwen/qwen3.5-397b-a17b` | tool_calls populated | normal completion | ~$0.012 / call |
+
+So the contract clearly works end-to-end through AnyRouter when the
+underlying model is well-behaved and (in Gemini's case) routed through
+a backend that doesn't require signature round-tripping. The two bugs
+above are specific to the broken combinations.
+
+## Environment
+
+- API base: `https://anyrouter.dev/api/v1`
+- Client: direct `curl` (verified) and Vercel AI SDK ToolLoopAgent
+  through Next.js 15 (also verified, same symptoms)
+- Date of repro: 2026-05-27 UTC
+- Key: same `sk-ar-v1-…` used in production for the ClickHouse
+  Monitoring deploy at chmonitor.dev (happy to share specific
+  requestIds privately if you need account scope to look them up)

--- a/docs/anyrouter-bugs.md
+++ b/docs/anyrouter-bugs.md
@@ -11,6 +11,7 @@ an OpenAI-compatible client/agent runtime expects.
 ## Bug 1 — `@preset/chmonitor` (and any preset resolving to `z-ai/glm-4.7-flash`) never produces structured tool_calls
 
 ### What I see
+
 The preset currently resolves to `z-ai/glm-4.7-flash` via the `deepinfra`
 backend. Given a tool definition and a prompt that explicitly asks it to
 call the tool, the model returns:
@@ -78,6 +79,7 @@ Sample failing requestIds from my tests:
 - `req_8787a2e30c4e4c0d9d52476b` (direct, no tools — also went to glm-4.7-flash)
 
 ### What should happen
+
 Either:
 
 1. **Preset routing fix (preferred):** `@preset/chmonitor` should route
@@ -94,6 +96,7 @@ Either:
    in your routing.
 
 ### Why this is an AnyRouter-side problem, not a client problem
+
 - The tools array uses the standard OpenAI schema.
 - Other AnyRouter-served models (`google/gemma-4-26b-a4b-it`,
   `qwen/qwen3.5-397b-a17b`) get the same request and emit proper
@@ -106,6 +109,7 @@ Either:
 ## Bug 2 — `google/gemini-3.1-flash-lite` via the `cloudflare` backend strips Gemini's `thought_signature`, breaking every follow-up tool turn
 
 ### What I see
+
 Step 1 works: model returns a normal-looking OpenAI `tool_calls` block.
 
 When the client sends the conventional follow-up — the same
@@ -214,6 +218,7 @@ Sample requestIds:
 - another full repro end-to-end through our stack: `req_dde198eb75d54643a2ae4b1c`
 
 ### What should happen
+
 When AnyRouter receives a tool_call from a Gemini-family upstream:
 
 1. **Capture the upstream's `thought_signature`** (Vertex returns it
@@ -243,6 +248,7 @@ extension field and asks clients to pass it back. Either eliminates the
 400.
 
 ### Why this is an AnyRouter-side problem, not a client problem
+
 - The Gemini `thought_signature` is **only available** in Gemini's
   native response format. Clients calling AnyRouter speak
   OpenAI-compatible JSON — they cannot retrieve a field your shim

--- a/docs/knowledge/conventions.md
+++ b/docs/knowledge/conventions.md
@@ -39,6 +39,17 @@ related:
 - Create wrapper components in `components/` (not `components/ui/`) if needed
 - Use `cn()` utility to merge classes
 
+## className Composition
+
+**Always use `cn()` for className — never string concatenation or template literals.**
+
+- Bad: `` className={`flex ${isActive ? 'text-red' : 'text-gray'}`} ``
+- Bad: `className={'flex ' + (isActive ? 'text-red' : 'text-gray')}`
+- Good: `className={cn('flex', isActive ? 'text-red' : 'text-gray')}`
+- Good: `className={cn('flex', isActive && 'text-red')}`
+
+Reason: `cn()` (clsx + tailwind-merge) deduplicates conflicting Tailwind classes (e.g. `p-2 p-4` → `p-4`) and handles falsy values cleanly. Template literals leave conflicting classes in place, causing unpredictable specificity bugs.
+
 ## Query Patterns
 
 - All queries include `QUERY_COMMENT` for identification (applied centrally in `fetchData()`)

--- a/lib/ai/agent-models.test.ts
+++ b/lib/ai/agent-models.test.ts
@@ -20,7 +20,7 @@ describe('isFreeAgentModel', () => {
 })
 
 describe('AnyRouter model registry', () => {
-  test('includes the curated AnyRouter models and OpenRouter free default', () => {
+  test('defaults to AnyRouter Gemma 4 26B and includes curated free models', () => {
     const options = getAllModelOptions()
 
     expect(DEFAULT_AGENT_MODEL).toBe('anyrouter:google/gemma-4-26b-a4b-it')


### PR DESCRIPTION
## Summary
- Heading title, description, and padding now shrink when density is `compact` or `dense`, restoring vertical rhythm against denser row spacing.
- Refactored to use `cn()` for className composition.
- Documents the `cn()`-only convention in `docs/knowledge/conventions.md`.

## Test plan
- [ ] Visit `/replicas?host=0`, open density toggle, switch between Comfortable / Compact / Dense — heading size and padding should scale.
- [ ] Comfortable mode unchanged.
- [ ] CI green.

## Summary by Sourcery

Adjust data table header styling for compact and dense densities and update the default agent model configuration.

New Features:
- Scale the data table header title, description, and padding according to compact and dense density modes to match row spacing.

Enhancements:
- Refine data table header className composition to use the shared cn() utility.
- Document the convention to always use cn() for className composition in React components.
- Change the default agent model to an AnyRouter-backed Gemma 4 26B configuration to avoid tool-calling issues with the previous preset.

Tests:
- Update agent model registry tests to assert the new default agent model id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Data table headers now adapt spacing and typography for compact vs. regular density.
  * Improved default agent model for more reliable multi-step task execution.

* **Documentation**
  * Added className composition conventions.
  * New diagnostic guide documenting reproducible issues and repro steps for external routing models.

* **Tests**
  * Updated tests to reflect the new default agent model.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->