### PR TITLE
fix(agents): tighten SQL/code block vertical spacing

### DIFF
--- a/components/agents/markdown-code.css
+++ b/components/agents/markdown-code.css
@@ -1,5 +1,30 @@
 /* Markdown code blocks with theme-aware syntax highlighting */
 
+/*
+ * Streamdown code-block spacing overrides.
+ *
+ * Streamdown renders:
+ *   [data-streamdown="code-block"]      outer card  (gap-2, p-2 by default)
+ *   [data-streamdown="code-block-header"] language label row (h-8)
+ *   [data-streamdown="code-block-body"]  code area   (p-4 by default)
+ *
+ * The default gap + body padding stacks to ~64 px of dead space above the
+ * first line of code.  These overrides tighten it to ~8 px while keeping
+ * the copy/download buttons, language label, line numbers, and horizontal
+ * scroll intact.
+ */
+
+/* Reduce the column gap between the language header and the code body */
+.markdown-content [data-streamdown='code-block'] {
+  gap: 0.25rem; /* 4 px instead of 8 px */
+}
+
+/* Tighten vertical padding inside the code body */
+.markdown-content [data-streamdown='code-block-body'] {
+  padding-top: 0.5rem;    /* 8 px instead of 16 px */
+  padding-bottom: 0.5rem; /* 8 px instead of 16 px */
+}
+
 /* Base code block styling */
 .markdown-content pre {
   background-color: hsl(var(--muted));


### PR DESCRIPTION
## Problem

Streamdown's default styles stack ~64 px of dead space above the first code line inside fenced code blocks (```sql, ```json, ```bash, ```ts, etc.):

- Outer container: `gap-2` (8 px) between language label and code body
- Code body: `p-4` (16 px top/bottom padding)

Combined with the 32 px language header, this produced the visible ~80 px empty gap reported by the user.

## Fix

Two CSS overrides in `components/agents/markdown-code.css`, scoped to `.markdown-content` to avoid leaking:

- `[data-streamdown='code-block']`: gap reduced from 8 px → 4 px
- `[data-streamdown='code-block-body']`: top/bottom padding reduced from 16 px → 8 px

Preserves: language label, copy button, download button, line numbers, horizontal scroll.

## Summary by Sourcery

Enhancements:
- Adjust Streamdown code block gap and padding within .markdown-content to significantly reduce empty space above code in fenced blocks.