### PR TITLE
feat(agents): MCP config panel in right sidebar

### DIFF
--- a/components/agents/welcome/agent-mcp-panel.tsx
+++ b/components/agents/welcome/agent-mcp-panel.tsx
@@ -1,0 +1,292 @@
+'use client'
+
+/**
+ * MCP Config Panel
+ *
+ * Shows the status of Model Context Protocol servers connected to the agent:
+ *   - Built-in clickhouse-monitor server (always present)
+ *   - User-added custom servers (UI-only; backend wiring is TODO)
+ *
+ * Follows the assistant-ui MCP config pattern:
+ *   https://www.assistant-ui.com/docs/ui/mcp-config
+ *
+ * Per-server enable/disable toggles and "Connect new server" are UI-only.
+ * TODO: wire toggles and custom-server form to agent runtime MCP config.
+ */
+
+import { PlusIcon, WrenchIcon } from 'lucide-react'
+
+import { useState } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { cn } from '@/lib/utils'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface McpServer {
+  id: string
+  name: string
+  /** Human-readable URL or transport description */
+  endpoint: string
+  toolCount: number
+  resourceCount?: number
+  version?: string
+  /** Whether this server ships with the app and cannot be removed */
+  builtin: boolean
+  enabled: boolean
+  /** Connection status */
+  status: 'connected' | 'connecting' | 'error' | 'unconfigured'
+}
+
+// ---------------------------------------------------------------------------
+// Built-in server definition (always present)
+// ---------------------------------------------------------------------------
+
+const BUILTIN_SERVER: McpServer = {
+  id: 'clickhouse-monitor',
+  name: 'clickhouse-monitor',
+  endpoint: '/api/mcp',
+  toolCount: 14,
+  resourceCount: 2,
+  version: 'v1.0.0',
+  builtin: true,
+  enabled: true,
+  status: 'connected',
+}
+
+// ---------------------------------------------------------------------------
+// Status badge helper
+// ---------------------------------------------------------------------------
+
+function StatusBadge({ status }: { status: McpServer['status'] }) {
+  if (status === 'connected') {
+    return (
+      <span className="flex items-center gap-1 text-[10px] text-emerald-600 dark:text-emerald-400">
+        <span className="size-1.5 rounded-full bg-emerald-500" />
+        Connected
+      </span>
+    )
+  }
+  if (status === 'connecting') {
+    return (
+      <span className="flex items-center gap-1 text-[10px] text-amber-600 dark:text-amber-400">
+        <span className="size-1.5 animate-pulse rounded-full bg-amber-500" />
+        Connecting
+      </span>
+    )
+  }
+  if (status === 'error') {
+    return (
+      <span className="flex items-center gap-1 text-[10px] text-destructive">
+        <span className="size-1.5 rounded-full bg-destructive" />
+        Error
+      </span>
+    )
+  }
+  return <span className="text-muted-foreground text-[10px]">Unconfigured</span>
+}
+
+// ---------------------------------------------------------------------------
+// Single server row
+// ---------------------------------------------------------------------------
+
+function McpServerRow({
+  server,
+  onToggle,
+}: {
+  server: McpServer
+  onToggle: (id: string, next: boolean) => void
+}) {
+  return (
+    <div className="flex items-center gap-2 py-2 pr-3 pl-2">
+      {/* Icon */}
+      <div className="bg-muted inline-flex size-7 shrink-0 items-center justify-center rounded-md">
+        <WrenchIcon className="text-foreground size-3.5" />
+      </div>
+
+      {/* Info */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <span className="truncate font-mono text-[12.5px]">
+            {server.name}
+          </span>
+          {server.version && (
+            <Badge
+              variant="outline"
+              className="h-4 shrink-0 px-1.5 text-[10px]"
+            >
+              {server.version}
+            </Badge>
+          )}
+        </div>
+        <div className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-[10.5px] tabular-nums">
+          <span>{server.toolCount} tools</span>
+          {server.resourceCount !== undefined && (
+            <>
+              <span className="text-border">·</span>
+              <span>{server.resourceCount} resources</span>
+            </>
+          )}
+          <span className="text-border">·</span>
+          <StatusBadge status={server.status} />
+        </div>
+      </div>
+
+      {/* Toggle */}
+      <Switch
+        checked={server.enabled}
+        onCheckedChange={(next) => onToggle(server.id, next)}
+        className="shrink-0"
+        aria-label={`Toggle ${server.name}`}
+        // TODO: wire to agent runtime MCP config to actually enable/disable the server
+      />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// "Connect new server" form (UI-only)
+// ---------------------------------------------------------------------------
+
+function AddServerForm({ onCancel }: { onCancel: () => void }) {
+  const [name, setName] = useState('')
+  const [url, setUrl] = useState('')
+
+  const inputClass = cn(
+    'bg-background border-input h-8 w-full rounded-md border px-3 text-[12px]',
+    'placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring'
+  )
+
+  return (
+    <div className="border-border mt-2 space-y-2 rounded-md border p-2.5">
+      <p className="text-muted-foreground text-[10.5px] font-medium tracking-wide uppercase">
+        New server
+      </p>
+      <input
+        type="text"
+        placeholder="Server name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className={inputClass}
+      />
+      <input
+        type="url"
+        placeholder="Endpoint URL (https://…)"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        className={inputClass}
+      />
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          className="h-7 flex-1 text-[11.5px]"
+          disabled
+          // TODO: implement server registration via agent runtime MCP config
+          title="Backend wiring not yet implemented"
+        >
+          Connect
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 flex-1 text-[11.5px]"
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Panel root
+// ---------------------------------------------------------------------------
+
+export interface AgentMcpPanelProps {
+  /**
+   * Overall MCP status.
+   * TODO: derive from a real useMcpStatus() hook once backend wiring is done.
+   */
+  status?: 'configured' | 'unconfigured'
+  /**
+   * Additional servers beyond the built-in one.
+   * TODO: read from agent runtime MCP config.
+   */
+  extraServers?: McpServer[]
+}
+
+export function AgentMcpPanel({
+  status = 'configured',
+  extraServers = [],
+}: AgentMcpPanelProps) {
+  const [servers, setServers] = useState<McpServer[]>([
+    BUILTIN_SERVER,
+    ...extraServers,
+  ])
+  const [showAddForm, setShowAddForm] = useState(false)
+
+  const handleToggle = (id: string, next: boolean) => {
+    setServers((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, enabled: next } : s))
+    )
+    // TODO: persist toggle state via agent runtime MCP config
+  }
+
+  const activeCount = servers.filter((s) => s.enabled).length
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Summary row */}
+      <div className="text-muted-foreground flex items-center justify-between text-[10.5px]">
+        <span>
+          <span className="text-foreground font-medium">{activeCount}</span>/
+          {servers.length} active
+        </span>
+        {status === 'configured' ? (
+          <span className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+            <span className="size-1.5 rounded-full bg-emerald-500" />
+            Configured
+          </span>
+        ) : (
+          <span className="text-muted-foreground flex items-center gap-1">
+            <span className="size-1.5 rounded-full bg-muted-foreground/40" />
+            Unconfigured
+          </span>
+        )}
+      </div>
+
+      {/* Server list */}
+      <div className="border-border divide-border divide-y rounded-md border">
+        {servers.map((server) => (
+          <McpServerRow
+            key={server.id}
+            server={server}
+            onToggle={handleToggle}
+          />
+        ))}
+      </div>
+
+      {/* Add server form / button */}
+      {showAddForm ? (
+        <AddServerForm onCancel={() => setShowAddForm(false)} />
+      ) : (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="mt-1 h-8 w-full justify-center gap-1.5 text-[11.5px]"
+          onClick={() => setShowAddForm(true)}
+        >
+          <PlusIcon className="size-3" />
+          Connect new server
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/components/agents/welcome/agent-settings-sidebar.tsx
+++ b/components/agents/welcome/agent-settings-sidebar.tsx
@@ -14,16 +14,15 @@ import {
   MonitorIcon,
   PanelRightCloseIcon,
   SparklesIcon,
-  WrenchIcon,
 } from 'lucide-react'
 
 import type { Skill } from '@/components/agents/welcome/skills-data'
 
 import { useState } from 'react'
+import { AgentMcpPanel } from '@/components/agents/welcome/agent-mcp-panel'
 import { AgentModelPicker } from '@/components/agents/welcome/agent-model-picker'
 import { SkillDetailDialog } from '@/components/agents/welcome/skill-detail-dialog'
 import { SUGGESTED_PROMPTS } from '@/components/agents/welcome/suggested-prompts'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { useAgentSkills } from '@/lib/hooks/use-agent-skills'
@@ -96,33 +95,8 @@ export function AgentSettingsSidebar({
         </SidebarSection>
 
         {/* MCP SERVER */}
-        <SidebarSection
-          label="MCP Server"
-          right={
-            <span className="flex items-center gap-1.5 text-[10px] text-emerald-600 dark:text-emerald-400">
-              <span className="size-1.5 rounded-full bg-emerald-500" />
-              Connected
-            </span>
-          }
-        >
-          <div className="border-border rounded-md border p-2.5">
-            <div className="flex items-center gap-2">
-              <div className="bg-muted inline-flex size-7 items-center justify-center rounded-md">
-                <WrenchIcon className="text-foreground size-3.5" />
-              </div>
-              <div className="min-w-0 flex-1">
-                <div className="truncate font-mono text-[12.5px]">
-                  clickhouse-monitor
-                </div>
-                <div className="text-muted-foreground text-[10.5px] tabular-nums">
-                  14 tools · 2 resources
-                </div>
-              </div>
-              <Badge variant="outline" className="h-4 px-1.5 text-[10px]">
-                v1.0.0
-              </Badge>
-            </div>
-          </div>
+        <SidebarSection label="MCP Servers">
+          <AgentMcpPanel />
         </SidebarSection>
 
         {/* SKILLS */}


### PR DESCRIPTION
## Summary

Add a dedicated **MCP Servers** panel to the agent settings sidebar.

### Changes

- **`components/agents/welcome/agent-mcp-panel.tsx`** (new) — self-contained MCP config panel:
  - Per-server rows: name, tool count, resource count, version badge, connection status, enable/disable toggle
  - `StatusBadge` helper (connected / connecting / error / unconfigured) with colour-coded dots
  - `AddServerForm` — inline form to connect a new MCP server (UI-only; Connect button disabled with TODO)
  - Summary row showing active server count and overall configured/unconfigured status
  - Built-in `clickhouse-monitor` server pre-populated (14 tools, 2 resources, v1.0.0)
- **`components/agents/welcome/agent-settings-sidebar.tsx`** — replaces hardcoded static MCP block with `<AgentMcpPanel />`, removes now-unused `Badge` and `WrenchIcon` imports

### Out of scope (TODOs left in code)

- Wiring toggles to agent runtime MCP config
- Persisting custom-server registrations
- `useMcpStatus()` hook deriving live status from `/api/mcp` health

### Quality

- Build passes (`bun run build`) — no type errors
- Lint passes (`bun run lint`) — no warnings
- No `components/ui/` files modified
- Existing agent settings sidebar sections (Host, Model, Skills, Prompts) unchanged

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Add a dedicated MCP servers configuration panel to the agent settings sidebar, replacing the previous static MCP server block with a more flexible UI.

New Features:
- Introduce an AgentMcpPanel component that lists MCP servers with status, version, and enable/disable controls.
- Add a UI-only form to connect new MCP servers, including name and endpoint inputs.

Enhancements:
- Prepopulate the panel with a built-in clickhouse-monitor MCP server and display an overall configured/unconfigured summary state.