### PR TITLE
feat(agents): Streamdown audit + theme-aware syntax highlighting

### DIFF
--- a/components/agents/markdown-code.css
+++ b/components/agents/markdown-code.css
@@ -4,14 +4,16 @@
  * Streamdown code-block spacing overrides.
  *
  * Streamdown renders:
- *   [data-streamdown="code-block"]      outer card  (gap-2, p-2 by default)
+ *   [data-streamdown="code-block"]        outer card  (gap-2, p-2 by default)
  *   [data-streamdown="code-block-header"] language label row (h-8)
- *   [data-streamdown="code-block-body"]  code area   (p-4 by default)
+ *   [data-streamdown="code-block-body"]   code area   (p-4 by default)
  *
  * The default gap + body padding stacks to ~64 px of dead space above the
  * first line of code.  These overrides tighten it to ~8 px while keeping
  * the copy/download buttons, language label, line numbers, and horizontal
  * scroll intact.
+ *
+ * PR #1184 — do not remove these overrides.
  */
 
 /* Reduce the column gap between the language header and the code body */
@@ -46,162 +48,15 @@
   border-radius: 0.25rem;
 }
 
-/* Syntax highlighting - light mode */
-.markdown-content .hljs {
-  color: #24292e;
-  background: transparent;
-}
-
-.markdown-content .hljs-comment,
-.markdown-content .hljs-quote {
-  color: #6a737d;
-  font-style: italic;
-}
-
-.markdown-content .hljs-keyword,
-.markdown-content .hljs-selector-tag,
-.markdown-content .hljs-subst {
-  color: #d73a49;
-}
-
-.markdown-content .hljs-number,
-.markdown-content .hljs-literal,
-.markdown-content .hljs-variable,
-.markdown-content .hljs-template-variable,
-.markdown-content .hljs-tag .hljs-attr {
-  color: #005cc5;
-}
-
-.markdown-content .hljs-string,
-.markdown-content .hljs-doctag {
-  color: #032f62;
-}
-
-.markdown-content .hljs-title,
-.markdown-content .hljs-section,
-.markdown-content .hljs-selector-id {
-  color: #6f42c1;
-  font-weight: bold;
-}
-
-.markdown-content .hljs-type,
-.markdown-content .hljs-class .hljs-title {
-  color: #6f42c1;
-}
-
-.markdown-content .hljs-tag,
-.markdown-content .hljs-name,
-.markdown-content .hljs-attribute {
-  color: #22863a;
-  font-weight: normal;
-}
-
-.markdown-content .hljs-regexp,
-.markdown-content .hljs-link {
-  color: #032f62;
-}
-
-.markdown-content .hljs-symbol,
-.markdown-content .hljs-bullet {
-  color: #005cc5;
-}
-
-.markdown-content .hljs-built_in,
-.markdown-content .hljs-builtin-name {
-  color: #005cc5;
-}
-
-.markdown-content .hljs-meta {
-  color: #6a737d;
-}
-
-.markdown-content .hljs-deletion {
-  background-color: #ffeef0;
-}
-
-.markdown-content .hljs-addition {
-  background-color: #e6ffec;
-}
-
-.markdown-content .hljs-emphasis {
-  font-style: italic;
-}
-
-.markdown-content .hljs-strong {
-  font-weight: bold;
-}
-
-/* Syntax highlighting - dark mode */
-.dark .markdown-content .hljs {
-  color: #e1e4e8;
-  background: transparent;
-}
-
-.dark .markdown-content .hljs-comment,
-.dark .markdown-content .hljs-quote {
-  color: #8b949e;
-}
-
-.dark .markdown-content .hljs-keyword,
-.dark .markdown-content .hljs-selector-tag,
-.dark .markdown-content .hljs-subst {
-  color: #ff7b72;
-}
-
-.dark .markdown-content .hljs-number,
-.dark .markdown-content .hljs-literal,
-.dark .markdown-content .hljs-variable,
-.dark .markdown-content .hljs-template-variable,
-.dark .markdown-content .hljs-tag .hljs-attr {
-  color: #79c0ff;
-}
-
-.dark .markdown-content .hljs-string,
-.dark .markdown-content .hljs-doctag {
-  color: #a5d6ff;
-}
-
-.dark .markdown-content .hljs-title,
-.dark .markdown-content .hljs-section,
-.dark .markdown-content .hljs-selector-id {
-  color: #d2a8ff;
-  font-weight: bold;
-}
-
-.dark .markdown-content .hljs-type,
-.dark .markdown-content .hljs-class .hljs-title {
-  color: #d2a8ff;
-}
-
-.dark .markdown-content .hljs-tag,
-.dark .markdown-content .hljs-name,
-.dark .markdown-content .hljs-attribute {
-  color: #7ee787;
-}
-
-.dark .markdown-content .hljs-regexp,
-.dark .markdown-content .hljs-link {
-  color: #a5d6ff;
-}
-
-.dark .markdown-content .hljs-symbol,
-.dark .markdown-content .hljs-bullet {
-  color: #79c0ff;
-}
-
-.dark .markdown-content .hljs-built_in,
-.dark .markdown-content .hljs-builtin-name {
-  color: #79c0ff;
-}
-
-.dark .markdown-content .hljs-meta {
-  color: #8b949e;
-}
-
-.dark .markdown-content .hljs-deletion {
-  background-color: rgba(248, 81, 73, 0.15);
-}
-
-.dark .markdown-content .hljs-addition {
-  background-color: rgba(46, 160, 67, 0.15);
-}
+/*
+ * NOTE: .hljs-* rules have been removed.
+ *
+ * Streamdown v2.4.0 uses Shiki for syntax highlighting via the `shikiTheme`
+ * prop. Shiki outputs inline color styles using CSS custom properties
+ * (--shiki-light / --shiki-dark), not .hljs-* class names. The previous
+ * manual highlight.js theme rules were dead code and have been removed.
+ *
+ * Theme switching (light ↔ dark) is handled automatically by Streamdown
+ * reading the `.dark` class on <html> (set by next-themes), matching the
+ * @custom-variant dark (&:is(.dark *)) declaration in globals.css.
+ */

--- a/components/assistant-ui/markdown-text.tsx
+++ b/components/assistant-ui/markdown-text.tsx
@@ -5,7 +5,7 @@ import type { MermaidErrorComponentProps } from 'streamdown'
 
 import { mermaid as mermaidPlugin } from '@streamdown/mermaid'
 import { useTheme } from 'next-themes'
-import { memo } from 'react'
+import { memo, useMemo } from 'react'
 import { Streamdown } from 'streamdown'
 
 import '@/components/agents/markdown-code.css'
@@ -34,15 +34,34 @@ function MermaidError({ chart, error }: MermaidErrorComponentProps) {
  * cleanly while a response is in flight, and keeps mermaid diagram support
  * plus the project's existing `.markdown-content` styling from globals.css.
  *
+ * Syntax highlighting is provided by Streamdown's built-in Shiki integration
+ * via the `shikiTheme` prop. The theme tuple is wired to next-themes so code
+ * blocks switch between github-light (light mode) and github-dark (dark mode)
+ * automatically. This replaces the previous manual .hljs-* CSS overrides which
+ * are now removed from markdown-code.css.
+ *
  * Mermaid theme adapts to the app's dark/light mode via next-themes.
  */
 const MarkdownTextImpl: TextMessagePartComponent = ({ text }) => {
   const { resolvedTheme } = useTheme()
-  const mermaidTheme = resolvedTheme === 'dark' ? 'dark' : 'default'
+  const isDark = resolvedTheme === 'dark'
+
+  const mermaidTheme = isDark ? 'dark' : 'default'
+
+  // Shiki theme tuple: [light-theme, dark-theme].
+  // Streamdown reads the active theme from the CSS `color-scheme` on the
+  // root element (set by next-themes). Passing both themes lets Shiki embed
+  // dual-theme CSS vars; Streamdown then switches via the dark-class variant
+  // already declared in globals.css (@custom-variant dark (&:is(.dark *))).
+  const shikiTheme = useMemo(
+    () => ['github-light', 'github-dark'] as [string, string],
+    []
+  )
 
   return (
     <div className="markdown-content aui-md text-sm leading-6">
       <Streamdown
+        shikiTheme={shikiTheme}
         mermaid={{
           config: { theme: mermaidTheme },
           errorComponent: MermaidError,


### PR DESCRIPTION
## Summary

Audit of the Streamdown integration in `components/assistant-ui/markdown-text.tsx` and cleanup of dead code in `components/agents/markdown-code.css`.

## What was audited

- Streamdown v2.4.0 ships Shiki built-in via `shikiTheme` prop (defaults to `["github-light", "github-dark"]`). No separate `@streamdown/code` package needed.
- The previous code did not pass `shikiTheme` explicitly — Shiki was technically active via default but not clearly wired.
- The `.hljs-*` CSS rules in `markdown-code.css` (~160 lines) were entirely dead code: Shiki emits inline CSS vars (`--shiki-light`/`--shiki-dark`) via Tailwind `dark:` utilities, not `.hljs-*` class names.
- Math (KaTeX): not added — no math use case in the agents UI yet; can be added if needed.
- CJK plugin: not added — no CJK-specific user base.
- Security (allowedElements/disallowedElements): Streamdown defaults are appropriate for assistant-ui chat; no restriction needed.
- `globals.css` `@source` directive for streamdown dist already present from PR #1186; no change required.

## What was changed

- **`markdown-text.tsx`**: Added explicit `shikiTheme={["github-light", "github-dark"]}` prop via stable `useMemo`. Added comment explaining the dual-theme CSS var mechanism and the `.dark` class integration with next-themes.
- **`markdown-code.css`**: Removed ~160 lines of dead `.hljs-*` light/dark rules. Kept all spacing overrides from PR #1184 (gap + padding tightening). Added explanatory comment documenting why the hljs rules were removed and how Shiki themes now work.

## What remained the same

- Mermaid error fallback component (from PR #1186) — unchanged
- Mermaid theme switching via `resolvedTheme` — unchanged
- Code-block spacing overrides from PR #1184 — preserved exactly
- `globals.css` — no changes
- `highlight.js` package — still in package.json (removal is a separate cleanup task to avoid unintended breakage if any other code references it)

## Verification

- `bun run lint` — passes (0 errors)
- `bun run build` — passes (TypeScript + Next.js build)

Closes tasks #9 and #10.

## Summary by Sourcery

Wire Streamdown’s built-in Shiki syntax highlighting to the assistant UI with explicit light/dark themes and remove obsolete highlight.js-based CSS.

New Features:
- Enable theme-aware Shiki syntax highlighting for assistant markdown via an explicit shikiTheme configuration.

Enhancements:
- Refine markdown code-block spacing comments and guardrails to preserve existing layout overrides.
- Remove dead .hljs-based syntax highlighting rules now that Streamdown uses Shiki with CSS custom properties.
- Clarify Mermaid and theme-handling logic by factoring out an isDark flag and documenting the Shiki/next-themes integration.