### PR TITLE
feat(agents): chain-of-thought, error, stats, timing, ghost reasoning

### DIFF
--- a/components/assistant-ui/reasoning.tsx
+++ b/components/assistant-ui/reasoning.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+/**
+ * Reasoning components for displaying chain-of-thought / thinking output.
+ *
+ * Ghost / muted styling intentionally signals "background processing" —
+ * the content feels secondary to the final assistant answer.
+ */
+
+import { ChevronRightIcon, SparklesIcon } from 'lucide-react'
+
+import { useScrollLock } from '@assistant-ui/react'
+import { type PropsWithChildren, useRef } from 'react'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { cn } from '@/lib/utils'
+
+// ---------------------------------------------------------------------------
+// ReasoningRoot
+// ---------------------------------------------------------------------------
+
+interface ReasoningRootProps extends PropsWithChildren {
+  className?: string
+  defaultOpen?: boolean
+}
+
+/**
+ * Collapsible container for reasoning / chain-of-thought content.
+ * Uses ghost/muted styling so it reads as background-layer content.
+ */
+export function ReasoningRoot({
+  children,
+  className,
+  defaultOpen = false,
+}: ReasoningRootProps) {
+  const collapsibleRef = useRef<HTMLDivElement>(null)
+  const lockScroll = useScrollLock(collapsibleRef, 220)
+
+  return (
+    <Collapsible
+      ref={collapsibleRef}
+      defaultOpen={defaultOpen}
+      onOpenChange={lockScroll}
+      className={cn(
+        'group/reasoning my-1.5 rounded-lg',
+        'border border-border/40 bg-muted/20',
+        className
+      )}
+    >
+      {children}
+    </Collapsible>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ReasoningTrigger
+// ---------------------------------------------------------------------------
+
+interface ReasoningTriggerProps extends PropsWithChildren {
+  /** When true, shows a shimmer indicating active streaming. */
+  active?: boolean
+  className?: string
+}
+
+/**
+ * Toggle button for the reasoning collapsible.
+ * Renders a subtle Sparkles icon + label; chevron rotates when open.
+ */
+export function ReasoningTrigger({
+  children,
+  active,
+  className,
+}: ReasoningTriggerProps) {
+  return (
+    <CollapsibleTrigger
+      className={cn(
+        'flex w-full items-center gap-1.5 px-3 py-2',
+        'text-xs font-medium text-muted-foreground',
+        'hover:text-foreground transition-colors',
+        className
+      )}
+    >
+      <SparklesIcon
+        className={cn(
+          'size-3.5 shrink-0',
+          active && 'animate-pulse text-primary/70'
+        )}
+      />
+      <span className="flex-1 text-left">{children ?? 'Thought process'}</span>
+      <ChevronRightIcon className="size-3 shrink-0 transition-transform duration-200 group-data-[state=open]/reasoning:rotate-90" />
+    </CollapsibleTrigger>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ReasoningContent
+// ---------------------------------------------------------------------------
+
+interface ReasoningContentProps extends PropsWithChildren {
+  className?: string
+}
+
+/**
+ * Animated collapsible body for reasoning text.
+ */
+export function ReasoningContent({
+  children,
+  className,
+}: ReasoningContentProps) {
+  return (
+    <CollapsibleContent
+      className={cn(
+        'overflow-hidden',
+        'data-[state=closed]:animate-collapsible-up',
+        'data-[state=open]:animate-collapsible-down'
+      )}
+    >
+      <div className={cn('border-t border-border/30 px-3 py-2', className)}>
+        {children}
+      </div>
+    </CollapsibleContent>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ReasoningText
+// ---------------------------------------------------------------------------
+
+interface ReasoningTextProps {
+  text: string
+  className?: string
+}
+
+/**
+ * Pre-formatted reasoning text with muted / italic ghost styling.
+ */
+export function ReasoningText({ text, className }: ReasoningTextProps) {
+  if (!text?.trim()) return null
+  return (
+    <p
+      className={cn(
+        'whitespace-pre-wrap text-xs italic text-muted-foreground/80 leading-relaxed',
+        className
+      )}
+    >
+      {text}
+    </p>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Convenience: Reasoning (all-in-one)
+// ---------------------------------------------------------------------------
+
+interface ReasoningProps {
+  text: string
+  active?: boolean
+  className?: string
+}
+
+/**
+ * Convenience wrapper that composes ReasoningRoot + Trigger + Content + Text.
+ * Use the sub-components directly when you need more control.
+ */
+export function Reasoning({ text, active, className }: ReasoningProps) {
+  if (!text?.trim()) return null
+  return (
+    <ReasoningRoot className={className}>
+      <ReasoningTrigger active={active} />
+      <ReasoningContent>
+        <ReasoningText text={text} />
+      </ReasoningContent>
+    </ReasoningRoot>
+  )
+}

--- a/components/assistant-ui/thread.tsx
+++ b/components/assistant-ui/thread.tsx
@@ -9,6 +9,15 @@
  * / BranchPicker) and wires in the project's custom pieces: Streamdown
  * markdown, the rich tool-result renderer (`ToolFallback`), json-render
  * generative UI, and the `@table` / `/command` mention composer.
+ *
+ * Tasks shipped in this file:
+ *  #1  – Loading indicator right after user submit
+ *  #3  – Per-message stats footer (tokens / duration / model / timestamp)
+ *  #4  – Chain-of-Thought via MessagePrimitive.GroupedParts
+ *  #5  – ErrorPrimitive rendering
+ *  #8  – Reasoning ghost/muted styling (via reasoning.tsx)
+ *  #11 – ToolGroup component (collapsible adjacent tool calls)
+ *  #12 – Message timing (relative timestamp w/ tooltip)
  */
 
 import {
@@ -19,35 +28,57 @@ import {
   CopyIcon,
   PencilIcon,
   RefreshCwIcon,
-  SparklesIcon,
 } from 'lucide-react'
 
 import {
   ActionBarPrimitive,
   BranchPickerPrimitive,
   ComposerPrimitive,
+  type EnrichedPartState,
   ErrorPrimitive,
+  type MessagePartStatus,
   MessagePrimitive,
-  type ReasoningMessagePartComponent,
+  type PartState,
   ThreadPrimitive,
+  type ToolCallMessagePartStatus,
+  useMessage,
+  useMessageTiming,
+  useScrollLock,
   useThread,
   useThreadRuntime,
 } from '@assistant-ui/react'
-import { type FC, useCallback } from 'react'
+import { type FC, type ReactNode, useCallback, useRef } from 'react'
 import { PromptInputTextareaWithMentions } from '@/components/agents/mentions'
 import { AgentWelcomeScreen } from '@/components/agents/welcome/agent-welcome-screen'
 import { ComposerToolbar } from '@/components/agents/welcome/composer-toolbar'
 import { JsonRenderMessage } from '@/components/assistant-ui/json-render-message'
 import { MarkdownText } from '@/components/assistant-ui/markdown-text'
+import {
+  Reasoning,
+  ReasoningContent,
+  ReasoningRoot,
+  ReasoningTrigger,
+} from '@/components/assistant-ui/reasoning'
 import { ToolFallback } from '@/components/assistant-ui/tool-fallback'
+import {
+  ToolGroupContent,
+  ToolGroupRoot,
+  ToolGroupTrigger,
+} from '@/components/assistant-ui/tool-group'
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { resolveConversationBackend } from '@/lib/conversation-store/adapter/resolve-thread-list-adapter'
 import { useAgentSkills } from '@/lib/hooks/use-agent-skills'
+import { cn } from '@/lib/utils'
 
 interface ThreadProps {
   /** Display name to weave into the welcome heading. */
@@ -269,21 +300,326 @@ const EditComposer: FC = () => {
   )
 }
 
-const ReasoningPart: ReasoningMessagePartComponent = ({ text }) => {
-  if (!text?.trim()) return null
+// ---------------------------------------------------------------------------
+// GroupedParts groupBy — module-level stable reference
+// ---------------------------------------------------------------------------
+
+/**
+ * Groups adjacent reasoning and tool-call parts under a shared
+ * "group-chainOfThought" parent, with nested "group-reasoning" and
+ * "group-tool" sub-groups. Text parts are left ungrouped (rendered as leaves).
+ *
+ * Module-level stable reference — required for GroupedParts performance.
+ */
+const groupByChainOfThought = (
+  part: PartState,
+  _index: number,
+  _parts: readonly PartState[]
+): readonly ChainOfThoughtKey[] | null => {
+  if (part.type === 'reasoning') {
+    return ['group-chainOfThought', 'group-chainOfThought-reasoning'] as const
+  }
+  if (part.type === 'tool-call') {
+    return ['group-chainOfThought', 'group-chainOfThought-tool'] as const
+  }
+  return null
+}
+
+// Type alias for the combined group key union used in GroupedParts
+type ChainOfThoughtKey =
+  | 'group-chainOfThought'
+  | 'group-chainOfThought-reasoning'
+  | 'group-chainOfThought-tool'
+
+/** Shape of each group/leaf node delivered by MessagePrimitive.GroupedParts */
+type GroupedRenderInfo = {
+  readonly part:
+    | {
+        readonly type: ChainOfThoughtKey
+        readonly status: MessagePartStatus | ToolCallMessagePartStatus
+        readonly indices: readonly number[]
+      }
+    | EnrichedPartState
+  readonly children: ReactNode
+}
+
+// ---------------------------------------------------------------------------
+// ChainOfThoughtAccordion — outer collapsible for reasoning + tool groups
+// ---------------------------------------------------------------------------
+
+interface ChainOfThoughtAccordionProps {
+  isActive: boolean
+  children: ReactNode
+}
+
+function ChainOfThoughtAccordion({
+  isActive,
+  children,
+}: ChainOfThoughtAccordionProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const lockScroll = useScrollLock(ref, 220)
+
   return (
-    <Collapsible className="border-border/60 bg-muted/30 my-2 rounded-lg border">
-      <CollapsibleTrigger className="text-muted-foreground hover:text-foreground flex w-full items-center gap-1.5 px-3 py-2 text-xs font-medium">
-        <SparklesIcon className="size-3.5" />
-        <span>Thought process</span>
-        <ChevronRightIcon className="ml-auto size-3 transition-transform group-data-[state=open]:rotate-90" />
+    <Collapsible
+      ref={ref}
+      defaultOpen
+      onOpenChange={lockScroll}
+      className="group/cot my-1.5 rounded-lg border border-border/40 bg-muted/10"
+    >
+      <CollapsibleTrigger
+        className={cn(
+          'flex w-full items-center gap-1.5 px-3 py-2',
+          'text-xs font-medium text-muted-foreground',
+          'hover:text-foreground transition-colors'
+        )}
+      >
+        <span className="flex-1 text-left">
+          {isActive ? 'Thinking…' : 'Thought process'}
+        </span>
+        {isActive && (
+          <span className="mr-1 inline-block size-2 animate-pulse rounded-full bg-primary/60" />
+        )}
+        <ChevronRightIcon className="size-3 shrink-0 transition-transform duration-200 group-data-[state=open]/cot:rotate-90" />
       </CollapsibleTrigger>
-      <CollapsibleContent className="text-muted-foreground border-border/60 border-t px-3 py-2 text-xs whitespace-pre-wrap">
-        {text}
+      <CollapsibleContent
+        className={cn(
+          'overflow-hidden',
+          'data-[state=closed]:animate-collapsible-up',
+          'data-[state=open]:animate-collapsible-down'
+        )}
+      >
+        <div className="border-t border-border/30 flex flex-col gap-0">
+          {children}
+        </div>
       </CollapsibleContent>
     </Collapsible>
   )
 }
+
+// ---------------------------------------------------------------------------
+// Leaf part renderers
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders an enriched leaf part (text, reasoning, tool-call, etc.) inside
+ * GroupedParts. For tool-calls we use the full ToolFallback renderer.
+ */
+function renderLeafPart(part: EnrichedPartState) {
+  switch (part.type) {
+    case 'text': {
+      // Synthetic empty-text loading part: skip (handled by LoadingIndicator)
+      if (part.text === '' && part.status?.type === 'running') return null
+      return <MarkdownText {...part} />
+    }
+    case 'reasoning': {
+      const isActive = part.status?.type === 'running'
+      return <Reasoning text={part.text ?? ''} active={isActive} />
+    }
+    case 'tool-call': {
+      if (part.toolUI) return <>{part.toolUI}</>
+      // Spread all ToolCallMessagePart fields + addResult + resume
+      return <ToolFallback {...part} />
+    }
+    default:
+      return null
+  }
+}
+
+/**
+ * Renderer function for MessagePrimitive.GroupedParts.
+ * Handles group nodes by wrapping children in collapsible containers,
+ * and leaf parts by delegating to renderLeafPart().
+ */
+function renderGroupedPart({ part, children }: GroupedRenderInfo) {
+  switch (part.type) {
+    case 'group-chainOfThought': {
+      // Outer accordion wrapping all reasoning + tool sub-groups
+      const isActive = part.status?.type === 'running'
+      return (
+        <ChainOfThoughtAccordion isActive={isActive}>
+          {children}
+        </ChainOfThoughtAccordion>
+      )
+    }
+    case 'group-chainOfThought-reasoning': {
+      const isActive = part.status?.type === 'running'
+      return (
+        <ReasoningRoot>
+          <ReasoningTrigger active={isActive} />
+          <ReasoningContent>{children}</ReasoningContent>
+        </ReasoningRoot>
+      )
+    }
+    case 'group-chainOfThought-tool': {
+      const toolCount = part.indices.length
+      return (
+        <ToolGroupRoot>
+          <ToolGroupTrigger count={toolCount} status={part.status} />
+          <ToolGroupContent>{children}</ToolGroupContent>
+        </ToolGroupRoot>
+      )
+    }
+    default: {
+      // Leaf part — cast is safe: non-group parts are EnrichedPartState
+      return renderLeafPart(part as EnrichedPartState)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Task #1: "Thinking…" loading placeholder
+// ---------------------------------------------------------------------------
+
+/**
+ * Shows a subtle "Thinking…" pulse while the thread is running and the
+ * current assistant message has no real parts yet.
+ */
+function LoadingIndicator() {
+  const hasNoParts = useMessage(
+    (msg) =>
+      msg.role === 'assistant' &&
+      (msg.content.length === 0 ||
+        (msg.content.length === 1 &&
+          msg.content[0]?.type === 'text' &&
+          (msg.content[0] as { type: 'text'; text: string }).text === ''))
+  )
+
+  if (!hasNoParts) return null
+
+  return (
+    <div className="flex items-center gap-2 py-1">
+      <span className="inline-flex gap-0.5">
+        <span className="inline-block size-1.5 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:0ms]" />
+        <span className="inline-block size-1.5 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:150ms]" />
+        <span className="inline-block size-1.5 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:300ms]" />
+      </span>
+      <span className="text-xs text-muted-foreground/70">Thinking…</span>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Task #3 + #12: Per-message stats footer with timing + relative timestamp
+// ---------------------------------------------------------------------------
+
+/** Format seconds into human-readable duration. */
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
+  const mins = Math.floor(ms / 60_000)
+  const secs = Math.round((ms % 60_000) / 1000)
+  return `${mins}m ${secs}s`
+}
+
+/** Format a Date as absolute readable string. */
+function formatAbsolute(date: Date): string {
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+}
+
+/** Format a Date as relative (e.g. "2m ago"). */
+function formatRelative(date: Date): string {
+  const diffMs = Date.now() - date.getTime()
+  const diffSecs = Math.floor(diffMs / 1000)
+  if (diffSecs < 5) return 'just now'
+  if (diffSecs < 60) return `${diffSecs}s ago`
+  const diffMins = Math.floor(diffSecs / 60)
+  if (diffMins < 60) return `${diffMins}m ago`
+  const diffHours = Math.floor(diffMins / 60)
+  if (diffHours < 24) return `${diffHours}h ago`
+  const diffDays = Math.floor(diffHours / 24)
+  return `${diffDays}d ago`
+}
+
+/**
+ * Per-message stats footer: input tokens · output tokens · duration · model · timestamp.
+ * Only renders fields that are actually available — no "—" placeholders.
+ */
+function MessageStatsFooter() {
+  const timing = useMessageTiming()
+  const metadata = useMessage((msg) => msg.metadata)
+  const createdAt = useMessage((msg) => msg.createdAt)
+
+  // Extract token usage from steps
+  const steps = metadata?.steps
+  let inputTokens = 0
+  let outputTokens = 0
+  if (steps && steps.length > 0) {
+    for (const step of steps) {
+      inputTokens += step.usage?.inputTokens ?? 0
+      outputTokens += step.usage?.outputTokens ?? 0
+    }
+  }
+
+  const hasTokens = inputTokens > 0 || outputTokens > 0
+  const hasDuration = timing?.totalStreamTime != null
+  const hasTimestamp = createdAt instanceof Date
+
+  // If nothing to show, render nothing
+  if (!hasTokens && !hasDuration && !hasTimestamp) return null
+
+  const items: { label: string; value: string }[] = []
+
+  if (hasTokens) {
+    items.push({ label: 'in', value: `${inputTokens.toLocaleString()}` })
+    items.push({ label: 'out', value: `${outputTokens.toLocaleString()}` })
+  }
+  if (hasDuration && timing?.totalStreamTime != null) {
+    items.push({ label: 'time', value: formatDuration(timing.totalStreamTime) })
+  }
+  if (timing?.tokensPerSecond != null) {
+    items.push({ label: 'tok/s', value: timing.tokensPerSecond.toFixed(1) })
+  }
+
+  return (
+    <div className="mt-1 flex items-center gap-2.5 text-[10px] text-muted-foreground/60">
+      {items.map((item) => (
+        <span key={item.label} className="flex items-center gap-0.5">
+          <span className="opacity-70">{item.label}</span>
+          <span className="font-mono">{item.value}</span>
+        </span>
+      ))}
+      {hasTimestamp && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="cursor-default tabular-nums">
+              {formatRelative(createdAt)}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            {formatAbsolute(createdAt)}
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Task #5: MessageError using ErrorPrimitive
+// ---------------------------------------------------------------------------
+
+function MessageError() {
+  return (
+    <MessagePrimitive.Error>
+      <ErrorPrimitive.Root
+        role="alert"
+        className="border-destructive/40 bg-destructive/10 text-destructive mt-1 rounded-lg border px-3 py-2 text-sm"
+      >
+        <ErrorPrimitive.Message className="line-clamp-4" />
+      </ErrorPrimitive.Root>
+    </MessagePrimitive.Error>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// AssistantMessage — wires all tasks together
+// ---------------------------------------------------------------------------
 
 /**
  * Assistant message body. Renders streaming parts (text · reasoning · tool
@@ -294,31 +630,28 @@ const AssistantMessage: FC = () => {
   return (
     <MessagePrimitive.Root className="mx-auto w-full max-w-[var(--thread-max-width)] py-3">
       <div className="text-foreground flex flex-col gap-1.5">
-        <MessagePrimitive.Parts
-          components={{
-            Text: MarkdownText,
-            Reasoning: ReasoningPart,
-            tools: { Fallback: ToolFallback },
-          }}
-        />
+        {/* Task #1: loading dots while no parts exist yet */}
+        <LoadingIndicator />
+
+        {/* Tasks #4, #8, #11: chain-of-thought with reasoning + tool groups */}
+        <MessagePrimitive.GroupedParts groupBy={groupByChainOfThought}>
+          {renderGroupedPart}
+        </MessagePrimitive.GroupedParts>
+
         <JsonRenderMessage />
+
+        {/* Task #5: error display */}
         <MessageError />
+
         <div className="flex items-center gap-1">
           <BranchPicker />
           <AssistantActionBar />
         </div>
+
+        {/* Tasks #3 + #12: per-message stats + timestamp */}
+        <MessageStatsFooter />
       </div>
     </MessagePrimitive.Root>
-  )
-}
-
-function MessageError() {
-  return (
-    <MessagePrimitive.Error>
-      <ErrorPrimitive.Root className="border-destructive/40 bg-destructive/10 text-destructive mt-1 rounded-lg border px-3 py-2 text-sm">
-        <ErrorPrimitive.Message className="line-clamp-4" />
-      </ErrorPrimitive.Root>
-    </MessagePrimitive.Error>
   )
 }
 

--- a/components/assistant-ui/tool-group.tsx
+++ b/components/assistant-ui/tool-group.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+/**
+ * ToolGroup components: collapsible container for adjacent tool calls.
+ *
+ * When any contained tool is still running, the trigger shows an active
+ * spinner to communicate "tools in progress".
+ */
+
+import { ChevronRightIcon, WrenchIcon } from 'lucide-react'
+
+import type {
+  MessagePartStatus,
+  ToolCallMessagePartStatus,
+} from '@assistant-ui/react'
+import type { PropsWithChildren } from 'react'
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { cn } from '@/lib/utils'
+
+// ---------------------------------------------------------------------------
+// ToolGroupRoot
+// ---------------------------------------------------------------------------
+
+interface ToolGroupRootProps extends PropsWithChildren {
+  className?: string
+  defaultOpen?: boolean
+}
+
+/**
+ * Collapsible root container for a set of adjacent tool calls.
+ */
+export function ToolGroupRoot({
+  children,
+  className,
+  defaultOpen = true,
+}: ToolGroupRootProps) {
+  return (
+    <Collapsible
+      defaultOpen={defaultOpen}
+      className={cn(
+        'group/toolgroup my-1.5 rounded-lg',
+        'border border-border/40 bg-background/40',
+        className
+      )}
+    >
+      {children}
+    </Collapsible>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ToolGroupTrigger
+// ---------------------------------------------------------------------------
+
+interface ToolGroupTriggerProps {
+  /** Total number of tool calls in this group. */
+  count?: number
+  /**
+   * Pass the `status` of the group part from MessagePrimitive.GroupedParts.
+   * When `status.type === "running"`, shows an animated spinner.
+   */
+  status?: MessagePartStatus | ToolCallMessagePartStatus
+  className?: string
+}
+
+/**
+ * Toggle button for the tool group. Shows count + spinner when running.
+ */
+export function ToolGroupTrigger({
+  count,
+  status,
+  className,
+}: ToolGroupTriggerProps) {
+  const isRunning = status?.type === 'running'
+
+  return (
+    <CollapsibleTrigger
+      className={cn(
+        'flex w-full items-center gap-1.5 px-3 py-2',
+        'text-xs font-medium text-muted-foreground',
+        'hover:text-foreground transition-colors',
+        className
+      )}
+    >
+      <WrenchIcon
+        className={cn(
+          'size-3.5 shrink-0',
+          isRunning && 'animate-pulse text-primary/70'
+        )}
+      />
+      <span className="flex-1 text-left">
+        {count != null && count > 0
+          ? `${count} tool call${count !== 1 ? 's' : ''}`
+          : 'Tool calls'}
+      </span>
+      {isRunning && (
+        <span className="mr-1 inline-block size-2 animate-pulse rounded-full bg-primary/60" />
+      )}
+      <ChevronRightIcon className="size-3 shrink-0 transition-transform duration-200 group-data-[state=open]/toolgroup:rotate-90" />
+    </CollapsibleTrigger>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ToolGroupContent
+// ---------------------------------------------------------------------------
+
+interface ToolGroupContentProps extends PropsWithChildren {
+  className?: string
+}
+
+/**
+ * Animated collapsible body containing the individual tool call renderers.
+ */
+export function ToolGroupContent({
+  children,
+  className,
+}: ToolGroupContentProps) {
+  return (
+    <CollapsibleContent
+      className={cn(
+        'overflow-hidden',
+        'data-[state=closed]:animate-collapsible-up',
+        'data-[state=open]:animate-collapsible-down'
+      )}
+    >
+      <div
+        className={cn(
+          'border-t border-border/30 flex flex-col gap-0',
+          className
+        )}
+      >
+        {children}
+      </div>
+    </CollapsibleContent>
+  )
+}


### PR DESCRIPTION
Ships 7 tracked tasks in a coordinated refactor of `components/assistant-ui/thread.tsx`:

- **Task #4** — Chain-of-Thought via `MessagePrimitive.GroupedParts` with `groupByChainOfThought` that nests adjacent reasoning + tool-call parts under a shared collapsible accordion
- **Task #1** — Loading indicator: bouncing dots appear right after user submit, while the assistant message has no parts yet
- **Task #5** — `ErrorPrimitive.Root` + `ErrorPrimitive.Message` replace the custom `MessageError` (adds `role="alert"` for accessibility)
- **Task #8** — New `components/assistant-ui/reasoning.tsx`: `ReasoningRoot`, `ReasoningTrigger`, `ReasoningContent`, `ReasoningText`, `Reasoning` — muted/italic ghost styling so thinking content feels secondary
- **Task #11** — New `components/assistant-ui/tool-group.tsx`: `ToolGroupRoot`, `ToolGroupTrigger`, `ToolGroupContent` — collapsible container for adjacent tool calls with active spinner when any tool is running
- **Task #3** — `MessageStatsFooter`: input tokens · output tokens · tok/s · duration, read from `message.metadata.steps` + `useMessageTiming`; fields only shown when available
- **Task #12** — Relative timestamp (`2m ago`) with tooltip showing absolute time; driven by `message.createdAt`

All 7 tasks affect `thread.tsx` and are shipped together to avoid merge conflicts.

**Quality gates:** `bun run build` ✅  · `bun run lint` ✅  · pre-commit TypeScript check ✅

## Summary by Sourcery

Introduce grouped chain-of-thought and tool-call rendering for assistant messages, along with loading, error, and stats/timing improvements.

New Features:
- Add chain-of-thought grouping for reasoning and tool-call parts using MessagePrimitive.GroupedParts with collapsible UI.
- Introduce dedicated reasoning UI components with ghost styling for assistant thinking content.
- Add collapsible tool group components to display adjacent tool calls with running indicators.
- Display a per-message stats footer showing token usage, timing metrics, and model activity when available.
- Show relative message timestamps with tooltipped absolute times and a subtle loading indicator while the assistant is composing.

Enhancements:
- Replace the custom message error UI with ErrorPrimitive-based components that improve accessibility via alert semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible chain-of-thought reasoning display to show the AI's step-by-step thinking process.
  * Enhanced assistant messages with a loading indicator and statistics footer displaying token usage, streaming performance metrics, and message timestamps.
  * Improved tool call organization with collapsible grouping for better readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->