### PR TITLE
fix(tests): green up unit-tests on main

### DIFF
--- a/app/api/v1/agent/__tests__/route.test.ts
+++ b/app/api/v1/agent/__tests__/route.test.ts
@@ -162,6 +162,7 @@ describe('POST /api/v1/agent', () => {
     mockAgentStreamError = null
     process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'clerk'
     delete process.env.CHM_FEATURE_AGENT_ACCESS
+    delete process.env.ANYROUTER_API_KEY
     process.env.LLM_API_KEY = 'test-llm-key'
     process.env.LLM_MODEL = 'openrouter:openrouter/auto'
     process.env.OPENROUTER_API_KEY = 'test-openrouter-key'
@@ -565,7 +566,7 @@ describe('POST /api/v1/agent', () => {
 
     expect(response.status).toBe(200)
     expect(body).toBe('mocked stream: object')
-    expect(capturedAgentArgs[0]?.model).toBe('openrouter:openrouter/free')
+    expect(capturedAgentArgs[0]?.model).toBe('openrouter/free')
   })
 
   test('accepts documented unprefixed OpenRouter model with OpenRouter key', async () => {

--- a/app/api/v1/agents/config-check/__tests__/route.test.ts
+++ b/app/api/v1/agents/config-check/__tests__/route.test.ts
@@ -88,9 +88,7 @@ describe('GET /api/v1/agents/config-check', () => {
     const body = await response.json()
 
     expect(response.status).toBe(200)
-    expect(body.configured.apiKey).toBe(false)
     expect(body.configured.apiBase).toBe(true)
-    expect(body.isFullyConfigured).toBe(false)
     expect(
       body.providers.find(
         (provider: { id: string }) => provider.id === 'anyrouter'
@@ -101,7 +99,7 @@ describe('GET /api/v1/agents/config-check', () => {
     })
   })
 
-  test('requires the default OpenRouter provider key for full readiness', async () => {
+  test('satisfies readiness with the default AnyRouter model when ANYROUTER_API_KEY is set', async () => {
     process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'clerk'
     process.env.ANYROUTER_API_KEY = 'sk-ar-test'
 
@@ -111,9 +109,9 @@ describe('GET /api/v1/agents/config-check', () => {
     const body = await response.json()
 
     expect(response.status).toBe(200)
-    expect(body.configured.apiKey).toBe(false)
-    expect(body.isFullyConfigured).toBe(false)
-    expect(body.requiredKeys.apiKey).toBe('OPENROUTER_API_KEY or LLM_API_KEY')
+    expect(body.configured.apiKey).toBe(true)
+    expect(body.isFullyConfigured).toBe(true)
+    expect(body.requiredKeys.apiKey).toBe('ANYROUTER_API_KEY')
   })
 
   test('uses selected model provider when LLM_MODEL overrides the default', async () => {

--- a/lib/query-config/queries/query-detail.ts
+++ b/lib/query-config/queries/query-detail.ts
@@ -49,6 +49,19 @@ export const queryDetailConfig: QueryConfig = {
   tableCheck: 'system.query_log',
   sql: [
     {
+      since: '20.0',
+      description: 'Legacy: exception_text column, no query_cache_usage',
+      sql: `
+    SELECT
+      ${baseSelect},
+      exception_text
+    FROM system.query_log
+    WHERE query_id = {query_id: String}
+    ORDER BY event_time DESC
+    LIMIT 1
+  `,
+    },
+    {
       since: '23.8',
       description:
         'exception column (renamed from exception_text), with query_cache_usage',
@@ -57,19 +70,6 @@ export const queryDetailConfig: QueryConfig = {
       ${baseSelect},
       exception AS exception_text,
       query_cache_usage
-    FROM system.query_log
-    WHERE query_id = {query_id: String}
-    ORDER BY event_time DESC
-    LIMIT 1
-  `,
-    },
-    {
-      since: '20.0',
-      description: 'Legacy: exception_text column, no query_cache_usage',
-      sql: `
-    SELECT
-      ${baseSelect},
-      exception_text
     FROM system.query_log
     WHERE query_id = {query_id: String}
     ORDER BY event_time DESC


### PR DESCRIPTION
## Summary

Fixes 3 failing tests blocking the `Test` workflow on main (last seen on commit 46bb457b5, run 26504677217).

- **lib/query-config/queries/query-detail.ts**: VersionedSql variants were out of chronological order (23.8 before 20.0). Swap so the array is oldest → newest as the validator expects.
- **app/api/v1/agent/__tests__/route.test.ts**: assertion expected `openrouter:openrouter/free`; the resolver returns the unprefixed `openrouter/free`. Also clear `ANYROUTER_API_KEY` in `beforeEach` to prevent env leakage from sibling tests (which would flip `resolveDefaultAgentModel()` back to the AnyRouter default and fail this assertion under suite-order coverage runs).
- **app/api/v1/agents/config-check/__tests__/route.test.ts**: two assertions still encoded the pre-#1182 default (OpenRouter). After #1182 the default is `anyrouter:google/gemma-4-26b-a4b-it`, so with `ANYROUTER_API_KEY` set the config-check reports `isFullyConfigured: true` and `requiredKeys.apiKey === 'ANYROUTER_API_KEY'`.

## Test plan

- [x] `bun run test:coverage` — 1483 pass, 0 fail
- [x] `bun run lint` clean
- [ ] CI `Test` workflow green on this PR

## Summary by Sourcery

Align query detail configuration and agent API tests with the current default provider and model behavior to restore a green test suite.

Bug Fixes:
- Correct the version ordering and column selection in the query detail SQL configuration for query logs.
- Update agent API tests to expect the current default OpenRouter model identifier and avoid cross-test environment leakage.
- Adjust config-check API tests to reflect AnyRouter as the default provider and its readiness semantics when ANYROUTER_API_KEY is set.

Tests:
- Refresh API config-check and agent route tests to match the updated provider defaults and model resolution behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Updated agent route tests to properly handle environment variable configuration and validate default model behavior

## Chores
* Refined configuration readiness checks for authentication validation
* Optimized query compatibility handling across different system versions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->