### PR TITLE
fix(agents): mobile-responsive settings via shadcn Drawer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -121,6 +121,7 @@
         "undici": "^7.24.5",
         "use-stick-to-bottom": "^1.1.3",
         "usehooks-ts": "^3.1.1",
+        "vaul": "^1.1.2",
         "wait-on": "^9.0.10",
         "zod": "^4.3.6",
       },

--- a/components/agents/welcome/agent-settings-sidebar.tsx
+++ b/components/agents/welcome/agent-settings-sidebar.tsx
@@ -5,8 +5,9 @@
  *
  * Five stacked sections — Host · Model · MCP Server · Skills · Suggested
  * prompts — that mirror the chrome of competing agent UIs (Codex, Replit
- * Agent etc.). The sidebar is collapsible; when closed the parent surfaces
- * a "Agent settings" affordance so it can be reopened.
+ * Agent etc.). On desktop the sidebar is an inline collapsible column; on
+ * mobile (< 768px) it slides up as a shadcn Drawer so the chat column
+ * stays usable on small screens.
  */
 
 import {
@@ -24,7 +25,15 @@ import { AgentModelPicker } from '@/components/agents/welcome/agent-model-picker
 import { SkillDetailDialog } from '@/components/agents/welcome/skill-detail-dialog'
 import { SUGGESTED_PROMPTS } from '@/components/agents/welcome/suggested-prompts'
 import { Button } from '@/components/ui/button'
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer'
 import { Switch } from '@/components/ui/switch'
+import { useIsMobile } from '@/hooks/use-mobile'
 import { useAgentSkills } from '@/lib/hooks/use-agent-skills'
 import { cn } from '@/lib/utils'
 
@@ -43,6 +52,7 @@ export function AgentSettingsSidebar({
   onPickPrompt,
   onOpenSkillsLibrary,
 }: AgentSettingsSidebarProps) {
+  const isMobile = useIsMobile()
   const {
     skills,
     isSkillEnabled,
@@ -52,6 +62,152 @@ export function AgentSettingsSidebar({
   } = useAgentSkills()
   const topSkills = skills.slice(0, 3)
   const [skillDetail, setSkillDetail] = useState<Skill | null>(null)
+
+  const sections = (
+    <>
+      {/* HOST */}
+      <SidebarSection label="Host">
+        <div className="bg-background border-input flex h-9 items-center gap-2 rounded-md border px-3">
+          <MonitorIcon className="text-muted-foreground size-3.5" />
+          <span className="font-mono text-[12.5px]">{hostName}</span>
+        </div>
+      </SidebarSection>
+
+      {/* MODEL */}
+      <SidebarSection label="Model">
+        <AgentModelPicker variant="panel" />
+      </SidebarSection>
+
+      {/* MCP SERVER */}
+      <SidebarSection label="MCP Servers">
+        <AgentMcpPanel />
+      </SidebarSection>
+
+      {/* SKILLS */}
+      <SidebarSection
+        label="Skills"
+        right={
+          <span className="text-muted-foreground text-[10px] tabular-nums">
+            <span className="text-foreground font-medium">
+              {activeSkillCount}
+            </span>
+            /{totalSkillCount} on
+          </span>
+        }
+      >
+        <div className="border-border divide-border divide-y rounded-md border">
+          {topSkills.map((skill) => {
+            const Icon = skill.icon
+            const on = isSkillEnabled(skill.id)
+            return (
+              <div
+                key={skill.id}
+                className="flex items-center gap-2 py-2 pr-3 pl-2"
+              >
+                <button
+                  type="button"
+                  onClick={() => setSkillDetail(skill)}
+                  className="hover:bg-muted/40 flex min-w-0 flex-1 items-center gap-2 rounded px-1 py-0.5 text-left"
+                >
+                  <div className="bg-muted text-muted-foreground inline-flex size-6 shrink-0 items-center justify-center rounded-md">
+                    <Icon className="size-3" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-[12px] font-medium">
+                      {skill.name}
+                    </div>
+                    <div className="text-muted-foreground text-[10px] tabular-nums">
+                      {skill.tools.length} tools · {skill.source}
+                    </div>
+                  </div>
+                </button>
+                <Switch
+                  checked={on}
+                  onCheckedChange={() => toggleSkill(skill.id)}
+                  className="shrink-0"
+                  aria-label={`Toggle ${skill.name}`}
+                />
+              </div>
+            )
+          })}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onOpenSkillsLibrary}
+          className="mt-1.5 h-8 w-full justify-center gap-1.5 text-[11.5px]"
+        >
+          <SparklesIcon className="size-3" />
+          Skill library
+          <span className="text-muted-foreground tabular-nums">
+            ({totalSkillCount})
+          </span>
+          <ArrowRightIcon className="text-muted-foreground size-2.5" />
+        </Button>
+      </SidebarSection>
+
+      {/* SUGGESTED PROMPTS */}
+      <SidebarSection
+        label="Suggested prompts"
+        right={
+          <button
+            type="button"
+            className="text-muted-foreground hover:text-foreground text-[10.5px]"
+          >
+            Show more
+          </button>
+        }
+      >
+        <div className="space-y-1.5 text-[11.5px]">
+          {SUGGESTED_PROMPTS.slice(0, 3).map((entry) => (
+            <button
+              key={entry.title}
+              type="button"
+              onClick={() => onPickPrompt?.(entry.prompt)}
+              className="text-muted-foreground hover:text-foreground hover:bg-muted/40 -mx-1 flex w-[calc(100%+0.5rem)] items-start gap-1.5 rounded px-1 py-0.5 text-left transition-colors"
+            >
+              <span className="text-foreground w-14 shrink-0 pt-0.5 text-[9.5px] font-semibold tracking-wider uppercase">
+                {entry.category}
+              </span>
+              <span className="line-clamp-2 leading-snug">{entry.prompt}</span>
+            </button>
+          ))}
+        </div>
+      </SidebarSection>
+
+      <SkillDetailDialog
+        skill={skillDetail}
+        open={skillDetail !== null}
+        onOpenChange={(next) => {
+          if (!next) setSkillDetail(null)
+        }}
+        isEnabled={skillDetail ? isSkillEnabled(skillDetail.id) : false}
+        onToggle={(id) => toggleSkill(id)}
+      />
+    </>
+  )
+
+  if (isMobile) {
+    return (
+      <Drawer
+        open={open}
+        onOpenChange={(next) => {
+          if (!next) onClose()
+        }}
+      >
+        <DrawerContent className="max-h-[85dvh]">
+          <DrawerHeader className="text-left">
+            <DrawerTitle className="text-[14px]">Agent settings</DrawerTitle>
+            <DrawerDescription className="text-[11.5px]">
+              Host, model, tools, and skills.
+            </DrawerDescription>
+          </DrawerHeader>
+          <div className="overflow-y-auto px-4 pb-6">{sections}</div>
+        </DrawerContent>
+      </Drawer>
+    )
+  }
 
   return (
     <aside
@@ -80,129 +236,7 @@ export function AgentSettingsSidebar({
         <p className="text-muted-foreground mb-4 text-[11.5px]">
           Host, model, tools, and skills.
         </p>
-
-        {/* HOST */}
-        <SidebarSection label="Host">
-          <div className="bg-background border-input flex h-9 items-center gap-2 rounded-md border px-3">
-            <MonitorIcon className="text-muted-foreground size-3.5" />
-            <span className="font-mono text-[12.5px]">{hostName}</span>
-          </div>
-        </SidebarSection>
-
-        {/* MODEL */}
-        <SidebarSection label="Model">
-          <AgentModelPicker variant="panel" />
-        </SidebarSection>
-
-        {/* MCP SERVER */}
-        <SidebarSection label="MCP Servers">
-          <AgentMcpPanel />
-        </SidebarSection>
-
-        {/* SKILLS */}
-        <SidebarSection
-          label="Skills"
-          right={
-            <span className="text-muted-foreground text-[10px] tabular-nums">
-              <span className="text-foreground font-medium">
-                {activeSkillCount}
-              </span>
-              /{totalSkillCount} on
-            </span>
-          }
-        >
-          <div className="border-border divide-border divide-y rounded-md border">
-            {topSkills.map((skill) => {
-              const Icon = skill.icon
-              const on = isSkillEnabled(skill.id)
-              return (
-                <div
-                  key={skill.id}
-                  className="flex items-center gap-2 py-2 pr-3 pl-2"
-                >
-                  <button
-                    type="button"
-                    onClick={() => setSkillDetail(skill)}
-                    className="hover:bg-muted/40 flex min-w-0 flex-1 items-center gap-2 rounded px-1 py-0.5 text-left"
-                  >
-                    <div className="bg-muted text-muted-foreground inline-flex size-6 shrink-0 items-center justify-center rounded-md">
-                      <Icon className="size-3" />
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-[12px] font-medium">
-                        {skill.name}
-                      </div>
-                      <div className="text-muted-foreground text-[10px] tabular-nums">
-                        {skill.tools.length} tools · {skill.source}
-                      </div>
-                    </div>
-                  </button>
-                  <Switch
-                    checked={on}
-                    onCheckedChange={() => toggleSkill(skill.id)}
-                    className="shrink-0"
-                    aria-label={`Toggle ${skill.name}`}
-                  />
-                </div>
-              )
-            })}
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={onOpenSkillsLibrary}
-            className="mt-1.5 h-8 w-full justify-center gap-1.5 text-[11.5px]"
-          >
-            <SparklesIcon className="size-3" />
-            Skill library
-            <span className="text-muted-foreground tabular-nums">
-              ({totalSkillCount})
-            </span>
-            <ArrowRightIcon className="text-muted-foreground size-2.5" />
-          </Button>
-        </SidebarSection>
-
-        {/* SUGGESTED PROMPTS */}
-        <SidebarSection
-          label="Suggested prompts"
-          right={
-            <button
-              type="button"
-              className="text-muted-foreground hover:text-foreground text-[10.5px]"
-            >
-              Show more
-            </button>
-          }
-        >
-          <div className="space-y-1.5 text-[11.5px]">
-            {SUGGESTED_PROMPTS.slice(0, 3).map((entry) => (
-              <button
-                key={entry.title}
-                type="button"
-                onClick={() => onPickPrompt?.(entry.prompt)}
-                className="text-muted-foreground hover:text-foreground hover:bg-muted/40 -mx-1 flex w-[calc(100%+0.5rem)] items-start gap-1.5 rounded px-1 py-0.5 text-left transition-colors"
-              >
-                <span className="text-foreground w-14 shrink-0 pt-0.5 text-[9.5px] font-semibold tracking-wider uppercase">
-                  {entry.category}
-                </span>
-                <span className="line-clamp-2 leading-snug">
-                  {entry.prompt}
-                </span>
-              </button>
-            ))}
-          </div>
-        </SidebarSection>
-
-        <SkillDetailDialog
-          skill={skillDetail}
-          open={skillDetail !== null}
-          onOpenChange={(next) => {
-            if (!next) setSkillDetail(null)
-          }}
-          isEnabled={skillDetail ? isSkillEnabled(skillDetail.id) : false}
-          onToggle={(id) => toggleSkill(id)}
-        />
+        {sections}
       </div>
     </aside>
   )

--- a/components/agents/welcome/agent-settings-sidebar.tsx
+++ b/components/agents/welcome/agent-settings-sidebar.tsx
@@ -212,12 +212,12 @@ export function AgentSettingsSidebar({
   return (
     <aside
       className={cn(
-        'bg-card border-border shrink-0 overflow-y-auto border-l transition-all duration-200',
+        'bg-card border-border shrink-0 overflow-x-hidden overflow-y-auto border-l transition-all duration-200',
         open ? 'w-[320px] opacity-100' : 'pointer-events-none w-0 opacity-0'
       )}
       style={{ maxHeight: 'calc(100dvh - 6rem)' }}
     >
-      <div className="w-[320px] p-4">
+      <div className="w-[320px] min-w-0 max-w-full p-4">
         <div className="mb-1 flex items-center justify-between gap-2">
           <h3 className="text-[14px] font-semibold whitespace-nowrap">
             Agent settings

--- a/components/assistant-ui/agent-thread-page.tsx
+++ b/components/assistant-ui/agent-thread-page.tsx
@@ -18,12 +18,13 @@ import { PanelLeftOpenIcon, PanelRightOpenIcon } from 'lucide-react'
 import { ErrorBoundary } from 'react-error-boundary'
 
 import { useUser } from '@clerk/nextjs'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { AgentSettingsSidebar } from '@/components/agents/welcome/agent-settings-sidebar'
 import { AgentRuntimeProvider } from '@/components/assistant-ui/agent-runtime-provider'
 import { Thread } from '@/components/assistant-ui/thread'
 import { ThreadList } from '@/components/assistant-ui/thread-list'
 import { Button } from '@/components/ui/button'
+import { useIsMobile } from '@/hooks/use-mobile'
 import { useHostId } from '@/lib/swr/use-host'
 import { useHosts } from '@/lib/swr/use-hosts'
 
@@ -40,8 +41,12 @@ function AgentThreadPageError() {
 }
 
 export function AgentThreadPage() {
+  const isMobile = useIsMobile()
   const [leftSidebarOpen, setLeftSidebarOpen] = useState(false)
-  const [rightSidebarOpen, setRightSidebarOpen] = useState(true)
+  const [rightSidebarOpen, setRightSidebarOpen] = useState(false)
+  useEffect(() => {
+    setRightSidebarOpen(!isMobile)
+  }, [isMobile])
   const { user } = useUser()
   const hostId = useHostId()
   const { hosts } = useHosts()

--- a/components/assistant-ui/thread.tsx
+++ b/components/assistant-ui/thread.tsx
@@ -105,7 +105,10 @@ export function Thread({
         ['--user-max-width' as string]: 'min(100%, 46rem)',
       }}
     >
-      <ThreadPrimitive.Viewport className="relative flex flex-1 flex-col overflow-y-auto scroll-smooth px-4 pt-14">
+      <ThreadPrimitive.Viewport
+        scrollToBottomOnInitialize={false}
+        className="relative flex flex-1 flex-col overflow-y-auto scroll-smooth px-4 pt-14"
+      >
         <ThreadWelcome
           firstName={firstName}
           clusterName={clusterName}

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import * as React from 'react'
+import { Drawer as DrawerPrimitive } from 'vaul'
+import { cn } from '@/lib/utils'
+
+const Drawer = ({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+  <DrawerPrimitive.Root
+    shouldScaleBackground={shouldScaleBackground}
+    {...props}
+  />
+)
+Drawer.displayName = 'Drawer'
+
+const DrawerTrigger = DrawerPrimitive.Trigger
+
+const DrawerPortal = DrawerPrimitive.Portal
+
+const DrawerClose = DrawerPrimitive.Close
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-black/80', className)}
+    {...props}
+  />
+))
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background',
+        className
+      )}
+      {...props}
+    >
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+))
+DrawerContent.displayName = 'DrawerContent'
+
+const DrawerHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('grid gap-1.5 p-4 text-center sm:text-left', className)}
+    {...props}
+  />
+)
+DrawerHeader.displayName = 'DrawerHeader'
+
+const DrawerFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('mt-auto flex flex-col gap-2 p-4', className)}
+    {...props}
+  />
+)
+DrawerFooter.displayName = 'DrawerFooter'
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn(
+      'text-lg font-semibold leading-none tracking-tight',
+      className
+    )}
+    {...props}
+  />
+))
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+))
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+}

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "undici": "^7.24.5",
     "use-stick-to-bottom": "^1.1.3",
     "usehooks-ts": "^3.1.1",
+    "vaul": "^1.1.2",
     "wait-on": "^9.0.10",
     "zod": "^4.3.6"
   },


### PR DESCRIPTION
## Summary

On phones (< 768px) the right "Agent settings" panel rendered as an inline column that overlapped the chat area, leaving the welcome screen barely usable. This change makes the settings panel responsive:

- **Mobile (< 768px)**: settings slide up as a shadcn `Drawer` (vaul-based bottom sheet) — tap the backdrop or swipe down to dismiss.
- **Desktop (≥ 768px)**: unchanged — same inline `<aside>` with width animation.
- Right sidebar now defaults to **closed** on mobile so the chat is the focus on first load.

## Changes

- New `components/ui/drawer.tsx` (canonical shadcn Drawer; CLI registry was unreachable so the file was added directly).
- `components/agents/welcome/agent-settings-sidebar.tsx` — `useIsMobile()` switches between Drawer and inline aside; settings sections live in a single shared block.
- `components/assistant-ui/agent-thread-page.tsx` — initial `rightSidebarOpen` follows viewport via `useEffect`.
- Adds `vaul@^1.1.2` dependency.

## Test plan

- [ ] `bun run dev` → `/agents?host=0`
- [ ] Mobile width (DevTools < 768px): welcome screen fully visible on first load; tapping "Agent settings" opens a bottom drawer; backdrop / swipe-down dismisses it
- [ ] Desktop width (≥ 768px): right panel opens by default and toggles with the existing width animation
- [ ] Skill switches, MCP toggle, and model picker remain interactive inside the drawer
- [ ] `bun run lint` and `bun run type-check` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_018yjWJswaGXjp41s8sSBrf1)_