### PR TITLE
fix(explorer): share truncateLargeValues across query and preview routes

### DIFF
--- a/app/api/v1/explorer/preview/route.ts
+++ b/app/api/v1/explorer/preview/route.ts
@@ -12,6 +12,7 @@ import {
   getHostIdFromParams,
   type RouteContext,
 } from '@/lib/api/error-handler'
+import { truncateLargeValues } from '@/lib/api/shared'
 import { ApiErrorType } from '@/lib/api/types'
 import { fetchData } from '@/lib/clickhouse'
 import { TABLES_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
@@ -167,8 +168,11 @@ export async function GET(request: Request): Promise<Response> {
     )
   }
 
+  // Truncate large cell values to prevent browser OOM on large text/JSON columns
+  const truncatedData = truncateLargeValues(result.data)
+
   // Create successful response
-  return createSuccessResponse(result.data, result.metadata)
+  return createSuccessResponse(truncatedData, result.metadata)
 }
 
 /**

--- a/app/api/v1/explorer/query/route.ts
+++ b/app/api/v1/explorer/query/route.ts
@@ -17,6 +17,7 @@ import {
   getHostIdFromParams,
   type RouteContext,
 } from '@/lib/api/error-handler'
+import { truncateLargeValues } from '@/lib/api/shared'
 import {
   isSupportedFormat,
   SUPPORTED_FORMATS,
@@ -37,32 +38,6 @@ const MAX_GET_QUERY_LENGTH = 8_000
 
 /** Maximum query length for POST requests */
 const MAX_POST_QUERY_LENGTH = 100_000
-
-/** Maximum string length for individual cell values to prevent OOM in the browser */
-const MAX_CELL_VALUE_LENGTH = 10_000
-
-/**
- * Truncate large string values in result rows to prevent browser OOM.
- * ClickHouse tables can contain very large text/JSON columns that,
- * when serialized as JSON, create responses too large for the browser to parse.
- */
-function truncateLargeValues<T>(data: T): T {
-  if (!Array.isArray(data)) return data
-
-  return data.map((row: Record<string, unknown>) => {
-    const truncatedRow: Record<string, unknown> = {}
-    for (const [key, value] of Object.entries(row)) {
-      if (typeof value === 'string' && value.length > MAX_CELL_VALUE_LENGTH) {
-        truncatedRow[key] =
-          value.slice(0, MAX_CELL_VALUE_LENGTH) +
-          `… (truncated, ${value.length} chars total)`
-      } else {
-        truncatedRow[key] = value
-      }
-    }
-    return truncatedRow
-  }) as T
-}
 
 /**
  * Extract the first SQL verb from a query for safe logging

--- a/lib/api/shared/__tests__/truncate-large-values.test.ts
+++ b/lib/api/shared/__tests__/truncate-large-values.test.ts
@@ -1,0 +1,49 @@
+import {
+  MAX_CELL_VALUE_LENGTH,
+  truncateLargeValues,
+} from '../truncate-large-values'
+import { describe, expect, it } from 'bun:test'
+
+describe('truncateLargeValues', () => {
+  it('returns non-array input unchanged', () => {
+    expect(truncateLargeValues(null)).toBeNull()
+    expect(truncateLargeValues({ a: 1 } as unknown)).toEqual({ a: 1 })
+    expect(truncateLargeValues('plain string' as unknown)).toBe('plain string')
+  })
+
+  it('leaves short string values alone', () => {
+    const rows = [{ id: 1, name: 'alice' }]
+    expect(truncateLargeValues(rows)).toEqual(rows)
+  })
+
+  it('truncates strings longer than the cap and tags the original length', () => {
+    const big = 'x'.repeat(MAX_CELL_VALUE_LENGTH + 500)
+    const [row] = truncateLargeValues([{ payload: big }])
+    expect(typeof row.payload).toBe('string')
+    expect(
+      (row.payload as string).startsWith('x'.repeat(MAX_CELL_VALUE_LENGTH))
+    ).toBe(true)
+    expect(row.payload as string).toContain(
+      `(truncated, ${MAX_CELL_VALUE_LENGTH + 500} chars total)`
+    )
+  })
+
+  it('preserves non-string values as-is', () => {
+    const rows = [{ n: 42, b: true, arr: [1, 2, 3], obj: { a: 1 } }]
+    expect(truncateLargeValues(rows)).toEqual(rows)
+  })
+
+  it('skips row entries that are not plain objects', () => {
+    const rows = [null, 'string-row', [1, 2], { ok: 'short' }]
+    const [a, b, c, d] = truncateLargeValues(rows as unknown[])
+    expect(a).toBeNull()
+    expect(b).toBe('string-row')
+    expect(c).toEqual([1, 2])
+    expect(d).toEqual({ ok: 'short' })
+  })
+
+  it('respects a custom maxLength override', () => {
+    const [row] = truncateLargeValues([{ s: 'abcdef' }], 3)
+    expect(row.s).toBe('abc… (truncated, 6 chars total)')
+  })
+})

--- a/lib/api/shared/index.ts
+++ b/lib/api/shared/index.ts
@@ -15,6 +15,11 @@ export {
 } from './response-builder'
 // Status code mapping
 export { mapErrorTypeToStatusCode } from './status-code-mapper'
+// Result-data sanitizers
+export {
+  MAX_CELL_VALUE_LENGTH,
+  truncateLargeValues,
+} from './truncate-large-values'
 // Validators
 export {
   getAndValidateHostId,

--- a/lib/api/shared/truncate-large-values.ts
+++ b/lib/api/shared/truncate-large-values.ts
@@ -1,0 +1,36 @@
+/**
+ * Truncate large string values in result rows to prevent browser OOM.
+ *
+ * ClickHouse tables can contain very large text/JSON columns that, when
+ * serialized as JSON, create responses too large for the browser to parse.
+ * Any string value longer than `MAX_CELL_VALUE_LENGTH` is sliced and tagged
+ * with the original length so the UI can communicate that truncation occurred.
+ */
+
+export const MAX_CELL_VALUE_LENGTH = 10_000
+
+function isPlainRow(row: unknown): row is Record<string, unknown> {
+  return typeof row === 'object' && row !== null && !Array.isArray(row)
+}
+
+export function truncateLargeValues<T>(
+  data: T,
+  maxLength: number = MAX_CELL_VALUE_LENGTH
+): T {
+  if (!Array.isArray(data)) return data
+
+  return data.map((row) => {
+    if (!isPlainRow(row)) return row
+    const truncatedRow: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(row)) {
+      if (typeof value === 'string' && value.length > maxLength) {
+        truncatedRow[key] =
+          value.slice(0, maxLength) +
+          `… (truncated, ${value.length} chars total)`
+      } else {
+        truncatedRow[key] = value
+      }
+    }
+    return truncatedRow
+  }) as T
+}


### PR DESCRIPTION
## Summary

Follow-up to #1191. The cell-value truncation added there to `/api/v1/explorer/query` lives inline in the route file. The `/api/v1/explorer/preview` route has identical OOM exposure (it also returns raw `SELECT *` rows from arbitrary tables) but didn't get the same safeguard.

This PR:

- Extracts the truncation into `lib/api/shared/truncate-large-values.ts` with two small hardenings:
  - An `isPlainRow` guard so non-object rows (e.g., if a future endpoint uses `JSONCompactEachRow`) pass through unchanged instead of crashing on `Object.entries(row)`.
  - An optional `maxLength` argument so callers can override the 10k cap when appropriate (default unchanged).
- Switches `/explorer/query` from its inline copy to the shared helper.
- Adds the same truncation call to `/explorer/preview`.
- Adds `lib/api/shared/__tests__/truncate-large-values.test.ts` covering truncation, short-string passthrough, non-string values, non-object rows, and the custom cap.

No behavior change for `/explorer/query` — same cap, same suffix, same call site. New behavior for `/explorer/preview`: rows with strings longer than 10k chars are now truncated server-side instead of being shipped whole.

## Test plan

- [x] `bun run type-check` clean
- [x] `bun test lib/api/shared/__tests__/truncate-large-values.test.ts` → 6 pass
- [ ] CI green (build, lint, unit, e2e, component)
- [ ] Smoke: load a table with a huge string column in the explorer preview; row renders truncated with the `… (truncated, N chars total)` suffix.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Share a reusable helper for truncating large cell values across explorer APIs and apply it to both query and preview responses to prevent browser OOM from huge text/JSON columns.

Bug Fixes:
- Apply server-side cell value truncation to the explorer preview endpoint to avoid sending excessively large string payloads to the browser.

Enhancements:
- Extract cell value truncation logic into a shared utility with a configurable maximum length and safer handling of non-object rows.
- Re-export shared truncation helpers from the API shared index for centralized use across endpoints.

Tests:
- Add unit tests for the shared truncate-large-values helper covering truncation behavior, passthrough cases, non-string values, non-object rows, and custom length caps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Large cell values in ClickHouse preview and query results are now automatically truncated to prevent sending excessive data to the client. Truncated values include a notification showing the original character count. This improves performance and responsiveness when working with large text or JSON fields in your query results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->