### PR TITLE
fix(feedback): render table guidance instructions as markdown

### DIFF
--- a/components/charts/chart-error.tsx
+++ b/components/charts/chart-error.tsx
@@ -11,6 +11,8 @@ import {
 import { toast } from 'sonner'
 
 import { memo, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import { chartCard } from '@/components/charts/chart-card-styles'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
@@ -278,9 +280,42 @@ ${error.stack}
                       {tableMissingInfo.guidance?.enableInstructions && (
                         <div className="p-3 bg-muted/40 dark:bg-zinc-900 rounded-md border border-border/50">
                           <p className="font-semibold mb-1">How to enable:</p>
-                          <pre className="text-[11px] font-mono whitespace-pre-wrap text-foreground/90">
-                            {tableMissingInfo.guidance.enableInstructions}
-                          </pre>
+                          <div className="text-[11px] text-foreground/90 leading-relaxed [&>p]:my-0 [&>p+p]:mt-2">
+                            <ReactMarkdown
+                              remarkPlugins={[remarkGfm]}
+                              components={{
+                                code: ({ className, children, ...props }) => {
+                                  const isInline =
+                                    !className?.startsWith('language-')
+                                  if (isInline) {
+                                    return (
+                                      <code
+                                        className="rounded bg-muted px-1 py-0.5 font-mono text-[0.9em]"
+                                        {...props}
+                                      >
+                                        {children}
+                                      </code>
+                                    )
+                                  }
+                                  return (
+                                    <code
+                                      className={cn('font-mono', className)}
+                                      {...props}
+                                    >
+                                      {children}
+                                    </code>
+                                  )
+                                },
+                                pre: ({ children }) => (
+                                  <pre className="my-2 overflow-x-auto rounded border border-border/50 bg-background p-2 text-[0.9em] leading-snug">
+                                    {children}
+                                  </pre>
+                                ),
+                              }}
+                            >
+                              {tableMissingInfo.guidance.enableInstructions}
+                            </ReactMarkdown>
+                          </div>
                         </div>
                       )}
                     </div>

--- a/components/feedback/optional-table-info.tsx
+++ b/components/feedback/optional-table-info.tsx
@@ -4,6 +4,8 @@ import { ExternalLink, Info } from 'lucide-react'
 
 import type { TableGuidance } from '@/lib/table-guidance'
 
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import { Card, CardContent } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 
@@ -70,43 +72,37 @@ export function OptionalTableInfo({
 
             {/* Instructions */}
             <div className="text-sm text-muted-foreground space-y-3">
-              <div className="leading-relaxed">
-                {/* Handle markdown-like code blocks by splitting and rendering */}
-                {guidance.enableInstructions
-                  .split(/```/g)
-                  .map((part, index) => {
-                    // Odd indices are inside code blocks
-                    if (index % 2 === 1) {
-                      const language = part.split('\n')[0] || ''
-                      const codeContent = part
-                        .split('\n')
-                        .slice(language ? 1 : 0)
-                        .join('\n')
-                        .trim()
-
+              <div className="leading-relaxed [&>p]:my-0 [&>p+p]:mt-2">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={{
+                    code: ({ className, children, ...props }) => {
+                      const isInline = !className?.startsWith('language-')
+                      if (isInline) {
+                        return (
+                          <code
+                            className="rounded bg-blue-100/60 px-1 py-0.5 font-mono text-[0.85em] text-blue-900 dark:bg-blue-900/40 dark:text-blue-100"
+                            {...props}
+                          >
+                            {children}
+                          </code>
+                        )
+                      }
                       return (
-                        <pre
-                          key={`code-${index}`}
-                          className="mt-2 mb-2 overflow-x-auto rounded border border-blue-300/60 bg-slate-900 p-3 text-xs text-slate-50 dark:border-blue-800/60 dark:bg-slate-950 dark:text-slate-100"
-                        >
-                          <code>{codeContent}</code>
-                        </pre>
+                        <code className={cn('font-mono', className)} {...props}>
+                          {children}
+                        </code>
                       )
-                    }
-
-                    // Even indices are regular text
-                    if (part.trim()) {
-                      return (
-                        <div
-                          key={`text-${index}`}
-                          className="whitespace-pre-wrap"
-                        >
-                          {part.trim()}
-                        </div>
-                      )
-                    }
-                    return null
-                  })}
+                    },
+                    pre: ({ children }) => (
+                      <pre className="mt-2 mb-2 overflow-x-auto rounded border border-blue-300/60 bg-slate-900 p-3 text-xs text-slate-50 dark:border-blue-800/60 dark:bg-slate-950 dark:text-slate-100">
+                        {children}
+                      </pre>
+                    ),
+                  }}
+                >
+                  {guidance.enableInstructions}
+                </ReactMarkdown>
               </div>
 
               {/* Documentation link */}

--- a/components/tables/table-client.tsx
+++ b/components/tables/table-client.tsx
@@ -6,6 +6,8 @@ import type { ApiResponseMetadata } from '@/lib/api/types'
 import type { QueryConfig } from '@/types/query-config'
 
 import { memo, useMemo } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import { CardToolbar } from '@/components/cards/card-toolbar'
 import { DataTable } from '@/components/data-table/data-table'
 import { TableSkeleton } from '@/components/skeletons'
@@ -46,6 +48,54 @@ interface TableClientProps {
 }
 
 const tableRowFormatter = new Intl.NumberFormat('en-US')
+
+function GuidanceMarkdown({ content }: { content: string }) {
+  return (
+    <div className="text-foreground/80 leading-relaxed [&>p]:my-0 [&>p+p]:mt-2">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          p: ({ children }) => <p>{children}</p>,
+          code: ({ className, children, ...props }) => {
+            const isInline = !className?.startsWith('language-')
+            if (isInline) {
+              return (
+                <code
+                  className="rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]"
+                  {...props}
+                >
+                  {children}
+                </code>
+              )
+            }
+            return (
+              <code className={cn('font-mono', className)} {...props}>
+                {children}
+              </code>
+            )
+          },
+          pre: ({ children }) => (
+            <pre className="my-2 overflow-x-auto rounded border bg-muted p-2 text-[0.85em] leading-snug">
+              {children}
+            </pre>
+          ),
+          a: ({ href, children }) => (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline-offset-2 hover:underline"
+            >
+              {children}
+            </a>
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  )
+}
 
 function TableResultFootnote({ metadata }: { metadata: ApiResponseMetadata }) {
   const beforeCap =
@@ -172,9 +222,7 @@ export const TableClient = memo(function TableClient({
                 <p>{errorDescription}</p>
                 {guidance ? (
                   <div className="flex flex-col gap-1 border-t pt-3 text-xs">
-                    <p className="text-foreground/80">
-                      {guidance.enableInstructions}
-                    </p>
+                    <GuidanceMarkdown content={guidance.enableInstructions} />
                     {guidance.docsUrl && (
                       <Button
                         asChild


### PR DESCRIPTION
## Summary

The "Missing required tables" alert (e.g. on `/logs/text-log` when `system.text_log` is not configured) was rendering `guidance.enableInstructions` as plain text. The string contains markdown — triple-backtick code blocks for the XML snippet plus inline backticks for tag names — so users saw literal `` ``` `` markers and the multi-line XML collapsed onto one line.

Switched the three surfaces that render `enableInstructions` to use `react-markdown` + `remark-gfm` (already project dependencies) with custom code/pre/inline-code components styled to fit each container:

- `components/tables/table-client.tsx` — main table page alert (the screenshot)
- `components/charts/chart-error.tsx` — chart error dialog "How to enable" section (was using `<pre whitespace-pre-wrap>`, which kept newlines but still showed `` ``` `` literally)
- `components/feedback/optional-table-info.tsx` — replaced the hand-rolled backtick splitter with `ReactMarkdown` so inline `` `<session_log>` `` style references also format correctly

## Test plan

- [x] `bun run type-check` clean
- [x] `bun run build` clean
- [x] Biome lint produces no new warnings on the touched files
- [ ] Visit `/logs/text-log` with a ClickHouse cluster where `system.text_log` is disabled and confirm the XML snippet renders as a code block, not as raw backticks

https://claude.ai/code/session_01WSGYr7oRpJJr37wEa5FwXf

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSGYr7oRpJJr37wEa5FwXf)_

## Summary by Sourcery

Render feedback guidance instructions as markdown across table, chart error, and optional table info views so code blocks and inline code are displayed correctly.

Bug Fixes:
- Fix missing-table feedback alerts that showed raw markdown syntax instead of formatted content.

Enhancements:
- Unify markdown rendering for guidance instructions using ReactMarkdown with consistent styling for inline code, code blocks, and links across affected components.