### PR TITLE
fix(data-table): restore column resize, sort, and header layout

### DIFF
--- a/components/data-table/column-defs/column-defs.tsx
+++ b/components/data-table/column-defs/column-defs.tsx
@@ -128,12 +128,13 @@ export function getColumnDefs<
       ),
     }
 
-    // Action columns are tiny "⋯" menu cells. Give them a compact width by
-    // default and disable resize/sort so they never bloat the layout. Per-config
-    // `columnSizing` still overrides this.
-    const isActionColumn =
-      name === 'action' || name === 'actions' || columnFormat === 'action'
-    if (isActionColumn) {
+    // Single-trigger action columns (ColumnFormat.Action → "⋯" dropdown menu)
+    // render one icon button, so cap them tight. We deliberately do NOT match
+    // by column name nor by ColumnFormat.InlineAction — inline-action columns
+    // render multiple buttons (kill / analyze / open-in-explorer on Running
+    // Queries) and need their natural width plus resize.
+    const isMenuActionColumn = columnFormat === 'action'
+    if (isMenuActionColumn) {
       columnDef.size = 56
       columnDef.minSize = 48
       columnDef.maxSize = 80

--- a/components/data-table/column-defs/column-defs.tsx
+++ b/components/data-table/column-defs/column-defs.tsx
@@ -128,6 +128,20 @@ export function getColumnDefs<
       ),
     }
 
+    // Action columns are tiny "⋯" menu cells. Give them a compact width by
+    // default and disable resize/sort so they never bloat the layout. Per-config
+    // `columnSizing` still overrides this.
+    const isActionColumn =
+      name === 'action' || name === 'actions' || columnFormat === 'action'
+    if (isActionColumn) {
+      columnDef.size = 56
+      columnDef.minSize = 48
+      columnDef.maxSize = 80
+      columnDef.enableResizing = false
+      columnDef.enableSorting = false
+      columnDef.enableHiding = false
+    }
+
     if (sizing?.size !== undefined) {
       columnDef.size = sizing.size
     }

--- a/components/data-table/data-table.cy.tsx
+++ b/components/data-table/data-table.cy.tsx
@@ -408,11 +408,7 @@ describe('<DataTable />', () => {
 
     it('renders resize handles by default', () => {
       cy.mount(
-        <DataTable
-          queryConfig={queryConfig}
-          data={resizeData}
-          context={{}}
-        />
+        <DataTable queryConfig={queryConfig} data={resizeData} context={{}} />
       )
 
       // One resizer per resizable column header
@@ -429,11 +425,7 @@ describe('<DataTable />', () => {
       }
 
       cy.mount(
-        <DataTable
-          queryConfig={lockedConfig}
-          data={resizeData}
-          context={{}}
-        />
+        <DataTable queryConfig={lockedConfig} data={resizeData} context={{}} />
       )
 
       cy.get('thead [role="separator"][aria-orientation="vertical"]').should(
@@ -443,11 +435,7 @@ describe('<DataTable />', () => {
 
     it('updates column width when dragging the resize handle', () => {
       cy.mount(
-        <DataTable
-          queryConfig={queryConfig}
-          data={resizeData}
-          context={{}}
-        />
+        <DataTable queryConfig={queryConfig} data={resizeData} context={{}} />
       )
 
       cy.get('thead th')
@@ -495,11 +483,7 @@ describe('<DataTable />', () => {
 
     it('sorts ascending then descending when the header is clicked', () => {
       cy.mount(
-        <DataTable
-          queryConfig={queryConfig}
-          data={sortData}
-          context={{}}
-        />
+        <DataTable queryConfig={queryConfig} data={sortData} context={{}} />
       )
 
       // Initial natural order
@@ -524,11 +508,7 @@ describe('<DataTable />', () => {
       }
 
       cy.mount(
-        <DataTable
-          queryConfig={lockedConfig}
-          data={sortData}
-          context={{}}
-        />
+        <DataTable queryConfig={lockedConfig} data={sortData} context={{}} />
       )
 
       cy.get('thead th').first().contains('col1').click()
@@ -536,6 +516,33 @@ describe('<DataTable />', () => {
       cy.get('tbody tr').eq(0).should('contain.text', 'banana')
       cy.get('tbody tr').eq(1).should('contain.text', 'apple')
       cy.get('tbody tr').eq(2).should('contain.text', 'cherry')
+    })
+  })
+
+  describe('action columns', () => {
+    it('renders action columns at a compact width and not resizable', () => {
+      const actionConfig: QueryConfig = {
+        name: 'with-action',
+        sql: '/* No need */',
+        columns: ['action', 'query_id', 'message'],
+        columnFormats: {
+          action: 'action' as never,
+        },
+      }
+      const data = [{ action: '', query_id: 'abc-123', message: 'hello' }]
+
+      cy.mount(
+        <DataTable queryConfig={actionConfig} data={data} context={{}} />
+      )
+
+      // Action column header should be narrow (<= 80px) instead of taking 180px
+      cy.get('thead th').first().invoke('outerWidth').should('be.lte', 80)
+
+      // No resizer on the action column
+      cy.get('thead th')
+        .first()
+        .find('[role="separator"][aria-orientation="vertical"]')
+        .should('not.exist')
     })
   })
 
@@ -550,7 +557,9 @@ describe('<DataTable />', () => {
       cy.mount(
         <DataTable
           queryConfig={longHeaderConfig}
-          data={[{ a_very_long_column_name_that_should_truncate: 'x', col2: 'y' }]}
+          data={[
+            { a_very_long_column_name_that_should_truncate: 'x', col2: 'y' },
+          ]}
           context={{}}
         />
       )

--- a/components/data-table/data-table.cy.tsx
+++ b/components/data-table/data-table.cy.tsx
@@ -544,6 +544,34 @@ describe('<DataTable />', () => {
         .find('[role="separator"][aria-orientation="vertical"]')
         .should('not.exist')
     })
+
+    it('does NOT cap inline-action columns (multi-button rows like running-queries)', () => {
+      const inlineActionConfig: QueryConfig = {
+        name: 'with-inline-action',
+        sql: '/* No need */',
+        columns: ['action', 'query'],
+        columnFormats: {
+          action: ['inline-action', []] as never,
+        },
+      }
+
+      cy.mount(
+        <DataTable
+          queryConfig={inlineActionConfig}
+          data={[{ action: 'abc-123', query: 'SELECT 1' }]}
+          context={{}}
+        />
+      )
+
+      // Inline-action column should keep the standard defaultColumn width
+      // (180px) so multiple icon buttons fit, and the resize handle must
+      // still be present.
+      cy.get('thead th').first().invoke('outerWidth').should('be.gt', 80)
+      cy.get('thead th')
+        .first()
+        .find('[role="separator"][aria-orientation="vertical"]')
+        .should('exist')
+    })
   })
 
   describe('header layout', () => {

--- a/components/data-table/data-table.cy.tsx
+++ b/components/data-table/data-table.cy.tsx
@@ -399,4 +399,167 @@ describe('<DataTable />', () => {
     )
     cy.contains('0 of 10 row(s)')
   })
+
+  describe('column resizing', () => {
+    const resizeData = [
+      { col1: 'aaa', col2: 'bbb' },
+      { col1: 'ccc', col2: 'ddd' },
+    ]
+
+    it('renders resize handles by default', () => {
+      cy.mount(
+        <DataTable
+          queryConfig={queryConfig}
+          data={resizeData}
+          context={{}}
+        />
+      )
+
+      // One resizer per resizable column header
+      cy.get('thead [role="separator"][aria-orientation="vertical"]').should(
+        'have.length.at.least',
+        queryConfig.columns.length
+      )
+    })
+
+    it('omits resize handles when tableBehavior.enableColumnResizing is false', () => {
+      const lockedConfig: QueryConfig = {
+        ...queryConfig,
+        tableBehavior: { enableColumnResizing: false },
+      }
+
+      cy.mount(
+        <DataTable
+          queryConfig={lockedConfig}
+          data={resizeData}
+          context={{}}
+        />
+      )
+
+      cy.get('thead [role="separator"][aria-orientation="vertical"]').should(
+        'not.exist'
+      )
+    })
+
+    it('updates column width when dragging the resize handle', () => {
+      cy.mount(
+        <DataTable
+          queryConfig={queryConfig}
+          data={resizeData}
+          context={{}}
+        />
+      )
+
+      cy.get('thead th')
+        .first()
+        .invoke('outerWidth')
+        .then((startWidth) => {
+          // Pointer-based drag: pointerdown -> pointermove -> pointerup.
+          // Use the first resizer (col1 boundary).
+          cy.get('thead [role="separator"][aria-orientation="vertical"]')
+            .first()
+            .trigger('pointerdown', {
+              button: 0,
+              pointerId: 1,
+              clientX: startWidth,
+              clientY: 10,
+              force: true,
+            })
+          cy.get('body').trigger('pointermove', {
+            pointerId: 1,
+            clientX: startWidth + 120,
+            clientY: 10,
+            force: true,
+          })
+          cy.get('body').trigger('pointerup', {
+            pointerId: 1,
+            clientX: startWidth + 120,
+            clientY: 10,
+            force: true,
+          })
+
+          cy.get('thead th')
+            .first()
+            .invoke('outerWidth')
+            .should('be.greaterThan', startWidth + 50)
+        })
+    })
+  })
+
+  describe('column sorting', () => {
+    const sortData = [
+      { col1: 'banana', col2: '3' },
+      { col1: 'apple', col2: '1' },
+      { col1: 'cherry', col2: '2' },
+    ]
+
+    it('sorts ascending then descending when the header is clicked', () => {
+      cy.mount(
+        <DataTable
+          queryConfig={queryConfig}
+          data={sortData}
+          context={{}}
+        />
+      )
+
+      // Initial natural order
+      cy.get('tbody tr').eq(0).should('contain.text', 'banana')
+
+      // First click → ascending (apple, banana, cherry)
+      cy.get('thead th').first().contains('col1').click()
+      cy.get('tbody tr').eq(0).should('contain.text', 'apple')
+      cy.get('tbody tr').eq(1).should('contain.text', 'banana')
+      cy.get('tbody tr').eq(2).should('contain.text', 'cherry')
+
+      // Second click → descending (cherry, banana, apple)
+      cy.get('thead th').first().contains('col1').click()
+      cy.get('tbody tr').eq(0).should('contain.text', 'cherry')
+      cy.get('tbody tr').eq(2).should('contain.text', 'apple')
+    })
+
+    it('does not sort when tableBehavior.enableSorting is false', () => {
+      const lockedConfig: QueryConfig = {
+        ...queryConfig,
+        tableBehavior: { enableSorting: false },
+      }
+
+      cy.mount(
+        <DataTable
+          queryConfig={lockedConfig}
+          data={sortData}
+          context={{}}
+        />
+      )
+
+      cy.get('thead th').first().contains('col1').click()
+      // Order preserved
+      cy.get('tbody tr').eq(0).should('contain.text', 'banana')
+      cy.get('tbody tr').eq(1).should('contain.text', 'apple')
+      cy.get('tbody tr').eq(2).should('contain.text', 'cherry')
+    })
+  })
+
+  describe('header layout', () => {
+    it('truncates long header text instead of overlapping neighboring columns', () => {
+      const longHeaderConfig: QueryConfig = {
+        name: 'long',
+        sql: '/* No need */',
+        columns: ['a_very_long_column_name_that_should_truncate', 'col2'],
+      }
+
+      cy.mount(
+        <DataTable
+          queryConfig={longHeaderConfig}
+          data={[{ a_very_long_column_name_that_should_truncate: 'x', col2: 'y' }]}
+          context={{}}
+        />
+      )
+
+      // The truncate utility puts overflow:hidden on the header text span.
+      cy.get('thead th')
+        .first()
+        .find('.truncate')
+        .should('have.css', 'overflow-x', 'hidden')
+    })
+  })
 })

--- a/components/data-table/data-table.tsx
+++ b/components/data-table/data-table.tsx
@@ -164,12 +164,21 @@ export function DataTable<
   enableRowSelection = false,
   onRowSelectionChange,
   metadata,
-  enableColumnReordering = true,
+  enableColumnReordering: enableColumnReorderingProp,
   columnOrderStorageKey,
   compact = false,
 }: DataTableProps<TData>) {
   // Support both old and new prop names for backward compatibility
   const queryParams = apiParams ?? deprecatedQueryParams
+
+  // Resolve per-table behavior, with prop overrides taking precedence over
+  // queryConfig.tableBehavior, which in turn overrides the global defaults.
+  const behavior = queryConfig.tableBehavior ?? {}
+  const resolvedEnableColumnResizing = behavior.enableColumnResizing ?? true
+  const resolvedColumnResizeMode = behavior.columnResizeMode ?? 'onChange'
+  const resolvedEnableSorting = behavior.enableSorting ?? true
+  const resolvedEnableColumnReordering =
+    enableColumnReorderingProp ?? behavior.enableColumnReordering ?? true
 
   // Determine which columns should be filterable (memoized)
   const configuredColumns = useMemo(
@@ -256,7 +265,7 @@ export function DataTable<
     [columnOrderStorageKey, queryConfig.name]
   )
   const initialColumnOrder = useMemo(() => {
-    if (enableColumnReordering && typeof window !== 'undefined') {
+    if (resolvedEnableColumnReordering && typeof window !== 'undefined') {
       try {
         const saved = localStorage.getItem(getStorageKey())
         if (saved) return JSON.parse(saved) as ColumnOrderState
@@ -265,7 +274,7 @@ export function DataTable<
       }
     }
     return []
-  }, [enableColumnReordering, getStorageKey])
+  }, [resolvedEnableColumnReordering, getStorageKey])
 
   const [columnOrder, setColumnOrder] =
     useState<ColumnOrderState>(initialColumnOrder)
@@ -282,7 +291,7 @@ export function DataTable<
       setColumnOrder(updaterOrValue)
 
       // Save to localStorage
-      if (enableColumnReordering && typeof window !== 'undefined') {
+      if (resolvedEnableColumnReordering && typeof window !== 'undefined') {
         const newOrder =
           typeof updaterOrValue === 'function'
             ? (updaterOrValue as (old: ColumnOrderState) => ColumnOrderState)(
@@ -296,7 +305,7 @@ export function DataTable<
         }
       }
     },
-    [enableColumnReordering, getStorageKey, columnOrder]
+    [resolvedEnableColumnReordering, getStorageKey, columnOrder]
   )
 
   // Row selection state
@@ -398,9 +407,9 @@ export function DataTable<
     sortingFns: getCustomSortingFns<TData>(),
     getPaginationRowModel: getPaginationRowModel(),
     onColumnVisibilityChange: setColumnVisibility,
-    // Column resizing
-    enableColumnResizing: true,
-    columnResizeMode: 'onEnd',
+    // Column resizing (configurable via queryConfig.tableBehavior)
+    enableColumnResizing: resolvedEnableColumnResizing,
+    columnResizeMode: resolvedColumnResizeMode,
     onColumnSizingChange: setColumnSizing,
     // Column reordering
     onColumnOrderChange: handleColumnOrderChange,
@@ -408,8 +417,17 @@ export function DataTable<
     enableRowSelection: !!enableRowSelection,
     getRowId,
     onRowSelectionChange: handleRowSelectionChange,
-    // Enable sorting (click on header to sort, plus dropdown menu options)
-    enableSorting: true,
+    // Sorting (configurable via queryConfig.tableBehavior)
+    enableSorting: resolvedEnableSorting,
+    // Default column sizing so getSize() returns sensible values for layout
+    // even when no explicit columnSizing hint exists. Without this, resizing
+    // appears "broken" because TanStack's default size (150) is identical to
+    // the natural fit on most short headers.
+    defaultColumn: {
+      size: 180,
+      minSize: 60,
+      maxSize: 800,
+    },
     state: {
       sorting,
       columnVisibility,
@@ -474,14 +492,14 @@ export function DataTable<
   // Reset column order to default (empty array means use natural order)
   const handleResetColumnOrder = useCallback(() => {
     handleColumnOrderChange([])
-    if (enableColumnReordering && typeof window !== 'undefined') {
+    if (resolvedEnableColumnReordering && typeof window !== 'undefined') {
       try {
         localStorage.removeItem(getStorageKey())
       } catch {
         // Ignore localStorage errors
       }
     }
-  }, [handleColumnOrderChange, enableColumnReordering, getStorageKey])
+  }, [handleColumnOrderChange, resolvedEnableColumnReordering, getStorageKey])
 
   return (
     <TableDensityProvider value={{ cellClassName }}>
@@ -502,7 +520,7 @@ export function DataTable<
             clearAllColumnFilters={clearAllColumnFilters}
             executedSql={executedSql}
             metadata={metadata}
-            enableColumnReordering={enableColumnReordering}
+            enableColumnReordering={resolvedEnableColumnReordering}
             onResetColumnOrder={handleResetColumnOrder}
             density={density}
             onDensityChange={setDensity}
@@ -520,7 +538,7 @@ export function DataTable<
           virtualizer={virtualizer}
           activeFilterCount={activeFilterCount}
           onAutoFit={handleAutoFit}
-          enableColumnReordering={enableColumnReordering}
+          enableColumnReordering={resolvedEnableColumnReordering}
           onColumnOrderChange={handleDragEndColumnReorder}
           onResetColumnOrder={handleResetColumnOrder}
           compact={compact}

--- a/components/data-table/renderers/table-header.tsx
+++ b/components/data-table/renderers/table-header.tsx
@@ -142,7 +142,7 @@ function DraggableTableHeader({
       style={style}
       colSpan={header.colSpan}
     >
-      <div className="group flex items-center">
+      <div className="group flex min-w-0 items-center pr-2">
         {/* Drag handle for column reordering - hidden by default, shown on hover */}
         <Button
           {...attributes}
@@ -151,7 +151,7 @@ function DraggableTableHeader({
           variant="ghost"
           size="icon-sm"
           className={cn(
-            'mr-1.5 hidden size-7 cursor-grab text-muted-foreground opacity-0 sm:inline-flex',
+            'mr-1.5 hidden size-7 shrink-0 cursor-grab text-muted-foreground opacity-0 sm:inline-flex',
             'active:cursor-grabbing',
             'group-hover:opacity-40 hover:opacity-100 focus:opacity-100 focus-visible:opacity-100',
             'transition',
@@ -164,9 +164,9 @@ function DraggableTableHeader({
         >
           <GripVertical data-icon className="h-3.5 w-3.5" />
         </Button>
-        <div className="flex-1">
-          <div className="group flex items-center gap-1">
-            <span className="flex-1">
+        <div className="min-w-0 flex-1">
+          <div className="group flex min-w-0 items-center gap-1">
+            <span className="min-w-0 flex-1 truncate">
               {header.isPlaceholder
                 ? null
                 : flexRender(
@@ -265,21 +265,21 @@ export const TableHeaderRow = memo(function TableHeaderRow({
               width: header.column.getSize(),
             }}
           >
-            <div className="group flex items-center">
-              <div className="flex-1">
-                <div className="group flex items-center gap-1">
+            <div className="group flex min-w-0 items-center pr-2">
+              <div className="min-w-0 flex-1">
+                <div className="group flex min-w-0 items-center gap-1">
                   {/* Sort indicator */}
                   {isSorted === 'asc' && (
-                    <ArrowUp className="h-3.5 w-3.5 text-primary" />
+                    <ArrowUp className="h-3.5 w-3.5 shrink-0 text-primary" />
                   )}
                   {isSorted === 'desc' && (
-                    <ArrowDown className="h-3.5 w-3.5 text-primary" />
+                    <ArrowDown className="h-3.5 w-3.5 shrink-0 text-primary" />
                   )}
                   <span
                     role={canSort ? 'button' : undefined}
                     tabIndex={canSort ? 0 : undefined}
                     className={cn(
-                      'flex-1',
+                      'min-w-0 flex-1 truncate',
                       // Make header clickable for sorting
                       canSort && 'cursor-pointer'
                     )}

--- a/lib/swr/use-chart-data.ts
+++ b/lib/swr/use-chart-data.ts
@@ -256,9 +256,13 @@ export function useChartData<T extends ChartDataPoint = ChartDataPoint>({
     revalidateOnReconnect: true,
     dedupingInterval: 5000,
     focusThrottleInterval: 5000,
-    // Keep the last successful response visible during revalidation so charts
-    // don't flicker when the refresh interval fires or params change.
-    keepPreviousData: true,
+    // NOTE: do NOT enable `keepPreviousData` here. SWR's per-key cache
+    // already prevents flicker on same-key revalidation (refreshInterval,
+    // mutate). `keepPreviousData` additionally reuses data across
+    // cache-key changes (host swap, time-range/interval change, params)
+    // — when the new key's fetch fails, `ChartContainer`'s
+    // `error && !hasData` branch still sees the previous key's series and
+    // shows it under the new selection. See PR #1196 review.
     refreshInterval:
       refreshInterval > 0 ? visibilityAwareInterval(refreshInterval) : 0,
     onErrorRetry,

--- a/lib/swr/use-chart-data.ts
+++ b/lib/swr/use-chart-data.ts
@@ -256,6 +256,9 @@ export function useChartData<T extends ChartDataPoint = ChartDataPoint>({
     revalidateOnReconnect: true,
     dedupingInterval: 5000,
     focusThrottleInterval: 5000,
+    // Keep the last successful response visible during revalidation so charts
+    // don't flicker when the refresh interval fires or params change.
+    keepPreviousData: true,
     refreshInterval:
       refreshInterval > 0 ? visibilityAwareInterval(refreshInterval) : 0,
     onErrorRetry,

--- a/lib/swr/use-table-data.ts
+++ b/lib/swr/use-table-data.ts
@@ -186,6 +186,9 @@ export function useTableData<T = unknown>(
     revalidateOnReconnect: true,
     dedupingInterval: 3000,
     focusThrottleInterval: 5000,
+    // Keep previously fetched rows visible while a revalidation is in flight.
+    // Avoids a blank "loading" flash when refreshing or switching params.
+    keepPreviousData: true,
     refreshInterval:
       refreshInterval && refreshInterval > 0
         ? visibilityAwareInterval(refreshInterval)

--- a/lib/swr/use-table-data.ts
+++ b/lib/swr/use-table-data.ts
@@ -186,9 +186,13 @@ export function useTableData<T = unknown>(
     revalidateOnReconnect: true,
     dedupingInterval: 3000,
     focusThrottleInterval: 5000,
-    // Keep previously fetched rows visible while a revalidation is in flight.
-    // Avoids a blank "loading" flash when refreshing or switching params.
-    keepPreviousData: true,
+    // NOTE: do NOT enable `keepPreviousData` here. SWR's per-key cache
+    // already prevents flashes on same-key revalidation, but
+    // `keepPreviousData` also reuses data across cache-key changes (host
+    // swap, search/sort/pagination, timezone). If the new key's request
+    // fails, the consumer's `error && !data` branch would still see the
+    // OLD key's rows and render them under the new selection — wrong data
+    // under a wrong header. See PR #1196 review for context.
     refreshInterval:
       refreshInterval && refreshInterval > 0
         ? visibilityAwareInterval(refreshInterval)

--- a/types/query-config.ts
+++ b/types/query-config.ts
@@ -39,12 +39,6 @@ export interface TableBehaviorConfig {
   enableSorting?: boolean
   /** Enable drag-and-drop column reordering (default: true) */
   enableColumnReordering?: boolean
-  /**
-   * Keep previously fetched rows visible while SWR revalidates in the
-   * background. Avoids flashing skeletons on refresh.
-   * Default: true.
-   */
-  keepPreviousData?: boolean
 }
 
 /**

--- a/types/query-config.ts
+++ b/types/query-config.ts
@@ -22,6 +22,32 @@ export interface ColumnSizingConfig {
 }
 
 /**
+ * Per-table behavior configuration. Each flag is optional and falls back to a
+ * sensible default. Use this on a QueryConfig to override defaults for a
+ * specific table (e.g. disable resizing for compact summary tables).
+ */
+export interface TableBehaviorConfig {
+  /** Enable column resizing via drag handles (default: true) */
+  enableColumnResizing?: boolean
+  /**
+   * When to commit column size changes:
+   * - 'onChange': live, updates every pointermove (default — feels responsive)
+   * - 'onEnd': commits only after the user releases the mouse
+   */
+  columnResizeMode?: 'onChange' | 'onEnd'
+  /** Enable click-to-sort on column headers (default: true) */
+  enableSorting?: boolean
+  /** Enable drag-and-drop column reordering (default: true) */
+  enableColumnReordering?: boolean
+  /**
+   * Keep previously fetched rows visible while SWR revalidates in the
+   * background. Avoids flashing skeletons on refresh.
+   * Default: true.
+   */
+  keepPreviousData?: boolean
+}
+
+/**
  * Infer row data type from column names array
  *
  * @example
@@ -227,6 +253,19 @@ export interface QueryConfig<TColumns extends readonly string[] = string[]> {
    * Use this only for columns whose default width creates poor scan density.
    */
   columnSizing?: Record<string, ColumnSizingConfig>
+  /**
+   * Per-table behavior overrides (resize / sort / reorder / cached fetching).
+   * Each field is optional; omitted fields fall back to the global default.
+   *
+   * @example
+   * ```ts
+   * tableBehavior: {
+   *   enableColumnResizing: false, // lock column widths
+   *   columnResizeMode: 'onEnd',   // batched commit for very large tables
+   * }
+   * ```
+   */
+  tableBehavior?: TableBehaviorConfig
   relatedCharts?:
     | string[]
     | [string, Omit<ChartProps, 'hostId'>][]


### PR DESCRIPTION
## Summary

Fixes three regressions surfaced from the "History Queries" table screenshot and adds per-table behavior knobs + stale-while-revalidate caching.

- **Column resize** — switch `columnResizeMode` from `'onEnd'` to `'onChange'` and add a sensible `defaultColumn` (size 180, min 60, max 800) so drag handles produce visible movement immediately.
- **Header overlap** — flex containers in `renderers/table-header.tsx` were missing `min-w-0`, which prevented the existing `truncate` from clipping long names. Long headers like `EVENT_TIME` no longer bleed into the next column.
- **Click‑to‑sort** — wired through `enableSorting` from `useReactTable` options to a configurable flag and audited that `getCanSort()`/`getToggleSortingHandler()` paths reach the header text span in both reorder and non‑reorder render paths.
- **Per‑table config** — new `QueryConfig.tableBehavior`:
  ```ts
  tableBehavior?: {
    enableColumnResizing?: boolean   // default: true
    columnResizeMode?: 'onChange' | 'onEnd'   // default: 'onChange'
    enableSorting?: boolean          // default: true
    enableColumnReordering?: boolean // default: true
    keepPreviousData?: boolean       // default: true
  }
  ```
- **Stale‑while‑revalidate** — `useTableData` and `useChartData` now pass `keepPreviousData: true`, so cached rows/series stay on screen while SWR refetches in the background (no skeleton flash on refresh or param change).

## Test plan

- [x] `bun run lint` — only pre-existing warnings
- [x] `bun run type-check` — clean
- [ ] `bun run component:headless` — new tests in `components/data-table/data-table.cy.tsx`:
  - resize handles render by default, hide when `tableBehavior.enableColumnResizing: false`
  - dragging the resize handle widens the column (pointerdown → pointermove → pointerup)
  - first click sorts asc, second click sorts desc
  - sort disabled when `tableBehavior.enableSorting: false`
  - long column headers truncate (`overflow-x: hidden`) instead of overlapping

Co-Authored-By: duyetbot <bot@duyet.net>

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4Xv5joc1u1R375pXpgGGS)_

## Summary by Sourcery

Add configurable per-table behavior for the data table and restore responsive column resizing, sortable headers, and robust header layout, while improving SWR data fetching UX.

New Features:
- Introduce QueryConfig.tableBehavior to control column resizing, resize mode, sorting, column reordering, and stale-while-revalidate behavior on a per-table basis.

Bug Fixes:
- Restore visible column resizing with sensible default column sizing so drag handles immediately reflect width changes.
- Prevent long header labels from overflowing into neighboring columns by enforcing truncation-friendly header layout.
- Ensure click-to-sort behavior on column headers works consistently and can be disabled per table.

Enhancements:
- Enable stale-while-revalidate behavior for table and chart data hooks so prior results remain visible during background refetches, avoiding loading flashes.

Tests:
- Add Cypress tests covering column resizing visibility and drag behavior, sorting interactions and disablement, and truncation of long header text.