### PR TITLE
feat(host): show version and uptime in host switcher popover

### DIFF
--- a/components/host/format-uptime.ts
+++ b/components/host/format-uptime.ts
@@ -1,0 +1,31 @@
+const UNIT_SHORT: Record<string, string> = {
+  year: 'y',
+  month: 'mo',
+  week: 'w',
+  day: 'd',
+  hour: 'h',
+  minute: 'm',
+  second: 's',
+}
+
+/**
+ * Compact a ClickHouse `formatReadableTimeDelta` string into a short label.
+ * Examples:
+ *   "4 days, 14 hours, 31 minutes and 52 seconds" -> "4d 14h"
+ *   "2 hours and 5 minutes"                       -> "2h 5m"
+ *   "45 seconds"                                  -> "45s"
+ */
+export function formatCompactUptime(input: string, maxParts = 2): string {
+  if (!input) return ''
+  const parts: string[] = []
+  const re = /(\d+)\s+(year|month|week|day|hour|minute|second)s?/gi
+  let match: RegExpExecArray | null
+  while ((match = re.exec(input)) !== null) {
+    const [, value, unit] = match
+    const short = UNIT_SHORT[unit.toLowerCase()]
+    if (!short) continue
+    parts.push(`${value}${short}`)
+    if (parts.length >= maxParts) break
+  }
+  return parts.length > 0 ? parts.join(' ') : input
+}

--- a/components/host/host-menu-row.cy.tsx
+++ b/components/host/host-menu-row.cy.tsx
@@ -15,7 +15,9 @@ describe('<HostMenuRow />', () => {
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={false} />
+    )
 
     cy.contains('Production').should('exist')
 
@@ -32,7 +34,9 @@ describe('<HostMenuRow />', () => {
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={false} />
+    )
 
     cy.get('.bg-gray-400.animate-pulse').should('exist')
 
@@ -49,7 +53,9 @@ describe('<HostMenuRow />', () => {
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={false} />
+    )
 
     // Skeleton is rendered while loading (not version/uptime text)
     cy.contains('Offline').should('not.exist')
@@ -68,9 +74,15 @@ describe('<HostMenuRow />', () => {
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={false} />
+    )
 
-    cy.get('.bg-gray-400.animate-pulse').should('have.attr', 'title', 'Checking...')
+    cy.get('.bg-gray-400.animate-pulse').should(
+      'have.attr',
+      'title',
+      'Checking...'
+    )
 
     cy.wait('@hostStatus')
   })
@@ -82,11 +94,17 @@ describe('<HostMenuRow />', () => {
       statusCode: 200,
       body: {
         success: true,
-        data: { version: '24.3.1.1', uptime: '1 day 2 hours', hostname: 'clickhouse-01' },
+        data: {
+          version: '24.3.1.1',
+          uptime: '1 day 2 hours',
+          hostname: 'clickhouse-01',
+        },
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={false} />
+    )
 
     cy.wait('@hostStatus')
 
@@ -100,11 +118,17 @@ describe('<HostMenuRow />', () => {
       statusCode: 200,
       body: {
         success: true,
-        data: { version: '24.3.1.1', uptime: '1 day 2 hours', hostname: 'clickhouse-01' },
+        data: {
+          version: '24.3.1.1',
+          uptime: '1 day 2 hours',
+          hostname: 'clickhouse-01',
+        },
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="My Cluster" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="My Cluster" isActive={false} />
+    )
 
     cy.wait('@hostStatus')
 
@@ -116,11 +140,17 @@ describe('<HostMenuRow />', () => {
       statusCode: 200,
       body: {
         success: true,
-        data: { version: '24.3.1.1', uptime: '1 day 2 hours', hostname: 'clickhouse-01' },
+        data: {
+          version: '24.3.1.1',
+          uptime: '1 day 2 hours',
+          hostname: 'clickhouse-01',
+        },
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={false} />
+    )
 
     cy.wait('@hostStatus')
 
@@ -132,11 +162,17 @@ describe('<HostMenuRow />', () => {
       statusCode: 200,
       body: {
         success: true,
-        data: { version: '24.3.1.1', uptime: '1 day 2 hours', hostname: 'clickhouse-01' },
+        data: {
+          version: '24.3.1.1',
+          uptime: '1 day 2 hours',
+          hostname: 'clickhouse-01',
+        },
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={false} />
+    )
 
     cy.wait('@hostStatus')
 
@@ -148,11 +184,17 @@ describe('<HostMenuRow />', () => {
       statusCode: 200,
       body: {
         success: true,
-        data: { version: '24.3.1.1', uptime: '5 hours', hostname: 'clickhouse-01' },
+        data: {
+          version: '24.3.1.1',
+          uptime: '5 hours',
+          hostname: 'clickhouse-01',
+        },
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={false} />
+    )
 
     cy.wait('@hostStatus')
 
@@ -164,11 +206,17 @@ describe('<HostMenuRow />', () => {
       statusCode: 200,
       body: {
         success: true,
-        data: { version: '24.3.1.1', uptime: '1 day 2 hours', hostname: 'clickhouse-01' },
+        data: {
+          version: '24.3.1.1',
+          uptime: '1 day 2 hours',
+          hostname: 'clickhouse-01',
+        },
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={false} />
+    )
 
     cy.wait('@hostStatus')
 
@@ -191,7 +239,9 @@ describe('<HostMenuRow />', () => {
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={false} />
+    )
 
     cy.wait('@hostStatus')
 
@@ -208,7 +258,9 @@ describe('<HostMenuRow />', () => {
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={false} />
+    )
 
     cy.wait('@hostStatus')
 
@@ -224,7 +276,9 @@ describe('<HostMenuRow />', () => {
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={false} />
+    )
 
     cy.wait('@hostStatus')
 
@@ -240,7 +294,9 @@ describe('<HostMenuRow />', () => {
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={false} />
+    )
 
     cy.wait('@hostStatus')
 
@@ -253,7 +309,9 @@ describe('<HostMenuRow />', () => {
       body: { success: false, error: 'Connection failed' },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={false} />
+    )
 
     cy.wait('@hostStatus')
 
@@ -270,7 +328,9 @@ describe('<HostMenuRow />', () => {
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Staging DB" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Staging DB" isActive={false} />
+    )
 
     cy.wait('@hostStatus')
 
@@ -288,7 +348,9 @@ describe('<HostMenuRow />', () => {
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={true} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={true} />
+    )
 
     cy.wait('@hostStatus')
 
@@ -306,7 +368,9 @@ describe('<HostMenuRow />', () => {
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={false} />
+    )
 
     cy.wait('@hostStatus')
 
@@ -323,7 +387,9 @@ describe('<HostMenuRow />', () => {
       },
     }).as('hostStatus')
 
-    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Production" isActive={false} />
+    )
 
     cy.wait('@hostStatus')
 
@@ -364,7 +430,11 @@ describe('<HostMenuRow />', () => {
     }).as('hostStatus')
 
     cy.mount(
-      <HostMenuRow hostId={hostId} hostName="Always Visible Name" isActive={false} />
+      <HostMenuRow
+        hostId={hostId}
+        hostName="Always Visible Name"
+        isActive={false}
+      />
     )
 
     // Name visible before data loads

--- a/components/host/host-menu-row.cy.tsx
+++ b/components/host/host-menu-row.cy.tsx
@@ -1,0 +1,378 @@
+import { HostMenuRow } from './host-menu-row'
+
+describe('<HostMenuRow />', () => {
+  const hostId = 0
+
+  // ── Loading state ────────────────────────────────────────────────────────────
+
+  it('shows host name during loading', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      delay: 1000,
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '24.3.1.1', uptime: '1 day', hostname: 'ch-01' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+
+    cy.contains('Production').should('exist')
+
+    cy.wait('@hostStatus')
+  })
+
+  it('shows pulsing gray dot during loading', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      delay: 1000,
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '24.3.1.1', uptime: '1 day', hostname: 'ch-01' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+
+    cy.get('.bg-gray-400.animate-pulse').should('exist')
+
+    cy.wait('@hostStatus')
+  })
+
+  it('shows skeleton placeholder during loading', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      delay: 1000,
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '24.3.1.1', uptime: '1 day', hostname: 'ch-01' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+
+    // Skeleton is rendered while loading (not version/uptime text)
+    cy.contains('Offline').should('not.exist')
+    cy.contains('24.3.1.1').should('not.exist')
+
+    cy.wait('@hostStatus')
+  })
+
+  it('shows Checking... tooltip while loading', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      delay: 1000,
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '24.3.1.1', uptime: '1 day', hostname: 'ch-01' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+
+    cy.get('.bg-gray-400.animate-pulse').should('have.attr', 'title', 'Checking...')
+
+    cy.wait('@hostStatus')
+  })
+
+  // ── Online state ─────────────────────────────────────────────────────────────
+
+  it('shows green dot when online', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '24.3.1.1', uptime: '1 day 2 hours', hostname: 'clickhouse-01' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+
+    cy.wait('@hostStatus')
+
+    cy.get('.bg-emerald-500').should('exist')
+    cy.get('.bg-red-400').should('not.exist')
+    cy.get('.animate-pulse').should('not.exist')
+  })
+
+  it('shows host name when online', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '24.3.1.1', uptime: '1 day 2 hours', hostname: 'clickhouse-01' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="My Cluster" isActive={false} />)
+
+    cy.wait('@hostStatus')
+
+    cy.contains('My Cluster').should('exist')
+  })
+
+  it('shows version when online', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '24.3.1.1', uptime: '1 day 2 hours', hostname: 'clickhouse-01' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+
+    cy.wait('@hostStatus')
+
+    cy.contains('24.3.1.1').should('exist')
+  })
+
+  it('shows uptime when online', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '24.3.1.1', uptime: '1 day 2 hours', hostname: 'clickhouse-01' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+
+    cy.wait('@hostStatus')
+
+    cy.contains('1 day 2 hours').should('exist')
+  })
+
+  it('shows dot separator between version and uptime when online', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '24.3.1.1', uptime: '5 hours', hostname: 'clickhouse-01' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+
+    cy.wait('@hostStatus')
+
+    cy.get('.opacity-60').should('exist')
+  })
+
+  it('shows hostname and uptime in tooltip when online', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '24.3.1.1', uptime: '1 day 2 hours', hostname: 'clickhouse-01' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+
+    cy.wait('@hostStatus')
+
+    // StatusIndicator renders title as array joined with ' - '
+    cy.get('.bg-emerald-500').should(
+      'have.attr',
+      'title',
+      'Host: clickhouse-01 - Uptime: 1 day 2 hours'
+    )
+  })
+
+  // ── Offline state ─────────────────────────────────────────────────────────────
+
+  it('shows red dot when offline', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '', uptime: '', hostname: '' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+
+    cy.wait('@hostStatus')
+
+    cy.get('.bg-red-400').should('exist')
+    cy.get('.bg-emerald-500').should('not.exist')
+  })
+
+  it('shows Offline text when offline', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '', uptime: '', hostname: '' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+
+    cy.wait('@hostStatus')
+
+    cy.contains('Offline').should('exist')
+  })
+
+  it('does not show version or uptime when offline', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '', uptime: '', hostname: '' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+
+    cy.wait('@hostStatus')
+
+    cy.get('.opacity-60').should('not.exist')
+  })
+
+  it('shows Offline tooltip when offline', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '', uptime: '', hostname: '' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+
+    cy.wait('@hostStatus')
+
+    cy.get('.bg-red-400').should('have.attr', 'title', 'Offline')
+  })
+
+  it('shows Offline when API returns an error', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 500,
+      body: { success: false, error: 'Connection failed' },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+
+    cy.wait('@hostStatus')
+
+    cy.contains('Offline').should('exist')
+    cy.get('.bg-red-400').should('exist')
+  })
+
+  it('shows host name when offline', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '', uptime: '', hostname: '' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Staging DB" isActive={false} />)
+
+    cy.wait('@hostStatus')
+
+    cy.contains('Staging DB').should('exist')
+  })
+
+  // ── Active / inactive check mark ─────────────────────────────────────────────
+
+  it('shows check mark with full opacity when active', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '24.3.1.1', uptime: '1 day', hostname: 'ch-01' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={true} />)
+
+    cy.wait('@hostStatus')
+
+    // The Check icon wrapper should have opacity-100 (not opacity-0)
+    cy.get('.opacity-100').should('exist')
+    cy.get('.opacity-0').should('not.exist')
+  })
+
+  it('hides check mark when not active', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '24.3.1.1', uptime: '1 day', hostname: 'ch-01' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+
+    cy.wait('@hostStatus')
+
+    cy.get('.opacity-0').should('exist')
+    cy.get('.opacity-100').should('not.exist')
+  })
+
+  it('check mark is hidden regardless of online/offline state when inactive', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '', uptime: '', hostname: '' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostMenuRow hostId={hostId} hostName="Production" isActive={false} />)
+
+    cy.wait('@hostStatus')
+
+    cy.get('.opacity-0').should('exist')
+  })
+
+  // ── Different hostId (boundary) ──────────────────────────────────────────────
+
+  it('uses the correct hostId in the API request', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=7*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '23.8.1.1', uptime: '7 days', hostname: 'ch-07' },
+      },
+    }).as('hostStatus7')
+
+    cy.mount(<HostMenuRow hostId={7} hostName="Analytics" isActive={false} />)
+
+    cy.wait('@hostStatus7')
+
+    cy.contains('23.8.1.1').should('exist')
+    cy.contains('7 days').should('exist')
+    cy.get('.bg-emerald-500').should('exist')
+  })
+
+  // ── Regression: host name always visible ─────────────────────────────────────
+
+  it('always displays the host name prop regardless of status', () => {
+    // Test with a delayed response to verify name shown in all states
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      delay: 500,
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '24.3.1.1', uptime: '1 hour', hostname: 'ch-01' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(
+      <HostMenuRow hostId={hostId} hostName="Always Visible Name" isActive={false} />
+    )
+
+    // Name visible before data loads
+    cy.contains('Always Visible Name').should('exist')
+
+    cy.wait('@hostStatus')
+
+    // Name still visible after data loads
+    cy.contains('Always Visible Name').should('exist')
+  })
+})

--- a/components/host/host-menu-row.tsx
+++ b/components/host/host-menu-row.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { Check } from 'lucide-react'
+
+import { StatusIndicator } from './shared'
+import { memo } from 'react'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useHostStatus } from '@/lib/swr/use-host-status'
+import { cn } from '@/lib/utils'
+
+interface HostMenuRowProps {
+  hostId: number
+  hostName: string
+  isActive: boolean
+}
+
+export const HostMenuRow = memo(function HostMenuRow({
+  hostId,
+  hostName,
+  isActive,
+}: HostMenuRowProps) {
+  const { data, isOnline, isLoading } = useHostStatus(hostId, {
+    refreshInterval: 60000,
+    revalidateOnFocus: false,
+  })
+
+  const dotClass = isLoading
+    ? 'bg-gray-400 animate-pulse'
+    : isOnline
+      ? 'bg-emerald-500'
+      : 'bg-red-400'
+
+  const tooltip = isLoading
+    ? ['Checking...']
+    : isOnline && data
+      ? [`Host: ${data.hostname}`, `Uptime: ${data.uptime}`]
+      : ['Offline']
+
+  return (
+    <div className="flex w-full items-center gap-2.5">
+      <StatusIndicator className={dotClass} title={tooltip} />
+      <div className="flex min-w-0 flex-1 flex-col leading-tight">
+        <span className="truncate text-sm font-medium">{hostName}</span>
+        {isLoading ? (
+          <Skeleton className="mt-0.5 h-3 w-24" />
+        ) : isOnline && data ? (
+          <span className="truncate text-xs text-muted-foreground">
+            {data.version}
+            <span className="mx-1 opacity-60">·</span>
+            {data.uptime}
+          </span>
+        ) : (
+          <span className="truncate text-xs text-muted-foreground">
+            Offline
+          </span>
+        )}
+      </div>
+      <Check
+        className={cn(
+          'ml-auto size-4 shrink-0 text-muted-foreground transition-opacity',
+          isActive ? 'opacity-100' : 'opacity-0'
+        )}
+      />
+    </div>
+  )
+})

--- a/components/host/host-menu-row.tsx
+++ b/components/host/host-menu-row.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { Check } from 'lucide-react'
+import { Check, ClockIcon, TagIcon } from 'lucide-react'
 
+import { formatCompactUptime } from './format-uptime'
 import { StatusIndicator } from './shared'
 import { memo } from 'react'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -44,10 +45,17 @@ export const HostMenuRow = memo(function HostMenuRow({
         {isLoading ? (
           <Skeleton className="mt-0.5 h-3 w-24" />
         ) : isOnline && data ? (
-          <span className="truncate text-xs text-muted-foreground">
-            {data.version}
-            <span className="mx-1 opacity-60">·</span>
-            {data.uptime}
+          <span
+            className="mt-0.5 flex items-center gap-1.5 truncate text-xs text-muted-foreground"
+            title={`Version ${data.version} · Uptime ${data.uptime}`}
+          >
+            <TagIcon className="size-3 shrink-0 opacity-70" />
+            <span className="truncate tabular-nums">{data.version}</span>
+            <span className="opacity-40">·</span>
+            <ClockIcon className="size-3 shrink-0 opacity-70" />
+            <span className="truncate tabular-nums">
+              {formatCompactUptime(data.uptime)}
+            </span>
           </span>
         ) : (
           <span className="truncate text-xs text-muted-foreground">

--- a/components/host/host-switcher.cy.tsx
+++ b/components/host/host-switcher.cy.tsx
@@ -1,9 +1,19 @@
-import { SidebarProvider } from '@/components/ui/sidebar'
 import { HostSwitcher } from './host-switcher'
+import { SidebarProvider } from '@/components/ui/sidebar'
 
 const mockHosts = [
-  { id: 0, name: 'Production', host: 'prod.clickhouse.internal', user: 'default' },
-  { id: 1, name: 'Staging', host: 'staging.clickhouse.internal', user: 'default' },
+  {
+    id: 0,
+    name: 'Production',
+    host: 'prod.clickhouse.internal',
+    user: 'default',
+  },
+  {
+    id: 1,
+    name: 'Staging',
+    host: 'staging.clickhouse.internal',
+    user: 'default',
+  },
   { id: 2, name: '', host: 'localhost:8123', user: 'admin' },
 ]
 
@@ -25,7 +35,11 @@ describe('<HostSwitcher /> - dropdown items use HostMenuRow', () => {
       statusCode: 200,
       body: {
         success: true,
-        data: { version: '24.3.1.1', uptime: '2 days', hostname: 'prod.clickhouse.internal' },
+        data: {
+          version: '24.3.1.1',
+          uptime: '2 days',
+          hostname: 'prod.clickhouse.internal',
+        },
       },
     }).as('hostStatus0')
 
@@ -33,7 +47,11 @@ describe('<HostSwitcher /> - dropdown items use HostMenuRow', () => {
       statusCode: 200,
       body: {
         success: true,
-        data: { version: '24.2.1.1', uptime: '5 hours', hostname: 'staging.clickhouse.internal' },
+        data: {
+          version: '24.2.1.1',
+          uptime: '5 hours',
+          hostname: 'staging.clickhouse.internal',
+        },
       },
     }).as('hostStatus1')
 
@@ -65,7 +83,9 @@ describe('<HostSwitcher /> - dropdown items use HostMenuRow', () => {
 
     cy.get('[data-testid="host-switcher"]').click()
 
-    cy.get('[data-testid="host-option-0"]').contains('Production').should('exist')
+    cy.get('[data-testid="host-option-0"]')
+      .contains('Production')
+      .should('exist')
     cy.get('[data-testid="host-option-1"]').contains('Staging').should('exist')
   })
 
@@ -77,7 +97,9 @@ describe('<HostSwitcher /> - dropdown items use HostMenuRow', () => {
     cy.get('[data-testid="host-switcher"]').click()
 
     // Host 2 has no name, should show extracted host
-    cy.get('[data-testid="host-option-2"]').contains('localhost:8123').should('exist')
+    cy.get('[data-testid="host-option-2"]')
+      .contains('localhost:8123')
+      .should('exist')
   })
 
   it('shows version and uptime for each online host in the dropdown', () => {
@@ -145,8 +167,12 @@ describe('<HostSwitcher /> - dropdown items use HostMenuRow', () => {
     cy.wait('@hostStatus2')
 
     // Online hosts have green dot
-    cy.get('[data-testid="host-option-0"]').find('.bg-emerald-500').should('exist')
-    cy.get('[data-testid="host-option-1"]').find('.bg-emerald-500').should('exist')
+    cy.get('[data-testid="host-option-0"]')
+      .find('.bg-emerald-500')
+      .should('exist')
+    cy.get('[data-testid="host-option-1"]')
+      .find('.bg-emerald-500')
+      .should('exist')
 
     // Offline host has red dot
     cy.get('[data-testid="host-option-2"]').find('.bg-red-400').should('exist')

--- a/components/host/host-switcher.cy.tsx
+++ b/components/host/host-switcher.cy.tsx
@@ -1,0 +1,154 @@
+import { SidebarProvider } from '@/components/ui/sidebar'
+import { HostSwitcher } from './host-switcher'
+
+const mockHosts = [
+  { id: 0, name: 'Production', host: 'prod.clickhouse.internal', user: 'default' },
+  { id: 1, name: 'Staging', host: 'staging.clickhouse.internal', user: 'default' },
+  { id: 2, name: '', host: 'localhost:8123', user: 'admin' },
+]
+
+const mountWithSidebar = (defaultOpen = true) =>
+  cy.mount(
+    <SidebarProvider defaultOpen={defaultOpen}>
+      <HostSwitcher />
+    </SidebarProvider>
+  )
+
+describe('<HostSwitcher /> - dropdown items use HostMenuRow', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/api/v1/hosts', {
+      statusCode: 200,
+      body: { success: true, data: mockHosts },
+    }).as('hosts')
+
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '24.3.1.1', uptime: '2 days', hostname: 'prod.clickhouse.internal' },
+      },
+    }).as('hostStatus0')
+
+    cy.intercept('GET', '/api/v1/host-status?hostId=1*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '24.2.1.1', uptime: '5 hours', hostname: 'staging.clickhouse.internal' },
+      },
+    }).as('hostStatus1')
+
+    cy.intercept('GET', '/api/v1/host-status?hostId=2*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '', uptime: '', hostname: '' },
+      },
+    }).as('hostStatus2')
+  })
+
+  it('renders one dropdown item per configured host', () => {
+    mountWithSidebar()
+
+    cy.wait('@hosts')
+
+    cy.get('[data-testid="host-switcher"]').click()
+
+    cy.get('[data-testid="host-option-0"]').should('exist')
+    cy.get('[data-testid="host-option-1"]').should('exist')
+    cy.get('[data-testid="host-option-2"]').should('exist')
+  })
+
+  it('each dropdown item shows the host name via HostMenuRow', () => {
+    mountWithSidebar()
+
+    cy.wait('@hosts')
+
+    cy.get('[data-testid="host-switcher"]').click()
+
+    cy.get('[data-testid="host-option-0"]').contains('Production').should('exist')
+    cy.get('[data-testid="host-option-1"]').contains('Staging').should('exist')
+  })
+
+  it('falls back to hostname when host name is empty', () => {
+    mountWithSidebar()
+
+    cy.wait('@hosts')
+
+    cy.get('[data-testid="host-switcher"]').click()
+
+    // Host 2 has no name, should show extracted host
+    cy.get('[data-testid="host-option-2"]').contains('localhost:8123').should('exist')
+  })
+
+  it('shows version and uptime for each online host in the dropdown', () => {
+    mountWithSidebar()
+
+    cy.wait('@hosts')
+
+    cy.get('[data-testid="host-switcher"]').click()
+
+    cy.wait('@hostStatus0')
+    cy.wait('@hostStatus1')
+
+    cy.get('[data-testid="host-option-0"]').contains('24.3.1.1').should('exist')
+    cy.get('[data-testid="host-option-0"]').contains('2 days').should('exist')
+
+    cy.get('[data-testid="host-option-1"]').contains('24.2.1.1').should('exist')
+    cy.get('[data-testid="host-option-1"]').contains('5 hours').should('exist')
+  })
+
+  it('shows Offline for hosts that are down', () => {
+    mountWithSidebar()
+
+    cy.wait('@hosts')
+
+    cy.get('[data-testid="host-switcher"]').click()
+
+    cy.wait('@hostStatus2')
+
+    cy.get('[data-testid="host-option-2"]').contains('Offline').should('exist')
+  })
+
+  it('marks the active host with a visible check mark (opacity-100)', () => {
+    // SearchParamsContext is seeded with host=0, so index 0 is active
+    mountWithSidebar()
+
+    cy.wait('@hosts')
+
+    cy.get('[data-testid="host-switcher"]').click()
+
+    // The active host's HostMenuRow check icon should be fully visible
+    cy.get('[data-testid="host-option-0"]').find('.opacity-100').should('exist')
+  })
+
+  it('hides the check mark for inactive hosts (opacity-0)', () => {
+    mountWithSidebar()
+
+    cy.wait('@hosts')
+
+    cy.get('[data-testid="host-switcher"]').click()
+
+    // Inactive hosts should have the check icon hidden
+    cy.get('[data-testid="host-option-1"]').find('.opacity-0').should('exist')
+    cy.get('[data-testid="host-option-2"]').find('.opacity-0').should('exist')
+  })
+
+  it('shows status dot for each host in the dropdown', () => {
+    mountWithSidebar()
+
+    cy.wait('@hosts')
+
+    cy.get('[data-testid="host-switcher"]').click()
+
+    cy.wait('@hostStatus0')
+    cy.wait('@hostStatus1')
+    cy.wait('@hostStatus2')
+
+    // Online hosts have green dot
+    cy.get('[data-testid="host-option-0"]').find('.bg-emerald-500').should('exist')
+    cy.get('[data-testid="host-option-1"]').find('.bg-emerald-500').should('exist')
+
+    // Offline host has red dot
+    cy.get('[data-testid="host-option-2"]').find('.bg-red-400').should('exist')
+  })
+})

--- a/components/host/host-switcher.tsx
+++ b/components/host/host-switcher.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { Check, ChevronsUpDown } from 'lucide-react'
+import { ChevronsUpDown } from 'lucide-react'
 
-import { HostStatusDropdown } from './host-status-dropdown'
+import { HostMenuRow } from './host-menu-row'
 import { HostVersionWithStatus } from './host-version-status'
 import {
   LogoStatusIndicator,
@@ -179,15 +179,11 @@ export function HostSwitcher() {
                   className="gap-2 p-2"
                   data-testid={`host-option-${index}`}
                 >
-                  <div className="flex flex-1 items-center gap-2">
-                    <span className="truncate">
-                      {host.name || getHost(host.host)}
-                    </span>
-                    <HostStatusDropdown hostId={host.id} />
-                  </div>
-                  {index === currentHostId && (
-                    <Check className="ml-auto size-4" />
-                  )}
+                  <HostMenuRow
+                    hostId={host.id}
+                    hostName={host.name || getHost(host.host)}
+                    isActive={index === currentHostId}
+                  />
                 </DropdownMenuItem>
               ))}
             </DropdownMenuContent>

--- a/components/host/host-version-status.cy.tsx
+++ b/components/host/host-version-status.cy.tsx
@@ -107,4 +107,90 @@ describe('<HostVersionWithStatus />', () => {
     cy.contains('23.10.1.1').should('exist')
     cy.get('.bg-emerald-500').should('exist')
   })
+
+  it('renders uptime alongside version when online', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: {
+          version: '24.3.1.1',
+          uptime: '3 days 4 hours',
+          hostname: 'clickhouse-01',
+        },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostVersionWithStatus hostId={hostId} />)
+
+    cy.wait('@hostStatus')
+
+    cy.contains('24.3.1.1').should('exist')
+    cy.contains('3 days 4 hours').should('exist')
+  })
+
+  it('shows dot separator between version and uptime when online', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: {
+          version: '24.3.1.1',
+          uptime: '2 hours',
+          hostname: 'clickhouse-01',
+        },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostVersionWithStatus hostId={hostId} />)
+
+    cy.wait('@hostStatus')
+
+    // The separator span has opacity-60 class
+    cy.get('.opacity-60').should('exist')
+  })
+
+  it('shows tooltip with hostname, uptime, and version when online', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: {
+          version: '24.3.1.1',
+          uptime: '1 day 2 hours',
+          hostname: 'clickhouse-01',
+        },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostVersionWithStatus hostId={hostId} />)
+
+    cy.wait('@hostStatus')
+
+    // Outer span should carry the full title attribute
+    cy.get('.bg-emerald-500')
+      .closest('span')
+      .should(
+        'have.attr',
+        'title',
+        'Host: clickhouse-01\nUptime: 1 day 2 hours\nVersion: 24.3.1.1'
+      )
+  })
+
+  it('does not show uptime or version when offline', () => {
+    cy.intercept('GET', '/api/v1/host-status?hostId=0*', {
+      statusCode: 200,
+      body: {
+        success: true,
+        data: { version: '', uptime: '', hostname: '' },
+      },
+    }).as('hostStatus')
+
+    cy.mount(<HostVersionWithStatus hostId={hostId} />)
+
+    cy.wait('@hostStatus')
+
+    cy.contains('Offline').should('exist')
+    cy.get('.opacity-60').should('not.exist')
+  })
 })

--- a/components/host/host-version-status.tsx
+++ b/components/host/host-version-status.tsx
@@ -29,9 +29,16 @@ export function HostVersionWithStatus({ hostId }: HostVersionWithStatusProps) {
 
   if (isOnline && data) {
     return (
-      <span className="flex items-center gap-1.5 truncate text-xs text-muted-foreground">
+      <span
+        className="flex items-center gap-1.5 truncate text-xs text-muted-foreground"
+        title={`Host: ${data.hostname}\nUptime: ${data.uptime}\nVersion: ${data.version}`}
+      >
         <StatusIndicatorOnline />
-        {data.version}
+        <span className="truncate">
+          {data.version}
+          <span className="mx-1 opacity-60">·</span>
+          {data.uptime}
+        </span>
       </span>
     )
   }

--- a/components/host/host-version-status.tsx
+++ b/components/host/host-version-status.tsx
@@ -6,6 +6,9 @@
 
 'use client'
 
+import { ClockIcon, TagIcon } from 'lucide-react'
+
+import { formatCompactUptime } from './format-uptime'
 import { useHostStatus } from '@/lib/swr/use-host-status'
 
 interface HostVersionWithStatusProps {
@@ -31,13 +34,15 @@ export function HostVersionWithStatus({ hostId }: HostVersionWithStatusProps) {
     return (
       <span
         className="flex items-center gap-1.5 truncate text-xs text-muted-foreground"
-        title={`Host: ${data.hostname}\nUptime: ${data.uptime}\nVersion: ${data.version}`}
+        title={`Host: ${data.hostname}\nVersion: ${data.version}\nUptime: ${data.uptime}`}
       >
         <StatusIndicatorOnline />
-        <span className="truncate">
-          {data.version}
-          <span className="mx-1 opacity-60">·</span>
-          {data.uptime}
+        <TagIcon className="size-3 shrink-0 opacity-70" />
+        <span className="truncate tabular-nums">{data.version}</span>
+        <span className="opacity-40">·</span>
+        <ClockIcon className="size-3 shrink-0 opacity-70" />
+        <span className="truncate tabular-nums">
+          {formatCompactUptime(data.uptime)}
         </span>
       </span>
     )

--- a/components/host/host-version-status.tsx
+++ b/components/host/host-version-status.tsx
@@ -23,7 +23,7 @@ export function HostVersionWithStatus({ hostId }: HostVersionWithStatusProps) {
 
   if (isLoading) {
     return (
-      <span className="flex items-center gap-1.5 truncate text-xs text-muted-foreground">
+      <span className="flex items-center gap-1.5 min-w-0 text-xs text-muted-foreground">
         <span className="size-2 rounded-full bg-gray-400 animate-pulse" />
         Loading...
       </span>
@@ -33,7 +33,7 @@ export function HostVersionWithStatus({ hostId }: HostVersionWithStatusProps) {
   if (isOnline && data) {
     return (
       <span
-        className="flex items-center gap-1.5 truncate text-xs text-muted-foreground"
+        className="flex items-center gap-1.5 min-w-0 text-xs text-muted-foreground"
         title={`Host: ${data.hostname}\nVersion: ${data.version}\nUptime: ${data.uptime}`}
       >
         <StatusIndicatorOnline />
@@ -49,7 +49,7 @@ export function HostVersionWithStatus({ hostId }: HostVersionWithStatusProps) {
   }
 
   return (
-    <span className="flex items-center gap-1.5 truncate text-xs text-muted-foreground">
+    <span className="flex items-center gap-1.5 min-w-0 text-xs text-muted-foreground">
       <StatusIndicatorOffline />
       Offline
     </span>


### PR DESCRIPTION
## Summary

Redesigns each row in the sidebar **ClickHouse Hosts** dropdown so users can tell instances apart at a glance — without leaving the menu.

Each row now uses a compact two-line, status-led layout:

```
●  duet-ubuntu                     ✓
   26.1.3.52 · 4 days 2 hours
```

- Status dot (emerald / red / gray-pulse) + host name on top, `version · uptime` below in muted xs text.
- Hostname surfaced via tooltip on the status dot to keep rows compact.
- Skeleton placeholder for the second line while loading so rows don't jump.
- Offline rows show "Offline" and a red dot.
- Active host tile under the logo now uses the same `version · uptime` format for consistency.

All data comes from the existing `useHostStatus` hook (`/api/v1/host-status`) — no new endpoints, SWR dedupes per-host requests across rows.

## Test plan

- [ ] `bun run build` succeeds (type-check passes).
- [ ] `bun run dev`, open `/overview?host=0`, click the host switcher: each row shows name + status dot + version + uptime, active row has a check.
- [ ] Hover the status dot in a row — tooltip shows hostname + uptime.
- [ ] Sidebar collapsed: logo's status dot still renders.
- [ ] Sidebar expanded: active host tile shows `version · uptime` under the name.
- [ ] Set an invalid password for one host: that row shows "Offline" with a red dot; other hosts stay green.
- [ ] Network tab: only one `/api/v1/host-status?hostId=N` request per host per minute.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FMAWAZafbo3QjugmLUFeyA)_