### PR TITLE
fix(explorer): render deep-linked tab and stop 500 on missing ddl queue

### DIFF
--- a/app/api/v1/menu-counts/[key]/route.ts
+++ b/app/api/v1/menu-counts/[key]/route.ts
@@ -168,9 +168,14 @@ export async function GET(
       hostId,
     })
 
-    // Handle errors - for optional tables, return null count
+    // Handle errors - for optional tables, return null count only when the
+    // table genuinely does not exist. Other failures (permissions, timeouts,
+    // connectivity, query errors) must surface so the badge isn't silently wrong.
     if (result.error) {
-      if (menuCount.optional) {
+      if (
+        menuCount.optional &&
+        result.error.type === ApiErrorType.TableNotFound
+      ) {
         debug('[GET /api/v1/menu-counts] Optional table not found:', {
           requestId,
           countKey,

--- a/components/explorer/explorer-content.tsx
+++ b/components/explorer/explorer-content.tsx
@@ -23,17 +23,19 @@ interface ExplorerContentProps {
 }
 
 // Track which tabs have been visited for this table to enable pre-loading
-function useTabVisitTracker(tableKey: string | null) {
-  const [visitedTabs, setVisitedTabs] = useState<Set<string>>(new Set(['data']))
+function useTabVisitTracker(tableKey: string | null, currentTab: string) {
+  const [visitedTabs, setVisitedTabs] = useState<Set<string>>(
+    () => new Set(['data', currentTab])
+  )
   const prevTableKey = useRef<string | null>(null)
 
   useEffect(() => {
     if (tableKey !== prevTableKey.current) {
-      // Reset visited tabs when table changes
-      setVisitedTabs(new Set(['data']))
+      // Reset visited tabs when table changes, but keep the active tab
+      setVisitedTabs(new Set(['data', currentTab]))
       prevTableKey.current = tableKey
     }
-  }, [tableKey])
+  }, [tableKey, currentTab])
 
   const markVisited = (tab: string) => {
     setVisitedTabs((prev) => new Set([...prev, tab]))
@@ -47,7 +49,7 @@ export function ExplorerContent({ hostName }: ExplorerContentProps) {
   const { database, table, tab, setTab } = useExplorerState()
   const [isTabSwitching, setIsTabSwitching] = useState(false)
   const tableKey = database && table ? `${database}.${table}` : null
-  const { visitedTabs, markVisited } = useTabVisitTracker(tableKey)
+  const { visitedTabs, markVisited } = useTabVisitTracker(tableKey, tab)
 
   // Handle tab switching with instant visual feedback
   const handleTabChange = (value: string) => {

--- a/components/explorer/explorer-content.tsx
+++ b/components/explorer/explorer-content.tsx
@@ -29,21 +29,32 @@ function useTabVisitTracker(tableKey: string | null, currentTab: ExplorerTab) {
   )
   const prevTableKey = useRef<string | null>(null)
 
+  // Reset visited tabs when table changes, keeping the active tab
+  // biome-ignore lint/correctness/useExhaustiveDependencies: currentTab is only used to seed the set on table reset
   useEffect(() => {
     if (tableKey !== prevTableKey.current) {
-      // Reset visited tabs when table changes, but keep the active tab
       setVisitedTabs(new Set<ExplorerTab>(['data', currentTab]))
       prevTableKey.current = tableKey
-    } else {
-      // Mark the active tab visited when it changes externally (e.g. URL/history navigation)
-      setVisitedTabs((prev) =>
-        prev.has(currentTab) ? prev : new Set([...prev, currentTab])
-      )
     }
-  }, [tableKey, currentTab])
+  }, [tableKey])
+
+  // Track visited tabs when currentTab changes externally (e.g. URL/history navigation)
+  useEffect(() => {
+    setVisitedTabs((prev) => {
+      if (prev.has(currentTab)) return prev
+      const next = new Set(prev)
+      next.add(currentTab)
+      return next
+    })
+  }, [currentTab])
 
   const markVisited = (tab: ExplorerTab) => {
-    setVisitedTabs((prev) => new Set([...prev, tab]))
+    setVisitedTabs((prev) => {
+      if (prev.has(tab)) return prev
+      const next = new Set(prev)
+      next.add(tab)
+      return next
+    })
   }
 
   return { visitedTabs, markVisited }

--- a/components/explorer/explorer-content.tsx
+++ b/components/explorer/explorer-content.tsx
@@ -23,21 +23,26 @@ interface ExplorerContentProps {
 }
 
 // Track which tabs have been visited for this table to enable pre-loading
-function useTabVisitTracker(tableKey: string | null, currentTab: string) {
-  const [visitedTabs, setVisitedTabs] = useState<Set<string>>(
-    () => new Set(['data', currentTab])
+function useTabVisitTracker(tableKey: string | null, currentTab: ExplorerTab) {
+  const [visitedTabs, setVisitedTabs] = useState<Set<ExplorerTab>>(
+    () => new Set<ExplorerTab>(['data', currentTab])
   )
   const prevTableKey = useRef<string | null>(null)
 
   useEffect(() => {
     if (tableKey !== prevTableKey.current) {
       // Reset visited tabs when table changes, but keep the active tab
-      setVisitedTabs(new Set(['data', currentTab]))
+      setVisitedTabs(new Set<ExplorerTab>(['data', currentTab]))
       prevTableKey.current = tableKey
+    } else {
+      // Mark the active tab visited when it changes externally (e.g. URL/history navigation)
+      setVisitedTabs((prev) =>
+        prev.has(currentTab) ? prev : new Set([...prev, currentTab])
+      )
     }
   }, [tableKey, currentTab])
 
-  const markVisited = (tab: string) => {
+  const markVisited = (tab: ExplorerTab) => {
     setVisitedTabs((prev) => new Set([...prev, tab]))
   }
 
@@ -56,7 +61,7 @@ export function ExplorerContent({ hostName }: ExplorerContentProps) {
     if (value === tab) return
 
     setIsTabSwitching(true)
-    markVisited(value)
+    markVisited(value as ExplorerTab)
     setTab(value as ExplorerTab)
 
     // Clear switching state after a brief moment

--- a/lib/api/menu-count-registry.ts
+++ b/lib/api/menu-count-registry.ts
@@ -30,6 +30,8 @@ export const menuCountRegistry: Record<string, MenuCountQuery> = {
   },
   'distributed-ddl-queue': {
     query: `SELECT COUNT() as count FROM system.distributed_ddl_queue WHERE status != 'Finished'`,
+    optional: true,
+    tableCheck: 'system.distributed_ddl_queue',
   },
   'table-replicas': {
     query: `SELECT COUNT() as count FROM system.replicas`,


### PR DESCRIPTION
## Summary

Fixes two issues reported from production (`chmonitor.dev`):

1. **`GET /api/v1/menu-counts/distributed-ddl-queue` returns 500.** The `distributed-ddl-queue` entry in `menu-count-registry.ts` was not marked `optional`, so on hosts where `system.distributed_ddl_queue` is unavailable (no cluster / Keeper configured) the query error surfaced as a 500 instead of a `null` count. Added `optional: true` + `tableCheck`, matching the corresponding `QueryConfig`.

2. **Explorer page does not render when deep-linked to a non-data tab.** e.g. `/explorer?host=1&database=...&table=events&tab=query`. `useTabVisitTracker` seeded `visitedTabs` with only `{'data'}`, and force-mounted tabs (`query`, `ddl`, `indexes`, `dependencies`) only render their content once visited. Loading such a URL directly left the tab blank. The tracker now seeds with the active tab as well, on both initial mount and table change.

## Test plan

- [x] `bun run type-check` passes
- [x] `bun test app/api/v1/menu-counts` passes
- [ ] Load `/explorer?...&tab=query` directly and confirm the Query tab renders
- [ ] Hit `/api/v1/menu-counts/distributed-ddl-queue?hostId=1` on a host without the table and confirm `{ count: null }` instead of 500

Co-Authored-By: duyetbot <bot@duyet.net>

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkFCUjho5FTAysNQo5NBFv)_

## Summary by Sourcery

Fix handling of explorer tab rendering and distributed DDL queue menu counts.

Bug Fixes:
- Ensure explorer renders correctly when deep-linked directly to non-data tabs by tracking the active tab as visited.
- Prevent 500 errors for distributed DDL queue menu counts on hosts without the underlying table by treating the query as optional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved tab caching and preloading behavior in the explorer, ensuring the currently selected tab content loads immediately without additional delays.
  * Enhanced handling of distributed DDL queue counts for better system queue monitoring support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->