### PR TITLE
fix(explorer): preserve selected tab when switching tables in tree

### DIFF
--- a/components/explorer/hooks/use-explorer-state.ts
+++ b/components/explorer/hooks/use-explorer-state.ts
@@ -20,6 +20,19 @@ export interface ExplorerState {
   customQuery: string | null
 }
 
+/**
+ * Exposes explorer state derived from the current URL search parameters and provides setters that update those parameters.
+ *
+ * The returned state mirrors the explorer's URL-driven values: `hostId`, `database`, `table`, `engine`, `tab`, and `customQuery`.
+ * Setter functions modify the URL search parameters so the explorer state stays in sync with the browser address bar.
+ *
+ * @returns An object containing the current explorer state and setter functions:
+ * - `setDatabase(database: string | null)` — set or clear the `database` parameter; clearing the database also clears `table` and `engine`.
+ * - `setTable(table: string | null, engine?: string | null)` — set or clear the `table` parameter; optionally set or clear `engine`. Clearing the table also clears `engine`.
+ * - `setDatabaseAndTable(database: string, table: string, engine?: string)` — set `database`, `table`, and `engine` (defaults `engine` to `null` when omitted) and clear `customQuery`.
+ * - `setTab(tab: ExplorerTab)` — set the `tab` parameter.
+ * - `setCustomQuery(sql: string | null)` — set or clear the encoded custom query (`q`) parameter.
+ */
 export function useExplorerState(): ExplorerState & {
   setDatabase: (database: string | null) => void
   setTable: (table: string | null, engine?: string | null) => void

--- a/components/explorer/hooks/use-explorer-state.ts
+++ b/components/explorer/hooks/use-explorer-state.ts
@@ -133,7 +133,7 @@ export function useExplorerState(): ExplorerState & {
         database,
         table,
         engine: engine ?? null,
-        tab: 'data',
+        // Preserve the currently selected tab when switching tables
         customQuery: null, // Clear stale query when switching tables
       })
     },


### PR DESCRIPTION
## Summary

Clicking a table in the explorer tree browser reset the active tab back to `data`, losing the user's currently selected tab (e.g. `tab=query`).

Example: navigating from `/explorer?...&table=foo&tab=query` and clicking another table in the tree dropped `tab=query`.

The cause was `setDatabaseAndTable` in `components/explorer/hooks/use-explorer-state.ts` hardcoding `tab: 'data'` in its `updateParams` call. Since `updateParams` already preserves any query param not present in the updates object, simply omitting `tab` keeps the current tab.

## Changes

- Remove the hardcoded `tab: 'data'` from `setDatabaseAndTable` so the active tab is preserved when switching tables. (`customQuery` is still cleared to avoid carrying a stale query across tables.)

## Test plan

- [ ] Open explorer, select a table, switch to a non-default tab (e.g. Query), then click a different table in the tree → the same tab stays selected
- [ ] Switching databases still behaves as before


---
_Generated by [Claude Code](https://claude.ai/code/session_01VF3fFSicpGJHzBc3Tv9nGW)_

## Summary by Sourcery

Bug Fixes:
- Fix explorer behavior so changing tables in the tree no longer resets the active tab back to the default data tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves your currently selected tab when switching databases or tables so it no longer resets.
  * Clears any custom query when changing database/table to prevent carrying over stale query state.
  * Resets the engine selection to a neutral/default state when not explicitly set during navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->