### PR TITLE
fix(agent): coerce string hostId in tool calls and add system-tables skill

### DIFF
--- a/.agents/skills/system-tables-reference/SKILL.md
+++ b/.agents/skills/system-tables-reference/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: system-tables-reference
+description: "Exact column names for the system tables the agent queries most (processes, query_log, parts, merges, replicas, metrics) plus rules for choosing dedicated tools over raw SQL. Load before hand-writing SQL against system tables."
+---
+
+# System Tables Reference
+
+Load this skill before writing raw SQL against `system.*` tables. It lists the
+columns that actually exist so you don't reference hallucinated columns. When a
+dedicated tool exists for what you need, call it instead of writing SQL.
+
+## Prefer Dedicated Tools Over Raw SQL
+
+Many questions map to a purpose-built tool. Use it — the SQL is already correct
+and version-aware:
+
+| Question | Use this tool, not raw SQL |
+|----------|----------------------------|
+| What is running now? | `get_running_queries` |
+| Slowest finished queries? | `get_slow_queries` |
+| Recent failures/errors? | `get_failed_queries` |
+| Heaviest queries by memory/bytes/duration? | `get_expensive_queries` |
+| Active merges? | `get_merge_status` |
+| Replication health? | `get_replication_status` |
+| Disk space? | `get_disk_usage` |
+| Server version/uptime/connections? | `get_metrics` |
+
+Only fall back to the `query` tool for ad-hoc questions that no dedicated tool
+covers. If a dedicated tool returns an error, fix the call (e.g. `hostId` is a
+number like `0`, not a string), do **not** rewrite it as raw SQL.
+
+## system.processes — currently running queries
+
+There is **no `database` column** on `system.processes`. Selecting it fails with
+"Unknown expression identifier `database`".
+
+Available columns:
+`query_id`, `user`, `query`, `elapsed`, `read_rows`, `read_bytes`,
+`written_rows`, `written_bytes`, `total_rows_approx`, `memory_usage`,
+`peak_memory_usage`, `query_kind`, `is_initial_query`, `address`, `port`,
+`initial_user`, `initial_query_id`, `client_name`, `thread_ids`, `ProfileEvents`,
+`Settings`, `current_database`.
+
+- Use `current_database` (not `database`) for the session's database.
+- To exclude the monitoring query itself: `WHERE query NOT LIKE '%processes%'`.
+  Do not invent syntax like `WHERE is_query SELECT WITHOUT '...'`.
+- `elapsed` is seconds (Float64). Display with `formatReadableTimeDelta(elapsed)`.
+
+```sql
+SELECT query_id, user, current_database, elapsed, read_rows, memory_usage,
+       substring(query, 1, 200) AS query
+FROM system.processes
+WHERE query NOT LIKE '%processes%'
+ORDER BY elapsed DESC
+```
+
+## system.query_log — query history
+
+Filter by `type` and time. Each query produces a `QueryStart` row and a finish
+row (`QueryFinish` on success, `ExceptionWhileProcessing` on error). For
+completed queries always filter `WHERE type = 'QueryFinish'`, otherwise you
+double-count starts.
+
+Key columns: `query_id`, `type`, `event_time`, `event_date`, `query_start_time`,
+`query_duration_ms`, `read_rows`, `read_bytes`, `result_rows`, `memory_usage`,
+`user`, `query`, `exception_code`, `exception`, `normalized_query_hash`,
+`is_initial_query`, `databases`, `tables`, `columns`, `ProfileEvents`.
+
+- The per-row database/table lists are `databases`/`tables`/`columns` (Array),
+  not `database`/`table`.
+- Add `AND is_initial_query = 1` to avoid counting internal sub-queries.
+
+## system.parts — table parts
+
+Has `database` and `table`. Filter `WHERE active = 1` for live parts.
+Key columns: `database`, `table`, `partition`, `name`, `active`, `rows`,
+`bytes_on_disk`, `data_compressed_bytes`, `data_uncompressed_bytes`,
+`marks`, `modification_time`, `min_time`, `max_time`, `part_type`, `disk_name`.
+
+Compression ratio: `data_uncompressed_bytes / data_compressed_bytes`.
+
+## system.merges — active merges
+
+Columns: `database`, `table`, `elapsed`, `progress` (0..1), `num_parts`,
+`source_part_names`, `result_part_name`, `total_size_bytes_compressed`,
+`rows_read`, `rows_written`, `memory_usage`, `is_mutation`, `merge_type`.
+
+## system.replicas — replication status
+
+One row per replicated table. Columns: `database`, `table`, `is_leader`,
+`is_readonly`, `absolute_delay`, `queue_size`, `inserts_in_queue`,
+`merges_in_queue`, `total_replicas`, `active_replicas`, `last_queue_update`,
+`zookeeper_path`. Healthy = `absolute_delay = 0`, `is_readonly = 0`,
+`active_replicas = total_replicas`.
+
+## system.metrics vs system.events vs system.asynchronous_metrics
+
+These three are easy to confuse — they use different column names:
+
+- `system.metrics`: instantaneous gauges. Columns `metric`, `value`,
+  `description`. e.g. `Query`, `TCPConnection`, `MemoryTracking`.
+- `system.events`: cumulative counters. Columns `event`, `value`,
+  `description` — the name column is `event`, **not** `metric`.
+- `system.asynchronous_metrics`: periodically sampled. Columns `metric`,
+  `value`. e.g. `Uptime`, `jemalloc.*`, disk/CPU samples.
+
+## system.errors — error counters
+
+Columns: `name`, `code`, `value`, `last_error_time`, `last_error_message`,
+`last_error_trace`. There is no `last_update_time` column.
+
+## Recovery Rules
+
+- Unknown column (code 47) or unknown identifier → load this skill or call
+  `get_table_schema` for the table, then retry with real column names. Do not
+  guess again.
+- There is no CPU% column anywhere. Approximate load via `memory_usage`,
+  `read_rows`, `read_bytes` on `system.processes`, or `ProfileEvents` such as
+  `OSCPUVirtualTimeMicroseconds` in `system.query_log`.
+
+## Cross-references
+- Load `query-optimization` for EXPLAIN, PREWHERE, JOIN tuning.
+- Load `troubleshooting` for error-code-driven diagnosis.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,12 @@ Build lock errors: remove `.next/lock` and retry.
 - `bun run dev` then open `/docs` - Preview docs through the main app shell
 - `DOCS_CONTENT_ROOT=<path> bun run dev` - Override docs source root for local validation
 
+**IMPORTANT — keep the AI Agent docs in sync**: `docs/content/ai-agent.mdx` is
+the user-facing reference for the agent's tools, skills, and configuration.
+Whenever you add, rename, or remove an agent tool (`lib/ai/agent/tools/*.ts`), a
+skill (`.agents/skills/*/SKILL.md`), or an agent env var, update
+`docs/content/ai-agent.mdx` in the same change so the docs do not drift.
+
 ## Architecture
 
 ### Core Technologies

--- a/app/api/v1/agent/route.ts
+++ b/app/api/v1/agent/route.ts
@@ -388,9 +388,11 @@ export async function POST(request: Request) {
     )
   }
 
+  const rawHostId =
+    typeof body.hostId === 'string' ? Number(body.hostId) : body.hostId
   const hostId =
-    typeof body.hostId === 'number' && Number.isFinite(body.hostId)
-      ? Math.max(0, Math.trunc(body.hostId))
+    typeof rawHostId === 'number' && Number.isFinite(rawHostId)
+      ? Math.max(0, Math.trunc(rawHostId))
       : 0
   const configuredModel = process.env.LLM_MODEL?.trim()
   const model =

--- a/docs/content/_meta.ts
+++ b/docs/content/_meta.ts
@@ -2,6 +2,7 @@ export const meta = {
   index: 'Introduction',
   'getting-started': 'Getting Started',
   features: 'Features',
+  'ai-agent': 'AI Agent',
   settings: 'Settings',
   reference: 'Reference',
   deploy: 'Deployments',

--- a/docs/content/ai-agent.mdx
+++ b/docs/content/ai-agent.mdx
@@ -1,0 +1,249 @@
+# AI Agent
+
+The AI Agent turns natural language into ClickHouse insights. Ask a question in
+plain English and the agent plans a series of tool calls — running read-only
+SQL, inspecting `system.*` tables, comparing hosts, spotting issues — then
+summarizes the findings and can render charts inline.
+
+The agent connects through the **same configured ClickHouse host and user** as
+the rest of the dashboard, so its visibility is limited by the grants you give
+that user. By default it only runs read-only queries.
+
+> Open the agent at `/agents` (use the host selector or `?host=0` to pick a
+> host). It is available on any deployment that has an LLM provider configured.
+
+## How It Works
+
+1. You send a message (optionally targeting a specific `hostId`).
+2. The agent calls one or more **tools** to gather evidence — each tool is a
+   purpose-built, version-aware query against ClickHouse system tables.
+3. When a question needs deeper expertise, the agent loads a **skill** — a
+   bundled expert guide — to inform its analysis before answering.
+4. It streams back a concise answer, shows the SQL it ran, and suggests
+   follow-ups or visualizations.
+
+The agent runs in a bounded tool loop: it keeps calling tools until it has
+enough to answer, then stops. Destructive actions (kill query, optimize) are
+disabled unless explicitly enabled (see [Configuration](#configuration)).
+
+## Configuration
+
+The agent uses an OpenAI-compatible API. At minimum set `LLM_API_KEY`.
+
+```bash
+LLM_API_KEY=your-provider-key
+LLM_API_BASE=https://openrouter.ai/api/v1   # default
+LLM_MODEL=openrouter:openrouter/free        # default
+```
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `LLM_API_KEY` | — | Provider API key (required). |
+| `LLM_API_BASE` | `https://openrouter.ai/api/v1` | OpenAI-compatible base URL. |
+| `LLM_MODEL` | `openrouter:openrouter/free` | Model identifier. |
+| `AGENT_API_TOKEN` | — | Shared Bearer token for the agent API. |
+| `AGENT_ENABLE_CONTROL_TOOLS` | `false` | Enables destructive tools (kill query, optimize). |
+
+For public deployments, require authentication for the agent:
+
+```bash
+CHM_FEATURE_AGENT_ACCESS=authenticated
+```
+
+See [Environment Variables](/docs/reference/environment-variables) and
+[Feature Permissions](/docs/advanced/feature-permissions) for the full list.
+
+## Tools
+
+Tools are the functions the agent calls to gather data. Every tool accepts an
+optional `hostId` (a numeric, 0-based index — `0`, `1`, `2`) and defaults to the
+current host. The agent picks tools automatically; you never call them directly.
+
+### Schema & Exploration
+
+| Tool | Description |
+|---|---|
+| `query` | Execute a read-only SQL query (SELECT, WITH/CTE, DESCRIBE). |
+| `list_databases` | List all databases. |
+| `list_tables` | List tables in a database with sizes and row counts. |
+| `get_table_schema` | Column definitions for a table. |
+| `explore_table_schema` | Schema exploration with relationship discovery. |
+| `discover_data_sources` | Find tables/columns relevant to a topic. |
+
+### Query Analysis
+
+| Tool | Description |
+|---|---|
+| `get_running_queries` | Currently executing queries with elapsed time. |
+| `get_slow_queries` | Slowest completed queries. |
+| `get_failed_queries` | Recent failed queries with error details. |
+| `get_expensive_queries` | Top queries by memory, bytes read, or duration. |
+| `get_query_patterns` | Aggregated query fingerprints with frequency. |
+| `explain_query` | EXPLAIN plan / pipeline / indexes for a query. |
+| `analyze_query_optimization` | Optimization opportunities for a SQL query. |
+| `repair_query` | Self-fix a broken or slow read-only query. |
+| `spot_issues` | Scan recent history for likely problems. |
+
+### System Health
+
+| Tool | Description |
+|---|---|
+| `get_metrics` | Server version, uptime, connections, memory. |
+| `get_system_resources` | CPU, memory, disk, network, thread metrics. |
+| `get_disk_usage` | Per-disk free/total/used percentage. |
+| `get_errors` | Recent system errors with counts. |
+| `get_crash_log` | Server crash history. |
+| `detect_anomalies` | Compare recent vs baseline metrics for anomalies. |
+| `generate_health_report` | Collect all key metrics into one report. |
+| `investigate_incident` | Automated root-cause analysis for an incident. |
+
+### Storage, Merges & Mutations
+
+| Tool | Description |
+|---|---|
+| `get_table_parts` | Part-level sizes, rows, compression ratio. |
+| `get_detached_parts` | Detached parts needing attention. |
+| `get_top_tables_by_size` | Top tables by compressed size. |
+| `get_merge_status` | Active merge operations with progress. |
+| `get_mutations` | Pending and stuck mutations. |
+| `get_merge_performance` | Historical merge throughput. |
+
+### Replication & Cluster
+
+| Tool | Description |
+|---|---|
+| `get_replication_status` | Per-table lag, queue size, leader/readonly. |
+| `get_replication_queue` | Pending replication tasks. |
+| `get_clusters` | Cluster topology: shards, replicas, hosts. |
+| `get_distributed_ddl_queue` | Pending/failed distributed DDL operations. |
+| `get_zookeeper_info` | ZooKeeper/Keeper node data. |
+
+### Security & Audit
+
+| Tool | Description |
+|---|---|
+| `get_active_sessions` | Current sessions with user/client info. |
+| `get_login_attempts` | Recent login successes/failures. |
+| `get_users_and_roles` | Users, roles, and access grants. |
+
+### Schema Migration
+
+| Tool | Description |
+|---|---|
+| `analyze_schema_change` | Assess impact of a proposed ALTER TABLE. |
+| `get_column_usage` | Find queries referencing a column (blast radius). |
+| `recommend_table_design` | Suggest ORDER BY, types, indexes, MVs. |
+
+### Comparison, Insights & Visualization
+
+| Tool | Description |
+|---|---|
+| `compare_time_periods` | Compare metrics between two time periods. |
+| `compare_hosts` | Compare two hosts side-by-side. |
+| `get_query_insights` | Highlight stats: largest scans, peak memory, etc. |
+| `get_table_insights` | Table-level insights: size, rows, compression. |
+| `forecast_capacity` | Forecast days-until-disk-full from 30-day trends. |
+| `query_and_visualize` | Run SQL and return an interactive chart config. |
+
+### Settings, Logs & Navigation
+
+| Tool | Description |
+|---|---|
+| `get_settings` | Server settings changed from defaults. |
+| `get_mergetree_settings` | MergeTree settings changed from defaults. |
+| `get_text_log` | Server log entries by level and pattern. |
+| `get_stack_traces` | Current thread stack traces. |
+| `get_dashboard_pages` | List dashboard pages and routes. |
+| `get_chart_data` | Fetch data from a specific dashboard chart. |
+
+### Control Actions (destructive)
+
+Disabled unless `AGENT_ENABLE_CONTROL_TOOLS=true`. The agent always confirms
+before using them.
+
+| Tool | Description |
+|---|---|
+| `optimize_table` | Trigger `OPTIMIZE TABLE`. |
+| `kill_query` | Kill a running query by id. |
+
+### Interaction & Knowledge
+
+| Tool | Description |
+|---|---|
+| `ask_user` | Ask a structured clarifying question. |
+| `load_skill` | Load a specialized expert guide (see Skills below). |
+
+## Skills
+
+Skills are bundled expert guides the agent loads on demand to deepen its
+answers. They live in `.agents/skills/<name>/SKILL.md` and are compiled into a
+registry. The agent loads the relevant skill before answering domain questions.
+
+| Skill | Covers |
+|---|---|
+| `clickhouse-best-practices` | Schema design, query tuning, operational guidelines. |
+| `query-optimization` | PREWHERE, JOIN patterns, materialized views, EXPLAIN, indexes. |
+| `system-tables-reference` | Exact columns of `system.processes`, `query_log`, `parts`, `merges`, `replicas`, `metrics`; when to prefer dedicated tools over raw SQL. |
+| `troubleshooting` | OOM, slow merges, stuck mutations, error-code diagnosis. |
+| `replication-guide` | ReplicatedMergeTree, failover, lag diagnosis, Keeper. |
+| `cluster-operations` | Distributed tables, resharding, node management, topology. |
+| `storage-optimization` | Compression codecs, TTL, tiered storage, part management. |
+| `migration-patterns` | Schema migrations, ALTER patterns, zero-downtime changes. |
+| `security-hardening` | RBAC, row policies, quotas, audit logging. |
+
+The available skills are exposed at `GET /api/v1/agent/skills`.
+
+## Examples
+
+Ask questions the way you would ask a teammate:
+
+- **"Which queries are running right now and how long have they been executing?"**
+  The agent calls `get_running_queries` and lists query id, user, elapsed time,
+  and memory, sorted by duration.
+
+- **"What were the 10 slowest queries in the last 24 hours?"**
+  Uses `get_slow_queries`, then offers to `explain_query` on any of them.
+
+- **"Why is the cluster slow right now?"**
+  Loads the `troubleshooting` skill, runs `spot_issues` and `detect_anomalies`,
+  and correlates merges, errors, and expensive queries into a root-cause summary.
+
+- **"Show me query volume per hour over the last day as a chart."**
+  Uses `query_and_visualize` to run the aggregation and render a line chart.
+
+- **"Compare disk usage and query load between host 0 and host 1."**
+  Calls `compare_hosts` with `hostId1: 0` and `hostId2: 1`.
+
+- **"Is it safe to drop the `event_payload` column from `analytics.events`?"**
+  Runs `get_column_usage` to assess blast radius and `analyze_schema_change`
+  to classify the ALTER risk before recommending.
+
+- **"Forecast when our biggest disk will fill up."**
+  Uses `forecast_capacity` on 30-day storage trends.
+
+## API
+
+The agent is also available over HTTP for integrations.
+
+```bash
+curl -X POST https://your-host/api/v1/agent \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $AGENT_API_TOKEN" \
+  -d '{
+    "message": "Which queries are running right now?",
+    "hostId": 0
+  }'
+```
+
+`hostId` may be a number or a numeric string; it defaults to `0`. List loadable
+skills with `GET /api/v1/agent/skills`.
+
+## Security Notes
+
+- The agent inherits the configured ClickHouse user's grants — scope that user
+  to read-only system access for safe exposure.
+- Keep destructive control tools off (`AGENT_ENABLE_CONTROL_TOOLS=false`) unless
+  the ClickHouse user is trusted and you intend to allow kill/optimize.
+- Require authentication on public deployments with
+  `CHM_FEATURE_AGENT_ACCESS=authenticated`.
+- Keep LLM keys server-side — never in `NEXT_PUBLIC_` variables.

--- a/docs/content/features.mdx
+++ b/docs/content/features.mdx
@@ -62,6 +62,9 @@ LLM_MODEL=your-model
 For deployments that expose the agent publicly, configure feature permissions
 so agent access requires authentication.
 
+See the [AI Agent](/docs/ai-agent) guide for the full list of tools, skills,
+and example questions.
+
 ## MCP Server
 
 The MCP endpoint lets external AI tools query the monitor through `/api/mcp`.

--- a/lib/ai/agent/prompts/clickhouse-instructions.ts
+++ b/lib/ai/agent/prompts/clickhouse-instructions.ts
@@ -25,6 +25,7 @@ You are part of a monitoring dashboard that provides real-time insights into Cli
 **CRITICAL**: This dashboard supports monitoring multiple ClickHouse instances. Users can switch between hosts using the host selector.
 
 - Every tool accepts a \`hostId\` parameter (default: 0 for the first host)
+- \`hostId\` is a **numeric** 0-based index (\`0\`, \`1\`, \`2\`), not a string. Pass \`hostId: 0\`, never \`hostId: "0"\`
 - When users ask about "host 1" or "the second cluster", use \`hostId: 1\`
 - Users may want to compare data across hosts - query each host separately
 - Always specify the hostId when users mention a specific host or cluster
@@ -159,6 +160,7 @@ The \`load_skill\` tool gives you access to expert-level guides on specific Clic
 - \`migration-patterns\` — Schema migrations, ALTER patterns, engine changes, zero-downtime
 - \`storage-optimization\` — Compression codecs, TTL, tiered storage, part management
 - \`clickhouse-best-practices\` — Schema design, query tuning, operational guidelines
+- \`system-tables-reference\` — Exact column names for system.processes/query_log/parts/merges/replicas/metrics and when to use dedicated tools vs raw SQL
 
 **When to load skills:**
 - User asks "best practices" or "how should I" → load \`clickhouse-best-practices\` or the relevant domain skill
@@ -169,6 +171,7 @@ The \`load_skill\` tool gives you access to expert-level guides on specific Clic
 - User asks about schema changes or migrations → load \`migration-patterns\`
 - User asks about disk usage, compression, or TTL → load \`storage-optimization\`
 - User asks about distributed tables or cluster scaling → load \`cluster-operations\`
+- Before hand-writing SQL against \`system.*\` tables, or after a query fails with an unknown column/identifier → load \`system-tables-reference\`
 
 Load the skill **before** answering so your response is informed by the expert guide.
 
@@ -272,7 +275,7 @@ Use mermaid when it communicates structure more clearly than text. Prefer simple
 - **Common system tables**:
   - system.tables: Table metadata (name, engine, total_rows, total_bytes)
   - system.columns: Column definitions (name, type, default_expression)
-  - system.processes: Currently running queries
+  - system.processes: Currently running queries. Has \`current_database\` (NOT \`database\`), \`query_id\`, \`user\`, \`elapsed\`, \`read_rows\`, \`memory_usage\`. Prefer the \`get_running_queries\` tool over raw SQL here.
   - system.query_log: Query history (filter by type = 'QueryFinish' for completed queries)
   - system.merges: Active merge operations
   - system.parts: Table partitions and parts

--- a/lib/ai/agent/skills/registry.ts
+++ b/lib/ai/agent/skills/registry.ts
@@ -9,9 +9,166 @@ import type { Skill } from './types'
 
 export const SKILLS: readonly Skill[] = [
   {
+    name: 'system-tables-reference',
+    description: 'Exact column names for the system tables the agent queries most (processes, query_log, parts, merges, replicas, metrics) plus rules for choosing dedicated tools over raw SQL. Load before hand-writing SQL against system tables.',
+    content: `# System Tables Reference
+
+Load this skill before writing raw SQL against \`system.*\` tables. It lists the
+columns that actually exist so you don't reference hallucinated columns. When a
+dedicated tool exists for what you need, call it instead of writing SQL.
+
+## Prefer Dedicated Tools Over Raw SQL
+
+Many questions map to a purpose-built tool. Use it — the SQL is already correct
+and version-aware:
+
+| Question | Use this tool, not raw SQL |
+|----------|----------------------------|
+| What is running now? | \`get_running_queries\` |
+| Slowest finished queries? | \`get_slow_queries\` |
+| Recent failures/errors? | \`get_failed_queries\` |
+| Heaviest queries by memory/bytes/duration? | \`get_expensive_queries\` |
+| Active merges? | \`get_merge_status\` |
+| Replication health? | \`get_replication_status\` |
+| Disk space? | \`get_disk_usage\` |
+| Server version/uptime/connections? | \`get_metrics\` |
+
+Only fall back to the \`query\` tool for ad-hoc questions that no dedicated tool
+covers. If a dedicated tool returns an error, fix the call (e.g. \`hostId\` is a
+number like \`0\`, not a string), do **not** rewrite it as raw SQL.
+
+## system.processes — currently running queries
+
+There is **no \`database\` column** on \`system.processes\`. Selecting it fails with
+"Unknown expression identifier \`database\`".
+
+Available columns:
+\`query_id\`, \`user\`, \`query\`, \`elapsed\`, \`read_rows\`, \`read_bytes\`,
+\`written_rows\`, \`written_bytes\`, \`total_rows_approx\`, \`memory_usage\`,
+\`peak_memory_usage\`, \`query_kind\`, \`is_initial_query\`, \`address\`, \`port\`,
+\`initial_user\`, \`initial_query_id\`, \`client_name\`, \`thread_ids\`, \`ProfileEvents\`,
+\`Settings\`, \`current_database\`.
+
+- Use \`current_database\` (not \`database\`) for the session's database.
+- To exclude the monitoring query itself: \`WHERE query NOT LIKE '%processes%'\`.
+  Do not invent syntax like \`WHERE is_query SELECT WITHOUT '...'\`.
+- \`elapsed\` is seconds (Float64). Display with \`formatReadableTimeDelta(elapsed)\`.
+
+\`\`\`sql
+SELECT query_id, user, current_database, elapsed, read_rows, memory_usage,
+       substring(query, 1, 200) AS query
+FROM system.processes
+WHERE query NOT LIKE '%processes%'
+ORDER BY elapsed DESC
+\`\`\`
+
+## system.query_log — query history
+
+Filter by \`type\` and time. Each query produces a \`QueryStart\` row and a finish
+row (\`QueryFinish\` on success, \`ExceptionWhileProcessing\` on error). For
+completed queries always filter \`WHERE type = 'QueryFinish'\`, otherwise you
+double-count starts.
+
+Key columns: \`query_id\`, \`type\`, \`event_time\`, \`event_date\`, \`query_start_time\`,
+\`query_duration_ms\`, \`read_rows\`, \`read_bytes\`, \`result_rows\`, \`memory_usage\`,
+\`user\`, \`query\`, \`exception_code\`, \`exception\`, \`normalized_query_hash\`,
+\`is_initial_query\`, \`databases\`, \`tables\`, \`columns\`, \`ProfileEvents\`.
+
+- The per-row database/table lists are \`databases\`/\`tables\`/\`columns\` (Array),
+  not \`database\`/\`table\`.
+- Add \`AND is_initial_query = 1\` to avoid counting internal sub-queries.
+
+## system.parts — table parts
+
+Has \`database\` and \`table\`. Filter \`WHERE active = 1\` for live parts.
+Key columns: \`database\`, \`table\`, \`partition\`, \`name\`, \`active\`, \`rows\`,
+\`bytes_on_disk\`, \`data_compressed_bytes\`, \`data_uncompressed_bytes\`,
+\`marks\`, \`modification_time\`, \`min_time\`, \`max_time\`, \`part_type\`, \`disk_name\`.
+
+Compression ratio: \`data_uncompressed_bytes / data_compressed_bytes\`.
+
+## system.merges — active merges
+
+Columns: \`database\`, \`table\`, \`elapsed\`, \`progress\` (0..1), \`num_parts\`,
+\`source_part_names\`, \`result_part_name\`, \`total_size_bytes_compressed\`,
+\`rows_read\`, \`rows_written\`, \`memory_usage\`, \`is_mutation\`, \`merge_type\`.
+
+## system.replicas — replication status
+
+One row per replicated table. Columns: \`database\`, \`table\`, \`is_leader\`,
+\`is_readonly\`, \`absolute_delay\`, \`queue_size\`, \`inserts_in_queue\`,
+\`merges_in_queue\`, \`total_replicas\`, \`active_replicas\`, \`last_queue_update\`,
+\`zookeeper_path\`. Healthy = \`absolute_delay = 0\`, \`is_readonly = 0\`,
+\`active_replicas = total_replicas\`.
+
+## system.metrics vs system.events vs system.asynchronous_metrics
+
+These three are easy to confuse — they use different column names:
+
+- \`system.metrics\`: instantaneous gauges. Columns \`metric\`, \`value\`,
+  \`description\`. e.g. \`Query\`, \`TCPConnection\`, \`MemoryTracking\`.
+- \`system.events\`: cumulative counters. Columns \`event\`, \`value\`,
+  \`description\` — the name column is \`event\`, **not** \`metric\`.
+- \`system.asynchronous_metrics\`: periodically sampled. Columns \`metric\`,
+  \`value\`. e.g. \`Uptime\`, \`jemalloc.*\`, disk/CPU samples.
+
+## system.errors — error counters
+
+Columns: \`name\`, \`code\`, \`value\`, \`last_error_time\`, \`last_error_message\`,
+\`last_error_trace\`. There is no \`last_update_time\` column.
+
+## Recovery Rules
+
+- Unknown column (code 47) or unknown identifier → load this skill or call
+  \`get_table_schema\` for the table, then retry with real column names. Do not
+  guess again.
+- There is no CPU% column anywhere. Approximate load via \`memory_usage\`,
+  \`read_rows\`, \`read_bytes\` on \`system.processes\`, or \`ProfileEvents\` such as
+  \`OSCPUVirtualTimeMicroseconds\` in \`system.query_log\`.
+
+## Cross-references
+- Load \`query-optimization\` for EXPLAIN, PREWHERE, JOIN tuning.
+- Load \`troubleshooting\` for error-code-driven diagnosis.`,
+  },
+  {
+    name: 'query-optimization',
+    description: 'Advanced query tuning: join algorithms, skip index selection, EXPLAIN interpretation, ProfileEvents profiling, and optimizer settings.',
+    content: `# Query Optimization
+
+## JOIN Strategies
+- \`join_algorithm\` setting: \`hash\` (default, in-memory), \`partial_merge\` (spills to disk for large right table), \`auto\` (lets ClickHouse decide)
+- \`JOIN ... USING\` avoids repeated column names vs \`ON\` for same-name columns
+- Filter both sides before joining to reduce intermediate data
+- \`GLOBAL JOIN\` broadcasts the right table to all shards for distributed queries
+
+## EXPLAIN Analysis
+- \`EXPLAIN PLAN\` — logical plan, shows projection/pushdown transformations
+- \`EXPLAIN PIPELINE\` — physical execution with parallelism info and port counts
+- \`EXPLAIN INDEXES\` — which indexes fire, granules selected vs total
+- Look for: full table scans, missing index usage, excessive granule reads
+
+## Index Usage
+- Skip index types with use-cases:
+  - \`minmax\` — range queries on numeric/date columns
+  - \`set(N)\` — equality on low-cardinality columns, stores N unique values per granule
+  - \`bloom_filter\` — equality on high-cardinality strings
+  - \`tokenbf_v1\` — tokenized text search (logs, URLs)
+- Check effectiveness via \`ProfileEvents['SelectedRows']\` vs result size
+
+## Query Profiling
+- \`ProfileEvents\` map counters: \`SelectedRows\`, \`MergedRows\`, \`FileOpen\`, \`SeekCount\`
+- \`normalized_query_hash\` to group parameterized query variants
+- \`system.query_log\` columns: \`query_duration_ms\`, \`memory_usage\`, \`read_bytes\`
+
+## Optimizer Settings
+- \`enable_optimizer = 1\` — activates ClickHouse's new cost-based query optimizer (v22.6+)
+- \`max_threads\` — controls query parallelism; higher = faster but more memory; lower for concurrent workloads
+- \`prefer_localhost_replica = 1\` — avoids network round-trip by reading from local replica on distributed queries
+- \`system.query_plan\` (v23.6+) — persisted query plans for analysis across runs`,
+  },
+  {
     name: 'replication-guide',
-    description:
-      'ReplicatedMergeTree operations, failover procedures, lag diagnosis, quorum writes, and Keeper management.',
+    description: 'ReplicatedMergeTree operations, failover procedures, lag diagnosis, quorum writes, and Keeper management.',
     content: `# Replication Guide
 
 ## ReplicatedMergeTree Basics
@@ -56,46 +213,8 @@ export const SKILLS: readonly Skill[] = [
 - Load the \`troubleshooting\` skill for OOM-related replica failures and disk-full scenarios.`,
   },
   {
-    name: 'query-optimization',
-    description:
-      'Advanced query tuning: join algorithms, skip index selection, EXPLAIN interpretation, ProfileEvents profiling, and optimizer settings.',
-    content: `# Query Optimization
-
-## JOIN Strategies
-- \`join_algorithm\` setting: \`hash\` (default, in-memory), \`partial_merge\` (spills to disk for large right table), \`auto\` (lets ClickHouse decide)
-- \`JOIN ... USING\` avoids repeated column names vs \`ON\` for same-name columns
-- Filter both sides before joining to reduce intermediate data
-- \`GLOBAL JOIN\` broadcasts the right table to all shards for distributed queries
-
-## EXPLAIN Analysis
-- \`EXPLAIN PLAN\` — logical plan, shows projection/pushdown transformations
-- \`EXPLAIN PIPELINE\` — physical execution with parallelism info and port counts
-- \`EXPLAIN INDEXES\` — which indexes fire, granules selected vs total
-- Look for: full table scans, missing index usage, excessive granule reads
-
-## Index Usage
-- Skip index types with use-cases:
-  - \`minmax\` — range queries on numeric/date columns
-  - \`set(N)\` — equality on low-cardinality columns, stores N unique values per granule
-  - \`bloom_filter\` — equality on high-cardinality strings
-  - \`tokenbf_v1\` — tokenized text search (logs, URLs)
-- Check effectiveness via \`ProfileEvents['SelectedRows']\` vs result size
-
-## Query Profiling
-- \`ProfileEvents\` map counters: \`SelectedRows\`, \`MergedRows\`, \`FileOpen\`, \`SeekCount\`
-- \`normalized_query_hash\` to group parameterized query variants
-- \`system.query_log\` columns: \`query_duration_ms\`, \`memory_usage\`, \`read_bytes\`
-
-## Optimizer Settings
-- \`enable_optimizer = 1\` — activates ClickHouse's new cost-based query optimizer (v22.6+)
-- \`max_threads\` — controls query parallelism; higher = faster but more memory; lower for concurrent workloads
-- \`prefer_localhost_replica = 1\` — avoids network round-trip by reading from local replica on distributed queries
-- \`system.query_plan\` (v23.6+) — persisted query plans for analysis across runs`,
-  },
-  {
     name: 'cluster-operations',
-    description:
-      'Cluster management: distributed tables, ON CLUSTER DDL, node lifecycle, resharding, load balancing, and Keeper migration.',
+    description: 'Cluster management: distributed tables, ON CLUSTER DDL, node lifecycle, resharding, load balancing, and Keeper migration.',
     content: `# Cluster Operations
 
 ## Distributed Tables
@@ -147,64 +266,50 @@ export const SKILLS: readonly Skill[] = [
 5. Verify replication recovers, then remove ZooKeeper`,
   },
   {
-    name: 'troubleshooting',
-    description:
-      'Diagnose and resolve ClickHouse issues: OOM, slow merges, stuck mutations, query failures with error codes, and systematic error clustering.',
-    content: `# Troubleshooting Guide
+    name: 'storage-optimization',
+    description: 'Compression codecs, TTL policies, tiered storage, part management, and disk space optimization.',
+    content: `# Storage Optimization
 
-## OOM (Out of Memory)
-**Diagnosis**: \`system.query_log\` WHERE \`memory_usage\` is high. \`system.metrics\` WHERE metric = 'MemoryTracking'.
+## Compression Codecs
+- Default: LZ4 — fast, moderate compression
+- \`ZSTD(level)\` — better compression, slower. Level 1-22 (3 is good default)
+- \`Delta\` + ZSTD — excellent for time-series monotonic data
+- \`DoubleDelta\` — best for timestamps and counters
+- \`Gorilla\` — optimized for floating-point gauge metrics
+- \`T64\` — for integer columns with small range
+- Per-column: \`ALTER TABLE t MODIFY COLUMN col TYPE UInt32 CODEC(Delta, ZSTD(3))\`
+- In-place codec change: \`ALTER TABLE t MODIFY COLUMN col CODEC(Delta, ZSTD(3))\`
 
-**Solutions**:
-- \`max_memory_usage\` per query (e.g., 10GB), \`max_memory_usage_for_user\` per user
-- \`max_bytes_before_external_group_by\` / \`max_bytes_before_external_sort\` for spill-to-disk
-- Reduce JOIN sizes with pre-filtering; use SAMPLE for approximate aggregations
+## TTL Policies
+- Table-level: \`ALTER TABLE t MODIFY TTL event_time + INTERVAL 90 DAY\`
+- Column-level: \`ALTER TABLE t MODIFY COLUMN old_col TTL event_time + INTERVAL 30 DAY\`
+- Move to volume: \`TTL event_time + INTERVAL 7 DAY TO VOLUME 'cold'\`
+- Delete: \`TTL event_time + INTERVAL 365 DAY DELETE\`
+- Monitor TTL merges: \`system.merges WHERE is_ttl_merge = 1\`
 
-## Slow Merges
-**Diagnosis**: \`system.merges\` — check \`elapsed\`, \`progress\`, \`total_size_bytes_compressed\`. \`system.part_log\` WHERE event_type = 'MergeParts' for throughput. Too many parts: \`max_parts_count_for_partition\` in \`system.asynchronous_metrics\`.
+## Tiered Storage
+- Define storage policies in config: hot (SSD) → warm (HDD) → cold (S3)
+- \`<storage_configuration>\` in config.xml
+- Move rules: \`TTL event_time + INTERVAL 7 DAY TO DISK 'hdd'\`
+- Check disk usage: \`system.disks\`
+- Check volume usage: \`system.storage_policies\`
 
-**Solutions**:
-- Increase \`background_pool_size\` (default: 16)
-- Check disk I/O via \`system.asynchronous_metrics\` (ReadBufferFromFileDescriptorReadBytes)
-- Batch larger inserts to reduce frequency; avoid excessive partitioning
-- \`OPTIMIZE TABLE ... FINAL\` to force merge (expensive, off-peak only)
+## Part Management
+- Monitor part count: \`SELECT count() FROM system.parts WHERE active AND database = 'db' AND table = 't'\`
+- Too many parts (>300 per partition) = degraded performance
+- Detached parts: check \`system.detached_parts\`, clean with \`DROP DETACHED PART\`
+- Part size target: 1-10GB per part for optimal performance
 
-## Stuck Mutations
-**Diagnosis**: \`system.mutations\` WHERE is_done = 0 — check \`parts_to_do\`, \`latest_fail_reason\`. Mutations block new merges on affected parts.
-
-**Solutions**:
-- \`KILL MUTATION WHERE mutation_id = '...'\` to cancel
-- Fix underlying issue (schema mismatch, disk space), then re-submit
-- Prefer INSERT + ReplacingMergeTree over UPDATE mutations
-
-## Query Failures
-**Diagnosis**: \`system.query_log\` WHERE type = 'ExceptionWhileProcessing'. Use error clustering to find patterns:
-\`\`\`sql
-SELECT exception_code, count(), topK(10)(exception)
-FROM system.query_log
-WHERE type = 'ExceptionWhileProcessing'
-GROUP BY exception_code ORDER BY count() DESC
-\`\`\`
-For persistent errors, check \`system.error_log\` (requires error logging enabled).
-
-**Common error codes**:
-- **60**: table not found — verify table exists, check database name
-- **47**: unknown column — use \`get_table_schema\` to check column names
-- **241**: memory limit — reduce scope, add LIMIT, use SAMPLE
-- **159**: timeout — add time filters, use LIMIT
-- **252**: too many parts — wait for merges or OPTIMIZE
-
-## Network Connectivity
-**Diagnosis**: Check inter-server connectivity for replication or distributed queries. Verify \`interserver_http_port\` is reachable between nodes. Test with \`curl http://<peer>:9009\`. Check firewall rules and DNS resolution.
-
-## Cross-references
-- Load the \`replication-guide\` skill for replication lag diagnosis and recovery.
-- Load the \`storage-optimization\` skill for disk recovery and tiered storage management.`,
+## Disk Space Recovery
+- \`DROP PARTITION\` for bulk deletion by time
+- \`TRUNCATE TABLE\` for full table cleanup
+- Check for orphaned data: detached parts, temporary files
+- System tables can grow large — set TTL on query_log, trace_log, etc.
+- Load the \`troubleshooting\` skill for disk-full recovery procedures.`,
   },
   {
     name: 'security-hardening',
-    description:
-      'RBAC configuration, row policies, quotas, network security, audit logging, and access control best practices.',
+    description: 'RBAC configuration, row policies, quotas, network security, audit logging, and access control best practices.',
     content: `# Security Hardening
 
 ## RBAC (Role-Based Access Control)
@@ -249,9 +354,49 @@ For persistent errors, check \`system.error_log\` (requires error logging enable
 - Use \`readonly = 1\` setting for monitoring connections`,
   },
   {
+    name: 'clickhouse-best-practices',
+    description: 'Production operational practices: insert batching, async writes, query cache, connection pooling, and recommended settings.',
+    content: `# ClickHouse Best Practices
+
+## Insert Best Practices
+
+- Batch 10k-100k rows per insert; max 1-2 inserts/sec per table
+- Sub-1k-row inserts cause part proliferation; insert in sorting-key order to reduce merge work
+- For bulk loads, tune \`min_insert_block_size_rows\` / \`max_insert_block_size_rows\`
+
+## Async Inserts
+
+- \`SET async_insert = 1; SET wait_for_async_insert = 1;\` (1=durable, 0=fire-and-forget)
+- Tune \`async_insert_max_data_size\` (1M) and \`async_insert_busy_timeout_ms\` (10s) for batch window
+
+## Query Cache (v23.5+)
+
+- \`SET allow_experimental_query_cache = 1; SET use_query_cache = 1;\`
+- TTL: \`query_cache_ttl\`; share across users: \`query_cache_shared_between_users = 1\`
+- Control: \`enable_writes_to_query_cache\`, \`enable_reads_from_query_cache\`
+
+## Connection Pooling
+
+- HTTP: set \`pool_size\`, \`max_queries\`; keep-alive is critical
+- TCP: built-in multiplexing; tune \`max_connections\`
+- Monitor \`system.metrics\` for \`HTTPConnection\`/\`TCPConnection\` to size pools
+
+## Production Settings
+
+- \`max_threads\` — lower for concurrent loads; \`max_insert_threads\` — raise for parallel inserts
+- \`max_execution_time\` / \`max_memory_usage\` — per-query limits
+- \`join_algorithm\` — prefer \`grace_hash\` or \`auto\` for large joins
+- \`input_format_allow_errors_num\` / \`ratio\` — tolerate parse errors in bulk imports
+
+## Query Patterns
+
+- \`COLUMNS('pattern')\` — regex column selection; \`APPLY func\` transforms matches
+- \`clusterAllReplicas('cluster')\` — aggregate across all replicas
+- \`FINAL\` — force merge for ReplacingMergeTree; use sparingly (full scan)`,
+  },
+  {
     name: 'migration-patterns',
-    description:
-      'Schema migrations: ALTER patterns, engine changes, zero-downtime swaps, clickhouse-local offline migrations, and lightweight UPDATE/DELETE strategies.',
+    description: 'Schema migrations: ALTER patterns, engine changes, zero-downtime swaps, clickhouse-local offline migrations, and lightweight UPDATE/DELETE strategies.',
     content: `# Migration Patterns
 
 ## ALTER TABLE Operations
@@ -329,90 +474,59 @@ CREATE TABLE _schema_migrations (name String, applied_at DateTime DEFAULT now())
 - \`EXCHANGE TABLES\` fails if either table is replicated with different replica paths`,
   },
   {
-    name: 'storage-optimization',
-    description:
-      'Compression codecs, TTL policies, tiered storage, part management, and disk space optimization.',
-    content: `# Storage Optimization
+    name: 'troubleshooting',
+    description: 'Diagnose and resolve ClickHouse issues: OOM, slow merges, stuck mutations, query failures with error codes, and systematic error clustering.',
+    content: `# Troubleshooting Guide
 
-## Compression Codecs
-- Default: LZ4 — fast, moderate compression
-- \`ZSTD(level)\` — better compression, slower. Level 1-22 (3 is good default)
-- \`Delta\` + ZSTD — excellent for time-series monotonic data
-- \`DoubleDelta\` — best for timestamps and counters
-- \`Gorilla\` — optimized for floating-point gauge metrics
-- \`T64\` — for integer columns with small range
-- Per-column: \`ALTER TABLE t MODIFY COLUMN col TYPE UInt32 CODEC(Delta, ZSTD(3))\`
-- In-place codec change: \`ALTER TABLE t MODIFY COLUMN col CODEC(Delta, ZSTD(3))\`
+## OOM (Out of Memory)
+**Diagnosis**: \`system.query_log\` WHERE \`memory_usage\` is high. \`system.metrics\` WHERE metric = 'MemoryTracking'.
 
-## TTL Policies
-- Table-level: \`ALTER TABLE t MODIFY TTL event_time + INTERVAL 90 DAY\`
-- Column-level: \`ALTER TABLE t MODIFY COLUMN old_col TTL event_time + INTERVAL 30 DAY\`
-- Move to volume: \`TTL event_time + INTERVAL 7 DAY TO VOLUME 'cold'\`
-- Delete: \`TTL event_time + INTERVAL 365 DAY DELETE\`
-- Monitor TTL merges: \`system.merges WHERE is_ttl_merge = 1\`
+**Solutions**:
+- \`max_memory_usage\` per query (e.g., 10GB), \`max_memory_usage_for_user\` per user
+- \`max_bytes_before_external_group_by\` / \`max_bytes_before_external_sort\` for spill-to-disk
+- Reduce JOIN sizes with pre-filtering; use SAMPLE for approximate aggregations
 
-## Tiered Storage
-- Define storage policies in config: hot (SSD) → warm (HDD) → cold (S3)
-- \`<storage_configuration>\` in config.xml
-- Move rules: \`TTL event_time + INTERVAL 7 DAY TO DISK 'hdd'\`
-- Check disk usage: \`system.disks\`
-- Check volume usage: \`system.storage_policies\`
+## Slow Merges
+**Diagnosis**: \`system.merges\` — check \`elapsed\`, \`progress\`, \`total_size_bytes_compressed\`. \`system.part_log\` WHERE event_type = 'MergeParts' for throughput. Too many parts: \`max_parts_count_for_partition\` in \`system.asynchronous_metrics\`.
 
-## Part Management
-- Monitor part count: \`SELECT count() FROM system.parts WHERE active AND database = 'db' AND table = 't'\`
-- Too many parts (>300 per partition) = degraded performance
-- Detached parts: check \`system.detached_parts\`, clean with \`DROP DETACHED PART\`
-- Part size target: 1-10GB per part for optimal performance
+**Solutions**:
+- Increase \`background_pool_size\` (default: 16)
+- Check disk I/O via \`system.asynchronous_metrics\` (ReadBufferFromFileDescriptorReadBytes)
+- Batch larger inserts to reduce frequency; avoid excessive partitioning
+- \`OPTIMIZE TABLE ... FINAL\` to force merge (expensive, off-peak only)
 
-## Disk Space Recovery
-- \`DROP PARTITION\` for bulk deletion by time
-- \`TRUNCATE TABLE\` for full table cleanup
-- Check for orphaned data: detached parts, temporary files
-- System tables can grow large — set TTL on query_log, trace_log, etc.
-- Load the \`troubleshooting\` skill for disk-full recovery procedures.`,
-  },
-  {
-    name: 'clickhouse-best-practices',
-    description:
-      'Production operational practices: insert batching, async writes, query cache, connection pooling, and recommended settings.',
-    content: `# ClickHouse Best Practices
+## Stuck Mutations
+**Diagnosis**: \`system.mutations\` WHERE is_done = 0 — check \`parts_to_do\`, \`latest_fail_reason\`. Mutations block new merges on affected parts.
 
-## Insert Best Practices
+**Solutions**:
+- \`KILL MUTATION WHERE mutation_id = '...'\` to cancel
+- Fix underlying issue (schema mismatch, disk space), then re-submit
+- Prefer INSERT + ReplacingMergeTree over UPDATE mutations
 
-- Batch 10k-100k rows per insert; max 1-2 inserts/sec per table
-- Sub-1k-row inserts cause part proliferation; insert in sorting-key order to reduce merge work
-- For bulk loads, tune \`min_insert_block_size_rows\` / \`max_insert_block_size_rows\`
+## Query Failures
+**Diagnosis**: \`system.query_log\` WHERE type = 'ExceptionWhileProcessing'. Use error clustering to find patterns:
+\`\`\`sql
+SELECT exception_code, count(), topK(10)(exception)
+FROM system.query_log
+WHERE type = 'ExceptionWhileProcessing'
+GROUP BY exception_code ORDER BY count() DESC
+\`\`\`
+For persistent errors, check \`system.error_log\` (requires error logging enabled).
 
-## Async Inserts
+**Common error codes**:
+- **60**: table not found — verify table exists, check database name
+- **47**: unknown column — use \`get_table_schema\` to check column names
+- **241**: memory limit — reduce scope, add LIMIT, use SAMPLE
+- **159**: timeout — add time filters, use LIMIT
+- **252**: too many parts — wait for merges or OPTIMIZE
 
-- \`SET async_insert = 1; SET wait_for_async_insert = 1;\` (1=durable, 0=fire-and-forget)
-- Tune \`async_insert_max_data_size\` (1M) and \`async_insert_busy_timeout_ms\` (10s) for batch window
+## Network Connectivity
+**Diagnosis**: Check inter-server connectivity for replication or distributed queries. Verify \`interserver_http_port\` is reachable between nodes. Test with \`curl http://<peer>:9009\`. Check firewall rules and DNS resolution.
 
-## Query Cache (v23.5+)
-
-- \`SET allow_experimental_query_cache = 1; SET use_query_cache = 1;\`
-- TTL: \`query_cache_ttl\`; share across users: \`query_cache_shared_between_users = 1\`
-- Control: \`enable_writes_to_query_cache\`, \`enable_reads_from_query_cache\`
-
-## Connection Pooling
-
-- HTTP: set \`pool_size\`, \`max_queries\`; keep-alive is critical
-- TCP: built-in multiplexing; tune \`max_connections\`
-- Monitor \`system.metrics\` for \`HTTPConnection\`/\`TCPConnection\` to size pools
-
-## Production Settings
-
-- \`max_threads\` — lower for concurrent loads; \`max_insert_threads\` — raise for parallel inserts
-- \`max_execution_time\` / \`max_memory_usage\` — per-query limits
-- \`join_algorithm\` — prefer \`grace_hash\` or \`auto\` for large joins
-- \`input_format_allow_errors_num\` / \`ratio\` — tolerate parse errors in bulk imports
-
-## Query Patterns
-
-- \`COLUMNS('pattern')\` — regex column selection; \`APPLY func\` transforms matches
-- \`clusterAllReplicas('cluster')\` — aggregate across all replicas
-- \`FINAL\` — force merge for ReplacingMergeTree; use sparingly (full scan)`,
-  },
+## Cross-references
+- Load the \`replication-guide\` skill for replication lag diagnosis and recovery.
+- Load the \`storage-optimization\` skill for disk recovery and tiered storage management.`,
+  }
 ]
 
 /** Get all available skills metadata (without content) */

--- a/lib/ai/agent/tools/__tests__/helpers.test.ts
+++ b/lib/ai/agent/tools/__tests__/helpers.test.ts
@@ -11,7 +11,12 @@ mock.module('@/lib/clickhouse', () => ({
   },
 }))
 
-const { resolveHostId, isValidTableIdentifier } = await import('../helpers')
+const {
+  resolveHostId,
+  isValidTableIdentifier,
+  hostIdSchema,
+  requiredHostIdSchema,
+} = await import('../helpers')
 
 describe('resolveHostId', () => {
   test('returns default when tool host ID is undefined', () => {
@@ -57,5 +62,56 @@ describe('isValidTableIdentifier', () => {
   test('rejects identifiers with special characters', () => {
     expect(isValidTableIdentifier('table;DROP')).toBe(false)
     expect(isValidTableIdentifier("table'OR")).toBe(false)
+  })
+})
+
+describe('hostIdSchema', () => {
+  test('accepts valid integers and coerces valid strings', () => {
+    expect(hostIdSchema.safeParse(0).success).toBe(true)
+    expect(hostIdSchema.safeParse(0).data).toBe(0)
+    expect(hostIdSchema.safeParse(3).success).toBe(true)
+    expect(hostIdSchema.safeParse(3).data).toBe(3)
+    expect(hostIdSchema.safeParse('1').success).toBe(true)
+    expect(hostIdSchema.safeParse('1').data).toBe(1)
+  })
+
+  test('accepts undefined, null, empty strings and coerces them to undefined', () => {
+    expect(hostIdSchema.safeParse(undefined).success).toBe(true)
+    expect(hostIdSchema.safeParse(undefined).data).toBeUndefined()
+    expect(hostIdSchema.safeParse(null).success).toBe(true)
+    expect(hostIdSchema.safeParse(null).data).toBeUndefined()
+    expect(hostIdSchema.safeParse('').success).toBe(true)
+    expect(hostIdSchema.safeParse('').data).toBeUndefined()
+    expect(hostIdSchema.safeParse('   ').success).toBe(true)
+    expect(hostIdSchema.safeParse('   ').data).toBeUndefined()
+  })
+
+  test('rejects negative integers, floats, and invalid strings', () => {
+    expect(hostIdSchema.safeParse(-1).success).toBe(false)
+    expect(hostIdSchema.safeParse('-2').success).toBe(false)
+    expect(hostIdSchema.safeParse(1.5).success).toBe(false)
+    expect(hostIdSchema.safeParse('abc').success).toBe(false)
+  })
+})
+
+describe('requiredHostIdSchema', () => {
+  test('accepts valid integers and coerces valid strings', () => {
+    expect(requiredHostIdSchema.safeParse(0).success).toBe(true)
+    expect(requiredHostIdSchema.safeParse(0).data).toBe(0)
+    expect(requiredHostIdSchema.safeParse('2').success).toBe(true)
+    expect(requiredHostIdSchema.safeParse('2').data).toBe(2)
+  })
+
+  test('rejects undefined, null, and empty strings', () => {
+    expect(requiredHostIdSchema.safeParse(undefined).success).toBe(false)
+    expect(requiredHostIdSchema.safeParse(null).success).toBe(false)
+    expect(requiredHostIdSchema.safeParse('').success).toBe(false)
+    expect(requiredHostIdSchema.safeParse('   ').success).toBe(false)
+  })
+
+  test('rejects negative integers, floats, and invalid strings', () => {
+    expect(requiredHostIdSchema.safeParse(-1).success).toBe(false)
+    expect(requiredHostIdSchema.safeParse(1.5).success).toBe(false)
+    expect(requiredHostIdSchema.safeParse('abc').success).toBe(false)
   })
 })

--- a/lib/ai/agent/tools/anomaly-tools.ts
+++ b/lib/ai/agent/tools/anomaly-tools.ts
@@ -48,7 +48,7 @@ export function createAnomalyTools(hostId: number) {
       description:
         'Detect statistical anomalies by comparing recent (1h) vs baseline (24h) metrics. Checks error rate, query duration P95, query volume, memory usage, and part counts. Returns severity levels.',
       inputSchema: z.object({
-        hostId: z.number().optional().describe('Override host ID'),
+        hostId: z.coerce.number().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const { hostId: toolHostId } = input as { hostId?: number }

--- a/lib/ai/agent/tools/anomaly-tools.ts
+++ b/lib/ai/agent/tools/anomaly-tools.ts
@@ -1,4 +1,4 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -48,7 +48,7 @@ export function createAnomalyTools(hostId: number) {
       description:
         'Detect statistical anomalies by comparing recent (1h) vs baseline (24h) metrics. Checks error rate, query duration P95, query volume, memory usage, and part counts. Returns severity levels.',
       inputSchema: z.object({
-        hostId: z.coerce.number().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { hostId: toolHostId } = input as { hostId?: number }

--- a/lib/ai/agent/tools/capacity-tools.ts
+++ b/lib/ai/agent/tools/capacity-tools.ts
@@ -17,7 +17,7 @@ export function createCapacityTools(hostId: number) {
           .optional()
           .default(90)
           .describe('Number of days to forecast ahead (default: 90)'),
-        hostId: z.number().optional().describe('Override host ID'),
+        hostId: z.coerce.number().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const { forecastDays = 90, hostId: toolHostId } = input as {

--- a/lib/ai/agent/tools/capacity-tools.ts
+++ b/lib/ai/agent/tools/capacity-tools.ts
@@ -1,4 +1,4 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 import { formatBytes } from '@/lib/utils'
@@ -17,7 +17,7 @@ export function createCapacityTools(hostId: number) {
           .optional()
           .default(90)
           .describe('Number of days to forecast ahead (default: 90)'),
-        hostId: z.coerce.number().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { forecastDays = 90, hostId: toolHostId } = input as {

--- a/lib/ai/agent/tools/cluster-tools.ts
+++ b/lib/ai/agent/tools/cluster-tools.ts
@@ -8,7 +8,7 @@ export function createClusterTools(hostId: number) {
       description:
         'Get cluster topology including shards, replicas, and host addresses.',
       inputSchema: z.object({
-        hostId: z
+        hostId: z.coerce
           .number()
           .optional()
           .describe('Override the default ClickHouse host index.'),
@@ -41,7 +41,7 @@ export function createClusterTools(hostId: number) {
           .optional()
           .default(50)
           .describe('Maximum number of rows to return.'),
-        hostId: z
+        hostId: z.coerce
           .number()
           .optional()
           .describe('Override the default ClickHouse host index.'),

--- a/lib/ai/agent/tools/cluster-tools.ts
+++ b/lib/ai/agent/tools/cluster-tools.ts
@@ -1,4 +1,4 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -8,10 +8,7 @@ export function createClusterTools(hostId: number) {
       description:
         'Get cluster topology including shards, replicas, and host addresses.',
       inputSchema: z.object({
-        hostId: z.coerce
-          .number()
-          .optional()
-          .describe('Override the default ClickHouse host index.'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { hostId: toolHostId } = input as { hostId?: number }
@@ -41,10 +38,7 @@ export function createClusterTools(hostId: number) {
           .optional()
           .default(50)
           .describe('Maximum number of rows to return.'),
-        hostId: z.coerce
-          .number()
-          .optional()
-          .describe('Override the default ClickHouse host index.'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { limit = 50, hostId: toolHostId } = input as {

--- a/lib/ai/agent/tools/comparison-tools.ts
+++ b/lib/ai/agent/tools/comparison-tools.ts
@@ -1,4 +1,9 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import {
+  hostIdSchema,
+  readOnlyQuery,
+  requiredHostIdSchema,
+  resolveHostId,
+} from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -39,7 +44,7 @@ export function createComparisonTools(hostId: number) {
           .min(1)
           .max(168)
           .describe('Duration of period 2 in hours'),
-        hostId: z.coerce.number().int().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const params = input as {
@@ -149,18 +154,12 @@ export function createComparisonTools(hostId: number) {
       description:
         'Compare two ClickHouse hosts side-by-side: version, uptime, query load, storage, and disk usage.',
       inputSchema: z.object({
-        hostId1: z.coerce
-          .number()
-          .int()
-          .describe(
-            'First host ID (0-based index matching the configured CLICKHOUSE_HOST list)'
-          ),
-        hostId2: z.coerce
-          .number()
-          .int()
-          .describe(
-            'Second host ID (0-based index matching the configured CLICKHOUSE_HOST list)'
-          ),
+        hostId1: requiredHostIdSchema.describe(
+          'First host ID (0-based index matching the configured CLICKHOUSE_HOST list)'
+        ),
+        hostId2: requiredHostIdSchema.describe(
+          'Second host ID (0-based index matching the configured CLICKHOUSE_HOST list)'
+        ),
       }),
       execute: async (input: unknown) => {
         const { hostId1, hostId2 } = input as {

--- a/lib/ai/agent/tools/comparison-tools.ts
+++ b/lib/ai/agent/tools/comparison-tools.ts
@@ -39,7 +39,7 @@ export function createComparisonTools(hostId: number) {
           .min(1)
           .max(168)
           .describe('Duration of period 2 in hours'),
-        hostId: z.number().int().optional().describe('Override host ID'),
+        hostId: z.coerce.number().int().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const params = input as {
@@ -149,13 +149,13 @@ export function createComparisonTools(hostId: number) {
       description:
         'Compare two ClickHouse hosts side-by-side: version, uptime, query load, storage, and disk usage.',
       inputSchema: z.object({
-        hostId1: z
+        hostId1: z.coerce
           .number()
           .int()
           .describe(
             'First host ID (0-based index matching the configured CLICKHOUSE_HOST list)'
           ),
-        hostId2: z
+        hostId2: z.coerce
           .number()
           .int()
           .describe(

--- a/lib/ai/agent/tools/control-tools.ts
+++ b/lib/ai/agent/tools/control-tools.ts
@@ -9,7 +9,7 @@ export function createControlTools(hostId: number) {
         'Kill a running query by its query_id. DESTRUCTIVE — confirm with user before executing.',
       inputSchema: z.object({
         queryId: z.string().describe('The query_id of the query to kill'),
-        hostId: z.number().optional().describe('Host index override'),
+        hostId: z.coerce.number().optional().describe('Host index override'),
       }),
       execute: async (input: unknown) => {
         const { queryId, hostId: hostIdOverride } = input as {
@@ -36,7 +36,7 @@ export function createControlTools(hostId: number) {
           .optional()
           .default(false)
           .describe('Whether to run OPTIMIZE FINAL'),
-        hostId: z.number().optional().describe('Host index override'),
+        hostId: z.coerce.number().optional().describe('Host index override'),
       }),
       execute: async (input: unknown) => {
         const {
@@ -74,7 +74,7 @@ export function createControlTools(hostId: number) {
         database: z.string().describe('Database name'),
         table: z.string().describe('Table name'),
         mutationId: z.string().describe('The mutation_id to cancel'),
-        hostId: z.number().optional().describe('Host index override'),
+        hostId: z.coerce.number().optional().describe('Host index override'),
       }),
       execute: async (input: unknown) => {
         const {

--- a/lib/ai/agent/tools/control-tools.ts
+++ b/lib/ai/agent/tools/control-tools.ts
@@ -1,4 +1,9 @@
-import { isValidTableIdentifier, resolveHostId, writeQuery } from './helpers'
+import {
+  hostIdSchema,
+  isValidTableIdentifier,
+  resolveHostId,
+  writeQuery,
+} from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -9,7 +14,7 @@ export function createControlTools(hostId: number) {
         'Kill a running query by its query_id. DESTRUCTIVE — confirm with user before executing.',
       inputSchema: z.object({
         queryId: z.string().describe('The query_id of the query to kill'),
-        hostId: z.coerce.number().optional().describe('Host index override'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { queryId, hostId: hostIdOverride } = input as {
@@ -36,7 +41,7 @@ export function createControlTools(hostId: number) {
           .optional()
           .default(false)
           .describe('Whether to run OPTIMIZE FINAL'),
-        hostId: z.coerce.number().optional().describe('Host index override'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {
@@ -74,7 +79,7 @@ export function createControlTools(hostId: number) {
         database: z.string().describe('Database name'),
         table: z.string().describe('Table name'),
         mutationId: z.string().describe('The mutation_id to cancel'),
-        hostId: z.coerce.number().optional().describe('Host index override'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {

--- a/lib/ai/agent/tools/dashboard-tools.ts
+++ b/lib/ai/agent/tools/dashboard-tools.ts
@@ -1,3 +1,4 @@
+import { hostIdSchema } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -73,7 +74,7 @@ export function createDashboardTools() {
         'Fetch chart data for a named chart. Provides guidance on how to retrieve data using the query tool.',
       inputSchema: z.object({
         chartName: z.string().describe('Name of the chart to fetch data for'),
-        hostId: z.coerce.number().optional().describe('Host index override'),
+        hostId: hostIdSchema,
       }),
       execute: async (_input: unknown) => {
         return {

--- a/lib/ai/agent/tools/dashboard-tools.ts
+++ b/lib/ai/agent/tools/dashboard-tools.ts
@@ -73,7 +73,7 @@ export function createDashboardTools() {
         'Fetch chart data for a named chart. Provides guidance on how to retrieve data using the query tool.',
       inputSchema: z.object({
         chartName: z.string().describe('Name of the chart to fetch data for'),
-        hostId: z.number().optional().describe('Host index override'),
+        hostId: z.coerce.number().optional().describe('Host index override'),
       }),
       execute: async (_input: unknown) => {
         return {

--- a/lib/ai/agent/tools/diagnostics-tools.ts
+++ b/lib/ai/agent/tools/diagnostics-tools.ts
@@ -195,7 +195,7 @@ export function createDiagnosticsTools(hostId: number) {
           .optional()
           .default(24)
           .describe('Lookback window for query-log based checks'),
-        hostId: z.number().int().optional().describe('Override host ID'),
+        hostId: z.coerce.number().int().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const { lastHours = 24, hostId: toolHostId } = input as {
@@ -433,7 +433,7 @@ export function createDiagnosticsTools(hostId: number) {
           .string()
           .optional()
           .describe('Default database for table metadata lookup'),
-        hostId: z.number().int().optional().describe('Override host ID'),
+        hostId: z.coerce.number().int().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const {
@@ -555,7 +555,7 @@ export function createDiagnosticsTools(hostId: number) {
           .optional()
           .default(7)
           .describe('Lookback window for query pattern analysis'),
-        hostId: z.number().int().optional().describe('Override host ID'),
+        hostId: z.coerce.number().int().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const {

--- a/lib/ai/agent/tools/diagnostics-tools.ts
+++ b/lib/ai/agent/tools/diagnostics-tools.ts
@@ -1,6 +1,6 @@
 import 'server-only'
 
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import {
   extractReferencedTables,
   extractWhereColumns,
@@ -195,7 +195,7 @@ export function createDiagnosticsTools(hostId: number) {
           .optional()
           .default(24)
           .describe('Lookback window for query-log based checks'),
-        hostId: z.coerce.number().int().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { lastHours = 24, hostId: toolHostId } = input as {
@@ -433,7 +433,7 @@ export function createDiagnosticsTools(hostId: number) {
           .string()
           .optional()
           .describe('Default database for table metadata lookup'),
-        hostId: z.coerce.number().int().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {
@@ -555,7 +555,7 @@ export function createDiagnosticsTools(hostId: number) {
           .optional()
           .default(7)
           .describe('Lookback window for query pattern analysis'),
-        hostId: z.coerce.number().int().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {

--- a/lib/ai/agent/tools/health-tools.ts
+++ b/lib/ai/agent/tools/health-tools.ts
@@ -1,4 +1,4 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -8,7 +8,7 @@ export function createHealthTools(hostId: number) {
       description:
         'Get server health metrics including version, uptime, and connection counts.',
       inputSchema: z.object({
-        hostId: z.coerce.number().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { hostId: toolHostId } = input as { hostId?: number }
@@ -53,7 +53,7 @@ export function createHealthTools(hostId: number) {
       description:
         'Get CPU, memory, disk, and thread usage from system metrics.',
       inputSchema: z.object({
-        hostId: z.coerce.number().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { hostId: toolHostId } = input as { hostId?: number }
@@ -80,7 +80,7 @@ export function createHealthTools(hostId: number) {
     get_disk_usage: dynamicTool({
       description: 'Get per-disk space usage including free and total space.',
       inputSchema: z.object({
-        hostId: z.coerce.number().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { hostId: toolHostId } = input as { hostId?: number }
@@ -101,7 +101,7 @@ export function createHealthTools(hostId: number) {
           .optional()
           .default(20)
           .describe('Maximum number of errors to return'),
-        hostId: z.coerce.number().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { limit = 20, hostId: toolHostId } = input as {
@@ -126,7 +126,7 @@ export function createHealthTools(hostId: number) {
           .optional()
           .default(10)
           .describe('Maximum number of crash entries to return'),
-        hostId: z.coerce.number().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { limit = 10, hostId: toolHostId } = input as {

--- a/lib/ai/agent/tools/health-tools.ts
+++ b/lib/ai/agent/tools/health-tools.ts
@@ -8,7 +8,7 @@ export function createHealthTools(hostId: number) {
       description:
         'Get server health metrics including version, uptime, and connection counts.',
       inputSchema: z.object({
-        hostId: z.number().optional().describe('Override host ID'),
+        hostId: z.coerce.number().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const { hostId: toolHostId } = input as { hostId?: number }
@@ -53,7 +53,7 @@ export function createHealthTools(hostId: number) {
       description:
         'Get CPU, memory, disk, and thread usage from system metrics.',
       inputSchema: z.object({
-        hostId: z.number().optional().describe('Override host ID'),
+        hostId: z.coerce.number().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const { hostId: toolHostId } = input as { hostId?: number }
@@ -80,7 +80,7 @@ export function createHealthTools(hostId: number) {
     get_disk_usage: dynamicTool({
       description: 'Get per-disk space usage including free and total space.',
       inputSchema: z.object({
-        hostId: z.number().optional().describe('Override host ID'),
+        hostId: z.coerce.number().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const { hostId: toolHostId } = input as { hostId?: number }
@@ -101,7 +101,7 @@ export function createHealthTools(hostId: number) {
           .optional()
           .default(20)
           .describe('Maximum number of errors to return'),
-        hostId: z.number().optional().describe('Override host ID'),
+        hostId: z.coerce.number().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const { limit = 20, hostId: toolHostId } = input as {
@@ -126,7 +126,7 @@ export function createHealthTools(hostId: number) {
           .optional()
           .default(10)
           .describe('Maximum number of crash entries to return'),
-        hostId: z.number().optional().describe('Override host ID'),
+        hostId: z.coerce.number().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const { limit = 10, hostId: toolHostId } = input as {

--- a/lib/ai/agent/tools/helpers.ts
+++ b/lib/ai/agent/tools/helpers.ts
@@ -9,6 +9,7 @@ import 'server-only'
 
 import type { DataFormat } from '@clickhouse/client'
 
+import { z } from 'zod/v3'
 import { validateSqlQuery } from '@/lib/api/shared/validators/sql'
 import { fetchData } from '@/lib/clickhouse'
 
@@ -109,3 +110,27 @@ export function isValidTableIdentifier(table: string): boolean {
   if (!table || table.length > 256) return false
   return VALID_TABLE_IDENTIFIER.test(table.trim())
 }
+
+/**
+ * Standardized schema for ClickHouse host ID overriding.
+ * Preprocesses null, empty string, and whitespace-only strings into undefined
+ * to prevent silent coercion to host 0, while coercing integer values safely.
+ */
+export const hostIdSchema = z
+  .preprocess((val) => {
+    if (val === null || val === undefined) return undefined
+    if (typeof val === 'string' && val.trim() === '') return undefined
+    return val
+  }, z.coerce.number().int().nonnegative().optional())
+  .describe('Override host ID')
+
+/**
+ * Standardized schema for required ClickHouse host IDs.
+ * Preprocesses null, empty string, and whitespace-only strings into undefined
+ * to trigger validation failures instead of silent coercion to host 0.
+ */
+export const requiredHostIdSchema = z.preprocess((val) => {
+  if (val === null || val === undefined) return undefined
+  if (typeof val === 'string' && val.trim() === '') return undefined
+  return val
+}, z.coerce.number().int().nonnegative())

--- a/lib/ai/agent/tools/incident-tools.ts
+++ b/lib/ai/agent/tools/incident-tools.ts
@@ -1,4 +1,4 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -141,7 +141,7 @@ export function createIncidentTools(hostId: number) {
           .optional()
           .default('1 HOUR')
           .describe('Time window, e.g. "2 HOUR", "30 MINUTE"'),
-        hostId: z.coerce.number().int().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {

--- a/lib/ai/agent/tools/incident-tools.ts
+++ b/lib/ai/agent/tools/incident-tools.ts
@@ -141,7 +141,7 @@ export function createIncidentTools(hostId: number) {
           .optional()
           .default('1 HOUR')
           .describe('Time window, e.g. "2 HOUR", "30 MINUTE"'),
-        hostId: z.number().int().optional().describe('Override host ID'),
+        hostId: z.coerce.number().int().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const {

--- a/lib/ai/agent/tools/insights-tools.ts
+++ b/lib/ai/agent/tools/insights-tools.ts
@@ -1,4 +1,4 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 import { formatDuration } from '@/lib/utils'
@@ -57,7 +57,7 @@ export function createInsightsTools(hostId: number) {
           .max(720)
           .default(720)
           .describe('Look back period in hours'),
-        hostId: z.coerce.number().int().optional(),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const params = input as {
@@ -220,7 +220,7 @@ WHERE type = 'QueryFinish' AND event_time > now() - INTERVAL {lastHours:UInt32} 
           .optional()
           .describe('Table name (required for column_breakdown)'),
         limit: z.number().int().min(1).max(50).optional().default(10),
-        hostId: z.coerce.number().int().optional(),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const params = input as {

--- a/lib/ai/agent/tools/insights-tools.ts
+++ b/lib/ai/agent/tools/insights-tools.ts
@@ -57,7 +57,7 @@ export function createInsightsTools(hostId: number) {
           .max(720)
           .default(720)
           .describe('Look back period in hours'),
-        hostId: z.number().int().optional(),
+        hostId: z.coerce.number().int().optional(),
       }),
       execute: async (input: unknown) => {
         const params = input as {
@@ -220,7 +220,7 @@ WHERE type = 'QueryFinish' AND event_time > now() - INTERVAL {lastHours:UInt32} 
           .optional()
           .describe('Table name (required for column_breakdown)'),
         limit: z.number().int().min(1).max(50).optional().default(10),
-        hostId: z.number().int().optional(),
+        hostId: z.coerce.number().int().optional(),
       }),
       execute: async (input: unknown) => {
         const params = input as {

--- a/lib/ai/agent/tools/log-tools.ts
+++ b/lib/ai/agent/tools/log-tools.ts
@@ -29,7 +29,7 @@ export function createLogTools(hostId: number) {
           .optional()
           .default('')
           .describe('Optional LIKE pattern to filter log messages'),
-        hostId: z.number().optional().describe('Host index override'),
+        hostId: z.coerce.number().optional().describe('Host index override'),
       }),
       execute: async (input: unknown) => {
         const {
@@ -63,7 +63,7 @@ export function createLogTools(hostId: number) {
           .optional()
           .default(20)
           .describe('Maximum number of stack traces to return'),
-        hostId: z.number().optional().describe('Host index override'),
+        hostId: z.coerce.number().optional().describe('Host index override'),
       }),
       execute: async (input: unknown) => {
         const { limit = 20, hostId: hostIdOverride } = input as {

--- a/lib/ai/agent/tools/log-tools.ts
+++ b/lib/ai/agent/tools/log-tools.ts
@@ -1,4 +1,4 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -29,7 +29,7 @@ export function createLogTools(hostId: number) {
           .optional()
           .default('')
           .describe('Optional LIKE pattern to filter log messages'),
-        hostId: z.coerce.number().optional().describe('Host index override'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {
@@ -63,7 +63,7 @@ export function createLogTools(hostId: number) {
           .optional()
           .default(20)
           .describe('Maximum number of stack traces to return'),
-        hostId: z.coerce.number().optional().describe('Host index override'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { limit = 20, hostId: hostIdOverride } = input as {

--- a/lib/ai/agent/tools/merge-tools.ts
+++ b/lib/ai/agent/tools/merge-tools.ts
@@ -1,4 +1,4 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -8,7 +8,7 @@ export function createMergeTools(hostId: number) {
       description:
         'Get currently active merges with progress and elapsed time.',
       inputSchema: z.object({
-        hostId: z.coerce.number().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { hostId: toolHostId } = input as { hostId?: number }
@@ -32,7 +32,7 @@ export function createMergeTools(hostId: number) {
           .optional()
           .default(50)
           .describe('Maximum number of mutations to return'),
-        hostId: z.coerce.number().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {
@@ -77,7 +77,7 @@ export function createMergeTools(hostId: number) {
           .optional()
           .default(24)
           .describe('Number of hours to look back'),
-        hostId: z.coerce.number().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { lastHours = 24, hostId: toolHostId } = input as {

--- a/lib/ai/agent/tools/merge-tools.ts
+++ b/lib/ai/agent/tools/merge-tools.ts
@@ -8,7 +8,7 @@ export function createMergeTools(hostId: number) {
       description:
         'Get currently active merges with progress and elapsed time.',
       inputSchema: z.object({
-        hostId: z.number().optional().describe('Override host ID'),
+        hostId: z.coerce.number().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const { hostId: toolHostId } = input as { hostId?: number }
@@ -32,7 +32,7 @@ export function createMergeTools(hostId: number) {
           .optional()
           .default(50)
           .describe('Maximum number of mutations to return'),
-        hostId: z.number().optional().describe('Override host ID'),
+        hostId: z.coerce.number().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const {
@@ -77,7 +77,7 @@ export function createMergeTools(hostId: number) {
           .optional()
           .default(24)
           .describe('Number of hours to look back'),
-        hostId: z.number().optional().describe('Override host ID'),
+        hostId: z.coerce.number().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const { lastHours = 24, hostId: toolHostId } = input as {

--- a/lib/ai/agent/tools/migration-tools.ts
+++ b/lib/ai/agent/tools/migration-tools.ts
@@ -22,7 +22,7 @@ export function createMigrationTools(hostId: number) {
           .describe(
             'The ALTER TABLE statement to analyze (will NOT be executed)'
           ),
-        hostId: z.number().int().optional().describe('Host ID override'),
+        hostId: z.coerce.number().int().optional().describe('Host ID override'),
       }),
       execute: async (input: unknown) => {
         const {
@@ -128,7 +128,7 @@ export function createMigrationTools(hostId: number) {
           .optional()
           .default(7)
           .describe('Days of query history to search (default: 7)'),
-        hostId: z.number().int().optional().describe('Host ID override'),
+        hostId: z.coerce.number().int().optional().describe('Host ID override'),
       }),
       execute: async (input: unknown) => {
         const {

--- a/lib/ai/agent/tools/migration-tools.ts
+++ b/lib/ai/agent/tools/migration-tools.ts
@@ -5,7 +5,7 @@
  * before executing DDL operations on production tables.
  */
 
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -22,7 +22,7 @@ export function createMigrationTools(hostId: number) {
           .describe(
             'The ALTER TABLE statement to analyze (will NOT be executed)'
           ),
-        hostId: z.coerce.number().int().optional().describe('Host ID override'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {
@@ -128,7 +128,7 @@ export function createMigrationTools(hostId: number) {
           .optional()
           .default(7)
           .describe('Days of query history to search (default: 7)'),
-        hostId: z.coerce.number().int().optional().describe('Host ID override'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {

--- a/lib/ai/agent/tools/optimizer-tools.ts
+++ b/lib/ai/agent/tools/optimizer-tools.ts
@@ -1,4 +1,4 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { extractReferencedTables, validateAgentSql } from './sql-analysis'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
@@ -14,11 +14,7 @@ export function createOptimizerTools(hostId: number) {
           .string()
           .optional()
           .describe('Database context for table lookups'),
-        hostId: z.coerce
-          .number()
-          .int()
-          .optional()
-          .describe('Host ID to query (defaults to provided host)'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {

--- a/lib/ai/agent/tools/optimizer-tools.ts
+++ b/lib/ai/agent/tools/optimizer-tools.ts
@@ -14,7 +14,7 @@ export function createOptimizerTools(hostId: number) {
           .string()
           .optional()
           .describe('Database context for table lookups'),
-        hostId: z
+        hostId: z.coerce
           .number()
           .int()
           .optional()

--- a/lib/ai/agent/tools/query-tools.ts
+++ b/lib/ai/agent/tools/query-tools.ts
@@ -1,4 +1,4 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 import { validateSqlQuery } from '@/lib/api/shared/validators/sql'
@@ -9,11 +9,7 @@ export function createQueryTools(hostId: number) {
       description:
         'Get currently running queries. Useful for identifying long-running queries and monitoring active workloads.',
       inputSchema: z.object({
-        hostId: z.coerce
-          .number()
-          .int()
-          .optional()
-          .describe('Host ID to query (defaults to provided host)'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { hostId: toolHostId } = input as { hostId?: number }
@@ -48,11 +44,7 @@ export function createQueryTools(hostId: number) {
           .optional()
           .default(10)
           .describe('Number of queries to return'),
-        hostId: z.coerce
-          .number()
-          .int()
-          .optional()
-          .describe('Host ID to query (defaults to provided host)'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { limit = 10, hostId: toolHostId } = input as {
@@ -102,11 +94,7 @@ export function createQueryTools(hostId: number) {
           .optional()
           .default(24)
           .describe('Time window in hours'),
-        hostId: z.coerce
-          .number()
-          .int()
-          .optional()
-          .describe('Host ID to query (defaults to provided host)'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {
@@ -167,11 +155,7 @@ export function createQueryTools(hostId: number) {
           .optional()
           .default(24)
           .describe('Time window in hours'),
-        hostId: z.coerce
-          .number()
-          .int()
-          .optional()
-          .describe('Host ID to query (defaults to provided host)'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {
@@ -248,11 +232,7 @@ export function createQueryTools(hostId: number) {
           .optional()
           .default(2)
           .describe('Minimum occurrence count'),
-        hostId: z.coerce
-          .number()
-          .int()
-          .optional()
-          .describe('Host ID to query (defaults to provided host)'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {
@@ -305,11 +285,7 @@ export function createQueryTools(hostId: number) {
           .optional()
           .default('plan')
           .describe('Type of explanation'),
-        hostId: z.coerce
-          .number()
-          .int()
-          .optional()
-          .describe('Host ID to query (defaults to provided host)'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {

--- a/lib/ai/agent/tools/query-tools.ts
+++ b/lib/ai/agent/tools/query-tools.ts
@@ -9,7 +9,7 @@ export function createQueryTools(hostId: number) {
       description:
         'Get currently running queries. Useful for identifying long-running queries and monitoring active workloads.',
       inputSchema: z.object({
-        hostId: z
+        hostId: z.coerce
           .number()
           .int()
           .optional()
@@ -48,7 +48,7 @@ export function createQueryTools(hostId: number) {
           .optional()
           .default(10)
           .describe('Number of queries to return'),
-        hostId: z
+        hostId: z.coerce
           .number()
           .int()
           .optional()
@@ -102,7 +102,7 @@ export function createQueryTools(hostId: number) {
           .optional()
           .default(24)
           .describe('Time window in hours'),
-        hostId: z
+        hostId: z.coerce
           .number()
           .int()
           .optional()
@@ -167,7 +167,7 @@ export function createQueryTools(hostId: number) {
           .optional()
           .default(24)
           .describe('Time window in hours'),
-        hostId: z
+        hostId: z.coerce
           .number()
           .int()
           .optional()
@@ -248,7 +248,7 @@ export function createQueryTools(hostId: number) {
           .optional()
           .default(2)
           .describe('Minimum occurrence count'),
-        hostId: z
+        hostId: z.coerce
           .number()
           .int()
           .optional()
@@ -305,7 +305,7 @@ export function createQueryTools(hostId: number) {
           .optional()
           .default('plan')
           .describe('Type of explanation'),
-        hostId: z
+        hostId: z.coerce
           .number()
           .int()
           .optional()

--- a/lib/ai/agent/tools/replication-tools.ts
+++ b/lib/ai/agent/tools/replication-tools.ts
@@ -1,4 +1,4 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -13,10 +13,7 @@ export function createReplicationTools(hostId: number) {
           .optional()
           .default('')
           .describe('Filter by database name, or empty for all databases.'),
-        hostId: z.coerce
-          .number()
-          .optional()
-          .describe('Override the default ClickHouse host index.'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { database = '', hostId: toolHostId } = input as {
@@ -65,10 +62,7 @@ export function createReplicationTools(hostId: number) {
           .optional()
           .default(50)
           .describe('Maximum number of rows to return.'),
-        hostId: z.coerce
-          .number()
-          .optional()
-          .describe('Override the default ClickHouse host index.'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {

--- a/lib/ai/agent/tools/replication-tools.ts
+++ b/lib/ai/agent/tools/replication-tools.ts
@@ -13,7 +13,7 @@ export function createReplicationTools(hostId: number) {
           .optional()
           .default('')
           .describe('Filter by database name, or empty for all databases.'),
-        hostId: z
+        hostId: z.coerce
           .number()
           .optional()
           .describe('Override the default ClickHouse host index.'),
@@ -65,7 +65,7 @@ export function createReplicationTools(hostId: number) {
           .optional()
           .default(50)
           .describe('Maximum number of rows to return.'),
-        hostId: z
+        hostId: z.coerce
           .number()
           .optional()
           .describe('Override the default ClickHouse host index.'),

--- a/lib/ai/agent/tools/report-tools.ts
+++ b/lib/ai/agent/tools/report-tools.ts
@@ -16,7 +16,7 @@ export function createReportTools(hostId: number) {
           .optional()
           .default(24)
           .describe('Time window in hours (default: 24)'),
-        hostId: z.number().int().optional().describe('Host ID override'),
+        hostId: z.coerce.number().int().optional().describe('Host ID override'),
       }),
       execute: async (input: unknown) => {
         const { lastHours = 24, hostId: toolHostId } = input as {

--- a/lib/ai/agent/tools/report-tools.ts
+++ b/lib/ai/agent/tools/report-tools.ts
@@ -1,4 +1,4 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -16,7 +16,7 @@ export function createReportTools(hostId: number) {
           .optional()
           .default(24)
           .describe('Time window in hours (default: 24)'),
-        hostId: z.coerce.number().int().optional().describe('Host ID override'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { lastHours = 24, hostId: toolHostId } = input as {

--- a/lib/ai/agent/tools/schema-tools.ts
+++ b/lib/ai/agent/tools/schema-tools.ts
@@ -9,7 +9,7 @@ export function createSchemaTools(hostId: number) {
         'Execute read-only SQL queries on ClickHouse. Use this to fetch data, analyze metrics, and explore the database structure.',
       inputSchema: z.object({
         sql: z.string().describe('The SQL query to execute'),
-        hostId: z
+        hostId: z.coerce
           .number()
           .optional()
           .describe('The host ID (defaults to the session host)'),
@@ -31,7 +31,7 @@ export function createSchemaTools(hostId: number) {
       description:
         'List all databases in ClickHouse with their engine and comment metadata.',
       inputSchema: z.object({
-        hostId: z
+        hostId: z.coerce
           .number()
           .optional()
           .describe('The host ID (defaults to the session host)'),
@@ -53,7 +53,7 @@ export function createSchemaTools(hostId: number) {
         'List tables in a specific database with row counts and size information.',
       inputSchema: z.object({
         database: z.string().describe('The database name'),
-        hostId: z
+        hostId: z.coerce
           .number()
           .optional()
           .describe('The host ID (defaults to the session host)'),
@@ -86,7 +86,7 @@ export function createSchemaTools(hostId: number) {
       inputSchema: z.object({
         database: z.string().describe('The database name'),
         table: z.string().describe('The table name'),
-        hostId: z
+        hostId: z.coerce
           .number()
           .optional()
           .describe('The host ID (defaults to the session host)'),
@@ -118,7 +118,7 @@ export function createSchemaTools(hostId: number) {
       inputSchema: z.object({
         database: z.string().optional().describe('The database name'),
         table: z.string().optional().describe('The table name'),
-        hostId: z
+        hostId: z.coerce
           .number()
           .optional()
           .describe('The host ID (defaults to the session host)'),

--- a/lib/ai/agent/tools/schema-tools.ts
+++ b/lib/ai/agent/tools/schema-tools.ts
@@ -1,4 +1,9 @@
-import { readOnlyQuery, resolveHostId, validatedReadOnlyQuery } from './helpers'
+import {
+  hostIdSchema,
+  readOnlyQuery,
+  resolveHostId,
+  validatedReadOnlyQuery,
+} from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -9,10 +14,7 @@ export function createSchemaTools(hostId: number) {
         'Execute read-only SQL queries on ClickHouse. Use this to fetch data, analyze metrics, and explore the database structure.',
       inputSchema: z.object({
         sql: z.string().describe('The SQL query to execute'),
-        hostId: z.coerce
-          .number()
-          .optional()
-          .describe('The host ID (defaults to the session host)'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { sql, hostId: paramHostId } = input as {
@@ -31,10 +33,7 @@ export function createSchemaTools(hostId: number) {
       description:
         'List all databases in ClickHouse with their engine and comment metadata.',
       inputSchema: z.object({
-        hostId: z.coerce
-          .number()
-          .optional()
-          .describe('The host ID (defaults to the session host)'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { hostId: paramHostId } = input as { hostId?: number }
@@ -53,10 +52,7 @@ export function createSchemaTools(hostId: number) {
         'List tables in a specific database with row counts and size information.',
       inputSchema: z.object({
         database: z.string().describe('The database name'),
-        hostId: z.coerce
-          .number()
-          .optional()
-          .describe('The host ID (defaults to the session host)'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { database, hostId: paramHostId } = input as {
@@ -86,10 +82,7 @@ export function createSchemaTools(hostId: number) {
       inputSchema: z.object({
         database: z.string().describe('The database name'),
         table: z.string().describe('The table name'),
-        hostId: z.coerce
-          .number()
-          .optional()
-          .describe('The host ID (defaults to the session host)'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {
@@ -118,10 +111,7 @@ export function createSchemaTools(hostId: number) {
       inputSchema: z.object({
         database: z.string().optional().describe('The database name'),
         table: z.string().optional().describe('The table name'),
-        hostId: z.coerce
-          .number()
-          .optional()
-          .describe('The host ID (defaults to the session host)'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {

--- a/lib/ai/agent/tools/security-tools.ts
+++ b/lib/ai/agent/tools/security-tools.ts
@@ -1,4 +1,4 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -8,10 +8,7 @@ export function createSecurityTools(hostId: number) {
       description:
         'Get active sessions with user, client info, and resource usage.',
       inputSchema: z.object({
-        hostId: z.coerce
-          .number()
-          .optional()
-          .describe('Override the default ClickHouse host index.'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { hostId: toolHostId } = input as { hostId?: number }
@@ -48,10 +45,7 @@ export function createSecurityTools(hostId: number) {
           .optional()
           .default(24)
           .describe('Number of hours to look back.'),
-        hostId: z.coerce
-          .number()
-          .optional()
-          .describe('Override the default ClickHouse host index.'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {
@@ -86,10 +80,7 @@ export function createSecurityTools(hostId: number) {
       description:
         'Get all users and roles defined in ClickHouse access control.',
       inputSchema: z.object({
-        hostId: z.coerce
-          .number()
-          .optional()
-          .describe('Override the default ClickHouse host index.'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { hostId: toolHostId } = input as { hostId?: number }

--- a/lib/ai/agent/tools/security-tools.ts
+++ b/lib/ai/agent/tools/security-tools.ts
@@ -8,7 +8,7 @@ export function createSecurityTools(hostId: number) {
       description:
         'Get active sessions with user, client info, and resource usage.',
       inputSchema: z.object({
-        hostId: z
+        hostId: z.coerce
           .number()
           .optional()
           .describe('Override the default ClickHouse host index.'),
@@ -48,7 +48,7 @@ export function createSecurityTools(hostId: number) {
           .optional()
           .default(24)
           .describe('Number of hours to look back.'),
-        hostId: z
+        hostId: z.coerce
           .number()
           .optional()
           .describe('Override the default ClickHouse host index.'),
@@ -86,7 +86,7 @@ export function createSecurityTools(hostId: number) {
       description:
         'Get all users and roles defined in ClickHouse access control.',
       inputSchema: z.object({
-        hostId: z
+        hostId: z.coerce
           .number()
           .optional()
           .describe('Override the default ClickHouse host index.'),

--- a/lib/ai/agent/tools/settings-tools.ts
+++ b/lib/ai/agent/tools/settings-tools.ts
@@ -1,4 +1,4 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -13,7 +13,7 @@ export function createSettingsTools(hostId: number) {
           .optional()
           .default('')
           .describe('Optional LIKE pattern to filter setting names'),
-        hostId: z.coerce.number().optional().describe('Host index override'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { pattern = '', hostId: hostIdOverride } = input as {
@@ -38,7 +38,7 @@ export function createSettingsTools(hostId: number) {
           .optional()
           .default('')
           .describe('Optional LIKE pattern to filter setting names'),
-        hostId: z.coerce.number().optional().describe('Host index override'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { pattern = '', hostId: hostIdOverride } = input as {

--- a/lib/ai/agent/tools/settings-tools.ts
+++ b/lib/ai/agent/tools/settings-tools.ts
@@ -13,7 +13,7 @@ export function createSettingsTools(hostId: number) {
           .optional()
           .default('')
           .describe('Optional LIKE pattern to filter setting names'),
-        hostId: z.number().optional().describe('Host index override'),
+        hostId: z.coerce.number().optional().describe('Host index override'),
       }),
       execute: async (input: unknown) => {
         const { pattern = '', hostId: hostIdOverride } = input as {
@@ -38,7 +38,7 @@ export function createSettingsTools(hostId: number) {
           .optional()
           .default('')
           .describe('Optional LIKE pattern to filter setting names'),
-        hostId: z.number().optional().describe('Host index override'),
+        hostId: z.coerce.number().optional().describe('Host index override'),
       }),
       execute: async (input: unknown) => {
         const { pattern = '', hostId: hostIdOverride } = input as {

--- a/lib/ai/agent/tools/storage-tools.ts
+++ b/lib/ai/agent/tools/storage-tools.ts
@@ -1,4 +1,4 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -19,7 +19,7 @@ export function createStorageTools(hostId: number) {
           .optional()
           .default(100)
           .describe('Maximum number of parts to return'),
-        hostId: z.coerce.number().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {
@@ -62,7 +62,7 @@ export function createStorageTools(hostId: number) {
           .optional()
           .default('')
           .describe('Filter by database name'),
-        hostId: z.coerce.number().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { database = '', hostId: toolHostId } = input as {
@@ -87,7 +87,7 @@ export function createStorageTools(hostId: number) {
           .optional()
           .default(20)
           .describe('Maximum number of tables to return'),
-        hostId: z.coerce.number().optional().describe('Override host ID'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { limit = 20, hostId: toolHostId } = input as {

--- a/lib/ai/agent/tools/storage-tools.ts
+++ b/lib/ai/agent/tools/storage-tools.ts
@@ -19,7 +19,7 @@ export function createStorageTools(hostId: number) {
           .optional()
           .default(100)
           .describe('Maximum number of parts to return'),
-        hostId: z.number().optional().describe('Override host ID'),
+        hostId: z.coerce.number().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const {
@@ -62,7 +62,7 @@ export function createStorageTools(hostId: number) {
           .optional()
           .default('')
           .describe('Filter by database name'),
-        hostId: z.number().optional().describe('Override host ID'),
+        hostId: z.coerce.number().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const { database = '', hostId: toolHostId } = input as {
@@ -87,7 +87,7 @@ export function createStorageTools(hostId: number) {
           .optional()
           .default(20)
           .describe('Maximum number of tables to return'),
-        hostId: z.number().optional().describe('Override host ID'),
+        hostId: z.coerce.number().optional().describe('Override host ID'),
       }),
       execute: async (input: unknown) => {
         const { limit = 20, hostId: toolHostId } = input as {

--- a/lib/ai/agent/tools/visualization-tools.ts
+++ b/lib/ai/agent/tools/visualization-tools.ts
@@ -1,6 +1,11 @@
 import 'server-only'
 
-import { readOnlyQuery, resolveHostId, validatedReadOnlyQuery } from './helpers'
+import {
+  hostIdSchema,
+  readOnlyQuery,
+  resolveHostId,
+  validatedReadOnlyQuery,
+} from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -45,11 +50,7 @@ export function createVisualizationTools(hostId: number) {
           .enum(['bytes', 'duration', 'number', 'quantity'])
           .optional()
           .describe('Value format hint'),
-        hostId: z.coerce
-          .number()
-          .int()
-          .optional()
-          .describe('Host ID (defaults to session host)'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {
@@ -129,11 +130,7 @@ export function createVisualizationTools(hostId: number) {
       inputSchema: z.object({
         searchTerm: z.string().describe('Topic to search for'),
         database: z.string().optional().describe('Limit to specific database'),
-        hostId: z.coerce
-          .number()
-          .int()
-          .optional()
-          .describe('Host ID (defaults to session host)'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const {

--- a/lib/ai/agent/tools/visualization-tools.ts
+++ b/lib/ai/agent/tools/visualization-tools.ts
@@ -45,7 +45,7 @@ export function createVisualizationTools(hostId: number) {
           .enum(['bytes', 'duration', 'number', 'quantity'])
           .optional()
           .describe('Value format hint'),
-        hostId: z
+        hostId: z.coerce
           .number()
           .int()
           .optional()
@@ -129,7 +129,7 @@ export function createVisualizationTools(hostId: number) {
       inputSchema: z.object({
         searchTerm: z.string().describe('Topic to search for'),
         database: z.string().optional().describe('Limit to specific database'),
-        hostId: z
+        hostId: z.coerce
           .number()
           .int()
           .optional()

--- a/lib/ai/agent/tools/zookeeper-tools.ts
+++ b/lib/ai/agent/tools/zookeeper-tools.ts
@@ -1,4 +1,4 @@
-import { readOnlyQuery, resolveHostId } from './helpers'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
 import { dynamicTool } from 'ai'
 import { z } from 'zod/v3'
 
@@ -13,7 +13,7 @@ export function createZookeeperTools(hostId: number) {
           .optional()
           .default('/')
           .describe('ZooKeeper path to inspect (default: root path "/")'),
-        hostId: z.coerce.number().optional().describe('Host index override'),
+        hostId: hostIdSchema,
       }),
       execute: async (input: unknown) => {
         const { path = '/', hostId: hostIdOverride } = input as {

--- a/lib/ai/agent/tools/zookeeper-tools.ts
+++ b/lib/ai/agent/tools/zookeeper-tools.ts
@@ -13,7 +13,7 @@ export function createZookeeperTools(hostId: number) {
           .optional()
           .default('/')
           .describe('ZooKeeper path to inspect (default: root path "/")'),
-        hostId: z.number().optional().describe('Host index override'),
+        hostId: z.coerce.number().optional().describe('Host index override'),
       }),
       execute: async (input: unknown) => {
         const { path = '/', hostId: hostIdOverride } = input as {


### PR DESCRIPTION
## Summary

Fixes the agent/tool-call failures seen on `/agents` where a question like "which queries are running right now" failed repeatedly.

Two root causes, both addressed:

1. **`hostId` type rejection (the main bug).** Every agent tool declared `hostId` as `z.number()`. The LLM commonly passes `hostId: "0"` (a string), which zod rejected with `Expected number, received string`, so `get_running_queries` (and every other tool) failed. After the tool failed, the model fell back to hand-writing SQL and produced invalid queries (e.g. selecting a non-existent `database` column from `system.processes`, malformed `WHERE` syntax).

   - All `hostId`/`hostId1`/`hostId2` fields now use `z.coerce.number()`. String indices are accepted at runtime, while the JSON schema advertised to the LLM still says `number`.
   - `/api/v1/agent` now coerces a string `hostId` from the request body instead of silently falling back to host `0`.

2. **SQL hallucination guidance.** Added a new `system-tables-reference` skill documenting the exact columns of the most-queried system tables — notably that `system.processes` exposes `current_database`, **not** `database` — plus rules for preferring dedicated tools over raw SQL and recovery steps for unknown-column errors. Wired it into the agent system instructions (skills list, when-to-load triggers, and a `system.processes` column note), and added an explicit reminder that `hostId` is a numeric 0-based index.

## Changes
- `lib/ai/agent/tools/*.ts` — `z.number()` → `z.coerce.number()` for all host id fields (23 files)
- `app/api/v1/agent/route.ts` — coerce string `hostId` from request body
- `.agents/skills/system-tables-reference/SKILL.md` — new skill; registry regenerated via `bun run build:skills`
- `lib/ai/agent/prompts/clickhouse-instructions.ts` — reference the new skill, clarify numeric `hostId`, note `system.processes` columns

## Test plan
- [x] `bun run type-check` passes
- [x] `bun test lib/ai/agent/tools/__tests__/` — 13 pass
- [x] biome lint/format clean on changed files
- [x] Verified `z.coerce.number().int().optional()` accepts `"0"`, `1`, and `undefined`
- [ ] Manual check on `/agents`: ask "which queries are running right now" and confirm `get_running_queries` succeeds

Co-Authored-By: duyetbot <bot@duyet.net>

---
_Generated by [Claude Code](https://claude.ai/code/session_015TkvE48o3HLb3GqoEqjfBF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced AI Agent documentation for natural-language ClickHouse queries with integrated skills support
  * Added system tables reference skill to guide accurate queries against ClickHouse system tables
  * Enhanced agent input parsing to accept more flexible host ID specification formats

* **Documentation**
  * Added comprehensive AI Agent guide covering tools, skills, environment configuration, and example usage patterns

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->