### PR TITLE
feat(charts): render correct units in compact chart row mode

### DIFF
--- a/components/layout/query-page/__tests__/chart-format.test.ts
+++ b/components/layout/query-page/__tests__/chart-format.test.ts
@@ -1,0 +1,58 @@
+import { formatChartValue, inferUnit } from '../chart-format'
+import { describe, expect, it } from 'bun:test'
+
+describe('inferUnit', () => {
+  it('detects byte-like metrics', () => {
+    expect(inferUnit('memory_usage')).toBe('bytes')
+    expect(inferUnit('used_space')).toBe('bytes')
+    expect(inferUnit('result_size')).toBe('bytes')
+    expect(inferUnit('total_bytes')).toBe('bytes')
+  })
+
+  it('detects millisecond and second durations', () => {
+    expect(inferUnit('query_duration_ms')).toBe('ms')
+    expect(inferUnit('query_duration_s')).toBe('seconds')
+    expect(inferUnit('p95_s')).toBe('seconds')
+  })
+
+  it('detects percentages', () => {
+    expect(inferUnit('cpu_percent')).toBe('percent')
+    expect(inferUnit('pct_used')).toBe('percent')
+  })
+
+  it('falls back to count for plain or unknown fields', () => {
+    expect(inferUnit('query_count')).toBe('count')
+    expect(inferUnit('count')).toBe('count')
+    expect(inferUnit(null)).toBe('count')
+    expect(inferUnit(undefined)).toBe('count')
+  })
+})
+
+describe('formatChartValue', () => {
+  it('formats bytes as readable sizes', () => {
+    expect(formatChartValue(4_400_000, 'bytes')).toBe('4.2 MiB')
+    expect(formatChartValue(1024, 'bytes')).toBe('1 KiB')
+  })
+
+  it('formats milliseconds with ms / s units', () => {
+    expect(formatChartValue(1.2, 'ms')).toBe('1.20 ms')
+    expect(formatChartValue(450, 'ms')).toBe('450 ms')
+    expect(formatChartValue(1500, 'ms')).toBe('1.50 s')
+  })
+
+  it('formats seconds by promoting through duration units', () => {
+    expect(formatChartValue(1.2, 'seconds')).toBe('1.20 s')
+    expect(formatChartValue(90, 'seconds')).toBe('1m 30s')
+  })
+
+  it('formats percentages', () => {
+    expect(formatChartValue(3.456, 'percent')).toBe('3.5%')
+    expect(formatChartValue(42.6, 'percent')).toBe('43%')
+  })
+
+  it('falls back to compact counts', () => {
+    expect(formatChartValue(115, 'count')).toBe((115).toLocaleString())
+    expect(formatChartValue(2_345_678, 'count')).toBe('2.3M')
+    expect(formatChartValue(1500)).toBe('1.5K')
+  })
+})

--- a/components/layout/query-page/__tests__/derive-chart-summary.test.ts
+++ b/components/layout/query-page/__tests__/derive-chart-summary.test.ts
@@ -9,6 +9,7 @@ describe('deriveChartSummary', () => {
       spark: [],
       deltaPct: null,
       trend: null,
+      field: null,
     })
     expect(deriveChartSummary([])).toEqual({
       latest: null,
@@ -16,6 +17,7 @@ describe('deriveChartSummary', () => {
       spark: [],
       deltaPct: null,
       trend: null,
+      field: null,
     })
   })
 
@@ -29,6 +31,35 @@ describe('deriveChartSummary', () => {
 
     expect(result.latest).toBe(20)
     expect(result.prev).toBe(10)
+  })
+
+  it('reports the detected value field for unit inference', () => {
+    const data = [
+      { event_time: '2026-01-01', memory_usage: 100 },
+      { event_time: '2026-01-02', memory_usage: 200 },
+    ]
+
+    expect(deriveChartSummary(data).field).toBe('memory_usage')
+  })
+
+  it('skips hash / id / code identifier columns during auto-detection', () => {
+    // top-query-fingerprints shape: the hash is numeric but is not the metric.
+    const fingerprints = [
+      { event_time: '2026-01-01', hash: 56708661833928, count: 10 },
+      { event_time: '2026-01-02', hash: 56708661833928, count: 20 },
+    ]
+    const fp = deriveChartSummary(fingerprints)
+    expect(fp.field).toBe('count')
+    expect(fp.latest).toBe(20)
+
+    // cancelled-queries shape: exception_code is numeric but not the metric.
+    const cancelled = [
+      { event_time: '2026-01-01', exception_code: 394, count: 3 },
+      { event_time: '2026-01-02', exception_code: 159, count: 5 },
+    ]
+    const c = deriveChartSummary(cancelled)
+    expect(c.field).toBe('count')
+    expect(c.latest).toBe(5)
   })
 
   it('skips readable_ / percent_ fields during auto-detection', () => {

--- a/components/layout/query-page/__tests__/format-compact.test.ts
+++ b/components/layout/query-page/__tests__/format-compact.test.ts
@@ -1,4 +1,4 @@
-import { formatCompact } from '../chart-chip'
+import { formatCompact } from '../chart-format'
 import { describe, expect, it } from 'bun:test'
 
 describe('formatCompact', () => {

--- a/components/layout/query-page/chart-chip.tsx
+++ b/components/layout/query-page/chart-chip.tsx
@@ -4,6 +4,11 @@ import { TrendingDownIcon, TrendingUpIcon } from 'lucide-react'
 
 import type { ClickHouseInterval } from '@/types/clickhouse-interval'
 
+import {
+  type ChartValueUnit,
+  formatChartValue,
+  inferUnit,
+} from './chart-format'
 import { deriveChartSummary } from './derive-chart-summary'
 import { memo } from 'react'
 import { MiniAreaChart } from '@/components/charts/mini-charts'
@@ -16,6 +21,7 @@ export interface ChartChipProps {
   chartName: string
   label: string
   valueField?: string
+  unit?: ChartValueUnit
   interval?: ClickHouseInterval
   lastHours?: number
 }
@@ -32,17 +38,11 @@ const SPARK_COLOR = {
   flat: 'hsl(217 10% 60%)',
 } as const
 
-export function formatCompact(n: number): string {
-  if (Math.abs(n) >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (Math.abs(n) >= 1_000) return `${(n / 1_000).toFixed(1)}K`
-  if (Number.isInteger(n)) return n.toLocaleString()
-  return n.toFixed(2)
-}
-
 export const ChartChip = memo(function ChartChip({
   chartName,
   label,
   valueField,
+  unit,
   interval,
   lastHours,
 }: ChartChipProps) {
@@ -69,7 +69,7 @@ export const ChartChip = memo(function ChartChip({
       ) : summary.latest !== null ? (
         <>
           <span className="shrink-0 text-xs font-semibold tabular-nums text-foreground/90">
-            {formatCompact(summary.latest)}
+            {formatChartValue(summary.latest, unit ?? inferUnit(summary.field))}
           </span>
           {summary.deltaPct !== null &&
           summary.trend &&

--- a/components/layout/query-page/chart-format.ts
+++ b/components/layout/query-page/chart-format.ts
@@ -1,0 +1,58 @@
+import { formatReadableSize } from '@/lib/format-readable'
+
+export type ChartValueUnit = 'count' | 'bytes' | 'ms' | 'seconds' | 'percent'
+
+/** Compact K/M/B number used for plain counts. */
+export function formatCompact(n: number): string {
+  if (Math.abs(n) >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (Math.abs(n) >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  if (Number.isInteger(n)) return n.toLocaleString()
+  return n.toFixed(2)
+}
+
+/** Render a millisecond value with a sensible ms / s / m unit. */
+function formatDuration(ms: number): string {
+  const sign = ms < 0 ? '-' : ''
+  const abs = Math.abs(ms)
+  if (abs < 1000) {
+    return `${sign}${abs < 10 ? abs.toFixed(2) : Math.round(abs).toLocaleString()} ms`
+  }
+  const s = abs / 1000
+  if (s < 60) return `${sign}${s.toFixed(2)} s`
+  const m = Math.floor(s / 60)
+  return `${sign}${m}m ${Math.round(s % 60)}s`
+}
+
+export function formatChartValue(value: number, unit?: ChartValueUnit): string {
+  switch (unit) {
+    case 'bytes':
+      return formatReadableSize(value)
+    case 'ms':
+      return formatDuration(value)
+    case 'seconds':
+      return formatDuration(value * 1000)
+    case 'percent':
+      return `${Math.abs(value) < 10 ? value.toFixed(1) : Math.round(value)}%`
+    default:
+      return formatCompact(value)
+  }
+}
+
+const FIELD_UNIT_PATTERNS: Array<[RegExp, ChartValueUnit]> = [
+  [/(duration_ms|_ms|_millis)$/i, 'ms'],
+  [/(_s|_sec|_secs|_seconds)$/i, 'seconds'],
+  [/(bytes|memory|_size|^size|_space)/i, 'bytes'],
+  [/(pct|percent)/i, 'percent'],
+]
+
+/**
+ * Infer the unit of a metric from its column name so compact chips render
+ * e.g. `memory_usage` as MiB and `query_duration_ms` as ms.
+ */
+export function inferUnit(field: string | null | undefined): ChartValueUnit {
+  if (!field) return 'count'
+  for (const [pattern, unit] of FIELD_UNIT_PATTERNS) {
+    if (pattern.test(field)) return unit
+  }
+  return 'count'
+}

--- a/components/layout/query-page/chart-row-summary.tsx
+++ b/components/layout/query-page/chart-row-summary.tsx
@@ -2,9 +2,18 @@
 
 import type { ClickHouseInterval } from '@/types/clickhouse-interval'
 import type { QueryConfig } from '@/types/query-config'
+import type { ChartValueUnit } from './chart-format'
 
 import { ChartChip } from './chart-chip'
 import { memo } from 'react'
+
+const VALID_UNITS: ReadonlySet<string> = new Set([
+  'count',
+  'bytes',
+  'ms',
+  'seconds',
+  'percent',
+])
 
 type ChartConfig = NonNullable<QueryConfig['relatedCharts']>[number]
 
@@ -33,6 +42,10 @@ export const ChartRowSummary = memo(function ChartRowSummary({
         : undefined
       const valueField =
         typeof props?.valueField === 'string' ? props.valueField : undefined
+      const unit =
+        typeof props?.unit === 'string' && VALID_UNITS.has(props.unit)
+          ? (props.unit as ChartValueUnit)
+          : undefined
       const interval =
         typeof props?.interval === 'string'
           ? (props.interval as ClickHouseInterval)
@@ -43,6 +56,7 @@ export const ChartRowSummary = memo(function ChartRowSummary({
         name,
         label: chartLabel(name, props),
         valueField,
+        unit,
         interval,
         lastHours,
       }
@@ -58,6 +72,7 @@ export const ChartRowSummary = memo(function ChartRowSummary({
           chartName={item.name}
           label={item.label}
           valueField={item.valueField}
+          unit={item.unit}
           interval={item.interval}
           lastHours={item.lastHours}
         />

--- a/components/layout/query-page/derive-chart-summary.ts
+++ b/components/layout/query-page/derive-chart-summary.ts
@@ -6,6 +6,8 @@ export interface ChartSummary {
   spark: number[]
   deltaPct: number | null
   trend: 'up' | 'down' | 'flat' | null
+  /** The numeric column used for the summary, for unit inference. */
+  field: string | null
 }
 
 const EMPTY: ChartSummary = {
@@ -14,6 +16,7 @@ const EMPTY: ChartSummary = {
   spark: [],
   deltaPct: null,
   trend: null,
+  field: null,
 }
 
 const TIME_FIELDS = new Set([
@@ -33,6 +36,14 @@ const IGNORED_FIELD_PATTERNS = [
   /_percent$/i,
   /^readable_/i,
   /_readable$/i,
+  // Identifier-like columns are never the headline metric (e.g. the
+  // `normalized_query_hash` in top-query-fingerprints, or `exception_code`
+  // in cancelled-queries).
+  /hash$/i,
+  /^id$/i,
+  /_id$/i,
+  /^code$/i,
+  /_code$/i,
 ]
 
 function isFiniteNumber(value: unknown): value is number {
@@ -128,5 +139,5 @@ export function deriveChartSummary(
     trend = latest > 0 ? 'up' : 'flat'
   }
 
-  return { latest, prev, spark, deltaPct, trend }
+  return { latest, prev, spark, deltaPct, trend, field }
 }


### PR DESCRIPTION
## Summary

In the collapsed "chart row compact mode", chips rendered every metric as a raw compact number with no unit, and sometimes picked the wrong column entirely. This PR makes the chips unit-aware and fixes value-field selection.

Before (from the reported screenshot):
- `query memory 4.4M` — bytes shown as a bare count
- `query duration 1.20` — no `ms`/`s` unit
- `top query fingerprints 56708661833928.2M` — the `normalized_query_hash` was being formatted as the value instead of the query count

After:
- `query memory 4.2 MiB` (readable size)
- `query duration 1.20 ms` / `1.50 s` (ms → s → m promotion)
- `top query fingerprints 20` (actual count), `cancelled queries 5` (count, not exception code)

## Changes

- Add `components/layout/query-page/chart-format.ts`:
  - `formatChartValue(value, unit)` — renders `bytes` (readable size), `ms`/`seconds` (durations), `percent`, and `count` (compact K/M/B).
  - `inferUnit(field)` — infers the unit from the metric column name (`memory_usage` → bytes, `query_duration_ms` → ms, `p95_s` → seconds, `*_percent` → percent).
  - `formatCompact` moved here (pure module, no React) and re-pointed the existing test at it.
- `derive-chart-summary.ts`: skip identifier-like columns (`hash`, `id`, `code`) during auto-detection, and return the detected `field` so the chip can infer the unit.
- `chart-chip.tsx`: render via `formatChartValue` with the inferred unit (or an explicit override).
- `chart-row-summary.tsx`: pass an optional `unit` override from chart config props through to the chip.

## Test plan

- [x] `bun test components/layout/query-page/__tests__/` — 30 pass (new `chart-format.test.ts`, updated `derive-chart-summary.test.ts`)
- [x] `bun run type-check`
- [x] `bunx biome check`

https://claude.ai/code/session_01HSwfrQpaSkgTdDbMgcHq9x

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSwfrQpaSkgTdDbMgcHq9x)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent unit formatting for chart values, displaying bytes as readable sizes (KiB/MiB), durations in milliseconds or seconds, and percentages with appropriate precision.
  * Improved metric field selection to prioritize meaningful data columns and avoid identifier-like fields in chart summaries.

* **Tests**
  * Added comprehensive test coverage for chart formatting utilities and summary derivation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->