### PR TITLE
chore: address react-doctor mechanical findings (safe, behavior-preserving)

### DIFF
--- a/app/(dashboard)/mcp/page.tsx
+++ b/app/(dashboard)/mcp/page.tsx
@@ -40,19 +40,19 @@ export default function McpPage() {
         <p className="text-sm text-muted-foreground max-w-2xl">
           Connect AI assistants like Claude, Cursor, and other MCP-compatible
           clients directly to your ClickHouse cluster. Query data, explore
-          schemas, and investigate performance — all through natural language.
+          schemas, and investigate performance, all through natural language.
         </p>
         <div className="flex flex-wrap gap-4">
           <FeaturePill
-            icon={<Globe className="h-3.5 w-3.5" />}
+            icon={<Globe className="size-3.5" />}
             label="Streamable HTTP"
           />
           <FeaturePill
-            icon={<Lock className="h-3.5 w-3.5" />}
+            icon={<Lock className="size-3.5" />}
             label="Read-only access"
           />
           <FeaturePill
-            icon={<Zap className="h-3.5 w-3.5" />}
+            icon={<Zap className="size-3.5" />}
             label="8 tools available"
           />
         </div>

--- a/app/(docs)/docs/[[...slug]]/page.tsx
+++ b/app/(docs)/docs/[[...slug]]/page.tsx
@@ -106,7 +106,7 @@ function DocsMobileNav({
             Close
           </span>
         </summary>
-        <div className="max-h-[calc(100vh-8rem)] overflow-y-auto border-border border-t px-3 py-3">
+        <div className="max-h-[calc(100vh-8rem)] overflow-y-auto border-border border-t p-3">
           <DocsNavList activeSlug={activeSlug} compact />
           {headings.length > 0 ? (
             <div className="mt-4 border-border border-t pt-4">

--- a/app/context.tsx
+++ b/app/context.tsx
@@ -7,7 +7,7 @@ import {
   createContext,
   type Dispatch,
   type SetStateAction,
-  useContext,
+  use,
   useState,
 } from 'react'
 
@@ -56,7 +56,7 @@ export const AppProvider = ({
 }
 
 export const useAppContext = () => {
-  const context = useContext(Context)
+  const context = use(Context)
 
   if (context === undefined) {
     throw new Error('useAppContext must be used within a AppProvider')

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -47,7 +47,7 @@ export default function GlobalError({
       <body className="font-sans">
         <div className="bg-background flex min-h-dvh flex-col items-center justify-center px-4 py-12 sm:px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
-            <div className="text-primary mx-auto h-12 w-12" />
+            <div className="text-primary mx-auto size-12" />
             <h1 className="text-foreground mt-4 text-3xl font-bold tracking-tight sm:text-4xl">
               {formattedError.title}
             </h1>
@@ -59,7 +59,7 @@ export default function GlobalError({
             {formattedError.details?.stack && (
               <div className="bg-muted/30 mt-6 rounded-lg border p-4 text-left">
                 <div className="mb-2 flex items-center gap-2">
-                  <BugIcon className="h-4 w-4" />
+                  <BugIcon className="size-4" />
                   <span className="text-sm font-medium">Stack Trace:</span>
                 </div>
                 <pre className="text-muted-foreground max-h-64 overflow-auto text-xs">
@@ -72,7 +72,7 @@ export default function GlobalError({
             {formattedError.details?.digest && (
               <div className="bg-muted/30 mt-4 rounded-lg border p-4 text-left">
                 <div className="mb-2 flex items-center gap-2">
-                  <BugIcon className="h-4 w-4" />
+                  <BugIcon className="size-4" />
                   <span className="text-sm font-medium">
                     Error ID (for support):
                   </span>
@@ -85,10 +85,11 @@ export default function GlobalError({
 
             <div className="mt-6">
               <button
+                type="button"
                 className="bg-primary text-primary-foreground hover:bg-primary/90 focus:ring-primary inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium shadow-xs transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
                 onClick={() => reset()}
               >
-                <RefreshCwIcon className="h-4 w-4" />
+                <RefreshCwIcon className="size-4" />
                 Try again
               </button>
             </div>

--- a/components/agents/agent-chart-renderer.tsx
+++ b/components/agents/agent-chart-renderer.tsx
@@ -78,7 +78,7 @@ export interface AgentChartRendererProps {
 function ChartSkeleton() {
   return (
     <div className="flex items-center justify-center p-8">
-      <Loader2Icon className="h-6 w-6 animate-spin text-muted-foreground" />
+      <Loader2Icon className="size-6 animate-spin text-muted-foreground" />
     </div>
   )
 }

--- a/components/agents/agent-config-guidance.tsx
+++ b/components/agents/agent-config-guidance.tsx
@@ -62,7 +62,7 @@ export function AgentConfigGuidance({
         <div className="flex gap-3 items-start">
           {/* Icon */}
           <div className="flex-shrink-0 pt-0.5">
-            <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+            <AlertTriangle className="size-4 text-amber-600 dark:text-amber-400" />
           </div>
 
           {/* Content */}
@@ -76,10 +76,10 @@ export function AgentConfigGuidance({
                   variant="ghost"
                   size="icon"
                   onClick={onDismiss}
-                  className="h-6 w-6 shrink-0"
+                  className="size-6 shrink-0"
                   aria-label="Dismiss"
                 >
-                  <X className="h-3.5 w-3.5" />
+                  <X className="size-3.5" />
                 </Button>
               )}
             </div>
@@ -166,7 +166,7 @@ LLM_API_BASE=https://openrouter.ai/api/v1`}</code>
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-1.5 text-xs text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline"
                 >
-                  <ExternalLink className="h-3 w-3" />
+                  <ExternalLink className="size-3" />
                   OpenRouter Quick Start Guide
                 </a>
               </div>
@@ -174,17 +174,18 @@ LLM_API_BASE=https://openrouter.ai/api/v1`}</code>
 
             {/* Toggle button */}
             <button
+              type="button"
               onClick={() => setIsDetailsExpanded(!isDetailsExpanded)}
               className="text-xs text-amber-700 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-300 mt-2 flex items-center gap-1"
             >
               {isDetailsExpanded ? (
                 <>
-                  <ChevronDown className="h-3 w-3" />
+                  <ChevronDown className="size-3" />
                   Hide details
                 </>
               ) : (
                 <>
-                  <BookOpen className="h-3 w-3" />
+                  <BookOpen className="size-3" />
                   View setup instructions
                 </>
               )}

--- a/components/agents/agent-data-sources.tsx
+++ b/components/agents/agent-data-sources.tsx
@@ -18,9 +18,9 @@ import { cn } from '@/lib/utils'
 
 function ChevronToggle({ open }: { open: boolean }) {
   return open ? (
-    <ChevronDownIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+    <ChevronDownIcon className="size-3.5 shrink-0 text-muted-foreground" />
   ) : (
-    <ChevronRightIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+    <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground" />
   )
 }
 
@@ -95,7 +95,7 @@ function DataSourceItem({
         >
           <ChevronToggle open={isOpen} />
 
-          <TableIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <TableIcon className="size-3.5 shrink-0 text-muted-foreground" />
 
           <span className="flex-1 min-w-0 text-xs font-semibold text-foreground truncate">
             {source.database}.{source.table}
@@ -174,7 +174,7 @@ export function AgentDataSources({
           >
             <ChevronToggle open={isGroupOpen} />
 
-            <DatabaseIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <DatabaseIcon className="size-3.5 shrink-0 text-muted-foreground" />
 
             <span className="text-xs font-medium text-foreground">
               Discovered sources

--- a/components/agents/agent-diagnostics.tsx
+++ b/components/agents/agent-diagnostics.tsx
@@ -103,7 +103,7 @@ export function AgentIssuesPanel({ output }: { output: AgentIssuesOutput }) {
     <div className="rounded-md border border-border/60 bg-muted/20">
       <div className="flex items-center justify-between gap-3 border-b border-border/50 px-3 py-2">
         <div className="flex min-w-0 items-center gap-2">
-          <AlertTriangleIcon className="h-4 w-4 text-amber-500" />
+          <AlertTriangleIcon className="size-4 text-amber-500" />
           <span className="text-sm font-semibold">Issue scan</span>
         </div>
         <Badge variant="outline" className="text-[10px]">
@@ -112,8 +112,8 @@ export function AgentIssuesPanel({ output }: { output: AgentIssuesOutput }) {
       </div>
 
       {output.issues.length === 0 ? (
-        <div className="flex items-center gap-2 px-3 py-3 text-sm text-muted-foreground">
-          <CheckCircle2Icon className="h-4 w-4 text-emerald-500" />
+        <div className="flex items-center gap-2 p-3 text-sm text-muted-foreground">
+          <CheckCircle2Icon className="size-4 text-emerald-500" />
           No confirmed issues found in the selected window.
         </div>
       ) : (
@@ -121,10 +121,10 @@ export function AgentIssuesPanel({ output }: { output: AgentIssuesOutput }) {
           {output.issues.map((issue) => {
             const Icon = SEVERITY_ICON[issue.severity]
             return (
-              <div key={issue.id} className="space-y-2 px-3 py-3">
+              <div key={issue.id} className="space-y-2 p-3">
                 <div className="flex items-start justify-between gap-3">
                   <div className="flex min-w-0 items-start gap-2">
-                    <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                    <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
                     <div className="min-w-0">
                       <div className="text-sm font-medium text-foreground">
                         {issue.title}
@@ -168,7 +168,7 @@ export function QueryRepairPanel({ output }: { output: QueryRepairOutput }) {
     <div className="space-y-3 rounded-md border border-border/60 bg-muted/20 p-3">
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">
-          <FileCode2Icon className="h-4 w-4 text-primary" />
+          <FileCode2Icon className="size-4 text-primary" />
           <span className="text-sm font-semibold">Query repair</span>
         </div>
         <Badge
@@ -242,7 +242,7 @@ export function TableDesignPanel({ output }: { output: TableDesignOutput }) {
     <div className="rounded-md border border-border/60 bg-muted/20">
       <div className="flex items-center justify-between gap-3 border-b border-border/50 px-3 py-2">
         <div className="flex min-w-0 items-center gap-2">
-          <DatabaseIcon className="h-4 w-4 text-primary" />
+          <DatabaseIcon className="size-4 text-primary" />
           <span className="truncate text-sm font-semibold">
             Table design: {output.table}
           </span>
@@ -253,7 +253,7 @@ export function TableDesignPanel({ output }: { output: TableDesignOutput }) {
       </div>
 
       {output.suggestedOrderBy.length > 0 ? (
-        <div className="border-b border-border/40 px-3 py-3">
+        <div className="border-b border-border/40 p-3">
           <div className="mb-1.5 text-xs font-medium text-muted-foreground">
             Suggested ORDER BY candidates
           </div>
@@ -269,14 +269,14 @@ export function TableDesignPanel({ output }: { output: TableDesignOutput }) {
 
       <div className="divide-y divide-border/40">
         {output.recommendations.length === 0 ? (
-          <div className="px-3 py-3 text-sm text-muted-foreground">
+          <div className="p-3 text-sm text-muted-foreground">
             No table-design recommendations found from available evidence.
           </div>
         ) : (
           output.recommendations.map((recommendation) => (
             <div
               key={`${recommendation.category}-${recommendation.title}`}
-              className="space-y-2 px-3 py-3"
+              className="space-y-2 p-3"
             >
               <div className="flex items-start justify-between gap-3">
                 <div>

--- a/components/agents/agent-error-display.tsx
+++ b/components/agents/agent-error-display.tsx
@@ -153,7 +153,7 @@ export function AgentErrorDisplay({
           embedded && 'border-destructive/30 bg-destructive/5 text-foreground'
         )}
       >
-        <AlertCircleIcon className="h-4 w-4 shrink-0 mt-0.5" />
+        <AlertCircleIcon className="size-4 shrink-0 mt-0.5" />
         <AlertDescription className="flex flex-col gap-2 min-w-0">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
             <div className="flex flex-col gap-1 min-w-0">
@@ -188,7 +188,7 @@ export function AgentErrorDisplay({
                 className="h-7 text-xs"
                 title="Copy error details"
               >
-                <CopyIcon className="h-3 w-3 mr-1" />
+                <CopyIcon className="size-3 mr-1" />
                 {copied ? 'Copied' : 'Copy'}
               </Button>
               {onRetry && (
@@ -198,7 +198,7 @@ export function AgentErrorDisplay({
                   onClick={onRetry}
                   className="h-7 text-xs"
                 >
-                  <RefreshCwIcon className="h-3 w-3 mr-1" />
+                  <RefreshCwIcon className="size-3 mr-1" />
                   Retry
                 </Button>
               )}
@@ -207,10 +207,10 @@ export function AgentErrorDisplay({
                   variant="ghost"
                   size="icon"
                   onClick={onDismiss}
-                  className="h-7 w-7"
+                  className="size-7"
                   title="Dismiss"
                 >
-                  <XIcon className="h-3 w-3" />
+                  <XIcon className="size-3" />
                 </Button>
               )}
             </div>
@@ -281,7 +281,7 @@ export function AgentErrorDisplay({
                   onClick={handleCopy}
                   className="h-7 gap-1.5 px-2.5 text-xs"
                 >
-                  <CopyIcon className="h-3.5 w-3.5" />
+                  <CopyIcon className="size-3.5" />
                   {copied ? 'Copied' : 'Copy'}
                 </Button>
               </div>

--- a/components/agents/agent-insight-cards.tsx
+++ b/components/agents/agent-insight-cards.tsx
@@ -29,7 +29,7 @@ const INSIGHT_CARDS: InsightCardConfig[] = [
   {
     chartName: 'running-queries-count',
     label: 'Running Queries',
-    icon: <ActivityIcon className="h-4 w-4" />,
+    icon: <ActivityIcon className="size-4" />,
     question: 'Which queries are running right now?',
     getValue: (data) => Number(data[0]?.count ?? 0),
     getSeverity: (v) => (v > 50 ? 'critical' : v > 10 ? 'watch' : 'healthy'),
@@ -37,7 +37,7 @@ const INSIGHT_CARDS: InsightCardConfig[] = [
   {
     chartName: 'merge-active-count',
     label: 'Active Merges',
-    icon: <MergeIcon className="h-4 w-4" />,
+    icon: <MergeIcon className="size-4" />,
     question: 'How is the merge queue performing?',
     getValue: (data) => Number(data[0]?.count ?? 0),
     getSeverity: (v) => (v > 20 ? 'critical' : v > 5 ? 'watch' : 'healthy'),
@@ -45,7 +45,7 @@ const INSIGHT_CARDS: InsightCardConfig[] = [
   {
     chartName: 'summary-stuck-mutations',
     label: 'Stuck Mutations',
-    icon: <AlertTriangleIcon className="h-4 w-4" />,
+    icon: <AlertTriangleIcon className="size-4" />,
     question: 'Are there stuck mutations?',
     getValue: (data) => Number(data[0]?.count ?? 0),
     getSeverity: (v) => (v > 0 ? 'critical' : 'healthy'),
@@ -53,7 +53,7 @@ const INSIGHT_CARDS: InsightCardConfig[] = [
   {
     chartName: 'health-max-part-count',
     label: 'Max Part Count',
-    icon: <TablePropertiesIcon className="h-4 w-4" />,
+    icon: <TablePropertiesIcon className="size-4" />,
     question: 'Show tables with high part counts',
     getValue: (data) => Number(data[0]?.count ?? data[0]?.max_parts_count ?? 0),
     getSeverity: (v) => (v > 3000 ? 'critical' : v > 300 ? 'watch' : 'healthy'),
@@ -112,6 +112,7 @@ function InsightCard({
   if (error || !data || data.length === 0) {
     return (
       <button
+        type="button"
         onClick={() => onClick(config.question)}
         className="group w-full min-w-0 rounded-xl border border-dashed border-border/60 bg-card/40 p-3 text-left transition-colors hover:border-border hover:bg-accent/20"
       >
@@ -128,7 +129,7 @@ function InsightCard({
               Ask the agent to inspect this area directly.
             </div>
           </div>
-          <ArrowRightIcon className="mt-1 h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+          <ArrowRightIcon className="mt-1 size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
         </div>
       </button>
     )
@@ -140,6 +141,7 @@ function InsightCard({
 
   return (
     <button
+      type="button"
       onClick={() => onClick(config.question)}
       className={cn(
         'group w-full min-w-0 rounded-xl border border-border/60 bg-card/50 p-3 text-left transition-[border-color,background-color] hover:border-border hover:bg-accent/20'
@@ -171,7 +173,7 @@ function InsightCard({
       </div>
       <div className="mt-2.5 flex items-center justify-between gap-3 text-xs text-muted-foreground">
         <span className="line-clamp-2">{config.question}</span>
-        <ArrowRightIcon className="h-4 w-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
+        <ArrowRightIcon className="size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
       </div>
     </button>
   )

--- a/components/agents/agent-visualization.tsx
+++ b/components/agents/agent-visualization.tsx
@@ -140,7 +140,7 @@ function sortRows(
 function ChartLoadingSkeleton() {
   return (
     <div className="flex items-center justify-center h-48">
-      <Loader2Icon className="h-5 w-5 animate-spin text-muted-foreground" />
+      <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
     </div>
   )
 }
@@ -343,6 +343,7 @@ function ChartControls({
         {/* Stacked toggle (bar and area) */}
         {(chartType === 'bar' || chartType === 'area') && yKeys.length > 1 && (
           <button
+            type="button"
             onClick={() => onStackedChange(!stacked)}
             className={cn(
               'h-7 px-2 rounded-md border text-xs transition-colors',
@@ -358,6 +359,7 @@ function ChartControls({
         {/* Log scale toggle */}
         {chartType !== 'pie' && (
           <button
+            type="button"
             onClick={() => onLogScaleChange(!logScale)}
             className={cn(
               'h-7 px-2 rounded-md border text-xs transition-colors',
@@ -379,6 +381,7 @@ function ChartControls({
               const isRight = rightAxisKeys.has(col)
               return (
                 <button
+                  type="button"
                   key={col}
                   onClick={() => {
                     const next = new Set(rightAxisKeys)
@@ -767,7 +770,7 @@ export function AgentVisualization({
     >
       {/* Header */}
       <div className="flex flex-wrap items-center gap-2 px-3 py-2 border-b">
-        <BarChart3Icon className="h-4 w-4 text-muted-foreground shrink-0" />
+        <BarChart3Icon className="size-4 text-muted-foreground shrink-0" />
         {title && (
           <span className="text-sm font-semibold truncate max-w-[200px]">
             {title}
@@ -801,12 +804,12 @@ export function AgentVisualization({
           <Button
             variant="ghost"
             size="icon"
-            className="h-7 w-7"
+            className="size-7"
             onClick={handleDownload}
             title="Download CSV"
             disabled={!hasData}
           >
-            <DownloadIcon className="h-3.5 w-3.5" />
+            <DownloadIcon className="size-3.5" />
           </Button>
         </div>
       </div>

--- a/components/agents/ask-user-widget.tsx
+++ b/components/agents/ask-user-widget.tsx
@@ -83,7 +83,7 @@ export function AskUserWidget({
     return (
       <div className="my-2 rounded-lg border border-green-200 bg-green-50 px-4 py-3 dark:border-green-900 dark:bg-green-950/30">
         <div className="flex items-center gap-2 text-sm text-green-700 dark:text-green-400">
-          <CheckIcon className="h-4 w-4" />
+          <CheckIcon className="size-4" />
           <span>Response submitted</span>
         </div>
       </div>
@@ -94,7 +94,7 @@ export function AskUserWidget({
     <div className="my-2 rounded-lg border border-blue-200 bg-blue-50/50 px-4 py-3 dark:border-blue-900 dark:bg-blue-950/20">
       {/* Question header */}
       <div className="flex items-start gap-2 mb-3">
-        <MessageCircleQuestionIcon className="h-4 w-4 mt-0.5 text-blue-600 dark:text-blue-400 shrink-0" />
+        <MessageCircleQuestionIcon className="size-4 mt-0.5 text-blue-600 dark:text-blue-400 shrink-0" />
         <div>
           {output.context && (
             <p className="text-xs text-muted-foreground mb-1">
@@ -110,6 +110,7 @@ export function AskUserWidget({
         <div className="space-y-1.5 mb-3">
           {safeOptions.map((opt) => (
             <button
+              type="button"
               key={opt.value}
               onClick={() => setSelectedValue(opt.value)}
               className={cn(
@@ -128,7 +129,7 @@ export function AskUserWidget({
                 )}
               >
                 {selectedValue === opt.value && (
-                  <div className="h-2 w-2 rounded-full bg-blue-500" />
+                  <div className="size-2 rounded-full bg-blue-500" />
                 )}
               </div>
               <div>
@@ -246,6 +247,7 @@ export function AskUserWidget({
             {Array.from({ length: ratingSpan }, (_, i) => i + ratingMin).map(
               (n) => (
                 <button
+                  type="button"
                   key={n}
                   onClick={() => setRatingValue(n)}
                   className={cn(
@@ -256,7 +258,7 @@ export function AskUserWidget({
                   )}
                 >
                   <StarIcon
-                    className="h-6 w-6"
+                    className="size-6"
                     fill={ratingValue >= n ? 'currentColor' : 'none'}
                   />
                 </button>

--- a/components/agents/chat/message-details-dialog.tsx
+++ b/components/agents/chat/message-details-dialog.tsx
@@ -138,7 +138,7 @@ export function MessageDetailsDialog({
           size="sm"
           className="h-7 gap-1.5 rounded-full px-2.5 text-[11px] text-muted-foreground transition-[transform,background-color,color] hover:text-foreground active:scale-[0.96]"
         >
-          <BarChart3Icon className="h-3.5 w-3.5" />
+          <BarChart3Icon className="size-3.5" />
           Details
         </Button>
       </DialogTrigger>
@@ -289,7 +289,7 @@ export function MessageDetailsDialog({
                   onClick={handleCopy}
                   className="h-7 gap-1.5 rounded-full px-2.5 text-xs transition-[transform,background-color] active:scale-[0.96]"
                 >
-                  <CopyIcon className="h-3.5 w-3.5" />
+                  <CopyIcon className="size-3.5" />
                   {copied ? 'Copied' : 'Copy'}
                 </Button>
               </div>

--- a/components/agents/chat/message-details-dialog.tsx
+++ b/components/agents/chat/message-details-dialog.tsx
@@ -20,20 +20,23 @@ import {
 import { getAgentMessageMetadata } from '@/lib/ai/agent/message-metadata'
 import { cn, formatDuration } from '@/lib/utils'
 
+const NUMBER_FORMAT = new Intl.NumberFormat('en-US')
+const CURRENCY_FORMAT = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 6,
+})
+
 function formatNumber(value: number | undefined): string {
   if (typeof value !== 'number' || !Number.isFinite(value)) return '-'
-  return new Intl.NumberFormat('en-US').format(value)
+  return NUMBER_FORMAT.format(value)
 }
 
 function formatCost(value: number | null | undefined): string {
   if (typeof value !== 'number' || !Number.isFinite(value)) return '-'
   if (value === 0) return '$0.00'
   if (value < 0.0001) return '<$0.0001'
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    maximumFractionDigits: 6,
-  }).format(value)
+  return CURRENCY_FORMAT.format(value)
 }
 
 function DetailRow({

--- a/components/agents/chat/query-insights-card.tsx
+++ b/components/agents/chat/query-insights-card.tsx
@@ -109,7 +109,7 @@ export function QueryInsightsCard({ insights }: QueryInsightsCardProps) {
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <TrendingUpIcon className="h-4 w-4 text-primary" />
+          <TrendingUpIcon className="size-4 text-primary" />
           <span className="text-sm font-semibold">Query Insights</span>
         </div>
         <Badge variant="outline" className="text-[10px]">

--- a/components/agents/chat/tool-output.tsx
+++ b/components/agents/chat/tool-output.tsx
@@ -194,12 +194,13 @@ function ExpandTableButton({
     <Dialog>
       <DialogTrigger asChild>
         <button
+          type="button"
           className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
           aria-label="Expand table"
           title="Expand table"
           onClick={(event) => event.stopPropagation()}
         >
-          <Maximize2Icon className="h-3 w-3" />
+          <Maximize2Icon className="size-3" />
         </button>
       </DialogTrigger>
       <DialogContent className="flex max-h-[90vh] max-w-[95vw] flex-col">
@@ -425,15 +426,16 @@ export function ToolCallPart({
       >
         <div className="flex w-full items-center transition-colors">
           <button
+            type="button"
             onClick={() => setIsExpanded((previous) => !previous)}
             className="flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 text-left"
             aria-expanded={isExpanded}
           >
             <span className="text-muted-foreground shrink-0">
               {isExpanded ? (
-                <ChevronDownIcon className="h-3 w-3" />
+                <ChevronDownIcon className="size-3" />
               ) : (
-                <ChevronRightIcon className="h-3 w-3" />
+                <ChevronRightIcon className="size-3" />
               )}
             </span>
 
@@ -465,7 +467,7 @@ export function ToolCallPart({
                   variant="outline"
                   className="shrink-0 text-[10px] text-yellow-600"
                 >
-                  Executing...
+                  Executing…
                 </Badge>
               )}
               {hasOutput && (
@@ -490,6 +492,7 @@ export function ToolCallPart({
           {hasOutput && outputRows.length > 0 && outputQueryConfig && (
             <div className="shrink-0 flex items-center gap-1 pr-2">
               <button
+                type="button"
                 className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
                 aria-label="Download CSV"
                 title="Download CSV"
@@ -498,7 +501,7 @@ export function ToolCallPart({
                   downloadCsv(outputRows, `${toolName}-results.csv`)
                 }}
               >
-                <DownloadIcon className="h-3 w-3" />
+                <DownloadIcon className="size-3" />
               </button>
               <ExpandTableButton
                 rows={outputRows}
@@ -511,18 +514,18 @@ export function ToolCallPart({
         {isExpanded ? (
           <div className="bg-background/50">
             {isStreaming ? (
-              <div className="px-2.5 py-2.5">
+              <div className="p-2.5">
                 <div className="flex items-center gap-2">
-                  <Loader2Icon className="h-4 w-4 animate-spin text-yellow-500" />
+                  <Loader2Icon className="size-4 animate-spin text-yellow-500" />
                   <span className="text-xs text-muted-foreground">
-                    Executing {toolName}...
+                    Executing {toolName}…
                   </span>
                 </div>
               </div>
             ) : null}
 
             {hasOutput && part.output != null && !promotedOutput ? (
-              <div className="px-1 py-1">
+              <div className="p-1">
                 {isAskUserOutput(part.output) && onToolResult ? (
                   <AskUserWidget
                     output={part.output}

--- a/components/agents/mentions/autocomplete-popover.tsx
+++ b/components/agents/mentions/autocomplete-popover.tsx
@@ -28,13 +28,13 @@ function ItemIcon({ type }: { type: AutocompleteItem['type'] }) {
   switch (type) {
     case 'table':
     case 'database':
-      return <Database className="h-3.5 w-3.5 shrink-0 text-blue-500" />
+      return <Database className="size-3.5 shrink-0 text-blue-500" />
     case 'resource':
-      return <Terminal className="h-3.5 w-3.5 shrink-0 text-green-500" />
+      return <Terminal className="size-3.5 shrink-0 text-green-500" />
     case 'skill':
-      return <Zap className="h-3.5 w-3.5 shrink-0 text-purple-500" />
+      return <Zap className="size-3.5 shrink-0 text-purple-500" />
     case 'command':
-      return <Slash className="h-3.5 w-3.5 shrink-0 text-orange-500" />
+      return <Slash className="size-3.5 shrink-0 text-orange-500" />
     default:
       return null
   }

--- a/components/agents/mentions/mention-badge.tsx
+++ b/components/agents/mentions/mention-badge.tsx
@@ -37,7 +37,7 @@ export function MentionBadge({ mention, onRemove }: MentionBadgeProps) {
         onClick={() => onRemove(mention.id)}
         className="ml-0.5 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
       >
-        <X className="h-3 w-3" />
+        <X className="size-3" />
       </button>
     </Badge>
   )
@@ -67,7 +67,7 @@ export function SlashCommandBadge({
         onClick={onRemove}
         className="ml-0.5 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
       >
-        <X className="h-3 w-3" />
+        <X className="size-3" />
       </button>
     </Badge>
   )

--- a/components/agents/session-stats.tsx
+++ b/components/agents/session-stats.tsx
@@ -31,7 +31,7 @@ function StatItem({
 }) {
   return (
     <div className="flex items-center gap-2 text-xs">
-      <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+      <Icon className="size-3.5 text-muted-foreground" />
       <span className="text-muted-foreground">{label}:</span>
       <span className="font-medium">{value}</span>
     </div>

--- a/components/agents/skills-tree-dialog.tsx
+++ b/components/agents/skills-tree-dialog.tsx
@@ -228,7 +228,7 @@ function SkillBody({ lines }: { lines: string[] }) {
                   key={`${item}-${itemIndex}`}
                   className="flex gap-2 leading-6"
                 >
-                  <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-primary/70" />
+                  <span className="mt-2 size-1.5 shrink-0 rounded-full bg-primary/70" />
                   <span>{item}</span>
                 </li>
               ))}
@@ -278,15 +278,15 @@ function SkillTreeNodeView({
             aria-expanded={hasChildren ? open : undefined}
             className="flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-muted/30"
           >
-            <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border/60 bg-background text-muted-foreground">
+            <span className="flex size-7 shrink-0 items-center justify-center rounded-full border border-border/60 bg-background text-muted-foreground">
               {hasChildren || hasBody ? (
                 open ? (
-                  <ChevronDownIcon className="h-4 w-4" />
+                  <ChevronDownIcon className="size-4" />
                 ) : (
-                  <ChevronRightIcon className="h-4 w-4" />
+                  <ChevronRightIcon className="size-4" />
                 )
               ) : (
-                <FileCode2Icon className="h-4 w-4" />
+                <FileCode2Icon className="size-4" />
               )}
             </span>
             <div className="min-w-0 flex-1">
@@ -304,7 +304,7 @@ function SkillTreeNodeView({
           </button>
 
           {open && (hasBody || hasChildren) ? (
-            <div className="space-y-3 border-t border-border/60 px-3 py-3">
+            <div className="space-y-3 border-t border-border/60 p-3">
               {hasBody ? <SkillBody lines={node.body} /> : null}
               {hasChildren ? (
                 <div className="space-y-3" role="group">
@@ -340,8 +340,8 @@ export function SkillsTreeDialog({
       <DialogContent className="max-h-[90vh] max-w-[min(96vw,64rem)] overflow-hidden border-border/70 p-0">
         <DialogHeader className="border-b border-border/60 bg-muted/20 px-5 py-4 text-left">
           <div className="flex items-start gap-3">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-border/60 bg-background">
-              <BookOpenIcon className="h-4.5 w-4.5 text-foreground" />
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-border/60 bg-background">
+              <BookOpenIcon className="size-4.5 text-foreground" />
             </div>
             <div className="min-w-0 space-y-1">
               <DialogTitle className="truncate text-left text-xl">
@@ -355,7 +355,7 @@ export function SkillsTreeDialog({
           </div>
           <div className="flex items-center gap-2 pt-2 text-xs text-muted-foreground">
             <span className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-background px-2.5 py-1">
-              <ListTreeIcon className="h-3.5 w-3.5" />
+              <ListTreeIcon className="size-3.5" />
               Tree view
             </span>
             <span className="inline-flex items-center rounded-full border border-border/60 bg-background px-2.5 py-1">

--- a/components/agents/welcome/agent-welcome-screen.tsx
+++ b/components/agents/welcome/agent-welcome-screen.tsx
@@ -52,7 +52,7 @@ export function AgentWelcomeScreen({
     <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-6 pt-10 pb-6">
       {/* Greeting */}
       <div className="mb-8 text-center">
-        <div className="mx-auto mb-4 inline-flex h-11 w-11 items-center justify-center rounded-xl bg-foreground/[0.04]">
+        <div className="mx-auto mb-4 inline-flex size-11 items-center justify-center rounded-xl bg-foreground/[0.04]">
           <SparklesIcon
             className="text-foreground/70 size-[18px]"
             strokeWidth={1.8}
@@ -67,7 +67,7 @@ export function AgentWelcomeScreen({
           <span className="text-foreground/80 font-mono text-[12.5px]">
             {clusterName ?? 'unknown'}
           </span>
-          . Ask anything — schemas, queries, performance, health.
+          . Ask anything: schemas, queries, performance, health.
         </p>
       </div>
 

--- a/components/agents/welcome/recommendations-list.tsx
+++ b/components/agents/welcome/recommendations-list.tsx
@@ -46,7 +46,7 @@ export function RecommendationsList({
           Suggested questions
         </h3>
         <p className="text-muted-foreground text-[11.5px]">
-          Pick one to get started — or write your own.
+          Pick one to get started, or write your own.
         </p>
       </div>
 

--- a/components/ai-elements/reasoning.tsx
+++ b/components/ai-elements/reasoning.tsx
@@ -121,7 +121,7 @@ export type ReasoningTriggerProps = ComponentProps<
 
 const defaultGetThinkingMessage = (isStreaming: boolean, duration?: number) => {
   if (isStreaming || duration === 0) {
-    return <Shimmer duration={1}>Thinking...</Shimmer>
+    return <Shimmer duration={1}>Thinking…</Shimmer>
   }
   if (duration === undefined) {
     return <p>Thought for a few seconds</p>

--- a/components/ai-elements/sources.tsx
+++ b/components/ai-elements/sources.tsx
@@ -37,7 +37,7 @@ export const SourcesTrigger = ({
     {children ?? (
       <>
         <p className="font-medium">Used {count} sources</p>
-        <ChevronDownIcon className="h-4 w-4" />
+        <ChevronDownIcon className="size-4" />
       </>
     )}
   </CollapsibleTrigger>
@@ -71,7 +71,7 @@ export const Source = ({ href, title, children, ...props }: SourceProps) => (
   >
     {children ?? (
       <>
-        <BookIcon className="h-4 w-4" />
+        <BookIcon className="size-4" />
         <span className="block font-medium">{title}</span>
       </>
     )}

--- a/components/ai-elements/web-preview.tsx
+++ b/components/ai-elements/web-preview.tsx
@@ -109,7 +109,7 @@ export const WebPreviewNavigationButton = ({
     <Tooltip>
       <TooltipTrigger asChild>
         <Button
-          className="h-8 w-8 p-0 hover:text-foreground"
+          className="size-8 p-0 hover:text-foreground"
           disabled={disabled}
           onClick={onClick}
           size="sm"

--- a/components/cards/card-toolbar.tsx
+++ b/components/cards/card-toolbar.tsx
@@ -109,6 +109,7 @@ function CopyableValue({
 
   return (
     <button
+      type="button"
       onClick={handleCopy}
       className={cn(
         'font-mono font-medium text-right truncate min-w-0 hover:text-primary cursor-pointer transition-colors inline-flex items-center gap-1 group/copy',
@@ -273,6 +274,7 @@ export const CardToolbar = memo(function CardToolbar({
                       </dt>
                       <dd className="min-w-0 flex-1 text-right">
                         <button
+                          type="button"
                           onClick={() => handleCopy(fullApiUrl)}
                           className="font-mono text-xs text-right truncate max-w-full hover:text-primary cursor-pointer transition-colors inline-flex items-center gap-1.5 group/copy"
                           title={`Click to copy: ${fullApiUrl}`}

--- a/components/charts/chart-empty.tsx
+++ b/components/charts/chart-empty.tsx
@@ -178,7 +178,7 @@ export const ChartEmpty = memo(function ChartEmpty({
             onClick={onRetry}
             className="mt-3 gap-1.5 text-xs interactive-element"
           >
-            <RefreshCw className="h-3 w-3" />
+            <RefreshCw className="size-3" />
             Refresh data
           </Button>
         )}

--- a/components/charts/chart-error.tsx
+++ b/components/charts/chart-error.tsx
@@ -135,7 +135,7 @@ ${error.stack}
                   label: 'Retry',
                   onClick: onRetry,
                   icon: (
-                    <RefreshCw className="mr-1.5 h-3.5 w-3.5 animate-spin-slow" />
+                    <RefreshCw className="mr-1.5 size-3.5 animate-spin-slow" />
                   ),
                 }
               : undefined
@@ -154,7 +154,7 @@ ${error.stack}
               onClick={() => setDetailsOpen(true)}
               className="h-7 px-2.5 text-xs rounded-full hover:bg-destructive/10 hover:text-destructive hover:border-destructive/30 transition-all"
             >
-              <Info className="h-3 w-3 mr-1 shrink-0" />
+              <Info className="size-3 mr-1 shrink-0" />
               Diagnostics
             </Button>
           </div>
@@ -165,7 +165,7 @@ ${error.stack}
           <DialogContent className="max-w-2xl max-h-[85vh] flex flex-col p-6 rounded-xl border border-border/80 shadow-2xl backdrop-blur-xl">
             <DialogHeader className="shrink-0 pb-2">
               <DialogTitle className="flex items-center gap-2 text-lg font-semibold text-destructive dark:text-red-400">
-                <AlertCircle className="h-5 w-5 shrink-0" />
+                <AlertCircle className="size-5 shrink-0" />
                 {title}
               </DialogTitle>
               <DialogDescription className="text-sm text-muted-foreground/90 mt-1">
@@ -195,7 +195,7 @@ ${error.stack}
                           }
                         }}
                       >
-                        <Copy className="h-3 w-3" />
+                        <Copy className="size-3" />
                         Copy SQL
                       </Button>
                     </div>
@@ -273,7 +273,7 @@ ${error.stack}
                           rel="noopener noreferrer"
                           className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline font-medium"
                         >
-                          <ExternalLink className="h-3 w-3" />
+                          <ExternalLink className="size-3" />
                           View ClickHouse docs
                         </a>
                       )}
@@ -333,7 +333,7 @@ ${error.stack}
                   onClick={handleCopyError}
                   className="text-xs h-8 gap-1.5"
                 >
-                  <Copy className="h-3.5 w-3.5" />
+                  <Copy className="size-3.5" />
                   Copy Diagnostics MD
                 </Button>
                 <Button
@@ -342,7 +342,7 @@ ${error.stack}
                   onClick={handleAskAI}
                   className="text-xs h-8 gap-1.5"
                 >
-                  <BotMessageSquare className="h-3.5 w-3.5" />
+                  <BotMessageSquare className="size-3.5" />
                   Ask AI to fix
                 </Button>
               </div>

--- a/components/charts/chart-scale-context.tsx
+++ b/components/charts/chart-scale-context.tsx
@@ -2,7 +2,7 @@
 
 import type { YAxisScale } from '@/types/charts'
 
-import { createContext, useContext, useEffect, useState } from 'react'
+import { createContext, use, useEffect, useState } from 'react'
 
 const LOCAL_STORAGE_KEY = 'chart-log-scale-preference'
 
@@ -101,7 +101,7 @@ export function ChartScaleProvider({
  * Returns null if not within a ChartScaleProvider
  */
 export function useChartScale(): ChartScaleContextValue | null {
-  return useContext(ChartScaleContext)
+  return use(ChartScaleContext)
 }
 
 /**
@@ -109,6 +109,6 @@ export function useChartScale(): ChartScaleContextValue | null {
  * Falls back to 'auto' if not in a provider
  */
 export function useChartScaleValue(): YAxisScale {
-  const context = useContext(ChartScaleContext)
+  const context = use(ChartScaleContext)
   return context?.scale ?? 'auto'
 }

--- a/components/charts/chart-zoom-dialog.tsx
+++ b/components/charts/chart-zoom-dialog.tsx
@@ -89,6 +89,7 @@ function CopyableValue({
     <Tooltip>
       <TooltipTrigger asChild>
         <button
+          type="button"
           onClick={handleCopy}
           className={cn(
             'font-mono font-medium text-right truncate min-w-0 hover:text-primary cursor-pointer transition-colors inline-flex items-center gap-1 group/copy',

--- a/components/charts/primitives/area.cy.tsx
+++ b/components/charts/primitives/area.cy.tsx
@@ -39,7 +39,7 @@ describe('<AreaChart />', () => {
     cy.screenshot()
 
     // Render as svg
-    cy.get('svg:first').as('chart').should('be.visible')
+    cy.get('.recharts-surface').first().as('chart').should('be.visible')
 
     // Contains legend
     cy.get('.recharts-legend-wrapper').as('legend').should('be.visible')
@@ -63,7 +63,7 @@ describe('<AreaChart />', () => {
     cy.screenshot()
 
     // Render as svg
-    cy.get('svg:first').as('chart').should('be.visible')
+    cy.get('.recharts-surface').first().as('chart').should('be.visible')
 
     // Contains legend
     cy.get('.recharts-legend-wrapper').as('legend').should('be.visible')
@@ -94,7 +94,7 @@ describe('<AreaChart />', () => {
     cy.screenshot()
 
     // Render as svg
-    cy.get('svg:first').as('chart').should('be.visible')
+    cy.get('.recharts-surface').first().as('chart').should('be.visible')
 
     // Display data from readable_A instead of A
     // cy.get('@chart')
@@ -122,7 +122,7 @@ describe('<AreaChart />', () => {
     cy.screenshot()
 
     // Render as svg
-    cy.get('svg:first').as('chart').should('be.visible')
+    cy.get('.recharts-surface').first().as('chart').should('be.visible')
 
     // Show legend
     cy.get('.recharts-legend-wrapper').should('be.visible')
@@ -141,7 +141,7 @@ describe('<AreaChart />', () => {
     cy.screenshot()
 
     // Render as svg
-    cy.get('svg:first').as('chart').should('be.visible')
+    cy.get('.recharts-surface').first().as('chart').should('be.visible')
 
     // Should have sticks (do not have start, end)
     cy.get('.recharts-cartesian-axis-tick').should(
@@ -163,7 +163,7 @@ describe('<AreaChart />', () => {
     cy.screenshot()
 
     // Render as svg
-    cy.get('svg:first').as('chart').should('be.visible')
+    cy.get('.recharts-surface').first().as('chart').should('be.visible')
     cy.get('.recharts-area').should('have.length', 2)
   })
 
@@ -176,7 +176,7 @@ describe('<AreaChart />', () => {
     cy.screenshot()
 
     // Render as svg
-    cy.get('svg:first').as('chart').should('be.visible')
+    cy.get('.recharts-surface').first().as('chart').should('be.visible')
 
     // Single circle data point
     cy.get('.recharts-area-dots circle').should('have.length', 1)
@@ -207,7 +207,7 @@ describe('<AreaChart />', () => {
     cy.screenshot()
 
     // Render as svg
-    cy.get('svg:first').as('chart').should('be.visible')
+    cy.get('.recharts-surface').first().as('chart').should('be.visible')
 
     // Should have two layer
     cy.get('.recharts-area').should('have.length', 2)
@@ -269,7 +269,7 @@ describe('<AreaChart />', () => {
     cy.screenshot()
 
     // Render as svg
-    cy.get('svg:first').as('chart').should('be.visible')
+    cy.get('.recharts-surface').first().as('chart').should('be.visible')
 
     // Hover to show tooltip
     cy.get('.recharts-area-area').realHover()
@@ -301,7 +301,7 @@ describe('<AreaChart />', () => {
     cy.screenshot()
 
     // Render as svg
-    cy.get('svg:first').as('chart').should('be.visible')
+    cy.get('.recharts-surface').first().as('chart').should('be.visible')
 
     // Hover to show tooltip
     cy.get('.recharts-area-area').realHover()
@@ -333,7 +333,7 @@ describe('<AreaChart />', () => {
     )
     cy.screenshot()
 
-    cy.get('svg:first').as('chart').should('be.visible')
+    cy.get('.recharts-surface').first().as('chart').should('be.visible')
 
     // Hover to show tooltip
     cy.get('.recharts-area-area').realHover()

--- a/components/charts/primitives/bar-tooltip.tsx
+++ b/components/charts/primitives/bar-tooltip.tsx
@@ -55,7 +55,7 @@ export function renderBarTooltip({
             formatter={(value, name, item, index) => (
               <>
                 <div
-                  className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+                  className="size-2.5 shrink-0 rounded-[2px]"
                   style={{ backgroundColor: item.color }}
                 />
                 <span className="text-muted-foreground">
@@ -98,7 +98,7 @@ export function renderBarTooltip({
           formatter={(value, name, item) => (
             <>
               <div
-                className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+                className="size-2.5 shrink-0 rounded-[2px]"
                 style={{ backgroundColor: item.color }}
               />
               <span className="text-muted-foreground">

--- a/components/charts/query/query-count-heatmap.tsx
+++ b/components/charts/query/query-count-heatmap.tsx
@@ -488,7 +488,7 @@ function HeatmapBody({
 
   return (
     <TooltipProvider delayDuration={0}>
-      <div className="flex flex-col gap-3 px-1 py-1">
+      <div className="flex flex-col gap-3 p-1">
         {/* KPI strip */}
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
           <KpiCard

--- a/components/charts/zookeeper/zookeeper-uptime.tsx
+++ b/components/charts/zookeeper/zookeeper-uptime.tsx
@@ -42,7 +42,7 @@ export const ChartZookeeperUptime = memo(function ChartZookeeperUptime({
               <CardMultiMetrics
                 primary={
                   <span className="flex flex-row items-center gap-2">
-                    <ArrowUpIcon className="h-6 w-6" />
+                    <ArrowUpIcon className="size-6" />
                     {uptime.uptime}
                   </span>
                 }

--- a/components/connections/connection-form.tsx
+++ b/components/connections/connection-form.tsx
@@ -141,7 +141,7 @@ export function ConnectionForm({
           Host URL
         </Label>
         <div className="relative">
-          <Globe className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+          <Globe className="absolute left-2.5 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
           <Input
             id="conn-host"
             placeholder="https://clickhouse.example.com:8123"
@@ -195,9 +195,9 @@ export function ConnectionForm({
             aria-label={showPassword ? 'Hide password' : 'Show password'}
           >
             {showPassword ? (
-              <EyeOff className="h-4 w-4" />
+              <EyeOff className="size-4" />
             ) : (
-              <Eye className="h-4 w-4" />
+              <Eye className="size-4" />
             )}
           </button>
         </div>
@@ -218,20 +218,20 @@ export function ConnectionForm({
           disabled={!valid || testStatus.state === 'loading'}
         >
           {testStatus.state === 'loading' ? (
-            <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+            <Loader2 className="size-3.5 mr-1.5 animate-spin" />
           ) : null}
           Test Connection
         </Button>
 
         {testStatus.state === 'success' && (
           <span className="flex items-center gap-1.5 text-xs text-emerald-600 dark:text-emerald-400">
-            <Check className="h-3.5 w-3.5" />
+            <Check className="size-3.5" />
             {testStatus.message}
           </span>
         )}
         {testStatus.state === 'error' && (
           <span className="flex items-center gap-1.5 text-xs text-destructive">
-            <X className="h-3.5 w-3.5" />
+            <X className="size-3.5" />
             {testStatus.message}
           </span>
         )}

--- a/components/connections/connection-manager-dialog.tsx
+++ b/components/connections/connection-manager-dialog.tsx
@@ -105,7 +105,7 @@ export function ConnectionManagerDialog({
           <div className="space-y-3">
             {connections.length === 0 ? (
               <div className="flex flex-col items-center justify-center gap-3 py-8 text-center text-muted-foreground">
-                <Plug className="h-8 w-8 opacity-40" />
+                <Plug className="size-8 opacity-40" />
                 <p className="text-sm">No connections yet</p>
               </div>
             ) : (
@@ -167,22 +167,22 @@ export function ConnectionManagerDialog({
                             <Button
                               variant="ghost"
                               size="icon"
-                              className="h-7 w-7"
+                              className="size-7"
                               aria-label="Edit connection"
                               onClick={() =>
                                 setView({ type: 'form', editing: conn })
                               }
                             >
-                              <Pencil className="h-3.5 w-3.5" />
+                              <Pencil className="size-3.5" />
                             </Button>
                             <Button
                               variant="ghost"
                               size="icon"
-                              className="h-7 w-7 text-destructive hover:text-destructive"
+                              className="size-7 text-destructive hover:text-destructive"
                               aria-label="Delete connection"
                               onClick={() => setConfirmDeleteId(conn.id)}
                             >
-                              <Trash2 className="h-3.5 w-3.5" />
+                              <Trash2 className="size-3.5" />
                             </Button>
                           </>
                         )}
@@ -195,7 +195,7 @@ export function ConnectionManagerDialog({
 
             <div className="flex justify-end pt-1">
               <Button size="sm" onClick={() => setView({ type: 'form' })}>
-                <Plus className="h-4 w-4 mr-1.5" />
+                <Plus className="size-4 mr-1.5" />
                 Add Connection
               </Button>
             </div>

--- a/components/controls/command-palette.tsx
+++ b/components/controls/command-palette.tsx
@@ -111,7 +111,7 @@ export const CommandPalette = memo(function CommandPalette({
     <>
       {/* Search icon button for small screens */}
       <IconButton
-        icon={<Search className="h-4 w-4" />}
+        icon={<Search className="size-4" />}
         onClick={() => setOpen(true)}
         tooltip="Search"
         className="md:hidden"
@@ -127,9 +127,9 @@ export const CommandPalette = memo(function CommandPalette({
       >
         <Search
           aria-hidden="true"
-          className="h-3.5 w-3.5 text-muted-foreground/60"
+          className="size-3.5 text-muted-foreground/60"
         />
-        <span className="text-muted-foreground/60">Search...</span>
+        <span className="text-muted-foreground/60">Search…</span>
         <kbd
           id="search-shortcut"
           className="ml-auto rounded border bg-muted px-1.5 text-[10px] font-medium"
@@ -163,7 +163,7 @@ export const CommandPalette = memo(function CommandPalette({
                     onSelect={handleGoToQuery}
                     value={`query-id-${inputValue}`}
                   >
-                    <TextSearch className="mr-2 h-4 w-4" />
+                    <TextSearch className="mr-2 size-4" />
                     <span>Go to query: </span>
                     <span className="ml-1 font-mono text-xs text-muted-foreground truncate">
                       {inputValue.trim()}
@@ -175,7 +175,7 @@ export const CommandPalette = memo(function CommandPalette({
                     onSelect={handleOpenInExplorer}
                     value={`explorer-${inputValue}`}
                   >
-                    <Table className="mr-2 h-4 w-4" />
+                    <Table className="mr-2 size-4" />
                     <span>Open in explorer: </span>
                     <span className="ml-1 font-mono text-xs text-muted-foreground">
                       {inputValue.trim()}
@@ -200,7 +200,7 @@ export const CommandPalette = memo(function CommandPalette({
                     className="flex-col items-start gap-0.5"
                   >
                     <div className="flex w-full items-center gap-2">
-                      {item.icon && <item.icon className="h-4 w-4 shrink-0" />}
+                      {item.icon && <item.icon className="size-4 shrink-0" />}
                       <span className="font-medium">{item.title}</span>
                     </div>
                     {item.description && (
@@ -216,7 +216,7 @@ export const CommandPalette = memo(function CommandPalette({
                   onSelect={() => navigate(group.href)}
                   value={group.title}
                 >
-                  {group.icon && <group.icon className="mr-2 h-4 w-4" />}
+                  {group.icon && <group.icon className="mr-2 size-4" />}
                   <span>{group.title}</span>
                 </CommandItem>
               )}
@@ -228,7 +228,7 @@ export const CommandPalette = memo(function CommandPalette({
               <CommandSeparator />
               <CommandGroup heading="Actions">
                 <CommandItem onSelect={handleOpenSettings} value="Settings">
-                  <Settings className="mr-2 h-4 w-4" />
+                  <Settings className="mr-2 size-4" />
                   <span>Settings</span>
                   <span className="ml-auto text-xs text-muted-foreground">
                     ⌘,

--- a/components/dashboard/chart-params.cy.tsx
+++ b/components/dashboard/chart-params.cy.tsx
@@ -107,7 +107,7 @@ describe('<ChartParams />', () => {
       cy.get('input[name="interval"]').clear().type('600')
       cy.contains('button', 'Update').click()
 
-      cy.contains('Updating...').should('be.visible')
+      cy.contains('Updating…').should('be.visible')
       cy.wait('@updateSettings')
       cy.get('@routerRefresh').should('have.been.calledOnce')
       cy.contains('button', 'Update').should('be.visible')
@@ -149,7 +149,7 @@ describe('<ChartParams />', () => {
       cy.contains('button', 'Update').click()
 
       cy.get('.animate-spin').should('be.visible')
-      cy.contains('Updating...').should('be.visible')
+      cy.contains('Updating…').should('be.visible')
     })
   })
 
@@ -202,7 +202,7 @@ describe('<ChartParams />', () => {
       }).as('updateSettingsSuccess')
 
       cy.contains('button', 'Update (error)').click()
-      cy.contains('Updating...').should('be.visible')
+      cy.contains('Updating…').should('be.visible')
       cy.wait('@updateSettingsSuccess')
 
       cy.contains('(error)').should('not.exist')
@@ -335,7 +335,7 @@ describe('<ChartParams />', () => {
 
       cy.contains('button', 'Update').click()
 
-      cy.contains('button', 'Updating...').should('be.disabled')
+      cy.contains('button', 'Updating…').should('be.disabled')
     })
 
     it('shows Update icon in button during loading', () => {

--- a/components/dashboard/chart-params.tsx
+++ b/components/dashboard/chart-params.tsx
@@ -89,7 +89,7 @@ export const ChartParamsForm = ({
           {form.formState.isSubmitting ? (
             <span className="flex-rows flex gap-2">
               <UpdateIcon className="mr-2 size-3 animate-spin" />
-              Updating...
+              Updating…
             </span>
           ) : (
             'Update'

--- a/components/dashboard/chart-picker.tsx
+++ b/components/dashboard/chart-picker.tsx
@@ -100,7 +100,7 @@ export function ChartPicker({ selectedCharts, onChange }: ChartPickerProps) {
                       {checked && (
                         <svg
                           viewBox="0 0 10 10"
-                          className="h-2.5 w-2.5"
+                          className="size-2.5"
                           fill="currentColor"
                         >
                           <path

--- a/components/dashboard/render-chart.cy.tsx
+++ b/components/dashboard/render-chart.cy.tsx
@@ -20,6 +20,8 @@ describe('<RenderChart />', () => {
     hostId: 0,
   }
 
+  const chartRegion = () => cy.get('[aria-label="Test Chart chart"]')
+
   beforeEach(() => {
     // Mock the useFetchData hook by intercepting the API call
     cy.intercept('POST', '/api/v1/data', {
@@ -41,7 +43,7 @@ describe('<RenderChart />', () => {
       cy.contains('Test Chart').should('be.visible')
 
       // Should render SVG chart
-      cy.get('svg').should('be.visible')
+      chartRegion().find('.recharts-surface').should('be.visible')
 
       // Should have area chart elements
       cy.get('.recharts-area').should('have.length', 2) // value1 and value2
@@ -56,7 +58,7 @@ describe('<RenderChart />', () => {
 
       cy.wait('@fetchData')
 
-      cy.get('svg').should('be.visible')
+      chartRegion().find('.recharts-surface').should('be.visible')
       cy.get('.recharts-area').should('have.length', 2)
     })
 
@@ -69,7 +71,7 @@ describe('<RenderChart />', () => {
 
       cy.wait('@fetchData')
 
-      cy.get('svg').should('be.visible')
+      chartRegion().find('.recharts-surface').should('be.visible')
     })
   })
 
@@ -83,7 +85,7 @@ describe('<RenderChart />', () => {
       cy.contains('Test Chart').should('be.visible')
 
       // Should render SVG chart
-      cy.get('svg').should('be.visible')
+      chartRegion().find('.recharts-surface').should('be.visible')
 
       // Should have bar chart elements
       cy.get('.recharts-bar').should('exist')
@@ -98,7 +100,7 @@ describe('<RenderChart />', () => {
 
       cy.wait('@fetchData')
 
-      cy.get('svg').should('be.visible')
+      chartRegion().find('.recharts-surface').should('be.visible')
       cy.get('.recharts-bar').should('exist')
     })
   })
@@ -127,7 +129,7 @@ describe('<RenderChart />', () => {
       cy.contains('Test Chart').should('be.visible')
 
       // Should render SVG chart
-      cy.get('svg').should('be.visible')
+      chartRegion().find('svg').should('be.visible')
     })
 
     it('renders calendar chart with custom colors', () => {
@@ -139,7 +141,7 @@ describe('<RenderChart />', () => {
 
       cy.wait('@fetchData')
 
-      cy.get('svg').should('be.visible')
+      chartRegion().find('.recharts-surface').should('be.visible')
     })
   })
 
@@ -220,7 +222,7 @@ describe('<RenderChart />', () => {
       cy.wait('@fetchDataSlow')
 
       // After data loads, skeleton should be gone
-      cy.get('svg').should('be.visible')
+      chartRegion().find('.recharts-surface').should('be.visible')
     })
   })
 
@@ -276,7 +278,7 @@ describe('<RenderChart />', () => {
       cy.wait('@fetchData')
 
       // Should render chart
-      cy.get('svg').should('be.visible')
+      chartRegion().find('.recharts-surface').should('be.visible')
     })
   })
 

--- a/components/data-table/buttons/column-header-dropdown.tsx
+++ b/components/data-table/buttons/column-header-dropdown.tsx
@@ -94,13 +94,13 @@ export const ColumnHeaderDropdown = memo(function ColumnHeaderDropdown({
         {canSort && (
           <>
             <DropdownMenuItem onClick={handleSortAsc}>
-              <SortAscIcon className="mr-2 h-3.5 w-3.5" />A → Z
+              <SortAscIcon className="mr-2 size-3.5" />A → Z
               {column.getIsSorted() === 'asc' && (
                 <span className="ml-auto text-xs">✓</span>
               )}
             </DropdownMenuItem>
             <DropdownMenuItem onClick={handleSortDesc}>
-              <SortDescIcon className="mr-2 h-3.5 w-3.5" />Z → A
+              <SortDescIcon className="mr-2 size-3.5" />Z → A
               {column.getIsSorted() === 'desc' && (
                 <span className="ml-auto text-xs">✓</span>
               )}
@@ -109,12 +109,12 @@ export const ColumnHeaderDropdown = memo(function ColumnHeaderDropdown({
         )}
         {(canSort || column.getIsSorted()) && (
           <DropdownMenuItem onClick={handleResetSort}>
-            <RotateCcwIcon className="mr-2 h-3.5 w-3.5" />
+            <RotateCcwIcon className="mr-2 size-3.5" />
             Reset sort
           </DropdownMenuItem>
         )}
         <DropdownMenuItem onClick={handleCopy}>
-          <CopyIcon className="mr-2 h-3.5 w-3.5" />
+          <CopyIcon className="mr-2 size-3.5" />
           {copied ? 'Copied!' : 'Copy name'}
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/components/data-table/cells/running-query-expanded-details.tsx
+++ b/components/data-table/cells/running-query-expanded-details.tsx
@@ -157,7 +157,7 @@ export const RunningQueryExpandedDetails = memo(
     return (
       <div
         data-slot="running-query-expanded"
-        className="border-t border-border/60 bg-muted/20 px-4 py-4"
+        className="border-t border-border/60 bg-muted/20 p-4"
       >
         <div className="flex flex-wrap items-center gap-1.5 pb-3">
           {queryKind && (

--- a/components/data-table/column-filter.tsx
+++ b/components/data-table/column-filter.tsx
@@ -64,7 +64,7 @@ export const ColumnFilter = memo(function ColumnFilter({
     >
       <div className="relative flex-1">
         <Search
-          className="absolute left-1.5 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground/50"
+          className="absolute left-1.5 top-1/2 -translate-y-1/2 size-3 text-muted-foreground/50"
           aria-hidden="true"
         />
         <DebouncedInput
@@ -92,11 +92,11 @@ export const ColumnFilter = memo(function ColumnFilter({
         <Button
           variant="ghost"
           size="sm"
-          className="h-7 w-7 p-0 hover:bg-muted/60"
+          className="size-7 p-0 hover:bg-muted/60"
           onClick={handleClear}
           aria-label={`Clear ${column} filter`}
         >
-          <X className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
+          <X className="size-3 text-muted-foreground" aria-hidden="true" />
         </Button>
       )}
     </div>

--- a/components/data-table/components/data-table-footer.tsx
+++ b/components/data-table/components/data-table-footer.tsx
@@ -53,27 +53,27 @@ export const DataTableFooter = memo(function DataTableFooter<
     const hasMultiplePages = canPrev || canNext
 
     return (
-      <div className="flex shrink-0 items-center justify-between px-1 py-1 text-xs text-muted-foreground">
+      <div className="flex shrink-0 items-center justify-between p-1 text-xs text-muted-foreground">
         <span>{formatNumber(totalRows)} rows</span>
         {hasMultiplePages && (
           <div className="flex items-center gap-0.5">
             <Button
               variant="ghost"
               size="icon"
-              className="h-6 w-6"
+              className="size-6"
               onClick={() => table.previousPage()}
               disabled={!canPrev}
             >
-              <ChevronLeftIcon className="h-3 w-3" />
+              <ChevronLeftIcon className="size-3" />
             </Button>
             <Button
               variant="ghost"
               size="icon"
-              className="h-6 w-6"
+              className="size-6"
               onClick={() => table.nextPage()}
               disabled={!canNext}
             >
-              <ChevronRightIcon className="h-3 w-3" />
+              <ChevronRightIcon className="size-3" />
             </Button>
           </div>
         )}

--- a/components/data-table/components/mobile-table-cards.tsx
+++ b/components/data-table/components/mobile-table-cards.tsx
@@ -194,7 +194,7 @@ const MobileTableCard = memo(function MobileTableCard<TData extends RowData>({
             onClick={() => row.toggleExpanded()}
             aria-expanded={isExpanded}
             aria-label={isExpanded ? 'Collapse row' : 'Expand row'}
-            className="-ml-1 mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            className="-ml-1 mt-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted/60 hover:text-foreground"
             data-testid="mobile-table-card-expand"
           >
             <ExpandIcon className="size-4" />
@@ -299,7 +299,7 @@ export const MobileTableCards = memo(function MobileTableCards<
         <Empty className="min-h-48 border-0 p-4">
           <EmptyHeader>
             <EmptyMedia variant="icon">
-              <SearchX className="h-5 w-5" />
+              <SearchX className="size-5" />
             </EmptyMedia>
             <EmptyTitle>No results</EmptyTitle>
             <EmptyDescription>

--- a/components/data-table/context/table-density-context.tsx
+++ b/components/data-table/context/table-density-context.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext } from 'react'
+import { createContext, use } from 'react'
 
 interface TableDensityContextValue {
   /** CSS classes applied to each table cell for density control */
@@ -14,5 +14,5 @@ const TableDensityContext = createContext<TableDensityContextValue>({
 export const TableDensityProvider = TableDensityContext.Provider
 
 export function useTableDensityContext(): TableDensityContextValue {
-  return useContext(TableDensityContext)
+  return use(TableDensityContext)
 }

--- a/components/data-table/data-table-faceted-filter.tsx
+++ b/components/data-table/data-table-faceted-filter.tsx
@@ -53,7 +53,7 @@ export function DataTableFacetedFilter({
           data-is-activate={selectedCount > 0}
           className="data-[is-activate=true]:bg-accent"
         >
-          <ListFilterIcon className="mr-2 h-4 w-4" />
+          <ListFilterIcon className="mr-2 size-4" />
           {title}
           {selectedCount > 0 && ` (${selectedCount})`}
         </Button>

--- a/components/data-table/renderers/table-body.tsx
+++ b/components/data-table/renderers/table-body.tsx
@@ -395,7 +395,7 @@ export const TableBodyEmptyState = memo(function TableBodyEmptyState<
         <Empty className="h-full min-h-48 border-0 p-4 md:p-6">
           <EmptyHeader>
             <EmptyMedia variant="icon">
-              <SearchX className="h-5 w-5" />
+              <SearchX className="size-5" />
             </EmptyMedia>
             <EmptyTitle>No results</EmptyTitle>
             <EmptyDescription>

--- a/components/data-table/renderers/table-header.tsx
+++ b/components/data-table/renderers/table-header.tsx
@@ -162,7 +162,7 @@ function DraggableTableHeader({
           style={{ touchAction: 'none' }}
           onClick={(e) => e.stopPropagation()} // Prevent drag from triggering sort
         >
-          <GripVertical data-icon className="h-3.5 w-3.5" />
+          <GripVertical data-icon className="size-3.5" />
         </Button>
         <div className="min-w-0 flex-1">
           <div className="group flex min-w-0 items-center gap-1">
@@ -277,10 +277,10 @@ export const TableHeaderRow = memo(function TableHeaderRow({
                 <div className="group flex min-w-0 items-center gap-1">
                   {/* Sort indicator */}
                   {isSorted === 'asc' && (
-                    <ArrowUp className="h-3.5 w-3.5 shrink-0 text-primary" />
+                    <ArrowUp className="size-3.5 shrink-0 text-primary" />
                   )}
                   {isSorted === 'desc' && (
-                    <ArrowDown className="h-3.5 w-3.5 shrink-0 text-primary" />
+                    <ArrowDown className="size-3.5 shrink-0 text-primary" />
                   )}
                   <span className="min-w-0 flex-1 truncate">
                     {header.isPlaceholder

--- a/components/dialogs/dialog-sql.tsx
+++ b/components/dialogs/dialog-sql.tsx
@@ -98,6 +98,7 @@ function CopyableValue({
 
   return (
     <button
+      type="button"
       onClick={handleCopy}
       className={cn(
         'font-mono font-medium text-right truncate min-w-0 hover:text-primary cursor-pointer transition-colors inline-flex items-center gap-1 group/copy',

--- a/components/explorer/dependency-graph/dependency-graph.tsx
+++ b/components/explorer/dependency-graph/dependency-graph.tsx
@@ -512,6 +512,7 @@ export function DependencyGraph({
         {/* Layout controls */}
         <Panel position="top-left" className="flex gap-1">
           <button
+            type="button"
             onClick={() => onLayoutChange('TB')}
             className={cn(
               'rounded px-2 py-1 text-xs font-medium transition-colors',
@@ -523,6 +524,7 @@ export function DependencyGraph({
             Vertical
           </button>
           <button
+            type="button"
             onClick={() => onLayoutChange('LR')}
             className={cn(
               'rounded px-2 py-1 text-xs font-medium transition-colors',

--- a/components/feedback/error-alert/error-alert-accordion.tsx
+++ b/components/feedback/error-alert/error-alert-accordion.tsx
@@ -36,7 +36,7 @@ export function ErrorAlertAccordion({
         <AccordionItem className="border-0" value="item-1">
           <AccordionTrigger className="px-0 py-2 text-sm hover:no-underline">
             <div className="flex items-center gap-2">
-              <DatabaseIcon className="h-4 w-4" />
+              <DatabaseIcon className="size-4" />
               {title}
             </div>
           </AccordionTrigger>
@@ -68,7 +68,7 @@ export function ErrorAlertDocs({ docs }: ErrorAlertDocsProps) {
   return (
     <div className="mt-3 border-t pt-3">
       <div className="flex items-start gap-2">
-        <NotebookPenIcon className="text-muted-foreground mt-0.5 h-4 w-4 flex-none" />
+        <NotebookPenIcon className="text-muted-foreground mt-0.5 size-4 flex-none" />
         <div className="text-muted-foreground text-sm">{docs}</div>
       </div>
     </div>
@@ -86,7 +86,7 @@ export function ErrorAlertDigest({ digest }: ErrorAlertDigestProps) {
   return (
     <div className="mt-3 border-t pt-3">
       <div className="flex items-start gap-2">
-        <BugIcon className="text-muted-foreground mt-0.5 h-4 w-4 flexnone" />
+        <BugIcon className="text-muted-foreground mt-0.5 size-4 flexnone" />
         <div className="text-muted-foreground text-xs">
           <div className="font-medium">Error ID (for support):</div>
           <code className="bg-muted/30 mt-1 block rounded px-2 py-1 font-mono">

--- a/components/feedback/error-alert/error-alert-accordion.tsx
+++ b/components/feedback/error-alert/error-alert-accordion.tsx
@@ -86,7 +86,7 @@ export function ErrorAlertDigest({ digest }: ErrorAlertDigestProps) {
   return (
     <div className="mt-3 border-t pt-3">
       <div className="flex items-start gap-2">
-        <BugIcon className="text-muted-foreground mt-0.5 size-4 flexnone" />
+        <BugIcon className="text-muted-foreground mt-0.5 size-4 flex-none" />
         <div className="text-muted-foreground text-xs">
           <div className="font-medium">Error ID (for support):</div>
           <code className="bg-muted/30 mt-1 block rounded px-2 py-1 font-mono">

--- a/components/feedback/error-alert/variants/full.tsx
+++ b/components/feedback/error-alert/variants/full.tsx
@@ -111,7 +111,7 @@ export function FullErrorAlert({
                 onClick={() => reset()}
                 className="flex items-center gap-2"
               >
-                <RefreshCwIcon className="h-4 w-4" />
+                <RefreshCwIcon className="size-4" />
                 Try again {countdown >= 0 && `(${countdown}s)`}
               </Button>
             </div>

--- a/components/feedback/layout-error-boundary.tsx
+++ b/components/feedback/layout-error-boundary.tsx
@@ -15,7 +15,7 @@ function LayoutErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
     <div className="flex min-h-[400px] flex-col items-center justify-center p-8 text-center">
       <div className="flex max-w-md flex-col items-center gap-4">
         <div className="bg-destructive/10 flex size-16 items-center justify-center rounded-full">
-          <AlertTriangleIcon className="text-destructive h-8 w-8" />
+          <AlertTriangleIcon className="text-destructive size-8" />
         </div>
         <div className="space-y-2">
           <h2 className="text-xl font-semibold">Something went wrong</h2>
@@ -25,7 +25,7 @@ function LayoutErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
           </p>
         </div>
         <Button onClick={resetErrorBoundary} className="gap-2">
-          <RefreshCwIcon className="h-4 w-4" />
+          <RefreshCwIcon className="size-4" />
           Try Again
         </Button>
       </div>

--- a/components/feedback/optional-table-info.tsx
+++ b/components/feedback/optional-table-info.tsx
@@ -56,7 +56,7 @@ export function OptionalTableInfo({
         <div className="flex gap-4">
           {/* Icon */}
           <div className="flex-shrink-0">
-            <Info className="h-5 w-5 text-blue-600 dark:text-blue-400 mt-0.5" />
+            <Info className="size-5 text-blue-600 dark:text-blue-400 mt-0.5" />
           </div>
 
           {/* Content */}
@@ -114,7 +114,7 @@ export function OptionalTableInfo({
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-1.5 text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline font-medium"
                   >
-                    <ExternalLink className="h-3.5 w-3.5" />
+                    <ExternalLink className="size-3.5" />
                     View ClickHouse documentation
                   </a>
                 </div>

--- a/components/filters/filter-editor.tsx
+++ b/components/filters/filter-editor.tsx
@@ -372,13 +372,13 @@ function OptionsList({
       <CommandList className="max-h-44">
         {error && (
           <div className="px-2 py-3 text-xs text-amber-600 dark:text-amber-400">
-            Failed to load values — showing cached results
+            Failed to load values: showing cached results
           </div>
         )}
         {isLoading && (
           <div className="flex items-center justify-center gap-2 py-4 text-xs text-muted-foreground">
             <Loader2Icon className="size-3.5 animate-spin" />
-            Loading values...
+            Loading values…
           </div>
         )}
         {!isLoading && <CommandEmpty>No matching values</CommandEmpty>}

--- a/components/header/header-actions.tsx
+++ b/components/header/header-actions.tsx
@@ -67,7 +67,7 @@ export const HeaderActions = memo(function HeaderActions({
         />
       ) : (
         <Button variant="ghost" size="icon" className="inline-flex">
-          <Sun className="h-4 w-4" />
+          <Sun className="size-4" />
         </Button>
       )}
 

--- a/components/header/header-brand.tsx
+++ b/components/header/header-brand.tsx
@@ -27,7 +27,7 @@ export const HeaderBrand = memo(function HeaderBrand({
         <ClickHouseLogo
           width={24}
           height={24}
-          className="h-6 w-6 text-foreground dark:text-white"
+          className="size-6 text-foreground dark:text-white"
         />
       </Link>
 

--- a/components/header/header-nav.tsx
+++ b/components/header/header-nav.tsx
@@ -34,7 +34,7 @@ export const HeaderNav = memo(function HeaderNav({
               isActive ? 'text-foreground' : 'text-muted-foreground'
             )}
           >
-            <item.icon className="h-3.5 w-3.5" />
+            <item.icon className="size-3.5" />
             {item.name}
             {isActive && (
               <span className="absolute bottom-0 left-0 h-[1.5px] w-full bg-primary animate-in fade-in slide-in-from-bottom-1" />

--- a/components/health/health-audit-prompt-dialog.tsx
+++ b/components/health/health-audit-prompt-dialog.tsx
@@ -46,7 +46,7 @@ export function HealthAuditPromptDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-3xl">
         <DialogHeader>
-          <DialogTitle>Audit prompt — {title}</DialogTitle>
+          <DialogTitle>Audit prompt: {title}</DialogTitle>
           <DialogDescription>
             Copy and paste this prompt into any AI/coding agent (Claude,
             ChatGPT, etc.) to get a tailored diagnosis and remediation plan.
@@ -67,9 +67,9 @@ export function HealthAuditPromptDialog({
           </Button>
           <Button onClick={handleCopy}>
             {copied ? (
-              <Check className="mr-2 h-4 w-4" />
+              <Check className="mr-2 size-4" />
             ) : (
-              <Copy className="mr-2 h-4 w-4" />
+              <Copy className="mr-2 size-4" />
             )}
             {copied ? 'Copied' : 'Copy prompt'}
           </Button>

--- a/components/health/health-card.tsx
+++ b/components/health/health-card.tsx
@@ -135,7 +135,7 @@ export function HealthCard({ check, thresholds }: HealthCardProps) {
             aria-label={`Open ${check.title} details`}
             className="ml-auto rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
           >
-            <Maximize2 className="h-3.5 w-3.5" />
+            <Maximize2 className="size-3.5" />
           </button>
         </div>
         <button

--- a/components/health/health-detail-dialog.tsx
+++ b/components/health/health-detail-dialog.tsx
@@ -240,7 +240,7 @@ export function HealthDetailDialog({
                             className="text-primary hover:underline inline-flex items-center gap-1"
                           >
                             {d.label}
-                            <ExternalLink className="h-3 w-3" />
+                            <ExternalLink className="size-3" />
                           </a>
                         </li>
                       ))}
@@ -256,7 +256,7 @@ export function HealthDetailDialog({
               Close
             </Button>
             <Button onClick={() => setPromptOpen(true)}>
-              <Sparkles className="mr-2 h-4 w-4" />
+              <Sparkles className="mr-2 size-4" />
               Generate audit prompt
             </Button>
           </DialogFooter>

--- a/components/health/health-settings-dialog.tsx
+++ b/components/health/health-settings-dialog.tsx
@@ -162,7 +162,7 @@ export function HealthSettingsDialog() {
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button variant="outline" size="sm">
-          <Settings className="mr-2 h-4 w-4" />
+          <Settings className="mr-2 size-4" />
           Settings
         </Button>
       </DialogTrigger>

--- a/components/host/host-version-status.tsx
+++ b/components/host/host-version-status.tsx
@@ -25,7 +25,7 @@ export function HostVersionWithStatus({ hostId }: HostVersionWithStatusProps) {
     return (
       <span className="flex items-center gap-1.5 min-w-0 text-xs text-muted-foreground">
         <span className="size-2 rounded-full bg-gray-400 animate-pulse" />
-        Loading...
+        Loading…
       </span>
     )
   }

--- a/components/layout/query-page/chart-chip.tsx
+++ b/components/layout/query-page/chart-chip.tsx
@@ -81,9 +81,9 @@ export const ChartChip = memo(function ChartChip({
               )}
             >
               {summary.trend === 'up' ? (
-                <TrendingUpIcon className="h-3 w-3" />
+                <TrendingUpIcon className="size-3" />
               ) : (
-                <TrendingDownIcon className="h-3 w-3" />
+                <TrendingDownIcon className="size-3" />
               )}
               {Math.abs(summary.deltaPct).toFixed(0)}%
             </span>

--- a/components/layout/query-page/chart-row.tsx
+++ b/components/layout/query-page/chart-row.tsx
@@ -70,7 +70,7 @@ export const ChartRow = memo(function ChartRow({
               <ChartRowSummary charts={charts} />
               <span className="ml-auto flex shrink-0 items-center gap-1 rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground opacity-0 group-hover/row:opacity-100 transition-opacity duration-200">
                 Show
-                <ChevronDownIcon className="h-3 w-3" />
+                <ChevronDownIcon className="size-3" />
               </span>
             </div>
           </CollapsibleTrigger>
@@ -151,7 +151,7 @@ export const ChartRow = memo(function ChartRow({
                 )}
                 aria-label="Collapse row"
               >
-                <ChevronUpIcon className="h-3 w-3" />
+                <ChevronUpIcon className="size-3" />
                 <span>Hide</span>
               </Button>
             </CollapsibleTrigger>

--- a/components/mcp/copy-button.tsx
+++ b/components/mcp/copy-button.tsx
@@ -31,10 +31,10 @@ export function CopyButton({ text, className, label }: CopyButtonProps) {
       >
         {copied ? (
           <span className="t-success-check">
-            <Check className="h-3.5 w-3.5 text-green-600" />
+            <Check className="size-3.5 text-green-600" />
           </span>
         ) : (
-          <Copy className="h-3.5 w-3.5" />
+          <Copy className="size-3.5" />
         )}
         {copied ? 'Copied!' : label}
       </Button>
@@ -49,9 +49,9 @@ export function CopyButton({ text, className, label }: CopyButtonProps) {
       onClick={handleCopy}
     >
       {copied ? (
-        <Check className="h-3.5 w-3.5 text-green-600" />
+        <Check className="size-3.5 text-green-600" />
       ) : (
-        <Copy className="h-3.5 w-3.5" />
+        <Copy className="size-3.5" />
       )}
     </Button>
   )

--- a/components/mcp/mcp-endpoint-url.tsx
+++ b/components/mcp/mcp-endpoint-url.tsx
@@ -16,7 +16,7 @@ export function McpEndpointUrl() {
   return (
     <div className="flex flex-col sm:flex-row sm:items-center gap-2">
       <div className="flex items-center gap-2 min-w-0 flex-1">
-        <Globe className="h-4 w-4 text-muted-foreground shrink-0" />
+        <Globe className="size-4 text-muted-foreground shrink-0" />
         <code className="flex-1 min-w-0 rounded-md bg-muted px-3 py-2 text-sm font-mono truncate block">
           {endpointUrl || 'Loading...'}
         </code>

--- a/components/mcp/mcp-example-prompts.tsx
+++ b/components/mcp/mcp-example-prompts.tsx
@@ -24,18 +24,19 @@ function PromptItem({ prompt }: { prompt: string }) {
 
   return (
     <button
+      type="button"
       onClick={handleCopy}
       className="group w-full flex items-center justify-between gap-3 rounded-md border px-3 py-2.5 text-left text-sm hover:bg-muted/50 transition-colors"
     >
       <div className="flex items-center gap-2.5 min-w-0">
-        <MessageSquare className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        <MessageSquare className="size-3.5 text-muted-foreground shrink-0" />
         <span className="text-sm truncate">{prompt}</span>
       </div>
       <span className="shrink-0 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity">
         {copied ? (
-          <Check className="h-3.5 w-3.5 text-green-600" />
+          <Check className="size-3.5 text-green-600" />
         ) : (
-          <Copy className="h-3.5 w-3.5" />
+          <Copy className="size-3.5" />
         )}
       </span>
     </button>

--- a/components/mcp/mcp-info-card.tsx
+++ b/components/mcp/mcp-info-card.tsx
@@ -68,9 +68,9 @@ function CopyButton({ text, className }: { text: string; className?: string }) {
       onClick={handleCopy}
     >
       {copied ? (
-        <Check className="h-3.5 w-3.5 text-green-600" />
+        <Check className="size-3.5 text-green-600" />
       ) : (
-        <Copy className="h-3.5 w-3.5" />
+        <Copy className="size-3.5" />
       )}
     </Button>
   )
@@ -126,7 +126,7 @@ export function McpInfoCard() {
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-base">
-          <Globe className="h-4 w-4" />
+          <Globe className="size-4" />
           MCP Server
         </CardTitle>
         <CardDescription>
@@ -179,7 +179,7 @@ export function McpInfoCard() {
           {/* Generic / curl */}
           <div className="space-y-2">
             <p className="text-xs font-medium text-muted-foreground flex items-center gap-1">
-              <Terminal className="h-3 w-3" />
+              <Terminal className="size-3" />
               Test with curl
             </p>
             <CodeBlock>{curlExample}</CodeBlock>

--- a/components/mcp/mcp-setup-guides.tsx
+++ b/components/mcp/mcp-setup-guides.tsx
@@ -28,6 +28,7 @@ function GuideSection({ guide }: { guide: SetupGuide }) {
   return (
     <div className="border rounded-lg overflow-hidden">
       <button
+        type="button"
         className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-muted/50 transition-colors"
         onClick={() => setExpanded(!expanded)}
       >
@@ -38,14 +39,14 @@ function GuideSection({ guide }: { guide: SetupGuide }) {
           </div>
         </div>
         {expanded ? (
-          <ChevronDown className="h-4 w-4 text-muted-foreground shrink-0 ml-3" />
+          <ChevronDown className="size-4 text-muted-foreground shrink-0 ml-3" />
         ) : (
-          <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0 ml-3" />
+          <ChevronRight className="size-4 text-muted-foreground shrink-0 ml-3" />
         )}
       </button>
 
       {expanded && (
-        <div className="border-t px-4 py-4 space-y-3 bg-muted/20">
+        <div className="border-t p-4 space-y-3 bg-muted/20">
           {guide.steps.map((step, i) =>
             step.type === 'text' ? (
               <p key={i} className="text-xs text-muted-foreground">

--- a/components/mcp/mcp-tools-docs.tsx
+++ b/components/mcp/mcp-tools-docs.tsx
@@ -25,6 +25,7 @@ function ToolCard({ tool }: { tool: (typeof MCP_TOOLS)[number] }) {
   return (
     <div className="border rounded-lg overflow-hidden">
       <button
+        type="button"
         className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-muted/50 transition-colors"
         onClick={() => setExpanded(!expanded)}
       >
@@ -44,15 +45,15 @@ function ToolCard({ tool }: { tool: (typeof MCP_TOOLS)[number] }) {
             {tool.params.length} param{tool.params.length !== 1 ? 's' : ''}
           </Badge>
           {expanded ? (
-            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            <ChevronDown className="size-4 text-muted-foreground" />
           ) : (
-            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+            <ChevronRight className="size-4 text-muted-foreground" />
           )}
         </div>
       </button>
 
       {expanded && (
-        <div className="border-t px-4 py-4 space-y-4 bg-muted/20">
+        <div className="border-t p-4 space-y-4 bg-muted/20">
           <p className="text-sm text-muted-foreground sm:hidden">
             {tool.description}
           </p>

--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -63,7 +63,7 @@ export function NavUser({
       className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
       data-testid="nav-user-trigger"
     >
-      <Avatar className="avatar h-8 w-8 rounded-lg">
+      <Avatar className="avatar size-8 rounded-lg">
         <AvatarImage src={user.avatar} alt={user.name} />
         <AvatarFallback className="rounded-lg">G</AvatarFallback>
       </Avatar>
@@ -94,7 +94,7 @@ export function NavUser({
               >
                 <DropdownMenuLabel className="p-0 font-normal">
                   <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                    <Avatar className="avatar h-8 w-8 rounded-lg">
+                    <Avatar className="avatar size-8 rounded-lg">
                       <AvatarImage src={user.avatar} alt={user.name} />
                       <AvatarFallback className="rounded-lg">G</AvatarFallback>
                     </Avatar>
@@ -111,7 +111,7 @@ export function NavUser({
                     onClick={() => (window.location.href = '/about')}
                     data-testid="nav-user-about"
                   >
-                    <Info className="h-4 w-4" />
+                    <Info className="size-4" />
                     <span>About</span>
                   </DropdownMenuItem>
                   <DropdownMenuItem asChild>
@@ -122,7 +122,7 @@ export function NavUser({
                       className="flex items-center gap-2"
                       data-testid="nav-user-github"
                     >
-                      <ExternalLink className="h-4 w-4" />
+                      <ExternalLink className="size-4" />
                       <span>GitHub Repo</span>
                     </a>
                   </DropdownMenuItem>
@@ -134,7 +134,7 @@ export function NavUser({
                       }}
                       data-testid="nav-user-settings"
                     >
-                      <Settings className="h-4 w-4" />
+                      <Settings className="size-4" />
                       <span>Settings</span>
                       <span className="ml-auto text-xs text-muted-foreground">
                         ⌘,

--- a/components/nav-user/clerk-nav.tsx
+++ b/components/nav-user/clerk-nav.tsx
@@ -69,9 +69,9 @@ export function ClerkNavWrapper() {
                 className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
                 data-testid="nav-user-trigger"
               >
-                <Avatar className="avatar h-8 w-8 rounded-lg">
+                <Avatar className="avatar size-8 rounded-lg">
                   <AvatarFallback className="rounded-lg bg-primary/10 text-primary">
-                    <UserIcon className="h-4 w-4" />
+                    <UserIcon className="size-4" />
                   </AvatarFallback>
                 </Avatar>
                 <div className="grid flex-1 text-left text-sm leading-tight">
@@ -93,7 +93,7 @@ export function ClerkNavWrapper() {
                   className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
                   data-testid="nav-user-trigger"
                 >
-                  <Avatar className="avatar h-8 w-8 rounded-lg">
+                  <Avatar className="avatar size-8 rounded-lg">
                     <AvatarImage
                       src={user?.imageUrl}
                       alt={user?.fullName ?? 'User'}
@@ -127,7 +127,7 @@ export function ClerkNavWrapper() {
               >
                 <DropdownMenuLabel className="p-0 font-normal">
                   <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                    <Avatar className="avatar h-8 w-8 rounded-lg">
+                    <Avatar className="avatar size-8 rounded-lg">
                       <AvatarImage
                         src={user?.imageUrl}
                         alt={user?.fullName ?? 'User'}
@@ -153,7 +153,7 @@ export function ClerkNavWrapper() {
                     onSelect={() => openUserProfile()}
                     data-testid="nav-user-account"
                   >
-                    <UserIcon className="h-4 w-4" />
+                    <UserIcon className="size-4" />
                     <span>Account Settings</span>
                   </DropdownMenuItem>
                   <DropdownMenuItem
@@ -161,7 +161,7 @@ export function ClerkNavWrapper() {
                     onClick={() => (window.location.href = '/about')}
                     data-testid="nav-user-about"
                   >
-                    <Info className="h-4 w-4" />
+                    <Info className="size-4" />
                     <span>About</span>
                   </DropdownMenuItem>
                   <DropdownMenuItem asChild>
@@ -172,7 +172,7 @@ export function ClerkNavWrapper() {
                       className="flex items-center gap-2"
                       data-testid="nav-user-github"
                     >
-                      <ExternalLink className="h-4 w-4" />
+                      <ExternalLink className="size-4" />
                       <span>GitHub Repo</span>
                     </a>
                   </DropdownMenuItem>
@@ -184,7 +184,7 @@ export function ClerkNavWrapper() {
                       }}
                       data-testid="nav-user-settings"
                     >
-                      <Settings className="h-4 w-4" />
+                      <Settings className="size-4" />
                       <span>Settings</span>
                       <span className="ml-auto text-xs text-muted-foreground">
                         ⌘,
@@ -195,7 +195,7 @@ export function ClerkNavWrapper() {
                 <DropdownMenuSeparator />
                 <SignOutButton>
                   <DropdownMenuItem className="flex items-center gap-2 text-destructive focus:text-destructive">
-                    <LogOut className="h-4 w-4" />
+                    <LogOut className="size-4" />
                     <span>Sign Out</span>
                   </DropdownMenuItem>
                 </SignOutButton>
@@ -221,7 +221,7 @@ function UserSkeleton() {
     <SidebarMenu>
       <SidebarMenuItem>
         <SidebarMenuButton size="lg" disabled data-testid="nav-user-trigger">
-          <div className="h-8 w-8 rounded-lg bg-muted animate-pulse" />
+          <div className="size-8 rounded-lg bg-muted animate-pulse" />
           <div className="grid flex-1 gap-1">
             <div className="h-4 w-24 bg-muted animate-pulse rounded" />
             <div className="h-3 w-16 bg-muted animate-pulse rounded" />

--- a/components/navigation/nav-main/menu-item.tsx
+++ b/components/navigation/nav-main/menu-item.tsx
@@ -90,7 +90,7 @@ const SingleMenuItem = memo(function SingleMenuItem({
           className="flex w-full items-center"
           onClick={closeMobileSidebar}
         >
-          {item.icon && <item.icon className="h-4 w-4 shrink-0" />}
+          {item.icon && <item.icon className="size-4 shrink-0" />}
           <span className="group-data-[state=collapsed]/sidebar:hidden">
             {item.title}
           </span>
@@ -140,7 +140,7 @@ const CollapsibleMenuItem = memo(function CollapsibleMenuItem({
   if (isCollapsed) {
     const triggerButton = (
       <SidebarMenuButton isActive={hasActiveChild}>
-        {item.icon && <item.icon className="h-4 w-4" />}
+        {item.icon && <item.icon className="size-4" />}
         <span className="group-data-[state=collapsed]/sidebar:hidden">
           {item.title}
         </span>
@@ -181,7 +181,7 @@ const CollapsibleMenuItem = memo(function CollapsibleMenuItem({
       <SidebarMenuItem>
         <CollapsibleTrigger asChild>
           <SidebarMenuButton isActive={hasActiveChild} tooltip={item.title}>
-            {item.icon && <item.icon className="h-4 w-4" />}
+            {item.icon && <item.icon className="size-4" />}
             <span>{item.title}</span>
             <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
           </SidebarMenuButton>

--- a/components/navigation/nav-secondary.tsx
+++ b/components/navigation/nav-secondary.tsx
@@ -42,12 +42,12 @@ export function NavSecondary({
                   rel={item.external ? 'noopener noreferrer' : undefined}
                   className="flex items-center gap-2"
                 >
-                  <item.icon className="h-4 w-4" />
+                  <item.icon className="size-4" />
                   <span className="group-data-[state=collapsed]/sidebar:hidden">
                     {item.title}
                   </span>
                   {item.external && (
-                    <ExternalLinkIcon className="ml-auto h-3 w-3 group-data-[state=collapsed]/sidebar:hidden" />
+                    <ExternalLinkIcon className="ml-auto size-3 group-data-[state=collapsed]/sidebar:hidden" />
                   )}
                 </Link>
               </SidebarMenuButton>

--- a/components/notifications/notifications-popover.tsx
+++ b/components/notifications/notifications-popover.tsx
@@ -131,7 +131,7 @@ export const NotificationsPopover = memo(function NotificationsPopover() {
           <Button
             variant="ghost"
             size="icon"
-            className="h-7 w-7"
+            className="size-7"
             onClick={() => setIsOpen(false)}
           >
             <X className="size-3.5" />

--- a/components/query-detail/query-detail-view.tsx
+++ b/components/query-detail/query-detail-view.tsx
@@ -397,7 +397,7 @@ export const QueryDetailView = memo(function QueryDetailView({
   return (
     <div className="flex flex-col gap-4">
       {/* ── 1. Header card ── */}
-      <div className="overflow-hidden rounded-xl border border-border bg-card px-4 py-4">
+      <div className="overflow-hidden rounded-xl border border-border bg-card p-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
           {/* Left: id + badges */}
           <div className="flex flex-wrap items-center gap-2">

--- a/components/resizable-sidebar-provider.tsx
+++ b/components/resizable-sidebar-provider.tsx
@@ -161,7 +161,7 @@ function ResizeHandle() {
           isResizing && 'opacity-100'
         )}
       >
-        <GripVertical className="h-3 w-3 text-muted-foreground" />
+        <GripVertical className="size-3 text-muted-foreground" />
       </div>
     </div>
   )

--- a/components/running-queries/running-queries-view.tsx
+++ b/components/running-queries/running-queries-view.tsx
@@ -56,7 +56,7 @@ function LoadingState() {
       {[0, 1, 2, 3].map((i) => (
         <div
           key={i}
-          className="flex items-center gap-3 border-b border-border px-3 py-3"
+          className="flex items-center gap-3 border-b border-border p-3"
         >
           <Skeleton className="h-5 w-16" />
           <Skeleton className="h-4 flex-1" />
@@ -85,7 +85,7 @@ function HistoryLink() {
       <span className="min-w-0 flex-1">
         <span className="block text-[13px] font-medium">Completed queries</span>
         <span className="block text-[12px] text-muted-foreground">
-          Queries that finish leave this list — browse them in query history.
+          Queries that finish leave this list. Browse them in query history.
         </span>
       </span>
       <span className="inline-flex shrink-0 items-center gap-1 text-[12px] font-medium text-muted-foreground transition-colors group-hover:text-foreground">
@@ -234,7 +234,7 @@ export const RunningQueriesView = memo(function RunningQueriesView() {
                 action={{
                   label: 'Retry',
                   onClick: refresh,
-                  icon: <RefreshCw className="mr-1.5 h-3.5 w-3.5" />,
+                  icon: <RefreshCw className="mr-1.5 size-3.5" />,
                 }}
               />
             </CardContent>

--- a/components/settings/settings-dialog.tsx
+++ b/components/settings/settings-dialog.tsx
@@ -41,7 +41,7 @@ export function SettingsDialog({
         <DialogTrigger asChild>
           {children || (
             <Button variant="ghost" size="icon">
-              <Settings className="h-4 w-4" />
+              <Settings className="size-4" />
             </Button>
           )}
         </DialogTrigger>

--- a/components/settings/settings-form.tsx
+++ b/components/settings/settings-form.tsx
@@ -102,7 +102,7 @@ export function SettingsForm({
               onClick={handleResetTimezone}
               disabled={!!isUsingDefault}
             >
-              <RotateCcw className="h-3 w-3 mr-1" />
+              <RotateCcw className="size-3 mr-1" />
               Reset to default
             </Button>
           )}
@@ -165,7 +165,7 @@ export function SettingsForm({
                 aria-pressed={isSelected}
                 aria-label={`Select ${option.description}`}
               >
-                <Icon className="mb-2 h-5 w-5" aria-hidden="true" />
+                <Icon className="mb-2 size-5" aria-hidden="true" />
                 <span className="text-xs font-medium">{option.label}</span>
               </button>
             )
@@ -176,7 +176,7 @@ export function SettingsForm({
       {/* MCP Server Section */}
       <div className="space-y-3">
         <Label className="text-sm font-medium flex items-center gap-1.5">
-          <Globe className="h-3.5 w-3.5" />
+          <Globe className="size-3.5" />
           MCP Server
         </Label>
         <p className="text-xs text-muted-foreground">
@@ -190,7 +190,7 @@ export function SettingsForm({
           className="w-full justify-start text-xs"
           onClick={() => window.open('/mcp', '_blank')}
         >
-          <Globe className="h-3 w-3 mr-2" />
+          <Globe className="size-3 mr-2" />
           View MCP Server Details
         </Button>
       </div>

--- a/components/skeletons/chart.tsx
+++ b/components/skeletons/chart.tsx
@@ -187,7 +187,7 @@ const TableSkeletonMini = () => (
     </div>
 
     {/* Table rows with shimmering effects */}
-    <div className="space-y-3 px-1 py-1 flex-1">
+    <div className="space-y-3 p-1 flex-1">
       {[1, 2, 3].map((row) => (
         <div key={row} className="flex items-center gap-4">
           <Skeleton variant="shimmer" className="h-3 w-2/5" />
@@ -244,7 +244,7 @@ export const ChartSkeleton = memo(function ChartSkeleton({
             <span className="flex items-center gap-2">
               <span className="truncate max-w-[200px]">{title}</span>
               <span className="text-[10px] text-muted-foreground/40 font-normal lowercase animate-pulse">
-                (loading...)
+                (loading…)
               </span>
             </span>
           ) : (

--- a/components/skeletons/table.tsx
+++ b/components/skeletons/table.tsx
@@ -64,7 +64,7 @@ export const TableSkeleton = memo(function TableSkeleton({
       </div>
 
       {/* Pagination footer */}
-      <span className="sr-only">Loading table data...</span>
+      <span className="sr-only">Loading table data…</span>
     </div>
   )
 })

--- a/components/skeletons/ui.tsx
+++ b/components/skeletons/ui.tsx
@@ -22,7 +22,7 @@ export const SingleLineSkeleton = memo(function SingleLineSkeleton({
     >
       <Skeleton className="h-6 w-3/5" />
       <Skeleton className="h-6 w-2/5" />
-      <span className="sr-only">Loading...</span>
+      <span className="sr-only">Loading…</span>
     </div>
   )
 })
@@ -51,7 +51,7 @@ export const MultiLineSkeleton = memo(function MultiLineSkeleton({
         <Skeleton className="h-6 w-2/5" />
         <Skeleton className="h-6 w-1/5" />
       </div>
-      <span className="sr-only">Loading...</span>
+      <span className="sr-only">Loading…</span>
     </div>
   )
 })
@@ -76,7 +76,7 @@ export const ListSkeleton = memo(function ListSkeleton({
       {Array.from({ length: nrows }).map((_, i) => (
         <Skeleton key={i} className="h-6 w-full" />
       ))}
-      <span className="sr-only">Loading list items...</span>
+      <span className="sr-only">Loading list items…</span>
     </div>
   )
 })

--- a/components/status/network-status-banner.tsx
+++ b/components/status/network-status-banner.tsx
@@ -78,6 +78,7 @@ export const NetworkStatusBanner = memo(function NetworkStatusBanner() {
             </span>
           </div>
           <button
+            type="button"
             onClick={() => window.location.reload()}
             className="text-xs font-medium underline hover:no-underline"
           >

--- a/components/tables/table-client.tsx
+++ b/components/tables/table-client.tsx
@@ -319,7 +319,7 @@ export const TableClient = memo(function TableClient({
                 ? {
                     label: 'Retry',
                     onClick: refresh,
-                    icon: <RefreshCw className="mr-1.5 h-3.5 w-3.5" />,
+                    icon: <RefreshCw className="mr-1.5 size-3.5" />,
                   }
                 : undefined
             }

--- a/components/utilities/truncated-list.tsx
+++ b/components/utilities/truncated-list.tsx
@@ -24,6 +24,7 @@ export const TruncatedList = memo(function TruncatedList({
 
       {isClamped && (
         <button
+          type="button"
           onClick={() => setIsExpanded(!isExpanded)}
           className="mt-2 text-sm text-blue-500 hover:text-blue-700 focus:outline-hidden"
         >

--- a/components/utilities/truncated-paragraph.tsx
+++ b/components/utilities/truncated-paragraph.tsx
@@ -54,6 +54,7 @@ export const TruncatedParagraph = memo(function TruncatedParagraph({
 
       {isClamped && (
         <button
+          type="button"
           onClick={() => setIsExpanded(!isExpanded)}
           className="mt-2 text-sm text-blue-500 hover:text-blue-700 focus:outline-hidden"
         >

--- a/lib/ai/agent/skills/registry.ts
+++ b/lib/ai/agent/skills/registry.ts
@@ -10,7 +10,8 @@ import type { Skill } from './types'
 export const SKILLS: readonly Skill[] = [
   {
     name: 'system-tables-reference',
-    description: 'Exact column names for the system tables the agent queries most (processes, query_log, parts, merges, replicas, metrics) plus rules for choosing dedicated tools over raw SQL. Load before hand-writing SQL against system tables.',
+    description:
+      'Exact column names for the system tables the agent queries most (processes, query_log, parts, merges, replicas, metrics) plus rules for choosing dedicated tools over raw SQL. Load before hand-writing SQL against system tables.',
     content: `# System Tables Reference
 
 Load this skill before writing raw SQL against \`system.*\` tables. It lists the
@@ -132,7 +133,8 @@ Columns: \`name\`, \`code\`, \`value\`, \`last_error_time\`, \`last_error_messag
   },
   {
     name: 'query-optimization',
-    description: 'Advanced query tuning: join algorithms, skip index selection, EXPLAIN interpretation, ProfileEvents profiling, and optimizer settings.',
+    description:
+      'Advanced query tuning: join algorithms, skip index selection, EXPLAIN interpretation, ProfileEvents profiling, and optimizer settings.',
     content: `# Query Optimization
 
 ## JOIN Strategies
@@ -168,7 +170,8 @@ Columns: \`name\`, \`code\`, \`value\`, \`last_error_time\`, \`last_error_messag
   },
   {
     name: 'replication-guide',
-    description: 'ReplicatedMergeTree operations, failover procedures, lag diagnosis, quorum writes, and Keeper management.',
+    description:
+      'ReplicatedMergeTree operations, failover procedures, lag diagnosis, quorum writes, and Keeper management.',
     content: `# Replication Guide
 
 ## ReplicatedMergeTree Basics
@@ -214,7 +217,8 @@ Columns: \`name\`, \`code\`, \`value\`, \`last_error_time\`, \`last_error_messag
   },
   {
     name: 'cluster-operations',
-    description: 'Cluster management: distributed tables, ON CLUSTER DDL, node lifecycle, resharding, load balancing, and Keeper migration.',
+    description:
+      'Cluster management: distributed tables, ON CLUSTER DDL, node lifecycle, resharding, load balancing, and Keeper migration.',
     content: `# Cluster Operations
 
 ## Distributed Tables
@@ -267,7 +271,8 @@ Columns: \`name\`, \`code\`, \`value\`, \`last_error_time\`, \`last_error_messag
   },
   {
     name: 'storage-optimization',
-    description: 'Compression codecs, TTL policies, tiered storage, part management, and disk space optimization.',
+    description:
+      'Compression codecs, TTL policies, tiered storage, part management, and disk space optimization.',
     content: `# Storage Optimization
 
 ## Compression Codecs
@@ -309,7 +314,8 @@ Columns: \`name\`, \`code\`, \`value\`, \`last_error_time\`, \`last_error_messag
   },
   {
     name: 'security-hardening',
-    description: 'RBAC configuration, row policies, quotas, network security, audit logging, and access control best practices.',
+    description:
+      'RBAC configuration, row policies, quotas, network security, audit logging, and access control best practices.',
     content: `# Security Hardening
 
 ## RBAC (Role-Based Access Control)
@@ -355,7 +361,8 @@ Columns: \`name\`, \`code\`, \`value\`, \`last_error_time\`, \`last_error_messag
   },
   {
     name: 'clickhouse-best-practices',
-    description: 'Production operational practices: insert batching, async writes, query cache, connection pooling, and recommended settings.',
+    description:
+      'Production operational practices: insert batching, async writes, query cache, connection pooling, and recommended settings.',
     content: `# ClickHouse Best Practices
 
 ## Insert Best Practices
@@ -396,7 +403,8 @@ Columns: \`name\`, \`code\`, \`value\`, \`last_error_time\`, \`last_error_messag
   },
   {
     name: 'migration-patterns',
-    description: 'Schema migrations: ALTER patterns, engine changes, zero-downtime swaps, clickhouse-local offline migrations, and lightweight UPDATE/DELETE strategies.',
+    description:
+      'Schema migrations: ALTER patterns, engine changes, zero-downtime swaps, clickhouse-local offline migrations, and lightweight UPDATE/DELETE strategies.',
     content: `# Migration Patterns
 
 ## ALTER TABLE Operations
@@ -475,7 +483,8 @@ CREATE TABLE _schema_migrations (name String, applied_at DateTime DEFAULT now())
   },
   {
     name: 'troubleshooting',
-    description: 'Diagnose and resolve ClickHouse issues: OOM, slow merges, stuck mutations, query failures with error codes, and systematic error clustering.',
+    description:
+      'Diagnose and resolve ClickHouse issues: OOM, slow merges, stuck mutations, query failures with error codes, and systematic error clustering.',
     content: `# Troubleshooting Guide
 
 ## OOM (Out of Memory)
@@ -526,7 +535,7 @@ For persistent errors, check \`system.error_log\` (requires error logging enable
 ## Cross-references
 - Load the \`replication-guide\` skill for replication lag diagnosis and recovery.
 - Load the \`storage-optimization\` skill for disk recovery and tiered storage management.`,
-  }
+  },
 ]
 
 /** Get all available skills metadata (without content) */

--- a/lib/context/browser-connections-context.tsx
+++ b/lib/context/browser-connections-context.tsx
@@ -2,13 +2,7 @@
 
 import type { BrowserConnection } from '@/lib/types/browser-connection'
 
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-} from 'react'
+import { createContext, use, useCallback, useEffect, useState } from 'react'
 import { BROWSER_CONNECTIONS_STORAGE_KEY } from '@/lib/types/browser-connection'
 
 interface BrowserConnectionsContextValue {
@@ -80,5 +74,5 @@ export function BrowserConnectionsProvider({
  * Returns connections stored in localStorage.
  */
 export function useBrowserConnectionsContext(): BrowserConnectionsContextValue {
-  return useContext(BrowserConnectionsContext)
+  return use(BrowserConnectionsContext)
 }

--- a/lib/context/time-range-context.tsx
+++ b/lib/context/time-range-context.tsx
@@ -2,13 +2,7 @@
 
 import type { ClickHouseInterval } from '@/types/clickhouse-interval'
 
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useMemo,
-  useState,
-} from 'react'
+import { createContext, use, useCallback, useMemo, useState } from 'react'
 
 export interface TimeRangeOption {
   /** Display label shown in the picker (e.g., "24h") */
@@ -79,5 +73,5 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
 }
 
 export function useTimeRange(): TimeRangeContextValue {
-  return useContext(TimeRangeContext)
+  return use(TimeRangeContext)
 }

--- a/lib/context/timezone-context.tsx
+++ b/lib/context/timezone-context.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext } from 'react'
+import { createContext, use } from 'react'
 import { useUserSettings } from '@/lib/hooks/use-user-settings'
 
 const TimezoneContext = createContext<string>('UTC')
@@ -15,6 +15,6 @@ export function TimezoneProvider({ children }: { children: React.ReactNode }) {
 }
 
 export function useTimezone(): string {
-  const context = useContext(TimezoneContext)
+  const context = use(TimezoneContext)
   return context || 'UTC'
 }

--- a/lib/feature-permissions/context.tsx
+++ b/lib/feature-permissions/context.tsx
@@ -6,7 +6,7 @@ import { isFeatureAllowed, resolveFeatureState } from './shared'
 import {
   createContext,
   type ReactNode,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useState,
@@ -84,7 +84,7 @@ export function FeaturePermissionsProvider({
 
 export function useFeaturePermissions() {
   return (
-    useContext(FeaturePermissionsContext) ?? {
+    use(FeaturePermissionsContext) ?? {
       config: DEFAULT_PUBLIC_CONFIG,
       isLoading: true,
       isAllowed: (permission?: FeaturePermission) =>

--- a/lib/swr/host-context.tsx
+++ b/lib/swr/host-context.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, type ReactNode, useContext, useMemo } from 'react'
+import { createContext, type ReactNode, use, useMemo } from 'react'
 
 interface HostContextValue {
   hostId: number
@@ -42,7 +42,7 @@ export function HostProvider({
  * useHostContext - Access hostId from context (throws if not in provider)
  */
 export function useHostContext(): HostContextValue {
-  const context = useContext(HostContext)
+  const context = use(HostContext)
   if (!context) {
     throw new Error('useHostContext must be used within a HostProvider')
   }
@@ -57,7 +57,7 @@ export function useHostContext(): HostContextValue {
  * On client hydration, the actual hostId from URL will be used.
  */
 export function useHostIdFromContext(): number {
-  const context = useContext(HostContext)
+  const context = use(HostContext)
   // Return default host if context not available (during SSG)
   return context?.hostId ?? 0
 }


### PR DESCRIPTION
## Summary

Runs `npx react-doctor@latest` and clears the **safe, high-confidence, behavior-preserving** findings. Diagnostics so far: **1803 → 1548** (255 fewer; all warnings — see note on errors below).

Changes (all mechanical, no behavior change):
- **Tailwind axes**: collapse `w-N h-N` → `size-N` and `px-N py-N` → `p-N` (185 + 17).
- **Typography in JSX text**: `...` → `…`, em dashes → comma/colon (per react-doctor's `design-*` rules).
- **Buttons**: add explicit `type="button"` to 24 interactive buttons (none are form submits).
- **React 19**: migrate project-owned context consumers from `useContext(X)` → `use(X)`.
- **Perf**: hoist static `Intl.NumberFormat` instances to module scope.
- **Chore**: format the generated `lib/ai/agent/skills/registry.ts` (pre-existing drift that blocked the pre-push `biome check`).

Vendored components (`components/ui/`, and the registry-vendored `components/ai-elements/` / `components/assistant-ui/`) were intentionally left untouched per project convention.

Verified after each batch: `tsc --noEmit` clean, `biome check .` clean.

## Not in this PR (need a decision — see PR thread)

The remaining ~1548 are dominated by changes that are risky or architectural and shouldn't be auto-applied:
- **`react-compiler-no-manual-memoization` (568, ~all the errors)** — wants mass removal of `useMemo`/`useCallback`/`memo`, only safe if the **React Compiler** is enabled (it is not). This is why the error count is unchanged.
- **Dead code (~235)** — deleting 95 files + 140 exports; false-positive-prone.
- **State/effects refactors** (`set-state-in-effect`, `exhaustive-deps`, etc.) — behavioral.

> Note: react-doctor's numeric score is computed by its hosted API (`www.react.doctor/api/score`), which is blocked by this environment's network allowlist, so the score reads as `null` here. Progress is tracked via the diagnostic count instead.

## Test plan
- [ ] `bun run type-check` passes
- [ ] `bun run check` (biome) passes
- [ ] `bun run build` succeeds
- [ ] Spot-check touched UI (icons render at correct size, buttons work, context-consuming components render)

https://claude.ai/code/session_01CKyamcbKVLCKahjFMsXZsY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKyamcbKVLCKahjFMsXZsY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Buttons now behave correctly in forms (explicit non-submit type) to avoid accidental submissions.

* **Style**
  * Unified icon sizing and consolidated padding across the UI for consistent visuals.
  * Normalized punctuation and ellipses (commas/colons, single-character ellipsis) and minor copy reflow/wording updates in several UI descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->