### PR TITLE
fix(peerdb): normalize log-level casing in mirror logs panel

### DIFF
--- a/components/peerdb/mirror-logs-panel.tsx
+++ b/components/peerdb/mirror-logs-panel.tsx
@@ -4,6 +4,7 @@ import type { ListMirrorLogsResponse } from '@/lib/peerdb/types'
 
 import {
   LOG_LEVEL_META,
+  normalizePdbLogLevel,
   parseTs,
   pdbFmtClock,
   pdbFmtRelative,
@@ -49,8 +50,7 @@ export function MirrorLogsPanel({ flowJobName }: { flowJobName: string }) {
     const c: Record<Level, number> = { all: 0, error: 0, warn: 0, info: 0 }
     for (const l of countsReq.data?.errors ?? []) {
       c.all++
-      const t = (l.errorType ?? 'info') as Level
-      if (t in c) c[t]++
+      c[normalizePdbLogLevel(l.errorType)]++
     }
     return c
   }, [countsReq.data])
@@ -60,7 +60,7 @@ export function MirrorLogsPanel({ flowJobName }: { flowJobName: string }) {
     // Client-side filter as a safety net for upstreams that ignore `level`.
     return level === 'all'
       ? sorted
-      : sorted.filter((l) => (l.errorType ?? 'info') === level)
+      : sorted.filter((l) => normalizePdbLogLevel(l.errorType) === level)
   }, [listReq.data, level])
   const rows = showAll ? filtered : filtered.slice(0, 6)
 
@@ -103,8 +103,8 @@ export function MirrorLogsPanel({ flowJobName }: { flowJobName: string }) {
       ) : (
         <ul className="divide-y divide-border">
           {rows.map((l, i) => {
-            const meta =
-              LOG_LEVEL_META[l.errorType ?? 'info'] ?? LOG_LEVEL_META.info
+            const lvl = normalizePdbLogLevel(l.errorType)
+            const meta = LOG_LEVEL_META[lvl]
             return (
               <li
                 key={l.id ?? i}
@@ -123,9 +123,7 @@ export function MirrorLogsPanel({ flowJobName }: { flowJobName: string }) {
                 <div className="min-w-0 flex-1">
                   <div
                     className="break-words font-mono text-[11.5px] leading-snug"
-                    style={
-                      l.errorType === 'error' ? { color: meta.dot } : undefined
-                    }
+                    style={lvl === 'error' ? { color: meta.dot } : undefined}
                   >
                     {l.errorMessage}
                   </div>

--- a/components/peerdb/peerdb-utils.ts
+++ b/components/peerdb/peerdb-utils.ts
@@ -509,6 +509,20 @@ export const LOG_LEVEL_META: Record<string, LogLevelMeta> = {
   info: { label: 'INFO', dot: '#3b82f6' },
 }
 
+/**
+ * Normalize a PeerDB log `errorType` to a canonical level. PeerDB is not
+ * consistent about casing (`ERROR`, `WARNING`, `warn`), so fold to lowercase
+ * and collapse the `warning` synonym before matching tabs/colors.
+ */
+export function normalizePdbLogLevel(
+  errorType?: string | null
+): 'error' | 'warn' | 'info' {
+  const t = (errorType ?? 'info').toLowerCase()
+  if (t.startsWith('err')) return 'error'
+  if (t.startsWith('warn')) return 'warn'
+  return 'info'
+}
+
 /** Relative "Ns ago / Nm ago / Nh ago" from an ISO timestamp. */
 export function pdbFmtRelative(iso?: string | number): string {
   const t = parseTs(iso)


### PR DESCRIPTION
## Summary
Follow-up to #1209. PeerDB returns log `errorType` in inconsistent casing (`ERROR`, `WARNING`, `warn`), but the mirror logs panel compared it against lowercase `error`/`warn`/`info`. Uppercase values silently fell through:
- per-tab **counts stayed 0**,
- selecting the ERROR/WARN tab showed **"No logs at this level"** even when such logs existed,
- every row rendered with the default blue **INFO** pill.

## Changes
- Add `normalizePdbLogLevel()` in `peerdb-utils.ts` — lowercases and collapses the `warning` synonym to the canonical `error` | `warn` | `info`.
- Apply it at all four comparison sites in `mirror-logs-panel.tsx`: tab counts, client-side filter, pill metadata lookup, and the row error-color condition.

## Test plan
- [ ] With a PeerDB instance emitting uppercase `errorType`, verify ERROR/WARN tab counts are non-zero and filtering shows the rows.
- [ ] Verify pills color correctly (red ERROR / amber WARN / blue INFO).
- [x] `bun run type-check` passes
- [x] `bun run lint` clean (no new warnings)

Detected during the multi-agent review of #1209.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized log level display and filtering in mirror logs by normalizing various log level formats into consistent categories, ensuring reliable categorization and proper visual presentation of error, warning, and information messages throughout the logs interface.
  * Improved the robustness and consistency of error highlighting and log level-based filtering functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->