### PR TITLE
perf(peerdb): memoize smoothPath in sparkline/area charts

### DIFF
--- a/components/peerdb/pdb-charts.tsx
+++ b/components/peerdb/pdb-charts.tsx
@@ -50,6 +50,10 @@ export function PdbSparkline({
   // Cap rendered points to roughly the pixel width — more is invisible but
   // still costs DOM/curve work when a mirror returns thousands of samples.
   const points = useMemo(() => downsample(data ?? [], width), [data, width])
+  const { line } = useMemo(
+    () => smoothPath(points, width, height),
+    [points, width, height]
+  )
   if (!data || data.length < 2) {
     return (
       <div
@@ -60,7 +64,6 @@ export function PdbSparkline({
       </div>
     )
   }
-  const { line } = smoothPath(points, width, height)
   return (
     <svg width={width} height={height} className="block">
       <defs>
@@ -178,6 +181,7 @@ export function PdbAreaChart({
   // The chart is drawn in a 100-unit viewBox; ~160 points is far more than the
   // curve can resolve, so downsample longer series before building the path.
   const points = useMemo(() => downsample(data ?? [], 160), [data])
+  const { line } = useMemo(() => smoothPath(points, 100, 100, 4), [points])
   if (!data || data.length < 2) {
     return (
       <div
@@ -190,7 +194,6 @@ export function PdbAreaChart({
   }
   const w = 100
   const h = 100
-  const { line } = smoothPath(points, w, h, 4)
   return (
     <div className="w-full" style={{ height }}>
       <svg


### PR DESCRIPTION
## Summary
Follow-up to #1209. `smoothPath()` builds the full cubic-bezier path string by iterating every point, but it ran **outside `useMemo`** in both `PdbSparkline` and `PdbAreaChart`. Every parent re-render — including the 60s metrics refresh and unrelated state changes — rebuilt the path string even when the downsampled `points` were unchanged. Each expanded mirror renders three area charts, so this multiplied across rows.

## Changes
- Hoist `smoothPath(points, …)` into a `useMemo` keyed on the downsampled points (and width/height for the sparkline).
- Placed the memo **before** the early-return guard to satisfy rules-of-hooks.
- Pure performance change — identical output.

## Test plan
- [x] `bun run type-check` passes
- [x] `bun run lint` clean
- [ ] Visual: expanded mirror charts render identically; no flicker on 60s refresh.

Detected during the multi-agent review of #1209 (tracked in #1212).

## Summary by Sourcery

Enhancements:
- Memoize smoothPath-derived line paths in sparkline and area charts to avoid recomputation on unchanged data and dimensions.