### PR TITLE
fix(maintenance): guard PeerDB cache envs and release reruns

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,13 +391,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.meta.outputs.tag }}
         run: |
+          NEW_NOTES="$(cat release-notes.md)"
           if gh release view "$TAG" >/dev/null 2>&1; then
-            # Append on top: keep any existing notes, prepend the new content.
+            # Keep prior manual notes, but avoid duplicating the generated block
+            # when the release workflow is re-run for the same tag.
             EXISTING="$(gh release view "$TAG" --json body --jq '.body // ""')"
-            if [ -n "$EXISTING" ]; then
-              printf '%s\n\n---\n\n%s\n' "$(cat release-notes.md)" "$EXISTING" > final-notes.md
+            if [ -n "$EXISTING" ] && [ "${EXISTING#"$NEW_NOTES"}" != "$EXISTING" ]; then
+              printf '%s\n' "$EXISTING" > final-notes.md
+            elif [ -n "$EXISTING" ]; then
+              printf '%s\n\n---\n\n%s\n' "$NEW_NOTES" "$EXISTING" > final-notes.md
             else
-              cp release-notes.md final-notes.md
+              printf '%s\n' "$NEW_NOTES" > final-notes.md
             fi
             gh release edit "$TAG" \
               --title "$TAG" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ Build lock errors: remove `.next/lock` and retry.
 - Failed-job logs in restricted cache environments: `XDG_CACHE_HOME=/private/tmp/gh-cache gh run view <RUN_ID> --job <JOB_ID> --log-failed`
 - E2E page-load flake triage: `XDG_CACHE_HOME=/private/tmp/gh-cache gh run view <RUN_ID> --job <JOB_ID> --log-failed | grep -n -E "Timed out after waiting .* for your remote page to load"`
 - Docker deps-stage parity check: `bun install --frozen-lockfile --ignore-scripts && bun run build` (`lib/platform/adapters/cloudflare.ts` imports `@opennextjs/cloudflare` during build)
-- Worktree fallback for PR operations: if automation checkout is detached (`git status --short --branch` shows `HEAD (no branch)`) or git metadata writes fail (`FETCH_HEAD`/`HEAD.lock`/`index.lock`), refresh refs through `/Users/duet/project/clickhouse-monitor`; if that checkout is dirty, create a clean worktree under `/private/tmp` for commit/PR commands
+- Worktree fallback for PR operations: if automation checkout is detached (`git status --short --branch` shows `HEAD (no branch)`), stale versus `origin/main`, or git metadata writes fail (`FETCH_HEAD`/`HEAD.lock`/`index.lock`), run `git -C /Users/duet/project/clickhouse-monitor fetch origin`; if that checkout is dirty, create a clean worktree under `/private/tmp` for commit/PR commands
 - Cloudflare worker size dry-run: `bun wrangler deploy --minify --dry-run`
 - Code-smell automation workflow now records findings in `docs/knowledge/core-memory.md`, then validates `gh run list --branch main --limit 10 ...` and keeps a dedicated memory note under `/Users/duet/.codex/automations/code-smell-detector/memory.md`.
 

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -36,7 +36,7 @@ Durable code-smell/dead-code automation memory. Do not create dated files under 
 - `/docs` route reads source files from `docs/content` through `app/(docs)/docs/_lib/docs.ts`
 - Verify dead-code claims with zero non-test references before deleting symbols
 - Docker build must install full deps (`bun install --frozen-lockfile --ignore-scripts`) because `lib/platform/adapters/cloudflare.ts` imports `@opennextjs/cloudflare` during `bun run build`
-- If automation checkout is detached (`git status --short --branch` shows `HEAD (no branch)`) or `.git/worktrees/...` writes fail (`FETCH_HEAD`/`HEAD.lock`/`index.lock`), refresh refs through `/Users/duet/project/clickhouse-monitor`; if that checkout is dirty, create a clean worktree under `/private/tmp` for commit/PR commands
+- If automation checkout is detached (`git status --short --branch` shows `HEAD (no branch)`), stale versus `origin/main`, or `.git/worktrees/...` writes fail (`FETCH_HEAD`/`HEAD.lock`/`index.lock`), run `git -C /Users/duet/project/clickhouse-monitor fetch origin`; if that checkout is dirty, create a clean worktree under `/private/tmp` for commit/PR commands
 
 ## Latest Update
 
@@ -54,3 +54,4 @@ Durable code-smell/dead-code automation memory. Do not create dated files under 
 - 2026-05-23 (follow-up): E2E failures in PR `#1159` were traced to an intermittently visible issues overlay button (`button[data-issues-collapse="true"]`) covering the user trigger during Cypress auth menu actions and causing `cy.click` timeouts. Hardened `cypress/e2e/authentication.cy.ts` with an overlay-dismiss helper and consistent `openUserMenu` menu-entry flow to keep coverage stable without changing app behavior.
 - 2026-05-23 (follow-up): Full `cypress/e2e/authentication.cy.ts` logs in PR check `26313228001` showed 8 hard failures caused by `nav-user-trigger` being covered; follow-up hardening removes `should('be.visible')` assertions before clicking/focusing and relies on `click({ force: true })` after overlay dismissal to prevent false negatives from transient blockers.
 - 2026-05-22 (follow-up): CI run `26316686483` (`Test` job on `main`) reported repeated `CypressError: Timed out after waiting 30000ms for your remote page to load` in `host-switching.cy.ts` and `navigation.cy.js`; removed hardcoded `timeout: 30000` from those `cy.visit` calls so they follow global `pageLoadTimeout`.
+- 2026-05-29: from the `2026-05-28T06:13:19.122Z` window, fixed `lib/peerdb/peerdb-config.ts` so invalid `PEERDB_CACHE_TTL_MS` / `PEERDB_CACHE_MAX_ENTRIES` env values fall back to safe defaults instead of disabling TTL/cap logic, and hardened `.github/workflows/release.yml` so rerunning the release workflow for the same tag does not prepend duplicate generated notes to an existing GitHub release.

--- a/lib/__tests__/peerdb-config.test.ts
+++ b/lib/__tests__/peerdb-config.test.ts
@@ -1,0 +1,37 @@
+import { readNonNegativeIntEnv } from '../peerdb/peerdb-config'
+
+describe('readNonNegativeIntEnv', () => {
+  const originalCacheTtl = process.env.PEERDB_CACHE_TTL_MS
+
+  afterEach(() => {
+    if (originalCacheTtl === undefined) {
+      delete process.env.PEERDB_CACHE_TTL_MS
+    } else {
+      process.env.PEERDB_CACHE_TTL_MS = originalCacheTtl
+    }
+  })
+
+  it('returns the fallback when the env var is missing', () => {
+    delete process.env.PEERDB_CACHE_TTL_MS
+
+    expect(readNonNegativeIntEnv('PEERDB_CACHE_TTL_MS', 10_000)).toBe(10_000)
+  })
+
+  it('returns the fallback for invalid values', () => {
+    process.env.PEERDB_CACHE_TTL_MS = 'not-a-number'
+
+    expect(readNonNegativeIntEnv('PEERDB_CACHE_TTL_MS', 10_000)).toBe(10_000)
+  })
+
+  it('returns the fallback for negative values', () => {
+    process.env.PEERDB_CACHE_TTL_MS = '-5'
+
+    expect(readNonNegativeIntEnv('PEERDB_CACHE_TTL_MS', 10_000)).toBe(10_000)
+  })
+
+  it('floors positive numeric values', () => {
+    process.env.PEERDB_CACHE_TTL_MS = '2500.9'
+
+    expect(readNonNegativeIntEnv('PEERDB_CACHE_TTL_MS', 10_000)).toBe(2500)
+  })
+})

--- a/lib/peerdb/peerdb-config.ts
+++ b/lib/peerdb/peerdb-config.ts
@@ -53,6 +53,17 @@ export class PeerDBError extends Error {
   }
 }
 
+export function readNonNegativeIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim()
+  if (!raw) return fallback
+
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed)) return fallback
+
+  const normalized = Math.floor(parsed)
+  return normalized >= 0 ? normalized : fallback
+}
+
 /**
  * Server-side fetch against the PeerDB REST API.
  *
@@ -66,9 +77,10 @@ export class PeerDBError extends Error {
  * reads for a few seconds collapses bursts and refresh cycles into one upstream
  * call. TTL is tunable via PEERDB_CACHE_TTL_MS (default 10s; 0 disables).
  */
-const CACHE_TTL_MS = Number(process.env.PEERDB_CACHE_TTL_MS ?? 10_000)
-const CACHE_MAX_ENTRIES = Number(process.env.PEERDB_CACHE_MAX_ENTRIES ?? 500)
-const FETCH_TIMEOUT_MS = Number(process.env.PEERDB_FETCH_TIMEOUT_MS) || 10_000
+const CACHE_TTL_MS = readNonNegativeIntEnv('PEERDB_CACHE_TTL_MS', 10_000)
+const CACHE_MAX_ENTRIES = readNonNegativeIntEnv('PEERDB_CACHE_MAX_ENTRIES', 500)
+const FETCH_TIMEOUT_MS =
+  readNonNegativeIntEnv('PEERDB_FETCH_TIMEOUT_MS', 10_000) || 10_000
 const responseCache = new Map<string, { at: number; value: unknown }>()
 
 /**


### PR DESCRIPTION
## Summary
- guard PeerDB cache env parsing so invalid values fall back to safe defaults
- stop release workflow reruns from prepending duplicate generated notes
- record the detached-worktree fetch workflow in durable repo memory

## Verification
- `TMPDIR=/private/tmp bun test lib/__tests__/peerdb-config.test.ts`
- `PATH=/Users/duet/project/clickhouse-monitor/node_modules/.bin:$PATH tsc --noEmit`
- `PATH=/Users/duet/project/clickhouse-monitor/node_modules/.bin:$PATH TMPDIR=/private/tmp bun run build`
