### PR TITLE
refactor(monorepo): add tsconfig.base.json + Turbo pipeline (Phase 0)

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,6 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "es2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "incremental": true,
     "plugins": [
       {
         "name": "next"

--- a/turbo.json
+++ b/turbo.json
@@ -1,11 +1,26 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["tsconfig.base.json", "biome.json", "bun.lock"],
   "tasks": {
     "build": {
-      "outputs": [".next/**", "!.next/cache/**"]
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.test.ts", "!**/__tests__/**"],
+      "outputs": [".next/**", "!.next/cache/**", "dist/**", ".open-next/**"]
+    },
+    "wasm:build": {
+      "inputs": ["rust/monitor-core/**", "scripts/build-wasm.ts"],
+      "outputs": ["lib/wasm/generated/**"]
+    },
+    "type-check": {
+      "dependsOn": ["^build"]
     },
     "lint": {},
-    "fmt": {},
-    "test": {}
+    "fmt": {
+      "cache": false
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"]
+    }
   }
 }


### PR DESCRIPTION
## Phase 0: Bun Workspaces + Turbo Pipeline Foundation

**No file moves, no import changes, no behavior change.** This PR establishes the config infrastructure for the full monorepo migration described in the plan.

### Changes

| File | Change |
|------|--------|
| `tsconfig.base.json` | **New** — shared TypeScript compiler options for future `@chm/*` packages |
| `tsconfig.json` | Refactored to extend base; keeps only web-specific opts (Next.js plugin, `@/*` paths, Cypress types) |
| `turbo.json` | Upgraded from minimal stub to real pipeline with `dependsOn`, `inputs`, `outputs`, `globalDependencies` |

### What `turbo.json` now provides

- **`build`**: `dependsOn: ["^build"]` — automatic package-level build ordering (active in Phase 1+)
- **`wasm:build`**: keyed on `rust/monitor-core/**` sources — replaces the "skip if file exists" hack
- **`type-check` / `test`**: `dependsOn: ["^build"]` — run after all workspace builds complete
- **`fmt`**: `cache: false` — formatting should always run fresh
- **`globalDependencies`**: changes to `tsconfig.base.json`, `biome.json`, or `bun.lock` invalidate all caches

### Verification

| Gate | Result |
|------|--------|
| `turbo run type-check` | ✅ pass |
| `turbo run lint` | ✅ pass (4 pre-existing warnings) |
| `turbo run test` | ✅ 1739 pass, 0 fail |
| Cache HIT on second run | ✅ `FULL TURBO` — 3 cached, 288ms |

### Why no `workspaces` field yet

Adding `"workspaces": ["apps/*", "packages/*"]` switches Turborepo from *single-package mode* to *monorepo mode*. With empty directories, Turbo finds 0 packages and refuses to run tasks. The `workspaces` declaration will be added in **Phase 1** when the first packages (`@chm/types`, `@chm/sql-builder`, etc.) are extracted.

### Next: Phase 1

Extract Tier-1 leaf packages + break the `lib/swr → app/api/v1/hosts` import cycle.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Introduce shared TypeScript configuration and establish a Turborepo pipeline foundation for the monorepo migration.

Enhancements:
- Extract shared TypeScript compiler options into a new tsconfig.base.json and have the root tsconfig.json extend it, keeping only app-specific settings.
- Expand turbo.json from a stub into a real task pipeline with appropriate dependencies, inputs, outputs, and global cache invalidation rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored TypeScript configuration to improve standardization and maintainability across the project.
  * Enhanced build pipeline with improved caching, task dependencies, and support for additional build outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->