### PR TITLE
fix(cf): resolve nested standalone path in stub script for monorepo

### DIFF
--- a/scripts/stub-prerendered-handlers.ts
+++ b/scripts/stub-prerendered-handlers.ts
@@ -45,11 +45,32 @@ interface AppPathRoutesManifest {
 }
 
 const ROOT = process.cwd()
+// In a monorepo (lockfile at the repo root, app under e.g. `apps/web`),
+// `output: 'standalone'` nests the build under the app's path relative to the
+// monorepo root: `.next/standalone/apps/web/.next/server/app`. Detect that
+// package sub-path the same way opennextjs/aws does (first lockfile walking up)
+// so this works in both single-package and monorepo layouts.
+function findMonorepoRoot(start: string): string {
+  const LOCKFILES = [
+    'bun.lockb',
+    'bun.lock',
+    'package-lock.json',
+    'yarn.lock',
+    'pnpm-lock.yaml',
+  ]
+  let cur = start
+  while (cur !== path.dirname(cur)) {
+    if (LOCKFILES.some((f) => existsSync(path.join(cur, f)))) return cur
+    cur = path.dirname(cur)
+  }
+  return start
+}
+const PKG_PATH = path.relative(findMonorepoRoot(ROOT), ROOT) // '' or e.g. 'apps/web'
 // `output: 'standalone'` produces a self-contained copy under `.next/standalone`
 // that opennextjs-cloudflare uses as its source of truth. We have to stub there
 // (and also in `.next/server/app` for symmetry) — the plain copy alone is ignored.
 const APP_ROOTS = [
-  path.join(ROOT, '.next/standalone/.next/server/app'),
+  path.join(ROOT, '.next/standalone', PKG_PATH, '.next/server/app'),
   path.join(ROOT, '.next/server/app'),
 ]
 // Originals are copied here before stubbing so `restore-prerendered-handlers.ts`


### PR DESCRIPTION
## Fix broken `cf:build`/`preview` after Phase 2 monorepo move (#1222)

Phase 2 moved the app to `apps/web/`. With `output: 'standalone'` in a monorepo (lockfile at repo root), Next.js **nests** the build under the package path: `.next/standalone/apps/web/.next/server/app`.

`scripts/stub-prerendered-handlers.ts` hardcoded the non-nested path `.next/standalone/.next/server/app`, so `cf:build` failed with:
```
Required path missing: .../apps/web/.next/standalone/.next/server/app. Did 'next build' run first?
```
This slipped past PR #1222's merge because `preview` is not a required check.

### Fix
Detect the package sub-path the same way `@opennextjs/aws` locates the monorepo root (first lockfile walking up), then build `.next/standalone/<pkgPath>/.next/server/app`. Works in both single-package (`pkgPath=''`) and monorepo (`pkgPath='apps/web'`) layouts.

### Verified
Full `cf:build` end-to-end locally: ✅ 75 handlers stubbed → Worker saved → OpenNext complete → 97 prerendered files copied → 306 restored. Exit 0.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Next.js standalone output handling for monorepo projects by automatically detecting package paths relative to the repository root, enabling proper support for packages at any directory level.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->