### PR TITLE
fix(peerdb): correctness fixes + code review P1 fixes (#1212)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -27,8 +27,15 @@ module.exports = {
       name: 'no-cross-app-imports',
       severity: 'error',
       comment: 'Apps must not import from other apps.',
-      from: { path: '^apps/([^/]+)/' },
-      to: { path: '^apps/(?!(\\1))([^/]+)/' },
+      from: { path: '^apps/web/' },
+      to: { path: '^apps/mcp-worker/' },
+    },
+    {
+      name: 'no-cross-app-imports-reverse',
+      severity: 'error',
+      comment: 'Apps must not import from other apps.',
+      from: { path: '^apps/mcp-worker/' },
+      to: { path: '^apps/web/' },
     },
 
     // ── Leaf packages must stay leaf-only ─────────────────────────────────

--- a/apps/web/app/(peerdb)/layout.tsx
+++ b/apps/web/app/(peerdb)/layout.tsx
@@ -1,3 +1,8 @@
+// Near-identical to (dashboard)/layout.tsx — kept as a separate copy so PeerDB
+// pages can diverge (different sidebar, metadata, or provider tree) without
+// risking breakage in the main dashboard. If the layouts stay identical for
+// 60+ days, consider extracting a shared layout component.
+
 import type { Metadata, Viewport } from 'next'
 
 import Script from 'next/script'

--- a/apps/web/components/peerdb/kpi-card.tsx
+++ b/apps/web/components/peerdb/kpi-card.tsx
@@ -1,3 +1,6 @@
+// PeerDB-specific KPI card with integrated sparkline and status dot.
+// Differs from overview-charts/kpi-card.tsx (main dashboard). Do not merge without design sign-off.
+
 import type { ReactNode } from 'react'
 
 import { PdbSparkline } from './pdb-charts'

--- a/apps/web/components/peerdb/peerdb-utils.ts
+++ b/apps/web/components/peerdb/peerdb-utils.ts
@@ -212,7 +212,13 @@ export function isPeerDBNotConfigured(error: unknown): boolean {
 
 // ─────────────────────── design-spec formatting (CHM Redesign) ───────────────────────
 
-/** Compact count: 1.2K / 3.4M / 1.23B / 2.10T. */
+/**
+ * Compact count: 1.2K / 3.4M / 1.23B / 2.10T.
+ *
+ * Note: intentionally separate from formatCompactNumber (lib/format-readable.ts) due to
+ * different thresholds (adds T tier) and sub-1000 formatting (toLocaleString).
+ * Do not merge without design sign-off.
+ */
 export function pdbFmtNum(n?: number | null): string {
   if (n == null) return '—'
   if (n >= 1e12) return `${(n / 1e12).toFixed(2)}T`
@@ -254,11 +260,17 @@ export function pdbFmtDuration(s?: number | null): string {
  */
 export function parseTs(value?: string | number | null): number | null {
   if (value == null || value === '') return null
-  if (typeof value === 'number' || /^\d+$/.test(value)) {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return null
+    // < 1e11 (100 billion) is epoch seconds, otherwise epoch milliseconds.
+    // Using 1e11 avoids misclassifying epoch-ms timestamps before ~2001.
+    return value < 1e11 ? value * 1000 : value
+  }
+  if (/^\d+$/.test(value)) {
     const n = Number(value)
     if (!Number.isFinite(n)) return null
-    // < 1e12 is epoch seconds, otherwise epoch milliseconds.
-    return n < 1e12 ? n * 1000 : n
+    // < 1e11 (100 billion) is epoch seconds, otherwise epoch milliseconds.
+    return n < 1e11 ? n * 1000 : n
   }
   const t = Date.parse(value)
   return Number.isNaN(t) ? null : t
@@ -278,15 +290,8 @@ export function pdbFmtClock(iso?: string | number): string {
  */
 export function pdbFmtAgo(value?: string | number): string {
   if (value == null || value === '') return '—'
-  let t: number
-  if (typeof value === 'number' || /^\d+$/.test(value)) {
-    const n = Number(value)
-    // Heuristic: < 1e12 is epoch seconds, otherwise epoch milliseconds.
-    t = n < 1e12 ? n * 1000 : n
-  } else {
-    t = Date.parse(value)
-  }
-  if (Number.isNaN(t)) return '—'
+  const t = parseTs(value)
+  if (t == null) return '—'
   const sec = Math.max(0, (Date.now() - t) / 1000)
   const d = Math.floor(sec / 86400)
   const h = Math.floor((sec % 86400) / 3600)

--- a/apps/web/components/peerdb/qrep-partitions.tsx
+++ b/apps/web/components/peerdb/qrep-partitions.tsx
@@ -10,8 +10,14 @@ import {
 
 export function partitionState(
   p: QRepPartition
-): 'done' | 'running' | 'queued' {
-  if (p.endTime) return 'done'
+): 'done' | 'running' | 'queued' | 'error' {
+  if (p.endTime) {
+    const synced = toNumber(p.rowsSynced)
+    const total = toNumber(p.rowsInPartition ?? p.numRows)
+    // If endTime is set but rowsSynced < rowsInPartition, the partition failed.
+    if (total > 0 && synced > 0 && synced < total) return 'error'
+    return 'done'
+  }
   // A partition that has started (has a startTime) or already synced rows is
   // in flight; only un-started partitions are queued.
   if (p.startTime || toNumber(p.rowsSynced) > 0) return 'running'
@@ -22,6 +28,7 @@ const PART_TONE: Record<string, string> = {
   done: '#10b981',
   running: '#3b82f6',
   queued: '#94a3b8',
+  error: '#f43f5e',
 }
 
 /** Bucket partition rows-synced by completion hour for the sync-history chart. */
@@ -56,6 +63,7 @@ export function QRepPartitions({
   partitions: QRepPartition[]
 }) {
   const done = partitions.filter((p) => partitionState(p) === 'done').length
+  const errored = partitions.filter((p) => partitionState(p) === 'error').length
   const running = partitions.filter(
     (p) => partitionState(p) === 'running'
   ).length
@@ -82,6 +90,15 @@ export function QRepPartitions({
               {queued}
             </span>
             <span className="text-muted-foreground"> queued</span>
+            {errored > 0 && (
+              <>
+                <span className="mx-1.5 text-muted-foreground">·</span>
+                <span className="font-semibold text-rose-600 dark:text-rose-400">
+                  {errored}
+                </span>
+                <span className="text-muted-foreground"> error</span>
+              </>
+            )}
           </span>
         </div>
       </div>

--- a/apps/web/components/peerdb/use-mirror-metrics.ts
+++ b/apps/web/components/peerdb/use-mirror-metrics.ts
@@ -8,7 +8,7 @@ import type {
   QRepPartition,
 } from '@/lib/peerdb/types'
 
-import { toNumber } from './peerdb-utils'
+import { parseTs, toNumber } from './peerdb-utils'
 import { usePeerDB } from '@/lib/swr'
 
 export interface DerivedMetrics {
@@ -72,7 +72,10 @@ export function useMirrorMetrics(
   const batches = batchesReq.data?.cdcBatches ?? cdc?.cdcBatches ?? []
   const trend = (graph.data?.data ?? []).map((p) => toNumber(p.rows))
 
-  const rowsPerSec = trend.length ? Math.round(trend[trend.length - 1] / 60) : 0
+  // Use the second-to-last bucket when available (complete 1-min window);
+  // the latest bucket may be partial and understate throughput.
+  const _bucketIdx = trend.length > 1 ? trend.length - 2 : trend.length - 1
+  const rowsPerSec = trend.length ? trend[_bucketIdx] / 60 : 0
 
   const rowsSynced = isCdc
     ? cdc?.rowsSynced == null
@@ -83,8 +86,8 @@ export function useMirrorMetrics(
   let lagSec: number | null = status.data?.lagSec ?? null
   if (lagSec === null && isCdc && batches.length) {
     const last = batches[batches.length - 1]
-    const end = last.endTime ? Date.parse(last.endTime) : NaN
-    if (!Number.isNaN(end)) lagSec = Math.max(0, (Date.now() - end) / 1000)
+    const end = last.endTime ? parseTs(last.endTime) : null
+    if (end != null) lagSec = Math.max(0, (Date.now() - end) / 1000)
   }
 
   return {


### PR DESCRIPTION
## PeerDB Correctness Fixes (issue #1212)

Addresses the PLAUSIBLE correctness findings from the multi-agent review of #1209.

### Fixes

**parseTs epoch heuristic** (`peerdb-utils.ts`)
- Changed threshold from `1e12` to `1e11` — old value misclassified epoch-ms before ~2001
- Added `typeof value === 'number'` branch to handle numeric epoch values directly
- Consolidated timestamp parsing to single heuristic location

**partitionState marks failed partitions** (`qrep-partitions.tsx`)
- Added `'error'` state when `endTime` is set but `rowsSynced < rowsInPartition`
- Previously marked these as `'done'` — now shows error styling (rose/red)

**rowsPerSec partial bucket** (`use-mirror-metrics.ts`)
- Uses second-to-last bucket for complete 1-min window instead of partial in-progress bucket
- Falls back to latest bucket only when single data point

**lag NaN for epoch numbers** (`use-mirror-metrics.ts`)
- Replaced `Date.parse(endTime)` with `parseTs(endTime)` to handle epoch-number timestamps

### Code Review P1 Fixes

**Depcruise cross-app regex** (`.dependency-cruiser.cjs`)
- Fixed broken backreference that made the `no-cross-app-imports` rule a complete no-op
- Replaced with explicit bidirectional app-name rules

**Changeset config** (`.changeset/config.json`)
- Changed `access` from `"restricted"` to `"public"` to match per-package `publishConfig`

### Cleanup
- Added dedup comments to `pdbFmtNum`, `kpi-card.tsx`, and `(peerdb)/layout.tsx`

Closes #1212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Partitions now display error status when synced rows are below expected totals.
  * Improved timestamp parsing to correctly handle edge cases.
  * Updated throughput and lag metric calculations for accuracy.

* **Chores**
  * Updated configuration settings and internal dependency rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->