### PR TITLE
fix(agents): gate useUser behind isClerkEnabled + fail-fast query-config test

### DIFF
--- a/apps/web/components/assistant-ui/agent-thread-page.tsx
+++ b/apps/web/components/assistant-ui/agent-thread-page.tsx
@@ -17,7 +17,6 @@
 import { PanelLeftOpenIcon, PanelRightOpenIcon } from 'lucide-react'
 import { ErrorBoundary } from 'react-error-boundary'
 
-import { useUser } from '@clerk/nextjs'
 import { useEffect, useState } from 'react'
 import { AgentSettingsSidebar } from '@/components/agents/welcome/agent-settings-sidebar'
 import { AgentRuntimeProvider } from '@/components/assistant-ui/agent-runtime-provider'
@@ -25,8 +24,20 @@ import { Thread } from '@/components/assistant-ui/thread'
 import { ThreadList } from '@/components/assistant-ui/thread-list'
 import { Button } from '@/components/ui/button'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { isClerkEnabled } from '@/lib/clerk/clerk-client'
 import { useHostId } from '@/lib/swr/use-host'
 import { useHosts } from '@/lib/swr/use-hosts'
+
+/**
+ * Clerk's `useUser()` throws unless a `<ClerkProvider />` is mounted, and that
+ * provider is only rendered when `isClerkEnabled()` is true (see
+ * `components/clerk/clerk-auth-provider.tsx`). Gate the hook behind the same
+ * build-time constant so the agents page never calls `useUser()` when Clerk is
+ * disabled — same lazy-require pattern as `components/nav-user.tsx`.
+ */
+const useClerkFirstName: () => string | null = isClerkEnabled()
+  ? require('@/components/assistant-ui/use-clerk-first-name').useClerkFirstName
+  : () => null
 
 function AgentThreadPageError() {
   return (
@@ -47,15 +58,11 @@ export function AgentThreadPage() {
   useEffect(() => {
     setRightSidebarOpen(!isMobile)
   }, [isMobile])
-  const { user } = useUser()
+  const firstName = useClerkFirstName()
   const hostId = useHostId()
   const { hosts } = useHosts()
   const currentHost = hosts.find((h) => h.id === hostId)
   const clusterName = currentHost?.name ?? null
-  const firstName =
-    user?.firstName ??
-    (user?.fullName ? user.fullName.split(' ')[0] : null) ??
-    null
 
   return (
     <ErrorBoundary FallbackComponent={AgentThreadPageError}>

--- a/apps/web/components/assistant-ui/use-clerk-first-name.ts
+++ b/apps/web/components/assistant-ui/use-clerk-first-name.ts
@@ -1,0 +1,22 @@
+'use client'
+
+import { useUser } from '@clerk/nextjs'
+
+/**
+ * Returns the signed-in user's first name (or null) for the agent welcome
+ * greeting.
+ *
+ * IMPORTANT: This calls Clerk's `useUser()`, which throws when no
+ * `<ClerkProvider />` is mounted. It MUST only be imported/invoked when
+ * `isClerkEnabled()` is true. The consumer gates this behind a build-time
+ * conditional `require` (see `agent-thread-page.tsx`), mirroring
+ * `components/nav-user.tsx`.
+ */
+export function useClerkFirstName(): string | null {
+  const { user } = useUser()
+  return (
+    user?.firstName ??
+    (user?.fullName ? user.fullName.split(' ')[0] : null) ??
+    null
+  )
+}

--- a/apps/web/lib/query-config/__tests__/query-config.test.ts
+++ b/apps/web/lib/query-config/__tests__/query-config.test.ts
@@ -137,6 +137,13 @@ describe('Query Config Validation', () => {
       host,
       username,
       password,
+      // Fail fast when no ClickHouse is reachable (e.g. the unit-tests job runs
+      // this suite with no service container). Without a client-side timeout a
+      // hanging or proxied host burns the full QUERY_TIMEOUT_MS hook budget and
+      // fails `beforeAll` as "(unnamed)" before the catch below can mark it
+      // unavailable. test-queries-config has a real ClickHouse that responds in
+      // milliseconds, so this never trips there.
+      request_timeout: 10000,
       clickhouse_settings: {
         max_execution_time: 30,
       },


### PR DESCRIPTION
## Problem

Two issues on `main`:

1. **`/agents` crashes in production** with `useUser can only be used within the <ClerkProvider />`. `AgentThreadPage` called Clerk's `useUser()` unconditionally, but `ClerkProvider` only mounts when `isClerkEnabled()` is true. When Clerk is disabled at build time (no `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` inlined), the provider is absent and the hook throws — crashing only `/agents`, while gated consumers like `nav-user` stayed safe. Verified there is a single `@clerk/shared@4.13.1` in the lockfile, so the error's "multiple versions" hypothesis is ruled out.

2. **`Test → unit-tests` job red on main.** The job runs the full suite (`test:coverage`) with **no ClickHouse service container**. The query-config integration test's `beforeAll` is meant to skip gracefully when ClickHouse is down, but the client had no client-side timeout — a hanging/proxied host (returned a `502 Every upstream failed`) burned the full 30s hook budget and failed as `(unnamed)` before the catch ran.

## Fix

- Move `useUser()` into a lazily-`require()`d helper (`use-clerk-first-name.ts`) gated by the same build-time constant as `nav-user.tsx`, so it's never invoked when Clerk is off. `firstName` is purely cosmetic (welcome greeting), falls back to `null`.
- Add `request_timeout: 10000` to the query-config test's ClickHouse client so an unreachable host fails fast (<30s hook budget) and the existing skip logic engages. `test-queries-config` (real ClickHouse) responds in ms, so it's unaffected.

## Verification

- `tsc --noEmit` ✅
- `biome lint` ✅ on changed files
- `bun test query-config.test.ts` with no ClickHouse → **287 pass, 0 fail** (graceful skip, 125ms)

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication system reliability by optimizing how user information is retrieved when Clerk authentication provider is disabled or unavailable, reducing potential application errors.

* **Tests**
  * Added request timeout configuration to integration test suite to prevent tests from hanging when services are unreachable, improving test reliability and preventing resource exhaustion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->