### PR TITLE
fix(test): abort query-config version probe instead of request_timeout

### DIFF
--- a/apps/web/lib/query-config/__tests__/query-config.test.ts
+++ b/apps/web/lib/query-config/__tests__/query-config.test.ts
@@ -137,23 +137,27 @@ describe('Query Config Validation', () => {
       host,
       username,
       password,
-      // Fail fast when no ClickHouse is reachable (e.g. the unit-tests job runs
-      // this suite with no service container). Without a client-side timeout a
-      // hanging or proxied host burns the full QUERY_TIMEOUT_MS hook budget and
-      // fails `beforeAll` as "(unnamed)" before the catch below can mark it
-      // unavailable. test-queries-config has a real ClickHouse that responds in
-      // milliseconds, so this never trips there.
-      request_timeout: 10000,
       clickhouse_settings: {
         max_execution_time: 30,
       },
     })
 
-    // Get ClickHouse version
+    // Get ClickHouse version.
+    //
+    // Fail fast when no ClickHouse is reachable (e.g. the unit-tests job runs
+    // this suite with no service container; the host may hang behind a proxy
+    // rather than refuse the connection). `request_timeout` does not abort such
+    // a hung fetch, so without an explicit abort the connect burns the full
+    // QUERY_TIMEOUT_MS hook budget and fails `beforeAll` as "(unnamed)". An
+    // AbortSignal cancels the fetch in 5s so the catch below can mark
+    // ClickHouse unavailable and the integration assertions skip.
+    // test-queries-config has a real ClickHouse that responds in milliseconds,
+    // so this never trips there.
     try {
       const result = await client.query({
         query: 'SELECT version() as version',
         format: 'JSONEachRow',
+        abort_signal: AbortSignal.timeout(5000),
       })
       const rows = await result.json<{ version: string }[]>()
       if (rows[0]?.version) {


### PR DESCRIPTION
Follow-up to #1235.

## Problem

#1235 added `request_timeout: 10000` to the query-config integration test's ClickHouse client to stop the `unit-tests` job (full suite, no ClickHouse service container) from hanging the 30s `beforeAll` budget. But `request_timeout` does **not** abort a hung/proxied connection in `@clickhouse/client-web` — verified on the merged commit, where `unit-tests` still failed with the identical `Query Config Validation > (unnamed) [30000ms]` timeout.

## Fix

Replace `request_timeout` with `abort_signal: AbortSignal.timeout(5000)` on the version probe. The AbortSignal cancels the fetch after 5s, so the existing `try/catch` marks ClickHouse unavailable and the integration assertions skip — instead of blowing the hook timeout.

`test-queries-config` (real ClickHouse, sub-second responses) is unaffected; the abort never trips there.

## Verification

- `bun test query-config.test.ts` with no ClickHouse → **287 pass, 0 fail** (graceful skip, ~100ms)
- `biome lint` ✅

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated ClickHouse integration test configuration to improve timeout handling and failure detection when ClickHouse is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->