### PR TITLE
fix(test): bound query-config probe with a wall-clock race

### DIFF
--- a/apps/web/lib/query-config/__tests__/query-config.test.ts
+++ b/apps/web/lib/query-config/__tests__/query-config.test.ts
@@ -142,22 +142,24 @@ describe('Query Config Validation', () => {
       },
     })
 
-    // Get ClickHouse version.
+    // Probe the ClickHouse version with a hard wall-clock cap.
     //
-    // Fail fast when no ClickHouse is reachable (e.g. the unit-tests job runs
-    // this suite with no service container; the host may hang behind a proxy
-    // rather than refuse the connection). `request_timeout` does not abort such
-    // a hung fetch, so without an explicit abort the connect burns the full
-    // QUERY_TIMEOUT_MS hook budget and fails `beforeAll` as "(unnamed)". An
-    // AbortSignal cancels the fetch in 5s so the catch below can mark
-    // ClickHouse unavailable and the integration assertions skip.
-    // test-queries-config has a real ClickHouse that responds in milliseconds,
-    // so this never trips there.
-    try {
+    // The unit-tests CI job runs this suite with no ClickHouse service
+    // container; the configured host hangs behind a proxy rather than refusing
+    // the connection. Neither `request_timeout` nor `abort_signal` reliably
+    // aborts that hung fetch in CI (verified: both still burned the full 30s
+    // QUERY_TIMEOUT_MS hook budget and failed `beforeAll` as "(unnamed)"). So
+    // race the probe against a timer we fully control — it always wins if the
+    // fetch hangs, letting the catch mark ClickHouse unavailable so the
+    // integration assertions skip. test-queries-config has a real ClickHouse
+    // that responds in milliseconds, so the timer never trips there; the
+    // abandoned fetch (if any) is torn down by client.close() in afterAll.
+    const PROBE_TIMEOUT_MS = 6000
+    const probe = (async () => {
       const result = await client.query({
         query: 'SELECT version() as version',
         format: 'JSONEachRow',
-        abort_signal: AbortSignal.timeout(5000),
+        abort_signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
       })
       const rows = await result.json<{ version: string }[]>()
       if (rows[0]?.version) {
@@ -166,11 +168,29 @@ describe('Query Config Validation', () => {
         isClickHouseAvailable = true
         console.log(`Connected to ClickHouse version: ${versionString}`)
       }
+    })()
+    // Swallow a late rejection from an abandoned (timed-out) probe so it does
+    // not surface as an unhandled rejection after the race resolves.
+    probe.catch(() => {})
+
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      await Promise.race([
+        probe,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error('ClickHouse probe timed out')),
+            PROBE_TIMEOUT_MS + 500
+          )
+        }),
+      ])
     } catch (_err) {
       console.warn(
         'ClickHouse not available - integration tests will be skipped'
       )
       console.warn('Run with ClickHouse running or in CI environment')
+    } finally {
+      if (timer) clearTimeout(timer)
     }
   }, QUERY_TIMEOUT_MS)
 


### PR DESCRIPTION
Follow-up to #1235 and #1236.

## Problem

The `unit-tests` CI job has failed on `main` across several commits with `Query Config Validation > (unnamed) [30000ms]`. The job runs the full suite with **no ClickHouse service container**, and the configured host hangs behind a proxy. Both prior attempts failed in CI:

- #1235 `request_timeout: 10000` — still hung 30s
- #1236 `abort_signal: AbortSignal.timeout(5000)` — still hung 30s

`@clickhouse/client-web` does not propagate either cancellation to its underlying fetch in the CI runtime.

## Fix

Race the version probe against a **timer we fully control** (6.5s). Whichever settles first wins, so the `beforeAll` hook always returns even when the client ignores the abort. The `catch` marks ClickHouse unavailable → integration assertions skip. An abandoned probe is torn down by `client.close()` in `afterAll`, so the test process still exits cleanly.

## Verification

Reproduced the exact CI scenario locally with a TCP server that accepts connections but never replies:

- **Before**: 30s timeout, `beforeAll` fails as `(unnamed)`
- **After**: **287 pass, 0 fail, ~6s**, clean process exit

`test-queries-config` (real ClickHouse, sub-second responses) never trips the timer.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced ClickHouse availability detection in the test suite with improved timeout handling to prevent unreliable test behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->