### PR TITLE
feat(agents): show chat UI for everyone, gate sending on sign-in

### DIFF
--- a/apps/web/components/assistant-ui/agent-auth-gate.tsx
+++ b/apps/web/components/assistant-ui/agent-auth-gate.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { LockKeyholeIcon } from 'lucide-react'
+
+import {
+  createContext,
+  type ReactNode,
+  use,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { isClerkEnabled } from '@/lib/clerk/clerk-client'
+import { useFeaturePermissions } from '@/lib/feature-permissions/context'
+import { AGENT_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
+
+/**
+ * Clerk's `SignInButton` requires a mounted `<ClerkProvider />`. Gate it behind
+ * the build-time `isClerkEnabled()` constant (same lazy-require pattern as
+ * `components/nav-user.tsx`) so this never loads Clerk when auth is disabled.
+ * When Clerk is off there is no sign-in to offer, so the value is null and the
+ * dialog renders without a sign-in action.
+ */
+const ClerkSignInButton:
+  | ((props: { children: ReactNode }) => ReactNode)
+  | null = isClerkEnabled()
+  ? require('@/components/clerk/clerk-sign-in-button').ClerkSignInButton
+  : null
+
+interface AgentAuthGateValue {
+  /**
+   * Call before an auth-requiring interaction (e.g. sending a message).
+   * Returns true if the user may proceed; otherwise opens the sign-in dialog
+   * and returns false so the caller can abort.
+   */
+  ensureAuthed: () => boolean
+}
+
+const AgentAuthGateContext = createContext<AgentAuthGateValue | null>(null)
+
+/**
+ * Renders the agent chat UI for everyone (the route is interaction-gated, see
+ * `feature-route-gate.tsx`) and prompts for sign-in only when an
+ * auth-requiring action is attempted.
+ */
+export function AgentAuthGate({ children }: { children: ReactNode }) {
+  const { isAllowed, isLoading } = useFeaturePermissions()
+  const [open, setOpen] = useState(false)
+
+  const ensureAuthed = useCallback(() => {
+    // Optimistic while the permission config loads — the server still enforces
+    // auth on /api/v1/agent. Once loaded, gate strictly on the agent feature.
+    if (isLoading) return true
+    if (isAllowed(AGENT_FEATURE_PERMISSION)) return true
+    setOpen(true)
+    return false
+  }, [isAllowed, isLoading])
+
+  const value = useMemo<AgentAuthGateValue>(
+    () => ({ ensureAuthed }),
+    [ensureAuthed]
+  )
+
+  return (
+    <AgentAuthGateContext.Provider value={value}>
+      {children}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <div className="bg-muted mb-2 flex size-12 items-center justify-center rounded-full">
+              <LockKeyholeIcon className="text-muted-foreground size-5" />
+            </div>
+            <DialogTitle>Authentication required</DialogTitle>
+            <DialogDescription>
+              Sign in to chat with the AI agent. You can keep exploring the
+              interface without an account.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2 sm:gap-2">
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              Keep exploring
+            </Button>
+            {ClerkSignInButton ? (
+              <ClerkSignInButton>
+                <Button>Sign in</Button>
+              </ClerkSignInButton>
+            ) : null}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </AgentAuthGateContext.Provider>
+  )
+}
+
+/**
+ * Access the agent auth gate. Falls back to an always-allow gate when used
+ * outside an `AgentAuthGate` (e.g. in isolated tests), so callers never crash.
+ */
+export function useAgentAuthGate(): AgentAuthGateValue {
+  return use(AgentAuthGateContext) ?? { ensureAuthed: () => true }
+}

--- a/apps/web/components/assistant-ui/agent-thread-page.tsx
+++ b/apps/web/components/assistant-ui/agent-thread-page.tsx
@@ -19,6 +19,7 @@ import { ErrorBoundary } from 'react-error-boundary'
 
 import { useEffect, useState } from 'react'
 import { AgentSettingsSidebar } from '@/components/agents/welcome/agent-settings-sidebar'
+import { AgentAuthGate } from '@/components/assistant-ui/agent-auth-gate'
 import { AgentRuntimeProvider } from '@/components/assistant-ui/agent-runtime-provider'
 import { Thread } from '@/components/assistant-ui/thread'
 import { ThreadList } from '@/components/assistant-ui/thread-list'
@@ -66,67 +67,69 @@ export function AgentThreadPage() {
 
   return (
     <ErrorBoundary FallbackComponent={AgentThreadPageError}>
-      <AgentRuntimeProvider>
-        <div className="bg-background flex h-[calc(100dvh-6rem)] min-h-0 overflow-hidden rounded-xl border">
-          {/* Conversation rail */}
-          {leftSidebarOpen ? (
-            <aside className="bg-muted/30 hidden w-64 shrink-0 flex-col gap-2 overflow-y-auto border-r p-2 lg:flex">
-              <div className="flex items-center justify-between gap-2 px-2 pt-1">
-                <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-                  Conversations
-                </p>
+      <AgentAuthGate>
+        <AgentRuntimeProvider>
+          <div className="bg-background flex h-[calc(100dvh-6rem)] min-h-0 overflow-hidden rounded-xl border">
+            {/* Conversation rail */}
+            {leftSidebarOpen ? (
+              <aside className="bg-muted/30 hidden w-64 shrink-0 flex-col gap-2 overflow-y-auto border-r p-2 lg:flex">
+                <div className="flex items-center justify-between gap-2 px-2 pt-1">
+                  <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                    Conversations
+                  </p>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => setLeftSidebarOpen(false)}
+                    className="text-muted-foreground hover:text-foreground size-6 shrink-0"
+                    aria-label="Hide conversations"
+                  >
+                    <PanelLeftOpenIcon className="size-3.5 rotate-180" />
+                  </Button>
+                </div>
+                <ThreadList />
+              </aside>
+            ) : null}
+
+            {/* Main column */}
+            <div className="relative flex min-w-0 flex-1 flex-col">
+              {!leftSidebarOpen ? (
                 <Button
                   type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => setLeftSidebarOpen(false)}
-                  className="text-muted-foreground hover:text-foreground size-6 shrink-0"
-                  aria-label="Hide conversations"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setLeftSidebarOpen(true)}
+                  className="absolute top-3 left-3 z-10 hidden h-8 gap-1.5 px-2.5 text-[11.5px] whitespace-nowrap lg:inline-flex"
                 >
-                  <PanelLeftOpenIcon className="size-3.5 rotate-180" />
+                  <PanelLeftOpenIcon className="size-3.5" />
+                  Conversations
                 </Button>
-              </div>
-              <ThreadList />
-            </aside>
-          ) : null}
+              ) : null}
+              {!rightSidebarOpen ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setRightSidebarOpen(true)}
+                  className="absolute top-3 right-3 z-10 h-8 gap-1.5 px-2.5 text-[11.5px] whitespace-nowrap"
+                >
+                  <PanelRightOpenIcon className="size-3.5" />
+                  Agent settings
+                </Button>
+              ) : null}
+              <Thread firstName={firstName} clusterName={clusterName} />
+            </div>
 
-          {/* Main column */}
-          <div className="relative flex min-w-0 flex-1 flex-col">
-            {!leftSidebarOpen ? (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => setLeftSidebarOpen(true)}
-                className="absolute top-3 left-3 z-10 hidden h-8 gap-1.5 px-2.5 text-[11.5px] whitespace-nowrap lg:inline-flex"
-              >
-                <PanelLeftOpenIcon className="size-3.5" />
-                Conversations
-              </Button>
-            ) : null}
-            {!rightSidebarOpen ? (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => setRightSidebarOpen(true)}
-                className="absolute top-3 right-3 z-10 h-8 gap-1.5 px-2.5 text-[11.5px] whitespace-nowrap"
-              >
-                <PanelRightOpenIcon className="size-3.5" />
-                Agent settings
-              </Button>
-            ) : null}
-            <Thread firstName={firstName} clusterName={clusterName} />
+            {/* Settings sidebar */}
+            <AgentSettingsSidebar
+              open={rightSidebarOpen}
+              onClose={() => setRightSidebarOpen(false)}
+              hostName={clusterName ?? 'duyet-agent'}
+            />
           </div>
-
-          {/* Settings sidebar */}
-          <AgentSettingsSidebar
-            open={rightSidebarOpen}
-            onClose={() => setRightSidebarOpen(false)}
-            hostName={clusterName ?? 'duyet-agent'}
-          />
-        </div>
-      </AgentRuntimeProvider>
+        </AgentRuntimeProvider>
+      </AgentAuthGate>
     </ErrorBoundary>
   )
 }

--- a/apps/web/components/assistant-ui/thread.tsx
+++ b/apps/web/components/assistant-ui/thread.tsx
@@ -51,6 +51,7 @@ import { type FC, type ReactNode, useCallback, useRef } from 'react'
 import { PromptInputTextareaWithMentions } from '@/components/agents/mentions'
 import { AgentWelcomeScreen } from '@/components/agents/welcome/agent-welcome-screen'
 import { ComposerToolbar } from '@/components/agents/welcome/composer-toolbar'
+import { useAgentAuthGate } from '@/components/assistant-ui/agent-auth-gate'
 import { JsonRenderMessage } from '@/components/assistant-ui/json-render-message'
 import { MarkdownText } from '@/components/assistant-ui/markdown-text'
 import {
@@ -173,17 +174,19 @@ function ThreadWelcome({
 }: ThreadWelcomeProps) {
   const { activeToolCount } = useAgentSkills()
   const threadRuntime = useThreadRuntime()
+  const { ensureAuthed } = useAgentAuthGate()
 
   const handlePickPrompt = useCallback(
     (prompt: string) => {
       const trimmed = prompt.trim()
       if (!trimmed) return
+      if (!ensureAuthed()) return
       threadRuntime.append({
         role: 'user',
         content: [{ type: 'text', text: trimmed }],
       })
     },
-    [threadRuntime]
+    [threadRuntime, ensureAuthed]
   )
 
   return (
@@ -208,6 +211,7 @@ function ThreadWelcome({
 function WelcomeComposer() {
   const threadRuntime = useThreadRuntime()
   const isRunning = useThread((thread) => thread.isRunning)
+  const { ensureAuthed } = useAgentAuthGate()
 
   return (
     <div className="flex flex-col gap-2">
@@ -216,6 +220,7 @@ function WelcomeComposer() {
         onResolvedSubmit={(text) => {
           const trimmed = text.trim()
           if (!trimmed) return
+          if (!ensureAuthed()) return
           threadRuntime.append({
             role: 'user',
             content: [{ type: 'text', text: trimmed }],
@@ -231,6 +236,7 @@ function WelcomeComposer() {
 function ThreadComposer() {
   const threadRuntime = useThreadRuntime()
   const isRunning = useThread((thread) => thread.isRunning)
+  const { ensureAuthed } = useAgentAuthGate()
 
   return (
     <div className="w-full">
@@ -239,6 +245,7 @@ function ThreadComposer() {
         onResolvedSubmit={(text) => {
           const trimmed = text.trim()
           if (!trimmed) return
+          if (!ensureAuthed()) return
           threadRuntime.append({
             role: 'user',
             content: [{ type: 'text', text: trimmed }],

--- a/apps/web/components/clerk/clerk-sign-in-button.tsx
+++ b/apps/web/components/clerk/clerk-sign-in-button.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import type { ReactNode } from 'react'
+
+import { SignInButton } from '@clerk/nextjs'
+
+/**
+ * Thin wrapper over Clerk's modal `SignInButton`.
+ *
+ * IMPORTANT: `SignInButton` requires a mounted `<ClerkProvider />`, so this
+ * module MUST only be imported/rendered when `isClerkEnabled()` is true. The
+ * consumer gates it behind a build-time conditional `require` (see
+ * `agent-auth-gate.tsx`), mirroring `components/nav-user.tsx`.
+ */
+export function ClerkSignInButton({ children }: { children: ReactNode }) {
+  return <SignInButton mode="modal">{children}</SignInButton>
+}

--- a/apps/web/components/feature-permissions/feature-route-gate.tsx
+++ b/apps/web/components/feature-permissions/feature-route-gate.tsx
@@ -30,6 +30,9 @@ export function FeatureRouteGate({ children }: { children: ReactNode }) {
     state.access === 'authenticated' &&
     config.principal !== 'authenticated'
   ) {
+    // Interaction-gated features (e.g. the agent) render their UI for everyone
+    // and prompt for sign-in only when an auth-requiring action is attempted.
+    if (permission.interactionGated) return children
     return <FeatureUnavailable feature={permission.feature} reason="auth" />
   }
 

--- a/apps/web/lib/feature-permissions/permissions.ts
+++ b/apps/web/lib/feature-permissions/permissions.ts
@@ -2,6 +2,7 @@ import type { FeaturePermission } from './types'
 
 export const AGENT_FEATURE_PERMISSION = {
   feature: 'agent',
+  interactionGated: true,
 } satisfies FeaturePermission
 
 export const ACTIONS_FEATURE_PERMISSION = {

--- a/apps/web/lib/feature-permissions/types.ts
+++ b/apps/web/lib/feature-permissions/types.ts
@@ -33,6 +33,15 @@ export interface FeaturePermission {
    * @default public
    */
   defaultAccess?: FeatureAccess
+  /**
+   * When true, an `authenticated`-only feature is NOT blocked at the route
+   * level for anonymous principals — the page renders and the feature gates
+   * the auth-requiring *interaction* itself (e.g. the agent shows its chat UI
+   * and only prompts for sign-in when the user tries to send a message).
+   *
+   * @default false
+   */
+  interactionGated?: boolean
 }
 
 export interface FeatureOverride {

--- a/apps/web/menu.ts
+++ b/apps/web/menu.ts
@@ -55,7 +55,9 @@ export const menuItemsConfig: MenuItem[] = [
     icon: SparklesIcon,
     section: 'main',
     isNew: true,
-    permission: { feature: 'agent' },
+    // Render the chat UI for everyone; sign-in is prompted on send, not at the
+    // route level. See AGENT_FEATURE_PERMISSION / AgentAuthGate.
+    permission: { feature: 'agent', interactionGated: true },
   },
   {
     title: 'Insights',


### PR DESCRIPTION
## Motivation

`/agents` was fully blocked by `FeatureRouteGate` with a full-page "Authentication required" card for anonymous principals — visitors never saw the agent. We want to **show off** the chat UI and only prompt for sign-in when someone actually tries to send a message.

## Changes

- **`interactionGated` flag on `FeaturePermission`.** When set, an `authenticated`-only feature renders its UI at the route level instead of being blocked; the feature gates the auth-requiring *interaction* itself. Set on the agent menu entry and `AGENT_FEATURE_PERMISSION`.
- **`FeatureRouteGate`**: for `interactionGated` permissions, render children instead of the auth block.
- **`AgentAuthGate`** (new): provides `ensureAuthed()` + an "Authentication required" dialog with a Clerk sign-in button. The sign-in button is gated behind `isClerkEnabled()` via the same lazy-`require` pattern as `nav-user.tsx`, so it never loads Clerk when auth is disabled.
- **`thread.tsx`**: all three user-send paths (suggestion picks, welcome composer, in-thread composer) call `ensureAuthed()` before `append()` — the single choke point for user messages.

The `/api/v1/agent` route still enforces auth server-side; this only changes the client UX.

## Behavior

| | Before | After |
|---|---|---|
| Anonymous visits `/agents` | Full-page "Authentication required" | Full chat UI |
| Anonymous sends a message | (unreachable) | "Authentication required" dialog → sign in |
| Signed-in user | Chat UI | Chat UI (unchanged) |

## Verification

- `tsc --noEmit` ✅
- `biome check` ✅
- No existing tests asserted the old route-block behavior.

Co-Authored-By: duyetbot <bot@duyet.net>