### PR TITLE
feat(agents): polish agents page — dialogs, scrollable popovers, header cleanup

### DIFF
--- a/apps/web/components/agents/welcome/add-context-dialog.tsx
+++ b/apps/web/components/agents/welcome/add-context-dialog.tsx
@@ -1,0 +1,228 @@
+'use client'
+
+/**
+ * "Add context" dialog for the AI Agent composer.
+ *
+ * Lets the user attach extra context to their next message without typing it
+ * inline: a documentation link, a link to a saved/shared query, or a pasted
+ * SQL snippet. Added items are owned by the composer (see `WelcomeComposer` in
+ * thread.tsx) and prepended to the message as a context block on submit.
+ *
+ * NOTE: a "pick from query history" tab is intentionally omitted for now — the
+ * app has no query-history data source hook yet. Tracked as follow-up.
+ */
+
+import { FileTextIcon, LinkIcon, TerminalIcon, XIcon } from 'lucide-react'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Textarea } from '@/components/ui/textarea'
+
+export type ContextItemKind = 'docs' | 'query' | 'snippet'
+
+export interface ContextItem {
+  id: string
+  kind: ContextItemKind
+  /** Short display label shown on the chip. */
+  label: string
+  /** The full value (URL or SQL) injected into the message. */
+  value: string
+}
+
+const KIND_META: Record<
+  ContextItemKind,
+  { icon: typeof LinkIcon; label: string }
+> = {
+  docs: { icon: FileTextIcon, label: 'Docs' },
+  query: { icon: LinkIcon, label: 'Query link' },
+  snippet: { icon: TerminalIcon, label: 'Query' },
+}
+
+interface AddContextDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  items: ContextItem[]
+  onAdd: (item: ContextItem) => void
+  onRemove: (id: string) => void
+}
+
+export function AddContextDialog({
+  open,
+  onOpenChange,
+  items,
+  onAdd,
+  onRemove,
+}: AddContextDialogProps) {
+  const [docsUrl, setDocsUrl] = useState('')
+  const [queryUrl, setQueryUrl] = useState('')
+  const [snippet, setSnippet] = useState('')
+
+  // IDs are derived from a monotonic counter so this stays deterministic for
+  // tests (no Math.random / Date.now in the render path).
+  const [seq, setSeq] = useState(0)
+  const nextId = () => {
+    const id = `ctx-${seq}`
+    setSeq((n) => n + 1)
+    return id
+  }
+
+  const add = (kind: ContextItemKind, value: string, label: string) => {
+    const trimmed = value.trim()
+    if (!trimmed) return
+    onAdd({ id: nextId(), kind, value: trimmed, label })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add context</DialogTitle>
+          <DialogDescription>
+            Attach a doc, a query link, or a SQL snippet to your next message.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Tabs defaultValue="docs">
+          <TabsList className="w-full">
+            <TabsTrigger value="docs" className="flex-1 text-[12px]">
+              Docs link
+            </TabsTrigger>
+            <TabsTrigger value="query" className="flex-1 text-[12px]">
+              Query link
+            </TabsTrigger>
+            <TabsTrigger value="snippet" className="flex-1 text-[12px]">
+              Paste query
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="docs" className="space-y-2">
+            <Input
+              value={docsUrl}
+              onChange={(e) => setDocsUrl(e.target.value)}
+              placeholder="https://clickhouse.com/docs/…"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  add('docs', docsUrl, docsUrl.trim())
+                  setDocsUrl('')
+                }
+              }}
+            />
+            <Button
+              type="button"
+              size="sm"
+              disabled={!docsUrl.trim()}
+              onClick={() => {
+                add('docs', docsUrl, docsUrl.trim())
+                setDocsUrl('')
+              }}
+            >
+              Add docs link
+            </Button>
+          </TabsContent>
+
+          <TabsContent value="query" className="space-y-2">
+            <Input
+              value={queryUrl}
+              onChange={(e) => setQueryUrl(e.target.value)}
+              placeholder="Link to a saved or shared query"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  add('query', queryUrl, queryUrl.trim())
+                  setQueryUrl('')
+                }
+              }}
+            />
+            <Button
+              type="button"
+              size="sm"
+              disabled={!queryUrl.trim()}
+              onClick={() => {
+                add('query', queryUrl, queryUrl.trim())
+                setQueryUrl('')
+              }}
+            >
+              Add query link
+            </Button>
+          </TabsContent>
+
+          <TabsContent value="snippet" className="space-y-2">
+            <Textarea
+              value={snippet}
+              onChange={(e) => setSnippet(e.target.value)}
+              placeholder="SELECT … FROM system.query_log …"
+              className="min-h-24 font-mono text-[12px]"
+            />
+            <Button
+              type="button"
+              size="sm"
+              disabled={!snippet.trim()}
+              onClick={() => {
+                const label =
+                  snippet.trim().slice(0, 40) +
+                  (snippet.trim().length > 40 ? '…' : '')
+                add('snippet', snippet, label)
+                setSnippet('')
+              }}
+            >
+              Add query
+            </Button>
+          </TabsContent>
+        </Tabs>
+
+        {items.length > 0 ? (
+          <div className="border-t pt-3">
+            <div className="text-muted-foreground mb-2 text-[10.5px] font-semibold tracking-wider uppercase">
+              Attached ({items.length})
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {items.map((item) => {
+                const Icon = KIND_META[item.kind].icon
+                return (
+                  <span
+                    key={item.id}
+                    className="bg-muted flex max-w-full items-center gap-1.5 rounded-md py-1 pr-1 pl-2 text-[11.5px]"
+                  >
+                    <Icon className="text-muted-foreground size-3 shrink-0" />
+                    <span className="truncate">{item.label}</span>
+                    <button
+                      type="button"
+                      onClick={() => onRemove(item.id)}
+                      className="text-muted-foreground hover:text-foreground hover:bg-background rounded p-0.5"
+                      aria-label={`Remove ${item.label}`}
+                    >
+                      <XIcon className="size-3" />
+                    </button>
+                  </span>
+                )
+              })}
+            </div>
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/**
+ * Format attached context items into a markdown block prepended to the user's
+ * message so the agent sees the references.
+ */
+export function formatContextBlock(items: ContextItem[]): string {
+  if (items.length === 0) return ''
+  const lines = items.map((item) => {
+    if (item.kind === 'snippet') {
+      return `- ${KIND_META[item.kind].label}:\n\`\`\`sql\n${item.value}\n\`\`\``
+    }
+    return `- ${KIND_META[item.kind].label}: ${item.value}`
+  })
+  return `Context:\n${lines.join('\n')}`
+}

--- a/apps/web/components/agents/welcome/agent-mcp-panel.tsx
+++ b/apps/web/components/agents/welcome/agent-mcp-panel.tsx
@@ -16,6 +16,7 @@
 
 import { PlusIcon, WrenchIcon } from 'lucide-react'
 
+import { McpToolsResourcesDialog } from './mcp-tools-resources-dialog'
 import { useState } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -96,9 +97,11 @@ function StatusBadge({ status }: { status: McpServer['status'] }) {
 function McpServerRow({
   server,
   onToggle,
+  onViewDetails,
 }: {
   server: McpServer
   onToggle: (id: string, next: boolean) => void
+  onViewDetails: (server: McpServer) => void
 }) {
   return (
     <div className="flex items-center gap-2 py-2 pr-3 pl-2">
@@ -107,8 +110,13 @@ function McpServerRow({
         <WrenchIcon className="text-foreground size-3.5" />
       </div>
 
-      {/* Info */}
-      <div className="min-w-0 flex-1">
+      {/* Info — clickable region; stopPropagation not needed since Toggle is a sibling */}
+      <button
+        type="button"
+        className="hover:bg-muted/40 -mx-1 min-w-0 flex-1 cursor-pointer rounded px-1 py-0.5 text-left transition-colors"
+        onClick={() => onViewDetails(server)}
+        aria-label={`View tools and resources for ${server.name}`}
+      >
         <div className="flex items-center gap-1.5">
           <span className="truncate font-mono text-[12.5px]">
             {server.name}
@@ -133,9 +141,9 @@ function McpServerRow({
           <span className="text-border">·</span>
           <StatusBadge status={server.status} />
         </div>
-      </div>
+      </button>
 
-      {/* Toggle */}
+      {/* Toggle — separate from the clickable info region */}
       <Switch
         checked={server.enabled}
         onCheckedChange={(next) => onToggle(server.id, next)}
@@ -230,6 +238,7 @@ export function AgentMcpPanel({
     ...extraServers,
   ])
   const [showAddForm, setShowAddForm] = useState(false)
+  const [selectedServer, setSelectedServer] = useState<McpServer | null>(null)
 
   const handleToggle = (id: string, next: boolean) => {
     setServers((prev) =>
@@ -242,6 +251,15 @@ export function AgentMcpPanel({
 
   return (
     <div className="flex flex-col gap-2">
+      {/* Tools/resources detail dialog */}
+      <McpToolsResourcesDialog
+        server={selectedServer}
+        open={selectedServer !== null}
+        onOpenChange={(open) => {
+          if (!open) setSelectedServer(null)
+        }}
+      />
+
       {/* Summary row */}
       <div className="text-muted-foreground flex items-center justify-between text-[10.5px]">
         <span>
@@ -268,6 +286,7 @@ export function AgentMcpPanel({
             key={server.id}
             server={server}
             onToggle={handleToggle}
+            onViewDetails={setSelectedServer}
           />
         ))}
       </div>

--- a/apps/web/components/agents/welcome/agent-settings-sidebar.tsx
+++ b/apps/web/components/agents/welcome/agent-settings-sidebar.tsx
@@ -14,6 +14,7 @@ import {
   ArrowRightIcon,
   MonitorIcon,
   PanelRightCloseIcon,
+  PlugZapIcon,
   SparklesIcon,
 } from 'lucide-react'
 
@@ -23,6 +24,7 @@ import { useState } from 'react'
 import { AgentMcpPanel } from '@/components/agents/welcome/agent-mcp-panel'
 import { AgentModelPicker } from '@/components/agents/welcome/agent-model-picker'
 import { SkillDetailDialog } from '@/components/agents/welcome/skill-detail-dialog'
+import { SkillsLibraryDialog } from '@/components/agents/welcome/skills-library-dialog'
 import { SUGGESTED_PROMPTS } from '@/components/agents/welcome/suggested-prompts'
 import { Button } from '@/components/ui/button'
 import {
@@ -35,6 +37,7 @@ import {
 import { Switch } from '@/components/ui/switch'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useAgentSkills } from '@/lib/hooks/use-agent-skills'
+import { useHostId } from '@/lib/swr/use-host'
 import { cn } from '@/lib/utils'
 
 interface AgentSettingsSidebarProps {
@@ -62,6 +65,8 @@ export function AgentSettingsSidebar({
   } = useAgentSkills()
   const topSkills = skills.slice(0, 3)
   const [skillDetail, setSkillDetail] = useState<Skill | null>(null)
+  const [libraryOpen, setLibraryOpen] = useState(false)
+  const hostId = useHostId()
 
   const sections = (
     <>
@@ -81,6 +86,23 @@ export function AgentSettingsSidebar({
       {/* MCP SERVER */}
       <SidebarSection label="MCP Servers">
         <AgentMcpPanel />
+        {/* For users who run their own agent/IDE and want to point it at this
+            cluster's MCP endpoint directly. */}
+        <a
+          href={`/mcp?host=${hostId}`}
+          className="text-muted-foreground hover:text-foreground hover:bg-muted/40 mt-1.5 flex items-center gap-2 rounded-md border border-dashed px-3 py-2 text-[11.5px] transition-colors"
+        >
+          <PlugZapIcon className="size-3.5 shrink-0" />
+          <span className="min-w-0 flex-1">
+            <span className="text-foreground font-medium">
+              Connect your own agent
+            </span>
+            <span className="block text-[10.5px]">
+              Use this cluster&apos;s MCP endpoint in your IDE or tooling
+            </span>
+          </span>
+          <ArrowRightIcon className="size-3 shrink-0" />
+        </a>
       </SidebarSection>
 
       {/* SKILLS */}
@@ -135,7 +157,7 @@ export function AgentSettingsSidebar({
           type="button"
           variant="outline"
           size="sm"
-          onClick={onOpenSkillsLibrary}
+          onClick={onOpenSkillsLibrary ?? (() => setLibraryOpen(true))}
           className="mt-1.5 h-8 w-full justify-center gap-1.5 text-[11.5px]"
         >
           <SparklesIcon className="size-3" />
@@ -185,6 +207,8 @@ export function AgentSettingsSidebar({
         isEnabled={skillDetail ? isSkillEnabled(skillDetail.id) : false}
         onToggle={(id) => toggleSkill(id)}
       />
+
+      <SkillsLibraryDialog open={libraryOpen} onOpenChange={setLibraryOpen} />
     </>
   )
 

--- a/apps/web/components/agents/welcome/composer-toolbar.tsx
+++ b/apps/web/components/agents/welcome/composer-toolbar.tsx
@@ -20,6 +20,10 @@
 import { HashIcon, SparklesIcon, WrenchIcon } from 'lucide-react'
 
 import { useState } from 'react'
+import {
+  AddContextDialog,
+  type ContextItem,
+} from '@/components/agents/welcome/add-context-dialog'
 import { AgentModelPicker } from '@/components/agents/welcome/agent-model-picker'
 import { SkillDetailDialog } from '@/components/agents/welcome/skill-detail-dialog'
 import {
@@ -41,15 +45,17 @@ import { useToolConfig } from '@/lib/hooks/use-tool-config'
 import { cn } from '@/lib/utils'
 
 interface ComposerToolbarProps {
-  /** Number of "context" chips the user has attached (queries, tables, …). */
-  contextCount?: number
-  onAddContext?: () => void
+  /** Context items the user has attached (docs links, queries, …). */
+  contextItems?: ContextItem[]
+  onAddContext?: (item: ContextItem) => void
+  onRemoveContext?: (id: string) => void
   className?: string
 }
 
 export function ComposerToolbar({
-  contextCount = 0,
+  contextItems = [],
   onAddContext,
+  onRemoveContext,
   className,
 }: ComposerToolbarProps) {
   const {
@@ -64,6 +70,8 @@ export function ComposerToolbar({
   const [skillsOpen, setSkillsOpen] = useState(false)
   const [toolsOpen, setToolsOpen] = useState(false)
   const [skillDetail, setSkillDetail] = useState<Skill | null>(null)
+  const [addContextOpen, setAddContextOpen] = useState(false)
+  const contextCount = contextItems.length
 
   const allTools = getAllSkillTools()
   const enabledToolCount = allTools.filter((t) => isToolEnabled(t)).length
@@ -95,14 +103,14 @@ export function ComposerToolbar({
         <PopoverContent
           align="start"
           sideOffset={4}
-          className="w-[340px] p-1"
+          className="flex max-h-[min(28rem,var(--radix-popover-content-available-height))] w-[340px] flex-col overflow-hidden p-1"
           collisionPadding={8}
         >
-          <div className="text-muted-foreground px-2 py-1.5 text-[10px] font-semibold tracking-wider uppercase">
+          <div className="text-muted-foreground shrink-0 px-2 py-1.5 text-[10px] font-semibold tracking-wider uppercase">
             Skills
           </div>
-          <ScrollArea className="max-h-96">
-            <div className="space-y-0.5">
+          <ScrollArea className="min-h-0 flex-1">
+            <div className="space-y-0.5 pr-1">
               {skills.map((skill) => {
                 const Icon = skill.icon
                 const on = isSkillEnabled(skill.id)
@@ -181,17 +189,17 @@ export function ComposerToolbar({
         <PopoverContent
           align="start"
           sideOffset={4}
-          className="w-[320px] p-1"
+          className="flex max-h-[min(28rem,var(--radix-popover-content-available-height))] w-[320px] flex-col overflow-hidden p-1"
           collisionPadding={8}
         >
-          <div className="text-muted-foreground flex items-center justify-between px-2 py-1.5 text-[10px] font-semibold tracking-wider uppercase">
+          <div className="text-muted-foreground flex shrink-0 items-center justify-between px-2 py-1.5 text-[10px] font-semibold tracking-wider uppercase">
             <span>Tools</span>
             <span className="text-muted-foreground/70 font-normal normal-case tabular-nums">
               {enabledToolCount} active
             </span>
           </div>
-          <ScrollArea className="max-h-96">
-            <div className="space-y-0.5">
+          <ScrollArea className="min-h-0 flex-1">
+            <div className="space-y-0.5 pr-1">
               {allTools.map((tool) => {
                 const on = isToolEnabled(tool)
                 const owners = getSkillsForTool(tool)
@@ -235,7 +243,7 @@ export function ComposerToolbar({
         type="button"
         variant="ghost"
         size="sm"
-        onClick={onAddContext}
+        onClick={() => setAddContextOpen(true)}
         className="text-muted-foreground hover:text-foreground h-7 gap-1.5 px-2 text-[11.5px]"
       >
         <HashIcon className="size-3" />
@@ -257,6 +265,14 @@ export function ComposerToolbar({
         }}
         isEnabled={skillDetail ? isSkillEnabled(skillDetail.id) : false}
         onToggle={(id) => toggleSkill(id)}
+      />
+
+      <AddContextDialog
+        open={addContextOpen}
+        onOpenChange={setAddContextOpen}
+        items={contextItems}
+        onAdd={(item) => onAddContext?.(item)}
+        onRemove={(id) => onRemoveContext?.(id)}
       />
     </div>
   )

--- a/apps/web/components/agents/welcome/mcp-tools-resources-dialog.tsx
+++ b/apps/web/components/agents/welcome/mcp-tools-resources-dialog.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+/**
+ * McpToolsResourcesDialog
+ *
+ * Shows the tools and resources exposed by a single MCP server.
+ * Opens when the user clicks on an MCP server row in AgentMcpPanel.
+ *
+ * Data: fetched once via useMcpServerInfo() (SWR, 5-min cache).
+ * Layout: mirrors skill-detail-dialog.tsx — muted-bg header, ScrollArea body.
+ */
+
+import { WrenchIcon } from 'lucide-react'
+
+import type { McpServer } from './agent-mcp-panel'
+
+import { Badge } from '@/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { useMcpServerInfo } from '@/lib/swr/use-mcp-server-info'
+
+// ---------------------------------------------------------------------------
+// Category badge colours
+// ---------------------------------------------------------------------------
+
+const CATEGORY_STYLES: Record<string, string> = {
+  query:
+    'bg-blue-50 text-blue-700 hover:bg-blue-50 dark:bg-blue-500/10 dark:text-blue-300',
+  schema:
+    'bg-violet-50 text-violet-700 hover:bg-violet-50 dark:bg-violet-500/10 dark:text-violet-300',
+  system:
+    'bg-amber-50 text-amber-700 hover:bg-amber-50 dark:bg-amber-500/10 dark:text-amber-300',
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface McpToolsResourcesDialogProps {
+  server: McpServer | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function McpToolsResourcesDialog({
+  server,
+  open,
+  onOpenChange,
+}: McpToolsResourcesDialogProps) {
+  const { data, isLoading, error, retry } = useMcpServerInfo()
+
+  if (!server) return null
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg overflow-hidden p-0">
+        {/* Header — mirrors skill-detail-dialog muted header */}
+        <DialogHeader className="border-b bg-muted/30 px-5 py-4 text-left">
+          <div className="flex items-start gap-3">
+            <div className="bg-background border-border inline-flex size-10 shrink-0 items-center justify-center rounded-xl border">
+              <WrenchIcon
+                className="text-foreground size-4"
+                strokeWidth={1.6}
+              />
+            </div>
+            <div className="min-w-0 flex-1 space-y-1">
+              <DialogTitle className="flex items-center gap-2 text-base">
+                <span className="truncate font-mono">{server.name}</span>
+                {server.version && (
+                  <Badge
+                    variant="outline"
+                    className="h-4 shrink-0 px-1.5 text-[10px] font-normal"
+                  >
+                    {server.version}
+                  </Badge>
+                )}
+              </DialogTitle>
+              <DialogDescription className="text-left text-[12.5px] leading-snug">
+                {server.endpoint}
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        {/* Body */}
+        <ScrollArea className="max-h-[70dvh]">
+          <div className="space-y-5 p-5">
+            {isLoading && (
+              <p className="text-muted-foreground text-[12.5px]">
+                Loading tools…
+              </p>
+            )}
+
+            {error && !isLoading && (
+              <div className="space-y-2">
+                <p className="text-destructive text-[12.5px]">
+                  Failed to load server info.
+                </p>
+                <button
+                  type="button"
+                  onClick={retry}
+                  className="border-border bg-background hover:bg-muted h-7 rounded-md border px-2.5 text-[11.5px] font-medium transition-colors"
+                >
+                  Retry
+                </button>
+              </div>
+            )}
+
+            {data && (
+              <>
+                {/* Tools section */}
+                <div>
+                  <div className="text-muted-foreground mb-2 text-[10.5px] font-semibold tracking-wider uppercase">
+                    Tools ({data.tools.length})
+                  </div>
+                  {data.tools.length === 0 ? (
+                    <p className="text-muted-foreground text-[12px]">
+                      No tools exposed.
+                    </p>
+                  ) : (
+                    <div className="space-y-1.5">
+                      {data.tools.map((tool) => (
+                        <div
+                          key={tool.name}
+                          className="border-border bg-card rounded-md border px-3 py-2"
+                        >
+                          <div className="flex items-center gap-2">
+                            <span className="min-w-0 flex-1 truncate font-mono text-[11.5px]">
+                              {tool.name}
+                            </span>
+                            <Badge
+                              variant="outline"
+                              className={`h-4 shrink-0 px-1.5 text-[10px] font-normal ${CATEGORY_STYLES[tool.category] ?? ''}`}
+                            >
+                              {tool.category}
+                            </Badge>
+                          </div>
+                          {tool.description && (
+                            <p className="text-muted-foreground mt-0.5 text-[11px] leading-snug">
+                              {tool.description}
+                            </p>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Resources section */}
+                <div>
+                  <div className="text-muted-foreground mb-2 text-[10.5px] font-semibold tracking-wider uppercase">
+                    Resources ({data.resources.length})
+                  </div>
+                  {data.resources.length === 0 ? (
+                    <p className="text-muted-foreground text-[12px]">
+                      No resources exposed.
+                    </p>
+                  ) : (
+                    <div className="space-y-1.5">
+                      {data.resources.map((resource) => (
+                        <div
+                          key={resource.uri}
+                          className="border-border bg-card rounded-md border px-3 py-2"
+                        >
+                          <div className="flex items-center gap-2">
+                            <span className="min-w-0 flex-1 truncate font-mono text-[11.5px]">
+                              {resource.name}
+                            </span>
+                            <span className="text-muted-foreground shrink-0 truncate font-mono text-[10px]">
+                              {resource.uri}
+                            </span>
+                          </div>
+                          {resource.description && (
+                            <p className="text-muted-foreground mt-0.5 text-[11px] leading-snug">
+                              {resource.description}
+                            </p>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/components/agents/welcome/skills-library-dialog.tsx
+++ b/apps/web/components/agents/welcome/skills-library-dialog.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+/**
+ * Full skills library, opened from the "Skill library" button in the agent
+ * settings sidebar. Lists every skill bundle (not just the top 3) with a
+ * search box, full descriptions, the tools each bundle covers, and a per-skill
+ * enable toggle. Reuses the shared `useAgentSkills` state so toggles here stay
+ * in sync with the composer toolbar and sidebar.
+ */
+
+import { SearchIcon } from 'lucide-react'
+
+import { useMemo, useState } from 'react'
+import { Badge } from '@/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Switch } from '@/components/ui/switch'
+import { useAgentSkills } from '@/lib/hooks/use-agent-skills'
+import { cn } from '@/lib/utils'
+
+interface SkillsLibraryDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function SkillsLibraryDialog({
+  open,
+  onOpenChange,
+}: SkillsLibraryDialogProps) {
+  const { skills, isSkillEnabled, toggleSkill, activeSkillCount } =
+    useAgentSkills()
+  const [query, setQuery] = useState('')
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return skills
+    return skills.filter(
+      (s) =>
+        s.name.toLowerCase().includes(q) ||
+        s.description.toLowerCase().includes(q) ||
+        s.tools.some((t) => t.toLowerCase().includes(q))
+    )
+  }, [skills, query])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[85dvh] flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl">
+        <DialogHeader className="border-b px-5 py-4">
+          <DialogTitle>Skill library</DialogTitle>
+          <DialogDescription>
+            {activeSkillCount} of {skills.length} skills enabled. Toggle a skill
+            to add or remove the tools it covers.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="border-b px-5 py-3">
+          <div className="relative">
+            <SearchIcon className="text-muted-foreground absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search skills or tools…"
+              className="h-9 pl-8 text-[12.5px]"
+            />
+          </div>
+        </div>
+
+        <ScrollArea className="min-h-0 flex-1">
+          <div className="space-y-1 p-3">
+            {filtered.length === 0 ? (
+              <p className="text-muted-foreground px-2 py-6 text-center text-[12px]">
+                No skills match “{query}”.
+              </p>
+            ) : (
+              filtered.map((skill) => {
+                const Icon = skill.icon
+                const on = isSkillEnabled(skill.id)
+                return (
+                  <div
+                    key={skill.id}
+                    className="hover:bg-muted/40 flex items-start gap-3 rounded-lg border p-3"
+                  >
+                    <div className="bg-muted text-muted-foreground inline-flex size-8 shrink-0 items-center justify-center rounded-md">
+                      <Icon className="size-4" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-1.5">
+                        <span className="truncate text-[13px] font-medium">
+                          {skill.name}
+                        </span>
+                        <Badge
+                          variant={
+                            skill.source === 'system' ? 'default' : 'outline'
+                          }
+                          className={cn(
+                            'h-4 px-1.5 text-[10px] font-normal',
+                            skill.source === 'system'
+                              ? 'bg-blue-50 text-blue-700 hover:bg-blue-50 dark:bg-blue-500/10 dark:text-blue-300'
+                              : 'text-muted-foreground'
+                          )}
+                        >
+                          {skill.source}
+                        </Badge>
+                      </div>
+                      <p className="text-muted-foreground mt-0.5 text-[11.5px] leading-snug">
+                        {skill.description}
+                      </p>
+                      {skill.tools.length > 0 ? (
+                        <div className="mt-2 flex flex-wrap gap-1">
+                          {skill.tools.map((tool) => (
+                            <span
+                              key={tool}
+                              className="bg-muted text-muted-foreground rounded px-1.5 py-0.5 font-mono text-[10px]"
+                            >
+                              {tool}
+                            </span>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                    <Switch
+                      checked={on}
+                      onCheckedChange={() => toggleSkill(skill.id)}
+                      className="mt-0.5 shrink-0"
+                      aria-label={`Toggle ${skill.name}`}
+                    />
+                  </div>
+                )
+              })
+            )}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/components/assistant-ui/agent-thread-page.tsx
+++ b/apps/web/components/assistant-ui/agent-thread-page.tsx
@@ -3,18 +3,16 @@
 /**
  * Full-page `/agents` experience.
  *
- * Three-column layout:
- *   1. Conversation rail (assistant-ui `ThreadList`) — collapsible, hidden by
- *      default. A toggle in the top-left of the main column re-opens it.
+ * Layout:
+ *   1. Conversation history — opened from the top-left "Conversations" button
+ *      into a large centered dialog (assistant-ui `ThreadList`).
  *   2. Main column — welcome screen when empty, threaded messages otherwise.
  *   3. Agent-settings sidebar (host · model · MCP server · skills · prompts) —
- *      collapsible, open by default.
- *
- * Both sidebars surface a small "Show <sidebar>" affordance over the main
- * column when closed so the user can reopen them at any time.
+ *      collapsible, open by default. Surfaces a "Show settings" affordance when
+ *      closed.
  */
 
-import { PanelLeftOpenIcon, PanelRightOpenIcon } from 'lucide-react'
+import { MessagesSquareIcon, PanelRightOpenIcon } from 'lucide-react'
 import { ErrorBoundary } from 'react-error-boundary'
 
 import { useEffect, useState } from 'react'
@@ -24,6 +22,14 @@ import { AgentRuntimeProvider } from '@/components/assistant-ui/agent-runtime-pr
 import { Thread } from '@/components/assistant-ui/thread'
 import { ThreadList } from '@/components/assistant-ui/thread-list'
 import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { isClerkEnabled } from '@/lib/clerk/clerk-client'
 import { useHostId } from '@/lib/swr/use-host'
@@ -54,7 +60,7 @@ function AgentThreadPageError() {
 
 export function AgentThreadPage() {
   const isMobile = useIsMobile()
-  const [leftSidebarOpen, setLeftSidebarOpen] = useState(false)
+  const [conversationsOpen, setConversationsOpen] = useState(false)
   const [rightSidebarOpen, setRightSidebarOpen] = useState(false)
   useEffect(() => {
     setRightSidebarOpen(!isMobile)
@@ -70,42 +76,44 @@ export function AgentThreadPage() {
       <AgentAuthGate>
         <AgentRuntimeProvider>
           <div className="bg-background flex h-[calc(100dvh-6rem)] min-h-0 overflow-hidden rounded-xl border">
-            {/* Conversation rail */}
-            {leftSidebarOpen ? (
-              <aside className="bg-muted/30 hidden w-64 shrink-0 flex-col gap-2 overflow-y-auto border-r p-2 lg:flex">
-                <div className="flex items-center justify-between gap-2 px-2 pt-1">
-                  <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-                    Conversations
-                  </p>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => setLeftSidebarOpen(false)}
-                    className="text-muted-foreground hover:text-foreground size-6 shrink-0"
-                    aria-label="Hide conversations"
+            {/* Conversation history — large centered dialog */}
+            <Dialog
+              open={conversationsOpen}
+              onOpenChange={setConversationsOpen}
+            >
+              <DialogContent className="flex max-h-[85dvh] flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl">
+                <DialogHeader className="border-b px-5 py-4">
+                  <DialogTitle>Conversations</DialogTitle>
+                  <DialogDescription>
+                    Pick up a previous chat or start a new one.
+                  </DialogDescription>
+                </DialogHeader>
+                <ScrollArea className="min-h-0 flex-1">
+                  {/* Bubbling onClick closes the dialog AFTER assistant-ui's own
+                      handler activates the selected (or new) thread. Items stay
+                      independently keyboard-accessible. */}
+                  <div
+                    className="p-3"
+                    onClick={() => setConversationsOpen(false)}
                   >
-                    <PanelLeftOpenIcon className="size-3.5 rotate-180" />
-                  </Button>
-                </div>
-                <ThreadList />
-              </aside>
-            ) : null}
+                    <ThreadList />
+                  </div>
+                </ScrollArea>
+              </DialogContent>
+            </Dialog>
 
             {/* Main column */}
             <div className="relative flex min-w-0 flex-1 flex-col">
-              {!leftSidebarOpen ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setLeftSidebarOpen(true)}
-                  className="absolute top-3 left-3 z-10 hidden h-8 gap-1.5 px-2.5 text-[11.5px] whitespace-nowrap lg:inline-flex"
-                >
-                  <PanelLeftOpenIcon className="size-3.5" />
-                  Conversations
-                </Button>
-              ) : null}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setConversationsOpen(true)}
+                className="absolute top-3 left-3 z-10 inline-flex h-8 gap-1.5 px-2.5 text-[11.5px] whitespace-nowrap"
+              >
+                <MessagesSquareIcon className="size-3.5" />
+                Conversations
+              </Button>
               {!rightSidebarOpen ? (
                 <Button
                   type="button"

--- a/apps/web/components/assistant-ui/thread.tsx
+++ b/apps/web/components/assistant-ui/thread.tsx
@@ -47,8 +47,12 @@ import {
   useThread,
   useThreadRuntime,
 } from '@assistant-ui/react'
-import { type FC, type ReactNode, useCallback, useRef } from 'react'
+import { type FC, type ReactNode, useCallback, useRef, useState } from 'react'
 import { PromptInputTextareaWithMentions } from '@/components/agents/mentions'
+import {
+  type ContextItem,
+  formatContextBlock,
+} from '@/components/agents/welcome/add-context-dialog'
 import { AgentWelcomeScreen } from '@/components/agents/welcome/agent-welcome-screen'
 import { ComposerToolbar } from '@/components/agents/welcome/composer-toolbar'
 import { useAgentAuthGate } from '@/components/assistant-ui/agent-auth-gate'
@@ -212,6 +216,7 @@ function WelcomeComposer() {
   const threadRuntime = useThreadRuntime()
   const isRunning = useThread((thread) => thread.isRunning)
   const { ensureAuthed } = useAgentAuthGate()
+  const [contextItems, setContextItems] = useState<ContextItem[]>([])
 
   return (
     <div className="flex flex-col gap-2">
@@ -221,14 +226,23 @@ function WelcomeComposer() {
           const trimmed = text.trim()
           if (!trimmed) return
           if (!ensureAuthed()) return
+          const block = formatContextBlock(contextItems)
+          const full = block ? `${block}\n\n${trimmed}` : trimmed
           threadRuntime.append({
             role: 'user',
-            content: [{ type: 'text', text: trimmed }],
+            content: [{ type: 'text', text: full }],
           })
+          setContextItems([])
         }}
         onStop={() => threadRuntime.cancelRun()}
       />
-      <ComposerToolbar />
+      <ComposerToolbar
+        contextItems={contextItems}
+        onAddContext={(item) => setContextItems((prev) => [...prev, item])}
+        onRemoveContext={(id) =>
+          setContextItems((prev) => prev.filter((i) => i.id !== id))
+        }
+      />
     </div>
   )
 }

--- a/apps/web/components/header/header-actions.tsx
+++ b/apps/web/components/header/header-actions.tsx
@@ -2,6 +2,7 @@
 
 import { Moon, Sun } from 'lucide-react'
 
+import { usePathname } from 'next/navigation'
 import { useTheme } from 'next-themes'
 import { useEffect, useState } from 'react'
 import { CommandPalette } from '@/components/controls/command-palette'
@@ -28,6 +29,10 @@ export const HeaderActions = function HeaderActions({
   const [settingsOpen, setSettingsOpen] = useState(false)
   const { config } = useFeaturePermissions()
   const canUseSettings = isFeatureAllowed(SETTINGS_FEATURE_PERMISSION, config)
+  const pathname = usePathname()
+  // The /agents page owns its own surface and has no time-series charts, so the
+  // global time-range selector and refresh countdown are noise there.
+  const showTimeControls = !pathname?.startsWith('/agents')
 
   // Handle hydration - set mounted state after client-side render
   useEffect(() => {
@@ -40,9 +45,13 @@ export const HeaderActions = function HeaderActions({
 
   return (
     <div className="flex w-max shrink-0 items-center gap-1 sm:ml-auto sm:w-auto sm:gap-3">
-      <GlobalTimeRangePicker />
+      {showTimeControls ? (
+        <>
+          <GlobalTimeRangePicker />
 
-      <RefreshCountdown />
+          <RefreshCountdown />
+        </>
+      ) : null}
 
       <CommandPalette
         open={commandPaletteOpen}

--- a/apps/web/lib/conversation-store/adapter/d1-thread-list-adapter.tsx
+++ b/apps/web/lib/conversation-store/adapter/d1-thread-list-adapter.tsx
@@ -102,25 +102,40 @@ async function apiDelete(id: string): Promise<void> {
 }
 
 function deriveTitle(
-  message: { role?: string; parts?: unknown[] } | undefined
+  message:
+    | {
+        role?: string
+        parts?: unknown[]
+        content?: string | Array<{ text?: string }>
+      }
+    | undefined
 ): string | undefined {
-  if (!message || message.role !== 'user' || !Array.isArray(message.parts)) {
+  if (!message || message.role !== 'user') {
     return undefined
   }
-  for (const part of message.parts) {
-    if (
-      part &&
-      typeof part === 'object' &&
-      (part as { type?: unknown }).type === 'text' &&
-      typeof (part as { text?: unknown }).text === 'string'
-    ) {
-      const text = ((part as { text: string }).text ?? '').trim()
-      if (text) {
-        return text.length > 50 ? `${text.slice(0, 50)}...` : text
+  let text = ''
+  if (Array.isArray(message.parts)) {
+    for (const part of message.parts) {
+      if (
+        part &&
+        typeof part === 'object' &&
+        (part as { type?: unknown }).type === 'text' &&
+        typeof (part as { text?: unknown }).text === 'string'
+      ) {
+        text = ((part as { text: string }).text ?? '').trim()
+        if (text) break
       }
     }
   }
-  return undefined
+  if (!text && typeof message.content === 'string') {
+    text = message.content.trim()
+  } else if (!text && Array.isArray(message.content)) {
+    text = message.content
+      .map((p) => p.text ?? '')
+      .join(' ')
+      .trim()
+  }
+  return text ? generateTitleFromMessage(text) : undefined
 }
 
 /**
@@ -174,10 +189,20 @@ function createD1HistoryAdapter(
           const payload: { messages: unknown[]; title?: string } = {
             messages: repo.messages,
           }
-          // Seed the title from the first message only — never overwrite.
-          if (!aui.threadListItem().getState().title) {
+          // Auto-title: seed from the first user message when the thread has
+          // no title yet (or still has the default placeholder).
+          const currentTitle = aui.threadListItem().getState().title
+          const isUntitled =
+            !currentTitle ||
+            currentTitle === 'New Conversation' ||
+            currentTitle === 'New Chat'
+          if (isUntitled) {
             const title = deriveTitle(
-              item.message as { role?: string; parts?: unknown[] }
+              item.message as {
+                role?: string
+                parts?: unknown[]
+                content?: string | Array<{ text?: string }>
+              }
             )
             if (title) payload.title = title
           }

--- a/apps/web/lib/conversation-store/adapter/local-thread-list-adapter.tsx
+++ b/apps/web/lib/conversation-store/adapter/local-thread-list-adapter.tsx
@@ -66,6 +66,9 @@ function removeKey(key: string): void {
   }
 }
 
+const loadThreads = () => readJson<ThreadMeta[]>(THREADS_KEY, [])
+const saveThreads = (threads: ThreadMeta[]) => writeJson(THREADS_KEY, threads)
+
 /**
  * Per-thread message history. `useChatRuntime` calls `withFormat()` to obtain a
  * format-bound `GenericThreadHistoryAdapter`; the legacy `load` / `append` are
@@ -99,6 +102,55 @@ function createLocalHistoryAdapter(
           const repo = readRepo(remoteId)
           upsertHistoryItem(repo, item, getId)
           writeJson(messagesKey(remoteId), repo)
+
+          // Auto-title: derive from the first user message when the thread has
+          // no title yet (or still has the default placeholder).
+          const currentTitle = aui.threadListItem().getState().title
+          const isUntitled =
+            !currentTitle ||
+            currentTitle === 'New Conversation' ||
+            currentTitle === 'New Chat'
+          if (isUntitled) {
+            const msg = item.message as {
+              role?: string
+              parts?: Array<{ type?: unknown; text?: string }>
+              content?: string | Array<{ text?: string }>
+            }
+            if (msg.role === 'user') {
+              // Extract text from parts (AI SDK format) or content (plain string)
+              let text = ''
+              if (Array.isArray(msg.parts)) {
+                text = msg.parts
+                  .filter(
+                    (p) =>
+                      p &&
+                      typeof p === 'object' &&
+                      p.type === 'text' &&
+                      typeof p.text === 'string'
+                  )
+                  .map((p) => p.text ?? '')
+                  .join(' ')
+                  .trim()
+              }
+              if (!text && typeof msg.content === 'string') {
+                text = msg.content.trim()
+              } else if (!text && Array.isArray(msg.content)) {
+                text = (msg.content as Array<{ text?: string }>)
+                  .map((p) => p.text ?? '')
+                  .join(' ')
+                  .trim()
+              }
+              if (text) {
+                const title = generateTitleFromMessage(text)
+                const threads = loadThreads()
+                const thread = threads.find((t) => t.remoteId === remoteId)
+                if (thread) {
+                  thread.title = title
+                  saveThreads(threads)
+                }
+              }
+            }
+          }
         },
         async update(item, localMessageId) {
           const remoteId = aui.threadListItem().getState().remoteId
@@ -128,9 +180,6 @@ const HistoryProvider: FC<PropsWithChildren> = ({ children }) => {
  * `window.localStorage`.
  */
 export function createLocalThreadListAdapter(): RemoteThreadListAdapter {
-  const loadThreads = () => readJson<ThreadMeta[]>(THREADS_KEY, [])
-  const saveThreads = (threads: ThreadMeta[]) => writeJson(THREADS_KEY, threads)
-
   return {
     unstable_Provider: HistoryProvider,
 


### PR DESCRIPTION
Addresses the batch of `/agents` UX issues reported.

| # | Issue | Fix |
|---|---|---|
| 1 | "Skill library" button does nothing | Opens a searchable **SkillsLibraryDialog** (all bundles, full descriptions, tool chips, toggles). The `onOpenSkillsLibrary` callback was never wired. |
| 2 | "why skills included Tools?" | No code change — **skills are capability bundles that group tools**; the Tools popover lists the individual tools. Clarified in dialogs/labels. |
| 3 | Skills dropdown overflows | PopoverContent capped to `--radix-popover-content-available-height`, list is a `flex-1` ScrollArea → scrolls instead of clipping. |
| 4 | Tools dropdown not scrollable | Same flex-col + capped-height + ScrollArea fix. |
| 5 | No way to see an MCP server's tools/resources | MCP rows are now clickable → **McpToolsResourcesDialog** (tools + resources via existing `useMcpServerInfo`). |
| 6 | "Add context" button does nothing | Opens **AddContextDialog** (docs link · query link · pasted query). Items are owned by the composer and prepended as a `Context:` block on submit. The `onAddContext` callback was never wired. |
| 7 | Conversations should be a large dialog | Replaced the desktop-only rail with a large centered Dialog (works on all screen sizes). |
| 8 | Auto-generate conversation title | Both thread-list adapters now derive a title from the first user message via the existing `generateTitleFromMessage` util. |
| 9 | Hide date-range + reload on /agents | `HeaderActions` hides `GlobalTimeRangePicker` + `RefreshCountdown` when `pathname` starts with `/agents`. |
| 10 | Link to connect your own agent | "Connect your own agent" link to `/mcp?host=` in the MCP section. |

## Notes / follow-ups
- **#6**: a "pick from query history" tab was intentionally omitted — the app has no query-history data-source hook yet. The docs-link / query-link / paste-query paths are fully functional. Worth a follow-up once a history hook exists.
- **#2**: this is a naming clarity thing, not a bug. If you'd prefer the bottom bar to drop one of the two counts, say which.

## Verification
- `tsc --noEmit` ✅ (whole app)
- `biome check` ✅ (no warnings)

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context dialog for composing agent prompts with documentation links, queries, and SQL snippets
  * Introduced skills library modal for viewing and toggling available agent skills
  * New details panel for MCP servers displaying available tools and resources
  * Conversations moved to modal dialog interface for improved navigation
  * Automatic thread title generation from initial messages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->