### PR TITLE
fix(agents): don't auto-scroll the welcome screen on open

### DIFF
--- a/apps/web/components/assistant-ui/thread.tsx
+++ b/apps/web/components/assistant-ui/thread.tsx
@@ -110,29 +110,35 @@ export function Thread({
         ['--user-max-width' as string]: 'min(100%, 46rem)',
       }}
     >
-      <ThreadPrimitive.Viewport
-        scrollToBottomOnInitialize={false}
-        className="relative flex flex-1 flex-col overflow-y-auto scroll-smooth px-4 pt-14"
-      >
-        <ThreadWelcome
-          firstName={firstName}
-          clusterName={clusterName}
-          hasClusterIssue={hasClusterIssue}
-        />
+      {/* Empty (welcome) state lives OUTSIDE the auto-scrolling Viewport.
+          assistant-ui's Viewport pins toward the bottom as content grows, so
+          the tall welcome screen (composer + suggested questions) scrolled
+          itself down on open. A plain overflow container starts at the top. */}
+      <ThreadPrimitive.If empty>
+        <div className="flex flex-1 flex-col overflow-y-auto px-4 pt-14">
+          <ThreadWelcome
+            firstName={firstName}
+            clusterName={clusterName}
+            hasClusterIssue={hasClusterIssue}
+          />
+        </div>
+      </ThreadPrimitive.If>
 
-        <ThreadPrimitive.Messages
-          components={{
-            UserMessage,
-            EditComposer,
-            AssistantMessage,
-          }}
-        />
+      <ThreadPrimitive.If empty={false}>
+        <ThreadPrimitive.Viewport
+          scrollToBottomOnInitialize={false}
+          className="relative flex flex-1 flex-col overflow-y-auto scroll-smooth px-4 pt-14"
+        >
+          <ThreadPrimitive.Messages
+            components={{
+              UserMessage,
+              EditComposer,
+              AssistantMessage,
+            }}
+          />
 
-        <ThreadPrimitive.If empty={false}>
           <div className="min-h-6 grow" />
-        </ThreadPrimitive.If>
 
-        <ThreadPrimitive.If empty={false}>
           <div className="sticky bottom-0 z-10 mx-auto flex w-full max-w-[var(--thread-max-width)] flex-col items-center gap-2 bg-background pb-3">
             <ThreadScrollToBottom />
             <ThreadComposer />
@@ -145,8 +151,8 @@ export function Thread({
               .
             </p>
           </div>
-        </ThreadPrimitive.If>
-      </ThreadPrimitive.Viewport>
+        </ThreadPrimitive.Viewport>
+      </ThreadPrimitive.If>
     </ThreadPrimitive.Root>
   )
 }


### PR DESCRIPTION
## Problem

Opening `/agents` always scrolled the chat area down (verified live: the welcome viewport sat at `scrollTop≈518` of `1119`).

## Cause

The empty/welcome state was rendered **inside** assistant-ui's auto-scrolling `Viewport`. The Viewport pins toward the bottom as content grows, and the welcome screen (composer + 8 suggested questions) renders progressively and is taller than the viewport — so it scrolled itself down on open. `scrollToBottomOnInitialize={false}` only suppresses the *first* scroll, not subsequent content-growth re-pins.

## Fix

Render the welcome state in a plain `overflow-y-auto` container (starts at the top, no auto-scroll). Keep the auto-scrolling `Viewport` only for actual conversations, where pinning to the latest message is the desired behavior.

## Verification
- `tsc --noEmit` ✅ · `biome check` ✅
- Will confirm on the deployed page after merge (the live console check is how the root cause was measured).

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the thread component's empty state rendering to optimize layout performance and separation of concerns. The welcome screen now renders outside the auto-scrolling viewport container, improving component organization and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->