### PR TITLE
feat(ui): keeper cards + connections expand, health cards, security charts, menu

### DIFF
--- a/apps/web/app/(dashboard)/keeper/overview/page.tsx
+++ b/apps/web/app/(dashboard)/keeper/overview/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Suspense } from 'react'
+import { KeeperNodeCards } from '@/components/keeper/keeper-node-cards'
 import { KeeperOverviewKpis } from '@/components/keeper/keeper-overview-kpis'
 import { PageLayout } from '@/components/layout/query-page'
 import { ChartSkeleton } from '@/components/skeletons'
@@ -10,7 +11,11 @@ function KeeperOverviewContent() {
   return (
     <div className="flex flex-col gap-3 sm:gap-4">
       <KeeperOverviewKpis />
-      <PageLayout queryConfig={keeperOverviewConfig} title="Keeper Nodes" />
+      <PageLayout
+        queryConfig={keeperOverviewConfig}
+        title="Keeper Nodes"
+        tableSlot={<KeeperNodeCards />}
+      />
     </div>
   )
 }

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { BookOpenIcon } from 'lucide-react'
 import { menuItemsConfig } from '@/menu'
 
 import { HostSwitcher } from '@/components/host/host-switcher'
@@ -10,6 +11,9 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
 } from '@/components/ui/sidebar'
 import { GUEST_USER } from '@/lib/clerk/guest-user'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
@@ -30,6 +34,17 @@ export function AppSidebar() {
       </SidebarContent>
 
       <SidebarFooter>
+        {/* Small Docs link sitting just above the user button. */}
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild size="sm" tooltip="Docs">
+              <a href="/docs">
+                <BookOpenIcon />
+                <span>Docs</span>
+              </a>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
         <NavUser user={GUEST_USER} />
       </SidebarFooter>
     </Sidebar>

--- a/apps/web/components/charts/registry/chart-imports.ts
+++ b/apps/web/components/charts/registry/chart-imports.ts
@@ -27,6 +27,7 @@ import { miscChartImports } from './imports/misc-charts'
 import { queryChartImports } from './imports/query-charts'
 import { queryPerfChartImports } from './imports/query-perf-charts'
 import { replicationChartImports } from './imports/replication-charts'
+import { securityChartImports } from './imports/security-charts'
 import { systemChartImports } from './imports/system-charts'
 import { threadChartImports } from './imports/thread-charts'
 import { zookeeperChartImports } from './imports/zookeeper-charts'
@@ -44,4 +45,5 @@ export const chartImports: ChartRegistryMap = {
   ...threadChartImports,
   ...miscChartImports,
   ...queryPerfChartImports,
+  ...securityChartImports,
 }

--- a/apps/web/components/charts/registry/imports/security-charts.ts
+++ b/apps/web/components/charts/registry/imports/security-charts.ts
@@ -1,0 +1,22 @@
+/**
+ * Security chart imports
+ *
+ * Lazy-loaded authentication and session monitoring charts.
+ */
+
+import type { ChartRegistryMap } from '@/components/charts/registry/types'
+
+import { lazy } from 'react'
+
+export const securityChartImports: ChartRegistryMap = {
+  'login-success-rate': lazy(() =>
+    import('@/components/charts/security/login-success-rate').then((m) => ({
+      default: m.ChartLoginSuccessRate,
+    }))
+  ),
+  'active-sessions-count': lazy(() =>
+    import('@/components/charts/security/active-sessions-count').then((m) => ({
+      default: m.ChartActiveSessionsCount,
+    }))
+  ),
+}

--- a/apps/web/components/charts/security/active-sessions-count.tsx
+++ b/apps/web/components/charts/security/active-sessions-count.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createCustomChart } from '@/components/charts/factory'
+
+interface ActiveSessionsData {
+  active_count: number
+  unique_users: number
+}
+
+export const ChartActiveSessionsCount = createCustomChart({
+  chartName: 'active-sessions-count',
+  defaultTitle: 'Active Sessions',
+  dataTestId: 'active-sessions-count-chart',
+  render: (dataArray) => {
+    const row = (dataArray[0] as ActiveSessionsData) ?? {
+      active_count: 0,
+      unique_users: 0,
+    }
+
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 p-4 h-full min-h-[120px]">
+        <div className="flex gap-8">
+          <div className="flex flex-col items-center gap-1">
+            <span className="text-3xl font-semibold tabular-nums">
+              {row.active_count.toLocaleString()}
+            </span>
+            <span className="text-xs text-muted-foreground uppercase tracking-wide">
+              Active Sessions
+            </span>
+          </div>
+          <div className="w-px bg-border" />
+          <div className="flex flex-col items-center gap-1">
+            <span className="text-3xl font-semibold tabular-nums">
+              {row.unique_users.toLocaleString()}
+            </span>
+            <span className="text-xs text-muted-foreground uppercase tracking-wide">
+              Unique Users
+            </span>
+          </div>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Sessions active in the last hour
+        </p>
+      </div>
+    )
+  },
+})
+
+export type ChartActiveSessionsCountProps = ChartProps
+
+export default ChartActiveSessionsCount

--- a/apps/web/components/charts/security/login-success-rate.tsx
+++ b/apps/web/components/charts/security/login-success-rate.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+export const ChartLoginSuccessRate = createAreaChart({
+  chartName: 'login-success-rate',
+  index: 'event_time',
+  categories: ['success_count', 'failure_count'],
+  defaultTitle: 'Login Activity',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24 * 7,
+  dataTestId: 'login-success-rate-chart',
+  dateRangeConfig: 'system-metrics',
+  areaChartProps: {
+    stack: true,
+    showLegend: true,
+    showXAxis: true,
+    showCartesianGrid: true,
+    colors: ['--chart-10', '--chart-8'],
+    yAxisTickFormatter: chartTickFormatters.count,
+  },
+})
+
+export type ChartLoginSuccessRateProps = ChartProps
+
+export default ChartLoginSuccessRate

--- a/apps/web/components/data-table/cells/keeper-connection-expanded-details.tsx
+++ b/apps/web/components/data-table/cells/keeper-connection-expanded-details.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import {
+  ClockIcon,
+  DatabaseIcon,
+  FingerprintIcon,
+  LayersIcon,
+  MapPinIcon,
+  TimerIcon,
+} from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+interface KeeperConnectionExpandedDetailsProps {
+  row: Record<string, unknown>
+}
+
+function hasValue(value: unknown): boolean {
+  return value !== undefined && value !== null && String(value) !== ''
+}
+
+function toStringSafe(value: unknown): string {
+  return hasValue(value) ? String(value) : ''
+}
+
+interface DetailFieldProps {
+  label: string
+  value: React.ReactNode
+  icon?: React.ComponentType<{ className?: string }>
+  mono?: boolean
+  className?: string
+}
+
+function DetailField({
+  label,
+  value,
+  icon: Icon,
+  mono = false,
+  className,
+}: DetailFieldProps) {
+  if (!hasValue(value)) return null
+
+  return (
+    <div
+      className={cn(
+        'min-w-0 rounded-md border border-border/60 bg-background/60 px-3 py-2',
+        className
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        {Icon && <Icon className="size-3.5 shrink-0" aria-hidden="true" />}
+        <span className="truncate">{label}</span>
+      </div>
+      <div
+        className={cn(
+          'mt-1 min-w-0 truncate text-sm text-foreground tabular-nums',
+          mono && 'font-mono'
+        )}
+        title={typeof value === 'string' ? value : undefined}
+      >
+        {value}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Inline expanded-row detail panel for the keeper-connections table.
+ *
+ * Renders the secondary fields that are moved out of the main column list:
+ * index, client_id, xid, keeper_api_version, session_timeout_ms,
+ * last_zxid_seen, enabled_feature_flags, availability_zone.
+ *
+ * Fields that are absent from the row (version-dependent columns) are
+ * silently omitted — the panel only shows what is present.
+ */
+export const KeeperConnectionExpandedDetails =
+  function KeeperConnectionExpandedDetails({
+    row,
+  }: KeeperConnectionExpandedDetailsProps) {
+    const index = toStringSafe(row.index)
+    const clientId = toStringSafe(row.client_id)
+    const xid = toStringSafe(row.xid)
+    const keeperApiVersion = toStringSafe(row.keeper_api_version)
+    const sessionTimeoutMs = toStringSafe(row.session_timeout_ms)
+    const lastZxidSeen = toStringSafe(row.last_zxid_seen)
+    const enabledFeatureFlags = toStringSafe(row.enabled_feature_flags)
+    const availabilityZone = toStringSafe(row.availability_zone)
+
+    return (
+      <div
+        data-slot="keeper-connection-expanded"
+        className="border-t border-border/60 bg-muted/20 p-4"
+      >
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          <DetailField icon={LayersIcon} label="Index" value={index} mono />
+          <DetailField
+            icon={FingerprintIcon}
+            label="Client ID"
+            value={clientId}
+            mono
+          />
+          <DetailField icon={FingerprintIcon} label="XID" value={xid} mono />
+          <DetailField
+            icon={DatabaseIcon}
+            label="Keeper API Version"
+            value={keeperApiVersion}
+            mono
+          />
+          <DetailField
+            icon={TimerIcon}
+            label="Session Timeout (ms)"
+            value={sessionTimeoutMs}
+            mono
+          />
+          <DetailField
+            icon={ClockIcon}
+            label="Last ZXID Seen"
+            value={lastZxidSeen}
+            mono
+          />
+          <DetailField
+            icon={LayersIcon}
+            label="Feature Flags"
+            value={enabledFeatureFlags}
+            className="sm:col-span-2"
+          />
+          <DetailField
+            icon={MapPinIcon}
+            label="Availability Zone"
+            value={availabilityZone}
+          />
+        </div>
+      </div>
+    )
+  }

--- a/apps/web/components/health/health-card.tsx
+++ b/apps/web/components/health/health-card.tsx
@@ -18,7 +18,7 @@ function StatusDot({ status }: { status: HealthStatus }) {
   return (
     <span
       className={cn(
-        'inline-block h-3 w-3 rounded-full flex-shrink-0',
+        'inline-block h-2 w-2 rounded-full flex-shrink-0',
         status === 'ok' && 'bg-green-500',
         status === 'warning' && 'bg-amber-500',
         status === 'critical' && 'bg-red-500',
@@ -115,6 +115,8 @@ export function HealthCard({ check, thresholds }: HealthCardProps) {
   const withHost = (href: string) =>
     `${href}${href.includes('?') ? '&' : '?'}host=${hostId}`
 
+  const Icon = check.icon
+
   return (
     <>
       <div
@@ -124,41 +126,67 @@ export function HealthCard({ check, thresholds }: HealthCardProps) {
           status === 'warning' && 'border-amber-500/50 bg-amber-500/5'
         )}
       >
+        {/* Header: icon + title + status dot + expand button */}
         <div className="flex items-center gap-2">
-          <StatusDot status={status} />
-          <span className="text-sm font-medium text-muted-foreground">
+          {Icon && (
+            <Icon
+              className={cn(
+                'size-4 flex-shrink-0',
+                status === 'critical' && 'text-red-500',
+                status === 'warning' && 'text-amber-500',
+                status === 'ok' && 'text-green-500',
+                (status === 'loading' || status === 'error') &&
+                  'text-muted-foreground'
+              )}
+              aria-hidden
+            />
+          )}
+          <span className="text-[12.5px] font-medium text-muted-foreground leading-tight flex-1 min-w-0 truncate">
             {check.title}
           </span>
+          <StatusDot status={status} />
           <button
             type="button"
             onClick={() => setDetailOpen(true)}
             aria-label={`Open ${check.title} details`}
-            className="ml-auto rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
+            className="rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
           >
-            <Maximize2 className="size-3.5" />
+            <Maximize2 className="size-3" />
           </button>
         </div>
+
+        {/* Body: big number + sub-label */}
         <button
           type="button"
           onClick={() => setDetailOpen(true)}
           className="text-left"
         >
           <div className="text-2xl font-bold tabular-nums">{displayValue}</div>
-          <div className="text-xs text-muted-foreground mt-1">{label}</div>
+          <div className="text-[11.5px] text-muted-foreground mt-0.5 leading-snug">
+            {label}
+          </div>
         </button>
+
+        {/* Footer: related links as tappable chips */}
         {check.relatedLinks && check.relatedLinks.length > 0 && (
-          <div className="flex flex-wrap gap-x-2 gap-y-1 border-t pt-2 text-xs text-muted-foreground">
-            {check.relatedLinks.slice(0, 3).map((l, i) => (
-              <span key={l.href} className="inline-flex items-center gap-2">
-                {i > 0 && <span aria-hidden>·</span>}
+          <div className="border-t pt-2">
+            <div className="flex flex-wrap gap-1">
+              {check.relatedLinks.slice(0, 3).map((l) => (
                 <AppLink
+                  key={l.href}
                   href={withHost(l.href)}
-                  className="text-primary hover:underline"
+                  className={cn(
+                    'inline-flex items-center rounded-md px-2 py-0.5',
+                    'text-[11px] font-medium leading-none',
+                    'bg-muted/60 text-muted-foreground',
+                    'hover:bg-muted hover:text-foreground',
+                    'transition-colors'
+                  )}
                 >
                   {l.label}
                 </AppLink>
-              </span>
-            ))}
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/apps/web/components/health/health-checks.ts
+++ b/apps/web/components/health/health-checks.ts
@@ -1,3 +1,16 @@
+import type { LucideIcon } from 'lucide-react'
+import {
+  Clock,
+  HardDrive,
+  Layers,
+  MemoryStick,
+  PauseCircle,
+  ServerCrash,
+  ShieldAlert,
+  Timer,
+  XCircle,
+} from 'lucide-react'
+
 import type { Thresholds } from '@/lib/health/thresholds-storage'
 
 export interface RelatedLink {
@@ -15,6 +28,8 @@ export interface DocsLink {
 export interface HealthCheckDef {
   id: string
   title: string
+  /** Lucide icon rendered in the card header. */
+  icon?: LucideIcon
   chartName: string
   /** Field on first data row to read the numeric value from. */
   valueKey: string
@@ -47,6 +62,7 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
   {
     id: 'readonly-replicas',
     title: 'Readonly Replicas',
+    icon: ShieldAlert,
     chartName: 'health-readonly-replicas',
     valueKey: 'readonly_count',
     defaults: { warning: 1, critical: 3 },
@@ -78,6 +94,7 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
   {
     id: 'delayed-inserts',
     title: 'Delayed Inserts',
+    icon: PauseCircle,
     chartName: 'health-delayed-inserts',
     valueKey: 'delayed_inserts',
     defaults: { warning: 1, critical: 5 },
@@ -105,6 +122,7 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
   {
     id: 'max-parts',
     title: 'Max Parts / Partition',
+    icon: Layers,
     chartName: 'health-max-part-count',
     valueKey: 'part_count',
     defaults: { warning: 150, critical: 300 },
@@ -136,6 +154,7 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
   {
     id: 'long-running-queries',
     title: 'Long-Running Queries',
+    icon: Timer,
     chartName: 'health-long-running-queries',
     valueKey: 'long_running',
     defaults: { warning: 1, critical: 5 },
@@ -167,6 +186,7 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
   {
     id: 'oom-killed',
     title: 'OOM-Killed Queries (1h)',
+    icon: MemoryStick,
     chartName: 'health-oom-killed-recent',
     valueKey: 'oom_count',
     defaults: { warning: 1, critical: 10 },
@@ -198,6 +218,7 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
   {
     id: 'failed-queries',
     title: 'Failed Queries (1h)',
+    icon: XCircle,
     chartName: 'health-failed-queries-recent',
     valueKey: 'failed_count',
     defaults: { warning: 10, critical: 100 },
@@ -229,6 +250,7 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
   {
     id: 'replication-lag',
     title: 'Replication Lag',
+    icon: Clock,
     chartName: 'health-replication-lag',
     valueKey: 'max_lag',
     defaults: { warning: 30, critical: 300 },
@@ -260,6 +282,7 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
   {
     id: 'keeper-exceptions',
     title: 'Keeper Exceptions (1h)',
+    icon: ServerCrash,
     chartName: 'health-keeper-exceptions-recent',
     valueKey: 'exception_count',
     defaults: { warning: 1, critical: 20 },
@@ -286,6 +309,7 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
   {
     id: 'memory-percent',
     title: 'Memory Usage',
+    icon: MemoryStick,
     chartName: 'health-memory-percent',
     valueKey: 'memory_percent',
     defaults: { warning: 80, critical: 95 },
@@ -314,6 +338,7 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
   {
     id: 'disk-percent',
     title: 'Disk Usage',
+    icon: HardDrive,
     chartName: 'health-disk-percent',
     valueKey: 'disk_percent',
     defaults: { warning: 80, critical: 95 },

--- a/apps/web/components/health/mutations-cards.tsx
+++ b/apps/web/components/health/mutations-cards.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { GitMerge, Wrench } from 'lucide-react'
+
 import type { HealthStatus } from './health-card'
 
 import { useEffect, useRef } from 'react'
@@ -11,7 +13,7 @@ function StatusDot({ status }: { status: HealthStatus }) {
   return (
     <span
       className={cn(
-        'inline-block h-3 w-3 rounded-full flex-shrink-0',
+        'inline-block h-2 w-2 rounded-full flex-shrink-0',
         status === 'ok' && 'bg-green-500',
         status === 'warning' && 'bg-amber-500',
         status === 'critical' && 'bg-red-500',
@@ -118,13 +120,26 @@ export function StuckMutationsCard() {
       )}
     >
       <div className="flex items-center gap-2">
-        <StatusDot status={status} />
-        <span className="text-sm font-medium text-muted-foreground">
+        <Wrench
+          className={cn(
+            'size-4 flex-shrink-0',
+            status === 'critical' && 'text-red-500',
+            status === 'warning' && 'text-amber-500',
+            status === 'ok' && 'text-green-500',
+            (status === 'loading' || status === 'error') &&
+              'text-muted-foreground'
+          )}
+          aria-hidden
+        />
+        <span className="text-[12.5px] font-medium text-muted-foreground leading-tight flex-1 min-w-0 truncate">
           Mutations
         </span>
+        <StatusDot status={status} />
       </div>
       <div className="text-2xl font-bold tabular-nums">{stuck}</div>
-      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="text-[11.5px] text-muted-foreground leading-snug">
+        {label}
+      </div>
     </div>
   )
 }
@@ -181,15 +196,28 @@ export function RunningMutationsCard() {
       )}
     >
       <div className="flex items-center gap-2">
-        <StatusDot status={status} />
-        <span className="text-sm font-medium text-muted-foreground">
+        <GitMerge
+          className={cn(
+            'size-4 flex-shrink-0',
+            status === 'critical' && 'text-red-500',
+            status === 'warning' && 'text-amber-500',
+            status === 'ok' && 'text-green-500',
+            (status === 'loading' || status === 'error') &&
+              'text-muted-foreground'
+          )}
+          aria-hidden
+        />
+        <span className="text-[12.5px] font-medium text-muted-foreground leading-tight flex-1 min-w-0 truncate">
           Running Mutations
         </span>
+        <StatusDot status={status} />
       </div>
       <div className="text-2xl font-bold tabular-nums">
         {value.toLocaleString()}
       </div>
-      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="text-[11.5px] text-muted-foreground leading-snug">
+        {label}
+      </div>
     </div>
   )
 }

--- a/apps/web/components/keeper/keeper-node-cards.tsx
+++ b/apps/web/components/keeper/keeper-node-cards.tsx
@@ -1,0 +1,459 @@
+'use client'
+
+import { Database, Layers, ServerCrash, Wifi, WifiOff } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import {
+  detectKeeperType,
+  type KeeperType,
+} from '@/lib/keeper/detect-keeper-type'
+import { useHostId } from '@/lib/swr/use-host'
+import { useTableData } from '@/lib/swr/use-table-data'
+import { cn } from '@/lib/utils'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface KeeperInfoRow {
+  zookeeper_cluster_name: string
+  host: string
+  port: number | string
+  is_connected: boolean | number | string
+  server_state: string
+  is_leader: boolean | number | string
+  version: string
+  avg_latency: number | string
+  min_latency: number | string
+  max_latency: number | string
+  znode_count: number | string
+  watch_count: number | string
+  ephemerals_count: number | string
+  approximate_data_size: number | string
+  readable_approximate_data_size: string
+  packets_received: number | string
+  packets_sent: number | string
+  outstanding_requests: number | string
+  followers: number | string
+  synced_followers: number | string
+  zxid: number | string
+  last_log_idx: number | string
+  last_committed_idx: number | string
+  [key: string]: unknown
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Coerce a value that may arrive as boolean, number, or string "1"/"true". */
+function isTruthy(v: boolean | number | string | undefined): boolean {
+  if (typeof v === 'boolean') return v
+  if (typeof v === 'number') return v !== 0
+  if (typeof v === 'string') return v === '1' || v.toLowerCase() === 'true'
+  return false
+}
+
+function num(v: number | string | undefined): number {
+  return Number(v ?? 0)
+}
+
+/** Format a latency value (stored as milliseconds) with one decimal. */
+function fmtMs(v: number | string | undefined): string {
+  const n = num(v)
+  return n === 0
+    ? '0 ms'
+    : `${n.toLocaleString(undefined, { maximumFractionDigits: 1 })} ms`
+}
+
+/** Format a large integer compactly (e.g. 1 234 567 → "1.23M"). */
+function fmtCount(v: number | string | undefined): string {
+  const n = num(v)
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return n.toLocaleString()
+}
+
+// ---------------------------------------------------------------------------
+// Role badge
+// ---------------------------------------------------------------------------
+
+type RoleVariant = 'leader' | 'follower' | 'observer' | 'standalone'
+
+function deriveRole(row: KeeperInfoRow): RoleVariant {
+  const state = (row.server_state ?? '').toLowerCase()
+  if (state === 'leader' || isTruthy(row.is_leader)) return 'leader'
+  if (state === 'follower') return 'follower'
+  if (state === 'observer') return 'observer'
+  return 'standalone'
+}
+
+const ROLE_STYLES: Record<RoleVariant, string> = {
+  leader:
+    'border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-700/60 dark:bg-amber-900/20 dark:text-amber-300',
+  follower:
+    'border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-300',
+  observer:
+    'border-violet-300 bg-violet-50 text-violet-700 dark:border-violet-700/60 dark:bg-violet-900/20 dark:text-violet-300',
+  standalone:
+    'border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-700/60 dark:bg-emerald-900/20 dark:text-emerald-300',
+}
+
+const ROLE_LABEL: Record<RoleVariant, string> = {
+  leader: 'Leader',
+  follower: 'Follower',
+  observer: 'Observer',
+  standalone: 'Standalone',
+}
+
+function RoleBadge({ role }: { role: RoleVariant }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        'text-[10.5px] font-semibold px-1.5 py-0',
+        ROLE_STYLES[role]
+      )}
+    >
+      {ROLE_LABEL[role]}
+    </Badge>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Keeper-type badge
+// ---------------------------------------------------------------------------
+
+const KEEPER_TYPE_STYLES: Record<KeeperType, string> = {
+  'clickhouse-keeper':
+    'border-orange-300 bg-orange-50 text-orange-700 dark:border-orange-700/60 dark:bg-orange-900/20 dark:text-orange-300',
+  zookeeper:
+    'border-cyan-300 bg-cyan-50 text-cyan-700 dark:border-cyan-700/60 dark:bg-cyan-900/20 dark:text-cyan-300',
+  unknown: 'border-border bg-muted/40 text-muted-foreground',
+}
+
+const KEEPER_TYPE_LABEL: Record<KeeperType, string> = {
+  'clickhouse-keeper': 'ClickHouse Keeper',
+  zookeeper: 'ZooKeeper',
+  unknown: 'Unknown',
+}
+
+function KeeperTypeBadge({ version }: { version: string | undefined }) {
+  const type = detectKeeperType(version)
+  const label = KEEPER_TYPE_LABEL[type]
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge
+          variant="outline"
+          className={cn(
+            'text-[10.5px] font-semibold px-1.5 py-0 cursor-default',
+            KEEPER_TYPE_STYLES[type]
+          )}
+        >
+          {label}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-[260px] text-center">
+        {version ? `Detected from version: ${version}` : 'Version not reported'}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Metric row inside a card
+// ---------------------------------------------------------------------------
+
+function MetricRow({
+  label,
+  value,
+  className,
+}: {
+  label: string
+  value: string | number
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        'flex items-baseline justify-between gap-2 min-w-0',
+        className
+      )}
+    >
+      <span className="shrink-0 text-[11px] text-muted-foreground leading-snug">
+        {label}
+      </span>
+      <span className="truncate text-right font-mono text-[11.5px] tabular-nums text-foreground/85">
+        {value}
+      </span>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Single node card
+// ---------------------------------------------------------------------------
+
+function NodeCard({ row }: { row: KeeperInfoRow }) {
+  const connected = isTruthy(row.is_connected)
+  const role = deriveRole(row)
+  const isStandalone = role === 'standalone'
+  const raftLag = num(row.last_log_idx) - num(row.last_committed_idx)
+
+  return (
+    <Card className="flex flex-col min-w-0 overflow-hidden">
+      {/* Header */}
+      <CardHeader className="flex flex-row flex-wrap items-start gap-2 p-3 pb-2.5 border-b border-border/60">
+        <div className="flex flex-1 min-w-0 flex-col gap-1">
+          {/* host:port */}
+          <span className="font-mono text-[12.5px] font-semibold text-foreground/90 truncate leading-tight">
+            {row.host}:{row.port}
+          </span>
+          {/* cluster name */}
+          {row.zookeeper_cluster_name && (
+            <span className="text-[10.5px] text-muted-foreground truncate leading-snug">
+              {row.zookeeper_cluster_name}
+            </span>
+          )}
+        </div>
+
+        {/* Badges + connection dot */}
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <RoleBadge role={role} />
+          <KeeperTypeBadge version={row.version} />
+          {/* Connection status dot */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className={cn(
+                  'inline-flex items-center justify-center size-4 rounded-full cursor-default',
+                  connected
+                    ? 'bg-emerald-100 dark:bg-emerald-900/30'
+                    : 'bg-rose-100 dark:bg-rose-900/30'
+                )}
+              >
+                {connected ? (
+                  <Wifi
+                    className="size-2.5 text-emerald-600 dark:text-emerald-400"
+                    aria-label="Connected"
+                  />
+                ) : (
+                  <WifiOff
+                    className="size-2.5 text-rose-600 dark:text-rose-400"
+                    aria-label="Disconnected"
+                  />
+                )}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {connected ? 'Connected' : 'Disconnected'}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </CardHeader>
+
+      {/* Metrics grid */}
+      <CardContent className="p-3 pt-2.5 flex flex-col gap-1">
+        {/* Latency */}
+        <div className="mb-1">
+          <span className="text-[10px] uppercase tracking-wide font-semibold text-muted-foreground/70">
+            Latency
+          </span>
+          <div className="mt-0.5 grid grid-cols-3 gap-1">
+            <MetricRow label="avg" value={fmtMs(row.avg_latency)} />
+            <MetricRow label="min" value={fmtMs(row.min_latency)} />
+            <MetricRow label="max" value={fmtMs(row.max_latency)} />
+          </div>
+        </div>
+
+        {/* Znodes / watches / ephemerals / data */}
+        <div className="mb-1">
+          <span className="text-[10px] uppercase tracking-wide font-semibold text-muted-foreground/70">
+            Storage
+          </span>
+          <div className="mt-0.5 flex flex-col gap-0.5">
+            <MetricRow label="Znodes" value={fmtCount(row.znode_count)} />
+            <MetricRow label="Watches" value={fmtCount(row.watch_count)} />
+            <MetricRow
+              label="Ephemerals"
+              value={fmtCount(row.ephemerals_count)}
+            />
+            <MetricRow
+              label="Data size"
+              value={row.readable_approximate_data_size || '—'}
+            />
+          </div>
+        </div>
+
+        {/* Network */}
+        <div className="mb-1">
+          <span className="text-[10px] uppercase tracking-wide font-semibold text-muted-foreground/70">
+            Network
+          </span>
+          <div className="mt-0.5 flex flex-col gap-0.5">
+            <MetricRow
+              label="Packets sent"
+              value={fmtCount(row.packets_sent)}
+            />
+            <MetricRow
+              label="Packets recv"
+              value={fmtCount(row.packets_received)}
+            />
+            <MetricRow
+              label="Outstanding"
+              value={fmtCount(row.outstanding_requests)}
+            />
+          </div>
+        </div>
+
+        {/* Raft (only meaningful when not standalone) */}
+        {!isStandalone && (
+          <div>
+            <span className="text-[10px] uppercase tracking-wide font-semibold text-muted-foreground/70">
+              Raft
+            </span>
+            <div className="mt-0.5 flex flex-col gap-0.5">
+              <MetricRow
+                label="Log lag"
+                value={raftLag.toLocaleString()}
+                className={cn(
+                  raftLag > 1000 && 'text-rose-600 dark:text-rose-400'
+                )}
+              />
+              <MetricRow label="Zxid" value={fmtCount(row.zxid)} />
+              {num(row.followers) > 0 && (
+                <MetricRow
+                  label="Followers"
+                  value={`${fmtCount(row.synced_followers)}/${fmtCount(row.followers)} synced`}
+                />
+              )}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function NodeCardSkeleton() {
+  return (
+    <div className="rounded-xl border border-border bg-card p-3 flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <div className="h-4 w-32 animate-pulse rounded bg-foreground/[0.06]" />
+        <div className="ml-auto flex gap-1.5">
+          <div className="h-4 w-14 animate-pulse rounded bg-foreground/[0.06]" />
+          <div className="h-4 w-20 animate-pulse rounded bg-foreground/[0.06]" />
+        </div>
+      </div>
+      <div className="h-3 w-20 animate-pulse rounded bg-foreground/[0.04]" />
+      <div className="mt-1 flex flex-col gap-1.5">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="h-2.5 animate-pulse rounded bg-foreground/[0.04]"
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Public component
+// ---------------------------------------------------------------------------
+
+export function KeeperNodeCards() {
+  const hostId = useHostId()
+  const { data, error, isLoading } = useTableData<KeeperInfoRow>(
+    'keeper-info',
+    hostId
+  )
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <NodeCardSkeleton />
+        <NodeCardSkeleton />
+        <NodeCardSkeleton />
+      </div>
+    )
+  }
+
+  if (error) {
+    const msg = (error as Error)?.message ?? String(error)
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2.5 text-[12.5px] text-rose-700 dark:border-rose-800/60 dark:bg-rose-900/20 dark:text-rose-300">
+        <ServerCrash className="size-4 shrink-0" />
+        <span>Failed to load keeper nodes: {msg}</span>
+      </div>
+    )
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-border py-10 text-center text-muted-foreground">
+        <Database className="size-8 opacity-30" />
+        <p className="text-[12.5px]">
+          No keeper nodes found.
+          <br />
+          <span className="text-[11.5px] opacity-70">
+            system.zookeeper_info requires ClickHouse ≥ 26.1 and an active
+            Keeper / ZooKeeper connection.
+          </span>
+        </p>
+      </div>
+    )
+  }
+
+  // Group by cluster name — mostly a single cluster, but support multiple
+  const clusters = new Map<string, KeeperInfoRow[]>()
+  for (const row of data) {
+    const name = row.zookeeper_cluster_name ?? ''
+    if (!clusters.has(name)) clusters.set(name, [])
+    clusters.get(name)!.push(row)
+  }
+
+  const multiCluster = clusters.size > 1
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <div className="flex flex-col gap-4">
+        {Array.from(clusters.entries()).map(([clusterName, nodes]) => (
+          <div key={clusterName} className="flex flex-col gap-2">
+            {multiCluster && (
+              <div className="flex items-center gap-2">
+                <Layers className="size-3.5 text-muted-foreground" />
+                <span className="text-[11.5px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  {clusterName || 'default'}
+                </span>
+                <span className="text-[11px] text-muted-foreground/60">
+                  ({nodes.length} {nodes.length === 1 ? 'node' : 'nodes'})
+                </span>
+              </div>
+            )}
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {nodes.map((row) => (
+                <NodeCard key={`${row.host}:${row.port}`} row={row} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </TooltipProvider>
+  )
+}
+
+export default KeeperNodeCards

--- a/apps/web/components/tables/table-client.tsx
+++ b/apps/web/components/tables/table-client.tsx
@@ -217,7 +217,7 @@ export const TableClient = function TableClient({
               aria-label={
                 title ? `${title} unavailable` : 'Table not available'
               }
-              className="pr-12"
+              className="border-0 pr-12"
             >
               <Info />
               <AlertTitle>{errorTitle}</AlertTitle>

--- a/apps/web/lib/keeper/detect-keeper-type.test.ts
+++ b/apps/web/lib/keeper/detect-keeper-type.test.ts
@@ -1,0 +1,64 @@
+import { detectKeeperType } from './detect-keeper-type'
+import { describe, expect, it } from 'bun:test'
+
+describe('detectKeeperType', () => {
+  describe('ClickHouse Keeper', () => {
+    it('detects from stable suffix', () => {
+      expect(detectKeeperType('v26.1.3.52-stable-abc123')).toBe(
+        'clickhouse-keeper'
+      )
+    })
+
+    it('detects from lts suffix', () => {
+      expect(detectKeeperType('24.8.5.115-lts')).toBe('clickhouse-keeper')
+    })
+
+    it('detects from testing suffix', () => {
+      expect(detectKeeperType('25.3.0.1-testing')).toBe('clickhouse-keeper')
+    })
+
+    it('detects from major version >= 18', () => {
+      expect(detectKeeperType('26.1.3.52')).toBe('clickhouse-keeper')
+    })
+
+    it('detects from major version exactly 18', () => {
+      expect(detectKeeperType('18.14.19')).toBe('clickhouse-keeper')
+    })
+
+    it('detects when the word "keeper" appears in version', () => {
+      expect(detectKeeperType('keeper-1.0')).toBe('clickhouse-keeper')
+    })
+
+    it('handles leading "v" prefix', () => {
+      expect(detectKeeperType('v25.5.1.1')).toBe('clickhouse-keeper')
+    })
+  })
+
+  describe('Apache ZooKeeper', () => {
+    it('detects 3.x versions', () => {
+      expect(detectKeeperType('3.8.4')).toBe('zookeeper')
+    })
+
+    it('detects 3.x with patch', () => {
+      expect(detectKeeperType('3.6.3')).toBe('zookeeper')
+    })
+  })
+
+  describe('unknown', () => {
+    it('returns unknown for null', () => {
+      expect(detectKeeperType(null)).toBe('unknown')
+    })
+
+    it('returns unknown for undefined', () => {
+      expect(detectKeeperType(undefined)).toBe('unknown')
+    })
+
+    it('returns unknown for empty string', () => {
+      expect(detectKeeperType('')).toBe('unknown')
+    })
+
+    it('returns unknown for unrecognised version', () => {
+      expect(detectKeeperType('2.0.1')).toBe('unknown')
+    })
+  })
+})

--- a/apps/web/lib/keeper/detect-keeper-type.ts
+++ b/apps/web/lib/keeper/detect-keeper-type.ts
@@ -1,0 +1,48 @@
+/**
+ * Keeper type detection.
+ *
+ * ClickHouse Keeper reports the _ClickHouse server_ version (e.g. "v26.1.3.52-stable-…"
+ * or just "26.1.3.52"), because it is bundled inside the ClickHouse binary.
+ * Apache ZooKeeper follows its own versioning on the 3.x line (e.g. "3.8.4").
+ *
+ * Detection rules (applied in priority order):
+ *  1. The string contains the word "keeper"  → ClickHouse Keeper
+ *  2. Known ClickHouse build suffixes present ("-stable", "-lts", "-testing") → ClickHouse Keeper
+ *  3. Major version ≥ 18 (ClickHouse started at v1.x in 2016, jumped to 18.x;
+ *     ZooKeeper never reached 18)  → ClickHouse Keeper
+ *  4. Major version === 3  → Apache ZooKeeper
+ *  5. Otherwise  → unknown
+ */
+
+export type KeeperType = 'clickhouse-keeper' | 'zookeeper' | 'unknown'
+
+/** Strip a leading "v" and return the normalised lowercase string. */
+function normalise(version: string): string {
+  return version.replace(/^v/i, '').toLowerCase().trim()
+}
+
+/** Extract the numeric major version from the normalised version string. */
+function majorVersion(norm: string): number | null {
+  const match = /^(\d+)/.exec(norm)
+  return match ? Number.parseInt(match[1], 10) : null
+}
+
+export function detectKeeperType(version?: string | null): KeeperType {
+  if (!version) return 'unknown'
+
+  const norm = normalise(version)
+
+  // Rule 1: explicit "keeper" substring
+  if (norm.includes('keeper')) return 'clickhouse-keeper'
+
+  // Rule 2: ClickHouse release-channel suffixes
+  if (/-stable|-lts|-testing/.test(norm)) return 'clickhouse-keeper'
+
+  // Rule 3 / 4: major-version heuristic
+  const major = majorVersion(norm)
+  if (major === null) return 'unknown'
+  if (major >= 18) return 'clickhouse-keeper'
+  if (major === 3) return 'zookeeper'
+
+  return 'unknown'
+}

--- a/apps/web/lib/query-config/keeper/keeper-connections.tsx
+++ b/apps/web/lib/query-config/keeper/keeper-connections.tsx
@@ -1,6 +1,7 @@
 import type { QueryConfig } from '@/types/query-config'
 
 import { QUERY_COMMENT } from '@chm/clickhouse-client/constants'
+import { KeeperConnectionExpandedDetails } from '@/components/data-table/cells/keeper-connection-expanded-details'
 import { ColumnFormat } from '@/types/column-format'
 
 export const keeperConnectionsConfig: QueryConfig = {
@@ -97,36 +98,28 @@ export const keeperConnectionsConfig: QueryConfig = {
       `,
     },
   ],
+  // Key columns shown by default in the table.
+  // Secondary fields (index, client_id, xid, keeper_api_version,
+  // session_timeout_ms, last_zxid_seen, enabled_feature_flags,
+  // availability_zone) are rendered in the expandable detail panel.
   columns: [
     'name',
     'host',
     'port',
-    'index',
     'connected_time',
     'session_uptime_elapsed_seconds',
     'is_expired',
-    'keeper_api_version',
-    'client_id',
-    'xid',
-    'session_timeout_ms',
-    'last_zxid_seen',
-    'enabled_feature_flags',
-    'availability_zone',
   ],
   columnFormats: {
     name: ColumnFormat.Badge,
     host: ColumnFormat.Text,
     port: ColumnFormat.Number,
-    index: ColumnFormat.Number,
     connected_time: ColumnFormat.RelatedTime,
     session_uptime_elapsed_seconds: ColumnFormat.Duration,
     is_expired: ColumnFormat.Boolean,
-    keeper_api_version: ColumnFormat.Number,
-    client_id: ColumnFormat.Number,
-    xid: ColumnFormat.Number,
-    session_timeout_ms: ColumnFormat.Duration,
-    last_zxid_seen: ColumnFormat.Number,
-    enabled_feature_flags: ColumnFormat.ColoredBadge,
-    availability_zone: ColumnFormat.Text,
+  },
+
+  expandable: {
+    renderExpanded: (row) => <KeeperConnectionExpandedDetails row={row} />,
   },
 }

--- a/apps/web/menu.ts
+++ b/apps/web/menu.ts
@@ -259,7 +259,7 @@ export const menuItemsConfig: MenuItem[] = [
     ],
   },
   {
-    title: 'Monitoring',
+    title: 'Metrics',
     href: '',
     icon: BarChartIcon,
     section: 'main',
@@ -281,13 +281,6 @@ export const menuItemsConfig: MenuItem[] = [
         icon: BarChartIcon,
         permission: { feature: 'metrics' },
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/asynchronous_metrics',
-      },
-      {
-        title: 'Chart Builder',
-        href: '/dashboard',
-        description: 'Build custom monitoring dashboards with charts',
-        icon: DashboardIcon,
-        permission: { feature: 'dashboard' },
       },
       {
         title: 'Profiler',
@@ -538,6 +531,13 @@ export const menuItemsConfig: MenuItem[] = [
     section: 'others',
     permission: { feature: 'operations' },
     items: [
+      {
+        title: 'Chart Builder',
+        href: '/dashboard',
+        description: 'Build custom monitoring dashboards with charts',
+        icon: DashboardIcon,
+        permission: { feature: 'dashboard' },
+      },
       {
         title: 'Backups',
         href: '/backups',


### PR DESCRIPTION
A batch of UI improvements (built in a worktree, parallel sub-agents per area).

### Keeper
- **/keeper/overview**: "Keeper Nodes" now renders detailed **per-node cards** (role, connection, latency avg/min/max, znodes/watches/ephemerals, raft log lag, data size) instead of a 22-column table — clusters usually have 1/3/5 nodes. Each card shows a **ClickHouse Keeper vs ZooKeeper** badge. Detection (`lib/keeper/detect-keeper-type.ts`, unit-tested): ClickHouse Keeper reports the CH server version (`vNN.x`/`-stable`), Apache ZooKeeper is on the `3.x` line.
- **/keeper/connections**: **toggleable rows** — key columns visible (name, host, port, connected_time, session uptime, expired), the rest in an expandable detail panel. Version-varying columns render only when present.

### Health
- **Health Summary cards**: per-metric **icon** in the header + footer related-links rendered as clean wrap-friendly **chips**. Warning/critical tints preserved.

### Security
- **/security/sessions**: registered the missing **client** chart components for `login-success-rate` and `active-sessions-count` (server queries already existed in the registry) → fixes the "Unknown chart" tiles. Both degrade gracefully when `system.session_log` is absent.
- Removed the **double border** on the table-missing notice (`border-0` on the inner Alert; the Card owns the border).

### Menu / nav
- Renamed **"Monitoring" → "Metrics"**; moved **"Chart Builder" into Operations**.
- Added a small **"Docs"** link above the user button in the sidebar footer.

Co-Authored-By: duyetbot <bot@duyet.net>