### PR TITLE
fix(agents): break mcp-panel↔dialog import cycle

### DIFF
--- a/apps/web/components/agents/welcome/agent-mcp-panel.tsx
+++ b/apps/web/components/agents/welcome/agent-mcp-panel.tsx
@@ -16,6 +16,8 @@
 
 import { PlusIcon, WrenchIcon } from 'lucide-react'
 
+import type { McpServer } from './mcp-types'
+
 import { McpToolsResourcesDialog } from './mcp-tools-resources-dialog'
 import { useState } from 'react'
 import { Badge } from '@/components/ui/badge'
@@ -23,24 +25,8 @@ import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface McpServer {
-  id: string
-  name: string
-  /** Human-readable URL or transport description */
-  endpoint: string
-  toolCount: number
-  resourceCount?: number
-  version?: string
-  /** Whether this server ships with the app and cannot be removed */
-  builtin: boolean
-  enabled: boolean
-  /** Connection status */
-  status: 'connected' | 'connecting' | 'error' | 'unconfigured'
-}
+// Re-exported for existing consumers; canonical definition lives in mcp-types.ts.
+export type { McpServer }
 
 // ---------------------------------------------------------------------------
 // Built-in server definition (always present)

--- a/apps/web/components/agents/welcome/mcp-tools-resources-dialog.tsx
+++ b/apps/web/components/agents/welcome/mcp-tools-resources-dialog.tsx
@@ -12,7 +12,7 @@
 
 import { WrenchIcon } from 'lucide-react'
 
-import type { McpServer } from './agent-mcp-panel'
+import type { McpServer } from './mcp-types'
 
 import { Badge } from '@/components/ui/badge'
 import {

--- a/apps/web/components/agents/welcome/mcp-types.ts
+++ b/apps/web/components/agents/welcome/mcp-types.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared MCP panel types.
+ *
+ * Lives in its own leaf module so that both `agent-mcp-panel.tsx` (which renders
+ * the dialog) and `mcp-tools-resources-dialog.tsx` (which needs the server type)
+ * can depend on it without forming an import cycle.
+ */
+
+export interface McpServer {
+  id: string
+  name: string
+  /** Human-readable URL or transport description */
+  endpoint: string
+  toolCount: number
+  resourceCount?: number
+  version?: string
+  /** Whether this server ships with the app and cannot be removed */
+  builtin: boolean
+  enabled: boolean
+  /** Connection status */
+  status: 'connected' | 'connecting' | 'error' | 'unconfigured'
+}


### PR DESCRIPTION
## Problem

The `depcruise` job has been **failing on main** (and every branch) since the agents dialog work landed. Its `no-circular` rule rejects:

```
agent-mcp-panel.tsx → mcp-tools-resources-dialog.tsx → agent-mcp-panel.tsx
```

The panel imports the dialog **component**, while the dialog imports the `McpServer` **type** back from the panel — a graph cycle (dependency-cruiser flags it even though `import type` is erased at build time).

## Fix

Hoist `McpServer` into a leaf `mcp-types.ts` module that both files import. The panel re-exports the type (`export type { McpServer }`) so existing consumers are unaffected.

## Verification

- ✅ `bun run depcruise` — no dependency violations (was: 1 error)
- ✅ `bun run type-check` — clean
- ✅ `bun run lint` — no new warnings

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal type definitions for MCP server components to a shared module, improving code maintainability with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->