### PR TITLE
feat(health): SQL in detail dialog + audit-prompt toggles & token count

### DIFF
--- a/apps/web/components/health/health-audit-prompt-dialog.tsx
+++ b/apps/web/components/health/health-audit-prompt-dialog.tsx
@@ -3,7 +3,7 @@
 import { Check, Copy } from 'lucide-react'
 import { toast } from 'sonner'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -13,23 +13,85 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
+import {
+  type AuditPromptInput,
+  type AuditPromptOptions,
+  buildAuditPrompt,
+  DEFAULT_AUDIT_PROMPT_OPTIONS,
+  estimateTokens,
+} from '@/lib/health/audit-prompt'
 
 interface HealthAuditPromptDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   title: string
-  prompt: string
+  input: AuditPromptInput
+}
+
+/** A toggleable section, shown only when the check actually has that content. */
+interface ToggleDef {
+  key: keyof AuditPromptOptions
+  label: string
+  available: boolean
 }
 
 export function HealthAuditPromptDialog({
   open,
   onOpenChange,
   title,
-  prompt,
+  input,
 }: HealthAuditPromptDialogProps) {
   const [copied, setCopied] = useState(false)
+  const [options, setOptions] = useState<AuditPromptOptions>(
+    DEFAULT_AUDIT_PROMPT_OPTIONS
+  )
+
+  const { check, row } = input
+
+  // Only surface toggles for sections this particular check can populate.
+  const toggles: ToggleDef[] = [
+    { key: 'sql', label: 'Metric query', available: Boolean(check.sql) },
+    {
+      key: 'rawData',
+      label: 'Raw data row',
+      available: Boolean(row && Object.keys(row).length > 0),
+    },
+    {
+      key: 'systemTables',
+      label: 'System tables',
+      available: Boolean(check.systemTables?.length),
+    },
+    {
+      key: 'commonCauses',
+      label: 'Common causes',
+      available: Boolean(check.commonCauses?.length),
+    },
+    {
+      key: 'relatedLinks',
+      label: 'Related dashboards',
+      available: Boolean(check.relatedLinks?.length),
+    },
+    {
+      key: 'docsLinks',
+      label: 'Documentation',
+      available: Boolean(check.docsLinks?.length),
+    },
+    {
+      key: 'docsMarkdown',
+      label: 'Doc markdown URLs',
+      available: Boolean(check.docsLinks?.length) && Boolean(options.docsLinks),
+    },
+  ]
+
+  const prompt = useMemo(
+    () => buildAuditPrompt(input, options),
+    [input, options]
+  )
+  const tokens = useMemo(() => estimateTokens(prompt), [prompt])
 
   const handleCopy = async () => {
     try {
@@ -53,26 +115,55 @@ export function HealthAuditPromptDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <ScrollArea className="h-[420px] rounded-md border">
+        {/* Section toggles — trim the prompt to control its size/cost. */}
+        <div className="flex flex-wrap gap-x-4 gap-y-2 rounded-md border p-3">
+          {toggles
+            .filter((t) => t.available)
+            .map((t) => (
+              <div key={t.key} className="flex items-center gap-2">
+                <Switch
+                  id={`audit-toggle-${t.key}`}
+                  checked={Boolean(options[t.key])}
+                  onCheckedChange={(next) =>
+                    setOptions((prev) => ({ ...prev, [t.key]: next }))
+                  }
+                />
+                <Label
+                  htmlFor={`audit-toggle-${t.key}`}
+                  className="text-xs font-normal"
+                >
+                  {t.label}
+                </Label>
+              </div>
+            ))}
+        </div>
+
+        <ScrollArea className="h-[360px] rounded-md border">
           <Textarea
             readOnly
             value={prompt}
-            className="min-h-[420px] resize-none border-0 font-mono text-xs leading-relaxed focus-visible:ring-0"
+            className="min-h-[360px] resize-none border-0 font-mono text-xs leading-relaxed focus-visible:ring-0"
           />
         </ScrollArea>
 
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Close
-          </Button>
-          <Button onClick={handleCopy}>
-            {copied ? (
-              <Check className="mr-2 size-4" />
-            ) : (
-              <Copy className="mr-2 size-4" />
-            )}
-            {copied ? 'Copied' : 'Copy prompt'}
-          </Button>
+        <DialogFooter className="items-center sm:justify-between">
+          <span className="text-xs text-muted-foreground tabular-nums">
+            ~{tokens.toLocaleString()} tokens · {prompt.length.toLocaleString()}{' '}
+            chars
+          </span>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Close
+            </Button>
+            <Button onClick={handleCopy}>
+              {copied ? (
+                <Check className="mr-2 size-4" />
+              ) : (
+                <Copy className="mr-2 size-4" />
+              )}
+              {copied ? 'Copied' : 'Copy prompt'}
+            </Button>
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/web/components/health/health-checks.ts
+++ b/apps/web/components/health/health-checks.ts
@@ -51,6 +51,13 @@ export interface HealthCheckDef {
   relatedLinks?: readonly RelatedLink[]
   /** External documentation links. */
   docsLinks?: readonly DocsLink[]
+  /**
+   * The SQL query that computes this check's value. Shown in the detail dialog
+   * and embedded in the audit prompt. Kept verbatim in sync with the backing
+   * chart query in `lib/api/charts/system-charts.ts` (display-only — importing
+   * the chart registry here would cross a layering boundary depcruise enforces).
+   */
+  sql?: string
 }
 
 const fmtCount = (singular: string, plural?: string) => (v: number | null) => {
@@ -90,6 +97,9 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
         url: 'https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replication',
       },
     ],
+    sql: `SELECT count() AS readonly_count
+FROM system.replicas
+WHERE is_readonly = 1`,
   },
   {
     id: 'delayed-inserts',
@@ -118,6 +128,9 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
         url: 'https://clickhouse.com/docs/en/operations/settings/merge-tree-settings#parts-to-delay-insert',
       },
     ],
+    sql: `SELECT value AS delayed_inserts
+FROM system.metrics
+WHERE metric = 'DelayedInserts'`,
   },
   {
     id: 'max-parts',
@@ -150,6 +163,15 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
         url: 'https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/custom-partitioning-key',
       },
     ],
+    sql: `SELECT
+  concat(database, '.', table) AS table_path,
+  partition,
+  count() AS part_count
+FROM system.parts
+WHERE active AND database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
+GROUP BY database, table, partition
+ORDER BY part_count DESC
+LIMIT 1`,
   },
   {
     id: 'long-running-queries',
@@ -182,6 +204,9 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
         url: 'https://clickhouse.com/docs/en/sql-reference/statements/kill',
       },
     ],
+    sql: `SELECT count() AS long_running
+FROM system.processes
+WHERE elapsed > 60 AND is_initial_query`,
   },
   {
     id: 'oom-killed',
@@ -214,6 +239,11 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
         url: 'https://clickhouse.com/docs/en/operations/settings/query-complexity#settings-max_bytes_before_external_group_by',
       },
     ],
+    sql: `SELECT count() AS oom_count
+FROM system.query_log
+WHERE event_time > now() - INTERVAL 1 HOUR
+  AND type IN ('ExceptionWhileProcessing', 'ExceptionBeforeStart')
+  AND (exception_code = 241 OR exception LIKE '%MEMORY_LIMIT_EXCEEDED%')`,
   },
   {
     id: 'failed-queries',
@@ -246,6 +276,10 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
         url: 'https://clickhouse.com/docs/en/operations/system-tables/errors',
       },
     ],
+    sql: `SELECT count() AS failed_count
+FROM system.query_log
+WHERE event_time > now() - INTERVAL 1 HOUR
+  AND type IN ('ExceptionWhileProcessing', 'ExceptionBeforeStart')`,
   },
   {
     id: 'replication-lag',
@@ -278,6 +312,8 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
         url: 'https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replication#recovery-after-failures',
       },
     ],
+    sql: `SELECT max(absolute_delay) AS max_lag
+FROM system.replicas`,
   },
   {
     id: 'keeper-exceptions',
@@ -305,6 +341,10 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
         url: 'https://clickhouse.com/docs/en/operations/clickhouse-keeper',
       },
     ],
+    sql: `SELECT coalesce(max(value) - min(value), 0) AS exception_count
+FROM merge('system', '^error_log')
+WHERE error = 'KEEPER_EXCEPTION'
+  AND event_time > now() - INTERVAL 1 HOUR`,
   },
   {
     id: 'memory-percent',
@@ -334,6 +374,14 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
         url: 'https://clickhouse.com/docs/en/operations/system-tables/asynchronous_metrics',
       },
     ],
+    sql: `SELECT round(
+  (
+    (SELECT value FROM system.asynchronous_metrics WHERE metric = 'OSMemoryTotal')
+    - (SELECT value FROM system.asynchronous_metrics WHERE metric = 'OSMemoryAvailable')
+  ) * 100.0
+  / nullIf((SELECT value FROM system.asynchronous_metrics WHERE metric = 'OSMemoryTotal'), 0),
+  1
+) AS memory_percent`,
   },
   {
     id: 'disk-percent',
@@ -367,5 +415,7 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
         url: 'https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#table_engine-mergetree-multiple-volumes',
       },
     ],
+    sql: `SELECT round(max((total_space - free_space) * 100.0 / nullIf(total_space, 0)), 1) AS disk_percent
+FROM system.disks`,
   },
 ] as const

--- a/apps/web/components/health/health-detail-dialog.tsx
+++ b/apps/web/components/health/health-detail-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { ExternalLink, Sparkles } from 'lucide-react'
 
+import type { AuditPromptInput } from '@/lib/health/audit-prompt'
 import type { HealthCheckDef } from './health-checks'
 
 import { HealthAuditPromptDialog } from './health-audit-prompt-dialog'
@@ -19,7 +20,6 @@ import {
 } from '@/components/ui/dialog'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
-import { buildAuditPrompt } from '@/lib/health/audit-prompt'
 import { cn } from '@/lib/utils'
 
 interface HealthDetailDialogProps {
@@ -71,7 +71,7 @@ export function HealthDetailDialog({
 }: HealthDetailDialogProps) {
   const [promptOpen, setPromptOpen] = useState(false)
 
-  const prompt = buildAuditPrompt({
+  const promptInput: AuditPromptInput = {
     check,
     value,
     thresholds,
@@ -79,7 +79,7 @@ export function HealthDetailDialog({
     row,
     hostId,
     clickhouseVersion,
-  })
+  }
 
   const displayValue = check.formatValue
     ? check.formatValue(value)
@@ -159,6 +159,18 @@ export function HealthDetailDialog({
                         </tbody>
                       </table>
                     </div>
+                  </div>
+                </>
+              )}
+
+              {check.sql && (
+                <>
+                  <Separator />
+                  <div>
+                    <h4 className="text-sm font-semibold mb-2">SQL query</h4>
+                    <pre className="rounded-md border bg-muted/40 p-3 overflow-x-auto text-xs font-mono leading-relaxed">
+                      <code>{check.sql}</code>
+                    </pre>
                   </div>
                 </>
               )}
@@ -263,7 +275,7 @@ export function HealthDetailDialog({
         open={promptOpen}
         onOpenChange={setPromptOpen}
         title={check.title}
-        prompt={prompt}
+        input={promptInput}
       />
     </>
   )

--- a/apps/web/lib/docs/clickhouse-doc-md-url.test.ts
+++ b/apps/web/lib/docs/clickhouse-doc-md-url.test.ts
@@ -1,0 +1,69 @@
+import { toClickHouseDocMarkdownUrl } from './clickhouse-doc-md-url'
+import { describe, expect, it } from 'bun:test'
+
+describe('toClickHouseDocMarkdownUrl', () => {
+  const RAW_BASE =
+    'https://raw.githubusercontent.com/ClickHouse/ClickHouse/refs/heads/master/docs/en/'
+
+  it('converts a plain clickhouse docs URL', () => {
+    const result = toClickHouseDocMarkdownUrl(
+      'https://clickhouse.com/docs/operations/system-tables/disks'
+    )
+    expect(result).toBe(`${RAW_BASE}operations/system-tables/disks.md`)
+  })
+
+  it('converts a URL with /en/ prefix already present', () => {
+    const result = toClickHouseDocMarkdownUrl(
+      'https://clickhouse.com/docs/en/operations/system-tables/replicas'
+    )
+    expect(result).toBe(`${RAW_BASE}operations/system-tables/replicas.md`)
+  })
+
+  it('strips trailing slash before converting', () => {
+    const result = toClickHouseDocMarkdownUrl(
+      'https://clickhouse.com/docs/operations/system-tables/query_log/'
+    )
+    expect(result).toBe(`${RAW_BASE}operations/system-tables/query_log.md`)
+  })
+
+  it('strips fragment anchors', () => {
+    const result = toClickHouseDocMarkdownUrl(
+      'https://clickhouse.com/docs/operations/settings/merge-tree-settings#parts-to-delay-insert'
+    )
+    expect(result).toBe(`${RAW_BASE}operations/settings/merge-tree-settings.md`)
+  })
+
+  it('returns null for non-clickhouse-docs URLs', () => {
+    expect(
+      toClickHouseDocMarkdownUrl('https://example.com/docs/something')
+    ).toBeNull()
+  })
+
+  it('returns null for a partial match (not a docs URL)', () => {
+    expect(
+      toClickHouseDocMarkdownUrl('https://clickhouse.com/blog/some-post')
+    ).toBeNull()
+  })
+
+  it('returns null for an empty path after the docs prefix', () => {
+    expect(
+      toClickHouseDocMarkdownUrl('https://clickhouse.com/docs/')
+    ).toBeNull()
+  })
+
+  it('converts a deeply nested path', () => {
+    const result = toClickHouseDocMarkdownUrl(
+      'https://clickhouse.com/docs/engines/table-engines/mergetree-family/replication'
+    )
+    expect(result).toBe(
+      `${RAW_BASE}engines/table-engines/mergetree-family/replication.md`
+    )
+  })
+
+  it('converts a URL with settings and anchor', () => {
+    const result = toClickHouseDocMarkdownUrl(
+      'https://clickhouse.com/docs/operations/settings/query-complexity#max_memory_usage'
+    )
+    expect(result).toBe(`${RAW_BASE}operations/settings/query-complexity.md`)
+  })
+})

--- a/apps/web/lib/docs/clickhouse-doc-md-url.ts
+++ b/apps/web/lib/docs/clickhouse-doc-md-url.ts
@@ -1,0 +1,52 @@
+/**
+ * Converts ClickHouse HTML documentation URLs to their raw GitHub Markdown equivalents.
+ *
+ * Example:
+ *   https://clickhouse.com/docs/operations/system-tables/disks
+ *   -> https://raw.githubusercontent.com/ClickHouse/ClickHouse/refs/heads/master/docs/en/operations/system-tables/disks.md
+ *
+ * The `/en/` segment and `.md` suffix are injected automatically.
+ * Trailing slashes in the input path are stripped before conversion.
+ *
+ * Returns null for URLs that are not ClickHouse documentation links.
+ */
+
+const CLICKHOUSE_DOCS_ORIGIN = 'https://clickhouse.com/docs/'
+const RAW_GITHUB_BASE =
+  'https://raw.githubusercontent.com/ClickHouse/ClickHouse/refs/heads/master/docs/en/'
+
+/**
+ * Converts a clickhouse.com/docs/<path> URL to its raw GitHub markdown URL.
+ *
+ * @param htmlUrl - The clickhouse.com docs HTML URL (with or without trailing slash,
+ *                  with or without anchor fragments, with or without /en/ prefix).
+ * @returns The raw GitHub markdown URL, or null if the input is not a ClickHouse docs URL.
+ */
+export function toClickHouseDocMarkdownUrl(htmlUrl: string): string | null {
+  if (!htmlUrl.startsWith(CLICKHOUSE_DOCS_ORIGIN)) {
+    return null
+  }
+
+  // Strip the base prefix to get the relative path (may include /en/ already).
+  let relativePath = htmlUrl.slice(CLICKHOUSE_DOCS_ORIGIN.length)
+
+  // Strip fragment (#anchor) — not meaningful for raw file fetches.
+  const fragmentIndex = relativePath.indexOf('#')
+  if (fragmentIndex !== -1) {
+    relativePath = relativePath.slice(0, fragmentIndex)
+  }
+
+  // Strip trailing slashes.
+  relativePath = relativePath.replace(/\/+$/, '')
+
+  // Strip a leading /en/ or en/ prefix if already present to avoid doubling it.
+  if (relativePath.startsWith('en/')) {
+    relativePath = relativePath.slice(3)
+  }
+
+  if (!relativePath) {
+    return null
+  }
+
+  return `${RAW_GITHUB_BASE}${relativePath}.md`
+}

--- a/apps/web/lib/health/audit-prompt.test.ts
+++ b/apps/web/lib/health/audit-prompt.test.ts
@@ -1,0 +1,92 @@
+import type { HealthCheckDef } from '@/components/health/health-checks'
+
+import {
+  type AuditPromptInput,
+  buildAuditPrompt,
+  estimateTokens,
+} from './audit-prompt'
+import { describe, expect, it } from 'bun:test'
+
+const check: HealthCheckDef = {
+  id: 'demo',
+  title: 'Demo Check',
+  chartName: 'demo-chart',
+  valueKey: 'demo_value',
+  defaults: { warning: 1, critical: 3 },
+  description: 'A demo check.',
+  systemTables: ['system.replicas'],
+  commonCauses: ['Cause one'],
+  relatedLinks: [{ label: 'Replicas', href: '/replicas' }],
+  docsLinks: [
+    {
+      label: 'system.replicas',
+      url: 'https://clickhouse.com/docs/en/operations/system-tables/replicas',
+    },
+  ],
+  sql: 'SELECT count() AS readonly_count\nFROM system.replicas\nWHERE is_readonly = 1',
+}
+
+const input: AuditPromptInput = {
+  check,
+  value: 2,
+  thresholds: { warning: 1, critical: 3 },
+  status: 'warning',
+  row: { readonly_count: 2 },
+  hostId: 0,
+}
+
+describe('buildAuditPrompt', () => {
+  it('includes every optional section by default', () => {
+    const prompt = buildAuditPrompt(input)
+    expect(prompt).toContain('## Metric query')
+    expect(prompt).toContain('```sql')
+    expect(prompt).toContain('## Raw data row')
+    expect(prompt).toContain('## Relevant ClickHouse system tables')
+    expect(prompt).toContain('## Common causes to consider')
+    expect(prompt).toContain('## Related dashboards')
+    expect(prompt).toContain('## Documentation')
+  })
+
+  it('omits a section when its toggle is off', () => {
+    const prompt = buildAuditPrompt(input, { sql: false, rawData: false })
+    expect(prompt).not.toContain('## Metric query')
+    expect(prompt).not.toContain('## Raw data row')
+    // Untouched sections remain.
+    expect(prompt).toContain('## Common causes to consider')
+  })
+
+  it('appends raw-markdown doc URLs when docsMarkdown is on', () => {
+    const prompt = buildAuditPrompt(input, { docsMarkdown: true })
+    expect(prompt).toContain('raw markdown: https://raw.githubusercontent.com/')
+    expect(prompt).toContain('operations/system-tables/replicas.md')
+  })
+
+  it('omits raw-markdown doc URLs when docsMarkdown is off', () => {
+    const prompt = buildAuditPrompt(input, { docsMarkdown: false })
+    expect(prompt).not.toContain('raw markdown:')
+    // The HTML doc link itself is still present.
+    expect(prompt).toContain('## Documentation')
+  })
+
+  it('always keeps the core observation and requested-output sections', () => {
+    const prompt = buildAuditPrompt(input, {
+      sql: false,
+      rawData: false,
+      systemTables: false,
+      commonCauses: false,
+      relatedLinks: false,
+      docsLinks: false,
+    })
+    expect(prompt).toContain('## Observation')
+    expect(prompt).toContain('## Requested output')
+  })
+})
+
+describe('estimateTokens', () => {
+  it('approximates ~4 chars per token', () => {
+    expect(estimateTokens('')).toBe(0)
+    expect(estimateTokens('abcd')).toBe(1)
+    expect(estimateTokens('abcdefgh')).toBe(2)
+    expect(estimateTokens('abcde')).toBe(2) // rounds up
+  })
+})

--- a/apps/web/lib/health/audit-prompt.ts
+++ b/apps/web/lib/health/audit-prompt.ts
@@ -4,6 +4,8 @@ import type {
   RelatedLink,
 } from '@/components/health/health-checks'
 
+import { toClickHouseDocMarkdownUrl } from '@/lib/docs/clickhouse-doc-md-url'
+
 export interface AuditPromptInput {
   check: HealthCheckDef
   /** Current numeric value of the check (or null if unavailable). */
@@ -18,6 +20,42 @@ export interface AuditPromptInput {
   hostId: number
   /** Optional ClickHouse version, when known. */
   clickhouseVersion?: string
+}
+
+/**
+ * Toggles for which optional sections to include in the generated prompt.
+ * Header / Observation / Requested output are always present. Every optional
+ * section defaults to `true`.
+ */
+export interface AuditPromptOptions {
+  sql?: boolean
+  rawData?: boolean
+  systemTables?: boolean
+  commonCauses?: boolean
+  relatedLinks?: boolean
+  docsLinks?: boolean
+  /** When docsLinks is on, also emit raw-GitHub `.md` URLs an agent can fetch. */
+  docsMarkdown?: boolean
+}
+
+/** All optional sections enabled — the default prompt shape. */
+export const DEFAULT_AUDIT_PROMPT_OPTIONS: Required<AuditPromptOptions> = {
+  sql: true,
+  rawData: true,
+  systemTables: true,
+  commonCauses: true,
+  relatedLinks: true,
+  docsLinks: true,
+  docsMarkdown: true,
+}
+
+/**
+ * Rough token estimate for the generated prompt. Uses the common ~4-chars-per-token
+ * heuristic; exact tokenization varies per model but this is good enough to show
+ * the relative cost impact of toggling sections.
+ */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4)
 }
 
 const bullet = (lines: readonly string[]) =>
@@ -35,8 +73,15 @@ const formatLinks = (
     )
     .join('\n')
 
-const formatDocs = (links: readonly DocsLink[]) =>
-  links.map((l) => `- [${l.label}](${l.url})`).join('\n')
+const formatDocs = (links: readonly DocsLink[], withMarkdown: boolean) =>
+  links
+    .map((l) => {
+      const mdUrl = withMarkdown ? toClickHouseDocMarkdownUrl(l.url) : null
+      return mdUrl
+        ? `- [${l.label}](${l.url}) — raw markdown: ${mdUrl}`
+        : `- [${l.label}](${l.url})`
+    })
+    .join('\n')
 
 const formatRow = (row?: Record<string, unknown>) => {
   if (!row) return '_(no row data)_'
@@ -47,9 +92,13 @@ const formatRow = (row?: Record<string, unknown>) => {
     .join('\n')
 }
 
-export function buildAuditPrompt(input: AuditPromptInput): string {
+export function buildAuditPrompt(
+  input: AuditPromptInput,
+  options?: AuditPromptOptions
+): string {
   const { check, value, thresholds, status, row, hostId, clickhouseVersion } =
     input
+  const opts = { ...DEFAULT_AUDIT_PROMPT_OPTIONS, ...options }
 
   const appBase =
     typeof window !== 'undefined'
@@ -93,11 +142,26 @@ export function buildAuditPrompt(input: AuditPromptInput): string {
     sections.push('## Description', '', check.description, '')
   }
 
-  if (row && Object.keys(row).length > 0) {
+  if (opts.sql && check.sql) {
+    sections.push(
+      '## Metric query (how this value is computed)',
+      '',
+      '```sql',
+      check.sql,
+      '```',
+      ''
+    )
+  }
+
+  if (opts.rawData && row && Object.keys(row).length > 0) {
     sections.push('## Raw data row', '', formatRow(row), '')
   }
 
-  if (check.systemTables && check.systemTables.length > 0) {
+  if (
+    opts.systemTables &&
+    check.systemTables &&
+    check.systemTables.length > 0
+  ) {
     sections.push(
       '## Relevant ClickHouse system tables',
       '',
@@ -106,7 +170,11 @@ export function buildAuditPrompt(input: AuditPromptInput): string {
     )
   }
 
-  if (check.commonCauses && check.commonCauses.length > 0) {
+  if (
+    opts.commonCauses &&
+    check.commonCauses &&
+    check.commonCauses.length > 0
+  ) {
     sections.push(
       '## Common causes to consider',
       '',
@@ -115,7 +183,11 @@ export function buildAuditPrompt(input: AuditPromptInput): string {
     )
   }
 
-  if (check.relatedLinks && check.relatedLinks.length > 0) {
+  if (
+    opts.relatedLinks &&
+    check.relatedLinks &&
+    check.relatedLinks.length > 0
+  ) {
     sections.push(
       '## Related dashboards (this monitor)',
       '',
@@ -124,8 +196,13 @@ export function buildAuditPrompt(input: AuditPromptInput): string {
     )
   }
 
-  if (check.docsLinks && check.docsLinks.length > 0) {
-    sections.push('## Documentation', '', formatDocs(check.docsLinks), '')
+  if (opts.docsLinks && check.docsLinks && check.docsLinks.length > 0) {
+    sections.push(
+      '## Documentation',
+      '',
+      formatDocs(check.docsLinks, opts.docsMarkdown),
+      ''
+    )
   }
 
   sections.push(


### PR DESCRIPTION
## Summary

Completes the remaining health-audit work (the part that previously stalled). Builds on the health UI that landed in #1241.

### What's new
1. **SQL in the detail dialog** — each `HealthCheckDef` gains a display-only `sql` field (copied verbatim from its backing chart query in `system-charts.ts`), rendered as a *SQL query* section so users see exactly how each metric is computed.
2. **`toClickHouseDocMarkdownUrl()` util (+9 tests)** — maps `clickhouse.com/docs/...` HTML URLs to raw-GitHub `.md` URLs that an AI agent can actually fetch.
3. **Audit-prompt toggles** — `buildAuditPrompt()` now accepts `AuditPromptOptions` to include/exclude optional sections, embeds the metric SQL, and (when enabled) appends raw-markdown doc URLs. The audit-prompt dialog renders per-section toggles (only for sections the check populates).
4. **Live token count** — the dialog shows a `~N tokens · M chars` estimate that updates as you toggle sections, so users can trim the prompt to control cost.

### Design notes
- The `sql` field is duplicated (not imported from the chart registry) on purpose: `health-checks.ts` is leaf client config and importing the api-layer chart registry would cross a layering boundary `depcruise` enforces. Same tradeoff the existing `systemTables`/`commonCauses` fields already make. A comment documents the sync requirement.

### Verification
- ✅ `bun test` — 15 pass (9 doc-url + 6 audit-prompt)
- ✅ `bun run depcruise` — no violations
- ✅ `bun run type-check` — clean
- ✅ `bun run lint` — clean on touched files

Co-Authored-By: duyetbot <bot@duyet.net>