### PR TITLE
perf(ci): validate-docker reuses prebuilt amd64 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,15 +263,62 @@ jobs:
             docker buildx imagetools create -t "$TAG" "$AMD64" "$ARM64"
           done
 
-  # Validate only on main/release
+  # Validate only on main/release.
+  # Reuse the image build-docker-amd64 already built & pushed instead of
+  # rebuilding from scratch — tests the exact artifact that ships, and removes
+  # a full redundant image build (~5-10 min) from every main/release run.
   validate-docker:
     name: validate-docker
     if: github.event_name != 'pull_request'
     needs: [build-docker-amd64]
-    uses: ./.github/workflows/base.yml
-    with:
-      job-type: docker
-      clickhouse-versions: '["24.5"]'
-      platforms: linux/amd64
-      load-image: true
-      test-container: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read
+
+    services:
+      clickhouse:
+        image: ghcr.io/duyet/docker-images:clickhouse_24.5
+        ports:
+          - 8123:8123
+          - 9000:9000
+        options: >-
+          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:8123/?query=SELECT%201 || exit 1"
+          --health-interval 30s
+          --health-timeout 10s
+          --health-retries 5
+          --health-start-period 30s
+          --env CLICKHOUSE_SKIP_USER_SETUP=1
+
+    steps:
+      - name: Login to Container registry
+        uses: docker/login-action@db14339dbc0a1f0b184157be94b23a2138122354
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull prebuilt AMD64 image
+        run: docker pull "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}-amd64"
+
+      - name: Test container
+        env:
+          TAG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}-amd64
+        run: |
+          docker run -d \
+            --name test-app \
+            --network host \
+            -e CLICKHOUSE_HOST=http://localhost:8123 \
+            -e CLICKHOUSE_USER=default \
+            -e CLICKHOUSE_PASSWORD="" \
+            -e PORT=3000 \
+            "$TAG"
+
+          # Wait for container health
+          timeout 60 bash -c 'until curl -sSf http://localhost:3000/ > /dev/null 2>&1; do sleep 2; done'
+
+          # Health checks
+          curl -sSf http://localhost:3000/ | grep -q "ClickHouse Monitoring"
+          curl -sSf http://localhost:3000/api/healthz | grep -q "ok"
+          curl -sSf http://localhost:3000/api/version | grep -q "version"


### PR DESCRIPTION
## Problem

`validate-docker` (runs on main/release in `ci.yml`) called the reusable `base.yml` with `push-image: false`, which **rebuilds the entire Docker image from scratch** just to smoke-test the container. Worse, its cache scope was `docker-` (empty suffix), which doesn't match `build-docker-amd64`'s `docker--amd64` scope — so it didn't even share build cache. Net: a full redundant ~5-10 min app+image build on every main/release run.

## Fix

Replace it with a standalone job that:
1. `docker pull`s the image `build-docker-amd64` **already built and pushed** (`sha-<sha>-amd64`).
2. Runs the identical container health checks (`/`, `/api/healthz`, `/api/version`) against a ClickHouse service.

### Why this is better
- **Faster + cheaper**: removes a whole image build from the critical path.
- **More correct**: tests the *exact artifact that ships*, not a separately-rebuilt one.
- **Least privilege**: job permissions tightened to `packages: read`.

The container-test steps and ClickHouse service are copied verbatim from `base.yml`, and the registry login from `build-docker-arm64` — no new patterns introduced.

Part of an ongoing CI speed/cost effort (see also the component-test hang fix).

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Optimize the validate-docker CI job to reuse the prebuilt amd64 image instead of rebuilding it on main and release branches.

CI:
- Replace the reusable base workflow invocation for validate-docker with an inline job that pulls the already-built amd64 image and runs container health checks against a ClickHouse service.
- Tighten validate-docker job permissions to read-only for contents and packages while maintaining existing container smoke tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline with improved Docker image validation
  * Added automated health checks for critical application endpoints
  * Optimized CI workflow efficiency
  * Strengthened security permissions configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->