### PR TITLE
fix(charts): stabilize scroll while lazy charts render

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -13,9 +13,24 @@
   }
   html {
     @apply h-full;
+    /* Reserve the scrollbar track so content width never shifts when a chart
+       grows the page past one viewport — a subtle but real source of horizontal
+       jump while charts stream in. */
+    scrollbar-gutter: stable;
   }
   body {
     @apply min-h-full bg-background text-foreground;
+  }
+}
+
+@layer utilities {
+  /* Opt an element out of the browser's scroll-anchoring heuristic. Used on
+     lazily-mounted chart slots so inserting a chart above the viewport during a
+     fast scroll-to-bottom doesn't yank the scroll position around ("flaking").
+     Pairs with reserved slot heights so there is no shift to anchor against. */
+  .overflow-anchor-none {
+    overflow-anchor: none;
+    content-visibility: auto;
   }
 }
 

--- a/apps/web/components/charts/lazy-chart-wrapper.tsx
+++ b/apps/web/components/charts/lazy-chart-wrapper.tsx
@@ -2,11 +2,19 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { Skeleton } from '@/components/ui/skeleton'
+import { cn } from '@/lib/utils'
 
 interface LazyChartWrapperProps {
   children: React.ReactNode
   className?: string
   rootMargin?: string
+  /**
+   * Reserved height for the slot before the chart loads. Keeps the placeholder
+   * from collapsing to 0px on pages without a fixed-height grid, which is what
+   * causes every IntersectionObserver to fire at once and the page to jump while
+   * scrolling. Accepts any CSS length. Defaults to a single grid-cell height.
+   */
+  minHeight?: number | string
 }
 
 /**
@@ -15,13 +23,20 @@ interface LazyChartWrapperProps {
  * Uses IntersectionObserver to detect when the placeholder enters the viewport.
  * Once visible, renders the chart and disconnects the observer (one-shot).
  *
- * rootMargin='200px' starts loading 200px before the chart becomes visible,
- * giving the data fetch time to complete before the user reaches the chart.
+ * rootMargin='400px' starts loading well before the chart becomes visible so the
+ * data fetch finishes before the user reaches it — this is what keeps a fast
+ * scroll-to-bottom smooth instead of swapping skeletons inside the viewport.
+ *
+ * Scroll stability: the slot reserves its height up front (`minHeight` +
+ * `contain-intrinsic-size`) and opts out of browser scroll anchoring
+ * (`overflow-anchor: none`). Together these stop the layout shift / scroll-jump
+ * "flaking" that happened when charts mounted above the viewport during a scroll.
  */
 export const LazyChartWrapper = function LazyChartWrapper({
   children,
   className,
-  rootMargin = '200px',
+  rootMargin = '400px 0px',
+  minHeight = 280,
 }: LazyChartWrapperProps) {
   const ref = useRef<HTMLDivElement>(null)
   const [isVisible, setIsVisible] = useState(false)
@@ -45,8 +60,20 @@ export const LazyChartWrapper = function LazyChartWrapper({
     return () => observer.disconnect()
   }, [rootMargin, isVisible])
 
+  const minHeightValue =
+    typeof minHeight === 'number' ? `${minHeight}px` : minHeight
+
   return (
-    <div ref={ref} className={className}>
+    <div
+      ref={ref}
+      className={cn('overflow-anchor-none', className)}
+      style={{
+        // Reserve height so the slot never collapses, even outside a
+        // fixed-height grid, and so off-screen slots can skip rendering work.
+        minHeight: isVisible ? undefined : minHeightValue,
+        containIntrinsicSize: isVisible ? undefined : `auto ${minHeightValue}`,
+      }}
+    >
       {isVisible ? children : <Skeleton className="h-full w-full rounded-xl" />}
     </div>
   )


### PR DESCRIPTION
## Problem

Scrolling to the bottom of a page while charts were still mounting was **flaking** — the scroll position got yanked around and sometimes wouldn't reach the bottom.

Two root causes:
1. Lazy chart slots (`LazyChartWrapper`) collapsed to `0px` until they became visible. Outside the overview's fixed-height grid (e.g. dashboard, insights, related charts) this meant the whole page was short, so **every `IntersectionObserver` fired at once** and the page grew abruptly under the scroll.
2. Charts inserted **above the viewport** during a fast scroll fought the browser's **scroll anchoring**, shifting the scroll offset.

## Changes

- **`LazyChartWrapper`**
  - Reserves slot height up front via `minHeight` + `contain-intrinsic-size`, so a slot never collapses regardless of parent layout. Inside the overview grid the fixed `auto-rows-*` track still wins, so this is purely a floor.
  - Loads earlier (`rootMargin` `200px` → `400px`) so the fetch finishes before the slot enters the viewport — fewer in-view skeleton swaps during scroll.
  - Opts the slot out of scroll anchoring.
- **`globals.css`**
  - `scrollbar-gutter: stable` on `html` to stop horizontal width jump when content grows past one viewport.
  - New `.overflow-anchor-none` utility (`overflow-anchor: none` + `content-visibility: auto`) — the `content-visibility` also lets off-screen chart slots skip rendering work (perf win on dense tabs).

## Verification

- `tsc --noEmit` clean
- Biome lint clean
- Backward-compatible: all three `LazyChartWrapper` call sites (overview, dashboard, insights) keep working; new props are optional with sensible defaults.

Part of the chart/table rendering improvement series.

https://claude.ai/code/session_01FnfaAX3JryuTkbH3noaQKC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnfaAX3JryuTkbH3noaQKC)_

## Summary by Sourcery

Stabilize scroll behavior while lazy-loaded charts render by reserving slot height, adjusting load timing, and reducing scroll anchoring side effects.

Enhancements:
- Update LazyChartWrapper to reserve a minimum height before charts load, adjust the IntersectionObserver margin, and apply scroll-anchoring safeguards for smoother scrolling.
- Introduce a reusable CSS utility class to opt elements out of scroll anchoring and enable off-screen rendering optimizations.
- Apply a stable scrollbar gutter on the html element to prevent horizontal layout shifts as content height grows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll stability and reduced visual jumping when dynamic content loads.
  * Prevented horizontal layout shifts caused by scrollbar appearance during viewport interactions.
  * Enhanced asynchronous content loading with improved placeholder management to minimize scroll disruption.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->