### PR TITLE
feat(tables): expandable "more info" rows for config tables

### DIFF
--- a/apps/web/components/data-table/cells/config-expanded-details.tsx
+++ b/apps/web/components/data-table/cells/config-expanded-details.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { InfoIcon } from 'lucide-react'
+
+import type { ExpandedRenderer } from '@/types/query-config'
+
+/**
+ * Generic expanded-row renderer for "config"-style tables (system.settings,
+ * system.merge_tree_settings, system.users, …). These tables fetch many more
+ * columns than the table comfortably shows; this panel surfaces the rest as a
+ * readable key/value grid plus the full (untruncated) description on top.
+ *
+ * Use {@link createConfigExpandedDetails} from a QueryConfig:
+ *
+ *   expandable: {
+ *     renderExpanded: createConfigExpandedDetails({
+ *       primaryColumns: SETTINGS_COLUMNS,
+ *     }),
+ *   }
+ */
+
+interface CreateConfigExpandedDetailsOptions {
+  /**
+   * Columns already shown in the table. They are skipped in the grid so the
+   * panel only adds *new* information instead of repeating the row.
+   */
+  primaryColumns?: readonly string[]
+  /** Key holding a long description to render as prose. Default: `description`. */
+  descriptionKey?: string
+}
+
+function hasValue(value: unknown): boolean {
+  return value !== undefined && value !== null && String(value).trim() !== ''
+}
+
+/** snake_case / camelCase → "Title Case" for human-readable field labels. */
+function humanizeKey(key: string): string {
+  return key
+    .replace(/_/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim()
+}
+
+function formatValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.length === 0 ? '—' : value.map((v) => String(v)).join(', ')
+  }
+  if (value !== null && typeof value === 'object') {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+  return String(value)
+}
+
+function DetailField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 rounded-md border border-border/60 bg-background/60 px-3 py-2">
+      <div className="truncate text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </div>
+      <div
+        className="mt-1 min-w-0 truncate font-mono text-sm tabular-nums text-foreground"
+        title={value}
+      >
+        {value}
+      </div>
+    </div>
+  )
+}
+
+interface ConfigExpandedDetailsProps
+  extends CreateConfigExpandedDetailsOptions {
+  row: Record<string, unknown>
+}
+
+export function ConfigExpandedDetails({
+  row,
+  primaryColumns = [],
+  descriptionKey = 'description',
+}: ConfigExpandedDetailsProps) {
+  const description = row[descriptionKey]
+  const skip = new Set<string>([...primaryColumns, descriptionKey])
+
+  const entries = Object.entries(row).filter(
+    ([key, value]) => !skip.has(key) && hasValue(value)
+  )
+
+  if (!hasValue(description) && entries.length === 0) {
+    return (
+      <div className="border-t border-border/60 bg-muted/20 p-4 text-xs text-muted-foreground">
+        No additional details.
+      </div>
+    )
+  }
+
+  return (
+    <div
+      data-slot="config-expanded"
+      className="space-y-3 border-t border-border/60 bg-muted/20 p-4"
+    >
+      {hasValue(description) && (
+        <div className="flex gap-2 text-sm leading-relaxed text-muted-foreground">
+          <InfoIcon className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+          <p className="min-w-0">{formatValue(description)}</p>
+        </div>
+      )}
+
+      {entries.length > 0 && (
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {entries.map(([key, value]) => (
+            <DetailField
+              key={key}
+              label={humanizeKey(key)}
+              value={formatValue(value)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Factory returning an {@link ExpandedRenderer} bound to a set of options.
+ * Lives in this `.tsx` module so plain `.ts` query-config files can opt into
+ * row expansion without importing JSX themselves.
+ */
+export function createConfigExpandedDetails(
+  options: CreateConfigExpandedDetailsOptions = {}
+): ExpandedRenderer {
+  return (row) => (
+    <ConfigExpandedDetails row={row as Record<string, unknown>} {...options} />
+  )
+}

--- a/apps/web/components/data-table/cells/config-expanded-details.tsx
+++ b/apps/web/components/data-table/cells/config-expanded-details.tsx
@@ -1,4 +1,9 @@
-'use client'
+// NOTE: intentionally NOT a 'use client' module. This component is purely
+// presentational (no hooks, state, or event handlers), so it is a shared
+// component that renders on either side of the boundary. Crucially, that lets
+// `createConfigExpandedDetails()` be CALLED from server modules (the query-config
+// registry is imported by API routes); a 'use client' module's exports become
+// client references that throw when invoked on the server.
 
 import { InfoIcon } from 'lucide-react'
 

--- a/apps/web/lib/query-config/more/settings.ts
+++ b/apps/web/lib/query-config/more/settings.ts
@@ -1,6 +1,9 @@
 import type { QueryConfig } from '@/types/query-config'
 
+import { createConfigExpandedDetails } from '@/components/data-table/cells/config-expanded-details'
 import { ColumnFormat } from '@/types/column-format'
+
+const SETTINGS_COLUMNS = ['name', 'value', 'changed', 'description', 'default']
 
 export const settingsConfig: QueryConfig = {
   name: 'settings',
@@ -12,7 +15,14 @@ export const settingsConfig: QueryConfig = {
       WHERE if({changed: String} != '', changed = {changed: String}, true)
       ORDER BY name
   `,
-  columns: ['name', 'value', 'changed', 'description', 'default'],
+  columns: SETTINGS_COLUMNS,
+  // Expand a row to reveal the columns system.settings exposes beyond the
+  // table view: type, min, max, readonly, tier, is_obsolete, alias_for, …
+  expandable: {
+    renderExpanded: createConfigExpandedDetails({
+      primaryColumns: SETTINGS_COLUMNS,
+    }),
+  },
   columnFormats: {
     name: ColumnFormat.Code,
     changed: ColumnFormat.Boolean,

--- a/apps/web/lib/query-config/more/users.ts
+++ b/apps/web/lib/query-config/more/users.ts
@@ -1,5 +1,20 @@
 import type { QueryConfig } from '@/types/query-config'
 
+import { createConfigExpandedDetails } from '@/components/data-table/cells/config-expanded-details'
+
+const USERS_COLUMNS = [
+  'name',
+  'storage',
+  'auth_type',
+  'auth_params',
+  'host_ip',
+  'host_names',
+  'default_roles_all',
+  'default_roles_list',
+  'default_roles_except',
+  'default_database',
+]
+
 export const usersConfig: QueryConfig = {
   name: 'users',
   description: 'Users account',
@@ -9,17 +24,13 @@ export const usersConfig: QueryConfig = {
       FROM system.users
       ORDER BY name
     `,
-  columns: [
-    'name',
-    'storage',
-    'auth_type',
-    'auth_params',
-    'host_ip',
-    'host_names',
-    'default_roles_all',
-    'default_roles_list',
-    'default_roles_except',
-    'default_database',
-  ],
+  columns: USERS_COLUMNS,
   columnFormats: {},
+  // Expand a row to reveal the host/grantee/role-restriction columns that
+  // system.users exposes beyond the table view (grantees_*, host_regexp, …).
+  expandable: {
+    renderExpanded: createConfigExpandedDetails({
+      primaryColumns: USERS_COLUMNS,
+    }),
+  },
 }


### PR DESCRIPTION
## Problem

The config tables (`system.settings`, `system.users`, …) fetch far more columns than they display. Useful metadata — value type, min/max bounds, readonly/tier flags, grantee restrictions — is fetched but thrown away, and long descriptions are truncated in the table cell.

## Changes

- **New reusable renderer** `components/data-table/cells/config-expanded-details.tsx`
  - `ConfigExpandedDetails` renders the full description as prose plus every *extra* row field (those not already shown as a column) in a labeled key/value grid, with snake_case → Title Case labels and array/object-safe formatting.
  - `createConfigExpandedDetails({ primaryColumns })` factory returns an `ExpandedRenderer`, so plain `.ts` query-config files opt into row expansion without importing JSX.
- **Wired onto two config tables** (reusing the existing `expandable` row-expansion infra — chevron toggle + full-width detail panel):
  - `settings` → reveals `type`, `min`, `max`, `readonly`, `tier`, `is_obsolete`, `alias_for`
  - `users` → reveals the host/grantee/role-restriction columns from `SELECT *`

No SQL changes — the data was already being fetched. Tables without extra columns are unaffected.

## Verification

- `tsc --noEmit` clean
- Biome clean
- Uses the same row-expansion mechanism already proven by `running-queries` and `keeper-connections`.

Part of the chart/table rendering improvement series.

https://claude.ai/code/session_01FnfaAX3JryuTkbH3noaQKC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnfaAX3JryuTkbH3noaQKC)_

## Summary by Sourcery

Add reusable expanded-row details renderer for configuration-style tables and wire it into the settings and users tables to expose additional metadata beyond visible columns.

New Features:
- Introduce a generic ConfigExpandedDetails component that displays full descriptions and extra row fields for configuration tables in an expanded panel.
- Enable expandable rows on the system.settings table to surface hidden metadata fields not shown in the main columns.
- Enable expandable rows on the system.users table to reveal additional host and role restriction columns beyond the primary view.