### PR TITLE
feat(tables): card view for low-cardinality tables

### DIFF
--- a/apps/web/components/data-table/components/data-table-content.tsx
+++ b/apps/web/components/data-table/components/data-table-content.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { LayoutGrid, Table2 } from 'lucide-react'
 import type { ColumnDef, RowData } from '@tanstack/react-table'
 
 import type { ExpandableConfig, QueryConfig } from '@/types/query-config'
@@ -24,8 +25,49 @@ import {
   TableBody as TableBodyRenderer,
   TableHeader as TableHeaderRenderer,
 } from '@/components/data-table/renderers'
+import { Button } from '@/components/ui/button'
 import { Table, TableBody, TableHeader } from '@/components/ui/table'
 import { cn } from '@/lib/utils'
+
+/** Segmented table/cards toggle shown above the content when offered. */
+function ViewToggle({
+  view,
+  onViewChange,
+}: {
+  view: 'table' | 'cards'
+  onViewChange?: (view: 'table' | 'cards') => void
+}) {
+  return (
+    <div
+      className="inline-flex items-center gap-0.5 rounded-md border border-border/60 p-0.5"
+      role="group"
+      aria-label="Result view"
+    >
+      <Button
+        type="button"
+        variant={view === 'table' ? 'secondary' : 'ghost'}
+        size="sm"
+        className="h-7 gap-1.5 px-2 text-xs"
+        aria-pressed={view === 'table'}
+        onClick={() => onViewChange?.('table')}
+      >
+        <Table2 className="size-3.5" />
+        Table
+      </Button>
+      <Button
+        type="button"
+        variant={view === 'cards' ? 'secondary' : 'ghost'}
+        size="sm"
+        className="h-7 gap-1.5 px-2 text-xs"
+        aria-pressed={view === 'cards'}
+        onClick={() => onViewChange?.('cards')}
+      >
+        <LayoutGrid className="size-3.5" />
+        Cards
+      </Button>
+    </div>
+  )
+}
 
 /**
  * Props for the DataTableContent component
@@ -80,6 +122,12 @@ export interface DataTableContentProps<
   compact?: boolean
   /** When set, rows render an expand chevron and clicking a row toggles a detail panel below it. */
   expandable?: true | ExpandableConfig
+  /** Active view. `'cards'` renders the card layout at all breakpoints. */
+  view?: 'table' | 'cards'
+  /** Show the table/cards toggle control above the content. */
+  offerViewToggle?: boolean
+  /** Callback when the user switches view. */
+  onViewChange?: (view: 'table' | 'cards') => void
 }
 
 /**
@@ -117,7 +165,11 @@ export const DataTableContent = memo(function DataTableContent<
   onResetColumnOrder: _onResetColumnOrder,
   compact = false,
   expandable,
+  view = 'table',
+  offerViewToggle = false,
+  onViewChange,
 }: DataTableContentProps<TData, TValue>) {
+  const cardsOnly = view === 'cards'
   // Configure drag-and-drop sensors
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -197,6 +249,11 @@ export const DataTableContent = memo(function DataTableContent<
 
   return (
     <div className="relative">
+      {offerViewToggle && !compact && (
+        <div className="mb-2 flex justify-end">
+          <ViewToggle view={view} onViewChange={onViewChange} />
+        </div>
+      )}
       <div
         ref={tableContainerRef}
         className={cn(
@@ -204,15 +261,17 @@ export const DataTableContent = memo(function DataTableContent<
           isVirtualized ? 'flex-1 overflow-auto' : 'w-full overflow-x-auto',
           {
             'max-h-[50vh]': compact && !isVirtualized,
-            'mb-5 rounded-lg border border-border/50 bg-card/30': !compact,
+            'mb-5 rounded-lg border border-border/50 bg-card/30':
+              !compact && !cardsOnly,
           }
         )}
         role="region"
         aria-label={`${title || 'Data'} table`}
         style={isVirtualized ? { height: '60vh' } : undefined}
       >
+        {/* Card layout: always on mobile, and at all widths when view==='cards'. */}
         {!compact && (
-          <div className="p-3 sm:hidden">
+          <div className={cn('p-3', cardsOnly ? 'block' : 'sm:hidden')}>
             <MobileTableCards
               table={table}
               title={title}
@@ -224,7 +283,9 @@ export const DataTableContent = memo(function DataTableContent<
             />
           </div>
         )}
-        <div className={cn(!compact && 'hidden sm:block')}>
+        <div
+          className={cn(cardsOnly ? 'hidden' : !compact && 'hidden sm:block')}
+        >
           {enableColumnReordering ? (
             <DndContext
               sensors={sensors}

--- a/apps/web/components/data-table/data-table.tsx
+++ b/apps/web/components/data-table/data-table.tsx
@@ -504,6 +504,13 @@ export function DataTable<
     { disabled: Boolean(expandable) }
   )
 
+  // Card vs. table view. Only offered (with a toolbar toggle) when the config
+  // opts in via `defaultView`; otherwise tables behave exactly as before.
+  const offerViewToggle = queryConfig.defaultView !== undefined
+  const [view, setView] = useState<'table' | 'cards'>(
+    queryConfig.defaultView ?? 'table'
+  )
+
   // Auto-fit columns functionality
   const { autoFitColumn } = useAutoFitColumns<TData>(tableContainerRef)
 
@@ -595,6 +602,9 @@ export function DataTable<
           onResetColumnOrder={handleResetColumnOrder}
           compact={compact}
           expandable={expandable}
+          view={view}
+          offerViewToggle={offerViewToggle}
+          onViewChange={setView}
         />
 
         <DataTableFooter table={table} footnote={footnote} compact={compact} />

--- a/apps/web/lib/query-config/system/clusters.ts
+++ b/apps/web/lib/query-config/system/clusters.ts
@@ -23,6 +23,8 @@ export const clustersConfig: QueryConfig = {
     GROUP BY 1
   `,
   columns: ['cluster', 'shard_count', 'replica_count', 'replica_status'],
+  // Few, wide rows (one per cluster) — cards read better than a sparse table.
+  defaultView: 'cards',
   columnFormats: {
     replica_status: [
       ColumnFormat.Link,

--- a/apps/web/lib/query-config/system/disks.ts
+++ b/apps/web/lib/query-config/system/disks.ts
@@ -45,6 +45,9 @@ export const diskSpaceConfig: QueryConfig = {
     'percent_free',
     'keep_free_space',
   ],
+  // Usually only a handful of disks, each with many size columns — cards read
+  // better than a wide table.
+  defaultView: 'cards',
   columnFormats: {
     name: ColumnFormat.ColoredBadge,
   },

--- a/apps/web/types/query-config.ts
+++ b/apps/web/types/query-config.ts
@@ -414,6 +414,15 @@ export interface QueryConfig<TColumns extends readonly string[] = string[]> {
    */
   expandable?: true | ExpandableConfig
   /**
+   * Default rendering for the result set. `'cards'` renders each row as a card
+   * (reusing the responsive card layout) instead of a wide table — better UX
+   * for low-cardinality, wide tables like clusters or disks. When set, a
+   * table/cards toggle is offered in the toolbar so users can switch.
+   *
+   * @default 'table'
+   */
+  defaultView?: 'table' | 'cards'
+  /**
    * Bulk actions available for selected rows (shown in toolbar).
    * These actions apply to all selected rows at once.
    *


### PR DESCRIPTION
## Problem

Some pages always return only a handful of wide rows — `clusters` (one row per cluster), `disks` (a few disks with many size columns). A full-width data table reads poorly there: lots of horizontal scroll, mostly empty space. Cards present the same data far better.

## Changes

- **`QueryConfig.defaultView?: 'table' | 'cards'`** (new, optional).
- **`DataTable` / `DataTableContent`**: when a config opts in, a compact **Table / Cards toggle** is shown above the content. In `'cards'` mode the card layout renders at **all breakpoints**; in `'table'` mode behaviour is unchanged (cards on mobile, table on desktop, as today).
- The card view **reuses the existing `MobileTableCards` renderer**, which drives cells through the live TanStack `flexRender` context — so all cell formatting, links, badges, and row expansion behave identically to the table.
- **Enabled `defaultView: 'cards'`** on `clusters` and `disks`.

Tables without `defaultView` are completely untouched — no toggle, no behavioural change — so existing tables and their tests are unaffected.

## Verification

- Full `next build --webpack` passes (exit 0).
- `tsc --noEmit` clean, Biome clean.
- No new renderer: the proven mobile card component now also powers the desktop card view.

Part of the chart/table rendering improvement series.

https://claude.ai/code/session_01FnfaAX3JryuTkbH3noaQKC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnfaAX3JryuTkbH3noaQKC)_