### PR TITLE
feat(keeper): render /keeper/info with KeeperNodeCards

### DIFF
--- a/apps/web/app/(dashboard)/keeper/info/page.tsx
+++ b/apps/web/app/(dashboard)/keeper/info/page.tsx
@@ -1,12 +1,19 @@
 'use client'
 
 import { Suspense } from 'react'
+import { KeeperNodeCards } from '@/components/keeper/keeper-node-cards'
 import { PageLayout } from '@/components/layout/query-page'
 import { ChartSkeleton } from '@/components/skeletons'
 import { keeperInfoConfig } from '@/lib/query-config/keeper'
 
 function KeeperInfoPageContent() {
-  return <PageLayout queryConfig={keeperInfoConfig} title="Keeper Info" />
+  return (
+    <PageLayout
+      queryConfig={keeperInfoConfig}
+      title="Keeper Info"
+      tableSlot={<KeeperNodeCards />}
+    />
+  )
 }
 
 export default function KeeperInfoPage() {


### PR DESCRIPTION
## Summary

- Reuses the existing `KeeperNodeCards` component (already powering `/keeper/overview`) on the `/keeper/info` page via the `tableSlot` prop on `PageLayout`
- `/keeper/info` now shows the same rich per-node card view (latency, storage, network, raft metrics) instead of a plain data table
- No new data fetching — `KeeperNodeCards` already fetches `keeper-info` internally via `useTableData`

## Change

One-line wiring change in `apps/web/app/(dashboard)/keeper/info/page.tsx`: import `KeeperNodeCards` and pass it as `tableSlot={<KeeperNodeCards />}` to `PageLayout`, mirroring the overview page exactly.

## Test plan

- [ ] Visit `/keeper/info` — should display node cards identical to `/keeper/overview` (no plain table)
- [ ] Visit `/keeper/overview` — should be unaffected
- [ ] CI lint + build pass