### PR TITLE
fix(charts): add missing dictionary-count client chart

### DIFF
--- a/apps/web/components/charts/dictionary-count.tsx
+++ b/apps/web/components/charts/dictionary-count.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { ChartCard } from '@/components/cards/chart-card'
+import { ChartContainer } from '@/components/charts/chart-container'
+import { BarList } from '@/components/charts/primitives/bar-list'
+import { useChartData } from '@/lib/swr'
+
+type DataRow = {
+  status: string
+  count: number
+}
+
+export const ChartDictionaryCount = function ChartDictionaryCount({
+  title,
+  className,
+  hostId,
+}: ChartProps) {
+  const swr = useChartData<DataRow>({
+    chartName: 'dictionary-count',
+    hostId,
+    refreshInterval: 30000,
+  })
+
+  return (
+    <ChartContainer swr={swr} title={title} className={className}>
+      {(rows, sql, metadata) => {
+        const barData = rows.map((row) => ({
+          name: row.status,
+          value: Number(row.count),
+        }))
+
+        return (
+          <ChartCard
+            title={title}
+            className={className}
+            sql={sql}
+            data={rows}
+            metadata={metadata}
+            data-testid="dictionary-count-chart"
+          >
+            <BarList data={barData} />
+          </ChartCard>
+        )
+      }}
+    </ChartContainer>
+  )
+}

--- a/apps/web/components/charts/registry/imports/misc-charts.ts
+++ b/apps/web/components/charts/registry/imports/misc-charts.ts
@@ -64,6 +64,13 @@ export const miscChartImports: ChartRegistryMap = {
     }))
   ),
 
+  // Dictionary Charts
+  'dictionary-count': lazy(() =>
+    import('@/components/charts/dictionary-count').then((m) => ({
+      default: m.ChartDictionaryCount,
+    }))
+  ),
+
   // Page Analytics Charts
   'top-pages': lazy(() =>
     import('@/components/charts/top-pages').then((m) => ({


### PR DESCRIPTION
## Root cause

`dictionary-count` was registered on the **server side** (`lib/api/chart-registry.ts` imports `dictionaryCharts`) so the API endpoint `/api/v1/charts/dictionary-count` works, but the chart name was **absent from the client lazy-import registry** (`components/charts/registry/imports/misc-charts.ts`). When `RelatedCharts` on `/dictionaries` tried to render it, the registry lookup returned undefined and showed "Unknown chart: dictionary-count".

## Fix

- Added `apps/web/components/charts/dictionary-count.tsx` — a `ChartContainer` + `BarList` component (`ChartDictionaryCount`) following the same pattern as `parts-per-table`. It calls `useChartData({ chartName: 'dictionary-count', hostId })` and renders status→count rows as a bar list.
- Registered the lazy import for `'dictionary-count'` in `misc-charts.ts` under a new "Dictionary Charts" section.

No changes to query config or server-side code — only the missing client-side piece was added.

## Test plan

- [ ] Navigate to `/dictionaries` — the `dictionary-count` bar chart renders without "Unknown chart" error
- [ ] Chart shows each dictionary status (e.g. `LOADED`, `FAILED_AND_RELOADING`) with its count
- [ ] Chart handles empty state gracefully (no dictionaries configured)
- [ ] CI lint + build pass