### PR TITLE
fix(data-table): replace pill bars with clean full-height background bars

### DIFF
--- a/apps/web/components/data-table/cells/background-bar-format.tsx
+++ b/apps/web/components/data-table/cells/background-bar-format.tsx
@@ -42,23 +42,23 @@ export const BackgroundBarFormat = function BackgroundBarFormat({
   // Calculate shade based on percentage (larger = darker)
   const shade = getShade(pct as number)
 
-  // Build inline style with dynamic color
-  const barStyle = getBarStyle(baseColor, shade)
+  // Build inline style with dynamic color (lower opacity for a subtle background bar)
+  const barStyle = getBarStyle(baseColor, shade, 0.35)
 
   return (
     <div
-      className="relative flex items-center w-full h-full overflow-hidden rounded-sm"
+      className="relative flex items-center w-full h-full overflow-hidden"
       title={`${orgValue} (${pct}%)`}
       aria-label={`${orgValue} (${pct}%)`}
       aria-roledescription="background-bar"
     >
       {/* Background bar - uses inline styles for dynamic color */}
       <div
-        className="absolute inset-y-0 left-0 rounded-sm transition-[width]"
+        className="absolute inset-y-0 left-0 transition-[width]"
         style={{ width: `${pct}%`, ...barStyle }}
         aria-hidden="true"
       />
-      <span className="relative inline-block min-w-0 truncate">
+      <span className="relative inline-block min-w-0 truncate px-1.5">
         {options?.numberFormat
           ? formatReadableQuantity(value as number, 'long')
           : value}


### PR DESCRIPTION
## Summary

- Removes `rounded-sm` from both the outer wrapper and the filler div in `BackgroundBarFormat`, eliminating the pill/badge visual where the colored fill hugged only the text
- Lowers fill opacity from `0.6` → `0.35` so the background wash is subtle and value text stays fully legible at any percentage
- Adds `px-1.5` to the value `<span>` to give a small breathing gap between the text and the bar edge

The bar now renders as a clean, flat, proportional horizontal band spanning the full cell height — consistent across all tables that use `BackgroundBarFormat` (tables-overview and others).

All existing Cypress selectors (`aria-roledescription="background-bar"`, `title`, `aria-hidden`, inline `width`/`background-color` style) are unchanged, so component tests remain green.

## Test plan

- [ ] Visit `/tables-overview` — bars should appear as clean horizontal background fills, not rounded pill highlights
- [ ] Verify value text is legible over both small (narrow) and large (wide) bars
- [ ] Verify Cypress component tests pass (`bun run test:component:headless`)
- [ ] Spot-check other table pages that use background bars (e.g. merges, queries)