### PR TITLE
fix(explorer): dedup @codemirror/state to fix SQL editor crash

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -249,6 +249,10 @@
   "overrides": {
     "@anthropic-ai/sdk": "0.92.0",
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
+    "@codemirror/autocomplete": "6.20.2",
+    "@codemirror/language": "6.12.3",
+    "@codemirror/state": "6.6.0",
+    "@codemirror/view": "6.43.0",
     "@hono/node-server": "^2.0.0",
     "@protobufjs/utf8": "^1.1.1",
     "ajv": "^8.20.0",
@@ -4625,12 +4629,6 @@
 
     "@clerk/react/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@codemirror/lang-sql/@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A=="],
-
-    "@codemirror/lang-sql/@codemirror/language": ["@codemirror/language@6.12.2", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg=="],
-
-    "@codemirror/lang-sql/@codemirror/state": ["@codemirror/state@6.5.4", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw=="],
-
     "@commitlint/resolve-extends/global-directory": ["global-directory@5.0.0", "", { "dependencies": { "ini": "6.0.0" } }, "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w=="],
 
     "@cypress/code-coverage/@cypress/webpack-preprocessor": ["@cypress/webpack-preprocessor@6.0.4", "", { "dependencies": { "bluebird": "3.7.1", "debug": "^4.3.4", "lodash": "^4.17.20", "semver": "^7.3.2" }, "peerDependencies": { "@babel/core": "^7.25.2", "@babel/preset-env": "^7.25.3", "babel-loader": "^8.3 || ^9 || ^10", "webpack": "^4 || ^5" } }, "sha512-ly+EcabWWbhrSPr2J/njQX7Y3da+QqOmFg8Og/MVmLxhDLKIzr2WhTdgzDYviPTLx/IKsdb41cc2RLYp6mSBRA=="],
@@ -5720,10 +5718,6 @@
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@browserbasehq/sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
-
-    "@codemirror/lang-sql/@codemirror/autocomplete/@codemirror/view": ["@codemirror/view@6.39.16", "", { "dependencies": { "@codemirror/state": "^6.5.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-m6S22fFpKtOWhq8HuhzsI1WzUP/hB9THbDj0Tl5KX4gbO6Y91hwBl7Yky33NdvB6IffuRFiBxf1R8kJMyXmA4Q=="],
-
-    "@codemirror/lang-sql/@codemirror/language/@codemirror/view": ["@codemirror/view@6.39.16", "", { "dependencies": { "@codemirror/state": "^6.5.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-m6S22fFpKtOWhq8HuhzsI1WzUP/hB9THbDj0Tl5KX4gbO6Y91hwBl7Yky33NdvB6IffuRFiBxf1R8kJMyXmA4Q=="],
 
     "@commitlint/resolve-extends/global-directory/ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
 

--- a/package.json
+++ b/package.json
@@ -89,6 +89,10 @@
   },
   "pnpm": {
     "overrides": {
+      "@codemirror/state": "6.6.0",
+      "@codemirror/view": "6.43.0",
+      "@codemirror/language": "6.12.3",
+      "@codemirror/autocomplete": "6.20.2",
       "ajv": "^8.20.0",
       "axios": "^1.16.0",
       "brace-expansion": "^5.0.6",
@@ -117,6 +121,10 @@
     }
   },
   "overrides": {
+    "@codemirror/state": "6.6.0",
+    "@codemirror/view": "6.43.0",
+    "@codemirror/language": "6.12.3",
+    "@codemirror/autocomplete": "6.20.2",
     "@anthropic-ai/sdk": "0.92.0",
     "@types/react": "$@types/react",
     "@types/react-dom": "$@types/react-dom",


### PR DESCRIPTION
## Problem
The explorer query tab (e.g. `/explorer?...&tab=query`) crashes with:

> Unrecognized extension value in extension set ([object Object]). This sometimes happens because multiple instances of @codemirror/state are loaded, breaking instanceof checks.

## Root cause
`@codemirror/lang-sql` declares `@codemirror/state: "^6.0.0"`, which bun resolved to a **nested `6.5.4`**, while the app's direct dependency resolved to **`6.6.0`**. CodeMirror's extension/`Facet` system uses `instanceof` against the `@codemirror/state` module identity — two module copies = two distinct classes = valid extensions rejected.

## Fix
Pin `@codemirror/{state,view,language,autocomplete}` in both override blocks (`overrides` for bun + `pnpm.overrides` for parity) so all ranges collapse to one resolution.

## Verification
Regenerated `bun.lock`: exactly **one** copy of each `@codemirror/*` package remains; the nested `@codemirror/lang-sql/@codemirror/*` overrides (including `state@6.5.4`) are gone.

Co-Authored-By: duyetbot <bot@duyet.net>