### PR TITLE
feat(readonly-tables): expandable diagnostics row + AI fix prompt action

### DIFF
--- a/apps/web/components/data-table/cells/actions/action-item.tsx
+++ b/apps/web/components/data-table/cells/actions/action-item.tsx
@@ -74,6 +74,62 @@ export function ActionItem<TData extends RowData, TValue>({
         message: `/agents?host=${hostId}`,
       }),
     },
+    'generate-ai-prompt': {
+      label: 'Generate AI Fix Prompt',
+      handler: async () => {
+        const data = row.original as Record<string, unknown>
+        const table = String(data.table ?? value ?? '')
+        const zkException = String(data.zookeeper_exception ?? '')
+        const queueException = String(data.last_queue_update_exception ?? '')
+        const isSessionExpired = String(data.is_session_expired ?? '')
+        const absoluteDelay = String(data.absolute_delay ?? '')
+        const logPointer = String(data.log_pointer ?? '')
+        const replicaPath = String(data.replica_path ?? '')
+        const zkPath = String(data.zookeeper_path ?? '')
+        const totalReplicas = String(data.total_replicas ?? '')
+        const activeReplicas = String(data.active_replicas ?? '')
+
+        const lines: string[] = [
+          `I have a ClickHouse replicated table \`${table}\` that is in read-only mode. Please help me diagnose and fix it.`,
+          '',
+          '## Replica Status',
+          `- Table: \`${table}\``,
+          `- Replica path: \`${replicaPath}\``,
+          `- ZooKeeper path: \`${zkPath}\``,
+          `- Total replicas: ${totalReplicas}`,
+          `- Active replicas: ${activeReplicas}`,
+          `- Absolute delay: ${absoluteDelay} seconds`,
+          `- Log pointer: ${logPointer}`,
+          `- Session expired: ${isSessionExpired}`,
+        ]
+
+        if (zkException) {
+          lines.push('', '## ZooKeeper Exception', '```', zkException, '```')
+        }
+        if (queueException) {
+          lines.push(
+            '',
+            '## Last Queue Update Exception',
+            '```',
+            queueException,
+            '```'
+          )
+        }
+
+        lines.push(
+          '',
+          '## Questions',
+          '1. What is the root cause of this read-only state?',
+          '2. What are the exact steps to restore this replica to read-write mode?',
+          '3. Are there any ClickHouse SQL commands I should run to recover?',
+          '4. How can I prevent this from happening again?'
+        )
+
+        const prompt = lines.join('\n')
+        await navigator.clipboard.writeText(prompt)
+        return { success: true, message: 'AI prompt copied to clipboard' }
+      },
+    },
     optimize: {
       label: 'Optimize Table',
       handler: () => optimizeTable(String(value)),

--- a/apps/web/components/data-table/cells/actions/types.ts
+++ b/apps/web/components/data-table/cells/actions/types.ts
@@ -7,6 +7,7 @@ export type Action =
   | 'delete-backup'
   | 'optimize'
   | 'query-settings'
+  | 'generate-ai-prompt'
 
 export type ActionResponse = {
   action: 'redirect' | 'toast'

--- a/apps/web/components/data-table/cells/readonly-table-details.tsx
+++ b/apps/web/components/data-table/cells/readonly-table-details.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import {
+  AlertTriangleIcon,
+  ClockIcon,
+  DatabaseIcon,
+  NetworkIcon,
+  ServerIcon,
+  TimerIcon,
+} from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+interface ReadonlyTableDetailsProps {
+  row: Record<string, unknown>
+}
+
+function hasValue(value: unknown): boolean {
+  return value !== undefined && value !== null && String(value).trim() !== ''
+}
+
+function toStringSafe(value: unknown): string {
+  return hasValue(value) ? String(value) : ''
+}
+
+interface DetailFieldProps {
+  label: string
+  value: React.ReactNode
+  icon?: React.ComponentType<{ className?: string }>
+  mono?: boolean
+  wrap?: boolean
+  className?: string
+}
+
+function DetailField({
+  label,
+  value,
+  icon: Icon,
+  mono = false,
+  wrap = false,
+  className,
+}: DetailFieldProps) {
+  if (!hasValue(value)) return null
+
+  return (
+    <div
+      className={cn(
+        'min-w-0 rounded-md border border-border/60 bg-background/60 px-3 py-2',
+        className
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        {Icon && <Icon className="size-3.5 shrink-0" aria-hidden="true" />}
+        <span className="truncate">{label}</span>
+      </div>
+      <div
+        className={cn(
+          'mt-1 min-w-0 text-sm text-foreground tabular-nums',
+          mono && 'font-mono',
+          wrap ? 'whitespace-pre-wrap break-words' : 'truncate'
+        )}
+        title={!wrap && typeof value === 'string' ? value : undefined}
+      >
+        {value}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Inline expanded-row detail panel for the readonly-tables table.
+ *
+ * Prioritises the two exception fields (the actual failure reasons), then
+ * surfaces replica connectivity context. Fields absent from the row (e.g.
+ * version-dependent columns) are silently omitted.
+ */
+export const ReadonlyTableDetails = function ReadonlyTableDetails({
+  row,
+}: ReadonlyTableDetailsProps) {
+  const zkException = toStringSafe(row.zookeeper_exception)
+  const queueException = toStringSafe(row.last_queue_update_exception)
+  const isSessionExpired = toStringSafe(row.is_session_expired)
+  const absoluteDelay = toStringSafe(row.absolute_delay)
+  const logPointer = toStringSafe(row.log_pointer)
+  const replicaPath = toStringSafe(row.replica_path)
+  const activeReplicas = toStringSafe(row.active_replicas)
+  const totalReplicas = toStringSafe(row.total_replicas)
+  const zkPath = toStringSafe(row.zookeeper_path)
+
+  const replicaRatio =
+    hasValue(activeReplicas) && hasValue(totalReplicas)
+      ? `${activeReplicas} / ${totalReplicas}`
+      : ''
+
+  return (
+    <div
+      data-slot="readonly-table-expanded"
+      className="border-t border-border/60 bg-muted/20 p-4"
+    >
+      <div className="flex flex-col gap-3">
+        {/* Exception fields — most important, rendered full-width */}
+        {hasValue(zkException) && (
+          <DetailField
+            icon={AlertTriangleIcon}
+            label="ZooKeeper Exception"
+            value={zkException}
+            mono
+            wrap
+            className="border-amber-300/60 bg-amber-50/40 dark:border-amber-700/40 dark:bg-amber-950/20"
+          />
+        )}
+        {hasValue(queueException) && (
+          <DetailField
+            icon={AlertTriangleIcon}
+            label="Last Queue Update Exception"
+            value={queueException}
+            mono
+            wrap
+            className="border-amber-300/60 bg-amber-50/40 dark:border-amber-700/40 dark:bg-amber-950/20"
+          />
+        )}
+
+        {/* Replica context grid */}
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          <DetailField
+            icon={TimerIcon}
+            label="Absolute Delay (s)"
+            value={absoluteDelay}
+            mono
+          />
+          <DetailField
+            icon={ClockIcon}
+            label="Session Expired"
+            value={isSessionExpired}
+            mono
+          />
+          <DetailField
+            icon={DatabaseIcon}
+            label="Log Pointer"
+            value={logPointer}
+            mono
+          />
+          <DetailField
+            icon={NetworkIcon}
+            label="Active / Total Replicas"
+            value={replicaRatio}
+            mono
+          />
+          <DetailField
+            icon={ServerIcon}
+            label="Replica Path"
+            value={replicaPath}
+            mono
+            className="sm:col-span-2"
+          />
+          <DetailField
+            icon={DatabaseIcon}
+            label="ZooKeeper Path"
+            value={zkPath}
+            mono
+            className="sm:col-span-2"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/lib/query-config/tables/readonly-tables.tsx
+++ b/apps/web/lib/query-config/tables/readonly-tables.tsx
@@ -1,5 +1,6 @@
 import type { QueryConfig } from '@/types/query-config'
 
+import { ReadonlyTableDetails } from '@/components/data-table/cells/readonly-table-details'
 import { ColumnFormat } from '@/types/column-format'
 
 export const readOnlyTablesConfig: QueryConfig = {
@@ -51,6 +52,7 @@ export const readOnlyTablesConfig: QueryConfig = {
     'replica_path',
     'log_pointer',
     'engine',
+    'action',
   ],
   columnFormats: {
     table: ColumnFormat.ColoredBadge,
@@ -60,6 +62,7 @@ export const readOnlyTablesConfig: QueryConfig = {
     is_readonly: ColumnFormat.Boolean,
     is_session_expired: ColumnFormat.Boolean,
     replica_name: ColumnFormat.ColoredBadge,
+    action: [ColumnFormat.Action, ['generate-ai-prompt']],
   },
   relatedCharts: [
     [
@@ -71,4 +74,7 @@ export const readOnlyTablesConfig: QueryConfig = {
       },
     ],
   ],
+  expandable: {
+    renderExpanded: (row) => <ReadonlyTableDetails row={row} />,
+  },
 }


### PR DESCRIPTION
## Summary

- **Expandable rows**: clicking any row on `/readonly-tables` now reveals a diagnostics panel. ZooKeeper exception and last-queue-update exception are rendered first (full-width, amber border, monospace, word-wrapped — the two most actionable failure signals). Below those, a grid shows replica path, ZooKeeper path, active/total replica count, absolute delay, session expired, and log pointer. Fields absent from the row are silently omitted.

- **AI fix prompt action**: a "Generate AI Fix Prompt" item in the row action menu (⋯) builds a structured markdown prompt from the replica's diagnostics — table name, paths, exception text, replica counts — copies it to the clipboard, and shows a success toast. The user can paste this directly into any AI assistant to get targeted recovery steps.

- **Implementation details**:
  - New component: `apps/web/components/data-table/cells/readonly-table-details.tsx` — modelled on `keeper-connection-expanded-details.tsx` (DetailField grid pattern).
  - New action type `'generate-ai-prompt'` added to `types.ts` and handled in `action-item.tsx` using `row.original` for full row data access.
  - `readonly-tables.ts` renamed to `.tsx` (same pattern as `keeper-connections.tsx`) to allow JSX in the config.
  - No changes to boolean formatting, no modifications to `components/ui/`.

## Test plan

- [ ] Visit `/readonly-tables` with a ClickHouse instance that has read-only replicas; confirm rows are clickable/expandable and the panel renders exception text correctly.
- [ ] Click ⋯ → "Generate AI Fix Prompt"; confirm clipboard receives a markdown prompt with table name and exception details, and a toast appears.
- [ ] Confirm rows with no exceptions still expand and show the replica context fields.
- [ ] CI lint + build + component tests pass.