### PR TITLE
fix(explorer): reseed query tab SQL when selected table changes

### DIFF
--- a/apps/web/components/explorer/tabs/query-tab.tsx
+++ b/apps/web/components/explorer/tabs/query-tab.tsx
@@ -288,6 +288,24 @@ export function QueryTab() {
     }
   }, [customQuery, database, tableName])
 
+  // Re-seed the editor when the selected table changes.
+  // setDatabaseAndTable clears customQuery (sets q=null in URL), so when
+  // customQuery is null and database+table change, the user picked a new table.
+  const prevTableKeyRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!initialized.current) return
+    const tableKey = database && tableName ? `${database}.${tableName}` : null
+    if (tableKey === prevTableKeyRef.current) return
+    prevTableKeyRef.current = tableKey
+
+    if (!customQuery && database && tableName) {
+      const defaultQuery = `SELECT *\nFROM \`${database}\`.\`${tableName}\`\nLIMIT 100`
+      setEditorValue(defaultQuery)
+      setExecutedQuery(null)
+      setLimitAdded(false)
+    }
+  }, [database, tableName, customQuery])
+
   // Build the SWR URL only when we have an executed query
   const swrKey = (() => {
     if (!executedQuery) return null


### PR DESCRIPTION
## Root cause

The query tab initializes the editor once on mount using a `initialized.current` guard ref. This is correct for the first load, but it meant that when the user clicked a different table in the tree, the editor content never updated — it kept displaying the SQL for the first table selected.

`setDatabaseAndTable` (in `use-explorer-state.ts`) already clears `customQuery` (`q=null` in the URL) when a new table is picked, which is the right signal to detect a table switch vs a user-typed query.

## Fix

Added a second `useEffect` in `QueryTab` that tracks a `prevTableKeyRef` (`database.table` string). When `database` or `table` URL params change **and** `customQuery` is null, it:
- Reseeds `editorValue` with the default `SELECT * FROM \`db\`.\`table\` LIMIT 100` query
- Clears `executedQuery` so stale result rows for the old table are dismissed
- Resets `limitAdded`

The `SqlEditor` component already supports programmatic content updates via a value-sync `useEffect` that dispatches a CodeMirror transaction — no new CodeMirror dependencies needed.

## Test plan

- [ ] Open `/explorer?host=0&database=system&table=tables&tab=query` — editor shows `SELECT * FROM \`system\`.\`tables\` LIMIT 100`
- [ ] Click a different table in the sidebar tree (e.g. `system.query_log`) — editor updates to `SELECT * FROM \`system\`.\`query_log\` LIMIT 100` and previous results clear
- [ ] Run a custom query, then switch tables — editor resets (custom query is cleared by `setDatabaseAndTable`)
- [ ] Switch tables while on a non-query tab, then switch to query tab — editor shows the correct table's default query