### PR TITLE
fix(readonly-tables): render is_readonly in red (readonly = problem state)

### DIFF
--- a/apps/web/components/data-table/cells/boolean-format.tsx
+++ b/apps/web/components/data-table/cells/boolean-format.tsx
@@ -2,10 +2,18 @@ import { CheckCircledIcon, CrossCircledIcon } from '@radix-ui/react-icons'
 
 interface BooleanFormatProps {
   value: string | number | boolean
+  /**
+   * Invert the color semantics: render `true` as red (alarming) and `false`
+   * as green. Use when a truthy value represents a problem state — e.g.
+   * `is_readonly` on the Readonly Tables page, where a readonly replica is bad.
+   * Icons are unchanged (check for true, cross for false); only colors flip.
+   */
+  invert?: boolean
 }
 
 export const BooleanFormat = function BooleanFormat({
   value,
+  invert = false,
 }: BooleanFormatProps): React.ReactNode {
   const isTrue =
     typeof value === 'string'
@@ -13,8 +21,14 @@ export const BooleanFormat = function BooleanFormat({
       : !!value
 
   return isTrue ? (
-    <CheckCircledIcon aria-label="yes" className="text-green-700" />
+    <CheckCircledIcon
+      aria-label="yes"
+      className={invert ? 'text-rose-700' : 'text-green-700'}
+    />
   ) : (
-    <CrossCircledIcon aria-label="no" className="text-rose-700" />
+    <CrossCircledIcon
+      aria-label="no"
+      className={invert ? 'text-green-700' : 'text-rose-700'}
+    />
   )
 }

--- a/apps/web/components/data-table/formatters/value-formatters.tsx
+++ b/apps/web/components/data-table/formatters/value-formatters.tsx
@@ -34,6 +34,15 @@ export const booleanFormatter: ValueOnlyFormatter = (value) => (
 )
 
 /**
+ * Inverted boolean formatter - like {@link booleanFormatter} but renders a
+ * truthy value in red (alarming) and a falsy value in green. Use when `true`
+ * represents a problem state, e.g. `is_readonly` on the Readonly Tables page.
+ */
+export const booleanInvertedFormatter: ValueOnlyFormatter = (value) => (
+  <BooleanFormat value={value as string | number | boolean} invert />
+)
+
+/**
  * Duration formatter - converts seconds to human-readable duration
  *
  * @example
@@ -79,6 +88,7 @@ export const textFormatter: ValueOnlyFormatter = (value, options) => (
 export const VALUE_FORMATTERS: Record<
   | ColumnFormat.Badge
   | ColumnFormat.Boolean
+  | ColumnFormat.BooleanInverted
   | ColumnFormat.Duration
   | ColumnFormat.RelatedTime
   | ColumnFormat.Text,
@@ -86,6 +96,7 @@ export const VALUE_FORMATTERS: Record<
 > = {
   [ColumnFormat.Badge]: badgeFormatter,
   [ColumnFormat.Boolean]: booleanFormatter,
+  [ColumnFormat.BooleanInverted]: booleanInvertedFormatter,
   [ColumnFormat.Duration]: durationFormatter,
   [ColumnFormat.RelatedTime]: relatedTimeFormatter,
   [ColumnFormat.Text]: textFormatter,

--- a/apps/web/lib/query-config/tables/readonly-tables.tsx
+++ b/apps/web/lib/query-config/tables/readonly-tables.tsx
@@ -59,7 +59,7 @@ export const readOnlyTablesConfig: QueryConfig = {
     engine: ColumnFormat.ColoredBadge,
     is_leader: ColumnFormat.Boolean,
     can_become_leader: ColumnFormat.Boolean,
-    is_readonly: ColumnFormat.Boolean,
+    is_readonly: ColumnFormat.BooleanInverted,
     is_session_expired: ColumnFormat.Boolean,
     replica_name: ColumnFormat.ColoredBadge,
     action: [ColumnFormat.Action, ['generate-ai-prompt']],

--- a/apps/web/types/column-format.ts
+++ b/apps/web/types/column-format.ts
@@ -20,6 +20,7 @@ export enum ColumnFormat {
   Duration = 'duration',
   Markdown = 'markdown',
   Boolean = 'boolean',
+  BooleanInverted = 'boolean-inverted',
   Action = 'action',
   InlineAction = 'inline-action',
   Number = 'number',


### PR DESCRIPTION
## Problem
On `/readonly-tables`, the `is_readonly` column rendered a **green check** for `is_readonly = 1`. But this page only lists tables that are *stuck in readonly* — a problem state. Green wrongly reads as "healthy".

## Fix
- Add an opt-in `invert` prop to the shared `BooleanFormat` that flips **only the color** (true → red/alarming, false → green). Icons unchanged.
- Expose it as `ColumnFormat.BooleanInverted` and register `booleanInvertedFormatter` in the value-formatter registry.
- Apply `BooleanInverted` to the `is_readonly` column in `readonly-tables` config.

The global `ColumnFormat.Boolean` (true = green) is untouched, so every other table keeps the correct default. Dispatch is a by-key lookup, so the new member resolves with no exhaustive-switch changes; existing `boolean-format.cy.tsx` behavior is unchanged (invert defaults false).

Co-Authored-By: duyetbot <bot@duyet.net>