### PR TITLE
fix(ui): unify chart-grid and stack spacing rhythm

### DIFF
--- a/apps/web/app/(dashboard)/insights/page.tsx
+++ b/apps/web/app/(dashboard)/insights/page.tsx
@@ -77,7 +77,7 @@ export default function InsightsPage() {
   ).toLowerCase()
 
   return (
-    <div className="flex flex-col gap-4 p-3 sm:gap-6 sm:p-6">
+    <div className="flex flex-col gap-4 p-3 sm:gap-4 sm:p-6">
       <div className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:gap-4">
         <div>
           <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
@@ -914,7 +914,7 @@ function ChartsSection({ hostId }: { readonly hostId: number }) {
   const hasCompressionData = compressionData && compressionData.length > 0
 
   return (
-    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+    <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
       {hasTopTablesData && (
         <LazyChartWrapper>
           <TopTablesBySizeChart hostId={hostId} />

--- a/apps/web/components/overview-charts/overview-charts-client.tsx
+++ b/apps/web/components/overview-charts/overview-charts-client.tsx
@@ -25,7 +25,7 @@ export const OverviewCharts = function OverviewCharts({
   return (
     <div
       className={cn(
-        'grid auto-rows-fr grid-cols-1 gap-2 sm:gap-3 sm:grid-cols-2 md:grid-cols-4',
+        'grid auto-rows-fr grid-cols-1 gap-3 sm:gap-4 sm:grid-cols-2 md:grid-cols-4',
         className
       )}
       role="region"


### PR DESCRIPTION
## Summary

- Normalize stray `gap-2` / `gap-6` values on chart/card grids and page-level flex stacks to a single rhythm
- **Chart grids**: `gap-3` (base) with `sm:gap-4` / `lg:gap-4` for responsive bump
- **Vertical section stacks**: `gap-4` (major page sections)
- Spacing-only change — no markup restructuring, no grid-col changes, no padding changes unrelated to grid/stack gaps

## Files changed

- `apps/web/components/overview-charts/overview-charts-client.tsx`: KPI 4-card grid `gap-2 sm:gap-3` → `gap-3 sm:gap-4`
- `apps/web/app/(dashboard)/insights/page.tsx`: outer page stack `sm:gap-6` → `sm:gap-4`; ChartsSection 2-col chart grid `gap-4` → `gap-3`

## Test plan

- [ ] Visual check: overview KPI cards maintain uniform spacing at all breakpoints
- [ ] Visual check: insights page section rhythm is consistent (no jumpy gaps between responsive sizes)
- [ ] CI lint + build passes (spacing-only, no logic changes)