### PR TITLE
feat(charts): extract ProportionList primitive from 3 duplicated progress-bar charts

### DIFF
--- a/apps/web/components/charts/logs/log-level-distribution.tsx
+++ b/apps/web/components/charts/logs/log-level-distribution.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { createCustomChart } from '@/components/charts/factory'
-import { cn } from '@/lib/utils'
+import { ProportionList } from '@/components/charts/primitives/proportion-list'
 
 interface LogLevelData {
   level: string
@@ -27,38 +27,16 @@ export const ChartLogLevelDistribution = createCustomChart({
   dateRangeConfig: 'realtime',
   render: (dataArray) => {
     const data = dataArray as LogLevelData[]
-    const total = data.reduce((sum, d) => sum + d.count, 0)
 
     return (
-      <div className="flex flex-col gap-3 p-2">
-        {data.map((item, index) => {
-          const pct = total > 0 ? (item.count / total) * 100 : 0
-          return (
-            <div key={item.level} className="flex flex-col gap-1">
-              <div className="flex items-center justify-between text-sm">
-                <span className="font-medium">{item.level}</span>
-                <span className="text-muted-foreground">
-                  {item.count.toLocaleString()} ({pct.toFixed(1)}%)
-                </span>
-              </div>
-              <div className="bg-muted h-2 w-full overflow-hidden rounded-full">
-                <div
-                  className={cn(
-                    'h-full rounded-full transition-all',
-                    levelColors[item.level] || `bg-chart-${(index % 5) + 1}`
-                  )}
-                  style={{ width: `${pct}%` }}
-                />
-              </div>
-            </div>
-          )
-        })}
-        {data.length === 0 && (
-          <div className="text-muted-foreground text-center text-sm">
-            No log level data available
-          </div>
-        )}
-      </div>
+      <ProportionList
+        items={data.map((d, index) => ({
+          label: d.level,
+          value: d.count,
+          colorClass: levelColors[d.level] ?? `bg-chart-${(index % 5) + 1}`,
+        }))}
+        emptyMessage="No log level data available"
+      />
     )
   },
 })

--- a/apps/web/components/charts/primitives/proportion-list.tsx
+++ b/apps/web/components/charts/primitives/proportion-list.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+
+export interface ProportionItem {
+  label: string
+  value: number
+  /** Tailwind bg-* class or CSS-var class, e.g. "bg-emerald-500" or "bg-chart-1" */
+  colorClass?: string
+}
+
+export interface ProportionListProps {
+  items: ProportionItem[]
+  /** Pre-computed total; defaults to sum of all item values */
+  total?: number
+  /** Custom value formatter; defaults to toLocaleString */
+  formatValue?: (value: number) => string
+  /** Shown when items is empty */
+  emptyMessage?: string
+  className?: string
+}
+
+/**
+ * Renders a vertical list of labelled progress-bar rows.
+ * Each row shows: label | track+fill | count (pct%).
+ * Percentages are computed from `total` (or the sum of all values).
+ */
+export function ProportionList({
+  items,
+  total,
+  formatValue,
+  emptyMessage = 'No data available',
+  className,
+}: ProportionListProps) {
+  const computedTotal =
+    total ?? items.reduce((sum, item) => sum + item.value, 0)
+
+  const fmt = formatValue ?? ((v: number) => v.toLocaleString())
+
+  if (items.length === 0) {
+    return (
+      <div className={cn('p-2', className)}>
+        <p className="text-muted-foreground text-center text-sm">
+          {emptyMessage}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-3 p-2', className)}>
+      {items.map((item, index) => {
+        const pct = computedTotal > 0 ? (item.value / computedTotal) * 100 : 0
+        const fillClass = item.colorClass ?? `bg-chart-${(index % 5) + 1}`
+
+        return (
+          <div key={item.label} className="flex flex-col gap-1">
+            <div className="flex items-center justify-between text-sm">
+              <span className="font-medium">{item.label}</span>
+              <span className="text-muted-foreground tabular-nums">
+                {fmt(item.value)} ({pct.toFixed(1)}%)
+              </span>
+            </div>
+            <div className="bg-muted h-2 w-full overflow-hidden rounded-full">
+              <div
+                className={cn(
+                  'h-full rounded-full transition-[width]',
+                  fillClass
+                )}
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/components/charts/query/query-cache-usage.tsx
+++ b/apps/web/components/charts/query/query-cache-usage.tsx
@@ -3,7 +3,7 @@
 import type { ChartProps } from '@/components/charts/chart-props'
 
 import { createCustomChart } from '@/components/charts/factory'
-import { cn } from '@/lib/utils'
+import { ProportionList } from '@/components/charts/primitives/proportion-list'
 
 interface CacheUsageData {
   query_cache_usage: string
@@ -30,38 +30,16 @@ export const ChartQueryCacheUsage = createCustomChart({
   dateRangeConfig: 'standard',
   render: (dataArray) => {
     const data = dataArray as CacheUsageData[]
-    const total = data.reduce((sum, d) => sum + d.query_count, 0)
 
     return (
-      <div className="flex flex-col gap-3 p-2">
-        {data.map((item) => {
-          const pct = total > 0 ? (item.query_count / total) * 100 : 0
-          return (
-            <div key={item.query_cache_usage} className="flex flex-col gap-1">
-              <div className="flex items-center justify-between text-sm">
-                <span className="font-medium">{item.query_cache_usage}</span>
-                <span className="text-muted-foreground">
-                  {item.query_count.toLocaleString()} ({pct.toFixed(1)}%)
-                </span>
-              </div>
-              <div className="bg-muted h-2 w-full overflow-hidden rounded-full">
-                <div
-                  className={cn(
-                    'h-full rounded-full transition-[width]',
-                    cacheColors[item.query_cache_usage] || 'bg-chart-1'
-                  )}
-                  style={{ width: `${pct}%` }}
-                />
-              </div>
-            </div>
-          )
-        })}
-        {data.length === 0 && (
-          <div className="text-muted-foreground text-center text-sm">
-            No cache usage data available
-          </div>
-        )}
-      </div>
+      <ProportionList
+        items={data.map((d) => ({
+          label: d.query_cache_usage,
+          value: d.query_count,
+          colorClass: cacheColors[d.query_cache_usage] ?? 'bg-chart-1',
+        }))}
+        emptyMessage="No cache usage data available"
+      />
     )
   },
 })

--- a/apps/web/components/charts/query/query-type.tsx
+++ b/apps/web/components/charts/query/query-type.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { createCustomChart } from '@/components/charts/factory'
-import { cn } from '@/lib/utils'
+import { ProportionList } from '@/components/charts/primitives/proportion-list'
 
 interface QueryTypeData {
   type: string
@@ -23,38 +23,16 @@ export const ChartQueryType = createCustomChart({
   dateRangeConfig: 'realtime',
   render: (dataArray) => {
     const data = dataArray as QueryTypeData[]
-    const total = data.reduce((sum, d) => sum + d.query_count, 0)
 
     return (
-      <div className="flex flex-col gap-3 p-2">
-        {data.map((item, index) => {
-          const pct = total > 0 ? (item.query_count / total) * 100 : 0
-          return (
-            <div key={item.type} className="flex flex-col gap-1">
-              <div className="flex items-center justify-between text-sm">
-                <span className="font-medium">{item.type}</span>
-                <span className="text-muted-foreground">
-                  {item.query_count.toLocaleString()} ({pct.toFixed(1)}%)
-                </span>
-              </div>
-              <div className="bg-muted h-2 w-full overflow-hidden rounded-full">
-                <div
-                  className={cn(
-                    'h-full rounded-full transition-[width]',
-                    typeColors[item.type] || `bg-chart-${(index % 5) + 1}`
-                  )}
-                  style={{ width: `${pct}%` }}
-                />
-              </div>
-            </div>
-          )
-        })}
-        {data.length === 0 && (
-          <div className="text-muted-foreground text-center text-sm">
-            No query type data available
-          </div>
-        )}
-      </div>
+      <ProportionList
+        items={data.map((d, index) => ({
+          label: d.type,
+          value: d.query_count,
+          colorClass: typeColors[d.type] ?? `bg-chart-${(index % 5) + 1}`,
+        }))}
+        emptyMessage="No query type data available"
+      />
     )
   },
 })


### PR DESCRIPTION
## Summary

- Three charts (`query-type`, `query-cache-usage`, `log-level-distribution`) each hand-rolled near-identical "part-to-whole progress bar list" markup with subtle drift (`transition-[width]` vs `transition-all`, missing `tabular-nums`, separate empty-state strings).
- Extracted a single `ProportionList` primitive (`components/charts/primitives/proportion-list.tsx`) that renders the shared row markup once: label, track+fill bar, count and percentage.
- Each chart now maps its data to `ProportionItem[]` (passing the label-specific `colorClass`) and delegates rendering to `ProportionList`. Data fetching, SWR wiring, and `createCustomChart` config are untouched.
- Added `tabular-nums` on the count/pct span so numbers don't reflow on the 30 s auto-refresh.
- Unified bar transition to `transition-[width]` across all three.
- Color mappings (emerald/blue/orange/red/gray per label) stay per-chart — centralized in each chart's `*Colors` map, not inside the primitive.

## Test plan

- [ ] Existing `query-type.cy.tsx` Cypress component test passes (tests chart skeleton, title, className, hostId — no row-level testids that would break)
- [ ] Visual output is identical to before in browser (label left, count+pct right in `tabular-nums`, filled colored bar below)
- [ ] Dark mode: `bg-muted` track and `text-muted-foreground` label survive theme switch
- [ ] Empty state renders the per-chart message when data array is empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized the visual presentation of log-level distribution, query cache usage, and query type charts. These components now use a unified rendering approach with consistent formatting and styling for improved dashboard cohesion and information clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->