### PR TITLE
feat(charts): route status colors through shared tokens

### DIFF
--- a/apps/web/components/charts/replication/replication-lag.tsx
+++ b/apps/web/components/charts/replication/replication-lag.tsx
@@ -17,6 +17,10 @@ import {
 } from '@/components/ui/table'
 import { useChartData } from '@/lib/swr'
 import { cn } from '@/lib/utils'
+import {
+  STATUS_BADGE_CLASS,
+  type StatusTone,
+} from '@/lib/utils/status-badge-class'
 
 interface ReplicationLagData {
   database: string
@@ -30,14 +34,11 @@ interface ReplicationLagData {
   [key: string]: string | number // Index signature for ChartDataPoint compatibility
 }
 
-const lagStatusColors: Record<string, string> = {
-  synced:
-    'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
-  'slight lag':
-    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
-  'moderate lag':
-    'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300',
-  'severe lag': 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+const LAG_STATUS_TONE: Record<ReplicationLagData['lag_status'], StatusTone> = {
+  synced: 'ok',
+  'slight lag': 'warning',
+  'moderate lag': 'caution',
+  'severe lag': 'error',
 }
 
 /**
@@ -104,7 +105,7 @@ export const ChartReplicationLag = function ChartReplicationLag({
                     variant="outline"
                     className={cn(
                       'text-xs',
-                      lagStatusColors[row.lag_status] || ''
+                      STATUS_BADGE_CLASS[LAG_STATUS_TONE[row.lag_status]]
                     )}
                   >
                     {row.lag_status}

--- a/apps/web/components/charts/system/mutation-progress.tsx
+++ b/apps/web/components/charts/system/mutation-progress.tsx
@@ -7,6 +7,11 @@ import { ChartContainer } from '@/components/charts/chart-container'
 import { STUCK_THRESHOLD_SECONDS } from '@/lib/query-config/merges/mutations'
 import { useChartData } from '@/lib/swr'
 import { cn } from '@/lib/utils'
+import {
+  STATUS_BADGE_CLASS,
+  STATUS_ROW_CLASS,
+  type StatusTone,
+} from '@/lib/utils/status-badge-class'
 
 type DataRow = {
   mutation_id: string
@@ -20,17 +25,17 @@ type DataRow = {
   latest_fail_reason: string
 }
 
-function getStatusBadgeClass(row: DataRow): string {
+function getMutationTone(row: DataRow): StatusTone {
   if (
     row.elapsed_seconds > STUCK_THRESHOLD_SECONDS &&
     row.status === 'running'
   ) {
-    return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
+    return 'error'
   }
   if (row.status === 'waiting') {
-    return 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300'
+    return 'caution'
   }
-  return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300'
+  return 'info'
 }
 
 function getStatusLabel(row: DataRow): string {
@@ -97,59 +102,57 @@ export const ChartMutationProgress = function ChartMutationProgress({
                 <span className="text-right">Parts Left</span>
                 <span className="text-right">Elapsed</span>
               </div>
-              {rows.map((row) => (
-                <div
-                  key={row.mutation_id}
-                  className={cn(
-                    'grid grid-cols-[1fr_60px_80px_80px] gap-2 rounded px-2 py-1.5',
-                    'text-xs',
-                    row.elapsed_seconds > STUCK_THRESHOLD_SECONDS &&
-                      row.status === 'running'
-                      ? 'bg-red-50 dark:bg-red-950/20'
-                      : row.status === 'waiting'
-                        ? 'bg-amber-50 dark:bg-amber-950/20'
-                        : 'bg-muted/40'
-                  )}
-                >
-                  <div className="min-w-0">
-                    <div className="truncate font-medium text-foreground">
-                      {row.table_path}
-                    </div>
-                    <div
-                      className="truncate text-muted-foreground"
-                      title={row.command}
-                    >
-                      {row.command.length > 80
-                        ? `${row.command.slice(0, 80)}...`
-                        : row.command}
-                    </div>
-                    {row.latest_fail_reason && (
-                      <div
-                        className="truncate text-red-600 dark:text-red-400"
-                        title={row.latest_fail_reason}
-                      >
-                        {row.latest_fail_reason}
-                      </div>
+              {rows.map((row) => {
+                const tone = getMutationTone(row)
+                return (
+                  <div
+                    key={row.mutation_id}
+                    className={cn(
+                      'grid grid-cols-[1fr_60px_80px_80px] gap-2 rounded px-2 py-1.5',
+                      'text-xs',
+                      STATUS_ROW_CLASS[tone] || 'bg-muted/40'
                     )}
-                  </div>
-                  <div className="flex items-start justify-end pt-0.5">
-                    <span
-                      className={cn(
-                        'inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium',
-                        getStatusBadgeClass(row)
+                  >
+                    <div className="min-w-0">
+                      <div className="truncate font-medium text-foreground">
+                        {row.table_path}
+                      </div>
+                      <div
+                        className="truncate text-muted-foreground"
+                        title={row.command}
+                      >
+                        {row.command.length > 80
+                          ? `${row.command.slice(0, 80)}...`
+                          : row.command}
+                      </div>
+                      {row.latest_fail_reason && (
+                        <div
+                          className="truncate text-red-600 dark:text-red-400"
+                          title={row.latest_fail_reason}
+                        >
+                          {row.latest_fail_reason}
+                        </div>
                       )}
-                    >
-                      {getStatusLabel(row)}
-                    </span>
+                    </div>
+                    <div className="flex items-start justify-end pt-0.5">
+                      <span
+                        className={cn(
+                          'inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium',
+                          STATUS_BADGE_CLASS[tone]
+                        )}
+                      >
+                        {getStatusLabel(row)}
+                      </span>
+                    </div>
+                    <div className="flex items-start justify-end pt-1 tabular-nums text-foreground">
+                      {row.readable_parts_to_do}
+                    </div>
+                    <div className="flex items-start justify-end pt-1 tabular-nums text-muted-foreground">
+                      {row.readable_elapsed}
+                    </div>
                   </div>
-                  <div className="flex items-start justify-end pt-1 tabular-nums text-foreground">
-                    {row.readable_parts_to_do}
-                  </div>
-                  <div className="flex items-start justify-end pt-1 tabular-nums text-muted-foreground">
-                    {row.readable_elapsed}
-                  </div>
-                </div>
-              ))}
+                )
+              })}
             </div>
           </ChartCard>
         )

--- a/apps/web/lib/utils/status-badge-class.ts
+++ b/apps/web/lib/utils/status-badge-class.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared status-tone → Tailwind className mapping.
+ *
+ * Use this instead of scattering raw palette literals across chart/table
+ * components. The token set matches the rest of the app (see colored-badge-format,
+ * mirror-status-badge) so colors are consistent across light and dark mode.
+ */
+
+/** Semantic status tones used across charts and tables. */
+export type StatusTone =
+  | 'ok' // green  — synced, running normally
+  | 'warning' // yellow — slight degradation
+  | 'caution' // orange — moderate degradation / waiting
+  | 'error' // red    — severe problem or stuck
+  | 'info' // blue   — neutral informational / in-progress
+  | 'muted' // muted  — idle / unknown
+
+/** Tailwind class string per tone (light + dark, matching the app-wide convention). */
+export const STATUS_BADGE_CLASS: Record<StatusTone, string> = {
+  ok: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+  warning:
+    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+  caution:
+    'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
+  error: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+  info: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  muted: 'bg-muted text-muted-foreground',
+}
+
+/** Lighter row-background tint per tone (for row-level highlighting). */
+export const STATUS_ROW_CLASS: Record<StatusTone, string> = {
+  ok: '',
+  warning: 'bg-yellow-50 dark:bg-yellow-950/20',
+  caution: 'bg-amber-50 dark:bg-amber-950/20',
+  error: 'bg-red-50 dark:bg-red-950/20',
+  info: '',
+  muted: '',
+}


### PR DESCRIPTION
## Summary

- Add `lib/utils/status-badge-class.ts` with two exported maps (`STATUS_BADGE_CLASS`, `STATUS_ROW_CLASS`) keyed by semantic `StatusTone` (`ok` / `warning` / `caution` / `error` / `info` / `muted`). The Tailwind strings match what `colored-badge-format` and `mirror-status-badge` already use, so this is a centralisation, not a new palette.
- Replace the bespoke `lagStatusColors` literal map in `replication-lag.tsx` with a `LAG_STATUS_TONE` lookup into the shared module — the `Badge` component now receives its className from `STATUS_BADGE_CLASS`.
- Replace the inline `bg-red-100 / bg-amber-100 / bg-blue-100` strings in `mutation-progress.tsx` with `getMutationTone()` → `STATUS_BADGE_CLASS[tone]` and `STATUS_ROW_CLASS[tone]`, eliminating the dual raw-palette paths for badge and row background.

Visuals are near-identical (same Tailwind token values); `moderate lag` shifts from `orange` to `amber` to align with `caution` tone used elsewhere in the app (e.g. `mirror-status-badge` paused state). Behavior and all existing test selectors are unchanged.

## Test plan

- [ ] CI lint + type-check passes
- [ ] Cypress component tests remain green (no `.cy.tsx` for `replication-lag`; `mutation-progress` has none either)
- [ ] Visual spot-check: replication lag badges render green/yellow/amber/red; mutation badges render blue/amber/red for running/waiting/stuck