### PR TITLE
fix(ui): remove redundant padding from insights page

### DIFF
--- a/apps/web/app/(dashboard)/insights/page.tsx
+++ b/apps/web/app/(dashboard)/insights/page.tsx
@@ -77,7 +77,7 @@ export default function InsightsPage() {
   ).toLowerCase()
 
   return (
-    <div className="flex flex-col gap-4 p-3 sm:gap-4 sm:p-6">
+    <div className="flex flex-col gap-4 sm:gap-4">
       <div className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:gap-4">
         <div>
           <h1 className="text-xl font-bold tracking-tight sm:text-2xl">


### PR DESCRIPTION
## Summary

- The dashboard layout (`apps/web/app/(dashboard)/layout.tsx`) already applies `p-3 sm:p-4` to every page's content area
- The insights page had its own `p-3 sm:p-6` on its outermost `<div>`, causing double-padding and left-edge misalignment compared to every other dashboard page
- Removed only the padding utilities (`p-3` and `sm:p-6`) from the root container; gap utilities are unchanged

## Changes

- `apps/web/app/(dashboard)/insights/page.tsx`: `flex flex-col gap-4 p-3 sm:gap-4 sm:p-6` → `flex flex-col gap-4 sm:gap-4`

## Test plan

- [ ] Visit `/insights` — content left edge should align with other dashboard pages (overview, tables, etc.)
- [ ] Verify no double-padding on mobile and desktop viewports
- [ ] No other pages or components touched