### PR TITLE
fix(clusters): remove redundant breadcrumb and add Suspense to table

### DIFF
--- a/apps/web/app/(dashboard)/clusters/page.tsx
+++ b/apps/web/app/(dashboard)/clusters/page.tsx
@@ -1,14 +1,18 @@
 'use client'
 
+import { Suspense } from 'react'
+import { TableSkeleton } from '@/components/skeletons'
 import { TableClient } from '@/components/tables/table-client'
 import { queryConfig } from '@/lib/api/clusters-api'
 
 export default function ClustersPage() {
   return (
-    <TableClient
-      title={queryConfig.name}
-      description={queryConfig.description}
-      queryConfig={queryConfig}
-    />
+    <Suspense fallback={<TableSkeleton />}>
+      <TableClient
+        title={queryConfig.name}
+        description={queryConfig.description}
+        queryConfig={queryConfig}
+      />
+    </Suspense>
   )
 }

--- a/apps/web/app/(dashboard)/clusters/replicas-status/page.tsx
+++ b/apps/web/app/(dashboard)/clusters/replicas-status/page.tsx
@@ -18,33 +18,21 @@ function ReplicasStatusContent() {
 
   return (
     <div className="flex flex-col gap-4">
-      {/* Breadcrumb and cluster info */}
-      <div className="bg-card flex items-center justify-between gap-4 rounded-lg border p-4">
-        <div className="flex items-center gap-2">
-          <Link
-            href={clustersUrl}
-            className="text-muted-foreground hover:text-foreground text-sm transition-colors"
-          >
-            Clusters
-          </Link>
-          <span className="text-muted-foreground">/</span>
-          <span className="font-medium">{cluster || 'Select a cluster'}</span>
-        </div>
-
-        {/* Readonly tables warning indicator */}
-        {cluster && <ReadonlyTablesWarning hostId={hostId} cluster={cluster} />}
-      </div>
-
       {/* Table Content */}
       {cluster ? (
-        <Suspense fallback={<TableSkeleton />}>
-          <TableClient
-            title={`Replicas Status: ${cluster}`}
-            description={clustersReplicasStatusConfig.description}
-            queryConfig={clustersReplicasStatusConfig}
-            searchParams={{ cluster }}
-          />
-        </Suspense>
+        <>
+          {/* Readonly tables warning indicator */}
+          <ReadonlyTablesWarning hostId={hostId} cluster={cluster} />
+
+          <Suspense fallback={<TableSkeleton />}>
+            <TableClient
+              title={`Replicas Status: ${cluster}`}
+              description={clustersReplicasStatusConfig.description}
+              queryConfig={clustersReplicasStatusConfig}
+              searchParams={{ cluster }}
+            />
+          </Suspense>
+        </>
       ) : (
         <div className="bg-card flex h-96 items-center justify-center rounded-lg border">
           <p className="text-muted-foreground text-sm">


### PR DESCRIPTION
## Summary

- **replicas-status page**: Remove the in-content `bg-card` breadcrumb block ("Clusters / {cluster}") that duplicated the layout's breadcrumb trail. The `ReadonlyTablesWarning` that was co-located in that block is preserved — moved as a standalone element directly above the table when a cluster is selected.
- **clusters page**: Wrap `TableClient` in `<Suspense fallback={<TableSkeleton />}>`, matching the loading pattern used by sibling table pages (e.g. `part-info/page.tsx`). Adds the `TableSkeleton` import from `@/components/skeletons`.

## Test plan

- [ ] Navigate to `/clusters` — table shows skeleton on load, then renders
- [ ] Navigate to `/clusters/replicas-status?cluster=<name>` — no duplicate breadcrumb; `ReadonlyTablesWarning` still appears above the table
- [ ] Navigate to `/clusters/replicas-status` (no cluster param) — "Select a cluster" empty state shown with link back to clusters list