### PR TITLE
test(api): add unit tests for charts, cluster-counts, dashboard API routes

### DIFF
--- a/apps/web/app/api/v1/charts/__tests__/route.test.ts
+++ b/apps/web/app/api/v1/charts/__tests__/route.test.ts
@@ -102,7 +102,7 @@ beforeEach(() => {
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
 function chartUrl(name: string, extra = '') {
-  return `http://localhost:3000/api/v1/charts/${name}?hostId=0${extra ? '&' + extra : ''}`
+  return `http://localhost:3000/api/v1/charts/${name}?hostId=0${extra ? `&${extra}` : ''}`
 }
 
 function chartRequest(name: string, extra = '') {

--- a/apps/web/app/api/v1/charts/__tests__/route.test.ts
+++ b/apps/web/app/api/v1/charts/__tests__/route.test.ts
@@ -1,0 +1,618 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockFetchJson = mock(() =>
+  Promise.resolve({
+    dataJson: '[{"event_time":"2025-01-01","count":"5"}]',
+    metadata: { queryId: 'q1', duration: 10, rows: 1, host: '0' },
+  })
+)
+
+const mockGetClickHouseVersion = mock(() =>
+  Promise.resolve({ raw: '24.1.1.1', major: 24, minor: 1 })
+)
+const mockSelectVersionedSql = mock(
+  (sql: unknown[]) => (sql as { sql: string }[])[0].sql
+)
+const mockSelectQueryVariant = mock(() => 'SELECT 1')
+const mockCheckTableAvailability = mock(() =>
+  Promise.resolve({ exists: true, hasData: true })
+)
+const mockGetTableInfoMessage = mock(
+  (t: string) => `Table ${t} is not available`
+)
+
+mock.module('@chm/clickhouse-client', () => ({
+  fetchJsonEachRowAsNormalizedJson: mockFetchJson,
+  fetchData: mock(() => Promise.resolve({ data: [], metadata: {} })),
+  getClient: mock(() =>
+    Promise.resolve({
+      query: mock(() => Promise.resolve()),
+      command: mock(() => Promise.resolve()),
+    })
+  ),
+}))
+
+mock.module('@chm/clickhouse-client/clickhouse-version', () => ({
+  getClickHouseVersion: mockGetClickHouseVersion,
+  selectVersionedSql: mockSelectVersionedSql,
+  selectQueryVariant: mockSelectQueryVariant,
+  checkTableAvailability: mockCheckTableAvailability,
+  getTableInfoMessage: mockGetTableInfoMessage,
+}))
+
+const mockHasChart = mock(() => true)
+const mockGetChartQuery = mock(() => ({
+  query: 'SELECT 1',
+  queryParams: undefined,
+}))
+const mockGetAvailableCharts = mock(() => ['test-chart'])
+
+mock.module('@/lib/api/chart-registry', () => ({
+  hasChart: mockHasChart,
+  getChartQuery: mockGetChartQuery,
+  getAvailableCharts: mockGetAvailableCharts,
+}))
+
+mock.module('@/lib/feature-permissions/server', () => ({
+  authorizeFeatureRequest: () => Promise.resolve(null),
+}))
+
+// ── Import route after mocks ───────────────────────────────────────────────────
+
+let GET: (
+  request: Request,
+  context: { params: Promise<{ name: string }> }
+) => Promise<Response>
+
+beforeAll(async () => {
+  const route = await import('../[name]/route')
+  GET = route.GET
+})
+
+beforeEach(() => {
+  mockFetchJson.mockClear()
+  mockGetClickHouseVersion.mockClear()
+  mockSelectVersionedSql.mockClear()
+  mockSelectQueryVariant.mockClear()
+  mockCheckTableAvailability.mockClear()
+  mockHasChart.mockClear()
+  mockGetChartQuery.mockClear()
+  mockGetAvailableCharts.mockClear()
+
+  // Reset default resolved values
+  mockFetchJson.mockResolvedValue({
+    dataJson: '[{"event_time":"2025-01-01","count":"5"}]',
+    metadata: { queryId: 'q1', duration: 10, rows: 1, host: '0' },
+  })
+  mockHasChart.mockReturnValue(true)
+  mockGetChartQuery.mockReturnValue({
+    query: 'SELECT event_time, count FROM system.query_log',
+    queryParams: undefined,
+  })
+  mockGetClickHouseVersion.mockResolvedValue({
+    raw: '24.1.1.1',
+    major: 24,
+    minor: 1,
+  })
+  mockCheckTableAvailability.mockResolvedValue({ exists: true, hasData: true })
+})
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function chartUrl(name: string, extra = '') {
+  return `http://localhost:3000/api/v1/charts/${name}?hostId=0${extra ? '&' + extra : ''}`
+}
+
+function chartRequest(name: string, extra = '') {
+  return new Request(chartUrl(name, extra))
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('GET /api/v1/charts/[name]', () => {
+  test('returns 200 with chart data for a valid single-query chart', async () => {
+    const res = await GET(chartRequest('test-chart'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data).toBeDefined()
+    expect(body.metadata).toBeDefined()
+    expect(body.metadata.queryId).toBe('q1')
+  })
+
+  test('passes timezone to fetchJson as clickhouse_settings', async () => {
+    await GET(chartRequest('test-chart', 'timezone=UTC'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(mockFetchJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clickhouse_settings: { session_timezone: 'UTC' },
+      })
+    )
+  })
+
+  test('passes valid interval through to query builder', async () => {
+    await GET(chartRequest('test-chart', 'interval=toStartOfTenMinutes'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(mockGetChartQuery).toHaveBeenCalledWith(
+      'test-chart',
+      expect.objectContaining({
+        interval: 'toStartOfTenMinutes',
+      })
+    )
+  })
+
+  test('passes valid lastHours to query builder', async () => {
+    await GET(chartRequest('test-chart', 'lastHours=48'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(mockGetChartQuery).toHaveBeenCalledWith(
+      'test-chart',
+      expect.objectContaining({ lastHours: 48 })
+    )
+  })
+
+  test('rejects invalid interval silently (passes undefined)', async () => {
+    await GET(chartRequest('test-chart', 'interval=DROP TABLE'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(mockGetChartQuery).toHaveBeenCalledWith(
+      'test-chart',
+      expect.objectContaining({ interval: undefined })
+    )
+  })
+
+  test('rejects non-numeric lastHours (passes undefined)', async () => {
+    await GET(chartRequest('test-chart', 'lastHours=abc'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(mockGetChartQuery).toHaveBeenCalledWith(
+      'test-chart',
+      expect.objectContaining({ lastHours: undefined })
+    )
+  })
+
+  test('rejects negative lastHours (passes undefined)', async () => {
+    await GET(chartRequest('test-chart', 'lastHours=-5'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(mockGetChartQuery).toHaveBeenCalledWith(
+      'test-chart',
+      expect.objectContaining({ lastHours: undefined })
+    )
+  })
+
+  test('returns 404 when chart name is not in registry', async () => {
+    mockHasChart.mockReturnValue(false)
+
+    const res = await GET(chartRequest('nonexistent-chart'), {
+      params: Promise.resolve({ name: 'nonexistent-chart' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.success).toBe(false)
+    expect(body.error.type).toBe('table_not_found')
+  })
+
+  test('returns 500 when query builder returns null', async () => {
+    mockGetChartQuery.mockReturnValue(null)
+
+    const res = await GET(chartRequest('test-chart'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(body.success).toBe(false)
+    expect(body.error.type).toBe('query_error')
+  })
+
+  test('uses VersionedSql when sql array is present on query def', async () => {
+    mockGetChartQuery.mockReturnValue({
+      sql: [
+        { since: '23.8', sql: 'SELECT old_col FROM t' },
+        { since: '24.1', sql: 'SELECT new_col FROM t' },
+      ],
+      query: 'SELECT fallback FROM t',
+    })
+
+    const res = await GET(chartRequest('test-chart'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockSelectVersionedSql).toHaveBeenCalled()
+    expect(mockSelectQueryVariant).not.toHaveBeenCalled()
+  })
+
+  test('uses deprecated variants when present and no sql array', async () => {
+    mockGetChartQuery.mockReturnValue({
+      query: 'SELECT fallback FROM t',
+      variants: [
+        { versions: { minVersion: '23.0' }, query: 'SELECT v1 FROM t' },
+      ],
+    })
+
+    const res = await GET(chartRequest('test-chart'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockSelectQueryVariant).toHaveBeenCalled()
+    expect(mockSelectVersionedSql).not.toHaveBeenCalled()
+  })
+
+  test('falls back to query string when no sql or variants', async () => {
+    mockGetChartQuery.mockReturnValue({
+      query: 'SELECT simple FROM t',
+    })
+
+    const res = await GET(chartRequest('test-chart'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockFetchJson).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'SELECT simple FROM t' })
+    )
+  })
+
+  test('returns error response when fetchJson returns an error', async () => {
+    mockFetchJson.mockResolvedValue({
+      error: {
+        type: 'query_error',
+        message: 'Syntax error in query',
+        details: undefined,
+      },
+    })
+
+    const res = await GET(chartRequest('test-chart'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(body.success).toBe(false)
+    expect(body.error.message).toContain('Syntax error')
+  })
+
+  test('maps network_error to 503 status code', async () => {
+    mockFetchJson.mockResolvedValue({
+      error: {
+        type: 'network_error',
+        message: 'Connection refused',
+        details: undefined,
+      },
+    })
+
+    const res = await GET(chartRequest('test-chart'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(res.status).toBe(503)
+  })
+
+  test('maps timeout_error to 504 status code', async () => {
+    mockFetchJson.mockResolvedValue({
+      error: {
+        type: 'timeout_error',
+        message: 'Query timed out',
+        details: undefined,
+      },
+    })
+
+    const res = await GET(chartRequest('test-chart'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(res.status).toBe(504)
+  })
+
+  test('maps validation_error to 400 status code', async () => {
+    mockFetchJson.mockResolvedValue({
+      error: {
+        type: 'validation_error',
+        message: 'Invalid params',
+        details: undefined,
+      },
+    })
+
+    const res = await GET(chartRequest('test-chart'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  test('returns empty data with table_not_found status when optional table does not exist', async () => {
+    mockGetChartQuery.mockReturnValue({
+      query: 'SELECT * FROM system.backup_log',
+      optional: true,
+      tableCheck: 'system.backup_log',
+    })
+    mockCheckTableAvailability.mockResolvedValue({
+      exists: false,
+      hasData: false,
+    })
+
+    const res = await GET(chartRequest('test-chart'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.metadata.status).toBe('table_not_found')
+    expect(body.data).toEqual([])
+  })
+
+  test('returns table_empty status when table exists but has no data', async () => {
+    mockGetChartQuery.mockReturnValue({
+      query: 'SELECT * FROM system.backup_log',
+      optional: true,
+      tableCheck: 'system.backup_log',
+    })
+    mockCheckTableAvailability.mockResolvedValue({
+      exists: true,
+      hasData: false,
+    })
+
+    const res = await GET(chartRequest('test-chart'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.metadata.status).toBe('table_empty')
+  })
+
+  test('returns empty status when query returns zero rows', async () => {
+    mockFetchJson.mockResolvedValue({
+      dataJson: '[]',
+      metadata: { queryId: 'q1', duration: 5, rows: 0, host: '0' },
+    })
+
+    const res = await GET(chartRequest('test-chart'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.metadata.status).toBe('empty')
+  })
+
+  test('sets correct Cache-Control for realtime policy', async () => {
+    mockGetChartQuery.mockReturnValue({
+      query: 'SELECT 1',
+      cachePolicy: 'realtime',
+    })
+
+    const res = await GET(chartRequest('test-chart'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(res.headers.get('Cache-Control')).toBe(
+      'public, s-maxage=10, stale-while-revalidate=30'
+    )
+  })
+
+  test('sets correct Cache-Control for historical policy', async () => {
+    mockGetChartQuery.mockReturnValue({
+      query: 'SELECT 1',
+      cachePolicy: 'historical',
+    })
+
+    const res = await GET(chartRequest('test-chart'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(res.headers.get('Cache-Control')).toBe(
+      'public, s-maxage=120, stale-while-revalidate=300'
+    )
+  })
+
+  test('sets default Cache-Control when no policy specified', async () => {
+    const res = await GET(chartRequest('test-chart'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(res.headers.get('Cache-Control')).toBe(
+      'public, s-maxage=30, stale-while-revalidate=60'
+    )
+  })
+})
+
+describe('GET /api/v1/charts/[name] — multi-query charts', () => {
+  beforeEach(() => {
+    mockGetChartQuery.mockReturnValue({
+      queries: [
+        {
+          key: 'running',
+          query: 'SELECT COUNT() as count FROM system.processes',
+        },
+        {
+          key: 'total',
+          query: 'SELECT COUNT() as count FROM system.query_log',
+        },
+      ],
+      cachePolicy: 'realtime' as const,
+    })
+  })
+
+  test('returns combined data for multi-query charts', async () => {
+    const res = await GET(chartRequest('summary-chart'), {
+      params: Promise.resolve({ name: 'summary-chart' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data).toBeDefined()
+    expect(body.data.running).toBeDefined()
+    expect(body.data.total).toBeDefined()
+    expect(body.metadata.sql).toContain('Query 1: running')
+    expect(body.metadata.sql).toContain('Query 2: total')
+  })
+
+  test('returns error in response but still 200 when a sub-query fails', async () => {
+    mockFetchJson
+      .mockResolvedValueOnce({
+        dataJson: '[{"count":"5"}]',
+        metadata: { queryId: 'q1', duration: 1, rows: 1, host: '0' },
+      })
+      .mockResolvedValueOnce({
+        error: { type: 'query_error', message: 'Table not found' },
+      })
+
+    const res = await GET(chartRequest('summary-chart'), {
+      params: Promise.resolve({ name: 'summary-chart' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(false)
+    expect(body.error).toBeDefined()
+    expect(body.error.message).toContain('Table not found')
+  })
+
+  test('returns success=false with error when all sub-queries throw', async () => {
+    mockFetchJson.mockRejectedValue(new Error('Connection lost'))
+
+    const res = await GET(chartRequest('summary-chart'), {
+      params: Promise.resolve({ name: 'summary-chart' }),
+    })
+    const body = await res.json()
+
+    // Individual sub-query exceptions are caught per-query, so outer handler returns 200
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(false)
+    expect(body.error.message).toContain('Connection lost')
+  })
+
+  test('handles individual sub-query exception gracefully', async () => {
+    mockFetchJson.mockRejectedValueOnce(new Error('Query 1 crashed'))
+
+    const res = await GET(chartRequest('summary-chart'), {
+      params: Promise.resolve({ name: 'summary-chart' }),
+    })
+    const body = await res.json()
+
+    // Individual query errors are caught and returned as null data with error
+    expect(res.status).toBe(200)
+    // The first query failed, so success is false
+    expect(body.success).toBe(false)
+    expect(body.error).toBeDefined()
+  })
+})
+
+describe('GET /api/v1/charts/[name] — params handling', () => {
+  test('passes valid JSON params to query builder', async () => {
+    await GET(chartRequest('test-chart', 'params={"database":"system"}'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(mockGetChartQuery).toHaveBeenCalledWith(
+      'test-chart',
+      expect.objectContaining({
+        params: { database: 'system' },
+      })
+    )
+  })
+
+  test('ignores invalid JSON params silently', async () => {
+    await GET(chartRequest('test-chart', 'params=not-json'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(mockGetChartQuery).toHaveBeenCalledWith(
+      'test-chart',
+      expect.objectContaining({ params: undefined })
+    )
+  })
+
+  test('ignores array JSON params silently', async () => {
+    await GET(chartRequest('test-chart', 'params=[1,2,3]'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(mockGetChartQuery).toHaveBeenCalledWith(
+      'test-chart',
+      expect.objectContaining({ params: undefined })
+    )
+  })
+
+  test('ignores null JSON params silently', async () => {
+    await GET(chartRequest('test-chart', 'params=null'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(mockGetChartQuery).toHaveBeenCalledWith(
+      'test-chart',
+      expect.objectContaining({ params: undefined })
+    )
+  })
+})
+
+describe('GET /api/v1/charts/[name] — timezone validation', () => {
+  test('accepts valid IANA timezone', async () => {
+    await GET(chartRequest('test-chart', 'timezone=America/New_York'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(mockFetchJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clickhouse_settings: { session_timezone: 'America/New_York' },
+      })
+    )
+  })
+
+  test('ignores invalid timezone silently', async () => {
+    await GET(chartRequest('test-chart', 'timezone=Invalid/Zone'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+
+    expect(mockFetchJson).toHaveBeenCalledWith(
+      expect.objectContaining({ clickhouse_settings: undefined })
+    )
+  })
+})
+
+describe('GET /api/v1/charts/[name] — tableCheck as array', () => {
+  test('handles tableCheck as string array, using first element', async () => {
+    mockGetChartQuery.mockReturnValue({
+      query: 'SELECT * FROM system.backup_log',
+      optional: true,
+      tableCheck: ['system.backup_log', 'system.backup_settings'],
+    })
+    mockCheckTableAvailability.mockResolvedValue({
+      exists: false,
+      hasData: false,
+    })
+
+    const res = await GET(chartRequest('test-chart'), {
+      params: Promise.resolve({ name: 'test-chart' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.metadata.status).toBe('table_not_found')
+    expect(mockCheckTableAvailability).toHaveBeenCalledWith(
+      0,
+      'system',
+      'backup_log'
+    )
+  })
+})

--- a/apps/web/app/api/v1/cluster-counts/__tests__/route.test.ts
+++ b/apps/web/app/api/v1/cluster-counts/__tests__/route.test.ts
@@ -1,0 +1,287 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockFetchData = mock(() =>
+  Promise.resolve({
+    data: [{ count: 42 }],
+    metadata: { queryId: 'q1', duration: 5, rows: 1, host: '0' },
+  })
+)
+
+mock.module('@chm/clickhouse-client', () => ({
+  fetchData: mockFetchData,
+  fetchJsonEachRowAsNormalizedJson: mock(() =>
+    Promise.resolve({ dataJson: '[]', metadata: {} })
+  ),
+  getClient: mock(() =>
+    Promise.resolve({
+      query: mock(() => Promise.resolve()),
+      command: mock(() => Promise.resolve()),
+    })
+  ),
+}))
+
+const mockHasClusterCountKey = mock(() => true)
+const mockGetClusterCountQuery = mock(() => ({
+  query:
+    'SELECT COUNT() as count FROM clusterAllReplicas({cluster: String}, system.replicas) WHERE is_readonly = 1',
+}))
+
+mock.module('@/lib/api/cluster-count-registry', () => ({
+  hasClusterCountKey: mockHasClusterCountKey,
+  getClusterCountQuery: mockGetClusterCountQuery,
+}))
+
+mock.module('@/lib/feature-permissions/server', () => ({
+  authorizeFeatureRequest: () => Promise.resolve(null),
+}))
+
+// ── Import route after mocks ───────────────────────────────────────────────────
+
+let GET: (
+  request: Request,
+  context: { params: Promise<{ key: string }> }
+) => Promise<Response>
+
+beforeAll(async () => {
+  const route = await import('../[key]/route')
+  GET = route.GET
+})
+
+beforeEach(() => {
+  mockFetchData.mockClear()
+  mockHasClusterCountKey.mockClear()
+  mockGetClusterCountQuery.mockClear()
+
+  mockFetchData.mockResolvedValue({
+    data: [{ count: 42 }],
+    metadata: { queryId: 'q1', duration: 5, rows: 1, host: '0' },
+  })
+  mockHasClusterCountKey.mockReturnValue(true)
+  mockGetClusterCountQuery.mockReturnValue({
+    query:
+      'SELECT COUNT() as count FROM clusterAllReplicas({cluster: String}, system.replicas) WHERE is_readonly = 1',
+  })
+})
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function countUrl(key: string, extra = '') {
+  return `http://localhost:3000/api/v1/cluster-counts/${key}?cluster=default&hostId=0${extra ? '&' + extra : ''}`
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('GET /api/v1/cluster-counts/[key]', () => {
+  test('returns count for a valid key with cluster and hostId', async () => {
+    const res = await GET(new Request(countUrl('readonly-tables-in-cluster')), {
+      params: Promise.resolve({ key: 'readonly-tables-in-cluster' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data.count).toBe(42)
+    expect(body.metadata.queryId).toBe(
+      'cluster-count-readonly-tables-in-cluster'
+    )
+  })
+
+  test('passes cluster as query_params to fetchData', async () => {
+    await GET(
+      new Request(
+        'http://localhost:3000/api/v1/cluster-counts/readonly-tables-in-cluster?cluster=my-cluster&hostId=0'
+      ),
+      { params: Promise.resolve({ key: 'readonly-tables-in-cluster' }) }
+    )
+
+    expect(mockFetchData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query_params: { cluster: 'my-cluster' },
+      })
+    )
+  })
+
+  test('returns 400 when cluster parameter is missing', async () => {
+    const res = await GET(
+      new Request(
+        'http://localhost:3000/api/v1/cluster-counts/readonly-tables-in-cluster?hostId=0'
+      ),
+      { params: Promise.resolve({ key: 'readonly-tables-in-cluster' }) }
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.success).toBe(false)
+    expect(body.error.message).toContain('cluster')
+  })
+
+  test('returns 400 when cluster parameter is empty string', async () => {
+    const res = await GET(
+      new Request(
+        'http://localhost:3000/api/v1/cluster-counts/readonly-tables-in-cluster?cluster=&hostId=0'
+      ),
+      { params: Promise.resolve({ key: 'readonly-tables-in-cluster' }) }
+    )
+
+    expect(res.status).toBe(400)
+  })
+
+  test('returns 400 for invalid count key format', async () => {
+    const res = await GET(
+      new Request(
+        'http://localhost:3000/api/v1/cluster-counts/bad%20key?cluster=default&hostId=0'
+      ),
+      { params: Promise.resolve({ key: 'bad key' }) }
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.success).toBe(false)
+    expect(body.error.message).toContain('Invalid count key format')
+  })
+
+  test('returns 404 when count key is not in registry', async () => {
+    mockHasClusterCountKey.mockReturnValue(false)
+
+    const res = await GET(new Request(countUrl('nonexistent-key')), {
+      params: Promise.resolve({ key: 'nonexistent-key' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.success).toBe(false)
+    expect(body.error.message).toContain('not found')
+  })
+
+  test('returns 404 when getClusterCountQuery returns null', async () => {
+    mockGetClusterCountQuery.mockReturnValue(null)
+
+    const res = await GET(new Request(countUrl('some-key')), {
+      params: Promise.resolve({ key: 'some-key' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.error.message).toContain('not found in registry')
+  })
+
+  test('returns 400 when hostId is invalid', async () => {
+    const res = await GET(
+      new Request(
+        'http://localhost:3000/api/v1/cluster-counts/readonly-tables-in-cluster?cluster=default&hostId=abc'
+      ),
+      { params: Promise.resolve({ key: 'readonly-tables-in-cluster' }) }
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error.message).toContain('hostId')
+  })
+
+  test('defaults hostId to 0 when not provided', async () => {
+    const res = await GET(
+      new Request(
+        'http://localhost:3000/api/v1/cluster-counts/readonly-tables-in-cluster?cluster=default'
+      ),
+      { params: Promise.resolve({ key: 'readonly-tables-in-cluster' }) }
+    )
+
+    expect(res.status).toBe(200)
+    expect(mockFetchData).toHaveBeenCalledWith(
+      expect.objectContaining({ hostId: 0 })
+    )
+  })
+
+  test('returns null count for optional table when query fails', async () => {
+    mockGetClusterCountQuery.mockReturnValue({
+      query: 'SELECT COUNT() FROM system.backup_log',
+      optional: true,
+    })
+    mockFetchData.mockResolvedValue({
+      error: { type: 'query_error', message: 'Table not found' },
+    })
+
+    const res = await GET(new Request(countUrl('optional-key')), {
+      params: Promise.resolve({ key: 'optional-key' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.data.count).toBeNull()
+  })
+
+  test('returns 500 when non-optional query fails', async () => {
+    mockFetchData.mockResolvedValue({
+      error: { type: 'query_error', message: 'Connection refused' },
+    })
+
+    const res = await GET(new Request(countUrl('readonly-tables-in-cluster')), {
+      params: Promise.resolve({ key: 'readonly-tables-in-cluster' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(body.success).toBe(false)
+    expect(body.error.message).toContain('Connection refused')
+  })
+
+  test('returns null count when data array is empty', async () => {
+    mockFetchData.mockResolvedValue({
+      data: [],
+      metadata: { queryId: 'q1', duration: 1, rows: 0, host: '0' },
+    })
+
+    const res = await GET(new Request(countUrl('readonly-tables-in-cluster')), {
+      params: Promise.resolve({ key: 'readonly-tables-in-cluster' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.data.count).toBeNull()
+  })
+
+  test('converts string count to number', async () => {
+    mockFetchData.mockResolvedValue({
+      data: [{ count: '100' }],
+      metadata: { queryId: 'q1', duration: 1, rows: 1, host: '0' },
+    })
+
+    const res = await GET(new Request(countUrl('readonly-tables-in-cluster')), {
+      params: Promise.resolve({ key: 'readonly-tables-in-cluster' }),
+    })
+    const body = await res.json()
+
+    expect(body.data.count).toBe(100)
+  })
+
+  test('handles unexpected exceptions with 500', async () => {
+    mockFetchData.mockRejectedValue(new Error('Unexpected crash'))
+
+    const res = await GET(new Request(countUrl('readonly-tables-in-cluster')), {
+      params: Promise.resolve({ key: 'readonly-tables-in-cluster' }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(body.success).toBe(false)
+    expect(body.error.message).toContain('Unexpected crash')
+  })
+
+  test('includes X-Request-ID header in response', async () => {
+    const res = await GET(new Request(countUrl('readonly-tables-in-cluster')), {
+      params: Promise.resolve({ key: 'readonly-tables-in-cluster' }),
+    })
+
+    expect(res.headers.get('X-Request-ID')).toBeTruthy()
+  })
+
+  test('sets SHORT Cache-Control header', async () => {
+    const res = await GET(new Request(countUrl('readonly-tables-in-cluster')), {
+      params: Promise.resolve({ key: 'readonly-tables-in-cluster' }),
+    })
+
+    expect(res.headers.get('Cache-Control')).toContain('s-maxage=30')
+  })
+})

--- a/apps/web/app/api/v1/cluster-counts/__tests__/route.test.ts
+++ b/apps/web/app/api/v1/cluster-counts/__tests__/route.test.ts
@@ -68,7 +68,7 @@ beforeEach(() => {
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
 function countUrl(key: string, extra = '') {
-  return `http://localhost:3000/api/v1/cluster-counts/${key}?cluster=default&hostId=0${extra ? '&' + extra : ''}`
+  return `http://localhost:3000/api/v1/cluster-counts/${key}?cluster=default&hostId=0${extra ? `&${extra}` : ''}`
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────────

--- a/apps/web/app/api/v1/dashboard/settings/__tests__/route.test.ts
+++ b/apps/web/app/api/v1/dashboard/settings/__tests__/route.test.ts
@@ -1,0 +1,317 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockQuery = mock(() =>
+  Promise.resolve({
+    json: () =>
+      Promise.resolve([
+        { key: 'theme', value: 'dark' },
+        { key: 'refreshInterval', value: '30' },
+      ]),
+  })
+)
+
+const mockCommand = mock(() => Promise.resolve({}))
+const mockGetClient = mock(() =>
+  Promise.resolve({
+    query: mockQuery,
+    command: mockCommand,
+  })
+)
+
+mock.module('@chm/clickhouse-client', () => ({
+  getClient: mockGetClient,
+  fetchData: mock(() => Promise.resolve({ data: [], metadata: {} })),
+  fetchJsonEachRowAsNormalizedJson: mock(() =>
+    Promise.resolve({ dataJson: '[]', metadata: {} })
+  ),
+}))
+
+mock.module('@/lib/feature-permissions/server', () => ({
+  authorizeFeatureRequest: () => Promise.resolve(null),
+}))
+
+// ── Import route after mocks ───────────────────────────────────────────────────
+
+let GET: (request: Request) => Promise<Response>
+let POST: (request: Request) => Promise<Response>
+
+beforeAll(async () => {
+  const route = await import('../route')
+  GET = route.GET
+  POST = route.POST
+})
+
+beforeEach(() => {
+  mockGetClient.mockClear()
+  mockQuery.mockClear()
+  mockCommand.mockClear()
+
+  mockGetClient.mockResolvedValue({
+    query: mockQuery,
+    command: mockCommand,
+  })
+  mockQuery.mockResolvedValue({
+    json: () =>
+      Promise.resolve([
+        { key: 'theme', value: 'dark' },
+        { key: 'refreshInterval', value: '30' },
+      ]),
+  })
+  mockCommand.mockResolvedValue({})
+})
+
+// ── GET tests ──────────────────────────────────────────────────────────────────
+
+describe('GET /api/v1/dashboard/settings', () => {
+  test('returns settings as key-value params', async () => {
+    const res = await GET(
+      new Request('http://localhost:3000/api/v1/dashboard/settings?hostId=0')
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data.params.theme).toBe('dark')
+    expect(body.data.params.refreshInterval).toBe('30')
+    expect(body.metadata.rows).toBe(2)
+  })
+
+  test('defaults hostId to 0 when not provided', async () => {
+    const res = await GET(
+      new Request('http://localhost:3000/api/v1/dashboard/settings')
+    )
+
+    expect(res.status).toBe(200)
+    expect(mockGetClient).toHaveBeenCalledWith({ hostId: 0 })
+  })
+
+  test('uses provided hostId', async () => {
+    const res = await GET(
+      new Request('http://localhost:3000/api/v1/dashboard/settings?hostId=2')
+    )
+
+    expect(res.status).toBe(200)
+    expect(mockGetClient).toHaveBeenCalledWith({ hostId: 2 })
+  })
+
+  test('returns 400 for invalid hostId', async () => {
+    const res = await GET(
+      new Request('http://localhost:3000/api/v1/dashboard/settings?hostId=-1')
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.success).toBe(false)
+  })
+
+  test('returns 400 for non-integer hostId', async () => {
+    const res = await GET(
+      new Request('http://localhost:3000/api/v1/dashboard/settings?hostId=1.5')
+    )
+
+    expect(res.status).toBe(400)
+  })
+
+  test('returns empty params when settings table has no rows', async () => {
+    mockQuery.mockResolvedValue({
+      json: () => Promise.resolve([]),
+    })
+
+    const res = await GET(
+      new Request('http://localhost:3000/api/v1/dashboard/settings?hostId=0')
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.data.params).toEqual({})
+    expect(body.metadata.rows).toBe(0)
+  })
+
+  test('returns empty response when table is missing (UNKNOWN_TABLE)', async () => {
+    mockQuery.mockRejectedValue(new Error('UNKNOWN_TABLE: ch_monitor.settings'))
+
+    const res = await GET(
+      new Request('http://localhost:3000/api/v1/dashboard/settings?hostId=0')
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data.params).toEqual({})
+  })
+
+  test('returns empty response when table is missing (Unknown table expression)', async () => {
+    mockQuery.mockRejectedValue(
+      new Error('Unknown table expression: ch_monitor.settings')
+    )
+
+    const res = await GET(
+      new Request('http://localhost:3000/api/v1/dashboard/settings?hostId=0')
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data.params).toEqual({})
+  })
+
+  test("returns empty response when table is missing (doesn't exist)", async () => {
+    mockQuery.mockRejectedValue(
+      new Error("Table ch_monitor.settings doesn't exist")
+    )
+
+    const res = await GET(
+      new Request('http://localhost:3000/api/v1/dashboard/settings?hostId=0')
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data.params).toEqual({})
+  })
+
+  test('returns 500 for other query errors', async () => {
+    mockQuery.mockRejectedValue(new Error('Connection refused'))
+
+    const res = await GET(
+      new Request('http://localhost:3000/api/v1/dashboard/settings?hostId=0')
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(body.success).toBe(false)
+    expect(body.error.message).toContain('Connection refused')
+  })
+})
+
+// ── POST tests ─────────────────────────────────────────────────────────────────
+
+describe('POST /api/v1/dashboard/settings', () => {
+  test('updates settings with valid params', async () => {
+    const res = await POST(
+      new Request('http://localhost:3000/api/v1/dashboard/settings', {
+        method: 'POST',
+        body: JSON.stringify({ params: { theme: 'light' }, hostId: 0 }),
+      })
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data.success).toBe(true)
+    expect(mockCommand).toHaveBeenCalled()
+  })
+
+  test('passes hostId to getClient', async () => {
+    await POST(
+      new Request('http://localhost:3000/api/v1/dashboard/settings', {
+        method: 'POST',
+        body: JSON.stringify({ params: { theme: 'light' }, hostId: 3 }),
+      })
+    )
+
+    expect(mockGetClient).toHaveBeenCalledWith({ hostId: 3 })
+  })
+
+  test('defaults hostId to 0 when not in body', async () => {
+    await POST(
+      new Request('http://localhost:3000/api/v1/dashboard/settings', {
+        method: 'POST',
+        body: JSON.stringify({ params: { theme: 'light' } }),
+      })
+    )
+
+    expect(mockGetClient).toHaveBeenCalledWith({ hostId: 0 })
+  })
+
+  test('returns 400 when params is missing', async () => {
+    const res = await POST(
+      new Request('http://localhost:3000/api/v1/dashboard/settings', {
+        method: 'POST',
+        body: JSON.stringify({}),
+      })
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.success).toBe(false)
+    expect(body.error.message).toContain('params')
+  })
+
+  test('returns 400 when params is an array', async () => {
+    const res = await POST(
+      new Request('http://localhost:3000/api/v1/dashboard/settings', {
+        method: 'POST',
+        body: JSON.stringify({ params: [1, 2, 3] }),
+      })
+    )
+
+    expect(res.status).toBe(400)
+  })
+
+  test('returns 400 when params is not an object', async () => {
+    const res = await POST(
+      new Request('http://localhost:3000/api/v1/dashboard/settings', {
+        method: 'POST',
+        body: JSON.stringify({ params: 'string-value' }),
+      })
+    )
+
+    expect(res.status).toBe(400)
+  })
+
+  test('returns 400 for invalid hostId', async () => {
+    const res = await POST(
+      new Request('http://localhost:3000/api/v1/dashboard/settings', {
+        method: 'POST',
+        body: JSON.stringify({ params: { theme: 'light' }, hostId: -1 }),
+      })
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.success).toBe(false)
+    expect(body.error.message).toContain('hostId')
+  })
+
+  test('returns 400 for non-integer hostId', async () => {
+    const res = await POST(
+      new Request('http://localhost:3000/api/v1/dashboard/settings', {
+        method: 'POST',
+        body: JSON.stringify({ params: { theme: 'light' }, hostId: 3.14 }),
+      })
+    )
+
+    expect(res.status).toBe(400)
+  })
+
+  test('returns 500 when command throws', async () => {
+    mockCommand.mockRejectedValue(new Error('Write failed'))
+
+    const res = await POST(
+      new Request('http://localhost:3000/api/v1/dashboard/settings', {
+        method: 'POST',
+        body: JSON.stringify({ params: { theme: 'light' }, hostId: 0 }),
+      })
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(body.success).toBe(false)
+    expect(body.error.message).toContain('Write failed')
+  })
+
+  test('handles string hostId in body', async () => {
+    const res = await POST(
+      new Request('http://localhost:3000/api/v1/dashboard/settings', {
+        method: 'POST',
+        body: JSON.stringify({ params: { theme: 'light' }, hostId: '2' }),
+      })
+    )
+
+    expect(res.status).toBe(200)
+    expect(mockGetClient).toHaveBeenCalledWith({ hostId: 2 })
+  })
+})


### PR DESCRIPTION
## Summary
Add unit tests for 3 API route handlers to boost coverage.

## Coverage Targets
| Route | Before | Target |
|-------|--------|--------|
| charts/[name] | 15% | 80%+ |
| cluster-counts/[key] | 10% | 80%+ |
| dashboard/settings | 17% | 80%+ |

## Test Strategy
- Mock `@chm/clickhouse-client`, `@chm/clickhouse-client/clickhouse-version`, chart/cluster registries, feature permissions
- Test GET handler with valid/invalid/missing params
- Test error paths: query errors, network errors, timeouts, table not found
- Test multi-query charts (combined data, partial failures)
- Test POST handler (dashboard settings)
- Test versioned SQL selection (VersionedSql[], deprecated variants, fallback)
- Test optional table availability checks
- Test cache policy headers
- Test timezone and interval validation

## Test Count
- Charts: 33 tests
- Cluster-counts: 16 tests
- Dashboard settings: 20 tests
- **Total: 69 tests, all passing**

## Files Changed
- `apps/web/app/api/v1/charts/__tests__/route.test.ts` (new)
- `apps/web/app/api/v1/cluster-counts/__tests__/route.test.ts` (new)
- `apps/web/app/api/v1/dashboard/settings/__tests__/route.test.ts` (new)

🤖 Generated with [Claude Code](https://claude.ai/code)