### PR TITLE
fix(data-table): re-render memoized body on row expansion

### DIFF
--- a/apps/web/components/data-table/components/data-table-content.tsx
+++ b/apps/web/components/data-table/components/data-table-content.tsx
@@ -128,6 +128,14 @@ export interface DataTableContentProps<
   offerViewToggle?: boolean
   /** Callback when the user switches view. */
   onViewChange?: (view: 'table' | 'cards') => void
+  /**
+   * Render signature of the row-affecting table state, computed by the parent
+   * (which re-renders on every controlled-state change). Because this component
+   * is memoized and `table` has a stable identity, the parent MUST pass this so
+   * the memo busts when state like `expanded` changes. Falls back to a local
+   * computation only when omitted.
+   */
+  bodyRenderKey?: string
 }
 
 /**
@@ -168,6 +176,7 @@ export const DataTableContent = memo(function DataTableContent<
   view = 'table',
   offerViewToggle = false,
   onViewChange,
+  bodyRenderKey,
 }: DataTableContentProps<TData, TValue>) {
   const cardsOnly = view === 'cards'
   // Configure drag-and-drop sensors
@@ -199,19 +208,24 @@ export const DataTableContent = memo(function DataTableContent<
     .filter((id) => id !== EXPAND_COLUMN_ID && id !== 'select')
 
   // The memoized body reads row output from the stable `table` instance, so it
-  // needs an explicit signal to re-render when that output changes. Capture the
-  // state slices that affect rows/cells (order is set via columnOrder so it is
-  // covered) into a key the body memo can compare.
+  // needs an explicit signal to re-render when that output changes. The parent
+  // (DataTable) computes this from its controlled state and passes it in — that
+  // matters because THIS component is memoized: state like `expanded` does not
+  // change any prop here, so without the parent-provided key the memo would
+  // never bust and expansion (chevron + detail row) would silently no-op.
+  // The local computation is only a fallback for callers that don't pass it.
   const bodyState = table.getState()
-  const bodyRenderKey = JSON.stringify([
-    bodyState.sorting,
-    bodyState.pagination,
-    bodyState.expanded,
-    bodyState.columnSizing,
-    bodyState.columnOrder,
-    bodyState.columnVisibility,
-    bodyState.rowSelection,
-  ])
+  const resolvedRenderKey =
+    bodyRenderKey ??
+    JSON.stringify([
+      bodyState.sorting,
+      bodyState.pagination,
+      bodyState.expanded,
+      bodyState.columnSizing,
+      bodyState.columnOrder,
+      bodyState.columnVisibility,
+      bodyState.rowSelection,
+    ])
 
   const tableContent = (
     <Table
@@ -241,7 +255,7 @@ export const DataTableContent = memo(function DataTableContent<
           activeFilterCount={activeFilterCount}
           rowClassName={queryConfig.rowClassName}
           expandable={expandable}
-          renderKey={bodyRenderKey}
+          renderKey={resolvedRenderKey}
         />
       </TableBody>
     </Table>

--- a/apps/web/components/data-table/data-table.tsx
+++ b/apps/web/components/data-table/data-table.tsx
@@ -495,6 +495,23 @@ export function DataTable<
     },
   })
 
+  // Render signature for the memoized table body. Computed HERE (not inside the
+  // memoized DataTableContent) because DataTable re-renders on every controlled
+  // state change (sorting, expanded, columnSizing, rowSelection, ...) whereas
+  // DataTableContent's props are otherwise stable — so a state change like
+  // `expanded` would never reach the memo and row expansion would silently
+  // no-op. Passing this down guarantees the body memo busts when rows change.
+  const tableState = table.getState()
+  const bodyRenderKey = JSON.stringify([
+    tableState.sorting,
+    tableState.pagination,
+    tableState.expanded,
+    tableState.columnSizing,
+    tableState.columnOrder,
+    tableState.columnVisibility,
+    tableState.rowSelection,
+  ])
+
   // Virtual rows for datasets larger than the standard pagination range.
   // Disabled when row expansion is on because expanded rows add out-of-band
   // height the fixed-size virtualizer can't account for.
@@ -605,6 +622,7 @@ export function DataTable<
           view={view}
           offerViewToggle={offerViewToggle}
           onViewChange={setView}
+          bodyRenderKey={bodyRenderKey}
         />
 
         <DataTableFooter table={table} footnote={footnote} compact={compact} />


### PR DESCRIPTION
## Problem
Row expansion silently no-opped on every table that opts in (reported on **/keeper/connections**; also affects **/readonly-tables**). Clicking the expand chevron did nothing — no detail row, chevron never rotated.

## Root cause (verified live via React-fiber inspection)
The TanStack state **was** updating correctly — `row.getIsExpanded()` returned `true` and `table.getState().expanded` was `{"0":true}`. But the DOM stayed stale: the body's `renderKey` still encoded `expanded: {}`.

`bodyRenderKey` (the string that busts the memoized table body) was computed **inside** the `memo`-wrapped `DataTableContent`, from `table.getState()`. The `table` instance has a **stable identity**, so when `expanded` changes only the parent `DataTable` re-renders (it owns the `useState`); `DataTableContent`'s props are unchanged → its memo **skips** → the key never recomputes → the body memo sees a stale key → chevron + `ExpandedRow` never re-render.

Sorting/column-sizing happen to change other props, so they slipped through; `expanded` had no corresponding prop, so it was the one uniquely-dead interaction.

## Fix
Lift the `bodyRenderKey` computation up to `DataTable` (which re-renders on every controlled-state change) and pass it as a prop. The changed string prop busts `DataTableContent`'s memo, which forwards the key to the body memo. The internal computation is kept as a fallback for callers that don't pass it — so the change is additive.

## Verification
- Live fiber probe: state `{"0":true}` while body `renderKey` expanded-slice was `{}` — exactly this stale-memo path.
- Existing `data-table-expandable.cy.tsx` component test exercises this; CI validates.
- Post-deploy I'll re-verify expand on /keeper/connections and /readonly-tables.

Co-Authored-By: duyetbot <bot@duyet.net>