### PR TITLE
fix(charts): stop dictionary-count 500 + resilient chart route

### DIFF
--- a/apps/web/app/api/v1/charts/[name]/route.ts
+++ b/apps/web/app/api/v1/charts/[name]/route.ts
@@ -168,9 +168,36 @@ async function handleMultiQueryChart(
 }
 
 /**
- * Handle GET requests for chart data
+ * GET requests for chart data.
+ *
+ * Thin wrapper that guarantees any *uncaught* exception from the handler is
+ * returned as a structured JSON error instead of an empty-body 500 (which is
+ * what an unhandled throw produces on Workers). Returned query errors are
+ * already handled inside the handler; this only catches the unexpected.
  */
 export async function GET(
+  request: Request,
+  ctx: { params: Promise<{ name: string }> }
+): Promise<Response> {
+  try {
+    return await handleChartGet(request, ctx)
+  } catch (err) {
+    error('[GET /api/v1/charts/[name]] Unhandled exception:', err)
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.QueryError,
+        message: err instanceof Error ? err.message : 'Unknown error',
+      },
+      500,
+      { ...ROUTE_CONTEXT_BASE, method: 'GET' } as RouteContext
+    )
+  }
+}
+
+/**
+ * Handle GET requests for chart data
+ */
+async function handleChartGet(
   request: Request,
   { params }: { params: Promise<{ name: string }> }
 ): Promise<Response> {

--- a/apps/web/lib/api/charts/dictionary-charts.ts
+++ b/apps/web/lib/api/charts/dictionary-charts.ts
@@ -7,6 +7,11 @@ import type { ChartQueryBuilder } from './types'
 
 export const dictionaryCharts: Record<string, ChartQueryBuilder> = {
   'dictionary-count': () => ({
+    // `system.dictionaries` exists on all supported versions, but mark the chart
+    // optional + tableCheck so deployments without it (or with a restricted
+    // grant) degrade to an empty state instead of erroring with a 500.
+    optional: true,
+    tableCheck: 'system.dictionaries',
     query: `
       SELECT
         status,


### PR DESCRIPTION
## Problem
`/api/v1/charts/dictionary-count` returned an **empty-body 500** on production, so the chart on `/dictionaries` failed. (The client-side "Unknown chart" error was already fixed in #1258; this is the server side.)

An empty-body 500 on Workers is the signature of an **unhandled throw** — the chart route's single-query path had no top-level try/catch, so any exception escaped with no diagnostics.

## Fix
1. **`dictionary-count` builder**: add `optional: true` + `tableCheck: 'system.dictionaries'` so deployments without the table (or with a restricted grant) degrade to an empty state instead of erroring — supports all versions/setups.
2. **Resilient chart route**: `GET` is now a thin wrapper that try/catches the handler. Unhandled exceptions return a structured JSON `QueryError` (with message) and are logged, instead of an opaque empty 500. This makes *every* chart fail gracefully and surfaces the real cause.

## Follow-up
Post-deploy I'll re-check the endpoint; if a query-level error remains it will now be visible as JSON (not an empty 500) for a precise fix. The `count` field name is preserved so the `dictionary-count` client component is unaffected.

Co-Authored-By: duyetbot <bot@duyet.net>