### PR TITLE
feat(data-table): SQL-hero mobile cards + table/card toggle on mobile

### DIFF
--- a/apps/web/components/data-table/components/data-table-content.cy.tsx
+++ b/apps/web/components/data-table/components/data-table-content.cy.tsx
@@ -62,6 +62,9 @@ describe('<DataTableContent />', () => {
     onColumnOrderChange,
     virtualizer = defaultProps.virtualizer,
     columnVisibility,
+    view,
+    offerViewToggle,
+    onViewChange,
   }: {
     rows?: Row[]
     activeFilterCount?: number
@@ -72,6 +75,9 @@ describe('<DataTableContent />', () => {
     onColumnOrderChange?: (activeId: string, overId: string) => void
     virtualizer?: (typeof defaultProps)['virtualizer']
     columnVisibility?: Record<string, boolean>
+    view?: 'table' | 'cards' | 'auto'
+    offerViewToggle?: boolean
+    onViewChange?: (view: 'table' | 'cards') => void
   }) {
     const table = useReactTable({
       data: rows,
@@ -92,6 +98,9 @@ describe('<DataTableContent />', () => {
         queryConfig={config}
         table={table}
         virtualizer={virtualizer}
+        view={view}
+        offerViewToggle={offerViewToggle}
+        onViewChange={onViewChange}
       />
     )
   }
@@ -265,5 +274,39 @@ describe('<DataTableContent />', () => {
 
     cy.get('[data-testid="mobile-table-card"]').should('have.length', 1)
     cy.get('[data-testid="mobile-table-card"]').should('contain', 'val2')
+  })
+
+  it('offers a view toggle when opted in and reflects it to the caller', () => {
+    const onViewChange = cy.stub().as('onViewChange')
+    cy.mount(
+      <TestDataTableContent
+        view="auto"
+        offerViewToggle={true}
+        onViewChange={onViewChange}
+      />
+    )
+
+    cy.get('[role="group"][aria-label="Result view"]').should('be.visible')
+    cy.contains('button', 'Cards').click()
+    cy.get('@onViewChange').should('have.been.calledWith', 'cards')
+  })
+
+  it('forces the full table on mobile when the user picks table view', () => {
+    // The bug this guards against: phones were stuck in cards because the
+    // table/card split was CSS-breakpoint-only. With an explicit table choice
+    // the real table must show even on a narrow viewport.
+    cy.viewport(375, 667)
+    cy.mount(<TestDataTableContent view="table" offerViewToggle={true} />)
+
+    cy.get('table').should('be.visible')
+    cy.get('[data-testid="mobile-table-card"]').should('not.be.visible')
+  })
+
+  it('keeps cards on mobile by default (auto)', () => {
+    cy.viewport(375, 667)
+    cy.mount(<TestDataTableContent view="auto" offerViewToggle={true} />)
+
+    cy.get('[data-testid="mobile-table-card"]').should('be.visible')
+    cy.get('table').should('not.be.visible')
   })
 })

--- a/apps/web/components/data-table/components/data-table-content.tsx
+++ b/apps/web/components/data-table/components/data-table-content.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/components/data-table/renderers'
 import { Button } from '@/components/ui/button'
 import { Table, TableBody, TableHeader } from '@/components/ui/table'
+import { useIsMobile } from '@/hooks/use-mobile'
 import { cn } from '@/lib/utils'
 
 /** Segmented table/cards toggle shown above the content when offered. */
@@ -34,9 +35,13 @@ function ViewToggle({
   view,
   onViewChange,
 }: {
-  view: 'table' | 'cards'
+  view: 'table' | 'cards' | 'auto'
   onViewChange?: (view: 'table' | 'cards') => void
 }) {
+  // `'auto'` is resolved per breakpoint so the pressed state reflects what the
+  // user is actually looking at (cards on phones, table on wider screens).
+  const isMobile = useIsMobile()
+  const active = view === 'auto' ? (isMobile ? 'cards' : 'table') : view
   return (
     <div
       className="inline-flex items-center gap-0.5 rounded-md border border-border/60 p-0.5"
@@ -45,10 +50,10 @@ function ViewToggle({
     >
       <Button
         type="button"
-        variant={view === 'table' ? 'secondary' : 'ghost'}
+        variant={active === 'table' ? 'secondary' : 'ghost'}
         size="sm"
         className="h-7 gap-1.5 px-2 text-xs"
-        aria-pressed={view === 'table'}
+        aria-pressed={active === 'table'}
         onClick={() => onViewChange?.('table')}
       >
         <Table2 className="size-3.5" />
@@ -56,10 +61,10 @@ function ViewToggle({
       </Button>
       <Button
         type="button"
-        variant={view === 'cards' ? 'secondary' : 'ghost'}
+        variant={active === 'cards' ? 'secondary' : 'ghost'}
         size="sm"
         className="h-7 gap-1.5 px-2 text-xs"
-        aria-pressed={view === 'cards'}
+        aria-pressed={active === 'cards'}
         onClick={() => onViewChange?.('cards')}
       >
         <LayoutGrid className="size-3.5" />
@@ -122,8 +127,12 @@ export interface DataTableContentProps<
   compact?: boolean
   /** When set, rows render an expand chevron and clicking a row toggles a detail panel below it. */
   expandable?: true | ExpandableConfig
-  /** Active view. `'cards'` renders the card layout at all breakpoints. */
-  view?: 'table' | 'cards'
+  /**
+   * Active view. `'cards'`/`'table'` force that layout at every breakpoint;
+   * `'auto'` (the default) is CSS-responsive — cards on mobile, table on
+   * desktop.
+   */
+  view?: 'table' | 'cards' | 'auto'
   /** Show the table/cards toggle control above the content. */
   offerViewToggle?: boolean
   /** Callback when the user switches view. */
@@ -173,12 +182,18 @@ export const DataTableContent = memo(function DataTableContent<
   onResetColumnOrder: _onResetColumnOrder,
   compact = false,
   expandable,
-  view = 'table',
+  view = 'auto',
   offerViewToggle = false,
   onViewChange,
   bodyRenderKey,
 }: DataTableContentProps<TData, TValue>) {
   const cardsOnly = view === 'cards'
+  // Visibility per layout. `'auto'` keeps the responsive split (cards only
+  // below `sm`, table only at `sm`+); an explicit choice wins at every width.
+  const cardsVisibility =
+    view === 'cards' ? 'block' : view === 'table' ? 'hidden' : 'sm:hidden'
+  const tableVisibility =
+    view === 'cards' ? 'hidden' : view === 'table' ? 'block' : 'hidden sm:block'
   // Configure drag-and-drop sensors
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -283,9 +298,9 @@ export const DataTableContent = memo(function DataTableContent<
         aria-label={`${title || 'Data'} table`}
         style={isVirtualized ? { height: '60vh' } : undefined}
       >
-        {/* Card layout: always on mobile, and at all widths when view==='cards'. */}
+        {/* Card layout: on mobile by default, and at all widths when view==='cards'. */}
         {!compact && (
-          <div className={cn('p-3', cardsOnly ? 'block' : 'sm:hidden')}>
+          <div className={cn('p-3', cardsVisibility)}>
             <MobileTableCards
               table={table}
               title={title}
@@ -297,9 +312,7 @@ export const DataTableContent = memo(function DataTableContent<
             />
           </div>
         )}
-        <div
-          className={cn(cardsOnly ? 'hidden' : !compact && 'hidden sm:block')}
-        >
+        <div className={cn(compact ? undefined : tableVisibility)}>
           {enableColumnReordering ? (
             <DndContext
               sensors={sensors}

--- a/apps/web/components/data-table/components/mobile-table-cards.tsx
+++ b/apps/web/components/data-table/components/mobile-table-cards.tsx
@@ -5,6 +5,7 @@ import {
   Check,
   ChevronDown,
   ChevronRight,
+  Code2,
   RotateCcw,
   SearchX,
   SortAsc,
@@ -57,6 +58,9 @@ const PRIMARY_COLUMN_PRIORITY = [
   'table',
   'name',
 ]
+// Primary columns that carry SQL — rendered as a highlighted monospace block
+// (the "hero") at the top of the card so it reads first.
+const SQL_PRIMARY_COLUMNS = new Set(['query', 'query_detail'])
 
 function formatColumnLabel(columnId: string) {
   return columnId.replaceAll('_', ' ')
@@ -168,15 +172,23 @@ const MobileTableCard = function MobileTableCard<TData extends RowData>({
   const cells = row.getVisibleCells()
   const selectCell = cells.find((cell) => cell.column.id === 'select')
   const actionCell = cells.find((cell) => cell.column.id === 'action')
+  const kindCell = cells.find((cell) => cell.column.id === 'query_kind')
   const primaryCell = pickPrimaryCell(cells)
+  // Every non-utility cell stays as a label/value row, except the primary (it
+  // becomes the hero) and the query kind (surfaced as a header badge instead).
   const detailCells = cells.filter(
     (cell) =>
-      cell.id !== primaryCell?.id && !UTILITY_COLUMNS.has(cell.column.id)
+      cell.id !== primaryCell?.id &&
+      cell.id !== kindCell?.id &&
+      !UTILITY_COLUMNS.has(cell.column.id)
   )
+  const isSqlPrimary =
+    !!primaryCell && SQL_PRIMARY_COLUMNS.has(primaryCell.column.id)
   const customClass = rowClassName?.(row.original as Record<string, unknown>)
   const isExpandable = !!expandable && row.getCanExpand()
   const isExpanded = isExpandable && row.getIsExpanded()
   const ExpandIcon = isExpanded ? ChevronDown : ChevronRight
+  const hasHeader = isExpandable || !!selectCell || !!kindCell || !!actionCell
 
   return (
     <article
@@ -187,52 +199,77 @@ const MobileTableCard = function MobileTableCard<TData extends RowData>({
         customClass
       )}
     >
-      <div className="flex min-w-0 items-start gap-2">
-        {isExpandable && (
-          <button
-            type="button"
-            onClick={() => row.toggleExpanded()}
-            aria-expanded={isExpanded}
-            aria-label={isExpanded ? 'Collapse row' : 'Expand row'}
-            className="-ml-1 mt-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-            data-testid="mobile-table-card-expand"
-          >
-            <ExpandIcon className="size-4" />
-          </button>
-        )}
+      {hasHeader && (
+        <div className="mb-2.5 flex min-w-0 items-center gap-2">
+          {isExpandable && (
+            <button
+              type="button"
+              onClick={() => row.toggleExpanded()}
+              aria-expanded={isExpanded}
+              aria-label={isExpanded ? 'Collapse row' : 'Expand row'}
+              className="-ml-1 inline-flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              data-testid="mobile-table-card-expand"
+            >
+              <ExpandIcon className="size-4" />
+            </button>
+          )}
 
-        {selectCell && (
-          <div className="-ml-1 shrink-0 pt-1">
-            {flexRender(
-              selectCell.column.columnDef.cell,
-              selectCell.getContext()
-            )}
-          </div>
-        )}
-
-        {primaryCell && (
-          <div className="min-w-0 flex-1">
-            <div className="mb-1 text-[0.68rem] font-medium uppercase text-muted-foreground">
-              {formatColumnLabel(primaryCell.column.id)}
-            </div>
-            <div className="min-w-0 text-sm font-medium text-foreground [&_*]:max-w-full [&_button]:justify-start [&_code]:whitespace-normal">
+          {selectCell && (
+            <div className="-ml-1 shrink-0">
               {flexRender(
-                primaryCell.column.columnDef.cell,
-                primaryCell.getContext()
+                selectCell.column.columnDef.cell,
+                selectCell.getContext()
               )}
             </div>
-          </div>
-        )}
+          )}
 
-        {actionCell && (
-          <div className="-mr-1 shrink-0">
+          {kindCell && (
+            <div className="min-w-0 [&_*]:max-w-full">
+              {flexRender(
+                kindCell.column.columnDef.cell,
+                kindCell.getContext()
+              )}
+            </div>
+          )}
+
+          {actionCell && (
+            <div className="-mr-1 ml-auto shrink-0">
+              {flexRender(
+                actionCell.column.columnDef.cell,
+                actionCell.getContext()
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {primaryCell && (
+        <div
+          data-testid="mobile-table-card-primary"
+          className={cn(
+            'min-w-0 rounded-md border border-border/50 p-2.5',
+            isSqlPrimary ? 'bg-muted/60' : 'bg-muted/30'
+          )}
+        >
+          <div className="mb-1.5 flex items-center gap-1.5 text-[0.62rem] font-semibold uppercase tracking-wider text-muted-foreground">
+            {isSqlPrimary && <Code2 className="size-3 shrink-0" />}
+            {formatColumnLabel(primaryCell.column.id)}
+          </div>
+          <div
+            className={cn(
+              'min-w-0 text-foreground',
+              isSqlPrimary
+                ? 'font-mono text-[0.8rem] leading-relaxed [&_button]:!h-auto [&_button]:!max-w-full [&_button]:items-start [&_code]:line-clamp-4 [&_code]:!whitespace-pre-wrap [&_code]:!break-words [&_code]:!text-foreground'
+                : 'text-sm font-medium [&_*]:max-w-full [&_button]:justify-start [&_code]:whitespace-normal'
+            )}
+          >
             {flexRender(
-              actionCell.column.columnDef.cell,
-              actionCell.getContext()
+              primaryCell.column.columnDef.cell,
+              primaryCell.getContext()
             )}
           </div>
-        )}
-      </div>
+        </div>
+      )}
 
       {detailCells.length > 0 && (
         <dl className="mt-3 divide-y divide-border/50">

--- a/apps/web/components/data-table/data-table.tsx
+++ b/apps/web/components/data-table/data-table.tsx
@@ -523,10 +523,15 @@ export function DataTable<
 
   // Card vs. table view. Only offered (with a toolbar toggle) when the config
   // opts in via `defaultView`; otherwise tables behave exactly as before.
+  //
+  // The effective view is `'auto'` (CSS-responsive: cards on mobile, table on
+  // desktop — the historical default) until the user explicitly picks one with
+  // the toggle. Once picked, that choice applies at every breakpoint, so phone
+  // users can switch a card list back to the full table and vice versa.
   const offerViewToggle = queryConfig.defaultView !== undefined
-  const [view, setView] = useState<'table' | 'cards'>(
-    queryConfig.defaultView ?? 'table'
-  )
+  const [userView, setUserView] = useState<'table' | 'cards' | null>(null)
+  const baseView: 'table' | 'cards' | 'auto' = queryConfig.defaultView ?? 'auto'
+  const view = userView ?? baseView
 
   // Auto-fit columns functionality
   const { autoFitColumn } = useAutoFitColumns<TData>(tableContainerRef)
@@ -621,7 +626,7 @@ export function DataTable<
           expandable={expandable}
           view={view}
           offerViewToggle={offerViewToggle}
-          onViewChange={setView}
+          onViewChange={setUserView}
           bodyRenderKey={bodyRenderKey}
         />
 

--- a/apps/web/lib/query-config/queries/history-queries.ts
+++ b/apps/web/lib/query-config/queries/history-queries.ts
@@ -254,6 +254,9 @@ export const historyQueryFilterSchema: FilterSchema = {
 
 export const historyQueriesConfig: QueryConfig = {
   name: 'history-queries',
+  // Cards on phones (the wide query_log table is unreadable in a scroll box),
+  // table on desktop — with a toggle so either view is reachable anywhere.
+  defaultView: 'auto',
   description:
     'Contains information about executed queries: start time, duration of processing, error messages',
   docs: QUERY_LOG,

--- a/apps/web/types/query-config.ts
+++ b/apps/web/types/query-config.ts
@@ -416,12 +416,15 @@ export interface QueryConfig<TColumns extends readonly string[] = string[]> {
   /**
    * Default rendering for the result set. `'cards'` renders each row as a card
    * (reusing the responsive card layout) instead of a wide table — better UX
-   * for low-cardinality, wide tables like clusters or disks. When set, a
-   * table/cards toggle is offered in the toolbar so users can switch.
+   * for low-cardinality, wide tables like clusters or disks. `'auto'` keeps the
+   * responsive default (cards on mobile, table on desktop) while still offering
+   * the toggle, so phone users can opt back into the table. When set (including
+   * `'auto'`), a table/cards toggle is offered in the toolbar so users can
+   * switch, and the chosen view then applies at every breakpoint.
    *
    * @default 'table'
    */
-  defaultView?: 'table' | 'cards'
+  defaultView?: 'table' | 'cards' | 'auto'
   /**
    * Bulk actions available for selected rows (shown in toolbar).
    * These actions apply to all selected rows at once.


### PR DESCRIPTION
## Problem

On mobile, the **History Queries** table renders as cards (the wide `system.query_log` table is unreadable in a horizontal scroll box) — but the card/table split was **CSS-breakpoint-only**, so phone users were stuck in cards with **no way back to the table**. The card also buried the SQL: a cramped truncated line above 12 equal-weight metadata rows.

## Changes

**Toggle works at every breakpoint**
- New `defaultView: 'auto'` — cards on mobile, table on desktop (the historical responsive default) *and* offers the toggle.
- The view becomes the single source of truth once the user picks one: a phone user can switch a card list back to the full table, and a desktop user can switch to cards. Until they pick, `'auto'` stays pure-CSS (no hydration flash).
- The toggle resolves `'auto'` per breakpoint for its pressed state.
- Existing `defaultView: 'cards'` pages (clusters, disks) are unchanged in default; their toggle now also works on mobile. Pages with no `defaultView` are completely unchanged.

**Redesigned mobile card — SQL first**
- SQL leads as a highlighted, monospace, tappable-to-expand **hero block** (`focus on query sql first, make it highlight more`).
- Query kind surfaced as a header badge; **all other fields kept** as label/value rows below.

## Scope
- History Queries gets this via `defaultView: 'auto'`. (Running Queries — a separate custom table — is handled in a follow-up PR.)

## Tests
- `data-table-content.cy.tsx`: added cases — offers the toggle & reports the choice; **forces the full table on mobile** when the user picks table; keeps cards on mobile by default. All 21 specs pass locally (plus `data-table.cy.tsx`).

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced responsive "auto" view mode for data tables that intelligently switches between table and card layouts based on screen size.
  * Users can now manually toggle between table and card views via a view control in the toolbar.
  * Enhanced mobile card rendering with improved SQL query display, including syntax highlighting and dedicated styling.

* **Tests**
  * Added test coverage for view toggle functionality and responsive behavior on mobile devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->