### PR TITLE
feat(agent): workflow harness with dynamic workflow templates

### DIFF
--- a/.agents/skills/system-tables-reference/SKILL.md
+++ b/.agents/skills/system-tables-reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: system-tables-reference
-description: "Exact column names for the system tables the agent queries most (processes, query_log, parts, merges, replicas, metrics) plus rules for choosing dedicated tools over raw SQL. Load before hand-writing SQL against system tables."
+description: "Exact column names for the system tables the agent queries most (processes, query_log, parts, merges, mutations, replicas, replication_queue, disks, settings, zookeeper, users/grants, metrics) plus rules for choosing dedicated tools over raw SQL. Load before hand-writing SQL against system tables."
 ---
 
 # System Tables Reference
@@ -108,6 +108,76 @@ These three are easy to confuse — they use different column names:
 
 Columns: `name`, `code`, `value`, `last_error_time`, `last_error_message`,
 `last_error_trace`. There is no `last_update_time` column.
+
+## system.mutations — ALTER UPDATE/DELETE progress
+
+One row per mutation. Columns: `database`, `table`, `mutation_id`, `command`,
+`create_time`, `parts_to_do`, `parts_to_do_names`, `is_done`,
+`latest_failed_part`, `latest_fail_time`, `latest_fail_reason`.
+
+- Stuck mutation = `is_done = 0` with a non-empty `latest_fail_reason`.
+- Prefer the `get_mutations` tool. `parts_to_do > 0` means still running.
+
+## system.replication_queue — pending replication tasks
+
+Columns: `database`, `table`, `type`, `create_time`, `num_tries`,
+`last_exception`, `last_attempt_time`, `num_postponed`, `postpone_reason`,
+`node_name`, `is_currently_executing`. High `num_tries` + `last_exception`
+signals a stuck entry. Prefer the `get_replication_queue` tool.
+
+## system.disks — storage devices
+
+Columns: `name`, `path`, `free_space`, `total_space`, `unreserved_space`,
+`keep_free_space`, `type`. Used % = `(total_space - free_space) / total_space`.
+Prefer the `get_disk_usage` tool.
+
+## system.detached_parts — parts needing attention
+
+Columns: `database`, `table`, `partition_id`, `name`, `disk`, `reason`,
+`bytes_on_disk`. A non-null `reason` (e.g. `broken`, `unexpected`) flags parts
+that won't be merged. Prefer the `get_detached_parts` tool.
+
+## system.settings vs system.merge_tree_settings — configuration
+
+- `system.settings`: session/server settings. Columns `name`, `value`,
+  `changed`, `default`, `description`, `type`, `readonly`. Filter `changed = 1`
+  for non-default values. Prefer the `get_settings` tool.
+- `system.merge_tree_settings`: MergeTree engine settings, same columns. Prefer
+  the `get_mergetree_settings` tool.
+
+## system.zookeeper / Keeper — coordination
+
+`system.zookeeper` is an **optional** table that only exists when ZooKeeper or
+ClickHouse Keeper is configured. Querying it **requires a `path` filter**, e.g.
+`SELECT name, value, ctime, mtime FROM system.zookeeper WHERE path = '/'`.
+Without `WHERE path = ...` it errors. Prefer the `get_zookeeper_info` tool. If
+the query fails with "Unknown table", Keeper is not configured.
+
+## Users, roles & grants — access control
+
+- `system.users`: `name`, `id`, `storage`, `auth_type`, `host_ip`,
+  `host_names`, `default_roles_all`, `default_roles_list`.
+- `system.roles`: `name`, `id`, `storage`.
+- `system.grants`: `user_name`, `role_name`, `access_type`, `database`,
+  `table`, `column`, `is_partial_revoke`, `grant_option`.
+- `system.role_grants`: `user_name`, `role_name`, `granted_role_name`.
+- `currentUser()` returns the connected user; `system.session_log` (optional)
+  has login history. Prefer the `get_users_and_roles` / `get_login_attempts`
+  tools.
+
+## system.metric_log & system.asynchronous_metric_log — historical metrics
+
+Time-series snapshots of `system.metrics` / `system.asynchronous_metrics`.
+Columns: `event_time`, `event_date`, plus one column per metric (wide table) in
+`metric_log`; `metric`, `value` in `asynchronous_metric_log`. Use for trends
+over time rather than instantaneous values.
+
+## system.distributed_ddl_queue — ON CLUSTER operations
+
+Columns: `entry`, `host_name`, `query`, `status`, `cluster`, `initiator`,
+`query_create_time`, `query_finish_time`, `exception_code`. `status = 'Failed'`
+or a non-zero `exception_code` flags a failed distributed DDL. Prefer the
+`get_distributed_ddl_queue` tool.
 
 ## Recovery Rules
 

--- a/apps/web/components/agents/agent-workflow-plan.tsx
+++ b/apps/web/components/agents/agent-workflow-plan.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import {
+  CheckCircle2Icon,
+  CircleDashedIcon,
+  ListChecksIcon,
+  Loader2Icon,
+} from 'lucide-react'
+
+import { Progress } from '@/components/ui/progress'
+import { cn } from '@/lib/utils'
+
+export type WorkflowPlanStepStatus = 'pending' | 'in_progress' | 'completed'
+
+export interface WorkflowPlanStep {
+  id: number
+  title: string
+  status: WorkflowPlanStepStatus
+}
+
+export interface AgentWorkflowPlanProps {
+  steps: WorkflowPlanStep[]
+  note?: string
+  total?: number
+  completed?: number
+}
+
+function StepIcon({ status }: { status: WorkflowPlanStepStatus }) {
+  if (status === 'completed') {
+    return <CheckCircle2Icon className="size-4 shrink-0 text-emerald-500" />
+  }
+  if (status === 'in_progress') {
+    return (
+      <Loader2Icon className="size-4 shrink-0 animate-spin text-yellow-500" />
+    )
+  }
+  return <CircleDashedIcon className="size-4 shrink-0 text-muted-foreground" />
+}
+
+/**
+ * Renders the agent's live workflow plan (the output of the `update_plan` tool).
+ *
+ * Shows each step with a status icon, strikes through completed steps, and
+ * highlights the step currently in progress — giving the user a transparent view
+ * of where the agent is in its multi-step investigation harness.
+ */
+export function AgentWorkflowPlan({
+  steps,
+  note,
+  total,
+  completed,
+}: AgentWorkflowPlanProps) {
+  if (!Array.isArray(steps) || steps.length === 0) return null
+
+  const totalCount = total ?? steps.length
+  const completedCount =
+    completed ?? steps.filter((step) => step.status === 'completed').length
+  const pct = totalCount > 0 ? (completedCount / totalCount) * 100 : 0
+
+  return (
+    <div className="rounded-md border border-border/60 bg-muted/20 p-3">
+      <div className="mb-2 flex items-center gap-2">
+        <ListChecksIcon className="size-4 shrink-0 text-muted-foreground" />
+        <span className="text-xs font-medium text-foreground">
+          Workflow plan
+        </span>
+        <span className="ml-auto font-mono text-[11px] text-muted-foreground">
+          {completedCount}/{totalCount}
+        </span>
+      </div>
+
+      <Progress value={pct} className="mb-3 h-1.5" />
+
+      <ol className="space-y-1.5">
+        {steps.map((step) => (
+          <li key={step.id} className="flex items-start gap-2 text-sm">
+            <span className="mt-0.5">
+              <StepIcon status={step.status} />
+            </span>
+            <span
+              className={cn(
+                'leading-snug',
+                step.status === 'completed' &&
+                  'text-muted-foreground line-through',
+                step.status === 'in_progress' && 'font-medium text-foreground',
+                step.status === 'pending' && 'text-muted-foreground'
+              )}
+            >
+              {step.title}
+            </span>
+          </li>
+        ))}
+      </ol>
+
+      {note ? (
+        <p className="mt-2 border-t border-border/50 pt-2 text-xs text-muted-foreground">
+          {note}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/components/agents/agent-workflow-plan.tsx
+++ b/apps/web/components/agents/agent-workflow-plan.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   CheckCircle2Icon,
   CircleDashedIcon,

--- a/apps/web/components/agents/agent-workflow-plan.tsx
+++ b/apps/web/components/agents/agent-workflow-plan.tsx
@@ -21,6 +21,8 @@ export interface WorkflowPlanStep {
 export interface AgentWorkflowPlanProps {
   steps: WorkflowPlanStep[]
   note?: string
+  /** Workflow title shown when the plan was started from a template. */
+  workflow?: string
   total?: number
   completed?: number
 }
@@ -47,6 +49,7 @@ function StepIcon({ status }: { status: WorkflowPlanStepStatus }) {
 export function AgentWorkflowPlan({
   steps,
   note,
+  workflow,
   total,
   completed,
 }: AgentWorkflowPlanProps) {
@@ -62,7 +65,7 @@ export function AgentWorkflowPlan({
       <div className="mb-2 flex items-center gap-2">
         <ListChecksIcon className="size-4 shrink-0 text-muted-foreground" />
         <span className="text-xs font-medium text-foreground">
-          Workflow plan
+          {workflow ? `Workflow: ${workflow}` : 'Workflow plan'}
         </span>
         <span className="ml-auto font-mono text-[11px] text-muted-foreground">
           {completedCount}/{totalCount}

--- a/apps/web/components/agents/chat/tool-output.tsx
+++ b/apps/web/components/agents/chat/tool-output.tsx
@@ -301,6 +301,7 @@ export function renderToolOutput(output: unknown) {
       <AgentWorkflowPlan
         steps={outputObj.steps as WorkflowPlanStep[]}
         note={outputObj.note as string | undefined}
+        workflow={outputObj.workflow as string | undefined}
         total={outputObj.total as number | undefined}
         completed={outputObj.completed as number | undefined}
       />

--- a/apps/web/components/agents/chat/tool-output.tsx
+++ b/apps/web/components/agents/chat/tool-output.tsx
@@ -25,6 +25,10 @@ import {
 } from '@/components/agents/agent-diagnostics'
 import { AgentVisualization } from '@/components/agents/agent-visualization'
 import {
+  AgentWorkflowPlan,
+  type WorkflowPlanStep,
+} from '@/components/agents/agent-workflow-plan'
+import {
   AskUserWidget,
   isAskUserOutput,
 } from '@/components/agents/ask-user-widget'
@@ -98,6 +102,9 @@ function getPromotedOutputType(output: unknown) {
   }
   if (outputObj.type === 'data_sources' && Array.isArray(outputObj.sources)) {
     return 'data_sources' as const
+  }
+  if (outputObj.type === 'workflow_plan' && Array.isArray(outputObj.steps)) {
+    return 'workflow_plan' as const
   }
   if (outputObj.type === 'agent_issues' && Array.isArray(outputObj.issues)) {
     return 'agent_issues' as const
@@ -285,6 +292,17 @@ export function renderToolOutput(output: unknown) {
       <AgentDataSources
         searchTerm={outputObj.searchTerm as string}
         sources={outputObj.sources as AgentDataSourcesProps['sources']}
+      />
+    )
+  }
+
+  if (outputObj.type === 'workflow_plan' && Array.isArray(outputObj.steps)) {
+    return (
+      <AgentWorkflowPlan
+        steps={outputObj.steps as WorkflowPlanStep[]}
+        note={outputObj.note as string | undefined}
+        total={outputObj.total as number | undefined}
+        completed={outputObj.completed as number | undefined}
       />
     )
   }

--- a/apps/web/lib/ai/agent/prompts/clickhouse-instructions.ts
+++ b/apps/web/lib/ai/agent/prompts/clickhouse-instructions.ts
@@ -138,6 +138,9 @@ When queries fail due to missing columns:
   - You want to confirm scope before expensive operations
   - Gathering feedback on analysis quality
 
+### Planning & Workflow
+- **update_plan**: Create and update a visible, step-by-step workflow plan for the current investigation. Required \`steps\` (ordered list of \`{ title, status }\` where status is \`pending\`/\`in_progress\`/\`completed\`), optional \`note\`. Call it once to lay out a multi-step plan, then again to mark progress as you finish each step. The user sees this as a live checklist.
+
 ### Anomaly Detection
 - **detect_anomalies**: Compare recent (1h) vs baseline (24h) metrics to detect statistical anomalies. Checks error rate, query duration P95, query volume, memory usage, and part counts. Returns severity levels (ok, warning, critical). Supports \`hostId\`. Use proactively when users report "something seems wrong" or ask about system health.
 
@@ -174,6 +177,17 @@ The \`load_skill\` tool gives you access to expert-level guides on specific Clic
 - Before hand-writing SQL against \`system.*\` tables, or after a query fails with an unknown column/identifier → load \`system-tables-reference\`
 
 Load the skill **before** answering so your response is informed by the expert guide.
+
+## Workflow Harness (update_plan)
+
+For any task that genuinely spans multiple phases or tool calls (incident investigations, health reports, multi-host comparisons, "find and fix" requests), run a lightweight planning harness so the user can follow along:
+
+1. **Plan first**: As your first action, call \`update_plan\` with the full ordered list of steps, all set to \`pending\` except the first, which is \`in_progress\`. Keep steps short and action-oriented (e.g. "Scan query_log for slow queries", "Check merge backlog", "Summarize findings").
+2. **One step at a time**: Keep exactly ONE step \`in_progress\`. Everything before it is \`completed\`, everything after is \`pending\`.
+3. **Update as you go**: After finishing a step, call \`update_plan\` again to mark it \`completed\` and move \`in_progress\` to the next step. Use the optional \`note\` for a one-line status.
+4. **Finish clean**: Mark all steps \`completed\` when done.
+
+Skip the harness for simple, single-step answers — do not add planning overhead to a question that one tool call can answer. The plan is a transparency aid, not a substitute for actually running the tools.
 
 ## Diagnostic Workflow
 

--- a/apps/web/lib/ai/agent/prompts/clickhouse-instructions.ts
+++ b/apps/web/lib/ai/agent/prompts/clickhouse-instructions.ts
@@ -138,6 +138,9 @@ When queries fail due to missing columns:
   - You want to confirm scope before expensive operations
   - Gathering feedback on analysis quality
 
+### Context Management
+- **get_context**: Runtime context snapshot for orientation — ClickHouse version & uptime, current user, whether Keeper/ZooKeeper is configured, memory pressure, count of changed (non-default) settings, and the agent's own capabilities (tool count, loaded skills, available workflows). Supports \`hostId\`. Call it once at the start of a session on an unfamiliar host so you tailor queries to the actual version, user, and configuration instead of guessing.
+
 ### Planning & Workflow
 - **list_workflows**: List the available dynamic workflow templates (named runbooks). Use it to discover which workflow fits the request.
 - **start_workflow**: Instantiate a workflow template into a live plan checklist. Required \`workflow\` (template name). Optional \`customSteps\` (replace the template steps), \`extraSteps\` (append steps), \`note\`. The first step becomes \`in_progress\`; the rest \`pending\`.
@@ -221,6 +224,7 @@ When users ask to "spot issues", "find insights", "optimize queries", "self fix 
 ## Best Practices
 
 ### Exploration Pattern
+0. **Orient first (unfamiliar host)**: Call get_context once to learn the version, user, Keeper availability, memory pressure, and changed settings before deep work — it prevents version/column mistakes and wasted queries.
 1. **Start with exploration**: Use list_databases to see available databases
 2. **Understand structure**: Use list_tables to see what tables exist
 3. **Get column details**: Use get_table_schema to understand columns and types

--- a/apps/web/lib/ai/agent/prompts/clickhouse-instructions.ts
+++ b/apps/web/lib/ai/agent/prompts/clickhouse-instructions.ts
@@ -139,7 +139,9 @@ When queries fail due to missing columns:
   - Gathering feedback on analysis quality
 
 ### Planning & Workflow
-- **update_plan**: Create and update a visible, step-by-step workflow plan for the current investigation. Required \`steps\` (ordered list of \`{ title, status }\` where status is \`pending\`/\`in_progress\`/\`completed\`), optional \`note\`. Call it once to lay out a multi-step plan, then again to mark progress as you finish each step. The user sees this as a live checklist.
+- **list_workflows**: List the available dynamic workflow templates (named runbooks). Use it to discover which workflow fits the request.
+- **start_workflow**: Instantiate a workflow template into a live plan checklist. Required \`workflow\` (template name). Optional \`customSteps\` (replace the template steps), \`extraSteps\` (append steps), \`note\`. The first step becomes \`in_progress\`; the rest \`pending\`.
+- **update_plan**: Create and update a visible, step-by-step workflow plan. Required \`steps\` (ordered list of \`{ title, status }\` where status is \`pending\`/\`in_progress\`/\`completed\`), optional \`note\`, \`workflow\` (title to keep displayed). Use it to author a plan from scratch, or to adapt a plan started by \`start_workflow\` as findings emerge.
 
 ### Anomaly Detection
 - **detect_anomalies**: Compare recent (1h) vs baseline (24h) metrics to detect statistical anomalies. Checks error rate, query duration P95, query volume, memory usage, and part counts. Returns severity levels (ok, warning, critical). Supports \`hostId\`. Use proactively when users report "something seems wrong" or ask about system health.
@@ -178,13 +180,24 @@ The \`load_skill\` tool gives you access to expert-level guides on specific Clic
 
 Load the skill **before** answering so your response is informed by the expert guide.
 
-## Workflow Harness (update_plan)
+## Workflow Harness (dynamic workflows + update_plan)
 
-For any task that genuinely spans multiple phases or tool calls (incident investigations, health reports, multi-host comparisons, "find and fix" requests), run a lightweight planning harness so the user can follow along:
+For any task that genuinely spans multiple phases or tool calls (incident investigations, health reports, multi-host comparisons, "find and fix" requests), run a lightweight planning harness so the user can follow along.
 
-1. **Plan first**: As your first action, call \`update_plan\` with the full ordered list of steps, all set to \`pending\` except the first, which is \`in_progress\`. Keep steps short and action-oriented (e.g. "Scan query_log for slow queries", "Check merge backlog", "Summarize findings").
+**Prefer a dynamic workflow template when one fits.** Built-in templates:
+- \`incident-investigation\` — triage a reported problem to a root cause
+- \`health-check\` — full cluster health sweep
+- \`query-optimization\` — analyze and speed up a slow query
+- \`capacity-planning\` — forecast storage/resource needs
+- \`replication-triage\` — diagnose replication lag or failover
+- \`migration-safety\` — assess a schema change before applying it
+
+When the request matches a template, call \`start_workflow\` with that template name — adapt it on the fly with \`customSteps\` (tailor to the specific table/host) or \`extraSteps\` (add a verification step). The template also tells you which skill to load. If nothing fits, author the plan directly with \`update_plan\`.
+
+How to run the harness:
+1. **Plan first**: \`start_workflow\` (or \`update_plan\`) as your first action, with the first step \`in_progress\` and the rest \`pending\`. Keep step titles short and action-oriented.
 2. **One step at a time**: Keep exactly ONE step \`in_progress\`. Everything before it is \`completed\`, everything after is \`pending\`.
-3. **Update as you go**: After finishing a step, call \`update_plan\` again to mark it \`completed\` and move \`in_progress\` to the next step. Use the optional \`note\` for a one-line status.
+3. **Adapt dynamically**: After each step, call \`update_plan\` to mark it \`completed\` and move \`in_progress\` forward. If findings change the scope, revise the plan — add, drop, or reorder steps — and keep the \`workflow\` title so the UI stays consistent. Use \`note\` for a one-line status.
 4. **Finish clean**: Mark all steps \`completed\` when done.
 
 Skip the harness for simple, single-step answers — do not add planning overhead to a question that one tool call can answer. The plan is a transparency aid, not a substitute for actually running the tools.

--- a/apps/web/lib/ai/agent/skills/registry.ts
+++ b/apps/web/lib/ai/agent/skills/registry.ts
@@ -11,7 +11,7 @@ export const SKILLS: readonly Skill[] = [
   {
     name: 'system-tables-reference',
     description:
-      'Exact column names for the system tables the agent queries most (processes, query_log, parts, merges, replicas, metrics) plus rules for choosing dedicated tools over raw SQL. Load before hand-writing SQL against system tables.',
+      'Exact column names for the system tables the agent queries most (processes, query_log, parts, merges, mutations, replicas, replication_queue, disks, settings, zookeeper, users/grants, metrics) plus rules for choosing dedicated tools over raw SQL. Load before hand-writing SQL against system tables.',
     content: `# System Tables Reference
 
 Load this skill before writing raw SQL against \`system.*\` tables. It lists the
@@ -117,6 +117,76 @@ These three are easy to confuse — they use different column names:
 
 Columns: \`name\`, \`code\`, \`value\`, \`last_error_time\`, \`last_error_message\`,
 \`last_error_trace\`. There is no \`last_update_time\` column.
+
+## system.mutations — ALTER UPDATE/DELETE progress
+
+One row per mutation. Columns: \`database\`, \`table\`, \`mutation_id\`, \`command\`,
+\`create_time\`, \`parts_to_do\`, \`parts_to_do_names\`, \`is_done\`,
+\`latest_failed_part\`, \`latest_fail_time\`, \`latest_fail_reason\`.
+
+- Stuck mutation = \`is_done = 0\` with a non-empty \`latest_fail_reason\`.
+- Prefer the \`get_mutations\` tool. \`parts_to_do > 0\` means still running.
+
+## system.replication_queue — pending replication tasks
+
+Columns: \`database\`, \`table\`, \`type\`, \`create_time\`, \`num_tries\`,
+\`last_exception\`, \`last_attempt_time\`, \`num_postponed\`, \`postpone_reason\`,
+\`node_name\`, \`is_currently_executing\`. High \`num_tries\` + \`last_exception\`
+signals a stuck entry. Prefer the \`get_replication_queue\` tool.
+
+## system.disks — storage devices
+
+Columns: \`name\`, \`path\`, \`free_space\`, \`total_space\`, \`unreserved_space\`,
+\`keep_free_space\`, \`type\`. Used % = \`(total_space - free_space) / total_space\`.
+Prefer the \`get_disk_usage\` tool.
+
+## system.detached_parts — parts needing attention
+
+Columns: \`database\`, \`table\`, \`partition_id\`, \`name\`, \`disk\`, \`reason\`,
+\`bytes_on_disk\`. A non-null \`reason\` (e.g. \`broken\`, \`unexpected\`) flags parts
+that won't be merged. Prefer the \`get_detached_parts\` tool.
+
+## system.settings vs system.merge_tree_settings — configuration
+
+- \`system.settings\`: session/server settings. Columns \`name\`, \`value\`,
+  \`changed\`, \`default\`, \`description\`, \`type\`, \`readonly\`. Filter \`changed = 1\`
+  for non-default values. Prefer the \`get_settings\` tool.
+- \`system.merge_tree_settings\`: MergeTree engine settings, same columns. Prefer
+  the \`get_mergetree_settings\` tool.
+
+## system.zookeeper / Keeper — coordination
+
+\`system.zookeeper\` is an **optional** table that only exists when ZooKeeper or
+ClickHouse Keeper is configured. Querying it **requires a \`path\` filter**, e.g.
+\`SELECT name, value, ctime, mtime FROM system.zookeeper WHERE path = '/'\`.
+Without \`WHERE path = ...\` it errors. Prefer the \`get_zookeeper_info\` tool. If
+the query fails with "Unknown table", Keeper is not configured.
+
+## Users, roles & grants — access control
+
+- \`system.users\`: \`name\`, \`id\`, \`storage\`, \`auth_type\`, \`host_ip\`,
+  \`host_names\`, \`default_roles_all\`, \`default_roles_list\`.
+- \`system.roles\`: \`name\`, \`id\`, \`storage\`.
+- \`system.grants\`: \`user_name\`, \`role_name\`, \`access_type\`, \`database\`,
+  \`table\`, \`column\`, \`is_partial_revoke\`, \`grant_option\`.
+- \`system.role_grants\`: \`user_name\`, \`role_name\`, \`granted_role_name\`.
+- \`currentUser()\` returns the connected user; \`system.session_log\` (optional)
+  has login history. Prefer the \`get_users_and_roles\` / \`get_login_attempts\`
+  tools.
+
+## system.metric_log & system.asynchronous_metric_log — historical metrics
+
+Time-series snapshots of \`system.metrics\` / \`system.asynchronous_metrics\`.
+Columns: \`event_time\`, \`event_date\`, plus one column per metric (wide table) in
+\`metric_log\`; \`metric\`, \`value\` in \`asynchronous_metric_log\`. Use for trends
+over time rather than instantaneous values.
+
+## system.distributed_ddl_queue — ON CLUSTER operations
+
+Columns: \`entry\`, \`host_name\`, \`query\`, \`status\`, \`cluster\`, \`initiator\`,
+\`query_create_time\`, \`query_finish_time\`, \`exception_code\`. \`status = 'Failed'\`
+or a non-zero \`exception_code\` flags a failed distributed DDL. Prefer the
+\`get_distributed_ddl_queue\` tool.
 
 ## Recovery Rules
 

--- a/apps/web/lib/ai/agent/tools/__tests__/context-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/context-tools.test.ts
@@ -1,53 +1,49 @@
 import { describe, expect, mock, test } from 'bun:test'
+import { z } from 'zod/v3'
 
 mock.module('server-only', () => ({}))
 
 let zookeeperAvailable = true
 
-mock.module('@chm/clickhouse-client', () => ({
-  fetchData: mock(async ({ query }: { query: string }) => {
+// Mock the direct dependency (`./helpers`) rather than the deep
+// `@chm/clickhouse-client`. helpers.readOnlyQuery returns the data array
+// directly and throws on error, and mocking it here is immune to the suite-wide
+// mock-ordering leak that freezes the clickhouse-client binding.
+mock.module('../helpers', () => ({
+  hostIdSchema: z.number().int().min(0).optional(),
+  resolveHostId: (toolHostId: number | undefined, defaultHostId: number) =>
+    toolHostId ?? defaultHostId,
+  readOnlyQuery: mock(async ({ query }: { query: string }) => {
     if (query.includes('version()')) {
-      return {
-        data: [
-          {
-            version: '24.3.1',
-            uptime_seconds: 12345,
-            current_user: 'monitor',
-            timezone: 'UTC',
-          },
-        ],
-        error: null,
-      }
+      return [
+        {
+          version: '24.3.1',
+          uptime_seconds: 12345,
+          current_user: 'monitor',
+          timezone: 'UTC',
+        },
+      ]
     }
     if (query.includes('asynchronous_metrics')) {
-      return {
-        data: [
-          { metric: 'OSMemoryTotal', value: 16000000000 },
-          { metric: 'OSMemoryAvailable', value: 8000000000 },
-          { metric: 'MemoryTracking', value: 4000000000 },
-        ],
-        error: null,
-      }
+      return [
+        { metric: 'OSMemoryTotal', value: 16000000000 },
+        { metric: 'OSMemoryAvailable', value: 8000000000 },
+        { metric: 'MemoryTracking', value: 4000000000 },
+      ]
     }
     if (query.includes('system.settings') && query.includes('changed = 1')) {
-      return {
-        data: [
-          { name: 'max_threads', value: '8' },
-          { name: 'max_memory_usage', value: '10000000000' },
-        ],
-        error: null,
-      }
+      return [
+        { name: 'max_threads', value: '8' },
+        { name: 'max_memory_usage', value: '10000000000' },
+      ]
     }
     if (query.includes('system.zookeeper')) {
       if (!zookeeperAvailable) {
-        return {
-          data: null,
-          error: { message: 'Unknown table system.zookeeper' },
-        }
+        throw new Error('Unknown table system.zookeeper')
       }
-      return { data: [{ c: 3 }], error: null }
+      return [{ c: 3 }]
     }
-    return { data: [], error: null }
+    return []
   }),
 }))
 

--- a/apps/web/lib/ai/agent/tools/__tests__/context-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/context-tools.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, mock, test } from 'bun:test'
+
+mock.module('server-only', () => ({}))
+
+let zookeeperAvailable = true
+
+mock.module('@chm/clickhouse-client', () => ({
+  fetchData: mock(async ({ query }: { query: string }) => {
+    if (query.includes('version()')) {
+      return {
+        data: [
+          {
+            version: '24.3.1',
+            uptime_seconds: 12345,
+            current_user: 'monitor',
+            timezone: 'UTC',
+          },
+        ],
+        error: null,
+      }
+    }
+    if (query.includes('asynchronous_metrics')) {
+      return {
+        data: [
+          { metric: 'OSMemoryTotal', value: 16000000000 },
+          { metric: 'OSMemoryAvailable', value: 8000000000 },
+          { metric: 'MemoryTracking', value: 4000000000 },
+        ],
+        error: null,
+      }
+    }
+    if (query.includes('system.settings') && query.includes('changed = 1')) {
+      return {
+        data: [
+          { name: 'max_threads', value: '8' },
+          { name: 'max_memory_usage', value: '10000000000' },
+        ],
+        error: null,
+      }
+    }
+    if (query.includes('system.zookeeper')) {
+      if (!zookeeperAvailable) {
+        return {
+          data: null,
+          error: { message: 'Unknown table system.zookeeper' },
+        }
+      }
+      return { data: [{ c: 3 }], error: null }
+    }
+    return { data: [], error: null }
+  }),
+}))
+
+const { createContextTools } = await import('../context-tools')
+
+type Execute = (input: unknown) => Promise<Record<string, unknown>>
+
+function getExecute(toolCount = 80) {
+  const tools = createContextTools(0, { toolCount })
+  return (tools.get_context as unknown as { execute: Execute }).execute
+}
+
+describe('get_context', () => {
+  test('returns a runtime context snapshot', async () => {
+    zookeeperAvailable = true
+    const result = await getExecute(82)({ hostId: 0 })
+
+    expect(result.type).toBe('agent_context')
+    expect(result.hostId).toBe(0)
+
+    const server = result.server as Record<string, unknown>
+    expect(server.version).toBe('24.3.1')
+    expect(server.currentUser).toBe('monitor')
+
+    const memory = result.memory as Record<string, unknown>
+    expect(memory.osTotalBytes).toBe(16000000000)
+    expect(memory.trackedBytes).toBe(4000000000)
+
+    const settings = result.settings as Record<string, unknown>
+    expect(settings.changedCount).toBe(2)
+    expect(settings.notable).toContain('max_threads')
+  })
+
+  test('reports keeper as configured when system.zookeeper responds', async () => {
+    zookeeperAvailable = true
+    const result = await getExecute()({ hostId: 0 })
+    expect((result.keeper as Record<string, unknown>).configured).toBe(true)
+  })
+
+  test('reports keeper as not configured when system.zookeeper is missing', async () => {
+    zookeeperAvailable = false
+    const result = await getExecute()({ hostId: 0 })
+    expect((result.keeper as Record<string, unknown>).configured).toBe(false)
+  })
+
+  test('includes capabilities (tool count, skills, workflows)', async () => {
+    zookeeperAvailable = true
+    const result = await getExecute(99)({ hostId: 0 })
+    const caps = result.capabilities as Record<string, unknown>
+    expect(caps.toolCount).toBe(99)
+    expect(Array.isArray(caps.skills)).toBe(true)
+    expect((caps.skills as string[]).length).toBeGreaterThan(0)
+    expect(caps.workflows).toContain('incident-investigation')
+  })
+})

--- a/apps/web/lib/ai/agent/tools/__tests__/plan-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/plan-tools.test.ts
@@ -1,0 +1,86 @@
+import { createPlanTools } from '../plan-tools'
+import { describe, expect, test } from 'bun:test'
+
+type ExecuteFn = (input: unknown) => Promise<{
+  type: string
+  steps: Array<{ id: number; title: string; status: string }>
+  note?: string
+  total: number
+  completed: number
+  updatedAt: string
+}>
+
+function getExecute() {
+  const tools = createPlanTools()
+  const tool = tools.update_plan as unknown as { execute: ExecuteFn }
+  return tool.execute
+}
+
+describe('update_plan', () => {
+  test('exposes the update_plan tool', () => {
+    const tools = createPlanTools()
+    expect(tools.update_plan).toBeDefined()
+  })
+
+  test('normalizes steps with ids and defaults status to pending', async () => {
+    const execute = getExecute()
+    const result = await execute({
+      steps: [
+        { title: 'Scan query_log' },
+        { title: 'Check merges', status: 'in_progress' },
+        { title: 'Summarize', status: 'pending' },
+      ],
+    })
+
+    expect(result.type).toBe('workflow_plan')
+    expect(result.steps).toHaveLength(3)
+    expect(result.steps[0]).toEqual({
+      id: 1,
+      title: 'Scan query_log',
+      status: 'pending',
+    })
+    expect(result.steps[1].id).toBe(2)
+    expect(result.steps[1].status).toBe('in_progress')
+    expect(result.steps[2].id).toBe(3)
+  })
+
+  test('computes total and completed counts', async () => {
+    const execute = getExecute()
+    const result = await execute({
+      steps: [
+        { title: 'Step 1', status: 'completed' },
+        { title: 'Step 2', status: 'completed' },
+        { title: 'Step 3', status: 'in_progress' },
+        { title: 'Step 4', status: 'pending' },
+      ],
+    })
+
+    expect(result.total).toBe(4)
+    expect(result.completed).toBe(2)
+  })
+
+  test('passes through an optional note', async () => {
+    const execute = getExecute()
+    const result = await execute({
+      steps: [{ title: 'Only step' }],
+      note: 'Investigating slow merges',
+    })
+
+    expect(result.note).toBe('Investigating slow merges')
+  })
+
+  test('omits note when not provided', async () => {
+    const execute = getExecute()
+    const result = await execute({ steps: [{ title: 'Only step' }] })
+
+    expect(result.note).toBeUndefined()
+  })
+
+  test('returns an ISO timestamp', async () => {
+    const execute = getExecute()
+    const result = await execute({ steps: [{ title: 'Only step' }] })
+
+    expect(() => new Date(result.updatedAt).toISOString()).not.toThrow()
+    expect(result.updatedAt).toBe(new Date(result.updatedAt).toISOString())
+  })
+})

--- a/apps/web/lib/ai/agent/tools/__tests__/workflow-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/workflow-tools.test.ts
@@ -1,0 +1,97 @@
+import {
+  getAllWorkflows,
+  getWorkflow,
+  registerWorkflow,
+  unregisterWorkflow,
+} from '../../workflows/registry'
+import { createWorkflowTools } from '../workflow-tools'
+import { afterEach, describe, expect, test } from 'bun:test'
+
+type AnyExecute = (input: unknown) => Promise<Record<string, unknown>>
+
+function tool(name: 'list_workflows' | 'start_workflow') {
+  const tools = createWorkflowTools()
+  return (tools[name] as unknown as { execute: AnyExecute }).execute
+}
+
+describe('workflow registry', () => {
+  afterEach(() => {
+    unregisterWorkflow('test-runtime-workflow')
+  })
+
+  test('ships built-in workflow templates', () => {
+    const all = getAllWorkflows()
+    const names = all.map((w) => w.name)
+    expect(names).toContain('incident-investigation')
+    expect(names).toContain('health-check')
+    expect(names).toContain('query-optimization')
+    expect(all.every((w) => w.steps.length > 0)).toBe(true)
+  })
+
+  test('getWorkflow returns a template by name', () => {
+    const wf = getWorkflow('incident-investigation')
+    expect(wf?.title).toBe('Incident Investigation')
+    expect(wf?.source).toBe('builtin')
+  })
+
+  test('runtime workflows can be registered and override builtins', () => {
+    registerWorkflow({
+      name: 'test-runtime-workflow',
+      title: 'Test Runtime',
+      description: 'A runtime workflow',
+      triggers: ['test'],
+      steps: ['Step A', 'Step B'],
+    })
+    const wf = getWorkflow('test-runtime-workflow')
+    expect(wf?.source).toBe('runtime')
+    expect(wf?.steps).toEqual(['Step A', 'Step B'])
+  })
+})
+
+describe('list_workflows', () => {
+  test('returns the catalog of workflows', async () => {
+    const result = await tool('list_workflows')({})
+    expect(result.type).toBe('workflow_list')
+    expect(Array.isArray(result.workflows)).toBe(true)
+    expect((result.workflows as unknown[]).length).toBeGreaterThan(0)
+  })
+})
+
+describe('start_workflow', () => {
+  test('instantiates a template into a workflow_plan', async () => {
+    const result = await tool('start_workflow')({
+      workflow: 'health-check',
+    })
+    expect(result.type).toBe('workflow_plan')
+    expect(result.workflow).toBe('Cluster Health Check')
+    const steps = result.steps as Array<{ status: string }>
+    expect(steps[0].status).toBe('in_progress')
+    expect(steps.slice(1).every((s) => s.status === 'pending')).toBe(true)
+  })
+
+  test('customSteps replaces the template steps', async () => {
+    const result = await tool('start_workflow')({
+      workflow: 'health-check',
+      customSteps: ['Only check disks', 'Report'],
+    })
+    const steps = result.steps as Array<{ title: string }>
+    expect(steps).toHaveLength(2)
+    expect(steps[0].title).toBe('Only check disks')
+  })
+
+  test('extraSteps appends to the template steps', async () => {
+    const base = getWorkflow('health-check')?.steps.length ?? 0
+    const result = await tool('start_workflow')({
+      workflow: 'health-check',
+      extraSteps: ['Verify the fix'],
+    })
+    const steps = result.steps as unknown[]
+    expect(steps).toHaveLength(base + 1)
+  })
+
+  test('returns workflow_error for an unknown template', async () => {
+    const result = await tool('start_workflow')({ workflow: 'does-not-exist' })
+    expect(result.type).toBe('workflow_error')
+    expect(Array.isArray(result.available)).toBe(true)
+  })
+})

--- a/apps/web/lib/ai/agent/tools/context-tools.ts
+++ b/apps/web/lib/ai/agent/tools/context-tools.ts
@@ -1,0 +1,146 @@
+import 'server-only'
+
+import { getAllSkills } from '../skills/dynamic-loader'
+import { getAllWorkflows } from '../workflows/registry'
+import { hostIdSchema, readOnlyQuery, resolveHostId } from './helpers'
+import { dynamicTool } from 'ai'
+import { z } from 'zod/v3'
+
+const NOTABLE_SETTINGS_LIMIT = 12
+
+/**
+ * Best-effort query that returns a fallback when the table/feature is missing,
+ * so one unavailable source never blocks the whole context snapshot.
+ */
+async function safeQuery<T>(
+  fn: () => Promise<T>,
+  fallback: T
+): Promise<{ value: T; error?: string }> {
+  try {
+    return { value: await fn() }
+  } catch (err) {
+    return {
+      value: fallback,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+/**
+ * Creates the `get_context` tool — a runtime context-management snapshot.
+ *
+ * Gathers, in parallel and with graceful degradation, the situational
+ * information the agent otherwise has to rediscover each turn: ClickHouse
+ * version/uptime, the connected user, Keeper/ZooKeeper availability, memory
+ * pressure, how many settings differ from defaults, and the agent's own
+ * capabilities (tool count, loaded skills, available workflows). Call it once at
+ * the start of a session on an unfamiliar host to orient quickly.
+ *
+ * `toolCount` is injected by the assembler (index.ts) to avoid a circular import.
+ */
+export function createContextTools(
+  hostId: number,
+  options: { toolCount: number }
+) {
+  return {
+    get_context: dynamicTool({
+      description:
+        "Get a runtime context snapshot for orientation: ClickHouse version & uptime, the current user, whether Keeper/ZooKeeper is configured, memory pressure, the count of changed (non-default) settings, and the agent's own capabilities (tools, skills, workflows). Use it at the start of a session on an unfamiliar host. Supports hostId.",
+      inputSchema: z.object({ hostId: hostIdSchema }),
+      execute: async (input: unknown) => {
+        const { hostId: paramHostId } = input as { hostId?: number }
+        const effectiveHostId = resolveHostId(paramHostId, hostId)
+
+        const [server, memory, settings, keeper] = await Promise.all([
+          // Version, uptime, user, timezone
+          safeQuery(
+            async () =>
+              (await readOnlyQuery({
+                query:
+                  'SELECT version() AS version, uptime() AS uptime_seconds, currentUser() AS current_user, timezone() AS timezone',
+                hostId: effectiveHostId,
+              })) as Array<Record<string, unknown>>,
+            []
+          ),
+          // Memory pressure (tracked + OS total/available)
+          safeQuery(
+            async () =>
+              (await readOnlyQuery({
+                query: `SELECT metric, value FROM system.asynchronous_metrics
+                        WHERE metric IN ('OSMemoryTotal', 'OSMemoryAvailable')
+                        UNION ALL
+                        SELECT metric, value FROM system.metrics
+                        WHERE metric = 'MemoryTracking'`,
+                hostId: effectiveHostId,
+              })) as Array<{ metric: string; value: number }>,
+            []
+          ),
+          // Changed (non-default) settings
+          safeQuery(
+            async () =>
+              (await readOnlyQuery({
+                query: `SELECT name, value FROM system.settings WHERE changed = 1 ORDER BY name`,
+                hostId: effectiveHostId,
+              })) as Array<{ name: string; value: string }>,
+            []
+          ),
+          // Keeper/ZooKeeper availability (optional table)
+          safeQuery(
+            async () =>
+              (await readOnlyQuery({
+                query: `SELECT count() AS c FROM system.zookeeper WHERE path = '/'`,
+                hostId: effectiveHostId,
+              })) as Array<{ c: number }>,
+            null as Array<{ c: number }> | null
+          ),
+        ])
+
+        const serverRow = server.value[0] ?? {}
+        const memByMetric = new Map(
+          memory.value.map((row) => [row.metric, Number(row.value)])
+        )
+        const changedSettings = settings.value
+
+        // Capabilities are local (no DB) — describe what the agent can do.
+        const toolCount = options.toolCount
+        const skills = getAllSkills().map((skill) => skill.name)
+        const workflows = getAllWorkflows().map((workflow) => workflow.name)
+
+        return {
+          type: 'agent_context' as const,
+          hostId: effectiveHostId,
+          server: {
+            version: serverRow.version ?? null,
+            uptimeSeconds: serverRow.uptime_seconds ?? null,
+            currentUser: serverRow.current_user ?? null,
+            timezone: serverRow.timezone ?? null,
+            ...(server.error ? { error: server.error } : {}),
+          },
+          keeper: {
+            configured: keeper.value !== null,
+            ...(keeper.error
+              ? { detail: 'system.zookeeper not available' }
+              : {}),
+          },
+          memory: {
+            trackedBytes: memByMetric.get('MemoryTracking') ?? null,
+            osTotalBytes: memByMetric.get('OSMemoryTotal') ?? null,
+            osAvailableBytes: memByMetric.get('OSMemoryAvailable') ?? null,
+          },
+          settings: {
+            changedCount: changedSettings.length,
+            notable: changedSettings
+              .slice(0, NOTABLE_SETTINGS_LIMIT)
+              .map((row) => row.name),
+          },
+          capabilities: {
+            toolCount,
+            skills,
+            workflows,
+          },
+          generatedAt: new Date().toISOString(),
+        }
+      },
+    }),
+  }
+}

--- a/apps/web/lib/ai/agent/tools/index.ts
+++ b/apps/web/lib/ai/agent/tools/index.ts
@@ -12,6 +12,7 @@ import { createAskUserTools } from './ask-user-tools'
 import { createCapacityTools } from './capacity-tools'
 import { createClusterTools } from './cluster-tools'
 import { createComparisonTools } from './comparison-tools'
+import { createContextTools } from './context-tools'
 import { createControlTools } from './control-tools'
 import { createDashboardTools } from './dashboard-tools'
 import { createDiagnosticsTools } from './diagnostics-tools'
@@ -42,7 +43,7 @@ import { createZookeeperTools } from './zookeeper-tools'
 export function createAllTools(hostId: number, includeControlTools = false) {
   const enableControlTools = process.env.AGENT_ENABLE_CONTROL_TOOLS === 'true'
 
-  return {
+  const tools = {
     // Schema & exploration
     ...createSchemaTools(hostId),
 
@@ -125,5 +126,15 @@ export function createAllTools(hostId: number, includeControlTools = false) {
 
     // Visualization & data source discovery
     ...createVisualizationTools(hostId),
+  }
+
+  // Runtime context management — injected with the final tool count (+1 for
+  // get_context itself) to describe the agent's own capabilities without a
+  // circular import back into this assembler.
+  return {
+    ...tools,
+    ...createContextTools(hostId, {
+      toolCount: Object.keys(tools).length + 1,
+    }),
   }
 }

--- a/apps/web/lib/ai/agent/tools/index.ts
+++ b/apps/web/lib/ai/agent/tools/index.ts
@@ -32,6 +32,7 @@ import { createSettingsTools } from './settings-tools'
 import { createSkillTools } from './skill-tools'
 import { createStorageTools } from './storage-tools'
 import { createVisualizationTools } from './visualization-tools'
+import { createWorkflowTools } from './workflow-tools'
 import { createZookeeperTools } from './zookeeper-tools'
 
 /**
@@ -94,6 +95,9 @@ export function createAllTools(hostId: number, includeControlTools = false) {
 
     // Workflow planning harness
     ...createPlanTools(),
+
+    // Dynamic workflow templates
+    ...createWorkflowTools(),
 
     // Anomaly detection
     ...createAnomalyTools(hostId),

--- a/apps/web/lib/ai/agent/tools/index.ts
+++ b/apps/web/lib/ai/agent/tools/index.ts
@@ -22,6 +22,7 @@ import { createLogTools } from './log-tools'
 import { createMergeTools } from './merge-tools'
 import { createMigrationTools } from './migration-tools'
 import { createOptimizerTools } from './optimizer-tools'
+import { createPlanTools } from './plan-tools'
 import { createQueryTools } from './query-tools'
 import { createReplicationTools } from './replication-tools'
 import { createReportTools } from './report-tools'
@@ -90,6 +91,9 @@ export function createAllTools(hostId: number, includeControlTools = false) {
 
     // User interaction
     ...createAskUserTools(),
+
+    // Workflow planning harness
+    ...createPlanTools(),
 
     // Anomaly detection
     ...createAnomalyTools(hostId),

--- a/apps/web/lib/ai/agent/tools/plan-tools.ts
+++ b/apps/web/lib/ai/agent/tools/plan-tools.ts
@@ -1,0 +1,100 @@
+import { dynamicTool } from 'ai'
+import { z } from 'zod/v3'
+
+const MAX_STEPS = 20
+const MAX_TITLE_LEN = 140
+const MAX_NOTE_LEN = 280
+
+export type PlanStepStatus = 'pending' | 'in_progress' | 'completed'
+
+export interface WorkflowPlanStep {
+  id: number
+  title: string
+  status: PlanStepStatus
+}
+
+export interface WorkflowPlanOutput {
+  type: 'workflow_plan'
+  steps: WorkflowPlanStep[]
+  note?: string
+  total: number
+  completed: number
+  updatedAt: string
+}
+
+/**
+ * Creates the `update_plan` harness tool.
+ *
+ * This gives the agent an explicit, user-visible workflow: a checklist of the
+ * steps it intends to take for a multi-step investigation. The agent calls this
+ * once at the start to lay out the plan, then again after finishing each step to
+ * mark progress. The frontend renders the latest plan as a live checklist, so the
+ * user always knows where the agent is in its workflow.
+ *
+ * The tool is pure (no ClickHouse access) — it simply normalizes and echoes the
+ * plan back so the UI can render it and the model retains the plan in context.
+ *
+ * @returns An object containing the `update_plan` tool that emits a
+ * `{ type: 'workflow_plan', steps, note, total, completed, updatedAt }` payload.
+ */
+export function createPlanTools() {
+  return {
+    update_plan: dynamicTool({
+      description: `Create or update a step-by-step workflow plan for the current investigation. Use this as a lightweight planning harness:
+- Call it ONCE at the start of any multi-step task (3+ steps) to lay out the plan with all steps set to "pending".
+- Call it AGAIN after completing each step to mark that step "completed" and the next one "in_progress".
+- Keep exactly ONE step "in_progress" at a time; everything before it should be "completed" and everything after "pending".
+- Keep step titles short and action-oriented (e.g. "Scan query_log for slow queries", "Check merge backlog", "Summarize findings").
+Do NOT use this for single-step answers — only when the work genuinely spans multiple tool calls or phases.`,
+      inputSchema: z.object({
+        steps: z
+          .array(
+            z.object({
+              title: z
+                .string()
+                .min(1)
+                .max(MAX_TITLE_LEN)
+                .describe('Short, action-oriented description of the step'),
+              status: z
+                .enum(['pending', 'in_progress', 'completed'])
+                .optional()
+                .describe('Step status (default: pending)'),
+            })
+          )
+          .min(1)
+          .max(MAX_STEPS)
+          .describe('Ordered list of workflow steps'),
+        note: z
+          .string()
+          .max(MAX_NOTE_LEN)
+          .optional()
+          .describe('Optional one-line summary of the current focus or status'),
+      }),
+      execute: async (input: unknown): Promise<WorkflowPlanOutput> => {
+        const { steps, note } = input as {
+          steps: Array<{ title: string; status?: PlanStepStatus }>
+          note?: string
+        }
+
+        const normalized: WorkflowPlanStep[] = steps.map((step, index) => ({
+          id: index + 1,
+          title: step.title,
+          status: step.status ?? 'pending',
+        }))
+
+        const completed = normalized.filter(
+          (step) => step.status === 'completed'
+        ).length
+
+        return {
+          type: 'workflow_plan',
+          steps: normalized,
+          ...(note !== undefined ? { note } : {}),
+          total: normalized.length,
+          completed,
+          updatedAt: new Date().toISOString(),
+        }
+      },
+    }),
+  }
+}

--- a/apps/web/lib/ai/agent/tools/plan-tools.ts
+++ b/apps/web/lib/ai/agent/tools/plan-tools.ts
@@ -17,9 +17,41 @@ export interface WorkflowPlanOutput {
   type: 'workflow_plan'
   steps: WorkflowPlanStep[]
   note?: string
+  /** Human-readable workflow title when the plan came from a template. */
+  workflow?: string
   total: number
   completed: number
   updatedAt: string
+}
+
+/**
+ * Normalize a raw step list into a `workflow_plan` payload. Shared by the
+ * `update_plan` tool and the `start_workflow` tool so both emit an identical
+ * shape for the UI to render.
+ */
+export function buildWorkflowPlan(
+  steps: Array<{ title: string; status?: PlanStepStatus }>,
+  options: { note?: string; workflow?: string } = {}
+): WorkflowPlanOutput {
+  const normalized: WorkflowPlanStep[] = steps.map((step, index) => ({
+    id: index + 1,
+    title: step.title,
+    status: step.status ?? 'pending',
+  }))
+
+  const completed = normalized.filter(
+    (step) => step.status === 'completed'
+  ).length
+
+  return {
+    type: 'workflow_plan',
+    steps: normalized,
+    ...(options.note !== undefined ? { note: options.note } : {}),
+    ...(options.workflow !== undefined ? { workflow: options.workflow } : {}),
+    total: normalized.length,
+    completed,
+    updatedAt: new Date().toISOString(),
+  }
 }
 
 /**
@@ -69,31 +101,22 @@ Do NOT use this for single-step answers — only when the work genuinely spans m
           .max(MAX_NOTE_LEN)
           .optional()
           .describe('Optional one-line summary of the current focus or status'),
+        workflow: z
+          .string()
+          .max(MAX_TITLE_LEN)
+          .optional()
+          .describe(
+            'Optional workflow title to keep displayed when adapting a plan started via start_workflow'
+          ),
       }),
       execute: async (input: unknown): Promise<WorkflowPlanOutput> => {
-        const { steps, note } = input as {
+        const { steps, note, workflow } = input as {
           steps: Array<{ title: string; status?: PlanStepStatus }>
           note?: string
+          workflow?: string
         }
 
-        const normalized: WorkflowPlanStep[] = steps.map((step, index) => ({
-          id: index + 1,
-          title: step.title,
-          status: step.status ?? 'pending',
-        }))
-
-        const completed = normalized.filter(
-          (step) => step.status === 'completed'
-        ).length
-
-        return {
-          type: 'workflow_plan',
-          steps: normalized,
-          ...(note !== undefined ? { note } : {}),
-          total: normalized.length,
-          completed,
-          updatedAt: new Date().toISOString(),
-        }
+        return buildWorkflowPlan(steps, { note, workflow })
       },
     }),
   }

--- a/apps/web/lib/ai/agent/tools/workflow-tools.ts
+++ b/apps/web/lib/ai/agent/tools/workflow-tools.ts
@@ -1,0 +1,116 @@
+import { getAllWorkflows, getWorkflow } from '../workflows/registry'
+import { buildWorkflowPlan, type WorkflowPlanOutput } from './plan-tools'
+import { dynamicTool } from 'ai'
+import { z } from 'zod/v3'
+
+const MAX_STEPS = 20
+const MAX_TITLE_LEN = 140
+
+export interface WorkflowListOutput {
+  type: 'workflow_list'
+  workflows: Array<{
+    name: string
+    title: string
+    description: string
+    steps: string[]
+    skills: string[]
+  }>
+}
+
+/**
+ * Creates the dynamic-workflow tools.
+ *
+ * - `list_workflows` enumerates the available workflow templates so the agent
+ *   (or the user) can discover them.
+ * - `start_workflow` instantiates a template into a live `workflow_plan`: the
+ *   first step becomes `in_progress`, the rest `pending`. The agent can override
+ *   or extend the template steps for dynamic adaptation, then continue updating
+ *   the plan with `update_plan` as findings emerge.
+ *
+ * Both tools are pure — they read from the workflow registry and emit a payload
+ * for the UI / model; they do not touch ClickHouse.
+ */
+export function createWorkflowTools() {
+  return {
+    list_workflows: dynamicTool({
+      description:
+        'List the available dynamic workflow templates (named multi-step runbooks). Use this to discover which workflow best fits the user request before calling start_workflow.',
+      inputSchema: z.object({}),
+      execute: async (): Promise<WorkflowListOutput> => {
+        const workflows = getAllWorkflows().map((workflow) => ({
+          name: workflow.name,
+          title: workflow.title,
+          description: workflow.description,
+          steps: workflow.steps,
+          skills: workflow.skills ?? [],
+        }))
+        return { type: 'workflow_list', workflows }
+      },
+    }),
+
+    start_workflow: dynamicTool({
+      description: `Start a dynamic workflow: instantiate a named runbook template into a live plan checklist. Pick the template whose purpose matches the user's request, then proceed through it, calling update_plan after each step. You can adapt the template dynamically:
+- Pass customSteps to replace the template steps entirely (e.g. tailor to the specific table/host).
+- Pass extraSteps to append steps to the template (e.g. add a verification step).
+If no template fits, skip this and author the plan directly with update_plan instead.`,
+      inputSchema: z.object({
+        workflow: z
+          .string()
+          .describe(
+            'Name of the workflow template to start (see list_workflows)'
+          ),
+        customSteps: z
+          .array(z.string().min(1).max(MAX_TITLE_LEN))
+          .min(1)
+          .max(MAX_STEPS)
+          .optional()
+          .describe('Replace the template steps entirely with these'),
+        extraSteps: z
+          .array(z.string().min(1).max(MAX_TITLE_LEN))
+          .max(MAX_STEPS)
+          .optional()
+          .describe('Append these steps to the template steps'),
+        note: z
+          .string()
+          .max(280)
+          .optional()
+          .describe('Optional one-line summary of the current focus'),
+      }),
+      execute: async (
+        input: unknown
+      ): Promise<
+        | WorkflowPlanOutput
+        | { type: 'workflow_error'; error: string; available: string[] }
+      > => {
+        const { workflow, customSteps, extraSteps, note } = input as {
+          workflow: string
+          customSteps?: string[]
+          extraSteps?: string[]
+          note?: string
+        }
+
+        const template = getWorkflow(workflow)
+        if (!template) {
+          return {
+            type: 'workflow_error',
+            error: `Unknown workflow "${workflow}". Call list_workflows to see the available templates, or author the plan directly with update_plan.`,
+            available: getAllWorkflows().map((w) => w.name),
+          }
+        }
+
+        const baseSteps = customSteps ?? template.steps
+        const titles = [...baseSteps, ...(extraSteps ?? [])].slice(0, MAX_STEPS)
+
+        const steps = titles.map((title, index) => ({
+          title,
+          status: index === 0 ? ('in_progress' as const) : ('pending' as const),
+        }))
+
+        return buildWorkflowPlan(steps, {
+          workflow: template.title,
+          ...(note !== undefined ? { note } : {}),
+        })
+      },
+    }),
+  }
+}

--- a/apps/web/lib/ai/agent/workflows/registry.ts
+++ b/apps/web/lib/ai/agent/workflows/registry.ts
@@ -1,0 +1,166 @@
+/**
+ * Built-in dynamic workflow templates + registry.
+ *
+ * Templates are plain data so they can be composed, overridden, and extended at
+ * runtime. `registerWorkflow()` lets server code add workflows dynamically
+ * (e.g. cluster-specific runbooks), mirroring the dynamic skills loader.
+ */
+
+import type { WorkflowTemplate } from './types'
+
+export const BUILTIN_WORKFLOWS: readonly WorkflowTemplate[] = [
+  {
+    name: 'incident-investigation',
+    title: 'Incident Investigation',
+    description:
+      'Triage a reported problem: correlate symptoms across query log, errors, merges, and recent changes to find a root cause.',
+    triggers: [
+      'why is it slow',
+      'something is wrong',
+      'investigate the incident',
+      'queries are failing',
+      'production issue',
+    ],
+    steps: [
+      'Scope the symptom and time window',
+      'Run investigate_incident for correlated root cause',
+      'Inspect failed and slow queries for the window',
+      'Check system errors and resource pressure',
+      'Summarize root cause and recommended fix',
+    ],
+    skills: ['troubleshooting'],
+  },
+  {
+    name: 'health-check',
+    title: 'Cluster Health Check',
+    description:
+      'Full health sweep: server state, disks, top tables, slow queries, errors, merges, and replication.',
+    triggers: [
+      'health check',
+      'how is the cluster',
+      'overall status',
+      'is everything ok',
+    ],
+    steps: [
+      'Gather server metrics and uptime',
+      'Check disk usage and capacity headroom',
+      'Review slow queries and recent errors',
+      'Inspect merge backlog and replication status',
+      'Summarize health with prioritized findings',
+    ],
+  },
+  {
+    name: 'query-optimization',
+    title: 'Query Optimization',
+    description:
+      'Analyze and improve a slow query: explain the plan, check keys/indexes, and propose concrete rewrites.',
+    triggers: [
+      'optimize this query',
+      'why is this query slow',
+      'make this faster',
+      'improve query performance',
+    ],
+    steps: [
+      'Inspect the target table schema and sorting key',
+      'Run explain_query and analyze_query_optimization',
+      'Identify scan/index/JOIN inefficiencies',
+      'Propose rewrites with PREWHERE, indexes, or MVs',
+    ],
+    skills: ['query-optimization'],
+  },
+  {
+    name: 'capacity-planning',
+    title: 'Capacity Planning',
+    description:
+      'Forecast storage and resource needs from recent growth trends and flag risks.',
+    triggers: [
+      'capacity planning',
+      'when will the disk fill up',
+      'forecast storage',
+      'do we need more space',
+    ],
+    steps: [
+      'Measure current disk usage and largest tables',
+      'Run forecast_capacity on growth trends',
+      'Project days-until-full and query volume trend',
+      'Recommend TTL, tiering, or scaling actions',
+    ],
+    skills: ['storage-optimization'],
+  },
+  {
+    name: 'replication-triage',
+    title: 'Replication Triage',
+    description:
+      'Diagnose replication lag or failover: inspect status, queue backlog, and Keeper health.',
+    triggers: [
+      'replication lag',
+      'replica is behind',
+      'replication is stuck',
+      'failover issue',
+    ],
+    steps: [
+      'Check per-table replication status and lag',
+      'Inspect the replication queue for stuck tasks',
+      'Review ZooKeeper/Keeper and distributed DDL queue',
+      'Summarize cause and recovery steps',
+    ],
+    skills: ['replication-guide'],
+  },
+  {
+    name: 'migration-safety',
+    title: 'Migration Safety Review',
+    description:
+      'Assess a proposed schema change before applying it: blast radius, table state, and risk class.',
+    triggers: [
+      'is this alter safe',
+      'review this migration',
+      'schema change impact',
+      'can I drop this column',
+    ],
+    steps: [
+      'Inspect current table state, parts, and mutations',
+      'Run analyze_schema_change on the proposed ALTER',
+      'Assess column usage and blast radius',
+      'Recommend a safe, ordered migration plan',
+    ],
+    skills: ['migration-patterns'],
+  },
+]
+
+/** Runtime-registered workflows, keyed by name. */
+const runtimeWorkflows: Map<string, WorkflowTemplate> = new Map()
+
+/**
+ * Register (or override) a workflow template at runtime. Runtime templates take
+ * precedence over builtins with the same name.
+ */
+export function registerWorkflow(workflow: WorkflowTemplate): void {
+  runtimeWorkflows.set(workflow.name, { ...workflow, source: 'runtime' })
+}
+
+/** Remove a runtime-registered workflow. Builtins cannot be removed. */
+export function unregisterWorkflow(name: string): boolean {
+  return runtimeWorkflows.delete(name)
+}
+
+/** Get every available workflow (runtime overrides take precedence). */
+export function getAllWorkflows(): WorkflowTemplate[] {
+  const byName = new Map<string, WorkflowTemplate>()
+  for (const workflow of BUILTIN_WORKFLOWS) {
+    byName.set(workflow.name, { ...workflow, source: 'builtin' })
+  }
+  for (const [name, workflow] of runtimeWorkflows) {
+    byName.set(name, workflow)
+  }
+  return [...byName.values()]
+}
+
+/** Look up a single workflow by name (runtime overrides take precedence). */
+export function getWorkflow(name: string): WorkflowTemplate | undefined {
+  return getAllWorkflows().find((workflow) => workflow.name === name)
+}
+
+/** Stable list of workflow names for tool enums and docs. */
+export function getWorkflowNames(): string[] {
+  return getAllWorkflows().map((workflow) => workflow.name)
+}

--- a/apps/web/lib/ai/agent/workflows/registry.ts
+++ b/apps/web/lib/ai/agent/workflows/registry.ts
@@ -131,11 +131,27 @@ export const BUILTIN_WORKFLOWS: readonly WorkflowTemplate[] = [
 const runtimeWorkflows: Map<string, WorkflowTemplate> = new Map()
 
 /**
+ * Deep-clone a workflow so callers can't mutate registry/builtin state through
+ * shared array references (steps, triggers, skills).
+ */
+function cloneWorkflow(workflow: WorkflowTemplate): WorkflowTemplate {
+  return {
+    ...workflow,
+    triggers: [...workflow.triggers],
+    steps: [...workflow.steps],
+    ...(workflow.skills ? { skills: [...workflow.skills] } : {}),
+  }
+}
+
+/**
  * Register (or override) a workflow template at runtime. Runtime templates take
  * precedence over builtins with the same name.
  */
 export function registerWorkflow(workflow: WorkflowTemplate): void {
-  runtimeWorkflows.set(workflow.name, { ...workflow, source: 'runtime' })
+  runtimeWorkflows.set(workflow.name, {
+    ...cloneWorkflow(workflow),
+    source: 'runtime',
+  })
 }
 
 /** Remove a runtime-registered workflow. Builtins cannot be removed. */
@@ -147,10 +163,10 @@ export function unregisterWorkflow(name: string): boolean {
 export function getAllWorkflows(): WorkflowTemplate[] {
   const byName = new Map<string, WorkflowTemplate>()
   for (const workflow of BUILTIN_WORKFLOWS) {
-    byName.set(workflow.name, { ...workflow, source: 'builtin' })
+    byName.set(workflow.name, { ...cloneWorkflow(workflow), source: 'builtin' })
   }
   for (const [name, workflow] of runtimeWorkflows) {
-    byName.set(name, workflow)
+    byName.set(name, cloneWorkflow(workflow))
   }
   return [...byName.values()]
 }

--- a/apps/web/lib/ai/agent/workflows/types.ts
+++ b/apps/web/lib/ai/agent/workflows/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Dynamic workflow types.
+ *
+ * A workflow is a reusable, data-driven template for a multi-step
+ * investigation. The agent picks a template at runtime, instantiates it into a
+ * live plan (see `start_workflow`), then adapts the plan as findings emerge (see
+ * `update_plan`). Templates are data, not code, so they can be extended at
+ * runtime via the registry — the same pattern used by the skills loader.
+ */
+
+export type WorkflowSource = 'builtin' | 'runtime'
+
+export interface WorkflowTemplate {
+  /** Stable kebab-case identifier, e.g. `incident-investigation`. */
+  name: string
+  /** Human-readable title shown in the UI, e.g. `Incident Investigation`. */
+  title: string
+  /** One-line summary of what the workflow accomplishes. */
+  description: string
+  /** Example user phrases that should trigger this workflow. */
+  triggers: string[]
+  /** Ordered list of step titles used to seed the plan. */
+  steps: string[]
+  /** Skills the agent should consider loading for this workflow. */
+  skills?: string[]
+  /** Where the template came from (builtin vs registered at runtime). */
+  source?: WorkflowSource
+}

--- a/docs/content/ai-agent.mdx
+++ b/docs/content/ai-agent.mdx
@@ -66,6 +66,23 @@ single-step questions skip the plan entirely. The harness is a transparency aid
 layered on top of the tool loop; it does not change which tools run or the
 read-only safety guarantees.
 
+## Context Management
+
+On an unfamiliar host the agent can call `get_context` once to orient itself with
+a single snapshot instead of rediscovering everything query by query. The
+snapshot gathers, in parallel and with graceful degradation:
+
+- **ClickHouse version & uptime** — so queries target the right schema and avoid
+  version-specific column mistakes,
+- **Current user** — the connected ClickHouse user,
+- **Keeper/ZooKeeper availability** — whether replication coordination is configured,
+- **Memory pressure** — tracked vs. OS total/available memory,
+- **Changed settings** — how many settings differ from defaults (with notable names),
+- **Capabilities** — the agent's own tool count, loaded skills, and available workflows.
+
+Any unavailable source (e.g. a host without Keeper) is reported as such rather
+than failing the whole snapshot.
+
 ## Configuration
 
 The agent uses an OpenAI-compatible API. At minimum set `LLM_API_KEY`.
@@ -212,9 +229,10 @@ before using them.
 |---|---|
 | `ask_user` | Ask a structured clarifying question. |
 | `load_skill` | Load a specialized expert guide (see Skills below). |
+| `get_context` | Runtime context snapshot: version, user, Keeper, memory, settings, capabilities. |
 | `list_workflows` | List the available dynamic workflow templates. |
-| `start_workflow` | Start a workflow template as a live plan (see Workflow Harness below). |
-| `update_plan` | Create and update a live workflow checklist (see Workflow Harness below). |
+| `start_workflow` | Start a workflow template as a live plan (see Workflow Harness above). |
+| `update_plan` | Create and update a live workflow checklist (see Workflow Harness above). |
 
 ## Skills
 

--- a/docs/content/ai-agent.mdx
+++ b/docs/content/ai-agent.mdx
@@ -30,9 +30,29 @@ disabled unless explicitly enabled (see [Configuration](#configuration)).
 
 For multi-step tasks — incident investigations, health reports, cross-host
 comparisons, or any "find and fix" request — the agent runs a lightweight
-**planning harness**. It calls the `update_plan` tool to lay out an ordered
-checklist of steps up front, then updates it after each step so you can follow
-along live in the chat.
+**planning harness**. It lays out an ordered checklist of steps up front, then
+updates it after each step so you can follow along live in the chat.
+
+### Dynamic workflows
+
+The agent ships a set of **dynamic workflow templates** — data-driven runbooks it
+can launch with `start_workflow` and then adapt at runtime:
+
+| Workflow | Purpose |
+|---|---|
+| `incident-investigation` | Triage a reported problem to a root cause. |
+| `health-check` | Full cluster health sweep. |
+| `query-optimization` | Analyze and speed up a slow query. |
+| `capacity-planning` | Forecast storage and resource needs. |
+| `replication-triage` | Diagnose replication lag or failover. |
+| `migration-safety` | Assess a schema change before applying it. |
+
+When a request matches a template, the agent instantiates it into a plan
+(tailoring or extending the steps for the specific table/host) and proceeds. When
+nothing fits, it authors the plan directly with `update_plan`. Workflows are a
+registry, so cluster-specific runbooks can be registered at runtime. As the agent
+learns from intermediate results, it revises the plan — adding, dropping, or
+reordering steps — keeping the workflow checklist live and accurate.
 
 Each step has a status: `pending`, `in_progress`, or `completed`. Exactly one
 step is in progress at a time, rendered as a checklist with a progress bar:
@@ -192,6 +212,8 @@ before using them.
 |---|---|
 | `ask_user` | Ask a structured clarifying question. |
 | `load_skill` | Load a specialized expert guide (see Skills below). |
+| `list_workflows` | List the available dynamic workflow templates. |
+| `start_workflow` | Start a workflow template as a live plan (see Workflow Harness below). |
 | `update_plan` | Create and update a live workflow checklist (see Workflow Harness below). |
 
 ## Skills

--- a/docs/content/ai-agent.mdx
+++ b/docs/content/ai-agent.mdx
@@ -26,6 +26,26 @@ The agent runs in a bounded tool loop: it keeps calling tools until it has
 enough to answer, then stops. Destructive actions (kill query, optimize) are
 disabled unless explicitly enabled (see [Configuration](#configuration)).
 
+## Workflow Harness
+
+For multi-step tasks — incident investigations, health reports, cross-host
+comparisons, or any "find and fix" request — the agent runs a lightweight
+**planning harness**. It calls the `update_plan` tool to lay out an ordered
+checklist of steps up front, then updates it after each step so you can follow
+along live in the chat.
+
+Each step has a status: `pending`, `in_progress`, or `completed`. Exactly one
+step is in progress at a time, rendered as a checklist with a progress bar:
+
+- ✓ completed steps are struck through,
+- the in-progress step is highlighted with a spinner,
+- pending steps wait below.
+
+This makes the agent's reasoning transparent without slowing it down — simple
+single-step questions skip the plan entirely. The harness is a transparency aid
+layered on top of the tool loop; it does not change which tools run or the
+read-only safety guarantees.
+
 ## Configuration
 
 The agent uses an OpenAI-compatible API. At minimum set `LLM_API_KEY`.
@@ -172,6 +192,7 @@ before using them.
 |---|---|
 | `ask_user` | Ask a structured clarifying question. |
 | `load_skill` | Load a specialized expert guide (see Skills below). |
+| `update_plan` | Create and update a live workflow checklist (see Workflow Harness below). |
 
 ## Skills
 

--- a/scripts/build-skills-registry.ts
+++ b/scripts/build-skills-registry.ts
@@ -44,6 +44,8 @@ async function main() {
   const skillsDir = join(process.cwd(), '.agents', 'skills')
   const outputFile = join(
     process.cwd(),
+    'apps',
+    'web',
     'lib',
     'ai',
     'agent',


### PR DESCRIPTION
## Summary

Applies **agent-harness** research to the agent page by giving the agent an explicit, user-visible **workflow harness** — the planning/todo pattern modern harnesses (e.g. Claude Code) use — on top of the existing `ToolLoopAgent`.

Two layers:

1. **Plan harness** — a new `update_plan` tool the agent uses to maintain a live, step-by-step checklist for multi-step investigations. It renders in the chat as a progress-tracked checklist (`pending` / `in_progress` / `completed`).
2. **Dynamic workflows** — a data-driven, runtime-extensible registry of named runbook templates. The agent picks a template with `start_workflow`, instantiates it into a live plan, and adapts it (`customSteps` / `extraSteps`, then `update_plan`) as findings emerge.

This is purely additive and read-only — it changes neither which tools run nor the existing safety guarantees. Simple single-step questions skip the harness entirely.

## What's included

**Plan harness**
- `lib/ai/agent/tools/plan-tools.ts` — `update_plan` tool + shared `buildWorkflowPlan` helper (pure, no ClickHouse access)
- `components/agents/agent-workflow-plan.tsx` — checklist UI with status icons + progress bar
- Wired into `components/agents/chat/tool-output.tsx` (promoted-output rendering, same pattern as `query_and_visualize` / `agent_issues`)

**Dynamic workflows**
- `lib/ai/agent/workflows/` — `WorkflowTemplate` types + registry with 6 built-in runbooks (incident-investigation, health-check, query-optimization, capacity-planning, replication-triage, migration-safety) and `registerWorkflow()` for runtime extension (mirrors the dynamic skills loader)
- `lib/ai/agent/tools/workflow-tools.ts` — `list_workflows` + `start_workflow`

**Prompt + docs**
- System prompt: a Workflow Harness section (dynamic template selection + adaptive re-planning) and tool entries
- `docs/content/ai-agent.mdx`: Workflow Harness + Dynamic workflows sections and tool-table entries (per the keep-docs-in-sync rule)

## Testing
- `bun test` — new unit tests for `update_plan`, the workflow registry, `list_workflows`, and `start_workflow` (all green); existing `mcp-tool-adapter` suite still passes
- `tsc --noEmit` — clean
- `biome check` — clean on all touched files

> Note: the repo-wide pre-push `check` hook reports pre-existing lint issues in unrelated files (e.g. `health/webhook/route.ts`, `cluster-tools.test.ts`, `use-table-columns.ts`); none are in files touched by this PR.

🛠️ More work (richer system-table coverage in skills/prompt + agent context management) is planned in follow-up commits on this branch.

https://claude.ai/code/session_01Rp1eQpwhiJUHagNAgbCq1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rp1eQpwhiJUHagNAgbCq1q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent now supports multi-step workflow planning with live progress visualization, including a progress bar and interactive checklist.
  * Added predefined workflow templates for common tasks: incident investigation, health checks, query optimization, capacity planning, replication triage, and migration safety.
  * Agent can dynamically update workflow plans with step status tracking (pending, in-progress, completed).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->