### PR TITLE
fix(test): stop global mock.module pollution in the unit suite

### DIFF
--- a/apps/web/__mocks__/clerk-auth-mock.ts
+++ b/apps/web/__mocks__/clerk-auth-mock.ts
@@ -1,0 +1,26 @@
+import { mock } from 'bun:test'
+
+/**
+ * Shared Clerk auth mock for the agent API route tests.
+ *
+ * `mock.module()` registers a GLOBAL override, and in the aggregated
+ * `bun test` run the LAST registration wins for the whole process. When each
+ * route test mocked `@clerk/nextjs/server` over its own `mockClerkUserId`
+ * closure, a "returns 401 when unauthenticated" assertion in one file would
+ * read another file's authed user once the suites ran together (it passed in
+ * isolation, failed in CI).
+ *
+ * Routing every agent route test through this single module — backed by one
+ * shared, resettable `userId` — keeps the mock deterministic regardless of the
+ * order Bun loads the files in.
+ */
+const state: { userId: string | null } = { userId: null }
+
+/** Set the userId the mocked Clerk `auth()` resolves to (null = signed out). */
+export function setMockClerkUserId(userId: string | null): void {
+  state.userId = userId
+}
+
+mock.module('@clerk/nextjs/server', () => ({
+  auth: async () => ({ userId: state.userId }),
+}))

--- a/apps/web/app/api/v1/agent/__tests__/route.test.ts
+++ b/apps/web/app/api/v1/agent/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { setMockClerkUserId } from '@/__mocks__/clerk-auth-mock'
 import { AGENT_JSON_RENDER_MAX_SPEC_PART_BYTES } from '@/lib/ai/agent/json-render-catalog'
 import { AGENT_JSON_RENDER_INLINE_PROMPT } from '@/lib/ai/agent/json-render-inline-prompt'
 import { createJsonRenderPatchGuardStream } from '@/lib/ai/agent/json-render-patch-guard'
@@ -21,7 +22,6 @@ type CapturedAIArgs = {
 
 const capturedAgentArgs: Array<Record<string, unknown>> = []
 const capturedAIArgs: CapturedAIArgs[] = []
-let mockClerkUserId: string | null = null
 let mockAgentStreamError: unknown = null
 
 mock.module('@/lib/ai/agent', () => ({
@@ -128,12 +128,6 @@ mock.module('ai', () => {
   }
 })
 
-mock.module('@clerk/nextjs/server', () => ({
-  auth: async () => ({
-    userId: mockClerkUserId,
-  }),
-}))
-
 describe('POST /api/v1/agent', () => {
   const AGENT_API_TOKEN = 'test-agent-token'
 
@@ -158,7 +152,7 @@ describe('POST /api/v1/agent', () => {
   beforeEach(() => {
     capturedAgentArgs.length = 0
     capturedAIArgs.length = 0
-    mockClerkUserId = null
+    setMockClerkUserId(null)
     mockAgentStreamError = null
     process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'clerk'
     delete process.env.CHM_FEATURE_AGENT_ACCESS
@@ -269,7 +263,7 @@ describe('POST /api/v1/agent', () => {
 
   test('accepts Clerk session without Bearer token', async () => {
     process.env.CHM_FEATURE_AGENT_ACCESS = 'authenticated'
-    mockClerkUserId = 'user_123'
+    setMockClerkUserId('user_123')
 
     const request = new Request('http://localhost:3000/api/v1/agent', {
       method: 'POST',

--- a/apps/web/app/api/v1/agent/followups/__tests__/route.test.ts
+++ b/apps/web/app/api/v1/agent/followups/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { setMockClerkUserId } from '@/__mocks__/clerk-auth-mock'
 
 const generateTextMock = mock(async () => ({
   output: {
@@ -12,7 +13,6 @@ const generateTextMock = mock(async () => ({
 const outputObjectMock = mock((config: unknown) => config)
 const capturedModelOptions: Array<Record<string, unknown>> = []
 const AGENT_API_TOKEN = 'test-agent-token'
-let mockClerkUserId: string | null = null
 
 mock.module('server-only', () => ({}))
 mock.module('ai', () => ({
@@ -32,12 +32,6 @@ mock.module('@/lib/ai/agent/provider-chat-model', () => ({
     }
   },
 }))
-mock.module('@clerk/nextjs/server', () => ({
-  auth: async () => ({
-    userId: mockClerkUserId,
-  }),
-}))
-
 let POST: (request: Request) => Promise<Response>
 
 beforeAll(async () => {
@@ -50,7 +44,7 @@ beforeEach(() => {
   generateTextMock.mockClear()
   outputObjectMock.mockClear()
   capturedModelOptions.length = 0
-  mockClerkUserId = null
+  setMockClerkUserId(null)
   process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'clerk'
   delete process.env.CHM_FEATURE_AGENT_ACCESS
   delete process.env.LLM_API_KEY

--- a/apps/web/app/api/v1/agent/skills/__tests__/route.test.ts
+++ b/apps/web/app/api/v1/agent/skills/__tests__/route.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { setMockClerkUserId } from '@/__mocks__/clerk-auth-mock'
 
 const AGENT_API_TOKEN = 'test-agent-token'
-let mockClerkUserId: string | null = null
 let GET: (request: Request) => Promise<Response>
 
 mock.module('@/lib/ai/agent/skills/dynamic-loader', () => ({
@@ -14,12 +14,6 @@ mock.module('@/lib/ai/agent/skills/dynamic-loader', () => ({
   ],
 }))
 
-mock.module('@clerk/nextjs/server', () => ({
-  auth: async () => ({
-    userId: mockClerkUserId,
-  }),
-}))
-
 beforeAll(async () => {
   process.env.AGENT_API_TOKEN = AGENT_API_TOKEN
   const route = await import('../route')
@@ -30,7 +24,7 @@ beforeEach(() => {
   process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'none'
   delete process.env.CHM_AUTH_PROVIDER
   delete process.env.CHM_FEATURE_AGENT_ACCESS
-  mockClerkUserId = null
+  setMockClerkUserId(null)
 })
 
 describe('GET /api/v1/agent/skills', () => {
@@ -71,7 +65,7 @@ describe('GET /api/v1/agent/skills', () => {
   test('accepts Clerk session when Clerk auth is enabled', async () => {
     process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'clerk'
     process.env.CHM_FEATURE_AGENT_ACCESS = 'authenticated'
-    mockClerkUserId = 'user_123'
+    setMockClerkUserId('user_123')
 
     const response = await GET(skillsRequest())
 

--- a/apps/web/app/api/v1/agents/config-check/__tests__/route.test.ts
+++ b/apps/web/app/api/v1/agents/config-check/__tests__/route.test.ts
@@ -1,15 +1,10 @@
 import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { setMockClerkUserId } from '@/__mocks__/clerk-auth-mock'
 
 const AGENT_API_TOKEN = 'test-agent-token'
-let mockClerkUserId: string | null = null
 let GET: (request: Request) => Promise<Response>
 
 mock.module('server-only', () => ({}))
-mock.module('@clerk/nextjs/server', () => ({
-  auth: async () => ({
-    userId: mockClerkUserId,
-  }),
-}))
 
 beforeAll(async () => {
   process.env.AGENT_API_TOKEN = AGENT_API_TOKEN
@@ -30,7 +25,7 @@ beforeEach(() => {
   delete process.env.OPENROUTER_API_BASE
   delete process.env.NVIDIA_API_KEY
   delete process.env.NVIDIA_API_BASE
-  mockClerkUserId = null
+  setMockClerkUserId(null)
 })
 
 describe('GET /api/v1/agents/config-check', () => {
@@ -71,7 +66,7 @@ describe('GET /api/v1/agents/config-check', () => {
   test('accepts Clerk session when Clerk auth is enabled', async () => {
     process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'clerk'
     process.env.CHM_FEATURE_AGENT_ACCESS = 'authenticated'
-    mockClerkUserId = 'user_123'
+    setMockClerkUserId('user_123')
 
     const response = await GET(configRequest())
 

--- a/apps/web/app/api/v1/agents/models/__tests__/route.test.ts
+++ b/apps/web/app/api/v1/agents/models/__tests__/route.test.ts
@@ -7,18 +7,13 @@ import {
   mock,
   test,
 } from 'bun:test'
+import { setMockClerkUserId } from '@/__mocks__/clerk-auth-mock'
 
 const originalFetch = globalThis.fetch
 const AGENT_API_TOKEN = 'test-agent-token'
-let mockClerkUserId: string | null = null
 let GET: (request: Request) => Promise<Response>
 
 mock.module('server-only', () => ({}))
-mock.module('@clerk/nextjs/server', () => ({
-  auth: async () => ({
-    userId: mockClerkUserId,
-  }),
-}))
 
 beforeAll(async () => {
   process.env.AGENT_API_TOKEN = AGENT_API_TOKEN
@@ -30,7 +25,7 @@ beforeEach(() => {
   process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'none'
   delete process.env.CHM_AUTH_PROVIDER
   delete process.env.CHM_FEATURE_AGENT_ACCESS
-  mockClerkUserId = null
+  setMockClerkUserId(null)
 })
 
 afterEach(() => {
@@ -69,7 +64,7 @@ describe('GET /api/v1/agents/models', () => {
   test('accepts Clerk session when Clerk auth is enabled', async () => {
     process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'clerk'
     process.env.CHM_FEATURE_AGENT_ACCESS = 'authenticated'
-    mockClerkUserId = 'user_123'
+    setMockClerkUserId('user_123')
     globalThis.fetch = async () =>
       new Response(JSON.stringify({ data: [] }), { status: 200 })
 

--- a/apps/web/lib/hooks/__tests__/use-agent-session-stats.test.ts
+++ b/apps/web/lib/hooks/__tests__/use-agent-session-stats.test.ts
@@ -6,8 +6,14 @@ import {
 } from '../use-agent-session-stats'
 import { describe, expect, mock, test } from 'bun:test'
 
-// Mock React's useMemo to just call the factory directly (no React needed)
+// Mock React's useMemo to just call the factory directly (no React needed).
+// `mock.module('react')` is global AND persists across files in the aggregated
+// `bun test` run, so we MUST spread the real module — otherwise every later
+// test file loses `forwardRef`/`createContext`/etc. and breaks.
+const actualReact = await import('react')
+
 mock.module('react', () => ({
+  ...actualReact,
   useMemo: (factory: () => unknown) => factory(),
 }))
 

--- a/apps/web/lib/swr/__tests__/use-hosts.test.ts
+++ b/apps/web/lib/swr/__tests__/use-hosts.test.ts
@@ -6,13 +6,7 @@
  * is called with the correct parameters.
  */
 
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-} from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
 
 // Mock SWR before any imports that use it
 const mockUseSWR = mock(() => ({
@@ -46,8 +40,13 @@ mock.module('../api-fetch', () => ({
   apiFetch: mockApiFetch,
 }))
 
-// Mock React hooks
+// Mock React hooks. `mock.module('react')` is global AND persists across files
+// in the aggregated `bun test` run, so spread the real module — otherwise every
+// later test file loses `forwardRef`/`createContext`/etc. and breaks.
+const actualReact = await import('react')
+
 mock.module('react', () => ({
+  ...actualReact,
   useCallback: (fn: () => unknown) => fn,
 }))
 


### PR DESCRIPTION
## Problem

CI's `unit-tests` job runs the whole suite in one `bun test` process. Bun's `mock.module()` is a **global, persistent** override — it is *not* reset between files — so a partial mock in one file leaks into every file that loads after it. Tests passed in isolation but failed in CI:

- `React.forwardRef is not a function` / `createContext is undefined`
- `fetchViaBrowserProxy`, `createVisualizationTools`, `createIncidentTools` (downstream of the React breakage)
- agent route `returns 401 when Clerk auth is enabled` (read another file's authed user)

## Fixes

**React** — two files (`use-agent-session-stats`, `use-hosts`) mocked `react` *without* spreading the real module, replacing the entire module with a 1–2 key stub. Every later file then lost `forwardRef`/`createContext`/`useState`. Spread `...actualReact`, matching the five sibling mocks that already do this. (Verified: full-suite `forwardRef`/`createContext` errors 3 → 0; the browser-proxy / visualization / incident suites recover.)

**Clerk** — five agent route tests each mocked `@clerk/nextjs/server` over a *file-local* `mockClerkUserId`, and last-registration-wins meant a “401 when unauthenticated” assertion read another file’s authed user. Route them all through one shared, resettable mock: `apps/web/__mocks__/clerk-auth-mock.ts` (placed in `__mocks__/`, which the existing tsconfig rule excludes from type-checking, so it can import `bun:test` without tripping the build). (Verified: this consolidation alone took the local full-suite from 55 → 13 failures.)

Test-only changes; no runtime/production code touched.

## Verification
Local full `bun test`: the React cascade and the browser-proxy/visualization/incident failures are gone, and the agent-route Clerk pollution is consolidated. Watching CI `unit-tests` on this branch for the authoritative result (the local tree carries unrelated in-progress edits from a concurrent agent that CI does not).

Co-Authored-By: duyetbot <bot@duyet.net>