### PR TITLE
test(agent): fix context-tools mock contamination from #1279

### DIFF
--- a/apps/web/lib/ai/agent/tools/__tests__/context-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/context-tools.test.ts
@@ -1,51 +1,58 @@
-import { describe, expect, mock, test } from 'bun:test'
-import { z } from 'zod/v3'
-
-mock.module('server-only', () => ({}))
+import { mockFetchData } from './shared-mocks'
+import { describe, expect, test } from 'bun:test'
 
 let zookeeperAvailable = true
 
-// Mock the direct dependency (`./helpers`) rather than the deep
-// `@chm/clickhouse-client`. helpers.readOnlyQuery returns the data array
-// directly and throws on error, and mocking it here is immune to the suite-wide
-// mock-ordering leak that freezes the clickhouse-client binding.
-mock.module('../helpers', () => ({
-  hostIdSchema: z.number().int().min(0).optional(),
-  resolveHostId: (toolHostId: number | undefined, defaultHostId: number) =>
-    toolHostId ?? defaultHostId,
-  readOnlyQuery: mock(async ({ query }: { query: string }) => {
+// Use the shared `mockFetchData` (which mocks `@chm/clickhouse-client`) instead
+// of mocking `../helpers` directly. The real `helpers.readOnlyQuery` unwraps
+// `{ data, error }` and throws on error, so routing here mirrors ClickHouse.
+// This keeps the suite-global mock single-sourced and avoids contamination.
+function setupContextMock() {
+  mockFetchData.mockImplementation(async ({ query }: { query: string }) => {
     if (query.includes('version()')) {
-      return [
-        {
-          version: '24.3.1',
-          uptime_seconds: 12345,
-          current_user: 'monitor',
-          timezone: 'UTC',
-        },
-      ]
+      return {
+        data: [
+          {
+            version: '24.3.1',
+            uptime_seconds: 12345,
+            current_user: 'monitor',
+            timezone: 'UTC',
+          },
+        ],
+        error: null,
+      }
     }
     if (query.includes('asynchronous_metrics')) {
-      return [
-        { metric: 'OSMemoryTotal', value: 16000000000 },
-        { metric: 'OSMemoryAvailable', value: 8000000000 },
-        { metric: 'MemoryTracking', value: 4000000000 },
-      ]
+      return {
+        data: [
+          { metric: 'OSMemoryTotal', value: 16000000000 },
+          { metric: 'OSMemoryAvailable', value: 8000000000 },
+          { metric: 'MemoryTracking', value: 4000000000 },
+        ],
+        error: null,
+      }
     }
     if (query.includes('system.settings') && query.includes('changed = 1')) {
-      return [
-        { name: 'max_threads', value: '8' },
-        { name: 'max_memory_usage', value: '10000000000' },
-      ]
+      return {
+        data: [
+          { name: 'max_threads', value: '8' },
+          { name: 'max_memory_usage', value: '10000000000' },
+        ],
+        error: null,
+      }
     }
     if (query.includes('system.zookeeper')) {
       if (!zookeeperAvailable) {
-        throw new Error('Unknown table system.zookeeper')
+        return {
+          data: null,
+          error: { message: 'Unknown table system.zookeeper' },
+        }
       }
-      return [{ c: 3 }]
+      return { data: [{ c: 3 }], error: null }
     }
-    return []
-  }),
-}))
+    return { data: [], error: null }
+  })
+}
 
 const { createContextTools } = await import('../context-tools')
 
@@ -59,6 +66,7 @@ function getExecute(toolCount = 80) {
 describe('get_context', () => {
   test('returns a runtime context snapshot', async () => {
     zookeeperAvailable = true
+    setupContextMock()
     const result = await getExecute(82)({ hostId: 0 })
 
     expect(result.type).toBe('agent_context')
@@ -79,18 +87,21 @@ describe('get_context', () => {
 
   test('reports keeper as configured when system.zookeeper responds', async () => {
     zookeeperAvailable = true
+    setupContextMock()
     const result = await getExecute()({ hostId: 0 })
     expect((result.keeper as Record<string, unknown>).configured).toBe(true)
   })
 
   test('reports keeper as not configured when system.zookeeper is missing', async () => {
     zookeeperAvailable = false
+    setupContextMock()
     const result = await getExecute()({ hostId: 0 })
     expect((result.keeper as Record<string, unknown>).configured).toBe(false)
   })
 
   test('includes capabilities (tool count, skills, workflows)', async () => {
     zookeeperAvailable = true
+    setupContextMock()
     const result = await getExecute(99)({ hostId: 0 })
     const caps = result.capabilities as Record<string, unknown>
     expect(caps.toolCount).toBe(99)


### PR DESCRIPTION
## Problem

PR #1279 merged `context-tools.test.ts` using the old per-file `mock.module('../helpers')` pattern, which #1283 had just eliminated across all other agent-tool tests in favor of the shared `mockFetchData` (`shared-mocks.ts`). Because `mock.module()` is process-global, that one file's `../helpers` mock leaked into the shared-mocks setup and **reintroduced 26 suite failures** (`main` went from 0 → 27 fail in the combined run).

## Fix

Convert `context-tools.test.ts` to the established shared-mocks pattern: use the real `helpers` with the shared `mockFetchData` and a per-test `mockImplementation()` (returning `{ data, error }`, which the real `readOnlyQuery` unwraps). No file-level `mock.module()`.

## Result

- Combined suite: **27 fail → 1 fail**.
- The single remaining failure (`SWRProvider > exports swrConfig from config`) is **pre-existing and unrelated** — it fails on `main` with this file removed too.
- `context-tools.test.ts` passes in isolation (4/4) and in the full suite; `biome` clean.

https://claude.ai/code/session_01Rp1eQpwhiJUHagNAgbCq1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rp1eQpwhiJUHagNAgbCq1q)_