### PR TITLE
fix(ui): overview scroll-jump, agent menu gating, host badge truncation

### DIFF
--- a/apps/web/app/(dashboard)/overview/page.tsx
+++ b/apps/web/app/(dashboard)/overview/page.tsx
@@ -9,7 +9,7 @@ import { LazyChartWrapper } from '@/components/charts/lazy-chart-wrapper'
 import { ClientOnly } from '@/components/client-only'
 import { OverviewCharts } from '@/components/overview-charts/overview-charts-client'
 import { OverviewStatusStrip } from '@/components/overview-charts/overview-status-strip'
-import { ChartSkeleton, TabsSkeleton } from '@/components/skeletons'
+import { Skeleton, TabsSkeleton } from '@/components/skeletons'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useHostId } from '@/lib/swr'
 import { cn } from '@/lib/utils'
@@ -181,9 +181,32 @@ function OverviewPageContent() {
   )
 }
 
+/**
+ * Full-page loading fallback for the searchParams Suspense boundary.
+ *
+ * `OverviewPageContent` reads `useSearchParams()`/`useHostId()`, which Next.js
+ * requires to sit under Suspense. A tiny single-card fallback collapses the
+ * document to ~140px during that flash, so the scroll container has nothing to
+ * scroll and the viewport snaps back to the top. Reserving the real layout's
+ * height (status strip + KPI grid + tabs) keeps the scroll position stable.
+ */
+function OverviewPageFallback() {
+  return (
+    <div>
+      <Skeleton className="mb-3 h-10 w-full rounded-lg" />
+      <div className="mb-4 grid grid-cols-1 gap-3 sm:mb-6 sm:grid-cols-2 md:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 rounded-lg" />
+        ))}
+      </div>
+      <TabsSkeleton tabCount={OVERVIEW_TABS.length} />
+    </div>
+  )
+}
+
 export default function OverviewPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<OverviewPageFallback />}>
       <OverviewPageContent />
     </Suspense>
   )

--- a/apps/web/components/host/host-menu-row.tsx
+++ b/apps/web/components/host/host-menu-row.tsx
@@ -49,10 +49,12 @@ export const HostMenuRow = function HostMenuRow({
             title={`Version ${data.version} · Uptime ${data.uptime}`}
           >
             <TagIcon className="size-3 shrink-0 opacity-70" />
-            <span className="truncate tabular-nums">{data.version}</span>
-            <span className="opacity-40">·</span>
+            {/* Version is short and the priority — never shrink it. */}
+            <span className="shrink-0 tabular-nums">{data.version}</span>
+            <span className="shrink-0 opacity-40">·</span>
             <ClockIcon className="size-3 shrink-0 opacity-70" />
-            <span className="truncate tabular-nums">
+            {/* Uptime yields first: it needs min-w-0 to ellipsize inside a flex row. */}
+            <span className="min-w-0 truncate tabular-nums">
               {formatCompactUptime(data.uptime)}
             </span>
           </span>

--- a/apps/web/components/host/host-version-status.tsx
+++ b/apps/web/components/host/host-version-status.tsx
@@ -38,10 +38,12 @@ export function HostVersionWithStatus({ hostId }: HostVersionWithStatusProps) {
       >
         <StatusIndicatorOnline />
         <TagIcon className="size-3 shrink-0 opacity-70" />
-        <span className="truncate tabular-nums">{data.version}</span>
-        <span className="opacity-40">·</span>
+        {/* Version is short and the priority — never shrink it. */}
+        <span className="shrink-0 tabular-nums">{data.version}</span>
+        <span className="shrink-0 opacity-40">·</span>
         <ClockIcon className="size-3 shrink-0 opacity-70" />
-        <span className="truncate tabular-nums">
+        {/* Uptime yields first: it needs min-w-0 to ellipsize inside a flex row. */}
+        <span className="min-w-0 truncate tabular-nums">
           {formatCompactUptime(data.uptime)}
         </span>
       </span>

--- a/apps/web/lib/feature-permissions/server.test.ts
+++ b/apps/web/lib/feature-permissions/server.test.ts
@@ -121,6 +121,37 @@ access = "public"
     ).toBe(true)
   })
 
+  test('hides interaction-gated feature from anonymous when auth is enabled', () => {
+    // The agent renders for everyone but requires sign-in to use. With an auth
+    // provider active and an anonymous visitor, the menu entry must be hidden.
+    expect(
+      isFeatureAllowed(
+        { feature: 'agent', interactionGated: true },
+        { authProvider: 'clerk', principal: 'anonymous', features: {} }
+      )
+    ).toBe(false)
+  })
+
+  test('shows interaction-gated feature to authenticated users', () => {
+    expect(
+      isFeatureAllowed(
+        { feature: 'agent', interactionGated: true },
+        { authProvider: 'clerk', principal: 'authenticated', features: {} }
+      )
+    ).toBe(true)
+  })
+
+  test('shows interaction-gated feature when no auth provider is configured', () => {
+    // Without auth, every visitor is anonymous but no sign-in is possible, so
+    // the feature is fully usable and must stay visible.
+    expect(
+      isFeatureAllowed(
+        { feature: 'agent', interactionGated: true },
+        { authProvider: 'none', principal: 'anonymous', features: {} }
+      )
+    ).toBe(true)
+  })
+
   test('loads YAML overrides', async () => {
     await writeTempConfig(
       `

--- a/apps/web/lib/feature-permissions/shared.ts
+++ b/apps/web/lib/feature-permissions/shared.ts
@@ -89,6 +89,19 @@ export function isFeatureAllowed(
     return config.principal === 'authenticated'
   }
 
+  // Interaction-gated features (e.g. the agent) render their UI for everyone
+  // but require sign-in to actually use. When an auth provider is active and
+  // the visitor is anonymous, hide them from the menu instead of advertising a
+  // feature they can't use without logging in. With no auth provider everyone
+  // is anonymous yet no sign-in is possible, so keep them visible.
+  if (
+    permission?.interactionGated &&
+    config.authProvider !== 'none' &&
+    config.principal !== 'authenticated'
+  ) {
+    return false
+  }
+
   return true
 }
 


### PR DESCRIPTION
## Summary

Three small, independent UI fixes (reported from chmonitor.dev):

### 1. Overview page scroll jumps to top during loading
`/overview` reads `useSearchParams()`/`useHostId()`, which Next.js requires under a Suspense boundary. The fallback was a single `<ChartSkeleton />` (~140px), so during the loading flash the whole document collapsed — the scroll container had nothing to scroll and the viewport snapped back to top. Replaced it with a layout-matching fallback (status strip + KPI grid + tabs) that reserves realistic height, keeping scroll position stable.

### 2. AI Agent shown in menu even when login is required
Interaction-gated features (the agent) render their UI for everyone but require sign-in to actually use. Menu visibility (`isFeatureAllowed`) never accounted for `interactionGated`, so the entry was advertised to anonymous visitors even with auth enabled. Now an interaction-gated feature is hidden from the menu when an auth provider is active **and** the principal is anonymous. When no auth provider is configured (`authProvider: 'none'`), sign-in is impossible and the feature is fully usable, so it stays visible — this avoids wrongly hiding the agent on auth-less self-hosted deploys.

### 3. Host switcher truncates version/uptime into noise
Version and uptime both carried `truncate` and competed for flex space, producing useless `"26...."` / `"7..."` fragments. Pinned the short, higher-priority **version** with `shrink-0` and let only the **uptime** ellipsize (`min-w-0 truncate`) — applied to both the sidebar header (`host-version-status.tsx`) and the dropdown row (`host-menu-row.tsx`).

## Verification

- `lib/feature-permissions` unit tests: **29 pass / 0 fail** (added 3 cases covering the interaction-gated menu logic: anon+clerk hidden, authenticated shown, no-auth shown)
- `tsc --noEmit`: pass
- Biome: clean

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interaction-gated features now restrict access based on authentication status when an auth provider is configured.

* **UI/UX Improvements**
  * Overview page displays an enhanced full-page loading state during initial load.
  * Host version and uptime information display improved with better text handling and layout control.

* **Tests**
  * Expanded test coverage for authentication-based feature access rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->