### PR TITLE
feat(monitoring): add system.dropped_tables view at /dropped-tables

### DIFF
--- a/apps/web/app/(dashboard)/dropped-tables/page.tsx
+++ b/apps/web/app/(dashboard)/dropped-tables/page.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { Suspense } from 'react'
+import { PageLayout } from '@/components/layout/query-page'
+import { ChartSkeleton } from '@/components/skeletons'
+import { droppedTablesConfig } from '@/lib/query-config/tables/dropped-tables'
+
+function DroppedTablesPageContent() {
+  return <PageLayout queryConfig={droppedTablesConfig} title="Dropped Tables" />
+}
+
+export default function DroppedTablesPage() {
+  return (
+    <Suspense fallback={<ChartSkeleton />}>
+      <DroppedTablesPageContent />
+    </Suspense>
+  )
+}

--- a/apps/web/lib/query-config/index.ts
+++ b/apps/web/lib/query-config/index.ts
@@ -71,6 +71,7 @@ import {
 } from './system/replicas-status'
 import { detachedPartsConfig } from './tables/detached-parts'
 import { distributedDdlQueueConfig } from './tables/distributed-ddl-queue'
+import { droppedTablesConfig } from './tables/dropped-tables'
 import { partInfoConfig } from './tables/part-info'
 import { projectionsConfig } from './tables/projections'
 import { readOnlyTablesConfig } from './tables/readonly-tables'
@@ -93,6 +94,7 @@ export const queries: Array<QueryConfig> = [
   replicasConfig,
   replicationQueueConfig,
   readOnlyTablesConfig,
+  droppedTablesConfig,
   detachedPartsConfig,
   partInfoConfig,
   projectionsConfig,

--- a/apps/web/lib/query-config/tables/dropped-tables.ts
+++ b/apps/web/lib/query-config/tables/dropped-tables.ts
@@ -1,0 +1,29 @@
+import type { QueryConfig } from '@/types/query-config'
+
+import { ColumnFormat } from '@/types/column-format'
+
+export const droppedTablesConfig: QueryConfig = {
+  name: 'dropped-tables',
+  refreshInterval: 30_000,
+  description:
+    'Tables awaiting final asynchronous drop (Atomic database engine)',
+  // system.dropped_tables may not exist on every server / version
+  optional: true,
+  tableCheck: 'system.dropped_tables',
+  sql: `SELECT index, database, table, uuid, engine, metadata_dropped_path, table_dropped_time FROM system.dropped_tables ORDER BY table_dropped_time DESC`,
+  columns: [
+    'index',
+    'database',
+    'table',
+    'uuid',
+    'engine',
+    'metadata_dropped_path',
+    'table_dropped_time',
+  ],
+  columnFormats: {
+    database: ColumnFormat.ColoredBadge,
+    table: ColumnFormat.ColoredBadge,
+    engine: ColumnFormat.ColoredBadge,
+    table_dropped_time: ColumnFormat.RelatedTime,
+  },
+}

--- a/apps/web/menu.ts
+++ b/apps/web/menu.ts
@@ -31,6 +31,7 @@ import {
   ShieldAlertIcon,
   ShieldIcon,
   SparklesIcon,
+  Trash2Icon,
   TrendingUpIcon,
   UngroupIcon,
   UnplugIcon,
@@ -211,6 +212,14 @@ export const menuItemsConfig: MenuItem[] = [
         countVariant: 'destructive',
         icon: ExclamationTriangleIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/replicas',
+      },
+      {
+        title: 'Dropped Tables',
+        href: '/dropped-tables',
+        description:
+          'Tables awaiting final asynchronous drop (Atomic database engine)',
+        icon: Trash2Icon,
+        docs: 'https://clickhouse.com/docs/en/operations/system-tables/dropped_tables',
       },
       {
         title: 'Dictionaries',


### PR DESCRIPTION
Adds a monitored table view for `system.dropped_tables` at `/dropped-tables`.

- New query config (optional + tableCheck so it degrades gracefully when the table is absent)
- New static page under app/(dashboard)/dropped-tables
- Registered in lib/query-config/index.ts and menu.ts

Docs: https://clickhouse.com/docs/en/operations/system-tables/dropped_tables

Co-Authored-By: duyetbot <bot@duyet.net>