### PR TITLE
feat(monitoring): add system.moves view at /moves

### DIFF
--- a/apps/web/app/(dashboard)/moves/page.tsx
+++ b/apps/web/app/(dashboard)/moves/page.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { Suspense } from 'react'
+import { PageLayout } from '@/components/layout/query-page'
+import { ChartSkeleton } from '@/components/skeletons'
+import { movesConfig } from '@/lib/query-config/tables/moves'
+
+function MovesPageContent() {
+  return <PageLayout queryConfig={movesConfig} title="Moves" />
+}
+
+export default function MovesPage() {
+  return (
+    <Suspense fallback={<ChartSkeleton />}>
+      <MovesPageContent />
+    </Suspense>
+  )
+}

--- a/apps/web/lib/query-config/index.ts
+++ b/apps/web/lib/query-config/index.ts
@@ -72,6 +72,7 @@ import {
 import { detachedPartsConfig } from './tables/detached-parts'
 import { distributedDdlQueueConfig } from './tables/distributed-ddl-queue'
 import { droppedTablesConfig } from './tables/dropped-tables'
+import { movesConfig } from './tables/moves'
 import { partInfoConfig } from './tables/part-info'
 import { projectionsConfig } from './tables/projections'
 import { readOnlyTablesConfig } from './tables/readonly-tables'
@@ -93,6 +94,7 @@ export const queries: Array<QueryConfig> = [
   distributedDdlQueueConfig,
   replicasConfig,
   replicationQueueConfig,
+  movesConfig,
   readOnlyTablesConfig,
   droppedTablesConfig,
   detachedPartsConfig,

--- a/apps/web/lib/query-config/tables/moves.ts
+++ b/apps/web/lib/query-config/tables/moves.ts
@@ -1,0 +1,22 @@
+import type { QueryConfig } from '@/types/query-config'
+
+export const movesConfig: QueryConfig = {
+  name: 'moves',
+  description:
+    'In-progress part moves between disks and volumes (TTL / storage policy)',
+  refreshInterval: 30_000,
+  // system.moves may not exist on every server / version
+  optional: true,
+  tableCheck: 'system.moves',
+  sql: `SELECT database, table, elapsed, formatReadableTimeDelta(elapsed) AS readable_elapsed, target_disk_name, target_disk_path, part_name, formatReadableSize(part_size) AS readable_part_size, thread_id FROM system.moves ORDER BY elapsed DESC`,
+  columns: [
+    'database',
+    'table',
+    'readable_elapsed',
+    'target_disk_name',
+    'target_disk_path',
+    'part_name',
+    'readable_part_size',
+    'thread_id',
+  ],
+}

--- a/apps/web/menu.ts
+++ b/apps/web/menu.ts
@@ -26,6 +26,7 @@ import {
   HardDriveIcon,
   HeartPulseIcon,
   KeyIcon,
+  MoveIcon,
   RollerCoasterIcon,
   ScrollTextIcon,
   ShieldAlertIcon,
@@ -264,6 +265,14 @@ export const menuItemsConfig: MenuItem[] = [
         description: 'Table mutation status with progress and failures',
         icon: UpdateIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/mutations',
+      },
+      {
+        title: 'Moves',
+        href: '/moves',
+        description:
+          'In-progress part moves between disks and volumes (TTL / storage policy)',
+        icon: MoveIcon,
+        docs: 'https://clickhouse.com/docs/en/operations/system-tables/moves',
       },
     ],
   },


### PR DESCRIPTION
Adds a monitored table view for `system.moves` at `/moves`.

- New query config (optional + tableCheck so it degrades gracefully when the table is absent)
- New static page under app/(dashboard)/moves
- Registered in lib/query-config/index.ts and menu.ts

Docs: https://clickhouse.com/docs/en/operations/system-tables/moves

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Moves dashboard page to track in-progress part moves with time and size information
  * Added Moves menu item for easy navigation to the new dashboard

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->