### PR TITLE
feat(monitoring): add system.warnings view at /warnings

### DIFF
--- a/apps/web/app/(dashboard)/warnings/page.tsx
+++ b/apps/web/app/(dashboard)/warnings/page.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { Suspense } from 'react'
+import { PageLayout } from '@/components/layout/query-page'
+import { ChartSkeleton } from '@/components/skeletons'
+import { warningsConfig } from '@/lib/query-config/system/warnings'
+
+function WarningsPageContent() {
+  return <PageLayout queryConfig={warningsConfig} title="Warnings" />
+}
+
+export default function WarningsPage() {
+  return (
+    <Suspense fallback={<ChartSkeleton />}>
+      <WarningsPageContent />
+    </Suspense>
+  )
+}

--- a/apps/web/lib/query-config/index.ts
+++ b/apps/web/lib/query-config/index.ts
@@ -69,6 +69,7 @@ import {
   clustersReplicasStatusConfig,
   replicaTablesConfig,
 } from './system/replicas-status'
+import { warningsConfig } from './system/warnings'
 import { detachedPartsConfig } from './tables/detached-parts'
 import { distributedDdlQueueConfig } from './tables/distributed-ddl-queue'
 import { droppedTablesConfig } from './tables/dropped-tables'
@@ -154,6 +155,7 @@ export const queries: Array<QueryConfig> = [
   databaseDiskSpaceByDatabaseConfig,
   databaseTableColumnsConfig,
   tablesListConfig,
+  warningsConfig,
 
   // Security
   sessionsConfig,

--- a/apps/web/lib/query-config/system/warnings.ts
+++ b/apps/web/lib/query-config/system/warnings.ts
@@ -1,0 +1,13 @@
+import type { QueryConfig } from '@/types/query-config'
+
+export const warningsConfig: QueryConfig = {
+  name: 'warnings',
+  description:
+    'Server-side warnings about potential configuration or operational issues',
+  // system.warnings may not exist on every server / ClickHouse version
+  optional: true,
+  tableCheck: 'system.warnings',
+  refreshInterval: 30_000,
+  sql: `SELECT message FROM system.warnings`,
+  columns: ['message'],
+}

--- a/apps/web/menu.ts
+++ b/apps/web/menu.ts
@@ -16,6 +16,7 @@ import {
   UpdateIcon,
 } from '@radix-ui/react-icons'
 import {
+  AlertTriangleIcon,
   BookOpenIcon,
   CircleDollarSignIcon,
   CombineIcon,
@@ -506,6 +507,14 @@ export const menuItemsConfig: MenuItem[] = [
         countLabel: 'disks',
         icon: HardDriveIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/disks',
+      },
+      {
+        title: 'Warnings',
+        href: '/warnings',
+        description:
+          'Server-side warnings about potential configuration or operational issues',
+        icon: AlertTriangleIcon,
+        docs: 'https://clickhouse.com/docs/en/operations/system-tables/warnings',
       },
     ],
   },


### PR DESCRIPTION
Adds a monitored table view for `system.warnings` at `/warnings`.

- New query config (optional + tableCheck so it degrades gracefully when the table is absent)
- New static page under app/(dashboard)/warnings
- Registered in lib/query-config/index.ts and menu.ts

Docs: https://clickhouse.com/docs/en/operations/system-tables/warnings

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Warnings page accessible from the System menu in the dashboard
  * Displays server warnings with automatic 30-second refresh intervals

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->