### PR TITLE
feat(monitoring): add system.user_processes view at /user-processes

### DIFF
--- a/apps/web/app/(dashboard)/user-processes/page.tsx
+++ b/apps/web/app/(dashboard)/user-processes/page.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { Suspense } from 'react'
+import { PageLayout } from '@/components/layout/query-page'
+import { ChartSkeleton } from '@/components/skeletons'
+import { userProcessesConfig } from '@/lib/query-config/tables/user-processes'
+
+function UserProcessesPageContent() {
+  return <PageLayout queryConfig={userProcessesConfig} title="User Processes" />
+}
+
+export default function UserProcessesPage() {
+  return (
+    <Suspense fallback={<ChartSkeleton />}>
+      <UserProcessesPageContent />
+    </Suspense>
+  )
+}

--- a/apps/web/lib/query-config/index.ts
+++ b/apps/web/lib/query-config/index.ts
@@ -82,6 +82,7 @@ import { replicasConfig } from './tables/replicas'
 import { replicatedFetchesConfig } from './tables/replicated-fetches'
 import { replicationQueueConfig } from './tables/replication-queue'
 import { tablesOverviewConfig } from './tables/tables-overview'
+import { userProcessesConfig } from './tables/user-processes'
 import { viewRefreshesConfig } from './tables/view-refreshes'
 export const queries: Array<QueryConfig> = [
   // Explorer
@@ -117,6 +118,7 @@ export const queries: Array<QueryConfig> = [
   expensiveQueriesConfig,
   expensiveQueriesByMemoryConfig,
   slowQueriesConfig,
+  userProcessesConfig,
 
   // Merges
   mergesConfig,

--- a/apps/web/lib/query-config/tables/user-processes.ts
+++ b/apps/web/lib/query-config/tables/user-processes.ts
@@ -1,0 +1,18 @@
+import type { QueryConfig } from '@/types/query-config'
+
+export const userProcessesConfig: QueryConfig = {
+  name: 'user-processes',
+  description: 'Per-user memory usage and resource summary',
+  refreshInterval: 30_000,
+  // system.user_processes may not exist on every server / version
+  optional: true,
+  tableCheck: 'system.user_processes',
+  sql: `SELECT user, formatReadableSize(memory_usage) AS readable_memory, formatReadableSize(peak_memory_usage) AS readable_peak_memory, memory_usage, peak_memory_usage FROM system.user_processes ORDER BY memory_usage DESC`,
+  columns: [
+    'user',
+    'readable_memory',
+    'readable_peak_memory',
+    'memory_usage',
+    'peak_memory_usage',
+  ],
+}

--- a/apps/web/menu.ts
+++ b/apps/web/menu.ts
@@ -152,6 +152,14 @@ export const menuItemsConfig: MenuItem[] = [
         isNew: true,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_thread_log',
       },
+      {
+        title: 'User Processes',
+        href: '/user-processes',
+        description: 'Per-user memory usage and resource summary',
+        icon: UsersIcon,
+        isNew: true,
+        docs: 'https://clickhouse.com/docs/en/operations/system-tables/user_processes',
+      },
     ],
   },
   {


### PR DESCRIPTION
Adds a monitored table view for `system.user_processes` at `/user-processes`.

- New query config (optional + tableCheck so it degrades gracefully when the table is absent)
- New static page under app/(dashboard)/user-processes
- Registered in lib/query-config/index.ts and menu.ts

Docs: https://clickhouse.com/docs/en/operations/system-tables/user_processes

Co-Authored-By: duyetbot <bot@duyet.net>