### PR TITLE
feat(monitoring): add system.replicated_fetches view at /replicated-fetches

### DIFF
--- a/apps/web/app/(dashboard)/replicated-fetches/page.tsx
+++ b/apps/web/app/(dashboard)/replicated-fetches/page.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { Suspense } from 'react'
+import { PageLayout } from '@/components/layout/query-page'
+import { ChartSkeleton } from '@/components/skeletons'
+import { replicatedFetchesConfig } from '@/lib/query-config/tables/replicated-fetches'
+
+function ReplicatedFetchesPageContent() {
+  return (
+    <PageLayout
+      queryConfig={replicatedFetchesConfig}
+      title="Replicated Fetches"
+    />
+  )
+}
+
+export default function ReplicatedFetchesPage() {
+  return (
+    <Suspense fallback={<ChartSkeleton />}>
+      <ReplicatedFetchesPageContent />
+    </Suspense>
+  )
+}

--- a/apps/web/lib/query-config/index.ts
+++ b/apps/web/lib/query-config/index.ts
@@ -78,6 +78,7 @@ import { partInfoConfig } from './tables/part-info'
 import { projectionsConfig } from './tables/projections'
 import { readOnlyTablesConfig } from './tables/readonly-tables'
 import { replicasConfig } from './tables/replicas'
+import { replicatedFetchesConfig } from './tables/replicated-fetches'
 import { replicationQueueConfig } from './tables/replication-queue'
 import { tablesOverviewConfig } from './tables/tables-overview'
 import { viewRefreshesConfig } from './tables/view-refreshes'
@@ -96,6 +97,7 @@ export const queries: Array<QueryConfig> = [
   replicasConfig,
   replicationQueueConfig,
   movesConfig,
+  replicatedFetchesConfig,
   readOnlyTablesConfig,
   droppedTablesConfig,
   detachedPartsConfig,

--- a/apps/web/lib/query-config/tables/replicated-fetches.ts
+++ b/apps/web/lib/query-config/tables/replicated-fetches.ts
@@ -1,0 +1,42 @@
+import type { QueryConfig } from '@/types/query-config'
+
+export const replicatedFetchesConfig: QueryConfig = {
+  name: 'replicated-fetches',
+  description:
+    'Currently executing background part downloads from replica sources',
+  // system.replicated_fetches can be absent on servers/versions without
+  // replicated tables or active fetches
+  optional: true,
+  tableCheck: 'system.replicated_fetches',
+  refreshInterval: 30_000,
+  sql: `
+      SELECT
+        database,
+        table,
+        elapsed,
+        formatReadableTimeDelta(elapsed) AS readable_elapsed,
+        round(progress * 100, 1) AS progress_pct,
+        result_part_name,
+        formatReadableSize(total_size_bytes_compressed) AS readable_size,
+        formatReadableSize(bytes_read_compressed) AS readable_read,
+        source_replica_hostname,
+        source_replica_port,
+        to_detached,
+        thread_id
+      FROM system.replicated_fetches
+      ORDER BY elapsed DESC
+    `,
+  columns: [
+    'database',
+    'table',
+    'readable_elapsed',
+    'progress_pct',
+    'result_part_name',
+    'readable_size',
+    'readable_read',
+    'source_replica_hostname',
+    'source_replica_port',
+    'to_detached',
+    'thread_id',
+  ],
+}

--- a/apps/web/menu.ts
+++ b/apps/web/menu.ts
@@ -21,6 +21,7 @@ import {
   CircleDollarSignIcon,
   CombineIcon,
   CpuIcon,
+  DownloadIcon,
   EyeIcon,
   GitCompareArrowsIcon,
   Grid2x2CheckIcon,
@@ -204,6 +205,14 @@ export const menuItemsConfig: MenuItem[] = [
         countLabel: 'pending',
         icon: ShuffleIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/replication_queue',
+      },
+      {
+        title: 'Replicated Fetches',
+        href: '/replicated-fetches',
+        description:
+          'Currently executing background part downloads from replica sources',
+        icon: DownloadIcon,
+        docs: 'https://clickhouse.com/docs/en/operations/system-tables/replicated_fetches',
       },
       {
         title: 'Readonly Tables',


### PR DESCRIPTION
Adds a monitored table view for `system.replicated_fetches` at `/replicated-fetches`.

- New query config (optional + tableCheck so it degrades gracefully when the table is absent)
- New static page under app/(dashboard)/replicated-fetches
- Registered in lib/query-config/index.ts and menu.ts

Docs: https://clickhouse.com/docs/en/operations/system-tables/replicated_fetches

Co-Authored-By: duyetbot <bot@duyet.net>