### PR TITLE
feat(monitoring): add system.replicated_merge_tree_settings view at /replicated-merge-tree-settings

### DIFF
--- a/apps/web/app/(dashboard)/replicated-merge-tree-settings/page.tsx
+++ b/apps/web/app/(dashboard)/replicated-merge-tree-settings/page.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { Suspense } from 'react'
+import { PageLayout } from '@/components/layout/query-page'
+import { ChartSkeleton } from '@/components/skeletons'
+import { replicatedMergeTreeSettingsConfig } from '@/lib/query-config/system/replicated-merge-tree-settings'
+
+function ReplicatedMergeTreeSettingsPageContent() {
+  return (
+    <PageLayout
+      queryConfig={replicatedMergeTreeSettingsConfig}
+      title="Replicated MergeTree Settings"
+    />
+  )
+}
+
+export default function ReplicatedMergeTreeSettingsPage() {
+  return (
+    <Suspense fallback={<ChartSkeleton />}>
+      <ReplicatedMergeTreeSettingsPageContent />
+    </Suspense>
+  )
+}

--- a/apps/web/lib/query-config/index.ts
+++ b/apps/web/lib/query-config/index.ts
@@ -69,6 +69,7 @@ import {
   clustersReplicasStatusConfig,
   replicaTablesConfig,
 } from './system/replicas-status'
+import { replicatedMergeTreeSettingsConfig } from './system/replicated-merge-tree-settings'
 import { warningsConfig } from './system/warnings'
 import { detachedPartsConfig } from './tables/detached-parts'
 import { distributedDdlQueueConfig } from './tables/distributed-ddl-queue'
@@ -125,6 +126,7 @@ export const queries: Array<QueryConfig> = [
   // Settings
   settingsConfig,
   mergeTreeSettingsConfig,
+  replicatedMergeTreeSettingsConfig,
 
   // Top Usage
   topUsageTablesConfig,

--- a/apps/web/lib/query-config/system/replicated-merge-tree-settings.ts
+++ b/apps/web/lib/query-config/system/replicated-merge-tree-settings.ts
@@ -1,0 +1,19 @@
+import type { QueryConfig } from '@/types/query-config'
+
+import { ColumnFormat } from '@/types/column-format'
+
+export const replicatedMergeTreeSettingsConfig: QueryConfig = {
+  name: 'replicated-merge-tree-settings',
+  description:
+    'Replicated MergeTree engine settings and whether each was changed from default',
+  // system.replicated_merge_tree_settings may not exist on every server / version
+  optional: true,
+  tableCheck: 'system.replicated_merge_tree_settings',
+  sql: `SELECT name, value, changed, description, type FROM system.replicated_merge_tree_settings ORDER BY name`,
+  columns: ['name', 'value', 'changed', 'description', 'type'],
+  columnFormats: {
+    changed: ColumnFormat.Boolean,
+    value: ColumnFormat.Code,
+    type: ColumnFormat.ColoredBadge,
+  },
+}

--- a/apps/web/menu.ts
+++ b/apps/web/menu.ts
@@ -33,6 +33,7 @@ import {
   ScrollTextIcon,
   ShieldAlertIcon,
   ShieldIcon,
+  SlidersHorizontalIcon,
   SparklesIcon,
   Trash2Icon,
   TrendingUpIcon,
@@ -507,6 +508,14 @@ export const menuItemsConfig: MenuItem[] = [
         icon: TableIcon,
         permission: { feature: 'settings' },
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/merge_tree_settings',
+      },
+      {
+        title: 'Replicated MergeTree Settings',
+        href: '/replicated-merge-tree-settings',
+        description:
+          'Replicated MergeTree engine settings and whether each was changed from default',
+        icon: SlidersHorizontalIcon,
+        docs: 'https://clickhouse.com/docs/en/operations/system-tables/replicated_merge_tree_settings',
       },
       {
         title: 'Disks',


### PR DESCRIPTION
Adds a monitored table view for `system.replicated_merge_tree_settings` at `/replicated-merge-tree-settings`.

- New query config (optional + tableCheck so it degrades gracefully when the table is absent)
- New static page under app/(dashboard)/replicated-merge-tree-settings
- Registered in lib/query-config/index.ts and menu.ts

Docs: https://clickhouse.com/docs/en/operations/system-tables/replicated_merge_tree_settings

Co-Authored-By: duyetbot <bot@duyet.net>