### PR TITLE
feat(peerdb): enhance peers table with logos + mirror stats, center topology expand button

### DIFF
--- a/apps/web/app/(peerdb)/peerdb/page.tsx
+++ b/apps/web/app/(peerdb)/peerdb/page.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import {
+  ChevronDownIcon,
+  ChevronUpIcon,
   ExternalLinkIcon,
-  Maximize2Icon,
   NetworkIcon,
   RefreshCwIcon,
   SearchIcon,
@@ -376,10 +377,10 @@ export default function PeerDBMirrorsPage() {
         />
       </div>
 
-      {/* topology card */}
-      <div className="mb-4 overflow-hidden rounded-xl border border-border bg-card">
-        <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
-          <div className="flex min-w-0 items-center gap-2">
+      {/* topology card — expand button centered on bottom border */}
+      <div className="mb-6 relative">
+        <div className="overflow-hidden rounded-xl border border-border bg-card">
+          <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-3">
             <NetworkIcon className="size-3.5 text-muted-foreground" />
             <h2 className="text-[13px] font-semibold">Peer topology</h2>
             <span className="inline-flex items-center rounded-md border border-border bg-muted px-1.5 py-0.5 font-mono text-[10.5px] font-medium text-muted-foreground">
@@ -389,20 +390,30 @@ export default function PeerDBMirrorsPage() {
               live flow visualization
             </span>
           </div>
+          {graphOpen && (
+            <div className="p-4">
+              <PeerGraph
+                peers={peers}
+                mirrors={mirrors}
+                className="h-[420px]"
+              />
+            </div>
+          )}
+        </div>
+        <div className="absolute bottom-0 left-0 right-0 flex justify-center translate-y-1/2">
           <button
             type="button"
             onClick={() => setGraphOpen((v) => !v)}
-            className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground"
+            className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3.5 py-1 text-[11px] font-medium text-muted-foreground shadow-sm hover:bg-muted hover:text-foreground transition-colors"
           >
-            <Maximize2Icon className="size-3" />
+            {graphOpen ? (
+              <ChevronUpIcon className="size-3" />
+            ) : (
+              <ChevronDownIcon className="size-3" />
+            )}
             {graphOpen ? 'Collapse' : 'Expand'}
           </button>
         </div>
-        {graphOpen && (
-          <div className="p-4">
-            <PeerGraph peers={peers} mirrors={mirrors} className="h-[420px]" />
-          </div>
-        )}
       </div>
 
       {/* mirror table card */}

--- a/apps/web/app/(peerdb)/peerdb/peers/page.tsx
+++ b/apps/web/app/(peerdb)/peerdb/peers/page.tsx
@@ -3,9 +3,12 @@
 import type {
   ListMirrorsResponse,
   ListPeersResponse,
+  MirrorListItem,
   PeerListItem,
 } from '@/lib/peerdb/types'
 
+import { useMemo } from 'react'
+import { DbLogo, hasDbLogo } from '@/components/icons/peerdb-logo'
 import { PeerGraph } from '@/components/peerdb/peer-graph'
 import { PeerTypeIcon } from '@/components/peerdb/peer-type-icon'
 import { PeerDBConnectionStatus } from '@/components/peerdb/peerdb-connection-status'
@@ -13,6 +16,10 @@ import { PeerDBNotConfigured } from '@/components/peerdb/peerdb-not-configured'
 import {
   dbTypeLabel,
   isPeerDBNotConfigured,
+  normalizeDbType,
+  peerKind,
+  statusTone,
+  TONE_COLOR,
 } from '@/components/peerdb/peerdb-utils'
 import { AppLink } from '@/components/ui/app-link'
 import {
@@ -25,6 +32,59 @@ import {
 } from '@/components/ui/table'
 import { usePeerDB } from '@/lib/swr'
 
+/** Per-peer aggregate derived from the mirrors list. */
+interface PeerStats {
+  /** Number of mirrors where this peer is the source. */
+  sourceCount: number
+  /** Number of mirrors where this peer is the destination. */
+  destCount: number
+  /** Worst mirror status tone among mirrors touching this peer. */
+  worstTone: string | null
+  /** Mirror counts by status tone. */
+  toneCounts: Record<string, number>
+}
+
+function computePeerStats(
+  peerName: string,
+  mirrors: MirrorListItem[]
+): PeerStats {
+  const sourceCount = mirrors.filter((m) => m.sourceName === peerName).length
+  const destCount = mirrors.filter((m) => m.destinationName === peerName).length
+  const toneCounts: Record<string, number> = {}
+  for (const m of mirrors) {
+    if (m.sourceName !== peerName && m.destinationName !== peerName) continue
+    const t = statusTone(m.status)
+    toneCounts[t] = (toneCounts[t] ?? 0) + 1
+  }
+  const priority = ['failed', 'paused', 'progress', 'running', 'idle']
+  let worstTone: string | null = null
+  for (const t of priority) {
+    if (toneCounts[t]) {
+      worstTone = t
+      break
+    }
+  }
+  return { sourceCount, destCount, worstTone, toneCounts }
+}
+
+/** A single tone dot used in the status summary. */
+function ToneDot({ tone, count }: { tone: string; count: number }) {
+  return (
+    <span
+      className="inline-flex items-center gap-1 text-[11px]"
+      title={`${count} ${tone}`}
+    >
+      <span
+        className="size-1.5 rounded-full shrink-0"
+        style={{
+          background: TONE_COLOR[tone as keyof typeof TONE_COLOR] ?? '#94a3b8',
+        }}
+      />
+      <span className="tabular-nums text-muted-foreground">{count}</span>
+    </span>
+  )
+}
+
 export default function PeerDBPeersPage() {
   const peersReq = usePeerDB<ListPeersResponse>('/peers/list', {
     refreshInterval: 60_000,
@@ -33,10 +93,8 @@ export default function PeerDBPeersPage() {
     refreshInterval: 60_000,
   })
 
-  // PeerDB returns `items` plus split source/destination lists; merge + dedupe.
-  // Memoized so PeerGraph's dagre layout only recomputes when the data changes,
-  // not on every render (which would reset node positions and the viewport).
-  const peers = (() => {
+  // Merge + dedupe peers from all list buckets.
+  const peers = useMemo(() => {
     const seen = new Map<string, PeerListItem>()
     for (const p of [
       ...(peersReq.data?.items ?? []),
@@ -46,8 +104,18 @@ export default function PeerDBPeersPage() {
       if (p?.name && !seen.has(p.name)) seen.set(p.name, p)
     }
     return Array.from(seen.values())
-  })()
+  }, [peersReq.data])
+
   const mirrors = mirrorsReq.data?.mirrors ?? []
+
+  // Pre-compute per-peer stats from the mirrors list.
+  const statsMap = useMemo(() => {
+    const m = new Map<string, PeerStats>()
+    for (const p of peers) {
+      m.set(p.name, computePeerStats(p.name, mirrors))
+    }
+    return m
+  }, [peers, mirrors])
 
   if (isPeerDBNotConfigured(peersReq.error)) {
     return <PeerDBNotConfigured />
@@ -73,35 +141,109 @@ export default function PeerDBPeersPage() {
             <TableRow>
               <TableHead>Peer</TableHead>
               <TableHead>Type</TableHead>
+              <TableHead className="text-center">Source</TableHead>
+              <TableHead className="text-center">Destination</TableHead>
+              <TableHead>Status</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {peers.length === 0 ? (
               <TableRow>
                 <TableCell
-                  colSpan={2}
+                  colSpan={5}
                   className="py-8 text-center text-sm text-muted-foreground"
                 >
                   {peersReq.isLoading ? 'Loading peers…' : 'No peers found.'}
                 </TableCell>
               </TableRow>
             ) : (
-              peers.map((p) => (
-                <TableRow key={p.name}>
-                  <TableCell>
-                    <AppLink
-                      href={`/peerdb/peer?name=${encodeURIComponent(p.name)}`}
-                      className="inline-flex items-center gap-2 font-medium text-primary hover:underline"
-                    >
-                      <PeerTypeIcon type={p.type} />
-                      {p.name}
-                    </AppLink>
-                  </TableCell>
-                  <TableCell className="text-sm text-muted-foreground">
-                    {dbTypeLabel(p.type)}
-                  </TableCell>
-                </TableRow>
-              ))
+              peers.map((p) => {
+                const stats = statsMap.get(p.name)
+                const normalizedType = normalizeDbType(p.type)
+                const hasLogo = hasDbLogo(normalizedType)
+                return (
+                  <TableRow key={p.name}>
+                    {/* Peer name + logo */}
+                    <TableCell>
+                      <AppLink
+                        href={`/peerdb/peer?name=${encodeURIComponent(p.name)}`}
+                        className="inline-flex items-center gap-2.5 font-medium text-primary hover:underline"
+                      >
+                        {hasLogo ? (
+                          <DbLogo
+                            type={normalizedType}
+                            width={22}
+                            height={22}
+                          />
+                        ) : (
+                          <PeerTypeIcon type={p.type} className="size-[22px]" />
+                        )}
+                        {p.name}
+                      </AppLink>
+                    </TableCell>
+
+                    {/* Type with brand-colored dot */}
+                    <TableCell>
+                      <span className="inline-flex items-center gap-1.5 text-sm text-muted-foreground">
+                        <span
+                          className="inline-flex size-2 rounded-full shrink-0"
+                          style={{
+                            background: peerKind(normalizedType).dot,
+                          }}
+                        />
+                        {dbTypeLabel(p.type)}
+                      </span>
+                    </TableCell>
+
+                    {/* Source mirrors count */}
+                    <TableCell className="text-center tabular-nums text-sm">
+                      {stats?.sourceCount ? (
+                        <span className="font-medium">{stats.sourceCount}</span>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+
+                    {/* Destination mirrors count */}
+                    <TableCell className="text-center tabular-nums text-sm">
+                      {stats?.destCount ? (
+                        <span className="font-medium">{stats.destCount}</span>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+
+                    {/* Mirror health summary */}
+                    <TableCell>
+                      {stats && stats.sourceCount + stats.destCount > 0 ? (
+                        <div className="flex items-center gap-2">
+                          {(
+                            [
+                              'running',
+                              'progress',
+                              'failed',
+                              'paused',
+                              'idle',
+                            ] as const
+                          )
+                            .filter((t) => stats.toneCounts[t])
+                            .map((t) => (
+                              <ToneDot
+                                key={t}
+                                tone={t}
+                                count={stats.toneCounts[t]}
+                              />
+                            ))}
+                        </div>
+                      ) : (
+                        <span className="text-[11px] text-muted-foreground">
+                          No mirrors
+                        </span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                )
+              })
             )}
           </TableBody>
         </Table>


### PR DESCRIPTION
## Changes

### Peers Table Enhancement (`/peerdb/peers`)
- **Brand SVG logos**: Replaced generic Lucide icons with official database brand logos (Postgres, ClickHouse, MySQL, MongoDB, Snowflake, BigQuery) via `DbLogo` component, with `PeerTypeIcon` fallback for unsupported types
- **New columns**: Source and Destination mirror counts derived from the mirrors data already fetched on this page (zero additional API calls)
- **Status summary**: Per-peer mirror health breakdown with color-coded tone dots (running/failed/paused/progress)
- **Type column**: Now shows a brand-colored dot from the `peerKind` palette alongside the type label
- **Performance**: Peer deduplication and stats computation wrapped in `useMemo` to avoid unnecessary recomputation

### Topology Expand Button (`/peerdb`)
- Moved the Expand/Collapse button from the card header to a **centered pill on the bottom border** of the topology card
- Uses `translate-y-1/2` with `absolute` positioning to create the "on the border" visual effect
- Replaced `Maximize2Icon` with directional `ChevronDownIcon`/`ChevronUpIcon` for clearer affordance
- Rounded pill style with shadow for a polished floating appearance

## Screenshots
| Before | After |
|--------|-------|
| Simple 2-col table with Lucide icons | Rich table with brand logos, mirror counts, status dots |
| Expand button in header | Centered pill on bottom border |

Co-Authored-By: duyetbot <bot@duyet.net>