### PR TITLE
perf(build): optimizePackageImports for webpack production build

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -49,6 +49,15 @@ const nextConfig: NextConfig = {
   experimental: {
     workerThreads: false,
     cpus: 1,
+    // Production build uses webpack (not Turbopack), so barrel imports are not
+    // auto-optimized. Tree-shake heavy barrels (lucide-react is imported by 176
+    // files, recharts by chart primitives) to shrink bundles and speed builds.
+    optimizePackageImports: [
+      'lucide-react',
+      'recharts',
+      '@radix-ui/react-icons',
+      'date-fns',
+    ],
   },
 
   // Transpile workspace packages that ship raw TypeScript with node: scheme


### PR DESCRIPTION
## What

Add `optimizePackageImports` to the existing `experimental` block in `apps/web/next.config.ts`:

```ts
optimizePackageImports: ['lucide-react', 'recharts', '@radix-ui/react-icons', 'date-fns']
```

`workerThreads: false` and `cpus: 1` are kept intact. No other config key is touched.

## Why

The production build runs **webpack** (not Turbopack), so barrel imports are not automatically tree-shaken. 176 files import from `lucide-react`, and the chart primitives pull in the `recharts` barrel. `optimizePackageImports` makes Next rewrite these barrel imports to direct module imports, shrinking client bundles and reducing build work.

## Test notes

- Pure config change, no runtime/behavior change.
- Pre-commit `tsc --noEmit` type-check passed locally.
- CI build (webpack) verifies the optimized imports resolve and the bundle builds.

## Summary by Sourcery

Enhancements:
- Enable optimizePackageImports for lucide-react, recharts, @radix-ui/react-icons, and date-fns in the Next.js experimental configuration to improve tree-shaking and client bundle efficiency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized package imports for production builds to improve app performance and reduce bundle size.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->