### PR TITLE
fix(docker): healthcheck hits /api/healthz instead of root

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       clickhouse:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/"]
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:3000/api/healthz"]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## What

Change the `app` service healthcheck in `docker-compose.yml` to probe
`http://localhost:3000/api/healthz` instead of `http://localhost:3000/`.

## Why

The static shell at `/` returns HTTP 200 even when ClickHouse is
unreachable, so the container reported healthy with no working backend.
`/api/healthz` (`apps/web/app/api/healthz/route.ts`) returns **503** when
no ClickHouse host is up, so the healthcheck now reflects real backend
readiness.

This also aligns docker-compose with the rest of the project, which
already standardizes on `/api/healthz`:
- `package.json` `docker:health` script
- `docs/content/docker.mdx`

## Notes

- Uses the `wget -q -O /dev/null` form (matching the `docker:health`
  script) so the probe performs a GET and fails on non-2xx status. The
  previous `--spider` form would not exercise the GET handler.
- The ClickHouse service healthcheck (port 8123) is untouched.
- `start_period: 30s` is preserved (standalone server boots before
  ClickHouse settles).

## Test notes

No app code changed; only the compose healthcheck test command. Verified
`/api/healthz` returns 503 with no hosts up by reading the route handler.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Build:
- Change the app service healthcheck in docker-compose to query /api/healthz instead of the root endpoint, using a GET that fails on non-2xx responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application health monitoring with a more reliable endpoint check and reduced logging verbosity during health verification processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->