### PR TITLE
feat(tracking): persist global time range to localStorage + URL

### DIFF
--- a/apps/web/lib/context/time-range-context.tsx
+++ b/apps/web/lib/context/time-range-context.tsx
@@ -40,6 +40,52 @@ export const TIME_RANGE_PRESETS: TimeRangeOption[] = [
 
 const DEFAULT_TIME_RANGE = TIME_RANGE_PRESETS[2] // 24h
 
+/** localStorage key for the persisted global time range */
+const STORAGE_KEY = 'chm-global-time-range'
+/** URL search param used to share the active time range */
+const SEARCH_PARAM = 'range'
+
+/** Resolve a stored value string against the presets; unknown -> default. */
+function resolveTimeRange(value: string | null): TimeRangeOption {
+  if (!value) return DEFAULT_TIME_RANGE
+  return TIME_RANGE_PRESETS.find((p) => p.value === value) ?? DEFAULT_TIME_RANGE
+}
+
+/**
+ * Read the initial time range, preferring the URL `?range=` param, falling
+ * back to localStorage, then the default. Wrapped in try/catch for SSR and
+ * private-browsing safety.
+ */
+function readInitialTimeRange(): TimeRangeOption {
+  if (typeof window === 'undefined') return DEFAULT_TIME_RANGE
+  try {
+    const fromUrl = new URLSearchParams(window.location.search).get(
+      SEARCH_PARAM
+    )
+    if (fromUrl) return resolveTimeRange(fromUrl)
+    return resolveTimeRange(localStorage.getItem(STORAGE_KEY))
+  } catch {
+    return DEFAULT_TIME_RANGE
+  }
+}
+
+/** Persist the selected range to localStorage and the URL search param. */
+function persistTimeRange(option: TimeRangeOption): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(STORAGE_KEY, option.value)
+  } catch {
+    // localStorage may be full or unavailable (e.g. private browsing)
+  }
+  try {
+    const url = new URL(window.location.href)
+    url.searchParams.set(SEARCH_PARAM, option.value)
+    window.history.replaceState(window.history.state, '', url.toString())
+  } catch {
+    // history API may be unavailable in some embedded contexts
+  }
+}
+
 interface TimeRangeContextValue {
   timeRange: TimeRangeOption
   setTimeRange: (option: TimeRangeOption) => void
@@ -54,10 +100,11 @@ const TimeRangeContext = createContext<TimeRangeContextValue>({
 
 export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
   const [timeRange, setTimeRangeState] =
-    useState<TimeRangeOption>(DEFAULT_TIME_RANGE)
+    useState<TimeRangeOption>(readInitialTimeRange)
 
   const setTimeRange = (option: TimeRangeOption) => {
     setTimeRangeState(option)
+    persistTimeRange(option)
   }
 
   const value = { timeRange, setTimeRange, presets: TIME_RANGE_PRESETS }


### PR DESCRIPTION
## What

Make the global time range (the dashboard-wide window every chart reads from `TimeRangeProvider`) survive page reloads and become shareable via URL.

- **Seed from URL → localStorage → default**: `useState` now uses a lazy initializer (`readInitialTimeRange`) that reads `?range=` from the URL first, then the localStorage key `chm-global-time-range`, else the 24h default. The stored string is resolved against `TIME_RANGE_PRESETS` by `.value`; unknown values fall back to the default.
- **Persist on change**: `setTimeRange` writes the value to localStorage and updates the URL via `window.history.replaceState` (set/replace the `range` search param). It does **not** use the next/navigation router, which would break the static-site pattern.
- **Safe everywhere**: all localStorage/URL access is wrapped in try/catch with `typeof window` guards for SSR and private-browsing safety.

## Why

The provider previously seeded plain `useState(DEFAULT_TIME_RANGE)`, so every reload reset the window to 24h and the selected range was not shareable. This persists the user's selection and makes dashboard links reproduce the same window.

No API or query-path changes.

## Test notes

- Reload after picking a non-default range (e.g. 7d) → window stays 7d.
- Copy the URL (now carrying `?range=7d`) into a fresh tab → opens on 7d.
- URL param takes precedence over localStorage; unknown `?range=` value → falls back to 24h default.
- Private browsing / SSR: try/catch + `typeof window` guards mean no throw, falls back to default.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Persist and share the dashboard’s global time range selection across reloads and URLs.

New Features:
- Persist the global time range selection in localStorage and mirror it into the URL as a query parameter so it survives reloads and is shareable.

Enhancements:
- Initialize the global time range from URL, then localStorage, with safe fallbacks to the default for SSR and restricted environments.