### PR TITLE
feat(docs): surface AI Agent, Env Reference, PeerDB in sidebar nav

### DIFF
--- a/apps/web/app/(docs)/docs/_lib/docs.test.ts
+++ b/apps/web/app/(docs)/docs/_lib/docs.test.ts
@@ -1,0 +1,17 @@
+import { docsContent } from './content.generated'
+import { docsNav } from './docs'
+import { describe, expect, test } from 'bun:test'
+
+describe('docsNav coverage', () => {
+  test('every docsContent page is reachable from the sidebar', () => {
+    const navSlugs = new Set(
+      docsNav.flatMap((section) => section.items).map((item) => item.slug)
+    )
+
+    const orphans = Object.keys(docsContent).filter(
+      (slug) => !navSlugs.has(slug)
+    )
+
+    expect(orphans).toEqual([])
+  })
+})

--- a/apps/web/app/(docs)/docs/_lib/docs.ts
+++ b/apps/web/app/(docs)/docs/_lib/docs.ts
@@ -31,6 +31,7 @@ export const docsNav: DocsNavSection[] = [
     items: [
       { title: 'Introduction', slug: '' },
       { title: 'Features', slug: 'features' },
+      { title: 'AI Agent', slug: 'ai-agent' },
       { title: 'Settings', slug: 'settings' },
       { title: 'FAQ', slug: 'faq' },
     ],
@@ -72,6 +73,16 @@ export const docsNav: DocsNavSection[] = [
       { title: 'Queries History', slug: 'advanced/queries-history' },
       { title: 'Self-Tracking', slug: 'advanced/self-tracking' },
       { title: 'Feature Permissions', slug: 'advanced/feature-permissions' },
+      { title: 'PeerDB Monitoring', slug: 'advanced/peerdb-monitoring' },
+    ],
+  },
+  {
+    title: 'Reference',
+    items: [
+      {
+        title: 'Environment Variables',
+        slug: 'reference/environment-variables',
+      },
     ],
   },
 ]


### PR DESCRIPTION
## What

The hand-maintained `docsNav` in `apps/web/app/(docs)/docs/_lib/docs.ts` had drifted from generated content. Three pages existed in `content.generated.ts` but were unreachable from the sidebar:

- `ai-agent` → added **AI Agent** to the ClickHouse Monitoring section
- `reference/environment-variables` → added a new **Reference** section with **Environment Variables**
- `advanced/peerdb-monitoring` → added **PeerDB Monitoring** to the **Advanced** section

## Why

These docs pages were orphaned — rendered if you knew the URL, but invisible in navigation. Surfacing them makes the AI Agent, environment variable reference, and PeerDB monitoring docs discoverable.

## Guard test

Added `apps/web/app/(docs)/docs/_lib/docs.test.ts` (bun:test) that flattens every `docsNav` slug into a Set and asserts every key of `docsContent` is reachable. It fails with the orphaned slug list, preventing future drift.

## Test notes

- No content edits; pure navigation + test.
- `tsc --noEmit` passed in pre-commit type-check.
- Pre-existing Biome warnings/errors in unrelated agent/swr test files are not touched by this PR.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Update documentation navigation to surface previously orphaned pages and add a safeguard test to keep the nav in sync with generated content.

New Features:
- Expose the AI Agent page in the ClickHouse Monitoring docs section.
- Add a Reference section with an Environment Variables page in the docs sidebar.
- Surface the PeerDB Monitoring page under the Advanced docs section.

Tests:
- Add a docs navigation test ensuring every docs content entry is reachable from the sidebar navigation.