### PR TITLE
fix(ui): error-page hero icon, redirect skeletons, root 404

### DIFF
--- a/apps/web/app/(dashboard)/ai-chat/page.tsx
+++ b/apps/web/app/(dashboard)/ai-chat/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
+import { PageSkeleton } from '@/components/skeletons'
 
 /**
  * Redirect page for legacy /ai-chat route
@@ -14,5 +15,5 @@ export default function AiChatRedirectPage() {
     router.replace('/agents')
   }, [router])
 
-  return null
+  return <PageSkeleton />
 }

--- a/apps/web/app/(dashboard)/page.tsx
+++ b/apps/web/app/(dashboard)/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
+import { PageSkeleton } from '@/components/skeletons'
 
 /**
  * Root page - client-side redirect to /overview?host=0
@@ -16,5 +17,5 @@ export default function Home() {
     router.replace('/overview?host=0')
   }, [router])
 
-  return null
+  return <PageSkeleton />
 }

--- a/apps/web/app/(dashboard)/tables/page.tsx
+++ b/apps/web/app/(dashboard)/tables/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
+import { PageSkeleton } from '@/components/skeletons'
 
 export default function TablesPage() {
   const router = useRouter()
@@ -10,5 +11,5 @@ export default function TablesPage() {
     router.push('/table?database=default')
   }, [router])
 
-  return null
+  return <PageSkeleton />
 }

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -47,7 +47,10 @@ export default function GlobalError({
       <body className="font-sans">
         <div className="bg-background flex min-h-dvh flex-col items-center justify-center px-4 py-12 sm:px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
-            <div className="text-primary mx-auto size-12" />
+            <BugIcon
+              className="text-primary mx-auto size-12"
+              strokeWidth={1.5}
+            />
             <h1 className="text-foreground mt-4 text-3xl font-bold tracking-tight sm:text-4xl">
               {formattedError.title}
             </h1>

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { HomeIcon } from 'lucide-react'
+
+import { AppLink as Link } from '@/components/ui/app-link'
+import { Button } from '@/components/ui/button'
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 p-8">
+      <div className="text-center">
+        <h1 className="text-6xl font-bold text-muted-foreground">404</h1>
+        <h2 className="mt-4 text-2xl font-semibold">Page Not Found</h2>
+        <p className="mt-2 text-muted-foreground">
+          The page you are looking for does not exist or has been moved.
+        </p>
+      </div>
+
+      <Button asChild variant="default">
+        <Link href="/">
+          <HomeIcon className="mr-2 size-4" />
+          Go to Home
+        </Link>
+      </Button>
+    </div>
+  )
+}


### PR DESCRIPTION
## What

A bundle of zero-risk UX fixes:

1. **global-error hero icon** — `apps/web/app/global-error.tsx` had an empty placeholder `<div className="text-primary mx-auto size-12" />` above the "Something went wrong" title. Replaced it with the already-imported `<BugIcon>` (same classes, `strokeWidth={1.5}`) so the error page shows an actual icon. Layout unchanged.

2. **Redirect skeletons** — the three client-side redirect pages returned `null` while their `useEffect` redirect ran, showing a blank screen. They now render `<PageSkeleton />` (the same skeleton the `(dashboard)` `loading.tsx` uses):
   - `apps/web/app/(dashboard)/page.tsx` (→ `/overview?host=0`)
   - `apps/web/app/(dashboard)/tables/page.tsx` (→ `/table?database=default`)
   - `apps/web/app/(dashboard)/ai-chat/page.tsx` (→ `/agents`)

   Redirect logic is untouched.

3. **Root 404** — added `apps/web/app/not-found.tsx` (did not previously exist). Mirrors the styled `(dashboard)/not-found.tsx` (404 heading, "Page Not Found", Home link) but **without** the `LegacyUrlRedirect`/timer logic — just the styled fallback for unmatched routes outside the dashboard group.

## Why

Better perceived loading (no blank flashes on redirect), a visible icon on the global error page, and a styled fallback for any route not covered by the dashboard group's 404.

## Test notes

No behavior/data changes. Pre-commit `tsc --noEmit` type-check passed across all packages. Pure presentational additions; CI will verify.

## Summary by Sourcery

Improve error and not-found UX and show loading skeletons during dashboard redirects.

New Features:
- Add a styled root-level 404 page for unmatched routes outside the dashboard group.

Enhancements:
- Display a bug icon on the global error page instead of an empty placeholder.
- Show a shared loading skeleton on client-side dashboard redirect pages instead of a blank screen.