### PR TITLE
feat(monitoring): part lifecycle timeline from system.part_log

### DIFF
--- a/apps/web/app/(dashboard)/part-log/page.tsx
+++ b/apps/web/app/(dashboard)/part-log/page.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { Suspense } from 'react'
+import { PageLayout } from '@/components/layout/query-page'
+import { ChartSkeleton } from '@/components/skeletons'
+import { partLogConfig } from '@/lib/query-config/system/part-log'
+
+function PartLogPageContent() {
+  return <PageLayout queryConfig={partLogConfig} title="Part Log" />
+}
+
+export default function PartLogPage() {
+  return (
+    <Suspense fallback={<ChartSkeleton />}>
+      <PartLogPageContent />
+    </Suspense>
+  )
+}

--- a/apps/web/lib/query-config/index.ts
+++ b/apps/web/lib/query-config/index.ts
@@ -65,6 +65,7 @@ import {
   databaseDiskSpaceConfig,
   diskSpaceConfig,
 } from './system/disks'
+import { partLogConfig } from './system/part-log'
 import {
   clustersReplicasStatusConfig,
   replicaTablesConfig,
@@ -124,6 +125,7 @@ export const queries: Array<QueryConfig> = [
   mergesConfig,
   mergePerformanceConfig,
   mutationsConfig,
+  partLogConfig,
 
   // Settings
   settingsConfig,

--- a/apps/web/lib/query-config/system/part-log.ts
+++ b/apps/web/lib/query-config/system/part-log.ts
@@ -1,0 +1,67 @@
+import type { QueryConfig } from '@/types/query-config'
+
+import { PART_LOG } from '@/lib/table-notes'
+import { ColumnFormat } from '@/types/column-format'
+
+export const partLogConfig: QueryConfig = {
+  name: 'part-log',
+  description:
+    'Part lifecycle timeline: creation, merges, mutations, downloads, and removals from system.part_log',
+  docs: PART_LOG,
+  refreshInterval: 30_000,
+  // system.part_log is opt-in and may not exist on every server / version
+  optional: true,
+  tableCheck: 'system.part_log',
+  sql: `
+      SELECT
+        event_time,
+        event_type,
+        database || '.' || table AS table,
+        part_name,
+        partition_id,
+        merge_reason,
+        size_in_bytes,
+        formatReadableSize(size_in_bytes) AS readable_size,
+        round(size_in_bytes * 100.0 / nullIf(max(size_in_bytes) OVER (), 0), 2) AS pct_size,
+        rows,
+        formatReadableQuantity(rows) AS readable_rows,
+        round(rows * 100.0 / nullIf(max(rows) OVER (), 0), 2) AS pct_rows,
+        duration_ms,
+        formatReadableTimeDelta(duration_ms / 1000) AS readable_duration,
+        round(duration_ms * 100.0 / nullIf(max(duration_ms) OVER (), 0), 2) AS pct_duration,
+        formatReadableSize(peak_memory_usage) AS readable_peak_memory,
+        error,
+        exception
+      FROM system.part_log
+      ORDER BY event_time DESC
+      LIMIT 1000
+    `,
+  columns: [
+    'event_time',
+    'event_type',
+    'table',
+    'part_name',
+    'partition_id',
+    'merge_reason',
+    'readable_size',
+    'readable_rows',
+    'readable_duration',
+    'readable_peak_memory',
+    'error',
+    'exception',
+  ],
+  columnFormats: {
+    event_type: ColumnFormat.ColoredBadge,
+    table: ColumnFormat.ColoredBadge,
+    merge_reason: ColumnFormat.ColoredBadge,
+    readable_size: ColumnFormat.BackgroundBar,
+    readable_rows: ColumnFormat.BackgroundBar,
+    readable_duration: ColumnFormat.BackgroundBar,
+    exception: ColumnFormat.CodeDialog,
+  },
+  rowClassName: (row) => {
+    const error = Number(row.error || 0)
+    if (error) return 'bg-red-50 dark:bg-red-950/20'
+    return ''
+  },
+}

--- a/apps/web/menu.ts
+++ b/apps/web/menu.ts
@@ -28,6 +28,7 @@ import {
   HardDriveIcon,
   HeartPulseIcon,
   KeyIcon,
+  LayersIcon,
   MoveIcon,
   RollerCoasterIcon,
   ScrollTextIcon,
@@ -292,6 +293,14 @@ export const menuItemsConfig: MenuItem[] = [
           'In-progress part moves between disks and volumes (TTL / storage policy)',
         icon: MoveIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/moves',
+      },
+      {
+        title: 'Part Log',
+        href: '/part-log',
+        description:
+          'Part lifecycle timeline: creations, merges, mutations, downloads, and removals',
+        icon: LayersIcon,
+        docs: 'https://clickhouse.com/docs/en/operations/system-tables/part_log',
       },
     ],
   },


### PR DESCRIPTION
## What

Adds a full `system.part_log` lifecycle view at `/part-log`, under the **Merges** menu group (next to Moves).

Until now `system.part_log` was only consumed by `merges/merge-performance.ts` with `WHERE event_type = 2` — successful auto-merges only. This new view surfaces the complete part lifecycle: creations, merges, mutations, downloads, and removals.

Columns: `event_time`, `event_type`, `database.table`, `part_name`, `partition_id`, `merge_reason`, readable size / rows / duration (BackgroundBar), peak memory, `error`, `exception`. Rows where `error != 0` are highlighted red via `rowClassName`.

## Why

`part_log` is the canonical source for diagnosing part-level activity (merge storms, mutation churn, failed downloads, oversized parts). Exposing the raw timeline complements the aggregated Merge Performance view.

## Files

- `apps/web/lib/query-config/system/part-log.ts` — new `partLogConfig` (`optional: true`, `tableCheck: 'system.part_log'`, `refreshInterval: 30_000`)
- `apps/web/lib/query-config/index.ts` — register config in the Merges section
- `apps/web/app/(dashboard)/part-log/page.tsx` — thin client page using `PageLayout`
- `apps/web/menu.ts` — Part Log entry under Merges (LayersIcon + part_log docs link)

## Notes

- `optional: true` + `tableCheck` gives graceful degradation on servers/versions where part logging is disabled.
- BackgroundBar columns include companion `pct_*` columns so the bars render (per the documented 3-column convention).
- Local type-check passed via the pre-commit hook.

## Summary by Sourcery

Add a new dashboard page to visualize the full system.part_log part lifecycle timeline and expose it in the Merges navigation.

New Features:
- Introduce a Part Log timeline view backed by system.part_log with formatted size, row, and duration metrics and error highlighting.
- Add a dedicated Part Log dashboard route under /part-log using the shared query page layout.
- Expose the Part Log view in the Merges menu section with documentation links and appropriate iconography.

Enhancements:
- Register partLogConfig in the central query configuration with optional availability checks and periodic refresh.