### PR TITLE
feat(monitoring): Kafka consumer lag view from system.kafka_consumers

### DIFF
--- a/apps/web/app/(dashboard)/kafka-consumers/page.tsx
+++ b/apps/web/app/(dashboard)/kafka-consumers/page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { Suspense } from 'react'
+import { PageLayout } from '@/components/layout/query-page'
+import { ChartSkeleton } from '@/components/skeletons'
+import { kafkaConsumersConfig } from '@/lib/query-config/system/kafka-consumers'
+
+function KafkaConsumersPageContent() {
+  return (
+    <PageLayout queryConfig={kafkaConsumersConfig} title="Kafka Consumers" />
+  )
+}
+
+export default function KafkaConsumersPage() {
+  return (
+    <Suspense fallback={<ChartSkeleton />}>
+      <KafkaConsumersPageContent />
+    </Suspense>
+  )
+}

--- a/apps/web/lib/query-config/index.ts
+++ b/apps/web/lib/query-config/index.ts
@@ -65,6 +65,7 @@ import {
   databaseDiskSpaceConfig,
   diskSpaceConfig,
 } from './system/disks'
+import { kafkaConsumersConfig } from './system/kafka-consumers'
 import { partLogConfig } from './system/part-log'
 import {
   clustersReplicasStatusConfig,
@@ -164,6 +165,7 @@ export const queries: Array<QueryConfig> = [
   databaseTableColumnsConfig,
   tablesListConfig,
   warningsConfig,
+  kafkaConsumersConfig,
 
   // Security
   sessionsConfig,

--- a/apps/web/lib/query-config/system/kafka-consumers.ts
+++ b/apps/web/lib/query-config/system/kafka-consumers.ts
@@ -1,0 +1,54 @@
+import type { QueryConfig } from '@/types/query-config'
+
+import { ColumnFormat } from '@/types/column-format'
+
+export const kafkaConsumersConfig: QueryConfig = {
+  name: 'kafka-consumers',
+  description:
+    'Kafka table engine consumer state: poll/commit activity, messages read, and last exception per consumer',
+  refreshInterval: 15_000,
+  // system.kafka_consumers only exists if Kafka table engines are configured
+  optional: true,
+  tableCheck: 'system.kafka_consumers',
+  sql: `
+      SELECT
+        database,
+        table,
+        consumer_id,
+        assignments.topic AS topics,
+        assignments.partition_id AS partitions,
+        last_poll_time,
+        num_messages_read,
+        last_commit_time,
+        num_commits,
+        last_exception_time,
+        last_exception
+      FROM system.kafka_consumers
+      ORDER BY table
+    `,
+  columns: [
+    'database',
+    'table',
+    'consumer_id',
+    'topics',
+    'partitions',
+    'last_poll_time',
+    'num_messages_read',
+    'last_commit_time',
+    'num_commits',
+    'last_exception_time',
+    'last_exception',
+  ],
+  columnFormats: {
+    database: ColumnFormat.ColoredBadge,
+    table: ColumnFormat.ColoredBadge,
+    num_messages_read: ColumnFormat.NumberShort,
+    num_commits: ColumnFormat.NumberShort,
+    last_exception: ColumnFormat.CodeDialog,
+  },
+  rowClassName: (row) => {
+    const lastException = String(row.last_exception || '')
+    if (lastException !== '') return 'bg-red-50 dark:bg-red-950/20'
+    return ''
+  },
+}

--- a/apps/web/menu.ts
+++ b/apps/web/menu.ts
@@ -31,6 +31,7 @@ import {
   LayersIcon,
   MoveIcon,
   RollerCoasterIcon,
+  RssIcon,
   ScrollTextIcon,
   ShieldAlertIcon,
   ShieldIcon,
@@ -251,6 +252,15 @@ export const menuItemsConfig: MenuItem[] = [
         icon: BookOpenIcon,
         isNew: true,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/dictionaries',
+      },
+      {
+        title: 'Kafka Consumers',
+        href: '/kafka-consumers',
+        description:
+          'Kafka table engine consumer lag, poll/commit activity, and ingestion errors',
+        icon: RssIcon,
+        isNew: true,
+        docs: 'https://clickhouse.com/docs/en/operations/system-tables/kafka',
       },
     ],
   },


### PR DESCRIPTION
## What

Adds a new **Kafka Consumers** monitoring view at `/kafka-consumers`, backed by `system.kafka_consumers`.

- New query config `apps/web/lib/query-config/system/kafka-consumers.ts` (`name: 'kafka-consumers'`, `refreshInterval: 15_000`, `optional: true`, `tableCheck: 'system.kafka_consumers'`)
- Registered in `apps/web/lib/query-config/index.ts` (System group)
- New page `apps/web/app/(dashboard)/kafka-consumers/page.tsx` (copies the `moves` page structure, uses `PageLayout`)
- Menu entry under the **Tables** group in `apps/web/menu.ts` with the `RssIcon` lucide icon

## Why

Stalled Kafka table-engine consumers silently halt ingestion and there is zero coverage for this today. The view surfaces per-consumer poll/commit activity, messages read, and the last exception so broken consumers are obvious at a glance.

## Details

- SELECTs `database`, `table`, `consumer_id`, the nested `assignments.topic`/`assignments.partition_id` arrays (as `topics`/`partitions`), `last_poll_time`, `num_messages_read`, `last_commit_time`, `num_commits`, `last_exception_time`, `last_exception`, ordered by `table`.
- `rowClassName` highlights rows where `last_exception != ''` in red (shape copied from `merges/mutations.ts`).
- `optional` + `tableCheck` ensures graceful degradation on clusters/versions without Kafka table engines (no `system.kafka_consumers`).

## Test notes

- `tsc --noEmit` ran clean via the pre-commit hook for the changed files.
- No new tests: this follows the established 4-file monitoring-view pattern (config + index + page + menu), matching `moves` and other `optional` system views.