### PR TITLE
feat(alerting): autonomous scheduled health-sweep cron

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -30,6 +30,23 @@ CLICKHOUSE_MAX_EXECUTION_TIME=60
 CHM_API_KEY_SECRET=
 
 # ===========================================
+# Health Alerting (Cron Sweep)
+# ===========================================
+# The autonomous health sweep (GET /api/cron/health-sweep, triggered by the
+# Cloudflare Cron Trigger every 5 minutes) checks all hosts and dispatches
+# webhook alerts even when no browser tab is open.
+#
+# Shared secret guarding the cron endpoint. Sent as `Authorization: Bearer
+# <secret>` or `?secret=`. When unset, the endpoint is open.
+CRON_SECRET=
+# Set to 'true' to POST webhook alerts. When 'false', checks run but no alert.
+HEALTH_ALERT_ENABLED=false
+# Slack/Discord-compatible webhook URL. Required for alerts to dispatch.
+HEALTH_ALERT_WEBHOOK_URL=
+# Minimum severity to alert on: 'warning' (warning + critical) or 'critical'.
+HEALTH_ALERT_MIN_SEVERITY=warning
+
+# ===========================================
 # PeerDB Monitoring (optional, view-only)
 # ===========================================
 # Base URL of the PeerDB flow-api (grpc-gateway REST). When unset, the PeerDB

--- a/apps/web/app/api/cron/health-sweep/route.ts
+++ b/apps/web/app/api/cron/health-sweep/route.ts
@@ -1,0 +1,50 @@
+/**
+ * Autonomous Health Sweep Cron Endpoint
+ * GET /api/cron/health-sweep
+ *
+ * Invoked by the Cloudflare Cron Trigger (see apps/web/wrangler.toml) every
+ * 5 minutes. OpenNext routes scheduled events to the worker fetch handler, so
+ * the cron hits this GET route. Runs the health/anomaly sweep over all hosts
+ * and dispatches webhook alerts for findings at/above the configured severity.
+ *
+ * Guarded by a shared secret (CRON_SECRET) supplied via the `Authorization:
+ * Bearer <secret>` header or the `?secret=` query param. Returns 401 on
+ * mismatch. When CRON_SECRET is unset the endpoint is open (no secret to check).
+ */
+
+import { error } from '@chm/logger'
+import { runHealthSweep } from '@/lib/health/server-sweep'
+
+export const dynamic = 'force-dynamic'
+
+function isAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET?.trim()
+  if (!secret) return true
+
+  const authHeader = request.headers.get('authorization')
+  if (authHeader === `Bearer ${secret}`) return true
+
+  const url = new URL(request.url)
+  if (url.searchParams.get('secret') === secret) return true
+
+  return false
+}
+
+export async function GET(request: Request): Promise<Response> {
+  if (!isAuthorized(request)) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const summary = await runHealthSweep()
+    return Response.json(summary, { status: 200 })
+  } catch (err) {
+    error('[GET /api/cron/health-sweep] Sweep failed', err as Error)
+    return Response.json(
+      {
+        error: err instanceof Error ? err.message : 'Health sweep failed',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/web/lib/health/server-alert-config.ts
+++ b/apps/web/lib/health/server-alert-config.ts
@@ -1,0 +1,35 @@
+import 'server-only'
+
+import type { AlertSettings } from './alert-settings-storage'
+
+import { DEFAULT_ALERT_SETTINGS } from './alert-settings-storage'
+
+/**
+ * Server-side alert configuration sourced from environment variables.
+ *
+ * The client persists {@link AlertSettings} in localStorage (tab-scoped); the
+ * autonomous cron sweep cannot read that, so it reads the same shape from env:
+ *
+ *   - HEALTH_ALERT_ENABLED      → webhookEnabled (default false)
+ *   - HEALTH_ALERT_WEBHOOK_URL  → webhookUrl     (default '')
+ *   - HEALTH_ALERT_MIN_SEVERITY → minSeverity    (default 'warning')
+ *
+ * Browser notifications never apply server-side, so it is always disabled.
+ */
+export function getServerAlertConfig(): AlertSettings {
+  const webhookUrl = process.env.HEALTH_ALERT_WEBHOOK_URL?.trim() || ''
+  const enabled = process.env.HEALTH_ALERT_ENABLED === 'true'
+  const minSeverityEnv = process.env.HEALTH_ALERT_MIN_SEVERITY?.trim()
+  const minSeverity: AlertSettings['minSeverity'] =
+    minSeverityEnv === 'critical' || minSeverityEnv === 'warning'
+      ? minSeverityEnv
+      : 'warning'
+
+  return {
+    ...DEFAULT_ALERT_SETTINGS,
+    webhookUrl,
+    webhookEnabled: enabled,
+    browserNotificationsEnabled: false,
+    minSeverity,
+  }
+}

--- a/apps/web/lib/health/server-sweep.ts
+++ b/apps/web/lib/health/server-sweep.ts
@@ -1,0 +1,208 @@
+import 'server-only'
+
+import type { ClickHouseConfig } from '@chm/clickhouse-client'
+
+import { getServerAlertConfig } from './server-alert-config'
+import { fetchData, getClickHouseConfigs } from '@chm/clickhouse-client'
+import { debug, error } from '@chm/logger'
+import { HEALTH_CHECKS } from '@/components/health/health-checks'
+
+type Severity = 'ok' | 'warning' | 'critical'
+
+const SEVERITY_ORDER: Record<Severity, number> = {
+  ok: 0,
+  warning: 1,
+  critical: 2,
+}
+
+export interface SweepFinding {
+  hostId: number
+  hostName: string
+  checkId: string
+  title: string
+  severity: 'warning' | 'critical'
+  value: number | null
+  label: string
+}
+
+export interface SweepHostSummary {
+  hostId: number
+  hostName: string
+  checksRun: number
+  findings: number
+  errored: number
+}
+
+export interface SweepSummary {
+  ranAt: string
+  enabled: boolean
+  webhookConfigured: boolean
+  minSeverity: 'warning' | 'critical'
+  hostsChecked: number
+  totalChecks: number
+  totalFindings: number
+  alertsDispatched: number
+  hosts: SweepHostSummary[]
+  findings: SweepFinding[]
+}
+
+function hostLabel(config: ClickHouseConfig): string {
+  return config.customName?.trim() || config.host
+}
+
+/**
+ * Run a single health-check SQL on one host in read-only mode and read the
+ * numeric value from the configured `valueKey`. Mirrors the client read path
+ * (`readOnlyQuery`) so cron results match what the Health dashboard shows.
+ */
+async function runHealthCheck(
+  sql: string,
+  valueKey: string,
+  hostId: number
+): Promise<number | null> {
+  const result = await fetchData<Array<Record<string, unknown>>>({
+    query: sql,
+    hostId,
+    format: 'JSONEachRow',
+    clickhouse_settings: { readonly: '1' },
+  })
+
+  if (result.error) {
+    throw new Error(result.error.message)
+  }
+
+  const rows = result.data
+  if (!Array.isArray(rows) || rows.length === 0) return 0
+  const raw = rows[0]?.[valueKey]
+  if (raw === null || raw === undefined) return 0
+  const num = Number(raw)
+  return Number.isFinite(num) ? num : null
+}
+
+function classify(
+  value: number | null,
+  warning: number,
+  critical: number
+): Severity {
+  if (value === null || !Number.isFinite(value)) return 'ok'
+  if (value >= critical) return 'critical'
+  if (value >= warning) return 'warning'
+  return 'ok'
+}
+
+/**
+ * POST an alert to the configured webhook using the EXACT payload shape the
+ * `/api/v1/health/webhook` proxy forwards upstream (`{ text, content: text }`),
+ * so Slack (`text`) and Discord (`content`) both render it. Server-side, no CORS
+ * proxy needed — we post directly to the operator-configured webhook URL.
+ */
+async function postWebhook(url: string, text: string): Promise<boolean> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 10_000)
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, content: text }),
+      signal: controller.signal,
+    })
+    if (!res.ok) {
+      error(
+        '[health-sweep] Webhook returned non-OK status',
+        new Error(`Status ${res.status}`)
+      )
+    }
+    return res.ok
+  } catch (err) {
+    error('[health-sweep] Webhook POST failed', err as Error)
+    return false
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+/**
+ * Autonomous health sweep: runs every configured health check over ALL hosts,
+ * classifies severity from each check's default thresholds, and dispatches a
+ * webhook alert for any finding at or above the configured minimum severity.
+ *
+ * Disabled (or no webhook URL) → checks still run, alerts are skipped.
+ */
+export async function runHealthSweep(): Promise<SweepSummary> {
+  const ranAt = new Date().toISOString()
+  const settings = getServerAlertConfig()
+  const webhookConfigured = Boolean(settings.webhookUrl)
+  const canDispatch = settings.webhookEnabled && webhookConfigured
+  const minRank = SEVERITY_ORDER[settings.minSeverity]
+
+  const configs = getClickHouseConfigs()
+
+  const hosts: SweepHostSummary[] = []
+  const findings: SweepFinding[] = []
+
+  for (const config of configs) {
+    const name = hostLabel(config)
+    let checksRun = 0
+    let errored = 0
+
+    for (const check of HEALTH_CHECKS) {
+      if (!check.sql) continue
+      checksRun++
+      try {
+        const value = await runHealthCheck(check.sql, check.valueKey, config.id)
+        const severity = classify(
+          value,
+          check.defaults.warning,
+          check.defaults.critical
+        )
+        if (severity === 'ok') continue
+        findings.push({
+          hostId: config.id,
+          hostName: name,
+          checkId: check.id,
+          title: check.title,
+          severity,
+          value,
+          label: check.formatLabel ? check.formatLabel(value) : String(value),
+        })
+      } catch (err) {
+        errored++
+        debug(
+          `[health-sweep] check "${check.id}" failed on host ${config.id}`,
+          err instanceof Error ? err.message : String(err)
+        )
+      }
+    }
+
+    hosts.push({
+      hostId: config.id,
+      hostName: name,
+      checksRun,
+      findings: findings.filter((f) => f.hostId === config.id).length,
+      errored,
+    })
+  }
+
+  let alertsDispatched = 0
+  if (canDispatch) {
+    for (const finding of findings) {
+      if (SEVERITY_ORDER[finding.severity] < minRank) continue
+      const text = `[${finding.severity.toUpperCase()}] ${finding.title} — ${finding.label} (host ${finding.hostName})`
+      const ok = await postWebhook(settings.webhookUrl, text)
+      if (ok) alertsDispatched++
+    }
+  }
+
+  return {
+    ranAt,
+    enabled: settings.webhookEnabled,
+    webhookConfigured,
+    minSeverity: settings.minSeverity,
+    hostsChecked: configs.length,
+    totalChecks: hosts.reduce((sum, h) => sum + h.checksRun, 0),
+    totalFindings: findings.length,
+    alertsDispatched,
+    hosts,
+    findings,
+  }
+}

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -41,6 +41,14 @@ bucket_name = "clickhouse-monitoring-inc-cache"
 [observability]
 enabled = true
 
+# Scheduled Cron Triggers
+# Runs the autonomous health sweep every 5 minutes. OpenNext routes Cron
+# Triggers to the worker fetch handler, which dispatches to the
+# GET /api/cron/health-sweep route. Guard it with the CRON_SECRET secret.
+# Docs: https://developers.cloudflare.com/workers/configuration/cron-triggers/
+[triggers]
+crons = ["*/5 * * * *"]
+
 # Resource limits — Paid plan only.
 # When this account upgrades to Workers Paid, uncomment to extend the CPU
 # budget so multi-step agent loops don't hit Cloudflare 1027

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -40,6 +40,31 @@ All four vars must have the same number of values.
 
 ---
 
+## Health Alerting (Cron Sweep)
+
+The autonomous health sweep (`GET /api/cron/health-sweep`, triggered by the
+Cloudflare Cron Trigger every 5 minutes) runs the same health checks as the
+Health dashboard over **all** configured hosts and dispatches webhook alerts —
+even when no browser tab is open. Unlike the in-app alert settings (stored
+per-browser in localStorage), the cron sweep reads its configuration from env.
+
+| Variable | Default | Description |
+|---|---|---|
+| `CRON_SECRET` | — | Shared secret guarding `/api/cron/health-sweep`. Sent as `Authorization: Bearer <secret>` or `?secret=`. When unset, the endpoint is open. |
+| `HEALTH_ALERT_ENABLED` | `false` | Set to `true` to POST webhook alerts. When `false`, checks still run but no alert is sent. |
+| `HEALTH_ALERT_WEBHOOK_URL` | — | Slack/Discord-compatible webhook URL. Required for alerts to dispatch. |
+| `HEALTH_ALERT_MIN_SEVERITY` | `warning` | Minimum severity to alert on: `warning` (warning + critical) or `critical` (critical only). |
+
+```bash
+# Example: alert to Slack on warning-or-worse, every 5 minutes
+CRON_SECRET=a-long-random-string
+HEALTH_ALERT_ENABLED=true
+HEALTH_ALERT_WEBHOOK_URL=https://hooks.slack.com/services/T000/B000/XXXX
+HEALTH_ALERT_MIN_SEVERITY=warning
+```
+
+---
+
 ## Feature Permissions
 
 All features are **public and enabled by default**. Override only what needs


### PR DESCRIPTION
## What

Make health alerting **autonomous**. Today alerts only fire while a browser tab is open (`health-card.tsx` `useEffect`), and neither worker had any `[triggers]`/crons. This adds a Cloudflare Cron Trigger (every 5 minutes) that runs all health checks over every configured host and dispatches webhook alerts server-side.

## Changes

- **`lib/health/server-alert-config.ts`** — `getServerAlertConfig()` reads `HEALTH_ALERT_ENABLED` (default `false`), `HEALTH_ALERT_WEBHOOK_URL`, `HEALTH_ALERT_MIN_SEVERITY` (default `warning`) and returns the same `AlertSettings` shape used client-side (`browserNotificationsEnabled` is always `false` server-side).
- **`lib/health/server-sweep.ts`** — `runHealthSweep()` iterates `getClickHouseConfigs()` exactly like the `healthz` route, runs each `HEALTH_CHECKS` SQL read-only, classifies status/severity from each check's default thresholds, and for any finding `>= minSeverity` POSTs the **exact** `{ text, content: text }` payload the `/api/v1/health/webhook` proxy forwards upstream. If disabled or no webhook URL, checks still run but POST is skipped. Returns a per-host + findings summary.
- **`app/api/cron/health-sweep/route.ts`** — `export const dynamic = 'force-dynamic'`; `GET` guarded by `CRON_SECRET` via `Authorization: Bearer <secret>` header or `?secret=` (401 on mismatch), calls `runHealthSweep()`, returns the summary JSON.
- **`apps/web/wrangler.toml`** — adds `[triggers] crons = ["*/5 * * * *"]` on the top-level (production) worker. Existing config untouched; preview env intentionally omitted so PR deploys don't run the sweep.
- **Docs** — new env vars documented in `docs/content/reference/environment-variables.mdx` and `apps/web/.env.example`.

## Why

Operators want alerts even when nobody has the dashboard open. The cron sweep reuses the existing health checks, severity model, and webhook payload — no new shapes invented.

## OpenNext cron wiring

OpenNext routes Cloudflare Cron Triggers to the worker `fetch` handler, so the scheduled event reaches the `GET /api/cron/health-sweep` route as a normal request. This is the standard OpenNext approach (there is no separate `scheduled` export to wire up). Noted as the one area worth a sanity check on the first scheduled run.

## Test notes

- `tsc --noEmit` passes (pre-commit type-check, all 8 packages).
- No unit tests added — the sweep is I/O-bound (ClickHouse + webhook); behavior is covered by reusing the already-tested `HEALTH_CHECKS` SQL and `fetchData` read path.
- Manual verification: hit `GET /api/cron/health-sweep` with the bearer secret and confirm summary JSON; with `HEALTH_ALERT_ENABLED=true` + a webhook URL, confirm a Slack/Discord message renders.

## Deviation from spec

The spec mentioned reusing `ANOMALY_CHECKS` as well. The sweep reuses **`HEALTH_CHECKS`** because those map cleanly onto the threshold-based `AlertSettings` severity flow the spec asked to reuse (`warning`/`critical` from `defaults`, `formatLabel` for the alert text). The anomaly checks use a different percent-change-vs-baseline severity model that does not fit the threshold path, so folding them in would have required inventing a new alert shape. Flagging in case anomaly coverage is wanted as a follow-up.

Co-Authored-By: duyetbot <bot@duyet.net>