### PR TITLE
feat(deploy): vendor production Helm chart in-repo

### DIFF
--- a/deploy/helm/clickhouse-monitoring/.helmignore
+++ b/deploy/helm/clickhouse-monitoring/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/clickhouse-monitoring/Chart.yaml
+++ b/deploy/helm/clickhouse-monitoring/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: clickhouse-monitoring
+description: A Helm chart for the ClickHouse Monitoring dashboard
+type: application
+
+# version is the chart version. Bump on any chart change.
+version: 0.2.0
+
+# appVersion tracks the clickhouse-monitoring app release this chart ships.
+appVersion: "0.2.0"
+
+home: https://github.com/duyet/clickhouse-monitoring
+sources:
+  - https://github.com/duyet/clickhouse-monitoring
+maintainers:
+  - name: duyet
+    email: bot@duyet.net
+keywords:
+  - clickhouse
+  - monitoring
+  - dashboard
+  - observability

--- a/deploy/helm/clickhouse-monitoring/README.md
+++ b/deploy/helm/clickhouse-monitoring/README.md
@@ -1,0 +1,63 @@
+# clickhouse-monitoring Helm chart
+
+Production Helm chart for the [ClickHouse Monitoring](https://github.com/duyet/clickhouse-monitoring)
+dashboard. Vendored in-repo so the chart tracks the app it ships.
+
+## Install
+
+```bash
+helm install my-chm ./deploy/helm/clickhouse-monitoring \
+  --set clickhouse.host="https://clickhouse.example.com:8443" \
+  --set clickhouse.user="default" \
+  --set clickhouse.password="<password>"
+```
+
+Upgrade:
+
+```bash
+helm upgrade my-chm ./deploy/helm/clickhouse-monitoring -f my-values.yaml
+```
+
+Uninstall:
+
+```bash
+helm uninstall my-chm
+```
+
+## Values overview
+
+| Key | Default | Description |
+|---|---|---|
+| `replicaCount` | `1` | Number of pod replicas (ignored when autoscaling is on). |
+| `image.repository` | `ghcr.io/duyet/clickhouse-monitoring` | Container image. |
+| `image.tag` | `""` | Image tag; falls back to the chart `appVersion`. |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy. |
+| `service.type` | `ClusterIP` | Kubernetes Service type. |
+| `service.port` | `3000` | Service port. |
+| `containerPort` | `3000` | Container port the app listens on. |
+| `resources` | requests 100m/256Mi, limits 500m/512Mi | Pod resource requests/limits. |
+| `autoscaling.enabled` | `false` | Enable the HorizontalPodAutoscaler. |
+| `autoscaling.minReplicas` | `1` | Min replicas when autoscaling. |
+| `autoscaling.maxReplicas` | `10` | Max replicas when autoscaling. |
+| `autoscaling.targetCPUUtilizationPercentage` | `80` | CPU target for autoscaling. |
+| `ingress.enabled` | `false` | Enable the Ingress. |
+| `clickhouse.host` | `http://localhost:8123` | Comma-separated ClickHouse host URLs (`CLICKHOUSE_HOST`). |
+| `clickhouse.user` | `default` | Comma-separated usernames (`CLICKHOUSE_USER`). |
+| `clickhouse.password` | `""` | Comma-separated passwords; stored in a Secret (`CLICKHOUSE_PASSWORD`). |
+| `clickhouse.maxExecutionTime` | `"60"` | Query timeout in seconds (`CLICKHOUSE_MAX_EXECUTION_TIME`). |
+| `clickhouse.existingSecret` | `""` | Use an existing Secret (key `CLICKHOUSE_PASSWORD`) instead of `clickhouse.password`. |
+| `extraEnv` | `[]` | Extra environment variables (e.g. `CLICKHOUSE_NAME`). |
+
+See [`values.yaml`](./values.yaml) for the full list.
+
+## Health probes
+
+- **Liveness** — `GET /healthz` (static, always `200` while the process runs).
+- **Readiness** — `GET /api/healthz` (returns `503` when no configured
+  ClickHouse host is reachable, so traffic is only routed once a host is up).
+
+## Security
+
+Pods run as the non-root `app` user (uid/gid `1001`) baked into the Docker
+runner stage, with `allowPrivilegeEscalation: false` and all Linux capabilities
+dropped.

--- a/deploy/helm/clickhouse-monitoring/templates/NOTES.txt
+++ b/deploy/helm/clickhouse-monitoring/templates/NOTES.txt
@@ -1,0 +1,25 @@
+ClickHouse Monitoring has been deployed.
+
+Get the application URL by running these commands:
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "clickhouse-monitoring.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           Watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "clickhouse-monitoring.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "clickhouse-monitoring.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "clickhouse-monitoring.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/deploy/helm/clickhouse-monitoring/templates/_helpers.tpl
+++ b/deploy/helm/clickhouse-monitoring/templates/_helpers.tpl
@@ -1,0 +1,84 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "clickhouse-monitoring.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this
+(by the DNS naming spec). If release name contains chart name it will be used as
+a full name.
+*/}}
+{{- define "clickhouse-monitoring.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "clickhouse-monitoring.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "clickhouse-monitoring.labels" -}}
+helm.sh/chart: {{ include "clickhouse-monitoring.chart" . }}
+{{ include "clickhouse-monitoring.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "clickhouse-monitoring.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "clickhouse-monitoring.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "clickhouse-monitoring.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "clickhouse-monitoring.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+The container image reference. Falls back to the chart appVersion when
+image.tag is empty.
+*/}}
+{{- define "clickhouse-monitoring.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}
+
+{{/*
+The name of the Secret holding the ClickHouse password. Uses an existing Secret
+when provided, otherwise the chart-managed one.
+*/}}
+{{- define "clickhouse-monitoring.secretName" -}}
+{{- if .Values.clickhouse.existingSecret }}
+{{- .Values.clickhouse.existingSecret }}
+{{- else }}
+{{- include "clickhouse-monitoring.fullname" . }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/clickhouse-monitoring/templates/configmap.yaml
+++ b/deploy/helm/clickhouse-monitoring/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "clickhouse-monitoring.fullname" . }}
+  labels:
+    {{- include "clickhouse-monitoring.labels" . | nindent 4 }}
+data:
+  CLICKHOUSE_HOST: {{ .Values.clickhouse.host | quote }}
+  CLICKHOUSE_USER: {{ .Values.clickhouse.user | quote }}
+  CLICKHOUSE_MAX_EXECUTION_TIME: {{ .Values.clickhouse.maxExecutionTime | quote }}

--- a/deploy/helm/clickhouse-monitoring/templates/deployment.yaml
+++ b/deploy/helm/clickhouse-monitoring/templates/deployment.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "clickhouse-monitoring.fullname" . }}
+  labels:
+    {{- include "clickhouse-monitoring.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "clickhouse-monitoring.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "clickhouse-monitoring.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "clickhouse-monitoring.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "clickhouse-monitoring.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          env:
+            - name: CLICKHOUSE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "clickhouse-monitoring.fullname" . }}
+                  key: CLICKHOUSE_HOST
+            - name: CLICKHOUSE_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "clickhouse-monitoring.fullname" . }}
+                  key: CLICKHOUSE_USER
+            - name: CLICKHOUSE_MAX_EXECUTION_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "clickhouse-monitoring.fullname" . }}
+                  key: CLICKHOUSE_MAX_EXECUTION_TIME
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "clickhouse-monitoring.secretName" . }}
+                  key: CLICKHOUSE_PASSWORD
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          # Static liveness: /healthz always returns 200 while the process is up.
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          # Readiness gates on ClickHouse reachability: /api/healthz returns 503
+          # when no configured host is up.
+          readinessProbe:
+            httpGet:
+              path: /api/healthz
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/clickhouse-monitoring/templates/hpa.yaml
+++ b/deploy/helm/clickhouse-monitoring/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "clickhouse-monitoring.fullname" . }}
+  labels:
+    {{- include "clickhouse-monitoring.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "clickhouse-monitoring.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/clickhouse-monitoring/templates/ingress.yaml
+++ b/deploy/helm/clickhouse-monitoring/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled }}
+{{- $fullName := include "clickhouse-monitoring.fullname" . }}
+{{- $svcPort := .Values.service.port }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "clickhouse-monitoring.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/clickhouse-monitoring/templates/secret.yaml
+++ b/deploy/helm/clickhouse-monitoring/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.clickhouse.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "clickhouse-monitoring.fullname" . }}
+  labels:
+    {{- include "clickhouse-monitoring.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  CLICKHOUSE_PASSWORD: {{ .Values.clickhouse.password | quote }}
+{{- end }}

--- a/deploy/helm/clickhouse-monitoring/templates/service.yaml
+++ b/deploy/helm/clickhouse-monitoring/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clickhouse-monitoring.fullname" . }}
+  labels:
+    {{- include "clickhouse-monitoring.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "clickhouse-monitoring.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/clickhouse-monitoring/templates/serviceaccount.yaml
+++ b/deploy/helm/clickhouse-monitoring/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "clickhouse-monitoring.serviceAccountName" . }}
+  labels:
+    {{- include "clickhouse-monitoring.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/clickhouse-monitoring/values.yaml
+++ b/deploy/helm/clickhouse-monitoring/values.yaml
@@ -1,0 +1,104 @@
+# Default values for clickhouse-monitoring.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/duyet/clickhouse-monitoring
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+# Pod-level security context. Runs as the non-root "app" user (uid/gid 1001)
+# baked into the Docker runner stage.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+  fsGroup: 1001
+
+# Container-level security context.
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 3000
+
+# Container port the app listens on (matches PORT=3000 in the Docker image).
+containerPort: 3000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: clickhouse-monitoring.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# ClickHouse connection. Each value is comma-separated to support multiple hosts;
+# position i across host/user/name maps to the same host index.
+clickhouse:
+  # Comma-separated ClickHouse host URLs (required).
+  host: "http://localhost:8123"
+  # Comma-separated usernames.
+  user: "default"
+  # Comma-separated passwords. Stored in a Secret rendered by this chart.
+  password: ""
+  # Query timeout in seconds (CLICKHOUSE_MAX_EXECUTION_TIME).
+  maxExecutionTime: "60"
+  # Use an existing Secret for the ClickHouse password instead of `clickhouse.password`.
+  # The secret must contain a key named `CLICKHOUSE_PASSWORD`.
+  existingSecret: ""
+
+# Extra environment variables injected into the container, e.g.
+# extraEnv:
+#   - name: CLICKHOUSE_NAME
+#     value: "prod"
+extraEnv: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## What

Adds a self-contained, helm-lint-clean Helm chart at `deploy/helm/clickhouse-monitoring` for deploying the dashboard to Kubernetes. There was no `deploy/` directory before this PR.

Chart contents:
- `Chart.yaml` — name `clickhouse-monitoring`, type `application`, version `0.2.0`, appVersion `0.2.0` (the real current app version from `package.json`, not boilerplate).
- `values.yaml` — image `ghcr.io/duyet/clickhouse-monitoring` (tag falls back to `.Chart.AppVersion`), `replicaCount: 1`, `service.port: 3000`, `containerPort: 3000`, sane resource requests/limits, `autoscaling` (disabled, min 1 / max 10 / CPU 80%), `ingress` (disabled), `clickhouse` config block, non-root pod/container security contexts.
- Templates: `deployment.yaml`, `service.yaml`, `ingress.yaml`, `hpa.yaml`, `secret.yaml`, `configmap.yaml`, `serviceaccount.yaml`, `_helpers.tpl`, `NOTES.txt`.
- `.helmignore`, `README.md`.

## Why

Vendor the chart in-repo so it tracks the app it ships and fixes the rot in the external `duyet/charts` chart (real appVersion, correct probes, non-root UID matching the Dockerfile).

## Key details (verified against the codebase)

- **Liveness** `GET /healthz` (static — `apps/web/app/healthz/route.ts` always returns `{ok:true}`).
- **Readiness** `GET /api/healthz` (`apps/web/app/api/healthz/route.ts` returns `503` when no ClickHouse host is reachable, so traffic only routes once a host is up).
- **securityContext** `runAsNonRoot: true`, `runAsUser: 1001`, `runAsGroup: 1001` — matches the `app` user (uid/gid 1001) in the Dockerfile runner stage.
- **Env names** exactly as in `docs/content/reference/environment-variables.mdx`: `CLICKHOUSE_HOST`, `CLICKHOUSE_USER`, `CLICKHOUSE_MAX_EXECUTION_TIME` from the ConfigMap; `CLICKHOUSE_PASSWORD` from the Secret (with an `existingSecret` escape hatch).

## Test notes

Verified locally with helm v4.1.1:
- `helm lint` clean on default values and with `ingress.enabled=true autoscaling.enabled=true` (only the optional `icon` INFO).
- `helm template` renders correct image fallback, port 3000, non-root contexts, both probes, env wiring, and gates Ingress/HPA on their flags. Confirmed `existingSecret` suppresses the chart Secret and rewires the env reference.

All new files under `deploy/` — no conflict risk with other PRs.