### PR TITLE
perf(sidebar): batch menu-count requests into a single endpoint

### DIFF
--- a/apps/web/app/api/v1/menu-counts/route.ts
+++ b/apps/web/app/api/v1/menu-counts/route.ts
@@ -1,0 +1,188 @@
+/**
+ * Batched menu count API endpoint
+ * GET /api/v1/menu-counts?hostId=<n>
+ *
+ * Returns a map of every registered menu count key to its count in a single
+ * request, so the sidebar makes ONE call instead of N independent ones.
+ *
+ * Each key is still authorized against its feature permission (an unauthorized
+ * key is simply omitted from the map) and optional-table misses resolve to
+ * `null`, matching the per-key endpoint's behavior. A query failure on one key
+ * resolves that key to `null` rather than failing the whole batch, so a single
+ * broken count never blanks out every sidebar badge.
+ *
+ * SECURITY: No raw SQL is accepted from clients. Only pre-defined registry
+ * queries are executed.
+ */
+
+import { menuItemsConfig } from '@/menu'
+
+import { fetchData } from '@chm/clickhouse-client'
+import { debug, error, generateRequestId } from '@chm/logger'
+import { createErrorResponse } from '@/lib/api/error-handler'
+import {
+  getAvailableMenuCountKeys,
+  getMenuCountQuery,
+} from '@/lib/api/menu-count-registry'
+import { HostIdSchema } from '@/lib/api/schemas'
+import {
+  CacheControl,
+  createSuccessResponse,
+} from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import { findMenuPermissionForCountKey } from '@/lib/feature-permissions/menu'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
+
+export const dynamic = 'force-dynamic'
+
+const ROUTE_CONTEXT = { route: '/api/v1/menu-counts', method: 'GET' }
+
+interface MenuCountsResponse {
+  readonly counts: Record<string, number | null>
+}
+
+/**
+ * Resolves a single registry key to its count value for the given host.
+ *
+ * Returns `undefined` when the key should be omitted from the response (not
+ * authorized for this request). Returns `null` when the count is unavailable
+ * (optional table missing or query failed). Returns a number otherwise.
+ */
+async function resolveCount(
+  countKey: string,
+  hostId: number,
+  request: Request,
+  requestId: string
+): Promise<number | null | undefined> {
+  const permission = findMenuPermissionForCountKey(menuItemsConfig, countKey)
+  const permissionResponse = await authorizeFeatureRequest(permission, request)
+  if (permissionResponse) {
+    // Not authorized for this key - omit it from the batch entirely.
+    return undefined
+  }
+
+  const menuCount = getMenuCountQuery(countKey)
+  if (!menuCount) return undefined
+
+  const result = await fetchData({
+    query: menuCount.query,
+    format: 'JSONEachRow',
+    hostId,
+  })
+
+  if (result.error) {
+    if (
+      menuCount.optional &&
+      result.error.type === ApiErrorType.TableNotFound
+    ) {
+      debug('[GET /api/v1/menu-counts] Optional table not found:', {
+        requestId,
+        countKey,
+      })
+      return null
+    }
+
+    error('[GET /api/v1/menu-counts] Query error:', undefined, {
+      requestId,
+      countKey,
+      error: result.error.message,
+    })
+    return null
+  }
+
+  const data = result.data as Array<{ count?: number | string }>
+  return data.length > 0 && data[0].count !== undefined
+    ? Number(data[0].count)
+    : null
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const requestId = generateRequestId()
+
+  try {
+    const url = new URL(request.url)
+    const searchParams = url.searchParams
+
+    // Validate hostId parameter
+    const hostIdResult = HostIdSchema.safeParse(
+      searchParams.get('hostId') ?? '0'
+    )
+    if (!hostIdResult.success) {
+      error('[GET /api/v1/menu-counts] Invalid hostId parameter', undefined, {
+        requestId,
+      })
+      const errorResponse = createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Invalid hostId parameter: must be a non-negative integer',
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+      const headers = new Headers(errorResponse.headers)
+      headers.set('X-Request-ID', requestId)
+      return new Response(errorResponse.body, {
+        status: errorResponse.status,
+        statusText: errorResponse.statusText,
+        headers,
+      })
+    }
+
+    const hostId = hostIdResult.data
+
+    debug('[GET /api/v1/menu-counts] Fetching batched counts', {
+      requestId,
+      hostId,
+    })
+
+    const keys = getAvailableMenuCountKeys()
+    const resolved = await Promise.all(
+      keys.map(async (key) => {
+        const value = await resolveCount(key, hostId, request, requestId)
+        return [key, value] as const
+      })
+    )
+
+    const counts: Record<string, number | null> = {}
+    for (const [key, value] of resolved) {
+      if (value !== undefined) {
+        counts[key] = value
+      }
+    }
+
+    debug('[GET /api/v1/menu-counts] Batched count result:', {
+      requestId,
+      keys: Object.keys(counts).length,
+    })
+
+    const response = createSuccessResponse<MenuCountsResponse>(
+      { counts },
+      { queryId: 'menu-counts-batch', rows: Object.keys(counts).length }
+    )
+    const headers = new Headers(response.headers)
+    headers.set('X-Request-ID', requestId)
+    headers.set('Cache-Control', CacheControl.MEDIUM)
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    })
+  } catch (err) {
+    error('[GET /api/v1/menu-counts] Unexpected error:', err, { requestId })
+    const errorResponse = createErrorResponse(
+      {
+        type: ApiErrorType.QueryError,
+        message: err instanceof Error ? err.message : 'Unknown error',
+      },
+      500,
+      ROUTE_CONTEXT
+    )
+    const headers = new Headers(errorResponse.headers)
+    headers.set('X-Request-ID', requestId)
+    return new Response(errorResponse.body, {
+      status: errorResponse.status,
+      statusText: errorResponse.statusText,
+      headers,
+    })
+  }
+}

--- a/apps/web/components/menu/hooks/use-menu-count.ts
+++ b/apps/web/components/menu/hooks/use-menu-count.ts
@@ -1,8 +1,15 @@
 /**
- * Menu Count Hook
+ * Menu Count Hooks
  *
  * Fetches menu item counts via SWR with lazy loading and caching.
- * Uses a 2-minute refresh interval to minimize API load while keeping counts fresh.
+ *
+ * The sidebar renders up to ~18 count badges. Rather than firing one request
+ * per badge, all badges share a single batched request to
+ * `/api/v1/menu-counts?hostId=<n>` (deduped by SWR via a shared key). Each
+ * badge then selects its own value from the returned map.
+ *
+ * Uses a 2-minute refresh interval to minimize API load while keeping counts
+ * fresh.
  */
 
 'use client'
@@ -18,37 +25,37 @@ interface MenuCountResult {
   error?: Error
 }
 
-interface MenuCountResponse {
+interface MenuCountsResponse {
   success: boolean
-  data: { count: number | null }
+  data: { counts: Record<string, number | null> }
   error?: { message: string }
 }
 
 /**
- * Fetches a menu count by key for a specific host.
+ * Fetches the full map of menu counts for a host in a single request.
+ *
+ * All callers share the same SWR key (`['/api/v1/menu-counts', hostId]`), so
+ * SWR dedupes the N badge invocations into ONE network request per host.
  *
  * Features:
  * - 2-minute refresh interval (non-critical data)
  * - 1-minute deduping to prevent duplicate requests
  * - No revalidation on focus/reconnect (reduces API load)
- * - Silent failure - returns null on error
+ * - Silent failure - returns an empty map on error
  *
- * @param countKey - The count key from menu-count-registry
  * @param hostId - The current host ID
  */
-export function useMenuCount(
-  countKey: string | undefined,
-  hostId: number
-): MenuCountResult {
-  const { data, error, isLoading } = useSWR<MenuCountResponse>(
-    // Only fetch if countKey is provided
-    countKey ? [`/api/v1/menu-counts`, countKey, hostId] : null,
+export function useMenuCounts(hostId: number): {
+  counts: Record<string, number | null>
+  isLoading: boolean
+  error?: Error
+} {
+  const { data, error, isLoading } = useSWR<MenuCountsResponse>(
+    ['/api/v1/menu-counts', hostId],
     async () => {
-      const res = await apiFetch(
-        `/api/v1/menu-counts/${countKey}?hostId=${hostId}`
-      )
+      const res = await apiFetch(`/api/v1/menu-counts?hostId=${hostId}`)
       if (!res.ok) {
-        throw new Error('Failed to fetch menu count')
+        throw new Error('Failed to fetch menu counts')
       }
       return res.json()
     },
@@ -62,7 +69,29 @@ export function useMenuCount(
   )
 
   return {
-    count: data?.data?.count ?? null,
+    counts: data?.data?.counts ?? {},
+    isLoading,
+    error,
+  }
+}
+
+/**
+ * Selects a single menu count by key from the batched counts map.
+ *
+ * Backed by {@link useMenuCounts}, so every badge reuses the one shared
+ * request instead of fetching independently.
+ *
+ * @param countKey - The count key from menu-count-registry
+ * @param hostId - The current host ID
+ */
+export function useMenuCount(
+  countKey: string | undefined,
+  hostId: number
+): MenuCountResult {
+  const { counts, isLoading, error } = useMenuCounts(hostId)
+
+  return {
+    count: countKey ? (counts[countKey] ?? null) : null,
     isLoading,
     error,
   }


### PR DESCRIPTION
## What

The sidebar rendered up to ~18 count badges, each calling its own per-key endpoint `GET /api/v1/menu-counts/[key]` on first paint. That fanned out into N parallel requests that competed with the page's own data fetches.

This PR collapses those into **one** batched request:

- **New endpoint** `GET /api/v1/menu-counts?hostId=<n>` — returns `{ counts: Record<key, number|null> }` for every registered menu count key in a single request.
  - Each key is still authorized against its feature permission via `findMenuPermissionForCountKey` + `authorizeFeatureRequest` (unauthorized keys are omitted from the map, so their badge renders nothing — same visual result as the per-key 401/404).
  - Optional-table misses resolve to `null` (matches the per-key route's `TableNotFound` handling).
  - A query failure on a single key resolves *that* key to `null` instead of failing the whole batch, so one broken count never blanks out every sidebar badge.
- **New hook** `useMenuCounts(hostId)` fetches the batch once via a single shared SWR key `['/api/v1/menu-counts', hostId]`, so SWR dedupes the N badge invocations into one network request per host.
- `useMenuCount(countKey, hostId)` is refactored to select its value from `useMenuCounts`, keeping its exact `{ count, isLoading, error }` return contract.

## Why

Reduce first-paint request fan-out (~18 → 1) so menu counts stop competing with page data fetches, while keeping counts per-host and correct.

## Notes

- Both `CountBadge` components (`components/menu/count-badge.tsx` and `components/menu/components/count-badge.tsx`) are **untouched** — visual output is unchanged.
- The per-key `[key]/route.ts` endpoint is left intact (still valid, e.g. for direct/API use).
- Per spec, `lib/query-config/index.ts` and `menu.ts` structure are not touched (only count-fetching wiring).

## Test notes

- Pre-commit `tsc --noEmit` + Biome passed locally.
- Manual: load the sidebar — network tab should show a single `GET /api/v1/menu-counts?hostId=N` instead of N `.../menu-counts/<key>` calls; badge values and visibility match before/after; switching host triggers exactly one new batch request.

Co-Authored-By: duyetbot <bot@duyet.net>