### PR TITLE
feat(tracking): direct CSV export from any chart card

### DIFF
--- a/apps/web/components/cards/card-toolbar.tsx
+++ b/apps/web/components/cards/card-toolbar.tsx
@@ -19,6 +19,7 @@ import type { ChartDataPoint } from '@/types/chart-data'
 
 import { useState } from 'react'
 import { format } from 'sql-formatter'
+import { ChartCsvExportButton } from '@/components/cards/chart-csv-export-button'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -87,6 +88,8 @@ export interface CardToolbarProps {
   metadata?: CardToolbarMetadata
   /** Always show the button (not just on hover) */
   alwaysVisible?: boolean
+  /** Human-readable label used to name the CSV export download */
+  filename?: string
 }
 
 /**
@@ -140,6 +143,7 @@ export const CardToolbar = function CardToolbar({
   data,
   metadata,
   alwaysVisible = false,
+  filename,
 }: CardToolbarProps) {
   const [showRequestInfo, setShowRequestInfo] = useState(false)
   const [showData, setShowData] = useState(false)
@@ -204,6 +208,13 @@ export const CardToolbar = function CardToolbar({
 
   return (
     <>
+      {hasData && (
+        <ChartCsvExportButton
+          data={data as ChartDataPoint[] | Record<string, unknown>[]}
+          filename={filename}
+          alwaysVisible={alwaysVisible}
+        />
+      )}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button

--- a/apps/web/components/cards/chart-card.tsx
+++ b/apps/web/components/cards/chart-card.tsx
@@ -180,7 +180,12 @@ function ChartCardContentWithScale({
                   onChange={onRangeChange}
                 />
               )}
-              <CardToolbar sql={sql} data={data} metadata={metadata} />
+              <CardToolbar
+                sql={sql}
+                data={data}
+                metadata={metadata}
+                filename={typeof title === 'string' ? title : undefined}
+              />
             </div>
           </header>
         </CardHeader>
@@ -277,7 +282,12 @@ function ChartCardContentWithoutScale({
                   onChange={onRangeChange}
                 />
               )}
-              <CardToolbar sql={sql} data={data} metadata={metadata} />
+              <CardToolbar
+                sql={sql}
+                data={data}
+                metadata={metadata}
+                filename={typeof title === 'string' ? title : undefined}
+              />
             </div>
           </header>
         </CardHeader>

--- a/apps/web/components/cards/chart-csv-export-button.tsx
+++ b/apps/web/components/cards/chart-csv-export-button.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { Download } from 'lucide-react'
+import { toast } from 'sonner'
+
+import type { ChartDataPoint } from '@/types/chart-data'
+
+import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { arrayToCsv, downloadCsv, slugifyFilename } from '@/lib/csv'
+import { cn } from '@/lib/utils'
+
+interface ChartCsvExportButtonProps {
+  /** Current chart data array to serialize */
+  data: ChartDataPoint[] | Record<string, unknown>[]
+  /** Human-readable chart label used to name the downloaded file */
+  filename?: string
+  /** Always show the button (not just on card hover) */
+  alwaysVisible?: boolean
+}
+
+/**
+ * ChartCsvExportButton - one-click CSV export for a chart card.
+ *
+ * Serializes the chart's current data array to CSV and triggers a download
+ * named after the chart. Renders only when data is present and matches the
+ * hover-reveal behavior of the other chart card toolbar icons.
+ */
+export const ChartCsvExportButton = function ChartCsvExportButton({
+  data,
+  filename,
+  alwaysVisible = false,
+}: ChartCsvExportButtonProps) {
+  if (!data || data.length === 0) return null
+
+  const handleExport = () => {
+    const csv = arrayToCsv(data as Record<string, unknown>[])
+
+    if (!csv) {
+      toast.error('No data to export')
+      return
+    }
+
+    const timestamp = new Date().toISOString().slice(0, 10)
+    downloadCsv(csv, `${slugifyFilename(filename)}-${timestamp}`)
+    toast.success(`Exported ${data.length} rows to CSV`)
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handleExport}
+          aria-label="Export to CSV"
+          className={cn(
+            'size-6 rounded-full transition-opacity',
+            'relative before:content-[""] before:absolute before:-inset-4',
+            alwaysVisible
+              ? 'opacity-40 hover:opacity-100'
+              : 'opacity-0 group-hover:opacity-40 hover:!opacity-100'
+          )}
+        >
+          <Download className="size-3.5" strokeWidth={2} />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="text-xs">
+        Export to CSV
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/web/components/data-table/buttons/csv-export-button.tsx
+++ b/apps/web/components/data-table/buttons/csv-export-button.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { downloadCsv, valueToCsv } from '@/lib/csv'
 
 interface CsvExportButtonProps {
   // Using 'any' since the component only uses table methods that don't depend on TData
@@ -16,36 +17,6 @@ interface CsvExportButtonProps {
   table: Table<any>
   /** Optional filename for the download (without extension) */
   filename?: string
-}
-
-/**
- * Convert a value to a CSV-safe string
- * Handles null, undefined, objects, and strings with special characters
- */
-function valueToCsv(value: unknown): string {
-  // Handle null/undefined
-  if (value === null || value === undefined) {
-    return ''
-  }
-
-  // Handle objects (convert to JSON string)
-  if (typeof value === 'object') {
-    value = JSON.stringify(value)
-  }
-
-  // Convert to string
-  const strValue = String(value)
-
-  // If the value contains quotes, commas, or newlines, wrap in quotes and escape quotes
-  if (
-    strValue.includes('"') ||
-    strValue.includes(',') ||
-    strValue.includes('\n')
-  ) {
-    return `"${strValue.replace(/"/g, '""')}"`
-  }
-
-  return strValue
 }
 
 /**
@@ -75,26 +46,6 @@ function generateCsvContent<TData extends RowData>(
   }
 
   return csvRows.join('\n')
-}
-
-/**
- * Trigger a browser download for the given CSV content
- */
-function downloadCsv(content: string, filename: string) {
-  // Create a Blob with the CSV content
-  const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' })
-
-  // Create a temporary URL and trigger download
-  const url = URL.createObjectURL(blob)
-  const link = document.createElement('a')
-  link.href = url
-  link.download = `${filename}.csv`
-
-  // Trigger download and cleanup
-  document.body.appendChild(link)
-  link.click()
-  document.body.removeChild(link)
-  URL.revokeObjectURL(url)
 }
 
 /**

--- a/apps/web/lib/csv.test.ts
+++ b/apps/web/lib/csv.test.ts
@@ -1,0 +1,58 @@
+import { arrayToCsv, slugifyFilename, valueToCsv } from './csv'
+import { describe, expect, it } from 'bun:test'
+
+describe('csv', () => {
+  describe('valueToCsv', () => {
+    it('renders null and undefined as empty strings', () => {
+      expect(valueToCsv(null)).toBe('')
+      expect(valueToCsv(undefined)).toBe('')
+    })
+
+    it('passes through simple values', () => {
+      expect(valueToCsv('hello')).toBe('hello')
+      expect(valueToCsv(42)).toBe('42')
+      expect(valueToCsv(true)).toBe('true')
+    })
+
+    it('quotes and escapes values with commas, quotes, or newlines', () => {
+      expect(valueToCsv('a,b')).toBe('"a,b"')
+      expect(valueToCsv('say "hi"')).toBe('"say ""hi"""')
+      expect(valueToCsv('line1\nline2')).toBe('"line1\nline2"')
+    })
+
+    it('serializes objects to JSON', () => {
+      expect(valueToCsv({ a: 1 })).toBe('"{""a"":1}"')
+    })
+  })
+
+  describe('arrayToCsv', () => {
+    it('returns null for empty input', () => {
+      expect(arrayToCsv([])).toBeNull()
+    })
+
+    it('builds a header row from union of keys (first-seen order)', () => {
+      const csv = arrayToCsv([
+        { a: 1, b: 2 },
+        { a: 3, c: 4 },
+      ])
+      expect(csv).toBe('a,b,c\n1,2,\n3,,4')
+    })
+
+    it('escapes cell values', () => {
+      const csv = arrayToCsv([{ name: 'a,b', note: 'ok' }])
+      expect(csv).toBe('name,note\n"a,b",ok')
+    })
+  })
+
+  describe('slugifyFilename', () => {
+    it('slugifies a human-readable label', () => {
+      expect(slugifyFilename('Top Tables By Size')).toBe('top-tables-by-size')
+    })
+
+    it('falls back when label is empty or unusable', () => {
+      expect(slugifyFilename(undefined)).toBe('chart-export')
+      expect(slugifyFilename('   ')).toBe('chart-export')
+      expect(slugifyFilename('!!!', 'fallback')).toBe('fallback')
+    })
+  })
+})

--- a/apps/web/lib/csv.ts
+++ b/apps/web/lib/csv.ts
@@ -1,0 +1,113 @@
+/**
+ * Shared CSV serialization utilities.
+ *
+ * Used by both the data-table CSV export button (column/row based, driven by
+ * a TanStack table) and the chart card CSV export button (array-of-objects
+ * based, driven by the SWR chart data array).
+ */
+
+/**
+ * Convert a value to a CSV-safe string.
+ * Handles null, undefined, objects, and strings with special characters.
+ */
+export function valueToCsv(value: unknown): string {
+  // Handle null/undefined
+  if (value === null || value === undefined) {
+    return ''
+  }
+
+  // Handle objects (convert to JSON string)
+  if (typeof value === 'object') {
+    value = JSON.stringify(value)
+  }
+
+  // Convert to string
+  const strValue = String(value)
+
+  // If the value contains quotes, commas, or newlines, wrap in quotes and
+  // escape quotes
+  if (
+    strValue.includes('"') ||
+    strValue.includes(',') ||
+    strValue.includes('\n')
+  ) {
+    return `"${strValue.replace(/"/g, '""')}"`
+  }
+
+  return strValue
+}
+
+/**
+ * Serialize an array of plain objects to CSV.
+ *
+ * The header row is the union of keys across all rows (preserving first-seen
+ * order). Returns null when the input has no rows.
+ */
+export function arrayToCsv(
+  rows: ReadonlyArray<Record<string, unknown>>
+): string | null {
+  if (rows.length === 0) {
+    return null
+  }
+
+  // Collect column keys in first-seen order across all rows so rows with
+  // sparse/uneven shapes still serialize completely.
+  const keys: string[] = []
+  const seen = new Set<string>()
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (!seen.has(key)) {
+        seen.add(key)
+        keys.push(key)
+      }
+    }
+  }
+
+  if (keys.length === 0) {
+    return null
+  }
+
+  const csvRows = [keys.map(valueToCsv).join(',')]
+  for (const row of rows) {
+    csvRows.push(keys.map((key) => valueToCsv(row[key])).join(','))
+  }
+
+  return csvRows.join('\n')
+}
+
+/**
+ * Trigger a browser download for the given CSV content.
+ */
+export function downloadCsv(content: string, filename: string) {
+  // Create a Blob with the CSV content
+  const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' })
+
+  // Create a temporary URL and trigger download
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `${filename}.csv`
+
+  // Trigger download and cleanup
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+/**
+ * Slugify a label into a safe filename fragment (lowercase, hyphenated).
+ * Falls back to the provided default when nothing usable remains.
+ */
+export function slugifyFilename(
+  label: string | undefined,
+  fallback = 'chart-export'
+): string {
+  if (!label) return fallback
+  const slug = label
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return slug || fallback
+}


### PR DESCRIPTION
## What

Adds a one-click CSV export icon to the chart card toolbar so the current data of **any** chart card can be downloaded without digging into the buried zoom-dialog Data tab.

## Why

Previously the only way to export a chart's underlying data was to open the zoom dialog and switch to the Data tab (which embeds a full `DataTable`). For a quick "grab this chart's numbers" workflow that is several clicks deep. This surfaces the action directly on the card toolbar, next to the existing actions dropdown / date-range / scale icons.

## Changes

- **Extract shared CSV util** `apps/web/lib/csv.ts`: `valueToCsv` and `downloadCsv` are lifted out of the data-table CSV button (no reimplementation), plus a new `arrayToCsv` for the array-of-objects shape that chart cards expose via `useChartData`, and a small `slugifyFilename` helper for the download name.
- **New `ChartCsvExportButton`** (`components/cards/chart-csv-export-button.tsx`): serializes the chart's current `data` array to CSV and triggers a download named after the chart (`<slug>-<date>.csv`). Renders only when data is present and follows the same hover-reveal icon style as the existing `ScaleToggle` / `CardToolbar` trigger.
- **Wire into `CardToolbar`**: the export button renders before the actions dropdown and is gated on `hasData`. A `filename` prop is threaded from the chart `title` (string titles only). This single insertion point covers every chart card (overview/dashboard charts via `ChartCard`/`ChartContainer`, and the explorer dependency cards).
- **Refactor `CsvExportButton`** (data-table) to import the shared `valueToCsv` / `downloadCsv` instead of its private copies. No behavior change; its public API (`table`, `filename`) is unchanged.

No API changes. Pure client-side serialization + browser download.

## Notes

- Table data views already have their own CSV export in the data-table header, so the new button does not appear there (those `CardToolbar` call sites only pass `sql`/`metadata`, not `data`, so `hasData` is false).
- The zoom-dialog Data tab still renders a full `DataTable` with its own export — unchanged.

## Test notes

- Added `apps/web/lib/csv.test.ts` (bun:test) covering `valueToCsv` escaping/JSON, `arrayToCsv` header-union + escaping + empty input, and `slugifyFilename` fallbacks.
- Local `type-check` (pre-commit) passed; `biome check` clean on all 6 changed files.
- Manual: hover a chart card → CSV icon reveals → click downloads `<chart>-<date>.csv` with header row + all current data rows.

Co-Authored-By: duyetbot <bot@duyet.net>