### PR TITLE
feat(agent): persist agent findings + record_finding/list_recent_findings tools

### DIFF
--- a/apps/web/app/api/v1/findings/route.ts
+++ b/apps/web/app/api/v1/findings/route.ts
@@ -1,0 +1,85 @@
+/**
+ * Findings API endpoint
+ * GET /api/v1/findings
+ *
+ * Returns recently recorded monitoring findings for a host (newest first).
+ * Findings are produced by autonomous checks (cron health-sweep, the agent's
+ * record_finding tool) and persisted in the app-owned findings table.
+ *
+ * Query parameters:
+ * - host (optional, default 0): Host to read findings from
+ * - severity (optional): Filter to "info" | "warning" | "critical"
+ * - since (optional): Time window, e.g. "24 HOUR", "7 DAY"
+ * - limit (optional, default 100, max 1000): Max findings to return
+ */
+
+import { debug, error, generateRequestId } from '@chm/logger'
+import { NextResponse } from 'next/server'
+import {
+  type FindingSeverity,
+  listRecentFindings,
+} from '@/lib/findings/findings-store'
+
+export const dynamic = 'force-dynamic'
+
+const VALID_SEVERITIES = new Set<FindingSeverity>([
+  'info',
+  'warning',
+  'critical',
+])
+
+export async function GET(request: Request): Promise<Response> {
+  const requestId = generateRequestId()
+
+  try {
+    const searchParams = new URL(request.url).searchParams
+
+    const hostId = Number.parseInt(searchParams.get('host') ?? '0', 10)
+    if (!Number.isInteger(hostId) || hostId < 0) {
+      return NextResponse.json(
+        { error: 'Invalid host parameter: must be a non-negative integer' },
+        { status: 400 }
+      )
+    }
+
+    const severityParam = searchParams.get('severity') ?? undefined
+    if (
+      severityParam &&
+      !VALID_SEVERITIES.has(severityParam as FindingSeverity)
+    ) {
+      return NextResponse.json(
+        { error: 'Invalid severity: must be info, warning, or critical' },
+        { status: 400 }
+      )
+    }
+
+    const since = searchParams.get('since') ?? undefined
+    const limitParam = searchParams.get('limit')
+    const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined
+
+    debug('[GET /api/v1/findings] Fetching findings', {
+      requestId,
+      hostId,
+      severity: severityParam,
+      since,
+      limit,
+    })
+
+    const findings = await listRecentFindings(hostId, {
+      severity: severityParam as FindingSeverity | undefined,
+      since,
+      limit,
+    })
+
+    return NextResponse.json(
+      { findings, count: findings.length },
+      { headers: { 'X-Request-ID': requestId } }
+    )
+  } catch (err) {
+    error('[GET /api/v1/findings] Unexpected error:', err, { requestId })
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Unknown error' },
+      { status: 500, headers: { 'X-Request-ID': requestId } }
+    )
+  }
+}

--- a/apps/web/lib/ai/agent/tools/finding-tools.ts
+++ b/apps/web/lib/ai/agent/tools/finding-tools.ts
@@ -1,0 +1,133 @@
+import { hostIdSchema, resolveHostId } from './helpers'
+import { dynamicTool } from 'ai'
+import { z } from 'zod/v3'
+import {
+  type Finding,
+  type FindingSeverity,
+  listRecentFindings,
+  recordFinding,
+} from '@/lib/findings/findings-store'
+
+export function createFindingTools(hostId: number) {
+  return {
+    record_finding: dynamicTool({
+      description:
+        'Persist a monitoring finding to the app-owned findings table so it survives across sessions and powers autonomous monitoring. Use after detecting an anomaly, incident, or noteworthy condition. Best-effort: silently no-ops on read-only clusters.',
+      inputSchema: z.object({
+        severity: z
+          .enum(['info', 'warning', 'critical'])
+          .describe('How urgent the finding is'),
+        category: z
+          .string()
+          .describe('Domain, e.g. "merges", "replication", "memory", "errors"'),
+        source: z
+          .string()
+          .describe(
+            'What produced the finding, e.g. "detect_anomalies", "health-sweep", "manual"'
+          ),
+        title: z.string().describe('Short human-readable summary'),
+        detail: z.string().optional().describe('Longer explanation or context'),
+        metric: z
+          .string()
+          .optional()
+          .describe('Metric name this finding is about, e.g. "error_rate"'),
+        value: z
+          .number()
+          .optional()
+          .describe('Numeric value of the metric, if applicable'),
+        hostId: hostIdSchema,
+      }),
+      execute: async (input: unknown) => {
+        const {
+          severity,
+          category,
+          source,
+          title,
+          detail,
+          metric,
+          value,
+          hostId: toolHostId,
+        } = input as {
+          severity: FindingSeverity
+          category: string
+          source: string
+          title: string
+          detail?: string
+          metric?: string
+          value?: number
+          hostId?: number
+        }
+        const resolved = resolveHostId(toolHostId, hostId)
+
+        const finding: Finding = {
+          severity,
+          category,
+          source,
+          title,
+          detail,
+          metric,
+          value,
+        }
+        const recorded = await recordFinding(resolved, finding)
+
+        return {
+          recorded,
+          host_id: resolved,
+          finding,
+          message: recorded
+            ? 'Finding recorded.'
+            : 'Could not record finding (cluster may be read-only or table unavailable). Continuing without persistence.',
+        }
+      },
+    }),
+
+    list_recent_findings: dynamicTool({
+      description:
+        'List recently recorded monitoring findings for a host, newest first. Optionally filter by severity and time window. Use to recall what previous autonomous checks or sessions flagged.',
+      inputSchema: z.object({
+        severity: z
+          .enum(['info', 'warning', 'critical'])
+          .optional()
+          .describe('Filter to a single severity'),
+        since: z
+          .string()
+          .optional()
+          .describe('Time window, e.g. "24 HOUR", "7 DAY"'),
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .default(50)
+          .describe('Max findings to return (default 50, max 1000)'),
+        hostId: hostIdSchema,
+      }),
+      execute: async (input: unknown) => {
+        const {
+          severity,
+          since,
+          limit = 50,
+          hostId: toolHostId,
+        } = input as {
+          severity?: FindingSeverity
+          since?: string
+          limit?: number
+          hostId?: number
+        }
+        const resolved = resolveHostId(toolHostId, hostId)
+
+        const findings = await listRecentFindings(resolved, {
+          severity,
+          since,
+          limit,
+        })
+
+        return {
+          host_id: resolved,
+          count: findings.length,
+          findings,
+        }
+      },
+    }),
+  }
+}

--- a/apps/web/lib/ai/agent/tools/index.ts
+++ b/apps/web/lib/ai/agent/tools/index.ts
@@ -16,6 +16,7 @@ import { createContextTools } from './context-tools'
 import { createControlTools } from './control-tools'
 import { createDashboardTools } from './dashboard-tools'
 import { createDiagnosticsTools } from './diagnostics-tools'
+import { createFindingTools } from './finding-tools'
 import { createHealthTools } from './health-tools'
 import { createIncidentTools } from './incident-tools'
 import { createInsightsTools } from './insights-tools'
@@ -102,6 +103,9 @@ export function createAllTools(hostId: number, includeControlTools = false) {
 
     // Anomaly detection
     ...createAnomalyTools(hostId),
+
+    // Findings persistence
+    ...createFindingTools(hostId),
 
     // Reports
     ...createReportTools(hostId),

--- a/apps/web/lib/app-tables.ts
+++ b/apps/web/lib/app-tables.ts
@@ -21,6 +21,7 @@ export const DASHBOARD_CHARTS_TABLE_SHORT =
   'clickhouse_monitoring_custom_dashboard'
 export const DASHBOARD_SETTINGS_TABLE_SHORT =
   'clickhouse_monitoring_custom_dashboard_settings'
+export const FINDINGS_TABLE_SHORT = 'monitoring_findings'
 
 // Fully-qualified "database.table" names used in SQL.
 export const EVENTS_TABLE =
@@ -29,3 +30,5 @@ export const EVENTS_TABLE =
 export const DASHBOARD_CHARTS_TABLE = `${APP_DATABASE}.${DASHBOARD_CHARTS_TABLE_SHORT}`
 
 export const DASHBOARD_SETTINGS_TABLE = `${APP_DATABASE}.${DASHBOARD_SETTINGS_TABLE_SHORT}`
+
+export const FINDINGS_TABLE = `${APP_DATABASE}.${FINDINGS_TABLE_SHORT}`

--- a/apps/web/lib/findings/findings-store.ts
+++ b/apps/web/lib/findings/findings-store.ts
@@ -1,0 +1,217 @@
+/**
+ * Findings store — persistence foundation for autonomous monitoring.
+ *
+ * Autonomous checks (the cron health-sweep, the agent's anomaly/incident tools)
+ * produce *findings*: a short, structured record of something noteworthy on a
+ * cluster. This module owns an app-created ClickHouse table for those records
+ * and exposes best-effort read/write helpers.
+ *
+ * The table is created lazily the same way `monitoring_events` is (CREATE TABLE
+ * IF NOT EXISTS via the shared app-table mechanism — we do NOT hand-roll a
+ * migration runner). Every write is guarded: if the monitoring user is
+ * read-only or the table cannot be created, we log and return false instead of
+ * throwing so callers degrade silently.
+ */
+
+import 'server-only'
+
+import { fetchData, getClient } from '@chm/clickhouse-client'
+import { ErrorLogger } from '@chm/logger'
+import { FINDINGS_TABLE } from '@/lib/app-tables'
+
+const COMPONENT = 'findings-store'
+
+const log = (msg: string) =>
+  ErrorLogger.logDebug(`[findings-store] ${msg}`, { component: COMPONENT })
+const warn = (msg: string) =>
+  ErrorLogger.logWarning(`[findings-store] ${msg}`, { component: COMPONENT })
+
+/**
+ * DDL for the app-owned findings table.
+ *
+ * MergeTree ordered by event_time with a 30-day TTL — findings are transient
+ * operational signals, not long-term history.
+ */
+const CREATE_FINDINGS_TABLE = `
+  CREATE TABLE IF NOT EXISTS ${FINDINGS_TABLE} (
+    event_time DateTime DEFAULT now(),
+    host_id String,
+    severity LowCardinality(String),
+    category LowCardinality(String),
+    source LowCardinality(String),
+    title String,
+    detail String,
+    metric String,
+    value Float64
+  ) ENGINE = MergeTree
+  ORDER BY event_time
+  TTL event_time + INTERVAL 30 DAY
+`
+
+export type FindingSeverity = 'info' | 'warning' | 'critical'
+
+export interface Finding {
+  severity: FindingSeverity
+  category: string
+  source: string
+  title: string
+  detail?: string
+  metric?: string
+  value?: number
+}
+
+export interface FindingRow {
+  event_time: string
+  host_id: string
+  severity: string
+  category: string
+  source: string
+  title: string
+  detail: string
+  metric: string
+  value: number
+}
+
+export interface ListFindingsOptions {
+  severity?: FindingSeverity
+  /** ClickHouse time expression to bound the lower edge, e.g. "24 HOUR", "7 DAY". */
+  since?: string
+  limit?: number
+}
+
+// Per-host guard so we only attempt CREATE TABLE once per process per host.
+const ensuredHosts = new Set<number>()
+
+/**
+ * Best-effort CREATE TABLE IF NOT EXISTS. Never throws; returns whether the
+ * table is believed to exist after the call.
+ */
+async function ensureTable(hostId: number): Promise<boolean> {
+  if (ensuredHosts.has(hostId)) return true
+
+  try {
+    const client = await getClient({ hostId })
+    await client.command({ query: CREATE_FINDINGS_TABLE })
+    ensuredHosts.add(hostId)
+    log(`ensured ${FINDINGS_TABLE} on host ${hostId}`)
+    return true
+  } catch (err) {
+    warn(
+      `could not ensure ${FINDINGS_TABLE} on host ${hostId} (read-only?): ${err}`
+    )
+    return false
+  }
+}
+
+/**
+ * Sanitize a ClickHouse interval expression like "24 HOUR" / "7 DAY".
+ * Returns the normalized expression or null when invalid.
+ */
+function sanitizeSince(value: string): string | null {
+  const match = value
+    .trim()
+    .toUpperCase()
+    .match(/^(\d{1,5})\s+(SECOND|MINUTE|HOUR|DAY|WEEK|MONTH)S?$/)
+  if (!match) return null
+  return `${match[1]} ${match[2]}`
+}
+
+/**
+ * Persist a single finding. Best-effort: creates the table if needed and
+ * inserts one row. On read-only clusters or any failure it logs and returns
+ * false so autonomous callers never break.
+ */
+export async function recordFinding(
+  hostId: number,
+  finding: Finding
+): Promise<boolean> {
+  const ready = await ensureTable(hostId)
+  if (!ready) return false
+
+  try {
+    const client = await getClient({ hostId })
+    await client.insert({
+      table: FINDINGS_TABLE,
+      format: 'JSONEachRow',
+      values: [
+        {
+          host_id: String(hostId),
+          severity: finding.severity,
+          category: finding.category,
+          source: finding.source,
+          title: finding.title,
+          detail: finding.detail ?? '',
+          metric: finding.metric ?? '',
+          value: finding.value ?? 0,
+        },
+      ],
+    })
+    log(`recorded finding "${finding.title}" on host ${hostId}`)
+    return true
+  } catch (err) {
+    warn(`failed to record finding on host ${hostId}: ${err}`)
+    return false
+  }
+}
+
+/**
+ * Read recent findings for a host, newest first. Best-effort: returns an empty
+ * array if the table is missing or unreadable.
+ */
+export async function listRecentFindings(
+  hostId: number,
+  opts: ListFindingsOptions = {}
+): Promise<FindingRow[]> {
+  const { severity, since, limit = 100 } = opts
+
+  const conditions: string[] = ['host_id = {hostId:String}']
+  const query_params: Record<string, unknown> = { hostId: String(hostId) }
+
+  if (severity) {
+    conditions.push('severity = {severity:String}')
+    query_params.severity = severity
+  }
+
+  if (since) {
+    const sanitized = sanitizeSince(since)
+    if (!sanitized) {
+      warn(`ignoring invalid "since" value: ${since}`)
+    } else {
+      conditions.push(`event_time >= now() - INTERVAL ${sanitized}`)
+    }
+  }
+
+  const safeLimit = Math.min(Math.max(Math.trunc(limit) || 0, 1), 1000)
+
+  const sql = `
+    SELECT
+      toString(event_time) AS event_time,
+      host_id,
+      severity,
+      category,
+      source,
+      title,
+      detail,
+      metric,
+      value
+    FROM ${FINDINGS_TABLE}
+    WHERE ${conditions.join(' AND ')}
+    ORDER BY event_time DESC
+    LIMIT ${safeLimit}
+  `
+
+  const result = await fetchData<FindingRow[]>({
+    query: sql,
+    hostId,
+    format: 'JSONEachRow',
+    query_params,
+    clickhouse_settings: { readonly: '1' },
+  })
+
+  if (result.error) {
+    warn(`failed to list findings on host ${hostId}: ${result.error.message}`)
+    return []
+  }
+
+  return result.data ?? []
+}

--- a/docs/content/ai-agent.mdx
+++ b/docs/content/ai-agent.mdx
@@ -181,6 +181,18 @@ current host. The agent picks tools automatically; you never call them directly.
 | `generate_health_report` | Collect all key metrics into one report. |
 | `investigate_incident` | Automated root-cause analysis for an incident. |
 
+### Findings (persistence)
+
+Findings are short, structured records of noteworthy conditions, persisted to
+an app-owned `monitoring_findings` table (MergeTree, 30-day TTL). Writes are
+best-effort and silently no-op on read-only clusters. Also exposed at
+`GET /api/v1/findings`.
+
+| Tool | Description |
+|---|---|
+| `record_finding` | Persist a finding (severity, category, source, title, metric, value). |
+| `list_recent_findings` | List recent findings, newest first; filter by severity and time window. |
+
 ### Storage, Merges & Mutations
 
 | Tool | Description |
@@ -249,6 +261,7 @@ before using them.
 |---|---|
 | `optimize_table` | Trigger `OPTIMIZE TABLE`. |
 | `kill_query` | Kill a running query by id. |
+| `kill_mutation` | Cancel a running mutation on a table. |
 
 ### Interaction & Knowledge
 


### PR DESCRIPTION
## What

Builds the persistence foundation for autonomous monitoring. The cron health-sweep (#1305) currently only POSTs to a webhook and forgets; this adds a durable, app-owned store for findings plus agent tools and an API to read them.

- **`apps/web/lib/findings/findings-store.ts`** — app-owned `monitoring_findings` table (MergeTree `ORDER BY event_time`, 30-day TTL) created lazily via `CREATE TABLE IF NOT EXISTS` using the existing app-table bootstrap mechanism (`getClient().command()` + `client.insert()`). Reuses `FINDINGS_TABLE` from `lib/app-tables.ts` (new export) so the DB is configurable in one place. Exports:
  - `recordFinding(hostId, finding)` — best-effort; ensures table then inserts one row. On read-only/missing-table it logs and returns `false`.
  - `listRecentFindings(hostId, opts)` — read-only query, newest first, optional `severity`/`since`/`limit` (clamped to 1..1000), returns `[]` on error.
- **`apps/web/lib/ai/agent/tools/finding-tools.ts`** — `record_finding` and `list_recent_findings` agent tools following the `dynamicTool` + `zod/v3` convention of `anomaly-tools.ts`; registered in `tools/index.ts` alongside the other tool groups.
- **`apps/web/app/api/v1/findings/route.ts`** — `GET` (`force-dynamic`) returning recent findings JSON, accepts `?host=`, `?severity=`, `?since=`, `?limit=`.
- **`docs/content/ai-agent.mdx`** — documents `record_finding`, `list_recent_findings`, and the previously-undocumented `kill_mutation` control tool (keeps the agent docs in sync per CLAUDE.md).

## Why

Autonomous checks (cron sweep, agent anomaly/incident tools) had nowhere to persist what they flagged. The findings table schema (`severity`, `category`, `source`, `title`, `detail`, `metric`, `value`) aligns with the cron's `SweepFinding` shape so the sweep can be wired to `recordFinding` in a follow-up.

## Safety

Everything is guarded/best-effort: clusters whose monitoring user is read-only degrade silently (writes return `false`, reads return `[]`) rather than throwing. The `since` interval is sanitized against a strict regex before interpolation; `limit` is clamped; reads run with `readonly: '1'`.

## Test notes

- `tsc --noEmit` passes (pre-commit type-check green).
- Biome clean on all touched files.
- No hardcoded agent tool-count assertions in tests, so adding 2 tools is safe (`get_context` toolCount is computed dynamically).
- Manual: `GET /api/v1/findings?host=0&severity=warning&since=24%20HOUR&limit=20`.

Co-Authored-By: duyetbot <bot@duyet.net>