### PR TITLE
feat(ux): first-run onboarding, explorer skeleton, explain empty state

### DIFF
--- a/apps/web/app/(dashboard)/explain/page.tsx
+++ b/apps/web/app/(dashboard)/explain/page.tsx
@@ -15,6 +15,7 @@ import { ChartSkeleton } from '@/components/skeletons'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
+import { EmptyState } from '@/components/ui/empty-state'
 import { Label } from '@/components/ui/label'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
@@ -370,6 +371,18 @@ function ExplainContent() {
             >
               {data.data.map((row) => row.explain).join('\n')}
             </pre>
+          </CardContent>
+        </Card>
+      )}
+
+      {queryToExplain && !isLoading && !error && data?.data?.length === 0 && (
+        <Card>
+          <CardContent className="py-8">
+            <EmptyState
+              variant="no-data"
+              title="No plan to display"
+              description="The query was explained successfully but returned no plan output. Try a different EXPLAIN mode or adjust the query."
+            />
           </CardContent>
         </Card>
       )}

--- a/apps/web/app/(dashboard)/explorer/page.tsx
+++ b/apps/web/app/(dashboard)/explorer/page.tsx
@@ -2,20 +2,7 @@
 
 import dynamicModule from 'next/dynamic'
 import { Suspense } from 'react'
-import { Skeleton } from '@/components/ui/skeleton'
-
-function ExplorerSkeleton() {
-  return (
-    <div className="flex h-[calc(100vh-4rem)]">
-      <div className="w-80 border-r p-4">
-        <Skeleton className="h-full w-full" />
-      </div>
-      <div className="flex-1 p-4">
-        <Skeleton className="h-full w-full" />
-      </div>
-    </div>
-  )
-}
+import { ExplorerSkeleton } from '@/components/skeletons'
 
 const ExplorerLayout = dynamicModule(
   () =>

--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -15,6 +15,7 @@ import { GlobalAssistantModal } from '@/components/assistant-ui/global-assistant
 import { ClerkAuthProvider } from '@/components/clerk/clerk-auth-provider'
 import { KeyboardShortcuts } from '@/components/controls/keyboard-shortcuts'
 import { HeaderActions } from '@/components/header/header-actions'
+import { FirstRunGate } from '@/components/host/first-run-gate'
 import { Breadcrumb } from '@/components/navigation/breadcrumb'
 import { ResizableSidebarProvider } from '@/components/resizable-sidebar-provider'
 import { DynamicTitle } from '@/components/status/dynamic-title'
@@ -132,7 +133,7 @@ export default function RootLayout({
                   </div>
                 </header>
                 <div className="flex min-w-0 flex-1 flex-col gap-3 overflow-y-auto p-3 pt-0 sm:gap-4 sm:p-4 sm:pt-0">
-                  {children}
+                  <FirstRunGate>{children}</FirstRunGate>
                 </div>
               </SidebarInset>
             </ResizableSidebarProvider>

--- a/apps/web/components/host/first-run-empty-state.tsx
+++ b/apps/web/components/host/first-run-empty-state.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { DatabaseZap } from 'lucide-react'
+
+import { AppLink } from '@/components/ui/app-link'
+import { EmptyState } from '@/components/ui/empty-state'
+
+/**
+ * First-run onboarding surface.
+ *
+ * Rendered when ZERO ClickHouse hosts are configured (env + browser). Without
+ * this, the host switcher collapses to null and the dashboard is a bare,
+ * confusing surface. Guides the operator to set the required env vars with a
+ * link to the docs.
+ *
+ * @see components/host/first-run-gate.tsx
+ */
+export function FirstRunEmptyState() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 py-16">
+      <EmptyState
+        variant="no-data"
+        icon={
+          <DatabaseZap
+            className="h-10 w-10 text-muted-foreground/60"
+            strokeWidth={1.5}
+          />
+        }
+        title="Connect a ClickHouse host to get started"
+        description={
+          <span className="block">
+            No ClickHouse hosts are configured yet. Set{' '}
+            <code className="rounded bg-muted px-1 text-[11px]">
+              CLICKHOUSE_HOST
+            </code>
+            ,{' '}
+            <code className="rounded bg-muted px-1 text-[11px]">
+              CLICKHOUSE_USER
+            </code>{' '}
+            and{' '}
+            <code className="rounded bg-muted px-1 text-[11px]">
+              CLICKHOUSE_PASSWORD
+            </code>{' '}
+            (comma-separated for multiple hosts), then restart the app.
+          </span>
+        }
+        className="max-w-lg"
+      />
+
+      {/* Doc links live outside EmptyState because its built-in actions are
+          onClick-only (no href) and its description is line-clamped. */}
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <AppLink
+          href="/docs/getting-started"
+          className="inline-flex h-8 items-center gap-1.5 rounded-md bg-foreground px-3 text-[13px] font-medium text-background hover:bg-foreground/90"
+        >
+          Getting started
+        </AppLink>
+        <AppLink
+          href="/docs/reference/environment-variables"
+          className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-3 text-[13px] font-medium hover:bg-muted"
+        >
+          Environment variables
+        </AppLink>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/host/first-run-gate.tsx
+++ b/apps/web/components/host/first-run-gate.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { FirstRunEmptyState } from './first-run-empty-state'
+import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
+
+/**
+ * Gates the dashboard content on having at least one configured ClickHouse
+ * host. When zero hosts are configured (env + browser) the dashboard would
+ * otherwise be a bare, confusing surface, so we render a first-run onboarding
+ * EmptyState instead.
+ *
+ * While hosts are still loading we render children so existing skeletons /
+ * Suspense fallbacks keep showing — we only swap in onboarding once we are
+ * certain there are no hosts.
+ */
+export function FirstRunGate({ children }: { children: React.ReactNode }) {
+  const { hosts, isLoading } = useMergedHosts()
+
+  if (!isLoading && hosts.length === 0) {
+    return <FirstRunEmptyState />
+  }
+
+  return <>{children}</>
+}

--- a/apps/web/components/skeletons/explorer.tsx
+++ b/apps/web/components/skeletons/explorer.tsx
@@ -1,0 +1,90 @@
+import { Skeleton } from './base'
+import { cn } from '@/lib/utils'
+
+/**
+ * Structured skeleton for the database explorer.
+ *
+ * Mirrors the explorer layout (tree sidebar + content area) so the loading
+ * state matches the real UI and avoids a featureless grey slab / CLS.
+ *
+ * @see components/explorer/explorer-layout.tsx
+ */
+export function ExplorerSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn('flex h-full', className)}
+      role="status"
+      aria-label="Loading explorer"
+      aria-busy="true"
+    >
+      {/* Tree sidebar - matches ExplorerSidebar width */}
+      <div className="w-64 shrink-0 space-y-1 overflow-hidden border-r p-3 md:w-72 lg:w-80">
+        {/* Search / filter input */}
+        <Skeleton className="mb-3 h-9 w-full" />
+        {/* Database / table tree nodes */}
+        {Array.from({ length: 10 }).map((_, i) => (
+          <div
+            key={`tree-node-${i}`}
+            className="flex items-center gap-2 py-1.5 animate-pulse"
+            style={{
+              // Indent every other node to suggest tree nesting
+              paddingLeft: i % 3 === 0 ? '0.25rem' : '1.25rem',
+              animationDelay: `${i * 60}ms`,
+              animationFillMode: 'backwards',
+            }}
+          >
+            <Skeleton className="size-4 shrink-0 rounded-sm" />
+            <Skeleton
+              className="h-4"
+              style={{ width: `${55 + ((i * 13) % 35)}%` }}
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* Content area - matches ExplorerContent (breadcrumb + tabs + table) */}
+      <div className="flex-1 space-y-4 overflow-hidden p-4">
+        {/* Breadcrumb */}
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="size-3" />
+          <Skeleton className="h-4 w-32" />
+        </div>
+
+        {/* Tab bar */}
+        <div className="flex items-center gap-2 border-b pb-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={`tab-${i}`} className="h-8 w-20" />
+          ))}
+        </div>
+
+        {/* Content table */}
+        <div className="overflow-hidden rounded-md border">
+          {/* Table header */}
+          <div className="flex items-center gap-4 border-b bg-muted/30 px-4 py-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={`content-header-${i}`} className="h-4 flex-1" />
+            ))}
+          </div>
+          {/* Table rows */}
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={`content-row-${i}`}
+              className="flex items-center gap-4 border-b px-4 py-3 last:border-b-0 animate-pulse"
+              style={{
+                animationDelay: `${i * 75}ms`,
+                animationFillMode: 'backwards',
+              }}
+            >
+              {Array.from({ length: 5 }).map((_, j) => (
+                <Skeleton key={`content-cell-${j}`} className="h-4 flex-1" />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <span className="sr-only">Loading database explorer…</span>
+    </div>
+  )
+}

--- a/apps/web/components/skeletons/index.tsx
+++ b/apps/web/components/skeletons/index.tsx
@@ -13,6 +13,8 @@
 export { Skeleton } from './base'
 // Chart skeletons
 export { ChartSkeleton } from './chart'
+// Explorer skeleton
+export { ExplorerSkeleton } from './explorer'
 // Page skeletons
 export {
   ChartsOnlyPageSkeleton,


### PR DESCRIPTION
## What

Three self-contained, low-risk UX gaps:

1. **First-run onboarding** — When **zero** ClickHouse hosts are configured (env + browser), the host switcher collapses to `null` and the dashboard was a bare, confusing surface. A new `FirstRunGate` wraps the dashboard content region and, once host loading settles with `hosts.length === 0`, renders a friendly `EmptyState` (`apps/web/components/host/first-run-empty-state.tsx`) explaining `CLICKHOUSE_HOST` / `CLICKHOUSE_USER` / `CLICKHOUSE_PASSWORD`, with links to `/docs/getting-started` and `/docs/reference/environment-variables`.

2. **Structured explorer skeleton** — The `/explorer` page showed a featureless grey slab while loading. Replaced with `ExplorerSkeleton` (`apps/web/components/skeletons/explorer.tsx`) modeling the real tree-sidebar + content layout (search box, indented tree nodes, breadcrumb, tab bar, content table) to match the UI and avoid CLS. Exported from `@/components/skeletons` alongside the other type-aware skeletons.

3. **Explain empty state** — `/explain` rendered nothing when an explained query returned an empty result set. Now renders a `no-data` `EmptyState` so the surface is never silently blank.

## Why

These are verified onboarding/loading/empty-state gaps that leave users staring at blank or featureless surfaces. Each fix reuses the existing `EmptyState` (8 variants) / skeleton primitives and composes them at the usage site.

## Notes / deviation

- The spec pointed at the host-switcher's `if (!activeHost) return null` branch as the place to render the first-run state. The switcher lives in the **cramped sidebar header**, where a full `EmptyState` does not fit. I kept the switcher correctly hiding itself there and instead surfaced the first-run `EmptyState` on the **main dashboard content area** (the surface the spec describes as "bare and confusing") via `FirstRunGate`, gated on merged env+browser hosts so a user with a browser connection is never blocked. This is the correct nearest UX placement.
- `components/ui/*` left untouched — `EmptyState` is composed at the usage site (doc-link buttons rendered outside it because its built-in actions are `onClick`-only).

## Test notes

- Pre-commit Biome check + `tsc --noEmit` type-check passed locally.
- Manual: `/explorer` shows the structured skeleton during dynamic-import load; `/explain` of a query with empty plan output shows the empty state; with no `CLICKHOUSE_HOST` configured the dashboard shows the first-run onboarding instead of a blank surface.