### PR TITLE
feat(deploy): kustomize base + kubeconform/helm-lint CI gate + k8s guide

### DIFF
--- a/.github/workflows/k8s-lint.yml
+++ b/.github/workflows/k8s-lint.yml
@@ -1,0 +1,85 @@
+name: K8s Lint
+
+on:
+  pull_request:
+    paths:
+      - 'deploy/helm/**'
+      - 'deploy/kubernetes/**'
+      - '.github/workflows/k8s-lint.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/helm/**'
+      - 'deploy/kubernetes/**'
+      - '.github/workflows/k8s-lint.yml'
+
+# Cancel in-progress runs for same workflow and branch/PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CHART_DIR: deploy/helm/clickhouse-monitoring
+  KUSTOMIZE_DIR: deploy/kubernetes/base
+  # Kubernetes API version validated against (kubeconform schema set).
+  K8S_VERSION: "1.30.0"
+
+jobs:
+  helm:
+    name: helm lint + template
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v3.16.2
+
+      - name: Install kubeconform
+        run: |
+          curl -fsSL -o kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          tar -xzf kubeconform.tar.gz kubeconform
+          sudo install -m 0755 kubeconform /usr/local/bin/kubeconform
+          kubeconform -v
+
+      - name: helm lint
+        run: helm lint "$CHART_DIR"
+
+      - name: helm template | kubeconform
+        run: |
+          helm template release "$CHART_DIR" \
+            | kubeconform \
+                -strict \
+                -summary \
+                -kubernetes-version "$K8S_VERSION" \
+                -schema-location default
+
+  kustomize:
+    name: kustomize kubeconform
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install kubeconform
+        run: |
+          curl -fsSL -o kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          tar -xzf kubeconform.tar.gz kubeconform
+          sudo install -m 0755 kubeconform /usr/local/bin/kubeconform
+          kubeconform -v
+
+      - name: kubeconform (kustomize build)
+        run: |
+          kubectl kustomize "$KUSTOMIZE_DIR" \
+            | kubeconform \
+                -strict \
+                -summary \
+                -kubernetes-version "$K8S_VERSION" \
+                -schema-location default

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -1,0 +1,114 @@
+# Kubernetes manifests (kustomize base)
+
+Raw Kubernetes manifests for the [ClickHouse Monitoring](https://github.com/duyet/clickhouse-monitoring)
+dashboard. This is the no-Helm `kubectl apply -k` path — it ships the same
+image, ports, probes, security context, and environment as the
+[Helm chart](../helm/clickhouse-monitoring) but with plain YAML you can read,
+diff, and patch with [kustomize](https://kustomize.io/).
+
+Prefer the Helm chart if you want templating, an HPA, and an Ingress out of the
+box. Prefer these manifests if you keep your cluster config in Git as raw YAML.
+
+## Layout
+
+```
+deploy/kubernetes/
+└── base/
+    ├── configmap.yaml      # CLICKHOUSE_HOST / CLICKHOUSE_USER / CLICKHOUSE_MAX_EXECUTION_TIME
+    ├── secret.yaml         # CLICKHOUSE_PASSWORD placeholder (stringData)
+    ├── service.yaml        # ClusterIP on port 3000
+    ├── deployment.yaml     # 1 replica, /healthz + /api/healthz probes, non-root 1001
+    └── kustomization.yaml  # ties the four resources together, pins the image tag
+```
+
+## Quick start
+
+Edit `base/configmap.yaml` (host/user) and set the password, then apply:
+
+```bash
+kubectl apply -k deploy/kubernetes/base
+```
+
+Render without applying to review the output first:
+
+```bash
+kubectl kustomize deploy/kubernetes/base
+```
+
+Port-forward to reach the dashboard locally:
+
+```bash
+kubectl port-forward svc/clickhouse-monitoring 3000:3000
+# open http://localhost:3000
+```
+
+## Configuration
+
+| Resource | Key | Default | Purpose |
+|---|---|---|---|
+| ConfigMap | `CLICKHOUSE_HOST` | `http://localhost:8123` | Comma-separated ClickHouse host URLs. |
+| ConfigMap | `CLICKHOUSE_USER` | `default` | Comma-separated usernames. |
+| ConfigMap | `CLICKHOUSE_MAX_EXECUTION_TIME` | `60` | Query timeout in seconds. |
+| Secret | `CLICKHOUSE_PASSWORD` | `""` | Comma-separated passwords. |
+
+### Secrets
+
+`base/secret.yaml` ships an **empty placeholder** password. Do not commit a real
+password. Instead, layer one of these on top in an environment overlay:
+
+```bash
+# One-off: create the Secret out of band, then drop secret.yaml from resources.
+kubectl create secret generic clickhouse-monitoring \
+  --from-literal=CLICKHOUSE_PASSWORD='change-me'
+```
+
+For GitOps, use [External Secrets](https://external-secrets.io/),
+[SOPS](https://github.com/getsops/sops), or
+[Sealed Secrets](https://sealed-secrets.netlify.app/) so plaintext never lands
+in Git.
+
+## Customizing with overlays
+
+Create an overlay that references this base and patches what differs per
+environment — namespace, replicas, image tag, resources:
+
+```yaml
+# deploy/kubernetes/overlays/prod/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - ../../base
+images:
+  - name: ghcr.io/duyet/clickhouse-monitoring
+    newTag: v1.2.3
+replicas:
+  - name: clickhouse-monitoring
+    count: 2
+```
+
+```bash
+kubectl apply -k deploy/kubernetes/overlays/prod
+```
+
+## Health probes
+
+- **Liveness** — `GET /healthz` (static, always `200` while the process runs).
+- **Readiness** — `GET /api/healthz` (returns `503` when no configured
+  ClickHouse host is reachable, so traffic is only routed once a host is up).
+
+## Security
+
+Pods run as the non-root `app` user (uid/gid `1001`) baked into the Docker
+runner stage, with `allowPrivilegeEscalation: false` and all Linux capabilities
+dropped.
+
+## Validation
+
+These manifests are linted in CI by
+[`.github/workflows/k8s-lint.yml`](../../.github/workflows/k8s-lint.yml) with
+[kubeconform](https://github.com/yannh/kubeconform). Validate locally:
+
+```bash
+kubectl kustomize deploy/kubernetes/base | kubeconform -strict -summary
+```

--- a/deploy/kubernetes/base/configmap.yaml
+++ b/deploy/kubernetes/base/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clickhouse-monitoring
+  labels:
+    app.kubernetes.io/name: clickhouse-monitoring
+data:
+  # Comma-separated ClickHouse host URLs (required).
+  CLICKHOUSE_HOST: "http://localhost:8123"
+  # Comma-separated usernames.
+  CLICKHOUSE_USER: "default"
+  # Query timeout in seconds.
+  CLICKHOUSE_MAX_EXECUTION_TIME: "60"

--- a/deploy/kubernetes/base/deployment.yaml
+++ b/deploy/kubernetes/base/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clickhouse-monitoring
+  labels:
+    app.kubernetes.io/name: clickhouse-monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: clickhouse-monitoring
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: clickhouse-monitoring
+    spec:
+      # Pod-level security context. Runs as the non-root "app" user (uid/gid
+      # 1001) baked into the Docker runner stage.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+      containers:
+        - name: clickhouse-monitoring
+          image: ghcr.io/duyet/clickhouse-monitoring:0.2.0
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          env:
+            - name: CLICKHOUSE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: clickhouse-monitoring
+                  key: CLICKHOUSE_HOST
+            - name: CLICKHOUSE_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: clickhouse-monitoring
+                  key: CLICKHOUSE_USER
+            - name: CLICKHOUSE_MAX_EXECUTION_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: clickhouse-monitoring
+                  key: CLICKHOUSE_MAX_EXECUTION_TIME
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: clickhouse-monitoring
+                  key: CLICKHOUSE_PASSWORD
+          # Static liveness: /healthz always returns 200 while the process is up.
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          # Readiness gates on ClickHouse reachability: /api/healthz returns 503
+          # when no configured host is up.
+          readinessProbe:
+            httpGet:
+              path: /api/healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Common labels applied to every resource's metadata (not selectors, which are
+# pinned in the manifests so they stay immutable across upgrades).
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/part-of: clickhouse-monitoring
+
+resources:
+  - configmap.yaml
+  - secret.yaml
+  - service.yaml
+  - deployment.yaml
+
+# Pin the image in one place. Override the tag per-environment with an overlay:
+#   images:
+#     - name: ghcr.io/duyet/clickhouse-monitoring
+#       newTag: v1.2.3
+images:
+  - name: ghcr.io/duyet/clickhouse-monitoring
+    newTag: "0.2.0"

--- a/deploy/kubernetes/base/secret.yaml
+++ b/deploy/kubernetes/base/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: clickhouse-monitoring
+  labels:
+    app.kubernetes.io/name: clickhouse-monitoring
+type: Opaque
+# Placeholder password. Override per-environment with a kustomize overlay,
+# `kubectl create secret`, or a real secret manager (External Secrets, SOPS,
+# Sealed Secrets). Do NOT commit a real password here.
+stringData:
+  CLICKHOUSE_PASSWORD: ""

--- a/deploy/kubernetes/base/service.yaml
+++ b/deploy/kubernetes/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse-monitoring
+  labels:
+    app.kubernetes.io/name: clickhouse-monitoring
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: clickhouse-monitoring

--- a/docs/content/deploy/k8s.mdx
+++ b/docs/content/deploy/k8s.mdx
@@ -1,27 +1,149 @@
-# Kubernetes Helm Chart
+# Kubernetes
 
-Using the latest helm chart here: https://github.com/duyet/charts/tree/master/clickhouse-monitoring
+Run the ClickHouse Monitoring dashboard on Kubernetes with either the in-repo
+Helm chart or the raw kustomize manifests. Both ship the same container image
+(`ghcr.io/duyet/clickhouse-monitoring`), expose port `3000`, run as the non-root
+`app` user (uid/gid `1001`), and wire the same health probes and `CLICKHOUSE_*`
+environment.
+
+- **Helm** — templating, an optional HorizontalPodAutoscaler, and an Ingress.
+- **kustomize** — plain YAML you can read, diff, and patch with overlays.
+
+## Install with Helm
+
+The chart is vendored in the repo at
+[`deploy/helm/clickhouse-monitoring`](https://github.com/duyet/clickhouse-monitoring/tree/main/deploy/helm/clickhouse-monitoring)
+so it tracks the app it ships.
 
 ```bash
-helm repo add duyet https://duyet.github.io/charts
+helm install my-chm ./deploy/helm/clickhouse-monitoring \
+  --set clickhouse.host="https://clickhouse.example.com:8443" \
+  --set clickhouse.user="default" \
+  --set clickhouse.password="<password>"
+```
 
-cat <<EOF >> values.yaml
-env:
-  - name: CLICKHOUSE_HOST
-    value: http://localhost:8123
-  - name: CLICKHOUSE_USER
-    value: default
-  - name: CLICKHOUSE_PASSWORD
-    value: ''
+Or with a values file:
+
+```bash
+cat <<EOF > values.yaml
+clickhouse:
+  host: "https://clickhouse.example.com:8443"
+  user: "default"
+  password: "<password>"
+  maxExecutionTime: "60"
+extraEnv:
   - name: CLICKHOUSE_TZ
-    value: 'Asia/Ho_Chi_Minh'
-  - name: CLICKHOUSE_MAX_EXECUTION_TIME
-    value: '15'
-  - name: NEXT_QUERY_CACHE_TTL
-    value: '86400'
+    value: "UTC"
 EOF
 
-helm install -f values.yaml clickhouse-monitoring-release duyet/clickhouse-monitoring
+helm install my-chm ./deploy/helm/clickhouse-monitoring -f values.yaml
+```
+
+Upgrade and uninstall:
+
+```bash
+helm upgrade my-chm ./deploy/helm/clickhouse-monitoring -f values.yaml
+helm uninstall my-chm
+```
+
+## Install with kustomize (no Helm)
+
+The raw manifests live at
+[`deploy/kubernetes/base`](https://github.com/duyet/clickhouse-monitoring/tree/main/deploy/kubernetes/base).
+Edit `base/configmap.yaml` (host/user) and set the password, then:
+
+```bash
+# Review the rendered output first
+kubectl kustomize deploy/kubernetes/base
+
+# Apply
+kubectl apply -k deploy/kubernetes/base
+```
+
+Reach the dashboard locally:
+
+```bash
+kubectl port-forward svc/clickhouse-monitoring 3000:3000
+# open http://localhost:3000
+```
+
+### Overlays
+
+Keep environment differences (namespace, replicas, image tag) in an overlay that
+references the base:
+
+```yaml
+# deploy/kubernetes/overlays/prod/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - ../../base
+images:
+  - name: ghcr.io/duyet/clickhouse-monitoring
+    newTag: v1.2.3
+replicas:
+  - name: clickhouse-monitoring
+    count: 2
+```
+
+```bash
+kubectl apply -k deploy/kubernetes/overlays/prod
+```
+
+## Health probes
+
+Both install paths configure the same probes:
+
+- **Liveness** — `GET /healthz` (static, always `200` while the process runs).
+- **Readiness** — `GET /api/healthz` (returns `503` when no configured
+  ClickHouse host is reachable, so traffic is only routed once a host is up).
+
+## Secrets
+
+The ClickHouse password is stored in a Kubernetes `Secret`, never in a
+`ConfigMap`. The chart renders one for you (or reuses an existing one via
+`clickhouse.existingSecret`); the kustomize `secret.yaml` ships an **empty
+placeholder** you must override. Never commit a real password to Git — create
+the Secret out of band or use a secrets operator:
+
+```bash
+kubectl create secret generic clickhouse-monitoring \
+  --from-literal=CLICKHOUSE_PASSWORD='change-me'
+```
+
+For GitOps, prefer [External Secrets](https://external-secrets.io/),
+[SOPS](https://github.com/getsops/sops), or
+[Sealed Secrets](https://sealed-secrets.netlify.app/).
+
+## Autoscaling (HPA)
+
+The Helm chart can manage a HorizontalPodAutoscaler. Enable it and the chart
+drops the static `replicaCount` in favor of the HPA:
+
+```yaml
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+```
+
+With kustomize, add the HPA as an extra resource in your overlay. The dashboard
+is stateless, so scaling out is safe; the readiness probe keeps traffic off pods
+until ClickHouse is reachable.
+
+## Validation
+
+Manifests and the chart are linted in CI by
+[`.github/workflows/k8s-lint.yml`](https://github.com/duyet/clickhouse-monitoring/blob/main/.github/workflows/k8s-lint.yml)
+using `helm lint` and [kubeconform](https://github.com/yannh/kubeconform).
+Validate locally:
+
+```bash
+helm lint ./deploy/helm/clickhouse-monitoring
+helm template release ./deploy/helm/clickhouse-monitoring | kubeconform -strict -summary
+kubectl kustomize deploy/kubernetes/base | kubeconform -strict -summary
 ```
 
 import { Cards } from 'nextra/components'


### PR DESCRIPTION
## What

Completes the in-repo Kubernetes story alongside the Helm chart (added in #1306).

**1. kustomize base** — `deploy/kubernetes/base/` (no-Helm `kubectl apply -k` path)
- `deployment.yaml`, `service.yaml`, `configmap.yaml`, `secret.yaml`, `kustomization.yaml`
- Mirrors the Helm chart exactly: image `ghcr.io/duyet/clickhouse-monitoring`, port `3000`, `/healthz` liveness + `/api/healthz` readiness probes, non-root `1001` securityContext (all caps dropped), and `CLICKHOUSE_*` env sourced from a ConfigMap + a Secret.
- `secret.yaml` ships an **empty placeholder** password (stringData) — never a real credential.
- `deploy/kubernetes/README.md` documents quick start, secrets handling, and overlays.

**2. CI gate** — `.github/workflows/k8s-lint.yml` (runs on PRs/pushes touching `deploy/` paths)
- `helm lint` on the chart
- `helm template | kubeconform -strict -summary`
- `kubectl kustomize deploy/kubernetes/base | kubeconform -strict -summary`
- Self-contained: pinned `kubeconform` install + `azure/setup-helm`; `kubectl` is preinstalled on the runner.

**3. Docs** — expanded the existing `deploy/k8s` page **in place** (no new docs page → `docsNav` unchanged, guard test stays green) with both install paths (helm and `kubectl -k`) plus probe/secret/HPA/kustomize guidance.

## Why

The Helm chart was the only k8s path. This adds a raw-YAML option for teams that keep cluster config in Git as plain manifests, and a CI gate so both the chart and the manifests stay valid against the Kubernetes API schemas.

## Test notes

- `k8s-lint.yml` validates everything in CI on this PR (it touches `deploy/` paths).
- Local checks:
  - `helm lint ./deploy/helm/clickhouse-monitoring`
  - `helm template release ./deploy/helm/clickhouse-monitoring | kubeconform -strict -summary`
  - `kubectl kustomize deploy/kubernetes/base | kubeconform -strict -summary`
- No app/TS changes; the docsNav drift-guard test is unaffected since no new docs page was added.

Co-Authored-By: duyetbot <bot@duyet.net>