### PR TITLE
fix(overview): keep page scrollable to bottom during loading

### DIFF
--- a/apps/web/app/(dashboard)/overview/page.tsx
+++ b/apps/web/app/(dashboard)/overview/page.tsx
@@ -9,7 +9,7 @@ import { LazyChartWrapper } from '@/components/charts/lazy-chart-wrapper'
 import { ClientOnly } from '@/components/client-only'
 import { OverviewCharts } from '@/components/overview-charts/overview-charts-client'
 import { OverviewStatusStrip } from '@/components/overview-charts/overview-status-strip'
-import { Skeleton, TabsSkeleton } from '@/components/skeletons'
+import { ChartSkeleton, Skeleton, TabsSkeleton } from '@/components/skeletons'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useHostId } from '@/lib/swr'
 import { cn } from '@/lib/utils'
@@ -181,6 +181,10 @@ function OverviewPageContent() {
   )
 }
 
+// First (default) tab whose grid is shown on initial load. Reserving its real
+// height in the fallback is what keeps the page scrollable while data loads.
+const FIRST_TAB = OVERVIEW_TABS[0]
+
 /**
  * Full-page loading fallback for the searchParams Suspense boundary.
  *
@@ -188,7 +192,9 @@ function OverviewPageContent() {
  * requires to sit under Suspense. A tiny single-card fallback collapses the
  * document to ~140px during that flash, so the scroll container has nothing to
  * scroll and the viewport snaps back to the top. Reserving the real layout's
- * height (status strip + KPI grid + tabs) keeps the scroll position stable.
+ * height — status strip + KPI grid + tabs + the first tab's chart grid — keeps
+ * the scroll position stable and lets the user scroll to the bottom while the
+ * charts are still loading.
  */
 function OverviewPageFallback() {
   return (
@@ -200,6 +206,18 @@ function OverviewPageFallback() {
         ))}
       </div>
       <TabsSkeleton tabCount={OVERVIEW_TABS.length} />
+      {/* Reserve the first tab's chart grid so the loading document is roughly
+          as tall as the loaded page. Reuses the real grid class + chart count
+          so it stays in sync if charts are added/removed. */}
+      <div className={cn('mt-2', FIRST_TAB.gridClassName)} aria-hidden="true">
+        {FIRST_TAB.charts.map((chart) => (
+          <ChartSkeleton
+            key={chart.id}
+            className={cn(OVERVIEW_CHART_CLASS_NAME, chart.className)}
+            type={chart.type === 'metric' ? 'metric' : undefined}
+          />
+        ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## What

On `/overview?host=0`, while charts were still loading the user could not scroll to the bottom of the page; scrolling only worked after data loaded.

The searchParams Suspense fallback (`OverviewPageFallback`) only reserved the status strip, four KPI skeletons, and the tabs row — **not** the first-tab chart grid. During the Suspense flash and early loading the document was much shorter than the loaded page, so the scroll container (`flex-1 overflow-y-auto` in the dashboard layout) had little/nothing to scroll and the viewport snapped to the top.

## Fix

Extend `OverviewPageFallback` to also reserve the first tab's chart grid, reusing:
- the real grid class (`OVERVIEW_TABS[0].gridClassName`) and chart list/count, so it stays in sync if charts are added/removed
- `ChartSkeleton` for chart-sized cells, carrying each chart's `className` (incl. `row-span-2`/`col-span-*`) so the loading layout mirrors the loaded one

This makes the loading-phase document height ~= loaded height, so the page is fully scrollable during all loading phases. No change to the existing 'snap to top' fix's status-strip/KPI/tabs reservation. The lazy slots already reserve 280px matching `auto-rows-[280px]`, and the layout scroll container was already correct, so no other files needed changes.

Fixes scroll-during-loading on `/overview?host=0`.

## Summary by Sourcery

Ensure the overview page remains scrollable to the bottom while charts are loading by reserving the initial tab’s chart grid in the Suspense fallback layout.

Bug Fixes:
- Fix loss of scrollability during loading on the overview page by matching the fallback layout height to the loaded chart grid.

Enhancements:
- Extend the overview Suspense fallback to mirror the first tab’s chart grid using chart skeletons tied to the real grid configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced loading placeholders on the overview page to accurately reflect final chart layouts, preventing layout shifts and maintaining scroll position stability during data loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->