### PR TITLE
feat(failed-queries): add filters + fix truncated action-column header

### DIFF
--- a/apps/web/components/data-table/column-defs/components/column-header.tsx
+++ b/apps/web/components/data-table/column-defs/components/column-header.tsx
@@ -9,6 +9,7 @@ import {
   CaretSortIcon,
   CaretUpIcon,
 } from '@radix-ui/react-icons'
+import { MoreHorizontal } from 'lucide-react'
 import type { Column, RowData } from '@tanstack/react-table'
 
 import type { Icon } from '@chm/types/icon'
@@ -60,7 +61,12 @@ function HeaderContent({
   icon?: Icon
 }) {
   if (format === 'action') {
-    return <span className="text-muted-foreground/60">actions</span>
+    return (
+      <span className="inline-flex items-center text-muted-foreground/60">
+        <MoreHorizontal className="size-3.5 shrink-0" aria-hidden="true" />
+        <span className="sr-only">Actions</span>
+      </span>
+    )
   }
 
   return (

--- a/apps/web/lib/query-config/queries/failed-queries.ts
+++ b/apps/web/lib/query-config/queries/failed-queries.ts
@@ -8,6 +8,37 @@ export const failedQueriesConfig: QueryConfig = {
   description: "type IN ['ExceptionBeforeStart', 'ExceptionWhileProcessing']",
   docs: QUERY_LOG,
   tableCheck: 'system.query_log',
+  defaultParams: {
+    type: '',
+    last_hours: '336',
+  },
+  filterParamPresets: [
+    {
+      name: 'Exception before start',
+      key: 'type',
+      value: 'ExceptionBeforeStart',
+    },
+    {
+      name: 'Exception while processing',
+      key: 'type',
+      value: 'ExceptionWhileProcessing',
+    },
+    {
+      name: 'Last 1 hour',
+      key: 'last_hours',
+      value: '1',
+    },
+    {
+      name: 'Last 24 hours',
+      key: 'last_hours',
+      value: '24',
+    },
+    {
+      name: 'Last 7 days',
+      key: 'last_hours',
+      value: '168',
+    },
+  ],
   sql: [
     {
       since: '23.8',
@@ -48,6 +79,8 @@ export const failedQueriesConfig: QueryConfig = {
             Settings
         FROM system.query_log
         WHERE type IN ['ExceptionBeforeStart', 'ExceptionWhileProcessing']
+            AND ({type:String} = '' OR type = {type:String})
+            AND event_time > now() - interval {last_hours:UInt64} hour
         ORDER BY query_start_time DESC
         LIMIT 1000
       `,
@@ -92,6 +125,8 @@ export const failedQueriesConfig: QueryConfig = {
             Settings
         FROM system.query_log
         WHERE type IN ['ExceptionBeforeStart', 'ExceptionWhileProcessing']
+            AND ({type:String} = '' OR type = {type:String})
+            AND event_time > now() - interval {last_hours:UInt64} hour
         ORDER BY query_start_time DESC
         LIMIT 1000
       `,


### PR DESCRIPTION
## What

Two changes for `/failed-queries?host=0`:

**A) Filters dropdown.** Add `filterParamPresets` (+ `defaultParams`) to `failed-queries.ts` so `DataTableToolbar` auto-renders the Filters dropdown (same mechanism as `slow-queries` / `login-attempts`):
- Exception type: *Exception before start* (`type=ExceptionBeforeStart`), *Exception while processing* (`type=ExceptionWhileProcessing`)
- Time window: *Last 1 hour / 24 hours / 7 days* (`last_hours`)

The `type` and `last_hours` params are now consumed by both versioned SQL WHERE clauses via parameter placeholders (`AND ({type:String} = '' OR type = {type:String})` and `AND event_time > now() - interval {last_hours:UInt64} hour`), so the presets actually narrow results instead of being decorative. Defaults: `type=''` (all exception types), `last_hours='336'` (14d, matching the related charts window).

**B) Truncated header bug.** The first column is a ~56px-wide action column whose header rendered the text `actions`, which truncated to a stray `a` next to `query_id`. `HeaderContent` now renders an icon-only header (lucide `MoreHorizontal`, matching the row action menu icon) with a visually-hidden `Actions` label for accessibility. Column stays non-sortable / non-hideable and width is unchanged. This is a shared file but the change is isolated to the `format === 'action'` branch, so it improves every table.

## Why

Failed-queries had no way to filter by exception type or time window, and the truncated `actions` header showed a confusing stray `a`.

Fixes the UX of `/failed-queries?host=0` (and the action-column header across all tables).

## Summary by Sourcery

Add filtering capabilities and default parameters to the failed queries view and update the action-column header to use an icon-only label for better UX and accessibility across tables.

New Features:
- Introduce preset filters and default parameters for exception type and time window on the failed queries table.

Enhancements:
- Apply type and time window parameters to failed queries SQL to narrow results based on selected filters.
- Replace the text-based action column header with an icon-only header and accessible label across all data tables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Actions column header now displays as an icon instead of text for better visual clarity.
  * Added filtering options for failed queries by exception type and time window (1h, 24h, 7d).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->