### PR TITLE
feat(ui): premium redesign of Request Info (SQL) dialog

### DIFF
--- a/apps/web/components/cards/card-toolbar.tsx
+++ b/apps/web/components/cards/card-toolbar.tsx
@@ -1,25 +1,13 @@
 'use client'
 
-import {
-  Check,
-  Clock,
-  Copy,
-  Database,
-  ExternalLink,
-  Hash,
-  Info,
-  MoreHorizontal,
-  Server,
-  Sparkles,
-  Zap,
-} from 'lucide-react'
+import { Check, Copy, Database, Info, MoreHorizontal } from 'lucide-react'
 
 import type { ApiResponseMetadata } from '@/lib/api/types'
 import type { ChartDataPoint } from '@/types/chart-data'
 
 import { useState } from 'react'
-import { format } from 'sql-formatter'
 import { ChartCsvExportButton } from '@/components/cards/chart-csv-export-button'
+import { RequestInfoContent } from '@/components/dialogs/dialog-sql'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -33,47 +21,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Switch } from '@/components/ui/switch'
-import { cn, dedent } from '@/lib/utils'
-
-const SQL_BEAUTIFY_KEY = 'card-toolbar-sql-beautify'
-
-/** Get initial beautify state from localStorage */
-function getInitialBeautifyState(): boolean {
-  if (typeof window === 'undefined') return true
-  try {
-    const stored = localStorage.getItem(SQL_BEAUTIFY_KEY)
-    return stored === null ? true : stored === 'true'
-  } catch {
-    return true
-  }
-}
-
-/** Save beautify state to localStorage */
-function saveBeautifyState(value: boolean) {
-  if (typeof window === 'undefined') return
-  try {
-    localStorage.setItem(SQL_BEAUTIFY_KEY, String(value))
-  } catch {
-    // Ignore storage errors
-  }
-}
-
-/** Format SQL with ClickHouse dialect */
-function formatSQL(sql: string): string {
-  try {
-    return format(sql, {
-      language: 'sql',
-      keywordCase: 'upper',
-      identifierCase: 'preserve',
-      tabWidth: 2,
-      linesBetweenQueries: 2,
-    })
-  } catch {
-    // If formatting fails, return dedented original
-    return dedent(sql)
-  }
-}
+import { cn } from '@/lib/utils'
 
 /**
  * Metadata type for CardToolbar - uses shared ApiResponseMetadata
@@ -93,47 +41,6 @@ export interface CardToolbarProps {
 }
 
 /**
- * Copyable value component - displays a value that can be clicked to copy
- */
-function CopyableValue({
-  value,
-  className = '',
-}: {
-  value: string | number
-  className?: string
-}) {
-  const [copied, setCopied] = useState(false)
-
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(String(value))
-    setCopied(true)
-    setTimeout(() => setCopied(false), 1500)
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={handleCopy}
-      className={cn(
-        'font-mono font-medium text-right truncate min-w-0 hover:text-primary cursor-pointer transition-colors inline-flex items-center gap-1 group/copy',
-        className
-      )}
-      title={`Click to copy: ${value}`}
-    >
-      <span className="truncate">{value}</span>
-      {copied ? (
-        <Check className="size-3 text-green-500 shrink-0" strokeWidth={2} />
-      ) : (
-        <Copy
-          className="size-3 opacity-0 group-hover/copy:opacity-50 shrink-0 transition-opacity"
-          strokeWidth={1.5}
-        />
-      )}
-    </button>
-  )
-}
-
-/**
  * CardToolbar - Dropdown menu for viewing request info and raw data
  *
  * Extracted as a standalone component for reuse in both ChartCard and ChartEmpty.
@@ -147,32 +54,10 @@ export const CardToolbar = function CardToolbar({
 }: CardToolbarProps) {
   const [showRequestInfo, setShowRequestInfo] = useState(false)
   const [showData, setShowData] = useState(false)
-  const [isBeautified, setIsBeautified] = useState(getInitialBeautifyState)
-
-  const handleBeautifyToggle = (checked: boolean) => {
-    setIsBeautified(checked)
-    saveBeautifyState(checked)
-  }
+  const [copied, setCopied] = useState(false)
 
   const dataJson = (() => {
     return data ? JSON.stringify(data, null, 2) : null
-  })()
-
-  const displaySql = (() => {
-    if (!sql) return null
-    return isBeautified ? formatSQL(sql) : dedent(sql)
-  })()
-
-  const [copied, setCopied] = useState(false)
-
-  // Build full API URL for debugging - must be before any early returns
-  const fullApiUrl = (() => {
-    if (!metadata?.api) return null
-    // api field already contains full URL with params
-    const baseUrl = typeof window !== 'undefined' ? window.location.origin : ''
-    return metadata.api.startsWith('http')
-      ? metadata.api
-      : `${baseUrl}${metadata.api}`
   })()
 
   const handleCopy = async (text: string) => {
@@ -199,12 +84,6 @@ export const CardToolbar = function CardToolbar({
 
   // Don't render if nothing to show
   if (!sql && !hasData && !hasMetadata) return null
-
-  // Format duration for display
-  const formatDuration = (ms: number) => {
-    if (ms < 1000) return `${ms}ms`
-    return `${(ms / 1000).toFixed(2)}s`
-  }
 
   return (
     <>
@@ -260,158 +139,22 @@ export const CardToolbar = function CardToolbar({
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {/* Request Info Dialog (Metadata + SQL combined) */}
+      {/* Request Info Dialog (Metadata + SQL combined) — shares the same body
+          as DialogSQL so both Request Info dialogs stay identical. */}
       <Dialog open={showRequestInfo} onOpenChange={setShowRequestInfo}>
-        <DialogContent className="w-full max-w-[95vw] sm:min-w-[550px] sm:max-w-[800px] max-h-[90vh] flex flex-col p-6">
+        <DialogContent className="w-full max-w-[95vw] sm:min-w-[550px] sm:max-w-[850px] max-h-[90vh] flex flex-col p-6">
           <DialogHeader className="pb-2">
             <DialogTitle className="text-lg font-medium">
               Request Info
             </DialogTitle>
           </DialogHeader>
 
-          <div className="flex flex-col gap-6 overflow-auto">
-            {/* Metadata Section */}
-            {hasMetadata && (
-              <div className="space-y-4">
-                <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
-                  Metadata
-                </h3>
-                <dl className="space-y-3 text-sm [&_dt]:min-w-[100px]">
-                  {fullApiUrl && (
-                    <div className="flex items-center justify-between gap-6">
-                      <dt className="text-muted-foreground flex items-center gap-2 shrink-0">
-                        <ExternalLink className="size-3.5" strokeWidth={1.5} />
-                        API URL
-                      </dt>
-                      <dd className="min-w-0 flex-1 text-right">
-                        <button
-                          type="button"
-                          onClick={() => handleCopy(fullApiUrl)}
-                          className="font-mono text-xs text-right truncate max-w-full hover:text-primary cursor-pointer transition-colors inline-flex items-center gap-1.5 group/copy"
-                          title={`Click to copy: ${fullApiUrl}`}
-                        >
-                          <span className="truncate">
-                            {metadata?.api || fullApiUrl}
-                          </span>
-                          <Copy
-                            className="size-3 opacity-40 group-hover/copy:opacity-100 shrink-0 transition-opacity"
-                            strokeWidth={1.5}
-                          />
-                        </button>
-                      </dd>
-                    </div>
-                  )}
-                  {metadata?.duration !== undefined && (
-                    <div className="flex justify-between gap-6">
-                      <dt className="text-muted-foreground flex items-center gap-2 shrink-0">
-                        <Clock className="size-3.5" strokeWidth={1.5} />
-                        Duration
-                      </dt>
-                      <CopyableValue
-                        value={formatDuration(metadata.duration)}
-                      />
-                    </div>
-                  )}
-                  {metadata?.rows !== undefined && (
-                    <div className="flex justify-between gap-6">
-                      <dt className="text-muted-foreground flex items-center gap-2 shrink-0">
-                        <Database className="size-3.5" strokeWidth={1.5} />
-                        Rows
-                      </dt>
-                      <CopyableValue value={metadata.rows.toLocaleString()} />
-                    </div>
-                  )}
-                  {metadata?.clickhouseVersion && (
-                    <div className="flex justify-between gap-6">
-                      <dt className="text-muted-foreground flex items-center gap-2 shrink-0">
-                        <Zap className="size-3.5" strokeWidth={1.5} />
-                        Version
-                      </dt>
-                      <CopyableValue value={metadata.clickhouseVersion} />
-                    </div>
-                  )}
-                  {metadata?.host && (
-                    <div className="flex justify-between gap-6">
-                      <dt className="text-muted-foreground flex items-center gap-2 shrink-0">
-                        <Server className="size-3.5" strokeWidth={1.5} />
-                        Host
-                      </dt>
-                      <CopyableValue value={metadata.host} />
-                    </div>
-                  )}
-                  {metadata?.queryId && (
-                    <div className="flex justify-between gap-6">
-                      <dt className="text-muted-foreground flex items-center gap-2 shrink-0">
-                        <Hash className="size-3.5" strokeWidth={1.5} />
-                        Query ID
-                      </dt>
-                      <CopyableValue value={metadata.queryId} />
-                    </div>
-                  )}
-                  {metadata?.status && metadata.status !== 'ok' && (
-                    <div className="flex justify-between gap-6">
-                      <dt className="text-muted-foreground flex items-center gap-2 shrink-0">
-                        <Info className="size-3.5" strokeWidth={1.5} />
-                        Status
-                      </dt>
-                      <dd className="font-medium">
-                        {metadata.status.replace(/_/g, ' ')}
-                      </dd>
-                    </div>
-                  )}
-                </dl>
-                {metadata?.statusMessage && (
-                  <p className="text-sm text-muted-foreground pt-2 border-t">
-                    {metadata.statusMessage}
-                  </p>
-                )}
-              </div>
-            )}
-
-            {/* SQL Section */}
-            {displaySql && (
-              <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
-                    SQL Query
-                  </h3>
-                  <div className="flex items-center gap-3">
-                    <div className="flex items-center gap-1.5">
-                      <Sparkles
-                        className="size-3 text-muted-foreground"
-                        strokeWidth={1.5}
-                      />
-                      <span className="text-xs text-muted-foreground">
-                        Beautify
-                      </span>
-                      <Switch
-                        checked={isBeautified}
-                        onCheckedChange={handleBeautifyToggle}
-                        className="scale-75"
-                      />
-                    </div>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-6 gap-1.5 text-xs text-muted-foreground"
-                      onClick={() => displaySql && handleCopy(displaySql)}
-                    >
-                      {copied ? (
-                        <Check className="size-3" strokeWidth={1.5} />
-                      ) : (
-                        <Copy className="size-3" strokeWidth={1.5} />
-                      )}
-                      {copied ? 'Copied' : 'Copy'}
-                    </Button>
-                  </div>
-                </div>
-                <pre className="text-[13px] leading-relaxed font-mono bg-muted/50 p-4 rounded-lg overflow-auto max-h-[50vh]">
-                  <code className="whitespace-pre-wrap break-words">
-                    {displaySql}
-                  </code>
-                </pre>
-              </div>
-            )}
+          <div className="overflow-auto">
+            <RequestInfoContent
+              sql={sql}
+              metadata={metadata}
+              fullScreen={false}
+            />
           </div>
         </DialogContent>
       </Dialog>

--- a/apps/web/components/dialogs/dialog-sql.tsx
+++ b/apps/web/components/dialogs/dialog-sql.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import {
   Check,
   Clock,
@@ -13,8 +15,9 @@ import {
 
 import type { ApiResponseMetadata } from '@/lib/api/types'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { format } from 'sql-formatter'
+import { highlightCode } from '@/components/ai-elements/code-block'
 import {
   DialogContent,
   type DialogContentProps,
@@ -119,16 +122,26 @@ function CopyableValue({
   )
 }
 
-export const DialogSQL = function DialogSQL({
-  button,
-  title = 'SQL Code',
-  description = 'Raw SQL code of this table',
+/** Shared hljs color tokens (matches CodeBlock / CodeDialogFormat). */
+const HLJS_TOKEN_CLASSES =
+  '[&_code]:break-words [&_pre]:m-0 [&_pre]:max-w-full [&_pre]:whitespace-pre-wrap [&_.hljs-keyword]:text-purple-600 [&_.hljs-string]:text-green-700 [&_.hljs-number]:text-blue-600 [&_.hljs-comment]:text-gray-500 [&_.hljs-built_in]:text-cyan-700 [&_.hljs-title]:text-blue-700 [&_.hljs-attr]:text-orange-600 [&_.hljs-literal]:text-blue-600 dark:[&_.hljs-keyword]:text-purple-400 dark:[&_.hljs-string]:text-green-400 dark:[&_.hljs-number]:text-blue-400 dark:[&_.hljs-comment]:text-gray-400 dark:[&_.hljs-built_in]:text-cyan-400 dark:[&_.hljs-title]:text-blue-400 dark:[&_.hljs-attr]:text-orange-400 dark:[&_.hljs-literal]:text-blue-400'
+
+/**
+ * Shared Request Info body: query metadata grid + syntax-highlighted SQL.
+ *
+ * Rendered both by {@link DialogSQL} (inside the shared DialogContent wrapper)
+ * and by `CardToolbar` (inside its controlled Dialog) so the two "Request Info"
+ * dialogs stay identical.
+ */
+export function RequestInfoContent({
   sql,
-  fullScreen = true,
   metadata,
-  ...props
-}: ShowSQLButtonProps) {
-  const [isFullScreen, _setIsFullScreen] = useState(fullScreen)
+  fullScreen = true,
+}: {
+  sql?: string
+  metadata?: Partial<ApiResponseMetadata>
+  fullScreen?: boolean
+}) {
   const [isBeautified, setIsBeautified] = useState(getInitialBeautifyState)
   const [copied, setCopied] = useState(false)
 
@@ -162,208 +175,201 @@ export const DialogSQL = function DialogSQL({
       metadata.queryId ||
       metadata.api)
 
-  if (!sql) {
-    return null
-  }
+  const displaySQL = sql ? (isBeautified ? formatSQL(sql) : dedent(sql)) : ''
 
-  const displaySQL = isBeautified ? formatSQL(sql) : dedent(sql)
+  const highlightedHtml = useMemo(() => {
+    if (!displaySQL) return ''
+    return highlightCode(displaySQL, 'sql')
+  }, [displaySQL])
 
   return (
-    <DialogContent
-      button={
-        button ? (
-          button
-        ) : (
-          <Button
-            variant="outline"
-            className="ml-auto"
-            aria-label="Show SQL"
-            title="Show SQL for this table"
-          >
-            <CodeIcon className="size-4" />
-          </Button>
-        )
-      }
-      title={title}
-      description={description}
-      headerActions={
-        <>
-          <div className="flex items-center gap-1.5">
-            <SparklesIcon className="size-3 text-muted-foreground" />
-            <span className="text-xs text-muted-foreground">Beautify</span>
-            <Switch
-              checked={isBeautified}
-              onCheckedChange={handleBeautifyToggle}
-              aria-label="Toggle SQL beautification"
-              className="scale-75"
-            />
+    <div className="flex flex-col gap-3">
+      {/* Metadata Section */}
+      {hasMetadata && (
+        <div className="rounded-xl border border-border/60 bg-gradient-to-b from-muted/40 to-muted/20 p-4">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-xs font-semibold text-foreground uppercase tracking-wider flex items-center gap-2">
+              <Info className="size-3.5 text-primary" strokeWidth={2} />
+              Request Info
+            </h3>
+            <Badge
+              variant="outline"
+              className="font-mono text-[10px] bg-background/50 border-border/40"
+            >
+              {metadata?.host || 'Local'}
+            </Badge>
           </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-6 gap-1 text-xs text-muted-foreground px-2"
-            onClick={() => handleCopy(displaySQL)}
-          >
-            {copied ? (
-              <Check className="size-3" strokeWidth={1.5} />
-            ) : (
-              <Copy className="size-3" strokeWidth={1.5} />
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3">
+            {fullApiUrl && (
+              <div className="col-span-full group/api">
+                <dt className="text-[10px] font-medium text-muted-foreground uppercase tracking-tight mb-1 flex items-center gap-1.5">
+                  <ExternalLink className="size-3" strokeWidth={1.5} />
+                  API Endpoint
+                </dt>
+                <dd className="flex items-center gap-2 bg-background/50 rounded-md border border-border/40 px-2 py-1.5 transition-colors group-hover/api:border-primary/30">
+                  <code className="text-[11px] font-mono truncate flex-1 text-muted-foreground group-hover/api:text-foreground transition-colors">
+                    {metadata?.api || fullApiUrl}
+                  </code>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-6 shrink-0 opacity-40 group-hover/api:opacity-100"
+                    onClick={() => handleCopy(fullApiUrl)}
+                    title="Copy API URL"
+                  >
+                    <Copy className="size-3" />
+                  </Button>
+                </dd>
+              </div>
             )}
-            {copied ? 'Copied' : 'Copy'}
-          </Button>
-        </>
-      }
-      content={
-        <div className="flex flex-col gap-3">
-          {/* Metadata Section */}
-          {hasMetadata && (
-            <div className="rounded-xl border border-border/60 bg-muted/30 p-4">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-xs font-semibold text-foreground uppercase tracking-wider flex items-center gap-2">
-                  <Info className="size-3.5 text-primary" strokeWidth={2} />
-                  Request Info
-                </h3>
-                <Badge
-                  variant="outline"
-                  className="font-mono text-[10px] bg-background/50 border-border/40"
-                >
-                  {metadata?.host || 'Local'}
-                </Badge>
-              </div>
 
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3">
-                {fullApiUrl && (
-                  <div className="col-span-full group/api">
-                    <dt className="text-[10px] font-medium text-muted-foreground uppercase tracking-tight mb-1 flex items-center gap-1.5">
-                      <ExternalLink className="size-3" strokeWidth={1.5} />
-                      API Endpoint
-                    </dt>
-                    <dd className="flex items-center gap-2 bg-background/50 rounded-md border border-border/40 px-2 py-1.5 transition-colors group-hover/api:border-primary/30">
-                      <code className="text-[11px] font-mono truncate flex-1 text-muted-foreground group-hover/api:text-foreground transition-colors">
-                        {metadata?.api || fullApiUrl}
-                      </code>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="size-6 shrink-0 opacity-40 group-hover/api:opacity-100"
-                        onClick={() => handleCopy(fullApiUrl)}
-                        title="Copy API URL"
-                      >
-                        <Copy className="size-3" />
-                      </Button>
-                    </dd>
-                  </div>
-                )}
+            <Separator className="col-span-full bg-border/40" />
 
-                <Separator className="col-span-full bg-border/40" />
-
-                <div className="space-y-3">
-                  {metadata?.duration !== undefined && (
-                    <div className="flex items-center justify-between group/item">
-                      <dt className="text-xs text-muted-foreground flex items-center gap-2">
-                        <Clock
-                          className="size-3.5 text-muted-foreground/70"
-                          strokeWidth={1.5}
-                        />
-                        Duration
-                      </dt>
-                      <dd>
-                        <Badge
-                          variant="secondary"
-                          className="font-mono text-xs font-medium tabular-nums bg-background/50"
-                        >
-                          <CopyableValue
-                            value={formatDuration(metadata.duration)}
-                          />
-                        </Badge>
-                      </dd>
-                    </div>
-                  )}
-
-                  {metadata?.rows !== undefined && (
-                    <div className="flex items-center justify-between group/item">
-                      <dt className="text-xs text-muted-foreground flex items-center gap-2">
-                        <Database
-                          className="size-3.5 text-muted-foreground/70"
-                          strokeWidth={1.5}
-                        />
-                        Rows
-                      </dt>
-                      <dd>
-                        <Badge
-                          variant="secondary"
-                          className="font-mono text-xs font-medium tabular-nums bg-background/50"
-                        >
-                          <CopyableValue
-                            value={metadata.rows.toLocaleString()}
-                          />
-                        </Badge>
-                      </dd>
-                    </div>
-                  )}
+            <div className="space-y-3">
+              {metadata?.duration !== undefined && (
+                <div className="flex items-center justify-between group/item">
+                  <dt className="text-xs text-muted-foreground flex items-center gap-2">
+                    <Clock
+                      className="size-3.5 text-muted-foreground/70"
+                      strokeWidth={1.5}
+                    />
+                    Duration
+                  </dt>
+                  <dd>
+                    <Badge
+                      variant="secondary"
+                      className="font-mono text-xs font-medium tabular-nums bg-background/50"
+                    >
+                      <CopyableValue
+                        value={formatDuration(metadata.duration)}
+                      />
+                    </Badge>
+                  </dd>
                 </div>
+              )}
 
-                <div className="space-y-3 border-t md:border-t-0 md:border-l border-border/40 pt-3 md:pt-0 md:pl-4">
-                  {metadata?.clickhouseVersion && (
-                    <div className="flex items-center justify-between group/item">
-                      <dt className="text-xs text-muted-foreground flex items-center gap-2">
-                        <Zap
-                          className="size-3.5 text-muted-foreground/70"
-                          strokeWidth={1.5}
-                        />
-                        Version
-                      </dt>
-                      <dd>
-                        <Badge
-                          variant="outline"
-                          className="font-mono text-[11px] border-border/40"
-                        >
-                          <CopyableValue value={metadata.clickhouseVersion} />
-                        </Badge>
-                      </dd>
-                    </div>
-                  )}
-
-                  {metadata?.queryId && (
-                    <div className="flex flex-col gap-1 group/item">
-                      <dt className="text-xs text-muted-foreground flex items-center gap-2">
-                        <Hash
-                          className="size-3.5 text-muted-foreground/70"
-                          strokeWidth={1.5}
-                        />
-                        Query ID
-                      </dt>
-                      <dd className="bg-background/50 rounded px-2 py-1 border border-border/40">
-                        <CopyableValue
-                          value={metadata.queryId}
-                          className="text-[10px] w-full"
-                        />
-                      </dd>
-                    </div>
-                  )}
+              {metadata?.rows !== undefined && (
+                <div className="flex items-center justify-between group/item">
+                  <dt className="text-xs text-muted-foreground flex items-center gap-2">
+                    <Database
+                      className="size-3.5 text-muted-foreground/70"
+                      strokeWidth={1.5}
+                    />
+                    Rows
+                  </dt>
+                  <dd>
+                    <Badge
+                      variant="secondary"
+                      className="font-mono text-xs font-medium tabular-nums bg-background/50"
+                    >
+                      <CopyableValue value={metadata.rows.toLocaleString()} />
+                    </Badge>
+                  </dd>
                 </div>
-              </div>
+              )}
             </div>
-          )}
 
-          {/* SQL code display */}
+            <div className="space-y-3 border-t md:border-t-0 md:border-l border-border/40 pt-3 md:pt-0 md:pl-4">
+              {metadata?.clickhouseVersion && (
+                <div className="flex items-center justify-between group/item">
+                  <dt className="text-xs text-muted-foreground flex items-center gap-2">
+                    <Zap
+                      className="size-3.5 text-muted-foreground/70"
+                      strokeWidth={1.5}
+                    />
+                    Version
+                  </dt>
+                  <dd>
+                    <Badge
+                      variant="outline"
+                      className="font-mono text-[11px] border-border/40"
+                    >
+                      <CopyableValue value={metadata.clickhouseVersion} />
+                    </Badge>
+                  </dd>
+                </div>
+              )}
+
+              {metadata?.queryId && (
+                <div className="flex flex-col gap-1 group/item">
+                  <dt className="text-xs text-muted-foreground flex items-center gap-2">
+                    <Hash
+                      className="size-3.5 text-muted-foreground/70"
+                      strokeWidth={1.5}
+                    />
+                    Query ID
+                  </dt>
+                  <dd className="bg-background/50 rounded px-2 py-1 border border-border/40">
+                    <CopyableValue
+                      value={metadata.queryId}
+                      className="text-[10px] w-full"
+                    />
+                  </dd>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Data status (e.g. partial / empty results) */}
+          {metadata?.statusMessage && (
+            <p className="mt-3 pt-3 border-t border-border/40 text-xs text-muted-foreground">
+              {metadata.statusMessage}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* SQL code display */}
+      {sql && (
+        <>
+          <div className="flex items-center justify-between">
+            <h3 className="text-xs font-semibold text-foreground uppercase tracking-wider flex items-center gap-2">
+              <CodeIcon className="size-3.5 text-primary" strokeWidth={2} />
+              SQL Query
+            </h3>
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-1.5">
+                <SparklesIcon className="size-3 text-muted-foreground" />
+                <span className="text-xs text-muted-foreground">Beautify</span>
+                <Switch
+                  checked={isBeautified}
+                  onCheckedChange={handleBeautifyToggle}
+                  aria-label="Toggle SQL beautification"
+                  className="scale-75"
+                />
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 gap-1 text-xs text-muted-foreground px-2"
+                onClick={() => handleCopy(displaySQL)}
+              >
+                {copied ? (
+                  <Check className="size-3" strokeWidth={1.5} />
+                ) : (
+                  <Copy className="size-3" strokeWidth={1.5} />
+                )}
+                {copied ? 'Copied' : 'Copy'}
+              </Button>
+            </div>
+          </div>
+
           <div className="relative group/sql">
             <ScrollArea
               className={cn(
-                'rounded-xl border border-border/60 bg-muted/40 font-mono',
-                isFullScreen ? 'h-[calc(100vh-22rem)]' : 'h-[400px]'
+                'rounded-xl border border-border/60 bg-muted/40',
+                fullScreen ? 'h-[calc(100vh-24rem)]' : 'h-[400px]'
               )}
             >
-              <pre
+              <div
                 className={cn(
-                  'p-4 leading-relaxed',
-                  isFullScreen ? 'text-sm' : 'text-xs'
+                  '[&_pre]:bg-transparent! [&_pre]:p-4 [&_pre]:leading-relaxed',
+                  fullScreen ? '[&_pre]:text-sm' : '[&_pre]:text-xs',
+                  HLJS_TOKEN_CLASSES
                 )}
-              >
-                <code className="whitespace-pre-wrap break-words text-foreground/90">
-                  {displaySQL}
-                </code>
-              </pre>
+                dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+              />
             </ScrollArea>
 
             <div className="absolute top-3 right-3 flex items-center gap-2 opacity-0 group-hover/sql:opacity-100 transition-opacity">
@@ -396,11 +402,53 @@ export const DialogSQL = function DialogSQL({
             <span>ClickHouse SQL Dialect</span>
             <span>{displaySQL.split('\n').length} lines</span>
           </div>
-        </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+export const DialogSQL = function DialogSQL({
+  button,
+  title = 'SQL Code',
+  description = 'Raw SQL code of this table',
+  sql,
+  fullScreen = true,
+  metadata,
+  ...props
+}: ShowSQLButtonProps) {
+  if (!sql) {
+    return null
+  }
+
+  return (
+    <DialogContent
+      button={
+        button ? (
+          button
+        ) : (
+          <Button
+            variant="outline"
+            className="ml-auto"
+            aria-label="Show SQL"
+            title="Show SQL for this table"
+          >
+            <CodeIcon className="size-4" />
+          </Button>
+        )
+      }
+      title={title}
+      description={description}
+      content={
+        <RequestInfoContent
+          sql={sql}
+          metadata={metadata}
+          fullScreen={fullScreen}
+        />
       }
       contentClassName={cn(
         'max-w-[95vw] md:max-w-[90vw] lg:max-w-[85vw]',
-        isFullScreen && '!max-w-[98vw]'
+        fullScreen && '!max-w-[98vw]'
       )}
       {...props}
     />


### PR DESCRIPTION
## What

Redesign the **Request Info (SQL)** dialog and unify the two near-identical implementations.

- **Unify**: extracted a shared `RequestInfoContent` body from `dialog-sql.tsx` (metadata grid + SQL view). `card-toolbar.tsx` now renders the same body inside its controlled `Dialog`, so the two "Request Info" dialogs are identical (previously they were two divergent copies).
- **Syntax highlighting**: the SQL section now uses the existing `highlightCode()` helper from `ai-elements/code-block` (the same one `code-dialog-format.tsx` uses) with the shared hljs color tokens, replacing the plain `<pre>/<code>`.
- **Premium hierarchy**: metadata grouped in a `rounded-xl border-border/60` card with a subtle gradient, monospace inline-copy values, `Separator` dividers, and uppercase `tracking-wider` section labels (matching `chart-error.tsx`). Adds a dedicated "SQL Query" section header with the Beautify toggle + Copy beside it.
- Surfaces `metadata.statusMessage` (previously only card-toolbar showed it).

## Why

The card-toolbar Request Info dialog had drifted into a separate, plainer implementation. Unifying behind one shared body keeps both consistent and gives both syntax highlighting + the premium look.

## Behavior preserved

All props/behavior intact: metadata fields, `fullScreen`, Beautify toggle + localStorage persistence, Copy buttons, `ScrollArea`. Native shadcn primitives only — no `components/ui/*` edits.

Fixes the Request Info dialog surfaced from chart cards and the data-table "Show SQL" button.