### PR TITLE
feat(agent): auto-generate conversation titles from first message

### DIFF
--- a/apps/web/lib/ai/agent/__tests__/conversation-title.test.ts
+++ b/apps/web/lib/ai/agent/__tests__/conversation-title.test.ts
@@ -1,0 +1,90 @@
+import {
+  deriveTitleFromUserMessage,
+  extractMessageText,
+  isUntitledThread,
+} from '../conversation-utils'
+import { describe, expect, test } from 'bun:test'
+
+describe('extractMessageText', () => {
+  test('reads text from AI SDK parts', () => {
+    expect(
+      extractMessageText({
+        role: 'user',
+        parts: [
+          { type: 'text', text: 'show me' },
+          { type: 'text', text: 'slow queries' },
+        ],
+      })
+    ).toBe('show me slow queries')
+  })
+
+  test('ignores non-text parts', () => {
+    expect(
+      extractMessageText({
+        role: 'user',
+        parts: [{ type: 'step-start' }, { type: 'text', text: 'hello' }],
+      })
+    ).toBe('hello')
+  })
+
+  test('falls back to plain string content', () => {
+    expect(extractMessageText({ role: 'user', content: '  hi there  ' })).toBe(
+      'hi there'
+    )
+  })
+
+  test('falls back to array content', () => {
+    expect(
+      extractMessageText({
+        role: 'user',
+        content: [{ text: 'a' }, { text: 'b' }],
+      })
+    ).toBe('a b')
+  })
+
+  test('returns empty string for missing message', () => {
+    expect(extractMessageText(undefined)).toBe('')
+    expect(extractMessageText(null)).toBe('')
+  })
+})
+
+describe('deriveTitleFromUserMessage', () => {
+  test('derives a title from the first user message', () => {
+    expect(
+      deriveTitleFromUserMessage({
+        role: 'user',
+        parts: [{ type: 'text', text: 'What are the slowest queries today?' }],
+      })
+    ).toBe('What are the slowest queries today?')
+  })
+
+  test('returns undefined for assistant messages', () => {
+    expect(
+      deriveTitleFromUserMessage({
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Here you go' }],
+      })
+    ).toBeUndefined()
+  })
+
+  test('returns undefined when there is no text', () => {
+    expect(
+      deriveTitleFromUserMessage({ role: 'user', parts: [] })
+    ).toBeUndefined()
+    expect(deriveTitleFromUserMessage(undefined)).toBeUndefined()
+  })
+})
+
+describe('isUntitledThread', () => {
+  test('treats missing and placeholder titles as untitled', () => {
+    expect(isUntitledThread(undefined)).toBe(true)
+    expect(isUntitledThread(null)).toBe(true)
+    expect(isUntitledThread('')).toBe(true)
+    expect(isUntitledThread('New Conversation')).toBe(true)
+    expect(isUntitledThread('New Chat')).toBe(true)
+  })
+
+  test('treats a real title as titled', () => {
+    expect(isUntitledThread('Slowest queries today')).toBe(false)
+  })
+})

--- a/apps/web/lib/ai/agent/conversation-utils.ts
+++ b/apps/web/lib/ai/agent/conversation-utils.ts
@@ -105,6 +105,92 @@ export function generateTitleFromMessage(message: string): string {
 }
 
 /**
+ * A loosely-typed user/assistant message, matching the shapes produced by the
+ * AI SDK runtime (`parts: [{ type: 'text', text }]`) and the legacy plain-text
+ * format (`content: string` or `content: [{ text }]`).
+ */
+export interface TitleSourceMessage {
+  role?: string
+  parts?: unknown[]
+  content?: string | Array<{ text?: string }>
+}
+
+/**
+ * Extract the plain text of a message, regardless of whether it uses the AI SDK
+ * `parts` array or the legacy `content` string / array form.
+ *
+ * @param message - The message to read text from
+ * @returns The concatenated, trimmed text content (empty string if none)
+ */
+export function extractMessageText(
+  message: TitleSourceMessage | undefined | null
+): string {
+  if (!message) return ''
+
+  // AI SDK format: parts: [{ type: 'text', text: '...' }]
+  if (Array.isArray(message.parts)) {
+    const text = message.parts
+      .filter(
+        (part): part is { type: 'text'; text: string } =>
+          !!part &&
+          typeof part === 'object' &&
+          (part as { type?: unknown }).type === 'text' &&
+          typeof (part as { text?: unknown }).text === 'string'
+      )
+      .map((part) => part.text)
+      .join(' ')
+      .trim()
+    if (text) return text
+  }
+
+  // Legacy plain-string content.
+  if (typeof message.content === 'string') {
+    return message.content.trim()
+  }
+
+  // Legacy array content: [{ text: '...' }].
+  if (Array.isArray(message.content)) {
+    return message.content
+      .map((part) => part?.text ?? '')
+      .join(' ')
+      .trim()
+  }
+
+  return ''
+}
+
+/**
+ * Derive a conversation title from a message, but only when it is a user
+ * message that contains text. Returns `undefined` otherwise so callers can skip
+ * persisting a placeholder title.
+ *
+ * Reuses {@link generateTitleFromMessage} for the actual derivation, so the
+ * D1 / Postgres and localStorage stores produce identical titles client-side
+ * without an extra LLM call.
+ *
+ * @param message - The first user message in a conversation
+ * @returns A derived title, or `undefined` when no title can be derived
+ */
+export function deriveTitleFromUserMessage(
+  message: TitleSourceMessage | undefined | null
+): string | undefined {
+  if (!message || message.role !== 'user') return undefined
+  const text = extractMessageText(message)
+  return text ? generateTitleFromMessage(text) : undefined
+}
+
+/**
+ * Whether a thread title is still the default placeholder (or absent) and
+ * therefore eligible to be replaced by an auto-derived title.
+ *
+ * @param title - The current thread title (may be undefined)
+ * @returns `true` when the title is missing or a known placeholder
+ */
+export function isUntitledThread(title: string | undefined | null): boolean {
+  return !title || title === 'New Conversation' || title === 'New Chat'
+}
+
+/**
  * Format a timestamp as relative time or date string.
  *
  * Returns human-readable relative time for recent timestamps:

--- a/apps/web/lib/conversation-store/adapter/d1-thread-list-adapter.tsx
+++ b/apps/web/lib/conversation-store/adapter/d1-thread-list-adapter.tsx
@@ -22,7 +22,11 @@ import type { FC, PropsWithChildren } from 'react'
 
 import { RuntimeAdapterProvider, useAui } from '@assistant-ui/react'
 import { createAssistantStream } from 'assistant-stream'
-import { generateTitleFromMessage } from '@/lib/ai/agent/conversation-utils'
+import {
+  deriveTitleFromUserMessage,
+  isUntitledThread,
+  type TitleSourceMessage,
+} from '@/lib/ai/agent/conversation-utils'
 import {
   replaceHistoryItem,
   upsertHistoryItem,
@@ -101,43 +105,6 @@ async function apiDelete(id: string): Promise<void> {
   }
 }
 
-function deriveTitle(
-  message:
-    | {
-        role?: string
-        parts?: unknown[]
-        content?: string | Array<{ text?: string }>
-      }
-    | undefined
-): string | undefined {
-  if (!message || message.role !== 'user') {
-    return undefined
-  }
-  let text = ''
-  if (Array.isArray(message.parts)) {
-    for (const part of message.parts) {
-      if (
-        part &&
-        typeof part === 'object' &&
-        (part as { type?: unknown }).type === 'text' &&
-        typeof (part as { text?: unknown }).text === 'string'
-      ) {
-        text = ((part as { text: string }).text ?? '').trim()
-        if (text) break
-      }
-    }
-  }
-  if (!text && typeof message.content === 'string') {
-    text = message.content.trim()
-  } else if (!text && Array.isArray(message.content)) {
-    text = message.content
-      .map((p) => p.text ?? '')
-      .join(' ')
-      .trim()
-  }
-  return text ? generateTitleFromMessage(text) : undefined
-}
-
 /**
  * Per-thread message history backed by the conversations API. `useChatRuntime`
  * calls `withFormat()` for a format-bound `GenericThreadHistoryAdapter`; the
@@ -186,27 +153,21 @@ function createD1HistoryAdapter(
           upsertHistoryItem(repo, item, getId)
           repoCache.set(remoteId, repo)
 
-          const payload: { messages: unknown[]; title?: string } = {
-            messages: repo.messages,
-          }
-          // Auto-title: seed from the first user message when the thread has
-          // no title yet (or still has the default placeholder).
-          const currentTitle = aui.threadListItem().getState().title
-          const isUntitled =
-            !currentTitle ||
-            currentTitle === 'New Conversation' ||
-            currentTitle === 'New Chat'
-          if (isUntitled) {
-            const title = deriveTitle(
-              item.message as {
-                role?: string
-                parts?: unknown[]
-                content?: string | Array<{ text?: string }>
-              }
+          await apiPut(remoteId, { messages: repo.messages })
+
+          // Auto-title: derive from the first user message when the thread has
+          // no title yet (or still has the default placeholder). Route through
+          // the runtime's `rename()` so the thread-list UI updates immediately
+          // (optimistic in-memory state) and the title is persisted via the
+          // adapter's `rename()` (server-side `apiPut({ title })`).
+          if (isUntitledThread(aui.threadListItem().getState().title)) {
+            const title = deriveTitleFromUserMessage(
+              item.message as TitleSourceMessage
             )
-            if (title) payload.title = title
+            if (title) {
+              await aui.threadListItem().rename(title)
+            }
           }
-          await apiPut(remoteId, payload)
         },
         async update(item, localMessageId) {
           const remoteId = aui.threadListItem().getState().remoteId
@@ -298,20 +259,22 @@ export function createD1ThreadListAdapter(): RemoteThreadListAdapter {
 
     async generateTitle(remoteId) {
       const conversation = await apiGet(remoteId)
-      const messages = Array.isArray(conversation?.messages)
-        ? (conversation.messages as Array<Record<string, unknown>>)
+      const stored = Array.isArray(conversation?.messages)
+        ? (conversation.messages as unknown[])
         : []
-      const firstUserMsg = messages.find((m) => m.role === 'user')
-      const text =
-        typeof firstUserMsg?.content === 'string'
-          ? firstUserMsg.content
-          : Array.isArray(firstUserMsg?.content)
-            ? (firstUserMsg.content as Array<{ text?: string }>)
-                .map((p) => p.text ?? '')
-                .join(' ')
-            : ''
-
-      const title = text ? generateTitleFromMessage(text) : 'New Chat'
+      // Stored entries may be bare messages or `{ message }` wrappers
+      // (the format-adapter repository shape), so normalize before reading.
+      const messages = stored.map((entry) => {
+        const candidate =
+          entry &&
+          typeof entry === 'object' &&
+          'message' in (entry as Record<string, unknown>)
+            ? (entry as { message: unknown }).message
+            : entry
+        return candidate as TitleSourceMessage
+      })
+      const firstUserMsg = messages.find((m) => m?.role === 'user')
+      const title = deriveTitleFromUserMessage(firstUserMsg) ?? 'New Chat'
 
       // Persist the title server-side
       await apiPut(remoteId, { title })

--- a/apps/web/lib/conversation-store/adapter/local-thread-list-adapter.tsx
+++ b/apps/web/lib/conversation-store/adapter/local-thread-list-adapter.tsx
@@ -20,7 +20,11 @@ import type { FC, PropsWithChildren } from 'react'
 
 import { RuntimeAdapterProvider, useAui } from '@assistant-ui/react'
 import { createAssistantStream } from 'assistant-stream'
-import { generateTitleFromMessage } from '@/lib/ai/agent/conversation-utils'
+import {
+  deriveTitleFromUserMessage,
+  isUntitledThread,
+  type TitleSourceMessage,
+} from '@/lib/ai/agent/conversation-utils'
 import {
   replaceHistoryItem,
   upsertHistoryItem,
@@ -104,51 +108,16 @@ function createLocalHistoryAdapter(
           writeJson(messagesKey(remoteId), repo)
 
           // Auto-title: derive from the first user message when the thread has
-          // no title yet (or still has the default placeholder).
-          const currentTitle = aui.threadListItem().getState().title
-          const isUntitled =
-            !currentTitle ||
-            currentTitle === 'New Conversation' ||
-            currentTitle === 'New Chat'
-          if (isUntitled) {
-            const msg = item.message as {
-              role?: string
-              parts?: Array<{ type?: unknown; text?: string }>
-              content?: string | Array<{ text?: string }>
-            }
-            if (msg.role === 'user') {
-              // Extract text from parts (AI SDK format) or content (plain string)
-              let text = ''
-              if (Array.isArray(msg.parts)) {
-                text = msg.parts
-                  .filter(
-                    (p) =>
-                      p &&
-                      typeof p === 'object' &&
-                      p.type === 'text' &&
-                      typeof p.text === 'string'
-                  )
-                  .map((p) => p.text ?? '')
-                  .join(' ')
-                  .trim()
-              }
-              if (!text && typeof msg.content === 'string') {
-                text = msg.content.trim()
-              } else if (!text && Array.isArray(msg.content)) {
-                text = (msg.content as Array<{ text?: string }>)
-                  .map((p) => p.text ?? '')
-                  .join(' ')
-                  .trim()
-              }
-              if (text) {
-                const title = generateTitleFromMessage(text)
-                const threads = loadThreads()
-                const thread = threads.find((t) => t.remoteId === remoteId)
-                if (thread) {
-                  thread.title = title
-                  saveThreads(threads)
-                }
-              }
+          // no title yet (or still has the default placeholder). Route through
+          // the runtime's `rename()` so the thread-list UI updates immediately
+          // (optimistic in-memory state) and the title is persisted via the
+          // adapter's `rename()` below — no page reload required.
+          if (isUntitledThread(aui.threadListItem().getState().title)) {
+            const title = deriveTitleFromUserMessage(
+              item.message as TitleSourceMessage
+            )
+            if (title) {
+              await aui.threadListItem().rename(title)
             }
           }
         },
@@ -255,19 +224,22 @@ export function createLocalThreadListAdapter(): RemoteThreadListAdapter {
 
     async generateTitle(remoteId) {
       // Derive a title from the first user message in the stored conversation.
-      type Msg = { role: string; content?: string | Array<{ text?: string }> }
-      const repo = readJson<{ messages: Msg[] }>(messagesKey(remoteId), {
+      // Stored entries may be either bare messages or `{ message }` wrappers
+      // (the format-adapter repository shape), so normalize before reading.
+      const repo = readJson<{ messages: unknown[] }>(messagesKey(remoteId), {
         messages: [],
       })
-      const firstUserMsg = repo.messages.find((m) => m.role === 'user')
-      const text =
-        typeof firstUserMsg?.content === 'string'
-          ? firstUserMsg.content
-          : Array.isArray(firstUserMsg?.content)
-            ? firstUserMsg.content.map((p) => p.text ?? '').join(' ')
-            : ''
-
-      const title = text ? generateTitleFromMessage(text) : 'New Chat'
+      const messages = repo.messages.map((entry) => {
+        const candidate =
+          entry &&
+          typeof entry === 'object' &&
+          'message' in (entry as Record<string, unknown>)
+            ? (entry as { message: unknown }).message
+            : entry
+        return candidate as TitleSourceMessage
+      })
+      const firstUserMsg = messages.find((m) => m?.role === 'user')
+      const title = deriveTitleFromUserMessage(firstUserMsg) ?? 'New Chat'
 
       // Persist the generated title
       const threads = loadThreads()


### PR DESCRIPTION
## What

Make first-user-message conversation auto-titling reliable and **immediately reflected in the thread-list UI** on `/agents?host=0`, instead of conversations staying "New Chat"/"New Conversation" until a page reload.

## Why

Both the localStorage (`local-thread-list-adapter.tsx`) and D1/server (`d1-thread-list-adapter.tsx`) backends already derived a title from the first user message inside their `append()` handler, but they wrote the title **straight to storage** (localStorage `saveThreads` / a `title` field on the messages PUT). That persists the title but never updates assistant-ui's in-memory thread-list state, so `ThreadListItemPrimitive.Title` kept showing the `New Chat` fallback until the next `list()`/reload.

## Fix

- In both adapters' `append()`, when the thread is still untitled, route the derived title through `aui.threadListItem().rename(title)`. The runtime applies an optimistic in-memory update (UI refreshes instantly) **and** calls the adapter's own `rename()` to persist (localStorage `saveThreads` / server `apiPut({ title })`). No extra LLM call — pure client derivation via `generateTitleFromMessage`.
- Extract shared pure helpers into `conversation-utils.ts` (`extractMessageText`, `deriveTitleFromUserMessage`, `isUntitledThread`) so both stores derive identical titles, removing the duplicated/inline extraction logic (local adapter inline block + D1 adapter's private `deriveTitle`).
- `generateTitle()` fallbacks in both adapters now reuse the shared helper and normalize `{ message }`-wrapped repository entries.
- Add unit tests for the new helpers.

## Verification

- New unit tests pass (`bun test lib/ai/agent/__tests__/conversation-title.test.ts`: 10 pass).
- `tsc --noEmit` clean, Biome clean on changed files.