### PR TITLE
feat(slow-queries): redesigned responsive table with expand, filters, highlight

### DIFF
--- a/apps/web/app/(dashboard)/slow-queries/page.tsx
+++ b/apps/web/app/(dashboard)/slow-queries/page.tsx
@@ -1,9 +1,7 @@
 'use client'
 
-import { createPage } from '@/lib/create-page'
-import { slowQueriesConfig } from '@/lib/query-config/queries/slow-queries'
+import { SlowQueriesView } from '@/components/slow-queries'
 
-export default createPage({
-  queryConfig: slowQueriesConfig,
-  title: 'Slow Queries',
-})
+export default function SlowQueriesPage() {
+  return <SlowQueriesView />
+}

--- a/apps/web/components/slow-queries/index.ts
+++ b/apps/web/components/slow-queries/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Slow Queries components
+ *
+ * Purpose-built, dense table for the Slow Queries page — a sortable,
+ * responsive view of the slowest `system.query_log` rows with per-row
+ * expand, preset filters, rank badges, and a syntax-highlighted query dialog.
+ */
+
+export {
+  SlowQueriesTable,
+  type SlowQueryRow,
+} from '@/components/slow-queries/slow-queries-table'
+export { SlowQueriesView } from '@/components/slow-queries/slow-queries-view'

--- a/apps/web/components/slow-queries/slow-queries-table.tsx
+++ b/apps/web/components/slow-queries/slow-queries-table.tsx
@@ -1,0 +1,668 @@
+'use client'
+
+import {
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  Clock,
+  Database,
+  ExternalLink,
+  MemoryStick,
+  Rows3,
+  ScanSearch,
+  User as UserIcon,
+} from 'lucide-react'
+
+import { memo, useMemo, useState } from 'react'
+import { CodeDialogFormat } from '@/components/data-table/cells/code-dialog-format'
+import { AppLink as Link } from '@/components/ui/app-link'
+import { Button } from '@/components/ui/button'
+import { buildExplorerQueryUrl } from '@/lib/explorer-url'
+import { formatCompactNumber, formatReadableSize } from '@/lib/format-readable'
+import { useHostId } from '@/lib/swr/use-host'
+import { cn } from '@/lib/utils'
+
+/**
+ * Shape of a single `system.query_log` row as returned by the `slow-queries`
+ * table API. Only the fields the view reads are typed; the index signature
+ * keeps it tolerant of the extra `pct_*` / `readable_*` columns the query
+ * also selects.
+ */
+export interface SlowQueryRow {
+  query_id: string
+  query: string
+  query_start_time?: string
+  query_duration?: number
+  query_duration_ms?: number
+  user?: string
+  query_cache_usage?: string
+  read_rows?: number
+  readable_read_rows?: string
+  read_bytes?: number
+  readable_read_bytes?: string
+  memory_usage?: number
+  readable_memory_usage?: string
+  pct_read_rows?: number
+  pct_read_bytes?: number
+  pct_memory_usage?: number
+  [key: string]: unknown
+}
+
+// ───────────────────────── helpers ─────────────────────────
+
+type Severity = 'critical' | 'warning' | 'normal'
+
+/** Classify a query by how long it took (seconds). */
+function getSeverity(durationS: number): Severity {
+  if (durationS > 60) return 'critical'
+  if (durationS > 10) return 'warning'
+  return 'normal'
+}
+
+/** Compact a duration in seconds as a `{value, unit}` pair. */
+function formatDuration(seconds: number): { value: string; unit: string } {
+  if (!Number.isFinite(seconds) || seconds < 0)
+    return { value: '0.0', unit: 's' }
+  if (seconds < 60) return { value: seconds.toFixed(1), unit: 's' }
+  if (seconds < 3600) return { value: (seconds / 60).toFixed(1), unit: 'm' }
+  return { value: (seconds / 3600).toFixed(1), unit: 'h' }
+}
+
+/** Toned chip for the query-cache usage enum. */
+const CACHE_BADGE: Record<string, string> = {
+  Hit: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  Write: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  Unknown: 'bg-muted text-muted-foreground',
+  None: 'bg-muted text-muted-foreground',
+}
+
+function cacheBadgeClass(value: string): string {
+  return CACHE_BADGE[value] ?? 'bg-muted text-muted-foreground'
+}
+
+// ───────────────────────── derived row ─────────────────────────
+
+/**
+ * A `SlowQueryRow` with every metric the view sorts or renders pre-computed
+ * once, plus the rank assigned by the active sort (1 = worst).
+ */
+interface DerivedQuery {
+  row: SlowQueryRow
+  id: string
+  query: string
+  user: string
+  cacheUsage: string
+  startTime: string
+  duration: number
+  readableDuration: { value: string; unit: string }
+  readRows: number
+  readableReadRows: string
+  pctReadRows: number
+  readBytes: number
+  readableReadBytes: string
+  pctReadBytes: number
+  memory: number
+  readableMemory: string
+  pctMemory: number
+  severity: Severity
+}
+
+function derive(row: SlowQueryRow): DerivedQuery {
+  const duration = Number(
+    row.query_duration ??
+      (row.query_duration_ms != null ? Number(row.query_duration_ms) / 1000 : 0)
+  )
+  const readRows = Number(row.read_rows ?? 0)
+  const readBytes = Number(row.read_bytes ?? 0)
+  const memory = Number(row.memory_usage ?? 0)
+
+  return {
+    row,
+    id: String(row.query_id ?? ''),
+    query: String(row.query ?? ''),
+    user: String(row.user ?? ''),
+    cacheUsage: String(row.query_cache_usage ?? '').trim(),
+    startTime: String(row.query_start_time ?? ''),
+    duration,
+    readableDuration: formatDuration(duration),
+    readRows,
+    readableReadRows: row.readable_read_rows || formatCompactNumber(readRows),
+    pctReadRows: Number(row.pct_read_rows ?? 0),
+    readBytes,
+    readableReadBytes: row.readable_read_bytes || formatReadableSize(readBytes),
+    pctReadBytes: Number(row.pct_read_bytes ?? 0),
+    memory,
+    readableMemory: row.readable_memory_usage || formatReadableSize(memory),
+    pctMemory: Number(row.pct_memory_usage ?? 0),
+    severity: getSeverity(duration),
+  }
+}
+
+// ───────────────────────── sorting ─────────────────────────
+
+type SortKey = 'duration' | 'readRows' | 'readBytes' | 'memory'
+type SortDir = 'asc' | 'desc'
+
+const SORT_ACCESSOR: Record<SortKey, (d: DerivedQuery) => number> = {
+  duration: (d) => d.duration,
+  readRows: (d) => d.readRows,
+  readBytes: (d) => d.readBytes,
+  memory: (d) => d.memory,
+}
+
+// ───────────────────────── cells ─────────────────────────
+
+const SEVERITY_ACCENT: Record<Severity, string> = {
+  critical: 'bg-rose-500',
+  warning: 'bg-amber-500',
+  normal: 'bg-blue-500',
+}
+
+const SEVERITY_DURATION: Record<Severity, string> = {
+  critical: 'text-rose-600 dark:text-rose-400',
+  warning: 'text-amber-600 dark:text-amber-400',
+  normal: 'text-foreground',
+}
+
+const SEVERITY_RANK: Record<Severity, string> = {
+  critical: 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300',
+  warning:
+    'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  normal: 'bg-muted text-muted-foreground',
+}
+
+/** Rank badge — emphasises the slowest queries (1 = worst). */
+function RankBadge({ rank, severity }: { rank: number; severity: Severity }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex size-6 shrink-0 items-center justify-center rounded-full text-[11px] font-bold tabular-nums',
+        SEVERITY_RANK[severity]
+      )}
+      title={`Rank #${rank} by duration`}
+    >
+      {rank}
+    </span>
+  )
+}
+
+/** A toned cache-usage chip. */
+function CacheBadge({ value }: { value: string }) {
+  if (!value) return <span className="text-muted-foreground">—</span>
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded px-1.5 py-0.5 font-mono text-[10.5px] font-semibold uppercase tracking-wide',
+        cacheBadgeClass(value)
+      )}
+    >
+      {value}
+    </span>
+  )
+}
+
+/** A compact metric bar (value + share of the slowest run). */
+function MetricBar({ label, pct }: { label: string; pct: number }) {
+  const width = Math.max(Math.min(pct, 100), 2)
+  return (
+    <div className="flex min-w-[72px] flex-col gap-1">
+      <span className="truncate text-right text-[11.5px] font-medium tabular-nums">
+        {label}
+      </span>
+      <div className="relative h-1.5 overflow-hidden rounded-full bg-muted">
+        <div
+          className="absolute inset-y-0 left-0 rounded-full bg-blue-500/70 transition-all"
+          style={{ width: `${width}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+interface SortableHeaderProps {
+  children: React.ReactNode
+  align?: 'left' | 'right'
+  width?: string
+  className?: string
+  sortKey?: SortKey
+  activeKey?: SortKey
+  dir?: SortDir
+  onSort?: (key: SortKey) => void
+}
+
+/** Table header cell with an optional click-to-sort affordance. */
+function SortableHeader({
+  children,
+  align = 'left',
+  width,
+  className,
+  sortKey,
+  activeKey,
+  dir,
+  onSort,
+}: SortableHeaderProps) {
+  const active = sortKey != null && sortKey === activeKey
+  return (
+    <th
+      className={cn(
+        'select-none whitespace-nowrap px-2 py-2 text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground sm:px-3',
+        align === 'right' ? 'text-right' : 'text-left',
+        className
+      )}
+      style={width ? { width } : undefined}
+    >
+      {sortKey && onSort ? (
+        <button
+          type="button"
+          onClick={() => onSort(sortKey)}
+          className={cn(
+            'inline-flex items-center gap-1 transition-colors hover:text-foreground',
+            align === 'right' && 'flex-row-reverse'
+          )}
+        >
+          {children}
+          {active ? (
+            dir === 'desc' ? (
+              <ChevronDown className="size-3 text-foreground" />
+            ) : (
+              <ChevronUp className="size-3 text-foreground" />
+            )
+          ) : (
+            <ChevronDown className="size-3 opacity-30" />
+          )}
+        </button>
+      ) : (
+        children
+      )}
+    </th>
+  )
+}
+
+// ───────────────────────── expanded row ─────────────────────────
+
+/** A labelled value in the expandable detail grid. */
+function DetailField({
+  label,
+  value,
+  mono = true,
+}: {
+  label: string
+  value: React.ReactNode
+  mono?: boolean
+}) {
+  return (
+    <div className="min-w-0 border-l border-t border-border px-3 py-2">
+      <dt className="text-[10px] font-semibold uppercase leading-tight tracking-wider text-muted-foreground">
+        {label}
+      </dt>
+      <dd
+        className={cn(
+          'mt-0.5 truncate text-[12.5px] font-medium tabular-nums',
+          mono && 'font-mono'
+        )}
+        title={typeof value === 'string' ? value : undefined}
+      >
+        {value || '—'}
+      </dd>
+    </div>
+  )
+}
+
+/**
+ * Expanded row — secondary-metric grid, the full query with syntax
+ * highlighting (via {@link CodeDialogFormat}), then row actions.
+ */
+function ExpandedDetail({ d }: { d: DerivedQuery }) {
+  const hostId = useHostId()
+  const explorerUrl = buildExplorerQueryUrl(d.query, hostId)
+  const detailUrl = d.id
+    ? `/query?query_id=${encodeURIComponent(d.id)}&host=${hostId}`
+    : ''
+
+  const fields: { label: string; value: React.ReactNode; mono?: boolean }[] = [
+    { label: 'Query ID', value: d.id },
+    { label: 'User', value: d.user, mono: false },
+    { label: 'Started', value: d.startTime, mono: false },
+    { label: 'Cache', value: d.cacheUsage || '—', mono: false },
+    {
+      label: 'Duration',
+      value: `${d.readableDuration.value} ${d.readableDuration.unit}`,
+    },
+    { label: 'Rows read', value: d.readableReadRows },
+    { label: 'Data read', value: d.readableReadBytes },
+    { label: 'Memory', value: d.readableMemory },
+  ]
+
+  return (
+    <div className="space-y-3 border-t border-border bg-muted/40 px-3 py-3.5 sm:px-5">
+      {/* Secondary metrics — a compact key/value grid */}
+      <div className="overflow-hidden rounded-md border border-border bg-card">
+        <div className="border-b border-border bg-muted/40 px-3 pb-1.5 pt-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Query metrics
+        </div>
+        <dl className="-ml-px -mt-px grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
+          {fields.map((f) => (
+            <DetailField
+              key={f.label}
+              label={f.label}
+              value={f.value}
+              mono={f.mono}
+            />
+          ))}
+        </dl>
+      </div>
+
+      {/* Full query — syntax-highlighted dialog with EXPLAIN plan tab. */}
+      <div>
+        <div className="mb-1.5 text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Full query
+        </div>
+        <CodeDialogFormat
+          value={d.query}
+          options={{
+            max_truncate: 280,
+            hide_query_comment: true,
+            force_dialog: true,
+            show_query_plan: true,
+            dialog_title: 'Slow Query',
+            trigger_classname: 'w-full',
+          }}
+        />
+      </div>
+
+      {/* Actions */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Button variant="outline" size="sm" className="h-7 gap-1.5" asChild>
+          <Link href={explorerUrl}>
+            <ExternalLink className="size-3.5" />
+            Open in Explorer
+          </Link>
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 gap-1.5"
+          asChild={Boolean(detailUrl)}
+          disabled={!detailUrl}
+        >
+          {detailUrl ? (
+            <Link href={detailUrl}>
+              <ScanSearch className="size-3.5" />
+              Query detail
+            </Link>
+          ) : (
+            <span className="inline-flex h-7 items-center gap-1.5">
+              <ScanSearch className="size-3.5" />
+              Query detail
+            </span>
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ───────────────────────── row ─────────────────────────
+
+interface QueryRowProps {
+  d: DerivedQuery
+  rank: number
+  expanded: boolean
+  onToggle: () => void
+}
+
+/** One slow query rendered as a table row (collapsed) + detail row. */
+const QueryRow = memo(function QueryRow({
+  d,
+  rank,
+  expanded,
+  onToggle,
+}: QueryRowProps) {
+  const dur = d.readableDuration
+
+  return (
+    <>
+      <tr
+        className="group relative cursor-pointer border-b border-border align-middle hover:bg-muted/60"
+        onClick={onToggle}
+      >
+        {/* Severity accent stripe */}
+        <td className="relative w-0 p-0">
+          <span
+            className={cn(
+              'absolute inset-y-0 left-0 w-0.5',
+              SEVERITY_ACCENT[d.severity]
+            )}
+            aria-hidden
+          />
+        </td>
+
+        {/* Rank + expand chevron */}
+        <td className="px-2 py-2.5 sm:px-3">
+          <div className="flex items-center gap-1.5 sm:gap-2">
+            <ChevronRight
+              className={cn(
+                'size-3 shrink-0 text-muted-foreground transition-transform',
+                expanded && 'rotate-90'
+              )}
+            />
+            <RankBadge rank={rank} severity={d.severity} />
+          </div>
+        </td>
+
+        {/* Query text */}
+        <td className="max-w-0 px-2 py-2.5 sm:px-3">
+          <div className="truncate font-mono text-[12px] text-muted-foreground group-hover:text-foreground">
+            {d.query}
+          </div>
+          {/* Compact metric row on small viewports where columns collapse. */}
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[10.5px] text-muted-foreground md:hidden">
+            <span className="inline-flex items-center gap-1">
+              <UserIcon className="size-3" />
+              {d.user || 'anon'}
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <Rows3 className="size-3" />
+              {d.readableReadRows}
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <Database className="size-3" />
+              {d.readableReadBytes}
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <MemoryStick className="size-3" />
+              {d.readableMemory}
+            </span>
+          </div>
+        </td>
+
+        {/* Duration — the headline metric */}
+        <td className="px-2 py-2.5 text-right sm:px-3">
+          <span
+            className={cn(
+              'whitespace-nowrap font-semibold tabular-nums',
+              SEVERITY_DURATION[d.severity]
+            )}
+          >
+            {dur.value}
+            <span className="ml-0.5 text-[11px] font-normal text-muted-foreground">
+              {dur.unit}
+            </span>
+          </span>
+        </td>
+
+        {/* User — hidden on small screens (shown inline under query) */}
+        <td className="hidden px-2 py-2.5 sm:px-3 lg:table-cell">
+          <span className="truncate text-[12px]">{d.user || 'anon'}</span>
+        </td>
+
+        {/* Cache usage */}
+        <td className="hidden px-2 py-2.5 sm:px-3 xl:table-cell">
+          <CacheBadge value={d.cacheUsage} />
+        </td>
+
+        {/* Rows read */}
+        <td className="hidden px-2 py-2.5 sm:px-3 md:table-cell">
+          <div className="flex justify-end">
+            <MetricBar label={d.readableReadRows} pct={d.pctReadRows} />
+          </div>
+        </td>
+
+        {/* Data read */}
+        <td className="hidden px-2 py-2.5 sm:px-3 md:table-cell">
+          <div className="flex justify-end">
+            <MetricBar label={d.readableReadBytes} pct={d.pctReadBytes} />
+          </div>
+        </td>
+
+        {/* Memory */}
+        <td className="hidden px-2 py-2.5 sm:px-3 md:table-cell">
+          <div className="flex justify-end">
+            <MetricBar label={d.readableMemory} pct={d.pctMemory} />
+          </div>
+        </td>
+      </tr>
+      {expanded && (
+        <tr className="border-b border-border">
+          <td colSpan={9} className="p-0">
+            <ExpandedDetail d={d} />
+          </td>
+        </tr>
+      )}
+    </>
+  )
+})
+
+// ───────────────────────── table ─────────────────────────
+
+export interface SlowQueriesTableProps {
+  rows: SlowQueryRow[]
+}
+
+/**
+ * SlowQueriesTable — a dense, sortable, responsive view of the slowest
+ * `system.query_log` rows. Each row expands to reveal secondary metrics, the
+ * full syntax-highlighted query, and per-row actions. The slowest queries are
+ * highlighted via a rank badge + duration-severity heat accent.
+ *
+ * Columns progressively collapse on narrow viewports (the metric bars hide and
+ * fold into a compact inline row under the query text), keeping the table
+ * readable without heavy horizontal scrolling.
+ */
+export function SlowQueriesTable({ rows }: SlowQueriesTableProps) {
+  const [sortKey, setSortKey] = useState<SortKey>('duration')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+
+  const derived = useMemo(() => rows.map(derive), [rows])
+
+  // Rank is always assigned by duration (slowest = 1), independent of the
+  // active sort, so the badge keeps emphasising the slowest queries.
+  const rankById = useMemo(() => {
+    const byDuration = [...derived].sort((a, b) => b.duration - a.duration)
+    const map = new Map<DerivedQuery, number>()
+    byDuration.forEach((d, i) => map.set(d, i + 1))
+    return map
+  }, [derived])
+
+  const sorted = useMemo(() => {
+    const accessor = SORT_ACCESSOR[sortKey]
+    const factor = sortDir === 'desc' ? -1 : 1
+    return [...derived].sort((a, b) => factor * (accessor(a) - accessor(b)))
+  }, [derived, sortKey, sortDir])
+
+  const handleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === 'desc' ? 'asc' : 'desc'))
+    } else {
+      setSortKey(key)
+      setSortDir('desc')
+    }
+  }
+
+  const toggle = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-card">
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-sm">
+          <thead className="border-b border-border bg-muted/40">
+            <tr>
+              <th className="w-0 p-0" aria-hidden />
+              <SortableHeader width="64px">#</SortableHeader>
+              <SortableHeader>Query</SortableHeader>
+              <SortableHeader
+                align="right"
+                width="96px"
+                sortKey="duration"
+                activeKey={sortKey}
+                dir={sortDir}
+                onSort={handleSort}
+              >
+                <Clock className="size-3" />
+                Duration
+              </SortableHeader>
+              <SortableHeader className="hidden lg:table-cell" width="120px">
+                User
+              </SortableHeader>
+              <SortableHeader className="hidden xl:table-cell" width="80px">
+                Cache
+              </SortableHeader>
+              <SortableHeader
+                align="right"
+                width="120px"
+                className="hidden md:table-cell"
+                sortKey="readRows"
+                activeKey={sortKey}
+                dir={sortDir}
+                onSort={handleSort}
+              >
+                Rows read
+              </SortableHeader>
+              <SortableHeader
+                align="right"
+                width="120px"
+                className="hidden md:table-cell"
+                sortKey="readBytes"
+                activeKey={sortKey}
+                dir={sortDir}
+                onSort={handleSort}
+              >
+                Data read
+              </SortableHeader>
+              <SortableHeader
+                align="right"
+                width="120px"
+                className="hidden md:table-cell"
+                sortKey="memory"
+                activeKey={sortKey}
+                dir={sortDir}
+                onSort={handleSort}
+              >
+                Memory
+              </SortableHeader>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((d, index) => (
+              <QueryRow
+                key={d.id || `${index}-${d.query.slice(0, 32)}`}
+                d={d}
+                rank={rankById.get(d) ?? index + 1}
+                expanded={expanded.has(d.id)}
+                onToggle={() => toggle(d.id)}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/slow-queries/slow-queries-view.tsx
+++ b/apps/web/components/slow-queries/slow-queries-view.tsx
@@ -1,0 +1,275 @@
+'use client'
+
+import { ChevronDown, Gauge, RefreshCw, Timer } from 'lucide-react'
+
+import type { SlowQueryRow } from '@/components/slow-queries/slow-queries-table'
+import type { CardError } from '@/lib/card-error-utils'
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useMemo, useState } from 'react'
+import { PageHeader } from '@/components/layout'
+import { RelatedCharts } from '@/components/layout/query-page/related-charts'
+import { Skeleton } from '@/components/skeletons'
+import { SlowQueriesTable } from '@/components/slow-queries/slow-queries-table'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { EmptyState } from '@/components/ui/empty-state'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import {
+  detectCardErrorVariant,
+  getCardErrorDescription,
+  getCardErrorTitle,
+} from '@/lib/card-error-utils'
+import { slowQueriesConfig } from '@/lib/query-config/queries/slow-queries'
+import { useHostId } from '@/lib/swr/use-host'
+import { useTableData } from '@/lib/swr/use-table-data'
+import { cn } from '@/lib/utils'
+
+/** Refresh the slow-queries list every 60s — `query_log` is append-only. */
+const REFRESH_INTERVAL = 60_000
+
+const PRESETS = slowQueriesConfig.filterParamPresets ?? []
+const DEFAULTS = slowQueriesConfig.defaultParams ?? {}
+
+/** Group presets by the param key they drive (time window, min duration). */
+const PRESET_GROUPS: { key: string; icon: typeof Timer; label: string }[] = [
+  { key: 'last_hours', icon: Timer, label: 'Time window' },
+  { key: 'min_duration_s', icon: Gauge, label: 'Min duration' },
+]
+
+/** Skeleton placeholder shown during the initial load. */
+function LoadingState() {
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-card">
+      <div className="flex items-center gap-2 border-b border-border px-3 py-2.5">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="ml-auto h-4 w-16" />
+      </div>
+      {[0, 1, 2, 3, 4].map((i) => (
+        <div
+          key={i}
+          className="flex items-center gap-3 border-b border-border p-3"
+        >
+          <Skeleton className="h-6 w-6 rounded-full" />
+          <Skeleton className="h-4 flex-1" />
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/** A single-select chip group bound to one filter param key. */
+function FilterGroup({
+  groupKey,
+  icon: Icon,
+  label,
+  active,
+  onSelect,
+}: {
+  groupKey: string
+  icon: typeof Timer
+  label: string
+  active: string
+  onSelect: (key: string, value: string) => void
+}) {
+  const options = PRESETS.filter((p) => p.key === groupKey)
+  if (options.length === 0) return null
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="inline-flex items-center gap-1 text-[11px] font-medium text-muted-foreground">
+        <Icon className="size-3.5" />
+        {label}
+      </span>
+      <div className="flex flex-wrap items-center gap-1">
+        {options.map((opt) => {
+          const selected = active === String(opt.value)
+          return (
+            <button
+              key={`${opt.key}-${opt.value}`}
+              type="button"
+              onClick={() => onSelect(opt.key, String(opt.value))}
+              className={cn(
+                'rounded-md border px-2 py-1 text-[11px] font-medium tabular-nums transition-colors',
+                selected
+                  ? 'border-primary bg-primary/10 text-primary'
+                  : 'border-border bg-card text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+              )}
+            >
+              {opt.name}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * SlowQueriesView — the Slow Queries page.
+ *
+ * Header (title, slowest-query badge, refresh) → preset filter bar (time
+ * window + min duration) → the related occurrences chart → the bespoke
+ * {@link SlowQueriesTable}. Filters are stored in the URL so they survive
+ * reloads and shape the data fetched from `/api/v1/tables/slow-queries`.
+ */
+export function SlowQueriesView() {
+  const hostId = useHostId()
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const [chartsOpen, setChartsOpen] = useState(true)
+
+  // Resolve the active value of each filter key: URL param → default.
+  const filterParams = useMemo(() => {
+    const params: Record<string, string> = {}
+    for (const [key, value] of Object.entries(DEFAULTS)) {
+      const fromUrl = searchParams.get(key)
+      const resolved = fromUrl ?? (value as string)
+      if (resolved !== '') params[key] = resolved
+    }
+    return params
+  }, [searchParams])
+
+  const { data, error, isLoading, isValidating, refresh } =
+    useTableData<SlowQueryRow>(
+      'slow-queries',
+      hostId,
+      filterParams,
+      REFRESH_INTERVAL
+    )
+
+  const rows = data ?? []
+
+  // Slowest duration drives the header highlight.
+  const slowest = useMemo(() => {
+    let max = 0
+    for (const row of rows) {
+      const d = Number(
+        row.query_duration ??
+          (row.query_duration_ms != null
+            ? Number(row.query_duration_ms) / 1000
+            : 0)
+      )
+      if (d > max) max = d
+    }
+    return max
+  }, [rows])
+
+  const setFilter = (key: string, value: string) => {
+    const next = new URLSearchParams(searchParams)
+    next.set(key, value)
+    router.replace(`${pathname}?${next.toString()}`, { scroll: false })
+  }
+
+  return (
+    <TooltipProvider>
+      <div className="flex flex-col gap-4">
+        <PageHeader
+          title={
+            <div className="flex items-center gap-2">
+              Slow Queries
+              {rows.length > 0 && (
+                <span className="rounded-md bg-rose-100 px-2 py-0.5 text-xs font-medium tabular-nums text-rose-700 dark:bg-rose-900/40 dark:text-rose-300">
+                  slowest {slowest.toFixed(1)}s
+                </span>
+              )}
+            </div>
+          }
+          description="The slowest finished queries from the query log, worst first"
+          actions={
+            <div className="flex flex-wrap items-center gap-1.5">
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-8 gap-1.5 text-[12px]"
+                onClick={() => setChartsOpen((v) => !v)}
+              >
+                <ChevronDown
+                  className={cn(
+                    'size-3.5 transition-transform',
+                    !chartsOpen && '-rotate-90'
+                  )}
+                />
+                {chartsOpen ? 'Hide chart' : 'Show chart'}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-8 gap-1.5 text-[12px]"
+                onClick={() => refresh()}
+                disabled={isValidating}
+              >
+                <RefreshCw
+                  className={cn('size-3.5', isValidating && 'animate-spin')}
+                />
+                Refresh
+              </Button>
+            </div>
+          }
+        />
+
+        {/* Filter bar */}
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-2 rounded-xl border border-border bg-card px-3 py-2.5">
+          {PRESET_GROUPS.map((group) => (
+            <FilterGroup
+              key={group.key}
+              groupKey={group.key}
+              icon={group.icon}
+              label={group.label}
+              active={filterParams[group.key] ?? ''}
+              onSelect={setFilter}
+            />
+          ))}
+        </div>
+
+        {/* Body */}
+        {isLoading && !data ? (
+          <LoadingState />
+        ) : error && !data ? (
+          <Card className="rounded-xl">
+            <CardContent className="p-4">
+              <EmptyState
+                variant={detectCardErrorVariant(error as CardError)}
+                title={getCardErrorTitle(
+                  detectCardErrorVariant(error as CardError),
+                  'Slow Queries'
+                )}
+                description={getCardErrorDescription(
+                  error as CardError,
+                  detectCardErrorVariant(error as CardError)
+                )}
+                compact
+                action={{
+                  label: 'Retry',
+                  onClick: refresh,
+                  icon: <RefreshCw className="mr-1.5 size-3.5" />,
+                }}
+              />
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            {chartsOpen && slowQueriesConfig.relatedCharts && (
+              <RelatedCharts relatedCharts={slowQueriesConfig.relatedCharts} />
+            )}
+            {rows.length === 0 ? (
+              <Card className="rounded-xl border-dashed">
+                <CardContent className="p-6">
+                  <EmptyState
+                    variant="no-data"
+                    title="No slow queries"
+                    description="No queries crossed the duration threshold in this window. Try widening the time range or lowering the minimum duration."
+                  />
+                </CardContent>
+              </Card>
+            ) : (
+              <SlowQueriesTable rows={rows} />
+            )}
+          </>
+        )}
+      </div>
+    </TooltipProvider>
+  )
+}


### PR DESCRIPTION
## What

Redesigns `/slow-queries?host=0` with the same bespoke treatment as the running-queries / expensive-queries views. Replaces the generic `createPage` data-table with a purpose-built per-page view in a new `apps/web/components/slow-queries/` directory.

### Features
- **Per-row expand/collapse** revealing secondary metrics (query id, user, start time, cache, rows/data/memory) and the full query in a syntax-highlighted dialog (reuses `CodeDialogFormat` with the EXPLAIN plan tab + copy/beautify).
- **Preset filters** — a single-select chip bar for *time window* and *min duration*, driven from the existing `slowQueriesConfig.filterParamPresets`. Selections persist in the URL (`?last_hours=...&min_duration_s=...`) and shape the SWR fetch.
- **Responsive layout** — the Rows / Data / Memory metric-bar columns progressively collapse on narrow viewports and fold into a compact inline metric row under the query text, avoiding heavy horizontal scrolling. Sortable headers for duration / rows / data / memory.
- **Slowest-query emphasis** — a rank badge (1 = slowest, always by duration regardless of active sort), a duration-severity heat accent stripe + colored duration, and a header "slowest Ns" highlight.

## Why
Brings slow-queries to parity with the redesigned query-monitoring pages: clearer at-a-glance triage of the worst queries, better full-query readability, and a responsive layout that works on small screens.

## Scope
All new code lives in `apps/web/components/slow-queries/`; only `app/(dashboard)/slow-queries/page.tsx` is rewired to render the new view. No shared `components/data-table` internals, no other pages, and `lib/query-config/index.ts` untouched. The existing `slow-queries` query config already exposes the `readable_*` / `pct_*` columns the view needs, so it required no changes.

Fixes the `/slow-queries?host=0` page UX.