### PR TITLE
feat(explain): render query plan as a tree visualization

### DIFF
--- a/apps/web/app/(dashboard)/explain/page.tsx
+++ b/apps/web/app/(dashboard)/explain/page.tsx
@@ -10,6 +10,7 @@ import useSWR from 'swr'
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { Suspense, useState } from 'react'
+import { ExplainResult } from '@/components/explain/explain-result'
 import { ErrorAlert } from '@/components/feedback'
 import { ChartSkeleton } from '@/components/skeletons'
 import { Button } from '@/components/ui/button'
@@ -21,7 +22,6 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
 import { useHostId } from '@/lib/swr'
 import { apiFetch } from '@/lib/swr/api-fetch'
-import { cn } from '@/lib/utils'
 
 const EXPLAIN_MODES = [
   { value: '', label: 'Plan' },
@@ -280,6 +280,12 @@ function ExplainContent() {
 
   const { data, error, isLoading } = useSWR<ApiResponse>(apiUrl, fetcher)
 
+  // EXPLAIN PLAN (mode '') and PIPELINE return indent-nested text that renders
+  // as a tree. AST/SYNTAX/ESTIMATE are flat or non-hierarchical, and the JSON
+  // plan setting emits JSON rather than indented text — show text only there.
+  const treeRenderable =
+    (mode === '' || mode === 'PIPELINE') && planSettings.json !== 1
+
   const handleExplain = () => {
     setQueryToExplain(queryInput)
   }
@@ -356,23 +362,11 @@ function ExplainContent() {
       )}
 
       {data?.data && data.data.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">
-              {mode ? `EXPLAIN ${mode}` : 'Execution Plan'}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <pre
-              className={cn(
-                'bg-muted overflow-x-auto rounded-md p-4',
-                'font-mono text-sm whitespace-pre-wrap'
-              )}
-            >
-              {data.data.map((row) => row.explain).join('\n')}
-            </pre>
-          </CardContent>
-        </Card>
+        <ExplainResult
+          title={mode ? `EXPLAIN ${mode}` : 'Execution Plan'}
+          lines={data.data.map((row) => row.explain)}
+          treeRenderable={treeRenderable}
+        />
       )}
 
       {queryToExplain && !isLoading && !error && data?.data?.length === 0 && (

--- a/apps/web/components/explain/explain-result.tsx
+++ b/apps/web/components/explain/explain-result.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { ExplainTree } from './explain-tree'
+import { countNodes, parseExplainTree } from './parse-explain-tree'
+import { useMemo, useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { cn } from '@/lib/utils'
+
+type ViewMode = 'tree' | 'text'
+
+/**
+ * Render an EXPLAIN result. The API returns one row per output line; the raw
+ * text is reconstructed by joining them. PLAN and PIPELINE output is indented
+ * and renders as a collapsible tree; a Tree | Text toggle keeps the raw text
+ * available. AST / SYNTAX / JSON output is flat or non-hierarchical, so the
+ * tree toggle is hidden and only text is shown.
+ */
+export function ExplainResult({
+  lines,
+  title,
+  treeRenderable,
+}: {
+  lines: string[]
+  title: string
+  /** Whether a tree view makes sense for this EXPLAIN mode. */
+  treeRenderable: boolean
+}) {
+  const text = useMemo(() => lines.join('\n'), [lines])
+
+  const tree = useMemo(
+    () => (treeRenderable ? parseExplainTree(lines) : []),
+    [lines, treeRenderable]
+  )
+
+  // A tree only adds value when it actually nests (more than just flat roots).
+  const hasNesting = useMemo(
+    () => tree.some((n) => n.children.length > 0),
+    [tree]
+  )
+  const showTreeToggle = treeRenderable && hasNesting && countNodes(tree) > 0
+
+  const [view, setView] = useState<ViewMode>('tree')
+  const effectiveView: ViewMode = showTreeToggle ? view : 'text'
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between gap-2 space-y-0">
+        <CardTitle className="text-lg">{title}</CardTitle>
+        {showTreeToggle && (
+          <Tabs value={view} onValueChange={(v) => setView(v as ViewMode)}>
+            <TabsList>
+              <TabsTrigger value="tree">Tree</TabsTrigger>
+              <TabsTrigger value="text">Text</TabsTrigger>
+            </TabsList>
+          </Tabs>
+        )}
+      </CardHeader>
+      <CardContent>
+        {effectiveView === 'tree' ? (
+          <div className="bg-muted rounded-md p-4">
+            <ExplainTree nodes={tree} />
+          </div>
+        ) : (
+          <pre
+            className={cn(
+              'bg-muted overflow-x-auto rounded-md p-4',
+              'font-mono text-sm whitespace-pre-wrap'
+            )}
+          >
+            {text}
+          </pre>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/components/explain/explain-tree.tsx
+++ b/apps/web/components/explain/explain-tree.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { ChevronDownIcon, ChevronRightIcon } from '@radix-ui/react-icons'
+
+import type { ExplainTreeNode } from './parse-explain-tree'
+
+import { useState } from 'react'
+import { cn } from '@/lib/utils'
+
+/**
+ * Split a node label into its primary step name and the parenthetical detail
+ * ClickHouse appends, e.g. "ReadFromMergeTree (default.hits)" ->
+ * { name: "ReadFromMergeTree", detail: "default.hits" }. The detail is shown
+ * muted next to the name. Labels without a trailing "(...)" return detail=''.
+ */
+function splitLabel(label: string): { name: string; detail: string } {
+  const match = label.match(/^(.*?)\s*\((.*)\)\s*$/)
+  if (match && match[1].length > 0) {
+    return { name: match[1].trim(), detail: match[2].trim() }
+  }
+  return { name: label, detail: '' }
+}
+
+function TreeNode({
+  node,
+  collapsed,
+  onToggle,
+}: {
+  node: ExplainTreeNode
+  collapsed: Set<string>
+  onToggle: (id: string) => void
+}) {
+  const hasChildren = node.children.length > 0
+  const isCollapsed = collapsed.has(node.id)
+  const { name, detail } = splitLabel(node.label)
+
+  return (
+    <li className="relative">
+      <div
+        className={cn(
+          'group flex items-start gap-1.5 rounded-md py-1 pr-2 transition-colors',
+          'hover:bg-muted/60'
+        )}
+      >
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={() => onToggle(node.id)}
+            aria-expanded={!isCollapsed}
+            aria-label={isCollapsed ? 'Expand node' : 'Collapse node'}
+            className="text-muted-foreground hover:text-foreground mt-0.5 flex size-4 shrink-0 items-center justify-center"
+          >
+            {isCollapsed ? (
+              <ChevronRightIcon className="size-4" />
+            ) : (
+              <ChevronDownIcon className="size-4" />
+            )}
+          </button>
+        ) : (
+          <span className="mt-0.5 flex size-4 shrink-0 items-center justify-center">
+            <span className="bg-muted-foreground/40 size-1.5 rounded-full" />
+          </span>
+        )}
+
+        <span className="min-w-0 font-mono text-sm leading-relaxed">
+          <span className="text-foreground font-medium">{name}</span>
+          {detail && (
+            <span className="text-muted-foreground ml-1.5 break-all">
+              {detail}
+            </span>
+          )}
+        </span>
+      </div>
+
+      {hasChildren && !isCollapsed && (
+        <ul className="border-border/60 ml-[0.4375rem] border-l pl-3">
+          {node.children.map((child) => (
+            <TreeNode
+              key={child.id}
+              node={child}
+              collapsed={collapsed}
+              onToggle={onToggle}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  )
+}
+
+/**
+ * Collapsible CSS tree view of a parsed EXPLAIN plan. Pure CSS/flex layout —
+ * no graph dependency. Nodes with children get an expand/collapse chevron;
+ * collapsed node ids are tracked in local state.
+ */
+export function ExplainTree({ nodes }: { nodes: ExplainTreeNode[] }) {
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
+
+  const toggle = (id: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  return (
+    <ul className="overflow-x-auto">
+      {nodes.map((node) => (
+        <TreeNode
+          key={node.id}
+          node={node}
+          collapsed={collapsed}
+          onToggle={toggle}
+        />
+      ))}
+    </ul>
+  )
+}

--- a/apps/web/components/explain/parse-explain-tree.ts
+++ b/apps/web/components/explain/parse-explain-tree.ts
@@ -1,0 +1,90 @@
+/**
+ * Parse ClickHouse EXPLAIN text output into a nested tree.
+ *
+ * EXPLAIN PLAN and EXPLAIN PIPELINE return a hierarchical structure encoded as
+ * plain text with leading-space indentation, e.g.:
+ *
+ *   Expression ((Project names + Projection))
+ *     Aggregating
+ *       Expression (Before GROUP BY)
+ *         ReadFromMergeTree (default.hits)
+ *
+ * Each increase in leading-space width is a deeper level. This converts the
+ * flat list of lines into a tree of {label, children} nodes by tracking
+ * indentation depth on a stack. Lines that ClickHouse prefixes with structural
+ * characters (e.g. PIPELINE's "(NodeName)") still nest purely by indentation,
+ * so the same algorithm handles both modes.
+ */
+
+export interface ExplainTreeNode {
+  /** Stable id for React keys / expand-collapse state (path-based). */
+  id: string
+  /** Trimmed text content of the line. */
+  label: string
+  /** Original leading-space width, kept for debugging / tooltips. */
+  indent: number
+  children: ExplainTreeNode[]
+}
+
+/** Number of leading whitespace characters (treating a tab as one level). */
+function leadingIndent(line: string): number {
+  let count = 0
+  for (const ch of line) {
+    if (ch === ' ') count += 1
+    else if (ch === '\t') count += 2
+    else break
+  }
+  return count
+}
+
+/**
+ * Build a tree from EXPLAIN text lines.
+ *
+ * Returns the list of root nodes. Lines that are blank after trimming are
+ * skipped. If every line is at the same (zero) indent the result is a flat
+ * list of roots — the renderer treats that as a degenerate tree and the Text
+ * view remains the better choice, but the tree still renders correctly.
+ */
+export function parseExplainTree(lines: string[]): ExplainTreeNode[] {
+  const roots: ExplainTreeNode[] = []
+  // Stack of {node, indent} for ancestors of the current line.
+  const stack: { node: ExplainTreeNode; indent: number }[] = []
+  let counter = 0
+
+  for (const raw of lines) {
+    if (raw.trim().length === 0) continue
+
+    const indent = leadingIndent(raw)
+    const label = raw.trim()
+    const node: ExplainTreeNode = {
+      id: `n${counter++}`,
+      label,
+      indent,
+      children: [],
+    }
+
+    // Pop ancestors that are not shallower than the current line.
+    while (stack.length > 0 && stack[stack.length - 1].indent >= indent) {
+      stack.pop()
+    }
+
+    if (stack.length === 0) {
+      roots.push(node)
+    } else {
+      stack[stack.length - 1].node.children.push(node)
+    }
+
+    stack.push({ node, indent })
+  }
+
+  return roots
+}
+
+/** Total node count, useful for empty / expand-all decisions. */
+export function countNodes(nodes: ExplainTreeNode[]): number {
+  let total = 0
+  for (const n of nodes) {
+    total += 1 + countNodes(n.children)
+  }
+  return total
+}


### PR DESCRIPTION
## What

On `/explain?host=0`, render the ClickHouse EXPLAIN output as a collapsible **tree** in addition to the existing plain text.

- New `apps/web/components/explain/`:
  - `parse-explain-tree.ts` — parses indent-nested EXPLAIN text (leading-space depth → nesting) into a tree of `{label, children}` nodes via an indentation stack.
  - `explain-tree.tsx` — lightweight CSS tree renderer (no new deps) with per-node expand/collapse; splits `Step (detail)` labels for readability.
  - `explain-result.tsx` — result card with a **Tree | Text** toggle.
- `page.tsx` wires it in; tree is offered only for PLAN and PIPELINE (indented text). AST / SYNTAX / ESTIMATE and JSON-plan output fall back to text-only.

## Why

EXPLAIN PLAN/PIPELINE output is hierarchical but was shown as flat `<pre>` text. A collapsible tree makes the plan structure scannable while keeping the raw text one click away.

## Notes

- Uses only existing primitives (`Card`, `Tabs`, radix icons, Tailwind) — no graph library added.
- Toggle is hidden automatically when the output has no nesting, so text remains the view for flat results.

Co-Authored-By: duyetbot <bot@duyet.net>