### PR TITLE
feat(user-processes): format columns (user badge, memory bars, readable values)

### DIFF
--- a/apps/web/lib/query-config/tables/user-processes.ts
+++ b/apps/web/lib/query-config/tables/user-processes.ts
@@ -1,5 +1,7 @@
 import type { QueryConfig } from '@/types/query-config'
 
+import { ColumnFormat } from '@/types/column-format'
+
 export const userProcessesConfig: QueryConfig = {
   name: 'user-processes',
   description: 'Per-user memory usage and resource summary',
@@ -7,12 +9,27 @@ export const userProcessesConfig: QueryConfig = {
   // system.user_processes may not exist on every server / version
   optional: true,
   tableCheck: 'system.user_processes',
-  sql: `SELECT user, formatReadableSize(memory_usage) AS readable_memory, formatReadableSize(peak_memory_usage) AS readable_peak_memory, memory_usage, peak_memory_usage FROM system.user_processes ORDER BY memory_usage DESC`,
-  columns: [
-    'user',
-    'readable_memory',
-    'readable_peak_memory',
-    'memory_usage',
-    'peak_memory_usage',
-  ],
+  // BackgroundBar requires base + readable_{column} + pct_{column}
+  sql: `
+    SELECT
+      user,
+      memory_usage,
+      formatReadableSize(memory_usage) AS readable_memory_usage,
+      round(memory_usage * 100.0 / nullIf(max(memory_usage) OVER (), 0), 2) AS pct_memory_usage,
+      peak_memory_usage,
+      formatReadableSize(peak_memory_usage) AS readable_peak_memory_usage
+    FROM system.user_processes
+    ORDER BY memory_usage DESC
+  `,
+  columns: ['user', 'readable_memory_usage', 'readable_peak_memory_usage'],
+  columnFormats: {
+    user: ColumnFormat.ColoredBadge,
+    readable_memory_usage: ColumnFormat.BackgroundBar,
+    // readable_peak_memory_usage is already a human-readable string from
+    // formatReadableSize() in SQL, rendered as plain text
+  },
+  sortingFns: {
+    readable_memory_usage: 'sort_column_using_actual_value',
+    readable_peak_memory_usage: 'sort_column_using_actual_value',
+  },
 }


### PR DESCRIPTION
## What

Formats the table on `/user-processes?host=0` (config `apps/web/lib/query-config/tables/user-processes.ts`):

- `user` -> `ColoredBadge`
- `memory_usage` -> `BackgroundBar` percentage. SQL now emits the 3-column tuple the format needs: base `memory_usage`, `readable_memory_usage` (formatReadableSize), and `pct_memory_usage` (round(... / nullIf(max() OVER (),0))).
- `peak_memory_usage` -> human-readable size via `formatReadableSize` rendered as plain text.
- Numeric sorting (`sort_column_using_actual_value`) on the readable memory columns.

## Why

The page previously rendered raw/unformatted columns. This matches the BackgroundBar tuple convention used by `part-info.ts` and gives per-user memory a visual bar plus a colored user badge.

Note: `system.user_processes` only exposes `user`, `memory_usage`, `peak_memory_usage` (no row/duration columns), so only memory columns are formatted. `ColumnFormat.ReadableSize` does not exist in the enum; readable size is produced in SQL per the codebase convention.

## Summary by Sourcery

Format the user processes table to display user badges and readable memory values with visual bars while simplifying the exposed columns.

New Features:
- Add formatted user badge and memory usage bar columns to the user processes table.

Enhancements:
- Adjust the user processes SQL and column configuration to emit readable and percentage memory usage fields compatible with BackgroundBar display.
- Enable numeric sorting on human-readable memory columns in the user processes view.