### PR TITLE
feat(disks): redesign disks page with bento grid cards

### DIFF
--- a/apps/web/app/(dashboard)/disks/page.tsx
+++ b/apps/web/app/(dashboard)/disks/page.tsx
@@ -1,9 +1,13 @@
 'use client'
 
+import { DisksBento } from '@/components/disks/disks-bento'
 import { createPage } from '@/lib/create-page'
 import { diskSpaceConfig } from '@/lib/query-config/system/disks'
 
 export default createPage({
   queryConfig: diskSpaceConfig,
   title: 'Disks',
+  // Replace the default wide data table with a responsive bento grid of disk
+  // cards. Related charts, title and permission gating come from createPage.
+  tableSlot: <DisksBento />,
 })

--- a/apps/web/components/disks/disk-card.tsx
+++ b/apps/web/components/disks/disk-card.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { FolderOpen, HardDrive } from 'lucide-react'
+
+import { DiskUsageBar, usageLevel } from './disk-usage-bar'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+/**
+ * Row shape returned by the `disks` query config (see
+ * lib/query-config/system/disks.ts). All readable_* fields are pre-formatted
+ * by ClickHouse `formatReadableSize`.
+ */
+export interface DiskRow {
+  name: string
+  path: string
+  used_space: number
+  readable_used_space: string
+  unreserved_space: number
+  readable_unreserved_space: string
+  free_space: number
+  readable_free_space: string
+  total_space: number
+  readable_total_space: string
+  percent_free: string
+  keep_free_space: number
+  /** Disk engine type, only present on some ClickHouse versions */
+  type?: string
+}
+
+const LEVEL_ACCENT: Record<ReturnType<typeof usageLevel>, string> = {
+  ok: 'text-emerald-600 dark:text-emerald-400',
+  warn: 'text-amber-600 dark:text-amber-400',
+  critical: 'text-red-600 dark:text-red-400',
+}
+
+function percentUsedOf(disk: DiskRow): number {
+  if (disk.total_space > 0) {
+    return (disk.used_space / disk.total_space) * 100
+  }
+  // Fall back to derived value from percent_free (e.g. "12.34%")
+  const free = Number.parseFloat(disk.percent_free)
+  return Number.isFinite(free) ? 100 - free : 0
+}
+
+interface MetricProps {
+  label: string
+  value: string
+  className?: string
+}
+
+function Metric({ label, value, className }: MetricProps) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      <span className={cn('text-sm font-semibold tabular-nums', className)}>
+        {value}
+      </span>
+    </div>
+  )
+}
+
+export function DiskCard({ disk }: { disk: DiskRow }) {
+  const percentUsed = percentUsedOf(disk)
+  const level = usageLevel(percentUsed)
+  const accent = LEVEL_ACCENT[level]
+
+  return (
+    <Card className="flex h-full flex-col transition-shadow hover:shadow-md">
+      <CardHeader className="gap-1 p-4 pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <HardDrive className="size-4 shrink-0 text-muted-foreground" />
+            <span className="truncate font-semibold leading-none tracking-tight">
+              {disk.name}
+            </span>
+          </div>
+          {disk.type ? (
+            <span className="shrink-0 rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+              {disk.type}
+            </span>
+          ) : null}
+        </div>
+        {disk.path ? (
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <FolderOpen className="size-3 shrink-0" />
+            <span className="truncate font-mono" title={disk.path}>
+              {disk.path}
+            </span>
+          </div>
+        ) : null}
+      </CardHeader>
+
+      <CardContent className="mt-auto flex flex-col gap-3 p-4 pt-0">
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-baseline justify-between">
+            <span className="text-xs text-muted-foreground">
+              {disk.readable_used_space} used
+            </span>
+            <span className={cn('text-sm font-semibold tabular-nums', accent)}>
+              {percentUsed.toFixed(1)}%
+            </span>
+          </div>
+          <DiskUsageBar percentUsed={percentUsed} />
+          <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+            <span>{disk.readable_free_space} free</span>
+            <span>{disk.readable_total_space} total</span>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 border-t pt-3">
+          <Metric label="Unreserved" value={disk.readable_unreserved_space} />
+          <Metric label="Free" value={disk.readable_free_space} />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/components/disks/disk-usage-bar.tsx
+++ b/apps/web/components/disks/disk-usage-bar.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { Progress } from '@/components/ui/progress'
+import { cn } from '@/lib/utils'
+
+/**
+ * Threshold-based accent for disk fill level.
+ * - < 75%  green (healthy)
+ * - 75-90% amber (warning)
+ * - >= 90%  red (critical)
+ */
+export function usageLevel(percentUsed: number): 'ok' | 'warn' | 'critical' {
+  if (percentUsed >= 90) return 'critical'
+  if (percentUsed >= 75) return 'warn'
+  return 'ok'
+}
+
+const INDICATOR_CLASS: Record<ReturnType<typeof usageLevel>, string> = {
+  ok: '[&>div]:bg-emerald-500',
+  warn: '[&>div]:bg-amber-500',
+  critical: '[&>div]:bg-red-500',
+}
+
+const TRACK_CLASS: Record<ReturnType<typeof usageLevel>, string> = {
+  ok: 'bg-emerald-500/15',
+  warn: 'bg-amber-500/15',
+  critical: 'bg-red-500/15',
+}
+
+interface DiskUsageBarProps {
+  /** Used percentage 0-100 */
+  percentUsed: number
+  className?: string
+}
+
+/**
+ * Color-accented usage bar. Composes the shadcn Progress primitive and
+ * overrides the indicator/track colors via className (never edits ui/*).
+ */
+export function DiskUsageBar({ percentUsed, className }: DiskUsageBarProps) {
+  const level = usageLevel(percentUsed)
+  const clamped = Math.max(0, Math.min(100, percentUsed))
+
+  return (
+    <Progress
+      value={clamped}
+      aria-label={`Disk used ${clamped.toFixed(1)}%`}
+      className={cn(
+        'h-2.5',
+        TRACK_CLASS[level],
+        INDICATOR_CLASS[level],
+        className
+      )}
+    />
+  )
+}

--- a/apps/web/components/disks/disks-bento.tsx
+++ b/apps/web/components/disks/disks-bento.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { DiskCard, type DiskRow } from './disk-card'
+import { ChartError } from '@/components/charts/chart-error'
+import { Skeleton } from '@/components/skeletons'
+import { EmptyState } from '@/components/ui/empty-state'
+import { useHostId } from '@/lib/swr'
+import { useTableData } from '@/lib/swr/use-table-data'
+
+const GRID_CLASS =
+  'grid grid-cols-1 gap-3 sm:gap-4 md:grid-cols-2 xl:grid-cols-3'
+
+function DisksBentoSkeleton() {
+  return (
+    <div className={GRID_CLASS}>
+      {Array.from({ length: 3 }).map((_, i) => (
+        <Skeleton key={i} className="h-44 w-full rounded-xl" />
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Bento/grid layout for system.disks — one card per disk with a
+ * color-accented usage bar. Used as the `tableSlot` of the disks page so the
+ * related charts, title and permission gating from QueryPageLayout are kept.
+ */
+export function DisksBento() {
+  const hostId = useHostId()
+  const { data, error, isLoading, hasData, refresh } = useTableData<DiskRow>(
+    'disks',
+    hostId
+  )
+
+  if (isLoading && !hasData) {
+    return <DisksBentoSkeleton />
+  }
+
+  if (error && !hasData) {
+    return <ChartError error={error} title="Disks" onRetry={() => refresh()} />
+  }
+
+  if (!data || data.length === 0) {
+    return <EmptyState title="No disks found" />
+  }
+
+  return (
+    <div className={GRID_CLASS}>
+      {data.map((disk) => (
+        <DiskCard key={disk.name} disk={disk} />
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## What

Redesign `/disks?host=0` from a wide data table into a responsive **bento grid of per-disk cards**.

Each card shows:
- Disk name + optional engine `type` + mount `path`
- A color-accented **usage bar** (green < 75%, amber 75-90%, red >= 90%)
- `used` / `free` / `total` readable sizes and a used percentage
- Unreserved and free space metrics

Responsive: 1 column on mobile, 2 on tablet (md), 3 on desktop (xl).

## Why

A handful of disks each with many size columns reads poorly as a wide table (the config already hinted `defaultView: 'cards'`). The bento layout surfaces fill level at a glance with threshold colors.

## How

- New `components/disks/` — `disk-usage-bar.tsx` (composes shadcn `Progress`, overrides colors via className), `disk-card.tsx`, `disks-bento.tsx` (SWR via `useTableData('disks')` + `useHostId`).
- Page keeps `createPage`/`QueryPageLayout` and injects the grid through the existing `tableSlot` prop, so related charts, title and permission gating are preserved.
- No changes to shared data-table internals or the query config; `components/ui/*` untouched (composed via className only).

Fixes the plain-table UX at `/disks?host=0`.