### PR TITLE
feat(cluster): upgrade /cluster into Cluster Topology visualization

### DIFF
--- a/apps/web/app/(dashboard)/cluster/page.tsx
+++ b/apps/web/app/(dashboard)/cluster/page.tsx
@@ -1,149 +1,46 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { Suspense } from 'react'
-import { ChartSummaryUsedByRunningQueries } from '@/components/charts/summary-used-by-running-queries'
-import { ChartCPUUsage } from '@/components/charts/system/cpu-usage'
-import { ChartMemoryUsage } from '@/components/charts/system/memory-usage'
-import { PageHeader } from '@/components/layout'
-import { ChartSkeleton } from '@/components/skeletons'
-import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
-import { useHosts } from '@/lib/swr/use-hosts'
-import { cn } from '@/lib/utils'
+import { useHostId } from '@/lib/swr'
 
-/** Metric row config */
-const METRICS = [
+// The topology view hand-builds a large SVG graph; lazy-load it so the page
+// shell paints immediately and the canvas code is split into its own chunk.
+const TopologyView = dynamic(
+  () => import('@/components/cluster-topology').then((m) => m.TopologyView),
   {
-    id: 'running-queries',
-    label: 'Running Queries',
-    Component: ChartSummaryUsedByRunningQueries,
-  },
-  {
-    id: 'cpu-usage',
-    label: 'CPU Usage',
-    Component: ChartCPUUsage,
-  },
-  {
-    id: 'memory-usage',
-    label: 'Memory Usage',
-    Component: ChartMemoryUsage,
-  },
-] as const
+    ssr: false,
+    loading: () => <PageSkeleton />,
+  }
+)
 
-function HostSkeleton() {
+function PageSkeleton() {
   return (
-    <div className="flex flex-col gap-3">
-      <Skeleton className="h-5 w-32" />
-      <Skeleton className="h-5 w-48 opacity-60" />
-      <Skeleton className="h-32 w-full" />
-    </div>
-  )
-}
-
-function LoadingSkeleton() {
-  return (
-    <div className="flex flex-col gap-8">
-      <div>
-        <Skeleton className="h-7 w-52 mb-1" />
-        <Skeleton className="h-4 w-80 opacity-60" />
+    <div className="max-w-[1640px]">
+      <Skeleton className="mb-4 h-4 w-72" />
+      <div className="mb-4 flex flex-wrap gap-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-9 w-40" />
+        ))}
       </div>
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
-        <HostSkeleton />
-        <HostSkeleton />
-        <HostSkeleton />
+      <div className="grid grid-cols-1 gap-3 xl:grid-cols-[1fr_360px]">
+        <Skeleton className="h-[540px] w-full rounded-xl" />
+        <Skeleton className="h-[540px] w-full rounded-xl" />
       </div>
     </div>
   )
 }
 
-function ClusterComparisonContent() {
-  const { hosts, isLoading, error } = useHosts()
-
-  if (isLoading) {
-    return <LoadingSkeleton />
-  }
-
-  if (error) {
-    return (
-      <Card>
-        <CardContent className="pt-6">
-          <p className="text-sm text-destructive">
-            Failed to load hosts: {error.message}
-          </p>
-        </CardContent>
-      </Card>
-    )
-  }
-
-  if (!hosts || hosts.length === 0) {
-    return (
-      <Card>
-        <CardContent className="pt-6">
-          <p className="text-sm text-muted-foreground">
-            No ClickHouse hosts configured.
-          </p>
-        </CardContent>
-      </Card>
-    )
-  }
-
-  // Single host: show a note that comparison requires multiple hosts
-  const isSingleHost = hosts.length === 1
-
-  return (
-    <div className="flex flex-col gap-6 sm:gap-8">
-      {/* Page header */}
-      <PageHeader
-        title="Cluster Comparison"
-        description={
-          isSingleHost
-            ? 'Side-by-side view of key metrics. Add more hosts to compare across nodes.'
-            : `Comparing ${hosts.length} hosts — spot imbalances in CPU, memory, and query load.`
-        }
-      />
-
-      {/* Metric rows: one section per metric, one card per host */}
-      {METRICS.map(({ id, label, Component }) => (
-        <section key={id} aria-label={label}>
-          <h2 className="mb-3 text-xs font-medium tracking-widest text-muted-foreground/70 uppercase">
-            {label}
-          </h2>
-          <div
-            className={cn(
-              'grid grid-cols-1 gap-4',
-              hosts.length === 1 && 'max-w-sm gap-0',
-              hosts.length === 2 && 'sm:grid-cols-2',
-              hosts.length >= 3 && 'sm:grid-cols-2 xl:grid-cols-3'
-            )}
-          >
-            {hosts.map((host) => (
-              <div key={host.id} className="flex flex-col gap-2">
-                {/* Host label above each card */}
-                <div className="flex flex-col">
-                  <span className="text-sm font-medium leading-none">
-                    {host.name}
-                  </span>
-                  <span className="mt-0.5 text-xs text-muted-foreground truncate">
-                    {host.host}
-                  </span>
-                </div>
-
-                <Suspense fallback={<ChartSkeleton />}>
-                  <Component hostId={host.id} />
-                </Suspense>
-              </div>
-            ))}
-          </div>
-        </section>
-      ))}
-    </div>
-  )
+function ClusterTopologyContent() {
+  const hostId = useHostId()
+  return <TopologyView hostId={hostId} />
 }
 
-export default function ClusterComparisonPage() {
+export default function ClusterTopologyPage() {
   return (
-    <Suspense fallback={<LoadingSkeleton />}>
-      <ClusterComparisonContent />
+    <Suspense fallback={<PageSkeleton />}>
+      <ClusterTopologyContent />
     </Suspense>
   )
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -641,3 +641,28 @@
     }
   }
 }
+
+/* Cluster Topology live indicator — a soft expanding pulse behind the dot,
+   matching the design's `live-dot`. Used on the status strip and inspector
+   "live" tags. */
+@keyframes topo-live-pulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.55;
+  }
+  70%,
+  100% {
+    transform: scale(2.4);
+    opacity: 0;
+  }
+}
+
+.topo-live-dot {
+  animation: topo-live-pulse 1.8s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .topo-live-dot {
+    animation: none;
+  }
+}

--- a/apps/web/components/cluster-topology/geometry.ts
+++ b/apps/web/components/cluster-topology/geometry.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure geometry helpers for the topology canvas.
+ *
+ * Ported from the design prototype (topology.jsx) — convex hull + closed
+ * Catmull-Rom spline + a rounded "blob" hull that wraps a set of node centers.
+ * No React, no data dependencies, fully deterministic — safe to call inside
+ * useMemo so layout is computed once and never on a live tick.
+ */
+
+export type Point = [number, number]
+export interface Center {
+  x: number
+  y: number
+}
+
+/** Andrew's monotone-chain convex hull. */
+export function convexHull(points: Point[]): Point[] {
+  const pts = [...points].sort((a, b) => a[0] - b[0] || a[1] - b[1])
+  if (pts.length < 3) return pts
+  const cross = (o: Point, a: Point, b: Point) =>
+    (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
+
+  const lower: Point[] = []
+  for (const p of pts) {
+    while (
+      lower.length >= 2 &&
+      cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0
+    ) {
+      lower.pop()
+    }
+    lower.push(p)
+  }
+  const upper: Point[] = []
+  for (let i = pts.length - 1; i >= 0; i--) {
+    const p = pts[i]
+    while (
+      upper.length >= 2 &&
+      cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0
+    ) {
+      upper.pop()
+    }
+    upper.push(p)
+  }
+  lower.pop()
+  upper.pop()
+  return lower.concat(upper)
+}
+
+/** Smooth closed path through points using a Catmull-Rom → bezier conversion. */
+export function catmullRomClosed(p: Point[]): string {
+  const n = p.length
+  if (n < 3) return ''
+  let d = `M ${p[0][0].toFixed(1)} ${p[0][1].toFixed(1)}`
+  for (let i = 0; i < n; i++) {
+    const p0 = p[(i - 1 + n) % n]
+    const p1 = p[i]
+    const p2 = p[(i + 1) % n]
+    const p3 = p[(i + 2) % n]
+    const c1x = p1[0] + (p2[0] - p0[0]) / 6
+    const c1y = p1[1] + (p2[1] - p0[1]) / 6
+    const c2x = p2[0] - (p3[0] - p1[0]) / 6
+    const c2y = p2[1] - (p3[1] - p1[1]) / 6
+    d += ` C ${c1x.toFixed(1)} ${c1y.toFixed(1)} ${c2x.toFixed(1)} ${c2y.toFixed(1)} ${p2[0].toFixed(1)} ${p2[1].toFixed(1)}`
+  }
+  return `${d} Z`
+}
+
+/**
+ * Rounded convex blob wrapping every member node. Works for 1, 2, 3+ nodes by
+ * sampling a small ring around each center, hulling all sample points, then
+ * smoothing. `pad` controls how far the blob sits outside the node centers.
+ */
+export function hullPath(centers: Center[], pad: number): string {
+  if (centers.length === 0) return ''
+  const ring: Point[] = []
+  const N = 20
+  centers.forEach((c) => {
+    for (let i = 0; i < N; i++) {
+      const a = (i / N) * Math.PI * 2
+      ring.push([c.x + Math.cos(a) * pad, c.y + Math.sin(a) * pad])
+    }
+  })
+  return catmullRomClosed(convexHull(ring))
+}

--- a/apps/web/components/cluster-topology/index.ts
+++ b/apps/web/components/cluster-topology/index.ts
@@ -1,0 +1,1 @@
+export { TopologyView } from './topology-view'

--- a/apps/web/components/cluster-topology/inspector.tsx
+++ b/apps/web/components/cluster-topology/inspector.tsx
@@ -1,0 +1,618 @@
+'use client'
+
+import { CheckIcon } from 'lucide-react'
+
+import type { ChNode, ClusterInfo, KeeperNode, TopologyModel } from './model'
+
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+
+// ── inspector primitives (bespoke, translated from the design tokens) ──
+
+function InsRow({
+  label,
+  children,
+  mono,
+}: {
+  label: string
+  children: React.ReactNode
+  mono?: boolean
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 py-1.5">
+      <span className="text-[11.5px] text-muted-foreground">{label}</span>
+      <span
+        className={cn(
+          'text-right text-[12px] font-medium tabular-nums text-foreground',
+          mono && 'font-mono'
+        )}
+      >
+        {children}
+      </span>
+    </div>
+  )
+}
+
+/** Thin colored meter — design uses an inline bar, not the Radix Progress. */
+function Meter({ pct, color }: { pct: number; color: string }) {
+  return (
+    <div className="relative h-1.5 overflow-hidden rounded-full bg-muted">
+      <div
+        className="absolute inset-y-0 left-0 rounded-full transition-all"
+        style={{
+          width: `${Math.min(100, Math.max(0, pct))}%`,
+          background: color,
+        }}
+      />
+    </div>
+  )
+}
+
+function MeterRow({
+  label,
+  value,
+  sub,
+  pct,
+  color,
+}: {
+  label: string
+  value: string
+  sub?: string
+  pct: number
+  color: string
+}) {
+  return (
+    <div className="py-1.5">
+      <div className="mb-1 flex items-center justify-between">
+        <span className="text-[11.5px] text-muted-foreground">{label}</span>
+        <span className="text-[12px] font-medium tabular-nums text-foreground">
+          {value}{' '}
+          <span className="font-normal text-muted-foreground">{sub}</span>
+        </span>
+      </div>
+      <Meter pct={pct} color={color} />
+    </div>
+  )
+}
+
+function InsSection({
+  title,
+  right,
+  children,
+}: {
+  title: string
+  right?: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <div className="border-b border-border px-4 py-3">
+      <div className="mb-1.5 flex items-center justify-between">
+        <h4 className="text-[10.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+          {title}
+        </h4>
+        {right}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function LiveTag() {
+  return (
+    <span className="inline-flex items-center gap-1 text-[10px] text-emerald-600 dark:text-emerald-400">
+      <span className="topo-live-dot h-1.5 w-1.5 rounded-full bg-emerald-500" />
+      live
+    </span>
+  )
+}
+
+// Tiny inline sparkline (area). Deterministic over its `data`.
+function Sparkline({
+  data,
+  color,
+  width = 150,
+  height = 34,
+}: {
+  data: number[]
+  color: string
+  width?: number
+  height?: number
+}) {
+  if (!data || data.length < 2) {
+    return (
+      <div
+        className="text-[10px] text-muted-foreground"
+        style={{ width, height }}
+      />
+    )
+  }
+  const max = Math.max(...data, 1)
+  const min = Math.min(...data, 0)
+  const step = width / (data.length - 1)
+  const pts = data.map((v, i) => {
+    const x = i * step
+    const y = height - ((v - min) / (max - min || 1)) * (height - 4) - 2
+    return [x, y] as const
+  })
+  const id = `topo-sl-${color.replace(/[^a-z0-9]/gi, '')}`
+  let d = `M ${pts[0][0]} ${pts[0][1]}`
+  for (let i = 1; i < pts.length; i++) {
+    const [x0, y0] = pts[i - 1]
+    const [x1, y1] = pts[i]
+    const cx = (x0 + x1) / 2
+    d += ` C ${cx} ${y0} ${cx} ${y1} ${x1} ${y1}`
+  }
+  return (
+    <svg width={width} height={height} className="block">
+      <defs>
+        <linearGradient id={id} x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stopColor={color} stopOpacity={0.18} />
+          <stop offset="1" stopColor={color} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path
+        d={`${d} L ${width} ${height} L 0 ${height} Z`}
+        fill={`url(#${id})`}
+      />
+      <path d={d} fill="none" stroke={color} strokeWidth="1.4" />
+    </svg>
+  )
+}
+
+function fmtBytes(b: number): string {
+  if (!b || b <= 0) return '0'
+  const u = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']
+  let i = 0
+  let v = b
+  while (v >= 1024 && i < u.length - 1) {
+    v /= 1024
+    i++
+  }
+  return `${v.toFixed(v >= 100 ? 0 : 1)} ${u[i]}`
+}
+
+function fmtUptime(seconds: number): string {
+  if (!seconds || seconds <= 0) return '—'
+  const d = Math.floor(seconds / 86400)
+  const h = Math.floor((seconds % 86400) / 3600)
+  return d > 0 ? `${d}d ${String(h).padStart(2, '0')}h` : `${h}h`
+}
+
+// ── public live snapshot shape consumed by the inspector ──
+export interface LiveSnapshot {
+  cpuPct: number | null
+  memUsed: number | null
+  memTotal: number | null
+  diskUsed: number | null
+  diskTotal: number | null
+  activeQueries: number | null
+  uptimeSeconds: number | null
+  version: string | null
+  cpuHist: number[]
+  latHist: number[]
+}
+
+const EMPTY_LIVE: LiveSnapshot = {
+  cpuPct: null,
+  memUsed: null,
+  memTotal: null,
+  diskUsed: null,
+  diskTotal: null,
+  activeQueries: null,
+  uptimeSeconds: null,
+  version: null,
+  cpuHist: [],
+  latHist: [],
+}
+
+function membershipsOf(model: TopologyModel, id: string) {
+  return model.clusters
+    .filter((c) => c.members[id])
+    .map((c) => ({ cl: c, role: c.members[id] }))
+}
+
+// ── ClickHouse node inspector ──
+export function ChInspector({
+  node,
+  model,
+  live,
+}: {
+  node: ChNode
+  model: TopologyModel
+  live: LiveSnapshot
+}) {
+  const memPct =
+    live.memUsed !== null && live.memTotal
+      ? (live.memUsed / live.memTotal) * 100
+      : null
+  const diskPct =
+    live.diskUsed !== null && live.diskTotal
+      ? (live.diskUsed / live.diskTotal) * 100
+      : null
+  const cpu = live.cpuPct
+  const cpuColor =
+    cpu !== null && cpu > 85
+      ? 'hsl(0 84% 60%)'
+      : cpu !== null && cpu > 60
+        ? 'hsl(38 92% 50%)'
+        : 'hsl(217 91% 60%)'
+  const memColor =
+    memPct !== null && memPct > 85
+      ? 'hsl(0 84% 60%)'
+      : memPct !== null && memPct > 65
+        ? 'hsl(38 92% 50%)'
+        : 'hsl(217 91% 60%)'
+  const mems = membershipsOf(model, node.id)
+  const isLocal = node.isLocal
+
+  return (
+    <>
+      <InsSection
+        title="Identity"
+        right={
+          <Badge
+            variant="outline"
+            className={cn(
+              'border px-1.5 py-0.5 text-[10.5px]',
+              node.status === 'warn'
+                ? 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300'
+                : node.status === 'down'
+                  ? 'border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-300'
+                  : 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300'
+            )}
+          >
+            {node.status}
+          </Badge>
+        }
+      >
+        <InsRow label="Hostname" mono>
+          {node.host}
+        </InsRow>
+        <InsRow label="IP address" mono>
+          {node.address}
+          <span className="text-muted-foreground">:{node.port}</span>
+        </InsRow>
+        <InsRow label="Shard / Replica" mono>
+          {node.defaultRole
+            ? `shard ${node.defaultRole.s} · replica ${node.defaultRole.r}`
+            : '—'}
+        </InsRow>
+        <InsRow label="is_local" mono>
+          {isLocal ? 'true' : 'false'}
+        </InsRow>
+        <InsRow label="errors_count" mono>
+          <span
+            className={
+              node.errors > 0 ? 'text-amber-600 dark:text-amber-400' : ''
+            }
+          >
+            {node.errors}
+          </span>
+        </InsRow>
+        <InsRow label="slowdowns_count" mono>
+          {node.slowdowns}
+        </InsRow>
+        {live.version && (
+          <InsRow label="Version" mono>
+            {live.version}
+          </InsRow>
+        )}
+      </InsSection>
+
+      {isLocal ? (
+        <InsSection title="Live resources" right={<LiveTag />}>
+          <div className="mb-2 flex items-center justify-between">
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                CPU
+              </div>
+              <div className="text-[22px] font-bold leading-none tabular-nums">
+                {cpu !== null ? Math.round(cpu) : '—'}
+                <span className="ml-0.5 text-[12px] font-medium text-muted-foreground">
+                  %
+                </span>
+              </div>
+            </div>
+            <Sparkline data={live.cpuHist} color={cpuColor} />
+          </div>
+          {memPct !== null && (
+            <MeterRow
+              label="Memory"
+              value={`${fmtBytes(live.memUsed ?? 0)} / ${fmtBytes(live.memTotal ?? 0)}`}
+              pct={memPct}
+              color={memColor}
+            />
+          )}
+          {diskPct !== null && (
+            <MeterRow
+              label="Disk"
+              value={`${fmtBytes(live.diskUsed ?? 0)} / ${fmtBytes(live.diskTotal ?? 0)}`}
+              pct={diskPct}
+              color={diskPct > 85 ? 'hsl(0 84% 60%)' : 'hsl(158 64% 38%)'}
+            />
+          )}
+        </InsSection>
+      ) : (
+        <InsSection title="Live resources">
+          <p className="text-[10.5px] leading-relaxed text-muted-foreground">
+            Live CPU / memory / disk are shown for the connected node only.
+            Switch the host selector to this node to inspect its live metrics.
+          </p>
+        </InsSection>
+      )}
+
+      <InsSection title="Workload">
+        {isLocal && (
+          <InsRow label="Active queries">{live.activeQueries ?? '—'}</InsRow>
+        )}
+        <InsRow label="estimated_recovery_time" mono>
+          {node.recoveryTime}s
+        </InsRow>
+        {isLocal && (
+          <InsRow label="Uptime" mono>
+            {fmtUptime(live.uptimeSeconds ?? 0)}
+          </InsRow>
+        )}
+      </InsSection>
+
+      <InsSection title={`Cluster memberships · ${mems.length}`}>
+        <div className="space-y-1">
+          {mems.map(({ cl, role }) => (
+            <div
+              key={cl.id}
+              className="flex items-center justify-between gap-2 rounded-md bg-muted/50 px-2 py-1.5"
+            >
+              <span className="inline-flex min-w-0 items-center gap-1.5">
+                <span
+                  className="h-2 w-2 shrink-0 rounded-sm"
+                  style={{ background: cl.color }}
+                />
+                <span className="truncate font-mono text-[12px] font-medium">
+                  {cl.name}
+                </span>
+                {cl.kind === 'physical' && (
+                  <Badge
+                    variant="outline"
+                    className="border-border px-1.5 py-0 text-[10px] text-muted-foreground"
+                  >
+                    physical
+                  </Badge>
+                )}
+              </span>
+              <span className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground">
+                s{role.s} · r{role.r}
+              </span>
+            </div>
+          ))}
+        </div>
+        {mems.length > 1 && (
+          <p className="mt-2 text-[10.5px] leading-relaxed text-muted-foreground">
+            Same node, different shard/replica role per cluster — virtual
+            clusters overlap.
+          </p>
+        )}
+      </InsSection>
+    </>
+  )
+}
+
+// ── Keeper node inspector ──
+export function KeeperInspector({
+  node,
+  model,
+  live,
+}: {
+  node: KeeperNode
+  model: TopologyModel
+  live: LiveSnapshot
+}) {
+  const isLeader = node.isLeader
+  return (
+    <>
+      <InsSection
+        title="Identity"
+        right={
+          <Badge
+            variant="outline"
+            className={cn(
+              'border px-1.5 py-0.5 text-[10.5px]',
+              isLeader
+                ? 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300'
+                : 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300'
+            )}
+          >
+            {node.role}
+          </Badge>
+        }
+      >
+        <InsRow label="Hostname" mono>
+          {node.host}
+        </InsRow>
+        <InsRow label="Port" mono>
+          {node.port}
+        </InsRow>
+        <InsRow label="Cluster" mono>
+          {node.clusterName}
+        </InsRow>
+        <InsRow label="Version" mono>
+          {node.version}
+        </InsRow>
+      </InsSection>
+
+      <InsSection title="Raft state" right={<LiveTag />}>
+        <InsRow label="Role" mono>
+          {node.role}
+        </InsRow>
+        <InsRow label="Leader" mono>
+          {model.leaderId ?? '—'}
+        </InsRow>
+        <InsRow label="Connected" mono>
+          {node.isConnected ? 'true' : 'false'}
+        </InsRow>
+        <InsRow label="Outstanding req." mono>
+          {node.outstanding}
+        </InsRow>
+        <InsRow label="Watch count" mono>
+          {node.watchCount.toLocaleString()}
+        </InsRow>
+        <InsRow label="Znode count" mono>
+          {node.znodeCount.toLocaleString()}
+        </InsRow>
+      </InsSection>
+
+      <InsSection title="Latency">
+        <div className="mb-2 flex items-center justify-between">
+          <div>
+            <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+              avg request
+            </div>
+            <div className="text-[22px] font-bold leading-none tabular-nums">
+              {node.avgLatency ? node.avgLatency.toFixed(2) : '—'}
+              <span className="ml-0.5 text-[12px] font-medium text-muted-foreground">
+                ms
+              </span>
+            </div>
+          </div>
+          <Sparkline data={live.latHist} color="hsl(158 64% 38%)" />
+        </div>
+      </InsSection>
+    </>
+  )
+}
+
+// ── default: cluster overview ──
+export function ClusterOverview({
+  model,
+  live,
+}: {
+  model: TopologyModel
+  live: LiveSnapshot
+}) {
+  const avgLat =
+    model.keepers.length > 0
+      ? model.keepers.reduce((s, k) => s + k.avgLatency, 0) /
+        model.keepers.length
+      : null
+  const znodes = model.keepers.reduce((s, k) => s + k.znodeCount, 0)
+  const hasKeeper = model.keepers.length > 0
+
+  return (
+    <>
+      <InsSection
+        title="Keeper quorum"
+        right={
+          hasKeeper ? (
+            model.quorumHealthy ? (
+              <Badge
+                variant="outline"
+                className="border-emerald-200 bg-emerald-50 px-1.5 py-0.5 text-[10.5px] text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300"
+              >
+                <CheckIcon className="mr-1 h-2.5 w-2.5" />
+                healthy
+              </Badge>
+            ) : (
+              <Badge
+                variant="outline"
+                className="border-amber-200 bg-amber-50 px-1.5 py-0.5 text-[10.5px] text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300"
+              >
+                degraded
+              </Badge>
+            )
+          ) : (
+            <Badge
+              variant="outline"
+              className="border-border px-1.5 py-0.5 text-[10.5px] text-muted-foreground"
+            >
+              unavailable
+            </Badge>
+          )
+        }
+      >
+        {hasKeeper ? (
+          <>
+            <InsRow label="Members">
+              {model.keepers.length} node{model.keepers.length === 1 ? '' : 's'}{' '}
+              · quorum {Math.floor(model.keepers.length / 2) + 1}
+            </InsRow>
+            <InsRow label="Leader" mono>
+              {model.leaderId ?? '—'}
+            </InsRow>
+            <InsRow label="Avg latency" mono>
+              {avgLat !== null ? `${avgLat.toFixed(2)} ms` : '—'}
+            </InsRow>
+            <InsRow label="Znodes" mono>
+              {znodes.toLocaleString()}
+            </InsRow>
+          </>
+        ) : (
+          <p className="text-[10.5px] leading-relaxed text-muted-foreground">
+            system.zookeeper_info is unavailable on this server (requires
+            ClickHouse Keeper / ZooKeeper and v26.1+). Cluster structure is
+            shown without coordination details.
+          </p>
+        )}
+      </InsSection>
+
+      <InsSection
+        title="Virtual clusters"
+        right={
+          <span className="text-[11px] tabular-nums text-muted-foreground">
+            {model.clusters.length}
+          </span>
+        }
+      >
+        <div className="space-y-1.5">
+          {model.clusters.map((cl: ClusterInfo) => (
+            <div
+              key={cl.id}
+              className="rounded-lg border border-border px-2.5 py-2"
+            >
+              <div className="mb-0.5 flex items-center justify-between">
+                <span className="inline-flex items-center gap-1.5">
+                  {cl.outline ? (
+                    <span
+                      className="h-2.5 w-2.5 rounded-sm border-2 border-dotted"
+                      style={{ borderColor: cl.color }}
+                    />
+                  ) : (
+                    <span
+                      className="h-2.5 w-2.5 rounded-sm"
+                      style={{ background: cl.color }}
+                    />
+                  )}
+                  <span className="font-mono text-[12.5px] font-semibold">
+                    {cl.name}
+                  </span>
+                </span>
+                <span className="text-[11px] tabular-nums text-muted-foreground">
+                  {cl.nodeCount} node{cl.nodeCount === 1 ? '' : 's'}
+                </span>
+              </div>
+              <div className="text-[11px] text-muted-foreground">{cl.topo}</div>
+            </div>
+          ))}
+        </div>
+        <p className="mt-2.5 text-[10.5px] leading-relaxed text-muted-foreground">
+          Nodes can join several clusters at once — overlaps show where the
+          hulls intersect.
+        </p>
+      </InsSection>
+
+      <InsSection title="Totals">
+        {live.activeQueries !== null && (
+          <InsRow label="Active queries (local)">{live.activeQueries}</InsRow>
+        )}
+        <InsRow label="Nodes">
+          {model.counts.nodes} · {model.counts.keepers} Keeper /{' '}
+          {model.counts.chNodes} ClickHouse
+        </InsRow>
+        <InsRow label="Clusters">
+          {model.counts.clusters} ({model.counts.physical} physical ·{' '}
+          {model.counts.logical} logical)
+        </InsRow>
+      </InsSection>
+    </>
+  )
+}
+
+export { EMPTY_LIVE }

--- a/apps/web/components/cluster-topology/model.ts
+++ b/apps/web/components/cluster-topology/model.ts
@@ -1,0 +1,448 @@
+/**
+ * Build the topology model from REAL ClickHouse data.
+ *
+ * Inputs:
+ *  - rows from `clusters-topology` (system.clusters, one row per cluster/shard/replica)
+ *  - rows from `keeper-info` (system.zookeeper_info, one row per Keeper node) — optional
+ *
+ * Output: a deterministic, laid-out model the canvas + inspector render. Layout is a
+ * pure function of the structural data, so it is computed once in useMemo and is stable
+ * across live-metric ticks.
+ */
+
+import type { ClusterTopologyRow } from '@/lib/query-config/system/clusters-topology'
+
+import { hullPath } from './geometry'
+
+export interface KeeperNode {
+  id: string
+  host: string
+  port: number
+  role: 'leader' | 'follower' | 'standalone' | 'unknown'
+  isLeader: boolean
+  version: string
+  avgLatency: number
+  znodeCount: number
+  watchCount: number
+  outstanding: number
+  isConnected: boolean
+  clusterName: string
+  x: number
+  y: number
+}
+
+export interface ChNode {
+  id: string
+  host: string
+  address: string
+  port: number
+  isLocal: boolean
+  /** healthy | warn | down — derived from errors/active, never random */
+  status: 'healthy' | 'warn' | 'down'
+  errors: number
+  slowdowns: number
+  recoveryTime: number
+  isActive: number | null
+  /** default-cluster shard/replica role, if present */
+  defaultRole?: { s: number; r: number }
+  x: number
+  y: number
+}
+
+export interface ClusterInfo {
+  id: string
+  name: string
+  kind: 'physical' | 'logical'
+  color: string
+  topo: string
+  /** members keyed by node id → shard/replica role */
+  members: Record<string, { s: number; r: number }>
+  /** rendered as a dotted outline (physical default cluster) instead of a filled hull */
+  outline: boolean
+  nodeCount: number
+}
+
+export interface TopologyModel {
+  keepers: KeeperNode[]
+  chNodes: ChNode[]
+  clusters: ClusterInfo[]
+  nodeById: Record<string, KeeperNode | ChNode>
+  clusterById: Record<string, ClusterInfo>
+  raftEdges: [string, string][]
+  replEdges: [string, string][]
+  coordEdges: [string, string][]
+  keeperHull: string
+  leaderId: string | null
+  quorumHealthy: boolean
+  counts: {
+    nodes: number
+    keepers: number
+    chNodes: number
+    clusters: number
+    physical: number
+    logical: number
+  }
+}
+
+/** Type guard: is this node a Keeper (vs a ClickHouse node)? */
+export function isKeeperNode(n: KeeperNode | ChNode): n is KeeperNode {
+  return 'role' in n
+}
+
+// Canvas viewBox. Keep in sync with TopoCanvas VB_W/VB_H.
+export const VB_W = 770
+export const VB_H = 560
+const CH_R = 33
+
+export const STATUS_COLOR: Record<string, string> = {
+  healthy: '#10b981',
+  warn: '#f59e0b',
+  down: '#f43f5e',
+}
+
+// Stable palette for logical clusters (default/physical is always slate).
+const CLUSTER_PALETTE = [
+  '#3b82f6',
+  '#f59e0b',
+  '#8b5cf6',
+  '#ec4899',
+  '#14b8a6',
+  '#ef4444',
+]
+const PHYSICAL_COLOR = '#64748b'
+
+/** Keeper-row Keeper raw row shape (subset of keeper-info columns we use). */
+export interface KeeperInfoRow {
+  zookeeper_cluster_name?: string
+  host: string
+  port: number
+  is_connected: number | boolean
+  server_state?: string
+  is_leader: number | boolean
+  version?: string
+  avg_latency?: number
+  znode_count?: number
+  watch_count?: number
+  outstanding_requests?: number
+}
+
+const num = (v: unknown, d = 0): number => {
+  const n = typeof v === 'string' ? Number(v) : (v as number)
+  return Number.isFinite(n) ? n : d
+}
+const truthy = (v: unknown): boolean => v === 1 || v === true || v === '1'
+
+function deriveKeeperRole(
+  isLeader: boolean,
+  serverState: string | undefined,
+  count: number
+): KeeperNode['role'] {
+  if (isLeader) return 'leader'
+  const s = serverState?.toLowerCase()
+  if (s === 'follower' || s === 'standalone') return s
+  return count === 1 ? 'standalone' : 'follower'
+}
+
+/** Short, stable id for a host (last hostname label or the address). */
+function shortId(host: string, index: number): string {
+  const label = host.split('.')[0] || host
+  return label || `node-${index}`
+}
+
+function isPhysicalName(name: string): boolean {
+  // Heuristic: the implicit per-server clusters and the conventional defaults are
+  // "physical"; everything else is treated as a logical/virtual cluster.
+  return (
+    name === 'default' ||
+    name.startsWith('default') ||
+    name === 'all-replicated' ||
+    name === 'all-sharded'
+  )
+}
+
+export function buildTopologyModel(
+  clusterRows: ClusterTopologyRow[],
+  keeperRows: KeeperInfoRow[]
+): TopologyModel {
+  // ── 1. collect unique CH hosts across all clusters ──
+  // A host key combines name+port so the same machine in multiple clusters maps
+  // to ONE node (the overlapping-hull story).
+  const hostKey = (r: { host_name: string; port: number }) =>
+    `${r.host_name}:${r.port}`
+
+  const hostOrder: string[] = []
+  const hostMeta = new Map<
+    string,
+    { row: ClusterTopologyRow; errors: number; slowdowns: number }
+  >()
+
+  for (const r of clusterRows) {
+    const k = hostKey(r)
+    if (!hostMeta.has(k)) {
+      hostOrder.push(k)
+      hostMeta.set(k, {
+        row: r,
+        errors: num(r.errors_count),
+        slowdowns: num(r.slowdowns_count),
+      })
+    } else {
+      const m = hostMeta.get(k)!
+      m.errors += num(r.errors_count)
+      m.slowdowns += num(r.slowdowns_count)
+      if (truthy(r.is_local)) m.row = r
+    }
+  }
+
+  const idByHostKey = new Map<string, string>()
+  const chNodes: ChNode[] = hostOrder.map((k, i) => {
+    const { row, errors, slowdowns } = hostMeta.get(k)!
+    const id = shortId(row.host_name, i)
+    idByHostKey.set(k, id)
+    const isActive = row.is_active
+    const inactive =
+      isActive !== null && isActive !== undefined && !truthy(isActive)
+    const status: ChNode['status'] = inactive
+      ? 'down'
+      : errors > 0
+        ? 'warn'
+        : 'healthy'
+    return {
+      id,
+      host: row.host_name,
+      address: row.host_address,
+      port: num(row.port),
+      isLocal: truthy(row.is_local),
+      status,
+      errors,
+      slowdowns,
+      recoveryTime: num(row.estimated_recovery_time),
+      isActive: isActive ?? null,
+      x: 0,
+      y: 0,
+    }
+  })
+
+  // ── 2. build clusters with per-node shard/replica role ──
+  const clusterNames: string[] = []
+  const clusterMembers = new Map<
+    string,
+    Record<string, { s: number; r: number }>
+  >()
+  const clusterShards = new Map<string, Set<number>>()
+  const clusterReplicas = new Map<string, Set<number>>()
+
+  for (const r of clusterRows) {
+    const id = idByHostKey.get(hostKey(r))
+    if (!id) continue
+    if (!clusterMembers.has(r.cluster)) {
+      clusterNames.push(r.cluster)
+      clusterMembers.set(r.cluster, {})
+      clusterShards.set(r.cluster, new Set())
+      clusterReplicas.set(r.cluster, new Set())
+    }
+    clusterMembers.get(r.cluster)![id] = {
+      s: num(r.shard_num),
+      r: num(r.replica_num),
+    }
+    clusterShards.get(r.cluster)!.add(num(r.shard_num))
+    clusterReplicas.get(r.cluster)!.add(num(r.replica_num))
+  }
+
+  let paletteIdx = 0
+  const clusters: ClusterInfo[] = clusterNames.map((name) => {
+    const members = clusterMembers.get(name)!
+    const shards = clusterShards.get(name)!.size
+    const physical = isPhysicalName(name)
+    // replicas-per-shard: max replica_num seen
+    const maxR = Math.max(...clusterReplicas.get(name)!, 1)
+    const color = physical
+      ? PHYSICAL_COLOR
+      : CLUSTER_PALETTE[paletteIdx++ % CLUSTER_PALETTE.length]
+    return {
+      id: name,
+      name,
+      kind: physical ? 'physical' : 'logical',
+      color,
+      topo: `${shards} shard${shards === 1 ? '' : 's'} × ${maxR} replica${maxR === 1 ? '' : 's'}`,
+      members,
+      outline: physical,
+      nodeCount: Object.keys(members).length,
+    }
+  })
+
+  // attach default-cluster role to each CH node for the inspector identity row
+  const defaultCluster =
+    clusters.find((c) => c.name === 'default') ??
+    clusters.find((c) => c.outline)
+  if (defaultCluster) {
+    for (const n of chNodes) {
+      const role = defaultCluster.members[n.id]
+      if (role) n.defaultRole = role
+    }
+  }
+
+  // ── 3. keepers ──
+  const keeperRowsClean = keeperRows.filter((r) => r && r.host)
+  const hasExplicitLeader = keeperRowsClean.some((r) => truthy(r.is_leader))
+  const keepers: KeeperNode[] = keeperRowsClean.map((r, i) => {
+    const isLeader = truthy(r.is_leader)
+    const connected =
+      r.is_connected === undefined ? true : truthy(r.is_connected)
+    const role = deriveKeeperRole(
+      isLeader,
+      r.server_state,
+      keeperRowsClean.length
+    )
+    return {
+      id: shortId(r.host, i) || `kpr-${i + 1}`,
+      host: r.host,
+      port: num(r.port, 9181),
+      role,
+      isLeader,
+      version: r.version ?? '—',
+      avgLatency: num(r.avg_latency),
+      znodeCount: num(r.znode_count),
+      watchCount: num(r.watch_count),
+      outstanding: num(r.outstanding_requests),
+      isConnected: connected,
+      clusterName: r.zookeeper_cluster_name ?? 'keeper',
+      x: 0,
+      y: 0,
+    }
+  })
+
+  // Prefer the explicit leader; if none is reported (e.g. standalone Keeper),
+  // fall back to the first node so coordination links still anchor somewhere.
+  const leaderId =
+    keepers.find((k) => k.isLeader)?.id ??
+    (hasExplicitLeader ? null : (keepers[0]?.id ?? null))
+  const quorumHealthy =
+    keepers.length > 0 &&
+    keepers.every((k) => k.isConnected) &&
+    keepers.some((k) => k.isLeader || k.role === 'standalone')
+
+  // ── 4. layout (deterministic) ──
+  layoutKeepers(keepers)
+  layoutChNodes(chNodes)
+
+  // ── 5. edges ──
+  // Raft: full mesh among keepers (small N).
+  const raftEdges: [string, string][] = []
+  for (let i = 0; i < keepers.length; i++) {
+    for (let j = i + 1; j < keepers.length; j++) {
+      raftEdges.push([keepers[i].id, keepers[j].id])
+    }
+  }
+  // Coordination: every CH node ↔ keeper leader (dashed).
+  const coordEdges: [string, string][] =
+    leaderId && keepers.length > 0
+      ? chNodes.map((n) => [n.id, leaderId] as [string, string])
+      : []
+  // Replication: within each shard of each cluster, link consecutive replicas.
+  const replSet = new Set<string>()
+  const replEdges: [string, string][] = []
+  for (const c of clusters) {
+    const byShard = new Map<number, string[]>()
+    for (const [id, role] of Object.entries(c.members)) {
+      if (!byShard.has(role.s)) byShard.set(role.s, [])
+      byShard.get(role.s)!.push(id)
+    }
+    for (const ids of byShard.values()) {
+      for (let i = 0; i < ids.length - 1; i++) {
+        const a = ids[i]
+        const b = ids[i + 1]
+        const key = [a, b].sort().join('~')
+        if (a !== b && !replSet.has(key)) {
+          replSet.add(key)
+          replEdges.push([a, b])
+        }
+      }
+    }
+  }
+
+  const nodeById: Record<string, KeeperNode | ChNode> = {}
+  keepers.forEach((k) => {
+    nodeById[k.id] = k
+  })
+  chNodes.forEach((n) => {
+    nodeById[n.id] = n
+  })
+  const clusterById: Record<string, ClusterInfo> = {}
+  clusters.forEach((c) => {
+    clusterById[c.id] = c
+  })
+
+  const keeperHull = keepers.length >= 2 ? hullPath(keepers, 46) : ''
+
+  return {
+    keepers,
+    chNodes,
+    clusters,
+    nodeById,
+    clusterById,
+    raftEdges,
+    replEdges,
+    coordEdges,
+    keeperHull,
+    leaderId,
+    quorumHealthy,
+    counts: {
+      nodes: keepers.length + chNodes.length,
+      keepers: keepers.length,
+      chNodes: chNodes.length,
+      clusters: clusters.length,
+      physical: clusters.filter((c) => c.kind === 'physical').length,
+      logical: clusters.filter((c) => c.kind === 'logical').length,
+    },
+  }
+}
+
+/** Keeper quorum: a horizontal triangle near the top (leader centered above). */
+function layoutKeepers(keepers: KeeperNode[]) {
+  const n = keepers.length
+  if (n === 0) return
+  const cx = VB_W / 2
+  if (n === 1) {
+    keepers[0].x = cx
+    keepers[0].y = 110
+    return
+  }
+  // leader on top apex, followers spread on a lower row
+  const leaderIdx = Math.max(
+    0,
+    keepers.findIndex((k) => k.isLeader)
+  )
+  const followers = keepers.filter((_, i) => i !== leaderIdx)
+  keepers[leaderIdx].x = cx
+  keepers[leaderIdx].y = 92
+  const spread = Math.min(110, 70 + followers.length * 10)
+  const total = (followers.length - 1) * spread
+  followers.forEach((f, i) => {
+    f.x = cx - total / 2 + i * spread
+    f.y = 176
+  })
+}
+
+/** ClickHouse nodes: an arc/row below the keepers, centered. */
+function layoutChNodes(nodes: ChNode[]) {
+  const n = nodes.length
+  if (n === 0) return
+  const cx = VB_W / 2
+  const baseY = 400
+  if (n === 1) {
+    nodes[0].x = cx
+    nodes[0].y = baseY
+    return
+  }
+  const usable = VB_W - 2 * (CH_R + 60)
+  const step = Math.min(170, usable / (n - 1))
+  const total = (n - 1) * step
+  nodes.forEach((node, i) => {
+    node.x = cx - total / 2 + i * step
+    // Gentle arc: -1 at the left edge, 0 in the middle, +1 at the right edge.
+    // `1 - t²` peaks at the middle, so middle nodes dip ~24px lower than the
+    // outer ones — a shallow smile that keeps replication links readable.
+    const t = (i / (n - 1)) * 2 - 1
+    node.y = baseY + Math.round((1 - t * t) * 24)
+  })
+}

--- a/apps/web/components/cluster-topology/topo-canvas.tsx
+++ b/apps/web/components/cluster-topology/topo-canvas.tsx
@@ -1,0 +1,547 @@
+'use client'
+
+import type { ChNode, KeeperNode, TopologyModel } from './model'
+
+import { hullPath } from './geometry'
+import { STATUS_COLOR, VB_H, VB_W } from './model'
+import { useMemo } from 'react'
+
+const CH_R = 33
+const KP_R = 27
+
+interface LiveMetrics {
+  cpuPct: number | null
+  memPct: number | null
+}
+
+interface TopoCanvasProps {
+  model: TopologyModel
+  /** Live metrics for the connected (is_local) node, keyed by node id. */
+  liveById: Record<string, LiveMetrics>
+  selected: string | null
+  activeCluster: string | null
+  onSelect: (id: string) => void
+  onClearSelect: () => void
+}
+
+function clampPct(v: number): number {
+  return Math.max(0.02, Math.min(1, v || 0))
+}
+
+const DbMark = ({ r }: { r: number }) => (
+  <g
+    transform={`translate(0 ${-r * 0.42})`}
+    stroke="hsl(var(--muted-foreground))"
+    strokeWidth="1.4"
+    fill="none"
+    opacity="0.55"
+  >
+    <ellipse cx="0" cy="0" rx="7" ry="2.6" />
+    <path d="M -7 0 v 5 c 0 1.4 3.1 2.6 7 2.6 s 7 -1.2 7 -2.6 v -5" />
+  </g>
+)
+
+const KeeperMark = ({ r, isLeader }: { r: number; isLeader: boolean }) => (
+  <g
+    transform={`translate(0 ${-r * 0.42})`}
+    stroke={isLeader ? '#f59e0b' : 'hsl(var(--muted-foreground))'}
+    strokeWidth="1.5"
+    fill="none"
+    opacity="0.7"
+  >
+    <path d="M 0 -6 L 6 -3 v 4.5 c 0 4 -3 6.5 -6 7.5 c -3 -1 -6 -3.5 -6 -7.5 V -3 Z" />
+  </g>
+)
+
+function ChGlyph({
+  node,
+  live,
+  selected,
+  dimmed,
+  onSelect,
+}: {
+  node: ChNode
+  live: LiveMetrics | undefined
+  selected: boolean
+  dimmed: boolean
+  onSelect: (id: string) => void
+}) {
+  const r = CH_R
+  const statusCol = STATUS_COLOR[node.status]
+  const cpu = live?.cpuPct ?? null
+  // Ring: live CPU when available (local node), else a thin structural arc.
+  const ringPct = cpu !== null ? clampPct(cpu / 100) : 0.04
+  const ringCol =
+    cpu !== null
+      ? ringPct > 0.85
+        ? '#f43f5e'
+        : ringPct > 0.6
+          ? '#f59e0b'
+          : '#3b82f6'
+      : 'hsl(var(--muted-foreground))'
+  const circ = 2 * Math.PI * r
+  const sub1 =
+    cpu !== null
+      ? `cpu ${Math.round(cpu)}%${live?.memPct !== null && live?.memPct !== undefined ? ` · mem ${Math.round(live.memPct)}%` : ''}`
+      : node.errors > 0
+        ? `${node.errors} errors`
+        : 'remote node'
+
+  return (
+    <g
+      transform={`translate(${node.x} ${node.y})`}
+      onClick={(e) => {
+        e.stopPropagation()
+        onSelect(node.id)
+      }}
+      style={{
+        cursor: 'pointer',
+        opacity: dimmed ? 0.28 : 1,
+        transition: 'opacity .25s',
+      }}
+    >
+      {selected && (
+        <circle
+          r={r + 9}
+          fill="none"
+          stroke="hsl(var(--primary))"
+          strokeWidth="2.5"
+          opacity="0.9"
+          style={{ filter: 'drop-shadow(0 0 6px hsl(var(--primary)/0.5))' }}
+        />
+      )}
+      <circle
+        r={r}
+        fill="hsl(var(--card))"
+        stroke="hsl(var(--border))"
+        strokeWidth="1.5"
+      />
+      <circle r={r} fill="none" stroke="hsl(var(--muted))" strokeWidth="4" />
+      <circle
+        r={r}
+        fill="none"
+        stroke={ringCol}
+        strokeWidth="4"
+        strokeLinecap="round"
+        strokeDasharray={`${(circ * ringPct).toFixed(1)} ${circ.toFixed(1)}`}
+        transform="rotate(-90)"
+        style={{ transition: 'stroke-dasharray .6s ease' }}
+      />
+      <DbMark r={r} />
+      <text
+        textAnchor="middle"
+        y={7}
+        fontSize="12.5"
+        fontWeight="700"
+        fill="hsl(var(--foreground))"
+        className="font-mono"
+      >
+        {node.id}
+      </text>
+      <circle
+        cx={r * 0.72}
+        cy={-r * 0.72}
+        r="5.5"
+        fill={statusCol}
+        stroke="hsl(var(--card))"
+        strokeWidth="2"
+      />
+      <text
+        textAnchor="middle"
+        y={r + 16}
+        fontSize="11.5"
+        fontWeight="600"
+        fill="hsl(var(--foreground))"
+        className="font-mono"
+      >
+        {node.host}
+      </text>
+      <text
+        textAnchor="middle"
+        y={r + 31}
+        fontSize="10.5"
+        fill="hsl(var(--muted-foreground))"
+        className="font-mono"
+      >
+        {sub1}
+      </text>
+      {node.isLocal && (
+        <g transform={`translate(0 ${r + 40})`}>
+          <rect
+            x="-22"
+            y="0"
+            width="44"
+            height="15"
+            rx="7.5"
+            fill="hsl(var(--primary)/0.12)"
+            stroke="hsl(var(--primary)/0.4)"
+            strokeWidth="1"
+          />
+          <text
+            textAnchor="middle"
+            y="10.5"
+            fontSize="8.5"
+            fontWeight="700"
+            fill="hsl(var(--primary))"
+            style={{ letterSpacing: '0.06em' }}
+          >
+            LOCAL
+          </text>
+        </g>
+      )}
+    </g>
+  )
+}
+
+function KeeperGlyph({
+  node,
+  selected,
+  dimmed,
+  onSelect,
+}: {
+  node: KeeperNode
+  selected: boolean
+  dimmed: boolean
+  onSelect: (id: string) => void
+}) {
+  const r = KP_R
+  const isLeader = node.isLeader
+  const statusCol = node.isConnected ? STATUS_COLOR.healthy : STATUS_COLOR.down
+  // Ring reflects connection + latency lightly; full arc when connected.
+  const ringPct = node.isConnected ? 1 : 0.04
+  const ringCol = isLeader ? '#f59e0b' : '#10b981'
+  const circ = 2 * Math.PI * r
+  const sub1 = `${node.role} · ${node.avgLatency ? `${node.avgLatency.toFixed(1)}ms` : '—'}`
+
+  return (
+    <g
+      transform={`translate(${node.x} ${node.y})`}
+      onClick={(e) => {
+        e.stopPropagation()
+        onSelect(node.id)
+      }}
+      style={{
+        cursor: 'pointer',
+        opacity: dimmed ? 0.28 : 1,
+        transition: 'opacity .25s',
+      }}
+    >
+      {selected && (
+        <circle
+          r={r + 9}
+          fill="none"
+          stroke="hsl(var(--primary))"
+          strokeWidth="2.5"
+          opacity="0.9"
+          style={{ filter: 'drop-shadow(0 0 6px hsl(var(--primary)/0.5))' }}
+        />
+      )}
+      <circle
+        r={r}
+        fill="hsl(var(--card))"
+        stroke="hsl(var(--border))"
+        strokeWidth="1.5"
+      />
+      <circle r={r} fill="none" stroke="hsl(var(--muted))" strokeWidth="4" />
+      <circle
+        r={r}
+        fill="none"
+        stroke={ringCol}
+        strokeWidth="4"
+        strokeLinecap="round"
+        strokeDasharray={`${(circ * ringPct).toFixed(1)} ${circ.toFixed(1)}`}
+        transform="rotate(-90)"
+        style={{ transition: 'stroke-dasharray .6s ease' }}
+      />
+      <KeeperMark r={r} isLeader={isLeader} />
+      <text
+        textAnchor="middle"
+        y={5}
+        fontSize="12.5"
+        fontWeight="700"
+        fill="hsl(var(--foreground))"
+        className="font-mono"
+      >
+        {node.id}
+      </text>
+      <circle
+        cx={r * 0.72}
+        cy={-r * 0.72}
+        r="5.5"
+        fill={statusCol}
+        stroke="hsl(var(--card))"
+        strokeWidth="2"
+      />
+      {isLeader && (
+        <text textAnchor="middle" y={-r - 6} fontSize="15" fill="#f59e0b">
+          ★
+        </text>
+      )}
+      <text
+        textAnchor="middle"
+        y={r + 16}
+        fontSize="11.5"
+        fontWeight="600"
+        fill="hsl(var(--foreground))"
+        className="font-mono"
+      >
+        {node.host}
+      </text>
+      <text
+        textAnchor="middle"
+        y={r + 31}
+        fontSize="10.5"
+        fill="hsl(var(--muted-foreground))"
+        className="font-mono"
+      >
+        {sub1}
+      </text>
+    </g>
+  )
+}
+
+export function TopoCanvas({
+  model,
+  liveById,
+  selected,
+  activeCluster,
+  onSelect,
+  onClearSelect,
+}: TopoCanvasProps) {
+  const {
+    keepers,
+    chNodes,
+    clusters,
+    nodeById,
+    clusterById,
+    raftEdges,
+    replEdges,
+    coordEdges,
+    keeperHull,
+  } = model
+
+  // Hull paths are pure geometry over structural positions → memoize once.
+  const logicalHulls = useMemo(
+    () =>
+      clusters.map((cl) => {
+        const centers = Object.keys(cl.members)
+          .map((id) => nodeById[id])
+          .filter(Boolean)
+        const minY = centers.length ? Math.min(...centers.map((c) => c.y)) : 0
+        const cx = centers.length
+          ? centers.reduce((s, c) => s + c.x, 0) / centers.length
+          : 0
+        const pad = 50
+        return {
+          cl,
+          d: hullPath(centers, pad),
+          tagX: cx,
+          tagY: minY - pad - 6,
+        }
+      }),
+    [clusters, nodeById]
+  )
+
+  const edge = (a: string, b: string) => {
+    const na = nodeById[a]
+    const nb = nodeById[b]
+    if (!na || !nb) return null
+    return { x1: na.x, y1: na.y, x2: nb.x, y2: nb.y }
+  }
+  const memberOf = (id: string) =>
+    activeCluster ? !!clusterById[activeCluster]?.members[id] : true
+
+  return (
+    <svg
+      viewBox={`0 0 ${VB_W} ${VB_H}`}
+      preserveAspectRatio="xMidYMid meet"
+      className="block h-full w-full select-none"
+      onClick={onClearSelect}
+      role="img"
+      aria-label="Cluster topology graph"
+    >
+      <defs>
+        <pattern
+          id="topo-dots"
+          width="22"
+          height="22"
+          patternUnits="userSpaceOnUse"
+        >
+          <circle
+            cx="1.2"
+            cy="1.2"
+            r="1.2"
+            fill="hsl(var(--muted-foreground))"
+            opacity="0.1"
+          />
+        </pattern>
+      </defs>
+      <rect x="0" y="0" width={VB_W} height={VB_H} fill="url(#topo-dots)" />
+
+      {/* keeper quorum hull */}
+      {keeperHull && (
+        <g
+          opacity={activeCluster ? 0.4 : 1}
+          style={{ transition: 'opacity .25s' }}
+        >
+          <path
+            d={keeperHull}
+            fill="#10b981"
+            fillOpacity="0.06"
+            stroke="#10b981"
+            strokeOpacity="0.45"
+            strokeWidth="1.5"
+            strokeDasharray="5 4"
+          />
+          {keepers[0] && (
+            <text
+              x={VB_W / 2}
+              y={42}
+              textAnchor="middle"
+              fontSize="11"
+              fontWeight="700"
+              fill="#10b981"
+              style={{ letterSpacing: '0.04em' }}
+            >
+              Keeper quorum · Raft
+            </text>
+          )}
+        </g>
+      )}
+
+      {/* logical / physical cluster hulls */}
+      {logicalHulls.map(({ cl, d, tagX, tagY }) => {
+        const active = activeCluster === cl.id
+        const faded = activeCluster && !active
+        if (!d) return null
+        if (cl.outline) {
+          return (
+            <g
+              key={cl.id}
+              opacity={faded ? 0.25 : 1}
+              style={{ transition: 'opacity .25s' }}
+            >
+              <path
+                d={d}
+                fill="none"
+                stroke={cl.color}
+                strokeOpacity={active ? 0.9 : 0.5}
+                strokeWidth={active ? 2 : 1.4}
+                strokeDasharray="2 5"
+                strokeLinecap="round"
+              />
+            </g>
+          )
+        }
+        return (
+          <g
+            key={cl.id}
+            opacity={faded ? 0.22 : 1}
+            style={{ transition: 'opacity .25s' }}
+          >
+            <path
+              d={d}
+              fill={cl.color}
+              fillOpacity={active ? 0.2 : 0.12}
+              stroke={cl.color}
+              strokeOpacity={active ? 0.9 : 0.45}
+              strokeWidth={active ? 2 : 1.3}
+            />
+            <text
+              x={tagX}
+              y={tagY}
+              textAnchor="middle"
+              fontSize="11.5"
+              fontWeight="700"
+              fill={cl.color}
+              opacity={active ? 1 : 0.85}
+              className="font-mono"
+              style={{ letterSpacing: '0.02em' }}
+            >
+              {cl.name}
+            </text>
+          </g>
+        )
+      })}
+
+      {/* edges */}
+      <g
+        opacity={activeCluster ? 0.35 : 1}
+        style={{ transition: 'opacity .25s' }}
+      >
+        {coordEdges.map(([a, b], i) => {
+          const e = edge(a, b)
+          if (!e) return null
+          return (
+            <line
+              key={`c${i}`}
+              x1={e.x1}
+              y1={e.y1}
+              x2={e.x2}
+              y2={e.y2}
+              stroke="hsl(var(--muted-foreground))"
+              strokeOpacity="0.3"
+              strokeWidth="1.2"
+              strokeDasharray="4 5"
+            />
+          )
+        })}
+        {raftEdges.map(([a, b], i) => {
+          const e = edge(a, b)
+          if (!e) return null
+          return (
+            <line
+              key={`r${i}`}
+              x1={e.x1}
+              y1={e.y1}
+              x2={e.x2}
+              y2={e.y2}
+              stroke="#10b981"
+              strokeOpacity="0.45"
+              strokeWidth="1.8"
+            />
+          )
+        })}
+      </g>
+      {replEdges.map(([a, b], i) => {
+        const e = edge(a, b)
+        if (!e) return null
+        const lit = !activeCluster || (memberOf(a) && memberOf(b))
+        return (
+          <line
+            key={`p${i}`}
+            x1={e.x1}
+            y1={e.y1}
+            x2={e.x2}
+            y2={e.y2}
+            stroke="#3b82f6"
+            strokeOpacity={lit ? 0.55 : 0.12}
+            strokeWidth="2"
+            style={{ transition: 'stroke-opacity .25s' }}
+          />
+        )
+      })}
+
+      {/* nodes */}
+      {keepers.map((n) => (
+        <KeeperGlyph
+          key={n.id}
+          node={n}
+          selected={selected === n.id}
+          dimmed={false}
+          onSelect={onSelect}
+        />
+      ))}
+      {chNodes.map((n) => (
+        <ChGlyph
+          key={n.id}
+          node={n}
+          live={liveById[n.id]}
+          selected={selected === n.id}
+          dimmed={activeCluster ? !memberOf(n.id) : false}
+          onSelect={onSelect}
+        />
+      ))}
+    </svg>
+  )
+}

--- a/apps/web/components/cluster-topology/topology-view.tsx
+++ b/apps/web/components/cluster-topology/topology-view.tsx
@@ -1,0 +1,510 @@
+'use client'
+
+import {
+  BoxesIcon,
+  DatabaseIcon,
+  ExternalLinkIcon,
+  HashIcon,
+  RefreshCwIcon,
+  ShieldIcon,
+  XIcon,
+} from 'lucide-react'
+
+import type { ClusterLiveMetricsRow } from '@/lib/query-config/system/cluster-live-metrics'
+import type { ClusterTopologyRow } from '@/lib/query-config/system/clusters-topology'
+import type { LiveSnapshot } from './inspector'
+import type { KeeperInfoRow } from './model'
+
+import {
+  ChInspector,
+  ClusterOverview,
+  EMPTY_LIVE,
+  KeeperInspector,
+} from './inspector'
+import { buildTopologyModel, isKeeperNode, STATUS_COLOR } from './model'
+import { TopoCanvas } from './topo-canvas'
+import Link from 'next/link'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useTableData } from '@/lib/swr'
+import { cn } from '@/lib/utils'
+
+// Refresh cadences: structure is slow-moving (cache hard), live is fast.
+const STRUCTURE_INTERVAL = 60_000 // 60s
+const STRUCTURE_DEDUPE = 55_000
+const LIVE_INTERVAL = 8_000 // 8s
+const HIST_LEN = 28
+
+// ── summary pill ──
+function Pill({
+  icon: Icon,
+  label,
+  value,
+  tone,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  value: React.ReactNode
+  tone?: string
+}) {
+  return (
+    <div className="flex h-9 items-center gap-2 rounded-lg border border-border bg-card px-3">
+      <Icon className="h-[13px] w-[13px] text-muted-foreground" />
+      <span className="text-[11px] text-muted-foreground">{label}</span>
+      <span
+        className={cn(
+          'text-[12.5px] font-semibold tabular-nums',
+          tone || 'text-foreground'
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}
+
+export function TopologyView({ hostId }: { hostId: number }) {
+  // ── structural data (cached hard) ──
+  const {
+    data: clusterRows,
+    error: clusterError,
+    isLoading: clusterLoading,
+    refresh: refreshClusters,
+  } = useTableData<ClusterTopologyRow>(
+    'clusters-topology',
+    hostId,
+    undefined,
+    STRUCTURE_INTERVAL,
+    {
+      dedupingInterval: STRUCTURE_DEDUPE,
+      keepPreviousData: true,
+      revalidateOnFocus: false,
+    }
+  )
+
+  // ── keeper data (optional; degrade gracefully) ──
+  const { data: keeperRows, refresh: refreshKeeper } =
+    useTableData<KeeperInfoRow>(
+      'keeper-info',
+      hostId,
+      undefined,
+      STRUCTURE_INTERVAL,
+      {
+        dedupingInterval: STRUCTURE_DEDUPE,
+        keepPreviousData: true,
+        revalidateOnFocus: false,
+        shouldRetryOnError: false,
+      }
+    )
+
+  // ── live metrics for the connected node (fast interval, separate key) ──
+  const { data: liveRows, refresh: refreshLive } =
+    useTableData<ClusterLiveMetricsRow>(
+      'cluster-live-metrics',
+      hostId,
+      undefined,
+      LIVE_INTERVAL,
+      {
+        dedupingInterval: LIVE_INTERVAL - 1000,
+        keepPreviousData: true,
+        revalidateOnFocus: false,
+        shouldRetryOnError: false,
+      }
+    )
+
+  // ── model: rebuilt ONLY when structural data changes ──
+  const model = useMemo(
+    () => buildTopologyModel(clusterRows ?? [], keeperRows ?? []),
+    [clusterRows, keeperRows]
+  )
+
+  const liveRow = liveRows?.[0]
+
+  // Identify the local CH node id (the connected node).
+  const localNodeId = useMemo(
+    () => model.chNodes.find((n) => n.isLocal)?.id ?? null,
+    [model.chNodes]
+  )
+
+  // ── live history ring buffer (only the live bit re-renders) ──
+  const [cpuHist, setCpuHist] = useState<number[]>([])
+  const lastCpuRef = useRef<number | null>(null)
+  useEffect(() => {
+    const cpu = liveRow?.cpu_pct
+    if (cpu === undefined || cpu === null) return
+    const n = Number(cpu)
+    if (!Number.isFinite(n)) return
+    if (lastCpuRef.current === n && cpuHist.length > 0) return
+    lastCpuRef.current = n
+    setCpuHist((prev) => [...prev.slice(-(HIST_LEN - 1)), n])
+  }, [liveRow?.cpu_pct, cpuHist.length])
+
+  // Keeper latency history (avg across keepers).
+  const [latHist, setLatHist] = useState<number[]>([])
+  useEffect(() => {
+    if (model.keepers.length === 0) return
+    const avg =
+      model.keepers.reduce((s, k) => s + k.avgLatency, 0) / model.keepers.length
+    if (!Number.isFinite(avg) || avg <= 0) return
+    setLatHist((prev) => [...prev.slice(-(HIST_LEN - 1)), avg])
+  }, [model.keepers])
+
+  // ── selection + cluster filter ──
+  const [selected, setSelected] = useState<string | null>(null)
+  const [activeCluster, setActiveCluster] = useState<string | null>(null)
+  const [secsAgo, setSecsAgo] = useState(0)
+
+  useEffect(() => {
+    setSecsAgo(0)
+  }, [liveRow])
+  useEffect(() => {
+    const t = setInterval(() => setSecsAgo((s) => s + 1), 1000)
+    return () => clearInterval(t)
+  }, [])
+
+  // live numbers mapped to canvas glyph rings (local node only)
+  const liveById = useMemo(() => {
+    const map: Record<
+      string,
+      { cpuPct: number | null; memPct: number | null }
+    > = {}
+    if (localNodeId && liveRow) {
+      const cpu = Number(liveRow.cpu_pct)
+      const memUsed = Number(liveRow.mem_used_bytes)
+      const memTotal = Number(liveRow.mem_total_bytes)
+      map[localNodeId] = {
+        cpuPct: Number.isFinite(cpu) ? cpu : null,
+        memPct:
+          Number.isFinite(memUsed) && memTotal > 0
+            ? (memUsed / memTotal) * 100
+            : null,
+      }
+    }
+    return map
+  }, [localNodeId, liveRow])
+
+  // full live snapshot for the inspector (local node only)
+  const localSnapshot: LiveSnapshot = useMemo(() => {
+    if (!liveRow) return { ...EMPTY_LIVE, latHist }
+    const numOrNull = (v: unknown) => {
+      const n = Number(v)
+      return Number.isFinite(n) ? n : null
+    }
+    return {
+      cpuPct: numOrNull(liveRow.cpu_pct),
+      memUsed: numOrNull(liveRow.mem_used_bytes),
+      memTotal: numOrNull(liveRow.mem_total_bytes),
+      diskUsed: numOrNull(liveRow.disk_used_bytes),
+      diskTotal: numOrNull(liveRow.disk_total_bytes),
+      activeQueries: numOrNull(liveRow.active_queries),
+      uptimeSeconds: numOrNull(liveRow.uptime_seconds),
+      version: liveRow.version ?? null,
+      cpuHist,
+      latHist,
+    }
+  }, [liveRow, cpuHist, latHist])
+
+  const selectedNode = selected ? (model.nodeById[selected] ?? null) : null
+
+  const handleRefresh = () => {
+    refreshClusters()
+    refreshKeeper()
+    refreshLive()
+  }
+
+  // ── loading / empty states ──
+  if (clusterLoading && (!clusterRows || clusterRows.length === 0)) {
+    return <TopologySkeleton />
+  }
+
+  if (clusterError && (!clusterRows || clusterRows.length === 0)) {
+    return (
+      <Card className="p-6">
+        <p className="text-sm text-destructive">
+          Failed to load cluster topology: {clusterError.message}
+        </p>
+      </Card>
+    )
+  }
+
+  if (!clusterRows || clusterRows.length === 0) {
+    return (
+      <Card className="p-6">
+        <p className="text-sm text-muted-foreground">
+          No clusters found in system.clusters for this host.
+        </p>
+      </Card>
+    )
+  }
+
+  const dfltCluster =
+    model.clusters.find((c) => c.name === 'default')?.name ??
+    model.clusters[0]?.name ??
+    '—'
+  const leaderLabel = model.leaderId ? `leader ${model.leaderId}` : '—'
+
+  return (
+    <div className="max-w-[1640px]">
+      {/* status strip */}
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="relative inline-flex h-2 w-2">
+            <span
+              className={cn(
+                'absolute inset-0 rounded-full',
+                model.quorumHealthy || model.keepers.length === 0
+                  ? 'topo-live-dot bg-emerald-500'
+                  : 'bg-amber-500'
+              )}
+            />
+            <span
+              className={cn(
+                'relative h-2 w-2 rounded-full',
+                model.quorumHealthy || model.keepers.length === 0
+                  ? 'bg-emerald-500'
+                  : 'bg-amber-500'
+              )}
+            />
+          </span>
+          <span className="text-[12.5px] font-medium">
+            {model.keepers.length === 0
+              ? 'Cluster online'
+              : model.quorumHealthy
+                ? 'Quorum healthy · all replicas online'
+                : 'Quorum degraded'}
+          </span>
+          <span className="text-[11.5px] text-muted-foreground">
+            · cluster <span className="font-mono">{dfltCluster}</span> · updated{' '}
+            <span className="tabular-nums">{secsAgo}s</span> ago
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5 px-2 text-[12px]"
+            onClick={handleRefresh}
+          >
+            <RefreshCwIcon className="h-3 w-3" />
+            Refresh
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            asChild
+            className="h-7 gap-1.5 px-2 text-[12px]"
+          >
+            <Link href={`/clusters?host=${hostId}`}>
+              <ExternalLinkIcon className="h-3 w-3" />
+              system.clusters
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      {/* summary pills */}
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <Pill icon={BoxesIcon} label="Nodes" value={model.counts.nodes} />
+        <Pill
+          icon={ShieldIcon}
+          label="Keeper"
+          value={`${model.counts.keepers} · ${leaderLabel}`}
+        />
+        <Pill
+          icon={DatabaseIcon}
+          label="ClickHouse"
+          value={model.counts.chNodes}
+        />
+        <Pill
+          icon={HashIcon}
+          label="Clusters"
+          value={`${model.counts.clusters} (${model.counts.physical} physical · ${model.counts.logical} logical)`}
+        />
+        {localSnapshot.activeQueries !== null && (
+          <Pill
+            icon={RefreshCwIcon}
+            label="Active queries"
+            value={localSnapshot.activeQueries}
+            tone="text-amber-600 dark:text-amber-400"
+          />
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 items-start gap-3 xl:grid-cols-[1fr_360px]">
+        {/* canvas */}
+        <Card className="overflow-hidden">
+          {/* legend toolbar */}
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-2.5">
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="mr-1 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                Clusters
+              </span>
+              {model.clusters.map((cl) => {
+                const on = activeCluster === cl.id
+                return (
+                  <button
+                    type="button"
+                    key={cl.id}
+                    onClick={() => setActiveCluster(on ? null : cl.id)}
+                    className={cn(
+                      'inline-flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-[12px] font-medium transition-colors',
+                      on
+                        ? 'border-foreground/30 bg-muted text-foreground'
+                        : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground'
+                    )}
+                  >
+                    {cl.outline ? (
+                      <span
+                        className="h-2.5 w-2.5 rounded-sm border-2 border-dotted"
+                        style={{ borderColor: cl.color }}
+                      />
+                    ) : (
+                      <span
+                        className="h-2.5 w-2.5 rounded-sm"
+                        style={{ background: cl.color }}
+                      />
+                    )}
+                    <span className="font-mono">{cl.name}</span>
+                  </button>
+                )
+              })}
+              {activeCluster && (
+                <button
+                  type="button"
+                  onClick={() => setActiveCluster(null)}
+                  className="ml-1 text-[11px] text-muted-foreground underline hover:text-foreground"
+                >
+                  clear
+                </button>
+              )}
+            </div>
+            <div className="flex items-center gap-3 text-[10.5px] text-muted-foreground">
+              <span className="inline-flex items-center gap-1.5">
+                <span
+                  className="h-0.5 w-4 rounded-full"
+                  style={{ background: '#3b82f6', opacity: 0.6 }}
+                />
+                replication
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <span
+                  className="w-4 border-t-2 border-dashed"
+                  style={{
+                    borderColor: 'hsl(var(--muted-foreground))',
+                    opacity: 0.5,
+                  }}
+                />
+                coordination
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <span className="h-2 w-2 rounded-full bg-emerald-500" />
+                healthy
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <span className="h-2 w-2 rounded-full bg-amber-500" />
+                warn
+              </span>
+            </div>
+          </div>
+          <div className="h-[480px] bg-background/40 sm:h-[540px]">
+            <TopoCanvas
+              model={model}
+              liveById={liveById}
+              selected={selected}
+              activeCluster={activeCluster}
+              onSelect={setSelected}
+              onClearSelect={() => setSelected(null)}
+            />
+          </div>
+        </Card>
+
+        {/* inspector */}
+        <Card className="overflow-hidden xl:sticky xl:top-4">
+          <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-3">
+            <div className="min-w-0">
+              <div className="text-[10.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                Inspector
+              </div>
+              <div className="mt-0.5 flex items-center gap-2 truncate text-[14px] font-semibold">
+                {selectedNode ? (
+                  <>
+                    <span
+                      className="h-2 w-2 shrink-0 rounded-full"
+                      style={{
+                        background: isKeeperNode(selectedNode)
+                          ? selectedNode.isLeader
+                            ? STATUS_COLOR.warn
+                            : STATUS_COLOR.healthy
+                          : STATUS_COLOR[selectedNode.status],
+                      }}
+                    />
+                    <span className="font-mono">{selectedNode.id}</span>
+                    <span className="text-[11px] font-normal text-muted-foreground">
+                      {isKeeperNode(selectedNode) ? 'Keeper' : 'ClickHouse'}
+                    </span>
+                  </>
+                ) : (
+                  <span>Cluster overview</span>
+                )}
+              </div>
+            </div>
+            {selectedNode && (
+              <button
+                type="button"
+                onClick={() => setSelected(null)}
+                className="shrink-0 text-muted-foreground hover:text-foreground"
+                aria-label="Close inspector"
+              >
+                <XIcon className="h-[15px] w-[15px]" />
+              </button>
+            )}
+          </div>
+          <div className="max-h-[560px] overflow-y-auto">
+            {!selectedNode && (
+              <ClusterOverview model={model} live={localSnapshot} />
+            )}
+            {selectedNode && !isKeeperNode(selectedNode) && (
+              <ChInspector
+                node={selectedNode}
+                model={model}
+                live={
+                  selectedNode.isLocal
+                    ? localSnapshot
+                    : { ...EMPTY_LIVE, latHist }
+                }
+              />
+            )}
+            {selectedNode && isKeeperNode(selectedNode) && (
+              <KeeperInspector
+                node={selectedNode}
+                model={model}
+                live={localSnapshot}
+              />
+            )}
+          </div>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+function TopologySkeleton() {
+  return (
+    <div className="max-w-[1640px]">
+      <div className="mb-4 flex items-center gap-2">
+        <Skeleton className="h-4 w-72" />
+      </div>
+      <div className="mb-4 flex flex-wrap gap-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-9 w-40" />
+        ))}
+      </div>
+      <div className="grid grid-cols-1 gap-3 xl:grid-cols-[1fr_360px]">
+        <Skeleton className="h-[540px] w-full rounded-xl" />
+        <Skeleton className="h-[540px] w-full rounded-xl" />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/lib/query-config/index.ts
+++ b/apps/web/lib/query-config/index.ts
@@ -55,7 +55,9 @@ import { threadAnalysisConfig } from './queries/thread-analysis'
 import { loginAttemptsConfig } from './security/login-attempts'
 // Security
 import { sessionsConfig } from './security/sessions'
+import { clusterLiveMetricsConfig } from './system/cluster-live-metrics'
 import { clustersConfig } from './system/clusters'
+import { clustersTopologyConfig } from './system/clusters-topology'
 import {
   databaseTableColumnsConfig,
   tablesListConfig,
@@ -159,6 +161,8 @@ export const queries: Array<QueryConfig> = [
 
   // System
   clustersConfig,
+  clustersTopologyConfig,
+  clusterLiveMetricsConfig,
   clustersReplicasStatusConfig,
   replicaTablesConfig,
   diskSpaceConfig,

--- a/apps/web/lib/query-config/system/cluster-live-metrics.ts
+++ b/apps/web/lib/query-config/system/cluster-live-metrics.ts
@@ -1,0 +1,63 @@
+import type { QueryConfig } from '@/types/query-config'
+
+import { QUERY_COMMENT } from '@chm/clickhouse-client/constants'
+
+/**
+ * Live resource snapshot for the CONNECTED ClickHouse node.
+ *
+ * The topology graph shows live CPU / memory / disk / active-query numbers for the
+ * node we are connected to (the `is_local` node in system.clusters). We deliberately
+ * do NOT fan out to every replica here: `clusterAllReplicas` can fail or be slow when
+ * a cluster is partially down, and the design's per-node live numbers for remote nodes
+ * were a mock. Remote nodes render their structural state (errors / active) only —
+ * never fabricated metrics.
+ *
+ * One row. Cheap. Polled on a short interval, separate from the structural query so
+ * the slow-moving topology is not refetched on every live tick.
+ */
+export type ClusterLiveMetricsRow = {
+  hostname: string
+  cpu_pct: number
+  mem_used_bytes: number
+  mem_total_bytes: number
+  disk_used_bytes: number
+  disk_total_bytes: number
+  active_queries: number
+  uptime_seconds: number
+  version: string
+}
+
+export const clusterLiveMetricsConfig: QueryConfig = {
+  name: 'cluster-live-metrics',
+  description:
+    'Live CPU / memory / disk / active-query snapshot for the connected ClickHouse node.',
+  sql: `
+    ${QUERY_COMMENT}
+    SELECT
+        hostName() AS hostname,
+        round(
+          100 * (
+            (SELECT sum(value) FROM system.asynchronous_metrics WHERE metric IN ('OSUserTimeNormalized', 'OSSystemTimeNormalized'))
+          ),
+          1
+        ) AS cpu_pct,
+        (SELECT sum(value) FROM system.metrics WHERE metric = 'MemoryTracking') AS mem_used_bytes,
+        (SELECT sum(value) FROM system.asynchronous_metrics WHERE metric = 'OSMemoryTotal') AS mem_total_bytes,
+        (SELECT sum(total_space - free_space) FROM system.disks) AS disk_used_bytes,
+        (SELECT sum(total_space) FROM system.disks) AS disk_total_bytes,
+        (SELECT count() FROM system.processes WHERE is_cancelled = 0) AS active_queries,
+        toUInt64(uptime()) AS uptime_seconds,
+        version() AS version
+  `,
+  columns: [
+    'hostname',
+    'cpu_pct',
+    'mem_used_bytes',
+    'mem_total_bytes',
+    'disk_used_bytes',
+    'disk_total_bytes',
+    'active_queries',
+    'uptime_seconds',
+    'version',
+  ],
+}

--- a/apps/web/lib/query-config/system/clusters-topology.ts
+++ b/apps/web/lib/query-config/system/clusters-topology.ts
@@ -1,0 +1,96 @@
+import type { QueryConfig } from '@/types/query-config'
+
+import { QUERY_COMMENT } from '@chm/clickhouse-client/constants'
+
+/**
+ * Per-replica view of `system.clusters` used to build the Cluster Topology graph.
+ *
+ * Unlike `clustersConfig` (which aggregates to one row per cluster), this returns
+ * one row per (cluster, shard, replica) so the UI can reconstruct the full
+ * cluster → shard → replica hierarchy and detect a single host participating in
+ * multiple clusters with a different shard/replica role each time (the overlapping
+ * virtual-cluster story in the design).
+ *
+ * This is STRUCTURAL, slow-moving data — the consuming hook caches it hard.
+ *
+ * `is_active` was added in v24.10; the versioned SQL falls back to a NULL-ish 1
+ * (treated as "unknown / assume active") on older servers.
+ */
+export type ClusterTopologyRow = {
+  cluster: string
+  shard_num: number
+  shard_weight: number
+  replica_num: number
+  host_name: string
+  host_address: string
+  port: number
+  is_local: number
+  errors_count: number
+  slowdowns_count: number
+  estimated_recovery_time: number
+  is_active: number | null
+}
+
+export const clustersTopologyConfig: QueryConfig = {
+  name: 'clusters-topology',
+  description:
+    'Per-replica rows from system.clusters for the Cluster Topology graph (one row per cluster/shard/replica).',
+  sql: [
+    {
+      since: '23.3',
+      sql: `
+        ${QUERY_COMMENT}
+        SELECT
+            cluster,
+            shard_num,
+            shard_weight,
+            replica_num,
+            host_name,
+            host_address,
+            port,
+            is_local,
+            errors_count,
+            slowdowns_count,
+            toUInt32(estimated_recovery_time) AS estimated_recovery_time,
+            CAST(NULL AS Nullable(UInt8)) AS is_active
+        FROM system.clusters
+        ORDER BY cluster ASC, shard_num ASC, replica_num ASC
+      `,
+    },
+    {
+      since: '24.10',
+      sql: `
+        ${QUERY_COMMENT}
+        SELECT
+            cluster,
+            shard_num,
+            shard_weight,
+            replica_num,
+            host_name,
+            host_address,
+            port,
+            is_local,
+            errors_count,
+            slowdowns_count,
+            toUInt32(estimated_recovery_time) AS estimated_recovery_time,
+            is_active
+        FROM system.clusters
+        ORDER BY cluster ASC, shard_num ASC, replica_num ASC
+      `,
+    },
+  ],
+  columns: [
+    'cluster',
+    'shard_num',
+    'shard_weight',
+    'replica_num',
+    'host_name',
+    'host_address',
+    'port',
+    'is_local',
+    'errors_count',
+    'slowdowns_count',
+    'estimated_recovery_time',
+    'is_active',
+  ],
+}

--- a/apps/web/menu.ts
+++ b/apps/web/menu.ts
@@ -597,10 +597,10 @@ export const menuItemsConfig: MenuItem[] = [
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/metrics',
       },
       {
-        title: 'Cluster Compare',
+        title: 'Cluster Topology',
         href: '/cluster',
         description:
-          'Side-by-side comparison of CPU, memory, and query load across all configured hosts',
+          'Interactive graph of ClickHouse + Keeper nodes, virtual-cluster hulls, replication and coordination links, with a live inspector',
         icon: GitCompareArrowsIcon,
         isNew: true,
       },


### PR DESCRIPTION
## What

Replaces the host-comparison `/cluster` page with an interactive **Cluster Topology** graph, pixel-matched to the provided design and wired to **real ClickHouse data** — aggressively cached and performant.

## Highlights

- **Real data, no mocks** (the prototype's `initLive`/`walk` random walk is gone):
  - **Structure** from `system.clusters` (one node per host across clusters → overlapping virtual-cluster hulls, per-cluster shard/replica roles). New `clusters-topology` config, versioned for `is_active` (24.10+).
  - **Keeper quorum** from `system.zookeeper_info` (reuses `keeper-info`). Degrades gracefully when Keeper is absent — page still renders, Keeper section marked unavailable.
  - **Live metrics** for the connected node (CPU / memory / disk / active queries / uptime) via a new `cluster-live-metrics` config. Remote nodes show structural state only — never fabricated metrics.

- **Design fidelity**: status strip (live-dot + quorum health + updated Ns ago + Refresh + system.clusters link), summary pills (Nodes / Keeper·leader / ClickHouse / Clusters N (physical·logical) / Active queries), legend toolbar with per-cluster filter toggles + replication/coordination/healthy/warn legend, SVG canvas (Keeper quorum triangle with leader ★ + dashed coordination links + radial rings; ClickHouse nodes with CPU rings + status dots + host/cpu/mem labels + LOCAL badge; convex-hull tinted virtual-cluster overlays; solid replication links), and a docked sticky inspector (Cluster overview / ClickHouse / Keeper). Click a node to select, click empty space to deselect.

- **Caching + performance** (data is slow-moving):
  - Structure polls on a long **60s** cached interval (high `dedupingInterval`, `keepPreviousData`); live metrics on a separate **8s** SWR key so structure is not refetched on every live tick.
  - Layout computed once via `useMemo` (deterministic positions); animations via CSS; hand-built SVG (convex hull + Catmull-Rom blobs, no graph library).
  - `/cluster` page is a thin lazy (`next/dynamic`, `ssr:false`) wrapper.

## Files

- `components/cluster-topology/` — `model.ts`, `geometry.ts`, `topo-canvas.tsx`, `inspector.tsx`, `topology-view.tsx`, `index.ts`
- `lib/query-config/system/clusters-topology.ts`, `cluster-live-metrics.ts` (auto-registered via `queries`)
- `app/(dashboard)/cluster/page.tsx` — thin wrapper
- `menu.ts` — "Cluster Compare" → "Cluster Topology"
- `app/globals.css` — `topo-live-dot` pulse keyframe

Local `tsc --noEmit` + biome pass via pre-commit hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Replaced Cluster Comparison dashboard with an interactive Cluster Topology visualization showing ClickHouse and Keeper nodes with their coordination and replication relationships.
  * Added live node metrics display including CPU, memory, disk usage, and active queries.
  * Added node inspector panels showing detailed cluster membership, keeper quorum status, and per-node diagnostics.
  * Updated menu label from "Cluster Compare" to "Cluster Topology."

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->