### PR TITLE
test: fix unit-tests CI — add getClient to agent-tool mocks

### DIFF
--- a/apps/web/lib/ai/agent/__tests__/diagnostics-tools.test.ts
+++ b/apps/web/lib/ai/agent/__tests__/diagnostics-tools.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, mock, test } from 'bun:test'
 mock.module('server-only', () => ({}))
 
 mock.module('@chm/clickhouse-client', () => ({
+  // findings-store (via the tools index) imports getClient at module-eval time.
+  getClient: async () => ({
+    command: async () => ({}),
+    insert: async () => ({}),
+    query: async () => ({ json: async () => [] }),
+  }),
   fetchData: async ({
     query,
   }: {

--- a/apps/web/lib/ai/agent/__tests__/insights-tools.test.ts
+++ b/apps/web/lib/ai/agent/__tests__/insights-tools.test.ts
@@ -10,6 +10,12 @@ import { describe, expect, mock, test } from 'bun:test'
 mock.module('server-only', () => ({}))
 
 mock.module('@chm/clickhouse-client', () => ({
+  // findings-store (via the tools index) imports getClient at module-eval time.
+  getClient: async () => ({
+    command: async () => ({}),
+    insert: async () => ({}),
+    query: async () => ({ json: async () => [] }),
+  }),
   fetchData: async ({
     query,
   }: {

--- a/apps/web/lib/ai/agent/__tests__/mcp-tool-adapter.test.ts
+++ b/apps/web/lib/ai/agent/__tests__/mcp-tool-adapter.test.ts
@@ -15,6 +15,12 @@ mock.module('server-only', () => ({}))
 
 // Mock fetchData — all tool helpers delegate to this
 mock.module('@chm/clickhouse-client', () => ({
+  // findings-store (via the tools index) imports getClient at module-eval time.
+  getClient: async () => ({
+    command: async () => ({}),
+    insert: async () => ({}),
+    query: async () => ({ json: async () => [] }),
+  }),
   fetchData: async ({
     query,
   }: {

--- a/apps/web/lib/ai/agent/tools/__tests__/shared-mocks.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/shared-mocks.ts
@@ -48,4 +48,12 @@ export const mockFetchData = mock(
 
 mock.module('@chm/clickhouse-client', () => ({
   fetchData: mockFetchData,
+  // findings-store (pulled in via the tools index) imports getClient at
+  // module-eval time. Provide it so the import resolves; no agent-tool test
+  // exercises the real write client here.
+  getClient: async () => ({
+    command: async () => ({}),
+    insert: async () => ({}),
+    query: async () => ({ json: async () => [] }),
+  }),
 }))


### PR DESCRIPTION
## Problem
The `unit-tests` job on main was red: **2811 pass · 1 fail · 1 error**.

Root cause: `lib/findings/findings-store.ts` (added in #1312) imports `getClient` from `@chm/clickhouse-client`. The findings tools are now part of the agent-tools index, so any agent-tool test that loads `../tools` evaluates findings-store. Those tests mock `@chm/clickhouse-client` with **only** `fetchData`, so bun throws `Export named 'getClient' not found` → 1 error in `mcp-tool-adapter`, and the incomplete mock leaks into `dashboard/settings` → 1 fail.

## Fix
Add a minimal `getClient` to the four agent-tool mock factories: `shared-mocks.ts`, `mcp-tool-adapter.test.ts`, `diagnostics-tools.test.ts`, `insights-tools.test.ts`.

## Verification
Full web suite locally: **2812 pass · 0 fail · 0 error**. `tsc --noEmit` clean.

Co-Authored-By: duyetbot <bot@duyet.net>