### PR TITLE
fix(cluster): address Cluster Topology review feedback

### DIFF
--- a/apps/web/components/cluster-topology/inspector.tsx
+++ b/apps/web/components/cluster-topology/inspector.tsx
@@ -175,7 +175,10 @@ function fmtUptime(seconds: number): string {
   if (!seconds || seconds <= 0) return '—'
   const d = Math.floor(seconds / 86400)
   const h = Math.floor((seconds % 86400) / 3600)
-  return d > 0 ? `${d}d ${String(h).padStart(2, '0')}h` : `${h}h`
+  const m = Math.floor((seconds % 3600) / 60)
+  if (d > 0) return `${d}d ${String(h).padStart(2, '0')}h`
+  if (h > 0) return `${h}h ${String(m).padStart(2, '0')}m`
+  return `${m}m`
 }
 
 // ── public live snapshot shape consumed by the inspector ──

--- a/apps/web/components/cluster-topology/topo-canvas.tsx
+++ b/apps/web/components/cluster-topology/topo-canvas.tsx
@@ -85,7 +85,9 @@ function ChGlyph({
       ? `cpu ${Math.round(cpu)}%${live?.memPct !== null && live?.memPct !== undefined ? ` · mem ${Math.round(live.memPct)}%` : ''}`
       : node.errors > 0
         ? `${node.errors} errors`
-        : 'remote node'
+        : node.isLocal
+          ? 'local node'
+          : 'remote node'
 
   return (
     <g

--- a/apps/web/components/cluster-topology/topology-view.tsx
+++ b/apps/web/components/cluster-topology/topology-view.tsx
@@ -136,10 +136,10 @@ export function TopologyView({ hostId }: { hostId: number }) {
     if (cpu === undefined || cpu === null) return
     const n = Number(cpu)
     if (!Number.isFinite(n)) return
-    if (lastCpuRef.current === n && cpuHist.length > 0) return
+    if (lastCpuRef.current === n) return
     lastCpuRef.current = n
     setCpuHist((prev) => [...prev.slice(-(HIST_LEN - 1)), n])
-  }, [liveRow?.cpu_pct, cpuHist.length])
+  }, [liveRow?.cpu_pct])
 
   // Keeper latency history (avg across keepers).
   const [latHist, setLatHist] = useState<number[]>([])


### PR DESCRIPTION
Follow-up to #1328 addressing the three actionable review suggestions from gemini-code-assist:

1. **topo-canvas** — the connected node now shows `local node` (not `remote node`) as the glyph subtitle while its live metrics are still loading.
2. **inspector `fmtUptime`** — now renders minutes (`Xm`, or `Hh MMm` under a day) so a recently-restarted node no longer reads `0h`.
3. **topology-view CPU-history effect** — removed `cpuHist.length` from the dependency array; the functional `setState` + `lastCpuRef` guard already dedupe, and the extra dep made the effect run twice per tick during warmup.

Local `tsc --noEmit` + biome pass via pre-commit hook.