### PR TITLE
feat(seo): add sitemap.xml and robots.txt

### DIFF
--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next'
+
+/** Generate at build time — content is static. */
+export const dynamic = 'force-static'
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://chmonitor.dev'
+  return {
+    rules: { userAgent: '*', allow: '/' },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,0 +1,102 @@
+import { menuItemsConfig } from '@/menu'
+
+import type { MetadataRoute } from 'next'
+
+import { docsNav } from './(docs)/docs/_lib/docs'
+
+/** Generate at build time — content is static. */
+export const dynamic = 'force-static'
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://chmonitor.dev'
+
+/** Pages that exist as routes but aren't in the sidebar menu. */
+const HIDDEN_PAGES = [
+  '/expensive-queries-by-memory',
+  '/projections',
+  '/top-usage-columns',
+  '/top-usage-tables',
+  '/query-cache',
+  '/common-errors',
+  '/view-refreshes',
+  '/roles',
+  '/users',
+  '/detached-parts',
+  '/queries/parallelization',
+]
+
+/** Paths that are redirect-only — skip them to avoid duplicates. */
+const REDIRECT_PATHS = new Set([
+  '/ai-chat', // → /agents
+  '/zookeeper', // → /keeper
+  '/table', // → /explorer
+  '/tables', // → /explorer
+])
+
+/** Recursively extract all non-empty hrefs from menu items. */
+function extractMenuHrefs(items: { href: string; items?: any[] }[]): string[] {
+  const hrefs: string[] = []
+  for (const item of items) {
+    if (item.href && item.href !== '/') {
+      // Strip query params for sitemap — detail views are dynamic
+      const path = item.href.split('?')[0]
+      if (path && !REDIRECT_PATHS.has(path)) {
+        hrefs.push(path)
+      }
+    }
+    if (item.items) {
+      hrefs.push(...extractMenuHrefs(item.items))
+    }
+  }
+  return hrefs
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const entries: MetadataRoute.Sitemap = []
+
+  // Home page
+  entries.push({
+    url: BASE_URL,
+    lastModified: new Date(),
+    changeFrequency: 'daily',
+    priority: 1.0,
+  })
+
+  // Docs pages (24 pages from docsNav)
+  for (const section of docsNav) {
+    for (const item of section.items) {
+      const slug = item.slug
+      const path = slug ? `/docs/${slug}` : '/docs'
+      entries.push({
+        url: `${BASE_URL}${path}`,
+        lastModified: new Date(),
+        changeFrequency: 'weekly',
+        priority: slug === '' ? 0.9 : 0.8,
+      })
+    }
+  }
+
+  // Dashboard pages from menu.ts
+  const menuHrefs = [...new Set(extractMenuHrefs(menuItemsConfig))]
+  for (const path of menuHrefs) {
+    // Skip /docs — already added from docsNav above
+    if (path === '/docs') continue
+    entries.push({
+      url: `${BASE_URL}${path}`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.7,
+    })
+  }
+
+  // Hidden utility pages
+  for (const path of HIDDEN_PAGES) {
+    entries.push({
+      url: `${BASE_URL}${path}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.5,
+    })
+  }
+
+  return entries
+}


### PR DESCRIPTION
## Summary

Add SEO infrastructure — sitemap and robots.txt generated at build time.

### `sitemap.xml` (97 URLs)
- **Docs pages (24)** — imported from `docsNav` in `docs.ts`
- **Dashboard pages (~62)** — imported from `menuItemsConfig` in `menu.ts`
- **Hidden utility pages (11)** — routes that exist but aren't in the sidebar
- **Home page** — priority 1.0

Priority tiers: `1.0` home → `0.9` docs index → `0.8` docs → `0.7` dashboard → `0.5` utility

### `robots.txt`
- Allows all crawlers
- Points to `sitemap.xml`

### Design decisions
- **`export const dynamic = 'force-static'`** on both files — content is static, generated at build time
- **Derives URLs from existing code** (`docsNav`, `menuItemsConfig`) — zero duplication, auto-updates when pages are added
- **Excludes** redirect-only pages (`/ai-chat`, `/zookeeper`, `/table`), API routes, and query-param detail views

### Verification
- `bun run build` passes (type-check included)
- Build output confirms `○ /sitemap.xml` (static pre-render)
- Verified XML content: 97 `<url>` entries with correct priorities

Co-Authored-By: duyetbot <bot@duyet.net>