### PR TITLE
feat(cluster): robust offset-hull cluster overlays for all topology shapes

### DIFF
--- a/apps/web/components/cluster-topology/__tests__/fixtures.ts
+++ b/apps/web/components/cluster-topology/__tests__/fixtures.ts
@@ -1,0 +1,149 @@
+/**
+ * Deterministic fixtures for the topology rendering matrix:
+ *   node counts {1,2,3,5,12} × cluster counts {1,2,3,5} × replicated/sharded/mixed
+ *   × keeper {0,1,3,5} × a shared-host overlap case.
+ *
+ * Pure data builders — no randomness — so geometry/layout tests stay stable.
+ */
+
+import type { ClusterTopologyRow } from '@/lib/query-config/system/clusters-topology'
+import type { KeeperInfoRow } from '../model'
+
+export function chRow(
+  partial: Partial<ClusterTopologyRow> & {
+    cluster: string
+    host_name: string
+    shard_num: number
+    replica_num: number
+  }
+): ClusterTopologyRow {
+  return {
+    shard_weight: 1,
+    internal_replication: 0,
+    host_address: '127.0.0.1',
+    port: 9000,
+    is_local: 0,
+    user: 'default',
+    default_database: 'default',
+    errors_count: 0,
+    slowdowns_count: 0,
+    estimated_recovery_time: 0,
+    database_shard_name: '',
+    database_replica_name: '',
+    is_active: null,
+    replication_lag: null,
+    recovery_time: null,
+    ...partial,
+  }
+}
+
+/** A replicated cluster: 1 shard, N replicas (one host per replica). */
+export function replicatedCluster(
+  name: string,
+  replicas: number,
+  hostPrefix = name
+): ClusterTopologyRow[] {
+  return Array.from({ length: replicas }, (_, i) =>
+    chRow({
+      cluster: name,
+      shard_num: 1,
+      replica_num: i + 1,
+      host_name: `${hostPrefix}-r${i + 1}`,
+      port: 9000,
+    })
+  )
+}
+
+/** A sharded cluster: N shards, 1 replica each. */
+export function shardedCluster(
+  name: string,
+  shards: number,
+  hostPrefix = name
+): ClusterTopologyRow[] {
+  return Array.from({ length: shards }, (_, i) =>
+    chRow({
+      cluster: name,
+      shard_num: i + 1,
+      replica_num: 1,
+      host_name: `${hostPrefix}-s${i + 1}`,
+      port: 9000,
+    })
+  )
+}
+
+/** S shards × R replicas. */
+export function mixedCluster(
+  name: string,
+  shards: number,
+  replicas: number,
+  hostPrefix = name
+): ClusterTopologyRow[] {
+  const rows: ClusterTopologyRow[] = []
+  for (let s = 1; s <= shards; s++) {
+    for (let r = 1; r <= replicas; r++) {
+      rows.push(
+        chRow({
+          cluster: name,
+          shard_num: s,
+          replica_num: r,
+          host_name: `${hostPrefix}-s${s}r${r}`,
+          port: 9000,
+        })
+      )
+    }
+  }
+  return rows
+}
+
+export function keeperRow(
+  partial: Partial<KeeperInfoRow> & { host: string }
+): KeeperInfoRow {
+  return {
+    port: 9181,
+    is_connected: 1,
+    is_leader: 0,
+    ...partial,
+  }
+}
+
+/** N keeper nodes; the first is the leader (unless N===0). */
+export function keepers(n: number): KeeperInfoRow[] {
+  return Array.from({ length: n }, (_, i) =>
+    keeperRow({
+      host: `keeper-${i + 1}`,
+      is_leader: i === 0 ? 1 : 0,
+      server_state: i === 0 ? 'leader' : 'follower',
+      avg_latency: 1.2,
+    })
+  )
+}
+
+/** Overlap case: host `shared` belongs to BOTH cluster_a and cluster_b. */
+export function overlapClusters(): ClusterTopologyRow[] {
+  return [
+    chRow({
+      cluster: 'cluster_a',
+      host_name: 'a-1',
+      shard_num: 1,
+      replica_num: 1,
+    }),
+    chRow({
+      cluster: 'cluster_a',
+      host_name: 'shared',
+      shard_num: 1,
+      replica_num: 2,
+    }),
+    chRow({
+      cluster: 'cluster_b',
+      host_name: 'shared',
+      shard_num: 1,
+      replica_num: 1,
+    }),
+    chRow({
+      cluster: 'cluster_b',
+      host_name: 'b-1',
+      shard_num: 1,
+      replica_num: 2,
+    }),
+  ]
+}

--- a/apps/web/components/cluster-topology/__tests__/geometry.test.ts
+++ b/apps/web/components/cluster-topology/__tests__/geometry.test.ts
@@ -1,0 +1,117 @@
+import {
+  type Center,
+  convexHull,
+  offsetHullArea,
+  offsetHullPath,
+} from '../geometry'
+import { describe, expect, it } from 'bun:test'
+
+const R = 40
+
+/** A path is "closed" when it ends in Z and starts with a move command. */
+function isClosedPath(d: string): boolean {
+  return /^M/.test(d.trim()) && /Z\s*$/.test(d.trim())
+}
+
+describe('offsetHullPath — degenerate shapes', () => {
+  it('0 nodes → empty path', () => {
+    expect(offsetHullPath([], R)).toBe('')
+  })
+
+  it('1 node → a closed circle path of arcs', () => {
+    const d = offsetHullPath([{ x: 100, y: 100 }], R)
+    expect(d).not.toBe('')
+    expect(isClosedPath(d)).toBe(true)
+    // a circle is two A arcs
+    expect((d.match(/A /g) ?? []).length).toBe(2)
+  })
+
+  it('2 nodes → a closed stadium/capsule (two arcs + two lines)', () => {
+    const d = offsetHullPath(
+      [
+        { x: 100, y: 100 },
+        { x: 300, y: 100 },
+      ],
+      R
+    )
+    expect(isClosedPath(d)).toBe(true)
+    expect((d.match(/A /g) ?? []).length).toBe(2)
+    expect((d.match(/L /g) ?? []).length).toBe(2)
+  })
+
+  it('all-collinear N nodes → still a single capsule (segment hull)', () => {
+    const collinear: Center[] = [0, 1, 2, 3, 4].map((i) => ({
+      x: 50 + i * 60,
+      y: 200,
+    }))
+    const d = offsetHullPath(collinear, R)
+    expect(isClosedPath(d)).toBe(true)
+    // segment hull → exactly two end caps
+    expect((d.match(/A /g) ?? []).length).toBe(2)
+  })
+
+  it('coincident nodes collapse to a single circle', () => {
+    const d = offsetHullPath(
+      [
+        { x: 100, y: 100 },
+        { x: 100, y: 100 },
+        { x: 100, y: 100 },
+      ],
+      R
+    )
+    expect((d.match(/A /g) ?? []).length).toBe(2)
+  })
+
+  it('3+ non-collinear → rounded polygon: one corner arc per hull vertex', () => {
+    const tri: Center[] = [
+      { x: 100, y: 100 },
+      { x: 300, y: 120 },
+      { x: 180, y: 320 },
+    ]
+    const d = offsetHullPath(tri, R)
+    expect(isClosedPath(d)).toBe(true)
+    const hull = convexHull(tri.map((c) => [c.x, c.y]))
+    expect((d.match(/A /g) ?? []).length).toBe(hull.length)
+  })
+
+  it('R <= 0 → empty path (nothing to draw)', () => {
+    expect(offsetHullPath([{ x: 0, y: 0 }], 0)).toBe('')
+  })
+})
+
+describe('offsetHullArea — monotonic + ordering', () => {
+  it('area grows with member spread', () => {
+    const tight = offsetHullArea(
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ],
+      R
+    )
+    const wide = offsetHullArea(
+      [
+        { x: 0, y: 0 },
+        { x: 400, y: 0 },
+      ],
+      R
+    )
+    expect(wide).toBeGreaterThan(tight)
+  })
+
+  it('single point area ≈ disk πr²', () => {
+    const a = offsetHullArea([{ x: 5, y: 5 }], R)
+    expect(a).toBeCloseTo(Math.PI * R * R, 1)
+  })
+})
+
+describe('determinism', () => {
+  it('same input → identical path string', () => {
+    const pts: Center[] = [
+      { x: 12, y: 80 },
+      { x: 200, y: 40 },
+      { x: 340, y: 220 },
+      { x: 90, y: 260 },
+    ]
+    expect(offsetHullPath(pts, R)).toBe(offsetHullPath(pts, R))
+  })
+})

--- a/apps/web/components/cluster-topology/__tests__/model.test.ts
+++ b/apps/web/components/cluster-topology/__tests__/model.test.ts
@@ -1,0 +1,146 @@
+import { buildTopologyModel, CH_RENDER_CAP, VB_H, VB_W } from '../model'
+import {
+  keepers,
+  mixedCluster,
+  overlapClusters,
+  replicatedCluster,
+  shardedCluster,
+} from './fixtures'
+import { describe, expect, it } from 'bun:test'
+
+const NODE_COUNTS = [1, 2, 3, 5, 12]
+
+describe('buildTopologyModel — cluster overlay hulls for every shape', () => {
+  for (const n of NODE_COUNTS) {
+    it(`replicated cluster with ${n} replicas → one non-empty closed hull`, () => {
+      const model = buildTopologyModel(replicatedCluster('repl', n), [])
+      const hull = model.clusterHulls.find((h) => h.id === 'repl')
+      expect(hull).toBeDefined()
+      expect(hull?.d).not.toBe('')
+      expect(hull?.d.trim().endsWith('Z')).toBe(true)
+      expect(hull?.d.trim().startsWith('M')).toBe(true)
+    })
+  }
+
+  it('sharded cluster draws NO replication edges; replicated does', () => {
+    const sharded = buildTopologyModel(shardedCluster('sh', 4), [])
+    expect(sharded.replEdges.length).toBe(0)
+
+    const repl = buildTopologyModel(replicatedCluster('rp', 3), [])
+    expect(repl.replEdges.length).toBeGreaterThan(0)
+  })
+
+  it('mixed (2 shards × 3 replicas) links replicas within each shard only', () => {
+    const model = buildTopologyModel(mixedCluster('mx', 2, 3), [])
+    // 2 shards × (3 replicas → 2 consecutive links) = 4 edges, no cross-shard links
+    expect(model.replEdges.length).toBe(4)
+  })
+})
+
+describe('z-order is area DESCENDING', () => {
+  it('larger hull is listed before smaller', () => {
+    const rows = [
+      ...shardedCluster('big', 5), // spread wide → big area
+      ...replicatedCluster('small', 2), // 2 nodes → smaller
+    ]
+    const model = buildTopologyModel(rows, [])
+    const areas = model.clusterHulls.map((h) => h.area)
+    for (let i = 1; i < areas.length; i++) {
+      expect(areas[i - 1]).toBeGreaterThanOrEqual(areas[i])
+    }
+  })
+})
+
+describe('keeper quorum hull is optional', () => {
+  for (const k of [0, 1, 3, 5]) {
+    it(`keeper count ${k}`, () => {
+      const model = buildTopologyModel(replicatedCluster('c', 3), keepers(k))
+      expect(model.keepers.length).toBe(k)
+      if (k === 0) {
+        // keeper.source === none → render NO keeper region
+        expect(model.keeperHull).toBe('')
+        expect(model.coordEdges.length).toBe(0)
+        expect(model.raftEdges.length).toBe(0)
+      } else {
+        expect(model.keeperHull).not.toBe('')
+        // generalized quorum: full mesh among keepers
+        expect(model.raftEdges.length).toBe((k * (k - 1)) / 2)
+      }
+    })
+  }
+
+  it('keeper hull degenerates: N=1 ring, N=2 capsule, N>=3 polygon', () => {
+    const one = buildTopologyModel(replicatedCluster('c', 1), keepers(1))
+    expect((one.keeperHull.match(/A /g) ?? []).length).toBe(2) // ring
+    const two = buildTopologyModel(replicatedCluster('c', 1), keepers(2))
+    expect((two.keeperHull.match(/A /g) ?? []).length).toBe(2) // capsule
+    const three = buildTopologyModel(replicatedCluster('c', 1), keepers(3))
+    expect((three.keeperHull.match(/A /g) ?? []).length).toBeGreaterThanOrEqual(
+      3
+    )
+  })
+})
+
+describe('shared nodes land between their clusters (overlap lens)', () => {
+  it('a host in 2 clusters sits between the two cluster centroids', () => {
+    const model = buildTopologyModel(overlapClusters(), [])
+    const a1 = model.nodeById['a-1']
+    const b1 = model.nodeById['b-1']
+    const shared = model.nodeById['shared']
+    expect(a1 && b1 && shared).toBeTruthy()
+    // shared host x lies between the two exclusive members' x positions
+    const lo = Math.min(a1.x, b1.x)
+    const hi = Math.max(a1.x, b1.x)
+    expect(shared.x).toBeGreaterThanOrEqual(lo - 1)
+    expect(shared.x).toBeLessThanOrEqual(hi + 1)
+    // both cluster hulls exist and (sharing a node) their paths are present
+    expect(model.clusterHulls.length).toBe(2)
+    // dedup: the shared host is ONE node, not two
+    expect(model.counts.chNodes).toBe(3)
+  })
+})
+
+describe('large N respects CH_RENDER_CAP without breaking counts', () => {
+  it('renders at most CH_RENDER_CAP glyphs but reports the true total', () => {
+    const big = shardedCluster('huge', 60)
+    const model = buildTopologyModel(big, [])
+    expect(model.counts.chNodes).toBe(60) // true count preserved
+    expect(model.chNodes.length).toBeLessThanOrEqual(CH_RENDER_CAP)
+    // every rendered node has a real position inside the viewBox
+    for (const n of model.chNodes) {
+      expect(n.x).toBeGreaterThan(0)
+      expect(n.x).toBeLessThan(VB_W)
+      expect(n.y).toBeGreaterThan(0)
+      expect(n.y).toBeLessThan(VB_H)
+    }
+  })
+})
+
+describe('determinism across rebuilds (stable for live ticks)', () => {
+  it('identical structural input → identical layout + hulls', () => {
+    const rows = [...replicatedCluster('a', 3), ...shardedCluster('b', 2)]
+    const m1 = buildTopologyModel(rows, keepers(3))
+    const m2 = buildTopologyModel(rows, keepers(3))
+    expect(m1.clusterHulls.map((h) => h.d)).toEqual(
+      m2.clusterHulls.map((h) => h.d)
+    )
+    expect(m1.chNodes.map((n) => [n.x, n.y])).toEqual(
+      m2.chNodes.map((n) => [n.x, n.y])
+    )
+    expect(m1.keeperHull).toBe(m2.keeperHull)
+  })
+})
+
+describe('cluster-count matrix {1,2,3,5}', () => {
+  for (const c of [1, 2, 3, 5]) {
+    it(`${c} logical clusters each render a hull`, () => {
+      const rows = Array.from({ length: c }, (_, i) =>
+        replicatedCluster(`cl${i}`, 2)
+      ).flat()
+      const model = buildTopologyModel(rows, [])
+      const filled = model.clusterHulls.filter((h) => !h.outline)
+      expect(filled.length).toBe(c)
+      for (const h of filled) expect(h.d).not.toBe('')
+    })
+  }
+})

--- a/apps/web/components/cluster-topology/geometry.ts
+++ b/apps/web/components/cluster-topology/geometry.ts
@@ -1,8 +1,18 @@
 /**
  * Pure geometry helpers for the topology canvas.
  *
- * Ported from the design prototype (topology.jsx) — convex hull + closed
- * Catmull-Rom spline + a rounded "blob" hull that wraps a set of node centers.
+ * The cluster overlay is an OFFSET CONVEX HULL — the Minkowski sum of the convex
+ * hull of the member node centers with a disk of radius R. One algorithm covers
+ * every cluster shape with no special-casing:
+ *
+ *   - 1 node           → hull is a point   → a CIRCLE of radius R
+ *   - 2 / all-collinear → hull is a segment → a STADIUM / CAPSULE
+ *   - 3+ non-collinear  → a rounded convex polygon (offset edges + corner arcs)
+ *
+ * Each hull EDGE is translated outward by R (parallel offset); each hull VERTEX
+ * is replaced by a circular ARC of radius R sweeping the exterior angle. The
+ * result is emitted as a single closed SVG path (L lines + A arc segments).
+ *
  * No React, no data dependencies, fully deterministic — safe to call inside
  * useMemo so layout is computed once and never on a live tick.
  */
@@ -13,10 +23,27 @@ export interface Center {
   y: number
 }
 
-/** Andrew's monotone-chain convex hull. */
+const EPS = 1e-9
+
+/** Andrew's monotone-chain convex hull. Returns CCW hull vertices.
+ *
+ * Notes:
+ *  - Deduplicates identical points so coincident centers collapse to a point.
+ *  - For < 3 unique points returns the unique points (a point or a segment).
+ */
 export function convexHull(points: Point[]): Point[] {
-  const pts = [...points].sort((a, b) => a[0] - b[0] || a[1] - b[1])
+  const seen = new Set<string>()
+  const pts: Point[] = []
+  for (const p of points) {
+    const k = `${p[0].toFixed(4)},${p[1].toFixed(4)}`
+    if (!seen.has(k)) {
+      seen.add(k)
+      pts.push(p)
+    }
+  }
+  pts.sort((a, b) => a[0] - b[0] || a[1] - b[1])
   if (pts.length < 3) return pts
+
   const cross = (o: Point, a: Point, b: Point) =>
     (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
 
@@ -43,10 +70,16 @@ export function convexHull(points: Point[]): Point[] {
   }
   lower.pop()
   upper.pop()
-  return lower.concat(upper)
+  const hull = lower.concat(upper)
+  // Collinear set can collapse to 2 endpoints — keep them as a segment.
+  if (hull.length < 2)
+    return pts.length >= 2 ? [pts[0], pts[pts.length - 1]] : pts
+  return hull
 }
 
-/** Smooth closed path through points using a Catmull-Rom → bezier conversion. */
+/** Smooth closed path through points using a Catmull-Rom → bezier conversion.
+ * Retained for any caller that wants a smooth blob through points; the cluster
+ * overlay now uses {@link offsetHullPath} instead. */
 export function catmullRomClosed(p: Point[]): string {
   const n = p.length
   if (n < 3) return ''
@@ -65,20 +98,129 @@ export function catmullRomClosed(p: Point[]): string {
   return `${d} Z`
 }
 
+const f = (n: number) => n.toFixed(1)
+
+/** Full-circle path (used when the hull degenerates to a single point). */
+function circlePath(cx: number, cy: number, r: number): string {
+  // Two half-arcs form a full circle (a single A 360° arc is undefined in SVG).
+  return (
+    `M ${f(cx - r)} ${f(cy)} ` +
+    `A ${f(r)} ${f(r)} 0 1 0 ${f(cx + r)} ${f(cy)} ` +
+    `A ${f(r)} ${f(r)} 0 1 0 ${f(cx - r)} ${f(cy)} Z`
+  )
+}
+
+/** Stadium/capsule path: the Minkowski sum of a segment a→b with a disk of r. */
+function stadiumPath(a: Point, b: Point, r: number): string {
+  const dx = b[0] - a[0]
+  const dy = b[1] - a[1]
+  const len = Math.hypot(dx, dy)
+  if (len < EPS) return circlePath(a[0], a[1], r)
+  // Unit normal (left side). The two offset lines sit ±r·n from the segment.
+  const nx = -dy / len
+  const ny = dx / len
+  const ox = nx * r
+  const oy = ny * r
+  // Walk: a+offset → b+offset, semicircle around b, b−offset → a−offset, semicircle around a.
+  const a1: Point = [a[0] + ox, a[1] + oy]
+  const b1: Point = [b[0] + ox, b[1] + oy]
+  const b2: Point = [b[0] - ox, b[1] - oy]
+  const a2: Point = [a[0] - ox, a[1] - oy]
+  // sweep=1 wraps the cap on the correct (exterior) side for this winding.
+  return (
+    `M ${f(a1[0])} ${f(a1[1])} ` +
+    `L ${f(b1[0])} ${f(b1[1])} ` +
+    `A ${f(r)} ${f(r)} 0 0 1 ${f(b2[0])} ${f(b2[1])} ` +
+    `L ${f(a2[0])} ${f(a2[1])} ` +
+    `A ${f(r)} ${f(r)} 0 0 1 ${f(a1[0])} ${f(a1[1])} Z`
+  )
+}
+
 /**
- * Rounded convex blob wrapping every member node. Works for 1, 2, 3+ nodes by
- * sampling a small ring around each center, hulling all sample points, then
- * smoothing. `pad` controls how far the blob sits outside the node centers.
+ * Offset convex hull as a single closed SVG path: the Minkowski sum of the
+ * convex hull of `centers` with a disk of radius `r`.
+ *
+ *   0 centers → '' (nothing to draw)
+ *   1 center  → circle r
+ *   2 / collinear → stadium
+ *   3+        → straight offset edges joined by r corner arcs
+ *
+ * Pure + deterministic.
+ */
+export function offsetHullPath(centers: Center[], r: number): string {
+  if (centers.length === 0 || r <= 0) return ''
+  const pts: Point[] = centers.map((c) => [c.x, c.y])
+  const hull = convexHull(pts)
+
+  if (hull.length === 1) return circlePath(hull[0][0], hull[0][1], r)
+  if (hull.length === 2) return stadiumPath(hull[0], hull[1], r)
+
+  // hull is CCW. For each vertex i, the outward-offset endpoints of its two
+  // incident edges are joined by a convex (left-turn) arc of radius r.
+  const n = hull.length
+  // Per edge i (hull[i] → hull[i+1]): outward unit normal.
+  const edgeNormal: Point[] = []
+  for (let i = 0; i < n; i++) {
+    const a = hull[i]
+    const b = hull[(i + 1) % n]
+    const dx = b[0] - a[0]
+    const dy = b[1] - a[1]
+    const len = Math.hypot(dx, dy) || 1
+    // For a CCW polygon the outward normal is (dy, -dx)/len.
+    edgeNormal.push([dy / len, -dx / len])
+  }
+
+  // Offset endpoints. For vertex v shared by edge (v-1 → v) and (v → v+1):
+  //   arrival point  = v + r * normal(edge ending at v)   = edge (i-1)
+  //   departure point= v + r * normal(edge starting at v) = edge (i)
+  let d = ''
+  for (let i = 0; i < n; i++) {
+    const v = hull[i]
+    const nPrev = edgeNormal[(i - 1 + n) % n]
+    const nNext = edgeNormal[i]
+    const arrive: Point = [v[0] + r * nPrev[0], v[1] + r * nPrev[1]]
+    const depart: Point = [v[0] + r * nNext[0], v[1] + r * nNext[1]]
+    if (i === 0) {
+      d += `M ${f(arrive[0])} ${f(arrive[1])} `
+    } else {
+      d += `L ${f(arrive[0])} ${f(arrive[1])} `
+    }
+    // Corner arc from arrive→depart, radius r, sweeping the exterior (CCW → sweep 1).
+    d += `A ${f(r)} ${f(r)} 0 0 1 ${f(depart[0])} ${f(depart[1])} `
+  }
+  return `${d}Z`
+}
+
+/** Signed-area-based polygon area of the convex hull of `centers` PLUS the
+ * offset band, used to z-order overlapping blobs (largest drawn first/behind).
+ * Deterministic; approximate (good enough for ordering). */
+export function offsetHullArea(centers: Center[], r: number): number {
+  if (centers.length === 0) return 0
+  const hull = convexHull(centers.map((c) => [c.x, c.y] as Point))
+  if (hull.length === 1) return Math.PI * r * r
+  if (hull.length === 2) {
+    const len = Math.hypot(hull[1][0] - hull[0][0], hull[1][1] - hull[0][1])
+    // stadium = rectangle (len × 2r) + circle (πr²)
+    return len * 2 * r + Math.PI * r * r
+  }
+  // polygon area (shoelace) + perimeter*r + πr² (exact Minkowski area)
+  let area2 = 0
+  let perim = 0
+  const n = hull.length
+  for (let i = 0; i < n; i++) {
+    const a = hull[i]
+    const b = hull[(i + 1) % n]
+    area2 += a[0] * b[1] - b[0] * a[1]
+    perim += Math.hypot(b[0] - a[0], b[1] - a[1])
+  }
+  return Math.abs(area2) / 2 + perim * r + Math.PI * r * r
+}
+
+/**
+ * Rounded convex blob (legacy ring-sampled smooth hull). Retained so existing
+ * callers keep working; new code should prefer {@link offsetHullPath} which is
+ * exact and handles 1/2-node degeneracies cleanly.
  */
 export function hullPath(centers: Center[], pad: number): string {
-  if (centers.length === 0) return ''
-  const ring: Point[] = []
-  const N = 20
-  centers.forEach((c) => {
-    for (let i = 0; i < N; i++) {
-      const a = (i / N) * Math.PI * 2
-      ring.push([c.x + Math.cos(a) * pad, c.y + Math.sin(a) * pad])
-    }
-  })
-  return catmullRomClosed(convexHull(ring))
+  return offsetHullPath(centers, pad)
 }

--- a/apps/web/components/cluster-topology/model.ts
+++ b/apps/web/components/cluster-topology/model.ts
@@ -25,7 +25,7 @@
 
 import type { ClusterTopologyRow } from '@/lib/query-config/system/clusters-topology'
 
-import { hullPath } from './geometry'
+import { offsetHullArea, offsetHullPath } from './geometry'
 
 export interface NodeLiveMetrics {
   cpuPct: number | null
@@ -100,6 +100,28 @@ export interface ClusterInfo {
   /** rendered as a dotted outline (physical default cluster) instead of a filled hull */
   outline: boolean
   nodeCount: number
+  /** true when any shard has >1 replica → draw replication edges between replicas. */
+  replicated: boolean
+}
+
+/**
+ * Precomputed cluster overlay: an offset-convex-hull path plus the metadata the
+ * canvas needs to draw it (color, border style, area for z-ordering, label
+ * anchor). Pure function of structure + layout → stable across live ticks.
+ */
+export interface ClusterHull {
+  id: string
+  name: string
+  color: string
+  /** physical cluster → dotted outline (no fill); logical/virtual → dashed border + fill. */
+  outline: boolean
+  /** the single closed SVG path (circle / stadium / rounded polygon). */
+  d: string
+  /** Minkowski-sum area, used to z-order: largest drawn first (behind). */
+  area: number
+  /** label anchor near the blob's top edge. */
+  labelX: number
+  labelY: number
 }
 
 export type KeeperSource = 'keeper' | 'zookeeper' | 'none'
@@ -143,6 +165,8 @@ export interface TopologyData {
 export interface TopologyModel extends TopologyData {
   nodeById: Record<string, KeeperNode | ChNode>
   clusterById: Record<string, ClusterInfo>
+  /** cluster overlays, sorted by area DESCENDING (largest first / behind). */
+  clusterHulls: ClusterHull[]
   keeperHull: string
   /** mirror of keeper.leaderId for existing consumers */
   leaderId: string | null
@@ -160,10 +184,15 @@ export function isKeeperNode(n: KeeperNode | ChNode): n is KeeperNode {
 export const VB_W = 770
 export const VB_H = 560
 const CH_R = 33
+const KP_R = 27
 
 // Cap CH nodes drawn on the canvas so large clusters stay readable. The full
 // structural truth is preserved in meta.counts / meta.hiddenChNodes.
 export const CH_RENDER_CAP = 24
+
+/** Hull padding: comfortably clears a node glyph ring + its label allowance. */
+const CH_HULL_PAD = CH_R + 18
+const KP_HULL_PAD = KP_R + 16
 
 export const STATUS_COLOR: Record<string, string> = {
   healthy: '#10b981',
@@ -468,6 +497,7 @@ export function assembleTopology(
       members,
       outline: physical,
       nodeCount: Object.keys(members).length,
+      replicated: maxR > 1,
     }
   })
 
@@ -572,10 +602,12 @@ export function assembleTopology(
     leaderId && keepers.length > 0
       ? chNodes.map((n) => [n.id, leaderId] as [string, string])
       : []
-  // Replication: within each shard of each cluster, link consecutive replicas.
+  // Replication: only for REPLICATED clusters. Within each shard, link
+  // consecutive replicas. Sharded/distributed clusters get no inter-shard edges.
   const replSet = new Set<string>()
   const replEdges: [string, string][] = []
   for (const c of clusters) {
+    if (!c.replicated) continue
     const byShard = new Map<number, string[]>()
     for (const [id, role] of Object.entries(c.members)) {
       if (!byShard.has(role.s)) byShard.set(role.s, [])
@@ -651,7 +683,7 @@ export function layoutTopology(data: TopologyData): TopologyModel {
   const renderCh = chNodes.map((n) => ({ ...n }))
 
   layoutKeepers(keepers)
-  layoutChNodes(renderCh)
+  layoutChNodes(renderCh, data.clusters)
 
   const nodeById: Record<string, KeeperNode | ChNode> = {}
   keepers.forEach((k) => {
@@ -665,7 +697,16 @@ export function layoutTopology(data: TopologyData): TopologyModel {
     clusterById[c.id] = c
   })
 
-  const keeperHull = keepers.length >= 2 ? hullPath(keepers, 46) : ''
+  const renderedIds = new Set(renderCh.map((n) => n.id))
+
+  // Cluster overlays: offset convex hulls, z-ordered by area DESC, label-nudged.
+  const clusterHulls = buildClusterHulls(data.clusters, nodeById, renderedIds)
+
+  // Keeper quorum hull over VOTING keepers (observers excluded). Generalized to
+  // any N: N=1 ring, N=2 capsule, N≥3 rounded polygon. Absent keeper → ''.
+  const voters = keepers.filter((k) => k.role !== 'observer')
+  const keeperHull =
+    voters.length >= 1 ? offsetHullPath(voters, KP_HULL_PAD) : ''
 
   return {
     ...data,
@@ -676,6 +717,7 @@ export function layoutTopology(data: TopologyData): TopologyModel {
     raftEdges: data.raftEdges,
     replEdges: data.replEdges,
     coordEdges: data.coordEdges,
+    clusterHulls,
     keeperHull,
     leaderId: data.keeper.leaderId,
     quorumHealthy: data.keeper.quorumHealthy,
@@ -732,46 +774,203 @@ function layoutKeepers(keepers: KeeperNode[]) {
   })
 }
 
+// CH region: a band below the keepers. Layout is deterministic + seeded only by
+// structure so positions are stable across live ticks.
+const CH_BAND_Y = 380
+const CH_BAND_H = 150
+const CH_MARGIN = CH_R + 50
+
 /**
- * ClickHouse nodes: a centered grid below the keepers. A single row reads best
- * for small N; for larger N we wrap into rows so a wide cluster does not collide
- * within the fixed viewBox.
+ * ClickHouse node layout that makes overlapping clusters legible:
+ *  - group nodes by which DRAWABLE (logical/virtual) clusters they belong to;
+ *  - give each logical cluster a centroid slot along a horizontal band;
+ *  - place a node at the AVERAGE of its clusters' centroids, so a host shared by
+ *    two clusters lands on the boundary between them → their hulls intersect in
+ *    a small intentional lens (the ch-03 story);
+ *  - spread nodes inside the same group on a compact grid so glyphs don't stack.
+ *
+ * Falls back to the simple centered arc / multi-row grid when there are no
+ * logical clusters (e.g. only the implicit `default` cluster).
  */
-function layoutChNodes(nodes: ChNode[]) {
+function layoutChNodes(nodes: ChNode[], clusters: ClusterInfo[]) {
   const n = nodes.length
   if (n === 0) return
   const cx = VB_W / 2
-  const baseY = 400
   if (n === 1) {
     nodes[0].x = cx
-    nodes[0].y = baseY
+    nodes[0].y = CH_BAND_Y + CH_BAND_H / 2
     return
   }
-  const usable = VB_W - 2 * (CH_R + 60)
-  // How many fit on a row before they crowd (min ~120px center spacing).
-  const perRow = Math.max(2, Math.min(n, Math.floor(usable / 120) + 1))
-  if (n <= perRow) {
-    const step = Math.min(170, usable / (n - 1))
+
+  // Drawable clusters = logical/virtual (filled hulls). Physical/outline clusters
+  // span everything, so they don't drive grouping.
+  const ids = new Set(nodes.map((nd) => nd.id))
+  const logical = clusters
+    .filter((c) => !c.outline)
+    .filter((c) => Object.keys(c.members).some((id) => ids.has(id)))
+
+  if (logical.length === 0) {
+    layoutArc(nodes, cx)
+    return
+  }
+
+  // Centroid slot per logical cluster, evenly spread along the band.
+  const slotY = CH_BAND_Y + CH_BAND_H / 2
+  const usable = VB_W - 2 * CH_MARGIN
+  const centroid = new Map<string, { x: number; y: number }>()
+  logical.forEach((c, i) => {
+    const t = logical.length === 1 ? 0.5 : i / (logical.length - 1)
+    centroid.set(c.id, { x: CH_MARGIN + t * usable, y: slotY })
+  })
+
+  // Membership of each node among logical clusters (deterministic order).
+  const memberClusters = (id: string) =>
+    logical.filter((c) => c.members[id]).map((c) => c.id)
+
+  // Group nodes by membership signature; place the whole group near the average
+  // of its clusters' centroids (boundary for shared nodes), then fan out.
+  const groups = new Map<string, ChNode[]>()
+  for (const nd of nodes) {
+    const mc = memberClusters(nd.id)
+    const sig = mc.length ? mc.join('|') : '__none__'
+    if (!groups.has(sig)) groups.set(sig, [])
+    groups.get(sig)!.push(nd)
+  }
+
+  // Stable group order: by signature string.
+  const sigOrder = [...groups.keys()].sort()
+  for (const sig of sigOrder) {
+    const members = groups.get(sig)!
+    const mc = sig === '__none__' ? [] : sig.split('|')
+    let gx = cx
+    let gy = slotY
+    if (mc.length > 0) {
+      gx = mc.reduce((s, id) => s + (centroid.get(id)?.x ?? cx), 0) / mc.length
+      gy =
+        mc.reduce((s, id) => s + (centroid.get(id)?.y ?? slotY), 0) / mc.length
+      // Shared nodes (≥2 clusters) sit slightly higher so the lens reads cleanly.
+      if (mc.length >= 2) gy -= 30
+    }
+    fanOut(members, gx, gy)
+  }
+
+  clampToBand(nodes)
+}
+
+/** Spread `members` on a compact centered grid around (gx, gy). Deterministic.
+ * Row/col steps shrink for large groups so the grid stays inside the band. */
+function fanOut(members: ChNode[], gx: number, gy: number) {
+  const k = members.length
+  if (k === 1) {
+    members[0].x = gx
+    members[0].y = gy
+    return
+  }
+  const cols = Math.ceil(Math.sqrt(k))
+  const rows = Math.ceil(k / cols)
+  const stepY = Math.min(96, rows > 1 ? CH_BAND_H / (rows - 1) : 96)
+  const stepX = Math.min(88, Math.max(60, stepY))
+  members.forEach((nd, i) => {
+    const row = Math.floor(i / cols)
+    const col = i % cols
+    const rowCount = Math.min(cols, k - row * cols)
+    const rowOffset = ((rowCount - 1) * stepX) / 2
+    nd.x = gx - rowOffset + col * stepX
+    nd.y = gy + row * stepY - ((rows - 1) * stepY) / 2
+  })
+}
+
+/** Simple centered arc / multi-row grid (no logical clusters). Rows are packed
+ * into the readable band so even a capped-large N stays inside the viewBox. */
+function layoutArc(nodes: ChNode[], cx: number) {
+  const n = nodes.length
+  const usable = VB_W - 2 * CH_MARGIN
+  const perRow = Math.min(n, Math.max(1, Math.floor(usable / 150) + 1))
+  const rows = Math.ceil(n / perRow)
+  if (rows <= 1) {
+    const baseY = CH_BAND_Y + CH_BAND_H / 2
+    const step = n > 1 ? Math.min(170, usable / (n - 1)) : 0
     const total = (n - 1) * step
     nodes.forEach((node, i) => {
       node.x = cx - total / 2 + i * step
-      // Gentle arc: middle nodes dip slightly so replication links stay readable.
-      const t = (i / (n - 1)) * 2 - 1
+      const t = n > 1 ? (i / (n - 1)) * 2 - 1 : 0
       node.y = baseY + Math.round((1 - t * t) * 24)
     })
     return
   }
-  // Multi-row grid.
-  const rows = Math.ceil(n / perRow)
-  const rowGap = 96
-  const startY = baseY - ((rows - 1) * rowGap) / 2
+  const rowStep = Math.min(110, CH_BAND_H / Math.max(1, rows - 1))
+  const top = CH_BAND_Y
   nodes.forEach((node, i) => {
     const row = Math.floor(i / perRow)
-    const inRow = Math.min(perRow, n - row * perRow)
     const col = i % perRow
+    const inRow = Math.min(perRow, n - row * perRow)
     const step = inRow > 1 ? Math.min(150, usable / (inRow - 1)) : 0
     const total = (inRow - 1) * step
     node.x = cx - total / 2 + col * step
-    node.y = startY + row * rowGap
+    node.y = top + row * rowStep
   })
+}
+
+/** Keep nodes inside the readable band + horizontal margins. */
+function clampToBand(nodes: ChNode[]) {
+  for (const nd of nodes) {
+    nd.x = Math.max(CH_MARGIN, Math.min(VB_W - CH_MARGIN, nd.x))
+    nd.y = Math.max(CH_BAND_Y - 10, Math.min(CH_BAND_Y + CH_BAND_H, nd.y))
+  }
+}
+
+/**
+ * Build the cluster overlay paths from rendered member positions. Pure: depends
+ * only on structure + layout, not live metrics. Sorted by area DESCENDING so the
+ * canvas draws the largest blob first (behind) and smaller ones on top.
+ */
+function buildClusterHulls(
+  clusters: ClusterInfo[],
+  nodeById: Record<string, KeeperNode | ChNode>,
+  renderedIds: Set<string>
+): ClusterHull[] {
+  const hulls: ClusterHull[] = []
+  for (const cl of clusters) {
+    const centers = Object.keys(cl.members)
+      .filter((id) => renderedIds.has(id))
+      .map((id) => nodeById[id])
+      .filter(Boolean)
+    if (centers.length === 0) continue
+    const d = offsetHullPath(centers, CH_HULL_PAD)
+    if (!d) continue
+    const area = offsetHullArea(centers, CH_HULL_PAD)
+    const minY = Math.min(...centers.map((c) => c.y))
+    const labelX = centers.reduce((s, c) => s + c.x, 0) / centers.length
+    hulls.push({
+      id: cl.id,
+      name: cl.name,
+      color: cl.color,
+      outline: cl.outline,
+      d,
+      area,
+      labelX,
+      labelY: minY - CH_HULL_PAD - 6,
+    })
+  }
+  // Largest first (drawn behind). Tie-break by id for determinism.
+  hulls.sort((a, b) => b.area - a.area || a.id.localeCompare(b.id))
+  nudgeLabels(hulls)
+  return hulls
+}
+
+/** Push overlapping cluster labels apart so they stay readable. Deterministic. */
+function nudgeLabels(hulls: ClusterHull[]) {
+  const sorted = [...hulls].sort(
+    (a, b) => a.labelX - b.labelX || a.id.localeCompare(b.id)
+  )
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = sorted[i - 1]
+    const cur = sorted[i]
+    if (
+      Math.abs(cur.labelX - prev.labelX) < 70 &&
+      Math.abs(cur.labelY - prev.labelY) < 16
+    ) {
+      cur.labelY = prev.labelY - 16
+    }
+  }
 }

--- a/apps/web/components/cluster-topology/topo-canvas.tsx
+++ b/apps/web/components/cluster-topology/topo-canvas.tsx
@@ -2,9 +2,7 @@
 
 import type { ChNode, KeeperNode, TopologyModel } from './model'
 
-import { hullPath } from './geometry'
 import { STATUS_COLOR, VB_H, VB_W } from './model'
-import { useMemo } from 'react'
 
 const CH_R = 33
 const KP_R = 27
@@ -313,36 +311,14 @@ export function TopoCanvas({
   const {
     keepers,
     chNodes,
-    clusters,
     nodeById,
     clusterById,
     raftEdges,
     replEdges,
     coordEdges,
+    clusterHulls,
     keeperHull,
   } = model
-
-  // Hull paths are pure geometry over structural positions → memoize once.
-  const logicalHulls = useMemo(
-    () =>
-      clusters.map((cl) => {
-        const centers = Object.keys(cl.members)
-          .map((id) => nodeById[id])
-          .filter(Boolean)
-        const minY = centers.length ? Math.min(...centers.map((c) => c.y)) : 0
-        const cx = centers.length
-          ? centers.reduce((s, c) => s + c.x, 0) / centers.length
-          : 0
-        const pad = 50
-        return {
-          cl,
-          d: hullPath(centers, pad),
-          tagX: cx,
-          tagY: minY - pad - 6,
-        }
-      }),
-    [clusters, nodeById]
-  )
 
   const edge = (a: string, b: string) => {
     const na = nodeById[a]
@@ -411,22 +387,25 @@ export function TopoCanvas({
         </g>
       )}
 
-      {/* logical / physical cluster hulls */}
-      {logicalHulls.map(({ cl, d, tagX, tagY }) => {
-        const active = activeCluster === cl.id
+      {/* cluster overlays — offset convex hulls, z-ordered area DESC (largest
+          behind). Translucent fills blend via mix-blend-mode so a host shared by
+          two clusters shows a distinct lens, not last-one-wins opaque. Dotted
+          outline = physical/default cluster; dashed border = logical/virtual. */}
+      {clusterHulls.map((h) => {
+        const active = activeCluster === h.id
         const faded = activeCluster && !active
-        if (!d) return null
-        if (cl.outline) {
+        if (h.outline) {
+          // physical / default cluster: dotted outline, no fill
           return (
             <g
-              key={cl.id}
+              key={h.id}
               opacity={faded ? 0.25 : 1}
               style={{ transition: 'opacity .25s' }}
             >
               <path
-                d={d}
+                d={h.d}
                 fill="none"
-                stroke={cl.color}
+                stroke={h.color}
                 strokeOpacity={active ? 0.9 : 0.5}
                 strokeWidth={active ? 2 : 1.4}
                 strokeDasharray="2 5"
@@ -437,30 +416,37 @@ export function TopoCanvas({
         }
         return (
           <g
-            key={cl.id}
+            key={h.id}
             opacity={faded ? 0.22 : 1}
             style={{ transition: 'opacity .25s' }}
           >
             <path
-              d={d}
-              fill={cl.color}
-              fillOpacity={active ? 0.2 : 0.12}
-              stroke={cl.color}
-              strokeOpacity={active ? 0.9 : 0.45}
-              strokeWidth={active ? 2 : 1.3}
+              d={h.d}
+              fill={h.color}
+              fillOpacity={active ? 0.16 : 0.1}
+              className="[mix-blend-mode:multiply] dark:[mix-blend-mode:screen]"
+            />
+            <path
+              d={h.d}
+              fill="none"
+              stroke={h.color}
+              strokeOpacity={active ? 0.9 : 0.5}
+              strokeWidth={active ? 2 : 1.4}
+              strokeDasharray="7 5"
+              strokeLinecap="round"
             />
             <text
-              x={tagX}
-              y={tagY}
+              x={h.labelX}
+              y={h.labelY}
               textAnchor="middle"
               fontSize="11.5"
               fontWeight="700"
-              fill={cl.color}
+              fill={h.color}
               opacity={active ? 1 : 0.85}
               className="font-mono"
               style={{ letterSpacing: '0.02em' }}
             >
-              {cl.name}
+              {h.name}
             </text>
           </g>
         )


### PR DESCRIPTION
## What

Make the Cluster Topology cluster overlays robust + beautiful for **every** cluster shape, with no degenerate cases.

### Offset convex hull (Minkowski sum)
Replaces the ring-sampled convex hull + Catmull-Rom blob with an **offset convex hull**: the convex hull of the member-node centers, offset outward by R (each edge translated parallel by R, each vertex replaced by a corner arc of radius R). One algorithm, no special-casing:

- **1 node** → a circle of radius R
- **2 nodes / all-collinear** → a stadium/capsule
- **3+ non-collinear** → a rounded convex polygon

Emitted as a single closed SVG path (lines + `A` arcs). Pure, deterministic, side-effect-free → stable across live ticks inside `useMemo`.

### Overlap (a host in >1 cluster)
Translucent fills (~0.1 alpha) with `mix-blend-mode: multiply` (light) / `screen` (dark) so the shared region reads as a distinct **lens**, not last-one-wins opaque. Blobs are **z-ordered by area descending** (largest behind). Border style distinguishes physical (solid-ish) vs logical/virtual (dashed) clusters.

### Layout
CH nodes are grouped by their logical-cluster membership; a host shared by two clusters lands **between** those clusters' centroids so their hulls intersect in a small intentional lens (the ch-03 story). Multi-row grid + `CH_RENDER_CAP` keep large N readable inside the viewBox; counts still report true totals.

### Cluster kinds / Keeper
- Replication edges only for **replicated** clusters; sharded/distributed get none.
- Keeper quorum hull generalized to any N: **N=1 ring, N=2 capsule, N≥3 polygon**; **no keepers → no keeper region** (reclaimed space).

### Verify — fixtures matrix
New `bun:test` suites for the pure geometry + model functions cover node counts {1,2,3,5,12}, cluster counts {1,2,3,5}, replicated/sharded/mixed, keeper {0,1,3,5}, and a shared-host overlap case. Assert: hull path non-empty + closed for 1/2/3/N; z-order area-descending; no-keeper → empty keeper hull; shared node lands between its clusters; large N respects the cap and stays in-viewBox; identical structural input → identical layout (live-tick stable).

Does not regress the #1328/#1331 real-data wiring (API wire shape, 60s SWR, layout determinism, edges).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Cluster topology boundaries now display with greater precision and visual clarity
  * Node positioning enhanced for improved readability in complex cluster layouts
  * Better visual handling of nodes shared between multiple clusters
  * Rendering accuracy and consistency improvements across all topology views

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->