### PR TITLE
refactor(cluster): merge topology into /clusters page

### DIFF
--- a/apps/web/app/(dashboard)/cluster/page.tsx
+++ b/apps/web/app/(dashboard)/cluster/page.tsx
@@ -1,46 +1,16 @@
 'use client'
 
-import dynamic from 'next/dynamic'
-import { Suspense } from 'react'
-import { Skeleton } from '@/components/ui/skeleton'
-import { useHostId } from '@/lib/swr'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect } from 'react'
 
-// The topology view hand-builds a large SVG graph; lazy-load it so the page
-// shell paints immediately and the canvas code is split into its own chunk.
-const TopologyView = dynamic(
-  () => import('@/components/cluster-topology').then((m) => m.TopologyView),
-  {
-    ssr: false,
-    loading: () => <PageSkeleton />,
-  }
-)
+/** Redirect /cluster → /clusters (topology + table merged into one page) */
+export default function ClusterRedirectPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
 
-function PageSkeleton() {
-  return (
-    <div className="max-w-[1640px]">
-      <Skeleton className="mb-4 h-4 w-72" />
-      <div className="mb-4 flex flex-wrap gap-2">
-        {Array.from({ length: 5 }).map((_, i) => (
-          <Skeleton key={i} className="h-9 w-40" />
-        ))}
-      </div>
-      <div className="grid grid-cols-1 gap-3 xl:grid-cols-[1fr_360px]">
-        <Skeleton className="h-[540px] w-full rounded-xl" />
-        <Skeleton className="h-[540px] w-full rounded-xl" />
-      </div>
-    </div>
-  )
-}
+  useEffect(() => {
+    router.replace(`/clusters?${searchParams.toString()}`)
+  }, [router, searchParams])
 
-function ClusterTopologyContent() {
-  const hostId = useHostId()
-  return <TopologyView hostId={hostId} />
-}
-
-export default function ClusterTopologyPage() {
-  return (
-    <Suspense fallback={<PageSkeleton />}>
-      <ClusterTopologyContent />
-    </Suspense>
-  )
+  return null
 }

--- a/apps/web/app/(dashboard)/clusters/page.tsx
+++ b/apps/web/app/(dashboard)/clusters/page.tsx
@@ -1,18 +1,49 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { Suspense } from 'react'
 import { TableSkeleton } from '@/components/skeletons'
 import { TableClient } from '@/components/tables/table-client'
+import { Skeleton } from '@/components/ui/skeleton'
 import { queryConfig } from '@/lib/api/clusters-api'
+import { useHostId } from '@/lib/swr'
+
+// Lazy-load the topology SVG — it's a large chunk and must not SSR.
+const TopologyView = dynamic(
+  () => import('@/components/cluster-topology').then((m) => m.TopologyView),
+  {
+    ssr: false,
+    loading: () => <TopologySkeleton />,
+  }
+)
+
+function TopologySkeleton() {
+  return (
+    <div className="grid grid-cols-1 gap-3 xl:grid-cols-[1fr_360px]">
+      <Skeleton className="h-[540px] w-full rounded-xl" />
+      <Skeleton className="h-[540px] w-full rounded-xl" />
+    </div>
+  )
+}
 
 export default function ClustersPage() {
+  const hostId = useHostId()
+
   return (
-    <Suspense fallback={<TableSkeleton />}>
-      <TableClient
-        title={queryConfig.name}
-        description={queryConfig.description}
-        queryConfig={queryConfig}
-      />
-    </Suspense>
+    <div className="flex flex-col gap-6">
+      {/* Section 1: Cluster Topology visualization */}
+      <Suspense fallback={<TopologySkeleton />}>
+        <TopologyView hostId={hostId} />
+      </Suspense>
+
+      {/* Section 2: Raw clusters table from system.clusters */}
+      <Suspense fallback={<TableSkeleton />}>
+        <TableClient
+          title={queryConfig.name}
+          description={queryConfig.description}
+          queryConfig={queryConfig}
+        />
+      </Suspense>
+    </div>
   )
 }

--- a/apps/web/lib/ai/agent-models.test.ts
+++ b/apps/web/lib/ai/agent-models.test.ts
@@ -89,7 +89,8 @@ describe('parseExtraModels', () => {
   })
 
   test('parses a single entry with all fields', () => {
-    process.env.LLM_EXTRA_MODELS = 'nvidia:meta/llama-3.3-70b|131072|Llama 3.3 70B'
+    process.env.LLM_EXTRA_MODELS =
+      'nvidia:meta/llama-3.3-70b|131072|Llama 3.3 70B'
     const result = parseExtraModels()
     expect(result).toHaveLength(1)
     expect(result[0]).toEqual({
@@ -145,13 +146,15 @@ describe('parseExtraModels', () => {
   })
 
   test('skips entries with non-numeric contextLength', () => {
-    process.env.LLM_EXTRA_MODELS = 'openrouter:some/model|notanumber|Description'
+    process.env.LLM_EXTRA_MODELS =
+      'openrouter:some/model|notanumber|Description'
     const result = parseExtraModels()
     expect(result).toHaveLength(0)
   })
 
   test('skips entries with zero or negative contextLength', () => {
-    process.env.LLM_EXTRA_MODELS = 'openrouter:some/model|0,openrouter:other/model|-1024'
+    process.env.LLM_EXTRA_MODELS =
+      'openrouter:some/model|0,openrouter:other/model|-1024'
     const result = parseExtraModels()
     expect(result).toHaveLength(0)
   })
@@ -202,7 +205,8 @@ describe('getModelRegistry', () => {
 
   test('built-in entry wins when extra has the same provider:id key', () => {
     // openrouter:openrouter/free already exists in MODEL_REGISTRY
-    process.env.LLM_EXTRA_MODELS = 'openrouter:openrouter/free|999|My Custom Free'
+    process.env.LLM_EXTRA_MODELS =
+      'openrouter:openrouter/free|999|My Custom Free'
     const registry = getModelRegistry()
     const freeEntries = registry.filter((r) => r.id === 'openrouter/free')
     // Should only have one entry with that id (from registry)

--- a/apps/web/lib/ai/agent/__tests__/message-metadata.test.ts
+++ b/apps/web/lib/ai/agent/__tests__/message-metadata.test.ts
@@ -304,9 +304,7 @@ describe('extractMessageUsage — resolvedModel field', () => {
     const message = {
       id: 'msg-meta-resolved',
       role: 'assistant' as const,
-      parts: [
-        makeUsagePart({ resolvedModel: 'google/gemma-4-26b-it' }),
-      ],
+      parts: [makeUsagePart({ resolvedModel: 'google/gemma-4-26b-it' })],
     }
     const metadata = getAgentMessageMetadata({ message })
     expect(metadata.usage?.resolvedModel).toBe('google/gemma-4-26b-it')

--- a/apps/web/menu.ts
+++ b/apps/web/menu.ts
@@ -583,7 +583,7 @@ export const menuItemsConfig: MenuItem[] = [
       {
         title: 'Clusters',
         href: '/clusters',
-        description: 'Cluster configuration and member information',
+        description: 'Interactive topology map and cluster member information',
         countKey: 'clusters',
         countLabel: 'clusters',
         icon: UngroupIcon,
@@ -595,14 +595,6 @@ export const menuItemsConfig: MenuItem[] = [
         description: 'Client and inter-server connection metrics',
         icon: UnplugIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/metrics',
-      },
-      {
-        title: 'Cluster Topology',
-        href: '/cluster',
-        description:
-          'Interactive graph of ClickHouse + Keeper nodes, virtual-cluster hulls, replication and coordination links, with a live inspector',
-        icon: GitCompareArrowsIcon,
-        isNew: true,
       },
     ],
   },


### PR DESCRIPTION
## Summary

Merges the Cluster Topology visualization into the existing /clusters page, so users get both the interactive topology map AND the raw system.clusters table on one page.

### Changes
- **`/clusters/page.tsx`**: Added the lazy-loaded `TopologyView` above the existing table. Topology stays split into its own chunk via `dynamic(ssr: false)`.
- **`/cluster/page.tsx`**: Replaced with a client-side redirect to `/clusters` (preserves query params like `?host=0`). Any bookmarked `/cluster?host=0` links will seamlessly redirect.
- **`menu.ts`**: Removed the "Cluster Topology" entry. "Clusters" is now the single entry point with updated description.

### Before
- `/clusters` → table only
- `/cluster` → topology only (separate menu entry)

### After  
- `/clusters` → topology visualization + table below
- `/cluster` → redirects to `/clusters`

Co-Authored-By: duyetbot <bot@duyet.net>