### PR TITLE
fix(query-tables): deduplicate shared components and fix filter/sort bugs

### DIFF
--- a/apps/web/components/expensive-queries/expensive-queries-table.tsx
+++ b/apps/web/components/expensive-queries/expensive-queries-table.tsx
@@ -3,7 +3,6 @@
 import {
   ChevronDown,
   ChevronRight,
-  ChevronUp,
   Clock,
   Code2,
   Cpu,
@@ -24,6 +23,9 @@ import {
 
 import { memo, useCallback, useMemo, useState } from 'react'
 import { DialogSQL } from '@/components/dialogs/dialog-sql'
+import { DetailField } from '@/components/query-tables/detail-field'
+import { formatDuration } from '@/components/query-tables/format-duration'
+import { SortableHeader } from '@/components/query-tables/sortable-header'
 import { AppLink as Link } from '@/components/ui/app-link'
 import { Button } from '@/components/ui/button'
 import {
@@ -115,14 +117,8 @@ function num(value: unknown): number {
   return Number.isFinite(n) ? n : 0
 }
 
-/** Compact a seconds value as a `{value, unit}` pair, e.g. `28.1 s`. */
-function formatSecs(seconds: number): { value: string; unit: string } {
-  if (!Number.isFinite(seconds) || seconds < 0)
-    return { value: '0.0', unit: 's' }
-  if (seconds < 60) return { value: seconds.toFixed(1), unit: 's' }
-  if (seconds < 3600) return { value: (seconds / 60).toFixed(1), unit: 'm' }
-  return { value: (seconds / 3600).toFixed(1), unit: 'h' }
-}
+/** Alias for the shared duration formatter used throughout this module. */
+const formatSecs = formatDuration
 
 // ───────────────────────── derived row ─────────────────────────
 
@@ -197,7 +193,8 @@ type SortDir = 'asc' | 'desc'
 
 const SORT_ACCESSOR: Record<SortKey, (d: DerivedQuery) => number> = {
   // Rank ascending == most expensive first (the server's native order).
-  rank: (d) => -d.rank,
+  // Default sort is desc, so rank=1 (smallest accessor) sorts to the top.
+  rank: (d) => d.rank,
   cnt: (d) => d.cnt,
   duration: (d) => d.queriesDuration,
   cpu: (d) => d.userTime,
@@ -283,94 +280,7 @@ function TotalTimeCell({ d, max }: { d: DerivedQuery; max: number }) {
   )
 }
 
-interface SortableHeaderProps {
-  children: React.ReactNode
-  align?: 'left' | 'right'
-  width?: string
-  className?: string
-  sortKey?: SortKey
-  activeKey?: SortKey
-  dir?: SortDir
-  onSort?: (key: SortKey) => void
-}
-
-/** Table header cell with an optional click-to-sort affordance. */
-function SortableHeader({
-  children,
-  align = 'left',
-  width,
-  className,
-  sortKey,
-  activeKey,
-  dir,
-  onSort,
-}: SortableHeaderProps) {
-  const active = sortKey != null && sortKey === activeKey
-  return (
-    <th
-      className={cn(
-        'select-none whitespace-nowrap px-2 py-2 text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground sm:px-3',
-        align === 'right' ? 'text-right' : 'text-left',
-        className
-      )}
-      style={width ? { width } : undefined}
-    >
-      {sortKey && onSort ? (
-        <button
-          type="button"
-          onClick={() => onSort(sortKey)}
-          className={cn(
-            'inline-flex items-center gap-1 transition-colors hover:text-foreground',
-            align === 'right' && 'flex-row-reverse'
-          )}
-        >
-          {children}
-          {active ? (
-            dir === 'desc' ? (
-              <ChevronDown className="size-3 text-foreground" />
-            ) : (
-              <ChevronUp className="size-3 text-foreground" />
-            )
-          ) : (
-            <ChevronDown className="size-3 opacity-30" />
-          )}
-        </button>
-      ) : (
-        children
-      )}
-    </th>
-  )
-}
-
 // ───────────────────────── expanded row ─────────────────────────
-
-/** A labelled value in the expandable details grid. */
-function DetailField({
-  label,
-  value,
-  mono = true,
-}: {
-  label: string
-  value: React.ReactNode
-  mono?: boolean
-}) {
-  return (
-    <div className="min-w-0 border-l border-t border-border px-3 py-2">
-      <dt className="text-[10px] font-semibold uppercase leading-tight tracking-wider text-muted-foreground">
-        {label}
-      </dt>
-      <dd
-        className={cn(
-          'mt-0.5 truncate text-[12.5px] font-medium tabular-nums',
-          mono && 'font-mono'
-        )}
-        title={typeof value === 'string' ? value : undefined}
-      >
-        {value || '—'}
-      </dd>
-    </div>
-  )
-}
 
 /**
  * Expanded panel — the full secondary-metric grid, the full query as a
@@ -940,7 +850,7 @@ export const ExpensiveQueriesTable = memo(function ExpensiveQueriesTable({
     () => new Set()
   )
   const [sortKey, setSortKey] = useState<SortKey>('rank')
-  const [sortDir, setSortDir] = useState<SortDir>('asc')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
   const isMobile = useIsMobile()
   const [userView, setUserView] = useState<'table' | 'cards' | null>(null)
   const view = userView ?? (isMobile ? 'cards' : 'table')
@@ -964,7 +874,7 @@ export const ExpensiveQueriesTable = memo(function ExpensiveQueriesTable({
       if (minRuns > 0 && d.cnt < minRuns) return false
       if (minDurationSecs > 0 && d.queriesDuration < minDurationSecs)
         return false
-      if (q) return d.query.toLowerCase().includes(q)
+      if (q && !d.query.toLowerCase().includes(q)) return false
       return true
     })
     const accessor = SORT_ACCESSOR[sortKey]
@@ -993,7 +903,7 @@ export const ExpensiveQueriesTable = memo(function ExpensiveQueriesTable({
         setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
         return prevKey
       }
-      setSortDir(key === 'rank' ? 'asc' : 'desc')
+      setSortDir('desc')
       return key
     })
   }, [])

--- a/apps/web/components/query-tables/detail-field.tsx
+++ b/apps/web/components/query-tables/detail-field.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+
+/** A labelled value in the expandable details grid. */
+export function DetailField({
+  label,
+  value,
+  mono = true,
+}: {
+  label: string
+  value: React.ReactNode
+  mono?: boolean
+}) {
+  return (
+    <div className="min-w-0 border-l border-t border-border px-3 py-2">
+      <dt className="text-[10px] font-semibold uppercase leading-tight tracking-wider text-muted-foreground">
+        {label}
+      </dt>
+      <dd
+        className={cn(
+          'mt-0.5 truncate text-[12.5px] font-medium tabular-nums',
+          mono && 'font-mono'
+        )}
+        title={typeof value === 'string' ? value : undefined}
+      >
+        {value || '—'}
+      </dd>
+    </div>
+  )
+}

--- a/apps/web/components/query-tables/format-duration.ts
+++ b/apps/web/components/query-tables/format-duration.ts
@@ -1,0 +1,14 @@
+/**
+ * Compact a duration in seconds as a `{value, unit}` pair, e.g. `28.1 s`,
+ * `4.2 m`, `1.3 h`.
+ */
+export function formatDuration(seconds: number): {
+  value: string
+  unit: string
+} {
+  if (!Number.isFinite(seconds) || seconds < 0)
+    return { value: '0.0', unit: 's' }
+  if (seconds < 60) return { value: seconds.toFixed(1), unit: 's' }
+  if (seconds < 3600) return { value: (seconds / 60).toFixed(1), unit: 'm' }
+  return { value: (seconds / 3600).toFixed(1), unit: 'h' }
+}

--- a/apps/web/components/query-tables/sortable-header.tsx
+++ b/apps/web/components/query-tables/sortable-header.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { ChevronDown, ChevronUp } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+export interface SortableHeaderProps<T extends string = string> {
+  children: React.ReactNode
+  align?: 'left' | 'right'
+  width?: string
+  className?: string
+  sortKey?: T
+  activeKey?: T
+  dir?: 'asc' | 'desc'
+  onSort?: (key: T) => void
+}
+
+/** Table header cell with an optional click-to-sort affordance. */
+export function SortableHeader<T extends string = string>({
+  children,
+  align = 'left',
+  width,
+  className,
+  sortKey,
+  activeKey,
+  dir,
+  onSort,
+}: SortableHeaderProps<T>) {
+  const active = sortKey != null && sortKey === activeKey
+  return (
+    <th
+      className={cn(
+        'select-none whitespace-nowrap px-2 py-2 text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground sm:px-3',
+        align === 'right' ? 'text-right' : 'text-left',
+        className
+      )}
+      style={width ? { width } : undefined}
+    >
+      {sortKey && onSort ? (
+        <button
+          type="button"
+          onClick={() => onSort(sortKey)}
+          className={cn(
+            'inline-flex items-center gap-1 transition-colors hover:text-foreground',
+            align === 'right' && 'flex-row-reverse'
+          )}
+        >
+          {children}
+          {active ? (
+            dir === 'desc' ? (
+              <ChevronDown className="size-3 text-foreground" />
+            ) : (
+              <ChevronUp className="size-3 text-foreground" />
+            )
+          ) : (
+            <ChevronDown className="size-3 opacity-30" />
+          )}
+        </button>
+      ) : (
+        children
+      )}
+    </th>
+  )
+}

--- a/apps/web/components/running-queries/running-queries-table.tsx
+++ b/apps/web/components/running-queries/running-queries-table.tsx
@@ -3,7 +3,6 @@
 import {
   ChevronDown,
   ChevronRight,
-  ChevronUp,
   CircleX,
   Clock,
   Code2,
@@ -27,6 +26,9 @@ import {
 import { toast } from 'sonner'
 
 import { memo, useCallback, useMemo, useState } from 'react'
+import { DetailField } from '@/components/query-tables/detail-field'
+import { formatDuration } from '@/components/query-tables/format-duration'
+import { SortableHeader } from '@/components/query-tables/sortable-header'
 import { AppLink as Link } from '@/components/ui/app-link'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -158,15 +160,6 @@ function profileEvent(events: unknown, key: string): number {
     return Number.isFinite(n) ? n : 0
   }
   return 0
-}
-
-/** Compact elapsed time as a `{value, unit}` pair, e.g. `28.1 s`, `4.2 m`. */
-function formatDuration(elapsed: number): { value: string; unit: string } {
-  if (!Number.isFinite(elapsed) || elapsed < 0)
-    return { value: '0.0', unit: 's' }
-  if (elapsed < 60) return { value: elapsed.toFixed(1), unit: 's' }
-  if (elapsed < 3600) return { value: (elapsed / 60).toFixed(1), unit: 'm' }
-  return { value: (elapsed / 3600).toFixed(1), unit: 'h' }
 }
 
 // ───────────────────────── derived row ─────────────────────────
@@ -402,94 +395,7 @@ function CpuMeter({ pct }: { pct: number }) {
   )
 }
 
-interface SortableHeaderProps {
-  children: React.ReactNode
-  align?: 'left' | 'right'
-  width?: string
-  className?: string
-  sortKey?: SortKey
-  activeKey?: SortKey
-  dir?: SortDir
-  onSort?: (key: SortKey) => void
-}
-
-/** Table header cell with an optional click-to-sort affordance. */
-function SortableHeader({
-  children,
-  align = 'left',
-  width,
-  className,
-  sortKey,
-  activeKey,
-  dir,
-  onSort,
-}: SortableHeaderProps) {
-  const active = sortKey != null && sortKey === activeKey
-  return (
-    <th
-      className={cn(
-        'select-none whitespace-nowrap px-2 py-2 text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground sm:px-3',
-        align === 'right' ? 'text-right' : 'text-left',
-        className
-      )}
-      style={width ? { width } : undefined}
-    >
-      {sortKey && onSort ? (
-        <button
-          type="button"
-          onClick={() => onSort(sortKey)}
-          className={cn(
-            'inline-flex items-center gap-1 transition-colors hover:text-foreground',
-            align === 'right' && 'flex-row-reverse'
-          )}
-        >
-          {children}
-          {active ? (
-            dir === 'desc' ? (
-              <ChevronDown className="size-3 text-foreground" />
-            ) : (
-              <ChevronUp className="size-3 text-foreground" />
-            )
-          ) : (
-            <ChevronDown className="size-3 opacity-30" />
-          )}
-        </button>
-      ) : (
-        children
-      )}
-    </th>
-  )
-}
-
 // ───────────────────────── expanded row ─────────────────────────
-
-/** A labelled value in the expandable execution-details grid. */
-function DetailField({
-  label,
-  value,
-  mono = true,
-}: {
-  label: string
-  value: React.ReactNode
-  mono?: boolean
-}) {
-  return (
-    <div className="min-w-0 border-l border-t border-border px-3 py-2">
-      <dt className="text-[10px] font-semibold uppercase leading-tight tracking-wider text-muted-foreground">
-        {label}
-      </dt>
-      <dd
-        className={cn(
-          'mt-0.5 truncate text-[12.5px] font-medium tabular-nums',
-          mono && 'font-mono'
-        )}
-        title={typeof value === 'string' ? value : undefined}
-      >
-        {value || '—'}
-      </dd>
-    </div>
-  )
-}
 
 interface ExpandedRowProps {
   d: DerivedQuery

--- a/apps/web/components/slow-queries/slow-queries-table.tsx
+++ b/apps/web/components/slow-queries/slow-queries-table.tsx
@@ -1,9 +1,7 @@
 'use client'
 
 import {
-  ChevronDown,
   ChevronRight,
-  ChevronUp,
   Clock,
   Database,
   ExternalLink,
@@ -15,6 +13,9 @@ import {
 
 import { memo, useMemo, useState } from 'react'
 import { CodeDialogFormat } from '@/components/data-table/cells/code-dialog-format'
+import { DetailField } from '@/components/query-tables/detail-field'
+import { formatDuration } from '@/components/query-tables/format-duration'
+import { SortableHeader } from '@/components/query-tables/sortable-header'
 import { AppLink as Link } from '@/components/ui/app-link'
 import { Button } from '@/components/ui/button'
 import { buildExplorerQueryUrl } from '@/lib/explorer-url'
@@ -57,15 +58,6 @@ function getSeverity(durationS: number): Severity {
   if (durationS > 60) return 'critical'
   if (durationS > 10) return 'warning'
   return 'normal'
-}
-
-/** Compact a duration in seconds as a `{value, unit}` pair. */
-function formatDuration(seconds: number): { value: string; unit: string } {
-  if (!Number.isFinite(seconds) || seconds < 0)
-    return { value: '0.0', unit: 's' }
-  if (seconds < 60) return { value: seconds.toFixed(1), unit: 's' }
-  if (seconds < 3600) return { value: (seconds / 60).toFixed(1), unit: 'm' }
-  return { value: (seconds / 3600).toFixed(1), unit: 'h' }
 }
 
 /** Toned chip for the query-cache usage enum. */
@@ -219,94 +211,7 @@ function MetricBar({ label, pct }: { label: string; pct: number }) {
   )
 }
 
-interface SortableHeaderProps {
-  children: React.ReactNode
-  align?: 'left' | 'right'
-  width?: string
-  className?: string
-  sortKey?: SortKey
-  activeKey?: SortKey
-  dir?: SortDir
-  onSort?: (key: SortKey) => void
-}
-
-/** Table header cell with an optional click-to-sort affordance. */
-function SortableHeader({
-  children,
-  align = 'left',
-  width,
-  className,
-  sortKey,
-  activeKey,
-  dir,
-  onSort,
-}: SortableHeaderProps) {
-  const active = sortKey != null && sortKey === activeKey
-  return (
-    <th
-      className={cn(
-        'select-none whitespace-nowrap px-2 py-2 text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground sm:px-3',
-        align === 'right' ? 'text-right' : 'text-left',
-        className
-      )}
-      style={width ? { width } : undefined}
-    >
-      {sortKey && onSort ? (
-        <button
-          type="button"
-          onClick={() => onSort(sortKey)}
-          className={cn(
-            'inline-flex items-center gap-1 transition-colors hover:text-foreground',
-            align === 'right' && 'flex-row-reverse'
-          )}
-        >
-          {children}
-          {active ? (
-            dir === 'desc' ? (
-              <ChevronDown className="size-3 text-foreground" />
-            ) : (
-              <ChevronUp className="size-3 text-foreground" />
-            )
-          ) : (
-            <ChevronDown className="size-3 opacity-30" />
-          )}
-        </button>
-      ) : (
-        children
-      )}
-    </th>
-  )
-}
-
 // ───────────────────────── expanded row ─────────────────────────
-
-/** A labelled value in the expandable detail grid. */
-function DetailField({
-  label,
-  value,
-  mono = true,
-}: {
-  label: string
-  value: React.ReactNode
-  mono?: boolean
-}) {
-  return (
-    <div className="min-w-0 border-l border-t border-border px-3 py-2">
-      <dt className="text-[10px] font-semibold uppercase leading-tight tracking-wider text-muted-foreground">
-        {label}
-      </dt>
-      <dd
-        className={cn(
-          'mt-0.5 truncate text-[12.5px] font-medium tabular-nums',
-          mono && 'font-mono'
-        )}
-        title={typeof value === 'string' ? value : undefined}
-      >
-        {value || '—'}
-      </dd>
-    </div>
-  )
-}
 
 /**
  * Expanded row — secondary-metric grid, the full query with syntax


### PR DESCRIPTION
## Summary

- **Fix search filter logic bug** in expensive-queries-table: the search query short-circuited severity, minRuns, and minDurationSecs filters. Search is now an additional AND condition instead of a replacement.
- **Fix default rank sort** in expensive-queries-table: rank accessor used `-d.rank` with `sortDir=asc`, causing #2 to appear before #1. Changed accessor to `d.rank` with default `sortDir=desc` so rank=1 sorts first.
- **Extract SortableHeader** from 3 files into shared `components/query-tables/sortable-header.tsx` (generic over string literal types for type safety).
- **Extract DetailField** from 3 files into shared `components/query-tables/detail-field.tsx`.
- **Extract formatDuration** from 3 files into shared `components/query-tables/format-duration.tsx`.

Net: -170 lines of duplication removed, 2 logic bugs fixed.

## Test plan
- [x] TypeScript type-check passes
- [x] Biome lint passes
- [x] Pre-commit hooks pass (lint-staged + type-check)
- [ ] CI build passes
- [ ] Visual: verify expensive-queries table shows #1 rank first
- [ ] Visual: verify search + severity filters combine correctly