### PR TITLE
feat(data-table): declarative rich expand panels via createExpandedPanel

### DIFF
--- a/apps/web/components/data-table/cells/expanded-panel.tsx
+++ b/apps/web/components/data-table/cells/expanded-panel.tsx
@@ -1,0 +1,380 @@
+// NOTE: intentionally NOT a 'use client' module. Like
+// `config-expanded-details.tsx`, this is purely presentational (no hooks,
+// state, or event handlers) so `createExpandedPanel()` can be CALLED from the
+// query-config registry, which is imported by server-side API routes. A
+// 'use client' module's exports become client references that throw on the
+// server.
+
+import { Code2Icon } from 'lucide-react'
+
+import type { Icon } from '@chm/types/icon'
+import type { ExpandedRenderer } from '@/types/query-config'
+
+import { cn } from '@/lib/utils'
+
+/**
+ * Declarative, rich expanded-row panels — the config-driven counterpart to the
+ * bespoke running-queries `ExpandedRow`. A page composes a detail panel from
+ * sections instead of hand-writing JSX:
+ *
+ * ```ts
+ * expandable: {
+ *   renderExpanded: createExpandedPanel({
+ *     sections: [
+ *       { type: 'stats', columns: [{ key: 'query_duration', label: 'Duration' }] },
+ *       { type: 'bars', columns: [{ key: 'memory_usage', label: 'Memory', pctKey: 'pct_memory_usage' }] },
+ *       { type: 'fields', title: 'Identity', columns: ['query_id', 'user', 'client_name'] },
+ *       { type: 'code', title: 'Full query', column: 'query' },
+ *     ],
+ *   }),
+ * }
+ * ```
+ *
+ * Sections cover the four shapes a detail panel needs: scannable key/value
+ * **grids/lists**, big-number **stat tiles**, mini-bar **charts**, and full
+ * **code blocks**.
+ */
+
+/** A field in a `fields` section: a column name, or a name + explicit label. */
+export type ExpandedField = string | { key: string; label?: string }
+
+/** A big-number tile in a `stats` section. */
+export interface ExpandedStat {
+  /** Column holding the raw value (and, by convention, `readable_<key>`). */
+  key: string
+  /** Display label. Defaults to a humanized `key`. */
+  label?: string
+  /** Override which column holds the human-readable value. */
+  readableKey?: string
+  /** Optional leading icon. */
+  icon?: Icon
+}
+
+/** A labelled mini progress bar in a `bars` section. */
+export interface ExpandedBar {
+  /** Column holding the raw value (and, by convention, `readable_<key>`). */
+  key: string
+  /** Display label. Defaults to a humanized `key`. */
+  label?: string
+  /** Override which column holds the human-readable value. */
+  readableKey?: string
+  /** Column holding a 0–100 percentage for the bar width (default `pct_<key>`). */
+  pctKey?: string
+}
+
+export type ExpandedSection =
+  | {
+      type: 'fields'
+      title?: string
+      columns: ReadonlyArray<ExpandedField>
+      /** Max columns in the responsive grid (default 4). */
+      cols?: 2 | 3 | 4 | 5
+    }
+  | { type: 'stats'; title?: string; columns: ReadonlyArray<ExpandedStat> }
+  | { type: 'bars'; title?: string; columns: ReadonlyArray<ExpandedBar> }
+  | { type: 'code'; title?: string; column: string }
+
+export interface CreateExpandedPanelOptions {
+  sections: ReadonlyArray<ExpandedSection>
+}
+
+// ───────────────────────── value helpers ─────────────────────────
+
+function hasValue(value: unknown): boolean {
+  return value !== undefined && value !== null && String(value).trim() !== ''
+}
+
+/** snake_case / camelCase → "Title Case". */
+function humanizeKey(key: string): string {
+  return key
+    .replace(/_/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim()
+}
+
+function formatValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.length === 0 ? '—' : value.map((v) => String(v)).join(', ')
+  }
+  if (value !== null && typeof value === 'object') {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+  return String(value)
+}
+
+/** Prefer the human-readable companion column (`readable_<key>`) when present. */
+function displayValue(
+  row: Record<string, unknown>,
+  key: string,
+  readableKey?: string
+): string {
+  const rk = readableKey ?? `readable_${key}`
+  if (hasValue(row[rk])) return formatValue(row[rk])
+  if (hasValue(row[key])) return formatValue(row[key])
+  return '—'
+}
+
+function toPct(value: unknown): number {
+  const n = Number(value)
+  if (!Number.isFinite(n)) return 0
+  return Math.max(0, Math.min(100, n))
+}
+
+// ───────────────────────── section primitives ─────────────────────────
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+      {children}
+    </div>
+  )
+}
+
+const GRID_COLS: Record<number, string> = {
+  2: 'sm:grid-cols-2',
+  3: 'sm:grid-cols-2 lg:grid-cols-3',
+  4: 'sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
+  5: 'sm:grid-cols-3 lg:grid-cols-5',
+}
+
+function FieldsSection({
+  section,
+  row,
+}: {
+  section: Extract<ExpandedSection, { type: 'fields' }>
+  row: Record<string, unknown>
+}) {
+  const fields = section.columns
+    .map((field) =>
+      typeof field === 'string'
+        ? { key: field, label: humanizeKey(field) }
+        : { key: field.key, label: field.label ?? humanizeKey(field.key) }
+    )
+    .filter(
+      (field) =>
+        hasValue(row[field.key]) || hasValue(row[`readable_${field.key}`])
+    )
+
+  if (!fields.length) return null
+
+  return (
+    <div>
+      {section.title && <SectionTitle>{section.title}</SectionTitle>}
+      <div
+        className={cn('grid grid-cols-1 gap-2', GRID_COLS[section.cols ?? 4])}
+      >
+        {fields.map((field) => {
+          const value = displayValue(row, field.key)
+          return (
+            <div
+              key={field.key}
+              className="min-w-0 rounded-md border border-border/60 bg-background/60 px-3 py-2"
+            >
+              <div className="truncate text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                {field.label}
+              </div>
+              <div
+                className="mt-0.5 min-w-0 truncate font-mono text-[12.5px] tabular-nums text-foreground"
+                title={value}
+              >
+                {value}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function StatsSection({
+  section,
+  row,
+}: {
+  section: Extract<ExpandedSection, { type: 'stats' }>
+  row: Record<string, unknown>
+}) {
+  const stats = section.columns.filter(
+    (stat) =>
+      hasValue(row[stat.key]) ||
+      hasValue(row[stat.readableKey ?? `readable_${stat.key}`])
+  )
+  if (!stats.length) return null
+
+  return (
+    <div>
+      {section.title && <SectionTitle>{section.title}</SectionTitle>}
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+        {stats.map((stat) => {
+          const StatIcon = stat.icon
+          const value = displayValue(row, stat.key, stat.readableKey)
+          return (
+            <div
+              key={stat.key}
+              className="min-w-0 rounded-md border border-border/60 bg-background/60 px-3 py-2.5"
+            >
+              <div className="flex items-center gap-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                {StatIcon && <StatIcon className="size-3 shrink-0" />}
+                <span className="truncate">
+                  {stat.label ?? humanizeKey(stat.key)}
+                </span>
+              </div>
+              <div
+                className="mt-1 truncate text-lg font-semibold leading-none tabular-nums text-foreground"
+                title={value}
+              >
+                {value}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function BarsSection({
+  section,
+  row,
+}: {
+  section: Extract<ExpandedSection, { type: 'bars' }>
+  row: Record<string, unknown>
+}) {
+  const bars = section.columns.filter(
+    (bar) =>
+      hasValue(row[bar.key]) ||
+      hasValue(row[bar.readableKey ?? `readable_${bar.key}`])
+  )
+  if (!bars.length) return null
+
+  return (
+    <div>
+      {section.title && <SectionTitle>{section.title}</SectionTitle>}
+      <div className="space-y-2">
+        {bars.map((bar) => {
+          const value = displayValue(row, bar.key, bar.readableKey)
+          const pct = toPct(row[bar.pctKey ?? `pct_${bar.key}`])
+          return (
+            <div key={bar.key} className="min-w-0">
+              <div className="flex items-baseline justify-between gap-2 text-xs">
+                <span className="truncate text-muted-foreground">
+                  {bar.label ?? humanizeKey(bar.key)}
+                </span>
+                <span
+                  className="shrink-0 font-mono tabular-nums text-foreground"
+                  title={value}
+                >
+                  {value}
+                </span>
+              </div>
+              <div
+                className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-muted"
+                role="progressbar"
+                aria-valuenow={Math.round(pct)}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={bar.label ?? humanizeKey(bar.key)}
+              >
+                <div
+                  className="h-full rounded-full bg-primary/70"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function CodeSection({
+  section,
+  row,
+}: {
+  section: Extract<ExpandedSection, { type: 'code' }>
+  row: Record<string, unknown>
+}) {
+  const raw = row[section.column]
+  if (!hasValue(raw)) return null
+  const text = String(raw)
+  const lineCount = (text.match(/\n/g)?.length ?? 0) + 1
+
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <span className="inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          <Code2Icon className="size-3 shrink-0" />
+          {section.title ?? humanizeKey(section.column)}
+        </span>
+        <span className="whitespace-nowrap text-[10.5px] tabular-nums text-muted-foreground">
+          {text.length.toLocaleString()} chars
+          <span className="mx-1.5 opacity-50">·</span>
+          {lineCount} {lineCount === 1 ? 'line' : 'lines'}
+        </span>
+      </div>
+      <pre className="max-h-[180px] overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/60 bg-background/60 px-3 py-2 font-mono text-[11.5px] leading-relaxed text-foreground">
+        {text}
+      </pre>
+    </div>
+  )
+}
+
+interface ExpandedPanelProps extends CreateExpandedPanelOptions {
+  row: Record<string, unknown>
+}
+
+export function ExpandedPanel({ sections, row }: ExpandedPanelProps) {
+  const rendered = sections
+    .map((section, index) => {
+      const key = `${section.type}-${index}`
+      switch (section.type) {
+        case 'fields':
+          return <FieldsSection key={key} section={section} row={row} />
+        case 'stats':
+          return <StatsSection key={key} section={section} row={row} />
+        case 'bars':
+          return <BarsSection key={key} section={section} row={row} />
+        case 'code':
+          return <CodeSection key={key} section={section} row={row} />
+        default:
+          return null
+      }
+    })
+    .filter(Boolean)
+
+  if (!rendered.length) {
+    return (
+      <div className="text-xs text-muted-foreground">
+        No additional details.
+      </div>
+    )
+  }
+
+  return (
+    <div data-slot="expanded-panel" className="space-y-3.5">
+      {rendered}
+    </div>
+  )
+}
+
+/**
+ * Factory returning an {@link ExpandedRenderer} bound to a section layout.
+ * Lives in this `.tsx` module so plain `.ts` query-config files can opt into
+ * rich row expansion without importing JSX themselves.
+ */
+export function createExpandedPanel(
+  options: CreateExpandedPanelOptions
+): ExpandedRenderer {
+  return (row) => (
+    <ExpandedPanel
+      sections={options.sections}
+      row={row as Record<string, unknown>}
+    />
+  )
+}

--- a/apps/web/lib/query-config/queries/history-queries.ts
+++ b/apps/web/lib/query-config/queries/history-queries.ts
@@ -18,6 +18,7 @@ import {
 import type { FilterSchema } from '@/lib/filters/types'
 import type { QueryConfig } from '@/types/query-config'
 
+import { createExpandedPanel } from '@/components/data-table/cells/expanded-panel'
 import { FILTER_PLACEHOLDER } from '@/lib/filters/where-builder'
 import { QUERY_LOG } from '@/lib/table-notes'
 import { ColumnFormat } from '@/types/column-format'
@@ -274,6 +275,61 @@ export const historyQueriesConfig: QueryConfig = {
     user: UserIcon,
     query_duration: TimerIcon,
     event_time: ClockIcon,
+  },
+  // Rich expand panel (declarative): headline outcome tiles, relative-row
+  // mini-bars, an identity grid, then the full query as a code block. Renders
+  // identically in the table (full-width row) and card (inline) views.
+  expandable: {
+    renderExpanded: createExpandedPanel({
+      sections: [
+        {
+          type: 'stats',
+          columns: [
+            {
+              key: 'result_rows',
+              label: 'Result rows',
+              readableKey: 'readable_result_rows',
+            },
+            {
+              key: 'memory_usage',
+              label: 'Memory',
+              readableKey: 'readable_memory_usage',
+            },
+          ],
+        },
+        {
+          type: 'bars',
+          title: 'Rows scanned (relative to result set)',
+          columns: [
+            {
+              key: 'read_rows',
+              label: 'Read rows',
+              readableKey: 'readable_read_rows',
+              pctKey: 'pct_read_rows',
+            },
+            {
+              key: 'written_rows',
+              label: 'Written rows',
+              readableKey: 'readable_written_rows',
+              pctKey: 'pct_written_rows',
+            },
+          ],
+        },
+        {
+          type: 'fields',
+          title: 'Identity',
+          columns: [
+            'query_id',
+            'user',
+            'client_name',
+            'query_kind',
+            'type',
+            'event_time',
+          ],
+        },
+        { type: 'code', title: 'Full query', column: 'query' },
+      ],
+    }),
   },
   description:
     'Contains information about executed queries: start time, duration of processing, error messages',


### PR DESCRIPTION
## Why

PR #1339 made the **card layout** declarative. This does the same for **row expansion**. Today a page either gets `DefaultExpandedRow` (a raw key/value dump) or must hand-write a bespoke `renderExpanded` component (like running-queries' 100-line `ExpandedRow`). There was no declarative middle ground.

## What

New **`createExpandedPanel({ sections })`** — a server-safe factory (sibling to the existing `createConfigExpandedDetails`) that composes a rich detail panel from four section types:

| Section | Renders | Covers your ask |
|---|---|---|
| `stats` | big-number tiles (readable value + label + optional icon) | *highlight the important info* |
| `bars` | labelled mini progress bars (`pct_<col>` → width) | *mini charts* |
| `fields` | responsive key/value grid | *grid / list* |
| `code` | scrollable code block + char/line count | full SQL |

By convention each section prefers the `readable_<col>` companion column and `pct_<col>` for bar width.

## Why a factory (not a `sections` field on `ExpandableConfig`)

The two consumers — `row-expand/expanded-row.tsx` (table) and `mobile-table-cards.tsx` (card) — **already call `renderExpanded`**. A factory that *returns* a `renderExpanded` means **zero consumer changes and zero type changes**: rich expand is pure `data → JSX`. It's a plain `.tsx` (no `'use client'`) so the query-config registry that API routes import can call it on the server — same constraint `createConfigExpandedDetails` already satisfies, and `settings.ts`/`users.ts` already import it from `.ts` configs.

## Pilot

`history-queries` rows/cards now expand to: result/memory **stat tiles** → read/written **mini-bars** → identity **grid** → full-query **code block**. Identical in table and card views.

## Rollout

PR 2 of the consistency sweep. Next: apply `card` + `expandable` across `queries/`, `tables/`, `merges/`, `system/`, `more/`, `keeper/` configs.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Data tables now support expandable rows displaying detailed information, including statistics, visual indicators, identity fields, and code snippets for enhanced data inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->