### PR TITLE
feat(query-config): card + rich expand for query-log query lists

### DIFF
--- a/apps/web/lib/query-config/queries/expensive-queries-by-memory.ts
+++ b/apps/web/lib/query-config/queries/expensive-queries-by-memory.ts
@@ -1,10 +1,50 @@
 import type { QueryConfig, VersionedSql } from '@/types/query-config'
 
+import { HashIcon, UserIcon } from 'lucide-react'
+import { createExpandedPanel } from '@/components/data-table/cells/expanded-panel'
 import { QUERY_LOG } from '@/lib/table-notes'
 import { ColumnFormat } from '@/types/column-format'
 
 export const expensiveQueriesByMemoryConfig: QueryConfig = {
   name: 'expensive-queries-by-memory',
+  // Query is the hero; total/avg memory are the headline stats in the expand.
+  defaultView: 'auto',
+  card: {
+    primary: 'query',
+    badges: ['query_cache_usage'],
+    metrics: ['user', 'cnt'],
+  },
+  columnIcons: {
+    user: UserIcon,
+    cnt: HashIcon,
+  },
+  expandable: {
+    renderExpanded: createExpandedPanel({
+      sections: [
+        {
+          type: 'stats',
+          columns: [
+            {
+              key: 'sum_memory',
+              label: 'Total memory',
+              readableKey: 'readable_sum_memory',
+            },
+            {
+              key: 'avg_memory',
+              label: 'Avg memory',
+              readableKey: 'readable_avg_memory',
+            },
+          ],
+        },
+        {
+          type: 'fields',
+          title: 'Details',
+          columns: ['user', 'cnt', 'query_cache_usage'],
+        },
+        { type: 'code', title: 'Query', column: 'query' },
+      ],
+    }),
+  },
   description: 'Most expensive queries by memory finished over last 24 hours',
   docs: QUERY_LOG,
   tableCheck: 'system.query_log',

--- a/apps/web/lib/query-config/queries/expensive-queries.ts
+++ b/apps/web/lib/query-config/queries/expensive-queries.ts
@@ -1,10 +1,54 @@
 import type { QueryConfig, VersionedSql } from '@/types/query-config'
 
+import { HashIcon, TimerIcon } from 'lucide-react'
+import { createConfigExpandedDetails } from '@/components/data-table/cells/config-expanded-details'
 import { QUERY_LOG } from '@/lib/table-notes'
 import { ColumnFormat } from '@/types/column-format'
 
 export const expensiveQueriesConfig: QueryConfig = {
   name: 'expensive-queries',
+  // Query is the hero; the headline cost metrics ride as chips. The 20+ timing
+  // and byte-accounting columns are noise on a card, so they're hidden here and
+  // surfaced in the expand panel's auto-grid instead.
+  defaultView: 'auto',
+  card: {
+    primary: 'query',
+    badges: ['query_cache_usage'],
+    metrics: ['cnt', 'queries_duration', 'real_time'],
+    hidden: [
+      'user_time',
+      'system_time',
+      'disk_read_time',
+      'disk_write_time',
+      'network_send_time',
+      'network_receive_time',
+      'zookeeper_wait_time',
+      'os_io_wait_time',
+      'os_cpu_wait_time',
+      'os_cpu_virtual_time',
+      'selected_rows',
+      'selected_parts',
+      'selected_marks',
+      'selected_ranges',
+      'read_rows',
+      'written_rows',
+      'result_rows',
+      'read_bytes',
+      'written_bytes',
+      'result_bytes',
+      'selected_bytes',
+    ],
+  },
+  columnIcons: {
+    cnt: HashIcon,
+    queries_duration: TimerIcon,
+    real_time: TimerIcon,
+  },
+  expandable: {
+    renderExpanded: createConfigExpandedDetails({
+      primaryColumns: ['action', 'query'],
+    }),
+  },
   description: 'Most expensive queries finished over last 24 hours',
   docs: QUERY_LOG,
   tableCheck: 'system.query_log',

--- a/apps/web/lib/query-config/queries/failed-queries.ts
+++ b/apps/web/lib/query-config/queries/failed-queries.ts
@@ -1,10 +1,56 @@
 import type { QueryConfig } from '@/types/query-config'
 
+import { ClockIcon, TimerIcon, UserIcon } from 'lucide-react'
+import { createExpandedPanel } from '@/components/data-table/cells/expanded-panel'
 import { QUERY_LOG } from '@/lib/table-notes'
 import { ColumnFormat } from '@/types/column-format'
 
 export const failedQueriesConfig: QueryConfig = {
   name: 'failed-queries',
+  // For a failed query the *exception* is the most important thing — it leads
+  // the card, with type/kind as badges and identity/duration as metrics.
+  defaultView: 'auto',
+  card: {
+    primary: 'exception',
+    badges: ['type', 'query_kind'],
+    metrics: ['user', 'query_start_time', 'query_duration_ms'],
+    hidden: [
+      'stack_trace',
+      'normalized_query',
+      'is_initial_query',
+      'initial_user',
+      'client_hostname',
+    ],
+  },
+  columnIcons: {
+    user: UserIcon,
+    query_start_time: ClockIcon,
+    query_duration_ms: TimerIcon,
+  },
+  expandable: {
+    renderExpanded: createExpandedPanel({
+      sections: [
+        { type: 'code', title: 'Exception', column: 'exception' },
+        { type: 'code', title: 'Stack trace', column: 'stack_trace' },
+        {
+          type: 'fields',
+          title: 'Identity',
+          columns: [
+            'query_id',
+            'user',
+            'initial_user',
+            'type',
+            'query_kind',
+            'query_start_time',
+            'client',
+            'databases',
+            'tables',
+          ],
+        },
+        { type: 'code', title: 'Normalized query', column: 'normalized_query' },
+      ],
+    }),
+  },
   description: "type IN ['ExceptionBeforeStart', 'ExceptionWhileProcessing']",
   docs: QUERY_LOG,
   tableCheck: 'system.query_log',

--- a/apps/web/lib/query-config/queries/slow-queries.ts
+++ b/apps/web/lib/query-config/queries/slow-queries.ts
@@ -1,10 +1,70 @@
 import type { QueryConfig, VersionedSql } from '@/types/query-config'
 
+import { ClockIcon, TimerIcon, UserIcon } from 'lucide-react'
+import { createExpandedPanel } from '@/components/data-table/cells/expanded-panel'
 import { QUERY_LOG } from '@/lib/table-notes'
 import { ColumnFormat } from '@/types/column-format'
 
 export const slowQueriesConfig: QueryConfig = {
   name: 'slow-queries',
+  // Query is the hero; user/duration/start ride as metric chips, with memory
+  // and I/O surfaced in the expand panel.
+  defaultView: 'auto',
+  card: {
+    primary: 'query',
+    badges: ['query_cache_usage'],
+    metrics: ['user', 'query_duration', 'query_start_time'],
+  },
+  columnIcons: {
+    user: UserIcon,
+    query_duration: TimerIcon,
+    query_start_time: ClockIcon,
+  },
+  expandable: {
+    renderExpanded: createExpandedPanel({
+      sections: [
+        {
+          type: 'stats',
+          columns: [
+            {
+              key: 'memory_usage',
+              label: 'Memory',
+              readableKey: 'readable_memory_usage',
+            },
+          ],
+        },
+        {
+          type: 'bars',
+          title: 'I/O (relative to result set)',
+          columns: [
+            {
+              key: 'read_rows',
+              label: 'Read rows',
+              readableKey: 'readable_read_rows',
+              pctKey: 'pct_read_rows',
+            },
+            {
+              key: 'read_bytes',
+              label: 'Read bytes',
+              readableKey: 'readable_read_bytes',
+              pctKey: 'pct_read_bytes',
+            },
+          ],
+        },
+        {
+          type: 'fields',
+          title: 'Identity',
+          columns: [
+            'query_id',
+            'user',
+            'query_cache_usage',
+            'query_start_time',
+          ],
+        },
+        { type: 'code', title: 'Query', column: 'query' },
+      ],
+    }),
+  },
   description: 'Top 10 slowest queries with query_duration_ms >= 5000',
   docs: QUERY_LOG,
   tableCheck: 'system.query_log',


### PR DESCRIPTION
## What

PR 3 of the consistency sweep — applies the now-complete config vocabulary (`card` from #1339, `createExpandedPanel`/`createConfigExpandedDetails` from #1340) to the four `query_log` query-list siblings of `history-queries`:

| Config | Hero | Expand panel |
|---|---|---|
| `failed-queries` | **exception** (the error is what matters on a failure) | exception + stack trace (code) → identity grid → normalized query |
| `slow-queries` | query | memory **stat tile** → read rows/bytes **mini-bars** → identity grid → query |
| `expensive-queries-by-memory` | query | total/avg memory **stat tiles** → details → query |
| `expensive-queries` | query | 20+ timing/byte columns hidden on card → **auto-grid** expand |

Each also gets `defaultView: 'auto'` (table↔cards toggle) and `columnIcons` for the metric chips.

## Safety

100% config-only — no component/type changes. Referencing a column that doesn't exist is a no-op (`matchCell` skips it, expand sections filter on `hasValue`, missing `pct_` → 0% bar). `running-queries` stays untouched as the bespoke reference.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Apply card-based auto view and rich expand panels to query_log-derived query list configs for slow, failed, and expensive queries.

New Features:
- Add card layouts and default auto (table/cards) view for slow-queries, failed-queries, expensive-queries, and expensive-queries-by-memory configs.
- Introduce configurable expanded panels with stats, bar charts, identity fields, and code sections for slow-queries and expensive-queries-by-memory.
- Expose exception, stack trace, identity details, and normalized query in the expanded view for failed-queries.
- Surface expensive query details via a config-driven expanded details auto-grid for expensive-queries.

Enhancements:
- Add column icon mappings for key metric chips (user, timing, counts) across query_log query configs.