### PR TITLE
feat(query-config): card view for all table/replication pages

### DIFF
--- a/apps/web/lib/query-config/tables/detached-parts.ts
+++ b/apps/web/lib/query-config/tables/detached-parts.ts
@@ -2,6 +2,8 @@ import type { QueryConfig } from '@/types/query-config'
 
 export const detachedPartsConfig: QueryConfig = {
   name: 'detached_parts',
+  defaultView: 'auto',
+  card: { primary: 'table', badges: ['reason'] },
   description: `Contains information about detached parts of MergeTree tables. The reason column specifies why the part was detached`,
   tableCheck: 'system.detached_parts',
   sql: `

--- a/apps/web/lib/query-config/tables/distributed-ddl-queue.ts
+++ b/apps/web/lib/query-config/tables/distributed-ddl-queue.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const distributedDdlQueueConfig: QueryConfig = {
   name: 'distributed-ddl-queue',
+  defaultView: 'auto',
+  card: { primary: 'query', badges: ['status'] },
   description:
     'Distributed ddl queries (ON CLUSTER clause) that were executed on a cluster',
   optional: true,

--- a/apps/web/lib/query-config/tables/dropped-tables.ts
+++ b/apps/web/lib/query-config/tables/dropped-tables.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const droppedTablesConfig: QueryConfig = {
   name: 'dropped-tables',
+  defaultView: 'auto',
+  card: { primary: 'table', badges: ['engine'] },
   refreshInterval: 30_000,
   description:
     'Tables awaiting final asynchronous drop (Atomic database engine)',

--- a/apps/web/lib/query-config/tables/moves.ts
+++ b/apps/web/lib/query-config/tables/moves.ts
@@ -2,6 +2,8 @@ import type { QueryConfig } from '@/types/query-config'
 
 export const movesConfig: QueryConfig = {
   name: 'moves',
+  defaultView: 'auto',
+  card: { primary: 'table' },
   description:
     'In-progress part moves between disks and volumes (TTL / storage policy)',
   refreshInterval: 30_000,

--- a/apps/web/lib/query-config/tables/part-info.ts
+++ b/apps/web/lib/query-config/tables/part-info.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const partInfoConfig: QueryConfig = {
   name: 'part-info',
+  defaultView: 'auto',
+  card: { primary: 'name', badges: ['partition'] },
   description:
     'Information about currently active parts and levels for a table',
 

--- a/apps/web/lib/query-config/tables/projections.ts
+++ b/apps/web/lib/query-config/tables/projections.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const projectionsConfig: QueryConfig = {
   name: 'projections',
+  defaultView: 'auto',
+  card: { primary: 'name' },
   description: `Projection size. https://clickhouse.com/docs/en/sql-reference/statements/alter/projection`,
   sql: `
       SELECT

--- a/apps/web/lib/query-config/tables/readonly-tables.tsx
+++ b/apps/web/lib/query-config/tables/readonly-tables.tsx
@@ -5,6 +5,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const readOnlyTablesConfig: QueryConfig = {
   name: 'readonly-tables',
+  defaultView: 'auto',
+  card: { primary: 'table', badges: ['is_readonly'] },
   description: `Readonly tables and their replicas`,
   // Version-aware queries: system.replicas schema is stable across versions
   // No documented schema changes - using version-aware pattern for consistency

--- a/apps/web/lib/query-config/tables/replicas.ts
+++ b/apps/web/lib/query-config/tables/replicas.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const replicasConfig: QueryConfig = {
   name: 'replicas',
+  defaultView: 'auto',
+  card: { primary: 'database_table', badges: ['is_readonly', 'is_leader'] },
   refreshInterval: 30_000,
   description: `Contains information and status for replicated tables residing on the local server`,
   sql: `

--- a/apps/web/lib/query-config/tables/replicated-fetches.ts
+++ b/apps/web/lib/query-config/tables/replicated-fetches.ts
@@ -2,6 +2,8 @@ import type { QueryConfig } from '@/types/query-config'
 
 export const replicatedFetchesConfig: QueryConfig = {
   name: 'replicated-fetches',
+  defaultView: 'auto',
+  card: { primary: 'table' },
   description:
     'Currently executing background part downloads from replica sources',
   // system.replicated_fetches can be absent on servers/versions without

--- a/apps/web/lib/query-config/tables/replication-queue.ts
+++ b/apps/web/lib/query-config/tables/replication-queue.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const replicationQueueConfig: QueryConfig = {
   name: 'replication-queue',
+  defaultView: 'auto',
+  card: { primary: 'table', badges: ['type'] },
   refreshInterval: 30_000,
   description: `Contains information about tasks from replication queues stored in ClickHouse Keeper, or ZooKeeper, for tables in the ReplicatedMergeTree family`,
   tableCheck: 'system.replication_queue',

--- a/apps/web/lib/query-config/tables/tables-overview.ts
+++ b/apps/web/lib/query-config/tables/tables-overview.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const tablesOverviewConfig: QueryConfig = {
   name: 'tables-overview',
+  defaultView: 'auto',
+  card: { primary: 'table', badges: ['engine'] },
   sql: `
       WITH
         detached_parts AS

--- a/apps/web/lib/query-config/tables/user-processes.ts
+++ b/apps/web/lib/query-config/tables/user-processes.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const userProcessesConfig: QueryConfig = {
   name: 'user-processes',
+  defaultView: 'auto',
+  card: { primary: 'user' },
   description: 'Per-user memory usage and resource summary',
   refreshInterval: 30_000,
   // system.user_processes may not exist on every server / version

--- a/apps/web/lib/query-config/tables/view-refreshes.ts
+++ b/apps/web/lib/query-config/tables/view-refreshes.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const viewRefreshesConfig: QueryConfig = {
   name: 'view-refreshes',
+  defaultView: 'auto',
+  card: { primary: 'view', badges: ['status'] },
   description: `Contains information about refresh operations for materialized views using the REFRESH keyword. https://clickhouse.com/docs/operations/system-tables/view_refreshes`,
   suggestion: `Create a materialized view with REFRESH:
 


### PR DESCRIPTION
## What

PR 4 of the consistency sweep. Brings the dual table↔card view to every `tables/` page (13 configs) with the correct hero per entity type:

| Hero | Configs |
|---|---|
| `table` / `database_table` | tables-overview, detached_parts, dropped-tables, moves, replicas, replicated-fetches, replication-queue, readonly-tables |
| `name` | projections, part-info |
| `view` | view-refreshes |
| `user` | user-processes |
| `query` | distributed-ddl-queue |

Status columns (`reason`, `status`, `engine`, `type`, `is_readonly`, `is_leader`) become header badges; everything else stays as **labeled detail rows** (unambiguous for diverse entity tables — no metric-chip guessing).

## Safety

Config-only — no component/type/import changes. `card.primary`/`badges` referencing a missing column is a no-op. Rich expand panels for the wide configs (replicas, replication-queue, …) will follow in a later PR.

Co-Authored-By: duyetbot <bot@duyet.net>