### PR TITLE
feat(query-config): card view for merges + system entity pages

### DIFF
--- a/apps/web/lib/query-config/merges/merges.ts
+++ b/apps/web/lib/query-config/merges/merges.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const mergesConfig: QueryConfig = {
   name: 'merges',
+  defaultView: 'auto',
+  card: { primary: 'table', badges: ['merge_type', 'is_mutation'] },
   refreshInterval: 30_000,
   description:
     'Merges and part mutations currently in process for tables in the MergeTree family',

--- a/apps/web/lib/query-config/merges/mutations.ts
+++ b/apps/web/lib/query-config/merges/mutations.ts
@@ -9,6 +9,8 @@ export const LONG_RUNNING_THRESHOLD_SECONDS = 300
 
 export const mutationsConfig: QueryConfig = {
   name: 'mutations',
+  defaultView: 'auto',
+  card: { primary: 'command', badges: ['is_done', 'is_stuck'] },
   refreshInterval: 30_000,
   description:
     'Information about mutations of MergeTree tables and their progress',

--- a/apps/web/lib/query-config/system/clusters-topology.ts
+++ b/apps/web/lib/query-config/system/clusters-topology.ts
@@ -53,6 +53,8 @@ export type ClusterTopologyRow = {
 
 export const clustersTopologyConfig: QueryConfig = {
   name: 'clusters-topology',
+  defaultView: 'auto',
+  card: { primary: 'host_name', badges: ['is_local'] },
   description:
     'Per-replica rows from system.clusters for the Cluster Topology graph (one row per cluster/shard/replica).',
   sql: [

--- a/apps/web/lib/query-config/system/clusters.ts
+++ b/apps/web/lib/query-config/system/clusters.ts
@@ -11,6 +11,7 @@ export type Row = {
 
 export const clustersConfig: QueryConfig = {
   name: 'clusters',
+  card: { primary: 'cluster', badges: ['replica_status'] },
   description:
     'Contains information about clusters available in the config file and the servers in them',
   sql: `

--- a/apps/web/lib/query-config/system/database-table.ts
+++ b/apps/web/lib/query-config/system/database-table.ts
@@ -16,6 +16,8 @@ export type Row = {
 
 export const databaseTableColumnsConfig: QueryConfig = {
   name: 'columns',
+  defaultView: 'auto',
+  card: { primary: 'column', badges: ['type'] },
   sql: `
     WITH columns AS (
       SELECT database,

--- a/apps/web/lib/query-config/system/disks.ts
+++ b/apps/web/lib/query-config/system/disks.ts
@@ -21,6 +21,7 @@ export type Row = {
 
 export const diskSpaceConfig: QueryConfig = {
   name: 'disks',
+  card: { primary: 'name' },
   sql: `
       SELECT name,
              path,

--- a/apps/web/lib/query-config/system/kafka-consumers.ts
+++ b/apps/web/lib/query-config/system/kafka-consumers.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const kafkaConsumersConfig: QueryConfig = {
   name: 'kafka-consumers',
+  defaultView: 'auto',
+  card: { primary: 'table', badges: ['consumer_id'] },
   description:
     'Kafka table engine consumer state: poll/commit activity, messages read, and last exception per consumer',
   refreshInterval: 15_000,

--- a/apps/web/lib/query-config/system/part-log.ts
+++ b/apps/web/lib/query-config/system/part-log.ts
@@ -5,6 +5,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const partLogConfig: QueryConfig = {
   name: 'part-log',
+  defaultView: 'auto',
+  card: { primary: 'part_name', badges: ['event_type', 'merge_reason'] },
   description:
     'Part lifecycle timeline: creation, merges, mutations, downloads, and removals from system.part_log',
   docs: PART_LOG,

--- a/apps/web/lib/query-config/system/replicas-status.ts
+++ b/apps/web/lib/query-config/system/replicas-status.ts
@@ -14,6 +14,8 @@ export type Row = {
 
 export const clustersReplicasStatusConfig: QueryConfig = {
   name: 'replicas-status',
+  defaultView: 'auto',
+  card: { primary: 'host' },
   description: 'Replica status for all tables in the cluster',
   sql: `
       SELECT

--- a/apps/web/lib/query-config/system/replicated-merge-tree-settings.ts
+++ b/apps/web/lib/query-config/system/replicated-merge-tree-settings.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const replicatedMergeTreeSettingsConfig: QueryConfig = {
   name: 'replicated-merge-tree-settings',
+  defaultView: 'auto',
+  card: { primary: 'name', badges: ['changed', 'type'] },
   description:
     'Replicated MergeTree engine settings and whether each was changed from default',
   // system.replicated_merge_tree_settings may not exist on every server / version

--- a/apps/web/lib/query-config/system/warnings.ts
+++ b/apps/web/lib/query-config/system/warnings.ts
@@ -2,6 +2,8 @@ import type { QueryConfig } from '@/types/query-config'
 
 export const warningsConfig: QueryConfig = {
   name: 'warnings',
+  defaultView: 'auto',
+  card: { primary: 'message' },
   description:
     'Server-side warnings about potential configuration or operational issues',
   // system.warnings may not exist on every server / ClickHouse version


### PR DESCRIPTION
## What

PR 5 of the consistency sweep — `merges/` + `system/` entity lists (11 configs):

| Hero | Configs |
|---|---|
| `table` | merges, kafka-consumers |
| `command` | mutations (the ALTER/DELETE command is what you scan for) |
| `cluster` / `host` / `host_name` | clusters, replicas-status, clusters-topology |
| `name` / `column` | disks, replicated-merge-tree-settings, columns (system.columns) |
| `part_name` | part-log |
| `message` | warnings |

`clusters`/`disks` already had `defaultView`, so they only gain `card`.

## Skipped (intentionally)

`merge-performance` (aggregate), `cluster-live-metrics` (live metrics), `query-metric-log` (per-query time-series) — not entity lists; a card layout would be noise. Called out in the commit so the omission is explicit, not accidental.

## Safety

Config-only. Missing-column references are no-ops.

Co-Authored-By: duyetbot <bot@duyet.net>