### PR TITLE
feat(query-config): card view for more/ + keeper/ pages

### DIFF
--- a/apps/web/lib/query-config/keeper/keeper-connection-log.ts
+++ b/apps/web/lib/query-config/keeper/keeper-connection-log.ts
@@ -5,6 +5,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const keeperConnectionLogConfig: QueryConfig = {
   name: 'keeper-connection-log',
+  defaultView: 'auto',
+  card: { primary: 'host', badges: ['type'] },
   description:
     'Time-series log of ZooKeeper/Keeper connection and disconnection events with reason codes, ordered by most recent activity. https://clickhouse.com/docs/en/operations/system-tables/zookeeper_connection_log',
   optional: true,

--- a/apps/web/lib/query-config/keeper/keeper-connections.tsx
+++ b/apps/web/lib/query-config/keeper/keeper-connections.tsx
@@ -6,6 +6,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const keeperConnectionsConfig: QueryConfig = {
   name: 'keeper-connections',
+  defaultView: 'auto',
+  card: { primary: 'host', badges: ['is_expired'] },
   description:
     'Current live Keeper/ZooKeeper connections from this ClickHouse server, one row per active connection, with compatibility across ClickHouse releases.',
   optional: true,

--- a/apps/web/lib/query-config/keeper/keeper-info.ts
+++ b/apps/web/lib/query-config/keeper/keeper-info.ts
@@ -5,6 +5,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const keeperInfoConfig: QueryConfig = {
   name: 'keeper-info',
+  defaultView: 'auto',
+  card: { primary: 'host', badges: ['server_state', 'is_leader'] },
   description:
     'Cluster health introspection of all available Keeper/ZooKeeper nodes: one row per node with role, latency, raft log indices, znode/watch counts, and data size metrics.',
   optional: true,

--- a/apps/web/lib/query-config/keeper/keeper-log.ts
+++ b/apps/web/lib/query-config/keeper/keeper-log.ts
@@ -5,6 +5,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const keeperLogConfig: QueryConfig = {
   name: 'keeper-log',
+  defaultView: 'auto',
+  card: { primary: 'path', badges: ['type'] },
   description:
     'Per-request log of parameters sent to ZooKeeper/Keeper and the responses received. Requires <zookeeper_log> in server config (often absent in default installs). https://clickhouse.com/docs/en/operations/system-tables/zookeeper_log',
   optional: true,

--- a/apps/web/lib/query-config/keeper/keeper-presence.ts
+++ b/apps/web/lib/query-config/keeper/keeper-presence.ts
@@ -31,6 +31,8 @@ export type KeeperPresenceRow = {
 
 export const keeperPresenceConfig: QueryConfig = {
   name: 'keeper-presence',
+  defaultView: 'auto',
+  card: { primary: 'name', badges: ['is_expired'] },
   description:
     'Coordination-layer existence/liveness probe from system.zookeeper_connection (broad version coverage).',
   optional: true,

--- a/apps/web/lib/query-config/keeper/keeper-watches.ts
+++ b/apps/web/lib/query-config/keeper/keeper-watches.ts
@@ -5,6 +5,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const keeperWatchesConfig: QueryConfig = {
   name: 'keeper-watches',
+  defaultView: 'auto',
+  card: { primary: 'path', badges: ['watch_type'] },
   description:
     'Currently active ZooKeeper/Keeper watches registered by this server. One row per watch entry tracking path, session, and callback info. Available only on very recent ClickHouse builds (added by PR #99277, post-26.1).',
   optional: true,

--- a/apps/web/lib/query-config/more/asynchronous-metrics.ts
+++ b/apps/web/lib/query-config/more/asynchronous-metrics.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const asynchronousMetricsConfig: QueryConfig = {
   name: 'asynchronous-metrics',
+  defaultView: 'auto',
+  card: { primary: 'metric' },
   description:
     'Contains metrics that are calculated periodically in the background. For example, the amount of RAM in use',
   tableCheck: 'system.asynchronous_metrics',

--- a/apps/web/lib/query-config/more/backups.ts
+++ b/apps/web/lib/query-config/more/backups.ts
@@ -5,6 +5,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const backupsConfig: QueryConfig = {
   name: 'backups',
+  defaultView: 'auto',
+  card: { primary: 'name', badges: ['status'] },
   description: `To restore a backup:
       RESTORE TABLE data_lake.events AS data_lake.events_restore FROM Disk('s3_backup', 'data_lake.events_20231212')`,
   docs: BACKUP_LOG,

--- a/apps/web/lib/query-config/more/dictionaries.ts
+++ b/apps/web/lib/query-config/more/dictionaries.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const dictionariesConfig: QueryConfig = {
   name: 'dictionaries',
+  defaultView: 'auto',
+  card: { primary: 'name', badges: ['status', 'type'] },
   description: 'External dictionaries loaded in ClickHouse',
   suggestion: `Create an external dictionary:
 

--- a/apps/web/lib/query-config/more/errors.ts
+++ b/apps/web/lib/query-config/more/errors.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const errorsConfig: QueryConfig = {
   name: 'errors',
+  defaultView: 'auto',
+  card: { primary: 'error', badges: ['remote'] },
   description: 'System error logs and history',
   optional: true,
   tableCheck: 'system.error_log',

--- a/apps/web/lib/query-config/more/mergetree-settings.ts
+++ b/apps/web/lib/query-config/more/mergetree-settings.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const mergeTreeSettingsConfig: QueryConfig = {
   name: 'mergetree-settings',
+  defaultView: 'auto',
+  card: { primary: 'name', badges: ['changed', 'type'] },
   permission: { feature: 'settings' },
   tableCheck: 'system.merge_tree_settings',
   sql: `

--- a/apps/web/lib/query-config/more/metrics.ts
+++ b/apps/web/lib/query-config/more/metrics.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const metricsConfig: QueryConfig = {
   name: 'metrics',
+  defaultView: 'auto',
+  card: { primary: 'metric' },
   permission: { feature: 'metrics' },
   description:
     'Contains metrics which can be calculated instantly, or have a current value',

--- a/apps/web/lib/query-config/more/roles.ts
+++ b/apps/web/lib/query-config/more/roles.ts
@@ -2,6 +2,8 @@ import type { QueryConfig } from '@/types/query-config'
 
 export const rolesConfig: QueryConfig = {
   name: 'roles',
+  defaultView: 'auto',
+  card: { primary: 'name', badges: ['storage'] },
   description: 'Roles',
   tableCheck: 'system.roles',
   sql: `

--- a/apps/web/lib/query-config/more/settings.ts
+++ b/apps/web/lib/query-config/more/settings.ts
@@ -7,6 +7,8 @@ const SETTINGS_COLUMNS = ['name', 'value', 'changed', 'description', 'default']
 
 export const settingsConfig: QueryConfig = {
   name: 'settings',
+  defaultView: 'auto',
+  card: { primary: 'name', badges: ['changed'] },
   permission: { feature: 'settings' },
   tableCheck: 'system.settings',
   sql: `

--- a/apps/web/lib/query-config/more/top-usage-columns.ts
+++ b/apps/web/lib/query-config/more/top-usage-columns.ts
@@ -5,6 +5,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const topUsageColumnsConfig: QueryConfig = {
   name: 'top-usage-columns',
+  defaultView: 'auto',
+  card: { primary: 'column' },
   description: 'Most usage columns of table based on system.query_log',
   docs: QUERY_LOG,
   tableCheck: 'system.query_log',

--- a/apps/web/lib/query-config/more/top-usage-tables.ts
+++ b/apps/web/lib/query-config/more/top-usage-tables.ts
@@ -5,6 +5,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const topUsageTablesConfig: QueryConfig = {
   name: 'top-usage-tables',
+  defaultView: 'auto',
+  card: { primary: 'table' },
   description:
     'Most usage tables, ignore system tables, based on system.query_log (top 50). Click on table name to see top usage columns.',
   docs: QUERY_LOG,

--- a/apps/web/lib/query-config/more/users.ts
+++ b/apps/web/lib/query-config/more/users.ts
@@ -17,6 +17,8 @@ const USERS_COLUMNS = [
 
 export const usersConfig: QueryConfig = {
   name: 'users',
+  defaultView: 'auto',
+  card: { primary: 'name' },
   description: 'Users account',
   tableCheck: 'system.users',
   sql: `

--- a/apps/web/lib/query-config/more/zookeeper.ts
+++ b/apps/web/lib/query-config/more/zookeeper.ts
@@ -5,6 +5,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const zookeeperConfig: QueryConfig = {
   name: 'zookeeper',
+  defaultView: 'auto',
+  card: { primary: '_path' },
   description:
     'Exposes data from the Keeper cluster defined in the config. https://clickhouse.com/docs/en/operations/system-tables/zookeeper',
   docs: ZOOKEEPER,


### PR DESCRIPTION
## What

PR 6 of the consistency sweep — `more/` + `keeper/` (18 configs).

| Hero | Configs |
|---|---|
| `name` | backups, dictionaries, roles, settings, mergetree-settings, users, keeper-presence |
| `metric` | metrics, asynchronous-metrics |
| `error` | errors |
| `column` / `table` | top-usage-columns, top-usage-tables |
| `host` | keeper-info, keeper-connection-log, keeper-connections |
| `path` / `_path` | keeper-log, keeper-watches, zookeeper |

`settings`/`users`/`keeper-connections` keep their existing expand panels and only gain `card` + `defaultView`.

## Skipped (intentionally)

`page-views` (opaque internal analytics — `data`/`extra` blobs) and `keeper-overview` (single-row summary). Noted in commit.

## Safety

Config-only. Missing-column references are no-ops.

Co-Authored-By: duyetbot <bot@duyet.net>