### PR TITLE
feat(query-config): card view for remaining query diagnostic pages

### DIFF
--- a/apps/web/lib/query-config/queries/common-errors.ts
+++ b/apps/web/lib/query-config/queries/common-errors.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const commonErrorsConfig: QueryConfig = {
   name: 'common-errors',
+  defaultView: 'auto',
+  card: { primary: 'name', badges: ['remote'] },
   description:
     'This table `system.errors` contains error codes and the number of times each error has been triggered. Furthermore, we can see when the error last occurred coupled with the exact error message',
   tableCheck: 'system.errors',

--- a/apps/web/lib/query-config/queries/parallelization.ts
+++ b/apps/web/lib/query-config/queries/parallelization.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const parallelizationConfig: QueryConfig = {
   name: 'parallelization',
+  defaultView: 'auto',
+  card: { primary: 'query_id' },
   description: 'Query parallelization efficiency analysis',
   optional: true,
   tableCheck: 'system.query_thread_log',

--- a/apps/web/lib/query-config/queries/profiler.ts
+++ b/apps/web/lib/query-config/queries/profiler.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const profilerConfig: QueryConfig = {
   name: 'profiler',
+  defaultView: 'auto',
+  card: { primary: 'processor_name' },
   description: 'Query processor profiling data',
   optional: true,
   tableCheck: 'system.processors_profile_log',

--- a/apps/web/lib/query-config/queries/query-cache.ts
+++ b/apps/web/lib/query-config/queries/query-cache.ts
@@ -5,6 +5,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const queryCacheConfig: QueryConfig = {
   name: 'query-cache',
+  defaultView: 'auto',
+  card: { primary: 'query', badges: ['stale', 'shared', 'compressed'] },
   description:
     'https://clickhouse.com/blog/introduction-to-the-clickhouse-query-cache-and-design',
   suggestion: `Enable query cache with these settings:

--- a/apps/web/lib/query-config/queries/query-detail.ts
+++ b/apps/web/lib/query-config/queries/query-detail.ts
@@ -43,6 +43,8 @@ const baseSelect = `
 
 export const queryDetailConfig: QueryConfig = {
   name: 'query-detail',
+  defaultView: 'auto',
+  card: { primary: 'query', badges: ['type', 'query_kind'] },
   description: 'Detailed information about a specific query execution',
   docs: QUERY_LOG,
   permission: { feature: 'queries' },

--- a/apps/web/lib/query-config/queries/query-views-log.ts
+++ b/apps/web/lib/query-config/queries/query-views-log.ts
@@ -5,6 +5,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const queryViewsLogConfig: QueryConfig = {
   name: 'query-views-log',
+  defaultView: 'auto',
+  card: { primary: 'view_name', badges: ['status'] },
   description:
     'Materialized view execution log (target views, durations, read/written rows) with compatibility for old and new ClickHouse releases.',
   optional: true,

--- a/apps/web/lib/query-config/queries/thread-analysis.ts
+++ b/apps/web/lib/query-config/queries/thread-analysis.ts
@@ -4,6 +4,8 @@ import { ColumnFormat } from '@/types/column-format'
 
 export const threadAnalysisConfig: QueryConfig = {
   name: 'thread-analysis',
+  defaultView: 'auto',
+  card: { primary: 'thread_name' },
   description: 'Per-thread query execution statistics',
   optional: true,
   tableCheck: 'system.query_thread_log',


### PR DESCRIPTION
## What

PR 7 (final) of the consistency sweep — completes `queries/` with the 7 diagnostic configs:

| Config | Hero |
|---|---|
| common-errors | `name` (error name) |
| query-views-log | `view_name` |
| query-cache | `query` (badges: stale/shared/compressed) |
| query-detail | `query` (badges: type/query_kind) |
| thread-analysis | `thread_name` |
| parallelization | `query_id` |
| profiler | `processor_name` |

## Sweep complete

Every entity-list query config across `queries/`, `tables/`, `merges/`, `system/`, `more/`, `keeper/` now declares its card hero. `running-queries` stays as the untouched bespoke reference; intentional skips (aggregates / metrics / single-row summaries / opaque analytics) were documented in their respective PRs.

## Safety

Config-only. Missing-column references are no-ops.

Co-Authored-By: duyetbot <bot@duyet.net>