### PR TITLE
feat(data-table): responsive card grid for entity pages

### DIFF
--- a/apps/web/components/data-table/components/data-table-content.tsx
+++ b/apps/web/components/data-table/components/data-table-content.tsx
@@ -311,6 +311,7 @@ export const DataTableContent = memo(function DataTableContent<
               expandable={expandable}
               card={queryConfig.card}
               columnIcons={queryConfig.columnIcons}
+              view={view}
             />
           </div>
         )}

--- a/apps/web/components/data-table/components/mobile-table-cards.tsx
+++ b/apps/web/components/data-table/components/mobile-table-cards.tsx
@@ -67,6 +67,20 @@ const PRIMARY_COLUMN_PRIORITY = [
 // (the "hero") at the top of the card so it reads first.
 const SQL_PRIMARY_COLUMNS = new Set(['query', 'query_detail'])
 
+// Heroes whose content is long-form (SQL, stack traces, exception / error
+// messages, mutation commands) read far better as one wide, readable column
+// than squeezed into a grid cell — so the multi-column card grid keeps these
+// single-column and only grids short, scannable entity heroes.
+const STACK_PRIMARY_COLUMNS = new Set([
+  'query',
+  'query_detail',
+  'exception',
+  'command',
+  'message',
+  'error',
+  'last_error_message',
+])
+
 function formatColumnLabel(columnId: string) {
   return columnId.replaceAll('_', ' ')
 }
@@ -190,6 +204,8 @@ interface MobileTableCardProps<TData extends RowData> {
   card?: CardConfig
   /** Leading icons for metric chips, keyed by column name. */
   columnIcons?: Record<string, Icon>
+  /** In a multi-column card grid, an expanded card spans the full row. */
+  gridLayout?: boolean
 }
 
 const MobileTableCard = function MobileTableCard<TData extends RowData>({
@@ -198,6 +214,7 @@ const MobileTableCard = function MobileTableCard<TData extends RowData>({
   expandable,
   card,
   columnIcons,
+  gridLayout,
 }: MobileTableCardProps<TData>) {
   const cells = row.getVisibleCells()
   const selectCell = cells.find((cell) => cell.column.id === 'select')
@@ -262,6 +279,8 @@ const MobileTableCard = function MobileTableCard<TData extends RowData>({
       data-expanded={isExpanded || undefined}
       className={cn(
         'rounded-lg border border-border/60 bg-card/40 p-3',
+        // An expanded card needs the full row so its detail panel has room.
+        isExpanded && gridLayout && 'col-span-full',
         customClass
       )}
     >
@@ -407,6 +426,8 @@ export interface MobileTableCardsProps<TData extends RowData> {
   card?: CardConfig
   /** Leading icons for metric chips, keyed by column name. */
   columnIcons?: Record<string, Icon>
+  /** Active result view; an explicit 'cards' view enables the card grid. */
+  view?: 'table' | 'cards' | 'auto'
 }
 
 export const MobileTableCards = function MobileTableCards<
@@ -421,8 +442,18 @@ export const MobileTableCards = function MobileTableCards<
   expandable,
   card,
   columnIcons,
+  view,
 }: MobileTableCardsProps<TData>) {
   const rows = table.getRowModel().rows
+
+  // Multi-column card grid — only when the user has explicitly switched to the
+  // 'cards' view (in 'auto' mode cards only show on phones, where a single
+  // column is right), and only for short entity heroes. Long-form heroes (SQL,
+  // exceptions) stay single-column. The virtualized path always stacks.
+  const gridLayout =
+    view === 'cards' &&
+    !!card?.primary &&
+    !STACK_PRIMARY_COLUMNS.has(normalizeColumnName(card.primary))
 
   if (!rows.length) {
     return (
@@ -481,7 +512,13 @@ export const MobileTableCards = function MobileTableCards<
           })}
         </div>
       ) : (
-        <div className="flex flex-col gap-3">
+        <div
+          className={
+            gridLayout
+              ? 'grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3'
+              : 'flex flex-col gap-3'
+          }
+        >
           {rows.map((row) => (
             <MobileTableCard
               key={row.id}
@@ -490,6 +527,7 @@ export const MobileTableCards = function MobileTableCards<
               expandable={expandable}
               card={card}
               columnIcons={columnIcons}
+              gridLayout={gridLayout}
             />
           ))}
         </div>


### PR DESCRIPTION
## What

Closes the last item from the original request — cards as a **"grid, multiple per row."**

In the **explicit "Cards" view**, short-hero entity cards now lay out in a responsive grid (`grid-cols-1 sm:grid-cols-2 xl:grid-cols-3`). Long-form heroes stay single-column, and expanded cards span the full row.

## The rule (config-free)

`gridLayout = view === 'cards' && card.primary && !STACK_PRIMARY_COLUMNS.has(primary)`

- **Grid:** table / host / name / disk / cluster / column / metric / view … (short, scannable)
- **Stack:** query / query_detail / exception / command / message / error (long-form — a 2-column grid would hurt readability)

Derived entirely from `card.primary`, so **zero query-config changes**.

## Scope guards

- `auto` view (cards only on phones) → single column (correct for narrow screens).
- Virtualized path → single column (grid + absolute virtualization don't mix).
- Expanded card → `col-span-full` so its `createExpandedPanel` detail keeps full width.

## Safety

Default behavior unchanged: `gridLayout` is `false` for every non-`'cards'` view, so the single-column stack is byte-identical until a user explicitly toggles to Cards on a wide screen.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive grid layout support for card view, enabling cards to intelligently expand and display full-width content when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->