### PR TITLE
fix(data-table): card review follow-ups (empty-state, hit area, zone dedup)

### DIFF
--- a/apps/web/components/data-table/cells/expanded-panel.tsx
+++ b/apps/web/components/data-table/cells/expanded-panel.tsx
@@ -125,6 +125,41 @@ function toPct(value: unknown): number {
   return Math.max(0, Math.min(100, n))
 }
 
+/**
+ * Whether a section has any data to render for this row. Needed because the
+ * empty-state must be decided from the DATA, not from the rendered element list
+ * — React elements are always truthy, so a `.filter(Boolean)` over rendered
+ * sections never empties even when every section renders nothing.
+ */
+function sectionHasData(
+  section: ExpandedSection,
+  row: Record<string, unknown>
+): boolean {
+  switch (section.type) {
+    case 'code':
+      return hasValue(row[section.column])
+    case 'fields':
+      return section.columns.some((field) => {
+        const key = typeof field === 'string' ? field : field.key
+        return hasValue(row[key]) || hasValue(row[`readable_${key}`])
+      })
+    case 'stats':
+      return section.columns.some(
+        (stat) =>
+          hasValue(row[stat.key]) ||
+          hasValue(row[stat.readableKey ?? `readable_${stat.key}`])
+      )
+    case 'bars':
+      return section.columns.some(
+        (bar) =>
+          hasValue(row[bar.key]) ||
+          hasValue(row[bar.readableKey ?? `readable_${bar.key}`])
+      )
+    default:
+      return false
+  }
+}
+
 // ───────────────────────── section primitives ─────────────────────────
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
@@ -330,25 +365,11 @@ interface ExpandedPanelProps extends CreateExpandedPanelOptions {
 }
 
 export function ExpandedPanel({ sections, row }: ExpandedPanelProps) {
-  const rendered = sections
-    .map((section, index) => {
-      const key = `${section.type}-${index}`
-      switch (section.type) {
-        case 'fields':
-          return <FieldsSection key={key} section={section} row={row} />
-        case 'stats':
-          return <StatsSection key={key} section={section} row={row} />
-        case 'bars':
-          return <BarsSection key={key} section={section} row={row} />
-        case 'code':
-          return <CodeSection key={key} section={section} row={row} />
-        default:
-          return null
-      }
-    })
-    .filter(Boolean)
+  // Keep only sections that actually have data for this row, so the empty-state
+  // is reachable (see `sectionHasData`).
+  const visible = sections.filter((section) => sectionHasData(section, row))
 
-  if (!rendered.length) {
+  if (!visible.length) {
     return (
       <div className="text-xs text-muted-foreground">
         No additional details.
@@ -358,7 +379,21 @@ export function ExpandedPanel({ sections, row }: ExpandedPanelProps) {
 
   return (
     <div data-slot="expanded-panel" className="space-y-3.5">
-      {rendered}
+      {visible.map((section, index) => {
+        const key = `${section.type}-${index}`
+        switch (section.type) {
+          case 'fields':
+            return <FieldsSection key={key} section={section} row={row} />
+          case 'stats':
+            return <StatsSection key={key} section={section} row={row} />
+          case 'bars':
+            return <BarsSection key={key} section={section} row={row} />
+          case 'code':
+            return <CodeSection key={key} section={section} row={row} />
+          default:
+            return null
+        }
+      })}
     </div>
   )
 }

--- a/apps/web/components/data-table/components/mobile-table-cards.tsx
+++ b/apps/web/components/data-table/components/mobile-table-cards.tsx
@@ -231,14 +231,26 @@ const MobileTableCard = function MobileTableCard<TData extends RowData>({
     card?.badges
       ? card.badges.map((name) => matchCell(cells, name))
       : [cells.find((cell) => cell.column.id === 'query_kind')]
-  ).filter((cell): cell is Cell<TData, unknown> => Boolean(cell))
+  )
+    .filter((cell): cell is Cell<TData, unknown> => Boolean(cell))
+    // A column lives in exactly one zone — the hero never repeats as a badge.
+    .filter((cell) => cell.id !== primaryCell?.id)
+
+  // Cells already shown as the hero or a header badge must not also appear in
+  // the metric chip row.
+  const placedIds = new Set(
+    [primaryCell?.id, ...badgeCells.map((cell) => cell.id)].filter(
+      (id): id is string => Boolean(id)
+    )
+  )
 
   // Metric chips: a compact icon+value row of the most glanceable live metrics.
   // Only populated when the config opts in via `card.metrics`.
   const metricEntries = (card?.metrics ?? [])
     .map((name) => ({ name, cell: matchCell(cells, name) }))
-    .filter((entry): entry is { name: string; cell: Cell<TData, unknown> } =>
-      Boolean(entry.cell)
+    .filter(
+      (entry): entry is { name: string; cell: Cell<TData, unknown> } =>
+        entry.cell != null && !placedIds.has(entry.cell.id)
     )
 
   const hiddenIds = new Set(
@@ -292,7 +304,7 @@ const MobileTableCard = function MobileTableCard<TData extends RowData>({
               onClick={() => row.toggleExpanded()}
               aria-expanded={isExpanded}
               aria-label={isExpanded ? 'Collapse row' : 'Expand row'}
-              className="-ml-1 inline-flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-transform duration-100 hover:bg-muted/60 hover:text-foreground active:scale-[0.96]"
+              className="-ml-1 relative inline-flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-transform duration-100 before:absolute before:-inset-2 before:content-[''] hover:bg-muted/60 hover:text-foreground active:scale-[0.96]"
               data-testid="mobile-table-card-expand"
             >
               <ExpandIcon className="size-4" />


### PR DESCRIPTION
## Context

Follow-up to the dual table+card rollout (#1339–#1346), from a verifying code review. Fixes the **in-scope, real** findings; the review's out-of-scope findings are listed at the bottom for tracking (not fixed here).

## Fixes

**1. `ExpandedPanel` empty-state was unreachable (highest severity).**
`sections.map(...).filter(Boolean)` filters React *elements*, which are always truthy — so `rendered.length` equalled `sections.length` regardless of data, and the `No additional details.` branch never fired. A row with no data for any section rendered an empty `<div className="space-y-3.5">` (blank vertical gap). Now emptiness is decided from the data via `sectionHasData(section, row)`.

**2. Expand toggle hit area 24px → 40px.**
The per-card expand button was `size-6` (24px), below the 40×40 minimum. Added a `before:-inset-2` pseudo-element hit area (24 + 2×8 = 40px); the visible chevron stays 16px.

**3. Card zone dedup.**
`primary` / `badges` / `metrics` were resolved independently; a column in two zones rendered twice. Badges now exclude the hero, and metrics exclude hero + badges (latent today — no config triggers it — but the partition is now robust for future configs).

## Deliberately not changed

- **Grid auto-flow hole** on expanding a mid-row card: `grid-flow-dense` would reorder sorted rows, and dropping `col-span-full` cramps the detail panel — both worse than a transient gap. Kept `col-span-full`.
- **`matchCell` duplicate-id**: only triggers if a config lists both `read_rows` and `readable_read_rows`, which already produces duplicate TanStack column ids (a louder error). No config does this.

## Out of scope (review found, NOT mine — reported for tracking)

- `background-bar-format.tsx`: bar lacks `role="progressbar"` semantics; `transition-[width]` isn't GPU-composited (pre-existing shared formatter).
- `table-availability`/version-mismatch WIP (`card-error-utils.ts` dead import, `table-client.tsx`/menu-nav Biome `check` format violations, missing tests for new version helpers) — someone else's recently-merged feature; flagged to its author.

Co-Authored-By: duyetbot <bot@duyet.net>