### PR TITLE
fix(a11y): BackgroundBar progressbar semantics + GPU-composited fill

### DIFF
--- a/apps/web/components/data-table/cells/background-bar-format.cy.tsx
+++ b/apps/web/components/data-table/cells/background-bar-format.cy.tsx
@@ -27,14 +27,15 @@ describe('<BackgroundBarFormat />', () => {
       />
     )
 
-    cy.get('div[aria-roledescription="background-bar"]').as('cell')
+    cy.get('div[role="progressbar"]').as('cell')
 
     cy.get('@cell').should('contain.text', '100')
     cy.get('@cell').should('have.attr', 'title', '100 (50%)')
+    cy.get('@cell').should('have.attr', 'aria-valuenow', '50')
     cy.get('@cell')
       .find('[aria-hidden="true"]')
       .should('have.attr', 'style')
-      .and('include', 'width: 50%')
+      .and('include', 'scaleX(0.5)')
       .and('include', 'background-color')
   })
 
@@ -48,7 +49,7 @@ describe('<BackgroundBarFormat />', () => {
         options={{ numberFormat: true }}
       />
     )
-    cy.get('div[aria-roledescription="background-bar"]').as('cell')
+    cy.get('div[role="progressbar"]').as('cell')
     cy.get('@cell').should('contain.text', '1,000')
   })
 
@@ -62,7 +63,7 @@ describe('<BackgroundBarFormat />', () => {
       />
     )
 
-    cy.get('div[aria-roledescription="background-bar"]').as('cell')
+    cy.get('div[role="progressbar"]').as('cell')
     cy.get('@cell').should('contain.text', 'Two hundred')
     cy.get('@cell').should('have.attr', 'title', '200 (75%)')
   })
@@ -83,7 +84,7 @@ describe('<BackgroundBarFormat />', () => {
       />
     )
 
-    cy.get('div[aria-roledescription="background-bar"]').should('not.exist')
+    cy.get('div[role="progressbar"]').should('not.exist')
     cy.contains('100').should('exist')
   })
 

--- a/apps/web/components/data-table/cells/background-bar-format.tsx
+++ b/apps/web/components/data-table/cells/background-bar-format.tsx
@@ -49,13 +49,22 @@ export const BackgroundBarFormat = function BackgroundBarFormat({
     <div
       className="relative flex items-center w-full h-full overflow-hidden"
       title={`${orgValue} (${pct}%)`}
+      role="progressbar"
       aria-label={`${orgValue} (${pct}%)`}
-      aria-roledescription="background-bar"
+      aria-valuenow={Number(pct)}
+      aria-valuemin={0}
+      aria-valuemax={100}
     >
-      {/* Background bar - uses inline styles for dynamic color */}
+      {/* Background bar — a solid-color div. Animate fill with a GPU-composited
+          transform (scaleX) instead of width, so the per-refresh transition
+          doesn't trigger layout. */}
       <div
-        className="absolute inset-y-0 left-0 transition-[width]"
-        style={{ width: `${pct}%`, ...barStyle }}
+        className="absolute inset-y-0 left-0 origin-left transition-transform"
+        style={{
+          width: '100%',
+          transform: `scaleX(${Number(pct) / 100})`,
+          ...barStyle,
+        }}
         aria-hidden="true"
       />
       <span className="relative inline-block min-w-0 truncate px-1.5">


### PR DESCRIPTION
## What

The one **legitimately-committable** out-of-scope finding from the rollout code review. `BackgroundBarFormat` renders in every data table and the new card detail rows.

- **A11y:** replaced `aria-roledescription="background-bar"` (not a real ARIA pattern) with `role="progressbar"` + `aria-valuenow`/`aria-valuemin`/`aria-valuemax`, so assistive tech gets the actual percentage.
- **Perf:** the fill is a solid-color div (`getBarStyle` → `{ backgroundColor }`); animate it with `transform: scaleX(pct/100)` + `origin-left` + `transition-transform` instead of `transition-[width]`, so the transition is GPU-composited and doesn't trigger per-frame layout on data refresh. Visually identical.
- **Tests:** updated `background-bar-format.cy.tsx` selectors (`aria-roledescription` → `role="progressbar"`), the style assertion (`width: 50%` → `scaleX(0.5)`), and added an `aria-valuenow` check.

Verified `biome check` clean.

## NOT included (and why)

The review also flagged the `table-availability` / version-mismatch feature (`card-error-utils.ts` "dead import", `table-client.tsx`/nav-menu format, missing version-helper tests). On verification those are **uncommitted local WIP, not on `main`**: `route.ts`/`use-table-availability.ts` don't exist on `main`, the version helpers don't exist, and `EmptyStateVariant` is *used* (not dead) — the review agents had read a dirty working tree. Committing that in-progress feature here would hijack its author's branch, so it's intentionally excluded.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved progress bar accessibility with ARIA attributes for enhanced screen reader support.
  * Updated progress bar fill animation to use transform-based approach for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->