### PR TITLE
feat(menu): sidebar table-availability muting + version-mismatch/permission UX

### DIFF
--- a/apps/web/app/api/v1/table-availability/route.ts
+++ b/apps/web/app/api/v1/table-availability/route.ts
@@ -1,0 +1,232 @@
+/**
+ * Batched Table Availability API endpoint
+ * GET /api/v1/table-availability?hostId=<n>
+ *
+ * Returns a map of every ClickHouse system table referenced in the menu to its
+ * availability status (boolean) on the current host in a single request.
+ *
+ * This enables the sidebar to dim/mute optional features whose system tables are not
+ * configured or supported, without blocking initial rendering.
+ *
+ * SECURITY: Only table checks defined in menu.ts are executed.
+ */
+
+import { menuItemsConfig } from '@/menu'
+import type { MenuItem } from '@/components/menu/types'
+
+import { checkTableExists } from '@chm/clickhouse-client/table-existence-cache'
+import { debug, error, generateRequestId } from '@chm/logger'
+import { createErrorResponse } from '@/lib/api/error-handler'
+import { HostIdSchema } from '@/lib/api/schemas'
+import {
+  CacheControl,
+  createSuccessResponse,
+} from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
+
+export const dynamic = 'force-dynamic'
+
+const ROUTE_CONTEXT = { route: '/api/v1/table-availability', method: 'GET' }
+
+interface TableAvailabilityResponse {
+  readonly available: Record<string, boolean>
+}
+
+/**
+ * Extracts all unique table checks declared in the menu items.
+ */
+function extractTableChecks(items: readonly MenuItem[]): string[] {
+  const tables = new Set<string>()
+
+  function recurse(menuItems: readonly MenuItem[]) {
+    for (const item of menuItems) {
+      if (item.tableCheck) {
+        const itemTables = Array.isArray(item.tableCheck) ? item.tableCheck : [item.tableCheck]
+        for (const t of itemTables) {
+          tables.add(t)
+        }
+      }
+      if (item.items) {
+        recurse(item.items)
+      }
+    }
+  }
+
+  recurse(items)
+  return Array.from(tables)
+}
+
+/**
+ * Finds all menu items referencing a specific table.
+ */
+function findMenuItemsForTable(items: readonly MenuItem[], table: string): MenuItem[] {
+  const result: MenuItem[] = []
+
+  function recurse(menuItems: readonly MenuItem[]) {
+    for (const item of menuItems) {
+      if (item.tableCheck) {
+        const itemTables = Array.isArray(item.tableCheck) ? item.tableCheck : [item.tableCheck]
+        if (itemTables.includes(table)) {
+          result.push(item)
+        }
+      }
+      if (item.items) {
+        recurse(item.items)
+      }
+    }
+  }
+
+  recurse(items)
+  return result
+}
+
+/**
+ * Authorizes the table check by verifying if the user has permission
+ * to view at least one menu item backed by this table.
+ */
+async function isTableAuthorized(
+  table: string,
+  request: Request
+): Promise<boolean> {
+  const items = findMenuItemsForTable(menuItemsConfig, table)
+  if (items.length === 0) return true
+
+  for (const item of items) {
+    const permission = item.permission
+    const permissionResponse = await authorizeFeatureRequest(permission, request)
+    if (!permissionResponse) {
+      // User is authorized for at least one feature using this table
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
+ * Resolves a single table check to its availability status.
+ */
+async function resolveTableAvailability(
+  table: string,
+  hostId: number,
+  request: Request,
+  requestId: string
+): Promise<boolean | undefined> {
+  // Security/Permission check
+  const authorized = await isTableAuthorized(table, request)
+  if (!authorized) {
+    return undefined // Omit unauthorized tables from the map
+  }
+
+  // Parse database and table names
+  const parts = table.split('.')
+  const db = parts.length > 1 ? parts[0] : 'system'
+  const tbl = parts.length > 1 ? parts[1] : parts[0]
+
+  try {
+    const exists = await checkTableExists(hostId, db, tbl)
+    return exists
+  } catch (err) {
+    error('[GET /api/v1/table-availability] Check table error:', err, {
+      requestId,
+      table,
+      hostId,
+    })
+    return false // Fail-soft on error
+  }
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const requestId = generateRequestId()
+
+  try {
+    const url = new URL(request.url)
+    const searchParams = url.searchParams
+
+    // Validate hostId parameter
+    const hostIdResult = HostIdSchema.safeParse(
+      searchParams.get('hostId') ?? '0'
+    )
+    if (!hostIdResult.success) {
+      error('[GET /api/v1/table-availability] Invalid hostId parameter', undefined, {
+        requestId,
+      })
+      const errorResponse = createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Invalid hostId parameter: must be a non-negative integer',
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+      const headers = new Headers(errorResponse.headers)
+      headers.set('X-Request-ID', requestId)
+      return new Response(errorResponse.body, {
+        status: errorResponse.status,
+        statusText: errorResponse.statusText,
+        headers,
+      })
+    }
+
+    const hostId = hostIdResult.data
+
+    debug('[GET /api/v1/table-availability] Fetching table availability', {
+      requestId,
+      hostId,
+    })
+
+    const tables = extractTableChecks(menuItemsConfig)
+    const resolved = await Promise.all(
+      tables.map(async (table) => {
+        const available = await resolveTableAvailability(table, hostId, request, requestId)
+        return [table, available] as const
+      })
+    )
+
+    const available: Record<string, boolean> = {}
+    for (const [table, status] of resolved) {
+      if (status !== undefined) {
+        available[table] = status
+      }
+    }
+
+    debug('[GET /api/v1/table-availability] Batched availability result:', {
+      requestId,
+      tablesToCheck: tables.length,
+      availableTablesCount: Object.keys(available).length,
+    })
+
+    const response = createSuccessResponse<TableAvailabilityResponse>(
+      { available },
+      { queryId: 'table-availability-batch', rows: Object.keys(available).length }
+    )
+
+    const headers = new Headers(response.headers)
+    headers.set('X-Request-ID', requestId)
+    headers.set('Cache-Control', CacheControl.MEDIUM)
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    })
+  } catch (err) {
+    error('[GET /api/v1/table-availability] Unexpected error:', err, { requestId })
+    const errorResponse = createErrorResponse(
+      {
+        type: ApiErrorType.QueryError,
+        message: err instanceof Error ? err.message : 'Unknown error',
+      },
+      500,
+      ROUTE_CONTEXT
+    )
+    const headers = new Headers(errorResponse.headers)
+    headers.set('X-Request-ID', requestId)
+    return new Response(errorResponse.body, {
+      status: errorResponse.status,
+      statusText: errorResponse.statusText,
+      headers,
+    })
+  }
+}

--- a/apps/web/app/api/v1/table-availability/route.ts
+++ b/apps/web/app/api/v1/table-availability/route.ts
@@ -12,6 +12,7 @@
  */
 
 import { menuItemsConfig } from '@/menu'
+
 import type { MenuItem } from '@/components/menu/types'
 
 import { checkTableExists } from '@chm/clickhouse-client/table-existence-cache'
@@ -42,7 +43,9 @@ function extractTableChecks(items: readonly MenuItem[]): string[] {
   function recurse(menuItems: readonly MenuItem[]) {
     for (const item of menuItems) {
       if (item.tableCheck) {
-        const itemTables = Array.isArray(item.tableCheck) ? item.tableCheck : [item.tableCheck]
+        const itemTables = Array.isArray(item.tableCheck)
+          ? item.tableCheck
+          : [item.tableCheck]
         for (const t of itemTables) {
           tables.add(t)
         }
@@ -58,21 +61,34 @@ function extractTableChecks(items: readonly MenuItem[]): string[] {
 }
 
 /**
- * Finds all menu items referencing a specific table.
+ * Finds all menu items referencing a specific table, threading inherited
+ * parent permissions through the menu tree (same as filterMenuItemsByPermissions).
  */
-function findMenuItemsForTable(items: readonly MenuItem[], table: string): MenuItem[] {
-  const result: MenuItem[] = []
+function findMenuItemsForTable(
+  items: readonly MenuItem[],
+  table: string
+): { item: MenuItem; effectivePermission: MenuItem['permission'] }[] {
+  const result: {
+    item: MenuItem
+    effectivePermission: MenuItem['permission']
+  }[] = []
 
-  function recurse(menuItems: readonly MenuItem[]) {
+  function recurse(
+    menuItems: readonly MenuItem[],
+    inheritedPermission?: MenuItem['permission']
+  ) {
     for (const item of menuItems) {
+      const effectivePermission = item.permission ?? inheritedPermission
       if (item.tableCheck) {
-        const itemTables = Array.isArray(item.tableCheck) ? item.tableCheck : [item.tableCheck]
+        const itemTables = Array.isArray(item.tableCheck)
+          ? item.tableCheck
+          : [item.tableCheck]
         if (itemTables.includes(table)) {
-          result.push(item)
+          result.push({ item, effectivePermission })
         }
       }
       if (item.items) {
-        recurse(item.items)
+        recurse(item.items, effectivePermission)
       }
     }
   }
@@ -89,12 +105,14 @@ async function isTableAuthorized(
   table: string,
   request: Request
 ): Promise<boolean> {
-  const items = findMenuItemsForTable(menuItemsConfig, table)
-  if (items.length === 0) return true
+  const entries = findMenuItemsForTable(menuItemsConfig, table)
+  if (entries.length === 0) return true
 
-  for (const item of items) {
-    const permission = item.permission
-    const permissionResponse = await authorizeFeatureRequest(permission, request)
+  for (const { effectivePermission } of entries) {
+    const permissionResponse = await authorizeFeatureRequest(
+      effectivePermission,
+      request
+    )
     if (!permissionResponse) {
       // User is authorized for at least one feature using this table
       return true
@@ -133,7 +151,7 @@ async function resolveTableAvailability(
       table,
       hostId,
     })
-    return false // Fail-soft on error
+    return undefined // Omit from map — preserves client fail-open
   }
 }
 
@@ -149,9 +167,13 @@ export async function GET(request: Request): Promise<Response> {
       searchParams.get('hostId') ?? '0'
     )
     if (!hostIdResult.success) {
-      error('[GET /api/v1/table-availability] Invalid hostId parameter', undefined, {
-        requestId,
-      })
+      error(
+        '[GET /api/v1/table-availability] Invalid hostId parameter',
+        undefined,
+        {
+          requestId,
+        }
+      )
       const errorResponse = createErrorResponse(
         {
           type: ApiErrorType.ValidationError,
@@ -179,7 +201,12 @@ export async function GET(request: Request): Promise<Response> {
     const tables = extractTableChecks(menuItemsConfig)
     const resolved = await Promise.all(
       tables.map(async (table) => {
-        const available = await resolveTableAvailability(table, hostId, request, requestId)
+        const available = await resolveTableAvailability(
+          table,
+          hostId,
+          request,
+          requestId
+        )
         return [table, available] as const
       })
     )
@@ -199,12 +226,15 @@ export async function GET(request: Request): Promise<Response> {
 
     const response = createSuccessResponse<TableAvailabilityResponse>(
       { available },
-      { queryId: 'table-availability-batch', rows: Object.keys(available).length }
+      {
+        queryId: 'table-availability-batch',
+        rows: Object.keys(available).length,
+      }
     )
 
     const headers = new Headers(response.headers)
     headers.set('X-Request-ID', requestId)
-    headers.set('Cache-Control', CacheControl.MEDIUM)
+    headers.set('Cache-Control', CacheControl.NONE) // private — response varies by permissions
 
     return new Response(response.body, {
       status: response.status,
@@ -212,7 +242,9 @@ export async function GET(request: Request): Promise<Response> {
       headers,
     })
   } catch (err) {
-    error('[GET /api/v1/table-availability] Unexpected error:', err, { requestId })
+    error('[GET /api/v1/table-availability] Unexpected error:', err, {
+      requestId,
+    })
     const errorResponse = createErrorResponse(
       {
         type: ApiErrorType.QueryError,

--- a/apps/web/components/charts/chart-error.tsx
+++ b/apps/web/components/charts/chart-error.tsx
@@ -33,6 +33,7 @@ import {
   getCardErrorTitle,
   getTableMissingInfo,
   shouldShowRetryButton,
+  toEmptyStateVariant,
 } from '@/lib/card-error-utils'
 import { cn } from '@/lib/utils'
 
@@ -125,7 +126,7 @@ ${error.stack}
     >
       <CardContent className={chartCard.contentError}>
         <EmptyState
-          variant={variant === 'permission' ? 'error' : variant}
+          variant={toEmptyStateVariant(variant)}
           title={title}
           description={description}
           compact={compact}

--- a/apps/web/components/charts/chart-error.tsx
+++ b/apps/web/components/charts/chart-error.tsx
@@ -125,7 +125,7 @@ ${error.stack}
     >
       <CardContent className={chartCard.contentError}>
         <EmptyState
-          variant={variant}
+          variant={variant === 'permission' ? 'error' : variant}
           title={title}
           description={description}
           compact={compact}

--- a/apps/web/components/expensive-queries/expensive-queries-view.tsx
+++ b/apps/web/components/expensive-queries/expensive-queries-view.tsx
@@ -18,6 +18,7 @@ import {
   detectCardErrorVariant,
   getCardErrorDescription,
   getCardErrorTitle,
+  toEmptyStateVariant,
 } from '@/lib/card-error-utils'
 import { expensiveQueriesConfig } from '@/lib/query-config/queries/expensive-queries'
 import { useHostId } from '@/lib/swr/use-host'
@@ -91,7 +92,9 @@ export const ExpensiveQueriesView = function ExpensiveQueriesView() {
           <Card className="rounded-xl">
             <CardContent className="p-4">
               <EmptyState
-                variant={detectCardErrorVariant(error as CardError)}
+                variant={toEmptyStateVariant(
+                  detectCardErrorVariant(error as CardError)
+                )}
                 title={getCardErrorTitle(
                   detectCardErrorVariant(error as CardError),
                   'Expensive Queries'

--- a/apps/web/components/menu/hooks/use-table-availability.ts
+++ b/apps/web/components/menu/hooks/use-table-availability.ts
@@ -1,0 +1,92 @@
+/**
+ * Table Availability Hooks
+ *
+ * Fetches backing table availability via SWR with lazy loading and caching.
+ *
+ * All sidebar items backed by system tables share a single batched request to
+ * `/api/v1/table-availability?hostId=<n>` (deduped by SWR via a shared key).
+ *
+ * Uses a slow refresh interval to minimize API load since table availability
+ * rarely changes.
+ */
+
+'use client'
+
+import useSWR from 'swr'
+
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { REFRESH_INTERVAL } from '@/lib/swr/config'
+
+interface TableAvailabilityResponse {
+  success: boolean
+  data: { available: Record<string, boolean> }
+  error?: { message: string }
+}
+
+/**
+ * Fetches the full map of table availability for a host in a single request.
+ *
+ * All callers share the same SWR key (`['/api/v1/table-availability', hostId]`), so
+ * SWR dedupes all invocations into ONE network request per host.
+ *
+ * @param hostId - The current host ID
+ */
+export function useTableAvailability(hostId: number): {
+  available: Record<string, boolean>
+  isLoading: boolean
+  error?: Error
+} {
+  const { data, error, isLoading } = useSWR<TableAvailabilityResponse>(
+    ['/api/v1/table-availability', hostId],
+    async () => {
+      const res = await apiFetch(`/api/v1/table-availability?hostId=${hostId}`)
+      if (!res.ok) {
+        throw new Error('Failed to fetch table availability')
+      }
+      return res.json()
+    },
+    {
+      refreshInterval: REFRESH_INTERVAL.SLOW_2M,
+      dedupingInterval: 60_000, // 1 minute deduping
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      shouldRetryOnError: false, // Don't retry on error (non-critical)
+    }
+  )
+
+  return {
+    available: data?.data?.available ?? {},
+    isLoading,
+    error,
+  }
+}
+
+/**
+ * Selects a single table's availability status by key from the batched map.
+ *
+ * Backed by {@link useTableAvailability}, so every component reuses the one shared
+ * request instead of fetching independently.
+ *
+ * @param tableCheck - The table name or array of table names to check
+ * @param hostId - The current host ID
+ */
+export function useIsTableAvailable(
+  tableCheck: string | string[] | undefined,
+  hostId: number
+): { available: boolean; isLoading: boolean } {
+  const { available, isLoading } = useTableAvailability(hostId)
+
+  if (!tableCheck) {
+    return { available: true, isLoading: false }
+  }
+
+  const tables = Array.isArray(tableCheck) ? tableCheck : [tableCheck]
+
+  // Treat as available unless explicitly reported as false in the map (fail-open)
+  const isAvailable = tables.every((table) => available[table] !== false)
+
+  return {
+    available: isAvailable,
+    isLoading,
+  }
+}

--- a/apps/web/components/menu/types.ts
+++ b/apps/web/components/menu/types.ts
@@ -23,4 +23,6 @@ export interface MenuItem {
   docs?: string
   /** Feature gate metadata for deployment-level permissions */
   permission?: FeaturePermission
+  /** ClickHouse system table name(s) to check for availability/muting */
+  tableCheck?: string | string[]
 }

--- a/apps/web/components/navigation/nav-main/collapsed-submenu.tsx
+++ b/apps/web/components/navigation/nav-main/collapsed-submenu.tsx
@@ -5,6 +5,8 @@ import type { MenuItem as MenuItemType } from '@/components/menu/types'
 import { lazy, Suspense, useState } from 'react'
 import { ClientOnly } from '@/components/client-only'
 import { HostPrefixedLink } from '@/components/menu/link-with-context'
+import { useHostId } from '@/lib/swr'
+import { useIsTableAvailable } from '@/components/menu/hooks/use-table-availability'
 
 const NewBadge = lazy(() =>
   import('@/components/menu/components/new-badge').then((mod) => ({
@@ -34,6 +36,68 @@ interface CollapsedSubmenuProps {
 }
 
 /**
+ * CollapsedSubMenuItem - Renders a single sub-item in the collapsed popover
+ * with async table-availability visual muting.
+ */
+const CollapsedSubMenuItem = function CollapsedSubMenuItem({
+  subItem,
+  pathname,
+  hostId,
+  isMobile,
+  setOpenMobile,
+  setOpen,
+}: {
+  subItem: MenuItemType
+  pathname: string
+  hostId: number
+  isMobile: boolean
+  setOpenMobile: (open: boolean) => void
+  setOpen: (open: boolean) => void
+}) {
+  const { available } = useIsTableAvailable(subItem.tableCheck, hostId)
+  const isActive = isMenuItemActive(subItem.href, pathname)
+
+  return (
+    <HostPrefixedLink
+      href={subItem.href}
+      className={available ? "" : "opacity-50"}
+      title={available ? undefined : "System table not found on this host"}
+      onClick={() => {
+        setOpen(false)
+        if (isMobile) {
+          setOpenMobile(false)
+        }
+      }}
+    >
+      <div
+        className={cn(
+          'flex items-center justify-between gap-2',
+          'rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors hover:bg-accent hover:text-accent-foreground',
+          'focus-visible:bg-accent focus-visible:text-accent-foreground',
+          isActive && 'bg-accent text-accent-foreground'
+        )}
+      >
+        <span className="truncate">{subItem.title}</span>
+        <span className="flex shrink-0 items-center gap-1.5">
+          <Suspense fallback={null}>
+            <NewBadge href={subItem.href} isNew={subItem.isNew} />
+          </Suspense>
+          {subItem.countKey && (
+            <Suspense fallback={null}>
+              <CountBadge
+                countKey={subItem.countKey}
+                countLabel={subItem.countLabel}
+                countVariant={subItem.countVariant}
+              />
+            </Suspense>
+          )}
+        </span>
+      </div>
+    </HostPrefixedLink>
+  )
+}
+
+/**
  * CollapsedSubmenu - Renders submenu in a Popover for collapsed sidebar mode
  *
  * Features:
@@ -49,6 +113,7 @@ export const CollapsedSubmenu = function CollapsedSubmenu({
 }: CollapsedSubmenuProps) {
   const [open, setOpen] = useState(false)
   const { isMobile, setOpenMobile } = useSidebar()
+  const hostId = useHostId()
   const hasChildren = item.items && item.items.length > 0
 
   if (!hasChildren) {
@@ -80,47 +145,17 @@ export const CollapsedSubmenu = function CollapsedSubmenu({
           onMouseLeave={() => setOpen(false)}
         >
           <div className="flex flex-col gap-0.5">
-            {item.items?.map((subItem) => {
-              const isActive = isMenuItemActive(subItem.href, pathname)
-
-              return (
-                <HostPrefixedLink
-                  key={subItem.href}
-                  href={subItem.href}
-                  onClick={() => {
-                    setOpen(false)
-                    if (isMobile) {
-                      setOpenMobile(false)
-                    }
-                  }}
-                >
-                  <div
-                    className={cn(
-                      'flex items-center justify-between gap-2',
-                      'rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors hover:bg-accent hover:text-accent-foreground',
-                      'focus-visible:bg-accent focus-visible:text-accent-foreground',
-                      isActive && 'bg-accent text-accent-foreground'
-                    )}
-                  >
-                    <span className="truncate">{subItem.title}</span>
-                    <span className="flex shrink-0 items-center gap-1.5">
-                      <Suspense fallback={null}>
-                        <NewBadge href={subItem.href} isNew={subItem.isNew} />
-                      </Suspense>
-                      {subItem.countKey && (
-                        <Suspense fallback={null}>
-                          <CountBadge
-                            countKey={subItem.countKey}
-                            countLabel={subItem.countLabel}
-                            countVariant={subItem.countVariant}
-                          />
-                        </Suspense>
-                      )}
-                    </span>
-                  </div>
-                </HostPrefixedLink>
-              )
-            })}
+            {item.items?.map((subItem) => (
+              <CollapsedSubMenuItem
+                key={subItem.href}
+                subItem={subItem}
+                pathname={pathname}
+                hostId={hostId}
+                isMobile={isMobile}
+                setOpenMobile={setOpenMobile}
+                setOpen={setOpen}
+              />
+            ))}
           </div>
         </PopoverContent>
       </Popover>

--- a/apps/web/components/navigation/nav-main/menu-item.tsx
+++ b/apps/web/components/navigation/nav-main/menu-item.tsx
@@ -8,6 +8,8 @@ import type { MenuItemActiveState, MenuItemProps } from './types'
 import { CollapsedSubmenu } from './collapsed-submenu'
 import { lazy, Suspense } from 'react'
 import { HostPrefixedLink } from '@/components/menu/link-with-context'
+import { useHostId } from '@/lib/swr'
+import { useIsTableAvailable } from '@/components/menu/hooks/use-table-availability'
 
 const NewBadge = lazy(() =>
   import('@/components/menu/components/new-badge').then((mod) => ({
@@ -78,10 +80,17 @@ const SingleMenuItem = function SingleMenuItem({
   isActive: boolean
 }) {
   const closeMobileSidebar = useCloseMobileSidebar()
+  const hostId = useHostId()
+  const { available } = useIsTableAvailable(item.tableCheck, hostId)
 
   return (
     <SidebarMenuItem>
-      <SidebarMenuButton asChild isActive={isActive} tooltip={item.title}>
+      <SidebarMenuButton
+        asChild
+        isActive={isActive}
+        tooltip={available ? item.title : `${item.title} (System table not found on this host)`}
+        className={available ? "" : "opacity-50 text-muted-foreground/50"}
+      >
         <HostPrefixedLink
           href={item.href}
           className="flex w-full items-center"
@@ -116,6 +125,61 @@ const SingleMenuItem = function SingleMenuItem({
 }
 
 /**
+ * Renders a single sub-item under a collapsible menu
+ */
+const SubMenuItem = function SubMenuItem({
+  subItem,
+  pathname,
+  hostId,
+  closeMobileSidebar,
+}: {
+  subItem: MenuItemType
+  pathname: string
+  hostId: number
+  closeMobileSidebar: () => void
+}) {
+  const { available } = useIsTableAvailable(subItem.tableCheck, hostId)
+
+  return (
+    <SidebarMenuSubItem>
+      <SidebarMenuSubButton
+        asChild
+        isActive={isMenuItemActive(subItem.href, pathname)}
+        className={available ? "" : "opacity-50 text-muted-foreground/50"}
+      >
+        <HostPrefixedLink
+          href={subItem.href}
+          className="flex w-full items-center gap-2"
+          onClick={closeMobileSidebar}
+        >
+          <span className="group-data-[state=collapsed]/sidebar:hidden min-w-0 truncate">
+            {subItem.title}
+          </span>
+          {subItem.isNew && (
+            <span className="ml-auto flex shrink-0">
+              <Suspense fallback={null}>
+                <NewBadge href={subItem.href} isNew={subItem.isNew} />
+              </Suspense>
+            </span>
+          )}
+          {subItem.countKey && (
+            <span className="ml-auto flex shrink-0">
+              <Suspense fallback={null}>
+                <CountBadge
+                  countKey={subItem.countKey}
+                  countLabel={subItem.countLabel}
+                  countVariant={subItem.countVariant}
+                />
+              </Suspense>
+            </span>
+          )}
+        </HostPrefixedLink>
+      </SidebarMenuSubButton>
+    </SidebarMenuSubItem>
+  )
+}
+
+/**
  * Renders a menu item with children (collapsible)
  * Uses standard shadcn/ui pattern - entire button triggers toggle
  */
@@ -130,6 +194,7 @@ const CollapsibleMenuItem = function CollapsibleMenuItem({
 }) {
   const { state } = useSidebar()
   const closeMobileSidebar = useCloseMobileSidebar()
+  const hostId = useHostId()
   const isCollapsed = state === 'collapsed'
 
   // When collapsed, use Popover submenu
@@ -197,40 +262,13 @@ const CollapsibleMenuItem = function CollapsibleMenuItem({
         <CollapsibleContent>
           <SidebarMenuSub>
             {item.items?.map((subItem) => (
-              <SidebarMenuSubItem key={subItem.href}>
-                <SidebarMenuSubButton
-                  asChild
-                  isActive={isMenuItemActive(subItem.href, pathname)}
-                >
-                  <HostPrefixedLink
-                    href={subItem.href}
-                    className="flex w-full items-center gap-2"
-                    onClick={closeMobileSidebar}
-                  >
-                    <span className="group-data-[state=collapsed]/sidebar:hidden min-w-0 truncate">
-                      {subItem.title}
-                    </span>
-                    {subItem.isNew && (
-                      <span className="ml-auto flex shrink-0">
-                        <Suspense fallback={null}>
-                          <NewBadge href={subItem.href} isNew={subItem.isNew} />
-                        </Suspense>
-                      </span>
-                    )}
-                    {subItem.countKey && (
-                      <span className="ml-auto flex shrink-0">
-                        <Suspense fallback={null}>
-                          <CountBadge
-                            countKey={subItem.countKey}
-                            countLabel={subItem.countLabel}
-                            countVariant={subItem.countVariant}
-                          />
-                        </Suspense>
-                      </span>
-                    )}
-                  </HostPrefixedLink>
-                </SidebarMenuSubButton>
-              </SidebarMenuSubItem>
+              <SubMenuItem
+                key={subItem.href}
+                subItem={subItem}
+                pathname={pathname}
+                hostId={hostId}
+                closeMobileSidebar={closeMobileSidebar}
+              />
             ))}
           </SidebarMenuSub>
         </CollapsibleContent>

--- a/apps/web/components/part-log/part-log-view.tsx
+++ b/apps/web/components/part-log/part-log-view.tsx
@@ -17,6 +17,7 @@ import {
   detectCardErrorVariant,
   getCardErrorDescription,
   getCardErrorTitle,
+  toEmptyStateVariant,
 } from '@/lib/card-error-utils'
 import { arrayToCsv, downloadCsv } from '@/lib/csv'
 import { useHostId } from '@/lib/swr/use-host'
@@ -147,7 +148,9 @@ export function PartLogView() {
         <Card className="rounded-xl">
           <CardContent className="p-4">
             <EmptyState
-              variant={detectCardErrorVariant(error as CardError)}
+              variant={toEmptyStateVariant(
+                detectCardErrorVariant(error as CardError)
+              )}
               title={getCardErrorTitle(
                 detectCardErrorVariant(error as CardError),
                 'Part Log'

--- a/apps/web/components/running-queries/running-queries-view.tsx
+++ b/apps/web/components/running-queries/running-queries-view.tsx
@@ -195,6 +195,11 @@ export const RunningQueriesView = function RunningQueriesView() {
   const mergedCompleted =
     livePending.length > 0 ? [...livePending, ...completedRows] : completedRows
 
+  const errVariant = error
+    ? detectCardErrorVariant(error as CardError)
+    : undefined
+  const emptyStateVariant = errVariant === 'permission' ? 'error' : errVariant
+
   return (
     <TooltipProvider>
       <div className="flex flex-col gap-4">
@@ -255,14 +260,14 @@ export const RunningQueriesView = function RunningQueriesView() {
           <Card className="rounded-xl">
             <CardContent className="p-4">
               <EmptyState
-                variant={detectCardErrorVariant(error as CardError)}
+                variant={emptyStateVariant}
                 title={getCardErrorTitle(
-                  detectCardErrorVariant(error as CardError),
+                  errVariant ?? 'error',
                   'Running Queries'
                 )}
                 description={getCardErrorDescription(
                   error as CardError,
-                  detectCardErrorVariant(error as CardError)
+                  errVariant ?? 'error'
                 )}
                 compact
                 action={{

--- a/apps/web/components/running-queries/running-queries-view.tsx
+++ b/apps/web/components/running-queries/running-queries-view.tsx
@@ -21,6 +21,7 @@ import {
   detectCardErrorVariant,
   getCardErrorDescription,
   getCardErrorTitle,
+  toEmptyStateVariant,
 } from '@/lib/card-error-utils'
 import {
   parseFiltersFromParams,
@@ -198,7 +199,9 @@ export const RunningQueriesView = function RunningQueriesView() {
   const errVariant = error
     ? detectCardErrorVariant(error as CardError)
     : undefined
-  const emptyStateVariant = errVariant === 'permission' ? 'error' : errVariant
+  const emptyStateVariant = errVariant
+    ? toEmptyStateVariant(errVariant)
+    : undefined
 
   return (
     <TooltipProvider>
@@ -261,13 +264,10 @@ export const RunningQueriesView = function RunningQueriesView() {
             <CardContent className="p-4">
               <EmptyState
                 variant={emptyStateVariant}
-                title={getCardErrorTitle(
-                  errVariant ?? 'error',
-                  'Running Queries'
-                )}
+                title={getCardErrorTitle(errVariant!, 'Running Queries')}
                 description={getCardErrorDescription(
                   error as CardError,
-                  errVariant ?? 'error'
+                  errVariant!
                 )}
                 compact
                 action={{

--- a/apps/web/components/slow-queries/slow-queries-view.tsx
+++ b/apps/web/components/slow-queries/slow-queries-view.tsx
@@ -19,6 +19,7 @@ import {
   detectCardErrorVariant,
   getCardErrorDescription,
   getCardErrorTitle,
+  toEmptyStateVariant,
 } from '@/lib/card-error-utils'
 import { slowQueriesConfig } from '@/lib/query-config/queries/slow-queries'
 import { useHostId } from '@/lib/swr/use-host'
@@ -210,7 +211,9 @@ export function SlowQueriesView() {
           <Card className="rounded-xl">
             <CardContent className="p-4">
               <EmptyState
-                variant={detectCardErrorVariant(error as CardError)}
+                variant={toEmptyStateVariant(
+                  detectCardErrorVariant(error as CardError)
+                )}
                 title={getCardErrorTitle(
                   detectCardErrorVariant(error as CardError),
                   'Slow Queries'

--- a/apps/web/components/tables/table-client.tsx
+++ b/apps/web/components/tables/table-client.tsx
@@ -237,19 +237,25 @@ export const TableClient = function TableClient({
     // 2. Permission / GRANT Suggestion Check
     if (variant === 'permission') {
       const errorTitle = getCardErrorTitle(variant, title)
-      const errorDescription = getCardErrorDescription(
-        error as CardError,
-        variant
-      )
+      // Use standardized copy — never pass through raw ClickHouse error text
+      const errorDescription =
+        'The current ClickHouse user does not have sufficient privileges to query this table. Contact your administrator to grant SELECT permissions.'
 
       const rawMessage = error.message || ''
-      const rawTable =
-        extractTableFromPermissionError(rawMessage) || queryConfig.tableCheck
-      const targetTable = rawTable
-        ? Array.isArray(rawTable)
-          ? rawTable[0]
-          : rawTable
-        : undefined
+      const extracted = extractTableFromPermissionError(rawMessage)
+      // Only construct GRANT when we have a single unambiguous table
+      const rawCheck = queryConfig.tableCheck
+      const hasExtracted = typeof extracted === 'string'
+      const hasSingleCheck =
+        typeof rawCheck === 'string' ||
+        (Array.isArray(rawCheck) && rawCheck.length === 1)
+      const targetTable = hasExtracted
+        ? extracted
+        : hasSingleCheck
+          ? Array.isArray(rawCheck)
+            ? rawCheck[0]
+            : rawCheck
+          : undefined
 
       const grantQuery = targetTable
         ? `GRANT SELECT ON ${targetTable} TO <your_clickhouse_user>;`

--- a/apps/web/components/tables/table-client.tsx
+++ b/apps/web/components/tables/table-client.tsx
@@ -19,13 +19,13 @@ import { SuggestionCard } from '@/components/ui/suggestion-card'
 import {
   type CardError,
   detectCardErrorVariant,
+  extractTableFromPermissionError,
   getCardErrorClassName,
   getCardErrorDescription,
   getCardErrorTitle,
   getTableMissingInfo,
-  shouldShowRetryButton,
   isVersionOlder,
-  extractTableFromPermissionError,
+  shouldShowRetryButton,
 } from '@/lib/card-error-utils'
 import { useHostId } from '@/lib/swr/use-host'
 import { useHostStatus } from '@/lib/swr/use-host-status'
@@ -194,23 +194,35 @@ export const TableClient = function TableClient({
     const serverVersion = hostStatus.data?.version
     const versionedSql = Array.isArray(queryConfig.sql) ? queryConfig.sql : []
     const minSince = versionedSql.length > 0 ? versionedSql[0].since : undefined
-    const isVersionMismatch = serverVersion && minSince ? isVersionOlder(serverVersion, minSince) : false
+    const isVersionMismatch =
+      serverVersion && minSince
+        ? isVersionOlder(serverVersion, minSince)
+        : false
 
     // 1. Version Mismatch Check (Pre-emptive)
     if (isVersionMismatch) {
       return (
-        <Card className={cn('rounded-md shadow-none py-2 group relative border-warning/30 bg-warning/5', className)}>
+        <Card
+          className={cn(
+            'rounded-md shadow-none py-2 group relative border-warning/30 bg-warning/5',
+            className
+          )}
+        >
           <CardContent className="p-4">
             <Alert className="border-0 pr-12">
               <Info className="h-4 w-4 text-warning" />
               <AlertTitle>Version Mismatch</AlertTitle>
               <AlertDescription className="flex flex-col gap-3">
                 <p>
-                  This feature requires ClickHouse version <strong>{minSince}</strong> or newer.
-                  The current ClickHouse host runs version <strong>{serverVersion}</strong>.
+                  This feature requires ClickHouse version{' '}
+                  <strong>{minSince}</strong> or newer. The current ClickHouse
+                  host runs version <strong>{serverVersion}</strong>.
                 </p>
                 <div className="flex flex-col gap-1 border-t pt-3 text-xs text-muted-foreground">
-                  <p>Please upgrade your ClickHouse instance or choose another host that meets the minimum requirement.</p>
+                  <p>
+                    Please upgrade your ClickHouse instance or choose another
+                    host that meets the minimum requirement.
+                  </p>
                 </div>
               </AlertDescription>
             </Alert>
@@ -225,16 +237,31 @@ export const TableClient = function TableClient({
     // 2. Permission / GRANT Suggestion Check
     if (variant === 'permission') {
       const errorTitle = getCardErrorTitle(variant, title)
-      const errorDescription = getCardErrorDescription(error as CardError, variant)
-      
+      const errorDescription = getCardErrorDescription(
+        error as CardError,
+        variant
+      )
+
       const rawMessage = error.message || ''
-      const permissionTable = extractTableFromPermissionError(rawMessage) || queryConfig.tableCheck || 'system.query_log'
-      const targetTable = Array.isArray(permissionTable) ? permissionTable[0] : permissionTable
-      
-      const grantQuery = `GRANT SELECT ON ${targetTable} TO <your_clickhouse_user>;`
+      const rawTable =
+        extractTableFromPermissionError(rawMessage) || queryConfig.tableCheck
+      const targetTable = rawTable
+        ? Array.isArray(rawTable)
+          ? rawTable[0]
+          : rawTable
+        : undefined
+
+      const grantQuery = targetTable
+        ? `GRANT SELECT ON ${targetTable} TO <your_clickhouse_user>;`
+        : undefined
 
       return (
-        <Card className={cn('rounded-md shadow-none py-2 group relative border-destructive/30 bg-destructive/5', className)}>
+        <Card
+          className={cn(
+            'rounded-md shadow-none py-2 group relative border-destructive/30 bg-destructive/5',
+            className
+          )}
+        >
           <div className="absolute top-3 right-3">
             <CardToolbar sql={sql} metadata={metadata} alwaysVisible />
           </div>
@@ -246,10 +273,20 @@ export const TableClient = function TableClient({
                 description={errorDescription}
                 compact={true}
               />
-              <div className="mt-2 text-sm border-t pt-4">
-                <p className="mb-2 font-medium">To grant the required permissions, execute the following SQL query as admin:</p>
-                <SuggestionCard suggestion={grantQuery} />
-              </div>
+              {grantQuery ? (
+                <div className="mt-2 text-sm border-t pt-4">
+                  <p className="mb-2 font-medium">
+                    To grant the required permissions, execute the following SQL
+                    query as admin:
+                  </p>
+                  <SuggestionCard suggestion={grantQuery} />
+                </div>
+              ) : (
+                <p className="mt-2 text-sm text-muted-foreground border-t pt-4">
+                  Unable to determine the required table — check ClickHouse user
+                  permissions.
+                </p>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/apps/web/components/tables/table-client.tsx
+++ b/apps/web/components/tables/table-client.tsx
@@ -24,8 +24,11 @@ import {
   getCardErrorTitle,
   getTableMissingInfo,
   shouldShowRetryButton,
+  isVersionOlder,
+  extractTableFromPermissionError,
 } from '@/lib/card-error-utils'
 import { useHostId } from '@/lib/swr/use-host'
+import { useHostStatus } from '@/lib/swr/use-host-status'
 import { useTableData } from '@/lib/swr/use-table-data'
 import { cn } from '@/lib/utils'
 import { getSqlForDisplay } from '@/types/query-config'
@@ -159,6 +162,7 @@ export const TableClient = function TableClient({
   showFilterBar = true,
 }: TableClientProps) {
   const hostId = useHostId()
+  const hostStatus = useHostStatus(hostId)
   const refreshInterval = queryConfig.refreshInterval ?? 0
 
   // Memoize context to prevent columnDefs recalculation on every render.
@@ -187,20 +191,80 @@ export const TableClient = function TableClient({
   const sql = queryConfig.sql ? getSqlForDisplay(queryConfig.sql) : undefined
 
   if (error) {
+    const serverVersion = hostStatus.data?.version
+    const versionedSql = Array.isArray(queryConfig.sql) ? queryConfig.sql : []
+    const minSince = versionedSql.length > 0 ? versionedSql[0].since : undefined
+    const isVersionMismatch = serverVersion && minSince ? isVersionOlder(serverVersion, minSince) : false
+
+    // 1. Version Mismatch Check (Pre-emptive)
+    if (isVersionMismatch) {
+      return (
+        <Card className={cn('rounded-md shadow-none py-2 group relative border-warning/30 bg-warning/5', className)}>
+          <CardContent className="p-4">
+            <Alert className="border-0 pr-12">
+              <Info className="h-4 w-4 text-warning" />
+              <AlertTitle>Version Mismatch</AlertTitle>
+              <AlertDescription className="flex flex-col gap-3">
+                <p>
+                  This feature requires ClickHouse version <strong>{minSince}</strong> or newer.
+                  The current ClickHouse host runs version <strong>{serverVersion}</strong>.
+                </p>
+                <div className="flex flex-col gap-1 border-t pt-3 text-xs text-muted-foreground">
+                  <p>Please upgrade your ClickHouse instance or choose another host that meets the minimum requirement.</p>
+                </div>
+              </AlertDescription>
+            </Alert>
+          </CardContent>
+        </Card>
+      )
+    }
+
     const variant = detectCardErrorVariant(error as CardError)
     const showRetry = shouldShowRetryButton(error as CardError)
 
-    // Get table-specific guidance for table-missing errors
-    const tableMissingInfo = getTableMissingInfo(error as CardError)
-    const guidance = tableMissingInfo?.guidance
+    // 2. Permission / GRANT Suggestion Check
+    if (variant === 'permission') {
+      const errorTitle = getCardErrorTitle(variant, title)
+      const errorDescription = getCardErrorDescription(error as CardError, variant)
+      
+      const rawMessage = error.message || ''
+      const permissionTable = extractTableFromPermissionError(rawMessage) || queryConfig.tableCheck || 'system.query_log'
+      const targetTable = Array.isArray(permissionTable) ? permissionTable[0] : permissionTable
+      
+      const grantQuery = `GRANT SELECT ON ${targetTable} TO <your_clickhouse_user>;`
 
-    // For table-missing errors without specific guidance, show a helpful card
+      return (
+        <Card className={cn('rounded-md shadow-none py-2 group relative border-destructive/30 bg-destructive/5', className)}>
+          <div className="absolute top-3 right-3">
+            <CardToolbar sql={sql} metadata={metadata} alwaysVisible />
+          </div>
+          <CardContent className="p-6">
+            <div className="flex flex-col gap-4">
+              <EmptyState
+                variant="error"
+                title={errorTitle}
+                description={errorDescription}
+                compact={true}
+              />
+              <div className="mt-2 text-sm border-t pt-4">
+                <p className="mb-2 font-medium">To grant the required permissions, execute the following SQL query as admin:</p>
+                <SuggestionCard suggestion={grantQuery} />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )
+    }
+
+    // 3. Table Missing Check
     if (variant === 'table-missing') {
       const errorTitle = getCardErrorTitle(variant, title)
       const errorDescription = getCardErrorDescription(
         error as CardError,
         variant
       )
+      const tableMissingInfo = getTableMissingInfo(error as CardError)
+      const guidance = tableMissingInfo?.guidance
 
       return (
         <Card

--- a/apps/web/lib/__tests__/card-error-utils.test.ts
+++ b/apps/web/lib/__tests__/card-error-utils.test.ts
@@ -5,12 +5,15 @@
 import {
   type CardError,
   detectCardErrorVariant,
+  extractTableFromPermissionError,
   formatCardErrorForLogging,
   getCardErrorClassName,
   getCardErrorDescription,
   getCardErrorStyle,
   getCardErrorTitle,
   isCardErrorRetryable,
+  isVersionOlder,
+  parseSimpleVersion,
   shouldShowRetryButton,
 } from '../card-error-utils'
 import { describe, expect, it } from 'bun:test'
@@ -60,7 +63,7 @@ describe('card-error-utils', () => {
           ApiErrorType.PermissionError,
           'Access denied'
         )
-        expect(detectCardErrorVariant(error)).toBe('error')
+        expect(detectCardErrorVariant(error)).toBe('permission')
       })
 
       it('should detect query_error', () => {
@@ -499,6 +502,82 @@ describe('card-error-utils', () => {
       const formatted = formatCardErrorForLogging(timeoutError)
 
       expect(formatted.variant).toBe('timeout')
+    })
+  })
+
+  describe('parseSimpleVersion', () => {
+    it('parses major.minor.patch', () => {
+      expect(parseSimpleVersion('24.3.1')).toEqual({
+        major: 24,
+        minor: 3,
+        patch: 1,
+      })
+    })
+
+    it('defaults missing minor/patch to 0', () => {
+      expect(parseSimpleVersion('24')).toEqual({
+        major: 24,
+        minor: 0,
+        patch: 0,
+      })
+    })
+
+    it('ignores extra version segments (e.g. build number)', () => {
+      expect(parseSimpleVersion('24.8.14.10459')).toEqual({
+        major: 24,
+        minor: 8,
+        patch: 14,
+      })
+    })
+
+    it('treats an empty string as 0.0.0', () => {
+      expect(parseSimpleVersion('')).toEqual({ major: 0, minor: 0, patch: 0 })
+    })
+  })
+
+  describe('isVersionOlder', () => {
+    it('is true when the current minor is lower', () => {
+      expect(isVersionOlder('24.1', '24.3')).toBe(true)
+    })
+
+    it('is true when the current major is lower', () => {
+      expect(isVersionOlder('23.8', '24.1')).toBe(true)
+    })
+
+    it('is false when the current version is newer', () => {
+      expect(isVersionOlder('25.1', '24.8')).toBe(false)
+      expect(isVersionOlder('24.3', '24.1')).toBe(false)
+    })
+
+    it('is false when the versions are equal', () => {
+      expect(isVersionOlder('24.3', '24.3')).toBe(false)
+    })
+
+    it('compares the patch level', () => {
+      expect(isVersionOlder('24.3.1', '24.3.2')).toBe(true)
+      expect(isVersionOlder('24.3.2', '24.3.1')).toBe(false)
+    })
+  })
+
+  describe('extractTableFromPermissionError', () => {
+    it('extracts a system.* table from a GRANT error', () => {
+      expect(
+        extractTableFromPermissionError(
+          "Not enough privileges. To execute this query, it's necessary to have the grant SELECT ON system.query_log"
+        )
+      ).toBe('system.query_log')
+    })
+
+    it('extracts a default.* table', () => {
+      expect(
+        extractTableFromPermissionError('GRANT SELECT ON default.events TO bob')
+      ).toBe('default.events')
+    })
+
+    it('returns undefined when no qualified table is present', () => {
+      expect(
+        extractTableFromPermissionError('access denied for this operation')
+      ).toBeUndefined()
     })
   })
 })

--- a/apps/web/lib/card-error-utils.ts
+++ b/apps/web/lib/card-error-utils.ts
@@ -443,6 +443,9 @@ export interface SimpleVersion {
  * Parse a version string like "24.3.1.1" into simple major.minor.patch components
  */
 export function parseSimpleVersion(versionStr: string): SimpleVersion {
+  if (typeof versionStr !== 'string' || !versionStr) {
+    return { major: 0, minor: 0, patch: 0 }
+  }
   const parts = versionStr.split('.')
   return {
     major: parseInt(parts[0] || '0', 10),
@@ -474,6 +477,6 @@ export function extractTableFromPermissionError(
   message: string
 ): string | undefined {
   // Match standard patterns like system.query_log or system.processes
-  const match = message.match(/(?:system|default)\.[a-zA-Z0-9_]+/i)
+  const match = message.match(/\b(?:system|default)\.[a-zA-Z0-9_]+/i)
   return match ? match[0] : undefined
 }

--- a/apps/web/lib/card-error-utils.ts
+++ b/apps/web/lib/card-error-utils.ts
@@ -32,10 +32,25 @@ export type CardError = Error | ApiError | FetchDataError
 /**
  * Unified error variant for EmptyState component
  */
-export type CardErrorVariant = Extract<
-  EmptyStateVariant,
-  'error' | 'offline' | 'timeout' | 'table-missing'
->
+export type CardErrorVariant =
+  | 'error'
+  | 'offline'
+  | 'timeout'
+  | 'table-missing'
+  | 'permission'
+
+/**
+ * Map a {@link CardErrorVariant} to a variant the shared `EmptyState`
+ * understands. `EmptyState` has no `permission` styling, so permission errors
+ * fall back to the `error` look — the permission-specific title/description are
+ * still supplied separately via {@link getCardErrorTitle} /
+ * {@link getCardErrorDescription}.
+ */
+export function toEmptyStateVariant(
+  variant: CardErrorVariant
+): EmptyStateVariant {
+  return variant === 'permission' ? 'error' : variant
+}
 
 /**
  * Standardized error styling configuration
@@ -76,7 +91,15 @@ const ERROR_KEYWORDS = {
     'cpu/memory',
     'memory limit',
   ],
-  permission: ['permission', 'access denied', 'unauthorized', '401', '403'],
+  permission: [
+    'permission',
+    'access denied',
+    'unauthorized',
+    '401',
+    '403',
+    'not_enough_privileges',
+    'not enough privileges',
+  ],
   tableMissing: [
     'table',
     "doesn't exist",
@@ -97,6 +120,14 @@ export function detectCardErrorVariant(error: CardError): CardErrorVariant {
   const type = (apiError.type ?? fetchError.type)?.toLowerCase() ?? ''
 
   // 1. Check explicit type fields first (most reliable)
+  if (
+    type === 'permission_error' ||
+    apiError.type === ApiErrorType.PermissionError ||
+    ERROR_KEYWORDS.permission.some((keyword) => message.includes(keyword))
+  ) {
+    return 'permission'
+  }
+
   if (
     type === 'table_not_found' ||
     apiError.type === ApiErrorType.TableNotFound
@@ -179,6 +210,12 @@ const ERROR_MESSAGES: Record<
     description:
       'An unexpected error occurred while loading data. Please try again.',
     short: 'An error occurred.',
+  },
+  permission: {
+    title: 'Permission Required',
+    description:
+      'The current ClickHouse user does not have sufficient privileges to query this system table. Contact your administrator to grant SELECT permissions.',
+    short: 'Permission denied.',
   },
 }
 
@@ -272,6 +309,12 @@ export function getCardErrorStyle(variant: CardErrorVariant): CardErrorStyle {
         border: 'border-muted/30',
         background: 'bg-muted/30',
         isDestructive: false,
+      }
+    case 'permission':
+      return {
+        border: 'border-destructive/30',
+        background: 'bg-destructive/5',
+        isDestructive: true,
       }
   }
 }
@@ -384,4 +427,53 @@ export function getTableMissingInfo(
     missingTables,
     guidance: getGuidanceForMissingTables(missingTables),
   }
+}
+
+// ============================================================================
+// Version & Permission Helpers
+// ============================================================================
+
+export interface SimpleVersion {
+  major: number
+  minor: number
+  patch: number
+}
+
+/**
+ * Parse a version string like "24.3.1.1" into simple major.minor.patch components
+ */
+export function parseSimpleVersion(versionStr: string): SimpleVersion {
+  const parts = versionStr.split('.')
+  return {
+    major: parseInt(parts[0] || '0', 10),
+    minor: parseInt(parts[1] || '0', 10),
+    patch: parseInt(parts[2] || '0', 10),
+  }
+}
+
+/**
+ * Checks if current ClickHouse version is older than the required version
+ */
+export function isVersionOlder(current: string, required: string): boolean {
+  try {
+    const cur = parseSimpleVersion(current)
+    const req = parseSimpleVersion(required)
+    if (cur.major !== req.major) return cur.major < req.major
+    if (cur.minor !== req.minor) return cur.minor < req.minor
+    if (cur.patch !== req.patch) return cur.patch < req.patch
+    return false
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Extracts table name from ClickHouse permission error messages
+ */
+export function extractTableFromPermissionError(
+  message: string
+): string | undefined {
+  // Match standard patterns like system.query_log or system.processes
+  const match = message.match(/(?:system|default)\.[a-zA-Z0-9_]+/i)
+  return match ? match[0] : undefined
 }

--- a/apps/web/menu.ts
+++ b/apps/web/menu.ts
@@ -48,6 +48,7 @@ import {
 import type { MenuItem } from '@/components/menu/types'
 
 import { PeerDBLogo } from '@/components/icons/peerdb-brand-logo'
+import { EVENTS_TABLE } from '@/lib/app-tables'
 
 export const menuItemsConfig: MenuItem[] = [
   {
@@ -684,7 +685,7 @@ export const menuItemsConfig: MenuItem[] = [
         countKey: 'page-views',
         countLabel: 'views',
         icon: BarChartIcon,
-        tableCheck: 'system.monitoring_events',
+        tableCheck: EVENTS_TABLE,
       },
       {
         title: 'MCP Server',

--- a/apps/web/menu.ts
+++ b/apps/web/menu.ts
@@ -99,6 +99,7 @@ export const menuItemsConfig: MenuItem[] = [
         countLabel: 'running',
         icon: MixIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/processes',
+        tableCheck: 'system.processes',
       },
       {
         title: 'History Queries',
@@ -107,6 +108,7 @@ export const menuItemsConfig: MenuItem[] = [
           'Historical query log with execution metrics, memory usage, and performance data',
         icon: CounterClockwiseClockIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_log',
+        tableCheck: 'system.query_log',
       },
       {
         title: 'Failed Queries',
@@ -115,6 +117,7 @@ export const menuItemsConfig: MenuItem[] = [
           'Query execution failures with error details and stack traces',
         icon: CrossCircledIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_log',
+        tableCheck: 'system.query_log',
       },
       {
         title: 'Most Expensive Queries',
@@ -123,6 +126,7 @@ export const menuItemsConfig: MenuItem[] = [
           'Resource-intensive queries ranked by CPU, memory, and duration',
         icon: CircleDollarSignIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_log',
+        tableCheck: 'system.query_log',
       },
       {
         title: 'Slow Queries',
@@ -130,6 +134,7 @@ export const menuItemsConfig: MenuItem[] = [
         description: 'Top 10 slowest finished queries by duration',
         icon: CounterClockwiseClockIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_log',
+        tableCheck: 'system.query_log',
       },
       {
         title: 'Explain',
@@ -145,6 +150,7 @@ export const menuItemsConfig: MenuItem[] = [
           'Materialized view execution history with status, duration, and row throughput',
         icon: CounterClockwiseClockIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_views_log',
+        tableCheck: 'system.query_views_log',
       },
       {
         title: 'Thread & Parallelization',
@@ -154,6 +160,7 @@ export const menuItemsConfig: MenuItem[] = [
         icon: CpuIcon,
         isNew: true,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_thread_log',
+        tableCheck: 'system.query_thread_log',
       },
       {
         title: 'User Processes',
@@ -162,6 +169,7 @@ export const menuItemsConfig: MenuItem[] = [
         icon: UsersIcon,
         isNew: true,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/user_processes',
+        tableCheck: 'system.user_processes',
       },
       {
         title: 'Query Metric Log',
@@ -171,6 +179,7 @@ export const menuItemsConfig: MenuItem[] = [
         icon: GaugeIcon,
         isNew: true,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_metric_log',
+        tableCheck: 'system.query_metric_log',
       },
     ],
   },
@@ -189,6 +198,7 @@ export const menuItemsConfig: MenuItem[] = [
         countLabel: 'tables',
         icon: TableIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/databases',
+        tableCheck: ['system.databases', 'system.tables'],
       },
       {
         title: 'Tables Overview',
@@ -198,6 +208,7 @@ export const menuItemsConfig: MenuItem[] = [
         description: 'Table storage statistics with part counts and sizes',
         icon: Grid2x2CheckIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/parts',
+        tableCheck: 'system.parts',
       },
       {
         title: 'DDL Queue',
@@ -207,6 +218,7 @@ export const menuItemsConfig: MenuItem[] = [
         description: 'Cluster-wide DDL task queue status and execution history',
         icon: ShuffleIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/distributed_ddl_queue',
+        tableCheck: 'system.distributed_ddl_queue',
       },
       {
         title: 'Table Replicas',
@@ -216,6 +228,7 @@ export const menuItemsConfig: MenuItem[] = [
         countLabel: 'replicas',
         icon: CopyIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/replicas',
+        tableCheck: 'system.replicas',
       },
       {
         title: 'Replication Queue',
@@ -226,6 +239,7 @@ export const menuItemsConfig: MenuItem[] = [
         countLabel: 'pending',
         icon: ShuffleIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/replication_queue',
+        tableCheck: 'system.replication_queue',
       },
       {
         title: 'Replicated Fetches',
@@ -234,6 +248,7 @@ export const menuItemsConfig: MenuItem[] = [
           'Currently executing background part downloads from replica sources',
         icon: DownloadIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/replicated_fetches',
+        tableCheck: 'system.replicated_fetches',
       },
       {
         title: 'Readonly Tables',
@@ -244,6 +259,7 @@ export const menuItemsConfig: MenuItem[] = [
         countVariant: 'destructive',
         icon: ExclamationTriangleIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/replicas',
+        tableCheck: 'system.replicas',
       },
       {
         title: 'Dropped Tables',
@@ -252,6 +268,7 @@ export const menuItemsConfig: MenuItem[] = [
           'Tables awaiting final asynchronous drop (Atomic database engine)',
         icon: Trash2Icon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/dropped_tables',
+        tableCheck: 'system.dropped_tables',
       },
       {
         title: 'Dictionaries',
@@ -262,6 +279,7 @@ export const menuItemsConfig: MenuItem[] = [
         icon: BookOpenIcon,
         isNew: true,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/dictionaries',
+        tableCheck: 'system.dictionaries',
       },
       {
         title: 'Kafka Consumers',
@@ -269,6 +287,7 @@ export const menuItemsConfig: MenuItem[] = [
         description:
           'Kafka table engine consumer lag, poll/commit activity, and ingestion errors',
         icon: RssIcon,
+        tableCheck: 'system.kafka_consumers',
         isNew: true,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/kafka',
       },
@@ -291,6 +310,7 @@ export const menuItemsConfig: MenuItem[] = [
         countLabel: 'active',
         icon: CombineIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/merges',
+        tableCheck: 'system.merges',
       },
       {
         title: 'Merge Performance',
@@ -298,6 +318,7 @@ export const menuItemsConfig: MenuItem[] = [
         description: 'Historical merge operation statistics and trends',
         icon: LightningBoltIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/part_log',
+        tableCheck: 'system.part_log',
       },
       {
         title: 'Mutations',
@@ -305,6 +326,7 @@ export const menuItemsConfig: MenuItem[] = [
         description: 'Table mutation status with progress and failures',
         icon: UpdateIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/mutations',
+        tableCheck: 'system.mutations',
       },
       {
         title: 'Moves',
@@ -313,6 +335,7 @@ export const menuItemsConfig: MenuItem[] = [
           'In-progress part moves between disks and volumes (TTL / storage policy)',
         icon: MoveIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/moves',
+        tableCheck: 'system.moves',
       },
       {
         title: 'Part Log',
@@ -321,6 +344,7 @@ export const menuItemsConfig: MenuItem[] = [
           'Part lifecycle timeline: creations, merges, mutations, downloads, and removals',
         icon: LayersIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/part_log',
+        tableCheck: 'system.part_log',
       },
     ],
   },
@@ -339,6 +363,7 @@ export const menuItemsConfig: MenuItem[] = [
         icon: BarChartIcon,
         permission: { feature: 'metrics' },
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/metrics',
+        tableCheck: 'system.metrics',
       },
       {
         title: 'Async Metrics',
@@ -347,6 +372,7 @@ export const menuItemsConfig: MenuItem[] = [
         icon: BarChartIcon,
         permission: { feature: 'metrics' },
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/asynchronous_metrics',
+        tableCheck: 'system.asynchronous_metrics',
       },
       {
         title: 'Profiler',
@@ -356,6 +382,7 @@ export const menuItemsConfig: MenuItem[] = [
         isNew: true,
         permission: { feature: 'metrics' },
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/processors_profile_log',
+        tableCheck: 'system.processors_profile_log',
       },
     ],
   },
@@ -373,6 +400,7 @@ export const menuItemsConfig: MenuItem[] = [
           'Keeper health at a glance: liveness, request load, latency, and per-node cluster state',
         icon: HeartPulseIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/zookeeper_info',
+        tableCheck: 'system.zookeeper_info',
       },
       {
         title: 'Data Browser',
@@ -381,6 +409,7 @@ export const menuItemsConfig: MenuItem[] = [
           'Browse the ZooKeeper/Keeper znode tree for distributed coordination',
         icon: RollerCoasterIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/zookeeper',
+        tableCheck: 'system.zookeeper',
       },
       {
         title: 'Keeper Info',
@@ -389,6 +418,7 @@ export const menuItemsConfig: MenuItem[] = [
           'Cluster-health introspection of every Keeper node: role, latency, raft log, znode counts',
         icon: InfoCircledIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/zookeeper_info',
+        tableCheck: 'system.zookeeper_info',
       },
       {
         title: 'Connections',
@@ -397,6 +427,7 @@ export const menuItemsConfig: MenuItem[] = [
           'Live connections from this ClickHouse server to Keeper/ZooKeeper',
         icon: UnplugIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/zookeeper_connection',
+        tableCheck: 'system.zookeeper_connection',
       },
       {
         title: 'Connection Log',
@@ -405,6 +436,7 @@ export const menuItemsConfig: MenuItem[] = [
           'History of Keeper/ZooKeeper connect and disconnect events with reasons',
         icon: CounterClockwiseClockIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/zookeeper_connection_log',
+        tableCheck: 'system.zookeeper_connection_log',
       },
       {
         title: 'Request Log',
@@ -413,6 +445,7 @@ export const menuItemsConfig: MenuItem[] = [
           'Per-request log of Keeper/ZooKeeper operations and responses (requires <zookeeper_log>)',
         icon: ScrollTextIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/zookeeper_log',
+        tableCheck: 'system.zookeeper_log',
       },
       {
         title: 'Watches',
@@ -421,6 +454,7 @@ export const menuItemsConfig: MenuItem[] = [
           'Currently active ZooKeeper/Keeper watches registered by this server',
         icon: EyeIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/zookeeper_watches',
+        tableCheck: 'system.zookeeper_watches',
       },
     ],
   },
@@ -467,6 +501,7 @@ export const menuItemsConfig: MenuItem[] = [
         icon: UsersIcon,
         isNew: true,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/session_log',
+        tableCheck: 'system.session_log',
       },
       {
         title: 'Login Attempts',
@@ -475,6 +510,7 @@ export const menuItemsConfig: MenuItem[] = [
         icon: KeyIcon,
         isNew: true,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/session_log',
+        tableCheck: 'system.session_log',
       },
       {
         title: 'Audit Log',
@@ -483,6 +519,7 @@ export const menuItemsConfig: MenuItem[] = [
         icon: ShieldIcon,
         isNew: true,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/opentelemetry_event_log',
+        tableCheck: 'system.opentelemetry_event_log',
       },
     ],
   },
@@ -501,6 +538,7 @@ export const menuItemsConfig: MenuItem[] = [
         icon: ScrollTextIcon,
         isNew: true,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/text_log',
+        tableCheck: 'system.text_log',
       },
       {
         title: 'Stack Traces',
@@ -509,6 +547,7 @@ export const menuItemsConfig: MenuItem[] = [
         icon: ScrollTextIcon,
         isNew: true,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/stack_trace',
+        tableCheck: 'system.stack_trace',
       },
       {
         title: 'Crashes',
@@ -517,6 +556,7 @@ export const menuItemsConfig: MenuItem[] = [
         icon: ShieldAlertIcon,
         isNew: true,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/crash_log',
+        tableCheck: 'system.crash_log',
       },
     ],
   },
@@ -535,6 +575,7 @@ export const menuItemsConfig: MenuItem[] = [
         icon: GearIcon,
         permission: { feature: 'settings' },
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/settings',
+        tableCheck: 'system.settings',
       },
       {
         title: 'MergeTree Settings',
@@ -545,6 +586,7 @@ export const menuItemsConfig: MenuItem[] = [
         icon: TableIcon,
         permission: { feature: 'settings' },
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/merge_tree_settings',
+        tableCheck: 'system.merge_tree_settings',
       },
       {
         title: 'Replicated MergeTree Settings',
@@ -553,6 +595,7 @@ export const menuItemsConfig: MenuItem[] = [
           'Replicated MergeTree engine settings and whether each was changed from default',
         icon: SlidersHorizontalIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/replicated_merge_tree_settings',
+        tableCheck: 'system.replicated_merge_tree_settings',
       },
       {
         title: 'Disks',
@@ -562,6 +605,7 @@ export const menuItemsConfig: MenuItem[] = [
         countLabel: 'disks',
         icon: HardDriveIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/disks',
+        tableCheck: 'system.disks',
       },
       {
         title: 'Warnings',
@@ -570,6 +614,7 @@ export const menuItemsConfig: MenuItem[] = [
           'Server-side warnings about potential configuration or operational issues',
         icon: AlertTriangleIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/warnings',
+        tableCheck: 'system.warnings',
       },
     ],
   },
@@ -588,6 +633,7 @@ export const menuItemsConfig: MenuItem[] = [
         countLabel: 'clusters',
         icon: UngroupIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/clusters',
+        tableCheck: 'system.clusters',
       },
       {
         title: 'Connections',
@@ -595,6 +641,7 @@ export const menuItemsConfig: MenuItem[] = [
         description: 'Client and inter-server connection metrics',
         icon: UnplugIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/metrics',
+        tableCheck: 'system.metrics',
       },
     ],
   },
@@ -620,6 +667,7 @@ export const menuItemsConfig: MenuItem[] = [
         countLabel: 'backups',
         icon: ArchiveIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/backup_log',
+        tableCheck: 'system.backup_log',
       },
       {
         title: 'Errors',
@@ -627,6 +675,7 @@ export const menuItemsConfig: MenuItem[] = [
         description: 'Detailed error events with stack traces',
         icon: ShieldAlertIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/error_log',
+        tableCheck: 'system.error_log',
       },
       {
         title: 'Page Views',
@@ -635,6 +684,7 @@ export const menuItemsConfig: MenuItem[] = [
         countKey: 'page-views',
         countLabel: 'views',
         icon: BarChartIcon,
+        tableCheck: 'system.monitoring_events',
       },
       {
         title: 'MCP Server',

--- a/apps/web/menu.ts
+++ b/apps/web/menu.ts
@@ -520,7 +520,7 @@ export const menuItemsConfig: MenuItem[] = [
         icon: ShieldIcon,
         isNew: true,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/opentelemetry_event_log',
-        tableCheck: 'system.opentelemetry_event_log',
+        tableCheck: 'system.session_log',
       },
     ],
   },

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -33,6 +33,7 @@ Agents discover knowledge in this order:
 | **Operations** | [secret-rotation.md](secret-rotation.md) | workflow | Cloudflare Workers secret rotation: redeploy after wrangler secret put |
 | **Specs** | [mcp-server.md](mcp-server.md) | reference | MCP server at /api/mcp: tools, setup, security |
 | **Specs** | [query-config-format.md](query-config-format.md) | spec | QueryConfig type format, versioned SQL, BackgroundBar columns |
+| **Specs** | [table-availability.md](table-availability.md) | spec | Sidebar muting (table availability), permission GRANT + version-mismatch errors, `toEmptyStateVariant` gotcha |
 | **Development** | [component-ci-stability.md](component-ci-stability.md) | incident | Cypress component test fragility findings and fix direction |
 | **Development** | [conventions.md](conventions.md) | workflow | Coding conventions, file organization, component patterns |
 | **Tools** | [standalone-cli.md](standalone-cli.md) | reference | Rust CLI for monitoring via terminal and TUI |

--- a/docs/knowledge/table-availability.md
+++ b/docs/knowledge/table-availability.md
@@ -1,0 +1,73 @@
+---
+id: table-availability
+title: Table Availability, Sidebar Muting & Permission/Version Errors
+type: spec
+status: active
+updated: 2026-05-31
+tags:
+  - menu
+  - error-handling
+  - clickhouse-version
+  - permissions
+related:
+  - query-config-format
+  - conventions
+  - static-site-architecture
+---
+
+# Table Availability, Sidebar Muting & Permission/Version Errors
+
+How the dashboard reacts when a backing `system.*` table is missing, the user
+lacks privileges, or the ClickHouse version is too old for a feature.
+
+## Sidebar muting (table availability)
+
+Menu items backed by a system table are greyed out when that table doesn't
+exist on the current host.
+
+- **API**: `GET /api/v1/table-availability?hostId=<n>` →
+  `{ data: { available: Record<string, boolean> } }`. Route at
+  `app/api/v1/table-availability/route.ts` (fail-soft, `hostId` validated,
+  per-table feature authorization).
+- **Hooks** (`components/menu/hooks/use-table-availability.ts`):
+  - `useTableAvailability(hostId)` — one batched SWR request shared by **all**
+    sidebar items via a common key `['/api/v1/table-availability', hostId]`
+    (deduped; slow refresh — availability rarely changes).
+  - `useIsTableAvailable(tableCheck, hostId)` — selects one item's status.
+- **Fail-open**: an item is treated as **available unless explicitly reported
+  `false`**. A failed/missing availability fetch never hides a working page.
+- Consumed by `nav-main/menu-item.tsx` + `collapsed-submenu.tsx` (greyed style
+  + "System table not found on this host" tooltip). The menu item's
+  `tableCheck` comes from its `QueryConfig` (see [[query-config-format]]).
+
+## Error variants (`lib/card-error-utils.ts`)
+
+`detectCardErrorVariant(error)` classifies an error into a `CardErrorVariant`:
+`'error' | 'offline' | 'timeout' | 'table-missing' | 'permission'`.
+
+- **`permission`** — matched on keywords incl. ClickHouse's
+  `not_enough_privileges` / `not enough privileges`. `table-client.tsx` renders
+  a GRANT suggestion (`extractTableFromPermissionError` pulls the
+  `system.x`/`default.x` table out of the message to build
+  `GRANT SELECT ON <table> ...`).
+- **Version mismatch** — when a `QueryConfig.sql` is a `VersionedSql[]` whose
+  oldest `since` is newer than the host's version, `table-client.tsx` shows a
+  "requires ClickHouse ≥ X" notice instead of an error. Driven by
+  `isVersionOlder(current, required)` / `parseSimpleVersion()` (tested in
+  `lib/__tests__/card-error-utils.test.ts`).
+
+## GOTCHA — `permission` is NOT an `EmptyStateVariant`
+
+`CardErrorVariant` includes `'permission'`, but the shared `EmptyState`
+component's `variant` prop (`EmptyStateVariant`) does **not**. Passing a raw
+`detectCardErrorVariant(...)` straight into `<EmptyState variant={...}>` is a
+**type error**.
+
+Always map it through **`toEmptyStateVariant(variant)`** (in
+`card-error-utils.ts`), which falls back `permission → 'error'` for the visual
+while the permission-specific title/description still come from
+`getCardErrorTitle` / `getCardErrorDescription`. Every error `EmptyState` call
+site must use it: `running-queries`, `expensive-queries`, `part-log`,
+`slow-queries`, and `charts/chart-error.tsx`. Adding a new view that renders an
+error `EmptyState` from a `CardErrorVariant`? Wrap it with `toEmptyStateVariant`
+or the build breaks.


### PR DESCRIPTION
## What

Continues a stale in-progress branch, rebased onto current `main` and completed.

- **Sidebar muting**: menu items whose backing system table is missing on the current host are greyed out. One batched `/api/v1/table-availability?hostId=N` request (SWR-deduped, slow refresh, **fail-open** — treat as available unless explicitly false) powers all items (`useTableAvailability` / `useIsTableAvailable`).
- **Version-mismatch / permission UX**: table cards show a version-mismatch notice (feature needs CH ≥ X) and a permission notice with a GRANT example, instead of a raw error.
- **Version helpers** in `card-error-utils`: `parseSimpleVersion`, `isVersionOlder`, `extractTableFromPermissionError` — now **with tests** (the suite was missing them).

## Reconciliation (this was a rebase of stale WIP)

The branch predated a teammate's `permission`-variant merge, so it conflicted on `card-error-utils.ts` + `running-queries-view.tsx`:
- `card-error-utils.ts`: kept `origin`'s richer `timeout` keywords **and** merged in the WIP's ClickHouse-specific `permission` keywords.
- `running-queries-view.tsx`: kept **both** `origin`'s live "recently-completed" handoff block and the WIP's permission-variant handling.

## Completed the feature (was incomplete)

Adding `'permission'` to `CardErrorVariant` broke `<EmptyState variant={...}>` (no `permission` styling) at **3 sibling views the original WIP missed** — `expensive-queries`, `part-log`, `slow-queries`. Fixed centrally with a shared **`toEmptyStateVariant()`** (maps `permission → error`), which also re-uses the `EmptyStateVariant` import that was otherwise dead.

## Verified locally

`bun run type-check` ✅ · `biome check` ✅ · `bun test card-error-utils` ✅ (69 pass, incl. 12 new).

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar/menu items now mute when required system tables are unavailable.
  * Single batched availability check improves host-specific menu behavior.
  * Permission errors surface actionable GRANT suggestions; version checks warn when host is too old.

* **Improvements**
  * More accurate error classification and consistent empty-state rendering for permission/version cases.

* **Documentation**
  * Added docs describing table-availability behavior, API contract, and error/version guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->