### PR TITLE
fix(topology): stop label overlap, enclose keeper labels, move cluster pills to bottom

### DIFF
--- a/apps/web/components/cluster-topology/model.ts
+++ b/apps/web/components/cluster-topology/model.ts
@@ -190,7 +190,11 @@ export function isKeeperNode(n: KeeperNode | ChNode): n is KeeperNode {
 // room for each node's labels to sit INSIDE its cluster boundary.
 // Imported by the layout tests, so the in-viewBox bounds check moves with them.
 export const VB_W = 1280
-export const VB_H = 580
+// Taller than a pure 2-col fit so the keeper region (FQDN labels), the gap to
+// the CH band, and deeply-nested cluster rings + their bottom pills all sit in
+// view. The fixed-height container scales with preserveAspectRatio="meet", so
+// the extra height letterboxes gracefully instead of clipping content.
+export const VB_H = 640
 // Node radii are exported so the canvas glyphs render at exactly the size the
 // layout reserves spacing/hull padding for — no drift between layout and paint.
 // Sized so a typical hostname fits INSIDE the glyph (square card / hexagon).
@@ -211,7 +215,7 @@ export const CH_RENDER_CAP = 24
 // matching extent here or the label spills outside its cluster rect. The numbers
 // below decompose as: glyph radius (CH_R/KP_R) + label offset + line/badge height
 // + a small descender allowance. See docs/knowledge/cluster-topology.md.
-const ENVELOPE_MARGIN = 9 // breathing room between content and the boundary
+const ENVELOPE_MARGIN = 12 // breathing room between content and the boundary
 
 /** How far a ClickHouse glyph + its labels extend below its center. */
 function chDownExtent(n: ChNode): number {
@@ -224,9 +228,15 @@ const chUpExtent = () => CH_R + 8
 // Sub-line can be wider than the card (e.g. "cpu 99% · mem 99%"); clear it.
 const chHalfExtent = () => CH_R + 34
 
-/** Keeper hexagon + its labels. Leader has a star above; sub-line below. */
+/** Keeper hexagon + its labels. Leader has a star above; sub-line below.
+ *
+ * CONTRACT with `NodeLabel` in topo-canvas.tsx: when the host differs from the
+ * short id (an FQDN), the canvas paints the host line at `r+16` AND the sub-line
+ * at `r+31`; otherwise only the sub-line at `r+16`. The down-extent must cover
+ * whichever is drawn (+ a descender) or the follower labels spill below the
+ * keeper boundary into the cluster region — the reported overlap. */
 const keeperUpExtent = (k: KeeperNode) => KP_R + (k.isLeader ? 22 : 8)
-const keeperDownExtent = () => KP_R + 22
+const keeperDownExtent = (k: KeeperNode) => KP_R + (k.host !== k.id ? 42 : 26)
 const keeperHalfExtent = () => KP_R + 16
 
 export const STATUS_COLOR: Record<string, string> = {
@@ -833,7 +843,11 @@ export function layoutTopology(data: TopologyData): TopologyModel {
   // Auto-layout: translate the whole composition so its content (every node +
   // its labels) is centered in the draw area. This handles the no-keeper case
   // and any sparse layout — content sits in the middle instead of a fixed band.
-  centerContent(keepers, renderCh)
+  // Cluster RECTS outset past the node envelopes (margin + concentric NEST_STEP
+  // rings) and the name pills sit on the bottom edge, so reserve that room or a
+  // densely-nested graph spills below the viewBox.
+  const { padTop, padBottom } = boundaryReserve(data.clusters, chNodes)
+  centerContent(keepers, renderCh, padTop, padBottom)
 
   const nodeById: Record<string, KeeperNode | ChNode> = {}
   keepers.forEach((k) => {
@@ -915,18 +929,22 @@ function layoutKeepers(keepers: KeeperNode[]) {
   const followers = keepers.filter((_, i) => i !== leaderIdx)
   keepers[leaderIdx].x = cx
   keepers[leaderIdx].y = 100
-  const spread = Math.min(170, 110 + followers.length * 14)
+  // Spread followers wide enough that adjacent FQDN host labels (~166px when
+  // truncated to ~24 chars) never overlap — the glyph gap alone is not enough.
+  const spread = Math.min(280, 188 + followers.length * 16)
   const total = (followers.length - 1) * spread
+  // Sit the follower row below the leader's own label block (host + sub-line)
+  // so the leader's text never grazes the follower glyphs.
   followers.forEach((f, i) => {
     f.x = cx - total / 2 + i * spread
-    f.y = 198
+    f.y = 214
   })
 }
 
 // CH region: a band below the keepers. Layout is deterministic + seeded only by
 // structure so positions are stable across live ticks. The band leaves headroom
 // below for each node's two label lines + LOCAL badge (≈ CH_R + 46).
-const CH_BAND_Y = 340
+const CH_BAND_Y = 356
 const CH_BAND_H = 120
 const CH_MARGIN = 170
 
@@ -1087,7 +1105,45 @@ function clampToBand(nodes: ChNode[]) {
  * This is the "auto layout" — sparse graphs (no keeper, one node) sit centered
  * instead of stuck in a fixed band.
  */
-function centerContent(keepers: KeeperNode[], chNodes: ChNode[]) {
+/**
+ * Vertical room the cluster boundary rects + their bottom pills occupy BEYOND the
+ * node envelopes, so `centerContent` can keep the whole composition in view.
+ * Coincident logical clusters (same rendered member set) nest as concentric
+ * rings stepped by `NEST_STEP`; distinct ones get the small expand-only jitter.
+ * Name pills sit on the bottom edge → bottom needs an extra pill's worth.
+ */
+function boundaryReserve(
+  clusters: ClusterInfo[],
+  chNodes: ChNode[]
+): { padTop: number; padBottom: number } {
+  const ids = new Set(chNodes.map((n) => n.id))
+  const logical = clusters.filter(
+    (c) => !c.outline && Object.keys(c.members).some((id) => ids.has(id))
+  )
+  if (logical.length === 0) return { padTop: 0, padBottom: 0 }
+  const sig = (c: ClusterInfo) =>
+    Object.keys(c.members)
+      .filter((id) => ids.has(id))
+      .sort()
+      .join(',')
+  const groupSize = new Map<string, number>()
+  for (const c of logical) {
+    const s = sig(c)
+    groupSize.set(s, (groupSize.get(s) ?? 0) + 1)
+  }
+  const maxNest = Math.max(...groupSize.values())
+  // Outermost-ring outset for the deepest nest, else the distinct-rect jitter.
+  const ring = Math.max((maxNest - 1) * NEST_STEP, 21)
+  const pad = ring + ENVELOPE_MARGIN
+  return { padTop: pad, padBottom: pad + 20 }
+}
+
+function centerContent(
+  keepers: KeeperNode[],
+  chNodes: ChNode[],
+  padTop = 0,
+  padBottom = 0
+) {
   if (keepers.length === 0 && chNodes.length === 0) return
   let minX = Infinity
   let maxX = -Infinity
@@ -1097,7 +1153,7 @@ function centerContent(keepers: KeeperNode[], chNodes: ChNode[]) {
     minX = Math.min(minX, k.x - keeperHalfExtent())
     maxX = Math.max(maxX, k.x + keeperHalfExtent())
     minY = Math.min(minY, k.y - keeperUpExtent(k))
-    maxY = Math.max(maxY, k.y + keeperDownExtent())
+    maxY = Math.max(maxY, k.y + keeperDownExtent(k))
   }
   for (const c of chNodes) {
     minX = Math.min(minX, c.x - chHalfExtent())
@@ -1105,6 +1161,10 @@ function centerContent(keepers: KeeperNode[], chNodes: ChNode[]) {
     minY = Math.min(minY, c.y - chUpExtent())
     maxY = Math.max(maxY, c.y + chDownExtent(c))
   }
+  // Reserve room for the cluster boundary rects + their bottom pills, which sit
+  // outside the node envelopes, so the centered composition still fits.
+  minY -= padTop
+  maxY += padBottom
   let dx = (VB_W - minX - maxX) / 2
   let dy = (VB_H - minY - maxY) / 2
   // When content fits, keep it fully inside; otherwise anchor the top edge.
@@ -1178,7 +1238,7 @@ function buildKeeperRect(voters: KeeperNode[]): string {
   const minX = Math.min(...voters.map((k) => k.x - keeperHalfExtent()))
   const maxX = Math.max(...voters.map((k) => k.x + keeperHalfExtent()))
   const minY = Math.min(...voters.map((k) => k.y - keeperUpExtent(k)))
-  const maxY = Math.max(...voters.map((k) => k.y + keeperDownExtent()))
+  const maxY = Math.max(...voters.map((k) => k.y + keeperDownExtent(k)))
   const m = ENVELOPE_MARGIN
   return roundedRectPath(
     minX - m,
@@ -1200,7 +1260,7 @@ function buildKeeperRect(voters: KeeperNode[]): string {
 // Each coincident cluster (same member SET) is grown by this much per nesting
 // rank so the rects sit as concentric rings instead of stacking invisibly — the
 // "multiple clusters, same nodes" overlap case from the screenshot.
-const NEST_STEP = 16
+const NEST_STEP = 24
 
 function buildClusterHulls(
   clusters: ClusterInfo[],
@@ -1236,7 +1296,7 @@ function buildClusterHulls(
     let maxY = -Infinity
     for (const c of centers) {
       const down = isKeeperNode(c)
-        ? keeperDownExtent()
+        ? keeperDownExtent(c)
         : chDownExtent(c as ChNode)
       minX = Math.min(minX, c.x - chHalfExtent())
       maxX = Math.max(maxX, c.x + chHalfExtent())
@@ -1268,6 +1328,9 @@ function buildClusterHulls(
     const d = roundedRectPath(minX, minY, w, h, CLUSTER_RECT_RADIUS)
     if (!d) continue
     const cx = (minX + maxX) / 2
+    // Anchor the label to the rect's BOTTOM edge: the top edge sits in the
+    // crowded zone just under the keeper region, where pills get hidden or
+    // overlap node sub-lines. Below the cards is open space — pills stay clear.
     hulls.push({
       id: cl.id,
       name: cl.name,
@@ -1276,9 +1339,9 @@ function buildClusterHulls(
       d,
       area: w * h,
       labelX: cx,
-      labelY: minY,
+      labelY: maxY,
       anchorX: cx,
-      anchorY: minY,
+      anchorY: maxY,
       leader: false,
     })
   }
@@ -1289,16 +1352,18 @@ function buildClusterHulls(
 }
 
 /**
- * De-overlap cluster label pills so every name stays readable. Pills are stacked
- * upward when they would collide (estimating each pill's half-width from its
- * character count — matching `HullLabel`'s `text.length * 7 + 20`), and any pill
- * pushed away from its rect's top anchor is flagged so the canvas draws a thin
- * leader line back to the territory. Deterministic.
+ * De-overlap cluster label pills so every name stays readable. Pills anchor to
+ * each rect's BOTTOM edge and are stacked DOWNWARD when they would collide
+ * (estimating each pill's half-width from its character count — matching
+ * `HullLabel`'s `text.length * 7 + 20`). Any pill pushed away from its anchor is
+ * flagged so the canvas draws a thin leader line back to the territory. The open
+ * space below the cards means downward stacking never lands on a node.
+ * Deterministic.
  */
 function nudgeLabels(hulls: ClusterHull[]) {
   const ROW_H = 21 // pill height (19) + a hair of breathing room
   const halfW = (h: ClusterHull) => (h.name.length * 7 + 20) / 2
-  // Place left→right; lift each pill above any already-placed pill it overlaps.
+  // Place left→right; drop each pill below any already-placed pill it overlaps.
   const sorted = [...hulls].sort(
     (a, b) => a.labelX - b.labelX || a.id.localeCompare(b.id)
   )
@@ -1313,14 +1378,14 @@ function nudgeLabels(hulls: ClusterHull[]) {
         const overlapX = Math.abs(cur.labelX - p.labelX) < halfW(cur) + halfW(p)
         const overlapY = Math.abs(y - p.labelY) < ROW_H
         if (overlapX && overlapY) {
-          y = p.labelY - ROW_H
+          y = p.labelY + ROW_H
           moved = true
         }
       }
     }
     cur.labelY = y
-    // A pill lifted more than a row above its anchor reads as detached → leader.
-    cur.leader = cur.anchorY - cur.labelY > ROW_H + 2
+    // A pill dropped more than a row below its anchor reads as detached → leader.
+    cur.leader = cur.labelY - cur.anchorY > ROW_H + 2
     placed.push(cur)
   }
 }

--- a/apps/web/components/cluster-topology/model.ts
+++ b/apps/web/components/cluster-topology/model.ts
@@ -930,8 +930,15 @@ function layoutKeepers(keepers: KeeperNode[]) {
   keepers[leaderIdx].x = cx
   keepers[leaderIdx].y = 100
   // Spread followers wide enough that adjacent FQDN host labels (~166px when
-  // truncated to ~24 chars) never overlap — the glyph gap alone is not enough.
-  const spread = Math.min(280, 188 + followers.length * 16)
+  // truncated to ~24 chars) never overlap — the glyph gap alone is not enough —
+  // but cap the row to the usable width so large ensembles (7+ keepers) stay in
+  // the viewBox. centerContent can only clamp one side, so an over-wide row
+  // would leave the end keeper + its label off-canvas.
+  const desired = Math.min(280, 188 + followers.length * 16)
+  const spread =
+    followers.length > 1
+      ? Math.min(desired, (VB_W - 2 * CH_MARGIN) / (followers.length - 1))
+      : desired
   const total = (followers.length - 1) * spread
   // Sit the follower row below the leader's own label block (host + sub-line)
   // so the leader's text never grazes the follower glyphs.
@@ -1135,7 +1142,12 @@ function boundaryReserve(
   // Outermost-ring outset for the deepest nest, else the distinct-rect jitter.
   const ring = Math.max((maxNest - 1) * NEST_STEP, 21)
   const pad = ring + ENVELOPE_MARGIN
-  return { padTop: pad, padBottom: pad + 20 }
+  // Bottom pills can stack DOWNWARD by a PILL_ROW per horizontally-overlapping
+  // distinct cluster (coincident clusters nest as rings instead, so count member
+  // SETS, not clusters). Reserve a few rows so a busy graph's lowest pill stays
+  // in view; capped because spread-out pills rarely all share one x-column.
+  const stackRows = Math.min(groupSize.size, 3)
+  return { padTop: pad, padBottom: pad + stackRows * PILL_ROW_H + 8 }
 }
 
 function centerContent(
@@ -1223,6 +1235,11 @@ function enforceMinDistance(
 // Corner radius for the cluster territory rectangles — round enough that a
 // single-node cluster reads as a soft squircle, capped so it never over-rounds.
 const CLUSTER_RECT_RADIUS = 54
+
+// One stacked label-pill row (pill height 19 + a hair). Shared by `nudgeLabels`
+// (the actual downward stacking) and `boundaryReserve` (the room reserved for
+// it) so the two never drift.
+const PILL_ROW_H = 21
 
 /** Stable string hash → non-negative int. Deterministic (layout is tested). */
 function hashStr(s: string): number {
@@ -1361,7 +1378,7 @@ function buildClusterHulls(
  * Deterministic.
  */
 function nudgeLabels(hulls: ClusterHull[]) {
-  const ROW_H = 21 // pill height (19) + a hair of breathing room
+  const ROW_H = PILL_ROW_H
   const halfW = (h: ClusterHull) => (h.name.length * 7 + 20) / 2
   // Place left→right; drop each pill below any already-placed pill it overlaps.
   const sorted = [...hulls].sort(

--- a/apps/web/components/cluster-topology/topo-canvas.tsx
+++ b/apps/web/components/cluster-topology/topo-canvas.tsx
@@ -620,21 +620,21 @@ export function TopoCanvas({
             opacity={faded ? 0.2 : 1}
             style={{ transition: 'opacity .25s' }}
           >
-            <path d={h.d} fill={h.color} fillOpacity={active ? 0.16 : 0.1} />
+            <path d={h.d} fill={h.color} fillOpacity={active ? 0.14 : 0.08} />
             <path
               d={h.d}
               fill="none"
               stroke={h.color}
-              strokeOpacity={active ? 0.95 : 0.55}
-              strokeWidth={active ? 2.2 : 1.5}
+              strokeOpacity={active ? 0.95 : 0.65}
+              strokeWidth={active ? 2.4 : 1.7}
               strokeLinejoin="round"
             />
-            {/* leader line: when the pill was lifted off the rect to stay
-                readable, connect it back so the name stays clearly attributed. */}
+            {/* leader line: when the pill was dropped below the rect to stay
+                readable, connect it back up so the name stays attributed. */}
             {h.leader && (
               <line
                 x1={h.labelX}
-                y1={h.labelY + 9}
+                y1={h.labelY - 9}
                 x2={h.anchorX}
                 y2={h.anchorY}
                 stroke={h.color}

--- a/docs/knowledge/cluster-topology.md
+++ b/docs/knowledge/cluster-topology.md
@@ -186,7 +186,7 @@ only runs where `node_modules` is present, i.e. CI — not in a bare worktree).
 The canvas uses theme CSS vars, so you can't judge it from path strings. The reliable check is the
 committed harness **`scripts/topo-harness.tsx`**:
 
-```
+```shell
 bun run scripts/topo-harness.tsx > /tmp/topo.html   # then open via chrome-devtools MCP
 ```
 

--- a/docs/knowledge/cluster-topology.md
+++ b/docs/knowledge/cluster-topology.md
@@ -69,11 +69,12 @@ All in `model.ts` unless noted. **Do not change a number in isolation; check the
 
 | Constant | Meaning | Contract / why |
 |----------|---------|----------------|
-| `VB_W` `VB_H` | viewBox (1280×580) | Wide aspect fills the 2-col container (≈2.2). **Imported by the layout tests** so the in-bounds check moves with them. |
+| `VB_W` `VB_H` | viewBox (1280×640) | Taller than a pure 2-col fit so the keeper region (FQDN labels), the keeper↔CH gap, and deeply-nested rings + bottom pills all sit in view. The fixed-height container scales `preserveAspectRatio="meet"`, so extra height letterboxes instead of clipping. **Imported by the layout tests** so the in-bounds check moves with them. |
 | `CH_R` `KP_R` | node radii (42 / 40) | **Exported & imported by `topo-canvas.tsx`** so the drawn glyph == the size layout reserves. Single source of truth — never redeclare in the canvas. |
 | `chHalfExtent / chUpExtent / chDownExtent` | CH node CONTENT envelope (glyph + labels) | **CONTRACT with `topo-canvas.tsx` label positions.** `chDownExtent` must cover the sub-line / host line / LOCAL badge the canvas paints (see `NodeLabel` + the LOCAL badge `r + …`). If you move a label in the canvas, update the matching extent here or it spills outside its cluster boundary. |
-| `keeperHalf/Up/DownExtent` | Keeper envelope | Same contract with the keeper glyph (`star` above → bigger up-extent for leaders). |
-| `ENVELOPE_MARGIN` | breathing room between content and a boundary | Applied in `buildClusterHulls` + `buildKeeperRect`. |
+| `keeperHalf/Up/DownExtent` | Keeper envelope | Same contract with the keeper glyph (`star` above → bigger up-extent for leaders). `keeperDownExtent(k)` is **node-aware**: when the keeper host is an FQDN (`host !== id`), `NodeLabel` paints a host line AT `r+16` **and** a sub-line at `r+31`, so the extent is `KP_R + 42` (vs `KP_R + 26` for short hosts). Get this wrong and follower labels spill below the green boundary into the cluster region. |
+| `ENVELOPE_MARGIN` | breathing room between content and a boundary (12) | Applied in `buildClusterHulls` + `buildKeeperRect`. |
+| `boundaryReserve(...) → centerContent padTop/padBottom` | room the rings + bottom pills need beyond the node envelopes | `centerContent` only knows node envelopes; the rects outset past them (`ENVELOPE_MARGIN` + concentric `NEST_STEP`) and pills sit on the bottom edge. `boundaryReserve` derives a top/bottom pad from the deepest coincident nest so a densely-nested graph stays in view. |
 | `CLUSTER_RECT_RADIUS` | corner radius of territory rects | Capped to half the shorter side in `roundedRectPath`. |
 | `enforceMinDistance(... CH_R*2 + 92)` | min node gap | Sized so a **single-node** cluster boundary (≈ `CH_R + chHalfExtent + margin`) cannot reach a neighbor glyph. If you shrink this, boundaries start cutting neighbors. |
 | `CH_BAND_Y/H`, `CH_MARGIN` | the CH region rectangle | Relative placement only — `centerContent` re-centers afterward, so exact values matter less than the keeper↔CH gap. |
@@ -146,10 +147,14 @@ Locked by `model.test.ts` → "local-duplicate merge".
   the same hosts) are drawn as **concentric nested rects**: `buildClusterHulls` ranks each cluster
   within its member-set signature and outsets ring `k` by `k * NEST_STEP`. Distinct-but-overlapping
   clusters keep the small `hashStr` jitter instead.
-- **Cluster label pills** de-overlap in `nudgeLabels`: width-aware (`name.length*7+20`, matching
-  `HullLabel`) upward stacking against ALL already-placed pills. A pill lifted off its rect sets
-  `ClusterHull.leader`, and the canvas draws a thin dashed **leader line** from the pill back to the
-  rect's top-center (`anchorX/anchorY`) so the name stays attributed.
+- **Cluster label pills** anchor to each rect's **BOTTOM** edge (`labelY = maxY`), not the top: the
+  top edge sits in the crowded zone just under the keeper region where pills got hidden or overlapped
+  node sub-lines; below the cards is open space. `nudgeLabels` de-overlaps width-aware
+  (`name.length*7+20`, matching `HullLabel`) by stacking **downward** against ALL already-placed
+  pills. A pill dropped off its rect sets `ClusterHull.leader`, and the canvas draws a thin dashed
+  **leader line** from the pill UP to the rect's bottom-center (`anchorX/anchorY`). Concentric
+  coincident rings are stepped by `NEST_STEP` (24) > pill height, so each ring's pill sits on its own
+  bottom edge without stacking.
 
 ## Shared component
 
@@ -163,7 +168,7 @@ only branch in `page.tsx`.
 
 ## Test invariants (do not break)
 
-`bun test apps/web/components/cluster-topology/__tests__/` — 33 pure tests, runnable without
+`bun test apps/web/components/cluster-topology/__tests__/` — 36 pure tests, runnable without
 `node_modules`. They lock:
 - hull path shape per node count; **area-DESC z-order**; replication-edge rules.
 - **shared-node-between-centroids** (overlap lens) — relative x order; `centerContent` translates
@@ -178,19 +183,20 @@ only runs where `node_modules` is present, i.e. CI — not in a bare worktree).
 
 ## Verification harness (how to eyeball changes safely)
 
-The canvas uses theme CSS vars, so you can't judge it from path strings. The reliable check:
-render the **real laid-out model** into a standalone HTML page with the app's true OKLCH vars
-(light + dark) and screenshot it. Pattern used during development:
+The canvas uses theme CSS vars, so you can't judge it from path strings. The reliable check is the
+committed harness **`scripts/topo-harness.tsx`**:
 
-1. A bun script imports `buildTopologyModel` from `model.ts` (works without `node_modules` —
-   the model's only real import is `./geometry`; everything else is `import type`).
-2. Build fixtures (rich multi-cluster, single-node-no-keeper, dense) → models.
-3. Emit an SVG that **mirrors `topo-canvas.tsx`** glyphs, with `--card/--foreground/--muted/…`
-   set to the real oklch values for each theme.
-4. Open via the chrome-devtools MCP and screenshot.
+```
+bun run scripts/topo-harness.tsx > /tmp/topo.html   # then open via chrome-devtools MCP
+```
 
-This catches the OKLCH black-fill regression, label-outside-boundary, collisions, and clipping
-that pure tests can't. Mirror any canvas glyph change into the harness so the preview stays faithful.
+It renders the **real `<TopoCanvas>`** via `react-dom/server` (no glyph mirroring → no drift) for
+representative fixtures (local-duplicate = the reported screenshot, host-overlap, coincident nested
+rings), into a page carrying the true light-theme OKLCH vars from `globals.css`. Screenshot it, and
+for hard cases measure overflow directly in the browser — `getBoundingClientRect` of every `<text>`
+vs the `<svg>`'s client box is the ground truth for "does a label clip the viewBox" (`getBBox`
+returns *local* coords and will mislead). This catches the OKLCH black-fill regression,
+label-outside-boundary, collisions, and clipping that pure tests can't.
 
 ## Safe-change recipes
 

--- a/scripts/topo-harness.tsx
+++ b/scripts/topo-harness.tsx
@@ -48,6 +48,7 @@ const fqdnKeepers = (n: number): KeeperInfoRow[] =>
     avg_latency: i,
   }))
 
+/** Synthetic per-node CPU/mem so the live CPU meter + sub-line render. */
 const liveFor = (model: ReturnType<typeof buildTopologyModel>) => {
   const live: Record<string, { cpuPct: number | null; memPct: number | null }> =
     {}
@@ -103,7 +104,7 @@ const html = `<!doctype html><html><head><meta charset="utf-8"><style>
   section{padding:24px}
   h2{font-size:14px;font-weight:600;margin:0 0 8px;color:var(--muted-foreground)}
   .frame{border:1px solid var(--border);border-radius:12px;background:var(--background);
-    aspect-ratio:1280/580;width:100%;max-width:1280px;overflow:hidden}
+    aspect-ratio:2/1;width:100%;max-width:1280px;overflow:hidden}
   .frame svg{width:100%;height:100%}
 </style></head><body>${cards}</body></html>`
 

--- a/scripts/topo-harness.tsx
+++ b/scripts/topo-harness.tsx
@@ -1,0 +1,110 @@
+/**
+ * Dev-only verification harness for the cluster-topology canvas.
+ *
+ * Renders the REAL <TopoCanvas> (via react-dom/server) for representative
+ * fixtures into a standalone HTML page with the app's true OKLCH theme vars, so
+ * label overlaps / boundary spills can be eyeballed + screenshotted. NOT shipped.
+ *
+ *   bun run scripts/topo-harness.tsx > /tmp/topo.html
+ */
+
+import type { KeeperInfoRow } from '../apps/web/components/cluster-topology/model'
+
+import {
+  chRow,
+  keepers,
+  localDuplicateClusters,
+  overlapClusters,
+} from '../apps/web/components/cluster-topology/__tests__/fixtures'
+import { buildTopologyModel } from '../apps/web/components/cluster-topology/model'
+import { TopoCanvas } from '../apps/web/components/cluster-topology/topo-canvas'
+import { createElement as h } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+/** Three logical clusters over the SAME three hosts → concentric nested rings,
+ * exercising the downward pill stacking + leader lines. */
+const coincidentClusters = () =>
+  ['all-replicated-cluster', 'all-sharded', 'analytics'].flatMap((cluster) =>
+    [0, 1, 2].map((i) =>
+      chRow({
+        cluster,
+        host_name: `chi-clickhouse-cluster-0-${i}.clickhouse.svc.cluster.local`,
+        host_address: `10.0.0.${10 + i}`,
+        shard_num: i + 1,
+        replica_num: 1,
+        database_shard_name: 'sh',
+      })
+    )
+  )
+
+/** Keepers with real FQDN hosts (matches the reported screenshot). */
+const fqdnKeepers = (n: number): KeeperInfoRow[] =>
+  Array.from({ length: n }, (_, i) => ({
+    host: `clickhouse-keeper-${i}.clickhouse-keeper.svc.cluster.local`,
+    port: 9181,
+    is_connected: 1,
+    is_leader: i === 0 ? 1 : 0,
+    server_state: i === 0 ? 'leader' : 'follower',
+    avg_latency: i,
+  }))
+
+const liveFor = (model: ReturnType<typeof buildTopologyModel>) => {
+  const live: Record<string, { cpuPct: number | null; memPct: number | null }> =
+    {}
+  model.chNodes.forEach((n, i) => {
+    live[n.id] = { cpuPct: 1 + i * 7, memPct: 2 + i * 5 }
+  })
+  return live
+}
+
+const scenarios: {
+  name: string
+  model: ReturnType<typeof buildTopologyModel>
+}[] = [
+  {
+    name: 'local-duplicate (screenshot): 3 keepers + cluster pods',
+    model: buildTopologyModel(localDuplicateClusters(), fqdnKeepers(3)),
+  },
+  {
+    name: 'overlap: two clusters share a host, single keeper',
+    model: buildTopologyModel(overlapClusters(), keepers(1)),
+  },
+  {
+    name: 'coincident: 3 logical clusters over the same 3 hosts (nested rings)',
+    model: buildTopologyModel(coincidentClusters(), fqdnKeepers(3)),
+  },
+]
+
+const cards = scenarios
+  .map(({ name, model }) => {
+    const svg = renderToStaticMarkup(
+      h(TopoCanvas, {
+        model,
+        liveById: liveFor(model),
+        selected: null,
+        activeCluster: null,
+        onSelect: () => {},
+        onClearSelect: () => {},
+      })
+    )
+    return `<section><h2>${name}</h2><div class="frame">${svg}</div></section>`
+  })
+  .join('\n')
+
+// Real OKLCH theme tokens (light root) from apps/web/app/globals.css.
+const html = `<!doctype html><html><head><meta charset="utf-8"><style>
+  :root{
+    --background:oklch(1 0 0); --foreground:oklch(0.145 0 0);
+    --card:oklch(1 0 0); --muted:oklch(0.97 0 0);
+    --muted-foreground:oklch(0.556 0 0); --primary:oklch(0.205 0 0);
+    --border:oklch(0.922 0 0);
+  }
+  body{margin:0;background:var(--background);font-family:ui-sans-serif,system-ui;color:var(--foreground)}
+  section{padding:24px}
+  h2{font-size:14px;font-weight:600;margin:0 0 8px;color:var(--muted-foreground)}
+  .frame{border:1px solid var(--border);border-radius:12px;background:var(--background);
+    aspect-ratio:1280/580;width:100%;max-width:1280px;overflow:hidden}
+  .frame svg{width:100%;height:100%}
+</style></head><body>${cards}</body></html>`
+
+process.stdout.write(html)


### PR DESCRIPTION
## Problem

The `/clusters` topology graph (and the **Cluster Topology** tab on `/overview`) had three reported issues, all in the congested vertical zone between the Keeper quorum and the cluster region:

1. **Text overlap** — follower keeper FQDN labels collided with each other, and their sub-lines spilled *below* the green keeper boundary into the cluster region.
2. **Cluster labels hidden/overlapping** — logical-cluster name pills anchored to the rect's *top* edge, which sits exactly in that crowded zone.
3. **Weak boundaries** — concentric cluster rings read as one blur.

## Fix

`apps/web/components/cluster-topology/model.ts`:
- **`keeperDownExtent` is now node-aware** — an FQDN keeper paints a host line at `r+16` **and** a sub-line at `r+31`, so reserve `KP_R+42` (vs `KP_R+26`). This was the envelope↔label contract break that let follower labels spill below the boundary.
- **Widen follower spread** and drop the follower row below the leader's own label block so adjacent FQDN labels never collide.
- **Nudge the CH band down** for a clear gap below the (now taller) keeper region.
- **Cluster pills move to the rect BOTTOM edge** (open space below the cards); `nudgeLabels` stacks downward; the leader line points up to the bottom anchor.
- **Clearer boundaries** — `NEST_STEP` 16→24 + stronger border stroke so concentric rings read as distinct; `ENVELOPE_MARGIN` 9→12.
- **`boundaryReserve()`** feeds `centerContent` top/bottom padding from the deepest coincident nest, and **`VB_H` 580→640**, so densely-nested graphs + their bottom pills stay inside the viewBox.

## Verification

Added `scripts/topo-harness.tsx` — renders the **real** `<TopoCanvas>` via `react-dom/server` (no glyph mirroring → no drift) for the screenshot fixtures (local-duplicate, host-overlap, coincident nested rings). Verified visually with the chrome-devtools MCP and measured **zero label overflow** of the viewBox via `getBoundingClientRect` in all three scenarios.

- ✅ `bun test apps/web/components/cluster-topology/__tests__/` — 36 pass
- ✅ `bun run lint` (only pre-existing unrelated warnings)
- ✅ `bun run type-check`
- 📚 `docs/knowledge/cluster-topology.md` updated for every contract changed

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Expanded topology canvas vertical space and refined node/keeper placement for clearer layout
  * Wider follower spacing, adjusted vertical anchors, and improved cluster hull rendering and overlays
  * Label pills now anchor to territory bottoms and stack downward to avoid collisions; leader lines updated

* **Documentation**
  * Revised cluster-topology docs with updated layout contracts and verification guidance

* **Tools**
  * Added a dev harness to render and test representative topology scenarios in-browser/SSR
<!-- end of auto-generated comment: release notes by coderabbit.ai -->