### PR TITLE
fix(clerk): handle signOut error gracefully

### DIFF
--- a/apps/web/components/nav-user/clerk-nav.tsx
+++ b/apps/web/components/nav-user/clerk-nav.tsx
@@ -9,7 +9,7 @@ import {
   User as UserIcon,
 } from 'lucide-react'
 
-import { SignInButton, SignOutButton, useClerk, useUser } from '@clerk/nextjs'
+import { SignInButton, useClerk, useUser } from '@clerk/nextjs'
 import { useState } from 'react'
 import { useSettingsShortcut } from '@/components/nav-user/use-settings-shortcut'
 import { SettingsDialog } from '@/components/settings'
@@ -42,7 +42,7 @@ import { isFeatureAllowed } from '@/lib/feature-permissions/shared'
  */
 export function ClerkNavWrapper() {
   const { user, isLoaded, isSignedIn } = useUser()
-  const { openUserProfile } = useClerk()
+  const { openUserProfile, signOut } = useClerk()
   const { isMobile } = useSidebar()
   const [settingsOpen, setSettingsOpen] = useState(false)
   const { config } = useFeaturePermissions()
@@ -193,12 +193,20 @@ export function ClerkNavWrapper() {
                   )}
                 </DropdownMenuGroup>
                 <DropdownMenuSeparator />
-                <SignOutButton>
-                  <DropdownMenuItem className="flex items-center gap-2 text-destructive focus:text-destructive">
-                    <LogOut className="size-4" />
-                    <span>Sign Out</span>
-                  </DropdownMenuItem>
-                </SignOutButton>
+                <DropdownMenuItem
+                  className="flex items-center gap-2 text-destructive focus:text-destructive"
+                  onSelect={async () => {
+                    try {
+                      await signOut({ redirectUrl: '/' })
+                    } catch {
+                      // Fallback: force navigation to clear client-side state
+                      window.location.href = '/'
+                    }
+                  }}
+                >
+                  <LogOut className="size-4" />
+                  <span>Sign Out</span>
+                </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
           )}


### PR DESCRIPTION
## Problem

Clicking "Sign Out" in the user menu throws an uncaught promise rejection:

```
Uncaught (in promise) Error: An unexpected response was received from the server.
```

This happens because Clerk's `<SignOutButton>` component calls `signOut()` internally with **no error handling**. On Cloudflare Workers, the `__clerk` proxy response can fail (network latency, proxy race condition during session revoke), and the rejection propagates as an uncaught error.

## Fix

- Replace `<SignOutButton>` wrapper with direct `signOut()` call from `useClerk()`
- Add `try/catch` with `redirectUrl: '/'` and fallback `window.location.href = '/'`
- Eliminates nested interactive elements (`<button>` inside `<DropdownMenuItem>`)

## Changes

| File | Change |
|------|--------|
| `components/nav-user/clerk-nav.tsx` | Replace `SignOutButton` with `signOut()` + error handling |

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Handle Clerk sign-out errors gracefully in the user dropdown menu.

Bug Fixes:
- Prevent uncaught promise rejections when signing out by invoking Clerk's signOut with error handling from the user menu.

Enhancements:
- Simplify the sign-out dropdown item by removing the nested SignOutButton wrapper and using the menu item as the sole interactive element.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced sign-out functionality with improved error handling to ensure users are reliably signed out and properly redirected in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->