### PR TITLE
fix(data-table): address Gemini review on filterable columns

### DIFF
--- a/apps/web/components/data-table/components/data-table-header.cy.tsx
+++ b/apps/web/components/data-table/components/data-table-header.cy.tsx
@@ -261,6 +261,8 @@ describe('<DataTableHeader />', () => {
     cy.mount(<ActionTableHeader />)
 
     cy.contains('button', 'Filters').click()
+    // Radix Select mounts its options lazily — open the column select first.
+    cy.get('button').contains('query').click()
     cy.get('[role="option"]').should('contain.text', 'query')
     cy.get('[role="option"]').should('not.contain.text', 'action')
   })

--- a/apps/web/components/data-table/components/data-table-header.tsx
+++ b/apps/web/components/data-table/components/data-table-header.tsx
@@ -179,11 +179,11 @@ export const DataTableHeader = memo(function DataTableHeader<
   const [filterDrafts, setFilterDrafts] = useState<TableFilterCondition[]>([])
   const [isFiltersOpen, setIsFiltersOpen] = useState(false)
 
-  // Get eligible columns for advanced filtering
-  const filterableColumns = table.getAllLeafColumns().filter((col) => {
-    const id = col.id
-    return id !== '__expand' && id !== 'select' && id !== 'action'
-  })
+  // Get eligible columns for advanced filtering, excluding synthetic
+  // utility columns (see CLAUDE.md: `__expand`, `select`, `action`).
+  const filterableColumns = table
+    .getAllLeafColumns()
+    .filter((col) => !['__expand', 'select', 'action'].includes(col.id))
 
   // Stable unique IDs for filter drafts (avoids Math.random collisions)
   const createFilterId = () =>


### PR DESCRIPTION
Follow-up to #1357 (which auto-merged before these review comments were applied).

Addresses two Gemini review comments on the action-column filter work:

- **Cypress test (high):** open the column `Select` before asserting on its options. Radix mounts `SelectItem` (`[role="option"]`) lazily on open and portals them to `document.body`, so the prior assertion ran before any options existed.
- **Refactor (medium):** replace the `&&` chain with an array `.includes()` check for the synthetic-column exclusion, keeping the documented ids `__expand`/`select`/`action` (skipped the speculative `actions` plural — not a convention in this codebase per CLAUDE.md).

## Verification
- `bun run lint` ✅ · pre-commit `tsc --noEmit` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refine data table header filtering behavior and stabilize the associated Cypress test for filterable action columns.

Bug Fixes:
- Ensure the Cypress test opens the column select so lazily mounted Radix options exist before assertions.

Enhancements:
- Simplify filterable column selection by excluding known synthetic utility column IDs via an array includes check.