### PR TITLE
fix(filters): hide filter bar when empty, keep display options open, normal button sizes

### DIFF
--- a/apps/web/components/data-table/components/data-table-header.tsx
+++ b/apps/web/components/data-table/components/data-table-header.tsx
@@ -350,13 +350,22 @@ export const DataTableHeader = memo(function DataTableHeader<
                     <DropdownMenuRadioItem
                       value="comfortable"
                       className="text-xs"
+                      onSelect={(e) => e.preventDefault()}
                     >
                       Comfortable
                     </DropdownMenuRadioItem>
-                    <DropdownMenuRadioItem value="compact" className="text-xs">
+                    <DropdownMenuRadioItem
+                      value="compact"
+                      className="text-xs"
+                      onSelect={(e) => e.preventDefault()}
+                    >
                       Compact
                     </DropdownMenuRadioItem>
-                    <DropdownMenuRadioItem value="dense" className="text-xs">
+                    <DropdownMenuRadioItem
+                      value="dense"
+                      className="text-xs"
+                      onSelect={(e) => e.preventDefault()}
+                    >
                       Dense
                     </DropdownMenuRadioItem>
                   </DropdownMenuRadioGroup>
@@ -598,13 +607,22 @@ export const DataTableHeader = memo(function DataTableHeader<
                     <DropdownMenuRadioItem
                       value="comfortable"
                       className="text-xs"
+                      onSelect={(e) => e.preventDefault()}
                     >
                       Comfortable
                     </DropdownMenuRadioItem>
-                    <DropdownMenuRadioItem value="compact" className="text-xs">
+                    <DropdownMenuRadioItem
+                      value="compact"
+                      className="text-xs"
+                      onSelect={(e) => e.preventDefault()}
+                    >
                       Compact
                     </DropdownMenuRadioItem>
-                    <DropdownMenuRadioItem value="dense" className="text-xs">
+                    <DropdownMenuRadioItem
+                      value="dense"
+                      className="text-xs"
+                      onSelect={(e) => e.preventDefault()}
+                    >
                       Dense
                     </DropdownMenuRadioItem>
                   </DropdownMenuRadioGroup>

--- a/apps/web/components/data-table/data-table.tsx
+++ b/apps/web/components/data-table/data-table.tsx
@@ -609,7 +609,10 @@ export function DataTable<
             advancedFilters={advancedFilters}
             onAdvancedFiltersChange={setAdvancedFilters}
             filterBarSlot={
-              !compact && showFilterBar && queryConfig.filterSchema ? (
+              !compact &&
+              showFilterBar &&
+              queryConfig.filterSchema &&
+              data.length > 0 ? (
                 <FilterBar queryConfig={queryConfig} />
               ) : undefined
             }

--- a/apps/web/components/data-table/data-table.tsx
+++ b/apps/web/components/data-table/data-table.tsx
@@ -21,6 +21,7 @@ import type { ChartQueryParams } from '@/types/chart-data'
 import type { ExpandableConfig, QueryConfig } from '@/types/query-config'
 
 import { arrayMove } from '@dnd-kit/sortable'
+import { useSearchParams } from 'next/navigation'
 import { useState } from 'react'
 import {
   buildExpandColumnDef,
@@ -194,6 +195,16 @@ export function DataTable<
 }: DataTableProps<TData>) {
   // Resolve expansion config: explicit prop wins over QueryConfig declaration
   const expandable = expandableProp ?? queryConfig.expandable
+
+  // Check if schema-driven filter bar has active URL filters (q param or field keys)
+  const searchParams = useSearchParams()
+  const hasActiveSchemaFilters = Boolean(
+    queryConfig.filterSchema &&
+      (searchParams.get('q') ||
+        queryConfig.filterSchema.fields.some((field) =>
+          searchParams.has(field.key)
+        ))
+  )
 
   const {
     enableColumnResizing: resolvedEnableColumnResizing,
@@ -612,7 +623,7 @@ export function DataTable<
               !compact &&
               showFilterBar &&
               queryConfig.filterSchema &&
-              data.length > 0 ? (
+              (data.length > 0 || hasActiveSchemaFilters) ? (
                 <FilterBar queryConfig={queryConfig} />
               ) : undefined
             }

--- a/apps/web/components/data-table/data-table.tsx
+++ b/apps/web/components/data-table/data-table.tsx
@@ -201,7 +201,7 @@ export function DataTable<
   const hasActiveSchemaFilters = Boolean(
     queryConfig.filterSchema &&
       (searchParams.get('q') ||
-        queryConfig.filterSchema.fields.some((field) =>
+        queryConfig.filterSchema.fields?.some((field) =>
           searchParams.has(field.key)
         ))
   )

--- a/apps/web/components/filters/add-filter-popover.tsx
+++ b/apps/web/components/filters/add-filter-popover.tsx
@@ -51,11 +51,7 @@ export function AddFilterPopover({
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-7 gap-1 border-dashed text-xs"
-        >
+        <Button variant="outline" className="gap-1 border-dashed text-xs">
           <PlusIcon className="size-3.5" />
           Add filter
         </Button>

--- a/apps/web/components/filters/filter-bar.tsx
+++ b/apps/web/components/filters/filter-bar.tsx
@@ -159,8 +159,7 @@ export function FilterBar({ queryConfig }: FilterBarProps) {
       {activeFilters.length > 0 && (
         <Button
           variant="ghost"
-          size="sm"
-          className="h-7 text-xs text-muted-foreground"
+          className="text-xs text-muted-foreground"
           onClick={clearAll}
         >
           Clear all


### PR DESCRIPTION
## Summary

Three UX polish fixes for the filter bar and display options dropdown.

## Changes

- **Hide filter bar when no data** — Filter bar toolbar (search input, Add filter, chips) no longer renders when the table has zero rows. Avoids showing an empty bordered container.
- **Keep display options dropdown open on selection** — Added `onSelect={(e) => e.preventDefault()}` to density radio items so the dropdown stays open when toggling density/columns (column checkboxes already had this).
- **Default button sizes** — "Add filter" and "Clear all" buttons now use default size (`h-9`) instead of `size="sm"` with `h-7`, matching the filter bar's search input height.

## Files Changed

| File | Change |
|------|--------|
| `data-table.tsx` | Add `data.length > 0` check before rendering filterBarSlot |
| `data-table-header.tsx` | Add `onSelect preventDefault` to density radio items (both toolbar modes) |
| `add-filter-popover.tsx` | Remove `size="sm"` and `h-7` from Add filter button |
| `filter-bar.tsx` | Remove `size="sm"` and `h-7` from Clear all button |

## Summary by Sourcery

Polish the data table filter bar and display options dropdown behaviour for a smoother, more consistent UX.

Bug Fixes:
- Keep the display options density dropdown open when toggling between density options by preventing default selection behaviour.

Enhancements:
- Hide the filter bar entirely when the table has no rows to avoid displaying an empty container.
- Align the Add filter and Clear all buttons with default filter bar control sizing by removing their small/short styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filter bar now only appears when the table has data or when schema-driven filters are active.
  * Density dropdown selection adjusted to prevent unintended selection interactions.

* **Style**
  * Simplified styling for filter-related buttons and the "Add filter" trigger for a cleaner, more consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->