### PR TITLE
fix(data-table): stop Presets full-page re-render + redesign column headers

### DIFF
--- a/apps/web/components/filters/presets-menu.cy.tsx
+++ b/apps/web/components/filters/presets-menu.cy.tsx
@@ -36,4 +36,22 @@ describe('PresetsMenu', () => {
     // No menu items rendered, but the trigger should still exist.
     cy.get('[role="menuitem"]').should('not.exist')
   })
+
+  // Regression: a modal dropdown runs Radix `hideOthers()`, stamping
+  // `aria-hidden` across every sibling container on open. On a full page that
+  // recomputes the whole a11y/style tree — the "full page re-render" symptom.
+  // `modal={false}` must keep outside content untouched while the menu is open.
+  it('does not mark sibling content aria-hidden when opened', () => {
+    cy.mount(
+      <div>
+        <div data-testid="outside">Outside content</div>
+        <PresetsMenu presets={presets} onApply={cy.stub()} />
+      </div>
+    )
+
+    cy.contains('button', 'Presets').click()
+    cy.contains('Slow queries').should('be.visible')
+
+    cy.get('[data-testid="outside"]').should('not.have.attr', 'aria-hidden')
+  })
 })

--- a/apps/web/components/filters/presets-menu.tsx
+++ b/apps/web/components/filters/presets-menu.tsx
@@ -20,7 +20,12 @@ interface PresetsMenuProps {
 /** Dropdown of one-click filter bundles. */
 export function PresetsMenu({ presets, onApply }: PresetsMenuProps) {
   return (
-    <DropdownMenu>
+    // `modal={false}` matches the sibling "Display options" dropdown. The
+    // default modal behavior runs Radix `hideOthers()`, which stamps
+    // `aria-hidden` onto every top-level container (sidebar, header, the whole
+    // table) on open and strips them on close — forcing a full-page a11y/style
+    // recompute that reads as a "full page re-render" each time Presets opens.
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <Button variant="outline" size="sm" className="gap-1.5 px-3 rounded-lg">
           <SparklesIcon className="size-3.5" />


### PR DESCRIPTION
## 1. Presets menu full-page re-render

### Problem
On `/history-queries` (any table page with filter presets), clicking **Presets** triggered a full-page re-render / visible jank.

### Root cause
`PresetsMenu` used Radix `DropdownMenu` with its **default `modal={true}`**. A modal overlay runs Radix `hideOthers()`, which stamps `aria-hidden`/`data-aria-hidden` onto **every top-level sibling** of the menu portal — the sidebar, `<header>`, the `<main>` content wrapper, etc. — on open, then strips them on close.

Verified live on chmonitor.dev: opening Presets toggles `aria-hidden` on **18 root containers** wrapping the entire page → full-page a11y/style recompute.

`Popover` defaults to `modal={false}` (so Add filter / chips were fine); only the `DropdownMenu`-based Presets had it.

### Fix
`modal={false}` on the Presets `DropdownMenu`, matching the sibling **Display options** dropdown that already does this. Behavior otherwise unchanged. Added a Cypress regression test asserting siblings are not marked `aria-hidden` on open.

## 2. Column header redesign (Cloudflare-style)

Learned from the Cloudflare DNS table — clean, sentence-case, readable headers.

- **Background**: `bg-muted/95` → `bg-background/95`, separated by a bottom border (near-white, not gray).
- **Typography**: dropped `uppercase` + `tracking-wider`; sentence case at 13px, `foreground/80`. The caps + letter-spacing inflated text width ~25%, truncating labels (`memory_u…`, `event_ti…`) even with free column space.
- **Selection**: removed stacked `select-none` so header titles can be selected.

## Knowledge
Documented the `modal={false}` rule for toolbar overlays in `docs/knowledge/conventions.md`.

Co-Authored-By: duyetbot <bot@duyet.net>