### PR TITLE
fix(data-table): redesign column headers (Cloudflare-style)

### DIFF
--- a/apps/web/components/data-table/column-defs/components/column-header.tsx
+++ b/apps/web/components/data-table/column-defs/components/column-header.tsx
@@ -77,8 +77,8 @@ function HeaderContent({
   }
 
   return (
-    <span className="inline-flex flex-1 min-w-0 items-center gap-1 truncate text-muted-foreground">
-      {Icon && <Icon className="size-3 shrink-0" />}
+    <span className="inline-flex min-w-0 flex-1 items-center gap-1.5 text-foreground/80">
+      {Icon && <Icon className="size-3.5 shrink-0" />}
       <span className="truncate">{name}</span>
     </span>
   )
@@ -107,7 +107,7 @@ export function ColumnHeader<TData extends RowData>({
     <div className="flex flex-col gap-1">
       <div
         className={cn(
-          'flex w-full items-center gap-1 truncate text-xs font-medium uppercase tracking-wider select-none'
+          'flex w-full items-center gap-1 text-[13px] font-medium normal-case tracking-normal'
         )}
       >
         <button
@@ -118,7 +118,7 @@ export function ColumnHeader<TData extends RowData>({
             if (canSort) column.toggleSorting(sortState === 'asc')
           }}
           className={cn(
-            'flex flex-1 min-w-0 items-center gap-0.5 truncate text-left',
+            'flex min-w-0 flex-1 items-center gap-0.5 text-left',
             canSort && 'cursor-pointer hover:text-foreground'
           )}
         >

--- a/apps/web/components/data-table/components/data-table-content.tsx
+++ b/apps/web/components/data-table/components/data-table-content.tsx
@@ -207,7 +207,7 @@ export const DataTableContent = memo(function DataTableContent<
       <caption id="table-description" className="sr-only">
         {description || queryConfig.description || `${title} data table`}
       </caption>
-      <TableHeader className="bg-muted/95 backdrop-blur-sm sticky top-0 z-10 border-b border-border/50">
+      <TableHeader className="bg-background/95 backdrop-blur-sm sticky top-0 z-10 border-b border-border">
         <TableHeaderRenderer
           headerGroups={table.getHeaderGroups()}
           onAutoFit={onAutoFit}

--- a/apps/web/components/data-table/components/data-table-content.tsx
+++ b/apps/web/components/data-table/components/data-table-content.tsx
@@ -207,7 +207,7 @@ export const DataTableContent = memo(function DataTableContent<
       <caption id="table-description" className="sr-only">
         {description || queryConfig.description || `${title} data table`}
       </caption>
-      <TableHeader className="bg-background/95 backdrop-blur-sm sticky top-0 z-10 border-b border-border">
+      <TableHeader className="bg-background/95 backdrop-blur-sm sticky top-0 z-10">
         <TableHeaderRenderer
           headerGroups={table.getHeaderGroups()}
           onAutoFit={onAutoFit}

--- a/apps/web/components/data-table/renderers/table-header.tsx
+++ b/apps/web/components/data-table/renderers/table-header.tsx
@@ -203,7 +203,7 @@ function DraggableTableHeader({
         </Button>
         <div className="min-w-0 flex-1">
           <div className="group flex min-w-0 items-center gap-1.5 justify-between">
-            <span className="min-w-0 flex-1 truncate select-none">
+            <span className="min-w-0 flex-1 truncate">
               {header.isPlaceholder
                 ? null
                 : flexRender(
@@ -314,7 +314,7 @@ export const TableHeaderRow = function TableHeaderRow({
             <div className="group flex min-w-0 items-center pr-1.5">
               <div className="min-w-0 flex-1">
                 <div className="group flex min-w-0 items-center gap-1.5 justify-between">
-                  <span className="min-w-0 flex-1 truncate select-none">
+                  <span className="min-w-0 flex-1 truncate">
                     {header.isPlaceholder
                       ? null
                       : flexRender(

--- a/docs/knowledge/conventions.md
+++ b/docs/knowledge/conventions.md
@@ -3,7 +3,7 @@ id: conventions
 title: Development Conventions
 type: workflow
 status: active
-updated: 2026-05-13
+updated: 2026-06-02
 tags:
   - conventions
   - patterns
@@ -38,6 +38,22 @@ related:
 - Pass custom classes via `className` prop at usage site
 - Create wrapper components in `components/` (not `components/ui/`) if needed
 - Use `cn()` utility to merge classes
+
+## Radix Overlays (DropdownMenu / Popover)
+
+**Use `modal={false}` for toolbar/filter dropdowns and popovers.**
+
+Radix `DropdownMenu` defaults to `modal={true}`. A modal overlay runs
+`hideOthers()`, which stamps `aria-hidden`/`data-aria-hidden` onto **every
+top-level sibling** of the menu portal (sidebar, header, the whole table) on
+open and strips them on close. On a populated page that toggles the attribute
+on the root containers wrapping the entire UI, forcing a full-page
+accessibility/style recompute — perceived as a "full page re-render" each time
+the menu opens (e.g. the Presets menu, fixed in PR #1360).
+
+- `DropdownMenu` defaults to `modal={true}` → set `modal={false}` for toolbar menus.
+- `Popover` already defaults to `modal={false}` → safe as-is.
+- Reserve modal overlays for genuine modal flows (confirm dialogs), not toolbars.
 
 ## className Composition
 

--- a/docs/knowledge/conventions.md
+++ b/docs/knowledge/conventions.md
@@ -46,10 +46,10 @@ related:
 Radix `DropdownMenu` defaults to `modal={true}`. A modal overlay runs
 `hideOthers()`, which stamps `aria-hidden`/`data-aria-hidden` onto **every
 top-level sibling** of the menu portal (sidebar, header, the whole table) on
-open and strips them on close. On a populated page that toggles the attribute
-on the root containers wrapping the entire UI, forcing a full-page
-accessibility/style recompute — perceived as a "full page re-render" each time
-the menu opens (e.g. the Presets menu, fixed in PR #1360).
+open and strips them on close. On a populated page, toggling this attribute on
+the root containers wrapping the entire UI forces a full-page accessibility/style
+recompute — perceived as a "full-page re-render" each time the menu opens (e.g.
+the Presets menu, fixed in PR #1360).
 
 - `DropdownMenu` defaults to `modal={true}` → set `modal={false}` for toolbar menus.
 - `Popover` already defaults to `modal={false}` → safe as-is.


### PR DESCRIPTION
Follow-up to #1360 (the column-header changes were pushed after that PR auto-merged its first commit, so they were stranded on the old branch). This PR re-applies them cleanly on top of `main`.

## Problem

Table column headers (e.g. `/history-queries`) had readability issues:
- Heavy gray background, `UPPERCASE` + wide letter-spacing — visually noisy.
- Labels truncated (`memory_u…`, `event_ti…`) **even when the column had free space**.
- Header titles could not be text-selected.

## Root cause & fix

Learned from the Cloudflare DNS table — clean, sentence-case headers.

- **Background**: `bg-muted/95` → `bg-background/95`, separated only by a bottom border (near-white, not gray). Set at the usage site (`data-table-content.tsx`), not in `components/ui/`.
- **Typography**: dropped `uppercase` + `tracking-wider`; sentence case at 13px with `foreground/80`. The caps + letter-spacing inflated text width ~25%, which was the actual cause of truncation-despite-space — the glyphs were artificially wide, not the column too narrow.
- **Selection**: removed stacked `select-none` from the renderer label span and the header wrapper/button so titles can be selected.

## Knowledge

Also documents the Radix `modal={false}` rule for toolbar overlays in `docs/knowledge/conventions.md` (the convention behind #1360).

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved column header layout, alignment, ellipsis behavior, and icon sizing for better readability
  * Enhanced table header border visibility for clearer separation
  * Made column header text selectable for user convenience

* **Documentation**
  * Added guidelines for overlay components (dropdowns/popovers), clarifying modal vs non-modal usage and best practices
<!-- end of auto-generated comment: release notes by coderabbit.ai -->