### PR TITLE
fix(data-table): content-aware column widths, stop header truncation, square table corners

### DIFF
--- a/apps/web/components/data-table/column-defs/column-defs.tsx
+++ b/apps/web/components/data-table/column-defs/column-defs.tsx
@@ -107,7 +107,41 @@ export function getColumnDefs<
     const { format: columnFormat, options: columnFormatOptions } =
       parseColumnFormat(column, config.columnFormats || {})
     const sortingFnName = config.sortingFns?.[name]
-    const sizing = config.columnSizing?.[name] ?? config.columnSizing?.[column]
+    let sizing = config.columnSizing?.[name] ?? config.columnSizing?.[column]
+
+    // Content-aware column sizing when no explicit size is configured.
+    // Estimates width from the longer of header label or sampled cell values.
+    // Chrome budget: ~64px (header chrome + cell padding) + 32px buffer = 96px.
+    if (!sizing || sizing.size === undefined) {
+      const SAMPLE_SIZE = 30
+      const CHAR_WIDTH = 7.2 // Approximate width of a character in px
+      const CHROME_BUDGET = 96 // Header chrome + cell padding
+      const MIN_WIDTH = 80
+      const MAX_WIDTH = 480
+
+      let maxChars = name.length
+      // Sample cell values for content width estimation
+      const sampleSize = Math.min(data.length, SAMPLE_SIZE)
+      if (sampleSize > 0) {
+        const step =
+          data.length > sampleSize ? Math.floor(data.length / sampleSize) : 1
+        for (let i = 0; i < data.length; i += step) {
+          const row = data[i] as Record<string, unknown>
+          const value = row[column]
+          if (value != null) {
+            const strValue = String(value)
+            maxChars = Math.max(maxChars, strValue.length)
+          }
+        }
+      }
+      const estimatedSize = Math.round(maxChars * CHAR_WIDTH + CHROME_BUDGET)
+      const clampedSize = Math.max(
+        MIN_WIDTH,
+        Math.min(MAX_WIDTH, estimatedSize)
+      )
+
+      sizing = { ...(sizing || {}), size: clampedSize }
+    }
 
     // Check if this column should have a filter
     const isFilterable = isColumnFilterable(

--- a/apps/web/components/data-table/components/data-table-content.tsx
+++ b/apps/web/components/data-table/components/data-table-content.tsx
@@ -251,8 +251,7 @@ export const DataTableContent = memo(function DataTableContent<
             isVirtualized ? 'flex-1 overflow-auto' : 'w-full overflow-x-auto',
             {
               'max-h-[50vh]': compact && !isVirtualized,
-              'mb-5 rounded-lg border border-border/50 bg-card/30':
-                !compact && !cardsOnly,
+              'mb-5 border border-border/50 bg-card/30': !compact && !cardsOnly,
             }
           )}
           role="region"

--- a/apps/web/components/data-table/renderers/table-header.tsx
+++ b/apps/web/components/data-table/renderers/table-header.tsx
@@ -179,7 +179,7 @@ function DraggableTableHeader({
       style={style}
       colSpan={header.colSpan}
     >
-      <div className="group flex min-w-0 items-center pr-1.5">
+      <div className="group relative flex min-w-0 items-center pr-1.5">
         {/* Drag handle for column reordering - hidden by default, shown on hover */}
         <Button
           {...attributes}
@@ -188,7 +188,7 @@ function DraggableTableHeader({
           variant="ghost"
           size="icon-sm"
           className={cn(
-            'mr-1 hidden size-6 shrink-0 cursor-grab text-muted-foreground opacity-0 sm:inline-flex',
+            'absolute left-0 size-6 shrink-0 cursor-grab text-muted-foreground opacity-0 sm:inline-flex',
             'active:cursor-grabbing',
             'group-hover:opacity-40 hover:opacity-100 focus:opacity-100 focus-visible:opacity-100',
             'transition',
@@ -201,7 +201,7 @@ function DraggableTableHeader({
         >
           <GripVertical data-icon className="size-3" />
         </Button>
-        <div className="min-w-0 flex-1">
+        <div className="min-w-0 flex-1 pl-7">
           <div className="group flex min-w-0 items-center gap-1.5 justify-between">
             <span className="min-w-0 flex-1 truncate">
               {header.isPlaceholder


### PR DESCRIPTION
### Fixes
- Column widths are now content-aware: computes size from header label and sampled cell values when `columnSizing` is not explicitly configured. Clamps to [80, 480]px.
- Header labels stop truncating prematurely: drag handle is now absolutely positioned so it doesn't consume inline width when hidden.
- Table container corners are now square (removed `rounded-lg` while keeping border/bg).

### Details
- **Column sizing**: Added heuristic in `column-defs.tsx` that samples up to 30 rows to estimate max content width, using char-width ~7.2px + 96px chrome budget.
- **Header chrome**: Made drag handle `absolute left-0` with `opacity-0 sm:inline-flex` and added `pl-7` to content div to reserve hover space.
- **Rounded corners**: Removed `rounded-lg` from data-table-content.tsx ~line 254.

Co-Authored-By: duyetbot <bot@duyet.net>