### PR TITLE
fix(data-table): move card Sort into toolbar, add density support to cards

### DIFF
--- a/apps/web/components/data-table/components/data-table-content.tsx
+++ b/apps/web/components/data-table/components/data-table-content.tsx
@@ -234,16 +234,6 @@ export const DataTableContent = memo(function DataTableContent<
   return (
     <TooltipProvider>
       <div className="relative">
-        {offerViewToggle && !compact && view !== 'table' && (
-          <div
-            className={cn(
-              'mb-2 flex justify-end',
-              view === 'auto' && 'sm:hidden'
-            )}
-          >
-            <MobileSortMenu table={table} />
-          </div>
-        )}
         <div
           ref={tableContainerRef}
           className={cn(

--- a/apps/web/components/data-table/components/data-table-header.tsx
+++ b/apps/web/components/data-table/components/data-table-header.tsx
@@ -23,6 +23,7 @@ import { CardToolbar } from '@/components/cards/card-toolbar'
 import { CsvExportButton } from '@/components/data-table/buttons/csv-export-button'
 import { ResetColumnOrderButton } from '@/components/data-table/buttons/reset-column-order'
 import { BulkActions } from '@/components/data-table/components/bulk-actions'
+import { MobileSortMenu } from '@/components/data-table/components/mobile-table-cards'
 import { Button } from '@/components/ui/button'
 import { DebouncedInput } from '@/components/ui/debounced-input'
 import {
@@ -318,6 +319,12 @@ export const DataTableHeader = memo(function DataTableHeader<
         <div className="flex flex-wrap items-center gap-2 bg-card/65 dark:bg-card/40 border border-border/60 p-2 rounded-xl shadow-xs">
           {filterBarSlot}
           <div className="flex flex-wrap items-center gap-2 ml-auto">
+            {/* Sort control for card view — moved from separate row into unified toolbar */}
+            {offerViewToggle && (view === 'cards' || view === 'auto') && (
+              <div className={view === 'auto' ? 'sm:hidden' : ''}>
+                <MobileSortMenu table={table} />
+              </div>
+            )}
             {offerViewToggle && (
               <ViewToggle view={view} onViewChange={onViewChange} />
             )}

--- a/apps/web/components/data-table/components/mobile-table-cards.tsx
+++ b/apps/web/components/data-table/components/mobile-table-cards.tsx
@@ -35,6 +35,7 @@ import {
   EXPAND_COLUMN_ID,
   normalizeColumnName,
 } from '@/components/data-table/column-defs'
+import { useTableDensityContext } from '@/components/data-table/context/table-density-context'
 import { DefaultExpandedRow } from '@/components/data-table/row-expand/default-renderer'
 import { Button } from '@/components/ui/button'
 import {
@@ -274,19 +275,44 @@ const MobileTableCard = function MobileTableCard<TData extends RowData>({
   const hasHeader =
     isExpandable || !!selectCell || badgeCells.length > 0 || !!actionCell
 
+  // Density-aware spacing for cards
+  const { density } = useTableDensityContext()
+  const densitySpacing = {
+    comfortable: {
+      outer: 'p-3',
+      headerMb: 'mb-2.5',
+      sectionMt: 'mt-2.5',
+      detailPy: 'py-2',
+    },
+    compact: {
+      outer: 'p-2.5',
+      headerMb: 'mb-2',
+      sectionMt: 'mt-2',
+      detailPy: 'py-1.5',
+    },
+    dense: {
+      outer: 'p-2',
+      headerMb: 'mb-1.5',
+      sectionMt: 'mt-1.5',
+      detailPy: 'py-1',
+    },
+  }[density]
+
   return (
     <article
       data-testid="mobile-table-card"
       data-expanded={isExpanded || undefined}
       className={cn(
-        'rounded-lg border border-border/60 bg-card/40 p-3',
+        `rounded-lg border border-border/60 bg-card/40 ${densitySpacing.outer}`,
         // An expanded card needs the full row so its detail panel has room.
         isExpanded && gridLayout && 'col-span-full',
         customClass
       )}
     >
       {hasHeader && (
-        <div className="mb-2.5 flex min-w-0 items-center gap-2">
+        <div
+          className={`${densitySpacing.headerMb} flex min-w-0 items-center gap-2`}
+        >
           {isExpandable && (
             <button
               type="button"
@@ -357,7 +383,7 @@ const MobileTableCard = function MobileTableCard<TData extends RowData>({
       {metricEntries.length > 0 && (
         <div
           data-testid="mobile-table-card-metrics"
-          className="mt-2.5 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground"
+          className={`${densitySpacing.sectionMt} flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground`}
         >
           {metricEntries.map(({ name, cell }) => {
             const MetricIcon = columnIcons?.[name]
@@ -380,11 +406,11 @@ const MobileTableCard = function MobileTableCard<TData extends RowData>({
       )}
 
       {detailCells.length > 0 && (
-        <dl className="mt-3 divide-y divide-border/50">
+        <dl className={`${densitySpacing.sectionMt} divide-y divide-border/50`}>
           {detailCells.map((cell) => (
             <div
               key={cell.id}
-              className="grid min-w-0 grid-cols-[7rem_minmax(0,1fr)] gap-2 py-2 first:pt-0 last:pb-0"
+              className={`grid min-w-0 grid-cols-[7rem_minmax(0,1fr)] gap-2 ${densitySpacing.detailPy} first:pt-0 last:pb-0`}
             >
               <dt className="min-w-0 truncate text-xs text-muted-foreground">
                 {formatColumnLabel(cell.column.id)}

--- a/apps/web/components/data-table/context/table-density-context.tsx
+++ b/apps/web/components/data-table/context/table-density-context.tsx
@@ -1,14 +1,19 @@
 'use client'
 
+import type { TableDensity } from '@/components/data-table/hooks'
+
 import { createContext, use } from 'react'
 
 interface TableDensityContextValue {
   /** CSS classes applied to each table cell for density control */
   cellClassName: string
+  /** Current density mode for responsive layouts */
+  density: TableDensity
 }
 
 const TableDensityContext = createContext<TableDensityContextValue>({
   cellClassName: 'py-3 px-4',
+  density: 'comfortable',
 })
 
 export const TableDensityProvider = TableDensityContext.Provider

--- a/apps/web/components/data-table/data-table.tsx
+++ b/apps/web/components/data-table/data-table.tsx
@@ -597,7 +597,7 @@ export function DataTable<
   }
 
   return (
-    <TableDensityProvider value={{ cellClassName }}>
+    <TableDensityProvider value={{ cellClassName, density }}>
       <div className={cn('flex min-w-0 flex-col overflow-hidden', className)}>
         {!compact && (
           <DataTableHeader


### PR DESCRIPTION
Moves the Sort control from a separate row into the unified filter toolbar for card view, and makes the Density radio work on cards by extending TableDensityContext to expose the density value and consuming it in MobileTableCard to scale spacing per mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile sort menu now integrates with the main toolbar instead of appearing separately, improving layout consistency.
  * Card spacing now dynamically adjusts based on density settings for better visual hierarchy and responsive design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->