### PR TITLE
feat(filters): add per-page quick filters with segmented control

### DIFF
--- a/apps/web/components/data-table/components/data-table-header.tsx
+++ b/apps/web/components/data-table/components/data-table-header.tsx
@@ -18,7 +18,7 @@ import type { ApiResponseMetadata } from '@/lib/api/types'
 import type { QueryConfig } from '@/types/query-config'
 import type { TableFilterCondition } from '../hooks/use-filtered-data'
 
-import { memo, useState } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { CardToolbar } from '@/components/cards/card-toolbar'
 import { CsvExportButton } from '@/components/data-table/buttons/csv-export-button'
 import { ResetColumnOrderButton } from '@/components/data-table/buttons/reset-column-order'
@@ -180,26 +180,41 @@ export const DataTableHeader = memo(function DataTableHeader<
   const [filterDrafts, setFilterDrafts] = useState<TableFilterCondition[]>([])
   const [isFiltersOpen, setIsFiltersOpen] = useState(false)
 
-  // Get eligible columns for advanced filtering, excluding synthetic
-  // utility columns (see CLAUDE.md: `__expand`, `select`, `action`).
-  const filterableColumns = table
-    .getAllLeafColumns()
-    .filter((col) => !['__expand', 'select', 'action'].includes(col.id))
-
   // Stable unique IDs for filter drafts (avoids Math.random collisions)
   const createFilterId = () =>
     typeof crypto !== 'undefined' && 'randomUUID' in crypto
       ? crypto.randomUUID()
       : `${Date.now()}-${Math.random().toString(36).slice(2)}`
 
-  // Resolve a human-readable label for a column
-  const getColumnLabel = (col: {
-    id: string
-    columnDef: { header?: unknown }
-  }) => {
-    const header = col.columnDef.header
-    return typeof header === 'string' ? header : col.id
+  // Memoize filterable columns with their labels to avoid recomputing on every render.
+  // This stabilizes the SelectItem arrays and reduces popover open cost.
+  const filterableColumns = useMemo(() => {
+    const cols = table
+      .getAllLeafColumns()
+      .filter((col) => !['__expand', 'select', 'action'].includes(col.id))
+    // Pre-compute labels once
+    return cols.map((col) => {
+      const header = col.columnDef.header
+      const label = typeof header === 'string' ? header : col.id
+      return { column: col, label }
+    })
+  }, [table])
+
+  // Resolve a human-readable label for a column (uses memoized label)
+  const getColumnLabel = (colId: string) => {
+    const found = filterableColumns.find((item) => item.column.id === colId)
+    return found?.label || colId
   }
+
+  // Memoize operator options to avoid recreating SelectItems on every render
+  const operatorOptions = useMemo(
+    () =>
+      Object.entries(OPERATOR_LABELS).map(([value, label]) => ({
+        value,
+        label,
+      })),
+    []
+  )
 
   // Open popover: sync draft state with committed state
   const handleOpenFilters = (open: boolean) => {
@@ -211,7 +226,7 @@ export const DataTableHeader = memo(function DataTableHeader<
           : [
               {
                 id: createFilterId(),
-                columnId: filterableColumns[0]?.id || '',
+                columnId: filterableColumns[0]?.column.id || '',
                 operator: 'contains',
                 value: '',
               },
@@ -225,7 +240,7 @@ export const DataTableHeader = memo(function DataTableHeader<
       ...prev,
       {
         id: createFilterId(),
-        columnId: filterableColumns[0]?.id || '',
+        columnId: filterableColumns[0]?.column.id || '',
         operator: 'contains',
         value: '',
       },
@@ -249,7 +264,7 @@ export const DataTableHeader = memo(function DataTableHeader<
         : [
             {
               id: createFilterId(),
-              columnId: filterableColumns[0]?.id || '',
+              columnId: filterableColumns[0]?.column.id || '',
               operator: 'contains',
               value: '',
             },
@@ -395,7 +410,7 @@ export const DataTableHeader = memo(function DataTableHeader<
                         onSelect={(e) => e.preventDefault()}
                         className="text-xs"
                       >
-                        {getColumnLabel(column)}
+                        {getColumnLabel(column.id)}
                       </DropdownMenuCheckboxItem>
                     ))}
                 </div>
@@ -486,13 +501,13 @@ export const DataTableHeader = memo(function DataTableHeader<
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                          {filterableColumns.map((col) => (
+                          {filterableColumns.map(({ column: col, label }) => (
                             <SelectItem
                               key={col.id}
                               value={col.id}
                               className="text-xs"
                             >
-                              {getColumnLabel(col)}
+                              {label}
                             </SelectItem>
                           ))}
                         </SelectContent>
@@ -511,17 +526,11 @@ export const DataTableHeader = memo(function DataTableHeader<
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                          {Object.entries(OPERATOR_LABELS).map(
-                            ([op, label]) => (
-                              <SelectItem
-                                key={op}
-                                value={op}
-                                className="text-xs"
-                              >
-                                {label}
-                              </SelectItem>
-                            )
-                          )}
+                          {operatorOptions.map(({ value: op, label }) => (
+                            <SelectItem key={op} value={op} className="text-xs">
+                              {label}
+                            </SelectItem>
+                          ))}
                         </SelectContent>
                       </Select>
 
@@ -654,7 +663,7 @@ export const DataTableHeader = memo(function DataTableHeader<
                         onSelect={(e) => e.preventDefault()}
                         className="text-xs"
                       >
-                        {getColumnLabel(column)}
+                        {getColumnLabel(column.id)}
                       </DropdownMenuCheckboxItem>
                     ))}
                 </div>
@@ -697,10 +706,7 @@ export const DataTableHeader = memo(function DataTableHeader<
               )}
 
               {advancedFilters.map((filter) => {
-                const col = filterableColumns.find(
-                  (c) => c.id === filter.columnId
-                )
-                const label = col ? getColumnLabel(col) : filter.columnId
+                const label = getColumnLabel(filter.columnId)
                 return (
                   <div
                     key={filter.id}

--- a/apps/web/components/filters/filter-bar.tsx
+++ b/apps/web/components/filters/filter-bar.tsx
@@ -10,6 +10,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { AddFilterPopover } from '@/components/filters/add-filter-popover'
 import { FilterChip } from '@/components/filters/filter-chip'
 import { PresetsMenu } from '@/components/filters/presets-menu'
+import { QuickFilters } from '@/components/filters/quick-filters'
 import { Button } from '@/components/ui/button'
 import { DebouncedInput } from '@/components/ui/debounced-input'
 import {
@@ -95,6 +96,9 @@ export function FilterBar({ queryConfig }: FilterBarProps) {
 
   const activeKeys = activeFilters.map((filter) => filter.key)
   const hasPresets = Boolean(schema.presets && schema.presets.length > 0)
+  const hasQuickFilters = Boolean(
+    schema.quickFilters && schema.quickFilters.length > 0
+  )
 
   const searchValue = searchParams.get('q') ?? ''
 
@@ -129,6 +133,15 @@ export function FilterBar({ queryConfig }: FilterBarProps) {
           </button>
         )}
       </div>
+
+      {/* Quick filters: always-visible inline controls */}
+      {hasQuickFilters && (
+        <QuickFilters
+          configs={schema.quickFilters ?? []}
+          activeFilters={activeFilters}
+          onSetFilter={setFilter}
+        />
+      )}
 
       {activeFilters.map((filter) => {
         const field = fieldByKey.get(filter.key)

--- a/apps/web/components/filters/quick-filters.tsx
+++ b/apps/web/components/filters/quick-filters.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import type { FilterDraft } from '@/components/filters/filter-editor'
+import type { ActiveFilter, QuickFilterConfig } from '@/lib/filters/types'
+
+import { SegmentedControl } from '@/components/filters/segmented-control'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { cn } from '@/lib/utils'
+
+interface QuickFiltersProps {
+  /** Quick filter configs from schema */
+  configs: QuickFilterConfig[]
+  /** Currently active filters */
+  activeFilters: ActiveFilter[]
+  /** Callback to set a filter value */
+  onSetFilter: (key: string, draft: FilterDraft) => void
+  /** Optional className for the container */
+  className?: string
+}
+
+/**
+ * Renders quick filter controls based on their display type.
+ * - segmented: Row of pill buttons for selecting from options
+ * - select: Dropdown for selecting from options
+ * - radio: Radio buttons (future)
+ */
+export function QuickFilters({
+  configs,
+  activeFilters,
+  onSetFilter,
+  className,
+}: QuickFiltersProps) {
+  if (configs.length === 0) return null
+
+  // Map active filters by key for quick lookup
+  const activeByKey = new Map(activeFilters.map((f) => [f.key, f]))
+
+  return (
+    <div className={cn('flex flex-wrap items-center gap-2', className)}>
+      {configs.map((config) => {
+        const active = activeByKey.get(config.key)
+        const currentValue = active?.values[0] ?? ''
+
+        const handleValueChange = (value: string) => {
+          if (value === '') {
+            // Clear the filter (for "All" option)
+            onSetFilter(config.key, {
+              operator: 'eq',
+              values: [],
+            })
+          } else {
+            onSetFilter(config.key, {
+              operator: 'eq',
+              values: [value],
+            })
+          }
+        }
+
+        const label = config.label ?? config.key
+        const Icon = config.icon
+
+        switch (config.display) {
+          case 'segmented': {
+            const options = config.options ?? []
+            const segmentedOptions = config.includeAll
+              ? [{ label: 'All', value: '' }, ...options]
+              : options
+
+            return (
+              <div key={config.key} className="flex items-center gap-2">
+                {Icon && <Icon className="size-3.5 text-muted-foreground" />}
+                <span className="text-xs text-muted-foreground">{label}:</span>
+                <SegmentedControl
+                  options={segmentedOptions}
+                  value={currentValue}
+                  onChange={handleValueChange}
+                />
+              </div>
+            )
+          }
+
+          case 'select': {
+            const options = config.options ?? []
+            return (
+              <div key={config.key} className="flex items-center gap-2">
+                {Icon && <Icon className="size-3.5 text-muted-foreground" />}
+                <span className="text-xs text-muted-foreground">{label}:</span>
+                <Select value={currentValue} onValueChange={handleValueChange}>
+                  <SelectTrigger className="h-7 w-[140px] text-xs">
+                    <SelectValue placeholder={label} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="" className="text-xs">
+                      All
+                    </SelectItem>
+                    {options.map((opt) => (
+                      <SelectItem
+                        key={opt.value}
+                        value={opt.value}
+                        className="text-xs"
+                      >
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )
+          }
+
+          case 'radio':
+            // TODO: Implement radio button control
+            return null
+
+          default:
+            return null
+        }
+      })}
+    </div>
+  )
+}

--- a/apps/web/components/filters/segmented-control.tsx
+++ b/apps/web/components/filters/segmented-control.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { CheckIcon } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+export interface SegmentedOption {
+  label: string
+  value: string
+}
+
+interface SegmentedControlProps {
+  options: SegmentedOption[]
+  value: string
+  onChange: (value: string) => void
+  /** Optional placeholder shown when no value is selected */
+  placeholder?: string
+  /** Optional className for styling */
+  className?: string
+}
+
+/**
+ * Segmented control for selecting from a set of options.
+ * Renders as a row of pill-shaped buttons where the active one is highlighted.
+ * Used for quick filters like query type (ALL | SELECT | INSERT ...).
+ */
+export function SegmentedControl({
+  options,
+  value,
+  onChange,
+  placeholder,
+  className,
+}: SegmentedControlProps) {
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-0.5 rounded-lg border border-border/60 bg-muted/20 p-0.5',
+        className
+      )}
+      role="group"
+      aria-label="Segmented control"
+    >
+      {placeholder && value === '' && (
+        <div className="px-2.5 text-xs text-muted-foreground/70">
+          {placeholder}
+        </div>
+      )}
+      {options.map((option) => {
+        const isActive = value === option.value
+        return (
+          <Button
+            key={option.value}
+            type="button"
+            variant={isActive ? 'secondary' : 'ghost'}
+            size="sm"
+            className={cn(
+              'gap-1.5 px-2.5 text-xs h-7 rounded-md transition-all',
+              isActive
+                ? 'bg-background shadow-sm border border-border/50 font-medium'
+                : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+            )}
+            aria-pressed={isActive}
+            onClick={() => onChange(option.value)}
+          >
+            {isActive && <CheckIcon className="size-3" aria-hidden="true" />}
+            <span>{option.label}</span>
+          </Button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/lib/filters/types.ts
+++ b/apps/web/lib/filters/types.ts
@@ -100,12 +100,45 @@ export interface FilterPreset {
   filters: (FilterValue & { key: string })[]
 }
 
+/** Quick filter display type. */
+export type QuickFilterDisplay = 'segmented' | 'select' | 'radio'
+
+/**
+ * Quick filter: always-visible inline control for high-value filters.
+ * Renders before filter chips in the FilterBar.
+ */
+export interface QuickFilterConfig {
+  /** Field key from fields[] that this quick filter controls. */
+  key: string
+  /** How to render the inline control. */
+  display: QuickFilterDisplay
+  /** Override label (defaults to field.label). */
+  label?: string
+  /**
+   * For segmented/radio: options to show.
+   * Defaults to field.options (for select-type fields) or needs explicit options.
+   */
+  options?: { label: string; value: string }[]
+  /**
+   * For segmented: include an "All" option that clears the filter.
+   * When true, prepends { label: 'All', value: '' } to options.
+   */
+  includeAll?: boolean
+  /** Optional icon shown with the control. */
+  icon?: Icon
+}
+
 /** Declarative filter configuration attached to a `QueryConfig`. */
 export interface FilterSchema {
   /** Filterable fields rendered in the filter bar. */
   fields: FilterField[]
   /** Optional one-click filter bundles. */
   presets?: FilterPreset[]
+  /**
+   * Always-visible inline controls for high-value filters.
+   * Renders before filter chips in the FilterBar.
+   */
+  quickFilters?: QuickFilterConfig[]
 }
 
 /** A filter with a concrete operator + value, parsed from the URL. */

--- a/apps/web/lib/query-config/queries/history-queries.ts
+++ b/apps/web/lib/query-config/queries/history-queries.ts
@@ -251,6 +251,22 @@ export const historyQueryFilterSchema: FilterSchema = {
       filters: [{ key: 'query_kind', operator: 'in', value: 'Select' }],
     },
   ],
+  quickFilters: [
+    {
+      key: 'query_kind',
+      display: 'segmented',
+      label: 'Type',
+      icon: LayersIcon,
+      options: [
+        { label: 'Select', value: 'Select' },
+        { label: 'Insert', value: 'Insert' },
+        { label: 'Create', value: 'Create' },
+        { label: 'Alter', value: 'Alter' },
+        { label: 'Drop', value: 'Drop' },
+      ],
+      includeAll: true,
+    },
+  ],
 }
 
 export const historyQueriesConfig: QueryConfig = {


### PR DESCRIPTION
Adds a `quickFilters` array to FilterSchema for always-visible inline controls.

- SegmentedControl: pill-shaped buttons for selecting from options (e.g., query type)
- QuickFilters: renders inline controls per display type (segmented | select | radio)
- Integrated into FilterBar, renders after search input before filter chips
- Example: history-queries now shows inline "Type: [All | Select | Insert | Create | Alter | Drop]" segmented control

**Usage in QueryConfig:**
```typescript
quickFilters: [
  {
    key: 'query_kind',
    display: 'segmented',
    label: 'Type',
    includeAll: true,
    options: [{ label: 'Select', value: 'Select' }, ...],
  },
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quick filters feature for faster filtering with pre-built controls accessible directly in the UI.
  * New segmented button and dropdown controls for selecting filter options.
  * Query history filtering enhanced with dedicated Type quick filter supporting Select, Insert, Create, Alter, and Drop operations.

* **Refactor**
  * Optimized DataTableHeader component for improved performance through memoization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->