### PR TITLE
fix(data-table): render filter chip label as single text node

### DIFF
--- a/apps/web/components/data-table/components/data-table-header.tsx
+++ b/apps/web/components/data-table/components/data-table-header.tsx
@@ -712,11 +712,7 @@ export const DataTableHeader = memo(function DataTableHeader<
                     key={filter.id}
                     className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-muted/60 dark:bg-muted/40 border border-border/50 text-foreground/80 text-[11px] font-medium transition-colors"
                   >
-                    <span>
-                      {label} {OPERATOR_LABELS[filter.operator]} &ldquo;
-                      {filter.value}
-                      &rdquo;
-                    </span>
+                    <span>{`${label} ${OPERATOR_LABELS[filter.operator]} “${filter.value}”`}</span>
                     <button
                       type="button"
                       onClick={() => removeCommittedFilter(filter.id)}


### PR DESCRIPTION
## Problem

`component-test` is **red on `main`** (and on every open PR branched from it). The failing spec is `data-table-header.cy.tsx` → *"shows filter chips when advanced filters are active"*:

```
AssertionError: Timed out retrying after 8000ms:
Expected to find content: '/col1 contains .*test/' but never did.
```

## Root cause

The advanced-filter chip interpolated its label across several JSX text nodes:

```tsx
<span>
  {label} {OPERATOR_LABELS[filter.operator]} &ldquo;
  {filter.value}
  &rdquo;
</span>
```

This produces sibling text nodes `"col1"`, `" "`, `"contains"`, `" "`, `"“"`, `"test"`, `"”"`. Cypress `cy.contains(RegExp)` matches a regex against an **individual text node**, never the concatenated `textContent`, so `/col1 contains .*test/` could never match. The previous attempt (`7a1242d`) switched the assertion from a literal string to this regex, but the regex has the same limitation.

## Fix

Collapse the chip label into a single template literal so the DOM exposes one text node. Rendered output (including the “curly quotes”) is byte-for-byte unchanged.

Other chip tests (delete via `aria-label`, `Clear all`) were already passing and are unaffected.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Bug Fixes:
- Fix advanced-filter chip labels so they appear as a single contiguous text node instead of multiple split text nodes, allowing Cypress and other consumers to match the full label string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the display formatting of active filter indicators in data tables for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->