### PR TITLE
feat(landing): add remaining marketing sections

### DIFF
--- a/apps/landing/src/components/Capabilities.astro
+++ b/apps/landing/src/components/Capabilities.astro
@@ -1,0 +1,41 @@
+  <section id="capabilities" class="band">
+    <div class="wrap">
+      <div class="sec-head reveal">
+        <span class="eyebrow">And a lot more</span>
+        <h2>One dashboard for the whole cluster</h2>
+        <p>From a high-level overview down to ZooKeeper logs and replication mirrors — every system table you reach for, already laid out.</p>
+      </div>
+      <div class="cap-grid">
+        <div class="cap reveal">
+          <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11.5 12 4l9 7.5"/><path d="M5 10v10h14V10"/></svg></span>
+          <h4>Overview &amp; health</h4>
+          <p>CPU, memory, connections and replication status at a glance, with health checks across the cluster.</p>
+        </div>
+        <div class="cap reveal">
+          <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="m3 17 6-6 4 4 8-8"/><path d="M14 7h7v7"/></svg></span>
+          <h4>Cluster insights</h4>
+          <p>Record-breaking scans, busiest days, total rows read and storage — the highlights from all your data.</p>
+        </div>
+        <div class="cap reveal">
+          <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M6 8v3a3 3 0 0 0 3 3h6a3 3 0 0 0 3-3V8"/><path d="M12 14v2"/></svg></span>
+          <h4>PeerDB replication</h4>
+          <p>Watch mirrors and peers with live status, rows-synced trend and routing — failures surface immediately.</p>
+        </div>
+        <div class="cap reveal">
+          <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v6a6 6 0 0 0 6 6h6"/><path d="m15 12 3 3-3 3"/><path d="M18 3v3"/></svg></span>
+          <h4>Merges &amp; parts</h4>
+          <p>A live part-lifecycle timeline with merges, mutations, moves and part-size distribution by table.</p>
+        </div>
+        <div class="cap reveal">
+          <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M12 2 4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/></svg></span>
+          <h4>Security &amp; access</h4>
+          <p>Users, roles, grants and quotas — review who can touch what, all from the same place.</p>
+        </div>
+        <div class="cap reveal">
+          <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/><path d="M8 13h8M8 17h6"/></svg></span>
+          <h4>Logs &amp; system</h4>
+          <p>Query, error, trace and ZooKeeper logs alongside settings and metrics — searchable and time-ranged.</p>
+        </div>
+      </div>
+    </div>
+  </section>

--- a/apps/landing/src/components/DataExplorer.astro
+++ b/apps/landing/src/components/DataExplorer.astro
@@ -1,0 +1,31 @@
+  <section id="data-explorer" class="band" style="border-top:1px solid var(--border-soft)">
+    <div class="wrap">
+      <div class="sec-head reveal">
+        <span class="eyebrow">Data Explorer</span>
+        <h2>Explore tables and how they connect</h2>
+        <p>Browse every database and table, map dependencies between them, then drop into a SQL editor to query the data — all without leaving the dashboard.</p>
+      </div>
+      <div class="de-grid">
+        <div class="de-card reveal">
+          <div class="feat-shot">
+            <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
+            <img src="/landing-assets/data-explorer-graph.png" alt="chmonitor data explorer dependency graph" />
+          </div>
+          <div class="de-cap">
+            <span class="n">01</span>
+            <div><b>Dependency graph</b><span>See materialized views, dictionaries, joins and sources wired between tables — vertical or horizontal.</span></div>
+          </div>
+        </div>
+        <div class="de-card reveal">
+          <div class="feat-shot">
+            <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
+            <img src="/landing-assets/data-explorer-query.png" alt="chmonitor data explorer SQL query editor" />
+          </div>
+          <div class="de-cap">
+            <span class="n">02</span>
+            <div><b>Query editor</b><span>Run SQL with row counts and timing, inspect structure, DDL, indexes and parts for any table.</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>

--- a/apps/landing/src/components/Features.astro
+++ b/apps/landing/src/components/Features.astro
@@ -1,0 +1,69 @@
+  <section id="features" class="band band-soft">
+    <div class="wrap">
+      <div class="sec-head reveal">
+        <span class="eyebrow">What you get</span>
+        <h2>Everything about your cluster, in one place</h2>
+        <p>chmonitor reads ClickHouse system tables directly — no exporters, no extra storage. Each view is purpose-built so you can spot the problem and move on.</p>
+      </div>
+
+      <!-- AI Agent -->
+      <div class="feature" style="margin-top:64px">
+        <div class="feat-text reveal">
+          <span class="feat-ico"><svg viewBox="0 0 24 24" fill="none" stroke="var(--violet)" stroke-width="1.7" stroke-linejoin="round"><path d="M12 2 13.5 9.5 21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5z"/></svg></span>
+          <h3>Ask your cluster anything</h3>
+          <p>The built-in AI agent connects over MCP and answers questions about schemas, storage, query performance and health — then links you straight to the matching view.</p>
+          <ul class="feat-list">
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg> Chat about schema, storage, slow queries and system health</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg> Bring your own model, skills and MCP tools</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg> Read-only MCP endpoint for Claude, Cursor or any client</li>
+          </ul>
+        </div>
+        <div class="feat-shot reveal">
+          <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
+          <div class="carousel" data-autoplay="4600">
+            <div class="ctrack">
+              <div class="cslide"><img src="/landing-assets/agent-chat.png" alt="chmonitor AI agent chat" /></div>
+              <div class="cslide"><img src="/landing-assets/mcp-server.png" alt="chmonitor MCP server setup" /></div>
+            </div>
+            <div class="cdots"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Queries -->
+      <div class="feature flip">
+        <div class="feat-text reveal">
+          <span class="feat-ico"><svg viewBox="0 0 24 24" fill="none" stroke="var(--blue)" stroke-width="1.7"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg></span>
+          <h3>Every query, explained</h3>
+          <p>Running, history, failed, slowest and most expensive queries — each with duration, memory, rows read and the full statement. Filter by user, slice by time and find the culprit fast.</p>
+          <ul class="feat-list">
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg> Queries by user and top query patterns over time</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg> Saved filter presets and one-click EXPLAIN</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg> Kill long-running queries right from the table</li>
+          </ul>
+        </div>
+        <div class="feat-shot reveal">
+          <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
+          <img src="/landing-assets/queries-running.png" alt="chmonitor running queries with live charts and table" />
+        </div>
+      </div>
+
+      <!-- Cluster Topology -->
+      <div class="feature">
+        <div class="feat-text reveal">
+          <span class="feat-ico"><svg viewBox="0 0 24 24" fill="none" stroke="var(--emerald)" stroke-width="1.7"><rect x="3" y="3" width="6" height="6" rx="1.5"/><rect x="15" y="3" width="6" height="6" rx="1.5"/><rect x="9" y="15" width="6" height="6" rx="1.5"/><path d="M6 9v2a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V9"/><path d="M12 13v2"/></svg></span>
+          <h3>See the whole cluster at a glance</h3>
+          <p>An interactive topology map of nodes, shards, replicas and the Keeper quorum — with live replication and coordination links, health states and an inspector for every cluster.</p>
+          <ul class="feat-list">
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg> ClickHouse nodes and Keeper quorum with leader &amp; followers</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg> Physical and logical clusters, overlapping virtual clusters</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg> Per-node CPU, memory and latency, healthy / warn / unreachable</li>
+          </ul>
+        </div>
+        <div class="feat-shot reveal">
+          <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
+          <img src="/landing-assets/topology.png" alt="chmonitor cluster topology map" />
+        </div>
+      </div>
+    </div>
+  </section>

--- a/apps/landing/src/components/FinalCta.astro
+++ b/apps/landing/src/components/FinalCta.astro
@@ -1,0 +1,21 @@
+  <section class="band" style="padding-top:80px">
+    <div class="wrap">
+      <div class="cta reveal">
+        <span class="mark mark-lg" aria-hidden="true" style="margin:0 auto 22px">
+          <img src="/clickhouse.svg" alt="" />
+        </span>
+        <h2>Start monitoring in minutes</h2>
+        <p>Open the hosted dashboard and connect a cluster, or grab the source and run it yourself.</p>
+        <div class="hero-actions">
+          <a class="btn btn-primary" href="https://dash.chmonitor.dev" target="_blank" rel="noopener">
+            Open the cloud dashboard
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+          </a>
+          <a class="btn btn-ghost" href="https://github.com/duyet/clickhouse-monitoring" target="_blank" rel="noopener">
+            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>
+            View on GitHub
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>

--- a/apps/landing/src/components/Health.astro
+++ b/apps/landing/src/components/Health.astro
@@ -1,0 +1,45 @@
+  <section id="health" class="band band-soft">
+    <div class="wrap">
+      <div class="sec-head reveal">
+        <span class="eyebrow">Health Summary</span>
+        <h2>Catch issues early — then brief your agent to fix them</h2>
+        <p>Real-time health indicators for the whole cluster — replication lag, failed queries, disk and memory, stuck mutations and more. When something turns red, generate a ready-to-paste prompt that briefs your AI agent to debug it.</p>
+      </div>
+
+      <!-- health grid -->
+      <div class="feature" style="margin-top:64px">
+        <div class="feat-text reveal">
+          <span class="feat-ico"><svg viewBox="0 0 24 24" fill="none" stroke="var(--emerald)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></span>
+          <h3>Every health signal, color-coded</h3>
+          <p>A single board of indicators — green, warn or critical at a glance — each linking straight to the views that explain it.</p>
+          <ul class="feat-list">
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg> Replication lag, readonly replicas and delayed inserts</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg> Failed and long-running queries, OOM kills, Keeper exceptions</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg> Disk, memory, parts-per-partition and mutation status</li>
+          </ul>
+        </div>
+        <div class="feat-shot reveal">
+          <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
+          <img src="/landing-assets/health-summary.png" alt="chmonitor health summary indicators" />
+        </div>
+      </div>
+
+      <!-- audit prompt -->
+      <div class="feature flip">
+        <div class="feat-text reveal">
+          <span class="feat-ico"><svg viewBox="0 0 24 24" fill="none" stroke="var(--violet)" stroke-width="1.7" stroke-linejoin="round"><path d="M12 2 13.5 9.5 21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5z"/></svg></span>
+          <h3>A ready audit prompt for your agent</h3>
+          <p>One click turns any failing check into a structured prompt — the metric query, raw data, relevant system tables, common causes and docs. Paste it into Claude, ChatGPT or your coding agent for a tailored diagnosis and remediation plan.</p>
+          <ul class="feat-list">
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg> Toggle exactly what context to include</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg> Live values, thresholds, host and version baked in</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg> Copy as Markdown — works with any AI tool</li>
+          </ul>
+        </div>
+        <div class="feat-shot reveal">
+          <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
+          <img src="/landing-assets/health-audit.png" alt="chmonitor generated audit prompt dialog" />
+        </div>
+      </div>
+    </div>
+  </section>

--- a/apps/landing/src/components/OpenSource.astro
+++ b/apps/landing/src/components/OpenSource.astro
@@ -1,0 +1,127 @@
+  <section id="open-source" class="band band-soft">
+    <div class="wrap os">
+      <div class="reveal">
+        <div class="sec-head">
+          <span class="eyebrow">Open source</span>
+          <h2>Self-host it, or use the cloud</h2>
+          <p>chmonitor is open source. Deploy it to Cloudflare Workers, run it as a Docker container, or install the Helm chart on Kubernetes — or skip setup entirely and connect through the hosted cloud. Same UI, your choice.</p>
+        </div>
+        <ul class="os-points">
+          <li>
+            <span class="pico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 4 14h7l-1 8 10-12h-7l1-8z"/></svg></span>
+            <div><b>Up in minutes</b><span>Point it at a ClickHouse connection string and you're monitoring.</span></div>
+          </li>
+          <li>
+            <span class="pico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/></svg></span>
+            <div><b>Read-only by design</b><span>Connect with a least-privilege user — chmonitor only reads system tables.</span></div>
+          </li>
+          <li>
+            <span class="pico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 13.5 9.5 21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5z"/></svg></span>
+            <div><b>Yours to extend</b><span>GPL-3.0 licensed, community-driven, contributions welcome.</span></div>
+          </li>
+        </ul>
+        <div class="os-actions">
+          <a class="btn btn-primary" href="https://github.com/duyet/clickhouse-monitoring" target="_blank" rel="noopener">
+            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>
+            View on GitHub
+          </a>
+          <a class="btn btn-ghost" href="https://chmonitor.dev/docs" target="_blank" rel="noopener">Read the docs</a>
+        </div>
+      </div>
+
+      <div class="deploy reveal">
+        <div class="deploy-tabbar" role="tablist" id="deployTabs">
+          <button class="deploy-tab" role="tab" data-tab="cf" data-on="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M17.5 19a4.5 4.5 0 1 0 0-9h-.5a6 6 0 1 0-11 4"/><path d="M5 19h12.5"/></svg>
+            Cloudflare Workers
+          </button>
+          <button class="deploy-tab" role="tab" data-tab="docker" data-on="false">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="9" width="4" height="4"/><rect x="8" y="9" width="4" height="4"/><rect x="13" y="9" width="4" height="4"/><rect x="8" y="4" width="4" height="4"/><path d="M2 13h18a4 4 0 0 1-4 5H7a5 5 0 0 1-5-5z"/></svg>
+            Docker
+          </button>
+          <button class="deploy-tab" role="tab" data-tab="helm" data-on="false">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3 8 4.5v9L12 21l-8-4.5v-9z"/><path d="M12 12v9M12 12 4 7.5M12 12l8-4.5"/></svg>
+            Kubernetes + Helm
+          </button>
+        </div>
+
+        <!-- Cloudflare Workers -->
+        <div class="deploy-pane" data-pane="cf" data-on="true">
+          <p class="deploy-note">Edge hosting via the OpenNext adapter — no servers to run.</p>
+          <div class="terminal">
+            <div class="term-bar"><span class="lights"><i style="background:#ff5f57"></i><i style="background:#febc2e"></i><i style="background:#28c840"></i></span><span class="ttl">bash</span><button class="copy">Copy</button></div>
+            <div class="term-body">
+              <div><span class="p">$</span> git clone https://github.com/duyet/clickhouse-monitoring.git</div>
+              <div><span class="p">$</span> cd clickhouse-monitoring</div>
+              <div><span class="p">$</span> bun install</div>
+              <div>&nbsp;</div>
+              <div><span class="c"># production env + a token with Workers deploy permission</span></div>
+              <div><span class="p">$</span> cat &lt;&lt;'EOF' &gt; .env.prod</div>
+              <div>CLOUDFLARE_API_TOKEN=&lt;token&gt;</div>
+              <div>CLICKHOUSE_HOST=https://clickhouse.example.com:8443</div>
+              <div>CLICKHOUSE_USER=default</div>
+              <div>CLICKHOUSE_PASSWORD=change-me</div>
+              <div>EOF</div>
+              <div>&nbsp;</div>
+              <div><span class="p">$</span> bun run cf:config&nbsp;&nbsp;&nbsp;<span class="c"># push secrets to the Worker</span></div>
+              <div><span class="p">$</span> bun run cf:deploy&nbsp;&nbsp;&nbsp;<span class="c"># build + deploy + populate cache</span></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Docker -->
+        <div class="deploy-pane" data-pane="docker" data-on="false">
+          <p class="deploy-note">Single container from GHCR. Pin a release tag in production.</p>
+          <div class="terminal">
+            <div class="term-bar"><span class="lights"><i style="background:#ff5f57"></i><i style="background:#febc2e"></i><i style="background:#28c840"></i></span><span class="ttl">bash</span><button class="copy">Copy</button></div>
+            <div class="term-body">
+              <div><span class="p">$</span> docker run <span class="s">-d</span> <span class="s">--name</span> chmonitor <span class="s">-p</span> 3000:3000 <span class="f">\</span></div>
+              <div>&nbsp;&nbsp;<span class="s">-e</span> CLICKHOUSE_HOST='https://clickhouse.example.com:8443' <span class="f">\</span></div>
+              <div>&nbsp;&nbsp;<span class="s">-e</span> CLICKHOUSE_USER='default' <span class="f">\</span></div>
+              <div>&nbsp;&nbsp;<span class="s">-e</span> CLICKHOUSE_PASSWORD='change-me' <span class="f">\</span></div>
+              <div>&nbsp;&nbsp;ghcr.io/duyet/chmonitor:latest</div>
+              <div><span class="c"># open http://localhost:3000</span></div>
+            </div>
+          </div>
+          <div class="deploy-sub">Trial with a bundled ClickHouse</div>
+          <div class="terminal">
+            <div class="term-bar"><span class="lights"><i style="background:#ff5f57"></i><i style="background:#febc2e"></i><i style="background:#28c840"></i></span><span class="ttl">bash</span><button class="copy">Copy</button></div>
+            <div class="term-body">
+              <div><span class="p">$</span> git clone https://github.com/duyet/clickhouse-monitoring.git</div>
+              <div><span class="p">$</span> cd clickhouse-monitoring</div>
+              <div><span class="p">$</span> docker compose up <span class="s">-d</span></div>
+            </div>
+          </div>
+          <div class="callout"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16h.01"/></svg><div>ClickHouse running on the Docker host? <code>localhost</code> points at the container — use <code>host.docker.internal</code> (<code>--add-host=host.docker.internal:host-gateway</code> on Linux).</div></div>
+        </div>
+
+        <!-- Kubernetes / Helm -->
+        <div class="deploy-pane" data-pane="helm" data-on="false">
+          <p class="deploy-note">Chart vendored at <code>deploy/helm/chmonitor</code> — Secret-backed password, non-root uid 1001, health probes.</p>
+          <div class="terminal">
+            <div class="term-bar"><span class="lights"><i style="background:#ff5f57"></i><i style="background:#febc2e"></i><i style="background:#28c840"></i></span><span class="ttl">bash</span><button class="copy">Copy</button></div>
+            <div class="term-body">
+              <div><span class="p">$</span> git clone https://github.com/duyet/clickhouse-monitoring.git</div>
+              <div><span class="p">$</span> cd clickhouse-monitoring</div>
+              <div>&nbsp;</div>
+              <div><span class="p">$</span> helm install my-chm ./deploy/helm/chmonitor <span class="f">\</span></div>
+              <div>&nbsp;&nbsp;<span class="s">--set</span> clickhouse.host="https://clickhouse.example.com:8443" <span class="f">\</span></div>
+              <div>&nbsp;&nbsp;<span class="s">--set</span> clickhouse.user="default" <span class="f">\</span></div>
+              <div>&nbsp;&nbsp;<span class="s">--set</span> clickhouse.password="change-me"</div>
+              <div>&nbsp;</div>
+              <div><span class="p">$</span> kubectl port-forward svc/my-chm-chmonitor 3000:3000&nbsp;&nbsp;<span class="c"># &lt;release&gt;-chmonitor</span></div>
+            </div>
+          </div>
+          <div class="deploy-sub">Upgrade / remove</div>
+          <div class="terminal">
+            <div class="term-bar"><span class="lights"><i style="background:#ff5f57"></i><i style="background:#febc2e"></i><i style="background:#28c840"></i></span><span class="ttl">bash</span><button class="copy">Copy</button></div>
+            <div class="term-body">
+              <div><span class="p">$</span> helm upgrade my-chm ./deploy/helm/chmonitor <span class="s">-f</span> my-values.yaml</div>
+              <div><span class="p">$</span> helm uninstall my-chm</div>
+            </div>
+          </div>
+          <div class="callout"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16h.01"/></svg><div>For production, keep the password out of <code>--set</code> (use <code>clickhouse.existingSecret</code>), enable Ingress, and set <code>autoscaling.enabled=true</code>.</div></div>
+        </div>
+      </div>
+    </div>
+  </section>

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -2,13 +2,24 @@
 import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'
 import Hero from '../components/Hero.astro'
+import Features from '../components/Features.astro'
+import DataExplorer from '../components/DataExplorer.astro'
+import Health from '../components/Health.astro'
+import Capabilities from '../components/Capabilities.astro'
+import OpenSource from '../components/OpenSource.astro'
+import FinalCta from '../components/FinalCta.astro'
 import Footer from '../components/Footer.astro'
 ---
-
 <Base>
   <Nav />
   <main id="top">
     <Hero />
+    <Features />
+    <DataExplorer />
+    <Health />
+    <Capabilities />
+    <OpenSource />
+    <FinalCta />
   </main>
   <Footer />
 </Base>


### PR DESCRIPTION
## What

Completes the chmonitor.dev landing page with the six remaining design sections and wires all nine into `index.astro`:

- **Features** — AI agent (carousel), every-query, cluster topology
- **Data Explorer** — dependency graph + query editor (2-up)
- **Health Summary** — color-coded signals + ready-to-paste audit prompt
- **Capabilities** — 6-card grid
- **Open Source** — install points + Cloudflare/Docker/Helm deploy tabs (with copy)
- **Final CTA**

Each is a verbatim port of the Claude Design handoff (asset paths rewritten to Astro's public root). Builds clean as static output. Follows the scaffold in #1370.

## Prod impact

None — not deployed/routed yet (lands in the topology PR).

🤖 Part of the landing-page + domain-split effort.

Co-Authored-By: duyetbot <bot@duyet.net>