### PR TITLE
fix(docker): build dashboard only, exclude standalone astro apps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,10 @@ apps/dashboard/.next
 apps/dashboard/.open-next
 apps/dashboard/out
 
+# Standalone Astro apps ship as separate Cloudflare Workers — never in the image
+apps/landing
+apps/docs
+
 # Dependencies
 node_modules
 docs/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,11 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# Build the web app via turbo (root build delegates to the web workspace).
+# Build only the dashboard app via turbo. The standalone Astro apps
+# (apps/landing, apps/docs) are not workspace members and ship as separate
+# Cloudflare Workers, so they are never part of the Docker image.
 # wasm:build is skipped by next.config.ts when WASM files exist.
-RUN bun run build
+RUN bun run build --filter=dashboard
 
 # Production image, copy all the files and run next
 FROM base AS runner


### PR DESCRIPTION
## Summary

The Docker image is the dashboard Next.js standalone server. This makes the image build dashboard-only and keeps the standalone Astro apps out of the build entirely.

## Changes

- `Dockerfile`: `RUN bun run build` → `RUN bun run build --filter=dashboard` (turbo builds the `dashboard` package and its workspace deps only).
- `.dockerignore`: exclude `apps/landing` and `apps/docs` from the build context — they are standalone Astro apps deployed as separate Cloudflare Workers (`chmonitor-landing`, `chmonitor-docs`) and have no place in the image.

## Notes

- The dashboard keeps its bundled `/docs` route (`scripts/build-docs-content.ts`) for Docker self-hosting — untouched.
- `apps/mcp` is a Cloudflare Worker, not run in Docker, so it's intentionally not part of the filtered build.

https://claude.ai/code/session_01BkF5pPaR8AtTemN7pgZPPv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkF5pPaR8AtTemN7pgZPPv)_

## Summary by Sourcery

Restrict the Docker image build to the dashboard application and exclude unrelated standalone Astro apps from the image context.

Build:
- Update Dockerfile to run a filtered dashboard-only Turbo build for the Next.js app.
- Adjust Docker build context to ignore standalone Astro apps that are deployed separately as Cloudflare Workers.