### PR TITLE
feat(workers): rename workers and wire chmonitor.dev subdomains

### DIFF
--- a/apps/dashboard/middleware.ts
+++ b/apps/dashboard/middleware.ts
@@ -90,10 +90,38 @@ async function getAgentApiClerkPrecheck(request: NextRequest) {
   return null
 }
 
+// cloud.chmonitor.dev is a legacy alias of the dashboard. Permanently redirect
+// it to the canonical dash.chmonitor.dev host, preserving path and query.
+function getLegacyHostRedirect(request: NextRequest) {
+  const host = request.headers.get('host')
+  if (host !== 'cloud.chmonitor.dev') {
+    return null
+  }
+
+  const url = request.nextUrl
+  return NextResponse.redirect(
+    `https://dash.chmonitor.dev${url.pathname}${url.search}`,
+    301
+  )
+}
+
 export default async function middleware(
   request: NextRequest,
   event: NextFetchEvent
 ) {
+  const legacyHostRedirect = getLegacyHostRedirect(request)
+  if (legacyHostRedirect) {
+    return legacyHostRedirect
+  }
+
+  // The auth logic below only applies to API + Clerk internal routes. The
+  // matcher also covers page routes (so the host redirect above can fire), so
+  // pass everything else straight through without invoking Clerk.
+  const { pathname } = request.nextUrl
+  if (!pathname.startsWith('/api/v1/') && !pathname.startsWith('/__clerk/')) {
+    return NextResponse.next()
+  }
+
   let authProvider: ReturnType<typeof getAuthProvider>
 
   try {
@@ -127,5 +155,12 @@ export default async function middleware(
 }
 
 export const config = {
-  matcher: ['/api/v1/:path*', '/__clerk/:path*'],
+  // /api/v1 + /__clerk drive auth; the broad page matcher (excluding Next.js
+  // internals and static files) lets the cloud.chmonitor.dev host redirect fire
+  // on any path. Non-API page requests short-circuit to NextResponse.next().
+  matcher: [
+    '/api/v1/:path*',
+    '/__clerk/:path*',
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.[\\w]+$).*)',
+  ],
 }

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -1,7 +1,7 @@
-# wrangler.toml configuration for clickhouse-monitor
+# wrangler.toml configuration for the chmonitor dashboard worker
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/
 
-name = "clickhouse-monitor"
+name = "chmonitor-dash"
 main = ".open-next/worker.js"
 compatibility_date = "2026-05-28"
 
@@ -27,10 +27,21 @@ compatibility_flags = ["nodejs_compat", "nodejs_compat_populate_process_env", "g
 directory = ".open-next/assets"
 binding = "ASSETS"
 
+# Custom domains for the production dashboard.
+# dash.chmonitor.dev is the canonical host; cloud.chmonitor.dev is a legacy
+# alias that middleware.ts 301-redirects to dash.chmonitor.dev.
+[[routes]]
+pattern = "dash.chmonitor.dev"
+custom_domain = true
+
+[[routes]]
+pattern = "cloud.chmonitor.dev"
+custom_domain = true
+
 # Service binding for self-reference
 [[services]]
 binding = "WORKER_SELF_REFERENCE"
-service = "clickhouse-monitor"
+service = "chmonitor-dash"
 
 # R2 bucket for incremental cache
 [[r2_buckets]]
@@ -167,7 +178,7 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_live_Y2xlcmsuY2htb25pdG9yLmRldiQ"
 #   wrangler secret put CLICKHOUSE_PASSWORD --env preview
 # ─────────────────────────────────────────────────────────────────────────────
 [env.preview]
-name = "clickhouse-monitor-preview"
+name = "preview-chmonitor-dash"
 
 # Custom domain for the preview worker.
 # On the first deploy that includes this route, Wrangler provisions the DNS
@@ -206,7 +217,7 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_bWFnbmV0aWMtcmF5LTkwLmNsZXJrLmFjY29
 # Self-reference must point to the preview worker
 [[env.preview.services]]
 binding = "WORKER_SELF_REFERENCE"
-service = "clickhouse-monitor-preview"
+service = "preview-chmonitor-dash"
 
 # Durable Objects for cache queue (not inherited from top-level)
 [[env.preview.durable_objects.bindings]]

--- a/apps/docs/wrangler.toml
+++ b/apps/docs/wrangler.toml
@@ -1,0 +1,16 @@
+# wrangler.toml for the chmonitor documentation worker.
+#
+# Static-assets-only Worker: Astro Starlight builds to ./dist, which is served
+# directly by Workers Assets (no `main` script).
+#
+# Deploy: cd apps/docs && bun run build && wrangler deploy
+
+name = "chmonitor-docs"
+compatibility_date = "2026-05-28"
+
+[assets]
+directory = "./dist"
+
+[[routes]]
+pattern = "docs.chmonitor.dev"
+custom_domain = true

--- a/apps/landing/wrangler.toml
+++ b/apps/landing/wrangler.toml
@@ -1,0 +1,21 @@
+# wrangler.toml for the chmonitor marketing landing worker.
+#
+# Static-assets-only Worker: Astro builds to ./dist, which is served directly
+# by Workers Assets (no `main` script). public/_redirects (copied into dist)
+# sends /docs* to docs.chmonitor.dev.
+#
+# Deploy: cd apps/landing && bun run build && wrangler deploy
+#
+# Note: the chmonitor.dev apex is a custom domain. It currently lives on the
+# legacy worker; the live cutover detaches it there before the first deploy
+# here claims it (custom domains are exclusive).
+
+name = "chmonitor-landing"
+compatibility_date = "2026-05-28"
+
+[assets]
+directory = "./dist"
+
+[[routes]]
+pattern = "chmonitor.dev"
+custom_domain = true

--- a/apps/mcp/wrangler.toml
+++ b/apps/mcp/wrangler.toml
@@ -24,7 +24,7 @@
 #   CHM_API_KEY_SECRET (any value works; clients must use a key signed with
 #   the same secret) and CLICKHOUSE_PASSWORD.
 
-name = "clickhouse-monitor-mcp"
+name = "chmonitor-mcp"
 main = "src/index.ts"
 compatibility_date = "2026-05-28"
 
@@ -45,15 +45,16 @@ compatibility_flags = [
 [observability]
 enabled = true
 
-# Workers Routes — more specific than main worker's chmonitor.dev/*, win first.
+# Workers Routes — more specific than the dashboard worker's
+# dash.chmonitor.dev/* custom domain, so they win first.
 # Trailing-slash and future sub-path variants (/api/mcp/, /api/mcp/session/…)
 # are captured with the `*` suffix.
 [[routes]]
-pattern = "chmonitor.dev/api/mcp*"
+pattern = "dash.chmonitor.dev/api/mcp*"
 zone_name = "chmonitor.dev"
 
 [[routes]]
-pattern = "chmonitor.dev/api/v1/mcp/info*"
+pattern = "dash.chmonitor.dev/api/v1/mcp/info*"
 zone_name = "chmonitor.dev"
 
 [vars]
@@ -69,7 +70,7 @@ NODE_ENV = "production"
 # Preview environment (mirrors main worker preview at preview.chmonitor.dev)
 # ─────────────────────────────────────────────────────────────────────────────
 [env.preview]
-name = "clickhouse-monitor-mcp-preview"
+name = "preview-chmonitor-mcp"
 
 [[env.preview.routes]]
 pattern = "preview.chmonitor.dev/api/mcp*"


### PR DESCRIPTION
## Summary

Renames the Cloudflare Workers to their final names and attaches the new custom domains for the 4-app monorepo topology. Cloudflare bindings (D1/R2/KV/DO) are keyed by **id**, so renaming the worker is safe (DO restarts fresh).

## Changes

**dashboard** (`apps/dashboard/wrangler.toml`)
- `name` + `WORKER_SELF_REFERENCE` service → `chmonitor-dash`
- add custom domains: `dash.chmonitor.dev` (canonical) + `cloud.chmonitor.dev` (legacy alias)
- preview worker → `preview-chmonitor-dash` (keeps `preview.chmonitor.dev`)

**middleware** (`apps/dashboard/middleware.ts`)
- 301-redirect `cloud.chmonitor.dev` → `dash.chmonitor.dev` (path + query preserved)
- broaden the matcher to page routes so the host redirect can fire, while short-circuiting non-API requests with `NextResponse.next()` so Clerk is **not** invoked on pages

**mcp** (`apps/mcp/wrangler.toml`)
- `name` → `chmonitor-mcp`
- routes → `dash.chmonitor.dev/api/mcp*` + `dash.chmonitor.dev/api/v1/mcp/info*`
- preview → `preview-chmonitor-mcp`

**landing** (`apps/landing/wrangler.toml`, new) — `chmonitor-landing`, assets `./dist`, apex `chmonitor.dev` custom domain

**docs** (`apps/docs/wrangler.toml`, new) — `chmonitor-docs`, assets `./dist`, `docs.chmonitor.dev`

## Notes / sequencing

- New workers deploy with **new** domains (`dash.`, `cloud.`, `docs.`) — no conflict with the legacy `clickhouse-monitor*` workers, which keep serving the `chmonitor.dev` apex until the manual cutover. Prod stays up.
- The apex (`chmonitor.dev`) is **not** claimed here; the live cutover detaches it from the legacy worker before `chmonitor-landing` claims it (custom domains are exclusive).
- Transitional: a PR preview deploy may briefly fail to attach `preview.chmonitor.dev` (still on the legacy preview worker) until the old preview worker is removed during cutover. Preview is not a required check.

## Verification

`landing` + `docs` `wrangler deploy --dry-run` succeed; biome clean.

https://claude.ai/code/session_01BkF5pPaR8AtTemN7pgZPPv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkF5pPaR8AtTemN7pgZPPv)_