### PR TITLE
ci(cloudflare): deploy landing and docs workers

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -455,3 +455,90 @@ jobs:
           echo "| Branch/Tag | \`${{ steps.meta.outputs.git_ref }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "✅ Deployment completed successfully!" >> $GITHUB_STEP_SUMMARY
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Landing (apps/landing): standalone Astro static-assets worker.
+  # Built outside the bun workspace (own bun.lock). Production deploys
+  # chmonitor-landing (chmonitor.dev apex); PRs deploy preview-chmonitor-landing.
+  # ──────────────────────────────────────────────────────────────────────────
+  landing:
+    name: landing
+    # Skip on forked PRs — deploy secrets must not leak to PR-controlled code.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/landing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.3
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Deploy preview
+        if: github.event_name == 'pull_request'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bunx wrangler deploy --env preview
+
+      - name: Deploy production
+        if: github.event_name != 'pull_request'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bunx wrangler deploy
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Docs (apps/docs): standalone Astro Starlight static-assets worker.
+  # Built outside the bun workspace (own bun.lock). Production deploys
+  # chmonitor-docs (docs.chmonitor.dev); PRs deploy preview-chmonitor-docs.
+  # ──────────────────────────────────────────────────────────────────────────
+  docs:
+    name: docs
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/docs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.3
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Deploy preview
+        if: github.event_name == 'pull_request'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bunx wrangler deploy --env preview
+
+      - name: Deploy production
+        if: github.event_name != 'pull_request'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bunx wrangler deploy

--- a/apps/docs/wrangler.toml
+++ b/apps/docs/wrangler.toml
@@ -14,3 +14,12 @@ directory = "./dist"
 [[routes]]
 pattern = "docs.chmonitor.dev"
 custom_domain = true
+
+# Preview environment for PR deployments. Routes are not inherited by named
+# environments, so the preview worker has no custom domain — it is reachable at
+# preview-chmonitor-docs.<account>.workers.dev.
+[env.preview]
+name = "preview-chmonitor-docs"
+
+[env.preview.assets]
+directory = "./dist"

--- a/apps/landing/wrangler.toml
+++ b/apps/landing/wrangler.toml
@@ -19,3 +19,12 @@ directory = "./dist"
 [[routes]]
 pattern = "chmonitor.dev"
 custom_domain = true
+
+# Preview environment for PR deployments. Routes are not inherited by named
+# environments, so the preview worker has no custom domain — it is reachable at
+# preview-chmonitor-landing.<account>.workers.dev.
+[env.preview]
+name = "preview-chmonitor-landing"
+
+[env.preview.assets]
+directory = "./dist"


### PR DESCRIPTION
## Summary

Adds `landing` and `docs` jobs to `.github/workflows/cloudflare.yml` so the standalone Astro apps (outside the bun workspace, own `bun.lock`) deploy alongside the dashboard/mcp workers.

## Changes

- **`cloudflare.yml`**: two new jobs, each `bun install --frozen-lockfile && bun run build`, then `wrangler deploy` (prod, on main/tags) or `wrangler deploy --env preview` (PRs, skipped on forks):
  - `landing` → `chmonitor-landing` / `preview-chmonitor-landing`
  - `docs` → `chmonitor-docs` / `preview-chmonitor-docs`
- **`apps/landing/wrangler.toml`** + **`apps/docs/wrangler.toml`**: add `[env.preview]` (no custom domain — routes are not inherited by named environments, so preview workers land on `*.workers.dev`).

## Notes

- PR previews for landing/docs deploy to new `*.workers.dev` names — no conflict.
- The **landing production** deploy claims the `chmonitor.dev` apex, which remains attached to the legacy `clickhouse-monitor` worker until the manual cutover detaches it. The critical dashboard/mcp production deploys are unaffected. This red job is the trigger for the cutover (tracked separately).

## Verification

`wrangler deploy --env preview --dry-run` for both apps succeeds; YAML parses (jobs: preview, production, landing, docs).

https://claude.ai/code/session_01BkF5pPaR8AtTemN7pgZPPv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkF5pPaR8AtTemN7pgZPPv)_