### PR TITLE
fix(dashboard): unblock production deploy (cron over account limit) + shiki type

### DIFF
--- a/apps/dashboard/app/robots.ts
+++ b/apps/dashboard/app/robots.ts
@@ -4,7 +4,8 @@ import type { MetadataRoute } from 'next'
 export const dynamic = 'force-static'
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://dash.chmonitor.dev'
+  const baseUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || 'https://dash.chmonitor.dev'
   return {
     rules: { userAgent: '*', allow: '/' },
     sitemap: `${baseUrl}/sitemap.xml`,

--- a/apps/dashboard/app/sitemap.ts
+++ b/apps/dashboard/app/sitemap.ts
@@ -7,7 +7,8 @@ import { docsNav } from './(docs)/docs/_lib/docs'
 /** Generate at build time — content is static. */
 export const dynamic = 'force-static'
 
-const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://dash.chmonitor.dev'
+const BASE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || 'https://dash.chmonitor.dev'
 
 /** Pages that exist as routes but aren't in the sidebar menu. */
 const HIDDEN_PAGES = [

--- a/apps/dashboard/components/assistant-ui/markdown-text.tsx
+++ b/apps/dashboard/components/assistant-ui/markdown-text.tsx
@@ -5,7 +5,7 @@ import type { MermaidErrorComponentProps } from 'streamdown'
 
 import { mermaid as mermaidPlugin } from '@streamdown/mermaid'
 import { useTheme } from 'next-themes'
-import { memo, useMemo } from 'react'
+import { type ComponentProps, memo, useMemo } from 'react'
 import { Streamdown } from 'streamdown'
 
 import '@/components/agents/markdown-code.css'
@@ -53,10 +53,9 @@ const MarkdownTextImpl: TextMessagePartComponent = ({ text }) => {
   // root element (set by next-themes). Passing both themes lets Shiki embed
   // dual-theme CSS vars; Streamdown then switches via the dark-class variant
   // already declared in globals.css (@custom-variant dark (&:is(.dark *))).
-  const shikiTheme = useMemo(
-    () => ['github-light', 'github-dark'] as [string, string],
-    []
-  )
+  const shikiTheme = useMemo<
+    NonNullable<ComponentProps<typeof Streamdown>['shikiTheme']>
+  >(() => ['github-light', 'github-dark'], [])
 
   return (
     <div className="markdown-content aui-md text-sm leading-6">

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -57,8 +57,15 @@ enabled = true
 # Triggers to the worker fetch handler, which dispatches to the
 # GET /api/cron/health-sweep route. Guard it with the CRON_SECRET secret.
 # Docs: https://developers.cloudflare.com/workers/configuration/cron-triggers/
+#
+# TEMPORARILY DISABLED (crons = []): the account is at its 5-cron-trigger
+# limit because the pre-rename worker `clickhouse-monitor` still holds a slot.
+# Registering this cron made the `chmonitor-dash` deploy fail (CF error 10072),
+# which left dash.chmonitor.dev unattached. Once the old `clickhouse-monitor`
+# and `clickhouse-monitor-mcp` workers are decommissioned (freeing their
+# slots), restore: crons = ["*/5 * * * *"].
 [triggers]
-crons = ["*/5 * * * *"]
+crons = []
 
 # Resource limits — Paid plan only.
 # When this account upgrades to Workers Paid, uncomment to extend the CPU

--- a/apps/docs/src/content.config.ts
+++ b/apps/docs/src/content.config.ts
@@ -1,6 +1,6 @@
+import { defineCollection } from 'astro:content'
 import { docsLoader } from '@astrojs/starlight/loaders'
 import { docsSchema } from '@astrojs/starlight/schema'
-import { defineCollection } from 'astro:content'
 
 export const collections = {
   docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),


### PR DESCRIPTION
## P0 — dashboard unreachable after the domain split

`chmonitor-dash` uploads fine, but `wrangler deploy` then fails registering its cron trigger:

```
/workers/scripts/chmonitor-dash/schedules failed:
You have exceeded the limit of 5 cron triggers [code: 10072]
```

The account is at the 5-cron limit because the pre-rename `clickhouse-monitor` worker still holds a slot. The non-zero exit leaves **`dash.chmonitor.dev` unattached** and skips the mcp deploy → the dashboard + `dash.chmonitor.dev/api/mcp` are down.

## Fix

- **`apps/dashboard/wrangler.toml`: `crons = []`** — lets the deploy finish and attach `dash.chmonitor.dev`. Restore `crons = ["*/5 * * * *"]` once the old `clickhouse-monitor*` workers are decommissioned (freeing their cron slots).
- **`markdown-text.tsx`**: type `shikiTheme` via Streamdown's own prop type instead of the too-narrow `[string, string]` cast — fixes the strict `tsc --noEmit` that `next build` had been tolerating (was masked by turbo cache).
- **Drive-by Biome fixes** (pre-existing, were blocking `bun run check`): format `robots.ts`/`sitemap.ts`, sort imports in `apps/docs/src/content.config.ts`.

## Follow-up (needs CF API token — for @duyet / the ops agent)

After this restores the dashboard: delete old workers `clickhouse-monitor` + `clickhouse-monitor-mcp` (frees cron slots + completes decommission), then restore the dashboard cron.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure and type system optimizations for improved maintainability across dashboard and documentation components.

* **Chores**
  * Configuration updates to scheduled service triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->