### PR TITLE
fix(charts): stop lazy charts reloading on scroll-back

### DIFF
--- a/apps/dashboard/app/globals.css
+++ b/apps/dashboard/app/globals.css
@@ -27,10 +27,16 @@
   /* Opt an element out of the browser's scroll-anchoring heuristic. Used on
      lazily-mounted chart slots so inserting a chart above the viewport during a
      fast scroll-to-bottom doesn't yank the scroll position around ("flaking").
-     Pairs with reserved slot heights so there is no shift to anchor against. */
+     Pairs with reserved slot heights so there is no shift to anchor against.
+
+     NOTE: `content-visibility: auto` is intentionally NOT set here. It is
+     applied inline by LazyChartWrapper only while a slot is still off-screen and
+     unloaded. Once a chart has mounted we must NOT keep content-visibility on it
+     — the browser would skip rendering it whenever it scrolls out of view and
+     repaint (re-running entrance animations) on scroll-back, which looks like
+     the chart "reloading". See lazy-chart-wrapper.tsx. */
   .overflow-anchor-none {
     overflow-anchor: none;
-    content-visibility: auto;
   }
 }
 

--- a/apps/dashboard/components/charts/lazy-chart-wrapper.tsx
+++ b/apps/dashboard/components/charts/lazy-chart-wrapper.tsx
@@ -31,6 +31,14 @@ interface LazyChartWrapperProps {
  * `contain-intrinsic-size`) and opts out of browser scroll anchoring
  * (`overflow-anchor: none`). Together these stop the layout shift / scroll-jump
  * "flaking" that happened when charts mounted above the viewport during a scroll.
+ *
+ * No re-loading on scroll-back: `content-visibility: auto` is applied ONLY while
+ * the slot is still off-screen and unloaded (it lets the browser skip layout for
+ * the placeholder). It is dropped the moment the chart becomes visible. Keeping
+ * it on a mounted chart would make the browser skip its rendering whenever it
+ * scrolls out of view and repaint it (re-running the FadeIn / chart entrance
+ * animation) on scroll-back — which users perceive as the chart "reloading" or
+ * flashing a loading state again. Once loaded, a chart must stay painted.
  */
 export const LazyChartWrapper = function LazyChartWrapper({
   children,
@@ -70,7 +78,11 @@ export const LazyChartWrapper = function LazyChartWrapper({
       style={{
         // Reserve height so the slot never collapses, even outside a
         // fixed-height grid, and so off-screen slots can skip rendering work.
+        // All three are dropped once the chart is visible: a mounted chart must
+        // render normally and stay painted, otherwise scrolling it out of view
+        // and back re-skips/repaints it and it looks like it reloads.
         minHeight: isVisible ? undefined : minHeightValue,
+        contentVisibility: isVisible ? undefined : 'auto',
         containIntrinsicSize: isVisible ? undefined : `auto ${minHeightValue}`,
       }}
     >


### PR DESCRIPTION
## Problem

On pages that lazy-load charts (overview — incl. the storage tab — plus dashboard and insights), charts that had **already loaded** flashed a loading/skeleton state again whenever the user scrolled them out of view and back. Each chart already has its own SWR hook and state, so this was not a shared-state issue — it was a rendering issue.

## Root cause

`LazyChartWrapper` applied `content-visibility: auto` **unconditionally** via the `.overflow-anchor-none` utility class, and never removed it after the chart mounted.

`content-visibility: auto` tells the browser to skip rendering an element's contents while it is off-screen and repaint them when it scrolls back into view. For a chart that has already mounted, this means:

- scrolling it out of the viewport → the browser drops its rendering, and
- scrolling back → it repaints and re-runs the `FadeIn` / chart entrance animation.

That repaint is what users perceived as the chart "reloading" / flashing a loading state again.

The optimization was only ever meant to save work for slots that **haven't loaded yet**.

## Fix

Apply `content-visibility: auto` (and its paired `contain-intrinsic-size`) **only while the slot is still off-screen and unloaded**, and drop it the moment the chart becomes visible. Once a chart is mounted it renders normally and stays painted — scrolling away and back no longer re-skips or repaints it.

- `components/charts/lazy-chart-wrapper.tsx` — `content-visibility` is now set inline, conditional on `isVisible` (mirrors the existing `containIntrinsicSize`/`minHeight` treatment).
- `app/globals.css` — `.overflow-anchor-none` now carries only `overflow-anchor: none`; the `content-visibility` is moved to the conditional inline style.

`overflow-anchor: none` and the off-screen height reservation are preserved, so the existing scroll-stability ("no flaking") behavior is unchanged.

## Scope

`LazyChartWrapper` is the shared lazy-loading mechanism, so this fixes all affected pages at once: overview (all tabs, including storage), dashboard, and insights.

## Verification

- `tsc --noEmit` passes
- `biome check` passes on the changed files

(Cypress component tests can't run in the sandbox — its binary download is blocked by the network policy — so no `.cy.tsx` was added.)

https://claude.ai/code/session_01Moy4kcoZSKDjpAqQkBqGca

---
_Generated by [Claude Code](https://claude.ai/code/session_01Moy4kcoZSKDjpAqQkBqGca)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll stability for charts to prevent visual flashing and unnecessary re-animation when scrolling to previously loaded content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->