### PR TITLE
fix(dashboard): improve mobile layout for page header and table cards

### DIFF
--- a/apps/dashboard/components/data-table/components/mobile-table-cards.tsx
+++ b/apps/dashboard/components/data-table/components/mobile-table-cards.tsx
@@ -311,7 +311,7 @@ const MobileTableCard = function MobileTableCard<TData extends RowData>({
     >
       {hasHeader && (
         <div
-          className={`${densitySpacing.headerMb} flex min-w-0 items-center gap-2`}
+          className={`${densitySpacing.headerMb} flex min-w-0 items-start gap-2`}
         >
           {isExpandable && (
             <button
@@ -335,11 +335,18 @@ const MobileTableCard = function MobileTableCard<TData extends RowData>({
             </div>
           )}
 
-          {badgeCells.map((cell) => (
-            <div key={cell.id} className="min-w-0 [&_*]:max-w-full">
-              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+          {badgeCells.length > 0 && (
+            // Wrap badges in their own min-w-0 flex group so multiple badges
+            // (or one long one like `ExceptionWhileProcessing`) wrap onto a new
+            // line instead of collapsing and overflowing onto each other.
+            <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+              {badgeCells.map((cell) => (
+                <div key={cell.id} className="max-w-full [&_*]:max-w-full">
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </div>
+              ))}
             </div>
-          ))}
+          )}
 
           {actionCell && (
             <div className="-mr-1 ml-auto shrink-0">
@@ -475,7 +482,8 @@ export const MobileTableCards = function MobileTableCards<
 
   // Multi-column card grid — active in both explicit 'cards' view and 'auto'
   // mode. The virtualized path always stacks (separate code branch).
-  // Phones get 2 cols via grid-cols-2 base; desktop gets 3 at xl.
+  // Phones stack to a single column so each card is wide enough for its badges
+  // and label/value rows; tablets get 2 cols at sm and desktop 3 at xl.
   const gridLayout = view === 'cards' || view === 'auto'
 
   if (!rows.length) {
@@ -537,7 +545,7 @@ export const MobileTableCards = function MobileTableCards<
         <div
           className={
             gridLayout
-              ? 'grid grid-cols-2 gap-3 sm:grid-cols-2 xl:grid-cols-3'
+              ? 'grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3'
               : 'flex flex-col gap-3'
           }
         >

--- a/apps/dashboard/components/layout/page-header.tsx
+++ b/apps/dashboard/components/layout/page-header.tsx
@@ -12,10 +12,12 @@ interface PageHeaderProps {
 /**
  * PageHeader — shared page-level heading block.
  *
- * Renders a flex row with:
+ * On phones the title block and the actions stack vertically so the
+ * description gets the full width (instead of being squeezed into a narrow
+ * column that wraps one word per line) and the action buttons never overflow
+ * off-screen. From `sm:` up they sit on one row with actions right-aligned.
  * - `title` at `text-xl font-semibold tracking-tight sm:text-2xl`
  * - optional `description` as `text-sm text-muted-foreground` below the title
- * - optional `actions` slot right-aligned via `ml-auto`
  */
 export function PageHeader({
   title,
@@ -24,8 +26,13 @@ export function PageHeader({
   className,
 }: PageHeaderProps) {
   return (
-    <div className={cn('flex items-start justify-between gap-4', className)}>
-      <div className="min-w-0 flex-1">
+    <div
+      className={cn(
+        'flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4',
+        className
+      )}
+    >
+      <div className="min-w-0 sm:flex-1">
         <div className="text-xl font-semibold tracking-tight sm:text-2xl">
           {title}
         </div>


### PR DESCRIPTION
## Problem

On small (phone) screens several layouts broke, as seen on `dash.chmonitor.dev`:

1. **Page header** (e.g. Running Queries) — the action buttons (*Hide charts*, *Refresh*, *Live*) sat beside the title, which squeezed the title + description into a tiny column. The description rendered one word per line and the buttons overflowed off the right edge.
2. **Card view ("Cards" mode)** — the card grid forced **two columns even on the narrowest phones**, so each card was ~175px wide. As a result:
   - header badges (e.g. `Select` + `QueryStartingTime`, or `Exception` + `ExceptionWhileProcessing`) collapsed and **overlapped** onto each other, and
   - long label/value detail rows (e.g. `23 rows / 9.21 KiB`) **overflowed** into the neighbouring card.

## Changes

- **`components/layout/page-header.tsx`** — stack the title block and actions vertically on phones (`flex-col`), switching to a single row with right-aligned actions from `sm:` up. The description now spans the full width and action buttons wrap instead of running off-screen.
- **`components/data-table/components/mobile-table-cards.tsx`**
  - Card grid is now a single column on phones: `grid-cols-1 sm:grid-cols-2 xl:grid-cols-3` (was `grid-cols-2` base). Each card gets enough width for its badges and detail rows.
  - Card-header badges are wrapped in a `min-w-0 flex-1 flex-wrap` group so multiple badges — or one long one like `ExceptionWhileProcessing` — wrap to a new line instead of collapsing and overlapping. Removed the per-badge `min-w-0` that caused the wrappers to collapse to zero width and spill their text.

Desktop/tablet (`sm:` and up) layouts are unchanged.

## Verification

- `bun run type-check` — passes
- `biome lint` on the changed files — clean

No tests assert the affected class names.


---
_Generated by [Claude Code](https://claude.ai/code/session_0183iLn8dszSqKp7sNmcm3mN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mobile table card layout to display in a single column for improved phone usability
  * Improved badge rendering to wrap cleanly across multiple lines
  * Enhanced page header responsiveness: titles and actions now stack vertically on small screens and align horizontally on larger devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->