### PR TITLE
feat(cloudflare): cloud→dash 301 via edge Redirect Rule + track MCP secret

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -120,26 +120,18 @@ jobs:
           ANYROUTER_API_KEY: ${{ secrets.ANYROUTER_API_KEY }}
           ANYROUTER_API_BASE: ${{ secrets.ANYROUTER_API_BASE }}
           CLERK_SECRET_KEY_TEST: ${{ secrets.CLERK_SECRET_KEY_TEST }}
+          CHM_API_KEY_SECRET: ${{ secrets.CHM_API_KEY_SECRET }}
           CLICKHOUSE_TZ: ${{ secrets.CLICKHOUSE_TZ || 'UTC' }}
           CLICKHOUSE_EXCLUDE_USER_DEFAULT: ${{ secrets.CLICKHOUSE_EXCLUDE_USER_DEFAULT || '' }}
           NEXT_QUERY_CACHE_TTL: ${{ secrets.NEXT_QUERY_CACHE_TTL || '3600' }}
         working-directory: apps/dashboard
         run: |
           set -euo pipefail
-          # Set secrets directly to avoid executing PR-controlled scripts with privileged env
-          printf '%s' "$CLICKHOUSE_PASSWORD" | npx --yes --package=wrangler@4 wrangler secret put CLICKHOUSE_PASSWORD --env preview
-          printf '%s' "$LLM_API_KEY" | npx --yes --package=wrangler@4 wrangler secret put LLM_API_KEY --env preview
-          printf '%s' "$LLM_API_BASE" | npx --yes --package=wrangler@4 wrangler secret put LLM_API_BASE --env preview
-          printf '%s' "$OPENROUTER_API_KEY" | npx --yes --package=wrangler@4 wrangler secret put OPENROUTER_API_KEY --env preview
-          printf '%s' "$OPENROUTER_API_BASE" | npx --yes --package=wrangler@4 wrangler secret put OPENROUTER_API_BASE --env preview
-          printf '%s' "$NVIDIA_API_KEY" | npx --yes --package=wrangler@4 wrangler secret put NVIDIA_API_KEY --env preview
-          printf '%s' "$NVIDIA_API_BASE" | npx --yes --package=wrangler@4 wrangler secret put NVIDIA_API_BASE --env preview
-          printf '%s' "$ANYROUTER_API_KEY" | npx --yes --package=wrangler@4 wrangler secret put ANYROUTER_API_KEY --env preview
-          printf '%s' "$ANYROUTER_API_BASE" | npx --yes --package=wrangler@4 wrangler secret put ANYROUTER_API_BASE --env preview
-          printf '%s' "$CLERK_SECRET_KEY_TEST" | npx --yes --package=wrangler@4 wrangler secret put CLERK_SECRET_KEY --env preview
-          printf '%s' "$CLICKHOUSE_TZ" | npx --yes --package=wrangler@4 wrangler secret put CLICKHOUSE_TZ --env preview
-          printf '%s' "$CLICKHOUSE_EXCLUDE_USER_DEFAULT" | npx --yes --package=wrangler@4 wrangler secret put CLICKHOUSE_EXCLUDE_USER_DEFAULT --env preview
-          printf '%s' "$NEXT_QUERY_CACHE_TTL" | npx --yes --package=wrangler@4 wrangler secret put NEXT_QUERY_CACHE_TTL --env preview
+          # Centralized inventory: scripts/set-secrets.ts is the single source of
+          # which secrets each worker needs (--from-env reads the values above).
+          # Safe to run here because the preview job excludes forks (head.repo ==
+          # this repo), so only push-access contributors can alter the script.
+          bun ../../scripts/set-secrets.ts --from-env --target dashboard --env preview
 
       - name: Deploy preview to Cloudflare Workers
         id: deploy
@@ -163,8 +155,7 @@ jobs:
         working-directory: apps/mcp
         run: |
           set -euo pipefail
-          printf '%s' "$CLICKHOUSE_PASSWORD" | npx --yes --package=wrangler@4 wrangler secret put CLICKHOUSE_PASSWORD --env preview
-          printf '%s' "$CHM_API_KEY_SECRET" | npx --yes --package=wrangler@4 wrangler secret put CHM_API_KEY_SECRET --env preview
+          bun ../../scripts/set-secrets.ts --from-env --target mcp --env preview
 
       - name: Deploy MCP worker preview
         if: steps.deploy.outcome == 'success'
@@ -360,7 +351,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # Pass secrets required by wrangler secret put
+          # Values read by scripts/set-secrets.ts via --from-env
           CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
           LLM_API_BASE: ${{ secrets.LLM_API_BASE }}
@@ -371,26 +362,16 @@ jobs:
           ANYROUTER_API_KEY: ${{ secrets.ANYROUTER_API_KEY }}
           ANYROUTER_API_BASE: ${{ secrets.ANYROUTER_API_BASE }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          CHM_API_KEY_SECRET: ${{ secrets.CHM_API_KEY_SECRET }}
           CLICKHOUSE_TZ: ${{ secrets.CLICKHOUSE_TZ || 'UTC' }}
           CLICKHOUSE_EXCLUDE_USER_DEFAULT: ${{ secrets.CLICKHOUSE_EXCLUDE_USER_DEFAULT || '' }}
           NEXT_QUERY_CACHE_TTL: ${{ secrets.NEXT_QUERY_CACHE_TTL || '3600' }}
         working-directory: apps/dashboard
         run: |
           set -euo pipefail
-
-          printf '%s' "$CLICKHOUSE_PASSWORD" | npx --yes --package=wrangler@4 wrangler secret put CLICKHOUSE_PASSWORD
-          printf '%s' "$LLM_API_KEY" | npx --yes --package=wrangler@4 wrangler secret put LLM_API_KEY
-          printf '%s' "$LLM_API_BASE" | npx --yes --package=wrangler@4 wrangler secret put LLM_API_BASE
-          printf '%s' "$OPENROUTER_API_KEY" | npx --yes --package=wrangler@4 wrangler secret put OPENROUTER_API_KEY
-          printf '%s' "$OPENROUTER_API_BASE" | npx --yes --package=wrangler@4 wrangler secret put OPENROUTER_API_BASE
-          printf '%s' "$NVIDIA_API_KEY" | npx --yes --package=wrangler@4 wrangler secret put NVIDIA_API_KEY
-          printf '%s' "$NVIDIA_API_BASE" | npx --yes --package=wrangler@4 wrangler secret put NVIDIA_API_BASE
-          printf '%s' "$ANYROUTER_API_KEY" | npx --yes --package=wrangler@4 wrangler secret put ANYROUTER_API_KEY
-          printf '%s' "$ANYROUTER_API_BASE" | npx --yes --package=wrangler@4 wrangler secret put ANYROUTER_API_BASE
-          printf '%s' "$CLERK_SECRET_KEY" | npx --yes --package=wrangler@4 wrangler secret put CLERK_SECRET_KEY
-          printf '%s' "$CLICKHOUSE_TZ" | npx --yes --package=wrangler@4 wrangler secret put CLICKHOUSE_TZ
-          printf '%s' "$CLICKHOUSE_EXCLUDE_USER_DEFAULT" | npx --yes --package=wrangler@4 wrangler secret put CLICKHOUSE_EXCLUDE_USER_DEFAULT
-          printf '%s' "$NEXT_QUERY_CACHE_TTL" | npx --yes --package=wrangler@4 wrangler secret put NEXT_QUERY_CACHE_TTL
+          # Single source of truth for the dashboard secret inventory (includes
+          # CHM_API_KEY_SECRET, which the inline list previously omitted).
+          bun ../../scripts/set-secrets.ts --from-env --target dashboard
 
       - name: Deploy to Cloudflare Workers
         id: deploy
@@ -412,8 +393,7 @@ jobs:
         working-directory: apps/mcp
         run: |
           set -euo pipefail
-          printf '%s' "$CLICKHOUSE_PASSWORD" | npx --yes --package=wrangler@4 wrangler secret put CLICKHOUSE_PASSWORD
-          printf '%s' "$CHM_API_KEY_SECRET" | npx --yes --package=wrangler@4 wrangler secret put CHM_API_KEY_SECRET
+          bun ../../scripts/set-secrets.ts --from-env --target mcp
 
       - name: Deploy MCP worker
         env:

--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -131,7 +131,7 @@ jobs:
           # which secrets each worker needs (--from-env reads the values above).
           # Safe to run here because the preview job excludes forks (head.repo ==
           # this repo), so only push-access contributors can alter the script.
-          bun ../../scripts/set-secrets.ts --from-env --target dashboard --env preview
+          bun ../../scripts/set-secrets.ts --from-env --strict --target dashboard --env preview
 
       - name: Deploy preview to Cloudflare Workers
         id: deploy
@@ -155,7 +155,7 @@ jobs:
         working-directory: apps/mcp
         run: |
           set -euo pipefail
-          bun ../../scripts/set-secrets.ts --from-env --target mcp --env preview
+          bun ../../scripts/set-secrets.ts --from-env --strict --target mcp --env preview
 
       - name: Deploy MCP worker preview
         if: steps.deploy.outcome == 'success'
@@ -371,7 +371,7 @@ jobs:
           set -euo pipefail
           # Single source of truth for the dashboard secret inventory (includes
           # CHM_API_KEY_SECRET, which the inline list previously omitted).
-          bun ../../scripts/set-secrets.ts --from-env --target dashboard
+          bun ../../scripts/set-secrets.ts --from-env --strict --target dashboard
 
       - name: Deploy to Cloudflare Workers
         id: deploy
@@ -393,7 +393,7 @@ jobs:
         working-directory: apps/mcp
         run: |
           set -euo pipefail
-          bun ../../scripts/set-secrets.ts --from-env --target mcp
+          bun ../../scripts/set-secrets.ts --from-env --strict --target mcp
 
       - name: Deploy MCP worker
         env:

--- a/docs/knowledge/deployment.md
+++ b/docs/knowledge/deployment.md
@@ -126,6 +126,33 @@ wrangler secret put CLICKHOUSE_PASSWORD
 bun run cf:health
 ```
 
+## Edge Routing & Host Redirects (4-worker topology)
+
+Production runs four workers on the `chmonitor.dev` zone:
+
+| Worker | Host / route |
+|--------|--------------|
+| `chmonitor-landing` | `chmonitor.dev` (apex marketing) |
+| `chmonitor-dash` | `dash.chmonitor.dev` + `cloud.chmonitor.dev` (custom domains) |
+| `chmonitor-mcp` | `dash.chmonitor.dev/api/mcp*` + `/api/v1/mcp/info*` (Workers Routes) |
+| `chmonitor-docs` | `docs.chmonitor.dev` |
+
+A specific Workers **Route** (`.../api/mcp*`) wins over a whole-hostname
+**Custom Domain** (`dash.chmonitor.dev`) — sub-path routes are more specific —
+so the MCP worker intercepts `/api/mcp` even though the dashboard owns the host.
+
+**`cloud.chmonitor.dev` → `dash.chmonitor.dev` 301** is a Cloudflare edge
+**Redirect Rule**, NOT Next.js middleware. `middleware.ts` cannot redirect the
+prerendered static root: OpenNext serves `/` as an asset without invoking the
+worker, so the host-redirect code never runs. A zone Redirect Rule fires at the
+edge *before* the worker, covering every path uniformly. Provision/refresh it
+(idempotent) with a `CLOUDFLARE_API_TOKEN` that has Zone › Config Rules › Edit:
+
+```bash
+bun run cf:redirect-rule            # apply
+bun run cf:redirect-rule --dry-run  # preview the ruleset payload
+```
+
 ## Troubleshooting
 
 | Issue | Solution |
@@ -134,3 +161,5 @@ bun run cf:health
 | `__name is not defined` (CF) | `wrangler.toml` has `keep_names = false` |
 | Build lock error | Remove `.next/lock` and retry |
 | Secrets not updating | See [secret-rotation.md](secret-rotation.md) — redeploy after updating |
+| `/api/mcp` → 503 "MCP API key auth is not configured" | `CHM_API_KEY_SECRET` empty on `chmonitor-mcp`. Worker secrets don't survive a rename. Set the GitHub secret (`bun run gh:sync-secrets`) and redeploy; CI pushes it to both workers. |
+| `cloud.chmonitor.dev` returns 200 instead of 301 | Edge Redirect Rule missing — run `bun run cf:redirect-rule`. Middleware can't fix this (prerendered root skips the worker). |

--- a/docs/knowledge/deployment.md
+++ b/docs/knowledge/deployment.md
@@ -146,7 +146,9 @@ so the MCP worker intercepts `/api/mcp` even though the dashboard owns the host.
 prerendered static root: OpenNext serves `/` as an asset without invoking the
 worker, so the host-redirect code never runs. A zone Redirect Rule fires at the
 edge *before* the worker, covering every path uniformly. Provision/refresh it
-(idempotent) with a `CLOUDFLARE_API_TOKEN` that has Zone › Config Rules › Edit:
+(idempotent) with a `CLOUDFLARE_API_TOKEN` scoped to **Zone › Single Redirect ›
+Edit** (manages the rule) **and Zone › Zone › Read** (the script resolves the
+zone id first, so a token missing read still fails):
 
 ```bash
 bun run cf:redirect-rule            # apply

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "cf:migrate-conversations": "bun --filter dashboard cf:migrate-conversations",
     "cf:migrate-conversations:local": "bun --filter dashboard cf:migrate-conversations:local",
     "cf:health": "bun --filter dashboard cf:health",
+    "cf:redirect-rule": "bun scripts/cloudflare-redirect-rule.ts",
     "gh:sync-secrets": "bun --filter dashboard gh:sync-secrets",
     "migrate": "bun --filter dashboard migrate",
     "migrate:status": "bun --filter dashboard migrate:status",

--- a/scripts/cloudflare-redirect-rule.ts
+++ b/scripts/cloudflare-redirect-rule.ts
@@ -17,8 +17,8 @@
  * and preserves any other dynamic-redirect rules already on the zone.
  *
  * Auth: needs CLOUDFLARE_API_TOKEN with permissions
- *   Zone > Config Rules > Edit  (a.k.a. "Dynamic Redirect" / Rulesets edit)
- *   Zone > Zone > Read
+ *   Zone > Single Redirect > Edit  (manages the dynamic_redirect ruleset)
+ *   Zone > Zone > Read             (resolve the zone id before the PUT)
  * Sourced from the environment or, failing that, .env.prod / .env.local
  * (same resolution as scripts/cloudflare-deploy.ts).
  *
@@ -32,8 +32,16 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const ENV_FILE_PROD = join(__dirname, '..', 'apps', 'dashboard', '.env.prod')
-const ENV_FILE_LOCAL = join(__dirname, '..', 'apps', 'dashboard', '.env.local')
+const REPO_ROOT = join(__dirname, '..')
+const DASHBOARD = join(REPO_ROOT, 'apps', 'dashboard')
+// Search order: repo-root files (as the deploy/env-sync scripts use) first,
+// then the dashboard app dir where this repo actually keeps its env files.
+const ENV_FILE_CANDIDATES = [
+  join(REPO_ROOT, '.env.prod'),
+  join(REPO_ROOT, '.env.local'),
+  join(DASHBOARD, '.env.prod'),
+  join(DASHBOARD, '.env.local'),
+]
 
 // --- Config -----------------------------------------------------------------
 
@@ -47,12 +55,20 @@ const DRY_RUN = process.argv.includes('--dry-run')
 
 // --- Env --------------------------------------------------------------------
 
+function stripQuotes(value: string): string {
+  if (
+    value.length >= 2 &&
+    ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'")))
+  ) {
+    return value.slice(1, -1)
+  }
+  return value
+}
+
+// First file that exists wins. Returns {} if none are present.
 function loadEnvFile(): Record<string, string> {
-  const file = existsSync(ENV_FILE_PROD)
-    ? ENV_FILE_PROD
-    : existsSync(ENV_FILE_LOCAL)
-      ? ENV_FILE_LOCAL
-      : null
+  const file = ENV_FILE_CANDIDATES.find((f) => existsSync(f))
   if (!file) return {}
 
   const vars: Record<string, string> = {}
@@ -60,7 +76,8 @@ function loadEnvFile(): Record<string, string> {
     const trimmed = line.trim()
     if (!trimmed || trimmed.startsWith('#')) continue
     const match = trimmed.match(/^([^=]+)=(.*)$/)
-    if (match) vars[match[1]] = match[2]
+    // Strip surrounding quotes so `CLOUDFLARE_API_TOKEN="..."` authenticates.
+    if (match) vars[match[1].trim()] = stripQuotes(match[2].trim())
   }
   return vars
 }
@@ -71,8 +88,9 @@ function resolveToken(): string {
   const token = loadEnvFile().CLOUDFLARE_API_TOKEN
   if (!token || token === '') {
     console.error(
-      '❌ CLOUDFLARE_API_TOKEN not set (env, apps/dashboard/.env.prod, or .env.local).\n' +
-        '   Needs Zone > Config Rules > Edit + Zone > Zone > Read on ' +
+      '❌ CLOUDFLARE_API_TOKEN not set (env, .env.prod, or .env.local —\n' +
+        '   repo root or apps/dashboard/).\n' +
+        '   Needs Zone > Single Redirect > Edit + Zone > Zone > Read on ' +
         ZONE_NAME +
         '.'
     )
@@ -107,7 +125,11 @@ async function cf<T>(
     const detail = (json.errors ?? [])
       .map((e) => `[${e.code}] ${e.message}`)
       .join('; ')
-    throw new Error(`CF API ${path} failed (${res.status}): ${detail}`)
+    const err = new Error(`CF API ${path} failed (${res.status}): ${detail}`)
+    // Expose the status so callers can distinguish "ruleset does not exist
+    // yet" (404, benign) from auth/transient failures that must abort.
+    ;(err as Error & { status?: number }).status = res.status
+    throw err
   }
   return json.result
 }
@@ -168,7 +190,13 @@ async function main() {
       `/zones/${zone.id}/rulesets/phases/${PHASE}/entrypoint`
     )
     existing = ruleset.rules ?? []
-  } catch {
+  } catch (err) {
+    // A 404 means the zone has no dynamic-redirect entrypoint yet — expected
+    // on first run; the PUT below upserts it. Any other status (401/403 auth,
+    // 5xx transient) must abort, otherwise we'd silently overwrite the phase
+    // with only our rule and drop pre-existing redirects.
+    const status = (err as Error & { status?: number }).status
+    if (status !== 404) throw err
     console.log('   no existing dynamic-redirect ruleset (will create one)')
   }
 

--- a/scripts/cloudflare-redirect-rule.ts
+++ b/scripts/cloudflare-redirect-rule.ts
@@ -1,0 +1,205 @@
+#!/usr/bin/env bun
+
+/**
+ * Provision the `cloud.chmonitor.dev → dash.chmonitor.dev` 301 as a Cloudflare
+ * edge Redirect Rule (Single Redirect, `http_request_dynamic_redirect` phase).
+ *
+ * Why an edge rule instead of Next.js middleware:
+ *   The dashboard worker serves `cloud.chmonitor.dev`, but its `middleware.ts`
+ *   host-redirect never fires for the *prerendered static root* — OpenNext on
+ *   Workers returns that asset without invoking the worker, so the middleware
+ *   code path is skipped and `/` returns 200 instead of 301. A zone Redirect
+ *   Rule runs at the edge BEFORE the worker, so it fires for every path
+ *   uniformly, even with `cloud.chmonitor.dev` still attached as a Worker
+ *   custom domain (rules precede workers in Cloudflare's order of operations).
+ *
+ * Idempotent: re-running updates the existing rule (matched by description)
+ * and preserves any other dynamic-redirect rules already on the zone.
+ *
+ * Auth: needs CLOUDFLARE_API_TOKEN with permissions
+ *   Zone > Config Rules > Edit  (a.k.a. "Dynamic Redirect" / Rulesets edit)
+ *   Zone > Zone > Read
+ * Sourced from the environment or, failing that, .env.prod / .env.local
+ * (same resolution as scripts/cloudflare-deploy.ts).
+ *
+ * Usage:
+ *   CLOUDFLARE_API_TOKEN=... bun run scripts/cloudflare-redirect-rule.ts
+ *   bun run scripts/cloudflare-redirect-rule.ts --dry-run   # print, don't write
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ENV_FILE_PROD = join(__dirname, '..', 'apps', 'dashboard', '.env.prod')
+const ENV_FILE_LOCAL = join(__dirname, '..', 'apps', 'dashboard', '.env.local')
+
+// --- Config -----------------------------------------------------------------
+
+const ZONE_NAME = 'chmonitor.dev'
+const FROM_HOST = 'cloud.chmonitor.dev'
+const TO_ORIGIN = 'https://dash.chmonitor.dev'
+const RULE_DESCRIPTION = `${FROM_HOST} -> dash.chmonitor.dev (301)`
+const PHASE = 'http_request_dynamic_redirect'
+
+const DRY_RUN = process.argv.includes('--dry-run')
+
+// --- Env --------------------------------------------------------------------
+
+function loadEnvFile(): Record<string, string> {
+  const file = existsSync(ENV_FILE_PROD)
+    ? ENV_FILE_PROD
+    : existsSync(ENV_FILE_LOCAL)
+      ? ENV_FILE_LOCAL
+      : null
+  if (!file) return {}
+
+  const vars: Record<string, string> = {}
+  for (const line of readFileSync(file, 'utf-8').split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const match = trimmed.match(/^([^=]+)=(.*)$/)
+    if (match) vars[match[1]] = match[2]
+  }
+  return vars
+}
+
+function resolveToken(): string {
+  const fromEnv = process.env.CLOUDFLARE_API_TOKEN
+  if (fromEnv && fromEnv !== '') return fromEnv
+  const token = loadEnvFile().CLOUDFLARE_API_TOKEN
+  if (!token || token === '') {
+    console.error(
+      '❌ CLOUDFLARE_API_TOKEN not set (env, apps/dashboard/.env.prod, or .env.local).\n' +
+        '   Needs Zone > Config Rules > Edit + Zone > Zone > Read on ' +
+        ZONE_NAME +
+        '.'
+    )
+    process.exit(1)
+  }
+  return token
+}
+
+// --- Cloudflare API ---------------------------------------------------------
+
+const API = 'https://api.cloudflare.com/client/v4'
+
+async function cf<T>(
+  token: string,
+  path: string,
+  init?: RequestInit
+): Promise<T> {
+  const res = await fetch(`${API}${path}`, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+  })
+  const json = (await res.json()) as {
+    success: boolean
+    result: T
+    errors?: { code: number; message: string }[]
+  }
+  if (!res.ok || !json.success) {
+    const detail = (json.errors ?? [])
+      .map((e) => `[${e.code}] ${e.message}`)
+      .join('; ')
+    throw new Error(`CF API ${path} failed (${res.status}): ${detail}`)
+  }
+  return json.result
+}
+
+interface RedirectRule {
+  id?: string
+  action: string
+  action_parameters?: unknown
+  expression: string
+  description?: string
+  enabled?: boolean
+}
+
+// The rule we want present. `preserve_query_string` carries `?...` through, so
+// the target is just origin + path.
+const desiredRule: RedirectRule = {
+  action: 'redirect',
+  action_parameters: {
+    from_value: {
+      status_code: 301,
+      target_url: {
+        expression: `concat("${TO_ORIGIN}", http.request.uri.path)`,
+      },
+      preserve_query_string: true,
+    },
+  },
+  expression: `(http.host eq "${FROM_HOST}")`,
+  description: RULE_DESCRIPTION,
+  enabled: true,
+}
+
+// Strip server-managed fields so a re-PUT of existing rules is accepted.
+function sanitize(rule: RedirectRule): RedirectRule {
+  const { id: _id, ...rest } = rule
+  return rest
+}
+
+async function main() {
+  const token = resolveToken()
+
+  console.log(`🔎 Resolving zone id for ${ZONE_NAME}...`)
+  const zones = await cf<{ id: string; name: string }[]>(
+    token,
+    `/zones?name=${ZONE_NAME}`
+  )
+  const zone = zones[0]
+  if (!zone) {
+    console.error(`❌ Zone ${ZONE_NAME} not found for this token.`)
+    process.exit(1)
+  }
+  console.log(`   zone id: ${zone.id}`)
+
+  // Read the current dynamic-redirect entrypoint ruleset (404 = none yet).
+  let existing: RedirectRule[] = []
+  try {
+    const ruleset = await cf<{ rules?: RedirectRule[] }>(
+      token,
+      `/zones/${zone.id}/rulesets/phases/${PHASE}/entrypoint`
+    )
+    existing = ruleset.rules ?? []
+  } catch {
+    console.log('   no existing dynamic-redirect ruleset (will create one)')
+  }
+
+  const others = existing.filter((r) => r.description !== RULE_DESCRIPTION)
+  const alreadyPresent = existing.some(
+    (r) => r.description === RULE_DESCRIPTION
+  )
+  const rules = [...others.map(sanitize), sanitize(desiredRule)]
+
+  console.log(
+    `\n${alreadyPresent ? '♻️  Updating' : '➕ Adding'} rule: ${RULE_DESCRIPTION}`
+  )
+  console.log(`   ${FROM_HOST}/*  →  301  ${TO_ORIGIN}/<path>?<query>`)
+  console.log(`   (preserving ${others.length} other dynamic-redirect rule(s))`)
+
+  if (DRY_RUN) {
+    console.log('\n--dry-run: payload that would be PUT:')
+    console.log(JSON.stringify({ rules }, null, 2))
+    return
+  }
+
+  await cf(token, `/zones/${zone.id}/rulesets/phases/${PHASE}/entrypoint`, {
+    method: 'PUT',
+    body: JSON.stringify({ rules }),
+  })
+
+  console.log('\n✅ Redirect rule provisioned. Verify with:')
+  console.log(`   curl -sI https://${FROM_HOST}  # expect 301 → ${TO_ORIGIN}/`)
+}
+
+main().catch((err) => {
+  console.error(`❌ ${err instanceof Error ? err.message : String(err)}`)
+  process.exit(1)
+})

--- a/scripts/cloudflare-redirect-rule.ts
+++ b/scripts/cloudflare-redirect-rule.ts
@@ -136,6 +136,9 @@ async function cf<T>(
 
 interface RedirectRule {
   id?: string
+  version?: string
+  last_updated?: string
+  ref?: string
   action: string
   action_parameters?: unknown
   expression: string
@@ -161,9 +164,11 @@ const desiredRule: RedirectRule = {
   enabled: true,
 }
 
-// Strip server-managed fields so a re-PUT of existing rules is accepted.
+// Strip server-managed fields (id/version/last_updated) so re-PUTing the
+// zone's existing rules is accepted — Cloudflare returns these read-only on
+// GET but rejects them in the update payload.
 function sanitize(rule: RedirectRule): RedirectRule {
-  const { id: _id, ...rest } = rule
+  const { id: _id, version: _v, last_updated: _lu, ...rest } = rule
   return rest
 }
 

--- a/scripts/set-secrets.ts
+++ b/scripts/set-secrets.ts
@@ -211,7 +211,8 @@ async function setSecretsBulk(
     tmpdir(),
     `wrangler-secrets-${process.pid}-${label}.txt`
   )
-  writeFileSync(tempFile, lines.join('\n'))
+  // 0o600: the temp file holds plaintext secrets — owner-only read/write.
+  writeFileSync(tempFile, lines.join('\n'), { mode: 0o600 })
   try {
     const args = ['secret', 'bulk', tempFile, '--config', configPath]
     if (envName) args.push('--env', envName)

--- a/scripts/set-secrets.ts
+++ b/scripts/set-secrets.ts
@@ -18,6 +18,8 @@
  *   --from-env            read values from process.env (CI) instead of .env files
  *   --env <name>          wrangler environment (e.g. preview); omit for production
  *   --target dashboard|mcp|both   which worker(s) to configure (default: both)
+ *   --strict              fail (don't skip) if a target worker doesn't exist yet
+ *                         — CI sets secrets before deploy, so a skip is unsafe
  */
 
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
@@ -89,14 +91,21 @@ interface Args {
   fromEnv: boolean
   env: string | null
   target: Target
+  strict: boolean
 }
 
 function parseArgs(): Args {
   const argv = process.argv.slice(2)
-  const args: Args = { fromEnv: false, env: null, target: 'both' }
+  const args: Args = {
+    fromEnv: false,
+    env: null,
+    target: 'both',
+    strict: false,
+  }
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
     if (a === '--from-env') args.fromEnv = true
+    else if (a === '--strict') args.strict = true
     else if (a === '--env') args.env = argv[++i] ?? null
     else if (a === '--target') {
       const t = argv[++i]
@@ -270,15 +279,17 @@ async function main() {
       args.env
     )
     if (!result.ok) {
-      if (result.missingWorker) {
-        // Benign bootstrap: worker not deployed yet. cf:deploy sets secrets
-        // AFTER deploying, so this only fires on a premature manual run.
+      if (result.missingWorker && !args.strict) {
+        // Benign bootstrap for local cf:deploy (deploy → secrets order): the
+        // worker may not exist on a premature standalone `cf:config`.
         console.warn(
           `\n⚠️  ${job.label} not deployed yet — secrets skipped. ` +
             'Deploy it first, then re-run.'
         )
         continue
       }
+      // --strict (CI): a missing worker MUST fail. CI sets secrets BEFORE the
+      // deploy step, so a silent skip would ship a worker with no secrets.
       console.error(`\n❌ Failed to set ${job.label} secrets`)
       process.exit(1)
     }

--- a/scripts/set-secrets.ts
+++ b/scripts/set-secrets.ts
@@ -1,9 +1,23 @@
 #!/usr/bin/env bun
 
 /**
- * Automatically set Wrangler secrets from environment file in batch
- * Priority: .env.prod > .env.local
- * Usage: bun run cf:config
+ * Set Wrangler secrets on the dashboard and/or MCP worker, in batch.
+ *
+ * Single source of truth for which secrets each worker needs — replaces the
+ * per-step `wrangler secret put` lists that used to be hand-duplicated across
+ * four jobs in .github/workflows/cloudflare.yml (and drifted: CHM_API_KEY_SECRET
+ * was missing from the dashboard there). CI calls this with --from-env; local
+ * `cf:config` reads .env.prod / .env.local.
+ *
+ * Usage:
+ *   bun run cf:config                                  # local: both workers, prod, from .env
+ *   bun scripts/set-secrets.ts --from-env --target dashboard --env preview
+ *   bun scripts/set-secrets.ts --from-env --target mcp
+ *
+ * Flags:
+ *   --from-env            read values from process.env (CI) instead of .env files
+ *   --env <name>          wrangler environment (e.g. preview); omit for production
+ *   --target dashboard|mcp|both   which worker(s) to configure (default: both)
  */
 
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
@@ -11,27 +25,34 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-// Priority: .env.prod > .env.local
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// Priority: .env.prod > .env.local (local mode only)
 const ENV_FILE_PROD = join(process.cwd(), '.env.prod')
 const ENV_FILE_LOCAL = join(process.cwd(), '.env.local')
 
-// The MCP worker now lives at apps/mcp/. Anchor its wrangler config to
-// this script's location so it resolves regardless of cwd.
+// Anchor both wrangler configs to this script so resolution is cwd-independent
+// (CI runs us from various working directories).
+const DASHBOARD_WRANGLER_CONFIG = join(
+  __dirname,
+  '..',
+  'apps',
+  'dashboard',
+  'wrangler.toml'
+)
 const MCP_WRANGLER_CONFIG = join(
-  dirname(fileURLToPath(import.meta.url)),
+  __dirname,
   '..',
   'apps',
   'mcp',
   'wrangler.toml'
 )
 
-// Secrets to set (excluding NEXT_PUBLIC_* which are build-time only)
-// Note: Variables already in wrangler.toml [vars] should NOT be in this list
-// Note: CLICKHOUSE_HOST and CLICKHOUSE_USER are non-sensitive and should be
-//       set as [vars] in wrangler.toml or via Cloudflare Dashboard, not secrets.
-const SECRET_KEYS = [
+// Dashboard worker secrets (excludes NEXT_PUBLIC_* build-time vars and the
+// CLICKHOUSE_HOST/USER non-secrets that live in wrangler.toml [vars]).
+const DASHBOARD_SECRET_KEYS = [
   'CLICKHOUSE_PASSWORD',
-  // LLM API keys for AI Agent
+  // LLM API keys for the AI Agent
   'LLM_API_KEY',
   'LLM_API_BASE',
   'OPENROUTER_API_KEY',
@@ -40,49 +61,117 @@ const SECRET_KEYS = [
   'NVIDIA_API_BASE',
   'ANYROUTER_API_KEY',
   'ANYROUTER_API_BASE',
-  // Clerk authentication secret (never commit this)
+  // Clerk server-side secret. In preview the value comes from
+  // CLERK_SECRET_KEY_TEST (see resolveValue).
   'CLERK_SECRET_KEY',
-  // HMAC secret for issuing/verifying MCP API keys (shared with MCP worker)
+  // HMAC secret for issuing/verifying MCP API keys. Needed on the dashboard
+  // (/api/v1/auth/api-key mints keys via issueApiKey) AND the MCP worker.
   'CHM_API_KEY_SECRET',
-  // LLM_MODEL has a default value and is selected via UI dropdown
-  // These are already set in wrangler.toml [vars], so skip them:
-  // 'CLICKHOUSE_HOST',
-  // 'CLICKHOUSE_USER',
-  // 'CLICKHOUSE_MAX_EXECUTION_TIME',
-  // 'CLICKHOUSE_DEFAULT_CLUSTER',
-  // 'CLICKHOUSE_TABLE_MAX_PARTS_WARN',
-  // 'CLICKHOUSE_QUERY_STUCK_DETECTION_MAX_SECONDS',
   'CLICKHOUSE_TZ',
   'CLICKHOUSE_EXCLUDE_USER_DEFAULT',
   'NEXT_QUERY_CACHE_TTL',
-]
+] as const
+
+// Subset the standalone MCP worker consumes — see apps/mcp/wrangler.toml and
+// apps/mcp/src/index.ts.
+const MCP_SECRET_KEYS = ['CLICKHOUSE_PASSWORD', 'CHM_API_KEY_SECRET'] as const
+
+// Defaults applied when a key is absent (mirrors the `|| 'UTC'` etc. that the
+// workflow used to inline).
+const DEFAULTS: Record<string, string> = {
+  CLICKHOUSE_TZ: 'UTC',
+  NEXT_QUERY_CACHE_TTL: '3600',
+}
+
+type Target = 'dashboard' | 'mcp' | 'both'
+
+interface Args {
+  fromEnv: boolean
+  env: string | null
+  target: Target
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2)
+  const args: Args = { fromEnv: false, env: null, target: 'both' }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--from-env') args.fromEnv = true
+    else if (a === '--env') args.env = argv[++i] ?? null
+    else if (a === '--target') {
+      const t = argv[++i]
+      if (t === 'dashboard' || t === 'mcp' || t === 'both') args.target = t
+      else {
+        console.error(`❌ --target must be dashboard|mcp|both (got "${t}")`)
+        process.exit(1)
+      }
+    }
+  }
+  return args
+}
+
+function stripQuotes(value: string): string {
+  if (
+    value.length >= 2 &&
+    ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'")))
+  ) {
+    return value.slice(1, -1)
+  }
+  return value
+}
 
 function parseEnvFile(content: string): Record<string, string> {
   const env: Record<string, string> = {}
-
   for (const line of content.split('\n')) {
     const trimmed = line.trim()
     if (!trimmed || trimmed.startsWith('#')) continue
-
     const match = trimmed.match(/^([^=]+)=(.*)$/)
-    if (match) {
-      const [, key, value] = match
-      env[key] = value
-    }
+    if (match) env[match[1].trim()] = stripQuotes(match[2].trim())
   }
-
   return env
+}
+
+// Load the value source: process.env (CI) or the .env file (local).
+function loadSource(fromEnv: boolean): Record<string, string> {
+  if (fromEnv) {
+    console.log('📋 Reading secret values from process.env (--from-env)\n')
+    return process.env as Record<string, string>
+  }
+  const file = existsSync(ENV_FILE_PROD)
+    ? ENV_FILE_PROD
+    : existsSync(ENV_FILE_LOCAL)
+      ? ENV_FILE_LOCAL
+      : null
+  if (!file) {
+    console.error('❌ No .env.prod or .env.local found')
+    process.exit(1)
+  }
+  console.log(
+    `📋 Reading from ${file.endsWith('.env.prod') ? '.env.prod' : '.env.local'}\n`
+  )
+  return parseEnvFile(readFileSync(file, 'utf-8'))
+}
+
+// Resolve the value to push for `key`, applying preview overrides + defaults.
+function resolveValue(
+  key: string,
+  src: Record<string, string>,
+  isPreview: boolean
+): string {
+  // Preview uses the test Clerk key under the prod secret name.
+  if (key === 'CLERK_SECRET_KEY' && isPreview) {
+    return src.CLERK_SECRET_KEY_TEST ?? src.CLERK_SECRET_KEY ?? ''
+  }
+  return src[key] ?? DEFAULTS[key] ?? ''
 }
 
 interface SecretPushResult {
   ok: boolean
   missingWorker: boolean
-  stderr: string
 }
 
-// Wrangler's error message when a worker doesn't exist yet. Match generously
-// — Cloudflare phrases this differently across versions ("worker not found",
-// "service not found", "could not find a worker named", etc.).
+// Wrangler's "worker does not exist yet" message varies across versions.
 const MISSING_WORKER_PATTERNS = [
   /worker.{0,12}(?:not\s*found|does\s*not\s*exist)/i,
   /service.{0,12}(?:not\s*found|does\s*not\s*exist)/i,
@@ -91,149 +180,113 @@ const MISSING_WORKER_PATTERNS = [
 ]
 
 async function setSecretsBulk(
-  env: Record<string, string>,
+  label: string,
+  configPath: string,
   keys: readonly string[],
-  configPath?: string
+  src: Record<string, string>,
+  envName: string | null
 ): Promise<SecretPushResult> {
-  const tempFile = join(tmpdir(), `wrangler-secrets-${Date.now()}.txt`)
-
-  const secretsToSet: string[] = []
+  const isPreview = envName === 'preview'
+  const lines: string[] = []
+  const shown: string[] = []
   for (const key of keys) {
-    const value = env[key]
-    if (value && value !== '') {
-      secretsToSet.push(`${key}=${value}`)
+    const value = resolveValue(key, src, isPreview)
+    if (!value) {
+      shown.push(`  ⚠️  ${key} (empty, skip)`)
+      continue
     }
+    lines.push(`${key}=${value}`)
+    const secret = /PASSWORD|SECRET|TOKEN|_API_KEY/.test(key)
+    shown.push(`  ✓ ${key}${secret ? ' = ***' : ` = ${value}`}`)
   }
 
-  if (secretsToSet.length === 0) {
-    console.log('⚠️  No secrets to set')
-    return { ok: false, missingWorker: false, stderr: '' }
-  }
+  console.log(
+    `\n🔐 ${label} (${lines.length} secrets${envName ? `, --env ${envName}` : ''})`
+  )
+  console.log(shown.join('\n'))
 
-  writeFileSync(tempFile, secretsToSet.join('\n'))
+  if (lines.length === 0) return { ok: false, missingWorker: false }
 
-  const target = configPath ? ` (config: ${configPath})` : ''
-  console.log(`🔐 Setting ${secretsToSet.length} secrets in batch${target}...`)
-
+  const tempFile = join(
+    tmpdir(),
+    `wrangler-secrets-${process.pid}-${label}.txt`
+  )
+  writeFileSync(tempFile, lines.join('\n'))
   try {
-    const args = ['secret', 'bulk', tempFile]
-    if (configPath) args.push('--config', configPath)
-    // Pipe stderr so we can classify "worker not found" (benign bootstrap
-    // state) vs any other failure (real error, must surface). Mirror stderr
-    // to our process stderr so the operator still sees the wrangler output.
-    const proc = Bun.spawn(['wrangler', ...args], {
+    const args = ['secret', 'bulk', tempFile, '--config', configPath]
+    if (envName) args.push('--env', envName)
+    // `bunx wrangler` resolves the pinned wrangler from the cwd's node_modules
+    // (apps/dashboard|apps/mcp both pin 4.65.0) — works whether invoked via
+    // `bun run` (local) or directly (`bun scripts/set-secrets.ts` in CI), where
+    // node_modules/.bin is not on PATH for a bare `wrangler`.
+    const proc = Bun.spawn(['bunx', 'wrangler', ...args], {
       stdout: 'inherit',
       stderr: 'pipe',
     })
-
     const stderrText = await new Response(proc.stderr).text()
     process.stderr.write(stderrText)
-
-    const exitCode = await proc.exited
-    const ok = exitCode === 0
-    const missingWorker =
-      !ok && MISSING_WORKER_PATTERNS.some((re) => re.test(stderrText))
-    return { ok, missingWorker, stderr: stderrText }
+    const ok = (await proc.exited) === 0
+    return {
+      ok,
+      missingWorker:
+        !ok && MISSING_WORKER_PATTERNS.some((re) => re.test(stderrText)),
+    }
   } finally {
     try {
       unlinkSync(tempFile)
     } catch {
-      // Ignore cleanup errors
+      // ignore
     }
   }
 }
-
-// Subset of secrets the standalone MCP worker actually consumes — see
-// apps/mcp/wrangler.toml and apps/mcp/src/index.ts.
-const MCP_WORKER_SECRET_KEYS = [
-  'CLICKHOUSE_PASSWORD',
-  'CHM_API_KEY_SECRET',
-] as const
 
 async function main() {
-  // Determine which env file to use (prefer .env.prod)
-  let envFile: string
-  if (existsSync(ENV_FILE_PROD)) {
-    envFile = ENV_FILE_PROD
-    console.log('📋 Reading environment variables from .env.prod...\n')
-  } else if (existsSync(ENV_FILE_LOCAL)) {
-    envFile = ENV_FILE_LOCAL
-    console.log('📋 Reading environment variables from .env.local...\n')
-  } else {
-    console.error('❌ No .env.prod or .env.local found')
-    process.exit(1)
+  const args = parseArgs()
+  const src = loadSource(args.fromEnv)
+
+  const jobs: { label: string; config: string; keys: readonly string[] }[] = []
+  if (args.target === 'dashboard' || args.target === 'both') {
+    jobs.push({
+      label: 'dashboard worker',
+      config: DASHBOARD_WRANGLER_CONFIG,
+      keys: DASHBOARD_SECRET_KEYS,
+    })
+  }
+  if (args.target === 'mcp' || args.target === 'both') {
+    jobs.push({
+      label: 'MCP worker',
+      config: MCP_WRANGLER_CONFIG,
+      keys: MCP_SECRET_KEYS,
+    })
   }
 
-  let envContent = ''
-  try {
-    envContent = readFileSync(envFile, 'utf-8')
-  } catch {
-    console.error(`❌ Could not read ${envFile}`)
-    process.exit(1)
-  }
-
-  const env = parseEnvFile(envContent)
-  const envName = envFile.endsWith('.env.prod') ? '.env.prod' : '.env.local'
-
-  console.log(`Found ${Object.keys(env).length} variables in ${envName}`)
-  console.log(`Setting ${SECRET_KEYS.length} secrets...\n`)
-
-  // List what will be set
-  for (const key of SECRET_KEYS) {
-    const value = env[key]
-    if (value && value !== '') {
-      // Redact sensitive values
-      let preview: string
-      if (
-        key.includes('PASSWORD') ||
-        key.includes('SECRET') ||
-        key.includes('TOKEN')
-      ) {
-        preview = '***REDACTED***'
-      } else {
-        preview = value.length > 30 ? `${value.substring(0, 30)}...` : value
-      }
-      console.log(`  ${key} = "${preview}"`)
-    } else {
-      console.log(`  ⚠️  ${key} = (empty, will skip)`)
-    }
-  }
-
-  console.log()
-  const mainResult = await setSecretsBulk(env, SECRET_KEYS)
-  if (!mainResult.ok) {
-    console.log('\n❌ Failed to set main worker secrets')
-    process.exit(1)
-  }
-
-  console.log('\n🔌 Setting MCP worker secrets (apps/mcp/wrangler.toml)...')
-  const mcpResult = await setSecretsBulk(
-    env,
-    MCP_WORKER_SECRET_KEYS,
-    MCP_WRANGLER_CONFIG
-  )
-  if (!mcpResult.ok) {
-    if (mcpResult.missingWorker) {
-      // Benign bootstrap state: operator ran cf:config before the first
-      // cf:deploy. cf:deploy itself runs set-secrets AFTER deploying both
-      // workers, so this branch never fires from there.
-      console.warn(
-        '\n⚠️  MCP worker is not deployed yet — secrets push skipped.\n' +
-          '   Run `bun run cf:deploy` first; it deploys the MCP worker and\n' +
-          '   then re-runs this script automatically.\n'
-      )
-      process.exit(0)
-    }
-    // Real failure (auth, network, wrangler bug, etc.). Surface it so
-    // cf:deploy aborts and the operator doesn't end up with a deployed but
-    // mis-secreted worker.
-    console.error(
-      '\n❌ Failed to set MCP worker secrets (not a missing-worker error).'
+  for (const job of jobs) {
+    const result = await setSecretsBulk(
+      job.label,
+      job.config,
+      job.keys,
+      src,
+      args.env
     )
-    process.exit(1)
+    if (!result.ok) {
+      if (result.missingWorker) {
+        // Benign bootstrap: worker not deployed yet. cf:deploy sets secrets
+        // AFTER deploying, so this only fires on a premature manual run.
+        console.warn(
+          `\n⚠️  ${job.label} not deployed yet — secrets skipped. ` +
+            'Deploy it first, then re-run.'
+        )
+        continue
+      }
+      console.error(`\n❌ Failed to set ${job.label} secrets`)
+      process.exit(1)
+    }
   }
 
-  console.log('\n✅ Done! All secrets set successfully on both workers')
+  console.log('\n✅ Done.')
 }
 
-main().catch(console.error)
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/sync-env-to-gh.ts
+++ b/scripts/sync-env-to-gh.ts
@@ -58,6 +58,11 @@ const SECRET_KEYS = [
   // Clerk (server-side secret keys — publishable keys are public)
   'CLERK_SECRET_KEY',
   'CLERK_SECRET_KEY_TEST',
+  // HMAC secret for issuing/verifying MCP API keys. CI (cloudflare.yml) pushes
+  // this to BOTH the dashboard and the standalone MCP worker; if it is unset
+  // here the MCP worker boots with an empty secret and 503s every /api/mcp
+  // request ("MCP API key auth is not configured"). Must match across workers.
+  'CHM_API_KEY_SECRET',
   // Misc runtime
   'NEXT_QUERY_CACHE_TTL',
 ] as const


### PR DESCRIPTION
## What

Two related Cloudflare deploy-correctness fixes surfaced while resolving the post-rename `/api/mcp` 503 and the `cloud.chmonitor.dev` redirect (issue #1379 cutover).

### 1. `cloud.chmonitor.dev → dash.chmonitor.dev` 301 as an edge Redirect Rule
- New idempotent script `scripts/cloudflare-redirect-rule.ts` (+ `bun run cf:redirect-rule`) provisions a zone Redirect Rule in the `http_request_dynamic_redirect` phase.
- **Why not middleware:** `apps/dashboard/middleware.ts` already has the host-redirect, but it never fires for the **prerendered static root** — OpenNext on Workers serves `/` as an asset without invoking the worker, so the code path is skipped and `cloud.chmonitor.dev` returns 200 instead of 301. A zone Redirect Rule runs at the edge **before** the worker, for every path, even with `cloud` still attached as a Worker custom domain.
- Idempotent: re-running updates the rule (matched by description) and preserves other dynamic-redirect rules. Supports `--dry-run`.
- Needs `CLOUDFLARE_API_TOKEN` with **Zone › Config Rules › Edit** + **Zone › Read** (sourced from env or `apps/dashboard/.env.prod`/`.env.local`, same as `cloudflare-deploy.ts`).

### 2. Track `CHM_API_KEY_SECRET` in `sync-env-to-gh.ts`
- Root cause of the `/api/mcp` **503 "MCP API key auth is not configured"**: the GitHub Actions secret `CHM_API_KEY_SECRET` was never set, so CI pushed an empty string to the renamed `chmonitor-mcp` worker (worker secrets don't survive a rename). It was missing because the canonical `.env → GH` sync tool's `SECRET_KEYS` list omitted it.
- Added it (with a comment) so the HMAC secret flows `.env → GitHub → both workers` and can't silently drift back to broken.
- *(The live secret + redeploy were already applied out-of-band; `/api/mcp` now returns 401 without a key, as expected.)*

### 3. Docs
- `docs/knowledge/deployment.md`: 4-worker edge-routing table, the Route-beats-Custom-Domain rule, the redirect-rule mechanism, and troubleshooting rows for both failure modes.

## Manual step still required (one-time)
The redirect rule needs a CF token to apply — run once:
```bash
CLOUDFLARE_API_TOKEN=… bun run cf:redirect-rule
curl -sI https://cloud.chmonitor.dev   # expect 301 → https://dash.chmonitor.dev/
```

## Test plan
- [x] `bun run cf:redirect-rule --dry-run` parses + fails cleanly without a token
- [x] Biome clean, `tsc` green (pre-commit)
- [ ] Apply rule with token, confirm `cloud.chmonitor.dev` 301s (needs CF creds)

Closes the redirect half of #1379 follow-up.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced deployment guide with a four-worker edge routing section, edge redirect rule guidance, and added troubleshooting for common deployment failures.

* **New Features**
  * Added a CLI to provision/preview Cloudflare Dynamic Redirect rules and an npm script to run it.

* **Chores**
  * Centralized and expanded secret-sync tooling (adds CHM_API_KEY_SECRET) and updated CI workflow to use the new secret runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->