### PR TITLE
refactor(mcp): unify MCP HTTP handler across worker + in-process route

### DIFF
--- a/apps/dashboard/app/api/mcp/route.ts
+++ b/apps/dashboard/app/api/mcp/route.ts
@@ -1,43 +1,15 @@
-import { getBearerToken, verifyApiKey } from '@chm/mcp-server/auth'
-import { createMcpServer } from '@chm/mcp-server/server'
-import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+import { handleMcp } from '@chm/mcp-server/http'
 
 export const dynamic = 'force-dynamic'
 
-async function handleMcpRequest(req: Request) {
-  const authHeader = req.headers.get('authorization')
-  const bearerToken = getBearerToken(authHeader)
-  const apiKeyHeader = req.headers.get('x-api-key')
-  const token = bearerToken ?? apiKeyHeader
-  const apiKeySecret = process.env.CHM_API_KEY_SECRET
-  const authRequired =
-    process.env.NODE_ENV === 'production' || Boolean(apiKeySecret)
-
-  if (authRequired && !apiKeySecret) {
-    return new Response('MCP API key auth is not configured', { status: 503 })
-  }
-
-  if (authRequired) {
-    if (!token) {
-      return new Response('Unauthorized', { status: 401 })
-    }
-
-    const result = await verifyApiKey(token)
-    if (!result.valid) {
-      return new Response('Unauthorized', { status: 401 })
-    }
-  }
-
-  const server = createMcpServer()
-  const transport = new WebStandardStreamableHTTPServerTransport({
-    sessionIdGenerator: undefined,
-  })
-
-  await server.connect(transport)
-
-  return transport.handleRequest(req)
+// Transport/auth/CORS live in @chm/mcp-server/http, shared with the standalone
+// Cloudflare MCP Worker. Wrap explicitly (not `export const POST = handleMcp`)
+// because Next passes a route-context object as the second arg, which is not
+// handleMcp's options shape.
+function handler(req: Request): Promise<Response> {
+  return handleMcp(req)
 }
 
-export const POST = handleMcpRequest
-export const GET = handleMcpRequest
-export const DELETE = handleMcpRequest
+export const POST = handler
+export const GET = handler
+export const DELETE = handler

--- a/apps/dashboard/app/api/mcp/route.ts
+++ b/apps/dashboard/app/api/mcp/route.ts
@@ -1,4 +1,4 @@
-import { handleMcp } from '@chm/mcp-server/http'
+import { corsPreflight, handleMcp } from '@chm/mcp-server/http'
 
 export const dynamic = 'force-dynamic'
 
@@ -13,3 +13,9 @@ function handler(req: Request): Promise<Response> {
 export const POST = handler
 export const GET = handler
 export const DELETE = handler
+
+// Answer CORS preflight so cross-origin MCP clients work against the in-process
+// route too (parity with the Worker, which handles OPTIONS in its router).
+export function OPTIONS(): Response {
+  return corsPreflight()
+}

--- a/apps/dashboard/app/api/v1/mcp/info/route.ts
+++ b/apps/dashboard/app/api/v1/mcp/info/route.ts
@@ -5,64 +5,17 @@
  *
  * Returns information about the MCP server, its tools, and resources.
  * Used by the agents sidebar to display available tools.
+ *
+ * Auth: gated by middleware.ts for all /api/v1/* when apiKeyAuthEnabled(). The
+ * standalone Worker has no middleware, so it uses handleMcpInfo (inline auth)
+ * instead — same posture, different layer. The payload itself is shared via
+ * buildServerInfo() so the two deployments never drift.
  */
 
-import { MCP_TOOLS } from '@chm/mcp-server/data'
-import { NextResponse } from 'next/server'
-
-interface McpResourceInfo {
-  name: string
-  uri: string
-  description: string
-}
-
-interface McpServerInfo {
-  name: string
-  version: string
-  description: string
-  tools: {
-    name: string
-    description: string
-    category: 'schema' | 'query' | 'system'
-    params: Array<{
-      name: string
-      type: string
-      required: boolean
-      default?: string | number
-      description: string
-    }>
-  }[]
-  resources: McpResourceInfo[]
-}
+import { buildServerInfo, withCors } from '@chm/mcp-server/http'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET() {
-  const info: McpServerInfo = {
-    name: 'clickhouse-monitor',
-    version: '1.0.0',
-    description: 'ClickHouse monitoring and query tools',
-    tools: MCP_TOOLS.map((tool) => ({
-      name: tool.name,
-      description: tool.description,
-      category: tool.category,
-      params: tool.params,
-    })),
-    resources: [
-      {
-        name: 'system-tables',
-        uri: 'clickhouse://system-tables',
-        description:
-          'Reference of key ClickHouse system tables used for monitoring',
-      },
-      {
-        name: 'query-examples',
-        uri: 'clickhouse://query-examples',
-        description:
-          'Example SQL queries for common ClickHouse monitoring tasks',
-      },
-    ],
-  }
-
-  return NextResponse.json(info)
+export function GET() {
+  return withCors(Response.json(buildServerInfo()))
 }

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -24,19 +24,25 @@ import {
 
 export default {
   async fetch(request: Request): Promise<Response> {
-    const pathname = normalizePath(new URL(request.url).pathname)
+    try {
+      const pathname = normalizePath(new URL(request.url).pathname)
 
-    // CORS preflight: respond before auth so browsers can complete the dance.
-    if (request.method === 'OPTIONS') return corsPreflight()
+      // CORS preflight: respond before auth so browsers can complete the dance.
+      if (request.method === 'OPTIONS') return corsPreflight()
 
-    if (pathname === '/api/mcp') return handleMcp(request)
-    if (pathname === '/api/v1/mcp/info') {
-      if (request.method !== 'GET') {
-        return withCors(new Response('Method Not Allowed', { status: 405 }))
+      if (pathname === '/api/mcp') return await handleMcp(request)
+      if (pathname === '/api/v1/mcp/info') {
+        if (request.method !== 'GET') {
+          return withCors(new Response('Method Not Allowed', { status: 405 }))
+        }
+        return await handleMcpInfo(request)
       }
-      return handleMcpInfo(request)
-    }
 
-    return withCors(new Response('Not Found', { status: 404 }))
+      return withCors(new Response('Not Found', { status: 404 }))
+    } catch {
+      // handleMcp/handleMcpInfo already catch internally; this guards the router
+      // itself (URL parsing) so the Worker never returns a CORS-less 1101.
+      return withCors(new Response('Internal Server Error', { status: 500 }))
+    }
   },
 }

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -6,144 +6,35 @@
  * Routes deliver dash.chmonitor.dev/api/mcp* + /api/v1/mcp/info* to this
  * worker directly; the dashboard worker never sees those paths in production.
  *
+ * All transport/auth/CORS glue lives in @chm/mcp-server/http so this Worker and
+ * the in-process Next.js route (apps/dashboard/app/api/mcp/route.ts) share one
+ * implementation and cannot drift.
+ *
  * Bindings: shares ClickHouse env vars + CHM_API_KEY_SECRET secret. No
  * KV/D1/R2 — MCP tools only query ClickHouse over HTTP.
  */
 
 import {
-  apiKeyAuthEnabled,
-  createMcpServer,
-  getBearerToken,
-  MCP_TOOLS,
-  verifyApiKey,
-} from '@chm/mcp-server'
-import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
-
-// Minimal CORS for cross-origin MCP clients (browser-based playgrounds, web
-// MCP UIs, etc.). Cloudflare Workers default to no Access-Control-* headers,
-// so browsers reject preflights without these. `*` is safe here because the
-// payloads are auth-gated by CHM_API_KEY_SECRET — no cookies involved.
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
-  'Access-Control-Allow-Headers': 'authorization, content-type, x-api-key',
-  'Access-Control-Max-Age': '86400',
-}
-
-function withCors(res: Response): Response {
-  const headers = new Headers(res.headers)
-  for (const [k, v] of Object.entries(CORS_HEADERS)) headers.set(k, v)
-  return new Response(res.body, {
-    status: res.status,
-    statusText: res.statusText,
-    headers,
-  })
-}
-
-function unauthorized(): Response {
-  return withCors(new Response('Unauthorized', { status: 401 }))
-}
-
-async function authenticate(req: Request): Promise<Response | null> {
-  if (!apiKeyAuthEnabled()) return null
-  const authHeader = req.headers.get('authorization')
-  const bearerToken = getBearerToken(authHeader)
-  const apiKeyHeader = req.headers.get('x-api-key')
-  const token = bearerToken ?? apiKeyHeader
-  if (!token) return unauthorized()
-  const result = await verifyApiKey(token)
-  if (!result.valid) return unauthorized()
-  return null
-}
-
-async function handleMcp(req: Request): Promise<Response> {
-  // Mirrors the production posture of app/api/mcp/route.ts: in production
-  // auth is required even if the secret happens to be unset — we 503 instead
-  // of accepting anonymous traffic ("fail closed").
-  const apiKeySecret = process.env.CHM_API_KEY_SECRET
-  const authRequired =
-    process.env.NODE_ENV === 'production' || Boolean(apiKeySecret)
-  if (authRequired && !apiKeySecret) {
-    return withCors(
-      new Response('MCP API key auth is not configured', { status: 503 })
-    )
-  }
-  if (authRequired) {
-    const fail = await authenticate(req)
-    if (fail) return fail
-  }
-
-  const server = createMcpServer()
-  const transport = new WebStandardStreamableHTTPServerTransport({
-    sessionIdGenerator: undefined,
-  })
-  await server.connect(transport)
-  const res = await transport.handleRequest(req)
-  return withCors(res)
-}
-
-async function handleInfo(req: Request): Promise<Response> {
-  // Pre-split, /api/v1/mcp/info went through middleware.ts which applied the
-  // same apiKeyAuthEnabled() gate as every other /api/v1/* route. Preserve
-  // that posture here so the auth surface doesn't silently widen.
-  const fail = await authenticate(req)
-  if (fail) return fail
-
-  return withCors(
-    Response.json({
-      name: 'clickhouse-monitor',
-      version: '1.0.0',
-      description: 'ClickHouse monitoring and query tools',
-      tools: MCP_TOOLS.map((tool) => ({
-        name: tool.name,
-        description: tool.description,
-        category: tool.category,
-        params: tool.params,
-      })),
-      resources: [
-        {
-          name: 'system-tables',
-          uri: 'clickhouse://system-tables',
-          description:
-            'Reference of key ClickHouse system tables used for monitoring',
-        },
-        {
-          name: 'query-examples',
-          uri: 'clickhouse://query-examples',
-          description:
-            'Example SQL queries for common ClickHouse monitoring tasks',
-        },
-      ],
-    })
-  )
-}
-
-// Cloudflare Workers Route patterns are exact-match without a `*`, but proxies
-// and address-bar normalization can add trailing slashes. Match on a normalized
-// path so /api/mcp and /api/mcp/ behave identically.
-function normalizePath(pathname: string): string {
-  if (pathname.length > 1 && pathname.endsWith('/')) {
-    return pathname.replace(/\/+$/, '')
-  }
-  return pathname
-}
+  corsPreflight,
+  handleMcp,
+  handleMcpInfo,
+  normalizePath,
+  withCors,
+} from '@chm/mcp-server/http'
 
 export default {
   async fetch(request: Request): Promise<Response> {
-    const url = new URL(request.url)
-    const pathname = normalizePath(url.pathname)
+    const pathname = normalizePath(new URL(request.url).pathname)
 
     // CORS preflight: respond before auth so browsers can complete the dance.
-    if (request.method === 'OPTIONS') {
-      return withCors(new Response(null, { status: 204 }))
-    }
+    if (request.method === 'OPTIONS') return corsPreflight()
 
     if (pathname === '/api/mcp') return handleMcp(request)
     if (pathname === '/api/v1/mcp/info') {
       if (request.method !== 'GET') {
         return withCors(new Response('Method Not Allowed', { status: 405 }))
       }
-      return handleInfo(request)
+      return handleMcpInfo(request)
     }
 
     return withCors(new Response('Not Found', { status: 404 }))

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./server": "./src/server.ts",
+    "./http": "./src/http.ts",
     "./auth": "./src/auth/index.ts",
     "./data": "./src/data/mcp-tools-data.ts"
   },

--- a/packages/mcp-server/src/__tests__/http.test.ts
+++ b/packages/mcp-server/src/__tests__/http.test.ts
@@ -1,0 +1,132 @@
+import { issueApiKey } from '../auth/api-key'
+import {
+  apiKeyAuthenticator,
+  buildServerInfo,
+  corsPreflight,
+  handleMcp,
+  handleMcpInfo,
+  normalizePath,
+  withCors,
+} from '../http'
+import { afterEach, describe, expect, it } from 'bun:test'
+
+const TEST_SECRET = 'test-secret-key-for-unit-tests-at-least-32-chars'
+
+function req(headers: Record<string, string> = {}): Request {
+  return new Request('https://example.com/api/mcp', { method: 'POST', headers })
+}
+
+describe('mcp http', () => {
+  const originalSecret = process.env.CHM_API_KEY_SECRET
+
+  afterEach(() => {
+    if (originalSecret !== undefined) {
+      process.env.CHM_API_KEY_SECRET = originalSecret
+    } else {
+      delete process.env.CHM_API_KEY_SECRET
+    }
+  })
+
+  describe('withCors / corsPreflight', () => {
+    it('adds permissive CORS headers', () => {
+      const res = withCors(new Response('ok'))
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+      expect(res.headers.get('Access-Control-Allow-Methods')).toContain('POST')
+    })
+
+    it('preflight is 204 with CORS', () => {
+      const res = corsPreflight()
+      expect(res.status).toBe(204)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+    })
+  })
+
+  describe('normalizePath', () => {
+    it('strips trailing slashes but preserves root', () => {
+      expect(normalizePath('/api/mcp/')).toBe('/api/mcp')
+      expect(normalizePath('/api/mcp')).toBe('/api/mcp')
+      expect(normalizePath('/')).toBe('/')
+    })
+  })
+
+  describe('apiKeyAuthenticator', () => {
+    it('allows anonymous when no secret is configured (open case)', async () => {
+      delete process.env.CHM_API_KEY_SECRET
+      expect(await apiKeyAuthenticator(req())).toBeNull()
+    })
+
+    it('401s when secret is set but no token is provided', async () => {
+      process.env.CHM_API_KEY_SECRET = TEST_SECRET
+      const res = await apiKeyAuthenticator(req())
+      expect(res?.status).toBe(401)
+      // failures are CORS-wrapped so browser clients can read the status
+      expect(res?.headers.get('Access-Control-Allow-Origin')).toBe('*')
+    })
+
+    it('401s on an invalid token', async () => {
+      process.env.CHM_API_KEY_SECRET = TEST_SECRET
+      const res = await apiKeyAuthenticator(
+        req({ authorization: 'Bearer not-a-real-key' })
+      )
+      expect(res?.status).toBe(401)
+    })
+
+    it('allows a valid issued key (bearer or x-api-key)', async () => {
+      process.env.CHM_API_KEY_SECRET = TEST_SECRET
+      const key = await issueApiKey('test')
+      expect(
+        await apiKeyAuthenticator(req({ authorization: `Bearer ${key}` }))
+      ).toBeNull()
+      expect(await apiKeyAuthenticator(req({ 'x-api-key': key }))).toBeNull()
+    })
+  })
+
+  describe('handleMcp auth gate', () => {
+    it('short-circuits with the authenticator response and never runs the server', async () => {
+      const sentinel = new Response('nope', { status: 403 })
+      const res = await handleMcp(req(), {
+        authenticate: async () => sentinel,
+      })
+      expect(res.status).toBe(403)
+    })
+
+    it('honors a custom authenticator that allows through', async () => {
+      // We can't assert full MCP protocol output here, but reaching the
+      // transport (any non-403) proves the gate passed.
+      const res = await handleMcp(req({ 'content-type': 'application/json' }), {
+        authenticate: async () => null,
+      })
+      expect(res.status).not.toBe(403)
+    })
+  })
+
+  describe('buildServerInfo / handleMcpInfo', () => {
+    it('builds the expected server info payload', () => {
+      const info = buildServerInfo()
+      expect(info.name).toBe('chmonitor')
+      // version is sourced live from package.json, not hardcoded
+      expect(info.version).toMatch(/^\d+\.\d+\.\d+/)
+      expect(info.tools.length).toBeGreaterThan(0)
+      expect(info.resources.map((r) => r.name)).toContain('system-tables')
+    })
+
+    it('returns info JSON with CORS when auth is open', async () => {
+      delete process.env.CHM_API_KEY_SECRET
+      const res = await handleMcpInfo(
+        new Request('https://example.com/api/v1/mcp/info')
+      )
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+      const body = (await res.json()) as { name: string }
+      expect(body.name).toBe('chmonitor')
+    })
+
+    it('401s info when auth is required and no token is given', async () => {
+      process.env.CHM_API_KEY_SECRET = TEST_SECRET
+      const res = await handleMcpInfo(
+        new Request('https://example.com/api/v1/mcp/info')
+      )
+      expect(res.status).toBe(401)
+    })
+  })
+})

--- a/packages/mcp-server/src/__tests__/http.test.ts
+++ b/packages/mcp-server/src/__tests__/http.test.ts
@@ -88,6 +88,18 @@ describe('mcp http', () => {
         authenticate: async () => sentinel,
       })
       expect(res.status).toBe(403)
+      // a custom authenticator's bare Response is CORS-wrapped on the way out
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+    })
+
+    it('returns a CORS-wrapped 500 when the authenticator throws', async () => {
+      const res = await handleMcp(req(), {
+        authenticate: async () => {
+          throw new Error('boom')
+        },
+      })
+      expect(res.status).toBe(500)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
     })
 
     it('honors a custom authenticator that allows through', async () => {

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -112,16 +112,24 @@ export async function handleMcp(
   req: Request,
   { authenticate = apiKeyAuthenticator }: HandleMcpOptions = {}
 ): Promise<Response> {
-  const fail = await authenticate(req)
-  if (fail) return fail
+  try {
+    // withCors even on the auth failure: a custom authenticator may return a
+    // bare Response, and browser MCP clients need the CORS headers to read it.
+    const fail = await authenticate(req)
+    if (fail) return withCors(fail)
 
-  const server = createMcpServer()
-  const transport = new WebStandardStreamableHTTPServerTransport({
-    sessionIdGenerator: undefined,
-  })
-  await server.connect(transport)
-  const res = await transport.handleRequest(req)
-  return withCors(res)
+    const server = createMcpServer()
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    })
+    await server.connect(transport)
+    const res = await transport.handleRequest(req)
+    return withCors(res)
+  } catch {
+    // Never let an unhandled rejection escape as a CORS-less 500 (the Worker
+    // would surface a raw 1101). Keep the error shape consistent across runtimes.
+    return withCors(new Response('Internal Server Error', { status: 500 }))
+  }
 }
 
 /**
@@ -187,7 +195,11 @@ export async function handleMcpInfo(
   req: Request,
   { authenticate = apiKeyAuthenticator }: HandleMcpOptions = {}
 ): Promise<Response> {
-  const fail = await authenticate(req)
-  if (fail) return fail
-  return withCors(Response.json(buildServerInfo()))
+  try {
+    const fail = await authenticate(req)
+    if (fail) return withCors(fail)
+    return withCors(Response.json(buildServerInfo()))
+  } catch {
+    return withCors(new Response('Internal Server Error', { status: 500 }))
+  }
 }

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -1,0 +1,193 @@
+/**
+ * Runtime-agnostic HTTP glue for the MCP endpoint.
+ *
+ * Both the Next.js dashboard route (apps/dashboard/app/api/mcp/route.ts) and the
+ * standalone Cloudflare Worker (apps/mcp/src/index.ts) wrap the SAME MCP server.
+ * Pre-unification each owned its own copy of the auth gate + transport + CORS,
+ * and they had already drifted (the Worker added CORS, the route had none). This
+ * module is the single source of truth so they cannot drift again.
+ *
+ * Everything here speaks the Web standard Request/Response, so it runs unchanged
+ * in Node (Docker, in-process Next route) and in Workers.
+ *
+ * Auth is injectable: handleMcp/handleMcpInfo take an `authenticate` function so
+ * a caller can layer Clerk OAuth (or anything else) on top of the default
+ * API-key check without this Clerk-free package taking a Clerk dependency.
+ */
+
+import pkg from '../package.json'
+import { apiKeyAuthEnabled, verifyApiKey } from './auth/api-key'
+import { getBearerToken } from './auth/bearer-token'
+import {
+  MCP_TOOLS,
+  type McpResource,
+  type McpToolCategory,
+  type McpToolParam,
+} from './data/mcp-tools-data'
+import { createMcpServer } from './server'
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+
+// Minimal CORS for cross-origin MCP clients (browser-based playgrounds, web MCP
+// UIs). `*` is safe because payloads are auth-gated by bearer token, not cookies.
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, content-type, x-api-key',
+  'Access-Control-Max-Age': '86400',
+} as const
+
+export function withCors(res: Response): Response {
+  const headers = new Headers(res.headers)
+  for (const [key, value] of Object.entries(CORS_HEADERS)) {
+    headers.set(key, value)
+  }
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  })
+}
+
+/** CORS preflight response. Callers should answer OPTIONS with this before auth. */
+export function corsPreflight(): Response {
+  return withCors(new Response(null, { status: 204 }))
+}
+
+/**
+ * Workers Route patterns are exact-match; proxies and address-bar normalization
+ * can append a trailing slash. Normalize so /api/mcp and /api/mcp/ are identical.
+ */
+export function normalizePath(pathname: string): string {
+  if (pathname.length > 1 && pathname.endsWith('/')) {
+    return pathname.replace(/\/+$/, '')
+  }
+  return pathname
+}
+
+function unauthorized(): Response {
+  return withCors(new Response('Unauthorized', { status: 401 }))
+}
+
+/**
+ * Resolves a bearer/x-api-key token to a Response (auth failed) or null (allowed).
+ * Returning a Response — not throwing — lets callers compose multiple
+ * authenticators (try Clerk, then API key) by short-circuiting on the first
+ * non-null result.
+ */
+export type Authenticator = (req: Request) => Promise<Response | null>
+
+/**
+ * Default authenticator: HMAC API key.
+ *
+ * When CHM_API_KEY_SECRET is unset, apiKeyAuthEnabled() is false and this returns
+ * null — i.e. NO auth configured means anonymous AI clients are allowed through.
+ * This is the "open" case: a self-hosted operator who did not configure auth gets
+ * an open MCP endpoint, by their own choice. Deployments that want a closed
+ * endpoint set CHM_API_KEY_SECRET (or layer Clerk on top via a custom
+ * Authenticator).
+ */
+export const apiKeyAuthenticator: Authenticator = async (req) => {
+  if (!apiKeyAuthEnabled()) return null
+  const token =
+    getBearerToken(req.headers.get('authorization')) ??
+    req.headers.get('x-api-key')
+  if (!token) return unauthorized()
+  const result = await verifyApiKey(token)
+  return result.valid ? null : unauthorized()
+}
+
+interface HandleMcpOptions {
+  /** Override the auth check. Defaults to the API-key authenticator. */
+  authenticate?: Authenticator
+}
+
+/**
+ * Handle an MCP transport request (POST/GET/DELETE on /api/mcp).
+ *
+ * Note: unlike the previous per-handler copies, there is no production fail-closed
+ * 503 here. "No auth configured" now means "open" (see apiKeyAuthenticator), which
+ * is the behavior self-hosted users expect. Close the endpoint by configuring auth.
+ */
+export async function handleMcp(
+  req: Request,
+  { authenticate = apiKeyAuthenticator }: HandleMcpOptions = {}
+): Promise<Response> {
+  const fail = await authenticate(req)
+  if (fail) return fail
+
+  const server = createMcpServer()
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  })
+  await server.connect(transport)
+  const res = await transport.handleRequest(req)
+  return withCors(res)
+}
+
+/**
+ * Server-info wire shape. Intentionally a *subset* of McpTool — the /info
+ * endpoint omits each tool's `exampleResponse` to keep the sidebar payload
+ * small. This preserves the exact format both handlers returned pre-unification.
+ */
+interface McpToolSummary {
+  name: string
+  description: string
+  category: McpToolCategory
+  params: McpToolParam[]
+}
+
+export interface McpServerInfoResponse {
+  name: string
+  version: string
+  description: string
+  tools: McpToolSummary[]
+  resources: McpResource[]
+}
+
+/** Static server-info payload (GET /api/v1/mcp/info). Pure data, no auth. */
+export function buildServerInfo(): McpServerInfoResponse {
+  return {
+    name: 'chmonitor',
+    // Live version from the @chm/mcp-server package.json — bundlers (esbuild for
+    // the worker, Next for the in-process route, bun for tests) inline the JSON
+    // import, so there is no runtime fs read and it stays correct across bumps.
+    version: pkg.version,
+    description: 'ClickHouse monitoring and query tools',
+    tools: MCP_TOOLS.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      category: tool.category,
+      params: tool.params,
+    })),
+    resources: [
+      {
+        name: 'system-tables',
+        uri: 'clickhouse://system-tables',
+        description:
+          'Reference of key ClickHouse system tables used for monitoring',
+      },
+      {
+        name: 'query-examples',
+        uri: 'clickhouse://query-examples',
+        description:
+          'Example SQL queries for common ClickHouse monitoring tasks',
+      },
+    ],
+  }
+}
+
+/**
+ * Handle GET /api/v1/mcp/info with inline auth.
+ *
+ * Used by the standalone Worker, which has no middleware. The dashboard gates
+ * /api/v1/* in middleware.ts instead, so its route uses buildServerInfo()
+ * directly — same auth posture, different layer.
+ */
+export async function handleMcpInfo(
+  req: Request,
+  { authenticate = apiKeyAuthenticator }: HandleMcpOptions = {}
+): Promise<Response> {
+  const fail = await authenticate(req)
+  if (fail) return fail
+  return withCors(Response.json(buildServerInfo()))
+}


### PR DESCRIPTION
## What

Both MCP entry points wrapped the same `@chm/mcp-server` but each owned a private copy of the auth gate + transport + CORS — and they had **already drifted** (the worker added CORS, the in-process route had none). This extracts one runtime-agnostic module.

## Changes

**New `packages/mcp-server/src/http.ts`** (Web-standard Request/Response, runs in Node *and* Workers):
- `handleMcp` / `handleMcpInfo` with an **injectable `Authenticator`** — lets a caller layer Clerk OAuth on top without this Clerk-free package taking a Clerk dependency (foundation for the follow-up Clerk PR).
- `withCors` / `corsPreflight` / `normalizePath` / `buildServerInfo` / default `apiKeyAuthenticator`.

**Consumers become thin shims:**
- `apps/mcp/src/index.ts` (CF Worker) → router over the shared handlers.
- `apps/dashboard/app/api/mcp/route.ts` → `handleMcp`.
- `apps/dashboard/app/api/v1/mcp/info/route.ts` → `buildServerInfo` + `withCors` (auth stays in `middleware.ts`).

## Behavior changes (intentional)

- **"No auth configured" now returns `ok` (anonymous)** instead of a production `503`. Self-hosted operators who don't set `CHM_API_KEY_SECRET` get an open MCP endpoint by their own choice; configure auth to close it.
- **CORS now applied on the in-process route too** (parity with the worker).
- **Server info `name` → `chmonitor`**, `version` sourced **live from `package.json`** (JSON import, inlined by every bundler — no runtime fs read).

## Notes

- Docker is functionally unaffected — it already serves MCP in-process at `/api/mcp`; this only dedupes the glue and stops the drift.
- New unit test `http.test.ts` covers the three auth postures (open / api-key-required / invalid), CORS wrapping, and the info payload.

## Verification

- `bun test packages/mcp-server` → 80 pass (12 new in `http.test.ts`)
- `tsc --noEmit` clean for the new module
- `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated MCP HTTP handling into a shared layer used by dashboard and worker, centralizing auth, CORS, and routing for more consistent behavior.

* **New Features**
  * Added CORS preflight support (OPTIONS) and standardized server info endpoint behavior across deployments.

* **Tests**
  * Added comprehensive tests for auth, CORS preflight, path normalization, and server info responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->