### PR TITLE
feat(mcp): Clerk OAuth for MCP — login/consent flow + REST verify

### DIFF
--- a/apps/dashboard/app/.well-known/oauth-protected-resource/route.ts
+++ b/apps/dashboard/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,28 @@
+/**
+ * OAuth Protected Resource Metadata (RFC 9728)
+ *
+ * GET /.well-known/oauth-protected-resource
+ *
+ * Advertises Clerk as the authorization server for the MCP endpoint so MCP
+ * clients (Claude.ai, Cursor, …) can run the OAuth 2.1 login + consent flow
+ * against Clerk, then call /api/mcp with the resulting bearer token.
+ *
+ * Public by design (discovery happens before the client has a token) and shared
+ * with the standalone Worker via @chm/mcp-server/http. Returns 404 when Clerk
+ * OAuth is not configured. middleware.ts already lets /.well-known/* through.
+ */
+
+import {
+  corsPreflight,
+  handleProtectedResourceMetadata,
+} from '@chm/mcp-server/http'
+
+export const dynamic = 'force-dynamic'
+
+export function GET(req: Request): Response {
+  return handleProtectedResourceMetadata(req)
+}
+
+export function OPTIONS(): Response {
+  return corsPreflight()
+}

--- a/apps/dashboard/app/.well-known/oauth-protected-resource/route.ts
+++ b/apps/dashboard/app/.well-known/oauth-protected-resource/route.ts
@@ -7,15 +7,18 @@
  * clients (Claude.ai, Cursor, …) can run the OAuth 2.1 login + consent flow
  * against Clerk, then call /api/mcp with the resulting bearer token.
  *
- * Public by design (discovery happens before the client has a token) and shared
- * with the standalone Worker via @chm/mcp-server/http. Returns 404 when Clerk
- * OAuth is not configured. middleware.ts already lets /.well-known/* through.
+ * Public by design (discovery happens before the client has a token).
+ * middleware.ts already lets /.well-known/* through.
+ *
+ * Imports the SDK-free helpers (@chm/mcp-server/auth + /cors) — NOT
+ * @chm/mcp-server/http — so serving metadata does not pull createMcpServer +
+ * @modelcontextprotocol/sdk into the dashboard worker bundle (which would undo
+ * the separate MCP-worker split). Returns 404 when Clerk OAuth is not
+ * discoverable.
  */
 
-import {
-  corsPreflight,
-  handleProtectedResourceMetadata,
-} from '@chm/mcp-server/http'
+import { handleProtectedResourceMetadata } from '@chm/mcp-server/auth'
+import { corsPreflight } from '@chm/mcp-server/cors'
 
 export const dynamic = 'force-dynamic'
 

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -10,14 +10,16 @@
  * the in-process Next.js route (apps/dashboard/app/api/mcp/route.ts) share one
  * implementation and cannot drift.
  *
- * Bindings: shares ClickHouse env vars + CHM_API_KEY_SECRET secret. No
- * KV/D1/R2 — MCP tools only query ClickHouse over HTTP.
+ * Bindings: shares ClickHouse env vars + CHM_API_KEY_SECRET secret, plus the
+ * optional CLERK_SECRET_KEY for Clerk OAuth token verification. No KV/D1/R2 —
+ * MCP tools only query ClickHouse over HTTP.
  */
 
 import {
   corsPreflight,
   handleMcp,
   handleMcpInfo,
+  handleProtectedResourceMetadata,
   normalizePath,
   withCors,
 } from '@chm/mcp-server/http'
@@ -36,6 +38,15 @@ export default {
           return withCors(new Response('Method Not Allowed', { status: 405 }))
         }
         return await handleMcpInfo(request)
+      }
+      // OAuth discovery (RFC 9728). In production dash.chmonitor.dev/.well-known/*
+      // is served by the dashboard worker; this keeps the MCP worker
+      // self-contained when deployed on its own domain.
+      if (pathname === '/.well-known/oauth-protected-resource') {
+        if (request.method !== 'GET') {
+          return withCors(new Response('Method Not Allowed', { status: 405 }))
+        }
+        return handleProtectedResourceMetadata(request)
       }
 
       return withCors(new Response('Not Found', { status: 404 }))

--- a/apps/mcp/wrangler.toml
+++ b/apps/mcp/wrangler.toml
@@ -16,6 +16,11 @@
 # Secrets to set (or run `bun run cf:config`):
 #   wrangler secret put CHM_API_KEY_SECRET --config wrangler-mcp.toml
 #   wrangler secret put CLICKHOUSE_PASSWORD --config wrangler-mcp.toml
+#   # Optional — enables Clerk OAuth verification for MCP clients. When set, a
+#   # valid Clerk OAuth access token is accepted in addition to (not instead of)
+#   # CHM_API_KEY_SECRET keys. The Clerk login/consent flow is hosted by Clerk;
+#   # this worker only verifies the bearer token via Clerk's REST API.
+#   wrangler secret put CLERK_SECRET_KEY --config wrangler-mcp.toml
 #
 # Local development:
 #   `wrangler dev --config wrangler-mcp.toml` inherits NODE_ENV=production

--- a/apps/mcp/wrangler.toml
+++ b/apps/mcp/wrangler.toml
@@ -70,6 +70,12 @@ CLICKHOUSE_MAX_EXECUTION_TIME = "60"
 CLOUDFLARE_WORKERS = "1"
 # NODE_ENV gates auth: production requires CHM_API_KEY_SECRET to be set.
 NODE_ENV = "production"
+# Clerk issuer (publishable key — public, safe to commit). Without it
+# getClerkIssuer() returns null, so even with CLERK_SECRET_KEY set the worker
+# would emit a bare 401 with no WWW-Authenticate challenge and MCP clients could
+# never start the OAuth flow against /api/mcp. Pairs with the CLERK_SECRET_KEY
+# secret (set via scripts/set-secrets.ts) to make clerkOAuthDiscoverable() true.
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_live_Y2xlcmsuY2htb25pdG9yLmRldiQ"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Preview environment (mirrors the dashboard preview at preview.dash.chmonitor.dev)
@@ -92,3 +98,5 @@ CLICKHOUSE_NAME = "duet-ubuntu,duyet-agent"
 CLICKHOUSE_MAX_EXECUTION_TIME = "60"
 CLOUDFLARE_WORKERS = "1"
 NODE_ENV = "production"
+# Clerk issuer for the preview MCP worker — test instance (see [vars] above).
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_bWFnbmV0aWMtcmF5LTkwLmNsZXJrLmFjY291bnRzLmRldiQ"

--- a/docs/knowledge/mcp-clerk-oauth.md
+++ b/docs/knowledge/mcp-clerk-oauth.md
@@ -1,0 +1,80 @@
+---
+id: mcp-clerk-oauth
+title: MCP Clerk OAuth
+type: reference
+status: active
+updated: 2026-06-03
+tags:
+  - mcp
+  - auth
+  - clerk
+  - oauth
+related:
+  - mcp-server
+  - deployment
+---
+
+# MCP Clerk OAuth
+
+The MCP endpoint supports three auth postures, resolved per request by
+`defaultAuthenticator` in `@chm/mcp-server/http`:
+
+| Configured env | Behavior |
+|----------------|----------|
+| neither `CHM_API_KEY_SECRET` nor `CLERK_SECRET_KEY` | **open** — anonymous AI clients allowed (self-host default) |
+| `CHM_API_KEY_SECRET` | HMAC API key required (CLI / headless) |
+| `CLERK_SECRET_KEY` | Clerk OAuth access token required (humans via MCP clients) |
+
+When both API-key and Clerk are configured, **either** a valid API key **or** a
+valid Clerk token is accepted, so CLI and human clients coexist on one endpoint.
+API key is checked first (local HMAC, no network); Clerk is a REST call.
+
+## Why REST verification (not @clerk/nextjs)
+
+Token verification is a plain `fetch` to Clerk's introspection endpoint
+(`POST api.clerk.com/oauth_applications/access_tokens/verify` with
+`CLERK_SECRET_KEY`). That runs in **both** runtimes — the standalone Cloudflare
+Worker (no `@clerk/nextjs`) and the in-process Next.js route — so Clerk MCP auth
+behaves identically in Docker and Cloudflare. See
+`packages/mcp-server/src/auth/clerk-oauth.ts`.
+
+## The login / consent flow
+
+Clerk is the **authorization server**; we are only the **resource server**. We
+never build a login UI — Clerk hosts login, consent, and dynamic client
+registration.
+
+1. MCP client (Claude.ai, Cursor, …) calls `/api/mcp` with no token → `401` with
+   `WWW-Authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource"`.
+2. Client fetches `/.well-known/oauth-protected-resource` (RFC 9728). We return
+   `authorization_servers: ["https://clerk.<domain>"]` — the issuer is derived
+   from the Clerk publishable key (`pk_live_<base64("clerk.<domain>$")>`), or
+   `CLERK_OAUTH_ISSUER` if set. See `auth/oauth-metadata.ts`.
+3. Client discovers Clerk's AS metadata, runs OAuth 2.1 + PKCE, the user **logs
+   in and grants consent** in Clerk, and the client gets an access token.
+4. Client retries `/api/mcp` with `Authorization: Bearer <token>`; we verify it
+   via the REST call and serve the MCP request.
+
+The `.well-known` metadata is served by the dashboard app
+(`app/.well-known/oauth-protected-resource/route.ts`) and, for standalone use,
+by the Worker. In Cloudflare prod `dash.chmonitor.dev/.well-known/*` routes to
+the dashboard worker (same origin as `/api/mcp`).
+
+## Setup
+
+1. **Clerk dashboard**: enable OAuth applications + **Dynamic Client
+   Registration** so MCP clients can self-register.
+2. **Secrets**: set `CLERK_SECRET_KEY` on both the dashboard and the
+   `chmonitor-mcp` worker (`wrangler secret put CLERK_SECRET_KEY --config
+   apps/mcp/wrangler.toml`). The publishable key is already inlined for the
+   dashboard; set `CLERK_OAUTH_ISSUER` only for proxied Clerk domains.
+3. **Redeploy** after setting secrets (connection pool / inlined env are cached —
+   see [secret-rotation](secret-rotation.md)).
+
+## Gotchas
+
+- `.well-known/*` must stay public — `middleware.ts` already passes through any
+  path that is not `/api/v1/*` or `/__clerk/*`.
+- The Worker does not need the publishable key (it only verifies tokens); it
+  emits the `WWW-Authenticate` header using the request origin, so discovery
+  still points at the dashboard-served metadata on the same host.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -9,6 +9,7 @@
     ".": "./src/index.ts",
     "./server": "./src/server.ts",
     "./http": "./src/http.ts",
+    "./cors": "./src/cors.ts",
     "./auth": "./src/auth/index.ts",
     "./data": "./src/data/mcp-tools-data.ts"
   },

--- a/packages/mcp-server/src/__tests__/http-clerk.test.ts
+++ b/packages/mcp-server/src/__tests__/http-clerk.test.ts
@@ -81,6 +81,23 @@ describe('mcp http — clerk + composed auth', () => {
       expect(clerkCalled).toBe(false)
     })
 
+    it('never relays an x-api-key credential to Clerk', async () => {
+      clearEnv()
+      process.env.CHM_API_KEY_SECRET = API_SECRET
+      process.env.CLERK_SECRET_KEY = 'sk_test_x'
+      let clerkCalled = false
+      globalThis.fetch = (async () => {
+        clerkCalled = true
+        return Response.json({ subject: 'user_1' })
+      }) as typeof fetch
+      // A bad x-api-key must be rejected, NOT forwarded to Clerk as an OAuth token
+      const res = await defaultAuthenticator(
+        mcpReq({ 'x-api-key': 'chm_bogus' })
+      )
+      expect(res?.status).toBe(401)
+      expect(clerkCalled).toBe(false)
+    })
+
     it('401s a bad token and includes WWW-Authenticate discovery when Clerk is on', async () => {
       clearEnv()
       process.env.CLERK_SECRET_KEY = 'sk_test_x'
@@ -104,8 +121,10 @@ describe('mcp http — clerk + composed auth', () => {
   })
 
   describe('handleProtectedResourceMetadata', () => {
-    it('serves metadata pointing at the Clerk issuer when configured', async () => {
+    it('serves metadata for the MCP endpoint pointing at the Clerk issuer', async () => {
       clearEnv()
+      // discoverable requires BOTH a verifier (secret) and an issuer (pub key)
+      process.env.CLERK_SECRET_KEY = 'sk_test_x'
       process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = PUBLISHABLE_KEY
       const res = handleProtectedResourceMetadata(
         new Request(
@@ -118,14 +137,18 @@ describe('mcp http — clerk + composed auth', () => {
         resource: string
         authorization_servers: string[]
       }
-      expect(body.resource).toBe('https://dash.chmonitor.dev')
+      // resource is the MCP endpoint, not the bare origin (RFC 9728 match)
+      expect(body.resource).toBe('https://dash.chmonitor.dev/api/mcp')
       expect(body.authorization_servers).toEqual([
         'https://clerk.chmonitor.dev',
       ])
     })
 
-    it('404s when Clerk OAuth is not configured', () => {
+    it('404s when Clerk OAuth is not discoverable (issuer but no verifier)', () => {
       clearEnv()
+      // publishable key present but no CLERK_SECRET_KEY → cannot verify tokens,
+      // so we must NOT advertise a login flow
+      process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = PUBLISHABLE_KEY
       const res = handleProtectedResourceMetadata(
         new Request('https://x.dev/.well-known/oauth-protected-resource')
       )

--- a/packages/mcp-server/src/__tests__/http-clerk.test.ts
+++ b/packages/mcp-server/src/__tests__/http-clerk.test.ts
@@ -98,6 +98,50 @@ describe('mcp http — clerk + composed auth', () => {
       expect(clerkCalled).toBe(false)
     })
 
+    it('accepts a valid x-api-key even when an invalid Authorization bearer is present', async () => {
+      clearEnv()
+      process.env.CHM_API_KEY_SECRET = API_SECRET
+      process.env.CLERK_SECRET_KEY = 'sk_test_x'
+      let clerkCalled = false
+      globalThis.fetch = (async () => {
+        clerkCalled = true
+        return new Response('no', { status: 401 })
+      }) as typeof fetch
+      const key = await issueApiKey('cli')
+      // Mixed headers: a bad bearer must NOT mask a valid x-api-key. Composed
+      // auth accepts any configured scheme, so the valid key wins and the bad
+      // bearer (not an API key) never needs to reach Clerk.
+      const res = await defaultAuthenticator(
+        mcpReq({ authorization: 'Bearer not-a-key', 'x-api-key': key })
+      )
+      expect(res).toBeNull()
+      expect(clerkCalled).toBe(false)
+    })
+
+    it('rejects a Clerk token the verifier reports inactive (2xx but active:false)', async () => {
+      clearEnv()
+      process.env.CLERK_SECRET_KEY = 'sk_test_x'
+      // Clerk can answer 2xx for an inactive/revoked/expired token; that must
+      // not authenticate.
+      globalThis.fetch = (async () =>
+        Response.json({ subject: 'user_1', active: false })) as typeof fetch
+      const res = await defaultAuthenticator(
+        mcpReq({ authorization: 'Bearer revoked-tok' })
+      )
+      expect(res?.status).toBe(401)
+    })
+
+    it('rejects a Clerk 2xx response that carries no subject', async () => {
+      clearEnv()
+      process.env.CLERK_SECRET_KEY = 'sk_test_x'
+      globalThis.fetch = (async () =>
+        Response.json({ scopes: ['email'] })) as typeof fetch
+      const res = await defaultAuthenticator(
+        mcpReq({ authorization: 'Bearer subjectless' })
+      )
+      expect(res?.status).toBe(401)
+    })
+
     it('401s a bad token and includes WWW-Authenticate discovery when Clerk is on', async () => {
       clearEnv()
       process.env.CLERK_SECRET_KEY = 'sk_test_x'

--- a/packages/mcp-server/src/__tests__/http-clerk.test.ts
+++ b/packages/mcp-server/src/__tests__/http-clerk.test.ts
@@ -1,0 +1,135 @@
+import { issueApiKey } from '../auth/api-key'
+import { defaultAuthenticator, handleProtectedResourceMetadata } from '../http'
+import { afterEach, describe, expect, it } from 'bun:test'
+
+const API_SECRET = 'test-secret-key-for-unit-tests-at-least-32-chars'
+const PUBLISHABLE_KEY = `pk_test_${btoa('clerk.chmonitor.dev$')}`
+
+const ENV = [
+  'CHM_API_KEY_SECRET',
+  'CLERK_SECRET_KEY',
+  'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY',
+  'CLERK_OAUTH_ISSUER',
+] as const
+const saved = Object.fromEntries(ENV.map((k) => [k, process.env[k]]))
+const originalFetch = globalThis.fetch
+
+function clearEnv() {
+  for (const k of ENV) delete process.env[k]
+}
+
+function mcpReq(headers: Record<string, string> = {}): Request {
+  return new Request('https://example.com/api/mcp', { method: 'POST', headers })
+}
+
+function mockClerkVerify(valid: boolean) {
+  globalThis.fetch = (async () =>
+    valid
+      ? Response.json({ subject: 'user_1', scopes: ['email'] })
+      : new Response('no', { status: 401 })) as typeof fetch
+}
+
+describe('mcp http — clerk + composed auth', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    for (const k of ENV) {
+      if (saved[k] !== undefined) process.env[k] = saved[k]
+      else delete process.env[k]
+    }
+  })
+
+  describe('defaultAuthenticator', () => {
+    it('is open when neither API key nor Clerk is configured', async () => {
+      clearEnv()
+      expect(await defaultAuthenticator(mcpReq())).toBeNull()
+    })
+
+    it('accepts a valid API key', async () => {
+      clearEnv()
+      process.env.CHM_API_KEY_SECRET = API_SECRET
+      const key = await issueApiKey('cli')
+      expect(
+        await defaultAuthenticator(mcpReq({ authorization: `Bearer ${key}` }))
+      ).toBeNull()
+    })
+
+    it('accepts a valid Clerk OAuth token via REST verify', async () => {
+      clearEnv()
+      process.env.CLERK_SECRET_KEY = 'sk_test_x'
+      mockClerkVerify(true)
+      expect(
+        await defaultAuthenticator(
+          mcpReq({ authorization: 'Bearer clerk-tok' })
+        )
+      ).toBeNull()
+    })
+
+    it('accepts EITHER scheme when both are configured (API key path, no Clerk call)', async () => {
+      clearEnv()
+      process.env.CHM_API_KEY_SECRET = API_SECRET
+      process.env.CLERK_SECRET_KEY = 'sk_test_x'
+      let clerkCalled = false
+      globalThis.fetch = (async () => {
+        clerkCalled = true
+        return new Response('no', { status: 401 })
+      }) as typeof fetch
+      const key = await issueApiKey('cli')
+      expect(
+        await defaultAuthenticator(mcpReq({ authorization: `Bearer ${key}` }))
+      ).toBeNull()
+      // API key validated locally first → Clerk REST is never hit
+      expect(clerkCalled).toBe(false)
+    })
+
+    it('401s a bad token and includes WWW-Authenticate discovery when Clerk is on', async () => {
+      clearEnv()
+      process.env.CLERK_SECRET_KEY = 'sk_test_x'
+      process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = PUBLISHABLE_KEY
+      mockClerkVerify(false)
+      const res = await defaultAuthenticator(
+        mcpReq({ authorization: 'Bearer bad' })
+      )
+      expect(res?.status).toBe(401)
+      const wwwAuth = res?.headers.get('WWW-Authenticate')
+      expect(wwwAuth).toContain('resource_metadata=')
+      expect(wwwAuth).toContain('/.well-known/oauth-protected-resource')
+    })
+
+    it('401s with no token when a scheme is configured', async () => {
+      clearEnv()
+      process.env.CHM_API_KEY_SECRET = API_SECRET
+      const res = await defaultAuthenticator(mcpReq())
+      expect(res?.status).toBe(401)
+    })
+  })
+
+  describe('handleProtectedResourceMetadata', () => {
+    it('serves metadata pointing at the Clerk issuer when configured', async () => {
+      clearEnv()
+      process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = PUBLISHABLE_KEY
+      const res = handleProtectedResourceMetadata(
+        new Request(
+          'https://dash.chmonitor.dev/.well-known/oauth-protected-resource'
+        )
+      )
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+      const body = (await res.json()) as {
+        resource: string
+        authorization_servers: string[]
+      }
+      expect(body.resource).toBe('https://dash.chmonitor.dev')
+      expect(body.authorization_servers).toEqual([
+        'https://clerk.chmonitor.dev',
+      ])
+    })
+
+    it('404s when Clerk OAuth is not configured', () => {
+      clearEnv()
+      const res = handleProtectedResourceMetadata(
+        new Request('https://x.dev/.well-known/oauth-protected-resource')
+      )
+      expect(res.status).toBe(404)
+    })
+  })
+})

--- a/packages/mcp-server/src/auth/__tests__/clerk-oauth.test.ts
+++ b/packages/mcp-server/src/auth/__tests__/clerk-oauth.test.ts
@@ -1,0 +1,77 @@
+import { clerkOAuthEnabled, verifyClerkOAuthToken } from '../clerk-oauth'
+import { afterEach, describe, expect, it } from 'bun:test'
+
+const originalFetch = globalThis.fetch
+const originalSecret = process.env.CLERK_SECRET_KEY
+
+function mockFetch(impl: (url: string, init?: RequestInit) => Response) {
+  globalThis.fetch = (async (
+    input: string | URL | Request,
+    init?: RequestInit
+  ) => impl(String(input), init)) as typeof fetch
+}
+
+describe('clerk-oauth', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalSecret !== undefined)
+      process.env.CLERK_SECRET_KEY = originalSecret
+    else delete process.env.CLERK_SECRET_KEY
+  })
+
+  describe('clerkOAuthEnabled', () => {
+    it('reflects CLERK_SECRET_KEY presence', () => {
+      delete process.env.CLERK_SECRET_KEY
+      expect(clerkOAuthEnabled()).toBe(false)
+      process.env.CLERK_SECRET_KEY = 'sk_test_x'
+      expect(clerkOAuthEnabled()).toBe(true)
+    })
+  })
+
+  describe('verifyClerkOAuthToken', () => {
+    it('fails closed when no secret key is configured', async () => {
+      delete process.env.CLERK_SECRET_KEY
+      const res = await verifyClerkOAuthToken('tok')
+      expect(res.valid).toBe(false)
+      expect(res.reason).toContain('CLERK_SECRET_KEY')
+    })
+
+    it('returns valid + subject/scopes on a 200 from Clerk', async () => {
+      process.env.CLERK_SECRET_KEY = 'sk_test_x'
+      let sentAuth = ''
+      let sentBody = ''
+      mockFetch((url, init) => {
+        expect(url).toContain('/oauth_applications/access_tokens/verify')
+        sentAuth = String(
+          (init?.headers as Record<string, string>).Authorization
+        )
+        sentBody = String(init?.body)
+        return Response.json({ subject: 'user_123', scopes: ['email'] })
+      })
+      const res = await verifyClerkOAuthToken('tok-abc')
+      expect(res.valid).toBe(true)
+      expect(res.subject).toBe('user_123')
+      expect(res.scopes).toEqual(['email'])
+      expect(sentAuth).toBe('Bearer sk_test_x')
+      expect(sentBody).toContain('tok-abc')
+    })
+
+    it('treats a non-2xx (expired/unknown token) as invalid, not an error', async () => {
+      process.env.CLERK_SECRET_KEY = 'sk_test_x'
+      mockFetch(() => new Response('nope', { status: 404 }))
+      const res = await verifyClerkOAuthToken('tok')
+      expect(res.valid).toBe(false)
+      expect(res.reason).toContain('404')
+    })
+
+    it('returns invalid when the fetch itself throws', async () => {
+      process.env.CLERK_SECRET_KEY = 'sk_test_x'
+      mockFetch(() => {
+        throw new Error('network down')
+      })
+      const res = await verifyClerkOAuthToken('tok')
+      expect(res.valid).toBe(false)
+      expect(res.reason).toContain('request failed')
+    })
+  })
+})

--- a/packages/mcp-server/src/auth/__tests__/oauth-metadata.test.ts
+++ b/packages/mcp-server/src/auth/__tests__/oauth-metadata.test.ts
@@ -8,6 +8,7 @@ const ENV_KEYS = [
   'CLERK_OAUTH_ISSUER',
   'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY',
   'CLERK_PUBLISHABLE_KEY',
+  'CLERK_SECRET_KEY',
 ] as const
 const saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]))
 
@@ -50,6 +51,8 @@ describe('oauth-metadata', () => {
   describe('buildProtectedResourceMetadata', () => {
     it('builds RFC 9728 metadata pointing at the Clerk issuer', () => {
       delete process.env.CLERK_OAUTH_ISSUER
+      // discoverable requires a verifier (secret) plus an issuer (pub key)
+      process.env.CLERK_SECRET_KEY = 'sk_test_x'
       process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = publishableKey(
         'clerk.chmonitor.dev'
       )

--- a/packages/mcp-server/src/auth/__tests__/oauth-metadata.test.ts
+++ b/packages/mcp-server/src/auth/__tests__/oauth-metadata.test.ts
@@ -1,0 +1,69 @@
+import {
+  buildProtectedResourceMetadata,
+  getClerkIssuer,
+} from '../oauth-metadata'
+import { afterEach, describe, expect, it } from 'bun:test'
+
+const ENV_KEYS = [
+  'CLERK_OAUTH_ISSUER',
+  'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY',
+  'CLERK_PUBLISHABLE_KEY',
+] as const
+const saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]))
+
+// pk_<env>_<base64(frontendApiHost + '$')> — how Clerk encodes the issuer host.
+function publishableKey(host: string, env: 'test' | 'live' = 'live'): string {
+  return `pk_${env}_${btoa(`${host}$`)}`
+}
+
+describe('oauth-metadata', () => {
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] !== undefined) process.env[k] = saved[k]
+      else delete process.env[k]
+    }
+  })
+
+  describe('getClerkIssuer', () => {
+    it('derives the issuer host from the publishable key', () => {
+      delete process.env.CLERK_OAUTH_ISSUER
+      process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = publishableKey(
+        'clerk.chmonitor.dev'
+      )
+      expect(getClerkIssuer()).toBe('https://clerk.chmonitor.dev')
+    })
+
+    it('prefers an explicit CLERK_OAUTH_ISSUER override (trailing slash trimmed)', () => {
+      process.env.CLERK_OAUTH_ISSUER = 'https://auth.example.com/'
+      process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = publishableKey(
+        'clerk.chmonitor.dev'
+      )
+      expect(getClerkIssuer()).toBe('https://auth.example.com')
+    })
+
+    it('returns null when nothing is configured', () => {
+      for (const k of ENV_KEYS) delete process.env[k]
+      expect(getClerkIssuer()).toBeNull()
+    })
+  })
+
+  describe('buildProtectedResourceMetadata', () => {
+    it('builds RFC 9728 metadata pointing at the Clerk issuer', () => {
+      delete process.env.CLERK_OAUTH_ISSUER
+      process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = publishableKey(
+        'clerk.chmonitor.dev'
+      )
+      const md = buildProtectedResourceMetadata('https://dash.chmonitor.dev/')
+      expect(md).not.toBeNull()
+      expect(md?.resource).toBe('https://dash.chmonitor.dev')
+      expect(md?.authorization_servers).toEqual(['https://clerk.chmonitor.dev'])
+      expect(md?.bearer_methods_supported).toEqual(['header'])
+      expect(md?.scopes_supported.length).toBeGreaterThan(0)
+    })
+
+    it('returns null when Clerk is not configured (resource is not OAuth-protected)', () => {
+      for (const k of ENV_KEYS) delete process.env[k]
+      expect(buildProtectedResourceMetadata('https://x.dev')).toBeNull()
+    })
+  })
+})

--- a/packages/mcp-server/src/auth/clerk-oauth.ts
+++ b/packages/mcp-server/src/auth/clerk-oauth.ts
@@ -73,6 +73,28 @@ export async function verifyClerkOAuthToken(
     const data = (await res.json()) as {
       subject?: string
       scopes?: string[]
+      // Clerk can return 2xx for a structurally-valid but UNUSABLE token
+      // (introspection-style): inactive, revoked, or already expired. Treating
+      // every 2xx as valid would authenticate such tokens — an auth bypass.
+      active?: boolean
+      revoked?: boolean
+      expired?: boolean
+    }
+    if (
+      data.active === false ||
+      data.revoked === true ||
+      data.expired === true
+    ) {
+      return {
+        valid: false,
+        reason: 'clerk token inactive, revoked, or expired',
+      }
+    }
+    // A usable token always identifies a subject; its absence means the response
+    // does not describe a live token we can attribute, so reject rather than
+    // grant anonymous-but-authenticated access.
+    if (!data.subject) {
+      return { valid: false, reason: 'clerk verify returned no subject' }
     }
     return { valid: true, subject: data.subject, scopes: data.scopes }
   } catch {

--- a/packages/mcp-server/src/auth/clerk-oauth.ts
+++ b/packages/mcp-server/src/auth/clerk-oauth.ts
@@ -1,0 +1,81 @@
+/**
+ * Clerk OAuth access-token verification via Clerk's REST introspection endpoint.
+ *
+ * Deliberately runtime-agnostic — just `fetch` + the Clerk secret key — so the
+ * SAME verifier runs in the standalone Cloudflare Worker (which has no
+ * @clerk/nextjs) AND the in-process Next.js route. This is what lets Clerk MCP
+ * auth work identically across Docker and Cloudflare instead of being an
+ * in-process-only feature.
+ *
+ *   POST https://api.clerk.com/oauth_applications/access_tokens/verify
+ *     Authorization: Bearer <CLERK_SECRET_KEY>
+ *     { "access_token": "<token>" }
+ *
+ * Clerk hosts the authorization server (login + consent + dynamic client
+ * registration); we are only the resource server that verifies the bearer token
+ * the MCP client presents.
+ */
+
+const DEFAULT_CLERK_API_URL = 'https://api.clerk.com'
+
+export interface ClerkOAuthResult {
+  valid: boolean
+  /** Clerk user id the token was issued for (when valid). */
+  subject?: string
+  /** OAuth scopes granted to the token (when valid). */
+  scopes?: string[]
+  reason?: string
+}
+
+/** True when Clerk OAuth verification is configured (secret key present). */
+export function clerkOAuthEnabled(): boolean {
+  return Boolean(process.env.CLERK_SECRET_KEY)
+}
+
+interface VerifyOptions {
+  /** Override the secret key (defaults to CLERK_SECRET_KEY). */
+  secretKey?: string
+  /** Override the Clerk API base (defaults to CLERK_API_URL or api.clerk.com). */
+  apiUrl?: string
+}
+
+export async function verifyClerkOAuthToken(
+  token: string,
+  opts: VerifyOptions = {}
+): Promise<ClerkOAuthResult> {
+  const secretKey = opts.secretKey ?? process.env.CLERK_SECRET_KEY
+  if (!secretKey) {
+    return { valid: false, reason: 'CLERK_SECRET_KEY not configured' }
+  }
+  const apiUrl =
+    opts.apiUrl ?? process.env.CLERK_API_URL ?? DEFAULT_CLERK_API_URL
+
+  let res: Response
+  try {
+    res = await fetch(`${apiUrl}/oauth_applications/access_tokens/verify`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${secretKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ access_token: token }),
+    })
+  } catch {
+    return { valid: false, reason: 'clerk verify request failed' }
+  }
+
+  if (!res.ok) {
+    // 4xx (including 401/404 for unknown/expired tokens) → invalid, not an error.
+    return { valid: false, reason: `clerk verify responded ${res.status}` }
+  }
+
+  try {
+    const data = (await res.json()) as {
+      subject?: string
+      scopes?: string[]
+    }
+    return { valid: true, subject: data.subject, scopes: data.scopes }
+  } catch {
+    return { valid: false, reason: 'clerk verify returned malformed JSON' }
+  }
+}

--- a/packages/mcp-server/src/auth/index.ts
+++ b/packages/mcp-server/src/auth/index.ts
@@ -12,7 +12,10 @@ export {
 } from './clerk-oauth'
 export {
   buildProtectedResourceMetadata,
+  clerkOAuthDiscoverable,
   getClerkIssuer,
+  handleProtectedResourceMetadata,
+  MCP_ENDPOINT_PATH,
   MCP_OAUTH_SCOPES,
   PROTECTED_RESOURCE_METADATA_PATH,
   type ProtectedResourceMetadata,

--- a/packages/mcp-server/src/auth/index.ts
+++ b/packages/mcp-server/src/auth/index.ts
@@ -5,3 +5,16 @@ export {
   verifyApiKey,
 } from './api-key'
 export { getBearerToken } from './bearer-token'
+export {
+  type ClerkOAuthResult,
+  clerkOAuthEnabled,
+  verifyClerkOAuthToken,
+} from './clerk-oauth'
+export {
+  buildProtectedResourceMetadata,
+  getClerkIssuer,
+  MCP_OAUTH_SCOPES,
+  PROTECTED_RESOURCE_METADATA_PATH,
+  type ProtectedResourceMetadata,
+  wwwAuthenticateHeader,
+} from './oauth-metadata'

--- a/packages/mcp-server/src/auth/oauth-metadata.ts
+++ b/packages/mcp-server/src/auth/oauth-metadata.ts
@@ -6,10 +6,23 @@
  * client takes it from there (OAuth 2.1 + PKCE against Clerk), then calls
  * /api/mcp with the bearer token we verify in verifyClerkOAuthToken.
  *
- * Hand-rolled (no @clerk/mcp-tools) so the exact same builder runs in the
- * Cloudflare Worker and the in-process Next route, matching the rest of the
- * unified MCP surface.
+ * SDK-free on purpose (only imports ../cors + ./clerk-oauth) so the dashboard's
+ * /.well-known route can serve metadata WITHOUT pulling @modelcontextprotocol/sdk
+ * + createMcpServer into the dashboard worker bundle.
  */
+
+import { withCors } from '../cors'
+import { clerkOAuthEnabled } from './clerk-oauth'
+
+/** The protected resource is the MCP endpoint, not the bare origin (RFC 9728). */
+export const MCP_ENDPOINT_PATH = '/api/mcp'
+
+/** Path MCP clients fetch for resource metadata (RFC 9728). */
+export const PROTECTED_RESOURCE_METADATA_PATH =
+  '/.well-known/oauth-protected-resource'
+
+/** Default OAuth scopes the MCP server requests from Clerk. */
+export const MCP_OAUTH_SCOPES = ['email', 'profile'] as const
 
 /**
  * Clerk's authorization-server issuer = its Frontend API origin. The publishable
@@ -36,6 +49,17 @@ export function getClerkIssuer(): string | null {
   return host ? `https://${host}` : null
 }
 
+/**
+ * True only when we can both VERIFY Clerk tokens (CLERK_SECRET_KEY) AND advertise
+ * an issuer for discovery. Gating both the WWW-Authenticate challenge and the
+ * metadata route on this single predicate keeps them consistent — we never point
+ * a client at a 404 metadata URL, and never advertise a login flow whose tokens
+ * we cannot verify.
+ */
+export function clerkOAuthDiscoverable(): boolean {
+  return clerkOAuthEnabled() && getClerkIssuer() !== null
+}
+
 export interface ProtectedResourceMetadata {
   resource: string
   authorization_servers: string[]
@@ -43,22 +67,15 @@ export interface ProtectedResourceMetadata {
   bearer_methods_supported: string[]
 }
 
-/** Default OAuth scopes the MCP server requests from Clerk. */
-export const MCP_OAUTH_SCOPES = ['email', 'profile'] as const
-
-/** Path MCP clients fetch for resource metadata (RFC 9728). */
-export const PROTECTED_RESOURCE_METADATA_PATH =
-  '/.well-known/oauth-protected-resource'
-
 /**
- * Build the protected-resource metadata for the given resource origin. Returns
- * null when Clerk is not configured (no issuer derivable) — callers then 404 the
- * metadata route, signalling "this resource is not OAuth-protected".
+ * Build the protected-resource metadata for the given resource identifier.
+ * Returns null unless Clerk OAuth is fully discoverable (verifier + issuer).
  */
 export function buildProtectedResourceMetadata(
   resource: string,
   scopes: readonly string[] = MCP_OAUTH_SCOPES
 ): ProtectedResourceMetadata | null {
+  if (!clerkOAuthDiscoverable()) return null
   const issuer = getClerkIssuer()
   if (!issuer) return null
   return {
@@ -75,4 +92,22 @@ export function buildProtectedResourceMetadata(
  */
 export function wwwAuthenticateHeader(resourceMetadataUrl: string): string {
   return `Bearer resource_metadata="${resourceMetadataUrl}"`
+}
+
+/**
+ * Serve GET /.well-known/oauth-protected-resource (RFC 9728). Public by design —
+ * discovery happens before the client has a token. The advertised `resource` is
+ * the MCP endpoint on the request origin so RFC-9728 clients (which require the
+ * returned resource to match the one they are accessing) accept it. Returns 404
+ * when Clerk OAuth is not discoverable.
+ */
+export function handleProtectedResourceMetadata(req: Request): Response {
+  const origin = new URL(req.url).origin
+  const metadata = buildProtectedResourceMetadata(
+    `${origin}${MCP_ENDPOINT_PATH}`
+  )
+  if (!metadata) {
+    return withCors(new Response('Not Found', { status: 404 }))
+  }
+  return withCors(Response.json(metadata))
 }

--- a/packages/mcp-server/src/auth/oauth-metadata.ts
+++ b/packages/mcp-server/src/auth/oauth-metadata.ts
@@ -1,0 +1,78 @@
+/**
+ * OAuth discovery metadata for MCP clients (RFC 9728 Protected Resource
+ * Metadata). Clerk is the authorization server — it hosts login, consent, and
+ * dynamic client registration. We are only the resource server, so all we have
+ * to publish is "which authorization server protects this resource"; the MCP
+ * client takes it from there (OAuth 2.1 + PKCE against Clerk), then calls
+ * /api/mcp with the bearer token we verify in verifyClerkOAuthToken.
+ *
+ * Hand-rolled (no @clerk/mcp-tools) so the exact same builder runs in the
+ * Cloudflare Worker and the in-process Next route, matching the rest of the
+ * unified MCP surface.
+ */
+
+/**
+ * Clerk's authorization-server issuer = its Frontend API origin. The publishable
+ * key base64-encodes that host: `pk_live_<base64("clerk.chmonitor.dev$")>`.
+ * An explicit CLERK_OAUTH_ISSUER overrides the derivation (e.g. proxied domains).
+ */
+export function getClerkIssuer(): string | null {
+  const explicit = process.env.CLERK_OAUTH_ISSUER
+  if (explicit) return explicit.replace(/\/+$/, '')
+
+  const pk =
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ??
+    process.env.CLERK_PUBLISHABLE_KEY
+  if (!pk) return null
+
+  const encoded = pk.replace(/^pk_(test|live)_/, '')
+  let decoded: string
+  try {
+    decoded = atob(encoded)
+  } catch {
+    return null
+  }
+  const host = decoded.replace(/\$+$/, '')
+  return host ? `https://${host}` : null
+}
+
+export interface ProtectedResourceMetadata {
+  resource: string
+  authorization_servers: string[]
+  scopes_supported: string[]
+  bearer_methods_supported: string[]
+}
+
+/** Default OAuth scopes the MCP server requests from Clerk. */
+export const MCP_OAUTH_SCOPES = ['email', 'profile'] as const
+
+/** Path MCP clients fetch for resource metadata (RFC 9728). */
+export const PROTECTED_RESOURCE_METADATA_PATH =
+  '/.well-known/oauth-protected-resource'
+
+/**
+ * Build the protected-resource metadata for the given resource origin. Returns
+ * null when Clerk is not configured (no issuer derivable) — callers then 404 the
+ * metadata route, signalling "this resource is not OAuth-protected".
+ */
+export function buildProtectedResourceMetadata(
+  resource: string,
+  scopes: readonly string[] = MCP_OAUTH_SCOPES
+): ProtectedResourceMetadata | null {
+  const issuer = getClerkIssuer()
+  if (!issuer) return null
+  return {
+    resource: resource.replace(/\/+$/, ''),
+    authorization_servers: [issuer],
+    scopes_supported: [...scopes],
+    bearer_methods_supported: ['header'],
+  }
+}
+
+/**
+ * WWW-Authenticate header value that points an unauthenticated MCP client at the
+ * resource metadata, kicking off OAuth discovery (RFC 9728 §5.1).
+ */
+export function wwwAuthenticateHeader(resourceMetadataUrl: string): string {
+  return `Bearer resource_metadata="${resourceMetadataUrl}"`
+}

--- a/packages/mcp-server/src/cors.ts
+++ b/packages/mcp-server/src/cors.ts
@@ -1,0 +1,34 @@
+/**
+ * CORS helpers, deliberately free of any MCP-SDK import so that lightweight
+ * routes (e.g. the dashboard's /.well-known/oauth-protected-resource) can reuse
+ * them WITHOUT pulling @modelcontextprotocol/sdk + createMcpServer into the
+ * dashboard worker bundle — which would undo the separate MCP-worker split.
+ */
+
+// `*` is safe because MCP payloads are auth-gated by bearer token, not cookies.
+// Expose WWW-Authenticate so cross-origin browser clients can read the OAuth
+// discovery challenge on a 401 (browsers hide non-exposed response headers).
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, content-type, x-api-key',
+  'Access-Control-Expose-Headers': 'WWW-Authenticate',
+  'Access-Control-Max-Age': '86400',
+} as const
+
+export function withCors(res: Response): Response {
+  const headers = new Headers(res.headers)
+  for (const [key, value] of Object.entries(CORS_HEADERS)) {
+    headers.set(key, value)
+  }
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  })
+}
+
+/** CORS preflight response. Callers should answer OPTIONS with this before auth. */
+export function corsPreflight(): Response {
+  return withCors(new Response(null, { status: 204 }))
+}

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -18,6 +18,12 @@
 import pkg from '../package.json'
 import { apiKeyAuthEnabled, verifyApiKey } from './auth/api-key'
 import { getBearerToken } from './auth/bearer-token'
+import { clerkOAuthEnabled, verifyClerkOAuthToken } from './auth/clerk-oauth'
+import {
+  buildProtectedResourceMetadata,
+  PROTECTED_RESOURCE_METADATA_PATH,
+  wwwAuthenticateHeader,
+} from './auth/oauth-metadata'
 import {
   MCP_TOOLS,
   type McpResource,
@@ -64,40 +70,88 @@ export function normalizePath(pathname: string): string {
   return pathname
 }
 
-function unauthorized(): Response {
-  return withCors(new Response('Unauthorized', { status: 401 }))
+/**
+ * 401 response. When Clerk OAuth is enabled, attach the RFC 9728
+ * WWW-Authenticate header pointing at our resource metadata so MCP clients can
+ * discover the authorization server and start the login/consent flow.
+ */
+function unauthorized(req?: Request): Response {
+  const headers = new Headers()
+  if (req && clerkOAuthEnabled()) {
+    const metadataUrl = new URL(
+      PROTECTED_RESOURCE_METADATA_PATH,
+      new URL(req.url).origin
+    ).toString()
+    headers.set('WWW-Authenticate', wwwAuthenticateHeader(metadataUrl))
+  }
+  return withCors(new Response('Unauthorized', { status: 401, headers }))
+}
+
+/** Bearer token from the Authorization header, falling back to x-api-key. */
+function getRequestToken(req: Request): string | null {
+  return (
+    getBearerToken(req.headers.get('authorization')) ??
+    req.headers.get('x-api-key')
+  )
 }
 
 /**
- * Resolves a bearer/x-api-key token to a Response (auth failed) or null (allowed).
- * Returning a Response — not throwing — lets callers compose multiple
- * authenticators (try Clerk, then API key) by short-circuiting on the first
- * non-null result.
+ * Resolves a request to a Response (auth failed) or null (allowed).
+ * Returning a Response — not throwing — lets callers compose authenticators by
+ * short-circuiting on the first non-null result.
  */
 export type Authenticator = (req: Request) => Promise<Response | null>
 
 /**
- * Default authenticator: HMAC API key.
+ * HMAC API-key authenticator.
  *
- * When CHM_API_KEY_SECRET is unset, apiKeyAuthEnabled() is false and this returns
- * null — i.e. NO auth configured means anonymous AI clients are allowed through.
- * This is the "open" case: a self-hosted operator who did not configure auth gets
- * an open MCP endpoint, by their own choice. Deployments that want a closed
- * endpoint set CHM_API_KEY_SECRET (or layer Clerk on top via a custom
- * Authenticator).
+ * When CHM_API_KEY_SECRET is unset this returns null (allow) — see
+ * defaultAuthenticator for the full "open when nothing configured" rationale.
  */
 export const apiKeyAuthenticator: Authenticator = async (req) => {
   if (!apiKeyAuthEnabled()) return null
-  const token =
-    getBearerToken(req.headers.get('authorization')) ??
-    req.headers.get('x-api-key')
-  if (!token) return unauthorized()
+  const token = getRequestToken(req)
+  if (!token) return unauthorized(req)
   const result = await verifyApiKey(token)
-  return result.valid ? null : unauthorized()
+  return result.valid ? null : unauthorized(req)
+}
+
+/**
+ * Default MCP authenticator — precedence: (API key | Clerk OAuth) → open.
+ *
+ * - If NEITHER CHM_API_KEY_SECRET nor CLERK_SECRET_KEY is set, the endpoint is
+ *   OPEN: a self-hosted operator who configured no auth gets anonymous access by
+ *   their own choice. Close it by configuring either scheme.
+ * - If EITHER is configured, a token is required and is accepted when it
+ *   validates against ANY configured scheme. This lets API keys (CLI/headless)
+ *   and Clerk OAuth (humans via MCP clients) coexist on the same endpoint.
+ * - API key is checked first (local HMAC, no network); Clerk is a REST call, so
+ *   it runs only if the API-key check did not already accept the token.
+ *
+ * Clerk verification is a plain fetch (see verifyClerkOAuthToken), so this same
+ * authenticator works in the Worker and the in-process route — no @clerk/nextjs.
+ */
+export const defaultAuthenticator: Authenticator = async (req) => {
+  const apiKeyOn = apiKeyAuthEnabled()
+  const clerkOn = clerkOAuthEnabled()
+  if (!apiKeyOn && !clerkOn) return null // open
+
+  const token = getRequestToken(req)
+  if (!token) return unauthorized(req)
+
+  if (apiKeyOn) {
+    const result = await verifyApiKey(token)
+    if (result.valid) return null
+  }
+  if (clerkOn) {
+    const result = await verifyClerkOAuthToken(token)
+    if (result.valid) return null
+  }
+  return unauthorized(req)
 }
 
 interface HandleMcpOptions {
-  /** Override the auth check. Defaults to the API-key authenticator. */
+  /** Override the auth check. Defaults to defaultAuthenticator. */
   authenticate?: Authenticator
 }
 
@@ -110,7 +164,7 @@ interface HandleMcpOptions {
  */
 export async function handleMcp(
   req: Request,
-  { authenticate = apiKeyAuthenticator }: HandleMcpOptions = {}
+  { authenticate = defaultAuthenticator }: HandleMcpOptions = {}
 ): Promise<Response> {
   try {
     // withCors even on the auth failure: a custom authenticator may return a
@@ -193,7 +247,7 @@ export function buildServerInfo(): McpServerInfoResponse {
  */
 export async function handleMcpInfo(
   req: Request,
-  { authenticate = apiKeyAuthenticator }: HandleMcpOptions = {}
+  { authenticate = defaultAuthenticator }: HandleMcpOptions = {}
 ): Promise<Response> {
   try {
     const fail = await authenticate(req)
@@ -202,4 +256,19 @@ export async function handleMcpInfo(
   } catch {
     return withCors(new Response('Internal Server Error', { status: 500 }))
   }
+}
+
+/**
+ * Serve GET /.well-known/oauth-protected-resource (RFC 9728). Public by design —
+ * OAuth discovery metadata must be readable before the client has a token.
+ * Returns 404 when Clerk OAuth is not configured (the resource is then not
+ * OAuth-protected and clients should fall back to whatever auth is set).
+ */
+export function handleProtectedResourceMetadata(req: Request): Response {
+  const origin = new URL(req.url).origin
+  const metadata = buildProtectedResourceMetadata(origin)
+  if (!metadata) {
+    return withCors(new Response('Not Found', { status: 404 }))
+  }
+  return withCors(Response.json(metadata))
 }

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -82,7 +82,26 @@ function getRequestTokens(req: Request): {
   apiKey: string | null
 } {
   const bearer = getBearerToken(req.headers.get('authorization'))
-  return { bearer, apiKey: bearer ?? req.headers.get('x-api-key') }
+  // Keep the credentials distinct. An earlier version folded x-api-key into the
+  // bearer (`bearer ?? x-api-key`), which masked a real x-api-key whenever an
+  // Authorization header was also present — so `Bearer bad` + valid `x-api-key`
+  // was wrongly rejected. Returning them separately lets the authenticator try
+  // each against the right verifier.
+  return { bearer, apiKey: req.headers.get('x-api-key') }
+}
+
+/**
+ * An API key may be presented either via `x-api-key` or, by CLI convention, as
+ * `Authorization: Bearer <key>`. Accept it from either source — both are local
+ * HMAC checks (no network), so trying both is cheap and order-independent.
+ */
+async function anyApiKeyValid(
+  ...candidates: (string | null)[]
+): Promise<boolean> {
+  for (const candidate of candidates) {
+    if (candidate && (await verifyApiKey(candidate)).valid) return true
+  }
+  return false
 }
 
 /**
@@ -100,10 +119,8 @@ export type Authenticator = (req: Request) => Promise<Response | null>
  */
 export const apiKeyAuthenticator: Authenticator = async (req) => {
   if (!apiKeyAuthEnabled()) return null
-  const { apiKey } = getRequestTokens(req)
-  if (!apiKey) return unauthorized(req)
-  const result = await verifyApiKey(apiKey)
-  return result.valid ? null : unauthorized(req)
+  const { bearer, apiKey } = getRequestTokens(req)
+  return (await anyApiKeyValid(apiKey, bearer)) ? null : unauthorized(req)
 }
 
 /**
@@ -131,10 +148,10 @@ export const defaultAuthenticator: Authenticator = async (req) => {
   const { bearer, apiKey } = getRequestTokens(req)
   if (!bearer && !apiKey) return unauthorized(req)
 
-  if (apiKeyOn && apiKey) {
-    const result = await verifyApiKey(apiKey)
-    if (result.valid) return null
-  }
+  // API key may arrive via x-api-key or the Authorization bearer; accept either.
+  if (apiKeyOn && (await anyApiKeyValid(apiKey, bearer))) return null
+  // Only the Authorization bearer is ever forwarded to Clerk — an x-api-key is a
+  // server-issued credential and must never be relayed to a third party.
   if (clerkOn && bearer) {
     const result = await verifyClerkOAuthToken(bearer)
     if (result.valid) return null

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -20,10 +20,11 @@ import { apiKeyAuthEnabled, verifyApiKey } from './auth/api-key'
 import { getBearerToken } from './auth/bearer-token'
 import { clerkOAuthEnabled, verifyClerkOAuthToken } from './auth/clerk-oauth'
 import {
-  buildProtectedResourceMetadata,
+  clerkOAuthDiscoverable,
   PROTECTED_RESOURCE_METADATA_PATH,
   wwwAuthenticateHeader,
 } from './auth/oauth-metadata'
+import { withCors } from './cors'
 import {
   MCP_TOOLS,
   type McpResource,
@@ -33,31 +34,12 @@ import {
 import { createMcpServer } from './server'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
 
-// Minimal CORS for cross-origin MCP clients (browser-based playgrounds, web MCP
-// UIs). `*` is safe because payloads are auth-gated by bearer token, not cookies.
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
-  'Access-Control-Allow-Headers': 'authorization, content-type, x-api-key',
-  'Access-Control-Max-Age': '86400',
-} as const
-
-export function withCors(res: Response): Response {
-  const headers = new Headers(res.headers)
-  for (const [key, value] of Object.entries(CORS_HEADERS)) {
-    headers.set(key, value)
-  }
-  return new Response(res.body, {
-    status: res.status,
-    statusText: res.statusText,
-    headers,
-  })
-}
-
-/** CORS preflight response. Callers should answer OPTIONS with this before auth. */
-export function corsPreflight(): Response {
-  return withCors(new Response(null, { status: 204 }))
-}
+// SDK-free metadata handler, re-exported here for the Worker's single import.
+export { handleProtectedResourceMetadata } from './auth/oauth-metadata'
+// CORS helpers live in ./cors (SDK-free) so lightweight routes can reuse them
+// without pulling the MCP SDK into their bundle. Re-export for the Worker, which
+// imports everything from this one module.
+export { corsPreflight, withCors } from './cors'
 
 /**
  * Workers Route patterns are exact-match; proxies and address-bar normalization
@@ -77,7 +59,10 @@ export function normalizePath(pathname: string): string {
  */
 function unauthorized(req?: Request): Response {
   const headers = new Headers()
-  if (req && clerkOAuthEnabled()) {
+  // Only advertise discovery when it will actually work end to end (verifier +
+  // issuer), so we never point a client at a metadata URL that would 404 or at a
+  // login flow whose tokens we cannot verify.
+  if (req && clerkOAuthDiscoverable()) {
     const metadataUrl = new URL(
       PROTECTED_RESOURCE_METADATA_PATH,
       new URL(req.url).origin
@@ -87,12 +72,17 @@ function unauthorized(req?: Request): Response {
   return withCors(new Response('Unauthorized', { status: 401, headers }))
 }
 
-/** Bearer token from the Authorization header, falling back to x-api-key. */
-function getRequestToken(req: Request): string | null {
-  return (
-    getBearerToken(req.headers.get('authorization')) ??
-    req.headers.get('x-api-key')
-  )
+/**
+ * Tokens split by source. The Authorization bearer is the only credential we are
+ * willing to forward to Clerk's REST verifier — a server-issued API key sent via
+ * x-api-key must NEVER be relayed to a third party as if it were an OAuth token.
+ */
+function getRequestTokens(req: Request): {
+  bearer: string | null
+  apiKey: string | null
+} {
+  const bearer = getBearerToken(req.headers.get('authorization'))
+  return { bearer, apiKey: bearer ?? req.headers.get('x-api-key') }
 }
 
 /**
@@ -110,9 +100,9 @@ export type Authenticator = (req: Request) => Promise<Response | null>
  */
 export const apiKeyAuthenticator: Authenticator = async (req) => {
   if (!apiKeyAuthEnabled()) return null
-  const token = getRequestToken(req)
-  if (!token) return unauthorized(req)
-  const result = await verifyApiKey(token)
+  const { apiKey } = getRequestTokens(req)
+  if (!apiKey) return unauthorized(req)
+  const result = await verifyApiKey(apiKey)
   return result.valid ? null : unauthorized(req)
 }
 
@@ -126,7 +116,9 @@ export const apiKeyAuthenticator: Authenticator = async (req) => {
  *   validates against ANY configured scheme. This lets API keys (CLI/headless)
  *   and Clerk OAuth (humans via MCP clients) coexist on the same endpoint.
  * - API key is checked first (local HMAC, no network); Clerk is a REST call, so
- *   it runs only if the API-key check did not already accept the token.
+ *   it runs only if the API-key check did not already accept the credential.
+ * - Only the Authorization bearer is forwarded to Clerk. An x-api-key is treated
+ *   strictly as an API key and is never relayed to Clerk as an OAuth token.
  *
  * Clerk verification is a plain fetch (see verifyClerkOAuthToken), so this same
  * authenticator works in the Worker and the in-process route — no @clerk/nextjs.
@@ -136,15 +128,15 @@ export const defaultAuthenticator: Authenticator = async (req) => {
   const clerkOn = clerkOAuthEnabled()
   if (!apiKeyOn && !clerkOn) return null // open
 
-  const token = getRequestToken(req)
-  if (!token) return unauthorized(req)
+  const { bearer, apiKey } = getRequestTokens(req)
+  if (!bearer && !apiKey) return unauthorized(req)
 
-  if (apiKeyOn) {
-    const result = await verifyApiKey(token)
+  if (apiKeyOn && apiKey) {
+    const result = await verifyApiKey(apiKey)
     if (result.valid) return null
   }
-  if (clerkOn) {
-    const result = await verifyClerkOAuthToken(token)
+  if (clerkOn && bearer) {
+    const result = await verifyClerkOAuthToken(bearer)
     if (result.valid) return null
   }
   return unauthorized(req)
@@ -256,19 +248,4 @@ export async function handleMcpInfo(
   } catch {
     return withCors(new Response('Internal Server Error', { status: 500 }))
   }
-}
-
-/**
- * Serve GET /.well-known/oauth-protected-resource (RFC 9728). Public by design —
- * OAuth discovery metadata must be readable before the client has a token.
- * Returns 404 when Clerk OAuth is not configured (the resource is then not
- * OAuth-protected and clients should fall back to whatever auth is set).
- */
-export function handleProtectedResourceMetadata(req: Request): Response {
-  const origin = new URL(req.url).origin
-  const metadata = buildProtectedResourceMetadata(origin)
-  if (!metadata) {
-    return withCors(new Response('Not Found', { status: 404 }))
-  }
-  return withCors(Response.json(metadata))
 }

--- a/scripts/set-secrets.ts
+++ b/scripts/set-secrets.ts
@@ -75,8 +75,14 @@ const DASHBOARD_SECRET_KEYS = [
 ] as const
 
 // Subset the standalone MCP worker consumes — see apps/mcp/wrangler.toml and
-// apps/mcp/src/index.ts.
-const MCP_SECRET_KEYS = ['CLICKHOUSE_PASSWORD', 'CHM_API_KEY_SECRET'] as const
+// apps/mcp/src/index.ts. CLERK_SECRET_KEY is optional (Clerk OAuth verification)
+// and is skipped automatically when unset; without it the dashboard could
+// advertise Clerk OAuth while the worker rejects every Clerk token.
+const MCP_SECRET_KEYS = [
+  'CLICKHOUSE_PASSWORD',
+  'CHM_API_KEY_SECRET',
+  'CLERK_SECRET_KEY',
+] as const
 
 // Defaults applied when a key is absent (mirrors the `|| 'UTC'` etc. that the
 // workflow used to inline).


### PR DESCRIPTION
Builds on #1386's injectable `Authenticator` to add the **managed-auth path** — your "Clerk auth enabled → login + grant permission" requirement — while keeping **"no auth configured → open"** intact.

## Three postures, resolved per request (`defaultAuthenticator`)

| Configured env | Behavior |
|---|---|
| neither secret | **open** — anonymous AI clients (self-host default) |
| `CHM_API_KEY_SECRET` | HMAC API key (CLI / headless) |
| `CLERK_SECRET_KEY` | Clerk OAuth access token (humans via MCP clients) |
| both | accept **either** — API key checked first (local HMAC, no network); Clerk REST only if the key didn't match |

## How the login / consent flow works

Clerk is the **authorization server** (hosts login, consent, dynamic client registration); we're only the **resource server** — no login UI is built here.

1. Client calls `/api/mcp` with no token → `401` + `WWW-Authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource"`.
2. Client fetches `/.well-known/oauth-protected-resource` (RFC 9728) → we advertise `authorization_servers: ["https://clerk.<domain>"]`.
3. Client runs OAuth 2.1 + PKCE against Clerk → **user logs in + grants consent** → gets a token.
4. Client retries `/api/mcp` with the bearer token → we verify it via Clerk's REST endpoint.

## Why this unifies Docker + Cloudflare

`★ verifyClerkOAuthToken` is a plain `fetch` to Clerk's introspection endpoint (`POST api.clerk.com/oauth_applications/access_tokens/verify` + `CLERK_SECRET_KEY`). No `@clerk/nextjs` — so the **same verifier runs in the standalone Worker and the in-process Next route**. Clerk MCP auth behaves identically in both deployments.

## Files

- `packages/mcp-server/src/auth/clerk-oauth.ts` — REST token verify.
- `packages/mcp-server/src/auth/oauth-metadata.ts` — RFC 9728 metadata; Clerk issuer derived from the publishable key (or `CLERK_OAUTH_ISSUER`).
- `http.ts` — `defaultAuthenticator` (precedence), `handleProtectedResourceMetadata`, `WWW-Authenticate` on 401.
- `apps/dashboard/app/.well-known/oauth-protected-resource/route.ts` + Worker route.
- `apps/mcp/wrangler.toml` — `CLERK_SECRET_KEY` secret note.
- `docs/knowledge/mcp-clerk-oauth.md` — flow + Clerk-dashboard setup.

## Setup required (operator)

1. Clerk dashboard: enable OAuth applications + **Dynamic Client Registration**.
2. Set `CLERK_SECRET_KEY` on the dashboard and the `chmonitor-mcp` worker; redeploy.

## Verification

- Package suite **99 pass** (12 new: REST verify, issuer derivation, composed-auth precedence, `WWW-Authenticate` discovery, metadata 200/404).
- No new dependency — discovery metadata hand-rolled rather than pulling in `@clerk/mcp-tools` (keeps the package light, avoids lockfile churn).

> Note: end-to-end flow against a live MCP client (Claude.ai) needs the Clerk-dashboard DCR toggle + secret, which is an operator step. Token verification + discovery metadata are unit-tested; the live handshake should be smoke-tested after secrets land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Clerk OAuth as an optional authentication method for MCP endpoints
  * Add RFC 9728-style protected-resource discovery endpoint for OAuth client configuration

* **Bug Fixes**
  * Fix credential handling so API keys and bearer tokens are extracted and validated without interfering

* **Documentation**
  * New guide documenting Clerk OAuth setup, modes, and operational notes

* **Tests**
  * Expanded tests for OAuth discovery, Clerk token verification, and combined auth behavior

* **Chores**
  * Add optional Clerk secrets/vars to deployment configuration scripts and manifests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->