### PR TITLE
ci(cloudflare): per-app preview subdomains mirroring prod topology

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -27,7 +27,10 @@ permissions:
 
 jobs:
   # ──────────────────────────────────────────────────────────────────────────
-  # Preview: deploys pull requests to https://preview.chmonitor.dev.
+  # Preview: deploys the dashboard (+ MCP) worker for pull requests to
+  # https://preview.dash.chmonitor.dev. Mirrors production topology — landing
+  # and docs previews are deployed by their own jobs (preview.chmonitor.dev and
+  # preview.docs.chmonitor.dev respectively).
   # Skipped for forked PRs — deployment secrets must never be exposed to a
   # workflow running PR-controlled code from outside the repository.
   # ──────────────────────────────────────────────────────────────────────────
@@ -171,19 +174,24 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const previewUrl = 'https://preview.chmonitor.dev';
             const sha = '${{ steps.meta.outputs.git_sha }}';
             const timestamp = '${{ steps.meta.outputs.build_timestamp }}';
             const body = [
               '### ☁️ Cloudflare Preview Deployment',
               '',
+              '| App | Preview URL |',
+              '|-----|-------------|',
+              '| **Dashboard** | https://preview.dash.chmonitor.dev |',
+              '| **MCP** | https://preview.dash.chmonitor.dev/api/mcp |',
+              '| **Landing** | https://preview.chmonitor.dev |',
+              '| **Docs** | https://preview.docs.chmonitor.dev |',
+              '',
               `| Property | Value |`,
               `|----------|-------|`,
-              `| **Preview URL** | ${previewUrl} |`,
               `| **Commit** | \`${sha}\` |`,
               `| **Deployed at** | ${timestamp} |`,
               '',
-              '> This preview is automatically updated on every push to this PR.',
+              '> Previews are automatically updated on every push to this PR.',
             ].join('\n');
 
             // Always create a new comment to preserve deployment history

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -171,7 +171,7 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_live_Y2xlcmsuY2htb25pdG9yLmRldiQ"
 # ─────────────────────────────────────────────────────────────────────────────
 # Preview environment for PR deployments
 # Deployed by GitHub Actions on pull requests (see .github/workflows/cloudflare.yml)
-# and reachable at https://preview.chmonitor.dev.
+# and reachable at https://preview.dash.chmonitor.dev.
 # Inherits most top-level settings; vars require explicit declaration.
 #
 # One-time setup required:
@@ -181,11 +181,12 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_live_Y2xlcmsuY2htb25pdG9yLmRldiQ"
 name = "preview-chmonitor-dash"
 
 # Custom domain for the preview worker.
-# On the first deploy that includes this route, Wrangler provisions the DNS
-# record and TLS certificate for preview.chmonitor.dev automatically (the
-# chmonitor.dev zone must live in the same Cloudflare account).
+# Mirrors production topology: dashboard prod is dash.chmonitor.dev, so its
+# preview is preview.dash.chmonitor.dev. On the first deploy that includes this
+# route, Wrangler provisions the DNS record and TLS certificate automatically
+# (the chmonitor.dev zone must live in the same Cloudflare account).
 [[env.preview.routes]]
-pattern = "preview.chmonitor.dev"
+pattern = "preview.dash.chmonitor.dev"
 custom_domain = true
 
 # Vars must be explicitly set per environment (not inherited from top-level)

--- a/apps/docs/wrangler.toml
+++ b/apps/docs/wrangler.toml
@@ -15,11 +15,17 @@ directory = "./dist"
 pattern = "docs.chmonitor.dev"
 custom_domain = true
 
-# Preview environment for PR deployments. Routes are not inherited by named
-# environments, so the preview worker has no custom domain — it is reachable at
-# preview-chmonitor-docs.<account>.workers.dev.
+# Preview environment for PR deployments. Mirrors production topology: docs prod
+# is docs.chmonitor.dev, so its preview is preview.docs.chmonitor.dev. Routes are
+# not inherited by named environments, so the custom domain must be declared
+# explicitly here. On the first deploy Wrangler provisions DNS + TLS
+# automatically (chmonitor.dev zone must be in the same account).
 [env.preview]
 name = "preview-chmonitor-docs"
 
 [env.preview.assets]
 directory = "./dist"
+
+[[env.preview.routes]]
+pattern = "preview.docs.chmonitor.dev"
+custom_domain = true

--- a/apps/landing/wrangler.toml
+++ b/apps/landing/wrangler.toml
@@ -20,11 +20,20 @@ directory = "./dist"
 pattern = "chmonitor.dev"
 custom_domain = true
 
-# Preview environment for PR deployments. Routes are not inherited by named
-# environments, so the preview worker has no custom domain — it is reachable at
-# preview-chmonitor-landing.<account>.workers.dev.
+# Preview environment for PR deployments. Mirrors production topology: landing
+# prod is the chmonitor.dev apex, so its preview is the preview.chmonitor.dev
+# apex-preview. Routes are not inherited by named environments, so the custom
+# domain must be declared explicitly here. On the first deploy Wrangler
+# provisions DNS + TLS automatically (chmonitor.dev zone must be in the same
+# account). preview.chmonitor.dev was previously held by preview-chmonitor-dash;
+# that binding is detached during cutover before landing claims it (custom
+# domains are exclusive).
 [env.preview]
 name = "preview-chmonitor-landing"
 
 [env.preview.assets]
 directory = "./dist"
+
+[[env.preview.routes]]
+pattern = "preview.chmonitor.dev"
+custom_domain = true

--- a/apps/mcp/wrangler.toml
+++ b/apps/mcp/wrangler.toml
@@ -67,17 +67,17 @@ CLOUDFLARE_WORKERS = "1"
 NODE_ENV = "production"
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Preview environment (mirrors main worker preview at preview.chmonitor.dev)
+# Preview environment (mirrors the dashboard preview at preview.dash.chmonitor.dev)
 # ─────────────────────────────────────────────────────────────────────────────
 [env.preview]
 name = "preview-chmonitor-mcp"
 
 [[env.preview.routes]]
-pattern = "preview.chmonitor.dev/api/mcp*"
+pattern = "preview.dash.chmonitor.dev/api/mcp*"
 zone_name = "chmonitor.dev"
 
 [[env.preview.routes]]
-pattern = "preview.chmonitor.dev/api/v1/mcp/info*"
+pattern = "preview.dash.chmonitor.dev/api/v1/mcp/info*"
 zone_name = "chmonitor.dev"
 
 [env.preview.vars]

--- a/docs/knowledge/deployment.md
+++ b/docs/knowledge/deployment.md
@@ -141,6 +141,25 @@ A specific Workers **Route** (`.../api/mcp*`) wins over a whole-hostname
 **Custom Domain** (`dash.chmonitor.dev`) — sub-path routes are more specific —
 so the MCP worker intercepts `/api/mcp` even though the dashboard owns the host.
 
+### Preview topology (PR deployments)
+
+Each PR deploys a parallel set of `preview-chmonitor-*` workers (`--env preview`)
+under `preview.*` subdomains that mirror production exactly:
+
+| Worker (preview) | Host / route |
+|------------------|--------------|
+| `preview-chmonitor-landing` | `preview.chmonitor.dev` (apex-preview) |
+| `preview-chmonitor-dash` | `preview.dash.chmonitor.dev` (custom domain) |
+| `preview-chmonitor-mcp` | `preview.dash.chmonitor.dev/api/mcp*` + `/api/v1/mcp/info*` (Workers Routes) |
+| `preview-chmonitor-docs` | `preview.docs.chmonitor.dev` |
+
+Wrangler auto-provisions DNS + TLS for a `custom_domain` route on first deploy,
+**but custom domains are exclusive** — a hostname can attach to only one worker.
+`preview.chmonitor.dev` originally lived on `preview-chmonitor-dash`; the cutover
+to the per-app topology above detaches it there first (it cannot be auto-stolen),
+then `preview-chmonitor-landing` claims it. The two new subdomains
+(`preview.dash`, `preview.docs`) have no prior holder, so they provision cleanly.
+
 **`cloud.chmonitor.dev` → `dash.chmonitor.dev` 301** is a Cloudflare edge
 **Redirect Rule**, NOT Next.js middleware. `middleware.ts` cannot redirect the
 prerendered static root: OpenNext serves `/` as an asset without invoking the


### PR DESCRIPTION
## What

Give every app a predictable **preview** custom domain that mirrors the production topology, instead of only the dashboard owning `preview.chmonitor.dev` while landing/docs previews sit on opaque `*.workers.dev` URLs.

| App | Production | Preview (new) |
|-----|-----------|---------------|
| landing | `chmonitor.dev` | `preview.chmonitor.dev` |
| dashboard | `dash.chmonitor.dev` | `preview.dash.chmonitor.dev` |
| mcp | `dash.chmonitor.dev/api/mcp*` | `preview.dash.chmonitor.dev/api/mcp*` |
| docs | `docs.chmonitor.dev` | `preview.docs.chmonitor.dev` |

## Changes

- **`apps/dashboard/wrangler.toml`** — preview route `preview.chmonitor.dev` → `preview.dash.chmonitor.dev`.
- **`apps/mcp/wrangler.toml`** — preview routes onto `preview.dash.chmonitor.dev/api/mcp*` + `/api/v1/mcp/info*`.
- **`apps/landing/wrangler.toml`** — declare explicit `custom_domain` preview route `preview.chmonitor.dev` (named envs don't inherit top-level routes).
- **`apps/docs/wrangler.toml`** — declare explicit `custom_domain` preview route `preview.docs.chmonitor.dev`.
- **`.github/workflows/cloudflare.yml`** — preview PR comment lists all four app preview URLs; header comment updated.
- **`docs/knowledge/deployment.md`** — new "Preview topology" table + custom-domain exclusivity note.

## ⚠️ Custom-domain handoff (one-time)

Cloudflare custom domains are **exclusive** — a hostname attaches to one worker only. `preview.chmonitor.dev` is currently bound to `preview-chmonitor-dash`. wrangler will **not** auto-steal it, so the cutover must:

1. Detach `preview.chmonitor.dev` from `preview-chmonitor-dash`.
2. Let `preview-chmonitor-landing` claim it (its preview deploy).

The two new subdomains (`preview.dash`, `preview.docs`) have no prior holder and provision DNS+TLS automatically on first deploy. This handoff is being executed out-of-band via the CF API token during merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: duyetbot <bot@duyet.net>