### PR TITLE
fix(mcp): wire CLERK_SECRET_KEY to MCP worker deploys + bound Clerk verify

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -155,6 +155,11 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
           CHM_API_KEY_SECRET: ${{ secrets.CHM_API_KEY_SECRET }}
+          # Enables Clerk OAuth verification on the preview MCP worker. set-secrets.ts
+          # reads CLERK_SECRET_KEY_TEST first for --env preview (resolveValue). Without
+          # it the worker has the issuer (pubkey in wrangler.toml) but no verifier, so
+          # /api/mcp emits a bare 401 and Clerk bearer tokens are rejected.
+          CLERK_SECRET_KEY_TEST: ${{ secrets.CLERK_SECRET_KEY_TEST }}
         working-directory: apps/mcp
         run: |
           set -euo pipefail
@@ -398,6 +403,11 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
           CHM_API_KEY_SECRET: ${{ secrets.CHM_API_KEY_SECRET }}
+          # Enables Clerk OAuth verification on the production MCP worker
+          # (chmonitor-mcp). MCP_SECRET_KEYS lists CLERK_SECRET_KEY, but without it
+          # in this env block set-secrets.ts reads an empty value and skips it, so
+          # dash.chmonitor.dev/api/mcp would reject every Clerk OAuth token.
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
         working-directory: apps/mcp
         run: |
           set -euo pipefail

--- a/packages/mcp-server/src/auth/clerk-oauth.ts
+++ b/packages/mcp-server/src/auth/clerk-oauth.ts
@@ -17,6 +17,11 @@
  */
 
 const DEFAULT_CLERK_API_URL = 'https://api.clerk.com'
+// Cap the verify round-trip. Cloudflare Workers bound subrequests (~30s), but
+// Node/Docker fetch has no default timeout — a hung Clerk API would otherwise
+// block every bearer-bearing MCP request indefinitely (a DoS vector). 5s is well
+// above Clerk's normal latency while still failing fast.
+const DEFAULT_VERIFY_TIMEOUT_MS = 5000
 
 export interface ClerkOAuthResult {
   valid: boolean
@@ -37,6 +42,8 @@ interface VerifyOptions {
   secretKey?: string
   /** Override the Clerk API base (defaults to CLERK_API_URL or api.clerk.com). */
   apiUrl?: string
+  /** Verify-request timeout in ms (defaults to DEFAULT_VERIFY_TIMEOUT_MS). */
+  timeoutMs?: number
 }
 
 export async function verifyClerkOAuthToken(
@@ -59,9 +66,11 @@ export async function verifyClerkOAuthToken(
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ access_token: token }),
+      signal: AbortSignal.timeout(opts.timeoutMs ?? DEFAULT_VERIFY_TIMEOUT_MS),
     })
   } catch {
-    return { valid: false, reason: 'clerk verify request failed' }
+    // Includes the AbortError thrown when the timeout fires — fail closed.
+    return { valid: false, reason: 'clerk verify request failed or timed out' }
   }
 
   if (!res.ok) {


### PR DESCRIPTION
Follow-up to #1388, surfaced by a max-effort review of the merged code.

## 1. 🔴 Clerk OAuth was inert on the production MCP worker

`#1388` added `CLERK_SECRET_KEY` to `MCP_SECRET_KEYS` in `set-secrets.ts` and the issuer (publishable key) to `apps/mcp/wrangler.toml` — but **neither MCP-worker secret step in `cloudflare.yml` exported the secret into the environment** `set-secrets.ts` reads from. So `resolveValue` got `''` and skipped it.

Net effect: `chmonitor-mcp` (which serves prod `dash.chmonitor.dev/api/mcp`) booted with the issuer but **no verifier** → `clerkOAuthEnabled()` false → every Clerk OAuth bearer rejected. The feature shipped non-functional in production.

Three layers must agree; only two did:
| Layer | Had `CLERK_SECRET_KEY`? |
|---|---|
| Inventory (`set-secrets.ts` `MCP_SECRET_KEYS`) | ✅ |
| Consumer (`apps/mcp/wrangler.toml` issuer) | ✅ |
| **Plumbing (`cloudflare.yml` step `env:`)** | ❌ → fixed here |

Fix: add `CLERK_SECRET_KEY` to the production MCP step and `CLERK_SECRET_KEY_TEST` to the preview MCP step (`resolveValue` reads the `_TEST` variant first for `--env preview`), mirroring the dashboard steps.

## 2. 🟠 Clerk verify `fetch` had no timeout

Workers bound subrequests (~30s) but Node/Docker `fetch` does not — a hung `api.clerk.com` would block every bearer-bearing MCP request indefinitely (DoS vector). Added `AbortSignal.timeout` (5s default, `opts.timeoutMs` override); the abort is caught and fails closed.

## Verification
- 17 clerk-oauth + http-clerk tests pass; full turbo type-check clean (pre-commit).

## Deferred (review notes, not in this PR)
Lower-priority findings from the same review, left for a focused cleanup: cache `buildServerInfo()` (re-maps tools per `/info` request); de-dup the double `getClerkIssuer()` call; `atob()` base64url normalization in `getClerkIssuer`; dashboard `/api/v1/mcp/info` vs worker auth-posture asymmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Ensure MCP worker deployments correctly support Clerk OAuth verification and make Clerk token verification calls fail fast on network hangs.

Bug Fixes:
- Wire Clerk secret keys into preview and production MCP worker Cloudflare deployments so Clerk OAuth verification functions in both environments.

Enhancements:
- Add a configurable timeout to Clerk OAuth token verification requests to avoid hanging on stalled Clerk API calls.

CI:
- Update Cloudflare workflow environment variables to pass Clerk secret keys to MCP worker deployments for preview and production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added timeout protection to authentication token verification to prevent hanging requests and improve system reliability.

* **Chores**
  * Updated deployment configuration to properly provision authentication secrets in production and preview environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->