### PR TITLE
feat(dashboard-tsr): @chm/clickhouse-client on workerd + 3 API routes

### DIFF
--- a/apps/dashboard-tsr/bun.lock
+++ b/apps/dashboard-tsr/bun.lock
@@ -5,15 +5,19 @@
     "": {
       "name": "dashboard-tsr",
       "dependencies": {
+        "@clickhouse/client-web": "^1.18.5",
         "@tanstack/react-router": "^1.170.11",
         "@tanstack/react-start": "^1.168.19",
         "clsx": "^2.1.1",
+        "lru-cache": "^11.5.0",
         "react": "^19",
         "react-dom": "^19",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@clickhouse/client": "^1.18.5",
         "@cloudflare/vite-plugin": "^1.39.2",
         "@cloudflare/workers-types": "^4.20260603.1",
         "@tailwindcss/vite": "^4.3.0",
@@ -65,6 +69,12 @@
     "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@clickhouse/client": ["@clickhouse/client@1.19.0", "", { "dependencies": { "@clickhouse/client-common": "1.19.0" } }, "sha512-R/35tIFZjwRyqtTN0cnlvd45zU+YREuQ/cnfi6c+KGGkVSCF+1cl8mZ9kkxshqHx2U4YjcmPVElJaRn2bEqJ4g=="],
+
+    "@clickhouse/client-common": ["@clickhouse/client-common@1.19.0", "", {}, "sha512-HHQw7MUt1aFquSlnoQhlRO8e7zhRw7rJZFNSYiHP2wxzEVeoI0cX8kKoTp+xlVySvFi8s0mAC3bi8D031xmIQg=="],
+
+    "@clickhouse/client-web": ["@clickhouse/client-web@1.19.0", "", { "dependencies": { "@clickhouse/client-common": "1.19.0" } }, "sha512-5o3Ka8I0gg6g8gMvzZ48fQ0n/ih952s5ONT53+Dh+d/HtWU70P84fWxj/t/FNrNiSELvBBuc7KNDdvJ3P3Ta2Q=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 
@@ -428,7 +438,7 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
-    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+    "lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -533,6 +543,8 @@
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 

--- a/apps/dashboard-tsr/package.json
+++ b/apps/dashboard-tsr/package.json
@@ -18,15 +18,19 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@clickhouse/client-web": "^1.18.5",
     "@tanstack/react-router": "^1.170.11",
     "@tanstack/react-start": "^1.168.19",
     "clsx": "^2.1.1",
+    "lru-cache": "^11.5.0",
     "react": "^19",
     "react-dom": "^19",
     "tailwind-merge": "^3.6.0",
-    "tailwindcss": "^4"
+    "tailwindcss": "^4",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@clickhouse/client": "^1.18.5",
     "@cloudflare/vite-plugin": "^1.39.2",
     "@cloudflare/workers-types": "^4.20260603.1",
     "@tailwindcss/vite": "^4.3.0",

--- a/apps/dashboard-tsr/src/lib/empty.ts
+++ b/apps/dashboard-tsr/src/lib/empty.ts
@@ -1,0 +1,10 @@
+// Empty stub for the node @clickhouse/client on Cloudflare Workers.
+// clickhouse-client.ts statically imports `createClient` from it, but only
+// invokes it on the web:false branch — never reached because this app forces
+// web:true (the fetch-based @clickhouse/client-web). The throw guards against
+// an accidental node-client code path on the edge.
+export function createClient(): never {
+  throw new Error(
+    'node @clickhouse/client is unavailable on Cloudflare Workers; use web:true (createClientWeb)'
+  )
+}

--- a/apps/dashboard-tsr/src/routes/api/healthz.ts
+++ b/apps/dashboard-tsr/src/routes/api/healthz.ts
@@ -1,0 +1,126 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { ClickHouseConfig } from '@chm/clickhouse-client'
+
+import { env } from 'cloudflare:workers'
+// Public client factory. We pass `web: true` so it always uses
+// @clickhouse/client-web (fetch-based) and never touches the node
+// @clickhouse/client (node:os/node:stream/TCP) — excluded from the worker
+// bundle in vite.config.ts.
+import { getClient } from '@chm/clickhouse-client'
+
+// Mirrors @chm/clickhouse-client getClickHouseConfigs(), but sources the
+// comma-separated lists from the Cloudflare env binding (workerd does not map
+// arbitrary bindings onto process.env) instead of process.env.
+function splitByComma(value: string | undefined): string[] {
+  return (value ?? '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+function getClickHouseConfigsFromEnv(): ClickHouseConfig[] {
+  const bindings = env as Record<string, string | undefined>
+
+  const hosts = splitByComma(bindings.CLICKHOUSE_HOST)
+  const users = splitByComma(bindings.CLICKHOUSE_USER)
+  const passwords = splitByComma(bindings.CLICKHOUSE_PASSWORD)
+  const customLabels = splitByComma(bindings.CLICKHOUSE_NAME)
+
+  return hosts.map((host, index) => {
+    // User/password fall back to the first entry so a single credential pair
+    // can serve many hosts — identical to getClickHouseConfigs().
+    let user: string
+    let password: string
+    if (users.length === 1 && passwords.length === 1) {
+      user = users[0]
+      password = passwords[0]
+    } else {
+      user = users[index] || 'default'
+      password = passwords[index] || ''
+    }
+
+    return {
+      id: index,
+      host,
+      user,
+      password,
+      customName: customLabels[index],
+    }
+  })
+}
+
+interface HostHealth {
+  host: string
+  name?: string
+  status: 'up' | 'down'
+  latencyMs: number
+  error?: string
+}
+
+export const Route = createFileRoute('/api/healthz')({
+  server: {
+    handlers: {
+      GET: async () => {
+        const configs = getClickHouseConfigsFromEnv()
+
+        if (configs.length === 0) {
+          return Response.json(
+            {
+              ok: false,
+              error: 'No ClickHouse hosts configured',
+              hosts: [],
+              timestamp: new Date().toISOString(),
+            },
+            { status: 503 }
+          )
+        }
+
+        const hosts: HostHealth[] = await Promise.all(
+          configs.map(async (config) => {
+            const start = Date.now()
+            try {
+              // web: true forces the fetch-based client-web on workerd.
+              const client = await getClient({
+                web: true,
+                clientConfig: config,
+              })
+              const resultSet = await client.query({
+                query: 'SELECT 1',
+                format: 'JSON',
+              })
+              // Drain the response so the ping is a real round-trip.
+              await resultSet.text()
+
+              return {
+                host: config.host,
+                name: config.customName,
+                status: 'up' as const,
+                latencyMs: Date.now() - start,
+              }
+            } catch (err) {
+              return {
+                host: config.host,
+                name: config.customName,
+                status: 'down' as const,
+                latencyMs: Date.now() - start,
+                error: err instanceof Error ? err.message : String(err),
+              }
+            }
+          })
+        )
+
+        const allUp = hosts.every((h) => h.status === 'up')
+
+        return Response.json(
+          {
+            ok: allUp,
+            hosts,
+            timestamp: new Date().toISOString(),
+          },
+          { status: allUp ? 200 : 503 }
+        )
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/hosts.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/hosts.ts
@@ -1,0 +1,75 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+
+interface HostInfo {
+  id: number
+  name: string
+  host: string
+}
+
+// Strip credentials and query params so we never leak passwords to the client.
+// Handles bare hostnames, host:port, and full URLs.
+function sanitizeHost(raw: string): string {
+  const trimmed = raw.trim()
+  const hasScheme = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(trimmed)
+  try {
+    const url = new URL(hasScheme ? trimmed : `http://${trimmed}`)
+    url.username = ''
+    url.password = ''
+    url.search = ''
+    url.hash = ''
+    return hasScheme ? url.origin : url.origin.replace(/^https?:\/\//, '')
+  } catch {
+    const withoutQueryOrHash = trimmed.split('?')[0].split('#')[0]
+    const withoutUserInfo = withoutQueryOrHash.split('@').at(-1) ?? ''
+    return withoutUserInfo.replace(/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//, '')
+  }
+}
+
+// Parse CLICKHOUSE_HOST / CLICKHOUSE_NAME comma lists into host descriptors.
+// Env-only — no ClickHouse query.
+function parseHosts(
+  rawHosts: string | undefined,
+  rawNames: string | undefined
+): HostInfo[] {
+  if (!rawHosts?.trim()) return []
+
+  const hosts = rawHosts
+    .split(',')
+    .map((h) => h.trim())
+    .filter(Boolean)
+  const names = rawNames ? rawNames.split(',').map((n) => n.trim()) : []
+
+  return hosts.map((host, i) => ({
+    id: i,
+    name: names[i]?.trim() || sanitizeHost(host) || `Host ${i}`,
+    host: sanitizeHost(host),
+  }))
+}
+
+export const Route = createFileRoute('/api/v1/hosts')({
+  server: {
+    handlers: {
+      GET: () => {
+        const bindings = env as Record<string, string | undefined>
+        const hosts = parseHosts(
+          bindings.CLICKHOUSE_HOST,
+          bindings.CLICKHOUSE_NAME
+        )
+
+        if (hosts.length === 0) {
+          return Response.json(
+            {
+              error:
+                'No ClickHouse hosts configured. CLICKHOUSE_HOST environment variable is missing or empty.',
+            },
+            { status: 503 }
+          )
+        }
+
+        return Response.json(hosts)
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/version.ts
+++ b/apps/dashboard-tsr/src/routes/api/version.ts
@@ -1,0 +1,18 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+
+// App version (mirrors apps/dashboard/app/api/version, minus the CH version()
+// query which is deferred to a CH-querying route). Overridable via env.
+const APP_VERSION = '0.2.0'
+
+export const Route = createFileRoute('/api/version')({
+  server: {
+    handlers: {
+      GET: () => {
+        const bindings = env as Record<string, string | undefined>
+        return Response.json({ ui: bindings.APP_VERSION ?? APP_VERSION })
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/tsconfig.json
+++ b/apps/dashboard-tsr/tsconfig.json
@@ -5,7 +5,19 @@
     "paths": {
       "@/*": ["./src/*"],
       "@chm/sql-builder": ["../../packages/sql-builder/src/index.ts"],
-      "@chm/logger": ["../../packages/logger/src/index.ts"]
+      "@chm/logger": ["../../packages/logger/src/index.ts"],
+      "@chm/clickhouse-client": [
+        "../../packages/clickhouse-client/src/index.ts"
+      ],
+      "@chm/clickhouse-client/runtime/cloudflare-workers": [
+        "../../packages/clickhouse-client/src/runtime/cloudflare-workers.ts"
+      ],
+      "@clickhouse/client": ["./node_modules/@clickhouse/client"],
+      "@clickhouse/client-web": [
+        "./node_modules/@clickhouse/client-web/dist/index.d.ts"
+      ],
+      "zod": ["./node_modules/zod"],
+      "lru-cache": ["./node_modules/lru-cache"]
     }
   },
   "include": ["src", "vite.config.ts"]

--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -19,6 +19,17 @@ export default defineConfig({
     fs: { allow: ['../..'] },
   },
   resolve: {
+    // The @chm/* source packages live at ../../packages and are transpiled into
+    // the worker (ssr.noExternal). Their npm deps live in THIS app's isolated
+    // node_modules (own-lockfile), which is not on the packages' upward resolve
+    // path — dedupe forces these bare specifiers to resolve from the app root.
+    dedupe: [
+      '@clickhouse/client-web',
+      'lru-cache',
+      'zod',
+      'react',
+      'react-dom',
+    ],
     alias: {
       '@': r('./src'),
       // Shared workspace packages resolved from SOURCE — own-lockfile isolation
@@ -26,10 +37,34 @@ export default defineConfig({
       // (below) bundles them into the worker rather than externalizing.
       '@chm/sql-builder': r('../../packages/sql-builder/src/index.ts'),
       '@chm/logger': r('../../packages/logger/src/index.ts'),
+      '@chm/clickhouse-client': r(
+        '../../packages/clickhouse-client/src/index.ts'
+      ),
+      '@chm/clickhouse-client/runtime/cloudflare-workers': r(
+        '../../packages/clickhouse-client/src/runtime/cloudflare-workers.ts'
+      ),
+      // The node @clickhouse/client (node:os/node:stream/TCP) is a static value
+      // import in clickhouse-client.ts, used only on the web:false branch which
+      // never runs (we force web:true). Because @chm/clickhouse-client is
+      // noExternal, Rolldown walks that import — alias it to an empty stub so it
+      // resolves in the worker instead of leaving an unresolvable bare specifier.
+      '@clickhouse/client': r('./src/lib/empty.ts'),
     },
   },
   ssr: {
-    noExternal: ['@chm/sql-builder', '@chm/logger'],
+    // Transpile + bundle the @chm source packages and their bundleable leaf
+    // deps into the worker.
+    noExternal: [
+      '@chm/sql-builder',
+      '@chm/logger',
+      '@chm/clickhouse-client',
+      '@clickhouse/client-web',
+      'lru-cache',
+      'zod',
+    ],
+    // The node @clickhouse/client is kept out of the worker via the empty-stub
+    // resolve.alias above. (ssr.external is rejected by @cloudflare/vite-plugin
+    // for Worker environments, so the alias is the only mechanism.)
   },
   plugins: [
     tailwindcss(),


### PR DESCRIPTION
## Wave-3 — data-layer foundation (`@chm/clickhouse-client` on workerd)

Part of #1396 · epic #1392 · builds on #1407

Proves the **heavy** shared package (`node:`/WASM/zod) builds + bundles on Cloudflare workerd, and ports the 3 simplest API routes. Designed via a cost-tiered parallel workflow (3 agents).

### 🔑 Workerd wiring (the de-risk)
- **`getClient({ web: true })` is mandatory** — `isCloudflareWorkers()` checks `typeof process === undefined`, but `nodejs_compat` defines `process` → false-negative → would pick the node `@clickhouse/client` (node:os/stream/TCP) → break. `web:true` forces `@clickhouse/client-web`.
- **node `@clickhouse/client` → empty-stub alias** — it's a dead static value import that Rolldown still walks (the package is `noExternal`); `ssr.external` is *rejected* by `@cloudflare/vite-plugin`, so the alias is the only mechanism.
- **`resolve.dedupe`** forces the source packages' npm deps (`@clickhouse/client-web`, `lru-cache`, `zod`) to resolve from the app's isolated `node_modules` (they're not on the `../../packages` upward path).
- **tsc**: leaf-dep `paths` → `./node_modules` (+ `@clickhouse/client` for types only; `client-web` exposes types via an exports map so its path points at `dist/index.d.ts`).

### Routes
`/api/healthz` (real ClickHouse ping via the web client), `/api/version`, `/api/v1/hosts`.

### Verified
`vite build` (client + SSR/workerd, 308 modules) ✅ · `tsc` ✅ · biome ✅ · `wrangler --dry-run` = **1079.63 KiB / 233.12 KiB gzip** (+55 KiB gzip over hello-world = the entire CH client stack).

### Scope
3/56 routes — the **foundation + pattern**. Remaining 53 are mechanical fan-out (future workflow). Isolation (own lockfile) intact.

🤖 Autonomous wave-3. Coordination: epic #1392.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health check endpoint (`/api/healthz`) to verify ClickHouse connectivity and monitor host status
  * Added hosts endpoint (`/api/v1/hosts`) to retrieve configured ClickHouse host information
  * Added version endpoint (`/api/version`) to expose application version details

* **Chores**
  * Updated dependencies to support ClickHouse web-based client for Cloudflare Workers environment
  * Adjusted build configuration for improved dependency resolution in serverless context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->