### PR TITLE
feat(dashboard-tsr): dual-target build — Cloudflare Workers + Docker/Node

### DIFF
--- a/apps/dashboard-tsr/Dockerfile
+++ b/apps/dashboard-tsr/Dockerfile
@@ -1,0 +1,58 @@
+# Dockerfile — Node/Docker target for the TanStack Start dashboard (#1409).
+# Built from the REPO ROOT (context: .) so both apps/dashboard-tsr/ and the
+# shared packages/ sources (resolved via ../../ Vite aliases) are reachable.
+#   docker build -f apps/dashboard-tsr/Dockerfile -t chmonitor-dash-tsr .
+ARG GITHUB_SHA=unknown
+ARG GITHUB_REF=unknown
+
+FROM oven/bun:1-alpine AS base
+WORKDIR /app
+
+# ── deps ──────────────────────────────────────────────────────────────────
+# Install only the isolated app's own dependencies (own bun.lock; NOT a root
+# workspace member). packages/ is copied so bun can resolve the transitive deps
+# of @chm/clickhouse-client (@clickhouse/client-web, lru-cache, zod) during the
+# frozen install.
+FROM base AS deps
+ENV NODE_ENV=production
+RUN apk add --no-cache libc6-compat
+COPY apps/dashboard-tsr/package.json apps/dashboard-tsr/bun.lock ./apps/dashboard-tsr/
+COPY packages/ ./packages/
+WORKDIR /app/apps/dashboard-tsr
+RUN --mount=type=cache,id=bun-tsr,target=/root/.bun/install/cache \
+    bun install --frozen-lockfile --ignore-scripts
+
+# ── builder ────────────────────────────────────────────────────────────────
+FROM base AS builder
+ARG GITHUB_SHA
+ARG GITHUB_REF
+ENV NODE_ENV=production \
+    GITHUB_SHA=${GITHUB_SHA} \
+    GITHUB_REF=${GITHUB_REF} \
+    BUILD_TARGET=node
+COPY --from=deps /app/apps/dashboard-tsr/node_modules /app/apps/dashboard-tsr/node_modules
+# packages/ is needed at build time for the @chm/* source aliases (../../).
+COPY packages/ /app/packages/
+COPY apps/dashboard-tsr/ /app/apps/dashboard-tsr/
+WORKDIR /app/apps/dashboard-tsr
+# BUILD_TARGET=node switches vite.config.ts to the Nitro node-server preset,
+# emitting a self-contained bundle at .output/server/index.mjs.
+RUN BUILD_TARGET=node bun run build:node
+
+# ── runner ─────────────────────────────────────────────────────────────────
+# The Nitro node-server output is a plain Node bundle — run on node:22-alpine
+# (smaller than the bun image, no runtime deps needed beyond .output).
+FROM node:22-alpine AS runner
+ENV NODE_ENV=production \
+    PORT=3000 \
+    HOST=0.0.0.0
+RUN apk add --no-cache libc6-compat && \
+    addgroup --system --gid 1001 app && \
+    adduser --system --uid 1001 app
+WORKDIR /app
+COPY --from=builder --chown=app:app /app/apps/dashboard-tsr/.output ./
+USER app
+EXPOSE 3000
+HEALTHCHECK --interval=10s --timeout=5s --retries=3 --start-period=20s \
+  CMD wget -q -O /dev/null http://localhost:3000/api/healthz || exit 1
+CMD ["node", "server/index.mjs"]

--- a/apps/dashboard-tsr/bun.lock
+++ b/apps/dashboard-tsr/bun.lock
@@ -25,6 +25,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^6.0.2",
+        "nitro": "^3.0.260522-beta",
         "typescript": "^6",
         "vite": "^8.0.16",
         "wrangler": "^4.97.0",
@@ -362,13 +363,19 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
 
+    "crossws": ["crossws@0.4.5", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "db0": ["db0@0.3.4", "", { "peerDependencies": { "@electric-sql/pglite": "*", "@libsql/client": "*", "better-sqlite3": "*", "drizzle-orm": "*", "mysql2": "*", "sqlite3": "*" }, "optionalPeers": ["@electric-sql/pglite", "@libsql/client", "better-sqlite3", "drizzle-orm", "mysql2", "sqlite3"] }, "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -379,6 +386,8 @@
     "electron-to-chromium": ["electron-to-chromium@1.5.366", "", {}, "sha512-OlRuhb688YTCzzU3gXPLn6nGyd+F+53INE1qaKKlu6kETErE8FYsyDh0XqXEU+uBRn0MpCzz2vfNwORhkap8qg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.22.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww=="],
+
+    "env-runner": ["env-runner@0.1.9", "", { "dependencies": { "crossws": "^0.4.5", "exsolve": "^1.0.8", "httpxy": "^0.5.3", "srvx": "^0.11.15" }, "peerDependencies": { "@netlify/runtime": "^4.1.23", "@vercel/queue": "^0.2.0", "miniflare": "^4.20260515.0" }, "optionalPeers": ["@netlify/runtime", "@vercel/queue", "miniflare"], "bin": { "env-runner": "dist/cli.mjs" } }, "sha512-W9AiZlPx0uXtghAJiTBkeZOgyQdecVvoln3cHoOEZswPq0cVMi+WBhUQjdUn+JcZFAFgOt+i5fcO7C2zniZoCg=="],
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
@@ -398,7 +407,13 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "h3": ["h3@2.0.1-rc.22", "", { "dependencies": { "rou3": "^0.8.1", "srvx": "^0.11.15" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA=="],
+
     "h3-v2": ["h3@2.0.1-rc.20", "", { "dependencies": { "rou3": "^0.8.1", "srvx": "^0.11.13" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg=="],
+
+    "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
+
+    "httpxy": ["httpxy@0.5.3", "", {}, "sha512-SMS9V6Sn7VWaS11lYhoAr0ceoaiolTWf4jYdJn0NJhCdKMu9R2H9Fh0LBDWBHQF6HRLI1PmaePYsjanSpE5PEw=="],
 
     "isbot": ["isbot@5.1.40", "", {}, "sha512-yNeeynhhtIVRBk12tBV4eHNxwB42HzR4Q3Ea7vCOiJhImGaAIdIMrbJtacQlBizGLjUPw+akkFI5Dn9T70XoVQ=="],
 
@@ -448,7 +463,17 @@
 
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
+    "nf3": ["nf3@0.3.17", "", {}, "sha512-N9zEWySuJFw+gR0lhS5863YsvNeudOdqRyFvNb+jMXbeTJOdrjDqkCpDginIZfUm0LzT1t1nCRiDeqQm/8kirQ=="],
+
+    "nitro": ["nitro@3.0.260522-beta", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.5", "db0": "^0.3.4", "env-runner": "^0.1.9", "h3": "^2.0.1-rc.22", "hookable": "^6.1.1", "nf3": "^0.3.17", "ocache": "^0.1.4", "ofetch": "^2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.0.2", "srvx": "^0.11.15", "unenv": "^2.0.0-rc.24", "unstorage": "^2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.2.0", "dotenv": "*", "giget": "*", "jiti": "^2.6.1", "rollup": "^4.60.3", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^0.2.0" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-L/z2eOWgkiQHc65kv+SEMgau505afSRF7NJlbooaaZEZscFrNSD7rXZzeVubQlgIzPbhOG8o73bk9soIiGTHRA=="],
+
     "node-releases": ["node-releases@2.0.47", "", {}, "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og=="],
+
+    "ocache": ["ocache@0.1.4", "", { "dependencies": { "ohash": "^2.0.11" } }, "sha512-e7geNdWjxSnvsSgvLuPvgKgu7ubM10ZmTPOgpr7mz2BXYtvjMKTiLhjFi/gWU8chkuP6hNkZBsa9LzOusyaqkQ=="],
+
+    "ofetch": ["ofetch@2.0.0-alpha.3", "", {}, "sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA=="],
+
+    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
@@ -511,6 +536,8 @@
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "unplugin": ["unplugin@3.0.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg=="],
+
+    "unstorage": ["unstorage@2.0.0-alpha.7", "", { "peerDependencies": { "@azure/app-configuration": "^1.11.0", "@azure/cosmos": "^4.9.1", "@azure/data-tables": "^13.3.2", "@azure/identity": "^4.13.0", "@azure/keyvault-secrets": "^4.10.0", "@azure/storage-blob": "^12.31.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.13.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.36.2", "@vercel/blob": ">=0.27.3", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1.0.1", "aws4fetch": "^1.0.20", "chokidar": "^4 || ^5", "db0": ">=0.3.4", "idb-keyval": "^6.2.2", "ioredis": "^5.9.3", "lru-cache": "^11.2.6", "mongodb": "^6 || ^7", "ofetch": "*", "uploadthing": "^7.7.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "chokidar", "db0", "idb-keyval", "ioredis", "lru-cache", "mongodb", "ofetch", "uploadthing"] }, "sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 

--- a/apps/dashboard-tsr/package.json
+++ b/apps/dashboard-tsr/package.json
@@ -10,6 +10,8 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && tsc --noEmit",
+    "build:node": "BUILD_TARGET=node vite build",
+    "start:node": "node .output/server/index.mjs",
     "preview": "vite preview",
     "deploy": "bun run build && wrangler deploy",
     "cf:deploy": "bun run build && wrangler deploy",
@@ -38,6 +40,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.2",
+    "nitro": "^3.0.260522-beta",
     "typescript": "^6",
     "vite": "^8.0.16",
     "wrangler": "^4.97.0"

--- a/apps/dashboard-tsr/src/lib/cloudflare-workers-shim.ts
+++ b/apps/dashboard-tsr/src/lib/cloudflare-workers-shim.ts
@@ -1,0 +1,17 @@
+// Node-build shim for the `cloudflare:workers` virtual module.
+//
+// Aliased in vite.config.ts when BUILD_TARGET=node so the API routes'
+//   import { env } from 'cloudflare:workers'
+// resolves here under Node instead of the workerd built-in.
+//
+// On workerd, `env` is the Worker bindings object (process.env is NOT
+// populated). On Node there are no bindings — env vars live on process.env —
+// so we expose process.env under the same `env` name. The routes read only
+// string-valued keys (CLICKHOUSE_HOST/USER/PASSWORD/NAME, APP_VERSION, etc.)
+// and treat env as Record<string, string | undefined>, which is exactly
+// process.env's shape.
+//
+// NOTE: only `env` is shimmed. Any new `cloudflare:workers` import a future
+// route adds (WorkerEntrypoint, DurableObject, …) must be re-exported here for
+// the Node target, or it will break the node build.
+export const env: Record<string, string | undefined> = process.env

--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -3,15 +3,34 @@ import { cloudflare } from '@cloudflare/vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'
 import viteReact from '@vitejs/plugin-react'
-import { defineConfig } from 'vite'
+import { nitro } from 'nitro/vite'
+import { defineConfig, type PluginOption } from 'vite'
 
 const r = (p: string) => fileURLToPath(new URL(p, import.meta.url))
 
-// Plugin order is load-bearing for the Cloudflare target:
-//  - cloudflare() retargets the SSR environment to the workerd runtime
-//  - tanstackStart() generates routeTree.gen.ts and wires SSR/server routes
-//  - viteReact() MUST come after tanstackStart()
+// Dual build target from ONE source (#1409):
+//  - default / BUILD_TARGET=cloudflare: @cloudflare/vite-plugin → workerd bundle
+//    (the proven, merged CF path; deployed by `wrangler deploy`).
+//  - BUILD_TARGET=node: drop @cloudflare/vite-plugin, add nitro() node-server
+//    preset → .output/server/index.mjs for the Docker image. Same routes, same
+//    @chm/* seam; `cloudflare:workers` is aliased to a process.env shim so the
+//    routes' static `import { env } from 'cloudflare:workers'` resolves on Node.
+const isNode = process.env.BUILD_TARGET === 'node'
+
+// Plugin order is load-bearing:
+//  - CF: cloudflare() retargets the SSR env to workerd and MUST precede
+//    tanstackStart(); viteReact() MUST come after tanstackStart().
+//  - Node: nitro() goes AFTER tanstackStart() (per TanStack hosting docs); no
+//    cloudflare() plugin.
 // tailwindcss() (Tailwind v4) is order-independent; kept first by convention.
+const runtimePlugins: PluginOption[] = isNode
+  ? [tanstackStart(), nitro({ preset: 'node-server' }), viteReact()]
+  : [
+      cloudflare({ viteEnvironment: { name: 'ssr' } }),
+      tanstackStart(),
+      viteReact(),
+    ]
+
 export default defineConfig({
   server: {
     port: 3000,
@@ -20,8 +39,8 @@ export default defineConfig({
   },
   resolve: {
     // The @chm/* source packages live at ../../packages and are transpiled into
-    // the worker (ssr.noExternal). Their npm deps live in THIS app's isolated
-    // node_modules (own-lockfile), which is not on the packages' upward resolve
+    // the server bundle (ssr.noExternal). Their npm deps live in THIS app's
+    // isolated node_modules (own-lockfile), not on the packages' upward resolve
     // path — dedupe forces these bare specifiers to resolve from the app root.
     dedupe: [
       '@clickhouse/client-web',
@@ -34,7 +53,7 @@ export default defineConfig({
       '@': r('./src'),
       // Shared workspace packages resolved from SOURCE — own-lockfile isolation
       // means no `workspace:*` protocol. Vite transpiles them; ssr.noExternal
-      // (below) bundles them into the worker rather than externalizing.
+      // (below) bundles them into the server build rather than externalizing.
       '@chm/sql-builder': r('../../packages/sql-builder/src/index.ts'),
       '@chm/logger': r('../../packages/logger/src/index.ts'),
       '@chm/clickhouse-client': r(
@@ -43,17 +62,20 @@ export default defineConfig({
       '@chm/clickhouse-client/runtime/cloudflare-workers': r(
         '../../packages/clickhouse-client/src/runtime/cloudflare-workers.ts'
       ),
-      // The node @clickhouse/client (node:os/node:stream/TCP) is a static value
-      // import in clickhouse-client.ts, used only on the web:false branch which
-      // never runs (we force web:true). Because @chm/clickhouse-client is
-      // noExternal, Rolldown walks that import — alias it to an empty stub so it
-      // resolves in the worker instead of leaving an unresolvable bare specifier.
+      // The node @clickhouse/client (node:os/node:stream/TCP) is a dead static
+      // import in clickhouse-client.ts (routes force web:true). Alias it to an
+      // empty stub so it resolves in the bundle on BOTH targets.
       '@clickhouse/client': r('./src/lib/empty.ts'),
+      // Node has no `cloudflare:workers` virtual module — alias the routes'
+      // static `import { env } from 'cloudflare:workers'` to a process.env shim.
+      ...(isNode
+        ? { 'cloudflare:workers': r('./src/lib/cloudflare-workers-shim.ts') }
+        : {}),
     },
   },
   ssr: {
     // Transpile + bundle the @chm source packages and their bundleable leaf
-    // deps into the worker.
+    // deps into the server build.
     noExternal: [
       '@chm/sql-builder',
       '@chm/logger',
@@ -62,14 +84,6 @@ export default defineConfig({
       'lru-cache',
       'zod',
     ],
-    // The node @clickhouse/client is kept out of the worker via the empty-stub
-    // resolve.alias above. (ssr.external is rejected by @cloudflare/vite-plugin
-    // for Worker environments, so the alias is the only mechanism.)
   },
-  plugins: [
-    tailwindcss(),
-    cloudflare({ viteEnvironment: { name: 'ssr' } }),
-    tanstackStart(),
-    viteReact(),
-  ],
+  plugins: [tailwindcss(), ...runtimePlugins],
 })


### PR DESCRIPTION
## Dual-target: Cloudflare Workers AND Docker/Node, one source

Closes #1409 · epic #1392

The Next app shipped both ways; this restores that for TanStack Start — **seamless, no UX change**.

### How
`vite.config.ts` branches on `BUILD_TARGET`:
- **default / `cloudflare`**: the proven #1408 CF config **byte-for-behavior** (`@cloudflare/vite-plugin`, all `@chm/*` aliases, `dedupe`, `ssr.noExternal`, `@clickhouse/client` empty stub).
- **`node`**: drop the CF plugin, add `nitro({ preset: 'node-server' })`, and alias `cloudflare:workers` → a `process.env` shim so the routes' static `import { env }` resolves on Node — **no route changes**.

Plus: `src/lib/cloudflare-workers-shim.ts`, a multi-stage `Dockerfile` (repo-root context so `@chm/*` source + the isolated `bun.lock` are reachable; runs the Nitro node server; HEALTHCHECK `/api/healthz`), and `build:node`/`start:node` scripts (+ `nitro` devDep).

### Verified BOTH targets
| Target | Result |
|---|---|
| Cloudflare | `bun run build` + `wrangler --dry-run` = **233.12 KiB gzip** (identical to #1408 — no regression) |
| Node | `bun run build:node` → `.output/server/index.mjs`; server serves `/api/version` → `{"ui":"0.2.0"}`, `/api/v1/hosts` → parsed JSON, `/` → 200 SPA shell |

`getClient({ web: true })` (fetch-based `@clickhouse/client-web`) already runs on both runtimes, so the data layer is target-agnostic.

> compose service snippet (host port 3001) in the issue; wiring the Docker CI job lands with the CI rewire (#1403).

🤖 Autonomous, designed via a cost-tiered parallel workflow + adversarial verify (reconciled against #1408 ground truth).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Node.js runtime support for the dashboard, enabling deployment to Node.js environments alongside existing Cloudflare Workers infrastructure.

* **Chores**
  * Added Docker containerization and build configuration to support Node.js deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->