### PR TITLE
feat(dashboard-tsr): routing + TanStack Query + static prerender

### DIFF
--- a/apps/dashboard-tsr/bun.lock
+++ b/apps/dashboard-tsr/bun.lock
@@ -6,10 +6,12 @@
       "name": "dashboard-tsr",
       "dependencies": {
         "@clickhouse/client-web": "^1.18.5",
+        "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-router": "^1.170.11",
         "@tanstack/react-start": "^1.168.19",
         "clsx": "^2.1.1",
         "lru-cache": "^11.5.0",
+        "next-themes": "^0.4.6",
         "react": "^19",
         "react-dom": "^19",
         "tailwind-merge": "^3.6.0",
@@ -301,6 +303,10 @@
 
     "@tanstack/history": ["@tanstack/history@1.162.0", "", {}, "sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA=="],
 
+    "@tanstack/query-core": ["@tanstack/query-core@5.101.0", "", {}, "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.101.0", "", { "dependencies": { "@tanstack/query-core": "5.101.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg=="],
+
     "@tanstack/react-router": ["@tanstack/react-router@1.170.11", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.9", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-gP2vzdyaI8Ow/Uz/MRPfK2wN09YwRI0Y/oF74Wuy9R3KmjbfJv2tLrkM+Onu1xWklSn3ugZarMPJXRE0kzrJTA=="],
 
     "@tanstack/react-start": ["@tanstack/react-start@1.168.19", "", { "dependencies": { "@tanstack/react-router": "1.170.11", "@tanstack/react-start-client": "1.168.8", "@tanstack/react-start-rsc": "0.1.18", "@tanstack/react-start-server": "1.167.14", "@tanstack/router-utils": "1.162.1", "@tanstack/start-client-core": "1.170.7", "@tanstack/start-plugin-core": "1.171.11", "@tanstack/start-server-core": "1.169.9", "pathe": "^2.0.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-UGguzD22ZdxZmz/Rcw2My/L40il/S51adm1zARclr7zkhoQfV7WlgBxjskPi5ngiOYAPlI7847Ptz8we5TSM3Q=="],
@@ -462,6 +468,8 @@
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
     "nf3": ["nf3@0.3.17", "", {}, "sha512-N9zEWySuJFw+gR0lhS5863YsvNeudOdqRyFvNb+jMXbeTJOdrjDqkCpDginIZfUm0LzT1t1nCRiDeqQm/8kirQ=="],
 

--- a/apps/dashboard-tsr/package.json
+++ b/apps/dashboard-tsr/package.json
@@ -21,10 +21,12 @@
   },
   "dependencies": {
     "@clickhouse/client-web": "^1.18.5",
+    "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-router": "^1.170.11",
     "@tanstack/react-start": "^1.168.19",
     "clsx": "^2.1.1",
     "lru-cache": "^11.5.0",
+    "next-themes": "^0.4.6",
     "react": "^19",
     "react-dom": "^19",
     "tailwind-merge": "^3.6.0",

--- a/apps/dashboard-tsr/src/lib/api/types.ts
+++ b/apps/dashboard-tsr/src/lib/api/types.ts
@@ -1,0 +1,77 @@
+/**
+ * API types for the ClickHouse monitoring API layer (ported from the Next app,
+ * apps/dashboard/lib/api/types.ts — pure types, framework-agnostic).
+ *
+ * Internal tool: API responses include sensitive info (raw SQL, host/version).
+ * Do not expose publicly without auth/authorization.
+ */
+
+export enum ApiErrorType {
+  TableNotFound = 'table_not_found',
+  ValidationError = 'validation_error',
+  QueryError = 'query_error',
+  NetworkError = 'network_error',
+  PermissionError = 'permission_error',
+  SslError = 'ssl_error',
+  TimeoutError = 'timeout_error',
+}
+
+export interface ApiError {
+  readonly type: ApiErrorType
+  readonly message: string
+  readonly details?: {
+    readonly [key: string]:
+      | string
+      | number
+      | boolean
+      | undefined
+      | readonly string[]
+      | readonly (string | number | boolean)[]
+  }
+}
+
+export type DataStatus =
+  | 'ok'
+  | 'empty'
+  | 'table_not_configured'
+  | 'table_not_found'
+  | 'table_empty'
+
+export interface ApiResponseMetadata {
+  readonly queryId: string
+  readonly duration: number
+  readonly rows: number
+  readonly host: string
+  readonly clickhouseVersion?: string
+  readonly cachedAt?: number
+  readonly status?: DataStatus
+  readonly statusMessage?: string
+  readonly checkedTables?: readonly string[]
+  readonly missingTables?: readonly string[]
+  readonly api?: string
+  readonly securityNote?: string
+  readonly table?: string
+  readonly sql?: string
+  readonly params?: Record<string, unknown> | null
+  readonly timezone?: string
+  readonly resultRowLimit?: number
+  readonly resultOverflowMode?: string
+  readonly resultRowsBeforeCap?: number
+  readonly resultRowsTruncated?: boolean
+}
+
+export interface ApiResponse<T = unknown> {
+  readonly success: boolean
+  readonly data?: T
+  readonly metadata: ApiResponseMetadata
+  readonly error?: ApiError
+}
+
+export interface ApiRequest {
+  readonly query: string
+  readonly queryParams?: Record<string, string | number | boolean>
+  readonly hostId: string
+  readonly format?: 'JSONEachRow' | 'JSON' | 'CSV' | 'TSV'
+  readonly queryConfigName?: string
+  readonly timezone?: string
+}

--- a/apps/dashboard-tsr/src/lib/query/provider.tsx
+++ b/apps/dashboard-tsr/src/lib/query/provider.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { useState } from 'react'
+
+interface QueryProviderProps {
+  children: React.ReactNode
+}
+
+export function QueryProvider({ children }: QueryProviderProps) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            // SWR dedupingInterval: 5000ms
+            // Requests made within this window share the same in-flight fetch
+            // and the cached result is considered fresh for this long.
+            staleTime: 5_000,
+
+            // SWR revalidateOnFocus: false
+            // Don't refetch when the browser tab regains focus.
+            refetchOnWindowFocus: false,
+
+            // SWR errorRetryCount: 3
+            // Retry failed queries up to 3 times before surfacing the error.
+            retry: 3,
+
+            // SWR onErrorRetry uses exponential backoff starting at 1 s (errorRetryInterval: 1000),
+            // doubling each attempt and capped at 30 s.
+            // attempt index is 0-based; match SWR's 2^n * 1000 formula.
+            retryDelay: (attempt) => Math.min(30_000, 1_000 * 2 ** attempt),
+
+            // SWR sets no global refreshInterval — polling is opt-in per query.
+            // TanStack Query default (false) matches: no background refetch unless
+            // the caller passes refetchInterval explicitly.
+            refetchInterval: false,
+          },
+        },
+      })
+  )
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}

--- a/apps/dashboard-tsr/src/lib/query/use-chart-data.ts
+++ b/apps/dashboard-tsr/src/lib/query/use-chart-data.ts
@@ -1,0 +1,157 @@
+import { useQuery } from '@tanstack/react-query'
+
+import type { ApiResponseMetadata } from '@/lib/api/types'
+
+import { useMemo, useRef } from 'react'
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { REFRESH_INTERVAL, type RefreshInterval } from '@/lib/swr/config'
+import { throwIfNotOk } from '@/lib/swr/fetch-error'
+
+export interface ChartDataPoint {
+  [key: string]: unknown
+}
+
+export type ChartMetadata = ApiResponseMetadata
+
+interface ChartDataResponse<T = unknown> {
+  data: T[] | Record<string, unknown>
+  metadata: ChartMetadata
+}
+
+export interface StaleError extends Error {
+  timestamp: number
+  type?: string
+  details?: { missingTables?: readonly string[]; [key: string]: unknown }
+}
+
+export interface UseChartResult<TData extends ChartDataPoint = ChartDataPoint> {
+  data: TData[]
+  metadata?: ChartMetadata
+  sql?: string
+  error?: Error
+  isLoading: boolean
+  isValidating: boolean
+  mutate: () => Promise<undefined | unknown>
+  hasData: boolean
+  staleError?: StaleError
+  chartName: string
+}
+
+export interface UseChartDataParams {
+  chartName: string
+  hostId?: number | string
+  interval?: string
+  lastHours?: number
+  params?: Record<string, unknown>
+  timezone?: string
+  refreshInterval?: RefreshInterval | number
+}
+
+export function useChartData<T extends ChartDataPoint = ChartDataPoint>({
+  chartName,
+  hostId,
+  interval,
+  lastHours,
+  params,
+  timezone,
+  refreshInterval = REFRESH_INTERVAL.DEFAULT_60S,
+}: UseChartDataParams): UseChartResult<T> {
+  const searchParams = new URLSearchParams()
+  if (hostId !== undefined) searchParams.append('hostId', String(hostId))
+  if (interval) searchParams.append('interval', interval)
+  if (lastHours !== undefined)
+    searchParams.append('lastHours', String(lastHours))
+  if (params) searchParams.append('params', JSON.stringify(params))
+  if (timezone) searchParams.append('timezone', timezone)
+
+  const queryString = searchParams.toString()
+  const url = `/api/v1/charts/${chartName}${queryString ? `?${queryString}` : ''}`
+
+  const queryKey = [
+    '/api/v1/charts',
+    chartName,
+    hostId,
+    interval,
+    lastHours,
+    JSON.stringify(params ?? null),
+    timezone,
+  ] as const
+
+  const resolvedRefetchInterval =
+    refreshInterval > 0
+      ? () =>
+          typeof document !== 'undefined' && document.hidden
+            ? false
+            : (refreshInterval as number)
+      : false
+
+  const { data, error, isPending, isFetching, refetch } = useQuery<
+    ChartDataResponse<T>,
+    Error
+  >({
+    queryKey,
+    queryFn: async () => {
+      const response = await apiFetch(url)
+      await throwIfNotOk(response, 'Failed to fetch chart data')
+      return response.json() as Promise<ChartDataResponse<T>>
+    },
+    staleTime: 5_000,
+    refetchInterval: resolvedRefetchInterval,
+    refetchOnMount: true,
+    refetchOnReconnect: true,
+    refetchOnWindowFocus: true,
+    retry: (failureCount, err) => {
+      if (
+        'status' in err &&
+        typeof (err as { status?: number }).status === 'number'
+      ) {
+        const status = (err as { status: number }).status
+        if (status >= 400 && status < 500 && status !== 429) return false
+      }
+      return failureCount < 3
+    },
+    retryDelay: (attemptIndex) => Math.min(30_000, 1_000 * 2 ** attemptIndex),
+  })
+
+  const dataArray =
+    Array.isArray(data?.data) || !data?.data
+      ? (data?.data as T[])
+      : ([data.data] as T[])
+
+  const hasData = Boolean(dataArray && dataArray.length > 0)
+  const isLoading = isPending && isFetching
+  const isValidating = isFetching
+
+  const staleErrorTimestampRef = useRef<number>(0)
+
+  const staleError = useMemo<StaleError | undefined>(() => {
+    if (!error || !hasData || isLoading) {
+      staleErrorTimestampRef.current = 0
+      return undefined
+    }
+    if (staleErrorTimestampRef.current === 0) {
+      staleErrorTimestampRef.current = Date.now()
+    }
+    return {
+      ...error,
+      name: error.name,
+      message: error.message,
+      timestamp: staleErrorTimestampRef.current,
+      type: (error as Error & { type?: string }).type,
+      details: (error as Error & { details?: StaleError['details'] }).details,
+    }
+  }, [error, hasData, isLoading])
+
+  return {
+    data: dataArray ?? [],
+    metadata: data?.metadata,
+    sql: data?.metadata?.sql,
+    error: error ?? undefined,
+    isLoading,
+    isValidating,
+    mutate: () => refetch().then(() => undefined),
+    hasData,
+    staleError,
+    chartName,
+  }
+}

--- a/apps/dashboard-tsr/src/lib/query/use-table-data.ts
+++ b/apps/dashboard-tsr/src/lib/query/use-table-data.ts
@@ -1,0 +1,116 @@
+import { useQuery } from '@tanstack/react-query'
+
+import type { ApiResponseMetadata } from '@/lib/api/types'
+import type { StaleError } from './use-chart-data'
+
+import { useMemo, useRef } from 'react'
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { throwIfNotOk } from '@/lib/swr/fetch-error'
+
+interface TableDataResponse<T = unknown> {
+  data: T[]
+  metadata: ApiResponseMetadata & {
+    rows_before_limit_at_least?: number
+    exception?: string
+  }
+}
+
+interface TableQueryParams {
+  search?: string
+  sortBy?: string
+  sortOrder?: 'asc' | 'desc'
+  page?: number
+  limit?: number
+  [key: string]: string | number | boolean | undefined
+}
+
+export function useTableData<T = unknown>(
+  queryConfigName: string,
+  hostId?: number,
+  searchParams?: TableQueryParams,
+  refreshInterval?: number,
+  timezone?: string
+) {
+  const params = new URLSearchParams()
+  if (hostId !== undefined) params.append('hostId', String(hostId))
+  if (searchParams) {
+    Object.entries(searchParams).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '') {
+        params.append(key, String(value))
+      }
+    })
+  }
+  if (timezone) params.append('timezone', timezone)
+
+  const queryString = params.toString()
+  const url = `/api/v1/tables/${queryConfigName}${queryString ? `?${queryString}` : ''}`
+
+  const queryKey = [
+    '/api/v1/tables',
+    queryConfigName,
+    hostId,
+    JSON.stringify(searchParams ?? {}),
+    timezone,
+  ] as const
+
+  const resolvedRefetchInterval =
+    refreshInterval && refreshInterval > 0
+      ? () =>
+          typeof document !== 'undefined' && document.hidden
+            ? false
+            : refreshInterval
+      : false
+
+  const { data, error, isPending, isFetching, refetch } = useQuery<
+    TableDataResponse<T>,
+    Error
+  >({
+    queryKey,
+    queryFn: async () => {
+      const response = await apiFetch(url)
+      await throwIfNotOk(response, 'Failed to fetch table data')
+      return response.json() as Promise<TableDataResponse<T>>
+    },
+    staleTime: 3_000,
+    refetchInterval: resolvedRefetchInterval,
+    refetchOnMount: true,
+    refetchOnReconnect: true,
+    refetchOnWindowFocus: true,
+  })
+
+  const dataArray = data?.data ?? []
+  const hasData = dataArray.length > 0
+  const isLoading = isPending && isFetching
+  const isValidating = isFetching
+
+  const staleErrorTimestampRef = useRef<number>(0)
+
+  const staleError = useMemo<StaleError | undefined>(() => {
+    if (!error || !hasData || isLoading) {
+      staleErrorTimestampRef.current = 0
+      return undefined
+    }
+    if (staleErrorTimestampRef.current === 0) {
+      staleErrorTimestampRef.current = Date.now()
+    }
+    return {
+      ...error,
+      name: error.name,
+      message: error.message,
+      timestamp: staleErrorTimestampRef.current,
+      type: (error as Error & { type?: string }).type,
+      details: (error as Error & { details?: StaleError['details'] }).details,
+    }
+  }, [error, hasData, isLoading])
+
+  return {
+    data: dataArray,
+    metadata: data?.metadata,
+    error: error ?? undefined,
+    isLoading,
+    isValidating,
+    refresh: () => refetch().then(() => undefined),
+    hasData,
+    staleError,
+  }
+}

--- a/apps/dashboard-tsr/src/lib/swr/api-fetch.ts
+++ b/apps/dashboard-tsr/src/lib/swr/api-fetch.ts
@@ -1,0 +1,37 @@
+/**
+ * Fetch wrapper for first-party dashboard API calls (ported from the Next app).
+ *
+ * Intercepts non-stream HTML error responses (e.g. Cloudflare's "Worker
+ * exceeded resource limits" page) so they surface as real errors rather than
+ * being rendered as content. Framework-agnostic — used by the TanStack Query
+ * hooks as the queryFn fetcher.
+ */
+export async function apiFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): Promise<Response> {
+  const response =
+    init === undefined ? await fetch(input) : await fetch(input, init)
+
+  const contentType = response.headers?.get?.('content-type') ?? ''
+  const isStream =
+    contentType.includes('text/event-stream') ||
+    contentType.includes('application/json') ||
+    contentType.includes('application/x-ndjson')
+
+  if (response.ok && isStream) return response
+
+  if (!response.ok && !isStream && contentType.includes('text/html')) {
+    const bodyText = await response.clone().text()
+    const truncated = bodyText.slice(0, 500)
+    const isCfResourceLimit = /Worker exceeded resource limits/i.test(bodyText)
+    const message = isCfResourceLimit
+      ? 'Cloudflare Worker exceeded resource limits (CPU/memory). Try a smaller question, disable some tools, or use a faster model.'
+      : `Request failed (${response.status} ${response.statusText || 'Error'})`
+    const err = new Error(message)
+    ;(err as { details?: string }).details = truncated
+    throw err
+  }
+
+  return response
+}

--- a/apps/dashboard-tsr/src/lib/swr/config.ts
+++ b/apps/dashboard-tsr/src/lib/swr/config.ts
@@ -1,0 +1,34 @@
+/**
+ * Refresh-interval presets (ported from the Next app). The SWR-typed
+ * `swrConfig`/`onErrorRetry` presets are intentionally dropped — retry/backoff
+ * now lives in the TanStack Query client defaults (src/lib/query/provider.tsx).
+ * The interval constants + visibility-aware helper are kept because the data
+ * hooks reference them.
+ */
+
+export const REFRESH_INTERVAL = {
+  /** Never refresh (static data) */
+  NEVER: 0,
+  /** Refresh every 15 seconds - critical real-time data only */
+  FAST_15S: 15_000,
+  /** Refresh every 30 seconds - important real-time metrics */
+  MEDIUM_30S: 30_000,
+  /** Refresh every 60 seconds - default for most metrics */
+  DEFAULT_60S: 60_000,
+  /** Refresh every 2 minutes - slower changing data */
+  SLOW_2M: 120_000,
+  /** Refresh every 5 minutes - historical/trend data */
+  VERY_SLOW_5M: 300_000,
+} as const
+
+export type RefreshInterval =
+  (typeof REFRESH_INTERVAL)[keyof typeof REFRESH_INTERVAL]
+
+/**
+ * Visibility-aware refresh interval. Returns `false` (paused) when the tab is
+ * hidden, otherwise the given interval — shape matches TanStack Query's
+ * `refetchInterval: number | false | (() => number | false)`.
+ */
+export function visibilityAwareInterval(ms: number): () => number | false {
+  return () => (typeof document !== 'undefined' && document.hidden ? false : ms)
+}

--- a/apps/dashboard-tsr/src/lib/swr/fetch-error.ts
+++ b/apps/dashboard-tsr/src/lib/swr/fetch-error.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared fetch error handling (ported from the Next app). Reads the JSON error
+ * body and throws a richly-annotated FetchError. Used by the data hooks.
+ */
+interface ApiErrorBody {
+  error?: {
+    message?: string
+    type?: string
+    details?: { missingTables?: readonly string[]; [key: string]: unknown }
+  }
+}
+
+export interface FetchError extends Error {
+  status?: number
+  type?: string
+  details?: { missingTables?: readonly string[]; [key: string]: unknown }
+}
+
+export async function throwIfNotOk(
+  response: Response,
+  fallbackMessage = 'Request failed'
+): Promise<void> {
+  if (response.ok) return
+
+  const errorData = (await response.json().catch(() => ({}))) as ApiErrorBody
+
+  const error = new Error(
+    errorData.error?.message || `${fallbackMessage}: ${response.statusText}`
+  ) as FetchError
+
+  error.status = response.status
+
+  if (errorData.error) {
+    error.type = errorData.error.type
+    error.details = errorData.error.details
+  }
+
+  throw error
+}

--- a/apps/dashboard-tsr/src/lib/swr/index.ts
+++ b/apps/dashboard-tsr/src/lib/swr/index.ts
@@ -1,0 +1,11 @@
+// Barrel for the data-fetching helpers. NOTE: the directory name `swr` is
+// legacy — the app uses TanStack Query (see ../query). These are generic fetch
+// helpers + the router-based host hook, not SWR-specific.
+export { apiFetch } from './api-fetch'
+export {
+  REFRESH_INTERVAL,
+  type RefreshInterval,
+  visibilityAwareInterval,
+} from './config'
+export { type FetchError, throwIfNotOk } from './fetch-error'
+export { useHostId } from './use-host'

--- a/apps/dashboard-tsr/src/lib/swr/use-host.ts
+++ b/apps/dashboard-tsr/src/lib/swr/use-host.ts
@@ -1,0 +1,16 @@
+import { useSearch } from '@tanstack/react-router'
+
+/**
+ * Read the active host id from the typed `?host=` search param (declared +
+ * defaulted to 0 on the root route's validateSearch). Replaces the Next app's
+ * `useSearchParams().get('host')`.
+ *
+ * `strict: false` so deeply-nested, route-agnostic consumers (charts, badges —
+ * the "hooks at deepest consumer" convention) can read it without knowing their
+ * route. The root validator always supplies a number, so `?? 0` is belt-and-
+ * suspenders.
+ */
+export function useHostId(): number {
+  const search = useSearch({ strict: false }) as { host?: number }
+  return search.host ?? 0
+}

--- a/apps/dashboard-tsr/src/lib/theme/theme-provider.tsx
+++ b/apps/dashboard-tsr/src/lib/theme/theme-provider.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react'
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+
+// Thin next-themes wrapper matching the Next app's ThemeProvider config.
+// next-themes is framework-agnostic (not Next-specific) and this is the same
+// lib + version, so dark/light behavior is identical. In SPA mode there's no
+// server render, so the usual <html class> hydration mismatch is moot.
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      {children}
+    </NextThemesProvider>
+  )
+}

--- a/apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { throwIfNotOk } from '@/lib/swr/fetch-error'
+import { useHostId } from '@/lib/swr/use-host'
+
+interface HostInfo {
+  id: number
+  name: string
+  host: string
+}
+
+export const Route = createFileRoute('/(dashboard)/overview')({
+  component: OverviewPage,
+})
+
+// Foundation placeholder: proves QueryProvider + useHostId + the API binding
+// work end-to-end. Static structure prerenders; the host list hydrates client
+// side via TanStack Query against /api/v1/hosts.
+function OverviewPage() {
+  const hostId = useHostId()
+  const { data, isPending, error } = useQuery<HostInfo[], Error>({
+    queryKey: ['/api/v1/hosts'],
+    queryFn: async () => {
+      const res = await apiFetch('/api/v1/hosts')
+      await throwIfNotOk(res, 'Failed to fetch hosts')
+      return res.json() as Promise<HostInfo[]>
+    },
+  })
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-2xl font-bold">Overview</h1>
+      <p className="text-zinc-500">Active host: {hostId}</p>
+      {isPending && <p className="text-zinc-400">Loading hosts…</p>}
+      {error && <p className="text-red-500">{error.message}</p>}
+      {data && (
+        <ul className="flex flex-col gap-1">
+          {data.map((h) => (
+            <li key={h.id}>
+              #{h.id} · {h.name} · {h.host}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard-tsr/src/routes/(dashboard)/route.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/route.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+
+// Pathless `(dashboard)` group = the TanStack equivalent of the Next app's
+// app/(dashboard) segment. Bare layout for the foundation; the real
+// sidebar/header/breadcrumb chrome is ported in a later issue.
+export const Route = createFileRoute('/(dashboard)')({
+  component: DashboardLayout,
+})
+
+function DashboardLayout() {
+  return (
+    <main className="mx-auto max-w-7xl p-6">
+      <Outlet />
+    </main>
+  )
+}

--- a/apps/dashboard-tsr/src/routes/__root.tsx
+++ b/apps/dashboard-tsr/src/routes/__root.tsx
@@ -8,12 +8,27 @@ import {
 import type { ReactNode } from 'react'
 
 import appCss from '../styles.css?url'
+import { QueryProvider } from '@/lib/query/provider'
+import { ThemeProvider } from '@/lib/theme/theme-provider'
 
-// Root route renders the full HTML document shell. In current TanStack Start
-// the shell lives in the route `component` (the older `shellComponent` split
-// is gone). <HeadContent/> injects head tags; <Scripts/> injects the client
-// runtime + hydration scripts.
+// Typed global `?host=` search param, declared on the ROOT so every route
+// inherits it and useHostId can read it via useSearch({ strict: false }).
+// Mirrors the Next app's host parsing (Number() coerce, fall back to 0).
+interface RootSearch {
+  host: number
+}
+
+function validateSearch(search: Record<string, unknown>): RootSearch {
+  const raw = search.host
+  const parsed = Number(raw)
+  return {
+    host:
+      raw === undefined || raw === null || Number.isNaN(parsed) ? 0 : parsed,
+  }
+}
+
 export const Route = createRootRoute({
+  validateSearch,
   head: () => ({
     meta: [
       { charSet: 'utf-8' },
@@ -33,14 +48,18 @@ function RootComponent() {
   )
 }
 
+// Root renders the full HTML document (the SPA shell in SPA mode). Providers
+// mount client-side: ThemeProvider > QueryProvider (TanStack Query).
 function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <HeadContent />
       </head>
-      <body>
-        {children}
+      <body className="bg-background font-sans antialiased">
+        <ThemeProvider>
+          <QueryProvider>{children}</QueryProvider>
+        </ThemeProvider>
         <Scripts />
       </body>
     </html>

--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -23,11 +23,20 @@ const isNode = process.env.BUILD_TARGET === 'node'
 //  - Node: nitro() goes AFTER tanstackStart() (per TanStack hosting docs); no
 //    cloudflare() plugin.
 // tailwindcss() (Tailwind v4) is order-independent; kept first by convention.
+// Static prerender: emit per-route static HTML at build (fast first paint,
+// served via Cloudflare Workers Assets / Docker static files), with a SPA
+// fallback shell for any non-crawled route. Dynamic data still loads
+// client-side via TanStack Query against the API routes — "fast like SSR".
+const startConfig = {
+  prerender: { enabled: true, crawlLinks: true },
+  spa: { enabled: true },
+}
+
 const runtimePlugins: PluginOption[] = isNode
-  ? [tanstackStart(), nitro({ preset: 'node-server' }), viteReact()]
+  ? [tanstackStart(startConfig), nitro({ preset: 'node-server' }), viteReact()]
   : [
       cloudflare({ viteEnvironment: { name: 'ssr' } }),
-      tanstackStart(),
+      tanstackStart(startConfig),
       viteReact(),
     ]
 


### PR DESCRIPTION
Closes #1395 · epic #1392

**Static prerender (fast first paint, like SSR)** + client-rendered data:
- `tanstackStart({ prerender: { enabled: true, crawlLinks: true }, spa: { enabled: true } })` → per-route static HTML (`dist/client/overview/index.html`) served via Workers Assets / Docker static + SPA fallback; dynamic data client-side. Works on BOTH targets.
- Typed `?host=` search param (root `validateSearch`); `useHostId` via `useSearch({strict:false})`.
- **Data layer = TanStack Query** (not SWR): `QueryProvider` + `useChartData`/`useTableData` on `useQuery` (graceful `staleError`/`hasData`/`mutate` shape preserved; config mapped from old SWRConfig). Ported fetch helpers + `api/types`.
- `__root` → ThemeProvider(next-themes) > QueryProvider; `(dashboard)` group + overview placeholder proving Query + useHostId + `/api/v1/hosts`.

Verified: vite build + tsc + prerender green. 🤖 Assembled from 2 cost-tiered parallel workflows (routing + SWR→Query), reconciled to TanStack Query.