### PR TITLE
feat(dashboard-tsr): 4 more API routes (timezone, host-status, notifications, health)

### DIFF
--- a/apps/dashboard-tsr/src/routes/api/health.ts
+++ b/apps/dashboard-tsr/src/routes/api/health.ts
@@ -1,0 +1,69 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+
+function getDeploymentInfo(bindings: Record<string, string | undefined>) {
+  // Determine runtime: in workerd the CLOUDFLARE_WORKERS binding is set to '1'
+  const runtime = bindings.CLOUDFLARE_WORKERS === '1' ? 'cloudflare' : 'node'
+
+  return {
+    gitSha: bindings.NEXT_PUBLIC_GIT_SHA ?? null,
+    gitRef: bindings.NEXT_PUBLIC_GIT_REF ?? null,
+    buildTimestamp: bindings.NEXT_PUBLIC_BUILD_TIMESTAMP ?? null,
+    ci: bindings.NEXT_PUBLIC_CI === 'true',
+    runtime,
+    // Auth provider as set at build time (NEXT_PUBLIC_AUTH_PROVIDER) and
+    // at runtime (CHM_AUTH_PROVIDER). The source route used @/lib/auth/provider
+    // which is not yet in dashboard-tsr, so we read the env vars directly.
+    authProvider:
+      bindings.CHM_AUTH_PROVIDER ?? bindings.NEXT_PUBLIC_AUTH_PROVIDER ?? null,
+    clientAuthProvider: bindings.NEXT_PUBLIC_AUTH_PROVIDER ?? null,
+    agentAccess: bindings.CHM_FEATURE_AGENT_ACCESS ?? 'public',
+    clerkPublishableKeyPrefix:
+      bindings.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?.slice(0, 8) ?? null,
+  }
+}
+
+export const Route = createFileRoute('/api/health')({
+  server: {
+    handlers: {
+      GET: () => {
+        try {
+          const bindings = env as Record<string, string | undefined>
+
+          return Response.json(
+            {
+              status: 'ok',
+              timestamp: new Date().toISOString(),
+              deployment: getDeploymentInfo(bindings),
+            },
+            {
+              status: 200,
+              headers: {
+                'Content-Type': 'application/json',
+                'Cache-Control': 'no-cache, no-store, must-revalidate',
+              },
+            }
+          )
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : 'Unknown error'
+
+          return Response.json(
+            {
+              status: 'error',
+              error: errorMessage,
+              timestamp: new Date().toISOString(),
+            },
+            {
+              status: 500,
+              headers: {
+                'Content-Type': 'application/json',
+              },
+            }
+          )
+        }
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/timezone.ts
+++ b/apps/dashboard-tsr/src/routes/api/timezone.ts
@@ -1,0 +1,78 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { ClickHouseConfig } from '@chm/clickhouse-client'
+
+import { env } from 'cloudflare:workers'
+import { getClient } from '@chm/clickhouse-client'
+
+function splitByComma(value: string | undefined): string[] {
+  return (value ?? '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+function getClickHouseConfigsFromEnv(): ClickHouseConfig[] {
+  const bindings = env as Record<string, string | undefined>
+
+  const hosts = splitByComma(bindings.CLICKHOUSE_HOST)
+  const users = splitByComma(bindings.CLICKHOUSE_USER)
+  const passwords = splitByComma(bindings.CLICKHOUSE_PASSWORD)
+  const customLabels = splitByComma(bindings.CLICKHOUSE_NAME)
+
+  return hosts.map((host, index) => {
+    let user: string
+    let password: string
+    if (users.length === 1 && passwords.length === 1) {
+      user = users[0]
+      password = passwords[0]
+    } else {
+      user = users[index] || 'default'
+      password = passwords[index] || ''
+    }
+
+    return {
+      id: index,
+      host,
+      user,
+      password,
+      customName: customLabels[index],
+    }
+  })
+}
+
+export const Route = createFileRoute('/api/timezone')({
+  server: {
+    handlers: {
+      GET: async () => {
+        const configs = getClickHouseConfigsFromEnv()
+
+        if (configs.length === 0) {
+          return Response.json({}, { status: 500 })
+        }
+
+        try {
+          const client = await getClient({
+            web: true,
+            clientConfig: configs[0],
+          })
+          const resultSet = await client.query({
+            query: 'SELECT timezone() AS tz',
+            format: 'JSON',
+          })
+          // JSON format wraps rows: json<Row>() => { data: Row[], ... }
+          const json = await resultSet.json<{ tz: string }>()
+          const tz = json.data[0]?.tz
+
+          if (!tz) {
+            return Response.json({}, { status: 500 })
+          }
+
+          return Response.json({ tz })
+        } catch {
+          return Response.json({}, { status: 500 })
+        }
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/host-status.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/host-status.ts
@@ -1,0 +1,124 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { ClickHouseConfig } from '@chm/clickhouse-client'
+
+import { env } from 'cloudflare:workers'
+import { getClient } from '@chm/clickhouse-client'
+
+const QUERY_COMMENT = '/* { "client": "clickhouse-monitoring" } */\n'
+
+function splitByComma(value: string | undefined): string[] {
+  return (value ?? '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+function getClickHouseConfigsFromEnv(): ClickHouseConfig[] {
+  const bindings = env as Record<string, string | undefined>
+
+  const hosts = splitByComma(bindings.CLICKHOUSE_HOST)
+  const users = splitByComma(bindings.CLICKHOUSE_USER)
+  const passwords = splitByComma(bindings.CLICKHOUSE_PASSWORD)
+  const customLabels = splitByComma(bindings.CLICKHOUSE_NAME)
+
+  return hosts.map((host, index) => {
+    let user: string
+    let password: string
+    if (users.length === 1 && passwords.length === 1) {
+      user = users[0]
+      password = passwords[0]
+    } else {
+      user = users[index] || 'default'
+      password = passwords[index] || ''
+    }
+
+    return {
+      id: index,
+      host,
+      user,
+      password,
+      customName: customLabels[index],
+    }
+  })
+}
+
+export const Route = createFileRoute('/api/v1/host-status')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const searchParams = new URL(request.url).searchParams
+        const hostIdRaw = searchParams.get('hostId')
+
+        if (hostIdRaw === null || hostIdRaw === '') {
+          return Response.json(
+            { success: false, error: 'hostId query parameter is required' },
+            { status: 400 }
+          )
+        }
+
+        const hostId = Number(hostIdRaw)
+        if (!Number.isInteger(hostId) || hostId < 0) {
+          return Response.json(
+            { success: false, error: 'hostId must be a non-negative integer' },
+            { status: 400 }
+          )
+        }
+
+        const configs = getClickHouseConfigsFromEnv()
+
+        if (hostId >= configs.length) {
+          return Response.json(
+            {
+              success: false,
+              error: `hostId ${hostId} is out of range (${configs.length} host(s) configured)`,
+            },
+            { status: 400 }
+          )
+        }
+
+        const clientConfig = configs[hostId]
+
+        try {
+          const client = await getClient({ web: true, clientConfig })
+          const resultSet = await client.query({
+            query: `${QUERY_COMMENT}SELECT
+  version() AS version,
+  formatReadableTimeDelta(uptime()) AS uptime,
+  hostName() AS hostname`,
+            format: 'JSONEachRow',
+          })
+
+          // JSONEachRow returns rows directly: json<Row>() => Row[]
+          const rows = await resultSet.json<{
+            version: string
+            uptime: string
+            hostname: string
+          }>()
+
+          const data = rows[0]
+          const version = data?.version ?? ''
+          const uptime = data?.uptime ?? ''
+          const hostname = data?.hostname ?? ''
+
+          return Response.json({
+            success: true,
+            data: { version, uptime, hostname },
+          })
+        } catch (error) {
+          console.error('Host status API error:', error)
+          return Response.json(
+            {
+              success: false,
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to fetch host status',
+            },
+            { status: 500 }
+          )
+        }
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/notifications.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/notifications.ts
@@ -1,0 +1,185 @@
+/**
+ * Notifications API endpoint
+ * GET /api/v1/notifications?hostId=n
+ *
+ * Returns active alerts across all clusters.
+ * Currently: readonly-tables warnings (via clusterAllReplicas on system.replicas).
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { ClickHouseConfig } from '@chm/clickhouse-client'
+
+import { env } from 'cloudflare:workers'
+import { getClient } from '@chm/clickhouse-client'
+
+// ---------------------------------------------------------------------------
+// Env helpers (mirrors healthz.ts)
+// ---------------------------------------------------------------------------
+
+function splitByComma(value: string | undefined): string[] {
+  return (value ?? '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+function getClickHouseConfigsFromEnv(): ClickHouseConfig[] {
+  const bindings = env as Record<string, string | undefined>
+
+  const hosts = splitByComma(bindings.CLICKHOUSE_HOST)
+  const users = splitByComma(bindings.CLICKHOUSE_USER)
+  const passwords = splitByComma(bindings.CLICKHOUSE_PASSWORD)
+  const customLabels = splitByComma(bindings.CLICKHOUSE_NAME)
+
+  return hosts.map((host, index) => {
+    let user: string
+    let password: string
+    if (users.length === 1 && passwords.length === 1) {
+      user = users[0]
+      password = passwords[0]
+    } else {
+      user = users[index] || 'default'
+      password = passwords[index] || ''
+    }
+
+    return {
+      id: index,
+      host,
+      user,
+      password,
+      customName: customLabels[index],
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface Notification {
+  readonly type: 'readonly-tables'
+  readonly cluster: string
+  readonly count: number
+  readonly severity: 'critical' | 'warning'
+}
+
+interface NotificationsResponse {
+  readonly notifications: readonly Notification[]
+  readonly totalCount: number
+}
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+export const Route = createFileRoute('/api/v1/notifications')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const url = new URL(request.url)
+        const rawHostId = url.searchParams.get('hostId') ?? '0'
+        const hostId = Number(rawHostId)
+
+        if (!Number.isInteger(hostId) || hostId < 0) {
+          return Response.json(
+            {
+              error: 'Invalid hostId parameter: must be a non-negative integer',
+            },
+            { status: 400 }
+          )
+        }
+
+        const configs = getClickHouseConfigsFromEnv()
+
+        if (configs.length === 0) {
+          return Response.json(
+            { error: 'No ClickHouse hosts configured' },
+            { status: 503 }
+          )
+        }
+
+        const clientConfig = configs[hostId]
+        if (!clientConfig) {
+          return Response.json(
+            {
+              error: `Invalid hostId: ${hostId}. Available host indices: 0–${configs.length - 1}`,
+            },
+            { status: 400 }
+          )
+        }
+
+        try {
+          const client = await getClient({ web: true, clientConfig })
+
+          // Step 1: get all clusters
+          const clustersResult = await client.query({
+            query: `
+              SELECT DISTINCT cluster
+              FROM system.clusters
+              ORDER BY cluster ASC
+            `,
+            format: 'JSONEachRow',
+          })
+          const clusters = (await clustersResult.json()) as Array<{
+            cluster: string
+          }>
+
+          // Step 2: for each cluster check readonly replica count
+          const notifications: Notification[] = []
+
+          for (const { cluster } of clusters) {
+            try {
+              const readonlyResult = await client.query({
+                query: `
+                  SELECT COUNT() as count
+                  FROM clusterAllReplicas({cluster: String}, system.replicas)
+                  WHERE is_readonly = 1
+                `,
+                format: 'JSONEachRow',
+                query_params: { cluster },
+              })
+              const readonlyData = (await readonlyResult.json()) as Array<{
+                count?: number | string
+              }>
+              const readonlyCount =
+                readonlyData.length > 0 && readonlyData[0].count !== undefined
+                  ? Number(readonlyData[0].count)
+                  : 0
+
+              if (readonlyCount > 0) {
+                notifications.push({
+                  type: 'readonly-tables',
+                  cluster,
+                  count: readonlyCount,
+                  severity: readonlyCount > 10 ? 'critical' : 'warning',
+                })
+              }
+            } catch {
+              // Skip clusters that don't support this query
+            }
+          }
+
+          const totalCount = notifications.length
+          const body: NotificationsResponse = { notifications, totalCount }
+
+          return new Response(JSON.stringify(body), {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+              // Short cache — 30 seconds, matching the source route
+              'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=30',
+            },
+          })
+        } catch (err) {
+          return Response.json(
+            {
+              error: err instanceof Error ? err.message : 'Unknown error',
+            },
+            { status: 500 }
+          )
+        }
+      },
+    },
+  },
+})


### PR DESCRIPTION
Part of #1396 · epic #1392. Faithful ports via the healthz env-binding + `getClient({web:true})` pattern. Fixed the `@clickhouse/client-web` `json<Row>()` generic (wraps rows). 7/56 routes now. Deferred: mcp-info (needs @chm/mcp-server), version-full. Build green. 🤖 dynamic per-route fan-out workflow.