### PR TITLE
feat(dashboard-tsr): Clerk auth provider gating (@clerk/tanstack-react-start)

### DIFF
--- a/apps/dashboard-tsr/bun.lock
+++ b/apps/dashboard-tsr/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "dashboard-tsr",
       "dependencies": {
+        "@clerk/tanstack-react-start": "^1.3.2",
         "@clickhouse/client-web": "^1.18.5",
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-router": "^1.170.11",
@@ -72,6 +73,14 @@
     "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@clerk/backend": ["@clerk/backend@3.4.14", "", { "dependencies": { "@clerk/shared": "^4.14.0", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-0iaMT7k4wDk31QVC3HMaoeVFttblwsCECTHKNQpbRzIyD8j2gHdKEw/FNjffoyqyBqPw869IQlk1YokUlwVAqQ=="],
+
+    "@clerk/react": ["@clerk/react@6.7.2", "", { "dependencies": { "@clerk/shared": "^4.14.0", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-tgRWWTfW+ejXj6WiZqx7iMbtvh45h0445uEvbSNVCyJBEOaBlCF0/ZfAfXlWAQNbRZ+bPIphEfNUmatadZgGOQ=="],
+
+    "@clerk/shared": ["@clerk/shared@4.14.0", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-StZCFJ2rg0ITE3fYjIN9CKuKq8ZACW6l2+5qGCFPPYd4hZphA+VDselmh/lHPsF1ex/WRVUSHvquykAHR8cQbQ=="],
+
+    "@clerk/tanstack-react-start": ["@clerk/tanstack-react-start@1.3.2", "", { "dependencies": { "@clerk/backend": "^3.4.14", "@clerk/react": "^6.7.2", "@clerk/shared": "^4.14.0", "tslib": "2.8.1" }, "peerDependencies": { "@tanstack/react-router": "^1.157.0", "@tanstack/react-start": "^1.157.0", "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-x+kxE1UlNnZYhoMIvjJKvITe5n6ZJx94xOvdE/vtvM+pS/UXtEyhGaZA6JMwN16yJFdhS2A01/LtNrPTPJtwPA=="],
 
     "@clickhouse/client": ["@clickhouse/client@1.19.0", "", { "dependencies": { "@clickhouse/client-common": "1.19.0" } }, "sha512-R/35tIFZjwRyqtTN0cnlvd45zU+YREuQ/cnfi6c+KGGkVSCF+1cl8mZ9kkxshqHx2U4YjcmPVElJaRn2bEqJ4g=="],
 
@@ -271,6 +280,8 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.15", "", {}, "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw=="],
 
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.0", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.0", "@tailwindcss/oxide-darwin-arm64": "4.3.0", "@tailwindcss/oxide-darwin-x64": "4.3.0", "@tailwindcss/oxide-freebsd-x64": "4.3.0", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0", "@tailwindcss/oxide-linux-arm64-musl": "4.3.0", "@tailwindcss/oxide-linux-x64-gnu": "4.3.0", "@tailwindcss/oxide-linux-x64-musl": "4.3.0", "@tailwindcss/oxide-wasm32-wasi": "4.3.0", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0", "@tailwindcss/oxide-win32-x64-msvc": "4.3.0" } }, "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg=="],
@@ -385,6 +396,8 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
@@ -403,6 +416,8 @@
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetchdts": ["fetchdts@0.1.7", "", {}, "sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA=="],
@@ -410,6 +425,8 @@
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -424,6 +441,8 @@
     "isbot": ["isbot@5.1.40", "", {}, "sha512-yNeeynhhtIVRBk12tBV4eHNxwB42HzR4Q3Ea7vCOiJhImGaAIdIMrbJtacQlBizGLjUPw+akkFI5Dn9T70XoVQ=="],
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -520,6 +539,10 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "srvx": ["srvx@0.11.16", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw=="],
+
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 

--- a/apps/dashboard-tsr/package.json
+++ b/apps/dashboard-tsr/package.json
@@ -20,6 +20,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@clerk/tanstack-react-start": "^1.3.2",
     "@clickhouse/client-web": "^1.18.5",
     "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-router": "^1.170.11",

--- a/apps/dashboard-tsr/src/components/clerk/clerk-auth-provider.tsx
+++ b/apps/dashboard-tsr/src/components/clerk/clerk-auth-provider.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react'
+
+import { ClerkProvider } from '@clerk/tanstack-react-start'
+import { CLERK_PUBLISHABLE_KEY, isClerkEnabled } from '@/lib/clerk/clerk-client'
+
+// Port of apps/dashboard/components/clerk/clerk-auth-provider.tsx.
+//
+// Conditionally mounts Clerk's <ClerkProvider> ONLY when isClerkEnabled() is
+// true. When disabled, children render untouched and <ClerkProvider> is never
+// instantiated - so non-Clerk builds never reach into Clerk's runtime, and any
+// Clerk hook (useUser/useClerk), which MUST be gated behind the same
+// isClerkEnabled() flag at its call site, is never invoked outside a provider.
+//
+// isClerkEnabled() is a build-time constant (both inputs are import.meta.env),
+// so a non-Clerk build tree-shakes this down to `return children`.
+//
+// NOTE: this is the ONLY place that should import @clerk/tanstack-react-start
+// unconditionally. Every other Clerk hook/component import must sit behind a
+// lazy require/dynamic import guarded by isClerkEnabled() (mirroring the Next
+// app's nav-user.tsx / agent-thread-page.tsx pattern).
+interface ClerkAuthProviderProps {
+  children: ReactNode
+}
+
+export function ClerkAuthProvider({ children }: ClerkAuthProviderProps) {
+  if (!isClerkEnabled()) {
+    return children
+  }
+
+  // Pass the key explicitly so the gate's check and Clerk's init read the same
+  // value. Clerk also auto-reads VITE_CLERK_PUBLISHABLE_KEY, but being explicit
+  // keeps the contract self-documenting and decoupled from Clerk's lookup order.
+  return (
+    <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
+      {children}
+    </ClerkProvider>
+  )
+}

--- a/apps/dashboard-tsr/src/lib/clerk/clerk-client.ts
+++ b/apps/dashboard-tsr/src/lib/clerk/clerk-client.ts
@@ -1,0 +1,45 @@
+/**
+ * Clerk client utilities for optional authentication support (TanStack Start).
+ *
+ * Port of apps/dashboard/lib/clerk/clerk-client.ts. Clerk is opt-in - the app
+ * functions fully without it. These utilities let components safely check if
+ * Clerk is enabled BEFORE touching any Clerk hook/component.
+ *
+ * Gating contract (identical to the Next app):
+ *   isClerkEnabled() === true  <=>  auth provider is 'clerk' AND a valid
+ *   publishable key (pk_...) is present.
+ *
+ * Both inputs come from import.meta.env, so Vite inlines them at build time -
+ * isClerkEnabled() is a per-build compile-time constant (the same property the
+ * Next app got from NEXT_PUBLIC_* inlining). This is what makes the
+ * lazy-require gating pattern in nav-user.tsx etc. safe.
+ */
+
+import { error } from '@chm/logger'
+import { getClientAuthProvider } from '@/lib/env'
+
+/**
+ * Client-safe publishable key, resolved at build time from
+ * VITE_CLERK_PUBLISHABLE_KEY (the NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY equivalent).
+ *
+ * Clerk's <ClerkProvider> auto-reads this same env var, so the value the gate
+ * checks and the value Clerk initializes from are guaranteed to match.
+ */
+export const CLERK_PUBLISHABLE_KEY: string | undefined = import.meta.env
+  .VITE_CLERK_PUBLISHABLE_KEY
+
+/**
+ * Check if Clerk authentication is enabled.
+ *
+ * @returns true if auth provider is clerk and the publishable key is valid
+ */
+export function isClerkEnabled(): boolean {
+  try {
+    if (getClientAuthProvider() !== 'clerk') return false
+  } catch (err) {
+    error('[clerk] Auth provider check failed', err)
+    return false
+  }
+
+  return Boolean(CLERK_PUBLISHABLE_KEY?.startsWith('pk_'))
+}

--- a/apps/dashboard-tsr/src/routes/__root.tsx
+++ b/apps/dashboard-tsr/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import {
 import type { ReactNode } from 'react'
 
 import appCss from '../styles.css?url'
+import { ClerkAuthProvider } from '@/components/clerk/clerk-auth-provider'
 import { QueryProvider } from '@/lib/query/provider'
 import { ThemeProvider } from '@/lib/theme/theme-provider'
 
@@ -57,9 +58,11 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
         <HeadContent />
       </head>
       <body className="bg-background font-sans antialiased">
-        <ThemeProvider>
-          <QueryProvider>{children}</QueryProvider>
-        </ThemeProvider>
+        <ClerkAuthProvider>
+          <ThemeProvider>
+            <QueryProvider>{children}</QueryProvider>
+          </ThemeProvider>
+        </ClerkAuthProvider>
         <Scripts />
       </body>
     </html>

--- a/apps/dashboard-tsr/src/vite-env.d.ts
+++ b/apps/dashboard-tsr/src/vite-env.d.ts
@@ -5,6 +5,7 @@
 // here so they are typed wherever import.meta.env is read.
 interface ImportMetaEnv {
   readonly VITE_AUTH_PROVIDER?: string
+  readonly VITE_CLERK_PUBLISHABLE_KEY?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Closes #1400 · epic #1392. Build-time-gated Clerk (`isClerkEnabled` = VITE_AUTH_PROVIDER==='clerk' AND pk_ key), `ClerkAuthProvider` mounts `<ClerkProvider>` only when enabled (sole unconditional Clerk import; hooks stay gated). Wired into `__root`. Builds + prerenders on workerd via `@clerk/tanstack-react-start`. Server verify + downstream consumers deferred. 🤖 cost-tiered workflow + adversarial verify.