### PR TITLE
refactor(dashboard-tsr): address CodeRabbit review findings

### DIFF
--- a/apps/dashboard-tsr/src/components/clerk/clerk-auth-provider.tsx
+++ b/apps/dashboard-tsr/src/components/clerk/clerk-auth-provider.tsx
@@ -1,29 +1,32 @@
 import type { ReactNode } from 'react'
 
 import { ClerkProvider } from '@clerk/tanstack-react-start'
-import { CLERK_PUBLISHABLE_KEY, isClerkEnabled } from '@/lib/clerk/clerk-client'
+import {
+  CLERK_PUBLISHABLE_KEY,
+  isClerkClientEnabled,
+} from '@/lib/clerk/clerk-client'
 
 // Port of apps/dashboard/components/clerk/clerk-auth-provider.tsx.
 //
-// Conditionally mounts Clerk's <ClerkProvider> ONLY when isClerkEnabled() is
+// Conditionally mounts Clerk's <ClerkProvider> ONLY when isClerkClientEnabled() is
 // true. When disabled, children render untouched and <ClerkProvider> is never
 // instantiated - so non-Clerk builds never reach into Clerk's runtime, and any
 // Clerk hook (useUser/useClerk), which MUST be gated behind the same
-// isClerkEnabled() flag at its call site, is never invoked outside a provider.
+// isClerkClientEnabled() flag at its call site, is never invoked outside a provider.
 //
-// isClerkEnabled() is a build-time constant (both inputs are import.meta.env),
+// isClerkClientEnabled() is a build-time constant (both inputs are import.meta.env),
 // so a non-Clerk build tree-shakes this down to `return children`.
 //
 // NOTE: this is the ONLY place that should import @clerk/tanstack-react-start
 // unconditionally. Every other Clerk hook/component import must sit behind a
-// lazy require/dynamic import guarded by isClerkEnabled() (mirroring the Next
+// lazy require/dynamic import guarded by isClerkClientEnabled() (mirroring the Next
 // app's nav-user.tsx / agent-thread-page.tsx pattern).
 interface ClerkAuthProviderProps {
   children: ReactNode
 }
 
 export function ClerkAuthProvider({ children }: ClerkAuthProviderProps) {
-  if (!isClerkEnabled()) {
+  if (!isClerkClientEnabled()) {
     return children
   }
 

--- a/apps/dashboard-tsr/src/lib/api/clickhouse-config.ts
+++ b/apps/dashboard-tsr/src/lib/api/clickhouse-config.ts
@@ -1,0 +1,36 @@
+import type { ClickHouseConfig } from '@chm/clickhouse-client'
+
+// Shared ClickHouse host-config resolver for server routes. Builds
+// ClickHouseConfig[] from the comma-separated env lists (the Cloudflare binding
+// or process.env), mirroring @chm/clickhouse-client getClickHouseConfigs() but
+// sourcing from the passed bindings. Extracted to one place (was duplicated in
+// every CH route — flagged in review).
+export function splitByComma(value: string | undefined): string[] {
+  return (value ?? '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+export function getClickHouseConfigsFromEnv(
+  bindings: Record<string, string | undefined>
+): ClickHouseConfig[] {
+  const hosts = splitByComma(bindings.CLICKHOUSE_HOST)
+  const users = splitByComma(bindings.CLICKHOUSE_USER)
+  const passwords = splitByComma(bindings.CLICKHOUSE_PASSWORD)
+  const customLabels = splitByComma(bindings.CLICKHOUSE_NAME)
+
+  return hosts.map((host, index) => {
+    // A single credential pair serves many hosts; otherwise index by position.
+    let user: string
+    let password: string
+    if (users.length === 1 && passwords.length === 1) {
+      user = users[0]
+      password = passwords[0]
+    } else {
+      user = users[index] || 'default'
+      password = passwords[index] || ''
+    }
+    return { id: index, host, user, password, customName: customLabels[index] }
+  })
+}

--- a/apps/dashboard-tsr/src/lib/clerk/clerk-client.ts
+++ b/apps/dashboard-tsr/src/lib/clerk/clerk-client.ts
@@ -33,7 +33,7 @@ export const CLERK_PUBLISHABLE_KEY: string | undefined = import.meta.env
  *
  * @returns true if auth provider is clerk and the publishable key is valid
  */
-export function isClerkEnabled(): boolean {
+export function isClerkClientEnabled(): boolean {
   try {
     if (getClientAuthProvider() !== 'clerk') return false
   } catch (err) {

--- a/apps/dashboard-tsr/src/lib/cloudflare-workers-shim.ts
+++ b/apps/dashboard-tsr/src/lib/cloudflare-workers-shim.ts
@@ -14,4 +14,8 @@
 // NOTE: only `env` is shimmed. Any new `cloudflare:workers` import a future
 // route adds (WorkerEntrypoint, DurableObject, …) must be re-exported here for
 // the Node target, or it will break the node build.
-export const env: Record<string, string | undefined> = process.env
+// Guard `process` — it may be undefined if this module is ever evaluated in a
+// browser/client context (the Node target only aliases this server-side, but
+// defensive against accidental client bundling).
+export const env: Record<string, string | undefined> =
+  typeof process !== 'undefined' && process.env ? process.env : {}

--- a/apps/dashboard-tsr/src/routes/api/healthz.ts
+++ b/apps/dashboard-tsr/src/routes/api/healthz.ts
@@ -8,47 +8,11 @@ import { env } from 'cloudflare:workers'
 // @clickhouse/client (node:os/node:stream/TCP) — excluded from the worker
 // bundle in vite.config.ts.
 import { getClient } from '@chm/clickhouse-client'
+import { getClickHouseConfigsFromEnv } from '@/lib/api/clickhouse-config'
 
 // Mirrors @chm/clickhouse-client getClickHouseConfigs(), but sources the
 // comma-separated lists from the Cloudflare env binding (workerd does not map
 // arbitrary bindings onto process.env) instead of process.env.
-function splitByComma(value: string | undefined): string[] {
-  return (value ?? '')
-    .split(',')
-    .map((item) => item.trim())
-    .filter(Boolean)
-}
-
-function getClickHouseConfigsFromEnv(): ClickHouseConfig[] {
-  const bindings = env as Record<string, string | undefined>
-
-  const hosts = splitByComma(bindings.CLICKHOUSE_HOST)
-  const users = splitByComma(bindings.CLICKHOUSE_USER)
-  const passwords = splitByComma(bindings.CLICKHOUSE_PASSWORD)
-  const customLabels = splitByComma(bindings.CLICKHOUSE_NAME)
-
-  return hosts.map((host, index) => {
-    // User/password fall back to the first entry so a single credential pair
-    // can serve many hosts — identical to getClickHouseConfigs().
-    let user: string
-    let password: string
-    if (users.length === 1 && passwords.length === 1) {
-      user = users[0]
-      password = passwords[0]
-    } else {
-      user = users[index] || 'default'
-      password = passwords[index] || ''
-    }
-
-    return {
-      id: index,
-      host,
-      user,
-      password,
-      customName: customLabels[index],
-    }
-  })
-}
 
 interface HostHealth {
   host: string
@@ -62,7 +26,9 @@ export const Route = createFileRoute('/api/healthz')({
   server: {
     handlers: {
       GET: async () => {
-        const configs = getClickHouseConfigsFromEnv()
+        const configs = getClickHouseConfigsFromEnv(
+          env as Record<string, string | undefined>
+        )
 
         if (configs.length === 0) {
           return Response.json(

--- a/apps/dashboard-tsr/src/routes/api/timezone.ts
+++ b/apps/dashboard-tsr/src/routes/api/timezone.ts
@@ -4,48 +4,15 @@ import type { ClickHouseConfig } from '@chm/clickhouse-client'
 
 import { env } from 'cloudflare:workers'
 import { getClient } from '@chm/clickhouse-client'
-
-function splitByComma(value: string | undefined): string[] {
-  return (value ?? '')
-    .split(',')
-    .map((item) => item.trim())
-    .filter(Boolean)
-}
-
-function getClickHouseConfigsFromEnv(): ClickHouseConfig[] {
-  const bindings = env as Record<string, string | undefined>
-
-  const hosts = splitByComma(bindings.CLICKHOUSE_HOST)
-  const users = splitByComma(bindings.CLICKHOUSE_USER)
-  const passwords = splitByComma(bindings.CLICKHOUSE_PASSWORD)
-  const customLabels = splitByComma(bindings.CLICKHOUSE_NAME)
-
-  return hosts.map((host, index) => {
-    let user: string
-    let password: string
-    if (users.length === 1 && passwords.length === 1) {
-      user = users[0]
-      password = passwords[0]
-    } else {
-      user = users[index] || 'default'
-      password = passwords[index] || ''
-    }
-
-    return {
-      id: index,
-      host,
-      user,
-      password,
-      customName: customLabels[index],
-    }
-  })
-}
+import { getClickHouseConfigsFromEnv } from '@/lib/api/clickhouse-config'
 
 export const Route = createFileRoute('/api/timezone')({
   server: {
     handlers: {
       GET: async () => {
-        const configs = getClickHouseConfigsFromEnv()
+        const configs = getClickHouseConfigsFromEnv(
+          env as Record<string, string | undefined>
+        )
 
         if (configs.length === 0) {
           return Response.json({}, { status: 500 })

--- a/apps/dashboard-tsr/src/routes/api/v1/host-status.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/host-status.ts
@@ -4,44 +4,9 @@ import type { ClickHouseConfig } from '@chm/clickhouse-client'
 
 import { env } from 'cloudflare:workers'
 import { getClient } from '@chm/clickhouse-client'
+import { getClickHouseConfigsFromEnv } from '@/lib/api/clickhouse-config'
 
 const QUERY_COMMENT = '/* { "client": "clickhouse-monitoring" } */\n'
-
-function splitByComma(value: string | undefined): string[] {
-  return (value ?? '')
-    .split(',')
-    .map((item) => item.trim())
-    .filter(Boolean)
-}
-
-function getClickHouseConfigsFromEnv(): ClickHouseConfig[] {
-  const bindings = env as Record<string, string | undefined>
-
-  const hosts = splitByComma(bindings.CLICKHOUSE_HOST)
-  const users = splitByComma(bindings.CLICKHOUSE_USER)
-  const passwords = splitByComma(bindings.CLICKHOUSE_PASSWORD)
-  const customLabels = splitByComma(bindings.CLICKHOUSE_NAME)
-
-  return hosts.map((host, index) => {
-    let user: string
-    let password: string
-    if (users.length === 1 && passwords.length === 1) {
-      user = users[0]
-      password = passwords[0]
-    } else {
-      user = users[index] || 'default'
-      password = passwords[index] || ''
-    }
-
-    return {
-      id: index,
-      host,
-      user,
-      password,
-      customName: customLabels[index],
-    }
-  })
-}
 
 export const Route = createFileRoute('/api/v1/host-status')({
   server: {
@@ -65,7 +30,9 @@ export const Route = createFileRoute('/api/v1/host-status')({
           )
         }
 
-        const configs = getClickHouseConfigsFromEnv()
+        const configs = getClickHouseConfigsFromEnv(
+          env as Record<string, string | undefined>
+        )
 
         if (hostId >= configs.length) {
           return Response.json(

--- a/apps/dashboard-tsr/src/routes/api/v1/notifications.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/notifications.ts
@@ -12,46 +12,11 @@ import type { ClickHouseConfig } from '@chm/clickhouse-client'
 
 import { env } from 'cloudflare:workers'
 import { getClient } from '@chm/clickhouse-client'
+import { getClickHouseConfigsFromEnv } from '@/lib/api/clickhouse-config'
 
 // ---------------------------------------------------------------------------
 // Env helpers (mirrors healthz.ts)
 // ---------------------------------------------------------------------------
-
-function splitByComma(value: string | undefined): string[] {
-  return (value ?? '')
-    .split(',')
-    .map((item) => item.trim())
-    .filter(Boolean)
-}
-
-function getClickHouseConfigsFromEnv(): ClickHouseConfig[] {
-  const bindings = env as Record<string, string | undefined>
-
-  const hosts = splitByComma(bindings.CLICKHOUSE_HOST)
-  const users = splitByComma(bindings.CLICKHOUSE_USER)
-  const passwords = splitByComma(bindings.CLICKHOUSE_PASSWORD)
-  const customLabels = splitByComma(bindings.CLICKHOUSE_NAME)
-
-  return hosts.map((host, index) => {
-    let user: string
-    let password: string
-    if (users.length === 1 && passwords.length === 1) {
-      user = users[0]
-      password = passwords[0]
-    } else {
-      user = users[index] || 'default'
-      password = passwords[index] || ''
-    }
-
-    return {
-      id: index,
-      host,
-      user,
-      password,
-      customName: customLabels[index],
-    }
-  })
-}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -90,7 +55,9 @@ export const Route = createFileRoute('/api/v1/notifications')({
           )
         }
 
-        const configs = getClickHouseConfigsFromEnv()
+        const configs = getClickHouseConfigsFromEnv(
+          env as Record<string, string | undefined>
+        )
 
         if (configs.length === 0) {
           return Response.json(


### PR DESCRIPTION
Consolidated follow-up addressing CodeRabbit comments on the merged TanStack Start PRs (#1406–#1413):
- **dedup**: shared `src/lib/api/clickhouse-config.ts` (was copy-pasted in 4 routes)
- **bug**: `cloudflare-workers-shim` guards `typeof process` (crash risk if evaluated client-side)
- **naming collision**: `clerk-client` `isClerkEnabled`→`isClerkClientEnabled` (clashed with `env.ts`'s server-side one)

Skipped false-positives: raw-array API response (consumer agrees by design), `.filter(Boolean)` (matches Next behavior). Build + prerender green. 🤖 babysit-pr review triage.