### PR TITLE
feat(dashboard-tsr): query-config + chart/table registry foundation

### DIFF
--- a/apps/dashboard-tsr/src/lib/api/chart-registry.ts
+++ b/apps/dashboard-tsr/src/lib/api/chart-registry.ts
@@ -1,0 +1,105 @@
+/**
+ * Chart query registry for dashboard-tsr.
+ *
+ * Ported from apps/dashboard/lib/api/chart-registry.ts. A chart is a builder
+ * function `(params) => ChartQueryResult` registered under a name. The
+ * dashboard composes ~14 domain chart modules into one map; here the map
+ * starts EMPTY (chart fan-out is later) and exposes `registerChartQuery` so
+ * ported modules can self-register, plus the same get/has/list surface the
+ * route handler uses.
+ *
+ * Chart-data types are defined locally (the dashboard re-exports them from
+ * its `@/types/chart-data`, which is not ported). They mirror that shape so
+ * ported chart builders need no edits.
+ */
+
+import type { VersionedSql } from '@chm/sql-builder'
+import type { ClickHouseInterval } from './query-executor'
+
+/** Cache policy → Cache-Control TTL bucket (handler maps to headers). */
+export type CachePolicy = 'realtime' | 'standard' | 'historical'
+
+/** A single chart row — permissive, like the dashboard's ChartDataPoint. */
+export interface ChartDataPoint {
+  [key: string]: unknown
+}
+
+/** Time-series row with a required `event_time`. */
+export interface TimeSeriesPoint extends ChartDataPoint {
+  event_time: string
+}
+
+/** Params passed to a chart builder. */
+export interface ChartQueryParams {
+  interval?: ClickHouseInterval
+  lastHours?: number
+  params?: Record<string, unknown>
+  /** IANA timezone for the ClickHouse session. */
+  timezone?: string
+}
+
+/** Single-query chart result. */
+export interface ChartQueryResult<_T extends ChartDataPoint = ChartDataPoint> {
+  /** SQL (string) — required; the executor runs this. */
+  query: string
+  /** Optional version-aware SQL; takes precedence over `query` when present. */
+  sql?: VersionedSql[]
+  queryParams?: Record<string, unknown>
+  optional?: boolean
+  tableCheck?: string | string[]
+  cachePolicy?: CachePolicy
+}
+
+/** Multi-query chart result (executed in parallel, keyed). */
+export interface MultiChartQueryResult {
+  queries: Array<{ key: string; query: string; optional?: boolean }>
+  cachePolicy?: CachePolicy
+}
+
+/** A chart builder maps params to a (multi-)query result. */
+export type ChartQueryBuilder<T extends ChartDataPoint = ChartDataPoint> = (
+  params: ChartQueryParams
+) => ChartQueryResult<T> | MultiChartQueryResult
+
+/**
+ * Lazy registry map. Empty in the foundation; populated by ported chart
+ * modules via `registerChartQuery` (or a bulk `registerChartQueries`).
+ */
+const chartRegistry = new Map<string, ChartQueryBuilder<ChartDataPoint>>()
+
+/** Register one chart builder. Last write wins (overwrite warns in dev). */
+export function registerChartQuery(
+  name: string,
+  builder: ChartQueryBuilder<ChartDataPoint>
+): void {
+  chartRegistry.set(name, builder)
+}
+
+/** Register a map of chart builders (spread a ported domain module). */
+export function registerChartQueries(
+  builders: Record<string, ChartQueryBuilder<ChartDataPoint>>
+): void {
+  for (const [name, builder] of Object.entries(builders)) {
+    chartRegistry.set(name, builder)
+  }
+}
+
+/** Build a chart query by name. Returns null if unknown. */
+export function getChartQuery(
+  chartName: string,
+  params: ChartQueryParams = {}
+): ChartQueryResult | MultiChartQueryResult | null {
+  const builder = chartRegistry.get(chartName)
+  if (!builder) return null
+  return builder(params)
+}
+
+/** All registered chart names. */
+export function getAvailableCharts(): string[] {
+  return Array.from(chartRegistry.keys())
+}
+
+/** Does a chart exist? */
+export function hasChart(chartName: string): boolean {
+  return chartRegistry.has(chartName)
+}

--- a/apps/dashboard-tsr/src/lib/api/query-executor.ts
+++ b/apps/dashboard-tsr/src/lib/api/query-executor.ts
@@ -1,0 +1,273 @@
+/**
+ * Server-side query executor for dashboard-tsr.
+ *
+ * Distills what apps/dashboard's route handlers (charts/[name]/route.ts and
+ * tables/[name]/route.ts) do into two reusable functions that TanStack Start
+ * `server.handlers` call. It:
+ *  - bridges the Worker env onto process.env (see server-env.ts),
+ *  - resolves the CH version per host,
+ *  - selects the right SQL via @chm/sql-builder's VersionedSql `since` rule,
+ *  - runs the query with the WEB client (getClient is invoked internally by
+ *    fetchData/fetchJsonEachRowAsNormalizedJson; this app only ships
+ *    @clickhouse/client-web and runs on Workers, so the auto-detected client
+ *    is the web client — getClient({ web: true }) is the explicit form used
+ *    where a raw client is needed),
+ *  - passes `optional`/`tableCheck` through for graceful missing-table handling.
+ *
+ * Auth / feature-permission gating and the schema-driven filter injection from
+ * the dashboard are DEFERRED (those modules are not ported yet).
+ */
+
+import type { FetchDataResult } from '@chm/clickhouse-client'
+import type { VersionedSql } from '@chm/sql-builder'
+import type { ClickHouseBindings } from '@/lib/api/server-env'
+import type { QueryConfig } from '@/lib/query-config'
+
+import {
+  fetchData,
+  fetchJsonEachRowAsNormalizedJson,
+  getClient,
+} from '@chm/clickhouse-client'
+import {
+  getClickHouseVersion,
+  selectVersionedSql,
+} from '@chm/clickhouse-client/clickhouse-version'
+import { error } from '@chm/logger'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { getSqlForDisplay } from '@/lib/query-config'
+
+/**
+ * Interval allowlist for time-bucketing charts. Inlined (not imported from
+ * @chm/types, which is not aliased in this app's tsconfig) so the executor
+ * can validate the `interval` query param against SQL injection. Mirrors
+ * @chm/types/clickhouse-interval VALID_INTERVALS.
+ */
+export const VALID_INTERVALS = [
+  'toStartOfMinute',
+  'toStartOfFiveMinutes',
+  'toStartOfTenMinutes',
+  'toStartOfFifteenMinutes',
+  'toStartOfHour',
+  'toStartOfDay',
+  'toStartOfWeek',
+  'toStartOfMonth',
+] as const
+
+export type ClickHouseInterval = (typeof VALID_INTERVALS)[number]
+
+export function isValidInterval(value: string): value is ClickHouseInterval {
+  return (VALID_INTERVALS as readonly string[]).includes(value)
+}
+
+/** Coerce a hostId (string|number) to a finite number or throw. */
+function toNumericHostId(hostId: number | string): number {
+  const n = typeof hostId === 'string' ? Number.parseInt(hostId, 10) : hostId
+  if (!Number.isFinite(n)) {
+    throw new Error(`Invalid hostId: ${String(hostId)}. Must be a number.`)
+  }
+  return n
+}
+
+/**
+ * Pick the SQL string to execute for the current CH version.
+ * Priority: VersionedSql[] (`sql`) → plain string (`sql`). The deprecated
+ * `variants` form is not handled here (port it if a ported config needs it).
+ */
+async function selectSqlForHost(
+  sql: string | VersionedSql[],
+  numericHostId: number
+): Promise<{ sql: string; version: string | undefined }> {
+  if (typeof sql === 'string') return { sql, version: undefined }
+  const version = await getClickHouseVersion(numericHostId)
+  return { sql: selectVersionedSql(sql, version), version: version?.raw }
+}
+
+/** Options shared by table/chart execution. */
+export interface ExecuteOptions {
+  /** Worker env binding — bridged onto process.env before querying. */
+  bindings?: ClickHouseBindings
+  /** IANA timezone for the ClickHouse session. */
+  timezone?: string
+}
+
+/** Result of executing a table QueryConfig. */
+export interface ExecuteTableResult<
+  T extends Record<string, unknown> = Record<string, unknown>,
+> {
+  result: FetchDataResult<T[]>
+  /** SQL actually executed (version-selected). */
+  executedSql: string
+  /** Resolved CH version, if a versioned SQL forced a lookup. */
+  clickhouseVersion?: string
+}
+
+/**
+ * Execute a table QueryConfig and return rows as objects. Resolves the right
+ * SQL for the host's CH version, then runs via `fetchData` (JSONEachRow).
+ */
+export async function executeTableConfig<
+  T extends Record<string, unknown> = Record<string, unknown>,
+>(
+  queryConfig: QueryConfig,
+  hostId: number | string,
+  queryParams: Record<string, unknown> | undefined,
+  options: ExecuteOptions = {}
+): Promise<ExecuteTableResult<T>> {
+  if (options.bindings) bridgeClickHouseEnv(options.bindings)
+
+  const numericHostId = toNumericHostId(hostId)
+  const { sql: executedSql, version } = await selectSqlForHost(
+    queryConfig.sql,
+    numericHostId
+  )
+
+  const result = await fetchData<T[]>({
+    query: executedSql,
+    query_params: queryParams,
+    hostId,
+    format: 'JSONEachRow',
+    clickhouse_settings: {
+      ...queryConfig.clickhouseSettings,
+      ...(options.timezone ? { session_timezone: options.timezone } : {}),
+    },
+    // Pass the config so fetchData can existence-check optional tables.
+    queryConfig: queryConfig.optional
+      ? {
+          name: queryConfig.name,
+          sql: executedSql,
+          tableCheck: queryConfig.tableCheck,
+          optional: true,
+        }
+      : undefined,
+  })
+
+  if (result.error) {
+    error(`[executeTableConfig:${queryConfig.name}]`, result.error)
+  }
+
+  return { result, executedSql, clickhouseVersion: version }
+}
+
+/** Result of executing a chart query — raw JSON string (no per-row parse). */
+export interface ExecuteChartResult {
+  /** ClickHouse rows serialized as a JSON array string (or 'null'). */
+  dataJson: string | null
+  metadata: Record<string, string | number>
+  error?: FetchDataResult<never>['error']
+  executedSql: string
+  clickhouseVersion?: string
+}
+
+/**
+ * Execute a single-query chart. Uses `fetchJsonEachRowAsNormalizedJson` so the
+ * handler can stream the JSON string straight into the response body without a
+ * parse/reserialize round-trip (matches the dashboard chart route).
+ */
+export async function executeChartQuery(
+  chartName: string,
+  sql: string | VersionedSql[],
+  hostId: number | string,
+  queryParams: Record<string, unknown> | undefined,
+  opts: ExecuteOptions & {
+    optional?: boolean
+    tableCheck?: string | string[]
+  } = {}
+): Promise<ExecuteChartResult> {
+  if (opts.bindings) bridgeClickHouseEnv(opts.bindings)
+
+  const numericHostId = toNumericHostId(hostId)
+  const { sql: executedSql, version } = await selectSqlForHost(
+    sql,
+    numericHostId
+  )
+
+  const result = await fetchJsonEachRowAsNormalizedJson({
+    query: executedSql,
+    query_params: queryParams,
+    hostId,
+    clickhouse_settings: opts.timezone
+      ? { session_timezone: opts.timezone }
+      : undefined,
+    queryConfig: opts.optional
+      ? {
+          name: chartName,
+          sql: executedSql,
+          tableCheck: opts.tableCheck,
+          optional: true,
+        }
+      : undefined,
+  })
+
+  if (result.error) {
+    error(`[executeChartQuery:${chartName}]`, result.error)
+  }
+
+  return {
+    dataJson: result.dataJson,
+    metadata: result.metadata,
+    error: result.error,
+    executedSql,
+    clickhouseVersion: version,
+  }
+}
+
+/**
+ * Execute a multi-query chart: run every keyed query in parallel and return a
+ * `{ key: dataJson }` map plus the first error. Mirrors the dashboard's
+ * handleMultiQueryChart, minus the response shaping (left to the handler).
+ */
+export async function executeMultiChartQuery(
+  queries: Array<{ key: string; query: string; optional?: boolean }>,
+  hostId: number | string,
+  opts: ExecuteOptions = {}
+): Promise<{
+  results: Array<{
+    key: string
+    dataJson: string | null
+    error?: FetchDataResult<never>['error']
+  }>
+}> {
+  if (opts.bindings) bridgeClickHouseEnv(opts.bindings)
+
+  const results = await Promise.all(
+    queries.map(async (q) => {
+      try {
+        const r = await fetchJsonEachRowAsNormalizedJson({
+          query: q.query,
+          hostId,
+          clickhouse_settings: opts.timezone
+            ? { session_timezone: opts.timezone }
+            : undefined,
+        })
+        return { key: q.key, dataJson: r.dataJson ?? 'null', error: r.error }
+      } catch (err) {
+        return {
+          key: q.key,
+          dataJson: null,
+          error: {
+            type: 'query_error' as const,
+            message: err instanceof Error ? err.message : 'Unknown error',
+          },
+        }
+      }
+    })
+  )
+
+  return { results }
+}
+
+/**
+ * Get a raw web ClickHouse client for the given host. Thin wrapper over
+ * `getClient({ web: true, hostId })` for callers that need direct client
+ * access (e.g. one-off introspection) outside the fetchData helpers. Bridges
+ * the Worker env first when provided.
+ */
+export async function getWebClient(
+  hostId: number,
+  bindings?: ClickHouseBindings
+) {
+  if (bindings) bridgeClickHouseEnv(bindings)
+  return getClient({ web: true, hostId })
+}
+
+export { getSqlForDisplay }

--- a/apps/dashboard-tsr/src/lib/api/server-env.ts
+++ b/apps/dashboard-tsr/src/lib/api/server-env.ts
@@ -1,0 +1,45 @@
+/**
+ * Server env bridge for ClickHouse access on Cloudflare Workers.
+ *
+ * `@chm/clickhouse-client` resolves host config from `process.env.CLICKHOUSE_*`
+ * (see packages/clickhouse-client/.../env-schema.ts — it reads `process.env`
+ * directly and caches the result). In the Next dashboard those vars are present
+ * on `process.env` ambiently. In this TanStack Start / Workers app the canonical
+ * source is the Worker binding (`import { env } from 'cloudflare:workers'`), so
+ * we must copy the CLICKHOUSE_* values onto `process.env` before the first
+ * query — otherwise the client sees no hosts.
+ *
+ * Call `bridgeClickHouseEnv(env)` at the top of every CH-querying route handler,
+ * passing the Worker `env` binding. It is idempotent and cheap.
+ *
+ * NOTE: the client caches the parsed env after first read. The bridge runs
+ * before any client call within a request, and Worker isolates are short-lived,
+ * so the cache reflects the bound values. If you ever rotate a secret you must
+ * redeploy (same constraint as the Next app — see secret-rotation knowledge).
+ */
+
+const CLICKHOUSE_ENV_KEYS = [
+  'CLICKHOUSE_HOST',
+  'CLICKHOUSE_USER',
+  'CLICKHOUSE_PASSWORD',
+  'CLICKHOUSE_NAME',
+  'CLICKHOUSE_MAX_EXECUTION_TIME',
+] as const
+
+export type ClickHouseBindings = Record<string, string | undefined>
+
+/**
+ * Copy CLICKHOUSE_* values from the Worker `env` binding onto `process.env`
+ * so `@chm/clickhouse-client` can read them. Only sets keys that are present
+ * on the binding and not already set, to avoid clobbering a local `.dev.vars`
+ * / process env during `vite dev` on node.
+ */
+export function bridgeClickHouseEnv(bindings: ClickHouseBindings): void {
+  if (typeof process === 'undefined' || !process.env) return
+  for (const key of CLICKHOUSE_ENV_KEYS) {
+    const value = bindings[key]
+    if (value != null && value !== '' && process.env[key] == null) {
+      process.env[key] = value
+    }
+  }
+}

--- a/apps/dashboard-tsr/src/lib/api/table-registry.ts
+++ b/apps/dashboard-tsr/src/lib/api/table-registry.ts
@@ -1,0 +1,96 @@
+/**
+ * Table/query-config registry for dashboard-tsr.
+ *
+ * Ported from apps/dashboard/lib/api/table-registry.ts. Maps a config `name`
+ * to its QueryConfig and resolves a runnable query (SQL + params) from URL
+ * search params.
+ *
+ * Foundation simplifications:
+ * - The source list is `queries` from `@/lib/query-config` (empty until the
+ *   54 configs are ported). `registerTableConfig` lets ported modules add
+ *   configs without editing this file.
+ * - The dashboard's schema-driven `filterSchema` WHERE-clause injection
+ *   (filters/url-state + filters/where-builder) is DEFERRED — those modules
+ *   are not ported. Until then, params come from defaultParams + raw search
+ *   params, exactly like the dashboard's non-filterSchema branch.
+ */
+
+import type { QueryConfig } from '@/lib/query-config'
+
+import { getSqlForDisplay, queries } from '@/lib/query-config'
+
+/** Params for building a table query. */
+export interface TableQueryParams {
+  /** Host id to run against. */
+  hostId: number | string
+  /** URL search params (filters + query params), minus hostId. */
+  searchParams?: Record<string, string>
+}
+
+/** Result of resolving a table query. */
+export interface TableQueryResult {
+  /** SQL string for display; execution re-selects the versioned SQL. */
+  query: string
+  /** Params to substitute (`{name:Type}`). */
+  queryParams?: Record<string, unknown>
+  /** The resolved config (passed to the executor for version selection). */
+  queryConfig: QueryConfig
+}
+
+/**
+ * Lazy registry seeded from `queries`. Ported domain modules can also call
+ * `registerTableConfig` at import time to add configs not in the aggregate.
+ */
+const tableRegistry = new Map<string, QueryConfig>(
+  queries.map((config) => [config.name, config])
+)
+
+/** Register one config (overwrites by name). */
+export function registerTableConfig(config: QueryConfig): void {
+  tableRegistry.set(config.name, config)
+}
+
+/** Register many configs at once. */
+export function registerTableConfigs(configs: QueryConfig[]): void {
+  for (const config of configs) tableRegistry.set(config.name, config)
+}
+
+/**
+ * Resolve a runnable table query from a config name + URL search params.
+ * Returns null if the name is unknown.
+ */
+export function getTableQuery(
+  name: string,
+  params: TableQueryParams
+): TableQueryResult | null {
+  const queryConfig = tableRegistry.get(name)
+  if (!queryConfig) return null
+
+  // Start from the config's default params, then layer URL search params.
+  const queryParams: Record<string, unknown> = {
+    ...(queryConfig.defaultParams ?? {}),
+  }
+  if (params.searchParams) Object.assign(queryParams, params.searchParams)
+
+  return {
+    // Display string; the executor calls selectVersionedSql for execution.
+    query: getSqlForDisplay(queryConfig.sql),
+    queryParams: Object.keys(queryParams).length > 0 ? queryParams : undefined,
+    queryConfig,
+  }
+}
+
+/** Does a table config exist? */
+export function hasTable(name: string): boolean {
+  return tableRegistry.has(name)
+}
+
+/** All registered config names, sorted. */
+export function getAvailableTables(): string[] {
+  return Array.from(tableRegistry.keys()).sort()
+}
+
+/** Get a raw config by name. */
+export function getTableConfig(name: string): QueryConfig | undefined {
+  return tableRegistry.get(name)
+}

--- a/apps/dashboard-tsr/src/lib/query-config/index.ts
+++ b/apps/dashboard-tsr/src/lib/query-config/index.ts
@@ -1,0 +1,9 @@
+import type { QueryConfig } from './types'
+
+export type { QueryConfig } from './types'
+
+export { getSqlForDisplay } from './types'
+
+// Flat list of all table QueryConfigs. Empty in the foundation; the per-domain
+// configs (54 in the Next app) are a later fan-out. table-registry maps this.
+export const queries: QueryConfig[] = []

--- a/apps/dashboard-tsr/src/lib/query-config/types.ts
+++ b/apps/dashboard-tsr/src/lib/query-config/types.ts
@@ -1,0 +1,110 @@
+/**
+ * QueryConfig types for the TanStack Start dashboard (dashboard-tsr).
+ *
+ * Ported from apps/dashboard/types/query-config.ts, trimmed to the
+ * *foundation* surface: the fields the server-side query executor and the
+ * registries actually consume. The dashboard's full QueryConfig couples to
+ * web-app-only types (ChartProps, CustomSortingFnNames, FeaturePermission,
+ * FilterSchema, ColumnFormat) that belong to the not-yet-ported component /
+ * data-table layer. Those UI-formatting fields are DEFERRED and intentionally
+ * omitted here so this module has zero dependencies on un-ported app code.
+ *
+ * VersionedSql / QueryConfigVariant / getAllSqlStrings come from
+ * @chm/sql-builder (aliased to source in tsconfig.json) so this app never
+ * depends on the dashboard package.
+ */
+
+import type { ClickHouseSettings } from '@clickhouse/client'
+
+import type { QueryConfigVariant, VersionedSql } from '@chm/sql-builder'
+
+// Re-export the version-compat SQL primitives from the shared package so
+// `@/lib/query-config/types` consumers can import them from one place,
+// mirroring the dashboard's `@/types/query-config` re-export.
+export {
+  getAllSqlStrings,
+  type QueryConfigVariant,
+  type VersionedSql,
+} from '@chm/sql-builder'
+
+/**
+ * Foundation QueryConfig.
+ *
+ * Generic over the column-name tuple, exactly like the dashboard. Only the
+ * fields the executor / registry need are kept:
+ * - identity + SQL (name, sql, columns)
+ * - version compat (sql: VersionedSql[] | string, deprecated `variants`)
+ * - execution knobs (defaultParams, clickhouseSettings, optional, tableCheck)
+ * - validation toggle (disableSqlValidation)
+ *
+ * To extend with UI-formatting later (columnFormats, filterSchema, card, …),
+ * add them here as the corresponding component layer is ported. Keeping them
+ * out now avoids importing un-ported app types.
+ */
+export interface QueryConfig<TColumns extends readonly string[] = string[]> {
+  /** Unique registry key. */
+  name: string
+  /** Optional human description. */
+  description?: string
+  /**
+   * SQL — a plain string (version-independent) or VersionedSql[] (ordered
+   * oldest→newest; the executor picks the highest `since` <= CH version).
+   */
+  sql: string | VersionedSql[]
+  /** Result column names (drives row typing + display ordering). */
+  columns: TColumns
+  /**
+   * Default ClickHouse query parameters, e.g. `{ database: 'default' }` for
+   * `WHERE database = {database:String}`. Merged under URL search params.
+   */
+  defaultParams?: Record<string, string | number | boolean>
+  /** Per-query ClickHouse settings (e.g. result limits, timezone). */
+  clickhouseSettings?: ClickHouseSettings
+  /**
+   * Auto-refresh interval (ms) for client polling. Foundation carries it so
+   * the later client layer can read it; the server executor ignores it.
+   */
+  refreshInterval?: number
+  /**
+   * Mark the query as optional — its table(s) may not exist (e.g.
+   * system.error_log, system.backup_log, system.zookeeper). The executor
+   * passes this through to fetchData so a missing table degrades gracefully
+   * instead of erroring.
+   */
+  optional?: boolean
+  /**
+   * Explicit table(s) to existence-check when `optional`. If omitted, tables
+   * are auto-extracted from the SQL by the underlying validator.
+   */
+  tableCheck?: string | string[]
+  /** Disable SQL validation (used by the query-config test suite). */
+  disableSqlValidation?: boolean
+  /** Optional docs URL surfaced on query error. */
+  docs?: string
+  /**
+   * @deprecated Use `sql: VersionedSql[]`. Legacy min/max version variants,
+   * kept only so ported configs that still use it resolve correctly.
+   */
+  variants?: QueryConfigVariant[]
+}
+
+/** Map a column-name tuple to a permissive row-data shape. */
+export type QueryConfigRowData<T extends readonly string[]> = {
+  [K in T[number]]: unknown
+}
+
+/** Extract the row-data shape from a QueryConfig. */
+export type QueryConfigToRowData<T extends QueryConfig> = QueryConfigRowData<
+  T['columns']
+>
+
+/**
+ * Get a single SQL string for *display* (not execution). Returns the string
+ * directly, or the newest (last) entry of a VersionedSql[]. Execution-time
+ * version selection happens in the executor via `selectVersionedSql`.
+ */
+export function getSqlForDisplay(sql: string | VersionedSql[]): string {
+  if (typeof sql === 'string') return sql
+  if (sql.length === 0) return ''
+  return sql[sql.length - 1].sql
+}

--- a/apps/dashboard-tsr/tsconfig.json
+++ b/apps/dashboard-tsr/tsconfig.json
@@ -12,6 +12,9 @@
       "@chm/clickhouse-client/runtime/cloudflare-workers": [
         "../../packages/clickhouse-client/src/runtime/cloudflare-workers.ts"
       ],
+      "@chm/clickhouse-client/clickhouse-version": [
+        "../../packages/clickhouse-client/src/clickhouse-version.ts"
+      ],
       "@clickhouse/client": ["./node_modules/@clickhouse/client"],
       "@clickhouse/client-web": [
         "./node_modules/@clickhouse/client-web/dist/index.d.ts"

--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -71,6 +71,9 @@ export default defineConfig({
       '@chm/clickhouse-client/runtime/cloudflare-workers': r(
         '../../packages/clickhouse-client/src/runtime/cloudflare-workers.ts'
       ),
+      '@chm/clickhouse-client/clickhouse-version': r(
+        '../../packages/clickhouse-client/src/clickhouse-version.ts'
+      ),
       // The node @clickhouse/client (node:os/node:stream/TCP) is a dead static
       // import in clickhouse-client.ts (routes force web:true). Alias it to an
       // empty stub so it resolves in the bundle on BOTH targets.


### PR DESCRIPTION
Part of #1396 · epic #1392. Server-side query foundation for registry-backed routes: QueryConfig types + empty aggregate, chart/table registries, version-aware query-executor (getClient web:true), server-env bridge. Foundation-only (54 domain configs = later fan-out). Build + prerender green. 🤖 workflow + adversarial verify, reconciled to foundation-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added support for chart query registration and dynamic execution with configurable parameters and caching policies.
  * Implemented table query configuration and registry system for flexible query management.
  * Introduced server-side query execution layer supporting multi-query operations and version-aware SQL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->