### PR TITLE
feat(dashboard-tsr): port ~22 Next API routes to TanStack Start (Phase 5, #1396)

### DIFF
--- a/apps/dashboard-tsr/scripts/route-port-contract.md
+++ b/apps/dashboard-tsr/scripts/route-port-contract.md
@@ -1,0 +1,61 @@
+# Next → TanStack Start: API route port contract
+
+Reusable spec for porting `apps/dashboard/app/api/**/route.ts` →
+`apps/dashboard-tsr/src/routes/api/**/*.ts`. Mechanical; follow exactly.
+
+## Wrapper
+```ts
+import { createFileRoute } from '@tanstack/react-router'
+export const Route = createFileRoute('/api/v1/<path>')({
+  server: { handlers: { GET: async ({ request, params }) => { /* body */ } } },
+})
+```
+- `export const GET/POST = ...` → a `handlers.GET/POST` entry.
+- Drop `export const dynamic = 'force-dynamic'` (Next-only).
+- File-route path string MUST equal the URL (`/api/v1/...`).
+
+## Dynamic segments
+- `[name]` → `$name`, `[key]` → `$key` (dir + filename). Read via `params.name`.
+- `[...slug]` → `$` splat (defer these — usually proxy routes).
+
+## ClickHouse env bridge (REQUIRED before any fetchData/getClient)
+```ts
+import { env } from 'cloudflare:workers'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+// inside handler, before querying:
+bridgeClickHouseEnv(env as Record<string, string | undefined>)
+```
+Then `fetchData({ query, hostId, format, query_params, queryConfig })` works
+unchanged. For ad-hoc clients use `getWebClient(hostId, env)` from
+`@/lib/api/query-executor`. For registry configs use `executeTableConfig` /
+`executeChartQuery` with `{ bindings: env }`.
+
+## Auth / permissions — DROP at route level
+- Remove `import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'`
+  and its call/`permissionResponse` block. (Pulls Clerk-Next + js-yaml + smol-toml.)
+- Per-route auth is centralized in the request **middleware (#1397)**. Precedent:
+  merged `charts/$name.ts` / `tables/$name.ts` call no per-route auth.
+- Keep `serverQueryConfig` itself (it still feeds `fetchData`); only drop the
+  `?.permission` → `authorizeFeatureRequest` usage.
+
+## Shared helpers — already exist in TSR (import unchanged)
+`@/lib/api/error-handler` (`withApiHandler`, `createValidationError`,
+`createErrorResponse`, `getHostIdFromParams`), `@/lib/api/shared/response-builder`
+(`createSuccessResponse`), `@/lib/api/shared/status-code-mapper`
+(`mapErrorTypeToStatusCode`), `@/lib/api/shared/validators` (`validateSearchParams`,
+`getAndValidateHostId`, `validateDataRequest`, `sanitizeQueryParams`),
+`@/lib/api/table-registry`, `@/lib/api/chart-registry`, `@/lib/api/types`.
+
+`withApiHandler(fn, ctx)` returns `(request) => Promise<Response>`; expose as
+`GET: ({ request }) => wrapped(request)`. Use it for routes that used it in Next;
+otherwise inline try/catch returning `{ success, data|error, metadata }`.
+
+## Co-located non-route helpers
+Next co-locates `validators/` + `utils/` next to `route.ts`. TSR routes dir
+can't hold arbitrary files → move them to `src/lib/api/<route>/` and fix imports.
+
+## Fail loud
+If a route's core depends on a module ABSENT in TSR (Clerk server, Postgres,
+D1 conversation store, agent infra), DO NOT fake it — report it deferred with
+the missing dep. Deferred set: agent*, agents/*, conversations*, auth/api-key,
+browser-connections/*, peerdb/$ (splat), health/webhook, cron/*, clean, init.

--- a/apps/dashboard-tsr/src/lib/api/data/cache-manager.ts
+++ b/apps/dashboard-tsr/src/lib/api/data/cache-manager.ts
@@ -1,0 +1,201 @@
+/**
+ * Cache Manager for Dashboard Queries
+ *
+ * Manages in-memory caching of valid dashboard queries to avoid repeated
+ * database lookups. Uses time-based cache invalidation (TTL).
+ *
+ * Ported from apps/dashboard/app/api/v1/data/utils/cache-manager.ts —
+ * pure in-memory, framework-agnostic (no imports to fix).
+ *
+ * @module lib/api/data/cache-manager
+ */
+
+/** Cache entry for dashboard queries with timestamp */
+interface CacheEntry {
+  readonly queries: Set<string>
+  readonly timestamp: number
+}
+
+/** Cache storage map */
+const cache = new Map<string, CacheEntry>()
+
+/** Cache timestamp for tracking last invalidation */
+let cacheTimestamp = 0
+
+/** Default cache TTL: 5 minutes */
+const DEFAULT_CACHE_TTL = 5 * 60 * 1000
+
+/** Current TTL value (can be configured) */
+let currentCacheTTL = DEFAULT_CACHE_TTL
+
+/**
+ * Get the current cache TTL in milliseconds
+ */
+export function getCacheTTL(): number {
+  return currentCacheTTL
+}
+
+/**
+ * Set a custom cache TTL (for testing or configuration)
+ *
+ * @param ttl - Time to live in milliseconds
+ */
+export function setCacheTTL(ttl: number): void {
+  currentCacheTTL = ttl
+}
+
+/**
+ * Reset the cache TTL to default
+ */
+export function resetCacheTTL(): void {
+  currentCacheTTL = DEFAULT_CACHE_TTL
+}
+
+/**
+ * Check if the cache has expired and needs to be cleared
+ *
+ * @returns True if cache is stale and should be cleared
+ */
+function isCacheExpired(): boolean {
+  const now = Date.now()
+  return now - cacheTimestamp > currentCacheTTL
+}
+
+/**
+ * Clear expired cache entries
+ * Called automatically when accessing cached data
+ */
+function clearExpiredCache(): void {
+  if (isCacheExpired()) {
+    cache.clear()
+    cacheTimestamp = Date.now()
+  }
+}
+
+/**
+ * Get cached dashboard queries for a specific host
+ *
+ * @param hostId - The host identifier
+ * @returns Set of valid queries or undefined if not cached/expired
+ *
+ * @example
+ * ```ts
+ * const queries = getCachedDashboardQueries(0)
+ * if (queries?.has('SELECT count() FROM system.tables')) {
+ *   // Query is valid
+ * }
+ * ```
+ */
+export function getCachedDashboardQueries(
+  hostId: number
+): Set<string> | undefined {
+  clearExpiredCache()
+
+  const cacheKey = String(hostId)
+  const entry = cache.get(cacheKey)
+
+  return entry?.queries
+}
+
+/**
+ * Update the cache with new queries for a specific host
+ *
+ * @param hostId - The host identifier
+ * @param queries - Set of valid queries to cache
+ *
+ * @example
+ * ```ts
+ * const queries = new Set(['SELECT count() FROM system.tables'])
+ * updateDashboardQueryCache(0, queries)
+ * ```
+ */
+export function updateDashboardQueryCache(
+  hostId: number,
+  queries: Set<string>
+): void {
+  const cacheKey = String(hostId)
+
+  cache.set(cacheKey, {
+    queries: new Set(queries), // Create a copy to prevent external mutation
+    timestamp: Date.now(),
+  })
+}
+
+/**
+ * Clear all cached dashboard queries
+ * Useful for testing or manual cache invalidation
+ *
+ * @example
+ * ```ts
+ * clearAllCache()
+ * ```
+ */
+export function clearAllCache(): void {
+  cache.clear()
+  cacheTimestamp = Date.now()
+}
+
+/**
+ * Clear cache for a specific host
+ *
+ * @param hostId - The host identifier
+ *
+ * @example
+ * ```ts
+ * clearHostCache(0)
+ * ```
+ */
+export function clearHostCache(hostId: number): void {
+  const cacheKey = String(hostId)
+  cache.delete(cacheKey)
+}
+
+/**
+ * Get cache statistics for monitoring/debugging
+ *
+ * @returns Object with cache stats
+ *
+ * @example
+ * ```ts
+ * const stats = getCacheStats()
+ * console.log(`Cache entries: ${stats.entryCount}, TTL: ${stats.ttl}ms`)
+ * ```
+ */
+export function getCacheStats(): {
+  readonly entryCount: number
+  readonly ttl: number
+  readonly lastClear: number
+  readonly entries: ReadonlyArray<{
+    readonly hostId: string
+    readonly queryCount: number
+  }>
+} {
+  return {
+    entryCount: cache.size,
+    ttl: currentCacheTTL,
+    lastClear: cacheTimestamp,
+    entries: Array.from(cache.entries()).map(([hostId, entry]) => ({
+      hostId,
+      queryCount: entry.queries.size,
+    })),
+  }
+}
+
+/**
+ * Check if a specific query is cached for a host
+ *
+ * @param hostId - The host identifier
+ * @param query - The query string to check
+ * @returns True if the query is in the cache
+ *
+ * @example
+ * ```ts
+ * if (isQueryCached(0, 'SELECT count() FROM system.tables')) {
+ *   // Query is cached
+ * }
+ * ```
+ */
+export function isQueryCached(hostId: number, query: string): boolean {
+  const queries = getCachedDashboardQueries(hostId)
+  return queries?.has(query) ?? false
+}

--- a/apps/dashboard-tsr/src/lib/api/data/dashboard-query-validator.ts
+++ b/apps/dashboard-tsr/src/lib/api/data/dashboard-query-validator.ts
@@ -1,0 +1,119 @@
+/**
+ * Dashboard Query Validator
+ *
+ * Validates that queries exist in the dashboard tables before execution.
+ * This prevents arbitrary SQL execution from clients.
+ *
+ * Only queries stored in the clickhouse_monitoring_custom_dashboard table
+ * are allowed to be executed without a queryConfig.
+ *
+ * Ported from apps/dashboard/app/api/v1/data/validators/dashboard-query-validator.ts.
+ * Import paths fixed: co-located cache-manager moved alongside this file.
+ * SECURITY behavior preserved exactly (fail-closed allowlist).
+ *
+ * @module lib/api/data/dashboard-query-validator
+ */
+
+import { fetchData } from '@chm/clickhouse-client'
+import { error } from '@chm/logger'
+import { DASHBOARD_CHARTS_TABLE } from '@/lib/app-tables'
+import { getCachedDashboardQueries } from './cache-manager'
+
+/** Dashboard table name for query validation */
+export const DASHBOARD_QUERIES_TABLE = DASHBOARD_CHARTS_TABLE
+
+/**
+ * Validation result for dashboard queries
+ */
+export interface DashboardQueryValidationResult {
+  readonly valid: boolean
+  readonly error?: {
+    readonly type: string
+    readonly message: string
+  }
+}
+
+/**
+ * Validates that a query exists in the dashboard tables
+ * Uses cache to avoid repeated lookups for the same host
+ *
+ * SECURITY: This prevents execution of arbitrary SQL from clients by only
+ * allowing queries that have been pre-registered in the dashboard tables.
+ *
+ * @param query - The SQL query to validate
+ * @param hostId - The host identifier to validate against
+ * @returns Validation result with valid flag and optional error
+ *
+ * @example
+ * ```ts
+ * const result = await validateDashboardQuery('SELECT count() FROM system.tables', 0)
+ * if (!result.valid) {
+ *   return createErrorResponse(result.error!, 403)
+ * }
+ * ```
+ */
+export async function validateDashboardQuery(
+  query: string,
+  hostId: number
+): Promise<DashboardQueryValidationResult> {
+  try {
+    // Check cache first to avoid repeated database queries
+    const cachedQueries = getCachedDashboardQueries(hostId)
+    if (cachedQueries?.has(query)) {
+      return { valid: true }
+    }
+
+    // Query the dashboard table to verify this query exists
+    const result = await fetchData({
+      query: `SELECT query FROM ${DASHBOARD_QUERIES_TABLE}`,
+      format: 'JSONEachRow',
+      hostId,
+    })
+
+    if (result.error) {
+      // Table doesn't exist or other error - fail closed for security
+      error('[Dashboard Query Validation] Error:', result.error)
+      return {
+        valid: false,
+        error: {
+          type: 'permission_error',
+          message:
+            'Query validation failed: dashboard table not accessible. Use /api/v1/charts/[name] or /api/v1/tables/[name] for registry-based queries.',
+        },
+      }
+    }
+
+    // Extract and cache queries
+    const queries = new Set<string>()
+    for (const row of result.data as Array<{ query: string }>) {
+      queries.add(row.query)
+    }
+
+    // Update cache with new queries
+    const { updateDashboardQueryCache } = await import('./cache-manager')
+    updateDashboardQueryCache(hostId, queries)
+
+    // Check if the query exists in the table
+    if (!queries.has(query)) {
+      return {
+        valid: false,
+        error: {
+          type: 'permission_error',
+          message:
+            'Query not found in dashboard tables. Use /api/v1/charts/[name] or /api/v1/tables/[name] for registry-based queries.',
+        },
+      }
+    }
+
+    return { valid: true }
+  } catch (err) {
+    error('[Dashboard Query Validation] Unexpected error:', err)
+    return {
+      valid: false,
+      error: {
+        type: 'permission_error',
+        message: 'Query validation failed due to an unexpected error',
+      },
+    }
+  }
+}

--- a/apps/dashboard-tsr/src/routes/api/v1/actions.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/actions.ts
@@ -1,0 +1,250 @@
+/**
+ * Actions API Endpoint
+ * POST /api/v1/actions?hostId=0
+ *
+ * Executes ClickHouse actions: killQuery, optimizeTable, querySettings.
+ * Ported from apps/dashboard/app/api/v1/actions/route.ts.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { z } from 'zod'
+import { env } from 'cloudflare:workers'
+import { fetchData } from '@chm/clickhouse-client'
+import { ErrorLogger, log } from '@chm/logger'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+
+const ROUTE_CONTEXT = { route: '/api/v1/actions', method: 'POST' }
+
+// --- Inline ActionSchema (not yet ported to TSR lib/api/schemas) ---
+
+const KillQueryActionSchema = z.object({
+  action: z.literal('killQuery'),
+  params: z.object({
+    queryId: z.string().min(1, 'queryId must not be empty'),
+  }),
+})
+
+const OptimizeTableActionSchema = z.object({
+  action: z.literal('optimizeTable'),
+  params: z.object({
+    table: z.string().min(1, 'table must not be empty'),
+  }),
+})
+
+const QuerySettingsActionSchema = z.object({
+  action: z.literal('querySettings'),
+  params: z.object({
+    queryId: z.string().min(1, 'queryId must not be empty'),
+  }),
+})
+
+const ActionSchema = z.discriminatedUnion('action', [
+  KillQueryActionSchema,
+  OptimizeTableActionSchema,
+  QuerySettingsActionSchema,
+])
+
+type Action = z.infer<typeof ActionSchema>
+
+// --- Helpers ---
+
+/**
+ * Valid SQL identifier pattern for table names.
+ * Allows: database.table, table, `quoted.table`
+ */
+const VALID_TABLE_IDENTIFIER =
+  /^(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_]*)(\.[\s]*(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_]*))?$/
+
+function isValidTableIdentifier(table: string): boolean {
+  if (!table || table.length > 256) return false
+  return VALID_TABLE_IDENTIFIER.test(table.trim())
+}
+
+function generateRequestId(): string {
+  return Math.random().toString(36).slice(2, 10)
+}
+
+interface ActionResult {
+  success: boolean
+  message: string
+  data?: unknown
+}
+
+async function handleKillQuery(
+  hostId: number,
+  queryId: string
+): Promise<ActionResult> {
+  const { error } = await fetchData({
+    query: `KILL QUERY WHERE query_id = {queryId: String}`,
+    query_params: { queryId },
+    hostId,
+  })
+
+  if (error) {
+    ErrorLogger.logError(new Error(error.message), {
+      action: 'killQuery',
+      queryId,
+      errorType: error.type,
+    })
+    return {
+      success: false,
+      message: `Failed to kill query ${queryId}: ${error.message}`,
+    }
+  }
+
+  return { success: true, message: `Killed query ${queryId}` }
+}
+
+async function handleOptimizeTable(
+  hostId: number,
+  table: string
+): Promise<ActionResult> {
+  if (!isValidTableIdentifier(table)) {
+    ErrorLogger.logError(new Error('Invalid table identifier'), {
+      action: 'optimizeTable',
+      table,
+      reason: 'Failed identifier validation',
+    })
+    return {
+      success: false,
+      message: `Invalid table identifier: ${table}. Table names must be alphanumeric with optional database prefix.`,
+    }
+  }
+
+  const { error } = await fetchData({
+    query: `OPTIMIZE TABLE ${table}`,
+    hostId,
+  })
+
+  if (error) {
+    ErrorLogger.logError(new Error(error.message), {
+      action: 'optimizeTable',
+      table,
+      errorType: error.type,
+    })
+    return {
+      success: false,
+      message: `Failed to optimize table ${table}: ${error.message}`,
+    }
+  }
+
+  return { success: true, message: `Running query optimize table ${table}` }
+}
+
+async function handleQuerySettings(
+  hostId: number,
+  queryId: string
+): Promise<ActionResult> {
+  const { data, error } = await fetchData<{ Settings: string }[]>({
+    query: `SELECT Settings FROM system.processes WHERE query_id = {queryId: String}`,
+    query_params: { queryId },
+    hostId,
+  })
+
+  if (error) {
+    ErrorLogger.logError(new Error(error.message), {
+      action: 'querySettings',
+      queryId,
+      errorType: error.type,
+    })
+    return {
+      success: false,
+      message: `Failed to get query settings ${queryId}: ${error.message}`,
+    }
+  }
+
+  return { success: true, message: JSON.stringify(data), data }
+}
+
+// --- Route ---
+
+export const Route = createFileRoute('/api/v1/actions')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const requestId = generateRequestId()
+
+        const url = new URL(request.url)
+        const hostIdRaw = url.searchParams.get('hostId')
+
+        if (hostIdRaw === null || hostIdRaw === '') {
+          return Response.json(
+            { success: false, message: 'Missing required parameter: hostId' },
+            { status: 400 }
+          )
+        }
+
+        const hostId = Number.parseInt(hostIdRaw, 10)
+        if (!Number.isInteger(hostId) || hostId < 0) {
+          return Response.json(
+            {
+              success: false,
+              message: 'Invalid parameter: hostId must be a non-negative integer',
+            },
+            { status: 400 }
+          )
+        }
+
+        let body: unknown
+        try {
+          body = await request.json()
+        } catch {
+          return Response.json(
+            { success: false, message: 'Invalid JSON body' },
+            { status: 400 }
+          )
+        }
+
+        const parseResult = ActionSchema.safeParse(body)
+        if (!parseResult.success) {
+          const errorMessages = parseResult.error.issues
+            .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+            .join('; ')
+          return Response.json(
+            {
+              success: false,
+              message: `Invalid action request: ${errorMessages}`,
+            },
+            { status: 400 }
+          )
+        }
+
+        const action: Action = parseResult.data
+
+        log('[AUDIT] Action requested', {
+          requestId,
+          action: action.action,
+          hostId,
+          params: action.params,
+        })
+
+        let result: ActionResult
+
+        switch (action.action) {
+          case 'killQuery':
+            result = await handleKillQuery(hostId, action.params.queryId)
+            break
+
+          case 'optimizeTable':
+            result = await handleOptimizeTable(hostId, action.params.table)
+            break
+
+          case 'querySettings':
+            result = await handleQuerySettings(hostId, action.params.queryId)
+            break
+        }
+
+        return new Response(JSON.stringify(result), {
+          status: result.success ? 200 : 500,
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Request-ID': requestId,
+          },
+        })
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/cluster-counts/$key.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/cluster-counts/$key.ts
@@ -1,0 +1,289 @@
+/**
+ * Cluster count API endpoint
+ * GET /api/v1/cluster-counts/$key
+ *
+ * Returns the count for a specific cluster metric based on a pre-defined query.
+ * Queries use clusterAllReplicas() to aggregate data across all nodes.
+ *
+ * SECURITY: No raw SQL is accepted from clients.
+ * Only countKey identifiers are used to look up pre-defined queries.
+ *
+ * Required parameters:
+ * - key (path): Count key from cluster-count-registry
+ * - cluster (query): Cluster name to query
+ * - hostId (query): Host to execute the query on
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { fetchData } from '@chm/clickhouse-client'
+import { debug, error, generateRequestId } from '@chm/logger'
+import {
+  getClusterCountQuery,
+  hasClusterCountKey,
+} from '@/lib/api/cluster-count-registry'
+import { createErrorResponse } from '@/lib/api/error-handler'
+import { HostIdSchema, MenuCountKeySchema } from '@/lib/api/schemas'
+import {
+  CacheControl,
+  createSuccessResponse,
+} from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+
+const ROUTE_CONTEXT = { route: '/api/v1/cluster-counts/$key', method: 'GET' }
+
+interface ClusterCountResponse {
+  readonly count: number | null
+}
+
+async function handler(request: Request, params: { key: string }): Promise<Response> {
+  const requestId = generateRequestId()
+
+  try {
+    const countKey = params.key
+    const url = new URL(request.url)
+    const searchParams = url.searchParams
+
+    // Validate count key format
+    const countKeyResult = MenuCountKeySchema.safeParse(countKey)
+    if (!countKeyResult.success) {
+      error(
+        '[GET /api/v1/cluster-counts] Invalid count key format:',
+        countKey,
+        { requestId }
+      )
+      const errorResponse = createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: `Invalid count key format: ${countKey}`,
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+      const headers = new Headers(errorResponse.headers)
+      headers.set('X-Request-ID', requestId)
+      return new Response(errorResponse.body, {
+        status: errorResponse.status,
+        statusText: errorResponse.statusText,
+        headers,
+      })
+    }
+
+    // Validate count key exists in registry
+    if (!hasClusterCountKey(countKey)) {
+      error(
+        '[GET /api/v1/cluster-counts] Count key not registered:',
+        undefined,
+        { requestId, countKey }
+      )
+      const errorResponse = createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: `Count key not found: ${countKey}`,
+        },
+        404,
+        ROUTE_CONTEXT
+      )
+      const headers = new Headers(errorResponse.headers)
+      headers.set('X-Request-ID', requestId)
+      return new Response(errorResponse.body, {
+        status: errorResponse.status,
+        statusText: errorResponse.statusText,
+        headers,
+      })
+    }
+
+    // Validate cluster parameter (required for cluster counts)
+    const cluster = searchParams.get('cluster')
+    if (!cluster || cluster.trim() === '') {
+      error(
+        '[GET /api/v1/cluster-counts] Missing cluster parameter',
+        undefined,
+        { requestId, countKey }
+      )
+      const errorResponse = createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'cluster parameter is required',
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+      const headers = new Headers(errorResponse.headers)
+      headers.set('X-Request-ID', requestId)
+      return new Response(errorResponse.body, {
+        status: errorResponse.status,
+        statusText: errorResponse.statusText,
+        headers,
+      })
+    }
+
+    // Validate hostId parameter
+    const hostIdResult = HostIdSchema.safeParse(
+      searchParams.get('hostId') ?? '0'
+    )
+    if (!hostIdResult.success) {
+      error(
+        '[GET /api/v1/cluster-counts] Invalid hostId parameter',
+        undefined,
+        { requestId, countKey }
+      )
+      const errorResponse = createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Invalid hostId parameter: must be a non-negative integer',
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+      const headers = new Headers(errorResponse.headers)
+      headers.set('X-Request-ID', requestId)
+      return new Response(errorResponse.body, {
+        status: errorResponse.status,
+        statusText: errorResponse.statusText,
+        headers,
+      })
+    }
+
+    const hostId = hostIdResult.data
+
+    debug('[GET /api/v1/cluster-counts] Fetching count', {
+      requestId,
+      countKey,
+      cluster,
+      hostId,
+    })
+
+    // Get the pre-defined query from registry
+    const clusterCount = getClusterCountQuery(countKey)
+    if (!clusterCount) {
+      error('[GET /api/v1/cluster-counts] Count query not found:', undefined, {
+        requestId,
+        countKey,
+      })
+      const errorResponse = createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: `Count key not found in registry: ${countKey}`,
+        },
+        404,
+        ROUTE_CONTEXT
+      )
+      const headers = new Headers(errorResponse.headers)
+      headers.set('X-Request-ID', requestId)
+      return new Response(errorResponse.body, {
+        status: errorResponse.status,
+        statusText: errorResponse.statusText,
+        headers,
+      })
+    }
+
+    bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+    // Execute the query with cluster parameter
+    const result = await fetchData({
+      query: clusterCount.query,
+      format: 'JSONEachRow',
+      hostId,
+      query_params: { cluster },
+    })
+
+    // Handle errors - for optional tables, return null count
+    if (result.error) {
+      if (clusterCount.optional) {
+        debug('[GET /api/v1/cluster-counts] Optional table not found:', {
+          requestId,
+          countKey,
+        })
+
+        const response = createSuccessResponse<ClusterCountResponse>(
+          { count: null },
+          { queryId: `cluster-count-${countKey}`, rows: 1 }
+        )
+        const headers = new Headers(response.headers)
+        headers.set('X-Request-ID', requestId)
+        headers.set('Cache-Control', CacheControl.SHORT)
+        return new Response(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        })
+      }
+
+      error('[GET /api/v1/cluster-counts] Query error:', undefined, {
+        requestId,
+        countKey,
+        error: result.error.message,
+      })
+      const errorResponse = createErrorResponse(
+        {
+          type: result.error.type as ApiErrorType,
+          message: result.error.message,
+        },
+        500,
+        { ...ROUTE_CONTEXT, hostId }
+      )
+      const headers = new Headers(errorResponse.headers)
+      headers.set('X-Request-ID', requestId)
+      return new Response(errorResponse.body, {
+        status: errorResponse.status,
+        statusText: errorResponse.statusText,
+        headers,
+      })
+    }
+
+    // Extract count from result
+    const data = result.data as Array<{ count?: number | string }>
+    const count =
+      data.length > 0 && data[0].count !== undefined
+        ? Number(data[0].count)
+        : null
+
+    debug('[GET /api/v1/cluster-counts] Count result:', {
+      requestId,
+      countKey,
+      cluster,
+      count,
+    })
+
+    const response = createSuccessResponse<ClusterCountResponse>(
+      { count },
+      { queryId: `cluster-count-${countKey}`, rows: 1 }
+    )
+    const headers = new Headers(response.headers)
+    headers.set('X-Request-ID', requestId)
+    headers.set('Cache-Control', CacheControl.SHORT)
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    })
+  } catch (err) {
+    error('[GET /api/v1/cluster-counts] Unexpected error:', err, { requestId })
+    const errorResponse = createErrorResponse(
+      {
+        type: ApiErrorType.QueryError,
+        message: err instanceof Error ? err.message : 'Unknown error',
+      },
+      500,
+      ROUTE_CONTEXT
+    )
+    const headers = new Headers(errorResponse.headers)
+    headers.set('X-Request-ID', requestId)
+    return new Response(errorResponse.body, {
+      status: errorResponse.status,
+      statusText: errorResponse.statusText,
+      headers,
+    })
+  }
+}
+
+export const Route = createFileRoute('/api/v1/cluster-counts/$key')({
+  server: {
+    handlers: {
+      GET: ({ request, params }) => handler(request, params),
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/config.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/config.ts
@@ -1,0 +1,238 @@
+/**
+ * App config endpoint
+ * GET /api/v1/config
+ *
+ * Returns the public feature-permission config the client consumes:
+ *   { authProvider, principal, features, resolved }
+ *
+ * Ported from apps/dashboard/app/api/v1/config/route.ts +
+ * apps/dashboard/lib/feature-permissions/server.ts:getPublicFeaturePermissionConfig.
+ *
+ * WORKERD CONSTRAINTS (intentional differences from the Next app):
+ * - No CHM_CONFIG_FILE loading: the dashboard's loadConfigFile() uses
+ *   `node:fs/promises` + js-yaml/smol-toml, which are not wired in this app.
+ *   File-based overrides are therefore NOT read here — env-driven config only.
+ * - Principal is ALWAYS 'anonymous': resolving an authenticated principal
+ *   requires Clerk's server `auth()` from '@clerk/nextjs/server', which is not
+ *   available in workerd and must not be imported (FAIL-LOUD rule). Per-request
+ *   auth is centralized in middleware. The client treats principal as a hint;
+ *   the server still enforces auth on protected routes.
+ * - authProvider is read from the Worker env binding (canonical source on
+ *   Workers) falling back to process.env, via the same CHM_AUTH_PROVIDER /
+ *   NEXT_PUBLIC_AUTH_PROVIDER precedence the dashboard uses.
+ *
+ * The shared feature-resolution helpers (lib/feature-permissions/shared.ts) and
+ * env-override parsing (server.ts) are not ported into this app, so the minimal
+ * pieces are inlined below. Response SHAPE matches PublicFeaturePermissionConfig.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type {
+  FeatureAccess,
+  FeatureId,
+  FeatureOverride,
+  FeatureOverrides,
+  FeatureState,
+  PublicFeaturePermissionConfig,
+} from '@/lib/feature-permissions/types'
+
+import { env } from 'cloudflare:workers'
+import { parseAuthProvider } from '@/lib/auth/provider'
+import {
+  FEATURE_ACCESS_VALUES,
+  FEATURE_IDS,
+} from '@/lib/feature-permissions/types'
+
+// ---------------------------------------------------------------------------
+// Inlined feature-permission resolution (mirror lib/feature-permissions/shared.ts).
+// ---------------------------------------------------------------------------
+
+const DEFAULT_FEATURE_ACCESS: FeatureAccess = 'public'
+
+const FEATURE_ID_SET = new Set<string>(FEATURE_IDS)
+const FEATURE_ACCESS_SET = new Set<string>(FEATURE_ACCESS_VALUES)
+const FEATURE_ACCESS_ALIASES: Record<string, FeatureAccess> = {
+  guest: 'public',
+}
+
+function isFeatureId(value: string): value is FeatureId {
+  return FEATURE_ID_SET.has(value)
+}
+
+function isFeatureAccess(value: string): value is FeatureAccess {
+  return FEATURE_ACCESS_SET.has(value)
+}
+
+function normalizeFeatureId(value: string): FeatureId {
+  const normalized = value.trim().toLowerCase().replaceAll('-', '_')
+  if (isFeatureId(normalized)) return normalized
+  throw new Error(
+    `Invalid feature "${value}". Expected one of: ${FEATURE_IDS.join(', ')}.`
+  )
+}
+
+function normalizeFeatureAccess(value: string): FeatureAccess {
+  const normalized = value.trim().toLowerCase()
+  const alias = FEATURE_ACCESS_ALIASES[normalized]
+  if (alias) return alias
+  if (isFeatureAccess(normalized)) return normalized
+  throw new Error(
+    `Invalid feature access "${value}". Expected one of: ${FEATURE_ACCESS_VALUES.join(
+      ', '
+    )}, guest.`
+  )
+}
+
+function resolveFeatureState(
+  feature: FeatureId,
+  features: FeatureOverrides
+): FeatureState {
+  const override = features[feature]
+  return {
+    enabled: override?.enabled ?? true,
+    access: override?.access ?? DEFAULT_FEATURE_ACCESS,
+  }
+}
+
+function getResolvedFeatureStates(
+  features: FeatureOverrides
+): Record<FeatureId, FeatureState> {
+  const resolved: Record<string, FeatureState> = {}
+  for (const featureId of FEATURE_IDS) {
+    resolved[featureId] = resolveFeatureState(featureId, features)
+  }
+  return resolved as Record<FeatureId, FeatureState>
+}
+
+function mergeFeatureOverrides(
+  base: FeatureOverrides,
+  next: FeatureOverrides
+): FeatureOverrides {
+  const merged: FeatureOverrides = {}
+  for (const [feature, override] of Object.entries(base)) {
+    merged[normalizeFeatureId(feature)] = { ...override }
+  }
+  for (const [feature, override] of Object.entries(next)) {
+    const id = normalizeFeatureId(feature)
+    merged[id] = { ...(merged[id] ?? {}), ...override }
+  }
+  return merged
+}
+
+// ---------------------------------------------------------------------------
+// Env access (Worker binding first, then process.env).
+// ---------------------------------------------------------------------------
+
+type EnvBindings = Record<string, string | undefined>
+
+function readEnv(key: string): string | undefined {
+  const bindings = env as EnvBindings
+  const fromBinding = bindings[key]
+  if (fromBinding !== undefined && fromBinding !== '') return fromBinding
+  if (typeof process !== 'undefined' && process.env) {
+    const fromProcess = process.env[key]
+    if (fromProcess !== undefined && fromProcess !== '') return fromProcess
+  }
+  return undefined
+}
+
+function parseBoolean(value: string | undefined): boolean | undefined {
+  if (value === undefined || value === '') return undefined
+  const normalized = value.trim().toLowerCase()
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false
+  return undefined
+}
+
+function splitFeatureList(value: string | undefined): string[] {
+  return (value ?? '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+/**
+ * Build feature overrides from env vars (mirror server.ts parseEnvFeatureOverrides):
+ *   CHM_DISABLED_FEATURES, CHM_AUTH_REQUIRED_FEATURES (comma lists),
+ *   CHM_FEATURE_<ID>_ENABLED, CHM_FEATURE_<ID>_ACCESS (per feature).
+ */
+function parseEnvFeatureOverrides(): FeatureOverrides {
+  let overrides: FeatureOverrides = {}
+
+  for (const feature of splitFeatureList(readEnv('CHM_DISABLED_FEATURES'))) {
+    overrides = mergeFeatureOverrides(overrides, {
+      [normalizeFeatureId(feature)]: { enabled: false },
+    })
+  }
+
+  for (const feature of splitFeatureList(
+    readEnv('CHM_AUTH_REQUIRED_FEATURES')
+  )) {
+    overrides = mergeFeatureOverrides(overrides, {
+      [normalizeFeatureId(feature)]: { access: 'authenticated' },
+    })
+  }
+
+  for (const feature of FEATURE_IDS) {
+    const envKey = `CHM_FEATURE_${feature.toUpperCase()}`
+    const enabled = parseBoolean(readEnv(`${envKey}_ENABLED`))
+    const access = readEnv(`${envKey}_ACCESS`)
+
+    const override: FeatureOverride = {}
+    if (enabled !== undefined) override.enabled = enabled
+    if (access !== undefined && access !== '') {
+      override.access = normalizeFeatureAccess(access)
+    }
+
+    if (Object.keys(override).length > 0) {
+      overrides = mergeFeatureOverrides(overrides, { [feature]: override })
+    }
+  }
+
+  return overrides
+}
+
+function getPublicFeaturePermissionConfig(): PublicFeaturePermissionConfig {
+  const authProvider = parseAuthProvider(
+    readEnv('CHM_AUTH_PROVIDER') ?? readEnv('NEXT_PUBLIC_AUTH_PROVIDER')
+  )
+
+  const features = parseEnvFeatureOverrides()
+  const resolved = getResolvedFeatureStates(features)
+
+  return {
+    authProvider,
+    // WORKERD: no server-side Clerk auth() here → always anonymous.
+    // Protected routes are enforced by middleware regardless.
+    principal: 'anonymous',
+    features,
+    resolved,
+  }
+}
+
+export const Route = createFileRoute('/api/v1/config')({
+  server: {
+    handlers: {
+      GET: async () => {
+        try {
+          const config = getPublicFeaturePermissionConfig()
+          return Response.json(config)
+        } catch (err) {
+          return Response.json(
+            {
+              error: {
+                code: 'INVALID_FEATURE_PERMISSION_CONFIG',
+                message:
+                  err instanceof Error
+                    ? err.message
+                    : 'Invalid feature permission config',
+              },
+            },
+            { status: 500 }
+          )
+        }
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/dashboard/settings.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/dashboard/settings.ts
@@ -1,0 +1,243 @@
+/**
+ * Dashboard settings API endpoint
+ * GET /api/v1/dashboard/settings - Retrieve dashboard settings
+ * POST /api/v1/dashboard/settings - Update dashboard settings
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { ApiResponse } from '@/lib/api/types'
+
+import { env } from 'cloudflare:workers'
+import { getClient } from '@chm/clickhouse-client'
+import { debug, error } from '@chm/logger'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { ApiErrorType } from '@/lib/api/types'
+import { DASHBOARD_SETTINGS_TABLE } from '@/lib/app-tables'
+
+const TABLE_SETTINGS = DASHBOARD_SETTINGS_TABLE
+
+const ROUTE_CONTEXT_GET = {
+  route: '/api/v1/dashboard/settings',
+  method: 'GET',
+}
+const ROUTE_CONTEXT_POST = {
+  route: '/api/v1/dashboard/settings',
+  method: 'POST',
+}
+
+function isValidHostId(hostId: number): boolean {
+  return Number.isInteger(hostId) && hostId >= 0
+}
+
+function emptySettingsResponse(
+  hostId: number
+): ApiResponse<{ params: Record<string, string> }> {
+  return {
+    success: true,
+    data: { params: {} },
+    metadata: {
+      queryId: 'dashboard-settings-get',
+      duration: 0,
+      rows: 0,
+      host: String(hostId),
+    },
+  }
+}
+
+function isTableMissingError(msg: string): boolean {
+  return (
+    msg.includes('UNKNOWN_TABLE') ||
+    msg.includes('Unknown table expression') ||
+    (msg.includes('Table') && msg.includes("doesn't exist"))
+  )
+}
+
+function makeErrorResponse(
+  type: ApiErrorType,
+  message: string,
+  status: number,
+  context?: { route?: string; method?: string }
+): Response {
+  return Response.json(
+    {
+      success: false,
+      metadata: {
+        queryId: '',
+        duration: 0,
+        rows: 0,
+        host: 'unknown',
+      },
+      error: { type, message },
+    },
+    {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  )
+}
+
+export const Route = createFileRoute('/api/v1/dashboard/settings')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+        debug('[GET /api/v1/dashboard/settings] Fetching settings')
+
+        const { searchParams } = new URL(request.url)
+        const hostId = Number(searchParams.get('hostId') ?? '0')
+        if (!isValidHostId(hostId)) {
+          return makeErrorResponse(
+            ApiErrorType.ValidationError,
+            'Invalid hostId: expected a non-negative integer',
+            400,
+            ROUTE_CONTEXT_GET
+          )
+        }
+
+        try {
+          debug('[GET /api/v1/dashboard/settings]', { hostId })
+
+          const query = `
+            SELECT key, value
+            FROM ${TABLE_SETTINGS} FINAL
+          `
+
+          const client = await getClient({ hostId })
+          const resultSet = await client.query({
+            query,
+            format: 'JSONEachRow',
+          })
+
+          const rows = (await resultSet.json()) as unknown as {
+            key: string
+            value: string
+          }[]
+
+          const params = rows.reduce(
+            (acc, row) => {
+              acc[row.key] = row.value
+              return acc
+            },
+            {} as Record<string, string>
+          )
+
+          const response: ApiResponse<{ params: Record<string, string> }> = {
+            success: true,
+            data: { params },
+            metadata: {
+              queryId: 'dashboard-settings-get',
+              duration: 0,
+              rows: rows.length,
+              host: String(hostId),
+            },
+          }
+
+          return Response.json(response, {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        } catch (err) {
+          const errorMessage =
+            err instanceof Error ? err.message : 'Unknown error occurred'
+
+          if (isTableMissingError(errorMessage)) {
+            debug(
+              '[GET /api/v1/dashboard/settings] Settings table missing; returning empty response',
+              { hostId }
+            )
+            return Response.json(emptySettingsResponse(hostId), { status: 200 })
+          }
+
+          error('[GET /api/v1/dashboard/settings] Error:', errorMessage)
+          return makeErrorResponse(
+            ApiErrorType.QueryError,
+            errorMessage,
+            500,
+            ROUTE_CONTEXT_GET
+          )
+        }
+      },
+
+      POST: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+        debug('[POST /api/v1/dashboard/settings] Updating settings')
+
+        try {
+          const body = (await request.json()) as {
+            params?: Record<string, string>
+            hostId?: number | string
+          }
+          const { params, hostId = 0 } = body
+          const parsedHostId = Number(hostId)
+
+          if (!params || typeof params !== 'object' || Array.isArray(params)) {
+            return makeErrorResponse(
+              ApiErrorType.ValidationError,
+              'Missing or invalid field: params',
+              400,
+              ROUTE_CONTEXT_POST
+            )
+          }
+          if (!isValidHostId(parsedHostId)) {
+            return makeErrorResponse(
+              ApiErrorType.ValidationError,
+              'Invalid hostId: expected a non-negative integer',
+              400,
+              ROUTE_CONTEXT_POST
+            )
+          }
+
+          debug('[POST /api/v1/dashboard/settings]', {
+            hostId: parsedHostId,
+            paramsKeys: Object.keys(params),
+          })
+
+          const query = `
+            ALTER TABLE ${TABLE_SETTINGS}
+            UPDATE value = {value:String}, updated_at = NOW()
+            WHERE key = {key:String}
+          `
+
+          const query_params = {
+            key: 'params',
+            value: JSON.stringify(params),
+          }
+
+          const client = await getClient({ hostId: parsedHostId })
+          await client.command({
+            query,
+            query_params,
+          })
+
+          const response: ApiResponse<{ success: boolean }> = {
+            success: true,
+            data: { success: true },
+            metadata: {
+              queryId: 'dashboard-settings-update',
+              duration: 0,
+              rows: 0,
+              host: String(parsedHostId),
+            },
+          }
+
+          return Response.json(response, {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        } catch (err) {
+          const errorMessage =
+            err instanceof Error ? err.message : 'Unknown error occurred'
+
+          error('[POST /api/v1/dashboard/settings] Error:', errorMessage)
+          return makeErrorResponse(
+            ApiErrorType.QueryError,
+            errorMessage,
+            500,
+            ROUTE_CONTEXT_POST
+          )
+        }
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/data.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/data.ts
@@ -1,0 +1,621 @@
+/**
+ * Generic data endpoint for executing ClickHouse queries
+ * POST /api/v1/data, GET /api/v1/data
+ *
+ * Accepts a query and parameters, returns data with metadata.
+ * Includes caching headers for performance optimization.
+ *
+ * SECURITY: This endpoint validates that queries being executed are either:
+ * 1. Pre-defined in the chart/table registries (recommended)
+ * 2. Stored in the dashboard tables (for Chart Builder)
+ * This prevents clients from sending arbitrary SQL queries.
+ *
+ * Ported from apps/dashboard/app/api/v1/data/route.ts.
+ * - Per-route feature-permission auth (authorizeFeatureRequest) is DROPPED:
+ *   it is centralized in middleware (#1397), matching merged charts/tables routes.
+ * - The shared @/lib/api/error-handler / response-builder / status-code-mapper /
+ *   validators modules are not yet ported into this app, so their behavior is
+ *   inlined below (response shapes and validation logic are identical).
+ */
+
+import type { DataFormat } from '@clickhouse/client'
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { FetchDataError } from '@chm/clickhouse-client'
+import type { ApiError, ApiRequest, ApiResponse } from '@/lib/api/types'
+
+import { env } from 'cloudflare:workers'
+import { fetchData } from '@chm/clickhouse-client'
+import { debug, error } from '@chm/logger'
+import { validateSqlQuery } from '@chm/sql-builder'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { getTableConfig } from '@/lib/api/table-registry'
+import { ApiErrorType } from '@/lib/api/types'
+import { validateDashboardQuery } from '@/lib/api/data/dashboard-query-validator'
+
+const ROUTE_CONTEXT = { route: '/api/v1/data' } as const
+
+interface RouteContext {
+  readonly route?: string
+  readonly method?: string
+  readonly hostId?: number | string
+}
+
+// ---------------------------------------------------------------------------
+// Inlined response builders (mirror @/lib/api/shared/response-builder and
+// @/lib/api/error-handler — identical response shapes).
+// ---------------------------------------------------------------------------
+
+const SUCCESS_CACHE_HEADERS = {
+  'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+} as const
+
+function createSuccessResponse<T>(
+  data: T,
+  meta?: {
+    readonly queryId?: string | number
+    readonly duration?: number
+    readonly rows?: number
+    readonly sql?: string
+    readonly timezone?: string
+    readonly [key: string]: unknown
+  }
+): Response {
+  const response: ApiResponse<T> = {
+    success: true,
+    data,
+    metadata: {
+      queryId: meta?.queryId ? String(meta.queryId) : '',
+      duration: meta?.duration ? Number(meta.duration) : 0,
+      rows: meta?.rows ? Number(meta.rows) : 0,
+      host: '',
+      ...(meta?.sql && { sql: String(meta.sql) }),
+      ...(meta?.timezone && { timezone: String(meta.timezone) }),
+    },
+  }
+
+  return Response.json(response, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      ...SUCCESS_CACHE_HEADERS,
+    },
+  })
+}
+
+function createApiErrorResponse(
+  apiError:
+    | ApiError
+    | { type: ApiErrorType; message: string; details?: ApiError['details'] },
+  status: number,
+  context?: RouteContext
+): Response {
+  const response: ApiResponse = {
+    success: false,
+    metadata: {
+      queryId: '',
+      duration: 0,
+      rows: 0,
+      host: String(context?.hostId || 'unknown'),
+    },
+    error: apiError,
+  }
+
+  return Response.json(response, {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function createValidationError(
+  message: string,
+  context?: RouteContext
+): Response {
+  return createApiErrorResponse(
+    { type: ApiErrorType.ValidationError, message },
+    400,
+    context
+  )
+}
+
+const ERROR_TYPE_STATUS_MAP: Readonly<Record<ApiErrorType, number>> = {
+  [ApiErrorType.ValidationError]: 400,
+  [ApiErrorType.PermissionError]: 403,
+  [ApiErrorType.TableNotFound]: 404,
+  [ApiErrorType.NetworkError]: 503,
+  [ApiErrorType.QueryError]: 500,
+  [ApiErrorType.SslError]: 503,
+  [ApiErrorType.TimeoutError]: 504,
+}
+
+function mapErrorTypeToStatusCode(errorType: ApiErrorType): number {
+  return ERROR_TYPE_STATUS_MAP[errorType] ?? 500
+}
+
+// ---------------------------------------------------------------------------
+// Inlined validators (mirror @/lib/api/shared/validators).
+// ---------------------------------------------------------------------------
+
+function validateSearchParams(
+  searchParams: URLSearchParams,
+  requiredParams: string[]
+): ApiError | undefined {
+  for (const param of requiredParams) {
+    const value = searchParams.get(param)
+    if (!value || value.trim() === '') {
+      return {
+        type: ApiErrorType.ValidationError,
+        message: `Missing required parameter: ${param}`,
+      }
+    }
+  }
+  return undefined
+}
+
+function getAndValidateHostId(
+  searchParams: URLSearchParams
+): number | ApiError {
+  const hostId = searchParams.get('hostId')
+  if (!hostId) {
+    return {
+      type: ApiErrorType.ValidationError,
+      message: 'Missing required parameter: hostId',
+    }
+  }
+
+  const parsed = Number.parseInt(hostId, 10)
+  if (Number.isNaN(parsed) || parsed < 0) {
+    return {
+      type: ApiErrorType.ValidationError,
+      message: 'Invalid hostId: must be a non-negative number',
+    }
+  }
+  return parsed
+}
+
+const SUPPORTED_FORMATS = ['JSONEachRow', 'JSON', 'CSV', 'TSV'] as const
+
+function validateFormat(format: unknown): ApiError | undefined {
+  if (format === undefined || format === null) return undefined
+  if (typeof format !== 'string') {
+    return {
+      type: ApiErrorType.ValidationError,
+      message:
+        'Invalid format: must be a string. Supported formats: JSONEachRow, JSON, CSV, TSV',
+    }
+  }
+  if (
+    !SUPPORTED_FORMATS.includes(format as (typeof SUPPORTED_FORMATS)[number])
+  ) {
+    return {
+      type: ApiErrorType.ValidationError,
+      message: 'Invalid format. Supported formats: JSONEachRow, JSON, CSV, TSV',
+    }
+  }
+  return undefined
+}
+
+function validateHostIdWithError(hostId: unknown): ApiError | undefined {
+  if (hostId === undefined || hostId === null || hostId === '') {
+    return {
+      type: ApiErrorType.ValidationError,
+      message: 'Missing required field: hostId',
+    }
+  }
+
+  const parsed =
+    typeof hostId === 'number'
+      ? hostId
+      : typeof hostId === 'string'
+        ? Number.parseInt(hostId, 10)
+        : Number.NaN
+
+  if (Number.isNaN(parsed) || parsed < 0) {
+    return {
+      type: ApiErrorType.ValidationError,
+      message: 'Invalid hostId: must be a non-negative number',
+    }
+  }
+  return undefined
+}
+
+function validateRequiredString(
+  value: unknown,
+  fieldName: string
+): ApiError | undefined {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return {
+      type: ApiErrorType.ValidationError,
+      message: `Missing required field: ${fieldName}`,
+    }
+  }
+  return undefined
+}
+
+function validateDataRequest(body: Partial<ApiRequest>): ApiError | undefined {
+  const queryError = validateRequiredString(body.query, 'query')
+  if (queryError) return queryError
+
+  const hostIdError = validateHostIdWithError(body.hostId)
+  if (hostIdError) return hostIdError
+
+  const formatError = validateFormat(body.format)
+  if (formatError) return formatError
+
+  return undefined
+}
+
+// ---------------------------------------------------------------------------
+// Inlined error classifier (mirror @/lib/api/error-handler/error-classifier).
+// ---------------------------------------------------------------------------
+
+function classifyError(err: unknown): { type: ApiErrorType; message: string } {
+  const message =
+    err instanceof Error
+      ? err.message
+      : typeof err === 'string'
+        ? err
+        : 'An unexpected error occurred'
+  const normalized = message.toLowerCase()
+
+  if (
+    normalized.includes('table') &&
+    (normalized.includes('not found') ||
+      normalized.includes("doesn't exist") ||
+      normalized.includes('does not exist') ||
+      normalized.includes('missing'))
+  ) {
+    return { type: ApiErrorType.TableNotFound, message }
+  }
+
+  const patterns: Array<{ type: ApiErrorType; keywords: string[] }> = [
+    {
+      type: ApiErrorType.PermissionError,
+      keywords: ['permission', 'access denied', 'unauthorized', 'forbidden'],
+    },
+    {
+      type: ApiErrorType.NetworkError,
+      keywords: [
+        'network',
+        'connection',
+        'econnrefused',
+        'enotfound',
+        'connect failed',
+      ],
+    },
+    {
+      type: ApiErrorType.TimeoutError,
+      keywords: ['timeout', 'etimedout', 'socket timeout'],
+    },
+    {
+      type: ApiErrorType.SslError,
+      keywords: ['ssl', 'tls', 'certificate', 'handshake', '525', '526'],
+    },
+    {
+      type: ApiErrorType.ValidationError,
+      keywords: [
+        'invalid',
+        'missing',
+        'required',
+        'malformed',
+        'syntax error',
+        'parse error',
+      ],
+    },
+  ]
+
+  for (const { type, keywords } of patterns) {
+    if (keywords.some((kw) => normalized.includes(kw))) {
+      return { type, message }
+    }
+  }
+
+  return { type: ApiErrorType.QueryError, message }
+}
+
+/**
+ * Wrap a handler so uncaught errors are classified into a standardized
+ * error response (mirror @/lib/api/error-handler withApiHandler).
+ */
+function withApiHandler(
+  handler: (request: Request) => Promise<Response>,
+  context?: RouteContext
+): (request: Request) => Promise<Response> {
+  return async (request: Request): Promise<Response> => {
+    try {
+      return await handler(request)
+    } catch (err) {
+      const { type, message } = classifyError(err)
+      return createApiErrorResponse(
+        {
+          type,
+          message,
+          details: { timestamp: new Date().toISOString() },
+        },
+        mapErrorTypeToStatusCode(type),
+        context
+      )
+    }
+  }
+}
+
+/**
+ * Handle query execution errors with proper status code mapping
+ */
+function handleQueryError(
+  queryError: FetchDataError,
+  hostId: string | number,
+  method: string
+): Response {
+  const errorTypeMap: Record<FetchDataError['type'], ApiErrorType> = {
+    table_not_found: ApiErrorType.TableNotFound,
+    validation_error: ApiErrorType.ValidationError,
+    query_error: ApiErrorType.QueryError,
+    network_error: ApiErrorType.NetworkError,
+    permission_error: ApiErrorType.PermissionError,
+    ssl_error: ApiErrorType.SslError,
+    timeout_error: ApiErrorType.TimeoutError,
+  }
+
+  const apiErrorType = errorTypeMap[queryError.type] ?? ApiErrorType.QueryError
+
+  return createApiErrorResponse(
+    {
+      type: apiErrorType,
+      message: queryError.message,
+      details: queryError.details as Record<
+        string,
+        string | number | boolean | undefined
+      >,
+    },
+    mapErrorTypeToStatusCode(apiErrorType),
+    { ...ROUTE_CONTEXT, method, hostId }
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle GET requests for data fetching
+ * Accepts query and parameters via URL query string
+ *
+ * @example
+ * GET /api/v1/data?hostId=0&sql=SELECT%20count()%20FROM%20system.tables&format=JSONEachRow
+ */
+const handleGet = withApiHandler(async (request: Request) => {
+  bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+  const url = new URL(request.url)
+  const searchParams = url.searchParams
+
+  // Parse query parameters from URL
+  const query =
+    searchParams.get('sql') || searchParams.get('query') || undefined
+  const format = searchParams.get('format') as DataFormat | null
+  const timezone = searchParams.get('timezone') || undefined
+
+  // Validate required parameters
+  const validationError = validateSearchParams(searchParams, ['hostId'])
+  if (validationError) {
+    return createValidationError(validationError.message, {
+      ...ROUTE_CONTEXT,
+      method: 'GET',
+    })
+  }
+
+  if (!query) {
+    return createValidationError('Missing required parameter: sql or query', {
+      ...ROUTE_CONTEXT,
+      method: 'GET',
+    })
+  }
+
+  // SECURITY: Validate SQL query to prevent injection attacks
+  try {
+    validateSqlQuery(query)
+  } catch (validationErr) {
+    error('[GET /api/v1/data] Security: SQL validation failed', {
+      queryPreview: query.substring(0, 100),
+      error:
+        validationErr instanceof Error
+          ? validationErr.message
+          : 'Unknown error',
+    })
+    return createValidationError(
+      validationErr instanceof Error
+        ? validationErr.message
+        : 'SQL validation failed',
+      { ...ROUTE_CONTEXT, method: 'GET' }
+    )
+  }
+
+  // Get and validate hostId from search params
+  const hostIdResult = getAndValidateHostId(searchParams)
+  if (typeof hostIdResult !== 'number') {
+    return createValidationError(hostIdResult.message, {
+      ...ROUTE_CONTEXT,
+      method: 'GET',
+    })
+  }
+  const hostId = hostIdResult
+
+  debug('[GET /api/v1/data]', {
+    hostId,
+    format: format || 'JSONEachRow',
+    timezone,
+  })
+
+  // SECURITY: Validate GET query against dashboard allowlist to prevent
+  // arbitrary SQL execution through query-string requests.
+  const validationResult = await validateDashboardQuery(query, hostId)
+  if (!validationResult.valid) {
+    error('[GET /api/v1/data] Security: Query not found in dashboard tables', {
+      queryPreview: query.substring(0, 100),
+    })
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.PermissionError,
+        message: validationResult.error?.message || 'Query validation failed',
+      },
+      403,
+      { ...ROUTE_CONTEXT, method: 'GET', hostId }
+    )
+  }
+
+  // Execute the query
+  const result = await fetchData({
+    query,
+    format: (format || 'JSONEachRow') as DataFormat,
+    hostId,
+    // Pass timezone to ClickHouse for session-level time conversion
+    clickhouse_settings: timezone ? { session_timezone: timezone } : undefined,
+  })
+
+  // Handle errors
+  if (result.error) {
+    error('[GET /api/v1/data] Query error:', result.error)
+    return handleQueryError(result.error, hostId, 'GET')
+  }
+
+  // Create successful response with timezone in metadata
+  return createSuccessResponse(result.data, { ...result.metadata, timezone })
+}, ROUTE_CONTEXT)
+
+/**
+ * Handle POST requests for data fetching
+ * Accepts query and parameters in the request body
+ *
+ * SECURITY: When queryConfig is not provided, validates that the query
+ * exists in the dashboard tables to prevent arbitrary SQL execution.
+ *
+ * @example
+ * POST /api/v1/data
+ * {
+ *   "query": "SELECT count() FROM system.tables",
+ *   "hostId": 0,
+ *   "format": "JSONEachRow"
+ * }
+ */
+const handlePost = withApiHandler(async (request: Request) => {
+  bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+  // Parse request body
+  const body = (await request.json()) as Partial<ApiRequest>
+
+  // Validate required fields using shared validator
+  const validationError = validateDataRequest(body)
+  if (validationError) {
+    return createApiErrorResponse(validationError, 400, {
+      ...ROUTE_CONTEXT,
+      method: 'POST',
+    })
+  }
+
+  const typedBody = body as ApiRequest
+  const {
+    query,
+    queryParams,
+    hostId,
+    format = 'JSONEachRow',
+    queryConfigName,
+    timezone,
+  } = typedBody
+
+  debug('[POST /api/v1/data]', {
+    hostId,
+    format,
+    queryConfigName,
+    timezone,
+  })
+
+  // SECURITY: Reject client-supplied QueryConfig objects to prevent SQL override attacks.
+  if (
+    typeof body === 'object' &&
+    body !== null &&
+    'queryConfig' in body &&
+    (body as { queryConfig?: unknown }).queryConfig !== undefined
+  ) {
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message:
+          'queryConfig is not accepted from clients. Use queryConfigName instead.',
+      },
+      400,
+      { ...ROUTE_CONTEXT, method: 'POST', hostId }
+    )
+  }
+
+  // SECURITY: If no queryConfigName provided, validate the query exists in dashboard tables
+  // This prevents arbitrary SQL execution from clients
+  if (!queryConfigName) {
+    const validationResult = await validateDashboardQuery(query, Number(hostId))
+    if (!validationResult.valid) {
+      error(
+        '[POST /api/v1/data] Security: Query not found in dashboard tables',
+        {
+          queryPreview: query.substring(0, 100),
+        }
+      )
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.PermissionError,
+          message: validationResult.error?.message || 'Query validation failed',
+        },
+        403,
+        { ...ROUTE_CONTEXT, method: 'POST', hostId }
+      )
+    }
+  }
+
+  const serverQueryConfig = queryConfigName
+    ? getTableConfig(queryConfigName)
+    : undefined
+  if (queryConfigName && !serverQueryConfig) {
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message: `Unknown query config: ${queryConfigName}`,
+      },
+      400,
+      { ...ROUTE_CONTEXT, method: 'POST', hostId }
+    )
+  }
+
+  // NOTE: per-route feature-permission gate (authorizeFeatureRequest) removed —
+  // centralized in middleware (#1397). serverQueryConfig still feeds fetchData.
+
+  // Convert format string to DataFormat if needed
+  const dataFormat = (format || 'JSONEachRow') as DataFormat
+
+  // Execute the query
+  const result = await fetchData({
+    query,
+    query_params: queryParams,
+    format: dataFormat,
+    hostId,
+    queryConfig: serverQueryConfig,
+    // Pass timezone to ClickHouse for session-level time conversion
+    clickhouse_settings: timezone ? { session_timezone: timezone } : undefined,
+  })
+
+  // Handle errors
+  if (result.error) {
+    error('[POST /api/v1/data] Query error:', result.error)
+    return handleQueryError(result.error, hostId, 'POST')
+  }
+
+  // Create successful response with timezone in metadata
+  return createSuccessResponse(result.data, { ...result.metadata, timezone })
+}, ROUTE_CONTEXT)
+
+export const Route = createFileRoute('/api/v1/data')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => handleGet(request),
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/explain.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explain.ts
@@ -1,0 +1,467 @@
+/**
+ * Explain Query endpoint
+ *
+ * Executes EXPLAIN on the provided query and returns the execution plan.
+ *
+ *   GET  /api/v1/explain?hostId=0&query=SELECT...
+ *   POST /api/v1/explain   { "hostId": 0, "query": "SELECT ..." }
+ *
+ * Ported from apps/dashboard/app/api/v1/explain/route.ts.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import {
+  fetchData,
+  getAndValidateClientConfig,
+  getClient,
+} from '@chm/clickhouse-client'
+import { QUERY_COMMENT } from '@chm/clickhouse-client/constants'
+import { debug, error as logError } from '@chm/logger'
+import { validateSqlQuery } from '@chm/sql-builder'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+
+const ROUTE_CONTEXT = { route: '/api/v1/explain' }
+
+/**
+ * Valid ClickHouse EXPLAIN modes. Empty string maps to plain EXPLAIN (PLAN).
+ */
+const VALID_EXPLAIN_MODES = [
+  '',
+  'PIPELINE',
+  'AST',
+  'SYNTAX',
+  'ESTIMATE',
+] as const
+type ExplainMode = (typeof VALID_EXPLAIN_MODES)[number]
+
+const VALID_PLAN_SETTING_KEYS = new Set([
+  'optimize',
+  'header',
+  'description',
+  'indexes',
+  'projections',
+  'actions',
+  'sorting',
+  'keep_logical_steps',
+  'json',
+  'distributed',
+])
+
+const MAX_QUERY_LENGTH = 100000
+
+/**
+ * Parse and validate the planSettings parameter.
+ * Expects comma-separated key=value pairs where value is 0 or 1.
+ */
+function parsePlanSettings(
+  raw: string
+): { clause: string } | { error: string } {
+  if (!raw) return { clause: '' }
+
+  const pairs = raw.split(',')
+  const validated: string[] = []
+
+  for (const pair of pairs) {
+    const trimmed = pair.trim()
+    if (!trimmed) continue
+
+    const eqIndex = trimmed.indexOf('=')
+    if (eqIndex === -1) {
+      return {
+        error: `Invalid plan setting format: "${trimmed}". Expected key=value.`,
+      }
+    }
+
+    const key = trimmed.slice(0, eqIndex).trim()
+    const value = trimmed.slice(eqIndex + 1).trim()
+
+    if (!VALID_PLAN_SETTING_KEYS.has(key)) {
+      return {
+        error: `Unknown plan setting: "${key}". Valid settings: ${Array.from(VALID_PLAN_SETTING_KEYS).join(', ')}`,
+      }
+    }
+
+    if (value !== '0' && value !== '1') {
+      return {
+        error: `Invalid value for "${key}": "${value}". Must be 0 or 1.`,
+      }
+    }
+
+    validated.push(`${key} = ${value}`)
+  }
+
+  if (validated.length === 0) return { clause: '' }
+  return { clause: `${validated.join(', ')} ` }
+}
+
+/**
+ * EXPLAIN AST and EXPLAIN SYNTAX return raw text that ClickHouse does not wrap
+ * in JSONEachRow. Fetch as plain text and convert each line to {explain: string}.
+ */
+async function fetchExplainAsText(
+  explainQuery: string,
+  hostId: number
+): Promise<
+  | { data: { explain: string }[]; metadata: Record<string, string | number> }
+  | { error: { type: string; message: string } }
+> {
+  let clientConfig
+  try {
+    clientConfig = getAndValidateClientConfig(hostId)
+  } catch (err) {
+    return {
+      error: {
+        type: 'validation_error',
+        message: err instanceof Error ? err.message : String(err),
+      },
+    }
+  }
+
+  try {
+    const client = await getClient({ clientConfig })
+    const resultSet = await client.query({
+      query: QUERY_COMMENT + explainQuery,
+      format: 'TabSeparatedRaw',
+    })
+    const text = await resultSet.text()
+    const lines = text.split('\n').filter((line) => line.length > 0)
+    return {
+      data: lines.map((line) => ({ explain: line })),
+      metadata: {
+        queryId: resultSet.query_id,
+        sql: explainQuery,
+        host: clientConfig.host,
+      },
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return {
+      error: {
+        type: 'query_error',
+        message: `${msg} (host: ${clientConfig.host})`,
+      },
+    }
+  }
+}
+
+/**
+ * Run a ClickHouse EXPLAIN once request inputs have been collected.
+ * Shared by the GET and POST handlers.
+ */
+async function runExplain(
+  hostId: number,
+  query: string | null,
+  modeParam: string,
+  planSettingsRaw: string
+): Promise<Response> {
+  if (!query || query.trim() === '') {
+    return Response.json(
+      {
+        success: false,
+        error: 'Missing required parameter: query',
+        ...ROUTE_CONTEXT,
+      },
+      { status: 400 }
+    )
+  }
+
+  if (query.length > MAX_QUERY_LENGTH) {
+    return Response.json(
+      {
+        success: false,
+        error: `Query is too long (maximum ${MAX_QUERY_LENGTH} characters)`,
+        ...ROUTE_CONTEXT,
+      },
+      { status: 400 }
+    )
+  }
+
+  // SECURITY: Validate SQL query to prevent injection attacks
+  try {
+    validateSqlQuery(query)
+  } catch (validationError) {
+    logError('[/api/v1/explain] Security: SQL validation failed', {
+      queryPreview: query.substring(0, 100),
+      error:
+        validationError instanceof Error
+          ? validationError.message
+          : 'Unknown error',
+    })
+    return Response.json(
+      {
+        success: false,
+        error:
+          validationError instanceof Error
+            ? validationError.message
+            : 'SQL validation failed',
+        ...ROUTE_CONTEXT,
+      },
+      { status: 400 }
+    )
+  }
+
+  if (modeParam && !VALID_EXPLAIN_MODES.includes(modeParam as ExplainMode)) {
+    return Response.json(
+      {
+        success: false,
+        error: `Invalid explain mode: ${modeParam}. Valid modes: ${VALID_EXPLAIN_MODES.filter(Boolean).join(', ')}`,
+        ...ROUTE_CONTEXT,
+      },
+      { status: 400 }
+    )
+  }
+
+  let settingsClause = ''
+
+  if (planSettingsRaw && modeParam) {
+    return Response.json(
+      {
+        success: false,
+        error: 'planSettings cannot be combined with a non-PLAN explain mode',
+        ...ROUTE_CONTEXT,
+      },
+      { status: 400 }
+    )
+  }
+
+  if (planSettingsRaw && !modeParam) {
+    const result = parsePlanSettings(planSettingsRaw)
+    if ('error' in result) {
+      return Response.json(
+        { success: false, error: result.error, ...ROUTE_CONTEXT },
+        { status: 400 }
+      )
+    }
+    settingsClause = result.clause
+  }
+
+  debug('[/api/v1/explain]', {
+    hostId,
+    queryLength: query.length,
+    mode: modeParam || 'PLAN',
+    planSettings: settingsClause || '(defaults)',
+  })
+
+  // Build EXPLAIN query
+  let explainQuery: string
+  if (settingsClause) {
+    explainQuery = `EXPLAIN PLAN ${settingsClause.trim()} ${query}`
+  } else if (modeParam) {
+    explainQuery = `EXPLAIN ${modeParam} ${query}`
+  } else {
+    explainQuery = `EXPLAIN ${query}`
+  }
+
+  // AST and SYNTAX modes return raw text, not valid JSONEachRow
+  const isTextMode = modeParam === 'AST' || modeParam === 'SYNTAX'
+
+  if (isTextMode) {
+    const textResult = await fetchExplainAsText(explainQuery, hostId)
+
+    if ('error' in textResult) {
+      logError('[/api/v1/explain] Query error:', textResult.error)
+      return Response.json(
+        { success: false, error: textResult.error.message, ...ROUTE_CONTEXT },
+        { status: 500 }
+      )
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: textResult.data,
+        metadata: {
+          sql: explainQuery,
+          rows: textResult.data.length,
+          queryId: String(textResult.metadata.queryId || ''),
+        },
+      }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store, no-cache, must-revalidate',
+        },
+      }
+    )
+  }
+
+  // PLAN, PIPELINE, ESTIMATE modes return valid JSONEachRow
+  const result = await fetchData({
+    query: explainQuery,
+    hostId,
+    format: 'JSONEachRow',
+  })
+
+  if (result.error) {
+    logError('[/api/v1/explain] Query error:', result.error)
+    return Response.json(
+      { success: false, error: result.error.message, ...ROUTE_CONTEXT },
+      { status: 500 }
+    )
+  }
+
+  return new Response(
+    JSON.stringify({
+      success: true,
+      data: result.data,
+      metadata: {
+        sql: explainQuery,
+        rows: Number(result.metadata.rows || 0),
+        duration: Number(result.metadata.duration || 0),
+        queryId: String(result.metadata.queryId || ''),
+      },
+    }),
+    {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store, no-cache, must-revalidate',
+      },
+    }
+  )
+}
+
+/**
+ * Validate required search parameters (hostId + query present and non-empty).
+ */
+function validateSearchParams(
+  searchParams: URLSearchParams
+): { message: string } | null {
+  for (const param of ['hostId', 'query']) {
+    const value = searchParams.get(param)
+    if (!value || value.trim() === '') {
+      return { message: `Missing required parameter: ${param}` }
+    }
+  }
+  return null
+}
+
+/**
+ * Parse and validate hostId from URLSearchParams.
+ * Returns the numeric hostId or an error object.
+ */
+function getAndValidateHostId(
+  searchParams: URLSearchParams
+): number | { message: string } {
+  const raw = searchParams.get('hostId')
+  if (!raw || raw.trim() === '') {
+    return { message: 'Missing required parameter: hostId' }
+  }
+  const n = Number.parseInt(raw, 10)
+  if (!Number.isInteger(n) || n < 0) {
+    return { message: 'hostId must be a non-negative integer' }
+  }
+  return n
+}
+
+export const Route = createFileRoute('/api/v1/explain')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const { searchParams } = new URL(request.url)
+
+        const validationError = validateSearchParams(searchParams)
+        if (validationError) {
+          return Response.json(
+            {
+              success: false,
+              error: validationError.message,
+              ...ROUTE_CONTEXT,
+            },
+            { status: 400 }
+          )
+        }
+
+        const hostIdResult = getAndValidateHostId(searchParams)
+        if (typeof hostIdResult !== 'number') {
+          return Response.json(
+            {
+              success: false,
+              error: hostIdResult.message,
+              ...ROUTE_CONTEXT,
+            },
+            { status: 400 }
+          )
+        }
+
+        return runExplain(
+          hostIdResult,
+          searchParams.get('query'),
+          (searchParams.get('mode') || '').toUpperCase(),
+          searchParams.get('planSettings') || ''
+        )
+      },
+
+      POST: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        let body: unknown
+        try {
+          body = await request.json()
+        } catch {
+          return Response.json(
+            {
+              success: false,
+              error: 'Request body must be valid JSON',
+              ...ROUTE_CONTEXT,
+            },
+            { status: 400 }
+          )
+        }
+
+        if (body === null || Array.isArray(body) || typeof body !== 'object') {
+          return Response.json(
+            {
+              success: false,
+              error: 'Request body must be a JSON object',
+              ...ROUTE_CONTEXT,
+            },
+            { status: 400 }
+          )
+        }
+
+        const { hostId, query, mode, planSettings } = body as Record<
+          string,
+          unknown
+        >
+
+        if (hostId === undefined || hostId === null || hostId === '') {
+          return Response.json(
+            {
+              success: false,
+              error: 'Missing required parameter: hostId',
+              ...ROUTE_CONTEXT,
+            },
+            { status: 400 }
+          )
+        }
+
+        const hostIdResult = getAndValidateHostId(
+          new URLSearchParams({ hostId: String(hostId) })
+        )
+        if (typeof hostIdResult !== 'number') {
+          return Response.json(
+            {
+              success: false,
+              error: hostIdResult.message,
+              ...ROUTE_CONTEXT,
+            },
+            { status: 400 }
+          )
+        }
+
+        return runExplain(
+          hostIdResult,
+          typeof query === 'string' ? query : null,
+          typeof mode === 'string' ? mode.toUpperCase() : '',
+          typeof planSettings === 'string' ? planSettings : ''
+        )
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/columns.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/columns.ts
@@ -1,0 +1,125 @@
+/**
+ * Explorer columns endpoint
+ * GET /api/v1/explorer/columns?hostId=0&database=default&table=users
+ *
+ * Returns list of columns in a table
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { ApiResponse } from '@/lib/api/types'
+
+import { fetchData } from '@chm/clickhouse-client'
+import { debug, error } from '@chm/logger'
+import { env } from 'cloudflare:workers'
+import { getHostIdFromParams, type RouteContext } from '@/lib/api/error-handler'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { getTableQuery } from '@/lib/api/table-registry'
+import { ApiErrorType } from '@/lib/api/types'
+
+const ROUTE = '/api/v1/explorer/columns'
+
+function mapErrorTypeToStatusCode(errorType: ApiErrorType): number {
+  const statusMap: Record<ApiErrorType, number> = {
+    [ApiErrorType.ValidationError]: 400,
+    [ApiErrorType.PermissionError]: 403,
+    [ApiErrorType.TableNotFound]: 404,
+    [ApiErrorType.NetworkError]: 503,
+    [ApiErrorType.QueryError]: 500,
+    [ApiErrorType.SslError]: 503,
+    [ApiErrorType.TimeoutError]: 504,
+  }
+  return statusMap[errorType] ?? 500
+}
+
+function createSuccessResponse<T>(
+  data: T,
+  metadata: Record<string, string | number>
+): Response {
+  const response: ApiResponse<T> = {
+    success: true,
+    data,
+    metadata: {
+      queryId: String(metadata.queryId || ''),
+      duration: Number(metadata.duration || 0),
+      rows: Number(metadata.rows || 0),
+      host: String(metadata.host || ''),
+    },
+  }
+  return Response.json(response, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+    },
+  })
+}
+
+export const Route = createFileRoute('/api/v1/explorer/columns')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const { searchParams } = new URL(request.url)
+        const routeContext: RouteContext = { route: ROUTE, method: 'GET' }
+
+        const hostId = getHostIdFromParams(searchParams, routeContext)
+
+        debug(`[GET ${ROUTE}]`, { hostId })
+
+        const searchParamsObj: Record<string, string> = {}
+        searchParams.forEach((value, key) => {
+          if (key !== 'hostId') searchParamsObj[key] = value
+        })
+
+        const queryDef = getTableQuery('explorer-columns', {
+          hostId,
+          searchParams: searchParamsObj,
+        })
+
+        if (!queryDef) {
+          error(`[GET ${ROUTE}] Failed to build query`)
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: ApiErrorType.QueryError,
+                message: 'Failed to build query for columns',
+              },
+            },
+            { status: 500 }
+          )
+        }
+
+        const result = await fetchData({
+          query: queryDef.query,
+          query_params: queryDef.queryParams,
+          hostId,
+          format: 'JSONEachRow',
+        })
+
+        if (result.error) {
+          error(`[GET ${ROUTE}] Query error:`, result.error)
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: result.error.type,
+                message: result.error.message,
+                details: result.error.details,
+              },
+            },
+            {
+              status: mapErrorTypeToStatusCode(
+                result.error.type as ApiErrorType
+              ),
+            }
+          )
+        }
+
+        return createSuccessResponse(result.data, result.metadata)
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/databases.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/databases.ts
@@ -1,0 +1,123 @@
+/**
+ * Explorer databases endpoint
+ * GET /api/v1/explorer/databases?hostId=0
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { ApiResponse } from '@/lib/api/types'
+
+import { fetchData } from '@chm/clickhouse-client'
+import { debug, error } from '@chm/logger'
+import { env } from 'cloudflare:workers'
+import { getHostIdFromParams, type RouteContext } from '@/lib/api/error-handler'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { getTableQuery } from '@/lib/api/table-registry'
+import { ApiErrorType } from '@/lib/api/types'
+
+const ROUTE = '/api/v1/explorer/databases'
+
+function mapErrorTypeToStatusCode(errorType: ApiErrorType): number {
+  const statusMap: Record<ApiErrorType, number> = {
+    [ApiErrorType.ValidationError]: 400,
+    [ApiErrorType.PermissionError]: 403,
+    [ApiErrorType.TableNotFound]: 404,
+    [ApiErrorType.NetworkError]: 503,
+    [ApiErrorType.QueryError]: 500,
+    [ApiErrorType.SslError]: 503,
+    [ApiErrorType.TimeoutError]: 504,
+  }
+  return statusMap[errorType] ?? 500
+}
+
+function createSuccessResponse<T>(
+  data: T,
+  metadata: Record<string, string | number>
+): Response {
+  const response: ApiResponse<T> = {
+    success: true,
+    data,
+    metadata: {
+      queryId: String(metadata.queryId || ''),
+      duration: Number(metadata.duration || 0),
+      rows: Number(metadata.rows || 0),
+      host: String(metadata.host || ''),
+    },
+  }
+  return Response.json(response, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+    },
+  })
+}
+
+export const Route = createFileRoute('/api/v1/explorer/databases')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const { searchParams } = new URL(request.url)
+        const routeContext: RouteContext = { route: ROUTE, method: 'GET' }
+
+        const hostId = getHostIdFromParams(searchParams, routeContext)
+
+        debug(`[GET ${ROUTE}]`, { hostId })
+
+        const searchParamsObj: Record<string, string> = {}
+        searchParams.forEach((value, key) => {
+          if (key !== 'hostId') searchParamsObj[key] = value
+        })
+
+        const queryDef = getTableQuery('explorer-databases', {
+          hostId,
+          searchParams: searchParamsObj,
+        })
+
+        if (!queryDef) {
+          error(`[GET ${ROUTE}] Failed to build query`)
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: ApiErrorType.QueryError,
+                message: 'Failed to build query for explorer-databases',
+              },
+            },
+            { status: 500 }
+          )
+        }
+
+        const result = await fetchData({
+          query: queryDef.query,
+          query_params: queryDef.queryParams,
+          hostId,
+          format: 'JSONEachRow',
+        })
+
+        if (result.error) {
+          error(`[GET ${ROUTE}] Query error:`, result.error)
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: result.error.type,
+                message: result.error.message,
+                details: result.error.details,
+              },
+            },
+            {
+              status: mapErrorTypeToStatusCode(
+                result.error.type as ApiErrorType
+              ),
+            }
+          )
+        }
+
+        return createSuccessResponse(result.data, result.metadata)
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/ddl.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/ddl.ts
@@ -1,0 +1,123 @@
+/**
+ * Explorer DDL endpoint
+ * GET /api/v1/explorer/ddl?hostId=0&database=default&table=users
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { ApiResponse } from '@/lib/api/types'
+
+import { fetchData } from '@chm/clickhouse-client'
+import { debug, error } from '@chm/logger'
+import { env } from 'cloudflare:workers'
+import { getHostIdFromParams, type RouteContext } from '@/lib/api/error-handler'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { getTableQuery } from '@/lib/api/table-registry'
+import { ApiErrorType } from '@/lib/api/types'
+
+const ROUTE = '/api/v1/explorer/ddl'
+
+function mapErrorTypeToStatusCode(errorType: ApiErrorType): number {
+  const statusMap: Record<ApiErrorType, number> = {
+    [ApiErrorType.ValidationError]: 400,
+    [ApiErrorType.PermissionError]: 403,
+    [ApiErrorType.TableNotFound]: 404,
+    [ApiErrorType.NetworkError]: 503,
+    [ApiErrorType.QueryError]: 500,
+    [ApiErrorType.SslError]: 503,
+    [ApiErrorType.TimeoutError]: 504,
+  }
+  return statusMap[errorType] ?? 500
+}
+
+function createSuccessResponse<T>(
+  data: T,
+  metadata: Record<string, string | number>
+): Response {
+  const response: ApiResponse<T> = {
+    success: true,
+    data,
+    metadata: {
+      queryId: String(metadata.queryId || ''),
+      duration: Number(metadata.duration || 0),
+      rows: Number(metadata.rows || 0),
+      host: String(metadata.host || ''),
+    },
+  }
+  return Response.json(response, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+    },
+  })
+}
+
+export const Route = createFileRoute('/api/v1/explorer/ddl')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const { searchParams } = new URL(request.url)
+        const routeContext: RouteContext = { route: ROUTE, method: 'GET' }
+
+        const hostId = getHostIdFromParams(searchParams, routeContext)
+
+        debug(`[GET ${ROUTE}]`, { hostId })
+
+        const searchParamsObj: Record<string, string> = {}
+        searchParams.forEach((value, key) => {
+          if (key !== 'hostId') searchParamsObj[key] = value
+        })
+
+        const queryDef = getTableQuery('explorer-ddl', {
+          hostId,
+          searchParams: searchParamsObj,
+        })
+
+        if (!queryDef) {
+          error(`[GET ${ROUTE}] Failed to build query`)
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: ApiErrorType.QueryError,
+                message: 'Failed to build query for explorer-ddl',
+              },
+            },
+            { status: 500 }
+          )
+        }
+
+        const result = await fetchData({
+          query: queryDef.query,
+          query_params: queryDef.queryParams,
+          hostId,
+          format: 'JSONEachRow',
+        })
+
+        if (result.error) {
+          error(`[GET ${ROUTE}] Query error:`, result.error)
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: result.error.type,
+                message: result.error.message,
+                details: result.error.details,
+              },
+            },
+            {
+              status: mapErrorTypeToStatusCode(
+                result.error.type as ApiErrorType
+              ),
+            }
+          )
+        }
+
+        return createSuccessResponse(result.data, result.metadata)
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/dependencies.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/dependencies.ts
@@ -1,0 +1,153 @@
+/**
+ * Explorer dependencies endpoint
+ * GET /api/v1/explorer/dependencies?hostId=0&database=default&table=users&direction=upstream|downstream
+ * GET /api/v1/explorer/dependencies?hostId=0&database=default&direction=database (all deps in database)
+ * GET /api/v1/explorer/dependencies?hostId=0&database=default&table=dict_name&direction=dictionary (dictionary source)
+ *
+ * Returns dependency information for a table (upstream or downstream) or entire database
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { ApiResponse } from '@/lib/api/types'
+
+import { fetchData } from '@chm/clickhouse-client'
+import { debug, error } from '@chm/logger'
+import { env } from 'cloudflare:workers'
+import { getHostIdFromParams, type RouteContext } from '@/lib/api/error-handler'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { getTableQuery } from '@/lib/api/table-registry'
+import { ApiErrorType } from '@/lib/api/types'
+
+const ROUTE = '/api/v1/explorer/dependencies'
+
+function mapErrorTypeToStatusCode(errorType: ApiErrorType): number {
+  const statusMap: Record<ApiErrorType, number> = {
+    [ApiErrorType.ValidationError]: 400,
+    [ApiErrorType.PermissionError]: 403,
+    [ApiErrorType.TableNotFound]: 404,
+    [ApiErrorType.NetworkError]: 503,
+    [ApiErrorType.QueryError]: 500,
+    [ApiErrorType.SslError]: 503,
+    [ApiErrorType.TimeoutError]: 504,
+  }
+  return statusMap[errorType] ?? 500
+}
+
+function createSuccessResponse<T>(
+  data: T,
+  metadata: Record<string, string | number>
+): Response {
+  const response: ApiResponse<T> = {
+    success: true,
+    data,
+    metadata: {
+      queryId: String(metadata.queryId || ''),
+      duration: Number(metadata.duration || 0),
+      rows: Number(metadata.rows || 0),
+      host: String(metadata.host || ''),
+    },
+  }
+  return Response.json(response, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120',
+    },
+  })
+}
+
+export const Route = createFileRoute('/api/v1/explorer/dependencies')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const { searchParams } = new URL(request.url)
+        const routeContext: RouteContext = { route: ROUTE, method: 'GET' }
+
+        const hostId = getHostIdFromParams(searchParams, routeContext)
+        const direction = searchParams.get('direction') || 'downstream'
+
+        debug(`[GET ${ROUTE}]`, { hostId, direction })
+
+        const searchParamsObj: Record<string, string> = {}
+        searchParams.forEach((value, key) => {
+          if (key !== 'hostId' && key !== 'direction')
+            searchParamsObj[key] = value
+        })
+
+        let configName: string
+        switch (direction) {
+          case 'upstream':
+            configName = 'explorer-dependencies-upstream'
+            break
+          case 'downstream':
+            configName = 'explorer-dependencies-downstream'
+            break
+          case 'database':
+            configName = 'explorer-database-dependencies'
+            break
+          case 'dictionary':
+            configName = 'explorer-dictionary-source'
+            break
+          case 'all':
+            configName = 'explorer-all-dependencies'
+            break
+          case 'table':
+            configName = 'explorer-table-dependencies'
+            break
+          default:
+            configName = 'explorer-dependencies-downstream'
+        }
+
+        const queryDef = getTableQuery(configName, {
+          hostId,
+          searchParams: searchParamsObj,
+        })
+
+        if (!queryDef) {
+          error(`[GET ${ROUTE}] Failed to build query`)
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: ApiErrorType.QueryError,
+                message: 'Failed to build query for dependencies',
+              },
+            },
+            { status: 500 }
+          )
+        }
+
+        const result = await fetchData({
+          query: queryDef.query,
+          query_params: queryDef.queryParams,
+          hostId,
+          format: 'JSONEachRow',
+        })
+
+        if (result.error) {
+          error(`[GET ${ROUTE}] Query error:`, result.error)
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: result.error.type,
+                message: result.error.message,
+                details: result.error.details,
+              },
+            },
+            {
+              status: mapErrorTypeToStatusCode(
+                result.error.type as ApiErrorType
+              ),
+            }
+          )
+        }
+
+        return createSuccessResponse(result.data, result.metadata)
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/indexes.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/indexes.ts
@@ -1,0 +1,123 @@
+/**
+ * Explorer indexes endpoint
+ * GET /api/v1/explorer/indexes?hostId=0&database=default&table=users
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { ApiResponse } from '@/lib/api/types'
+
+import { fetchData } from '@chm/clickhouse-client'
+import { debug, error } from '@chm/logger'
+import { env } from 'cloudflare:workers'
+import { getHostIdFromParams, type RouteContext } from '@/lib/api/error-handler'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { getTableQuery } from '@/lib/api/table-registry'
+import { ApiErrorType } from '@/lib/api/types'
+
+const ROUTE = '/api/v1/explorer/indexes'
+
+function mapErrorTypeToStatusCode(errorType: ApiErrorType): number {
+  const statusMap: Record<ApiErrorType, number> = {
+    [ApiErrorType.ValidationError]: 400,
+    [ApiErrorType.PermissionError]: 403,
+    [ApiErrorType.TableNotFound]: 404,
+    [ApiErrorType.NetworkError]: 503,
+    [ApiErrorType.QueryError]: 500,
+    [ApiErrorType.SslError]: 503,
+    [ApiErrorType.TimeoutError]: 504,
+  }
+  return statusMap[errorType] ?? 500
+}
+
+function createSuccessResponse<T>(
+  data: T,
+  metadata: Record<string, string | number>
+): Response {
+  const response: ApiResponse<T> = {
+    success: true,
+    data,
+    metadata: {
+      queryId: String(metadata.queryId || ''),
+      duration: Number(metadata.duration || 0),
+      rows: Number(metadata.rows || 0),
+      host: String(metadata.host || ''),
+    },
+  }
+  return Response.json(response, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+    },
+  })
+}
+
+export const Route = createFileRoute('/api/v1/explorer/indexes')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const { searchParams } = new URL(request.url)
+        const routeContext: RouteContext = { route: ROUTE, method: 'GET' }
+
+        const hostId = getHostIdFromParams(searchParams, routeContext)
+
+        debug(`[GET ${ROUTE}]`, { hostId })
+
+        const searchParamsObj: Record<string, string> = {}
+        searchParams.forEach((value, key) => {
+          if (key !== 'hostId') searchParamsObj[key] = value
+        })
+
+        const queryDef = getTableQuery('explorer-indexes', {
+          hostId,
+          searchParams: searchParamsObj,
+        })
+
+        if (!queryDef) {
+          error(`[GET ${ROUTE}] Failed to build query`)
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: ApiErrorType.QueryError,
+                message: 'Failed to build query for explorer-indexes',
+              },
+            },
+            { status: 500 }
+          )
+        }
+
+        const result = await fetchData({
+          query: queryDef.query,
+          query_params: queryDef.queryParams,
+          hostId,
+          format: 'JSONEachRow',
+        })
+
+        if (result.error) {
+          error(`[GET ${ROUTE}] Query error:`, result.error)
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: result.error.type,
+                message: result.error.message,
+                details: result.error.details,
+              },
+            },
+            {
+              status: mapErrorTypeToStatusCode(
+                result.error.type as ApiErrorType
+              ),
+            }
+          )
+        }
+
+        return createSuccessResponse(result.data, result.metadata)
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/preview.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/preview.ts
@@ -1,0 +1,198 @@
+/**
+ * Explorer preview endpoint
+ * GET /api/v1/explorer/preview?hostId=0&database=default&table=users&limit=100
+ *
+ * Returns preview data (SELECT *) from a table with pagination.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { fetchData } from '@chm/clickhouse-client'
+import { debug, error } from '@chm/logger'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { ApiErrorType } from '@/lib/api/types'
+
+// Validation regex for identifiers (database and table names)
+const VALID_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/
+
+const MAX_CELL_VALUE_LENGTH = 10_000
+
+function truncateLargeValues<T>(data: T): T {
+  if (!Array.isArray(data)) return data
+  return data.map((row) => {
+    if (typeof row !== 'object' || row === null || Array.isArray(row)) return row
+    const truncated: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(row as Record<string, unknown>)) {
+      if (typeof value === 'string' && value.length > MAX_CELL_VALUE_LENGTH) {
+        truncated[key] =
+          value.slice(0, MAX_CELL_VALUE_LENGTH) +
+          `… (truncated, ${value.length} chars total)`
+      } else {
+        truncated[key] = value
+      }
+    }
+    return truncated
+  }) as T
+}
+
+function mapErrorTypeToStatusCode(errorType: string): number {
+  const statusMap: Record<string, number> = {
+    [ApiErrorType.ValidationError]: 400,
+    [ApiErrorType.PermissionError]: 403,
+    [ApiErrorType.TableNotFound]: 404,
+    [ApiErrorType.NetworkError]: 503,
+    [ApiErrorType.QueryError]: 500,
+    [ApiErrorType.SslError]: 503,
+    [ApiErrorType.TimeoutError]: 504,
+  }
+  return statusMap[errorType] ?? 500
+}
+
+export const Route = createFileRoute('/api/v1/explorer/preview')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const { searchParams } = new URL(request.url)
+
+        // Validate hostId
+        const hostIdRaw = searchParams.get('hostId')
+        if (hostIdRaw === null || hostIdRaw === '') {
+          return Response.json(
+            {
+              success: false,
+              error: { type: ApiErrorType.ValidationError, message: 'Missing required parameter: hostId' },
+            },
+            { status: 400 }
+          )
+        }
+        const hostId = Number(hostIdRaw)
+        if (!Number.isFinite(hostId)) {
+          return Response.json(
+            {
+              success: false,
+              error: { type: ApiErrorType.ValidationError, message: `Invalid hostId: ${hostIdRaw}` },
+            },
+            { status: 400 }
+          )
+        }
+
+        const database = searchParams.get('database')
+        const table = searchParams.get('table')
+        const limit = searchParams.get('limit') ?? '100'
+        const offset = searchParams.get('offset') ?? '0'
+
+        debug('[GET /api/v1/explorer/preview]', { hostId, database, table, limit, offset })
+
+        if (!database || !VALID_IDENTIFIER.test(database)) {
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: 'Invalid database identifier',
+                details: { database: database ?? 'missing' },
+              },
+            },
+            { status: 400 }
+          )
+        }
+
+        if (!table || !VALID_IDENTIFIER.test(table)) {
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: 'Invalid table identifier',
+                details: { table: table ?? 'missing' },
+              },
+            },
+            { status: 400 }
+          )
+        }
+
+        const parsedLimit = parseInt(limit, 10)
+        if (Number.isNaN(parsedLimit) || parsedLimit < 1 || parsedLimit > 10000) {
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: 'Invalid limit parameter (must be between 1 and 10000)',
+                details: { limit },
+              },
+            },
+            { status: 400 }
+          )
+        }
+
+        const parsedOffset = parseInt(offset, 10)
+        if (Number.isNaN(parsedOffset) || parsedOffset < 0 || parsedOffset > 10000) {
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: 'Invalid offset parameter (must be a non-negative integer and <= 10000)',
+                details: { offset },
+              },
+            },
+            { status: 400 }
+          )
+        }
+
+        const query =
+          'SELECT * FROM {database:Identifier}.{table:Identifier} LIMIT {limit:UInt32} OFFSET {offset:UInt32}'
+
+        debug('[GET /api/v1/explorer/preview] Executing query:', { query })
+
+        const result = await fetchData({
+          query,
+          query_params: { database, table, limit: parsedLimit, offset: parsedOffset },
+          hostId,
+          format: 'JSONEachRow',
+        })
+
+        if (result.error) {
+          error('[GET /api/v1/explorer/preview] Query error:', result.error)
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: result.error.type,
+                message: result.error.message,
+                details: result.error.details,
+              },
+            },
+            { status: mapErrorTypeToStatusCode(result.error.type) }
+          )
+        }
+
+        const truncatedData = truncateLargeValues(result.data)
+
+        return Response.json(
+          {
+            success: true,
+            data: truncatedData,
+            metadata: {
+              queryId: String(result.metadata.queryId ?? ''),
+              duration: Number(result.metadata.duration ?? 0),
+              rows: Number(result.metadata.rows ?? 0),
+              host: String(result.metadata.host ?? ''),
+            },
+          },
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+              'Cache-Control': 'private, max-age=0',
+            },
+          }
+        )
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/projections.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/projections.ts
@@ -1,0 +1,117 @@
+/**
+ * Explorer projections endpoint
+ * GET /api/v1/explorer/projections?hostId=0&database=default&table=users
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { debug, error } from '@chm/logger'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { executeTableConfig } from '@/lib/api/query-executor'
+import { getTableQuery } from '@/lib/api/table-registry'
+import { ApiErrorType } from '@/lib/api/types'
+
+export const Route = createFileRoute('/api/v1/explorer/projections')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const { searchParams } = new URL(request.url)
+
+        const hostIdRaw = searchParams.get('hostId')
+        if (hostIdRaw === null || hostIdRaw === '') {
+          return Response.json(
+            {
+              success: false,
+              error: { type: ApiErrorType.ValidationError, message: 'Missing required parameter: hostId' },
+            },
+            { status: 400 }
+          )
+        }
+        const hostId = Number(hostIdRaw)
+        if (!Number.isFinite(hostId)) {
+          return Response.json(
+            {
+              success: false,
+              error: { type: ApiErrorType.ValidationError, message: `Invalid hostId: ${hostIdRaw}` },
+            },
+            { status: 400 }
+          )
+        }
+
+        debug('[GET /api/v1/explorer/projections]', { hostId })
+
+        const searchParamsObj: Record<string, string> = {}
+        searchParams.forEach((value, key) => {
+          if (key !== 'hostId') searchParamsObj[key] = value
+        })
+
+        const queryDef = getTableQuery('explorer-projections', { hostId, searchParams: searchParamsObj })
+
+        if (!queryDef) {
+          error('[GET /api/v1/explorer/projections] Failed to build query')
+          return Response.json(
+            {
+              success: false,
+              error: { type: ApiErrorType.QueryError, message: 'Failed to build query for explorer-projections' },
+            },
+            { status: 500 }
+          )
+        }
+
+        const { result, executedSql: _sql } = await executeTableConfig(
+          queryDef.queryConfig,
+          hostId,
+          queryDef.queryParams,
+          { bindings: env as Record<string, string | undefined> }
+        )
+
+        if (result.error) {
+          error('[GET /api/v1/explorer/projections] Query error:', result.error)
+          const statusMap: Record<string, number> = {
+            [ApiErrorType.ValidationError]: 400,
+            [ApiErrorType.PermissionError]: 403,
+            [ApiErrorType.TableNotFound]: 404,
+            [ApiErrorType.NetworkError]: 503,
+            [ApiErrorType.QueryError]: 500,
+            [ApiErrorType.SslError]: 503,
+            [ApiErrorType.TimeoutError]: 504,
+          }
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: result.error.type,
+                message: result.error.message,
+                details: result.error.details,
+              },
+            },
+            { status: statusMap[result.error.type] ?? 500 }
+          )
+        }
+
+        return Response.json(
+          {
+            success: true,
+            data: result.data,
+            metadata: {
+              queryId: String(result.metadata.queryId ?? ''),
+              duration: Number(result.metadata.duration ?? 0),
+              rows: Number(result.metadata.rows ?? 0),
+              host: String(result.metadata.host ?? ''),
+            },
+          },
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+              'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+            },
+          }
+        )
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/query.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/query.ts
@@ -1,0 +1,345 @@
+/**
+ * Explorer query endpoint
+ * GET  /api/v1/explorer/query?hostId=0&sql=SELECT...&format=JSONEachRow&timezone=UTC
+ * POST /api/v1/explorer/query  (body: { sql, hostId, format?, timezone? })
+ *
+ * Executes custom SQL queries from the explorer page.
+ * Only SELECT queries are allowed; all queries run in readonly mode.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { DataFormat } from '@clickhouse/client'
+
+import { env } from 'cloudflare:workers'
+import { fetchData } from '@chm/clickhouse-client'
+import { debug, error } from '@chm/logger'
+import { validateSqlQuery } from '@chm/sql-builder'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { ApiErrorType } from '@/lib/api/types'
+
+const MAX_GET_QUERY_LENGTH = 8_000
+const MAX_POST_QUERY_LENGTH = 100_000
+const MAX_CELL_VALUE_LENGTH = 10_000
+
+const SUPPORTED_FORMATS = ['JSONEachRow', 'JSON', 'CSV', 'TSV'] as const
+type SupportedFormat = (typeof SUPPORTED_FORMATS)[number]
+
+function isSupportedFormat(format: string): format is SupportedFormat {
+  return (SUPPORTED_FORMATS as readonly string[]).includes(format)
+}
+
+function truncateLargeValues<T>(data: T): T {
+  if (!Array.isArray(data)) return data
+  return data.map((row) => {
+    if (typeof row !== 'object' || row === null || Array.isArray(row))
+      return row
+    const truncated: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(row as Record<string, unknown>)) {
+      if (typeof value === 'string' && value.length > MAX_CELL_VALUE_LENGTH) {
+        truncated[key] =
+          value.slice(0, MAX_CELL_VALUE_LENGTH) +
+          `… (truncated, ${value.length} chars total)`
+      } else {
+        truncated[key] = value
+      }
+    }
+    return truncated
+  }) as T
+}
+
+function mapErrorTypeToStatusCode(errorType: string): number {
+  const statusMap: Record<string, number> = {
+    [ApiErrorType.ValidationError]: 400,
+    [ApiErrorType.PermissionError]: 403,
+    [ApiErrorType.TableNotFound]: 404,
+    [ApiErrorType.NetworkError]: 503,
+    [ApiErrorType.QueryError]: 500,
+    [ApiErrorType.SslError]: 503,
+    [ApiErrorType.TimeoutError]: 504,
+  }
+  return statusMap[errorType] ?? 500
+}
+
+function getSqlVerb(sql: string): string {
+  const match = sql.trim().match(/^(\w+)/i)
+  return match ? match[1].toUpperCase() : 'UNKNOWN'
+}
+
+async function executeQuery(params: {
+  sql: string
+  hostId: number
+  format: string
+  timezone: string | null
+  method: string
+  maxLength: number
+}): Promise<Response> {
+  const { sql, hostId, format, timezone, method, maxLength } = params
+
+  if (!sql) {
+    return Response.json(
+      {
+        success: false,
+        error: {
+          type: ApiErrorType.ValidationError,
+          message: 'Missing required parameter: sql',
+          details: { sql: 'missing' },
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  if (sql.length > maxLength) {
+    return Response.json(
+      {
+        success: false,
+        error: {
+          type: ApiErrorType.ValidationError,
+          message: `SQL query exceeds maximum length of ${maxLength} characters`,
+          details: { length: sql.length, maxLength },
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  try {
+    validateSqlQuery(sql)
+  } catch (validationError) {
+    return Response.json(
+      {
+        success: false,
+        error: {
+          type: ApiErrorType.ValidationError,
+          message:
+            validationError instanceof Error
+              ? validationError.message
+              : 'Invalid SQL query',
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  if (!isSupportedFormat(format)) {
+    return Response.json(
+      {
+        success: false,
+        error: {
+          type: ApiErrorType.ValidationError,
+          message: `Invalid format parameter. Allowed formats: ${SUPPORTED_FORMATS.join(', ')}`,
+          details: { format },
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  debug(`[${method} /api/v1/explorer/query] Executing query:`, {
+    sqlLength: sql.length,
+    sqlVerb: getSqlVerb(sql),
+    format,
+    timezone,
+  })
+
+  const clickhouse_settings: Record<string, string | number> = { readonly: 1 }
+  if (timezone) clickhouse_settings.session_timezone = timezone
+
+  const result = await fetchData({
+    query: sql,
+    hostId,
+    format: format as DataFormat,
+    clickhouse_settings,
+  })
+
+  if (result.error) {
+    error(`[${method} /api/v1/explorer/query] Query error:`, result.error)
+    return Response.json(
+      {
+        success: false,
+        error: {
+          type: result.error.type,
+          message: result.error.message,
+          details: result.error.details,
+        },
+      },
+      { status: mapErrorTypeToStatusCode(result.error.type) }
+    )
+  }
+
+  const truncatedData = truncateLargeValues(result.data)
+
+  return Response.json(
+    {
+      success: true,
+      data: truncatedData,
+      metadata: {
+        queryId: String(result.metadata.queryId ?? ''),
+        duration: Number(result.metadata.duration ?? 0),
+        rows: Number(result.metadata.rows ?? 0),
+        host: String(result.metadata.host ?? ''),
+      },
+    },
+    {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'private, max-age=0',
+      },
+    }
+  )
+}
+
+export const Route = createFileRoute('/api/v1/explorer/query')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const { searchParams } = new URL(request.url)
+
+        const hostIdRaw = searchParams.get('hostId')
+        if (hostIdRaw === null || hostIdRaw === '') {
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: 'Missing required parameter: hostId',
+              },
+            },
+            { status: 400 }
+          )
+        }
+        const hostId = Number(hostIdRaw)
+        if (!Number.isFinite(hostId)) {
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: `Invalid hostId: ${hostIdRaw}`,
+              },
+            },
+            { status: 400 }
+          )
+        }
+
+        const sql = searchParams.get('sql') ?? ''
+        const format = searchParams.get('format') ?? 'JSONEachRow'
+        const timezone = searchParams.get('timezone')
+
+        debug('[GET /api/v1/explorer/query]', { hostId, format, timezone })
+
+        try {
+          return await executeQuery({
+            sql,
+            hostId,
+            format,
+            timezone,
+            method: 'GET',
+            maxLength: MAX_GET_QUERY_LENGTH,
+          })
+        } catch (err) {
+          error('[GET /api/v1/explorer/query] Unexpected error:', err)
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: ApiErrorType.ValidationError,
+                message:
+                  err instanceof Error
+                    ? err.message
+                    : 'Unexpected error occurred',
+              },
+            },
+            { status: 400 }
+          )
+        }
+      },
+
+      POST: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        let body: Record<string, unknown>
+        try {
+          body = (await request.json()) as Record<string, unknown>
+        } catch {
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: 'Invalid JSON request body',
+              },
+            },
+            { status: 400 }
+          )
+        }
+
+        const sql = typeof body.sql === 'string' ? body.sql : ''
+        const hostIdParam = body.hostId
+        const format =
+          typeof body.format === 'string' ? body.format : 'JSONEachRow'
+        const timezone =
+          typeof body.timezone === 'string' ? body.timezone : null
+
+        if (hostIdParam === undefined || hostIdParam === null) {
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: 'Missing required parameter: hostId',
+              },
+            },
+            { status: 400 }
+          )
+        }
+
+        const hostId = Number(hostIdParam)
+        if (Number.isNaN(hostId)) {
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: `Invalid hostId: ${String(hostIdParam)}. Must be a valid number.`,
+              },
+            },
+            { status: 400 }
+          )
+        }
+
+        debug('[POST /api/v1/explorer/query]', { hostId, format, timezone })
+
+        try {
+          return await executeQuery({
+            sql,
+            hostId,
+            format,
+            timezone,
+            method: 'POST',
+            maxLength: MAX_POST_QUERY_LENGTH,
+          })
+        } catch (err) {
+          error('[POST /api/v1/explorer/query] Unexpected error:', err)
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: ApiErrorType.ValidationError,
+                message:
+                  err instanceof Error
+                    ? err.message
+                    : 'Unexpected error occurred',
+              },
+            },
+            { status: 400 }
+          )
+        }
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/skip-indexes.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/skip-indexes.ts
@@ -1,0 +1,117 @@
+/**
+ * Explorer skip indexes endpoint
+ * GET /api/v1/explorer/skip-indexes?hostId=0&database=default&table=users
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { debug, error } from '@chm/logger'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { executeTableConfig } from '@/lib/api/query-executor'
+import { getTableQuery } from '@/lib/api/table-registry'
+import { ApiErrorType } from '@/lib/api/types'
+
+export const Route = createFileRoute('/api/v1/explorer/skip-indexes')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const { searchParams } = new URL(request.url)
+
+        const hostIdRaw = searchParams.get('hostId')
+        if (hostIdRaw === null || hostIdRaw === '') {
+          return Response.json(
+            {
+              success: false,
+              error: { type: ApiErrorType.ValidationError, message: 'Missing required parameter: hostId' },
+            },
+            { status: 400 }
+          )
+        }
+        const hostId = Number(hostIdRaw)
+        if (!Number.isFinite(hostId)) {
+          return Response.json(
+            {
+              success: false,
+              error: { type: ApiErrorType.ValidationError, message: `Invalid hostId: ${hostIdRaw}` },
+            },
+            { status: 400 }
+          )
+        }
+
+        debug('[GET /api/v1/explorer/skip-indexes]', { hostId })
+
+        const searchParamsObj: Record<string, string> = {}
+        searchParams.forEach((value, key) => {
+          if (key !== 'hostId') searchParamsObj[key] = value
+        })
+
+        const queryDef = getTableQuery('explorer-skip-indexes', { hostId, searchParams: searchParamsObj })
+
+        if (!queryDef) {
+          error('[GET /api/v1/explorer/skip-indexes] Failed to build query')
+          return Response.json(
+            {
+              success: false,
+              error: { type: ApiErrorType.QueryError, message: 'Failed to build query for explorer-skip-indexes' },
+            },
+            { status: 500 }
+          )
+        }
+
+        const { result } = await executeTableConfig(
+          queryDef.queryConfig,
+          hostId,
+          queryDef.queryParams,
+          { bindings: env as Record<string, string | undefined> }
+        )
+
+        if (result.error) {
+          error('[GET /api/v1/explorer/skip-indexes] Query error:', result.error)
+          const statusMap: Record<string, number> = {
+            [ApiErrorType.ValidationError]: 400,
+            [ApiErrorType.PermissionError]: 403,
+            [ApiErrorType.TableNotFound]: 404,
+            [ApiErrorType.NetworkError]: 503,
+            [ApiErrorType.QueryError]: 500,
+            [ApiErrorType.SslError]: 503,
+            [ApiErrorType.TimeoutError]: 504,
+          }
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: result.error.type,
+                message: result.error.message,
+                details: result.error.details,
+              },
+            },
+            { status: statusMap[result.error.type] ?? 500 }
+          )
+        }
+
+        return Response.json(
+          {
+            success: true,
+            data: result.data,
+            metadata: {
+              queryId: String(result.metadata.queryId ?? ''),
+              duration: Number(result.metadata.duration ?? 0),
+              rows: Number(result.metadata.rows ?? 0),
+              host: String(result.metadata.host ?? ''),
+            },
+          },
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+              'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+            },
+          }
+        )
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/tables.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/tables.ts
@@ -1,0 +1,123 @@
+/**
+ * Explorer tables endpoint
+ * GET /api/v1/explorer/tables?hostId=0&database=default
+ *
+ * Returns list of tables in a database.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { fetchData } from '@chm/clickhouse-client'
+import { debug, error } from '@chm/logger'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { getTableQuery } from '@/lib/api/table-registry'
+import { ApiErrorType } from '@/lib/api/types'
+
+function mapErrorTypeToStatusCode(errorType: string): number {
+  const statusMap: Record<string, number> = {
+    [ApiErrorType.ValidationError]: 400,
+    [ApiErrorType.PermissionError]: 403,
+    [ApiErrorType.TableNotFound]: 404,
+    [ApiErrorType.NetworkError]: 503,
+    [ApiErrorType.QueryError]: 500,
+    [ApiErrorType.SslError]: 503,
+    [ApiErrorType.TimeoutError]: 504,
+  }
+  return statusMap[errorType] ?? 500
+}
+
+export const Route = createFileRoute('/api/v1/explorer/tables')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const { searchParams } = new URL(request.url)
+
+        const hostIdRaw = searchParams.get('hostId')
+        if (hostIdRaw === null || hostIdRaw === '') {
+          return Response.json(
+            {
+              success: false,
+              error: { type: ApiErrorType.ValidationError, message: 'Missing required parameter: hostId' },
+            },
+            { status: 400 }
+          )
+        }
+        const hostId = Number(hostIdRaw)
+        if (!Number.isFinite(hostId)) {
+          return Response.json(
+            {
+              success: false,
+              error: { type: ApiErrorType.ValidationError, message: `Invalid hostId: ${hostIdRaw}` },
+            },
+            { status: 400 }
+          )
+        }
+
+        debug('[GET /api/v1/explorer/tables]', { hostId })
+
+        const searchParamsObj: Record<string, string> = {}
+        searchParams.forEach((value, key) => {
+          if (key !== 'hostId') searchParamsObj[key] = value
+        })
+
+        const queryDef = getTableQuery('explorer-tables', { hostId, searchParams: searchParamsObj })
+
+        if (!queryDef) {
+          error('[GET /api/v1/explorer/tables] Failed to build query')
+          return Response.json(
+            {
+              success: false,
+              error: { type: ApiErrorType.QueryError, message: 'Failed to build query for tables' },
+            },
+            { status: 500 }
+          )
+        }
+
+        const result = await fetchData({
+          query: queryDef.query,
+          query_params: queryDef.queryParams,
+          hostId,
+          format: 'JSONEachRow',
+        })
+
+        if (result.error) {
+          error('[GET /api/v1/explorer/tables] Query error:', result.error)
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: result.error.type,
+                message: result.error.message,
+                details: result.error.details,
+              },
+            },
+            { status: mapErrorTypeToStatusCode(result.error.type) }
+          )
+        }
+
+        return Response.json(
+          {
+            success: true,
+            data: result.data,
+            metadata: {
+              queryId: String(result.metadata.queryId ?? ''),
+              duration: Number(result.metadata.duration ?? 0),
+              rows: Number(result.metadata.rows ?? 0),
+              host: String(result.metadata.host ?? ''),
+            },
+          },
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+              'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+            },
+          }
+        )
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/findings.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/findings.ts
@@ -1,0 +1,214 @@
+/**
+ * Findings API endpoint
+ * GET /api/v1/findings
+ *
+ * Returns recently recorded monitoring findings for a host (newest first).
+ * Findings are produced by autonomous checks (cron health-sweep, the agent's
+ * record_finding tool) and persisted in the app-owned findings table.
+ *
+ * Query parameters:
+ * - host (optional, default 0): Host to read findings from
+ * - severity (optional): Filter to "info" | "warning" | "critical"
+ * - since (optional): Time window, e.g. "24 HOUR", "7 DAY"
+ * - limit (optional, default 100, max 1000): Max findings to return
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { fetchData, getClient } from '@chm/clickhouse-client'
+import { debug, error, generateRequestId } from '@chm/logger'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { FINDINGS_TABLE } from '@/lib/app-tables'
+
+type FindingSeverity = 'info' | 'warning' | 'critical'
+
+interface FindingRow {
+  event_time: string
+  host_id: string
+  severity: string
+  category: string
+  source: string
+  title: string
+  detail: string
+  metric: string
+  value: number
+}
+
+interface ListFindingsOptions {
+  severity?: FindingSeverity
+  /** ClickHouse time expression to bound the lower edge, e.g. "24 HOUR", "7 DAY". */
+  since?: string
+  limit?: number
+}
+
+const VALID_SEVERITIES = new Set<FindingSeverity>([
+  'info',
+  'warning',
+  'critical',
+])
+
+/**
+ * Sanitize a ClickHouse interval expression like "24 HOUR" / "7 DAY".
+ * Returns the normalized expression or null when invalid.
+ */
+function sanitizeSince(value: string): string | null {
+  const match = value
+    .trim()
+    .toUpperCase()
+    .match(/^(\d{1,5})\s+(SECOND|MINUTE|HOUR|DAY|WEEK|MONTH)S?$/)
+  if (!match) return null
+  return `${match[1]} ${match[2]}`
+}
+
+// Per-host guard so we only attempt CREATE TABLE once per process per host.
+const ensuredHosts = new Set<number>()
+
+const CREATE_FINDINGS_TABLE = `
+  CREATE TABLE IF NOT EXISTS ${FINDINGS_TABLE} (
+    event_time DateTime DEFAULT now(),
+    host_id String,
+    severity LowCardinality(String),
+    category LowCardinality(String),
+    source LowCardinality(String),
+    title String,
+    detail String,
+    metric String,
+    value Float64
+  ) ENGINE = MergeTree
+  ORDER BY event_time
+  TTL event_time + INTERVAL 30 DAY
+`
+
+async function ensureTable(hostId: number): Promise<boolean> {
+  if (ensuredHosts.has(hostId)) return true
+  try {
+    const client = await getClient({ hostId })
+    await client.command({ query: CREATE_FINDINGS_TABLE })
+    ensuredHosts.add(hostId)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function listRecentFindings(
+  hostId: number,
+  opts: ListFindingsOptions = {}
+): Promise<FindingRow[]> {
+  const { severity, since, limit = 100 } = opts
+
+  const conditions: string[] = ['host_id = {hostId:String}']
+  const query_params: Record<string, unknown> = { hostId: String(hostId) }
+
+  if (severity) {
+    conditions.push('severity = {severity:String}')
+    query_params.severity = severity
+  }
+
+  if (since) {
+    const sanitized = sanitizeSince(since)
+    if (sanitized) {
+      conditions.push(`event_time >= now() - INTERVAL ${sanitized}`)
+    }
+  }
+
+  const safeLimit = Math.min(Math.max(Math.trunc(limit) || 0, 1), 1000)
+
+  const sql = `
+    SELECT
+      toString(event_time) AS event_time,
+      host_id,
+      severity,
+      category,
+      source,
+      title,
+      detail,
+      metric,
+      value
+    FROM ${FINDINGS_TABLE}
+    WHERE ${conditions.join(' AND ')}
+    ORDER BY event_time DESC
+    LIMIT ${safeLimit}
+  `
+
+  const result = await fetchData<FindingRow[]>({
+    query: sql,
+    hostId,
+    format: 'JSONEachRow',
+    query_params,
+    clickhouse_settings: { readonly: '1' },
+  })
+
+  if (result.error) {
+    return []
+  }
+
+  return result.data ?? []
+}
+
+export const Route = createFileRoute('/api/v1/findings')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const requestId = generateRequestId()
+
+        try {
+          const searchParams = new URL(request.url).searchParams
+
+          const hostId = Number.parseInt(searchParams.get('host') ?? '0', 10)
+          if (!Number.isInteger(hostId) || hostId < 0) {
+            return Response.json(
+              { error: 'Invalid host parameter: must be a non-negative integer' },
+              { status: 400, headers: { 'X-Request-ID': requestId } }
+            )
+          }
+
+          const severityParam = searchParams.get('severity') ?? undefined
+          if (
+            severityParam &&
+            !VALID_SEVERITIES.has(severityParam as FindingSeverity)
+          ) {
+            return Response.json(
+              { error: 'Invalid severity: must be info, warning, or critical' },
+              { status: 400, headers: { 'X-Request-ID': requestId } }
+            )
+          }
+
+          const since = searchParams.get('since') ?? undefined
+          const limitParam = searchParams.get('limit')
+          const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined
+
+          debug('[GET /api/v1/findings] Fetching findings', {
+            requestId,
+            hostId,
+            severity: severityParam,
+            since,
+            limit,
+          })
+
+          await ensureTable(hostId)
+
+          const findings = await listRecentFindings(hostId, {
+            severity: severityParam as FindingSeverity | undefined,
+            since,
+            limit,
+          })
+
+          return Response.json(
+            { findings, count: findings.length },
+            { headers: { 'X-Request-ID': requestId } }
+          )
+        } catch (err) {
+          error('[GET /api/v1/findings] Unexpected error:', err, { requestId })
+          return Response.json(
+            { error: err instanceof Error ? err.message : 'Unknown error' },
+            { status: 500, headers: { 'X-Request-ID': requestId } }
+          )
+        }
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/menu-counts/$key.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/menu-counts/$key.ts
@@ -1,0 +1,257 @@
+/**
+ * Menu count API endpoint
+ * GET /api/v1/menu-counts/$key
+ *
+ * Returns the count for a specific menu item based on a pre-defined query.
+ * This endpoint only accepts whitelisted count keys to prevent SQL injection.
+ *
+ * SECURITY: No raw SQL is accepted from clients.
+ * Only countKey identifiers are used to look up pre-defined queries.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { fetchData } from '@chm/clickhouse-client'
+import { debug, error, generateRequestId } from '@chm/logger'
+import { createErrorResponse } from '@/lib/api/error-handler'
+import {
+  getMenuCountQuery,
+  hasMenuCountKey,
+} from '@/lib/api/menu-count-registry'
+import { HostIdSchema, MenuCountKeySchema } from '@/lib/api/schemas'
+import {
+  CacheControl,
+  createSuccessResponse,
+} from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+
+const ROUTE_CONTEXT = { route: '/api/v1/menu-counts/$key', method: 'GET' }
+
+interface MenuCountResponse {
+  readonly count: number | null
+}
+
+async function handler(request: Request, params: { key: string }): Promise<Response> {
+  const requestId = generateRequestId()
+
+  try {
+    const countKey = params.key
+    const url = new URL(request.url)
+    const searchParams = url.searchParams
+
+    // Validate count key format
+    const countKeyResult = MenuCountKeySchema.safeParse(countKey)
+    if (!countKeyResult.success) {
+      error('[GET /api/v1/menu-counts] Invalid count key format:', countKey, {
+        requestId,
+      })
+      const errorResponse = createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: `Invalid count key format: ${countKey}`,
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+      const headers = new Headers(errorResponse.headers)
+      headers.set('X-Request-ID', requestId)
+      return new Response(errorResponse.body, {
+        status: errorResponse.status,
+        statusText: errorResponse.statusText,
+        headers,
+      })
+    }
+
+    // Validate count key exists in registry
+    if (!hasMenuCountKey(countKey)) {
+      error('[GET /api/v1/menu-counts] Count key not registered:', undefined, {
+        requestId,
+        countKey,
+      })
+      const errorResponse = createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: `Count key not found: ${countKey}`,
+        },
+        404,
+        ROUTE_CONTEXT
+      )
+      const headers = new Headers(errorResponse.headers)
+      headers.set('X-Request-ID', requestId)
+      return new Response(errorResponse.body, {
+        status: errorResponse.status,
+        statusText: errorResponse.statusText,
+        headers,
+      })
+    }
+
+    // Validate hostId parameter
+    const hostIdResult = HostIdSchema.safeParse(
+      searchParams.get('hostId') ?? '0'
+    )
+    if (!hostIdResult.success) {
+      error('[GET /api/v1/menu-counts] Invalid hostId parameter', undefined, {
+        requestId,
+        countKey,
+      })
+      const errorResponse = createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Invalid hostId parameter: must be a non-negative integer',
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+      const headers = new Headers(errorResponse.headers)
+      headers.set('X-Request-ID', requestId)
+      return new Response(errorResponse.body, {
+        status: errorResponse.status,
+        statusText: errorResponse.statusText,
+        headers,
+      })
+    }
+
+    const hostId = hostIdResult.data
+
+    debug('[GET /api/v1/menu-counts] Fetching count', {
+      requestId,
+      countKey,
+      hostId,
+    })
+
+    // Get the pre-defined query from registry
+    const menuCount = getMenuCountQuery(countKey)
+    if (!menuCount) {
+      error('[GET /api/v1/menu-counts] Count query not found:', undefined, {
+        requestId,
+        countKey,
+      })
+      const errorResponse = createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: `Count key not found in registry: ${countKey}`,
+        },
+        404,
+        ROUTE_CONTEXT
+      )
+      const headers = new Headers(errorResponse.headers)
+      headers.set('X-Request-ID', requestId)
+      return new Response(errorResponse.body, {
+        status: errorResponse.status,
+        statusText: errorResponse.statusText,
+        headers,
+      })
+    }
+
+    bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+    // Execute the query
+    const result = await fetchData({
+      query: menuCount.query,
+      format: 'JSONEachRow',
+      hostId,
+    })
+
+    // Handle errors - for optional tables, return null count only when the
+    // table genuinely does not exist. Other failures (permissions, timeouts,
+    // connectivity, query errors) must surface so the badge isn't silently wrong.
+    if (result.error) {
+      if (
+        menuCount.optional &&
+        result.error.type === ApiErrorType.TableNotFound
+      ) {
+        debug('[GET /api/v1/menu-counts] Optional table not found:', {
+          requestId,
+          countKey,
+        })
+
+        const response = createSuccessResponse<MenuCountResponse>(
+          { count: null },
+          { queryId: `menu-count-${countKey}`, rows: 1 }
+        )
+        const headers = new Headers(response.headers)
+        headers.set('X-Request-ID', requestId)
+        headers.set('Cache-Control', CacheControl.MEDIUM)
+        return new Response(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        })
+      }
+
+      error('[GET /api/v1/menu-counts] Query error:', undefined, {
+        requestId,
+        countKey,
+        error: result.error.message,
+      })
+      const errorResponse = createErrorResponse(
+        {
+          type: result.error.type as ApiErrorType,
+          message: result.error.message,
+        },
+        500,
+        { ...ROUTE_CONTEXT, hostId }
+      )
+      const headers = new Headers(errorResponse.headers)
+      headers.set('X-Request-ID', requestId)
+      return new Response(errorResponse.body, {
+        status: errorResponse.status,
+        statusText: errorResponse.statusText,
+        headers,
+      })
+    }
+
+    // Extract count from result
+    const data = result.data as Array<{ count?: number | string }>
+    const count =
+      data.length > 0 && data[0].count !== undefined
+        ? Number(data[0].count)
+        : null
+
+    debug('[GET /api/v1/menu-counts] Count result:', {
+      requestId,
+      countKey,
+      count,
+    })
+
+    const response = createSuccessResponse<MenuCountResponse>(
+      { count },
+      { queryId: `menu-count-${countKey}`, rows: 1 }
+    )
+    const headers = new Headers(response.headers)
+    headers.set('X-Request-ID', requestId)
+    headers.set('Cache-Control', CacheControl.MEDIUM)
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    })
+  } catch (err) {
+    error('[GET /api/v1/menu-counts] Unexpected error:', err, { requestId })
+    const errorResponse = createErrorResponse(
+      {
+        type: ApiErrorType.QueryError,
+        message: err instanceof Error ? err.message : 'Unknown error',
+      },
+      500,
+      ROUTE_CONTEXT
+    )
+    const headers = new Headers(errorResponse.headers)
+    headers.set('X-Request-ID', requestId)
+    return new Response(errorResponse.body, {
+      status: errorResponse.status,
+      statusText: errorResponse.statusText,
+      headers,
+    })
+  }
+}
+
+export const Route = createFileRoute('/api/v1/menu-counts/$key')({
+  server: {
+    handlers: {
+      GET: ({ request, params }) => handler(request, params),
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/menu-counts/index.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/menu-counts/index.ts
@@ -1,0 +1,187 @@
+/**
+ * Batched menu count API endpoint
+ * GET /api/v1/menu-counts?hostId=<n>
+ *
+ * Returns a map of every registered menu count key to its count in a single
+ * request, so the sidebar makes ONE call instead of N independent ones.
+ *
+ * Optional-table misses resolve to `null`, matching the per-key endpoint's
+ * behavior. A query failure on one key resolves that key to `null` rather than
+ * failing the whole batch, so a single broken count never blanks out every
+ * sidebar badge.
+ *
+ * SECURITY: No raw SQL is accepted from clients. Only pre-defined registry
+ * queries are executed.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { fetchData } from '@chm/clickhouse-client'
+import { debug, error, generateRequestId } from '@chm/logger'
+import { createErrorResponse } from '@/lib/api/error-handler'
+import {
+  getAvailableMenuCountKeys,
+  getMenuCountQuery,
+} from '@/lib/api/menu-count-registry'
+import { HostIdSchema } from '@/lib/api/schemas'
+import {
+  CacheControl,
+  createSuccessResponse,
+} from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+
+const ROUTE_CONTEXT = { route: '/api/v1/menu-counts', method: 'GET' }
+
+interface MenuCountsResponse {
+  readonly counts: Record<string, number | null>
+}
+
+/**
+ * Resolves a single registry key to its count value for the given host.
+ *
+ * Returns `undefined` when the key has no registered query.
+ * Returns `null` when the count is unavailable (optional table missing or
+ * query failed). Returns a number otherwise.
+ */
+async function resolveCount(
+  countKey: string,
+  hostId: number,
+  requestId: string
+): Promise<number | null | undefined> {
+  const menuCount = getMenuCountQuery(countKey)
+  if (!menuCount) return undefined
+
+  const result = await fetchData({
+    query: menuCount.query,
+    format: 'JSONEachRow',
+    hostId,
+  })
+
+  if (result.error) {
+    if (
+      menuCount.optional &&
+      result.error.type === ApiErrorType.TableNotFound
+    ) {
+      debug('[GET /api/v1/menu-counts] Optional table not found:', {
+        requestId,
+        countKey,
+      })
+      return null
+    }
+
+    error('[GET /api/v1/menu-counts] Query error:', undefined, {
+      requestId,
+      countKey,
+      error: result.error.message,
+    })
+    return null
+  }
+
+  const data = result.data as Array<{ count?: number | string }>
+  return data.length > 0 && data[0].count !== undefined
+    ? Number(data[0].count)
+    : null
+}
+
+async function handler(request: Request): Promise<Response> {
+  const requestId = generateRequestId()
+
+  try {
+    const url = new URL(request.url)
+    const searchParams = url.searchParams
+
+    // Validate hostId parameter
+    const hostIdResult = HostIdSchema.safeParse(
+      searchParams.get('hostId') ?? '0'
+    )
+    if (!hostIdResult.success) {
+      error('[GET /api/v1/menu-counts] Invalid hostId parameter', undefined, {
+        requestId,
+      })
+      const errorResponse = createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Invalid hostId parameter: must be a non-negative integer',
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+      const headers = new Headers(errorResponse.headers)
+      headers.set('X-Request-ID', requestId)
+      return new Response(errorResponse.body, {
+        status: errorResponse.status,
+        statusText: errorResponse.statusText,
+        headers,
+      })
+    }
+
+    const hostId = hostIdResult.data
+
+    debug('[GET /api/v1/menu-counts] Fetching batched counts', {
+      requestId,
+      hostId,
+    })
+
+    bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+    const keys = getAvailableMenuCountKeys()
+    const resolved = await Promise.all(
+      keys.map(async (key) => {
+        const value = await resolveCount(key, hostId, requestId)
+        return [key, value] as const
+      })
+    )
+
+    const counts: Record<string, number | null> = {}
+    for (const [key, value] of resolved) {
+      if (value !== undefined) {
+        counts[key] = value
+      }
+    }
+
+    debug('[GET /api/v1/menu-counts] Batched count result:', {
+      requestId,
+      keys: Object.keys(counts).length,
+    })
+
+    const response = createSuccessResponse<MenuCountsResponse>(
+      { counts },
+      { queryId: 'menu-counts-batch', rows: Object.keys(counts).length }
+    )
+    const headers = new Headers(response.headers)
+    headers.set('X-Request-ID', requestId)
+    headers.set('Cache-Control', CacheControl.MEDIUM)
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    })
+  } catch (err) {
+    error('[GET /api/v1/menu-counts] Unexpected error:', err, { requestId })
+    const errorResponse = createErrorResponse(
+      {
+        type: ApiErrorType.QueryError,
+        message: err instanceof Error ? err.message : 'Unknown error',
+      },
+      500,
+      ROUTE_CONTEXT
+    )
+    const headers = new Headers(errorResponse.headers)
+    headers.set('X-Request-ID', requestId)
+    return new Response(errorResponse.body, {
+      status: errorResponse.status,
+      statusText: errorResponse.statusText,
+      headers,
+    })
+  }
+}
+
+export const Route = createFileRoute('/api/v1/menu-counts/')({
+  server: {
+    handlers: {
+      GET: ({ request }) => handler(request),
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/overview.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/overview.ts
@@ -1,0 +1,191 @@
+/**
+ * Overview Batch API Endpoint
+ * GET /api/v1/overview?hostId=0
+ *
+ * Batch endpoint that returns all overview page metrics in a single request.
+ * Ported from apps/dashboard/app/api/v1/overview/route.ts.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { fetchData } from '@chm/clickhouse-client'
+import { error } from '@chm/logger'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+
+const ROUTE_CONTEXT = { route: '/api/v1/overview' }
+
+function formatSize(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+  const k = 1024
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return `${parseFloat((bytes / k ** i).toFixed(2))} ${units[i]}`
+}
+
+export const Route = createFileRoute('/api/v1/overview')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const url = new URL(request.url)
+        const hostIdRaw = url.searchParams.get('hostId')
+
+        if (hostIdRaw === null || hostIdRaw === '') {
+          return Response.json(
+            { success: false, error: 'Missing required parameter: hostId' },
+            { status: 400 }
+          )
+        }
+
+        const hostId = Number.parseInt(hostIdRaw, 10)
+        if (!Number.isInteger(hostId) || hostId < 0) {
+          return Response.json(
+            {
+              success: false,
+              error: 'Invalid parameter: hostId must be a non-negative integer',
+            },
+            { status: 400 }
+          )
+        }
+
+        try {
+          // Single batch query returning all overview metrics
+          const result = await fetchData({
+            query: `
+              -- Running queries count
+              SELECT 'running_queries' as metric, COUNT() as value, COUNT() as value_num
+              FROM system.processes
+              WHERE is_cancelled = 0
+
+              UNION ALL
+
+              -- Today's query count
+              SELECT 'today_queries' as metric, COUNT() as value, COUNT() as value_num
+              FROM merge('system', '^query_log')
+              WHERE type = 'QueryFinish' AND toDate(event_time) = today()
+
+              UNION ALL
+
+              -- Database count
+              SELECT 'database_count' as metric, countDistinct(database) as value, countDistinct(database) as value_num
+              FROM system.tables
+              WHERE lower(database) NOT IN ('system', 'information_schema')
+
+              UNION ALL
+
+              -- Table count
+              SELECT 'table_count' as metric, countDistinct(format('{}.{}', database, table)) as value, countDistinct(format('{}.{}', database, table)) as value_num
+              FROM system.tables
+              WHERE lower(database) NOT IN ('system', 'information_schema')
+
+              UNION ALL
+
+              -- Disk usage (used space in bytes)
+              SELECT 'disk_used' as metric, toString((total_space - unreserved_space)) as value, (total_space - unreserved_space) as value_num
+              FROM system.disks
+              ORDER BY name
+              LIMIT 1
+
+              UNION ALL
+
+              -- Disk total space
+              SELECT 'disk_total' as metric, toString(total_space) as value, total_space as value_num
+              FROM system.disks
+              ORDER BY name
+              LIMIT 1
+            `,
+            hostId,
+            format: 'JSONEachRow',
+          })
+
+          if (result.error || !result.data) {
+            error('[GET /api/v1/overview] Query error:', result.error)
+            return Response.json(
+              {
+                success: false,
+                error: result.error?.message || 'No data returned',
+              },
+              { status: 500 }
+            )
+          }
+
+          const metrics = result.data as Array<{
+            metric: string
+            value: string
+            value_num: number
+          }>
+
+          const overviewData: Record<string, number> = {}
+          for (const row of metrics) {
+            overviewData[row.metric] = row.value_num
+          }
+
+          // Fetch host info separately (different return shape)
+          const hostResult = await fetchData({
+            query: `
+              SELECT
+                version() as version,
+                formatReadableTimeDelta(uptime()) as uptime,
+                hostName() as hostname
+            `,
+            hostId,
+            format: 'JSONEachRow',
+          })
+
+          const hostInfo = (
+            hostResult.data as Array<{
+              version: string
+              uptime: string
+              hostname: string
+            }>
+          )?.[0] || { version: '', uptime: '', hostname: '' }
+
+          const diskUsed = overviewData.disk_used || 0
+          const diskTotal = overviewData.disk_total || 1
+          const diskPercent =
+            diskTotal > 0 ? Math.round((diskUsed / diskTotal) * 100) : 0
+
+          const response = {
+            runningQueries: overviewData.running_queries || 0,
+            todayQueries: overviewData.today_queries || 0,
+            databaseCount: overviewData.database_count || 0,
+            tableCount: overviewData.table_count || 0,
+            diskUsage: {
+              used: formatSize(diskUsed),
+              total: formatSize(diskTotal),
+              percent: diskPercent,
+              usedBytes: diskUsed,
+              totalBytes: diskTotal,
+            },
+            hostInfo: {
+              version: hostInfo.version || '',
+              uptime: hostInfo.uptime || '',
+              hostname: hostInfo.hostname || '',
+            },
+          }
+
+          return Response.json({
+            success: true,
+            data: response,
+            metadata: {
+              rows: Number(result.metadata.rows ?? 0),
+              duration: Number(result.metadata.duration ?? 0),
+            },
+          })
+        } catch (err) {
+          error('[GET /api/v1/overview] Error:', err, ROUTE_CONTEXT)
+          return Response.json(
+            {
+              success: false,
+              error:
+                err instanceof Error ? err.message : 'Internal server error',
+            },
+            { status: 500 }
+          )
+        }
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/peerdb-status.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/peerdb-status.ts
@@ -1,0 +1,172 @@
+/**
+ * PeerDB connection status (server-side probe).
+ *
+ * Returns a typed, browser-safe summary the connection pill can render without
+ * sniffing HTTP status codes: whether PeerDB is configured, the sanitized host
+ * (origin only — never credentials), and the live reachability/auth state from
+ * a cheap `/version` probe.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { generateRequestId } from '@chm/logger'
+
+/** Browser-safe PeerDB connection status payload. */
+interface PeerDBStatusPayload {
+  configured: boolean
+  /** Sanitized host as `hostname:port` (no scheme/credentials/path), or null. */
+  host: string | null
+  state: 'connected' | 'auth' | 'unreachable' | 'not-configured'
+  version?: string
+  error?: string
+}
+
+interface PeerDBConfig {
+  baseUrl: string
+  password?: string
+}
+
+interface VersionResponse {
+  version?: string
+}
+
+class PeerDBError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message)
+    this.name = 'PeerDBError'
+  }
+}
+
+/** Strip credentials and path so only the origin is exposed to the browser. */
+function sanitizeHost(baseUrl: string): string {
+  try {
+    return new URL(baseUrl).host
+  } catch {
+    let sanitized = baseUrl.replace(/^[a-z]+:\/\//i, '')
+    const atIndex = sanitized.indexOf('@')
+    if (atIndex !== -1) {
+      sanitized = sanitized.slice(atIndex + 1)
+    }
+    return sanitized.split('/')[0]
+  }
+}
+
+function getPeerDBConfig(
+  bindings: Record<string, string | undefined>
+): PeerDBConfig | null {
+  const baseUrl = bindings.PEERDB_API_URL?.trim()
+  if (!baseUrl) return null
+  return {
+    baseUrl: baseUrl.replace(/\/+$/, ''),
+    password: bindings.PEERDB_PASSWORD?.trim() || undefined,
+  }
+}
+
+function authHeader(config: PeerDBConfig): Record<string, string> {
+  if (!config.password) return {}
+  // PeerDB uses Basic auth with an empty username: base64(':' + password)
+  // btoa is available in all Workers runtimes (no Buffer needed)
+  const token = btoa(`:${config.password}`)
+  return { Authorization: `Basic ${token}` }
+}
+
+const FETCH_TIMEOUT_MS = 10_000
+
+async function peerdbFetch<T = unknown>(
+  config: PeerDBConfig,
+  path: string
+): Promise<T> {
+  const url = `${config.baseUrl}${path.startsWith('/') ? path : `/${path}`}`
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+  let response: Response
+  try {
+    response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeader(config),
+      },
+    })
+  } catch (err) {
+    const aborted = err instanceof Error && err.name === 'AbortError'
+    throw new PeerDBError(
+      aborted
+        ? `PeerDB request timed out after ${FETCH_TIMEOUT_MS}ms`
+        : `Failed to reach PeerDB: ${
+            err instanceof Error ? err.message : 'unknown error'
+          }`,
+      502
+    )
+  } finally {
+    clearTimeout(timeout)
+  }
+
+  if (!response.ok) {
+    throw new PeerDBError(
+      `PeerDB API error ${response.status}: ${response.statusText}`,
+      response.status
+    )
+  }
+
+  return (await response.json()) as T
+}
+
+export const Route = createFileRoute('/api/v1/peerdb-status')({
+  server: {
+    handlers: {
+      GET: async () => {
+        const bindings = env as Record<string, string | undefined>
+        const requestId = generateRequestId()
+
+        const config = getPeerDBConfig(bindings)
+
+        if (!config) {
+          const payload: PeerDBStatusPayload = {
+            configured: false,
+            host: null,
+            state: 'not-configured',
+          }
+          return Response.json(
+            { success: true, data: payload, metadata: { queryId: requestId } },
+            { status: 200 }
+          )
+        }
+
+        const host = sanitizeHost(config.baseUrl)
+
+        try {
+          const version = await peerdbFetch<VersionResponse>(config, '/v1/version')
+          const payload: PeerDBStatusPayload = {
+            configured: true,
+            host,
+            state: 'connected',
+            version: version.version,
+          }
+          return Response.json(
+            { success: true, data: payload, metadata: { queryId: requestId } },
+            { status: 200 }
+          )
+        } catch (err) {
+          const status = err instanceof PeerDBError ? err.status : 0
+          const state = status === 401 || status === 403 ? 'auth' : 'unreachable'
+          const payload: PeerDBStatusPayload = {
+            configured: true,
+            host,
+            state,
+            error: err instanceof Error ? err.message : 'PeerDB probe failed',
+          }
+          return Response.json(
+            { success: true, data: payload, metadata: { queryId: requestId } },
+            { status: 200 }
+          )
+        }
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/table-availability.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/table-availability.ts
@@ -1,0 +1,200 @@
+/**
+ * Batched Table Availability API endpoint
+ * GET /api/v1/table-availability?hostId=<n>
+ *
+ * Returns a map of every ClickHouse system table referenced in the menu to its
+ * availability status (boolean) on the current host in a single request, so the
+ * sidebar can dim/mute optional features whose system tables are not configured.
+ *
+ * SECURITY: only table checks declared in menu.ts are executed. Per-route
+ * feature-permission gating is centralized in the request middleware (#1397);
+ * this route no longer authorizes per-table (the previous `isTableAuthorized`
+ * path), so it now reports availability for every menu-referenced table.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { MenuItem } from '@/components/menu/types'
+
+import { env } from 'cloudflare:workers'
+import { checkTableExists } from '@chm/clickhouse-client/table-existence-cache'
+import { debug, error, generateRequestId } from '@chm/logger'
+import { createErrorResponse } from '@/lib/api/error-handler'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import {
+  CacheControl,
+  createSuccessResponse,
+} from '@/lib/api/shared/response-builder'
+import { HostIdSchema } from '@/lib/api/schemas'
+import { ApiErrorType } from '@/lib/api/types'
+import { menuItemsConfig } from '@/menu'
+
+const ROUTE_CONTEXT = { route: '/api/v1/table-availability', method: 'GET' }
+
+interface TableAvailabilityResponse {
+  readonly available: Record<string, boolean>
+}
+
+/** Extracts all unique table checks declared in the menu items. */
+function extractTableChecks(items: readonly MenuItem[]): string[] {
+  const tables = new Set<string>()
+
+  function recurse(menuItems: readonly MenuItem[]) {
+    for (const item of menuItems) {
+      if (item.tableCheck) {
+        const itemTables = Array.isArray(item.tableCheck)
+          ? item.tableCheck
+          : [item.tableCheck]
+        for (const t of itemTables) {
+          tables.add(t)
+        }
+      }
+      if (item.items) {
+        recurse(item.items)
+      }
+    }
+  }
+
+  recurse(items)
+  return Array.from(tables)
+}
+
+/** Resolves a single table check to its availability status. */
+async function resolveTableAvailability(
+  table: string,
+  hostId: number,
+  requestId: string
+): Promise<boolean | undefined> {
+  // Parse database and table names
+  const parts = table.split('.')
+  const db = parts.length > 1 ? parts[0] : 'system'
+  const tbl = parts.length > 1 ? parts[1] : parts[0]
+
+  try {
+    return await checkTableExists(hostId, db, tbl)
+  } catch (err) {
+    error('[GET /api/v1/table-availability] Check table error:', err, {
+      requestId,
+      table,
+      hostId,
+    })
+    return undefined // Omit from map — preserves client fail-open
+  }
+}
+
+export const Route = createFileRoute('/api/v1/table-availability')({
+  server: {
+    handlers: {
+      GET: async ({ request }): Promise<Response> => {
+        const requestId = generateRequestId()
+
+        try {
+          const searchParams = new URL(request.url).searchParams
+
+          // Validate hostId parameter
+          const hostIdResult = HostIdSchema.safeParse(
+            searchParams.get('hostId') ?? '0'
+          )
+          if (!hostIdResult.success) {
+            error(
+              '[GET /api/v1/table-availability] Invalid hostId parameter',
+              undefined,
+              { requestId }
+            )
+            const errorResponse = createErrorResponse(
+              {
+                type: ApiErrorType.ValidationError,
+                message:
+                  'Invalid hostId parameter: must be a non-negative integer',
+              },
+              400,
+              ROUTE_CONTEXT
+            )
+            const headers = new Headers(errorResponse.headers)
+            headers.set('X-Request-ID', requestId)
+            return new Response(errorResponse.body, {
+              status: errorResponse.status,
+              statusText: errorResponse.statusText,
+              headers,
+            })
+          }
+
+          const hostId = hostIdResult.data
+          bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+          debug(
+            '[GET /api/v1/table-availability] Fetching table availability',
+            {
+              requestId,
+              hostId,
+            }
+          )
+
+          const tables = extractTableChecks(menuItemsConfig)
+          const resolved = await Promise.all(
+            tables.map(async (table) => {
+              const available = await resolveTableAvailability(
+                table,
+                hostId,
+                requestId
+              )
+              return [table, available] as const
+            })
+          )
+
+          const available: Record<string, boolean> = {}
+          for (const [table, status] of resolved) {
+            if (status !== undefined) {
+              available[table] = status
+            }
+          }
+
+          debug(
+            '[GET /api/v1/table-availability] Batched availability result:',
+            {
+              requestId,
+              tablesToCheck: tables.length,
+              availableTablesCount: Object.keys(available).length,
+            }
+          )
+
+          const response = createSuccessResponse<TableAvailabilityResponse>(
+            { available },
+            {
+              queryId: 'table-availability-batch',
+              rows: Object.keys(available).length,
+            }
+          )
+
+          const headers = new Headers(response.headers)
+          headers.set('X-Request-ID', requestId)
+          headers.set('Cache-Control', CacheControl.NONE)
+
+          return new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers,
+          })
+        } catch (err) {
+          error('[GET /api/v1/table-availability] Unexpected error:', err, {
+            requestId,
+          })
+          const errorResponse = createErrorResponse(
+            {
+              type: ApiErrorType.QueryError,
+              message: err instanceof Error ? err.message : 'Unknown error',
+            },
+            500,
+            ROUTE_CONTEXT
+          )
+          const headers = new Headers(errorResponse.headers)
+          headers.set('X-Request-ID', requestId)
+          return new Response(errorResponse.body, {
+            status: errorResponse.status,
+            statusText: errorResponse.statusText,
+            headers,
+          })
+        }
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/tables/$name/filter-options.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/tables/$name/filter-options.ts
@@ -1,0 +1,146 @@
+/**
+ * Filter options endpoint
+ * GET /api/v1/tables/$name/filter-options?hostId=0&key=user
+ *
+ * Returns the distinct values for a `select` filter field that declares
+ * `dynamicOptions`. Table and column come exclusively from the trusted
+ * filter schema — the request only supplies the (validated) config name and
+ * field key, never raw SQL identifiers.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { QueryConfig } from '@/types/query-config'
+
+import { env } from 'cloudflare:workers'
+import { fetchData } from '@chm/clickhouse-client'
+import { QUERY_COMMENT } from '@chm/clickhouse-client/constants'
+import { error } from '@chm/logger'
+import { getTableConfig } from '@/lib/api/table-registry'
+import { ApiErrorType } from '@/lib/api/types'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+
+const ROUTE_CONTEXT = {
+  route: '/api/v1/tables/$name/filter-options',
+  method: 'GET',
+}
+
+interface FilterOption {
+  value: string
+  count: number
+}
+
+export const Route = createFileRoute('/api/v1/tables/$name/filter-options')({
+  server: {
+    handlers: {
+      GET: async ({ request, params }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const { name } = params
+        const { searchParams } = new URL(request.url)
+        const routeContext = { ...ROUTE_CONTEXT, tableName: name }
+
+        const rawHostId = searchParams.get('hostId') ?? '0'
+        const hostId = Number.parseInt(rawHostId, 10)
+        const key = searchParams.get('key')
+
+        if (!key) {
+          return Response.json(
+            {
+              success: false,
+              metadata: {
+                queryId: '',
+                duration: 0,
+                rows: 0,
+                host: String(hostId),
+              },
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: 'Missing required parameter: key',
+              },
+            },
+            { status: 400 }
+          )
+        }
+
+        const config = getTableConfig(name) as QueryConfig | undefined
+        const field = config?.filterSchema?.fields.find((f) => f.key === key)
+
+        if (!field?.dynamicOptions) {
+          return Response.json(
+            {
+              success: false,
+              metadata: {
+                queryId: '',
+                duration: 0,
+                rows: 0,
+                host: String(hostId),
+              },
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: `Filter field "${key}" does not provide dynamic options`,
+              },
+            },
+            { status: 404 }
+          )
+        }
+
+        const { table, column, where } = field.dynamicOptions
+        const whereClause = where
+          ? `WHERE ${where} AND notEmpty(toString(${column}))`
+          : `WHERE notEmpty(toString(${column}))`
+        const sql = `
+          ${QUERY_COMMENT}
+          SELECT
+            ${column} AS value,
+            count() AS count
+          FROM ${table}
+          ${whereClause}
+          GROUP BY value
+          ORDER BY count DESC
+          LIMIT 200`
+
+        const result = await fetchData<FilterOption[]>({
+          query: sql,
+          hostId,
+          format: 'JSONEachRow',
+        })
+
+        if (result.error) {
+          error(
+            `[GET /api/v1/tables/${name}/filter-options] Query error:`,
+            result.error
+          )
+          return Response.json(
+            {
+              success: false,
+              metadata: {
+                queryId: '',
+                duration: 0,
+                rows: 0,
+                host: String(hostId),
+              },
+              error: {
+                type: result.error.type as ApiErrorType,
+                message: result.error.message,
+              },
+            },
+            { status: 500 }
+          )
+        }
+
+        return Response.json(
+          { options: result.data ?? [] },
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+              'Cache-Control':
+                'public, s-maxage=120, stale-while-revalidate=300',
+            },
+          }
+        )
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/tables/index.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/tables/index.ts
@@ -1,0 +1,114 @@
+/**
+ * Tables list endpoint
+ * GET /api/v1/tables?hostId=0&limit=500
+ *
+ * Returns a lightweight list of tables for client-side autocomplete.
+ * Excludes system databases and temporary tables.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { ApiErrorType } from '@/lib/api/types'
+
+import { env } from 'cloudflare:workers'
+import { fetchData } from '@chm/clickhouse-client'
+import { debug, error } from '@chm/logger'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+
+const ROUTE_CONTEXT = {
+  route: '/api/v1/tables',
+  method: 'GET',
+}
+
+const DEFAULT_LIMIT = 500
+const MAX_LIMIT = 1000
+
+interface TableRow {
+  database: string
+  name: string
+  engine: string
+  total_rows: string
+}
+
+export const Route = createFileRoute('/api/v1/tables')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const { searchParams } = new URL(request.url)
+        const rawHostId = searchParams.get('hostId') ?? '0'
+        const hostId = Number.parseInt(rawHostId, 10)
+
+        const rawLimit = searchParams.get('limit')
+        const parsedLimit = rawLimit
+          ? Number.parseInt(rawLimit, 10)
+          : DEFAULT_LIMIT
+        const limit =
+          Number.isFinite(parsedLimit) && parsedLimit > 0
+            ? Math.min(parsedLimit, MAX_LIMIT)
+            : DEFAULT_LIMIT
+
+        debug('[GET /api/v1/tables]', { hostId, limit })
+
+        const result = await fetchData<TableRow[]>({
+          query: `
+            SELECT
+              database,
+              name,
+              engine,
+              toString(total_rows) AS total_rows
+            FROM system.tables
+            WHERE database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
+              AND NOT is_temporary
+            ORDER BY total_bytes DESC NULLS LAST
+            LIMIT {limit: UInt32}
+          `,
+          query_params: { limit },
+          hostId,
+          format: 'JSONEachRow',
+        })
+
+        if (result.error) {
+          error('[GET /api/v1/tables] Query error:', result.error)
+          return Response.json(
+            {
+              success: false,
+              metadata: {
+                queryId: '',
+                duration: 0,
+                rows: 0,
+                host: String(hostId),
+              },
+              error: {
+                type: result.error.type as ApiErrorType,
+                message: result.error.message,
+              },
+            },
+            { status: 500 }
+          )
+        }
+
+        const rows = result.data ?? []
+        return Response.json(
+          {
+            success: true,
+            data: rows,
+            metadata: {
+              queryId: String(result.metadata.queryId || ''),
+              rows: rows.length,
+              host: String(result.metadata.host || ''),
+            },
+          },
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+              'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+            },
+          }
+        )
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/tsconfig.json
+++ b/apps/dashboard-tsr/tsconfig.json
@@ -18,9 +18,14 @@
       "@chm/clickhouse-client/constants": [
         "../../packages/clickhouse-client/src/clickhouse/constants.ts"
       ],
+      "@chm/clickhouse-client/table-existence-cache": [
+        "../../packages/clickhouse-client/src/table-existence-cache.ts"
+      ],
       "@chm/types": ["../../packages/types/src/index.ts"],
       "@chm/types/*": ["../../packages/types/src/*"],
-      "@chm/mcp-server/data": ["../../packages/mcp-server/src/data/mcp-tools-data.ts"],
+      "@chm/mcp-server/data": [
+        "../../packages/mcp-server/src/data/mcp-tools-data.ts"
+      ],
       "@clickhouse/client": ["./node_modules/@clickhouse/client"],
       "@clickhouse/client-web": [
         "./node_modules/@clickhouse/client-web/dist/index.d.ts"

--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -80,12 +80,17 @@ export default defineConfig({
       '@chm/clickhouse-client/constants': r(
         '../../packages/clickhouse-client/src/clickhouse/constants.ts'
       ),
+      '@chm/clickhouse-client/table-existence-cache': r(
+        '../../packages/clickhouse-client/src/table-existence-cache.ts'
+      ),
       // Generic entry (must be after sub-paths)
       '@chm/clickhouse-client': r(
         '../../packages/clickhouse-client/src/index.ts'
       ),
       '@chm/types': r('../../packages/types/src/index.ts'),
-      '@chm/mcp-server/data': r('../../packages/mcp-server/src/data/mcp-tools-data.ts'),
+      '@chm/mcp-server/data': r(
+        '../../packages/mcp-server/src/data/mcp-tools-data.ts'
+      ),
       // The node @clickhouse/client (node:os/node:stream/TCP) is a dead static
       // import in clickhouse-client.ts (routes force web:true). Alias it to an
       // empty stub so it resolves in the bundle on BOTH targets.


### PR DESCRIPTION
Part of the Next.js → TanStack Start migration (epic #1392, Phase 5 / #1396).

Ports ~22 `/api/v1/*` route handlers from `apps/dashboard` (Next) to `apps/dashboard-tsr` (`createFileRoute` server handlers). Generated by a batched dynamic workflow (Opus for the security-critical `data` + auth-judgment `config` routes; Sonnet for the mechanical bulk), then hand-verified with `tsc`.

### Routes ported
data (GET+POST), config, overview, actions, explain, table-availability, findings, peerdb-status, dashboard/settings, cluster-counts/$key, menu-counts (index + $key), tables (index + $name/filter-options), explorer/{columns, databases, ddl, dependencies, indexes, preview, projections, query, skip-indexes, tables}.

### Conversion contract (documented in `scripts/route-port-contract.md`)
- Next `export const GET = …` → `createFileRoute(path).server.handlers`
- `bridgeClickHouseEnv(env)` before `fetchData` — workerd has no ambient `process.env`
- per-route `authorizeFeatureRequest` **dropped**; auth centralizes in the request middleware (#1397), matching the merged `charts/$name` / `tables/$name` precedent
- `[name]`→`$name`, `[key]`→`$key`; removed `export const dynamic`
- **`data` route security preserved exactly**: `validateSqlQuery`, dashboard-allowlist validation, reject client-supplied `queryConfig`; co-located `cache-manager`/`dashboard-query-validator` moved to `lib/api/data/`
- added `@chm/clickhouse-client/table-existence-cache` subpath alias (vite + tsconfig)

### Verification
`tsc --noEmit` is clean for these files **except** the expected `routeTree.gen` regeneration errors (`createFileRoute(path)` not yet in `FileRoutesByPath`) — resolved by the TanStack Router plugin at dev/build, identical to the already-merged `host-status`/`hosts`/`notifications` routes. dashboard-tsr build is not in CI yet (Phase 6 / #1403), so this was verified locally.

### Deferred (follow-up)
- `cluster-topology` — needs `assembleTopology` + keeper/cluster-live-metrics configs wired
- `agent`, `agents/*`, `conversations*`, `auth/api-key`, `browser-connections/*`, `peerdb/$` (splat), `health/webhook`, `cron/*`, `clean`, `init` — depend on the middleware / AI / D1 subsystems (Phase 5 sub-tasks #1397 / #1399 / #1401)

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added comprehensive dashboard API endpoints supporting query execution, database exploration, and settings management
  * Added explorer functionality to view and analyze database structures (tables, columns, indexes, projections, dependencies)
  * Added cluster metrics collection and monitoring features including findings/alerts retrieval
  * Added PeerDB integration status monitoring
  * Added table availability checking and dynamic filter options

* **Documentation**
  * Added specification for API handler migration and porting guidelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->