### PR TITLE
feat(ci): add preview deployment for TanStack Start dashboard

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -187,6 +187,7 @@ jobs:
               '| App | Preview URL |',
               '|-----|-------------|',
               '| **Dashboard** | https://preview.dash.chmonitor.dev |',
+              '| **Dashboard (TSR)** | https://preview.dash-tsr.chmonitor.dev |',
               '| **MCP** | https://preview.dash.chmonitor.dev/api/mcp |',
               '| **Landing** | https://preview.chmonitor.dev |',
               '| **Docs** | https://preview.docs.chmonitor.dev |',
@@ -257,6 +258,165 @@ jobs:
             ].join('\n');
 
             // Always create a new comment to preserve deployment history
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+
+      - name: Fail job if build or deploy failed
+        if: always() && (steps.build.outcome == 'failure' || steps.deploy.outcome == 'failure')
+        run: exit 1
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Preview TSR: deploys the TanStack Start dashboard for pull requests to
+  # https://preview.dash-tsr.chmonitor.dev. Runs in parallel with the
+  # Next.js preview job. Own lockfile (not in root workspaces).
+  # ──────────────────────────────────────────────────────────────────────────
+  preview-tsr:
+    name: preview-tsr
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+
+    defaults:
+      run:
+        working-directory: apps/dashboard-tsr
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Bun Cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-tsr-v1-${{ hashFiles('apps/dashboard-tsr/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-tsr-v1-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build for Cloudflare
+        id: build
+        continue-on-error: true
+        run: bun run build 2>&1 | tee /tmp/tsr-build-output.txt
+          ; exit ${PIPESTATUS[0]}
+
+      - name: Set preview secrets
+        if: steps.build.outcome == 'success'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_API_BASE: ${{ secrets.LLM_API_BASE }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENROUTER_API_BASE: ${{ secrets.OPENROUTER_API_BASE }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          NVIDIA_API_BASE: ${{ secrets.NVIDIA_API_BASE }}
+          ANYROUTER_API_KEY: ${{ secrets.ANYROUTER_API_KEY }}
+          ANYROUTER_API_BASE: ${{ secrets.ANYROUTER_API_BASE }}
+          CLERK_SECRET_KEY_TEST: ${{ secrets.CLERK_SECRET_KEY_TEST }}
+          CHM_API_KEY_SECRET: ${{ secrets.CHM_API_KEY_SECRET }}
+          CLICKHOUSE_TZ: ${{ secrets.CLICKHOUSE_TZ || 'UTC' }}
+          CLICKHOUSE_EXCLUDE_USER_DEFAULT: ${{ secrets.CLICKHOUSE_EXCLUDE_USER_DEFAULT || '' }}
+          NEXT_QUERY_CACHE_TTL: ${{ secrets.NEXT_QUERY_CACHE_TTL || '3600' }}
+        run: |
+          set -euo pipefail
+          bun ../../scripts/set-secrets.ts --from-env --strict --target dashboard-tsr --env preview
+
+      - name: Deploy preview to Cloudflare Workers
+        id: deploy
+        if: steps.build.outcome == 'success'
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx --yes --package=wrangler@4 wrangler deploy --env preview --minify 2>&1 | tee /tmp/tsr-deploy-output.txt
+          exit ${PIPESTATUS[0]}
+
+      - name: Comment preview URL on PR
+        if: steps.deploy.outcome == 'success'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const sha = '${{ github.event.pull_request.head.sha }}'.slice(0, 7);
+            const body = [
+              '### ☁️ Cloudflare Preview Deployment (TSR)',
+              '',
+              '| App | Preview URL |',
+              '|-----|-------------|',
+              '| **Dashboard (TSR)** | https://preview.dash-tsr.chmonitor.dev |',
+              '',
+              `| **Commit** | \`${sha}\` |`,
+              '',
+              '> TanStack Start preview — automatically updated on every push to this PR.',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+
+      - name: Comment failure on PR
+        if: always() && (steps.build.outcome == 'failure' || steps.deploy.outcome == 'failure')
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const sha = '${{ github.event.pull_request.head.sha }}'.slice(0, 7);
+            const buildOutcome = '${{ steps.build.outcome }}';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            let failedStep, logContent;
+            if (buildOutcome === 'failure') {
+              failedStep = 'Build (`bun run build`)';
+              logContent = fs.existsSync('/tmp/tsr-build-output.txt')
+                ? fs.readFileSync('/tmp/tsr-build-output.txt', 'utf8')
+                : 'No build output captured.';
+            } else {
+              failedStep = 'Deploy (`wrangler deploy --env preview`)';
+              logContent = fs.existsSync('/tmp/tsr-deploy-output.txt')
+                ? fs.readFileSync('/tmp/tsr-deploy-output.txt', 'utf8')
+                : 'No deploy output captured.';
+            }
+
+            const lines = logContent.split('\n');
+            const truncated = lines.length > 200;
+            const tail = lines.slice(-200).join('\n');
+
+            const body = [
+              '### ☁️ Cloudflare Preview Deployment (TSR) — Failed',
+              '',
+              `| **Failed step** | ${failedStep} |`,
+              `| **Commit** | \`${sha}\` |`,
+              `| **Workflow run** | [View logs](${runUrl}) |`,
+              '',
+              '<details>',
+              '<summary>Error log (click to expand)</summary>',
+              '',
+              truncated ? `> Showing last 200 of ${lines.length} lines\n` : '',
+              '```',
+              tail,
+              '```',
+              '',
+              '</details>',
+            ].join('\n');
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -187,7 +187,6 @@ jobs:
               '| App | Preview URL |',
               '|-----|-------------|',
               '| **Dashboard** | https://preview.dash.chmonitor.dev |',
-              '| **Dashboard (TSR)** | https://preview.dash-tsr.chmonitor.dev |',
               '| **MCP** | https://preview.dash.chmonitor.dev/api/mcp |',
               '| **Landing** | https://preview.chmonitor.dev |',
               '| **Docs** | https://preview.docs.chmonitor.dev |',

--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -270,14 +270,15 @@ jobs:
         run: exit 1
 
   # ──────────────────────────────────────────────────────────────────────────
-  # Preview TSR: deploys the TanStack Start dashboard for pull requests to
-  # https://preview.dash-tsr.chmonitor.dev. Runs in parallel with the
-  # Next.js preview job. Own lockfile (not in root workspaces).
+  # Dashboard TSR: TanStack Start dashboard (own lockfile, not in root workspaces).
+  # Production: https://dash-tsr.chmonitor.dev (on merge to main).
+  # Preview:    https://preview.dash-tsr.chmonitor.dev (on PRs).
+  # Mirrors the landing/docs pattern — single job, conditional deploy target.
   # ──────────────────────────────────────────────────────────────────────────
-  preview-tsr:
-    name: preview-tsr
+  dashboard-tsr:
+    name: dashboard-tsr
     if: >-
-      github.event_name == 'pull_request' &&
+      github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
@@ -308,13 +309,9 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build for Cloudflare
-        id: build
-        continue-on-error: true
-        run: bun run build 2>&1 | tee /tmp/tsr-build-output.txt
-          ; exit ${PIPESTATUS[0]}
+        run: bun run build
 
-      - name: Set preview secrets
-        if: steps.build.outcome == 'success'
+      - name: Set secrets
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -327,6 +324,7 @@ jobs:
           NVIDIA_API_BASE: ${{ secrets.NVIDIA_API_BASE }}
           ANYROUTER_API_KEY: ${{ secrets.ANYROUTER_API_KEY }}
           ANYROUTER_API_BASE: ${{ secrets.ANYROUTER_API_BASE }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           CLERK_SECRET_KEY_TEST: ${{ secrets.CLERK_SECRET_KEY_TEST }}
           CHM_API_KEY_SECRET: ${{ secrets.CHM_API_KEY_SECRET }}
           CLICKHOUSE_TZ: ${{ secrets.CLICKHOUSE_TZ || 'UTC' }}
@@ -334,21 +332,28 @@ jobs:
           NEXT_QUERY_CACHE_TTL: ${{ secrets.NEXT_QUERY_CACHE_TTL || '3600' }}
         run: |
           set -euo pipefail
-          bun ../../scripts/set-secrets.ts --from-env --strict --target dashboard-tsr --env preview
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            bun ../../scripts/set-secrets.ts --from-env --strict --target dashboard-tsr --env preview
+          else
+            bun ../../scripts/set-secrets.ts --from-env --strict --target dashboard-tsr
+          fi
 
-      - name: Deploy preview to Cloudflare Workers
-        id: deploy
-        if: steps.build.outcome == 'success'
-        continue-on-error: true
+      - name: Deploy preview
+        if: github.event_name == 'pull_request'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          npx --yes --package=wrangler@4 wrangler deploy --env preview --minify 2>&1 | tee /tmp/tsr-deploy-output.txt
-          exit ${PIPESTATUS[0]}
+        run: bunx wrangler deploy --env preview --minify
+
+      - name: Deploy production
+        if: github.event_name != 'pull_request'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bunx wrangler deploy --minify
 
       - name: Comment preview URL on PR
-        if: steps.deploy.outcome == 'success'
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v9
         with:
           script: |
@@ -372,61 +377,17 @@ jobs:
               body,
             });
 
-      - name: Comment failure on PR
-        if: always() && (steps.build.outcome == 'failure' || steps.deploy.outcome == 'failure')
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const fs = require('fs');
-            const sha = '${{ github.event.pull_request.head.sha }}'.slice(0, 7);
-            const buildOutcome = '${{ steps.build.outcome }}';
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-
-            let failedStep, logContent;
-            if (buildOutcome === 'failure') {
-              failedStep = 'Build (`bun run build`)';
-              logContent = fs.existsSync('/tmp/tsr-build-output.txt')
-                ? fs.readFileSync('/tmp/tsr-build-output.txt', 'utf8')
-                : 'No build output captured.';
-            } else {
-              failedStep = 'Deploy (`wrangler deploy --env preview`)';
-              logContent = fs.existsSync('/tmp/tsr-deploy-output.txt')
-                ? fs.readFileSync('/tmp/tsr-deploy-output.txt', 'utf8')
-                : 'No deploy output captured.';
-            }
-
-            const lines = logContent.split('\n');
-            const truncated = lines.length > 200;
-            const tail = lines.slice(-200).join('\n');
-
-            const body = [
-              '### ☁️ Cloudflare Preview Deployment (TSR) — Failed',
-              '',
-              `| **Failed step** | ${failedStep} |`,
-              `| **Commit** | \`${sha}\` |`,
-              `| **Workflow run** | [View logs](${runUrl}) |`,
-              '',
-              '<details>',
-              '<summary>Error log (click to expand)</summary>',
-              '',
-              truncated ? `> Showing last 200 of ${lines.length} lines\n` : '',
-              '```',
-              tail,
-              '```',
-              '',
-              '</details>',
-            ].join('\n');
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });
-
-      - name: Fail job if build or deploy failed
-        if: always() && (steps.build.outcome == 'failure' || steps.deploy.outcome == 'failure')
-        run: exit 1
+      - name: Deployment summary
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "### 🚀 TSR Dashboard Deployment" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| URL | https://dash-tsr.chmonitor.dev |" >> $GITHUB_STEP_SUMMARY
+          echo "| Commit | \`${{ github.sha }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ TSR dashboard deployed successfully!" >> $GITHUB_STEP_SUMMARY
 
   # ──────────────────────────────────────────────────────────────────────────
   # Production: deploy on merge to main, releases, or manual trigger

--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -350,7 +350,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: bunx wrangler deploy --env preview --minify
+        run: bunx wrangler deploy --minify
 
       - name: Deploy production
         if: github.event_name != 'pull_request'

--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -311,6 +311,14 @@ jobs:
       - name: Build for Cloudflare
         run: bun run build
 
+      - name: Patch wrangler config with env sections
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            bun scripts/patch-wrangler-env.ts --env preview
+          else
+            bun scripts/patch-wrangler-env.ts
+          fi
+
       - name: Set secrets
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
+++ b/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env bun
+
+/**
+ * Patch the generated wrangler.json with routes and env sections from wrangler.toml.
+ *
+ * @cloudflare/vite-plugin generates dist/server/wrangler.json during build,
+ * but strips [env.*] sections and [[routes]] (routes, vars, etc). This script
+ * reads the original wrangler.toml, extracts configs, and injects them into
+ * the generated JSON so `wrangler deploy --env <name>` works correctly.
+ *
+ * Usage:
+ *   bun scripts/patch-wrangler-env.ts              # patch production routes + all envs
+ *   bun scripts/patch-wrangler-env.ts --env preview # patch only env.preview
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(__dirname, '..')
+
+// Parse --env flag
+const envFlag = process.argv.find((a) => a === '--env')
+const envName = envFlag ? process.argv[process.argv.indexOf(envFlag) + 1] : null
+
+const TOML_PATH = join(ROOT, 'wrangler.toml')
+const JSON_PATH = join(ROOT, 'dist', 'server', 'wrangler.json')
+
+if (!existsSync(JSON_PATH)) {
+  console.error(`❌ Generated config not found: ${JSON_PATH}`)
+  console.error('   Run `bun run build` first.')
+  process.exit(1)
+}
+
+const { parse } = await import('smol-toml')
+const toml = parse(readFileSync(TOML_PATH, 'utf-8'))
+const generated = JSON.parse(readFileSync(JSON_PATH, 'utf-8'))
+
+let patched = 0
+
+// Patch top-level routes (production custom domains)
+if (toml.routes && !envName) {
+  generated.routes = toml.routes
+  patched++
+  console.log(`✅ Patched top-level routes into generated wrangler.json`)
+}
+
+// Patch top-level vars (production vars)
+if (toml.vars && !envName) {
+  generated.vars = toml.vars
+  patched++
+  console.log(`✅ Patched top-level vars into generated wrangler.json`)
+}
+
+// Patch env sections
+const tomlEnvs = (toml.env || {}) as Record<string, unknown>
+const envNames = envName ? [envName] : Object.keys(tomlEnvs)
+
+if (!generated.env) generated.env = {}
+
+for (const name of envNames) {
+  const envConfig = tomlEnvs[name]
+  if (!envConfig || typeof envConfig !== 'object') {
+    console.warn(`⚠️  env.${name} not found in wrangler.toml, skipping.`)
+    continue
+  }
+
+  generated.env[name] = envConfig
+  patched++
+  console.log(`✅ Patched env.${name} into generated wrangler.json`)
+}
+
+writeFileSync(JSON_PATH, JSON.stringify(generated, null, 2))
+
+console.log(`\n📝 Patched ${patched} section(s) into generated wrangler.json`)

--- a/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
+++ b/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
@@ -1,18 +1,18 @@
 #!/usr/bin/env bun
 
 /**
- * Patch the generated wrangler.json with routes and env sections.
+ * Patch the generated wrangler.json with routes, vars, and worker name.
  *
  * @cloudflare/vite-plugin generates dist/server/wrangler.json during build,
- * but strips [env.*] sections and [[routes]]. This script injects them back
- * so `wrangler deploy --env <name>` works correctly.
+ * but strips [[routes]] and [vars]. Additionally, Wrangler REJECTS env
+ * sections in "redirected" (tool-generated) configs, so we can't use --env.
+ * Instead, this script patches the top-level config directly for each target.
  *
- * IMPORTANT: If wrangler.toml routes/vars/env sections change, update the
- * objects below to match.
+ * IMPORTANT: If wrangler.toml routes/vars change, update the objects below.
  *
  * Usage:
- *   bun scripts/patch-wrangler-env.ts              # production routes + vars
- *   bun scripts/patch-wrangler-env.ts --env preview # env.preview only
+ *   bun scripts/patch-wrangler-env.ts              # patch production values
+ *   bun scripts/patch-wrangler-env.ts --env preview # patch preview values
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
@@ -34,33 +34,39 @@ if (!existsSync(JSON_PATH)) {
 }
 
 const generated = JSON.parse(readFileSync(JSON_PATH, 'utf-8'))
-let patched = 0
 
-// --- Production routes and vars (keep in sync with wrangler.toml) ---
-const PROD_ROUTES = [{ pattern: 'dash-tsr.chmonitor.dev', custom_domain: true }]
-
-const PROD_VARS = {
+// --- Shared vars (keep in sync with wrangler.toml) ---
+const SHARED_VARS = {
   CLICKHOUSE_HOST:
     'https://duet-ubuntu.dingo-mora.ts.net,https://openclaw.dingo-mora.ts.net',
   CLICKHOUSE_USER: 'duyet,monitoring',
   CLICKHOUSE_NAME: 'duet-ubuntu,duyet-agent',
   CLICKHOUSE_MAX_EXECUTION_TIME: '60',
   CLOUDFLARE_WORKERS: '1',
-  LLM_MODEL: 'anyrouter:@preset/chmonitor',
   OPENROUTER_REFERER: 'https://clickhouse.duyet.net',
   OPENROUTER_APP_NAME: 'chmonitor',
   CHM_AUTH_PROVIDER: 'clerk',
   NEXT_PUBLIC_AUTH_PROVIDER: 'clerk',
   CHM_FEATURE_AGENT_ACCESS: 'authenticated',
-  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: 'pk_live_Y2xlcmsuY2htb25pdG9yLmRldiQ',
 }
 
-// --- Preview env (keep in sync with wrangler.toml [env.preview]) ---
-const PREVIEW_ENV = {
+// --- Production config (keep in sync with wrangler.toml top-level) ---
+const PROD_CONFIG = {
+  name: 'chmonitor-dash-tsr',
+  routes: [{ pattern: 'dash-tsr.chmonitor.dev', custom_domain: true }],
+  vars: {
+    ...SHARED_VARS,
+    LLM_MODEL: 'anyrouter:@preset/chmonitor',
+    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: 'pk_live_Y2xlcmsuY2htb25pdG9yLmRldiQ',
+  },
+}
+
+// --- Preview config (keep in sync with wrangler.toml [env.preview]) ---
+const PREVIEW_CONFIG = {
   name: 'preview-chmonitor-dash-tsr',
   routes: [{ pattern: 'preview.dash-tsr.chmonitor.dev', custom_domain: true }],
   vars: {
-    ...PROD_VARS,
+    ...SHARED_VARS,
     LLM_MODEL: 'anyrouter:z-ai/glm-4.7-flash',
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:
       'pk_test_bWFnbmV0aWMtcmF5LTkwLmNsZXJrLmFjY291bnRzLmRldiQ',
@@ -68,25 +74,18 @@ const PREVIEW_ENV = {
 }
 
 // --- Apply patches ---
-if (envName === 'preview') {
-  if (!generated.env) generated.env = {}
-  generated.env.preview = PREVIEW_ENV
-  patched++
-  console.log('✅ Patched env.preview into generated wrangler.json')
-} else if (!envName) {
-  // Production: patch top-level routes and vars
-  generated.routes = PROD_ROUTES
-  generated.vars = PROD_VARS
-  patched += 2
-  console.log('✅ Patched top-level routes into generated wrangler.json')
-  console.log('✅ Patched top-level vars into generated wrangler.json')
+const config = envName === 'preview' ? PREVIEW_CONFIG : PROD_CONFIG
 
-  // Also patch env sections if they exist in the config above
-  if (!generated.env) generated.env = {}
-  generated.env.preview = PREVIEW_ENV
-  patched++
-  console.log('✅ Patched env.preview into generated wrangler.json')
-}
+generated.name = config.name
+generated.routes = config.routes
+generated.vars = config.vars
+
+// Remove any env sections — Wrangler rejects them in redirected configs
+delete generated.env
 
 writeFileSync(JSON_PATH, JSON.stringify(generated, null, 2))
-console.log(`\n📝 Patched ${patched} section(s) into generated wrangler.json`)
+
+console.log(`✅ Patched wrangler.json for ${envName || 'production'}`)
+console.log(`   name: ${config.name}`)
+console.log(`   routes: ${config.routes.map((r) => r.pattern).join(', ')}`)
+console.log(`   vars: ${Object.keys(config.vars).length} keys`)

--- a/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
+++ b/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
@@ -1,16 +1,18 @@
 #!/usr/bin/env bun
 
 /**
- * Patch the generated wrangler.json with routes and env sections from wrangler.toml.
+ * Patch the generated wrangler.json with routes and env sections.
  *
  * @cloudflare/vite-plugin generates dist/server/wrangler.json during build,
- * but strips [env.*] sections and [[routes]] (routes, vars, etc). This script
- * reads the original wrangler.toml, extracts configs, and injects them into
- * the generated JSON so `wrangler deploy --env <name>` works correctly.
+ * but strips [env.*] sections and [[routes]]. This script injects them back
+ * so `wrangler deploy --env <name>` works correctly.
+ *
+ * IMPORTANT: If wrangler.toml routes/vars/env sections change, update the
+ * objects below to match.
  *
  * Usage:
- *   bun scripts/patch-wrangler-env.ts              # patch production routes + all envs
- *   bun scripts/patch-wrangler-env.ts --env preview # patch only env.preview
+ *   bun scripts/patch-wrangler-env.ts              # production routes + vars
+ *   bun scripts/patch-wrangler-env.ts --env preview # env.preview only
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
@@ -20,11 +22,9 @@ import { fileURLToPath } from 'node:url'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '..')
 
-// Parse --env flag
 const envFlag = process.argv.find((a) => a === '--env')
 const envName = envFlag ? process.argv[process.argv.indexOf(envFlag) + 1] : null
 
-const TOML_PATH = join(ROOT, 'wrangler.toml')
 const JSON_PATH = join(ROOT, 'dist', 'server', 'wrangler.json')
 
 if (!existsSync(JSON_PATH)) {
@@ -33,44 +33,60 @@ if (!existsSync(JSON_PATH)) {
   process.exit(1)
 }
 
-const { parse } = await import('smol-toml')
-const toml = parse(readFileSync(TOML_PATH, 'utf-8'))
 const generated = JSON.parse(readFileSync(JSON_PATH, 'utf-8'))
-
 let patched = 0
 
-// Patch top-level routes (production custom domains)
-if (toml.routes && !envName) {
-  generated.routes = toml.routes
-  patched++
-  console.log(`✅ Patched top-level routes into generated wrangler.json`)
+// --- Production routes and vars (keep in sync with wrangler.toml) ---
+const PROD_ROUTES = [{ pattern: 'dash-tsr.chmonitor.dev', custom_domain: true }]
+
+const PROD_VARS = {
+  CLICKHOUSE_HOST:
+    'https://duet-ubuntu.dingo-mora.ts.net,https://openclaw.dingo-mora.ts.net',
+  CLICKHOUSE_USER: 'duyet,monitoring',
+  CLICKHOUSE_NAME: 'duet-ubuntu,duyet-agent',
+  CLICKHOUSE_MAX_EXECUTION_TIME: '60',
+  CLOUDFLARE_WORKERS: '1',
+  LLM_MODEL: 'anyrouter:@preset/chmonitor',
+  OPENROUTER_REFERER: 'https://clickhouse.duyet.net',
+  OPENROUTER_APP_NAME: 'chmonitor',
+  CHM_AUTH_PROVIDER: 'clerk',
+  NEXT_PUBLIC_AUTH_PROVIDER: 'clerk',
+  CHM_FEATURE_AGENT_ACCESS: 'authenticated',
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: 'pk_live_Y2xlcmsuY2htb25pdG9yLmRldiQ',
 }
 
-// Patch top-level vars (production vars)
-if (toml.vars && !envName) {
-  generated.vars = toml.vars
-  patched++
-  console.log(`✅ Patched top-level vars into generated wrangler.json`)
+// --- Preview env (keep in sync with wrangler.toml [env.preview]) ---
+const PREVIEW_ENV = {
+  name: 'preview-chmonitor-dash-tsr',
+  routes: [{ pattern: 'preview.dash-tsr.chmonitor.dev', custom_domain: true }],
+  vars: {
+    ...PROD_VARS,
+    LLM_MODEL: 'anyrouter:z-ai/glm-4.7-flash',
+    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:
+      'pk_test_bWFnbmV0aWMtcmF5LTkwLmNsZXJrLmFjY291bnRzLmRldiQ',
+  },
 }
 
-// Patch env sections
-const tomlEnvs = (toml.env || {}) as Record<string, unknown>
-const envNames = envName ? [envName] : Object.keys(tomlEnvs)
-
-if (!generated.env) generated.env = {}
-
-for (const name of envNames) {
-  const envConfig = tomlEnvs[name]
-  if (!envConfig || typeof envConfig !== 'object') {
-    console.warn(`⚠️  env.${name} not found in wrangler.toml, skipping.`)
-    continue
-  }
-
-  generated.env[name] = envConfig
+// --- Apply patches ---
+if (envName === 'preview') {
+  if (!generated.env) generated.env = {}
+  generated.env.preview = PREVIEW_ENV
   patched++
-  console.log(`✅ Patched env.${name} into generated wrangler.json`)
+  console.log('✅ Patched env.preview into generated wrangler.json')
+} else if (!envName) {
+  // Production: patch top-level routes and vars
+  generated.routes = PROD_ROUTES
+  generated.vars = PROD_VARS
+  patched += 2
+  console.log('✅ Patched top-level routes into generated wrangler.json')
+  console.log('✅ Patched top-level vars into generated wrangler.json')
+
+  // Also patch env sections if they exist in the config above
+  if (!generated.env) generated.env = {}
+  generated.env.preview = PREVIEW_ENV
+  patched++
+  console.log('✅ Patched env.preview into generated wrangler.json')
 }
 
 writeFileSync(JSON_PATH, JSON.stringify(generated, null, 2))
-
 console.log(`\n📝 Patched ${patched} section(s) into generated wrangler.json`)

--- a/apps/dashboard-tsr/src/lib/api/data/dashboard-query-validator.ts
+++ b/apps/dashboard-tsr/src/lib/api/data/dashboard-query-validator.ts
@@ -14,10 +14,10 @@
  * @module lib/api/data/dashboard-query-validator
  */
 
+import { getCachedDashboardQueries } from './cache-manager'
 import { fetchData } from '@chm/clickhouse-client'
 import { error } from '@chm/logger'
 import { DASHBOARD_CHARTS_TABLE } from '@/lib/app-tables'
-import { getCachedDashboardQueries } from './cache-manager'
 
 /** Dashboard table name for query validation */
 export const DASHBOARD_QUERIES_TABLE = DASHBOARD_CHARTS_TABLE

--- a/apps/dashboard-tsr/src/routes/api/healthz.ts
+++ b/apps/dashboard-tsr/src/routes/api/healthz.ts
@@ -1,7 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import type { ClickHouseConfig } from '@chm/clickhouse-client'
-
 import { env } from 'cloudflare:workers'
 // Public client factory. We pass `web: true` so it always uses
 // @clickhouse/client-web (fetch-based) and never touches the node

--- a/apps/dashboard-tsr/src/routes/api/timezone.ts
+++ b/apps/dashboard-tsr/src/routes/api/timezone.ts
@@ -1,7 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import type { ClickHouseConfig } from '@chm/clickhouse-client'
-
 import { env } from 'cloudflare:workers'
 import { getClient } from '@chm/clickhouse-client'
 import { getClickHouseConfigsFromEnv } from '@/lib/api/clickhouse-config'

--- a/apps/dashboard-tsr/src/routes/api/v1/actions.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/actions.ts
@@ -6,15 +6,15 @@
  * Ported from apps/dashboard/app/api/v1/actions/route.ts.
  */
 
+import { z } from 'zod'
 import { createFileRoute } from '@tanstack/react-router'
 
-import { z } from 'zod'
 import { env } from 'cloudflare:workers'
 import { fetchData } from '@chm/clickhouse-client'
 import { ErrorLogger, log } from '@chm/logger'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 
-const ROUTE_CONTEXT = { route: '/api/v1/actions', method: 'POST' }
+const _ROUTE_CONTEXT = { route: '/api/v1/actions', method: 'POST' }
 
 // --- Inline ActionSchema (not yet ported to TSR lib/api/schemas) ---
 
@@ -182,7 +182,8 @@ export const Route = createFileRoute('/api/v1/actions')({
           return Response.json(
             {
               success: false,
-              message: 'Invalid parameter: hostId must be a non-negative integer',
+              message:
+                'Invalid parameter: hostId must be a non-negative integer',
             },
             { status: 400 }
           )

--- a/apps/dashboard-tsr/src/routes/api/v1/actions.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/actions.ts
@@ -14,8 +14,6 @@ import { fetchData } from '@chm/clickhouse-client'
 import { ErrorLogger, log } from '@chm/logger'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 
-const _ROUTE_CONTEXT = { route: '/api/v1/actions', method: 'POST' }
-
 // --- Inline ActionSchema (not yet ported to TSR lib/api/schemas) ---
 
 const KillQueryActionSchema = z.object({

--- a/apps/dashboard-tsr/src/routes/api/v1/cluster-counts/$key.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/cluster-counts/$key.ts
@@ -25,12 +25,12 @@ import {
 } from '@/lib/api/cluster-count-registry'
 import { createErrorResponse } from '@/lib/api/error-handler'
 import { HostIdSchema, MenuCountKeySchema } from '@/lib/api/schemas'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import {
   CacheControl,
   createSuccessResponse,
 } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
-import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 
 const ROUTE_CONTEXT = { route: '/api/v1/cluster-counts/$key', method: 'GET' }
 
@@ -38,7 +38,10 @@ interface ClusterCountResponse {
   readonly count: number | null
 }
 
-async function handler(request: Request, params: { key: string }): Promise<Response> {
+async function handler(
+  request: Request,
+  params: { key: string }
+): Promise<Response> {
   const requestId = generateRequestId()
 
   try {

--- a/apps/dashboard-tsr/src/routes/api/v1/dashboard/settings.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/dashboard/settings.ts
@@ -57,7 +57,7 @@ function makeErrorResponse(
   type: ApiErrorType,
   message: string,
   status: number,
-  context?: { route?: string; method?: string }
+  _context?: { route?: string; method?: string }
 ): Response {
   return Response.json(
     {

--- a/apps/dashboard-tsr/src/routes/api/v1/data.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/data.ts
@@ -18,8 +18,8 @@
  *   inlined below (response shapes and validation logic are identical).
  */
 
-import type { DataFormat } from '@clickhouse/client'
 import { createFileRoute } from '@tanstack/react-router'
+import type { DataFormat } from '@clickhouse/client'
 
 import type { FetchDataError } from '@chm/clickhouse-client'
 import type { ApiError, ApiRequest, ApiResponse } from '@/lib/api/types'
@@ -28,10 +28,10 @@ import { env } from 'cloudflare:workers'
 import { fetchData } from '@chm/clickhouse-client'
 import { debug, error } from '@chm/logger'
 import { validateSqlQuery } from '@chm/sql-builder'
+import { validateDashboardQuery } from '@/lib/api/data/dashboard-query-validator'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { getTableConfig } from '@/lib/api/table-registry'
 import { ApiErrorType } from '@/lib/api/types'
-import { validateDashboardQuery } from '@/lib/api/data/dashboard-query-validator'
 
 const ROUTE_CONTEXT = { route: '/api/v1/data' } as const
 

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/columns.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/columns.ts
@@ -9,9 +9,9 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import type { ApiResponse } from '@/lib/api/types'
 
+import { env } from 'cloudflare:workers'
 import { fetchData } from '@chm/clickhouse-client'
 import { debug, error } from '@chm/logger'
-import { env } from 'cloudflare:workers'
 import { getHostIdFromParams, type RouteContext } from '@/lib/api/error-handler'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { getTableQuery } from '@/lib/api/table-registry'

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/databases.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/databases.ts
@@ -7,9 +7,9 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import type { ApiResponse } from '@/lib/api/types'
 
+import { env } from 'cloudflare:workers'
 import { fetchData } from '@chm/clickhouse-client'
 import { debug, error } from '@chm/logger'
-import { env } from 'cloudflare:workers'
 import { getHostIdFromParams, type RouteContext } from '@/lib/api/error-handler'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { getTableQuery } from '@/lib/api/table-registry'

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/ddl.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/ddl.ts
@@ -7,9 +7,9 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import type { ApiResponse } from '@/lib/api/types'
 
+import { env } from 'cloudflare:workers'
 import { fetchData } from '@chm/clickhouse-client'
 import { debug, error } from '@chm/logger'
-import { env } from 'cloudflare:workers'
 import { getHostIdFromParams, type RouteContext } from '@/lib/api/error-handler'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { getTableQuery } from '@/lib/api/table-registry'

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/dependencies.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/dependencies.ts
@@ -11,9 +11,9 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import type { ApiResponse } from '@/lib/api/types'
 
+import { env } from 'cloudflare:workers'
 import { fetchData } from '@chm/clickhouse-client'
 import { debug, error } from '@chm/logger'
-import { env } from 'cloudflare:workers'
 import { getHostIdFromParams, type RouteContext } from '@/lib/api/error-handler'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { getTableQuery } from '@/lib/api/table-registry'

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/indexes.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/indexes.ts
@@ -7,9 +7,9 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import type { ApiResponse } from '@/lib/api/types'
 
+import { env } from 'cloudflare:workers'
 import { fetchData } from '@chm/clickhouse-client'
 import { debug, error } from '@chm/logger'
-import { env } from 'cloudflare:workers'
 import { getHostIdFromParams, type RouteContext } from '@/lib/api/error-handler'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { getTableQuery } from '@/lib/api/table-registry'

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/preview.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/preview.ts
@@ -21,7 +21,8 @@ const MAX_CELL_VALUE_LENGTH = 10_000
 function truncateLargeValues<T>(data: T): T {
   if (!Array.isArray(data)) return data
   return data.map((row) => {
-    if (typeof row !== 'object' || row === null || Array.isArray(row)) return row
+    if (typeof row !== 'object' || row === null || Array.isArray(row))
+      return row
     const truncated: Record<string, unknown> = {}
     for (const [key, value] of Object.entries(row as Record<string, unknown>)) {
       if (typeof value === 'string' && value.length > MAX_CELL_VALUE_LENGTH) {
@@ -63,7 +64,10 @@ export const Route = createFileRoute('/api/v1/explorer/preview')({
           return Response.json(
             {
               success: false,
-              error: { type: ApiErrorType.ValidationError, message: 'Missing required parameter: hostId' },
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: 'Missing required parameter: hostId',
+              },
             },
             { status: 400 }
           )
@@ -73,7 +77,10 @@ export const Route = createFileRoute('/api/v1/explorer/preview')({
           return Response.json(
             {
               success: false,
-              error: { type: ApiErrorType.ValidationError, message: `Invalid hostId: ${hostIdRaw}` },
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: `Invalid hostId: ${hostIdRaw}`,
+              },
             },
             { status: 400 }
           )
@@ -84,7 +91,13 @@ export const Route = createFileRoute('/api/v1/explorer/preview')({
         const limit = searchParams.get('limit') ?? '100'
         const offset = searchParams.get('offset') ?? '0'
 
-        debug('[GET /api/v1/explorer/preview]', { hostId, database, table, limit, offset })
+        debug('[GET /api/v1/explorer/preview]', {
+          hostId,
+          database,
+          table,
+          limit,
+          offset,
+        })
 
         if (!database || !VALID_IDENTIFIER.test(database)) {
           return Response.json(
@@ -115,13 +128,18 @@ export const Route = createFileRoute('/api/v1/explorer/preview')({
         }
 
         const parsedLimit = parseInt(limit, 10)
-        if (Number.isNaN(parsedLimit) || parsedLimit < 1 || parsedLimit > 10000) {
+        if (
+          Number.isNaN(parsedLimit) ||
+          parsedLimit < 1 ||
+          parsedLimit > 10000
+        ) {
           return Response.json(
             {
               success: false,
               error: {
                 type: ApiErrorType.ValidationError,
-                message: 'Invalid limit parameter (must be between 1 and 10000)',
+                message:
+                  'Invalid limit parameter (must be between 1 and 10000)',
                 details: { limit },
               },
             },
@@ -130,13 +148,18 @@ export const Route = createFileRoute('/api/v1/explorer/preview')({
         }
 
         const parsedOffset = parseInt(offset, 10)
-        if (Number.isNaN(parsedOffset) || parsedOffset < 0 || parsedOffset > 10000) {
+        if (
+          Number.isNaN(parsedOffset) ||
+          parsedOffset < 0 ||
+          parsedOffset > 10000
+        ) {
           return Response.json(
             {
               success: false,
               error: {
                 type: ApiErrorType.ValidationError,
-                message: 'Invalid offset parameter (must be a non-negative integer and <= 10000)',
+                message:
+                  'Invalid offset parameter (must be a non-negative integer and <= 10000)',
                 details: { offset },
               },
             },
@@ -151,7 +174,12 @@ export const Route = createFileRoute('/api/v1/explorer/preview')({
 
         const result = await fetchData({
           query,
-          query_params: { database, table, limit: parsedLimit, offset: parsedOffset },
+          query_params: {
+            database,
+            table,
+            limit: parsedLimit,
+            offset: parsedOffset,
+          },
           hostId,
           format: 'JSONEachRow',
         })

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/projections.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/projections.ts
@@ -7,8 +7,8 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { env } from 'cloudflare:workers'
 import { debug, error } from '@chm/logger'
-import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { executeTableConfig } from '@/lib/api/query-executor'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { getTableQuery } from '@/lib/api/table-registry'
 import { ApiErrorType } from '@/lib/api/types'
 
@@ -25,7 +25,10 @@ export const Route = createFileRoute('/api/v1/explorer/projections')({
           return Response.json(
             {
               success: false,
-              error: { type: ApiErrorType.ValidationError, message: 'Missing required parameter: hostId' },
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: 'Missing required parameter: hostId',
+              },
             },
             { status: 400 }
           )
@@ -35,7 +38,10 @@ export const Route = createFileRoute('/api/v1/explorer/projections')({
           return Response.json(
             {
               success: false,
-              error: { type: ApiErrorType.ValidationError, message: `Invalid hostId: ${hostIdRaw}` },
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: `Invalid hostId: ${hostIdRaw}`,
+              },
             },
             { status: 400 }
           )
@@ -48,14 +54,20 @@ export const Route = createFileRoute('/api/v1/explorer/projections')({
           if (key !== 'hostId') searchParamsObj[key] = value
         })
 
-        const queryDef = getTableQuery('explorer-projections', { hostId, searchParams: searchParamsObj })
+        const queryDef = getTableQuery('explorer-projections', {
+          hostId,
+          searchParams: searchParamsObj,
+        })
 
         if (!queryDef) {
           error('[GET /api/v1/explorer/projections] Failed to build query')
           return Response.json(
             {
               success: false,
-              error: { type: ApiErrorType.QueryError, message: 'Failed to build query for explorer-projections' },
+              error: {
+                type: ApiErrorType.QueryError,
+                message: 'Failed to build query for explorer-projections',
+              },
             },
             { status: 500 }
           )

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/query.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/query.ts
@@ -8,7 +8,6 @@
  */
 
 import { createFileRoute } from '@tanstack/react-router'
-
 import type { DataFormat } from '@clickhouse/client'
 
 import { env } from 'cloudflare:workers'

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/skip-indexes.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/skip-indexes.ts
@@ -7,8 +7,8 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { env } from 'cloudflare:workers'
 import { debug, error } from '@chm/logger'
-import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { executeTableConfig } from '@/lib/api/query-executor'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { getTableQuery } from '@/lib/api/table-registry'
 import { ApiErrorType } from '@/lib/api/types'
 
@@ -25,7 +25,10 @@ export const Route = createFileRoute('/api/v1/explorer/skip-indexes')({
           return Response.json(
             {
               success: false,
-              error: { type: ApiErrorType.ValidationError, message: 'Missing required parameter: hostId' },
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: 'Missing required parameter: hostId',
+              },
             },
             { status: 400 }
           )
@@ -35,7 +38,10 @@ export const Route = createFileRoute('/api/v1/explorer/skip-indexes')({
           return Response.json(
             {
               success: false,
-              error: { type: ApiErrorType.ValidationError, message: `Invalid hostId: ${hostIdRaw}` },
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: `Invalid hostId: ${hostIdRaw}`,
+              },
             },
             { status: 400 }
           )
@@ -48,14 +54,20 @@ export const Route = createFileRoute('/api/v1/explorer/skip-indexes')({
           if (key !== 'hostId') searchParamsObj[key] = value
         })
 
-        const queryDef = getTableQuery('explorer-skip-indexes', { hostId, searchParams: searchParamsObj })
+        const queryDef = getTableQuery('explorer-skip-indexes', {
+          hostId,
+          searchParams: searchParamsObj,
+        })
 
         if (!queryDef) {
           error('[GET /api/v1/explorer/skip-indexes] Failed to build query')
           return Response.json(
             {
               success: false,
-              error: { type: ApiErrorType.QueryError, message: 'Failed to build query for explorer-skip-indexes' },
+              error: {
+                type: ApiErrorType.QueryError,
+                message: 'Failed to build query for explorer-skip-indexes',
+              },
             },
             { status: 500 }
           )
@@ -69,7 +81,10 @@ export const Route = createFileRoute('/api/v1/explorer/skip-indexes')({
         )
 
         if (result.error) {
-          error('[GET /api/v1/explorer/skip-indexes] Query error:', result.error)
+          error(
+            '[GET /api/v1/explorer/skip-indexes] Query error:',
+            result.error
+          )
           const statusMap: Record<string, number> = {
             [ApiErrorType.ValidationError]: 400,
             [ApiErrorType.PermissionError]: 403,

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/tables.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/tables.ts
@@ -40,7 +40,10 @@ export const Route = createFileRoute('/api/v1/explorer/tables')({
           return Response.json(
             {
               success: false,
-              error: { type: ApiErrorType.ValidationError, message: 'Missing required parameter: hostId' },
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: 'Missing required parameter: hostId',
+              },
             },
             { status: 400 }
           )
@@ -50,7 +53,10 @@ export const Route = createFileRoute('/api/v1/explorer/tables')({
           return Response.json(
             {
               success: false,
-              error: { type: ApiErrorType.ValidationError, message: `Invalid hostId: ${hostIdRaw}` },
+              error: {
+                type: ApiErrorType.ValidationError,
+                message: `Invalid hostId: ${hostIdRaw}`,
+              },
             },
             { status: 400 }
           )
@@ -63,14 +69,20 @@ export const Route = createFileRoute('/api/v1/explorer/tables')({
           if (key !== 'hostId') searchParamsObj[key] = value
         })
 
-        const queryDef = getTableQuery('explorer-tables', { hostId, searchParams: searchParamsObj })
+        const queryDef = getTableQuery('explorer-tables', {
+          hostId,
+          searchParams: searchParamsObj,
+        })
 
         if (!queryDef) {
           error('[GET /api/v1/explorer/tables] Failed to build query')
           return Response.json(
             {
               success: false,
-              error: { type: ApiErrorType.QueryError, message: 'Failed to build query for tables' },
+              error: {
+                type: ApiErrorType.QueryError,
+                message: 'Failed to build query for tables',
+              },
             },
             { status: 500 }
           )

--- a/apps/dashboard-tsr/src/routes/api/v1/findings.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/findings.ts
@@ -161,7 +161,9 @@ export const Route = createFileRoute('/api/v1/findings')({
           const hostId = Number.parseInt(searchParams.get('host') ?? '0', 10)
           if (!Number.isInteger(hostId) || hostId < 0) {
             return Response.json(
-              { error: 'Invalid host parameter: must be a non-negative integer' },
+              {
+                error: 'Invalid host parameter: must be a non-negative integer',
+              },
               { status: 400, headers: { 'X-Request-ID': requestId } }
             )
           }

--- a/apps/dashboard-tsr/src/routes/api/v1/host-status.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/host-status.ts
@@ -1,7 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import type { ClickHouseConfig } from '@chm/clickhouse-client'
-
 import { env } from 'cloudflare:workers'
 import { getClient } from '@chm/clickhouse-client'
 import { getClickHouseConfigsFromEnv } from '@/lib/api/clickhouse-config'

--- a/apps/dashboard-tsr/src/routes/api/v1/menu-counts/$key.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/menu-counts/$key.ts
@@ -20,12 +20,12 @@ import {
   hasMenuCountKey,
 } from '@/lib/api/menu-count-registry'
 import { HostIdSchema, MenuCountKeySchema } from '@/lib/api/schemas'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import {
   CacheControl,
   createSuccessResponse,
 } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
-import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 
 const ROUTE_CONTEXT = { route: '/api/v1/menu-counts/$key', method: 'GET' }
 
@@ -33,7 +33,10 @@ interface MenuCountResponse {
   readonly count: number | null
 }
 
-async function handler(request: Request, params: { key: string }): Promise<Response> {
+async function handler(
+  request: Request,
+  params: { key: string }
+): Promise<Response> {
   const requestId = generateRequestId()
 
   try {

--- a/apps/dashboard-tsr/src/routes/api/v1/menu-counts/index.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/menu-counts/index.ts
@@ -25,12 +25,12 @@ import {
   getMenuCountQuery,
 } from '@/lib/api/menu-count-registry'
 import { HostIdSchema } from '@/lib/api/schemas'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import {
   CacheControl,
   createSuccessResponse,
 } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
-import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 
 const ROUTE_CONTEXT = { route: '/api/v1/menu-counts', method: 'GET' }
 

--- a/apps/dashboard-tsr/src/routes/api/v1/notifications.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/notifications.ts
@@ -8,8 +8,6 @@
 
 import { createFileRoute } from '@tanstack/react-router'
 
-import type { ClickHouseConfig } from '@chm/clickhouse-client'
-
 import { env } from 'cloudflare:workers'
 import { getClient } from '@chm/clickhouse-client'
 import { getClickHouseConfigsFromEnv } from '@/lib/api/clickhouse-config'

--- a/apps/dashboard-tsr/src/routes/api/v1/peerdb-status.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/peerdb-status.ts
@@ -141,7 +141,10 @@ export const Route = createFileRoute('/api/v1/peerdb-status')({
         const host = sanitizeHost(config.baseUrl)
 
         try {
-          const version = await peerdbFetch<VersionResponse>(config, '/v1/version')
+          const version = await peerdbFetch<VersionResponse>(
+            config,
+            '/v1/version'
+          )
           const payload: PeerDBStatusPayload = {
             configured: true,
             host,
@@ -154,7 +157,8 @@ export const Route = createFileRoute('/api/v1/peerdb-status')({
           )
         } catch (err) {
           const status = err instanceof PeerDBError ? err.status : 0
-          const state = status === 401 || status === 403 ? 'auth' : 'unreachable'
+          const state =
+            status === 401 || status === 403 ? 'auth' : 'unreachable'
           const payload: PeerDBStatusPayload = {
             configured: true,
             host,

--- a/apps/dashboard-tsr/src/routes/api/v1/table-availability.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/table-availability.ts
@@ -12,6 +12,7 @@
  * path), so it now reports availability for every menu-referenced table.
  */
 import { createFileRoute } from '@tanstack/react-router'
+import { menuItemsConfig } from '@/menu'
 
 import type { MenuItem } from '@/components/menu/types'
 
@@ -19,14 +20,13 @@ import { env } from 'cloudflare:workers'
 import { checkTableExists } from '@chm/clickhouse-client/table-existence-cache'
 import { debug, error, generateRequestId } from '@chm/logger'
 import { createErrorResponse } from '@/lib/api/error-handler'
+import { HostIdSchema } from '@/lib/api/schemas'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import {
   CacheControl,
   createSuccessResponse,
 } from '@/lib/api/shared/response-builder'
-import { HostIdSchema } from '@/lib/api/schemas'
 import { ApiErrorType } from '@/lib/api/types'
-import { menuItemsConfig } from '@/menu'
 
 const ROUTE_CONTEXT = { route: '/api/v1/table-availability', method: 'GET' }
 

--- a/apps/dashboard-tsr/src/routes/api/v1/tables/$name.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/tables/$name.ts
@@ -8,7 +8,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { env } from 'cloudflare:workers'
 import { error } from '@chm/logger'
-import { executeTableConfig, isValidInterval } from '@/lib/api/query-executor'
+import { executeTableConfig } from '@/lib/api/query-executor'
 import {
   getAvailableTables,
   getTableConfig,

--- a/apps/dashboard-tsr/src/routes/api/v1/tables/$name/filter-options.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/tables/$name/filter-options.ts
@@ -16,9 +16,9 @@ import { env } from 'cloudflare:workers'
 import { fetchData } from '@chm/clickhouse-client'
 import { QUERY_COMMENT } from '@chm/clickhouse-client/constants'
 import { error } from '@chm/logger'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { getTableConfig } from '@/lib/api/table-registry'
 import { ApiErrorType } from '@/lib/api/types'
-import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 
 const ROUTE_CONTEXT = {
   route: '/api/v1/tables/$name/filter-options',
@@ -38,7 +38,7 @@ export const Route = createFileRoute('/api/v1/tables/$name/filter-options')({
 
         const { name } = params
         const { searchParams } = new URL(request.url)
-        const routeContext = { ...ROUTE_CONTEXT, tableName: name }
+        const _routeContext = { ...ROUTE_CONTEXT, tableName: name }
 
         const rawHostId = searchParams.get('hostId') ?? '0'
         const hostId = Number.parseInt(rawHostId, 10)

--- a/apps/dashboard-tsr/src/routes/api/v1/tables/$name/filter-options.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/tables/$name/filter-options.ts
@@ -20,11 +20,6 @@ import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { getTableConfig } from '@/lib/api/table-registry'
 import { ApiErrorType } from '@/lib/api/types'
 
-const ROUTE_CONTEXT = {
-  route: '/api/v1/tables/$name/filter-options',
-  method: 'GET',
-}
-
 interface FilterOption {
   value: string
   count: number
@@ -38,7 +33,6 @@ export const Route = createFileRoute('/api/v1/tables/$name/filter-options')({
 
         const { name } = params
         const { searchParams } = new URL(request.url)
-        const _routeContext = { ...ROUTE_CONTEXT, tableName: name }
 
         const rawHostId = searchParams.get('hostId') ?? '0'
         const hostId = Number.parseInt(rawHostId, 10)

--- a/apps/dashboard-tsr/src/routes/api/v1/tables/index.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/tables/index.ts
@@ -15,11 +15,6 @@ import { fetchData } from '@chm/clickhouse-client'
 import { debug, error } from '@chm/logger'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 
-const _ROUTE_CONTEXT = {
-  route: '/api/v1/tables',
-  method: 'GET',
-}
-
 const DEFAULT_LIMIT = 500
 const MAX_LIMIT = 1000
 

--- a/apps/dashboard-tsr/src/routes/api/v1/tables/index.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/tables/index.ts
@@ -15,7 +15,7 @@ import { fetchData } from '@chm/clickhouse-client'
 import { debug, error } from '@chm/logger'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 
-const ROUTE_CONTEXT = {
+const _ROUTE_CONTEXT = {
   route: '/api/v1/tables',
   method: 'GET',
 }
@@ -104,7 +104,8 @@ export const Route = createFileRoute('/api/v1/tables')({
             status: 200,
             headers: {
               'Content-Type': 'application/json',
-              'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+              'Cache-Control':
+                'public, s-maxage=60, stale-while-revalidate=300',
             },
           }
         )

--- a/apps/dashboard-tsr/wrangler.toml
+++ b/apps/dashboard-tsr/wrangler.toml
@@ -15,6 +15,38 @@ compatibility_flags = ["nodejs_compat", "nodejs_compat_populate_process_env"]
 [observability]
 enabled = true
 
-# Preview environment for PR deployments (mirrors repo `preview-chmonitor-*`).
+# ─────────────────────────────────────────────────────────────────────────────
+# Preview environment for PR deployments
+# Deployed by GitHub Actions on pull requests (see .github/workflows/cloudflare.yml)
+# and reachable at https://preview.dash-tsr.chmonitor.dev.
+# Inherits most top-level settings; vars require explicit declaration.
+#
+# One-time setup required:
+#   wrangler secret put CLICKHOUSE_PASSWORD --env preview
+# ─────────────────────────────────────────────────────────────────────────────
 [env.preview]
 name = "preview-chmonitor-dash-tsr"
+
+# Custom domain for the preview worker.
+[[env.preview.routes]]
+pattern = "preview.dash-tsr.chmonitor.dev"
+custom_domain = true
+
+# Vars must be explicitly set per environment (not inherited from top-level)
+[env.preview.vars]
+CLICKHOUSE_HOST = "https://duet-ubuntu.dingo-mora.ts.net,https://openclaw.dingo-mora.ts.net"
+CLICKHOUSE_USER = "duyet,monitoring"
+CLICKHOUSE_NAME = "duet-ubuntu,duyet-agent"
+CLICKHOUSE_MAX_EXECUTION_TIME = "60"
+CLOUDFLARE_WORKERS = "1"
+LLM_MODEL = "anyrouter:z-ai/glm-4.7-flash"
+OPENROUTER_REFERER = "https://clickhouse.duyet.net"
+OPENROUTER_APP_NAME = "chmonitor"
+
+# Auth provider for preview deployment
+CHM_AUTH_PROVIDER = "clerk"
+NEXT_PUBLIC_AUTH_PROVIDER = "clerk"
+CHM_FEATURE_AGENT_ACCESS = "authenticated"
+
+# Clerk test key for preview environment
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_bWFnbmV0aWMtcmF5LTkwLmNsZXJrLmFjY291bnRzLmRldiQ"

--- a/apps/dashboard-tsr/wrangler.toml
+++ b/apps/dashboard-tsr/wrangler.toml
@@ -1,4 +1,4 @@
-# wrangler.toml — chmonitor TanStack Start dashboard worker (substrate spike).
+# wrangler.toml — chmonitor TanStack Start dashboard worker.
 #
 # `main` resolves the built-in TanStack Start server entry from node_modules;
 # the @cloudflare/vite-plugin produces the worker bundle + client asset
@@ -14,6 +14,29 @@ compatibility_flags = ["nodejs_compat", "nodejs_compat_populate_process_env"]
 
 [observability]
 enabled = true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Production: custom domain for the TanStack Start dashboard.
+# Deployed alongside the existing Next.js dashboard (dash.chmonitor.dev).
+# Will replace it once the migration is complete (#1392).
+# ─────────────────────────────────────────────────────────────────────────────
+[[routes]]
+pattern = "dash-tsr.chmonitor.dev"
+custom_domain = true
+
+[vars]
+CLICKHOUSE_HOST = "https://duet-ubuntu.dingo-mora.ts.net,https://openclaw.dingo-mora.ts.net"
+CLICKHOUSE_USER = "duyet,monitoring"
+CLICKHOUSE_NAME = "duet-ubuntu,duyet-agent"
+CLICKHOUSE_MAX_EXECUTION_TIME = "60"
+CLOUDFLARE_WORKERS = "1"
+LLM_MODEL = "anyrouter:@preset/chmonitor"
+OPENROUTER_REFERER = "https://clickhouse.duyet.net"
+OPENROUTER_APP_NAME = "chmonitor"
+CHM_AUTH_PROVIDER = "clerk"
+NEXT_PUBLIC_AUTH_PROVIDER = "clerk"
+CHM_FEATURE_AGENT_ACCESS = "authenticated"
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_live_Y2xlcmsuY2htb25pdG9yLmRldiQ"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Preview environment for PR deployments

--- a/scripts/set-secrets.ts
+++ b/scripts/set-secrets.ts
@@ -17,7 +17,7 @@
  * Flags:
  *   --from-env            read values from process.env (CI) instead of .env files
  *   --env <name>          wrangler environment (e.g. preview); omit for production
- *   --target dashboard|mcp|both   which worker(s) to configure (default: both)
+ *   --target dashboard|dashboard-tsr|mcp|both   which worker(s) to configure (default: both)
  *   --strict              fail (don't skip) if a target worker doesn't exist yet
  *                         — CI sets secrets before deploy, so a skip is unsafe
  */
@@ -47,6 +47,13 @@ const MCP_WRANGLER_CONFIG = join(
   '..',
   'apps',
   'mcp',
+  'wrangler.toml'
+)
+const DASH_TSR_WRANGLER_CONFIG = join(
+  __dirname,
+  '..',
+  'apps',
+  'dashboard-tsr',
   'wrangler.toml'
 )
 
@@ -84,6 +91,10 @@ const MCP_SECRET_KEYS = [
   'CLERK_SECRET_KEY',
 ] as const
 
+// TanStack Start dashboard worker secrets — mirrors the main dashboard since
+// dashboard-tsr has the same capabilities (ClickHouse queries, Clerk auth, MCP route).
+const DASH_TSR_SECRET_KEYS = DASHBOARD_SECRET_KEYS
+
 // Defaults applied when a key is absent (mirrors the `|| 'UTC'` etc. that the
 // workflow used to inline).
 const DEFAULTS: Record<string, string> = {
@@ -91,7 +102,7 @@ const DEFAULTS: Record<string, string> = {
   NEXT_QUERY_CACHE_TTL: '3600',
 }
 
-type Target = 'dashboard' | 'mcp' | 'both'
+type Target = 'dashboard' | 'dashboard-tsr' | 'mcp' | 'both'
 
 interface Args {
   fromEnv: boolean
@@ -115,9 +126,17 @@ function parseArgs(): Args {
     else if (a === '--env') args.env = argv[++i] ?? null
     else if (a === '--target') {
       const t = argv[++i]
-      if (t === 'dashboard' || t === 'mcp' || t === 'both') args.target = t
+      if (
+        t === 'dashboard' ||
+        t === 'dashboard-tsr' ||
+        t === 'mcp' ||
+        t === 'both'
+      )
+        args.target = t
       else {
-        console.error(`❌ --target must be dashboard|mcp|both (got "${t}")`)
+        console.error(
+          `❌ --target must be dashboard|dashboard-tsr|mcp|both (got "${t}")`
+        )
         process.exit(1)
       }
     }
@@ -273,6 +292,13 @@ async function main() {
       label: 'MCP worker',
       config: MCP_WRANGLER_CONFIG,
       keys: MCP_SECRET_KEYS,
+    })
+  }
+  if (args.target === 'dashboard-tsr' || args.target === 'both') {
+    jobs.push({
+      label: 'dashboard-tsr worker',
+      config: DASH_TSR_WRANGLER_CONFIG,
+      keys: DASH_TSR_SECRET_KEYS,
     })
   }
 


### PR DESCRIPTION
## Summary

Add CI preview deployment for the TanStack Start dashboard (`apps/dashboard-tsr`) so both the old Next.js and new TSR dashboards have live previews on every PR.

### Changes

| File | Change |
|------|--------|
| `apps/dashboard-tsr/wrangler.toml` | Add `[env.preview]` with custom domain `preview.dash-tsr.chmonitor.dev`, ClickHouse vars, Clerk config |
| `scripts/set-secrets.ts` | Add `dashboard-tsr` target for CI secret injection (same secret set as main dashboard) |
| `.github/workflows/cloudflare.yml` | Add `preview-tsr` job: build + deploy on PRs in parallel with existing Next.js preview |

### Preview URLs

| App | Preview |
|-----|---------|
| Dashboard (Next.js) | https://preview.dash.chmonitor.dev |
| **Dashboard (TSR)** | **https://preview.dash-tsr.chmonitor.dev** ← new |
| MCP | https://preview.dash.chmonitor.dev/api/mcp |
| Landing | https://preview.chmonitor.dev |
| Docs | https://preview.docs.chmonitor.dev |

Refs: #1392

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Add CI and infrastructure support for preview deployments of the TanStack Start dashboard alongside the existing Next.js dashboard previews.

New Features:
- Introduce a Cloudflare preview deployment job for the TanStack Start dashboard on pull requests, with PR comments linking to the live preview URL.

Enhancements:
- Configure a dedicated Cloudflare Workers preview environment and routing for the TanStack Start dashboard, including ClickHouse and auth-related runtime configuration.
- Extend the shared secret-injection script to support the TanStack Start dashboard worker using the same secret set as the main dashboard.
- Tidy up TanStack Start API route handlers by standardizing imports, logging, and response formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TSR dashboard preview deployed for pull requests; PR comments now include a preview URL.
  * Production routing added for the TSR dashboard on the custom domain.

* **Chores**
  * Build/deploy automation extended to support the dashboard-tsr target and its preview/production flows.
  * Preview environment configuration expanded with additional runtime variables.
  * Miscellaneous import reordering and formatting across server routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->