### PR TITLE
feat(dashboard-tsr): port logs/peerdb/docs pages + simple/infra API routes + lint-clean (#1396 #1402)

### DIFF
--- a/apps/dashboard-tsr/src/routes/(dashboard)/logs/crashes.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/logs/crashes.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { Suspense } from 'react'
+import { PageLayout } from '@/components/layout/query-page'
+import { ChartSkeleton } from '@/components/skeletons'
+import { crashLogConfig } from '@/lib/query-config/logs/crashes'
+
+function CrashesContent() {
+  return <PageLayout queryConfig={crashLogConfig} title="Crash Log" />
+}
+
+function CrashesPage() {
+  return (
+    <Suspense fallback={<ChartSkeleton />}>
+      <CrashesContent />
+    </Suspense>
+  )
+}
+
+export const Route = createFileRoute('/(dashboard)/logs/crashes')({
+  component: CrashesPage,
+})

--- a/apps/dashboard-tsr/src/routes/(dashboard)/logs/stack-traces.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/logs/stack-traces.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { Suspense } from 'react'
+import { PageLayout } from '@/components/layout/query-page'
+import { ChartSkeleton } from '@/components/skeletons'
+import { stackTracesConfig } from '@/lib/query-config/logs/stack-traces'
+
+function StackTracesContent() {
+  return (
+    <PageLayout queryConfig={stackTracesConfig} title="Current Stack Traces" />
+  )
+}
+
+function StackTracesPage() {
+  return (
+    <Suspense fallback={<ChartSkeleton />}>
+      <StackTracesContent />
+    </Suspense>
+  )
+}
+
+export const Route = createFileRoute('/(dashboard)/logs/stack-traces')({
+  component: StackTracesPage,
+})

--- a/apps/dashboard-tsr/src/routes/(dashboard)/logs/text-log.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/logs/text-log.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { Suspense } from 'react'
+import { PageLayout } from '@/components/layout/query-page'
+import { ChartSkeleton } from '@/components/skeletons'
+import { textLogConfig } from '@/lib/query-config/logs/text-log'
+
+function TextLogContent() {
+  return <PageLayout queryConfig={textLogConfig} title="Server Text Log" />
+}
+
+function TextLogPage() {
+  return (
+    <Suspense fallback={<ChartSkeleton />}>
+      <TextLogContent />
+    </Suspense>
+  )
+}
+
+export const Route = createFileRoute('/(dashboard)/logs/text-log')({
+  component: TextLogPage,
+})

--- a/apps/dashboard-tsr/src/routes/(docs)/docs/$.tsx
+++ b/apps/dashboard-tsr/src/routes/(docs)/docs/$.tsx
@@ -1,0 +1,187 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+
+import { DocsMarkdown } from './_components/docs-markdown'
+import {
+  type DocsHeading,
+  type DocsPage,
+  docsHref,
+  docsNav,
+  getDocsPage,
+} from './_lib/docs'
+import { cn } from '@/lib/utils'
+
+export const Route = createFileRoute('/(docs)/docs/$')({
+  component: DocsPage,
+})
+
+function DocsPage() {
+  const { _splat } = Route.useParams()
+  const slug = _splat ?? ''
+  const page = getDocsPage(slug)
+
+  if (!page) {
+    return (
+      <div className="flex min-h-dvh flex-col items-center justify-center bg-background px-4 text-center">
+        <h1 className="text-2xl font-bold text-foreground">Page not found</h1>
+        <p className="mt-2 text-muted-foreground">
+          The documentation page you are looking for does not exist.
+        </p>
+        <Link
+          to="/docs"
+          search={(prev) => ({ host: prev.host ?? 0 })}
+          className="mt-6 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90"
+        >
+          Go to Docs Introduction
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-dvh px-4 py-6 lg:px-6 xl:px-8">
+      <DocsMobileNav
+        activeSlug={page.slug}
+        activeTitle={page.title}
+        headings={page.headings}
+      />
+      <div className="mx-auto flex w-full max-w-[96rem] items-start gap-8">
+        <DocsSidebar activeSlug={page.slug} />
+        <main className="min-w-0 flex-1 pb-16">
+          <div className="mx-auto max-w-4xl">
+            <DocsMarkdown markdown={page.markdown} />
+          </div>
+        </main>
+        <DocsToc headings={page.headings} />
+      </div>
+    </div>
+  )
+}
+
+function DocsMobileNav({
+  activeSlug,
+  activeTitle,
+  headings,
+}: {
+  activeSlug: string
+  activeTitle: string
+  headings: DocsHeading[]
+}) {
+  return (
+    <div className="sticky top-14 z-20 mb-6 border-border border-b bg-background/95 pb-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 lg:hidden">
+      <details className="group rounded-md border bg-card">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2 font-medium text-sm [&::-webkit-details-marker]:hidden">
+          <span className="min-w-0 truncate">{activeTitle}</span>
+          <span className="shrink-0 text-muted-foreground text-xs group-open:hidden">
+            Menu
+          </span>
+          <span className="hidden shrink-0 text-muted-foreground text-xs group-open:inline">
+            Close
+          </span>
+        </summary>
+        <div className="max-h-[calc(100vh-8rem)] overflow-y-auto border-border border-t p-3">
+          <DocsNavList activeSlug={activeSlug} compact />
+          {headings.length > 0 ? (
+            <div className="mt-4 border-border border-t pt-4">
+              <div className="mb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+                On this page
+              </div>
+              <DocsTocList headings={headings} />
+            </div>
+          ) : null}
+        </div>
+      </details>
+    </div>
+  )
+}
+
+function DocsSidebar({ activeSlug }: { activeSlug: string }) {
+  return (
+    <aside className="sticky top-6 hidden h-[calc(100vh-3rem)] w-64 shrink-0 overflow-y-auto border-border border-r pr-6 lg:block">
+      <Link
+        to="/docs"
+        search={(prev) => ({ host: prev.host ?? 0 })}
+        className="mb-4 block font-semibold text-foreground text-sm"
+      >
+        chmonitor
+      </Link>
+      <DocsNavList activeSlug={activeSlug} />
+    </aside>
+  )
+}
+
+function DocsNavList({
+  activeSlug,
+  compact = false,
+}: {
+  activeSlug: string
+  compact?: boolean
+}) {
+  return (
+    <nav className={cn('space-y-6', compact && 'space-y-4')}>
+      {docsNav.map((section) => (
+        <div key={section.title}>
+          <div className="mb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+            {section.title}
+          </div>
+          <ul className="space-y-1">
+            {section.items.map((item) => {
+              const isActive = item.slug === activeSlug
+              return (
+                <li key={item.slug || 'index'}>
+                  <Link
+                    to={docsHref(item.slug) as never}
+                    className={cn(
+                      'block rounded-md px-2 py-1.5 text-sm transition-colors',
+                      isActive
+                        ? 'bg-accent font-medium text-foreground'
+                        : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+                    )}
+                  >
+                    {item.title}
+                  </Link>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  )
+}
+
+function DocsToc({ headings }: { headings: DocsHeading[] }) {
+  if (headings.length === 0) {
+    return null
+  }
+
+  return (
+    <aside className="sticky top-6 hidden h-[calc(100vh-3rem)] w-56 shrink-0 overflow-y-auto xl:block">
+      <div className="mb-3 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+        On this page
+      </div>
+      <DocsTocList headings={headings} />
+    </aside>
+  )
+}
+
+function DocsTocList({ headings }: { headings: DocsHeading[] }) {
+  return (
+    <nav>
+      <ul className="space-y-1 border-border border-l">
+        {headings.map((heading) => (
+          <li key={heading.id}>
+            <a
+              href={`#${heading.id}`}
+              className={cn(
+                'block py-1 text-muted-foreground text-sm hover:text-foreground',
+                heading.level === 3 ? 'pl-6' : 'pl-3'
+              )}
+            >
+              {heading.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/apps/dashboard-tsr/src/routes/(docs)/docs/_components/docs-markdown.tsx
+++ b/apps/dashboard-tsr/src/routes/(docs)/docs/_components/docs-markdown.tsx
@@ -1,0 +1,138 @@
+import { Link } from '@tanstack/react-router'
+
+import type { ReactNode } from 'react'
+
+import { rewriteDocsHref, rewriteDocsImageSrc, slugify } from '../_lib/shared'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+type DocsMarkdownProps = {
+  markdown: string
+}
+
+export function DocsMarkdown({ markdown }: DocsMarkdownProps) {
+  const seenHeadingIds = new Map<string, number>()
+  const headingId = (children: ReactNode) => {
+    const baseId = slugify(nodeText(children))
+    const count = seenHeadingIds.get(baseId) ?? 0
+    seenHeadingIds.set(baseId, count + 1)
+    return count === 0 ? baseId : `${baseId}-${count}`
+  }
+
+  return (
+    <div className="markdown-content docs-markdown">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          a: ({ href, children }) => {
+            const resolvedHref = rewriteDocsHref(href)
+            const isExternal = resolvedHref?.startsWith('http')
+
+            if (!resolvedHref || isExternal) {
+              return (
+                <a
+                  href={resolvedHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {children}
+                </a>
+              )
+            }
+
+            // Internal link — use TanStack Router Link with `to` for type safety.
+            // Cast href as `any` since docs slugs are not registered routes.
+            return <Link to={resolvedHref as never}>{children}</Link>
+          },
+          h1: ({ children }) => (
+            <h1
+              id={headingId(children)}
+              className="scroll-m-20 text-4xl font-bold tracking-normal"
+            >
+              {children}
+            </h1>
+          ),
+          h2: ({ children }) => (
+            <h2
+              id={headingId(children)}
+              className="scroll-m-20 border-border border-b pb-2 text-2xl font-semibold tracking-normal"
+            >
+              {children}
+            </h2>
+          ),
+          h3: ({ children }) => (
+            <h3
+              id={headingId(children)}
+              className="scroll-m-20 text-xl font-semibold tracking-normal"
+            >
+              {children}
+            </h3>
+          ),
+          h4: ({ children }) => (
+            <h4
+              id={headingId(children)}
+              className="scroll-m-20 text-base font-semibold tracking-normal"
+            >
+              {children}
+            </h4>
+          ),
+          img: ({ src, alt }) => {
+            if (typeof src !== 'string') {
+              return null
+            }
+
+            return (
+              <img
+                src={rewriteDocsImageSrc(src) ?? src}
+                alt={alt ?? ''}
+                width={1200}
+                height={675}
+                className="h-auto w-full rounded-lg"
+              />
+            )
+          },
+          table: ({ children }) => (
+            <div className="my-4 overflow-x-auto rounded-lg border">
+              <table className="min-w-full border-collapse">{children}</table>
+            </div>
+          ),
+          th: ({ children }) => (
+            <th className="border-border border-b bg-muted px-3 py-2 text-left font-medium text-sm">
+              {children}
+            </th>
+          ),
+          td: ({ children }) => (
+            <td className="border-border border-t px-3 py-2 text-sm">
+              {children}
+            </td>
+          ),
+        }}
+      >
+        {markdown}
+      </ReactMarkdown>
+    </div>
+  )
+}
+
+function nodeText(children: ReactNode): string {
+  if (typeof children === 'string' || typeof children === 'number') {
+    return String(children)
+  }
+
+  if (Array.isArray(children)) {
+    return children.map(nodeText).join('')
+  }
+
+  if (
+    children &&
+    typeof children === 'object' &&
+    'props' in children &&
+    children.props &&
+    typeof children.props === 'object' &&
+    'children' in children.props
+  ) {
+    return nodeText(children.props.children as ReactNode)
+  }
+
+  return ''
+}

--- a/apps/dashboard-tsr/src/routes/(docs)/docs/_lib/content.ts
+++ b/apps/dashboard-tsr/src/routes/(docs)/docs/_lib/content.ts
@@ -1,0 +1,41 @@
+/**
+ * Loads docs MDX/markdown source files via import.meta.glob.
+ *
+ * Vite resolves glob paths relative to the source file at build time.
+ * The path below navigates from this file up to the repo root's docs/content/.
+ *
+ * Hierarchy (from this file):
+ *   _lib -> docs -> docs -> (docs) -> routes -> src -> dashboard-tsr -> apps -> (repo root) -> docs/content
+ *   = 7 levels up  (verified via os.path.relpath)
+ *
+ * `{ eager: true, query: '?raw', import: 'default' }` gives us the raw file
+ * text synchronously — no dynamic import() needed, which is important for SSR
+ * and the static prerender pass.
+ */
+const rawModules = import.meta.glob(
+  '../../../../../../../docs/content/**/*.{md,mdx}',
+  { eager: true, query: '?raw', import: 'default' }
+)
+
+function pathToSlug(path: string): string {
+  // path looks like: ../../../../../../../docs/content/advanced/custom-name.mdx
+  const contentMarker = '/docs/content/'
+  const idx = path.indexOf(contentMarker)
+  if (idx === -1) return ''
+  const rel = path.slice(idx + contentMarker.length)
+  const noExt = rel.replace(/\.(mdx|md)$/, '')
+  return noExt === 'index' ? '' : noExt.replace(/\/index$/, '')
+}
+
+/**
+ * Map of slug -> raw markdown/MDX source text.
+ *
+ * Keys match those produced by the Next app's build-docs-content.ts script.
+ * Empty string key = index / introduction page.
+ */
+export const docsContent: Record<string, string> = Object.fromEntries(
+  Object.entries(rawModules).map(([path, source]) => [
+    pathToSlug(path),
+    source as string,
+  ])
+)

--- a/apps/dashboard-tsr/src/routes/(docs)/docs/_lib/docs.ts
+++ b/apps/dashboard-tsr/src/routes/(docs)/docs/_lib/docs.ts
@@ -1,0 +1,249 @@
+import { docsContent } from './content'
+import { rewriteDocsHref, slugify } from './shared'
+
+export type DocsNavItem = {
+  title: string
+  slug: string
+}
+
+export type DocsNavSection = {
+  title: string
+  items: DocsNavItem[]
+}
+
+export type DocsHeading = {
+  id: string
+  text: string
+  level: number
+}
+
+export type DocsPage = {
+  slug: string
+  title: string
+  markdown: string
+  headings: DocsHeading[]
+}
+
+export const docsNav: DocsNavSection[] = [
+  {
+    title: 'chmonitor',
+    items: [
+      { title: 'Introduction', slug: '' },
+      { title: 'Features', slug: 'features' },
+      { title: 'AI Agent', slug: 'ai-agent' },
+      { title: 'Settings', slug: 'settings' },
+      { title: 'FAQ', slug: 'faq' },
+    ],
+  },
+  {
+    title: 'Getting Started',
+    items: [
+      { title: 'Getting Started', slug: 'getting-started' },
+      { title: 'Local Development', slug: 'getting-started/local' },
+      {
+        title: 'User Roles and Profile',
+        slug: 'getting-started/clickhouse-requirements',
+      },
+      {
+        title: 'Enable System Tables',
+        slug: 'getting-started/clickhouse-enable-system-tables',
+      },
+    ],
+  },
+  {
+    title: 'Deployments',
+    items: [
+      { title: 'Deploy', slug: 'deploy' },
+      { title: 'Vercel', slug: 'deploy/vercel' },
+      { title: 'Cloudflare', slug: 'deploy/cloudflare' },
+      { title: 'Docker', slug: 'deploy/docker' },
+      { title: 'Kubernetes', slug: 'deploy/k8s' },
+      {
+        title: 'Production Checklist',
+        slug: 'deploy/production-checklist',
+      },
+    ],
+  },
+  {
+    title: 'Advanced',
+    items: [
+      { title: 'Multiple Hosts', slug: 'advanced/multiple-hosts' },
+      { title: 'Custom Host Name', slug: 'advanced/custom-name' },
+      { title: 'Queries History', slug: 'advanced/queries-history' },
+      { title: 'Self-Tracking', slug: 'advanced/self-tracking' },
+      { title: 'Feature Permissions', slug: 'advanced/feature-permissions' },
+      { title: 'PeerDB Monitoring', slug: 'advanced/peerdb-monitoring' },
+    ],
+  },
+  {
+    title: 'Reference',
+    items: [
+      {
+        title: 'Configuration',
+        slug: 'reference/configuration',
+      },
+      {
+        title: 'Environment Variables',
+        slug: 'reference/environment-variables',
+      },
+      {
+        title: 'MCP Server',
+        slug: 'reference/mcp-server',
+      },
+    ],
+  },
+]
+
+export function docsHref(slug: string) {
+  return slug ? `/docs/${slug}` : '/docs'
+}
+
+export function getDocsPage(slug: string): DocsPage | null {
+  const normalizedSlug = normalizeSlug(slug)
+  const source = docsContent[normalizedSlug] ?? null
+
+  if (source === null) {
+    return null
+  }
+
+  const markdown = normalizeMdx(source)
+  const title = extractTitle(markdown, normalizedSlug)
+  const headings = extractHeadings(markdown)
+
+  return {
+    slug: normalizedSlug,
+    title,
+    markdown,
+    headings,
+  }
+}
+
+function normalizeSlug(slug: string) {
+  return slug
+    .split('/')
+    .filter(Boolean)
+    .filter((part) => part !== '..' && part !== '.')
+    .join('/')
+}
+
+/**
+ * Converts the Nextra-flavored MDX source into markdown that DocsMarkdown can render.
+ *
+ * Fenced code blocks are protected before component/import cleanup so examples are
+ * not modified by the regex transforms.
+ */
+function normalizeMdx(source: string) {
+  const normalizedCodeFences = source.replace(
+    /```(\w+)\s+([^`\n]+?)\s+```/g,
+    '```$1\n$2\n```'
+  )
+  const protectedSource = protectFencedCodeBlocks(normalizedCodeFences)
+
+  return demoteNestedTitles(
+    protectedSource.markdown
+      .replace(/^import\s+['"][^'"]+['"];?\s*$/gm, '')
+      .replace(/^import[\s\S]*?from\s+['"][^'"]+['"];?\s*$/gm, '')
+      .replace(/<Cards>[\s\S]*?<\/Cards>/g, cardsToMarkdown)
+      .replace(
+        /<Tabs items=\{\[([\s\S]*?)\]\}>[\s\S]*?<\/Tabs>/g,
+        tabsToMarkdown
+      )
+      .replace(/<\/?Steps>/g, '')
+      .replace(/<\/?Tabs\.Tab>/g, '')
+      .replace(/\n{3,}/g, '\n\n')
+  )
+    .trim()
+    .replace(
+      /<!-- DOCS_CODE_BLOCK_(\d+) -->/g,
+      (_match, index) => protectedSource.codeBlocks[Number(index)] ?? ''
+    )
+}
+
+/**
+ * Replaces fenced code blocks with stable placeholders during MDX cleanup.
+ */
+function protectFencedCodeBlocks(markdown: string) {
+  const codeBlocks: string[] = []
+
+  return {
+    markdown: markdown.replace(/```[\s\S]*?```/g, (match) => {
+      const index = codeBlocks.push(match) - 1
+      return `<!-- DOCS_CODE_BLOCK_${index} -->`
+    }),
+    codeBlocks,
+  }
+}
+
+function demoteNestedTitles(markdown: string) {
+  let seenTitle = false
+
+  return markdown.replace(/^#\s+(.+)$/gm, (match) => {
+    if (!seenTitle) {
+      seenTitle = true
+      return match
+    }
+    return `#${match}`
+  })
+}
+
+function cardsToMarkdown(block: string) {
+  const cards = block
+    .split('<Cards.Card')
+    .slice(1)
+    .map((match) => {
+      const title = match.match(/title="([^"]+)"/)?.[1]
+      const href = match.match(/href="([^"]+)"/)?.[1]
+
+      if (!title || !href) {
+        return null
+      }
+
+      return `- [${title}](${rewriteDocsHref(href)})`
+    })
+    .filter(Boolean)
+
+  return cards.length > 0 ? `\n\n${cards.join('\n')}\n\n` : ''
+}
+
+function tabsToMarkdown(block: string, labelsSource: string) {
+  const labels = [...labelsSource.matchAll(/["']([^"']+)["']/g)].map(
+    (match) => match[1]
+  )
+  const tabs = [...block.matchAll(/<Tabs\.Tab>([\s\S]*?)<\/Tabs\.Tab>/g)].map(
+    (match) => match[1].trim()
+  )
+
+  return tabs
+    .map((tab, index) => {
+      const label = labels[index] ?? `Option ${index + 1}`
+      return `\n\n#### ${label}\n\n${tab}\n`
+    })
+    .join('')
+}
+
+function extractTitle(markdown: string, slug: string) {
+  return (
+    markdown.match(/^#\s+(.+)$/m)?.[1] ??
+    docsNav
+      .flatMap((section) => section.items)
+      .find((item) => item.slug === slug)?.title ??
+    'Docs'
+  )
+}
+
+function extractHeadings(markdown: string): DocsHeading[] {
+  const seenIds = new Map<string, number>()
+
+  return [...markdown.matchAll(/^(#{2,3})\s+(.+)$/gm)].map((match) => {
+    const text = match[2].replace(/\s+#$/, '')
+    const baseId = slugify(text)
+    const count = seenIds.get(baseId) ?? 0
+    seenIds.set(baseId, count + 1)
+
+    return {
+      id: count === 0 ? baseId : `${baseId}-${count}`,
+      text,
+      level: match[1].length,
+    }
+  })
+}

--- a/apps/dashboard-tsr/src/routes/(docs)/docs/_lib/shared.ts
+++ b/apps/dashboard-tsr/src/routes/(docs)/docs/_lib/shared.ts
@@ -1,0 +1,47 @@
+export function rewriteDocsHref(href: string | undefined) {
+  if (!href) {
+    return href
+  }
+
+  if (href.startsWith('/docs') || href.startsWith('#')) {
+    return href
+  }
+
+  if (href.startsWith('/')) {
+    return `/docs${href}`
+  }
+
+  return href
+}
+
+export function rewriteDocsImageSrc(src: string | undefined) {
+  if (!src) {
+    return src
+  }
+
+  if (src.startsWith('http://') || src.startsWith('https://')) {
+    return src
+  }
+
+  const filename = src.split('/').filter(Boolean).at(-1)
+  if (!filename) {
+    return src
+  }
+
+  if (src.includes('.github/screenshots')) {
+    return `/docs-assets/screenshots/${filename}`
+  }
+
+  return `/docs-assets/${filename}`
+}
+
+export function slugify(text: string) {
+  return text
+    .toLowerCase()
+    .replace(/`/g, '')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}

--- a/apps/dashboard-tsr/src/routes/(docs)/docs/index.tsx
+++ b/apps/dashboard-tsr/src/routes/(docs)/docs/index.tsx
@@ -1,0 +1,173 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+
+import { DocsMarkdown } from './_components/docs-markdown'
+import { type DocsHeading, docsHref, docsNav, getDocsPage } from './_lib/docs'
+import { cn } from '@/lib/utils'
+
+export const Route = createFileRoute('/(docs)/docs/')({
+  component: DocsIndexPage,
+})
+
+function DocsIndexPage() {
+  // slug '' = introduction / index page
+  const page = getDocsPage('')
+
+  if (!page) {
+    return (
+      <div className="flex min-h-dvh flex-col items-center justify-center bg-background px-4 text-center">
+        <h1 className="text-2xl font-bold text-foreground">Page not found</h1>
+        <p className="mt-2 text-muted-foreground">
+          The documentation introduction page could not be loaded.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-dvh px-4 py-6 lg:px-6 xl:px-8">
+      <DocsMobileNav
+        activeSlug={page.slug}
+        activeTitle={page.title}
+        headings={page.headings}
+      />
+      <div className="mx-auto flex w-full max-w-[96rem] items-start gap-8">
+        <DocsSidebar activeSlug={page.slug} />
+        <main className="min-w-0 flex-1 pb-16">
+          <div className="mx-auto max-w-4xl">
+            <DocsMarkdown markdown={page.markdown} />
+          </div>
+        </main>
+        <DocsToc headings={page.headings} />
+      </div>
+    </div>
+  )
+}
+
+function DocsMobileNav({
+  activeSlug,
+  activeTitle,
+  headings,
+}: {
+  activeSlug: string
+  activeTitle: string
+  headings: DocsHeading[]
+}) {
+  return (
+    <div className="sticky top-14 z-20 mb-6 border-border border-b bg-background/95 pb-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 lg:hidden">
+      <details className="group rounded-md border bg-card">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2 font-medium text-sm [&::-webkit-details-marker]:hidden">
+          <span className="min-w-0 truncate">{activeTitle}</span>
+          <span className="shrink-0 text-muted-foreground text-xs group-open:hidden">
+            Menu
+          </span>
+          <span className="hidden shrink-0 text-muted-foreground text-xs group-open:inline">
+            Close
+          </span>
+        </summary>
+        <div className="max-h-[calc(100vh-8rem)] overflow-y-auto border-border border-t p-3">
+          <DocsNavList activeSlug={activeSlug} compact />
+          {headings.length > 0 ? (
+            <div className="mt-4 border-border border-t pt-4">
+              <div className="mb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+                On this page
+              </div>
+              <DocsTocList headings={headings} />
+            </div>
+          ) : null}
+        </div>
+      </details>
+    </div>
+  )
+}
+
+function DocsSidebar({ activeSlug }: { activeSlug: string }) {
+  return (
+    <aside className="sticky top-6 hidden h-[calc(100vh-3rem)] w-64 shrink-0 overflow-y-auto border-border border-r pr-6 lg:block">
+      <Link
+        to="/docs"
+        search={(prev) => ({ host: prev.host ?? 0 })}
+        className="mb-4 block font-semibold text-foreground text-sm"
+      >
+        chmonitor
+      </Link>
+      <DocsNavList activeSlug={activeSlug} />
+    </aside>
+  )
+}
+
+function DocsNavList({
+  activeSlug,
+  compact = false,
+}: {
+  activeSlug: string
+  compact?: boolean
+}) {
+  return (
+    <nav className={cn('space-y-6', compact && 'space-y-4')}>
+      {docsNav.map((section) => (
+        <div key={section.title}>
+          <div className="mb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+            {section.title}
+          </div>
+          <ul className="space-y-1">
+            {section.items.map((item) => {
+              const isActive = item.slug === activeSlug
+              return (
+                <li key={item.slug || 'index'}>
+                  <Link
+                    to={docsHref(item.slug) as never}
+                    className={cn(
+                      'block rounded-md px-2 py-1.5 text-sm transition-colors',
+                      isActive
+                        ? 'bg-accent font-medium text-foreground'
+                        : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+                    )}
+                  >
+                    {item.title}
+                  </Link>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  )
+}
+
+function DocsToc({ headings }: { headings: DocsHeading[] }) {
+  if (headings.length === 0) {
+    return null
+  }
+
+  return (
+    <aside className="sticky top-6 hidden h-[calc(100vh-3rem)] w-56 shrink-0 overflow-y-auto xl:block">
+      <div className="mb-3 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+        On this page
+      </div>
+      <DocsTocList headings={headings} />
+    </aside>
+  )
+}
+
+function DocsTocList({ headings }: { headings: DocsHeading[] }) {
+  return (
+    <nav>
+      <ul className="space-y-1 border-border border-l">
+        {headings.map((heading) => (
+          <li key={heading.id}>
+            <a
+              href={`#${heading.id}`}
+              className={cn(
+                'block py-1 text-muted-foreground text-sm hover:text-foreground',
+                heading.level === 3 ? 'pl-6' : 'pl-3'
+              )}
+            >
+              {heading.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/apps/dashboard-tsr/src/routes/(docs)/route.tsx
+++ b/apps/dashboard-tsr/src/routes/(docs)/route.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+
+// Pathless `(docs)` layout group — mirrors the Next app's app/(docs) segment.
+// The docs section uses the same root providers (ClerkAuthProvider, ThemeProvider, etc.)
+// already mounted by __root.tsx, so this layout only wraps the content area.
+export const Route = createFileRoute('/(docs)')({
+  component: DocsLayout,
+})
+
+function DocsLayout() {
+  return (
+    <div className="bg-background font-sans antialiased">
+      <Outlet />
+    </div>
+  )
+}

--- a/apps/dashboard-tsr/src/routes/(peerdb)/peerdb/index.tsx
+++ b/apps/dashboard-tsr/src/routes/(peerdb)/peerdb/index.tsx
@@ -1,0 +1,566 @@
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  ExternalLinkIcon,
+  NetworkIcon,
+  RefreshCwIcon,
+  SearchIcon,
+  XIcon,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { MirrorMetricsSummary } from '@/components/peerdb/mirror-row'
+import type { ListMirrorsResponse, ListPeersResponse } from '@/lib/peerdb/types'
+
+import { useEffect, useState } from 'react'
+import { KpiCard } from '@/components/peerdb/kpi-card'
+import { MirrorRow } from '@/components/peerdb/mirror-row'
+import { PeerGraph } from '@/components/peerdb/peer-graph'
+import { PeerDBNotConfigured } from '@/components/peerdb/peerdb-not-configured'
+import {
+  DESIGN_STATUS_META,
+  type DesignStatus,
+  isPeerDBNotConfigured,
+  pdbFmtNum,
+  toDesignStatus,
+} from '@/components/peerdb/peerdb-utils'
+import { usePeerDBStatus } from '@/components/peerdb/use-peerdb-status'
+import { usePeerDB } from '@/lib/swr'
+import { cn } from '@/lib/utils'
+
+export const Route = createFileRoute('/(peerdb)/peerdb/')({
+  component: PeerDBMirrorsPage,
+})
+
+const FILTERS: { k: DesignStatus | 'all'; label: string }[] = [
+  { k: 'all', label: 'All' },
+  { k: 'running', label: 'Running' },
+  { k: 'snapshotting', label: 'Snapshot' },
+  { k: 'paused', label: 'Paused' },
+  { k: 'failed', label: 'Failed' },
+]
+
+/** Rows rendered before "Show more" — windows huge fleets so the DOM stays light. */
+const PAGE_SIZE = 60
+
+function PeerDBMirrorsPage() {
+  const {
+    data,
+    error,
+    isLoading: isLoadingMirrors,
+    isValidating: isValidatingMirrors,
+    refresh: refreshMirrors,
+  } = usePeerDB<ListMirrorsResponse>('/mirrors/list', {
+    refreshInterval: 60_000,
+  })
+  const {
+    data: peersData,
+    error: peersError,
+    isLoading: isLoadingPeers,
+    isValidating: isValidatingPeers,
+    refresh: refreshPeers,
+  } = usePeerDB<ListPeersResponse>('/peers/list', {
+    refreshInterval: 120_000,
+  })
+  const {
+    data: status,
+    error: statusError,
+    isLoading: isLoadingStatus,
+    isFetching: isValidatingStatus,
+    refetch: refreshStatus,
+  } = usePeerDBStatus(120_000)
+
+  const isRefreshing =
+    isValidatingMirrors || isValidatingPeers || isValidatingStatus
+  const isLoadingAny = isLoadingMirrors || isLoadingPeers || isLoadingStatus
+
+  const refreshAll = async () => {
+    try {
+      await Promise.all([refreshMirrors(), refreshPeers(), refreshStatus()])
+    } catch {
+      // SWR surfaces per-hook errors in the UI; swallow here so the manual
+      // refresh click never produces an unhandled rejection.
+    }
+  }
+
+  // Trigger sonner toast notifications on fetching errors
+  useEffect(() => {
+    if (error) {
+      toast.error(`Mirrors API Error: ${error.message}`)
+    }
+  }, [error])
+
+  useEffect(() => {
+    if (peersError) {
+      toast.error(`Peers API Error: ${peersError.message}`)
+    }
+  }, [peersError])
+
+  useEffect(() => {
+    if (statusError) {
+      toast.error(`Connection Probe Error: ${statusError.message}`)
+    }
+  }, [statusError])
+
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [statusFilter, setStatusFilter] = useState<DesignStatus | 'all'>('all')
+  const [search, setSearch] = useState('')
+  const [graphOpen, setGraphOpen] = useState(false)
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
+  const [metrics, setMetrics] = useState<Record<string, MirrorMetricsSummary>>(
+    {}
+  )
+
+  const onMetrics = (name: string, m: MirrorMetricsSummary) => {
+    setMetrics((prev) => {
+      const cur = prev[name]
+      const sameTrend =
+        cur &&
+        cur.trend.length === m.trend.length &&
+        cur.trend.every((v, i) => v === m.trend[i])
+      if (
+        cur &&
+        cur.rowsPerSec === m.rowsPerSec &&
+        cur.rowsSynced === m.rowsSynced &&
+        sameTrend
+      ) {
+        return prev
+      }
+      return { ...prev, [name]: m }
+    })
+  }
+
+  const mirrors = data?.mirrors ?? []
+  const peers = (() => {
+    const seen = new Map<
+      string,
+      NonNullable<ListPeersResponse['items']>[number]
+    >()
+    for (const p of [
+      ...(peersData?.items ?? []),
+      ...(peersData?.sourceItems ?? []),
+      ...(peersData?.destinationItems ?? []),
+    ]) {
+      if (p?.name && !seen.has(p.name)) seen.set(p.name, p)
+    }
+    return Array.from(seen.values())
+  })()
+
+  const counts = (() => {
+    const c: Record<DesignStatus, number> = {
+      running: 0,
+      snapshotting: 0,
+      paused: 0,
+      failed: 0,
+    }
+    for (const m of mirrors) c[toDesignStatus(m.status)]++
+    return c
+  })()
+
+  const totals = (() => {
+    let rowsPerSec = 0
+    let rowsSynced = 0
+    let trendLen = 0
+    let measured = 0
+    for (const m of mirrors) {
+      const v = metrics[m.name]
+      if (!v) continue
+      measured++
+      rowsPerSec += v.rowsPerSec
+      rowsSynced += v.rowsSynced
+      trendLen = Math.max(trendLen, v.trend.length)
+    }
+    const aggTrend = Array.from({ length: trendLen }, (_, i) =>
+      mirrors.reduce((a, m) => a + (metrics[m.name]?.trend[i] ?? 0), 0)
+    )
+    return { rowsPerSec, rowsSynced, aggTrend, measured }
+  })()
+
+  const filtered = mirrors.filter((m) => {
+    if (statusFilter !== 'all' && toDesignStatus(m.status) !== statusFilter)
+      return false
+    if (
+      search &&
+      !`${m.name} ${m.sourceName ?? ''} ${m.destinationName ?? ''}`
+        .toLowerCase()
+        .includes(search.toLowerCase())
+    )
+      return false
+    return true
+  })
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deliberate reset triggers
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE)
+  }, [statusFilter, search])
+
+  const visible = filtered.slice(0, visibleCount)
+
+  if (isPeerDBNotConfigured(error)) {
+    return <PeerDBNotConfigured />
+  }
+
+  // Small fleets eagerly load per-row metrics; large fleets load lazily on expand.
+  const eagerMetrics = mirrors.length > 0 && mirrors.length <= 24
+
+  const toggleRow = (id: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+
+  const connected = status?.state === 'connected'
+  const chipTone = connected
+    ? 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300'
+    : status?.state === 'auth'
+      ? 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300'
+      : 'border-border bg-muted text-muted-foreground'
+  const dotColor = connected
+    ? '#10b981'
+    : status?.state === 'auth'
+      ? '#f59e0b'
+      : '#94a3b8'
+
+  return (
+    <div className="max-w-[1640px] px-3 py-4 sm:px-4 sm:py-5 md:px-6">
+      {/* header */}
+      <div className="mb-1 flex flex-wrap items-start justify-between gap-3 sm:items-center">
+        <div className="flex min-w-0 items-center gap-2">
+          <h1 className="text-[20px] font-bold tracking-tight sm:text-[22px]">
+            PeerDB Mirrors
+          </h1>
+          <span className="ml-1 inline-flex items-center rounded-md border border-border bg-muted px-1.5 py-0.5 font-mono text-[10.5px] font-medium text-muted-foreground">
+            {mirrors.length} mirrors
+          </span>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span
+            className={cn(
+              'inline-flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-[11.5px] font-medium',
+              chipTone
+            )}
+            title={status?.error}
+          >
+            <span className="relative inline-flex">
+              <span
+                className="size-1.5 rounded-full"
+                style={{ background: dotColor }}
+              />
+              {connected && (
+                <span
+                  className="absolute inset-0 animate-ping rounded-full"
+                  style={{ background: dotColor, opacity: 0.6 }}
+                />
+              )}
+            </span>
+            PeerDB API ·{' '}
+            <span className="font-mono tabular-nums">
+              {status?.host ?? '—'}
+            </span>
+          </span>
+          {isRefreshing && (
+            <span className="mr-1 inline-flex animate-pulse items-center gap-1.5 text-[11px] text-muted-foreground">
+              <span className="size-1.5 rounded-full bg-primary" />
+              Syncing in background...
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={refreshAll}
+            disabled={isLoadingAny || isRefreshing}
+            className="inline-flex h-7 items-center gap-1.5 rounded-md border border-border px-2 text-[12px] font-medium text-foreground transition-all hover:bg-muted disabled:cursor-not-allowed disabled:opacity-85"
+          >
+            <RefreshCwIcon
+              className={cn(
+                'size-3',
+                (isLoadingAny || isRefreshing) && 'animate-spin text-primary'
+              )}
+            />
+            <span className="hidden sm:inline">
+              {isLoadingAny || isRefreshing ? 'Refreshing...' : 'Refresh'}
+            </span>
+          </button>
+          {status?.host && (
+            <a
+              href={`${status.host.includes('localhost') || status.host.startsWith('127.') ? 'http' : 'https'}://${status.host}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex h-7 items-center gap-1.5 rounded-md border border-border px-2 text-[12px] font-medium text-foreground hover:bg-muted"
+            >
+              <ExternalLinkIcon className="size-3" />
+              <span className="hidden sm:inline">Open PeerDB</span>
+            </a>
+          )}
+        </div>
+      </div>
+      <p className="mb-4 text-[12.5px] text-muted-foreground">
+        Replication mirrors with live status, rows-synced trend, and routing
+        topology. Data sourced from{' '}
+        <span className="font-mono">/v1/mirrors/list</span>.
+      </p>
+
+      {/* API connection error warning banner */}
+      {(error || peersError || statusError) && (
+        <div className="mb-4 animate-in fade-in slide-in-from-top-2 flex flex-wrap items-center justify-between gap-2 rounded-md border border-destructive/20 bg-destructive/10 px-4 py-3 text-[12.5px] text-destructive shadow-sm duration-300">
+          <div className="flex items-center gap-2">
+            <span className="mr-1 rounded bg-destructive/20 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider">
+              Connection Alert
+            </span>
+            <span className="text-left font-medium">
+              {error?.message || peersError?.message || statusError?.message}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={refreshAll}
+            className="flex shrink-0 items-center gap-1 rounded border border-destructive/30 bg-background px-2.5 py-1 text-[11.5px] font-medium text-foreground shadow-sm transition-all hover:bg-muted"
+          >
+            <RefreshCwIcon className="size-3" />
+            Retry Connection
+          </button>
+        </div>
+      )}
+
+      {/* KPI row */}
+      <div className="mb-4 grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-6">
+        <KpiCard
+          label="Running"
+          value={counts.running}
+          dotColor={DESIGN_STATUS_META.running.dot}
+          pulse
+          sub="CDC active"
+          sparkData={totals.aggTrend}
+          sparkColor={DESIGN_STATUS_META.running.dot}
+        />
+        <KpiCard
+          label="Snapshotting"
+          value={counts.snapshotting}
+          dotColor={DESIGN_STATUS_META.snapshotting.dot}
+          pulse
+          sub="QRep + initial"
+        />
+        <KpiCard
+          label="Paused"
+          value={counts.paused}
+          dotColor={DESIGN_STATUS_META.paused.dot}
+          sub="user / auto"
+        />
+        <KpiCard
+          label="Failed"
+          value={counts.failed}
+          dotColor={DESIGN_STATUS_META.failed.dot}
+          sub="needs attention"
+          accent={counts.failed > 0 ? DESIGN_STATUS_META.failed.dot : undefined}
+        />
+        <KpiCard
+          label="Throughput"
+          value={pdbFmtNum(totals.rowsPerSec)}
+          sub={
+            eagerMetrics
+              ? 'rows/s · all mirrors'
+              : `rows/s · ${totals.measured}/${mirrors.length} loaded`
+          }
+          dotColor="#6366f1"
+          sparkData={totals.aggTrend}
+          sparkColor="#6366f1"
+        />
+        <KpiCard
+          label="Rows synced"
+          value={pdbFmtNum(totals.rowsSynced)}
+          sub={
+            eagerMetrics
+              ? 'cumulative all-time'
+              : `cumulative · ${totals.measured}/${mirrors.length} loaded`
+          }
+        />
+      </div>
+
+      {/* topology card — expand button centered on bottom border */}
+      <div className="relative mb-6">
+        <div className="overflow-hidden rounded-xl border border-border bg-card">
+          <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-3">
+            <NetworkIcon className="size-3.5 text-muted-foreground" />
+            <h2 className="text-[13px] font-semibold">Peer topology</h2>
+            <span className="inline-flex items-center rounded-md border border-border bg-muted px-1.5 py-0.5 font-mono text-[10.5px] font-medium text-muted-foreground">
+              {peers.length} peers
+            </span>
+            <span className="hidden text-[11px] text-muted-foreground sm:inline">
+              live flow visualization
+            </span>
+          </div>
+          {graphOpen && (
+            <div className="p-4">
+              <PeerGraph
+                peers={peers}
+                mirrors={mirrors}
+                className="h-[420px]"
+              />
+            </div>
+          )}
+        </div>
+        <div className="absolute bottom-0 left-0 right-0 flex translate-y-1/2 justify-center">
+          <button
+            type="button"
+            onClick={() => setGraphOpen((v) => !v)}
+            className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3.5 py-1 text-[11px] font-medium text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground"
+          >
+            {graphOpen ? (
+              <ChevronUpIcon className="size-3" />
+            ) : (
+              <ChevronDownIcon className="size-3" />
+            )}
+            {graphOpen ? 'Collapse' : 'Expand'}
+          </button>
+        </div>
+      </div>
+
+      {/* mirror table card */}
+      <div className="overflow-hidden rounded-xl border border-border bg-card">
+        {/* toolbar */}
+        <div className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2.5">
+          <div className="flex h-8 min-w-[200px] max-w-[360px] flex-1 items-center gap-1.5 rounded-md border border-border bg-card px-2.5">
+            <SearchIcon className="size-3 text-muted-foreground" />
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search mirror, source, destination…"
+              className="min-w-0 flex-1 bg-transparent text-[12.5px] outline-none placeholder:text-muted-foreground"
+            />
+            {search && (
+              <button
+                type="button"
+                onClick={() => setSearch('')}
+                className="text-[12px] text-muted-foreground"
+              >
+                <XIcon className="size-3" />
+              </button>
+            )}
+          </div>
+          <div className="flex items-center gap-0.5 rounded-md bg-muted p-0.5">
+            {FILTERS.map((o) => {
+              const count =
+                o.k === 'all' ? mirrors.length : counts[o.k as DesignStatus]
+              const on = statusFilter === o.k
+              return (
+                <button
+                  key={o.k}
+                  type="button"
+                  onClick={() => setStatusFilter(o.k)}
+                  className={cn(
+                    'inline-flex h-7 items-center gap-1.5 rounded px-2.5 text-[11.5px] font-medium',
+                    on
+                      ? 'bg-card text-foreground shadow-sm'
+                      : 'text-muted-foreground'
+                  )}
+                >
+                  {o.label}
+                  <span className="rounded px-1 text-[10px] tabular-nums text-muted-foreground/70">
+                    {count}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+          <div className="flex-1" />
+        </div>
+
+        <div className="overflow-x-auto">
+          <table
+            className="w-full border-collapse"
+            style={{ tableLayout: 'fixed' }}
+          >
+            <colgroup>
+              <col style={{ width: '230px' }} />
+              <col style={{ width: '160px' }} />
+              <col style={{ width: '92px' }} />
+              <col style={{ width: '160px' }} />
+              <col style={{ width: '88px' }} />
+              <col style={{ width: '92px' }} />
+              <col />
+              <col style={{ width: '90px' }} />
+            </colgroup>
+            <thead className="border-b border-border bg-muted/40">
+              <tr className="text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">
+                <th className="px-3 py-2 text-left">Mirror</th>
+                <th className="hidden px-3 py-2 text-left md:table-cell">
+                  Source
+                </th>
+                <th className="hidden px-1 py-2 text-center md:table-cell">
+                  Type
+                </th>
+                <th className="hidden px-3 py-2 text-left md:table-cell">
+                  Destination
+                </th>
+                <th className="hidden px-3 py-2 text-right lg:table-cell">
+                  Lag
+                </th>
+                <th className="hidden px-3 py-2 text-right lg:table-cell">
+                  Rows/s
+                </th>
+                <th className="px-3 py-2 text-right">Rows synced (trend)</th>
+                <th className="hidden px-3 py-2 text-right xl:table-cell">
+                  Created
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((m) => (
+                <MirrorRow
+                  key={m.name}
+                  mirror={m}
+                  expanded={expanded.has(m.name)}
+                  onToggle={() => toggleRow(m.name)}
+                  loadMetrics={eagerMetrics}
+                  onMetrics={onMetrics}
+                />
+              ))}
+              {filtered.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={8}
+                    className="px-6 py-12 text-center text-[13px] text-muted-foreground"
+                  >
+                    No mirrors match your filter
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {visible.length < filtered.length && (
+          <div className="border-t border-border px-3 py-2 text-center">
+            <button
+              type="button"
+              onClick={() => setVisibleCount((n) => n + PAGE_SIZE)}
+              className="text-[12px] font-medium text-muted-foreground hover:text-foreground"
+            >
+              Show {Math.min(PAGE_SIZE, filtered.length - visible.length)} more
+              mirrors
+            </button>
+          </div>
+        )}
+
+        <div className="flex flex-wrap items-center justify-between gap-2 border-t border-border px-3 py-2 text-[11.5px] text-muted-foreground">
+          <div>
+            Showing{' '}
+            <span className="font-medium tabular-nums text-foreground">
+              {visible.length}
+            </span>{' '}
+            of {filtered.length}
+            {filtered.length !== mirrors.length
+              ? ` (filtered from ${mirrors.length})`
+              : ''}{' '}
+            mirrors
+          </div>
+          <div className="flex items-center gap-2">
+            <RefreshCwIcon className="size-3" />
+            <span>Auto-refresh · every 60s</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/dashboard-tsr/src/routes/(peerdb)/peerdb/mirror.tsx
+++ b/apps/dashboard-tsr/src/routes/(peerdb)/peerdb/mirror.tsx
@@ -1,0 +1,225 @@
+import { createFileRoute, useSearch } from '@tanstack/react-router'
+
+import type {
+  CDCTableTotalCountsResponse,
+  GraphResponse,
+  ListMirrorLogsResponse,
+  MirrorStatusResponse,
+} from '@/lib/peerdb/types'
+
+import { Suspense } from 'react'
+import { MirrorStatusBadge } from '@/components/peerdb/mirror-status-badge'
+import { PartitionTable } from '@/components/peerdb/partition-table'
+import { PeerDBNotConfigured } from '@/components/peerdb/peerdb-not-configured'
+import {
+  formatDateTime,
+  isPeerDBNotConfigured,
+  toNumber,
+} from '@/components/peerdb/peerdb-utils'
+import { RowsSyncedChart } from '@/components/peerdb/rows-synced-chart'
+import { AppLink } from '@/components/ui/app-link'
+import { Card, CardContent } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { formatReadableQuantity } from '@/lib/format-readable'
+import { usePeerDB } from '@/lib/swr'
+
+export const Route = createFileRoute('/(peerdb)/peerdb/mirror')({
+  component: PeerDBMirrorDetailPage,
+})
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-1 p-4">
+        <span className="text-xs text-muted-foreground">{label}</span>
+        <span className="text-xl font-semibold tabular-nums">{value}</span>
+      </CardContent>
+    </Card>
+  )
+}
+
+function MirrorDetailContent() {
+  const search = useSearch({ strict: false }) as { name?: string }
+  const name = search.name ?? ''
+  const enabled = Boolean(name)
+
+  const status = usePeerDB<MirrorStatusResponse>(
+    enabled ? '/mirrors/status' : null,
+    {
+      body: { flowJobName: name, includeFlowInfo: true },
+      refreshInterval: 30_000,
+    }
+  )
+  const graph = usePeerDB<GraphResponse>(
+    enabled ? '/mirrors/cdc/graph' : null,
+    {
+      body: { flowJobName: name, aggregateType: '1hour' },
+      refreshInterval: 60_000,
+    }
+  )
+  const tableCounts = usePeerDB<CDCTableTotalCountsResponse>(
+    enabled
+      ? `/mirrors/cdc/table_total_counts/${encodeURIComponent(name)}`
+      : null
+  )
+  const logs = usePeerDB<ListMirrorLogsResponse>(
+    enabled ? '/mirrors/logs' : null,
+    { body: { flowJobName: name, level: 'error', page: 0, numPerPage: 20 } }
+  )
+
+  if (isPeerDBNotConfigured(status.error)) {
+    return <PeerDBNotConfigured />
+  }
+
+  if (!name) {
+    return <p className="text-sm text-muted-foreground">No mirror selected.</p>
+  }
+
+  const data = status.data
+  const cdc = data?.cdcStatus
+  const qrep = data?.qrepStatus
+  const partitions = qrep?.partitions ?? []
+  const tables = tableCounts.data?.tablesData ?? []
+  const errors = logs.data?.errors ?? []
+  const rowsSynced = toNumber(cdc?.rowsSynced)
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <AppLink
+          href="/peerdb"
+          className="text-sm text-muted-foreground hover:underline"
+        >
+          ← Mirrors
+        </AppLink>
+        <h1 className="text-2xl font-semibold">{name}</h1>
+        <MirrorStatusBadge status={data?.currentFlowState} />
+        <span className="text-xs text-muted-foreground">
+          {qrep ? 'Query Replication' : 'CDC'}
+        </span>
+      </div>
+
+      {data?.errorMessage ? (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+          {data.errorMessage}
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <StatCard
+          label="Rows synced (CDC)"
+          value={
+            cdc?.rowsSynced !== undefined
+              ? formatReadableQuantity(rowsSynced)
+              : '—'
+          }
+        />
+        <StatCard
+          label="Tables"
+          value={String(tables.length || partitions.length || 0)}
+        />
+        <StatCard
+          label="Total (graph)"
+          value={
+            graph.data
+              ? formatReadableQuantity(toNumber(graph.data.totalRows))
+              : '—'
+          }
+        />
+      </div>
+
+      <section className="flex flex-col gap-2 rounded-lg border p-4">
+        <h2 className="text-sm font-semibold">Rows synced over time</h2>
+        <RowsSyncedChart data={graph.data?.data ?? []} />
+      </section>
+
+      {partitions.length > 0 ? (
+        <section className="flex flex-col gap-2">
+          <h2 className="text-sm font-semibold">Partitions</h2>
+          <PartitionTable partitions={partitions} />
+        </section>
+      ) : null}
+
+      {tables.length > 0 ? (
+        <section className="flex flex-col gap-2">
+          <h2 className="text-sm font-semibold">Per-table stats</h2>
+          <div className="overflow-x-auto rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Table</TableHead>
+                  <TableHead className="text-right">Inserts</TableHead>
+                  <TableHead className="text-right">Updates</TableHead>
+                  <TableHead className="text-right">Deletes</TableHead>
+                  <TableHead className="text-right">Total</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {tables.map((t) => (
+                  <TableRow key={t.tableName}>
+                    <TableCell className="font-mono text-xs">
+                      {t.tableName}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatReadableQuantity(toNumber(t.counts?.insertsCount))}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatReadableQuantity(toNumber(t.counts?.updatesCount))}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatReadableQuantity(toNumber(t.counts?.deletesCount))}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatReadableQuantity(toNumber(t.counts?.totalCount))}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </section>
+      ) : null}
+
+      {errors.length > 0 ? (
+        <section className="flex flex-col gap-2">
+          <h2 className="text-sm font-semibold">Recent errors</h2>
+          <div className="flex flex-col gap-2">
+            {errors.map((e, i) => (
+              <div
+                key={e.id ?? i}
+                className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-medium text-destructive">
+                    {e.errorType ?? 'error'}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {formatDateTime(e.errorTimestamp)}
+                  </span>
+                </div>
+                <p className="mt-1 whitespace-pre-wrap break-words text-xs text-muted-foreground">
+                  {e.errorMessage}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  )
+}
+
+function PeerDBMirrorDetailPage() {
+  return (
+    <Suspense fallback={<div className="p-4 text-sm">Loading…</div>}>
+      <MirrorDetailContent />
+    </Suspense>
+  )
+}

--- a/apps/dashboard-tsr/src/routes/(peerdb)/peerdb/peer.tsx
+++ b/apps/dashboard-tsr/src/routes/(peerdb)/peerdb/peer.tsx
@@ -1,0 +1,209 @@
+import { createFileRoute, useSearch } from '@tanstack/react-router'
+
+import type {
+  PeerSlotResponse,
+  PeerStatResponse,
+  SlotLagHistoryResponse,
+} from '@/lib/peerdb/types'
+
+import { Suspense } from 'react'
+import { MiniAreaChart } from '@/components/charts/mini-charts'
+import { PeerDetailSkeleton } from '@/components/peerdb/peer-detail-skeleton'
+import { PeerDBNotConfigured } from '@/components/peerdb/peerdb-not-configured'
+import {
+  isPeerDBNotConfigured,
+  toNumber,
+} from '@/components/peerdb/peerdb-utils'
+import { AppLink } from '@/components/ui/app-link'
+import { Badge } from '@/components/ui/badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { usePeerDB } from '@/lib/swr'
+
+export const Route = createFileRoute('/(peerdb)/peerdb/peer')({
+  component: PeerDBPeerDetailPage,
+})
+
+function PeerDetailContent() {
+  const search = useSearch({ strict: false }) as { name?: string }
+  const name = search.name ?? ''
+  const enabled = Boolean(name)
+
+  const slots = usePeerDB<PeerSlotResponse>(
+    enabled ? `/peers/slots/${encodeURIComponent(name)}` : null,
+    { refreshInterval: 30_000 }
+  )
+  const stats = usePeerDB<PeerStatResponse>(
+    enabled ? `/peers/stats/${encodeURIComponent(name)}` : null,
+    { refreshInterval: 30_000 }
+  )
+
+  const slotData = slots.data?.slotData ?? []
+  const primarySlot = slotData[0]?.slotName
+
+  const lag = usePeerDB<SlotLagHistoryResponse>(
+    enabled && primarySlot ? '/peers/slots/lag_history' : null,
+    {
+      body: { peerName: name, slotName: primarySlot, timeSince: '1day' },
+    }
+  )
+
+  if (isPeerDBNotConfigured(slots.error)) {
+    return <PeerDBNotConfigured />
+  }
+
+  if (!name) {
+    return <p className="text-sm text-muted-foreground">No peer selected.</p>
+  }
+
+  const queries = stats.data?.statData ?? []
+  const lagPoints = (lag.data?.data ?? []).map((p) => toNumber(p.size))
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <AppLink
+          href="/peerdb/peers"
+          className="text-sm text-muted-foreground hover:underline"
+        >
+          ← Peers
+        </AppLink>
+        <h1 className="text-2xl font-semibold">{name}</h1>
+      </div>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-semibold">Replication slots</h2>
+        <div className="overflow-x-auto rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Slot</TableHead>
+                <TableHead>Active</TableHead>
+                <TableHead className="text-right">Lag (MB)</TableHead>
+                <TableHead>WAL status</TableHead>
+                <TableHead>Restart LSN</TableHead>
+                <TableHead>Confirmed flush LSN</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {slotData.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={6}
+                    className="py-6 text-center text-sm text-muted-foreground"
+                  >
+                    {slots.isLoading
+                      ? 'Loading slots…'
+                      : 'No replication slots (non-Postgres peer or no CDC).'}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                slotData.map((s) => (
+                  <TableRow key={s.slotName}>
+                    <TableCell className="font-mono text-xs">
+                      {s.slotName}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={s.active ? 'default' : 'secondary'}>
+                        {s.active ? 'active' : 'inactive'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {toNumber(s.lagInMb).toFixed(1)}
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {s.walStatus ?? '—'}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {s.restartLSN ?? '—'}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {s.confirmedFlushLSN ?? '—'}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </section>
+
+      {lagPoints.length >= 2 ? (
+        <section className="flex flex-col gap-2 rounded-lg border p-4">
+          <h2 className="text-sm font-semibold">
+            Slot lag (MB) — {primarySlot}
+          </h2>
+          <div className="h-[160px] w-full">
+            <MiniAreaChart
+              data={lagPoints}
+              label="Lag (MB)"
+              color="var(--chart-2, #f59e0b)"
+              valueFormatter={(v) => `${v.toFixed(1)} MB`}
+            />
+          </div>
+        </section>
+      ) : null}
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-semibold">Active queries</h2>
+        <div className="overflow-x-auto rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>PID</TableHead>
+                <TableHead>State</TableHead>
+                <TableHead className="text-right">Duration</TableHead>
+                <TableHead>Wait event</TableHead>
+                <TableHead>Query</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {queries.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={5}
+                    className="py-6 text-center text-sm text-muted-foreground"
+                  >
+                    {stats.isLoading ? 'Loading…' : 'No active queries.'}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                queries.map((q, i) => (
+                  <TableRow key={q.pid ?? i}>
+                    <TableCell className="tabular-nums">
+                      {q.pid ?? '—'}
+                    </TableCell>
+                    <TableCell className="text-xs">{q.state ?? '—'}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {q.duration ?? '—'}
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {q.waitEvent ?? '—'}
+                    </TableCell>
+                    <TableCell className="max-w-md truncate font-mono text-xs">
+                      {q.query}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function PeerDBPeerDetailPage() {
+  return (
+    <Suspense fallback={<PeerDetailSkeleton />}>
+      <PeerDetailContent />
+    </Suspense>
+  )
+}

--- a/apps/dashboard-tsr/src/routes/(peerdb)/peerdb/peers.tsx
+++ b/apps/dashboard-tsr/src/routes/(peerdb)/peerdb/peers.tsx
@@ -1,0 +1,257 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import type {
+  ListMirrorsResponse,
+  ListPeersResponse,
+  MirrorListItem,
+  PeerListItem,
+} from '@/lib/peerdb/types'
+
+import { useMemo } from 'react'
+import { DbLogo, hasDbLogo } from '@/components/icons/peerdb-logo'
+import { PeerGraph } from '@/components/peerdb/peer-graph'
+import { PeerTypeIcon } from '@/components/peerdb/peer-type-icon'
+import { PeerDBConnectionStatus } from '@/components/peerdb/peerdb-connection-status'
+import { PeerDBNotConfigured } from '@/components/peerdb/peerdb-not-configured'
+import {
+  dbTypeLabel,
+  isPeerDBNotConfigured,
+  normalizeDbType,
+  peerKind,
+  statusTone,
+  TONE_COLOR,
+} from '@/components/peerdb/peerdb-utils'
+import { AppLink } from '@/components/ui/app-link'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { usePeerDB } from '@/lib/swr'
+
+export const Route = createFileRoute('/(peerdb)/peerdb/peers')({
+  component: PeerDBPeersPage,
+})
+
+/** Per-peer aggregate derived from the mirrors list. */
+interface PeerStats {
+  /** Number of mirrors where this peer is the source. */
+  sourceCount: number
+  /** Number of mirrors where this peer is the destination. */
+  destCount: number
+  /** Worst mirror status tone among mirrors touching this peer. */
+  worstTone: string | null
+  /** Mirror counts by status tone. */
+  toneCounts: Record<string, number>
+}
+
+function computePeerStats(
+  peerName: string,
+  mirrors: MirrorListItem[]
+): PeerStats {
+  const sourceCount = mirrors.filter((m) => m.sourceName === peerName).length
+  const destCount = mirrors.filter((m) => m.destinationName === peerName).length
+  const toneCounts: Record<string, number> = {}
+  for (const m of mirrors) {
+    if (m.sourceName !== peerName && m.destinationName !== peerName) continue
+    const t = statusTone(m.status)
+    toneCounts[t] = (toneCounts[t] ?? 0) + 1
+  }
+  const priority = ['failed', 'paused', 'progress', 'running', 'idle']
+  let worstTone: string | null = null
+  for (const t of priority) {
+    if (toneCounts[t]) {
+      worstTone = t
+      break
+    }
+  }
+  return { sourceCount, destCount, worstTone, toneCounts }
+}
+
+/** A single tone dot used in the status summary. */
+function ToneDot({ tone, count }: { tone: string; count: number }) {
+  return (
+    <span
+      className="inline-flex items-center gap-1 text-[11px]"
+      title={`${count} ${tone}`}
+    >
+      <span
+        className="size-1.5 shrink-0 rounded-full"
+        style={{
+          background: TONE_COLOR[tone as keyof typeof TONE_COLOR] ?? '#94a3b8',
+        }}
+      />
+      <span className="tabular-nums text-muted-foreground">{count}</span>
+    </span>
+  )
+}
+
+function PeerDBPeersPage() {
+  const peersReq = usePeerDB<ListPeersResponse>('/peers/list', {
+    refreshInterval: 60_000,
+  })
+  const mirrorsReq = usePeerDB<ListMirrorsResponse>('/mirrors/list', {
+    refreshInterval: 60_000,
+  })
+
+  // Merge + dedupe peers from all list buckets.
+  const peers = useMemo(() => {
+    const seen = new Map<string, PeerListItem>()
+    for (const p of [
+      ...(peersReq.data?.items ?? []),
+      ...(peersReq.data?.sourceItems ?? []),
+      ...(peersReq.data?.destinationItems ?? []),
+    ]) {
+      if (p?.name && !seen.has(p.name)) seen.set(p.name, p)
+    }
+    return Array.from(seen.values())
+  }, [peersReq.data])
+
+  const mirrors = mirrorsReq.data?.mirrors ?? []
+
+  // Pre-compute per-peer stats from the mirrors list.
+  const statsMap = useMemo(() => {
+    const m = new Map<string, PeerStats>()
+    for (const p of peers) {
+      m.set(p.name, computePeerStats(p.name, mirrors))
+    }
+    return m
+  }, [peers, mirrors])
+
+  if (isPeerDBNotConfigured(peersReq.error)) {
+    return <PeerDBNotConfigured />
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h1 className="text-2xl font-semibold">PeerDB Peers</h1>
+          <p className="text-sm text-muted-foreground">
+            Source and destination peers and the mirrors that connect them.
+          </p>
+        </div>
+        <PeerDBConnectionStatus />
+      </div>
+
+      <PeerGraph peers={peers} mirrors={mirrors} className="h-[460px]" />
+
+      <div className="overflow-x-auto rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Peer</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead className="text-center">Source</TableHead>
+              <TableHead className="text-center">Destination</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {peers.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={5}
+                  className="py-8 text-center text-sm text-muted-foreground"
+                >
+                  {peersReq.isLoading ? 'Loading peers…' : 'No peers found.'}
+                </TableCell>
+              </TableRow>
+            ) : (
+              peers.map((p) => {
+                const stats = statsMap.get(p.name)
+                const normalizedType = normalizeDbType(p.type)
+                const hasLogo = hasDbLogo(normalizedType)
+                return (
+                  <TableRow key={p.name}>
+                    {/* Peer name + logo */}
+                    <TableCell>
+                      <AppLink
+                        href={`/peerdb/peer?name=${encodeURIComponent(p.name)}`}
+                        className="inline-flex items-center gap-2.5 font-medium text-primary hover:underline"
+                      >
+                        {hasLogo ? (
+                          <DbLogo
+                            type={normalizedType}
+                            width={22}
+                            height={22}
+                          />
+                        ) : (
+                          <PeerTypeIcon type={p.type} className="size-[22px]" />
+                        )}
+                        {p.name}
+                      </AppLink>
+                    </TableCell>
+
+                    {/* Type with brand-colored dot */}
+                    <TableCell>
+                      <span className="inline-flex items-center gap-1.5 text-sm text-muted-foreground">
+                        <span
+                          className="inline-flex size-2 shrink-0 rounded-full"
+                          style={{
+                            background: peerKind(normalizedType).dot,
+                          }}
+                        />
+                        {dbTypeLabel(p.type)}
+                      </span>
+                    </TableCell>
+
+                    {/* Source mirrors count */}
+                    <TableCell className="text-center tabular-nums text-sm">
+                      {stats?.sourceCount ? (
+                        <span className="font-medium">{stats.sourceCount}</span>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+
+                    {/* Destination mirrors count */}
+                    <TableCell className="text-center tabular-nums text-sm">
+                      {stats?.destCount ? (
+                        <span className="font-medium">{stats.destCount}</span>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+
+                    {/* Mirror health summary */}
+                    <TableCell>
+                      {stats && stats.sourceCount + stats.destCount > 0 ? (
+                        <div className="flex items-center gap-2">
+                          {(
+                            [
+                              'running',
+                              'progress',
+                              'failed',
+                              'paused',
+                              'idle',
+                            ] as const
+                          )
+                            .filter((t) => stats.toneCounts[t])
+                            .map((t) => (
+                              <ToneDot
+                                key={t}
+                                tone={t}
+                                count={stats.toneCounts[t]}
+                              />
+                            ))}
+                        </div>
+                      ) : (
+                        <span className="text-[11px] text-muted-foreground">
+                          No mirrors
+                        </span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                )
+              })
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}

--- a/apps/dashboard-tsr/src/routes/(peerdb)/route.tsx
+++ b/apps/dashboard-tsr/src/routes/(peerdb)/route.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+
+// Pathless `(peerdb)` group — mirrors the Next app's app/(peerdb) segment.
+// Shares the same bare layout as (dashboard); add a separate sidebar/header
+// here later if the two layouts diverge.
+export const Route = createFileRoute('/(peerdb)')({
+  component: PeerDBLayout,
+})
+
+function PeerDBLayout() {
+  return (
+    <main className="mx-auto max-w-7xl p-6">
+      <Outlet />
+    </main>
+  )
+}

--- a/apps/dashboard-tsr/src/routes/api/clean.ts
+++ b/apps/dashboard-tsr/src/routes/api/clean.ts
@@ -1,0 +1,201 @@
+/**
+ * Cleanup Endpoint — POST /api/clean
+ *
+ * Kills long-running hang queries (>10 min with zero read_rows) via the
+ * monitoring user, then records a LastCleanup + SystemKillQuery event.
+ * Skips if the last cleanup happened within QUERY_CLEANUP_MAX_DURATION_SECONDS.
+ *
+ * Ported from apps/dashboard/app/api/clean/route.ts.
+ * - Per-route feature-permission auth (authorizeFeatureRequest) is DROPPED:
+ *   centralized in middleware (#1397).
+ * - ErrorLogger replaced with @chm/logger debug/error.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { getClient } from '@chm/clickhouse-client'
+import { debug, error } from '@chm/logger'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { EVENTS_TABLE } from '@/lib/app-tables'
+
+const QUERY_CLEANUP_MAX_DURATION_SECONDS = 10 * 60 // 10 minutes
+const MONITORING_USER = () => process.env.CLICKHOUSE_USER || ''
+
+type KillQueryRow = { kill_status: string; query_id: string; user: string }
+
+type KillQueryResponse = {
+  meta: object[]
+  data: KillQueryRow[]
+  rows: number
+  statistics: object
+}
+
+type CHClient = Awaited<ReturnType<typeof getClient>>
+
+async function getLastCleanup(client: CHClient): Promise<[Date, Date]> {
+  try {
+    const response = await client.query({
+      query: `
+        SELECT max(event_time) as last_cleanup,
+               now() as now
+        FROM ${EVENTS_TABLE}
+        WHERE kind = 'LastCleanup'
+      `,
+      format: 'JSONEachRow',
+      clickhouse_settings: { max_execution_time: 15 },
+    })
+    const data: { last_cleanup: string; now: string }[] = await response.json()
+    const lastCleanup = new Date(data[0].last_cleanup)
+    const now = new Date(data[0].now)
+    debug(`[/api/clean] Last cleanup: ${lastCleanup}, now: ${now}`)
+    return [lastCleanup, now]
+  } catch (err) {
+    throw new Error(`Error when getting last cleanup: ${err}`)
+  }
+}
+
+function shouldCleanup(lastCleanup: Date, now: Date): boolean {
+  return (
+    now.getTime() - lastCleanup.getTime() >=
+    QUERY_CLEANUP_MAX_DURATION_SECONDS * 1000
+  )
+}
+
+async function killHangingQueries(
+  client: CHClient
+): Promise<KillQueryResponse | null> {
+  try {
+    const resp = await client.query({
+      query: `
+        KILL QUERY
+        WHERE user = currentUser()
+          AND read_rows = 0
+          AND elapsed > {maxDuration: UInt32}
+        ASYNC
+      `,
+      format: 'JSON',
+      query_params: { maxDuration: QUERY_CLEANUP_MAX_DURATION_SECONDS },
+    })
+    const killQueryResp = (await resp.json()) as unknown as KillQueryResponse
+    debug('[/api/clean] queries found', {
+      queryIds: killQueryResp.data.map((r) => r.query_id).join(', '),
+    })
+    return killQueryResp
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      err.message.includes('Unexpected end of JSON input')
+    ) {
+      debug('[/api/clean] Done, nothing to cleanup')
+      return null
+    }
+    throw new Error(`Error when killing queries: ${err}`)
+  }
+}
+
+async function updateLastCleanup(client: CHClient): Promise<void> {
+  try {
+    await client.insert({
+      table: EVENTS_TABLE,
+      values: [{ kind: 'LastCleanup', actor: MONITORING_USER() }],
+      format: 'JSONEachRow',
+    })
+    debug('[/api/clean] LastCleanup event created')
+  } catch (err) {
+    error('[/api/clean] LastCleanup event error', err as Error)
+    throw new Error(`'LastCleanup' event creating error: ${err}`)
+  }
+}
+
+async function createSystemKillQueryEvent(
+  client: CHClient,
+  killQueryResp: KillQueryResponse
+): Promise<void> {
+  try {
+    const killStatus = killQueryResp.data.reduce(
+      (acc, row) => {
+        acc[row.kill_status] = (acc[row.kill_status] || 0) + 1
+        return acc
+      },
+      {} as Record<string, number>
+    )
+    const value = {
+      kind: 'SystemKillQuery',
+      actor: MONITORING_USER(),
+      data: `Detected ${killQueryResp.rows} hang queries (>${QUERY_CLEANUP_MAX_DURATION_SECONDS}s), killing them, result: ${JSON.stringify(killStatus)}`,
+    }
+    await client.insert({
+      table: EVENTS_TABLE,
+      format: 'JSONEachRow',
+      values: [value],
+    })
+  } catch (err) {
+    error('[/api/clean] SystemKillQuery event error', err as Error)
+  }
+}
+
+async function cleanupHangQuery(
+  client: CHClient
+): Promise<{ lastCleanup: Date; message: string }> {
+  const [lastCleanup, now] = await getLastCleanup(client)
+
+  if (!shouldCleanup(lastCleanup, now)) {
+    return {
+      lastCleanup,
+      message: `Not triggering cleanup, last ${lastCleanup.toISOString()}, now: ${now.toISOString()}, QUERY_CLEANUP_MAX_DURATION_SECONDS=${QUERY_CLEANUP_MAX_DURATION_SECONDS}s`,
+    }
+  }
+
+  debug('[/api/clean] Starting clean up hang queries')
+
+  const killQueryResp = await killHangingQueries(client)
+  await updateLastCleanup(client)
+
+  if (!killQueryResp || killQueryResp.rows === 0) {
+    debug('[/api/clean] Done, nothing to cleanup')
+    return { lastCleanup, message: 'Nothing to cleanup' }
+  }
+
+  await createSystemKillQueryEvent(client, killQueryResp)
+  return { lastCleanup, message: 'Cleanup completed' }
+}
+
+export const Route = createFileRoute('/api/clean')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const searchParams = new URL(request.url).searchParams
+        const hostIdRaw = searchParams.get('hostId')
+        if (!hostIdRaw) {
+          return Response.json(
+            { error: 'Missing required parameter: hostId' },
+            { status: 400 }
+          )
+        }
+
+        const hostId = parseInt(hostIdRaw, 10)
+        if (Number.isNaN(hostId) || hostId < 0) {
+          return Response.json(
+            { error: 'Invalid hostId: must be a non-negative number' },
+            { status: 400 }
+          )
+        }
+
+        try {
+          const client = await getClient({ hostId })
+          const resp = await cleanupHangQuery(client)
+          return Response.json({ status: true, ...resp }, { status: 200 })
+        } catch (err) {
+          error('[/api/clean] Handler error', err as Error)
+          return Response.json(
+            { status: false, error: String(err) },
+            { status: 500 }
+          )
+        }
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/cron/health-sweep.ts
+++ b/apps/dashboard-tsr/src/routes/api/cron/health-sweep.ts
@@ -1,0 +1,35 @@
+/**
+ * Autonomous Health Sweep Cron Endpoint — GET /api/cron/health-sweep
+ *
+ * Intended to be invoked by a Cloudflare Cron Trigger every 5 minutes.
+ * Runs the health/anomaly sweep over all hosts and dispatches webhook
+ * alerts for findings at or above the configured minimum severity.
+ *
+ * Ported from apps/dashboard/app/api/cron/health-sweep/route.ts.
+ *
+ * STATUS: 501 stub — @/lib/health/server-sweep (runHealthSweep) and
+ * @/lib/health/server-alert-config (getServerAlertConfig) are not yet
+ * ported into dashboard-tsr. Port those modules first, then remove the
+ * stub and wire the real handler below.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/cron/health-sweep')({
+  server: {
+    handlers: {
+      GET: async () => {
+        return Response.json(
+          {
+            error: 'Not Implemented',
+            message:
+              'health-sweep is not yet available in dashboard-tsr: ' +
+              'lib/health/server-sweep and lib/health/server-alert-config ' +
+              'must be ported first.',
+          },
+          { status: 501 }
+        )
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/init.ts
+++ b/apps/dashboard-tsr/src/routes/api/init.ts
@@ -1,0 +1,56 @@
+/**
+ * Init Endpoint — POST /api/init
+ *
+ * Creates (or migrates) the monitoring_events tracking table for a given host.
+ * Safe to call repeatedly — the underlying schema logic is idempotent.
+ *
+ * Ported from apps/dashboard/app/api/init/route.ts.
+ * - Per-route feature-permission auth (authorizeFeatureRequest) is DROPPED:
+ *   centralized in middleware (#1397).
+ * - ErrorLogger replaced with @chm/logger error.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { getClient } from '@chm/clickhouse-client'
+import { error } from '@chm/logger'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { initTrackingTable } from '@/lib/tracking'
+
+export const Route = createFileRoute('/api/init')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const searchParams = new URL(request.url).searchParams
+        const hostIdRaw = searchParams.get('hostId')
+        if (!hostIdRaw) {
+          return Response.json(
+            { error: 'Missing required parameter: hostId' },
+            { status: 400 }
+          )
+        }
+
+        const hostId = parseInt(hostIdRaw, 10)
+        if (Number.isNaN(hostId) || hostId < 0) {
+          return Response.json(
+            { error: 'Invalid hostId: must be a non-negative number' },
+            { status: 400 }
+          )
+        }
+
+        const client = await getClient({ hostId })
+
+        try {
+          await initTrackingTable(client)
+          return Response.json({ message: 'Ok.' })
+        } catch (err) {
+          error('[/api/init] Handler error', err as Error)
+          return Response.json({ error: String(err) }, { status: 500 })
+        }
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/pageview.ts
+++ b/apps/dashboard-tsr/src/routes/api/pageview.ts
@@ -1,0 +1,97 @@
+/**
+ * PageView Tracking Endpoint — GET /api/pageview
+ *
+ * Records a PageView event to the monitoring_events table. Collects URL,
+ * browser user-agent, and IP/geo from standard request headers.
+ *
+ * Ported from apps/dashboard/app/api/pageview/route.ts.
+ * - next/server (userAgent) and @vercel/functions (geolocation) are replaced
+ *   with direct header reads — equivalent for Cloudflare Workers.
+ * - ErrorLogger replaced with @chm/logger debug/error.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { getClient } from '@chm/clickhouse-client'
+import { debug, error } from '@chm/logger'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { EVENTS_TABLE } from '@/lib/app-tables'
+
+/** Trim whitespace and strip trailing slash/question-mark from a URL string. */
+function normalizeUrl(url: string): string {
+  return url.trim().replace(/(\/|\?)$/, '')
+}
+
+export const Route = createFileRoute('/api/pageview')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const searchParams = new URL(request.url).searchParams
+        const rawUrl = searchParams.get('url') || request.headers.get('referer')
+        const hostId = parseInt(searchParams.get('hostId') || '0', 10)
+
+        if (!rawUrl) {
+          return Response.json({ error: 'No URL provided' }, { status: 400 })
+        }
+
+        const url = normalizeUrl(rawUrl)
+        const client = await getClient({ hostId })
+
+        // User-agent: parse browser/os/device from the UA string directly.
+        // next/server's userAgent() is not available; Cloudflare provides the
+        // raw header. We forward the raw string in the extra payload.
+        const uaString = request.headers.get('user-agent') ?? ''
+
+        // Geo: Cloudflare Workers expose CF-IPCountry, CF-IPCity etc.
+        const country =
+          request.headers.get('cf-ipcountry') ??
+          request.headers.get('x-vercel-ip-country') ??
+          undefined
+        const city =
+          request.headers.get('cf-ipcity') ??
+          request.headers.get('x-vercel-ip-city') ??
+          undefined
+        const region =
+          request.headers.get('cf-region') ??
+          request.headers.get('x-vercel-ip-country-region') ??
+          undefined
+
+        const realIp = request.headers.get('x-real-ip') ?? ''
+        const forwardedFor = request.headers.get('x-forwarded-for') ?? realIp
+        const ip = (forwardedFor.split(',')[0] || '').trim()
+
+        try {
+          await client.insert({
+            table: EVENTS_TABLE,
+            format: 'JSONEachRow',
+            values: [
+              {
+                kind: 'PageView',
+                data: url,
+                actor: 'user',
+                extra: JSON.stringify({
+                  userAgent: uaString,
+                  ip,
+                  city,
+                  country,
+                  region,
+                }),
+              },
+            ],
+          })
+          debug('[/api/pageview] PageView event created', { url })
+          return Response.json({ message: 'PageView event created', url })
+        } catch (err) {
+          error('[/api/pageview] PageView insert error', err as Error)
+          return Response.json(
+            { error: `Error creating PageView event: ${err}` },
+            { status: 500 }
+          )
+        }
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/auth/api-key.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/auth/api-key.ts
@@ -1,0 +1,32 @@
+/**
+ * API Key Issuance Endpoint
+ * POST /api/v1/auth/api-key
+ *
+ * Mints a signed API key for use with the MCP server.
+ * Requires CHM_API_KEY_SECRET as a Bearer token to authorize issuance.
+ *
+ * NOTE: This endpoint depends on @chm/mcp-server/auth (getBearerToken,
+ * issueApiKey) which is not present in this app. It returns HTTP 501 until
+ * the mcp-server package is added as a dependency.
+ *
+ * Ported from apps/dashboard/app/api/v1/auth/api-key/route.ts.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/v1/auth/api-key')({
+  server: {
+    handlers: {
+      POST: async (): Promise<Response> => {
+        return Response.json(
+          {
+            error:
+              'Not implemented: @chm/mcp-server is not available in this app. ' +
+              'Add @chm/mcp-server to apps/dashboard-tsr dependencies to enable this endpoint.',
+          },
+          { status: 501 }
+        )
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/browser-connections/proxy.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/browser-connections/proxy.ts
@@ -1,0 +1,145 @@
+/**
+ * Browser Connection Proxy endpoint
+ * POST /api/v1/browser-connections/proxy
+ *
+ * Executes a ClickHouse query using browser-provided connection credentials.
+ * Returns results in the same shape as /api/v1/data.
+ * Credentials are provided in the request body and never logged.
+ *
+ * Ported from apps/dashboard/app/api/v1/browser-connections/proxy/route.ts.
+ * - Per-route auth (authorizeFeatureRequest) dropped; centralized in middleware (#1397).
+ * - NextResponse replaced with standard Response / Response.json.
+ * - @/lib/api/error-handler and @/lib/api/shared/response-builder both exist in
+ *   this app and are imported directly.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+import type { DataFormat } from '@clickhouse/client'
+import { createClient } from '@clickhouse/client-web'
+
+import { createValidationError } from '@/lib/api/error-handler'
+import {
+  createErrorResponse,
+  createSuccessResponse,
+} from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import {
+  createHostValidationFetch,
+  validateHostUrl,
+} from '@/lib/browser-connections/host-url'
+
+const ROUTE_CONTEXT = {
+  route: '/api/v1/browser-connections/proxy',
+  method: 'POST',
+} as const
+
+interface ProxyConnection {
+  host: string
+  user: string
+  password: string
+}
+
+interface ProxyRequest {
+  connection: ProxyConnection
+  query: string
+  query_params?: Record<string, string | number | boolean>
+  format?: string
+}
+
+async function handlePost(request: Request): Promise<Response> {
+  let body: Partial<ProxyRequest>
+  try {
+    body = (await request.json()) as Partial<ProxyRequest>
+  } catch {
+    return createValidationError(
+      'Request body must be valid JSON',
+      ROUTE_CONTEXT
+    )
+  }
+
+  const { connection, query, query_params, format = 'JSONEachRow' } = body
+
+  if (!connection || typeof connection !== 'object') {
+    return createValidationError(
+      'Missing required field: connection',
+      ROUTE_CONTEXT
+    )
+  }
+
+  const { host, user, password } = connection
+
+  if (!host || typeof host !== 'string') {
+    return createValidationError(
+      'Missing required field: connection.host',
+      ROUTE_CONTEXT
+    )
+  }
+  if (!user || typeof user !== 'string') {
+    return createValidationError(
+      'Missing required field: connection.user',
+      ROUTE_CONTEXT
+    )
+  }
+  if (typeof password !== 'string') {
+    return createValidationError(
+      'Missing required field: connection.password',
+      ROUTE_CONTEXT
+    )
+  }
+  if (!query || typeof query !== 'string') {
+    return createValidationError('Missing required field: query', ROUTE_CONTEXT)
+  }
+
+  // Validate host URL and block SSRF targets
+  const ssrfError = await validateHostUrl(host)
+  if (ssrfError) {
+    return createValidationError(ssrfError, ROUTE_CONTEXT)
+  }
+
+  const start = Date.now()
+
+  try {
+    const client = createClient({
+      host,
+      username: user,
+      password,
+      fetch: createHostValidationFetch(),
+    })
+
+    const result = await client.query({
+      query,
+      query_params,
+      format: format as DataFormat,
+    })
+
+    const rows = await result.json<unknown[]>()
+    const duration = Date.now() - start
+    const rowCount = Array.isArray(rows) ? rows.length : 0
+
+    return createSuccessResponse(rows, {
+      duration,
+      rows: rowCount,
+      queryId: result.query_id,
+    })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Query execution failed'
+    return createErrorResponse(
+      {
+        type: ApiErrorType.QueryError,
+        message,
+        details: { timestamp: new Date().toISOString() },
+      },
+      500,
+      ROUTE_CONTEXT
+    )
+  }
+}
+
+export const Route = createFileRoute('/api/v1/browser-connections/proxy')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/browser-connections/test.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/browser-connections/test.ts
@@ -1,0 +1,102 @@
+/**
+ * Browser Connection Test endpoint
+ * POST /api/v1/browser-connections/test
+ *
+ * Validates a browser-provided ClickHouse connection by running SELECT version().
+ * Credentials are provided in the request body and never logged.
+ *
+ * Ported from apps/dashboard/app/api/v1/browser-connections/test/route.ts.
+ * - Per-route auth dropped; centralized in middleware (#1397).
+ * - NextResponse replaced with standard Response / Response.json.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+import { createClient } from '@clickhouse/client-web'
+
+import { createValidationError } from '@/lib/api/error-handler'
+import {
+  createHostValidationFetch,
+  validateHostUrl,
+} from '@/lib/browser-connections/host-url'
+
+const ROUTE_CONTEXT = {
+  route: '/api/v1/browser-connections/test',
+  method: 'POST',
+} as const
+
+interface TestConnectionRequest {
+  host: string
+  user: string
+  password: string
+}
+
+interface TestConnectionResponse {
+  ok: boolean
+  version?: string
+  error?: string
+}
+
+async function handlePost(request: Request): Promise<Response> {
+  let body: Partial<TestConnectionRequest>
+  try {
+    body = (await request.json()) as Partial<TestConnectionRequest>
+  } catch {
+    return createValidationError(
+      'Request body must be valid JSON',
+      ROUTE_CONTEXT
+    )
+  }
+
+  const { host, user, password } = body
+
+  if (!host || typeof host !== 'string') {
+    return createValidationError('Missing required field: host', ROUTE_CONTEXT)
+  }
+  if (!user || typeof user !== 'string') {
+    return createValidationError('Missing required field: user', ROUTE_CONTEXT)
+  }
+  if (typeof password !== 'string') {
+    return createValidationError(
+      'Missing required field: password',
+      ROUTE_CONTEXT
+    )
+  }
+
+  // Validate host URL and block SSRF targets
+  const ssrfError = await validateHostUrl(host)
+  if (ssrfError) {
+    return createValidationError(ssrfError, ROUTE_CONTEXT)
+  }
+
+  try {
+    const client = createClient({
+      host,
+      username: user,
+      password,
+      fetch: createHostValidationFetch(),
+    })
+
+    const result = await client.query({
+      query: 'SELECT version() AS version',
+      format: 'JSONEachRow',
+    })
+
+    const rows = (await result.json()) as { version: string }[]
+    const version = rows[0]?.version
+
+    const response: TestConnectionResponse = { ok: true, version }
+    return Response.json(response, { status: 200 })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Connection failed'
+    const response: TestConnectionResponse = { ok: false, error: message }
+    return Response.json(response, { status: 200 })
+  }
+}
+
+export const Route = createFileRoute('/api/v1/browser-connections/test')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/health/webhook.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/health/webhook.ts
@@ -1,0 +1,123 @@
+/**
+ * Health Webhook Proxy Endpoint
+ * POST /api/v1/health/webhook
+ *
+ * Securely proxies Slack/Discord webhook requests from the server side to
+ * bypass browser CORS preflight restrictions.
+ *
+ * Ported from apps/dashboard/app/api/v1/health/webhook/route.ts.
+ * - Per-route auth (authorizeFeatureRequest / SETTINGS_FEATURE_PERMISSION)
+ *   dropped; centralized in middleware (#1397).
+ * - NextResponse replaced with standard Response / Response.json.
+ * - @/lib/api/error-handler exists in this app and is imported directly.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { debug, error } from '@chm/logger'
+import { createErrorResponse } from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+
+const ROUTE_CONTEXT = {
+  route: '/api/v1/health/webhook',
+  method: 'POST',
+} as const
+
+async function handlePost(request: Request): Promise<Response> {
+  debug('[POST /api/v1/health/webhook] Proxying alert webhook')
+
+  let body: { url?: string; text?: string }
+  try {
+    body = (await request.json()) as { url?: string; text?: string }
+  } catch {
+    return createErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message: 'Request body must be valid JSON',
+      },
+      400,
+      ROUTE_CONTEXT
+    )
+  }
+
+  const { url, text } = body
+
+  if (!url || typeof url !== 'string' || !url.startsWith('https://')) {
+    return createErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message: 'Missing or invalid "url": expected an HTTPS webhook URL',
+      },
+      400,
+      ROUTE_CONTEXT
+    )
+  }
+
+  if (!text || typeof text !== 'string') {
+    return createErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message: 'Missing or invalid "text": expected a string payload',
+      },
+      400,
+      ROUTE_CONTEXT
+    )
+  }
+
+  debug(
+    '[POST /api/v1/health/webhook] Proxying to:',
+    `${url.substring(0, 40)}...`
+  )
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 10_000)
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, content: text }),
+      signal: controller.signal,
+    })
+
+    clearTimeout(timeout)
+
+    if (!res.ok) {
+      const errText = await res.text().catch(() => '')
+      error(
+        '[POST /api/v1/health/webhook] Remote webhook error:',
+        new Error(`Status ${res.status}`),
+        { errText }
+      )
+      return createErrorResponse(
+        {
+          type: ApiErrorType.QueryError,
+          message: `Remote webhook returned status ${res.status}: ${errText}`,
+        },
+        res.status,
+        ROUTE_CONTEXT
+      )
+    }
+
+    return Response.json({ success: true }, { status: 200 })
+  } catch (fetchErr: unknown) {
+    clearTimeout(timeout)
+    error('[POST /api/v1/health/webhook] Webhook fetch exception:', fetchErr)
+    return createErrorResponse(
+      {
+        type: ApiErrorType.NetworkError,
+        message: `Failed to connect to remote webhook: ${fetchErr instanceof Error ? fetchErr.message : String(fetchErr)}`,
+      },
+      502,
+      ROUTE_CONTEXT
+    )
+  }
+}
+
+export const Route = createFileRoute('/api/v1/health/webhook')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/peerdb/$.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/peerdb/$.ts
@@ -1,0 +1,237 @@
+/**
+ * PeerDB REST proxy (view-only).
+ *
+ * Forwards GET/POST requests to the configured PeerDB flow-api, but ONLY for an
+ * explicit read-only allowlist. Any path/method not on the list is rejected
+ * with 403 so mutating endpoints can never be reached through CHM.
+ *
+ * The PeerDB Basic-auth credential is attached server-side and never exposed to
+ * the browser.
+ *
+ * Ported from apps/dashboard/app/api/v1/peerdb/[...slug]/route.ts.
+ * - Per-route authorizeFeatureRequest dropped (centralized in middleware #1397).
+ * - process.env replaced with `env` from cloudflare:workers (Workers runtime).
+ * - [...slug] -> $ splat; slug read via params._splat.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { generateRequestId } from '@chm/logger'
+
+// ---------------------------------------------------------------------------
+// Inlined Workers-safe PeerDB config + fetch (mirrors peerdb-status.ts pattern)
+// ---------------------------------------------------------------------------
+
+interface PeerDBConfig {
+  baseUrl: string
+  password?: string
+}
+
+class PeerDBError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message)
+    this.name = 'PeerDBError'
+  }
+}
+
+function getPeerDBConfig(
+  bindings: Record<string, string | undefined>
+): PeerDBConfig | null {
+  const baseUrl = bindings.PEERDB_API_URL?.trim()
+  if (!baseUrl) return null
+  return {
+    baseUrl: baseUrl.replace(/\/+$/, ''),
+    password: bindings.PEERDB_PASSWORD?.trim() || undefined,
+  }
+}
+
+function authHeader(config: PeerDBConfig): Record<string, string> {
+  if (!config.password) return {}
+  // PeerDB uses Basic auth with an empty username: base64(':' + password).
+  // btoa is available in all Workers runtimes (no Buffer needed).
+  const token = btoa(`:${config.password}`)
+  return { Authorization: `Basic ${token}` }
+}
+
+const FETCH_TIMEOUT_MS = 10_000
+
+async function peerdbFetch(
+  config: PeerDBConfig,
+  path: string,
+  init?: { method: 'GET' | 'POST'; body?: string }
+): Promise<unknown> {
+  const url = `${config.baseUrl}${path.startsWith('/') ? path : `/${path}`}`
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: init?.method ?? 'GET',
+      body: init?.body,
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeader(config),
+      },
+    })
+  } catch (err) {
+    const aborted = err instanceof Error && err.name === 'AbortError'
+    throw new PeerDBError(
+      aborted
+        ? `PeerDB request timed out after ${FETCH_TIMEOUT_MS}ms`
+        : `Failed to reach PeerDB: ${
+            err instanceof Error ? err.message : 'unknown error'
+          }`,
+      502
+    )
+  } finally {
+    clearTimeout(timeout)
+  }
+
+  if (!response.ok) {
+    throw new PeerDBError(
+      `PeerDB API error ${response.status}: ${response.statusText}`,
+      response.status
+    )
+  }
+
+  return response.json()
+}
+
+// ---------------------------------------------------------------------------
+// Allowlist — only these paths may be read-proxied
+// ---------------------------------------------------------------------------
+
+const ALLOWLIST: Record<'GET' | 'POST', RegExp[]> = {
+  GET: [
+    /^\/v1\/version$/,
+    /^\/v1\/dynamic_settings$/,
+    /^\/v1\/mirrors\/(list|names)$/,
+    /^\/v1\/mirrors\/cdc\/table_total_counts\/[^/]+$/,
+    /^\/v1\/mirrors\/cdc\/initial_load\/[^/]+$/,
+    /^\/v1\/mirrors\/total_rows_synced\/[^/]+$/,
+    /^\/v1\/peers\/(list)$/,
+    /^\/v1\/peers\/(slots|stats|info|type)\/[^/]+$/,
+  ],
+  POST: [
+    /^\/v1\/mirrors\/status$/,
+    /^\/v1\/mirrors\/cdc\/graph$/,
+    /^\/v1\/mirrors\/cdc\/batches$/,
+    /^\/v1\/mirrors\/logs$/,
+    /^\/v1\/peers\/slots\/lag_history$/,
+  ],
+}
+
+function isAllowed(method: 'GET' | 'POST', path: string): boolean {
+  return ALLOWLIST[method].some((re) => re.test(path))
+}
+
+/**
+ * Build the upstream PeerDB path from the splat.
+ *
+ * The splat value for `/api/v1/peerdb/mirrors/list` is `mirrors/list`.
+ * PeerDB expects `/v1/mirrors/list`, so we prepend `/v1/`.
+ */
+function buildPath(splat: string): string {
+  // splat may have leading slash or not; normalise then prefix.
+  const cleaned = splat.replace(/^\/+/, '')
+  return `/v1/${cleaned}`
+}
+
+// ---------------------------------------------------------------------------
+// Error response helpers (inlined from data.ts pattern)
+// ---------------------------------------------------------------------------
+
+function errorResponse(message: string, status: number): Response {
+  return Response.json({ success: false, error: { message } }, { status })
+}
+
+// ---------------------------------------------------------------------------
+// Shared handler
+// ---------------------------------------------------------------------------
+
+async function handle(
+  method: 'GET' | 'POST',
+  request: Request,
+  splat: string
+): Promise<Response> {
+  const requestId = generateRequestId()
+  const bindings = env as Record<string, string | undefined>
+  const config = getPeerDBConfig(bindings)
+
+  if (!config) {
+    return Response.json(
+      {
+        success: false,
+        error: { message: 'PeerDB is not configured on this deployment' },
+        metadata: { queryId: requestId },
+      },
+      { status: 503 }
+    )
+  }
+
+  const path = buildPath(splat)
+
+  if (!isAllowed(method, path)) {
+    return errorResponse(
+      `Endpoint not allowed (read-only proxy): ${method} ${path}`,
+      403
+    )
+  }
+
+  const url = new URL(request.url)
+  const upstreamPath = url.search ? `${path}${url.search}` : path
+
+  try {
+    const body = method === 'POST' ? await request.text() : undefined
+    const data = await peerdbFetch(config, upstreamPath, {
+      method,
+      ...(body ? { body } : {}),
+    })
+
+    const responseBody = JSON.stringify({
+      success: true,
+      data,
+      metadata: { queryId: requestId, apiUrl: path },
+    })
+
+    return new Response(responseBody, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'private, max-age=0',
+        'X-Request-ID': requestId,
+      },
+    })
+  } catch (err) {
+    const status = err instanceof PeerDBError ? err.status : 500
+    return Response.json(
+      {
+        success: false,
+        error: {
+          message: err instanceof Error ? err.message : 'PeerDB request failed',
+        },
+        metadata: { queryId: requestId },
+      },
+      { status }
+    )
+  }
+}
+
+export const Route = createFileRoute('/api/v1/peerdb/$')({
+  server: {
+    handlers: {
+      GET: async ({ request, params }) => {
+        return handle('GET', request, params._splat ?? '')
+      },
+      POST: async ({ request, params }) => {
+        return handle('POST', request, params._splat ?? '')
+      },
+    },
+  },
+})

--- a/apps/dashboard-tsr/src/routes/api/v1/tables/index.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/tables/index.ts
@@ -25,7 +25,7 @@ interface TableRow {
   total_rows: string
 }
 
-export const Route = createFileRoute('/api/v1/tables')({
+export const Route = createFileRoute('/api/v1/tables/')({
   server: {
     handlers: {
       GET: async ({ request }) => {


### PR DESCRIPTION
## Wave A — mechanical bulk port (autonomous TSR finish)

Part of the TanStack Start migration epic #1392. Ports the remaining **mechanical** Next→TanStack Start surfaces. Verified locally: `vite build` + `tsc --noEmit` **green (0 errors)**, **109 pages prerendered**.

### Pages
- `logs/{crashes,stack-traces,text-log}` — reuse existing logs query-configs + chart components
- `(peerdb)` group — `peerdb` index/mirror/peer/peers + `/api/v1/peerdb/$` splat
- `(docs)` group — docs catch-all via `import.meta.glob` over `docs/content` (all `/docs/*` prerender)

### API routes (full ports)
- `v1/browser-connections/{proxy,test}`, `v1/health/webhook`
- `clean`, `init`, `pageview` (Cloudflare-header geolocation in place of `@vercel/functions`)

### Deferred — honest 501 stubs (wired in Wave B with their deps)
- `v1/auth/api-key` — needs `@chm/mcp-server/auth`
- `cron/health-sweep` — needs `lib/health/server-sweep` + `server-alert-config`

### Also
- Fix latent type bug: `tables/index.ts` route path → `/api/v1/tables/` (canonical index-route form; surfaced by actually building dashboard-tsr, which main CI does not yet do).
- **Biome lint-clean** the whole app (unused imports/vars, import sort, format) — clears debt that accumulated because dashboard-tsr isn't yet covered by any CI lint/type-check/build job. Prepares it for CI wiring (Wave D).

Closes part of #1396, #1402.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Port remaining logs, PeerDB, and docs pages and associated API endpoints from the Next.js app into the TanStack Start dashboard, while aligning API routes with Workers env and adding a reusable migration codemod.

New Features:
- Add PeerDB mirrors, peers, peer, and mirror detail pages backed by a read-only PeerDB REST proxy and shared status components.
- Introduce a docs section powered by import.meta.glob-based content loading, markdown rendering, and navigation/TOC scaffolding within a dedicated (docs) layout group.
- Expose browser connection proxy and test endpoints that validate ClickHouse hosts with SSRF-safe client-web connections.
- Provide cleanup, init, pageview tracking, and health webhook API endpoints compatible with the Cloudflare Workers runtime, plus 501 stubs for cron health sweep and MCP API key issuance.

Bug Fixes:
- Correct the /api/v1/tables/ route path to use a canonical trailing-slash index form discovered during dashboard-tsr build.
- Harden parameter validation and logging formatting across several explorer and findings API routes without changing behavior.

Enhancements:
- Add a deterministic Bun-based TanStack Start codemod script to automate common Next→TSR migration edits.
- Normalize imports, unused variables, and formatting across dashboard-tsr routes to satisfy Biome linting and prep the app for CI.
- Unify PeerDB configuration and fetch logic between the status and REST proxy routes, including stricter timeouts and error handling.

Documentation:
- Document and structure docs navigation and headings via typed metadata, slug helpers, and URL rewrite utilities for internal and external docs links.