### PR TITLE
feat(dashboard-tsr): port middleware.ts to TanStack auth guards (#1397)

### DIFF
--- a/apps/dashboard-tsr/src/lib/auth/api-guard.ts
+++ b/apps/dashboard-tsr/src/lib/auth/api-guard.ts
@@ -1,0 +1,156 @@
+/**
+ * Request-level auth guard for `/api/v1/*` routes.
+ *
+ * Ported from apps/dashboard/middleware.ts (#1397). The Next app ran this in
+ * Next middleware; TanStack Start has no `middleware.ts`, so the equivalent
+ * runs as a global request middleware registered in `src/start.ts`.
+ *
+ * Two pieces of the Next middleware are reproduced here:
+ *
+ *  1. API-key auth (`getApiKeyAuthFailure`) — when `apiKeyAuthEnabled()` is
+ *     true, EVERY `/api/v1/*` route requires a valid `chm_` Bearer token and
+ *     returns a 401 JSON `{ error: 'API key required' }` (or
+ *     `Invalid API key: <reason>`) otherwise. Exempt: `/api/v1/auth/api-key`
+ *     (it owns its own secret-based auth in the handler).
+ *
+ *  2. cloud→dash 301 redirect (`getLegacyHostRedirect`).
+ *
+ * NOT ported: the Next `clerkMiddleware()` / Clerk-cookie precheck for
+ * protected agent routes (`getAgentApiClerkPrecheck`). In this app those routes
+ * (`/api/v1/agent`, …) already enforce feature-permission auth in-handler via
+ * `authorizeAgentApiRequest` / `authorizeFeatureRequest`, and Clerk runs as a
+ * client provider (see __root.tsx) — there is no server-side Clerk middleware
+ * to bypass. The route handlers own that decision, identical to Next behavior.
+ *
+ * `apiKeyAuthEnabled()` and `verifyApiKey()` read `process.env.CHM_API_KEY_SECRET`
+ * directly. On Cloudflare Workers the canonical source is the `env` binding, so
+ * `bridgeApiKeyEnv(env)` copies the secret onto `process.env` before the check
+ * (same bridge pattern as `bridgeClickHouseEnv`).
+ */
+
+import {
+  apiKeyAuthEnabled,
+  getBearerToken,
+  verifyApiKey,
+} from '@chm/mcp-server/auth'
+import { getAuthProvider, isAuthProviderConfigError } from '@/lib/auth/provider'
+
+const API_V1_PREFIX = '/api/v1/'
+// Key issuance route has its own secret-based auth in its handler.
+const API_KEY_ISSUANCE_PATH = '/api/v1/auth/api-key'
+
+const LEGACY_HOST = 'cloud.chmonitor.dev'
+const CANONICAL_HOST = 'dash.chmonitor.dev'
+
+type EnvBindings = Record<string, string | undefined>
+
+/**
+ * Copy CHM_API_KEY_SECRET from the Worker `env` binding onto `process.env`
+ * so `apiKeyAuthEnabled()` / `verifyApiKey()` (which read process.env) see it.
+ * Idempotent; only sets when present on the binding and not already set.
+ */
+export function bridgeApiKeyEnv(bindings: EnvBindings): void {
+  if (typeof process === 'undefined' || !process.env) return
+  const value = bindings.CHM_API_KEY_SECRET
+  if (value != null && value !== '' && process.env.CHM_API_KEY_SECRET == null) {
+    process.env.CHM_API_KEY_SECRET = value
+  }
+}
+
+function jsonError(message: string, status: number): Response {
+  return Response.json({ error: message }, { status })
+}
+
+/**
+ * cloud.chmonitor.dev is a legacy alias of the dashboard. Permanently redirect
+ * it to the canonical dash.chmonitor.dev host, preserving path and query.
+ *
+ * Mirrors `getLegacyHostRedirect` from the Next middleware.
+ */
+export function getLegacyHostRedirect(request: Request): Response | null {
+  const host = request.headers.get('host')
+  if (host !== LEGACY_HOST) {
+    return null
+  }
+
+  const url = new URL(request.url)
+  return Response.redirect(
+    `https://${CANONICAL_HOST}${url.pathname}${url.search}`,
+    301
+  )
+}
+
+/**
+ * Enforce API-key auth for `/api/v1/*` routes when it is enabled.
+ *
+ * Returns a 401 Response to short-circuit, or `null` to allow the request.
+ * Mirrors `getApiKeyAuthFailure` from the Next middleware.
+ */
+export async function getApiKeyAuthFailure(
+  request: Request
+): Promise<Response | null> {
+  const { pathname } = new URL(request.url)
+
+  if (!pathname.startsWith(API_V1_PREFIX)) {
+    return null
+  }
+
+  if (!apiKeyAuthEnabled()) return null
+
+  // Key issuance route has its own secret-based auth in the handler.
+  if (pathname === API_KEY_ISSUANCE_PATH) {
+    return null
+  }
+
+  const headerToken = getBearerToken(request.headers.get('authorization'))
+
+  if (!headerToken) {
+    return jsonError('API key required', 401)
+  }
+
+  const result = await verifyApiKey(headerToken)
+  if (!result.valid) {
+    return jsonError(`Invalid API key: ${result.reason}`, 401)
+  }
+
+  return null
+}
+
+/**
+ * Resolve the auth-guard response for a request, or `null` to proceed.
+ *
+ * Order mirrors the Next middleware:
+ *  1. legacy host 301 redirect (any path)
+ *  2. only `/api/v1/*` requests run the auth checks (others pass through)
+ *  3. invalid auth-provider config → 500
+ *  4. API-key auth failure → 401
+ *
+ * `bridgeApiKeyEnv` must be called by the caller (start.ts) before this, so
+ * the env binding is visible to process.env-based helpers on Workers.
+ */
+export async function resolveApiGuard(
+  request: Request
+): Promise<Response | null> {
+  const legacyHostRedirect = getLegacyHostRedirect(request)
+  if (legacyHostRedirect) {
+    return legacyHostRedirect
+  }
+
+  const { pathname } = new URL(request.url)
+  if (!pathname.startsWith(API_V1_PREFIX)) {
+    return null
+  }
+
+  // Surface invalid auth-provider configuration the same way Next did (500),
+  // rather than letting a misconfig silently fall through.
+  try {
+    getAuthProvider()
+  } catch (error) {
+    if (isAuthProviderConfigError(error)) {
+      return jsonError('Invalid auth provider configuration', 500)
+    }
+    throw error
+  }
+
+  return getApiKeyAuthFailure(request)
+}

--- a/apps/dashboard-tsr/src/start.ts
+++ b/apps/dashboard-tsr/src/start.ts
@@ -1,0 +1,43 @@
+/**
+ * TanStack Start server configuration.
+ *
+ * Registers the global request middleware that ports the Next.js
+ * `apps/dashboard/middleware.ts` security posture (#1397): API-key auth for
+ * `/api/v1/*` routes and the cloud→dash 301 redirect. See
+ * `@/lib/auth/api-guard` for the ported logic and the rationale for what is
+ * (and is not) reproduced from the Next middleware.
+ *
+ * The `tanstackStart()` vite plugin auto-discovers this file by convention.
+ * `requestMiddleware` runs for EVERY request (server routes, SSR, server
+ * functions), so it can return a 401/redirect Response before any `/api/v1/*`
+ * handler executes — matching how Next middleware intercepted the request.
+ */
+
+import { createMiddleware, createStart } from '@tanstack/react-start'
+
+import { env } from 'cloudflare:workers'
+import { bridgeApiKeyEnv, resolveApiGuard } from '@/lib/auth/api-guard'
+
+// Returning a Response from a request middleware short-circuits the chain and
+// sends that Response without running the route handler (same mechanism the
+// built-in CSRF middleware uses). Calling `next()` proceeds normally.
+const apiAuthMiddleware = createMiddleware().server(
+  async ({ next, request }) => {
+    // Bridge the Worker env secret onto process.env so apiKeyAuthEnabled() /
+    // verifyApiKey() (which read process.env.CHM_API_KEY_SECRET) can see it.
+    bridgeApiKeyEnv(env as Record<string, string | undefined>)
+
+    const guardResponse = await resolveApiGuard(request)
+    if (guardResponse) {
+      return guardResponse
+    }
+
+    return next()
+  }
+)
+
+export const startInstance = createStart(() => {
+  return {
+    requestMiddleware: [apiAuthMiddleware],
+  }
+})


### PR DESCRIPTION
## Summary

Ports `apps/dashboard/middleware.ts` to a TanStack Start global request middleware so the `dashboard-tsr` app enforces auth on `/api/v1/*` **identically to the Next prod app**.

**Why:** A parity comparison found TSR `/api/v1/*` routes returned `200` (OPEN) where Next returns `401` — the TSR app had **no auth enforcement**. The data/charts/tables routes were ported with their per-route feature-permission auth dropped, explicitly expecting it to be centralized in middleware (see the comment in `src/routes/api/v1/data.ts`). This PR adds that centralized layer.

Closes #1397. Part of epic #1392.

## What changed

- **`src/start.ts`** (new) — Registers a global request middleware via `createStart()` → `requestMiddleware: [...]`. The `tanstackStart()` vite plugin auto-discovers `src/start.ts` by convention. Request middleware runs for **every** request and short-circuits by returning a `Response` instead of calling `next()` — the same mechanism the framework's built-in CSRF middleware uses.
- **`src/lib/auth/api-guard.ts`** (new) — Ported logic, reusing the Wave B auth helpers (`@chm/mcp-server/auth`, `@/lib/auth/provider`):
  - `getApiKeyAuthFailure` — when `apiKeyAuthEnabled()` is true, every `/api/v1/*` route requires a valid `chm_` Bearer token → `401 { error: 'API key required' }` (or `Invalid API key: <reason>`). **Exempt:** `/api/v1/auth/api-key` (owns its own secret auth in-handler). When `CHM_API_KEY_SECRET` is unset, `apiKeyAuthEnabled()` is false → **no enforcement**, so anonymous dashboards keep working (matches Next; does NOT hard-enforce).
  - `getLegacyHostRedirect` — `cloud.chmonitor.dev` → `dash.chmonitor.dev` 301, preserving path + query.
  - Invalid auth-provider config → `500 { error: 'Invalid auth provider configuration' }`, matching Next.
  - `bridgeApiKeyEnv` — copies `CHM_API_KEY_SECRET` from the Worker `env` binding onto `process.env` (the mcp-server helpers read `process.env`), same bridge pattern as `bridgeClickHouseEnv`.

### Not ported (intentional)
The Next `clerkMiddleware()` / Clerk-cookie precheck for protected agent routes (`getAgentApiClerkPrecheck`) is **not** reproduced. In this app those routes (`/api/v1/agent`, etc.) already enforce feature-permission auth **in-handler** via `authorizeAgentApiRequest` / `authorizeFeatureRequest`, and Clerk runs as a **client provider** (see `__root.tsx`) — there is no server-side Clerk middleware to bypass. The route handlers own that decision, so the security posture matches Next.

## TanStack API used
- `createStart()` + `requestMiddleware` (global request middleware) from `@tanstack/react-start` — runs for all server routes/SSR/server functions.
- `createMiddleware().server(({ next, request }) => ...)` — default `'request'` type; returning a `Response` short-circuits before the handler.

## Verification
- `bunx tsc --noEmit` → **0 errors**.
- `bun run build` (vite + tsc) → **GREEN** (`BUILD_EXIT=0`).
- `bun wrangler deploy --dry-run` → **gzip 2365.59 KiB** (under the 3072 KiB / 3 MiB worker limit; +~3 KiB vs ~2362 KiB baseline).
- Confirmed the middleware is bundled and registered: `dist/server/assets/start-*.js` exports `createStart(() => ({ requestMiddleware: [apiAuthMiddleware] }))` with `jsonError("API key required", 401)`, and is imported by the worker entry `dist/server/index.js`.

**Runtime 401 not yet verified against a live deploy** (no deploy from this PR). To verify post-deploy with `CHM_API_KEY_SECRET` set:
- `curl -s -o /dev/null -w '%{http_code}' https://<host>/api/v1/data?hostId=0&sql=...` (no Bearer) → expect `401` `{ error: 'API key required' }`.
- Same with a valid `chm_` Bearer (mint via `POST /api/v1/auth/api-key`) → expect `200`.
- `curl https://<host>/api/v1/auth/api-key` with the secret as Bearer → still works (exempt route).
- With `CHM_API_KEY_SECRET` unset → all `/api/v1/*` return their normal responses (no 401), confirming anonymous mode is preserved.

> Security code — left for review, **auto-merge not armed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added API key authentication requirement for API endpoints
* Implemented automatic redirect from legacy domain to current domain
* Enhanced security with request-level validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->