### PR TITLE
fix(dashboard-tsr): perf + dual-target build fixes (#1392)

### DIFF
--- a/apps/dashboard-tsr/src/components/agents/agents-page-client.tsx
+++ b/apps/dashboard-tsr/src/components/agents/agents-page-client.tsx
@@ -3,6 +3,7 @@
 import type { JSX } from 'react'
 
 import { lazy, Suspense } from 'react'
+import { AgentsPageSkeleton } from '@/components/skeletons'
 
 /**
  * Client entry point for the `/agents` route. The assistant-ui runtime, the
@@ -16,8 +17,10 @@ const AgentThreadPage = lazy(() =>
 )
 
 export function AgentsPageClient(): JSX.Element {
+  // The skeleton reserves the same footprint as AgentThreadPage (composer +
+  // 320px sidebar) so nothing shifts when the lazy chunk mounts (CLS fix).
   return (
-    <Suspense fallback={<div className="bg-background h-full" />}>
+    <Suspense fallback={<AgentsPageSkeleton />}>
       <AgentThreadPage />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/components/agents/welcome/agent-settings-sidebar.tsx
+++ b/apps/dashboard-tsr/src/components/agents/welcome/agent-settings-sidebar.tsx
@@ -20,7 +20,7 @@ import {
 
 import type { Skill } from '@/components/agents/welcome/skills-data'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { AgentMcpPanel } from '@/components/agents/welcome/agent-mcp-panel'
 import { AgentModelPicker } from '@/components/agents/welcome/agent-model-picker'
 import { SkillDetailDialog } from '@/components/agents/welcome/skill-detail-dialog'
@@ -67,6 +67,18 @@ export function AgentSettingsSidebar({
   const [skillDetail, setSkillDetail] = useState<Skill | null>(null)
   const [libraryOpen, setLibraryOpen] = useState(false)
   const hostId = useHostId()
+
+  // The parent opens this sidebar via a post-mount effect (`!isMobile`), so the
+  // very first commit on desktop transitions `open` false → true. Animating the
+  // width (`w-0` → `w-[320px]`) on that initial open reflows the chat column on
+  // every frame → ~0.12 CLS. Enable the width transition only AFTER first paint
+  // so the load-time open snaps to full width (space reserved instantly); later
+  // user toggles still animate.
+  const [animateOpen, setAnimateOpen] = useState(false)
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setAnimateOpen(true))
+    return () => cancelAnimationFrame(id)
+  }, [])
 
   const sections = (
     <>
@@ -236,7 +248,8 @@ export function AgentSettingsSidebar({
   return (
     <aside
       className={cn(
-        'bg-card border-border shrink-0 overflow-x-hidden overflow-y-auto border-l transition-all duration-200',
+        'bg-card border-border shrink-0 overflow-x-hidden overflow-y-auto border-l',
+        animateOpen && 'transition-all duration-200',
         open ? 'w-[320px] opacity-100' : 'pointer-events-none w-0 opacity-0'
       )}
       style={{ maxHeight: 'calc(100dvh - 6rem)' }}

--- a/apps/dashboard-tsr/src/components/assistant-ui/agent-thread-page.tsx
+++ b/apps/dashboard-tsr/src/components/assistant-ui/agent-thread-page.tsx
@@ -61,7 +61,12 @@ function AgentThreadPageError() {
 export function AgentThreadPage() {
   const isMobile = useIsMobile()
   const [conversationsOpen, setConversationsOpen] = useState(false)
-  const [rightSidebarOpen, setRightSidebarOpen] = useState(false)
+  // Open by default so the 320px settings sidebar reserves its space on the
+  // first paint (desktop). Starting closed and opening in a post-mount effect
+  // animated the column from 0 → 320px on load, shifting the chat content
+  // (~0.12 CLS). The effect below still closes it on mobile (which renders a
+  // Drawer instead of the inline column, so no reflow there).
+  const [rightSidebarOpen, setRightSidebarOpen] = useState(true)
   useEffect(() => {
     setRightSidebarOpen(!isMobile)
   }, [isMobile])

--- a/apps/dashboard-tsr/src/components/skeletons/index.tsx
+++ b/apps/dashboard-tsr/src/components/skeletons/index.tsx
@@ -40,6 +40,7 @@ export function TableSkeleton({ rows = 8 }: { rows?: number }) {
 // foundation kept ChartSkeleton/TableSkeleton inline with the shimmer variant).
 export { ExplorerSkeleton } from './explorer'
 export {
+  AgentsPageSkeleton,
   ChartsOnlyPageSkeleton,
   PageSkeleton,
   TableOnlyPageSkeleton,

--- a/apps/dashboard-tsr/src/components/skeletons/page.tsx
+++ b/apps/dashboard-tsr/src/components/skeletons/page.tsx
@@ -80,6 +80,58 @@ export const TableOnlyPageSkeleton = function TableOnlyPageSkeleton({
 }
 
 /**
+ * Agents Page Skeleton
+ *
+ * Reserves the exact footprint of the lazy-mounted `AgentThreadPage` so the
+ * chat composer + settings sidebar don't shift content when they mount after
+ * first paint (CLS). Mirrors that component's outer container
+ * (`h-[calc(100dvh-6rem)] rounded-xl border`), a main column with a bottom
+ * composer strip, and the 320px settings sidebar (open by default on desktop).
+ */
+export const AgentsPageSkeleton = function AgentsPageSkeleton({
+  className,
+}: {
+  className?: string
+} = {}) {
+  return (
+    <div
+      className={cn(
+        'bg-background flex h-[calc(100dvh-6rem)] min-h-0 overflow-hidden rounded-xl border',
+        className
+      )}
+      role="status"
+      aria-busy="true"
+      aria-label="Loading agent"
+    >
+      {/* Main column */}
+      <div className="relative flex min-w-0 flex-1 flex-col">
+        {/* Top-left "Conversations" button placeholder */}
+        <Skeleton className="absolute top-3 left-3 h-8 w-32 rounded-md" />
+        {/* Centered welcome area */}
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6">
+          <Skeleton className="h-6 w-64" />
+          <Skeleton className="h-4 w-80" />
+        </div>
+        {/* Bottom composer strip — the late-mounting element that shifts */}
+        <div className="border-t p-4">
+          <Skeleton className="h-12 w-full rounded-xl" />
+        </div>
+      </div>
+
+      {/* Settings sidebar — 320px, open by default on desktop */}
+      <div className="hidden w-[320px] shrink-0 border-l p-4 md:block">
+        <Skeleton className="mb-4 h-5 w-32" />
+        <div className="flex flex-col gap-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={`agent-sidebar-row-${i}`} className="h-9 w-full" />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
  * Chart Skeleton
  */
 const ChartSkeleton = function ChartSkeleton() {

--- a/apps/dashboard-tsr/src/lib/next-compat.ts
+++ b/apps/dashboard-tsr/src/lib/next-compat.ts
@@ -16,6 +16,28 @@ export function useSearchParams(): URLSearchParams {
 }
 
 /**
+ * Split a Next-style `href` (path with an optional `?query` string) into the
+ * `{ to, search }` shape TanStack Router's `navigate` expects.
+ *
+ * `router.navigate({ to: '/explorer?database=default' })` treats the WHOLE
+ * string as the path, so the `?query` gets percent-encoded into the pathname
+ * (e.g. `/explorer%3Fdatabase=default`). Parsing the query out and passing it
+ * as `search` makes ported `router.push('/path?a=b')` calls navigate correctly.
+ */
+function splitHref(href: string): {
+  to: string
+  search?: Record<string, string>
+} {
+  const queryIndex = href.indexOf('?')
+  if (queryIndex === -1) return { to: href }
+  const to = href.slice(0, queryIndex)
+  const search = Object.fromEntries(
+    new URLSearchParams(href.slice(queryIndex + 1))
+  )
+  return { to, search }
+}
+
+/**
  * Next.js-compatible router wrapping TanStack Router.
  * Accepts Next.js navigation options (scroll, shallow, etc.) and ignores them.
  */
@@ -23,9 +45,9 @@ export function useRouter() {
   const router = useTanStackRouter()
   return {
     push: (href: string, _opts?: Record<string, unknown>) =>
-      router.navigate({ to: href }),
+      router.navigate(splitHref(href)),
     replace: (href: string, _opts?: Record<string, unknown>) =>
-      router.navigate({ to: href, replace: true }),
+      router.navigate({ ...splitHref(href), replace: true }),
     back: () => router.history.back(),
     forward: () => router.history.forward(),
     refresh: () => router.invalidate(),

--- a/apps/dashboard-tsr/src/router.tsx
+++ b/apps/dashboard-tsr/src/router.tsx
@@ -11,6 +11,11 @@ export function getRouter() {
   return createTanstackRouter({
     routeTree,
     scrollRestoration: true,
+    // No trailing-slash redirect (the old Next app served `/overview` directly).
+    // Default behaviour 301/308-redirects `/overview` → `/overview/`, adding
+    // ~55-60 ms TTFB to every page load; `'never'` strips it so routes resolve
+    // without the round-trip.
+    trailingSlash: 'never',
   })
 }
 

--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -95,6 +95,11 @@ ${namedExports}
     name: 'chm:ssr-client-only-stub',
     enforce: 'pre',
     resolveId(id) {
+      // The stub exists ONLY to keep the Cloudflare Worker under the free-plan
+      // 3 MiB limit (#1393). The Node/Docker target has no size limit and its
+      // prerender needs the REAL libs — e.g. computeDagrePositions (PeerGraph)
+      // calls dagre during SSR — so never stub when BUILD_TARGET=node.
+      if (isNode) return null
       // `this.environment` is the per-environment build context (Vite 6+/8).
       // Only stub in the worker/SSR environment, never the browser client build.
       if (this.environment?.name === 'client') return null

--- a/docs/knowledge/tsr-migration.md
+++ b/docs/knowledge/tsr-migration.md
@@ -1,0 +1,161 @@
+---
+id: tsr-migration
+type: architecture
+related: [static-site-architecture, deployment, mcp-server, rust-wasm-performance]
+tags: [tanstack-start, migration, cloudflare-workers, vite, dual-target, agent]
+---
+
+# Next.js → TanStack Start migration
+
+The dashboard was migrated from **Next.js 15 (App Router + OpenNext on Cloudflare)** to
+**TanStack Start** (`@tanstack/react-start` + `@cloudflare/vite-plugin`). The new app
+lives in `apps/dashboard-tsr` and ships beside the original `apps/dashboard` as a
+**parallel app, dark-launched** at `dash-tsr.chmonitor.dev` (the live `dash.chmonitor.dev`
+stays on Next until an explicit route re-point). Epic: #1392.
+
+## Why / trade-offs
+
+The app is a **fully static SPA** (see [[static-site-architecture]]) — it deliberately
+avoids SSR/server-components, which is exactly what TanStack Start exists to provide. So
+the product value of the migration is ~zero; the justification is **engineering metrics**
+(build time/memory, bundle size, dependency count) and removing the OpenNext layer. The
+CF target is simpler: `@cloudflare/vite-plugin` → workerd directly, **no OpenNext, no
+KV/R2/D1 incremental-cache layer**.
+
+## Topology
+
+```
+apps/dashboard-tsr/
+  vite.config.ts        # tanstackStart() + @cloudflare/vite-plugin (CF) | nitro() (Node)
+  wrangler.toml         # name = chmonitor-dash-tsr, routes → dash-tsr.chmonitor.dev
+  scripts/patch-wrangler-env.ts   # re-injects [[routes]]/[vars] the vite plugin strips
+  src/
+    routes/             # TanStack Router file routes (was app/)
+      (dashboard)/ (docs)/ (peerdb)/   # route groups
+      api/              # server routes (was app/api/*/route.ts)
+    start.ts            # global request middleware (was middleware.ts)
+    router.tsx, routeTree.gen.ts (generated, gitignored)
+```
+
+## Routing translation (Next → TSR)
+
+| Next | TanStack Start |
+|---|---|
+| `app/foo/page.tsx` | `src/routes/(group)/foo.tsx` via `createFileRoute` |
+| `app/api/x/route.ts` (`GET`/`POST`) | `createFileRoute('/api/x')({ server: { handlers: { GET } } })` |
+| `[name]` / `[...slug]` dynamic | `$name` / `$` splat (`params.name`, `params._splat`) |
+| `next/navigation` (useRouter/useSearchParams) | `@tanstack/react-router` (useNavigate / `Route.useSearch`) |
+| `next/link`, `next/image`, `next/dynamic` | router `Link`, `<img>`, `React.lazy` |
+| `middleware.ts` | `createStart({ requestMiddleware: [...] })` in `src/start.ts` |
+| `export const dynamic = 'force-dynamic'` | (dropped) |
+
+Typed `?host=` search params are declared on the **root route** (`__root.tsx`), so
+`host` is a required search param every `Link` must carry (e.g.
+`search={(prev) => ({ host: prev.host ?? 0 })}`).
+
+## The ClickHouse env seam
+
+Routes do `import { env } from 'cloudflare:workers'` then call
+`bridgeClickHouseEnv(env)` (`@/lib/api/server-env`) before any `fetchData` — this copies
+the Worker bindings into where `@chm/clickhouse-client`'s `getClient` looks, so the
+downstream query code is unchanged across both build targets. On the Node target,
+`cloudflare:workers` is aliased to a `process.env` shim (`src/lib/cloudflare-workers-shim.ts`).
+
+## Dual build target (#1409) — Cloudflare AND Docker/Node
+
+One source, two outputs, selected by `BUILD_TARGET`:
+- **default / `cloudflare`**: `@cloudflare/vite-plugin` → workerd bundle, deployed via
+  `wrangler deploy`.
+- **`BUILD_TARGET=node`**: drop the CF plugin, add `nitro({ preset: 'node-server' })` →
+  `.output/server/index.mjs` for the Docker image; `cloudflare:workers` aliased to the
+  process.env shim.
+
+## Hard problems solved during the migration
+
+1. **`nitro` lockfile drift** — the dual-target work declared `nitro` in package.json +
+   imported `nitro/vite`, but the lockfile was never updated, so local builds failed at
+   config-load. Uncaught because dashboard-tsr was in **no CI job** at the time.
+
+2. **OpenNext coupling for D1** — the conversation store binds D1 via `@chm/platform`'s
+   `getCloudflareContext()` (an `@opennextjs/cloudflare` API that does **not** exist in a
+   TanStack Start worker). Fix: a **native `cloudflare:workers` platform adapter**
+   (`src/lib/platform-native.ts`, aliased as `@chm/platform`) reads bindings straight from
+   the Worker `env`; D1 degrades to `null` (memory/client store) when unbound.
+   `auto-migrate` is a **no-op** (D1 schema applied via `wrangler d1 migrations`).
+
+3. **`server-only` sentinels** — Next's `import 'server-only'` resolves to a virtual
+   module under TanStack that **throws** when pulled into the client/prerender graph.
+   Removed from the ported server modules (the boundary is enforced by route placement).
+
+4. **Worker size limit (free-tier 3 MiB)** — the agent subsystem pushed the worker to
+   3.6 MiB gzip → deploy failed (`code 10027`). Root cause: the worker deploys
+   `no_bundle: true`, so `wrangler` counts **every** `dist/server/assets` chunk — including
+   `React.lazy` chunks — against the limit, so existing lazy boundaries didn't help. Fix:
+   a Vite plugin (`chm:ssr-client-only-stub`) resolves browser-only render libs (mermaid,
+   cytoscape, katex, dagre, codemirror) to an empty stub **in the worker/SSR environment
+   only** (`this.environment.name !== 'client'`). They run exclusively in browser
+   lazy-chunks, so the worker never needs them. **Worker: 3.6 → 2.36 MiB gzip (−37%).**
+   Next headroom candidate: `@xyflow/react` (~349K). The clean long-term fix is **Workers
+   Paid ($5/mo → 10 MiB)**.
+
+## Auth model (important)
+
+There are **two independent auth layers**:
+- **Feature-permissions** (per-route `authorizeFeatureRequest`): `public`/`guest`/
+  `authenticated` access per feature (Clerk). The agent routes self-enforce this in-handler.
+- **API-key gate** (`src/start.ts` request middleware, ported from `middleware.ts`): when
+  `CHM_API_KEY_SECRET` is set (`apiKeyAuthEnabled()`), **every `/api/v1/*` requires a
+  `chm_` Bearer token → 401** (except `/api/v1/auth/api-key`). Config-driven: dormant when
+  the secret is unset.
+
+**Verified behavior:** `dash.chmonitor.dev` (Next prod) has the secret set, so a real
+browser gets **401 on every `/api/v1/*`** — the dashboard is a key-gated deployment and
+does not serve data anonymously. The TSR app must match this; the `src/start.ts`
+middleware (#1397, PR #1428) restores that parity.
+
+## Parity & verification
+
+- **Pages: 82/82** return matching status on both deployments (`/tmp/compare-prod.sh`).
+- **APIs**: both key-gated (401 to anonymous) once #1428 deploys.
+- Build gate: `bun run build` (`vite build && tsc --noEmit`) must be green; 112 pages
+  prerender. dashboard-tsr is now wired into CI (the `dashboard-tsr` job).
+
+## Performance (framework shell, Next+OpenNext vs TanStack Start)
+
+> Both deployments are key-gated, so this measures the **app shell + client JS** load
+> (the migration's Win-Metric), not data. Captured via Chrome DevTools traces on
+> `dash.chmonitor.dev` (Next) vs `dash-tsr.chmonitor.dev` (TSR). Single-sample, desktop,
+> unthrottled — treat sub-second deltas as ±10-20%.
+
+| Route | LCP Next | LCP TSR | Δ | Note |
+|---|---|---|---|---|
+| /dashboard | 1074 ms | **253 ms** | **−76%** | render-delay 1011→133 ms |
+| /running-queries | 1146 ms | **478 ms** | **−58%** | |
+| /explorer | 1094 ms | **622 ms** | **−43%** | |
+| /agents | 837 ms | 818 ms | −2% | tie; but CLS 0→0.28 ⚠️ |
+| /overview | 895 ms | 1280 ms | +43% ⚠️ | heaviest hydration; Next's static shell wins |
+| /tables | 572 ms | — | 🐛 | broken redirect (see below) |
+
+**Net:** TSR's lighter client bootstrap makes it **faster to LCP on the heavy
+data-dashboard pages** (render-delay collapses), but it's not universal.
+
+### Performance issues found (to fix)
+1. **Trailing-slash redirect** — every TSR route 301/308s `/x` → `/x/`, adding a uniform
+   **~55-60 ms TTFB** tax (confirmed by the DocumentLatency insight on all routes). Disable
+   the trailing-slash redirect in the router/start config.
+2. **`/tables` broken** — client-redirects to a malformed URL
+   `/explorer?database=default%3Fhost%3D0?host=0` — the `?host=0` search string is encoded
+   *into* the `database` param (double `?`). The redirect/search serializer concatenates
+   instead of merging search params. Functional bug.
+3. **`/agents` CLS 0.28** (Next: 0.00) — the chat composer/sidebar mounts after first paint
+   without reserving height. Reserve layout space.
+
+## Known follow-ups
+
+- Conversation **server-persistence** needs a provisioned `CONVERSATIONS_D1`
+  (`wrangler d1 create`) + binding in `wrangler.toml` + `patch-wrangler-env.ts`. Agent chat
+  works via the client thread store until then.
+- Copied agent-subsystem **test files** are excluded from the production typecheck
+  (mirrors the Next app's tsconfig); wiring `bun test` for them is a follow-up.
+- Make the **Cloudflare deploy a required CI check** — a size-failing deploy reached main
+  during the migration because it isn't.


### PR DESCRIPTION
Four fixes in `apps/dashboard-tsr` found by a perf comparison + dual-target build check. Part of the TanStack Start migration (#1392).

## Fixes

### 1. Dual-target regression (HIGH) — SSR stub broke the Node/Docker build
`vite.config.ts`'s `chm:ssr-client-only-stub` (added for the Cloudflare Worker 3 MiB limit) stubbed mermaid/cytoscape/katex/**dagre**/codemirror for any non-`client` environment — which also caught the Node target. The Node prerender then crashed in `computeDagrePositions` (PeerGraph) because dagre was stubbed. The Node target has no size limit and needs the real libs, so `resolveId` now returns `null` (no stub) when `BUILD_TARGET=node`.

**Verified:** `BUILD_TARGET=node bun run build:node` completes including prerender (112 pages, all `/peerdb/*` dagre routes rendered, no crash), producing a runnable `.output/server/index.mjs` (`node .output/server/index.mjs` → `Listening on …`, serves pages).

### 2. Trailing-slash redirect tax (perf, every route)
Every route 301/308-redirected `/overview` → `/overview/`, adding ~55-60 ms TTFB. The old Next app had no such redirect. Set `trailingSlash: 'never'` in `createRouter`.

**Verified:** `/overview` → 307 → `/overview?host=0` (host-param redirect only, no trailing slash); `/overview/` → `/overview?host=0` (slash stripped, no `/overview/`); `/dashboard?host=0` → 200 direct, no redirect.

### 3. `/tables` redirected to a malformed URL (HIGH, functional bug)
`/tables` → `/explorer?database=default%3Fhost%3D0?host=0` — the `?host=0` was URL-encoded into the `database` param. Root cause: the `next-compat` router shim passed `'/path?query'` strings straight to `router.navigate({ to })`, which percent-encodes the query into the path. Fixed in the shim (`splitHref`) so it parses the query and passes it as `search` — fixes `/tables` **and every other ported redirect** (cluster, zookeeper, table, filters).

**Verified:** `/tables?host=0` now lands on `/explorer?database=default&host=0` (clean separate params, no `%3F`/`%3D`), matching the Next app's intended target.

### 4. `/agents` layout shift 0.28 (CLS, MEDIUM)
The settings sidebar opened in a post-mount effect, animating the chat column `0 → 320px` on load (the dominant ~0.12 shift), plus reflow as content populated. Fixed by opening the sidebar by default (space reserved on first paint), skipping the width transition until after first paint, and reserving the layout in the Suspense fallback skeleton (`AgentsPageSkeleton`).

**Verified (Chrome DevTools, layout-shift PerformanceObserver):** CLS **0.2666 → 0.0002** (matches the Next app's 0.00), stable across repeated navigations.

## Build results
- `bun run build` (Cloudflare: vite + tsc): green, 0 type errors, 112 pages prerendered
- `BUILD_TARGET=node bun run build:node` (Node): green, prerender complete, valid `.output/server/index.mjs`
- Worker size: **2371 KiB gzip** (< 3 MiB / 3072 KiB limit) — SSR stub still active for CF

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Fix dashboard-tsr routing, layout stability, and dual-target build behavior while adding documentation for the TanStack Start migration.

Bug Fixes:
- Correct Next-style href handling in the TanStack router shim so query strings are passed as structured search params, fixing malformed redirects such as /tables.
- Prevent SSR client-only stubbing from affecting the Node/Docker build target so server-side prerendering can use the real visualization libraries.

Enhancements:
- Eliminate trailing-slash redirects in the TanStack router configuration to avoid unnecessary round-trips on all routes.
- Reduce CLS on the agents page by reserving sidebar and composer layout space via a dedicated skeleton and by deferring sidebar open animations until after first paint.

Documentation:
- Add architectural documentation describing the Next.js to TanStack Start migration, dual Cloudflare/Node targets, constraints, and verification status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved loading skeleton for the agents page with layout preservation

* **Improvements**
  * Agent thread sidebar now displays by default on desktop
  * Reduced layout shift during page load with optimized animation timing
  * Enhanced URL routing with trailing slash configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->