### PR TITLE
test(dashboard-tsr): fix stale clerk test + add test script (#1392)

### DIFF
--- a/apps/dashboard-tsr/package.json
+++ b/apps/dashboard-tsr/package.json
@@ -17,7 +17,8 @@
     "cf:deploy": "bun run build && wrangler deploy",
     "cf:dry-run": "vite build && wrangler deploy --dry-run",
     "cf-typegen": "wrangler types",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "bun test src/"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.65",

--- a/apps/dashboard-tsr/src/lib/auth/__tests__/clerk-client.test.ts
+++ b/apps/dashboard-tsr/src/lib/auth/__tests__/clerk-client.test.ts
@@ -1,28 +1,47 @@
-import { describe, expect, test } from 'bun:test'
-import { isClerkEnabled } from '@/lib/clerk/clerk-client'
+import { afterEach, describe, expect, test } from 'bun:test'
+
+/**
+ * isClerkEnabled() resolves its inputs from `import.meta.env.VITE_*` (Vite inlines
+ * them at build time — the NEXT_PUBLIC_* equivalent). `CLERK_PUBLISHABLE_KEY` is a
+ * module-level const captured at import, so each case sets the env vars (bun mirrors
+ * process.env into import.meta.env) BEFORE a fresh dynamic import of the module.
+ */
+const MODULE = '@/lib/clerk/clerk-client'
+
+async function freshIsClerkEnabled(): Promise<boolean> {
+  // Cache-bust so the module re-evaluates with the current env.
+  const mod = await import(
+    `${MODULE}?t=${Date.now()}-${Math.round(performance.now())}`
+  )
+  return mod.isClerkEnabled()
+}
 
 describe('isClerkEnabled', () => {
-  test('returns true with clerk provider and pk_ key', () => {
-    const originalAuthProvider = process.env.NEXT_PUBLIC_AUTH_PROVIDER
-    const originalClerkKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+  const origProvider = process.env.VITE_AUTH_PROVIDER
+  const origKey = process.env.VITE_CLERK_PUBLISHABLE_KEY
 
-    try {
-      process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'clerk'
-      process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_test_123'
+  afterEach(() => {
+    if (origProvider === undefined) delete process.env.VITE_AUTH_PROVIDER
+    else process.env.VITE_AUTH_PROVIDER = origProvider
+    if (origKey === undefined) delete process.env.VITE_CLERK_PUBLISHABLE_KEY
+    else process.env.VITE_CLERK_PUBLISHABLE_KEY = origKey
+  })
 
-      expect(isClerkEnabled()).toBe(true)
-    } finally {
-      if (originalAuthProvider === undefined) {
-        delete process.env.NEXT_PUBLIC_AUTH_PROVIDER
-      } else {
-        process.env.NEXT_PUBLIC_AUTH_PROVIDER = originalAuthProvider
-      }
+  test('returns true with clerk provider and pk_ key', async () => {
+    process.env.VITE_AUTH_PROVIDER = 'clerk'
+    process.env.VITE_CLERK_PUBLISHABLE_KEY = 'pk_test_123'
+    expect(await freshIsClerkEnabled()).toBe(true)
+  })
 
-      if (originalClerkKey === undefined) {
-        delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
-      } else {
-        process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = originalClerkKey
-      }
-    }
+  test('returns false without a pk_ key', async () => {
+    process.env.VITE_AUTH_PROVIDER = 'clerk'
+    delete process.env.VITE_CLERK_PUBLISHABLE_KEY
+    expect(await freshIsClerkEnabled()).toBe(false)
+  })
+
+  test('returns false when provider is not clerk', async () => {
+    process.env.VITE_AUTH_PROVIDER = 'none'
+    process.env.VITE_CLERK_PUBLISHABLE_KEY = 'pk_test_123'
+    expect(await freshIsClerkEnabled()).toBe(false)
   })
 })


### PR DESCRIPTION
Fixes the one failing copied test (stale NEXT_PUBLIC_* → VITE_* env convention) and adds a runnable `test` script. **Full dashboard-tsr suite: 361 pass, 0 fail** (38 files). Part of #1392.

## Summary by Sourcery

Update dashboard-tsr Clerk auth tests to use Vite env conventions and add a runnable test script.

Build:
- Add a bun-based `test` script for the dashboard-tsr app to run tests under src/.

Tests:
- Adjust Clerk isClerkEnabled tests to use VITE_* env vars and force fresh module imports per case to reflect environment changes.
- Restore original Vite auth-related environment variables after each test via an afterEach hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a test script to the dashboard application's package configuration, enabling automated tests to be run with a simple command.

* **Tests**
  * Refactored clerk authentication configuration tests to use dynamic module re-importing with cache-busting and improved environment variable management, ensuring better test isolation and reliability when validating different authentication configuration states and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->