### PR TITLE
fix(dashboard-tsr): drop trailing-slash redirect (~55ms/page) (#1392)

### DIFF
--- a/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
+++ b/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
@@ -80,6 +80,17 @@ generated.name = config.name
 generated.routes = config.routes
 generated.vars = config.vars
 
+// Serve prerendered routes WITHOUT a trailing-slash redirect. The prerender emits
+// dir-style output (dist/client/overview/index.html); CF Workers Assets' default
+// `auto-trailing-slash` 308-redirects /overview -> /overview/, adding ~55 ms TTFB on
+// every page. `drop-trailing-slash` serves /overview/index.html at /overview directly
+// (matching the router's trailingSlash:'never'); /overview/ -> /overview. The
+// @cloudflare/vite-plugin only sets `assets.directory`, so html_handling is added here.
+generated.assets = {
+  ...(generated.assets ?? {}),
+  html_handling: 'drop-trailing-slash',
+}
+
 // Remove any env sections — Wrangler rejects them in redirected configs
 delete generated.env
 


### PR DESCRIPTION
Eliminates the trailing-slash 308 redirect (`/overview` → `/overview/`) that added ~55 ms TTFB on every page — the main TSR perf regression the Lighthouse comparison found. Sets CF Workers Assets `html_handling: drop-trailing-slash` in the deploy config. Part of #1392.

## Summary by Sourcery

Enhancements:
- Set Cloudflare Workers assets html_handling to drop trailing slashes so prerendered routes are served directly without redirect-induced latency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated wrangler configuration patching to set asset handling properties in the build output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->