### PR TITLE
fix(dashboard-tsr): migrate client env NEXT_PUBLIC_* → VITE_* (#1392)

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -308,6 +308,19 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build for Cloudflare
+        # Client-exposed config is build-time inlined via import.meta.env.VITE_*
+        # (vite.config.ts CLIENT_ENV). Preview (PR) builds use the Clerk pk_test
+        # key; production (push/release) builds use pk_live. Non-secret public
+        # keys mirror wrangler.toml / patch-wrangler-env.ts defaults.
+        env:
+          VITE_AUTH_PROVIDER: clerk
+          VITE_CLERK_PUBLISHABLE_KEY: >-
+            ${{ github.event_name == 'pull_request'
+              && 'pk_test_bWFnbmV0aWMtcmF5LTkwLmNsZXJrLmFjY291bnRzLmRldiQ'
+              || 'pk_live_Y2xlcmsuY2htb25pdG9yLmRldiQ' }}
+          VITE_GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          VITE_GIT_REF: ${{ github.head_ref || github.ref_name }}
+          VITE_CI: 'true'
         run: bun run build
 
       - name: Patch wrangler config with env sections

--- a/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
+++ b/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
@@ -46,9 +46,11 @@ const SHARED_VARS = {
   OPENROUTER_REFERER: 'https://clickhouse.duyet.net',
   OPENROUTER_APP_NAME: 'chmonitor',
   CHM_AUTH_PROVIDER: 'clerk',
-  NEXT_PUBLIC_AUTH_PROVIDER: 'clerk',
   CHM_FEATURE_AGENT_ACCESS: 'authenticated',
 }
+// NOTE: client auth config (auth provider + Clerk publishable key) is NOT a
+// runtime worker var — it is build-time inlined via import.meta.env.VITE_* (see
+// vite.config.ts CLIENT_ENV). Only the SERVER-side CHM_AUTH_PROVIDER lives here.
 
 // --- Production config (keep in sync with wrangler.toml top-level) ---
 const PROD_CONFIG = {
@@ -57,7 +59,6 @@ const PROD_CONFIG = {
   vars: {
     ...SHARED_VARS,
     LLM_MODEL: 'anyrouter:@preset/chmonitor',
-    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: 'pk_live_Y2xlcmsuY2htb25pdG9yLmRldiQ',
   },
 }
 
@@ -68,8 +69,6 @@ const PREVIEW_CONFIG = {
   vars: {
     ...SHARED_VARS,
     LLM_MODEL: 'anyrouter:z-ai/glm-4.7-flash',
-    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:
-      'pk_test_bWFnbmV0aWMtcmF5LTkwLmNsZXJrLmFjY291bnRzLmRldiQ',
   },
 }
 

--- a/apps/dashboard-tsr/src/components/running-queries/running-queries-view.tsx
+++ b/apps/dashboard-tsr/src/components/running-queries/running-queries-view.tsx
@@ -35,10 +35,10 @@ import { cn } from '@/lib/utils'
  *
  * Defaults to 5s so the table reads as genuinely "live"; `system.processes`
  * is an in-memory table, so frequent polling is cheap.
- * Override with `NEXT_PUBLIC_RUNNING_QUERIES_REFRESH_MS`.
+ * Override with `VITE_RUNNING_QUERIES_REFRESH_MS`.
  */
 const REFRESH_INTERVAL = (() => {
-  const envValue = process.env.NEXT_PUBLIC_RUNNING_QUERIES_REFRESH_MS
+  const envValue = import.meta.env.VITE_RUNNING_QUERIES_REFRESH_MS
   const parsed = envValue ? Number.parseInt(envValue, 10) : NaN
   return !Number.isNaN(parsed) && parsed > 0 ? parsed : 5_000
 })()

--- a/apps/dashboard-tsr/src/lib/auth/provider.test.ts
+++ b/apps/dashboard-tsr/src/lib/auth/provider.test.ts
@@ -6,19 +6,12 @@ import {
 import { afterEach, describe, expect, test } from 'bun:test'
 
 const originalChmAuthProvider = process.env.CHM_AUTH_PROVIDER
-const originalNextPublicAuthProvider = process.env.NEXT_PUBLIC_AUTH_PROVIDER
 
 afterEach(() => {
   if (originalChmAuthProvider === undefined) {
     delete process.env.CHM_AUTH_PROVIDER
   } else {
     process.env.CHM_AUTH_PROVIDER = originalChmAuthProvider
-  }
-
-  if (originalNextPublicAuthProvider === undefined) {
-    delete process.env.NEXT_PUBLIC_AUTH_PROVIDER
-  } else {
-    process.env.NEXT_PUBLIC_AUTH_PROVIDER = originalNextPublicAuthProvider
   }
 })
 
@@ -40,10 +33,13 @@ describe('parseAuthProvider', () => {
     expect(() => parseAuthProvider('basic')).toThrow(AuthProviderConfigError)
   })
 
-  test('prefers CHM_AUTH_PROVIDER over legacy public auth provider env', () => {
+  test('reads the runtime CHM_AUTH_PROVIDER worker var', () => {
+    // Server reads CHM_AUTH_PROVIDER first, then the build-time
+    // import.meta.env.VITE_AUTH_PROVIDER fallback (undefined under bun test).
     process.env.CHM_AUTH_PROVIDER = 'none'
-    process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'clerk'
-
     expect(getAuthProvider()).toBe('none')
+
+    process.env.CHM_AUTH_PROVIDER = 'clerk'
+    expect(getAuthProvider()).toBe('clerk')
   })
 })

--- a/apps/dashboard-tsr/src/lib/auth/provider.ts
+++ b/apps/dashboard-tsr/src/lib/auth/provider.ts
@@ -1,6 +1,9 @@
+// Server reads the runtime worker var CHM_AUTH_PROVIDER first, then falls back
+// to the build-time client constant VITE_AUTH_PROVIDER (import.meta.env). The
+// legacy Next `NEXT_PUBLIC_AUTH_PROVIDER` prefix is gone in the Vite app.
 export const AUTH_PROVIDER_ENV_VARS = [
   'CHM_AUTH_PROVIDER',
-  'NEXT_PUBLIC_AUTH_PROVIDER',
+  'VITE_AUTH_PROVIDER',
 ] as const
 
 export const AUTH_PROVIDERS = ['none', 'clerk'] as const
@@ -36,7 +39,7 @@ export function parseAuthProvider(
 
 export function getAuthProvider(): AuthProvider {
   return parseAuthProvider(
-    process.env.CHM_AUTH_PROVIDER ?? process.env.NEXT_PUBLIC_AUTH_PROVIDER
+    process.env.CHM_AUTH_PROVIDER ?? import.meta.env.VITE_AUTH_PROVIDER
   )
 }
 

--- a/apps/dashboard-tsr/src/lib/feature-flags.ts
+++ b/apps/dashboard-tsr/src/lib/feature-flags.ts
@@ -19,8 +19,8 @@ export const featureFlags = {
    * Enable persistent database storage for AI agent conversations.
    *
    * When enabled, conversations are stored in D1 (Cloudflare Workers) or PostgreSQL
-   * instead of localStorage. Requires NEXT_PUBLIC_AUTH_PROVIDER=clerk for user
-   * isolation.
+   * instead of localStorage. Requires the clerk auth provider
+   * (VITE_AUTH_PROVIDER=clerk) for user isolation.
    *
    * @default false (unset)
    * @env VITE_FEATURE_CONVERSATION_DB (was NEXT_PUBLIC_FEATURE_CONVERSATION_DB)

--- a/apps/dashboard-tsr/src/lib/feature-permissions/server.ts
+++ b/apps/dashboard-tsr/src/lib/feature-permissions/server.ts
@@ -127,7 +127,7 @@ interface AppConfig {
 
 function getAppConfig(): AppConfig {
   const authProvider = parseAuthProvider(
-    readEnv('CHM_AUTH_PROVIDER') ?? readEnv('NEXT_PUBLIC_AUTH_PROVIDER')
+    readEnv('CHM_AUTH_PROVIDER') ?? import.meta.env.VITE_AUTH_PROVIDER
   )
   return { authProvider, features: parseEnvFeatureOverrides() }
 }

--- a/apps/dashboard-tsr/src/lib/hooks/use-autocomplete-data.ts
+++ b/apps/dashboard-tsr/src/lib/hooks/use-autocomplete-data.ts
@@ -15,7 +15,7 @@ import { useHostId } from '@/lib/swr/use-host'
 const AUTOCOMPLETE_LIMIT = (() => {
   const envLimit =
     typeof process !== 'undefined'
-      ? process.env.NEXT_PUBLIC_AUTOCOMPLETE_LIMIT
+      ? import.meta.env.VITE_AUTOCOMPLETE_LIMIT
       : undefined
   const parsed = envLimit ? parseInt(envLimit, 10) : 500
   // Clamp between 1 and 1000, fallback to 500 if invalid

--- a/apps/dashboard-tsr/src/routes/(dashboard)/about.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/about.tsx
@@ -160,7 +160,7 @@ function AboutPage() {
       <Separator />
 
       {/* Build Information - Only show in production builds */}
-      {process.env.NEXT_PUBLIC_CI && (
+      {import.meta.env.VITE_CI && (
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">Build Information</h2>
           <Card>
@@ -173,11 +173,11 @@ function AboutPage() {
                   </p>
                   <div className="flex items-center gap-2">
                     <code className="bg-muted rounded px-2 py-1 text-sm font-mono">
-                      {process.env.NEXT_PUBLIC_GIT_SHA?.slice(0, 7)}
+                      {import.meta.env.VITE_GIT_SHA?.slice(0, 7)}
                     </code>
-                    {process.env.NEXT_PUBLIC_GIT_SHA && (
+                    {import.meta.env.VITE_GIT_SHA && (
                       <a
-                        href={`${GITHUB_REPO.replace('git+', '').replace('.git', '')}/commit/${process.env.NEXT_PUBLIC_GIT_SHA}`}
+                        href={`${GITHUB_REPO.replace('git+', '').replace('.git', '')}/commit/${import.meta.env.VITE_GIT_SHA}`}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-muted-foreground hover:text-foreground text-sm"
@@ -196,7 +196,7 @@ function AboutPage() {
                   </p>
                   <div className="flex items-center gap-2">
                     <Badge variant="secondary" className="font-mono text-xs">
-                      {process.env.NEXT_PUBLIC_GIT_REF}
+                      {import.meta.env.VITE_GIT_REF}
                     </Badge>
                   </div>
                 </div>
@@ -207,9 +207,9 @@ function AboutPage() {
                     Build Time
                   </p>
                   <p className="text-sm">
-                    {process.env.NEXT_PUBLIC_BUILD_TIMESTAMP
+                    {import.meta.env.VITE_BUILD_TIMESTAMP
                       ? new Date(
-                          process.env.NEXT_PUBLIC_BUILD_TIMESTAMP
+                          import.meta.env.VITE_BUILD_TIMESTAMP
                         ).toLocaleString('en-US', {
                           dateStyle: 'long',
                           timeStyle: 'medium',

--- a/apps/dashboard-tsr/src/routes/api/health.ts
+++ b/apps/dashboard-tsr/src/routes/api/health.ts
@@ -6,21 +6,21 @@ function getDeploymentInfo(bindings: Record<string, string | undefined>) {
   // Determine runtime: in workerd the CLOUDFLARE_WORKERS binding is set to '1'
   const runtime = bindings.CLOUDFLARE_WORKERS === '1' ? 'cloudflare' : 'node'
 
+  // Build-time metadata + client config are inlined via import.meta.env.VITE_*
+  // (the Next NEXT_PUBLIC_* equivalent). Runtime auth comes from the worker
+  // binding CHM_AUTH_PROVIDER, with the build-time VITE_AUTH_PROVIDER fallback.
   return {
-    gitSha: bindings.NEXT_PUBLIC_GIT_SHA ?? null,
-    gitRef: bindings.NEXT_PUBLIC_GIT_REF ?? null,
-    buildTimestamp: bindings.NEXT_PUBLIC_BUILD_TIMESTAMP ?? null,
-    ci: bindings.NEXT_PUBLIC_CI === 'true',
+    gitSha: import.meta.env.VITE_GIT_SHA || null,
+    gitRef: import.meta.env.VITE_GIT_REF || null,
+    buildTimestamp: import.meta.env.VITE_BUILD_TIMESTAMP || null,
+    ci: import.meta.env.VITE_CI === 'true',
     runtime,
-    // Auth provider as set at build time (NEXT_PUBLIC_AUTH_PROVIDER) and
-    // at runtime (CHM_AUTH_PROVIDER). The source route used @/lib/auth/provider
-    // which is not yet in dashboard-tsr, so we read the env vars directly.
     authProvider:
-      bindings.CHM_AUTH_PROVIDER ?? bindings.NEXT_PUBLIC_AUTH_PROVIDER ?? null,
-    clientAuthProvider: bindings.NEXT_PUBLIC_AUTH_PROVIDER ?? null,
+      bindings.CHM_AUTH_PROVIDER ?? import.meta.env.VITE_AUTH_PROVIDER ?? null,
+    clientAuthProvider: import.meta.env.VITE_AUTH_PROVIDER || null,
     agentAccess: bindings.CHM_FEATURE_AGENT_ACCESS ?? 'public',
     clerkPublishableKeyPrefix:
-      bindings.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?.slice(0, 8) ?? null,
+      import.meta.env.VITE_CLERK_PUBLISHABLE_KEY?.slice(0, 8) || null,
   }
 }
 

--- a/apps/dashboard-tsr/src/routes/api/v1/config.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/config.ts
@@ -17,9 +17,8 @@
  *   available in workerd and must not be imported (FAIL-LOUD rule). Per-request
  *   auth is centralized in middleware. The client treats principal as a hint;
  *   the server still enforces auth on protected routes.
- * - authProvider is read from the Worker env binding (canonical source on
- *   Workers) falling back to process.env, via the same CHM_AUTH_PROVIDER /
- *   NEXT_PUBLIC_AUTH_PROVIDER precedence the dashboard uses.
+ * - authProvider is read from the runtime CHM_AUTH_PROVIDER worker var, falling
+ *   back to the build-time import.meta.env.VITE_AUTH_PROVIDER constant.
  *
  * The shared feature-resolution helpers (lib/feature-permissions/shared.ts) and
  * env-override parsing (server.ts) are not ported into this app, so the minimal
@@ -195,7 +194,7 @@ function parseEnvFeatureOverrides(): FeatureOverrides {
 
 function getPublicFeaturePermissionConfig(): PublicFeaturePermissionConfig {
   const authProvider = parseAuthProvider(
-    readEnv('CHM_AUTH_PROVIDER') ?? readEnv('NEXT_PUBLIC_AUTH_PROVIDER')
+    readEnv('CHM_AUTH_PROVIDER') ?? import.meta.env.VITE_AUTH_PROVIDER
   )
 
   const features = parseEnvFeatureOverrides()

--- a/apps/dashboard-tsr/src/vite-env.d.ts
+++ b/apps/dashboard-tsr/src/vite-env.d.ts
@@ -7,6 +7,13 @@ interface ImportMetaEnv {
   readonly VITE_AUTH_PROVIDER?: string
   readonly VITE_CLERK_PUBLISHABLE_KEY?: string
   readonly VITE_FEATURE_CONVERSATION_DB?: string
+  readonly VITE_AUTOCOMPLETE_LIMIT?: string
+  readonly VITE_RUNNING_QUERIES_REFRESH_MS?: string
+  // Build metadata (injected by vite.config define / CI build step)
+  readonly VITE_GIT_SHA?: string
+  readonly VITE_GIT_REF?: string
+  readonly VITE_BUILD_TIMESTAMP?: string
+  readonly VITE_CI?: string
 }
 
 interface ImportMeta {

--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { cloudflare } from '@cloudflare/vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
@@ -7,6 +8,52 @@ import { nitro } from 'nitro/vite'
 import { defineConfig, type PluginOption } from 'vite'
 
 const r = (p: string) => fileURLToPath(new URL(p, import.meta.url))
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Build-time client env (`import.meta.env.VITE_*`).
+//
+// Vite/TanStack inline `import.meta.env.VITE_*` into BOTH the client and server
+// bundles at build time — the equivalent of Next's `NEXT_PUBLIC_*` inlining.
+// Cloudflare Worker `[vars]` are RUNTIME-only and never reach the client bundle,
+// so anything the browser needs at build time lives here, not in wrangler vars.
+//
+// Values come from `process.env.VITE_*` (CI overrides — e.g. the pk_test Clerk
+// key for preview deploys) with non-secret committed defaults that mirror
+// `scripts/patch-wrangler-env.ts`. The Clerk publishable key is a PUBLIC key
+// (already committed in wrangler.toml), so defaulting it here is safe.
+function git(cmd: string): string {
+  try {
+    return execSync(`git ${cmd}`, { encoding: 'utf-8' }).trim()
+  } catch {
+    return ''
+  }
+}
+
+const CLIENT_ENV = {
+  VITE_AUTH_PROVIDER: process.env.VITE_AUTH_PROVIDER ?? 'clerk',
+  VITE_CLERK_PUBLISHABLE_KEY:
+    process.env.VITE_CLERK_PUBLISHABLE_KEY ??
+    'pk_live_Y2xlcmsuY2htb25pdG9yLmRldiQ',
+  VITE_FEATURE_CONVERSATION_DB:
+    process.env.VITE_FEATURE_CONVERSATION_DB ?? 'true',
+  VITE_AUTOCOMPLETE_LIMIT: process.env.VITE_AUTOCOMPLETE_LIMIT ?? '',
+  VITE_RUNNING_QUERIES_REFRESH_MS:
+    process.env.VITE_RUNNING_QUERIES_REFRESH_MS ?? '',
+  VITE_GIT_SHA: process.env.VITE_GIT_SHA ?? git('rev-parse HEAD'),
+  VITE_GIT_REF: process.env.VITE_GIT_REF ?? git('rev-parse --abbrev-ref HEAD'),
+  VITE_BUILD_TIMESTAMP:
+    process.env.VITE_BUILD_TIMESTAMP ?? new Date().toISOString(),
+  VITE_CI: process.env.VITE_CI ?? (process.env.CI ? 'true' : ''),
+} as const
+
+// Explicit text-replacement of each `import.meta.env.VITE_*` read. Deterministic
+// across local + CI builds regardless of Vite's .env-file discovery.
+const CLIENT_ENV_DEFINE = Object.fromEntries(
+  Object.entries(CLIENT_ENV).map(([k, v]) => [
+    `import.meta.env.${k}`,
+    JSON.stringify(v),
+  ])
+)
 
 // ─────────────────────────────────────────────────────────────────────────────
 // SSR stub for browser-only render libraries (#1393 worker size limit).
@@ -147,6 +194,9 @@ const runtimePlugins: PluginOption[] = isNode
     ]
 
 export default defineConfig({
+  // Inline client-exposed build-time env (`import.meta.env.VITE_*`). See
+  // CLIENT_ENV above — Worker [vars] are runtime-only and never reach the client.
+  define: CLIENT_ENV_DEFINE,
   server: {
     port: 3000,
     // Allow Vite to read shared @chm/* package sources outside the app root.

--- a/apps/dashboard-tsr/wrangler.toml
+++ b/apps/dashboard-tsr/wrangler.toml
@@ -33,10 +33,11 @@ CLOUDFLARE_WORKERS = "1"
 LLM_MODEL = "anyrouter:@preset/chmonitor"
 OPENROUTER_REFERER = "https://clickhouse.duyet.net"
 OPENROUTER_APP_NAME = "chmonitor"
+# Server-side auth provider (runtime). The CLIENT auth provider + Clerk
+# publishable key are NOT runtime vars — they are build-time inlined via
+# import.meta.env.VITE_* (see vite.config.ts CLIENT_ENV).
 CHM_AUTH_PROVIDER = "clerk"
-NEXT_PUBLIC_AUTH_PROVIDER = "clerk"
 CHM_FEATURE_AGENT_ACCESS = "authenticated"
-NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_live_Y2xlcmsuY2htb25pdG9yLmRldiQ"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Preview environment for PR deployments
@@ -66,10 +67,8 @@ LLM_MODEL = "anyrouter:z-ai/glm-4.7-flash"
 OPENROUTER_REFERER = "https://clickhouse.duyet.net"
 OPENROUTER_APP_NAME = "chmonitor"
 
-# Auth provider for preview deployment
+# Server-side auth provider for preview (runtime). Client auth provider + the
+# Clerk publishable key are build-time inlined (import.meta.env.VITE_*); the CI
+# build step sets the pk_test key for preview deploys.
 CHM_AUTH_PROVIDER = "clerk"
-NEXT_PUBLIC_AUTH_PROVIDER = "clerk"
 CHM_FEATURE_AGENT_ACCESS = "authenticated"
-
-# Clerk test key for preview environment
-NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_bWFnbmV0aWMtcmF5LTkwLmNsZXJrLmFjY291bnRzLmRldiQ"


### PR DESCRIPTION
## Problem

The TanStack Start / Vite dashboard only inlines `import.meta.env.VITE_*` into the **client** bundle at build time. Cloudflare Worker `[vars]` are **runtime-only** and never reach the browser.

The env-bridge (`lib/env.ts`, `clerk-client.ts`) already *read* `VITE_AUTH_PROVIDER` / `VITE_CLERK_PUBLISHABLE_KEY`, but **nothing ever defined them** — and many files still read `process.env.NEXT_PUBLIC_*` (a Next.js-only convention). Result on every build:

- `import.meta.env.VITE_CLERK_PUBLISHABLE_KEY` → `undefined` → the Clerk key was **absent from the client bundle**
- `isClerkClientEnabled()` → always `false` → **Clerk auth silently disabled** client-side

Verified: on `main`, `grep pk_live dist/client/assets/*.js` returns **zero** hits.

## Fix

- **`vite.config.ts`** — `CLIENT_ENV` + `define` block inlines every `VITE_*` (auth provider, Clerk key, feature flags, limits, git metadata) with non-secret committed defaults that mirror `patch-wrangler-env.ts`. CI/local override via `process.env.VITE_*`.
- **Code migration** — replace all functional `process.env.NEXT_PUBLIC_*`:
  - client (`about`, `use-autocomplete-data`, `running-queries-view`) → `import.meta.env.VITE_*`
  - server (`auth/provider`, `feature-permissions/server`, `api/v1/config`, `api/health`) → runtime `CHM_AUTH_PROVIDER` with build-time `VITE_AUTH_PROVIDER` fallback
- **Drop dead runtime vars** — remove `NEXT_PUBLIC_AUTH_PROVIDER` / `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` from `wrangler.toml` + `patch-wrangler-env.ts` (keep server-side `CHM_AUTH_PROVIDER`).
- **CI** — `dashboard-tsr` build step exports `VITE_*`: `pk_test` for PR previews, `pk_live` for production, plus git SHA/ref.
- **Types** — declare the new `VITE_*` in `vite-env.d.ts`.

## Why "missing host" wasn't a missing var

For context: I verified from the latest deploy logs that `CLICKHOUSE_HOST` **is** correctly deployed to both `chmonitor-dash` and `chmonitor-dash-tsr` workers, and the Tailscale Funnel hosts answer `HTTP 200` on `/ping` publicly. The actual breakage was the client-side env prefix above.

## Verification

- `pk_live` is now inlined into `dist/client` (was absent before).
- Build green: `vite build && tsc --noEmit` + full prerender.
- `provider.test.ts` passes (updated for the new precedence).

Scope: TSR app only — the old Next.js dashboard correctly uses `NEXT_PUBLIC_*`.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated client-side build configuration to inject environment variables at compile time
  * Reorganized authentication and deployment configuration sources
  * Enhanced build metadata capture for deployment information display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->