### PR TITLE
feat(dashboard-tsr): post-deploy verify skill + env normalization (#1392)

### DIFF
--- a/.claude/skills/verify-deploy.md
+++ b/.claude/skills/verify-deploy.md
@@ -1,0 +1,61 @@
+# Skill: verify-deploy (post-deploy self-test)
+
+Verify a **live** dashboard-tsr deployment after every deploy — both the
+**unauthenticated** surface (what an anonymous visitor / the CDN sees) and the
+**authenticated** surface (token-gated data API actually reaching ClickHouse).
+
+## When to use
+
+- Right after a `chmonitor-dash-tsr` deploy (prod or preview).
+- When diagnosing "no data / missing host / blank overview" reports.
+- As the gate after any change to env wiring, auth guards, or the build.
+
+## Run it
+
+```bash
+# Unauthenticated checks only (no secret needed)
+bun apps/dashboard-tsr/scripts/verify-deploy.ts --skip-auth
+
+# Full check incl. ClickHouse connectivity (mints a short-lived chm_ token)
+CHM_API_KEY_SECRET=… bun apps/dashboard-tsr/scripts/verify-deploy.ts --hosts 0,1
+
+# Preview deployment, JSON output for CI
+bun apps/dashboard-tsr/scripts/verify-deploy.ts \
+  --base-url https://preview.dash-tsr.chmonitor.dev --json
+```
+
+The secret lives in `apps/dashboard/.env.local` (`CHM_API_KEY_SECRET`) and the
+GitHub secret of the same name. Never print it; source it into the env var.
+
+Flags: `--base-url <url>` (default `https://dash-tsr.chmonitor.dev`),
+`--hosts 0,1`, `--json`, `--skip-auth`. Exit 0 = all pass, 1 = failures, 2 = harness error.
+
+## What it asserts
+
+**Unauthenticated**
+1. `GET /api/health` → 200, reports `runtime / authProvider / clientAuthProvider /
+   gitSha / buildTimestamp / clerkPublishableKeyPrefix`.
+2. `GET /overview?host=0` → 200 and the HTML references the client entry bundle.
+3. **The client entry bundle contains the Clerk `pk_` key when authProvider=clerk.**
+   This is the regression guard for the `NEXT_PUBLIC_*` → `VITE_*` migration: a
+   broken build inlines NO key (`grep pk_live dist/client` = 0) → Clerk silently
+   disabled → no login → no token → the entire data API 401s ("missing data").
+4. `GET /api/v1/menu-counts` with no token → 401 when API-key auth is enabled.
+
+**Authenticated** (only when `CHM_API_KEY_SECRET` is set)
+5. `POST /api/v1/auth/api-key` with the secret as Bearer → mints a `chm_` token.
+   The token is JWT-shaped (`chm_<payload>.<sig>`) — extract the **full** value
+   including the `.`; a regex like `chm_[A-Za-z0-9_]+` truncates it → "malformed token".
+6. `GET /api/v1/menu-counts?hostId=H` with the token → 200 `success:true` with live
+   ClickHouse system-table counts === the worker reaches and queries ClickHouse.
+   Runs per host in `--hosts`.
+
+## Notes / gotchas learned
+
+- `/api/v1/data` rejects arbitrary SQL by design (`permission_error`); only the
+  registry endpoints (`/api/v1/charts/[name]`, `/api/v1/tables/[name]`,
+  `menu-counts`, …) run queries. Use those to prove connectivity.
+- The ClickHouse hosts are **Tailscale Funnel** URLs (`*.dingo-mora.ts.net`):
+  from on the tailnet MagicDNS gives `100.x` (private), but public DNS resolves
+  the funnel ingress and `https://<host>/ping` → 200 — reachable from the CF edge.
+- The data API param is `hostId`, not `host`.

--- a/apps/dashboard-tsr/.env.example
+++ b/apps/dashboard-tsr/.env.example
@@ -1,0 +1,91 @@
+# ============================================================================
+# dashboard-tsr (TanStack Start) — environment variables
+# ============================================================================
+# Copy to `.env` for local dev: `cp .env.example .env`
+#
+# THREE tiers — know which one a var belongs to before adding it:
+#
+#   1. VITE_*   CLIENT, build-time. Inlined into the browser bundle by Vite at
+#               `vite build` (see vite.config.ts CLIENT_ENV). Worker [vars] do
+#               NOT reach the client. Read via `import.meta.env.VITE_*`.
+#               (the Next.js NEXT_PUBLIC_* equivalent.)
+#   2. runtime vars   SERVER, non-secret. Set in wrangler.toml [vars] /
+#               patch-wrangler-env.ts. Read via `process.env` / the Worker
+#               `env` binding. Safe to commit (no credentials).
+#   3. secrets  SERVER, sensitive. Set via `wrangler secret` /
+#               scripts/set-secrets.ts (CI). NEVER commit real values.
+#
+# Adding a var? Update ALL of its tier's sources so they don't drift:
+#   VITE_*  -> vite.config.ts CLIENT_ENV + .github/workflows/cloudflare.yml
+#             (dashboard-tsr build step) + src/vite-env.d.ts
+#   var     -> wrangler.toml ([vars] + [env.preview.vars]) + patch-wrangler-env.ts
+#   secret  -> scripts/set-secrets.ts (DASH_TSR_SECRET_KEYS) + cloudflare.yml
+# ============================================================================
+
+# ── 1. VITE_* — client, build-time inlined ─────────────────────────────────
+# Auth provider exposed to the browser. 'clerk' enables Clerk; 'none' disables.
+VITE_AUTH_PROVIDER=none
+# Clerk PUBLISHABLE key (public, pk_...). Required when VITE_AUTH_PROVIDER=clerk.
+VITE_CLERK_PUBLISHABLE_KEY=
+# Persist agent conversations in D1/Postgres instead of localStorage.
+VITE_FEATURE_CONVERSATION_DB=false
+# Optional client tuning (empty = code default).
+VITE_AUTOCOMPLETE_LIMIT=
+VITE_RUNNING_QUERIES_REFRESH_MS=
+# Build metadata — normally injected by CI/vite.config (git + timestamp); leave unset locally.
+# VITE_GIT_SHA=
+# VITE_GIT_REF=
+# VITE_BUILD_TIMESTAMP=
+# VITE_CI=
+
+# ── 2. Runtime vars — server, non-secret (wrangler [vars]) ──────────────────
+# Comma-separated, index-aligned across HOST/USER/NAME for multi-host.
+CLICKHOUSE_HOST=http://localhost:8123
+CLICKHOUSE_USER=default
+CLICKHOUSE_NAME=localhost
+CLICKHOUSE_MAX_EXECUTION_TIME=60
+# Server-side auth provider (runtime). Mirrors VITE_AUTH_PROVIDER; CHM_ wins on the server.
+CHM_AUTH_PROVIDER=none
+# Agent feature access: public | authenticated.
+CHM_FEATURE_AGENT_ACCESS=public
+# Default AI model (provider:model or anyrouter:@preset/...).
+LLM_MODEL=anyrouter/free
+# OpenRouter attribution (non-secret).
+OPENROUTER_REFERER=http://localhost:3000
+OPENROUTER_APP_NAME=chmonitor
+# Set to '1' only inside the Cloudflare Worker runtime (CI/wrangler sets it).
+# CLOUDFLARE_WORKERS=1
+
+# ── 3. Secrets — server, sensitive (wrangler secret / CI) ───────────────────
+# NEVER commit real values. Comma-separated to match the HOST list above.
+CLICKHOUSE_PASSWORD=
+# Gate /api/v1/* behind chm_ Bearer tokens. When set, the data API requires a
+# token minted at POST /api/v1/auth/api-key (Bearer = this secret).
+CHM_API_KEY_SECRET=
+# Clerk server secret (sk_...). Required when auth provider = clerk.
+CLERK_SECRET_KEY=
+# AI providers (set the one(s) you use).
+LLM_API_KEY=
+LLM_API_BASE=
+OPENROUTER_API_KEY=
+OPENROUTER_API_BASE=
+ANYROUTER_API_KEY=
+ANYROUTER_API_BASE=
+NVIDIA_API_KEY=
+NVIDIA_API_BASE=
+
+# ── Optional subsystems ─────────────────────────────────────────────────────
+# Query timezone / cache.
+# CLICKHOUSE_TZ=UTC
+# CLICKHOUSE_EXCLUDE_USER_DEFAULT=
+# NEXT_QUERY_CACHE_TTL=3600
+# Health-sweep cron alerting.
+# CRON_SECRET=
+# HEALTH_ALERT_ENABLED=false
+# HEALTH_ALERT_MIN_SEVERITY=warning
+# HEALTH_ALERT_WEBHOOK_URL=
+# PeerDB monitoring.
+# PEERDB_API_URL=
+# PEERDB_PASSWORD=
+# Conversation store (when VITE_FEATURE_CONVERSATION_DB=true on non-CF targets).
+# DATABASE_URL=

--- a/apps/dashboard-tsr/package.json
+++ b/apps/dashboard-tsr/package.json
@@ -18,7 +18,8 @@
     "cf:dry-run": "vite build && wrangler deploy --dry-run",
     "cf-typegen": "wrangler types",
     "type-check": "tsc --noEmit",
-    "test": "bun test src/"
+    "test": "bun test src/",
+    "verify-deploy": "bun scripts/verify-deploy.ts"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.65",

--- a/apps/dashboard-tsr/scripts/verify-deploy.ts
+++ b/apps/dashboard-tsr/scripts/verify-deploy.ts
@@ -1,0 +1,281 @@
+#!/usr/bin/env bun
+/**
+ * Post-deploy verification for the dashboard-tsr (TanStack Start) worker.
+ *
+ * Runs two scenarios against a LIVE deployment:
+ *
+ *  UNAUTHENTICATED (always)
+ *   1. GET /api/health           -> 200 + reports git sha / auth provider / build ts
+ *   2. GET / and /overview?host=0 -> 200, HTML references the client entry bundle
+ *   3. client entry bundle        -> contains the Clerk pk_ key when authProvider=clerk
+ *      (guards the NEXT_PUBLIC_* -> VITE_* regression: a broken build ships NO key)
+ *   4. GET /api/v1/menu-counts (no token) -> 401 when API-key auth is enabled
+ *
+ *  AUTHENTICATED (when CHM_API_KEY_SECRET is set)
+ *   5. POST /api/v1/auth/api-key (Bearer secret) -> mints a chm_ token
+ *   6. GET /api/v1/menu-counts?hostId=H (Bearer token) -> 200 success:true with live
+ *      ClickHouse system-table counts === the worker reaches + queries ClickHouse
+ *
+ * Run:
+ *   bun scripts/verify-deploy.ts [--base-url URL] [--hosts 0,1] [--json] [--skip-auth]
+ *   CHM_API_KEY_SECRET=... bun scripts/verify-deploy.ts            # enables authed scenario
+ *
+ * Exit codes: 0 = all checks pass, 1 = one or more failed, 2 = harness error.
+ */
+
+const args = process.argv.slice(2)
+function flag(name: string): string | undefined {
+  const eq = args.find((a) => a.startsWith(`--${name}=`))
+  if (eq) return eq.split('=').slice(1).join('=')
+  const i = args.indexOf(`--${name}`)
+  return i !== -1 ? args[i + 1] : undefined
+}
+
+const BASE_URL = (flag('base-url') ?? 'https://dash-tsr.chmonitor.dev').replace(
+  /\/$/,
+  ''
+)
+const HOSTS = (flag('hosts') ?? '0,1')
+  .split(',')
+  .map((h) => h.trim())
+  .filter(Boolean)
+const JSON_OUTPUT = args.includes('--json')
+const SKIP_AUTH = args.includes('--skip-auth')
+const SECRET = process.env.CHM_API_KEY_SECRET
+
+interface Check {
+  scenario: 'unauthenticated' | 'authenticated'
+  name: string
+  ok: boolean
+  detail: string
+}
+const checks: Check[] = []
+function record(c: Check) {
+  checks.push(c)
+  if (!JSON_OUTPUT) {
+    const icon = c.ok ? '✅' : '❌'
+    console.log(`${icon} [${c.scenario}] ${c.name} — ${c.detail}`)
+  }
+}
+
+const TIMEOUT_MS = 30_000
+async function http(
+  path: string,
+  init?: RequestInit
+): Promise<{ status: number; text: string; json: unknown }> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    ...init,
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  })
+  const text = await res.text()
+  let json: unknown = null
+  try {
+    json = JSON.parse(text)
+  } catch {
+    /* non-JSON (HTML/asset) */
+  }
+  return { status: res.status, text, json }
+}
+
+// ── Unauthenticated scenario ──────────────────────────────────────────────
+
+let clerkExpected = false
+
+async function runUnauthenticated() {
+  // 1. health
+  try {
+    const { status, json } = await http('/api/health')
+    const d = (json as { deployment?: Record<string, unknown> })?.deployment
+    clerkExpected =
+      d?.authProvider === 'clerk' || d?.clientAuthProvider === 'clerk'
+    record({
+      scenario: 'unauthenticated',
+      name: 'GET /api/health',
+      ok: status === 200 && !!d,
+      detail:
+        status === 200 && d
+          ? `runtime=${d.runtime} authProvider=${d.authProvider} clientAuthProvider=${d.clientAuthProvider} sha=${String(d.gitSha).slice(0, 7)} clerkKey=${d.clerkPublishableKeyPrefix ?? 'none'}`
+          : `HTTP ${status}`,
+    })
+  } catch (e) {
+    record({
+      scenario: 'unauthenticated',
+      name: 'GET /api/health',
+      ok: false,
+      detail: String(e),
+    })
+  }
+
+  // 2. prerendered pages + 3. client bundle carries the Clerk key
+  try {
+    const { status, text } = await http('/overview?host=0')
+    const asset = text.match(/\/assets\/index-[A-Za-z0-9_-]+\.js/)?.[0]
+    record({
+      scenario: 'unauthenticated',
+      name: 'GET /overview?host=0',
+      ok: status === 200 && !!asset,
+      detail:
+        status === 200 ? `entry=${asset ?? 'NOT FOUND'}` : `HTTP ${status}`,
+    })
+    if (asset) {
+      const bundle = await http(asset)
+      const hasKey = /pk_(live|test)_[A-Za-z0-9]+/.test(bundle.text)
+      // Only an assertion failure when Clerk is the configured provider.
+      record({
+        scenario: 'unauthenticated',
+        name: 'client bundle has Clerk key',
+        ok: clerkExpected ? hasKey : true,
+        detail: hasKey
+          ? `key inlined (${bundle.text.match(/pk_(live|test)_[A-Za-z0-9]+/)?.[0]?.slice(0, 12)}…)`
+          : clerkExpected
+            ? 'MISSING — VITE_CLERK_PUBLISHABLE_KEY not inlined (the NEXT_PUBLIC regression)'
+            : 'no key (auth provider is not clerk — ok)',
+      })
+    }
+  } catch (e) {
+    record({
+      scenario: 'unauthenticated',
+      name: 'GET /overview',
+      ok: false,
+      detail: String(e),
+    })
+  }
+
+  // 4. anonymous data call is rejected when API-key auth is enabled
+  try {
+    const { status, json } = await http(
+      `/api/v1/menu-counts?hostId=${HOSTS[0]}`
+    )
+    const isAuthGate = status === 401
+    record({
+      scenario: 'unauthenticated',
+      name: 'anon /api/v1/menu-counts blocked',
+      ok: isAuthGate || status === 200,
+      detail: isAuthGate
+        ? `401 (${(json as { error?: string })?.error}) — API-key auth enforced`
+        : status === 200
+          ? '200 — API-key auth is DISABLED (open data API)'
+          : `unexpected HTTP ${status}`,
+    })
+  } catch (e) {
+    record({
+      scenario: 'unauthenticated',
+      name: 'anon /api/v1 blocked',
+      ok: false,
+      detail: String(e),
+    })
+  }
+}
+
+// ── Authenticated scenario ────────────────────────────────────────────────
+
+async function runAuthenticated() {
+  if (SKIP_AUTH) return
+  if (!SECRET) {
+    if (!JSON_OUTPUT)
+      console.log(
+        'ℹ️  [authenticated] skipped — set CHM_API_KEY_SECRET to run CH connectivity checks'
+      )
+    return
+  }
+
+  // 5. mint a chm_ token
+  let token = ''
+  try {
+    const { status, json } = await http('/api/v1/auth/api-key', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${SECRET}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ label: 'verify-deploy', days: 1 }),
+    })
+    token = (json as { data?: { apiKey?: string } })?.data?.apiKey ?? ''
+    record({
+      scenario: 'authenticated',
+      name: 'POST /api/v1/auth/api-key (mint token)',
+      ok: status === 200 && token.startsWith('chm_'),
+      detail:
+        status === 200 && token
+          ? `minted ${token.slice(0, 10)}… (len=${token.length})`
+          : `HTTP ${status} ${(json as { error?: string })?.error ?? ''}`,
+    })
+  } catch (e) {
+    record({
+      scenario: 'authenticated',
+      name: 'mint token',
+      ok: false,
+      detail: String(e),
+    })
+  }
+  if (!token) return
+
+  // 6. real CH query per host via the registry endpoint
+  for (const h of HOSTS) {
+    try {
+      const { status, json } = await http(`/api/v1/menu-counts?hostId=${h}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const body = json as {
+        success?: boolean
+        data?: { counts?: Record<string, number> }
+        error?: { message?: string }
+      }
+      const counts = body?.data?.counts ?? {}
+      const sample = ['tables-overview', 'metrics', 'settings', 'clusters']
+        .filter((k) => k in counts)
+        .map((k) => `${k}=${counts[k]}`)
+        .join(' ')
+      record({
+        scenario: 'authenticated',
+        name: `CH query hostId=${h} (menu-counts)`,
+        ok: status === 200 && body?.success === true,
+        detail:
+          status === 200 && body?.success
+            ? `connected — ${sample}`
+            : `HTTP ${status} ${body?.error?.message ?? body?.error ?? ''}`,
+      })
+    } catch (e) {
+      record({
+        scenario: 'authenticated',
+        name: `CH query hostId=${h}`,
+        ok: false,
+        detail: String(e),
+      })
+    }
+  }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+
+async function main() {
+  if (!JSON_OUTPUT) console.log(`\n🔎 Verifying ${BASE_URL}\n`)
+  await runUnauthenticated()
+  await runAuthenticated()
+
+  const failed = checks.filter((c) => !c.ok)
+  if (JSON_OUTPUT) {
+    console.log(
+      JSON.stringify(
+        {
+          baseUrl: BASE_URL,
+          passed: checks.length - failed.length,
+          failed: failed.length,
+          checks,
+        },
+        null,
+        2
+      )
+    )
+  } else {
+    console.log(
+      `\n${failed.length === 0 ? '✅ ALL PASS' : `❌ ${failed.length} FAILED`} — ${checks.length - failed.length}/${checks.length} checks\n`
+    )
+  }
+  process.exit(failed.length === 0 ? 0 : 1)
+}
+
+main().catch((e) => {
+  console.error('harness error:', e)
+  process.exit(2)
+})

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -2,6 +2,22 @@
 
 Reference of all supported environment variables, grouped by category.
 
+> **Client var prefix differs by app.** Browser-exposed (client) variables are
+> **build-time inlined** and the prefix depends on which dashboard you run:
+>
+> | App | Client prefix | Read via |
+> |---|---|---|
+> | `apps/dashboard` (Next.js, legacy) | `NEXT_PUBLIC_*` | `process.env.NEXT_PUBLIC_*` |
+> | `apps/dashboard-tsr` (TanStack Start) | `VITE_*` | `import.meta.env.VITE_*` |
+>
+> Same variable, different prefix — e.g. `NEXT_PUBLIC_AUTH_PROVIDER` ↔
+> `VITE_AUTH_PROVIDER`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` ↔
+> `VITE_CLERK_PUBLISHABLE_KEY`. The tables below list the legacy `NEXT_PUBLIC_*`
+> names; for the TanStack app substitute the `VITE_` prefix. Worker `[vars]` are
+> runtime-only and never reach the client, so these MUST be set at build time
+> (CI build step / `vite.config.ts`). Authoritative TanStack reference:
+> [`apps/dashboard-tsr/.env.example`](https://github.com/duyet/clickhouse-monitoring/blob/main/apps/dashboard-tsr/.env.example).
+
 ---
 
 ## ClickHouse Connection


### PR DESCRIPTION
## What

Two cohesive pieces of post-migration env/deploy hygiene.

### 1. Post-deploy self-test (`verify-deploy`)

`apps/dashboard-tsr/scripts/verify-deploy.ts` (+ `bun run verify-deploy`, and a `.claude/skills/verify-deploy.md` skill) verifies a **live** deployment in both scenarios:

**Unauthenticated**
- `GET /api/health` → 200, reports runtime / authProvider / gitSha / clerkKey prefix
- `GET /overview?host=0` → 200 + references the client entry bundle
- **client bundle contains the Clerk `pk_` key** when authProvider=clerk — this is the regression guard for the `NEXT_PUBLIC_*` → `VITE_*` fix (#1435): a broken build ships **no** key
- anon `GET /api/v1/menu-counts` → 401 (API-key auth enforced)

**Authenticated** (when `CHM_API_KEY_SECRET` is set)
- `POST /api/v1/auth/api-key` → mints a `chm_` token
- `GET /api/v1/menu-counts?hostId=H` → 200 with live ClickHouse counts === worker reaches + queries ClickHouse, per host

Verified **7/7 green** against prod `dash-tsr.chmonitor.dev` (host 0: 125 tables / 444 metrics / 2 clusters; host 1: 21 tables / 480 metrics / 1 cluster).

```
bun run verify-deploy --skip-auth                       # anon only
CHM_API_KEY_SECRET=… bun run verify-deploy --hosts 0,1  # full
```

### 2. Env normalization

- **`apps/dashboard-tsr/.env.example`** — the missing TanStack template (the app had none). Organised by tier — `VITE_*` (client, build-time inlined) / runtime `[vars]` (server, non-secret) / secrets — with a note listing every source each tier must update to prevent drift across `vite.config.ts` / `wrangler.toml` / `patch-wrangler-env.ts` / `cloudflare.yml` / `set-secrets.ts`.
- **`docs/environment-variables.mdx`** — callout mapping `NEXT_PUBLIC_*` (legacy Next app) ↔ `VITE_*` (TanStack app) for client vars, pointing at the new example.

## Scope note

Deliberately **did not** rename the working `CLICKHOUSE_*` / `LLM_*` / `OPENROUTER_*` runtime vars — they're conventional, shared with the old dashboard, and a rename is high-risk for no functional gain. Normalization here = a documented, consistent convention + the missing template + doc-drift fix. Happy to do a deeper rename pass if wanted.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added environment variable configuration guide for the TanStack Start dashboard app
  * Updated environment variables reference with clarification on build-time vs. runtime variables

* **New Features**
  * Added post-deploy verification tooling to validate health, configuration, and connectivity after deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->