### PR TITLE
docs(dashboard-tsr): env back-compat + Migrating guide (#1392)

### DIFF
--- a/apps/dashboard-tsr/src/lib/auth/provider.ts
+++ b/apps/dashboard-tsr/src/lib/auth/provider.ts
@@ -38,8 +38,12 @@ export function parseAuthProvider(
 }
 
 export function getAuthProvider(): AuthProvider {
+  // Precedence: runtime CHM_AUTH_PROVIDER → build-time VITE_AUTH_PROVIDER →
+  // legacy NEXT_PUBLIC_AUTH_PROVIDER (back-compat for pre-rename configs).
   return parseAuthProvider(
-    process.env.CHM_AUTH_PROVIDER ?? import.meta.env.VITE_AUTH_PROVIDER
+    process.env.CHM_AUTH_PROVIDER ??
+      import.meta.env.VITE_AUTH_PROVIDER ??
+      process.env.NEXT_PUBLIC_AUTH_PROVIDER
   )
 }
 

--- a/apps/dashboard-tsr/src/lib/feature-permissions/server.ts
+++ b/apps/dashboard-tsr/src/lib/feature-permissions/server.ts
@@ -127,7 +127,9 @@ interface AppConfig {
 
 function getAppConfig(): AppConfig {
   const authProvider = parseAuthProvider(
-    readEnv('CHM_AUTH_PROVIDER') ?? import.meta.env.VITE_AUTH_PROVIDER
+    readEnv('CHM_AUTH_PROVIDER') ??
+      import.meta.env.VITE_AUTH_PROVIDER ??
+      readEnv('NEXT_PUBLIC_AUTH_PROVIDER')
   )
   return { authProvider, features: parseEnvFeatureOverrides() }
 }

--- a/apps/dashboard-tsr/src/routes/(docs)/docs/_lib/docs.ts
+++ b/apps/dashboard-tsr/src/routes/(docs)/docs/_lib/docs.ts
@@ -76,6 +76,10 @@ export const docsNav: DocsNavSection[] = [
     ],
   },
   {
+    title: 'Migrating',
+    items: [{ title: 'To TanStack (v0.3)', slug: 'migrating/to-tanstack' }],
+  },
+  {
     title: 'Reference',
     items: [
       {

--- a/apps/dashboard-tsr/src/routes/api/v1/config.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/config.ts
@@ -194,7 +194,9 @@ function parseEnvFeatureOverrides(): FeatureOverrides {
 
 function getPublicFeaturePermissionConfig(): PublicFeaturePermissionConfig {
   const authProvider = parseAuthProvider(
-    readEnv('CHM_AUTH_PROVIDER') ?? import.meta.env.VITE_AUTH_PROVIDER
+    readEnv('CHM_AUTH_PROVIDER') ??
+      import.meta.env.VITE_AUTH_PROVIDER ??
+      readEnv('NEXT_PUBLIC_AUTH_PROVIDER')
   )
 
   const features = parseEnvFeatureOverrides()

--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -29,21 +29,39 @@ function git(cmd: string): string {
   }
 }
 
+// Back-compat: each client var also accepts its legacy Next `NEXT_PUBLIC_*`
+// build-env name as a fallback, so configs from before the VITE_ rename keep
+// working. Precedence: VITE_* (new) → NEXT_PUBLIC_* (legacy) → committed default.
+// Only PUBLIC vars live here — never a runtime secret (security boundary).
+const e = process.env
 const CLIENT_ENV = {
-  VITE_AUTH_PROVIDER: process.env.VITE_AUTH_PROVIDER ?? 'clerk',
+  VITE_AUTH_PROVIDER:
+    e.VITE_AUTH_PROVIDER ?? e.NEXT_PUBLIC_AUTH_PROVIDER ?? 'clerk',
   VITE_CLERK_PUBLISHABLE_KEY:
-    process.env.VITE_CLERK_PUBLISHABLE_KEY ??
+    e.VITE_CLERK_PUBLISHABLE_KEY ??
+    e.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ??
     'pk_live_Y2xlcmsuY2htb25pdG9yLmRldiQ',
   VITE_FEATURE_CONVERSATION_DB:
-    process.env.VITE_FEATURE_CONVERSATION_DB ?? 'true',
-  VITE_AUTOCOMPLETE_LIMIT: process.env.VITE_AUTOCOMPLETE_LIMIT ?? '',
+    e.VITE_FEATURE_CONVERSATION_DB ??
+    e.NEXT_PUBLIC_FEATURE_CONVERSATION_DB ??
+    'true',
+  VITE_AUTOCOMPLETE_LIMIT:
+    e.VITE_AUTOCOMPLETE_LIMIT ?? e.NEXT_PUBLIC_AUTOCOMPLETE_LIMIT ?? '',
   VITE_RUNNING_QUERIES_REFRESH_MS:
-    process.env.VITE_RUNNING_QUERIES_REFRESH_MS ?? '',
-  VITE_GIT_SHA: process.env.VITE_GIT_SHA ?? git('rev-parse HEAD'),
-  VITE_GIT_REF: process.env.VITE_GIT_REF ?? git('rev-parse --abbrev-ref HEAD'),
+    e.VITE_RUNNING_QUERIES_REFRESH_MS ??
+    e.NEXT_PUBLIC_RUNNING_QUERIES_REFRESH_MS ??
+    '',
+  VITE_GIT_SHA:
+    e.VITE_GIT_SHA ?? e.NEXT_PUBLIC_GIT_SHA ?? git('rev-parse HEAD'),
+  VITE_GIT_REF:
+    e.VITE_GIT_REF ??
+    e.NEXT_PUBLIC_GIT_REF ??
+    git('rev-parse --abbrev-ref HEAD'),
   VITE_BUILD_TIMESTAMP:
-    process.env.VITE_BUILD_TIMESTAMP ?? new Date().toISOString(),
-  VITE_CI: process.env.VITE_CI ?? (process.env.CI ? 'true' : ''),
+    e.VITE_BUILD_TIMESTAMP ??
+    e.NEXT_PUBLIC_BUILD_TIMESTAMP ??
+    new Date().toISOString(),
+  VITE_CI: e.VITE_CI ?? e.NEXT_PUBLIC_CI ?? (e.CI ? 'true' : ''),
 } as const
 
 // Explicit text-replacement of each `import.meta.env.VITE_*` read. Deterministic

--- a/docs/content/migrating/to-tanstack.mdx
+++ b/docs/content/migrating/to-tanstack.mdx
@@ -1,0 +1,134 @@
+# Migrating to TanStack Start (v0.3)
+
+chmonitor is moving its dashboard from **Next.js** to **TanStack Start** (Vite +
+TanStack Router). The biggest user-visible change is the **environment variable
+convention** for client-exposed config. This page explains what changes, how to
+migrate, and gives a prompt you can hand to an AI agent to do it for you.
+
+> **Backward compatible.** The new app still reads the legacy `NEXT_PUBLIC_*`
+> names as a fallback, so existing configs keep working. You can migrate at your
+> own pace; renaming is recommended but not required.
+
+---
+
+## What changes: client env prefix
+
+Next.js inlined browser-exposed variables prefixed with `NEXT_PUBLIC_`. Vite /
+TanStack Start inlines variables prefixed with **`VITE_`** instead — and reads
+them via `import.meta.env`, not `process.env`.
+
+| Concern | Next.js (legacy) | TanStack Start (v0.3) |
+|---|---|---|
+| Client (browser) vars | `NEXT_PUBLIC_*` via `process.env` | **`VITE_*` via `import.meta.env`** |
+| When inlined | build time | build time |
+| Server (runtime) vars | `process.env.*` | `process.env.*` / Worker `env` binding |
+| Secrets | runtime only, never client | runtime only, never client |
+
+### Security boundary (unchanged)
+
+Keep the two tiers strictly separate:
+
+- **Public / client (`VITE_*`)** — inlined into the browser bundle at build
+  time. **Never** put a secret here. Anything `VITE_`-prefixed is world-readable.
+- **Runtime / server (`CHM_*`, `CLICKHOUSE_*`, secrets)** — read at runtime from
+  the Worker `env` binding / `process.env`. Never reaches the browser.
+
+The Cloudflare Worker `[vars]` are **runtime-only** and do **not** reach the
+client bundle — so a browser-needed value must be set at **build time** as a
+`VITE_*` var (in CI / `vite.config.ts`), not only in `wrangler.toml`.
+
+---
+
+## Variable rename map
+
+| Legacy (`NEXT_PUBLIC_*`) | New (`VITE_*`) |
+|---|---|
+| `NEXT_PUBLIC_AUTH_PROVIDER` | `VITE_AUTH_PROVIDER` |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | `VITE_CLERK_PUBLISHABLE_KEY` |
+| `NEXT_PUBLIC_FEATURE_CONVERSATION_DB` | `VITE_FEATURE_CONVERSATION_DB` |
+| `NEXT_PUBLIC_AUTOCOMPLETE_LIMIT` | `VITE_AUTOCOMPLETE_LIMIT` |
+| `NEXT_PUBLIC_RUNNING_QUERIES_REFRESH_MS` | `VITE_RUNNING_QUERIES_REFRESH_MS` |
+| `NEXT_PUBLIC_GIT_SHA` / `_REF` / `_BUILD_TIMESTAMP` / `_CI` | `VITE_GIT_SHA` / `_REF` / `_BUILD_TIMESTAMP` / `_CI` |
+
+Server-side / runtime variables (`CLICKHOUSE_*`, `CHM_*`, `LLM_*`,
+`OPENROUTER_*`, secrets) are **unchanged** — keep their names.
+
+The full reference template lives at
+[`apps/dashboard-tsr/.env.example`](https://github.com/duyet/clickhouse-monitoring/blob/main/apps/dashboard-tsr/.env.example).
+
+---
+
+## Manual migration steps
+
+1. **Rename client vars** in your `.env` / deploy config: `NEXT_PUBLIC_X` →
+   `VITE_X` (see the map above). Leave runtime/server vars and secrets alone.
+2. **Set `VITE_*` at build time.** On Cloudflare, the publishable Clerk key and
+   auth provider are inlined during `vite build` — set them in the CI build step
+   env (or `vite.config.ts`), not only as Worker `[vars]` (those don't reach the
+   browser).
+3. **Keep secrets server-side.** `CLERK_SECRET_KEY`, `CLICKHOUSE_PASSWORD`,
+   `CHM_API_KEY_SECRET`, LLM keys stay as Worker secrets / `process.env`.
+4. **Verify after deploy** (see below).
+
+---
+
+## Verify after deploy
+
+Run the bundled post-deploy self-test — it checks both the unauthenticated
+surface and (with a secret) ClickHouse connectivity:
+
+```bash
+# Unauthenticated checks (health, prerendered pages, client bundle has the key)
+bun apps/dashboard-tsr/scripts/verify-deploy.ts --skip-auth
+
+# Full check incl. ClickHouse connectivity
+CHM_API_KEY_SECRET=… bun apps/dashboard-tsr/scripts/verify-deploy.ts --hosts 0,1
+```
+
+A green run confirms the client bundle carries the Clerk publishable key
+(`VITE_CLERK_PUBLISHABLE_KEY` correctly inlined) and that the worker reaches
+ClickHouse.
+
+---
+
+## Auto-migrate with an AI agent
+
+Hand the following prompt to an AI coding agent (Claude Code, Cursor, etc.)
+pointed at your repo to perform the rename automatically:
+
+````text
+Migrate this project's client-exposed environment variables from the Next.js
+`NEXT_PUBLIC_*` convention to the Vite/TanStack `VITE_*` convention. Rules:
+
+1. SCOPE: only CLIENT-exposed (browser) vars. Do NOT rename server/runtime vars
+   (CLICKHOUSE_*, CHM_*, LLM_*, OPENROUTER_*, secrets) — those keep their names.
+
+2. CODE READS:
+   - Client reads `process.env.NEXT_PUBLIC_X` → `import.meta.env.VITE_X`.
+   - Server reads that referenced `NEXT_PUBLIC_X` → read the runtime var first
+     (e.g. CHM_*), then fall back to `import.meta.env.VITE_X`, then keep
+     `NEXT_PUBLIC_X` as a final back-compat fallback.
+
+3. BUILD WIRING: ensure each `VITE_X` is provided at BUILD time (Vite only
+   inlines `import.meta.env.VITE_*` from the build environment, not from runtime
+   Worker vars). Add a `define`/CLIENT_ENV block in vite.config.ts that maps
+   `process.env.VITE_X ?? process.env.NEXT_PUBLIC_X ?? <default>` for each, and
+   set the values in the CI build step env. Keep secrets OUT of this block.
+
+4. TYPES: declare each `VITE_X` in `src/vite-env.d.ts` (ImportMetaEnv).
+
+5. CONFIG: drop dead `NEXT_PUBLIC_*` entries from runtime Worker `[vars]`; keep
+   the server-side equivalents (CHM_*). Update `.env.example` and docs.
+
+6. BACKWARD COMPATIBILITY: old `NEXT_PUBLIC_*` names must still work as a
+   fallback everywhere.
+
+7. SECURITY: never inline a runtime secret into the client bundle. Only PUBLIC
+   values may be `VITE_*`.
+
+Verify: run the build; then `grep -rl '<your pk_ key>' dist/client/assets/*.js`
+must return ≥1 file (the publishable key is inlined). Migrate, build, and report
+the diff.
+````
+
+After the agent finishes, run the verify step above against a deployed preview.


### PR DESCRIPTION
## What

Follow-up to the `NEXT_PUBLIC_* → VITE_*` migration: **backward compatibility** + a **Migrating** docs section.

### Backward compatibility (keep old configs working)
- `vite.config.ts` `CLIENT_ENV`: each client var now resolves `VITE_X ?? NEXT_PUBLIC_X ?? default` at build time, so deploy configs from before the rename keep working.
- Server auth reads (`provider.ts`, `feature-permissions/server.ts`, `config.ts`): fall back to `NEXT_PUBLIC_AUTH_PROVIDER` after `CHM_AUTH_PROVIDER` / `VITE_AUTH_PROVIDER`.
- **Security boundary preserved**: only PUBLIC values are `VITE_*` (inlined to the client); runtime secrets stay server-side. No secret enters the client define.

### Docs — new "Migrating" section
`docs/content/migrating/to-tanstack.mdx` (registered in the docs nav):
- `NEXT_PUBLIC_* → VITE_*` rename map + the runtime/public separation rule
- Manual migration steps + `verify-deploy` usage
- A copy-paste **prompt to auto-migrate with an AI agent**

## Verify
Build green (vite + tsc + prerender); the new page prerenders `200`.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Maintain backward compatibility for dashboard-tsr client and auth configuration while documenting the Next.js to TanStack/Vite env migration.

New Features:
- Add a Migrating section to the docs with a guide for moving from Next.js to TanStack Start and the NEXT_PUBLIC_* to VITE_* env convention.

Enhancements:
- Extend client build-time env resolution to fall back from VITE_* to legacy NEXT_PUBLIC_* variables in vite.config.ts.
- Update server-side auth configuration to fall back to legacy NEXT_PUBLIC_AUTH_PROVIDER when CHM_AUTH_PROVIDER or VITE_AUTH_PROVIDER are not set.
- Expose the new migration guide in the docs navigation under a Migrating section.

Documentation:
- Document the env var migration from NEXT_PUBLIC_* to VITE_* including rename map, manual steps, verification commands, and an AI-agent migration prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive migration guide for transitioning to TanStack Start, including environment variable conventions and step-by-step migration instructions.

* **Improvements**
  * Enhanced environment variable precedence handling with improved backward compatibility for legacy configurations across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->