### PR TITLE
feat(dashboard-tsr): pluggable auth providers (none|clerk|proxy) + CF Access/proxy + auth docs + v0.3 changelog (#1392)

### DIFF
--- a/apps/dashboard-tsr/src/components/host/first-run-gate.tsx
+++ b/apps/dashboard-tsr/src/components/host/first-run-gate.tsx
@@ -1,18 +1,24 @@
 import { FirstRunEmptyState } from './first-run-empty-state'
+import { FirstRunUnauthorizedState } from './first-run-unauthorized-state'
 import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
 
 /**
  * Gates the dashboard content on having at least one configured ClickHouse
- * host. When zero hosts are configured (env + browser) the dashboard would
- * otherwise be a bare, confusing surface, so we render a first-run onboarding
- * EmptyState instead.
+ * host. Two first-run surfaces replace the bare, confusing default:
+ *
+ *  - unauthorized (hosts fetch 401/403) → prompt to sign in
+ *  - zero hosts configured (env + browser) → onboarding EmptyState
  *
  * While hosts are still loading we render children so existing skeletons /
  * Suspense fallbacks keep showing — we only swap in onboarding once we are
- * certain there are no hosts.
+ * certain about the state.
  */
 export function FirstRunGate({ children }: { children: React.ReactNode }) {
-  const { hosts, isLoading } = useMergedHosts()
+  const { hosts, isLoading, isUnauthorized } = useMergedHosts()
+
+  if (!isLoading && isUnauthorized) {
+    return <FirstRunUnauthorizedState />
+  }
 
   if (!isLoading && hosts.length === 0) {
     return <FirstRunEmptyState />

--- a/apps/dashboard-tsr/src/components/host/first-run-unauthorized-state.tsx
+++ b/apps/dashboard-tsr/src/components/host/first-run-unauthorized-state.tsx
@@ -1,0 +1,66 @@
+import { LockKeyhole } from 'lucide-react'
+
+import type { ReactNode } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/ui/empty-state'
+import { isClerkEnabled } from '@/lib/clerk/clerk-client'
+
+/**
+ * Clerk's `SignInButton` requires a mounted `<ClerkProvider />`. Gate it behind
+ * the build-time `isClerkEnabled()` constant (same lazy-require pattern as
+ * `components/assistant-ui/agent-auth-gate.tsx`) so this never loads Clerk when
+ * auth is disabled or driven by a non-Clerk provider (`proxy` / `none`).
+ */
+const ClerkSignInButton:
+  | ((props: { children: ReactNode }) => ReactNode)
+  | null = isClerkEnabled()
+  ? require('@/components/clerk/clerk-sign-in-button').ClerkSignInButton
+  : null
+
+/**
+ * Unauthorized first-run surface.
+ *
+ * Rendered when the hosts fetch comes back 401/403 — the dashboard requires
+ * sign-in. With the Clerk provider we offer a sign-in button; with proxy/none
+ * there is no in-app sign-in (the identity provider sits in front of the app),
+ * so we show a generic instruction instead.
+ *
+ * @see components/host/first-run-gate.tsx
+ */
+export function FirstRunUnauthorizedState() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 py-16">
+      <EmptyState
+        variant="no-data"
+        icon={
+          <LockKeyhole
+            className="h-10 w-10 text-muted-foreground/60"
+            strokeWidth={1.5}
+          />
+        }
+        title="Sign in to view the dashboard"
+        description={
+          ClerkSignInButton ? (
+            <span className="block">
+              This dashboard requires authentication. Sign in to load your
+              ClickHouse hosts.
+            </span>
+          ) : (
+            <span className="block">
+              Authentication required — sign in through your identity provider
+              to load your ClickHouse hosts.
+            </span>
+          )
+        }
+        className="max-w-lg"
+      />
+
+      {ClerkSignInButton ? (
+        <ClerkSignInButton>
+          <Button size="sm">Sign in</Button>
+        </ClerkSignInButton>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/dashboard-tsr/src/components/host/host-switcher.tsx
+++ b/apps/dashboard-tsr/src/components/host/host-switcher.tsx
@@ -39,7 +39,7 @@ export function HostSwitcher() {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const { isMobile, state } = useSidebar()
-  const { hosts, isLoading } = useHosts()
+  const { hosts, isLoading, error, isUnauthorized } = useHosts()
   const currentHostId = useHostId()
 
   const activeHost = hosts[currentHostId] || hosts[0]
@@ -81,9 +81,51 @@ export function HostSwitcher() {
     )
   }
 
-  // Don't render switcher if no hosts configured
+  // No active host: instead of disappearing, keep the switcher's shape and
+  // surface WHY there is no host — unauthorized (sign in), a load error, or
+  // genuinely none configured. Same layout as the normal single-host view.
   if (!activeHost) {
-    return null
+    const { label, hint } = isUnauthorized
+      ? { label: 'Sign in to load hosts', hint: 'Authentication required' }
+      : error
+        ? { label: "Couldn't load hosts", hint: 'Tap to retry from a page' }
+        : { label: 'No host', hint: 'None configured' }
+
+    return (
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton size="lg" asChild>
+            <div
+              className={cn(
+                'flex gap-2',
+                showExpanded ? 'items-center' : 'items-center justify-center'
+              )}
+              data-testid="host-switcher-empty"
+              aria-label={label}
+              title={showExpanded ? undefined : label}
+            >
+              <div className="relative">
+                <ClickHouseLogo
+                  width={20}
+                  height={20}
+                  className="size-5 opacity-50"
+                />
+              </div>
+              {showExpanded && (
+                <div className="grid flex-1 text-left text-sm leading-tight">
+                  <span className="truncate font-medium text-muted-foreground">
+                    {label}
+                  </span>
+                  <span className="truncate text-xs text-muted-foreground/70">
+                    {hint}
+                  </span>
+                </div>
+              )}
+            </div>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    )
   }
 
   // For single host, render simplified view without dropdown

--- a/apps/dashboard-tsr/src/lib/auth/api-guard.ts
+++ b/apps/dashboard-tsr/src/lib/auth/api-guard.ts
@@ -5,21 +5,26 @@
  * Next middleware; TanStack Start has no `middleware.ts`, so the equivalent
  * runs as a global request middleware registered in `src/start.ts`.
  *
- * Two pieces of the Next middleware are reproduced here:
+ * Pluggable auth model. The active provider comes from `getAuthProvider()`
+ * (`CHM_AUTH_PROVIDER` / `VITE_AUTH_PROVIDER`):
  *
- *  1. API-key auth (`getApiKeyAuthFailure`) — when `apiKeyAuthEnabled()` is
- *     true, every `/api/v1/*` route requires EITHER a valid `chm_` Bearer token
- *     (programmatic/MCP clients) OR a valid Clerk session (browser clients, via
- *     the `__session` cookie). Anonymous requests get a 401 JSON
- *     `{ error: 'API key required' }` (or `Invalid API key: <reason>`). Exempt:
- *     `/api/v1/auth/api-key` (it owns its own secret-based auth in the handler).
+ *  - `none`  — public dashboard; every caller is authenticated.
+ *  - `clerk` — browser Clerk session (the `__session` cookie / Clerk token).
+ *  - `proxy` — a trusted reverse proxy (Cloudflare Access JWT, or a trusted
+ *              identity header gated by a shared secret).
  *
- *     The Clerk-session branch (`hasValidClerkSession`) is the Next
- *     `clerkMiddleware()` cookie precheck — #1397 dropped it during the port,
- *     which made a logged-in dashboard 401 on every data call (the browser
- *     holds a Clerk session, not a chm_ token).
+ * On top of the provider, API-key auth (`chm_` Bearer tokens) is ALWAYS on
+ * whenever `CHM_API_KEY_SECRET` is set, for programmatic/MCP clients.
  *
- *  2. cloud→dash 301 redirect (`getLegacyHostRedirect`).
+ * Enforcement on `/api/v1/*` (`getApiKeyAuthFailure`):
+ *  - PUBLIC passthrough only when provider is `none` AND API-key auth is off.
+ *  - Otherwise a request must present EITHER a valid `chm_` Bearer token OR pass
+ *    the active provider's `authenticateRequest`. Anonymous requests get a 401
+ *    JSON `{ error: 'Authentication required' }`. Exempt: `/api/v1/auth/api-key`
+ *    (it owns its own secret-based auth in the handler).
+ *
+ * Also reproduced from the Next middleware: the cloud→dash 301 redirect
+ * (`getLegacyHostRedirect`).
  *
  * `apiKeyAuthEnabled()` and `verifyApiKey()` read `process.env.CHM_API_KEY_SECRET`
  * directly. On Cloudflare Workers the canonical source is the `env` binding, so
@@ -33,6 +38,7 @@ import {
   verifyApiKey,
 } from '@chm/mcp-server/auth'
 import { getAuthProvider, isAuthProviderConfigError } from '@/lib/auth/provider'
+import { resolveServerAuthProvider } from '@/lib/auth/providers'
 
 const API_V1_PREFIX = '/api/v1/'
 // Key issuance route has its own secret-based auth in its handler.
@@ -94,7 +100,9 @@ export async function getApiKeyAuthFailure(
     return null
   }
 
-  if (!apiKeyAuthEnabled()) return null
+  // Public passthrough only when the dashboard is fully open: provider is
+  // `none` AND API-key auth is off. Any other config enforces.
+  if (getAuthProvider() === 'none' && !apiKeyAuthEnabled()) return null
 
   // Key issuance route has its own secret-based auth in the handler.
   if (pathname === API_KEY_ISSUANCE_PATH) {
@@ -106,44 +114,29 @@ export async function getApiKeyAuthFailure(
   if (headerToken) {
     const result = await verifyApiKey(headerToken)
     if (result.valid) return null
-    // Not a valid chm_ key — fall through to the Clerk-session check; the
-    // Authorization header may carry a Clerk token rather than a chm_ key.
+    // Not a valid chm_ key — fall through to the provider check; the
+    // Authorization header may carry a Clerk/proxy token rather than a chm_ key.
   }
 
-  // 2. Browser clients: a valid Clerk session. Clerk sets the `__session`
-  //    cookie (sent automatically same-origin) and may also send a Clerk token
-  //    in the Authorization header. This restores the Clerk-cookie precheck the
-  //    Next middleware relied on, which #1397 dropped — without it a logged-in
-  //    dashboard 401s on every data call because the browser holds a Clerk
-  //    session, not a chm_ token.
-  if (await hasValidClerkSession(request)) return null
-
-  return jsonError('API key required', 401)
-}
-
-/**
- * Verify a Clerk session straight off the `Request` — networkless JWT
- * verification via `clerkClient().authenticateRequest` (reads `CLERK_SECRET_KEY`
- * from the runtime env; publishable key inlined at build time). Works in the
- * request middleware without Clerk's ambient context, and fails closed on any
- * error. Only consulted when the configured auth provider is `clerk`.
- */
-async function hasValidClerkSession(request: Request): Promise<boolean> {
-  if (getAuthProvider() !== 'clerk') return false
-
-  const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
-  if (!publishableKey || !process.env.CLERK_SECRET_KEY) return false
-
-  try {
-    const { clerkClient } = await import('@clerk/tanstack-react-start/server')
-    const requestState = await clerkClient().authenticateRequest(request, {
-      publishableKey,
-      authorizedParties: [new URL(request.url).origin],
-    })
-    return requestState.isSignedIn
-  } catch {
-    return false
+  // 2. The active auth provider (clerk session, proxy identity, …). Browser
+  //    clients send a Clerk `__session` cookie; proxy deployments send a
+  //    Cloudflare Access JWT or a trusted identity header.
+  //
+  //    Skip this for the `none` provider: reaching here with `none` means
+  //    API-key auth is ON (the public passthrough above already returned for
+  //    `none` + no key), so the API key is the ONLY accepted credential. The
+  //    `none` provider authenticates everyone, so consulting it here would let
+  //    keyless requests through and silently defeat API-key auth.
+  const provider = getAuthProvider()
+  if (
+    provider !== 'none' &&
+    (await resolveServerAuthProvider(provider).authenticateRequest(request))
+      .authenticated
+  ) {
+    return null
   }
+
+  return jsonError('Authentication required', 401)
 }
 
 /**

--- a/apps/dashboard-tsr/src/lib/auth/provider.ts
+++ b/apps/dashboard-tsr/src/lib/auth/provider.ts
@@ -6,7 +6,7 @@ export const AUTH_PROVIDER_ENV_VARS = [
   'VITE_AUTH_PROVIDER',
 ] as const
 
-export const AUTH_PROVIDERS = ['none', 'clerk'] as const
+export const AUTH_PROVIDERS = ['none', 'clerk', 'proxy'] as const
 
 export type AuthProvider = (typeof AUTH_PROVIDERS)[number]
 
@@ -15,7 +15,7 @@ export class AuthProviderConfigError extends Error {
     super(
       `Invalid auth provider value "${value}" in ${AUTH_PROVIDER_ENV_VARS.join(
         ' or '
-      )}. Expected one of: none, clerk.`
+      )}. Expected one of: none, clerk, proxy.`
     )
     this.name = 'AuthProviderConfigError'
   }
@@ -32,6 +32,10 @@ export function parseAuthProvider(
 
   if (normalized === 'clerk') {
     return 'clerk'
+  }
+
+  if (normalized === 'proxy') {
+    return 'proxy'
   }
 
   throw new AuthProviderConfigError(value ?? '')

--- a/apps/dashboard-tsr/src/lib/auth/providers/clerk.ts
+++ b/apps/dashboard-tsr/src/lib/auth/providers/clerk.ts
@@ -1,0 +1,38 @@
+import type { AuthResult, ServerAuthProvider } from './types'
+
+/**
+ * Clerk session provider — networkless JWT verification straight off the
+ * `Request` via `clerkClient().authenticateRequest`. Browser clients send
+ * Clerk's `__session` cookie (same-origin, automatic) and may also carry a
+ * Clerk token in the Authorization header; both are handled by Clerk.
+ *
+ * Reads `CLERK_SECRET_KEY` from the runtime env and the publishable key inlined
+ * at build time (`VITE_CLERK_PUBLISHABLE_KEY`). When either is absent the
+ * provider is unconfigured and returns not-authenticated. Fails closed on any
+ * verification error (this also keeps keyless prerender safe).
+ *
+ * Moved here from the inline `hasValidClerkSession` in `api-guard.ts` (#1437)
+ * when auth providers became pluggable.
+ */
+export class ClerkAuthProvider implements ServerAuthProvider {
+  async authenticateRequest(request: Request): Promise<AuthResult> {
+    const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+    if (!publishableKey || !process.env.CLERK_SECRET_KEY) {
+      return { authenticated: false }
+    }
+
+    try {
+      const { clerkClient } = await import('@clerk/tanstack-react-start/server')
+      const requestState = await clerkClient().authenticateRequest(request, {
+        publishableKey,
+        authorizedParties: [new URL(request.url).origin],
+      })
+      return {
+        authenticated: requestState.isSignedIn,
+        subject: requestState.toAuth?.()?.userId ?? undefined,
+      }
+    } catch {
+      return { authenticated: false }
+    }
+  }
+}

--- a/apps/dashboard-tsr/src/lib/auth/providers/index.ts
+++ b/apps/dashboard-tsr/src/lib/auth/providers/index.ts
@@ -1,0 +1,34 @@
+import type { AuthProvider } from '@/lib/auth/provider'
+import type { ServerAuthProvider } from './types'
+
+import { ClerkAuthProvider } from './clerk'
+import { NoneAuthProvider } from './none'
+import { ProxyAuthProvider } from './proxy'
+
+export type { AuthResult, ServerAuthProvider } from './types'
+
+// Provider implementations are stateless (config is read per request from
+// process.env / import.meta.env), so a single instance per kind is reused.
+const noneProvider = new NoneAuthProvider()
+const clerkProvider = new ClerkAuthProvider()
+const proxyProvider = new ProxyAuthProvider()
+
+/**
+ * Resolve the server-side auth provider for the active `AuthProvider`.
+ *
+ * Named `resolveServerAuthProvider` (not `getServerAuthProvider`) to avoid the
+ * existing `getServerAuthProvider` export in `@/lib/env`. Unknown values fall
+ * back to the public `none` provider.
+ */
+export function resolveServerAuthProvider(
+  provider: AuthProvider
+): ServerAuthProvider {
+  switch (provider) {
+    case 'clerk':
+      return clerkProvider
+    case 'proxy':
+      return proxyProvider
+    default:
+      return noneProvider
+  }
+}

--- a/apps/dashboard-tsr/src/lib/auth/providers/none.ts
+++ b/apps/dashboard-tsr/src/lib/auth/providers/none.ts
@@ -1,0 +1,12 @@
+import type { AuthResult, ServerAuthProvider } from './types'
+
+/**
+ * The `none` provider treats every caller as authenticated. The dashboard is
+ * public; access control (if any) is left to always-on API-key auth and to
+ * ClickHouse itself. This is the default when no auth provider is configured.
+ */
+export class NoneAuthProvider implements ServerAuthProvider {
+  async authenticateRequest(_request: Request): Promise<AuthResult> {
+    return { authenticated: true }
+  }
+}

--- a/apps/dashboard-tsr/src/lib/auth/providers/proxy.ts
+++ b/apps/dashboard-tsr/src/lib/auth/providers/proxy.ts
@@ -1,0 +1,247 @@
+/**
+ * Reverse-proxy auth provider.
+ *
+ * Authenticates requests that arrive through a TRUSTED reverse proxy (the proxy
+ * does the real login; the worker trusts the proxy's verdict). Two independent
+ * mechanisms are supported; the first that succeeds authenticates the request:
+ *
+ *   (a) Cloudflare Access — a signed `Cf-Access-Jwt-Assertion` JWT, verified
+ *       cryptographically against the team's JWKS. This needs no shared secret
+ *       because the signature is the proof.
+ *
+ *   (b) Trusted header + shared secret — the proxy sets an identity header and
+ *       a shared-secret header; we trust the identity ONLY when the secret
+ *       matches (constant-time).
+ *
+ * SECURITY: mechanism (b) is unsafe WITHOUT the shared secret. On a
+ * publicly-reachable worker any client can forge `X-Forwarded-User`, so header
+ * trust is gated on `CHM_PROXY_AUTH_SECRET` being set and matched. Never enable
+ * proxy auth on a publicly-reachable worker that strips neither header nor
+ * checks the secret — only put it behind a proxy that overwrites these headers.
+ */
+
+import type { AuthResult, ServerAuthProvider } from './types'
+
+const CF_ACCESS_JWT_HEADER = 'Cf-Access-Jwt-Assertion'
+const DEFAULT_SHARED_SECRET_HEADER = 'X-Chm-Proxy-Secret'
+const DEFAULT_IDENTITY_HEADER = 'X-Forwarded-User'
+// Cache JWKS keys for ~1h to avoid fetching certs on every request.
+const JWKS_TTL_MS = 60 * 60 * 1000
+
+interface CachedKey {
+  key: CryptoKey
+  expiresAt: number
+}
+
+// In-module JWKS cache keyed by JWT `kid`. Cleared on TTL expiry per kid.
+const jwksCache = new Map<string, CachedKey>()
+
+function unb64url(input: string): Uint8Array<ArrayBuffer> | null {
+  const base64 = input.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
+  try {
+    const binary = atob(padded)
+    // Allocate an explicitly ArrayBuffer-backed view so the bytes satisfy
+    // crypto.subtle's BufferSource (Uint8Array.from widens to ArrayBufferLike).
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i)
+    }
+    return bytes
+  } catch {
+    return null
+  }
+}
+
+function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false
+
+  let diff = 0
+  for (let index = 0; index < a.length; index += 1) {
+    diff |= a[index] ^ b[index]
+  }
+
+  return diff === 0
+}
+
+interface JwtParts {
+  header: { kid?: string; alg?: string }
+  payload: Record<string, unknown>
+  signingInput: Uint8Array<ArrayBuffer>
+  signature: Uint8Array<ArrayBuffer>
+}
+
+function decodeJwt(token: string): JwtParts | null {
+  const segments = token.split('.')
+  if (segments.length !== 3) return null
+  const [headerEnc, payloadEnc, sigEnc] = segments
+
+  const headerBytes = unb64url(headerEnc)
+  const payloadBytes = unb64url(payloadEnc)
+  const signature = unb64url(sigEnc)
+  if (!headerBytes || !payloadBytes || !signature) return null
+
+  try {
+    const header = JSON.parse(new TextDecoder().decode(headerBytes)) as {
+      kid?: string
+      alg?: string
+    }
+    const payload = JSON.parse(
+      new TextDecoder().decode(payloadBytes)
+    ) as Record<string, unknown>
+    return {
+      header,
+      payload,
+      signingInput: new TextEncoder().encode(`${headerEnc}.${payloadEnc}`),
+      signature,
+    }
+  } catch {
+    return null
+  }
+}
+
+interface Jwk extends JsonWebKey {
+  kid?: string
+}
+
+async function getVerificationKey(
+  teamDomain: string,
+  kid: string
+): Promise<CryptoKey | null> {
+  const cached = jwksCache.get(kid)
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.key
+  }
+
+  let res: Response
+  try {
+    res = await fetch(`${teamDomain}/cdn-cgi/access/certs`, {
+      signal: AbortSignal.timeout(5000),
+    })
+  } catch {
+    return null
+  }
+  if (!res.ok) return null
+
+  let jwks: { keys?: Jwk[] }
+  try {
+    jwks = (await res.json()) as { keys?: Jwk[] }
+  } catch {
+    return null
+  }
+
+  const jwk = jwks.keys?.find((k) => k.kid === kid)
+  if (!jwk) return null
+
+  try {
+    const key = await crypto.subtle.importKey(
+      'jwk',
+      jwk,
+      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+      false,
+      ['verify']
+    )
+    jwksCache.set(kid, { key, expiresAt: Date.now() + JWKS_TTL_MS })
+    return key
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Verify a Cloudflare Access JWT. Returns the authenticated principal, or null
+ * when the header is absent, Access is unconfigured, or verification fails.
+ */
+async function verifyCfAccess(request: Request): Promise<AuthResult | null> {
+  const teamDomain = process.env.CHM_CF_ACCESS_TEAM_DOMAIN
+  const expectedAud = process.env.CHM_CF_ACCESS_AUD
+  // Access is opt-in: skip this mechanism entirely when unconfigured.
+  if (!teamDomain || !expectedAud) return null
+
+  const token = request.headers.get(CF_ACCESS_JWT_HEADER)
+  if (!token) return null
+
+  const issuer = teamDomain.replace(/\/$/, '')
+
+  const parts = decodeJwt(token)
+  if (!parts || parts.header.alg !== 'RS256' || !parts.header.kid) {
+    return { authenticated: false }
+  }
+
+  const key = await getVerificationKey(issuer, parts.header.kid)
+  if (!key) return { authenticated: false }
+
+  let verified: boolean
+  try {
+    verified = await crypto.subtle.verify(
+      'RSASSA-PKCS1-v1_5',
+      key,
+      parts.signature,
+      parts.signingInput
+    )
+  } catch {
+    return { authenticated: false }
+  }
+  if (!verified) return { authenticated: false }
+
+  const { aud, iss, exp, email, sub } = parts.payload as {
+    aud?: string | string[]
+    iss?: string
+    exp?: number
+    email?: string
+    sub?: string
+  }
+
+  const audList = Array.isArray(aud) ? aud : aud ? [aud] : []
+  if (!audList.includes(expectedAud)) return { authenticated: false }
+  if (iss !== issuer) return { authenticated: false }
+  if (typeof exp !== 'number' || exp <= Math.floor(Date.now() / 1000)) {
+    return { authenticated: false }
+  }
+
+  return { authenticated: true, subject: email ?? sub }
+}
+
+/**
+ * Verify a trusted identity header gated by a shared secret. Returns the
+ * principal when the secret matches AND a non-empty identity header is present;
+ * null when the shared secret is unconfigured (mechanism disabled) or absent.
+ */
+function verifyTrustedHeader(request: Request): AuthResult | null {
+  const sharedSecret = process.env.CHM_PROXY_AUTH_SECRET
+  // Header trust is unsafe without a shared secret — disable the mechanism.
+  if (!sharedSecret) return null
+
+  const secretHeader =
+    process.env.CHM_PROXY_SHARED_SECRET_HEADER ?? DEFAULT_SHARED_SECRET_HEADER
+  const provided = request.headers.get(secretHeader)
+  if (!provided) return null
+
+  const encoder = new TextEncoder()
+  if (
+    !constantTimeEqual(encoder.encode(provided), encoder.encode(sharedSecret))
+  ) {
+    return { authenticated: false }
+  }
+
+  const identityHeader =
+    process.env.CHM_PROXY_AUTH_HEADER ?? DEFAULT_IDENTITY_HEADER
+  const subject = request.headers.get(identityHeader)
+  if (!subject) return { authenticated: false }
+
+  return { authenticated: true, subject }
+}
+
+export class ProxyAuthProvider implements ServerAuthProvider {
+  async authenticateRequest(request: Request): Promise<AuthResult> {
+    // Try Cloudflare Access first; its signed JWT is self-proving.
+    const cfAccess = await verifyCfAccess(request)
+    if (cfAccess?.authenticated) return cfAccess
+
+    // Then the trusted header + shared secret.
+    const trustedHeader = verifyTrustedHeader(request)
+    if (trustedHeader?.authenticated) return trustedHeader
+
+    return { authenticated: false }
+  }
+}

--- a/apps/dashboard-tsr/src/lib/auth/providers/proxy.ts
+++ b/apps/dashboard-tsr/src/lib/auth/providers/proxy.ts
@@ -25,16 +25,21 @@ import type { AuthResult, ServerAuthProvider } from './types'
 const CF_ACCESS_JWT_HEADER = 'Cf-Access-Jwt-Assertion'
 const DEFAULT_SHARED_SECRET_HEADER = 'X-Chm-Proxy-Secret'
 const DEFAULT_IDENTITY_HEADER = 'X-Forwarded-User'
-// Cache JWKS keys for ~1h to avoid fetching certs on every request.
+// Cache the WHOLE JWKS document per team domain for ~1h to avoid fetching certs
+// on every request. Caching the full set (not per-kid) is deliberate: a forged
+// token with an unknown `kid` must NOT trigger a fetch — otherwise an
+// unauthenticated client could force an outbound JWKS fetch on every request (a
+// DoS / latency vector on the auth path). An unknown kid simply misses the
+// already-cached set until the TTL expires and the set is refreshed.
 const JWKS_TTL_MS = 60 * 60 * 1000
 
-interface CachedKey {
-  key: CryptoKey
+interface CachedKeySet {
+  keys: Map<string, CryptoKey> // kid → imported verify key
   expiresAt: number
 }
 
-// In-module JWKS cache keyed by JWT `kid`. Cleared on TTL expiry per kid.
-const jwksCache = new Map<string, CachedKey>()
+// In-module JWKS cache keyed by team domain.
+const jwksCache = new Map<string, CachedKeySet>()
 
 function unb64url(input: string): Uint8Array<ArrayBuffer> | null {
   const base64 = input.replace(/-/g, '+').replace(/_/g, '/')
@@ -104,15 +109,10 @@ interface Jwk extends JsonWebKey {
   kid?: string
 }
 
-async function getVerificationKey(
-  teamDomain: string,
-  kid: string
-): Promise<CryptoKey | null> {
-  const cached = jwksCache.get(kid)
-  if (cached && cached.expiresAt > Date.now()) {
-    return cached.key
-  }
-
+/** Fetch + import the team's full JWKS into a kid→key map, or null on failure. */
+async function fetchKeySet(
+  teamDomain: string
+): Promise<Map<string, CryptoKey> | null> {
   let res: Response
   try {
     res = await fetch(`${teamDomain}/cdn-cgi/access/certs`, {
@@ -130,22 +130,43 @@ async function getVerificationKey(
     return null
   }
 
-  const jwk = jwks.keys?.find((k) => k.kid === kid)
-  if (!jwk) return null
-
-  try {
-    const key = await crypto.subtle.importKey(
-      'jwk',
-      jwk,
-      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-      false,
-      ['verify']
-    )
-    jwksCache.set(kid, { key, expiresAt: Date.now() + JWKS_TTL_MS })
-    return key
-  } catch {
-    return null
+  const keys = new Map<string, CryptoKey>()
+  for (const jwk of jwks.keys ?? []) {
+    if (!jwk.kid) continue
+    try {
+      keys.set(
+        jwk.kid,
+        await crypto.subtle.importKey(
+          'jwk',
+          jwk,
+          { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+          false,
+          ['verify']
+        )
+      )
+    } catch {
+      // Skip an individual unusable key; keep the rest.
+    }
   }
+  return keys
+}
+
+async function getVerificationKey(
+  teamDomain: string,
+  kid: string
+): Promise<CryptoKey | null> {
+  const cached = jwksCache.get(teamDomain)
+  // Fresh cache: resolve the kid against it WITHOUT any fetch. An unknown kid
+  // (e.g. a forged token) misses here and returns null — no outbound request.
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.keys.get(kid) ?? null
+  }
+
+  // Stale or absent: refresh the whole set once, cache it, then resolve.
+  const keys = await fetchKeySet(teamDomain)
+  if (!keys) return null
+  jwksCache.set(teamDomain, { keys, expiresAt: Date.now() + JWKS_TTL_MS })
+  return keys.get(kid) ?? null
 }
 
 /**

--- a/apps/dashboard-tsr/src/lib/auth/providers/types.ts
+++ b/apps/dashboard-tsr/src/lib/auth/providers/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Pluggable server-side auth provider contract.
+ *
+ * A `ServerAuthProvider` answers one question for an incoming `/api/v1`
+ * request: is the caller an authenticated principal? Each configured auth
+ * provider (`none` / `clerk` / `proxy`) supplies one implementation; the guard
+ * in `api-guard.ts` resolves the active one via `resolveServerAuthProvider`.
+ *
+ * Every implementation MUST fail closed — any internal error or missing config
+ * resolves to `{ authenticated: false }` rather than throwing, so a misconfig
+ * never accidentally grants access.
+ */
+export interface AuthResult {
+  authenticated: boolean
+  /** Stable identifier for the principal (user id, email, …) when known. */
+  subject?: string
+}
+
+export interface ServerAuthProvider {
+  authenticateRequest(request: Request): Promise<AuthResult>
+}

--- a/apps/dashboard-tsr/src/lib/feature-permissions/types.ts
+++ b/apps/dashboard-tsr/src/lib/feature-permissions/types.ts
@@ -61,7 +61,7 @@ export type Principal = 'anonymous' | 'authenticated'
 export type ResolvedFeatureStates = Record<FeatureId, FeatureState>
 
 export interface PublicFeaturePermissionConfig {
-  authProvider: 'none' | 'clerk'
+  authProvider: 'none' | 'clerk' | 'proxy'
   principal: Principal
   features: FeatureOverrides
   resolved?: ResolvedFeatureStates

--- a/apps/dashboard-tsr/src/lib/swr/use-hosts.ts
+++ b/apps/dashboard-tsr/src/lib/swr/use-hosts.ts
@@ -11,37 +11,43 @@ interface HostsResponse {
   data?: HostInfo[]
 }
 
+/** Error carrying the HTTP status so callers can distinguish 401 from empty. */
+class HostsFetchError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message)
+    this.name = 'HostsFetchError'
+  }
+}
+
 /**
  * TanStack Query hook to fetch the list of configured ClickHouse hosts.
  * Provides automatic caching and deduplication.
  *
- * @returns {Object} Query state with hosts array, error, isLoading
+ * On failure the fetcher THROWS (rather than swallowing to `[]`) so callers can
+ * tell "no hosts configured" (success, empty list) apart from "couldn't load /
+ * unauthorized" (error). `hosts` still falls back to `[]` so existing consumers
+ * are unaffected; new `error` / `isUnauthorized` surface the failure mode.
  *
- * @example
- * ```typescript
- * const { hosts, error, isLoading } = useHosts()
- * ```
+ * @returns {Object} Query state: hosts, error, isLoading, isUnauthorized
  */
 export function useHosts() {
-  const fetcher = useCallback(async () => {
-    try {
-      const response = await apiFetch('/api/v1/hosts')
-      if (!response.ok) {
-        ErrorLogger.logWarning(
-          `Failed to fetch hosts: ${response.status} ${response.statusText}`,
-          { component: 'useHosts' }
-        )
-        return []
-      }
-      const result = (await response.json()) as HostsResponse
-      return result.success && result.data ? result.data : []
-    } catch (err) {
-      ErrorLogger.logError(
-        err instanceof Error ? err : new Error('Failed to fetch hosts'),
+  const fetcher = useCallback(async (): Promise<HostInfo[]> => {
+    const response = await apiFetch('/api/v1/hosts')
+    if (!response.ok) {
+      ErrorLogger.logWarning(
+        `Failed to fetch hosts: ${response.status} ${response.statusText}`,
         { component: 'useHosts' }
       )
-      return []
+      throw new HostsFetchError(
+        `Failed to fetch hosts: ${response.status}`,
+        response.status
+      )
     }
+    const result = (await response.json()) as HostsResponse
+    return result.success && result.data ? result.data : []
   }, [])
 
   const { data, error, isLoading } = useQuery<HostInfo[]>({
@@ -51,11 +57,21 @@ export function useHosts() {
     staleTime: 300000,
     refetchOnWindowFocus: false,
     refetchOnReconnect: true,
+    // Don't hammer the server when auth is the problem — a 401/403 won't change
+    // on retry. Other failures keep the default-ish 2 retries.
+    retry: (failureCount, err) => {
+      const status = err instanceof HostsFetchError ? err.status : undefined
+      if (status === 401 || status === 403) return false
+      return failureCount < 2
+    },
   })
+
+  const status = error instanceof HostsFetchError ? error.status : undefined
 
   return {
     hosts: data ?? [],
     error,
     isLoading,
+    isUnauthorized: status === 401 || status === 403,
   }
 }

--- a/apps/dashboard-tsr/src/lib/swr/use-merged-hosts.ts
+++ b/apps/dashboard-tsr/src/lib/swr/use-merged-hosts.ts
@@ -23,7 +23,7 @@ export interface MergedHostInfo extends HostInfo {
  * ```
  */
 export function useMergedHosts() {
-  const { hosts: envHosts, error, isLoading } = useHosts()
+  const { hosts: envHosts, error, isLoading, isUnauthorized } = useHosts()
   const { connections, mounted } = useBrowserConnections()
 
   const mergedHosts: MergedHostInfo[] = [
@@ -42,6 +42,8 @@ export function useMergedHosts() {
   return {
     hosts: mergedHosts,
     error,
+    // Only the env-host fetch can be unauthorized; browser connections are local.
+    isUnauthorized: Boolean(isUnauthorized),
     isLoading: isLoading || !mounted,
   }
 }

--- a/apps/dashboard-tsr/src/routes/(docs)/docs/_lib/docs.ts
+++ b/apps/dashboard-tsr/src/routes/(docs)/docs/_lib/docs.ts
@@ -81,6 +81,11 @@ export const docsNav: DocsNavSection[] = [
     items: [{ title: 'Migrate to v0.3', slug: 'migrating/v0-3' }],
   },
   {
+    // One "What's New in vX.Y" page per release, newest first.
+    title: 'Releases',
+    items: [{ title: "What's New in v0.3", slug: 'releases/v0-3' }],
+  },
+  {
     title: 'Reference',
     items: [
       {
@@ -90,6 +95,10 @@ export const docsNav: DocsNavSection[] = [
       {
         title: 'Environment Variables',
         slug: 'reference/environment-variables',
+      },
+      {
+        title: 'Authentication',
+        slug: 'reference/authentication',
       },
       {
         title: 'MCP Server',

--- a/apps/dashboard-tsr/wrangler.toml
+++ b/apps/dashboard-tsr/wrangler.toml
@@ -40,6 +40,26 @@ CHM_AUTH_PROVIDER = "clerk"
 CHM_FEATURE_AGENT_ACCESS = "authenticated"
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Reverse-proxy auth (EXAMPLE — not active; dash-tsr uses `clerk` above).
+# Set CHM_AUTH_PROVIDER = "proxy" to authenticate requests via a trusted proxy.
+# Two mechanisms; either success authenticates a request:
+#
+#   (a) Cloudflare Access — verifies the signed `Cf-Access-Jwt-Assertion` JWT.
+#       CHM_CF_ACCESS_TEAM_DOMAIN is your Access team URL; CHM_CF_ACCESS_AUD is
+#       the Access application AUD tag.
+#   (b) Trusted identity header — read CHM_PROXY_AUTH_HEADER (default
+#       `X-Forwarded-User`) ONLY when the request also presents the shared
+#       secret `CHM_PROXY_AUTH_SECRET` (set via `wrangler secret put`, never a
+#       plaintext var). Without the secret, header trust is disabled because any
+#       client could forge it on a publicly-reachable worker.
+#
+# CHM_AUTH_PROVIDER = "proxy"
+# CHM_CF_ACCESS_TEAM_DOMAIN = "https://your-team.cloudflareaccess.com"
+# CHM_CF_ACCESS_AUD = "<access-application-aud-tag>"
+# CHM_PROXY_AUTH_HEADER = "X-Forwarded-User"
+# CHM_PROXY_AUTH_SECRET via: wrangler secret put CHM_PROXY_AUTH_SECRET
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Preview environment for PR deployments
 # Deployed by GitHub Actions on pull requests (see .github/workflows/cloudflare.yml)
 # and reachable at https://preview.dash-tsr.chmonitor.dev.

--- a/docs/content/reference/authentication.mdx
+++ b/docs/content/reference/authentication.mdx
@@ -1,0 +1,165 @@
+# Authentication
+
+chmonitor ships with a pluggable authentication model. A single server-side
+**auth provider** decides whether a browser request is authenticated, and an
+always-on **API key** layer authenticates programmatic clients. Pick the
+provider that matches how you deploy.
+
+The server provider is selected with `CHM_AUTH_PROVIDER` (`none` by default).
+Browser-facing settings mirror it on the client via `VITE_AUTH_PROVIDER`
+(`NEXT_PUBLIC_AUTH_PROVIDER` in the legacy Next app), inlined at build time.
+
+Enforcement runs on every `/api/v1/*` route. A request is allowed when it
+carries a valid `chm_` API key **or** the active provider authenticates it.
+The only public passthrough is `CHM_AUTH_PROVIDER=none` with no API key
+configured — i.e. a fully open dashboard.
+
+---
+
+## Summary
+
+| Method | Who reads it | Browser / proxy auth | curl auth |
+|---|---|---|---|
+| Public (`none`) | — | open | none needed |
+| API key | Provider-agnostic, always on when `CHM_API_KEY_SECRET` set | — | `Authorization: Bearer chm_…` |
+| Clerk | `clerk` provider | Clerk `__session` cookie | Clerk token / `chm_` key |
+| Clerk OAuth (MCP) | MCP server | — | OAuth bearer token |
+| Proxy → Cloudflare Access | `proxy` provider | `Cf-Access-Jwt-Assertion` JWT | — |
+| Proxy → trusted header | `proxy` provider | `X-Forwarded-User` + shared secret | shared secret header |
+
+---
+
+## Public (`none`)
+
+The default. The dashboard is open and `/api/v1/*` requires no authentication —
+unless you also set an API key (see below), in which case the key is still
+enforced for non-browser callers.
+
+```bash
+CHM_AUTH_PROVIDER=none   # or unset
+```
+
+---
+
+## API key (`chm_` Bearer)
+
+Independent of the provider. When `CHM_API_KEY_SECRET` is set, every
+`/api/v1/*` route accepts a signed `chm_` token in the `Authorization` header.
+This is how MCP clients and scripts authenticate. Keys are HMAC-SHA-256 signed
+and time-limited; issue one via `/api/v1/auth/api-key` (which has its own
+secret-based auth).
+
+```bash
+CHM_API_KEY_SECRET=a-long-random-string
+```
+
+```bash
+curl https://dash.example.com/api/v1/hosts \
+  -H "Authorization: Bearer chm_eyJ...<signed>"
+```
+
+API-key auth coexists with any provider: a valid key always satisfies the
+guard, and otherwise the provider gets a chance to authenticate the request.
+
+---
+
+## Clerk (browser session)
+
+Set the provider to `clerk` and supply Clerk keys. Browser clients sign in
+through Clerk; the `__session` cookie (sent automatically same-origin) is
+verified networklessly on each `/api/v1/*` call.
+
+```bash
+CHM_AUTH_PROVIDER=clerk
+VITE_AUTH_PROVIDER=clerk            # client mirror (NEXT_PUBLIC_AUTH_PROVIDER on Next)
+VITE_CLERK_PUBLISHABLE_KEY=pk_live_...
+CLERK_SECRET_KEY=sk_live_...
+```
+
+The publishable key must be present at build time for the client gate to enable
+Clerk UI (sign-in buttons, user menu). The secret key is read at runtime to
+verify sessions.
+
+---
+
+## Clerk OAuth (MCP)
+
+The MCP server (`/api/mcp`) additionally accepts Clerk **OAuth** access tokens.
+Clerk hosts the authorization server (login + consent + dynamic client
+registration); chmonitor is only the resource server that verifies the bearer
+token via Clerk's REST introspection endpoint. This lets MCP clients
+authenticate with an OAuth flow instead of a `chm_` key. See the
+[MCP Server](/docs/reference/mcp-server) reference for details. It uses the same
+`CLERK_SECRET_KEY` as the browser session provider.
+
+---
+
+## Proxy → Cloudflare Access
+
+Set `CHM_AUTH_PROVIDER=proxy` and put the worker behind
+[Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/policies/access/).
+Access authenticates the user and forwards a signed `Cf-Access-Jwt-Assertion`
+JWT, which chmonitor verifies cryptographically against your team's JWKS. No
+shared secret is needed — the signature is the proof.
+
+```bash
+CHM_AUTH_PROVIDER=proxy
+CHM_CF_ACCESS_TEAM_DOMAIN=https://your-team.cloudflareaccess.com
+CHM_CF_ACCESS_AUD=<access-application-aud-tag>
+```
+
+The JWT is validated for: a matching `aud`, an issuer equal to your team
+domain, an unexpired `exp`, and an `RS256` signature from a current Access
+signing key. The authenticated subject is the token's `email` (falling back to
+`sub`). When `CHM_CF_ACCESS_*` are unset, this mechanism is skipped.
+
+---
+
+## Proxy → trusted header + shared secret
+
+Also under `CHM_AUTH_PROVIDER=proxy`. When you front the worker with a proxy
+that performs its own authentication (e.g. nginx + an SSO module), the proxy can
+forward the authenticated identity in a header. Because any client could forge
+such a header on a publicly-reachable worker, the header is trusted **only** when
+the request also presents a shared secret.
+
+```bash
+CHM_AUTH_PROVIDER=proxy
+CHM_PROXY_AUTH_HEADER=X-Forwarded-User          # identity header (default)
+CHM_PROXY_SHARED_SECRET_HEADER=X-Chm-Proxy-Secret  # secret header (default)
+# Set the secret out-of-band, never as a plaintext var:
+#   wrangler secret put CHM_PROXY_AUTH_SECRET
+```
+
+Example nginx config that sets both headers after authenticating the user:
+
+```nginx
+location / {
+  # ...your auth_request / SSO module sets $authenticated_user...
+  proxy_set_header X-Forwarded-User  $authenticated_user;
+  proxy_set_header X-Chm-Proxy-Secret "the-same-long-random-secret";
+  proxy_pass http://chmonitor_upstream;
+}
+```
+
+The shared secret is compared in constant time. Without
+`CHM_PROXY_AUTH_SECRET`, the trusted-header mechanism is disabled and only
+Cloudflare Access (if configured) can authenticate proxy requests.
+
+---
+
+## How enforcement decides
+
+For each `/api/v1/*` request:
+
+1. If `CHM_AUTH_PROVIDER=none` and no `CHM_API_KEY_SECRET` is set → allow (public).
+2. The key-issuance route `/api/v1/auth/api-key` is exempt (it has its own auth).
+3. A valid `chm_` Bearer token → allow.
+4. Otherwise the active provider's check runs; if it authenticates → allow.
+5. Else → `401 { "error": "Authentication required" }`.
+
+All auth paths fail closed: a missing config or verification error resolves to
+"not authenticated" rather than granting access.
+
+See [Environment Variables](/docs/reference/environment-variables#authentication)
+for every variable referenced here.

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -111,17 +111,35 @@ full details.
 
 ---
 
-## Authentication (Clerk)
+## Authentication
 
-Only needed when any feature is set to `access = "authenticated"`.
+The active server-side auth provider is chosen by `CHM_AUTH_PROVIDER`. See the
+[Authentication](/docs/reference/authentication) reference for the full model
+(public, API key, Clerk, and reverse-proxy methods).
 
 | Variable | Default | Description |
 |---|---|---|
-| `CHM_AUTH_PROVIDER` | `none` | Auth provider: `none`, `clerk`. |
+| `CHM_AUTH_PROVIDER` | `none` | Server auth provider: `none`, `clerk`, `proxy`. |
 | `NEXT_PUBLIC_AUTH_PROVIDER` | `none` | Client-side auth provider (mirror `CHM_AUTH_PROVIDER`). |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | — | Clerk publishable key (`pk_...`). |
 | `CLERK_SECRET_KEY` | — | Clerk secret key (`sk_...`). |
-| `CHM_API_KEY_SECRET` | — | Shared secret for `/api/v1/auth/api-key` and MCP auth. |
+| `CHM_API_KEY_SECRET` | — | Shared secret for `chm_` API keys (`/api/v1/auth/api-key` + MCP auth). When set, API-key auth is always on alongside the provider. |
+
+### Reverse proxy (`CHM_AUTH_PROVIDER=proxy`)
+
+Trust a reverse proxy that already authenticated the user. Either mechanism
+below authenticates a request; whichever succeeds first wins.
+
+| Variable | Default | Description |
+|---|---|---|
+| `CHM_CF_ACCESS_TEAM_DOMAIN` | — | Cloudflare Access team URL (`https://<team>.cloudflareaccess.com`). Enables `Cf-Access-Jwt-Assertion` JWT verification. |
+| `CHM_CF_ACCESS_AUD` | — | Access application AUD tag the JWT must carry. |
+| `CHM_PROXY_AUTH_SECRET` | — | Shared secret. When set, a trusted identity header is honored only if the request also presents this secret (constant-time compared). Set via `wrangler secret put`. |
+| `CHM_PROXY_SHARED_SECRET_HEADER` | `X-Chm-Proxy-Secret` | Header the proxy sets to the shared secret. |
+| `CHM_PROXY_AUTH_HEADER` | `X-Forwarded-User` | Header the proxy sets to the authenticated user identity. |
+
+> Without `CHM_PROXY_AUTH_SECRET`, the trusted-header mechanism is **disabled** —
+> any client could forge `X-Forwarded-User` on a publicly-reachable worker.
 
 ---
 

--- a/docs/content/releases/v0-3.mdx
+++ b/docs/content/releases/v0-3.mdx
@@ -1,0 +1,137 @@
+# v0.3 — What's New
+
+v0.3 rebuilds the dashboard on TanStack Start, ships a pluggable authentication
+system, and delivers a batch of monitoring and UI improvements that accumulated
+during the v0.2 cycle.
+
+---
+
+## New framework (TanStack Start)
+
+The dashboard is rewritten on [TanStack Start](https://tanstack.com/start) with
+Vite as the build tool. Every page is pre-rendered at build time so the initial
+shell loads from cache even before ClickHouse is contacted.
+
+- Static prerender for all 75+ dashboard pages.
+- TanStack Query replaces SWR for client-side data fetching.
+- Cloudflare Workers and Docker/Node builds produced from the same source.
+- `NEXT_PUBLIC_*` env vars renamed to `VITE_*`; old names still work as a
+  fallback.
+
+See [Migrate to v0.3](/docs/migrating/v0-3) for the one-step upgrade.
+
+---
+
+## Pluggable authentication
+
+A new server-side auth layer replaces the previous Clerk-only approach. Set
+`CHM_AUTH_PROVIDER` to choose how requests are authenticated:
+
+| Provider | Description |
+|---|---|
+| `none` | Default. Dashboard is open (no login required). |
+| `clerk` | Clerk browser sessions — same as before. |
+| `proxy` | Trust a reverse proxy: Cloudflare Access JWT or a trusted header + shared secret. |
+
+An always-on **API key** layer (`CHM_API_KEY_SECRET`) issues signed `chm_`
+Bearer tokens for scripts and MCP clients, independent of the active provider.
+
+See the [Authentication](/docs/reference/authentication) reference for setup
+details and the decision flow.
+
+---
+
+## Cluster topology visualization
+
+The `/cluster` page is now a live topology diagram.
+
+- Shard and replica nodes are drawn with distinct shapes and the ClickHouse
+  logo.
+- Physical cluster groupings are shown with labeled hull overlays.
+- Nodes are sized and colored by live metrics.
+- Nodes can be toggled on/off; the diagram adjusts height to the data.
+
+---
+
+## Query page improvements
+
+- **Running queries** split into a live "Running" table and a
+  "Recently completed" table with animated row transitions.
+- **Slow, expensive, and failed query** pages redesigned with expand panels,
+  per-column filters, and highlighted columns.
+- **EXPLAIN tree** — the Explain page renders the query plan as an interactive
+  tree instead of raw text. Five explain modes (Plan, Pipeline, AST, Syntax,
+  Estimate).
+- **Request Info dialog** redesigned with formatted SQL and metadata badges.
+
+---
+
+## Table/card layout for all data pages
+
+Every data table now has a card grid view alongside the standard table view.
+Toggle between them per-page. Cards are the default on narrow screens.
+
+- Sitewide card toggle rolls out across all 54 query-config pages (tables,
+  merges, replication, system, diagnostics, keeper, and more).
+- Rich expandable rows let you inspect SQL, metadata, and related actions
+  inline without leaving the page.
+- Mobile layout uses SQL-hero cards so the most important column is always
+  visible.
+
+---
+
+## New monitoring views
+
+Views added from ClickHouse system tables:
+
+- **Kafka consumers** — `system.kafka_consumers` at `/kafka-consumers`.
+- **Part log** — `system.part_log` redesigned with lifecycle charts, KPIs, and
+  a filterable events table.
+- **Query metric log** — `system.query_metric_log` view at `/query-metric-log`.
+- **User processes** — `system.user_processes` with formatted badges and memory
+  bars.
+- **Moves** — `system.moves` at `/moves`.
+- **Dropped tables** — `system.dropped_tables` at `/dropped-tables`.
+- **Warnings** — `system.warnings` at `/warnings`.
+- **Replicated fetches** — `system.replicated_fetches` at `/replicated-fetches`.
+- **Replicated MergeTree settings** — at `/replicated-merge-tree-settings`.
+
+---
+
+## AI agent improvements
+
+- **Conversation titles** auto-generated from the first message.
+- **Findings** — the agent can now record and list persistent findings across
+  sessions.
+- **Workflow harness** — dynamic workflow templates for multi-step analysis.
+- Multi-provider LLM config (`LLM_API_KEY`, `LLM_API_BASE`, `LLM_MODEL`) plus a
+  redesigned chat UI with model selector.
+
+---
+
+## MCP server improvements
+
+- Clerk OAuth login/consent flow for MCP clients — authenticate with an OAuth
+  browser flow instead of a `chm_` key.
+- In-process MCP route in the TanStack app; no separate worker required.
+
+---
+
+## Deployment
+
+- **Helm chart** — a production-ready Helm chart is now vendored in the repo
+  (`deploy/helm/`) alongside kustomize bases.
+- **Kubernetes guide** added to the docs.
+- **Health alerting** — a cron-based health sweep runs automatically and can
+  post alerts.
+- **CSV export** — export any chart card's data directly to a CSV file.
+- **Auto-refresh interval** persisted to `localStorage` across reloads.
+- **Time range** persisted to `localStorage` and synced to the URL.
+
+---
+
+## Breaking changes and upgrading
+
+See [Migrate to v0.3](/docs/migrating/v0-3) for the complete upgrade steps. The
+only change most self-hosters need is a redeploy; the optional `NEXT_PUBLIC_*` →
+`VITE_*` rename is backward-compatible.


### PR DESCRIPTION
## Problem

dash-tsr showed **"Connect a ClickHouse host"** even though hosts are configured. Root cause (confirmed in the live browser — **27× 401** on `/api/v1/*`):

- `CHM_API_KEY_SECRET` is set on the worker → `apiKeyAuthEnabled()` is true → the guard required a `chm_` Bearer on **every** `/api/v1/*` call.
- The browser UI never sends one (`apiFetch` attaches no auth header by design — it holds a **Clerk session**, not an API key).
- So `useHosts` → 401 → `[]` → `FirstRunGate` rendered the first-run empty state.

## Fix (static-UI + data-via-API model, Clerk TanStack Start standard)

- **`start.ts`**: register `clerkMiddleware()` first (the standard) so `auth()` resolves the browser session. Gated on `VITE_AUTH_PROVIDER==='clerk'` **and** `process.env.CLERK_SECRET_KEY` — the secret-key check stops the static **prerender** build (which runs page routes keyless) from throwing `no secret key provided`.
- **`api-guard.ts`**: accept a valid `chm_` API key (curl/programmatic) **OR** a valid Clerk session (browser); else `401 Authentication required`. Static HTML is served by CF Assets and never hits the worker, so only the API is gated.
- **`feature-permissions/server.ts`**: export `isClerkSessionAuthenticated()`.
- **`wrangler.toml` + `patch-wrangler-env.ts`**: add `CLERK_PUBLISHABLE_KEY` worker var (public key; server Clerk reads it from `process.env`).

## UI for login-required mode (signed-out)

- `useHosts`: throw typed `HostsFetchError` on `!ok` (stop swallowing to `[]`), no retry on 401/403, expose `isUnauthorized`.
- `FirstRunGate`: sign-in prompt when unauthorized, not the "configure a host" screen.
- `HostSwitcher`: graceful "Sign in" / "Couldn't load hosts" / "No host" shell instead of `return null`.

## Auth model (answers "how many ways to authenticate")

| Credential | Used by | Accepted by guard |
|---|---|---|
| `chm_` API key (Bearer) | curl / scripts | ✅ |
| Clerk session (cookie) | browser UI | ✅ (new) |
| none | anonymous | ❌ 401 |

## Verification

- `tsc --noEmit` clean; `vite build` green (116 pages prerendered, ~14s).
- Worker bundle **2.42 MB gzipped** (< 3 MiB free-plan limit).
- Browser verification on the preview deploy once CI publishes it.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable server-side authentication: none, Clerk, and reverse-proxy modes
  * API key auth (HMAC-SHA-256) for API access
  * First-run unauthorized UI surface and improved host switcher messaging for auth/loading/failure states

* **Documentation**
  * New authentication reference and updated environment variable docs (proxy settings)
  * Added v0.3 release notes and expanded docs navigation with a Releases section
<!-- end of auto-generated comment: release notes by coderabbit.ai -->