### PR TITLE
fix(release): remove duplicated Git changes and Docker tags from release notes

### DIFF
--- a/scripts/generate-release-notes.ts
+++ b/scripts/generate-release-notes.ts
@@ -1,5 +1,3 @@
-const repo = process.env.GITHUB_REPOSITORY ?? 'duyet/clickhouse-monitoring'
-const tag = process.env.RELEASE_TAG ?? process.env.GITHUB_REF_NAME ?? 'v0.0.0'
 const sha = process.env.GITHUB_SHA ?? ''
 const shortSha = sha.slice(0, 7) || 'unknown'
 const date = new Date().toISOString()

--- a/scripts/generate-release-notes.ts
+++ b/scripts/generate-release-notes.ts
@@ -1,46 +1,13 @@
-import { execFileSync } from 'node:child_process'
-
 const repo = process.env.GITHUB_REPOSITORY ?? 'duyet/clickhouse-monitoring'
 const tag = process.env.RELEASE_TAG ?? process.env.GITHUB_REF_NAME ?? 'v0.0.0'
-const version = tag.replace(/^v/, '')
 const sha = process.env.GITHUB_SHA ?? ''
 const shortSha = sha.slice(0, 7) || 'unknown'
-const image = `ghcr.io/${repo}`
 const date = new Date().toISOString()
-const isPrerelease = version.includes('-')
-const major = version.split('.')[0]
-const minor = version.split('.').slice(0, 2).join('.')
-const stableTagNotes = isPrerelease
-  ? '- Prerelease tags do not update the major or major.minor Docker aliases.'
-  : `- Stable aliases: \`${image}:${minor}\`, \`${image}:${major}\`, and \`${image}:latest\`.`
 
 // AI-generated summary of changes, produced by the GitHub Models action in CI
 // and passed through the AI_SUMMARY env var. Empty when generation is skipped
-// (no models access) so the section is omitted and Git changes remains.
+// (no models access) so the section is omitted.
 const aiSummary = (process.env.AI_SUMMARY ?? '').trim()
-
-function runGit(args: string[]) {
-  try {
-    return execFileSync('git', args, {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim()
-  } catch {
-    return ''
-  }
-}
-
-const previousTag =
-  process.env.PREVIOUS_TAG ||
-  runGit(['describe', '--tags', '--abbrev=0', `${tag}^`]) ||
-  runGit(['describe', '--tags', '--abbrev=0', 'HEAD^'])
-const changeRange = previousTag ? `${previousTag}..HEAD` : 'HEAD'
-const gitChanges =
-  runGit(['log', '--pretty=format:- %s (%h)', changeRange]) ||
-  '- No git changes were detected by the release note generator.'
-const compareUrl = previousTag
-  ? `https://github.com/${repo}/compare/${previousTag}...${tag}`
-  : `https://github.com/${repo}/commits/${tag}`
 
 const summarySection = aiSummary
   ? `## What's changed
@@ -52,17 +19,6 @@ ${aiSummary}
 
 const notes = `Built from commit \`${shortSha}\` on ${date}.
 
-${summarySection}## Published Docker tags
-
-- \`${image}:${version}\`
-${stableTagNotes}
-- Commit tag: \`${image}:sha-${shortSha}\`
-
-## Git changes
-
-${gitChanges}
-
-Complete diff: ${compareUrl}
-`
+${summarySection}`
 
 process.stdout.write(notes)


### PR DESCRIPTION
GitHub auto-generates commit diffs and comparison links on releases. Docker tags are visible in the GitHub Container Registry. Remove both sections and the git subprocess to keep notes minimal: only the build header + AI summary.

**Before:**
```
Built from commit abc1234 on 2026-06-04T...
## What's changed
- ...
## Published Docker tags          ← duplicated (GHCR shows these)
- ghcr.io/...:0.3.0
## Git changes                    ← duplicated (GitHub auto-generates)
- commit messages...
Complete diff: https://...
```

**After:**
```
Built from commit abc1234 on 2026-06-04T...
## What's changed
- ...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified release notes generation to focus on commit information and AI-generated summaries, removing ancillary build details from the output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->