### PR TITLE
fix(dashboard-tsr): populate client chart-component registry (71 charts) (#1392)

### DIFF
--- a/apps/dashboard-tsr/src/components/charts/registry/imports/logs-charts.ts
+++ b/apps/dashboard-tsr/src/components/charts/registry/imports/logs-charts.ts
@@ -1,3 +1,27 @@
+/**
+ * Logs chart imports
+ *
+ * Lazy-loaded logging and error tracking charts.
+ */
+
 import type { ChartRegistryMap } from '../types'
 
-export const logsChartImports: ChartRegistryMap = {}
+import { lazy } from 'react'
+
+export const logsChartImports: ChartRegistryMap = {
+  'log-level-distribution': lazy(() =>
+    import('@/components/charts/logs/log-level-distribution').then((m) => ({
+      default: m.ChartLogLevelDistribution,
+    }))
+  ),
+  'error-rate-over-time': lazy(() =>
+    import('@/components/charts/logs/error-rate-over-time').then((m) => ({
+      default: m.ChartErrorRateOverTime,
+    }))
+  ),
+  'crash-frequency': lazy(() =>
+    import('@/components/charts/logs/crash-frequency').then((m) => ({
+      default: m.ChartCrashFrequency,
+    }))
+  ),
+}

--- a/apps/dashboard-tsr/src/components/charts/registry/imports/merge-charts.ts
+++ b/apps/dashboard-tsr/src/components/charts/registry/imports/merge-charts.ts
@@ -1,3 +1,37 @@
+/**
+ * Merge chart imports
+ *
+ * Lazy-loaded merge operation charts.
+ */
+
 import type { ChartRegistryMap } from '../types'
 
-export const mergeChartImports: ChartRegistryMap = {}
+import { lazy } from 'react'
+
+export const mergeChartImports: ChartRegistryMap = {
+  'merge-count': lazy(() =>
+    import('@/components/charts/merge/merge-count').then((m) => ({
+      default: m.ChartMergeCount,
+    }))
+  ),
+  'summary-used-by-merges': lazy(() =>
+    import('@/components/charts/merge/summary-used-by-merges').then((m) => ({
+      default: m.default,
+    }))
+  ),
+  'merge-avg-duration': lazy(() =>
+    import('@/components/charts/merge/merge-avg-duration').then((m) => ({
+      default: m.ChartMergeAvgDuration,
+    }))
+  ),
+  'merge-sum-read-rows': lazy(() =>
+    import('@/components/charts/merge/merge-sum-read-rows').then((m) => ({
+      default: m.ChartMergeSumReadRows,
+    }))
+  ),
+  'new-parts-created': lazy(() =>
+    import('@/components/charts/merge/new-parts-created').then((m) => ({
+      default: m.ChartNewPartsCreated,
+    }))
+  ),
+}

--- a/apps/dashboard-tsr/src/components/charts/registry/imports/misc-charts.ts
+++ b/apps/dashboard-tsr/src/components/charts/registry/imports/misc-charts.ts
@@ -1,3 +1,95 @@
+/**
+ * Miscellaneous chart imports
+ *
+ * Lazy-loaded charts that don't fit into specific categories.
+ */
+
 import type { ChartRegistryMap } from '../types'
 
-export const miscChartImports: ChartRegistryMap = {}
+import { lazy } from 'react'
+
+export const miscChartImports: ChartRegistryMap = {
+  // Mutation Charts
+  'summary-used-by-mutations': lazy(() =>
+    import('@/components/charts/summary-used-by-mutations').then((m) => ({
+      default: m.ChartSummaryUsedByMutations,
+    }))
+  ),
+  'summary-stuck-mutations': lazy(() =>
+    import('@/components/charts/summary-stuck-mutations').then((m) => ({
+      default: m.ChartSummaryStuckMutations,
+    }))
+  ),
+
+  // Running Queries Charts
+  'summary-used-by-running-queries': lazy(() =>
+    import('@/components/charts/summary-used-by-running-queries').then((m) => ({
+      default: m.default,
+    }))
+  ),
+
+  // Connection Charts
+  'connections-interserver': lazy(() =>
+    import('@/components/charts/connections-interserver').then((m) => ({
+      default: m.ChartConnectionsInterserver,
+    }))
+  ),
+  'connections-http': lazy(() =>
+    import('@/components/charts/connections-http').then((m) => ({
+      default: m.ChartConnectionsHttp,
+    }))
+  ),
+  'connections-pool': lazy(() =>
+    import('@/components/charts/connections-pool').then((m) => ({
+      default: m.ChartConnectionsPool,
+    }))
+  ),
+
+  // Table Charts
+  'top-table-size': lazy(() =>
+    import('@/components/charts/top-table-size').then((m) => ({
+      default: m.default,
+    }))
+  ),
+  'parts-per-table': lazy(() =>
+    import('@/components/charts/parts-per-table').then((m) => ({
+      default: m.ChartPartsPerTable,
+    }))
+  ),
+
+  // Page Views Charts
+  'page-view': lazy(() =>
+    import('@/components/charts/page-view').then((m) => ({
+      default: m.PageViewBarChart,
+    }))
+  ),
+
+  // Dictionary Charts
+  'dictionary-count': lazy(() =>
+    import('@/components/charts/dictionary-count').then((m) => ({
+      default: m.ChartDictionaryCount,
+    }))
+  ),
+
+  // Page Analytics Charts
+  'top-pages': lazy(() =>
+    import('@/components/charts/top-pages').then((m) => ({
+      default: m.TopPagesChart,
+    }))
+  ),
+  'human-vs-bot-pageviews': lazy(() =>
+    import('@/components/charts/human-vs-bot-pageviews').then((m) => ({
+      default: m.HumanVsBotPageviewsChart,
+    }))
+  ),
+  'pageviews-by-device': lazy(() =>
+    import('@/components/charts/pageviews-by-device').then((m) => ({
+      default: m.PageviewsByDeviceChart,
+    }))
+  ),
+  'pageviews-by-country': lazy(() =>
+    import('@/components/charts/pageviews-by-country').then((m) => ({
+      default: m.PageviewsByCountryChart,
+    }))
+  ),
+}

--- a/apps/dashboard-tsr/src/components/charts/registry/imports/query-charts.ts
+++ b/apps/dashboard-tsr/src/components/charts/registry/imports/query-charts.ts
@@ -1,3 +1,81 @@
+/**
+ * Query chart imports
+ *
+ * Lazy-loaded query-related charts.
+ */
+
 import type { ChartRegistryMap } from '../types'
 
-export const queryChartImports: ChartRegistryMap = {}
+import { lazy } from 'react'
+
+export const queryChartImports: ChartRegistryMap = {
+  'query-count': lazy(() =>
+    import('@/components/charts/query/query-count').then((m) => ({
+      default: m.ChartQueryCount,
+    }))
+  ),
+  'query-count-by-user': lazy(() =>
+    import('@/components/charts/query/query-count-by-user').then((m) => ({
+      default: m.ChartQueryCountByUser,
+    }))
+  ),
+  'query-duration': lazy(() =>
+    import('@/components/charts/query/query-duration').then((m) => ({
+      default: m.ChartQueryDuration,
+    }))
+  ),
+  'query-memory': lazy(() =>
+    import('@/components/charts/query/query-memory').then((m) => ({
+      default: m.ChartQueryMemory,
+    }))
+  ),
+  'query-type': lazy(() =>
+    import('@/components/charts/query/query-type').then((m) => ({
+      default: m.ChartQueryType,
+    }))
+  ),
+  'failed-query-count': lazy(() =>
+    import('@/components/charts/query/failed-query-count').then((m) => ({
+      default: m.ChartFailedQueryCount,
+    }))
+  ),
+  'failed-query-count-by-user': lazy(() =>
+    import('@/components/charts/query/failed-query-count-by-user').then(
+      (m) => ({
+        default: m.ChartFailedQueryCountByUser,
+      })
+    )
+  ),
+  'query-cache': lazy(() =>
+    import('@/components/charts/query/query-cache').then((m) => ({
+      default: m.ChartQueryCache,
+    }))
+  ),
+  'top-query-fingerprints': lazy(() =>
+    import('@/components/charts/query/top-query-fingerprints').then((m) => ({
+      default: m.ChartTopQueryFingerprints,
+    }))
+  ),
+  'cancelled-queries': lazy(() =>
+    import('@/components/charts/query/cancelled-queries').then((m) => ({
+      default: m.ChartCancelledQueries,
+    }))
+  ),
+  'query-duration-percentiles': lazy(() =>
+    import('@/components/charts/query/query-duration-percentiles').then(
+      (m) => ({
+        default: m.ChartQueryDurationPercentiles,
+      })
+    )
+  ),
+  'slow-query-occurrences': lazy(() =>
+    import('@/components/charts/query/slow-query-occurrences').then((m) => ({
+      default: m.ChartSlowQueryOccurrences,
+    }))
+  ),
+  'query-count-heatmap': lazy(() =>
+    import('@/components/charts/query/query-count-heatmap').then((m) => ({
+      default: m.ChartQueryCountHeatmap,
+    }))
+  ),
+}

--- a/apps/dashboard-tsr/src/components/charts/registry/imports/query-perf-charts.ts
+++ b/apps/dashboard-tsr/src/components/charts/registry/imports/query-perf-charts.ts
@@ -1,3 +1,38 @@
+/**
+ * Query performance chart imports
+ *
+ * Lazy-loaded charts for insert throughput and top inserters.
+ */
+
 import type { ChartRegistryMap } from '../types'
 
-export const queryPerfChartImports: ChartRegistryMap = {}
+import { lazy } from 'react'
+
+export const queryPerfChartImports: ChartRegistryMap = {
+  'insert-performance': lazy(() =>
+    import('@/components/charts/query-performance/insert-performance').then(
+      (m) => ({
+        default: m.ChartInsertPerformance,
+      })
+    )
+  ),
+  'top-inserters': lazy(() =>
+    import('@/components/charts/query-performance/top-inserters').then((m) => ({
+      default: m.ChartTopInserters,
+    }))
+  ),
+  'top-query-fingerprints-perf': lazy(() =>
+    import('@/components/charts/query-performance/top-query-fingerprints').then(
+      (m) => ({
+        default: m.ChartTopQueryFingerprints,
+      })
+    )
+  ),
+  'query-duration-trend': lazy(() =>
+    import('@/components/charts/query-performance/query-duration-trend').then(
+      (m) => ({
+        default: m.ChartQueryDurationTrend,
+      })
+    )
+  ),
+}

--- a/apps/dashboard-tsr/src/components/charts/registry/imports/replication-charts.ts
+++ b/apps/dashboard-tsr/src/components/charts/registry/imports/replication-charts.ts
@@ -1,3 +1,36 @@
+/**
+ * Replication chart imports
+ *
+ * Lazy-loaded replication-related charts.
+ */
+
 import type { ChartRegistryMap } from '../types'
 
-export const replicationChartImports: ChartRegistryMap = {}
+import { lazy } from 'react'
+
+export const replicationChartImports: ChartRegistryMap = {
+  'replication-queue-count': lazy(() =>
+    import('@/components/charts/replication/replication-queue-count').then(
+      (m) => ({
+        default: m.default,
+      })
+    )
+  ),
+  'replication-summary-table': lazy(() =>
+    import('@/components/charts/replication/replication-summary-table').then(
+      (m) => ({
+        default: m.default,
+      })
+    )
+  ),
+  'readonly-replica': lazy(() =>
+    import('@/components/charts/replication/readonly-replica').then((m) => ({
+      default: m.ChartReadonlyReplica,
+    }))
+  ),
+  'replication-lag': lazy(() =>
+    import('@/components/charts/replication/replication-lag').then((m) => ({
+      default: m.ChartReplicationLag,
+    }))
+  ),
+}

--- a/apps/dashboard-tsr/src/components/charts/registry/imports/security-charts.ts
+++ b/apps/dashboard-tsr/src/components/charts/registry/imports/security-charts.ts
@@ -1,3 +1,22 @@
+/**
+ * Security chart imports
+ *
+ * Lazy-loaded authentication and session monitoring charts.
+ */
+
 import type { ChartRegistryMap } from '../types'
 
-export const securityChartImports: ChartRegistryMap = {}
+import { lazy } from 'react'
+
+export const securityChartImports: ChartRegistryMap = {
+  'login-success-rate': lazy(() =>
+    import('@/components/charts/security/login-success-rate').then((m) => ({
+      default: m.ChartLoginSuccessRate,
+    }))
+  ),
+  'active-sessions-count': lazy(() =>
+    import('@/components/charts/security/active-sessions-count').then((m) => ({
+      default: m.ChartActiveSessionsCount,
+    }))
+  ),
+}

--- a/apps/dashboard-tsr/src/components/charts/registry/imports/system-charts.ts
+++ b/apps/dashboard-tsr/src/components/charts/registry/imports/system-charts.ts
@@ -1,3 +1,97 @@
+/**
+ * System chart imports
+ *
+ * Lazy-loaded system metric charts.
+ */
+
 import type { ChartRegistryMap } from '../types'
 
-export const systemChartImports: ChartRegistryMap = {}
+import { lazy } from 'react'
+
+export const systemChartImports: ChartRegistryMap = {
+  'disk-size': lazy(() =>
+    import('@/components/charts/system/disk-size').then((m) => ({
+      default: m.ChartDiskSize,
+    }))
+  ),
+  'disk-usage-trend': lazy(() =>
+    import('@/components/charts/system/disk-usage-trend').then((m) => ({
+      default: m.ChartDiskUsageTrend,
+    }))
+  ),
+  'disks-usage': lazy(() =>
+    import('@/components/charts/system/disks-usage').then((m) => ({
+      default: m.ChartDisksUsage,
+    }))
+  ),
+  'backup-size': lazy(() =>
+    import('@/components/charts/system/backup-size').then((m) => ({
+      default: m.ChartBackupSize,
+    }))
+  ),
+  'memory-usage': lazy(() =>
+    import('@/components/charts/system/memory-usage').then((m) => ({
+      default: m.ChartMemoryUsage,
+    }))
+  ),
+  'cpu-usage': lazy(() =>
+    import('@/components/charts/system/cpu-usage').then((m) => ({
+      default: m.ChartCPUUsage,
+    }))
+  ),
+  'disk-usage-by-database': lazy(() =>
+    import('@/components/charts/system/disk-usage-by-database').then((m) => ({
+      default: m.ChartDiskUsageByDatabase,
+    }))
+  ),
+  'data-freshness': lazy(() =>
+    import('@/components/charts/system/data-freshness').then((m) => ({
+      default: m.ChartDataFreshness,
+    }))
+  ),
+  'compression-ratio': lazy(() =>
+    import('@/components/charts/system/compression-ratio').then((m) => ({
+      default: m.ChartCompressionRatio,
+    }))
+  ),
+  'partition-part-health': lazy(() =>
+    import('@/components/charts/system/partition-part-health').then((m) => ({
+      default: m.ChartPartitionPartHealth,
+    }))
+  ),
+  'oom-killed-queries': lazy(() =>
+    import('@/components/charts/system/oom-killed-queries').then((m) => ({
+      default: m.ChartOomKilledQueries,
+    }))
+  ),
+  'top-memory-queries': lazy(() =>
+    import('@/components/charts/system/top-memory-queries').then((m) => ({
+      default: m.ChartTopMemoryQueries,
+    }))
+  ),
+  'mutation-progress': lazy(() =>
+    import('@/components/charts/system/mutation-progress').then((m) => ({
+      default: m.ChartMutationProgress,
+    }))
+  ),
+  'keeper-requests': lazy(() =>
+    import('@/components/charts/system/keeper-requests').then((m) => ({
+      default: m.ChartKeeperRequests,
+    }))
+  ),
+  'keeper-wait-time': lazy(() =>
+    import('@/components/charts/system/keeper-wait-time').then((m) => ({
+      default: m.ChartKeeperWaitTime,
+    }))
+  ),
+  'disk-io-throughput': lazy(() =>
+    import('@/components/charts/system/disk-io-throughput').then((m) => ({
+      default: m.ChartDiskIOThroughput,
+    }))
+  ),
+  'storage-policies': lazy(() =>
+    import('@/components/charts/system/storage-policies').then((m) => ({
+      default: m.ChartStoragePolicies,
+    }))
+  ),
+}

--- a/apps/dashboard-tsr/src/components/charts/registry/imports/thread-charts.ts
+++ b/apps/dashboard-tsr/src/components/charts/registry/imports/thread-charts.ts
@@ -1,3 +1,17 @@
+/**
+ * Thread chart imports
+ *
+ * Lazy-loaded thread performance and utilization charts.
+ */
+
 import type { ChartRegistryMap } from '../types'
 
-export const threadChartImports: ChartRegistryMap = {}
+import { lazy } from 'react'
+
+export const threadChartImports: ChartRegistryMap = {
+  'thread-utilization': lazy(() =>
+    import('@/components/charts/threads/thread-utilization').then((m) => ({
+      default: m.ChartThreadUtilization,
+    }))
+  ),
+}

--- a/apps/dashboard-tsr/src/components/charts/registry/imports/zookeeper-charts.ts
+++ b/apps/dashboard-tsr/src/components/charts/registry/imports/zookeeper-charts.ts
@@ -1,3 +1,56 @@
+/**
+ * ZooKeeper chart imports
+ *
+ * Lazy-loaded ZooKeeper-related charts.
+ */
+
 import type { ChartRegistryMap } from '../types'
 
-export const zookeeperChartImports: ChartRegistryMap = {}
+import { lazy } from 'react'
+
+export const zookeeperChartImports: ChartRegistryMap = {
+  'zookeeper-summary-table': lazy(() =>
+    import('@/components/charts/zookeeper/zookeeper-summary-table').then(
+      (m) => ({
+        default: m.default,
+      })
+    )
+  ),
+  'zookeeper-uptime': lazy(() =>
+    import('@/components/charts/zookeeper/zookeeper-uptime').then((m) => ({
+      default: m.ChartZookeeperUptime,
+    }))
+  ),
+  'zookeeper-requests': lazy(() =>
+    import('@/components/charts/zookeeper/zookeeper-requests').then((m) => ({
+      default: m.default,
+    }))
+  ),
+  'zookeeper-wait': lazy(() =>
+    import('@/components/charts/zookeeper/zookeeper-wait').then((m) => ({
+      default: m.default,
+    }))
+  ),
+  'zookeeper-exception': lazy(() =>
+    import('@/components/charts/zookeeper/zookeeper-exception').then((m) => ({
+      default: m.ChartKeeperException,
+    }))
+  ),
+  'keeper-operation-mix': lazy(() =>
+    import('@/components/charts/zookeeper/keeper-operation-mix').then((m) => ({
+      default: m.default,
+    }))
+  ),
+  'keeper-bytes': lazy(() =>
+    import('@/components/charts/zookeeper/keeper-bytes').then((m) => ({
+      default: m.default,
+    }))
+  ),
+  'keeper-connection-events': lazy(() =>
+    import('@/components/charts/zookeeper/keeper-connection-events').then(
+      (m) => ({
+        default: m.default,
+      })
+    )
+  ),
+}


### PR DESCRIPTION
## Problem

Across query pages (`/history-queries`, `/failed-queries`, `/slow-queries`, …) every chart rendered a placeholder:

```
Unknown chart: query-count
Unknown chart: query-duration-percentiles
Unknown chart: top-query-fingerprints
Unknown chart: failed-query-count
Unknown chart: slow-query-occurrences
...
```

## Root cause

`apps/dashboard-tsr/src/components/charts/registry/imports/*.ts` — the 10 lazy-component import maps — were **all ported as empty objects** (`export const xChartImports: ChartRegistryMap = {}`). So the combined `chartImports` registry was empty and `getChartComponent(name)` returned `undefined`, making `<DynamicChart>` show "Unknown chart" for every name.

This is the **same dead-registry gap as the API chart-registry (#1441), one layer up**: that map binds names → SQL builders; this one binds names → lazy React components. Both were stubbed empty during the TSR port.

## Fix

Populate all 10 import modules from the original `apps/dashboard` composition — **71 charts** (query, query-perf, merge, system, replication, zookeeper, logs, threads, security, misc). The chart component `.tsx` files were already ported; only the registry wiring was missing. Repointed only the `ChartRegistryMap` types import (`@/…/registry/types` → `../types`); the `@/components/charts/**` lazy-import paths resolve unchanged (`@/*` → `./src/*`).

## Verification

- `bun run type-check` → 0 errors.
- Client registry **0 → 71 components**; all reported names resolve via `hasChart()`/`getChartComponent()`.
- Validated every referenced component path + export exists (60 named + 11 default exports).
- Complete `relatedCharts` + `chartName` reference sweep: all real referenced charts are now registered.

## Pre-existing (NOT introduced here)

Two `relatedCharts` refs point at charts that have API/SQL but **no React component** — dangling in `apps/dashboard` too:
- `failed-login-by-user` — `security/login-attempts.ts`
- `parallelization-efficiency` — `queries/parallelization.ts`, `queries/thread-analysis.ts`

These render "Unknown chart" in the original dashboard as well. Flagged for a follow-up (generic API-driven renderer, or remove the dangling refs).

Part of #1392 (TSR migration). With #1441 (API registry) this restores the full chart surface on `dash-tsr` before the #1405 production cutover.

Co-Authored-By: duyetbot <bot@duyet.net>