### PR TITLE
fix(dashboard-tsr): wire table filterSchema + restore actions feature-auth (#1392)

### DIFF
--- a/apps/dashboard-tsr/src/lib/api/table-registry.ts
+++ b/apps/dashboard-tsr/src/lib/api/table-registry.ts
@@ -9,14 +9,19 @@
  * - The source list is `queries` from `@/lib/query-config` (empty until the
  *   54 configs are ported). `registerTableConfig` lets ported modules add
  *   configs without editing this file.
- * - The dashboard's schema-driven `filterSchema` WHERE-clause injection
- *   (filters/url-state + filters/where-builder) is DEFERRED — those modules
- *   are not ported. Until then, params come from defaultParams + raw search
- *   params, exactly like the dashboard's non-filterSchema branch.
+ * - Schema-driven `filterSchema` WHERE-clause injection (filters/url-state +
+ *   filters/where-builder) is wired in `getTableQuery` below, matching the
+ *   dashboard. Configs without a filterSchema fall through to the plain
+ *   defaultParams + raw search-params path.
  */
 
 import type { QueryConfig } from '@/lib/query-config'
 
+import { parseFiltersFromParams } from '@/lib/filters/url-state'
+import {
+  applyFilterPlaceholder,
+  buildWhereClause,
+} from '@/lib/filters/where-builder'
 import { getSqlForDisplay, queries } from '@/lib/query-config'
 
 /** Params for building a table query. */
@@ -65,6 +70,38 @@ export function getTableQuery(
 ): TableQueryResult | null {
   const queryConfig = tableRegistry.get(name)
   if (!queryConfig) return null
+
+  // Schema-driven dynamic filtering: parse + validate active filters against
+  // the config's filterSchema, then inject a parameterized WHERE clause into
+  // the `/* __FILTERS__ */` placeholder. The resolved config (clause baked in)
+  // is returned so the executor's version selection runs on the filtered SQL,
+  // not the bare template.
+  if (queryConfig.filterSchema) {
+    const urlParams = new URLSearchParams(params.searchParams ?? {})
+    const activeFilters = parseFiltersFromParams(
+      queryConfig.filterSchema,
+      urlParams
+    )
+    const { clause, params: filterParams } = buildWhereClause(
+      queryConfig.filterSchema,
+      activeFilters
+    )
+    const resolvedConfig: QueryConfig = {
+      ...queryConfig,
+      sql: applyFilterPlaceholder(queryConfig.sql, clause),
+    }
+    const mergedParams = {
+      ...(resolvedConfig.defaultParams ?? {}),
+      ...filterParams,
+    }
+
+    return {
+      query: getSqlForDisplay(resolvedConfig.sql),
+      queryParams:
+        Object.keys(mergedParams).length > 0 ? mergedParams : undefined,
+      queryConfig: resolvedConfig,
+    }
+  }
 
   // Start from the config's default params, then layer URL search params.
   const queryParams: Record<string, unknown> = {

--- a/apps/dashboard-tsr/src/lib/query-config/types.ts
+++ b/apps/dashboard-tsr/src/lib/query-config/types.ts
@@ -5,9 +5,10 @@
  * *foundation* surface: the fields the server-side query executor and the
  * registries actually consume. The dashboard's full QueryConfig couples to
  * web-app-only types (ChartProps, CustomSortingFnNames, FeaturePermission,
- * FilterSchema, ColumnFormat) that belong to the not-yet-ported component /
- * data-table layer. Those UI-formatting fields are DEFERRED and intentionally
- * omitted here so this module has zero dependencies on un-ported app code.
+ * ColumnFormat) that belong to the not-yet-ported component / data-table
+ * layer. Those UI-formatting fields are DEFERRED and intentionally omitted
+ * here. `filterSchema` IS included — it drives server-side WHERE injection
+ * (see the table registry), and `@/lib/filters/types` is ported.
  *
  * VersionedSql / QueryConfigVariant / getAllSqlStrings come from
  * @chm/sql-builder (aliased to source in tsconfig.json) so this app never
@@ -17,6 +18,7 @@
 import type { ClickHouseSettings } from '@clickhouse/client'
 
 import type { QueryConfigVariant, VersionedSql } from '@chm/sql-builder'
+import type { FilterSchema } from '@/lib/filters/types'
 
 // Re-export the version-compat SQL primitives from the shared package so
 // `@/lib/query-config/types` consumers can import them from one place,
@@ -77,6 +79,13 @@ export interface QueryConfig<TColumns extends readonly string[] = string[]> {
    * are auto-extracted from the SQL by the underlying validator.
    */
   tableCheck?: string | string[]
+  /**
+   * Schema-driven dynamic filtering. When present, the table registry parses
+   * active filters from URL params against this schema and injects a
+   * parameterized WHERE clause into the SQL's `/* __FILTERS__ *​/` placeholder.
+   * The schema is the trusted SQL source (column UI is sugar over it).
+   */
+  filterSchema?: FilterSchema
   /** Disable SQL validation (used by the query-config test suite). */
   disableSqlValidation?: boolean
   /** Optional docs URL surfaced on query error. */

--- a/apps/dashboard-tsr/src/routes/api/v1/actions.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/actions.ts
@@ -13,6 +13,8 @@ import { env } from 'cloudflare:workers'
 import { fetchData } from '@chm/clickhouse-client'
 import { ErrorLogger, log } from '@chm/logger'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { ACTIONS_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 
 // --- Inline ActionSchema (not yet ported to TSR lib/api/schemas) ---
 
@@ -162,6 +164,19 @@ export const Route = createFileRoute('/api/v1/actions')({
     handlers: {
       POST: async ({ request }) => {
         bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        // Feature-permission gate: mutating actions (KILL QUERY / OPTIMIZE
+        // TABLE) honor CHM_FEATURE_ACTIONS_ACCESS / disabled-feature config
+        // independently of the global API guard. The global guard is a
+        // public passthrough under provider='none', so without this an
+        // operator who sets actions to `authenticated`/disabled would be
+        // silently ignored (anonymous mutating actions). Matches the
+        // dashboard route.
+        const permissionResponse = await authorizeFeatureRequest(
+          ACTIONS_FEATURE_PERMISSION,
+          request
+        )
+        if (permissionResponse) return permissionResponse
 
         const requestId = generateRequestId()
 

--- a/apps/dashboard-tsr/src/routes/api/v1/tables/$name.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/tables/$name.ts
@@ -11,7 +11,7 @@ import { error } from '@chm/logger'
 import { executeTableConfig } from '@/lib/api/query-executor'
 import {
   getAvailableTables,
-  getTableConfig,
+  getTableQuery,
   hasTable,
 } from '@/lib/api/table-registry'
 
@@ -51,8 +51,21 @@ export const Route = createFileRoute('/api/v1/tables/$name')({
           )
         }
 
-        const config = getTableConfig(name)
-        if (!config) {
+        // Resolve the runnable query via the registry. This applies the
+        // config's schema-driven filterSchema WHERE injection (history-queries,
+        // running-queries) and merges defaultParams + filter params. Configs
+        // without a filterSchema get the plain defaultParams + search-params
+        // merge.
+        const searchParamsObj: Record<string, string> = {}
+        for (const [key, value] of searchParams.entries()) {
+          if (key === 'hostId') continue
+          searchParamsObj[key] = value
+        }
+        const queryDef = getTableQuery(name, {
+          hostId,
+          searchParams: searchParamsObj,
+        })
+        if (!queryDef) {
           return Response.json(
             {
               success: false,
@@ -64,15 +77,10 @@ export const Route = createFileRoute('/api/v1/tables/$name')({
             { status: 500 }
           )
         }
-
-        // Build query params: config defaults first, then URL params override
-        const queryParams: Record<string, unknown> = {
-          ...(config.defaultParams ?? {}),
-        }
-        for (const [key, value] of searchParams.entries()) {
-          if (key === 'hostId') continue
-          queryParams[key] = value
-        }
+        // The resolved config carries the filter-injected SQL; execution runs
+        // version selection on it.
+        const config = queryDef.queryConfig
+        const queryParams = queryDef.queryParams
 
         // Validate timezone
         const timezoneParam = searchParams.get('timezone') || undefined


### PR DESCRIPTION
Two real functional regressions found comparing `apps/dashboard-tsr` against `apps/dashboard` — both block the #1405 production cutover. Found via a systematic old-vs-new audit (agent + MCP subsystems were also audited and are at **full parity**, no changes needed).

## 1. Table filter schema silently dropped 🔴 (user-visible)

`routes/api/v1/tables/$name.ts` bypassed `getTableQuery`, so the schema-driven `filterSchema` → WHERE injection never ran. Result:
- **History Queries / Running Queries filters were ignored** — the UI showed active filter chips but returned unfiltered data.
- The `/* __FILTERS__ */` placeholder survived as a no-op SQL comment.
- The default `excluded_users` exclusion (`CLICKHOUSE_EXCLUDE_USER_DEFAULT`) was lost, so service-user noise reappeared.
- `where-builder.ts` / `url-state.ts` were present but had **zero importers**.

**Fix:**
- Add the `filterSchema` branch to `getTableQuery` (parse → `buildWhereClause` → `applyFilterPlaceholder`, return resolved config with the clause baked in).
- Change the table route to call `getTableQuery` so version selection runs on the filtered SQL.
- Add `filterSchema?: FilterSchema` to the `QueryConfig` type (`@/lib/filters/types` is ported).

**Verified:** `?user=in:default,monitoring&query=contains:select` →
```
WHERE user IN ({flt_0:String}, {flt_1:String})
  AND positionCaseInsensitiveUTF8(toString(query), {flt_2:String}) > 0
```
params `{flt_0:default, flt_1:monitoring, flt_2:select}` — parameterized, injection-safe, matches the dashboard.

## 2. Actions feature-auth dropped 🟡 (config-gated)

`routes/api/v1/actions.ts` (KILL QUERY / OPTIMIZE TABLE) lost `authorizeFeatureRequest(ACTIONS_FEATURE_PERMISSION)`. No-op in the default config, but under `provider='none'` an operator who sets `CHM_FEATURE_ACTIONS_ACCESS=authenticated` / disabled was **silently ignored** → anonymous mutating actions. Restored the gate at the top of the POST handler, matching the dashboard route. (SQL-injection guard, dashboard allowlist, and identifier validation were already at parity.)

## Verification
- `bun run type-check` → 0 errors.
- Filter wiring functionally tested (WHERE clause + bound params).

Part of #1392. Closes the last two functional gaps before the #1405 cutover.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled schema-driven dynamic filtering for table queries, allowing URL-based filter parameters to be parsed and applied to queries
  * Added feature-permission authorization gate for mutating actions to enforce access control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->