### PR TITLE
fix(dashboard-tsr): enforce chart feature perms + port deprecated chart variants (#1392)

### DIFF
--- a/apps/dashboard-tsr/src/lib/api/chart-registry.ts
+++ b/apps/dashboard-tsr/src/lib/api/chart-registry.ts
@@ -15,6 +15,7 @@
  */
 
 import type { VersionedSql } from '@chm/sql-builder'
+import type { FeaturePermission } from '@/lib/feature-permissions/types'
 import type { ClickHouseInterval } from './query-executor'
 
 import { connectionCharts } from './charts/connection-charts'
@@ -65,12 +66,20 @@ export interface ChartQueryResult<_T extends ChartDataPoint = ChartDataPoint> {
   optional?: boolean
   tableCheck?: string | string[]
   cachePolicy?: CachePolicy
+  /**
+   * Deployment-level feature gate (e.g. METRICS_PERMISSION on system charts).
+   * The route enforces it via `authorizeFeatureRequest` before executing, so
+   * `CHM_DISABLED_FEATURES` / `CHM_AUTH_REQUIRED_FEATURES` are honored.
+   */
+  permission?: FeaturePermission
 }
 
 /** Multi-query chart result (executed in parallel, keyed). */
 export interface MultiChartQueryResult {
   queries: Array<{ key: string; query: string; optional?: boolean }>
   cachePolicy?: CachePolicy
+  /** Deployment-level feature gate; enforced by the route before executing. */
+  permission?: FeaturePermission
 }
 
 /** A chart builder maps params to a (multi-)query result. */

--- a/apps/dashboard-tsr/src/lib/api/charts/merge-charts.ts
+++ b/apps/dashboard-tsr/src/lib/api/charts/merge-charts.ts
@@ -45,12 +45,14 @@ export const mergeCharts: Record<string, ChartQueryBuilder> = {
   `,
       optional: true,
       tableCheck: 'system.metric_log',
-      // Query variants for different ClickHouse versions
-      variants: [
+      // metric_log exists from v20.5; older versions fall back to the
+      // point-in-time system.metrics. VersionedSql picks the highest `since`
+      // <= CH version (first/oldest entry is the unknown-version fallback).
+      // Replaces the deprecated `variants` form (not selected by the executor).
+      sql: [
         {
-          // For very old versions without metric_log, provide current values only
-          versions: { maxVersion: '20.5' },
-          query: `
+          since: '1.0',
+          sql: `
     SELECT
       now() AS event_time,
       toFloat64(value) AS avg_CurrentMetric_Merge,
@@ -66,8 +68,19 @@ export const mergeCharts: Record<string, ChartQueryBuilder> = {
     WHERE metric = 'PartMutation'
     ORDER BY event_time
         `,
-          description:
-            'Fallback for pre-20.5: returns current merge count only (no history)',
+        },
+        {
+          since: '20.5',
+          sql: `
+    SELECT ${applyInterval(interval, 'event_time')},
+           avg(CurrentMetric_Merge) AS avg_CurrentMetric_Merge,
+           avg(CurrentMetric_PartMutation) AS avg_CurrentMetric_PartMutation
+    FROM merge('system', '^metric_log')
+    ${timeFilter ? `WHERE ${timeFilter}` : ''}
+    GROUP BY 1
+    ORDER BY 1
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+  `,
         },
       ],
     }

--- a/apps/dashboard-tsr/src/lib/api/charts/query-charts.ts
+++ b/apps/dashboard-tsr/src/lib/api/charts/query-charts.ts
@@ -137,7 +137,10 @@ export const queryCharts: Record<string, ChartQueryBuilder> = {
   `,
   }),
 
-  // v24.1+: Query cache usage stats from query_log
+  // query_cache_usage column only exists from v24.1. VersionedSql picks the
+  // highest `since` <= CH version; the first (oldest) entry is the fallback for
+  // older / unknown versions. (Replaces the deprecated `variants` form, which
+  // the TSR executor does not select.)
   'query-cache-usage': ({ lastHours = 24 * 7 }) => {
     const timeFilter = buildTimeFilter(lastHours)
     return {
@@ -152,12 +155,24 @@ export const queryCharts: Record<string, ChartQueryBuilder> = {
     GROUP BY query_cache_usage
     ORDER BY query_count DESC
   `,
-      // Fallback for pre-24.1 versions
-      variants: [
+      sql: [
         {
-          versions: { maxVersion: '24.1' },
-          query: `SELECT 'Not available' AS query_cache_usage, 0 AS query_count, 0 AS percentage`,
-          description: 'query_cache_usage column not available before v24.1',
+          since: '1.0',
+          sql: `SELECT 'Not available' AS query_cache_usage, 0 AS query_count, 0 AS percentage`,
+        },
+        {
+          since: '24.1',
+          sql: `
+    SELECT
+      query_cache_usage,
+      COUNT() AS query_count,
+      round(100 * query_count / sum(query_count) OVER (), 2) AS percentage
+    FROM merge('system', '^query_log')
+    WHERE type = 'QueryFinish'
+          ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY query_cache_usage
+    ORDER BY query_count DESC
+  `,
         },
       ],
     }

--- a/apps/dashboard-tsr/src/routes/api/v1/charts/$name.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/charts/$name.ts
@@ -19,6 +19,7 @@ import {
   executeMultiChartQuery,
   isValidInterval,
 } from '@/lib/api/query-executor'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 
 export const Route = createFileRoute('/api/v1/charts/$name')({
   server: {
@@ -125,6 +126,17 @@ export const Route = createFileRoute('/api/v1/charts/$name')({
             { status: 500 }
           )
         }
+
+        // Enforce the chart's deployment-level feature gate (e.g. system
+        // metric charts carry METRICS_PERMISSION). Without this, direct
+        // requests like /api/v1/charts/memory-usage would bypass
+        // CHM_DISABLED_FEATURES / CHM_AUTH_REQUIRED_FEATURES. Matches the
+        // dashboard chart route.
+        const permissionResponse = await authorizeFeatureRequest(
+          queryDef.permission,
+          request
+        )
+        if (permissionResponse) return permissionResponse
 
         try {
           // Multi-query chart (summary charts)


### PR DESCRIPTION
Addresses the Codex review findings on #1441 (chart-registry wiring).

## P1 🟠 — Enforce metric feature permissions for system charts
The chart route ran `getChartQuery()` without `authorizeFeatureRequest`, so now-registered system metric charts (`memory-usage`, `cpu-usage`, `disk-*`) that carry `METRICS_PERMISSION` bypassed `CHM_DISABLED_FEATURES` / `CHM_AUTH_REQUIRED_FEATURES` on direct API requests.

**Fix:** surface `permission` on the registry result types (`ChartQueryResult` / `MultiChartQueryResult`) and gate the route via `authorizeFeatureRequest(queryDef.permission, request)` before executing — matching the dashboard chart route and the actions route (#1444). Verified: `getChartQuery('memory-usage').permission.feature === 'metrics'`.

## P2 🟡 — Preserve variant selection for registered charts
`query-cache-usage` and `merge-count` still used the deprecated `variants` form, which the TSR executor does **not** select (it only handles `string | VersionedSql[]`). On older ClickHouse they'd execute the version-incompatible main query → 500s instead of the compatibility fallback.

**Fix:** converted both to `sql: VersionedSql[]` (oldest-first; `selectVersionedSql` picks highest `since` ≤ CH version, with the first entry as the unknown/old-version fallback). Verified:
- `query-cache-usage` @23.8 → `'Not available'`, @24.3 → real `query_cache_usage` query.
- `merge-count` @19.0 → `system.metrics` point-in-time, @23.0 → `metric_log` history.

## Third finding (default `excluded_users` in Workers) — non-issue
The reviewer flagged that `history-queries.ts` reads `process.env.CLICKHOUSE_EXCLUDE_USER_DEFAULT` at module load. This works in Workers: vite `define` only replaces `import.meta.env.*` (not `process.env.*`), so the server bundle keeps a runtime read; `nodejs_compat_populate_process_env` + the deployed worker secret (`set-secrets.ts --target dashboard-tsr`) populate it before module evaluation. No change needed.

## Verification
`bun run type-check` → 0 errors; registry functional checks above.

Part of #1392.

Co-Authored-By: duyetbot <bot@duyet.net>