### PR TITLE
test(dashboard-tsr): chart builder + utility tests (62.8% → 71.2% cov) (#1392)

### DIFF
--- a/apps/dashboard-tsr/src/lib/__tests__/clickhouse-query.test.ts
+++ b/apps/dashboard-tsr/src/lib/__tests__/clickhouse-query.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  applyInterval,
+  buildTimeFilter,
+  buildTimeFilterInterval,
+  fillStep,
+  nowOrToday,
+  withQueryParams,
+} from '@/lib/clickhouse-query'
+
+describe('applyInterval', () => {
+  test('wraps date-returning intervals with toDate()', () => {
+    expect(applyInterval('toStartOfMonth', 'event_time')).toBe(
+      'toDate(toStartOfMonth(event_time)) AS event_time'
+    )
+    expect(applyInterval('toStartOfWeek', 'event_time')).toBe(
+      'toDate(toStartOfWeek(event_time)) AS event_time'
+    )
+    expect(applyInterval('toStartOfDay', 'ts')).toBe(
+      'toDate(toStartOfDay(ts)) AS ts'
+    )
+  })
+
+  test('passes through non-date intervals as-is', () => {
+    expect(applyInterval('toStartOfHour', 'event_time')).toBe(
+      'toStartOfHour(event_time) AS event_time'
+    )
+    expect(applyInterval('toStartOfMinute', 'event_time')).toBe(
+      'toStartOfMinute(event_time) AS event_time'
+    )
+  })
+
+  test('uses alias when provided', () => {
+    expect(applyInterval('toStartOfHour', 'event_time', 'hour')).toBe(
+      'toStartOfHour(event_time) AS hour'
+    )
+    expect(applyInterval('toStartOfMonth', 'event_time', 'month')).toBe(
+      'toDate(toStartOfMonth(event_time)) AS month'
+    )
+  })
+})
+
+describe('fillStep', () => {
+  test('returns correct interval for each granularity', () => {
+    expect(fillStep('toStartOfMinute')).toBe('toIntervalMinute(1)')
+    expect(fillStep('toStartOfFiveMinutes')).toBe('toIntervalMinute(5)')
+    expect(fillStep('toStartOfTenMinutes')).toBe('toIntervalMinute(10)')
+    expect(fillStep('toStartOfFifteenMinutes')).toBe('toIntervalMinute(15)')
+    expect(fillStep('toStartOfHour')).toBe('toIntervalHour(1)')
+    expect(fillStep('toStartOfDay')).toBe('toIntervalDay(1)')
+    expect(fillStep('toStartOfWeek')).toBe('toIntervalDay(7)')
+    expect(fillStep('toStartOfMonth')).toBe('toIntervalMonth(1)')
+  })
+
+  test('returns empty string for unknown interval', () => {
+    expect(fillStep('unknown' as any)).toBe('')
+  })
+})
+
+describe('nowOrToday', () => {
+  test('returns now() for sub-day intervals', () => {
+    expect(nowOrToday('toStartOfMinute')).toBe('now()')
+    expect(nowOrToday('toStartOfHour')).toBe('now()')
+  })
+
+  test('returns today() for day+ intervals', () => {
+    expect(nowOrToday('toStartOfDay')).toBe('today()')
+    expect(nowOrToday('toStartOfWeek')).toBe('today()')
+    expect(nowOrToday('toStartOfMonth')).toBe('today()')
+  })
+
+  test('returns empty string for unknown interval', () => {
+    expect(nowOrToday('unknown' as any)).toBe('')
+  })
+})
+
+describe('buildTimeFilter', () => {
+  test('returns empty string for undefined lastHours', () => {
+    expect(buildTimeFilter(undefined)).toBe('')
+  })
+
+  test('returns SQL condition for valid lastHours', () => {
+    expect(buildTimeFilter(24)).toBe('event_time >= (now() - INTERVAL 24 HOUR)')
+  })
+
+  test('uses custom column name', () => {
+    expect(buildTimeFilter(12, 'query_start_time')).toBe(
+      'query_start_time >= (now() - INTERVAL 12 HOUR)'
+    )
+  })
+
+  test('floors fractional hours', () => {
+    expect(buildTimeFilter(24.7)).toBe(
+      'event_time >= (now() - INTERVAL 24 HOUR)'
+    )
+  })
+
+  test('rejects zero and negative values', () => {
+    expect(buildTimeFilter(0)).toBe('')
+    expect(buildTimeFilter(-1)).toBe('')
+  })
+
+  test('rejects NaN and Infinity', () => {
+    expect(buildTimeFilter(NaN)).toBe('')
+    expect(buildTimeFilter(Infinity)).toBe('')
+  })
+})
+
+describe('buildTimeFilterInterval', () => {
+  test('returns empty string for undefined lastHours', () => {
+    expect(buildTimeFilterInterval(undefined)).toBe('')
+  })
+
+  test('returns toIntervalHour form', () => {
+    expect(buildTimeFilterInterval(24)).toBe(
+      'event_time >= (now() - toIntervalHour(24))'
+    )
+  })
+
+  test('uses custom column', () => {
+    expect(buildTimeFilterInterval(6, 'query_start_time')).toBe(
+      'query_start_time >= (now() - toIntervalHour(6))'
+    )
+  })
+
+  test('rejects invalid values', () => {
+    expect(buildTimeFilterInterval(0)).toBe('')
+    expect(buildTimeFilterInterval(-5)).toBe('')
+    expect(buildTimeFilterInterval(NaN)).toBe('')
+  })
+})
+
+describe('withQueryParams', () => {
+  test('returns query as-is when no params', () => {
+    const q = 'SELECT 1'
+    expect(withQueryParams(q)).toBe(q)
+    expect(withQueryParams(q, {})).toBe(q)
+  })
+
+  test('prepends SET statements for numeric params', () => {
+    const result = withQueryParams('SELECT {limit:UInt64} FROM t', {
+      limit: 100,
+    })
+    expect(result).toContain('SET param_limit=100')
+    expect(result).toContain('SELECT {limit:UInt64} FROM t')
+  })
+
+  test('handles string params with quote escaping', () => {
+    const result = withQueryParams('SELECT {name:String}', {
+      name: "O'Brien",
+    })
+    expect(result).toContain("SET param_name='O''Brien'")
+  })
+
+  test('handles boolean params', () => {
+    const result = withQueryParams('SELECT {flag:UInt8}', { flag: true })
+    expect(result).toContain('SET param_flag=1')
+
+    const result2 = withQueryParams('SELECT {flag:UInt8}', { flag: false })
+    expect(result2).toContain('SET param_flag=0')
+  })
+
+  test('handles multiple params', () => {
+    const result = withQueryParams('SELECT 1', { a: 1, b: 'test' })
+    expect(result).toContain('SET param_a=1')
+    expect(result).toContain("SET param_b='test'")
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/__tests__/chart-registry-imports.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/chart-registry-imports.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Verify chart registry import maps are non-empty and have correct keys.
+ *
+ * These import maps were all empty `{}` during the initial port (#1443).
+ * The registry-completeness test verifies the composed registry, but this
+ * test catches a regression at the source — a map that went back to empty.
+ */
+import { describe, expect, test } from 'bun:test'
+import { logsChartImports } from '@/components/charts/registry/imports/logs-charts'
+import { mergeChartImports } from '@/components/charts/registry/imports/merge-charts'
+import { miscChartImports } from '@/components/charts/registry/imports/misc-charts'
+import { queryChartImports } from '@/components/charts/registry/imports/query-charts'
+import { queryPerfChartImports } from '@/components/charts/registry/imports/query-perf-charts'
+import { replicationChartImports } from '@/components/charts/registry/imports/replication-charts'
+import { securityChartImports } from '@/components/charts/registry/imports/security-charts'
+import { systemChartImports } from '@/components/charts/registry/imports/system-charts'
+import { threadChartImports } from '@/components/charts/registry/imports/thread-charts'
+import { zookeeperChartImports } from '@/components/charts/registry/imports/zookeeper-charts'
+
+const importMaps = [
+  { name: 'logs', map: logsChartImports, min: 2 },
+  { name: 'merge', map: mergeChartImports, min: 3 },
+  { name: 'misc', map: miscChartImports, min: 10 },
+  { name: 'query', map: queryChartImports, min: 8 },
+  { name: 'query-perf', map: queryPerfChartImports, min: 3 },
+  { name: 'replication', map: replicationChartImports, min: 3 },
+  { name: 'security', map: securityChartImports, min: 1 },
+  { name: 'system', map: systemChartImports, min: 10 },
+  { name: 'thread', map: threadChartImports, min: 1 },
+  { name: 'zookeeper', map: zookeeperChartImports, min: 5 },
+]
+
+describe('Chart registry import maps', () => {
+  for (const { name, map, min } of importMaps) {
+    describe(`${name} import map`, () => {
+      test('is non-empty', () => {
+        const keys = Object.keys(map)
+        expect(keys.length).toBeGreaterThan(0)
+      })
+
+      test(`has at least ${min} charts`, () => {
+        const keys = Object.keys(map)
+        expect(keys.length).toBeGreaterThanOrEqual(min)
+      })
+
+      test('all values are React lazy components', () => {
+        for (const [, val] of Object.entries(map)) {
+          // React.lazy returns a lazy component object with _payload and _init
+          expect(val).toBeDefined()
+          expect(typeof val).toBe('object')
+        }
+      })
+    })
+  }
+})

--- a/apps/dashboard-tsr/src/lib/api/__tests__/charts/connection-charts.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/charts/connection-charts.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test'
+import { connectionCharts } from '@/lib/api/charts/connection-charts'
+
+describe('connectionCharts', () => {
+  const entries = Object.entries(connectionCharts)
+
+  test('map is non-empty', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  describe.each(entries)('chart "%s"', (name, builder) => {
+    test('returns an object with a query property', () => {
+      const result = builder({})
+      expect(result).toBeDefined()
+      expect(result).toHaveProperty('query')
+    })
+
+    test('query is a non-empty string containing SELECT', () => {
+      const result = builder({})
+      if ('query' in result) {
+        expect(typeof result.query).toBe('string')
+        expect(result.query.length).toBeGreaterThan(0)
+        expect(result.query).toMatch(/SELECT/i)
+      }
+    })
+  })
+
+  test('connections-http references HTTPConnection metrics', () => {
+    const result = connectionCharts['connections-http']({})
+    if ('query' in result) {
+      expect(result.query).toContain('HTTPConnection')
+    }
+  })
+
+  test('connections-interserver references InterserverConnection metrics', () => {
+    const result = connectionCharts['connections-interserver']({})
+    if ('query' in result) {
+      expect(result.query).toContain('InterserverConnection')
+    }
+  })
+
+  test('connections-pool queries multiple connection types', () => {
+    const result = connectionCharts['connections-pool']({})
+    if ('query' in result) {
+      expect(result.query).toContain('TCPConnection')
+      expect(result.query).toContain('HTTPConnection')
+      expect(result.query).toContain('InterserverConnection')
+    }
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/__tests__/charts/dashboard-charts.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/charts/dashboard-charts.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test'
+import { dashboardCharts } from '@/lib/api/charts/dashboard-charts'
+
+describe('dashboard-charts', () => {
+  const entries = Object.entries(dashboardCharts)
+
+  test('is non-empty', () => {
+    expect(entries.length).toBeGreaterThanOrEqual(2)
+  })
+
+  test.each(entries)('%s returns a query', (_name, builder) => {
+    const result = builder({})
+    expect(result).toBeDefined()
+    expect(result.query).toContain('SELECT')
+    expect(result.optional).toBe(true)
+  })
+
+  test('dashboard-charts queries chart config table', () => {
+    const result = dashboardCharts['dashboard-charts']!({})
+    expect(result.query).toContain('FINAL')
+    expect(result.query).toContain('ordering')
+  })
+
+  test('dashboard-settings queries settings table', () => {
+    const result = dashboardCharts['dashboard-settings']!({})
+    expect(result.query).toContain('FINAL')
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/__tests__/charts/dictionary-charts.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/charts/dictionary-charts.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test'
+import { dictionaryCharts } from '@/lib/api/charts/dictionary-charts'
+
+describe('dictionary-charts', () => {
+  test('is non-empty', () => {
+    expect(Object.keys(dictionaryCharts).length).toBeGreaterThan(0)
+  })
+
+  test('dictionary-count queries system.dictionaries', () => {
+    const result = dictionaryCharts['dictionary-count']!({})
+    expect(result).toBeDefined()
+    expect(result.query).toContain('SELECT')
+    expect(result.query).toContain('system.dictionaries')
+    expect(result.optional).toBe(true)
+    expect(result.tableCheck).toBe('system.dictionaries')
+  })
+
+  test('dictionary-count groups by status', () => {
+    const result = dictionaryCharts['dictionary-count']!({})
+    expect(result.query).toContain('GROUP BY status')
+    expect(result.query).toContain('count()')
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/__tests__/charts/insight-charts.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/charts/insight-charts.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test'
+import { insightCharts } from '@/lib/api/charts/insight-charts'
+
+describe('insightCharts', () => {
+  const entries = Object.entries(insightCharts)
+
+  test('map is non-empty', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  describe.each(entries)('chart "%s"', (name, builder) => {
+    test('returns an object with a query property', () => {
+      const result = builder({})
+      expect(result).toBeDefined()
+      expect(result).toHaveProperty('query')
+    })
+
+    test('query is a non-empty string containing SELECT', () => {
+      const result = builder({})
+      if ('query' in result) {
+        expect(typeof result.query).toBe('string')
+        expect(result.query.length).toBeGreaterThan(0)
+        expect(result.query).toMatch(/SELECT/i)
+      }
+    })
+
+    if (name === 'insight-detached-parts') {
+      test('marks itself as optional with tableCheck', () => {
+        const result = builder({})
+        if ('optional' in result) {
+          expect(result.optional).toBe(true)
+          expect(result.tableCheck).toBe('system.detached_parts')
+        }
+      })
+    }
+  })
+
+  test('time-filtered charts accept lastHours parameter', () => {
+    const timeFilteredCharts = [
+      'insight-largest-scan',
+      'insight-fastest-scan',
+      'insight-longest-query',
+      'insight-query-summary',
+    ] as const
+
+    for (const chartName of timeFilteredCharts) {
+      const builder = insightCharts[chartName]
+      const result = builder({ lastHours: 48 })
+      if ('query' in result) {
+        expect(result.query).toContain('48')
+      }
+    }
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/__tests__/charts/logs-charts.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/charts/logs-charts.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test'
+import { logsCharts } from '@/lib/api/charts/logs-charts'
+
+describe('logs-charts', () => {
+  const entries = Object.entries(logsCharts)
+
+  test('is non-empty', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  test.each(entries)('%s returns a query', (_name, builder) => {
+    const result = builder({ lastHours: 24 })
+    expect(result).toBeDefined()
+    expect(result.query).toContain('SELECT')
+    expect(result.optional).toBe(true)
+  })
+
+  test('log-level-distribution uses text_log', () => {
+    const result = logsCharts['log-level-distribution']!({ lastHours: 24 })
+    expect(result.query).toContain('system.text_log')
+    expect(result.tableCheck).toBe('system.text_log')
+  })
+
+  test('error-rate-over-time uses interval', () => {
+    const result = logsCharts['error-rate-over-time']!({
+      interval: 'toStartOfHour',
+      lastHours: 24,
+    })
+    expect(result.query).toContain('toStartOfHour')
+    expect(result.query).toContain('error_count')
+  })
+
+  test('crash-frequency uses crash_log', () => {
+    const result = logsCharts['crash-frequency']!({ lastHours: 24 * 30 })
+    expect(result.query).toContain('system.crash_log')
+    expect(result.tableCheck).toBe('system.crash_log')
+  })
+
+  test('log-count-today has no time filter param', () => {
+    const result = logsCharts['log-count-today']!({})
+    expect(result.query).toContain('today()')
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/__tests__/charts/merge-charts.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/charts/merge-charts.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test'
+import { mergeCharts } from '@/lib/api/charts/merge-charts'
+
+describe('mergeCharts', () => {
+  const entries = Object.entries(mergeCharts)
+
+  test('map is non-empty', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  describe.each(entries)('chart "%s"', (name, builder) => {
+    test('returns an object with query or queries property', () => {
+      const result = builder({})
+      expect(result).toBeDefined()
+      expect('query' in result || 'queries' in result).toBe(true)
+    })
+
+    if (name === 'summary-used-by-merges') {
+      test('returns MultiChartQueryResult with queries array', () => {
+        const result = builder({})
+        if ('queries' in result) {
+          expect(Array.isArray(result.queries)).toBe(true)
+          expect(result.queries.length).toBeGreaterThan(0)
+          for (const q of result.queries) {
+            expect(q).toHaveProperty('key')
+            expect(q).toHaveProperty('query')
+            expect(typeof q.query).toBe('string')
+            expect(q.query).toMatch(/SELECT/i)
+          }
+        }
+      })
+    } else {
+      test('query is a non-empty string containing SELECT', () => {
+        const result = builder({})
+        if ('query' in result) {
+          expect(typeof result.query).toBe('string')
+          expect(result.query.length).toBeGreaterThan(0)
+          expect(result.query).toMatch(/SELECT/i)
+        }
+      })
+    }
+
+    if (name === 'merge-count') {
+      test('has VersionedSql array in sql property', () => {
+        const result = builder({})
+        if ('sql' in result && result.sql) {
+          expect(Array.isArray(result.sql)).toBe(true)
+          expect(result.sql.length).toBeGreaterThan(0)
+          for (const entry of result.sql) {
+            expect(entry).toHaveProperty('since')
+            expect(entry).toHaveProperty('sql')
+            expect(typeof entry.since).toBe('string')
+            expect(typeof entry.sql).toBe('string')
+            expect(entry.sql).toMatch(/SELECT/i)
+          }
+        }
+      })
+
+      test('marks itself as optional with tableCheck', () => {
+        const result = builder({})
+        if ('optional' in result) {
+          expect(result.optional).toBe(true)
+          expect(result.tableCheck).toBe('system.metric_log')
+        }
+      })
+    }
+
+    if (name === 'merge-avg-duration' || name === 'merge-sum-read-rows') {
+      test('marks itself as optional with part_log tableCheck', () => {
+        const result = builder({})
+        if ('optional' in result) {
+          expect(result.optional).toBe(true)
+          expect(result.tableCheck).toBe('system.part_log')
+        }
+      })
+    }
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/__tests__/charts/overview-charts.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/charts/overview-charts.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test'
+import { overviewCharts } from '@/lib/api/charts/overview-charts'
+
+describe('overview-charts', () => {
+  const entries = Object.entries(overviewCharts)
+
+  test('is non-empty', () => {
+    expect(entries.length).toBeGreaterThanOrEqual(5)
+  })
+
+  test.each(entries)('%s returns a query', (_name, builder) => {
+    const result = builder({})
+    expect(result).toBeDefined()
+    expect(result.query).toContain('SELECT')
+  })
+
+  test('running-queries-count counts processes', () => {
+    const result = overviewCharts['running-queries-count']!({})
+    expect(result.query).toContain('system.processes')
+    expect(result.query).toContain('COUNT')
+  })
+
+  test('database-count excludes system databases', () => {
+    const result = overviewCharts['database-count']!({})
+    expect(result.query).toContain('system.tables')
+    expect(result.query).toContain('information_schema')
+  })
+
+  test('disk-size-single returns disk metrics', () => {
+    const result = overviewCharts['disk-size-single']!({})
+    expect(result.query).toContain('system.disks')
+    expect(result.query).toContain('formatReadableSize')
+    expect(result.query).toContain('LIMIT 1')
+  })
+
+  test('table-count counts unique tables', () => {
+    const result = overviewCharts['table-count']!({})
+    expect(result.query).toContain('countDistinct')
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/__tests__/charts/page-view-charts.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/charts/page-view-charts.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test'
+import { pageViewCharts } from '@/lib/api/charts/page-view-charts'
+
+const defaultParams = { interval: 'toStartOfDay' as const, lastHours: 24 * 14 }
+
+describe('pageViewCharts', () => {
+  const entries = Object.entries(pageViewCharts)
+
+  test('map is non-empty', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  test.each(
+    entries
+  )('"%s" builder returns valid query result', (name, builder) => {
+    const result = builder(defaultParams)
+
+    // Must have a query property
+    expect(result).toHaveProperty('query')
+    expect(typeof result.query).toBe('string')
+    expect(result.query.length).toBeGreaterThan(0)
+
+    // Query must contain SELECT
+    expect(result.query).toMatch(/SELECT/i)
+  })
+
+  test('known chart names are present', () => {
+    const names = Object.keys(pageViewCharts)
+    expect(names).toContain('page-view')
+    expect(names).toContain('top-pages')
+    expect(names).toContain('human-vs-bot-pageviews')
+    expect(names).toContain('pageviews-by-device')
+    expect(names).toContain('pageviews-by-country')
+  })
+
+  test('all charts are optional (require events table)', () => {
+    for (const [name, builder] of entries) {
+      const result = builder(defaultParams)
+      expect(result.optional, `${name} should be optional`).toBe(true)
+      expect(result.tableCheck, `${name} should have tableCheck`).toBeDefined()
+    }
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/__tests__/charts/query-charts.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/charts/query-charts.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test'
+import { queryCharts } from '@/lib/api/charts/query-charts'
+
+describe('queryCharts', () => {
+  const entries = Object.entries(queryCharts)
+
+  test('map is non-empty', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  describe.each(entries)('chart "%s"', (name, builder) => {
+    test('returns an object with a query property', () => {
+      const result = builder({})
+      expect(result).toBeDefined()
+      expect(result).toHaveProperty('query')
+    })
+
+    test('query is a non-empty string containing SELECT', () => {
+      const result = builder({})
+      if ('query' in result) {
+        expect(typeof result.query).toBe('string')
+        expect(result.query.length).toBeGreaterThan(0)
+        expect(result.query).toMatch(/SELECT/i)
+      }
+    })
+
+    if (name === 'query-cache-usage') {
+      test('has VersionedSql array in sql property', () => {
+        const result = builder({})
+        if ('sql' in result && result.sql) {
+          expect(Array.isArray(result.sql)).toBe(true)
+          expect(result.sql.length).toBeGreaterThan(0)
+          for (const entry of result.sql) {
+            expect(entry).toHaveProperty('since')
+            expect(entry).toHaveProperty('sql')
+            expect(typeof entry.since).toBe('string')
+            expect(typeof entry.sql).toBe('string')
+            expect(entry.sql).toMatch(/SELECT/i)
+          }
+        }
+      })
+    }
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/__tests__/charts/query-perf-charts.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/charts/query-perf-charts.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test'
+import { queryPerfCharts } from '@/lib/api/charts/query-perf-charts'
+
+const defaultParams = { interval: 'toStartOfHour' as const, lastHours: 24 }
+
+describe('queryPerfCharts', () => {
+  const entries = Object.entries(queryPerfCharts)
+
+  test('map is non-empty', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  test.each(
+    entries
+  )('"%s" builder returns valid query result', (name, builder) => {
+    const result = builder(defaultParams)
+
+    // Must have a query property
+    expect(result).toHaveProperty('query')
+    expect(typeof result.query).toBe('string')
+    expect(result.query.length).toBeGreaterThan(0)
+
+    // Query must contain SELECT
+    expect(result.query).toMatch(/SELECT/i)
+  })
+
+  test('known chart names are present', () => {
+    const names = Object.keys(queryPerfCharts)
+    expect(names).toContain('insert-performance')
+    expect(names).toContain('top-query-fingerprints-perf')
+    expect(names).toContain('query-duration-trend')
+    expect(names).toContain('top-inserters')
+  })
+
+  test('queries reference expected system tables', () => {
+    for (const [, builder] of entries) {
+      const result = builder(defaultParams)
+      // All query-perf charts query query_log
+      expect(result.query).toMatch(/query_log/)
+    }
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/__tests__/charts/replication-charts.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/charts/replication-charts.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test'
+import { replicationCharts } from '@/lib/api/charts/replication-charts'
+
+const defaultParams = { interval: 'toStartOfHour' as const, lastHours: 24 }
+
+describe('replicationCharts', () => {
+  const entries = Object.entries(replicationCharts)
+
+  test('map is non-empty', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  test.each(
+    entries
+  )('"%s" builder returns valid query result', (name, builder) => {
+    const result = builder(defaultParams)
+
+    // Must have a query property
+    expect(result).toHaveProperty('query')
+    expect(typeof result.query).toBe('string')
+    expect(result.query.length).toBeGreaterThan(0)
+
+    // Query must contain SELECT
+    expect(result.query).toMatch(/SELECT/i)
+  })
+
+  test('known chart names are present', () => {
+    const names = Object.keys(replicationCharts)
+    expect(names).toContain('replication-queue-count')
+    expect(names).toContain('replication-summary-table')
+    expect(names).toContain('readonly-replica')
+    expect(names).toContain('replication-lag')
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/__tests__/charts/security-charts.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/charts/security-charts.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test'
+import { securityCharts } from '@/lib/api/charts/security-charts'
+
+const defaultParams = { interval: 'toStartOfHour' as const, lastHours: 24 }
+
+describe('securityCharts', () => {
+  const entries = Object.entries(securityCharts)
+
+  test('map is non-empty', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  test.each(
+    entries
+  )('"%s" builder returns valid query result', (name, builder) => {
+    const result = builder(defaultParams)
+
+    // Must have a query property
+    expect(result).toHaveProperty('query')
+    expect(typeof result.query).toBe('string')
+    expect(result.query.length).toBeGreaterThan(0)
+
+    // Query must contain SELECT
+    expect(result.query).toMatch(/SELECT/i)
+  })
+
+  test('known chart names are present', () => {
+    const names = Object.keys(securityCharts)
+    expect(names).toContain('login-success-rate')
+    expect(names).toContain('failed-login-by-user')
+    expect(names).toContain('active-sessions-count')
+    expect(names).toContain('sessions-by-auth-type')
+    expect(names).toContain('sessions-by-interface')
+  })
+
+  test('all charts are optional (require system.session_log)', () => {
+    for (const [name, builder] of entries) {
+      const result = builder(defaultParams)
+      expect(result.optional, `${name} should be optional`).toBe(true)
+      expect(result.tableCheck, `${name} should have tableCheck`).toBeDefined()
+    }
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/__tests__/charts/system-charts.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/charts/system-charts.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test'
+import { systemCharts } from '@/lib/api/charts/system-charts'
+
+describe('systemCharts', () => {
+  const entries = Object.entries(systemCharts)
+
+  test('map is non-empty', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  describe.each(entries)('chart "%s"', (name, builder) => {
+    test('returns an object with query or queries property', () => {
+      const result = builder({})
+      expect(result).toBeDefined()
+      expect('query' in result || 'queries' in result).toBe(true)
+    })
+
+    if (name === 'summary-used-by-running-queries') {
+      test('returns MultiChartQueryResult with queries array', () => {
+        const result = builder({})
+        if ('queries' in result) {
+          expect(Array.isArray(result.queries)).toBe(true)
+          expect(result.queries.length).toBeGreaterThan(0)
+          for (const q of result.queries) {
+            expect(q).toHaveProperty('key')
+            expect(q).toHaveProperty('query')
+            expect(typeof q.query).toBe('string')
+            expect(q.query).toMatch(/SELECT/i)
+          }
+        }
+      })
+    } else {
+      test('query is a non-empty string containing SELECT', () => {
+        const result = builder({})
+        if ('query' in result) {
+          expect(typeof result.query).toBe('string')
+          expect(result.query.length).toBeGreaterThan(0)
+          expect(result.query).toMatch(/SELECT/i)
+        }
+      })
+    }
+
+    if (name === 'disk-size') {
+      test('accepts params.name for disk filtering', () => {
+        const result = builder({ params: { name: 'default' } })
+        if ('query' in result) {
+          expect(result.query).toContain("name = 'default'")
+        }
+      })
+    }
+
+    if (name === 'top-table-size') {
+      test('respects params.limit for row limiting', () => {
+        const result = builder({ params: { limit: 5 } })
+        if ('query' in result) {
+          expect(result.query).toContain('LIMIT 5')
+        }
+      })
+    }
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/__tests__/charts/thread-charts.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/charts/thread-charts.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test'
+import { threadCharts } from '@/lib/api/charts/thread-charts'
+
+describe('thread-charts', () => {
+  const entries = Object.entries(threadCharts)
+
+  test('is non-empty', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  test.each(entries)('%s returns a query', (_name, builder) => {
+    const result = builder({ interval: 'toStartOfHour', lastHours: 24 })
+    expect(result).toBeDefined()
+    expect(result.query).toContain('SELECT')
+    expect(result.optional).toBe(true)
+  })
+
+  test('thread-utilization uses query_thread_log', () => {
+    const result = threadCharts['thread-utilization']!({
+      interval: 'toStartOfHour',
+      lastHours: 24,
+    })
+    expect(result.query).toContain('system.query_thread_log')
+    expect(result.tableCheck).toBe('system.query_thread_log')
+  })
+
+  test('parallelization-efficiency buckets threads', () => {
+    const result = threadCharts['parallelization-efficiency']!({
+      lastHours: 168,
+    })
+    expect(result.query).toContain('thread_bucket')
+    expect(result.query).toContain('1 thread')
+  })
+
+  test('cpu-time-per-thread uses interval', () => {
+    const result = threadCharts['cpu-time-per-thread']!({
+      interval: 'toStartOfHour',
+      lastHours: 24,
+    })
+    expect(result.query).toContain('toStartOfHour')
+    expect(result.query).toContain('OSCPUVirtualTimeMicroseconds')
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/__tests__/charts/zookeeper-charts.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/charts/zookeeper-charts.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test'
+import { zookeeperCharts } from '@/lib/api/charts/zookeeper-charts'
+
+const defaultParams = { interval: 'toStartOfHour' as const, lastHours: 24 }
+
+describe('zookeeperCharts', () => {
+  const entries = Object.entries(zookeeperCharts)
+
+  test('map is non-empty', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  test.each(
+    entries
+  )('"%s" builder returns valid query result', (name, builder) => {
+    const result = builder(defaultParams)
+
+    // Must have a query property
+    expect(result).toHaveProperty('query')
+    expect(typeof result.query).toBe('string')
+    expect(result.query.length).toBeGreaterThan(0)
+
+    // Query must contain SELECT
+    expect(result.query).toMatch(/SELECT/i)
+  })
+
+  test('known chart names are present', () => {
+    const names = Object.keys(zookeeperCharts)
+    expect(names).toContain('zookeeper-requests')
+    expect(names).toContain('zookeeper-exception')
+    expect(names).toContain('zookeeper-uptime')
+    expect(names).toContain('zookeeper-wait')
+    expect(names).toContain('zookeeper-summary-table')
+    expect(names).toContain('keeper-health')
+    expect(names).toContain('keeper-info-summary')
+    expect(names).toContain('keeper-operation-mix')
+    expect(names).toContain('keeper-bytes')
+    expect(names).toContain('keeper-connection-events')
+  })
+
+  test('optional charts are marked correctly', () => {
+    expect(zookeeperCharts['zookeeper-exception'](defaultParams).optional).toBe(
+      true
+    )
+    expect(zookeeperCharts['keeper-info-summary'](defaultParams).optional).toBe(
+      true
+    )
+    expect(
+      zookeeperCharts['keeper-connection-events']({
+        ...defaultParams,
+        lastHours: 24 * 14,
+      }).optional
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
## Coverage Boost — Chart Builders + Utilities

### What
17 new test files covering the largest uncovered areas in `apps/dashboard-tsr`:

| Category | Files | Tests | What's tested |
|----------|-------|-------|---------------|
| Chart builder modules | 15 | ~250 | Every chart returns valid SQL, correct system tables, optional/tableCheck flags |
| clickhouse-query utility | 1 | 23 | applyInterval, buildTimeFilter, fillStep, nowOrToday, withQueryParams |
| Chart import maps | 1 | 30 | All 10 import modules non-empty, correct key counts |

### Coverage Impact

| Metric | Before | After | Δ |
|--------|--------|-------|---|
| Statements | 62.8% | 71.2% | **+8.4pp** |
| Branches | 75.9% | 83.3% | **+7.4pp** |
| Tests | 368 | 619 | **+251** |
| Assertions | 871 | 1,594 | **+723** |

### Remaining Gaps (next PR)
- `packages/sql-builder/*` — 0% on builder/column/extension/validator (shared packages, tested from old dashboard)
- `packages/mcp-server/src/auth/*` — 0% on clerk-oauth, api-key, oauth-metadata
- `packages/clickhouse-client/*` — low coverage on fetch, connection-pool
- React components (data-table cells, UI) — need DOM testing

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for chart registries and query builders across multiple domains (connection, dashboard, dictionary, insight, logs, merge, overview, query, replication, security, system, thread, and zookeeper charts).
  * Added tests for ClickHouse query construction and chart registry imports validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->