### PR TITLE
test(dashboard-tsr): cover filters + format utils (#1392)

### DIFF
--- a/apps/dashboard-tsr/src/lib/filters/operators.test.ts
+++ b/apps/dashboard-tsr/src/lib/filters/operators.test.ts
@@ -1,0 +1,48 @@
+import type { FilterOperator } from './types'
+
+import {
+  isFilterOperator,
+  isMultiValueOperator,
+  isRangeOperator,
+  KNOWN_OPERATORS,
+  OPERATORS,
+} from './operators'
+import { describe, expect, test } from 'bun:test'
+
+describe('OPERATORS metadata', () => {
+  test('every operator declares a label, arity and field types', () => {
+    for (const meta of Object.values(OPERATORS)) {
+      expect(meta.label.length).toBeGreaterThan(0)
+      expect(meta.fieldTypes.length).toBeGreaterThan(0)
+      expect([0, 1, 2, 'multi']).toContain(meta.arity)
+    }
+    expect(KNOWN_OPERATORS).toEqual(Object.keys(OPERATORS) as FilterOperator[])
+  })
+})
+
+describe('isFilterOperator', () => {
+  test('accepts known tokens, rejects unknown ones', () => {
+    expect(isFilterOperator('eq')).toBe(true)
+    expect(isFilterOperator('withinHours')).toBe(true)
+    expect(isFilterOperator('nope')).toBe(false)
+    expect(isFilterOperator('')).toBe(false)
+    expect(isFilterOperator('toString')).toBe(false) // not a prototype key leak
+  })
+})
+
+describe('isMultiValueOperator', () => {
+  test('true only for arity:multi operators', () => {
+    expect(isMultiValueOperator('in')).toBe(true)
+    expect(isMultiValueOperator('notIn')).toBe(true)
+    expect(isMultiValueOperator('eq')).toBe(false)
+    expect(isMultiValueOperator('between')).toBe(false)
+  })
+})
+
+describe('isRangeOperator', () => {
+  test('true only for arity:2 operators', () => {
+    expect(isRangeOperator('between')).toBe(true)
+    expect(isRangeOperator('in')).toBe(false)
+    expect(isRangeOperator('gt')).toBe(false)
+  })
+})

--- a/apps/dashboard-tsr/src/lib/filters/url-state.test.ts
+++ b/apps/dashboard-tsr/src/lib/filters/url-state.test.ts
@@ -1,0 +1,134 @@
+import type { FilterField, FilterSchema } from './types'
+
+import {
+  parseFiltersFromParams,
+  parseFilterValue,
+  serializeActiveFilters,
+  serializeFilter,
+} from './url-state'
+import { describe, expect, test } from 'bun:test'
+
+const userField: FilterField = {
+  key: 'user',
+  column: 'user',
+  label: 'User',
+  type: 'text',
+  operators: ['eq', 'in', 'contains'],
+}
+
+const memField: FilterField = {
+  key: 'mem',
+  column: 'memory',
+  label: 'Memory',
+  type: 'number',
+  operators: ['gt', 'between'],
+}
+
+describe('parseFilterValue', () => {
+  test('parses an explicit operator:value fragment', () => {
+    expect(parseFilterValue(userField, 'eq:default')).toEqual({
+      key: 'user',
+      operator: 'eq',
+      values: ['default'],
+    })
+  })
+
+  test('a bare value falls back to the field default operator', () => {
+    expect(parseFilterValue(userField, 'default')).toEqual({
+      key: 'user',
+      operator: 'eq', // first in operators[]
+      values: ['default'],
+    })
+  })
+
+  test('a multi-value operator splits on commas', () => {
+    expect(parseFilterValue(userField, 'in:a,b,c')?.values).toEqual([
+      'a',
+      'b',
+      'c',
+    ])
+  })
+
+  test('a known-but-disallowed operator prefix is still stripped, operator falls back to default', () => {
+    // 'gt' is a recognized token so the prefix is consumed (value → '5'),
+    // but the field disallows gt → operator resets to the default (eq).
+    const parsed = parseFilterValue(userField, 'gt:5')
+    expect(parsed?.operator).toBe('eq')
+    expect(parsed?.values).toEqual(['5'])
+  })
+
+  test('an unrecognized prefix is treated as part of the value', () => {
+    const parsed = parseFilterValue(userField, 'http://x')
+    expect(parsed?.operator).toBe('eq')
+    expect(parsed?.values).toEqual(['http://x'])
+  })
+
+  test('returns null when no usable value remains', () => {
+    expect(parseFilterValue(userField, 'eq:   ')).toBeNull()
+    expect(parseFilterValue(userField, 'in: , ,')).toBeNull()
+  })
+})
+
+describe('parseFiltersFromParams', () => {
+  const schema: FilterSchema = { fields: [userField, memField] }
+
+  test('reads explicit params into active filters', () => {
+    const params = new URLSearchParams('user=in:a,b&mem=gt:100')
+    const filters = parseFiltersFromParams(schema, params)
+    expect(filters).toHaveLength(2)
+    expect(filters.find((f) => f.key === 'user')?.values).toEqual(['a', 'b'])
+  })
+
+  test('an explicit empty param clears the field (overrides default)', () => {
+    const withDefault: FilterSchema = {
+      fields: [
+        { ...userField, defaultValue: { operator: 'eq', value: 'monitoring' } },
+      ],
+    }
+    // ?user= present-but-empty → no filter, even though a default exists.
+    const filters = parseFiltersFromParams(
+      withDefault,
+      new URLSearchParams('user=')
+    )
+    expect(filters).toHaveLength(0)
+  })
+
+  test('a missing param applies the field defaultValue', () => {
+    const withDefault: FilterSchema = {
+      fields: [
+        { ...userField, defaultValue: { operator: 'eq', value: 'monitoring' } },
+      ],
+    }
+    const filters = parseFiltersFromParams(withDefault, new URLSearchParams(''))
+    expect(filters).toEqual([
+      { key: 'user', operator: 'eq', values: ['monitoring'] },
+    ])
+  })
+})
+
+describe('serialize round-trip', () => {
+  test('serializeFilter renders operator:value', () => {
+    expect(
+      serializeFilter({ key: 'user', operator: 'in', values: ['a', 'b'] })
+    ).toBe('in:a,b')
+  })
+
+  test('serializeActiveFilters keys by field', () => {
+    expect(
+      serializeActiveFilters([
+        { key: 'user', operator: 'eq', values: ['default'] },
+        { key: 'mem', operator: 'gt', values: ['100'] },
+      ])
+    ).toEqual({ user: 'eq:default', mem: 'gt:100' })
+  })
+
+  test('parse(serialize(x)) === x for a multi-value filter', () => {
+    const original = {
+      key: 'user',
+      operator: 'in' as const,
+      values: ['a', 'b'],
+    }
+    const roundTripped = parseFilterValue(userField, serializeFilter(original))
+    expect(roundTripped).toEqual(original)
+  })
+})

--- a/apps/dashboard-tsr/src/lib/filters/where-builder.test.ts
+++ b/apps/dashboard-tsr/src/lib/filters/where-builder.test.ts
@@ -1,0 +1,266 @@
+import type { ActiveFilter, FilterField, FilterSchema } from './types'
+
+import {
+  applyFilterPlaceholder,
+  buildWhereClause,
+  FILTER_PLACEHOLDER,
+} from './where-builder'
+import { describe, expect, test } from 'bun:test'
+
+/** Build a one-field schema quickly. */
+function schemaOf(
+  field: Partial<FilterField> & Pick<FilterField, 'key'>
+): FilterSchema {
+  return {
+    fields: [
+      {
+        column: field.key,
+        label: field.key,
+        type: 'text',
+        operators: [
+          'eq',
+          'ne',
+          'contains',
+          'notContains',
+          'in',
+          'notIn',
+          'between',
+          'gt',
+          'gte',
+          'lt',
+          'lte',
+          'withinHours',
+        ],
+        ...field,
+      } as FilterField,
+    ],
+  }
+}
+
+function filter(
+  key: string,
+  operator: ActiveFilter['operator'],
+  values: string[]
+): ActiveFilter {
+  return { key, operator, values }
+}
+
+describe('buildWhereClause — security invariant', () => {
+  test('user values are NEVER interpolated into the SQL string', () => {
+    const schema = schemaOf({ key: 'user', column: 'user', type: 'text' })
+    const malicious = "default'; DROP TABLE system.query_log; --"
+    const { clause, params } = buildWhereClause(schema, [
+      filter('user', 'eq', [malicious]),
+    ])
+
+    // The dangerous value must live in params, not in the clause text.
+    expect(clause).not.toContain('DROP TABLE')
+    expect(clause).toContain('{flt_0:String}')
+    expect(Object.values(params)).toContain(malicious)
+  })
+
+  test('column names come from the schema, not the filter key alias', () => {
+    const schema = schemaOf({
+      key: 'mem',
+      column: 'memory_usage',
+      type: 'number',
+    })
+    const { clause } = buildWhereClause(schema, [filter('mem', 'gt', ['100'])])
+    expect(clause).toContain('memory_usage >')
+  })
+})
+
+describe('buildWhereClause — schema gating', () => {
+  test('skips filters referencing an unknown field', () => {
+    const schema = schemaOf({ key: 'user' })
+    const { clause, params } = buildWhereClause(schema, [
+      filter('ghost', 'eq', ['x']),
+    ])
+    expect(clause).toBe('')
+    expect(params).toEqual({})
+  })
+
+  test('skips an operator the field does not allow', () => {
+    const schema: FilterSchema = {
+      fields: [
+        {
+          key: 'user',
+          column: 'user',
+          label: 'user',
+          type: 'text',
+          operators: ['eq'],
+        },
+      ],
+    }
+    const { clause } = buildWhereClause(schema, [filter('user', 'gt', ['5'])])
+    expect(clause).toBe('')
+  })
+
+  test('returns empty clause when there are no filters', () => {
+    expect(buildWhereClause(schemaOf({ key: 'user' }), [])).toEqual({
+      clause: '',
+      params: {},
+    })
+  })
+})
+
+describe('buildWhereClause — operators', () => {
+  test('eq / ne / gt / gte / lt / lte map to SQL symbols', () => {
+    const schema = schemaOf({ key: 'n', column: 'n', type: 'number' })
+    const cases: Array<[ActiveFilter['operator'], string]> = [
+      ['eq', 'n ='],
+      ['ne', 'n !='],
+      ['gt', 'n >'],
+      ['gte', 'n >='],
+      ['lt', 'n <'],
+      ['lte', 'n <='],
+    ]
+    for (const [op, expected] of cases) {
+      const { clause } = buildWhereClause(schema, [filter('n', op, ['1'])])
+      expect(clause).toContain(expected)
+    }
+  })
+
+  test('contains / notContains use positionCaseInsensitiveUTF8', () => {
+    const schema = schemaOf({ key: 'q', column: 'query', type: 'text' })
+    expect(
+      buildWhereClause(schema, [filter('q', 'contains', ['SELECT'])]).clause
+    ).toContain(
+      'positionCaseInsensitiveUTF8(toString(query), {flt_0:String}) > 0'
+    )
+    expect(
+      buildWhereClause(schema, [filter('q', 'notContains', ['x'])]).clause
+    ).toContain('= 0')
+  })
+
+  test('in / notIn emit a parameterized list', () => {
+    const schema = schemaOf({ key: 'u', column: 'user', type: 'text' })
+    const { clause, params } = buildWhereClause(schema, [
+      filter('u', 'in', ['a', 'b', 'c']),
+    ])
+    expect(clause).toContain(
+      'user IN ({flt_0:String}, {flt_1:String}, {flt_2:String})'
+    )
+    expect(Object.keys(params)).toHaveLength(3)
+
+    expect(
+      buildWhereClause(schema, [filter('u', 'notIn', ['a'])]).clause
+    ).toContain('user NOT IN')
+  })
+
+  test('between needs two operands', () => {
+    const schema = schemaOf({ key: 'n', column: 'n', type: 'number' })
+    const { clause } = buildWhereClause(schema, [
+      filter('n', 'between', ['10', '20']),
+    ])
+    expect(clause).toContain('n BETWEEN {flt_0:Float64} AND {flt_1:Float64}')
+
+    // A single value is insufficient → condition dropped.
+    expect(
+      buildWhereClause(schema, [filter('n', 'between', ['10'])]).clause
+    ).toBe('')
+  })
+
+  test('withinHours coerces to an interval-hour expression', () => {
+    const schema = schemaOf({
+      key: 't',
+      column: 'event_time',
+      type: 'datetime',
+    })
+    const { clause } = buildWhereClause(schema, [
+      filter('t', 'withinHours', ['24']),
+    ])
+    expect(clause).toContain(
+      'event_time > now() - toIntervalHour(toUInt64OrZero({flt_0:String}))'
+    )
+  })
+
+  test('joins multiple conditions with AND', () => {
+    const schema: FilterSchema = {
+      fields: [
+        {
+          key: 'u',
+          column: 'user',
+          label: 'u',
+          type: 'text',
+          operators: ['eq'],
+        },
+        {
+          key: 'n',
+          column: 'n',
+          label: 'n',
+          type: 'number',
+          operators: ['gt'],
+        },
+      ],
+    }
+    const { clause } = buildWhereClause(schema, [
+      filter('u', 'eq', ['default']),
+      filter('n', 'gt', ['5']),
+    ])
+    expect(clause.startsWith('WHERE ')).toBe(true)
+    expect(clause).toContain('AND')
+  })
+})
+
+describe('buildWhereClause — operand coercion', () => {
+  test('number field scales the value before parameterizing', () => {
+    const schema = schemaOf({
+      key: 'mem',
+      column: 'memory',
+      type: 'number',
+      scale: 1048576, // MB → bytes
+    })
+    const { params } = buildWhereClause(schema, [filter('mem', 'eq', ['2'])])
+    expect(Object.values(params)).toContain(2 * 1048576)
+  })
+
+  test('non-numeric value on a number field drops the condition', () => {
+    const schema = schemaOf({ key: 'n', column: 'n', type: 'number' })
+    expect(buildWhereClause(schema, [filter('n', 'eq', ['abc'])]).clause).toBe(
+      ''
+    )
+  })
+
+  test('datetime field wraps the value in parseDateTimeBestEffortOrNull', () => {
+    const schema = schemaOf({ key: 't', column: 'ts', type: 'datetime' })
+    const { clause } = buildWhereClause(schema, [
+      filter('t', 'eq', ['2026-01-01']),
+    ])
+    expect(clause).toContain('parseDateTimeBestEffortOrNull({flt_0:String})')
+  })
+
+  test('blank/whitespace-only values are dropped', () => {
+    const schema = schemaOf({ key: 'u', column: 'user', type: 'text' })
+    expect(buildWhereClause(schema, [filter('u', 'eq', ['   '])]).clause).toBe(
+      ''
+    )
+  })
+})
+
+describe('applyFilterPlaceholder', () => {
+  const clause = 'WHERE user = {flt_0:String}'
+
+  test('replaces the marker in a plain SQL string', () => {
+    const sql = `SELECT * FROM t ${FILTER_PLACEHOLDER}`
+    expect(applyFilterPlaceholder(sql, clause)).toBe(
+      `SELECT * FROM t ${clause}`
+    )
+  })
+
+  test('replaces the marker in every versioned SQL variant', () => {
+    const versioned = [
+      { sql: `SELECT a FROM t ${FILTER_PLACEHOLDER}` },
+      { since: '24.1', sql: `SELECT a, b FROM t ${FILTER_PLACEHOLDER}` },
+    ]
+    const out = applyFilterPlaceholder(versioned, clause)
+    expect(out[0].sql).toContain(clause)
+    expect(out[1].sql).toContain(clause)
+    expect(out[1].since).toBe('24.1')
+  })
+
+  test('replaces every occurrence of the marker', () => {
+    const sql = `${FILTER_PLACEHOLDER} ... ${FILTER_PLACEHOLDER}`
+    expect(applyFilterPlaceholder(sql, 'X').match(/X/g)).toHaveLength(2)
+  })
+})

--- a/apps/dashboard-tsr/src/lib/format-number.test.ts
+++ b/apps/dashboard-tsr/src/lib/format-number.test.ts
@@ -1,0 +1,26 @@
+import { formatCompactNumber, formatNumber } from './format-number'
+import { describe, expect, test } from 'bun:test'
+
+describe('formatCompactNumber (Intl compact)', () => {
+  test('values under 1000 are shown in full', () => {
+    expect(formatCompactNumber(0)).toBe('0')
+    expect(formatCompactNumber(999)).toBe('999')
+  })
+
+  test('large values use compact notation', () => {
+    // Locale-dependent suffix; assert the magnitude letter is present.
+    expect(formatCompactNumber(1_234_567)).toMatch(/M$/)
+    expect(formatCompactNumber(45_678)).toMatch(/K$/)
+  })
+
+  test('negative values below the threshold stay full', () => {
+    expect(formatCompactNumber(-500)).toBe('-500')
+  })
+})
+
+describe('formatNumber', () => {
+  test('applies locale grouping', () => {
+    // en-like locales group with commas; assert digits are preserved.
+    expect(formatNumber(1234567).replace(/[^0-9]/g, '')).toBe('1234567')
+  })
+})

--- a/apps/dashboard-tsr/src/lib/format-readable.test.ts
+++ b/apps/dashboard-tsr/src/lib/format-readable.test.ts
@@ -1,0 +1,96 @@
+import {
+  formatCompactNumber,
+  formatQuery,
+  formatReadableQuantity,
+  formatReadableSecondDuration,
+  formatReadableSize,
+} from './format-readable'
+import { describe, expect, test } from 'bun:test'
+
+describe('formatReadableSize', () => {
+  test('zero / falsy bytes render as "0 Bytes"', () => {
+    expect(formatReadableSize(0)).toBe('0 Bytes')
+    expect(formatReadableSize(Number.NaN)).toBe('0 Bytes')
+  })
+
+  test('scales through binary units (1024-based)', () => {
+    expect(formatReadableSize(1024)).toBe('1 KiB')
+    expect(formatReadableSize(1024 * 1024)).toBe('1 MiB')
+    expect(formatReadableSize(1536)).toBe('1.5 KiB')
+  })
+
+  test('honors the decimals argument', () => {
+    expect(formatReadableSize(1536, 0)).toBe('2 KiB')
+    expect(formatReadableSize(1536, 3)).toBe('1.5 KiB')
+  })
+
+  test('negative sizes keep their sign', () => {
+    expect(formatReadableSize(-1024)).toBe('-1 KiB')
+  })
+
+  test('caps at the largest unit', () => {
+    expect(formatReadableSize(1024 ** 9)).toContain('YiB')
+  })
+})
+
+describe('formatReadableQuantity', () => {
+  test('short preset uses compact notation', () => {
+    expect(formatReadableQuantity(123456789)).toBe('123M')
+  })
+
+  test('long preset uses grouped standard notation', () => {
+    expect(formatReadableQuantity(123456789, 'long')).toBe('123,456,789')
+  })
+})
+
+describe('formatCompactNumber (K/M/B suffix)', () => {
+  test('non-positive / non-finite collapses to "0"', () => {
+    expect(formatCompactNumber(0)).toBe('0')
+    expect(formatCompactNumber(-5)).toBe('0')
+    expect(formatCompactNumber(Number.POSITIVE_INFINITY)).toBe('0')
+  })
+
+  test('thresholds at K / M / B with one decimal', () => {
+    expect(formatCompactNumber(999)).toBe('999')
+    expect(formatCompactNumber(13247)).toBe('13.2K')
+    expect(formatCompactNumber(1_400_000)).toBe('1.4M')
+    expect(formatCompactNumber(2_500_000_000)).toBe('2.5B')
+  })
+})
+
+describe('formatReadableSecondDuration', () => {
+  test('sub-second is "0s"', () => {
+    expect(formatReadableSecondDuration(0.4)).toBe('0s')
+  })
+
+  test('under a minute shows seconds', () => {
+    expect(formatReadableSecondDuration(45)).toBe('45s')
+  })
+
+  test('a minute or more shows minutes and seconds', () => {
+    expect(formatReadableSecondDuration(90)).toBe('1m 30s')
+    expect(formatReadableSecondDuration(60)).toBe('1m 0s')
+  })
+})
+
+describe('formatQuery', () => {
+  test('collapses whitespace and trims by default', () => {
+    expect(formatQuery({ query: '  SELECT\n  1,\n  2  ' })).toBe('SELECT 1, 2')
+  })
+
+  test('comment_remove strips block comments', () => {
+    expect(
+      formatQuery({ query: '/* hint */ SELECT 1', comment_remove: true })
+    ).toBe('SELECT 1')
+  })
+
+  test('truncate appends an ellipsis past the limit', () => {
+    expect(formatQuery({ query: 'SELECT abcdef', truncate: 6 })).toBe(
+      'SELECT...'
+    )
+  })
+
+  test('trim:false preserves original spacing', () => {
+    expect(formatQuery({ query: 'a\nb', trim: false })).toBe('a\nb')
+  })
+})


### PR DESCRIPTION
Adds tests for 5 untested pure-function modules in `apps/dashboard-tsr` (672 LOC, all 0% before).

## Coverage
| | before | after |
|---|---|---|
| Functions | 71.2% | **73.8%** |
| Lines | 83.3% | **84.9%** |

54 new tests, 0 fail.

## What's covered
- **`filters/where-builder`** — the SQL `WHERE` builder, including the **security invariant** (user values always parameterized as `{flt_n:Type}`, never interpolated into SQL; column names come only from the trusted schema). All operator branches, operand coercion (number scaling, non-numeric drop, datetime wrapping), and `applyFilterPlaceholder` (string + versioned SQL).
- **`filters/operators`** — operator metadata integrity + arity type guards.
- **`filters/url-state`** — URL ↔ ActiveFilter round-trip, default/clear semantics, operator-prefix fallback.
- **`format-readable` / `format-number`** — size, quantity, compact, duration, query formatting incl. edge cases.

Part of the dash-tsr hardening for epic #1392 (raise coverage toward the old app's bar before cutover).

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for filter operations, query parameter parsing, SQL query building, and formatting utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->