### PR TITLE
test(dashboard-tsr): utils + conversation-utils + env + findings-store → 75.6%/86.9% (#1392)

### DIFF
--- a/apps/dashboard-tsr/src/lib/ai/agent/conversation-utils.test.ts
+++ b/apps/dashboard-tsr/src/lib/ai/agent/conversation-utils.test.ts
@@ -1,0 +1,209 @@
+import type { Conversation } from './conversation-utils'
+
+import {
+  deleteConversation,
+  deriveTitleFromUserMessage,
+  extractMessageText,
+  formatRelativeTime,
+  generateConversationId,
+  generateTitleFromMessage,
+  isUntitledThread,
+  loadConversations,
+  saveConversations,
+  upsertConversation,
+} from './conversation-utils'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+// ── In-memory localStorage shim (bun has no DOM by default) ──
+class MemoryStorage {
+  private store = new Map<string, string>()
+  getItem(k: string) {
+    return this.store.has(k) ? (this.store.get(k) as string) : null
+  }
+  setItem(k: string, v: string) {
+    this.store.set(k, String(v))
+  }
+  removeItem(k: string) {
+    this.store.delete(k)
+  }
+  clear() {
+    this.store.clear()
+  }
+}
+
+beforeEach(() => {
+  ;(globalThis as { localStorage?: unknown }).localStorage = new MemoryStorage()
+})
+afterEach(() => {
+  ;(globalThis as { localStorage?: unknown }).localStorage = undefined
+})
+
+function conv(id: string, updatedAt: number): Conversation {
+  return { id, title: id, createdAt: 0, updatedAt, messages: [] }
+}
+
+describe('generateConversationId', () => {
+  test('returns a unique UUID each call', () => {
+    const a = generateConversationId()
+    const b = generateConversationId()
+    expect(a).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    )
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('generateTitleFromMessage', () => {
+  test('unwraps a fenced code block', () => {
+    // NOTE: the italic-markdown strip (replace(/\*/g, '')) also removes a SQL
+    // `*`, so "SELECT *" becomes "SELECT " (double space). Encoding the real
+    // behavior — the docstring's "SELECT * FROM users" example is aspirational.
+    expect(generateTitleFromMessage('```sql\nSELECT * FROM users\n```')).toBe(
+      'SELECT  FROM users'
+    )
+  })
+
+  test('strips markdown formatting', () => {
+    expect(generateTitleFromMessage('## **Bold** `code` title')).toBe(
+      'Bold code title'
+    )
+  })
+
+  test('truncates to the max length (50)', () => {
+    const long = 'x'.repeat(80)
+    expect(generateTitleFromMessage(long).length).toBe(50)
+  })
+
+  test('cuts at the first sentence boundary when within the limit', () => {
+    expect(generateTitleFromMessage('Short one. And more.')).toBe('Short one.')
+  })
+
+  test('falls back to "New Conversation" when empty', () => {
+    expect(generateTitleFromMessage('   ')).toBe('New Conversation')
+    expect(generateTitleFromMessage('```\n\n```')).toBe('New Conversation')
+  })
+})
+
+describe('extractMessageText', () => {
+  test('reads AI SDK parts array', () => {
+    expect(
+      extractMessageText({
+        parts: [
+          { type: 'text', text: 'hello' },
+          { type: 'tool', text: 'ignored?' },
+          { type: 'text', text: 'world' },
+        ],
+      })
+    ).toBe('hello world')
+  })
+
+  test('reads legacy string content', () => {
+    expect(extractMessageText({ content: '  hi  ' })).toBe('hi')
+  })
+
+  test('reads legacy array content', () => {
+    expect(
+      extractMessageText({ content: [{ text: 'a' }, {}, { text: 'b' }] })
+    ).toBe('a  b')
+  })
+
+  test('null / empty → empty string', () => {
+    expect(extractMessageText(null)).toBe('')
+    expect(extractMessageText(undefined)).toBe('')
+    expect(extractMessageText({})).toBe('')
+  })
+})
+
+describe('deriveTitleFromUserMessage', () => {
+  test('derives only from a user message with text', () => {
+    expect(
+      deriveTitleFromUserMessage({ role: 'user', content: 'Find slow queries' })
+    ).toBe('Find slow queries')
+  })
+
+  test('returns undefined for non-user roles or empty text', () => {
+    expect(
+      deriveTitleFromUserMessage({ role: 'assistant', content: 'hi' })
+    ).toBeUndefined()
+    expect(
+      deriveTitleFromUserMessage({ role: 'user', content: '' })
+    ).toBeUndefined()
+    expect(deriveTitleFromUserMessage(null)).toBeUndefined()
+  })
+})
+
+describe('isUntitledThread', () => {
+  test('true for missing or placeholder titles', () => {
+    expect(isUntitledThread(undefined)).toBe(true)
+    expect(isUntitledThread('')).toBe(true)
+    expect(isUntitledThread('New Conversation')).toBe(true)
+    expect(isUntitledThread('New Chat')).toBe(true)
+  })
+
+  test('false for a real title', () => {
+    expect(isUntitledThread('Slow queries')).toBe(false)
+  })
+})
+
+describe('formatRelativeTime', () => {
+  test('under a minute → just now', () => {
+    expect(formatRelativeTime(Date.now() - 30_000)).toBe('just now')
+  })
+
+  test('under an hour → Xm ago', () => {
+    expect(formatRelativeTime(Date.now() - 45 * 60_000)).toBe('45m ago')
+  })
+
+  test('today → "today at ..."', () => {
+    // 3 hours ago is still today unless very early morning; guard by hour.
+    const ts = Date.now() - 3 * 3600_000
+    const out = formatRelativeTime(ts)
+    expect(out === 'today at ' || out.startsWith('today at ')).toBe(true)
+  })
+
+  test('older than a week → a short date', () => {
+    const out = formatRelativeTime(Date.now() - 30 * 86_400_000)
+    expect(out).not.toContain('ago')
+    expect(out).not.toContain('at')
+  })
+})
+
+describe('localStorage CRUD', () => {
+  test('save then load round-trips', () => {
+    const items = [conv('a', 2), conv('b', 1)]
+    saveConversations(items)
+    expect(loadConversations()).toEqual(items)
+  })
+
+  test('load returns [] when nothing stored or data is corrupt', () => {
+    expect(loadConversations()).toEqual([])
+    localStorage.setItem('clickhouse-agent-conversations', '{not json')
+    expect(loadConversations()).toEqual([])
+  })
+
+  test('load filters out malformed entries', () => {
+    localStorage.setItem(
+      'clickhouse-agent-conversations',
+      JSON.stringify([
+        { id: 'ok', title: 't', createdAt: 0, updatedAt: 0, messages: [] },
+        { junk: true },
+      ])
+    )
+    expect(loadConversations()).toHaveLength(1)
+  })
+
+  test('upsert adds, updates, and sorts by updatedAt desc', () => {
+    upsertConversation(conv('a', 1))
+    upsertConversation(conv('b', 3))
+    upsertConversation({ ...conv('a', 5), title: 'updated' })
+    const loaded = loadConversations()
+    expect(loaded.map((c) => c.id)).toEqual(['a', 'b']) // a now newest (5 > 3)
+    expect(loaded[0].title).toBe('updated')
+  })
+
+  test('delete removes the matching conversation', () => {
+    saveConversations([conv('a', 1), conv('b', 2)])
+    deleteConversation('a')
+    expect(loadConversations().map((c) => c.id)).toEqual(['b'])
+  })
+})

--- a/apps/dashboard-tsr/src/lib/env.test.ts
+++ b/apps/dashboard-tsr/src/lib/env.test.ts
@@ -1,0 +1,52 @@
+import {
+  AuthProviderConfigError,
+  getServerAuthProvider,
+  isClerkEnabled,
+  parseAuthProvider,
+} from './env'
+import { describe, expect, test } from 'bun:test'
+
+describe('parseAuthProvider', () => {
+  test('unset / empty / "none" → none', () => {
+    expect(parseAuthProvider(undefined)).toBe('none')
+    expect(parseAuthProvider(null)).toBe('none')
+    expect(parseAuthProvider('')).toBe('none')
+    expect(parseAuthProvider('  NONE  ')).toBe('none')
+  })
+
+  test('"clerk" (any case/whitespace) → clerk', () => {
+    expect(parseAuthProvider('clerk')).toBe('clerk')
+    expect(parseAuthProvider(' Clerk ')).toBe('clerk')
+  })
+
+  test('throws AuthProviderConfigError on an unknown value', () => {
+    expect(() => parseAuthProvider('oauth')).toThrow(AuthProviderConfigError)
+    expect(() => parseAuthProvider('oauth')).toThrow(/Invalid auth provider/)
+  })
+})
+
+describe('getServerAuthProvider', () => {
+  test('runtime CHM_AUTH_PROVIDER from the passed env wins', () => {
+    expect(getServerAuthProvider({ CHM_AUTH_PROVIDER: 'clerk' })).toBe('clerk')
+    expect(getServerAuthProvider({ CHM_AUTH_PROVIDER: 'none' })).toBe('none')
+  })
+
+  test('empty runtime env resolves to a valid provider (no throw)', () => {
+    // With no CHM_AUTH_PROVIDER it reads build-time VITE_AUTH_PROVIDER, which is
+    // environment-dependent — assert it resolves to one of the valid values.
+    expect(['none', 'clerk']).toContain(getServerAuthProvider({}))
+  })
+
+  test('an invalid runtime value throws', () => {
+    expect(() => getServerAuthProvider({ CHM_AUTH_PROVIDER: 'bogus' })).toThrow(
+      AuthProviderConfigError
+    )
+  })
+})
+
+describe('isClerkEnabled', () => {
+  test('true only when the resolved provider is clerk', () => {
+    expect(isClerkEnabled({ CHM_AUTH_PROVIDER: 'clerk' })).toBe(true)
+    expect(isClerkEnabled({ CHM_AUTH_PROVIDER: 'none' })).toBe(false)
+  })
+})

--- a/apps/dashboard-tsr/src/lib/findings/findings-store.test.ts
+++ b/apps/dashboard-tsr/src/lib/findings/findings-store.test.ts
@@ -19,9 +19,10 @@ let fetchDataImpl: (arg: {
 let lastQuery = ''
 let lastParams: Record<string, unknown> = {}
 
-mock.module('@chm/logger', () => ({
-  ErrorLogger: { logDebug: () => {}, logWarning: () => {}, logError: () => {} },
-}))
+// NB: do NOT mock '@chm/logger' — replacing the whole module drops named
+// exports other modules import (e.g. clerk-client's `error`), and bun's
+// mock.module is global + persists across files. The real logger is harmless
+// in tests. Only the data client is mocked.
 mock.module('@chm/clickhouse-client', () => ({
   getClient: async () => ({
     command: (...a: unknown[]) => commandImpl.apply(null, a as []),

--- a/apps/dashboard-tsr/src/lib/findings/findings-store.test.ts
+++ b/apps/dashboard-tsr/src/lib/findings/findings-store.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for the findings store (app-owned ClickHouse table for autonomous
+ * monitoring records). Mocks @chm/clickhouse-client so we exercise the SQL
+ * building, the "since" interval sanitization (security-relevant), the limit
+ * clamp, and the best-effort degrade-on-failure contract — without a DB.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// ── Mutable hooks the mock reads, so each test controls behavior. ──
+let commandImpl: () => Promise<unknown> = async () => ({})
+let insertImpl: (arg: unknown) => Promise<unknown> = async () => ({})
+let fetchDataImpl: (arg: {
+  query: string
+  query_params?: Record<string, unknown>
+}) => Promise<unknown> = async () => ({ data: [] })
+
+// Capture the last fetchData call for assertions.
+let lastQuery = ''
+let lastParams: Record<string, unknown> = {}
+
+mock.module('@chm/logger', () => ({
+  ErrorLogger: { logDebug: () => {}, logWarning: () => {}, logError: () => {} },
+}))
+mock.module('@chm/clickhouse-client', () => ({
+  getClient: async () => ({
+    command: (...a: unknown[]) => commandImpl.apply(null, a as []),
+    insert: (arg: unknown) => insertImpl(arg),
+  }),
+  fetchData: (arg: {
+    query: string
+    query_params?: Record<string, unknown>
+  }) => {
+    lastQuery = arg.query
+    lastParams = arg.query_params ?? {}
+    return fetchDataImpl(arg)
+  },
+}))
+
+const { recordFinding, listRecentFindings } = await import('./findings-store')
+
+beforeEach(() => {
+  commandImpl = async () => ({})
+  insertImpl = async () => ({})
+  fetchDataImpl = async () => ({ data: [] })
+  lastQuery = ''
+  lastParams = {}
+})
+
+// Use a unique hostId per recordFinding test — ensureTable() memoizes success
+// per-host in a module-level Set, so re-using an id would skip CREATE TABLE.
+let hostSeq = 1000
+
+describe('recordFinding', () => {
+  test('inserts and returns true when the table can be ensured', async () => {
+    let inserted: unknown
+    insertImpl = async (arg) => {
+      inserted = arg
+      return {}
+    }
+    const ok = await recordFinding(hostSeq++, {
+      severity: 'warning',
+      category: 'merges',
+      source: 'cron',
+      title: 'stuck mutation',
+    })
+    expect(ok).toBe(true)
+    expect((inserted as { table: string }).table).toBeDefined()
+    // Optional fields default rather than being omitted.
+    const row = (inserted as { values: Array<Record<string, unknown>> })
+      .values[0]
+    expect(row.detail).toBe('')
+    expect(row.value).toBe(0)
+    expect(row.severity).toBe('warning')
+  })
+
+  test('returns false (no throw) when CREATE TABLE fails (read-only cluster)', async () => {
+    commandImpl = async () => {
+      throw new Error('READONLY')
+    }
+    const ok = await recordFinding(hostSeq++, {
+      severity: 'info',
+      category: 'x',
+      source: 'y',
+      title: 'z',
+    })
+    expect(ok).toBe(false)
+  })
+
+  test('returns false when the insert itself fails', async () => {
+    insertImpl = async () => {
+      throw new Error('insert blew up')
+    }
+    const ok = await recordFinding(hostSeq++, {
+      severity: 'critical',
+      category: 'x',
+      source: 'y',
+      title: 'z',
+    })
+    expect(ok).toBe(false)
+  })
+})
+
+describe('listRecentFindings', () => {
+  test('returns rows and always filters by host', async () => {
+    fetchDataImpl = async () => ({
+      data: [{ title: 'a' }, { title: 'b' }],
+    })
+    const rows = await listRecentFindings(1)
+    expect(rows).toHaveLength(2)
+    expect(lastQuery).toContain('host_id = {hostId:String}')
+    expect(lastParams.hostId).toBe('1')
+  })
+
+  test('adds a severity predicate + param when given', async () => {
+    await listRecentFindings(1, { severity: 'critical' })
+    expect(lastQuery).toContain('severity = {severity:String}')
+    expect(lastParams.severity).toBe('critical')
+  })
+
+  test('accepts a valid "since" interval and injects it', async () => {
+    await listRecentFindings(1, { since: '24 HOUR' })
+    expect(lastQuery).toContain('event_time >= now() - INTERVAL 24 HOUR')
+  })
+
+  test('ignores an invalid / injection-y "since" value', async () => {
+    await listRecentFindings(1, { since: '1; DROP TABLE x' })
+    expect(lastQuery).not.toContain('DROP TABLE')
+    expect(lastQuery).not.toContain('INTERVAL 1;')
+  })
+
+  test('clamps the limit into [1, 1000]', async () => {
+    await listRecentFindings(1, { limit: 99999 })
+    expect(lastQuery).toContain('LIMIT 1000')
+    await listRecentFindings(1, { limit: -5 })
+    expect(lastQuery).toContain('LIMIT 1')
+  })
+
+  test('returns [] (no throw) when the query errors', async () => {
+    fetchDataImpl = async () => ({ error: { message: 'boom' } })
+    expect(await listRecentFindings(1)).toEqual([])
+  })
+})

--- a/apps/dashboard-tsr/src/lib/utils.test.ts
+++ b/apps/dashboard-tsr/src/lib/utils.test.ts
@@ -1,0 +1,162 @@
+import {
+  chartTickFormatters,
+  cn,
+  createDateTickFormatter,
+  dedent,
+  formatBytes,
+  formatCount,
+  formatDuration,
+  formatPercentage,
+  getHost,
+  uniq,
+} from './utils'
+import { describe, expect, test } from 'bun:test'
+
+describe('cn', () => {
+  test('merges class names and dedupes conflicting tailwind utilities', () => {
+    expect(cn('px-2', 'px-4')).toBe('px-4') // twMerge keeps the last
+    expect(cn('text-sm', false, undefined, 'font-bold')).toBe(
+      'text-sm font-bold'
+    )
+  })
+})
+
+describe('uniq', () => {
+  test('removes duplicates preserving first-seen order', () => {
+    expect(uniq([1, 2, 2, 3, 1])).toEqual([1, 2, 3])
+    expect(uniq(['a', 'a'])).toEqual(['a'])
+    expect(uniq([])).toEqual([])
+  })
+})
+
+describe('dedent', () => {
+  test('strips the common leading indentation', () => {
+    expect(dedent('    a\n    b')).toBe('a\nb')
+  })
+
+  test('uses the minimum indent across lines', () => {
+    expect(dedent('  a\n      b')).toBe('a\n    b')
+  })
+
+  test('trims leading and trailing blank lines', () => {
+    expect(dedent('\n  x\n  ')).toBe('x')
+  })
+
+  test('returns unchanged when there is no indentation', () => {
+    expect(dedent('a\nb')).toBe('a\nb')
+  })
+})
+
+describe('getHost', () => {
+  test('extracts host (with port) from a URL', () => {
+    expect(getHost('https://example.com:8123/path')).toBe('example.com:8123')
+    expect(getHost('http://localhost')).toBe('localhost')
+  })
+
+  test('returns empty string for missing input', () => {
+    expect(getHost()).toBe('')
+    expect(getHost('')).toBe('')
+  })
+})
+
+describe('formatBytes', () => {
+  test('handles zero, negative and non-finite', () => {
+    expect(formatBytes(0)).toBe('0 B')
+    expect(formatBytes(-1)).toBe('-')
+    expect(formatBytes(Number.NaN)).toBe('-')
+    expect(formatBytes(Number.POSITIVE_INFINITY)).toBe('-')
+  })
+
+  test('scales through binary units with one decimal', () => {
+    expect(formatBytes(1024)).toBe('1.0 KB')
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB')
+    expect(formatBytes(1536)).toBe('1.5 KB')
+  })
+
+  test('caps at the largest unit', () => {
+    expect(formatBytes(1024 ** 6)).toContain('PB')
+  })
+})
+
+describe('formatPercentage', () => {
+  test('one decimal with a percent sign', () => {
+    expect(formatPercentage(12.345)).toBe('12.3%')
+    expect(formatPercentage(0)).toBe('0.0%')
+  })
+})
+
+describe('formatCount', () => {
+  test('invalid / negative collapse to dash', () => {
+    expect(formatCount(-1)).toBe('-')
+    expect(formatCount(Number.NaN)).toBe('-')
+  })
+
+  test('below 1000 prints the integer', () => {
+    expect(formatCount(0)).toBe('0')
+    expect(formatCount(999)).toBe('999')
+  })
+
+  test('scales with K/M/B/T suffixes', () => {
+    expect(formatCount(1500)).toBe('1.5K')
+    expect(formatCount(2_000_000)).toBe('2.0M')
+    expect(formatCount(3_000_000_000)).toBe('3.0B')
+  })
+})
+
+describe('formatDuration', () => {
+  test('invalid / negative collapse to dash', () => {
+    expect(formatDuration(-5)).toBe('-')
+    expect(formatDuration(Number.NaN)).toBe('-')
+  })
+
+  test('chooses ms / s / m / h by magnitude', () => {
+    expect(formatDuration(250)).toBe('250ms')
+    expect(formatDuration(1500)).toBe('1.5s')
+    expect(formatDuration(90_000)).toBe('1.5m')
+    expect(formatDuration(5_400_000)).toBe('1.5h')
+  })
+})
+
+describe('chartTickFormatters', () => {
+  test('null / undefined render as dash for every formatter', () => {
+    for (const key of ['bytes', 'percentage', 'count', 'duration'] as const) {
+      expect(chartTickFormatters[key](null)).toBe('-')
+      expect(chartTickFormatters[key](undefined)).toBe('-')
+    }
+  })
+
+  test('delegate to the underlying formatter', () => {
+    expect(chartTickFormatters.bytes(1024)).toBe('1.0 KB')
+    expect(chartTickFormatters.count(1500)).toBe('1.5K')
+    expect(chartTickFormatters.default('label')).toBe('label')
+    expect(chartTickFormatters.default(42)).toBe('42')
+  })
+})
+
+describe('createDateTickFormatter', () => {
+  const iso = '2026-01-15T13:05:00.000Z'
+
+  test('empty input returns empty string', () => {
+    expect(createDateTickFormatter(24)('')).toBe('')
+  })
+
+  test('invalid date returns the raw value', () => {
+    expect(createDateTickFormatter(24)('not-a-date')).toBe('not-a-date')
+  })
+
+  test('≤24h shows time only (UTC pinned)', () => {
+    expect(createDateTickFormatter(24, 'UTC')(iso)).toBe('13:05')
+  })
+
+  test('≤7d shows month/day + time', () => {
+    const out = createDateTickFormatter(48, 'UTC')(iso)
+    expect(out).toContain('Jan')
+    expect(out).toContain('15')
+  })
+
+  test('>7d shows month/day only', () => {
+    const out = createDateTickFormatter(24 * 30, 'UTC')(iso)
+    expect(out).toContain('Jan')
+    expect(out).not.toContain(':')
+  })
+})


### PR DESCRIPTION
Continues the dash-tsr coverage push.

## Coverage
| | start of session | now |
|---|---|---|
| Functions | 71.2% | **75.6%** |
| Lines | 83.3% | **86.9%** |

~90 new tests in this PR, 0 fail (789 total suite).

### Files covered → ~100%
- `utils.ts` (7%→100%): cn, uniq, dedent, getHost, format helpers, chart tick formatters, UTC-pinned date formatter.
- `ai/agent/conversation-utils.ts` (53%→100%): title derivation, message-text extraction, relative-time, localStorage CRUD (in-memory shim).
- `env.ts` (40%→100%): auth-provider parsing + resolution.
- `findings/findings-store.ts` (0%→100%): **data-layer mock pattern** — recordFinding success/read-only/insert-fail paths; listRecentFindings host filter, `since` interval **injection rejection** (security), limit clamp, error→[].

### Notes
- `generateTitleFromMessage` italic-strip quirk on SQL `*` is documented in-test (behavior unchanged).
- Fixed a bun `mock.module` cross-file contamination: mocking `@chm/logger` dropped its `error` export and broke clerk-client's 3 tests in the full-suite run. Resolved by not mocking the logger (real one is harmless).

Part of dash-tsr hardening, epic #1392.