### PR TITLE
fix(dashboard-tsr): stop full-page skeleton flash on overview tab switch

### DIFF
--- a/apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx
@@ -101,6 +101,29 @@ const LazyTabContent = function LazyTabContent({
   )
 }
 
+/**
+ * Per-tab loading fallback shown while a newly-visited tab's lazy chart chunks
+ * load. Mirrors the tab's real grid (class + chart count) so the swap is
+ * height-stable and only the tab region — not the whole page — shows skeletons.
+ */
+function TabContentSkeleton({ tab }: { tab: (typeof OVERVIEW_TABS)[number] }) {
+  if (tab.customContent === 'topology') {
+    return <Skeleton className="h-[420px] w-full rounded-lg" />
+  }
+
+  return (
+    <div className={tab.gridClassName} aria-hidden="true">
+      {tab.charts.map((chart) => (
+        <ChartSkeleton
+          key={chart.id}
+          className={cn(OVERVIEW_CHART_CLASS_NAME, chart.className)}
+          type={chart.type === 'metric' ? 'metric' : undefined}
+        />
+      ))}
+    </div>
+  )
+}
+
 function OverviewPageContent() {
   const hostId = useHostId()
   const searchParams = useSearchParams()
@@ -183,19 +206,28 @@ function OverviewPageContent() {
               forceMount={visitedTabs.has(tab.value) ? true : undefined}
             >
               {visitedTabs.has(tab.value) ? (
-                tab.customContent === 'topology' ? (
-                  <TopologyView
-                    hostId={hostId}
-                    detailHref={`/clusters?host=${hostId}`}
-                  />
-                ) : (
-                  <LazyTabContent
-                    charts={tab.charts}
-                    gridClassName={tab.gridClassName}
-                    label={tab.label}
-                    hostId={hostId}
-                  />
-                )
+                // LOCAL Suspense per tab: the charts are React.lazy(), so a
+                // first-time tab visit suspends while its chunk loads. Without
+                // a boundary here that suspension bubbles to the page-level
+                // <Suspense> and flashes the FULL-PAGE skeleton (status strip +
+                // KPI cards + tab bar) on every first tab switch. Catching it
+                // locally swaps only the tab's chart region; everything outside
+                // the tab content stays mounted.
+                <Suspense fallback={<TabContentSkeleton tab={tab} />}>
+                  {tab.customContent === 'topology' ? (
+                    <TopologyView
+                      hostId={hostId}
+                      detailHref={`/clusters?host=${hostId}`}
+                    />
+                  ) : (
+                    <LazyTabContent
+                      charts={tab.charts}
+                      gridClassName={tab.gridClassName}
+                      label={tab.label}
+                      hostId={hostId}
+                    />
+                  )}
+                </Suspense>
               ) : null}
             </TabsContent>
           ))}


### PR DESCRIPTION
## Problem
On `/overview?host=0&tab=health`, switching tabs flashes the **full-page skeleton** — status strip, KPI cards, and the tab bar all reload — instead of swapping just the tab content.

## Root cause
All 52 overview tab charts are `React.lazy()`. Visiting a tab for the first time mounts its lazy charts, which **suspend** while their chunk loads. There was no `Suspense` boundary around `TabsContent`, so the suspension bubbled to the page-level `<Suspense fallback={<OverviewPageFallback/>}>` and replaced the whole page — even though the surrounding KPI cards' SWR data was already cached.

The existing `history.replaceState` design only prevents *router* re-suspension; it can't help here because the suspension comes from React.lazy chunk loading, not `useSearchParams`.

## Fix
Add a **local per-tab `Suspense` boundary** with a grid-matched `TabContentSkeleton` (topology gets a single block). A first-time tab visit now swaps only the tab's chart region; everything outside stays mounted.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab loading behavior with localized loading indicators that display only within the active tab during content fetch, instead of triggering page-level loading states. This provides faster visual feedback and a more responsive experience when switching between dashboard tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->