### PR TITLE
test(dashboard-tsr): cover 8 pure modules (+369 tests) + fix cache-control bug

### DIFF
--- a/apps/dashboard-tsr/src/lib/__tests__/card-error-utils.test.ts
+++ b/apps/dashboard-tsr/src/lib/__tests__/card-error-utils.test.ts
@@ -1,0 +1,529 @@
+import { describe, expect, test } from 'bun:test'
+import { ApiErrorType } from '@/lib/api/types'
+import {
+  detectCardErrorVariant,
+  extractTableFromPermissionError,
+  formatCardErrorForLogging,
+  getCardErrorClassName,
+  getCardErrorDescription,
+  getCardErrorStyle,
+  getCardErrorTitle,
+  getTableMissingInfo,
+  isCardErrorRetryable,
+  isVersionOlder,
+  parseSimpleVersion,
+  shouldShowRetryButton,
+  toEmptyStateVariant,
+} from '@/lib/card-error-utils'
+
+// ---------------------------------------------------------------------------
+// toEmptyStateVariant
+// ---------------------------------------------------------------------------
+
+describe('toEmptyStateVariant', () => {
+  test('maps permission to error', () => {
+    expect(toEmptyStateVariant('permission')).toBe('error')
+  })
+
+  test('passes through all other variants unchanged', () => {
+    expect(toEmptyStateVariant('error')).toBe('error')
+    expect(toEmptyStateVariant('offline')).toBe('offline')
+    expect(toEmptyStateVariant('timeout')).toBe('timeout')
+    expect(toEmptyStateVariant('table-missing')).toBe('table-missing')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detectCardErrorVariant — explicit type fields
+// ---------------------------------------------------------------------------
+
+describe('detectCardErrorVariant — ApiErrorType fields', () => {
+  test('returns permission for ApiErrorType.PermissionError', () => {
+    const err = { type: ApiErrorType.PermissionError, message: '' }
+    expect(detectCardErrorVariant(err as any)).toBe('permission')
+  })
+
+  test('returns table-missing for ApiErrorType.TableNotFound', () => {
+    const err = { type: ApiErrorType.TableNotFound, message: '' }
+    expect(detectCardErrorVariant(err as any)).toBe('table-missing')
+  })
+
+  test('returns offline for ApiErrorType.NetworkError', () => {
+    const err = { type: ApiErrorType.NetworkError, message: '' }
+    expect(detectCardErrorVariant(err as any)).toBe('offline')
+  })
+
+  test('explicit type fields take priority over message keywords', () => {
+    // TableNotFound type but message says "connection" — type wins
+    const err = {
+      type: ApiErrorType.TableNotFound,
+      message: 'connection refused',
+    }
+    expect(detectCardErrorVariant(err as any)).toBe('table-missing')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detectCardErrorVariant — permission keyword detection
+// ---------------------------------------------------------------------------
+
+describe('detectCardErrorVariant — permission keywords', () => {
+  const permissionKeywords = [
+    'permission denied',
+    'access denied',
+    'unauthorized',
+    '401 error',
+    '403 forbidden',
+    'not_enough_privileges',
+    'not enough privileges',
+  ]
+
+  for (const msg of permissionKeywords) {
+    test(`detects permission from message: "${msg}"`, () => {
+      expect(detectCardErrorVariant(new Error(msg))).toBe('permission')
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// detectCardErrorVariant — timeout keywords
+// ---------------------------------------------------------------------------
+
+describe('detectCardErrorVariant — timeout keywords', () => {
+  const timeoutMessages = [
+    'timeout exceeded',
+    'query timed out',
+    'query timeout',
+    'resource limits exceeded',
+    'exceeded resource',
+    'cpu/memory limit hit',
+    'memory limit exceeded',
+  ]
+
+  for (const msg of timeoutMessages) {
+    test(`detects timeout from message: "${msg}"`, () => {
+      expect(detectCardErrorVariant(new Error(msg))).toBe('timeout')
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// detectCardErrorVariant — offline keywords
+// ---------------------------------------------------------------------------
+
+describe('detectCardErrorVariant — offline keywords', () => {
+  const offlineMessages = [
+    'offline',
+    'network error',
+    'fetch failed',
+    'connection refused',
+    'ECONNREFUSED: connect failed',
+    'ENOTFOUND: host not found',
+    'ETIMEDOUT: econnrefused',
+  ]
+
+  for (const msg of offlineMessages) {
+    test(`detects offline from message: "${msg}"`, () => {
+      expect(detectCardErrorVariant(new Error(msg))).toBe('offline')
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// detectCardErrorVariant — table-missing keywords
+// ---------------------------------------------------------------------------
+
+describe('detectCardErrorVariant — table-missing keywords', () => {
+  test('detects table missing from "doesn\'t exist" message', () => {
+    expect(detectCardErrorVariant(new Error("table doesn't exist"))).toBe(
+      'table-missing'
+    )
+  })
+
+  test('detects table missing from "unknown table" message', () => {
+    expect(detectCardErrorVariant(new Error('unknown table system.foo'))).toBe(
+      'table-missing'
+    )
+  })
+
+  test('detects table missing from "table_not_found" message', () => {
+    expect(detectCardErrorVariant(new Error('table_not_found error'))).toBe(
+      'table-missing'
+    )
+  })
+
+  test('detects table missing from "missing" message', () => {
+    expect(detectCardErrorVariant(new Error('table is missing'))).toBe(
+      'table-missing'
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detectCardErrorVariant — HTTP status codes
+// ---------------------------------------------------------------------------
+
+describe('detectCardErrorVariant — HTTP status codes', () => {
+  test('5xx (non-503) returns timeout', () => {
+    expect(detectCardErrorVariant({ message: '', status: 500 } as any)).toBe(
+      'timeout'
+    )
+    expect(detectCardErrorVariant({ message: '', status: 502 } as any)).toBe(
+      'timeout'
+    )
+    expect(detectCardErrorVariant({ message: '', status: 504 } as any)).toBe(
+      'timeout'
+    )
+  })
+
+  test('503 returns offline', () => {
+    expect(detectCardErrorVariant({ message: '', status: 503 } as any)).toBe(
+      'offline'
+    )
+  })
+
+  test('4xx does not trigger status-based classification', () => {
+    // 404 should fall through to generic 'error'
+    expect(detectCardErrorVariant({ message: '', status: 404 } as any)).toBe(
+      'error'
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detectCardErrorVariant — default fallback
+// ---------------------------------------------------------------------------
+
+describe('detectCardErrorVariant — default', () => {
+  test('returns error for unrecognized message', () => {
+    expect(detectCardErrorVariant(new Error('something went wrong'))).toBe(
+      'error'
+    )
+  })
+
+  test('handles missing message gracefully', () => {
+    expect(detectCardErrorVariant({ message: undefined } as any)).toBe('error')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getCardErrorTitle
+// ---------------------------------------------------------------------------
+
+describe('getCardErrorTitle', () => {
+  test('returns standard title for each variant', () => {
+    expect(getCardErrorTitle('error')).toBe('Failed to load')
+    expect(getCardErrorTitle('offline')).toBe("You're offline")
+    expect(getCardErrorTitle('timeout')).toBe('Request timed out')
+    expect(getCardErrorTitle('table-missing')).toBe('Table not available')
+    expect(getCardErrorTitle('permission')).toBe('Permission Required')
+  })
+
+  test('custom title overrides default', () => {
+    expect(getCardErrorTitle('error', 'Custom Title')).toBe('Custom Title')
+  })
+
+  test('empty string custom title falls back to default', () => {
+    expect(getCardErrorTitle('error', '')).toBe('Failed to load')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getCardErrorDescription
+// ---------------------------------------------------------------------------
+
+describe('getCardErrorDescription', () => {
+  test('returns compact short message when compact=true and short is defined', () => {
+    const err = new Error('x')
+    expect(getCardErrorDescription(err, 'error', true)).toBe(
+      'An error occurred.'
+    )
+    expect(getCardErrorDescription(err, 'offline', true)).toBe(
+      'Cannot connect to server.'
+    )
+    expect(getCardErrorDescription(err, 'timeout', true)).toBe(
+      'Query execution timed out.'
+    )
+    expect(getCardErrorDescription(err, 'table-missing', true)).toBe(
+      'Required system table not configured.'
+    )
+    expect(getCardErrorDescription(err, 'permission', true)).toBe(
+      'Permission denied.'
+    )
+  })
+
+  test('returns original message when non-generic and 10 < length < 100', () => {
+    const err = new Error('Connection to 10.0.0.1:9000 refused')
+    const result = getCardErrorDescription(err, 'offline')
+    expect(result).toBe('Connection to 10.0.0.1:9000 refused')
+  })
+
+  test('falls back to standardized description when message is generic', () => {
+    const err = new Error('An error occurred')
+    const result = getCardErrorDescription(err, 'error')
+    expect(result).toBe(
+      'An unexpected error occurred while loading data. Please try again.'
+    )
+  })
+
+  test('falls back to standardized description when message is too short (<=10 chars)', () => {
+    const err = new Error('oops')
+    const result = getCardErrorDescription(err, 'error')
+    expect(result).toContain('unexpected error')
+  })
+
+  test('falls back to standardized description when message is too long (>=100 chars)', () => {
+    const longMsg = 'a'.repeat(101)
+    const err = new Error(longMsg)
+    const result = getCardErrorDescription(err, 'error')
+    expect(result).toContain('unexpected error')
+  })
+
+  test('falls back to standardized when message contains "failed"', () => {
+    const err = new Error('Something has failed badly')
+    const result = getCardErrorDescription(err, 'error')
+    expect(result).toContain('unexpected error')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getCardErrorStyle
+// ---------------------------------------------------------------------------
+
+describe('getCardErrorStyle', () => {
+  test('error variant is destructive', () => {
+    const style = getCardErrorStyle('error')
+    expect(style.isDestructive).toBe(true)
+    expect(style.border).toContain('destructive')
+    expect(style.background).toContain('destructive')
+  })
+
+  test('permission variant is destructive', () => {
+    const style = getCardErrorStyle('permission')
+    expect(style.isDestructive).toBe(true)
+  })
+
+  test('timeout variant is not destructive', () => {
+    const style = getCardErrorStyle('timeout')
+    expect(style.isDestructive).toBe(false)
+    expect(style.border).toContain('warning')
+  })
+
+  test('offline variant is not destructive', () => {
+    const style = getCardErrorStyle('offline')
+    expect(style.isDestructive).toBe(false)
+    expect(style.border).toContain('warning')
+  })
+
+  test('table-missing variant is not destructive', () => {
+    const style = getCardErrorStyle('table-missing')
+    expect(style.isDestructive).toBe(false)
+    expect(style.border).toContain('muted')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getCardErrorClassName
+// ---------------------------------------------------------------------------
+
+describe('getCardErrorClassName', () => {
+  test('returns a string combining border and background classes', () => {
+    const cls = getCardErrorClassName('error')
+    expect(cls).toContain('border-destructive')
+    expect(cls).toContain('bg-destructive')
+  })
+
+  test('offline includes warning classes', () => {
+    const cls = getCardErrorClassName('offline')
+    expect(cls).toContain('warning')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isCardErrorRetryable / shouldShowRetryButton
+// ---------------------------------------------------------------------------
+
+describe('isCardErrorRetryable', () => {
+  test('offline errors are retryable', () => {
+    expect(isCardErrorRetryable(new Error('connection refused'))).toBe(true)
+  })
+
+  test('timeout errors are retryable', () => {
+    expect(isCardErrorRetryable(new Error('timeout exceeded'))).toBe(true)
+  })
+
+  test('permission errors are not retryable', () => {
+    expect(isCardErrorRetryable(new Error('access denied'))).toBe(false)
+  })
+
+  test('table-missing errors are not retryable', () => {
+    expect(isCardErrorRetryable(new Error("table doesn't exist"))).toBe(false)
+  })
+
+  test('generic errors are not retryable', () => {
+    expect(isCardErrorRetryable(new Error('something went wrong'))).toBe(false)
+  })
+})
+
+describe('shouldShowRetryButton', () => {
+  test('is equivalent to isCardErrorRetryable', () => {
+    const err = new Error('network error')
+    expect(shouldShowRetryButton(err)).toBe(isCardErrorRetryable(err))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatCardErrorForLogging
+// ---------------------------------------------------------------------------
+
+describe('formatCardErrorForLogging', () => {
+  test('formats a plain Error', () => {
+    const result = formatCardErrorForLogging(new Error('oops'))
+    expect(result.variant).toBe('error')
+    expect(result.type).toBe('unknown')
+    expect(result.message).toBe('oops')
+    expect(result.hasApiType).toBe(false)
+    expect(result.hasFetchType).toBe(false)
+  })
+
+  test('extracts type from ApiError-shaped object', () => {
+    const err = { type: ApiErrorType.NetworkError, message: 'down' }
+    const result = formatCardErrorForLogging(err as any)
+    expect(result.variant).toBe('offline')
+    expect(result.type).toBe('network_error')
+    expect(result.hasApiType).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getTableMissingInfo
+// ---------------------------------------------------------------------------
+
+describe('getTableMissingInfo', () => {
+  test('returns undefined for non-table-missing errors', () => {
+    expect(getTableMissingInfo(new Error('connection refused'))).toBeUndefined()
+    expect(getTableMissingInfo(new Error('access denied'))).toBeUndefined()
+  })
+
+  test('returns undefined for table-missing error with no missingTables', () => {
+    const err = { type: ApiErrorType.TableNotFound, message: '' }
+    expect(getTableMissingInfo(err as any)).toBeUndefined()
+  })
+
+  test('extracts missingTables from error.missingTables', () => {
+    const err = {
+      type: ApiErrorType.TableNotFound,
+      message: '',
+      missingTables: ['system.query_log'],
+    }
+    const info = getTableMissingInfo(err as any)
+    expect(info).toBeDefined()
+    expect(info!.missingTables).toEqual(['system.query_log'])
+  })
+
+  test('extracts missingTables from error.details.missingTables', () => {
+    const err = {
+      type: ApiErrorType.TableNotFound,
+      message: '',
+      details: { missingTables: ['system.backup_log'] },
+    }
+    const info = getTableMissingInfo(err as any)
+    expect(info).toBeDefined()
+    expect(info!.missingTables).toEqual(['system.backup_log'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseSimpleVersion
+// ---------------------------------------------------------------------------
+
+describe('parseSimpleVersion', () => {
+  test('parses standard ClickHouse version string', () => {
+    expect(parseSimpleVersion('24.3.1.1')).toEqual({
+      major: 24,
+      minor: 3,
+      patch: 1,
+    })
+    expect(parseSimpleVersion('23.8.12.0')).toEqual({
+      major: 23,
+      minor: 8,
+      patch: 12,
+    })
+  })
+
+  test('handles short version strings', () => {
+    expect(parseSimpleVersion('24.3')).toEqual({
+      major: 24,
+      minor: 3,
+      patch: 0,
+    })
+    expect(parseSimpleVersion('24')).toEqual({ major: 24, minor: 0, patch: 0 })
+  })
+
+  test('returns zeroes for empty or invalid input', () => {
+    expect(parseSimpleVersion('')).toEqual({ major: 0, minor: 0, patch: 0 })
+    expect(parseSimpleVersion(null as any)).toEqual({
+      major: 0,
+      minor: 0,
+      patch: 0,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isVersionOlder
+// ---------------------------------------------------------------------------
+
+describe('isVersionOlder', () => {
+  test('returns false when versions are equal', () => {
+    expect(isVersionOlder('24.3.1', '24.3.1')).toBe(false)
+  })
+
+  test('detects older major version', () => {
+    expect(isVersionOlder('23.8.0', '24.0.0')).toBe(true)
+  })
+
+  test('detects newer major version', () => {
+    expect(isVersionOlder('25.1.0', '24.8.0')).toBe(false)
+  })
+
+  test('compares minor versions when major is equal', () => {
+    expect(isVersionOlder('24.2.5', '24.3.0')).toBe(true)
+    expect(isVersionOlder('24.4.0', '24.3.9')).toBe(false)
+  })
+
+  test('compares patch versions when major and minor are equal', () => {
+    expect(isVersionOlder('24.3.1', '24.3.2')).toBe(true)
+    expect(isVersionOlder('24.3.3', '24.3.2')).toBe(false)
+  })
+
+  test('returns false on invalid input', () => {
+    expect(isVersionOlder('bad', 'worse')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractTableFromPermissionError
+// ---------------------------------------------------------------------------
+
+describe('extractTableFromPermissionError', () => {
+  test('extracts system.* table names', () => {
+    expect(
+      extractTableFromPermissionError('Access to system.query_log is denied')
+    ).toBe('system.query_log')
+  })
+
+  test('extracts default.* table names', () => {
+    expect(
+      extractTableFromPermissionError('No access to default.my_table')
+    ).toBe('default.my_table')
+  })
+
+  test('returns undefined when no table name found', () => {
+    expect(extractTableFromPermissionError('generic error')).toBeUndefined()
+  })
+
+  test('handles empty string', () => {
+    expect(extractTableFromPermissionError('')).toBeUndefined()
+  })
+})

--- a/apps/dashboard-tsr/src/lib/__tests__/clickhouse-engine-icons.test.ts
+++ b/apps/dashboard-tsr/src/lib/__tests__/clickhouse-engine-icons.test.ts
@@ -1,0 +1,481 @@
+import {
+  Binary,
+  BookOpen,
+  Boxes,
+  CloudCog,
+  Database,
+  Eye,
+  FileText,
+  FolderKanban,
+  GitMerge,
+  Layers,
+  Link,
+  MemoryStick,
+  Network,
+  Rabbit,
+  RefreshCw,
+  Server,
+  TableIcon,
+  Timer,
+  Trash2,
+  Waves,
+} from 'lucide-react'
+
+import { describe, expect, test } from 'bun:test'
+import {
+  getEngineCategory,
+  getEngineIcon,
+  getEngineIconConfig,
+  isIntegrationEngine,
+  isReplicatedEngine,
+  isSharedEngine,
+  isViewEngine,
+} from '@/lib/clickhouse-engine-icons'
+
+describe('getEngineIconConfig — MergeTree family', () => {
+  test('MergeTree returns mergetree category with TableIcon', () => {
+    const cfg = getEngineIconConfig('MergeTree')
+    expect(cfg.category).toBe('mergetree')
+    expect(cfg.icon).toBe(TableIcon)
+    expect(cfg.color).toBeUndefined()
+  })
+
+  test('ReplacingMergeTree is mergetree', () => {
+    const cfg = getEngineIconConfig('ReplacingMergeTree')
+    expect(cfg.category).toBe('mergetree')
+    expect(cfg.icon).toBe(TableIcon)
+  })
+
+  test('SummingMergeTree is mergetree', () => {
+    expect(getEngineIconConfig('SummingMergeTree').category).toBe('mergetree')
+  })
+
+  test('AggregatingMergeTree is mergetree', () => {
+    expect(getEngineIconConfig('AggregatingMergeTree').category).toBe(
+      'mergetree'
+    )
+  })
+
+  test('CollapsingMergeTree is mergetree', () => {
+    expect(getEngineIconConfig('CollapsingMergeTree').category).toBe(
+      'mergetree'
+    )
+  })
+
+  test('VersionedCollapsingMergeTree is mergetree', () => {
+    expect(getEngineIconConfig('VersionedCollapsingMergeTree').category).toBe(
+      'mergetree'
+    )
+  })
+
+  test('GraphiteMergeTree is mergetree', () => {
+    expect(getEngineIconConfig('GraphiteMergeTree').category).toBe('mergetree')
+  })
+
+  test('CoalescingMergeTree is mergetree', () => {
+    expect(getEngineIconConfig('CoalescingMergeTree').category).toBe(
+      'mergetree'
+    )
+  })
+
+  test('ReplicatedMergeTree is mergetree', () => {
+    const cfg = getEngineIconConfig('ReplicatedMergeTree')
+    expect(cfg.category).toBe('mergetree')
+    expect(cfg.icon).toBe(TableIcon)
+    expect(cfg.label).toBe('ReplicatedMergeTree')
+  })
+
+  test('ReplicatedReplacingMergeTree is mergetree', () => {
+    expect(getEngineIconConfig('ReplicatedReplacingMergeTree').category).toBe(
+      'mergetree'
+    )
+  })
+
+  test('ReplicatedAggregatingMergeTree is mergetree', () => {
+    expect(getEngineIconConfig('ReplicatedAggregatingMergeTree').category).toBe(
+      'mergetree'
+    )
+  })
+
+  test('SharedMergeTree is mergetree', () => {
+    const cfg = getEngineIconConfig('SharedMergeTree')
+    expect(cfg.category).toBe('mergetree')
+    expect(cfg.icon).toBe(TableIcon)
+  })
+
+  test('SharedReplacingMergeTree is mergetree', () => {
+    expect(getEngineIconConfig('SharedReplacingMergeTree').category).toBe(
+      'mergetree'
+    )
+  })
+
+  test('Replicated prefix on non-MergeTree base is NOT mergetree', () => {
+    // e.g. ReplicatedLog does not exist in MERGETREE_VARIANTS
+    const cfg = getEngineIconConfig('ReplicatedLog')
+    expect(cfg.category).toBe('unknown')
+  })
+
+  test('TimeSeries is categorised as mergetree', () => {
+    const cfg = getEngineIconConfig('TimeSeries')
+    expect(cfg.category).toBe('mergetree')
+    expect(cfg.icon).toBe(TableIcon)
+    expect(cfg.label).toBe('Time Series')
+  })
+})
+
+describe('getEngineIconConfig — views', () => {
+  test('View returns view category with Eye icon', () => {
+    const cfg = getEngineIconConfig('View')
+    expect(cfg.category).toBe('view')
+    expect(cfg.icon).toBe(Eye)
+    expect(cfg.color).toBe('text-gray-500')
+  })
+
+  test('MaterializedView returns materialized-view category with Layers icon', () => {
+    const cfg = getEngineIconConfig('MaterializedView')
+    expect(cfg.category).toBe('materialized-view')
+    expect(cfg.icon).toBe(Layers)
+    expect(cfg.color).toBe('text-indigo-500')
+  })
+
+  test('LiveView returns view category with RefreshCw icon', () => {
+    const cfg = getEngineIconConfig('LiveView')
+    expect(cfg.category).toBe('view')
+    expect(cfg.icon).toBe(RefreshCw)
+    expect(cfg.color).toBe('text-green-500')
+  })
+
+  test('WindowView returns view category with Timer icon', () => {
+    const cfg = getEngineIconConfig('WindowView')
+    expect(cfg.category).toBe('view')
+    expect(cfg.icon).toBe(Timer)
+    expect(cfg.color).toBe('text-amber-500')
+  })
+})
+
+describe('getEngineIconConfig — dictionary', () => {
+  test('Dictionary returns BookOpen with orange color', () => {
+    const cfg = getEngineIconConfig('Dictionary')
+    expect(cfg.category).toBe('dictionary')
+    expect(cfg.icon).toBe(BookOpen)
+    expect(cfg.color).toBe('text-orange-500')
+  })
+})
+
+describe('getEngineIconConfig — database integrations', () => {
+  test('PostgreSQL gets sky-600 color', () => {
+    const cfg = getEngineIconConfig('PostgreSQL')
+    expect(cfg.category).toBe('database-integration')
+    expect(cfg.icon).toBe(Database)
+    expect(cfg.color).toBe('text-sky-600')
+    expect(cfg.label).toBe('PostgreSQL')
+  })
+
+  test('MaterializedPostgreSQL also gets PostgreSQL label and sky-600', () => {
+    const cfg = getEngineIconConfig('MaterializedPostgreSQL')
+    expect(cfg.category).toBe('database-integration')
+    expect(cfg.color).toBe('text-sky-600')
+    expect(cfg.label).toBe('PostgreSQL')
+  })
+
+  test('MySQL gets orange-600', () => {
+    const cfg = getEngineIconConfig('MySQL')
+    expect(cfg.category).toBe('database-integration')
+    expect(cfg.color).toBe('text-orange-600')
+    expect(cfg.label).toBe('MySQL')
+  })
+
+  test('MongoDB gets green-600', () => {
+    const cfg = getEngineIconConfig('MongoDB')
+    expect(cfg.category).toBe('database-integration')
+    expect(cfg.color).toBe('text-green-600')
+    expect(cfg.label).toBe('MongoDB')
+  })
+
+  test('other DB engines fall back to slate-500', () => {
+    for (const engine of [
+      'SQLite',
+      'ODBC',
+      'JDBC',
+      'ExternalDistributed',
+      'EmbeddedRocksDB',
+    ]) {
+      const cfg = getEngineIconConfig(engine)
+      expect(cfg.category).toBe('database-integration')
+      expect(cfg.icon).toBe(Database)
+      expect(cfg.color).toBe('text-slate-500')
+      expect(cfg.label).toBe(engine)
+    }
+  })
+})
+
+describe('getEngineIconConfig — queue integrations', () => {
+  test('Kafka gets Waves icon with slate-700', () => {
+    const cfg = getEngineIconConfig('Kafka')
+    expect(cfg.category).toBe('queue-integration')
+    expect(cfg.icon).toBe(Waves)
+    expect(cfg.color).toBe('text-slate-700')
+  })
+
+  test('RabbitMQ gets Rabbit icon with orange-500', () => {
+    const cfg = getEngineIconConfig('RabbitMQ')
+    expect(cfg.category).toBe('queue-integration')
+    expect(cfg.icon).toBe(Rabbit)
+    expect(cfg.color).toBe('text-orange-500')
+  })
+
+  test('NATS falls back to Waves with cyan-500', () => {
+    const cfg = getEngineIconConfig('NATS')
+    expect(cfg.category).toBe('queue-integration')
+    expect(cfg.icon).toBe(Waves)
+    expect(cfg.color).toBe('text-cyan-500')
+  })
+})
+
+describe('getEngineIconConfig — cloud storage', () => {
+  test('S3 returns CloudCog with amber-600 and label S3', () => {
+    const cfg = getEngineIconConfig('S3')
+    expect(cfg.category).toBe('cloud-storage')
+    expect(cfg.icon).toBe(CloudCog)
+    expect(cfg.color).toBe('text-amber-600')
+    expect(cfg.label).toBe('S3')
+  })
+
+  test('S3Queue returns CloudCog with label "S3 Queue"', () => {
+    const cfg = getEngineIconConfig('S3Queue')
+    expect(cfg.category).toBe('cloud-storage')
+    expect(cfg.icon).toBe(CloudCog)
+    expect(cfg.label).toBe('S3 Queue')
+  })
+
+  test('URL returns Link icon with blue-500', () => {
+    const cfg = getEngineIconConfig('URL')
+    expect(cfg.category).toBe('cloud-storage')
+    expect(cfg.icon).toBe(Link)
+    expect(cfg.color).toBe('text-blue-500')
+  })
+
+  test('other cloud engines fall back to CloudCog with sky-500', () => {
+    for (const engine of ['HDFS', 'AzureBlobStorage', 'GCS']) {
+      const cfg = getEngineIconConfig(engine)
+      expect(cfg.category).toBe('cloud-storage')
+      expect(cfg.icon).toBe(CloudCog)
+      expect(cfg.color).toBe('text-sky-500')
+    }
+  })
+})
+
+describe('getEngineIconConfig — data lake', () => {
+  test('data lake engines return Waves with teal-500', () => {
+    for (const engine of ['Iceberg', 'DeltaLake', 'Hudi', 'Hive']) {
+      const cfg = getEngineIconConfig(engine)
+      expect(cfg.category).toBe('data-lake')
+      expect(cfg.icon).toBe(Waves)
+      expect(cfg.color).toBe('text-teal-500')
+      expect(cfg.label).toBe(engine)
+    }
+  })
+})
+
+describe('getEngineIconConfig — log engines', () => {
+  test('log engines return FileText with gray-500', () => {
+    for (const engine of ['TinyLog', 'StripeLog', 'Log']) {
+      const cfg = getEngineIconConfig(engine)
+      expect(cfg.category).toBe('log')
+      expect(cfg.icon).toBe(FileText)
+      expect(cfg.color).toBe('text-gray-500')
+    }
+  })
+})
+
+describe('getEngineIconConfig — memory engines', () => {
+  test('memory engines return MemoryStick with violet-500', () => {
+    for (const engine of ['Memory', 'Set', 'Join']) {
+      const cfg = getEngineIconConfig(engine)
+      expect(cfg.category).toBe('memory')
+      expect(cfg.icon).toBe(MemoryStick)
+      expect(cfg.color).toBe('text-violet-500')
+    }
+  })
+})
+
+describe('getEngineIconConfig — special engines', () => {
+  test('Buffer is buffer category with FolderKanban and yellow-500', () => {
+    const cfg = getEngineIconConfig('Buffer')
+    expect(cfg.category).toBe('buffer')
+    expect(cfg.icon).toBe(FolderKanban)
+    expect(cfg.color).toBe('text-yellow-500')
+  })
+
+  test('Distributed is distributed category with Network and blue-600', () => {
+    const cfg = getEngineIconConfig('Distributed')
+    expect(cfg.category).toBe('distributed')
+    expect(cfg.icon).toBe(Network)
+    expect(cfg.color).toBe('text-blue-600')
+  })
+
+  test('Merge is distributed category with GitMerge and purple-500', () => {
+    const cfg = getEngineIconConfig('Merge')
+    expect(cfg.category).toBe('distributed')
+    expect(cfg.icon).toBe(GitMerge)
+    expect(cfg.color).toBe('text-purple-500')
+  })
+
+  test('Null is utility with Trash2 and gray-400', () => {
+    const cfg = getEngineIconConfig('Null')
+    expect(cfg.category).toBe('utility')
+    expect(cfg.icon).toBe(Trash2)
+    expect(cfg.color).toBe('text-gray-400')
+  })
+
+  test('File is utility with FileText and slate-500', () => {
+    const cfg = getEngineIconConfig('File')
+    expect(cfg.category).toBe('utility')
+    expect(cfg.icon).toBe(FileText)
+    expect(cfg.color).toBe('text-slate-500')
+  })
+
+  test('GenerateRandom is utility with Binary and pink-500', () => {
+    const cfg = getEngineIconConfig('GenerateRandom')
+    expect(cfg.category).toBe('utility')
+    expect(cfg.icon).toBe(Binary)
+    expect(cfg.color).toBe('text-pink-500')
+    expect(cfg.label).toBe('Random Generator')
+  })
+
+  test('Executable is utility with Server and red-500', () => {
+    const cfg = getEngineIconConfig('Executable')
+    expect(cfg.category).toBe('utility')
+    expect(cfg.icon).toBe(Server)
+    expect(cfg.color).toBe('text-red-500')
+    expect(cfg.label).toBe('Executable')
+  })
+
+  test('ExecutablePool shares the same config as Executable', () => {
+    const cfg = getEngineIconConfig('ExecutablePool')
+    expect(cfg.category).toBe('utility')
+    expect(cfg.icon).toBe(Server)
+    expect(cfg.color).toBe('text-red-500')
+  })
+
+  test('KeeperMap is utility with Boxes and emerald-500', () => {
+    const cfg = getEngineIconConfig('KeeperMap')
+    expect(cfg.category).toBe('utility')
+    expect(cfg.icon).toBe(Boxes)
+    expect(cfg.color).toBe('text-emerald-500')
+    expect(cfg.label).toBe('Keeper Map')
+  })
+})
+
+describe('getEngineIconConfig — unknown / fallback', () => {
+  test('completely unknown engine returns unknown category with TableIcon', () => {
+    const cfg = getEngineIconConfig('SomeNewEngine')
+    expect(cfg.category).toBe('unknown')
+    expect(cfg.icon).toBe(TableIcon)
+    expect(cfg.color).toBeUndefined()
+    expect(cfg.label).toBe('SomeNewEngine')
+  })
+
+  test('empty string engine label falls back to "Table"', () => {
+    const cfg = getEngineIconConfig('')
+    expect(cfg.category).toBe('unknown')
+    expect(cfg.label).toBe('Table')
+  })
+})
+
+describe('getEngineIcon', () => {
+  test('returns icon directly for MergeTree', () => {
+    expect(getEngineIcon('MergeTree')).toBe(TableIcon)
+  })
+
+  test('returns icon directly for Kafka', () => {
+    expect(getEngineIcon('Kafka')).toBe(Waves)
+  })
+
+  test('returns TableIcon for unknown engine', () => {
+    expect(getEngineIcon('Bogus')).toBe(TableIcon)
+  })
+})
+
+describe('getEngineCategory', () => {
+  test('returns mergetree for MergeTree', () => {
+    expect(getEngineCategory('MergeTree')).toBe('mergetree')
+  })
+
+  test('returns unknown for unrecognised engine', () => {
+    expect(getEngineCategory('NoSuchEngine')).toBe('unknown')
+  })
+})
+
+describe('isViewEngine', () => {
+  test('returns true for view engines', () => {
+    expect(isViewEngine('View')).toBe(true)
+    expect(isViewEngine('LiveView')).toBe(true)
+    expect(isViewEngine('WindowView')).toBe(true)
+  })
+
+  test('returns true for materialized-view', () => {
+    expect(isViewEngine('MaterializedView')).toBe(true)
+  })
+
+  test('returns false for non-view engines', () => {
+    expect(isViewEngine('MergeTree')).toBe(false)
+    expect(isViewEngine('Kafka')).toBe(false)
+    expect(isViewEngine('Unknown')).toBe(false)
+  })
+})
+
+describe('isReplicatedEngine', () => {
+  test('returns true for Replicated* engines', () => {
+    expect(isReplicatedEngine('ReplicatedMergeTree')).toBe(true)
+    expect(isReplicatedEngine('ReplicatedAggregatingMergeTree')).toBe(true)
+  })
+
+  test('returns false for non-Replicated engines', () => {
+    expect(isReplicatedEngine('MergeTree')).toBe(false)
+    expect(isReplicatedEngine('SharedMergeTree')).toBe(false)
+    expect(isReplicatedEngine('')).toBe(false)
+  })
+})
+
+describe('isSharedEngine', () => {
+  test('returns true for Shared* engines', () => {
+    expect(isSharedEngine('SharedMergeTree')).toBe(true)
+    expect(isSharedEngine('SharedReplacingMergeTree')).toBe(true)
+  })
+
+  test('returns false for non-Shared engines', () => {
+    expect(isSharedEngine('MergeTree')).toBe(false)
+    expect(isSharedEngine('ReplicatedMergeTree')).toBe(false)
+    expect(isSharedEngine('')).toBe(false)
+  })
+})
+
+describe('isIntegrationEngine', () => {
+  test('returns true for database-integration', () => {
+    expect(isIntegrationEngine('PostgreSQL')).toBe(true)
+    expect(isIntegrationEngine('MySQL')).toBe(true)
+  })
+
+  test('returns true for queue-integration', () => {
+    expect(isIntegrationEngine('Kafka')).toBe(true)
+    expect(isIntegrationEngine('RabbitMQ')).toBe(true)
+  })
+
+  test('returns true for cloud-storage', () => {
+    expect(isIntegrationEngine('S3')).toBe(true)
+    expect(isIntegrationEngine('URL')).toBe(true)
+  })
+
+  test('returns true for data-lake', () => {
+    expect(isIntegrationEngine('Iceberg')).toBe(true)
+    expect(isIntegrationEngine('DeltaLake')).toBe(true)
+  })
+
+  test('returns false for non-integration engines', () => {
+    expect(isIntegrationEngine('MergeTree')).toBe(false)
+    expect(isIntegrationEngine('View')).toBe(false)
+    expect(isIntegrationEngine('Null')).toBe(false)
+    expect(isIntegrationEngine('Unknown')).toBe(false)
+  })
+})

--- a/apps/dashboard-tsr/src/lib/ai/__tests__/agent-model-registry.test.ts
+++ b/apps/dashboard-tsr/src/lib/ai/__tests__/agent-model-registry.test.ts
@@ -1,0 +1,348 @@
+import {
+  DEFAULT_AGENT_MODEL,
+  FALLBACK_AGENT_MODEL,
+  getAllModelOptions,
+  getModelRegistry,
+  isFreeAgentModel,
+  MODEL_REGISTRY,
+  parseExtraModels,
+  resolveDefaultAgentModel,
+} from '../agent-model-registry'
+import { afterEach, describe, expect, test } from 'bun:test'
+
+/**
+ * Surgically set/restore env keys WITHOUT replacing the global `process.env`
+ * object. Swapping the reference (`process.env = {...}`) poisons env for EVERY
+ * test file that runs after this one in the same bun process — it broke an
+ * unrelated clerk-client test in the full suite. Mutate keys in place and undo
+ * exactly those keys in afterEach instead. See CLAUDE.md bun global-state notes.
+ */
+function createEnvSandbox() {
+  const saved: Record<string, string | undefined> = {}
+  return {
+    set(vars: Record<string, string | undefined>) {
+      for (const [key, value] of Object.entries(vars)) {
+        if (!(key in saved)) saved[key] = process.env[key]
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      }
+    },
+    restore() {
+      for (const [key, value] of Object.entries(saved)) {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      }
+      for (const key of Object.keys(saved)) delete saved[key]
+    },
+  }
+}
+
+// ── constants ────────────────────────────────────────────────────────────────
+
+describe('constants', () => {
+  test('DEFAULT_AGENT_MODEL uses anyrouter prefix', () => {
+    expect(DEFAULT_AGENT_MODEL).toMatch(/^anyrouter:/)
+  })
+
+  test('FALLBACK_AGENT_MODEL is the openrouter free auto-router', () => {
+    expect(FALLBACK_AGENT_MODEL).toBe('openrouter/free')
+  })
+})
+
+// ── MODEL_REGISTRY ───────────────────────────────────────────────────────────
+
+describe('MODEL_REGISTRY', () => {
+  test('is a non-empty array', () => {
+    expect(Array.isArray(MODEL_REGISTRY)).toBe(true)
+    expect(MODEL_REGISTRY.length).toBeGreaterThan(0)
+  })
+
+  test('every entry has required fields', () => {
+    for (const entry of MODEL_REGISTRY) {
+      expect(typeof entry.id).toBe('string')
+      expect(entry.id.length).toBeGreaterThan(0)
+      expect(typeof entry.description).toBe('string')
+      expect(typeof entry.contextLength).toBe('number')
+      expect(entry.contextLength).toBeGreaterThan(0)
+      expect(Array.isArray(entry.providers)).toBe(true)
+      expect(entry.providers.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('DEFAULT_AGENT_MODEL id exists in the registry', () => {
+    // DEFAULT_AGENT_MODEL = 'anyrouter:google/gemma-4-26b-a4b-it'
+    const modelId = DEFAULT_AGENT_MODEL.slice(
+      DEFAULT_AGENT_MODEL.indexOf(':') + 1
+    )
+    const found = MODEL_REGISTRY.some((m) => m.id === modelId)
+    expect(found).toBe(true)
+  })
+
+  test('FALLBACK_AGENT_MODEL id exists in the registry', () => {
+    const found = MODEL_REGISTRY.some((m) => m.id === FALLBACK_AGENT_MODEL)
+    expect(found).toBe(true)
+  })
+
+  test('optional pricing field has both input and output when present', () => {
+    for (const entry of MODEL_REGISTRY) {
+      if (entry.pricing !== undefined) {
+        expect(typeof entry.pricing.inputPerMillion).toBe('number')
+        expect(typeof entry.pricing.outputPerMillion).toBe('number')
+      }
+    }
+  })
+})
+
+// ── resolveDefaultAgentModel ─────────────────────────────────────────────────
+
+describe('resolveDefaultAgentModel', () => {
+  const env = createEnvSandbox()
+  const setEnv = (vars: Record<string, string | undefined>) => env.set(vars)
+  afterEach(() => env.restore())
+
+  test('returns DEFAULT_AGENT_MODEL when ANYROUTER_API_KEY is set', () => {
+    setEnv({
+      ANYROUTER_API_KEY: 'ar-key',
+      LLM_API_KEY: undefined,
+      OPENROUTER_API_KEY: undefined,
+    })
+    expect(resolveDefaultAgentModel()).toBe(DEFAULT_AGENT_MODEL)
+  })
+
+  test('returns FALLBACK_AGENT_MODEL when only LLM_API_KEY is set', () => {
+    setEnv({
+      ANYROUTER_API_KEY: undefined,
+      LLM_API_KEY: 'llm-key',
+      OPENROUTER_API_KEY: undefined,
+    })
+    expect(resolveDefaultAgentModel()).toBe(FALLBACK_AGENT_MODEL)
+  })
+
+  test('returns FALLBACK_AGENT_MODEL when only OPENROUTER_API_KEY is set', () => {
+    setEnv({
+      ANYROUTER_API_KEY: undefined,
+      LLM_API_KEY: undefined,
+      OPENROUTER_API_KEY: 'or-key',
+    })
+    expect(resolveDefaultAgentModel()).toBe(FALLBACK_AGENT_MODEL)
+  })
+
+  test('ANYROUTER_API_KEY takes precedence over LLM_API_KEY', () => {
+    setEnv({
+      ANYROUTER_API_KEY: 'ar-key',
+      LLM_API_KEY: 'llm-key',
+      OPENROUTER_API_KEY: undefined,
+    })
+    expect(resolveDefaultAgentModel()).toBe(DEFAULT_AGENT_MODEL)
+  })
+
+  test('falls back to DEFAULT_AGENT_MODEL when no keys are configured', () => {
+    setEnv({
+      ANYROUTER_API_KEY: undefined,
+      LLM_API_KEY: undefined,
+      OPENROUTER_API_KEY: undefined,
+    })
+    expect(resolveDefaultAgentModel()).toBe(DEFAULT_AGENT_MODEL)
+  })
+})
+
+// ── parseExtraModels ─────────────────────────────────────────────────────────
+
+describe('parseExtraModels', () => {
+  const env = createEnvSandbox()
+  const setEnv = (vars: Record<string, string | undefined>) => env.set(vars)
+  afterEach(() => env.restore())
+
+  test('returns empty array when LLM_EXTRA_MODELS is unset', () => {
+    setEnv({ LLM_EXTRA_MODELS: undefined })
+    expect(parseExtraModels()).toEqual([])
+  })
+
+  test('returns empty array for empty string', () => {
+    setEnv({ LLM_EXTRA_MODELS: '' })
+    expect(parseExtraModels()).toEqual([])
+  })
+
+  test('parses a single full entry with contextLength and description', () => {
+    setEnv({
+      LLM_EXTRA_MODELS: 'nvidia:meta/llama-3.3-70b|131072|Llama 3.3 70B',
+    })
+    const result = parseExtraModels()
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      id: 'meta/llama-3.3-70b',
+      description: 'Llama 3.3 70B',
+      contextLength: 131072,
+      providers: ['nvidia'],
+    })
+  })
+
+  test('defaults contextLength to 128000 when omitted', () => {
+    setEnv({ LLM_EXTRA_MODELS: 'openrouter:x-ai/grok-2' })
+    const result = parseExtraModels()
+    expect(result).toHaveLength(1)
+    expect(result[0].contextLength).toBe(128_000)
+  })
+
+  test('defaults description to modelId when omitted', () => {
+    setEnv({ LLM_EXTRA_MODELS: 'openrouter:x-ai/grok-2' })
+    const result = parseExtraModels()
+    expect(result[0].description).toBe('x-ai/grok-2')
+  })
+
+  test('parses multiple comma-separated entries', () => {
+    setEnv({
+      LLM_EXTRA_MODELS:
+        'nvidia:meta/llama-3.3-70b|131072|Llama 3.3 70B,openrouter:x-ai/grok-2',
+    })
+    const result = parseExtraModels()
+    expect(result).toHaveLength(2)
+    expect(result[0].id).toBe('meta/llama-3.3-70b')
+    expect(result[1].id).toBe('x-ai/grok-2')
+  })
+
+  test('handles model ids that themselves contain colons (e.g. :free suffix)', () => {
+    setEnv({ LLM_EXTRA_MODELS: 'openrouter:qwen/qwen3-coder:free' })
+    const result = parseExtraModels()
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('qwen/qwen3-coder:free')
+    expect(result[0].providers).toEqual(['openrouter'])
+  })
+
+  test('skips entries with no colon separator', () => {
+    setEnv({ LLM_EXTRA_MODELS: 'bad-entry-no-colon' })
+    expect(parseExtraModels()).toEqual([])
+  })
+
+  test('skips entries where colon is the first char', () => {
+    setEnv({ LLM_EXTRA_MODELS: ':modelid' })
+    expect(parseExtraModels()).toEqual([])
+  })
+
+  test('skips entries with invalid (non-positive) contextLength', () => {
+    setEnv({ LLM_EXTRA_MODELS: 'openrouter:x-ai/grok-2|abc' })
+    expect(parseExtraModels()).toEqual([])
+  })
+
+  test('skips empty segments between commas', () => {
+    setEnv({ LLM_EXTRA_MODELS: ',openrouter:x-ai/grok-2,' })
+    const result = parseExtraModels()
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('x-ai/grok-2')
+  })
+})
+
+// ── getModelRegistry ─────────────────────────────────────────────────────────
+
+describe('getModelRegistry', () => {
+  const env = createEnvSandbox()
+  const setEnv = (vars: Record<string, string | undefined>) => env.set(vars)
+  afterEach(() => env.restore())
+
+  test('contains at minimum all MODEL_REGISTRY entries', () => {
+    setEnv({ LLM_EXTRA_MODELS: undefined })
+    const result = getModelRegistry()
+    expect(result.length).toBeGreaterThanOrEqual(MODEL_REGISTRY.length)
+    for (const entry of MODEL_REGISTRY) {
+      expect(result.some((r) => r.id === entry.id)).toBe(true)
+    }
+  })
+
+  test('appends extra models from LLM_EXTRA_MODELS', () => {
+    setEnv({
+      LLM_EXTRA_MODELS: 'nvidia:custom/new-model|65536|Custom New Model',
+    })
+    const result = getModelRegistry()
+    const extra = result.find((m) => m.id === 'custom/new-model')
+    expect(extra).toBeDefined()
+    expect(extra?.providers).toEqual(['nvidia'])
+    expect(extra?.contextLength).toBe(65536)
+  })
+
+  test('deduplicates: registry entry wins over extra with same provider:id', () => {
+    // qwen/qwen3.5-397b-a17b is in MODEL_REGISTRY under openrouter provider
+    setEnv({
+      LLM_EXTRA_MODELS: 'openrouter:qwen/qwen3.5-397b-a17b|9999|Duplicate',
+    })
+    const result = getModelRegistry()
+    const matches = result.filter((m) => m.id === 'qwen/qwen3.5-397b-a17b')
+    // Should only appear once (from MODEL_REGISTRY)
+    expect(matches).toHaveLength(1)
+    // The registry entry has pricing; the extra does not — confirm registry wins
+    expect(matches[0].pricing).toBeDefined()
+  })
+
+  test('extra with different provider is not deduped', () => {
+    // Add the same model id but under a provider that is NOT in MODEL_REGISTRY for it
+    setEnv({
+      LLM_EXTRA_MODELS:
+        'newprovider:qwen/qwen3.5-397b-a17b|131072|From newprovider',
+    })
+    const result = getModelRegistry()
+    const extra = result.find(
+      (m) =>
+        m.id === 'qwen/qwen3.5-397b-a17b' && m.providers.includes('newprovider')
+    )
+    expect(extra).toBeDefined()
+  })
+})
+
+// ── getAllModelOptions ────────────────────────────────────────────────────────
+
+describe('getAllModelOptions', () => {
+  test('returns provider:id strings for every model in MODEL_REGISTRY', () => {
+    const options = getAllModelOptions()
+    expect(Array.isArray(options)).toBe(true)
+    // Each registry entry produces one option per provider
+    const expected = MODEL_REGISTRY.flatMap((m) =>
+      m.providers.map((p) => `${p}:${m.id}`)
+    )
+    expect(options).toEqual(expected)
+  })
+
+  test('multi-provider entries produce multiple options', () => {
+    const options = getAllModelOptions()
+    // qwen/qwen3.5-397b-a17b has openrouter, nvidia, anyrouter
+    expect(options).toContain('openrouter:qwen/qwen3.5-397b-a17b')
+    expect(options).toContain('nvidia:qwen/qwen3.5-397b-a17b')
+    expect(options).toContain('anyrouter:qwen/qwen3.5-397b-a17b')
+  })
+
+  test('does NOT include extra models from LLM_EXTRA_MODELS (uses MODEL_REGISTRY only)', () => {
+    const env = createEnvSandbox()
+    env.set({ LLM_EXTRA_MODELS: 'nvidia:custom/extra-model' })
+    try {
+      const options = getAllModelOptions()
+      expect(options.some((o) => o.includes('custom/extra-model'))).toBe(false)
+    } finally {
+      env.restore()
+    }
+  })
+})
+
+// ── isFreeAgentModel ─────────────────────────────────────────────────────────
+
+describe('isFreeAgentModel', () => {
+  test('openrouter/free is free', () => {
+    expect(isFreeAgentModel('openrouter/free')).toBe(true)
+  })
+
+  test('model ending in :free is free', () => {
+    expect(isFreeAgentModel('qwen/qwen3-coder:free')).toBe(true)
+    expect(isFreeAgentModel('google/gemma-4-31b-it:free')).toBe(true)
+  })
+
+  test('paid model is not free', () => {
+    expect(isFreeAgentModel('qwen/qwen3.5-397b-a17b')).toBe(false)
+    expect(isFreeAgentModel('anyrouter:google/gemma-4-26b-a4b-it')).toBe(false)
+  })
+
+  test('provider-prefixed free model is not matched (prefix has no :free)', () => {
+    // 'openrouter:qwen/qwen3-coder:free' ends in ':free' so it IS matched
+    expect(isFreeAgentModel('openrouter:qwen/qwen3-coder:free')).toBe(true)
+  })
+
+  test('empty string is not free', () => {
+    expect(isFreeAgentModel('')).toBe(false)
+  })
+})

--- a/apps/dashboard-tsr/src/lib/ai/agent/__tests__/json-render-patch-guard.test.ts
+++ b/apps/dashboard-tsr/src/lib/ai/agent/__tests__/json-render-patch-guard.test.ts
@@ -1,0 +1,451 @@
+import { createJsonRenderPatchGuardStream } from '../json-render-patch-guard'
+import { describe, expect, test } from 'bun:test'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Collect all chunks emitted from a ReadableStream<T> into an array. */
+async function collect<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const reader = stream.getReader()
+  const chunks: T[] = []
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  return chunks
+}
+
+/** Build a ReadableStream from a fixed list of chunks. */
+function makeStream<T>(chunks: T[]): ReadableStream<T> {
+  return new ReadableStream<T>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk)
+      controller.close()
+    },
+  })
+}
+
+/** Minimal valid allowed component element. */
+const validElement = (type = 'Card') => ({ type })
+
+/** A minimal valid spec object that passes validateJsonRenderSpecCandidate. */
+const validSpec = () => ({
+  root: 'el1',
+  elements: { el1: validElement('Card') },
+})
+
+/** Build a data-spec chunk with a patch payload. */
+function patchChunk(patch: unknown) {
+  return { type: 'data-spec', data: { type: 'patch', patch } } as const
+}
+
+/** Build a data-spec chunk with a flat payload. */
+function flatChunk(spec: unknown) {
+  return { type: 'data-spec', data: { type: 'flat', spec } } as const
+}
+
+/** Build a data-spec chunk with a nested payload. */
+function nestedChunk(spec: unknown) {
+  return { type: 'data-spec', data: { type: 'nested', spec } } as const
+}
+
+// ---------------------------------------------------------------------------
+// Pass-through: non-data-spec chunks
+// ---------------------------------------------------------------------------
+
+describe('non-data-spec chunks', () => {
+  test('passes through chunks whose type is not data-spec', async () => {
+    const input = [
+      { type: 'text', content: 'hello' },
+      { type: 'some-other', foo: 42 },
+    ]
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream(input))
+    )
+    expect(out).toEqual(input)
+  })
+
+  test('passes through a chunk whose data.type is an unrecognised string', async () => {
+    // isDataSpecChunk returns false when data.type is not patch/flat/nested,
+    // so the chunk is treated as a non-data-spec chunk and passed straight through.
+    const unknown = { type: 'data-spec', data: { type: 'unknown-type' } }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([unknown]))
+    )
+    expect(out).toEqual([unknown])
+  })
+
+  test('passes through empty stream', async () => {
+    const out = await collect(createJsonRenderPatchGuardStream(makeStream([])))
+    expect(out).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// stream without pipeThrough (no-op path)
+// ---------------------------------------------------------------------------
+
+describe('stream without pipeThrough', () => {
+  test('returns original stream when pipeThrough is missing', () => {
+    const fakeStream = {
+      pipeThrough: undefined,
+    } as unknown as ReadableStream<unknown>
+    const result = createJsonRenderPatchGuardStream(fakeStream)
+    expect(result).toBe(fakeStream)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// flat / nested spec chunks
+// ---------------------------------------------------------------------------
+
+describe('flat spec chunks', () => {
+  test('allows a valid flat spec with an allowed component', async () => {
+    const chunk = flatChunk(validSpec())
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([chunk]))
+    )
+    expect(out).toHaveLength(1)
+    expect(out[0]).toBe(chunk)
+  })
+
+  test('drops a flat spec that uses a disallowed component', async () => {
+    const spec = { root: 'x', elements: { x: { type: 'DangerousIframe' } } }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([flatChunk(spec)]))
+    )
+    expect(out).toEqual([])
+  })
+
+  test('drops a flat spec missing root', async () => {
+    const spec = { elements: { el1: { type: 'Card' } } }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([flatChunk(spec)]))
+    )
+    expect(out).toEqual([])
+  })
+
+  test('drops a flat spec that is not an object', async () => {
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([flatChunk('string')]))
+    )
+    expect(out).toEqual([])
+  })
+
+  test('drops a flat spec with null elements', async () => {
+    const spec = { root: 'el1', elements: null }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([flatChunk(spec)]))
+    )
+    expect(out).toEqual([])
+  })
+
+  test('drops a flat spec with array elements', async () => {
+    const spec = { root: 'el1', elements: [{ type: 'Card' }] }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([flatChunk(spec)]))
+    )
+    expect(out).toEqual([])
+  })
+
+  test('drops a flat spec when one element has a non-string type', async () => {
+    const spec = { root: 'el1', elements: { el1: { type: 123 } } }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([flatChunk(spec)]))
+    )
+    expect(out).toEqual([])
+  })
+})
+
+describe('nested spec chunks', () => {
+  test('allows a valid nested spec', async () => {
+    const chunk = nestedChunk(validSpec())
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([chunk]))
+    )
+    expect(out).toHaveLength(1)
+  })
+
+  test('drops a nested spec that is not an object', async () => {
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([nestedChunk(null)]))
+    )
+    expect(out).toEqual([])
+  })
+
+  test('drops a nested spec with a disallowed component', async () => {
+    const spec = { root: 'x', elements: { x: { type: 'Script' } } }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([nestedChunk(spec)]))
+    )
+    expect(out).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// patch spec chunks — op validation
+// ---------------------------------------------------------------------------
+
+describe('patch spec — op field', () => {
+  test('drops patch with an unknown op', async () => {
+    const patch = { op: 'hack', path: '/elements/x' }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([patchChunk(patch)]))
+    )
+    expect(out).toEqual([])
+  })
+
+  test('drops patch with missing op', async () => {
+    const patch = { path: '/elements/x' }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([patchChunk(patch)]))
+    )
+    expect(out).toEqual([])
+  })
+
+  test('drops patch where op is not a string', async () => {
+    const patch = { op: 42, path: '/elements/x' }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([patchChunk(patch)]))
+    )
+    expect(out).toEqual([])
+  })
+
+  test('drops patch that is not an object', async () => {
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([patchChunk('oops')]))
+    )
+    expect(out).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// patch spec chunks — path validation
+// ---------------------------------------------------------------------------
+
+describe('patch spec — path field', () => {
+  test('drops patch with missing path', async () => {
+    const patch = { op: 'add' }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([patchChunk(patch)]))
+    )
+    expect(out).toEqual([])
+  })
+
+  test('drops patch whose path does not start with /', async () => {
+    const patch = { op: 'add', path: 'elements/x', value: { type: 'Card' } }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([patchChunk(patch)]))
+    )
+    expect(out).toEqual([])
+  })
+
+  test('drops patch targeting __proto__', async () => {
+    const patch = { op: 'add', path: '/__proto__/x', value: 'evil' }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([patchChunk(patch)]))
+    )
+    expect(out).toEqual([])
+  })
+
+  test('drops patch targeting prototype', async () => {
+    const patch = { op: 'add', path: '/prototype/x', value: 'evil' }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([patchChunk(patch)]))
+    )
+    expect(out).toEqual([])
+  })
+
+  test('drops patch targeting constructor', async () => {
+    const patch = { op: 'add', path: '/constructor/x', value: 'evil' }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([patchChunk(patch)]))
+    )
+    expect(out).toEqual([])
+  })
+
+  test('drops patch with JSON-Pointer encoded dangerous segment (~1 for /)', async () => {
+    // ~0 decodes to ~, ~1 decodes to /. A segment literally named __proto__ should still be blocked.
+    const patch = { op: 'add', path: '/__proto__', value: 'evil' }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([patchChunk(patch)]))
+    )
+    expect(out).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// patch spec chunks — move/copy from field
+// ---------------------------------------------------------------------------
+
+describe('patch spec — move/copy from field', () => {
+  test('drops move patch with from not starting with /', async () => {
+    // The patch references a valid path but a relative `from` — must be rejected.
+    const patch = { op: 'move', path: '/elements/dest', from: 'elements/src' }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([patchChunk(patch)]))
+    )
+    expect(out).toEqual([])
+  })
+
+  test('drops copy patch with dangerous from path', async () => {
+    const patch = { op: 'copy', path: '/elements/dest', from: '/__proto__/x' }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([patchChunk(patch)]))
+    )
+    expect(out).toEqual([])
+  })
+
+  test('drops move patch whose from targets constructor', async () => {
+    const patch = { op: 'move', path: '/elements/dest', from: '/constructor/x' }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([patchChunk(patch)]))
+    )
+    expect(out).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Limits enforcement
+// ---------------------------------------------------------------------------
+
+describe('part count limit', () => {
+  test('drops chunks beyond AGENT_JSON_RENDER_MAX_SPEC_PARTS (80)', async () => {
+    // Build 81 valid flat chunks. First 80 should pass, 81st should be dropped.
+    const chunks = Array.from({ length: 81 }, (_, i) =>
+      flatChunk({
+        root: 'el',
+        elements: { el: validElement(i % 2 === 0 ? 'Card' : 'Text') },
+      })
+    )
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream(chunks))
+    )
+    expect(out).toHaveLength(80)
+  })
+})
+
+describe('part byte limit', () => {
+  test('drops a single chunk that exceeds AGENT_JSON_RENDER_MAX_SPEC_PART_BYTES (24 KiB)', async () => {
+    // Create a spec with a very large value to exceed 24 KiB
+    const bigString = 'x'.repeat(25 * 1024)
+    const spec = {
+      root: 'el',
+      elements: { el: { type: 'Card', _pad: bigString } },
+    }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([flatChunk(spec)]))
+    )
+    expect(out).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Allowed component names
+// ---------------------------------------------------------------------------
+
+describe('allowed component names', () => {
+  const ALLOWED = [
+    'Card',
+    'Stack',
+    'Grid',
+    'Separator',
+    'Heading',
+    'Text',
+    'Alert',
+    'Badge',
+    'Progress',
+    'Skeleton',
+    'Spinner',
+  ]
+
+  for (const name of ALLOWED) {
+    test(`allows component type "${name}"`, async () => {
+      const spec = { root: 'el', elements: { el: { type: name } } }
+      const out = await collect(
+        createJsonRenderPatchGuardStream(makeStream([flatChunk(spec)]))
+      )
+      expect(out).toHaveLength(1)
+    })
+  }
+
+  test('drops a spec with an unlisted component type', async () => {
+    const spec = { root: 'el', elements: { el: { type: 'CustomDanger' } } }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([flatChunk(spec)]))
+    )
+    expect(out).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isDataSpecChunk — data field shape validation
+// ---------------------------------------------------------------------------
+// When a chunk has type 'data-spec' but the data field is not a valid
+// JsonRenderSpecData (patch/flat/nested), isDataSpecChunk returns false and
+// the chunk is treated as opaque — it passes through unchanged.
+// ---------------------------------------------------------------------------
+
+describe('isDataSpecChunk guard — invalid data shapes pass through untouched', () => {
+  test('passes through chunk where data is null', async () => {
+    const chunk = { type: 'data-spec', data: null }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([chunk]))
+    )
+    expect(out).toEqual([chunk])
+  })
+
+  test('passes through chunk where data.type is missing', async () => {
+    const chunk = { type: 'data-spec', data: { spec: validSpec() } }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([chunk]))
+    )
+    expect(out).toEqual([chunk])
+  })
+
+  test('passes through chunk where data.type is a number', async () => {
+    // data.type=42 is not a string matching patch/flat/nested, so isDataSpecChunk
+    // returns false and the chunk is forwarded as-is.
+    const chunk = { type: 'data-spec', data: { type: 42, spec: validSpec() } }
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream([chunk]))
+    )
+    expect(out).toEqual([chunk])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Sequential stream state — compiledSpec accumulation
+// ---------------------------------------------------------------------------
+
+describe('stream state accumulation', () => {
+  test('accepts multiple valid flat chunks in sequence', async () => {
+    const chunks = [
+      flatChunk(validSpec()),
+      flatChunk({ root: 'a', elements: { a: { type: 'Text' } } }),
+    ]
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream(chunks))
+    )
+    expect(out).toHaveLength(2)
+  })
+
+  test('non-data-spec chunks do not affect the spec byte budget', async () => {
+    // Send 79 valid flat specs (under limit), one non-data-spec, then one more flat spec.
+    // All 80 flat specs should pass.
+    const flatChunks = Array.from({ length: 79 }, () => flatChunk(validSpec()))
+    const textChunk = { type: 'text', content: 'hello' }
+    const lastFlat = flatChunk({
+      root: 'b',
+      elements: { b: { type: 'Badge' } },
+    })
+    const chunks = [...flatChunks, textChunk, lastFlat]
+    const out = await collect(
+      createJsonRenderPatchGuardStream(makeStream(chunks))
+    )
+    // 79 flat + 1 text + 1 flat = 81 out, all passing (80 flat within limit + 1 text)
+    expect(out).toHaveLength(81)
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/shared/__tests__/response-builder.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/shared/__tests__/response-builder.test.ts
@@ -1,0 +1,329 @@
+import {
+  CacheControl,
+  createCachedResponse,
+  createErrorResponse,
+  createPlainResponse,
+  createSuccessResponse,
+} from '../response-builder'
+import { describe, expect, test } from 'bun:test'
+import { ApiErrorType } from '@/lib/api/types'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function json(res: Response) {
+  return res.json()
+}
+
+// ---------------------------------------------------------------------------
+// CacheControl constants
+// ---------------------------------------------------------------------------
+
+describe('CacheControl', () => {
+  test('NONE is private with max-age=0', () => {
+    expect(CacheControl.NONE).toBe('private, max-age=0')
+  })
+
+  test('SHORT has s-maxage=30', () => {
+    expect(CacheControl.SHORT).toContain('s-maxage=30')
+  })
+
+  test('MEDIUM has s-maxage=60', () => {
+    expect(CacheControl.MEDIUM).toContain('s-maxage=60')
+  })
+
+  test('LONG has s-maxage=300', () => {
+    expect(CacheControl.LONG).toContain('s-maxage=300')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createSuccessResponse
+// ---------------------------------------------------------------------------
+
+describe('createSuccessResponse', () => {
+  test('returns success:true with data', async () => {
+    const res = createSuccessResponse({ rows: [1, 2, 3] })
+    const body = await json(res)
+    expect(body.success).toBe(true)
+    expect(body.data).toEqual({ rows: [1, 2, 3] })
+  })
+
+  test('defaults to HTTP 200', () => {
+    const res = createSuccessResponse(null)
+    expect(res.status).toBe(200)
+  })
+
+  test('uses custom status code', () => {
+    const res = createSuccessResponse({ created: true }, undefined, 201)
+    expect(res.status).toBe(201)
+  })
+
+  test('metadata defaults are empty/zero when no meta provided', async () => {
+    const res = createSuccessResponse([])
+    const body = await json(res)
+    const { metadata } = body
+    expect(metadata.queryId).toBe('')
+    expect(metadata.duration).toBe(0)
+    expect(metadata.rows).toBe(0)
+    expect(metadata.host).toBe('')
+  })
+
+  test('maps meta fields into metadata', async () => {
+    const res = createSuccessResponse([], {
+      queryId: 'qid-1',
+      duration: 42,
+      rows: 7,
+      sql: 'SELECT 1',
+      apiUrl: '/api/v1/test',
+      timezone: 'UTC',
+      cachedAt: 1000,
+      apiParams: { limit: 10 },
+    })
+    const { metadata } = await json(res)
+    expect(metadata.queryId).toBe('qid-1')
+    expect(metadata.duration).toBe(42)
+    expect(metadata.rows).toBe(7)
+    expect(metadata.sql).toBe('SELECT 1')
+    expect(metadata.apiUrl).toBe('/api/v1/test')
+    expect(metadata.timezone).toBe('UTC')
+    expect(metadata.cachedAt).toBe(1000)
+    expect(metadata.apiParams).toEqual({ limit: 10 })
+  })
+
+  test('omits optional metadata fields when not provided', async () => {
+    const res = createSuccessResponse([])
+    const { metadata } = await json(res)
+    expect(metadata.cachedAt).toBeUndefined()
+    expect(metadata.sql).toBeUndefined()
+    expect(metadata.apiUrl).toBeUndefined()
+    expect(metadata.apiParams).toBeUndefined()
+    expect(metadata.timezone).toBeUndefined()
+  })
+
+  test('coerces numeric meta to numbers', async () => {
+    const res = createSuccessResponse([], {
+      duration: '15' as unknown as number,
+      rows: '3' as unknown as number,
+    })
+    const { metadata } = await json(res)
+    expect(typeof metadata.duration).toBe('number')
+    expect(typeof metadata.rows).toBe('number')
+  })
+
+  test('adds Cache-Control header for 2xx status', () => {
+    const res = createSuccessResponse({})
+    expect(res.headers.get('Cache-Control')).toBe(CacheControl.SHORT)
+  })
+
+  test('adds Cache-Control header for 201', () => {
+    const res = createSuccessResponse({}, undefined, 201)
+    expect(res.headers.get('Cache-Control')).toBe(CacheControl.SHORT)
+  })
+
+  test('does not add Cache-Control for 3xx', () => {
+    const res = createSuccessResponse({}, undefined, 301)
+    // Cache-Control may be absent or null for non-2xx
+    const cc = res.headers.get('Cache-Control')
+    expect(cc).toBeNull()
+  })
+
+  test('content-type is application/json', () => {
+    const res = createSuccessResponse({})
+    expect(res.headers.get('Content-Type')).toContain('application/json')
+  })
+
+  test('custom headers are forwarded', () => {
+    const res = createSuccessResponse({}, undefined, 200, { 'X-Custom': 'hi' })
+    expect(res.headers.get('X-Custom')).toBe('hi')
+  })
+
+  test('accepts null data', async () => {
+    const res = createSuccessResponse(null)
+    const body = await json(res)
+    expect(body.data).toBeNull()
+    expect(body.success).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createErrorResponse
+// ---------------------------------------------------------------------------
+
+describe('createErrorResponse', () => {
+  test('returns success:false', async () => {
+    const res = createErrorResponse(
+      { type: ApiErrorType.ValidationError, message: 'bad input' },
+      400
+    )
+    const body = await json(res)
+    expect(body.success).toBe(false)
+  })
+
+  test('sets the correct HTTP status', () => {
+    const res = createErrorResponse(
+      { type: ApiErrorType.TableNotFound, message: 'not found' },
+      404
+    )
+    expect(res.status).toBe(404)
+  })
+
+  test('includes error type and message', async () => {
+    const res = createErrorResponse(
+      { type: ApiErrorType.QueryError, message: 'query failed' },
+      500
+    )
+    const body = await json(res)
+    expect(body.error.type).toBe(ApiErrorType.QueryError)
+    expect(body.error.message).toBe('query failed')
+  })
+
+  test('propagates details when provided', async () => {
+    const res = createErrorResponse(
+      {
+        type: ApiErrorType.TableNotFound,
+        message: 'Table not found',
+        details: { table: 'system.x', count: 0 },
+      },
+      404
+    )
+    const body = await json(res)
+    expect(body.error.details).toEqual({ table: 'system.x', count: 0 })
+  })
+
+  test('metadata.host is populated from context.hostId', async () => {
+    const res = createErrorResponse(
+      { type: ApiErrorType.ValidationError, message: 'err' },
+      400,
+      { hostId: 2 }
+    )
+    const body = await json(res)
+    expect(body.metadata.host).toBe('2')
+  })
+
+  test('metadata.host defaults to unknown when no context', async () => {
+    const res = createErrorResponse(
+      { type: ApiErrorType.NetworkError, message: 'unreachable' },
+      503
+    )
+    const body = await json(res)
+    expect(body.metadata.host).toBe('unknown')
+  })
+
+  test('metadata defaults are empty/zero for error shape', async () => {
+    const res = createErrorResponse(
+      { type: ApiErrorType.ValidationError, message: 'x' },
+      400
+    )
+    const body = await json(res)
+    expect(body.metadata.queryId).toBe('')
+    expect(body.metadata.duration).toBe(0)
+    expect(body.metadata.rows).toBe(0)
+  })
+
+  test('content-type is application/json', () => {
+    const res = createErrorResponse(
+      { type: ApiErrorType.ValidationError, message: 'x' },
+      400
+    )
+    expect(res.headers.get('Content-Type')).toContain('application/json')
+  })
+
+  test('context route and method fields are accepted without error', () => {
+    // context.route and context.method are accepted but not stored in the response body
+    expect(() =>
+      createErrorResponse(
+        { type: ApiErrorType.ValidationError, message: 'x' },
+        400,
+        { route: '/api/v1/test', method: 'GET', hostId: '0' }
+      )
+    ).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createCachedResponse
+// ---------------------------------------------------------------------------
+
+describe('createCachedResponse', () => {
+  // The caller-supplied cache strategy must win over the SHORT default —
+  // that is the entire purpose of createCachedResponse. (Previously a trailing
+  // Object.assign of DEFAULT_CACHE_HEADERS clobbered it; fixed by spreading
+  // defaults BEFORE caller headers in createSuccessResponse.)
+  test('applies the requested preset (LONG), not the SHORT default', () => {
+    const res = createCachedResponse({ ok: true }, CacheControl.LONG)
+    expect(res.headers.get('Cache-Control')).toBe(CacheControl.LONG)
+  })
+
+  test('applies a custom cache-control string verbatim', () => {
+    const res = createCachedResponse([], 'no-store, no-cache, must-revalidate')
+    expect(res.headers.get('Cache-Control')).toBe(
+      'no-store, no-cache, must-revalidate'
+    )
+  })
+
+  test('wraps data in success ApiResponse shape', async () => {
+    const res = createCachedResponse([1, 2], CacheControl.SHORT)
+    const body = await json(res)
+    expect(body.success).toBe(true)
+    expect(body.data).toEqual([1, 2])
+  })
+
+  test('forwards meta into metadata', async () => {
+    const res = createCachedResponse([], CacheControl.MEDIUM, {
+      rows: 5,
+      sql: 'SELECT 2',
+    })
+    const { metadata } = await json(res)
+    expect(metadata.rows).toBe(5)
+    expect(metadata.sql).toBe('SELECT 2')
+  })
+
+  test('always returns HTTP 200', () => {
+    const res = createCachedResponse({}, CacheControl.NONE)
+    expect(res.status).toBe(200)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createPlainResponse
+// ---------------------------------------------------------------------------
+
+describe('createPlainResponse', () => {
+  test('returns raw data without ApiResponse wrapper', async () => {
+    const res = createPlainResponse({ hosts: ['0', '1'] })
+    const body = await json(res)
+    // There should be no 'success' or 'metadata' wrapping
+    expect(body.hosts).toEqual(['0', '1'])
+    expect(body.success).toBeUndefined()
+    expect(body.metadata).toBeUndefined()
+  })
+
+  test('defaults to HTTP 200', () => {
+    const res = createPlainResponse({})
+    expect(res.status).toBe(200)
+  })
+
+  test('respects custom status', () => {
+    const res = createPlainResponse({ error: 'not found' }, 404)
+    expect(res.status).toBe(404)
+  })
+
+  test('content-type is application/json', () => {
+    const res = createPlainResponse({})
+    expect(res.headers.get('Content-Type')).toContain('application/json')
+  })
+
+  test('handles array data', async () => {
+    const res = createPlainResponse([1, 2, 3])
+    const body = await json(res)
+    expect(body).toEqual([1, 2, 3])
+  })
+
+  test('handles null data', async () => {
+    const res = createPlainResponse(null)
+    const body = await json(res)
+    expect(body).toBeNull()
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/shared/response-builder.ts
+++ b/apps/dashboard-tsr/src/lib/api/shared/response-builder.ts
@@ -119,14 +119,14 @@ export function createSuccessResponse<T>(
     metadata: responseMetadata,
   }
 
+  // Default cache headers apply to successful GET-like responses, but
+  // caller-supplied headers must WIN — otherwise createCachedResponse's custom
+  // Cache-Control is silently clobbered by the default, defeating its purpose.
+  // Spread defaults first, then `headers`, so explicit values take precedence.
   const responseHeaders: HeadersInit = {
     'Content-Type': 'application/json',
+    ...(status >= 200 && status < 300 ? DEFAULT_CACHE_HEADERS : {}),
     ...headers,
-  }
-
-  // Add cache headers for successful GET-like responses
-  if (status >= 200 && status < 300) {
-    Object.assign(responseHeaders, DEFAULT_CACHE_HEADERS)
   }
 
   return Response.json(response, {

--- a/apps/dashboard-tsr/src/lib/api/shared/validators/__tests__/request.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/shared/validators/__tests__/request.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Tests for lib/api/shared/validators/request
+ *
+ * Covers every exported function with valid inputs, invalid branches,
+ * and boundary values. Each test is written to fail if the logic changes.
+ */
+import { describe, expect, test } from 'bun:test'
+import {
+  validateDataRequest,
+  validateEnumValue,
+  validateIntervalParam,
+  validatePaginationParams,
+  validateRequiredString,
+  validateSearchParams,
+} from '@/lib/api/shared/validators/request'
+import { ApiErrorType } from '@/lib/api/types'
+
+// ---------------------------------------------------------------------------
+// validateRequiredString
+// ---------------------------------------------------------------------------
+
+describe('validateRequiredString', () => {
+  test('returns undefined for a valid non-empty string', () => {
+    expect(validateRequiredString('SELECT 1', 'query')).toBeUndefined()
+  })
+
+  test('returns undefined for a string with only internal spaces (not trimmed to empty)', () => {
+    expect(validateRequiredString('a b', 'query')).toBeUndefined()
+  })
+
+  test('returns ValidationError when value is empty string', () => {
+    const err = validateRequiredString('', 'query')
+    expect(err).toBeDefined()
+    expect(err?.type).toBe(ApiErrorType.ValidationError)
+    expect(err?.message).toContain('query')
+  })
+
+  test('returns ValidationError when value is whitespace-only', () => {
+    const err = validateRequiredString('   ', 'query')
+    expect(err).toBeDefined()
+    expect(err?.type).toBe(ApiErrorType.ValidationError)
+  })
+
+  test('returns ValidationError when value is undefined', () => {
+    const err = validateRequiredString(undefined, 'myField')
+    expect(err).toBeDefined()
+    expect(err?.message).toContain('myField')
+  })
+
+  test('returns ValidationError when value is null', () => {
+    const err = validateRequiredString(null, 'myField')
+    expect(err).toBeDefined()
+    expect(err?.type).toBe(ApiErrorType.ValidationError)
+  })
+
+  test('returns ValidationError when value is a number', () => {
+    const err = validateRequiredString(42, 'myField')
+    expect(err).toBeDefined()
+  })
+
+  test('error message includes fieldName', () => {
+    const err = validateRequiredString('', 'theFieldName')
+    expect(err?.message).toContain('theFieldName')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateDataRequest
+// ---------------------------------------------------------------------------
+
+describe('validateDataRequest', () => {
+  test('returns undefined for a fully valid body', () => {
+    const err = validateDataRequest({ query: 'SELECT 1', hostId: 0 })
+    expect(err).toBeUndefined()
+  })
+
+  test('returns undefined for valid body with explicit format', () => {
+    const err = validateDataRequest({
+      query: 'SELECT 1',
+      hostId: 1,
+      format: 'JSON',
+    })
+    expect(err).toBeUndefined()
+  })
+
+  test('returns ValidationError when query is missing', () => {
+    const err = validateDataRequest({ hostId: 0 })
+    expect(err).toBeDefined()
+    expect(err?.type).toBe(ApiErrorType.ValidationError)
+    expect(err?.message).toContain('query')
+  })
+
+  test('returns ValidationError when query is empty string', () => {
+    const err = validateDataRequest({ query: '', hostId: 0 })
+    expect(err).toBeDefined()
+    expect(err?.message).toContain('query')
+  })
+
+  test('returns ValidationError when hostId is missing', () => {
+    const err = validateDataRequest({ query: 'SELECT 1' })
+    expect(err).toBeDefined()
+    expect(err?.type).toBe(ApiErrorType.ValidationError)
+    expect(err?.message).toContain('hostId')
+  })
+
+  test('returns ValidationError when hostId is negative', () => {
+    const err = validateDataRequest({ query: 'SELECT 1', hostId: -1 })
+    expect(err).toBeDefined()
+    expect(err?.message).toContain('hostId')
+  })
+
+  test('returns ValidationError when format is unsupported', () => {
+    const err = validateDataRequest({
+      query: 'SELECT 1',
+      hostId: 0,
+      format: 'XML' as never,
+    })
+    expect(err).toBeDefined()
+    expect(err?.type).toBe(ApiErrorType.ValidationError)
+  })
+
+  test('query error takes precedence over hostId error', () => {
+    const err = validateDataRequest({ query: '', hostId: -1 })
+    expect(err?.message).toContain('query')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateSearchParams
+// ---------------------------------------------------------------------------
+
+describe('validateSearchParams', () => {
+  test('returns undefined when all required params are present', () => {
+    const params = new URLSearchParams({ hostId: '0', sql: 'SELECT 1' })
+    expect(validateSearchParams(params, ['hostId', 'sql'])).toBeUndefined()
+  })
+
+  test('returns undefined for empty requiredParams array', () => {
+    const params = new URLSearchParams()
+    expect(validateSearchParams(params, [])).toBeUndefined()
+  })
+
+  test('returns ValidationError when a param is missing', () => {
+    const params = new URLSearchParams({ hostId: '0' })
+    const err = validateSearchParams(params, ['hostId', 'sql'])
+    expect(err).toBeDefined()
+    expect(err?.type).toBe(ApiErrorType.ValidationError)
+    expect(err?.message).toContain('sql')
+  })
+
+  test('returns ValidationError when a param is present but empty', () => {
+    const params = new URLSearchParams({ hostId: '0', sql: '' })
+    const err = validateSearchParams(params, ['hostId', 'sql'])
+    expect(err).toBeDefined()
+    expect(err?.message).toContain('sql')
+  })
+
+  test('returns ValidationError when a param is whitespace-only', () => {
+    const params = new URLSearchParams({ hostId: '   ' })
+    const err = validateSearchParams(params, ['hostId'])
+    expect(err).toBeDefined()
+    expect(err?.message).toContain('hostId')
+  })
+
+  test('reports the first missing param', () => {
+    const params = new URLSearchParams()
+    const err = validateSearchParams(params, ['alpha', 'beta'])
+    expect(err?.message).toContain('alpha')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validatePaginationParams
+// ---------------------------------------------------------------------------
+
+describe('validatePaginationParams', () => {
+  test('returns default limit=100 offset=0 when params absent', () => {
+    const params = new URLSearchParams()
+    const result = validatePaginationParams(params)
+    expect(result.limit).toBe(100)
+    expect(result.offset).toBe(0)
+    expect(result.error).toBeUndefined()
+  })
+
+  test('parses valid limit and offset', () => {
+    const params = new URLSearchParams({ limit: '50', offset: '10' })
+    const result = validatePaginationParams(params)
+    expect(result.limit).toBe(50)
+    expect(result.offset).toBe(10)
+    expect(result.error).toBeUndefined()
+  })
+
+  test('accepts limit=1 (minimum positive integer)', () => {
+    const params = new URLSearchParams({ limit: '1' })
+    const result = validatePaginationParams(params)
+    expect(result.limit).toBe(1)
+    expect(result.error).toBeUndefined()
+  })
+
+  test('accepts offset=0 (minimum non-negative integer)', () => {
+    const params = new URLSearchParams({ offset: '0' })
+    const result = validatePaginationParams(params)
+    expect(result.offset).toBe(0)
+    expect(result.error).toBeUndefined()
+  })
+
+  test('returns error when limit=0', () => {
+    const params = new URLSearchParams({ limit: '0' })
+    const result = validatePaginationParams(params)
+    expect(result.error).toBeDefined()
+    expect(result.error?.type).toBe(ApiErrorType.ValidationError)
+    expect(result.error?.message).toContain('limit')
+  })
+
+  test('returns error when limit is negative', () => {
+    const params = new URLSearchParams({ limit: '-5' })
+    const result = validatePaginationParams(params)
+    expect(result.error).toBeDefined()
+    expect(result.error?.message).toContain('limit')
+  })
+
+  test('returns error when limit is non-numeric', () => {
+    const params = new URLSearchParams({ limit: 'abc' })
+    const result = validatePaginationParams(params)
+    expect(result.error).toBeDefined()
+    expect(result.error?.message).toContain('limit')
+  })
+
+  test('returns error when limit exceeds 10000', () => {
+    const params = new URLSearchParams({ limit: '10001' })
+    const result = validatePaginationParams(params)
+    expect(result.error).toBeDefined()
+    expect(result.error?.message).toContain('10000')
+  })
+
+  test('accepts limit=10000 (boundary — exactly at max)', () => {
+    const params = new URLSearchParams({ limit: '10000' })
+    const result = validatePaginationParams(params)
+    expect(result.limit).toBe(10000)
+    expect(result.error).toBeUndefined()
+  })
+
+  test('returns error when offset is negative', () => {
+    const params = new URLSearchParams({ offset: '-1' })
+    const result = validatePaginationParams(params)
+    expect(result.error).toBeDefined()
+    expect(result.error?.message).toContain('offset')
+  })
+
+  test('returns error when offset is non-numeric', () => {
+    const params = new URLSearchParams({ offset: 'xyz' })
+    const result = validatePaginationParams(params)
+    expect(result.error).toBeDefined()
+    expect(result.error?.message).toContain('offset')
+  })
+
+  test('limit error uses default values in returned object', () => {
+    const params = new URLSearchParams({ limit: 'bad' })
+    const result = validatePaginationParams(params)
+    expect(result.limit).toBe(100)
+    expect(result.offset).toBe(0)
+  })
+
+  test('valid limit is preserved in returned object when offset errors', () => {
+    const params = new URLSearchParams({ limit: '25', offset: 'bad' })
+    const result = validatePaginationParams(params)
+    expect(result.limit).toBe(25)
+    expect(result.offset).toBe(0)
+    expect(result.error).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateIntervalParam
+// ---------------------------------------------------------------------------
+
+describe('validateIntervalParam', () => {
+  test('returns undefined for null (interval is optional)', () => {
+    expect(validateIntervalParam(null)).toBeUndefined()
+  })
+
+  test('returns undefined for empty string (falsy → optional)', () => {
+    expect(validateIntervalParam('')).toBeUndefined()
+  })
+
+  test('accepts every valid interval', () => {
+    const valid = [
+      'toStartOfSecond',
+      'toStartOfMinute',
+      'toStartOfFiveMinutes',
+      'toStartOfTenMinutes',
+      'toStartOfFifteenMinutes',
+      'toStartOfHour',
+      'toStartOfDay',
+      'toStartOfWeek',
+      'toStartOfMonth',
+      'toStartOfQuarter',
+      'toStartOfYear',
+    ]
+    for (const interval of valid) {
+      expect(validateIntervalParam(interval)).toBeUndefined()
+    }
+  })
+
+  test('returns ValidationError for unknown interval', () => {
+    const err = validateIntervalParam('toStartOfDecade')
+    expect(err).toBeDefined()
+    expect(err?.type).toBe(ApiErrorType.ValidationError)
+    expect(err?.message).toContain('toStartOfDecade')
+  })
+
+  test('returns ValidationError for SQL-injection-style value', () => {
+    const err = validateIntervalParam(
+      "toStartOfDay'; DROP TABLE system.query_log;--"
+    )
+    expect(err).toBeDefined()
+    expect(err?.type).toBe(ApiErrorType.ValidationError)
+  })
+
+  test('returns ValidationError for mixed-case variant of a valid interval', () => {
+    const err = validateIntervalParam('TOSTARTOFDAY')
+    expect(err).toBeDefined()
+    expect(err?.type).toBe(ApiErrorType.ValidationError)
+  })
+
+  test('error message lists at least one valid interval', () => {
+    const err = validateIntervalParam('bad')
+    expect(err?.message).toContain('toStartOfMinute')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateEnumValue
+// ---------------------------------------------------------------------------
+
+describe('validateEnumValue', () => {
+  const ALLOWED = ['asc', 'desc'] as const
+
+  test('returns undefined for undefined (optional field)', () => {
+    expect(validateEnumValue(undefined, ALLOWED, 'order')).toBeUndefined()
+  })
+
+  test('returns undefined for null (optional field)', () => {
+    expect(validateEnumValue(null, ALLOWED, 'order')).toBeUndefined()
+  })
+
+  test('returns undefined for a valid allowed value', () => {
+    expect(validateEnumValue('asc', ALLOWED, 'order')).toBeUndefined()
+    expect(validateEnumValue('desc', ALLOWED, 'order')).toBeUndefined()
+  })
+
+  test('returns ValidationError when value is not in allowed list', () => {
+    const err = validateEnumValue('random', ALLOWED, 'order')
+    expect(err).toBeDefined()
+    expect(err?.type).toBe(ApiErrorType.ValidationError)
+    expect(err?.message).toContain('order')
+  })
+
+  test('error message lists allowed values', () => {
+    const err = validateEnumValue('bad', ALLOWED, 'order')
+    expect(err?.message).toContain('asc')
+    expect(err?.message).toContain('desc')
+  })
+
+  test('returns ValidationError when value is a number (wrong type)', () => {
+    const err = validateEnumValue(1, ALLOWED, 'order')
+    expect(err).toBeDefined()
+    expect(err?.message).toContain('string')
+  })
+
+  test('returns ValidationError when value is an object', () => {
+    const err = validateEnumValue({}, ALLOWED, 'order')
+    expect(err).toBeDefined()
+    expect(err?.type).toBe(ApiErrorType.ValidationError)
+  })
+
+  test('is case-sensitive — "ASC" is not valid when only "asc" is allowed', () => {
+    const err = validateEnumValue('ASC', ALLOWED, 'order')
+    expect(err).toBeDefined()
+  })
+})

--- a/apps/dashboard-tsr/src/lib/auth/providers/__tests__/proxy.test.ts
+++ b/apps/dashboard-tsr/src/lib/auth/providers/__tests__/proxy.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Tests for the reverse-proxy auth provider (proxy.ts).
+ *
+ * Covers:
+ *   - verifyTrustedHeader: header extraction, allow/deny, missing/malformed,
+ *     custom header names, constant-time comparison, edge cases
+ *   - ProxyAuthProvider.authenticateRequest: integration of both mechanisms
+ *
+ * The CF Access JWT path (verifyCfAccess) requires real crypto + a live JWKS
+ * endpoint. The fully-cryptographic path is exercised via the public
+ * authenticateRequest surface: when env vars are absent CF Access is disabled
+ * (returns null), so the provider falls through to the trusted-header path.
+ * We skip forging valid signed JWTs — that would require generating an RSA key
+ * pair + fake JWKS server which is heavy infrastructure for a unit suite.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { ProxyAuthProvider } from '@/lib/auth/providers/proxy'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request('https://example.com/api/v1/test', { headers })
+}
+
+// Store original env values so we can restore them after each test.
+const originalEnv: Record<string, string | undefined> = {}
+const MANAGED_KEYS = [
+  'CHM_PROXY_AUTH_SECRET',
+  'CHM_PROXY_SHARED_SECRET_HEADER',
+  'CHM_PROXY_AUTH_HEADER',
+  'CHM_CF_ACCESS_TEAM_DOMAIN',
+  'CHM_CF_ACCESS_AUD',
+]
+
+beforeEach(() => {
+  for (const key of MANAGED_KEYS) {
+    originalEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+})
+
+afterEach(() => {
+  for (const key of MANAGED_KEYS) {
+    if (originalEnv[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = originalEnv[key]
+    }
+  }
+})
+
+// ---------------------------------------------------------------------------
+// ProxyAuthProvider — trusted header path (CF Access disabled)
+// ---------------------------------------------------------------------------
+
+describe('ProxyAuthProvider — trusted-header mechanism', () => {
+  test('returns authenticated=false when CHM_PROXY_AUTH_SECRET is unset', async () => {
+    // No secret → mechanism disabled → deny
+    const provider = new ProxyAuthProvider()
+    const result = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'alice@example.com',
+        'X-Chm-Proxy-Secret': 'anything',
+      })
+    )
+    expect(result.authenticated).toBe(false)
+  })
+
+  test('returns authenticated=false when secret header is absent', async () => {
+    process.env.CHM_PROXY_AUTH_SECRET = 'supersecret'
+    const provider = new ProxyAuthProvider()
+    const result = await provider.authenticateRequest(
+      makeRequest({ 'X-Forwarded-User': 'alice@example.com' })
+    )
+    expect(result.authenticated).toBe(false)
+  })
+
+  test('returns authenticated=false when secret is wrong', async () => {
+    process.env.CHM_PROXY_AUTH_SECRET = 'correct-secret'
+    const provider = new ProxyAuthProvider()
+    const result = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'alice@example.com',
+        'X-Chm-Proxy-Secret': 'wrong-secret',
+      })
+    )
+    expect(result.authenticated).toBe(false)
+  })
+
+  test('returns authenticated=true with subject when secret and identity match', async () => {
+    process.env.CHM_PROXY_AUTH_SECRET = 'correct-secret'
+    const provider = new ProxyAuthProvider()
+    const result = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'alice@example.com',
+        'X-Chm-Proxy-Secret': 'correct-secret',
+      })
+    )
+    expect(result.authenticated).toBe(true)
+    expect(result.subject).toBe('alice@example.com')
+  })
+
+  test('returns authenticated=false when secret matches but identity header is absent', async () => {
+    process.env.CHM_PROXY_AUTH_SECRET = 'correct-secret'
+    const provider = new ProxyAuthProvider()
+    const result = await provider.authenticateRequest(
+      makeRequest({ 'X-Chm-Proxy-Secret': 'correct-secret' })
+    )
+    expect(result.authenticated).toBe(false)
+  })
+
+  test('returns authenticated=false when secret matches but identity header is empty string', async () => {
+    process.env.CHM_PROXY_AUTH_SECRET = 'correct-secret'
+    const provider = new ProxyAuthProvider()
+    // Browsers/fetch won't send empty-string headers in practice, but the
+    // Headers API does preserve them — Request.headers.get returns '' not null
+    // for an explicitly-set empty header value, so our guard returns false.
+    const req = new Request('https://example.com/', {
+      headers: new Headers([
+        ['X-Chm-Proxy-Secret', 'correct-secret'],
+        ['X-Forwarded-User', ''],
+      ]),
+    })
+    const result = await provider.authenticateRequest(req)
+    // An empty identity header means no usable principal — deny
+    expect(result.authenticated).toBe(false)
+  })
+
+  test('uses custom secret header name from CHM_PROXY_SHARED_SECRET_HEADER', async () => {
+    process.env.CHM_PROXY_AUTH_SECRET = 'secret123'
+    process.env.CHM_PROXY_SHARED_SECRET_HEADER = 'X-My-Custom-Secret'
+    const provider = new ProxyAuthProvider()
+
+    // Default header name → should NOT be recognised
+    const resultDefaultHeader = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'alice@example.com',
+        'X-Chm-Proxy-Secret': 'secret123',
+      })
+    )
+    expect(resultDefaultHeader.authenticated).toBe(false)
+
+    // Custom header name → should authenticate
+    const resultCustomHeader = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'alice@example.com',
+        'X-My-Custom-Secret': 'secret123',
+      })
+    )
+    expect(resultCustomHeader.authenticated).toBe(true)
+    expect(resultCustomHeader.subject).toBe('alice@example.com')
+  })
+
+  test('uses custom identity header name from CHM_PROXY_AUTH_HEADER', async () => {
+    process.env.CHM_PROXY_AUTH_SECRET = 'secret123'
+    process.env.CHM_PROXY_AUTH_HEADER = 'X-Remote-User'
+    const provider = new ProxyAuthProvider()
+
+    // Default header → identity not found → deny
+    const resultDefault = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'alice@example.com',
+        'X-Chm-Proxy-Secret': 'secret123',
+      })
+    )
+    expect(resultDefault.authenticated).toBe(false)
+
+    // Custom header → identity found → allow
+    const resultCustom = await provider.authenticateRequest(
+      makeRequest({
+        'X-Remote-User': 'alice@example.com',
+        'X-Chm-Proxy-Secret': 'secret123',
+      })
+    )
+    expect(resultCustom.authenticated).toBe(true)
+    expect(resultCustom.subject).toBe('alice@example.com')
+  })
+
+  test('does constant-time comparison: off-by-one char in secret is denied', async () => {
+    process.env.CHM_PROXY_AUTH_SECRET = 'correct-secret'
+    const provider = new ProxyAuthProvider()
+
+    // One char off at end
+    const r1 = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'alice@example.com',
+        'X-Chm-Proxy-Secret': 'correct-secreX',
+      })
+    )
+    expect(r1.authenticated).toBe(false)
+
+    // Extra char appended (different length — constantTimeEqual returns false for len mismatch)
+    const r2 = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'alice@example.com',
+        'X-Chm-Proxy-Secret': 'correct-secret!',
+      })
+    )
+    expect(r2.authenticated).toBe(false)
+
+    // One char shorter
+    const r3 = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'alice@example.com',
+        'X-Chm-Proxy-Secret': 'correct-secre',
+      })
+    )
+    expect(r3.authenticated).toBe(false)
+  })
+
+  test('subject is preserved as-is (arbitrary identity values)', async () => {
+    process.env.CHM_PROXY_AUTH_SECRET = 's3cr3t'
+    const provider = new ProxyAuthProvider()
+
+    const subjects = [
+      'user-with-dashes',
+      'user@domain.tld',
+      '12345',
+      'cn=Alice,dc=example,dc=com',
+    ]
+
+    for (const subject of subjects) {
+      const result = await provider.authenticateRequest(
+        makeRequest({
+          'X-Forwarded-User': subject,
+          'X-Chm-Proxy-Secret': 's3cr3t',
+        })
+      )
+      expect(result.authenticated).toBe(true)
+      expect(result.subject).toBe(subject)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ProxyAuthProvider — CF Access mechanism disabled (no team domain / aud)
+// ---------------------------------------------------------------------------
+
+describe('ProxyAuthProvider — CF Access disabled (no env vars)', () => {
+  test('falls through to trusted header when CF Access is unconfigured', async () => {
+    // CF Access env vars absent → verifyCfAccess returns null → falls through
+    process.env.CHM_PROXY_AUTH_SECRET = 'my-secret'
+    const provider = new ProxyAuthProvider()
+    const result = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'bob@example.com',
+        'X-Chm-Proxy-Secret': 'my-secret',
+        // Provide a dummy Cf-Access-Jwt-Assertion to confirm it doesn't
+        // interfere when CF Access is disabled
+        'Cf-Access-Jwt-Assertion': 'not.a.valid.jwt',
+      })
+    )
+    expect(result.authenticated).toBe(true)
+    expect(result.subject).toBe('bob@example.com')
+  })
+
+  test('denies when neither mechanism authenticates', async () => {
+    // CF Access unconfigured, trusted-header unconfigured too
+    const provider = new ProxyAuthProvider()
+    const result = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'mallory@evil.com',
+        'X-Chm-Proxy-Secret': 'forged-secret',
+        'Cf-Access-Jwt-Assertion': 'forged.jwt.here',
+      })
+    )
+    expect(result.authenticated).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ProxyAuthProvider — CF Access present but malformed JWT
+// ---------------------------------------------------------------------------
+
+describe('ProxyAuthProvider — CF Access present with malformed JWT', () => {
+  test('CF Access configured but JWT is malformed → falls through to trusted header', async () => {
+    process.env.CHM_CF_ACCESS_TEAM_DOMAIN =
+      'https://myteam.cloudflareaccess.com'
+    process.env.CHM_CF_ACCESS_AUD = 'test-audience'
+    process.env.CHM_PROXY_AUTH_SECRET = 'shared-secret'
+
+    const provider = new ProxyAuthProvider()
+    // malformed JWT: not three dot-separated segments
+    const result = await provider.authenticateRequest(
+      makeRequest({
+        'Cf-Access-Jwt-Assertion': 'not-a-valid-jwt',
+        'X-Forwarded-User': 'alice@example.com',
+        'X-Chm-Proxy-Secret': 'shared-secret',
+      })
+    )
+    // CF Access returns { authenticated: false } for bad JWT, not null,
+    // so the provider short-circuits on that instead of falling through.
+    // Either way the result must not be authenticated=true with a forged identity.
+    expect(typeof result.authenticated).toBe('boolean')
+    // With malformed JWT (not 3 segments) decodeJwt returns null → authenticated:false
+    // We then check: cfAccess.authenticated is false, so we don't return early.
+    // Then trusted header succeeds.
+    if (result.authenticated) {
+      expect(result.subject).toBe('alice@example.com')
+    }
+  })
+
+  test('CF Access configured + JWT with wrong segment count → authenticated false', async () => {
+    process.env.CHM_CF_ACCESS_TEAM_DOMAIN =
+      'https://myteam.cloudflareaccess.com'
+    process.env.CHM_CF_ACCESS_AUD = 'test-audience'
+    // No trusted-header secret set
+    const provider = new ProxyAuthProvider()
+    const result = await provider.authenticateRequest(
+      makeRequest({
+        'Cf-Access-Jwt-Assertion': 'only.two',
+      })
+    )
+    expect(result.authenticated).toBe(false)
+  })
+
+  test('CF Access configured + JWT with non-RS256 alg → authenticated false', async () => {
+    process.env.CHM_CF_ACCESS_TEAM_DOMAIN =
+      'https://myteam.cloudflareaccess.com'
+    process.env.CHM_CF_ACCESS_AUD = 'test-audience'
+
+    // Build a 3-part JWT with HS256 alg (not RS256) — valid base64url segments
+    const header = btoa(JSON.stringify({ alg: 'HS256', kid: 'test-kid' }))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')
+    const payload = btoa(JSON.stringify({ sub: 'alice' }))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')
+    const sig = 'fakesignature'
+    const token = `${header}.${payload}.${sig}`
+
+    const provider = new ProxyAuthProvider()
+    const result = await provider.authenticateRequest(
+      makeRequest({ 'Cf-Access-Jwt-Assertion': token })
+    )
+    expect(result.authenticated).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ProxyAuthProvider — no credentials at all
+// ---------------------------------------------------------------------------
+
+describe('ProxyAuthProvider — bare request with no auth headers', () => {
+  test('returns authenticated=false for a completely bare request', async () => {
+    const provider = new ProxyAuthProvider()
+    const result = await provider.authenticateRequest(makeRequest())
+    expect(result.authenticated).toBe(false)
+  })
+
+  test('returns authenticated=false even with CHM_PROXY_AUTH_SECRET set but no headers', async () => {
+    process.env.CHM_PROXY_AUTH_SECRET = 'anything'
+    const provider = new ProxyAuthProvider()
+    const result = await provider.authenticateRequest(makeRequest())
+    expect(result.authenticated).toBe(false)
+  })
+})

--- a/apps/dashboard-tsr/src/lib/health/__tests__/audit-prompt.test.ts
+++ b/apps/dashboard-tsr/src/lib/health/__tests__/audit-prompt.test.ts
@@ -1,0 +1,429 @@
+import type { HealthCheckDef } from '@/components/health/health-checks'
+import type {
+  AuditPromptInput,
+  AuditPromptOptions,
+} from '@/lib/health/audit-prompt'
+
+import { describe, expect, test } from 'bun:test'
+import {
+  buildAuditPrompt,
+  DEFAULT_AUDIT_PROMPT_OPTIONS,
+  estimateTokens,
+} from '@/lib/health/audit-prompt'
+
+// ---------------------------------------------------------------------------
+// Minimal fixtures
+// ---------------------------------------------------------------------------
+
+const minimalCheck: HealthCheckDef = {
+  id: 'test-check',
+  title: 'Test Check',
+}
+
+const fullCheck: HealthCheckDef = {
+  id: 'merge-queue-depth',
+  title: 'Merge Queue Depth',
+  description: 'Number of parts waiting to be merged.',
+  sql: 'SELECT count() FROM system.merges',
+  systemTables: ['system.merges', 'system.parts'],
+  commonCauses: ['Too many inserts', 'Slow merges'],
+  relatedLinks: [
+    { label: 'Merges', href: '/merges' },
+    { label: 'Running Queries', href: '/running-queries?tab=merges' },
+  ],
+  docsLinks: [
+    {
+      label: 'Merges docs',
+      url: 'https://clickhouse.com/docs/operations/system-tables/merges',
+    },
+  ],
+}
+
+function makeInput(
+  overrides: Partial<AuditPromptInput> = {}
+): AuditPromptInput {
+  return {
+    check: minimalCheck,
+    value: 42,
+    thresholds: { warning: 10, critical: 50 },
+    status: 'warning',
+    hostId: 0,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// estimateTokens
+// ---------------------------------------------------------------------------
+
+describe('estimateTokens', () => {
+  test('returns 0 for empty string', () => {
+    expect(estimateTokens('')).toBe(0)
+  })
+
+  test('returns ceil(length / 4)', () => {
+    expect(estimateTokens('abcd')).toBe(1)
+    expect(estimateTokens('abcde')).toBe(2)
+    expect(estimateTokens('a'.repeat(400))).toBe(100)
+  })
+
+  test('estimate grows with prompt length', () => {
+    const short = buildAuditPrompt(makeInput())
+    const withAll = buildAuditPrompt(makeInput({ check: fullCheck }))
+    expect(estimateTokens(withAll)).toBeGreaterThan(estimateTokens(short))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DEFAULT_AUDIT_PROMPT_OPTIONS
+// ---------------------------------------------------------------------------
+
+describe('DEFAULT_AUDIT_PROMPT_OPTIONS', () => {
+  test('all sections are enabled by default', () => {
+    const keys: (keyof Required<AuditPromptOptions>)[] = [
+      'sql',
+      'rawData',
+      'systemTables',
+      'commonCauses',
+      'relatedLinks',
+      'docsLinks',
+      'docsMarkdown',
+    ]
+    for (const k of keys) {
+      expect(DEFAULT_AUDIT_PROMPT_OPTIONS[k]).toBe(true)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildAuditPrompt — header / observation (always present)
+// ---------------------------------------------------------------------------
+
+describe('buildAuditPrompt — header', () => {
+  test('contains the check title in the H1', () => {
+    const out = buildAuditPrompt(makeInput())
+    expect(out).toContain('# ClickHouse Health Audit — Test Check')
+  })
+
+  test('contains the status in uppercase in the intro paragraph', () => {
+    const out = buildAuditPrompt(makeInput({ status: 'critical' }))
+    expect(out).toContain('**CRITICAL**')
+  })
+
+  test('contains the check id in the observation', () => {
+    const out = buildAuditPrompt(makeInput())
+    expect(out).toContain('`test-check`')
+  })
+
+  test('contains the numeric value', () => {
+    const out = buildAuditPrompt(makeInput({ value: 99 }))
+    expect(out).toContain('99')
+  })
+
+  test('shows "unavailable" when value is null', () => {
+    const out = buildAuditPrompt(makeInput({ value: null }))
+    expect(out).toContain('unavailable')
+  })
+
+  test('uses formatValue when provided', () => {
+    const check: HealthCheckDef = {
+      ...minimalCheck,
+      formatValue: (v) => `${v}ms`,
+    }
+    const out = buildAuditPrompt(makeInput({ check, value: 123 }))
+    expect(out).toContain('123ms')
+  })
+
+  test('contains warning and critical thresholds', () => {
+    const out = buildAuditPrompt(
+      makeInput({ thresholds: { warning: 5, critical: 20 } })
+    )
+    expect(out).toContain('`5`')
+    expect(out).toContain('`20`')
+  })
+
+  test('contains the host id', () => {
+    const out = buildAuditPrompt(makeInput({ hostId: 3 }))
+    expect(out).toContain('`3`')
+  })
+
+  test('shows clickhouse version when provided', () => {
+    const out = buildAuditPrompt(makeInput({ clickhouseVersion: '24.3.1' }))
+    expect(out).toContain('`24.3.1`')
+  })
+
+  test('shows _unknown_ when version is absent', () => {
+    const out = buildAuditPrompt(makeInput())
+    expect(out).toContain('_unknown_')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildAuditPrompt — description section
+// ---------------------------------------------------------------------------
+
+describe('buildAuditPrompt — description section', () => {
+  test('included when check has a description', () => {
+    const check: HealthCheckDef = {
+      ...minimalCheck,
+      description: 'Parts waiting to merge.',
+    }
+    const out = buildAuditPrompt(makeInput({ check }))
+    expect(out).toContain('## Description')
+    expect(out).toContain('Parts waiting to merge.')
+  })
+
+  test('omitted when check has no description', () => {
+    const out = buildAuditPrompt(makeInput())
+    expect(out).not.toContain('## Description')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildAuditPrompt — SQL section
+// ---------------------------------------------------------------------------
+
+describe('buildAuditPrompt — SQL section', () => {
+  test('included when check.sql is set and opts.sql is true', () => {
+    const out = buildAuditPrompt(makeInput({ check: fullCheck }))
+    expect(out).toContain('## Metric query (how this value is computed)')
+    expect(out).toContain('SELECT count() FROM system.merges')
+  })
+
+  test('omitted when opts.sql = false', () => {
+    const out = buildAuditPrompt(makeInput({ check: fullCheck }), {
+      sql: false,
+    })
+    expect(out).not.toContain('## Metric query')
+  })
+
+  test('omitted when check has no sql', () => {
+    const out = buildAuditPrompt(makeInput())
+    expect(out).not.toContain('## Metric query')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildAuditPrompt — raw data section
+// ---------------------------------------------------------------------------
+
+describe('buildAuditPrompt — raw data section', () => {
+  test('included when row has entries and opts.rawData is true', () => {
+    const out = buildAuditPrompt(
+      makeInput({ row: { parts: 7, database: 'default' } })
+    )
+    expect(out).toContain('## Raw data row')
+    expect(out).toContain('`parts`')
+    expect(out).toContain('`7`')
+  })
+
+  test('omitted when row is undefined', () => {
+    const out = buildAuditPrompt(makeInput())
+    expect(out).not.toContain('## Raw data row')
+  })
+
+  test('omitted when row is empty object', () => {
+    const out = buildAuditPrompt(makeInput({ row: {} }))
+    expect(out).not.toContain('## Raw data row')
+  })
+
+  test('omitted when opts.rawData = false', () => {
+    const out = buildAuditPrompt(makeInput({ row: { parts: 7 } }), {
+      rawData: false,
+    })
+    expect(out).not.toContain('## Raw data row')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildAuditPrompt — system tables section
+// ---------------------------------------------------------------------------
+
+describe('buildAuditPrompt — system tables section', () => {
+  test('included when check.systemTables is non-empty', () => {
+    const out = buildAuditPrompt(makeInput({ check: fullCheck }))
+    expect(out).toContain('## Relevant ClickHouse system tables')
+    expect(out).toContain('`system.merges`')
+    expect(out).toContain('`system.parts`')
+  })
+
+  test('omitted when check has no systemTables', () => {
+    const out = buildAuditPrompt(makeInput())
+    expect(out).not.toContain('## Relevant ClickHouse system tables')
+  })
+
+  test('omitted when opts.systemTables = false', () => {
+    const out = buildAuditPrompt(makeInput({ check: fullCheck }), {
+      systemTables: false,
+    })
+    expect(out).not.toContain('## Relevant ClickHouse system tables')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildAuditPrompt — common causes section
+// ---------------------------------------------------------------------------
+
+describe('buildAuditPrompt — common causes section', () => {
+  test('included when check.commonCauses is non-empty', () => {
+    const out = buildAuditPrompt(makeInput({ check: fullCheck }))
+    expect(out).toContain('## Common causes to consider')
+    expect(out).toContain('Too many inserts')
+    expect(out).toContain('Slow merges')
+  })
+
+  test('omitted when check has no commonCauses', () => {
+    const out = buildAuditPrompt(makeInput())
+    expect(out).not.toContain('## Common causes to consider')
+  })
+
+  test('omitted when opts.commonCauses = false', () => {
+    const out = buildAuditPrompt(makeInput({ check: fullCheck }), {
+      commonCauses: false,
+    })
+    expect(out).not.toContain('## Common causes to consider')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildAuditPrompt — related links section
+// ---------------------------------------------------------------------------
+
+describe('buildAuditPrompt — related links section', () => {
+  test('included when check.relatedLinks is non-empty', () => {
+    const out = buildAuditPrompt(makeInput({ check: fullCheck, hostId: 2 }))
+    expect(out).toContain('## Related dashboards (this monitor)')
+    expect(out).toContain('[Merges]')
+    // host query param appended
+    expect(out).toContain('host=2')
+  })
+
+  test('appends ?host= to links without existing query string', () => {
+    const out = buildAuditPrompt(makeInput({ check: fullCheck, hostId: 1 }))
+    expect(out).toContain('/merges?host=1')
+  })
+
+  test('appends &host= to links that already have a query string', () => {
+    const out = buildAuditPrompt(makeInput({ check: fullCheck, hostId: 0 }))
+    expect(out).toContain('/running-queries?tab=merges&host=0')
+  })
+
+  test('omitted when check has no relatedLinks', () => {
+    const out = buildAuditPrompt(makeInput())
+    expect(out).not.toContain('## Related dashboards')
+  })
+
+  test('omitted when opts.relatedLinks = false', () => {
+    const out = buildAuditPrompt(makeInput({ check: fullCheck }), {
+      relatedLinks: false,
+    })
+    expect(out).not.toContain('## Related dashboards')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildAuditPrompt — docs links section
+// ---------------------------------------------------------------------------
+
+describe('buildAuditPrompt — docs links section', () => {
+  test('included when check.docsLinks is non-empty', () => {
+    const out = buildAuditPrompt(makeInput({ check: fullCheck }))
+    expect(out).toContain('## Documentation')
+    expect(out).toContain('[Merges docs]')
+    expect(out).toContain(
+      'https://clickhouse.com/docs/operations/system-tables/merges'
+    )
+  })
+
+  test('includes raw markdown URL when docsMarkdown = true (default)', () => {
+    const out = buildAuditPrompt(makeInput({ check: fullCheck }))
+    expect(out).toContain('raw.githubusercontent.com')
+    expect(out).toContain('merges.md')
+  })
+
+  test('omits raw markdown URL when docsMarkdown = false', () => {
+    const out = buildAuditPrompt(makeInput({ check: fullCheck }), {
+      docsMarkdown: false,
+    })
+    expect(out).toContain('## Documentation')
+    expect(out).not.toContain('raw.githubusercontent.com')
+  })
+
+  test('omitted when opts.docsLinks = false', () => {
+    const out = buildAuditPrompt(makeInput({ check: fullCheck }), {
+      docsLinks: false,
+    })
+    expect(out).not.toContain('## Documentation')
+  })
+
+  test('omitted when check has no docsLinks', () => {
+    const out = buildAuditPrompt(makeInput())
+    expect(out).not.toContain('## Documentation')
+  })
+
+  test('non-clickhouse.com URLs produce no markdown link', () => {
+    const check: HealthCheckDef = {
+      ...minimalCheck,
+      docsLinks: [
+        { label: 'External', url: 'https://example.com/docs/something' },
+      ],
+    }
+    const out = buildAuditPrompt(makeInput({ check }))
+    expect(out).toContain('[External]')
+    expect(out).not.toContain('raw.githubusercontent.com')
+    expect(out).not.toContain('— raw markdown:')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildAuditPrompt — requested output section (always present)
+// ---------------------------------------------------------------------------
+
+describe('buildAuditPrompt — requested output section', () => {
+  test('always present', () => {
+    const out = buildAuditPrompt(makeInput())
+    expect(out).toContain('## Requested output')
+  })
+
+  test('lists five numbered items', () => {
+    const out = buildAuditPrompt(makeInput())
+    for (let i = 1; i <= 5; i++) {
+      expect(out).toContain(`${i}.`)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildAuditPrompt — option merging
+// ---------------------------------------------------------------------------
+
+describe('buildAuditPrompt — option merging', () => {
+  test('partial options override only the specified fields', () => {
+    const out = buildAuditPrompt(makeInput({ check: fullCheck }), {
+      sql: false,
+    })
+    // sql is off, but everything else should remain
+    expect(out).not.toContain('## Metric query')
+    expect(out).toContain('## Relevant ClickHouse system tables')
+    expect(out).toContain('## Common causes to consider')
+  })
+
+  test('all sections off produces minimal prompt with just header+observation+requested', () => {
+    const allOff: AuditPromptOptions = {
+      sql: false,
+      rawData: false,
+      systemTables: false,
+      commonCauses: false,
+      relatedLinks: false,
+      docsLinks: false,
+      docsMarkdown: false,
+    }
+    const out = buildAuditPrompt(makeInput({ check: fullCheck }), allOff)
+    expect(out).toContain('# ClickHouse Health Audit')
+    expect(out).toContain('## Observation')
+    expect(out).toContain('## Requested output')
+    expect(out).not.toContain('## Metric query')
+    expect(out).not.toContain('## Relevant ClickHouse system tables')
+    expect(out).not.toContain('## Documentation')
+  })
+})


### PR DESCRIPTION
Adds bun:test suites for 8 previously-untested pure/type-only modules (parallel cheap-model authored, then reviewed): proxy auth, request validators, response-builder, card-error-utils, clickhouse-engine-icons, agent-model-registry, json-render-patch-guard, audit-prompt. **369 net-new tests; full suite 802 → 1171 pass.**

## Two real findings — fixed, not enshrined
1. **Cache-control precedence bug** (`response-builder.ts`): `createSuccessResponse` ran `Object.assign(headers, DEFAULT_CACHE_HEADERS)` *after* spreading caller headers, so `createCachedResponse`'s custom `Cache-Control` was always clobbered by the SHORT preset — defeating its entire purpose. Now defaults are spread *before* caller headers, so explicit values win. Tests assert the requested preset/custom string is applied.
2. **Test global-state leak** (`agent-model-registry.test`): the agent-authored file used `process.env = {...}` whole-object swaps. Reassigning the `process.env` binding poisoned env for every file running after it — invisible per-file/per-pair, only surfaced in the full 75-file suite (broke an unrelated clerk-client test). Replaced with a per-key set/restore sandbox.

Co-Authored-By: duyetbot <bot@duyet.net>