### PR TITLE
fix(dashboard-tsr): shrink OverviewPageFallback status strip skeleton h-10→h-5

### DIFF
--- a/apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx
@@ -223,7 +223,7 @@ const FIRST_TAB = OVERVIEW_TABS[0]
 function OverviewPageFallback() {
   return (
     <div>
-      <Skeleton className="mb-3 h-10 w-full rounded-lg" />
+      <Skeleton className="mb-3 h-5 w-full rounded-lg" />
       <div className="mb-4 grid grid-cols-1 gap-3 sm:mb-6 sm:grid-cols-2 md:grid-cols-4">
         {Array.from({ length: 4 }).map((_, i) => (
           <Skeleton key={i} className="h-24 rounded-lg" />


### PR DESCRIPTION
## Finding

`OverviewPageFallback` reserved `h-10` (40px) for the status strip skeleton. The real `OverviewStatusStrip` renders as an inline flex row of `text-[12.5px]` text + a 2px dot — natural height ~18–20px. The ~20px mismatch pushed the KPI grid and tab area down on hydration, causing measurable layout shift (CLS).

## Change

Changed the fallback skeleton from `h-10` to `h-5` (20px) in `OverviewPageFallback` to match the strip's actual rendered height.

**File**: `apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx` line 226.

## Verified

- Pre-commit hook ran Biome check + TypeScript type-check — both passed.
- Pre-push hook ran full Biome check — 12 pre-existing warnings (unrelated), no errors, no fixes applied.
- Pure visual sizing change; no behavior change; no new test needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the loading screen skeleton height for improved visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->