### PR TITLE
fix(dashboard-tsr): add SheetTitle to ExplorerSidebar for screen-reader a11y

### DIFF
--- a/apps/dashboard-tsr/src/components/explorer/explorer-sidebar.tsx
+++ b/apps/dashboard-tsr/src/components/explorer/explorer-sidebar.tsx
@@ -1,5 +1,10 @@
 import { DatabaseTree } from './tree/database-tree'
-import { Sheet, SheetContent } from '@/components/ui/sheet'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
 import {
   SidebarContent,
   SidebarGroup,
@@ -37,6 +42,9 @@ export function ExplorerSidebar({
     return (
       <Sheet open={isOpen} onOpenChange={onOpenChange}>
         <SheetContent side="left" className="w-80 p-0">
+          <SheetHeader className="sr-only">
+            <SheetTitle>Database browser</SheetTitle>
+          </SheetHeader>
           <div className="flex h-full flex-col">{content}</div>
         </SheetContent>
       </Sheet>


### PR DESCRIPTION
## Finding

`ExplorerSidebar` opens a `<Sheet>` (Radix Dialog) on mobile with `<SheetContent>` but no `<SheetTitle>`. Radix Dialog requires an accessible title; without it NVDA/VoiceOver announces an untitled dialog.

## Change

Added `<SheetHeader className="sr-only"><SheetTitle>Database browser</SheetTitle></SheetHeader>` inside `SheetContent`. The header is visually hidden (`sr-only`) so it has no visual impact.

## Verified

- Pre-commit lint + TypeScript type-check passed
- No behavior change — purely an accessibility annotation