### PR TITLE
fix(dashboard-tsr): add focus-visible ring to explorer tree expand button

### DIFF
--- a/apps/dashboard-tsr/src/components/explorer/tree/tree-node.tsx
+++ b/apps/dashboard-tsr/src/components/explorer/tree/tree-node.tsx
@@ -72,7 +72,7 @@ export const TreeNode = function TreeNode({
             <CollapsibleTrigger asChild>
               <button
                 type="button"
-                className="flex size-4 items-center justify-center rounded-sm hover:bg-sidebar-accent"
+                className="flex size-4 items-center justify-center rounded-sm hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                 onClick={(e) => {
                   e.stopPropagation()
                 }}


### PR DESCRIPTION
## Finding

The collapse/expand chevron button in `TreeNode` (`apps/dashboard-tsr/src/components/explorer/tree/tree-node.tsx`) had no focus-visible ring. Keyboard users tabbing through the explorer tree received no visible focus indicator on the expand button, breaking keyboard accessibility.

## Change

Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1` to the button's `className`, matching the project's standard focus style pattern.

## Verified

- Pre-commit hook: Biome lint + TypeScript type-check passed (cache hit)
- Pre-push hook: Biome full check passed (12 pre-existing warnings, none from this change)
- Pure CSS class addition — no behavioral change, no test required