### PR TITLE
fix(dashboard-tsr): use Skeleton shimmer in KpiCard loading state

### DIFF
--- a/apps/dashboard-tsr/src/components/overview-charts/kpi-card.tsx
+++ b/apps/dashboard-tsr/src/components/overview-charts/kpi-card.tsx
@@ -12,6 +12,7 @@ import {
 import { AnimatedNumber } from '@/components/cards/animated-number'
 import { MiniAreaChart } from '@/components/charts/mini-charts'
 import { AppLink as Link } from '@/components/ui/app-link'
+import { Skeleton } from '@/components/ui/skeleton'
 import { cn } from '@/lib/utils'
 
 /** Sparkline color when a card does not specify one (blue-600). */
@@ -93,9 +94,9 @@ export const KpiCard = function KpiCard({
   if (isLoading) {
     return (
       <div className={cn(cardStyles.base, 'gap-2.5 p-3 sm:p-4')}>
-        <div className="h-3 w-24 animate-pulse rounded bg-foreground/[0.06]" />
-        <div className="h-7 w-20 animate-pulse rounded-md bg-foreground/[0.06]" />
-        <div className="h-3 w-28 animate-pulse rounded bg-foreground/[0.04]" />
+        <Skeleton variant="shimmer" className="h-3 w-24" />
+        <Skeleton variant="shimmer" className="h-7 w-20" />
+        <Skeleton variant="shimmer" className="h-3 w-28" />
       </div>
     )
   }


### PR DESCRIPTION
## Finding

`KpiCard` rendered its own loading placeholder with three raw `<div className="... animate-pulse ...">` elements. The rest of the dashboard uses `<Skeleton variant="shimmer">` (gradient sweep animation, consistent bg). This caused two different shimmer appearances side-by-side when the overview KPI strip and charts both loaded.

## Change

Replaced the three ad-hoc animate-pulse divs in the `isLoading` branch with `<Skeleton variant="shimmer">` calls, matching the shared component used everywhere else.

File: `apps/dashboard-tsr/src/components/overview-charts/kpi-card.tsx`

## Verified

- Pre-commit hook: Biome lint + TypeScript type-check passed (cache hit, 411ms)
- Pre-push hook: Biome full check passed (12 pre-existing warnings, none in changed file)
- Pure visual change — no behavior change, no new tests needed