### PR TITLE
fix(dashboard-tsr): add underline variant to TabsSkeleton to fix CLS on overview load

### DIFF
--- a/apps/dashboard-tsr/src/components/skeletons/tabs.tsx
+++ b/apps/dashboard-tsr/src/components/skeletons/tabs.tsx
@@ -8,19 +8,43 @@ import { cn } from '@/lib/utils'
 interface TabsSkeletonProps {
   tabCount?: number
   className?: string
+  /**
+   * "pill"      — default shadcn pill tabs (h-9 rounded bg-muted container)
+   * "underline" — flat border-bottom style used by the overview page tabs
+   *               (no background, no rounded corners, matches the real TabsList
+   *               geometry to prevent CLS on hydration)
+   */
+  variant?: 'pill' | 'underline'
 }
 
-export function TabsSkeleton({ tabCount = 5, className }: TabsSkeletonProps) {
+export function TabsSkeleton({
+  tabCount = 5,
+  className,
+  variant = 'pill',
+}: TabsSkeletonProps) {
   return (
     <div className={cn('space-y-2', className)}>
       {/* Tabs list skeleton */}
-      <div className="overflow-x-auto pb-1 -mx-1 px-1 sm:mx-0 sm:px-0">
-        <div className="bg-muted inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px] gap-1">
-          {Array.from({ length: tabCount }).map((_, i) => (
-            <Skeleton key={i} className="h-7 w-20 rounded-md" />
-          ))}
+      {variant === 'underline' ? (
+        <div className="overflow-x-auto pb-px">
+          <div className="inline-flex h-auto w-full min-w-max items-center justify-start gap-1 border-b border-border bg-transparent p-0">
+            {Array.from({ length: tabCount }).map((_, i) => (
+              <Skeleton
+                key={i}
+                className="h-9 w-20 rounded-none border-b-2 border-transparent bg-transparent"
+              />
+            ))}
+          </div>
         </div>
-      </div>
+      ) : (
+        <div className="overflow-x-auto pb-1 -mx-1 px-1 sm:mx-0 sm:px-0">
+          <div className="bg-muted inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px] gap-1">
+            {Array.from({ length: tabCount }).map((_, i) => (
+              <Skeleton key={i} className="h-7 w-20 rounded-md" />
+            ))}
+          </div>
+        </div>
+      )}
       {/* Tab content skeleton */}
       <div className="space-y-2">
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">

--- a/apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx
@@ -155,7 +155,11 @@ function OverviewPageContent() {
       <OverviewStatusStrip className="mb-3" />
       <OverviewCharts className="mb-4 sm:mb-6" />
 
-      <ClientOnly fallback={<TabsSkeleton tabCount={OVERVIEW_TABS.length} />}>
+      <ClientOnly
+        fallback={
+          <TabsSkeleton tabCount={OVERVIEW_TABS.length} variant="underline" />
+        }
+      >
         <Tabs
           value={activeTab}
           onValueChange={handleTabChange}
@@ -229,7 +233,7 @@ function OverviewPageFallback() {
           <Skeleton key={i} className="h-24 rounded-lg" />
         ))}
       </div>
-      <TabsSkeleton tabCount={OVERVIEW_TABS.length} />
+      <TabsSkeleton tabCount={OVERVIEW_TABS.length} variant="underline" />
       {/* Reserve the first tab's chart grid so the loading document is roughly
           as tall as the loaded page. Reuses the real grid class + chart count
           so it stays in sync if charts are added/removed. */}


### PR DESCRIPTION
## Finding

The overview page shows `TabsSkeleton` while `ClientOnly` hydrates. `TabsSkeleton` renders a pill-shaped `h-9 bg-muted rounded-lg` container (standard shadcn pill tabs). The real `TabsList` uses a flat underline style — `h-auto bg-transparent rounded-none border-b border-border p-0`. Height and shape differ enough to cause a visible jump (CLS) on hydration.

## Fix

Added `variant` prop to `TabsSkeleton`:
- `"pill"` (default) — existing behaviour, unchanged for all other callers
- `"underline"` — matches the overview's flat border-bottom geometry: no background, no rounded corners, `border-b border-border`, same `h-auto` layout

Both `ClientOnly` fallback and `OverviewPageFallback` in `overview.tsx` now use `variant="underline"`.

## Verified

- Pre-commit: Biome check + TypeScript type-check passed
- Pre-push: Biome full check passed (12 pre-existing warnings, none from this change)
- Existing utility tests (`utils.test.ts`, `env.test.ts`) pass
- Default `"pill"` behaviour is unchanged — no other callers affected