### PR TITLE
fix(dashboard-tsr): restore focus-visible ring on overview tab triggers

### DIFF
--- a/apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx
@@ -36,7 +36,9 @@ const TAB_TRIGGER_CLASS = cn(
   // states
   'transition-colors hover:text-foreground',
   'data-[state=active]:border-foreground data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none',
-  'dark:data-[state=active]:border-foreground dark:data-[state=active]:bg-transparent'
+  'dark:data-[state=active]:border-foreground dark:data-[state=active]:bg-transparent',
+  // keyboard focus — inset ring stays inside the bottom-border strip
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset'
 )
 
 interface LazyTabContentProps {


### PR DESCRIPTION
## Finding

`TAB_TRIGGER_CLASS` in `apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx` overrides the default shadcn `TabsTrigger` styles with `border-0 rounded-none shadow-none` and never restores `focus-visible:ring-2`. Keyboard users cannot see which tab is focused.

## Change

Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset` to `TAB_TRIGGER_CLASS`. Using `ring-inset` keeps the focus ring inside the bottom-border strip to avoid layout shift.

## Verified

- Biome lint: no new warnings from this change
- TypeScript type-check: cache hit, no errors
- Pre-commit and pre-push hooks both passed