### PR TITLE
perf(dashboard-tsr): stub recharts in SSR worker bundle (~1 MiB reduction)

### DIFF
--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -102,6 +102,12 @@ const SSR_STUB_PREFIXES = [
   // OFF and getInitialBeautifyState() returns false under SSR (no `window`), so
   // it never executes during prerender. Stub it out of the worker bundle.
   'sql-formatter',
+  // recharts (~1 MiB raw). All recharts consumers are client-only: full chart
+  // components load via React.lazy() through the chart registry, and KpiCard
+  // sparklines guard recharts behind `spark && spark.length >= 2` which is
+  // always false during prerender (TanStack Query data is empty). Stubbing this
+  // out of the worker bundle is the single largest remaining size win.
+  'recharts',
 ]
 
 // rolldown does not honour `syntheticNamedExports` from a resolveId result, so
@@ -128,6 +134,25 @@ const SSR_STUB_NAMED_EXPORTS = [
   'keymap',
   // sql-formatter
   'format',
+  // recharts — all named imports from src/ (rolldown doesn't honour
+  // syntheticNamedExports; `import * as RechartsPrimitive` and `import type`
+  // need no entry — namespace uses the Proxy default; types are erased).
+  'Area',
+  'AreaChart',
+  'Bar',
+  'BarChart',
+  'CartesianGrid',
+  'Cell',
+  'ComposedChart',
+  'Label',
+  'LabelList',
+  'Line',
+  'Pie',
+  'PieChart',
+  'RadialBar',
+  'RadialBarChart',
+  'XAxis',
+  'YAxis',
 ]
 
 const SSR_STUB_VIRTUAL_ID = '\0chm-ssr-client-only-stub'


### PR DESCRIPTION
## Finding

recharts is the single largest client-only library not yet stubbed in the SSR worker bundle. The SSR build code-splits it into a 736K `chart-FcuQL7MS.js` chunk plus copies across area/AreaChart/BarChart/donut/YAxis/peerdb/thread chunks — all uploaded under `no_bundle:true` against the Cloudflare Workers free-plan 3 MiB limit.

## Why it's safe to stub

All recharts consumers are client-only:
1. Full chart components load via `React.lazy()` through `src/components/charts/registry/imports/*.ts` — never executed during SSR/prerender.
2. KpiCard sparklines guard `<MiniAreaChart>` behind `spark && spark.length >= 2` — spark comes from TanStack Query data which is empty during prerender, so recharts is never invoked.
3. Same guarded pattern in `running-queries-card.tsx` and `routes/(peerdb)/peerdb/peer.tsx`.

## Change

- Add `'recharts'` to `SSR_STUB_PREFIXES` in `vite.config.ts`
- Add 16 named recharts exports to `SSR_STUB_NAMED_EXPORTS` (rolldown does not honour `syntheticNamedExports`; `import * as RechartsPrimitive` uses the Proxy default and needs no entry; `import type` is erased)

## Verified

A prior full `vite build` with this change confirmed:
- Build succeeded, prerender did not crash
- Total `dist/server/assets` dropped ~944K raw (11704K → 10760K)
- The 736K chart chunk shrank to 12K (stub reference only)
- No d3-shape/d3-scale/generateCategoricalChart internals remained in any server chunk
- Pre-commit TypeScript type-check: cache hit, passed ✅