### PR TITLE
fix(dashboard-tsr): use 100dvh in explorer to fix mobile viewport overflow

### DIFF
--- a/apps/dashboard-tsr/src/routes/(dashboard)/explorer.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/explorer.tsx
@@ -14,7 +14,7 @@ const ExplorerLayout = lazy(() =>
 function ExplorerPage() {
   return (
     <Suspense fallback={<ExplorerSkeleton />}>
-      <div className="h-[calc(100vh-4rem)]">
+      <div className="h-[calc(100dvh-4rem)]">
         <ExplorerLayout />
       </div>
     </Suspense>


### PR DESCRIPTION
## Finding

`explorer.tsx` used `h-[calc(100vh-4rem)]` while `agent-thread-page.tsx` already uses `100dvh`. On iOS/Android browsers, `100vh` includes the browser chrome (address bar), so the explorer panel overflowed under the browser UI.

## Change

- `apps/dashboard-tsr/src/routes/(dashboard)/explorer.tsx`: `100vh` → `100dvh`

The `4rem` offset is kept — it matches the `min-h-16` (= 4rem) shell header confirmed in `dashboard-shell.tsx`. The `6rem` offset in the agents page is a separate pre-existing value and is not changed here.

## Verified

- Pre-commit hook (Biome + tsc) passed
- Pre-push hook (Biome full check) passed with 0 errors (12 pre-existing warnings unrelated to this change)