### PR TITLE
fix(dashboard-tsr): replace running-queries Suspense fallback with full-page skeleton

### DIFF
--- a/apps/dashboard-tsr/src/components/query-tables/query-page-skeleton.tsx
+++ b/apps/dashboard-tsr/src/components/query-tables/query-page-skeleton.tsx
@@ -27,3 +27,67 @@ export function QueryPageSkeleton({
     </div>
   )
 }
+
+/**
+ * Running-queries page skeleton — reserves space for the full page layout
+ * (header + chart strip + running table + completed table) so the Suspense
+ * fallback matches the final rendered height and avoids a CLS flash.
+ */
+export function RunningQueriesPageSkeleton() {
+  return (
+    <div
+      className="flex flex-col gap-4"
+      role="status"
+      aria-busy="true"
+      aria-label="Loading running queries"
+    >
+      {/* Header — mirrors PageHeader layout */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+        <div className="min-w-0 sm:flex-1">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-7 w-44" />
+            <Skeleton className="h-5 w-16 rounded-md" />
+          </div>
+          <Skeleton className="mt-1 h-4 w-72" />
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Skeleton className="h-8 w-24 rounded-md" />
+          <Skeleton className="h-8 w-20 rounded-md" />
+          <Skeleton className="h-8 w-16 rounded-md" />
+        </div>
+      </div>
+
+      {/* Chart strip (4 cards, open by default) */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }, (_, i) => (
+          <Skeleton
+            key={`chart-${i}`}
+            className="h-[160px] w-full rounded-xl"
+          />
+        ))}
+      </div>
+
+      {/* Running queries table */}
+      <QueryPageSkeleton rows={5} />
+
+      {/* Completed queries table */}
+      <div className="overflow-hidden rounded-xl border border-border bg-card">
+        <div className="flex items-center gap-2 border-b border-border px-3 py-2.5">
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="ml-auto h-4 w-16" />
+        </div>
+        {Array.from({ length: 3 }, (_, i) => (
+          <div
+            key={`completed-${i}`}
+            className="flex items-center gap-3 border-b border-border p-3"
+          >
+            <Skeleton className="h-5 w-12" />
+            <Skeleton className="h-4 flex-1" />
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-16" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/dashboard-tsr/src/routes/(dashboard)/running-queries.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/running-queries.tsx
@@ -1,19 +1,20 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
+import { RunningQueriesPageSkeleton } from '@/components/query-tables/query-page-skeleton'
 import { RunningQueriesView } from '@/components/running-queries'
-import { ChartSkeleton } from '@/components/skeletons'
 
 /**
  * Running Queries page.
  *
  * {@link RunningQueriesView} is self-contained — it renders its own header,
  * the collapsible chart strip and the query table — so the page just wraps it
- * in a Suspense boundary.
+ * in a Suspense boundary. The fallback reserves space for the full layout
+ * (header + charts + table + completed table) to avoid a CLS flash.
  */
 function RunningQueriesPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<RunningQueriesPageSkeleton />}>
       <RunningQueriesView />
     </Suspense>
   )


### PR DESCRIPTION
Finding: Running-queries page Suspense fallback was a single ChartSkeleton (~160px chart card), but RunningQueriesView renders a header, 4-card chart strip, running queries table, and completed queries table. The page collapsed to ~160px during chunk loading then inflated to thousands of pixels — a severe CLS flash and poor perceived load experience.

Fix: Added RunningQueriesPageSkeleton that reserves proportional space for the full page layout:
- Page header skeleton (title + badge + description + action buttons)
- Chart strip (4 cards matching the grid layout)
- Running queries table skeleton (5 rows)
- Completed queries table skeleton (3 rows)

Verified: bun test src/ — 828 pass, 0 fail. Pre-commit Biome lint + TypeScript type-check pass. Pre-push full Biome check pass (all warnings pre-existing).

Part of #1392.