### PR TITLE
fix(dashboard-tsr): use grid skeleton for dashboard page loading state

### DIFF
--- a/apps/dashboard-tsr/src/routes/(dashboard)/dashboard.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/dashboard.tsx
@@ -5,7 +5,7 @@ import { LazyChartWrapper } from '@/components/charts/lazy-chart-wrapper'
 import { getChartComponent, hasChart } from '@/components/charts/registry'
 import { ChartPicker } from '@/components/dashboard/chart-picker'
 import { SavedDashboardsToolbar } from '@/components/dashboard/saved-dashboards-toolbar'
-import { ChartSkeleton } from '@/components/skeletons'
+import { ChartSkeleton, ChartsOnlyPageSkeleton } from '@/components/skeletons'
 import { useHostId } from '@/lib/swr'
 
 /** Charts shown when no saved dashboard is loaded */
@@ -106,7 +106,7 @@ function DashboardContent() {
 
 function DashboardPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<ChartsOnlyPageSkeleton chartCount={8} />}>
       <DashboardContent />
     </Suspense>
   )


### PR DESCRIPTION
## Finding

Dashboard page fallback: single ChartSkeleton for multi-chart grid.

In `dashboard.tsx`, the outer Suspense fallback was `<ChartSkeleton />` (one chart ~160px), but the page renders a toolbar row plus a 2-column grid of up to 8 charts. The loading state collapsed to a single chart placeholder causing layout shift.

## Change

Replace `<ChartSkeleton />` with `<ChartsOnlyPageSkeleton chartCount={8} />` in the outer Suspense fallback so the loading skeleton matches the 2-column grid layout.

## Verified

- 828 bun tests pass (0 fail)
- Pre-commit: Biome lint + tsc type-check pass
- Pre-push: full Biome check pass (12 pre-existing warnings, none from this change)

Co-Authored-By: duyetbot <bot@duyet.net>