### PR TITLE
fix(dashboard-tsr): add a11y attributes to KpiCard loading skeleton

### DIFF
--- a/apps/dashboard-tsr/src/components/overview-charts/kpi-card.tsx
+++ b/apps/dashboard-tsr/src/components/overview-charts/kpi-card.tsx
@@ -93,7 +93,12 @@ export const KpiCard = function KpiCard({
 }: KpiCardProps) {
   if (isLoading) {
     return (
-      <div className={cn(cardStyles.base, 'gap-2.5 p-3 sm:p-4')}>
+      <div
+        className={cn(cardStyles.base, 'gap-2.5 p-3 sm:p-4')}
+        role="status"
+        aria-busy="true"
+        aria-label={`Loading ${label}`}
+      >
         <Skeleton variant="shimmer" className="h-3 w-24" />
         <Skeleton variant="shimmer" className="h-7 w-20" />
         <Skeleton variant="shimmer" className="h-3 w-28" />


### PR DESCRIPTION
## Finding

KpiCard loading skeleton lacks `role`/`aria` attributes for screen readers.

**Detail:** The `KpiCard` component (`overview-charts/kpi-card.tsx`) returns a plain `<div>` with three `<Skeleton>` bars when `isLoading` is true, but has no `role="status"`, `aria-busy="true"`, or `aria-label`. Every other skeleton in the codebase (ChartSkeleton, TableSkeleton, ExplorerSkeleton, AgentsPageSkeleton, PageSkeleton, OverviewStatusStrip) includes these attributes. Screen readers cannot announce the loading state for the KPI cards.

## Change

Add `role="status"`, `aria-busy="true"`, and `aria-label="Loading ${label}"` to the KpiCard loading skeleton div, matching the established pattern from `ChartSkeleton` and other skeletons.

## Verified

- Pre-commit: Biome lint + TypeScript type-check passed
- Pre-push: Full Biome check passed (no new warnings)
- No behavioral change; markup-only a11y improvement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced accessibility for KPI card loading states, providing better support for screen reader users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->