### PR TITLE
fix(sql-validator): catch UNION ALL SELECT injection bypass

### DIFF
--- a/packages/sql-builder/src/__tests__/sql-validator.test.ts
+++ b/packages/sql-builder/src/__tests__/sql-validator.test.ts
@@ -201,11 +201,24 @@ describe('SQL_PATTERNS', () => {
       expect(SQL_PATTERNS.UNION_INJECTION.test('union select')).toBe(true)
     })
 
-    test('should not match UNION ALL SELECT (in allowed context)', () => {
-      // The pattern specifically matches UNION followed by SELECT
+    test('should match UNION SELECT with table reference', () => {
       expect(SQL_PATTERNS.UNION_INJECTION.test('UNION SELECT * FROM t')).toBe(
         true
       )
+    })
+
+    test('should match UNION ALL SELECT', () => {
+      expect(SQL_PATTERNS.UNION_INJECTION.test('UNION ALL SELECT')).toBe(true)
+      expect(SQL_PATTERNS.UNION_INJECTION.test('union all select')).toBe(true)
+      expect(
+        SQL_PATTERNS.UNION_INJECTION.test(
+          'SELECT 1 UNION ALL SELECT secret FROM system.users'
+        )
+      ).toBe(true)
+    })
+
+    test('should not match UNION without SELECT', () => {
+      expect(SQL_PATTERNS.UNION_INJECTION.test('UNION')).toBe(false)
     })
   })
 
@@ -560,6 +573,12 @@ describe.skipIf(actuallyMocked)('validateSqlQuery', () => {
         validateSqlQuery(
           "SELECT * FROM users WHERE name = '' UNION SELECT * FROM passwords"
         )
+      ).toThrow('Potentially dangerous SQL detected')
+    })
+
+    test('should reject UNION ALL injection', () => {
+      expect(() =>
+        validateSqlQuery('SELECT 1 UNION ALL SELECT secret FROM system.users')
       ).toThrow('Potentially dangerous SQL detected')
     })
 

--- a/packages/sql-builder/src/sql-validator.ts
+++ b/packages/sql-builder/src/sql-validator.ts
@@ -53,7 +53,7 @@ export const SQL_PATTERNS = {
   /**
    * UNION-based injection attacks
    */
-  UNION_INJECTION: /\bunion\s+select\b/i,
+  UNION_INJECTION: /\bunion\s+(all\s+)?select\b/i,
 
   /** ClickHouse SET commands that modify server behavior */
   SET_COMMAND: /\bSET\b/i,


### PR DESCRIPTION
## Finding

Security audit: `UNION_INJECTION` regex `/\bunion\s+select\b/i` in `packages/sql-builder/src/sql-validator.ts` matches `UNION SELECT` but not `UNION ALL SELECT` -- the `ALL` keyword sits between UNION and SELECT, breaking the single-`\s+` match.

An attacker could use `SELECT 1 UNION ALL SELECT secret FROM system.users` to bypass this check. While defense-in-depth mitigations exist (registry-defined SQL, `readonly: 1` on explorer, dangerous function blocking), the `data.ts` POST path lacks both readonly and this validator.

## Fix

Changed regex from:
```
/\bunion\s+select\b/i
```
to:
```
/\bunion\s+(all\s+)?select\b/i
```

## Verification

- 108 tests pass (6 new: UNION ALL SELECT pattern match, integration rejection, and UNION-without-SELECT negative case)
- Pre-commit hooks pass (Biome lint + TypeScript type-check)
- Surgical change: 1 regex line + test updates

Co-Authored-By: duyetbot <bot@duyet.net>