### PR TITLE
fix(dashboard-tsr): enforce ClickHouse readonly mode in /api/v1/data

### DIFF
--- a/apps/dashboard-tsr/src/routes/api/v1/data.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/data.ts
@@ -469,8 +469,11 @@ const handleGet = withApiHandler(async (request: Request) => {
     query,
     format: (format || 'JSONEachRow') as DataFormat,
     hostId,
-    // Pass timezone to ClickHouse for session-level time conversion
-    clickhouse_settings: timezone ? { session_timezone: timezone } : undefined,
+    // SECURITY: Enforce readonly mode to prevent DML/DDL even if SQL validation is bypassed
+    clickhouse_settings: {
+      readonly: 1,
+      ...(timezone ? { session_timezone: timezone } : {}),
+    },
   })
 
   // Handle errors
@@ -597,8 +600,11 @@ const handlePost = withApiHandler(async (request: Request) => {
     format: dataFormat,
     hostId,
     queryConfig: serverQueryConfig,
-    // Pass timezone to ClickHouse for session-level time conversion
-    clickhouse_settings: timezone ? { session_timezone: timezone } : undefined,
+    // SECURITY: Enforce readonly mode to prevent DML/DDL even if SQL validation is bypassed
+    clickhouse_settings: {
+      readonly: 1,
+      ...(timezone ? { session_timezone: timezone } : {}),
+    },
   })
 
   // Handle errors

--- a/apps/dashboard-tsr/src/routes/api/v1/data/__tests__/readonly.test.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/data/__tests__/readonly.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for data.ts ClickHouse readonly enforcement
+ *
+ * Structural verification that the /api/v1/data route enforces
+ * `readonly: 1` in clickhouse_settings for both GET and POST handlers.
+ * This is a defense-in-depth measure: even if the SQL validation blocklist
+ * is bypassed or incomplete, ClickHouse itself will reject DML/DDL.
+ *
+ * The explorer/query.ts route already sets `readonly: 1`; this test
+ * ensures the data route follows the same pattern.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Source file is routes/api/v1/data.ts (sibling of the data/ directory)
+const DATA_SOURCE = readFileSync(
+  join(import.meta.dir, '..', '..', 'data.ts'),
+  'utf-8'
+)
+
+describe('data.ts readonly enforcement (structural)', () => {
+  test('GET handler sets readonly: 1 in clickhouse_settings', () => {
+    // The GET handler should have readonly: 1 in its clickhouse_settings
+    // within the handleGet function
+    expect(DATA_SOURCE).toMatch(
+      /handleGet[\s\S]*?clickhouse_settings:\s*\{[^}]*readonly:\s*1/
+    )
+  })
+
+  test('POST handler sets readonly: 1 in clickhouse_settings', () => {
+    // The POST handler should have readonly: 1 in its clickhouse_settings
+    // within the handlePost function
+    expect(DATA_SOURCE).toMatch(
+      /handlePost[\s\S]*?clickhouse_settings:\s*\{[^}]*readonly:\s*1/
+    )
+  })
+
+  test('readonly appears exactly twice (once per handler)', () => {
+    const matches = DATA_SOURCE.match(/readonly:\s*1/g)
+    expect(matches).not.toBeNull()
+    expect(matches!.length).toBe(2)
+  })
+
+  test('session_timezone is preserved alongside readonly', () => {
+    // Both handlers should spread session_timezone conditionally after readonly
+    expect(DATA_SOURCE).toMatch(
+      /readonly:\s*1,\s*\.\.\.\(timezone\s*\?\s*\{\s*session_timezone:\s*timezone\s*\}\s*:\s*\{\}\)/
+    )
+  })
+})


### PR DESCRIPTION
## Security Fix: Add `readonly: 1` to /api/v1/data clickhouse_settings

### Finding
The `/api/v1/data` route (both GET and POST handlers) was passing `clickhouse_settings` with only an optional `session_timezone` but **no `readonly: 1`**. Compare with `/api/v1/explorer/query` which correctly sets `{ readonly: 1 }`.

If the `validateSqlQuery` blocklist is ever bypassed or is incomplete, the data endpoint would allow DML/DDL statements against ClickHouse (e.g., `DROP TABLE`, `INSERT`, `ALTER`).

### Fix
Added `readonly: 1` to `clickhouse_settings` in both GET and POST handlers of `data.ts`, preserving the optional `session_timezone` spread:

```typescript
clickhouse_settings: {
  readonly: 1,
  ...(timezone ? { session_timezone: timezone } : {}),
},
```

This matches the pattern already established in `explorer/query.ts`.

### Verified
- 4 new structural tests (readonly.test.ts) confirming `readonly: 1` appears in both handlers
- Full suite passes: **1209 pass, 0 fail** across 79 files
- Diff is surgical: only the two `clickhouse_settings` assignments changed

### Files
- `apps/dashboard-tsr/src/routes/api/v1/data.ts` — readonly enforcement
- `apps/dashboard-tsr/src/routes/api/v1/data/__tests__/readonly.test.ts` — structural tests