### PR TITLE
perf(dashboard-tsr): stub @json-render/shadcn + @json-render/react from SSR bundle

### DIFF
--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -127,6 +127,13 @@ const SSR_STUB_PREFIXES = [
   // remend, emenda-carousel, vaul, hast/rehype/marked, nanoid, zustand, dequal.
   '@assistant-ui/react',
   '@assistant-ui/react-ai-sdk',
+  // @json-render/shadcn (~532 KiB) + @json-render/react (~20 KiB). Only imported
+  // by json-render-registry.ts and json-render-catalog-with-schema.ts, which are
+  // consumed exclusively by the lazy-loaded assistant-ui components (json-render-
+  // message.tsx behind React.lazy). The server-side API route (api/v1/agent.ts)
+  // only imports @json-render/core (~60 KiB, must NOT be stubbed).
+  '@json-render/shadcn',
+  '@json-render/react',
 ]
 
 // rolldown does not honour `syntheticNamedExports` from a resolveId result, so
@@ -234,6 +241,18 @@ const SSR_STUB_NAMED_EXPORTS = [
   'useThreadRuntime',
   // @assistant-ui/react-ai-sdk
   'useChatRuntime',
+  // @json-render/react — value imports from json-render-catalog-with-schema.ts,
+  // json-render-registry.ts, and json-render-message.tsx. (type imports like
+  // DataPart are erased at build time and need no entry).
+  'schema',
+  'defineRegistry',
+  'getTextFromParts',
+  'Renderer',
+  'useJsonRenderMessage',
+  // @json-render/shadcn — value import from json-render-registry.ts.
+  'shadcnComponents',
+  // @json-render/shadcn/catalog — value import from json-render-catalog-with-schema.ts.
+  'shadcnComponentDefinitions',
 ]
 
 const SSR_STUB_VIRTUAL_ID = '\0chm-ssr-client-only-stub'


### PR DESCRIPTION
## Finding

`@json-render/shadcn` (532 KiB) and `@json-render/react` (20 KiB) are imported only by client-side files consumed by lazy-loaded assistant-ui components (behind `React.lazy`). The server-side API route (`api/v1/agent.ts`) only imports `@json-render/core` (~60 KiB, must stay).

## Change

Add `@json-render/shadcn` and `@json-render/react` to `SSR_STUB_PREFIXES` and declare all required named value exports in `SSR_STUB_NAMED_EXPORTS`:

**From `@json-render/react`:** `schema`, `defineRegistry`, `getTextFromParts`, `Renderer`, `useJsonRenderMessage`
**From `@json-render/shadcn`:** `shadcnComponents`
**From `@json-render/shadcn/catalog`:** `shadcnComponentDefinitions`

`@json-render/core` is explicitly NOT stubbed — used server-side by `api/v1/agent.ts` and `json-render-patch-guard.ts`.

## Verified

- `vite build` succeeds
- `wrangler deploy --minify --dry-run` succeeds (Total Upload: 8386 KiB / gzip: 1796 KiB)
- 1204/1205 tests pass (1 pre-existing `isClerkEnabled` flake unrelated to this change)
- Only `vite.config.ts` touched (19 lines added, 0 modified)

## Note

This stub only takes effect once the underlying SSR stub mechanism is active (finding #1). The prefix match covers `@json-render/shadcn/catalog` subpath as well.