### PR TITLE
fix(dashboard-tsr): add keyboard a11y to ChartEmpty clickable card

### DIFF
--- a/apps/dashboard-tsr/src/components/charts/chart-empty.tsx
+++ b/apps/dashboard-tsr/src/components/charts/chart-empty.tsx
@@ -72,6 +72,11 @@ export const ChartEmpty = function ChartEmpty({
         toolbarMetadata.host ||
         toolbarMetadata.queryId))
 
+  const navigateToHref = () => {
+    if (!href) return
+    router.push(`${href}${href.includes('?') ? '&' : '?'}host=${hostId}`)
+  }
+
   const handleCardClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!href) return
 
@@ -84,7 +89,15 @@ export const ChartEmpty = function ChartEmpty({
       return
     }
 
-    router.push(`${href}${href.includes('?') ? '&' : '?'}host=${hostId}`)
+    navigateToHref()
+  }
+
+  const handleCardKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!href) return
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      navigateToHref()
+    }
   }
 
   return (
@@ -97,8 +110,18 @@ export const ChartEmpty = function ChartEmpty({
         className
       )}
       onClick={handleCardClick}
-      role="status"
-      aria-label={title ? `${title} - no data` : 'No data available'}
+      onKeyDown={handleCardKeyDown}
+      tabIndex={href ? 0 : undefined}
+      role={href ? 'link' : 'status'}
+      aria-label={
+        href
+          ? title
+            ? `${title} - no data, click to navigate`
+            : 'No data available, click to navigate'
+          : title
+            ? `${title} - no data`
+            : 'No data available'
+      }
     >
       {/* Header with title and toolbar */}
       {(title || hasToolbar) && (


### PR DESCRIPTION
## Finding

ChartEmpty clickable Card missing tabIndex and keyboard handler (dash-tsr UI/UX polish — a11y).

In `charts/chart-empty.tsx`, the `<Card>` has `onClick={handleCardClick}` for navigation when `href` is set, but no `tabIndex={0}`, no `role="link"`, and no `onKeyDown` handler. Keyboard-only users cannot activate the card. The card also lacks an explicit `aria-label` describing the link target when `href` is set.

## Changes

- Extract `navigateToHref()` helper to share between click and keyboard handlers
- Add `handleCardKeyDown` for Enter/Space key activation
- Set `tabIndex={0}` when `href` is present (focusable)
- Set `role="link"` when `href` is present (overrides `role="status"`)
- Update `aria-label` to indicate navigability when `href` is set

## Verified

- All 1205 tests pass (`bun test src/`)
- Only `chart-empty.tsx` touched — surgical change