### PR TITLE
fix(dashboard-tsr): correct explorer page height to match shell padding

### DIFF
--- a/apps/dashboard-tsr/src/routes/(dashboard)/explorer.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/explorer.tsx
@@ -14,7 +14,7 @@ const ExplorerLayout = lazy(() =>
 function ExplorerPage() {
   return (
     <Suspense fallback={<ExplorerSkeleton />}>
-      <div className="h-[calc(100dvh-4rem)]">
+      <div className="h-[calc(100dvh-6rem)]">
         <ExplorerLayout />
       </div>
     </Suspense>


### PR DESCRIPTION
## Finding

Explorer page height mismatch: the wrapper `h-[calc(100dvh-4rem)]` only accounted for the header (4rem) but not the content area padding (`p-4 pt-0`) and gap (`gap-4`) in `DashboardShell`. This caused the explorer to overflow its container, producing layout shift between the skeleton fallback and the live content.

## Fix

Changed the explorer wrapper height from `h-[calc(100dvh-4rem)]` to `h-[calc(100dvh-6rem)]`, matching the convention used by the agents page (`agent-thread-page.tsx`, skeleton in `skeletons/page.tsx`) which correctly subtracts header (4rem) + padding/gap (2rem).

## Verified

- `vite build` passes
- `bun test src/` — 1204 pass, 1 fail (pre-existing `isClerkEnabled` mock contamination, unrelated)
- Biome lint clean (12 pre-existing warnings, none from this change)
- TypeScript type-check passes

## Files

- `apps/dashboard-tsr/src/routes/(dashboard)/explorer.tsx` — single CSS class change on line 17