### PR TITLE
fix(dashboard-tsr): match overview fallback skeleton to KpiCard layout

### DIFF
--- a/apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx
@@ -6,6 +6,7 @@ import { OVERVIEW_TABS } from './-charts-config'
 import { lazy, Suspense, useState } from 'react'
 import { LazyChartWrapper } from '@/components/charts/lazy-chart-wrapper'
 import { ClientOnly } from '@/components/client-only'
+import { cardStyles } from '@/components/overview-charts/card-styles'
 import { OverviewCharts } from '@/components/overview-charts/overview-charts-client'
 import { OverviewStatusStrip } from '@/components/overview-charts/overview-status-strip'
 import { ChartSkeleton, Skeleton, TabsSkeleton } from '@/components/skeletons'
@@ -262,9 +263,13 @@ function OverviewPageFallback() {
   return (
     <div>
       <Skeleton className="mb-3 h-5 w-full rounded-lg" />
-      <div className="mb-4 grid grid-cols-1 gap-3 sm:mb-6 sm:grid-cols-2 md:grid-cols-4">
+      <div className="mb-4 grid auto-rows-fr grid-cols-1 gap-3 sm:mb-6 sm:gap-4 sm:grid-cols-2 md:grid-cols-4">
         {Array.from({ length: 4 }).map((_, i) => (
-          <Skeleton key={i} className="h-24 rounded-lg" />
+          <div key={i} className={cn(cardStyles.base, 'gap-2.5 p-3 sm:p-4')}>
+            <Skeleton variant="shimmer" className="h-3 w-24" />
+            <Skeleton variant="shimmer" className="h-7 w-20" />
+            <Skeleton variant="shimmer" className="h-3 w-28" />
+          </div>
         ))}
       </div>
       <TabsSkeleton tabCount={OVERVIEW_TABS.length} variant="underline" />


### PR DESCRIPTION
## Finding

`OverviewPageFallback` rendered 4 flat `h-24` grey boxes for the KPI grid. The real `KpiCard` uses `cardStyles.base` (gradient, border, backdrop-blur, rounded-xl) with `gap-2.5 p-3 sm:p-4` and a 3-line inner skeleton (label, value, sub). The mismatch caused a visible CLS flash when data loaded — cards shifted from 96px grey slabs to ~120px gradient cards with border and padding.

## What changed

- Replaced flat `<Skeleton className="h-24 rounded-lg">` boxes with the same `cardStyles.base` wrapper and inner 3-line shimmer skeleton structure used by `KpiCard`'s `isLoading` branch
- Aligned grid classes with `OverviewCharts` (`auto-rows-fr`, `sm:gap-4`)

## Verified

- `bun test src/` in `apps/dashboard-tsr`: **1205 pass, 0 fail**
- Only touched `overview.tsx` (7 lines added, 2 removed)

## Files

- `apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx` — `OverviewPageFallback` KPI grid