### PR TITLE
fix(dashboard-tsr): add keyboard a11y to explorer database cards

### DIFF
--- a/apps/dashboard-tsr/src/components/explorer/explorer-empty-state.tsx
+++ b/apps/dashboard-tsr/src/components/explorer/explorer-empty-state.tsx
@@ -159,8 +159,16 @@ export function ExplorerEmptyState() {
               return (
                 <Card
                   key={db.name}
+                  role="button"
+                  tabIndex={0}
                   className="group cursor-pointer p-4 transition-[border-color,background-color] hover:border-primary/50 hover:bg-muted/50"
                   onClick={() => setDatabase(db.name)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      setDatabase(db.name)
+                    }
+                  }}
                 >
                   <div className="flex items-center gap-3">
                     <div


### PR DESCRIPTION
## Finding
ExplorerEmptyState renders database cards as `<Card>` (a `<div>`) with `cursor-pointer` and `onClick` but no `role="button"`, `tabIndex={0}`, or keyboard event handler. Screen reader and keyboard users cannot activate these cards.

## Fix
Added `role="button"`, `tabIndex={0}`, and `onKeyDown` handler (Enter/Space) to the database `<Card>` elements so they are accessible via keyboard and announced correctly to assistive technology.

## Verified
- `bun test src/` — 1209 pass, 0 fail
- Pre-commit: Biome lint + TypeScript type-check pass
- Pre-push: full Biome check passes (no new warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard accessibility for database selection. Users can now navigate and interact with database cards using keyboard navigation and Enter/Space keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->