### PR TITLE
fix(dashboard-tsr): remove aria-hidden suppressing skeleton loading announcements

### DIFF
--- a/apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx
@@ -115,7 +115,11 @@ function TabContentSkeleton({ tab }: { tab: (typeof OVERVIEW_TABS)[number] }) {
   }
 
   return (
-    <div className={tab.gridClassName} aria-hidden="true">
+    <div
+      className={tab.gridClassName}
+      role="status"
+      aria-label={`Loading ${tab.label} charts`}
+    >
       {tab.charts.map((chart) => (
         <ChartSkeleton
           key={chart.id}
@@ -276,7 +280,11 @@ function OverviewPageFallback() {
       {/* Reserve the first tab's chart grid so the loading document is roughly
           as tall as the loaded page. Reuses the real grid class + chart count
           so it stays in sync if charts are added/removed. */}
-      <div className={cn('mt-2', FIRST_TAB.gridClassName)} aria-hidden="true">
+      <div
+        className={cn('mt-2', FIRST_TAB.gridClassName)}
+        role="status"
+        aria-label="Loading charts"
+      >
         {FIRST_TAB.charts.map((chart) => (
           <ChartSkeleton
             key={chart.id}


### PR DESCRIPTION
## Finding

Overview skeleton has `aria-hidden` conflicting with children `role=status`.

## Detail

In `overview.tsx`, `TabContentSkeleton` and `OverviewPageFallback` wrap `ChartSkeleton` children with `aria-hidden="true"`, but each `ChartSkeleton` declares `role="status" aria-busy="true" aria-label`. Per the ARIA spec, `aria-hidden` on an ancestor hides all descendants from the accessibility tree, so the `ChartSkeleton` announcements were suppressed. No loading state was announced to screen readers for these regions.

## Fix

- Remove `aria-hidden="true"` from both wrapper divs
- Add `role="status"` + `aria-label="Loading ..."` on each wrapper so the loading region is announced once to screen readers

## Verified

- All 1209 tests pass (`bun test src/`)
- Pre-commit: Biome lint + TypeScript type-check pass
- Pre-push: full Biome check passes (only pre-existing warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility for loading indicators in the dashboard overview by improving how loading states are announced to screen readers, providing better support for users with assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->