### PR TITLE
fix(dashboard-tsr): validate SQL on POST /api/v1/data with queryConfigName

### DIFF
--- a/apps/dashboard-tsr/src/routes/api/v1/data.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/data.ts
@@ -551,6 +551,26 @@ const handlePost = withApiHandler(async (request: Request) => {
     )
   }
 
+  // SECURITY: Validate SQL query to prevent injection attacks (mirrors GET handler).
+  // This must run before fetchData regardless of whether queryConfigName is provided.
+  try {
+    validateSqlQuery(query)
+  } catch (validationErr) {
+    error('[POST /api/v1/data] Security: SQL validation failed', {
+      queryPreview: query.substring(0, 100),
+      error:
+        validationErr instanceof Error
+          ? validationErr.message
+          : 'Unknown error',
+    })
+    return createValidationError(
+      validationErr instanceof Error
+        ? validationErr.message
+        : 'SQL validation failed',
+      { ...ROUTE_CONTEXT, method: 'POST', hostId }
+    )
+  }
+
   // SECURITY: If no queryConfigName provided, validate the query exists in dashboard tables
   // This prevents arbitrary SQL execution from clients
   if (!queryConfigName) {

--- a/apps/dashboard-tsr/src/routes/api/v1/data/__tests__/sql-validation.test.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/data/__tests__/sql-validation.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for data.ts SQL validation on POST handler
+ *
+ * Structural verification that the POST /api/v1/data route calls
+ * `validateSqlQuery` before executing any query, including when
+ * `queryConfigName` is provided. This closes a gap where an authenticated
+ * attacker knowing a valid queryConfigName could send arbitrary SQL that
+ * bypassed the pattern-based SQL validator.
+ *
+ * The GET handler already validates SQL; this test ensures the POST handler
+ * does the same.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Source file is routes/api/v1/data.ts (sibling of the data/ directory)
+const DATA_SOURCE = readFileSync(
+  join(import.meta.dir, '..', '..', 'data.ts'),
+  'utf-8'
+)
+
+describe('data.ts SQL validation (structural)', () => {
+  test('GET handler calls validateSqlQuery', () => {
+    // The GET handler should call validateSqlQuery within its body
+    const getHandler = DATA_SOURCE.match(
+      /const handleGet[\s\S]*?^}, ROUTE_CONTEXT\)/m
+    )
+    expect(getHandler).not.toBeNull()
+    expect(getHandler![0]).toContain('validateSqlQuery(query)')
+  })
+
+  test('POST handler calls validateSqlQuery before fetchData', () => {
+    // The POST handler should call validateSqlQuery within its body
+    const postHandler = DATA_SOURCE.match(
+      /const handlePost[\s\S]*?^}, ROUTE_CONTEXT\)/m
+    )
+    expect(postHandler).not.toBeNull()
+    expect(postHandler![0]).toContain('validateSqlQuery(query)')
+  })
+
+  test('POST handler validates SQL before dashboard-query allowlist check', () => {
+    // validateSqlQuery must appear before validateDashboardQuery in handlePost
+    const postHandler = DATA_SOURCE.match(
+      /const handlePost[\s\S]*?^}, ROUTE_CONTEXT\)/m
+    )
+    expect(postHandler).not.toBeNull()
+    const body = postHandler![0]
+    const sqlValidationPos = body.indexOf('validateSqlQuery(query)')
+    const allowlistPos = body.indexOf('validateDashboardQuery(query')
+    expect(sqlValidationPos).toBeGreaterThan(-1)
+    expect(allowlistPos).toBeGreaterThan(-1)
+    // SQL validation must come BEFORE the allowlist check
+    expect(sqlValidationPos).toBeLessThan(allowlistPos)
+  })
+
+  test('POST handler SQL validation block is before queryConfigName branch', () => {
+    // The validateSqlQuery call should appear before the queryConfigName branch
+    // that resolves serverQueryConfig and calls fetchData
+    const postHandler = DATA_SOURCE.match(
+      /const handlePost[\s\S]*?^}, ROUTE_CONTEXT\)/m
+    )
+    expect(postHandler).not.toBeNull()
+    const body = postHandler![0]
+    const sqlValidationPos = body.indexOf('validateSqlQuery(query)')
+    const serverQueryConfigPos = body.indexOf(
+      'const serverQueryConfig = queryConfigName'
+    )
+    expect(sqlValidationPos).toBeGreaterThan(-1)
+    expect(serverQueryConfigPos).toBeGreaterThan(-1)
+    // SQL validation must come BEFORE serverQueryConfig resolution
+    expect(sqlValidationPos).toBeLessThan(serverQueryConfigPos)
+  })
+})


### PR DESCRIPTION
## Security Fix

**Finding**: POST `/api/v1/data` with `queryConfigName` bypasses SQL validation.

In `routes/api/v1/data.ts`, the POST handler calls `validateSqlQuery` nowhere on its path. When `queryConfigName` is provided and resolves to a server config, the client-supplied `query` string is passed directly to `fetchData` (line 597) with only `readonly: 1` as a backstop. The GET handler validates SQL (line 416) and checks the dashboard allowlist (line 452), but the POST-with-configName path does neither.

An authenticated attacker who knows any valid `queryConfigName` can send arbitrary SELECT SQL (e.g., resource-exhaustive queries, `remote()` table function calls if not blocked by `readonly`) that bypasses the pattern-based SQL validator entirely.

**Fix**: Add `validateSqlQuery(query)` before `fetchData` on the POST path, mirroring the GET handler.

**Verified**:
- All 8 data API tests pass (4 existing readonly + 4 new SQL validation structural tests)
- Full test suite passes: 1213 tests, 0 failures
- Pre-commit lint/typecheck passed
- Pre-push biome check passed (only pre-existing warnings in unrelated files)