### PR TITLE
perf(dashboard-tsr): stub assistant-stream out of CF Worker bundle

### DIFF
--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -134,6 +134,10 @@ const SSR_STUB_PREFIXES = [
   // only imports @json-render/core (~60 KiB, must NOT be stubbed).
   '@json-render/shadcn',
   '@json-render/react',
+  // assistant-stream (~15 KiB gz). Only imported by d1-thread-list-adapter.tsx
+  // and local-thread-list-adapter.tsx, both behind React.lazy in the agent thread.
+  // Never executes during SSR or prerender.
+  'assistant-stream',
 ]
 
 // rolldown does not honour `syntheticNamedExports` from a resolveId result, so
@@ -253,6 +257,9 @@ const SSR_STUB_NAMED_EXPORTS = [
   'shadcnComponents',
   // @json-render/shadcn/catalog — value import from json-render-catalog-with-schema.ts.
   'shadcnComponentDefinitions',
+  // assistant-stream — named import from d1-thread-list-adapter.tsx and
+  // local-thread-list-adapter.tsx (both behind React.lazy agent boundary).
+  'createAssistantStream',
 ]
 
 const SSR_STUB_VIRTUAL_ID = '\0chm-ssr-client-only-stub'


### PR DESCRIPTION
## Finding

SSR stub candidate: **assistant-stream** (~15 KiB gz) is imported only by two adapter files:
- `src/lib/conversation-store/adapter/d1-thread-list-adapter.tsx`
- `src/lib/conversation-store/adapter/local-thread-list-adapter.tsx`

Both are behind React.lazy in the agent thread boundary (`agents-page-client.tsx`) and never execute during SSR or prerender.

## Change

- Add `assistant-stream` to `SSR_STUB_PREFIXES` in vite.config.ts
- Add `createAssistantStream` (the sole named import) to `SSR_STUB_NAMED_EXPORTS`

## Verification

- `grep -rn 'assistant-stream' src/` confirms only the two adapter files import it
- Both adapters are lazy-loaded behind the agent boundary
- No API route or prerender path imports it
- Type-check passed (pre-commit hook)
- Biome lint passed (pre-push hook)
- CI will verify the full build and worker size

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved server-side rendering configuration to ensure proper dependency resolution during prerender.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->