### PR TITLE
fix(dashboard-tsr): add a11y loading announcement to LazyChartWrapper placeholder

### DIFF
--- a/apps/dashboard-tsr/src/components/charts/lazy-chart-wrapper.tsx
+++ b/apps/dashboard-tsr/src/components/charts/lazy-chart-wrapper.tsx
@@ -84,7 +84,19 @@ export const LazyChartWrapper = function LazyChartWrapper({
         containIntrinsicSize: isVisible ? undefined : `auto ${minHeightValue}`,
       }}
     >
-      {isVisible ? children : <Skeleton className="h-full w-full rounded-xl" />}
+      {isVisible ? (
+        children
+      ) : (
+        <div
+          role="status"
+          aria-busy="true"
+          aria-label="Loading chart"
+          className="h-full w-full"
+        >
+          <Skeleton className="h-full w-full rounded-xl" />
+          <span className="sr-only">Loading chart…</span>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Finding

`lazy-chart-wrapper.tsx` renders `<Skeleton className="h-full w-full rounded-xl" />` as the off-screen placeholder with no `role="status"`, `aria-busy`, or `aria-label`. All other skeleton components in the codebase consistently declare these ARIA attributes. A screen reader user scrolling to a lazy-loaded chart gets no loading announcement.

## What changed

Wrapped the bare `<Skeleton>` placeholder in a `<div>` with `role="status"`, `aria-busy="true"`, `aria-label="Loading chart"`, and a `<span className="sr-only">Loading chart…</span>` — matching the established pattern in `components/skeletons/ui.tsx`.

## Verified

- All 1209 dashboard-tsr tests pass (`bun test src/`)
- Pre-commit hooks pass (Biome lint + TypeScript type-check)
- Pre-push hooks pass (full Biome check)