### PR TITLE
fix(dashboard-tsr): use h-96 for table redirect skeleton

### DIFF
--- a/apps/dashboard-tsr/src/routes/(dashboard)/table.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/table.tsx
@@ -22,7 +22,7 @@ function TableRedirect() {
   }, [searchParams, router])
 
   return (
-    <div className="flex h-screen items-center justify-center">
+    <div className="flex h-96 items-center justify-center">
       <div className="space-y-4">
         <Skeleton className="h-8 w-64" />
         <Skeleton className="h-96 w-full" />
@@ -35,7 +35,7 @@ function TablePage() {
   return (
     <Suspense
       fallback={
-        <div className="flex h-screen items-center justify-center">
+        <div className="flex h-96 items-center justify-center">
           <div className="space-y-4">
             <Skeleton className="h-8 w-64" />
             <Skeleton className="h-96 w-full" />


### PR DESCRIPTION
## Finding

The `/table` redirect page skeleton used `h-screen` (full viewport height) but lives inside `DashboardShell` (sidebar + header + scrollable content area). `h-screen` overflows the content region, pushing the skeleton below the viewport so the user sees an empty content area during redirect.

## Fix

Replace both `h-screen` instances with `h-96` to keep the skeleton visible within the dashboard shell during the redirect to `/explorer`.

## Verified

- Biome lint: passed (pre-commit hook)
- TypeScript type-check: passed (pre-commit hook)
- Pre-push full Biome check: passed (warnings are pre-existing)
- Change is CSS-only (`h-screen` → `h-96`), no behavioral logic change, no tests needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the container height for the dashboard table's loading and redirect display states to optimize visual layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->