### PR TITLE
fix(dashboard-tsr): add security response headers

### DIFF
--- a/apps/dashboard-tsr/src/lib/security-headers.test.ts
+++ b/apps/dashboard-tsr/src/lib/security-headers.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test'
+import { SECURITY_HEADERS, withSecurityHeaders } from '@/lib/security-headers'
+
+describe('SECURITY_HEADERS', () => {
+  test('contains all expected headers', () => {
+    expect(SECURITY_HEADERS['X-Content-Type-Options']).toBe('nosniff')
+    expect(SECURITY_HEADERS['X-Frame-Options']).toBe('DENY')
+    expect(SECURITY_HEADERS['Referrer-Policy']).toBe(
+      'strict-origin-when-cross-origin'
+    )
+    expect(SECURITY_HEADERS['Permissions-Policy']).toBe(
+      'camera=(), microphone=(), geolocation=()'
+    )
+  })
+
+  test('has exactly 4 entries (no accidental additions)', () => {
+    expect(Object.keys(SECURITY_HEADERS)).toHaveLength(4)
+  })
+})
+
+describe('withSecurityHeaders', () => {
+  test('adds security headers to a plain response', () => {
+    const original = new Response('ok', { status: 200 })
+    const result = withSecurityHeaders(original)
+
+    expect(result.headers.get('X-Content-Type-Options')).toBe('nosniff')
+    expect(result.headers.get('X-Frame-Options')).toBe('DENY')
+    expect(result.headers.get('Referrer-Policy')).toBe(
+      'strict-origin-when-cross-origin'
+    )
+    expect(result.headers.get('Permissions-Policy')).toBe(
+      'camera=(), microphone=(), geolocation=()'
+    )
+  })
+
+  test('preserves original status, statusText, and body', async () => {
+    const original = new Response('hello', {
+      status: 201,
+      statusText: 'Created',
+      headers: { 'Content-Type': 'text/plain' },
+    })
+    const result = withSecurityHeaders(original)
+
+    expect(result.status).toBe(201)
+    expect(result.statusText).toBe('Created')
+    expect(await result.text()).toBe('hello')
+  })
+
+  test('preserves existing non-security headers', () => {
+    const original = new Response('ok', {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Custom': 'value',
+      },
+    })
+    const result = withSecurityHeaders(original)
+
+    expect(result.headers.get('Content-Type')).toBe('application/json')
+    expect(result.headers.get('X-Custom')).toBe('value')
+  })
+
+  test('overwrites pre-existing security header values', () => {
+    const original = new Response('ok', {
+      headers: { 'X-Frame-Options': 'SAMEORIGIN' },
+    })
+    const result = withSecurityHeaders(original)
+
+    expect(result.headers.get('X-Frame-Options')).toBe('DENY')
+  })
+
+  test('does not mutate the original response', () => {
+    const original = new Response('ok', {
+      headers: { 'X-Frame-Options': 'SAMEORIGIN' },
+    })
+    withSecurityHeaders(original)
+
+    expect(original.headers.get('X-Frame-Options')).toBe('SAMEORIGIN')
+  })
+})

--- a/apps/dashboard-tsr/src/lib/security-headers.ts
+++ b/apps/dashboard-tsr/src/lib/security-headers.ts
@@ -1,0 +1,36 @@
+/**
+ * Security response headers applied to every response.
+ *
+ * Covers MIME-sniffing protection, clickjacking prevention, referrer
+ * information leakage, and feature gating. CSP is intentionally omitted —
+ * the app loads remote scripts (Clerk, analytics) and constructing a strict
+ * CSP would require ongoing maintenance that outweighs the benefit at this
+ * stage.
+ */
+
+export const SECURITY_HEADERS: Record<string, string> = {
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+}
+
+/**
+ * Clone a Response with security headers appended.
+ *
+ * Preserves status, statusText, body, and all original headers.
+ * Security headers overwrite any pre-existing values for the same names
+ * (defence-in-depth — e.g. an API route that accidentally sets a permissive
+ * X-Frame-Options gets corrected).
+ */
+export function withSecurityHeaders(response: Response): Response {
+  const headers = new Headers(response.headers)
+  for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
+    headers.set(key, value)
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}

--- a/apps/dashboard-tsr/src/start.ts
+++ b/apps/dashboard-tsr/src/start.ts
@@ -57,11 +57,17 @@ const apiAuthMiddleware = createMiddleware().server(
  */
 const securityHeadersMiddleware = createMiddleware().server(
   async ({ next }) => {
-    const ctx = await next()
+    const result = await next()
 
-    if (ctx.response instanceof Response) {
-      ctx.response = withSecurityHeaders(ctx.response)
+    if (result.response instanceof Response) {
+      result.response = withSecurityHeaders(result.response)
     }
+
+    // Return the result (not void) — TanStack Start types a request middleware
+    // as returning `RequestServerResult | Response`, and the runtime reads the
+    // response from the returned value. Returning the mutated result both
+    // type-checks and avoids relying on by-reference ctx mutation.
+    return result
   }
 )
 

--- a/apps/dashboard-tsr/src/start.ts
+++ b/apps/dashboard-tsr/src/start.ts
@@ -17,6 +17,7 @@ import { createMiddleware, createStart } from '@tanstack/react-start'
 
 import { env } from 'cloudflare:workers'
 import { bridgeApiKeyEnv, resolveApiGuard } from '@/lib/auth/api-guard'
+import { withSecurityHeaders } from '@/lib/security-headers'
 
 // Returning a Response from a request middleware short-circuits the chain and
 // sends that Response without running the route handler (same mechanism the
@@ -36,8 +37,38 @@ const apiAuthMiddleware = createMiddleware().server(
   }
 )
 
+// ---------------------------------------------------------------------------
+// Security response headers
+// ---------------------------------------------------------------------------
+// Applied to every response (pages, API, static assets). The middleware runs
+// AFTER the downstream chain (via `next()`) so it can patch the final
+// Response. See `@/lib/security-headers` for the header set and rationale.
+// CSP is intentionally omitted — the app loads remote scripts (Clerk,
+// analytics) and constructing a strict CSP would require ongoing maintenance
+// that outweighs the benefit at this stage.
+
+/**
+ * Appends security headers to every response.
+ *
+ * `next()` returns the accumulated middleware context whose `.response` is
+ * the final `Response` produced by the route handler or prerender. We clone
+ * it with the extra headers. The middleware MUST come first in the array so
+ * it wraps the entire chain (outermost position).
+ */
+const securityHeadersMiddleware = createMiddleware().server(
+  async ({ next }) => {
+    const ctx = await next()
+
+    if (ctx.response instanceof Response) {
+      ctx.response = withSecurityHeaders(ctx.response)
+    }
+  }
+)
+
 export const startInstance = createStart(() => {
   return {
-    requestMiddleware: [apiAuthMiddleware],
+    // Order matters: security-headers is first so it wraps the entire chain
+    // and patches the response on the way out.
+    requestMiddleware: [securityHeadersMiddleware, apiAuthMiddleware],
   }
 })


### PR DESCRIPTION
**Finding:** Security audit found no security response headers set anywhere in the app -- no `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, or `Content-Security-Policy`. This left the app vulnerable to clickjacking, MIME-type sniffing, and information leakage via Referrer headers.

**Fix:** Add a global request middleware in `start.ts` (outermost position) that wraps every downstream response with security headers. The header logic is extracted into a testable `@/lib/security-headers` module.

Headers added:
- `X-Content-Type-Options: nosniff` -- prevents MIME-type sniffing
- `X-Frame-Options: DENY` -- prevents clickjacking via iframe embedding
- `Referrer-Policy: strict-origin-when-cross-origin` -- limits referrer leakage
- `Permissions-Policy: camera=(), microphone=(), geolocation=()` -- gates sensitive APIs

CSP intentionally omitted -- the app loads remote scripts (Clerk, analytics) and constructing a strict CSP would require ongoing nonce/hash maintenance that outweighs the benefit at this stage.

**Verified:**
- 7 unit tests pass (`bun test src/lib/security-headers.test.ts`)
- Full suite passes (1215 pass, 1 pre-existing flake in clerk-client test from env ordering)
- Pre-push lint + type-check clean (no new warnings)
- No changes to build config, routing, or UI components

**Files changed:**
- `apps/dashboard-tsr/src/lib/security-headers.ts` -- SECURITY_HEADERS map + `withSecurityHeaders()` Response cloner
- `apps/dashboard-tsr/src/lib/security-headers.test.ts` -- 7 tests
- `apps/dashboard-tsr/src/start.ts` -- adds `securityHeadersMiddleware` as outermost middleware