### PR TITLE
fix(dashboard-tsr): unblock main — chainable SSR stub + readonly string type

### DIFF
--- a/apps/dashboard-tsr/src/routes/api/v1/data.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/data.ts
@@ -471,7 +471,7 @@ const handleGet = withApiHandler(async (request: Request) => {
     hostId,
     // SECURITY: Enforce readonly mode to prevent DML/DDL even if SQL validation is bypassed
     clickhouse_settings: {
-      readonly: 1,
+      readonly: '1',
       ...(timezone ? { session_timezone: timezone } : {}),
     },
   })
@@ -602,7 +602,7 @@ const handlePost = withApiHandler(async (request: Request) => {
     queryConfig: serverQueryConfig,
     // SECURITY: Enforce readonly mode to prevent DML/DDL even if SQL validation is bypassed
     clickhouse_settings: {
-      readonly: 1,
+      readonly: '1',
       ...(timezone ? { session_timezone: timezone } : {}),
     },
   })

--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -269,8 +269,11 @@ function isStubbedSpecifier(id: string): boolean {
 function ssrClientOnlyStub(): PluginOption {
   // Virtual module: a Proxy default export (covers default/namespace imports of
   // mermaid/katex/cytoscape) plus explicit named aliases for the codemirror
-  // symbols. The Proxy is never invoked — these modules only execute inside
-  // browser effects / lazy chunks that the worker never reaches.
+  // symbols. The modules only execute meaningfully inside browser effects /
+  // lazy chunks the worker never reaches, BUT some are evaluated at module
+  // top-level during prerender (e.g. `defineRegistry(...).registry` in
+  // json-render-registry.ts). So `apply()`/`get` both return the chainable
+  // `stub` — calling or property-accessing a stub stays safe and never throws.
   const namedExports = SSR_STUB_NAMED_EXPORTS.map(
     (n) => `export const ${n} = stub`
   ).join('\n')
@@ -282,7 +285,7 @@ const stub = new Proxy(noop, {
     if (typeof p === 'symbol') return undefined
     return stub
   },
-  apply() { return undefined },
+  apply() { return stub },
   construct() { return {} },
 })
 export default stub


### PR DESCRIPTION
Main's required `dashboard-tsr` check is **red on two counts**, both masked by a hard prerender crash. This PR fixes both so one merge restores green and unblocks all 7 open dash-tsr PRs (#1481–#1487).

## Fix 1 — SSR stub apply() chainable (prerender crash)

`src/lib/ai/agent/json-render-registry.ts:24` evaluates `defineRegistry(...).registry` at **module top-level**. Since #1477 stubbed `@json-render/react`, `defineRegistry` resolves to the SSR stub whose Proxy `apply()` returned `undefined` → `.registry` threw:
```
TypeError: Cannot read properties of undefined (reading 'registry')
```
The Proxy's `get` trap already returns the chainable `stub`; align `apply()` to match so `stubbedFn().anyProp` stays safe. Validated in isolation (old throws, new doesn't). These modules never execute meaningfully during SSR (agent UI is lazy/client-only).

## Fix 2 — readonly setting type (tsc failure)

Once the crash was fixed, prerender advanced to `tsc`, surfacing a pre-existing type error from #1476:
```
data.ts(474,7) & (605,7): error TS2322: Type 'number' is not assignable to type 'string'
```
`@clickhouse/client-common` 1.19 types `ClickHouseSettings.readonly` as `UInt64 = string`. Changed `readonly: 1` → `readonly: '1'` at both call sites.

## Notes
- The ~240 `graphlib.Graph is not a constructor` prerender warnings are **pre-existing non-fatal noise** (present in the last *successful* cycle-1 build, job 79518607937). Out of scope here; tracked for a prerender-coverage loop.

Co-Authored-By: duyetbot <bot@duyet.net>