### PR TITLE
perf(dashboard-tsr): set query gcTime to 30m for instant back-navigation

### DIFF
--- a/apps/dashboard-tsr/src/lib/query/provider.tsx
+++ b/apps/dashboard-tsr/src/lib/query/provider.tsx
@@ -17,6 +17,18 @@ export function QueryProvider({ children }: QueryProviderProps) {
             // and the cached result is considered fresh for this long.
             staleTime: 5_000,
 
+            // Keep inactive (unmounted) query data in cache for 30 min before
+            // garbage-collecting it. Orthogonal to staleTime: this does NOT
+            // affect freshness — data still revalidates per staleTime — it only
+            // controls how long a cached result survives after its last consumer
+            // unmounts. A monitoring dashboard hops between pages constantly;
+            // with the 5 min default, returning to a page after the GC window
+            // shows a loading skeleton. 30 min lets the user navigate back to an
+            // instant stale-while-revalidate render (cached data shown, refetch
+            // in background) instead of a blank skeleton. (TanStack Query
+            // default gcTime is 5 min.)
+            gcTime: 30 * 60_000,
+
             // SWR revalidateOnFocus: false
             // Don't refetch when the browser tab regains focus.
             refetchOnWindowFocus: false,


### PR DESCRIPTION
## What

Add `gcTime: 30 * 60_000` to the dash-tsr `QueryClient` defaults.

## Why

The client set `staleTime` (5s) but left `gcTime` at the TanStack Query default (5 min). These are orthogonal:
- **staleTime** — when cached data is considered stale and refetched.
- **gcTime** — how long an *inactive* (unmounted) query's data survives in cache before garbage collection.

On a monitoring dashboard users navigate between pages constantly. With the 5-min default, returning to a page after the GC window renders a blank loading skeleton. Raising `gcTime` to 30 min lets back-navigation render **instantly** — cached data shown immediately, revalidated in the background per `staleTime`.

## Risk

None to freshness — `staleTime` still governs refetch. Pure perceived-perf / UX win. Part of the cycle-5 "better query caching" optimization track (#1392).

Co-Authored-By: duyetbot <bot@duyet.net>