### PR TITLE
fix(dashboard-tsr): update readonly structural test for string value

### DIFF
--- a/apps/dashboard-tsr/src/routes/api/v1/data/__tests__/readonly.test.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/data/__tests__/readonly.test.ts
@@ -2,11 +2,11 @@
  * Tests for data.ts ClickHouse readonly enforcement
  *
  * Structural verification that the /api/v1/data route enforces
- * `readonly: 1` in clickhouse_settings for both GET and POST handlers.
+ * `readonly: '1'` in clickhouse_settings for both GET and POST handlers.
  * This is a defense-in-depth measure: even if the SQL validation blocklist
  * is bypassed or incomplete, ClickHouse itself will reject DML/DDL.
  *
- * The explorer/query.ts route already sets `readonly: 1`; this test
+ * The explorer/query.ts route already sets `readonly: '1'`; this test
  * ensures the data route follows the same pattern.
  */
 
@@ -21,24 +21,24 @@ const DATA_SOURCE = readFileSync(
 )
 
 describe('data.ts readonly enforcement (structural)', () => {
-  test('GET handler sets readonly: 1 in clickhouse_settings', () => {
-    // The GET handler should have readonly: 1 in its clickhouse_settings
+  test("GET handler sets readonly: '1' in clickhouse_settings", () => {
+    // The GET handler should have readonly: '1' in its clickhouse_settings
     // within the handleGet function
     expect(DATA_SOURCE).toMatch(
-      /handleGet[\s\S]*?clickhouse_settings:\s*\{[^}]*readonly:\s*1/
+      /handleGet[\s\S]*?clickhouse_settings:\s*\{[^}]*readonly:\s*'1'/
     )
   })
 
-  test('POST handler sets readonly: 1 in clickhouse_settings', () => {
-    // The POST handler should have readonly: 1 in its clickhouse_settings
+  test("POST handler sets readonly: '1' in clickhouse_settings", () => {
+    // The POST handler should have readonly: '1' in its clickhouse_settings
     // within the handlePost function
     expect(DATA_SOURCE).toMatch(
-      /handlePost[\s\S]*?clickhouse_settings:\s*\{[^}]*readonly:\s*1/
+      /handlePost[\s\S]*?clickhouse_settings:\s*\{[^}]*readonly:\s*'1'/
     )
   })
 
   test('readonly appears exactly twice (once per handler)', () => {
-    const matches = DATA_SOURCE.match(/readonly:\s*1/g)
+    const matches = DATA_SOURCE.match(/readonly:\s*'1'/g)
     expect(matches).not.toBeNull()
     expect(matches!.length).toBe(2)
   })
@@ -46,7 +46,7 @@ describe('data.ts readonly enforcement (structural)', () => {
   test('session_timezone is preserved alongside readonly', () => {
     // Both handlers should spread session_timezone conditionally after readonly
     expect(DATA_SOURCE).toMatch(
-      /readonly:\s*1,\s*\.\.\.\(timezone\s*\?\s*\{\s*session_timezone:\s*timezone\s*\}\s*:\s*\{\}\)/
+      /readonly:\s*'1',\s*\.\.\.\(timezone\s*\?\s*\{\s*session_timezone:\s*timezone\s*\}\s*:\s*\{\}\)/
     )
   })
 })


### PR DESCRIPTION
## Found by `/code-review` of the cycle-5 batch

**#1488** corrected `clickhouse_settings.readonly` from `1` (number) to `'1'` (string) — `@clickhouse/client-common` types `readonly` as `UInt64 = string`. But `readonly.test.ts` asserts `/readonly:\s*1/`, which no longer matches `readonly: '1'` (a quote now sits between `:` and `1`).

**All 4 structural tests were silently failing on main** — the dash-tsr unit suite isn't a required check, so the red tests didn't block the merge. This restores them.

## Fix
Update the 4 regexes from `/readonly:\s*1/` → `/readonly:\s*'1'/` and the prose comments to match.

```
bun test readonly.test.ts → 4 pass / 0 fail
```

Verified locally against the real `data.ts` (both GET/POST sites now `readonly: '1'`).

Co-Authored-By: duyetbot <bot@duyet.net>