### PR TITLE
fix(dashboard-tsr): apply security headers to static pages via _headers

### DIFF
--- a/apps/dashboard-tsr/public/_headers
+++ b/apps/dashboard-tsr/public/_headers
@@ -1,0 +1,14 @@
+# Cloudflare Workers static-asset response headers.
+# https://developers.cloudflare.com/workers/static-assets/headers/
+#
+# Vite copies this file from public/ to the client build output (dist/client),
+# which is the Workers assets root. It applies the same security headers as the
+# request middleware in src/lib/security-headers.ts (SECURITY_HEADERS) — but to
+# PRERENDERED STATIC PAGES, which are served straight from the edge asset store
+# and bypass the worker (so the middleware never runs for them). Keep this list
+# in sync with SECURITY_HEADERS.
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=()


### PR DESCRIPTION
## Gap (found by post-deploy verification of #1487)

#1487 applies security headers via a TanStack Start **request middleware** — which only runs for **worker-handled** responses. Verified live on `dash-tsr.chmonitor.dev`:

| Response | Headers |
|---|---|
| `GET /api/v1/config` (worker) | ✅ all 4 present |
| `GET /overview` (prerendered static, `cf-cache-status: HIT`, bypasses worker) | ❌ none |

Most user-facing loads are prerendered static pages served straight from CF edge assets — they had **no** security headers.

## Fix

Add a Cloudflare [`_headers`](https://developers.cloudflare.com/workers/static-assets/headers/) file. Vite copies `public/_headers` → `dist/client/_headers` (the Workers assets root), applying the same 4 headers (mirrors `SECURITY_HEADERS`) to all static pages. Combined with #1487's middleware → full coverage.

## ⚠️ Verification required post-deploy

CI green only proves the file builds. After merge+deploy I'll `curl -I https://dash-tsr.chmonitor.dev/overview` and confirm the 4 headers appear on the static page. If CF doesn't honor `_headers` for this assets setup, a fallback (worker-level asset interception) will be needed.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Bug Fixes:
- Add a Cloudflare _headers configuration to apply existing security headers to all static pages, closing the gap where only worker-handled responses were protected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured security headers for static assets to enforce consistent security standards across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->