### PR TITLE
refactor(dashboard-tsr): extract activateOnEnterOrSpace a11y helper

### DIFF
--- a/apps/dashboard-tsr/src/components/explorer/explorer-empty-state.tsx
+++ b/apps/dashboard-tsr/src/components/explorer/explorer-empty-state.tsx
@@ -15,6 +15,7 @@ import { useExplorerState } from './hooks/use-explorer-state'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { activateOnEnterOrSpace } from '@/lib/a11y'
 import { useHostId } from '@/lib/swr'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { cn } from '@/lib/utils'
@@ -163,12 +164,7 @@ export function ExplorerEmptyState() {
                   tabIndex={0}
                   className="group cursor-pointer p-4 transition-[border-color,background-color] hover:border-primary/50 hover:bg-muted/50"
                   onClick={() => setDatabase(db.name)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      setDatabase(db.name)
-                    }
-                  }}
+                  onKeyDown={activateOnEnterOrSpace(() => setDatabase(db.name))}
                 >
                   <div className="flex items-center gap-3">
                     <div

--- a/apps/dashboard-tsr/src/components/explorer/tabs/data-tab.tsx
+++ b/apps/dashboard-tsr/src/components/explorer/tabs/data-tab.tsx
@@ -29,6 +29,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { activateOnEnterOrSpace } from '@/lib/a11y'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { useHostId } from '@/lib/swr/use-host'
 import { cn } from '@/lib/utils'
@@ -48,13 +49,6 @@ const ExpandableCell = function ExpandableCell({ value }: { value: unknown }) {
     setExpanded((prev) => !prev)
   }
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault()
-      toggleExpand()
-    }
-  }
-
   if (!isLong) {
     return <span className="block truncate">{stringValue}</span>
   }
@@ -64,7 +58,7 @@ const ExpandableCell = function ExpandableCell({ value }: { value: unknown }) {
       role="button"
       tabIndex={0}
       onClick={toggleExpand}
-      onKeyDown={handleKeyDown}
+      onKeyDown={activateOnEnterOrSpace(toggleExpand)}
       className={cn(
         'block cursor-pointer transition-colors',
         expanded ? 'whitespace-pre-wrap break-words' : 'truncate',

--- a/apps/dashboard-tsr/src/components/explorer/tabs/query-tab.tsx
+++ b/apps/dashboard-tsr/src/components/explorer/tabs/query-tab.tsx
@@ -39,6 +39,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { apiFetch } from '@/lib/swr/api-fetch'
+import { activateOnEnterOrSpace } from '@/lib/a11y'
 import { useHostId } from '@/lib/swr/use-host'
 import { cn } from '@/lib/utils'
 
@@ -96,13 +97,6 @@ const ExpandableCell = function ExpandableCell({ value }: { value: unknown }) {
     setExpanded((prev) => !prev)
   }
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault()
-      toggleExpand()
-    }
-  }
-
   if (!isLong) {
     return <span className="block truncate">{stringValue}</span>
   }
@@ -112,7 +106,7 @@ const ExpandableCell = function ExpandableCell({ value }: { value: unknown }) {
       role="button"
       tabIndex={0}
       onClick={toggleExpand}
-      onKeyDown={handleKeyDown}
+      onKeyDown={activateOnEnterOrSpace(toggleExpand)}
       className={cn(
         'block cursor-pointer transition-colors',
         expanded ? 'whitespace-pre-wrap break-words' : 'truncate',

--- a/apps/dashboard-tsr/src/lib/a11y.test.ts
+++ b/apps/dashboard-tsr/src/lib/a11y.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test'
+import type { KeyboardEvent } from 'react'
+
+import { activateOnEnterOrSpace } from './a11y'
+
+function fakeEvent(key: string) {
+  let prevented = false
+  return {
+    event: {
+      key,
+      preventDefault: () => {
+        prevented = true
+      },
+    } as unknown as KeyboardEvent,
+    wasPrevented: () => prevented,
+  }
+}
+
+describe('activateOnEnterOrSpace', () => {
+  test('activates and preventsDefault on Enter', () => {
+    let called = 0
+    const handler = activateOnEnterOrSpace(() => {
+      called++
+    })
+    const { event, wasPrevented } = fakeEvent('Enter')
+    handler(event)
+    expect(called).toBe(1)
+    expect(wasPrevented()).toBe(true)
+  })
+
+  test('activates and preventsDefault on Space', () => {
+    let called = 0
+    const handler = activateOnEnterOrSpace(() => {
+      called++
+    })
+    const { event, wasPrevented } = fakeEvent(' ')
+    handler(event)
+    expect(called).toBe(1)
+    expect(wasPrevented()).toBe(true)
+  })
+
+  test('ignores other keys (no activation, no preventDefault)', () => {
+    let called = 0
+    const handler = activateOnEnterOrSpace(() => {
+      called++
+    })
+    for (const key of ['Tab', 'a', 'ArrowDown', 'Escape']) {
+      const { event, wasPrevented } = fakeEvent(key)
+      handler(event)
+      expect(wasPrevented()).toBe(false)
+    }
+    expect(called).toBe(0)
+  })
+})

--- a/apps/dashboard-tsr/src/lib/a11y.ts
+++ b/apps/dashboard-tsr/src/lib/a11y.ts
@@ -1,0 +1,23 @@
+import type { KeyboardEvent } from 'react'
+
+/**
+ * Build an onKeyDown handler that activates a non-button element (a clickable
+ * Card, span, etc. given `role="button"` + `tabIndex={0}`) on Enter or Space —
+ * mirroring native `<button>` keyboard semantics. `preventDefault` stops Space
+ * from scrolling the page.
+ *
+ * Replaces the copy-pasted
+ *   `if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); fn() }`
+ * blocks. Not a hook (uses no React hooks) — safe to call inline in JSX.
+ *
+ * @example
+ * <Card role="button" tabIndex={0} onClick={open} onKeyDown={activateOnEnterOrSpace(open)} />
+ */
+export function activateOnEnterOrSpace(activate: () => void) {
+  return (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      activate()
+    }
+  }
+}


### PR DESCRIPTION
## What (found by `/code-review` → `/simplify`)

The "activate a clickable non-button on Enter/Space" keydown block was copy-pasted across explorer clickable cards/cells:
```ts
if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); fn() }
```

Extract a single `activateOnEnterOrSpace(fn)` helper (`src/lib/a11y.ts`) **with a unit test**, and adopt it in `explorer-empty-state`, `data-tab`, `query-tab`.

## Notes
- **Plain factory, not a `use*` hook** (no React hooks inside) — lint-safe to call inline in JSX, no rules-of-hooks risk.
- **Behavior-preserving**: Enter/Space → activate + preventDefault; all other keys ignored (covered by `a11y.test.ts`, 3 pass locally).
- Serves *simplify codebase, well tested* (#1392). Other element types (buttons, menus) using a similar pattern are a documented follow-up sweep.

Co-Authored-By: duyetbot <bot@duyet.net>