### PR TITLE
refactor(dashboard-tsr): adopt activateOnEnterOrSpace in 2 more clickable sites

### DIFF
--- a/apps/dashboard-tsr/src/components/charts/chart-empty.tsx
+++ b/apps/dashboard-tsr/src/components/charts/chart-empty.tsx
@@ -14,6 +14,7 @@ import {
   CardHeader,
 } from '@/components/ui/card'
 import { SuggestionCard } from '@/components/ui/suggestion-card'
+import { activateOnEnterOrSpace } from '@/lib/a11y'
 import { useRouter } from '@/lib/next-compat'
 import { useHostId } from '@/lib/swr'
 import { cn } from '@/lib/utils'
@@ -92,14 +93,6 @@ export const ChartEmpty = function ChartEmpty({
     navigateToHref()
   }
 
-  const handleCardKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (!href) return
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault()
-      navigateToHref()
-    }
-  }
-
   return (
     <Card
       className={cn(
@@ -110,7 +103,7 @@ export const ChartEmpty = function ChartEmpty({
         className
       )}
       onClick={handleCardClick}
-      onKeyDown={handleCardKeyDown}
+      onKeyDown={href ? activateOnEnterOrSpace(navigateToHref) : undefined}
       tabIndex={href ? 0 : undefined}
       role={href ? 'link' : 'status'}
       aria-label={

--- a/apps/dashboard-tsr/src/components/utilities/expandable-text.tsx
+++ b/apps/dashboard-tsr/src/components/utilities/expandable-text.tsx
@@ -3,6 +3,7 @@ import { ChevronDown } from 'lucide-react'
 import type { CSSProperties, ReactNode } from 'react'
 
 import { useEffect, useRef, useState } from 'react'
+import { activateOnEnterOrSpace } from '@/lib/a11y'
 import { cn } from '@/lib/utils'
 
 export interface ExpandableTextProps {
@@ -24,15 +25,6 @@ function getLineClampStyle(maxLines: number): CSSProperties {
 
 function checkOverflow(element: HTMLElement): boolean {
   return element.scrollHeight > element.clientHeight
-}
-
-function useKeyboardToggle(toggle: () => void) {
-  return (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault()
-      toggle()
-    }
-  }
 }
 
 function useClickOutside(
@@ -95,7 +87,7 @@ const PopoverVariant = function PopoverVariant({
     setIsOpen((prev) => !prev)
   }
 
-  const handleKeyDown = useKeyboardToggle(handleToggle)
+  const handleKeyDown = activateOnEnterOrSpace(handleToggle)
 
   useClickOutside(isOpen, [contentRef, popoverRef], () => setIsOpen(false))
 
@@ -172,7 +164,7 @@ const InlineVariant = function InlineVariant({
     setIsExpanded((prev) => !prev)
   }
 
-  const handleKeyDown = useKeyboardToggle(handleToggle)
+  const handleKeyDown = activateOnEnterOrSpace(handleToggle)
 
   return (
     <div


### PR DESCRIPTION
Continues the a11y keydown DRY from #1494. Migrates the **two remaining faithful** clickable-activation sites to the shared `activateOnEnterOrSpace` helper:

- **chart-empty.tsx** — replace `handleCardKeyDown` (guard preserved via conditional `onKeyDown` when `href` is set)
- **expandable-text.tsx** — replace the local `useKeyboardToggle` (a mislabeled `use*`-prefixed duplicate of the helper)

### Deliberately NOT migrated (classified per-file — different semantics)
A blind sweep would have broken these:
- **Enter-only on text inputs** (filter-editor, web-preview, data-table-header, add-context-dialog) — Space must type a space, not activate
- **Cmd/Ctrl+Enter shortcut** (explain.tsx)
- **Enter-only, no preventDefault** (collapsed-submenu)

Behavior-preserving; helper is unit-tested (`a11y.test.ts`). Serves *simplify codebase, well tested* (#1392).

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced consistency in keyboard navigation across chart and expandable components for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->