### PR TITLE
fix(dashboard-tsr): register clerkMiddleware + missing explorer configs

### DIFF
--- a/apps/dashboard-tsr/src/components/explorer/tabs/query-tab.tsx
+++ b/apps/dashboard-tsr/src/components/explorer/tabs/query-tab.tsx
@@ -25,7 +25,7 @@ import type {
 } from '@/lib/api/types'
 
 import { useExplorerState } from '../hooks/use-explorer-state'
-import { lazy, Suspense, useEffect, useRef, useState } from 'react'
+import { lazy, useMemo, Suspense, useEffect, useRef, useState } from 'react'
 import { format } from 'sql-formatter'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
@@ -229,7 +229,10 @@ function useAutoCompleteSchema(hostId: number) {
     refetchOnWindowFocus: false,
   })
 
-  return (() => {
+  // Memoize to avoid returning a new object reference every render, which
+  // would trigger the SqlEditor's schema useEffect on every render and
+  // potentially cause expensive CodeMirror reconfigurations.
+  return useMemo(() => {
     const schema: Record<string, string[]> = {}
     const databases = dbResponse?.data || []
 
@@ -239,7 +242,7 @@ function useAutoCompleteSchema(hostId: number) {
     }
 
     return schema
-  })()
+  }, [dbResponse?.data])
 }
 
 export function QueryTab() {

--- a/apps/dashboard-tsr/src/lib/query-config/index.ts
+++ b/apps/dashboard-tsr/src/lib/query-config/index.ts
@@ -7,11 +7,18 @@ export { getSqlForDisplay } from './types'
 // Anomaly Detection
 import { anomalyQueries } from './anomaly/anomaly-queries'
 import {
+  explorerAllDependenciesConfig,
   explorerColumnsConfig,
+  explorerDatabaseDependenciesConfig,
   explorerDatabasesConfig,
   explorerDdlConfig,
+  explorerDependenciesDownstreamConfig,
+  explorerDependenciesUpstreamConfig,
+  explorerDictionarySourceConfig,
   explorerIndexesConfig,
+  explorerProjectionsConfig,
   explorerSkipIndexesConfig,
+  explorerTableDependenciesConfig,
   explorerTablesConfig,
 } from './explorer'
 import {
@@ -101,6 +108,13 @@ export const queries: Array<QueryConfig> = [
   explorerDdlConfig,
   explorerIndexesConfig,
   explorerSkipIndexesConfig,
+  explorerProjectionsConfig,
+  explorerAllDependenciesConfig,
+  explorerDatabaseDependenciesConfig,
+  explorerDependenciesDownstreamConfig,
+  explorerDependenciesUpstreamConfig,
+  explorerDictionarySourceConfig,
+  explorerTableDependenciesConfig,
 
   // Tables
   tablesOverviewConfig,

--- a/apps/dashboard-tsr/src/start.ts
+++ b/apps/dashboard-tsr/src/start.ts
@@ -16,7 +16,9 @@
 import { createMiddleware, createStart } from '@tanstack/react-start'
 
 import { env } from 'cloudflare:workers'
+import { clerkMiddleware } from '@clerk/tanstack-react-start/server'
 import { bridgeApiKeyEnv, resolveApiGuard } from '@/lib/auth/api-guard'
+import { isClerkAuthProvider } from '@/lib/auth/provider'
 import { withSecurityHeaders } from '@/lib/security-headers'
 
 // Returning a Response from a request middleware short-circuits the chain and
@@ -71,10 +73,30 @@ const securityHeadersMiddleware = createMiddleware().server(
   }
 )
 
+// ---------------------------------------------------------------------------
+// Clerk middleware
+// ---------------------------------------------------------------------------
+// `auth()` from `@clerk/tanstack-react-start/server` reads the authenticated
+// session from `getGlobalStartContext().auth`, which is ONLY populated by
+// `clerkMiddleware()`. Without it, every server-side `auth()` call throws
+// `clerkMiddlewareNotConfigured` (silently caught by try/catch in
+// feature-permission checks), causing all authenticated endpoints to return
+// 401 even when the user has a valid Clerk session cookie.
+//
+// The middleware must run before apiAuthMiddleware so the auth context is
+// available to downstream guards and route handlers. Only registered when
+// Clerk is the active auth provider (CHM_AUTH_PROVIDER=clerk).
+
 export const startInstance = createStart(() => {
-  return {
-    // Order matters: security-headers is first so it wraps the entire chain
-    // and patches the response on the way out.
-    requestMiddleware: [securityHeadersMiddleware, apiAuthMiddleware],
+  // Order matters: security-headers is first (outermost) so it wraps the
+  // entire chain and patches the response on the way out.
+  const middleware = [securityHeadersMiddleware]
+
+  if (isClerkAuthProvider()) {
+    middleware.push(clerkMiddleware())
   }
+
+  middleware.push(apiAuthMiddleware)
+
+  return { requestMiddleware: middleware }
 })

--- a/apps/dashboard-tsr/src/start.ts
+++ b/apps/dashboard-tsr/src/start.ts
@@ -84,15 +84,26 @@ const securityHeadersMiddleware = createMiddleware().server(
 // 401 even when the user has a valid Clerk session cookie.
 //
 // The middleware must run before apiAuthMiddleware so the auth context is
-// available to downstream guards and route handlers. Only registered when
-// Clerk is the active auth provider (CHM_AUTH_PROVIDER=clerk).
+// available to downstream guards and route handlers.
+//
+// GUARD: `clerkMiddleware()` calls `clerkClient()` which requires
+// `CLERK_SECRET_KEY`. This key is only available at runtime (Cloudflare Worker
+// secret), NOT during CI builds or prerender. Without the guard, the build
+// fails with "Clerk: no secret key provided" during static generation.
+
+/** True when the Clerk secret key is available (runtime only, not CI build). */
+function hasClerkSecretKey(): boolean {
+  return Boolean(
+    process.env.CLERK_SECRET_KEY || import.meta.env.CLERK_SECRET_KEY
+  )
+}
 
 export const startInstance = createStart(() => {
   // Order matters: security-headers is first (outermost) so it wraps the
   // entire chain and patches the response on the way out.
   const middleware = [securityHeadersMiddleware]
 
-  if (isClerkAuthProvider()) {
+  if (isClerkAuthProvider() && hasClerkSecretKey()) {
     middleware.push(clerkMiddleware())
   }
 


### PR DESCRIPTION
## Fixes

### 1. Systemic Clerk auth issue — all API endpoints return 401

`auth()` from `@clerk/tanstack-react-start/server` reads the authenticated session from `getGlobalStartContext().auth`, which is ONLY populated by `clerkMiddleware()`. Without it, every server-side `auth()` call throws `clerkMiddlewareNotConfigured` (silently caught by try/catch in feature-permission checks), causing all authenticated endpoints to return 401 even when the user has a valid Clerk session cookie.

**Fix**: Add `clerkMiddleware()` to the `start.ts` request middleware chain, conditionally when `isClerkAuthProvider()` returns true.

**Affected endpoints**: `/api/v1/agent`, `/api/v1/agents/models`, `/api/v1/conversations`, all feature-gated endpoints.

### 2. Explorer dependencies API 500 error

7 explorer query configs were exported from their modules but never added to the `queries` array in `lib/query-config/index.ts`. The `tableRegistry` is seeded from this array, so `getTableQuery()` returned null for these config names.

**Fix**: Add all 7 missing configs to the array.

**Affected endpoints**: `/api/v1/explorer/dependencies?direction=all`, `/api/v1/explorer/projections`, all dependency directions.

**Configs added**: `explorer-all-dependencies`, `explorer-database-dependencies`, `explorer-dependencies-downstream`, `explorer-dependencies-upstream`, `explorer-dictionary-source`, `explorer-table-dependencies`, `explorer-projections`.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded explorer query capabilities to add projections, dependency graphs, dictionary source lookups, and table-dependencies analysis within the dashboard.

* **Chores**
  * Improved authentication middleware setup to conditionally enable Clerk-based auth when available and ensure consistent middleware ordering for secure request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->