### PR TITLE
fix(dashboard-tsr): query detail button + collapse charts instead of hiding

### DIFF
--- a/apps/dashboard-tsr/src/components/expensive-queries/expensive-queries-view.tsx
+++ b/apps/dashboard-tsr/src/components/expensive-queries/expensive-queries-view.tsx
@@ -112,10 +112,21 @@ export const ExpensiveQueriesView = function ExpensiveQueriesView() {
           </Card>
         ) : (
           <>
-            {chartsOpen && expensiveQueriesConfig.relatedCharts && (
-              <RelatedCharts
-                relatedCharts={expensiveQueriesConfig.relatedCharts}
-              />
+            {expensiveQueriesConfig.relatedCharts && (
+              <div
+                className={cn(
+                  'grid transition-all duration-300 ease-in-out',
+                  chartsOpen
+                    ? 'grid-rows-[1fr] opacity-100'
+                    : 'grid-rows-[0fr] opacity-0'
+                )}
+              >
+                <div className="overflow-hidden">
+                  <RelatedCharts
+                    relatedCharts={expensiveQueriesConfig.relatedCharts}
+                  />
+                </div>
+              </div>
             )}
             {rows.length === 0 ? (
               <Card className="rounded-xl border-dashed">

--- a/apps/dashboard-tsr/src/components/part-log/part-log-view.tsx
+++ b/apps/dashboard-tsr/src/components/part-log/part-log-view.tsx
@@ -178,7 +178,18 @@ export function PartLogView() {
         </Card>
       ) : (
         <>
-          {chartsOpen && <PartLogCharts rows={rows} />}
+          <div
+            className={cn(
+              'grid transition-all duration-300 ease-in-out',
+              chartsOpen
+                ? 'grid-rows-[1fr] opacity-100'
+                : 'grid-rows-[0fr] opacity-0'
+            )}
+          >
+            <div className="overflow-hidden">
+              <PartLogCharts rows={rows} />
+            </div>
+          </div>
           <PartLogTable rows={rows} hostId={hostId} />
         </>
       )}

--- a/apps/dashboard-tsr/src/components/running-queries/completed-queries-table.tsx
+++ b/apps/dashboard-tsr/src/components/running-queries/completed-queries-table.tsx
@@ -1,4 +1,10 @@
-import { ArrowRight, CheckCircle2, Clock, User as UserIcon } from 'lucide-react'
+import {
+  ArrowRight,
+  CheckCircle2,
+  Clock,
+  ExternalLink,
+  User as UserIcon,
+} from 'lucide-react'
 
 import { memo, useMemo } from 'react'
 import { KindBadge } from '@/components/query-tables/kind-badge'
@@ -162,12 +168,21 @@ const CompletedRow = memo(function CompletedRow({
         </span>
         <div className="mt-1 flex flex-wrap items-center gap-x-2.5 gap-y-1 text-[10.5px] text-muted-foreground">
           {detailUrl ? (
-            <Link
-              href={detailUrl}
-              className="inline-flex items-center gap-1 font-mono transition-colors hover:text-foreground"
-            >
-              #{d.id.slice(0, 8)}
-            </Link>
+            <>
+              <Link
+                href={detailUrl}
+                className="inline-flex items-center gap-1 font-mono transition-colors hover:text-foreground"
+              >
+                #{d.id.slice(0, 8)}
+              </Link>
+              <Link
+                href={detailUrl}
+                className="inline-flex items-center gap-1 rounded px-1 py-0.5 font-medium text-primary transition-colors hover:bg-primary/10"
+              >
+                View
+                <ExternalLink className="size-3" />
+              </Link>
+            </>
           ) : (
             <span className="inline-flex items-center gap-1 font-mono">
               #n/a

--- a/apps/dashboard-tsr/src/components/running-queries/running-queries-view.tsx
+++ b/apps/dashboard-tsr/src/components/running-queries/running-queries-view.tsx
@@ -278,7 +278,18 @@ export const RunningQueriesView = function RunningQueriesView() {
           </Card>
         ) : (
           <>
-            {chartsOpen && <RunningQueriesCharts rows={rows} />}
+            <div
+              className={cn(
+                'grid transition-all duration-300 ease-in-out',
+                chartsOpen
+                  ? 'grid-rows-[1fr] opacity-100'
+                  : 'grid-rows-[0fr] opacity-0'
+              )}
+            >
+              <div className="overflow-hidden">
+                <RunningQueriesCharts rows={rows} />
+              </div>
+            </div>
             {rows.length === 0 ? (
               <Card className="rounded-xl border-dashed">
                 <CardContent className="p-6">

--- a/apps/dashboard-tsr/src/components/slow-queries/slow-queries-view.tsx
+++ b/apps/dashboard-tsr/src/components/slow-queries/slow-queries-view.tsx
@@ -231,8 +231,21 @@ export function SlowQueriesView() {
           </Card>
         ) : (
           <>
-            {chartsOpen && slowQueriesConfig.relatedCharts && (
-              <RelatedCharts relatedCharts={slowQueriesConfig.relatedCharts} />
+            {slowQueriesConfig.relatedCharts && (
+              <div
+                className={cn(
+                  'grid transition-all duration-300 ease-in-out',
+                  chartsOpen
+                    ? 'grid-rows-[1fr] opacity-100'
+                    : 'grid-rows-[0fr] opacity-0'
+                )}
+              >
+                <div className="overflow-hidden">
+                  <RelatedCharts
+                    relatedCharts={slowQueriesConfig.relatedCharts}
+                  />
+                </div>
+              </div>
             )}
             {rows.length === 0 ? (
               <Card className="rounded-xl border-dashed">


### PR DESCRIPTION
## Changes

### 1. Add visible query detail button to completed queries table

The 'Recently completed' table only had a subtle `#hash` link for query details. Added a visible 'View' button with ExternalLink icon next to the query ID for easier navigation to the query detail page.

### 2. Collapse charts to compact mode instead of unmounting

The 'Hide charts' toggle previously unmounted chart components entirely (`{chartsOpen && <Charts />}`). This destroyed component state and made the charts disappear completely.

Now charts are always mounted but collapsed via CSS grid animation (`grid-rows-[1fr]` → `grid-rows-[0fr]`) with opacity transition. Charts smoothly slide to zero height when collapsed and expand back instantly, preserving their data and state.

Applied to: running-queries, slow-queries, expensive-queries, part-log.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented smooth, animated transitions for collapsible chart panels across query views, enhancing visual feedback when expanding or collapsing sections.
  * Added a "View" link in the completed queries table for quicker access to detailed query information alongside existing query IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->