### PR TITLE
fix(dashboard-tsr): unmount collapsed query charts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,6 +405,8 @@ The project uses custom chart components with consistent patterns:
 
 **Chart Refactoring**: Donut charts have been replaced with progress bars for better readability in percentage-based displays (query cache usage, query type distribution).
 
+**Collapsible chart sections**: when a page hides an auto-refreshing chart strip, unmount the chart subtree instead of only collapsing it with CSS. Otherwise the hidden charts keep polling and rendering in the background. TanStack Query's 30-minute `gcTime` keeps reopen fast without paying that hidden-work cost.
+
 #### Request Info (SQL) Dialog
 - **Beautify SQL**: Disabled by default to prevent slow rendering of very large queries. Users can toggle it on manually.
 - **Design**: Uses native shadcn/ui components (`Badge`, `Separator`, `ScrollArea`) for a premium look and consistent UI.

--- a/apps/dashboard-tsr/src/components/expensive-queries/expensive-queries-view.tsx
+++ b/apps/dashboard-tsr/src/components/expensive-queries/expensive-queries-view.tsx
@@ -122,9 +122,11 @@ export const ExpensiveQueriesView = function ExpensiveQueriesView() {
                 )}
               >
                 <div className="overflow-hidden">
-                  <RelatedCharts
-                    relatedCharts={expensiveQueriesConfig.relatedCharts}
-                  />
+                  {chartsOpen && (
+                    <RelatedCharts
+                      relatedCharts={expensiveQueriesConfig.relatedCharts}
+                    />
+                  )}
                 </div>
               </div>
             )}

--- a/apps/dashboard-tsr/src/components/part-log/part-log-view.tsx
+++ b/apps/dashboard-tsr/src/components/part-log/part-log-view.tsx
@@ -187,7 +187,7 @@ export function PartLogView() {
             )}
           >
             <div className="overflow-hidden">
-              <PartLogCharts rows={rows} />
+              {chartsOpen && <PartLogCharts rows={rows} />}
             </div>
           </div>
           <PartLogTable rows={rows} hostId={hostId} />

--- a/apps/dashboard-tsr/src/components/running-queries/running-queries-view.tsx
+++ b/apps/dashboard-tsr/src/components/running-queries/running-queries-view.tsx
@@ -287,7 +287,7 @@ export const RunningQueriesView = function RunningQueriesView() {
               )}
             >
               <div className="overflow-hidden">
-                <RunningQueriesCharts rows={rows} />
+                {chartsOpen && <RunningQueriesCharts rows={rows} />}
               </div>
             </div>
             {rows.length === 0 ? (

--- a/apps/dashboard-tsr/src/components/slow-queries/slow-queries-view.tsx
+++ b/apps/dashboard-tsr/src/components/slow-queries/slow-queries-view.tsx
@@ -242,7 +242,9 @@ export function SlowQueriesView() {
               >
                 <div className="overflow-hidden">
                   {chartsOpen && (
-                    <RelatedCharts relatedCharts={slowQueriesConfig.relatedCharts} />
+                    <RelatedCharts
+                      relatedCharts={slowQueriesConfig.relatedCharts}
+                    />
                   )}
                 </div>
               </div>

--- a/apps/dashboard-tsr/src/components/slow-queries/slow-queries-view.tsx
+++ b/apps/dashboard-tsr/src/components/slow-queries/slow-queries-view.tsx
@@ -241,9 +241,9 @@ export function SlowQueriesView() {
                 )}
               >
                 <div className="overflow-hidden">
-                  <RelatedCharts
-                    relatedCharts={slowQueriesConfig.relatedCharts}
-                  />
+                  {chartsOpen && (
+                    <RelatedCharts relatedCharts={slowQueriesConfig.relatedCharts} />
+                  )}
                 </div>
               </div>
             )}

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -36,6 +36,7 @@ Durable code-smell/dead-code automation memory. Do not create dated files under 
 - `/docs` route reads source files from `docs/content` through `app/(docs)/docs/_lib/docs.ts`
 - Verify dead-code claims with zero non-test references before deleting symbols
 - Data-table synthetic utility column ids are `__expand`, `select`, and `action` (singular); exclude them from client-side filter/search/sort targets and card-control affordances
+- Collapsible TSR chart strips must unmount hidden chart subtrees, not just set `grid-rows-[0fr]` / `opacity-0`; otherwise auto-refreshing charts keep polling while invisible. The 30-minute TanStack Query `gcTime` already preserves fast reopen from cache.
 - Docker build must install full deps (`bun install --frozen-lockfile --ignore-scripts`) because `lib/platform/adapters/cloudflare.ts` imports `@opennextjs/cloudflare` during `bun run build`
 - If automation checkout is detached (`git status --short --branch` shows `HEAD (no branch)`), stale versus `origin/main`, or `.git/worktrees/...` writes fail (`FETCH_HEAD`/`HEAD.lock`/`index.lock`), run `git -C /Users/duet/project/clickhouse-monitor fetch origin`; if that checkout is dirty, create a clean worktree under `/private/tmp` for commit/PR commands
 


### PR DESCRIPTION
## Summary
- unmount hidden chart strips in the expensive, slow, running, and part-log TSR views so hidden charts stop polling in the background
- keep the collapse UI and rely on the existing 30-minute query cache for fast reopen
- document the pattern in CLAUDE.md and docs/knowledge/core-memory.md

## Verification
- bun test apps/dashboard-tsr/src/routes/api/v1/data apps/dashboard-tsr/src/routes/api/v1/browser-connections apps/dashboard-tsr/src/lib/auth apps/dashboard-tsr/src/lib/feature-permissions
- TMPDIR=/private/tmp/codex-bun-tmp bunx --bun biome check apps/dashboard-tsr/src/components/slow-queries/slow-queries-view.tsx

## Summary by Sourcery

Unmount hidden auto-refreshing chart sections in TSR views to avoid background polling and document the collapsible chart pattern.

Enhancements:
- Stop rendering collapsed chart strips in expensive, slow, running, and part-log TSR views by conditionally mounting their chart components.
- Document the expected unmounting behavior for collapsible auto-refreshing charts in CLAUDE.md and core memory guidelines.