### PR TITLE
fix(dashboard-tsr): make SSR stub constructable so prerender stops throwing

### DIFF
--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -278,13 +278,17 @@ function ssrClientOnlyStub(): PluginOption {
   // mermaid/katex/cytoscape) plus explicit named aliases for the codemirror
   // symbols. The modules only execute meaningfully inside browser effects /
   // lazy chunks the worker never reaches, BUT some are evaluated at module
-  // top-level during prerender (e.g. `defineRegistry(...).registry` in
-  // json-render-registry.ts). So `apply()`/`get` both return the chainable
-  // `stub` — calling or property-accessing a stub stays safe and never throws.
+  // top-level / during render at prerender time (e.g. `defineRegistry(...).registry`
+  // in json-render-registry.ts, or `new dagre.graphlib.Graph().setDefaultEdgeLabel()`
+  // in dagre-layout.ts). So `get`/`apply`/`construct` all return the chainable
+  // `stub` — property access, calls, AND `new X().chain()` stay safe and never throw.
+  // The Proxy target MUST be a regular `function` (not an arrow): a Proxy only
+  // exposes [[Construct]] when its target is constructable, so an arrow target
+  // would make `new stub()` throw "is not a constructor" before the trap fires.
   const namedExports = SSR_STUB_NAMED_EXPORTS.map(
     (n) => `export const ${n} = stub`
   ).join('\n')
-  const code = `const noop = () => undefined
+  const code = `function noop() {}
 const stub = new Proxy(noop, {
   get(_t, p) {
     if (p === '__esModule') return true
@@ -293,7 +297,7 @@ const stub = new Proxy(noop, {
     return stub
   },
   apply() { return stub },
-  construct() { return {} },
+  construct() { return stub },
 })
 export default stub
 ${namedExports}


### PR DESCRIPTION
## Summary
The dashboard-tsr SSR client-only stub (`vite.config.ts`) replaces browser-only libs (mermaid, cytoscape, dagre, codemirror, recharts, …) with a no-op `Proxy` in the Cloudflare/workerd prerender. The Proxy target was an **arrow function** (`const noop = () => undefined`) and `construct()` returned `{}`.

Two problems:
1. A `Proxy` only exposes `[[Construct]]` when its **target is constructable**. An arrow function has no `[[Construct]]`, so `new stub.graphlib.Graph()` (dagre is stubbed on the CF target) threw **`is not a constructor`** *before* the `construct` trap could fire.
2. Even if constructable, `construct() { return {} }` returned a plain object, so the chained `.setDefaultEdgeLabel(...)` in `lib/graph/dagre-layout.ts` would then throw `is not a function`.

## Fix
- `const noop = () => undefined` → `function noop() {}` (constructable target).
- `construct() { return {} }` → `construct() { return stub }` (chainable, mirroring `apply()`).

Now `new X().chain()` stays safe like every other stub access (`get`/`apply`/`construct` all return the chainable `stub`).

## Win Metrics (CF prerender build, `apps/dashboard-tsr`)

| Metric | Baseline (main) | After | Δ |
|--------|----------------|-------|---|
| `is not a constructor` prerender errors | **84** | **0** | −100% |
| Routes prerendered | 118 | 118 | — |
| `/explorer` static HTML | 78,269 b | 78,247 b | ~0 |

The errors were non-fatal (the route still emitted HTML via the prerender error boundary), but they polluted every build log and meant the dependency-graph subtree was rendered through an error path. The stub is now correct for the `new X()` pattern in general (also covers codemirror's `new EditorState()/EditorView()/Compartment()` should they ever evaluate during prerender).

## Verification
- `vite build` (CF target) green, prerender log shows 0 constructor errors (was 84 on main).
- Biome + `tsc --noEmit` pass (pre-commit).
- No structural test references the stub shape; the full prerender build (CI `dashboard-tsr` job) is the integration test.

Part of #1392.

Co-Authored-By: duyetbot <bot@duyet.net>