### PR TITLE
test(dashboard-tsr): cover host-id validators (37% → 100%)

### DIFF
--- a/apps/dashboard-tsr/src/lib/api/shared/validators/__tests__/host-id.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/shared/validators/__tests__/host-id.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for lib/api/shared/validators/host-id
+ *
+ * Covers every exported function with valid inputs, invalid branches, and
+ * boundary values. Each test encodes WHY the rule matters (hostId indexes the
+ * configured ClickHouse hosts, so it must be a non-negative integer) and is
+ * written to fail if the validation logic changes.
+ */
+import { describe, expect, test } from 'bun:test'
+import {
+  getAndValidateHostId,
+  validateHostId,
+  validateHostIdWithError,
+} from '@/lib/api/shared/validators/host-id'
+import { ApiErrorType } from '@/lib/api/types'
+
+// ---------------------------------------------------------------------------
+// validateHostId — throwing variant
+// ---------------------------------------------------------------------------
+
+describe('validateHostId', () => {
+  test('parses a valid numeric string to a number', () => {
+    expect(validateHostId('0')).toBe(0)
+    expect(validateHostId('1')).toBe(1)
+    expect(validateHostId('42')).toBe(42)
+  })
+
+  test('accepts host index 0 (first configured host, not falsy-rejected)', () => {
+    // Guards against a `!parsed` regression — 0 is a valid host index.
+    expect(validateHostId('0')).toBe(0)
+  })
+
+  test('parses leading-numeric strings the way parseInt does', () => {
+    // parseInt('1abc', 10) === 1; the function does not reject trailing junk.
+    expect(validateHostId('1abc')).toBe(1)
+  })
+
+  test('throws when hostId is null', () => {
+    expect(() => validateHostId(null)).toThrow(
+      'Missing required parameter: hostId'
+    )
+  })
+
+  test('throws when hostId is an empty string', () => {
+    expect(() => validateHostId('')).toThrow(
+      'Missing required parameter: hostId'
+    )
+  })
+
+  test('throws when hostId is non-numeric', () => {
+    expect(() => validateHostId('abc')).toThrow(
+      'Invalid hostId: must be a non-negative number'
+    )
+  })
+
+  test('throws when hostId is negative', () => {
+    expect(() => validateHostId('-1')).toThrow(
+      'Invalid hostId: must be a non-negative number'
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateHostIdWithError — non-throwing, accepts unknown
+// ---------------------------------------------------------------------------
+
+describe('validateHostIdWithError', () => {
+  test('returns undefined for a valid number', () => {
+    expect(validateHostIdWithError(0)).toBeUndefined()
+    expect(validateHostIdWithError(3)).toBeUndefined()
+  })
+
+  test('returns undefined for a valid numeric string', () => {
+    expect(validateHostIdWithError('0')).toBeUndefined()
+    expect(validateHostIdWithError('7')).toBeUndefined()
+  })
+
+  test('returns a ValidationError for undefined', () => {
+    const err = validateHostIdWithError(undefined)
+    expect(err).toEqual({
+      type: ApiErrorType.ValidationError,
+      message: 'Missing required field: hostId',
+    })
+  })
+
+  test('returns a ValidationError for null', () => {
+    expect(validateHostIdWithError(null)).toEqual({
+      type: ApiErrorType.ValidationError,
+      message: 'Missing required field: hostId',
+    })
+  })
+
+  test('returns a ValidationError for an empty string', () => {
+    expect(validateHostIdWithError('')).toEqual({
+      type: ApiErrorType.ValidationError,
+      message: 'Missing required field: hostId',
+    })
+  })
+
+  test('returns a ValidationError for a negative number', () => {
+    expect(validateHostIdWithError(-1)).toEqual({
+      type: ApiErrorType.ValidationError,
+      message: 'Invalid hostId: must be a non-negative number',
+    })
+  })
+
+  test('returns a ValidationError for a non-numeric string', () => {
+    expect(validateHostIdWithError('abc')).toEqual({
+      type: ApiErrorType.ValidationError,
+      message: 'Invalid hostId: must be a non-negative number',
+    })
+  })
+
+  test('returns a ValidationError for a non-string, non-number type (boolean)', () => {
+    // The `typeof` ladder falls through to NaN for unsupported types.
+    expect(validateHostIdWithError(true)).toEqual({
+      type: ApiErrorType.ValidationError,
+      message: 'Invalid hostId: must be a non-negative number',
+    })
+  })
+
+  test('returns a ValidationError for an object', () => {
+    expect(validateHostIdWithError({ hostId: 1 })).toEqual({
+      type: ApiErrorType.ValidationError,
+      message: 'Invalid hostId: must be a non-negative number',
+    })
+  })
+
+  test('does NOT reject host index 0 as missing (0 is falsy but valid)', () => {
+    // Distinguishes the "missing" branch (undefined/null/'') from numeric 0.
+    expect(validateHostIdWithError(0)).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getAndValidateHostId — reads from URLSearchParams
+// ---------------------------------------------------------------------------
+
+describe('getAndValidateHostId', () => {
+  test('returns the parsed number for a valid hostId param', () => {
+    const params = new URLSearchParams('hostId=2')
+    expect(getAndValidateHostId(params)).toBe(2)
+  })
+
+  test('returns 0 for hostId=0 (first host, not treated as missing)', () => {
+    const params = new URLSearchParams('hostId=0')
+    expect(getAndValidateHostId(params)).toBe(0)
+  })
+
+  test('returns a ValidationError when hostId param is absent', () => {
+    const params = new URLSearchParams('other=1')
+    expect(getAndValidateHostId(params)).toEqual({
+      type: ApiErrorType.ValidationError,
+      message: 'Missing required parameter: hostId',
+    })
+  })
+
+  test('returns a ValidationError when hostId is empty', () => {
+    const params = new URLSearchParams('hostId=')
+    expect(getAndValidateHostId(params)).toEqual({
+      type: ApiErrorType.ValidationError,
+      message: 'Missing required parameter: hostId',
+    })
+  })
+
+  test('returns a ValidationError when hostId is non-numeric', () => {
+    const params = new URLSearchParams('hostId=abc')
+    expect(getAndValidateHostId(params)).toEqual({
+      type: ApiErrorType.ValidationError,
+      message: 'Invalid hostId: must be a non-negative number',
+    })
+  })
+
+  test('returns a ValidationError when hostId is negative', () => {
+    const params = new URLSearchParams('hostId=-5')
+    expect(getAndValidateHostId(params)).toEqual({
+      type: ApiErrorType.ValidationError,
+      message: 'Invalid hostId: must be a non-negative number',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Add a dedicated `bun:test` suite for `lib/api/shared/validators/host-id`, which had **no co-located test** and sat at **37% line coverage**.

Covers all three exported functions across valid / invalid / boundary branches:
- **`validateHostId`** (throwing) — valid parse, the falsy-but-valid host index `0`, `parseInt` leading-numeric behaviour, null/empty "missing" branch, negative + non-numeric rejection.
- **`validateHostIdWithError`** (accepts `unknown`) — number & string happy paths, undefined/null/empty "missing" branch, negative, non-numeric, and non-string/non-number types (boolean, object) falling through to `NaN`.
- **`getAndValidateHostId`** (`URLSearchParams`) — present/absent/empty param, `hostId=0`, negative, non-numeric.

## Why it matters
`hostId` indexes the configured ClickHouse hosts, so these are **input-validation / security-relevant** rules. Several tests explicitly guard the `0` edge case (a `!parsed`-style regression would reject the first host) — encoding *why* the behaviour matters, not just *what* it does.

## Result
`host-id.ts`: **37% → 100%** line & func coverage. 23 tests, all green. No mocks (pure logic), so no `bun mock.module` contamination risk.

Part of #1392 (raises the TSR coverage axis on the Next-vs-TanStack scorecard).

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Tests:
- Add comprehensive tests for validateHostId, validateHostIdWithError, and getAndValidateHostId to cover valid, invalid, and edge-case inputs for host ID parsing and validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for host ID validation functionality, including valid inputs, edge cases, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->