### PR TITLE
fix(dashboard-tsr): deterministic cache-bust in clerk-client test

### DIFF
--- a/apps/dashboard-tsr/src/lib/auth/__tests__/clerk-client.test.ts
+++ b/apps/dashboard-tsr/src/lib/auth/__tests__/clerk-client.test.ts
@@ -8,11 +8,17 @@ import { afterEach, describe, expect, test } from 'bun:test'
  */
 const MODULE = '@/lib/clerk/clerk-client'
 
+// Monotonic counter for cache-busting. A timestamp (`Date.now()` +
+// `performance.now()`) collides when two cases run within the same millisecond
+// — the second import then resolves to the FIRST case's cached module (which
+// captured the other env), producing an intermittent failure under full-suite
+// load. A strictly-incrementing counter guarantees a unique specifier per call.
+let importCounter = 0
+
 async function freshIsClerkEnabled(): Promise<boolean> {
+  importCounter += 1
   // Cache-bust so the module re-evaluates with the current env.
-  const mod = await import(
-    `${MODULE}?t=${Date.now()}-${Math.round(performance.now())}`
-  )
+  const mod = await import(`${MODULE}?t=${importCounter}`)
   return mod.isClerkEnabled()
 }
 


### PR DESCRIPTION
## Problem
The `isClerkEnabled` suite (`clerk-client.test.ts`) was the **only source of non-determinism** in the dash-tsr unit suite — an intermittent failure of `returns false without a pk_ key` that showed up under full-suite load but never in isolation.

## Root cause
It cache-busts its dynamic `import()` with `?t=${Date.now()}-${Math.round(performance.now())}`. When two cases run within the **same millisecond** (likelier under full-suite CPU load), both build the *identical* import specifier, so the second `import()` resolves to the **first case's cached module** — which captured `pk_test_123` at module-eval. The "without a pk_ key" case then reads the stale `true` and fails. It passed in isolation because the two imports rarely landed in the same ms.

`--isolate` does **not** fix this: it resets the module registry per file but not within a file, and `process.env` is process-global regardless.

## Fix
Replace the timestamp with a strictly-incrementing counter — every call gets a guaranteed-unique specifier, so each case re-evaluates the module with its own env.

## Verification
Full `bun test src/` (**no** `--isolate`) now passes **5/5 consecutive runs** (1283 pass / 0 fail); previously intermittently 1 fail.

Part of #1392. Removing this non-determinism is a prerequisite for promoting the `unit-tests` job to a **required check** before cutover (#1405).

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Tests:
- Replace timestamp-based dynamic import identifiers with a monotonic counter in clerk-client tests to guarantee unique module specifiers per test run and remove flakiness.