### PR TITLE
perf(dashboard-tsr): cache host list to localStorage for instant cross-deploy host selector

### DIFF
--- a/apps/dashboard-tsr/src/lib/swr/host-cache.ts
+++ b/apps/dashboard-tsr/src/lib/swr/host-cache.ts
@@ -1,0 +1,54 @@
+import type { HostInfo } from '@chm/types/host-info'
+
+/**
+ * Dedicated localStorage cache for the configured host list.
+ *
+ * Why separate from the persisted TanStack Query cache (lib/query/provider.tsx)?
+ * That cache is wiped on every deploy by a git-SHA buster, because query shapes
+ * can change between builds. The host list, by contrast, has a stable shape
+ * ({@link HostInfo}: id/name/host/user) and is the very first thing every page
+ * needs to render its host selector. Caching it independently lets the selector
+ * paint instantly even on the first load after a deploy — then `useHosts`
+ * revalidates it in the background (stale-while-revalidate).
+ */
+const HOST_CACHE_KEY = 'chm-tsr-hosts'
+
+/** TanStack Query key for the configured host list. Shared so the cache seed
+ * (use-hosts.ts) and any future consumer key off the same string. */
+export const HOSTS_QUERY_KEY = ['/api/v1/hosts'] as const
+
+/** Read the cached host list, or `undefined` if absent/unparseable/non-browser. */
+export function readCachedHosts(): HostInfo[] | undefined {
+  if (typeof window === 'undefined') return undefined
+  try {
+    const raw = window.localStorage.getItem(HOST_CACHE_KEY)
+    if (!raw) return undefined
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return undefined
+    // Light structural guard — a stale/corrupt entry shouldn't crash render.
+    if (
+      parsed.every(
+        (h): h is HostInfo =>
+          typeof h === 'object' &&
+          h !== null &&
+          typeof (h as HostInfo).id === 'number' &&
+          typeof (h as HostInfo).name === 'string'
+      )
+    ) {
+      return parsed
+    }
+    return undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** Persist the latest host list so the next cold load can seed it instantly. */
+export function writeCachedHosts(hosts: HostInfo[]): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(HOST_CACHE_KEY, JSON.stringify(hosts))
+  } catch {
+    // Quota / private-mode failures are non-fatal — caching is best-effort.
+  }
+}

--- a/apps/dashboard-tsr/src/lib/swr/use-hosts.ts
+++ b/apps/dashboard-tsr/src/lib/swr/use-hosts.ts
@@ -1,10 +1,15 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import type { HostInfo } from '@chm/types/host-info'
 
 import { apiFetch } from './api-fetch'
+import {
+  HOSTS_QUERY_KEY,
+  readCachedHosts,
+  writeCachedHosts,
+} from './host-cache'
 import { ErrorLogger } from '@chm/logger'
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 
 interface HostsResponse {
   success: boolean
@@ -50,8 +55,10 @@ export function useHosts() {
     return result.success && result.data ? result.data : []
   }, [])
 
+  const queryClient = useQueryClient()
+
   const { data, error, isLoading } = useQuery<HostInfo[]>({
-    queryKey: ['/api/v1/hosts'],
+    queryKey: HOSTS_QUERY_KEY,
     queryFn: fetcher,
     // Hosts list changes rarely, so cache for 5 minutes
     staleTime: 300000,
@@ -65,6 +72,34 @@ export function useHosts() {
       return failureCount < 2
     },
   })
+
+  // Hydration-safe instant host list.
+  //
+  // We seed the cache AFTER mount (not via `initialData`, which renders at SSR
+  // time and would mismatch the prerendered skeleton — there is no localStorage
+  // on the server). On the first client paint the query has no data, matching
+  // the server HTML; this effect then fills it from the dedicated host cache so
+  // the selector shows the previous list immediately, even on the first load
+  // after a deploy when the git-SHA-busted query cache is empty. The background
+  // fetch still runs and overwrites it (stale-while-revalidate). When the
+  // persisted query cache already restored hosts, `getQueryData` is truthy and
+  // this is a no-op.
+  useEffect(() => {
+    if (queryClient.getQueryData<HostInfo[]>(HOSTS_QUERY_KEY)) return
+    const cached = readCachedHosts()
+    if (cached && cached.length > 0) {
+      queryClient.setQueryData(HOSTS_QUERY_KEY, cached)
+    }
+  }, [queryClient])
+
+  // Mirror every non-empty host list back into the dedicated cache so the next
+  // cold load can seed it. Writing a restored/seeded value back is harmless and
+  // keeps the entry fresh.
+  useEffect(() => {
+    if (data && data.length > 0 && !error) {
+      writeCachedHosts(data)
+    }
+  }, [data, error])
 
   const status = error instanceof HostsFetchError ? error.status : undefined
 


### PR DESCRIPTION
Builds on #1505 (persisted TanStack Query cache), which already landed on main.

## Gap this closes

#1505 persists the whole query cache to `localStorage` but invalidates it on every deploy via a git-SHA `buster` (query shapes can change across builds). That means the **host list** — the first thing every page needs to render its host selector — cold-loads from the network on the first visit after each deploy, flashing a skeleton.

## Fix

Cache the host list **independently** of the busted query cache:

- `lib/swr/host-cache.ts` — tiny localStorage read/write for the host list (`HostInfo[]`, stable shape) + the shared `HOSTS_QUERY_KEY`.
- `use-hosts.ts` — after mount, if the query has no data yet (busted cache), seed it from the host cache via `setQueryData`; mirror every non-empty result back. The background fetch still runs and overwrites it (stale-while-revalidate).

The host list has a stable shape, so it safely survives the git-SHA buster. The selector now paints the previous host list instantly even on the first load after a deploy, then revalidates.

## Why effect-based seed (not `initialData`)

`initialData`/`placeholderData` apply at **render time**; on the server there's no `localStorage`, so the prerendered skeleton would not match the first client render → React 19 hydration mismatch. Seeding in `useEffect` (after first paint) mirrors how `PersistQueryClientProvider` restores, keeping hydration clean.

## Verify

- `tsc --noEmit` ✅ (exit 0), `biome check` ✅
- Cold-load prerender already ships page chrome + per-component skeletons (0 full-page fallbacks) — confirmed for dashboard/overview.
- CI `dashboard-tsr` job deploys preview + runs `verify-deploy.ts`; production redeploys on merge to main (`dash-tsr.chmonitor.dev`).

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Host list data in the TSR dashboard is now cached locally, providing faster access and persistence across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->