### PR TITLE
ci(dashboard-tsr): wire chart-level smoke test into post-deploy CI

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -387,6 +387,24 @@ jobs:
           sleep 5
           bun scripts/verify-deploy.ts --base-url "$BASE" --hosts 0
 
+      - name: Chart smoke test
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        env:
+          CHM_API_KEY_SECRET: ${{ secrets.CHM_API_KEY_SECRET }}
+        run: |
+          echo "Running chart-level smoke test against $BASE ..."
+          bun ../../scripts/smoke-test.ts --base-url "$BASE" --json 2>&1 | tee smoke-result.json
+          # Parse pass/fail counts for the step summary
+          PASSED=$(jq -r '.passed // 0' smoke-result.json 2>/dev/null || echo '?')
+          FAILED=$(jq -r '.failed // 0' smoke-result.json 2>/dev/null || echo '?')
+          echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Charts passed | $PASSED |" >> $GITHUB_STEP_SUMMARY
+          echo "| Charts failed | $FAILED |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "_Informational gate — not blocking deploy. Promote to blocking once baseline is established._" >> $GITHUB_STEP_SUMMARY
+
       # The TSR preview URL is now included in the unified "☁️ Cloudflare Preview
       # Deployment" comment posted by the main dashboard job — no separate
       # comment here (avoids two preview comments per PR).

--- a/apps/dashboard-tsr/package.json
+++ b/apps/dashboard-tsr/package.json
@@ -23,6 +23,7 @@
     "test:e2e:headless": "cypress run --e2e",
     "test:component": "cypress open --component",
     "test:component:headless": "cypress run --component",
+    "smoke-test": "bun ../../scripts/smoke-test.ts --base-url https://dash-tsr.chmonitor.dev",
     "verify-deploy": "bun scripts/verify-deploy.ts"
   },
   "dependencies": {

--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -18,6 +18,15 @@ const BASE_URL =
   'https://clickhouse.duyet.net'
 const JSON_OUTPUT = args.includes('--json')
 const _VERBOSE = args.includes('--verbose')
+const API_KEY_SECRET =
+  args.find((a) => a.startsWith('--api-key-secret='))?.split('=')[1] ||
+  (args.indexOf('--api-key-secret') !== -1
+    ? args[args.indexOf('--api-key-secret') + 1]
+    : undefined) ||
+  process.env.CHM_API_KEY_SECRET
+
+/** Bearer token for authenticated requests (minted via /api/v1/auth/api-key). */
+let authToken = ''
 
 // ── Types ──────────────────────────────────────────────
 
@@ -62,9 +71,22 @@ interface CategoryGroup {
 
 // ── Helpers ────────────────────────────────────────────
 
-async function fetchJSON(url: string): Promise<any> {
-  const res = await fetch(url, { signal: AbortSignal.timeout(30_000) })
-  return res.json()
+async function fetchJSON(
+  url: string,
+  init?: RequestInit
+): Promise<{ status: number; json: any }> {
+  const headers: Record<string, string> = {
+    ...(init?.headers as Record<string, string>),
+  }
+  if (authToken) {
+    headers['Authorization'] = `Bearer ${authToken}`
+  }
+  const res = await fetch(url, {
+    ...init,
+    headers,
+    signal: AbortSignal.timeout(30_000),
+  })
+  return { status: res.status, json: await res.json() }
 }
 
 function categorizeError(error: string): ErrorCategory {
@@ -107,7 +129,7 @@ async function discoverHosts(): Promise<HostInfo[]> {
   const hosts: HostInfo[] = []
   // Try /api/v1/hosts first
   try {
-    const d = await fetchJSON(`${BASE_URL}/api/v1/hosts`)
+    const { json: d } = await fetchJSON(`${BASE_URL}/api/v1/hosts`)
     if (d.success && Array.isArray(d.data)) {
       for (const h of d.data) {
         hosts.push({
@@ -132,7 +154,7 @@ async function discoverHosts(): Promise<HostInfo[]> {
   if (hosts.length === 0) {
     for (let i = 0; i < 10; i++) {
       try {
-        const r = await fetchJSON(
+        const { json: r } = await fetchJSON(
           `${BASE_URL}/api/v1/data?hostId=${i}&sql=SELECT+1`
         )
         if (!r.success) break
@@ -157,7 +179,7 @@ async function discoverHosts(): Promise<HostInfo[]> {
 
 async function getHostVersion(hostId: number): Promise<string | undefined> {
   try {
-    const d = await fetchJSON(
+    const { json: d } = await fetchJSON(
       `${BASE_URL}/api/v1/data?hostId=${hostId}&sql=SELECT+version()`
     )
     if (d.success && Array.isArray(d.data) && d.data[0]) {
@@ -170,10 +192,46 @@ async function getHostVersion(hostId: number): Promise<string | undefined> {
 }
 
 async function getChartList(): Promise<string[]> {
-  const d = await fetchJSON(`${BASE_URL}/api/v1/charts/nonexistent?hostId=0`)
+  const { json: d } = await fetchJSON(
+    `${BASE_URL}/api/v1/charts/nonexistent?hostId=0`
+  )
   const list = d?.error?.details?.availableCharts as string
   if (!list) throw new Error('Could not fetch chart list from API')
   return list.split(', ').map((s: string) => s.trim())
+}
+
+// ── Auth ───────────────────────────────────────────────
+
+async function mintAuthToken(): Promise<void> {
+  if (!API_KEY_SECRET) return
+  try {
+    const { status, json } = await fetchJSON(
+      `${BASE_URL}/api/v1/auth/api-key`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${API_KEY_SECRET}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ label: 'smoke-test', days: 1 }),
+      }
+    )
+    const token = (json as { data?: { apiKey?: string } })?.data?.apiKey ?? ''
+    if (status === 200 && token.startsWith('chm_')) {
+      authToken = token
+      if (!JSON_OUTPUT) {
+        console.log(`  🔑 Authenticated: minted ${token.slice(0, 10)}…\n`)
+      }
+    } else if (!JSON_OUTPUT) {
+      console.log(
+        `  ⚠️  Token mint failed (HTTP ${status}) — proceeding unauthenticated\n`
+      )
+    }
+  } catch {
+    if (!JSON_OUTPUT) {
+      console.log('  ⚠️  Token mint failed — proceeding unauthenticated\n')
+    }
+  }
 }
 
 // ── Test runner ────────────────────────────────────────
@@ -181,7 +239,7 @@ async function getChartList(): Promise<string[]> {
 async function testChart(chart: string, hostId: number): Promise<TestResult> {
   const start = Date.now()
   try {
-    const d = await fetchJSON(
+    const { json: d } = await fetchJSON(
       `${BASE_URL}/api/v1/charts/${chart}?hostId=${hostId}`
     )
     const success = d.success === true
@@ -419,6 +477,9 @@ function wrapList(items: string, maxLen: number): string {
 // ── Main ───────────────────────────────────────────────
 
 async function main() {
+  // Mint auth token if API key secret is provided
+  await mintAuthToken()
+
   // Discover hosts
   const hosts = await discoverHosts()
   if (hosts.length === 0) {


### PR DESCRIPTION
## Changes

Wires the existing chart-level smoke test (`scripts/smoke-test.ts`) into the `dashboard-tsr` CI job as a post-deploy gate, and adds authentication support so it can run against auth-protected deployments.

### `scripts/smoke-test.ts` — auth support

- Adds `--api-key-secret` flag and `CHM_API_KEY_SECRET` env var support
- When provided, mints a `chm_` Bearer token via `POST /api/v1/auth/api-key` before running tests
- `fetchJSON()` now returns `{ status, json }` for consistent error handling
- Token is attached to all subsequent API requests

### `.github/workflows/cloudflare.yml` — new CI step

- Adds "Chart smoke test" step after "Verify deployment" in the `dashboard-tsr` job
- Runs the full chart suite against production deploy only (not PRs)
- **Informational gate** (`continue-on-error: true`) — writes pass/fail counts to `$GITHUB_STEP_SUMMARY`
- Can be promoted to a blocking gate once baseline pass rates are established

### `apps/dashboard-tsr/package.json` — local smoke script

- Adds `smoke-test` script: `bun ../../scripts/smoke-test.ts --base-url https://dash-tsr.chmonitor.dev`
- Run locally with: `CHM_API_KEY_SECRET=... bun run smoke-test`

## Test plan
- [x] `bun scripts/smoke-test.ts` — parses and runs (exits "No hosts found" without auth, expected)
- [ ] Push to main, check CI runs the new "Chart smoke test" step
- [ ] Verify step summary shows pass/fail counts

Refs #1392