### PR TITLE
perf(dashboard-tsr): fix loading CLS drift + cut hidden-tab polling and re-renders

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -228,7 +228,24 @@ jobs:
         working-directory: apps/dashboard-tsr
         run: bun install
 
+      # Cache the built Node target keyed on the exact build inputs (lockfile +
+      # app source/config + shared package source — the @chm/* packages are
+      # bundled from source via ssr.noExternal). On an exact hit we SKIP the
+      # ~15-min Vite build entirely (a production `vite build` rebuilds from
+      # scratch, so a stale `.output` is only useful if the build is skipped).
+      # No restore-keys: a partial/stale build must never be served to e2e.
+      # This shrinks the window in which a concurrency cancel-in-progress (a
+      # newer push to main) kills the run before the specs execute — the reason
+      # this gate has historically never completed on main.
+      - name: TSR Node build cache
+        id: tsr-build-cache
+        uses: actions/cache@v5
+        with:
+          path: apps/dashboard-tsr/.output
+          key: ${{ runner.os }}-tsr-output-v1-${{ hashFiles('apps/dashboard-tsr/bun.lock', 'apps/dashboard-tsr/src/**', 'apps/dashboard-tsr/vite.config.ts', 'apps/dashboard-tsr/package.json', 'apps/dashboard-tsr/public/**', 'packages/*/src/**', 'packages/*/package.json') }}
+
       - name: Build Node target
+        if: steps.tsr-build-cache.outputs.cache-hit != 'true'
         working-directory: apps/dashboard-tsr
         # CHM_SKIP_PRERENDER=1: skip the 119-route prerender for the e2e build.
         # It runs the un-stubbed real render libs (dagre/recharts/mermaid) across

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -228,24 +228,7 @@ jobs:
         working-directory: apps/dashboard-tsr
         run: bun install
 
-      # Cache the built Node target keyed on the exact build inputs (lockfile +
-      # app source/config + shared package source — the @chm/* packages are
-      # bundled from source via ssr.noExternal). On an exact hit we SKIP the
-      # ~15-min Vite build entirely (a production `vite build` rebuilds from
-      # scratch, so a stale `.output` is only useful if the build is skipped).
-      # No restore-keys: a partial/stale build must never be served to e2e.
-      # This shrinks the window in which a concurrency cancel-in-progress (a
-      # newer push to main) kills the run before the specs execute — the reason
-      # this gate has historically never completed on main.
-      - name: TSR Node build cache
-        id: tsr-build-cache
-        uses: actions/cache@v5
-        with:
-          path: apps/dashboard-tsr/.output
-          key: ${{ runner.os }}-tsr-output-v1-${{ hashFiles('apps/dashboard-tsr/bun.lock', 'apps/dashboard-tsr/src/**', 'apps/dashboard-tsr/vite.config.ts', 'apps/dashboard-tsr/package.json', 'apps/dashboard-tsr/public/**', 'packages/*/src/**', 'packages/*/package.json') }}
-
       - name: Build Node target
-        if: steps.tsr-build-cache.outputs.cache-hit != 'true'
         working-directory: apps/dashboard-tsr
         # CHM_SKIP_PRERENDER=1: skip the 119-route prerender for the e2e build.
         # It runs the un-stubbed real render libs (dagre/recharts/mermaid) across

--- a/apps/dashboard-tsr/src/components/charts/chart-container.tsx
+++ b/apps/dashboard-tsr/src/components/charts/chart-container.tsx
@@ -9,7 +9,13 @@ import { ChartEmpty } from './chart-empty'
 import { ChartError } from './chart-error'
 import { getChartSkeletonType } from './chart-registry'
 import { ChartZoomButton, ChartZoomDialog } from './chart-zoom-dialog'
-import { cloneElement, isValidElement, useState } from 'react'
+import {
+  cloneElement,
+  isValidElement,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react'
 import { ChartSkeleton } from '@/components/skeletons'
 import { FadeIn } from '@/components/ui/fade-in'
 import { cn } from '@/lib/utils'
@@ -102,14 +108,15 @@ export function ChartContainer<TData extends ChartDataPoint = ChartDataPoint>({
   })()
 
   // Stable retry handler to prevent re-renders in ChartError
-  const handleRetry = () => {
+  const handleRetry = useCallback(() => {
     mutate()
-  }
+  }, [mutate])
 
   // Pass all metadata fields dynamically
-  const toolbarMetadata: CardToolbarMetadata | undefined = metadata
-    ? { ...metadata }
-    : undefined
+  const toolbarMetadata: CardToolbarMetadata | undefined = useMemo(
+    () => (metadata ? { ...metadata } : undefined),
+    [metadata]
+  )
 
   // Render chart content (called once, before early returns to satisfy hook rules)
   const chartContent =

--- a/apps/dashboard-tsr/src/components/charts/factory/create-area-chart.tsx
+++ b/apps/dashboard-tsr/src/components/charts/factory/create-area-chart.tsx
@@ -11,6 +11,7 @@ import { AreaChart } from '@/components/charts/primitives/area'
 import { resolveDateRangeConfig } from '@/components/date-range'
 import { useTimezone } from '@/lib/context/timezone-context'
 import { useChartData, useHostId } from '@/lib/swr'
+import { REFRESH_INTERVAL } from '@/lib/swr/config'
 import { cn, createDateTickFormatter } from '@/lib/utils'
 
 /**
@@ -85,7 +86,7 @@ export function createAreaChart(
       hostId,
       interval: effectiveInterval,
       lastHours: effectiveLastHours,
-      refreshInterval: config.refreshInterval ?? 30000,
+      refreshInterval: config.refreshInterval ?? REFRESH_INTERVAL.DEFAULT_60S,
     })
 
     // Create smart date formatter based on time range

--- a/apps/dashboard-tsr/src/components/charts/factory/create-bar-chart.tsx
+++ b/apps/dashboard-tsr/src/components/charts/factory/create-bar-chart.tsx
@@ -11,6 +11,7 @@ import { BarChart } from '@/components/charts/primitives/bar/bar'
 import { resolveDateRangeConfig } from '@/components/date-range'
 import { useTimezone } from '@/lib/context/timezone-context'
 import { useChartData, useHostId } from '@/lib/swr'
+import { REFRESH_INTERVAL } from '@/lib/swr/config'
 import { cn, createDateTickFormatter } from '@/lib/utils'
 
 /**
@@ -83,7 +84,7 @@ export function createBarChart(config: BarChartFactoryConfig): FC<ChartProps> {
       hostId,
       interval: effectiveInterval,
       lastHours: effectiveLastHours,
-      refreshInterval: config.refreshInterval ?? 30000,
+      refreshInterval: config.refreshInterval ?? REFRESH_INTERVAL.DEFAULT_60S,
     })
 
     // Get categories (resolve if function)

--- a/apps/dashboard-tsr/src/components/charts/factory/create-custom-chart.tsx
+++ b/apps/dashboard-tsr/src/components/charts/factory/create-custom-chart.tsx
@@ -5,6 +5,7 @@ import { type FC, memo } from 'react'
 import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { useChartData, useHostId } from '@/lib/swr'
+import { REFRESH_INTERVAL } from '@/lib/swr/config'
 import { cn } from '@/lib/utils'
 
 /**
@@ -42,7 +43,7 @@ export function createCustomChart(
       hostId,
       interval,
       lastHours,
-      refreshInterval: config.refreshInterval ?? 30000,
+      refreshInterval: config.refreshInterval ?? REFRESH_INTERVAL.DEFAULT_60S,
     })
 
     return (

--- a/apps/dashboard-tsr/src/components/data-table/buttons/column-header-dropdown.tsx
+++ b/apps/dashboard-tsr/src/components/data-table/buttons/column-header-dropdown.tsx
@@ -71,7 +71,7 @@ export const ColumnHeaderDropdown = function ColumnHeaderDropdown({
             'opacity-0 group-hover:opacity-40 hover:opacity-100 focus:opacity-100 data-[state=open]:opacity-100',
             'transition'
           )}
-          aria-label="Column options"
+          aria-label={`Column options for ${column.id}`}
         >
           <EllipsisVerticalIcon data-icon="inline-start" />
         </Button>
@@ -82,13 +82,23 @@ export const ColumnHeaderDropdown = function ColumnHeaderDropdown({
             <DropdownMenuItem onClick={handleSortAsc}>
               <SortAscIcon className="mr-2 size-3.5" />A → Z
               {column.getIsSorted() === 'asc' && (
-                <span className="ml-auto text-xs">✓</span>
+                <>
+                  <span className="ml-auto text-xs" aria-hidden="true">
+                    ✓
+                  </span>
+                  <span className="sr-only">active</span>
+                </>
               )}
             </DropdownMenuItem>
             <DropdownMenuItem onClick={handleSortDesc}>
               <SortDescIcon className="mr-2 size-3.5" />Z → A
               {column.getIsSorted() === 'desc' && (
-                <span className="ml-auto text-xs">✓</span>
+                <>
+                  <span className="ml-auto text-xs" aria-hidden="true">
+                    ✓
+                  </span>
+                  <span className="sr-only">active</span>
+                </>
               )}
             </DropdownMenuItem>
           </>

--- a/apps/dashboard-tsr/src/components/data-table/components/data-table-footer.tsx
+++ b/apps/dashboard-tsr/src/components/data-table/components/data-table-footer.tsx
@@ -61,6 +61,7 @@ export const DataTableFooter = memo(function DataTableFooter<
               className="size-6"
               onClick={() => table.previousPage()}
               disabled={!canPrev}
+              aria-label="Previous page"
             >
               <ChevronLeftIcon className="size-3" />
             </Button>
@@ -70,6 +71,7 @@ export const DataTableFooter = memo(function DataTableFooter<
               className="size-6"
               onClick={() => table.nextPage()}
               disabled={!canNext}
+              aria-label="Next page"
             >
               <ChevronRightIcon className="size-3" />
             </Button>

--- a/apps/dashboard-tsr/src/components/data-table/components/data-table-header.tsx
+++ b/apps/dashboard-tsr/src/components/data-table/components/data-table-header.tsx
@@ -417,6 +417,7 @@ export const DataTableHeader = memo(function DataTableHeader<
                         size="icon-sm"
                         onClick={() => removeFilterDraft(draft.id)}
                         className="size-8 text-muted-foreground hover:text-destructive shrink-0"
+                        aria-label="Remove filter condition"
                       >
                         <Trash2Icon className="size-3.5" />
                       </Button>

--- a/apps/dashboard-tsr/src/components/data-table/data-table.tsx
+++ b/apps/dashboard-tsr/src/components/data-table/data-table.tsx
@@ -19,7 +19,7 @@ import type { ChartQueryParams } from '@/types/chart-data'
 import type { ExpandableConfig, QueryConfig } from '@/types/query-config'
 
 import { arrayMove } from '@dnd-kit/sortable'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import {
   buildExpandColumnDef,
   EXPAND_COLUMN_ID,
@@ -217,7 +217,10 @@ export function DataTable<
   >([])
 
   // Determine which columns should be filterable (memoized)
-  const configuredColumns = queryConfig.columns.map(normalizeColumnName)
+  const configuredColumns = useMemo(
+    () => queryConfig.columns.map(normalizeColumnName),
+    [queryConfig.columns]
+  )
 
   // Client-side column filtering state with optional URL sync
   const {
@@ -241,19 +244,33 @@ export function DataTable<
   })
 
   // Memoize filterableColumns to prevent filterContext recreation
-  const resolvedFilterableColumns = filterableColumns || configuredColumns
+  const resolvedFilterableColumns = useMemo(
+    () => filterableColumns || configuredColumns,
+    [filterableColumns, configuredColumns]
+  )
 
   // Memoize filter context to prevent columnDefs recreation on every render
-  // This is critical to avoid infinite loops when filters change
-  const filterContext = enableColumnFilters
-    ? {
-        enableColumnFilters,
-        filterableColumns: resolvedFilterableColumns,
-        columnFilters,
-        setColumnFilter,
-        clearColumnFilter,
-      }
-    : undefined
+  // This is critical to avoid infinite loops when filters change.
+  // setColumnFilter/clearColumnFilter are stable (useCallback in useTableFilters).
+  const filterContext = useMemo(
+    () =>
+      enableColumnFilters
+        ? {
+            enableColumnFilters,
+            filterableColumns: resolvedFilterableColumns,
+            columnFilters,
+            setColumnFilter,
+            clearColumnFilter,
+          }
+        : undefined,
+    [
+      enableColumnFilters,
+      resolvedFilterableColumns,
+      columnFilters,
+      setColumnFilter,
+      clearColumnFilter,
+    ]
+  )
 
   // Schema-driven typed column filter wiring (date-range, multi-select, etc.)
   const { getActiveFilter, setFilter, clearFilter } = useColumnFilterState(

--- a/apps/dashboard-tsr/src/components/explorer/tabs/query-tab.tsx
+++ b/apps/dashboard-tsr/src/components/explorer/tabs/query-tab.tsx
@@ -25,11 +25,12 @@ import type {
 } from '@/lib/api/types'
 
 import { useExplorerState } from '../hooks/use-explorer-state'
-import { lazy, useMemo, Suspense, useEffect, useRef, useState } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
 import { format } from 'sql-formatter'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
   TableBody,
@@ -38,8 +39,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { apiFetch } from '@/lib/swr/api-fetch'
 import { activateOnEnterOrSpace } from '@/lib/a11y'
+import { apiFetch } from '@/lib/swr/api-fetch'
 import { useHostId } from '@/lib/swr/use-host'
 import { cn } from '@/lib/utils'
 
@@ -53,9 +54,7 @@ function SqlEditorWrapper({ children }: { children: React.ReactNode }) {
     setMounted(true)
   }, [])
   if (!mounted) {
-    return (
-      <div className="min-h-[120px] rounded-md border border-input bg-muted/30 animate-pulse" />
-    )
+    return <Skeleton className="min-h-[120px] rounded-md" />
   }
   return <>{children}</>
 }
@@ -436,9 +435,7 @@ export function QueryTab() {
         </div>
         <SqlEditorWrapper>
           <Suspense
-            fallback={
-              <div className="min-h-[120px] rounded-md border border-input bg-muted/30 animate-pulse" />
-            }
+            fallback={<Skeleton className="min-h-[120px] rounded-md" />}
           >
             <SqlEditor
               value={editorValue}

--- a/apps/dashboard-tsr/src/components/keeper/keeper-node-cards.tsx
+++ b/apps/dashboard-tsr/src/components/keeper/keeper-node-cards.tsx
@@ -2,6 +2,7 @@ import { Database, Layers, ServerCrash, Wifi, WifiOff } from 'lucide-react'
 
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import {
   Tooltip,
   TooltipContent,
@@ -350,19 +351,16 @@ function NodeCardSkeleton() {
   return (
     <div className="rounded-xl border border-border bg-card p-3 flex flex-col gap-2">
       <div className="flex items-center gap-2">
-        <div className="h-4 w-32 animate-pulse rounded bg-foreground/[0.06]" />
+        <Skeleton className="h-4 w-32 rounded" />
         <div className="ml-auto flex gap-1.5">
-          <div className="h-4 w-14 animate-pulse rounded bg-foreground/[0.06]" />
-          <div className="h-4 w-20 animate-pulse rounded bg-foreground/[0.06]" />
+          <Skeleton className="h-4 w-14 rounded" />
+          <Skeleton className="h-4 w-20 rounded" />
         </div>
       </div>
-      <div className="h-3 w-20 animate-pulse rounded bg-foreground/[0.04]" />
+      <Skeleton className="h-3 w-20 rounded" />
       <div className="mt-1 flex flex-col gap-1.5">
         {[0, 1, 2, 3].map((i) => (
-          <div
-            key={i}
-            className="h-2.5 animate-pulse rounded bg-foreground/[0.04]"
-          />
+          <Skeleton key={i} className="h-2.5 rounded" />
         ))}
       </div>
     </div>

--- a/apps/dashboard-tsr/src/components/nav-user/clerk-nav.tsx
+++ b/apps/dashboard-tsr/src/components/nav-user/clerk-nav.tsx
@@ -27,6 +27,7 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from '@/components/ui/sidebar'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { SETTINGS_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
 import { isFeatureAllowed } from '@/lib/feature-permissions/shared'
@@ -227,10 +228,10 @@ function UserSkeleton() {
     <SidebarMenu>
       <SidebarMenuItem>
         <SidebarMenuButton size="lg" disabled data-testid="nav-user-trigger">
-          <div className="size-8 rounded-lg bg-muted animate-pulse" />
+          <Skeleton className="size-8 rounded-lg" />
           <div className="grid flex-1 gap-1">
-            <div className="h-4 w-24 bg-muted animate-pulse rounded" />
-            <div className="h-3 w-16 bg-muted animate-pulse rounded" />
+            <Skeleton className="h-4 w-24 rounded" />
+            <Skeleton className="h-3 w-16 rounded" />
           </div>
         </SidebarMenuButton>
       </SidebarMenuItem>

--- a/apps/dashboard-tsr/src/components/peerdb/peer-detail-skeleton.tsx
+++ b/apps/dashboard-tsr/src/components/peerdb/peer-detail-skeleton.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 export function PeerDetailSkeleton() {
   return (
-    <div className="flex flex-col gap-6 animate-pulse">
+    <div className="flex flex-col gap-6">
       {/* Title / Header Area */}
       <div className="flex flex-wrap items-center gap-3">
         <Skeleton className="h-4 w-16" />

--- a/apps/dashboard-tsr/src/components/ui/empty-state.tsx
+++ b/apps/dashboard-tsr/src/components/ui/empty-state.tsx
@@ -186,8 +186,14 @@ export const EmptyState = memo(function EmptyState({
     >
       {/* Decorative background circles */}
       <div className="relative mb-4">
-        <div className="absolute inset-0 scale-150 rounded-full bg-muted/20 animate-pulse" />
-        <div className="absolute inset-0 scale-125 rounded-full bg-muted/40" />
+        <div
+          className="absolute inset-0 scale-150 rounded-full bg-muted/20 animate-pulse"
+          aria-hidden="true"
+        />
+        <div
+          className="absolute inset-0 scale-125 rounded-full bg-muted/40"
+          aria-hidden="true"
+        />
         <div className="relative flex h-12 w-12 items-center justify-center rounded-full bg-muted/60 backdrop-blur-sm">
           {icon || config.icon}
         </div>

--- a/apps/dashboard-tsr/src/components/ui/empty-state.tsx
+++ b/apps/dashboard-tsr/src/components/ui/empty-state.tsx
@@ -186,14 +186,8 @@ export const EmptyState = memo(function EmptyState({
     >
       {/* Decorative background circles */}
       <div className="relative mb-4">
-        <div
-          className="absolute inset-0 scale-150 rounded-full bg-muted/20 animate-pulse"
-          aria-hidden="true"
-        />
-        <div
-          className="absolute inset-0 scale-125 rounded-full bg-muted/40"
-          aria-hidden="true"
-        />
+        <div className="absolute inset-0 scale-150 rounded-full bg-muted/20 animate-pulse" />
+        <div className="absolute inset-0 scale-125 rounded-full bg-muted/40" />
         <div className="relative flex h-12 w-12 items-center justify-center rounded-full bg-muted/60 backdrop-blur-sm">
           {icon || config.icon}
         </div>

--- a/apps/dashboard-tsr/src/lib/context/app-context.tsx
+++ b/apps/dashboard-tsr/src/lib/context/app-context.tsx
@@ -95,7 +95,7 @@ export const AppProvider = ({
       setReloadInterval,
       pathname,
     }),
-    [interval, reloadInterval, setReloadInterval, pathname]
+    [interval, setInterval, reloadInterval, setReloadInterval, pathname]
   )
 
   return <Context.Provider value={value}>{children}</Context.Provider>

--- a/apps/dashboard-tsr/src/lib/context/app-context.tsx
+++ b/apps/dashboard-tsr/src/lib/context/app-context.tsx
@@ -5,6 +5,8 @@ import {
   type Dispatch,
   type SetStateAction,
   use,
+  useCallback,
+  useMemo,
   useState,
 } from 'react'
 import { usePathname } from '@/lib/next-compat'
@@ -71,34 +73,32 @@ export const AppProvider = ({
     readInitialReloadInterval(reloadIntervalSecond * 1000)
   )
 
-  const setReloadInterval: Dispatch<SetStateAction<number | null>> = (
-    action
-  ) => {
-    setReloadIntervalState((prev) => {
-      const next =
-        typeof action === 'function'
-          ? (action as (p: number | null) => number | null)(prev)
-          : action
-      persistReloadInterval(next)
-      return next
-    })
-  }
+  const setReloadInterval: Dispatch<SetStateAction<number | null>> =
+    useCallback((action) => {
+      setReloadIntervalState((prev) => {
+        const next =
+          typeof action === 'function'
+            ? (action as (p: number | null) => number | null)(prev)
+            : action
+        persistReloadInterval(next)
+        return next
+      })
+    }, [])
 
   const pathname = usePathname()
 
-  return (
-    <Context.Provider
-      value={{
-        interval,
-        setInterval,
-        reloadInterval,
-        setReloadInterval,
-        pathname,
-      }}
-    >
-      {children}
-    </Context.Provider>
+  const value = useMemo<ContextValue>(
+    () => ({
+      interval,
+      setInterval,
+      reloadInterval,
+      setReloadInterval,
+      pathname,
+    }),
+    [interval, reloadInterval, setReloadInterval, pathname]
   )
+
+  return <Context.Provider value={value}>{children}</Context.Provider>
 }
 
 export const useAppContext = () => {

--- a/apps/dashboard-tsr/src/lib/context/time-range-context.tsx
+++ b/apps/dashboard-tsr/src/lib/context/time-range-context.tsx
@@ -1,6 +1,6 @@
 import type { ClickHouseInterval } from '@chm/types/clickhouse-interval'
 
-import { createContext, use, useState } from 'react'
+import { createContext, use, useCallback, useMemo, useState } from 'react'
 
 export interface TimeRangeOption {
   /** Display label shown in the picker (e.g., "24h") */
@@ -100,12 +100,15 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
   const [timeRange, setTimeRangeState] =
     useState<TimeRangeOption>(readInitialTimeRange)
 
-  const setTimeRange = (option: TimeRangeOption) => {
+  const setTimeRange = useCallback((option: TimeRangeOption) => {
     setTimeRangeState(option)
     persistTimeRange(option)
-  }
+  }, [])
 
-  const value = { timeRange, setTimeRange, presets: TIME_RANGE_PRESETS }
+  const value = useMemo<TimeRangeContextValue>(
+    () => ({ timeRange, setTimeRange, presets: TIME_RANGE_PRESETS }),
+    [timeRange, setTimeRange]
+  )
 
   return (
     <TimeRangeContext.Provider value={value}>

--- a/apps/dashboard-tsr/src/lib/query/use-chart-data.ts
+++ b/apps/dashboard-tsr/src/lib/query/use-chart-data.ts
@@ -56,18 +56,22 @@ export function useChartData<T extends ChartDataPoint = ChartDataPoint>({
   timezone,
   refreshInterval = REFRESH_INTERVAL.DEFAULT_60S,
 }: UseChartDataParams): UseChartResult<T> {
+  // Serialize params so the memo key is value-stable: a parent passing an
+  // inline `params` object literal changes its reference every render, which
+  // would otherwise defeat this memo (re-running on every render).
+  const paramsKey = params ? JSON.stringify(params) : ''
   const url = useMemo(() => {
     const searchParams = new URLSearchParams()
     if (hostId !== undefined) searchParams.append('hostId', String(hostId))
     if (interval) searchParams.append('interval', interval)
     if (lastHours !== undefined)
       searchParams.append('lastHours', String(lastHours))
-    if (params) searchParams.append('params', JSON.stringify(params))
+    if (paramsKey) searchParams.append('params', paramsKey)
     if (timezone) searchParams.append('timezone', timezone)
 
     const queryString = searchParams.toString()
     return `/api/v1/charts/${chartName}${queryString ? `?${queryString}` : ''}`
-  }, [chartName, hostId, interval, lastHours, params, timezone])
+  }, [chartName, hostId, interval, lastHours, paramsKey, timezone])
 
   const queryKey = [
     '/api/v1/charts',

--- a/apps/dashboard-tsr/src/lib/query/use-chart-data.ts
+++ b/apps/dashboard-tsr/src/lib/query/use-chart-data.ts
@@ -56,16 +56,18 @@ export function useChartData<T extends ChartDataPoint = ChartDataPoint>({
   timezone,
   refreshInterval = REFRESH_INTERVAL.DEFAULT_60S,
 }: UseChartDataParams): UseChartResult<T> {
-  const searchParams = new URLSearchParams()
-  if (hostId !== undefined) searchParams.append('hostId', String(hostId))
-  if (interval) searchParams.append('interval', interval)
-  if (lastHours !== undefined)
-    searchParams.append('lastHours', String(lastHours))
-  if (params) searchParams.append('params', JSON.stringify(params))
-  if (timezone) searchParams.append('timezone', timezone)
+  const url = useMemo(() => {
+    const searchParams = new URLSearchParams()
+    if (hostId !== undefined) searchParams.append('hostId', String(hostId))
+    if (interval) searchParams.append('interval', interval)
+    if (lastHours !== undefined)
+      searchParams.append('lastHours', String(lastHours))
+    if (params) searchParams.append('params', JSON.stringify(params))
+    if (timezone) searchParams.append('timezone', timezone)
 
-  const queryString = searchParams.toString()
-  const url = `/api/v1/charts/${chartName}${queryString ? `?${queryString}` : ''}`
+    const queryString = searchParams.toString()
+    return `/api/v1/charts/${chartName}${queryString ? `?${queryString}` : ''}`
+  }, [chartName, hostId, interval, lastHours, params, timezone])
 
   const queryKey = [
     '/api/v1/charts',
@@ -95,11 +97,10 @@ export function useChartData<T extends ChartDataPoint = ChartDataPoint>({
       await throwIfNotOk(response, 'Failed to fetch chart data')
       return response.json() as Promise<ChartDataResponse<T>>
     },
-    staleTime: 5_000,
+    staleTime: Math.max((refreshInterval as number) * 0.9, 5_000),
     refetchInterval: resolvedRefetchInterval,
     refetchOnMount: true,
     refetchOnReconnect: true,
-    refetchOnWindowFocus: true,
     retry: (failureCount, err) => {
       if (
         'status' in err &&

--- a/apps/dashboard-tsr/src/lib/query/use-table-data.ts
+++ b/apps/dashboard-tsr/src/lib/query/use-table-data.ts
@@ -31,19 +31,21 @@ export function useTableData<T = unknown>(
   refreshInterval?: number,
   timezone?: string
 ) {
-  const params = new URLSearchParams()
-  if (hostId !== undefined) params.append('hostId', String(hostId))
-  if (searchParams) {
-    Object.entries(searchParams).forEach(([key, value]) => {
-      if (value !== undefined && value !== null && value !== '') {
-        params.append(key, String(value))
-      }
-    })
-  }
-  if (timezone) params.append('timezone', timezone)
+  const url = useMemo(() => {
+    const params = new URLSearchParams()
+    if (hostId !== undefined) params.append('hostId', String(hostId))
+    if (searchParams) {
+      Object.entries(searchParams).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && value !== '') {
+          params.append(key, String(value))
+        }
+      })
+    }
+    if (timezone) params.append('timezone', timezone)
 
-  const queryString = params.toString()
-  const url = `/api/v1/tables/${queryConfigName}${queryString ? `?${queryString}` : ''}`
+    const queryString = params.toString()
+    return `/api/v1/tables/${queryConfigName}${queryString ? `?${queryString}` : ''}`
+  }, [queryConfigName, hostId, searchParams, timezone])
 
   const queryKey = [
     '/api/v1/tables',
@@ -71,11 +73,10 @@ export function useTableData<T = unknown>(
       await throwIfNotOk(response, 'Failed to fetch table data')
       return response.json() as Promise<TableDataResponse<T>>
     },
-    staleTime: 3_000,
+    staleTime: Math.max((refreshInterval ?? 0) * 0.9, 5_000),
     refetchInterval: resolvedRefetchInterval,
     refetchOnMount: true,
     refetchOnReconnect: true,
-    refetchOnWindowFocus: true,
   })
 
   const dataArray = data?.data ?? []

--- a/apps/dashboard-tsr/src/lib/query/use-table-data.ts
+++ b/apps/dashboard-tsr/src/lib/query/use-table-data.ts
@@ -31,6 +31,9 @@ export function useTableData<T = unknown>(
   refreshInterval?: number,
   timezone?: string
 ) {
+  // Serialize searchParams so the memo key is value-stable even when a parent
+  // recreates the object each render (inline literal / derived state).
+  const searchParamsKey = searchParams ? JSON.stringify(searchParams) : ''
   const url = useMemo(() => {
     const params = new URLSearchParams()
     if (hostId !== undefined) params.append('hostId', String(hostId))
@@ -45,7 +48,8 @@ export function useTableData<T = unknown>(
 
     const queryString = params.toString()
     return `/api/v1/tables/${queryConfigName}${queryString ? `?${queryString}` : ''}`
-  }, [queryConfigName, hostId, searchParams, timezone])
+    // searchParams is read inside but keyed via the stable searchParamsKey.
+  }, [queryConfigName, hostId, searchParamsKey, timezone])
 
   const queryKey = [
     '/api/v1/tables',

--- a/apps/dashboard-tsr/src/routes/(dashboard)/backups.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/backups.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { backupsConfig } from '@/lib/query-config/more/backups'
 
 function BackupsPageContent() {
@@ -11,7 +11,7 @@ function BackupsPageContent() {
 
 function BackupsPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <BackupsPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/charts.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/charts.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { getChartComponent, hasChart } from '@/components/charts/chart-registry'
-import { ChartSkeleton } from '@/components/skeletons'
+import { ChartSkeleton, ChartsOnlyPageSkeleton } from '@/components/skeletons'
 import { useSearchParams } from '@/lib/next-compat'
 import { useHostId } from '@/lib/swr'
 
@@ -81,7 +81,7 @@ function ChartsPageContent() {
 
 function ChartsPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<ChartsOnlyPageSkeleton chartCount={4} />}>
       <ChartsPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/dashboard.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/dashboard.tsx
@@ -6,6 +6,7 @@ import { getChartComponent, hasChart } from '@/components/charts/registry'
 import { ChartPicker } from '@/components/dashboard/chart-picker'
 import { SavedDashboardsToolbar } from '@/components/dashboard/saved-dashboards-toolbar'
 import { ChartSkeleton, ChartsOnlyPageSkeleton } from '@/components/skeletons'
+import { EmptyState } from '@/components/ui/empty-state'
 import { useHostId } from '@/lib/swr'
 
 /** Charts shown when no saved dashboard is loaded */
@@ -78,12 +79,11 @@ function DashboardContent() {
 
       {/* Empty state */}
       {validCharts.length === 0 && (
-        <div className="flex h-64 flex-col items-center justify-center gap-2 rounded-lg border border-dashed text-muted-foreground">
-          <p className="text-sm font-medium">No charts selected</p>
-          <p className="text-xs">
-            Use &ldquo;Add Charts&rdquo; to build your dashboard.
-          </p>
-        </div>
+        <EmptyState
+          variant="no-data"
+          title="No charts selected"
+          description='Use "Add Charts" to build your dashboard.'
+        />
       )}
 
       {/* Chart grid */}

--- a/apps/dashboard-tsr/src/routes/(dashboard)/dictionaries.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/dictionaries.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { dictionariesConfig } from '@/lib/query-config/more/dictionaries'
 
 function DictionariesContent() {
@@ -11,7 +11,7 @@ function DictionariesContent() {
 
 function DictionariesPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <DictionariesContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/dropped-tables.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/dropped-tables.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { droppedTablesConfig } from '@/lib/query-config/tables/dropped-tables'
 
 function DroppedTablesPageContent() {
@@ -11,7 +11,7 @@ function DroppedTablesPageContent() {
 
 function DroppedTablesPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <DroppedTablesPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/errors.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/errors.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { errorsConfig } from '@/lib/query-config/more/errors'
 
 function ErrorsPageContent() {
@@ -11,7 +11,7 @@ function ErrorsPageContent() {
 
 function ErrorsPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <ErrorsPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/expensive-queries.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/expensive-queries.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { ExpensiveQueriesView } from '@/components/expensive-queries'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 
 /**
  * Most Expensive Queries page.
@@ -13,7 +13,7 @@ import { ChartSkeleton } from '@/components/skeletons'
  */
 function ExpensiveQueriesPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <ExpensiveQueriesView />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/explain.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/explain.tsx
@@ -10,7 +10,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { Suspense, useState } from 'react'
 import { ExplainResult } from '@/components/explain/explain-result'
 import { ErrorAlert } from '@/components/feedback'
-import { ChartSkeleton } from '@/components/skeletons'
+import { TableSkeleton } from '@/components/skeletons'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -355,7 +355,7 @@ function ExplainContent() {
         </CardContent>
       </Card>
 
-      {isLoading && <ChartSkeleton />}
+      {isLoading && <TableSkeleton rows={3} />}
 
       {error && (
         <ErrorAlert
@@ -389,7 +389,7 @@ function ExplainContent() {
 
 function ExplainPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<TableSkeleton rows={3} />}>
       <ExplainContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/failed-queries.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/failed-queries.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { failedQueriesConfig } from '@/lib/query-config/queries/failed-queries'
 
 function FailedQueriesPageContent() {
@@ -11,7 +11,7 @@ function FailedQueriesPageContent() {
 
 function FailedQueriesPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <FailedQueriesPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/health.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/health.tsx
@@ -4,11 +4,11 @@ import { Suspense } from 'react'
 import { HealthGrid } from '@/components/health/health-grid'
 import { HealthSettingsDialog } from '@/components/health/health-settings-dialog'
 import { PageHeader } from '@/components/layout'
-import { ChartSkeleton } from '@/components/skeletons'
+import { ChartsOnlyPageSkeleton } from '@/components/skeletons'
 
 function HealthPageContent() {
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-3 sm:gap-4">
       <PageHeader
         title="Health Summary"
         description="Real-time health indicators for your ClickHouse cluster"
@@ -21,7 +21,7 @@ function HealthPageContent() {
 
 function HealthPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<ChartsOnlyPageSkeleton chartCount={8} />}>
       <HealthPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/history-queries.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/history-queries.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import {
   parseFiltersFromParams,
   serializeActiveFilters,
@@ -40,7 +40,7 @@ function HistoryQueriesPageContent() {
 
 function HistoryQueriesPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <HistoryQueriesPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/kafka-consumers.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/kafka-consumers.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { kafkaConsumersConfig } from '@/lib/query-config/system/kafka-consumers'
 
 function KafkaConsumersPageContent() {
@@ -13,7 +13,7 @@ function KafkaConsumersPageContent() {
 
 function KafkaConsumersPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <KafkaConsumersPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/keeper/connection-log.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/keeper/connection-log.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { keeperConnectionLogConfig } from '@/lib/query-config/keeper'
 
 function KeeperConnectionLogPageContent() {
@@ -16,7 +16,7 @@ function KeeperConnectionLogPageContent() {
 
 function KeeperConnectionLogPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <KeeperConnectionLogPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/keeper/connections.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/keeper/connections.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { keeperConnectionsConfig } from '@/lib/query-config/keeper'
 
 function KeeperConnectionsPageContent() {
@@ -16,7 +16,7 @@ function KeeperConnectionsPageContent() {
 
 function KeeperConnectionsPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <KeeperConnectionsPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/keeper/index.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/keeper/index.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { zookeeperConfig } from '@/lib/query-config/more/zookeeper'
 
 function KeeperBrowserPageContent() {
@@ -13,7 +13,7 @@ function KeeperBrowserPageContent() {
 
 function KeeperBrowserPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <KeeperBrowserPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/keeper/info.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/keeper/info.tsx
@@ -3,7 +3,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { Suspense } from 'react'
 import { KeeperNodeCards } from '@/components/keeper/keeper-node-cards'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { keeperInfoConfig } from '@/lib/query-config/keeper'
 
 function KeeperInfoPageContent() {
@@ -18,7 +18,7 @@ function KeeperInfoPageContent() {
 
 function KeeperInfoPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <KeeperInfoPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/keeper/log.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/keeper/log.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { keeperLogConfig } from '@/lib/query-config/keeper'
 
 function KeeperLogPageContent() {
@@ -11,7 +11,7 @@ function KeeperLogPageContent() {
 
 function KeeperLogPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <KeeperLogPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/keeper/overview.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/keeper/overview.tsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react'
 import { KeeperNodeCards } from '@/components/keeper/keeper-node-cards'
 import { KeeperOverviewKpis } from '@/components/keeper/keeper-overview-kpis'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { keeperOverviewConfig } from '@/lib/query-config/keeper'
 
 function KeeperOverviewContent() {
@@ -22,7 +22,7 @@ function KeeperOverviewContent() {
 
 function KeeperOverviewPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <KeeperOverviewContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/keeper/watches.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/keeper/watches.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { keeperWatchesConfig } from '@/lib/query-config/keeper'
 
 function KeeperWatchesPageContent() {
@@ -11,7 +11,7 @@ function KeeperWatchesPageContent() {
 
 function KeeperWatchesPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <KeeperWatchesPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/logs/crashes.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/logs/crashes.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { crashLogConfig } from '@/lib/query-config/logs/crashes'
 
 function CrashesContent() {
@@ -11,7 +11,7 @@ function CrashesContent() {
 
 function CrashesPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <CrashesContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/logs/stack-traces.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/logs/stack-traces.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { stackTracesConfig } from '@/lib/query-config/logs/stack-traces'
 
 function StackTracesContent() {
@@ -13,7 +13,7 @@ function StackTracesContent() {
 
 function StackTracesPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <StackTracesContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/logs/text-log.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/logs/text-log.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { textLogConfig } from '@/lib/query-config/logs/text-log'
 
 function TextLogContent() {
@@ -11,7 +11,7 @@ function TextLogContent() {
 
 function TextLogPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <TextLogContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/merge-performance.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/merge-performance.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { mergePerformanceConfig } from '@/lib/query-config/merges/merge-performance'
 
 function MergePerformancePageContent() {
@@ -16,7 +16,7 @@ function MergePerformancePageContent() {
 
 function MergePerformancePage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <MergePerformancePageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/merges.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/merges.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { mergesConfig } from '@/lib/query-config/merges/merges'
 
 function MergesPageContent() {
@@ -11,7 +11,7 @@ function MergesPageContent() {
 
 function MergesPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <MergesPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/moves.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/moves.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { movesConfig } from '@/lib/query-config/tables/moves'
 
 function MovesPageContent() {
@@ -11,7 +11,7 @@ function MovesPageContent() {
 
 function MovesPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <MovesPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/mutations.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/mutations.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { QueryPageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { mutationsConfig } from '@/lib/query-config/merges/mutations'
 
 function MutationsPageContent() {
@@ -11,7 +11,7 @@ function MutationsPageContent() {
 
 function MutationsPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <MutationsPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/overview.tsx
@@ -144,11 +144,6 @@ function OverviewPageContent() {
     return tabParam && VALID_TABS.has(tabParam) ? tabParam : DEFAULT_TAB
   })
 
-  // Track visited tabs for lazy loading (include the initial tab from URL)
-  const [visitedTabs, setVisitedTabs] = useState<Set<string>>(
-    () => new Set([activeTab])
-  )
-
   const handleTabChange = (value: string) => {
     // Update URL with new tab value, preserving other params
     const params = new URLSearchParams(searchParams.toString())
@@ -172,12 +167,6 @@ function OverviewPageContent() {
 
     // Local state drives the active tab instantly (no navigation round-trip).
     setActiveTab(value)
-
-    // Update visited tabs for lazy loading
-    setVisitedTabs((prev) => {
-      if (prev.has(value)) return prev
-      return new Set([...prev, value])
-    })
   }
 
   return (
@@ -213,33 +202,36 @@ function OverviewPageContent() {
             <TabsContent
               key={tab.value}
               value={tab.value}
-              className="space-y-2 animate-in fade-in-0 slide-in-from-bottom-1 duration-300 ease-out data-[state=inactive]:hidden"
-              forceMount={visitedTabs.has(tab.value) ? true : undefined}
+              className="space-y-2 animate-in fade-in-0 slide-in-from-bottom-1 duration-300 ease-out"
             >
-              {visitedTabs.has(tab.value) ? (
-                // LOCAL Suspense per tab: the charts are React.lazy(), so a
-                // first-time tab visit suspends while its chunk loads. Without
-                // a boundary here that suspension bubbles to the page-level
-                // <Suspense> and flashes the FULL-PAGE skeleton (status strip +
-                // KPI cards + tab bar) on every first tab switch. Catching it
-                // locally swaps only the tab's chart region; everything outside
-                // the tab content stays mounted.
-                <Suspense fallback={<TabContentSkeleton tab={tab} />}>
-                  {tab.customContent === 'topology' ? (
-                    <TopologyView
-                      hostId={hostId}
-                      detailHref={`/clusters?host=${hostId}`}
-                    />
-                  ) : (
-                    <LazyTabContent
-                      charts={tab.charts}
-                      gridClassName={tab.gridClassName}
-                      label={tab.label}
-                      hostId={hostId}
-                    />
-                  )}
-                </Suspense>
-              ) : null}
+              {/*
+                No forceMount: Radix unmounts inactive tab content, so hidden
+                tabs stop polling their charts' refetchInterval (the project
+                convention is to UNMOUNT hidden chart subtrees, not CSS-hide
+                them). Revisiting a tab re-mounts it but TanStack Query's
+                30-min gcTime serves the cached data instantly — no skeleton,
+                no refetch. LOCAL Suspense per tab: the charts are React.lazy(),
+                so a first-time visit suspends while its chunk loads. Without a
+                boundary here that suspension bubbles to the page-level
+                <Suspense> and flashes the FULL-PAGE skeleton (status strip +
+                KPI cards + tab bar). Catching it locally swaps only the tab's
+                chart region; everything outside the tab content stays mounted.
+              */}
+              <Suspense fallback={<TabContentSkeleton tab={tab} />}>
+                {tab.customContent === 'topology' ? (
+                  <TopologyView
+                    hostId={hostId}
+                    detailHref={`/clusters?host=${hostId}`}
+                  />
+                ) : (
+                  <LazyTabContent
+                    charts={tab.charts}
+                    gridClassName={tab.gridClassName}
+                    label={tab.label}
+                    hostId={hostId}
+                  />
+                )}
+              </Suspense>
             </TabsContent>
           ))}
         </Tabs>

--- a/apps/dashboard-tsr/src/routes/(dashboard)/page-views.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/page-views.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { pageViewsConfig } from '@/lib/query-config/more/page-views'
 
 function PageViewsPageContent() {
@@ -11,7 +11,7 @@ function PageViewsPageContent() {
 
 function PageViewsPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageViewsPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/part-info.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/part-info.tsx
@@ -5,6 +5,7 @@ import { DatabaseTableSelector } from '@/components/controls/database-table-sele
 import { TableSkeleton } from '@/components/skeletons'
 import { TableClient } from '@/components/tables/table-client'
 import { AppLink as Link } from '@/components/ui/app-link'
+import { EmptyState } from '@/components/ui/empty-state'
 import { useSearchParams } from '@/lib/next-compat'
 import { partInfoConfig } from '@/lib/query-config/tables/part-info'
 import { useHostId } from '@/lib/swr'
@@ -46,11 +47,12 @@ function PartInfoContent() {
           />
         </Suspense>
       ) : (
-        <div className="bg-card flex h-96 items-center justify-center rounded-lg border">
-          <p className="text-muted-foreground text-sm">
-            Select a database and table to view part information.
-          </p>
-        </div>
+        <EmptyState
+          variant="no-data"
+          title="Select a database and table"
+          description="Choose a database and table above to view part information."
+          className="h-96"
+        />
       )}
     </div>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/part-log.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/part-log.tsx
@@ -2,11 +2,11 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PartLogView } from '@/components/part-log'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 
 function PartLogPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PartLogView />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/profiler.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/profiler.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { profilerConfig } from '@/lib/query-config/queries/profiler'
 
 function ProfilerContent() {
@@ -11,7 +11,7 @@ function ProfilerContent() {
 
 function ProfilerPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <ProfilerContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/queries/parallelization.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/queries/parallelization.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { parallelizationConfig } from '@/lib/query-config/queries/parallelization'
 
 function ParallelizationContent() {
@@ -16,7 +16,7 @@ function ParallelizationContent() {
 
 function ParallelizationPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <ParallelizationContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/queries/thread-analysis.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/queries/thread-analysis.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { threadAnalysisConfig } from '@/lib/query-config/queries/thread-analysis'
 
 function ThreadAnalysisContent() {
@@ -13,7 +13,7 @@ function ThreadAnalysisContent() {
 
 function ThreadAnalysisPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <ThreadAnalysisContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/query-cache.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/query-cache.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { queryCacheConfig } from '@/lib/query-config/queries/query-cache'
 
 function QueryCachePageContent() {
@@ -11,7 +11,7 @@ function QueryCachePageContent() {
 
 function QueryCachePage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <QueryCachePageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/query-metric-log.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/query-metric-log.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { queryMetricLogConfig } from '@/lib/query-config/system/query-metric-log'
 
 function QueryMetricLogPageContent() {
@@ -13,7 +13,7 @@ function QueryMetricLogPageContent() {
 
 function QueryMetricLogPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <QueryMetricLogPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/readonly-tables.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/readonly-tables.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { readOnlyTablesConfig } from '@/lib/query-config/tables/readonly-tables'
 
 function ReadonlyTablesPageContent() {
@@ -13,7 +13,7 @@ function ReadonlyTablesPageContent() {
 
 function ReadonlyTablesPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <ReadonlyTablesPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/replicas.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/replicas.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { replicasConfig } from '@/lib/query-config/tables/replicas'
 
 function ReplicasPageContent() {
@@ -11,7 +11,7 @@ function ReplicasPageContent() {
 
 function ReplicasPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <ReplicasPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/replicated-fetches.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/replicated-fetches.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { replicatedFetchesConfig } from '@/lib/query-config/tables/replicated-fetches'
 
 function ReplicatedFetchesPageContent() {
@@ -16,7 +16,7 @@ function ReplicatedFetchesPageContent() {
 
 function ReplicatedFetchesPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <ReplicatedFetchesPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/replicated-merge-tree-settings.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/replicated-merge-tree-settings.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { replicatedMergeTreeSettingsConfig } from '@/lib/query-config/system/replicated-merge-tree-settings'
 
 function ReplicatedMergeTreeSettingsPageContent() {
@@ -16,7 +16,7 @@ function ReplicatedMergeTreeSettingsPageContent() {
 
 function ReplicatedMergeTreeSettingsPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <ReplicatedMergeTreeSettingsPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/replication-queue.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/replication-queue.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { replicationQueueConfig } from '@/lib/query-config/tables/replication-queue'
 
 function ReplicationQueuePageContent() {
@@ -16,7 +16,7 @@ function ReplicationQueuePageContent() {
 
 function ReplicationQueuePage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <ReplicationQueuePageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/security/audit-log.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/security/audit-log.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { sessionsConfig } from '@/lib/query-config/security/sessions'
 
 function AuditLogContent() {
@@ -11,7 +11,7 @@ function AuditLogContent() {
 
 function AuditLogPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <AuditLogContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/security/login-attempts.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/security/login-attempts.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { loginAttemptsConfig } from '@/lib/query-config/security/login-attempts'
 
 function LoginAttemptsContent() {
@@ -11,7 +11,7 @@ function LoginAttemptsContent() {
 
 function LoginAttemptsPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <LoginAttemptsContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/security/sessions.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/security/sessions.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { sessionsConfig } from '@/lib/query-config/security/sessions'
 
 function SessionsContent() {
@@ -11,7 +11,7 @@ function SessionsContent() {
 
 function SessionsPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <SessionsContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/user-processes.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/user-processes.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { userProcessesConfig } from '@/lib/query-config/tables/user-processes'
 
 function UserProcessesPageContent() {
@@ -11,7 +11,7 @@ function UserProcessesPageContent() {
 
 function UserProcessesPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <UserProcessesPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/src/routes/(dashboard)/warnings.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/warnings.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Suspense } from 'react'
 import { PageLayout } from '@/components/layout/query-page'
-import { ChartSkeleton } from '@/components/skeletons'
+import { PageSkeleton } from '@/components/skeletons'
 import { warningsConfig } from '@/lib/query-config/system/warnings'
 
 function WarningsPageContent() {
@@ -11,7 +11,7 @@ function WarningsPageContent() {
 
 function WarningsPage() {
   return (
-    <Suspense fallback={<ChartSkeleton />}>
+    <Suspense fallback={<PageSkeleton />}>
       <WarningsPageContent />
     </Suspense>
   )

--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -306,18 +306,11 @@ ${namedExports}
     name: 'chm:ssr-client-only-stub',
     enforce: 'pre',
     resolveId(id) {
-      // The stub keeps the Cloudflare Worker under the free-plan 3 MiB limit
-      // (#1393). The Node/Docker PRODUCTION target prerenders, and prerender
-      // runs the REAL libs during SSR — e.g. computeDagrePositions (PeerGraph)
-      // calls dagre — so prod Node must keep them.
-      //
-      // BUT the e2e Node build sets CHM_SKIP_PRERENDER=1: no prerender, and the
-      // server only emits the SPA fallback shell (the browser-only libs render
-      // client-side, where the client bundle still ships the real libs). With
-      // nothing rendering them server-side, stubbing these out of the Node
-      // server bundle is safe and cuts the build from >34 min (it was timing
-      // out at the 35 min ceiling on CI, killing the e2e gate) to ~CF speed.
-      if (isNode && !skipPrerender) return null
+      // The stub exists ONLY to keep the Cloudflare Worker under the free-plan
+      // 3 MiB limit (#1393). The Node/Docker target has no size limit and its
+      // prerender needs the REAL libs — e.g. computeDagrePositions (PeerGraph)
+      // calls dagre during SSR — so never stub when BUILD_TARGET=node.
+      if (isNode) return null
       // `this.environment` is the per-environment build context (Vite 6+/8).
       // Only stub in the worker/SSR environment, never the browser client build.
       if (this.environment?.name === 'client') return null

--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -306,11 +306,18 @@ ${namedExports}
     name: 'chm:ssr-client-only-stub',
     enforce: 'pre',
     resolveId(id) {
-      // The stub exists ONLY to keep the Cloudflare Worker under the free-plan
-      // 3 MiB limit (#1393). The Node/Docker target has no size limit and its
-      // prerender needs the REAL libs — e.g. computeDagrePositions (PeerGraph)
-      // calls dagre during SSR — so never stub when BUILD_TARGET=node.
-      if (isNode) return null
+      // The stub keeps the Cloudflare Worker under the free-plan 3 MiB limit
+      // (#1393). The Node/Docker PRODUCTION target prerenders, and prerender
+      // runs the REAL libs during SSR — e.g. computeDagrePositions (PeerGraph)
+      // calls dagre — so prod Node must keep them.
+      //
+      // BUT the e2e Node build sets CHM_SKIP_PRERENDER=1: no prerender, and the
+      // server only emits the SPA fallback shell (the browser-only libs render
+      // client-side, where the client bundle still ships the real libs). With
+      // nothing rendering them server-side, stubbing these out of the Node
+      // server bundle is safe and cuts the build from >34 min (it was timing
+      // out at the 35 min ceiling on CI, killing the e2e gate) to ~CF speed.
+      if (isNode && !skipPrerender) return null
       // `this.environment` is the per-environment build context (Vite 6+/8).
       // Only stub in the worker/SSR environment, never the browser client build.
       if (this.environment?.name === 'client') return null


### PR DESCRIPTION
Render-performance + loading-state pass on **dash-tsr** (the TanStack Start dashboard). Part of the epic #1392 readiness work — **not a cutover**; `apps/dashboard` stays the live app.

Came out of an honest "can dash-tsr replace dash now?" review: the app is functionally at parity, but loading had visible layout drift and the overview kept hidden charts polling. This addresses both, plus the CI gate that has never completed.

## 1. Loading CLS drift (primary)
The skeletons were already frame-matched by design, but **44 routes used a single ~160px `ChartSkeleton`** as the Suspense fallback for full charts+table pages → the document collapsed to ~160px then jumped to full height on load.
- Swap each for the correctly-sized pre-built skeleton: `PageSkeleton` (charts+table), `TableOnlyPageSkeleton` (table-only), `ChartsOnlyPageSkeleton` (KPI/health grids). `explain.tsx` → `TableSkeleton` (EXPLAIN is tabular, not a chart).
- Replace leftover raw `animate-pulse` divs with the static `<Skeleton>` (keeper node cards, peerdb detail, query editor, clerk nav) — consistent with the static-by-default skeleton decision.

## 2. Render performance
- **overview.tsx**: unmount inactive tabs instead of `forceMount` + CSS-hide, so hidden charts stop firing `refetchInterval` (was **60+ live polls** after visiting all tabs). TanStack Query `gcTime` keeps revisits instant.
- **use-chart-data / use-table-data**: stop overriding the global `refetchOnWindowFocus: false` (was N-chart refetch storms on every window focus); align `staleTime` to the refresh interval; memoize the request-URL build.
- Chart factories default refresh **30s → 60s** (matches the hook default).
- Memoize context values (`app-context`, `time-range-context`) and `DataTable` `filterContext`/`configuredColumns` to cut re-render storms (the latter was re-running O(cols×rows) column sizing on every sort/expand/page).

## 3. Empty / a11y
- `EmptyState` for the dashboard "no charts" + part-info no-selection states.
- aria-labels on icon-only pagination/filter/column buttons; `aria-hidden` on decorative pulse.

## 4. CI — e2e-test-tsr never completes
The job isn't hitting its 35m timeout; it's killed by **concurrency cancel-in-progress** (~20min job, faster main merges) so the e2e gate has never run to completion on main. Cache the Node build output keyed on build inputs and **skip the ~15-min build on an exact hit**, shrinking the cancel window so the specs actually execute.

## Verification
- `BUILD_TARGET=node bun run build` (vite + `tsc --noEmit`): ✅ clean.
- Targeted Biome on all 62 changed files: ✅ clean.
- Live browser CLS pass on the **preview deploy** (real data) to follow once the preview is up.

## Not included
- Moving `components/ui/empty-state.tsx` out of `ui/` (touches ~11 imports) — deferred.
- Hoisting a single `ChartScaleProvider` (bigger refactor) — deferred.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified loading skeleton components across all dashboard pages
  * Added `EmptyState` UI for improved empty data displays

* **Performance**
  * Implemented build output caching in CI/CD pipeline
  * Optimized component rendering with memoization techniques
  * Adjusted data refresh intervals for better efficiency

* **Accessibility**
  * Enhanced screen reader labels on pagination and filter controls
  * Improved semantic markup for interactive elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->