### PR TITLE
fix(agent): send AnyRouter category in X-AnyRouter-Categories, not the source header

### DIFF
--- a/apps/dashboard-tsr/src/lib/ai/agent/__tests__/clickhouse-agent-openrouter.test.ts
+++ b/apps/dashboard-tsr/src/lib/ai/agent/__tests__/clickhouse-agent-openrouter.test.ts
@@ -53,7 +53,7 @@ describe('createClickHouseAgent OpenRouter model resolution', () => {
     } else {
       delete process.env.APP_NAME
     }
-    if (originalAppSource) {
+    if (originalAppSource !== undefined) {
       process.env.APP_SOURCE = originalAppSource
     } else {
       delete process.env.APP_SOURCE
@@ -113,5 +113,28 @@ describe('createClickHouseAgent OpenRouter model resolution', () => {
     })
     expect(createOpenAIOptions[0]).not.toHaveProperty('name')
     expect(openAIChatMock).toHaveBeenCalledWith('google/gemma-test')
+  })
+
+  test('falls back to the default AnyRouter source when APP_SOURCE is unset', async () => {
+    process.env.ANYROUTER_API_KEY = 'ar-test'
+    process.env.APP_NAME = 'Agent Test'
+    delete process.env.APP_SOURCE
+    process.env.APP_CATEGORY = 'ops'
+    const { resolveAgentChatModel } = await import('../provider-chat-model')
+
+    resolveAgentChatModel({
+      model: 'anyrouter:google/gemma-test',
+      referer: 'https://example.test/agents',
+    })
+
+    // With APP_SOURCE unset, X-AnyRouter-Source falls back to DEFAULT_APP_SOURCE
+    // ('chmonitor') — the production path, since only OPENROUTER_APP_NAME is set
+    // in wrangler. The category stays in X-AnyRouter-Categories.
+    expect(createOpenAIOptions[0]).toMatchObject({
+      headers: {
+        'X-AnyRouter-Source': 'chmonitor',
+        'X-AnyRouter-Categories': 'ops',
+      },
+    })
   })
 })

--- a/apps/dashboard-tsr/src/lib/ai/agent/__tests__/clickhouse-agent-openrouter.test.ts
+++ b/apps/dashboard-tsr/src/lib/ai/agent/__tests__/clickhouse-agent-openrouter.test.ts
@@ -27,6 +27,7 @@ describe('createClickHouseAgent OpenRouter model resolution', () => {
   const originalFallback = process.env.OPENROUTER_FREE_FALLBACK_MODEL
   const originalAnyRouterKey = process.env.ANYROUTER_API_KEY
   const originalAppName = process.env.APP_NAME
+  const originalAppSource = process.env.APP_SOURCE
   const originalAppCategory = process.env.APP_CATEGORY
   const originalAppVersion = process.env.APP_VERSION
 
@@ -51,6 +52,11 @@ describe('createClickHouseAgent OpenRouter model resolution', () => {
       process.env.APP_NAME = originalAppName
     } else {
       delete process.env.APP_NAME
+    }
+    if (originalAppSource) {
+      process.env.APP_SOURCE = originalAppSource
+    } else {
+      delete process.env.APP_SOURCE
     }
     if (originalAppCategory) {
       process.env.APP_CATEGORY = originalAppCategory
@@ -84,6 +90,7 @@ describe('createClickHouseAgent OpenRouter model resolution', () => {
   test('passes AnyRouter attribution headers to OpenAI-compatible provider', async () => {
     process.env.ANYROUTER_API_KEY = 'ar-test'
     process.env.APP_NAME = 'Agent Test'
+    process.env.APP_SOURCE = 'agent-source'
     process.env.APP_CATEGORY = 'ops'
     process.env.APP_VERSION = 'test-version'
     const { resolveAgentChatModel } = await import('../provider-chat-model')
@@ -99,7 +106,8 @@ describe('createClickHouseAgent OpenRouter model resolution', () => {
       headers: {
         'HTTP-Referer': 'https://example.test/agents',
         'X-AnyRouter-Title': 'Agent Test',
-        'X-AnyRouter-Source': 'ops',
+        'X-AnyRouter-Source': 'agent-source',
+        'X-AnyRouter-Categories': 'ops',
         'X-AnyRouter-Version': 'test-version',
       },
     })

--- a/apps/dashboard-tsr/src/lib/ai/agent/provider-chat-model.ts
+++ b/apps/dashboard-tsr/src/lib/ai/agent/provider-chat-model.ts
@@ -51,7 +51,7 @@ function getAppMetadata(referer?: string) {
       process.env.APP_NAME ||
       process.env.OPENROUTER_APP_NAME ||
       DEFAULT_APP_NAME,
-    source: process.env.APP_SOURCE || DEFAULT_APP_SOURCE,
+    source: process.env.APP_SOURCE?.trim() || DEFAULT_APP_SOURCE,
     category: process.env.APP_CATEGORY || DEFAULT_APP_CATEGORY,
     version: process.env.APP_VERSION || DEFAULT_APP_VERSION,
   }

--- a/apps/dashboard-tsr/src/lib/ai/agent/provider-chat-model.ts
+++ b/apps/dashboard-tsr/src/lib/ai/agent/provider-chat-model.ts
@@ -17,6 +17,7 @@ export const DEFAULT_MODEL =
 
 export const DEFAULT_APP_REFERER = 'https://chmonitor.dev'
 export const DEFAULT_APP_NAME = 'chmonitor'
+export const DEFAULT_APP_SOURCE = 'chmonitor'
 export const DEFAULT_APP_CATEGORY = 'programming-app'
 export const DEFAULT_APP_VERSION = '0.2.0'
 
@@ -50,6 +51,7 @@ function getAppMetadata(referer?: string) {
       process.env.APP_NAME ||
       process.env.OPENROUTER_APP_NAME ||
       DEFAULT_APP_NAME,
+    source: process.env.APP_SOURCE || DEFAULT_APP_SOURCE,
     category: process.env.APP_CATEGORY || DEFAULT_APP_CATEGORY,
     version: process.env.APP_VERSION || DEFAULT_APP_VERSION,
   }
@@ -59,10 +61,16 @@ function getOpenAICompatibleHeaders(providerId: string, referer?: string) {
   if (providerId !== 'anyrouter') return undefined
 
   const meta = getAppMetadata(referer)
+  // X-AnyRouter-Source is the app identifier AnyRouter groups rankings by (its
+  // curation matches this against `chmonitor`); the marketplace category goes in
+  // X-AnyRouter-Categories. Keep them separate — sending the category as the
+  // source makes AnyRouter attribute usage to `programming-app` instead of
+  // chmonitor.dev.
   return {
     'HTTP-Referer': meta.referer,
     'X-AnyRouter-Title': meta.name,
-    'X-AnyRouter-Source': meta.category,
+    'X-AnyRouter-Source': meta.source,
+    'X-AnyRouter-Categories': meta.category,
     'X-AnyRouter-Version': meta.version,
   }
 }

--- a/apps/dashboard/lib/ai/agent/__tests__/clickhouse-agent-openrouter.test.ts
+++ b/apps/dashboard/lib/ai/agent/__tests__/clickhouse-agent-openrouter.test.ts
@@ -53,7 +53,7 @@ describe('createClickHouseAgent OpenRouter model resolution', () => {
     } else {
       delete process.env.APP_NAME
     }
-    if (originalAppSource) {
+    if (originalAppSource !== undefined) {
       process.env.APP_SOURCE = originalAppSource
     } else {
       delete process.env.APP_SOURCE
@@ -113,5 +113,28 @@ describe('createClickHouseAgent OpenRouter model resolution', () => {
     })
     expect(createOpenAIOptions[0]).not.toHaveProperty('name')
     expect(openAIChatMock).toHaveBeenCalledWith('google/gemma-test')
+  })
+
+  test('falls back to the default AnyRouter source when APP_SOURCE is unset', async () => {
+    process.env.ANYROUTER_API_KEY = 'ar-test'
+    process.env.APP_NAME = 'Agent Test'
+    delete process.env.APP_SOURCE
+    process.env.APP_CATEGORY = 'ops'
+    const { resolveAgentChatModel } = await import('../provider-chat-model')
+
+    resolveAgentChatModel({
+      model: 'anyrouter:google/gemma-test',
+      referer: 'https://example.test/agents',
+    })
+
+    // With APP_SOURCE unset, X-AnyRouter-Source falls back to DEFAULT_APP_SOURCE
+    // ('chmonitor') — the production path, since only OPENROUTER_APP_NAME is set
+    // in wrangler. The category stays in X-AnyRouter-Categories.
+    expect(createOpenAIOptions[0]).toMatchObject({
+      headers: {
+        'X-AnyRouter-Source': 'chmonitor',
+        'X-AnyRouter-Categories': 'ops',
+      },
+    })
   })
 })

--- a/apps/dashboard/lib/ai/agent/__tests__/clickhouse-agent-openrouter.test.ts
+++ b/apps/dashboard/lib/ai/agent/__tests__/clickhouse-agent-openrouter.test.ts
@@ -27,6 +27,7 @@ describe('createClickHouseAgent OpenRouter model resolution', () => {
   const originalFallback = process.env.OPENROUTER_FREE_FALLBACK_MODEL
   const originalAnyRouterKey = process.env.ANYROUTER_API_KEY
   const originalAppName = process.env.APP_NAME
+  const originalAppSource = process.env.APP_SOURCE
   const originalAppCategory = process.env.APP_CATEGORY
   const originalAppVersion = process.env.APP_VERSION
 
@@ -51,6 +52,11 @@ describe('createClickHouseAgent OpenRouter model resolution', () => {
       process.env.APP_NAME = originalAppName
     } else {
       delete process.env.APP_NAME
+    }
+    if (originalAppSource) {
+      process.env.APP_SOURCE = originalAppSource
+    } else {
+      delete process.env.APP_SOURCE
     }
     if (originalAppCategory) {
       process.env.APP_CATEGORY = originalAppCategory
@@ -84,6 +90,7 @@ describe('createClickHouseAgent OpenRouter model resolution', () => {
   test('passes AnyRouter attribution headers to OpenAI-compatible provider', async () => {
     process.env.ANYROUTER_API_KEY = 'ar-test'
     process.env.APP_NAME = 'Agent Test'
+    process.env.APP_SOURCE = 'agent-source'
     process.env.APP_CATEGORY = 'ops'
     process.env.APP_VERSION = 'test-version'
     const { resolveAgentChatModel } = await import('../provider-chat-model')
@@ -99,7 +106,8 @@ describe('createClickHouseAgent OpenRouter model resolution', () => {
       headers: {
         'HTTP-Referer': 'https://example.test/agents',
         'X-AnyRouter-Title': 'Agent Test',
-        'X-AnyRouter-Source': 'ops',
+        'X-AnyRouter-Source': 'agent-source',
+        'X-AnyRouter-Categories': 'ops',
         'X-AnyRouter-Version': 'test-version',
       },
     })

--- a/apps/dashboard/lib/ai/agent/provider-chat-model.ts
+++ b/apps/dashboard/lib/ai/agent/provider-chat-model.ts
@@ -53,7 +53,7 @@ function getAppMetadata(referer?: string) {
       process.env.APP_NAME ||
       process.env.OPENROUTER_APP_NAME ||
       DEFAULT_APP_NAME,
-    source: process.env.APP_SOURCE || DEFAULT_APP_SOURCE,
+    source: process.env.APP_SOURCE?.trim() || DEFAULT_APP_SOURCE,
     category: process.env.APP_CATEGORY || DEFAULT_APP_CATEGORY,
     version: process.env.APP_VERSION || DEFAULT_APP_VERSION,
   }

--- a/apps/dashboard/lib/ai/agent/provider-chat-model.ts
+++ b/apps/dashboard/lib/ai/agent/provider-chat-model.ts
@@ -19,6 +19,7 @@ export const DEFAULT_MODEL =
 
 export const DEFAULT_APP_REFERER = 'https://chmonitor.dev'
 export const DEFAULT_APP_NAME = 'chmonitor'
+export const DEFAULT_APP_SOURCE = 'chmonitor'
 export const DEFAULT_APP_CATEGORY = 'programming-app'
 export const DEFAULT_APP_VERSION = '0.2.0'
 
@@ -52,6 +53,7 @@ function getAppMetadata(referer?: string) {
       process.env.APP_NAME ||
       process.env.OPENROUTER_APP_NAME ||
       DEFAULT_APP_NAME,
+    source: process.env.APP_SOURCE || DEFAULT_APP_SOURCE,
     category: process.env.APP_CATEGORY || DEFAULT_APP_CATEGORY,
     version: process.env.APP_VERSION || DEFAULT_APP_VERSION,
   }
@@ -61,10 +63,16 @@ function getOpenAICompatibleHeaders(providerId: string, referer?: string) {
   if (providerId !== 'anyrouter') return undefined
 
   const meta = getAppMetadata(referer)
+  // X-AnyRouter-Source is the app identifier AnyRouter groups rankings by (its
+  // curation matches this against `chmonitor`); the marketplace category goes in
+  // X-AnyRouter-Categories. Keep them separate — sending the category as the
+  // source makes AnyRouter attribute usage to `programming-app` instead of
+  // chmonitor.dev.
   return {
     'HTTP-Referer': meta.referer,
     'X-AnyRouter-Title': meta.name,
-    'X-AnyRouter-Source': meta.category,
+    'X-AnyRouter-Source': meta.source,
+    'X-AnyRouter-Categories': meta.category,
     'X-AnyRouter-Version': meta.version,
   }
 }


### PR DESCRIPTION
## Problem

The chmonitor agent's traffic to AnyRouter was being attributed to the app
**`https://anyrouter.dev/app?id=programming-app`** instead of `chmonitor.dev`.

## Root cause

In `provider-chat-model.ts` (`getOpenAICompatibleHeaders`), the agent put the
marketplace **category** into the **source** header and never sent the
categories header:

```ts
'X-AnyRouter-Source': meta.category,   // "programming-app"  ❌
// no X-AnyRouter-Categories
```

AnyRouter records `generations.app_source = "programming-app"`. Its rankings
canonicalizer falls back to the raw `app_source` as the app id when no curation
matches, so the app surfaced at `/app?id=programming-app`. AnyRouter's chmonitor
curation expects `source: chmonitor`, which never arrived.

(The OpenRouter branch in the same file already does this correctly, sending the
category via `X-OpenRouter-Categories`.)

## Fix

Send a proper source slug and move the category to the right header:

```ts
'X-AnyRouter-Source': meta.source,       // "chmonitor"      ✅ matches curation
'X-AnyRouter-Categories': meta.category, // "programming-app" ✅
```

- New `DEFAULT_APP_SOURCE = 'chmonitor'` constant + `APP_SOURCE` env override.
- Applied to **both** dashboards (`apps/dashboard` and `apps/dashboard-tsr`).
- Updated both agent tests to assert the corrected `Source` / `Categories`
  split (passing).

## Companion change

AnyRouter side adds a `title: chmonitor` curation match so historical rows
(already written with `app_source=programming-app`) collapse back to
`chmonitor.dev`: duyet/anyrouter#<pending> (branch `claude/fervent-brown-eNqMY`).

## Verification

- `bun test .../clickhouse-agent-openrouter.test.ts -t "attribution headers"` →
  pass (both dashboards).
- Biome check clean on all 4 changed files.

https://claude.ai/code/session_01VfDvynLPMiHU3btDJ771vj

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfDvynLPMiHU3btDJ771vj)_

## Summary by Sourcery

Correct AnyRouter attribution metadata for the ClickHouse agent and ensure both dashboards send consistent headers.

Enhancements:
- Introduce an app source metadata field with a default of `chmonitor` and propagate it into AnyRouter headers for both dashboards.
- Separate AnyRouter app source and marketplace category into `X-AnyRouter-Source` and `X-AnyRouter-Categories` headers respectively.

Tests:
- Extend AnyRouter attribution header tests for both dashboards to cover the new app source and categories split and to preserve APP_SOURCE environment configuration across tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable app source attribution, now separately specified from category information in external service requests.

* **Tests**
  * Updated test coverage for app source configuration and header validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->