### PR TITLE
perf(dashboard-tsr): stop background polling on hidden tabs and inactive chart tabs

### DIFF
--- a/apps/dashboard-tsr/src/components/charts/page-views-analytics.tsx
+++ b/apps/dashboard-tsr/src/components/charts/page-views-analytics.tsx
@@ -1,5 +1,6 @@
 import type { ChartProps } from '@/components/charts/chart-props'
 
+import { useState } from 'react'
 import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { BarList } from '@/components/charts/primitives/bar-list'
@@ -31,22 +32,24 @@ export const PageViewsAnalyticsTabs = function PageViewsAnalyticsTabs({
   hostId,
   defaultTab = 'top-pages',
 }: PageViewsAnalyticsTabsProps) {
+  const [activeTab, setActiveTab] = useState<string>(defaultTab)
+
   const swrTopPages = useChartData<TopPagesRow>({
     chartName: 'top-pages',
     hostId,
-    refreshInterval: 30000,
+    refreshInterval: activeTab === 'top-pages' ? 30000 : 0,
   })
 
   const swrDevices = useChartData<DeviceRow>({
     chartName: 'pageviews-by-device',
     hostId,
-    refreshInterval: 30000,
+    refreshInterval: activeTab === 'devices' ? 30000 : 0,
   })
 
   const swrCountries = useChartData<CountryRow>({
     chartName: 'pageviews-by-country',
     hostId,
-    refreshInterval: 30000,
+    refreshInterval: activeTab === 'countries' ? 30000 : 0,
   })
 
   // Combine loading states
@@ -102,6 +105,7 @@ export const PageViewsAnalyticsTabs = function PageViewsAnalyticsTabs({
               id="page-views-analytics-tabs"
               defaultValue={defaultTab}
               className="overflow-hidden"
+              onValueChange={setActiveTab}
             >
               <TabsList className="h-11 sm:h-9 gap-1 mb-3 p-1">
                 <TabsTrigger

--- a/apps/dashboard-tsr/src/components/charts/pageviews-by-device.tsx
+++ b/apps/dashboard-tsr/src/components/charts/pageviews-by-device.tsx
@@ -1,5 +1,6 @@
 import type { ChartProps } from '@/components/charts/chart-props'
 
+import { useState } from 'react'
 import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { BarList } from '@/components/charts/primitives/bar-list'
@@ -26,22 +27,24 @@ export const PageviewsByDeviceChart = function PageviewsByDeviceChart({
   className,
   hostId,
 }: ChartProps) {
+  const [activeTab, setActiveTab] = useState<string>('devices')
+
   const swrTopPages = useChartData<TopPagesRow>({
     chartName: 'top-pages',
     hostId,
-    refreshInterval: 30000,
+    refreshInterval: activeTab === 'top-pages' ? 30000 : 0,
   })
 
   const swrDevices = useChartData<DeviceRow>({
     chartName: 'pageviews-by-device',
     hostId,
-    refreshInterval: 30000,
+    refreshInterval: activeTab === 'devices' ? 30000 : 0,
   })
 
   const swrCountries = useChartData<CountryRow>({
     chartName: 'pageviews-by-country',
     hostId,
-    refreshInterval: 30000,
+    refreshInterval: activeTab === 'countries' ? 30000 : 0,
   })
 
   // Combine loading states
@@ -97,6 +100,7 @@ export const PageviewsByDeviceChart = function PageviewsByDeviceChart({
               id="pageviews-by-device-tabs"
               defaultValue="devices"
               className="overflow-hidden"
+              onValueChange={setActiveTab}
             >
               <TabsList className="h-11 sm:h-9 gap-1 mb-3 p-1">
                 <TabsTrigger

--- a/apps/dashboard-tsr/src/lib/swr/use-host-status.ts
+++ b/apps/dashboard-tsr/src/lib/swr/use-host-status.ts
@@ -79,7 +79,13 @@ export function useHostStatus(
     },
     enabled: hostId !== null && !isBrowserConnection,
     staleTime: 10000,
-    refetchInterval: refreshInterval,
+    refetchInterval:
+      refreshInterval > 0
+        ? () =>
+            typeof document !== 'undefined' && document.hidden
+              ? false
+              : (refreshInterval as number)
+        : (refreshInterval as any),
     refetchOnWindowFocus: revalidateOnFocus,
     refetchOnReconnect: true,
   })


### PR DESCRIPTION
## Summary

- `use-host-status`: `refetchInterval` now returns `false` when `document.hidden`, matching the same guard used in `use-chart-data` — stops polling /api/v1/health while the tab is hidden
- `pageviews-by-device`: tracks `activeTab` state; only the active tab's `useChartData` call gets `refreshInterval: 30000`; inactive tabs get `0` (fetch once on mount, no re-polling)
- `page-views-analytics`: same pattern as above; `activeTab` initialised from `defaultTab` prop so the correct tab polls on first render

~6 fewer background requests per 30 s per page when inactive tabs are open.

Closes part of epic #1392.

## Test plan

- [ ] Open the dashboard, switch away to another browser tab — verify no network requests to `/api/v1/health` fire while hidden, resume on return
- [ ] Open the pageviews chart, switch between Top Pages / Devices / Countries tabs — verify only the active tab's chart endpoint is polled every 30 s
- [ ] Verify default tab data loads immediately on first render (initial fetch still fires for all tabs)