### PR TITLE
perf(dashboard-tsr): memoize data-table filter context and handlers

### DIFF
--- a/apps/dashboard-tsr/src/components/data-table/data-table.tsx
+++ b/apps/dashboard-tsr/src/components/data-table/data-table.tsx
@@ -324,8 +324,11 @@ export function DataTable<
   const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({})
 
   // Column ordering for drag-and-drop reordering (with optional localStorage persistence)
-  const getStorageKey = () =>
-    `data-table-column-order-${columnOrderStorageKey || queryConfig.name}`
+  const getStorageKey = useCallback(
+    () =>
+      `data-table-column-order-${columnOrderStorageKey || queryConfig.name}`,
+    [columnOrderStorageKey, queryConfig.name]
+  )
   const initialColumnOrder = (() => {
     if (resolvedEnableColumnReordering && typeof window !== 'undefined') {
       try {
@@ -343,29 +346,32 @@ export function DataTable<
 
   // Persist column order to localStorage when it changes
   // This handles both direct values and updater functions from TanStack Table
-  const handleColumnOrderChange = (
-    updaterOrValue:
-      | ColumnOrderState
-      | ((old: ColumnOrderState) => ColumnOrderState)
-  ) => {
-    // Update both React state and TanStack Table's state
-    setColumnOrder(updaterOrValue)
+  const handleColumnOrderChange = useCallback(
+    (
+      updaterOrValue:
+        | ColumnOrderState
+        | ((old: ColumnOrderState) => ColumnOrderState)
+    ) => {
+      // Update both React state and TanStack Table's state
+      setColumnOrder(updaterOrValue)
 
-    // Save to localStorage
-    if (resolvedEnableColumnReordering && typeof window !== 'undefined') {
-      const newOrder =
-        typeof updaterOrValue === 'function'
-          ? (updaterOrValue as (old: ColumnOrderState) => ColumnOrderState)(
-              columnOrder
-            )
-          : updaterOrValue
-      try {
-        localStorage.setItem(getStorageKey(), JSON.stringify(newOrder))
-      } catch {
-        // Ignore localStorage errors
+      // Save to localStorage
+      if (resolvedEnableColumnReordering && typeof window !== 'undefined') {
+        const newOrder =
+          typeof updaterOrValue === 'function'
+            ? (updaterOrValue as (old: ColumnOrderState) => ColumnOrderState)(
+                columnOrder
+              )
+            : updaterOrValue
+        try {
+          localStorage.setItem(getStorageKey(), JSON.stringify(newOrder))
+        } catch {
+          // Ignore localStorage errors
+        }
       }
-    }
-  }
+    },
+    [columnOrder, resolvedEnableColumnReordering, getStorageKey]
+  )
 
   // Row selection state
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})

--- a/apps/dashboard-tsr/src/components/data-table/data-table.tsx
+++ b/apps/dashboard-tsr/src/components/data-table/data-table.tsx
@@ -19,7 +19,7 @@ import type { ChartQueryParams } from '@/types/chart-data'
 import type { ExpandableConfig, QueryConfig } from '@/types/query-config'
 
 import { arrayMove } from '@dnd-kit/sortable'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import {
   buildExpandColumnDef,
   EXPAND_COLUMN_ID,
@@ -276,16 +276,26 @@ export function DataTable<
   const { getActiveFilter, setFilter, clearFilter } = useColumnFilterState(
     queryConfig.filterSchema
   )
-  const schemaFilterContext = ((): SchemaColumnFilterContext | undefined =>
-    queryConfig.filterSchema && queryConfig.columnFilters
-      ? {
-          schema: queryConfig.filterSchema,
-          configName: queryConfig.name,
-          getActiveFilter,
-          setFilter,
-          clearFilter,
-        }
-      : undefined)()
+  const schemaFilterContext = useMemo(
+    (): SchemaColumnFilterContext | undefined =>
+      queryConfig.filterSchema && queryConfig.columnFilters
+        ? {
+            schema: queryConfig.filterSchema,
+            configName: queryConfig.name,
+            getActiveFilter,
+            setFilter,
+            clearFilter,
+          }
+        : undefined,
+    [
+      queryConfig.filterSchema,
+      queryConfig.columnFilters,
+      queryConfig.name,
+      getActiveFilter,
+      setFilter,
+      clearFilter,
+    ]
+  )
 
   // Column calculations and definitions
   const { columnDefs } = useTableColumns<TData, TValue>({
@@ -570,37 +580,44 @@ export function DataTable<
   const { autoFitColumn } = useAutoFitColumns<TData>(tableContainerRef)
 
   // Handle auto-fit request for a specific column
-  const handleAutoFit = (columnId: string) => {
-    const column = table.getColumn(columnId)
-    if (!column) return
+  const handleAutoFit = useCallback(
+    (columnId: string) => {
+      const column = table.getColumn(columnId)
+      if (!column) return
 
-    const headerText = column.columnDef.header as string
-    autoFitColumn(column, rows, headerText)
-  }
+      const headerText = column.columnDef.header as string
+      autoFitColumn(column, rows, headerText)
+    },
+    [table, rows, autoFitColumn]
+  )
 
   // Handle drag end event for column reordering
   // This is called by table-header when columns are reordered via drag-and-drop
-  const handleDragEndColumnReorder = (activeId: string, overId: string) => {
-    const currentOrder = table.getState().columnOrder
+  const handleDragEndColumnReorder = useCallback(
+    (activeId: string, overId: string) => {
+      const currentOrder = table.getState().columnOrder
 
-    // Get ALL columns from the table (not just sortable ones)
-    const allColumnIds = table.getAllLeafColumns().map((col) => col.id)
+      // Get ALL columns from the table (not just sortable ones)
+      const allColumnIds = table.getAllLeafColumns().map((col) => col.id)
 
-    // Use currentOrder if it has values, otherwise use all columns in natural order
-    const effectiveOrder = currentOrder.length > 0 ? currentOrder : allColumnIds
+      // Use currentOrder if it has values, otherwise use all columns in natural order
+      const effectiveOrder =
+        currentOrder.length > 0 ? currentOrder : allColumnIds
 
-    const oldIndex = effectiveOrder.indexOf(activeId)
-    const newIndex = effectiveOrder.indexOf(overId)
+      const oldIndex = effectiveOrder.indexOf(activeId)
+      const newIndex = effectiveOrder.indexOf(overId)
 
-    if (oldIndex !== -1 && newIndex !== -1) {
-      // Reorder ALL columns, not just the sortable ones
-      const newOrder = arrayMove(effectiveOrder, oldIndex, newIndex)
-      handleColumnOrderChange(newOrder)
-    }
-  }
+      if (oldIndex !== -1 && newIndex !== -1) {
+        // Reorder ALL columns, not just the sortable ones
+        const newOrder = arrayMove(effectiveOrder, oldIndex, newIndex)
+        handleColumnOrderChange(newOrder)
+      }
+    },
+    [table, handleColumnOrderChange]
+  )
 
   // Reset column order to default (empty array means use natural order)
-  const handleResetColumnOrder = () => {
+  const handleResetColumnOrder = useCallback(() => {
     handleColumnOrderChange([])
     if (resolvedEnableColumnReordering && typeof window !== 'undefined') {
       try {
@@ -609,7 +626,7 @@ export function DataTable<
         // Ignore localStorage errors
       }
     }
-  }
+  }, [handleColumnOrderChange, resolvedEnableColumnReordering, getStorageKey])
 
   return (
     <TableDensityProvider value={{ cellClassName, density }}>


### PR DESCRIPTION
## Summary

- **Fix 1**: `schemaFilterContext` was rebuilt by a bare IIFE on every render, causing `getColumnDefs` (O(rows×cols)) to re-run on every sort/expand/resize via its `useMemo` dep in `use-table-columns.ts`. Wrapped in `useMemo` with deps `[queryConfig.filterSchema, queryConfig.columnFilters, queryConfig.name, getActiveFilter, setFilter, clearFilter]`.

- **Fix 2**: `handleAutoFit`, `handleDragEndColumnReorder`, and `handleResetColumnOrder` were plain arrow functions passed to `memo()`-wrapped `DataTableContent` and `DataTableHeader`, busting their memoization on every render. Wrapped in `useCallback` with correct deps. Also stabilized `getStorageKey` and `handleColumnOrderChange` with `useCallback` to complete the dep chain.

Part of epic #1392 perf work.

## Test plan

- [ ] CI passes
- [ ] Table sorting/resizing/expanding should not re-trigger column recalculation
- [ ] Column drag-and-drop reordering still works
- [ ] Column auto-fit still works
- [ ] Reset column order still works and removes localStorage entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal performance and stability of the data table component through optimized callback handling. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->