### PR TITLE
refactor(api): cache headers, parallel queries, and shared validators in dashboard-tsr

### DIFF
--- a/apps/dashboard-tsr/src/routes/api/v1/config.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/config.ts
@@ -218,7 +218,13 @@ export const Route = createFileRoute('/api/v1/config')({
       GET: async () => {
         try {
           const config = getPublicFeaturePermissionConfig()
-          return Response.json(config)
+          // Env-derived feature flags, principal always anonymous — cache at edge.
+          return Response.json(config, {
+            headers: {
+              'Cache-Control':
+                'public, s-maxage=300, stale-while-revalidate=300',
+            },
+          })
         } catch (err) {
           return Response.json(
             {

--- a/apps/dashboard-tsr/src/routes/api/v1/data.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/data.ts
@@ -13,37 +13,42 @@
  * Ported from apps/dashboard/app/api/v1/data/route.ts.
  * - Per-route feature-permission auth (authorizeFeatureRequest) is DROPPED:
  *   it is centralized in middleware (#1397), matching merged charts/tables routes.
- * - The shared @/lib/api/error-handler / response-builder / status-code-mapper /
- *   validators modules are not yet ported into this app, so their behavior is
- *   inlined below (response shapes and validation logic are identical).
+ * - Error handling and request validation reuse the shared
+ *   @/lib/api/error-handler and @/lib/api/shared/validators modules. Only the
+ *   route-specific success-response builder and the FetchDataError→status
+ *   mapping (handleQueryError) remain local.
  */
 
 import { createFileRoute } from '@tanstack/react-router'
 import type { DataFormat } from '@clickhouse/client'
 
 import type { FetchDataError } from '@chm/clickhouse-client'
-import type { ApiError, ApiRequest, ApiResponse } from '@/lib/api/types'
+import type { ApiRequest, ApiResponse } from '@/lib/api/types'
 
 import { env } from 'cloudflare:workers'
 import { fetchData } from '@chm/clickhouse-client'
 import { debug, error } from '@chm/logger'
 import { validateSqlQuery } from '@chm/sql-builder'
 import { validateDashboardQuery } from '@/lib/api/data/dashboard-query-validator'
+import {
+  createErrorResponse as createApiErrorResponse,
+  createValidationError,
+  getStatusCodeForErrorType as mapErrorTypeToStatusCode,
+  withApiHandler,
+} from '@/lib/api/error-handler'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import {
+  getAndValidateHostId,
+  validateDataRequest,
+  validateSearchParams,
+} from '@/lib/api/shared/validators'
 import { getTableConfig } from '@/lib/api/table-registry'
 import { ApiErrorType } from '@/lib/api/types'
 
 const ROUTE_CONTEXT = { route: '/api/v1/data' } as const
 
-interface RouteContext {
-  readonly route?: string
-  readonly method?: string
-  readonly hostId?: number | string
-}
-
 // ---------------------------------------------------------------------------
-// Inlined response builders (mirror @/lib/api/shared/response-builder and
-// @/lib/api/error-handler — identical response shapes).
+// Route-specific success response builder.
 // ---------------------------------------------------------------------------
 
 const SUCCESS_CACHE_HEADERS = {
@@ -65,9 +70,9 @@ function createSuccessResponse<T>(
     success: true,
     data,
     metadata: {
-      queryId: meta?.queryId ? String(meta.queryId) : '',
-      duration: meta?.duration ? Number(meta.duration) : 0,
-      rows: meta?.rows ? Number(meta.rows) : 0,
+      queryId: meta?.queryId != null ? String(meta.queryId) : '',
+      duration: meta?.duration != null ? Number(meta.duration) : 0,
+      rows: meta?.rows != null ? Number(meta.rows) : 0,
       host: '',
       ...(meta?.sql && { sql: String(meta.sql) }),
       ...(meta?.timezone && { timezone: String(meta.timezone) }),
@@ -81,262 +86,6 @@ function createSuccessResponse<T>(
       ...SUCCESS_CACHE_HEADERS,
     },
   })
-}
-
-function createApiErrorResponse(
-  apiError:
-    | ApiError
-    | { type: ApiErrorType; message: string; details?: ApiError['details'] },
-  status: number,
-  context?: RouteContext
-): Response {
-  const response: ApiResponse = {
-    success: false,
-    metadata: {
-      queryId: '',
-      duration: 0,
-      rows: 0,
-      host: String(context?.hostId || 'unknown'),
-    },
-    error: apiError,
-  }
-
-  return Response.json(response, {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
-}
-
-function createValidationError(
-  message: string,
-  context?: RouteContext
-): Response {
-  return createApiErrorResponse(
-    { type: ApiErrorType.ValidationError, message },
-    400,
-    context
-  )
-}
-
-const ERROR_TYPE_STATUS_MAP: Readonly<Record<ApiErrorType, number>> = {
-  [ApiErrorType.ValidationError]: 400,
-  [ApiErrorType.PermissionError]: 403,
-  [ApiErrorType.TableNotFound]: 404,
-  [ApiErrorType.NetworkError]: 503,
-  [ApiErrorType.QueryError]: 500,
-  [ApiErrorType.SslError]: 503,
-  [ApiErrorType.TimeoutError]: 504,
-}
-
-function mapErrorTypeToStatusCode(errorType: ApiErrorType): number {
-  return ERROR_TYPE_STATUS_MAP[errorType] ?? 500
-}
-
-// ---------------------------------------------------------------------------
-// Inlined validators (mirror @/lib/api/shared/validators).
-// ---------------------------------------------------------------------------
-
-function validateSearchParams(
-  searchParams: URLSearchParams,
-  requiredParams: string[]
-): ApiError | undefined {
-  for (const param of requiredParams) {
-    const value = searchParams.get(param)
-    if (!value || value.trim() === '') {
-      return {
-        type: ApiErrorType.ValidationError,
-        message: `Missing required parameter: ${param}`,
-      }
-    }
-  }
-  return undefined
-}
-
-function getAndValidateHostId(
-  searchParams: URLSearchParams
-): number | ApiError {
-  const hostId = searchParams.get('hostId')
-  if (!hostId) {
-    return {
-      type: ApiErrorType.ValidationError,
-      message: 'Missing required parameter: hostId',
-    }
-  }
-
-  const parsed = Number.parseInt(hostId, 10)
-  if (Number.isNaN(parsed) || parsed < 0) {
-    return {
-      type: ApiErrorType.ValidationError,
-      message: 'Invalid hostId: must be a non-negative number',
-    }
-  }
-  return parsed
-}
-
-const SUPPORTED_FORMATS = ['JSONEachRow', 'JSON', 'CSV', 'TSV'] as const
-
-function validateFormat(format: unknown): ApiError | undefined {
-  if (format === undefined || format === null) return undefined
-  if (typeof format !== 'string') {
-    return {
-      type: ApiErrorType.ValidationError,
-      message:
-        'Invalid format: must be a string. Supported formats: JSONEachRow, JSON, CSV, TSV',
-    }
-  }
-  if (
-    !SUPPORTED_FORMATS.includes(format as (typeof SUPPORTED_FORMATS)[number])
-  ) {
-    return {
-      type: ApiErrorType.ValidationError,
-      message: 'Invalid format. Supported formats: JSONEachRow, JSON, CSV, TSV',
-    }
-  }
-  return undefined
-}
-
-function validateHostIdWithError(hostId: unknown): ApiError | undefined {
-  if (hostId === undefined || hostId === null || hostId === '') {
-    return {
-      type: ApiErrorType.ValidationError,
-      message: 'Missing required field: hostId',
-    }
-  }
-
-  const parsed =
-    typeof hostId === 'number'
-      ? hostId
-      : typeof hostId === 'string'
-        ? Number.parseInt(hostId, 10)
-        : Number.NaN
-
-  if (Number.isNaN(parsed) || parsed < 0) {
-    return {
-      type: ApiErrorType.ValidationError,
-      message: 'Invalid hostId: must be a non-negative number',
-    }
-  }
-  return undefined
-}
-
-function validateRequiredString(
-  value: unknown,
-  fieldName: string
-): ApiError | undefined {
-  if (typeof value !== 'string' || value.trim() === '') {
-    return {
-      type: ApiErrorType.ValidationError,
-      message: `Missing required field: ${fieldName}`,
-    }
-  }
-  return undefined
-}
-
-function validateDataRequest(body: Partial<ApiRequest>): ApiError | undefined {
-  const queryError = validateRequiredString(body.query, 'query')
-  if (queryError) return queryError
-
-  const hostIdError = validateHostIdWithError(body.hostId)
-  if (hostIdError) return hostIdError
-
-  const formatError = validateFormat(body.format)
-  if (formatError) return formatError
-
-  return undefined
-}
-
-// ---------------------------------------------------------------------------
-// Inlined error classifier (mirror @/lib/api/error-handler/error-classifier).
-// ---------------------------------------------------------------------------
-
-function classifyError(err: unknown): { type: ApiErrorType; message: string } {
-  const message =
-    err instanceof Error
-      ? err.message
-      : typeof err === 'string'
-        ? err
-        : 'An unexpected error occurred'
-  const normalized = message.toLowerCase()
-
-  if (
-    normalized.includes('table') &&
-    (normalized.includes('not found') ||
-      normalized.includes("doesn't exist") ||
-      normalized.includes('does not exist') ||
-      normalized.includes('missing'))
-  ) {
-    return { type: ApiErrorType.TableNotFound, message }
-  }
-
-  const patterns: Array<{ type: ApiErrorType; keywords: string[] }> = [
-    {
-      type: ApiErrorType.PermissionError,
-      keywords: ['permission', 'access denied', 'unauthorized', 'forbidden'],
-    },
-    {
-      type: ApiErrorType.NetworkError,
-      keywords: [
-        'network',
-        'connection',
-        'econnrefused',
-        'enotfound',
-        'connect failed',
-      ],
-    },
-    {
-      type: ApiErrorType.TimeoutError,
-      keywords: ['timeout', 'etimedout', 'socket timeout'],
-    },
-    {
-      type: ApiErrorType.SslError,
-      keywords: ['ssl', 'tls', 'certificate', 'handshake', '525', '526'],
-    },
-    {
-      type: ApiErrorType.ValidationError,
-      keywords: [
-        'invalid',
-        'missing',
-        'required',
-        'malformed',
-        'syntax error',
-        'parse error',
-      ],
-    },
-  ]
-
-  for (const { type, keywords } of patterns) {
-    if (keywords.some((kw) => normalized.includes(kw))) {
-      return { type, message }
-    }
-  }
-
-  return { type: ApiErrorType.QueryError, message }
-}
-
-/**
- * Wrap a handler so uncaught errors are classified into a standardized
- * error response (mirror @/lib/api/error-handler withApiHandler).
- */
-function withApiHandler(
-  handler: (request: Request) => Promise<Response>,
-  context?: RouteContext
-): (request: Request) => Promise<Response> {
-  return async (request: Request): Promise<Response> => {
-    try {
-      return await handler(request)
-    } catch (err) {
-      const { type, message } = classifyError(err)
-      return createApiErrorResponse(
-        {
-          type,
-          message,
-          details: { timestamp: new Date().toISOString() },
-        },
-        mapErrorTypeToStatusCode(type),
-        context
-      )
-    }
-  }
 }
 
 /**

--- a/apps/dashboard-tsr/src/routes/api/v1/hosts.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/hosts.ts
@@ -68,7 +68,16 @@ export const Route = createFileRoute('/api/v1/hosts')({
           )
         }
 
-        return Response.json({ success: true, data: hosts })
+        // Host list is env-derived and constant per deploy — cache at the edge.
+        return Response.json(
+          { success: true, data: hosts },
+          {
+            headers: {
+              'Cache-Control':
+                'public, s-maxage=300, stale-while-revalidate=300',
+            },
+          }
+        )
       },
     },
   },

--- a/apps/dashboard-tsr/src/routes/api/v1/notifications.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/notifications.ts
@@ -90,40 +90,50 @@ export const Route = createFileRoute('/api/v1/notifications')({
             cluster: string
           }>
 
-          // Step 2: for each cluster check readonly replica count
-          const notifications: Notification[] = []
-
-          for (const { cluster } of clusters) {
-            try {
-              const readonlyResult = await client.query({
-                query: `
+          // Step 2: for each cluster check readonly replica count.
+          // Clusters are independent — fan out concurrently. Each query is
+          // best-effort: a failing cluster yields null and is skipped, so one
+          // failure never rejects the whole batch. Result order matches the
+          // cluster order (Promise.all preserves input order).
+          const perCluster = await Promise.all(
+            clusters.map(async ({ cluster }) => {
+              try {
+                const readonlyResult = await client.query({
+                  query: `
                   SELECT COUNT() as count
                   FROM clusterAllReplicas({cluster: String}, system.replicas)
                   WHERE is_readonly = 1
                 `,
-                format: 'JSONEachRow',
-                query_params: { cluster },
-              })
-              const readonlyData = (await readonlyResult.json()) as Array<{
-                count?: number | string
-              }>
-              const readonlyCount =
-                readonlyData.length > 0 && readonlyData[0].count !== undefined
-                  ? Number(readonlyData[0].count)
-                  : 0
-
-              if (readonlyCount > 0) {
-                notifications.push({
-                  type: 'readonly-tables',
-                  cluster,
-                  count: readonlyCount,
-                  severity: readonlyCount > 10 ? 'critical' : 'warning',
+                  format: 'JSONEachRow',
+                  query_params: { cluster },
                 })
+                const readonlyData = (await readonlyResult.json()) as Array<{
+                  count?: number | string
+                }>
+                const readonlyCount =
+                  readonlyData.length > 0 && readonlyData[0].count !== undefined
+                    ? Number(readonlyData[0].count)
+                    : 0
+
+                if (readonlyCount > 0) {
+                  return {
+                    type: 'readonly-tables',
+                    cluster,
+                    count: readonlyCount,
+                    severity: readonlyCount > 10 ? 'critical' : 'warning',
+                  } satisfies Notification
+                }
+                return null
+              } catch {
+                // Skip clusters that don't support this query
+                return null
               }
-            } catch {
-              // Skip clusters that don't support this query
-            }
-          }
+            })
+          )
+
+          const notifications: Notification[] = perCluster.filter(
+            (n): n is Notification => n !== null
+          )
 
           const totalCount = notifications.length
           const body = {

--- a/apps/dashboard-tsr/src/routes/api/v1/overview.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/overview.ts
@@ -51,8 +51,9 @@ export const Route = createFileRoute('/api/v1/overview')({
         }
 
         try {
-          // Single batch query returning all overview metrics
-          const result = await fetchData({
+          // The metrics batch query and the host-info query are independent —
+          // kick both off concurrently and await together.
+          const metricsPromise = fetchData({
             query: `
               -- Running queries count
               SELECT 'running_queries' as metric, COUNT() as value, COUNT() as value_num
@@ -100,6 +101,23 @@ export const Route = createFileRoute('/api/v1/overview')({
             format: 'JSONEachRow',
           })
 
+          // Fetch host info separately (different return shape)
+          const hostPromise = fetchData({
+            query: `
+              SELECT
+                version() as version,
+                formatReadableTimeDelta(uptime()) as uptime,
+                hostName() as hostname
+            `,
+            hostId,
+            format: 'JSONEachRow',
+          })
+
+          const [result, hostResult] = await Promise.all([
+            metricsPromise,
+            hostPromise,
+          ])
+
           if (result.error || !result.data) {
             error('[GET /api/v1/overview] Query error:', result.error)
             return Response.json(
@@ -121,18 +139,6 @@ export const Route = createFileRoute('/api/v1/overview')({
           for (const row of metrics) {
             overviewData[row.metric] = row.value_num
           }
-
-          // Fetch host info separately (different return shape)
-          const hostResult = await fetchData({
-            query: `
-              SELECT
-                version() as version,
-                formatReadableTimeDelta(uptime()) as uptime,
-                hostName() as hostname
-            `,
-            hostId,
-            format: 'JSONEachRow',
-          })
 
           const hostInfo = (
             hostResult.data as Array<{

--- a/apps/dashboard-tsr/src/routes/api/v1/table-availability.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/table-availability.ts
@@ -167,7 +167,8 @@ export const Route = createFileRoute('/api/v1/table-availability')({
 
           const headers = new Headers(response.headers)
           headers.set('X-Request-ID', requestId)
-          headers.set('Cache-Control', CacheControl.NONE)
+          // Table existence is slow-changing and anonymous — short edge cache.
+          headers.set('Cache-Control', CacheControl.MEDIUM)
 
           return new Response(response.body, {
             status: response.status,


### PR DESCRIPTION
Part of the epic #1392 code-review follow-ups. Hardens the `apps/dashboard-tsr/src/routes/api/v1/**` API routes. All changes are confined to that directory.

## Changes

**1. Edge cache headers** (anonymous, per-deploy-constant or slow-changing data)
- `hosts.ts` — env-derived host list → `Cache-Control: public, s-maxage=300, stale-while-revalidate=300`
- `config.ts` — env-derived feature flags, principal hardcoded `anonymous` → same 5-min edge cache
- `table-availability.ts` — was `CacheControl.NONE` (private, max-age=0) on slow-changing table-existence data → now `CacheControl.MEDIUM` (`public, s-maxage=60, stale-while-revalidate=120`)
- `overview.ts` left **uncached** (live metrics — correct to stay uncached)

**2. Parallelize independent ClickHouse queries**
- `overview.ts` — the metrics batch query and the version/uptime/hostName query have no data dependency but ran serially. Now kicked off together and awaited via `Promise.all`. Error handling and response shape unchanged.
- `notifications.ts` — per-cluster readonly-replica checks ran in a serial `for` loop (one `clusterAllReplicas` round-trip per cluster). Now fanned out with `Promise.all`. Each query stays best-effort (a failing cluster yields `null` and is filtered out — one failure never rejects the batch), and result order is preserved.

**3. Shared validator / response-builder dedup**
- `data.ts` — replaced ~290 lines of inlined error-handling and validation with imports from the shared modules:
  - `@/lib/api/error-handler`: `withApiHandler`, `createErrorResponse`, `createValidationError`, `getStatusCodeForErrorType` (verified drop-in: identical status map + classification order; sibling routes like `conversations.ts` already import these)
  - `@/lib/api/shared/validators`: `getAndValidateHostId`, `validateDataRequest`, `validateSearchParams` (byte-for-byte identical logic to the inlined copies)
  - **Fixed the falsy-zero bug**: the local success builder used `meta?.rows ? Number(meta.rows) : 0`, which coerced a legitimate `0` row count / duration to `0` via a truthy check (masking e.g. `rows: 0` vs missing). Now uses `!= null`.
  - Kept the route-specific `createSuccessResponse` (custom 30s cache header) and `handleQueryError` (`FetchDataError['type']` → status mapping) local — these have no exact shared equivalent. `handleQueryError` now routes through the shared `createErrorResponse` + `getStatusCodeForErrorType`.

## Skipped (intentional — noted for reviewers)
- **`createSuccessResponse` not migrated to the shared response-builder.** The shared `createSuccessResponse` (`response-builder.ts`) has the **same** `meta?.rows ? … : 0` falsy-zero pattern, so importing it would NOT fix the bug. Kept `data.ts`'s own (now-fixed) success builder instead. The shared builder could be fixed separately, but it lives in `lib/` (outside this PR's `routes/` scope).
- **`explorer/projections.ts`, `explorer/skip-indexes.ts`, `explorer/preview.ts`, `actions.ts` hostId validation NOT migrated** to shared `getAndValidateHostId`. Those routes validate with `Number.isFinite` (accepts negative / non-integer hostIds), emit a different error message (`Invalid hostId: <raw>`) and a different response shape than `getAndValidateHostId` (`parseInt` + reject `< 0` + `must be a non-negative number`). Swapping in the shared validator would change validation semantics and error output — left as-is to prioritize not breaking routes over maximal dedup.

Co-Authored-By: duyetbot <bot@duyet.net>