### PR TITLE
fix(dashboard-tsr): auth=none opens everything; frontend renders, backend enforces

### DIFF
--- a/apps/dashboard-tsr/src/components/feature-permissions/feature-route-gate.tsx
+++ b/apps/dashboard-tsr/src/components/feature-permissions/feature-route-gate.tsx
@@ -20,18 +20,12 @@ export function FeatureRouteGate({ children }: { children: ReactNode }) {
     return children
   }
 
+  // The frontend renders every enabled feature in every auth mode; access
+  // (public vs authenticated) is enforced by the backend, not here — see
+  // isFeatureAllowed and lib/feature-permissions/server.ts (the single security
+  // boundary). So the only route-level gate is the `enabled` deployment toggle.
   if (!state.enabled) {
     return <FeatureUnavailable feature={permission.feature} reason="disabled" />
-  }
-
-  if (
-    state.access === 'authenticated' &&
-    config.principal !== 'authenticated'
-  ) {
-    // Interaction-gated features (e.g. the agent) render their UI for everyone
-    // and prompt for sign-in only when an auth-requiring action is attempted.
-    if (permission.interactionGated) return children
-    return <FeatureUnavailable feature={permission.feature} reason="auth" />
   }
 
   return children

--- a/apps/dashboard-tsr/src/components/host/first-run-gate.tsx
+++ b/apps/dashboard-tsr/src/components/host/first-run-gate.tsx
@@ -1,26 +1,28 @@
 import { FirstRunEmptyState } from './first-run-empty-state'
-import { FirstRunUnauthorizedState } from './first-run-unauthorized-state'
 import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
 
 /**
- * Gates the dashboard content on having at least one configured ClickHouse
- * host. Two first-run surfaces replace the bare, confusing default:
+ * The frontend is a pure rendering layer; the backend is the security boundary
+ * (see lib/feature-permissions/server.ts). So this gate no longer walls the whole
+ * app behind an "Authentication required" screen on a 401/403 — that is not
+ * something the visitor can resolve here, in `none` mode there is no sign-in at
+ * all, and the workerd server can't tell an authenticated principal apart anyway.
+ * Pages render; individual data calls surface their own auth / empty / error
+ * states (and in `none` mode the API allows everything, so they just succeed).
  *
- *  - unauthorized (hosts fetch 401/403) → prompt to sign in
- *  - zero hosts configured (env + browser) → onboarding EmptyState
+ * The one first-run surface we keep is genuine onboarding: zero ClickHouse hosts
+ * configured — and only when that is the real state, not merely an auth failure
+ * that left the host list empty. While hosts are still loading we render children
+ * so existing skeletons / Suspense fallbacks keep showing.
  *
- * While hosts are still loading we render children so existing skeletons /
- * Suspense fallbacks keep showing — we only swap in onboarding once we are
- * certain about the state.
+ * NOTE: `FirstRunUnauthorizedState` is intentionally no longer rendered here. The
+ * component is kept for a possible future inline sign-in prompt rather than a
+ * full-page wall.
  */
 export function FirstRunGate({ children }: { children: React.ReactNode }) {
   const { hosts, isLoading, isUnauthorized } = useMergedHosts()
 
-  if (!isLoading && isUnauthorized) {
-    return <FirstRunUnauthorizedState />
-  }
-
-  if (!isLoading && hosts.length === 0) {
+  if (!isLoading && !isUnauthorized && hosts.length === 0) {
     return <FirstRunEmptyState />
   }
 

--- a/apps/dashboard-tsr/src/components/layout/query-page/layout.tsx
+++ b/apps/dashboard-tsr/src/components/layout/query-page/layout.tsx
@@ -78,28 +78,16 @@ export const QueryPageLayout = function QueryPageLayout({
   const hasCharts = relatedCharts.length > 0
   const featureState = resolveFeatureState(queryConfig.permission, config)
 
-  if (queryConfig.permission) {
-    if (!isLoading && !featureState.enabled) {
-      return (
-        <FeatureUnavailable
-          feature={queryConfig.permission.feature}
-          reason="disabled"
-        />
-      )
-    }
-
-    if (
-      !isLoading &&
-      featureState.access === 'authenticated' &&
-      config.principal !== 'authenticated'
-    ) {
-      return (
-        <FeatureUnavailable
-          feature={queryConfig.permission.feature}
-          reason="auth"
-        />
-      )
-    }
+  // Only the `enabled` deployment toggle gates rendering here. Access (public vs
+  // authenticated) is enforced by the backend, not the client — see
+  // lib/feature-permissions/server.ts (the single security boundary).
+  if (queryConfig.permission && !isLoading && !featureState.enabled) {
+    return (
+      <FeatureUnavailable
+        feature={queryConfig.permission.feature}
+        reason="disabled"
+      />
+    )
   }
 
   return (

--- a/apps/dashboard-tsr/src/lib/feature-permissions/__tests__/shared.test.ts
+++ b/apps/dashboard-tsr/src/lib/feature-permissions/__tests__/shared.test.ts
@@ -70,17 +70,13 @@ describe('isFeatureAllowed — access is a backend concern (FE renders all enabl
   })
 })
 
-describe('isFeatureAllowed — interactionGated (regression: agent menu)', () => {
-  const agentPerm: FeaturePermission = {
-    feature: 'agent',
-    interactionGated: true,
-  }
+describe('isFeatureAllowed — agent menu visible across deploy postures', () => {
+  const agentPerm: FeaturePermission = { feature: 'agent' }
 
-  // The bug: a fully-static workerd deploy can never report
-  // principal:'authenticated' (no server-side Clerk auth()), so /api/v1/config
-  // always returns 'anonymous'. The agent menu item is interaction-gated and
-  // MUST stay visible for everyone — the send action gates, not the route.
-  // Each row is a deploy posture the agent menu must survive.
+  // Regression: a static workerd deploy can never report principal:'authenticated'
+  // (no server-side Clerk auth()), so /api/v1/config always returns 'anonymous'.
+  // The agent menu must stay visible in every posture — the backend enforces auth
+  // on send, not the client route. Each row is a deploy posture it must survive.
   test.each([
     ['no auth provider, anonymous', 'none', 'anonymous'],
     ['clerk active, anonymous (workerd hard-anonymous)', 'clerk', 'anonymous'],
@@ -99,7 +95,7 @@ describe('isFeatureAllowed — interactionGated (regression: agent menu)', () =>
     ).toBe(true)
   })
 
-  test('interactionGated still hidden when the feature is disabled', () => {
+  test('hidden only when the feature is disabled', () => {
     expect(
       isFeatureAllowed(
         agentPerm,
@@ -109,19 +105,6 @@ describe('isFeatureAllowed — interactionGated (regression: agent menu)', () =>
         })
       )
     ).toBe(false)
-  })
-
-  test('interactionGated wins over access:authenticated (always visible)', () => {
-    expect(
-      isFeatureAllowed(
-        agentPerm,
-        config({
-          authProvider: 'clerk',
-          principal: 'anonymous',
-          features: { agent: { access: 'authenticated' } },
-        })
-      )
-    ).toBe(true)
   })
 })
 

--- a/apps/dashboard-tsr/src/lib/feature-permissions/__tests__/shared.test.ts
+++ b/apps/dashboard-tsr/src/lib/feature-permissions/__tests__/shared.test.ts
@@ -29,33 +29,44 @@ describe('isFeatureAllowed — defaults', () => {
   })
 })
 
-describe('isFeatureAllowed — access: authenticated', () => {
+describe('isFeatureAllowed — access is a backend concern (FE renders all enabled)', () => {
   const perm: FeaturePermission = { feature: 'agent' }
 
-  test('anonymous principal → not allowed', () => {
+  // The frontend is a pure rendering layer: it no longer gates on access or
+  // principal. Every ENABLED feature renders in every auth mode, and the backend
+  // (server.ts authorizeFeatureRequest) is the single security boundary — it 401s
+  // protected data/actions. So an `authenticated` feature is visible to everyone
+  // on the client; the page renders and the API call enforces.
+  test.each([
+    ['none, anonymous', 'none', 'anonymous'],
+    ['clerk, anonymous (workerd hard-anonymous)', 'clerk', 'anonymous'],
+    ['clerk, signed in', 'clerk', 'authenticated'],
+    ['proxy, anonymous', 'proxy', 'anonymous'],
+  ] as const)('authenticated feature renders — %s', (_label, authProvider, principal) => {
     expect(
       isFeatureAllowed(
         perm,
         config({
-          authProvider: 'clerk',
-          principal: 'anonymous',
+          authProvider:
+            authProvider as PublicFeaturePermissionConfig['authProvider'],
+          principal: principal as PublicFeaturePermissionConfig['principal'],
           features: { agent: { access: 'authenticated' } },
         })
       )
-    ).toBe(false)
+    ).toBe(true)
   })
 
-  test('authenticated principal → allowed', () => {
+  test('disabled wins over access — hidden even when authenticated', () => {
     expect(
       isFeatureAllowed(
         perm,
         config({
           authProvider: 'clerk',
           principal: 'authenticated',
-          features: { agent: { access: 'authenticated' } },
+          features: { agent: { access: 'authenticated', enabled: false } },
         })
       )
-    ).toBe(true)
+    ).toBe(false)
   })
 })
 

--- a/apps/dashboard-tsr/src/lib/feature-permissions/permissions.ts
+++ b/apps/dashboard-tsr/src/lib/feature-permissions/permissions.ts
@@ -2,7 +2,6 @@ import type { FeaturePermission } from './types'
 
 export const AGENT_FEATURE_PERMISSION = {
   feature: 'agent',
-  interactionGated: true,
 } satisfies FeaturePermission
 
 export const ACTIONS_FEATURE_PERMISSION = {

--- a/apps/dashboard-tsr/src/lib/feature-permissions/server.ts
+++ b/apps/dashboard-tsr/src/lib/feature-permissions/server.ts
@@ -143,6 +143,12 @@ async function isAuthenticatedRequest(
   config: AppConfig,
   options: { allowAgentBearerToken?: boolean } = {}
 ): Promise<boolean> {
+  // Auth disabled (`none`): there is no sign-in, so every request is authorized.
+  // This makes `authenticated`-access features fully open in `none` mode (the
+  // matrix's "everything open" end state). The backend remains the single
+  // security boundary; it simply has nothing to enforce when auth is off.
+  if (config.authProvider === 'none') return true
+
   if (
     options.allowAgentBearerToken &&
     (await isValidAgentApiBearerToken(request))

--- a/apps/dashboard-tsr/src/lib/feature-permissions/shared.ts
+++ b/apps/dashboard-tsr/src/lib/feature-permissions/shared.ts
@@ -83,27 +83,17 @@ export function isFeatureAllowed(
   permission: FeaturePermission | undefined,
   config: PublicFeaturePermissionConfig
 ): boolean {
-  const state = resolveFeatureState(permission, config)
-  if (!state.enabled) return false
-
-  // Interaction-gated features (e.g. the agent) render their UI for everyone
-  // and prompt sign-in only on the action (see AgentAuthGate). They are always
-  // menu-visible regardless of auth provider or principal — that is the whole
-  // point of the flag and matches the menu.ts contract ("Render the chat UI for
-  // everyone; sign-in is prompted on send, not at the route level").
-  //
-  // NOTE: This intentionally takes precedence over the `access: 'authenticated'`
-  // gate below. In a fully static workerd deploy the server cannot run Clerk's
-  // `auth()`, so /api/v1/config always reports `principal: 'anonymous'`; gating
-  // an interaction-gated feature on principal would hide it from signed-in users
-  // too. Server routes still enforce auth on the actual action.
-  if (permission?.interactionGated) return true
-
-  if (state.access === 'authenticated') {
-    return config.principal === 'authenticated'
-  }
-
-  return true
+  // The frontend is a pure rendering layer: it shows every ENABLED feature in
+  // every auth mode. Access enforcement (public vs authenticated) is the backend's
+  // job — see `authorizeFeatureRequest` in lib/feature-permissions/server.ts, the
+  // single security boundary. A client-side access gate would be both redundant
+  // and unreliable: the workerd config endpoint cannot run Clerk's `auth()`, so it
+  // always reports `principal: 'anonymous'`, which would wrongly hide authenticated
+  // features even from signed-in users. So the only thing that hides a feature on
+  // the client is the `enabled` flag (a deployment toggle, not security). Visitors
+  // who lack access still see the page; protected data/actions return 401 from the
+  // API and the UI surfaces an inline sign-in prompt.
+  return resolveFeatureState(permission, config).enabled
 }
 
 export function getResolvedFeatureStates(

--- a/apps/dashboard-tsr/src/lib/feature-permissions/shared.ts
+++ b/apps/dashboard-tsr/src/lib/feature-permissions/shared.ts
@@ -81,7 +81,7 @@ export function resolveFeatureState(
 
 export function isFeatureAllowed(
   permission: FeaturePermission | undefined,
-  config: PublicFeaturePermissionConfig
+  config: Pick<PublicFeaturePermissionConfig, 'features'>
 ): boolean {
   // The frontend is a pure rendering layer: it shows every ENABLED feature in
   // every auth mode. Access enforcement (public vs authenticated) is the backend's

--- a/apps/dashboard-tsr/src/lib/feature-permissions/types.ts
+++ b/apps/dashboard-tsr/src/lib/feature-permissions/types.ts
@@ -33,15 +33,6 @@ export interface FeaturePermission {
    * @default public
    */
   defaultAccess?: FeatureAccess
-  /**
-   * When true, an `authenticated`-only feature is NOT blocked at the route
-   * level for anonymous principals — the page renders and the feature gates
-   * the auth-requiring *interaction* itself (e.g. the agent shows its chat UI
-   * and only prompts for sign-in when the user tries to send a message).
-   *
-   * @default false
-   */
-  interactionGated?: boolean
 }
 
 export interface FeatureOverride {

--- a/apps/dashboard-tsr/src/menu.ts
+++ b/apps/dashboard-tsr/src/menu.ts
@@ -65,9 +65,9 @@ export const menuItemsConfig: MenuItem[] = [
     icon: SparklesIcon,
     section: 'main',
     isNew: true,
-    // Render the chat UI for everyone; sign-in is prompted on send, not at the
-    // route level. See AGENT_FEATURE_PERMISSION / AgentAuthGate.
-    permission: { feature: 'agent', interactionGated: true },
+    // The chat UI renders for everyone; the backend enforces auth on send (see
+    // AgentAuthGate / the /api/v1/agent route), not the client route gate.
+    permission: { feature: 'agent' },
   },
   {
     title: 'Insights',


### PR DESCRIPTION
## Problem

The feature-permission matrix gated **security on the client** and conflated two independent axes, which:
- broke `auth=none` (Guest) mode — every page was walled behind "Authentication required" even though there is no sign-in to perform, and
- was unreliable in workerd — the static config endpoint can't run Clerk's `auth()`, so it always reports `principal: 'anonymous'`, hiding `authenticated` features even from *signed-in* users.

## Model (now)

Two independent axes, in the right place:

| Axis | Meaning | Where enforced |
|---|---|---|
| `enabled` | deployment toggle | client (hide from nav) **and** server (block API), all auth modes |
| `access` (`public`/`authenticated`) | **security** | **backend only**, dynamic from runtime `CHM_AUTH_PROVIDER` |

**Frontend = pure rendering. Backend = single security boundary. Dynamic (runtime), not build-time.**

Across auth modes:
- `none` → auth off → **everything open**: all pages render AND all API calls succeed.
- `clerk`/`proxy` → pages still render; protected **data/actions 401 server-side**, UI shows an inline sign-in prompt.

## Changes

- **`isFeatureAllowed`** collapses to the `enabled` flag — no client-side access/principal gating.
- **`FirstRunGate`** no longer walls the app on 401/403; it renders the dashboard and keeps only genuine zero-host onboarding. (`FirstRunUnauthorizedState` retained for a possible future *inline* prompt.)
- **`isAuthenticatedRequest`** (server): `authProvider === 'none'` ⇒ every request authorized.

## Tests

Updated `shared.test.ts` to encode the new contract (FE renders all enabled; access is a backend concern). **37 pass**, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI Agent feature now displays for all users; authentication is enforced on the backend when sending messages.

* **Improvements**
  * Simplified feature availability logic to streamline access control.
  * First-run experience behavior updated for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->