### PR TITLE
chore(skills): add ui-ux-audit skill (Playwright a11y + visual sweep)

### DIFF
--- a/.claude/skills/ui-ux-audit/.gitignore
+++ b/.claude/skills/ui-ux-audit/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.claude/skills/ui-ux-audit/SKILL.md
+++ b/.claude/skills/ui-ux-audit/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: ui-ux-audit
+description: >-
+  Automated UI/UX + accessibility audit for the ClickHouse Monitor dashboard
+  (apps/dashboard-tsr). Use this whenever the user wants to "test all pages",
+  "audit the dashboard", "find UI/UX issues", "check accessibility / a11y",
+  "spot visual regressions", "screenshot every route", "reproduce a UI bug", or
+  asks to verify the dashboard UI after a change or deploy. It sweeps every
+  dashboard route headlessly, captures console errors + failed network calls,
+  runs axe-core accessibility scans, detects layout overflow and stuck loading
+  skeletons, diffs screenshots against a baseline for visual regression, and
+  emits a runnable repro (trace.zip + script) for each issue so it can be
+  replayed on demand. Runs against the local dev server (auth bypassed) by
+  default, or the live Clerk-protected deployment using the stored test session.
+  Prefer this over ad-hoc one-off Playwright scripts for any multi-page UI check.
+---
+
+# ClickHouse Monitor — UI/UX Audit
+
+This skill drives a real browser over **every dashboard route** and reports the
+UI/UX problems that matter, with a reproducible artifact for each one. It exists
+because the dashboard has ~85 routes; eyeballing them by hand misses regressions
+(a tab-switch freeze, a chart that overflows on one page, an a11y violation that
+only appears in an empty state). A scripted sweep catches the whole class at once.
+
+## When to reach for it
+
+Trigger on requests like "test all the pages", "audit the dashboard UI", "find
+accessibility issues", "did my change break any page", "screenshot every route",
+"check for visual regressions", or "reproduce that UI bug". It is the right tool
+any time the surface under test is *more than one or two pages*.
+
+## Mental model — why two targets
+
+The dashboard is **auth-aware, not auth-walled**: the shell, nav, and most pages
+render for anonymous users; only data calls are gated. That gives two useful
+targets:
+
+- **local** (default): `apps/dashboard-tsr` running with `VITE_AUTH_PROVIDER=none`.
+  Auth is fully bypassed, and `.env.local` points at a real ClickHouse, so you get
+  *data-bearing* states (real charts, tables) with zero login friction. Best for
+  catching structural/a11y/console-error/regression issues. CI-friendly.
+- **live**: `https://dash-tsr.chmonitor.dev`, which runs **pk_live Clerk**. The
+  audit reuses a stored browser session (`~/.config/chmonitor/clerk-state.json`)
+  from the dedicated test account, so it can exercise the *production auth path*
+  and authorized data without logging in each run. Use this to verify prod-only
+  states and post-deploy smoke. (See the `test-account-clerk` memory for how that
+  session was created and refreshed — Clerk's Turnstile means the session must be
+  minted with a **headed** browser; the audit itself runs headless off the cookie.)
+
+## One-time setup
+
+Install the toolchain (Playwright + axe-core + image-diff) outside the repo:
+
+```bash
+bash .claude/skills/ui-ux-audit/scripts/setup.sh
+```
+
+It installs into `~/.config/chmonitor/qa-tools` and downloads Chromium. Idempotent.
+
+## Running an audit
+
+Always run from the tools dir so `playwright` resolves:
+
+```bash
+cd ~/.config/chmonitor/qa-tools
+
+# Local sweep (default) — start the dev server first (see below)
+bun ~/project/clickhouse-monitor/.claude/skills/ui-ux-audit/scripts/audit.mjs --target=local
+
+# Just a couple of routes (fast iteration / reproduction)
+bun .../audit.mjs --target=local --only=/explorer,/sql,/overview
+
+# Live deployment, reusing the Clerk test session
+bun .../audit.mjs --target=live
+
+# Visual regression: pass a previous run's shots/ as the baseline
+bun .../audit.mjs --target=local --baseline=/tmp/chm-ui-audit/local-<prev>/shots
+```
+
+### Local dev server
+
+The **local** target needs the dev server up with auth disabled. `.env.local`
+already sets `VITE_AUTH_PROVIDER=none`. Start it and wait for the port:
+
+```bash
+cd ~/project/clickhouse-monitor/apps/dashboard-tsr && bun run dev
+```
+
+Vite prints the actual URL (usually `http://localhost:3000`). If it differs,
+pass it: `BASE_URL=http://localhost:5173 bun .../audit.mjs`.
+
+### Useful flags
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--target=local\|live` | `local` | which deployment to audit |
+| `--only=/a,/b` | all routes | restrict to specific routes (auto-discovers all otherwise) |
+| `--baseline=<dir>` | none | screenshot dir to diff against for visual regression |
+| `--host=N` | `0` | ClickHouse host id (`?host=`) |
+| `--a11y=off` | on | skip the axe-core accessibility scan |
+| `--settle=ms` | `3500` | wait after load for charts/data to render before checking |
+| `--headed` | off | watch the run in a visible window |
+| `--out=<dir>` | `/tmp/chm-ui-audit/...` | output directory |
+
+## What it checks per route
+
+Routes are **auto-discovered** by scanning `apps/dashboard-tsr/src/routes`
+(TanStack Start file routing — pathless `(group)` dirs, `route.tsx` layouts,
+`-`/`_` private files, and `$param` dynamic routes are handled). For each route:
+
+- **console errors** + uncaught `pageerror` (high) — the tab-switch-freeze class.
+- **failed network calls** (>=400, minus known-noisy ones).
+- **accessibility** via axe-core (WCAG 2 A/AA), reporting only `serious`/`critical`.
+- **horizontal overflow** — page wider than the viewport, with the offending nodes.
+- **stuck skeletons** — loading placeholders still present after settle (dead query).
+- **error states** — "something went wrong" / "is not a constructor" rendered text.
+- **visual regression** — pixel diff vs a baseline screenshot (when provided).
+
+## Output & reproduction
+
+Everything lands in `--out` (printed at the end):
+
+- `report.html` — open this first. Grouped by route, severity-colored, screenshots
+  inline, with the exact repro command per route.
+- `report.json` — machine-readable findings (feed to follow-up automation).
+- `shots/` — full-page screenshot of every route (also the next run's baseline).
+- `diffs/` — visual-regression diff images.
+- `traces/<route>.zip` — Playwright trace for routes **with findings**. Replay the
+  exact session: `bun x playwright show-trace traces/<route>.zip`.
+- `repro/<route>.mjs` — a standalone, headed Playwright script that re-opens the
+  route, prints the console errors, and leaves the browser open 60s to inspect.
+  This is the "reproduce it when needed" artifact — hand it to anyone.
+
+## Interpreting results
+
+- On **local**, some `failed-request` findings can be benign (a ClickHouse table
+  missing on the dev instance). Triage against the route's purpose before filing.
+- `a11y` findings cite the WCAG rule id and a `helpUrl` — fix at the component, not
+  in `components/ui/` (shadcn primitives stay pristine; style at the usage site).
+- Treat **console-error** and **error-state** on a previously-clean route as a real
+  regression — that is exactly the signal that caught the explorer tab-switch crash.
+
+## Refreshing the live session
+
+The live target reuses a **persistent browser profile** at
+`~/.config/chmonitor/clerk-userdata` (it keeps Clerk's full client state, unlike a
+storageState snapshot whose short-lived JWT expires). Populate or refresh it with
+the headed login helper (headed because pk_live Turnstile only auto-passes in a
+real browser window):
+
+```bash
+bun .claude/skills/ui-ux-audit/scripts/live-login.mjs   # HEADLESS=0 by default
+```
+
+It signs the dedicated test account in and writes the profile; `audit.mjs
+--target=live` then runs headless off it. If a verification code is required, it is
+emailed to `duyet.cs@gmail.com` (plus-addressed) — read it via the Gmail MCP and
+write the 6 digits to `/tmp/chm-otp.txt`; the helper polls that file. Full account
+details live in the `test-account-clerk` memory note.
+
+> Note: on a deployment where the client is built with `VITE_AUTH_PROVIDER=none`
+> (no Clerk mounted client-side), there is no in-app sign-in and the live target is
+> audited as an anonymous Guest — structure/a11y/visual coverage only, data calls
+> may 401 depending on the server's `CHM_AUTH_PROVIDER`.

--- a/.claude/skills/ui-ux-audit/scripts/audit.mjs
+++ b/.claude/skills/ui-ux-audit/scripts/audit.mjs
@@ -1,0 +1,371 @@
+#!/usr/bin/env bun
+/**
+ * UI/UX audit runner for the ClickHouse Monitor dashboard (dashboard-tsr).
+ *
+ * For every dashboard route it: navigates, waits for data/skeletons to settle,
+ * captures console errors + failed network calls, runs an axe-core accessibility
+ * scan, checks for horizontal-overflow and stuck-skeleton layout problems, takes
+ * a full-page screenshot, and (when a baseline exists) diffs against it for visual
+ * regression. Routes with findings also get a Playwright trace.zip + a runnable
+ * repro snippet so any issue can be replayed deterministically later.
+ *
+ * Targets:
+ *   --target=local  (default)  http://localhost:3000, auth bypassed (auth=none)
+ *   --target=live              https://dash-tsr.chmonitor.dev, Clerk session reused
+ *                              from ~/.config/chmonitor/clerk-state.json
+ *
+ * Usage (run from the qa-tools dir so `playwright` resolves — see setup.sh):
+ *   bun audit.mjs --target=local
+ *   bun audit.mjs --target=local --only=/explorer,/sql
+ *   bun audit.mjs --target=live --baseline=/path/to/baseline-shots
+ *   BASE_URL=http://localhost:5173 bun audit.mjs
+ */
+import { chromium } from 'playwright'
+import { AxeBuilder } from '@axe-core/playwright'
+import { readdirSync, statSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs'
+import { PNG } from 'pngjs'
+import pixelmatch from 'pixelmatch'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// ---------- args ----------
+const args = Object.fromEntries(
+  process.argv.slice(2).map((a) => {
+    const m = a.match(/^--([^=]+)(?:=(.*))?$/)
+    return m ? [m[1], m[2] ?? true] : [a, true]
+  }),
+)
+const TARGET = args.target || 'local'
+const HOST = args.host || '0'
+const A11Y = args.a11y !== 'off'
+const SETTLE = Number(args.settle || 3500)
+const HOME = process.env.HOME
+const SKILL_DIR = join(dirname(fileURLToPath(import.meta.url)), '..')
+// repo root: walk up from skill dir until we find apps/dashboard-tsr
+function findRepoRoot(start) {
+  let d = start
+  for (let i = 0; i < 8; i++) {
+    if (existsSync(join(d, 'apps/dashboard-tsr/src/routes'))) return d
+    d = dirname(d)
+  }
+  return null
+}
+const REPO = args.repo || findRepoRoot(SKILL_DIR)
+
+const BASE_URL =
+  process.env.BASE_URL ||
+  (TARGET === 'live' ? 'https://dash-tsr.chmonitor.dev' : 'http://localhost:3000')
+const STATE = `${HOME}/.config/chmonitor/clerk-state.json`
+const STAMP = args.stamp || new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+const OUT = args.out || `/tmp/chm-ui-audit/${TARGET}-${STAMP}`
+const SHOTS = join(OUT, 'shots')
+const TRACES = join(OUT, 'traces')
+const REPRO = join(OUT, 'repro')
+const DIFFS = join(OUT, 'diffs')
+for (const d of [OUT, SHOTS, TRACES, REPRO, DIFFS]) mkdirSync(d, { recursive: true })
+const BASELINE = args.baseline || null
+
+const log = (...a) => console.log(`[audit ${new Date().toISOString().slice(11, 19)}]`, ...a)
+
+// ---------- route discovery (TanStack Start file-based routes) ----------
+function discoverRoutes() {
+  if (args.only) return String(args.only).split(',').map((s) => s.trim()).filter(Boolean)
+  if (!REPO) { log('WARN: repo root not found, falling back to /overview'); return ['/overview'] }
+  const root = join(REPO, 'apps/dashboard-tsr/src/routes')
+  const out = new Set()
+  const walk = (dir, urlPrefix) => {
+    for (const name of readdirSync(dir)) {
+      const full = join(dir, name)
+      const isDir = statSync(full).isDirectory()
+      // skip non-route files/dirs: -components, _lib, __root, route.tsx (layouts)
+      if (name.startsWith('-') || name.startsWith('_')) continue
+      if (isDir) {
+        // pathless group "(group)" contributes nothing to the URL
+        const seg = name.startsWith('(') && name.endsWith(')') ? '' : `/${name}`
+        walk(full, urlPrefix + seg)
+        continue
+      }
+      if (!name.endsWith('.tsx')) continue
+      if (name === 'route.tsx' || name === '__root.tsx') continue
+      if (name.includes('$')) continue // dynamic params — skip (need sample values)
+      const base = name.replace(/\.tsx$/, '')
+      const path = base === 'index' ? urlPrefix || '/' : `${urlPrefix}/${base}`
+      out.add(path || '/')
+    }
+  }
+  walk(root, '')
+  return [...out].sort()
+}
+
+// network calls that are expected to fail / be noisy and should not count as findings
+const IGNORABLE = [
+  /\/api\/v1\/notifications/, // best-effort
+  /favicon/,
+  /analytics|seline|vercel-insights|gtag|google-analytics/,
+]
+function isIgnorable(url) { return IGNORABLE.some((re) => re.test(url)) }
+
+// ---------- per-route audit ----------
+async function auditRoute(ctx, route) {
+  const page = await ctx.newPage()
+  const consoleErrors = []
+  const failedRequests = []
+  page.on('console', (m) => { if (m.type() === 'error') consoleErrors.push(m.text().slice(0, 300)) })
+  page.on('pageerror', (e) => consoleErrors.push('pageerror: ' + e.message.slice(0, 300)))
+  page.on('response', (r) => {
+    const u = r.url()
+    if (r.status() >= 400 && !isIgnorable(u)) failedRequests.push(`${r.status()} ${u.replace(BASE_URL, '')}`.slice(0, 120))
+  })
+
+  const url = `${BASE_URL}${route}${route.includes('?') ? '&' : '?'}host=${HOST}`
+  const findings = []
+  let crashed = false
+  let tracing = false
+  try {
+    await ctx.tracing.start({ screenshots: true, snapshots: true, title: route })
+    tracing = true
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45000 })
+    // let SWR/Query fire and charts mount
+    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {})
+    await page.waitForTimeout(SETTLE)
+
+    // stuck skeleton: loading placeholders still present after settle
+    const stillLoading = await page
+      .locator('.animate-pulse, [data-loading="true"], [aria-busy="true"]')
+      .count()
+      .catch(() => 0)
+    if (stillLoading > 0) {
+      // give it one more chance, then flag
+      await page.waitForTimeout(4000)
+      const again = await page.locator('.animate-pulse, [data-loading="true"]').count().catch(() => 0)
+      if (again > 0) findings.push({ type: 'stuck-skeleton', severity: 'medium', detail: `${again} loading placeholder(s) still visible after ${(SETTLE + 4000) / 1000}s` })
+    }
+
+    // horizontal overflow (a very common dashboard regression)
+    const overflow = await page.evaluate(() => {
+      const de = document.documentElement
+      const w = window.innerWidth
+      const over = de.scrollWidth - w
+      const culprits = []
+      if (over > 4) {
+        for (const el of document.querySelectorAll('*')) {
+          const r = el.getBoundingClientRect()
+          if (r.right > w + 4 && r.width > 40 && r.height > 8) {
+            culprits.push((el.tagName.toLowerCase()) + (el.className && typeof el.className === 'string' ? '.' + el.className.split(' ').slice(0, 2).join('.') : ''))
+            if (culprits.length >= 4) break
+          }
+        }
+      }
+      return { over, culprits }
+    })
+    if (overflow.over > 4) findings.push({ type: 'horizontal-overflow', severity: 'medium', detail: `page overflows viewport by ${overflow.over}px`, culprits: overflow.culprits })
+
+    // explicit error / crash states in the content
+    const errText = await page.evaluate(() => {
+      const re = /(something went wrong|unexpected error|failed to load|application error|cannot read|is not a function|is not a constructor)/i
+      const main = document.querySelector('main') || document.body
+      const t = (main.innerText || '').slice(0, 4000)
+      const m = t.match(re)
+      return m ? m[0] : null
+    })
+    if (errText) findings.push({ type: 'error-state', severity: 'high', detail: `error text rendered: "${errText}"` })
+
+    // accessibility (axe-core) — serious+critical only by default to cut noise
+    if (A11Y) {
+      try {
+        const res = await new AxeBuilder({ page })
+          .withTags(['wcag2a', 'wcag2aa'])
+          .analyze()
+        const serious = res.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical')
+        for (const v of serious) {
+          findings.push({
+            type: 'a11y',
+            severity: v.impact === 'critical' ? 'high' : 'medium',
+            rule: v.id,
+            detail: v.help,
+            nodes: v.nodes.slice(0, 3).map((n) => n.target.join(' ')),
+            helpUrl: v.helpUrl,
+          })
+        }
+      } catch (e) { findings.push({ type: 'a11y-error', severity: 'low', detail: 'axe scan failed: ' + e.message.slice(0, 120) }) }
+    }
+
+    if (consoleErrors.length) findings.push({ type: 'console-error', severity: 'high', detail: `${consoleErrors.length} console error(s)`, sample: consoleErrors.slice(0, 5) })
+    if (failedRequests.length) findings.push({ type: 'failed-request', severity: TARGET === 'local' ? 'medium' : 'high', detail: `${failedRequests.length} request(s) >=400`, sample: failedRequests.slice(0, 6) })
+  } catch (e) {
+    crashed = true
+    findings.push({ type: 'navigation-crash', severity: 'high', detail: e.message.slice(0, 200) })
+  }
+
+  // screenshot (always)
+  const shotName = (route.replace(/[/?=&]/g, '_') || '_root') + '.png'
+  const shotPath = join(SHOTS, shotName)
+  await page.screenshot({ path: shotPath, fullPage: true }).catch(() => {})
+
+  // visual regression vs baseline
+  if (BASELINE) {
+    const basePath = join(BASELINE, shotName)
+    if (existsSync(basePath) && existsSync(shotPath)) {
+      try {
+        const a = PNG.sync.read(readFileSync(basePath))
+        const b = PNG.sync.read(readFileSync(shotPath))
+        if (a.width === b.width && a.height === b.height) {
+          const diff = new PNG({ width: a.width, height: a.height })
+          const n = pixelmatch(a.data, b.data, diff.data, a.width, a.height, { threshold: 0.1 })
+          const pct = (n / (a.width * a.height)) * 100
+          if (pct > 0.5) {
+            writeFileSync(join(DIFFS, shotName), PNG.sync.write(diff))
+            findings.push({ type: 'visual-regression', severity: 'medium', detail: `${pct.toFixed(2)}% pixels changed vs baseline`, diff: join('diffs', shotName) })
+          }
+        } else {
+          findings.push({ type: 'visual-regression', severity: 'medium', detail: `dimensions changed (${a.width}x${a.height} -> ${b.width}x${b.height})` })
+        }
+      } catch { /* baseline unreadable */ }
+    }
+  }
+
+  // trace + repro only when there is something to reproduce
+  if (tracing) {
+    if (findings.length) {
+      const traceName = (route.replace(/[/?=&]/g, '_') || '_root') + '.zip'
+      await ctx.tracing.stop({ path: join(TRACES, traceName) }).catch(() => {})
+      writeReproSnippet(route, url, findings)
+    } else {
+      await ctx.tracing.stop().catch(() => {})
+    }
+  }
+
+  await page.close()
+  return { route, url, shot: join('shots', shotName), crashed, findings }
+}
+
+function writeReproSnippet(route, url, findings) {
+  const id = (route.replace(/[/?=&]/g, '_') || '_root')
+  const types = [...new Set(findings.map((f) => f.type))].join(', ')
+  const snippet = `#!/usr/bin/env bun
+// Repro for ${route} — issues: ${types}
+// Run from ~/.config/chmonitor/qa-tools:  bun ${join('${OUT}', 'repro', id + '.mjs')}
+import { chromium } from 'playwright'
+const live = ${TARGET === 'live'}
+const ctx = live
+  ? await chromium.launchPersistentContext('${HOME}/.config/chmonitor/clerk-userdata', { headless: false, viewport: { width: 1440, height: 900 } })
+  : await (await chromium.launch({ headless: false })).newContext()
+const page = await ctx.newPage()
+const errs = []
+page.on('console', m => m.type()==='error' && errs.push(m.text()))
+page.on('pageerror', e => errs.push('pageerror: '+e.message))
+await page.goto('${url}', { waitUntil: 'domcontentloaded' })
+await page.waitForTimeout(6000)
+console.log('--- console errors ---'); console.log(errs.join('\\n') || '(none)')
+console.log('--- findings expected ---')
+console.log(${JSON.stringify(findings, null, 0).replace(/`/g, '\\`')})
+console.log('Leaving the browser open 60s so you can inspect. Trace: traces/${id}.zip (bun x playwright show-trace ...)')
+await page.waitForTimeout(60000)
+await ctx.close()
+`
+  writeFileSync(join(REPRO, id + '.mjs'), snippet)
+}
+
+// ---------- main ----------
+const USERDATA = `${HOME}/.config/chmonitor/clerk-userdata`
+const routes = discoverRoutes()
+log(`target=${TARGET} base=${BASE_URL} routes=${routes.length} out=${OUT}`)
+
+// Live uses a PERSISTENT browser profile (userDataDir). Unlike an exported
+// storageState snapshot, this keeps Clerk's entire client state on disk
+// (cookies + localStorage + IndexedDB), so the short-lived session JWT refreshes
+// itself on load and the audit stays authorized. Populate it once with
+// live-login.mjs (headed). Local uses a throwaway context (auth bypassed).
+let browser = null
+let ctx
+if (TARGET === 'live') {
+  if (!existsSync(USERDATA)) {
+    log(`ERROR: live needs an authenticated profile at ${USERDATA}. Run live-login.mjs (headed) first.`)
+    process.exit(2)
+  }
+  ctx = await chromium.launchPersistentContext(USERDATA, {
+    headless: !args.headed,
+    viewport: { width: 1440, height: 900 },
+    args: ['--disable-blink-features=AutomationControlled'],
+  })
+} else {
+  browser = await chromium.launch({ headless: !args.headed })
+  ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } })
+}
+
+// Warm up Clerk on live: the saved __session JWT is short-lived, so load the app
+// once and wait until Clerk refreshes the session (a data call returns 200) before
+// auditing — otherwise the first cold load falsely 401s every route. Re-save the
+// freshened cookies so the next run starts warmer.
+if (TARGET === 'live') {
+  const warm = await ctx.newPage()
+  let authed = false
+  warm.on('response', (r) => { if (r.url().includes('/api/v1/hosts') && r.status() === 200) authed = true })
+  await warm.goto(`${BASE_URL}/overview?host=${HOST}`, { waitUntil: 'domcontentloaded', timeout: 45000 }).catch(() => {})
+  for (let i = 0; i < 25 && !authed; i++) await warm.waitForTimeout(1000)
+  log(authed ? 'Clerk session warm (authorized)' : 'WARN: session did not authorize within 25s — re-mint with live-login.mjs (headed)')
+  await warm.close()
+}
+
+const results = []
+for (const route of routes) {
+  const r = await auditRoute(ctx, route)
+  const n = r.findings.length
+  log(`${n ? '✗' : '✓'} ${route}  (${n} finding${n === 1 ? '' : 's'})`)
+  results.push(r)
+}
+await ctx.close()
+if (browser) await browser.close()
+
+// ---------- report ----------
+const all = results.flatMap((r) => r.findings.map((f) => ({ route: r.route, ...f })))
+const bySeverity = (s) => all.filter((f) => f.severity === s).length
+const summary = {
+  target: TARGET,
+  baseUrl: BASE_URL,
+  routesAudited: results.length,
+  routesWithFindings: results.filter((r) => r.findings.length).length,
+  totalFindings: all.length,
+  high: bySeverity('high'),
+  medium: bySeverity('medium'),
+  low: bySeverity('low'),
+  byType: all.reduce((acc, f) => ((acc[f.type] = (acc[f.type] || 0) + 1), acc), {}),
+}
+writeFileSync(join(OUT, 'report.json'), JSON.stringify({ summary, results }, null, 2))
+writeFileSync(join(OUT, 'report.html'), renderHtml(summary, results))
+log('SUMMARY ' + JSON.stringify(summary))
+log('report -> ' + join(OUT, 'report.html'))
+
+function esc(s) { return String(s).replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c])) }
+function renderHtml(summary, results) {
+  const sevColor = { high: '#dc2626', medium: '#d97706', low: '#6b7280' }
+  const cards = results
+    .filter((r) => r.findings.length)
+    .map((r) => {
+      const items = r.findings
+        .map((f) => `<li><b style="color:${sevColor[f.severity]}">[${f.severity}] ${esc(f.type)}</b> ${esc(f.detail || f.rule || '')}${f.sample ? `<pre>${esc(f.sample.join('\n'))}</pre>` : ''}${f.nodes ? `<pre>${esc(f.nodes.join('\n'))}</pre>` : ''}</li>`)
+        .join('')
+      return `<section><h3>${esc(r.route)} <span class=count>${r.findings.length}</span></h3>
+        <a href="${r.shot}" target=_blank><img src="${r.shot}" loading=lazy></a>
+        <ul>${items}</ul>
+        <p class=repro>repro: <code>bun ${join(OUT, 'repro', (r.route.replace(/[/?=&]/g, '_') || '_root') + '.mjs')}</code></p></section>`
+    })
+    .join('')
+  const clean = results.filter((r) => !r.findings.length).map((r) => esc(r.route)).join(', ')
+  return `<!doctype html><meta charset=utf8><title>CHM UI/UX audit — ${summary.target}</title>
+<style>body{font:14px/1.5 system-ui;margin:0;background:#0b0b0c;color:#e5e5e5}
+header{padding:20px 28px;background:#111;position:sticky;top:0;border-bottom:1px solid #222}
+h1{margin:0 0 6px;font-size:18px} .pill{display:inline-block;padding:2px 8px;border-radius:99px;margin-right:6px;font-size:12px}
+section{padding:18px 28px;border-bottom:1px solid #1a1a1a} h3{margin:0 0 10px} .count{background:#dc2626;border-radius:99px;padding:1px 8px;font-size:12px}
+img{max-width:520px;border:1px solid #333;border-radius:8px;vertical-align:top}
+ul{margin:10px 0} pre{background:#161616;padding:8px;border-radius:6px;overflow:auto;font-size:12px;color:#bbb}
+.repro code{background:#161616;padding:2px 6px;border-radius:4px;font-size:12px} .ok{padding:18px 28px;color:#888}</style>
+<header><h1>ClickHouse Monitor — UI/UX audit (${summary.target})</h1>
+<div><span class=pill style="background:#dc2626">${summary.high} high</span>
+<span class=pill style="background:#d97706">${summary.medium} medium</span>
+<span class=pill style="background:#444">${summary.low} low</span>
+<span class=pill style="background:#222">${summary.routesWithFindings}/${summary.routesAudited} routes</span></div>
+<div style="margin-top:6px;color:#888;font-size:12px">${esc(JSON.stringify(summary.byType))}</div></header>
+${cards}
+<div class=ok><b>Clean routes (${results.length - summary.routesWithFindings}):</b> ${clean}</div>`
+}

--- a/.claude/skills/ui-ux-audit/scripts/live-login.mjs
+++ b/.claude/skills/ui-ux-audit/scripts/live-login.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env bun
+/**
+ * Populate the persistent Clerk browser profile used by the live audit target.
+ *
+ * Runs HEADED (Cloudflare Turnstile on pk_live only auto-passes in a real,
+ * non-headless browser). Signs the dedicated test account in; Clerk persists the
+ * full client state into the userDataDir, so `audit.mjs --target=live` can then
+ * run headless and stay authorized.
+ *
+ * If a verification code is required, it is emailed to duyet.cs@gmail.com (the
+ * plus-addressed inbox). Read it via the Gmail MCP and write it to
+ * /tmp/chm-otp.txt; this script polls that file.
+ *
+ *   HEADLESS=0 bun live-login.mjs          # normal (headed)
+ */
+import { chromium } from 'playwright'
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs'
+
+const HOME = process.env.HOME
+const creds = JSON.parse(readFileSync(`${HOME}/.config/chmonitor/test-account.json`, 'utf8'))
+const USERDATA = `${HOME}/.config/chmonitor/clerk-userdata`
+const TARGET = 'https://dash-tsr.chmonitor.dev/overview?host=0'
+const OTP_FILE = '/tmp/chm-otp.txt'
+const SHOT = '/tmp/chm-login'
+mkdirSync(USERDATA, { recursive: true })
+mkdirSync(SHOT, { recursive: true })
+const headless = process.env.HEADLESS === '1'
+const log = (...a) => console.log(`[login ${new Date().toISOString().slice(11, 19)}]`, ...a)
+
+const ctx = await chromium.launchPersistentContext(USERDATA, {
+  headless,
+  viewport: { width: 1440, height: 900 },
+  args: ['--disable-blink-features=AutomationControlled'],
+})
+const page = ctx.pages()[0] || (await ctx.newPage())
+const shot = (n) => page.screenshot({ path: `${SHOT}/${n}.png` }).catch(() => {})
+
+async function firstVisible(selectors, timeout = 8000) {
+  const deadline = Date.now() + timeout
+  while (Date.now() < deadline) {
+    for (const s of selectors) {
+      const loc = page.locator(s).first()
+      if (await loc.isVisible().catch(() => false)) return loc
+    }
+    await page.waitForTimeout(250)
+  }
+  return null
+}
+async function authorized() {
+  return await page.evaluate(async () => {
+    try { const r = await fetch('/api/v1/hosts'); return r.ok } catch { return false }
+  })
+}
+
+try {
+  await page.goto(TARGET, { waitUntil: 'domcontentloaded', timeout: 45000 })
+  await page.waitForTimeout(3500)
+  if (await authorized()) { log('already signed in (profile still valid) — nothing to do'); writeFileSync('/tmp/chm-login-status.txt', 'ALREADY\n'); await ctx.close(); process.exit(0) }
+
+  const trigger = await firstVisible(['[data-testid="nav-user-trigger"]', 'button:has-text("Sign In")', 'button:has-text("Sign in")'], 10000)
+  if (!trigger) throw new Error('Sign In trigger not found')
+  await trigger.click()
+  await page.waitForTimeout(2500)
+  await shot('01-modal')
+
+  // Sign-in form: identifier (email) first
+  const email = await firstVisible(['input[name="identifier"]', 'input[type="email"]', 'input[name="emailAddress"]'], 8000)
+  if (!email) throw new Error('email field not found')
+  await email.fill(creds.email)
+  let cont = await firstVisible(['.cl-formButtonPrimary', 'button:has-text("Continue")', 'button[type="submit"]'], 5000)
+  if (cont) { await cont.click(); await page.waitForTimeout(2500) }
+
+  // Password step (may be same step or next)
+  const pw = await firstVisible(['input[name="password"]:not([disabled])', 'input[type="password"]:not([disabled])'], 8000)
+  if (pw) {
+    await pw.fill(creds.password)
+    cont = await firstVisible(['.cl-formButtonPrimary', 'button:has-text("Continue")', 'button[type="submit"]'], 5000)
+    if (cont) { await cont.click(); await page.waitForTimeout(3500) }
+  }
+  await shot('02-after-password')
+
+  // Turnstile (headed auto-passes); wait for either authorization or an OTP prompt
+  for (let i = 0; i < 30; i++) {
+    if (await authorized()) break
+    const otp = await firstVisible(['input[name="codeInput-0"]', 'input[autocomplete="one-time-code"]', 'input[inputmode="numeric"]'], 1000)
+    if (otp) {
+      log('verification code required — waiting for', OTP_FILE)
+      writeFileSync('/tmp/chm-login-status.txt', 'AWAITING_OTP\n')
+      let code = null
+      const deadline = Date.now() + 5 * 60 * 1000
+      while (Date.now() < deadline) {
+        if (existsSync(OTP_FILE)) { const c = readFileSync(OTP_FILE, 'utf8').trim().replace(/\D/g, ''); if (c.length === 6) { code = c; break } }
+        await page.waitForTimeout(2000)
+      }
+      if (!code) throw new Error('timed out waiting for OTP')
+      await otp.click().catch(() => {})
+      await page.keyboard.type(code, { delay: 120 })
+      await page.waitForTimeout(3500)
+      const c2 = await firstVisible(['.cl-formButtonPrimary', 'button:has-text("Continue")'], 2000)
+      if (c2 && await c2.isVisible().catch(() => false)) await c2.click().catch(() => {})
+    }
+    await page.waitForTimeout(2000)
+  }
+
+  await page.waitForTimeout(2000)
+  await shot('03-final')
+  const ok = await authorized()
+  log(ok ? 'SIGNED IN — profile populated at ' + USERDATA : 'UNCERTAIN — check /tmp/chm-login/03-final.png')
+  writeFileSync('/tmp/chm-login-status.txt', (ok ? 'SIGNED_IN' : 'UNCERTAIN') + '\n')
+} catch (e) {
+  log('ERROR', e.message)
+  await shot('99-error')
+  writeFileSync('/tmp/chm-login-status.txt', 'ERROR: ' + e.message + '\n')
+} finally {
+  await ctx.close()
+}

--- a/.claude/skills/ui-ux-audit/scripts/setup.sh
+++ b/.claude/skills/ui-ux-audit/scripts/setup.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Idempotent setup for the UI/UX audit toolchain. Installs Playwright + axe-core +
+# image-diff deps into a tools dir OUTSIDE the repo (so it never pollutes the
+# project's node_modules), and downloads the Chromium browser binary.
+#
+# Safe to re-run; it only installs what's missing.
+set -euo pipefail
+
+TOOLS="${CHM_QA_TOOLS:-$HOME/.config/chmonitor/qa-tools}"
+mkdir -p "$TOOLS"
+cd "$TOOLS"
+
+# Load node (nvm) for non-interactive shells.
+export NVM_DIR="$HOME/.nvm"
+# shellcheck disable=SC1091
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" >/dev/null 2>&1 || true
+nvm use default >/dev/null 2>&1 || true
+
+[ -f package.json ] || echo '{"name":"chm-qa-tools","private":true}' > package.json
+
+need=()
+for pkg in playwright @axe-core/playwright pixelmatch pngjs; do
+  node -e "require.resolve('$pkg')" 2>/dev/null || need+=("$pkg")
+done
+
+if [ "${#need[@]}" -gt 0 ]; then
+  echo "Installing: ${need[*]}"
+  bun add -d "${need[@]}"
+else
+  echo "All node deps already present."
+fi
+
+# Ensure Chromium is installed for Playwright.
+bun x playwright install chromium >/dev/null 2>&1 || bun x playwright install chromium
+
+# Make the audit runner resolvable from any cwd: symlink node_modules into the
+# skill's scripts dir (bun/node resolve bare imports from the script's own dir).
+# The symlink is gitignored — it points outside the repo.
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ln -sfn "$TOOLS/node_modules" "$SCRIPTS_DIR/node_modules"
+
+echo "Tools ready at: $TOOLS"
+echo "Run the audit from anywhere, e.g.:  bun $SCRIPTS_DIR/audit.mjs --target=local"


### PR DESCRIPTION
Adds a project skill at `.claude/skills/ui-ux-audit/` that runs a real browser over **every dashboard-tsr route** and reports the UI/UX problems that matter, each with a reproducible artifact.

**Per route:** console errors + failed network calls, axe-core a11y (WCAG2 A/AA), horizontal overflow, stuck skeletons, error states, full-page screenshot, and pixel-diff vs a baseline.

**Output:** `report.html` + `report.json`, `shots/`, `diffs/`, plus — for routes with findings — a Playwright `trace.zip` and a runnable `repro/<route>.mjs` ("reproduce it when needed").

**Targets:** `local` (auth=none dev server) by default; `live` reuses a persistent Clerk browser profile. Tooling installs outside the repo via `scripts/setup.sh` (Playwright + axe-core + pixelmatch); `node_modules` is symlinked and gitignored.

On its first run it caught the `require is not defined` ESM crash fixed in #1532.

🤖 Generated with [Claude Code](https://claude.com/claude-code)