### PR TITLE
feat(auth): read/write permission model + CHM_CLERK_PUBLIC_READ

### DIFF
--- a/apps/dashboard-tsr/src/lib/auth/api-guard.ts
+++ b/apps/dashboard-tsr/src/lib/auth/api-guard.ts
@@ -62,6 +62,38 @@ export function bridgeApiKeyEnv(bindings: EnvBindings): void {
   }
 }
 
+/**
+ * Copy CHM_CLERK_PUBLIC_READ from the Worker `env` binding onto `process.env`
+ * so `publicReadEnabled()` (which reads process.env) sees it on workerd.
+ * Idempotent; only sets when present on the binding and not already set.
+ */
+export function bridgePublicReadEnv(bindings: EnvBindings): void {
+  if (typeof process === 'undefined' || !process.env) return
+  const value = bindings.CHM_CLERK_PUBLIC_READ
+  if (
+    value != null &&
+    value !== '' &&
+    process.env.CHM_CLERK_PUBLIC_READ == null
+  ) {
+    process.env.CHM_CLERK_PUBLIC_READ = value
+  }
+}
+
+/**
+ * Opt-in public read-only mode for the Clerk provider.
+ *
+ * When `CHM_CLERK_PUBLIC_READ` is truthy, anonymous `/api/v1/*` requests are
+ * NOT blanket-401'd; the per-route `authorizeFeatureRequest()` becomes the sole
+ * gate. Public features serve data to anonymous visitors, while `authenticated`
+ * features (agent, actions) still 401. Named with the CLERK prefix because it
+ * only relaxes the clerk posture — `none` is already fully open and `proxy`
+ * fronts its own auth.
+ */
+export function publicReadEnabled(): boolean {
+  const raw = process.env.CHM_CLERK_PUBLIC_READ?.trim().toLowerCase()
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on'
+}
+
 function jsonError(message: string, status: number): Response {
   return Response.json({ error: message }, { status })
 }
@@ -135,6 +167,11 @@ export async function getApiKeyAuthFailure(
   ) {
     return null
   }
+
+  // Opt-in public read-only mode (clerk only): let anonymous requests through
+  // and defer to each route's authorizeFeatureRequest(). Public features serve
+  // data; agent/actions are `authenticated` and still 401 at the route.
+  if (provider === 'clerk' && publicReadEnabled()) return null
 
   return jsonError('Authentication required', 401)
 }

--- a/apps/dashboard-tsr/src/lib/feature-permissions/__tests__/permissions.test.ts
+++ b/apps/dashboard-tsr/src/lib/feature-permissions/__tests__/permissions.test.ts
@@ -1,0 +1,96 @@
+import {
+  ACTIONS_FEATURE_PERMISSION,
+  AGENT_FEATURE_PERMISSION,
+  EXPLORER_QUERY_FEATURE_PERMISSION,
+  OVERVIEW_FEATURE_PERMISSION,
+  TABLES_FEATURE_PERMISSION,
+} from '../permissions'
+import { anonymousCapabilities, resolveFeatureState } from '../shared'
+import { describe, expect, test } from 'bun:test'
+
+// Security boundary: when CHM_CLERK_PUBLIC_READ relaxes the blanket API guard
+// for anonymous read-only access, the per-route authorizeFeatureRequest() is the
+// SOLE gate. agent + actions MUST resolve to `authenticated` and be classified
+// as `write` so anonymous callers cannot run the AI agent, mutating control
+// actions (KILL QUERY, OPTIMIZE TABLE), or arbitrary SQL.
+const NO_OVERRIDES = { features: {} }
+
+describe('feature permission defaults (security boundary)', () => {
+  test('agent defaults to authenticated', () => {
+    expect(resolveFeatureState(AGENT_FEATURE_PERMISSION, NO_OVERRIDES)).toEqual(
+      {
+        enabled: true,
+        access: 'authenticated',
+      }
+    )
+  })
+
+  test('actions defaults to authenticated', () => {
+    expect(
+      resolveFeatureState(ACTIONS_FEATURE_PERMISSION, NO_OVERRIDES)
+    ).toEqual({ enabled: true, access: 'authenticated' })
+  })
+
+  test('read-only features stay public', () => {
+    for (const perm of [
+      OVERVIEW_FEATURE_PERMISSION,
+      TABLES_FEATURE_PERMISSION,
+    ]) {
+      expect(resolveFeatureState(perm, NO_OVERRIDES).access).toBe('public')
+    }
+  })
+
+  test('operator can still loosen agent/actions to public via override', () => {
+    expect(
+      resolveFeatureState(ACTIONS_FEATURE_PERMISSION, {
+        features: { actions: { access: 'public' } },
+      }).access
+    ).toBe('public')
+  })
+})
+
+describe('write operation classification', () => {
+  test('agent + actions are writes', () => {
+    expect(AGENT_FEATURE_PERMISSION.operation).toBe('write')
+    expect(ACTIONS_FEATURE_PERMISSION.operation).toBe('write')
+  })
+
+  test('arbitrary SQL execution (explorer query) is a write on the tables feature', () => {
+    expect(EXPLORER_QUERY_FEATURE_PERMISSION.operation).toBe('write')
+    expect(EXPLORER_QUERY_FEATURE_PERMISSION.feature).toBe('tables')
+  })
+
+  test('schema-browsing tables permission is a read (default operation)', () => {
+    expect(TABLES_FEATURE_PERMISSION.operation).toBeUndefined()
+  })
+})
+
+describe('anonymousCapabilities matrix', () => {
+  test('auth=none → read + write', () => {
+    expect(anonymousCapabilities('none', false)).toEqual({
+      read: true,
+      write: true,
+    })
+  })
+
+  test('auth=clerk + public read → read only', () => {
+    expect(anonymousCapabilities('clerk', true)).toEqual({
+      read: true,
+      write: false,
+    })
+  })
+
+  test('auth=clerk default → no read, no write', () => {
+    expect(anonymousCapabilities('clerk', false)).toEqual({
+      read: false,
+      write: false,
+    })
+  })
+
+  test('auth=proxy → no read, no write (proxy fronts its own auth)', () => {
+    expect(anonymousCapabilities('proxy', true)).toEqual({
+      read: false,
+      write: false,
+    })
+  })
+})

--- a/apps/dashboard-tsr/src/lib/feature-permissions/permissions.ts
+++ b/apps/dashboard-tsr/src/lib/feature-permissions/permissions.ts
@@ -2,14 +2,32 @@ import type { FeaturePermission } from './types'
 
 export const AGENT_FEATURE_PERMISSION = {
   feature: 'agent',
+  // The AI agent runs queries and (with control tools) mutates the cluster — a
+  // write. defaultAccess keeps the existing frontend gate (AgentAuthGate keys
+  // off access === 'authenticated'); operation classifies it on the read/write
+  // axis so anonymous read-only deployments cannot drive the agent.
+  defaultAccess: 'authenticated',
+  operation: 'write',
 } satisfies FeaturePermission
 
 export const ACTIONS_FEATURE_PERMISSION = {
   feature: 'actions',
+  // Mutating control actions (KILL QUERY, OPTIMIZE TABLE) — a write.
+  defaultAccess: 'authenticated',
+  operation: 'write',
 } satisfies FeaturePermission
 
 export const TABLES_FEATURE_PERMISSION = {
   feature: 'tables',
+} satisfies FeaturePermission
+
+// Arbitrary user-supplied SQL execution (SQL Console, explorer query tab).
+// Same `tables` feature as schema browsing, but classified as a write: running
+// attacker-chosen SQL is a powerful capability distinct from a fixed registry
+// query, so anonymous read-only callers must not reach it.
+export const EXPLORER_QUERY_FEATURE_PERMISSION = {
+  feature: 'tables',
+  operation: 'write',
 } satisfies FeaturePermission
 
 export const OVERVIEW_FEATURE_PERMISSION = {

--- a/apps/dashboard-tsr/src/lib/feature-permissions/server.ts
+++ b/apps/dashboard-tsr/src/lib/feature-permissions/server.ts
@@ -18,6 +18,7 @@
 import type { FeaturePermission } from './types'
 
 import {
+  anonymousCapabilities,
   mergeFeatureOverrides,
   normalizeFeatureAccess,
   normalizeFeatureId,
@@ -134,6 +135,14 @@ function getAppConfig(): AppConfig {
   return { authProvider, features: parseEnvFeatureOverrides() }
 }
 
+/** Opt-in anonymous read under clerk (see api-guard.ts publicReadEnabled). */
+export function publicReadEnabled(): boolean {
+  return (
+    parseBoolean(readEnv('CHM_CLERK_PUBLIC_READ'), 'CHM_CLERK_PUBLIC_READ') ===
+    true
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Auth check.
 // ---------------------------------------------------------------------------
@@ -202,8 +211,16 @@ export async function authorizeFeatureRequest(
     )
   }
 
-  if (state.access === 'public') return null
+  // Anonymous baseline first (cheap, no Clerk call): a public READ is allowed
+  // when the deployment grants anonymous read. Writes never qualify here.
+  const operation = permission.operation ?? 'read'
+  const caps = anonymousCapabilities(config.authProvider, publicReadEnabled())
+  if (operation === 'read' && state.access === 'public' && caps.read) {
+    return null
+  }
 
+  // Otherwise require an authenticated caller (Clerk session / bearer token;
+  // `none` authenticates everyone).
   if (await isAuthenticatedRequest(request, config, options)) return null
 
   return jsonFeatureError(

--- a/apps/dashboard-tsr/src/lib/feature-permissions/shared.ts
+++ b/apps/dashboard-tsr/src/lib/feature-permissions/shared.ts
@@ -17,6 +17,28 @@ export const DEFAULT_FEATURE_STATE: FeatureState = {
   access: DEFAULT_FEATURE_ACCESS,
 }
 
+/**
+ * What an anonymous caller may do, by deployment posture:
+ *
+ *  - `none`                       → read + write   (everyone is authenticated)
+ *  - `clerk` + CHM_CLERK_PUBLIC_READ → read only   (the dash / dash-tsr posture)
+ *  - `clerk` (default) / `proxy`  → nothing        (sign in / proxy-auth required)
+ *
+ * Authenticated callers always get read + write; this only describes the
+ * anonymous baseline. Pure (publicRead passed in) so it is shared by the server
+ * authorize path and the public config endpoint.
+ */
+export function anonymousCapabilities(
+  authProvider: PublicFeaturePermissionConfig['authProvider'],
+  publicRead: boolean
+): { read: boolean; write: boolean } {
+  if (authProvider === 'none') return { read: true, write: true }
+  if (authProvider === 'clerk' && publicRead) {
+    return { read: true, write: false }
+  }
+  return { read: false, write: false }
+}
+
 const FEATURE_ID_SET = new Set<string>(FEATURE_IDS)
 const FEATURE_ACCESS_SET = new Set<string>(FEATURE_ACCESS_VALUES)
 const FEATURE_ACCESS_ALIASES: Record<string, FeatureAccess> = {

--- a/apps/dashboard-tsr/src/lib/feature-permissions/types.ts
+++ b/apps/dashboard-tsr/src/lib/feature-permissions/types.ts
@@ -25,6 +25,10 @@ export const FEATURE_IDS = [
 
 export type FeatureId = (typeof FEATURE_IDS)[number]
 
+export const FEATURE_OPERATIONS = ['read', 'write'] as const
+
+export type FeatureOperation = (typeof FEATURE_OPERATIONS)[number]
+
 export interface FeaturePermission {
   feature: FeatureId
   /**
@@ -33,6 +37,27 @@ export interface FeaturePermission {
    * @default public
    */
   defaultAccess?: FeatureAccess
+  /**
+   * Whether this call site READS data or WRITES (mutates the cluster, runs the
+   * AI agent, or executes arbitrary user-supplied SQL). Anonymous callers are
+   * allowed reads only when the deployment grants anonymous read
+   * (`CHM_CLERK_PUBLIC_READ` under clerk, or `auth=none`); writes always require
+   * an authenticated caller. The same feature can be referenced by both a read
+   * permission (e.g. schema browsing) and a write permission (arbitrary query).
+   *
+   * @default read
+   */
+  operation?: FeatureOperation
+}
+
+/**
+ * What an ANONYMOUS (unauthenticated) caller may do, derived from the auth
+ * provider and `CHM_CLERK_PUBLIC_READ`. Authenticated callers can always do
+ * both. Principal-independent, so it is safe to expose in the public config.
+ */
+export interface AnonymousCapabilities {
+  read: boolean
+  write: boolean
 }
 
 export interface FeatureOverride {
@@ -56,4 +81,6 @@ export interface PublicFeaturePermissionConfig {
   principal: Principal
   features: FeatureOverrides
   resolved?: ResolvedFeatureStates
+  /** What anonymous callers may do under this deployment's auth posture. */
+  capabilities?: AnonymousCapabilities
 }

--- a/apps/dashboard-tsr/src/routes/api/v1/actions.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/actions.ts
@@ -174,7 +174,10 @@ export const Route = createFileRoute('/api/v1/actions')({
         // dashboard route.
         const permissionResponse = await authorizeFeatureRequest(
           ACTIONS_FEATURE_PERMISSION,
-          request
+          request,
+          // Accept a valid `chm_` API key as authentication so programmatic
+          // clients keep working now that actions defaults to `authenticated`.
+          { allowAgentBearerToken: true }
         )
         if (permissionResponse) return permissionResponse
 

--- a/apps/dashboard-tsr/src/routes/api/v1/config.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/config.ts
@@ -202,6 +202,17 @@ function getPublicFeaturePermissionConfig(): PublicFeaturePermissionConfig {
   const features = parseEnvFeatureOverrides()
   const resolved = getResolvedFeatureStates(features)
 
+  // What an anonymous caller may do under this posture (mirror shared.ts
+  // anonymousCapabilities; inlined to keep this route self-contained). The
+  // client combines this with its Clerk signed-in state to gate write UI.
+  const publicRead = parseBoolean(readEnv('CHM_CLERK_PUBLIC_READ')) === true
+  const capabilities =
+    authProvider === 'none'
+      ? { read: true, write: true }
+      : authProvider === 'clerk' && publicRead
+        ? { read: true, write: false }
+        : { read: false, write: false }
+
   return {
     authProvider,
     // WORKERD: no server-side Clerk auth() here → always anonymous.
@@ -209,6 +220,7 @@ function getPublicFeaturePermissionConfig(): PublicFeaturePermissionConfig {
     principal: 'anonymous',
     features,
     resolved,
+    capabilities,
   }
 }
 

--- a/apps/dashboard-tsr/src/routes/api/v1/explorer/query.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/explorer/query.ts
@@ -16,6 +16,8 @@ import { debug, error } from '@chm/logger'
 import { validateSqlQuery } from '@chm/sql-builder'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { ApiErrorType } from '@/lib/api/types'
+import { EXPLORER_QUERY_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 
 const MAX_GET_QUERY_LENGTH = 8_000
 const MAX_POST_QUERY_LENGTH = 100_000
@@ -196,6 +198,16 @@ export const Route = createFileRoute('/api/v1/explorer/query')({
       GET: async ({ request }) => {
         bridgeClickHouseEnv(env as Record<string, string | undefined>)
 
+        // Arbitrary SQL execution is a WRITE capability: anonymous read-only
+        // callers (CHM_CLERK_PUBLIC_READ) are blocked; authenticated callers and
+        // API keys pass.
+        const authError = await authorizeFeatureRequest(
+          EXPLORER_QUERY_FEATURE_PERMISSION,
+          request,
+          { allowAgentBearerToken: true }
+        )
+        if (authError) return authError
+
         const { searchParams } = new URL(request.url)
 
         const hostIdRaw = searchParams.get('hostId')
@@ -260,6 +272,14 @@ export const Route = createFileRoute('/api/v1/explorer/query')({
 
       POST: async ({ request }) => {
         bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        // Arbitrary SQL execution is a WRITE capability (see GET handler).
+        const authError = await authorizeFeatureRequest(
+          EXPLORER_QUERY_FEATURE_PERMISSION,
+          request,
+          { allowAgentBearerToken: true }
+        )
+        if (authError) return authError
 
         let body: Record<string, unknown>
         try {

--- a/apps/dashboard-tsr/src/start.ts
+++ b/apps/dashboard-tsr/src/start.ts
@@ -17,7 +17,11 @@ import { createMiddleware, createStart } from '@tanstack/react-start'
 
 import { env } from 'cloudflare:workers'
 import { clerkMiddleware } from '@clerk/tanstack-react-start/server'
-import { bridgeApiKeyEnv, resolveApiGuard } from '@/lib/auth/api-guard'
+import {
+  bridgeApiKeyEnv,
+  bridgePublicReadEnv,
+  resolveApiGuard,
+} from '@/lib/auth/api-guard'
 import { isClerkAuthProvider } from '@/lib/auth/provider'
 import { withSecurityHeaders } from '@/lib/security-headers'
 
@@ -29,6 +33,7 @@ const apiAuthMiddleware = createMiddleware().server(
     // Bridge the Worker env secret onto process.env so apiKeyAuthEnabled() /
     // verifyApiKey() (which read process.env.CHM_API_KEY_SECRET) can see it.
     bridgeApiKeyEnv(env as Record<string, string | undefined>)
+    bridgePublicReadEnv(env as Record<string, string | undefined>)
 
     const guardResponse = await resolveApiGuard(request)
     if (guardResponse) {

--- a/apps/dashboard/app/api/v1/actions/route.ts
+++ b/apps/dashboard/app/api/v1/actions/route.ts
@@ -140,7 +140,10 @@ export const POST = withApiHandler(async (request: Request) => {
 
   const permissionResponse = await authorizeFeatureRequest(
     ACTIONS_FEATURE_PERMISSION,
-    request
+    request,
+    // Accept a valid `chm_` API key as authentication so programmatic clients
+    // keep working now that actions defaults to `authenticated`.
+    { allowAgentBearerToken: true }
   )
   if (permissionResponse) return permissionResponse
 

--- a/apps/dashboard/app/api/v1/explorer/query/route.ts
+++ b/apps/dashboard/app/api/v1/explorer/query/route.ts
@@ -26,7 +26,7 @@ import {
   SUPPORTED_FORMATS,
 } from '@/lib/api/shared/validators/format'
 import { ApiErrorType } from '@/lib/api/types'
-import { TABLES_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
+import { EXPLORER_QUERY_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
 import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 
 export const dynamic = 'force-dynamic'
@@ -182,9 +182,12 @@ export async function GET(request: Request): Promise<Response> {
     ...ROUTE_CONTEXT_BASE,
     method: 'GET',
   }
+  // Arbitrary SQL execution is a WRITE capability: anonymous read-only callers
+  // (CHM_CLERK_PUBLIC_READ) are blocked; authenticated callers and API keys pass.
   const permissionResponse = await authorizeFeatureRequest(
-    TABLES_FEATURE_PERMISSION,
-    request
+    EXPLORER_QUERY_FEATURE_PERMISSION,
+    request,
+    { allowAgentBearerToken: true }
   )
   if (permissionResponse) return permissionResponse
 
@@ -228,9 +231,12 @@ export async function POST(request: Request): Promise<Response> {
     method: 'POST',
   }
 
+  // Arbitrary SQL execution is a WRITE capability: anonymous read-only callers
+  // (CHM_CLERK_PUBLIC_READ) are blocked; authenticated callers and API keys pass.
   const permissionResponse = await authorizeFeatureRequest(
-    TABLES_FEATURE_PERMISSION,
-    request
+    EXPLORER_QUERY_FEATURE_PERMISSION,
+    request,
+    { allowAgentBearerToken: true }
   )
   if (permissionResponse) return permissionResponse
 

--- a/apps/dashboard/lib/feature-permissions/__tests__/permissions.test.ts
+++ b/apps/dashboard/lib/feature-permissions/__tests__/permissions.test.ts
@@ -1,0 +1,89 @@
+import {
+  ACTIONS_FEATURE_PERMISSION,
+  AGENT_FEATURE_PERMISSION,
+  EXPLORER_QUERY_FEATURE_PERMISSION,
+  OVERVIEW_FEATURE_PERMISSION,
+  TABLES_FEATURE_PERMISSION,
+} from '../permissions'
+import { anonymousCapabilities, resolveFeatureState } from '../shared'
+import { describe, expect, test } from 'bun:test'
+
+// Security boundary: when CHM_CLERK_PUBLIC_READ lets anonymous read-only requests
+// skip Clerk in middleware.ts, the per-route authorizeFeatureRequest() is the
+// SOLE gate. agent + actions MUST resolve to `authenticated` and be classified
+// as `write` so anonymous callers cannot run the AI agent, mutating control
+// actions (KILL QUERY, OPTIMIZE TABLE), or arbitrary SQL.
+const NO_OVERRIDES = { features: {} }
+
+describe('feature permission defaults (security boundary)', () => {
+  test('agent defaults to authenticated', () => {
+    expect(resolveFeatureState(AGENT_FEATURE_PERMISSION, NO_OVERRIDES)).toEqual(
+      {
+        enabled: true,
+        access: 'authenticated',
+      }
+    )
+  })
+
+  test('actions defaults to authenticated', () => {
+    expect(
+      resolveFeatureState(ACTIONS_FEATURE_PERMISSION, NO_OVERRIDES)
+    ).toEqual({ enabled: true, access: 'authenticated' })
+  })
+
+  test('read-only features stay public', () => {
+    for (const perm of [
+      OVERVIEW_FEATURE_PERMISSION,
+      TABLES_FEATURE_PERMISSION,
+    ]) {
+      expect(resolveFeatureState(perm, NO_OVERRIDES).access).toBe('public')
+    }
+  })
+
+  test('operator can still loosen agent/actions to public via override', () => {
+    expect(
+      resolveFeatureState(ACTIONS_FEATURE_PERMISSION, {
+        features: { actions: { access: 'public' } },
+      }).access
+    ).toBe('public')
+  })
+})
+
+describe('write operation classification', () => {
+  test('agent + actions are writes', () => {
+    expect(AGENT_FEATURE_PERMISSION.operation).toBe('write')
+    expect(ACTIONS_FEATURE_PERMISSION.operation).toBe('write')
+  })
+
+  test('arbitrary SQL execution (explorer query) is a write on the tables feature', () => {
+    expect(EXPLORER_QUERY_FEATURE_PERMISSION.operation).toBe('write')
+    expect(EXPLORER_QUERY_FEATURE_PERMISSION.feature).toBe('tables')
+  })
+
+  test('schema-browsing tables permission is a read (default operation)', () => {
+    expect(TABLES_FEATURE_PERMISSION.operation).toBeUndefined()
+  })
+})
+
+describe('anonymousCapabilities matrix', () => {
+  test('auth=none → read + write', () => {
+    expect(anonymousCapabilities('none', false)).toEqual({
+      read: true,
+      write: true,
+    })
+  })
+
+  test('auth=clerk + public read → read only', () => {
+    expect(anonymousCapabilities('clerk', true)).toEqual({
+      read: true,
+      write: false,
+    })
+  })
+
+  test('auth=clerk default → no read, no write', () => {
+    expect(anonymousCapabilities('clerk', false)).toEqual({
+      read: false,
+      write: false,
+    })
+  })
+})

--- a/apps/dashboard/lib/feature-permissions/permissions.ts
+++ b/apps/dashboard/lib/feature-permissions/permissions.ts
@@ -3,14 +3,32 @@ import type { FeaturePermission } from './types'
 export const AGENT_FEATURE_PERMISSION = {
   feature: 'agent',
   interactionGated: true,
+  // The AI agent runs queries and (with control tools) mutates the cluster — a
+  // write. defaultAccess keeps the existing frontend gate (AgentAuthGate keys
+  // off access === 'authenticated'); operation classifies it on the read/write
+  // axis so anonymous read-only deployments cannot drive the agent.
+  defaultAccess: 'authenticated',
+  operation: 'write',
 } satisfies FeaturePermission
 
 export const ACTIONS_FEATURE_PERMISSION = {
   feature: 'actions',
+  // Mutating control actions (KILL QUERY, OPTIMIZE TABLE) — a write.
+  defaultAccess: 'authenticated',
+  operation: 'write',
 } satisfies FeaturePermission
 
 export const TABLES_FEATURE_PERMISSION = {
   feature: 'tables',
+} satisfies FeaturePermission
+
+// Arbitrary user-supplied SQL execution (SQL Console, explorer query tab).
+// Same `tables` feature as schema browsing, but classified as a write: running
+// attacker-chosen SQL is a powerful capability distinct from a fixed registry
+// query, so anonymous read-only callers must not reach it.
+export const EXPLORER_QUERY_FEATURE_PERMISSION = {
+  feature: 'tables',
+  operation: 'write',
 } satisfies FeaturePermission
 
 export const OVERVIEW_FEATURE_PERMISSION = {

--- a/apps/dashboard/lib/feature-permissions/server.ts
+++ b/apps/dashboard/lib/feature-permissions/server.ts
@@ -8,6 +8,7 @@ import type {
 } from './types'
 
 import {
+  anonymousCapabilities,
   getResolvedFeatureStates,
   mergeFeatureOverrides,
   normalizeFeatureAccess,
@@ -210,6 +211,14 @@ function parseEnvFeatureOverrides(): FeatureOverrides {
   return overrides
 }
 
+/** Opt-in anonymous read under clerk (see middleware.ts publicReadEnabled). */
+function publicReadEnabled(): boolean {
+  return (
+    parseBoolean(process.env.CHM_CLERK_PUBLIC_READ, 'CHM_CLERK_PUBLIC_READ') ===
+    true
+  )
+}
+
 function parseEnvAuthProvider(): AuthProvider | undefined {
   const raw =
     process.env.CHM_AUTH_PROVIDER ?? process.env.NEXT_PUBLIC_AUTH_PROVIDER
@@ -289,6 +298,10 @@ export async function getPublicFeaturePermissionConfig(): Promise<PublicFeatureP
     principal,
     features: config.features,
     resolved,
+    capabilities: anonymousCapabilities(
+      config.authProvider,
+      publicReadEnabled()
+    ),
   }
 }
 
@@ -370,10 +383,16 @@ export async function authorizeFeatureRequest(
     )
   }
 
-  if (state.access === 'public') {
+  // Anonymous baseline first (cheap, no Clerk call): a public READ is allowed
+  // when the deployment grants anonymous read. Writes never qualify here.
+  const operation = permission.operation ?? 'read'
+  const caps = anonymousCapabilities(config.authProvider, publicReadEnabled())
+  if (operation === 'read' && state.access === 'public' && caps.read) {
     return null
   }
 
+  // Otherwise require an authenticated caller (Clerk session / bearer token;
+  // `none` authenticates everyone).
   if (await isAuthenticatedRequest(request, config, options)) {
     return null
   }

--- a/apps/dashboard/lib/feature-permissions/shared.ts
+++ b/apps/dashboard/lib/feature-permissions/shared.ts
@@ -17,6 +17,28 @@ export const DEFAULT_FEATURE_STATE: FeatureState = {
   access: DEFAULT_FEATURE_ACCESS,
 }
 
+/**
+ * What an anonymous caller may do, by deployment posture:
+ *
+ *  - `none`                       → read + write   (everyone is authenticated)
+ *  - `clerk` + CHM_CLERK_PUBLIC_READ → read only   (the dash / dash-tsr posture)
+ *  - `clerk` (default) / `proxy`  → nothing        (sign in / proxy-auth required)
+ *
+ * Authenticated callers always get read + write; this only describes the
+ * anonymous baseline. Pure (publicRead passed in) so it is shared by the server
+ * authorize path and the public config endpoint.
+ */
+export function anonymousCapabilities(
+  authProvider: PublicFeaturePermissionConfig['authProvider'],
+  publicRead: boolean
+): { read: boolean; write: boolean } {
+  if (authProvider === 'none') return { read: true, write: true }
+  if (authProvider === 'clerk' && publicRead) {
+    return { read: true, write: false }
+  }
+  return { read: false, write: false }
+}
+
 const FEATURE_ID_SET = new Set<string>(FEATURE_IDS)
 const FEATURE_ACCESS_SET = new Set<string>(FEATURE_ACCESS_VALUES)
 const FEATURE_ACCESS_ALIASES: Record<string, FeatureAccess> = {

--- a/apps/dashboard/lib/feature-permissions/types.ts
+++ b/apps/dashboard/lib/feature-permissions/types.ts
@@ -25,6 +25,10 @@ export const FEATURE_IDS = [
 
 export type FeatureId = (typeof FEATURE_IDS)[number]
 
+export const FEATURE_OPERATIONS = ['read', 'write'] as const
+
+export type FeatureOperation = (typeof FEATURE_OPERATIONS)[number]
+
 export interface FeaturePermission {
   feature: FeatureId
   /**
@@ -42,6 +46,27 @@ export interface FeaturePermission {
    * @default false
    */
   interactionGated?: boolean
+  /**
+   * Whether this call site READS data or WRITES (mutates the cluster, runs the
+   * AI agent, or executes arbitrary user-supplied SQL). Anonymous callers are
+   * allowed reads only when the deployment grants anonymous read
+   * (`CHM_CLERK_PUBLIC_READ` under clerk, or `auth=none`); writes always require
+   * an authenticated caller. The same feature can be referenced by both a read
+   * permission (e.g. schema browsing) and a write permission (arbitrary query).
+   *
+   * @default read
+   */
+  operation?: FeatureOperation
+}
+
+/**
+ * What an ANONYMOUS (unauthenticated) caller may do, derived from the auth
+ * provider and `CHM_CLERK_PUBLIC_READ`. Authenticated callers can always do
+ * both. Principal-independent, so it is safe to expose in the public config.
+ */
+export interface AnonymousCapabilities {
+  read: boolean
+  write: boolean
 }
 
 export interface FeatureOverride {
@@ -65,4 +90,6 @@ export interface PublicFeaturePermissionConfig {
   principal: Principal
   features: FeatureOverrides
   resolved?: ResolvedFeatureStates
+  /** What anonymous callers may do under this deployment's auth posture. */
+  capabilities?: AnonymousCapabilities
 }

--- a/apps/dashboard/middleware.ts
+++ b/apps/dashboard/middleware.ts
@@ -58,6 +58,25 @@ function isProtectedAgentApiRoute(request: NextRequest) {
   )
 }
 
+function isProtectedActionsRoute(request: NextRequest) {
+  return normalizePathname(request.nextUrl.pathname) === '/api/v1/actions'
+}
+
+/**
+ * Opt-in public read-only mode for the Clerk provider.
+ *
+ * When `CHM_CLERK_PUBLIC_READ` is truthy, anonymous read-only `/api/v1/*`
+ * requests skip the Clerk middleware so the per-route `authorizeFeatureRequest()`
+ * can serve public features to anonymous visitors. Agent and actions routes are
+ * excluded — they keep fronting Clerk and are `authenticated` per-route, so they
+ * stay login-gated. Named with the CLERK prefix because it only relaxes the
+ * clerk posture (`none` is already fully open).
+ */
+function publicReadEnabled() {
+  const raw = process.env.CHM_CLERK_PUBLIC_READ?.trim().toLowerCase()
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on'
+}
+
 function hasPotentialClerkCookie(request: NextRequest) {
   return request.cookies.getAll().some(({ name }) => {
     return (
@@ -146,6 +165,18 @@ export default async function middleware(
     const agentApiPrecheck = await getAgentApiClerkPrecheck(request)
     if (agentApiPrecheck) {
       return agentApiPrecheck
+    }
+
+    // Public read-only mode: let anonymous read-only /api/v1/* requests skip
+    // Clerk so the per-route feature gate can serve public features. Agent and
+    // actions routes are excluded — they stay Clerk-fronted and authenticated.
+    if (
+      publicReadEnabled() &&
+      pathname.startsWith('/api/v1/') &&
+      !isProtectedAgentApiRoute(request) &&
+      !isProtectedActionsRoute(request)
+    ) {
+      return NextResponse.next()
     }
 
     return clerkMiddleware()(request, event)

--- a/docs/content/advanced/feature-permissions.mdx
+++ b/docs/content/advanced/feature-permissions.mdx
@@ -1,6 +1,8 @@
 # Feature Permissions
 
-Feature permissions let you hide or protect specific dashboard sections without changing application code. All features are public and enabled by default — configure only what needs different behavior.
+Feature permissions let you hide or protect specific dashboard sections without changing application code. Features are enabled and public by default — except the **AI agent** (`agent`) and **control actions** (`actions`), which default to `authenticated`. Configure only what needs different behavior.
+
+Permissions also carry a **read / write** classification. Reads are predefined monitoring data; writes are the AI agent, control actions, and arbitrary SQL execution. Under `auth=clerk` with [`CHM_CLERK_PUBLIC_READ`](/docs/authentication/clerk#public-read-only-mode), anonymous visitors may perform reads but never writes; with `auth=none` everyone may do both.
 
 ---
 

--- a/docs/content/authentication/clerk.mdx
+++ b/docs/content/authentication/clerk.mdx
@@ -46,13 +46,53 @@ See [MCP Server](/docs/reference/mcp-server) for connection details.
 
 ## Gating features to authenticated users
 
-By default, features remain public even with Clerk enabled. To require sign-in for a feature:
+Most features are public even with Clerk enabled. The **AI agent** (`agent`) and
+**control actions** (`actions` — KILL QUERY, OPTIMIZE TABLE) default to
+`authenticated`, so they require sign-in. To change a feature's access:
 
 ```bash
-CHM_FEATURE_AGENT_ACCESS=authenticated
+CHM_FEATURE_AGENT_ACCESS=public          # loosen the agent to public
+CHM_FEATURE_TABLES_ACCESS=authenticated  # require sign-in for tables
 ```
 
 See [Feature Permissions](/docs/advanced/feature-permissions) for all feature ids and options.
+
+## Public read-only mode
+
+By default, Clerk gates **every** `/api/v1/*` request — an anonymous visitor sees
+the dashboard shell but no data (every data call returns `401`). Set
+`CHM_CLERK_PUBLIC_READ` to let anonymous visitors view read-only monitoring
+content while keeping sign-in required for writes:
+
+```bash
+CHM_AUTH_PROVIDER=clerk
+CHM_CLERK_PUBLIC_READ=true   # runtime / Worker var
+```
+
+Access is then split along a **read / write** boundary:
+
+- **Reads** — predefined monitoring data (overview, queries, tables, metrics,
+  charts, schema browsing) — serve to anonymous visitors.
+- **Writes** — the AI agent, control actions (KILL QUERY, OPTIMIZE TABLE), and
+  **arbitrary SQL execution** (SQL Console / explorer query) — still return `401`
+  for anonymous callers. Running attacker-chosen SQL is treated as a write even
+  though it runs read-only, because it is a far more powerful capability than a
+  fixed registry query.
+- API keys (`chm_` bearer tokens) and signed-in Clerk users get full read + write.
+
+### Anonymous capability matrix
+
+| Auth mode | Anonymous read | Anonymous write |
+|---|---|---|
+| `none` | ✅ | ✅ (everyone is authenticated) |
+| `clerk` + `CHM_CLERK_PUBLIC_READ=true` | ✅ | ❌ |
+| `clerk` (default) | ❌ | ❌ |
+| `proxy` | ❌ | ❌ (proxy authenticates upstream) |
+
+The flag only applies to the `clerk` provider — `none` is already fully public and
+`proxy` fronts its own auth. It is off by default, so existing locked-down Clerk
+deployments are unchanged. The client reads these flags from `GET /api/v1/config`
+(`capabilities.read` / `capabilities.write`) to decide what to surface.
 
 ## Related
 

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -117,6 +117,7 @@ The active server-side auth provider is set by `CHM_AUTH_PROVIDER`. See [Authent
 |---|---|---|
 | `VITE_CLERK_PUBLISHABLE_KEY` | — | Clerk publishable key (`pk_...`). Build-time — must be set before `bun run build`. |
 | `CLERK_SECRET_KEY` | — | Clerk secret key (`sk_...`). Runtime only. Never expose to the browser. |
+| `CHM_CLERK_PUBLIC_READ` | `false` | When `true`, anonymous visitors can view read-only monitoring content; writes (AI agent, control actions, arbitrary SQL) still require sign-in. Runtime only. See [Clerk → Public read-only mode](/docs/authentication/clerk#public-read-only-mode). |
 
 ### Reverse proxy (`CHM_AUTH_PROVIDER=proxy`)
 


### PR DESCRIPTION
## What

Introduces an explicit **read vs write** capability model so a Clerk deployment can let anonymous visitors **view** monitoring data while keeping **writes** behind sign-in. Opt-in via the new `CHM_CLERK_PUBLIC_READ` flag.

### Anonymous capability matrix

| Auth mode | Anonymous read | Anonymous write |
|---|---|---|
| `none` | ✅ | ✅ (everyone is authenticated) |
| `clerk` + `CHM_CLERK_PUBLIC_READ=true` | ✅ | ❌ |
| `clerk` (default) | ❌ | ❌ |
| `proxy` | ❌ | ❌ |

**Write** = AI agent, control actions (KILL QUERY / OPTIMIZE TABLE), and **arbitrary SQL execution** (SQL Console / explorer query — treated as a write because running attacker-chosen SQL is far more powerful than a fixed registry query). **Read** = predefined charts/tables/metrics/overview + schema browsing.

## How

Both `apps/dashboard` (Next.js) and `apps/dashboard-tsr` (TanStack Start):

- `FeaturePermission` gains `operation: 'read' | 'write'` (default `read`). `agent` + `actions` are classified `write`; new `EXPLORER_QUERY_FEATURE_PERMISSION` classifies arbitrary SQL as a write on the `tables` feature.
- `authorizeFeatureRequest` is operation-aware: an anonymous caller may run a **public read** only when the deployment grants anonymous read (`anonymousCapabilities`); writes always require an authenticated caller. `none` authenticates everyone; `chm_` API keys and Clerk sessions get full read+write.
- `CHM_CLERK_PUBLIC_READ` relaxes the blanket `/api/v1/*` guard (`api-guard.ts` / `middleware.ts`) for anonymous reads; per-route checks stay the security boundary.
- `/api/v1/config` now exposes anonymous `capabilities { read, write }` for the client to gate write UI later.
- `/api/v1/explorer/query` gated as a write in both apps; the `actions` route accepts `chm_` API keys.

## Security ordering

`agent`/`actions` previously defaulted to `public` and were protected **only** by the blanket guard. They are now `authenticated` **and** `operation: write`, so relaxing the guard cannot expose them. Closing the doors precedes opening the wall.

## Tests / verification

- New unit tests (both apps): default access, write classification, and the full capability matrix. ✅
- `bun run type-check` both apps ✅; Biome clean ✅ (pre-commit enforced).
- **Not run** (needs live Clerk + ClickHouse): manual end-to-end — anonymous incognito on `clerk` + `CHM_CLERK_PUBLIC_READ=true` → charts 200, `POST /api/v1/actions` & `/api/v1/agent` & `/api/v1/explorer/query` → 401.

## Follow-up (non-blocking)

Client UI still renders write buttons for anonymous users (they 401 with a clear message; agent already prompts via `AgentAuthGate`). A `capabilities`-driven pass to disable/hide write buttons is left as a fast follow.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added optional public read-only mode for Clerk authentication deployments
  - Configuration API now reports anonymous user capabilities based on auth mode

* **Security Updates**
  - Agent and control actions features now require authentication by default
  - Query execution endpoints now enforce proper authorization checks
  - API endpoints support agent API key authentication for programmatic access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->