### PR TITLE
feat(auth): activate CHM_CLERK_PUBLIC_READ on dash + dash-tsr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,14 @@ Co-Authored-By: duyetbot <bot@duyet.net>
 
 Use semantic commit format with consistent scope for commit messages and PR titles. Keep wording simple.
 
+## PR Workflow
+
+**Always auto-babysit PRs on this project.** After opening any PR, immediately arm
+auto-merge (`gh pr merge --auto --squash`) and babysit it (`/github:babysit-pr`):
+watch CI, fix failures, confirm the merge and production deploy. Do NOT ask the
+user whether to babysit — just do it. Known non-required checks (`e2e-test`,
+`e2e-test-tsr`, `component-test`, `unit-tests`) do not block auto-merge.
+
 ## Project Overview
 
 This is a Next.js 15 (React 19) ClickHouse monitoring dashboard that provides real-time insights into ClickHouse clusters through system tables. The application connects to ClickHouse instances and displays metrics, query performance, table information, and cluster health.

--- a/apps/dashboard-tsr/wrangler.toml
+++ b/apps/dashboard-tsr/wrangler.toml
@@ -38,6 +38,9 @@ OPENROUTER_APP_NAME = "chmonitor"
 # import.meta.env.VITE_* (see vite.config.ts CLIENT_ENV).
 CHM_AUTH_PROVIDER = "clerk"
 CHM_FEATURE_AGENT_ACCESS = "authenticated"
+# Public read-only mode: anonymous visitors can view monitoring data; writes
+# (AI agent, KILL QUERY / OPTIMIZE TABLE, arbitrary SQL) still require sign-in.
+CHM_CLERK_PUBLIC_READ = "true"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Reverse-proxy auth (EXAMPLE — not active; dash-tsr uses `clerk` above).
@@ -92,3 +95,4 @@ OPENROUTER_APP_NAME = "chmonitor"
 # build step sets the pk_test key for preview deploys.
 CHM_AUTH_PROVIDER = "clerk"
 CHM_FEATURE_AGENT_ACCESS = "authenticated"
+CHM_CLERK_PUBLIC_READ = "true"

--- a/apps/dashboard/middleware.ts
+++ b/apps/dashboard/middleware.ts
@@ -29,6 +29,12 @@ async function getApiKeyAuthFailure(request: Request) {
   const headerToken = getBearerToken(request.headers.get('authorization'))
 
   if (!headerToken) {
+    // Public read-only mode: let anonymous READ requests through even when
+    // API-key auth is enabled. Writes (agent / actions / arbitrary SQL) still
+    // require a credential — their route handlers enforce auth.
+    if (publicReadEnabled() && !isProtectedWritePath(pathname)) {
+      return null
+    }
     return NextResponse.json({ error: 'API key required' }, { status: 401 })
   }
 
@@ -58,8 +64,24 @@ function isProtectedAgentApiRoute(request: NextRequest) {
   )
 }
 
-function isProtectedActionsRoute(request: NextRequest) {
-  return normalizePathname(request.nextUrl.pathname) === '/api/v1/actions'
+// Write-capability paths: the AI agent, control actions, and arbitrary SQL
+// execution. These must NEVER be opened to anonymous callers by public read-only
+// mode — they stay Clerk-fronted / API-key-gated, and their route handlers run
+// authorizeFeatureRequest() (operation: 'write'). Skipping Clerk for these would
+// also break auth() for *signed-in* users, so the public-read bypasses exclude
+// them on both the API-key layer and the Clerk layer.
+const PROTECTED_WRITE_PATHS = new Set([
+  '/api/v1/agent',
+  '/api/v1/agent/followups',
+  '/api/v1/agent/skills',
+  '/api/v1/agents/config-check',
+  '/api/v1/agents/models',
+  '/api/v1/actions',
+  '/api/v1/explorer/query',
+])
+
+function isProtectedWritePath(pathname: string): boolean {
+  return PROTECTED_WRITE_PATHS.has(normalizePathname(pathname))
 }
 
 /**
@@ -168,13 +190,13 @@ export default async function middleware(
     }
 
     // Public read-only mode: let anonymous read-only /api/v1/* requests skip
-    // Clerk so the per-route feature gate can serve public features. Agent and
-    // actions routes are excluded — they stay Clerk-fronted and authenticated.
+    // Clerk so the per-route feature gate can serve public features. Write paths
+    // (agent / actions / arbitrary SQL) are excluded — they stay Clerk-fronted so
+    // auth() resolves for signed-in users and writes remain authenticated.
     if (
       publicReadEnabled() &&
       pathname.startsWith('/api/v1/') &&
-      !isProtectedAgentApiRoute(request) &&
-      !isProtectedActionsRoute(request)
+      !isProtectedWritePath(pathname)
     ) {
       return NextResponse.next()
     }

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -177,6 +177,9 @@ OPENROUTER_APP_NAME = "chmonitor"
 CHM_AUTH_PROVIDER = "clerk"
 NEXT_PUBLIC_AUTH_PROVIDER = "clerk"
 CHM_FEATURE_AGENT_ACCESS = "authenticated"
+# Public read-only mode: anonymous visitors can view monitoring data; writes
+# (AI agent, KILL QUERY / OPTIMIZE TABLE, arbitrary SQL) still require sign-in.
+CHM_CLERK_PUBLIC_READ = "true"
 
 # Clerk authentication (public key is safe to include)
 # Publishable key for Clerk authentication - identifies the Clerk application
@@ -221,6 +224,7 @@ OPENROUTER_APP_NAME = "chmonitor"
 CHM_AUTH_PROVIDER = "clerk"
 NEXT_PUBLIC_AUTH_PROVIDER = "clerk"
 CHM_FEATURE_AGENT_ACCESS = "authenticated"
+CHM_CLERK_PUBLIC_READ = "true"
 
 # Clerk authentication (public key is safe to include)
 # Test key for preview environment - uses Clerk's test instance


### PR DESCRIPTION
Follow-up to #1535. That PR shipped the read/write model but left it **dormant** — the flag was unset in every deploy env, so anonymous `/api/v1/*` still 401s on both instances (verified live: dash-tsr → `Authentication required`, dash → `API key required`).

## Changes

- **Enable the flag**: `CHM_CLERK_PUBLIC_READ="true"` in `apps/dashboard-tsr/wrangler.toml` and `apps/dashboard/wrangler.toml` (production + preview). Anonymous visitors can now view read-only monitoring data; writes (AI agent, KILL QUERY / OPTIMIZE TABLE, arbitrary SQL) still require sign-in.
- **Fix dash middleware ordering** (Next.js): API-key auth (`CHM_API_KEY_SECRET`) ran *before* the public-read bypass and hard-401'd tokenless anonymous requests, shadowing the flag. `getApiKeyAuthFailure` now lets anonymous **reads** through under public-read; writes still require a credential.
- **Unify write-path exclusion** on a single `PROTECTED_WRITE_PATHS` set (agent, actions, `explorer/query`). This also fixes a latent bug from #1535: `/api/v1/explorer/query` was not excluded from the Clerk-skip, so a **signed-in** user's request would skip `clerkMiddleware` and `auth()` would fail → 401 even when authenticated. It now stays Clerk-fronted.
- **CLAUDE.md**: record the standing "always auto-babysit PRs" workflow.

## Result (after deploy)

| Instance | Anonymous read | Anonymous write |
|---|---|---|
| dash-tsr.chmonitor.dev | ✅ | ❌ |
| dash.chmonitor.dev | ✅ | ❌ |

Verify post-deploy: `curl https://dash-tsr.chmonitor.dev/api/v1/config` → 200 with `capabilities: {read:true, write:false}`; `curl -XPOST .../api/v1/explorer/query` (anon) → 401.

## Verification
- `bun run type-check` (dashboard) ✅; Biome clean ✅ (pre-commit enforced).

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled public read-only access mode, allowing anonymous visitors to view monitoring dashboards and analytics without signing in. Write operations including agent actions, query modifications, and table optimization remain restricted to authenticated users.

* **Chores**
  * Updated contributor documentation with PR workflow guidelines, including auto-merge procedures and CI process monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->