### PR TITLE
fix(dashboard-tsr): deploy CHM_CLERK_PUBLIC_READ var (CI patch script)

### DIFF
--- a/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
+++ b/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
@@ -47,6 +47,9 @@ const SHARED_VARS = {
   OPENROUTER_APP_NAME: 'chmonitor',
   CHM_AUTH_PROVIDER: 'clerk',
   CHM_FEATURE_AGENT_ACCESS: 'authenticated',
+  // Public read-only mode: anonymous visitors can view monitoring data; writes
+  // (AI agent, KILL QUERY / OPTIMIZE TABLE, arbitrary SQL) still require sign-in.
+  CHM_CLERK_PUBLIC_READ: 'true',
 }
 // NOTE: client auth config (auth provider + Clerk publishable key) is NOT a
 // runtime worker var — it is build-time inlined via import.meta.env.VITE_* (see


### PR DESCRIPTION
#1536 enabled `CHM_CLERK_PUBLIC_READ` in `wrangler.toml`, but the dash-tsr CI deploy regenerates the worker config from `scripts/patch-wrangler-env.ts` and overwrites `[vars]` — so the flag was silently dropped (deploy log: `vars: 10 keys`, missing the new var). Live `dash-tsr.chmonitor.dev/api/v1/config` still returned `401` to anonymous after the #1536 deploy.

Fix: add `CHM_CLERK_PUBLIC_READ: 'true'` to `SHARED_VARS` so production + preview deploys include it. The dash Next app deploys `wrangler.toml` directly (no patch script), so its #1536 var edit already works.

Verify post-deploy: `curl https://dash-tsr.chmonitor.dev/api/v1/config` → 200 with `capabilities:{read:true,write:false}`.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

New Features:
- Enable public read-only access for anonymous users on the dashboard-tsr API by propagating CHM_CLERK_PUBLIC_READ via shared Wrangler vars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled read-only access for anonymous visitors while maintaining sign-in requirements for write and agent actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->