### PR TITLE
chore(dashboard-tsr): scrub homelab hosts/usernames from committed config (open-source defaults)

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -327,6 +327,16 @@ jobs:
         run: bun run build
 
       - name: Patch wrangler config with env sections
+        # Deployment-specific worker vars (ClickHouse host/user/name, OpenRouter
+        # referer) are injected here from repo secrets. The committed defaults in
+        # patch-wrangler-env.ts / wrangler.toml are public localhost placeholders,
+        # so the real homelab topology never lands in the public repo. Falls back
+        # to those defaults when a secret is unset.
+        env:
+          CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
+          CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+          CLICKHOUSE_NAME: ${{ secrets.CLICKHOUSE_NAME }}
+          OPENROUTER_REFERER: ${{ secrets.OPENROUTER_REFERER }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             bun scripts/patch-wrangler-env.ts --env preview

--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -336,7 +336,6 @@ jobs:
           CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
           CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
           CLICKHOUSE_NAME: ${{ secrets.CLICKHOUSE_NAME }}
-          OPENROUTER_REFERER: ${{ secrets.OPENROUTER_REFERER }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             bun scripts/patch-wrangler-env.ts --env preview

--- a/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
+++ b/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
@@ -37,13 +37,12 @@ const generated = JSON.parse(readFileSync(JSON_PATH, 'utf-8'))
 
 // --- Shared vars (keep in sync with wrangler.toml) ---
 const SHARED_VARS = {
-  CLICKHOUSE_HOST:
-    'https://duet-ubuntu.dingo-mora.ts.net:8443,https://openclaw.dingo-mora.ts.net',
-  CLICKHOUSE_USER: 'duyet,monitoring',
-  CLICKHOUSE_NAME: 'duet-ubuntu,duyet-agent',
+  CLICKHOUSE_HOST: process.env.CLICKHOUSE_HOST || 'http://localhost:8123',
+  CLICKHOUSE_USER: process.env.CLICKHOUSE_USER || 'default',
+  CLICKHOUSE_NAME: process.env.CLICKHOUSE_NAME || 'localhost',
   CLICKHOUSE_MAX_EXECUTION_TIME: '60',
   CLOUDFLARE_WORKERS: '1',
-  OPENROUTER_REFERER: 'https://clickhouse.duyet.net',
+  OPENROUTER_REFERER: 'http://localhost:3000',
   OPENROUTER_APP_NAME: 'chmonitor',
   CHM_AUTH_PROVIDER: 'clerk',
   CHM_FEATURE_AGENT_ACCESS: 'authenticated',

--- a/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
+++ b/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
@@ -36,13 +36,18 @@ if (!existsSync(JSON_PATH)) {
 const generated = JSON.parse(readFileSync(JSON_PATH, 'utf-8'))
 
 // --- Shared vars (keep in sync with wrangler.toml) ---
+// Deployment-specific values (ClickHouse host/user/name, OpenRouter referer)
+// are read from the environment at deploy time and fall back to public
+// localhost defaults. CI injects the real values from repo secrets (see the
+// "Patch wrangler config" step in .github/workflows/cloudflare.yml); the
+// committed defaults keep the public repo free of any private homelab info.
 const SHARED_VARS = {
   CLICKHOUSE_HOST: process.env.CLICKHOUSE_HOST || 'http://localhost:8123',
   CLICKHOUSE_USER: process.env.CLICKHOUSE_USER || 'default',
   CLICKHOUSE_NAME: process.env.CLICKHOUSE_NAME || 'localhost',
   CLICKHOUSE_MAX_EXECUTION_TIME: '60',
   CLOUDFLARE_WORKERS: '1',
-  OPENROUTER_REFERER: 'http://localhost:3000',
+  OPENROUTER_REFERER: process.env.OPENROUTER_REFERER || 'http://localhost:3000',
   OPENROUTER_APP_NAME: 'chmonitor',
   CHM_AUTH_PROVIDER: 'clerk',
   CHM_FEATURE_AGENT_ACCESS: 'authenticated',

--- a/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
+++ b/apps/dashboard-tsr/scripts/patch-wrangler-env.ts
@@ -36,18 +36,22 @@ if (!existsSync(JSON_PATH)) {
 const generated = JSON.parse(readFileSync(JSON_PATH, 'utf-8'))
 
 // --- Shared vars (keep in sync with wrangler.toml) ---
-// Deployment-specific values (ClickHouse host/user/name, OpenRouter referer)
-// are read from the environment at deploy time and fall back to public
-// localhost defaults. CI injects the real values from repo secrets (see the
-// "Patch wrangler config" step in .github/workflows/cloudflare.yml); the
-// committed defaults keep the public repo free of any private homelab info.
+// Private homelab topology (ClickHouse host/user/name) is read from the
+// environment at deploy time and falls back to public localhost defaults. CI
+// injects the real values from repo secrets (see the "Patch wrangler config"
+// step in .github/workflows/cloudflare.yml); the committed defaults keep the
+// public repo free of any private info.
+// OPENROUTER_REFERER is the OpenRouter/AnyRouter attribution header (HTTP-Referer
+// for app-ranking on their leaderboards) — not sensitive. It defaults to the
+// public product domain so every LLM call attributes back to chmonitor; forks
+// can override via env.
 const SHARED_VARS = {
   CLICKHOUSE_HOST: process.env.CLICKHOUSE_HOST || 'http://localhost:8123',
   CLICKHOUSE_USER: process.env.CLICKHOUSE_USER || 'default',
   CLICKHOUSE_NAME: process.env.CLICKHOUSE_NAME || 'localhost',
   CLICKHOUSE_MAX_EXECUTION_TIME: '60',
   CLOUDFLARE_WORKERS: '1',
-  OPENROUTER_REFERER: process.env.OPENROUTER_REFERER || 'http://localhost:3000',
+  OPENROUTER_REFERER: process.env.OPENROUTER_REFERER || 'https://chmonitor.dev',
   OPENROUTER_APP_NAME: 'chmonitor',
   CHM_AUTH_PROVIDER: 'clerk',
   CHM_FEATURE_AGENT_ACCESS: 'authenticated',

--- a/apps/dashboard-tsr/src/components/assistant-ui/agent-thread-page.tsx
+++ b/apps/dashboard-tsr/src/components/assistant-ui/agent-thread-page.tsx
@@ -141,7 +141,7 @@ export function AgentThreadPage() {
             <AgentSettingsSidebar
               open={rightSidebarOpen}
               onClose={() => setRightSidebarOpen(false)}
-              hostName={clusterName ?? 'duyet-agent'}
+              hostName={clusterName ?? 'default'}
             />
           </div>
         </AgentRuntimeProvider>

--- a/apps/dashboard-tsr/wrangler.toml
+++ b/apps/dashboard-tsr/wrangler.toml
@@ -4,8 +4,7 @@
 # the @cloudflare/vite-plugin produces the worker bundle + client asset
 # manifest at build time, so no explicit [assets] block is required.
 #
-# NOTE: no real ClickHouse hosts/credentials are committed here (public repo).
-# Runtime vars/secrets are injected per environment at deploy time.
+# Public defaults only — real hosts/users are injected per-environment at deploy time via CI secrets.
 
 name = "chmonitor-dash-tsr"
 main = "@tanstack/react-start/server-entry"
@@ -25,13 +24,13 @@ pattern = "dash-tsr.chmonitor.dev"
 custom_domain = true
 
 [vars]
-CLICKHOUSE_HOST = "https://duet-ubuntu.dingo-mora.ts.net:8443,https://openclaw.dingo-mora.ts.net"
-CLICKHOUSE_USER = "duyet,monitoring"
-CLICKHOUSE_NAME = "duet-ubuntu,duyet-agent"
+CLICKHOUSE_HOST = "http://localhost:8123"
+CLICKHOUSE_USER = "default"
+CLICKHOUSE_NAME = "localhost"
 CLICKHOUSE_MAX_EXECUTION_TIME = "60"
 CLOUDFLARE_WORKERS = "1"
 LLM_MODEL = "anyrouter:@preset/chmonitor"
-OPENROUTER_REFERER = "https://clickhouse.duyet.net"
+OPENROUTER_REFERER = "http://localhost:3000"
 OPENROUTER_APP_NAME = "chmonitor"
 # Server-side auth provider (runtime). The CLIENT auth provider + Clerk
 # publishable key are NOT runtime vars — they are build-time inlined via
@@ -81,13 +80,13 @@ custom_domain = true
 
 # Vars must be explicitly set per environment (not inherited from top-level)
 [env.preview.vars]
-CLICKHOUSE_HOST = "https://duet-ubuntu.dingo-mora.ts.net:8443,https://openclaw.dingo-mora.ts.net"
-CLICKHOUSE_USER = "duyet,monitoring"
-CLICKHOUSE_NAME = "duet-ubuntu,duyet-agent"
+CLICKHOUSE_HOST = "http://localhost:8123"
+CLICKHOUSE_USER = "default"
+CLICKHOUSE_NAME = "localhost"
 CLICKHOUSE_MAX_EXECUTION_TIME = "60"
 CLOUDFLARE_WORKERS = "1"
 LLM_MODEL = "anyrouter:z-ai/glm-4.7-flash"
-OPENROUTER_REFERER = "https://clickhouse.duyet.net"
+OPENROUTER_REFERER = "http://localhost:3000"
 OPENROUTER_APP_NAME = "chmonitor"
 
 # Server-side auth provider for preview (runtime). Client auth provider + the

--- a/apps/dashboard-tsr/wrangler.toml
+++ b/apps/dashboard-tsr/wrangler.toml
@@ -30,7 +30,7 @@ CLICKHOUSE_NAME = "localhost"
 CLICKHOUSE_MAX_EXECUTION_TIME = "60"
 CLOUDFLARE_WORKERS = "1"
 LLM_MODEL = "anyrouter:@preset/chmonitor"
-OPENROUTER_REFERER = "http://localhost:3000"
+OPENROUTER_REFERER = "https://chmonitor.dev"
 OPENROUTER_APP_NAME = "chmonitor"
 # Server-side auth provider (runtime). The CLIENT auth provider + Clerk
 # publishable key are NOT runtime vars — they are build-time inlined via
@@ -86,7 +86,7 @@ CLICKHOUSE_NAME = "localhost"
 CLICKHOUSE_MAX_EXECUTION_TIME = "60"
 CLOUDFLARE_WORKERS = "1"
 LLM_MODEL = "anyrouter:z-ai/glm-4.7-flash"
-OPENROUTER_REFERER = "http://localhost:3000"
+OPENROUTER_REFERER = "https://chmonitor.dev"
 OPENROUTER_APP_NAME = "chmonitor"
 
 # Server-side auth provider for preview (runtime). Client auth provider + the


### PR DESCRIPTION
## Summary

- `wrangler.toml` and `scripts/patch-wrangler-env.ts` contained real Tailscale homelab hostnames (`duet-ubuntu.dingo-mora.ts.net`, `openclaw.dingo-mora.ts.net`), a private ClickHouse username (`duyet,monitoring`), and a private referer URL (`clickhouse.duyet.net`) committed in plain text to a public repository.
- These are deploy-time variables that the owner overrides via Cloudflare secrets / CI; placeholder defaults are correct for open-source use.
- A hardcoded fallback `'duyet-agent'` in `agent-thread-page.tsx` was also replaced with `'default'`.

## Changes

| File | Change |
|------|--------|
| `apps/dashboard-tsr/wrangler.toml` | Replace real hosts/user/referer with `localhost` defaults in both `[vars]` and `[env.preview.vars]`; fix the inaccurate comment on line 7 |
| `apps/dashboard-tsr/scripts/patch-wrangler-env.ts` | Mirror the same replacements in `SHARED_VARS` (script mirrors wrangler.toml at deploy time) |
| `apps/dashboard-tsr/src/components/assistant-ui/agent-thread-page.tsx` | Change `clusterName ?? 'duyet-agent'` fallback to `clusterName ?? 'default'` |

## Note on git history

This PR scrubs the values from the tip of `main`. Git **history** still contains the old values. A separate follow-up issue should track a history rewrite (e.g. `git filter-repo`) and a force-push if needed.

## Intentionally left unchanged

`apps/dashboard-tsr/src/components/agents/welcome/agent-welcome-screen.tsx` line 25 retains `e.g. "duet-ubuntu"` inside a JSDoc `@prop` description comment — this is a documentation example, not a live default, and does not leak any real credential or network topology.

## Summary by Sourcery

Scrub hardcoded private infrastructure values from the dashboard-tsr configuration and align defaults with open-source, local development usage.

Bug Fixes:
- Replace hardcoded ClickHouse hosts, usernames, and referer URL in wrangler config with neutral localhost-based defaults suitable for public/open-source use.

Enhancements:
- Update wrangler configuration comments to clarify that real hosts and users are injected via per-environment CI secrets.
- Align the patch-wrangler-env deployment script defaults with the sanitized wrangler configuration values.
- Standardize the UI fallback cluster name from a personal 'duyet-agent' value to a generic 'default' identifier.