### PR TITLE
fix(dashboard-tsr): stabilize table/chart renders (memoize context + columns, keepPreviousData)

### DIFF
--- a/apps/dashboard-tsr/src/components/agents/agent-visualization/index.tsx
+++ b/apps/dashboard-tsr/src/components/agents/agent-visualization/index.tsx
@@ -34,6 +34,10 @@ import { cn } from '@/lib/utils'
 
 export type { AgentVisualizationProps, VizConfig } from './types'
 
+// Stable empty context object — avoids new reference on every render which
+// would defeat column-def memoization inside DataTable.
+const EMPTY_TABLE_CONTEXT: Record<string, string> = {}
+
 // ============================================================================
 // Lazy-loaded chart primitives
 // ============================================================================
@@ -140,7 +144,7 @@ export function AgentVisualization({
           <DataTable
             data={rows.slice(0, 100) as Record<string, unknown>[]}
             queryConfig={queryConfig}
-            context={{}}
+            context={EMPTY_TABLE_CONTEXT}
             defaultPageSize={Math.min(rows.length, 25)}
             showSQL={false}
             enableColumnFilters={false}
@@ -353,7 +357,7 @@ export function AgentVisualization({
             <DataTable
               data={rows.slice(0, 100) as Record<string, unknown>[]}
               queryConfig={queryConfig}
-              context={{}}
+              context={EMPTY_TABLE_CONTEXT}
               defaultPageSize={Math.min(rows.length, 25)}
               showSQL={false}
               enableColumnFilters={false}

--- a/apps/dashboard-tsr/src/components/agents/chat/tool-output.tsx
+++ b/apps/dashboard-tsr/src/components/agents/chat/tool-output.tsx
@@ -43,6 +43,10 @@ import {
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 
+// Stable empty context object — avoids new reference on every render which
+// would defeat column-def memoization inside DataTable.
+const EMPTY_TABLE_CONTEXT: Record<string, string> = {}
+
 export interface AgentToolPart {
   readonly type: string
   readonly toolCallId: string
@@ -153,7 +157,7 @@ export function ResultTable({
     <DataTable
       data={displayRows}
       queryConfig={queryConfig}
-      context={{}}
+      context={EMPTY_TABLE_CONTEXT}
       defaultPageSize={Math.min(displayRows.length, 25)}
       showSQL={false}
       enableColumnFilters={false}
@@ -218,7 +222,7 @@ function ExpandTableButton({
           <DataTable
             data={rows}
             queryConfig={queryConfig}
-            context={{}}
+            context={EMPTY_TABLE_CONTEXT}
             defaultPageSize={50}
             showSQL={false}
             enableColumnFilters={true}

--- a/apps/dashboard-tsr/src/components/charts/chart-zoom-dialog.tsx
+++ b/apps/dashboard-tsr/src/components/charts/chart-zoom-dialog.tsx
@@ -45,6 +45,10 @@ import { cn, dedent } from '@/lib/utils'
 
 const BEAUTIFY_STORAGE_KEY = 'chart-zoom-sql-beautify'
 
+// Stable empty context object — avoids new reference on every render which
+// would defeat column-def memoization inside DataTable.
+const EMPTY_TABLE_CONTEXT: Record<string, string> = {}
+
 function getInitialBeautifyState(): boolean {
   if (typeof window === 'undefined') return false
   try {
@@ -392,7 +396,7 @@ export const ChartZoomDialog = function ChartZoomDialog({
               <DataTable
                 data={data as Record<string, unknown>[]}
                 queryConfig={queryConfig}
-                context={{}}
+                context={EMPTY_TABLE_CONTEXT}
                 defaultPageSize={50}
                 showSQL={false}
                 enableColumnFilters={true}

--- a/apps/dashboard-tsr/src/components/data-table/data-table.tsx
+++ b/apps/dashboard-tsr/src/components/data-table/data-table.tsx
@@ -441,7 +441,10 @@ export function DataTable<
 
   // Combine special columns with data columns:
   // [expand?, select?, ...columnDefs]
-  const finalColumnDefs = (() => {
+  // Memoized so the array reference is stable across re-renders caused by data
+  // refetches — without this, TanStack Table sees a new columns array every
+  // render and remounts cells, causing visible flash.
+  const finalColumnDefs = useMemo(() => {
     const cols: ColumnDef<TData, unknown>[] = []
     if (expandable) cols.push(expandColumn as ColumnDef<TData, unknown>)
     if (enableRowSelection) cols.push(selectionColumn)
@@ -449,7 +452,8 @@ export function DataTable<
       ...cols,
       ...(columnDefs as ColumnDef<TData, unknown>[]),
     ] as ColumnDef<TData, TValue>[]
-  })()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [columnDefs, expandable, enableRowSelection])
 
   // Compose the effective column order. Saved orders in localStorage only
   // contain data columns (predating utility columns like `__expand`/`select`),

--- a/apps/dashboard-tsr/src/components/data-table/hooks/use-table-columns.ts
+++ b/apps/dashboard-tsr/src/components/data-table/hooks/use-table-columns.ts
@@ -38,7 +38,6 @@ export function useTableColumns<
   // Add `ctx.` prefix to all keys (memoized to prevent recalculation)
   // Use JSON.stringify for stable comparison - context is a small object
   // and referential equality fails when callers create inline objects.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const _contextKey = useMemo(() => JSON.stringify(context), [context])
   const contextWithPrefix = useMemo(
     () =>
@@ -49,8 +48,10 @@ export function useTableColumns<
         }),
         {} as Record<string, string>
       ),
+    // Use the stringified key so this is value-stable even when the caller
+    // recreates the context object reference each render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [context]
+    [_contextKey]
   )
 
   // Column definitions for the table (memoized to prevent recalculation)

--- a/apps/dashboard-tsr/src/components/explorer/tabs/data-tab.tsx
+++ b/apps/dashboard-tsr/src/components/explorer/tabs/data-tab.tsx
@@ -10,7 +10,7 @@ import {
 import type { ApiError, ApiResponse } from '@/lib/api/types'
 
 import { useExplorerState } from '../hooks/use-explorer-state'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { TableSkeleton } from '@/components/skeletons'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
@@ -136,8 +136,11 @@ export function DataTab() {
 
   const rows = response?.data || []
 
-  // Generate columns dynamically from data
-  const columns = (() => {
+  // Generate columns dynamically from data.
+  // Keyed on the column-name signature so the array is only rebuilt when the
+  // schema changes, not on every data refetch (which would remount all cells).
+  const _columnSchema = Object.keys(rows[0] ?? {}).join(',')
+  const columns = useMemo(() => {
     if (rows.length === 0) return []
     return Object.keys(rows[0]).map((key) =>
       columnHelper.accessor(key, {
@@ -148,7 +151,8 @@ export function DataTab() {
         maxSize: 500,
       })
     )
-  })()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [_columnSchema])
 
   const table = useReactTable({
     data: rows,

--- a/apps/dashboard-tsr/src/components/sql-console/result-table.tsx
+++ b/apps/dashboard-tsr/src/components/sql-console/result-table.tsx
@@ -6,7 +6,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import {
   Table,
   TableBody,
@@ -74,19 +74,26 @@ export function ResultTable({
   rows: RowData[]
   emptyMessage?: string
 }) {
-  const columns =
-    rows.length === 0
-      ? []
-      : Object.keys(rows[0]).map((key) =>
-          columnHelper.accessor((r) => r[key], {
-            id: key,
-            header: key,
-            cell: (info) => <ExpandableCell value={info.getValue()} />,
-            size: 220,
-            minSize: 80,
-            maxSize: 600,
-          })
-        )
+  // Keyed on the column-name signature so the array is only rebuilt when the
+  // schema changes, not on every data refetch (which would remount all cells).
+  const _columnSchema = Object.keys(rows[0] ?? {}).join(',')
+  const columns = useMemo(
+    () =>
+      rows.length === 0
+        ? []
+        : Object.keys(rows[0]).map((key) =>
+            columnHelper.accessor((r) => r[key], {
+              id: key,
+              header: key,
+              cell: (info) => <ExpandableCell value={info.getValue()} />,
+              size: 220,
+              minSize: 80,
+              maxSize: 600,
+            })
+          ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [_columnSchema]
+  )
 
   const table = useReactTable({
     data: rows,

--- a/apps/dashboard-tsr/src/components/tables/table-client.tsx
+++ b/apps/dashboard-tsr/src/components/tables/table-client.tsx
@@ -3,6 +3,7 @@ import { Info, RefreshCw } from 'lucide-react'
 import type { ApiResponseMetadata } from '@/lib/api/types'
 import type { QueryConfig } from '@/types/query-config'
 
+import { useMemo } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { CardToolbar } from '@/components/cards/card-toolbar'
@@ -166,7 +167,13 @@ export const TableClient = function TableClient({
   // Memoize context to prevent columnDefs recalculation on every render.
   // Without this, every SWR revalidation cycle triggers full table re-renders
   // because new context object → new contextWithPrefix → new columnDefs → all cells re-render.
-  const context = { ...searchParams, hostId: String(hostId) }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const context = useMemo(
+    () => ({ ...searchParams, hostId: String(hostId) }),
+    // JSON.stringify gives value-stable deps when callers pass an inline literal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(searchParams), hostId]
+  )
 
   const { data, metadata, error, isLoading, isValidating, refresh } =
     useTableData<Record<string, unknown>>(

--- a/apps/dashboard-tsr/src/lib/query/use-chart-data.ts
+++ b/apps/dashboard-tsr/src/lib/query/use-chart-data.ts
@@ -105,6 +105,9 @@ export function useChartData<T extends ChartDataPoint = ChartDataPoint>({
     refetchInterval: resolvedRefetchInterval,
     refetchOnMount: true,
     refetchOnReconnect: true,
+    // Keep previous data visible while re-fetching on host/range changes so the
+    // UI never blanks to a skeleton during transitions.
+    placeholderData: (prev) => prev,
     retry: (failureCount, err) => {
       if (
         'status' in err &&

--- a/apps/dashboard-tsr/src/lib/query/use-table-data.ts
+++ b/apps/dashboard-tsr/src/lib/query/use-table-data.ts
@@ -81,6 +81,9 @@ export function useTableData<T = unknown>(
     refetchInterval: resolvedRefetchInterval,
     refetchOnMount: true,
     refetchOnReconnect: true,
+    // Keep previous data visible while re-fetching on host/range changes so the
+    // UI never blanks to a skeleton during transitions.
+    placeholderData: (prev) => prev,
   })
 
   const dataArray = data?.data ?? []


### PR DESCRIPTION
## Summary

Five targeted memoization + TanStack Query fixes to kill visible render flicker and full-page skeleton blanking in `apps/dashboard-tsr`. No behavior changes — reference stability only.

### Fixes applied

1. **`table-client.tsx` — memoize `context` object** (`useMemo` with `JSON.stringify(searchParams)` as dep)
   Removes: table flash on every polling cycle because the inline `{ ...searchParams, hostId }` literal had a new reference each render → caused `contextWithPrefix` + `columnDefs` to rebuild → all cells remounted.

2. **`use-table-columns.ts` — switch `contextWithPrefix` deps to `[_contextKey]`**
   Removes: `_contextKey` was already computed but the `contextWithPrefix` memo still used `[context]` (reference). Now it uses the value-stable stringified key so `contextWithPrefix` is only recomputed when the actual values change.

3. **`use-chart-data.ts` + `use-table-data.ts` — add `placeholderData: (prev) => prev`**
   Removes: full-page skeleton blanking when switching `?host=` or date-range. Without this, every queryKey change blanked to `isPending=true` → skeleton. Now stale data stays visible during host/range transitions; the existing `staleError` mechanism still surfaces revalidation errors when they occur.

4. **`agent-visualization/index.tsx`, `tool-output.tsx`, `chart-zoom-dialog.tsx` — replace inline `context={{}}` with module-level `EMPTY_TABLE_CONTEXT`**
   Removes: agent-table cell remount on every re-render because `context={{}}` is a new object identity each time, defeating `useTableColumns`' memoization and causing TanStack Table to see new column defs → cells remount and flash.

5. **`data-table.tsx`, `data-tab.tsx`, `result-table.tsx` — wrap column definitions in `useMemo`**
   Removes: `finalColumnDefs` (main table), `columns` (explorer data tab), and `columns` (SQL console result table) were rebuilt on every render. Keyed on schema signature (`Object.keys(rows[0]).join(',')`) so rebuild only happens when columns actually change, not on data refreshes.

## Test plan

- [ ] Navigate between hosts (`?host=0` → `?host=1`) — tables/charts stay visible during transition, no blank skeleton flash
- [ ] Change date range on a chart page — chart keeps showing previous data while loading
- [ ] Watch a table with `refreshInterval` poll — rows stay in place, no cell remount visible
- [ ] Open agent chat, run a query tool — result table renders without flickering on each message update
- [ ] Open chart zoom dialog, click Data tab — table renders without flash

## Summary by Sourcery

Stabilize dashboard table and chart rendering by memoizing dynamic contexts and column definitions and preserving previous query data during refetches to eliminate flicker and skeleton blanking.

Bug Fixes:
- Prevent table cell remounting and visual flicker by memoizing table contexts and column definitions across re-renders.
- Keep chart and table data visible during host or date-range changes by reusing previous TanStack Query data instead of showing loading skeletons.

Enhancements:
- Use stable empty context objects where no context is needed so DataTable consumers benefit from column memoization.
- Base dynamic column generation on a memoized schema signature so columns only regenerate when the underlying data shape changes.
- Align table column context memoization with a value-stable string key to avoid unnecessary recomputation.