### PR TITLE
docs(dashboard-tsr): add Deploy to Cloudflare button + env-var template

### DIFF
--- a/apps/dashboard-tsr/README.md
+++ b/apps/dashboard-tsr/README.md
@@ -5,6 +5,39 @@ the migration target that replaces the Next.js app in `apps/dashboard`. Live at
 **[dash-tsr.chmonitor.dev](https://dash-tsr.chmonitor.dev)** (preview:
 `preview.dash-tsr.chmonitor.dev` on PRs).
 
+## Deploy your own
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/duyet/clickhouse-monitoring/tree/main/apps/dashboard-tsr)
+
+Click the button above to deploy your own instance to Cloudflare Workers. You will be prompted to connect your Cloudflare account and set the required environment variables.
+
+### Required variables
+
+| Variable | Purpose |
+|---|---|
+| `CLICKHOUSE_HOST` | ClickHouse URL(s). Comma-separated for multi-host (e.g. `https://ch1:8443,https://ch2:8443`) |
+| `CLICKHOUSE_USER` | Username(s). Single value or one per host, comma-separated |
+| `CLICKHOUSE_PASSWORD` | Password(s). Single value or one per host, comma-separated |
+
+### Optional variables
+
+| Variable | Purpose |
+|---|---|
+| `CLICKHOUSE_NAME` | Friendly display name(s) for each host, comma-separated |
+| `CLICKHOUSE_MAX_EXECUTION_TIME` | Query timeout in seconds (default: `60`) |
+| `VITE_AUTH_PROVIDER` | Auth mode: `none` (default) or `clerk` |
+| `VITE_CLERK_PUBLISHABLE_KEY` | Clerk publishable key (`pk_...`). Required when `VITE_AUTH_PROVIDER=clerk` |
+| `CLERK_SECRET_KEY` | Clerk server secret (`sk_...`). Required when auth provider is `clerk` |
+| `CHM_AUTH_PROVIDER` | Server-side auth mirror of `VITE_AUTH_PROVIDER` (`none` / `clerk` / `proxy`) |
+| `CHM_API_KEY_SECRET` | Enables Bearer-token auth on `/api/v1/*` |
+| `LLM_API_KEY` | AI provider key (OpenRouter, AnyRouter, etc.) |
+| `LLM_API_BASE` | AI provider base URL (e.g. `https://openrouter.ai/api/v1`) |
+| `LLM_MODEL` | Model to use (e.g. `openrouter/free`, `anyrouter/free`) |
+| `OPENROUTER_API_KEY` | OpenRouter API key (alternative to `LLM_API_KEY`) |
+| `ANYROUTER_API_KEY` | AnyRouter API key (alternative to `LLM_API_KEY`) |
+
+`VITE_*` variables are baked into the browser bundle at build time; `CLICKHOUSE_*` and secret keys are runtime Worker variables set via `wrangler secret put` or the Cloudflare dashboard.
+
 88 page routes and 53 API routes cover the full feature set: real-time cluster
 metrics, query/merge/mutation monitoring, a database explorer, ClickHouse Keeper
 views, log inspection, and an AI agent — all served as a fast static shell with
@@ -99,7 +132,7 @@ vars come from the Worker binding / `process.env`.
 | `CLICKHOUSE_MAX_EXECUTION_TIME` | | Query timeout (default 60s) |
 | `VITE_AUTH_PROVIDER` / `CHM_AUTH_PROVIDER` | | `none` (default) \| `clerk` \| `proxy` |
 | `CHM_API_KEY_SECRET` | | Enables API-key auth on `/api/v1/*` |
-| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` / `CLERK_SECRET_KEY` | | When auth provider is `clerk` |
+| `VITE_CLERK_PUBLISHABLE_KEY` / `CLERK_SECRET_KEY` | | When auth provider is `clerk` |
 | `LLM_API_KEY` / `LLM_API_BASE` / `LLM_MODEL` | | AI agent (OpenRouter/AnyRouter-compatible) |
 
 ### Security headers

--- a/docs/content/deploy/cloudflare.mdx
+++ b/docs/content/deploy/cloudflare.mdx
@@ -2,6 +2,12 @@
 
 Deploy chmonitor to Cloudflare Workers using the OpenNext adapter. Best for globally cached, serverless hosting with no servers to manage.
 
+## One-click deploy
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/duyet/clickhouse-monitoring/tree/main/apps/dashboard-tsr)
+
+This deploys the `apps/dashboard-tsr` worker (TanStack Start). You will be prompted to connect your Cloudflare account and configure variables. See the [environment variable reference](#configure) below and the [dashboard-tsr README](https://github.com/duyet/clickhouse-monitoring/tree/main/apps/dashboard-tsr#deploy-your-own) for the full variable list.
+
 ## Prerequisites
 
 - Cloudflare account


### PR DESCRIPTION
## What

Adds a one-click **Deploy to Cloudflare** button for the `apps/dashboard-tsr` worker (TanStack Start), plus a complete environment-variable reference table so anyone can self-host their own instance.

## Changes

- **`apps/dashboard-tsr/README.md`**: adds a "Deploy your own" section near the top with the deploy button, a required-vars table (CLICKHOUSE_HOST/USER/PASSWORD with multi-host notes), and an optional-vars table (CLICKHOUSE_NAME, auth vars, LLM/agent vars). All vars sourced directly from `.env.example`.
- **`apps/dashboard-tsr/README.md`**: fixes stale `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` → `VITE_CLERK_PUBLISHABLE_KEY` in the Configure table (this app is Vite/TanStack Start, not Next.js).
- **`docs/content/deploy/cloudflare.mdx`**: mirrors the deploy button at the top of the user-facing Cloudflare deployment doc with a link back to the README var reference.

## Deploy button URL

```
https://deploy.workers.cloudflare.com/?url=https://github.com/duyet/clickhouse-monitoring/tree/main/apps/dashboard-tsr
```

The subdirectory path (`/tree/main/apps/dashboard-tsr`) is the documented approach for monorepos per the Cloudflare deploy button docs — the deploy service reads `wrangler.toml` from that subdirectory.

## Required variables a deployer must set

| Variable | Purpose |
|---|---|
| `CLICKHOUSE_HOST` | ClickHouse URL(s), comma-separated for multi-host |
| `CLICKHOUSE_USER` | Username(s) |
| `CLICKHOUSE_PASSWORD` | Password(s) |

## Summary by Sourcery

Document one-click Cloudflare deployment for the dashboard-tsr worker and clarify its environment variable configuration.

Bug Fixes:
- Correct the dashboard-tsr auth configuration docs to reference VITE_CLERK_PUBLISHABLE_KEY instead of the stale NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY.

Enhancements:
- Clarify which environment variables are build-time Vite vars versus runtime Worker secrets in the dashboard-tsr README.

Documentation:
- Add a Deploy to Cloudflare button and environment variable reference tables to the dashboard-tsr README for self-hosting.
- Document a one-click Deploy to Cloudflare entry point in the Cloudflare deployment guide, linking to the dashboard-tsr README for configuration details.