### PR TITLE
chore(ci): remove WASM build job and turbo rust globalDependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,65 +64,10 @@ jobs:
       - name: Validate dependency boundaries
         run: bun run depcruise
 
-  # Build WASM natively on amd64 — WASM is platform-independent
-  build-wasm:
-    name: build-wasm
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Bun Cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-v1-${{ hashFiles('**/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-v1-
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.94.0
-        with:
-          targets: wasm32-unknown-unknown
-
-      - name: Cache Cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            rust/monitor-core/target
-          key: wasm-cargo-${{ runner.os }}-${{ hashFiles('rust/monitor-core/Cargo.lock', 'rust/monitor-core/Cargo.toml') }}
-          restore-keys: |
-            wasm-cargo-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Build WASM
-        run: bun run wasm:build
-
-      - name: Upload WASM artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: wasm-output
-          path: |
-            packages/clickhouse-client/src/wasm/generated/monitor_core.js
-            packages/clickhouse-client/src/wasm/generated/monitor_core.d.ts
-            packages/clickhouse-client/src/wasm/generated/monitor_core_bg.wasm
-          retention-days: 1
-
   # PRs: amd64 only for fast feedback (~3-5 min)
   build-docker-pr:
     name: build-docker-pr
     if: github.event_name == 'pull_request'
-    needs: [build-wasm]
     uses: ./.github/workflows/base.yml
     with:
       job-type: docker
@@ -135,7 +80,6 @@ jobs:
   build-docker-amd64:
     name: build-docker-amd64
     if: github.event_name != 'pull_request'
-    needs: [build-wasm]
     uses: ./.github/workflows/base.yml
     with:
       job-type: docker

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,6 @@
     "tsconfig.base.json",
     "biome.json",
     "bun.lock",
-    "rust/monitor-core/**",
     "scripts/**"
   ],
   "tasks": {


### PR DESCRIPTION
## Summary

Remove unused WASM infrastructure from CI and Turborepo config.

### Changes

1. **`.github/workflows/ci.yml`**: Remove the entire `build-wasm` job (Rust toolchain setup, wasm-pack build, artifact upload). Remove `needs: [build-wasm]` from `build-docker-pr` and `build-docker-amd64` (jobs kept, dependency removed).

2. **`turbo.json`**: Remove `"rust/monitor-core/**"` from `globalDependencies`. This entry invalidated **all** Turborepo task caches whenever any Rust file changed, even for packages that never use WASM.

### Evidence

- WASM has zero production usage: benchmark PR #1021 confirmed TS-only object transforms outperform WASM.
- `docs/knowledge/rust-wasm-performance.md` documents the benchmark findings.
- The `build-docker-*` jobs already pass `skip-rust: true` — they never consumed the WASM artifact.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Remove unused WebAssembly build infrastructure from CI and Turborepo configuration.

Build:
- Relax Turborepo global dependency tracking by excluding the Rust monitor-core workspace from globalDependencies.

CI:
- Delete the build-wasm GitHub Actions job and decouple docker build jobs from its output.

Chores:
- Clean up obsolete WASM-related configuration now that WASM artifacts are no longer used in the build pipeline.