### PR TITLE
fix(dashboard-tsr): convention fixes, stable keys, ai-agent docs sync, regression tests

### DIFF
--- a/apps/dashboard-tsr/src/components/cards/card-multi-metrics.tsx
+++ b/apps/dashboard-tsr/src/components/cards/card-multi-metrics.tsx
@@ -69,12 +69,13 @@ export const CardMultiMetrics = function CardMultiMetrics({
           </div>
         )}
 
-        {items.map((item) => {
+        {items.map((item, i) => {
           const percent =
             item.target > 0 ? (item.current / item.target) * 100 : 0
           const clampedPercent = Math.min(100, Math.max(0, percent))
+          // Index suffix keeps the fallback unique when readables repeat.
           const key =
-            item.label ?? `${item.currentReadable}-${item.targetReadable}`
+            item.label ?? `${item.currentReadable}-${item.targetReadable}-${i}`
 
           return (
             <div key={key} className="flex items-center gap-2 text-sm">

--- a/apps/dashboard-tsr/src/components/cards/card-multi-metrics.tsx
+++ b/apps/dashboard-tsr/src/components/cards/card-multi-metrics.tsx
@@ -53,10 +53,7 @@ export const CardMultiMetrics = function CardMultiMetrics({
   const showLabels = items.length > 0 && (currentLabel || targetLabel)
 
   return (
-    <div
-      className={cn('flex flex-col gap-3', className)}
-      aria-description="card-metrics"
-    >
+    <div className={cn('flex flex-col gap-3', className)}>
       {primary && (
         <div className="text-xl font-semibold leading-tight">{primary}</div>
       )}
@@ -72,13 +69,15 @@ export const CardMultiMetrics = function CardMultiMetrics({
           </div>
         )}
 
-        {items.map((item, i) => {
+        {items.map((item) => {
           const percent =
             item.target > 0 ? (item.current / item.target) * 100 : 0
           const clampedPercent = Math.min(100, Math.max(0, percent))
+          const key =
+            item.label ?? `${item.currentReadable}-${item.targetReadable}`
 
           return (
-            <div key={i} className="flex items-center gap-2 text-sm">
+            <div key={key} className="flex items-center gap-2 text-sm">
               <span className="text-muted-foreground truncate flex-1 min-w-0">
                 {item.currentReadable}
               </span>

--- a/apps/dashboard-tsr/src/components/cards/card-toolbar.tsx
+++ b/apps/dashboard-tsr/src/components/cards/card-toolbar.tsx
@@ -92,7 +92,7 @@ export const CardToolbar = function CardToolbar({
           alwaysVisible={alwaysVisible}
         />
       )}
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"

--- a/apps/dashboard-tsr/src/components/charts/zookeeper/zookeeper-summary-table.tsx
+++ b/apps/dashboard-tsr/src/components/charts/zookeeper/zookeeper-summary-table.tsx
@@ -73,7 +73,7 @@ export const ChartZookeeperSummaryTable = function ChartZookeeperSummaryTable({
             {dataArray.map((row) => (
               <TableRow key={row.metric}>
                 {Object.entries(row).map(([key, value]) => {
-                  return <TableCell key={key}>{value || ''} </TableCell>
+                  return <TableCell key={key}>{value ?? ''} </TableCell>
                 })}
               </TableRow>
             ))}

--- a/apps/dashboard-tsr/src/components/charts/zookeeper/zookeeper-summary-table.tsx
+++ b/apps/dashboard-tsr/src/components/charts/zookeeper/zookeeper-summary-table.tsx
@@ -70,10 +70,10 @@ export const ChartZookeeperSummaryTable = function ChartZookeeperSummaryTable({
             </TableRow>
           </TableHeader>
           <TableBody>
-            {dataArray.map((row, idx) => (
-              <TableRow key={idx}>
-                {Object.values(row).map((value, i) => {
-                  return <TableCell key={i}>{value || ''} </TableCell>
+            {dataArray.map((row) => (
+              <TableRow key={row.metric}>
+                {Object.entries(row).map(([key, value]) => {
+                  return <TableCell key={key}>{value || ''} </TableCell>
                 })}
               </TableRow>
             ))}

--- a/apps/dashboard-tsr/src/components/data-table/buttons/column-header-dropdown.tsx
+++ b/apps/dashboard-tsr/src/components/data-table/buttons/column-header-dropdown.tsx
@@ -7,7 +7,7 @@ import {
 } from 'lucide-react'
 import type { Header } from '@tanstack/react-table'
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -26,22 +26,31 @@ export const ColumnHeaderDropdown = function ColumnHeaderDropdown({
 }: ColumnHeaderDropdownProps) {
   const [copied, setCopied] = useState(false)
   const [open, setOpen] = useState(false)
+  const reopenTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  // Clear any pending re-open timeout on unmount
+  useEffect(() => {
+    return () => clearTimeout(reopenTimeoutRef.current)
+  }, [])
 
   const column = header.column
   const canSort = column.getCanSort()
 
+  // Close and re-open dropdown to force re-render with new sort
+  const reopenDropdown = () => {
+    setOpen(false)
+    clearTimeout(reopenTimeoutRef.current)
+    reopenTimeoutRef.current = setTimeout(() => setOpen(true), 0)
+  }
+
   const handleSortAsc = (_e: React.MouseEvent) => {
     column.toggleSorting(false)
-    // Close and re-open dropdown to force re-render with new sort
-    setOpen(false)
-    setTimeout(() => setOpen(true), 0)
+    reopenDropdown()
   }
 
   const handleSortDesc = (_e: React.MouseEvent) => {
     column.toggleSorting(true)
-    // Close and re-open dropdown to force re-render with new sort
-    setOpen(false)
-    setTimeout(() => setOpen(true), 0)
+    reopenDropdown()
   }
 
   const handleResetSort = (e: React.MouseEvent) => {

--- a/apps/dashboard-tsr/src/components/data-table/cells/actions/action-menu.tsx
+++ b/apps/dashboard-tsr/src/components/data-table/cells/actions/action-menu.tsx
@@ -40,7 +40,7 @@ function ActionMenuComponent<TData extends RowData, TValue>({
   actions,
 }: ActionMenuProps<TData, TValue>) {
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"

--- a/apps/dashboard-tsr/src/components/data-table/data-table-faceted-filter.tsx
+++ b/apps/dashboard-tsr/src/components/data-table/data-table-faceted-filter.tsx
@@ -43,7 +43,7 @@ export function DataTableFacetedFilter({
   if (!filters.length) return null
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <Button
           variant="outline"

--- a/apps/dashboard-tsr/src/components/header/refresh-countdown.tsx
+++ b/apps/dashboard-tsr/src/components/header/refresh-countdown.tsx
@@ -45,7 +45,7 @@ export const RefreshCountdown = function RefreshCountdown() {
   }
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"

--- a/apps/dashboard-tsr/src/lib/ai/agent/conversation-utils.test.ts
+++ b/apps/dashboard-tsr/src/lib/ai/agent/conversation-utils.test.ts
@@ -12,7 +12,14 @@ import {
   saveConversations,
   upsertConversation,
 } from './conversation-utils'
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  setSystemTime,
+  test,
+} from 'bun:test'
 
 // ── In-memory localStorage shim (bun has no DOM by default) ──
 class MemoryStorage {
@@ -155,12 +162,24 @@ describe('formatRelativeTime', () => {
   })
 
   test('today → "today at ..."', () => {
-    // 3 hours ago crosses midnight when the test runs early in the day,
-    // so assert the branch matching the actual calendar day.
-    const ts = Date.now() - 3 * 3600_000
-    const out = formatRelativeTime(ts)
-    const sameDay = new Date(ts).getDate() === new Date().getDate()
-    expect(out.startsWith(sameDay ? 'today at ' : 'yesterday at ')).toBe(true)
+    // Pin the clock to mid-afternoon so "3 hours ago" never crosses midnight.
+    setSystemTime(new Date(2026, 5, 12, 15, 0, 0))
+    try {
+      const out = formatRelativeTime(Date.now() - 3 * 3600_000)
+      expect(out.startsWith('today at ')).toBe(true)
+    } finally {
+      setSystemTime()
+    }
+  })
+
+  test('yesterday → "yesterday at ..."', () => {
+    setSystemTime(new Date(2026, 5, 12, 15, 0, 0))
+    try {
+      const out = formatRelativeTime(Date.now() - 26 * 3600_000)
+      expect(out.startsWith('yesterday at ')).toBe(true)
+    } finally {
+      setSystemTime()
+    }
   })
 
   test('older than a week → a short date', () => {

--- a/apps/dashboard-tsr/src/lib/ai/agent/tools/dashboard-tools.ts
+++ b/apps/dashboard-tsr/src/lib/ai/agent/tools/dashboard-tools.ts
@@ -72,7 +72,7 @@ export function createDashboardTools() {
 
     get_chart_data: dynamicTool({
       description:
-        'Fetch chart data for a named chart. Provides guidance on how to retrieve data using the query tool.',
+        'Does not fetch chart data directly. Returns a static guidance message advising to use the query tool with appropriate SQL to retrieve the underlying data for a named chart.',
       inputSchema: z.object({
         chartName: z.string().describe('Name of the chart to fetch data for'),
         hostId: hostIdSchema,

--- a/apps/dashboard-tsr/src/lib/query-config/__tests__/sql-regressions.test.ts
+++ b/apps/dashboard-tsr/src/lib/query-config/__tests__/sql-regressions.test.ts
@@ -1,0 +1,46 @@
+import { diskUsageChangeConfig } from '../anomaly/anomaly-queries'
+import { explorerProjectionsConfig } from '../explorer/projections'
+import { mergesConfig } from '../merges/merges'
+import { expensiveQueriesConfig } from '../queries/expensive-queries'
+import { projectionsConfig } from '../tables/projections'
+import { tablesOverviewConfig } from '../tables/tables-overview'
+import { describe, expect, test } from 'bun:test'
+
+/** Flatten versioned or plain sql into one string for assertions. */
+function allSql(config: { sql: string | { sql: string }[] }): string {
+  return typeof config.sql === 'string'
+    ? config.sql
+    : config.sql.map((v) => v.sql).join('\n')
+}
+
+// Regression guards for SQL bugs fixed in the core-values sweep.
+// These assert exact fragments so a revert reintroducing the bug fails fast.
+describe('query-config SQL regressions', () => {
+  test('expensive-queries aliases SelectedBytes as lowercase selected_bytes', () => {
+    const sql = allSql(expensiveQueriesConfig)
+    expect(sql).not.toContain('Selected_bytes')
+    expect(sql).toContain('as selected_bytes')
+    expect(expensiveQueriesConfig.columns).toContain('selected_bytes')
+  })
+
+  test('compression-ratio divisions are guarded with nullIf', () => {
+    expect(allSql(tablesOverviewConfig)).toContain(
+      'uncompressed / nullIf(compressed, 0)'
+    )
+    expect(allSql(projectionsConfig)).toContain(
+      'uncompressed / nullIf(compressed, 0)'
+    )
+    expect(allSql(explorerProjectionsConfig)).toContain(
+      'nullIf(sum(data_compressed_bytes), 0)'
+    )
+  })
+
+  test('disk-usage-change anomaly query is bounded by LIMIT', () => {
+    expect(allSql(diskUsageChangeConfig)).toContain('LIMIT 10000')
+  })
+
+  test('merges columnFormats only reference produced columns', () => {
+    // system.merges has no `query` column; a stale Code format once pointed at it.
+    expect(Object.keys(mergesConfig.columnFormats ?? {})).not.toContain('query')
+  })
+})

--- a/apps/dashboard-tsr/src/lib/query-config/tables/projections.ts
+++ b/apps/dashboard-tsr/src/lib/query-config/tables/projections.ts
@@ -16,15 +16,15 @@ export const projectionsConfig: QueryConfig = {
           (sum(data_uncompressed_bytes) AS usize) AS uncompressed,
           formatReadableSize(compressed) AS readable_compressed,
           formatReadableSize(uncompressed) AS readable_uncompressed,
-          round(100 * compressed / max(compressed) OVER ()) AS pct_compressed,
-          round(100 * uncompressed / max(uncompressed) OVER ()) AS pct_uncompressed,
+          round(100 * compressed / nullIf(max(compressed) OVER (), 0)) AS pct_compressed,
+          round(100 * uncompressed / nullIf(max(uncompressed) OVER (), 0)) AS pct_uncompressed,
           round(uncompressed / nullIf(compressed, 0), 2) AS compr_rate,
-          round(100 * compr_rate / max(compr_rate) OVER ()) AS pct_compr_rate,
+          round(100 * compr_rate / nullIf(max(compr_rate) OVER (), 0)) AS pct_compr_rate,
           sum(rows) AS rows,
           formatReadableQuantity(rows) AS readable_rows,
-          round(100 * rows / max(rows) OVER ()) AS pct_rows,
+          round(100 * rows / nullIf(max(rows) OVER (), 0)) AS pct_rows,
           count() AS part_count,
-          round(100 * part_count / max(part_count) OVER ()) AS pct_part_count
+          round(100 * part_count / nullIf(max(part_count) OVER (), 0)) AS pct_part_count
       FROM system.projection_parts
       WHERE active
       GROUP BY

--- a/apps/dashboard-tsr/src/lib/query-config/tables/tables-overview.ts
+++ b/apps/dashboard-tsr/src/lib/query-config/tables/tables-overview.ts
@@ -24,7 +24,7 @@ export const tablesOverviewConfig: QueryConfig = {
                 format('{}.{}', database, \`table\`) AS \`table\`,
                 sum(rows) AS total_rows,
                 formatReadableQuantity(total_rows) AS readable_total_rows,
-                round((100 * total_rows) / max(total_rows) OVER ()) AS pct_total_rows,
+                round((100 * total_rows) / nullIf(max(total_rows) OVER (), 0)) AS pct_total_rows,
                 max(modification_time) AS latest_modification,
 
                 sum(data_compressed_bytes) AS compressed,
@@ -32,30 +32,30 @@ export const tablesOverviewConfig: QueryConfig = {
                 round(uncompressed / nullIf(compressed, 0), 2) AS compr_rate,
                 formatReadableSize(compressed) AS readable_compressed,
                 formatReadableSize(uncompressed) AS readable_uncompressed,
-                round((100 * compressed) / max(compressed) OVER ()) AS pct_compressed,
-                round((100 * uncompressed) / max(uncompressed) OVER ()) AS pct_uncompressed,
-                round((100 * compr_rate) / max(compr_rate) OVER ()) AS pct_compr_rate,
+                round((100 * compressed) / nullIf(max(compressed) OVER (), 0)) AS pct_compressed,
+                round((100 * uncompressed) / nullIf(max(uncompressed) OVER (), 0)) AS pct_uncompressed,
+                round((100 * compr_rate) / nullIf(max(compr_rate) OVER (), 0)) AS pct_compr_rate,
 
                 avg(data_compressed_bytes) AS avg_part_size_compressed,
                 avg(data_uncompressed_bytes) AS avg_part_size_uncompressed,
                 formatReadableSize(avg_part_size_compressed) AS readable_avg_part_size_compressed,
                 formatReadableSize(avg_part_size_uncompressed) AS readable_avg_part_size_uncompressed,
-                round((100 * avg_part_size_compressed) / max(avg_part_size_compressed) OVER ()) AS pct_avg_part_size_compressed,
-                round((100 * avg_part_size_uncompressed) / max(avg_part_size_uncompressed) OVER ()) AS pct_avg_part_size_uncompressed,
+                round((100 * avg_part_size_compressed) / nullIf(max(avg_part_size_compressed) OVER (), 0)) AS pct_avg_part_size_compressed,
+                round((100 * avg_part_size_uncompressed) / nullIf(max(avg_part_size_uncompressed) OVER (), 0)) AS pct_avg_part_size_uncompressed,
 
                 max(data_compressed_bytes) AS max_part_size_compressed,
                 max(data_uncompressed_bytes) AS max_part_size_uncompressed,
                 formatReadableSize(max_part_size_compressed) AS readable_max_part_size_compressed,
                 formatReadableSize(max_part_size_uncompressed) AS readable_max_part_size_uncompressed,
-                round((100 * max_part_size_compressed) / max(max_part_size_compressed) OVER ()) AS pct_max_part_size_compressed,
-                round((100 * max_part_size_uncompressed) / max(max_part_size_uncompressed) OVER ()) AS pct_max_part_size_uncompressed,
+                round((100 * max_part_size_compressed) / nullIf(max(max_part_size_compressed) OVER (), 0)) AS pct_max_part_size_compressed,
+                round((100 * max_part_size_uncompressed) / nullIf(max(max_part_size_uncompressed) OVER (), 0)) AS pct_max_part_size_uncompressed,
 
                 sum(primary_key_bytes_in_memory) AS primary_keys_size,
                 formatReadableSize(primary_keys_size) AS readable_primary_keys_size,
-                round((100 * primary_keys_size) / max(primary_keys_size) OVER ()) AS pct_primary_keys_size,
+                round((100 * primary_keys_size) / nullIf(max(primary_keys_size) OVER (), 0)) AS pct_primary_keys_size,
                 any(engine) AS engine,
                 count() AS parts_count,
-                round((100 * parts_count) / max(parts_count) OVER ()) AS pct_parts_count
+                round((100 * parts_count) / nullIf(max(parts_count) OVER (), 0)) AS pct_parts_count
             FROM system.parts AS parts
             WHERE active
             GROUP BY 1

--- a/apps/dashboard-tsr/src/lib/swr/use-host-status.ts
+++ b/apps/dashboard-tsr/src/lib/swr/use-host-status.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { apiFetch } from './api-fetch'
+import { visibilityAwareInterval } from './config'
 
 /** API response format for host status */
 type HostStatusApiResponse = {
@@ -80,12 +81,7 @@ export function useHostStatus(
     enabled: hostId !== null && !isBrowserConnection,
     staleTime: 10000,
     refetchInterval:
-      refreshInterval > 0
-        ? () =>
-            typeof document !== 'undefined' && document.hidden
-              ? false
-              : (refreshInterval as number)
-        : (refreshInterval as any),
+      refreshInterval > 0 ? visibilityAwareInterval(refreshInterval) : false,
     refetchOnWindowFocus: revalidateOnFocus,
     refetchOnReconnect: true,
   })

--- a/apps/dashboard-tsr/src/routes/(dashboard)/about.tsx
+++ b/apps/dashboard-tsr/src/routes/(dashboard)/about.tsx
@@ -91,14 +91,14 @@ function AboutPage() {
       <section className="space-y-4">
         <h2 className="text-xl font-semibold">Technology Stack</h2>
         <div className="flex flex-wrap gap-2">
-          <Badge variant="secondary">Next.js 16</Badge>
+          <Badge variant="secondary">TanStack Start</Badge>
           <Badge variant="secondary">React 19</Badge>
           <Badge variant="secondary">TypeScript</Badge>
-          <Badge variant="secondary">Tailwind CSS</Badge>
+          <Badge variant="secondary">Vite</Badge>
+          <Badge variant="secondary">Tailwind CSS 4</Badge>
           <Badge variant="secondary">shadcn/ui</Badge>
           <Badge variant="secondary">ClickHouse</Badge>
-          <Badge variant="secondary">SWR</Badge>
-          <Badge variant="secondary">Turbopack</Badge>
+          <Badge variant="secondary">TanStack Query</Badge>
         </div>
       </section>
 

--- a/apps/dashboard-tsr/src/routes/__root.tsx
+++ b/apps/dashboard-tsr/src/routes/__root.tsx
@@ -39,7 +39,7 @@ export const Route = createRootRoute({
     meta: [
       { charSet: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      { title: 'chmonitor — TanStack Start' },
+      { title: 'chmonitor — ClickHouse Monitoring' },
     ],
     links: [{ rel: 'stylesheet', href: appCss }],
   }),

--- a/apps/dashboard-tsr/src/routes/api/v1/host-status.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/host-status.ts
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { env } from 'cloudflare:workers'
 import { getClient } from '@chm/clickhouse-client'
+import { error } from '@chm/logger'
 import { getClickHouseConfigsFromEnv } from '@/lib/api/clickhouse-config'
 
 const QUERY_COMMENT = '/* { "client": "clickhouse-monitoring" } */\n'
@@ -70,14 +71,14 @@ export const Route = createFileRoute('/api/v1/host-status')({
             success: true,
             data: { version, uptime, hostname },
           })
-        } catch (error) {
-          console.error('Host status API error:', error)
+        } catch (err) {
+          error('[GET /api/v1/host-status] Error:', err)
           return Response.json(
             {
               success: false,
               error:
-                error instanceof Error
-                  ? error.message
+                err instanceof Error
+                  ? err.message
                   : 'Failed to fetch host status',
             },
             { status: 500 }

--- a/docs/content/ai-agent/capabilities.mdx
+++ b/docs/content/ai-agent/capabilities.mdx
@@ -1,23 +1,25 @@
 # Agent capabilities
 
-The agent has 60+ tools organized into categories. You never call tools directly — the agent picks and chains them automatically. This page summarizes what is available and what you can ask.
+The agent has 60 tools organized into categories (63 when control tools are enabled). You never call tools directly — the agent picks and chains them automatically. This page summarizes what is available and what you can ask.
 
 ## Tool categories
 
 | Category | What it covers | Example tools |
 |---|---|---|
 | Schema & exploration | Databases, tables, columns, data source discovery | `list_tables`, `get_table_schema`, `discover_data_sources` |
-| Query analysis | Running, slow, failed, expensive queries; EXPLAIN; optimization | `get_running_queries`, `get_slow_queries`, `explain_query`, `analyze_query_optimization` |
-| Diagnostics & optimization | Query optimization advice, index recommendations, table insights | `optimize_query`, `get_table_insights`, `analyze_query_performance` |
-| System health | Server metrics, CPU/memory/disk, errors, crash log, anomalies | `get_metrics`, `get_system_resources`, `detect_anomalies`, `generate_health_report` |
+| Query analysis | Running, slow, failed, expensive queries; query patterns; EXPLAIN | `get_running_queries`, `get_slow_queries`, `get_expensive_queries`, `get_query_patterns`, `explain_query` |
+| Diagnostics & optimization | Issue scans, query optimization analysis, broken-query repair | `spot_issues`, `analyze_query_optimization`, `repair_query` |
+| System health | Server metrics, CPU/memory/disk, errors, crash log, anomalies | `get_metrics`, `get_system_resources`, `get_errors`, `get_crash_log`, `detect_anomalies` |
+| Query & table insights | Aggregated performance insights for query patterns and tables | `get_query_insights`, `get_table_insights` |
 | Findings persistence | Record and retrieve structured monitoring findings | `record_finding`, `list_recent_findings` |
-| Storage, merges & mutations | Part sizes, active merges, stuck mutations, merge throughput | `get_table_parts`, `get_merge_status`, `get_mutations` |
+| Storage, merges & mutations | Part sizes, table sizes, active merges, stuck mutations, merge throughput | `get_table_parts`, `get_top_tables_by_size`, `get_merge_status`, `get_merge_performance`, `get_mutations` |
 | Replication & cluster | Lag, queue, ZooKeeper/Keeper, topology, DDL queue | `get_replication_status`, `get_clusters`, `get_zookeeper_info` |
 | Security & audit | Sessions, login attempts, users and roles | `get_active_sessions`, `get_login_attempts`, `get_users_and_roles` |
 | Schema migration | ALTER impact assessment, column usage, table design | `analyze_schema_change`, `get_column_usage`, `recommend_table_design` |
 | Comparison & forecasting | Cross-host, time-period, capacity forecast | `compare_hosts`, `compare_time_periods`, `forecast_capacity` |
+| Incident response | Symptom-driven investigation with root-cause correlation | `investigate_incident` |
 | Charts & visualization | Run SQL and return an interactive chart | `query_and_visualize` |
-| Reports & dashboards | Health reports, incident reports, dashboard navigation | `generate_report`, `navigate_to_dashboard` |
+| Reports & dashboards | Health reports, dashboard page listing | `generate_health_report`, `get_dashboard_pages` |
 | Settings & logs | Changed server settings, text log, stack traces | `get_settings`, `get_text_log`, `get_stack_traces` |
 | Control actions | Kill query/mutation, optimize table (disabled by default) | `kill_query`, `kill_mutation`, `optimize_table` |
 | Interaction & knowledge | Skills, workflows, context snapshot, clarifying questions | `load_skill`, `start_workflow`, `get_context` |


### PR DESCRIPTION
Second batch of the dashboard-tsr core-values sweep (follow-up to #1554, which auto-merged while the remaining fixes were still landing). Also addresses both Sourcery review suggestions from #1554.

## Conventions (docs/knowledge/conventions.md)
- `modal={false}` on toolbar/filter Radix DropdownMenus: row action menu, card toolbar, faceted filter, refresh countdown — prevents the full-page `aria-hidden` recompute on open
- Stable React keys instead of array indices (ZooKeeper summary table, multi-metrics cards); removed invalid `aria-description` attribute
- Reopen `setTimeout` in column-header dropdown now cleared on unmount

## Correctness / polish
- About page tech stack said "Next.js 16" — corrected to TanStack Start / Vite / Tailwind 4 / TanStack Query; framework name removed from the document title
- `use-host-status`: `(refreshInterval as any)` replaced with the shared `visibilityAwareInterval` pattern
- `host-status` API route now logs via `@chm/logger` like the other 35+ api/v1 routes

## AI agent docs sync (CLAUDE.md requirement)
- `capabilities.mdx` re-synced against the real tool registry: 60 tools (63 with control tools), stale tool names fixed (`optimize_query` → `analyze_query_optimization`, `navigate_to_dashboard` → `get_dashboard_pages`, `generate_report` → `generate_health_report`), 14 previously undocumented tools added
- `get_chart_data` description now honest about returning guidance, not data

## Tests (Sourcery suggestions from #1554)
- `formatRelativeTime` tests pin the clock via `setSystemTime` (fully deterministic); added a `yesterday` branch test
- New `sql-regressions.test.ts` with targeted assertions for the #1554 SQL fixes (`selected_bytes` alias, `nullIf` guards, `LIMIT` cap, no stale columnFormats) — targeted rather than Sourcery's broad heuristics, which would false-positive on legitimate unguarded divisions

## Verified
- `bun test src/` — 1309 pass, 0 fail
- `vite build && tsc --noEmit` — passes; Biome clean

https://claude.ai/code/session_01AhaTsmQK5qpZa42WYpMLxg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhaTsmQK5qpZa42WYpMLxg)_

## Summary by Sourcery

Align dashboard-tsr with updated conventions and tooling while tightening SQL/query safety, host-status handling, and AI agent documentation, backed by new regression tests.

Bug Fixes:
- Guard compression ratio calculations against division by zero across projections and table overview queries.
- Correct the SelectedBytes aggregation alias to use the expected lowercase selected_bytes field in expensive queries configuration.
- Cap disk-usage anomaly queries with a LIMIT to avoid unbounded result sets.
- Ensure the column-header dropdown re-open timeout is cleared on unmount to prevent stray timers.
- Fix merges column formatting to avoid referencing a non-existent query column.
- Stabilize React list keys in ZooKeeper summary and multi-metrics cards to prevent remounting and UI inconsistencies.
- Make host-status query refetch intervals visibility-aware and standardize host-status API error logging.

Enhancements:
- Use non-modal Radix dropdown menus for table actions, filters, toolbars, and refresh countdown to avoid global aria-hidden recomputation.
- Stabilize memoization inputs and document dependency overrides with biome-ignore comments for table-related hooks to reduce unnecessary re-renders.
- Clarify the get_chart_data tool description to accurately describe its guidance-only behavior.
- Update the About page technology stack badges and root document title to reflect the current framework and tooling.
- Refine test parameter naming and unused variable handling in chart tests and Cypress specs.
- Remove invalid aria-description usage and clean up unnecessary biome-ignore comments around img elements.

Documentation:
- Synchronize AI agent capability documentation with the current tool registry, including updated categories, tool names, counts, and example tools, and clarify that get_chart_data returns guidance rather than data.

Tests:
- Make formatRelativeTime tests deterministic via setSystemTime and add coverage for yesterday formatting.
- Add focused SQL regression tests to assert aliases, guarded divisions, query limits, and valid column formats for key query-config modules.