### PR TITLE
fix(docker): copy tsconfig.base.json into builder stage

### DIFF
--- a/apps/dashboard-tsr/Dockerfile
+++ b/apps/dashboard-tsr/Dockerfile
@@ -33,6 +33,8 @@ ENV NODE_ENV=production \
 COPY --from=deps /app/apps/dashboard-tsr/node_modules /app/apps/dashboard-tsr/node_modules
 # packages/ is needed at build time for the @chm/* source aliases (../../).
 COPY packages/ /app/packages/
+# tsconfig.base.json lives at the repo root and is extended by apps/dashboard-tsr/tsconfig.json.
+COPY tsconfig.base.json /app/tsconfig.base.json
 COPY apps/dashboard-tsr/ /app/apps/dashboard-tsr/
 WORKDIR /app/apps/dashboard-tsr
 # BUILD_TARGET=node switches vite.config.ts to the Nitro node-server preset,


### PR DESCRIPTION
## Summary

- `apps/dashboard-tsr/tsconfig.json` extends `../../tsconfig.base.json` (repo root)
- The builder stage only copied `packages/` and `apps/dashboard-tsr/`, leaving `tsconfig.base.json` absent
- Build failed with: `Tsconfig not found /app/tsconfig.base.json`
- Fix: add `COPY tsconfig.base.json /app/tsconfig.base.json` before the app source copy in the builder stage

Fixes failing run 27401313629 ("Image build and Push" workflow).

## Test plan
- [ ] "Image build and Push" CI workflow passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to properly support TypeScript base configuration inheritance during container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->