### PR TITLE
fix(dashboard): keep view state local so toggle clicks work in Cypress

### DIFF
--- a/apps/dashboard/components/running-queries/running-queries-table.tsx
+++ b/apps/dashboard/components/running-queries/running-queries-table.tsx
@@ -24,7 +24,7 @@ import {
 import { toast } from 'sonner'
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { memo, useCallback, useMemo, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { DetailField } from '@/components/query-tables/detail-field'
 import { exportCsv } from '@/components/query-tables/export-csv'
 import { formatDuration } from '@/components/query-tables/format-duration'
@@ -956,6 +956,12 @@ interface RunningQueriesTableProps {
   rows: RunningQueryRow[]
 }
 
+function resolveView(param: string | null, mobile: boolean): 'table' | 'cards' {
+  if (param === 'card') return 'cards'
+  if (param === 'table') return 'table'
+  return mobile ? 'cards' : 'table'
+}
+
 /**
  * RunningQueriesTable — a dense, sortable, responsive table of in-flight
  * ClickHouse queries.
@@ -987,14 +993,23 @@ export const RunningQueriesTable = memo(function RunningQueriesTable({
   // Card view leads on phones (the wide metric table is unreadable in a scroll
   // box), table on desktop — with a toggle so either is reachable anywhere.
   const isMobile = useIsMobile()
-  const view = useMemo<'table' | 'cards'>(() => {
-    if (layoutParam === 'card') return 'cards'
-    if (layoutParam === 'table') return 'table'
-    return isMobile ? 'cards' : 'table'
+
+  // Derive the view from the URL param or mobile breakpoint. Kept in local
+  // state so toggle clicks take effect immediately without waiting for the
+  // router to reflect the new searchParam value in useSearchParams.
+  const [view, setView] = useState<'table' | 'cards'>(() =>
+    resolveView(layoutParam, isMobile)
+  )
+
+  // Keep in sync when the URL param or viewport class changes externally
+  // (e.g. browser back/forward nav, or a resize crossing the mobile breakpoint).
+  useEffect(() => {
+    setView(resolveView(layoutParam, isMobile))
   }, [layoutParam, isMobile])
 
   const handleViewChange = useCallback(
     (newView: 'table' | 'cards') => {
+      setView(newView)
       const params = new URLSearchParams(searchParams.toString())
       if (newView === 'cards') {
         params.set('layout', 'card')


### PR DESCRIPTION
## Summary

- **Root cause**: `RunningQueriesTable` derived `view` (table/cards) purely from `useSearchParams` via `useMemo`. In Cypress component tests the Next.js router mock does not propagate `router.replace()` back into `useSearchParams`, so after clicking the Table/Cards toggle, `searchParams.get('layout')` still returned `null` and the view stayed stuck on whatever `useIsMobile()` returned.
- **Fix**: Store `view` in `useState` (initialized from `layoutParam`/`isMobile`), call `setView(newView)` immediately in `handleViewChange`, and add a `useEffect` to re-sync when `layoutParam` or `isMobile` changes externally (back/forward nav, viewport resize). Real users are unaffected — the URL is still updated and the view follows it on navigation.
- **Tests fixed**: "lets a mobile user switch back to the table" and "lets a desktop user switch to cards" (both timed out at 8000ms in CI run 27401313592, job 80979812445)

## Test plan

- [x] `components/running-queries/running-queries-table.cy.tsx` — all 4 tests should pass
- [x] No TypeScript errors in `apps/dashboard`
- [x] Real-user toggle behaviour unchanged (view state tracks URL param on actual navigation)

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Keep the RunningQueriesTable layout view in local state while still syncing with the URL and responsive breakpoint.

Bug Fixes:
- Fix RunningQueriesTable layout toggle so view switches immediately on user click even when router search params are not updated (e.g. in Cypress component tests).

Enhancements:
- Add a helper to consistently resolve the initial view from the layout search param and mobile breakpoint, and keep local view state in sync when those change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * View switching in the running queries interface now responds immediately when toggled, showing the selected layout without delay.
  * The chosen layout remains synchronized with the URL and adapts reliably to mobile/responsive breakpoints.
  * Overall smoother and more predictable layout behavior when switching between table and card views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->