### PR TITLE
fix(dashboard-tsr): drop hardcoded clerk key default, sync env docs

### DIFF
--- a/apps/dashboard-tsr/.env.example
+++ b/apps/dashboard-tsr/.env.example
@@ -44,17 +44,52 @@ CLICKHOUSE_HOST=http://localhost:8123
 CLICKHOUSE_USER=default
 CLICKHOUSE_NAME=localhost
 CLICKHOUSE_MAX_EXECUTION_TIME=60
-# Server-side auth provider (runtime). Mirrors VITE_AUTH_PROVIDER; CHM_ wins on the server.
+# Database holding the monitoring app tables (events etc.). Default 'system'.
+# CLICKHOUSE_DATABASE=system
+# Fully-qualified monitoring events table. Default `system.monitoring_events`.
+# EVENTS_TABLE_NAME=system.monitoring_events
+# Server-side auth provider: none | clerk | proxy. Mirrors VITE_AUTH_PROVIDER
+# (none/clerk); CHM_ wins on the server. 'proxy' trusts an upstream (see below).
 CHM_AUTH_PROVIDER=none
 # Agent feature access: public | authenticated.
 CHM_FEATURE_AGENT_ACCESS=public
 # Default AI model (provider:model or anyrouter:@preset/...).
 LLM_MODEL=anyrouter/free
+# Extra agent models to expose, comma-separated provider:model ids.
+# LLM_EXTRA_MODELS=
+# OpenRouter free-tier fallback model (used when the free model is rate-limited).
+# OPENROUTER_FREE_FALLBACK_MODEL=
+# Override the OpenRouter models catalog endpoint.
+# OPENROUTER_MODELS_API=https://openrouter.ai/api/v1/models
 # OpenRouter attribution (non-secret).
 OPENROUTER_REFERER=http://localhost:3000
 OPENROUTER_APP_NAME=chmonitor
+# App-attribution metadata sent to LLM providers (all fall back to code defaults).
+# APP_REFERER overrides OPENROUTER_REFERER for the referer field.
+# APP_REFERER=
+# APP_NAME=
+# APP_CATEGORY=
+# APP_SOURCE=
+# APP_VERSION=
+# Allow the agent's destructive/control tools (KILL QUERY, etc.). Off unless 'true'.
+# AGENT_ENABLE_CONTROL_TOOLS=false
+# Debug logging for the agent json-render patch guard (set to '1').
+# AGENT_JSON_RENDER_PATCH_GUARD_DEBUG=
 # Set to '1' only inside the Cloudflare Worker runtime (CI/wrangler sets it).
 # CLOUDFLARE_WORKERS=1
+
+# Proxy auth (CHM_AUTH_PROVIDER=proxy) — front the app with nginx/k8s/CF Access.
+# Cloudflare Access JWT verification (validates Cf-Access-Jwt-Assertion):
+# CHM_CF_ACCESS_TEAM_DOMAIN=your-team.cloudflareaccess.com
+# CHM_CF_ACCESS_AUD=
+# Trusted-header identity from a reverse proxy, gated by a shared secret (the
+# secret itself is a secret — see below). Header names default to
+# X-Forwarded-User / X-Chm-Proxy-Secret.
+# CHM_PROXY_AUTH_HEADER=X-Forwarded-User
+# CHM_PROXY_SHARED_SECRET_HEADER=X-Chm-Proxy-Secret
+# Relax Clerk to public read-only: anonymous GET /api/v1/* allowed, per-route
+# feature gate still 401s `authenticated` features. Truthy = 1/true/yes/on.
+# CHM_CLERK_PUBLIC_READ=
 
 # ── 3. Secrets — server, sensitive (wrangler secret / CI) ───────────────────
 # NEVER commit real values. Comma-separated to match the HOST list above.
@@ -64,6 +99,11 @@ CLICKHOUSE_PASSWORD=
 CHM_API_KEY_SECRET=
 # Clerk server secret (sk_...). Required when auth provider = clerk.
 CLERK_SECRET_KEY=
+# Bearer token guarding the server-to-server agent API (/api/v1/agent).
+AGENT_API_TOKEN=
+# Shared secret for proxy trusted-header auth (CHM_AUTH_PROVIDER=proxy). When
+# set, the proxy must send it in CHM_PROXY_SHARED_SECRET_HEADER.
+CHM_PROXY_AUTH_SECRET=
 # AI providers (set the one(s) you use).
 LLM_API_KEY=
 LLM_API_BASE=
@@ -89,3 +129,9 @@ NVIDIA_API_BASE=
 # PEERDB_PASSWORD=
 # Conversation store (when VITE_FEATURE_CONVERSATION_DB=true on non-CF targets).
 # DATABASE_URL=
+# Postgres conversation store — POSTGRES_URL (or POSTGRES_PRISMA_URL) is used
+# when set, taking precedence over DATABASE_URL.
+# POSTGRES_URL=
+# POSTGRES_PRISMA_URL=
+# Redis-backed ClickHouse version cache (optional; falls back to in-memory).
+# REDIS_URL=

--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -19,8 +19,9 @@ const r = (p: string) => fileURLToPath(new URL(p, import.meta.url))
 //
 // Values come from `process.env.VITE_*` (CI overrides — e.g. the pk_test Clerk
 // key for preview deploys) with non-secret committed defaults that mirror
-// `scripts/patch-wrangler-env.ts`. The Clerk publishable key is a PUBLIC key
-// (already committed in wrangler.toml), so defaulting it here is safe.
+// `scripts/patch-wrangler-env.ts`. The Clerk publishable key has NO committed
+// default — it comes only from the build env so a missing key cleanly disables
+// Clerk (isClerkEnabled() → false) rather than silently re-enabling it.
 function git(cmd: string): string {
   try {
     return execSync(`git ${cmd}`, { encoding: 'utf-8' }).trim()
@@ -37,10 +38,12 @@ const e = process.env
 const CLIENT_ENV = {
   VITE_AUTH_PROVIDER:
     e.VITE_AUTH_PROVIDER ?? e.NEXT_PUBLIC_AUTH_PROVIDER ?? 'clerk',
+  // No committed default: the publishable key comes ONLY from the build env
+  // (CI sets VITE_CLERK_PUBLISHABLE_KEY — pk_test for previews, pk_live for prod;
+  // see .github/workflows/cloudflare.yml). With no key, isClerkEnabled() returns
+  // false and Clerk cleanly disables — the app runs unauthenticated, no crash.
   VITE_CLERK_PUBLISHABLE_KEY:
-    e.VITE_CLERK_PUBLISHABLE_KEY ??
-    e.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ??
-    'pk_live_Y2xlcmsuY2htb25pdG9yLmRldiQ',
+    e.VITE_CLERK_PUBLISHABLE_KEY ?? e.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? '',
   VITE_FEATURE_CONVERSATION_DB:
     e.VITE_FEATURE_CONVERSATION_DB ??
     e.NEXT_PUBLIC_FEATURE_CONVERSATION_DB ??


### PR DESCRIPTION
Config/env hygiene pass for `apps/dashboard-tsr`. Three sub-tasks:

## A) Remove hardcoded Clerk `pk_live` fallback in `vite.config.ts`
The `CLIENT_ENV.VITE_CLERK_PUBLISHABLE_KEY` default `'pk_live_Y2xlcmsuY2htb25pdG9yLmRldiQ'` is dropped; the key now comes **only** from the build env (`VITE_CLERK_PUBLISHABLE_KEY` → legacy `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` → `''`).

**Clean-disable verified:** `isClerkClientEnabled()` (`src/lib/clerk/clerk-client.ts`) gates on `Boolean(CLERK_PUBLISHABLE_KEY?.startsWith('pk_'))`. With an empty key it returns `false`, so Clerk disables and the app runs unauthenticated — no crash. The stale comment claiming "defaulting it here is safe" was corrected.

**CI secret verification (critical):** `.github/workflows/cloudflare.yml` `dashboard-tsr` build job (lines 319-323) already sets `VITE_CLERK_PUBLISHABLE_KEY` explicitly — `pk_test_…` for PR/preview builds, `pk_live_…` for prod/push builds. So removing the source fallback does **not** silently disable Clerk in prod. No workflow change was needed (the key is a public `pk_`, inlined as a literal in the workflow, consistent with `wrangler.toml`).

## B) Sync `apps/dashboard-tsr/.env.example` with real usage
Cross-referenced every `process.env.*` / `import.meta.env.*` read in `src` + `vite.config.ts`. Added the missing documented vars (each verified to appear in non-test code), grouped by tier:
- Agent: `AGENT_API_TOKEN`, `AGENT_ENABLE_CONTROL_TOOLS`, `AGENT_JSON_RENDER_PATCH_GUARD_DEBUG`
- Proxy / CF Access auth: `CHM_CF_ACCESS_TEAM_DOMAIN`, `CHM_CF_ACCESS_AUD`, `CHM_PROXY_AUTH_HEADER`, `CHM_PROXY_AUTH_SECRET`, `CHM_PROXY_SHARED_SECRET_HEADER`, `CHM_CLERK_PUBLIC_READ`
- App attribution: `APP_REFERER`, `APP_NAME`, `APP_CATEGORY`, `APP_SOURCE`, `APP_VERSION`
- LLM/OpenRouter: `LLM_EXTRA_MODELS`, `OPENROUTER_FREE_FALLBACK_MODEL`, `OPENROUTER_MODELS_API`
- ClickHouse: `CLICKHOUSE_DATABASE`, `EVENTS_TABLE_NAME`
- Stores: `POSTGRES_URL`, `POSTGRES_PRISMA_URL`, `REDIS_URL`

Build-internal vars (`BUILD_TARGET`, `CI`, `NODE_ENV`, `CHM_SKIP_PRERENDER`) were intentionally omitted.

## C) Fix `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` README references for dashboard-tsr
`apps/dashboard-tsr/README.md` already uses the correct `VITE_CLERK_PUBLISHABLE_KEY` (lines 29, 135) — no NEXT_PUBLIC_ refs remain in any dashboard-tsr markdown, so no change was required. The root `README.md` line 67 NEXT_PUBLIC reference is in the **legacy `apps/dashboard` (Next.js)** quick-start (`.env.local`, "Next.js 15 dashboard"), which genuinely uses `NEXT_PUBLIC_` — left untouched as instructed.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Clean up dashboard-tsr Clerk environment configuration and align example env with actual usage.

Enhancements:
- Remove the hardcoded Clerk publishable key fallback so it is sourced only from the build environment and cleanly disables Clerk when unset.

Documentation:
- Update the dashboard-tsr env example and related comments to document the full set of required environment variables and the Clerk key behavior.