### PR TITLE
refactor(dashboard-tsr): replace last swr usage with tanstack query, drop swr dep

### DIFF
--- a/apps/dashboard-tsr/src/lib/hooks/use-autocomplete-data.ts
+++ b/apps/dashboard-tsr/src/lib/hooks/use-autocomplete-data.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import useSWR from 'swr'
+import { useQuery } from '@tanstack/react-query'
 
 import type { AutocompleteItem } from '@/components/agents/mentions/types'
 
@@ -53,15 +53,21 @@ export function useAutocompleteData() {
   const hostId = useHostId()
 
   // Lazy-load tables list (only fetched when hook is mounted = when @ is first used)
-  const { data: tablesData, isLoading: tablesLoading } = useSWR<{
-    data: TableRow[]
-  }>(
-    hostId != null
-      ? `/api/v1/tables?hostId=${hostId}&limit=${AUTOCOMPLETE_LIMIT}`
-      : null,
-    (url: string) => fetchJson<{ data: TableRow[] }>(url),
-    { revalidateOnFocus: false, dedupingInterval: 60000 }
-  )
+  const {
+    data: tablesData,
+    isPending: tablesPending,
+    isFetching: tablesFetching,
+  } = useQuery<{ data: TableRow[] }>({
+    queryKey: ['/api/v1/tables', 'autocomplete', hostId, AUTOCOMPLETE_LIMIT],
+    queryFn: () =>
+      fetchJson<{ data: TableRow[] }>(
+        `/api/v1/tables?hostId=${hostId}&limit=${AUTOCOMPLETE_LIMIT}`
+      ),
+    enabled: hostId != null,
+    // SWR dedupingInterval: 60000 → keep results fresh for 60s before refetch.
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  })
 
   const tables: AutocompleteItem[] = (tablesData?.data || []).map((row) => ({
     id: `table-${row.database}-${row.name}`,
@@ -73,17 +79,18 @@ export function useAutocompleteData() {
   }))
 
   // Skills from agent tools metadata (static, loaded once)
-  const { data: skillsData } = useSWR<{
+  const { data: skillsData } = useQuery<{
     data: Array<{ name: string; description: string }>
-  }>(
-    '/api/v1/agent/skills',
-    (url: string) =>
-      fetchJson<{ data: Array<{ name: string; description: string }> }>(url),
-    {
-      revalidateOnFocus: false,
-      dedupingInterval: 300000,
-    }
-  )
+  }>({
+    queryKey: ['/api/v1/agent/skills'],
+    queryFn: () =>
+      fetchJson<{ data: Array<{ name: string; description: string }> }>(
+        '/api/v1/agent/skills'
+      ),
+    // SWR dedupingInterval: 300000 → effectively static, cache for 5 minutes.
+    staleTime: 300_000,
+    refetchOnWindowFocus: false,
+  })
 
   const skills: AutocompleteItem[] = (skillsData?.data || []).map((skill) => ({
     id: `skill-${skill.name}`,
@@ -99,6 +106,8 @@ export function useAutocompleteData() {
     resources: SYSTEM_RESOURCES,
     skills,
     commands: SLASH_COMMANDS,
-    isLoading: tablesLoading,
+    // Match sibling hooks: only "loading" while a fetch is in flight, so the
+    // disabled state (hostId == null) does not report a stuck loading state.
+    isLoading: tablesPending && tablesFetching,
   }
 }


### PR DESCRIPTION
## Summary

`apps/dashboard-tsr` standardized on `@tanstack/react-query`, but `src/lib/hooks/use-autocomplete-data.ts` was the **last** file still importing `swr` directly (relying on a transitively-hoisted copy). This ports it to `useQuery`, matching the sibling `use-chart-data` / `use-table-data` hooks.

## API preserved

Same return shape: `{ tables, resources, skills, commands, isLoading }`. The sole caller (`prompt-input-with-mentions.tsx`) destructures `{ tables, resources, skills, commands }` — unchanged.

### SWR → TanStack Query option mapping

| SWR | TanStack Query |
|-----|----------------|
| conditional key `hostId != null ? url : null` | `enabled: hostId != null` |
| `dedupingInterval: 60000` (tables) | `staleTime: 60_000` |
| `dedupingInterval: 300000` (skills) | `staleTime: 300_000` |
| `revalidateOnFocus: false` | `refetchOnWindowFocus: false` |
| `isLoading` | `isPending && isFetching` (sibling convention; avoids a stuck loading state while the query is disabled) |

## Notes on the `swr` dependency

There is **no direct `swr` entry in `apps/dashboard-tsr/package.json`** to remove — it was never a direct dep there; the source file relied on a hoisted copy. `swr@2.4.1` remains in `apps/dashboard-tsr/bun.lock` only as a **transitive dependency of `@ai-sdk/react`** (`swr: ^2.2.5`), so the lock is unchanged after `bun install`. The legacy `apps/dashboard` (Next.js) still uses `swr` directly and is untouched.

`use-swr-revalidate.ts` is swr-free (wraps a `mutate()` callback via a window event) and is left untouched — it is used by `keyboard-shortcuts.tsx`.

## Verification

- `rg -n "from 'swr'" apps/dashboard-tsr/src/` → **0 hits**
- `bun run type-check` introduces **no new errors** in touched files (the 146 pre-existing `routeTree.gen.ts` errors are present on clean main too, since the route tree isn't generated in a fresh worktree)

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Refactor the dashboard autocomplete data hook to use TanStack React Query instead of SWR while preserving its public API and behavior.

Enhancements:
- Migrate table and skills autocomplete data fetching from SWR to TanStack React Query with equivalent caching and refetch semantics.
- Align loading state computation in the autocomplete data hook with sibling hooks to avoid reporting loading when the query is disabled.