### PR TITLE
fix(dashboard-tsr): bridge CLICKHOUSE_DATABASE and EVENTS_TABLE_NAME on workers

### DIFF
--- a/apps/dashboard-tsr/src/lib/api/__tests__/server-env.test.ts
+++ b/apps/dashboard-tsr/src/lib/api/__tests__/server-env.test.ts
@@ -1,0 +1,55 @@
+import { bridgeClickHouseEnv } from '../server-env'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+describe('bridgeClickHouseEnv', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    // Clear ClickHouse env keys from process.env before each test
+    const keys = [
+      'CLICKHOUSE_HOST',
+      'CLICKHOUSE_USER',
+      'CLICKHOUSE_PASSWORD',
+      'CLICKHOUSE_NAME',
+      'CLICKHOUSE_MAX_EXECUTION_TIME',
+      'CLICKHOUSE_DATABASE',
+      'EVENTS_TABLE_NAME',
+    ]
+    for (const key of keys) {
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it('should copy ClickHouse environment variables to process.env', () => {
+    const mockBindings = {
+      CLICKHOUSE_HOST: 'http://my-host:8123',
+      CLICKHOUSE_USER: 'admin',
+      CLICKHOUSE_PASSWORD: 'secretpassword',
+      CLICKHOUSE_DATABASE: 'custom_db',
+      EVENTS_TABLE_NAME: 'custom_events',
+    }
+
+    bridgeClickHouseEnv(mockBindings)
+
+    expect(process.env.CLICKHOUSE_HOST).toBe('http://my-host:8123')
+    expect(process.env.CLICKHOUSE_USER).toBe('admin')
+    expect(process.env.CLICKHOUSE_PASSWORD).toBe('secretpassword')
+    expect(process.env.CLICKHOUSE_DATABASE).toBe('custom_db')
+    expect(process.env.EVENTS_TABLE_NAME).toBe('custom_events')
+  })
+
+  it('should not overwrite existing process.env values', () => {
+    process.env.CLICKHOUSE_HOST = 'http://existing:8123'
+    const mockBindings = {
+      CLICKHOUSE_HOST: 'http://new-host:8123',
+    }
+
+    bridgeClickHouseEnv(mockBindings)
+
+    expect(process.env.CLICKHOUSE_HOST).toBe('http://existing:8123')
+  })
+})

--- a/apps/dashboard-tsr/src/lib/api/server-env.ts
+++ b/apps/dashboard-tsr/src/lib/api/server-env.ts
@@ -24,6 +24,8 @@ const CLICKHOUSE_ENV_KEYS = [
   'CLICKHOUSE_PASSWORD',
   'CLICKHOUSE_NAME',
   'CLICKHOUSE_MAX_EXECUTION_TIME',
+  'CLICKHOUSE_DATABASE',
+  'EVENTS_TABLE_NAME',
 ] as const
 
 export type ClickHouseBindings = Record<string, string | undefined>


### PR DESCRIPTION
Bridges `CLICKHOUSE_DATABASE` and `EVENTS_TABLE_NAME` on Cloudflare Workers.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Extend dashboard ClickHouse worker configuration to include database and events table environment bindings.

New Features:
- Expose CLICKHOUSE_DATABASE and EVENTS_TABLE_NAME bindings for ClickHouse-backed Cloudflare Workers.

Tests:
- Add tests covering server environment bindings for ClickHouse configuration on workers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for database environment configuration handling and variable management.

* **Chores**
  * Extended environment variable support to include additional database configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->