### PR TITLE
fix(clickhouse-client): harden http status code regex in clickhouse-fetch

### DIFF
--- a/packages/clickhouse-client/src/__tests__/clickhouse-fetch.test.ts
+++ b/packages/clickhouse-client/src/__tests__/clickhouse-fetch.test.ts
@@ -86,6 +86,12 @@ describe('clickhouse-fetch error parsing', () => {
     })
 
     it('should extract HTTP status code from HTTP/1.1 status error messages', async () => {
+      mockClientQuery.mockRejectedValue(new Error('HTTP/1.1 403 Forbidden'))
+      const result = await fetchData({ hostId: 0, query: 'SELECT 1' })
+      expect(result.error?.details?.httpStatusCode).toBe(403)
+    })
+
+    it('should extract HTTP status code from HTTP status keyword messages', async () => {
       mockClientQuery.mockRejectedValue(new Error('HTTP status 403'))
       const result = await fetchData({ hostId: 0, query: 'SELECT 1' })
       expect(result.error?.details?.httpStatusCode).toBe(403)
@@ -95,6 +101,16 @@ describe('clickhouse-fetch error parsing', () => {
       mockClientQuery.mockRejectedValue(new Error('status 502 Bad Gateway'))
       const result = await fetchData({ hostId: 0, query: 'SELECT 1' })
       expect(result.error?.details?.httpStatusCode).toBe(502)
+    })
+
+    it('should extract HTTP status code from HTTP/1.1 status line even when Code: is present', async () => {
+      mockClientQuery.mockRejectedValue(
+        new Error(
+          'ClickHouse exception: Code: 159, DB::Exception: HTTP/1.1 500 Internal Server Error'
+        )
+      )
+      const result = await fetchData({ hostId: 0, query: 'SELECT 1' })
+      expect(result.error?.details?.httpStatusCode).toBe(500)
     })
 
     it('should ignore port numbers or data quantities without HTTP context when Code: is present', async () => {

--- a/packages/clickhouse-client/src/__tests__/clickhouse-fetch.test.ts
+++ b/packages/clickhouse-client/src/__tests__/clickhouse-fetch.test.ts
@@ -1,0 +1,141 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+const mockDebug = mock(() => {})
+const mockError = mock(() => {})
+const mockWarn = mock(() => {})
+
+mock.module('@chm/logger', () => ({
+  debug: mockDebug,
+  error: mockError,
+  warn: mockWarn,
+}))
+
+const mockCreateClient = mock(() => ({}))
+mock.module('@clickhouse/client', () => ({
+  createClient: mockCreateClient,
+}))
+
+const mockValidateTableExistence = mock(() =>
+  Promise.resolve({ shouldProceed: true, missingTables: [] })
+)
+const mockTransformClickHouseJsonEachRowWasmJson = mock((input: string) => {
+  return Promise.resolve(input)
+})
+
+mock.module('../table-validator', () => ({
+  validateTableExistence: mockValidateTableExistence,
+}))
+
+mock.module('../wasm/monitor-core', () => ({
+  transformClickHouseJsonEachRowWasmJson:
+    mockTransformClickHouseJsonEachRowWasmJson,
+  transformClickHouseJsonEachRowWasm: async (input: string) =>
+    JSON.parse(await mockTransformClickHouseJsonEachRowWasmJson(input)),
+}))
+
+// Clean up all module mocks after tests complete
+afterAll(() => {
+  mock.restore()
+})
+
+const { fetchData, fetchJsonEachRowAsNormalizedJson } = await import(
+  new URL('../clickhouse/clickhouse-fetch.ts', import.meta.url).href
+)
+
+const { _resetEnvCache: resetEnvCache } = await import(
+  '../clickhouse/env-schema'
+)
+const { clientPool } = await import('../clickhouse/connection-pool')
+
+describe('clickhouse-fetch error parsing', () => {
+  const originalEnv = { ...process.env }
+  const mockClientQuery = mock(() => Promise.resolve({}))
+  const mockClient = {
+    query: mockClientQuery,
+  }
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    process.env.CLICKHOUSE_HOST = 'http://localhost:8123'
+    process.env.CLICKHOUSE_USER = 'default'
+    process.env.CLICKHOUSE_PASSWORD = ''
+    resetEnvCache()
+    clientPool.clear()
+    mockCreateClient.mockReset()
+    mockClientQuery.mockReset()
+    mockCreateClient.mockReturnValue(mockClient)
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  describe('fetchData status code parsing', () => {
+    it('should ignore Code: XXX errors and not treat them as HTTP status codes', async () => {
+      mockClientQuery.mockRejectedValue(
+        new Error('ClickHouse exception: Code: 159, DB::Exception: ...')
+      )
+      const result = await fetchData({ hostId: 0, query: 'SELECT 1' })
+      expect(result.error?.details?.httpStatusCode).toBeUndefined()
+    })
+
+    it('should extract HTTP status code from HTTP error messages with status keyword', async () => {
+      mockClientQuery.mockRejectedValue(new Error('Failed with status: 500'))
+      const result = await fetchData({ hostId: 0, query: 'SELECT 1' })
+      expect(result.error?.details?.httpStatusCode).toBe(500)
+    })
+
+    it('should extract HTTP status code from HTTP/1.1 status error messages', async () => {
+      mockClientQuery.mockRejectedValue(new Error('HTTP status 403'))
+      const result = await fetchData({ hostId: 0, query: 'SELECT 1' })
+      expect(result.error?.details?.httpStatusCode).toBe(403)
+    })
+
+    it('should extract HTTP status code from status error messages without colon', async () => {
+      mockClientQuery.mockRejectedValue(new Error('status 502 Bad Gateway'))
+      const result = await fetchData({ hostId: 0, query: 'SELECT 1' })
+      expect(result.error?.details?.httpStatusCode).toBe(502)
+    })
+
+    it('should ignore port numbers or data quantities without HTTP context when Code: is present', async () => {
+      mockClientQuery.mockRejectedValue(
+        new Error(
+          'ClickHouse exception: Code: 100, DB::Exception: connection error on port 8123'
+        )
+      )
+      const result = await fetchData({ hostId: 0, query: 'SELECT 1' })
+      expect(result.error?.details?.httpStatusCode).toBeUndefined()
+    })
+  })
+
+  describe('fetchJsonEachRowAsNormalizedJson status code parsing', () => {
+    it('should ignore Code: XXX errors and not treat them as HTTP status codes', async () => {
+      mockClientQuery.mockRejectedValue(
+        new Error('ClickHouse exception: Code: 159, DB::Exception: ...')
+      )
+      const result = await fetchJsonEachRowAsNormalizedJson({
+        hostId: 0,
+        query: 'SELECT 1',
+      })
+      expect(result.error?.details?.httpStatusCode).toBeUndefined()
+    })
+
+    it('should extract HTTP status code from HTTP error messages with status keyword', async () => {
+      mockClientQuery.mockRejectedValue(new Error('Failed with status: 500'))
+      const result = await fetchJsonEachRowAsNormalizedJson({
+        hostId: 0,
+        query: 'SELECT 1',
+      })
+      expect(result.error?.details?.httpStatusCode).toBe(500)
+    })
+
+    it('should extract HTTP status code from HTTP/1.1 status error messages', async () => {
+      mockClientQuery.mockRejectedValue(new Error('HTTP status 403'))
+      const result = await fetchJsonEachRowAsNormalizedJson({
+        hostId: 0,
+        query: 'SELECT 1',
+      })
+      expect(result.error?.details?.httpStatusCode).toBe(403)
+    })
+  })
+})

--- a/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
+++ b/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
@@ -283,7 +283,14 @@ export const fetchData = async <
 
     // Extract HTTP status code from fetch errors
     let httpStatusCode: number | undefined
-    const statusMatch = errorMessage.match(/(\d{3})/)
+    // Match 3-digit HTTP status codes (100-599), optionally preceded by "status" or "HTTP" keywords.
+    // Avoid matching ClickHouse internal exception codes (preceded by "Code:").
+    let statusMatch = errorMessage.match(
+      /\b(?:status|HTTP\s+(?:status|error))\s*([1-5]\d{2})\b/i
+    )
+    if (!statusMatch && !errorMessage.includes('Code:')) {
+      statusMatch = errorMessage.match(/\b([1-5]\d{2})\b/)
+    }
     if (statusMatch) {
       httpStatusCode = parseInt(statusMatch[1], 10)
     }
@@ -548,7 +555,14 @@ export const fetchJsonEachRowAsNormalizedJson = async ({
 
     // Extract HTTP status code from fetch errors
     let httpStatusCode: number | undefined
-    const statusMatch = errorMessage.match(/(\d{3})/)
+    // Match 3-digit HTTP status codes (100-599), optionally preceded by "status" or "HTTP" keywords.
+    // Avoid matching ClickHouse internal exception codes (preceded by "Code:").
+    let statusMatch = errorMessage.match(
+      /\b(?:status|HTTP\s+(?:status|error))\s*([1-5]\d{2})\b/i
+    )
+    if (!statusMatch && !errorMessage.includes('Code:')) {
+      statusMatch = errorMessage.match(/\b([1-5]\d{2})\b/)
+    }
     if (statusMatch) {
       httpStatusCode = parseInt(statusMatch[1], 10)
     }

--- a/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
+++ b/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
@@ -25,6 +25,41 @@ type FetchJsonEachRowTextResult = FetchDataResult<never> & {
 }
 
 /**
+ * Extract an HTTP status code (100–599) from a fetch error message.
+ *
+ * Strategy:
+ * 1. Try a keyword-anchored match that handles:
+ *    - "status: 500", "HTTP status 403", "HTTP error 502"
+ *    - Standard HTTP status lines: "HTTP/1.1 500", "HTTP/2 502"
+ * 2. If (1) fails AND the message also contains a ClickHouse "Code:" clause
+ *    that sits at the start of a line or is unaccompanied by HTTP keywords,
+ *    skip the generic digit scan to avoid misidentifying internal error codes.
+ * 3. Otherwise fall back to a generic 3-digit match.
+ */
+function extractHttpStatusCode(errorMessage: string): number | undefined {
+  // Keyword-anchored: matches "status 500", "HTTP status 403", "HTTP/1.1 500", "HTTP/2 502", etc.
+  const keywordMatch = errorMessage.match(
+    /\b(?:status|HTTP(?:\/\d+(?:\.\d+)?)?(?:\s+(?:status|error))?)\s*([1-5]\d{2})\b/i
+  )
+  if (keywordMatch) {
+    return parseInt(keywordMatch[1], 10)
+  }
+
+  // Skip generic digit scan when ClickHouse internal codes are present and no
+  // HTTP keyword was found above, to avoid false positives like "Code: 210".
+  if (errorMessage.includes('Code:')) {
+    return undefined
+  }
+
+  const genericMatch = errorMessage.match(/\b([1-5]\d{2})\b/)
+  if (genericMatch) {
+    return parseInt(genericMatch[1], 10)
+  }
+
+  return undefined
+}
+
+/**
  * Fetch data from ClickHouse with comprehensive error handling
  */
 export const fetchData = async <
@@ -282,18 +317,7 @@ export const fetchData = async <
     let errorType: FetchDataErrorType = 'query_error'
 
     // Extract HTTP status code from fetch errors
-    let httpStatusCode: number | undefined
-    // Match 3-digit HTTP status codes (100-599), optionally preceded by "status" or "HTTP" keywords.
-    // Avoid matching ClickHouse internal exception codes (preceded by "Code:").
-    let statusMatch = errorMessage.match(
-      /\b(?:status|HTTP\s+(?:status|error))\s*([1-5]\d{2})\b/i
-    )
-    if (!statusMatch && !errorMessage.includes('Code:')) {
-      statusMatch = errorMessage.match(/\b([1-5]\d{2})\b/)
-    }
-    if (statusMatch) {
-      httpStatusCode = parseInt(statusMatch[1], 10)
-    }
+    const httpStatusCode = extractHttpStatusCode(errorMessage)
 
     // SSL/TLS errors (Cloudflare 525/526 as standalone status codes, not
     // digits embedded in larger numbers like "525.00 MiB" or "15251")
@@ -554,18 +578,7 @@ export const fetchJsonEachRowAsNormalizedJson = async ({
     let errorType: FetchDataErrorType = 'query_error'
 
     // Extract HTTP status code from fetch errors
-    let httpStatusCode: number | undefined
-    // Match 3-digit HTTP status codes (100-599), optionally preceded by "status" or "HTTP" keywords.
-    // Avoid matching ClickHouse internal exception codes (preceded by "Code:").
-    let statusMatch = errorMessage.match(
-      /\b(?:status|HTTP\s+(?:status|error))\s*([1-5]\d{2})\b/i
-    )
-    if (!statusMatch && !errorMessage.includes('Code:')) {
-      statusMatch = errorMessage.match(/\b([1-5]\d{2})\b/)
-    }
-    if (statusMatch) {
-      httpStatusCode = parseInt(statusMatch[1], 10)
-    }
+    const httpStatusCode = extractHttpStatusCode(errorMessage)
 
     // SSL/TLS errors (Cloudflare 525/526 as standalone status codes, not
     // digits embedded in larger numbers like "525.00 MiB" or "15251")


### PR DESCRIPTION
Hardens the HTTP status code regex to avoid greedily matching arbitrary 3-digit numbers or internal Clickhouse error codes.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Harden HTTP status code extraction in ClickHouse fetch helpers and add regression tests for error message parsing.

Bug Fixes:
- Prevent internal ClickHouse exception codes and unrelated 3-digit numbers from being misinterpreted as HTTP status codes in fetch error handling.

Tests:
- Add unit tests for fetchData and fetchJsonEachRowAsNormalizedJson to cover various HTTP and ClickHouse error message patterns and validate HTTP status code parsing behavior.