### PR TITLE
fix(clickhouse-client): redact inline credentials from host config debug logs

### DIFF
--- a/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-config.test.ts
+++ b/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-config.test.ts
@@ -13,6 +13,7 @@ const {
   getClickHouseHosts,
   getClickHouseConfigs,
   getAndValidateClientConfig,
+  redactHostCredentials,
   _resetEnvCache,
 } = await import(
   new URL('../clickhouse-config.ts?test=config', import.meta.url).href
@@ -218,5 +219,31 @@ describe('getAndValidateClientConfig', () => {
 
     expect(() => getAndValidateClientConfig(5)).toThrow('Invalid hostId: 5')
     expect(() => getAndValidateClientConfig(5)).toThrow('Available hosts: 0-0')
+  })
+})
+
+describe('redactHostCredentials', () => {
+  it('should leave host without credentials unchanged', () => {
+    expect(redactHostCredentials('http://localhost:8123')).toBe(
+      'http://localhost:8123/'
+    )
+  })
+
+  it('should redact username and password from http URL', () => {
+    expect(
+      redactHostCredentials('http://admin:secret@clickhouse.prod:8123')
+    ).toBe('http://***:***@clickhouse.prod:8123/')
+  })
+
+  it('should redact credentials from https URL', () => {
+    expect(redactHostCredentials('https://user:pass123@clickhouse.prod')).toBe(
+      'https://***:***@clickhouse.prod/'
+    )
+  })
+
+  it('should handle invalid URLs gracefully', () => {
+    expect(redactHostCredentials('invalid-url-string')).toBe(
+      'invalid-url-string'
+    )
   })
 })

--- a/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-config.test.ts
+++ b/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-config.test.ts
@@ -225,7 +225,7 @@ describe('getAndValidateClientConfig', () => {
 describe('redactHostCredentials', () => {
   it('should leave host without credentials unchanged', () => {
     expect(redactHostCredentials('http://localhost:8123')).toBe(
-      'http://localhost:8123/'
+      'http://localhost:8123'
     )
   })
 
@@ -238,6 +238,24 @@ describe('redactHostCredentials', () => {
   it('should redact credentials from https URL', () => {
     expect(redactHostCredentials('https://user:pass123@clickhouse.prod')).toBe(
       'https://***:***@clickhouse.prod/'
+    )
+  })
+
+  it('should redact password-only credentials (:pass@)', () => {
+    expect(redactHostCredentials('https://:secret@clickhouse.prod:8123')).toBe(
+      'https://:***@clickhouse.prod:8123/'
+    )
+  })
+
+  it('should redact username-only credentials (user@)', () => {
+    expect(redactHostCredentials('https://user@clickhouse.prod:8123')).toBe(
+      'https://***@clickhouse.prod:8123/'
+    )
+  })
+
+  it('should redact credentials from URL without protocol', () => {
+    expect(redactHostCredentials('admin:secret@clickhouse.prod:8123')).toBe(
+      '***:***@clickhouse.prod:8123'
     )
   })
 

--- a/packages/clickhouse-client/src/clickhouse/clickhouse-config.ts
+++ b/packages/clickhouse-client/src/clickhouse/clickhouse-config.ts
@@ -15,6 +15,23 @@ import { debug, error } from '@chm/logger'
 export { _resetEnvCache }
 
 /**
+ * Redacts username and password credentials from a ClickHouse host URL string
+ */
+export function redactHostCredentials(urlStr: string): string {
+  try {
+    const url = new URL(urlStr)
+    if (url.username || url.password) {
+      url.username = '***'
+      url.password = '***'
+    }
+    return url.toString()
+  } catch {
+    // Fallback regex if URL constructor fails (e.g. for incomplete or relative hosts)
+    return urlStr.replace(/(https?:\/\/)([^:]+):([^@]+)@/, '$1***:***@')
+  }
+}
+
+/**
  * Retrieve a single ClickHouseConfig by hostId, throwing if the id is out of
  * range.  Centralises the "lookup + validate" logic so callers like getClient
  * and fetchExplainAsText don't duplicate it.
@@ -65,7 +82,10 @@ export const getClickHouseConfigs = (): ClickHouseConfig[] => {
       Object.keys(process.env).filter((k) => k.includes('CLICK'))
     )
   } else {
-    debug('[ClickHouse Config] CLICKHOUSE_HOST:', hostEnv)
+    const redactedHostEnv = splitByComma(hostEnv)
+      .map(redactHostCredentials)
+      .join(',')
+    debug('[ClickHouse Config] CLICKHOUSE_HOST:', redactedHostEnv)
     debug('[ClickHouse Config] CLICKHOUSE_USER:', userEnv ? '***' : '(empty)')
     debug(
       '[ClickHouse Config] CLICKHOUSE_PASSWORD:',
@@ -111,7 +131,7 @@ export const getClickHouseConfigs = (): ClickHouseConfig[] => {
 
     debug(`[ClickHouse Config] Host ${index}:`, {
       id: config.id,
-      host: config.host,
+      host: redactHostCredentials(config.host),
       user: config.user,
       hasPassword: !!config.password,
       customName: config.customName,

--- a/packages/clickhouse-client/src/clickhouse/clickhouse-config.ts
+++ b/packages/clickhouse-client/src/clickhouse/clickhouse-config.ts
@@ -18,17 +18,33 @@ export { _resetEnvCache }
  * Redacts username and password credentials from a ClickHouse host URL string
  */
 export function redactHostCredentials(urlStr: string): string {
+  // Fast-path: no '@' means no credentials to redact.
+  if (!urlStr.includes('@')) {
+    return urlStr
+  }
   try {
     const url = new URL(urlStr)
-    if (url.username || url.password) {
-      url.username = '***'
-      url.password = '***'
+    // Only trust the parse result for http/https — other inputs (e.g.
+    // "admin:secret@host") are silently parsed with "admin:" as the scheme
+    // and no username/password, so we fall through to the regex path.
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      if (url.username) url.username = '***'
+      if (url.password) url.password = '***'
+      return url.toString()
     }
-    return url.toString()
   } catch {
-    // Fallback regex if URL constructor fails (e.g. for incomplete or relative hosts)
-    return urlStr.replace(/(https?:\/\/)([^:]+):([^@]+)@/, '$1***:***@')
+    // URL constructor threw — fall through to regex below.
   }
+  // Fallback for URLs without a recognized protocol (e.g. "admin:secret@host:8123").
+  // Handles user:pass@, :pass@ (password-only), and user@ (username-only).
+  return urlStr.replace(
+    /(?:(https?:\/\/))?([^:@]*)(?::([^@]*))?@/,
+    (_, proto, user, pass) => {
+      const redactedUser = user ? '***' : ''
+      const redactedPass = pass !== undefined ? ':***' : ''
+      return `${proto ?? ''}${redactedUser}${redactedPass}@`
+    }
+  )
 }
 
 /**


### PR DESCRIPTION
Redacts inline username and password credentials from ClickHouse host debug logs to prevent credential leakage.

Co-Authored-By: duyetbot <bot@duyet.net>