### PR TITLE
fix(dashboard-tsr): skip hash-anchor URLs in prerender crawl to unblock Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,13 @@ COPY --from=deps /app/apps/dashboard-tsr/node_modules /app/apps/dashboard-tsr/no
 WORKDIR /app/apps/dashboard-tsr
 # BUILD_TARGET=node switches vite.config.ts to the Nitro node-server preset,
 # emitting a self-contained bundle at .output/server/index.mjs.
-RUN BUILD_TARGET=node bun run build:node
+#
+# Use the build:node:ci wrapper, NOT a bare `vite build`: the prerender crawl
+# finishes writing `.output` but the process never exits (nitro's in-process
+# render server leaves a ref'd socket open), which would hang `RUN` until the
+# CI/Docker timeout. The wrapper detects completion (prerender marker + on-disk
+# artifacts) and reaps the lingering process group, exiting cleanly.
+RUN bun run build:node:ci
 
 # ── runner ─────────────────────────────────────────────────────────────────
 # The Nitro node-server output is a plain Node bundle — run on node:24-alpine

--- a/apps/dashboard-tsr/package.json
+++ b/apps/dashboard-tsr/package.json
@@ -11,6 +11,7 @@
     "dev": "vite dev",
     "build": "vite build && tsc --noEmit",
     "build:node": "BUILD_TARGET=node vite build",
+    "build:node:ci": "bun scripts/build-node-ci.ts",
     "start:node": "node .output/server/index.mjs",
     "preview": "vite preview",
     "deploy": "bun run build && wrangler deploy",

--- a/apps/dashboard-tsr/scripts/build-node-ci.ts
+++ b/apps/dashboard-tsr/scripts/build-node-ci.ts
@@ -7,10 +7,20 @@ const SUCCESS_MARKER = '[prerender] - /'
 const REQUIRED_ARTIFACTS = ['.output/server/index.mjs', '.output/nitro.json']
 const TIMEOUT_MS = 10 * 60 * 1000
 const GRACE_MS = 5_000
+// Prerender stays ON by default (prod/Docker needs the static HTML). Callers
+// that don't need prerendered output (the e2e CI build) opt out by setting
+// CHM_SKIP_PRERENDER=1 in the environment — we inherit it rather than force it.
+//
+// Why this wrapper exists: `BUILD_TARGET=node vite build` finishes writing the
+// full `.output` (and prints "[prerender] Prerendered N pages") but the process
+// never exits — nitro's in-process prerender render server leaves a ref'd
+// socket open (plus worker MessagePorts), so a bare `RUN ... build:node` in
+// Docker hangs until the CI timeout. We detect completion from the prerender
+// marker + the on-disk artifacts, then reap the lingering process group and
+// exit 0.
 const CHILD_ENV = {
   ...process.env,
   BUILD_TARGET: 'node',
-  CHM_SKIP_PRERENDER: '1',
 }
 const WAIT_FOR_PRERENDER_MARKER = CHILD_ENV.CHM_SKIP_PRERENDER !== '1'
 const startedAt = Date.now()
@@ -18,6 +28,7 @@ const startedAt = Date.now()
 let sawSuccessMarker = false
 let settled = false
 let graceTimer: ReturnType<typeof setTimeout> | undefined
+let artifactPoll: ReturnType<typeof setInterval> | undefined
 let recentOutput = ''
 
 const child = spawn('bun', ['run', 'build:node'], {
@@ -50,9 +61,20 @@ function finish(code: number) {
   if (settled) return
   settled = true
   if (graceTimer) clearTimeout(graceTimer)
+  if (artifactPoll) clearInterval(artifactPoll)
   clearTimeout(timeout)
   process.exit(code)
 }
+
+// Completion is level-triggered (artifacts on disk), but our only success
+// SIGNAL from stdout is edge-triggered (the `[prerender] - /` marker lines,
+// which all stream during the crawl-list phase BEFORE rendering writes
+// artifacts). If we only re-checked on marker chunks we'd miss the moment
+// artifacts appear — no more marker lines stream by then. Poll every second so
+// `scheduleSuccessfulShutdown()` re-evaluates `artifactsExist()` until the
+// build's output is on disk, then reaps the lingering process.
+artifactPoll = setInterval(() => scheduleSuccessfulShutdown(), 1_000)
+artifactPoll.unref()
 
 function scheduleSuccessfulShutdown() {
   const hasSuccessSignal = WAIT_FOR_PRERENDER_MARKER

--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -376,7 +376,14 @@ const startConfig = {
     // the query string (`/queries?host=0/`) → 404 → build failure. Query-string
     // variants prerender the same HTML shell as their base path (data loads
     // client-side), and every base path is already crawled — skip them.
-    filter: (page: { path: string }) => !page.path.includes('?'),
+    //
+    // Hash-anchor hrefs (docs in-page links like `/docs/x#section`) are crawled
+    // the same way, but a literal `#` in the request path matches NO route and
+    // the prerender render hangs forever (no timeout) — this stalled the whole
+    // Docker build crawl indefinitely. Anchors are client-side only and render
+    // the identical shell as their already-crawled base path, so skip them too.
+    filter: (page: { path: string }) =>
+      !page.path.includes('?') && !page.path.includes('#'),
   },
   spa: { enabled: true },
 }


### PR DESCRIPTION
## Problem (WS0 — critical path for 0.3 rollout)

The Docker build of `apps/dashboard-tsr` hangs: `BUILD_TARGET=node bun run build:node`
finishes writing the full `.output` but the process **never exits**, so the
`RUN` step in the Dockerfile blocks until the 30-min CI timeout
(`build-docker-amd64` → "cancelled"). This blocked all release Docker images +
asset tarballs (v0.2.7 tagged but never built). Regression since v0.2.6.

## Root cause (two compounding issues)

1. **Crawl hang on `#` anchors.** The prerender crawler follows `<a href>`
   links; docs pages contain in-page anchors like `/docs/x#section`. A literal
   `#` matches no route and that render hangs with no timeout, stalling the
   crawl mid-flight.
2. **Process never exits after a successful crawl.** Even once the crawl
   completes and nitro prints "[prerender] Prerendered N pages", the process
   stays alive. Diagnosed via `process.getActiveResourcesInfo()` /
   `_getActiveHandles()`: a ref'd `Socket` (reading=true, no remote) — nitro's
   in-process prerender render server — plus worker `MessagePort`s are never
   closed.

## Fix

1. Extend the prerender `filter` to skip `#`-anchor paths (same class as the
   existing `?`-query-string exclusion; both render the identical static shell
   as their already-crawled base path).
2. Wire up the existing-but-orphaned `build-node-ci.ts` wrapper and fix its two
   defects: it hardcoded `CHM_SKIP_PRERENDER=1` (skipped prerender entirely),
   and its success detection was edge-triggered on marker lines that all stream
   before artifacts are written. Now it keeps prerender on and polls
   `artifactsExist()` every 1s, then reaps the lingering process group and
   exits 0. Dockerfile calls it via a new `build:node:ci` script.

## Verification

With ClickHouse env unset (mimicking Docker): the wrapper exits **0** after
producing a full `.output` (137 prerendered pages), logging *"stopping lingering
build process"* instead of hanging. `tsc --noEmit` clean. The authoritative
check is `build-docker-pr` going green on this PR.

Co-Authored-By: duyetbot <bot@duyet.net>