### PR TITLE
ci: remove redundant rust toolchain installation from frontend workflows

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -57,9 +57,6 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.94.0
-
       - name: Bun Cache
         uses: actions/cache@v5
         with:
@@ -459,9 +456,6 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Bun Cache
         uses: actions/cache@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,6 @@ jobs:
           # recent Bun.
           bun-version: '1.3.13'
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.94.0
-
       - name: Bun Cache
         uses: actions/cache@v5
         with:
@@ -149,9 +146,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.3'
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Bun Cache
         uses: actions/cache@v5


### PR DESCRIPTION
Removes redundant Rust compiler toolchain setup steps (`dtolnay/rust-toolchain`) from frontend CI workflows (`test.yml` and `cloudflare.yml` preview/production jobs). This reduces GitHub Actions runner time since frontend test and build tasks load precompiled WASM assets from Git directly instead of compiling them from source code.

Co-Authored-By: duyetbot <bot@duyet.net>