### PR TITLE
ci: capture container logs on validate-docker timeout

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -263,8 +263,18 @@ jobs:
             -e PORT=3000 \
             "$TAG"
 
-          # Wait for container health
-          timeout 60 bash -c 'until curl -sSf http://localhost:3000/ > /dev/null 2>&1; do sleep 2; done'
+          # Wait for container health. On timeout, dump container logs + state so
+          # a boot hang is diagnosable instead of a bare "exit code 124" with no
+          # clue why / never answered (this step runs under `set -e`).
+          if ! timeout 60 bash -c 'until curl -sSf http://localhost:3000/ > /dev/null 2>&1; do sleep 2; done'; then
+            echo "::error::test-app did not serve http://localhost:3000/ within 60s"
+            docker ps -a --filter name=test-app --format 'table {{.Names}}\t{{.Status}}'
+            docker inspect test-app \
+              --format 'state={{.State.Status}} exitCode={{.State.ExitCode}} startedAt={{.State.StartedAt}} finishedAt={{.State.FinishedAt}} error={{.State.Error}}' 2>/dev/null || true
+            echo '----- docker logs (last 200 lines) -----'
+            docker logs --tail 200 test-app 2>&1 || true
+            exit 1
+          fi
 
           # Health checks
           curl -sSf http://localhost:3000/ | grep -q "chmonitor"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,8 +261,18 @@ jobs:
             -e PORT=3000 \
             "$TAG"
 
-          # Wait for container health
-          timeout 60 bash -c 'until curl -sSf http://localhost:3000/ > /dev/null 2>&1; do sleep 2; done'
+          # Wait for container health. On timeout, dump container logs + state so
+          # a boot hang is diagnosable instead of a bare "exit code 124" with no
+          # clue why / never answered (this step runs under `set -e`).
+          if ! timeout 60 bash -c 'until curl -sSf http://localhost:3000/ > /dev/null 2>&1; do sleep 2; done'; then
+            echo "::error::test-app did not serve http://localhost:3000/ within 60s"
+            docker ps -a --filter name=test-app --format 'table {{.Names}}\t{{.Status}}'
+            docker inspect test-app \
+              --format 'state={{.State.Status}} exitCode={{.State.ExitCode}} startedAt={{.State.StartedAt}} finishedAt={{.State.FinishedAt}} error={{.State.Error}}' 2>/dev/null || true
+            echo '----- docker logs (last 200 lines) -----'
+            docker logs --tail 200 test-app 2>&1 || true
+            exit 1
+          fi
 
           # Health checks
           curl -sSf http://localhost:3000/ | grep -q "chmonitor"


### PR DESCRIPTION
## Problem

The `validate-docker` "Test container" step (in `ci.yml` + `base.yml`) runs under `set -e`. When the 60s readiness probe times out, the step exits `124` and **discards the container's boot logs** — the failure is permanently undiagnosable.

This bit `main` at `88a6b67`: the container started (got a container ID) but never served `/` within 60s, and no `docker logs` was captured to explain why. Subsequent runs passed with **no code fix** (the only dashboard-tsr change in between was the unrelated #1588 a11y PR), so it was a transient — but the next one will be equally mysterious without this change.

## Fix

Wrap the probe in `if ! timeout …; then …; exit 1; fi`. On timeout it now dumps, **before** failing:
- `docker ps -a` — is the container even alive?
- `docker inspect` — state, exit code, started/finished, error
- `docker logs --tail 200` — the boot output / crash trace

Behavior-preserving on success — adds output only on failure.

## Why not bump the timeout or probe a lighter endpoint?

Deliberately left both alone (still 60s, still polls `/`). A higher ceiling or switching to `/api/healthz` would mask the real signal. **Diagnose first:** if flakes recur, the new logs justify a bump instead of a blind one. Applied to both copies: `ci.yml` (main/release `validate-docker`) and `base.yml` (PR-side `Test container`).

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker container health-check diagnostics in CI/CD pipelines with improved error reporting and debugging output for container readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->