### PR TITLE
fix(dashboard-tsr): type menu-counts test to unblock type-check:test

### DIFF
--- a/apps/dashboard-tsr/src/routes/api/v1/menu-counts/__tests__/index.test.ts
+++ b/apps/dashboard-tsr/src/routes/api/v1/menu-counts/__tests__/index.test.ts
@@ -9,9 +9,14 @@ mock.module('cloudflare:workers', () => ({
   },
 }))
 
-const mockFetchData = mock(async () => {
-  return { data: [], error: null }
-})
+const mockFetchData = mock(
+  async (_args: {
+    query: string
+  }): Promise<{
+    data: unknown[] | null
+    error: unknown
+  }> => ({ data: [], error: null })
+)
 
 mock.module('@chm/clickhouse-client', () => ({
   fetchData: mockFetchData,
@@ -57,7 +62,9 @@ describe('menu-counts API GET handler', () => {
     const response = await handler(request)
     expect(response.status).toBe(200)
 
-    const body = await response.json()
+    const body = (await response.json()) as {
+      data: { counts: Record<string, number | null> }
+    }
     expect(body.data).toHaveProperty('counts')
     expect(body.data.counts['tables-explorer']).toBe(5)
     expect(body.data.counts['tables-overview']).toBe(10)
@@ -68,8 +75,8 @@ describe('menu-counts API GET handler', () => {
 
     // Assert that exactly 2 queries were executed: system.tables check and the combined query
     expect(mockFetchData.mock.calls.length).toBe(2)
-    expect(mockFetchData.mock.calls[0][0].query).toContain('database, name')
-    expect(mockFetchData.mock.calls[1][0].query).toContain('AS')
+    expect(mockFetchData.mock.calls[0]?.[0]?.query).toContain('database, name')
+    expect(mockFetchData.mock.calls[1]?.[0]?.query).toContain('AS')
   })
 
   test('falls back to sequential loop when combined query fails', async () => {
@@ -100,7 +107,9 @@ describe('menu-counts API GET handler', () => {
     const response = await handler(request)
     expect(response.status).toBe(200)
 
-    const body = await response.json()
+    const body = (await response.json()) as {
+      data: { counts: Record<string, number | null> }
+    }
     expect(body.data.counts['tables-explorer']).toBe(42)
 
     // Verify it executed more queries because of fallback loop


### PR DESCRIPTION
## What

The `menu-counts` API test declared its `fetchData` mock with **no parameters**, which locked the mock's call signature to `()` and produced **15 type errors** under `tsconfig.test.json` (the test tsconfig added in plan 010):

- `mockImplementation(({ query }) => …)` — destructure on a zero-arg signature (TS7031 / TS2345)
- `await response.json()` returns `unknown` → `body.data.counts[…]` (TS18046)
- `mockFetchData.mock.calls[i][0].query` — indexes an empty arg tuple (TS2493 / TS2532)

## Fix

Type-only, no runtime change:
- Declare the mock parameter (`{ query: string }`) and return (`Promise<{ data: unknown[] | null; error: unknown }>`)
- Cast `response.json()` to the shape the assertions use
- Optional-chaining for call-record indexing

## Verification

- `bun run type-check:test` → **0 errors** (was 15)
- `bun test src/routes/api/v1/menu-counts/` → 2 pass, 0 fail (behavior unchanged)
- `bun test src/` → 1315 pass, 0 fail
- `biome check` → exit 0

## Why

`apps/dashboard-tsr` is the primary app but its TypeScript is never type-checked in CI. Plan 021 adds a `type-check-tsr` CI job running `bun run type-check && bun run type-check:test`. The test half is currently red solely because of this one test file, so this unblocks the full gate.

Co-Authored-By: duyetbot <bot@duyet.net>