### PR TITLE
ci: type-check apps/dashboard-tsr in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,37 @@ jobs:
       - name: Validate dependency boundaries
         run: bun run depcruise
 
+  # apps/dashboard-tsr is the primary app but has its own lockfile and is not
+  # part of the root turbo workspace, so nothing type-checks it in CI. Gate
+  # both the src tsconfig and the test tsconfig so type regressions surface
+  # before deploy instead of at build time.
+  type-check-tsr:
+    name: type-check-tsr
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Bun Cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-v1-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-v1-
+
+      - name: Install dashboard-tsr dependencies
+        working-directory: apps/dashboard-tsr
+        run: bun install --frozen-lockfile
+
+      - name: Type-check dashboard-tsr (src + tests)
+        working-directory: apps/dashboard-tsr
+        run: bun run type-check && bun run type-check:test
+
   # PRs: amd64 only for fast feedback (~3-5 min)
   build-docker-pr:
     name: build-docker-pr


### PR DESCRIPTION
## What

Adds a `type-check-tsr` job to `.github/workflows/ci.yml` that runs `bun run type-check && bun run type-check:test` inside `apps/dashboard-tsr`.

## Why

`apps/dashboard-tsr` is the primary, actively-developed app, but it has its own `bun.lock` and is **not** part of the root turbo workspace — so `turbo run type-check` (the pre-commit hook and any future root type-check job) never touches it. A repo-wide search found zero `type-check` invocations in any workflow. Type errors (including in test files) could land on `main` and only surface later at deploy/build time.

A dedicated, fast CI job makes type regressions a cheap gate.

## Scope

- Only `.github/workflows/ci.yml` — one new job (`type-check-tsr`) modeled on the existing `depcruise` job, scoped to the app via `working-directory: apps/dashboard-tsr`.

The test half (`type-check:test`) is green as of #1605, which fixed the `menu-counts` test's mock typing. Without that, this gate would have redden `main`.

Implements **plan 021**.

Co-Authored-By: duyetbot <bot@duyet.net>