### PR TITLE
fix(ci): pass -R to gh workflow run in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,4 +47,6 @@ jobs:
         if: steps.release.outputs.release_created == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run release.yml -f tag=${{ steps.release.outputs.tag_name }}
+        # No checkout precedes this step (release-please-action works via the
+        # API), so gh has no local repo to infer. Pass -R explicitly.
+        run: gh workflow run release.yml -R ${{ github.repository }} -f tag=${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
## Problem

`Release Please` on `main` is failing (first run today on the 0.2.8 release):

```
Run gh workflow run release.yml -f tag=v0.2.8
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
```

## Root cause

The `Trigger release build` step (added in #1604) runs `gh workflow run release.yml`, but **no `actions/checkout` precedes it** — `googleapis/release-please-action@v5` works via the API and does not create a working tree. With no local repo, `gh` cannot infer the repository and aborts.

This is the first release cut since #1604 landed, so this is the first time the step actually executed → it is a new regression, not flakiness.

## Fix

Pass `-R ${{ github.repository }}` to `gh workflow run` so the dispatch does not depend on a local git checkout:

```diff
- run: gh workflow run release.yml -f tag=${{ steps.release.outputs.tag_name }}
+ run: gh workflow run release.yml -R ${{ github.repository }} -f tag=${{ steps.release.outputs.tag_name }}
```

Narrow, one-line config fix. No code or behavior change beyond making the existing dispatch resolve its target repo.

## Out of scope (deferred)

`Image build and Push` / `validate-docker` is the same non-required boot-timeout flake (`test-app did not serve :3000 within 60s`) noted in repo conventions — not addressed here.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to explicitly specify the repository when triggering the release build, improving reliability and reducing dependency on local checkout inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->