### PR TITLE
fix(ci): align release docker cache scope + diagnosable container health checks

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -276,9 +276,27 @@ jobs:
             exit 1
           fi
 
-          # Health checks
-          # -L: GET / 307-redirects to /?host=0 (host-defaulting middleware);
-          # follow it so we grep the rendered shell, not the empty redirect body.
-          curl -sSLf http://localhost:3000/ | grep -q "chmonitor"
-          curl -sSf http://localhost:3000/api/healthz | grep -q "ok"
-          curl -sSf http://localhost:3000/api/version | grep -q "version"
+          # Health checks. Each asserts independently and dumps the response on
+          # failure so a broken endpoint is identifiable — a bare `curl | grep`
+          # under `set -e` gives no clue which of the three failed (this masked
+          # a /api/version contract drift for 8+ runs).
+          check() {
+            local label="$1" url="$2" needle="$3" follow="${4:-}"
+            local body
+            if ! body=$(curl -sSf $follow "$url"); then
+              echo "::error::$label: request to $url failed"; exit 1
+            fi
+            if ! grep -q "$needle" <<<"$body"; then
+              echo "::error::$label: response from $url missing '$needle'"
+              echo "----- body (first 40 lines) -----"; echo "$body" | head -40
+              exit 1
+            fi
+            echo "✓ $label OK"
+          }
+          # -L: GET / 307-redirects to /?host=0 (host-defaulting); follow it so
+          # we grep the rendered shell, not the empty redirect body.
+          check "root-shell" http://localhost:3000/ "chmonitor" "-L"
+          check "healthz" http://localhost:3000/api/healthz "ok"
+          # TSR /api/version returns {"ui":"<app version>"} — the CH version()
+          # query was dropped from this endpoint in the TanStack app.
+          check "version" http://localhost:3000/api/version '"ui"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,9 +274,27 @@ jobs:
             exit 1
           fi
 
-          # Health checks
-          # -L: GET / 307-redirects to /?host=0 (host-defaulting middleware);
-          # follow it so we grep the rendered shell, not the empty redirect body.
-          curl -sSLf http://localhost:3000/ | grep -q "chmonitor"
-          curl -sSf http://localhost:3000/api/healthz | grep -q "ok"
-          curl -sSf http://localhost:3000/api/version | grep -q "version"
+          # Health checks. Each asserts independently and dumps the response on
+          # failure so a broken endpoint is identifiable — a bare `curl | grep`
+          # under `set -e` gives no clue which of the three failed (this masked
+          # a /api/version contract drift for 8+ runs).
+          check() {
+            local label="$1" url="$2" needle="$3" follow="${4:-}"
+            local body
+            if ! body=$(curl -sSf $follow "$url"); then
+              echo "::error::$label: request to $url failed"; exit 1
+            fi
+            if ! grep -q "$needle" <<<"$body"; then
+              echo "::error::$label: response from $url missing '$needle'"
+              echo "----- body (first 40 lines) -----"; echo "$body" | head -40
+              exit 1
+            fi
+            echo "✓ $label OK"
+          }
+          # -L: GET / 307-redirects to /?host=0 (host-defaulting); follow it so
+          # we grep the rendered shell, not the empty redirect body.
+          check "root-shell" http://localhost:3000/ "chmonitor" "-L"
+          check "healthz" http://localhost:3000/api/healthz "ok"
+          # TSR /api/version returns {"ui":"<app version>"} — the CH version()
+          # query was dropped from this endpoint in the TanStack app.
+          check "version" http://localhost:3000/api/version '"ui"'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,10 @@ jobs:
     name: build-docker-amd64
     needs: [build-wasm]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 30min was exactly the cold-build wall time → timed out for v0.2.7/v0.2.8.
+    # With the shared warm cache this is ~1min; the headroom only matters if the
+    # cache was evicted, in which case a slow build should still complete.
+    timeout-minutes: 50
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -138,8 +141,14 @@ jobs:
             GITHUB_SHA=${{ github.sha }}
             GITHUB_REF=${{ github.ref }}
             SKIP_RUST=true
-          cache-from: type=gha,scope=docker-amd64
-          cache-to: type=gha,scope=docker-amd64,mode=max
+          # Reuse ci.yml's warm AMD64 layer cache. ci.yml builds on every main
+          # push via base.yml with tag-suffix '-amd64', producing the scope
+          # 'docker--amd64' (the suffix already carries a leading dash). main is
+          # the default branch, so its caches are readable from this tag-pinned
+          # release dispatch — turning a cold ~30min build (which timed out for
+          # v0.2.7/v0.2.8) into a ~1min warm one.
+          cache-from: type=gha,scope=docker--amd64
+          cache-to: type=gha,scope=docker--amd64,mode=max
           platforms: linux/amd64
 
   build-docker-arm64:


### PR DESCRIPTION
## Problem

Two CI defects in the TanStack (`apps/dashboard-tsr`) Docker pipeline:

### 1. `validate-docker` red on `main` for 8+ runs
The "Test container" step ran three health checks as bare `curl | grep` under `set -e` with no echo — so the failing one was invisible. Root cause: the TSR `/api/version` endpoint returns `{"ui":"<version>"}` (the `SELECT version()` round-trip was intentionally dropped from this route), but the check grepped for `"version"`, which never appears → silent abort.

### 2. `release.yml` never built Docker for v0.2.7 / v0.2.8
The AMD64 build ran the full cold build and hit the **30-min job timeout exactly** (`09:03:47 → 09:33:22`). `ci.yml`'s identical build finishes in ~1 min off a warm GHA cache, but the scopes differed:
- release.yml: `docker-amd64`
- ci.yml/base.yml: `docker--amd64` (the `tag-suffix` already carries a leading dash)

They never shared cache. With the build timing out, `docker-manifest` + `assets` were skipped, so `llm-release-action` never ran → no Docker pull/FROM block in the notes and no attached archives.

## Fix

- **Health checks** (`ci.yml` + `base.yml`): rewrite as a per-check helper that asserts independently and **dumps the response body on failure** (fail loud). Realign the version assertion to `"ui"` to match the actual TSR contract.
- **Release cache** (`release.yml`): point AMD64 build at the shared `docker--amd64` scope (`main`'s default-branch cache is readable from the tag-pinned dispatch), turning the cold ~30-min build into a ~1-min warm one. Raise timeout to 50 min as eviction headroom.

With the build no longer timing out, `docker-manifest` → `assets` → `llm-release-action` run, regenerating notes **with** the Docker block and attaching archives.

> #1608 already fixed the dispatch trigger that crashed (`fatal: not a git repository`) before this point.

## Note
v0.2.8 (current latest) still has no Docker images / proper notes because it was cut before these fixes. After merge, the release pipeline can be re-dispatched for v0.2.8 to backfill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker container health validation during testing with clearer error reporting, detailed diagnostic output, and explicit endpoint verification
  * Increased application build timeout from 30 to 50 minutes to prevent timeout failures during cold builds
  * Optimized build caching strategy for faster and more consistent release builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->