### PR TITLE
chore: configure release-please

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -7,7 +7,7 @@
   "tag-separator": "-",
   "packages": {
     ".": {
-      "release-type": "node",
+      "release-type": "simple",
       "package-name": "chmonitor",
       "changelog-path": "CHANGELOG.md",
       "draft": false,

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -276,9 +276,27 @@ jobs:
             exit 1
           fi
 
-          # Health checks
-          # -L: GET / 307-redirects to /?host=0 (host-defaulting middleware);
-          # follow it so we grep the rendered shell, not the empty redirect body.
-          curl -sSLf http://localhost:3000/ | grep -q "chmonitor"
-          curl -sSf http://localhost:3000/api/healthz | grep -q "ok"
-          curl -sSf http://localhost:3000/api/version | grep -q "version"
+          # Health checks. Each asserts independently and dumps the response on
+          # failure so a broken endpoint is identifiable — a bare `curl | grep`
+          # under `set -e` gives no clue which of the three failed (this masked
+          # a /api/version contract drift for 8+ runs).
+          check() {
+            local label="$1" url="$2" needle="$3" follow="${4:-}"
+            local body
+            if ! body=$(curl -sSf $follow "$url"); then
+              echo "::error::$label: request to $url failed"; exit 1
+            fi
+            if ! grep -q "$needle" <<<"$body"; then
+              echo "::error::$label: response from $url missing '$needle'"
+              echo "----- body (first 40 lines) -----"; echo "$body" | head -40
+              exit 1
+            fi
+            echo "✓ $label OK"
+          }
+          # -L: GET / 307-redirects to /?host=0 (host-defaulting); follow it so
+          # we grep the rendered shell, not the empty redirect body.
+          check "root-shell" http://localhost:3000/ "chmonitor" "-L"
+          check "healthz" http://localhost:3000/api/healthz "ok"
+          # TSR /api/version returns {"ui":"<app version>"} — the CH version()
+          # query was dropped from this endpoint in the TanStack app.
+          check "version" http://localhost:3000/api/version '"ui"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,9 +274,27 @@ jobs:
             exit 1
           fi
 
-          # Health checks
-          # -L: GET / 307-redirects to /?host=0 (host-defaulting middleware);
-          # follow it so we grep the rendered shell, not the empty redirect body.
-          curl -sSLf http://localhost:3000/ | grep -q "chmonitor"
-          curl -sSf http://localhost:3000/api/healthz | grep -q "ok"
-          curl -sSf http://localhost:3000/api/version | grep -q "version"
+          # Health checks. Each asserts independently and dumps the response on
+          # failure so a broken endpoint is identifiable — a bare `curl | grep`
+          # under `set -e` gives no clue which of the three failed (this masked
+          # a /api/version contract drift for 8+ runs).
+          check() {
+            local label="$1" url="$2" needle="$3" follow="${4:-}"
+            local body
+            if ! body=$(curl -sSf $follow "$url"); then
+              echo "::error::$label: request to $url failed"; exit 1
+            fi
+            if ! grep -q "$needle" <<<"$body"; then
+              echo "::error::$label: response from $url missing '$needle'"
+              echo "----- body (first 40 lines) -----"; echo "$body" | head -40
+              exit 1
+            fi
+            echo "✓ $label OK"
+          }
+          # -L: GET / 307-redirects to /?host=0 (host-defaulting); follow it so
+          # we grep the rendered shell, not the empty redirect body.
+          check "root-shell" http://localhost:3000/ "chmonitor" "-L"
+          check "healthz" http://localhost:3000/api/healthz "ok"
+          # TSR /api/version returns {"ui":"<app version>"} — the CH version()
+          # query was dropped from this endpoint in the TanStack app.
+          check "version" http://localhost:3000/api/version '"ui"'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,7 +35,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DUYETBOT_GITHUB_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,10 @@ jobs:
     name: build-docker-amd64
     needs: [build-wasm]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 30min was exactly the cold-build wall time → timed out for v0.2.7/v0.2.8.
+    # With the shared warm cache this is ~1min; the headroom only matters if the
+    # cache was evicted, in which case a slow build should still complete.
+    timeout-minutes: 50
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -138,8 +141,14 @@ jobs:
             GITHUB_SHA=${{ github.sha }}
             GITHUB_REF=${{ github.ref }}
             SKIP_RUST=true
-          cache-from: type=gha,scope=docker-amd64
-          cache-to: type=gha,scope=docker-amd64,mode=max
+          # Reuse ci.yml's warm AMD64 layer cache. ci.yml builds on every main
+          # push via base.yml with tag-suffix '-amd64', producing the scope
+          # 'docker--amd64' (the suffix already carries a leading dash). main is
+          # the default branch, so its caches are readable from this tag-pinned
+          # release dispatch — turning a cold ~30min build (which timed out for
+          # v0.2.7/v0.2.8) into a ~1min warm one.
+          cache-from: type=gha,scope=docker--amd64
+          cache-to: type=gha,scope=docker--amd64,mode=max
           platforms: linux/amd64
 
   build-docker-arm64:


### PR DESCRIPTION
Configured release-please-action to use DUYETBOT_GITHUB_TOKEN and set release-type to simple.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker container health check validation with better error diagnostics and response inspection
  * Increased Docker build timeout from 30 to 50 minutes for reliability
  * Updated Docker build cache configuration for improved reuse
  * Modified automated release configuration and credentials

<!-- end of auto-generated comment: release notes by coderabbit.ai -->