### PR TITLE
feat(docs): Vercel/Geist redesign for docs.chmonitor.dev and dash /docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ apps/dashboard/.next/next.config.compiled.js
 /build
 
 # external tool artifacts
+.extract-design-system/
 .entire/
 logs/
 # ...but `logs/` dirs under the dashboard SOURCE tree are log-monitoring

--- a/apps/dashboard/bun.lock
+++ b/apps/dashboard/bun.lock
@@ -23,6 +23,8 @@
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@fontsource-variable/geist": "^5.2.9",
+        "@fontsource/geist-mono": "^5.2.8",
         "@hookform/resolvers": "^5.4.0",
         "@json-render/core": "^0.19.0",
         "@json-render/react": "^0.19.0",
@@ -293,6 +295,10 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@fontsource-variable/geist": ["@fontsource-variable/geist@5.2.9", "", {}, "sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ=="],
+
+    "@fontsource/geist-mono": ["@fontsource/geist-mono@5.2.8", "", {}, "sha512-YqZUb3X42GjRaHkibUNyE8K4Rk9A6I9Ez81YpJYiuJN4ggmTW2ixoQpa9EWCPfXZtIsCQJTyrDoV9OJOZO/UcA=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -49,6 +49,8 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@fontsource-variable/geist": "^5.2.9",
+    "@fontsource/geist-mono": "^5.2.8",
     "@hookform/resolvers": "^5.4.0",
     "@json-render/core": "^0.19.0",
     "@json-render/react": "^0.19.0",

--- a/apps/dashboard/src/routes/(docs)/docs/$.tsx
+++ b/apps/dashboard/src/routes/(docs)/docs/$.tsx
@@ -1,8 +1,10 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 
 import { DocsMarkdown } from './-components/docs-markdown'
-import { type DocsHeading, docsHref, docsNav, getDocsPage } from './-lib/docs'
-import { cn } from '@/lib/utils'
+import { DocsShell } from './-components/docs-shell'
+import { docsHref, getDocsPage } from './-lib/docs'
+
+import './docs-theme.css'
 
 export const Route = createFileRoute('/(docs)/docs/$')({
   component: DocsPage,
@@ -15,15 +17,17 @@ function DocsPage() {
 
   if (!page) {
     return (
-      <div className="flex min-h-dvh flex-col items-center justify-center bg-background px-4 text-center">
-        <h1 className="text-2xl font-bold text-foreground">Page not found</h1>
-        <p className="mt-2 text-muted-foreground">
+      <div className="docs-vercel-theme flex min-h-dvh flex-col items-center justify-center px-4 text-center">
+        <h1 className="font-semibold text-2xl text-[var(--ds-gray-1000)]">
+          Page not found
+        </h1>
+        <p className="mt-2 text-[var(--ds-gray-900)]">
           The documentation page you are looking for does not exist.
         </p>
         <Link
           to="/docs"
           search={(prev) => ({ host: prev.host ?? 0 })}
-          className="mt-6 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90"
+          className="mt-6 rounded-full bg-[var(--ds-gray-1000)] px-4 py-2 font-medium text-[var(--ds-background-100)] text-sm transition-opacity hover:opacity-90"
         >
           Go to Docs Introduction
         </Link>
@@ -32,150 +36,12 @@ function DocsPage() {
   }
 
   return (
-    <div className="min-h-dvh px-4 py-6 lg:px-6 xl:px-8">
-      <DocsMobileNav
-        activeSlug={page.slug}
-        activeTitle={page.title}
-        headings={page.headings}
-      />
-      <div className="mx-auto flex w-full max-w-[96rem] items-start gap-8">
-        <DocsSidebar activeSlug={page.slug} />
-        <main className="min-w-0 flex-1 pb-16">
-          <div className="mx-auto max-w-4xl">
-            <DocsMarkdown markdown={page.markdown} />
-          </div>
-        </main>
-        <DocsToc headings={page.headings} />
-      </div>
-    </div>
-  )
-}
-
-function DocsMobileNav({
-  activeSlug,
-  activeTitle,
-  headings,
-}: {
-  activeSlug: string
-  activeTitle: string
-  headings: DocsHeading[]
-}) {
-  return (
-    <div className="sticky top-14 z-20 mb-6 border-border border-b bg-background/95 pb-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 lg:hidden">
-      <details className="group rounded-md border bg-card">
-        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2 font-medium text-sm [&::-webkit-details-marker]:hidden">
-          <span className="min-w-0 truncate">{activeTitle}</span>
-          <span className="shrink-0 text-muted-foreground text-xs group-open:hidden">
-            Menu
-          </span>
-          <span className="hidden shrink-0 text-muted-foreground text-xs group-open:inline">
-            Close
-          </span>
-        </summary>
-        <div className="max-h-[calc(100vh-8rem)] overflow-y-auto border-border border-t p-3">
-          <DocsNavList activeSlug={activeSlug} compact />
-          {headings.length > 0 ? (
-            <div className="mt-4 border-border border-t pt-4">
-              <div className="mb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
-                On this page
-              </div>
-              <DocsTocList headings={headings} />
-            </div>
-          ) : null}
-        </div>
-      </details>
-    </div>
-  )
-}
-
-function DocsSidebar({ activeSlug }: { activeSlug: string }) {
-  return (
-    <aside className="sticky top-6 hidden h-[calc(100vh-3rem)] w-64 shrink-0 overflow-y-auto border-border border-r pr-6 lg:block">
-      <Link
-        to="/docs"
-        search={(prev) => ({ host: prev.host ?? 0 })}
-        className="mb-4 block font-semibold text-foreground text-sm"
-      >
-        chmonitor
-      </Link>
-      <DocsNavList activeSlug={activeSlug} />
-    </aside>
-  )
-}
-
-function DocsNavList({
-  activeSlug,
-  compact = false,
-}: {
-  activeSlug: string
-  compact?: boolean
-}) {
-  return (
-    <nav className={cn('space-y-6', compact && 'space-y-4')}>
-      {docsNav.map((section) => (
-        <div key={section.title}>
-          <div className="mb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
-            {section.title}
-          </div>
-          <ul className="space-y-1">
-            {section.items.map((item) => {
-              const isActive = item.slug === activeSlug
-              return (
-                <li key={item.slug || 'index'}>
-                  <Link
-                    to={docsHref(item.slug) as never}
-                    className={cn(
-                      'block rounded-md px-2 py-1.5 text-sm transition-colors',
-                      isActive
-                        ? 'bg-accent font-medium text-foreground'
-                        : 'text-muted-foreground hover:bg-accent hover:text-foreground'
-                    )}
-                  >
-                    {item.title}
-                  </Link>
-                </li>
-              )
-            })}
-          </ul>
-        </div>
-      ))}
-    </nav>
-  )
-}
-
-function DocsToc({ headings }: { headings: DocsHeading[] }) {
-  if (headings.length === 0) {
-    return null
-  }
-
-  return (
-    <aside className="sticky top-6 hidden h-[calc(100vh-3rem)] w-56 shrink-0 overflow-y-auto xl:block">
-      <div className="mb-3 font-medium text-muted-foreground text-xs uppercase tracking-wide">
-        On this page
-      </div>
-      <DocsTocList headings={headings} />
-    </aside>
-  )
-}
-
-function DocsTocList({ headings }: { headings: DocsHeading[] }) {
-  return (
-    <nav>
-      <ul className="space-y-1 border-border border-l">
-        {headings.map((heading) => (
-          <li key={heading.id}>
-            <a
-              href={`#${heading.id}`}
-              className={cn(
-                'block py-1 text-muted-foreground text-sm hover:text-foreground',
-                heading.level === 3 ? 'pl-6' : 'pl-3'
-              )}
-            >
-              {heading.text}
-            </a>
-          </li>
-        ))}
-      </ul>
-    </nav>
+    <DocsShell
+      activeSlug={page.slug}
+      activeTitle={page.title}
+      headings={page.headings}
+    >
+      <DocsMarkdown markdown={page.markdown} />
+    </DocsShell>
   )
 }

--- a/apps/dashboard/src/routes/(docs)/docs/-components/docs-markdown.tsx
+++ b/apps/dashboard/src/routes/(docs)/docs/-components/docs-markdown.tsx
@@ -57,34 +57,22 @@ export function DocsMarkdown({ markdown }: DocsMarkdownProps) {
             return <Link to={resolvedHref as never}>{children}</Link>
           },
           h1: ({ children }) => (
-            <h1
-              id={headingId(children)}
-              className="scroll-m-20 text-4xl font-bold tracking-normal"
-            >
+            <h1 id={headingId(children)} className="scroll-m-20">
               {children}
             </h1>
           ),
           h2: ({ children }) => (
-            <h2
-              id={headingId(children)}
-              className="scroll-m-20 border-border border-b pb-2 text-2xl font-semibold tracking-normal"
-            >
+            <h2 id={headingId(children)} className="scroll-m-20">
               {children}
             </h2>
           ),
           h3: ({ children }) => (
-            <h3
-              id={headingId(children)}
-              className="scroll-m-20 text-xl font-semibold tracking-normal"
-            >
+            <h3 id={headingId(children)} className="scroll-m-20">
               {children}
             </h3>
           ),
           h4: ({ children }) => (
-            <h4
-              id={headingId(children)}
-              className="scroll-m-20 text-base font-semibold tracking-normal"
-            >
+            <h4 id={headingId(children)} className="scroll-m-20">
               {children}
             </h4>
           ),

--- a/apps/dashboard/src/routes/(docs)/docs/-components/docs-shell.tsx
+++ b/apps/dashboard/src/routes/(docs)/docs/-components/docs-shell.tsx
@@ -1,0 +1,173 @@
+import { Link } from '@tanstack/react-router'
+
+import type { ReactNode } from 'react'
+
+import { type DocsHeading, docsHref, docsNav } from '../-lib/docs'
+import { cn } from '@/lib/utils'
+
+type DocsShellProps = {
+  activeSlug: string
+  activeTitle: string
+  headings: DocsHeading[]
+  children: ReactNode
+}
+
+export function DocsShell({
+  activeSlug,
+  activeTitle,
+  headings,
+  children,
+}: DocsShellProps) {
+  return (
+    <div className="docs-vercel-theme min-h-dvh">
+      <div className="docs-shell__header sticky top-14 z-20 mb-0 px-4 py-3 lg:px-6">
+        <div className="mx-auto flex w-full max-w-[var(--ds-page-width)] items-center justify-between gap-4">
+          <Link
+            to="/docs"
+            search={(prev) => ({ host: prev.host ?? 0 })}
+            className="font-semibold text-[0.9375rem] text-[var(--ds-gray-1000)] tracking-[-0.02em]"
+          >
+            chmonitor docs
+          </Link>
+          <a
+            href="https://docs.chmonitor.dev"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden text-[0.8125rem] text-[var(--ds-gray-900)] hover:text-[var(--ds-gray-1000)] sm:inline"
+          >
+            docs.chmonitor.dev
+          </a>
+        </div>
+      </div>
+
+      <div className="px-4 pb-6 lg:px-6 xl:px-8">
+        <DocsMobileNav
+          activeSlug={activeSlug}
+          activeTitle={activeTitle}
+          headings={headings}
+        />
+        <div className="mx-auto flex w-full max-w-[var(--ds-page-width)] items-start gap-8">
+          <DocsSidebar activeSlug={activeSlug} />
+          <main className="min-w-0 flex-1 pb-16">
+            <div className="mx-auto max-w-[var(--content-max)]">{children}</div>
+          </main>
+          <DocsToc headings={headings} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function DocsMobileNav({
+  activeSlug,
+  activeTitle,
+  headings,
+}: {
+  activeSlug: string
+  activeTitle: string
+  headings: DocsHeading[]
+}) {
+  return (
+    <div className="mb-6 border-[var(--ds-gray-300)] border-b pb-3 lg:hidden">
+      <details className="group rounded-[var(--geist-radius)] border border-[var(--ds-gray-300)] bg-[var(--ds-background-100)]">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2 font-medium text-sm [&::-webkit-details-marker]:hidden">
+          <span className="min-w-0 truncate">{activeTitle}</span>
+          <span className="shrink-0 text-[var(--ds-gray-900)] text-xs group-open:hidden">
+            Menu
+          </span>
+          <span className="hidden shrink-0 text-[var(--ds-gray-900)] text-xs group-open:inline">
+            Close
+          </span>
+        </summary>
+        <div className="max-h-[calc(100vh-8rem)] overflow-y-auto border-[var(--ds-gray-300)] border-t p-3">
+          <DocsNavList activeSlug={activeSlug} compact />
+          {headings.length > 0 ? (
+            <div className="mt-4 border-[var(--ds-gray-300)] border-t pt-4">
+              <div className="docs-shell__toc-title mb-2">On this page</div>
+              <DocsTocList headings={headings} />
+            </div>
+          ) : null}
+        </div>
+      </details>
+    </div>
+  )
+}
+
+function DocsSidebar({ activeSlug }: { activeSlug: string }) {
+  return (
+    <aside className="docs-shell__sidebar sticky top-[calc(3.5rem+3.25rem)] hidden h-[calc(100vh-7rem)] w-[var(--sidebar-w)] shrink-0 overflow-y-auto pr-6 lg:block">
+      <DocsNavList activeSlug={activeSlug} />
+    </aside>
+  )
+}
+
+function DocsNavList({
+  activeSlug,
+  compact = false,
+}: {
+  activeSlug: string
+  compact?: boolean
+}) {
+  return (
+    <nav className={cn('space-y-5', compact && 'space-y-4')}>
+      {docsNav.map((section) => (
+        <div key={section.title}>
+          <div className="docs-shell__nav-section mb-2 px-2">
+            {section.title}
+          </div>
+          <ul className="space-y-0.5">
+            {section.items.map((item) => {
+              const isActive = item.slug === activeSlug
+              return (
+                <li key={item.slug || 'index'}>
+                  <Link
+                    to={docsHref(item.slug) as never}
+                    data-active={isActive}
+                    className="docs-shell__nav-link block px-2 py-1.5 transition-colors"
+                  >
+                    {item.title}
+                  </Link>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  )
+}
+
+function DocsToc({ headings }: { headings: DocsHeading[] }) {
+  if (headings.length === 0) {
+    return null
+  }
+
+  return (
+    <aside className="sticky top-[calc(3.5rem+3.25rem)] hidden h-[calc(100vh-7rem)] w-[var(--toc-w)] shrink-0 overflow-y-auto xl:block">
+      <div className="docs-shell__toc-title mb-3 px-2">On this page</div>
+      <DocsTocList headings={headings} />
+    </aside>
+  )
+}
+
+function DocsTocList({ headings }: { headings: DocsHeading[] }) {
+  return (
+    <nav>
+      <ul className="space-y-0.5">
+        {headings.map((heading) => (
+          <li key={heading.id}>
+            <a
+              href={`#${heading.id}`}
+              className={cn(
+                'docs-shell__toc-link block py-1',
+                heading.level === 3 ? 'pl-6' : 'pl-2'
+              )}
+            >
+              {heading.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/apps/dashboard/src/routes/(docs)/docs/docs-theme.css
+++ b/apps/dashboard/src/routes/(docs)/docs/docs-theme.css
@@ -1,0 +1,173 @@
+@import '@fontsource-variable/geist';
+@import '@fontsource/geist-mono/400.css';
+@import '@fontsource/geist-mono/500.css';
+@import '../../../../../../design-system/vercel-docs-tokens.css';
+
+.docs-vercel-theme {
+  --background: var(--ds-background-200);
+  --foreground: var(--ds-gray-1000);
+  --muted-foreground: var(--ds-gray-900);
+  --border: var(--ds-gray-300);
+  --accent: var(--ds-gray-200);
+  --primary: var(--geist-link-color);
+
+  font-family: var(--font-sans);
+  background: var(--ds-background-200);
+  color: var(--ds-gray-1000);
+}
+
+.docs-vercel-theme .docs-shell__header {
+  border-bottom: 1px solid var(--ds-gray-300);
+  background: var(--ds-background-100);
+}
+
+.docs-vercel-theme .docs-shell__sidebar {
+  border-right: 1px solid var(--ds-gray-300);
+}
+
+.docs-vercel-theme .docs-shell__nav-section {
+  color: var(--ds-gray-1000);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
+
+.docs-vercel-theme .docs-shell__nav-link {
+  border-radius: var(--geist-radius);
+  color: var(--ds-gray-900);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+.docs-vercel-theme .docs-shell__nav-link:hover {
+  background: var(--ds-gray-alpha-100);
+  color: var(--ds-gray-1000);
+}
+
+.docs-vercel-theme .docs-shell__nav-link[data-active='true'] {
+  background: var(--ds-gray-200);
+  color: var(--ds-gray-1000);
+}
+
+.docs-vercel-theme .docs-shell__toc-title {
+  color: var(--ds-gray-1000);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
+
+.docs-vercel-theme .docs-shell__toc-link {
+  border-radius: var(--geist-radius);
+  color: var(--ds-gray-900);
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+
+.docs-vercel-theme .docs-shell__toc-link:hover,
+.docs-vercel-theme .docs-shell__toc-link[data-active='true'] {
+  background: var(--ds-gray-200);
+  color: var(--ds-gray-1000);
+}
+
+.docs-vercel-theme .docs-markdown {
+  font-size: 0.875rem;
+  line-height: 1.5715;
+}
+
+.docs-vercel-theme .docs-markdown h1 {
+  color: var(--ds-gray-900);
+  font-size: 2rem;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1.2;
+  margin-bottom: 1rem;
+  margin-top: 0;
+}
+
+.docs-vercel-theme .docs-markdown h2 {
+  border-bottom: none;
+  color: var(--ds-gray-900);
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+  margin-top: 2.5rem;
+  padding-bottom: 0;
+}
+
+.docs-vercel-theme .docs-markdown h3 {
+  color: var(--ds-gray-900);
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-top: 2rem;
+}
+
+.docs-vercel-theme .docs-markdown h4 {
+  color: var(--ds-gray-900);
+  font-size: 1rem;
+  font-weight: 600;
+  margin-top: 1.5rem;
+}
+
+.docs-vercel-theme .docs-markdown p,
+.docs-vercel-theme .docs-markdown li {
+  color: var(--ds-gray-900);
+}
+
+.docs-vercel-theme .docs-markdown a {
+  color: var(--geist-link-color);
+  text-decoration-color: color-mix(in srgb, var(--geist-link-color) 35%, transparent);
+  text-decoration-line: underline;
+  text-underline-offset: 0.2em;
+}
+
+.docs-vercel-theme .docs-markdown a:hover {
+  color: var(--link-hover);
+  text-decoration-color: var(--link-hover);
+}
+
+.docs-vercel-theme .docs-markdown :not(pre) > code {
+  background: var(--ds-gray-100);
+  border: 1px solid var(--ds-gray-300);
+  border-radius: var(--geist-radius);
+  color: var(--ds-gray-1000);
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  font-weight: 500;
+  padding: 0.12em 0.4em;
+}
+
+.docs-vercel-theme .docs-markdown pre {
+  background: var(--ds-gray-100);
+  border: 1px solid var(--ds-gray-300);
+  border-radius: 10px;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  line-height: 1.6;
+}
+
+.docs-vercel-theme .docs-markdown table {
+  border: 1px solid var(--ds-gray-300);
+  border-radius: 10px;
+  font-size: 0.875rem;
+  overflow: hidden;
+}
+
+.docs-vercel-theme .docs-markdown th {
+  background: var(--ds-gray-100);
+  color: var(--ds-gray-1000);
+}
+
+.docs-vercel-theme .docs-markdown td,
+.docs-vercel-theme .docs-markdown th {
+  border-color: var(--ds-gray-300);
+}
+
+.dark .docs-vercel-theme {
+  --background: var(--ds-background-200);
+  --foreground: var(--ds-gray-1000);
+  --muted-foreground: var(--ds-gray-900);
+  --border: var(--ds-gray-300);
+  --accent: var(--ds-gray-200);
+}

--- a/apps/dashboard/src/routes/(docs)/docs/index.tsx
+++ b/apps/dashboard/src/routes/(docs)/docs/index.tsx
@@ -1,22 +1,25 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 
 import { DocsMarkdown } from './-components/docs-markdown'
-import { type DocsHeading, docsHref, docsNav, getDocsPage } from './-lib/docs'
-import { cn } from '@/lib/utils'
+import { DocsShell } from './-components/docs-shell'
+import { getDocsPage } from './-lib/docs'
+
+import './docs-theme.css'
 
 export const Route = createFileRoute('/(docs)/docs/')({
   component: DocsIndexPage,
 })
 
 function DocsIndexPage() {
-  // slug '' = introduction / index page
   const page = getDocsPage('')
 
   if (!page) {
     return (
-      <div className="flex min-h-dvh flex-col items-center justify-center bg-background px-4 text-center">
-        <h1 className="text-2xl font-bold text-foreground">Page not found</h1>
-        <p className="mt-2 text-muted-foreground">
+      <div className="docs-vercel-theme flex min-h-dvh flex-col items-center justify-center px-4 text-center">
+        <h1 className="font-semibold text-2xl text-[var(--ds-gray-1000)]">
+          Page not found
+        </h1>
+        <p className="mt-2 text-[var(--ds-gray-900)]">
           The documentation introduction page could not be loaded.
         </p>
       </div>
@@ -24,150 +27,12 @@ function DocsIndexPage() {
   }
 
   return (
-    <div className="min-h-dvh px-4 py-6 lg:px-6 xl:px-8">
-      <DocsMobileNav
-        activeSlug={page.slug}
-        activeTitle={page.title}
-        headings={page.headings}
-      />
-      <div className="mx-auto flex w-full max-w-[96rem] items-start gap-8">
-        <DocsSidebar activeSlug={page.slug} />
-        <main className="min-w-0 flex-1 pb-16">
-          <div className="mx-auto max-w-4xl">
-            <DocsMarkdown markdown={page.markdown} />
-          </div>
-        </main>
-        <DocsToc headings={page.headings} />
-      </div>
-    </div>
-  )
-}
-
-function DocsMobileNav({
-  activeSlug,
-  activeTitle,
-  headings,
-}: {
-  activeSlug: string
-  activeTitle: string
-  headings: DocsHeading[]
-}) {
-  return (
-    <div className="sticky top-14 z-20 mb-6 border-border border-b bg-background/95 pb-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 lg:hidden">
-      <details className="group rounded-md border bg-card">
-        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2 font-medium text-sm [&::-webkit-details-marker]:hidden">
-          <span className="min-w-0 truncate">{activeTitle}</span>
-          <span className="shrink-0 text-muted-foreground text-xs group-open:hidden">
-            Menu
-          </span>
-          <span className="hidden shrink-0 text-muted-foreground text-xs group-open:inline">
-            Close
-          </span>
-        </summary>
-        <div className="max-h-[calc(100vh-8rem)] overflow-y-auto border-border border-t p-3">
-          <DocsNavList activeSlug={activeSlug} compact />
-          {headings.length > 0 ? (
-            <div className="mt-4 border-border border-t pt-4">
-              <div className="mb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
-                On this page
-              </div>
-              <DocsTocList headings={headings} />
-            </div>
-          ) : null}
-        </div>
-      </details>
-    </div>
-  )
-}
-
-function DocsSidebar({ activeSlug }: { activeSlug: string }) {
-  return (
-    <aside className="sticky top-6 hidden h-[calc(100vh-3rem)] w-64 shrink-0 overflow-y-auto border-border border-r pr-6 lg:block">
-      <Link
-        to="/docs"
-        search={(prev) => ({ host: prev.host ?? 0 })}
-        className="mb-4 block font-semibold text-foreground text-sm"
-      >
-        chmonitor
-      </Link>
-      <DocsNavList activeSlug={activeSlug} />
-    </aside>
-  )
-}
-
-function DocsNavList({
-  activeSlug,
-  compact = false,
-}: {
-  activeSlug: string
-  compact?: boolean
-}) {
-  return (
-    <nav className={cn('space-y-6', compact && 'space-y-4')}>
-      {docsNav.map((section) => (
-        <div key={section.title}>
-          <div className="mb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
-            {section.title}
-          </div>
-          <ul className="space-y-1">
-            {section.items.map((item) => {
-              const isActive = item.slug === activeSlug
-              return (
-                <li key={item.slug || 'index'}>
-                  <Link
-                    to={docsHref(item.slug) as never}
-                    className={cn(
-                      'block rounded-md px-2 py-1.5 text-sm transition-colors',
-                      isActive
-                        ? 'bg-accent font-medium text-foreground'
-                        : 'text-muted-foreground hover:bg-accent hover:text-foreground'
-                    )}
-                  >
-                    {item.title}
-                  </Link>
-                </li>
-              )
-            })}
-          </ul>
-        </div>
-      ))}
-    </nav>
-  )
-}
-
-function DocsToc({ headings }: { headings: DocsHeading[] }) {
-  if (headings.length === 0) {
-    return null
-  }
-
-  return (
-    <aside className="sticky top-6 hidden h-[calc(100vh-3rem)] w-56 shrink-0 overflow-y-auto xl:block">
-      <div className="mb-3 font-medium text-muted-foreground text-xs uppercase tracking-wide">
-        On this page
-      </div>
-      <DocsTocList headings={headings} />
-    </aside>
-  )
-}
-
-function DocsTocList({ headings }: { headings: DocsHeading[] }) {
-  return (
-    <nav>
-      <ul className="space-y-1 border-border border-l">
-        {headings.map((heading) => (
-          <li key={heading.id}>
-            <a
-              href={`#${heading.id}`}
-              className={cn(
-                'block py-1 text-muted-foreground text-sm hover:text-foreground',
-                heading.level === 3 ? 'pl-6' : 'pl-3'
-              )}
-            >
-              {heading.text}
-            </a>
-          </li>
-        ))}
-      </ul>
-    </nav>
+    <DocsShell
+      activeSlug={page.slug}
+      activeTitle={page.title}
+      headings={page.headings}
+    >
+      <DocsMarkdown markdown={page.markdown} />
+    </DocsShell>
   )
 }

--- a/apps/dashboard/src/routes/(docs)/route.tsx
+++ b/apps/dashboard/src/routes/(docs)/route.tsx
@@ -9,7 +9,7 @@ export const Route = createFileRoute('/(docs)')({
 
 function DocsLayout() {
   return (
-    <div className="bg-background font-sans antialiased">
+    <div className="antialiased">
       <Outlet />
     </div>
   )

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -71,9 +71,10 @@ The next build picks it up automatically, makes `v0.4` the latest, and keeps
 
 ## Theme & customization
 
-The design (12-column sticky layout, Inter type, gray/blue/green/red token
-palette, shadow scale, `.component-preview`, content typography) is ported from
-astro-design-system and lives in plain CSS — no Tailwind dependency:
+The design follows the [Vercel Docs](https://vercel.com/docs) / Geist layout
+(three-column sticky shell, Geist Sans + Mono, `--ds-*` tokens, Pagefind
+search). Tokens live in `design-system/vercel-docs-tokens.css` and are applied
+via plain CSS — no Tailwind dependency:
 
 - **Tokens & layout** — `src/styles/global.css`, with light + dark themes driven
   by CSS custom properties and a `[data-theme]` attribute.
@@ -82,7 +83,7 @@ astro-design-system and lives in plain CSS — no Tailwind dependency:
 - **Site config** — `src/config.ts` (title, links). Sidebar order/labels are
   curated in `scripts/sync-docs.mjs` (`SECTION_ORDER`, `LABEL_OVERRIDES`).
 - **Logo & favicon** — `src/assets/logo.svg` and `public/favicon.svg`.
-- **Fonts** — Inter + IBM Plex Mono, self-hosted via `@fontsource*`.
+- **Fonts** — Geist Sans + Geist Mono, self-hosted via `@fontsource*`.
 
 ## Deploy
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -13,7 +13,7 @@ export default defineConfig({
   markdown: {
     shikiConfig: {
       themes: { light: 'github-light', dark: 'github-dark' },
-      wrap: false,
+      wrap: true,
     },
   },
 })

--- a/apps/docs/bun.lock
+++ b/apps/docs/bun.lock
@@ -6,8 +6,8 @@
       "name": "docs",
       "dependencies": {
         "@astrojs/sitemap": "^3.7.3",
-        "@fontsource-variable/inter": "^5.2.5",
-        "@fontsource/jetbrains-mono": "^5.2.5",
+        "@fontsource-variable/geist": "^5.2.9",
+        "@fontsource/geist-mono": "^5.2.8",
         "astro": "^6.1.10",
       },
       "devDependencies": {
@@ -113,9 +113,9 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
-    "@fontsource-variable/inter": ["@fontsource-variable/inter@5.2.8", "", {}, "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ=="],
+    "@fontsource-variable/geist": ["@fontsource-variable/geist@5.2.9", "", {}, "sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ=="],
 
-    "@fontsource/jetbrains-mono": ["@fontsource/jetbrains-mono@5.2.8", "", {}, "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ=="],
+    "@fontsource/geist-mono": ["@fontsource/geist-mono@5.2.8", "", {}, "sha512-YqZUb3X42GjRaHkibUNyE8K4Rk9A6I9Ez81YpJYiuJN4ggmTW2ixoQpa9EWCPfXZtIsCQJTyrDoV9OJOZO/UcA=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.3",
-    "@fontsource-variable/inter": "^5.2.5",
-    "@fontsource/jetbrains-mono": "^5.2.5",
+    "@fontsource-variable/geist": "^5.2.9",
+    "@fontsource/geist-mono": "^5.2.8",
     "astro": "^6.1.10"
   },
   "devDependencies": {

--- a/apps/docs/src/components/Sidebar.astro
+++ b/apps/docs/src/components/Sidebar.astro
@@ -1,7 +1,5 @@
 ---
 import navData from '../generated/nav.json'
-import { resolveNavIcon } from '../lib/nav-icons'
-import NavIcon from './NavIcon.astro'
 
 interface Props {
   version: string
@@ -22,7 +20,6 @@ const isActiveGroup = (group: any) => group.items?.some((it: any) => it.link ===
           <div class="nav-group__items">
             {group.items.map((item: any) => (
               <a class="nav-link" href={item.link} aria-current={item.link === current ? 'page' : undefined}>
-                <NavIcon name={resolveNavIcon(item.link)} />
                 <span class="nav-link__label">{item.label}</span>
               </a>
             ))}
@@ -31,7 +28,6 @@ const isActiveGroup = (group: any) => group.items?.some((it: any) => it.link ===
       ) : (
         <div class="nav-group">
           <a class="nav-link" href={group.link} aria-current={group.link === current ? 'page' : undefined}>
-            <NavIcon name={resolveNavIcon(group.link)} />
             <span class="nav-link__label">{group.label}</span>
           </a>
         </div>

--- a/apps/docs/src/layouts/MainLayout.astro
+++ b/apps/docs/src/layouts/MainLayout.astro
@@ -1,7 +1,7 @@
 ---
-import '@fontsource-variable/inter'
-import '@fontsource/jetbrains-mono/400.css'
-import '@fontsource/jetbrains-mono/500.css'
+import '@fontsource-variable/geist'
+import '@fontsource/geist-mono/400.css'
+import '@fontsource/geist-mono/500.css'
 import '../styles/global.css'
 import { SITE } from '../config'
 import Header from '../components/Header.astro'

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -1,87 +1,14 @@
-/* chmonitor docs — xAI docs-inspired design system */
+/* chmonitor docs — Vercel Docs / Geist design system */
 
-/* ── Design tokens ──────────────────────────────────────────────────── */
+@import '../../../../design-system/vercel-docs-tokens.css';
+
 :root {
-  --neutral-50: #fafafa;
-  --neutral-100: #f5f5f5;
-  --neutral-200: #e5e5e5;
-  --neutral-300: #d4d4d4;
-  --neutral-400: #a3a3a3;
-  --neutral-500: #737373;
-  --neutral-600: #525252;
-  --neutral-700: #404040;
-  --neutral-800: #262626;
-  --neutral-900: #171717;
-  --neutral-950: #0a0a0a;
-
-  --font-sans: 'Inter Variable', 'Inter', ui-sans-serif, system-ui, -apple-system,
-    'Segoe UI', sans-serif;
-  --font-mono: 'JetBrains Mono', ui-monospace, sfmono-regular, menlo, monaco,
-    consolas, monospace;
-
-  --radius-sm: 0.375rem;
-  --radius: 0.625rem;
-  --radius-lg: 0.75rem;
+  --radius-sm: var(--geist-radius);
+  --radius: 8px;
+  --radius-lg: 10px;
   --radius-pill: 9999px;
-  --radius-nav: 10px;
-
-  --header-h: 4rem;
-  --sidebar-w: 15.5rem;
-  --toc-w: 14rem;
-  --content-max: 46rem;
-  --layout-max: 120rem;
-
-  /* Semantic — light */
-  --bg: var(--neutral-50);
-  --bg-base: #ffffff;
-  --bg-elev: var(--neutral-100);
-  --bg-overlay-hover: rgba(23, 23, 23, 0.04);
-  --bg-header: transparent;
-  --fg: var(--neutral-900);
-  --fg-muted: var(--neutral-500);
-  --fg-subtle: var(--neutral-400);
-  --border: rgba(23, 23, 23, 0.08);
-  --border-strong: var(--neutral-200);
-  --link: var(--neutral-900);
-  --link-hover: var(--neutral-700);
-  --accent: var(--neutral-900);
-  --accent-soft: rgba(23, 23, 23, 0.04);
-  --code-bg: var(--neutral-100);
-  --code-border: var(--neutral-200);
-  --selection: rgba(23, 23, 23, 0.12);
-  --primary: var(--neutral-900);
-  --primary-fg: #ffffff;
-  --shadow-lg: 0 24px 48px -12px rgba(0, 0, 0, 0.12);
-}
-
-:root[data-theme='dark'] {
-  --bg: var(--neutral-950);
-  --bg-base: var(--neutral-950);
-  --bg-elev: var(--neutral-900);
-  --bg-overlay-hover: rgba(255, 255, 255, 0.06);
-  --bg-header: transparent;
-  --fg: var(--neutral-50);
-  --fg-muted: var(--neutral-400);
-  --fg-subtle: var(--neutral-500);
-  --border: rgba(255, 255, 255, 0.08);
-  --border-strong: var(--neutral-800);
-  --link: var(--neutral-50);
-  --link-hover: var(--neutral-200);
-  --accent: var(--neutral-50);
-  --accent-soft: rgba(255, 255, 255, 0.06);
-  --code-bg: var(--neutral-900);
-  --code-border: var(--neutral-800);
-  --selection: rgba(255, 255, 255, 0.16);
-  --primary: var(--neutral-50);
-  --primary-fg: var(--neutral-950);
-  --shadow-lg: 0 24px 48px -12px rgba(0, 0, 0, 0.55);
-}
-
-@media (min-width: 1280px) {
-  :root {
-    --sidebar-w: 18rem;
-    --header-h: 5rem;
-  }
+  --radius-nav: var(--geist-radius);
+  --header-h: var(--header-height);
 }
 
 /* ── Base ───────────────────────────────────────────────────────────── */
@@ -101,12 +28,12 @@ html {
 body {
   margin: 0;
   font-family: var(--font-sans);
-  font-size: 0.9375rem;
-  line-height: 1.65;
+  font-size: 0.875rem;
+  line-height: 1.5715;
   color: var(--fg);
   background: var(--bg);
   font-feature-settings: 'cv11', 'ss01';
-  letter-spacing: -0.011em;
+  letter-spacing: -0.01em;
   -webkit-font-smoothing: antialiased;
   overflow-x: clip;
 }
@@ -150,7 +77,7 @@ img {
   border-radius: var(--radius);
 }
 
-/* ── Header (fixed, gradient fade like docs.x.ai) ───────────────────── */
+/* ── Header (Vercel docs: fixed bar + bottom border) ───────────────── */
 .header {
   position: fixed;
   inset: 0 0 auto;
@@ -162,34 +89,12 @@ img {
   gap: 1rem;
   padding: 0 1rem;
   background: var(--bg-header);
+  box-shadow: var(--header-border);
 }
 @media (min-width: 1024px) {
   .header {
     padding: 0 1.5rem;
   }
-}
-.header::before {
-  content: '';
-  position: absolute;
-  inset: 0 0 auto;
-  height: 8rem;
-  pointer-events: none;
-  background: linear-gradient(to bottom, var(--bg) 0%, transparent 100%);
-  opacity: 0.95;
-}
-@media (min-width: 1024px) {
-  .header::before {
-    height: 6rem;
-    background: linear-gradient(
-      to bottom,
-      color-mix(in srgb, var(--bg) 75%, transparent) 0%,
-      transparent 100%
-    );
-  }
-}
-.header > * {
-  position: relative;
-  z-index: 1;
 }
 .header__start {
   display: flex;
@@ -267,6 +172,7 @@ img {
 .header-nav__link.is-active,
 .header-nav__item.is-active .header-nav__trigger {
   color: var(--fg);
+  background: var(--ds-gray-200);
 }
 .header-nav__item {
   position: relative;
@@ -401,8 +307,8 @@ img {
   height: 2.25rem;
   padding: 0 0.75rem 0 1rem;
   border-radius: var(--radius-pill);
-  border: 1px solid color-mix(in srgb, var(--fg) 15%, transparent);
-  background: transparent;
+  border: 1px solid var(--ds-gray-300);
+  background: var(--bg-base);
   color: var(--fg-muted);
   font: inherit;
   font-size: 0.875rem;
@@ -586,12 +492,9 @@ details.nav-group[open] > summary.nav-group__label::after {
   opacity: 1;
 }
 .nav-link[aria-current='page'] {
-  background: var(--bg-base);
+  background: var(--ds-gray-200);
   color: var(--fg);
   font-weight: 500;
-}
-:root[data-theme='dark'] .nav-link[aria-current='page'] {
-  background: var(--neutral-800);
 }
 
 /* ── Version switcher ───────────────────────────────────────────────── */
@@ -662,7 +565,7 @@ details.nav-group[open] > summary.nav-group__label::after {
 .toc a:hover,
 .toc a.active {
   color: var(--fg);
-  background: var(--bg-overlay-hover);
+  background: var(--ds-gray-200);
 }
 .toc li[data-depth='3'] a {
   padding-left: 1rem;
@@ -685,24 +588,28 @@ details.nav-group[open] > summary.nav-group__label::after {
   font-weight: 600;
 }
 .content h1 {
-  font-size: 2.25rem;
+  font-size: 2rem;
   font-weight: 600;
   letter-spacing: -0.03em;
   margin: 0 0 1rem;
+  color: var(--ds-gray-900);
 }
 .content h2 {
-  font-size: 1.375rem;
+  font-size: 1.5rem;
   margin: 2.5rem 0 0.75rem;
   padding-bottom: 0;
   border-bottom: none;
+  color: var(--ds-gray-900);
 }
 .content h3 {
-  font-size: 1.125rem;
+  font-size: 1.25rem;
   margin: 2rem 0 0.5rem;
+  color: var(--ds-gray-900);
 }
 .content h4 {
   font-size: 1rem;
   margin: 1.5rem 0 0.5rem;
+  color: var(--ds-gray-900);
 }
 .content p,
 .content li {
@@ -712,13 +619,14 @@ details.nav-group[open] > summary.nav-group__label::after {
   margin: 0.85rem 0;
 }
 .content a {
-  color: var(--fg);
+  color: var(--link);
   text-underline-offset: 0.2em;
   text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, var(--fg) 25%, transparent);
+  text-decoration-color: color-mix(in srgb, var(--link) 35%, transparent);
 }
 .content a:hover {
-  text-decoration-color: var(--fg);
+  color: var(--link-hover);
+  text-decoration-color: var(--link-hover);
 }
 .content ul,
 .content ol {

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -1,0 +1,1 @@
+@import './vercel-docs-tokens.css';

--- a/design-system/tokens.json
+++ b/design-system/tokens.json
@@ -1,0 +1,55 @@
+{
+  "source": {
+    "url": "https://vercel.com/docs",
+    "extractedAt": "2026-06-15T08:59:08.367Z",
+    "extractor": "dembrandt",
+    "enrichedAt": "2026-06-15T09:15:00.000Z",
+    "enrichedFrom": "vercel.com/vc-ap-vercel-docs CSS chunks"
+  },
+  "colors": {
+    "primary": "#171717",
+    "secondary": "#666666",
+    "accent": "#0070f3",
+    "background": "#ffffff",
+    "backgroundMuted": "#fafafa",
+    "palette": [
+      "#ffffff",
+      "#fafafa",
+      "#f5f5f5",
+      "#eaeaea",
+      "#171717",
+      "#666666",
+      "#0070f3"
+    ],
+    "cssVariables": {
+      "--ds-background-100": "#ffffff",
+      "--ds-background-200": "#fafafa",
+      "--ds-gray-1000": "#171717",
+      "--ds-gray-900": "#666666",
+      "--ds-blue-700": "#0070f3"
+    }
+  },
+  "typography": {
+    "headingFont": "Geist",
+    "bodyFont": "Geist",
+    "monoFont": "Geist Mono",
+    "scale": {
+      "copy14": "0.875rem",
+      "heading16": "1rem",
+      "heading20": "1.25rem",
+      "heading24": "1.5rem",
+      "heading32": "2rem"
+    }
+  },
+  "spacing": {
+    "scale": ["4px", "8px", "12px", "16px", "24px", "32px", "40px", "64px"],
+    "headerHeight": "64px",
+    "pageWidth": "1400px"
+  },
+  "radius": {
+    "scale": ["6px", "8px"]
+  },
+  "shadows": {
+    "scale": ["0 0 0 1px rgba(0,0,0,0.08)", "0 2px 2px rgba(0,0,0,0.04)"]
+  }
+}

--- a/design-system/vercel-docs-tokens.css
+++ b/design-system/vercel-docs-tokens.css
@@ -1,0 +1,108 @@
+/* Vercel Docs / Geist design tokens
+   Source: https://vercel.com/docs (extracted 2026-06-15) */
+
+:root {
+  --geist-space: 4px;
+  --geist-gap: 24px;
+  --geist-gap-half: 12px;
+  --geist-page-margin: var(--geist-gap);
+  --geist-radius: 6px;
+  --header-height: 64px;
+  --docs-header-height: 106px;
+  --ds-page-width: 1400px;
+
+  --font-sans-fallback: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  --font-mono-fallback: ui-monospace, 'Roboto Mono', Menlo, Monaco, monospace;
+  --font-sans: 'Geist Variable', 'Geist', ui-sans-serif, var(--font-sans-fallback);
+  --font-mono: 'Geist Mono', ui-monospace, var(--font-mono-fallback);
+
+  /* Light */
+  --ds-background-100: #ffffff;
+  --ds-background-200: #fafafa;
+  --ds-gray-100: #f5f5f5;
+  --ds-gray-200: #eaeaea;
+  --ds-gray-300: #e5e5e5;
+  --ds-gray-400: #d4d4d4;
+  --ds-gray-500: #a3a3a3;
+  --ds-gray-600: #888888;
+  --ds-gray-700: #666666;
+  --ds-gray-800: #444444;
+  --ds-gray-900: #666666;
+  --ds-gray-1000: #171717;
+  --ds-gray-alpha-100: rgba(0, 0, 0, 0.04);
+  --ds-gray-alpha-200: rgba(0, 0, 0, 0.08);
+  --ds-blue-700: #0070f3;
+  --geist-foreground: #000000;
+  --geist-background: #ffffff;
+  --geist-link-color: var(--ds-blue-700);
+
+  --ds-shadow-border-base: 0 0 0 1px rgba(0, 0, 0, 0.08);
+  --ds-shadow-small: 0 2px 2px rgba(0, 0, 0, 0.04);
+  --ds-shadow-menu: var(--ds-shadow-border-base), 0 1px 1px rgba(0, 0, 0, 0.02),
+    0 4px 8px -4px rgba(0, 0, 0, 0.04), 0 16px 24px -8px rgba(0, 0, 0, 0.06);
+  --ds-focus-ring: 0 0 0 2px var(--ds-background-100), 0 0 0 4px var(--ds-blue-700);
+
+  /* Semantic aliases for docs layout */
+  --bg: var(--ds-background-200);
+  --bg-base: var(--ds-background-100);
+  --bg-elev: var(--ds-gray-100);
+  --bg-overlay-hover: var(--ds-gray-alpha-100);
+  --bg-header: var(--ds-background-100);
+  --fg: var(--ds-gray-1000);
+  --fg-muted: var(--ds-gray-900);
+  --fg-subtle: var(--ds-gray-600);
+  --border: var(--ds-gray-alpha-200);
+  --border-strong: var(--ds-gray-300);
+  --link: var(--geist-link-color);
+  --link-hover: #0060df;
+  --accent: var(--ds-gray-1000);
+  --accent-soft: var(--ds-gray-alpha-100);
+  --code-bg: var(--ds-gray-100);
+  --code-border: var(--ds-gray-300);
+  --selection: var(--ds-gray-200);
+  --primary: var(--ds-gray-1000);
+  --primary-fg: #ffffff;
+  --shadow-lg: var(--ds-shadow-menu);
+  --header-border: 0 1px 0 rgba(0, 0, 0, 0.1);
+
+  --sidebar-w: 15.5rem;
+  --toc-w: 13.5rem;
+  --content-max: 42rem;
+  --layout-max: var(--ds-page-width);
+}
+
+:root[data-theme='dark'] {
+  --ds-background-100: #000000;
+  --ds-background-200: #0a0a0a;
+  --ds-gray-100: #1a1a1a;
+  --ds-gray-200: #292929;
+  --ds-gray-300: #333333;
+  --ds-gray-400: #444444;
+  --ds-gray-500: #666666;
+  --ds-gray-600: #888888;
+  --ds-gray-700: #999999;
+  --ds-gray-800: #aaaaaa;
+  --ds-gray-900: #a1a1a1;
+  --ds-gray-1000: #ededed;
+  --ds-gray-alpha-100: rgba(255, 255, 255, 0.06);
+  --ds-gray-alpha-200: rgba(255, 255, 255, 0.09);
+  --geist-foreground: #ededed;
+  --geist-background: #000000;
+  --geist-link-color: #3291ff;
+  --ds-blue-700: #3291ff;
+
+  --ds-shadow-border-base: 0 0 0 1px rgba(255, 255, 255, 0.1);
+  --ds-shadow-small: 0 2px 2px rgba(0, 0, 0, 0.4);
+  --ds-shadow-menu: var(--ds-shadow-border-base), 0 16px 24px -8px rgba(0, 0, 0, 0.6);
+  --header-border: 0 1px 0 rgba(255, 255, 255, 0.1);
+
+  --link: var(--geist-link-color);
+  --link-hover: #52a8ff;
+}
+
+@media (min-width: 1280px) {
+  :root {
+    --sidebar-w: 17rem;
+  }
+}


### PR DESCRIPTION
## Summary

Redesigns both documentation surfaces to match the Vercel Docs / Geist design system:

- **docs.chmonitor.dev** (`apps/docs`) — Astro theme updated with Geist typography, Vercel layout tokens, header border, blue links, and text-only sidebar nav
- **dash.chmonitor.dev/docs** (`apps/dashboard`) — new `DocsShell` + `docs-theme.css` sharing the same token file

Design tokens were extracted from https://vercel.com/docs and enriched from Vercel's published CSS (`--ds-*`, `--geist-*`). Shared tokens live in `design-system/vercel-docs-tokens.css`.

## Changes

- Add `design-system/vercel-docs-tokens.css` with light/dark Geist color scale, spacing, shadows
- Switch docs fonts from Inter/JetBrains Mono → Geist Sans/Mono
- Align typography (14px body, 32/24/20px headings), link color, nav active states
- Extract duplicated dashboard docs layout into `DocsShell`
- Ignore `.extract-design-system/` extraction cache

## Test plan

- [x] `cd apps/docs && bun run build` (54 pages + Pagefind index)
- [x] `cd apps/dashboard && bun run build` (vite + tsc)
- [ ] Visual check docs.chmonitor.dev after deploy
- [ ] Visual check dash.chmonitor.dev/docs after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced DocsShell layout component for improved documentation navigation and organization.

* **Style**
  * Updated fonts from Inter/IBM Plex Mono to Geist Sans/Geist Mono.
  * Applied Vercel Docs theme with refreshed visual styling.
  * Removed navigation icons from sidebar for a cleaner design.

* **Refactor**
  * Restructured docs page layout components for better maintainability.

* **Chores**
  * Added Geist font dependencies.
  * Enhanced code block wrapping behavior in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->