### PR TITLE
fix(docs): match Vercel Geist prose typography

### DIFF
--- a/apps/dashboard/src/routes/(docs)/docs/-components/docs-markdown.tsx
+++ b/apps/dashboard/src/routes/(docs)/docs/-components/docs-markdown.tsx
@@ -21,7 +21,7 @@ export function DocsMarkdown({ markdown }: DocsMarkdownProps) {
   }
 
   return (
-    <div className="markdown-content docs-markdown">
+    <div className="markdown-content docs-markdown" data-docs-prose>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{

--- a/apps/dashboard/src/routes/(docs)/docs/docs-theme.css
+++ b/apps/dashboard/src/routes/(docs)/docs/docs-theme.css
@@ -5,7 +5,7 @@
 
 .docs-vercel-theme {
   --background: var(--ds-background-100);
-  --foreground: var(--ds-gray-1000);
+  --foreground: var(--geist-foreground);
   --muted-foreground: var(--ds-gray-900);
   --border: var(--ds-gray-300);
   --accent: var(--ds-gray-200);
@@ -15,7 +15,7 @@
   font-size: 1rem;
   line-height: 1.5;
   background: var(--ds-background-100);
-  color: var(--ds-gray-1000);
+  color: var(--geist-foreground);
 }
 
 .docs-vercel-theme .docs-shell__header {
@@ -73,12 +73,14 @@
 }
 
 .docs-vercel-theme .docs-markdown {
+  font-kerning: normal;
   font-size: 1rem;
+  font-variant-ligatures: common-ligatures contextual;
   line-height: 1.5;
 }
 
 .docs-vercel-theme .docs-markdown h1 {
-  color: var(--ds-gray-1000);
+  color: var(--geist-foreground);
   font-size: 2rem;
   font-weight: 600;
   letter-spacing: -0.03em;
@@ -89,7 +91,7 @@
 
 .docs-vercel-theme .docs-markdown h2 {
   border-bottom: none;
-  color: var(--ds-gray-1000);
+  color: var(--geist-foreground);
   font-size: 1.5rem;
   font-weight: 600;
   letter-spacing: -0.025em;
@@ -99,34 +101,61 @@
 }
 
 .docs-vercel-theme .docs-markdown h3 {
-  color: var(--ds-gray-1000);
+  color: var(--geist-foreground);
   font-size: 1.25rem;
   font-weight: 600;
   margin-top: 2rem;
 }
 
 .docs-vercel-theme .docs-markdown h4 {
-  color: var(--ds-gray-1000);
+  color: var(--geist-foreground);
   font-size: 1rem;
   font-weight: 600;
   margin-top: 1.5rem;
 }
 
-.docs-vercel-theme .docs-markdown p,
-.docs-vercel-theme .docs-markdown li {
-  color: var(--ds-gray-900);
+.docs-vercel-theme .docs-markdown > p {
+  margin-top: 1.25em;
+  margin-bottom: 0;
+  color: var(--geist-foreground);
+  font-size: 1rem;
+  line-height: 1.7;
+  text-wrap: pretty;
 }
 
-.docs-vercel-theme .docs-markdown a {
-  color: var(--geist-link-color);
-  text-decoration-color: color-mix(in srgb, var(--geist-link-color) 35%, transparent);
-  text-decoration-line: underline;
-  text-underline-offset: 0.2em;
+.docs-vercel-theme .docs-markdown > p:first-child {
+  margin-top: 0;
 }
 
-.docs-vercel-theme .docs-markdown a:hover {
-  color: var(--link-hover);
-  text-decoration-color: var(--link-hover);
+.docs-vercel-theme .docs-markdown > h1 + p {
+  margin-top: 1.25em;
+  padding: 1rem 1.25rem;
+  border-radius: var(--geist-radius);
+  background: var(--ds-blue-100);
+}
+
+.docs-vercel-theme .docs-markdown > h2 + p,
+.docs-vercel-theme .docs-markdown > h3 + p,
+.docs-vercel-theme .docs-markdown > h4 + p {
+  margin-top: 0.75em;
+}
+
+.docs-vercel-theme .docs-markdown :is(p, li, td, th, blockquote) {
+  color: var(--geist-foreground);
+  line-height: 1.7;
+}
+
+.docs-vercel-theme .docs-markdown :is(p, li, td, th, dt, dd, blockquote) a {
+  color: inherit;
+  font-weight: 500;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: var(--ds-gray-alpha-600);
+}
+
+.docs-vercel-theme .docs-markdown :is(p, li, td, th, dt, dd, blockquote) a:hover,
+.docs-vercel-theme .docs-markdown :is(p, li, td, th, dt, dd, blockquote) a:focus-visible {
+  text-decoration-color: currentColor;
 }
 
 .docs-vercel-theme .docs-markdown :not(pre) > code {

--- a/apps/docs/src/layouts/MainLayout.astro
+++ b/apps/docs/src/layouts/MainLayout.astro
@@ -83,7 +83,7 @@ const ogImage = new URL('/og/og.png', Astro.site).toString()
     <div class="layout">
       <Sidebar version={version} currentSlug={currentSlug} />
       <main class="main">
-        <article id="article" class="content">
+        <article id="article" class="content" data-docs-prose>
           <slot />
         </article>
         {

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -34,7 +34,7 @@ body {
   font-family: var(--font-sans);
   font-size: 1rem;
   line-height: 1.5;
-  color: var(--fg);
+  color: var(--geist-foreground);
   background: var(--bg);
   font-feature-settings: 'cv11', 'ss01';
   letter-spacing: -0.01em;
@@ -697,81 +697,106 @@ details.nav-group[open] > summary.nav-group__label::after {
   font-weight: 400;
 }
 
-/* ── Content typography ─────────────────────────────────────────────── */
-.content > :first-child {
+/* ── Content typography (Vercel docs prose) ───────────────────────────── */
+[data-docs-prose] {
+  font-kerning: normal;
+  font-variant-ligatures: common-ligatures contextual;
+}
+[data-docs-prose] > :first-child {
   margin-top: 0;
 }
-.content h1,
-.content h2,
-.content h3,
-.content h4 {
+[data-docs-prose] h1,
+[data-docs-prose] h2,
+[data-docs-prose] h3,
+[data-docs-prose] h4 {
   line-height: 1.2;
   letter-spacing: -0.025em;
   scroll-margin-top: calc(var(--header-h) + 1rem);
-  color: var(--fg);
+  color: var(--geist-foreground);
   font-weight: 600;
 }
-.content h1 {
+[data-docs-prose] h1 {
   font-size: 2rem;
   font-weight: 600;
   letter-spacing: -0.03em;
   margin: 0 0 1rem;
-  color: var(--ds-gray-1000);
 }
-.content h2 {
+[data-docs-prose] h2 {
   font-size: 1.5rem;
   margin: 2.5rem 0 0.75rem;
   padding-bottom: 0;
   border-bottom: none;
-  color: var(--ds-gray-1000);
 }
-.content h3 {
+[data-docs-prose] h3 {
   font-size: 1.25rem;
   margin: 2rem 0 0.5rem;
-  color: var(--ds-gray-1000);
 }
-.content h4 {
+[data-docs-prose] h4 {
   font-size: 1rem;
   margin: 1.5rem 0 0.5rem;
-  color: var(--ds-gray-1000);
 }
-.content p,
-.content li {
-  color: var(--ds-gray-900);
+[data-docs-prose] > p {
+  margin-top: 1.25em;
+  margin-bottom: 0;
+  color: var(--geist-foreground);
   font-size: 1rem;
-  line-height: 1.5;
+  line-height: 1.7;
+  text-wrap: pretty;
 }
-.content p {
-  margin: 1rem 0;
+[data-docs-prose] > p:first-child {
+  margin-top: 0;
 }
-.content a {
-  color: var(--link);
-  text-underline-offset: 0.2em;
+/* Vercel docs: first summary paragraph after the page title */
+[data-docs-prose] > h1 + p {
+  margin-top: 1.25em;
+  padding: 1rem 1.25rem;
+  border-radius: var(--geist-radius);
+  background: var(--ds-blue-100);
+}
+[data-docs-prose] > h2 + p,
+[data-docs-prose] > h3 + p,
+[data-docs-prose] > h4 + p {
+  margin-top: 0.75em;
+}
+[data-docs-prose] :is(p, li, td, th, blockquote) {
+  color: var(--geist-foreground);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+[data-docs-prose] :is(p, li, td, th, dt, dd, blockquote) a {
+  color: inherit;
+  font-weight: 500;
   text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, var(--link) 35%, transparent);
+  text-underline-offset: 2px;
+  text-decoration-color: var(--ds-gray-alpha-600);
 }
-.content a:hover {
-  color: var(--link-hover);
-  text-decoration-color: var(--link-hover);
+[data-docs-prose] :is(p, li, td, th, dt, dd, blockquote) a:hover,
+[data-docs-prose] :is(p, li, td, th, dt, dd, blockquote) a:focus-visible {
+  text-decoration-color: currentColor;
 }
-.content ul,
-.content ol {
+[data-docs-prose] .page-foot a,
+[data-docs-prose] a.header-nav__link {
+  color: var(--link);
+}
+[data-docs-prose] > ul,
+[data-docs-prose] > ol {
   padding-left: 1.4rem;
-  margin: 0.85rem 0;
+  margin-top: 1em;
+  margin-bottom: 0;
 }
-.content li {
+[data-docs-prose] li {
   margin: 0.3rem 0;
 }
-.content strong {
-  color: var(--fg);
+[data-docs-prose] strong {
+  color: var(--geist-foreground);
   font-weight: 600;
 }
-.content hr {
+[data-docs-prose] hr {
   border: none;
   border-top: 1px solid var(--border);
   margin: 2.5rem 0;
 }
-.content blockquote {
+[data-docs-prose] blockquote {
   margin: 1.25rem 0;
   padding: 0.5rem 1rem;
   border-left: 2px solid var(--border-strong);
@@ -779,16 +804,20 @@ details.nav-group[open] > summary.nav-group__label::after {
   border-radius: 0 var(--radius) var(--radius) 0;
   color: var(--fg-muted);
 }
-.content blockquote p {
+[data-docs-prose] blockquote p {
   margin: 0.35rem 0;
 }
 
 /* Inline + block code */
-.content code {
+[data-docs-prose] code,
+[data-docs-prose] pre {
+  font-variant-ligatures: no-common-ligatures no-contextual;
+}
+[data-docs-prose] code {
   font-family: var(--font-mono);
   font-size: 0.85em;
 }
-.content :not(pre) > code {
+[data-docs-prose] :not(pre) > code {
   background: var(--code-bg);
   border: 1px solid var(--code-border);
   border-radius: var(--radius-sm);
@@ -796,7 +825,7 @@ details.nav-group[open] > summary.nav-group__label::after {
   font-weight: 500;
   color: var(--fg);
 }
-.content pre {
+[data-docs-prose] pre {
   margin: 1rem 0;
   padding: 1rem 1.1rem;
   border-radius: var(--radius-lg);
@@ -806,14 +835,14 @@ details.nav-group[open] > summary.nav-group__label::after {
   font-size: 0.8125rem;
   line-height: 1.6;
 }
-.content pre code {
+[data-docs-prose] pre code {
   background: none;
   border: none;
   padding: 0;
 }
 
 /* Tables */
-.content table {
+[data-docs-prose] table {
   width: 100%;
   border-collapse: collapse;
   margin: 1.25rem 0;
@@ -822,26 +851,26 @@ details.nav-group[open] > summary.nav-group__label::after {
   border-radius: var(--radius-lg);
   overflow: hidden;
 }
-.content th,
-.content td {
+[data-docs-prose] th,
+[data-docs-prose] td {
   text-align: left;
   padding: 0.55rem 0.8rem;
   border-bottom: 1px solid var(--border);
   vertical-align: top;
 }
-.content th {
+[data-docs-prose] th {
   background: var(--bg-elev);
   font-weight: 600;
   color: var(--fg);
 }
-.content tr:last-child td {
+[data-docs-prose] tr:last-child td {
   border-bottom: none;
 }
-.content td code {
+[data-docs-prose] td code {
   white-space: nowrap;
 }
 
-.content .component-preview {
+[data-docs-prose] .component-preview {
   padding: 3rem;
   display: flex;
   gap: 1rem;
@@ -957,7 +986,7 @@ dialog.search-modal::backdrop {
   .main {
     padding: 1.25rem 1.25rem 4rem;
   }
-  .content h1 {
+  [data-docs-prose] h1 {
     font-size: 1.75rem;
   }
 }

--- a/design-system/vercel-docs-tokens.css
+++ b/design-system/vercel-docs-tokens.css
@@ -16,25 +16,31 @@
   --font-sans-fallback: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
     sans-serif;
   --font-mono-fallback: ui-monospace, 'Roboto Mono', Menlo, Monaco, monospace;
-  --font-sans: 'Geist Variable', 'Geist', ui-sans-serif, var(--font-sans-fallback);
+  --font-sans:
+    'Geist Variable', 'Geist', Arial, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji', ui-sans-serif, var(--font-sans-fallback);
   --font-mono: 'Geist Mono', ui-monospace, var(--font-mono-fallback);
 
   /* Light */
   --ds-background-100: #ffffff;
   --ds-background-200: #fafafa;
-  --ds-gray-100: #f5f5f5;
-  --ds-gray-200: #eaeaea;
-  --ds-gray-300: #e5e5e5;
-  --ds-gray-400: #d4d4d4;
-  --ds-gray-500: #a3a3a3;
-  --ds-gray-600: #888888;
-  --ds-gray-700: #666666;
-  --ds-gray-800: #444444;
+  --ds-gray-100: #f2f2f2;
+  --ds-gray-200: #ebebeb;
+  --ds-gray-300: #e6e6e6;
+  --ds-gray-400: #eaeaea;
+  --ds-gray-500: #c9c9c9;
+  --ds-gray-600: #a8a8a8;
+  --ds-gray-700: #8f8f8f;
+  --ds-gray-800: #7d7d7d;
   --ds-gray-900: #666666;
   --ds-gray-1000: #171717;
   --ds-gray-alpha-100: rgba(0, 0, 0, 0.04);
   --ds-gray-alpha-200: rgba(0, 0, 0, 0.08);
+  --ds-gray-alpha-600: rgba(0, 0, 0, 0.34);
+  --ds-blue-100: hsl(212, 100%, 97%);
+  --ds-blue-200: hsl(210, 100%, 96%);
   --ds-blue-700: #0070f3;
+  --ds-blue-900: hsl(211, 100%, 42%);
   --geist-foreground: #000000;
   --geist-background: #ffffff;
   --geist-link-color: var(--ds-blue-700);
@@ -51,8 +57,9 @@
   --bg-elev: var(--ds-gray-100);
   --bg-overlay-hover: var(--ds-gray-alpha-100);
   --bg-header: var(--ds-background-100);
-  --fg: var(--ds-gray-1000);
+  --fg: var(--geist-foreground);
   --fg-muted: var(--ds-gray-900);
+  --fg-prose: var(--geist-foreground);
   --fg-subtle: var(--ds-gray-600);
   --border: var(--ds-gray-alpha-200);
   --border-strong: var(--ds-gray-300);
@@ -89,6 +96,10 @@
   --ds-gray-1000: #ededed;
   --ds-gray-alpha-100: rgba(255, 255, 255, 0.06);
   --ds-gray-alpha-200: rgba(255, 255, 255, 0.09);
+  --ds-gray-alpha-600: rgba(255, 255, 255, 0.34);
+  --ds-blue-100: hsl(216, 50%, 12%);
+  --ds-blue-200: hsl(214, 59%, 15%);
+  --ds-blue-900: hsl(210, 100%, 66%);
   --geist-foreground: #ededed;
   --geist-background: #000000;
   --geist-link-color: #3291ff;


### PR DESCRIPTION
## Summary

Matches docs body typography to Vercel docs (per DevTools reference):

- **16px Geist** with emoji fallbacks in the font stack
- **Near-black body text** (`--geist-foreground`) instead of muted gray
- **1.7 line-height** and Vercel-style paragraph spacing (`1.25em` top)
- **Inline links**: inherit text color with gray underline (not blue)
- **Intro callout**: first paragraph after `h1` gets `--ds-blue-100` background band

Applied to both `docs.chmonitor.dev` (Astro) and embedded `dash.chmonitor.dev/docs`.

## Test plan

- [x] `apps/docs` build passes
- [x] `apps/dashboard` build passes
- [ ] Visual check on Introduction page vs vercel.com/docs