### PR TITLE
fix(docs): 40px titles and Vercel mobile toolbar

### DIFF
--- a/apps/dashboard/src/routes/(docs)/docs/$.tsx
+++ b/apps/dashboard/src/routes/(docs)/docs/$.tsx
@@ -36,11 +36,7 @@ function DocsPage() {
   }
 
   return (
-    <DocsShell
-      activeSlug={page.slug}
-      activeTitle={page.title}
-      headings={page.headings}
-    >
+    <DocsShell activeSlug={page.slug} headings={page.headings}>
       <DocsMarkdown markdown={page.markdown} />
     </DocsShell>
   )

--- a/apps/dashboard/src/routes/(docs)/docs/-components/docs-markdown.tsx
+++ b/apps/dashboard/src/routes/(docs)/docs/-components/docs-markdown.tsx
@@ -21,7 +21,7 @@ export function DocsMarkdown({ markdown }: DocsMarkdownProps) {
   }
 
   return (
-    <div className="markdown-content docs-markdown">
+    <div className="markdown-content docs-markdown" data-docs-prose>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{

--- a/apps/dashboard/src/routes/(docs)/docs/-components/docs-shell.tsx
+++ b/apps/dashboard/src/routes/(docs)/docs/-components/docs-shell.tsx
@@ -1,23 +1,19 @@
+import { Menu } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 
-import type { ReactNode } from 'react'
-
 import { type DocsHeading, docsHref, docsNav } from '../-lib/docs'
+import { type ReactNode, useState } from 'react'
 import { cn } from '@/lib/utils'
 
 type DocsShellProps = {
   activeSlug: string
-  activeTitle: string
   headings: DocsHeading[]
   children: ReactNode
 }
 
-export function DocsShell({
-  activeSlug,
-  activeTitle,
-  headings,
-  children,
-}: DocsShellProps) {
+export function DocsShell({ activeSlug, headings, children }: DocsShellProps) {
+  const [mobilePanel, setMobilePanel] = useState<'menu' | 'toc' | null>(null)
+
   return (
     <div className="docs-vercel-theme min-h-dvh">
       <div className="docs-shell__header sticky top-14 z-20 mb-0 px-4 py-3 lg:px-6">
@@ -41,11 +37,31 @@ export function DocsShell({
       </div>
 
       <div className="px-4 pb-6 lg:px-6 xl:px-8">
-        <DocsMobileNav
-          activeSlug={activeSlug}
-          activeTitle={activeTitle}
-          headings={headings}
-        />
+        <div className="mx-auto w-full max-w-[var(--ds-page-width)]">
+          <DocsMobileToolbar
+            hasToc={headings.length > 0}
+            mobilePanel={mobilePanel}
+            onMenu={() =>
+              setMobilePanel((panel) => (panel === 'menu' ? null : 'menu'))
+            }
+            onToc={() =>
+              setMobilePanel((panel) => (panel === 'toc' ? null : 'toc'))
+            }
+          />
+          {mobilePanel === 'menu' ? (
+            <div className="docs-mobile-panel lg:hidden">
+              <DocsNavList activeSlug={activeSlug} compact />
+            </div>
+          ) : null}
+          {mobilePanel === 'toc' && headings.length > 0 ? (
+            <div className="docs-mobile-panel lg:hidden">
+              <div className="docs-shell__toc-title mb-2 px-2">
+                On this page
+              </div>
+              <DocsTocList headings={headings} />
+            </div>
+          ) : null}
+        </div>
         <div className="mx-auto flex w-full max-w-[var(--ds-page-width)] items-start gap-8">
           <DocsSidebar activeSlug={activeSlug} />
           <main className="min-w-0 flex-1 pb-16">
@@ -58,37 +74,38 @@ export function DocsShell({
   )
 }
 
-function DocsMobileNav({
-  activeSlug,
-  activeTitle,
-  headings,
+function DocsMobileToolbar({
+  hasToc,
+  mobilePanel,
+  onMenu,
+  onToc,
 }: {
-  activeSlug: string
-  activeTitle: string
-  headings: DocsHeading[]
+  hasToc: boolean
+  mobilePanel: 'menu' | 'toc' | null
+  onMenu: () => void
+  onToc: () => void
 }) {
   return (
-    <div className="mb-6 border-[var(--ds-gray-300)] border-b pb-3 lg:hidden">
-      <details className="group rounded-[var(--geist-radius)] border border-[var(--ds-gray-300)] bg-[var(--ds-background-100)]">
-        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2 font-medium text-sm [&::-webkit-details-marker]:hidden">
-          <span className="min-w-0 truncate">{activeTitle}</span>
-          <span className="shrink-0 text-[var(--ds-gray-900)] text-xs group-open:hidden">
-            Menu
-          </span>
-          <span className="hidden shrink-0 text-[var(--ds-gray-900)] text-xs group-open:inline">
-            Close
-          </span>
-        </summary>
-        <div className="max-h-[calc(100vh-8rem)] overflow-y-auto border-[var(--ds-gray-300)] border-t p-3">
-          <DocsNavList activeSlug={activeSlug} compact />
-          {headings.length > 0 ? (
-            <div className="mt-4 border-[var(--ds-gray-300)] border-t pt-4">
-              <div className="docs-shell__toc-title mb-2">On this page</div>
-              <DocsTocList headings={headings} />
-            </div>
-          ) : null}
-        </div>
-      </details>
+    <div className="docs-toolbar">
+      <button
+        type="button"
+        className="docs-toolbar__menu"
+        aria-expanded={mobilePanel === 'menu'}
+        onClick={onMenu}
+      >
+        <Menu className="size-[18px] opacity-70" aria-hidden />
+        <span>Menu</span>
+      </button>
+      {hasToc ? (
+        <button
+          type="button"
+          className="docs-toolbar__toc"
+          aria-expanded={mobilePanel === 'toc'}
+          onClick={onToc}
+        >
+          On this page
+        </button>
+      ) : null}
     </div>
   )
 }

--- a/apps/dashboard/src/routes/(docs)/docs/docs-theme.css
+++ b/apps/dashboard/src/routes/(docs)/docs/docs-theme.css
@@ -5,7 +5,7 @@
 
 .docs-vercel-theme {
   --background: var(--ds-background-100);
-  --foreground: var(--ds-gray-1000);
+  --foreground: var(--geist-foreground);
   --muted-foreground: var(--ds-gray-900);
   --border: var(--ds-gray-300);
   --accent: var(--ds-gray-200);
@@ -15,7 +15,7 @@
   font-size: 1rem;
   line-height: 1.5;
   background: var(--ds-background-100);
-  color: var(--ds-gray-1000);
+  color: var(--geist-foreground);
 }
 
 .docs-vercel-theme .docs-shell__header {
@@ -73,12 +73,14 @@
 }
 
 .docs-vercel-theme .docs-markdown {
+  font-kerning: normal;
   font-size: 1rem;
+  font-variant-ligatures: common-ligatures contextual;
   line-height: 1.5;
 }
 
 .docs-vercel-theme .docs-markdown h1 {
-  color: var(--ds-gray-1000);
+  color: var(--geist-foreground);
   font-size: 2rem;
   font-weight: 600;
   letter-spacing: -0.03em;
@@ -89,7 +91,7 @@
 
 .docs-vercel-theme .docs-markdown h2 {
   border-bottom: none;
-  color: var(--ds-gray-1000);
+  color: var(--geist-foreground);
   font-size: 1.5rem;
   font-weight: 600;
   letter-spacing: -0.025em;
@@ -99,34 +101,61 @@
 }
 
 .docs-vercel-theme .docs-markdown h3 {
-  color: var(--ds-gray-1000);
+  color: var(--geist-foreground);
   font-size: 1.25rem;
   font-weight: 600;
   margin-top: 2rem;
 }
 
 .docs-vercel-theme .docs-markdown h4 {
-  color: var(--ds-gray-1000);
+  color: var(--geist-foreground);
   font-size: 1rem;
   font-weight: 600;
   margin-top: 1.5rem;
 }
 
-.docs-vercel-theme .docs-markdown p,
-.docs-vercel-theme .docs-markdown li {
-  color: var(--ds-gray-900);
+.docs-vercel-theme .docs-markdown > p {
+  margin-top: 1.25em;
+  margin-bottom: 0;
+  color: var(--geist-foreground);
+  font-size: 1rem;
+  line-height: 1.7;
+  text-wrap: pretty;
 }
 
-.docs-vercel-theme .docs-markdown a {
-  color: var(--geist-link-color);
-  text-decoration-color: color-mix(in srgb, var(--geist-link-color) 35%, transparent);
-  text-decoration-line: underline;
-  text-underline-offset: 0.2em;
+.docs-vercel-theme .docs-markdown > p:first-child {
+  margin-top: 0;
 }
 
-.docs-vercel-theme .docs-markdown a:hover {
-  color: var(--link-hover);
-  text-decoration-color: var(--link-hover);
+.docs-vercel-theme .docs-markdown > h1 + p {
+  margin-top: 1.25em;
+  padding: 1rem 1.25rem;
+  border-radius: var(--geist-radius);
+  background: var(--ds-blue-100);
+}
+
+.docs-vercel-theme .docs-markdown > h2 + p,
+.docs-vercel-theme .docs-markdown > h3 + p,
+.docs-vercel-theme .docs-markdown > h4 + p {
+  margin-top: 0.75em;
+}
+
+.docs-vercel-theme .docs-markdown :is(p, li, td, th, blockquote) {
+  color: var(--geist-foreground);
+  line-height: 1.7;
+}
+
+.docs-vercel-theme .docs-markdown :is(p, li, td, th, dt, dd, blockquote) a {
+  color: inherit;
+  font-weight: 500;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: var(--ds-gray-alpha-600);
+}
+
+.docs-vercel-theme .docs-markdown :is(p, li, td, th, dt, dd, blockquote) a:hover,
+.docs-vercel-theme .docs-markdown :is(p, li, td, th, dt, dd, blockquote) a:focus-visible {
+  text-decoration-color: currentColor;
 }
 
 .docs-vercel-theme .docs-markdown :not(pre) > code {

--- a/apps/dashboard/src/routes/(docs)/docs/docs-theme.css
+++ b/apps/dashboard/src/routes/(docs)/docs/docs-theme.css
@@ -81,12 +81,88 @@
 
 .docs-vercel-theme .docs-markdown h1 {
   color: var(--geist-foreground);
-  font-size: 2rem;
+  font-size: 2.5rem;
   font-weight: 600;
   letter-spacing: -0.03em;
   line-height: 1.2;
   margin-bottom: 1rem;
   margin-top: 0;
+}
+
+@media (max-width: 820px) {
+  .docs-vercel-theme .docs-markdown h1 {
+    font-size: 2rem;
+  }
+}
+
+.docs-vercel-theme .docs-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  position: sticky;
+  top: calc(3.5rem + 3.25rem);
+  z-index: 20;
+  height: var(--docs-toolbar-height);
+  margin: 0 -1rem 1rem;
+  padding: 0 1.5rem;
+  border-bottom: 1px solid var(--ds-gray-300);
+  background: var(--ds-background-100);
+}
+
+@media (min-width: 1024px) {
+  .docs-vercel-theme .docs-toolbar {
+    display: none;
+  }
+}
+
+.docs-vercel-theme .docs-toolbar__menu {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  height: 2.25rem;
+  padding: 0 0.25rem;
+  border: none;
+  background: transparent;
+  color: var(--geist-foreground);
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: var(--geist-radius);
+}
+
+.docs-vercel-theme .docs-toolbar__menu:hover {
+  background: var(--ds-gray-alpha-100);
+}
+
+.docs-vercel-theme .docs-toolbar__toc {
+  display: inline-flex;
+  align-items: center;
+  height: 2rem;
+  padding: 0 0.875rem;
+  border: 1px solid var(--ds-gray-300);
+  border-radius: 9999px;
+  background: var(--ds-background-100);
+  color: var(--geist-foreground);
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.docs-vercel-theme .docs-toolbar__toc:hover {
+  background: var(--ds-gray-alpha-100);
+}
+
+.docs-vercel-theme .docs-mobile-panel {
+  margin-bottom: 1rem;
+  max-height: calc(100vh - 10rem);
+  overflow-y: auto;
+  border: 1px solid var(--ds-gray-300);
+  border-radius: var(--geist-radius);
+  background: var(--ds-background-100);
+  padding: 0.75rem;
 }
 
 .docs-vercel-theme .docs-markdown h2 {

--- a/apps/dashboard/src/routes/(docs)/docs/index.tsx
+++ b/apps/dashboard/src/routes/(docs)/docs/index.tsx
@@ -27,11 +27,7 @@ function DocsIndexPage() {
   }
 
   return (
-    <DocsShell
-      activeSlug={page.slug}
-      activeTitle={page.title}
-      headings={page.headings}
-    >
+    <DocsShell activeSlug={page.slug} headings={page.headings}>
       <DocsMarkdown markdown={page.markdown} />
     </DocsShell>
   )

--- a/apps/docs/src/components/DocsMobileToolbar.astro
+++ b/apps/docs/src/components/DocsMobileToolbar.astro
@@ -1,0 +1,99 @@
+---
+interface Heading {
+  depth: number
+  slug: string
+  text: string
+}
+interface Props {
+  headings: Heading[]
+}
+const { headings } = Astro.props
+const toc = headings.filter((h) => h.depth === 2 || h.depth === 3)
+const hasToc = toc.length > 0
+---
+
+<div class="docs-toolbar">
+  <button
+    class="docs-toolbar__menu"
+    id="sidebar-toggle"
+    type="button"
+    aria-label="Open docs menu"
+    aria-expanded="false"
+  >
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M4 6h16M4 12h16M4 18h16"></path>
+    </svg>
+    <span>Menu</span>
+  </button>
+  {
+    hasToc && (
+      <button
+        class="docs-toolbar__toc"
+        id="toc-mobile-toggle"
+        type="button"
+        aria-label="On this page"
+        aria-expanded="false"
+        aria-controls="toc-mobile-modal"
+      >
+        On this page
+      </button>
+    )
+  }
+</div>
+
+{
+  hasToc && (
+    <dialog class="toc-mobile-modal" id="toc-mobile-modal" aria-label="On this page">
+      <div class="toc-mobile-modal__head">
+        <span class="toc-mobile-modal__title">On this page</span>
+        <button class="icon-btn" type="button" data-close-toc-mobile aria-label="Close">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M18 6 6 18M6 6l12 12"></path>
+          </svg>
+        </button>
+      </div>
+      <nav class="toc-mobile-modal__nav" aria-label="On this page">
+        <ul>
+          {toc.map((h) => (
+            <li data-depth={h.depth}>
+              <a href={`#${h.slug}`} data-toc-mobile-link>
+                {h.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </dialog>
+  )
+}
+
+<script>
+  const tocToggle = document.getElementById('toc-mobile-toggle')
+  const tocModal = document.getElementById('toc-mobile-modal') as HTMLDialogElement | null
+
+  tocToggle?.addEventListener('click', () => {
+    if (!tocModal) return
+    if (tocModal.open) {
+      tocModal.close()
+    } else {
+      tocModal.showModal()
+    }
+    tocToggle.setAttribute('aria-expanded', tocModal.open ? 'true' : 'false')
+  })
+
+  tocModal?.addEventListener('close', () => {
+    tocToggle?.setAttribute('aria-expanded', 'false')
+  })
+
+  tocModal?.addEventListener('click', (e) => {
+    if (e.target === tocModal) tocModal.close()
+  })
+
+  for (const btn of document.querySelectorAll('[data-close-toc-mobile]')) {
+    btn.addEventListener('click', () => tocModal?.close())
+  }
+
+  for (const link of document.querySelectorAll<HTMLAnchorElement>('[data-toc-mobile-link]')) {
+    link.addEventListener('click', () => tocModal?.close())
+  }
+</script>

--- a/apps/docs/src/components/Header.astro
+++ b/apps/docs/src/components/Header.astro
@@ -17,18 +17,6 @@ const { version, subpath, currentSlug } = Astro.props
 <header class="header">
   <div class="header__top">
     <div class="header__start">
-      <button
-        class="icon-btn header__sidebar-toggle"
-        id="sidebar-toggle"
-        type="button"
-        aria-label="Toggle docs sidebar"
-        aria-expanded="false"
-      >
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="3" y="3" width="18" height="18" rx="2"></rect>
-          <path d="M9 3v18"></path>
-        </svg>
-      </button>
       <a class="header__brand" href="/">
         <svg class="header__logo" width="20" height="20" viewBox="0 0 24 24" fill="currentColor" role="img" aria-hidden="true">
           <path d="M21.333 10H24v4h-2.667ZM16 1.335h2.667v21.33H16Zm-5.333 0h2.666v21.33h-2.666ZM0 22.665V1.335h2.667v21.33zm5.333-21.33H8v21.33H5.333Z"></path>

--- a/apps/docs/src/layouts/MainLayout.astro
+++ b/apps/docs/src/layouts/MainLayout.astro
@@ -83,7 +83,7 @@ const ogImage = new URL('/og/og.png', Astro.site).toString()
     <div class="layout">
       <Sidebar version={version} currentSlug={currentSlug} />
       <main class="main">
-        <article id="article" class="content">
+        <article id="article" class="content" data-docs-prose>
           <slot />
         </article>
         {

--- a/apps/docs/src/layouts/MainLayout.astro
+++ b/apps/docs/src/layouts/MainLayout.astro
@@ -4,6 +4,7 @@ import '@fontsource/geist-mono/400.css'
 import '@fontsource/geist-mono/500.css'
 import '../styles/global.css'
 import { SITE } from '../config'
+import DocsMobileToolbar from '../components/DocsMobileToolbar.astro'
 import Header from '../components/Header.astro'
 import Sidebar from '../components/Sidebar.astro'
 import TableOfContents from '../components/TableOfContents.astro'
@@ -80,6 +81,7 @@ const ogImage = new URL('/og/og.png', Astro.site).toString()
   <body>
     <a href="#article" class="sr-only skiplink">Skip to content</a>
     <Header version={version} subpath={subpath} currentSlug={currentSlug} />
+    <DocsMobileToolbar headings={headings} />
     <div class="layout">
       <Sidebar version={version} currentSlug={currentSlug} />
       <main class="main">

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -34,7 +34,7 @@ body {
   font-family: var(--font-sans);
   font-size: 1rem;
   line-height: 1.5;
-  color: var(--fg);
+  color: var(--geist-foreground);
   background: var(--bg);
   font-feature-settings: 'cv11', 'ss01';
   letter-spacing: -0.01em;
@@ -697,81 +697,106 @@ details.nav-group[open] > summary.nav-group__label::after {
   font-weight: 400;
 }
 
-/* ── Content typography ─────────────────────────────────────────────── */
-.content > :first-child {
+/* ── Content typography (Vercel docs prose) ───────────────────────────── */
+[data-docs-prose] {
+  font-kerning: normal;
+  font-variant-ligatures: common-ligatures contextual;
+}
+[data-docs-prose] > :first-child {
   margin-top: 0;
 }
-.content h1,
-.content h2,
-.content h3,
-.content h4 {
+[data-docs-prose] h1,
+[data-docs-prose] h2,
+[data-docs-prose] h3,
+[data-docs-prose] h4 {
   line-height: 1.2;
   letter-spacing: -0.025em;
   scroll-margin-top: calc(var(--header-h) + 1rem);
-  color: var(--fg);
+  color: var(--geist-foreground);
   font-weight: 600;
 }
-.content h1 {
+[data-docs-prose] h1 {
   font-size: 2rem;
   font-weight: 600;
   letter-spacing: -0.03em;
   margin: 0 0 1rem;
-  color: var(--ds-gray-1000);
 }
-.content h2 {
+[data-docs-prose] h2 {
   font-size: 1.5rem;
   margin: 2.5rem 0 0.75rem;
   padding-bottom: 0;
   border-bottom: none;
-  color: var(--ds-gray-1000);
 }
-.content h3 {
+[data-docs-prose] h3 {
   font-size: 1.25rem;
   margin: 2rem 0 0.5rem;
-  color: var(--ds-gray-1000);
 }
-.content h4 {
+[data-docs-prose] h4 {
   font-size: 1rem;
   margin: 1.5rem 0 0.5rem;
-  color: var(--ds-gray-1000);
 }
-.content p,
-.content li {
-  color: var(--ds-gray-900);
+[data-docs-prose] > p {
+  margin-top: 1.25em;
+  margin-bottom: 0;
+  color: var(--geist-foreground);
   font-size: 1rem;
-  line-height: 1.5;
+  line-height: 1.7;
+  text-wrap: pretty;
 }
-.content p {
-  margin: 1rem 0;
+[data-docs-prose] > p:first-child {
+  margin-top: 0;
 }
-.content a {
-  color: var(--link);
-  text-underline-offset: 0.2em;
+/* Vercel docs: first summary paragraph after the page title */
+[data-docs-prose] > h1 + p {
+  margin-top: 1.25em;
+  padding: 1rem 1.25rem;
+  border-radius: var(--geist-radius);
+  background: var(--ds-blue-100);
+}
+[data-docs-prose] > h2 + p,
+[data-docs-prose] > h3 + p,
+[data-docs-prose] > h4 + p {
+  margin-top: 0.75em;
+}
+[data-docs-prose] :is(p, li, td, th, blockquote) {
+  color: var(--geist-foreground);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+[data-docs-prose] :is(p, li, td, th, dt, dd, blockquote) a {
+  color: inherit;
+  font-weight: 500;
   text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, var(--link) 35%, transparent);
+  text-underline-offset: 2px;
+  text-decoration-color: var(--ds-gray-alpha-600);
 }
-.content a:hover {
-  color: var(--link-hover);
-  text-decoration-color: var(--link-hover);
+[data-docs-prose] :is(p, li, td, th, dt, dd, blockquote) a:hover,
+[data-docs-prose] :is(p, li, td, th, dt, dd, blockquote) a:focus-visible {
+  text-decoration-color: currentColor;
 }
-.content ul,
-.content ol {
+[data-docs-prose] .page-foot a,
+[data-docs-prose] a.header-nav__link {
+  color: var(--link);
+}
+[data-docs-prose] > ul,
+[data-docs-prose] > ol {
   padding-left: 1.4rem;
-  margin: 0.85rem 0;
+  margin-top: 1em;
+  margin-bottom: 0;
 }
-.content li {
+[data-docs-prose] li {
   margin: 0.3rem 0;
 }
-.content strong {
-  color: var(--fg);
+[data-docs-prose] strong {
+  color: var(--geist-foreground);
   font-weight: 600;
 }
-.content hr {
+[data-docs-prose] hr {
   border: none;
   border-top: 1px solid var(--border);
   margin: 2.5rem 0;
 }
-.content blockquote {
+[data-docs-prose] blockquote {
   margin: 1.25rem 0;
   padding: 0.5rem 1rem;
   border-left: 2px solid var(--border-strong);
@@ -779,16 +804,20 @@ details.nav-group[open] > summary.nav-group__label::after {
   border-radius: 0 var(--radius) var(--radius) 0;
   color: var(--fg-muted);
 }
-.content blockquote p {
+[data-docs-prose] blockquote p {
   margin: 0.35rem 0;
 }
 
 /* Inline + block code */
-.content code {
+[data-docs-prose] code,
+[data-docs-prose] pre {
+  font-variant-ligatures: no-common-ligatures no-contextual;
+}
+[data-docs-prose] code {
   font-family: var(--font-mono);
   font-size: 0.85em;
 }
-.content :not(pre) > code {
+[data-docs-prose] :not(pre) > code {
   background: var(--code-bg);
   border: 1px solid var(--code-border);
   border-radius: var(--radius-sm);
@@ -796,7 +825,7 @@ details.nav-group[open] > summary.nav-group__label::after {
   font-weight: 500;
   color: var(--fg);
 }
-.content pre {
+[data-docs-prose] pre {
   margin: 1rem 0;
   padding: 1rem 1.1rem;
   border-radius: var(--radius-lg);
@@ -806,14 +835,14 @@ details.nav-group[open] > summary.nav-group__label::after {
   font-size: 0.8125rem;
   line-height: 1.6;
 }
-.content pre code {
+[data-docs-prose] pre code {
   background: none;
   border: none;
   padding: 0;
 }
 
 /* Tables */
-.content table {
+[data-docs-prose] table {
   width: 100%;
   border-collapse: collapse;
   margin: 1.25rem 0;
@@ -822,26 +851,26 @@ details.nav-group[open] > summary.nav-group__label::after {
   border-radius: var(--radius-lg);
   overflow: hidden;
 }
-.content th,
-.content td {
+[data-docs-prose] th,
+[data-docs-prose] td {
   text-align: left;
   padding: 0.55rem 0.8rem;
   border-bottom: 1px solid var(--border);
   vertical-align: top;
 }
-.content th {
+[data-docs-prose] th {
   background: var(--bg-elev);
   font-weight: 600;
   color: var(--fg);
 }
-.content tr:last-child td {
+[data-docs-prose] tr:last-child td {
   border-bottom: none;
 }
-.content td code {
+[data-docs-prose] td code {
   white-space: nowrap;
 }
 
-.content .component-preview {
+[data-docs-prose] .component-preview {
   padding: 3rem;
   display: flex;
   gap: 1rem;
@@ -957,7 +986,7 @@ dialog.search-modal::backdrop {
   .main {
     padding: 1.25rem 1.25rem 4rem;
   }
-  .content h1 {
+  [data-docs-prose] h1 {
     font-size: 1.75rem;
   }
 }

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -140,14 +140,7 @@ img {
     display: none;
   }
 }
-.header__sidebar-toggle {
-  display: inline-flex;
-}
-@media (min-width: 1024px) {
-  .header__sidebar-toggle {
-    display: none;
-  }
-}
+
 .header__start {
   display: flex;
   min-width: 0;
@@ -467,6 +460,131 @@ img {
   }
 }
 
+/* ── Mobile docs toolbar (Vercel: Menu + On this page) ──────────────── */
+.docs-toolbar {
+  display: none;
+}
+@media (max-width: 1023px) {
+  .docs-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    position: sticky;
+    top: var(--header-h);
+    z-index: 30;
+    height: var(--docs-toolbar-height);
+    padding: 0 1.5rem;
+    background: var(--ds-background-100);
+    border-bottom: 1px solid var(--ds-gray-300);
+  }
+}
+.docs-toolbar__menu {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  height: 2.25rem;
+  padding: 0 0.25rem;
+  border: none;
+  background: transparent;
+  color: var(--geist-foreground);
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background 0.15s ease;
+}
+.docs-toolbar__menu:hover {
+  background: var(--bg-overlay-hover);
+}
+.docs-toolbar__menu svg {
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+.docs-toolbar__toc {
+  display: inline-flex;
+  align-items: center;
+  height: 2rem;
+  padding: 0 0.875rem;
+  border: 1px solid var(--ds-gray-300);
+  border-radius: var(--radius-pill);
+  background: var(--ds-background-100);
+  color: var(--geist-foreground);
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+.docs-toolbar__toc:hover {
+  background: var(--bg-overlay-hover);
+  border-color: var(--ds-gray-400);
+}
+.toc-mobile-modal {
+  width: min(22rem, 92vw);
+  max-height: min(70vh, 28rem);
+  margin: auto;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  background: var(--bg-base);
+  color: var(--fg);
+  padding: 0;
+  box-shadow: var(--shadow-lg);
+}
+.toc-mobile-modal::backdrop {
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(4px);
+}
+.toc-mobile-modal__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--ds-gray-200);
+}
+.toc-mobile-modal__title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--geist-foreground);
+}
+.toc-mobile-modal__nav {
+  overflow-y: auto;
+  padding: 0.5rem;
+  max-height: calc(min(70vh, 28rem) - 3.25rem);
+}
+.toc-mobile-modal__nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+.toc-mobile-modal__nav a {
+  display: block;
+  padding: 0.45rem 0.75rem;
+  border-radius: var(--radius-sm);
+  color: var(--fg-muted);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+.toc-mobile-modal__nav a:hover,
+.toc-mobile-modal__nav a.active {
+  background: var(--ds-gray-200);
+  color: var(--geist-foreground);
+}
+.toc-mobile-modal__nav li[data-depth='3'] a {
+  padding-left: 1.25rem;
+  font-size: 0.75rem;
+}
+
 /* ── Layout: left nav · content · right TOC ─────────────────────────── */
 .layout {
   display: grid;
@@ -711,14 +829,15 @@ details.nav-group[open] > summary.nav-group__label::after {
 [data-docs-prose] h4 {
   line-height: 1.2;
   letter-spacing: -0.025em;
-  scroll-margin-top: calc(var(--header-h) + 1rem);
+  scroll-margin-top: calc(var(--header-h) + var(--docs-toolbar-offset, 0px) + 1rem);
   color: var(--geist-foreground);
   font-weight: 600;
 }
 [data-docs-prose] h1 {
-  font-size: 2rem;
+  font-size: 2.5rem;
   font-weight: 600;
   letter-spacing: -0.03em;
+  line-height: 1.2;
   margin: 0 0 1rem;
 }
 [data-docs-prose] h2 {
@@ -939,6 +1058,9 @@ dialog.search-modal::backdrop {
   }
 }
 @media (max-width: 1023px) {
+  :root {
+    --docs-toolbar-offset: var(--docs-toolbar-height);
+  }
   .sidebar {
     display: none;
   }
@@ -948,7 +1070,7 @@ dialog.search-modal::backdrop {
   :root[data-sidebar='expanded'] .sidebar {
     display: block;
     position: fixed;
-    inset: var(--header-h) auto 0 0;
+    inset: calc(var(--header-h) + var(--docs-toolbar-height)) auto 0 0;
     z-index: 40;
     width: min(var(--sidebar-w), 85vw);
     background: var(--bg);
@@ -958,7 +1080,7 @@ dialog.search-modal::backdrop {
   :root[data-sidebar='expanded'] .layout::before {
     content: '';
     position: fixed;
-    inset: var(--header-h) 0 0 0;
+    inset: calc(var(--header-h) + var(--docs-toolbar-height)) 0 0 0;
     z-index: 30;
     background: rgba(0, 0, 0, 0.4);
     pointer-events: auto;
@@ -977,8 +1099,7 @@ dialog.search-modal::backdrop {
   }
   .header__actions #theme-toggle,
   .header__actions #mobile-nav-toggle,
-  .header__actions #search-open-mobile,
-  .header__actions #sidebar-toggle {
+  .header__actions #search-open-mobile {
     display: inline-flex;
   }
 }
@@ -987,6 +1108,6 @@ dialog.search-modal::backdrop {
     padding: 1.25rem 1.25rem 4rem;
   }
   [data-docs-prose] h1 {
-    font-size: 1.75rem;
+    font-size: 2rem;
   }
 }

--- a/design-system/vercel-docs-tokens.css
+++ b/design-system/vercel-docs-tokens.css
@@ -16,25 +16,31 @@
   --font-sans-fallback: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
     sans-serif;
   --font-mono-fallback: ui-monospace, 'Roboto Mono', Menlo, Monaco, monospace;
-  --font-sans: 'Geist Variable', 'Geist', ui-sans-serif, var(--font-sans-fallback);
+  --font-sans:
+    'Geist Variable', 'Geist', Arial, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji', ui-sans-serif, var(--font-sans-fallback);
   --font-mono: 'Geist Mono', ui-monospace, var(--font-mono-fallback);
 
   /* Light */
   --ds-background-100: #ffffff;
   --ds-background-200: #fafafa;
-  --ds-gray-100: #f5f5f5;
-  --ds-gray-200: #eaeaea;
-  --ds-gray-300: #e5e5e5;
-  --ds-gray-400: #d4d4d4;
-  --ds-gray-500: #a3a3a3;
-  --ds-gray-600: #888888;
-  --ds-gray-700: #666666;
-  --ds-gray-800: #444444;
+  --ds-gray-100: #f2f2f2;
+  --ds-gray-200: #ebebeb;
+  --ds-gray-300: #e6e6e6;
+  --ds-gray-400: #eaeaea;
+  --ds-gray-500: #c9c9c9;
+  --ds-gray-600: #a8a8a8;
+  --ds-gray-700: #8f8f8f;
+  --ds-gray-800: #7d7d7d;
   --ds-gray-900: #666666;
   --ds-gray-1000: #171717;
   --ds-gray-alpha-100: rgba(0, 0, 0, 0.04);
   --ds-gray-alpha-200: rgba(0, 0, 0, 0.08);
+  --ds-gray-alpha-600: rgba(0, 0, 0, 0.34);
+  --ds-blue-100: hsl(212, 100%, 97%);
+  --ds-blue-200: hsl(210, 100%, 96%);
   --ds-blue-700: #0070f3;
+  --ds-blue-900: hsl(211, 100%, 42%);
   --geist-foreground: #000000;
   --geist-background: #ffffff;
   --geist-link-color: var(--ds-blue-700);
@@ -51,8 +57,9 @@
   --bg-elev: var(--ds-gray-100);
   --bg-overlay-hover: var(--ds-gray-alpha-100);
   --bg-header: var(--ds-background-100);
-  --fg: var(--ds-gray-1000);
+  --fg: var(--geist-foreground);
   --fg-muted: var(--ds-gray-900);
+  --fg-prose: var(--geist-foreground);
   --fg-subtle: var(--ds-gray-600);
   --border: var(--ds-gray-alpha-200);
   --border-strong: var(--ds-gray-300);
@@ -89,6 +96,10 @@
   --ds-gray-1000: #ededed;
   --ds-gray-alpha-100: rgba(255, 255, 255, 0.06);
   --ds-gray-alpha-200: rgba(255, 255, 255, 0.09);
+  --ds-gray-alpha-600: rgba(255, 255, 255, 0.34);
+  --ds-blue-100: hsl(216, 50%, 12%);
+  --ds-blue-200: hsl(214, 59%, 15%);
+  --ds-blue-900: hsl(210, 100%, 66%);
   --geist-foreground: #ededed;
   --geist-background: #000000;
   --geist-link-color: #3291ff;

--- a/design-system/vercel-docs-tokens.css
+++ b/design-system/vercel-docs-tokens.css
@@ -10,6 +10,7 @@
   --header-top-height: 64px;
   --header-sub-height: 42px;
   --header-height: calc(var(--header-top-height) + var(--header-sub-height));
+  --docs-toolbar-height: 55px;
   --docs-header-height: var(--header-height);
   --ds-page-width: 1400px;
 


### PR DESCRIPTION
## Summary

Matches two more Vercel docs patterns from reference screenshots:

- **Page title**: `h1` at **40px** Geist (was 32px)
- **Mobile toolbar**: sticky **55px** bar below header with **Menu** (sidebar drawer) and **On this page** (TOC dialog), white background, `px-6`

Sidebar toggle moved out of the top header into the docs toolbar on `<1024px`.

## Test plan

- [x] `apps/docs` build
- [x] `apps/dashboard` build
- [ ] Mobile viewport: toolbar sticks under header, Menu opens sidebar, On this page opens TOC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mobile toolbar for improved docs navigation with toggle between Menu and Table of Contents panels.
  * Introduced "On this page" (TOC) functionality on mobile devices, displaying when headings are available.

* **Style**
  * Enhanced h1 typography in docs with improved sizing and responsive adjustments.
  * Added responsive styling for mobile toolbar and TOC modal presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->