### PR TITLE
fix(docs): show current section in sidebar and consolidate header nav

### DIFF
--- a/apps/dashboard/src/routes/(docs)/docs/-components/docs-shell.tsx
+++ b/apps/dashboard/src/routes/(docs)/docs/-components/docs-shell.tsx
@@ -3,8 +3,9 @@ import { Link } from '@tanstack/react-router'
 
 import {
   type DocsHeading,
+  type DocsNavSection,
   docsHref,
-  docsNav,
+  findActiveDocsSection,
   resolveDocsBreadcrumb,
 } from '../-lib/docs'
 import { type ReactNode, useState } from 'react'
@@ -140,32 +141,50 @@ function DocsNavList({
   activeSlug: string
   compact?: boolean
 }) {
+  const section = findActiveDocsSection(activeSlug)
+
+  if (!section) {
+    return null
+  }
+
   return (
-    <nav className={cn('space-y-5', compact && 'space-y-4')}>
-      {docsNav.map((section) => (
-        <div key={section.title}>
-          <div className="docs-shell__nav-section mb-2 px-2">
-            {section.title}
-          </div>
-          <ul className="space-y-0.5">
-            {section.items.map((item) => {
-              const isActive = item.slug === activeSlug
-              return (
-                <li key={item.slug || 'index'}>
-                  <Link
-                    to={docsHref(item.slug) as never}
-                    data-active={isActive}
-                    className="docs-shell__nav-link block px-2 py-1.5 transition-colors"
-                  >
-                    {item.title}
-                  </Link>
-                </li>
-              )
-            })}
-          </ul>
-        </div>
-      ))}
+    <nav className={cn(compact && 'space-y-4')}>
+      <DocsNavSectionList section={section} activeSlug={activeSlug} />
     </nav>
+  )
+}
+
+function DocsNavSectionList({
+  section,
+  activeSlug,
+}: {
+  section: DocsNavSection
+  activeSlug: string
+}) {
+  const showHeading = section.items.length > 1
+
+  return (
+    <div>
+      {showHeading ? (
+        <div className="docs-shell__nav-section mb-2 px-2">{section.title}</div>
+      ) : null}
+      <ul className="space-y-0.5">
+        {section.items.map((item) => {
+          const isActive = item.slug === activeSlug
+          return (
+            <li key={item.slug || 'index'}>
+              <Link
+                to={docsHref(item.slug) as never}
+                data-active={isActive}
+                className="docs-shell__nav-link block px-2 py-1.5 transition-colors"
+              >
+                {item.title}
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
   )
 }
 

--- a/apps/dashboard/src/routes/(docs)/docs/-lib/docs.ts
+++ b/apps/dashboard/src/routes/(docs)/docs/-lib/docs.ts
@@ -24,20 +24,16 @@ export type DocsPage = {
   headings: DocsHeading[]
 }
 
+/** Sidebar groups — aligned with docs.chmonitor.dev nav.json. */
 export const docsNav: DocsNavSection[] = [
   {
-    title: 'chmonitor',
-    items: [
-      { title: 'Introduction', slug: '' },
-      { title: 'Features', slug: 'features' },
-      { title: 'FAQ', slug: 'faq' },
-    ],
+    title: 'Introduction',
+    items: [{ title: 'Introduction', slug: '' }],
   },
   {
     title: 'Getting Started',
     items: [
-      { title: 'Getting Started', slug: 'getting-started' },
-      { title: 'Local Development', slug: 'getting-started/local' },
+      { title: 'Overview', slug: 'getting-started' },
       {
         title: 'ClickHouse User & Grants',
         slug: 'getting-started/clickhouse-requirements',
@@ -46,118 +42,127 @@ export const docsNav: DocsNavSection[] = [
         title: 'Enable System Tables',
         slug: 'getting-started/clickhouse-enable-system-tables',
       },
+      { title: 'Local Development', slug: 'getting-started/local' },
     ],
   },
   {
-    // Each platform page is self-contained: install + every config category +
-    // auth + migration notes for that platform.
-    title: 'Install & Configure',
+    title: 'Deployment',
     items: [
-      { title: 'Choosing a Platform', slug: 'deploy' },
+      { title: 'Overview', slug: 'deploy' },
+      { title: 'Cloudflare Workers', slug: 'deploy/cloudflare' },
       { title: 'Docker', slug: 'deploy/docker' },
       { title: 'Kubernetes', slug: 'deploy/k8s' },
-      { title: 'Cloudflare Workers', slug: 'deploy/cloudflare' },
-      { title: 'Vercel', slug: 'deploy/vercel' },
-      { title: 'Self-Host (Node)', slug: 'deploy/self-host' },
       { title: 'Production Checklist', slug: 'deploy/production-checklist' },
+      { title: 'Self-host (Node / standalone)', slug: 'deploy/self-host' },
+      { title: 'Vercel', slug: 'deploy/vercel' },
     ],
   },
   {
-    // One page per supported auth method, plus an overview.
-    title: 'Authentication',
+    title: 'Features',
     items: [
-      { title: 'Overview', slug: 'authentication' },
-      { title: 'Public (no auth)', slug: 'authentication/public' },
-      { title: 'API Keys', slug: 'authentication/api-keys' },
-      { title: 'Clerk', slug: 'authentication/clerk' },
-      {
-        title: 'Cloudflare Access',
-        slug: 'authentication/cloudflare-access',
-      },
-      {
-        title: 'Trusted Header Proxy',
-        slug: 'authentication/trusted-header',
-      },
-    ],
-  },
-  {
-    // One templated page per feature group: what it does, permission, system
-    // tables, grants.
-    title: 'Feature Guides',
-    items: [
-      { title: 'Overview', slug: 'features/overview' },
-      { title: 'Query Monitoring', slug: 'features/queries' },
-      { title: 'Tables & Storage', slug: 'features/tables' },
-      { title: 'Data Explorer', slug: 'features/explorer' },
-      { title: 'Merges & Operations', slug: 'features/operations' },
-      { title: 'Clusters & Replication', slug: 'features/cluster' },
-      { title: 'Metrics & Profiler', slug: 'features/metrics' },
-      { title: 'Insights', slug: 'features/insights' },
-      { title: 'Health & Alerting', slug: 'features/health' },
-      { title: 'Security & Audit', slug: 'features/security' },
-      { title: 'Logs', slug: 'features/logs' },
-      { title: 'Settings', slug: 'features/settings' },
+      { title: 'Overview', slug: 'features' },
+      { title: 'Browser Connections', slug: 'features/browser-connections' },
+      { title: 'Cluster', slug: 'features/cluster' },
       { title: 'Dashboard', slug: 'features/dashboard' },
+      { title: 'Data Explorer', slug: 'features/explorer' },
+      { title: 'Health', slug: 'features/health' },
+      { title: 'Insights', slug: 'features/insights' },
+      { title: 'Logs', slug: 'features/logs' },
       { title: 'MCP Server', slug: 'features/mcp' },
+      { title: 'Metrics', slug: 'features/metrics' },
+      { title: 'Operations', slug: 'features/operations' },
+      { title: 'Overview', slug: 'features/overview' },
       { title: 'PeerDB', slug: 'features/peerdb' },
+      { title: 'Queries', slug: 'features/queries' },
+      { title: 'Security', slug: 'features/security' },
+      { title: 'Settings', slug: 'features/settings' },
+      { title: 'Tables', slug: 'features/tables' },
+    ],
+  },
+  {
+    title: 'Advanced',
+    items: [
       {
-        title: 'Browser Connections',
-        slug: 'features/browser-connections',
+        title: 'Agent Conversation Storage',
+        slug: 'advanced/agent-conversation-storage',
       },
+      { title: 'Custom Name', slug: 'advanced/custom-name' },
+      { title: 'Feature Permissions', slug: 'advanced/feature-permissions' },
+      { title: 'Multiple Hosts', slug: 'advanced/multiple-hosts' },
+      { title: 'PeerDB Monitoring', slug: 'advanced/peerdb-monitoring' },
+      { title: 'Query History', slug: 'advanced/queries-history' },
+      { title: 'Self-Tracking', slug: 'advanced/self-tracking' },
+    ],
+  },
+  {
+    title: 'Reference',
+    items: [
+      { title: 'Configuration', slug: 'reference/configuration' },
       {
-        title: 'User Connections',
-        slug: 'features/user-connections',
+        title: 'Environment Variables',
+        slug: 'reference/environment-variables',
       },
+      { title: 'MCP Server', slug: 'reference/mcp-server' },
     ],
   },
   {
     title: 'AI Agent',
     items: [
       { title: 'Overview', slug: 'ai-agent' },
-      { title: 'Configuration', slug: 'ai-agent/configuration' },
-      { title: 'Capabilities', slug: 'ai-agent/capabilities' },
+      { title: 'Agent capabilities', slug: 'ai-agent/capabilities' },
+      { title: 'Configure the AI Agent', slug: 'ai-agent/configuration' },
+      { title: 'Conversation history', slug: 'ai-agent/conversation-history' },
       {
-        title: 'Conversation History',
-        slug: 'ai-agent/conversation-history',
-      },
-      {
-        title: 'Conversation Backends',
+        title: 'Conversation store backends',
         slug: 'ai-agent/conversation-history/backends',
       },
     ],
   },
   {
-    title: 'Configuration',
+    title: 'Authentication',
     items: [
-      { title: 'Configuration Overview', slug: 'reference/configuration' },
+      { title: 'Overview', slug: 'authentication' },
+      { title: 'API keys (chm_ Bearer)', slug: 'authentication/api-keys' },
+      { title: 'Clerk', slug: 'authentication/clerk' },
+      { title: 'Public (no auth)', slug: 'authentication/public' },
       {
-        title: 'Environment Variables',
-        slug: 'reference/environment-variables',
+        title: 'Reverse proxy: Cloudflare Access',
+        slug: 'authentication/cloudflare-access',
       },
-      { title: 'Feature Permissions', slug: 'advanced/feature-permissions' },
-      { title: 'Multiple Hosts', slug: 'advanced/multiple-hosts' },
-      { title: 'Custom Host Name', slug: 'advanced/custom-name' },
-      { title: 'Queries History', slug: 'advanced/queries-history' },
-      { title: 'Self-Tracking', slug: 'advanced/self-tracking' },
-      { title: 'PeerDB Setup', slug: 'advanced/peerdb-monitoring' },
-      { title: 'Settings (in-app)', slug: 'settings' },
+      {
+        title: 'Reverse proxy: trusted header',
+        slug: 'authentication/trusted-header',
+      },
     ],
   },
   {
-    title: 'Reference',
-    items: [{ title: 'MCP Server', slug: 'reference/mcp-server' }],
-  },
-  {
-    // One "Migrate to vX.Y" page per breaking release, newest first.
     title: 'Migrating',
     items: [{ title: 'Migrate to v0.3', slug: 'migrating/v0-3' }],
   },
   {
-    // One "What's New in vX.Y" page per release, newest first.
     title: 'Releases',
-    items: [{ title: "What's New in v0.3", slug: 'releases/v0-3' }],
+    items: [{ title: "v0.3 — What's New", slug: 'releases/v0-3' }],
+  },
+  {
+    title: 'More',
+    items: [
+      { title: 'FAQ', slug: 'faq' },
+      { title: 'Settings', slug: 'settings' },
+    ],
   },
 ]
+
+export function findActiveDocsSection(slug: string): DocsNavSection | null {
+  const normalizedSlug = normalizeSlug(slug)
+
+  for (const section of docsNav) {
+    if (section.items.some((item) => item.slug === normalizedSlug)) {
+      return section
+    }
+  }
+
+  return docsNav[0] ?? null
+}
 
 export function docsHref(slug: string) {
   return slug ? `/docs/${slug}` : '/docs'
@@ -165,12 +170,11 @@ export function docsHref(slug: string) {
 
 export function resolveDocsBreadcrumb(slug: string, pageTitle: string) {
   const normalizedSlug = normalizeSlug(slug)
+  const section = findActiveDocsSection(normalizedSlug)
+  const item = section?.items.find((entry) => entry.slug === normalizedSlug)
 
-  for (const section of docsNav) {
-    const item = section.items.find((entry) => entry.slug === normalizedSlug)
-    if (item) {
-      return `${section.title} / ${item.title}`
-    }
+  if (section && item) {
+    return `${section.title} / ${item.title}`
   }
 
   return pageTitle

--- a/apps/docs/src/components/HeaderMobileMenu.astro
+++ b/apps/docs/src/components/HeaderMobileMenu.astro
@@ -1,6 +1,10 @@
 ---
 import navData from '../generated/nav.json'
-import { isGroupActive, toHeaderCategories, type NavGroup } from '../lib/header-nav'
+import {
+  isCategoryActive,
+  toHeaderCategories,
+  type NavGroup,
+} from '../lib/header-nav'
 import { resolveNavIcon } from '../lib/nav-icons'
 import NavIcon from './NavIcon.astro'
 
@@ -26,8 +30,7 @@ const categories = toHeaderCategories(groups)
   <nav class="mobile-nav-modal__nav">
     {
       categories.map((category) => {
-        const group = groups.find((g) => g.label === category.label)
-        const active = group ? isGroupActive(group, currentPath) : false
+        const active = isCategoryActive(category, currentPath)
 
         return (
           <section class={`mobile-nav-section${active ? ' is-active' : ''}`}>
@@ -38,18 +41,34 @@ const categories = toHeaderCategories(groups)
               category.items.length > 1 && (
                 <ul class="mobile-nav-section__items">
                   {
-                    category.items.map((item) => (
-                      <li>
-                        <a
-                          class="mobile-nav-section__link"
-                          href={item.link}
-                          aria-current={item.link === currentPath ? 'page' : undefined}
-                        >
-                          <NavIcon name={resolveNavIcon(item.link)} />
-                          <span>{item.label}</span>
-                        </a>
-                      </li>
-                    ))
+                    category.sections.length > 1
+                      ? category.sections.flatMap((section) => [
+                          <li class="mobile-nav-section__subheading">{section.label}</li>,
+                          ...section.items.map((item) => (
+                            <li>
+                              <a
+                                class="mobile-nav-section__link"
+                                href={item.link}
+                                aria-current={item.link === currentPath ? 'page' : undefined}
+                              >
+                                <NavIcon name={resolveNavIcon(item.link)} />
+                                <span>{item.label}</span>
+                              </a>
+                            </li>
+                          )),
+                        ])
+                      : category.items.map((item) => (
+                          <li>
+                            <a
+                              class="mobile-nav-section__link"
+                              href={item.link}
+                              aria-current={item.link === currentPath ? 'page' : undefined}
+                            >
+                              <NavIcon name={resolveNavIcon(item.link)} />
+                              <span>{item.label}</span>
+                            </a>
+                          </li>
+                        ))
                   }
                 </ul>
               )

--- a/apps/docs/src/components/HeaderNav.astro
+++ b/apps/docs/src/components/HeaderNav.astro
@@ -1,6 +1,10 @@
 ---
 import navData from '../generated/nav.json'
-import { isGroupActive, toHeaderCategories, type NavGroup } from '../lib/header-nav'
+import {
+  isCategoryActive,
+  toHeaderCategories,
+  type NavGroup,
+} from '../lib/header-nav'
 import { resolveNavIcon } from '../lib/nav-icons'
 import NavIcon from './NavIcon.astro'
 
@@ -17,32 +21,64 @@ const categories = toHeaderCategories(groups)
 <nav class="header__nav" aria-label="Documentation categories">
   {
     categories.map((category) => {
-      const group = groups.find((g) => g.label === category.label)
-      const active = group ? isGroupActive(group, currentPath) : false
+      const active = isCategoryActive(category, currentPath)
       const hasDropdown = category.items.length > 1
+      const multiSection = category.sections.length > 1
 
       return hasDropdown ? (
         <div class={`header-nav__item${active ? ' is-active' : ''}`}>
-          <a class="header-nav__trigger" href={category.href} aria-current={active ? 'page' : undefined}>
+          <a
+            class="header-nav__trigger"
+            href={category.href}
+            aria-current={active ? 'page' : undefined}
+          >
             <span>{category.label}</span>
-            <svg class="header-nav__chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <svg
+              class="header-nav__chevron"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
               <path d="m6 9 6 6 6-6" />
             </svg>
           </a>
           <div class="header-nav__dropdown" role="menu">
             <div class="header-nav__dropdown-inner">
               {
-                category.items.map((item) => (
-                  <a
-                    class="header-nav__dropdown-link"
-                    href={item.link}
-                    role="menuitem"
-                    aria-current={item.link === currentPath ? 'page' : undefined}
-                  >
-                    <NavIcon name={resolveNavIcon(item.link)} />
-                    <span>{item.label}</span>
-                  </a>
-                ))
+                multiSection
+                  ? category.sections.map((section) => (
+                      <div class="header-nav__dropdown-section">
+                        <div class="header-nav__dropdown-heading">{section.label}</div>
+                        {section.items.map((item) => (
+                          <a
+                            class="header-nav__dropdown-link"
+                            href={item.link}
+                            role="menuitem"
+                            aria-current={item.link === currentPath ? 'page' : undefined}
+                          >
+                            <NavIcon name={resolveNavIcon(item.link)} />
+                            <span>{item.label}</span>
+                          </a>
+                        ))}
+                      </div>
+                    ))
+                  : category.items.map((item) => (
+                      <a
+                        class="header-nav__dropdown-link"
+                        href={item.link}
+                        role="menuitem"
+                        aria-current={item.link === currentPath ? 'page' : undefined}
+                      >
+                        <NavIcon name={resolveNavIcon(item.link)} />
+                        <span>{item.label}</span>
+                      </a>
+                    ))
               }
             </div>
           </div>

--- a/apps/docs/src/components/Sidebar.astro
+++ b/apps/docs/src/components/Sidebar.astro
@@ -1,46 +1,35 @@
 ---
 import navData from '../generated/nav.json'
+import { findActiveGroup, getSidebarItems, type NavGroup } from '../lib/header-nav'
 
 interface Props {
   version: string
   currentSlug: string
 }
 const { version, currentSlug } = Astro.props
-const groups = (navData as Record<string, any[]>)[version] ?? []
-const current = `/${currentSlug}`
-const isActiveGroup = (group: any) => group.items?.some((it: any) => it.link === current)
+const groups = (navData as Record<string, NavGroup[]>)[version] ?? []
+const currentPath = currentSlug ? `/${currentSlug}` : '/'
+const activeGroup = findActiveGroup(groups, currentPath)
+const sidebarItems = getSidebarItems(activeGroup)
 ---
 
 <nav class="sidebar" aria-label="Documentation navigation">
   {
-    groups.map((group) =>
-      group.items ? (
-        <details class="nav-group" open={isActiveGroup(group)}>
-          <summary class="nav-group__label">{group.label}</summary>
-          <div class="nav-group__items">
-            {group.items.map((item: any) => (
-              <a class="nav-link" href={item.link} aria-current={item.link === current ? 'page' : undefined}>
-                <span class="nav-link__label">{item.label}</span>
-              </a>
-            ))}
-          </div>
-        </details>
-      ) : (
-        <div class="nav-group">
-          <a class="nav-link" href={group.link} aria-current={group.link === current ? 'page' : undefined}>
-            <span class="nav-link__label">{group.label}</span>
-          </a>
-        </div>
-      )
+    activeGroup && sidebarItems.length > 1 && (
+      <div class="sidebar__heading">{activeGroup.label}</div>
     )
   }
+  <div class="nav-group__items">
+    {
+      sidebarItems.map((item) => (
+        <a
+          class="nav-link"
+          href={item.link}
+          aria-current={item.link === currentPath ? 'page' : undefined}
+        >
+          <span class="nav-link__label">{item.label}</span>
+        </a>
+      ))
+    }
+  </div>
 </nav>
-
-<script>
-  const all = Array.from(document.querySelectorAll<HTMLDetailsElement>('details.nav-group'))
-  for (const d of all) {
-    d.addEventListener('toggle', () => {
-      if (d.open) for (const o of all) if (o !== d) o.open = false
-    })
-  }
-</script>

--- a/apps/docs/src/lib/docs-breadcrumb.ts
+++ b/apps/docs/src/lib/docs-breadcrumb.ts
@@ -1,5 +1,4 @@
-type NavItem = { label: string; link: string }
-type NavGroup = { label: string; link?: string; items?: NavItem[] }
+import { findActiveGroup, getSidebarItems, type NavGroup } from './header-nav'
 
 export function resolveDocsBreadcrumb(
   groups: NavGroup[],
@@ -7,19 +6,16 @@ export function resolveDocsBreadcrumb(
   pageTitle: string
 ): string {
   const current = currentSlug ? `/${currentSlug}` : '/'
+  const activeGroup = findActiveGroup(groups, current)
+  const items = getSidebarItems(activeGroup)
+  const activeItem = items.find((entry) => entry.link === current)
 
-  for (const group of groups) {
-    if (group.items) {
-      const item = group.items.find((entry) => entry.link === current)
-      if (item) {
-        return `${group.label} / ${item.label}`
-      }
-      continue
-    }
+  if (activeGroup && activeItem) {
+    return `${activeGroup.label} / ${activeItem.label}`
+  }
 
-    if (group.link === current) {
-      return group.label
-    }
+  if (activeGroup?.link === current) {
+    return activeGroup.label
   }
 
   return pageTitle

--- a/apps/docs/src/lib/header-nav.ts
+++ b/apps/docs/src/lib/header-nav.ts
@@ -11,14 +11,30 @@ export interface NavGroup {
   items?: NavItem[]
 }
 
+export interface HeaderCategorySection {
+  label: string
+  items: NavItem[]
+}
+
 export interface HeaderCategory {
   label: string
   href: string
   items: NavItem[]
+  sections: HeaderCategorySection[]
 }
 
-/** Groups omitted from the top menu (still in the left sidebar). */
-export const HEADER_NAV_SKIP = new Set(['More'])
+/** Top menu: fewer categories, each maps to one or more sidebar groups. */
+export const HEADER_CATEGORIES: { label: string; groups: string[] }[] = [
+  { label: 'Introduction', groups: ['Introduction', 'More'] },
+  { label: 'Getting Started', groups: ['Getting Started'] },
+  { label: 'Deploy', groups: ['Deployment', 'Authentication'] },
+  { label: 'Features', groups: ['Features'] },
+  { label: 'AI Agent', groups: ['AI Agent'] },
+  {
+    label: 'Reference',
+    groups: ['Reference', 'Advanced', 'Migrating', 'Releases'],
+  },
+]
 
 export function groupHref(group: NavGroup): string {
   if (group.link) return group.link
@@ -31,12 +47,70 @@ export function isGroupActive(group: NavGroup, currentPath: string): boolean {
   return group.items?.some((it) => it.link === currentPath) ?? false
 }
 
+export function findActiveGroup(
+  groups: NavGroup[],
+  currentPath: string
+): NavGroup | null {
+  for (const group of groups) {
+    if (isGroupActive(group, currentPath)) return group
+  }
+  return groups[0] ?? null
+}
+
+export function getSidebarItems(group: NavGroup | null): NavItem[] {
+  if (!group) return []
+  if (group.items?.length) return group.items
+  if (group.link) return [{ label: group.label, link: group.link }]
+  return []
+}
+
+function sectionForGroup(group: NavGroup): HeaderCategorySection {
+  if (group.items?.length) {
+    return { label: group.label, items: group.items }
+  }
+  if (group.link) {
+    return {
+      label: group.label,
+      items: [{ label: group.label, link: group.link }],
+    }
+  }
+  return { label: group.label, items: [] }
+}
+
 export function toHeaderCategories(groups: NavGroup[]): HeaderCategory[] {
-  return groups
-    .filter((g) => !HEADER_NAV_SKIP.has(g.label))
-    .map((g) => ({
-      label: g.label,
-      href: groupHref(g),
-      items: g.items ?? (g.link ? [{ label: g.label, link: g.link }] : []),
-    }))
+  const byLabel = new Map(groups.map((g) => [g.label, g]))
+
+  return HEADER_CATEGORIES.map(({ label, groups: groupLabels }) => {
+    const sections: HeaderCategorySection[] = []
+    for (const groupLabel of groupLabels) {
+      const group = byLabel.get(groupLabel)
+      if (!group) continue
+      const section = sectionForGroup(group)
+      if (section.items.length) sections.push(section)
+    }
+
+    const items = sections.flatMap((section) => section.items)
+    const href = items[0]?.link ?? '/'
+
+    return { label, href, items, sections }
+  }).filter((category) => category.items.length > 0)
+}
+
+export function isCategoryActive(
+  category: HeaderCategory,
+  currentPath: string
+): boolean {
+  return category.items.some((item) => item.link === currentPath)
+}
+
+export function findActiveHeaderCategory(
+  groups: NavGroup[],
+  currentPath: string
+): HeaderCategory | null {
+  const categories = toHeaderCategories(groups)
+  return (
+    categories.find((cat) => isCategoryActive(cat, currentPath)) ??
+    categories[0] ??
+    null
+  )
 }

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -277,6 +277,19 @@ img {
 .header-nav__dropdown-link[aria-current='page'] .nav-link__icon {
   opacity: 1;
 }
+.header-nav__dropdown-section + .header-nav__dropdown-section {
+  margin-top: 0.35rem;
+  padding-top: 0.35rem;
+  border-top: 1px solid var(--ds-gray-200);
+}
+.header-nav__dropdown-heading {
+  padding: 0.25rem 0.5rem 0.125rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg-subtle);
+}
 .header__actions {
   display: flex;
   align-items: center;
@@ -360,6 +373,15 @@ img {
 .mobile-nav-section__link[aria-current='page'] {
   background: var(--bg-overlay-hover);
   color: var(--fg);
+}
+.mobile-nav-section__subheading {
+  padding: 0.35rem 0.75rem 0.125rem 1.25rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg-subtle);
+  list-style: none;
 }
 .icon-btn {
   display: inline-flex;
@@ -664,6 +686,13 @@ img {
 }
 
 /* ── Left sidebar nav ───────────────────────────────────────────────── */
+.sidebar__heading {
+  padding: 0.5rem 0.5rem 0.375rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--fg);
+}
 .nav-group {
   margin-bottom: 0;
   padding-top: 0.75rem;


### PR DESCRIPTION
## Summary

- Left sidebar shows only pages in the **active section** (e.g. Getting Started, Features), not the full site tree
- Top header nav consolidated from many groups into **6 categories** with merged dropdowns:
  - Introduction (Introduction + More)
  - Getting Started
  - Deploy (Deployment + Authentication)
  - Features
  - AI Agent
  - Reference (Reference + Advanced + Migrating + Releases)
- Mobile category menu uses the same consolidated structure with section subheadings
- Embedded dashboard docs (`/docs`) aligned: sidebar filtered to active section, nav groups match docs.chmonitor.dev

## Test plan

- [x] `bun run build` in `apps/docs`
- [x] `bun run build` in `apps/dashboard`
- [ ] Verify sidebar on `/getting-started/local` shows only Getting Started pages
- [ ] Verify header shows 6 top-level items with merged dropdowns on Deploy / Reference

Co-Authored-By: duyetbot <bot@duyet.net>