### PR TITLE
feat(docs): polish nav mega-menu and mobile dialog

### DIFF
--- a/apps/dashboard/src/routes/(docs)/docs/-components/docs-shell.tsx
+++ b/apps/dashboard/src/routes/(docs)/docs/-components/docs-shell.tsx
@@ -176,7 +176,7 @@ function DocsNavSectionList({
               <Link
                 to={docsHref(item.slug) as never}
                 data-active={isActive}
-                className="docs-shell__nav-link block px-2 py-1.5 transition-colors"
+                className="docs-shell__nav-link block px-2.5 py-[0.4375rem] transition-colors"
               >
                 {item.title}
               </Link>

--- a/apps/dashboard/src/routes/(docs)/docs/docs-theme.css
+++ b/apps/dashboard/src/routes/(docs)/docs/docs-theme.css
@@ -39,7 +39,12 @@
   color: var(--ds-gray-900);
   font-size: 0.8125rem;
   font-weight: 500;
+  letter-spacing: -0.012em;
   line-height: 1.3;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 .docs-vercel-theme .docs-shell__nav-link:hover {
@@ -48,8 +53,10 @@
 }
 
 .docs-vercel-theme .docs-shell__nav-link[data-active='true'] {
-  background: var(--ds-gray-200);
+  background: var(--ds-gray-alpha-100);
   color: var(--ds-gray-1000);
+  font-weight: 600;
+  box-shadow: inset 0 0 0 1px var(--ds-gray-200);
 }
 
 .docs-vercel-theme .docs-shell__toc-title {
@@ -68,8 +75,9 @@
 
 .docs-vercel-theme .docs-shell__toc-link:hover,
 .docs-vercel-theme .docs-shell__toc-link[data-active='true'] {
-  background: var(--ds-gray-200);
+  background: var(--ds-gray-alpha-100);
   color: var(--ds-gray-1000);
+  box-shadow: inset 0 0 0 1px var(--ds-gray-200);
 }
 
 .docs-vercel-theme .docs-markdown {
@@ -180,12 +188,18 @@
 
 .docs-vercel-theme .docs-mobile-panel {
   margin-bottom: 1rem;
-  max-height: calc(100vh - 10rem);
+  max-height: calc(100dvh - 10rem);
   overflow-y: auto;
   border: 1px solid var(--ds-gray-300);
-  border-radius: var(--geist-radius);
+  border-radius: 10px;
   background: var(--ds-background-100);
-  padding: 0.75rem;
+  padding: 0.625rem;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.docs-vercel-theme .docs-mobile-panel::-webkit-scrollbar {
+  display: none;
 }
 
 .docs-vercel-theme .docs-markdown h2 {

--- a/apps/docs/src/components/Header.astro
+++ b/apps/docs/src/components/Header.astro
@@ -112,6 +112,10 @@ const { version, subpath, currentSlug } = Astro.props
       mobileNavModal.close()
     } else {
       mobileNavModal.showModal()
+      requestAnimationFrame(() => {
+        const searchInput = mobileNavModal.querySelector<HTMLInputElement>('[data-mobile-nav-search]')
+        searchInput?.focus()
+      })
     }
     mobileNavToggle.setAttribute('aria-expanded', mobileNavModal.open ? 'true' : 'false')
   })

--- a/apps/docs/src/components/HeaderMobileMenu.astro
+++ b/apps/docs/src/components/HeaderMobileMenu.astro
@@ -27,40 +27,50 @@ const categories = toHeaderCategories(groups)
       </svg>
     </button>
   </div>
-  <nav class="mobile-nav-modal__nav">
+  <div class="mobile-nav-modal__search">
+    <svg class="mobile-nav-modal__search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <circle cx="11" cy="11" r="8"></circle>
+      <path d="m21 21-4.3-4.3"></path>
+    </svg>
+    <input
+      class="mobile-nav-modal__search-input"
+      type="search"
+      placeholder="Search docs…"
+      autocomplete="off"
+      spellcheck="false"
+      data-mobile-nav-search
+    />
+    <kbd class="mobile-nav-modal__search-kbd" aria-hidden="true">Esc</kbd>
+  </div>
+  <nav class="mobile-nav-modal__nav" aria-label="Documentation categories">
     {
       categories.map((category) => {
         const active = isCategoryActive(category, currentPath)
+        const hasChildren = category.items.length > 1
 
-        return (
-          <section class={`mobile-nav-section${active ? ' is-active' : ''}`}>
-            <a class="mobile-nav-section__label" href={category.href}>
-              {category.label}
-            </a>
-            {
-              category.items.length > 1 && (
-                <ul class="mobile-nav-section__items">
-                  {
-                    category.sections.length > 1
-                      ? category.sections.flatMap((section) => [
-                          <li class="mobile-nav-section__subheading">{section.label}</li>,
-                          ...section.items.map((item) => (
-                            <li>
-                              <a
-                                class="mobile-nav-section__link"
-                                href={item.link}
-                                aria-current={item.link === currentPath ? 'page' : undefined}
-                              >
-                                <NavIcon name={resolveNavIcon(item.link)} />
-                                <span>{item.label}</span>
-                              </a>
-                            </li>
-                          )),
-                        ])
-                      : category.items.map((item) => (
-                          <li>
+        return hasChildren ? (
+          <details
+            class="mobile-nav-accordion"
+            data-mobile-nav-category
+            data-default-open={active ? 'true' : 'false'}
+            open={active ? true : undefined}
+          >
+            <summary class="mobile-nav-accordion__summary">
+              <span class="mobile-nav-accordion__label">{category.label}</span>
+              <svg class="mobile-nav-accordion__chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="m6 9 6 6 6-6"></path>
+              </svg>
+            </summary>
+            <div class="mobile-nav-accordion__panel">
+              <ul class="mobile-nav-accordion__items">
+                {
+                  category.sections.length > 1
+                    ? category.sections.flatMap((section) => [
+                        <li class="mobile-nav-accordion__subheading">{section.label}</li>,
+                        ...section.items.map((item) => (
+                          <li data-mobile-nav-item data-mobile-nav-label={item.label.toLowerCase()}>
                             <a
-                              class="mobile-nav-section__link"
+                              class="mobile-nav-accordion__link"
                               href={item.link}
                               aria-current={item.link === currentPath ? 'page' : undefined}
                             >
@@ -68,12 +78,33 @@ const categories = toHeaderCategories(groups)
                               <span>{item.label}</span>
                             </a>
                           </li>
-                        ))
-                  }
-                </ul>
-              )
-            }
-          </section>
+                        )),
+                      ])
+                    : category.items.map((item) => (
+                        <li data-mobile-nav-item data-mobile-nav-label={item.label.toLowerCase()}>
+                          <a
+                            class="mobile-nav-accordion__link"
+                            href={item.link}
+                            aria-current={item.link === currentPath ? 'page' : undefined}
+                          >
+                            <NavIcon name={resolveNavIcon(item.link)} />
+                            <span>{item.label}</span>
+                          </a>
+                        </li>
+                      ))
+                }
+              </ul>
+            </div>
+          </details>
+        ) : (
+          <a
+            class="mobile-nav-accordion__solo"
+            href={category.href}
+            aria-current={active ? 'page' : undefined}
+          >
+            <NavIcon name={resolveNavIcon(category.href)} />
+            <span>{category.label}</span>
+          </a>
         )
       })
     }
@@ -81,10 +112,77 @@ const categories = toHeaderCategories(groups)
 </dialog>
 
 <script>
+  const modal = document.getElementById('mobile-nav-modal') as HTMLDialogElement | null
+  const searchInput = document.querySelector<HTMLInputElement>('[data-mobile-nav-search]')
+
   for (const btn of document.querySelectorAll('[data-close-mobile-nav]')) {
-    btn.addEventListener('click', () => {
-      const modal = document.getElementById('mobile-nav-modal') as HTMLDialogElement | null
+    btn.addEventListener('click', () => modal?.close())
+  }
+
+  searchInput?.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
       modal?.close()
-    })
+    }
+  })
+
+  const resetMobileNavFilter = () => {
+    for (const category of document.querySelectorAll<HTMLDetailsElement>('[data-mobile-nav-category]')) {
+      category.hidden = false
+      category.open = category.dataset.defaultOpen === 'true'
+      for (const item of category.querySelectorAll<HTMLElement>('[data-mobile-nav-item]')) {
+        item.hidden = false
+      }
+      for (const heading of category.querySelectorAll<HTMLElement>('.mobile-nav-accordion__subheading')) {
+        heading.hidden = false
+      }
+    }
+  }
+
+  searchInput?.addEventListener('input', () => {
+    const query = searchInput.value.trim().toLowerCase()
+    if (!query) {
+      resetMobileNavFilter()
+      return
+    }
+
+    for (const category of document.querySelectorAll<HTMLDetailsElement>('[data-mobile-nav-category]')) {
+      const items = category.querySelectorAll<HTMLElement>('[data-mobile-nav-item]')
+      let visible = 0
+
+      for (const item of items) {
+        const label = item.dataset.mobileNavLabel ?? ''
+        const match = label.includes(query)
+        item.hidden = !match
+        if (match) visible++
+      }
+
+      for (const heading of category.querySelectorAll<HTMLElement>('.mobile-nav-accordion__subheading')) {
+        let sectionVisible = false
+        let sibling = heading.nextElementSibling
+        while (sibling && !sibling.classList.contains('mobile-nav-accordion__subheading')) {
+          if (sibling instanceof HTMLElement && sibling.matches('[data-mobile-nav-item]') && !sibling.hidden) {
+            sectionVisible = true
+            break
+          }
+          sibling = sibling.nextElementSibling
+        }
+        heading.hidden = !sectionVisible
+      }
+
+      category.open = visible > 0
+      category.hidden = visible === 0
+    }
+  })
+
+  modal?.addEventListener('close', () => {
+    if (searchInput) searchInput.value = ''
+    resetMobileNavFilter()
+  })
+
+  for (const link of document.querySelectorAll<HTMLAnchorElement>(
+    '.mobile-nav-accordion__link, .mobile-nav-accordion__solo'
+  )) {
+    link.addEventListener('click', () => modal?.close())
   }
 </script>

--- a/apps/docs/src/components/HeaderNav.astro
+++ b/apps/docs/src/components/HeaderNav.astro
@@ -5,8 +5,9 @@ import {
   toHeaderCategories,
   type NavGroup,
 } from '../lib/header-nav'
+import { resolveNavDescription } from '../lib/nav-meta'
 import { resolveNavIcon } from '../lib/nav-icons'
-import NavIcon from './NavIcon.astro'
+import NavDropdownCard from './NavDropdownCard.astro'
 
 interface Props {
   version: string
@@ -24,6 +25,7 @@ const categories = toHeaderCategories(groups)
       const active = isCategoryActive(category, currentPath)
       const hasDropdown = category.items.length > 1
       const multiSection = category.sections.length > 1
+      let cardIndex = 0
 
       return hasDropdown ? (
         <div class={`header-nav__item${active ? ' is-active' : ''}`}>
@@ -49,36 +51,46 @@ const categories = toHeaderCategories(groups)
             </svg>
           </a>
           <div class="header-nav__dropdown" role="menu">
-            <div class="header-nav__dropdown-inner">
+            <div
+              class:list={[
+                'header-nav__dropdown-inner',
+                multiSection && 'header-nav__dropdown-inner--columns',
+                !multiSection && category.items.length > 4 && 'header-nav__dropdown-inner--grid',
+              ]}
+            >
               {
                 multiSection
                   ? category.sections.map((section) => (
-                      <div class="header-nav__dropdown-section">
+                      <div class="header-nav__dropdown-column">
                         <div class="header-nav__dropdown-heading">{section.label}</div>
-                        {section.items.map((item) => (
-                          <a
-                            class="header-nav__dropdown-link"
-                            href={item.link}
-                            role="menuitem"
-                            aria-current={item.link === currentPath ? 'page' : undefined}
-                          >
-                            <NavIcon name={resolveNavIcon(item.link)} />
-                            <span>{item.label}</span>
-                          </a>
-                        ))}
+                        {section.items.map((item) => {
+                          const index = cardIndex++
+                          return (
+                            <NavDropdownCard
+                              href={item.link}
+                              label={item.label}
+                              description={resolveNavDescription(item.link, item.label)}
+                              icon={resolveNavIcon(item.link)}
+                              current={item.link === currentPath}
+                              index={index}
+                            />
+                          )
+                        })}
                       </div>
                     ))
-                  : category.items.map((item) => (
-                      <a
-                        class="header-nav__dropdown-link"
-                        href={item.link}
-                        role="menuitem"
-                        aria-current={item.link === currentPath ? 'page' : undefined}
-                      >
-                        <NavIcon name={resolveNavIcon(item.link)} />
-                        <span>{item.label}</span>
-                      </a>
-                    ))
+                  : category.items.map((item) => {
+                      const index = cardIndex++
+                      return (
+                        <NavDropdownCard
+                          href={item.link}
+                          label={item.label}
+                          description={resolveNavDescription(item.link, item.label)}
+                          icon={resolveNavIcon(item.link)}
+                          current={item.link === currentPath}
+                          index={index}
+                        />
+                      )
+                    })
               }
             </div>
           </div>

--- a/apps/docs/src/components/NavDropdownCard.astro
+++ b/apps/docs/src/components/NavDropdownCard.astro
@@ -1,0 +1,30 @@
+---
+import type { NavIconName } from '../lib/nav-icons'
+import NavIcon from './NavIcon.astro'
+
+interface Props {
+  href: string
+  label: string
+  description: string
+  icon: NavIconName
+  current?: boolean
+  index?: number
+}
+const { href, label, description, icon, current = false, index = 0 } = Astro.props
+---
+
+<a
+  class="header-nav__dropdown-card"
+  href={href}
+  role="menuitem"
+  aria-current={current ? 'page' : undefined}
+  style={`--nav-card-delay: ${index * 28}ms`}
+>
+  <span class="nav-link__icon-box" aria-hidden="true">
+    <NavIcon name={icon} />
+  </span>
+  <span class="header-nav__dropdown-card-text">
+    <span class="header-nav__dropdown-card-title">{label}</span>
+    <span class="header-nav__dropdown-card-desc">{description}</span>
+  </span>
+</a>

--- a/apps/docs/src/components/Sidebar.astro
+++ b/apps/docs/src/components/Sidebar.astro
@@ -1,6 +1,8 @@
 ---
 import navData from '../generated/nav.json'
 import { findActiveGroup, getSidebarItems, type NavGroup } from '../lib/header-nav'
+import { resolveNavIcon } from '../lib/nav-icons'
+import NavIcon from './NavIcon.astro'
 
 interface Props {
   version: string
@@ -27,6 +29,7 @@ const sidebarItems = getSidebarItems(activeGroup)
           href={item.link}
           aria-current={item.link === currentPath ? 'page' : undefined}
         >
+          <NavIcon name={resolveNavIcon(item.link)} />
           <span class="nav-link__label">{item.label}</span>
         </a>
       ))

--- a/apps/docs/src/lib/nav-meta.ts
+++ b/apps/docs/src/lib/nav-meta.ts
@@ -1,0 +1,88 @@
+import { linkToSubpath } from './nav-icons'
+
+const PAGE_DESCRIPTIONS: Record<string, string> = {
+  '': 'What ClickHouse Monitor is and how to use these docs',
+  'getting-started': 'Install, connect, and run your first dashboard',
+  'getting-started/clickhouse-requirements':
+    'Users, grants, and permissions for monitoring',
+  'getting-started/clickhouse-enable-system-tables':
+    'Turn on system tables the dashboard reads',
+  'getting-started/local': 'Run the dashboard locally with Bun or Docker',
+  deploy: 'Choose where and how to run ClickHouse Monitor',
+  'deploy/cloudflare': 'Deploy to Cloudflare Workers at the edge',
+  'deploy/docker': 'Run with Docker Compose or a container image',
+  'deploy/k8s': 'Helm chart and Kubernetes deployment patterns',
+  'deploy/production-checklist': 'Hardening checklist before going live',
+  'deploy/self-host': 'Node standalone or reverse-proxy hosting',
+  'deploy/vercel': 'Legacy Vercel deployment notes',
+  features: 'Dashboard pages, charts, and operational views',
+  'features/browser-connections':
+    'Connect from the browser without a backend proxy',
+  'features/cluster': 'Cluster topology, replicas, and node health',
+  'features/dashboard': 'Custom dashboards and saved layouts',
+  'features/explorer': 'Browse databases, tables, and dependencies',
+  'features/health': 'Cluster health signals and alerts',
+  'features/insights': 'Automated insights from system tables',
+  'features/logs': 'Query, error, and backup log views',
+  'features/mcp': 'Expose monitoring tools over MCP',
+  'features/metrics': 'Time-series metrics and resource usage',
+  'features/operations': 'Merges, mutations, and background work',
+  'features/overview': 'Connections, queries, merges at a glance',
+  'features/peerdb': 'PeerDB replication monitoring',
+  'features/queries': 'Running queries and query history',
+  'features/security': 'Users, grants, and access policies',
+  'features/settings': 'Dashboard settings and preferences',
+  'features/tables': 'Table sizes, parts, and storage breakdown',
+  'advanced/agent-conversation-storage': 'Persist AI agent threads and history',
+  'advanced/custom-name': 'Friendly names for multiple ClickHouse hosts',
+  'advanced/feature-permissions': 'Gate dashboard features by role',
+  'advanced/multiple-hosts': 'Monitor several clusters from one install',
+  'advanced/peerdb-monitoring': 'Deep PeerDB lag and pipeline metrics',
+  'advanced/queries-history': 'Long-retention query_log analytics',
+  'advanced/self-tracking': 'Let the dashboard track its own queries',
+  'reference/configuration': 'Config files, defaults, and overrides',
+  'reference/environment-variables': 'Every env var the app understands',
+  'reference/mcp-server': 'MCP server tools, auth, and setup',
+  'ai-agent': 'AI assistant built into the dashboard',
+  'ai-agent/capabilities': 'Tools, skills, and what the agent can do',
+  'ai-agent/configuration': 'Models, prompts, and agent env vars',
+  'ai-agent/conversation-history': 'Thread list, storage, and retention',
+  'ai-agent/conversation-history/backends': 'D1, KV, and other history stores',
+  authentication: 'Protect the dashboard and API routes',
+  'authentication/api-keys': 'Machine-to-machine access with chm_ keys',
+  'authentication/clerk': 'Sign-in with Clerk organizations',
+  'authentication/public': 'Run without authentication (dev only)',
+  'authentication/cloudflare-access': 'Gate access behind Cloudflare Access',
+  'authentication/trusted-header': 'Trust an upstream reverse-proxy header',
+  'migrating/v0-3': 'Upgrade from Next.js or older monitor versions',
+  'releases/v0-3': 'TanStack Start, Workers, and v0.3 highlights',
+  faq: 'Common setup and troubleshooting answers',
+  settings: 'Global settings reference for operators',
+}
+
+const SECTION_DESCRIPTIONS: Record<string, string> = {
+  Introduction: 'Product overview and housekeeping pages',
+  'Getting Started': 'First-time setup and local development',
+  Deployment: 'Production deployment guides',
+  Features: 'Dashboard capabilities and UI tours',
+  Advanced: 'Power-user configuration and multi-host setups',
+  Reference: 'Configuration reference and API surfaces',
+  'AI Agent': 'In-dashboard AI assistant',
+  Authentication: 'Auth modes and access control',
+  Migrating: 'Version upgrade paths',
+  Releases: 'Release notes and changelogs',
+  More: 'FAQ and settings',
+}
+
+export function resolveNavDescription(link: string, label: string): string {
+  const subpath = linkToSubpath(link)
+  if (PAGE_DESCRIPTIONS[subpath]) return PAGE_DESCRIPTIONS[subpath]
+  const section = subpath.split('/')[0]
+  if (section && SECTION_DESCRIPTIONS[section])
+    return SECTION_DESCRIPTIONS[section]
+  return `Documentation for ${label}`
+}
+
+export function resolveSectionDescription(label: string): string {
+  return SECTION_DESCRIPTIONS[label] ?? `Pages in ${label}`
+}

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -36,9 +36,12 @@ body {
   line-height: 1.5;
   color: var(--geist-foreground);
   background: var(--bg);
-  font-feature-settings: 'cv11', 'ss01';
-  letter-spacing: -0.01em;
+  font-feature-settings: 'cv11', 'ss01', 'cv02';
+  font-optical-sizing: auto;
+  letter-spacing: -0.011em;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
   overflow-x: clip;
 }
 
@@ -187,17 +190,18 @@ img {
 .header-nav__trigger {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.5rem 0.75rem;
+  gap: 0.3rem;
+  padding: 0.4375rem 0.75rem;
   border-radius: var(--radius-sm);
   color: var(--fg-muted);
   font-size: 0.875rem;
   font-weight: 500;
+  letter-spacing: -0.015em;
   white-space: nowrap;
   flex-shrink: 0;
   transition:
-    color 0.15s ease,
-    background 0.15s ease;
+    color 0.18s ease,
+    background 0.18s ease;
 }
 .header-nav__link:hover,
 .header-nav__trigger:hover,
@@ -209,14 +213,15 @@ img {
 .header-nav__link.is-active,
 .header-nav__item.is-active .header-nav__trigger {
   color: var(--fg);
-  background: var(--ds-gray-200);
+  background: var(--ds-gray-alpha-100);
+  box-shadow: inset 0 0 0 1px var(--ds-gray-200);
 }
 .header-nav__item {
   position: relative;
 }
 .header-nav__chevron {
   opacity: 0.45;
-  transition: transform 0.15s ease;
+  transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .header-nav__item:hover .header-nav__chevron,
 .header-nav__item:focus-within .header-nav__chevron {
@@ -224,71 +229,137 @@ img {
 }
 .header-nav__dropdown {
   position: absolute;
-  top: calc(100% + 0.35rem);
+  top: calc(100% + 0.5rem);
   left: 50%;
   z-index: 60;
   width: max-content;
-  min-width: 13rem;
-  max-width: min(18rem, 80vw);
-  transform: translateX(-50%) translateY(0.25rem);
+  min-width: 14rem;
+  max-width: min(44rem, 92vw);
+  transform: translateX(-50%) translateY(0.35rem) scale(0.98);
   opacity: 0;
   pointer-events: none;
   transition:
-    opacity 0.15s ease,
-    transform 0.15s ease;
+    opacity 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .header-nav__item:hover .header-nav__dropdown,
 .header-nav__item:focus-within .header-nav__dropdown {
   opacity: 1;
   pointer-events: auto;
-  transform: translateX(-50%) translateY(0);
+  transform: translateX(-50%) translateY(0) scale(1);
 }
 .header-nav__dropdown-inner {
-  padding: 0.35rem;
+  padding: 0.625rem;
   border: 1px solid var(--border-strong);
-  border-radius: var(--radius-lg);
+  border-radius: 12px;
   background: var(--bg-base);
   box-shadow: var(--shadow-lg);
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(16px);
 }
-.header-nav__dropdown-link {
+.header-nav__dropdown-inner--columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13.5rem, 1fr));
+  gap: 0.25rem 1.25rem;
+  min-width: min(36rem, 88vw);
+  padding: 0.75rem 0.875rem;
+}
+.header-nav__dropdown-inner--grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(12.5rem, 1fr));
+  gap: 0.125rem 0.5rem;
+  min-width: min(28rem, 88vw);
+}
+.header-nav__dropdown-column {
   display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  min-height: 2rem;
-  padding: 0.375rem 0.5rem;
-  border-radius: var(--radius-nav);
-  color: var(--fg-muted);
-  font-size: 0.8125rem;
-  font-weight: 500;
-  transition:
-    background 0.15s ease,
-    color 0.15s ease;
-}
-.header-nav__dropdown-link .nav-link__icon {
-  opacity: 0.55;
-}
-.header-nav__dropdown-link:hover,
-.header-nav__dropdown-link[aria-current='page'] {
-  background: var(--bg-overlay-hover);
-  color: var(--fg);
-}
-.header-nav__dropdown-link:hover .nav-link__icon,
-.header-nav__dropdown-link[aria-current='page'] .nav-link__icon {
-  opacity: 1;
-}
-.header-nav__dropdown-section + .header-nav__dropdown-section {
-  margin-top: 0.35rem;
-  padding-top: 0.35rem;
-  border-top: 1px solid var(--ds-gray-200);
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
 }
 .header-nav__dropdown-heading {
-  padding: 0.25rem 0.5rem 0.125rem;
-  font-size: 0.6875rem;
+  padding: 0.375rem 0.5rem 0.25rem;
+  font-size: 0.75rem;
   font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  color: var(--fg);
+}
+.header-nav__dropdown-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.5rem 0.625rem;
+  border-radius: 10px;
+  color: inherit;
+  transition:
+    background 0.15s ease,
+    transform 0.15s ease;
+  animation: nav-card-in 0.28s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: var(--nav-card-delay, 0ms);
+}
+@keyframes nav-card-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.header-nav__dropdown-card:hover,
+.header-nav__dropdown-card[aria-current='page'] {
+  background: var(--ds-gray-alpha-100);
+}
+.header-nav__dropdown-card[aria-current='page'] {
+  box-shadow: inset 0 0 0 1px var(--ds-gray-200);
+}
+.header-nav__dropdown-card-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+}
+.header-nav__dropdown-card-title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--fg);
+  line-height: 1.25;
+}
+.header-nav__dropdown-card-desc {
+  font-size: 0.75rem;
+  font-weight: 400;
+  letter-spacing: -0.01em;
   color: var(--fg-subtle);
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.nav-link__icon-box {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  flex-shrink: 0;
+  border-radius: 8px;
+  background: var(--ds-gray-100);
+  border: 1px solid var(--ds-gray-200);
+  color: var(--fg-muted);
+  transition:
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+.nav-link__icon-box .nav-link__icon {
+  width: 1rem;
+  height: 1rem;
+  opacity: 0.85;
+}
+.header-nav__dropdown-card:hover .nav-link__icon-box,
+.header-nav__dropdown-card[aria-current='page'] .nav-link__icon-box {
+  border-color: var(--ds-gray-300);
+  color: var(--fg);
 }
 .header__actions {
   display: flex;
@@ -301,87 +372,222 @@ img {
     gap: 0.5rem;
   }
 }
-/* Mobile category menu (dialog) */
+/* Mobile category menu (command-palette dialog) */
 .mobile-nav-modal {
-  width: min(22rem, 92vw);
-  max-height: min(80vh, 32rem);
+  width: min(32rem, 94vw);
+  max-height: min(85dvh, 36rem);
   margin: auto;
   border: 1px solid var(--border-strong);
-  border-radius: var(--radius-lg);
+  border-radius: 14px;
   background: var(--bg-base);
   color: var(--fg);
   padding: 0;
   box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 .mobile-nav-modal::backdrop {
   background: rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(4px);
+  backdrop-filter: blur(6px);
 }
 .mobile-nav-modal__head {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--ds-gray-200);
+  padding: 0.75rem 1rem 0.5rem;
+  flex-shrink: 0;
 }
 .mobile-nav-modal__title {
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
   font-weight: 600;
-  color: var(--ds-gray-1000);
+  letter-spacing: -0.015em;
+  color: var(--fg-subtle);
 }
-.mobile-nav-modal__nav {
-  overflow-y: auto;
-  padding: 0.5rem;
-  max-height: calc(min(80vh, 32rem) - 3.25rem);
-}
-.mobile-nav-section {
-  padding: 0.25rem 0;
-}
-.mobile-nav-section + .mobile-nav-section {
-  border-top: 1px solid var(--ds-gray-200);
-  margin-top: 0.25rem;
-  padding-top: 0.5rem;
-}
-.mobile-nav-section__label {
-  display: block;
-  padding: 0.5rem 0.75rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--ds-gray-1000);
-  border-radius: var(--radius-sm);
-}
-.mobile-nav-section.is-active .mobile-nav-section__label {
-  background: var(--ds-gray-200);
-}
-.mobile-nav-section__items {
-  list-style: none;
-  margin: 0;
-  padding: 0 0 0.25rem;
-}
-.mobile-nav-section__link {
+.mobile-nav-modal__search {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.45rem 0.75rem 0.45rem 1.25rem;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  color: var(--fg-muted);
-  border-radius: var(--radius-sm);
+  margin: 0 0.75rem 0.5rem;
+  padding: 0 0.75rem;
+  height: 2.5rem;
+  border: 1px solid var(--ds-gray-300);
+  border-radius: 10px;
+  background: var(--ds-background-100);
+  flex-shrink: 0;
 }
-.mobile-nav-section__link:hover,
-.mobile-nav-section__link[aria-current='page'] {
-  background: var(--bg-overlay-hover);
+.mobile-nav-modal__search-icon {
+  flex-shrink: 0;
+  opacity: 0.45;
+}
+.mobile-nav-modal__search-input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--fg);
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  letter-spacing: -0.015em;
+  outline: none;
+}
+.mobile-nav-modal__search-input::placeholder {
+  color: var(--fg-subtle);
+  font-weight: 400;
+}
+.mobile-nav-modal__search-kbd {
+  display: inline-flex;
+  align-items: center;
+  height: 1.375rem;
+  padding: 0 0.4rem;
+  border: 1px solid var(--ds-gray-300);
+  border-radius: 6px;
+  font-size: 0.625rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: var(--fg-subtle);
+  background: var(--ds-gray-100);
+}
+.mobile-nav-modal__nav {
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0.25rem 0.5rem 0.75rem;
+  flex: 1;
+  min-height: 0;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.mobile-nav-modal__nav::-webkit-scrollbar {
+  display: none;
+}
+.mobile-nav-accordion {
+  border-radius: 8px;
+}
+.mobile-nav-accordion + .mobile-nav-accordion {
+  margin-top: 0.125rem;
+}
+.mobile-nav-accordion__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.4375rem 0.625rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--fg);
+  border-radius: 8px;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  transition: background 0.15s ease;
+}
+.mobile-nav-accordion__summary::-webkit-details-marker {
+  display: none;
+}
+.mobile-nav-accordion__summary:hover {
+  background: var(--ds-gray-alpha-100);
+}
+.mobile-nav-accordion[open] > .mobile-nav-accordion__summary {
   color: var(--fg);
 }
-.mobile-nav-section__subheading {
-  padding: 0.35rem 0.75rem 0.125rem 1.25rem;
+.mobile-nav-accordion__chevron {
+  opacity: 0.45;
+  transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.mobile-nav-accordion[open] > .mobile-nav-accordion__summary .mobile-nav-accordion__chevron {
+  transform: rotate(180deg);
+}
+.mobile-nav-accordion__panel {
+  overflow: hidden;
+  animation: mobile-panel-in 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+}
+@keyframes mobile-panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.mobile-nav-accordion__panel--solo {
+  padding: 0 0.25rem 0.25rem;
+}
+.mobile-nav-accordion__items {
+  list-style: none;
+  margin: 0;
+  padding: 0.125rem 0 0.25rem 0.375rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.0625rem;
+}
+.mobile-nav-accordion__link {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.4375rem 0.625rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: -0.012em;
+  color: var(--fg-muted);
+  border-radius: 8px;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+.mobile-nav-accordion__link .nav-link__icon {
+  opacity: 0.55;
+  flex-shrink: 0;
+}
+.mobile-nav-accordion__link:hover {
+  background: var(--ds-gray-alpha-100);
+  color: var(--fg);
+}
+.mobile-nav-accordion__link:hover .nav-link__icon,
+.mobile-nav-accordion__link[aria-current='page'] .nav-link__icon {
+  opacity: 1;
+}
+.mobile-nav-accordion__link[aria-current='page'] {
+  background: var(--ds-gray-alpha-100);
+  color: var(--fg);
+  box-shadow: inset 0 0 0 1px var(--ds-gray-200);
+}
+.mobile-nav-accordion__subheading {
+  padding: 0.375rem 0.625rem 0.125rem;
   font-size: 0.6875rem;
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.03em;
   text-transform: uppercase;
   color: var(--fg-subtle);
   list-style: none;
+}
+.mobile-nav-accordion__solo {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  margin: 0.125rem 0;
+  padding: 0.4375rem 0.625rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--fg-muted);
+  border-radius: 8px;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+.mobile-nav-accordion__solo:hover,
+.mobile-nav-accordion__solo[aria-current='page'] {
+  background: var(--ds-gray-alpha-100);
+  color: var(--fg);
+}
+.mobile-nav-accordion__solo[aria-current='page'] {
+  box-shadow: inset 0 0 0 1px var(--ds-gray-200);
 }
 .icon-btn {
   display: inline-flex;
@@ -623,8 +829,9 @@ img {
 }
 .toc-mobile-modal__nav a:hover,
 .toc-mobile-modal__nav a.active {
-  background: var(--ds-gray-200);
+  background: var(--ds-gray-alpha-100);
   color: var(--geist-foreground);
+  box-shadow: inset 0 0 0 1px var(--ds-gray-200);
 }
 .toc-mobile-modal__nav li[data-depth='3'] a {
   padding-left: 1.25rem;
@@ -646,9 +853,12 @@ img {
   align-self: start;
   height: calc(100dvh - var(--header-h));
   overflow-y: auto;
-  padding: 0.5rem 0.5rem 4rem;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border-strong) transparent;
+  padding: 0.625rem 0.5rem 4rem;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.sidebar::-webkit-scrollbar {
+  display: none;
 }
 
 :root[data-sidebar='collapsed'] .sidebar {
@@ -747,17 +957,19 @@ details.nav-group[open] > summary.nav-group__label::after {
 .nav-link {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.625rem;
   min-height: 2rem;
-  padding: 0.375rem 0.5rem;
+  padding: 0.4375rem 0.625rem;
   border-radius: var(--radius-nav);
   color: var(--fg-muted);
   font-size: 0.8125rem;
   font-weight: 500;
+  letter-spacing: -0.012em;
   line-height: 1.3;
   transition:
     background 0.15s ease,
-    color 0.15s ease;
+    color 0.15s ease,
+    box-shadow 0.15s ease;
 }
 .nav-link__icon {
   flex-shrink: 0;
@@ -781,9 +993,10 @@ details.nav-group[open] > summary.nav-group__label::after {
   opacity: 1;
 }
 .nav-link[aria-current='page'] {
-  background: var(--ds-gray-200);
+  background: var(--ds-gray-alpha-100);
   color: var(--fg);
-  font-weight: 500;
+  font-weight: 600;
+  box-shadow: inset 0 0 0 1px var(--ds-gray-200);
 }
 
 /* ── Version switcher ───────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Polishes the docs navigation introduced in #1632 with a Vercel-style mega menu and a cleaner mobile command-palette dialog.

- **Header dropdowns**: icon cards with title + one-line description, multi-column layout for merged categories, staggered open animation
- **Mobile dialog**: searchable accordion (active section open by default), hidden scrollbar, no gray pill on category headers
- **Active states**: lighter inset highlight instead of heavy gray blocks; consistent padding across sidebar, header, and embedded `/docs`
- **Typography**: Geist optical sizing + tighter letter-spacing on nav labels

## Test plan

- [x] `cd apps/docs && bun run build`
- [x] `cd apps/dashboard && bun run build`
- [ ] Verify header dropdowns on desktop (Deploy, Reference multi-column)
- [ ] Verify mobile menu dialog: search filter, accordion, no visible scrollbar
- [ ] Verify sidebar active link padding on docs.chmonitor.dev after deploy

Co-Authored-By: duyetbot <bot@duyet.net>