### PR TITLE
fix(docs): hide nav menu until hover

### DIFF
--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -223,8 +223,7 @@ img {
   opacity: 0.45;
   transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 }
-.header-nav__item:hover .header-nav__chevron,
-.header-nav__item:focus-within .header-nav__chevron {
+.header-nav__item:hover .header-nav__chevron {
   transform: rotate(180deg);
 }
 .header-nav__dropdown {
@@ -237,16 +236,20 @@ img {
   max-width: min(44rem, 92vw);
   transform: translateX(-50%) translateY(0.35rem) scale(0.98);
   opacity: 0;
+  visibility: hidden;
   pointer-events: none;
   transition:
     opacity 0.2s cubic-bezier(0.16, 1, 0.3, 1),
-    transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+    transform 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+    visibility 0.2s;
 }
-.header-nav__item:hover .header-nav__dropdown,
-.header-nav__item:focus-within .header-nav__dropdown {
-  opacity: 1;
-  pointer-events: auto;
-  transform: translateX(-50%) translateY(0) scale(1);
+@media (hover: hover) and (pointer: fine) {
+  .header-nav__item:hover .header-nav__dropdown {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
 }
 .header-nav__dropdown-inner {
   padding: 0.625rem;
@@ -292,8 +295,12 @@ img {
   transition:
     background 0.15s ease,
     transform 0.15s ease;
-  animation: nav-card-in 0.28s cubic-bezier(0.16, 1, 0.3, 1) both;
-  animation-delay: var(--nav-card-delay, 0ms);
+}
+@media (hover: hover) and (pointer: fine) {
+  .header-nav__item:hover .header-nav__dropdown-card {
+    animation: nav-card-in 0.28s cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation-delay: var(--nav-card-delay, 0ms);
+  }
 }
 @keyframes nav-card-in {
   from {
@@ -373,7 +380,10 @@ img {
   }
 }
 /* Mobile category menu (command-palette dialog) */
-.mobile-nav-modal {
+.mobile-nav-modal:not([open]) {
+  display: none;
+}
+.mobile-nav-modal[open] {
   width: min(32rem, 94vw);
   max-height: min(85dvh, 36rem);
   margin: auto;


### PR DESCRIPTION
## Summary

Fixes the docs menu panel that was always visible on page load.

- **Root cause**: `.mobile-nav-modal { display: flex }` overrode the browser's closed `<dialog>` default (`display: none`), so the category menu rendered permanently.
- **Fix**: scope dialog layout to `.mobile-nav-modal[open]` and explicitly hide when not open.
- **Header dropdowns**: show child menus on **hover only** (removed `:focus-within` stickiness on active tabs); card stagger animation runs only while hovered.

## Test plan

- [x] `cd apps/docs && bun run build`
- [ ] Desktop: no floating menu on load; dropdown appears only on category hover
- [ ] Mobile: menu dialog hidden until hamburger tap

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined header navigation chevron to respond to hover interactions only.
  * Enhanced dropdown visibility with improved transition effects and behavior.
  * Adjusted dropdown animation to better adapt to different device interaction types.
  * Improved mobile category modal visibility and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->