### PR TITLE
feat(dashboard-tsr): collapse root redirect to avoid TTFB regression

### DIFF
--- a/apps/dashboard/src/routes/index.tsx
+++ b/apps/dashboard/src/routes/index.tsx
@@ -1,21 +1,12 @@
-import { createFileRoute } from '@tanstack/react-router'
-
-import { useEffect } from 'react'
-import { PageSkeleton } from '@/components/skeletons'
-import { useRouter } from '@/lib/next-compat'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/')({
-  component: Home,
+  beforeLoad: () => {
+    throw redirect({
+      to: '/overview',
+      search: {
+        host: 0,
+      },
+    })
+  },
 })
-
-// Root page — client-side redirect to /overview?host=0, mirroring the Next
-// app's app/(dashboard)/page.tsx. Fully static SPA: no server redirect.
-function Home() {
-  const router = useRouter()
-
-  useEffect(() => {
-    router.replace('/overview?host=0')
-  }, [router])
-
-  return <PageSkeleton />
-}


### PR DESCRIPTION
Replaces client-side JS redirect with server-side redirect via TanStack Router in index route.

Part of epic #1392 · Closes #1405