### PR TITLE
fix(dashboard): remove dark-mode hover overrides broken by Tailwind v4 color-mix

### DIFF
--- a/apps/dashboard/src/components/data-table/renderers/table-body.tsx
+++ b/apps/dashboard/src/components/data-table/renderers/table-body.tsx
@@ -105,11 +105,11 @@ export const VirtualizedTableRow = memo(function VirtualizedTableRow<
           : undefined
       }
       className={cn(
-        'border-b border-border/50 transition-colors hover:bg-accent/50 dark:hover:bg-accent/20',
+        'border-b border-border/50 transition-colors hover:bg-accent/50',
         virtualRow.index % 2 === 1 && 'odd:bg-muted/30',
         row.getIsSelected() && 'border-l-2 border-l-primary',
         canExpand && 'cursor-pointer',
-        isExpanded && 'bg-accent/30 hover:bg-accent/30 dark:bg-accent/15',
+        isExpanded && 'bg-accent/30 hover:bg-accent/30',
         customClass
       )}
       style={{
@@ -179,11 +179,11 @@ export const StandardTableRow = memo(function StandardTableRow<
           : undefined
       }
       className={cn(
-        'border-b border-border/50 transition-colors hover:bg-accent/50 dark:hover:bg-accent/20',
+        'border-b border-border/50 transition-colors hover:bg-accent/50',
         index % 2 === 1 && 'odd:bg-muted/30',
         row.getIsSelected() && 'border-l-2 border-l-primary',
         canExpand && 'cursor-pointer',
-        isExpanded && 'bg-accent/30 hover:bg-accent/30 dark:bg-accent/15',
+        isExpanded && 'bg-accent/30 hover:bg-accent/30',
         customClass
       )}
     >

--- a/apps/dashboard/src/components/data-table/row-expand/expanded-row.tsx
+++ b/apps/dashboard/src/components/data-table/row-expand/expanded-row.tsx
@@ -37,7 +37,7 @@ export function ExpandedRow<TData extends RowData>({
       data-expanded-row
       data-row-id={row.id}
       className={cn(
-        'bg-muted/40 hover:bg-muted/40 dark:bg-muted/20 dark:hover:bg-muted/20',
+        'bg-muted/40 hover:bg-muted/40',
         'border-b border-border/50'
       )}
     >


### PR DESCRIPTION
## Problem

Tailwind v4 replaces v3's opacity-layering with `color-mix()`, which changes how opacity modifiers work in dark mode.

`dark:hover:bg-accent/20` in v3 layered the accent color with 20% opacity on top of the dark background (\~19% lightness). In v4, `color-mix()` produces a solid opaque color at \~7.4% lightness — much darker than the 14.5% background, rendering as **black patches on hover**.

## Fix

Remove the dark-mode-specific opacity overrides that were needed in v3 but are now harmful in v4:

- `dark:hover:bg-accent/20` → relies on `hover:bg-accent/50` (\~18.5% lightness, safely above background)
- `dark:bg-accent/15` for expanded rows → `bg-accent/30` (\~11.1%) provides a subtle inset look naturally
- `dark:bg-muted/20 dark:hover:bg-muted/20` for expanded row wrapper → removed entirely

## Verification

- All pre-existing tests pass (854 pass, 0 fail)
- Build succeeds with no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dark mode styling for data table rows by adjusting hover and expanded state background effects across standard and virtualized table components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->