### PR TITLE
fix(dashboard): contain docs Vercel tokens to .docs-vercel-theme

### DIFF
--- a/apps/dashboard/src/routes/(docs)/docs/$.tsx
+++ b/apps/dashboard/src/routes/(docs)/docs/$.tsx
@@ -17,7 +17,7 @@ function DocsPage() {
 
   if (!page) {
     return (
-      <div className="docs-vercel-theme flex min-h-dvh flex-col items-center justify-center px-4 text-center">
+      <div className="docs-theme flex min-h-dvh flex-col items-center justify-center px-4 text-center">
         <h1 className="font-semibold text-2xl text-[var(--ds-gray-1000)]">
           Page not found
         </h1>

--- a/apps/dashboard/src/routes/(docs)/docs/-components/docs-shell.tsx
+++ b/apps/dashboard/src/routes/(docs)/docs/-components/docs-shell.tsx
@@ -28,7 +28,7 @@ export function DocsShell({
   const toolbarTitle = resolveDocsBreadcrumb(activeSlug, activeTitle)
 
   return (
-    <div className="docs-vercel-theme min-h-dvh">
+    <div className="docs-theme min-h-dvh">
       <div className="docs-shell__header sticky top-14 z-20 mb-0 px-4 py-3 lg:px-6">
         <div className="mx-auto flex w-full max-w-[var(--ds-page-width)] items-center justify-between gap-4">
           <Link

--- a/apps/dashboard/src/routes/(docs)/docs/docs-theme.css
+++ b/apps/dashboard/src/routes/(docs)/docs/docs-theme.css
@@ -1,9 +1,9 @@
 @import '@fontsource-variable/geist';
 @import '@fontsource/geist-mono/400.css';
 @import '@fontsource/geist-mono/500.css';
-@import '../../../../../../design-system/vercel-docs-tokens.css';
+@import '../../../../../../design-system/docs-tokens.css';
 
-.docs-vercel-theme {
+.docs-theme {
   --background: var(--ds-background-100);
   --foreground: var(--geist-foreground);
   --muted-foreground: var(--ds-gray-900);
@@ -18,30 +18,30 @@
   color: var(--geist-foreground);
 }
 
-.docs-vercel-theme .docs-shell__header {
+.docs-theme .docs-shell__header {
   border-bottom: 1px solid var(--ds-gray-300);
   background: var(--ds-background-100);
 }
 
-.docs-vercel-theme .docs-shell__sidebar {
+.docs-theme .docs-shell__sidebar {
   border-right: 1px solid var(--ds-gray-300);
 }
 
-.docs-vercel-theme .docs-shell__nav-section {
+.docs-theme .docs-shell__nav-section {
   color: var(--ds-gray-1000);
   font-size: 0.8125rem;
   font-weight: 500;
   letter-spacing: -0.01em;
 }
 
-.docs-vercel-theme .docs-shell__nav-section {
+.docs-theme .docs-shell__nav-section {
   padding: 0.75rem 0.625rem 0.5rem;
   font-size: 0.8125rem;
   font-weight: 600;
   letter-spacing: -0.02em;
 }
 
-.docs-vercel-theme .docs-shell__nav-link {
+.docs-theme .docs-shell__nav-link {
   position: relative;
   border-radius: 8px;
   color: var(--ds-gray-900);
@@ -56,7 +56,7 @@
     box-shadow 0.15s ease;
 }
 
-.docs-vercel-theme .docs-shell__nav-link::before {
+.docs-theme .docs-shell__nav-link::before {
   content: '';
   position: absolute;
   left: 0.25rem;
@@ -69,51 +69,51 @@
   transition: height 0.15s ease;
 }
 
-.docs-vercel-theme .docs-shell__nav-link:hover {
+.docs-theme .docs-shell__nav-link:hover {
   background: var(--ds-gray-alpha-100);
   color: var(--ds-gray-1000);
 }
 
-.docs-vercel-theme .docs-shell__nav-link[data-active='true'] {
+.docs-theme .docs-shell__nav-link[data-active='true'] {
   background: var(--ds-gray-alpha-100);
   color: var(--ds-gray-1000);
   font-weight: 600;
   box-shadow: inset 0 0 0 1px var(--ds-gray-200);
 }
 
-.docs-vercel-theme .docs-shell__nav-link[data-active='true']::before {
+.docs-theme .docs-shell__nav-link[data-active='true']::before {
   height: 1rem;
 }
 
-.docs-vercel-theme .docs-shell__toc-title {
+.docs-theme .docs-shell__toc-title {
   color: var(--ds-gray-1000);
   font-size: 0.8125rem;
   font-weight: 500;
   letter-spacing: -0.01em;
 }
 
-.docs-vercel-theme .docs-shell__toc-link {
+.docs-theme .docs-shell__toc-link {
   border-radius: var(--geist-radius);
   color: var(--ds-gray-900);
   font-size: 0.8125rem;
   font-weight: 500;
 }
 
-.docs-vercel-theme .docs-shell__toc-link:hover,
-.docs-vercel-theme .docs-shell__toc-link[data-active='true'] {
+.docs-theme .docs-shell__toc-link:hover,
+.docs-theme .docs-shell__toc-link[data-active='true'] {
   background: var(--ds-gray-alpha-100);
   color: var(--ds-gray-1000);
   box-shadow: inset 0 0 0 1px var(--ds-gray-200);
 }
 
-.docs-vercel-theme .docs-markdown {
+.docs-theme .docs-markdown {
   font-kerning: normal;
   font-size: 1rem;
   font-variant-ligatures: common-ligatures contextual;
   line-height: 1.5;
 }
 
-.docs-vercel-theme .docs-markdown h1 {
+.docs-theme .docs-markdown h1 {
   color: var(--geist-foreground);
   font-size: 2.5rem;
   font-weight: 600;
@@ -124,12 +124,12 @@
 }
 
 @media (max-width: 820px) {
-  .docs-vercel-theme .docs-markdown h1 {
+  .docs-theme .docs-markdown h1 {
     font-size: 2rem;
   }
 }
 
-.docs-vercel-theme .docs-toolbar {
+.docs-theme .docs-toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -146,18 +146,18 @@
 }
 
 @media (min-width: 1024px) {
-  .docs-vercel-theme .docs-toolbar {
+  .docs-theme .docs-toolbar {
     display: none;
   }
 }
 
 @media (max-width: 1023px) {
-  .docs-vercel-theme .docs-markdown h1 {
+  .docs-theme .docs-markdown h1 {
     display: none;
   }
 }
 
-.docs-vercel-theme .docs-toolbar__menu {
+.docs-theme .docs-toolbar__menu {
   display: inline-flex;
   min-width: 0;
   flex: 1;
@@ -176,7 +176,7 @@
   text-align: left;
 }
 
-.docs-vercel-theme .docs-toolbar__title {
+.docs-theme .docs-toolbar__title {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -185,15 +185,15 @@
   letter-spacing: -0.01em;
 }
 
-.docs-vercel-theme .docs-toolbar__toc {
+.docs-theme .docs-toolbar__toc {
   flex-shrink: 0;
 }
 
-.docs-vercel-theme .docs-toolbar__menu:hover {
+.docs-theme .docs-toolbar__menu:hover {
   background: var(--ds-gray-alpha-100);
 }
 
-.docs-vercel-theme .docs-toolbar__toc {
+.docs-theme .docs-toolbar__toc {
   display: inline-flex;
   align-items: center;
   height: 2rem;
@@ -208,11 +208,11 @@
   cursor: pointer;
 }
 
-.docs-vercel-theme .docs-toolbar__toc:hover {
+.docs-theme .docs-toolbar__toc:hover {
   background: var(--ds-gray-alpha-100);
 }
 
-.docs-vercel-theme .docs-mobile-panel {
+.docs-theme .docs-mobile-panel {
   margin-bottom: 1rem;
   max-height: calc(100dvh - 10rem);
   overflow-y: auto;
@@ -224,11 +224,11 @@
   -ms-overflow-style: none;
 }
 
-.docs-vercel-theme .docs-mobile-panel::-webkit-scrollbar {
+.docs-theme .docs-mobile-panel::-webkit-scrollbar {
   display: none;
 }
 
-.docs-vercel-theme .docs-markdown h2 {
+.docs-theme .docs-markdown h2 {
   border-bottom: none;
   color: var(--geist-foreground);
   font-size: 1.5rem;
@@ -239,21 +239,21 @@
   padding-bottom: 0;
 }
 
-.docs-vercel-theme .docs-markdown h3 {
+.docs-theme .docs-markdown h3 {
   color: var(--geist-foreground);
   font-size: 1.25rem;
   font-weight: 600;
   margin-top: 2rem;
 }
 
-.docs-vercel-theme .docs-markdown h4 {
+.docs-theme .docs-markdown h4 {
   color: var(--geist-foreground);
   font-size: 1rem;
   font-weight: 600;
   margin-top: 1.5rem;
 }
 
-.docs-vercel-theme .docs-markdown > p {
+.docs-theme .docs-markdown > p {
   margin-top: 1.25em;
   margin-bottom: 0;
   color: var(--geist-foreground);
@@ -262,29 +262,29 @@
   text-wrap: pretty;
 }
 
-.docs-vercel-theme .docs-markdown > p:first-child {
+.docs-theme .docs-markdown > p:first-child {
   margin-top: 0;
 }
 
-.docs-vercel-theme .docs-markdown > h1 + p {
+.docs-theme .docs-markdown > h1 + p {
   margin-top: 1.25em;
   padding: 1rem 1.25rem;
   border-radius: var(--geist-radius);
   background: var(--ds-blue-100);
 }
 
-.docs-vercel-theme .docs-markdown > h2 + p,
-.docs-vercel-theme .docs-markdown > h3 + p,
-.docs-vercel-theme .docs-markdown > h4 + p {
+.docs-theme .docs-markdown > h2 + p,
+.docs-theme .docs-markdown > h3 + p,
+.docs-theme .docs-markdown > h4 + p {
   margin-top: 0.75em;
 }
 
-.docs-vercel-theme .docs-markdown :is(p, li, td, th, blockquote) {
+.docs-theme .docs-markdown :is(p, li, td, th, blockquote) {
   color: var(--geist-foreground);
   line-height: 1.7;
 }
 
-.docs-vercel-theme .docs-markdown :is(p, li, td, th, dt, dd, blockquote) a {
+.docs-theme .docs-markdown :is(p, li, td, th, dt, dd, blockquote) a {
   color: inherit;
   font-weight: 500;
   text-decoration: underline;
@@ -292,12 +292,12 @@
   text-decoration-color: var(--ds-gray-alpha-600);
 }
 
-.docs-vercel-theme .docs-markdown :is(p, li, td, th, dt, dd, blockquote) a:hover,
-.docs-vercel-theme .docs-markdown :is(p, li, td, th, dt, dd, blockquote) a:focus-visible {
+.docs-theme .docs-markdown :is(p, li, td, th, dt, dd, blockquote) a:hover,
+.docs-theme .docs-markdown :is(p, li, td, th, dt, dd, blockquote) a:focus-visible {
   text-decoration-color: currentColor;
 }
 
-.docs-vercel-theme .docs-markdown :not(pre) > code {
+.docs-theme .docs-markdown :not(pre) > code {
   background: var(--ds-gray-100);
   border: 1px solid var(--ds-gray-300);
   border-radius: var(--geist-radius);
@@ -310,7 +310,7 @@
   -webkit-box-decoration-break: clone;
 }
 
-.docs-vercel-theme .docs-markdown pre {
+.docs-theme .docs-markdown pre {
   background: var(--ds-gray-100);
   border: 1px solid var(--ds-gray-300);
   border-radius: 10px;
@@ -319,24 +319,24 @@
   line-height: 1.6;
 }
 
-.docs-vercel-theme .docs-markdown table {
+.docs-theme .docs-markdown table {
   border: 1px solid var(--ds-gray-300);
   border-radius: 10px;
   font-size: 0.875rem;
   overflow: hidden;
 }
 
-.docs-vercel-theme .docs-markdown th {
+.docs-theme .docs-markdown th {
   background: var(--ds-gray-100);
   color: var(--ds-gray-1000);
 }
 
-.docs-vercel-theme .docs-markdown td,
-.docs-vercel-theme .docs-markdown th {
+.docs-theme .docs-markdown td,
+.docs-theme .docs-markdown th {
   border-color: var(--ds-gray-300);
 }
 
-.dark .docs-vercel-theme {
+.dark .docs-theme {
   --background: var(--ds-background-200);
   --foreground: var(--ds-gray-1000);
   --muted-foreground: var(--ds-gray-900);

--- a/apps/dashboard/src/routes/(docs)/docs/index.tsx
+++ b/apps/dashboard/src/routes/(docs)/docs/index.tsx
@@ -15,7 +15,7 @@ function DocsIndexPage() {
 
   if (!page) {
     return (
-      <div className="docs-vercel-theme flex min-h-dvh flex-col items-center justify-center px-4 text-center">
+      <div className="docs-theme flex min-h-dvh flex-col items-center justify-center px-4 text-center">
         <h1 className="font-semibold text-2xl text-[var(--ds-gray-1000)]">
           Page not found
         </h1>

--- a/design-system/docs-tokens.css
+++ b/design-system/docs-tokens.css
@@ -1,15 +1,15 @@
 /* Vercel Docs / Geist design tokens
    Source: https://vercel.com/docs (extracted 2026-06-15)
 
-   IMPORTANT: these tokens are SCOPED to `.docs-vercel-theme` (the docs shell
+   IMPORTANT: these tokens are SCOPED to `.docs-theme` (the docs shell
    root), NOT `:root`. The block below redefines shadcn-reserved variable names
    (`--accent`, `--primary`, `--border`, …). Defining them at global `:root`
    leaked the Vercel/Geist values into the whole dashboard — `bg-accent`
    skeletons and `hover:bg-accent` menus painted near-black (--ds-gray-1000).
-   Keeping them under `.docs-vercel-theme` confines the custom design system to
+   Keeping them under `.docs-theme` confines the custom design system to
    the docs subtree, which is the only place that opts in. */
 
-.docs-vercel-theme {
+.docs-theme {
   --geist-space: 4px;
   --geist-gap: 24px;
   --geist-gap-half: 12px;
@@ -90,7 +90,7 @@
   --layout-max: var(--ds-page-width);
 }
 
-.dark .docs-vercel-theme {
+.dark .docs-theme {
   --ds-background-100: #000000;
   --ds-background-200: #0a0a0a;
   --ds-gray-100: #1a1a1a;
@@ -124,7 +124,7 @@
 }
 
 @media (min-width: 1280px) {
-  .docs-vercel-theme {
+  .docs-theme {
     --sidebar-w: 17rem;
   }
 }

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -1,1 +1,1 @@
-@import './vercel-docs-tokens.css';
+@import './docs-tokens.css';

--- a/design-system/vercel-docs-tokens.css
+++ b/design-system/vercel-docs-tokens.css
@@ -1,7 +1,15 @@
 /* Vercel Docs / Geist design tokens
-   Source: https://vercel.com/docs (extracted 2026-06-15) */
+   Source: https://vercel.com/docs (extracted 2026-06-15)
 
-:root {
+   IMPORTANT: these tokens are SCOPED to `.docs-vercel-theme` (the docs shell
+   root), NOT `:root`. The block below redefines shadcn-reserved variable names
+   (`--accent`, `--primary`, `--border`, …). Defining them at global `:root`
+   leaked the Vercel/Geist values into the whole dashboard — `bg-accent`
+   skeletons and `hover:bg-accent` menus painted near-black (--ds-gray-1000).
+   Keeping them under `.docs-vercel-theme` confines the custom design system to
+   the docs subtree, which is the only place that opts in. */
+
+.docs-vercel-theme {
   --geist-space: 4px;
   --geist-gap: 24px;
   --geist-gap-half: 12px;
@@ -82,7 +90,7 @@
   --layout-max: var(--ds-page-width);
 }
 
-:root[data-theme='dark'] {
+.dark .docs-vercel-theme {
   --ds-background-100: #000000;
   --ds-background-200: #0a0a0a;
   --ds-gray-100: #1a1a1a;
@@ -116,7 +124,7 @@
 }
 
 @media (min-width: 1280px) {
-  :root {
+  .docs-vercel-theme {
     --sidebar-w: 17rem;
   }
 }


### PR DESCRIPTION
## Problem

Dashboard skeletons and some hover states (e.g. `hover:bg-accent` nav/menu items) render **near-black** instead of subtle gray — looked like missing CSS / broken Tailwind.

<img width="400" alt="black skeleton" src="https://github.com/user-attachments/assets/placeholder" />

## Root cause

The recent Vercel/Geist docs redesign (#1627–#1641) added `design-system/vercel-docs-tokens.css`, which redefines **shadcn-reserved CSS variables** — `--accent`, `--primary`, `--border` — at global **`:root`**, pointing at `--ds-gray-1000` (`#171717`, near-black in light mode).

That file is `@import`-ed by the docs routes, but CSS custom properties cascade globally, so those values overrode the dashboard's own `--accent` (`oklch(0.97 0 0)`, near-white) app-wide. `docs-theme.css` *already* re-scopes those tokens under `.docs-vercel-theme`, so the global `:root` copies were pure leakage.

## Fix (contain + audit)

- Scope the entire token block from `:root` → `.docs-vercel-theme` (the docs shell root, `docs-shell.tsx:31`). The custom design system is now inert outside the docs subtree.
- Switch the dark block from `:root[data-theme='dark']` → `.dark .docs-vercel-theme` to match the dashboard's `.dark` mechanism (also makes docs dark-mode primitives flip correctly).
- Audited: no docs UI uses portals/dialogs, so nothing escapes the scope; all `var(--ds-*)` references live inside `.docs-vercel-theme`.

docs.chmonitor.dev is a separate deployment — the docs design system should never touch the dashboard's global scope, which this enforces.

## Test

- Light + dark dashboard: skeletons/hover render subtle gray again.
- Docs (`/docs`): Vercel/Geist look unchanged.

Co-Authored-By: duyetbot <bot@duyet.net>