### PR TITLE
fix(docs): keep shared docs tokens at :root for standalone apps/docs

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -73,7 +73,7 @@ The next build picks it up automatically, makes `v0.4` the latest, and keeps
 
 The design follows the [Vercel Docs](https://vercel.com/docs) / Geist layout
 (three-column sticky shell, Geist Sans + Mono, `--ds-*` tokens, Pagefind
-search). Tokens live in `design-system/vercel-docs-tokens.css` and are applied
+search). Tokens live in `design-system/docs-tokens.css` and are applied
 via plain CSS — no Tailwind dependency:
 
 - **Tokens & layout** — `src/styles/global.css`, with light + dark themes driven

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -1,6 +1,6 @@
 /* chmonitor docs — Vercel Docs / Geist design system */
 
-@import '../../../../design-system/vercel-docs-tokens.css';
+@import '../../../../design-system/docs-tokens.css';
 
 :root {
   --radius-sm: var(--geist-radius);
@@ -9,6 +9,14 @@
   --radius-pill: 9999px;
   --radius-nav: var(--geist-radius);
   --header-h: var(--header-height);
+
+  /* Shadcn-reserved names the shared token file intentionally omits (they
+     leak into the dashboard). This standalone app has no shadcn surface, so
+     declare them here. They reference --ds-* primitives, so they follow the
+     data-theme dark flip automatically. */
+  --accent: var(--ds-gray-1000);
+  --primary: var(--ds-gray-1000);
+  --border: var(--ds-gray-alpha-200);
 }
 
 :root[data-header-compact='true'] {

--- a/design-system/docs-tokens.css
+++ b/design-system/docs-tokens.css
@@ -1,15 +1,19 @@
 /* Vercel Docs / Geist design tokens
    Source: https://vercel.com/docs (extracted 2026-06-15)
 
-   IMPORTANT: these tokens are SCOPED to `.docs-theme` (the docs shell
-   root), NOT `:root`. The block below redefines shadcn-reserved variable names
-   (`--accent`, `--primary`, `--border`, …). Defining them at global `:root`
-   leaked the Vercel/Geist values into the whole dashboard — `bg-accent`
-   skeletons and `hover:bg-accent` menus painted near-black (--ds-gray-1000).
-   Keeping them under `.docs-theme` confines the custom design system to
-   the docs subtree, which is the only place that opts in. */
+   Defined at `:root` because the standalone docs app (apps/docs, the
+   docs.chmonitor.dev Astro deployment) consumes these tokens directly with no
+   theme wrapper. The `--ds-*` primitives, fonts, and layout vars use
+   docs-specific names that never collide with the dashboard's shadcn tokens.
 
-.docs-theme {
+   IMPORTANT: do NOT add the shadcn-reserved names `--accent`, `--primary`, or
+   `--border` here. The dashboard embeds the docs routes and bundles this CSS
+   globally, so a `:root --accent` (etc.) would override the dashboard's own
+   token app-wide — that leak painted `bg-accent` skeletons and `hover:bg-accent`
+   menus near-black. The dashboard's docs scope those three under `.docs-theme`
+   (docs-theme.css); the standalone app declares them in its own `:root`. */
+
+:root {
   --geist-space: 4px;
   --geist-gap: 24px;
   --geist-gap-half: 12px;
@@ -70,16 +74,15 @@
   --fg-muted: var(--ds-gray-900);
   --fg-prose: var(--geist-foreground);
   --fg-subtle: var(--ds-gray-600);
-  --border: var(--ds-gray-alpha-200);
   --border-strong: var(--ds-gray-300);
   --link: var(--geist-link-color);
   --link-hover: #0060df;
-  --accent: var(--ds-gray-1000);
+  /* NOTE: --accent, --primary, --border intentionally omitted — see header.
+     They collide with shadcn tokens and would leak into the dashboard. */
   --accent-soft: var(--ds-gray-alpha-100);
   --code-bg: var(--ds-gray-100);
   --code-border: var(--ds-gray-300);
   --selection: var(--ds-gray-200);
-  --primary: var(--ds-gray-1000);
   --primary-fg: #ffffff;
   --shadow-lg: var(--ds-shadow-menu);
   --header-border: 0 1px 0 rgba(0, 0, 0, 0.1);
@@ -90,7 +93,7 @@
   --layout-max: var(--ds-page-width);
 }
 
-.dark .docs-theme {
+:root[data-theme='dark'] {
   --ds-background-100: #000000;
   --ds-background-200: #0a0a0a;
   --ds-gray-100: #1a1a1a;
@@ -124,7 +127,7 @@
 }
 
 @media (min-width: 1280px) {
-  .docs-theme {
+  :root {
     --sidebar-w: 17rem;
   }
 }


### PR DESCRIPTION
## Context

Fix-forward for #1643. That PR fixed the dashboard skeleton/hover black-color leak by scoping the shared docs token file to `.docs-theme`, but it **broke the standalone `apps/docs` deployment** (docs.chmonitor.dev) — an Astro site with no `.docs-theme` wrapper that consumes the tokens directly at `:root`. The CF deploy on main went red:

```
[vite] Unable to resolve @import ".../design-system/vercel-docs-tokens.css" from apps/docs/src/styles
```

(plus the tokens would no longer apply even once the path resolved).

## Root cause

One shared token file has **two consumers with opposite needs**:
- `apps/docs` (standalone Astro, no shadcn): needs tokens at `:root`.
- Dashboard embedded docs routes: needs tokens contained so they don't leak into the shadcn dashboard.

#1643 optimized for the dashboard and broke the standalone app.

## Fix

- `design-system/docs-tokens.css` → back to `:root` (serves the standalone app; `--ds-*`/font/layout primitives never collide with shadcn), but **drop only** the three shadcn-reserved aliases `--accent` / `--primary` / `--border` — the only names that leaked into the dashboard.
- `apps/docs/global.css` → fixes the import path and declares those three in its own `:root` (no collision there).
- Dashboard embedded docs already scope all three under `.docs-theme` (`docs-theme.css`), so the original skeleton/hover fix from #1643 stays in place.
- Restore `:root[data-theme='dark']` so `apps/docs` dark mode works (it toggles via `data-theme`).

## Verify

- `apps/docs` CSS import resolves (verified locally; build proceeds past the prior error).
- Dashboard: no `:root` shadcn-token leak — skeletons/hover stay subtle gray.
- docs.chmonitor.dev: Vercel/Geist look unchanged, dark mode intact.

Co-Authored-By: duyetbot <bot@duyet.net>