### PR TITLE
fix(docker): copy design-system into build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,11 @@ ENV NODE_ENV=production \
 COPY packages/ /app/packages/
 # tsconfig.base.json lives at the repo root and is extended by apps/dashboard/tsconfig.json.
 COPY tsconfig.base.json /app/tsconfig.base.json
+# design-system/ is needed at build time: docs-theme.css @imports
+# ../../../../../../design-system/docs-tokens.css, which Vite/PostCSS resolve
+# during `bun run build:node:ci`. Without this the Docker build fails with a
+# "Can't resolve .../design-system/docs-tokens.css" error (it's outside apps/dashboard/).
+COPY design-system/ /app/design-system/
 COPY apps/dashboard/ /app/apps/dashboard/
 COPY --from=deps /app/apps/dashboard/node_modules /app/apps/dashboard/node_modules
 WORKDIR /app/apps/dashboard


### PR DESCRIPTION
## Problem

Since the docs redesign, the Docker image build (`build-docker-pr` / `build-docker`) fails on `main`:

> Can't resolve \`../../../../../../design-system/docs-tokens.css\`

`apps/dashboard/src/routes/(docs)/docs/docs-theme.css` `@import`s that path, and Vite/PostCSS resolve it at **build time**. But `design-system/` lives at the repo root — outside the `apps/dashboard/` and `packages/` trees the Dockerfile already `COPY`s — so the file is invisible to the builder stage.

This was flagged as a known regression during the docs-tokens work (#1643) but left out of scope there since `build-docker-pr` is not a required check (only the dashboard build gates merges). It's still a real regression worth fixing.

## Fix

`COPY design-system/ /app/design-system/` in the builder stage, before `bun run build:node:ci`.

### Verification

- ✅ Path depth: `docs-theme.css` sits at `apps/dashboard/src/routes/(docs)/docs/`; six `../` climb to the repo root → resolves to `<root>/design-system/`, which maps to `/app/design-system/` in the image.
- ✅ `.dockerignore` does not exclude `design-system/` (so the `COPY` is not a silent no-op).
- ✅ Build-time resolution: CSS `@import` is handled by Vite/PostCSS during the build, which is why the failure is at build (not runtime).
- 🔄 CI `build-docker-pr` going green is the actual definition of done for this PR.

## Notes

Standalone Astro apps (`apps/docs`, `apps/landing`) are excluded from this image via `.dockerignore` and ship as separate Workers, so this only affects the dashboard image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Resolved build issue preventing successful dashboard deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->