### PR TITLE
test(dashboard): stabilize sidebar navigation e2e

### DIFF
--- a/apps/dashboard/cypress/e2e/sidebar-navigation.cy.ts
+++ b/apps/dashboard/cypress/e2e/sidebar-navigation.cy.ts
@@ -41,22 +41,37 @@ describe('Sidebar navigation', () => {
   })
 
   it('navigates to running-queries via sidebar', () => {
-    // Expand the "Queries" group menu first
+    // Ensure sidebar is in expanded state first (it starts expanded by default
+    // but collapse animation may interfere with visibility checks in CI).
+    cy.get('[data-slot="sidebar-trigger"]')
+      .should('exist')
+      .click({ force: true })
+    cy.get('[data-sidebar="sidebar"]').should('be.visible')
+    // Expand the "Queries" group menu
     cy.get(SIDEBAR).contains('button', 'Queries').click()
-    // Find the visible Running Queries link (handles both sidebar and popover)
-    // Using :visible ensures we only match elements actually visible to the user
-    cy.get('a[href*="/running-queries"]:visible').first().click()
+    // Use should('be.visible') instead of :visible CSS pseudo-selector for
+    // more reliable visibility detection in headless Electron with Radix UI
+    // collapsible animations.
+    cy.get('a[href*="/running-queries"]', { timeout: 10000 })
+      .should('be.visible')
+      .first()
+      .click()
     cy.url().should('include', '/running-queries')
     cy.url().should('include', 'host=0')
     cy.get('body').should('exist')
   })
 
   it('navigates to clusters via sidebar', () => {
-    // Expand the "Cluster" group menu first
+    cy.get('[data-slot="sidebar-trigger"]')
+      .should('exist')
+      .click({ force: true })
+    cy.get('[data-sidebar="sidebar"]').should('be.visible')
+    // Expand the "Cluster" group menu
     cy.get(SIDEBAR).contains('button', 'Cluster').click()
-    // Find the visible Clusters link (handles both sidebar and popover)
-    // Using :visible ensures we only match elements actually visible to the user
-    cy.get('a[href*="/clusters"]:visible').first().click()
+    cy.get('a[href*="/clusters"]', { timeout: 10000 })
+      .should('be.visible')
+      .first()
+      .click()
     cy.url().should('include', '/clusters')
     cy.url().should('include', 'host=0')
     cy.get('body').should('exist')


### PR DESCRIPTION
## What

The two `navigates to ... via sidebar` specs intermittently timed out in headless CI — they were red on #1645's `e2e-test` (a non-required check, but still real noise worth fixing).

## Root cause

The sidebar uses Radix UI's collapsible. Its enter animation races Cypress's `:visible` CSS pseudo-selector in headless Electron, so `a[href*="/running-queries"]:visible` matched nothing and the click never happened → timeout.

## Fix

- Force-click `[data-slot="sidebar-trigger"]` up front and assert the sidebar is visible, guaranteeing the expanded state regardless of starting animation timing.
- Replace `:visible` with `should('be.visible')` (+ 10s timeout), which waits for the Radix animation to settle before clicking the link.

## Verification

CI `e2e-test` on this PR going green — specifically the `sidebar-navigation` spec — is the signal it works. Other e2e failures from `/api/healthz fetch failed` are unrelated env noise (no ClickHouse in e2e CI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced sidebar navigation tests with improved visibility assertions and explicit sidebar expansion steps to ensure more reliable test execution across CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->