### PR TITLE
chore(release): use GITHUB_TOKEN for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,7 +35,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.DUYETBOT_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
 


### PR DESCRIPTION
## What

Switches `release-please` from the `DUYETBOT_GITHUB_TOKEN` PAT to the default `GITHUB_TOKEN`.

```diff
-  token: ${{ secrets.DUYETBOT_GITHUB_TOKEN }}
+  token: ${{ secrets.GITHUB_TOKEN }}
```

## ⚠️ Known consequence — auto-release of tagged Docker images stops

`release.yml` builds and pushes **version-tagged** Docker images on `release: published` events that release-please itself cuts (its own header comment documents this dependency). **GitHub does not trigger downstream workflows from events generated by the default `GITHUB_TOKEN`**, so after this change:

- `release.yml` **no longer auto-fires** when release-please publishes a release.
- Tagged image builds must be run **manually** via `release.yml`'s `workflow_dispatch` (it has a `tag` input for this).

### Unaffected

- The `latest` Docker image, built by `ci.yml` (`Image build and Push`) on `push: main`.
- release-please's own job: maintaining the release PR and cutting the release/tag still works with `GITHUB_TOKEN`.

## Why

Owner decision: accept manual dispatch for tagged image releases. (If the actual driver is that `DUYETBOT_GITHUB_TOKEN` is expired/revoked, that's worth confirming separately — but the token swap is wanted regardless.)

## Verification (on next release)

1. Confirm release-please still cuts the release (creates the tag + GitHub release).
2. `release.yml` will **not** run automatically — manually dispatch it with the new tag to build/push the tagged image.