### PR TITLE
fix(agent): add LIMITs to unbounded queries and fix variable shadowing

### DIFF
--- a/apps/dashboard/src/lib/ai/agent/tools/insights-tools.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/insights-tools.ts
@@ -151,42 +151,42 @@ WHERE type = 'QueryFinish' AND event_time > now() - INTERVAL {lastHours:UInt32} 
 
         const largestScan = resultMap.largest_scan
         if (largestScan) {
-          const h = buildHighlight('Largest Data Scan', largestScan, {
+          const highlight = buildHighlight('Largest Data Scan', largestScan, {
             valueKey: 'readable_bytes',
             detailFn: (r) =>
               `scanned ${r.readable_rows} rows in ${formatDuration(Number(r.query_duration_ms || 0))}`,
           })
-          if (h) highlights.push(h)
+          if (highlight) highlights.push(highlight)
         }
 
         const fastestScan = resultMap.fastest_scan
         if (fastestScan) {
-          const h = buildHighlight('Fastest Scan Speed', fastestScan, {
+          const highlight = buildHighlight('Fastest Scan Speed', fastestScan, {
             valueKey: 'readable_speed',
             detailFn: (r) =>
               `processed ${r.readable_bytes} in ${formatDuration(Number(r.query_duration_ms || 0))}`,
           })
-          if (h) highlights.push(h)
+          if (highlight) highlights.push(highlight)
         }
 
         const longestQuery = resultMap.longest_query
         if (longestQuery) {
-          const h = buildHighlight('Longest Query', longestQuery, {
+          const highlight = buildHighlight('Longest Query', longestQuery, {
             valueKey: 'query_duration_ms',
             detailFn: (r) =>
               `duration ${formatDuration(Number(r.query_duration_ms || 0))}, scanned ${r.readable_bytes}`,
           })
-          if (h) highlights.push(h)
+          if (highlight) highlights.push(highlight)
         }
 
         const peakMemory = resultMap.peak_memory
         if (peakMemory) {
-          const h = buildHighlight('Peak Memory', peakMemory, {
+          const highlight = buildHighlight('Peak Memory', peakMemory, {
             valueKey: 'readable_memory',
             detailFn: (r) =>
               `used ${r.readable_memory}, scanned ${r.readable_rows} rows`,
           })
-          if (h) highlights.push(h)
+          if (highlight) highlights.push(highlight)
         }
 
         return {

--- a/apps/dashboard/src/lib/ai/agent/tools/query-tools.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/query-tools.ts
@@ -26,6 +26,7 @@ export function createQueryTools(hostId: number) {
               substring(query, 1, 200) AS query
             FROM system.processes
             ORDER BY elapsed DESC
+            LIMIT 100
           `,
           hostId: resolvedHostId,
         })

--- a/apps/dashboard/src/lib/ai/agent/tools/schema-tools.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/schema-tools.ts
@@ -63,9 +63,9 @@ export function createSchemaTools(hostId: number) {
         const effectiveHostId = resolveHostId(paramHostId, hostId)
         const limit = 500
         const result = (await readOnlyQuery({
-          query: `SELECT name, engine, total_rows, formatReadableSize(total_bytes) AS size FROM system.tables WHERE database = {database:String} ORDER BY total_bytes DESC LIMIT ${limit}`,
+          query: `SELECT name, engine, total_rows, formatReadableSize(total_bytes) AS size FROM system.tables WHERE database = {database:String} ORDER BY total_bytes DESC LIMIT {limit:UInt32}`,
           hostId: effectiveHostId,
-          query_params: { database },
+          query_params: { database, limit },
         })) as unknown[]
         const truncated = Array.isArray(result) && result.length === limit
         return {
@@ -143,9 +143,9 @@ export function createSchemaTools(hostId: number) {
         if (!table) {
           const limit = 500
           const result = (await readOnlyQuery({
-            query: `SELECT name, engine, total_rows, formatReadableSize(total_bytes) AS size FROM system.tables WHERE database = {database:String} ORDER BY name LIMIT ${limit}`,
+            query: `SELECT name, engine, total_rows, formatReadableSize(total_bytes) AS size FROM system.tables WHERE database = {database:String} ORDER BY name LIMIT {limit:UInt32}`,
             hostId: effectiveHostId,
-            query_params: { database },
+            query_params: { database, limit },
           })) as unknown[]
           const truncated = Array.isArray(result) && result.length === limit
           return {

--- a/apps/dashboard/src/lib/ai/agent/tools/zookeeper-tools.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/zookeeper-tools.ts
@@ -23,7 +23,7 @@ export function createZookeeperTools(hostId: number) {
         }
         const resolvedHostId = resolveHostId(hostIdOverride, hostId)
         return readOnlyQuery({
-          query: `SELECT name, value, path FROM system.zookeeper WHERE path = {path:String}`,
+          query: `SELECT name, value, path FROM system.zookeeper WHERE path = {path:String} LIMIT 100`,
           query_params: { path },
           hostId: resolvedHostId,
         })


### PR DESCRIPTION
## Summary

Fixes unbounded query issues and variable shadowing in agent tools.

## Changes

- **P0-2**: Add LIMIT 100 to `get_running_queries` (query-tools.ts)
- **P2-5**: Add LIMIT 100 to `get_zookeeper_info` (zookeeper-tools.ts)  
- **P1-4**: Parameterize LIMIT in `list_tables` (schema-tools.ts)
- **P1-5**: Fix variable shadowing in insights-tools.ts (h → highlight)

## Impact

Prevents unbounded query results that could return millions of rows on busy ClickHouse instances. Improves code clarity by eliminating shadowed variables.

## Testing

Manual verification that queries now return bounded result sets.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Limited running queries results to 100 items for improved performance
  * Limited ZooKeeper information results to 100 items for improved performance

* **Refactor**
  * Improved internal query parameter handling for schema exploration
  * Enhanced highlight construction logic for better code maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->