### PR TITLE
fix(ci): use GITHUB_TOKEN for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,7 +35,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.DUYETBOT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
 


### PR DESCRIPTION
## Problem

Release Please fails on every push to `main` with `Bad credentials - https://docs.github.com/rest`.

The latest main commit re-introduced `token: ${{ secrets.DUYETBOT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}`. The `DUYETBOT_GITHUB_TOKEN` PAT is expired/revoked, and GitHub Actions `||` only falls back on an **empty** value — not an invalid one — so the bad PAT is always used and the job dies.

## Fix

Revert to `token: ${{ secrets.GITHUB_TOKEN }}` (re-applying #1647).

**Known tradeoff** (already documented in #1647): release.yml won't auto-fire downstream tagged-image builds on release events created by the default token; those must be run manually via `workflow_dispatch`. The `latest` image (ci.yml on push:main) is unaffected.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for release automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->