### PR TITLE
fix(overview): remove stray tab strip scrollbar

### DIFF
--- a/apps/dashboard/src/components/agents/agent-visualization/index.tsx
+++ b/apps/dashboard/src/components/agents/agent-visualization/index.tsx
@@ -263,7 +263,9 @@ export function AgentVisualization({
             <ScatterChartPrimitive
               data={sortedRows}
               xKey={xKey}
-              yKeys={yKeys.length > 0 ? yKeys : [columns[1] ?? columns[0] ?? '']}
+              yKeys={
+                yKeys.length > 0 ? yKeys : [columns[1] ?? columns[0] ?? '']
+              }
               readable={viz.readable}
             />
           </Suspense>

--- a/apps/dashboard/src/components/charts/chart-empty.tsx
+++ b/apps/dashboard/src/components/charts/chart-empty.tsx
@@ -36,6 +36,8 @@ interface ChartEmptyProps {
   metadata?: Partial<ApiResponseMetadata>
   /** Navigation target URL when clicked */
   href?: string
+  /** Extra classes applied to the card header — mirrors ChartCard's headerClassName. */
+  headerClassName?: string
 }
 
 export const ChartEmpty = function ChartEmpty({
@@ -49,6 +51,7 @@ export const ChartEmpty = function ChartEmpty({
   data,
   metadata,
   href,
+  headerClassName,
 }: ChartEmptyProps) {
   const router = useRouter()
   const hostId = useHostId()
@@ -118,7 +121,7 @@ export const ChartEmpty = function ChartEmpty({
     >
       {/* Header with title and toolbar */}
       {(title || hasToolbar) && (
-        <CardHeader className={chartCard.header}>
+        <CardHeader className={cn(chartCard.header, headerClassName)}>
           <header className="flex flex-row items-center justify-between gap-2">
             {title ? (
               <div className="flex items-center gap-1.5 min-w-0 flex-1">

--- a/apps/dashboard/src/components/charts/primitives/scatter.tsx
+++ b/apps/dashboard/src/components/charts/primitives/scatter.tsx
@@ -79,19 +79,10 @@ export const ScatterChartPrimitive = function ScatterChartPrimitive({
           }}
         />
         <Tooltip
-          content={
-            <ChartTooltipContent
-              labelKey={xKey}
-              nameKey={yKey}
-            />
-          }
+          content={<ChartTooltipContent labelKey={xKey} nameKey={yKey} />}
           cursor={{ strokeDasharray: '3 3' }}
         />
-        <Scatter
-          data={chartData}
-          fill="var(--chart-1)"
-          fillOpacity={0.7}
-        />
+        <Scatter data={chartData} fill="var(--chart-1)" fillOpacity={0.7} />
       </ScatterChart>
     </ChartContainer>
   )

--- a/apps/dashboard/src/components/skeletons/chart.tsx
+++ b/apps/dashboard/src/components/skeletons/chart.tsx
@@ -9,6 +9,9 @@ interface ChartSkeletonProps {
   className?: string
   title?: string
   type?: ChartSkeletonType
+  /** Extra classes applied to the card header — mirrors ChartCard's headerClassName so
+   *  skeleton and loaded states stay pixel-identical. */
+  headerClassName?: string
 }
 
 /** Area/Line chart skeleton using a beautifully simulated SVG wave */
@@ -195,6 +198,7 @@ export const ChartSkeleton = function ChartSkeleton({
   className,
   title,
   type = 'area',
+  headerClassName,
 }: ChartSkeletonProps = {}) {
   // Render appropriate loader based on type
   const renderContent = () => {
@@ -230,7 +234,7 @@ export const ChartSkeleton = function ChartSkeleton({
     >
       {/* Header geometry mirrors ChartCard's header (same padding + typography)
           so the title row is the same height in both states. */}
-      <CardHeader className={chartCard.header}>
+      <CardHeader className={cn(chartCard.header, headerClassName)}>
         <header className="flex flex-row items-center justify-between gap-2">
           {title ? (
             <span className="flex items-center gap-2 min-w-0">

--- a/apps/dashboard/src/components/skeletons/tabs.tsx
+++ b/apps/dashboard/src/components/skeletons/tabs.tsx
@@ -26,8 +26,8 @@ export function TabsSkeleton({
     <div className={cn('space-y-2', className)}>
       {/* Tabs list skeleton */}
       {variant === 'underline' ? (
-        <div className="overflow-x-auto pb-px">
-          <div className="inline-flex h-auto w-full min-w-max items-center justify-start gap-1 border-b border-border bg-transparent p-0">
+        <div className="scrollbar-hide overflow-x-auto pb-px">
+          <div className="inline-flex h-auto w-full items-center justify-start gap-1 border-b border-border bg-transparent p-0">
             {Array.from({ length: tabCount }).map((_, i) => (
               <Skeleton
                 key={i}

--- a/apps/dashboard/src/routes/(dashboard)/-charts-config.ts
+++ b/apps/dashboard/src/routes/(dashboard)/-charts-config.ts
@@ -360,6 +360,14 @@ const ChartZookeeperWait = lazy(() =>
  */
 export const OVERVIEW_TAB_CHARTS: OverviewChartConfig[] = [
   {
+    id: 'query-count-heatmap-overview',
+    component: ChartQueryCountHeatmap,
+    title: 'Query Activity Heatmap',
+    className: 'w-full h-full col-span-1 md:col-span-2 xl:col-span-3',
+    type: 'custom',
+    href: '/history-queries',
+  },
+  {
     id: 'query-count-24h',
     component: ChartQueryCount,
     title: 'Query Count',
@@ -513,20 +521,20 @@ export const OVERVIEW_TAB_CHARTS: OverviewChartConfig[] = [
     type: 'area',
     href: '/metrics',
   },
-  {
-    id: 'query-count-heatmap-overview',
-    component: ChartQueryCountHeatmap,
-    title: 'Query Activity Heatmap',
-    className: 'w-full h-full col-span-1 md:col-span-2 xl:col-span-3',
-    type: 'custom',
-    href: '/history-queries',
-  },
 ]
 
 /**
  * Queries tab charts - query performance and patterns (detailed view)
  */
 export const QUERIES_TAB_CHARTS: OverviewChartConfig[] = [
+  {
+    id: 'query-count-heatmap',
+    component: ChartQueryCountHeatmap,
+    title: 'Query Activity Heatmap',
+    className: 'w-full h-full col-span-1 md:col-span-2 xl:col-span-3',
+    type: 'custom',
+    href: '/history-queries',
+  },
   {
     id: 'query-count-14d',
     component: ChartQueryCountByUser,
@@ -581,14 +589,6 @@ export const QUERIES_TAB_CHARTS: OverviewChartConfig[] = [
     interval: 'toStartOfHour',
     className: 'w-full h-full',
     type: 'area',
-    href: '/history-queries',
-  },
-  {
-    id: 'query-count-heatmap',
-    component: ChartQueryCountHeatmap,
-    title: 'Query Activity Heatmap',
-    className: 'w-full h-full col-span-1 md:col-span-2 xl:col-span-3',
-    type: 'custom',
     href: '/history-queries',
   },
   {

--- a/apps/dashboard/src/routes/(dashboard)/-insights/stat-card.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/stat-card.tsx
@@ -8,7 +8,7 @@ import { ChartSkeleton } from '@/components/skeletons/chart'
 
 /** Skeleton shown while a stat's chart data is loading. */
 export function statLoading(title: string) {
-  return <ChartSkeleton title={title} />
+  return <ChartSkeleton title={title} headerClassName="py-1" />
 }
 
 /** Empty / error state shown when a stat has no data. */
@@ -25,6 +25,7 @@ export function statEmpty(
       data={data}
       metadata={metadata}
       compact
+      headerClassName="py-1"
     />
   )
 }

--- a/apps/dashboard/src/routes/(dashboard)/overview.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/overview.tsx
@@ -180,8 +180,8 @@ function OverviewPageContent() {
           onValueChange={handleTabChange}
           className="space-y-2"
         >
-          <div className="overflow-x-auto pb-px">
-            <TabsList className="inline-flex h-auto w-full min-w-max items-center justify-start gap-1 rounded-none border-b border-border bg-transparent p-0 text-muted-foreground">
+          <div className="scrollbar-hide overflow-x-auto pb-px">
+            <TabsList className="inline-flex h-auto w-full items-center justify-start gap-1 rounded-none border-b border-border bg-transparent p-0 text-muted-foreground">
               {OVERVIEW_TABS.map((tab) => (
                 <TabsTrigger
                   key={tab.value}


### PR DESCRIPTION
## Summary
- Drop `min-w-max` from `TabsList` in `overview.tsx` — it forced the inner element to always exceed its container, guaranteeing an overflow and a visible scrollbar thumb even when all 6 tabs fit.
- Add `scrollbar-hide` (already in `styles.css`) to the `overflow-x-auto` wrapper; swipe-scroll still works on narrow/mobile viewports.
- Mirror the same fix in `skeletons/tabs.tsx` (underline variant) so loading skeleton matches.

## Test plan
- [ ] Build passes (`bun run build`)
- [ ] Lint passes (`bun run lint`)
- [ ] Desktop: no visible scrollbar thumb on the overview tab strip
- [ ] Mobile (~390 px): clean swipe-scroll, no visible thumb

## Summary by Sourcery

Adjust overview and queries dashboard charts and clean up tab strip behavior and visuals.

New Features:
- Add a query activity heatmap chart to the overview tab layout.

Enhancements:
- Reorganize chart placement so the query activity heatmap appears in both overview and queries tab configurations without duplication.
- Hide the horizontal scrollbar on underline-style tabs while preserving swipe scrolling and align the tabs skeleton with the live overview tabs layout.
- Tidy chart primitive and agent visualization props for consistency and readability.