### PR TITLE
fix(insights): align card title padding between skeleton and loaded states

### DIFF
--- a/apps/dashboard/src/components/charts/chart-empty.tsx
+++ b/apps/dashboard/src/components/charts/chart-empty.tsx
@@ -36,6 +36,8 @@ interface ChartEmptyProps {
   metadata?: Partial<ApiResponseMetadata>
   /** Navigation target URL when clicked */
   href?: string
+  /** Extra classes applied to the card header — mirrors ChartCard's headerClassName. */
+  headerClassName?: string
 }
 
 export const ChartEmpty = function ChartEmpty({
@@ -49,6 +51,7 @@ export const ChartEmpty = function ChartEmpty({
   data,
   metadata,
   href,
+  headerClassName,
 }: ChartEmptyProps) {
   const router = useRouter()
   const hostId = useHostId()
@@ -118,7 +121,7 @@ export const ChartEmpty = function ChartEmpty({
     >
       {/* Header with title and toolbar */}
       {(title || hasToolbar) && (
-        <CardHeader className={chartCard.header}>
+        <CardHeader className={cn(chartCard.header, headerClassName)}>
           <header className="flex flex-row items-center justify-between gap-2">
             {title ? (
               <div className="flex items-center gap-1.5 min-w-0 flex-1">

--- a/apps/dashboard/src/components/skeletons/chart.tsx
+++ b/apps/dashboard/src/components/skeletons/chart.tsx
@@ -9,6 +9,9 @@ interface ChartSkeletonProps {
   className?: string
   title?: string
   type?: ChartSkeletonType
+  /** Extra classes applied to the card header — mirrors ChartCard's headerClassName so
+   *  skeleton and loaded states stay pixel-identical. */
+  headerClassName?: string
 }
 
 /** Area/Line chart skeleton using a beautifully simulated SVG wave */
@@ -195,6 +198,7 @@ export const ChartSkeleton = function ChartSkeleton({
   className,
   title,
   type = 'area',
+  headerClassName,
 }: ChartSkeletonProps = {}) {
   // Render appropriate loader based on type
   const renderContent = () => {
@@ -230,7 +234,7 @@ export const ChartSkeleton = function ChartSkeleton({
     >
       {/* Header geometry mirrors ChartCard's header (same padding + typography)
           so the title row is the same height in both states. */}
-      <CardHeader className={chartCard.header}>
+      <CardHeader className={cn(chartCard.header, headerClassName)}>
         <header className="flex flex-row items-center justify-between gap-2">
           {title ? (
             <span className="flex items-center gap-2 min-w-0">

--- a/apps/dashboard/src/routes/(dashboard)/-insights/stat-card.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/stat-card.tsx
@@ -8,7 +8,7 @@ import { ChartSkeleton } from '@/components/skeletons/chart'
 
 /** Skeleton shown while a stat's chart data is loading. */
 export function statLoading(title: string) {
-  return <ChartSkeleton title={title} />
+  return <ChartSkeleton title={title} headerClassName="py-1" />
 }
 
 /** Empty / error state shown when a stat has no data. */
@@ -25,6 +25,7 @@ export function statEmpty(
       data={data}
       metadata={metadata}
       compact
+      headerClassName="py-1"
     />
   )
 }


### PR DESCRIPTION
## Summary

- Thread `headerClassName` prop through `ChartSkeleton` and `ChartEmpty`
- Pass `headerClassName="py-1"` from `statLoading` and `statEmpty` in `stat-card.tsx`
- Matches the `headerClassName="py-1"` that `StatCard`'s loaded `ChartCard` already uses
- Prevents the card title from shifting position between skeleton → empty → loaded transitions

## Test plan

- [ ] Open `/insights?host=0` and reload; observe card titles stay stable during skeleton → loaded transition
- [ ] Build passes: `bun run build`
- [ ] Lint clean: `bun run lint`

## Summary by Sourcery

Align stat chart card header styling between skeleton, empty, and loaded states to prevent title position shifts.

Enhancements:
- Add an optional headerClassName prop to ChartSkeleton and ChartEmpty to allow consistent header styling with ChartCard.
- Apply matching header padding (py-1) to statLoading and statEmpty so their headers visually match the loaded stat card.