### PR TITLE
feat(overview): move query activity heatmap to top, full width

### DIFF
--- a/apps/dashboard/src/routes/(dashboard)/-charts-config.ts
+++ b/apps/dashboard/src/routes/(dashboard)/-charts-config.ts
@@ -360,6 +360,14 @@ const ChartZookeeperWait = lazy(() =>
  */
 export const OVERVIEW_TAB_CHARTS: OverviewChartConfig[] = [
   {
+    id: 'query-count-heatmap-overview',
+    component: ChartQueryCountHeatmap,
+    title: 'Query Activity Heatmap',
+    className: 'w-full h-full col-span-1 md:col-span-2 xl:col-span-3',
+    type: 'custom',
+    href: '/history-queries',
+  },
+  {
     id: 'query-count-24h',
     component: ChartQueryCount,
     title: 'Query Count',
@@ -513,20 +521,20 @@ export const OVERVIEW_TAB_CHARTS: OverviewChartConfig[] = [
     type: 'area',
     href: '/metrics',
   },
-  {
-    id: 'query-count-heatmap-overview',
-    component: ChartQueryCountHeatmap,
-    title: 'Query Activity Heatmap',
-    className: 'w-full h-full col-span-1 md:col-span-2 xl:col-span-3',
-    type: 'custom',
-    href: '/history-queries',
-  },
 ]
 
 /**
  * Queries tab charts - query performance and patterns (detailed view)
  */
 export const QUERIES_TAB_CHARTS: OverviewChartConfig[] = [
+  {
+    id: 'query-count-heatmap',
+    component: ChartQueryCountHeatmap,
+    title: 'Query Activity Heatmap',
+    className: 'w-full h-full col-span-1 md:col-span-2 xl:col-span-3',
+    type: 'custom',
+    href: '/history-queries',
+  },
   {
     id: 'query-count-14d',
     component: ChartQueryCountByUser,
@@ -581,14 +589,6 @@ export const QUERIES_TAB_CHARTS: OverviewChartConfig[] = [
     interval: 'toStartOfHour',
     className: 'w-full h-full',
     type: 'area',
-    href: '/history-queries',
-  },
-  {
-    id: 'query-count-heatmap',
-    component: ChartQueryCountHeatmap,
-    title: 'Query Activity Heatmap',
-    className: 'w-full h-full col-span-1 md:col-span-2 xl:col-span-3',
-    type: 'custom',
     href: '/history-queries',
   },
   {


### PR DESCRIPTION
Move `query-count-heatmap-overview` to first position in OVERVIEW_TAB_CHARTS
and `query-count-heatmap` to first position in QUERIES_TAB_CHARTS. Heatmap
already spans full width at every grid breakpoint (col-span-1/md:col-span-2/xl:col-span-3).

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Reorder query activity heatmap charts so they appear first and span full width in both the overview and queries dashboard tabs.

New Features:
- Surface the query activity heatmap at the top of the overview dashboard tab for at-a-glance visibility of query load.
- Promote the query activity heatmap to the first position in the queries tab to emphasize query activity patterns.