### PR TITLE
perf(health): batch health checks into one request + show cached values instantly

### DIFF
--- a/apps/dashboard/src/components/health/health-card.tsx
+++ b/apps/dashboard/src/components/health/health-card.tsx
@@ -2,12 +2,12 @@ import { Maximize2 } from 'lucide-react'
 
 import type { Thresholds } from '@/lib/health/thresholds-storage'
 import type { HealthCheckDef } from './health-checks'
+import type { HealthCheckState } from './use-health-checks'
 
 import { HealthDetailDialog } from './health-detail-dialog'
 import { useEffect, useRef, useState } from 'react'
 import { AppLink } from '@/components/ui/app-link'
 import { dispatchAlert, isEscalation } from '@/lib/health/alert-dispatcher'
-import { useChartData, useHostId } from '@/lib/swr'
 import { cn } from '@/lib/utils'
 
 export type HealthStatus = 'ok' | 'warning' | 'critical' | 'loading' | 'error'
@@ -32,37 +32,42 @@ function StatusDot({ status }: { status: HealthStatus }) {
 interface HealthCardProps {
   check: HealthCheckDef
   thresholds: Thresholds
+  hostId: number
+  /** Resolved data for this check from the batched health query. */
+  result: HealthCheckState
+  /** True only while the batched query has no cached data yet. */
+  isLoading: boolean
 }
 
-export function HealthCard({ check, thresholds }: HealthCardProps) {
-  const hostId = useHostId()
+export function HealthCard({
+  check,
+  thresholds,
+  hostId,
+  result,
+  isLoading,
+}: HealthCardProps) {
   const [detailOpen, setDetailOpen] = useState(false)
-  const swr = useChartData({
-    chartName: check.chartName,
-    hostId,
-    refreshInterval: 30000,
-  })
 
   let status: HealthStatus = 'loading'
   let value: number | null = null
   let label = ''
   let row: Record<string, unknown> | undefined
 
-  const metaStatus = swr.metadata?.status
+  const metaStatus = result.status
   const isUnavailable =
     metaStatus === 'table_not_found' || metaStatus === 'table_not_configured'
 
-  if (swr.isLoading) {
+  if (isLoading) {
     status = 'loading'
     label = 'Loading…'
-  } else if (swr.error) {
+  } else if (result.error) {
     status = 'error'
     label = 'Unavailable'
   } else if (isUnavailable) {
     status = 'error'
-    label = swr.metadata?.statusMessage ?? 'Unavailable'
-  } else if (swr.data && swr.data.length > 0) {
-    row = swr.data[0] as Record<string, unknown>
+    label = result.statusMessage ?? 'Unavailable'
+  } else if (result.data && result.data.length > 0) {
+    row = result.data[0] as Record<string, unknown>
     const raw = row[check.valueKey]
     value = raw === null || raw === undefined ? 0 : Number(raw)
     label = check.formatLabel ? check.formatLabel(value) : String(value)
@@ -200,7 +205,7 @@ export function HealthCard({ check, thresholds }: HealthCardProps) {
         label={label}
         thresholds={thresholds}
         row={row}
-        clickhouseVersion={swr.metadata?.clickhouseVersion}
+        clickhouseVersion={result.clickhouseVersion}
       />
     </>
   )

--- a/apps/dashboard/src/components/health/health-grid.tsx
+++ b/apps/dashboard/src/components/health/health-grid.tsx
@@ -1,10 +1,16 @@
 import { HealthCard } from './health-card'
 import { HEALTH_CHECKS } from './health-checks'
 import { RunningMutationsCard, StuckMutationsCard } from './mutations-cards'
-import { useEffect, useState } from 'react'
+import { EMPTY_STATE, useHealthChecks } from './use-health-checks'
+import { useEffect, useMemo, useState } from 'react'
 import { loadThresholds } from '@/lib/health/thresholds-storage'
+import { useHostId } from '@/lib/swr'
+
+const STUCK_MUTATIONS_CHART = 'summary-stuck-mutations'
+const RUNNING_MUTATIONS_CHART = 'summary-used-by-mutations'
 
 export function HealthGrid() {
+  const hostId = useHostId()
   const [overrides, setOverrides] = useState<
     Record<string, { warning: number; critical: number }>
   >({})
@@ -20,6 +26,18 @@ export function HealthGrid() {
     }
   }, [])
 
+  // Every card's chart name, fetched together in one request.
+  const chartNames = useMemo(
+    () => [
+      ...HEALTH_CHECKS.map((c) => c.chartName),
+      STUCK_MUTATIONS_CHART,
+      RUNNING_MUTATIONS_CHART,
+    ],
+    []
+  )
+
+  const { results, isLoading } = useHealthChecks(chartNames, hostId)
+
   return (
     <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
       {HEALTH_CHECKS.map((check) => (
@@ -27,10 +45,21 @@ export function HealthGrid() {
           key={check.id}
           check={check}
           thresholds={overrides[check.id] ?? check.defaults}
+          hostId={hostId}
+          result={results[check.chartName] ?? EMPTY_STATE}
+          isLoading={isLoading}
         />
       ))}
-      <RunningMutationsCard />
-      <StuckMutationsCard />
+      <RunningMutationsCard
+        hostId={hostId}
+        result={results[RUNNING_MUTATIONS_CHART] ?? EMPTY_STATE}
+        isLoading={isLoading}
+      />
+      <StuckMutationsCard
+        hostId={hostId}
+        result={results[STUCK_MUTATIONS_CHART] ?? EMPTY_STATE}
+        isLoading={isLoading}
+      />
     </div>
   )
 }

--- a/apps/dashboard/src/components/health/mutations-cards.tsx
+++ b/apps/dashboard/src/components/health/mutations-cards.tsx
@@ -1,11 +1,17 @@
 import { GitMerge, Wrench } from 'lucide-react'
 
 import type { HealthStatus } from './health-card'
+import type { HealthCheckState } from './use-health-checks'
 
 import { useEffect, useRef } from 'react'
 import { dispatchAlert, isEscalation } from '@/lib/health/alert-dispatcher'
-import { useChartData, useHostId } from '@/lib/swr'
 import { cn } from '@/lib/utils'
+
+interface MutationsCardProps {
+  hostId: number
+  result: HealthCheckState
+  isLoading: boolean
+}
 
 function StatusDot({ status }: { status: HealthStatus }) {
   return (
@@ -55,28 +61,25 @@ function useAlertOnEscalate(
   }, [status, value, label, checkId, title, hostId])
 }
 
-export function StuckMutationsCard() {
-  const hostId = useHostId()
-  const swr = useChartData({
-    chartName: 'summary-stuck-mutations',
-    hostId,
-    refreshInterval: 30000,
-  })
-
+export function StuckMutationsCard({
+  hostId,
+  result,
+  isLoading,
+}: MutationsCardProps) {
   let status: HealthStatus = 'loading'
   let stuck = 0
   let active = 0
   let failed = 0
   let label = ''
 
-  if (swr.isLoading) {
+  if (isLoading) {
     status = 'loading'
     label = 'Loading…'
-  } else if (swr.error) {
+  } else if (result.error) {
     status = 'error'
     label = 'Unavailable'
-  } else if (swr.data && swr.data.length > 0) {
-    const row = swr.data[0] as Record<string, unknown>
+  } else if (result.data && result.data.length > 0) {
+    const row = result.data[0] as Record<string, unknown>
     stuck = Number(row.stuck ?? 0)
     active = Number(row.active ?? 0)
     failed = Number(row.failed ?? 0)
@@ -143,26 +146,23 @@ export function StuckMutationsCard() {
   )
 }
 
-export function RunningMutationsCard() {
-  const hostId = useHostId()
-  const swr = useChartData({
-    chartName: 'summary-used-by-mutations',
-    hostId,
-    refreshInterval: 30000,
-  })
-
+export function RunningMutationsCard({
+  hostId,
+  result,
+  isLoading,
+}: MutationsCardProps) {
   let status: HealthStatus = 'loading'
   let value = 0
   let label = ''
 
-  if (swr.isLoading) {
+  if (isLoading) {
     status = 'loading'
     label = 'Loading…'
-  } else if (swr.error) {
+  } else if (result.error) {
     status = 'error'
     label = 'Unavailable'
-  } else if (swr.data && swr.data.length > 0) {
-    const row = swr.data[0] as Record<string, unknown>
+  } else if (result.data && result.data.length > 0) {
+    const row = result.data[0] as Record<string, unknown>
     value = Number(row.running_count ?? 0)
     if (!Number.isFinite(value)) {
       status = 'error'

--- a/apps/dashboard/src/components/health/use-health-checks.ts
+++ b/apps/dashboard/src/components/health/use-health-checks.ts
@@ -1,0 +1,184 @@
+/**
+ * Batched data hook for the /health page.
+ *
+ * Replaces the previous "one `useChartData` per card" pattern (~12 parallel
+ * requests, each with its own "Loading…" flash) with a SINGLE TanStack Query
+ * that feeds every card:
+ *
+ *  - Standard env hosts hit the batched `/api/v1/health/checks` endpoint, so
+ *    all checks resolve in one HTTP round-trip.
+ *  - Custom / browser / database-backed hosts (negative or non-env hostIds)
+ *    can't be reached server-side, so they fall back to per-chart client fetches
+ *    run in parallel — still surfaced through the same single query, so cards
+ *    share one cache entry and one loading state.
+ *
+ * Because it is one query, returning to /health renders last-known cached values
+ * instantly (TanStack Query gcTime + persisted cache) instead of a loading flash,
+ * while a background refetch updates them.
+ */
+import { useQuery } from '@tanstack/react-query'
+
+import type { DataStatus } from '@/lib/api/types'
+import type { ChartDataPoint } from '@/lib/swr'
+
+import { useMemo } from 'react'
+import {
+  fetchChartForHost,
+  isCustomHost,
+} from '@/lib/host-fetch/resolve-host-fetch'
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { throwIfNotOk } from '@/lib/swr/fetch-error'
+import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
+
+const REFRESH_INTERVAL_MS = 30_000
+
+/** Resolved data for a single health check, consumed by the cards. */
+export interface HealthCheckState {
+  data: ChartDataPoint[]
+  status?: DataStatus
+  statusMessage?: string
+  clickhouseVersion?: string
+  error?: { type: string; message: string }
+}
+
+interface BatchResponse {
+  success: boolean
+  checks: Record<string, HealthCheckState>
+}
+
+export interface UseHealthChecksResult {
+  /** Resolved state per chart name. Empty until the first fetch lands. */
+  results: Record<string, HealthCheckState>
+  isLoading: boolean
+  isValidating: boolean
+}
+
+const EMPTY_STATE: HealthCheckState = { data: [] }
+
+/**
+ * Fetch every requested health check in a single query.
+ *
+ * @param chartNames Chart names backing the cards (from the health card defs).
+ * @param hostId Active host.
+ * @param timezone Optional IANA timezone for the ClickHouse session.
+ */
+export function useHealthChecks(
+  chartNames: readonly string[],
+  hostId: number,
+  timezone?: string
+): UseHealthChecksResult {
+  const { hosts, getConnectionByHostId } = useMergedHosts()
+
+  // Stable, order-independent key for the requested checks. Sorting ~12 names
+  // each render is negligible and keeps the query key deterministic.
+  const sortedNames = [...chartNames].sort()
+
+  const browserConnection = isCustomHost(hostId)
+    ? getConnectionByHostId(hostId)
+    : null
+
+  const queryKey = [
+    '/api/v1/health/checks',
+    hostId,
+    sortedNames.join(','),
+    timezone,
+    hosts.length,
+    browserConnection?.id,
+  ] as const
+
+  const useBatchedEndpoint = !isCustomHost(hostId)
+
+  const { data, error, isPending, isFetching } = useQuery<BatchResponse, Error>(
+    {
+      queryKey,
+      queryFn: async () => {
+        if (useBatchedEndpoint) {
+          const params = new URLSearchParams()
+          params.set('hostId', String(hostId))
+          params.set('charts', sortedNames.join(','))
+          if (timezone) params.set('timezone', timezone)
+          const response = await apiFetch(`/api/v1/health/checks?${params}`)
+          await throwIfNotOk(response, 'Failed to fetch health checks')
+          return response.json() as Promise<BatchResponse>
+        }
+
+        // Custom / db / browser hosts: fan out client-side, one fetch per check,
+        // collapsing per-check failures into the same response shape.
+        const entries = await Promise.all(
+          sortedNames.map(async (name): Promise<[string, HealthCheckState]> => {
+            try {
+              const result = await fetchChartForHost<ChartDataPoint[]>({
+                chartName: name,
+                hostId,
+                hosts,
+                browserConnection,
+                timezone,
+              })
+              const meta = result.metadata as
+                | { status?: DataStatus; statusMessage?: string }
+                | undefined
+              return [
+                name,
+                {
+                  data: Array.isArray(result.data) ? result.data : [],
+                  status: meta?.status,
+                  statusMessage: meta?.statusMessage,
+                },
+              ]
+            } catch (err) {
+              return [
+                name,
+                {
+                  data: [],
+                  error: {
+                    type: 'query_error',
+                    message:
+                      err instanceof Error ? err.message : 'Unknown error',
+                  },
+                },
+              ]
+            }
+          })
+        )
+        const checks: Record<string, HealthCheckState> = {}
+        for (const [name, state] of entries) checks[name] = state
+        return { success: true, checks }
+      },
+      staleTime: REFRESH_INTERVAL_MS * 0.9,
+      refetchInterval: () =>
+        typeof document !== 'undefined' && document.hidden
+          ? false
+          : REFRESH_INTERVAL_MS,
+      refetchOnMount: true,
+      refetchOnReconnect: true,
+      // Keep prior data visible while refetching so revisits don't blank to a
+      // loading state.
+      placeholderData: (prev) => prev,
+    }
+  )
+
+  // Pending only when there is no cached data at all — once cache exists we show
+  // stale values instead of the loading label.
+  const isLoading = isPending && isFetching
+
+  // A top-level fetch failure with no cached data: surface it as a per-check
+  // error so every card shows "Unavailable" instead of a misleading "OK / 0".
+  const results = useMemo<Record<string, HealthCheckState>>(() => {
+    if (data?.checks) return data.checks
+    if (error && !isLoading) {
+      const errored: Record<string, HealthCheckState> = {}
+      for (const name of sortedNames) {
+        errored[name] = {
+          data: [],
+          error: { type: 'query_error', message: error.message },
+        }
+      }
+      return errored
+    }
+    return {}
+  }, [data, error, isLoading, sortedNames])
+
+  return { results, isLoading, isValidating: isFetching }
+}
+
+export { EMPTY_STATE }

--- a/apps/dashboard/src/routes/(dashboard)/-charts-config.ts
+++ b/apps/dashboard/src/routes/(dashboard)/-charts-config.ts
@@ -360,6 +360,14 @@ const ChartZookeeperWait = lazy(() =>
  */
 export const OVERVIEW_TAB_CHARTS: OverviewChartConfig[] = [
   {
+    id: 'query-count-heatmap-overview',
+    component: ChartQueryCountHeatmap,
+    title: 'Query Activity Heatmap',
+    className: 'w-full h-full col-span-1 md:col-span-2 xl:col-span-3',
+    type: 'custom',
+    href: '/history-queries',
+  },
+  {
     id: 'query-count-24h',
     component: ChartQueryCount,
     title: 'Query Count',
@@ -513,20 +521,20 @@ export const OVERVIEW_TAB_CHARTS: OverviewChartConfig[] = [
     type: 'area',
     href: '/metrics',
   },
-  {
-    id: 'query-count-heatmap-overview',
-    component: ChartQueryCountHeatmap,
-    title: 'Query Activity Heatmap',
-    className: 'w-full h-full col-span-1 md:col-span-2 xl:col-span-3',
-    type: 'custom',
-    href: '/history-queries',
-  },
 ]
 
 /**
  * Queries tab charts - query performance and patterns (detailed view)
  */
 export const QUERIES_TAB_CHARTS: OverviewChartConfig[] = [
+  {
+    id: 'query-count-heatmap',
+    component: ChartQueryCountHeatmap,
+    title: 'Query Activity Heatmap',
+    className: 'w-full h-full col-span-1 md:col-span-2 xl:col-span-3',
+    type: 'custom',
+    href: '/history-queries',
+  },
   {
     id: 'query-count-14d',
     component: ChartQueryCountByUser,
@@ -581,14 +589,6 @@ export const QUERIES_TAB_CHARTS: OverviewChartConfig[] = [
     interval: 'toStartOfHour',
     className: 'w-full h-full',
     type: 'area',
-    href: '/history-queries',
-  },
-  {
-    id: 'query-count-heatmap',
-    component: ChartQueryCountHeatmap,
-    title: 'Query Activity Heatmap',
-    className: 'w-full h-full col-span-1 md:col-span-2 xl:col-span-3',
-    type: 'custom',
     href: '/history-queries',
   },
   {

--- a/apps/dashboard/src/routes/api/v1/health/checks.ts
+++ b/apps/dashboard/src/routes/api/v1/health/checks.ts
@@ -1,0 +1,232 @@
+/**
+ * Batched health-checks endpoint
+ * GET /api/v1/health/checks?hostId=0&charts=health-readonly-replicas,health-...&timezone=...
+ *
+ * The /health page renders ~12 health cards, each backed by a chart query in
+ * the registry. Fetching them one-by-one means 12 parallel HTTP requests and a
+ * per-card "Loading…" flash. This endpoint runs all requested checks
+ * server-side in one round-trip and returns them keyed by chart name.
+ *
+ * It reuses the SAME chart query configs the individual cards use (resolved via
+ * chart-registry + query-executor) — no SQL is duplicated here. Each check is
+ * executed independently: if one fails server-side, its entry carries the error
+ * while the others still resolve, so the matching card shows its own error
+ * state and the rest render normally.
+ *
+ * The `charts` list is supplied by the client (derived from the health card
+ * definitions). Every name is validated against the registry and gated by the
+ * chart's own feature permission, so this exposes nothing the existing
+ * /api/v1/charts/$name endpoint does not already.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { DataStatus } from '@/lib/api/types'
+
+import { env } from 'cloudflare:workers'
+import { error } from '@chm/logger'
+import { getChartQuery, hasChart } from '@/lib/api/chart-registry'
+import { executeChartQuery } from '@/lib/api/query-executor'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
+
+/** Per-check result returned in the batched response. */
+interface HealthCheckEntry {
+  data: unknown[]
+  status?: DataStatus
+  statusMessage?: string
+  clickhouseVersion?: string
+  error?: { type: string; message: string }
+}
+
+/** Cap the number of checks a single request may ask for (defensive bound). */
+const MAX_CHECKS = 40
+
+export const Route = createFileRoute('/api/v1/health/checks')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const bindings = env as Record<string, string | undefined>
+        const { searchParams } = new URL(request.url)
+
+        // Validate hostId
+        const hostId = Number(searchParams.get('hostId') ?? '0')
+        if (!Number.isFinite(hostId)) {
+          return Response.json(
+            {
+              success: false,
+              error: { type: 'validation', message: 'Invalid hostId' },
+            },
+            { status: 400 }
+          )
+        }
+
+        // Validate timezone (ignore if invalid)
+        const timezoneParam = searchParams.get('timezone') || undefined
+        let timezone: string | undefined
+        if (timezoneParam) {
+          try {
+            new Intl.DateTimeFormat('en-US', {
+              timeZone: timezoneParam,
+            }).format(new Date())
+            timezone = timezoneParam
+          } catch {
+            // Invalid timezone, ignore
+          }
+        }
+
+        // Requested check chart names (comma-separated, deduped).
+        const charts = Array.from(
+          new Set(
+            (searchParams.get('charts') ?? '')
+              .split(',')
+              .map((c) => c.trim())
+              .filter(Boolean)
+          )
+        ).slice(0, MAX_CHECKS)
+
+        if (charts.length === 0) {
+          return Response.json(
+            {
+              success: false,
+              error: { type: 'validation', message: 'No charts requested' },
+            },
+            { status: 400 }
+          )
+        }
+
+        const entries = await Promise.all(
+          charts.map(async (name): Promise<[string, HealthCheckEntry]> => {
+            if (!hasChart(name)) {
+              return [
+                name,
+                {
+                  data: [],
+                  error: {
+                    type: 'table_not_found',
+                    message: 'Chart not found',
+                  },
+                },
+              ]
+            }
+
+            const queryDef = getChartQuery(name)
+            if (!queryDef || 'queries' in queryDef) {
+              // Health checks are all single-query charts; fail loud if a
+              // multi-query chart is requested rather than silently dropping it.
+              return [
+                name,
+                {
+                  data: [],
+                  error: {
+                    type: 'query_error',
+                    message: 'Unsupported health check query',
+                  },
+                },
+              ]
+            }
+
+            // Enforce the chart's deployment feature gate, same as the
+            // single-chart route. A blocked check carries an error instead of
+            // failing the whole batch.
+            const permissionResponse = await authorizeFeatureRequest(
+              queryDef.permission,
+              request
+            )
+            if (permissionResponse) {
+              return [
+                name,
+                {
+                  data: [],
+                  error: {
+                    type: 'permission_error',
+                    message: `Feature requires authentication (status ${permissionResponse.status})`,
+                  },
+                },
+              ]
+            }
+
+            try {
+              const result = await executeChartQuery(
+                name,
+                queryDef.sql ?? queryDef.query,
+                hostId,
+                queryDef.queryParams,
+                {
+                  bindings,
+                  timezone,
+                  optional: queryDef.optional,
+                  tableCheck: queryDef.tableCheck,
+                }
+              )
+
+              if (result.error) {
+                // Missing optional tables surface as a friendly "unavailable"
+                // status (matches the card's isUnavailable path) rather than a
+                // hard error.
+                if (result.error.type === 'table_not_found') {
+                  return [
+                    name,
+                    {
+                      data: [],
+                      status: 'table_not_found',
+                      statusMessage: result.error.message,
+                      clickhouseVersion: result.clickhouseVersion,
+                    },
+                  ]
+                }
+                return [
+                  name,
+                  {
+                    data: [],
+                    clickhouseVersion: result.clickhouseVersion,
+                    error: {
+                      type: result.error.type ?? 'query_error',
+                      message: result.error.message,
+                    },
+                  },
+                ]
+              }
+
+              const parsed: unknown = result.dataJson
+                ? JSON.parse(result.dataJson)
+                : []
+              return [
+                name,
+                {
+                  data: Array.isArray(parsed) ? parsed : [],
+                  clickhouseVersion: result.clickhouseVersion,
+                },
+              ]
+            } catch (err) {
+              error(`[GET /api/v1/health/checks:${name}]`, err)
+              return [
+                name,
+                {
+                  data: [],
+                  error: {
+                    type: 'query_error',
+                    message:
+                      err instanceof Error ? err.message : 'Unknown error',
+                  },
+                },
+              ]
+            }
+          })
+        )
+
+        const checks: Record<string, HealthCheckEntry> = {}
+        for (const [name, entry] of entries) checks[name] = entry
+
+        return new Response(
+          JSON.stringify({ success: true, host: String(hostId), checks }),
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+              'Cache-Control': 'public, s-maxage=10, stale-while-revalidate=30',
+            },
+          }
+        )
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Problem

The `/health` page rendered ~12 cards, each calling \`useChartData\` independently → **12 parallel HTTP requests**, each showing its own \"Loading…\" flash. Felt slow on every visit.

## Changes

**(B) Batch** — new \`GET /api/v1/health/checks\` endpoint runs all requested checks server-side in **one round-trip**, reusing the **same chart query configs** the cards use (resolved via \`chart-registry\` + \`query-executor\` — no SQL duplicated). Per-check error isolation: if one check fails (or its optional table is missing), that entry carries the error/\`table_not_found\` status while the others still resolve.

**(A) Instant cached values** — new \`useHealthChecks\` hook feeds **all** cards from a single TanStack Query. With the existing 30-min \`gcTime\` + persisted cache and \`placeholderData: (prev) => prev\`, revisiting \`/health\` renders last-known values **instantly** instead of a loading flash, while a background refetch updates them. Keeps the 30s refresh (paused when the tab is hidden).

Cards keep their existing visual states (loading / ok / warn / critical / error / unavailable) — the refactor is a 1:1 mapping of the old per-card SWR fields onto the shared \`result\` props.

### Edge cases
- Custom / browser / database-backed hosts (negative hostIds) can't be reached server-side → fall back to parallel client fetches through the **same** single query (one shared cache + loading state).
- Top-level fetch failure with no cache → every card shows \"Unavailable\" instead of a misleading \"OK / 0\".
- Requested chart names are validated against the registry and gated by each chart's own feature permission — no new exposure beyond the existing \`/api/v1/charts/\$name\` endpoint.

## Verification
- \`bun run build\` (vite + tsc --noEmit) ✅
- \`bun run lint\` ✅ · \`bun run test:unit\` ✅ (1183 pass)
- Endpoint smoke-tested via curl: single 200 JSON with all checks keyed; per-check error isolation confirmed (friendly \`table_not_found\` vs \`network_error\`); 400 on invalid hostId / empty charts. \`/health\` shell returns 200. No \`useChartData\` remains in the health components (one batched request, not 12). Live data not verifiable locally (ClickHouse down) — mechanism verified.

Co-Authored-By: duyetbot <bot@duyet.net>