### PR TITLE
fix(data-table): contain horizontal scroll within table on mobile

### DIFF
--- a/apps/dashboard/src/components/data-table/components/data-table-content.tsx
+++ b/apps/dashboard/src/components/data-table/components/data-table-content.tsx
@@ -231,7 +231,7 @@ export const DataTableContent = memo(function DataTableContent<
 
   return (
     <TooltipProvider>
-      <div className="relative">
+      <div className="relative min-w-0">
         <div
           ref={tableContainerRef}
           className={cn(
@@ -268,7 +268,7 @@ export const DataTableContent = memo(function DataTableContent<
               />
             </div>
           )}
-          <div className={cn(compact ? undefined : tableVisibility)}>
+          <div className={cn('min-w-0', compact ? undefined : tableVisibility)}>
             {enableColumnReordering ? (
               <DndContext
                 sensors={sensors}


### PR DESCRIPTION
## Summary

- Add `min-w-0` to the outer `<div className="relative">` wrapper in `DataTableContent` — this div is a flex item in DataTable's `flex-col` and without `min-w-0` it could expand to its content width (the wide table), pushing page-level horizontal scroll
- Add `min-w-0` to the table-visibility wrapper div so the intermediate block element also participates in width shrinking
- The `tableContainerRef` already had `overflow-x-auto`; these additions ensure the intermediate wrappers don't defeat it by expanding beyond the viewport

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run build` — passes (full prerender, no errors)
- [x] `bun run test:unit` — 1183 pass, 0 fail
- [x] Code review via `/code-review` — no findings
- [ ] Visual: narrow browser to ~390px on a table route (e.g. `/tables?host=0`), confirm table scrolls inside its box and page has no horizontal overflow

## Summary by Sourcery

Contain data table horizontal scrolling within its container on small viewports and tidy related chart component usage.

Bug Fixes:
- Ensure data table horizontal overflow is constrained to the table container on small screens by preventing wrapper elements from expanding beyond the viewport.

Enhancements:
- Simplify JSX formatting in scatter chart primitives and agent visualization components without changing behavior.