### PR TITLE
fix(insights): add auto-rows to charts grid to prevent blank space

### DIFF
--- a/apps/dashboard/src/routes/(dashboard)/-insights/charts-section.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/charts-section.tsx
@@ -35,7 +35,7 @@ export function ChartsSection({ hostId }: { readonly hostId: number }) {
   const hasCompressionData = compressionData && compressionData.length > 0
 
   return (
-    <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+    <div className="grid auto-rows-[280px] grid-cols-1 gap-3 lg:grid-cols-2">
       {hasTopTablesData && <TopTablesBySizeChart hostId={hostId} />}
       {hasCompressionData && <CompressionRatiosChart hostId={hostId} />}
       {!hasTopTablesData && !hasCompressionData && (


### PR DESCRIPTION
ChartsSection grid lacked explicit row heights. ChartCard uses h-full
which resolves to ~0px in auto-sized grid rows — only card headers were
visible and chart bodies collapsed, leaving a large blank area at the
bottom of the page. Add auto-rows-[280px] (matching the overview page)
to give rows a definite height so charts render properly.

Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Bug Fixes:
- Prevent insights chart cards from collapsing and leaving blank space by defining auto row heights in the charts grid layout.