### PR TITLE
fix(insights): give charts-section grid definite row height

### DIFF
--- a/apps/dashboard/src/routes/(dashboard)/-insights/charts-section.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/charts-section.tsx
@@ -35,7 +35,7 @@ export function ChartsSection({ hostId }: { readonly hostId: number }) {
   const hasCompressionData = compressionData && compressionData.length > 0
 
   return (
-    <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+    <div className="grid auto-rows-[280px] grid-cols-1 gap-3 lg:grid-cols-2">
       {hasTopTablesData && <TopTablesBySizeChart hostId={hostId} />}
       {hasCompressionData && <CompressionRatiosChart hostId={hostId} />}
       {!hasTopTablesData && !hasCompressionData && (


### PR DESCRIPTION
## Summary

- Adds `auto-rows-[280px]` to the `ChartsSection` grid in `-insights/charts-section.tsx`
- Root cause: CSS Grid without explicit row heights collapses `h-full` items to ~0px (only card headers were visible, leaving a large blank area below)
- Fix mirrors the same pattern used on the overview page (`auto-rows-[280px]` in `GRID_LAYOUT_2_COL`)
- No changes to `dashboard-shell.tsx` or any shared layout

## Test plan

- [ ] Visit `/insights` — Top 10 Tables by Size and Best Compression Ratios cards render at full height
- [ ] No blank space below the last card
- [ ] Responsive: single column on mobile, two columns on lg+

## Summary by Sourcery

Bug Fixes:
- Prevent insights charts grid items from collapsing to near-zero height by defining a consistent auto row height in the charts section layout.