### PR TITLE
feat(agent): add AgentState as a conversation-history backend option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Developer-facing docs live in `docs/knowledge/` as a linked knowledge graph. Eac
 | Operations | [secret-rotation.md](docs/knowledge/secret-rotation.md) | Redeploy after `wrangler secret put` |
 | Specs | [ai-insights.md](docs/knowledge/ai-insights.md) | AI Insights engine: collect→enrich→persist (findings store), cron + manual generation, stable-key dismissal, overview panel |
 | Specs | [mcp-server.md](docs/knowledge/mcp-server.md) | MCP server at /api/mcp: tools, setup, security |
+| Specs | [agentstate-conversation-store.md](docs/knowledge/agentstate-conversation-store.md) | AgentState conversation backend: store priority, per-user external_id/tag isolation, append-only upsert, AI enrichment, backend/follow-ups routes |
 | Specs | [query-config-format.md](docs/knowledge/query-config-format.md) | QueryConfig type, versioned SQL, BackgroundBar |
 | Specs | [cluster-topology.md](docs/knowledge/cluster-topology.md) | Cluster topology SVG: layout pipeline, constant contracts, OKLCH `hsl(var())` gotcha, shared component, verification harness |
 | Development | [component-ci-stability.md](docs/knowledge/component-ci-stability.md) | Cypress component test fragility and fixes |

--- a/apps/dashboard/bun.lock
+++ b/apps/dashboard/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "dashboard-tsr",
       "dependencies": {
+        "@agentstate/sdk": "^0.1.2",
         "@ai-sdk/openai": "^3.0.72",
         "@ai-sdk/provider-utils": "^4.0.30",
         "@assistant-ui/react": "0.14.11",
@@ -98,6 +99,8 @@
     },
   },
   "packages": {
+    "@agentstate/sdk": ["@agentstate/sdk@0.1.2", "", { "peerDependencies": { "@langchain/langgraph-checkpoint": "^1.0.2" }, "optionalPeers": ["@langchain/langgraph-checkpoint"] }, "sha512-zNFkVMRc+j462MbNzS3MY9gVGvBFd1Ic+odCFe5WDQrTMhaA038OqUAp/EZtW1WBVNaskrIrLVAO2eTzPHIlrA=="],
+
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.133", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.30", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Ebs+7iS9zUgJu5B0RlxM2JmDWzq79Cpd6YdiqcCzB5qFdpfQJPUDiXutqlQP89F2XGjOdDeidulBTXUdXWzOxw=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.72", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.30" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZF545m6pCXLUTERFfRCyfM7WsG4Nu/A+jlXQjSv7w22dGov02ssB0e1kviI3NLIERfRF/U+n2rKbFuUjzYY7CQ=="],

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -29,6 +29,7 @@
     "verify-deploy": "bun scripts/verify-deploy.ts"
   },
   "dependencies": {
+    "@agentstate/sdk": "^0.1.2",
     "@ai-sdk/openai": "^3.0.72",
     "@ai-sdk/provider-utils": "^4.0.30",
     "@assistant-ui/react": "0.14.11",

--- a/apps/dashboard/src/components/agents/welcome/agent-settings-sidebar.tsx
+++ b/apps/dashboard/src/components/agents/welcome/agent-settings-sidebar.tsx
@@ -12,6 +12,8 @@
 
 import {
   ArrowRightIcon,
+  DatabaseIcon,
+  ExternalLinkIcon,
   MonitorIcon,
   PanelRightCloseIcon,
   PlugZapIcon,
@@ -26,6 +28,7 @@ import { AgentModelPicker } from '@/components/agents/welcome/agent-model-picker
 import { SkillDetailDialog } from '@/components/agents/welcome/skill-detail-dialog'
 import { SkillsLibraryDialog } from '@/components/agents/welcome/skills-library-dialog'
 import { SUGGESTED_PROMPTS } from '@/components/agents/welcome/suggested-prompts'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   Drawer,
@@ -37,6 +40,10 @@ import {
 import { Switch } from '@/components/ui/switch'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useAgentSkills } from '@/lib/hooks/use-agent-skills'
+import {
+  CONVERSATION_BACKEND_LABELS,
+  useConversationBackend,
+} from '@/lib/hooks/use-conversation-backend'
 import { useHostId } from '@/lib/swr/use-host'
 import { cn } from '@/lib/utils'
 
@@ -88,6 +95,11 @@ export function AgentSettingsSidebar({
           <MonitorIcon className="text-muted-foreground size-3.5" />
           <span className="font-mono text-[12.5px]">{hostName}</span>
         </div>
+      </SidebarSection>
+
+      {/* CONVERSATION HISTORY */}
+      <SidebarSection label="Conversation History">
+        <ConversationHistoryPanel />
       </SidebarSection>
 
       {/* MODEL */}
@@ -276,6 +288,57 @@ export function AgentSettingsSidebar({
         {sections}
       </div>
     </aside>
+  )
+}
+
+/**
+ * Read-only panel showing where conversation history is persisted. The backend
+ * is fixed at deploy time via environment variables, so nothing here is
+ * editable — it only surfaces the active backend and, for AgentState, a link to
+ * the service plus the AI-enrichment status.
+ */
+function ConversationHistoryPanel() {
+  const { backend, supportsAiEnrichment, isLoading } = useConversationBackend()
+  const label = CONVERSATION_BACKEND_LABELS[backend]
+  const isAgentState = backend === 'agentstate'
+
+  return (
+    <div className="space-y-1.5">
+      <div className="bg-background border-input flex h-9 items-center gap-2 rounded-md border px-3">
+        <DatabaseIcon className="text-muted-foreground size-3.5 shrink-0" />
+        <span className="min-w-0 flex-1 truncate text-[12.5px]">
+          {isLoading ? 'Detecting…' : label}
+        </span>
+        {isAgentState && (
+          <Badge
+            variant={supportsAiEnrichment ? 'default' : 'secondary'}
+            className="shrink-0 text-[9.5px]"
+          >
+            {supportsAiEnrichment ? 'AI enrichment on' : 'AI enrichment off'}
+          </Badge>
+        )}
+      </div>
+
+      {isAgentState && (
+        <a
+          href="https://agentstate.app"
+          target="_blank"
+          rel="noreferrer"
+          className="text-muted-foreground hover:text-foreground hover:bg-muted/40 -mx-1 flex items-center gap-1.5 rounded px-1 py-0.5 text-[11px] transition-colors"
+        >
+          <ExternalLinkIcon className="size-3 shrink-0" />
+          <span className="min-w-0 flex-1 truncate">
+            Manage history on AgentState
+          </span>
+          <ArrowRightIcon className="size-2.5 shrink-0" />
+        </a>
+      )}
+
+      <p className="text-muted-foreground text-[10.5px] leading-snug">
+        The history backend is configured at deploy time via environment
+        variables and cannot be changed here.
+      </p>
+    </div>
   )
 }
 

--- a/apps/dashboard/src/components/assistant-ui/-thread/follow-up-suggestions.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/follow-up-suggestions.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+/**
+ * Follow-up suggestions affordance.
+ *
+ * When the active conversation backend supports AI enrichment (AgentState) and
+ * a persisted conversation exists, this renders a small "Suggested follow-ups"
+ * control. Suggestions are fetched on demand (not automatically) and rendered
+ * as clickable chips; clicking one appends it to the thread as a user message.
+ *
+ * The component renders nothing unless enrichment is supported and a remote
+ * conversation id is available, so it can be dropped into the thread
+ * unconditionally.
+ */
+
+import { SparklesIcon } from 'lucide-react'
+
+import { useThreadListItem, useThreadRuntime } from '@assistant-ui/react'
+import { useAgentAuthGate } from '@/components/assistant-ui/agent-auth-gate'
+import { Button } from '@/components/ui/button'
+import { useConversationBackend } from '@/lib/hooks/use-conversation-backend'
+import { useFollowUps } from '@/lib/hooks/use-follow-ups'
+
+export function FollowUpSuggestions() {
+  const { supportsAiEnrichment } = useConversationBackend()
+  // `remoteId` is the server-side conversation id used by the follow-ups route.
+  const conversationId = useThreadListItem((s) => s.remoteId)
+  const threadRuntime = useThreadRuntime()
+  const { ensureAuthed } = useAgentAuthGate()
+  const { questions, fetchFollowUps, isLoading } = useFollowUps(conversationId)
+
+  // Only available with an AI-enriched backend and an active, persisted thread.
+  if (!supportsAiEnrichment || !conversationId) return null
+
+  const handlePick = (question: string) => {
+    const trimmed = question.trim()
+    if (!trimmed) return
+    if (!ensureAuthed()) return
+    threadRuntime.append({
+      role: 'user',
+      content: [{ type: 'text', text: trimmed }],
+    })
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-1.5">
+      {questions.length === 0 ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => void fetchFollowUps()}
+          disabled={isLoading}
+          className="text-muted-foreground hover:text-foreground h-7 w-fit gap-1.5 px-2 text-[11px]"
+        >
+          <SparklesIcon className="size-3" />
+          {isLoading ? 'Loading suggestions…' : 'Suggested follow-ups'}
+        </Button>
+      ) : (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-muted-foreground inline-flex items-center gap-1 text-[10px] font-semibold tracking-wider uppercase">
+            <SparklesIcon className="size-3" />
+            Follow-ups
+          </span>
+          {questions.map((question) => (
+            <button
+              key={question}
+              type="button"
+              onClick={() => handlePick(question)}
+              className="border-border text-foreground hover:bg-muted/60 rounded-full border px-2.5 py-1 text-[11.5px] transition-colors"
+            >
+              {question}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/assistant-ui/thread.tsx
+++ b/apps/dashboard/src/components/assistant-ui/thread.tsx
@@ -38,6 +38,7 @@ import {
   renderGroupedPart,
 } from './-thread/chain-of-thought'
 import { ThreadComposer, WelcomeComposer } from './-thread/composer'
+import { FollowUpSuggestions } from './-thread/follow-up-suggestions'
 import { MessageStatsFooter } from './-thread/message-stats'
 import {
   ActionBarPrimitive,
@@ -111,6 +112,7 @@ export function Thread({
 
           <div className="sticky bottom-0 z-10 mx-auto flex w-full flex-col items-start gap-2 bg-background pb-3 px-4">
             <ThreadScrollToBottom />
+            <FollowUpSuggestions />
             <ThreadComposer />
             <p className="text-muted-foreground text-[11px] leading-4">
               The agent runs read-only ClickHouse queries. Conversations are

--- a/apps/dashboard/src/lib/conversation-store/agentstate-store.test.ts
+++ b/apps/dashboard/src/lib/conversation-store/agentstate-store.test.ts
@@ -1,0 +1,775 @@
+/**
+ * Unit tests for {@link AgentStateStore}.
+ *
+ * The store constructs `new AgentState(...)` internally and catches the SDK's
+ * `AgentStateError`, so we mock the entire `@agentstate/sdk` module BEFORE
+ * importing the store. The fake `AgentState` records calls and returns
+ * controllable values; the fake `AgentStateError` is the SAME class the store
+ * imports, so `instanceof` checks in the store resolve correctly.
+ *
+ * Tests assert only behaviors the source actually implements (verified against
+ * agentstate-store.ts).
+ */
+
+import type { UIMessage } from 'ai'
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// ── Fake AgentStateError matching the real SDK shape (.code / .status). ──
+class FakeAgentStateError extends Error {
+  code: string
+  status: number
+  constructor(message: string, code: string, status: number) {
+    super(message)
+    this.name = 'AgentStateError'
+    this.code = code
+    this.status = status
+  }
+}
+
+// ── Mutable fake client captured per-test. The store calls `new AgentState()`,
+// so we hand back the singleton `fakeClient` regardless of config. ──
+type AnyFn = (...args: unknown[]) => unknown
+
+interface Call {
+  method: string
+  args: unknown[]
+}
+
+let calls: Call[] = []
+let lastConfig: { apiKey?: string; baseUrl?: string } | undefined
+
+function record(method: string, args: unknown[]): void {
+  calls.push({ method, args })
+}
+
+function callsTo(method: string): Call[] {
+  return calls.filter((c) => c.method === method)
+}
+
+// Default implementations — each test overrides as needed.
+const impl: Record<string, AnyFn> = {}
+
+const fakeClient = {
+  getConversationByExternalId: (...a: unknown[]) =>
+    (
+      impl.getConversationByExternalId ??
+      (() => {
+        throw new FakeAgentStateError('not found', 'NOT_FOUND', 404)
+      })
+    )(...a),
+  listConversations: (...a: unknown[]) =>
+    (
+      impl.listConversations ??
+      (() => ({ data: [], pagination: { limit: 100, next_cursor: null } }))
+    )(...a),
+  createConversation: (...a: unknown[]) =>
+    (impl.createConversation ?? (() => ({ id: 'internal-new' })))(...a),
+  appendMessages: (...a: unknown[]) =>
+    (impl.appendMessages ?? (() => ({ messages: [] })))(...a),
+  updateConversation: (...a: unknown[]) =>
+    (impl.updateConversation ?? (() => ({})))(...a),
+  deleteConversation: (...a: unknown[]) =>
+    (impl.deleteConversation ?? (() => undefined))(...a),
+  generateTitle: (...a: unknown[]) =>
+    (impl.generateTitle ?? (() => ({ title: 'AI Title' })))(...a),
+  generateFollowUps: (...a: unknown[]) =>
+    (impl.generateFollowUps ?? (() => ({ questions: [] })))(...a),
+}
+
+// Wrap every method so calls are recorded.
+for (const method of Object.keys(fakeClient)) {
+  const original = (fakeClient as Record<string, AnyFn>)[method]
+  ;(fakeClient as Record<string, AnyFn>)[method] = (...args: unknown[]) => {
+    record(method, args)
+    return original(...args)
+  }
+}
+
+class FakeAgentState {
+  constructor(config: { apiKey?: string; baseUrl?: string }) {
+    lastConfig = config
+  }
+}
+// Make `new FakeAgentState()` yield the shared fakeClient.
+Object.setPrototypeOf(FakeAgentState.prototype, fakeClient)
+
+mock.module('@agentstate/sdk', () => ({
+  AgentState: FakeAgentState,
+  AgentStateError: FakeAgentStateError,
+}))
+
+const { AgentStateStore } = await import('./agentstate-store')
+const { ConversationStoreError } = await import('./types')
+
+// ── Helpers ──
+function uiMessage(
+  id: string,
+  role: UIMessage['role'],
+  text: string
+): UIMessage {
+  return {
+    id,
+    role,
+    parts: [{ type: 'text', text }],
+  } as UIMessage
+}
+
+function storedConversation(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'conv-1',
+    userId: 'user-a',
+    title: 'My Conversation',
+    messageCount: 1,
+    createdAt: 1000,
+    updatedAt: 2000,
+    messages: [uiMessage('m1', 'user', 'Hello')],
+    ...overrides,
+  } as Parameters<AgentStateStoreType['upsert']>[0]
+}
+
+type AgentStateStoreType = InstanceType<typeof AgentStateStore>
+
+beforeEach(() => {
+  calls = []
+  lastConfig = undefined
+  for (const k of Object.keys(impl)) delete impl[k]
+})
+
+// ============================================================================
+// constructor + config
+// ============================================================================
+describe('constructor', () => {
+  test('passes apiKey and default baseUrl to AgentState', () => {
+    new AgentStateStore({ apiKey: 'as_live_key' })
+    expect(lastConfig?.apiKey).toBe('as_live_key')
+    expect(lastConfig?.baseUrl).toBe('https://agentstate.app/api')
+  })
+
+  test('throws ConversationStoreError VALIDATION_ERROR when apiKey missing', () => {
+    expect(() => new AgentStateStore({ apiKey: '' })).toThrow(
+      ConversationStoreError
+    )
+    try {
+      new AgentStateStore({ apiKey: '' })
+    } catch (err) {
+      expect((err as InstanceType<typeof ConversationStoreError>).code).toBe(
+        'VALIDATION_ERROR'
+      )
+    }
+  })
+
+  test('honors custom baseUrl', () => {
+    new AgentStateStore({ apiKey: 'k', baseUrl: 'https://example.test/api' })
+    expect(lastConfig?.baseUrl).toBe('https://example.test/api')
+  })
+})
+
+// ============================================================================
+// upsert → create
+// ============================================================================
+describe('upsert (create path)', () => {
+  test('creates with deterministic external_id, metadata, and mapped messages', async () => {
+    impl.getConversationByExternalId = () => {
+      throw new FakeAgentStateError('missing', 'NOT_FOUND', 404)
+    }
+    let createArg: Record<string, unknown> | undefined
+    impl.createConversation = (arg: unknown) => {
+      createArg = arg as Record<string, unknown>
+      return { id: 'internal-1' }
+    }
+
+    const store = new AgentStateStore({ apiKey: 'k' })
+    await store.upsert(
+      storedConversation({
+        id: 'conv-x',
+        userId: 'user-z',
+        model: 'gpt-4',
+        hostId: 3,
+        messages: [
+          uiMessage('m1', 'user', 'Hello '),
+          uiMessage('m2', 'assistant', 'World'),
+        ],
+      })
+    )
+
+    expect(createArg?.external_id).toBe('user-z:conv-x')
+    const meta = createArg?.metadata as Record<string, unknown>
+    expect(meta.userId).toBe('user-z')
+    expect(meta.app).toBe('clickhouse-monitoring')
+    expect(meta.model).toBe('gpt-4')
+    expect(meta.hostId).toBe(3)
+    expect(meta.tags).toEqual(['user:user-z'])
+
+    const messages = createArg?.messages as Array<Record<string, unknown>>
+    expect(messages).toHaveLength(2)
+    // content is the joined text of text parts.
+    expect(messages[0].content).toBe('Hello ')
+    expect(messages[0].role).toBe('user')
+    // Full UIMessage preserved under metadata.ui, with uiId for diffing.
+    const m0meta = messages[0].metadata as Record<string, unknown>
+    expect((m0meta.ui as UIMessage).id).toBe('m1')
+    expect(m0meta.uiId).toBe('m1')
+
+    // No append/update on the create path.
+    expect(callsTo('appendMessages')).toHaveLength(0)
+    expect(callsTo('updateConversation')).toHaveLength(0)
+  })
+
+  test('empty text content falls back to a single space (min length 1)', async () => {
+    impl.getConversationByExternalId = () => {
+      throw new FakeAgentStateError('missing', 'NOT_FOUND', 404)
+    }
+    let createArg: Record<string, unknown> | undefined
+    impl.createConversation = (arg: unknown) => {
+      createArg = arg as Record<string, unknown>
+      return { id: 'internal-1' }
+    }
+    const store = new AgentStateStore({ apiKey: 'k' })
+    await store.upsert(
+      storedConversation({
+        messages: [{ id: 'm1', role: 'user', parts: [] } as UIMessage],
+      })
+    )
+    const messages = createArg?.messages as Array<Record<string, unknown>>
+    expect(messages[0].content).toBe(' ')
+  })
+})
+
+// ============================================================================
+// upsert → append-only diff
+// ============================================================================
+describe('upsert (append-only diff path)', () => {
+  test('appends only NEW messages (by metadata.uiId) and updates conversation', async () => {
+    impl.getConversationByExternalId = () => ({
+      id: 'internal-7',
+      external_id: 'user-a:conv-1',
+      title: 'Old',
+      metadata: { userId: 'user-a' },
+      message_count: 1,
+      created_at: 1,
+      updated_at: 2,
+      messages: [
+        {
+          id: 'agent-msg-1',
+          role: 'user',
+          content: 'Hello',
+          metadata: { uiId: 'm1' },
+        },
+      ],
+    })
+    let appendArgs: unknown[] | undefined
+    impl.appendMessages = (...a: unknown[]) => {
+      appendArgs = a
+      return { messages: [] }
+    }
+    let updateArgs: unknown[] | undefined
+    impl.updateConversation = (...a: unknown[]) => {
+      updateArgs = a
+      return {}
+    }
+
+    const store = new AgentStateStore({ apiKey: 'k' })
+    await store.upsert(
+      storedConversation({
+        title: 'Updated Title',
+        messages: [
+          uiMessage('m1', 'user', 'Hello'), // already stored
+          uiMessage('m2', 'assistant', 'New reply'), // new
+        ],
+      })
+    )
+
+    // createConversation must NOT be called when one exists.
+    expect(callsTo('createConversation')).toHaveLength(0)
+
+    // Append targets the internal id and only the new message.
+    expect(appendArgs?.[0]).toBe('internal-7')
+    const appended = appendArgs?.[1] as Array<Record<string, unknown>>
+    expect(appended).toHaveLength(1)
+    expect((appended[0].metadata as Record<string, unknown>).uiId).toBe('m2')
+
+    // updateConversation is called with new title + metadata.
+    expect(updateArgs?.[0]).toBe('internal-7')
+    const updatePayload = updateArgs?.[1] as Record<string, unknown>
+    expect(updatePayload.title).toBe('Updated Title')
+    expect((updatePayload.metadata as Record<string, unknown>).userId).toBe(
+      'user-a'
+    )
+  })
+
+  test('does not call appendMessages when there are no new messages', async () => {
+    impl.getConversationByExternalId = () => ({
+      id: 'internal-7',
+      external_id: 'user-a:conv-1',
+      title: 'Old',
+      metadata: { userId: 'user-a' },
+      message_count: 1,
+      created_at: 1,
+      updated_at: 2,
+      messages: [
+        {
+          id: 'agent-msg-1',
+          role: 'user',
+          content: 'Hello',
+          metadata: { uiId: 'm1' },
+        },
+      ],
+    })
+    const store = new AgentStateStore({ apiKey: 'k' })
+    await store.upsert(
+      storedConversation({ messages: [uiMessage('m1', 'user', 'Hello')] })
+    )
+    expect(callsTo('appendMessages')).toHaveLength(0)
+    // updateConversation is still called.
+    expect(callsTo('updateConversation')).toHaveLength(1)
+  })
+})
+
+// ============================================================================
+// get
+// ============================================================================
+describe('get', () => {
+  test('maps result to StoredConversation, reconstructing UIMessages from metadata.ui', async () => {
+    const richUi = uiMessage('m1', 'assistant', 'Hi')
+    impl.getConversationByExternalId = () => ({
+      id: 'internal-1',
+      external_id: 'user-a:conv-1',
+      title: 'A Title',
+      metadata: { userId: 'user-a', model: 'gpt-4', hostId: 2 },
+      message_count: 1,
+      created_at: 111,
+      updated_at: 222,
+      messages: [
+        {
+          id: 'agent-1',
+          role: 'assistant',
+          content: 'Hi',
+          metadata: { ui: richUi, uiId: 'm1' },
+        },
+      ],
+    })
+    const store = new AgentStateStore({ apiKey: 'k' })
+    const result = await store.get('user-a', 'conv-1')
+    expect(result).not.toBeNull()
+    expect(result?.id).toBe('conv-1')
+    expect(result?.title).toBe('A Title')
+    expect(result?.model).toBe('gpt-4')
+    expect(result?.hostId).toBe(2)
+    expect(result?.createdAt).toBe(111)
+    expect(result?.messages).toHaveLength(1)
+    // Reconstructed exact UIMessage from metadata.ui.
+    expect(result?.messages[0].id).toBe('m1')
+    expect(result?.messages[0]).toEqual(richUi)
+  })
+
+  test('falls back to a text part when metadata.ui is absent', async () => {
+    impl.getConversationByExternalId = () => ({
+      id: 'internal-1',
+      external_id: 'user-a:conv-1',
+      title: 'T',
+      metadata: { userId: 'user-a' },
+      message_count: 1,
+      created_at: 1,
+      updated_at: 2,
+      messages: [
+        { id: 'agent-1', role: 'user', content: 'plain text', metadata: {} },
+      ],
+    })
+    const store = new AgentStateStore({ apiKey: 'k' })
+    const result = await store.get('user-a', 'conv-1')
+    const msg = result?.messages[0]
+    expect(msg?.role).toBe('user')
+    expect(msg?.parts).toEqual([{ type: 'text', text: 'plain text' }])
+  })
+
+  test('returns null on 404 (NOT_FOUND)', async () => {
+    impl.getConversationByExternalId = () => {
+      throw new FakeAgentStateError('missing', 'NOT_FOUND', 404)
+    }
+    const store = new AgentStateStore({ apiKey: 'k' })
+    expect(await store.get('user-a', 'conv-1')).toBeNull()
+  })
+
+  test('returns null when metadata.userId !== userId (isolation)', async () => {
+    impl.getConversationByExternalId = () => ({
+      id: 'internal-1',
+      external_id: 'other:conv-1',
+      title: 'T',
+      metadata: { userId: 'someone-else' },
+      message_count: 0,
+      created_at: 1,
+      updated_at: 2,
+      messages: [],
+    })
+    const store = new AgentStateStore({ apiKey: 'k' })
+    expect(await store.get('user-a', 'conv-1')).toBeNull()
+  })
+})
+
+// ============================================================================
+// list
+// ============================================================================
+describe('list', () => {
+  function conv(id: string, userId: string, extId: string) {
+    return {
+      id,
+      external_id: extId,
+      title: `title-${id}`,
+      metadata: { userId },
+      message_count: 0,
+      created_at: 1,
+      updated_at: 2,
+    }
+  }
+
+  test('filters to conversations whose metadata.userId matches and maps to ConversationMeta', async () => {
+    impl.listConversations = () => ({
+      data: [
+        conv('a', 'user-a', 'user-a:conv-a'),
+        conv('b', 'other', 'other:conv-b'),
+        conv('c', 'user-a', 'user-a:conv-c'),
+      ],
+      pagination: { limit: 100, next_cursor: null },
+    })
+    const store = new AgentStateStore({ apiKey: 'k' })
+    const result = await store.list('user-a')
+    expect(result).toHaveLength(2)
+    // conversation id is derived from external_id (prefix stripped).
+    expect(result.map((r) => r.id)).toEqual(['conv-a', 'conv-c'])
+    expect(result[0].userId).toBe('user-a')
+    expect(result[0].title).toBe('title-a')
+  })
+
+  test('respects the limit', async () => {
+    impl.listConversations = () => ({
+      data: [
+        conv('a', 'user-a', 'user-a:conv-a'),
+        conv('b', 'user-a', 'user-a:conv-b'),
+        conv('c', 'user-a', 'user-a:conv-c'),
+      ],
+      pagination: { limit: 100, next_cursor: null },
+    })
+    const store = new AgentStateStore({ apiKey: 'k' })
+    const result = await store.list('user-a', 2)
+    expect(result).toHaveLength(2)
+    expect(result.map((r) => r.id)).toEqual(['conv-a', 'conv-b'])
+  })
+
+  test('paginates using pagination.next_cursor', async () => {
+    let page = 0
+    const cursors: (string | undefined)[] = []
+    impl.listConversations = (params: unknown) => {
+      cursors.push((params as { cursor?: string }).cursor)
+      page += 1
+      if (page === 1) {
+        return {
+          data: [conv('a', 'user-a', 'user-a:conv-a')],
+          pagination: { limit: 100, next_cursor: 'cursor-2' },
+        }
+      }
+      return {
+        data: [conv('b', 'user-a', 'user-a:conv-b')],
+        pagination: { limit: 100, next_cursor: null },
+      }
+    }
+    const store = new AgentStateStore({ apiKey: 'k' })
+    const result = await store.list('user-a', 50)
+    expect(result.map((r) => r.id)).toEqual(['conv-a', 'conv-b'])
+    // First call no cursor, second call uses next_cursor.
+    expect(cursors[0]).toBeUndefined()
+    expect(cursors[1]).toBe('cursor-2')
+  })
+})
+
+// ============================================================================
+// delete / deleteAll
+// ============================================================================
+describe('delete', () => {
+  test('resolves internal id then calls deleteConversation', async () => {
+    impl.getConversationByExternalId = () => ({
+      id: 'internal-9',
+      external_id: 'user-a:conv-1',
+      title: 'T',
+      metadata: { userId: 'user-a' },
+      message_count: 0,
+      created_at: 1,
+      updated_at: 2,
+      messages: [],
+    })
+    let deletedId: unknown
+    impl.deleteConversation = (id: unknown) => {
+      deletedId = id
+      return undefined
+    }
+    const store = new AgentStateStore({ apiKey: 'k' })
+    await store.delete('user-a', 'conv-1')
+    expect(deletedId).toBe('internal-9')
+  })
+
+  test('no-op when conversation missing (404)', async () => {
+    impl.getConversationByExternalId = () => {
+      throw new FakeAgentStateError('missing', 'NOT_FOUND', 404)
+    }
+    const store = new AgentStateStore({ apiKey: 'k' })
+    await store.delete('user-a', 'conv-1')
+    expect(callsTo('deleteConversation')).toHaveLength(0)
+  })
+
+  test('no-op when conversation owned by another user', async () => {
+    impl.getConversationByExternalId = () => ({
+      id: 'internal-9',
+      external_id: 'other:conv-1',
+      title: 'T',
+      metadata: { userId: 'other' },
+      message_count: 0,
+      created_at: 1,
+      updated_at: 2,
+      messages: [],
+    })
+    const store = new AgentStateStore({ apiKey: 'k' })
+    await store.delete('user-a', 'conv-1')
+    expect(callsTo('deleteConversation')).toHaveLength(0)
+  })
+})
+
+describe('deleteAll', () => {
+  test("iterates the user's conversations and deletes each owned one", async () => {
+    impl.listConversations = () => ({
+      data: [
+        {
+          id: 'internal-a',
+          external_id: 'user-a:conv-a',
+          metadata: { userId: 'user-a' },
+          title: null,
+          message_count: 0,
+          created_at: 1,
+          updated_at: 2,
+        },
+        {
+          id: 'internal-b',
+          external_id: 'other:conv-b',
+          metadata: { userId: 'other' },
+          title: null,
+          message_count: 0,
+          created_at: 1,
+          updated_at: 2,
+        },
+        {
+          id: 'internal-c',
+          external_id: 'user-a:conv-c',
+          metadata: { userId: 'user-a' },
+          title: null,
+          message_count: 0,
+          created_at: 1,
+          updated_at: 2,
+        },
+      ],
+      pagination: { limit: 100, next_cursor: null },
+    })
+    const deleted: unknown[] = []
+    impl.deleteConversation = (id: unknown) => {
+      deleted.push(id)
+      return undefined
+    }
+    const store = new AgentStateStore({ apiKey: 'k' })
+    await store.deleteAll('user-a')
+    expect(deleted).toEqual(['internal-a', 'internal-c'])
+  })
+})
+
+// ============================================================================
+// AI enrichment
+// ============================================================================
+describe('AI enrichment', () => {
+  function existingNone() {
+    impl.getConversationByExternalId = () => {
+      throw new FakeAgentStateError('missing', 'NOT_FOUND', 404)
+    }
+    impl.createConversation = () => ({ id: 'internal-1' })
+  }
+
+  test('calls generateTitle when aiEnrich and title is generic, with user+assistant messages', async () => {
+    existingNone()
+    const store = new AgentStateStore({ apiKey: 'k', aiEnrich: true })
+    await store.upsert(
+      storedConversation({
+        title: 'New Conversation',
+        messages: [
+          uiMessage('m1', 'user', 'hi'),
+          uiMessage('m2', 'assistant', 'hello'),
+        ],
+      })
+    )
+    expect(callsTo('generateTitle')).toHaveLength(1)
+    expect(callsTo('generateTitle')[0].args[0]).toBe('internal-1')
+  })
+
+  test('does NOT call generateTitle when aiEnrich is false', async () => {
+    existingNone()
+    const store = new AgentStateStore({ apiKey: 'k', aiEnrich: false })
+    await store.upsert(
+      storedConversation({
+        title: 'New Conversation',
+        messages: [
+          uiMessage('m1', 'user', 'hi'),
+          uiMessage('m2', 'assistant', 'hello'),
+        ],
+      })
+    )
+    expect(callsTo('generateTitle')).toHaveLength(0)
+  })
+
+  test('does NOT call generateTitle when title is not generic', async () => {
+    existingNone()
+    const store = new AgentStateStore({ apiKey: 'k', aiEnrich: true })
+    await store.upsert(
+      storedConversation({
+        title: 'A Specific Title',
+        messages: [
+          uiMessage('m1', 'user', 'hi'),
+          uiMessage('m2', 'assistant', 'hello'),
+        ],
+      })
+    )
+    expect(callsTo('generateTitle')).toHaveLength(0)
+  })
+
+  test('does NOT call generateTitle without both user and assistant messages', async () => {
+    existingNone()
+    const store = new AgentStateStore({ apiKey: 'k', aiEnrich: true })
+    await store.upsert(
+      storedConversation({
+        title: 'New Conversation',
+        messages: [uiMessage('m1', 'user', 'hi')],
+      })
+    )
+    expect(callsTo('generateTitle')).toHaveLength(0)
+  })
+
+  test('a thrown error from generateTitle does NOT fail the upsert', async () => {
+    existingNone()
+    impl.generateTitle = () => {
+      throw new Error('title boom')
+    }
+    const store = new AgentStateStore({ apiKey: 'k', aiEnrich: true })
+    // Should resolve without throwing.
+    await store.upsert(
+      storedConversation({
+        title: 'New Conversation',
+        messages: [
+          uiMessage('m1', 'user', 'hi'),
+          uiMessage('m2', 'assistant', 'hello'),
+        ],
+      })
+    )
+    expect(callsTo('generateTitle')).toHaveLength(1)
+  })
+})
+
+// ============================================================================
+// followUps
+// ============================================================================
+describe('followUps', () => {
+  test('returns generateFollowUps().questions', async () => {
+    impl.getConversationByExternalId = () => ({
+      id: 'internal-1',
+      external_id: 'user-a:conv-1',
+      title: 'T',
+      metadata: { userId: 'user-a' },
+      message_count: 0,
+      created_at: 1,
+      updated_at: 2,
+      messages: [],
+    })
+    impl.generateFollowUps = (id: unknown) => {
+      expect(id).toBe('internal-1')
+      return { questions: ['Q1', 'Q2'] }
+    }
+    const store = new AgentStateStore({ apiKey: 'k' })
+    const questions = await store.followUps('user-a', 'conv-1')
+    expect(questions).toEqual(['Q1', 'Q2'])
+  })
+
+  test('throws ConversationStoreError NOT_FOUND when conversation missing', async () => {
+    impl.getConversationByExternalId = () => {
+      throw new FakeAgentStateError('missing', 'NOT_FOUND', 404)
+    }
+    const store = new AgentStateStore({ apiKey: 'k' })
+    await expect(store.followUps('user-a', 'conv-1')).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    })
+  })
+
+  test('throws NOT_FOUND when conversation owned by another user', async () => {
+    impl.getConversationByExternalId = () => ({
+      id: 'internal-1',
+      external_id: 'other:conv-1',
+      title: 'T',
+      metadata: { userId: 'other' },
+      message_count: 0,
+      created_at: 1,
+      updated_at: 2,
+      messages: [],
+    })
+    const store = new AgentStateStore({ apiKey: 'k' })
+    await expect(store.followUps('user-a', 'conv-1')).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    })
+  })
+})
+
+// ============================================================================
+// error mapping (via wrap)
+// ============================================================================
+describe('error mapping', () => {
+  test('AgentStateError status 401 → UNAUTHORIZED', async () => {
+    impl.listConversations = () => {
+      throw new FakeAgentStateError('unauth', 'UNAUTHORIZED', 401)
+    }
+    const store = new AgentStateStore({ apiKey: 'k' })
+    await expect(store.list('user-a')).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    })
+  })
+
+  test('AgentStateError status 403 → UNAUTHORIZED', async () => {
+    impl.listConversations = () => {
+      throw new FakeAgentStateError('forbidden', 'FORBIDDEN', 403)
+    }
+    const store = new AgentStateStore({ apiKey: 'k' })
+    await expect(store.list('user-a')).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    })
+  })
+
+  test('AgentStateError status 400 → VALIDATION_ERROR', async () => {
+    impl.listConversations = () => {
+      throw new FakeAgentStateError('bad', 'BAD_REQUEST', 400)
+    }
+    const store = new AgentStateStore({ apiKey: 'k' })
+    await expect(store.list('user-a')).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+    })
+  })
+
+  test('other AgentStateError → STORAGE_ERROR', async () => {
+    impl.listConversations = () => {
+      throw new FakeAgentStateError('boom', 'INTERNAL', 500)
+    }
+    const store = new AgentStateStore({ apiKey: 'k' })
+    await expect(store.list('user-a')).rejects.toMatchObject({
+      code: 'STORAGE_ERROR',
+    })
+  })
+
+  test('non-AgentStateError → STORAGE_ERROR', async () => {
+    impl.listConversations = () => {
+      throw new Error('plain failure')
+    }
+    const store = new AgentStateStore({ apiKey: 'k' })
+    await expect(store.list('user-a')).rejects.toMatchObject({
+      code: 'STORAGE_ERROR',
+    })
+  })
+})

--- a/apps/dashboard/src/lib/conversation-store/agentstate-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/agentstate-store.ts
@@ -1,0 +1,672 @@
+/**
+ * AgentState-backed conversation storage.
+ *
+ * This module provides a ConversationStore implementation backed by the
+ * AgentState conversation-history service (https://agentstate.app). Each
+ * dashboard conversation is mapped to an AgentState conversation keyed by a
+ * deterministic `external_id` of the form `${userId}:${conversationId}`, which
+ * gives strong per-user isolation and lets us look conversations up without
+ * tracking AgentState's internal ids.
+ *
+ * Lossless round-tripping: the full assistant-ui `UIMessage` is stored inside
+ * each AgentState message's `metadata.ui` field so that reads reconstruct the
+ * exact same UIMessage (including non-text parts). The flattened text content
+ * is also written to AgentState's `content` column so the service can run
+ * title / follow-up generation against readable text.
+ *
+ * Append-only writes: AgentState messages are immutable, so `upsert` diffs the
+ * incoming messages against what is already stored (by UIMessage id) and only
+ * appends the new ones, then updates the conversation title/metadata.
+ */
+
+import type {
+  Conversation,
+  ConversationWithMessages,
+  Message,
+} from '@agentstate/sdk'
+import type { UIMessage } from 'ai'
+import type {
+  ConversationMeta,
+  ConversationMetadata,
+  ConversationStore,
+  StoredConversation,
+} from './types'
+
+import { ConversationStoreError } from './types'
+import { AgentState, AgentStateError } from '@agentstate/sdk'
+import { debug, error as logError } from '@chm/logger'
+
+/**
+ * Default AgentState API base URL.
+ */
+const DEFAULT_BASE_URL = 'https://agentstate.app/api'
+
+/**
+ * Application identifier stored in conversation metadata.
+ */
+const APP_ID = 'clickhouse-monitoring'
+
+/**
+ * Generic conversation titles that should be replaced by AI-generated titles
+ * when AI enrichment is enabled.
+ */
+const GENERIC_TITLES = new Set([
+  'New Conversation',
+  'Untitled Conversation',
+  '',
+])
+
+/**
+ * Maximum number of list pages to scan when filtering by user. Bounds the work
+ * done for users with many conversations while still returning a full page.
+ */
+const MAX_LIST_PAGES = 5
+
+/**
+ * Page size used when paginating AgentState's conversation list.
+ */
+const LIST_PAGE_SIZE = 100
+
+/**
+ * Constructor options for {@link AgentStateStore}.
+ */
+export interface AgentStateStoreOptions {
+  /** AgentState API key (`as_live_...`). Required. */
+  apiKey: string
+  /** AgentState API base URL. Defaults to {@link DEFAULT_BASE_URL}. */
+  baseUrl?: string
+  /** Whether to call AgentState AI enrichment (title generation). */
+  aiEnrich?: boolean
+}
+
+/**
+ * Shape of the conversation-level metadata we persist on AgentState. Mirrors
+ * the fixed columns of {@link ConversationMeta} so reads can reconstruct it
+ * without a separate database.
+ */
+interface StoredConversationMetadata {
+  userId: string
+  model?: string
+  provider?: string
+  hostId?: number
+  totalInputTokens?: number
+  totalOutputTokens?: number
+  totalReasoningTokens?: number
+  totalCachedTokens?: number
+  totalDurationMs?: number
+  totalCostUsd?: number
+  finishReason?: string
+  userRating?: number
+  errorCount?: number
+  app: string
+  tags?: string[]
+  meta?: ConversationMetadata
+}
+
+/**
+ * AgentState-based conversation storage implementation.
+ *
+ * @example
+ * ```ts
+ * const store = new AgentStateStore({ apiKey: process.env.AGENTSTATE_API_KEY! })
+ * await store.upsert({
+ *   id: 'conv-123',
+ *   userId: 'user-abc',
+ *   title: 'My Conversation',
+ *   messages: [...],
+ *   createdAt: Date.now(),
+ *   updatedAt: Date.now(),
+ *   messageCount: 5,
+ * })
+ * ```
+ */
+export class AgentStateStore implements ConversationStore {
+  private readonly client: AgentState
+  private readonly aiEnrich: boolean
+
+  constructor(options: AgentStateStoreOptions) {
+    const { apiKey, baseUrl = DEFAULT_BASE_URL, aiEnrich = false } = options
+
+    if (!apiKey) {
+      throw new ConversationStoreError(
+        'AGENTSTATE_API_KEY is required to construct AgentStateStore',
+        'VALIDATION_ERROR'
+      )
+    }
+
+    this.client = new AgentState({ apiKey, baseUrl })
+    this.aiEnrich = aiEnrich
+  }
+
+  /**
+   * Build the deterministic AgentState external id for a conversation.
+   */
+  private externalId(userId: string, conversationId: string): string {
+    return `${userId}:${conversationId}`
+  }
+
+  /**
+   * Derive the dashboard conversation id from an AgentState external id,
+   * falling back to the stored metadata if the prefix does not match.
+   */
+  private conversationIdFromExternal(
+    externalId: string | null,
+    userId: string
+  ): string | null {
+    if (!externalId) {
+      return null
+    }
+    const prefix = `${userId}:`
+    if (externalId.startsWith(prefix)) {
+      return externalId.slice(prefix.length)
+    }
+    return null
+  }
+
+  /**
+   * Convert a UIMessage into the AgentState message shape. The full UIMessage
+   * is preserved under `metadata.ui` for lossless reads; `content` is the
+   * concatenated text of all text parts (never empty — AgentState requires at
+   * least one character).
+   */
+  private toAgentMessage(
+    uiMessage: UIMessage
+  ): Omit<Message, 'id' | 'created_at'> {
+    const text = (uiMessage.parts ?? [])
+      .filter(
+        (part): part is { type: 'text'; text: string } =>
+          part.type === 'text' &&
+          typeof (part as { text?: unknown }).text === 'string'
+      )
+      .map((part) => part.text)
+      .join('')
+
+    const role: Message['role'] =
+      uiMessage.role === 'user' ||
+      uiMessage.role === 'assistant' ||
+      uiMessage.role === 'system'
+        ? uiMessage.role
+        : 'assistant'
+
+    return {
+      role,
+      // AgentState requires content min length 1.
+      content: text || ' ',
+      metadata: {
+        ui: uiMessage as unknown,
+        uiId: uiMessage.id,
+      },
+    }
+  }
+
+  /**
+   * Reconstruct a UIMessage from an AgentState message. Uses the lossless
+   * `metadata.ui` copy when present, otherwise builds a minimal text message.
+   */
+  private fromAgentMessage(agentMessage: Message): UIMessage {
+    const metadata = (agentMessage.metadata ?? {}) as Record<string, unknown>
+    const ui = metadata.ui
+
+    if (ui && typeof ui === 'object') {
+      return ui as UIMessage
+    }
+
+    const role: UIMessage['role'] =
+      agentMessage.role === 'user' ||
+      agentMessage.role === 'assistant' ||
+      agentMessage.role === 'system'
+        ? agentMessage.role
+        : 'assistant'
+
+    return {
+      id: agentMessage.id ?? crypto.randomUUID(),
+      role,
+      parts: [{ type: 'text', text: agentMessage.content }],
+    }
+  }
+
+  /**
+   * Extract the stored UIMessage id from an AgentState message (used for
+   * append diffing).
+   */
+  private uiIdOf(agentMessage: Message): string | undefined {
+    const metadata = (agentMessage.metadata ?? {}) as Record<string, unknown>
+    const uiId = metadata.uiId
+    return typeof uiId === 'string' ? uiId : undefined
+  }
+
+  /**
+   * Build the AgentState conversation metadata payload from a stored
+   * conversation. Only defined fields are included.
+   */
+  private buildMetadata(
+    conversation: StoredConversation
+  ): Record<string, unknown> {
+    const metadata: StoredConversationMetadata = {
+      userId: conversation.userId,
+      app: APP_ID,
+      tags: [`user:${conversation.userId}`],
+    }
+
+    if (conversation.model !== undefined) metadata.model = conversation.model
+    if (conversation.provider !== undefined)
+      metadata.provider = conversation.provider
+    if (conversation.hostId !== undefined) metadata.hostId = conversation.hostId
+    if (conversation.totalInputTokens !== undefined)
+      metadata.totalInputTokens = conversation.totalInputTokens
+    if (conversation.totalOutputTokens !== undefined)
+      metadata.totalOutputTokens = conversation.totalOutputTokens
+    if (conversation.totalReasoningTokens !== undefined)
+      metadata.totalReasoningTokens = conversation.totalReasoningTokens
+    if (conversation.totalCachedTokens !== undefined)
+      metadata.totalCachedTokens = conversation.totalCachedTokens
+    if (conversation.totalDurationMs !== undefined)
+      metadata.totalDurationMs = conversation.totalDurationMs
+    if (conversation.totalCostUsd !== undefined)
+      metadata.totalCostUsd = conversation.totalCostUsd
+    if (conversation.finishReason !== undefined)
+      metadata.finishReason = conversation.finishReason
+    if (conversation.userRating !== undefined)
+      metadata.userRating = conversation.userRating
+    if (conversation.errorCount !== undefined)
+      metadata.errorCount = conversation.errorCount
+    if (conversation.metadata !== undefined)
+      metadata.meta = conversation.metadata
+
+    return metadata as unknown as Record<string, unknown>
+  }
+
+  /**
+   * Reconstruct a ConversationMeta from an AgentState conversation.
+   */
+  private toConversationMeta(
+    conv: Conversation,
+    userId: string
+  ): ConversationMeta {
+    const metadata = (conv.metadata ??
+      {}) as Partial<StoredConversationMetadata>
+    const conversationId =
+      this.conversationIdFromExternal(conv.external_id, userId) ?? conv.id
+
+    return {
+      id: conversationId,
+      userId,
+      title: conv.title ?? 'Untitled Conversation',
+      messageCount: conv.message_count,
+      model: metadata.model,
+      provider: metadata.provider,
+      hostId: metadata.hostId,
+      totalInputTokens: metadata.totalInputTokens,
+      totalOutputTokens: metadata.totalOutputTokens,
+      totalReasoningTokens: metadata.totalReasoningTokens,
+      totalCachedTokens: metadata.totalCachedTokens,
+      totalDurationMs: metadata.totalDurationMs,
+      totalCostUsd: metadata.totalCostUsd,
+      finishReason: metadata.finishReason,
+      userRating: metadata.userRating,
+      errorCount: metadata.errorCount,
+      metadata: metadata.meta,
+      createdAt: conv.created_at,
+      updatedAt: conv.updated_at,
+    }
+  }
+
+  /**
+   * Look up an AgentState conversation by external id, returning null when it
+   * does not exist (NOT_FOUND / 404).
+   */
+  private async findByExternalId(
+    userId: string,
+    conversationId: string
+  ): Promise<ConversationWithMessages | null> {
+    try {
+      return await this.client.getConversationByExternalId(
+        this.externalId(userId, conversationId)
+      )
+    } catch (err) {
+      if (this.isNotFound(err)) {
+        return null
+      }
+      throw err
+    }
+  }
+
+  /**
+   * Whether an error represents a missing resource (NOT_FOUND / status 404).
+   */
+  private isNotFound(err: unknown): boolean {
+    return (
+      err instanceof AgentStateError &&
+      (err.code === 'NOT_FOUND' || err.status === 404)
+    )
+  }
+
+  /**
+   * Map an underlying error into a ConversationStoreError with an appropriate
+   * code. Re-throws existing ConversationStoreErrors untouched.
+   */
+  private wrap(message: string, err: unknown): ConversationStoreError {
+    if (err instanceof ConversationStoreError) {
+      return err
+    }
+
+    let code: ConversationStoreError['code'] = 'STORAGE_ERROR'
+    if (err instanceof AgentStateError) {
+      if (err.status === 404 || err.code === 'NOT_FOUND') {
+        code = 'NOT_FOUND'
+      } else if (err.status === 401 || err.status === 403) {
+        code = 'UNAUTHORIZED'
+      } else if (err.status === 400) {
+        code = 'VALIDATION_ERROR'
+      }
+    }
+
+    const detail = err instanceof Error ? err.message : 'Unknown error'
+    return new ConversationStoreError(`${message}: ${detail}`, code, err)
+  }
+
+  /**
+   * List conversations for a user.
+   *
+   * AgentState's list endpoint has no server-side tag/user filter, so this
+   * pages through results (newest first) and keeps only conversations whose
+   * stored `metadata.userId` matches, for defensive isolation. Scanning is
+   * bounded by {@link MAX_LIST_PAGES} and stops early once `limit` matches are
+   * collected or pagination is exhausted.
+   *
+   * @param userId - User ID to scope queries
+   * @param limit - Maximum number of conversations to return (default: 50)
+   * @returns Array of conversation metadata (no messages)
+   */
+  async list(userId: string, limit: number = 50): Promise<ConversationMeta[]> {
+    try {
+      const matches: ConversationMeta[] = []
+      let cursor: string | undefined
+      let pages = 0
+
+      while (pages < MAX_LIST_PAGES && matches.length < limit) {
+        const response = await this.client.listConversations({
+          order: 'desc',
+          limit: LIST_PAGE_SIZE,
+          cursor,
+        })
+
+        for (const conv of response.data) {
+          const metadata = (conv.metadata ??
+            {}) as Partial<StoredConversationMetadata>
+          if (metadata.userId !== userId) {
+            continue
+          }
+          matches.push(this.toConversationMeta(conv, userId))
+          if (matches.length >= limit) {
+            break
+          }
+        }
+
+        cursor = response.pagination.next_cursor ?? undefined
+        pages += 1
+        if (!cursor) {
+          break
+        }
+      }
+
+      return matches.slice(0, limit)
+    } catch (err) {
+      logError('[AgentStateStore.list] Failed to list conversations', err)
+      throw this.wrap('Failed to list conversations', err)
+    }
+  }
+
+  /**
+   * Get a single conversation with full messages.
+   *
+   * @param userId - User ID to scope queries (security check)
+   * @param conversationId - Conversation ID to retrieve
+   * @returns Conversation with messages, or null if not found / not owned
+   */
+  async get(
+    userId: string,
+    conversationId: string
+  ): Promise<StoredConversation | null> {
+    try {
+      const conv = await this.findByExternalId(userId, conversationId)
+      if (!conv) {
+        return null
+      }
+
+      const metadata = (conv.metadata ??
+        {}) as Partial<StoredConversationMetadata>
+      // Defensive isolation: never return another user's conversation.
+      if (metadata.userId !== userId) {
+        return null
+      }
+
+      const meta = this.toConversationMeta(conv, userId)
+      const messages = (conv.messages ?? []).map((message) =>
+        this.fromAgentMessage(message)
+      )
+
+      return {
+        ...meta,
+        messages,
+      }
+    } catch (err) {
+      if (this.isNotFound(err)) {
+        return null
+      }
+      logError('[AgentStateStore.get] Failed to get conversation', err)
+      throw this.wrap('Failed to get conversation', err)
+    }
+  }
+
+  /**
+   * Create or update a conversation (append-only diff).
+   *
+   * - If the conversation does not exist, it is created with all messages.
+   * - If it exists, only UIMessages whose id is not already stored are
+   *   appended, then the title and metadata are updated.
+   *
+   * When AI enrichment is enabled and the resulting title is empty or generic,
+   * a best-effort `generateTitle` call is made (failures are swallowed).
+   *
+   * @param conversation - Full conversation to upsert
+   */
+  async upsert(conversation: StoredConversation): Promise<void> {
+    try {
+      const externalId = this.externalId(conversation.userId, conversation.id)
+      const metadata = this.buildMetadata(conversation)
+      const existing = await this.findByExternalId(
+        conversation.userId,
+        conversation.id
+      )
+
+      let internalId: string
+
+      if (!existing) {
+        const created = await this.client.createConversation({
+          external_id: externalId,
+          title: conversation.title,
+          metadata,
+          messages: conversation.messages.map((message) =>
+            this.toAgentMessage(message)
+          ),
+        })
+        internalId = created.id
+      } else {
+        internalId = existing.id
+
+        // Append only messages we have not stored yet (by UIMessage id).
+        const storedUiIds = new Set(
+          (existing.messages ?? [])
+            .map((message) => this.uiIdOf(message))
+            .filter((id): id is string => id !== undefined)
+        )
+        const toAppend = conversation.messages.filter(
+          (message) => !storedUiIds.has(message.id)
+        )
+        if (toAppend.length > 0) {
+          await this.client.appendMessages(
+            internalId,
+            toAppend.map((message) => this.toAgentMessage(message))
+          )
+        }
+
+        await this.client.updateConversation(internalId, {
+          title: conversation.title,
+          metadata,
+        })
+      }
+
+      await this.maybeEnrichTitle(internalId, conversation)
+    } catch (err) {
+      logError('[AgentStateStore.upsert] Failed to upsert conversation', err)
+      throw this.wrap('Failed to upsert conversation', err)
+    }
+  }
+
+  /**
+   * Best-effort AI title generation. Only runs when AI enrichment is enabled,
+   * the current title is empty or generic, and the conversation has at least
+   * one user message and one assistant message. Never throws — enrichment
+   * failures must not fail the upsert.
+   */
+  private async maybeEnrichTitle(
+    internalId: string,
+    conversation: StoredConversation
+  ): Promise<void> {
+    if (!this.aiEnrich) {
+      return
+    }
+    if (!GENERIC_TITLES.has(conversation.title)) {
+      return
+    }
+
+    const hasUser = conversation.messages.some((m) => m.role === 'user')
+    const hasAssistant = conversation.messages.some(
+      (m) => m.role === 'assistant'
+    )
+    if (!hasUser || !hasAssistant) {
+      return
+    }
+
+    try {
+      const { title } = await this.client.generateTitle(internalId)
+      debug('[AgentStateStore.maybeEnrichTitle] Generated title', {
+        internalId,
+        title,
+      })
+    } catch (err) {
+      // Swallow — enrichment is best-effort and must never fail the upsert.
+      logError(
+        '[AgentStateStore.maybeEnrichTitle] Title generation failed',
+        err
+      )
+    }
+  }
+
+  /**
+   * Delete a single conversation (no-op if missing or not owned).
+   *
+   * @param userId - User ID to scope queries (security check)
+   * @param conversationId - Conversation ID to delete
+   */
+  async delete(userId: string, conversationId: string): Promise<void> {
+    try {
+      const existing = await this.findByExternalId(userId, conversationId)
+      if (!existing) {
+        return
+      }
+
+      const metadata = (existing.metadata ??
+        {}) as Partial<StoredConversationMetadata>
+      if (metadata.userId !== userId) {
+        return
+      }
+
+      await this.client.deleteConversation(existing.id)
+    } catch (err) {
+      if (this.isNotFound(err)) {
+        return
+      }
+      logError('[AgentStateStore.delete] Failed to delete conversation', err)
+      throw this.wrap('Failed to delete conversation', err)
+    }
+  }
+
+  /**
+   * Delete all conversations for a user.
+   *
+   * Pages through the conversation list (filtered by `metadata.userId`) and
+   * deletes each owned conversation.
+   *
+   * @param userId - User ID to scope queries
+   */
+  async deleteAll(userId: string): Promise<void> {
+    try {
+      let cursor: string | undefined
+
+      do {
+        const response = await this.client.listConversations({
+          order: 'desc',
+          limit: LIST_PAGE_SIZE,
+          cursor,
+        })
+
+        for (const conv of response.data) {
+          const metadata = (conv.metadata ??
+            {}) as Partial<StoredConversationMetadata>
+          if (metadata.userId !== userId) {
+            continue
+          }
+          await this.client.deleteConversation(conv.id)
+        }
+
+        cursor = response.pagination.next_cursor ?? undefined
+      } while (cursor)
+    } catch (err) {
+      logError(
+        '[AgentStateStore.deleteAll] Failed to delete all conversations',
+        err
+      )
+      throw this.wrap('Failed to delete all conversations', err)
+    }
+  }
+
+  /**
+   * Generate AI follow-up question suggestions for a conversation.
+   *
+   * Resolves the AgentState internal id via the external id, then calls
+   * AgentState's follow-up generation.
+   *
+   * @param userId - User ID to scope queries (security check)
+   * @param conversationId - Conversation ID to suggest follow-ups for
+   * @returns Array of suggested follow-up questions
+   * @throws ConversationStoreError NOT_FOUND when the conversation is missing
+   */
+  async followUps(userId: string, conversationId: string): Promise<string[]> {
+    try {
+      const existing = await this.findByExternalId(userId, conversationId)
+      if (!existing) {
+        throw new ConversationStoreError(
+          `Conversation ${conversationId} not found`,
+          'NOT_FOUND'
+        )
+      }
+
+      const metadata = (existing.metadata ??
+        {}) as Partial<StoredConversationMetadata>
+      if (metadata.userId !== userId) {
+        throw new ConversationStoreError(
+          `Conversation ${conversationId} not found`,
+          'NOT_FOUND'
+        )
+      }
+
+      const { questions } = await this.client.generateFollowUps(existing.id)
+      return questions
+    } catch (err) {
+      logError('[AgentStateStore.followUps] Failed to generate follow-ups', err)
+      throw this.wrap('Failed to generate follow-ups', err)
+    }
+  }
+}

--- a/apps/dashboard/src/lib/conversation-store/resolve-store.agentstate.test.ts
+++ b/apps/dashboard/src/lib/conversation-store/resolve-store.agentstate.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the AgentState branch of {@link resolveStore}.
+ *
+ * resolveStore() consults several collaborators before reaching a backend:
+ *   1. `featureFlags.conversationDb()` — gated on a Vite env flag + Clerk auth.
+ *   2. `process.env.CONVERSATION_STORE_BACKEND` / `AGENTSTATE_API_KEY`.
+ *   3. `getPlatformBindings().getD1Database(...)` for the D1 fallback.
+ *
+ * To isolate the AgentState branch in a unit test we mock:
+ *   - `@/lib/feature-flags` so conversationDb() returns true (avoids needing
+ *     import.meta.env + Clerk).
+ *   - `@chm/platform` so getD1Database() returns undefined (no D1 binding).
+ *   - `@agentstate/sdk` with a minimal fake so `new AgentStateStore(...)` works
+ *     without a real network client.
+ *
+ * We then exercise the forced-`agentstate` backend: missing key throws, present
+ * key returns an AgentStateStore. Env is set/reset around each test.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// ── Mocks (process-global; registered before importing resolve-store). ──
+mock.module('@/lib/feature-flags', () => ({
+  featureFlags: {
+    conversationDb: () => true,
+  },
+}))
+
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({
+    // No D1 binding available — pushes resolution past the D1 branch.
+    getD1Database: () => undefined,
+  }),
+}))
+
+class FakeAgentStateError extends Error {
+  code: string
+  status: number
+  constructor(message: string, code: string, status: number) {
+    super(message)
+    this.code = code
+    this.status = status
+  }
+}
+
+class FakeAgentState {}
+
+mock.module('@agentstate/sdk', () => ({
+  AgentState: FakeAgentState,
+  AgentStateError: FakeAgentStateError,
+}))
+
+const { resolveStore } = await import('./resolve-store')
+const { AgentStateStore } = await import('./agentstate-store')
+const { ConversationStoreError } = await import('./types')
+
+// ── Env snapshot/restore so tests don't leak state. ──
+const ENV_KEYS = [
+  'CONVERSATION_STORE_BACKEND',
+  'AGENTSTATE_API_KEY',
+  'AGENTSTATE_BASE_URL',
+  'AGENTSTATE_AI_ENRICH',
+  'DATABASE_URL',
+] as const
+
+let snapshot: Record<string, string | undefined> = {}
+
+beforeEach(() => {
+  snapshot = {}
+  for (const key of ENV_KEYS) {
+    snapshot[key] = process.env[key]
+    delete process.env[key]
+  }
+})
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (snapshot[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = snapshot[key]
+    }
+  }
+})
+
+describe('resolveStore — AgentState branch', () => {
+  test('forcing agentstate without AGENTSTATE_API_KEY throws VALIDATION_ERROR', async () => {
+    process.env.CONVERSATION_STORE_BACKEND = 'agentstate'
+    // No AGENTSTATE_API_KEY set.
+    await expect(resolveStore()).rejects.toBeInstanceOf(ConversationStoreError)
+    await expect(resolveStore()).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+    })
+  })
+
+  test('forcing agentstate with a key returns an AgentStateStore', async () => {
+    process.env.CONVERSATION_STORE_BACKEND = 'agentstate'
+    process.env.AGENTSTATE_API_KEY = 'as_live_key'
+    const store = await resolveStore()
+    expect(store).toBeInstanceOf(AgentStateStore)
+  })
+
+  test('an API key alone (no forced backend) returns an AgentStateStore', async () => {
+    process.env.AGENTSTATE_API_KEY = 'as_live_key'
+    const store = await resolveStore()
+    expect(store).toBeInstanceOf(AgentStateStore)
+  })
+
+  test('a key present but another backend forced does NOT pick AgentState', async () => {
+    process.env.AGENTSTATE_API_KEY = 'as_live_key'
+    process.env.CONVERSATION_STORE_BACKEND = 'memory'
+    const store = await resolveStore()
+    expect(store).not.toBeInstanceOf(AgentStateStore)
+  })
+})

--- a/apps/dashboard/src/lib/conversation-store/resolve-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/resolve-store.ts
@@ -7,9 +7,11 @@
 
 import type { ConversationStore } from './types'
 
+import { AgentStateStore } from './agentstate-store'
 import { BrowserStore } from './browser-store'
 import { D1Store } from './d1-store'
 import { MemoryStore } from './memory-store'
+import { ConversationStoreError } from './types'
 // PostgresStore is NOT statically imported: the `postgres` package is
 // Node-only and must NOT be bundled into the Cloudflare Workers build.
 // It is loaded only at runtime via dynamic import when DATABASE_URL is set
@@ -23,15 +25,21 @@ import { featureFlags } from '@/lib/feature-flags'
  */
 const D1_BINDING_NAME = 'CONVERSATIONS_D1'
 const DATABASE_URL = 'DATABASE_URL'
+const AGENTSTATE_API_KEY = 'AGENTSTATE_API_KEY'
+const AGENTSTATE_BASE_URL = 'AGENTSTATE_BASE_URL'
+const AGENTSTATE_AI_ENRICH = 'AGENTSTATE_AI_ENRICH'
+const CONVERSATION_STORE_BACKEND = 'CONVERSATION_STORE_BACKEND'
 
 /**
  * Resolves the appropriate conversation store implementation at runtime.
  *
  * Resolution priority:
  * 1. Feature flag disabled → BrowserStore (localStorage)
- * 2. D1 binding available → D1Store (Cloudflare D1)
- * 3. DATABASE_URL env var → PostgresStore
- * 4. No database config → MemoryStore with warning
+ * 2. AgentState (forced via CONVERSATION_STORE_BACKEND=agentstate, or when
+ *    AGENTSTATE_API_KEY is set and no other backend is explicitly forced)
+ * 3. D1 binding available → D1Store (Cloudflare D1)
+ * 4. DATABASE_URL env var → PostgresStore
+ * 5. No database config → MemoryStore with warning
  *
  * @returns Promise resolving to ConversationStore instance
  *
@@ -47,7 +55,30 @@ export async function resolveStore(): Promise<ConversationStore> {
     return new BrowserStore()
   }
 
-  // 2. Check for Cloudflare D1 binding (highest priority for serverless)
+  // 2. AgentState backend. Used when explicitly forced, or when an API key is
+  // present and no other concrete backend is forced. This sits ahead of D1 so
+  // that an explicit AgentState configuration wins even inside Cloudflare.
+  const backend = process.env[CONVERSATION_STORE_BACKEND]
+  const agentStateApiKey = process.env[AGENTSTATE_API_KEY]
+  const otherBackendForced =
+    backend === 'd1' || backend === 'postgres' || backend === 'memory'
+
+  if (backend === 'agentstate' || (agentStateApiKey && !otherBackendForced)) {
+    if (!agentStateApiKey) {
+      throw new ConversationStoreError(
+        'AGENTSTATE_API_KEY is required when CONVERSATION_STORE_BACKEND is set to "agentstate".',
+        'VALIDATION_ERROR'
+      )
+    }
+
+    return new AgentStateStore({
+      apiKey: agentStateApiKey,
+      baseUrl: process.env[AGENTSTATE_BASE_URL],
+      aiEnrich: process.env[AGENTSTATE_AI_ENRICH] === 'true',
+    })
+  }
+
+  // 3. Check for Cloudflare D1 binding (highest priority for serverless)
   try {
     const db = getPlatformBindings().getD1Database(D1_BINDING_NAME)
     if (db) {
@@ -58,7 +89,7 @@ export async function resolveStore(): Promise<ConversationStore> {
     // Not in Cloudflare environment or no binding - continue to next check
   }
 
-  // 3. Check for Postgres DATABASE_URL (traditional database, Node-only path).
+  // 4. Check for Postgres DATABASE_URL (traditional database, Node-only path).
   // Dynamic import keeps the `postgres` package out of the Cloudflare Workers
   // bundle — workerd never reaches this branch (D1 is resolved above).
   if (process.env[DATABASE_URL]) {
@@ -66,7 +97,7 @@ export async function resolveStore(): Promise<ConversationStore> {
     return new PostgresStore(process.env[DATABASE_URL])
   }
 
-  // 4. Fallback to MemoryStore with warning
+  // 5. Fallback to MemoryStore with warning
   if (process.env.NODE_ENV === 'development' || process.env.CI) {
     console.warn(
       '[ConversationStore] No database configured (D1 binding or DATABASE_URL). ' +
@@ -93,6 +124,7 @@ export function isPersistentStore(store: ConversationStore): boolean {
   return (
     store instanceof D1Store ||
     store instanceof BrowserStore ||
+    store instanceof AgentStateStore ||
     !(store instanceof MemoryStore)
   )
 }

--- a/apps/dashboard/src/lib/hooks/use-conversation-backend.ts
+++ b/apps/dashboard/src/lib/hooks/use-conversation-backend.ts
@@ -1,0 +1,141 @@
+'use client'
+
+/**
+ * useConversationBackend Hook
+ *
+ * Client-side hook that reports which conversation-history backend the Worker
+ * is configured to use, and whether that backend supports AI enrichment
+ * (follow-up suggestions, auto titles). The backend is fixed at deploy time via
+ * environment variables, so the result is fetched once and cached.
+ *
+ * Fails safe: any error resolves to the browser (localStorage) backend with AI
+ * enrichment disabled.
+ */
+
+import type { ApiResponse } from '@/lib/api/types'
+
+import { useEffect, useState } from 'react'
+import { apiFetch } from '@/lib/swr/api-fetch'
+
+/** Known conversation store backend identifiers. */
+export type ConversationBackendKind =
+  | 'browser'
+  | 'd1'
+  | 'postgres'
+  | 'memory'
+  | 'agentstate'
+
+/** Human-readable label for each backend kind. */
+export const CONVERSATION_BACKEND_LABELS: Record<
+  ConversationBackendKind,
+  string
+> = {
+  browser: 'Browser (localStorage)',
+  d1: 'Cloudflare D1',
+  postgres: 'PostgreSQL',
+  memory: 'In-memory (ephemeral)',
+  agentstate: 'AgentState',
+}
+
+interface ConversationBackendData {
+  backend: ConversationBackendKind
+  supportsAiEnrichment: boolean
+}
+
+export interface UseConversationBackendResult {
+  backend: ConversationBackendKind
+  supportsAiEnrichment: boolean
+  isLoading: boolean
+  error: Error | null
+}
+
+const FAIL_SAFE: ConversationBackendData = {
+  backend: 'browser',
+  supportsAiEnrichment: false,
+}
+
+// Module-level cache so the endpoint is hit once per page load regardless of
+// how many components mount the hook.
+let cachedData: ConversationBackendData | null = null
+let inFlight: Promise<ConversationBackendData> | null = null
+
+async function fetchBackend(): Promise<ConversationBackendData> {
+  if (cachedData) return cachedData
+  if (inFlight) return inFlight
+
+  inFlight = (async () => {
+    try {
+      const response = await apiFetch('/api/v1/conversations/backend')
+      if (!response.ok) {
+        throw new Error('Failed to fetch conversation backend')
+      }
+      const json =
+        (await response.json()) as ApiResponse<ConversationBackendData>
+      if (!json.success || !json.data) {
+        throw new Error('Malformed conversation backend response')
+      }
+      cachedData = json.data
+      return cachedData
+    } catch {
+      cachedData = FAIL_SAFE
+      return cachedData
+    } finally {
+      inFlight = null
+    }
+  })()
+
+  return inFlight
+}
+
+/**
+ * Reports the active conversation-history backend and its capabilities.
+ *
+ * The value is read-only: the backend is configured at deploy time. Result is
+ * cached at module scope so repeated mounts do not re-fetch.
+ */
+export function useConversationBackend(): UseConversationBackendResult {
+  const [data, setData] = useState<ConversationBackendData | null>(
+    () => cachedData
+  )
+  const [isLoading, setIsLoading] = useState(() => cachedData === null)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    if (cachedData) {
+      setData(cachedData)
+      setIsLoading(false)
+      return
+    }
+
+    let cancelled = false
+    setIsLoading(true)
+
+    fetchBackend()
+      .then((result) => {
+        if (cancelled) return
+        setData(result)
+        setError(null)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setData(FAIL_SAFE)
+        setError(err instanceof Error ? err : new Error(String(err)))
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const resolved = data ?? FAIL_SAFE
+
+  return {
+    backend: resolved.backend,
+    supportsAiEnrichment: resolved.supportsAiEnrichment,
+    isLoading,
+    error,
+  }
+}

--- a/apps/dashboard/src/lib/hooks/use-follow-ups.ts
+++ b/apps/dashboard/src/lib/hooks/use-follow-ups.ts
@@ -1,0 +1,83 @@
+'use client'
+
+/**
+ * useFollowUps Hook
+ *
+ * On-demand fetch of AI-generated follow-up question suggestions for a
+ * conversation. Follow-ups are only produced by the AgentState backend; for any
+ * other backend the endpoint returns 501, which this hook treats as "not
+ * supported" (empty list, no error) rather than a failure.
+ */
+
+import type { ApiResponse } from '@/lib/api/types'
+
+import { useCallback, useState } from 'react'
+import { apiFetch } from '@/lib/swr/api-fetch'
+
+interface FollowUpsData {
+  questions: string[]
+}
+
+export interface UseFollowUpsResult {
+  questions: string[]
+  /** Trigger a fetch on demand. Resolves to the fetched questions. */
+  fetchFollowUps: () => Promise<string[]>
+  isLoading: boolean
+  error: Error | null
+}
+
+/**
+ * Returns follow-up suggestions for `conversationId`, fetched on demand via
+ * {@link UseFollowUpsResult.fetchFollowUps}.
+ *
+ * @param conversationId - Server-side conversation id, or `null`/`undefined`
+ *   when no conversation is active (fetching is then a no-op).
+ */
+export function useFollowUps(
+  conversationId: string | null | undefined
+): UseFollowUpsResult {
+  const [questions, setQuestions] = useState<string[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+
+  const fetchFollowUps = useCallback(async (): Promise<string[]> => {
+    if (!conversationId) return []
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const response = await apiFetch(
+        `/api/v1/conversations/${encodeURIComponent(conversationId)}/follow-ups`
+      )
+
+      // 501 = backend does not support follow-ups. Treat as "not supported":
+      // clear questions, surface no error so we never toast.
+      if (response.status === 501) {
+        setQuestions([])
+        return []
+      }
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch follow-up suggestions')
+      }
+
+      const json = (await response.json()) as ApiResponse<FollowUpsData>
+      if (!json.success || !json.data) {
+        throw new Error('Malformed follow-up suggestions response')
+      }
+
+      const next = Array.isArray(json.data.questions) ? json.data.questions : []
+      setQuestions(next)
+      return next
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err : new Error(String(err)))
+      setQuestions([])
+      return []
+    } finally {
+      setIsLoading(false)
+    }
+  }, [conversationId])
+
+  return { questions, fetchFollowUps, isLoading, error }
+}

--- a/apps/dashboard/src/routes/api/v1/conversations/$id.follow-ups.ts
+++ b/apps/dashboard/src/routes/api/v1/conversations/$id.follow-ups.ts
@@ -1,0 +1,173 @@
+/**
+ * Conversation follow-up suggestions API endpoint
+ * GET /api/v1/conversations/$id/follow-ups - AI-generated follow-up questions
+ *
+ * Follow-up generation is only available when the resolved conversation store
+ * is the AgentState backend (it relies on AgentState's AI enrichment). For any
+ * other backend the endpoint returns 501.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { debug, error, generateRequestId } from '@chm/logger'
+import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import {
+  CacheControl,
+  createSuccessResponse,
+} from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import { AgentStateStore } from '@/lib/conversation-store/agentstate-store'
+import { resolveUserId } from '@/lib/conversation-store/auth'
+import { resolveStore } from '@/lib/conversation-store/resolve-store'
+import { ConversationStoreError } from '@/lib/conversation-store/types'
+import { isFeatureEnabled } from '@/lib/feature-flags'
+import { autoMigrate } from '@/lib/migration/auto-migrate'
+
+const ROUTE_CONTEXT_GET = {
+  route: '/api/v1/conversations/$id/follow-ups',
+  method: 'GET',
+}
+
+/**
+ * Handle GET requests for conversation follow-up suggestions.
+ */
+async function handleGet(id: string): Promise<Response> {
+  const requestId = generateRequestId()
+  debug('[GET /api/v1/conversations/$id/follow-ups] Generating follow-ups', {
+    conversationId: id,
+    requestId,
+  })
+
+  try {
+    await autoMigrate()
+
+    // Guard: conversation persistence must be explicitly enabled
+    if (!isFeatureEnabled('conversationDb')) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.PermissionError,
+          message: 'Conversation storage is not enabled.',
+          details: { timestamp: new Date().toISOString() },
+        },
+        501,
+        ROUTE_CONTEXT_GET
+      )
+    }
+
+    // Resolve authenticated user
+    const userId = await resolveUserId()
+    debug('[GET /api/v1/conversations/$id/follow-ups] User resolved', {
+      userId,
+      requestId,
+    })
+
+    // Validate conversation ID
+    if (!id) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Missing conversation ID',
+          details: { timestamp: new Date().toISOString() },
+        },
+        400,
+        ROUTE_CONTEXT_GET
+      )
+    }
+
+    // Resolve store and ensure it supports follow-up generation
+    const store = await resolveStore()
+    if (!(store instanceof AgentStateStore)) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.PermissionError,
+          message: 'Follow-up suggestions require the AgentState backend.',
+          details: { timestamp: new Date().toISOString() },
+        },
+        501,
+        ROUTE_CONTEXT_GET
+      )
+    }
+
+    const questions = await store.followUps(userId, id)
+
+    // Create response with standardized builder
+    const response = createSuccessResponse(
+      { questions },
+      {
+        queryId: 'conversation-follow-ups',
+        rows: questions.length,
+      }
+    )
+
+    // Add request ID header
+    const newHeaders = new Headers(response.headers)
+    newHeaders.set('X-Request-ID', requestId)
+    newHeaders.set('Cache-Control', CacheControl.NONE)
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: newHeaders,
+    })
+  } catch (err) {
+    const errorMessage =
+      err instanceof Error ? err.message : 'Unknown error occurred'
+
+    error('[GET /api/v1/conversations/$id/follow-ups] Error:', err, {
+      requestId,
+    })
+
+    // Handle conversation store errors
+    if (err instanceof ConversationStoreError) {
+      const errorType =
+        err.code === 'NOT_FOUND'
+          ? ApiErrorType.ValidationError
+          : err.code === 'UNAUTHORIZED'
+            ? ApiErrorType.PermissionError
+            : ApiErrorType.QueryError
+
+      const statusCode =
+        err.code === 'NOT_FOUND' || err.code === 'UNAUTHORIZED' ? 404 : 500
+
+      return createApiErrorResponse(
+        {
+          type: errorType,
+          message: err.message,
+          details: { timestamp: new Date().toISOString() },
+        },
+        statusCode,
+        ROUTE_CONTEXT_GET
+      )
+    }
+
+    const errorResponse = createApiErrorResponse(
+      {
+        type: ApiErrorType.QueryError,
+        message: errorMessage,
+        details: {
+          timestamp: new Date().toISOString(),
+        },
+      },
+      500,
+      ROUTE_CONTEXT_GET
+    )
+
+    // Add request ID header to error response
+    const errorHeaders = new Headers(errorResponse.headers)
+    errorHeaders.set('X-Request-ID', requestId)
+
+    return new Response(errorResponse.body, {
+      status: errorResponse.status,
+      statusText: errorResponse.statusText,
+      headers: errorHeaders,
+    })
+  }
+}
+
+export const Route = createFileRoute('/api/v1/conversations/$id/follow-ups')({
+  server: {
+    handlers: {
+      GET: ({ params }) => handleGet(params.id),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/v1/conversations/backend.ts
+++ b/apps/dashboard/src/routes/api/v1/conversations/backend.ts
@@ -1,0 +1,99 @@
+/**
+ * Conversation backend info API endpoint
+ * GET /api/v1/conversations/backend - Report the active conversation store
+ *   backend and whether it supports AI enrichment.
+ *
+ * This endpoint returns no user data and therefore requires only the
+ * conversationDb feature flag (no auth). It never leaks secrets — only the
+ * backend kind and an AI-enrichment capability flag are returned.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { error, generateRequestId } from '@chm/logger'
+import {
+  CacheControl,
+  createSuccessResponse,
+} from '@/lib/api/shared/response-builder'
+import { AgentStateStore } from '@/lib/conversation-store/agentstate-store'
+import { BrowserStore } from '@/lib/conversation-store/browser-store'
+import { D1Store } from '@/lib/conversation-store/d1-store'
+import { MemoryStore } from '@/lib/conversation-store/memory-store'
+import { resolveStore } from '@/lib/conversation-store/resolve-store'
+import { isFeatureEnabled } from '@/lib/feature-flags'
+
+/**
+ * Known conversation store backend identifiers.
+ */
+type BackendKind = 'browser' | 'd1' | 'postgres' | 'memory' | 'agentstate'
+
+/**
+ * Build a success response carrying the backend info.
+ */
+function backendResponse(
+  backend: BackendKind,
+  supportsAiEnrichment: boolean,
+  requestId: string
+): Response {
+  const response = createSuccessResponse(
+    { backend, supportsAiEnrichment },
+    {
+      queryId: 'conversation-backend',
+      rows: 1,
+    }
+  )
+
+  const headers = new Headers(response.headers)
+  headers.set('X-Request-ID', requestId)
+  headers.set('Cache-Control', CacheControl.NONE)
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
+/**
+ * Handle GET requests reporting the active backend.
+ */
+async function handleGet(): Promise<Response> {
+  const requestId = generateRequestId()
+
+  try {
+    // When persistence is disabled the BrowserStore (localStorage) is used.
+    if (!isFeatureEnabled('conversationDb')) {
+      return backendResponse('browser', false, requestId)
+    }
+
+    const store = await resolveStore()
+
+    let backend: BackendKind = 'postgres'
+    if (store instanceof AgentStateStore) {
+      backend = 'agentstate'
+    } else if (store instanceof D1Store) {
+      backend = 'd1'
+    } else if (store instanceof BrowserStore) {
+      backend = 'browser'
+    } else if (store instanceof MemoryStore) {
+      backend = 'memory'
+    }
+
+    const supportsAiEnrichment =
+      backend === 'agentstate' && process.env.AGENTSTATE_AI_ENRICH === 'true'
+
+    return backendResponse(backend, supportsAiEnrichment, requestId)
+  } catch (err) {
+    error('[GET /api/v1/conversations/backend] Error:', err, { requestId })
+    // Fail safe: default to the browser (localStorage) backend.
+    return backendResponse('browser', false, requestId)
+  }
+}
+
+export const Route = createFileRoute('/api/v1/conversations/backend')({
+  server: {
+    handlers: {
+      GET: () => handleGet(),
+    },
+  },
+})

--- a/docs/content/ai-agent.mdx
+++ b/docs/content/ai-agent.mdx
@@ -41,6 +41,91 @@ For full configuration options see [Configuration](/docs/ai-agent/configuration)
 - [Capabilities](/docs/ai-agent/capabilities) — tools, skills, plan & verify, examples
 - [Conversation History](/docs/ai-agent/conversation-history) — how history works, how to enable server persistence
   - [Store Backends](/docs/ai-agent/conversation-history/backends) — per-backend setup (D1, ClickHouse, Postgres, …)
+  - [AgentState](#conversation-history-backends) — managed/self-hosted persistence with AI enrichment (auto-titles, follow-ups)
+
+## Conversation history backends
+
+Agent chat history is persisted by a server-side `ConversationStore` chosen at **deploy time** by environment variables. Four backends are available:
+
+| Backend | Selected when | Notes |
+|---|---|---|
+| **Browser** | conversation-DB feature flag off | `localStorage` only; history is per-browser, no server setup |
+| **AgentState** | `AGENTSTATE_API_KEY` is set | Managed or self-hosted conversation-history service; optional AI enrichment |
+| **D1** | a Cloudflare D1 binding is present | Cloudflare-native SQLite |
+| **Postgres** | `DATABASE_URL` is set | Any PostgreSQL-compatible database |
+
+Selection priority when persistence is enabled: **AgentState** (if `AGENTSTATE_API_KEY`) → **D1** (Cloudflare binding) → **Postgres** (`DATABASE_URL`) → **Memory** (last-resort, non-persistent). With the feature flag off, history stays in the **Browser**.
+
+Server persistence requires `VITE_FEATURE_CONVERSATION_DB=true` and an authenticated user — configure Clerk (`VITE_AUTH_PROVIDER=clerk` + `CLERK_SECRET_KEY`) so history can be scoped per user. Unauthenticated sessions always fall back to browser history. See [Authentication](/docs/authentication).
+
+### AgentState
+
+[AgentState](https://agentstate.app) is a conversation-history database-as-a-service for AI agents. Use it when you want managed (or self-hosted) persistence that survives browser clears and is shared across devices, plus optional **AI enrichment** — auto-generated conversation titles and follow-up question suggestions — and per-project analytics. It is self-hostable as a single Cloudflare Worker (see [duyet/agentstate](https://github.com/duyet/agentstate)) and ships an npm SDK (`@agentstate/sdk`).
+
+Per-user isolation is built in: each thread is namespaced by AgentState `external_id` as `<userId>:<conversationId>` and tagged `user:<userId>`, so one project key safely holds every user's history without cross-talk.
+
+**Environment variables** (all server-side):
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `AGENTSTATE_API_KEY` | to enable | — | `as_live_...` project key; its presence activates the AgentState backend |
+| `AGENTSTATE_BASE_URL` | no | `https://agentstate.app/api` | endpoint; override to point at a self-hosted instance |
+| `AGENTSTATE_AI_ENRICH` | no | `false` | enable auto-title + follow-up suggestions |
+| `CONVERSATION_STORE_BACKEND` | no | `auto` | force `agentstate` when a Cloudflare D1 binding is also present |
+
+Still requires `VITE_FEATURE_CONVERSATION_DB=true` and a Clerk auth provider (`VITE_AUTH_PROVIDER=clerk` + `CLERK_SECRET_KEY`).
+
+#### Setup (hosted)
+
+1. Sign in at [agentstate.app](https://agentstate.app) and create a project.
+2. Create an API key — it is prefixed `as_live_` and shown **once**, so copy it immediately.
+3. Set it server-side:
+
+```bash
+VITE_FEATURE_CONVERSATION_DB=true
+AGENTSTATE_API_KEY=as_live_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# Optional: turn on auto-titles + follow-up suggestions
+AGENTSTATE_AI_ENRICH=true
+```
+
+#### Setup (self-host)
+
+Run your own AgentState Worker per [duyet/agentstate](https://github.com/duyet/agentstate), then point the dashboard at it:
+
+```bash
+VITE_FEATURE_CONVERSATION_DB=true
+AGENTSTATE_API_KEY=as_live_your_self_hosted_key
+AGENTSTATE_BASE_URL=https://your-agentstate-host/api
+```
+
+#### Local dev
+
+Against a locally running AgentState instance, use the seed test key:
+
+```bash
+VITE_FEATURE_CONVERSATION_DB=true
+AGENTSTATE_BASE_URL=http://localhost:8787
+AGENTSTATE_API_KEY=as_live_TEST_KEY_FOR_LOCAL_DEV_ONLY_1234567890ab
+```
+
+#### Verify it's active
+
+- **Settings sidebar** — the agent settings sidebar shows a read-only **Conversation History** section naming the active backend (e.g. `AgentState`).
+- **Endpoint** — `GET /api/v1/conversations/backend` reports the active backend and whether enrichment is available:
+
+```bash
+curl https://your-host/api/v1/conversations/backend
+# => { "backend": "agentstate", "supportsAiEnrichment": true }
+```
+
+#### AI enrichment
+
+When AgentState is active **and** `AGENTSTATE_AI_ENRICH=true`:
+
+- **Auto-title** — new conversations get a concise generated title instead of a placeholder.
+- **Follow-ups** — the chat suggests follow-up questions after a turn. The dashboard reads them from `GET /api/v1/conversations/$id/follow-ups`.
+
+With enrichment off, conversations persist normally but titles and follow-up suggestions are not generated.
 
 ## HTTP API
 

--- a/docs/content/settings.mdx
+++ b/docs/content/settings.mdx
@@ -15,6 +15,19 @@ To reach it, open the dashboard and click **Settings** in the navigation.
 
 Settings changes made in-app are stored per browser session or in the configured conversation store. They do not affect server-side environment variables.
 
+## Conversation History (agent settings sidebar)
+
+The agent settings sidebar includes a **read-only** "Conversation History" section that names the backend currently storing agent chats. The backend is chosen at deploy time by environment variables — it cannot be switched from the UI. Labels you may see:
+
+| Label | Meaning |
+|---|---|
+| **Browser** | History stays in `localStorage` (server persistence is off) |
+| **AgentState** | Managed/self-hosted [AgentState](https://agentstate.app) service; when AI enrichment is on, the chat also suggests follow-up questions |
+| **D1** | Cloudflare D1 (SQLite) database |
+| **Postgres** | A PostgreSQL-compatible database |
+
+To change the active backend, set the relevant server-side env vars and redeploy. See [Conversation history backends](/docs/ai-agent#conversation-history-backends) in the AI Agent docs for the full env-var reference and setup steps.
+
 ## Gating or disabling Settings
 
 By default, the Settings page is **public** — any visitor can open it. To restrict or remove it:

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -36,6 +36,7 @@ Agents discover knowledge in this order:
 | **Specs** | [ai-insights.md](ai-insights.md) | spec | AI Insights engine: collect→enrich→persist (findings store), cron + manual generation, stable-key dismissal, overview panel |
 | **Specs** | [mcp-server.md](mcp-server.md) | reference | MCP server at /api/mcp: tools, setup, security |
 | **Specs** | [agent-conversation-storage.md](agent-conversation-storage.md) | spec | Runtime-selected agent chat persistence backends and fallback rules |
+| **Specs** | [agentstate-conversation-store.md](agentstate-conversation-store.md) | spec | AgentState backend: resolveStore priority, external_id/tag isolation, append-only upsert, AI enrichment, backend/follow-ups routes |
 | **Specs** | [query-config-format.md](query-config-format.md) | spec | QueryConfig type format, versioned SQL, BackgroundBar columns |
 | **Specs** | [og-images.md](og-images.md) | spec | OG/social images: Satori+resvg generator, vendored fonts, auto-regenerated on Cloudflare deploy, meta wiring |
 | **Specs** | [cluster-topology.md](cluster-topology.md) | spec | Cluster topology SVG: layout pipeline, constant contracts, OKLCH gotcha, shared component, verification harness |

--- a/docs/knowledge/agentstate-conversation-store.md
+++ b/docs/knowledge/agentstate-conversation-store.md
@@ -1,0 +1,107 @@
+---
+id: agentstate-conversation-store
+title: AgentState Conversation Store
+type: spec
+status: active
+updated: 2026-06-17
+related:
+  - agent-conversation-storage
+  - ai-insights
+  - mcp-server
+  - conventions
+tags:
+  - ai-agent
+  - persistence
+  - agentstate
+  - conversation-store
+  - cloudflare
+---
+
+# AgentState Conversation Store
+
+AgentState (<https://agentstate.app>, self-hostable Cloudflare Worker, npm SDK
+`@agentstate/sdk`) is a conversation-history database-as-a-service. It is one of
+the agent's server-side `ConversationStore` backends, selected at deploy time
+alongside Browser / D1 / Postgres / Memory. It additionally enables **AI
+enrichment**: auto-generated conversation titles and follow-up question
+suggestions.
+
+User-facing reference: [docs/content/ai-agent.mdx](../content/ai-agent.mdx)
+("Conversation history backends" → "AgentState"). See also
+[agent-conversation-storage.md](agent-conversation-storage.md) for the broader
+store-selection rules.
+
+## Architecture
+
+The adapter implements the shared `ConversationStore` interface (read thread,
+append turn, list, delete) so the agent route is backend-agnostic. AgentState is
+the highest-priority backend in `resolveStore`.
+
+**Selection priority** (when persistence is enabled via
+`VITE_FEATURE_CONVERSATION_DB=true` and the user is authenticated):
+
+1. **AgentState** — when `AGENTSTATE_API_KEY` is set
+2. **D1** — when a Cloudflare D1 binding is present
+3. **Postgres** — when `DATABASE_URL` is set
+4. **Memory** — last-resort, non-persistent fallback
+
+With the feature flag off, history stays in the **Browser** (`localStorage`).
+`CONVERSATION_STORE_BACKEND=agentstate` forces AgentState even when a D1 binding
+is also present (otherwise `auto` follows the priority order above).
+
+## Per-user isolation
+
+A single AgentState project key holds every user's history without cross-talk:
+
+- `external_id` is namespaced as `<userId>:<conversationId>`.
+- Each record is tagged `user:<userId>`.
+
+Reads and listings filter by the `user:<userId>` tag / `external_id` prefix, so
+isolation requires an authenticated identity (Clerk: `VITE_AUTH_PROVIDER=clerk` +
+`CLERK_SECRET_KEY`). Unauthenticated sessions fall back to browser history.
+
+## Message mapping
+
+- **Append-only diff upsert** — on each turn the adapter upserts only the new
+  messages onto the existing AgentState conversation rather than rewriting the
+  whole thread.
+- **UIMessage ⇄ AgentState round-trip** — the AI SDK `UIMessage` shape is mapped
+  to AgentState's message records and back, preserving role/content plus the
+  metadata needed to reconstruct the `UIMessage` (parts, tool calls, ids) on
+  read so the chat re-hydrates exactly.
+
+## AI enrichment
+
+When AgentState is active **and** `AGENTSTATE_AI_ENRICH=true`:
+
+- **Auto-title** — AgentState generates a concise conversation title.
+- **Follow-ups** — AgentState suggests follow-up questions, surfaced in the chat.
+
+With enrichment off, conversations persist normally but no titles/follow-ups are
+generated. `supportsAiEnrichment` in the backend endpoint reflects this.
+
+## Routes
+
+- `GET /api/v1/conversations/backend` — reports the active backend and
+  `supportsAiEnrichment`. Drives the read-only "Conversation History" section in
+  the agent settings sidebar.
+- `GET /api/v1/conversations/$id/follow-ups` — returns enrichment-generated
+  follow-up question suggestions for a conversation.
+
+## Environment variables
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `AGENTSTATE_API_KEY` | to enable | — | `as_live_...` project key; presence activates the backend |
+| `AGENTSTATE_BASE_URL` | no | `https://agentstate.app/api` | self-host endpoint |
+| `AGENTSTATE_AI_ENRICH` | no | `false` | enable auto-title + follow-up suggestions |
+| `CONVERSATION_STORE_BACKEND` | no | `auto` | force `agentstate` when a D1 binding is also present |
+
+Also requires `VITE_FEATURE_CONVERSATION_DB=true` and a Clerk auth provider.
+
+**Local dev** against a self-hosted instance: `AGENTSTATE_BASE_URL=http://localhost:8787`
+with the seed test key `as_live_TEST_KEY_FOR_LOCAL_DEV_ONLY_1234567890ab`.
+
+On Cloudflare, set `AGENTSTATE_API_KEY` as a Worker secret
+(`wrangler secret put AGENTSTATE_API_KEY`) and add it to CI secrets; the other
+three vars are non-secret runtime `[vars]`.


### PR DESCRIPTION
## Summary

Adds [AgentState](https://agentstate.app) as a selectable backend for the AI agent's conversation history, alongside the existing Browser / D1 / Postgres backends. It plugs into the existing `ConversationStore` abstraction, so all chat/thread CRUD keeps flowing through the same `/api/v1/conversations*` routes — no breaking changes to other backends. When configured, it also enables AgentState's AI enrichment (auto-titles + follow-up suggestions).

Selection is **operator/deploy-time** via env vars (mirroring D1/Postgres); the agent settings sidebar surfaces which backend is active. The companion SDK change lives in `duyet/agentstate#181`.

## How it works

- **`AgentStateStore`** implements `ConversationStore` on top of `@agentstate/sdk`. Each dashboard conversation maps to an AgentState conversation via a deterministic `external_id = ${userId}:${conversationId}` for per-user isolation; the full assistant-ui `UIMessage` is round-tripped losslessly through message metadata (`metadata.ui`), and `upsert` is an **append-only diff** (AgentState messages are immutable).
- **`resolveStore()`** activates AgentState when `AGENTSTATE_API_KEY` is set (or `CONVERSATION_STORE_BACKEND=agentstate`), ahead of D1/Postgres, still gated behind the `conversationDb` flag + Clerk.
- **New routes:** `GET /api/v1/conversations/backend` (active backend + `supportsAiEnrichment`) and `GET /api/v1/conversations/$id/follow-ups` (AgentState-only).
- **UI:** a read-only "Conversation History" section in the agent settings sidebar, and AI-suggested follow-up chips above the chat composer when enrichment is enabled.

## Configuration (server-side)

| Var | Required | Default | Purpose |
|-----|----------|---------|---------|
| `AGENTSTATE_API_KEY` | to enable | — | `as_live_...` key; presence activates the backend |
| `AGENTSTATE_BASE_URL` | no | `https://agentstate.app/api` | self-host endpoint |
| `AGENTSTATE_AI_ENRICH` | no | `false` | enable auto-title + follow-ups |
| `CONVERSATION_STORE_BACKEND` | no | `auto` | force `agentstate` when a D1 binding is also present |

Still requires `VITE_FEATURE_CONVERSATION_DB=true` + a Clerk auth provider. Full setup in `docs/content/ai-agent.mdx` and `docs/knowledge/agentstate-conversation-store.md`.

## Verification

- `bun run type-check` (full project) → clean
- `bun test src/lib/conversation-store/` → **35 passed, 0 failed** (AgentStateStore CRUD, append-only diff, lossless round-trip, isolation, enrichment gating, follow-ups, error mapping; resolver selection)
- `biome check` on all changed files → clean

## Notes

- Backend selection is intentionally deploy-time (not a per-user runtime toggle): the API key is a server secret and history stays in one place.
- `list()` filters by `metadata.userId` client-side because SDK 0.1.2's list has no tag filter; `duyet/agentstate#181` adds a `tag` param that can later make this a single server-filtered call.
- Follow-up chips appear only once a thread has a server-side `remoteId` and `AGENTSTATE_AI_ENRICH` is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVRtn1t17iNe74i8ius8Ch

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVRtn1t17iNe74i8ius8Ch)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AgentState conversation history backend with per-user isolation.
  * Introduced Conversation History panel in agent settings sidebar.
  * Added AI-generated follow-up suggestions feature.
  * Enabled automatic conversation title enrichment.

* **Documentation**
  * Added setup guides for conversation history backends and AI enrichment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->