### PR TITLE
feat(overview): add multi-disk Disk Usage breakdown card

### DIFF
--- a/apps/dashboard/src/components/overview-charts/disk-usage-card.tsx
+++ b/apps/dashboard/src/components/overview-charts/disk-usage-card.tsx
@@ -1,0 +1,216 @@
+import { HardDrive } from 'lucide-react'
+
+import { DiskUsageBar, usageLevel } from '@/components/disks/disk-usage-bar'
+import { AppLink } from '@/components/ui/app-link'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { formatReadableSize } from '@/lib/format-readable'
+import { useChartData } from '@/lib/query/use-chart-data'
+import { REFRESH_INTERVAL, useHostId } from '@/lib/swr'
+import { buildUrl } from '@/lib/url/url-builder'
+import { cn } from '@/lib/utils'
+
+// ============================================================================
+// DiskUsageCard Component
+// ============================================================================
+
+/**
+ * DiskUsageCard — overview "Disk Usage" breakdown.
+ *
+ * Lists every disk reported by `system.disks` with a per-disk usage bar, the
+ * raw engine type, and `used / total` + free figures. The header summarises the
+ * aggregate across all disks. Complements the compact single-disk Storage KPI
+ * tile in the 4-up strip by showing the full storage picture at a glance.
+ *
+ * Reuses {@link usageLevel}/{@link DiskUsageBar} for the threshold colors so the
+ * card stays consistent with the /disks detail page (90% critical, 75% warn).
+ */
+
+type DiskRow = {
+  name: string
+  type?: string
+  used_space: number
+  readable_used_space: string
+  total_space: number
+  readable_total_space: string
+  free_space: number
+  readable_free_space: string
+}
+
+type UsageLevel = ReturnType<typeof usageLevel>
+
+/** Dot + percent text accent, matching DiskUsageBar's fill color per level. */
+const LEVEL_ACCENT: Record<UsageLevel, string> = {
+  ok: 'text-emerald-600 dark:text-emerald-400',
+  warn: 'text-amber-600 dark:text-amber-400',
+  critical: 'text-red-600 dark:text-red-400',
+}
+
+const LEVEL_DOT: Record<UsageLevel, string> = {
+  ok: 'bg-emerald-500',
+  warn: 'bg-amber-500',
+  critical: 'bg-red-500',
+}
+
+function percentUsed(used: number, total: number): number {
+  return total > 0 ? Math.min(100, (used / total) * 100) : 0
+}
+
+function DiskRowItem({ disk }: { disk: DiskRow }) {
+  const pct = percentUsed(disk.used_space, disk.total_space)
+  const level = usageLevel(pct)
+
+  return (
+    <div className="flex flex-col gap-1.5 border-t border-border py-4 first:border-t-0 first:pt-0">
+      {/* name + type + percent */}
+      <div className="flex items-center justify-between gap-2.5">
+        <div className="flex min-w-0 items-center gap-2">
+          <span
+            className={cn('size-2 shrink-0 rounded-full', LEVEL_DOT[level])}
+            aria-hidden
+          />
+          <span className="truncate text-[13px] font-semibold leading-none">
+            {disk.name}
+          </span>
+          {disk.type ? (
+            <span className="shrink-0 rounded-md bg-secondary px-1.5 py-0.5 text-[10px] font-medium text-secondary-foreground">
+              {disk.type}
+            </span>
+          ) : null}
+        </div>
+        <span
+          className={cn(
+            'shrink-0 font-mono text-[13px] font-semibold tabular-nums',
+            LEVEL_ACCENT[level]
+          )}
+        >
+          {pct.toFixed(0)}%
+        </span>
+      </div>
+
+      <DiskUsageBar percentUsed={pct} className="h-2" />
+
+      <div className="flex items-center justify-between font-mono text-[11.5px] tabular-nums text-muted-foreground">
+        <span>
+          {disk.readable_used_space} / {disk.readable_total_space}
+        </span>
+        <span>{disk.readable_free_space} free</span>
+      </div>
+    </div>
+  )
+}
+
+export const DiskUsageCard = function DiskUsageCard({
+  className,
+}: {
+  className?: string
+}) {
+  const hostId = useHostId()
+  const { data, isLoading, error, hasData } = useChartData<DiskRow>({
+    chartName: 'disk-size-all',
+    hostId,
+    refreshInterval: REFRESH_INTERVAL.SLOW_2M,
+  })
+
+  if (isLoading) {
+    return (
+      <Card
+        className={cn('gap-0 py-0', className)}
+        role="status"
+        aria-busy="true"
+        aria-label="Loading disk usage"
+      >
+        <CardHeader className="gap-0 p-5 pb-0">
+          <Skeleton className="h-4 w-40" />
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4 p-5">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex flex-col gap-2">
+              <Skeleton className="h-3.5 w-32" />
+              <Skeleton className="h-2 w-full" />
+              <Skeleton className="h-3 w-44" />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const disks = data ?? []
+
+  // An errored fetch resolves with an empty `data`; distinguish it from a
+  // genuine "no disks" result so a real failure is not shown as benign.
+  if (disks.length === 0) {
+    const message =
+      error && !hasData ? 'Failed to load disk usage.' : 'No disks reported.'
+    return (
+      <Card className={cn('gap-0 py-0', className)}>
+        <CardHeader className="gap-2 p-5">
+          <div className="flex items-center gap-2">
+            <HardDrive className="size-4 text-muted-foreground" />
+            <span className="text-sm font-semibold tracking-tight">
+              Disk Usage
+            </span>
+          </div>
+        </CardHeader>
+        <CardContent className="p-5 pt-0 text-sm text-muted-foreground">
+          {message}
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const usedSum = disks.reduce((acc, d) => acc + d.used_space, 0)
+  const totalSum = disks.reduce((acc, d) => acc + d.total_space, 0)
+  // Sum the native free_space column so the header total matches the sum of the
+  // per-disk "free" figures shown in each row (these differ from total-used
+  // when keep_free_space reservations apply).
+  const freeSum = disks.reduce((acc, d) => acc + d.free_space, 0)
+  const totalPct = percentUsed(usedSum, totalSum)
+  const countLabel = `${disks.length} ${disks.length === 1 ? 'disk' : 'disks'}`
+
+  return (
+    <AppLink
+      href={buildUrl('/disks', { host: hostId })}
+      className="group block"
+    >
+      <Card
+        className={cn(
+          'gap-0 py-0 transition-colors hover:border-border',
+          className
+        )}
+      >
+        <CardHeader className="gap-0 p-5 pb-0">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <HardDrive className="size-4 text-muted-foreground" />
+              <span className="text-sm font-semibold tracking-tight">
+                Disk Usage
+              </span>
+              <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                {countLabel}
+              </span>
+            </div>
+            <div className="text-right font-mono">
+              <div className="text-[13px] font-semibold tabular-nums">
+                {formatReadableSize(usedSum)}{' '}
+                <span className="font-normal text-muted-foreground">
+                  / {formatReadableSize(totalSum)}
+                </span>
+              </div>
+              <div className="mt-0.5 text-[11px] tabular-nums text-muted-foreground">
+                {formatReadableSize(freeSum)} free · {totalPct.toFixed(0)}% used
+              </div>
+            </div>
+          </div>
+        </CardHeader>
+
+        <CardContent className="flex flex-col p-5 pt-3">
+          {disks.map((disk) => (
+            <DiskRowItem key={disk.name} disk={disk} />
+          ))}
+        </CardContent>
+      </Card>
+    </AppLink>
+  )
+}

--- a/apps/dashboard/src/lib/api/__tests__/charts/overview-charts.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/charts/overview-charts.test.ts
@@ -33,6 +33,17 @@ describe('overview-charts', () => {
     expect(result.query).toContain('LIMIT 1')
   })
 
+  test('disk-size-all returns every disk with type and free space', () => {
+    const result = overviewCharts['disk-size-all']!({}) as any
+    expect(result.query).toContain('system.disks')
+    expect(result.query).toContain('formatReadableSize')
+    // Multi-disk breakdown: must NOT cap to a single disk like disk-size-single.
+    expect(result.query).not.toContain('LIMIT')
+    // Drives the per-disk type badge and the "free" figures in the card.
+    expect(result.query).toContain('type')
+    expect(result.query).toContain('free_space')
+  })
+
   test('table-count counts unique tables', () => {
     const result = overviewCharts['table-count']!({}) as any
     expect(result.query).toContain('countDistinct')

--- a/apps/dashboard/src/lib/api/charts/overview-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/overview-charts.ts
@@ -42,4 +42,23 @@ export const overviewCharts: Record<string, ChartQueryBuilder> = {
       LIMIT 1
     `,
   }),
+
+  // Every disk (no LIMIT) for the overview Disk Usage breakdown card. Includes
+  // the engine `type` (local / s3 / cache …) and free space so each disk row
+  // can show its own bar + figures. Mirrors the column shape of diskSpaceConfig
+  // in lib/query-config/system/disks.ts.
+  'disk-size-all': () => ({
+    query: `
+      SELECT name,
+             type,
+             (total_space - unreserved_space) AS used_space,
+             formatReadableSize(used_space) AS readable_used_space,
+             total_space,
+             formatReadableSize(total_space) AS readable_total_space,
+             free_space,
+             formatReadableSize(free_space) AS readable_free_space
+      FROM system.disks
+      ORDER BY name
+    `,
+  }),
 }

--- a/apps/dashboard/src/routes/(dashboard)/-insights/charts-section.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/charts-section.tsx
@@ -35,7 +35,7 @@ export function ChartsSection({ hostId }: { readonly hostId: number }) {
   const hasCompressionData = compressionData && compressionData.length > 0
 
   return (
-    <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+    <div className="grid auto-rows-[280px] grid-cols-1 gap-3 lg:grid-cols-2">
       {hasTopTablesData && <TopTablesBySizeChart hostId={hostId} />}
       {hasCompressionData && <CompressionRatiosChart hostId={hostId} />}
       {!hasTopTablesData && !hasCompressionData && (

--- a/apps/dashboard/src/routes/(dashboard)/overview.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/overview.tsx
@@ -7,6 +7,7 @@ import { lazy, Suspense, useState } from 'react'
 import { ClientOnly } from '@/components/client-only'
 import { InsightsPanel } from '@/components/insights/insights-panel'
 import { cardStyles } from '@/components/overview-charts/card-styles'
+import { DiskUsageCard } from '@/components/overview-charts/disk-usage-card'
 import { OverviewCharts } from '@/components/overview-charts/overview-charts-client'
 import { OverviewStatusStrip } from '@/components/overview-charts/overview-status-strip'
 import { ChartSkeleton, Skeleton, TabsSkeleton } from '@/components/skeletons'
@@ -165,6 +166,8 @@ function OverviewPageContent() {
     <div>
       <OverviewStatusStrip className="mb-3" />
       <OverviewCharts className="mb-4 sm:mb-6" />
+
+      <DiskUsageCard className="mb-4 sm:mb-6" />
 
       <ClientOnly fallback={null}>
         <InsightsPanel hostId={hostId} className="mb-4 sm:mb-6" />


### PR DESCRIPTION
## What

Adds a standalone **Disk Usage** breakdown card to the overview page, redesigned per the supplied mock. It lists *every* disk reported by `system.disks` with a per-disk usage bar, engine-type badge, percent, and `used / total` + `free` figures, plus an aggregate header (total used/cap, free, % used).

| Before | After |
|---|---|
| Overview "Storage" tile shows only the first disk (`LIMIT 1`) | New full-width card shows all disks; the compact KPI tile is unchanged |

## Why

On clusters with tiered storage (local + S3 + cache, etc.), the single-disk KPI tile hid every disk but the first. This surfaces the full storage picture at a glance.

## Changes

- **`disk-size-all` query** (`lib/api/charts/overview-charts.ts`) — all disks (no `LIMIT`), including engine `type` and the **native** `free_space` column.
- **`DiskUsageCard`** (`components/overview-charts/disk-usage-card.tsx`) — new presentational card. Reuses `usageLevel` / `DiskUsageBar` thresholds (90% critical / 75% warn) and `formatReadableSize`, so colors and figures stay consistent with the `/disks` detail page it links to. Surfaces fetch errors instead of masking them as an empty state.
- **Mount** on `/overview` below the KPI strip. The existing single-disk Storage tile is left untouched (per design decision).
- **Test** — focused assertion that `disk-size-all` is a multi-disk query with `type` + `free_space` and no `LIMIT`.

## Design decisions (confirmed with reviewer)

- **Placement:** keep the compact Storage KPI tile in the 4-up strip; add this richer card as its own full-width card.
- **Type badge:** show the raw `system.disks.type` string (e.g. `local`, `s3`); badge hidden when absent. `type` exists on CH 23.8+ (the documented minimum). The card surfaces an error state if the query ever fails (e.g. on an unsupported server).

## Verification

- `bun run lint` ✅ (Biome clean)
- `tsc --noEmit` ✅ (clean; the only errors in this checkout are pre-existing, from the optional `@agentstate/sdk` not being installed locally — unrelated to this PR)
- `bun test` on `overview-charts` + `registry-completeness` ✅
- Visual: deferred to the CI deploy preview — local ClickHouse is unavailable in this env, so a local screenshot would only show the card's skeleton/empty state.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a disk usage card to the dashboard overview displaying per-disk storage metrics with color-coded usage levels, showing used, total, and free space information.

* **Tests**
  * Added test coverage for disk metrics queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->