### PR TITLE
feat(overview): restyle disk size card to match storage redesign

### DIFF
--- a/apps/dashboard/src/components/charts/system/disk-size.tsx
+++ b/apps/dashboard/src/components/charts/system/disk-size.tsx
@@ -1,28 +1,152 @@
 import type { ChartProps } from '@/components/charts/chart-props'
 
-import { CardMetric } from '@/components/cards/card-metric'
 import { createCustomChart } from '@/components/charts/factory'
+import { Badge } from '@/components/ui/badge'
+import { Progress } from '@/components/ui/progress'
+import { cn } from '@/lib/utils'
+
+interface DiskRow {
+  name: string
+  path?: string
+  used_space: number
+  readable_used_space: string
+  unreserved_space?: number
+  readable_unreserved_space?: string
+  free_space: number
+  readable_free_space: string
+  total_space: number
+  readable_total_space: string
+  percent_free?: number
+  keep_free_space?: number
+  type?: string
+}
+
+function usedPct(row: DiskRow): number {
+  if (!row.total_space) return 0
+  return Math.min(100, (row.used_space / row.total_space) * 100)
+}
+
+function pctColor(pct: number): string {
+  if (pct >= 90) return 'bg-rose-500'
+  if (pct >= 70) return 'bg-amber-500'
+  return 'bg-emerald-500'
+}
+
+function UsageBadge({ pct }: { pct: number }) {
+  const label = `${Math.round(pct)}% used`
+  if (pct >= 90)
+    return (
+      <Badge className="border-transparent bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300">
+        {label}
+      </Badge>
+    )
+  if (pct >= 70)
+    return (
+      <Badge className="border-transparent bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
+        {label}
+      </Badge>
+    )
+  return <Badge variant="secondary">{label}</Badge>
+}
 
 export const ChartDiskSize = createCustomChart({
   chartName: 'disk-size',
   dataTestId: 'disk-size-chart',
   render: (dataArray) => {
-    const first = dataArray[0] as {
-      name: string
-      used_space: number
-      readable_used_space: string
-      total_space: number
-      readable_total_space: string
-    }
+    const rows = dataArray as DiskRow[]
+    if (!rows.length) return null
+
+    // Primary disk: prefer the one named "default", fall back to largest by total_space
+    const primary =
+      rows.find((r) => r.name === 'default') ??
+      rows.reduce((a, b) => (a.total_space >= b.total_space ? a : b))
+
+    const primaryPct = usedPct(primary)
+
+    // Parse readable_used_space: split the number from the unit suffix
+    const usedParts = primary.readable_used_space.split(' ')
+    const usedNumber = usedParts[0] ?? primary.readable_used_space
+    const usedUnit = usedParts.slice(1).join(' ') || ''
 
     return (
-      <CardMetric
-        current={first.used_space}
-        currentReadable={`${first.readable_used_space} used (${first.name})`}
-        target={first.total_space}
-        targetReadable={`${first.readable_total_space} total`}
-        className="p-2"
-      />
+      <div className="flex flex-col gap-0">
+        {/* Headline row: big number + badge */}
+        <div className="flex items-baseline justify-between gap-2">
+          <div className="flex items-baseline gap-1.5">
+            <span className="font-mono text-3xl font-semibold tracking-tight">
+              {usedNumber}
+            </span>
+            <span className="text-sm text-muted-foreground">
+              {usedUnit} used
+            </span>
+          </div>
+          <UsageBadge pct={primaryPct} />
+        </div>
+
+        {/* Subline */}
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          of {primary.readable_total_space} total &middot;{' '}
+          <span className="font-mono">default</span> policy &middot;{' '}
+          {primary.readable_free_space} free
+        </p>
+
+        {/* Overall progress bar */}
+        <div className="mt-3.5 mb-4">
+          <Progress
+            value={primaryPct}
+            className={cn('h-2.5 bg-muted', {
+              '[&>div]:bg-rose-500': primaryPct >= 90,
+              '[&>div]:bg-amber-500': primaryPct >= 70 && primaryPct < 90,
+              '[&>div]:bg-emerald-500': primaryPct < 70,
+            })}
+          />
+        </div>
+
+        {/* Per-disk rows */}
+        <div className="flex flex-col">
+          {rows.map((row) => {
+            const pct = usedPct(row)
+            const colorClass = pctColor(pct)
+            return (
+              <div
+                key={row.name}
+                className="flex flex-col gap-1.5 border-t border-border py-2.5"
+              >
+                <div className="flex items-center justify-between text-[12.5px]">
+                  <span className="flex items-center gap-1.5">
+                    <span
+                      className={cn(
+                        'size-[7px] shrink-0 rounded-full',
+                        colorClass
+                      )}
+                    />
+                    <span className="font-semibold">{row.name}</span>
+                    {row.type ? (
+                      <Badge
+                        variant="secondary"
+                        className="rounded-md px-1.5 py-0 text-[10px]"
+                      >
+                        {row.type}
+                      </Badge>
+                    ) : null}
+                  </span>
+                  <span className="font-mono text-muted-foreground">
+                    {row.readable_used_space} / {row.readable_total_space}{' '}
+                    &middot; {Math.round(pct)}%
+                  </span>
+                </div>
+                {/* Thin per-disk track */}
+                <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className={cn('h-full rounded-full', colorClass)}
+                    style={{ width: `${pct.toFixed(1)}%` }}
+                  />
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
     )
   },
 })

--- a/apps/dashboard/src/routes/(dashboard)/-insights/charts-section.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/charts-section.tsx
@@ -35,7 +35,7 @@ export function ChartsSection({ hostId }: { readonly hostId: number }) {
   const hasCompressionData = compressionData && compressionData.length > 0
 
   return (
-    <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+    <div className="grid auto-rows-[280px] grid-cols-1 gap-3 lg:grid-cols-2">
       {hasTopTablesData && <TopTablesBySizeChart hostId={hostId} />}
       {hasCompressionData && <CompressionRatiosChart hostId={hostId} />}
       {!hasTopTablesData && !hasCompressionData && (


### PR DESCRIPTION
## Summary

- Replaces the minimal `CardMetric` with a full multi-disk layout matching the storage redesign mockup
- Big mono headline (used-space number + unit suffix) with an inline amber/rose/neutral badge
- Subline: `of {total} total · default policy · {free} free`
- Overall progress bar (10px tall, colored by threshold: emerald <70%, amber 70–90%, rose ≥90%)
- Per-disk rows mapping **all** rows (not just `dataArray[0]`): color dot + disk name + optional tier `Badge` (renders only when `row.type` is a non-empty string — forward-compatible with the sibling PR that adds `type` to the query) + `used / total · pct%` mono label + thin 6px track

Shell untouched: `createCustomChart` wrapping, `chartName: 'disk-size'`, `data-testid="disk-size-chart"`, SQL toolbar, CSV, and `href` all preserved.

## Test plan

- [ ] CI lint + type-check passes
- [ ] Deployed to preview worker — verify Disk Size card renders with headline, progress bar, and per-disk rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Significantly enhanced the disk usage visualization with detailed metrics for each disk, including calculated usage percentages and color-coded status indicators (critical ≥90%, warning ≥70%). The chart now displays individual progress tracking for each disk and provides clearer identification of primary storage and overall system health status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->