### PR TITLE
chore(deps): bump @agentstate/sdk to 0.1.3

### DIFF
--- a/apps/dashboard/bun.lock
+++ b/apps/dashboard/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "dashboard-tsr",
       "dependencies": {
-        "@agentstate/sdk": "^0.1.2",
+        "@agentstate/sdk": "^0.1.3",
         "@ai-sdk/openai": "^3.0.72",
         "@ai-sdk/provider-utils": "^4.0.30",
         "@assistant-ui/react": "0.14.11",
@@ -99,7 +99,7 @@
     },
   },
   "packages": {
-    "@agentstate/sdk": ["@agentstate/sdk@0.1.2", "", { "peerDependencies": { "@langchain/langgraph-checkpoint": "^1.0.2" }, "optionalPeers": ["@langchain/langgraph-checkpoint"] }, "sha512-zNFkVMRc+j462MbNzS3MY9gVGvBFd1Ic+odCFe5WDQrTMhaA038OqUAp/EZtW1WBVNaskrIrLVAO2eTzPHIlrA=="],
+    "@agentstate/sdk": ["@agentstate/sdk@0.1.3", "", { "peerDependencies": { "@langchain/langgraph-checkpoint": "^1.1.1" }, "optionalPeers": ["@langchain/langgraph-checkpoint"] }, "sha512-0DBLMm3PF85IAy4PdsMYoaq9ya0CoPjm0qGcsBp3E6cQY5jLHegCyQ0e19Bpr3NxaJ3pQTVply7XoAbKR1fLog=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.133", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.30", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Ebs+7iS9zUgJu5B0RlxM2JmDWzq79Cpd6YdiqcCzB5qFdpfQJPUDiXutqlQP89F2XGjOdDeidulBTXUdXWzOxw=="],
 

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -29,7 +29,7 @@
     "verify-deploy": "bun scripts/verify-deploy.ts"
   },
   "dependencies": {
-    "@agentstate/sdk": "^0.1.2",
+    "@agentstate/sdk": "^0.1.3",
     "@ai-sdk/openai": "^3.0.72",
     "@ai-sdk/provider-utils": "^4.0.30",
     "@assistant-ui/react": "0.14.11",


### PR DESCRIPTION
## Summary

Updates the AgentState TypeScript SDK to the latest published version.

| | Old | New |
|---|---|---|
| `@agentstate/sdk` | `^0.1.2` | `^0.1.3` |

`0.1.3` is the highest version published on npm (`npm view @agentstate/sdk dist-tags` → `latest: 0.1.3`).

## Context

- This project uses AgentState **only via the TypeScript SDK** — there is no Python usage. The integration lives in `apps/dashboard/src/lib/conversation-store/agentstate-store.ts` (the `AgentStateStore` conversation backend) plus the `conversations/backend` and `conversations/$id.follow-ups` API routes.
- The `0.1.3` release is a **toolchain bump** (TypeScript 6, vitest, `@langchain/*`) with **no public API changes**, so the call sites (`getConversationByExternalId`, `listConversations`, `createConversation`, `appendMessages`, `updateConversation`, `deleteConversation`, `generateTitle`, `generateFollowUps`) are unchanged.
- The optional peer dependency `@langchain/langgraph-checkpoint` moves from `^1.0.2` → `^1.1.1`, but it is an *optional* peer and is unused by this project.
- The Python SDK feature-parity work (state-path `/v2/` → `/v1/` bugfix, ~20 new methods) noted in the task does not apply here since there is no Python AgentState usage.

## Files changed

- `apps/dashboard/package.json` — dependency bump
- `apps/dashboard/bun.lock` — lockfile updated to `@agentstate/sdk@0.1.3`

No source/call-site changes were required.

## Verification

- ✅ `bun install` (in `apps/dashboard`) — lock resolves to `0.1.3`
- ✅ `tsc --noEmit` type-check — clean
- ✅ `vite build` — succeeds (incl. prerender)
- ✅ conversation-store tests — 35/35 pass (`agentstate-store.test.ts`, `resolve-store.agentstate.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEQ1pP68t9Ha94qZ7Fffox)_