### PR TITLE
feat(overview): redesign Query Activity Heatmap as multi-metric full-width banner

### DIFF
--- a/apps/dashboard/src/components/charts/query/query-count-calendar.test.ts
+++ b/apps/dashboard/src/components/charts/query/query-count-calendar.test.ts
@@ -1,12 +1,30 @@
-import type { DayCell } from './query-count-calendar'
+import type { HeatmapDayRow } from './query-count-calendar'
 
 import {
   buildCalendarModel,
+  buildStatCards,
   formatCalendarDate,
+  formatDurationMs,
   getIntensityClass,
   isoDate,
+  METRIC_CONFIGS,
 } from './query-count-calendar'
 import { describe, expect, it } from 'bun:test'
+
+const QUERIES = METRIC_CONFIGS.queries
+
+/** Build a full day row, overriding only the metrics a test cares about. */
+function row(date: string, over: Partial<HeatmapDayRow> = {}): HeatmapDayRow {
+  return {
+    date,
+    query_count: 0,
+    failed_count: 0,
+    memory_peak: 0,
+    avg_duration_ms: 0,
+    written_bytes: 0,
+    ...over,
+  }
+}
 
 describe('getIntensityClass', () => {
   it('returns the empty tier for zero value or zero max', () => {
@@ -20,14 +38,23 @@ describe('getIntensityClass', () => {
 
   it('maps a mid ratio to a middle tier (walks thresholds down)', () => {
     // ratio 0.5 → threshold 0.5 (index 3) → tier index 4
-    expect(getIntensityClass(50, 100)).toBe('bg-chart-2/70')
+    expect(getIntensityClass(50, 100)).toBe('bg-chart-2/80')
     // ratio 0.25 → threshold 0.25 (index 2) → tier index 3
-    expect(getIntensityClass(25, 100)).toBe('bg-chart-2/50')
+    expect(getIntensityClass(25, 100)).toBe('bg-chart-2/60')
   })
 
   it('maps a tiny non-zero ratio to the first active tier, never the empty tier', () => {
     // ratio 0.001 ≥ first active threshold 0.01? No → but > 0, so tier 1.
     expect(getIntensityClass(1, 1000)).toBe('bg-chart-2/20')
+  })
+
+  it('uses the per-metric ramp when one is supplied', () => {
+    expect(getIntensityClass(100, 100, METRIC_CONFIGS.failed.tiers)).toBe(
+      'bg-rose-500'
+    )
+    expect(getIntensityClass(1, 1000, METRIC_CONFIGS.written.tiers)).toBe(
+      'bg-emerald-500/20'
+    )
   })
 })
 
@@ -45,12 +72,24 @@ describe('formatCalendarDate', () => {
   })
 })
 
+describe('formatDurationMs', () => {
+  it('formats sub-second values as milliseconds', () => {
+    expect(formatDurationMs(0)).toBe('0ms')
+    expect(formatDurationMs(420)).toBe('420ms')
+  })
+
+  it('formats seconds with one decimal under 10s and whole seconds above', () => {
+    expect(formatDurationMs(1800)).toBe('1.8s')
+    expect(formatDurationMs(18400)).toBe('18s')
+  })
+})
+
 describe('buildCalendarModel', () => {
   // Anchor "today" to a fixed Wednesday so the grid shape is deterministic.
   const today = new Date(2026, 5, 17) // Wed Jun 17 2026
 
   it('lays out whole Sunday-first weeks and ends on today', () => {
-    const model = buildCalendarModel([], today, 4)
+    const model = buildCalendarModel([], today, QUERIES, 4)
     // Every column has 7 slots.
     for (const week of model.weeks) {
       expect(week).toHaveLength(7)
@@ -67,7 +106,7 @@ describe('buildCalendarModel', () => {
   })
 
   it('leaves future slots in the trailing column as null', () => {
-    const model = buildCalendarModel([], today, 4)
+    const model = buildCalendarModel([], today, QUERIES, 4)
     const lastWeek = model.weeks.at(-1)
     // today is Wednesday (dow 3) → Thu/Fri/Sat slots are future → null.
     expect(lastWeek?.[4]).toBeNull()
@@ -77,13 +116,13 @@ describe('buildCalendarModel', () => {
     expect(lastWeek?.[3]?.iso).toBe('2026-06-17')
   })
 
-  it('joins counts onto the matching day and aggregates stats', () => {
-    const cells: DayCell[] = [
-      { date: '2026-06-15', query_count: 100, readable_count: '100' },
-      { date: '2026-06-16', query_count: 40, readable_count: '40' },
-      { date: '2026-06-17', query_count: 0, readable_count: '0' },
+  it('joins the selected metric onto the matching day and aggregates stats', () => {
+    const rows: HeatmapDayRow[] = [
+      row('2026-06-15', { query_count: 100 }),
+      row('2026-06-16', { query_count: 40 }),
+      row('2026-06-17', { query_count: 0 }),
     ]
-    const model = buildCalendarModel(cells, today, 4)
+    const model = buildCalendarModel(rows, today, QUERIES, 4)
     expect(model.total).toBe(140)
     expect(model.max).toBe(100)
     expect(model.activeDays).toBe(2) // zero-count day is not "active"
@@ -91,12 +130,73 @@ describe('buildCalendarModel', () => {
     expect(model.avgActive).toBe(70) // 140 / 2 active days
   })
 
+  it('reads a different metric when a different config is passed', () => {
+    const rows: HeatmapDayRow[] = [
+      row('2026-06-16', { query_count: 999, failed_count: 5 }),
+      row('2026-06-17', { query_count: 999, failed_count: 2 }),
+    ]
+    const model = buildCalendarModel(rows, today, METRIC_CONFIGS.failed, 4)
+    // Only failed_count contributes — query_count is ignored for this mode.
+    expect(model.total).toBe(7)
+    expect(model.max).toBe(5)
+    expect(model.peak?.iso).toBe('2026-06-16')
+  })
+
   it('labels each column where a new month begins, once per month', () => {
     // 12 weeks back from mid-June spans Apr→Jun.
-    const model = buildCalendarModel([], today, 12)
+    const model = buildCalendarModel([], today, QUERIES, 12)
     const labels = model.monthLabels.filter(Boolean)
     // Months are non-repeating and in calendar order.
     expect(new Set(labels).size).toBe(labels.length)
     expect(labels).toContain('Jun')
+  })
+
+  it('derives a month-year range caption from the rendered span', () => {
+    const model = buildCalendarModel([], today, QUERIES, 53)
+    expect(model.rangeLabel).toMatch(
+      /^[A-Z][a-z]{2} \d{4} – [A-Z][a-z]{2} \d{4}$/
+    )
+    expect(model.rangeLabel.endsWith('Jun 2026')).toBe(true)
+  })
+})
+
+describe('buildStatCards', () => {
+  const today = new Date(2026, 5, 17)
+  const rows: HeatmapDayRow[] = [
+    row('2026-06-15', {
+      query_count: 100,
+      failed_count: 3,
+      memory_peak: 600,
+      avg_duration_ms: 1800,
+      written_bytes: 1024,
+    }),
+    row('2026-06-16', {
+      query_count: 40,
+      failed_count: 1,
+      memory_peak: 400,
+      avg_duration_ms: 900,
+      written_bytes: 512,
+    }),
+  ]
+
+  it('leads a sum metric with a grand total and accented peak', () => {
+    const model = buildCalendarModel(rows, today, QUERIES, 4)
+    const cards = buildStatCards(QUERIES, model)
+    expect(cards).toHaveLength(4)
+    expect(cards[0].label).toBe('Total queries')
+    expect(cards[0].value).toBe('140')
+    expect(cards[1].label).toBe('Busiest day')
+    expect(cards[1].accent).toBe(true)
+  })
+
+  it('leads a gauge metric with the peak reading, not a meaningless sum', () => {
+    const memory = METRIC_CONFIGS.memory
+    const model = buildCalendarModel(rows, today, memory, 4)
+    const cards = buildStatCards(memory, model)
+    expect(cards[0].label).toContain('Peak')
+    expect(cards[0].accent).toBe(true)
+    // Peak memory = max daily reading = 600 bytes, formatted as a size.
+    expect(cards[0].value).toBe('600 Bytes')
+    expect(cards[1].label).toBe('Average')
   })
 })

--- a/apps/dashboard/src/components/charts/query/query-count-calendar.ts
+++ b/apps/dashboard/src/components/charts/query/query-count-calendar.ts
@@ -1,46 +1,199 @@
 /**
- * Pure helpers for the GitHub-style query-activity contribution calendar.
+ * Pure helpers for the GitHub-style "Activity Calendar" contribution heatmap.
  *
- * The backing query (`query-count-heatmap`) returns one row per calendar day:
- * `{ date: 'YYYY-MM-DD', query_count, readable_count }`. These helpers bucket
- * those rows into week columns (Sunday-first, matching GitHub) and derive the
- * summary stats shown in the KPI strip. All logic here is timezone-naive on
- * purpose: it operates on the date *strings* ClickHouse returns and on a local
- * "today" anchor, so it stays deterministic and unit-testable.
+ * The backing query (`query-count-heatmap`) returns one row per calendar day
+ * carrying several metrics (query volume, failures, peak memory, avg duration,
+ * bytes written). These helpers bucket those rows into Sunday-first week
+ * columns (matching GitHub) for a chosen {@link MetricConfig} and derive the
+ * summary stats shown in the KPI strip.
+ *
+ * All logic here is timezone-naive on purpose: it operates on the date *strings*
+ * ClickHouse returns and on a local "today" anchor, so it stays deterministic
+ * and unit-testable.
  */
 
-/** One row of the per-day query-count payload. */
-export interface DayCell {
+import { formatCompactNumber, formatReadableSize } from '@/lib/format-readable'
+
+/** One row of the per-day heatmap payload (all metrics for a single day). */
+export interface HeatmapDayRow {
   date: string // 'YYYY-MM-DD'
   query_count: number
-  readable_count: string
+  failed_count: number
+  memory_peak: number // bytes
+  avg_duration_ms: number // milliseconds
+  written_bytes: number // bytes
+}
+
+/** Backwards-compatible alias used by older imports. */
+export type DayCell = HeatmapDayRow
+
+/** Identifier for a heatmap metric / display mode. */
+export type MetricKey = 'queries' | 'failed' | 'memory' | 'duration' | 'written'
+
+/**
+ * How a metric aggregates across days:
+ * - `sum`: a daily volume that adds up (queries, failures, bytes written).
+ * - `gauge`: a daily reading that does not sum (peak memory, avg duration).
+ */
+export type MetricAggregation = 'sum' | 'gauge'
+
+export interface MetricConfig {
+  key: MetricKey
+  /** Pill + heading label, e.g. "Query Count". */
+  label: string
+  /** Aggregation behaviour, drives which KPI cards are shown. */
+  aggregation: MetricAggregation
+  /** Pull this metric's numeric value out of a day row. */
+  getValue: (row: HeatmapDayRow) => number
+  /** Format a value for KPIs / tooltips, e.g. 13247 → "13.2K". */
+  format: (value: number) => string
+  /**
+   * Tailwind background classes, low → high. Tier 0 is the empty/no-activity
+   * cell. Six entries: one empty tier + five intensity tiers. Class strings are
+   * written out in full so Tailwind's JIT can see (and emit) them.
+   */
+  tiers: readonly [string, string, string, string, string, string]
+  /** Accent text class for the highlighted ("peak") KPI value + legend. */
+  accentText: string
+  /** Accent background class for the active-mode dot / legend swatch. */
+  accentDot: string
+}
+
+/** Format milliseconds as a compact human duration ("420ms", "1.8s", "18s"). */
+export function formatDurationMs(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '0ms'
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  const s = ms / 1000
+  return s >= 10 ? `${Math.round(s)}s` : `${s.toFixed(1)}s`
 }
 
 /**
- * Intensity tiers, low → high. Tier 0 is the empty/no-activity cell. Kept in
- * sync with TIER_THRESHOLDS (one threshold per tier). Uses `--chart-2` so the
- * calendar matches the rest of the query charts' accent.
+ * Metric definitions, in display order. Each entry is fully self-describing so
+ * the component stays a thin renderer over the chosen config.
  */
-export const INTENSITY_TIERS = [
-  'bg-muted/50',
-  'bg-chart-2/20',
-  'bg-chart-2/35',
-  'bg-chart-2/50',
-  'bg-chart-2/70',
-  'bg-chart-2',
-] as const
+export const METRIC_CONFIGS: Record<MetricKey, MetricConfig> = {
+  queries: {
+    key: 'queries',
+    label: 'Query Count',
+    aggregation: 'sum',
+    getValue: (r) => r.query_count ?? 0,
+    format: formatCompactNumber,
+    // Keeps the existing chart-2 accent so the default mode matches the other
+    // query charts across the dashboard.
+    tiers: [
+      'bg-muted/50',
+      'bg-chart-2/20',
+      'bg-chart-2/40',
+      'bg-chart-2/60',
+      'bg-chart-2/80',
+      'bg-chart-2',
+    ],
+    accentText: 'text-chart-2',
+    accentDot: 'bg-chart-2',
+  },
+  failed: {
+    key: 'failed',
+    label: 'Failed Queries',
+    aggregation: 'sum',
+    getValue: (r) => r.failed_count ?? 0,
+    format: formatCompactNumber,
+    tiers: [
+      'bg-muted/50',
+      'bg-rose-500/20',
+      'bg-rose-500/40',
+      'bg-rose-500/60',
+      'bg-rose-500/80',
+      'bg-rose-500',
+    ],
+    accentText: 'text-rose-500',
+    accentDot: 'bg-rose-500',
+  },
+  memory: {
+    key: 'memory',
+    label: 'Memory Peak',
+    aggregation: 'gauge',
+    getValue: (r) => r.memory_peak ?? 0,
+    format: (v) => formatReadableSize(v),
+    tiers: [
+      'bg-muted/50',
+      'bg-amber-500/20',
+      'bg-amber-500/40',
+      'bg-amber-500/60',
+      'bg-amber-500/80',
+      'bg-amber-500',
+    ],
+    accentText: 'text-amber-600 dark:text-amber-500',
+    accentDot: 'bg-amber-500',
+  },
+  duration: {
+    key: 'duration',
+    label: 'Avg Duration',
+    aggregation: 'gauge',
+    getValue: (r) => r.avg_duration_ms ?? 0,
+    format: formatDurationMs,
+    tiers: [
+      'bg-muted/50',
+      'bg-violet-500/20',
+      'bg-violet-500/40',
+      'bg-violet-500/60',
+      'bg-violet-500/80',
+      'bg-violet-500',
+    ],
+    accentText: 'text-violet-500',
+    accentDot: 'bg-violet-500',
+  },
+  written: {
+    key: 'written',
+    label: 'Data Written',
+    aggregation: 'sum',
+    getValue: (r) => r.written_bytes ?? 0,
+    format: (v) => formatReadableSize(v),
+    tiers: [
+      'bg-muted/50',
+      'bg-emerald-500/20',
+      'bg-emerald-500/40',
+      'bg-emerald-500/60',
+      'bg-emerald-500/80',
+      'bg-emerald-500',
+    ],
+    accentText: 'text-emerald-600 dark:text-emerald-500',
+    accentDot: 'bg-emerald-500',
+  },
+}
+
+/** Metric configs in the order their switch pills should appear. */
+export const METRIC_ORDER: MetricKey[] = [
+  'queries',
+  'failed',
+  'memory',
+  'duration',
+  'written',
+]
+
+/**
+ * Default intensity ramp (query mode). Exported for the legend fallback and for
+ * back-compat with existing tests. Tier 0 is empty / no-activity.
+ */
+export const INTENSITY_TIERS = METRIC_CONFIGS.queries.tiers
 
 // Ratio (value / max) at or above which a cell takes the matching tier.
 export const TIER_THRESHOLDS = [0, 0.01, 0.25, 0.5, 0.75] as const
 
-/** Map an absolute count to a Tailwind background class for its intensity. */
-export function getIntensityClass(value: number, max: number): string {
-  if (max <= 0 || value <= 0) return INTENSITY_TIERS[0]
+/**
+ * Map an absolute value to a Tailwind background class for its intensity within
+ * the given tier ramp (defaults to the query ramp).
+ */
+export function getIntensityClass(
+  value: number,
+  max: number,
+  tiers: readonly string[] = INTENSITY_TIERS
+): string {
+  if (max <= 0 || value <= 0) return tiers[0]
   const ratio = value / max
   for (let i = TIER_THRESHOLDS.length - 1; i >= 0; i--) {
-    if (ratio >= TIER_THRESHOLDS[i]) return INTENSITY_TIERS[i + 1]
+    if (ratio >= TIER_THRESHOLDS[i]) return tiers[i + 1]
   }
-  return INTENSITY_TIERS[0]
+  return tiers[0]
 }
 
 const MONTH_NAMES_SHORT = [
@@ -82,11 +235,23 @@ export function formatCalendarDate(d: Date): string {
   return `${WEEKDAY_NAMES_SHORT[d.getDay()]}, ${MONTH_NAMES_SHORT[d.getMonth()]} ${d.getDate()} ${d.getFullYear()}`
 }
 
+/** Compact day label for KPI sublabels, e.g. "Jun 1". */
+export function formatShortDate(d: Date): string {
+  return `${MONTH_NAMES_SHORT[d.getMonth()]} ${d.getDate()}`
+}
+
+/** "Mon YYYY" for the date-range caption. */
+function formatMonthYear(d: Date): string {
+  return `${MONTH_NAMES_SHORT[d.getMonth()]} ${d.getFullYear()}`
+}
+
 /** A single day cell once placed in the calendar grid. */
 export interface CalendarDay {
   iso: string
   date: Date
-  count: number
+  /** The selected metric's value for this day. */
+  value: number
+  /** Pre-formatted value for tooltips/labels. */
   readable: string
 }
 
@@ -105,22 +270,26 @@ export interface CalendarModel {
   totalDays: number
   avgActive: number
   peak: CalendarDay | null
+  /** Caption like "Jun 2025 – Jun 2026", or '' when there are no days. */
+  rangeLabel: string
 }
 
 /**
- * Bucket per-day counts into Sunday-first week columns spanning the `weeksBack`
- * weeks ending at `today`. The first column is snapped back to a Sunday so each
- * column is a clean week; future slots in the last column are left `null`.
+ * Bucket per-day metric values into Sunday-first week columns spanning the
+ * `weeksBack` weeks ending at `today`, for the chosen `metric`. The first column
+ * is snapped back to a Sunday so each column is a clean week; future slots in
+ * the last column are left `null`.
  */
 export function buildCalendarModel(
-  cells: DayCell[],
+  rows: HeatmapDayRow[],
   today: Date,
+  metric: MetricConfig,
   weeksBack = 53
 ): CalendarModel {
-  const counts = new Map<string, DayCell>()
-  for (const c of cells) counts.set(c.date, c)
+  const byDate = new Map<string, HeatmapDayRow>()
+  for (const r of rows) byDate.set(r.date, r)
 
-  // Anchor at midnight-ish (noon avoids DST edge cases when stepping days).
+  // Anchor at noon to avoid DST edge cases when stepping days.
   const end = new Date(
     today.getFullYear(),
     today.getMonth(),
@@ -140,6 +309,8 @@ export function buildCalendarModel(
   let totalDays = 0
   let peak: CalendarDay | null = null
   let prevMonth = -1
+  let firstDay: Date | null = null
+  let lastDay: Date | null = null
 
   const cursor = new Date(start)
   while (cursor <= end) {
@@ -155,21 +326,24 @@ export function buildCalendarModel(
       }
 
       const iso = isoDate(cursor)
-      const rec = counts.get(iso)
-      const count = rec?.query_count ?? 0
+      const rec = byDate.get(iso)
+      const value = rec ? metric.getValue(rec) : 0
       const day: CalendarDay = {
         iso,
         date: new Date(cursor),
-        count,
-        readable: rec?.readable_count ?? '0',
+        value,
+        readable: metric.format(value),
       }
       week[dow] = day
 
+      if (!firstDay) firstDay = day.date
+      lastDay = day.date
+
       totalDays += 1
-      total += count
-      if (count > 0) activeDays += 1
-      if (count > max) max = count
-      if (!peak || count > peak.count) peak = day
+      total += value
+      if (value > 0) activeDays += 1
+      if (value > max) max = value
+      if (!peak || value > peak.value) peak = day
 
       // Label the column at the first day that opens a new month.
       const month = cursor.getMonth()
@@ -185,6 +359,11 @@ export function buildCalendarModel(
     monthLabels.push(label)
   }
 
+  const rangeLabel =
+    firstDay && lastDay
+      ? `${formatMonthYear(firstDay)} – ${formatMonthYear(lastDay)}`
+      : ''
+
   return {
     weeks,
     monthLabels,
@@ -194,5 +373,106 @@ export function buildCalendarModel(
     totalDays,
     avgActive: activeDays > 0 ? total / activeDays : 0,
     peak,
+    rangeLabel,
   }
+}
+
+/** A single KPI/stat card shown above the calendar. */
+export interface StatCard {
+  label: string
+  value: string
+  sub?: string
+  /** Highlight the value with the metric accent colour (used for the peak). */
+  accent?: boolean
+}
+
+/**
+ * Build the four KPI cards for a metric + model. `sum` metrics lead with a
+ * grand total; `gauge` metrics lead with the peak reading (a sum would be
+ * meaningless for e.g. peak memory).
+ */
+export function buildStatCards(
+  metric: MetricConfig,
+  model: CalendarModel
+): StatCard[] {
+  const { total, max, activeDays, totalDays, avgActive, peak } = model
+  const hasTraffic = max > 0
+  const pct = totalDays > 0 ? Math.round((activeDays * 100) / totalDays) : 0
+  const peakDate = peak && hasTraffic ? formatShortDate(peak.date) : '—'
+
+  if (metric.aggregation === 'gauge') {
+    return [
+      {
+        label: `Peak ${metric.label.split(' ')[0]}`,
+        value: hasTraffic ? metric.format(max) : '—',
+        sub: 'highest daily reading',
+        accent: true,
+      },
+      {
+        label: 'Average',
+        value: hasTraffic ? metric.format(avgActive) : '—',
+        sub: 'across active days',
+      },
+      {
+        label: 'Busiest day',
+        value: peakDate,
+        sub: hasTraffic ? 'when the peak occurred' : undefined,
+      },
+      {
+        label: 'Active days',
+        value: formatCompactNumber(activeDays),
+        sub: `of ${totalDays} (${pct}%)`,
+      },
+    ]
+  }
+
+  // sum metrics — vary the wording per metric so the cards read naturally.
+  const wording: Record<
+    'queries' | 'failed' | 'written',
+    { total: string; peak: string; active: string; avgNoun: string }
+  > = {
+    queries: {
+      total: 'Total queries',
+      peak: 'Busiest day',
+      active: 'Active days',
+      avgNoun: 'queries per active day',
+    },
+    failed: {
+      total: 'Total failed',
+      peak: 'Worst day',
+      active: 'Days with errors',
+      avgNoun: 'errors per active day',
+    },
+    written: {
+      total: 'Total written',
+      peak: 'Biggest day',
+      active: 'Active days',
+      avgNoun: 'per active day',
+    },
+  }
+  const w = wording[metric.key as 'queries' | 'failed' | 'written']
+
+  return [
+    {
+      label: w.total,
+      value: metric.format(total),
+      sub: `over ${totalDays} days`,
+    },
+    {
+      label: w.peak,
+      value: hasTraffic ? metric.format(max) : '—',
+      sub: hasTraffic ? `${peakDate} · peak daily volume` : undefined,
+      accent: true,
+    },
+    {
+      label: w.active,
+      value: formatCompactNumber(activeDays),
+      sub: `of ${totalDays} (${pct}%)`,
+    },
+    {
+      label: 'Avg / active day',
+      value: hasTraffic ? metric.format(avgActive) : '—',
+      sub: w.avgNoun,
+    },
+  ]
 }

--- a/apps/dashboard/src/components/charts/query/query-count-heatmap.tsx
+++ b/apps/dashboard/src/components/charts/query/query-count-heatmap.tsx
@@ -1,64 +1,26 @@
 import { ArrowUpRightIcon } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 
-import type { CalendarDay, DayCell } from './query-count-calendar'
+import type {
+  CalendarDay,
+  HeatmapDayRow,
+  MetricConfig,
+  MetricKey,
+} from './query-count-calendar'
 
 import {
   buildCalendarModel,
+  buildStatCards,
   CALENDAR_DAY_LABELS,
   formatCalendarDate,
   getIntensityClass,
-  INTENSITY_TIERS,
   isoDate,
+  METRIC_CONFIGS,
+  METRIC_ORDER,
 } from './query-count-calendar'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { createCustomChart } from '@/components/charts/factory'
-import { formatCompactNumber } from '@/lib/format-readable'
 import { cn } from '@/lib/utils'
-
-interface KpiCardProps {
-  label: string
-  value: string
-  sublabel?: string
-  hint?: string
-  accent?: 'default' | 'peak'
-}
-
-function KpiCard({
-  label,
-  value,
-  sublabel,
-  hint,
-  accent = 'default',
-}: KpiCardProps) {
-  return (
-    <div className="flex min-w-0 flex-col gap-0.5 rounded-md border border-border/60 bg-card/40 px-3 py-2 transition-colors hover:bg-card/70">
-      <span className="text-muted-foreground text-[10px] uppercase tracking-wide">
-        {label}
-      </span>
-      <div className="flex min-w-0 items-baseline gap-1.5">
-        <span
-          className={cn(
-            'truncate text-base font-semibold tabular-nums leading-tight',
-            accent === 'peak' && 'text-chart-2'
-          )}
-        >
-          {value}
-        </span>
-        {sublabel ? (
-          <span className="text-muted-foreground/80 truncate text-[11px] tabular-nums">
-            {sublabel}
-          </span>
-        ) : null}
-      </div>
-      {hint ? (
-        <span className="text-muted-foreground truncate text-[10px] tabular-nums">
-          {hint}
-        </span>
-      ) : null}
-    </div>
-  )
-}
 
 // Day-of-week rows that get a left-gutter label (GitHub shows Mon/Wed/Fri).
 const LABELLED_ROWS = new Set([1, 3, 5])
@@ -69,22 +31,120 @@ interface HoverState {
   y: number
 }
 
-function buildDrilldownHref(hostId: number, day: CalendarDay): string {
+/** Drill into the day's queries. Failed mode jumps straight to /failed-queries. */
+function buildDrilldownHref(
+  hostId: number,
+  day: CalendarDay,
+  metricKey: MetricKey
+): string {
   // Whole-day window. BETWEEN is inclusive on both ends in ClickHouse, so end
   // at 23:59:59 to keep the next day out of this cell's drilldown.
   const params = new URLSearchParams()
   params.set('host', String(hostId))
   params.set('event_time', `between:${day.iso} 00:00:00,${day.iso} 23:59:59`)
-  return `/history-queries?${params.toString()}`
+  const path = metricKey === 'failed' ? '/failed-queries' : '/history-queries'
+  return `${path}?${params.toString()}`
 }
 
-function CalendarBody({ data, hostId }: { data: DayCell[]; hostId: number }) {
-  const [hover, setHover] = useState<HoverState | null>(null)
+/** Pill button that switches the active metric. */
+function ModePill({
+  metric,
+  active,
+  onSelect,
+}: {
+  metric: MetricConfig
+  active: boolean
+  onSelect: (key: MetricKey) => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(metric.key)}
+      aria-pressed={active}
+      className={cn(
+        'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        active
+          ? 'border-foreground bg-foreground text-background'
+          : 'border-border bg-card text-muted-foreground hover:border-foreground/40 hover:text-foreground'
+      )}
+    >
+      {metric.label}
+    </button>
+  )
+}
 
-  // `today` is read once per render from the local clock; the model is cheap
-  // but memoizing keeps the ~371-cell build off every hover re-render.
-  const model = useMemo(() => buildCalendarModel(data, new Date()), [data])
+/** One KPI card in the summary strip. */
+function StatCardView({
+  label,
+  value,
+  sub,
+  accentClass,
+}: {
+  label: string
+  value: string
+  sub?: string
+  accentClass?: string
+}) {
+  return (
+    <div className="flex min-w-0 flex-col rounded-xl border border-border/60 bg-card/40 px-4 py-3">
+      <span className="text-muted-foreground truncate text-[11px] font-medium uppercase tracking-wide">
+        {label}
+      </span>
+      <span
+        className={cn(
+          'mt-1.5 truncate text-2xl font-semibold tabular-nums leading-none',
+          accentClass
+        )}
+      >
+        {value}
+      </span>
+      {sub ? (
+        <span className="text-muted-foreground mt-1.5 truncate text-xs">
+          {sub}
+        </span>
+      ) : null}
+    </div>
+  )
+}
+
+function CalendarBody({
+  data,
+  hostId,
+}: {
+  data: HeatmapDayRow[]
+  hostId: number
+}) {
+  const [mode, setMode] = useState<MetricKey>('queries')
+  const [hover, setHover] = useState<HoverState | null>(null)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  const metric = METRIC_CONFIGS[mode]
+
+  // `today` is read once per render from the local clock; memoize so the
+  // ~371-cell build is off every hover re-render and only reruns on mode change.
+  const model = useMemo(
+    () => buildCalendarModel(data, new Date(), metric),
+    [data, metric]
+  )
+  const statCards = useMemo(
+    () => buildStatCards(metric, model),
+    [metric, model]
+  )
   const todayIso = isoDate(new Date())
+
+  // Auto-focus the latest date: scroll the calendar to its right edge on mount
+  // and whenever the data set changes. No-op when the grid already fits (wide
+  // screens) since scrollWidth === clientWidth; matters on narrow/overflowing
+  // viewports where the most recent weeks would otherwise be off-screen.
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el || data.length === 0) return
+    const id = requestAnimationFrame(() => {
+      el.scrollLeft = el.scrollWidth
+    })
+    return () => cancelAnimationFrame(id)
+  }, [data])
 
   if (data.length === 0) {
     return (
@@ -94,61 +154,55 @@ function CalendarBody({ data, hostId }: { data: DayCell[]; hostId: number }) {
     )
   }
 
-  const {
-    weeks,
-    monthLabels,
-    max,
-    total,
-    activeDays,
-    totalDays,
-    avgActive,
-    peak,
-  } = model
+  const { weeks, monthLabels, max, rangeLabel } = model
   const hasTraffic = max > 0
 
   return (
-    <div data-calendar-root className="relative flex flex-col gap-3 p-1">
-      {/* KPI strip */}
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-        <KpiCard
-          label="Total queries"
-          value={formatCompactNumber(total)}
-          hint={`over ${totalDays} days`}
-        />
-        <KpiCard
-          label="Busiest day"
-          value={peak && hasTraffic ? peak.readable : '—'}
-          sublabel={
-            peak && hasTraffic
-              ? formatCalendarDate(peak.date).slice(5)
-              : undefined
-          }
-          accent="peak"
-          hint={peak && hasTraffic ? 'peak daily volume' : undefined}
-        />
-        <KpiCard
-          label="Active days"
-          value={formatCompactNumber(activeDays)}
-          hint={`of ${totalDays} (${totalDays > 0 ? Math.round((activeDays * 100) / totalDays) : 0}%)`}
-        />
-        <KpiCard
-          label="Avg / active day"
-          value={formatCompactNumber(Math.round(avgActive))}
-          hint="queries per active day"
-        />
+    <div
+      data-calendar-root
+      className="relative flex h-full w-full flex-col justify-center gap-4"
+    >
+      {/* Range caption + metric switcher */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <span className="text-muted-foreground font-mono text-xs">
+          {rangeLabel}
+        </span>
+        <div className="flex flex-wrap gap-1.5">
+          {METRIC_ORDER.map((key) => (
+            <ModePill
+              key={key}
+              metric={METRIC_CONFIGS[key]}
+              active={key === mode}
+              onSelect={setMode}
+            />
+          ))}
+        </div>
       </div>
 
-      {/* Calendar: month labels + weekday gutter + week columns. min-w lets it
-          stay legible on phones (horizontal scroll, like GitHub) while the fr
-          columns make it fluid up to the card width on larger screens. */}
-      <div className="overflow-x-auto">
-        <div className="min-w-[560px]">
+      {/* KPI strip */}
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        {statCards.map((card) => (
+          <StatCardView
+            key={card.label}
+            label={card.label}
+            value={card.value}
+            sub={card.sub}
+            accentClass={card.accent ? metric.accentText : undefined}
+          />
+        ))}
+      </div>
+
+      {/* Calendar: month labels + weekday gutter + week columns. The columns are
+          fluid (flex-1) so the grid fills the card/dialog width; a min width
+          keeps it legible on phones (horizontal scroll, like GitHub). */}
+      <div ref={scrollRef} className="overflow-x-auto pb-1">
+        <div className="min-w-[680px]">
           {/* Month labels, aligned to week columns (pl matches the gutter). */}
-          <div className="flex gap-[3px] pb-1 pl-8">
+          <div className="flex gap-[3px] pb-1.5 pl-9">
             {monthLabels.map((label, i) => (
               <div
-                key={weeks[i][0]?.iso ?? `col-${i}`}
-                className="text-muted-foreground min-w-0 flex-1 text-[10px] leading-none"
+                key={weeks[i].find(Boolean)?.iso ?? `col-${i}`}
+                className="text-muted-foreground min-w-0 flex-1 text-[11px] leading-none"
               >
                 {label ?? ''}
               </div>
@@ -157,11 +211,11 @@ function CalendarBody({ data, hostId }: { data: DayCell[]; hostId: number }) {
 
           <div className="flex gap-[3px]">
             {/* Weekday gutter */}
-            <div className="flex w-8 flex-shrink-0 flex-col gap-[3px]">
+            <div className="flex w-9 flex-shrink-0 flex-col gap-[3px]">
               {CALENDAR_DAY_LABELS.map((label, dow) => (
                 <div
                   key={label}
-                  className="text-muted-foreground flex aspect-square items-center justify-end pr-1 text-[9px] leading-none"
+                  className="text-muted-foreground flex aspect-square items-center justify-end pr-1.5 text-[10px] leading-none"
                 >
                   {LABELLED_ROWS.has(dow) ? label : ''}
                 </div>
@@ -184,9 +238,13 @@ function CalendarBody({ data, hostId }: { data: DayCell[]; hostId: number }) {
                       />
                     )
                   }
-                  const intensity = getIntensityClass(day.count, max)
+                  const intensity = getIntensityClass(
+                    day.value,
+                    max,
+                    metric.tiers
+                  )
                   const isToday = day.iso === todayIso
-                  const href = buildDrilldownHref(hostId, day)
+                  const href = buildDrilldownHref(hostId, day, mode)
                   const onEnter = (e: React.SyntheticEvent<HTMLElement>) => {
                     const rect = e.currentTarget.getBoundingClientRect()
                     const host = e.currentTarget.closest(
@@ -203,13 +261,13 @@ function CalendarBody({ data, hostId }: { data: DayCell[]; hostId: number }) {
                     <Link
                       key={day.iso}
                       to={href}
-                      aria-label={`${day.readable} queries on ${formatCalendarDate(day.date)}`}
+                      aria-label={`${day.readable} on ${formatCalendarDate(day.date)}`}
                       onMouseEnter={onEnter}
                       onFocus={onEnter}
                       onMouseLeave={() => setHover(null)}
                       onBlur={() => setHover(null)}
                       className={cn(
-                        'aspect-square w-full rounded-[2px] transition-transform duration-100',
+                        'aspect-square w-full rounded-[3px] transition-transform duration-100',
                         'hover:scale-125 hover:ring-1 hover:ring-foreground/40',
                         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                         intensity,
@@ -225,24 +283,24 @@ function CalendarBody({ data, hostId }: { data: DayCell[]; hostId: number }) {
       </div>
 
       {/* Footer: helper text + Less→More legend */}
-      <div className="flex flex-wrap items-center justify-between gap-2 pt-0.5">
-        <p className="text-muted-foreground text-[10px]">
-          Click any day to view its queries
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-muted-foreground text-xs">
+          Click any day to view its queries · hover for daily totals
         </p>
         <div className="flex items-center gap-1.5">
-          <span className="text-muted-foreground text-[10px]">Less</span>
-          <div className="flex items-center gap-[2px]">
-            {INTENSITY_TIERS.map((tierClass) => (
+          <span className="text-muted-foreground text-[11px]">Less</span>
+          <div className="flex items-center gap-[3px]">
+            {metric.tiers.map((tierClass) => (
               <div
                 key={tierClass}
                 className={cn(
-                  'h-[10px] w-[10px] flex-shrink-0 rounded-[2px]',
+                  'size-[11px] flex-shrink-0 rounded-[3px]',
                   tierClass
                 )}
               />
             ))}
           </div>
-          <span className="text-muted-foreground text-[10px]">More</span>
+          <span className="text-muted-foreground text-[11px]">More</span>
         </div>
       </div>
 
@@ -255,21 +313,23 @@ function CalendarBody({ data, hostId }: { data: DayCell[]; hostId: number }) {
             className="pointer-events-none absolute z-20 -translate-x-1/2 -translate-y-full"
             style={{ left: hover.x, top: hover.y - 6 }}
           >
-            <div className="bg-popover text-popover-foreground border-border/60 flex min-w-[160px] flex-col gap-1 rounded-md border px-3 py-2 shadow-md">
+            <div className="bg-popover text-popover-foreground border-border/60 flex min-w-[170px] flex-col gap-1 rounded-md border px-3 py-2 shadow-md">
               <div className="flex items-baseline justify-between gap-3">
                 <span className="text-sm font-semibold tabular-nums">
                   {hover.day.readable}
                 </span>
                 <span className="text-muted-foreground text-[10px] tabular-nums">
-                  {hasTraffic ? Math.round((hover.day.count * 100) / max) : 0}%
+                  {hasTraffic ? Math.round((hover.day.value * 100) / max) : 0}%
                   of peak
                 </span>
               </div>
               <span className="text-muted-foreground text-[11px]">
                 {formatCalendarDate(hover.day.date)}
               </span>
-              <div className="border-border/60 text-chart-2 flex items-center gap-1 border-t pt-1 text-[10px]">
-                <span>View queries</span>
+              <div className="border-border/60 flex items-center gap-1 border-t pt-1 text-[10px]">
+                <span className={metric.accentText}>
+                  {mode === 'failed' ? 'View failed queries' : 'View queries'}
+                </span>
                 <ArrowUpRightIcon className="size-3" />
               </div>
             </div>
@@ -287,7 +347,7 @@ export const ChartQueryCountHeatmap = createCustomChart({
   dataTestId: 'query-count-heatmap-chart',
   contentClassName: 'overflow-hidden',
   render: (dataArray, _sql, hostId) => (
-    <CalendarBody data={dataArray as DayCell[]} hostId={hostId} />
+    <CalendarBody data={dataArray as HeatmapDayRow[]} hostId={hostId} />
   ),
 })
 

--- a/apps/dashboard/src/lib/api/charts/query-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/query-charts.ts
@@ -333,19 +333,26 @@ export const queryCharts: Record<string, ChartQueryBuilder> = {
     }
   },
 
-  // Per-day query volume for the GitHub-style contribution calendar. One row
-  // per calendar day; the client buckets these into week columns. Default
-  // window is one year (24 * 365 hours) so the calendar spans ~53 columns.
+  // Per-day activity metrics for the GitHub-style "Activity Calendar" heatmap.
+  // One row per calendar day carrying every switchable metric (query volume,
+  // failures, peak memory, avg duration, bytes written) so the client can flip
+  // modes without a refetch. Conditional aggregation keeps it a single daily
+  // scan. Default window is one year (24 * 365 hours) → ~53 calendar columns.
   'query-count-heatmap': ({ lastHours = 24 * 365 }) => {
     const timeFilter = buildTimeFilter(lastHours)
     return {
       query: `
     SELECT
         toString(toDate(event_time)) AS date,
-        count() AS query_count,
-        formatReadableQuantity(count()) AS readable_count
+        countIf(type = 'QueryFinish') AS query_count,
+        countIf(type = 'ExceptionBeforeStart' OR type = 'ExceptionWhileProcessing') AS failed_count,
+        max(memory_usage) AS memory_peak,
+        round(avgIf(query_duration_ms, type = 'QueryFinish'), 2) AS avg_duration_ms,
+        sumIf(written_bytes, type = 'QueryFinish') AS written_bytes
     FROM merge('system', '^query_log')
-    WHERE type = 'QueryFinish'
+    WHERE (type = 'QueryFinish'
+           OR type = 'ExceptionBeforeStart'
+           OR type = 'ExceptionWhileProcessing')
       ${timeFilter ? `AND ${timeFilter}` : ''}
     GROUP BY date
     ORDER BY date ASC

--- a/apps/dashboard/src/routes/(dashboard)/-charts-config.ts
+++ b/apps/dashboard/src/routes/(dashboard)/-charts-config.ts
@@ -55,6 +55,13 @@ export interface OverviewChartConfig<
   props?: Omit<T, 'hostId'>
   /** Navigation target URL when clicked */
   href?: string
+  /**
+   * Render this chart as a full-width banner ABOVE the tab's chart grid (its
+   * own auto-height row) instead of as a fixed-height grid cell. Used by the
+   * Activity Heatmap hero card so its calendar isn't clipped by the grid's
+   * fixed row height.
+   */
+  fullWidth?: boolean
 }
 
 /**
@@ -368,9 +375,9 @@ export const OVERVIEW_TAB_CHARTS: OverviewChartConfig[] = [
     id: 'query-count-heatmap-overview',
     component: ChartQueryCountHeatmap,
     title: 'Query Activity Heatmap',
-    className: 'w-full h-full col-span-1 md:col-span-2 xl:col-span-3',
+    className: 'w-full',
     type: 'custom',
-    href: '/history-queries',
+    fullWidth: true,
   },
   {
     id: 'query-count-24h',
@@ -544,9 +551,9 @@ export const QUERIES_TAB_CHARTS: OverviewChartConfig[] = [
     id: 'query-count-heatmap',
     component: ChartQueryCountHeatmap,
     title: 'Query Activity Heatmap',
-    className: 'w-full h-full col-span-1 md:col-span-2 xl:col-span-3',
+    className: 'w-full',
     type: 'custom',
-    href: '/history-queries',
+    fullWidth: true,
   },
   {
     id: 'query-count-14d',

--- a/apps/dashboard/src/routes/(dashboard)/overview.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/overview.tsx
@@ -53,6 +53,43 @@ interface LazyTabContentProps {
 const OVERVIEW_CHART_CLASS_NAME = 'h-full min-h-0 w-full'
 const OVERVIEW_CHART_CARD_CONTENT_CLASS_NAME =
   'flex min-h-0 flex-1 flex-col px-3 pb-3 pt-0'
+// Full-width banner charts (e.g. the Activity Heatmap) size to their content
+// instead of a fixed grid row, so the card content uses auto height (no flex-1
+// / min-h-0 height cap that would clip the calendar).
+const BANNER_CHART_CARD_CONTENT_CLASS_NAME = 'flex flex-col px-4 pb-4 pt-0'
+
+function OverviewChart({
+  chartConfig,
+  hostId,
+  banner,
+}: {
+  chartConfig: OverviewChartConfig
+  hostId: number
+  banner: boolean
+}) {
+  const ChartComponent = chartConfig.component
+  return (
+    <ChartComponent
+      title={chartConfig.title}
+      interval={chartConfig.interval}
+      lastHours={chartConfig.lastHours}
+      className={chartConfig.className}
+      chartClassName={cn(
+        banner ? undefined : OVERVIEW_CHART_CLASS_NAME,
+        chartConfig.chartClassName
+      )}
+      chartCardContentClassName={cn(
+        banner
+          ? BANNER_CHART_CARD_CONTENT_CLASS_NAME
+          : OVERVIEW_CHART_CARD_CONTENT_CLASS_NAME,
+        chartConfig.chartCardContentClassName
+      )}
+      hostId={hostId}
+      href={chartConfig.href}
+      {...(chartConfig.props ?? {})}
+    />
+  )
+}
 
 const LazyTabContent = function LazyTabContent({
   charts,
@@ -67,31 +104,38 @@ const LazyTabContent = function LazyTabContent({
   // reveals ready content instead of a scroll-triggered skeleton. We do NOT
   // gate the mount on scroll: deferring the mount also defers the first fetch,
   // which is what made each card flash skeleton→content as it scrolled in.
+  //
+  // `fullWidth` charts render as their own auto-height banner rows ABOVE the
+  // fixed-height grid so a tall hero card (the Activity Heatmap) isn't clipped.
+  const banners = charts.filter((chart) => chart.fullWidth)
+  const gridCharts = charts.filter((chart) => !chart.fullWidth)
+
   return (
-    <div className={gridClassName} role="region" aria-label={`${label} charts`}>
-      {charts.map((chartConfig) => {
-        const ChartComponent = chartConfig.component
-        return (
-          <ChartComponent
-            key={chartConfig.id}
-            title={chartConfig.title}
-            interval={chartConfig.interval}
-            lastHours={chartConfig.lastHours}
-            className={chartConfig.className}
-            chartClassName={cn(
-              OVERVIEW_CHART_CLASS_NAME,
-              chartConfig.chartClassName
-            )}
-            chartCardContentClassName={cn(
-              OVERVIEW_CHART_CARD_CONTENT_CLASS_NAME,
-              chartConfig.chartCardContentClassName
-            )}
-            hostId={hostId}
-            href={chartConfig.href}
-            {...(chartConfig.props ?? {})}
-          />
-        )
-      })}
+    <div className="flex flex-col gap-3">
+      {banners.map((chartConfig) => (
+        <OverviewChart
+          key={chartConfig.id}
+          chartConfig={chartConfig}
+          hostId={hostId}
+          banner
+        />
+      ))}
+      {gridCharts.length > 0 && (
+        <div
+          className={gridClassName}
+          role="region"
+          aria-label={`${label} charts`}
+        >
+          {gridCharts.map((chartConfig) => (
+            <OverviewChart
+              key={chartConfig.id}
+              chartConfig={chartConfig}
+              hostId={hostId}
+              banner={false}
+            />
+          ))}
+        </div>
+      )}
     </div>
   )
 }
@@ -106,19 +150,29 @@ function TabContentSkeleton({ tab }: { tab: (typeof OVERVIEW_TABS)[number] }) {
     return <Skeleton className="h-[420px] w-full rounded-lg" />
   }
 
+  const banners = tab.charts.filter((chart) => chart.fullWidth)
+  const gridCharts = tab.charts.filter((chart) => !chart.fullWidth)
+
   return (
     <div
-      className={tab.gridClassName}
+      className="flex flex-col gap-3"
       role="status"
       aria-label={`Loading ${tab.label} charts`}
     >
-      {tab.charts.map((chart) => (
-        <ChartSkeleton
-          key={chart.id}
-          className={cn(OVERVIEW_CHART_CLASS_NAME, chart.className)}
-          type={chart.type === 'metric' ? 'metric' : undefined}
-        />
+      {banners.map((chart) => (
+        <Skeleton key={chart.id} className="h-[440px] w-full rounded-lg" />
       ))}
+      {gridCharts.length > 0 && (
+        <div className={tab.gridClassName}>
+          {gridCharts.map((chart) => (
+            <ChartSkeleton
+              key={chart.id}
+              className={cn(OVERVIEW_CHART_CLASS_NAME, chart.className)}
+              type={chart.type === 'metric' ? 'metric' : undefined}
+            />
+          ))}
+        </div>
+      )}
     </div>
   )
 }
@@ -265,21 +319,11 @@ function OverviewPageFallback() {
         ))}
       </div>
       <TabsSkeleton tabCount={OVERVIEW_TABS.length} variant="underline" />
-      {/* Reserve the first tab's chart grid so the loading document is roughly
-          as tall as the loaded page. Reuses the real grid class + chart count
-          so it stays in sync if charts are added/removed. */}
-      <div
-        className={cn('mt-2', FIRST_TAB.gridClassName)}
-        role="status"
-        aria-label="Loading charts"
-      >
-        {FIRST_TAB.charts.map((chart) => (
-          <ChartSkeleton
-            key={chart.id}
-            className={cn(OVERVIEW_CHART_CLASS_NAME, chart.className)}
-            type={chart.type === 'metric' ? 'metric' : undefined}
-          />
-        ))}
+      {/* Reserve the first tab's banners + chart grid so the loading document is
+          roughly as tall as the loaded page. Reuses TabContentSkeleton so the
+          banner/grid split stays in sync if charts are added/removed. */}
+      <div className="mt-2">
+        <TabContentSkeleton tab={FIRST_TAB} />
       </div>
     </div>
   )


### PR DESCRIPTION
## What

Redesigns the **Query Activity Heatmap** into a full-width "Activity Calendar" hero card on the first row of the Overview (and Queries) tabs, with a metric switcher — based on the provided reference design.

| Ask | Done |
|-----|------|
| Improve/redesign the heatmap | ✅ GitHub-style calendar reworked: range caption, redesigned KPI cards, larger fluid cells |
| Full width, first row of Overview | ✅ New `fullWidth` banner layout renders it in its own auto-height row above the grid (no more clipping) |
| Calendar auto-focus latest date | ✅ Auto-scrolls to the right edge (latest) on load |
| Bigger in the zoom dialog | ✅ Same component is fluid → fills the 95vw dialog width; content vertically centered |
| Switch heatmap by many modes | ✅ Query Count · Failed Queries · Memory Peak · Avg Duration · Data Written |

## How

- **One query, five metrics.** `query-count-heatmap` now uses conditional aggregation (`countIf`/`maxIf`/`sumIf`) to return all metrics per day in a single daily scan, so switching modes needs **no refetch**.
- **Metric-aware model.** `query-count-calendar.ts` generalized: each `MetricConfig` carries its value extractor, formatter (compact number / size / duration), colour ramp, and KPI definitions. `sum` metrics lead with a grand total; `gauge` metrics (peak memory, avg duration) lead with the peak reading instead of a meaningless sum.
- **Banner layout.** `OverviewChartConfig.fullWidth` charts render above the fixed-height grid in `overview.tsx`; loading skeletons mirror the split for height stability.
- **Per-mode colour:** queries=chart-2, failed=rose, memory=amber, duration=violet, written=emerald (all literal Tailwind classes so the JIT emits them).
- Drill-down is metric-aware: failed mode links to `/failed-queries`, others to `/history-queries`, scoped to the clicked day.

## Verification

- `bun test query-count-calendar.test.ts` → **17 pass** (intensity ramps, model aggregation per metric, range caption, sum-vs-gauge stat cards).
- `tsc --noEmit` → **0 type errors** in changed files.
- `biome check` → clean.

> Note: a local full `bun run build` fails only on a pre-existing `@agentstate/sdk` import (from #1673) missing in this machine's stale `node_modules` — unrelated to this change; CI's fresh install resolves it.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query Activity Heatmap now displays multiple metrics including query volume, failures, memory usage, duration, and written data with a metric mode switcher.
  * Dashboard supports full-width chart layouts for improved visibility of key metrics.
  * Enhanced metric-specific drill-down capabilities and KPI cards with metric-aware tooltips and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->