### PR TITLE
feat(telemetry): add opt-in telemetry core (off by default)

### DIFF
--- a/apps/dashboard/src/lib/telemetry/config.test.ts
+++ b/apps/dashboard/src/lib/telemetry/config.test.ts
@@ -1,0 +1,40 @@
+import { isTelemetryEnabled, parseTelemetryFlag } from './config'
+import { describe, expect, test } from 'bun:test'
+
+describe('parseTelemetryFlag', () => {
+  test('unset / null / empty → false', () => {
+    expect(parseTelemetryFlag(undefined)).toBe(false)
+    expect(parseTelemetryFlag(null)).toBe(false)
+    expect(parseTelemetryFlag('')).toBe(false)
+    expect(parseTelemetryFlag('   ')).toBe(false)
+  })
+
+  test('canonical "on" and convenience truthy values → true', () => {
+    expect(parseTelemetryFlag('on')).toBe(true)
+    expect(parseTelemetryFlag(' ON ')).toBe(true)
+    expect(parseTelemetryFlag('true')).toBe(true)
+    expect(parseTelemetryFlag('1')).toBe(true)
+    expect(parseTelemetryFlag('yes')).toBe(true)
+  })
+
+  test('off / false / arbitrary strings → false', () => {
+    expect(parseTelemetryFlag('off')).toBe(false)
+    expect(parseTelemetryFlag('false')).toBe(false)
+    expect(parseTelemetryFlag('0')).toBe(false)
+    expect(parseTelemetryFlag('enabled')).toBe(false)
+  })
+})
+
+describe('isTelemetryEnabled', () => {
+  test('off by default when nothing enables it', () => {
+    expect(isTelemetryEnabled({})).toBe(false)
+  })
+
+  test('runtime CHM_TELEMETRY=on enables', () => {
+    expect(isTelemetryEnabled({ CHM_TELEMETRY: 'on' })).toBe(true)
+  })
+
+  test('runtime CHM_TELEMETRY=off stays disabled', () => {
+    expect(isTelemetryEnabled({ CHM_TELEMETRY: 'off' })).toBe(false)
+  })
+})

--- a/apps/dashboard/src/lib/telemetry/config.ts
+++ b/apps/dashboard/src/lib/telemetry/config.ts
@@ -1,0 +1,27 @@
+// Telemetry enablement gate. OFF by default — telemetry runs only when it is
+// explicitly turned on, and makes ZERO network calls otherwise.
+//
+// Dual-source, mirroring lib/env.ts so the on/off semantics survive both the
+// Node and the Cloudflare Worker runtime:
+//   - Server: runtime CHM_TELEMETRY (Worker binding / process.env).
+//   - Client: build-time VITE_TELEMETRY_ENABLED (inlined by vite.config.ts).
+//
+// Canonical enabling value is `on` (i.e. CHM_TELEMETRY=on). `true`/`1`/`yes`
+// are also accepted for convenience. Anything else — including unset — is OFF.
+
+const ENABLED_VALUES = new Set(['on', 'true', '1', 'yes'])
+
+export function parseTelemetryFlag(value: string | null | undefined): boolean {
+  if (value == null) return false
+  return ENABLED_VALUES.has(value.trim().toLowerCase())
+}
+
+export function isTelemetryEnabled(
+  runtimeEnv?: Record<string, string | undefined>
+): boolean {
+  const source =
+    runtimeEnv ?? (typeof process !== 'undefined' ? process.env : {})
+  return parseTelemetryFlag(
+    source.CHM_TELEMETRY ?? import.meta.env.VITE_TELEMETRY_ENABLED
+  )
+}

--- a/apps/dashboard/src/lib/telemetry/events.ts
+++ b/apps/dashboard/src/lib/telemetry/events.ts
@@ -1,0 +1,34 @@
+// Telemetry event schema — a closed, typed set of event names plus a flat,
+// non-identifying props bag.
+//
+// Privacy contract: props carry only counts, enums, booleans, and durations.
+// No PII, query text, hostnames, IPs, or connection strings. redact.ts enforces
+// this defensively before any event is emitted.
+//
+// Naming note for prop keys: avoid the tokens the redactor blocks (`host`, `ip`,
+// `url`, `query`, `sql`, `email`, `token`, …). Name count dimensions plainly —
+// e.g. `num_hosts`, `view_count`, `ch_flavor` — not `host_count`/`query_count`.
+// Send a ClickHouse version as `major.minor` (e.g. `24.8`); a full four-part
+// version (`24.8.1.2`) collides with the IPv4 redaction pattern.
+
+export const TELEMETRY_EVENTS = [
+  'app_loaded',
+  'cluster_connected',
+  'health_viewed',
+  'queries_viewed',
+  'ai_query_sent',
+] as const
+
+export type TelemetryEvent = (typeof TELEMETRY_EVENTS)[number]
+
+export type TelemetryPropValue = string | number | boolean | undefined
+export type TelemetryProps = Record<string, TelemetryPropValue>
+
+export interface TelemetryPayload {
+  readonly event: TelemetryEvent
+  readonly props: TelemetryProps
+}
+
+export function isTelemetryEvent(value: string): value is TelemetryEvent {
+  return (TELEMETRY_EVENTS as readonly string[]).includes(value)
+}

--- a/apps/dashboard/src/lib/telemetry/index.ts
+++ b/apps/dashboard/src/lib/telemetry/index.ts
@@ -1,0 +1,22 @@
+// Opt-in, privacy-first product telemetry. OFF by default.
+//
+// Enable with CHM_TELEMETRY=on (server) or VITE_TELEMETRY_ENABLED=true (client
+// build). See docs/content/advanced/telemetry.mdx for the privacy stance and
+// the kill-switch. No call sites are wired yet — this is the core library only.
+
+export { isTelemetryEnabled, parseTelemetryFlag } from './config'
+export {
+  isTelemetryEvent,
+  TELEMETRY_EVENTS,
+  type TelemetryEvent,
+  type TelemetryPayload,
+  type TelemetryProps,
+  type TelemetryPropValue,
+} from './events'
+export { isBlockedKey, looksSensitive, redactProps } from './redact'
+export {
+  clearTelemetrySinks,
+  registerTelemetrySink,
+  type TelemetrySink,
+  track,
+} from './track'

--- a/apps/dashboard/src/lib/telemetry/redact.test.ts
+++ b/apps/dashboard/src/lib/telemetry/redact.test.ts
@@ -1,0 +1,86 @@
+import { isBlockedKey, looksSensitive, redactProps } from './redact'
+import { describe, expect, test } from 'bun:test'
+
+describe('isBlockedKey', () => {
+  test('blocks sensitive-named keys', () => {
+    for (const key of [
+      'password',
+      'apiKey',
+      'api_key',
+      'secret',
+      'authToken',
+      'email',
+      'host',
+      'hostname',
+      'ip',
+      'ipAddress',
+      'url',
+      'endpoint',
+      'dsn',
+      'sql',
+      'query',
+      'queryText',
+    ]) {
+      expect(isBlockedKey(key)).toBe(true)
+    }
+  })
+
+  test('allows safe count / enum keys', () => {
+    for (const key of [
+      'count',
+      'n',
+      'num_hosts',
+      'hosts',
+      'ch_flavor',
+      'duration_ms',
+      'deploy_target',
+      'view_count',
+      'tooltip',
+      'enabled',
+    ]) {
+      expect(isBlockedKey(key)).toBe(false)
+    }
+  })
+})
+
+describe('looksSensitive', () => {
+  test('detects email, IPv4, IPv6, and URL-ish values', () => {
+    expect(looksSensitive('me@example.com')).toBe(true)
+    expect(looksSensitive('10.0.0.1')).toBe(true)
+    expect(looksSensitive('fe80::1')).toBe(true)
+    expect(looksSensitive('https://ch.internal:8443')).toBe(true)
+    expect(looksSensitive('clickhouse://user:pw@host')).toBe(true)
+  })
+
+  test('passes safe enum / count strings', () => {
+    expect(looksSensitive('docker')).toBe(false)
+    expect(looksSensitive('oss')).toBe(false)
+    expect(looksSensitive('24.8')).toBe(false)
+    expect(looksSensitive('cloudflare')).toBe(false)
+  })
+})
+
+describe('redactProps', () => {
+  test('drops sensitive keys and values, keeps safe props', () => {
+    const out = redactProps({
+      deploy_target: 'docker',
+      ch_flavor: 'oss',
+      num_hosts: 3,
+      enabled: true,
+      duration_ms: 1200,
+      host: 'ch.internal', // blocked key
+      email: 'me@example.com', // blocked key
+      note: 'reach me@example.com', // sensitive value
+      endpoint: 'https://x', // blocked key
+      missing: undefined, // dropped (undefined)
+    })
+
+    expect(out).toEqual({
+      deploy_target: 'docker',
+      ch_flavor: 'oss',
+      num_hosts: 3,
+      enabled: true,
+      duration_ms: 1200,
+    })
+  })
+})

--- a/apps/dashboard/src/lib/telemetry/redact.ts
+++ b/apps/dashboard/src/lib/telemetry/redact.ts
@@ -1,0 +1,77 @@
+// Defensive redaction for telemetry props.
+//
+// Callers are expected to pass only non-identifying values (counts, enums,
+// booleans, durations). This is the belt-and-suspenders net that runs before
+// any event leaves the process: it drops props whose KEY names sensitive data,
+// and string VALUES that look like PII, a host, or a URL. Privacy-first — when
+// in doubt, drop.
+
+import type { TelemetryProps } from './events'
+
+// Key tokens that imply sensitive content. Matched as whole `_`/camelCase
+// tokens (not substrings), so `tooltip`/`clip_count` are NOT blocked while
+// `host`/`ip`/`query` are. Conservative on purpose: a dropped count is cheap,
+// a leaked hostname is not.
+const BLOCKED_KEY_TOKENS = new Set([
+  'password',
+  'passwd',
+  'secret',
+  'token',
+  'apikey',
+  'credential',
+  'credentials',
+  'email',
+  'dsn',
+  'sql',
+  'query',
+  'statement',
+  'ddl',
+  'host',
+  'hostname',
+  'ip',
+  'addr',
+  'address',
+  'url',
+  'uri',
+  'endpoint',
+])
+
+function keyTokens(key: string): string[] {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2') // camelCase → snake_case
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+}
+
+export function isBlockedKey(key: string): boolean {
+  const tokens = keyTokens(key)
+  if (tokens.some((token) => BLOCKED_KEY_TOKENS.has(token))) return true
+  // Catch separator-less spellings like `apiKey` → `apikey`.
+  return tokens.join('').includes('apikey')
+}
+
+const EMAIL_RE = /[\w.+-]+@[\w-]+\.[\w][\w.-]*/
+const IPV4_RE = /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/
+const IPV6_RE = /\b(?:[0-9a-f]{0,4}:){2,7}[0-9a-f]{0,4}\b/i
+const URLISH_RE = /:\/\//
+
+export function looksSensitive(value: string): boolean {
+  return (
+    EMAIL_RE.test(value) ||
+    IPV4_RE.test(value) ||
+    IPV6_RE.test(value) ||
+    URLISH_RE.test(value)
+  )
+}
+
+export function redactProps(props: TelemetryProps): TelemetryProps {
+  const out: TelemetryProps = {}
+  for (const [key, value] of Object.entries(props)) {
+    if (value === undefined) continue
+    if (isBlockedKey(key)) continue
+    if (typeof value === 'string' && looksSensitive(value)) continue
+    out[key] = value
+  }
+  return out
+}

--- a/apps/dashboard/src/lib/telemetry/track.test.ts
+++ b/apps/dashboard/src/lib/telemetry/track.test.ts
@@ -1,0 +1,60 @@
+import type { TelemetryPayload } from './events'
+
+import { clearTelemetrySinks, registerTelemetrySink, track } from './track'
+import { afterEach, describe, expect, test } from 'bun:test'
+
+afterEach(() => {
+  clearTelemetrySinks()
+})
+
+describe('track', () => {
+  test('is a no-op when telemetry is disabled', () => {
+    const seen: TelemetryPayload[] = []
+    registerTelemetrySink((payload) => seen.push(payload))
+
+    track('app_loaded', { num_hosts: 1 }, {}) // {} → disabled
+    track('health_viewed', {}, { CHM_TELEMETRY: 'off' })
+
+    expect(seen).toHaveLength(0)
+  })
+
+  test('emits to sinks when enabled, with redaction applied', () => {
+    const seen: TelemetryPayload[] = []
+    registerTelemetrySink((payload) => seen.push(payload))
+
+    track(
+      'cluster_connected',
+      { ch_flavor: 'oss', host: 'secret.internal', num_hosts: 2 },
+      { CHM_TELEMETRY: 'on' }
+    )
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toEqual({
+      event: 'cluster_connected',
+      props: { ch_flavor: 'oss', num_hosts: 2 }, // `host` dropped by redaction
+    })
+  })
+
+  test('sink errors never propagate to the caller', () => {
+    registerTelemetrySink(() => {
+      throw new Error('boom')
+    })
+    const ok: TelemetryPayload[] = []
+    registerTelemetrySink((payload) => ok.push(payload))
+
+    expect(() =>
+      track('ai_query_sent', { model_count: 1 }, { CHM_TELEMETRY: 'on' })
+    ).not.toThrow()
+    expect(ok).toHaveLength(1)
+  })
+
+  test('unsubscribe stops delivery', () => {
+    const seen: TelemetryPayload[] = []
+    const off = registerTelemetrySink((payload) => seen.push(payload))
+    off()
+
+    track('queries_viewed', {}, { CHM_TELEMETRY: 'on' })
+
+    expect(seen).toHaveLength(0)
+  })
+})

--- a/apps/dashboard/src/lib/telemetry/track.ts
+++ b/apps/dashboard/src/lib/telemetry/track.ts
@@ -1,0 +1,49 @@
+// Typed, privacy-first telemetry entry point.
+//
+// `track()` is a HARD no-op unless telemetry is enabled (see config.ts): when
+// disabled it returns immediately and makes zero network calls. When enabled it
+// redacts props and fans the event out to any registered sinks.
+//
+// There is no default sink — transports (self-hosted ClickHouse, opt-in
+// instance ping) are wired in later PRs. That keeps this module safe to import
+// anywhere today without changing behaviour ("dark" by construction).
+
+import type { TelemetryEvent, TelemetryPayload, TelemetryProps } from './events'
+
+import { isTelemetryEnabled } from './config'
+import { redactProps } from './redact'
+
+export type TelemetrySink = (payload: TelemetryPayload) => void
+
+const sinks = new Set<TelemetrySink>()
+
+/** Register a telemetry sink. Returns an unsubscribe function. */
+export function registerTelemetrySink(sink: TelemetrySink): () => void {
+  sinks.add(sink)
+  return () => {
+    sinks.delete(sink)
+  }
+}
+
+/** Drop all registered sinks (used in teardown / tests). */
+export function clearTelemetrySinks(): void {
+  sinks.clear()
+}
+
+export function track(
+  event: TelemetryEvent,
+  props: TelemetryProps = {},
+  runtimeEnv?: Record<string, string | undefined>
+): void {
+  // Hard gate: disabled telemetry does nothing and touches no network.
+  if (!isTelemetryEnabled(runtimeEnv)) return
+
+  const payload: TelemetryPayload = { event, props: redactProps(props) }
+  for (const sink of sinks) {
+    try {
+      sink(payload)
+    } catch {
+      // Telemetry must never break the app — swallow sink errors.
+    }
+  }
+}

--- a/apps/dashboard/src/vite-env.d.ts
+++ b/apps/dashboard/src/vite-env.d.ts
@@ -10,6 +10,8 @@ interface ImportMetaEnv {
   readonly VITE_FEATURE_USER_CONNECTIONS_DB?: string
   readonly VITE_AUTOCOMPLETE_LIMIT?: string
   readonly VITE_RUNNING_QUERIES_REFRESH_MS?: string
+  // Opt-in product telemetry (off by default). See lib/telemetry/.
+  readonly VITE_TELEMETRY_ENABLED?: string
   // Build metadata (injected by vite.config define / CI build step)
   readonly VITE_GIT_SHA?: string
   readonly VITE_GIT_REF?: string

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -58,6 +58,9 @@ const CLIENT_ENV = {
     e.VITE_RUNNING_QUERIES_REFRESH_MS ??
     e.NEXT_PUBLIC_RUNNING_QUERIES_REFRESH_MS ??
     '',
+  // Opt-in product telemetry: OFF by default — must be explicitly enabled.
+  VITE_TELEMETRY_ENABLED:
+    e.VITE_TELEMETRY_ENABLED ?? e.NEXT_PUBLIC_TELEMETRY_ENABLED ?? 'false',
   VITE_GIT_SHA:
     e.VITE_GIT_SHA ?? e.NEXT_PUBLIC_GIT_SHA ?? git('rev-parse HEAD'),
   VITE_GIT_REF:


### PR DESCRIPTION
## What

Adds `apps/dashboard/src/lib/telemetry/` — the **opt-in, privacy-first** product
telemetry core. This is PR **01a** of Plan 01; it ships the library only, **dark**
(no call sites yet).

- `track(event, props)` — a **hard no-op unless explicitly enabled**. When
  disabled it returns immediately and makes **zero network calls**.
- Closed, typed event schema: `app_loaded`, `cluster_connected`,
  `health_viewed`, `queries_viewed`, `ai_query_sent`.
- Defensive **redaction**: drops props whose value looks like an email / IPv4 /
  IPv6 / URL, and props whose key names sensitive data (`host`, `ip`, `url`,
  `query`, `sql`, `email`, `token`, `secret`, …).
- Sink registry with **no default transport** — real transports (self-hosted
  ClickHouse, opt-in instance ping) come in later PRs, so this is safe to import
  anywhere today.
- Off-by-default flag wired into the build: `CHM_TELEMETRY=on` (server runtime)
  / `VITE_TELEMETRY_ENABLED=true` (client build). Default is `false`.

## Why

We can't steer adoption→revenue blind, but telemetry must be **opt-in, no PII,
self-hostable, off by default** (STRATEGY Phase 0 + §8). This lays the typed,
redacted foundation before any event is wired up.

## Scope

In scope (additive only): new `lib/telemetry/` dir, one `vite-env.d.ts` type, one
off-by-default `vite.config.ts` flag. **No call sites, no route/component changes,
no runtime behavior change** (flag defaults off).

## How verified

- ✅ `bun test apps/dashboard/src/lib/telemetry/` → **15/15 pass** (on/off gate +
  redaction).
- ✅ Biome `check --write` clean on all changed files.
- ✅ `tsc --noEmit`: **0 errors from these files** (the only error is the
  pre-existing environmental `vite/client` resolution in the deps-light
  worktree; CI's full install resolves it).
- ℹ️ Full build + full test suite are **CI-verified** (the required `Test`
  workflow runs them with complete dependencies; worktree `node_modules` cannot
  install the full workspace dep set — a known constraint).

## Visual verification

N/A — no rendered UI changes (pure lib + off-by-default build flag).

## Guardrails

- [x] Scope respected (only files in plan's in-scope list)
- [x] tests green (telemetry unit tests; gate + redaction)
- [x] Biome clean on changed files
- [x] Backward compatible / behind a flag (default OFF)
- [x] auto-merge armed (`--auto --squash`) + babysit running
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: `cowork/plans/01-product-metrics.md` (PR 01a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added telemetry tracking system with opt-in enablement (disabled by default).
  * Includes automatic sensitive data redaction to protect privacy.

* **Tests**
  * Added comprehensive test coverage for telemetry configuration, event dispatching, and data redaction.

* **Chores**
  * Updated environment variable declarations to support telemetry configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->