### PR TITLE
feat(telemetry): wire activation events + define activation metric

### DIFF
--- a/apps/dashboard/src/components/assistant-ui/-thread/composer.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/composer.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/agents/welcome/add-context-dialog'
 import { ComposerToolbar } from '@/components/agents/welcome/composer-toolbar'
 import { useAgentAuthGate } from '@/components/assistant-ui/agent-auth-gate'
+import { track } from '@/lib/telemetry'
 
 /**
  * Welcome-screen composer card: mentions textarea + toolbar (model · skills ·
@@ -43,6 +44,7 @@ export function WelcomeComposer() {
             role: 'user',
             content: [{ type: 'text', text: full }],
           })
+          track('ai_query_sent')
           setContextItems([])
         }}
         onStop={() => threadRuntime.cancelRun()}
@@ -75,6 +77,7 @@ export function ThreadComposer() {
             role: 'user',
             content: [{ type: 'text', text: trimmed }],
           })
+          track('ai_query_sent')
         }}
         onStop={() => threadRuntime.cancelRun()}
       />

--- a/apps/dashboard/src/components/assistant-ui/-thread/follow-up-suggestions.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/follow-up-suggestions.tsx
@@ -20,6 +20,7 @@ import { useAgentAuthGate } from '@/components/assistant-ui/agent-auth-gate'
 import { Button } from '@/components/ui/button'
 import { useConversationBackend } from '@/lib/hooks/use-conversation-backend'
 import { useFollowUps } from '@/lib/hooks/use-follow-ups'
+import { track } from '@/lib/telemetry'
 
 export function FollowUpSuggestions() {
   const { supportsAiEnrichment } = useConversationBackend()
@@ -40,6 +41,7 @@ export function FollowUpSuggestions() {
       role: 'user',
       content: [{ type: 'text', text: trimmed }],
     })
+    track('ai_query_sent')
   }
 
   return (

--- a/apps/dashboard/src/components/assistant-ui/thread.tsx
+++ b/apps/dashboard/src/components/assistant-ui/thread.tsx
@@ -58,6 +58,7 @@ import { JsonRenderMessage } from '@/components/assistant-ui/json-render-message
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
 import { resolveConversationBackend } from '@/lib/conversation-store/adapter/resolve-thread-list-adapter'
 import { useAgentSkills } from '@/lib/hooks/use-agent-skills'
+import { track } from '@/lib/telemetry'
 
 interface ThreadProps {
   /** Display name to weave into the welcome heading. */
@@ -167,6 +168,7 @@ function ThreadWelcome({
         role: 'user',
         content: [{ type: 'text', text: trimmed }],
       })
+      track('ai_query_sent')
     },
     [threadRuntime, ensureAuthed]
   )

--- a/apps/dashboard/src/components/connections/connection-form.tsx
+++ b/apps/dashboard/src/components/connections/connection-form.tsx
@@ -10,6 +10,7 @@ import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { docsSiteUrl } from '@/lib/docs-site'
 import { apiFetch } from '@/lib/swr/api-fetch'
+import { track } from '@/lib/telemetry'
 
 export type { BrowserConnection }
 
@@ -103,6 +104,7 @@ export function ConnectionForm({
             ? `Connected — ClickHouse ${json.version}`
             : 'Connected',
         })
+        track('cluster_connected')
       } else {
         setTestStatus({
           state: 'error',

--- a/apps/dashboard/src/components/health/health-grid.tsx
+++ b/apps/dashboard/src/components/health/health-grid.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/lib/health/history-storage'
 import { loadThresholds } from '@/lib/health/thresholds-storage'
 import { useHostId } from '@/lib/swr'
+import { track } from '@/lib/telemetry'
 import { cn } from '@/lib/utils'
 
 const STUCK_MUTATIONS_CHART = 'summary-stuck-mutations'
@@ -73,6 +74,11 @@ export function HealthGrid() {
       window.removeEventListener('health-thresholds-changed', handler)
       window.removeEventListener('storage', handler)
     }
+  }, [])
+
+  // Fire-and-forget product telemetry — no-op unless enabled.
+  useEffect(() => {
+    track('health_viewed')
   }, [])
 
   // Every card's chart name, fetched together in one request.

--- a/apps/dashboard/src/components/running-queries/running-queries-view.tsx
+++ b/apps/dashboard/src/components/running-queries/running-queries-view.tsx
@@ -28,6 +28,7 @@ import { useSearchParams } from '@/lib/next-compat'
 import { useTableData } from '@/lib/query/use-table-data'
 import { runningQueriesConfig } from '@/lib/query-config/queries/running-queries'
 import { useHostId } from '@/lib/swr/use-host'
+import { track } from '@/lib/telemetry'
 import { cn } from '@/lib/utils'
 
 /**
@@ -97,6 +98,11 @@ export const RunningQueriesView = function RunningQueriesView() {
   const searchParams = useSearchParams()
   const [chartsOpen, setChartsOpen] = useState(true)
   const [live, setLive] = useState(true)
+
+  // Fire-and-forget product telemetry — no-op unless enabled.
+  useEffect(() => {
+    track('queries_viewed')
+  }, [])
 
   // Pipe URL-driven filter params into the SWR key so the schema-driven
   // header filters and bar (rendered by the underlying DataTable) actually

--- a/apps/dashboard/src/lib/context/app-context.tsx
+++ b/apps/dashboard/src/lib/context/app-context.tsx
@@ -6,9 +6,11 @@ import {
   type SetStateAction,
   use,
   useCallback,
+  useEffect,
   useMemo,
   useState,
 } from 'react'
+import { track } from '@/lib/telemetry'
 
 export interface ContextValue {
   interval: ClickHouseInterval
@@ -83,6 +85,11 @@ export const AppProvider = ({
         return next
       })
     }, [])
+
+  // Fire-and-forget product telemetry — no-op unless enabled. Once per app load.
+  useEffect(() => {
+    track('app_loaded')
+  }, [])
 
   const value = useMemo<ContextValue>(
     () => ({

--- a/apps/dashboard/src/lib/telemetry/activation.test.ts
+++ b/apps/dashboard/src/lib/telemetry/activation.test.ts
@@ -1,0 +1,30 @@
+import { isActivated } from './activation'
+import { describe, expect, test } from 'bun:test'
+
+describe('isActivated', () => {
+  test('no events → not activated', () => {
+    expect(isActivated([])).toBe(false)
+  })
+
+  test('connect alone → not activated (need a view)', () => {
+    expect(isActivated(['cluster_connected'])).toBe(false)
+  })
+
+  test('a view without connect → not activated', () => {
+    expect(isActivated(['health_viewed', 'queries_viewed'])).toBe(false)
+  })
+
+  test('connect + health view → activated', () => {
+    expect(isActivated(['cluster_connected', 'health_viewed'])).toBe(true)
+  })
+
+  test('connect + queries view → activated', () => {
+    expect(isActivated(['cluster_connected', 'queries_viewed'])).toBe(true)
+  })
+
+  test('accepts a Set as well as an array', () => {
+    expect(isActivated(new Set(['cluster_connected', 'health_viewed']))).toBe(
+      true
+    )
+  })
+})

--- a/apps/dashboard/src/lib/telemetry/activation.ts
+++ b/apps/dashboard/src/lib/telemetry/activation.ts
@@ -1,0 +1,25 @@
+// Activation metric definition (STRATEGY Phase 0 funnel).
+//
+// A first session is "activated" when the user connected a cluster AND looked
+// at either health or queries in that session:
+//
+//   activation = cluster_connected AND (health_viewed OR queries_viewed)
+//
+// Kept as one tested, executable definition so the client, an analytics query
+// over the telemetry store, and the docs all reference the same rule.
+
+import type { TelemetryEvent } from './events'
+
+export const ACTIVATION_REQUIRED: TelemetryEvent = 'cluster_connected'
+export const ACTIVATION_ANY_OF: readonly TelemetryEvent[] = [
+  'health_viewed',
+  'queries_viewed',
+]
+
+export function isActivated(seen: Iterable<TelemetryEvent>): boolean {
+  const set = seen instanceof Set ? seen : new Set(seen)
+  return (
+    set.has(ACTIVATION_REQUIRED) &&
+    ACTIVATION_ANY_OF.some((event) => set.has(event))
+  )
+}

--- a/apps/dashboard/src/lib/telemetry/index.ts
+++ b/apps/dashboard/src/lib/telemetry/index.ts
@@ -2,8 +2,13 @@
 //
 // Enable with CHM_TELEMETRY=on (server) or VITE_TELEMETRY_ENABLED=true (client
 // build). See docs/content/advanced/telemetry.mdx for the privacy stance and
-// the kill-switch. No call sites are wired yet — this is the core library only.
+// the kill-switch.
 
+export {
+  ACTIVATION_ANY_OF,
+  ACTIVATION_REQUIRED,
+  isActivated,
+} from './activation'
 export { isTelemetryEnabled, parseTelemetryFlag } from './config'
 export {
   isTelemetryEvent,


### PR DESCRIPTION
## What

PR **01b** of Plan 01 — wires the (still off-by-default) telemetry `track()` into
the activation funnel and defines the activation metric.

- `app_loaded` — once per app load (`AppProvider` mount effect).
- `cluster_connected` — on a successful connection test (`connection-form.tsx`).
- `health_viewed` — on Health grid mount (`health-grid.tsx`).
- `queries_viewed` — on Running Queries view mount (`running-queries-view.tsx`).
- `ai_query_sent` — at **all four** user-send sites (welcome + in-thread composer,
  example-prompt pick, follow-up-suggestion pick).
- New `lib/telemetry/activation.ts`: `isActivated(seen)` encoding
  **activation = cluster_connected AND (health_viewed OR queries_viewed)** — one
  tested, executable definition the client / analytics / docs can all share.

## Why

We can't measure the adoption funnel without firing the events. These calls are
fire-and-forget and **no-op unless telemetry is explicitly enabled** (default
off), so they change nothing in normal/prod builds.

## Scope

Additive only: one `track()` call per site (5 events, 7 files) + the activation
helper + tests. No rendering, layout, or behavior change. Props are intentionally
minimal — environment dimensions (CH version, flavor, deploy target) land in 01c.

## How verified

- ✅ `bun test …/telemetry` → **21/21** (gate + redaction + activation).
- ✅ `bun run test:unit` → **1266 pass / 0 fail** (full suite).
- ✅ `bun run build` (vite + `tsc --noEmit`) green — all routes prerender,
  confirming every wired component still compiles + renders.
- ✅ Biome clean on all changed files.

## Visual verification

**UI unaffected — verified by construction.** Telemetry is off by default and
`track()` returns immediately when disabled; all insertions are additive
fire-and-forget calls (no JSX/DOM/layout change). `useEffect` calls are
client-only (don't run during prerender) and handler calls fire only on user
action. The production build prerenders every affected route (`/overview`,
`/running-queries`, agent thread, connections) without error — that successful
render is the regression proof; there is no rendered delta to screenshot.

## Guardrails

- [x] Scope respected (plan 01b call sites + activation helper only)
- [x] build green (vite + tsc)
- [x] tests green (telemetry 21/21; full suite 1266/0)
- [x] Biome clean
- [x] Backward compatible / behind a flag (default OFF; no-op)
- [x] UI changed? → unaffected by construction (see above)
- [x] auto-merge armed + babysit
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: `cowork/plans/01-product-metrics.md` (PR 01b). Follow-up: the four
`threadRuntime.append({role:'user'})` send sites could later share a helper so a
5th path can't silently miss telemetry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added telemetry event tracking to dashboard components for AI queries, page views, cluster connections, and app initialization.
  * Introduced telemetry activation module with rules and tests to evaluate dashboard activation status based on tracked events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->