### PR TITLE
feat(query-config): add declarative config schema + validator

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/index.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/index.ts
@@ -1,0 +1,7 @@
+export {
+  type DeclarativeQueryConfig,
+  declarativeQueryConfigSchema,
+  sqlSchema,
+  versionedSqlEntrySchema,
+} from './schema'
+export { type ValidateResult, validateDeclarativeConfig } from './validate'

--- a/apps/dashboard/src/lib/query-config/declarative/schema.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/schema.test.ts
@@ -1,0 +1,276 @@
+import { validateDeclarativeConfig } from './validate'
+import { describe, expect, test } from 'bun:test'
+
+// ---------------------------------------------------------------------------
+// Valid — minimal config
+// ---------------------------------------------------------------------------
+
+describe('minimal valid config', () => {
+  test('accepts name + sql string + columns', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: 'SELECT 1',
+      columns: ['col1'],
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.config.name).toBe('my-query')
+    expect(result.config.sql).toBe('SELECT 1')
+    expect(result.config.optional).toBe(false) // default
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Valid — full-featured config (VersionedSql + BackgroundBar + optional)
+// ---------------------------------------------------------------------------
+
+describe('full-featured valid config', () => {
+  test('accepts versioned sql array', () => {
+    const result = validateDeclarativeConfig({
+      name: 'slow-queries',
+      description: 'Top 10 slowest queries',
+      docs: 'https://clickhouse.com/docs',
+      sql: [
+        { since: '23.8', sql: 'SELECT query_id FROM system.query_log' },
+        {
+          since: '24.1',
+          sql: 'SELECT query_id, query_cache_usage FROM system.query_log',
+          description: 'Added query_cache_usage',
+        },
+      ],
+      columns: ['query_id', 'readable_read_rows', 'readable_read_bytes'],
+      columnFormats: {
+        readable_read_rows: 'background-bar',
+        readable_read_bytes: ['background-bar', { numberFormat: true }],
+        query_id: ['link', { href: '/query?query_id=[query_id]' }],
+      },
+      optional: true,
+      tableCheck: 'system.query_log',
+      defaultParams: { min_duration_s: '5', last_hours: 24 },
+      filterParamPresets: [
+        { name: 'Last hour', key: 'last_hours', value: '1' },
+        { name: '> 5s', key: 'min_duration_s', value: '5' },
+      ],
+      relatedCharts: [
+        'slow-query-occurrences',
+        ['query-duration-histogram', { bucket: 60 }],
+      ],
+      card: {
+        primary: 'query',
+        badges: ['query_cache_usage'],
+        metrics: ['user', 'query_duration'],
+        hidden: ['readable_read_rows'],
+      },
+      defaultView: 'auto',
+      sortingFns: { readable_read_rows: 'sort_column_using_pct' },
+      refreshInterval: 30000,
+      tableBehavior: {
+        enableColumnResizing: true,
+        columnResizeMode: 'onChange',
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      console.error(result.errors)
+      return
+    }
+    expect(result.config.name).toBe('slow-queries')
+    expect(Array.isArray(result.config.sql)).toBe(true)
+    expect(result.config.optional).toBe(true)
+    expect(result.config.tableCheck).toBe('system.query_log')
+    expect(result.config.defaultView).toBe('auto')
+    expect(result.config.sortingFns?.readable_read_rows).toBe(
+      'sort_column_using_pct'
+    )
+  })
+
+  test('accepts action column format with array args', () => {
+    const result = validateDeclarativeConfig({
+      name: 'running-queries',
+      sql: 'SELECT query_id FROM system.processes',
+      columns: ['action', 'query_id'],
+      columnFormats: {
+        action: ['action', ['kill-query', 'explain-query']],
+      },
+    })
+
+    expect(result.ok).toBe(true)
+  })
+
+  test('accepts tableCheck as string array', () => {
+    const result = validateDeclarativeConfig({
+      name: 'backup-log',
+      sql: 'SELECT * FROM system.backup_log',
+      columns: ['name', 'status'],
+      optional: true,
+      tableCheck: ['system.backup_log', 'system.error_log'],
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.config.tableCheck).toEqual([
+      'system.backup_log',
+      'system.error_log',
+    ])
+  })
+
+  test('accepts bulkActions and bulkActionKey', () => {
+    const result = validateDeclarativeConfig({
+      name: 'queries',
+      sql: 'SELECT query_id FROM system.processes',
+      columns: ['query_id', 'user'],
+      bulkActions: ['kill-query'],
+      bulkActionKey: 'query_id',
+    })
+
+    expect(result.ok).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Invalid cases
+// ---------------------------------------------------------------------------
+
+describe('invalid configs', () => {
+  test('rejects missing name', () => {
+    const result = validateDeclarativeConfig({
+      sql: 'SELECT 1',
+      columns: ['col1'],
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some((e) => e.includes('name'))).toBe(true)
+  })
+
+  test('rejects empty name', () => {
+    const result = validateDeclarativeConfig({
+      name: '',
+      sql: 'SELECT 1',
+      columns: ['col1'],
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some((e) => e.includes('name'))).toBe(true)
+  })
+
+  test('rejects missing sql', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      columns: ['col1'],
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some((e) => e.includes('sql'))).toBe(true)
+  })
+
+  test('rejects empty sql string', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: '',
+      columns: ['col1'],
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some((e) => e.includes('sql'))).toBe(true)
+  })
+
+  test('rejects empty versioned sql array', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: [],
+      columns: ['col1'],
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some((e) => e.includes('sql'))).toBe(true)
+  })
+
+  test('rejects bad since version in versioned sql', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: [{ since: 'not-a-version', sql: 'SELECT 1' }],
+      columns: ['col1'],
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some((e) => e.includes('version'))).toBe(true)
+  })
+
+  test('rejects missing sql in versioned entry', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: [{ since: '23.8' }],
+      columns: ['col1'],
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.length).toBeGreaterThan(0)
+  })
+
+  test('rejects empty columns array', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: 'SELECT 1',
+      columns: [],
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some((e) => e.includes('columns'))).toBe(true)
+  })
+
+  test('rejects invalid defaultView value', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: 'SELECT 1',
+      columns: ['col1'],
+      defaultView: 'invalid-view',
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some((e) => e.includes('defaultView'))).toBe(true)
+  })
+
+  test('rejects non-URL docs field', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: 'SELECT 1',
+      columns: ['col1'],
+      docs: 'not-a-url',
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some((e) => e.includes('docs'))).toBe(true)
+  })
+
+  test('rejects unknown columnFormat enum value', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: 'SELECT 1',
+      columns: ['col1'],
+      columnFormats: { col1: 'not-a-format' },
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.length).toBeGreaterThan(0)
+  })
+
+  test('rejects non-object input', () => {
+    const result = validateDeclarativeConfig('not an object')
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.length).toBeGreaterThan(0)
+  })
+})

--- a/apps/dashboard/src/lib/query-config/declarative/schema.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/schema.ts
@@ -1,0 +1,238 @@
+/**
+ * Declarative query-config schema — the catalog contract.
+ *
+ * This module defines the SERIALIZABLE subset of QueryConfig that can live in
+ * a JSON / YAML / TOML file and be contributed by the community without
+ * requiring TypeScript knowledge.
+ *
+ * The companion loader (Plan 02b) will map a DeclarativeQueryConfig into the
+ * in-memory QueryConfig that the dashboard consumes at runtime. Fields that
+ * are runtime functions (rowClassName, expandable, columnIcons, filterSchema
+ * with Icon refs, FeaturePermission) are intentionally excluded here — they
+ * cannot be expressed declaratively and must be wired up by the loader.
+ *
+ * Serializable fields carried here:
+ *   identity:       name, description, docs, suggestion
+ *   sql:            string | VersionedSql[]
+ *   columns:        string[]
+ *   columnFormats:  record of column → format spec (enum or [enum, args])
+ *   columnDescriptions, columnSizing, tableBehavior
+ *   defaultParams, filterParamPresets (icon omitted — not serializable)
+ *   optional, tableCheck, disableSqlValidation, refreshInterval
+ *   relatedCharts:  string[] | [string, params][]
+ *   card, defaultView, bulkActions, bulkActionKey
+ *   sortingFns
+ */
+
+import { z } from 'zod'
+
+// ---------------------------------------------------------------------------
+// Version string: looks like "23.8", "24.1", "25.6.0", etc.
+// ---------------------------------------------------------------------------
+
+const versionPattern = /^\d+\.\d+(\.\d+)*$/
+
+const versionStringSchema = z
+  .string()
+  .regex(versionPattern, 'version must match X.Y or X.Y.Z format (e.g. "23.8")')
+
+// ---------------------------------------------------------------------------
+// SQL: plain string or versioned array
+// ---------------------------------------------------------------------------
+
+export const versionedSqlEntrySchema = z.object({
+  since: versionStringSchema,
+  sql: z.string().min(1, 'sql string must not be empty'),
+  description: z.string().optional(),
+})
+
+export const sqlSchema = z.union([
+  z.string().min(1, 'sql must not be empty'),
+  z
+    .array(versionedSqlEntrySchema)
+    .min(1, 'versioned sql array must have at least one entry'),
+])
+
+// ---------------------------------------------------------------------------
+// ColumnFormat enum values (mirrors ColumnFormat enum from types/column-format)
+// ---------------------------------------------------------------------------
+
+const columnFormatValues = [
+  'background-bar',
+  'colored-badge',
+  'related-time',
+  'number-short',
+  'code-toggle',
+  'code-dialog',
+  'running-query-summary',
+  'hover-card',
+  'duration',
+  'markdown',
+  'boolean',
+  'boolean-inverted',
+  'action',
+  'inline-action',
+  'number',
+  'badge',
+  'code',
+  'link',
+  'text',
+  'none',
+] as const
+
+const columnFormatEnumSchema = z.enum(columnFormatValues)
+
+// ---------------------------------------------------------------------------
+// Per-format args schemas (serializable subset of ColumnFormatWithArgs)
+//
+// For formats whose options are complex or component-coupled (RunningQuerySummary,
+// HoverCard), we accept a permissive record so contributors can still pass args;
+// the loader validates further at runtime.
+// TODO: tighten Action[], CodeDialogOptions, LinkFormatOptions shapes once
+//       those types are fully stable and independently importable.
+// ---------------------------------------------------------------------------
+
+const columnFormatArgsSchema = z.record(z.string(), z.unknown())
+
+// A column format is either a bare enum string, or a [enum, args] tuple.
+const columnFormatSpecSchema = z.union([
+  columnFormatEnumSchema,
+  z.tuple([columnFormatEnumSchema, columnFormatArgsSchema]),
+  z.tuple([columnFormatEnumSchema, z.array(z.unknown())]),
+])
+
+// ---------------------------------------------------------------------------
+// columnSizing
+// ---------------------------------------------------------------------------
+
+const columnSizingEntrySchema = z.object({
+  size: z.number().positive().optional(),
+  minSize: z.number().positive().optional(),
+  maxSize: z.number().positive().optional(),
+})
+
+// ---------------------------------------------------------------------------
+// tableBehavior
+// ---------------------------------------------------------------------------
+
+const tableBehaviorSchema = z.object({
+  enableColumnResizing: z.boolean().optional(),
+  columnResizeMode: z.enum(['onChange', 'onEnd']).optional(),
+  enableSorting: z.boolean().optional(),
+  enableColumnReordering: z.boolean().optional(),
+})
+
+// ---------------------------------------------------------------------------
+// filterParamPresets — icon is a React component, intentionally excluded
+// ---------------------------------------------------------------------------
+
+const filterParamPresetSchema = z.object({
+  name: z.string().min(1),
+  key: z.string().min(1),
+  value: z.string(),
+  // icon intentionally excluded — not serializable (React component reference)
+})
+
+// ---------------------------------------------------------------------------
+// card config
+// ---------------------------------------------------------------------------
+
+const cardConfigSchema = z.object({
+  primary: z.string().optional(),
+  badges: z.array(z.string()).optional(),
+  metrics: z.array(z.string()).optional(),
+  hidden: z.array(z.string()).optional(),
+})
+
+// ---------------------------------------------------------------------------
+// relatedCharts: string names or [name, params] tuples
+// ---------------------------------------------------------------------------
+
+const relatedChartSchema = z.union([
+  z.string().min(1),
+  z.tuple([z.string().min(1), z.record(z.string(), z.unknown())]),
+])
+
+// ---------------------------------------------------------------------------
+// sortingFns
+// ---------------------------------------------------------------------------
+
+const sortingFnValues = [
+  'sort_column_using_pct',
+  'sort_column_using_pct_inverted',
+] as const
+
+const sortingFnsSchema = z.record(z.string(), z.enum(sortingFnValues))
+
+// ---------------------------------------------------------------------------
+// Main declarative schema
+// ---------------------------------------------------------------------------
+
+export const declarativeQueryConfigSchema = z.object({
+  // Identity
+  name: z.string().min(1, 'name is required'),
+  description: z.string().optional(),
+  docs: z.string().url().optional(),
+  suggestion: z.string().optional(),
+
+  // SQL
+  sql: sqlSchema,
+
+  // Columns
+  columns: z
+    .array(z.string().min(1))
+    .min(1, 'columns must have at least one entry'),
+
+  // Column display
+  columnFormats: z.record(z.string(), columnFormatSpecSchema).optional(),
+  columnDescriptions: z.record(z.string(), z.string()).optional(),
+  columnSizing: z.record(z.string(), columnSizingEntrySchema).optional(),
+
+  // Table behavior
+  tableBehavior: tableBehaviorSchema.optional(),
+
+  // Query parameters
+  defaultParams: z
+    .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+    .optional(),
+
+  // Filters
+  filterParamPresets: z.array(filterParamPresetSchema).optional(),
+  // filterSchema intentionally excluded — FilterField.icon is a React component
+  // and FilterFieldDynamicOptions contains Icon refs; the loader wires it from TS.
+
+  // Optional table handling
+  optional: z.boolean().default(false),
+  tableCheck: z.union([z.string(), z.array(z.string())]).optional(),
+
+  // Validation toggle
+  disableSqlValidation: z.boolean().optional(),
+
+  // Refresh
+  refreshInterval: z.number().positive().optional(),
+
+  // Related charts
+  relatedCharts: z.array(relatedChartSchema).optional(),
+
+  // Card / view
+  card: cardConfigSchema.optional(),
+  defaultView: z.enum(['table', 'cards', 'auto']).optional(),
+
+  // Bulk actions
+  bulkActions: z.array(z.string()).optional(),
+  bulkActionKey: z.string().optional(),
+
+  // Sorting
+  sortingFns: sortingFnsSchema.optional(),
+
+  // Intentionally excluded (not serializable — require runtime code):
+  //   columnIcons     — React component refs
+  //   rowClassName    — function (row) => string
+  //   expandable      — function (row, ctx) => ReactNode
+  //   permission      — FeaturePermission (app-level import)
+  //   variants        — deprecated; use versioned sql[] instead
+})
+
+export type DeclarativeQueryConfig = z.infer<
+  typeof declarativeQueryConfigSchema
+>

--- a/apps/dashboard/src/lib/query-config/declarative/validate.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/validate.ts
@@ -1,0 +1,29 @@
+import {
+  type DeclarativeQueryConfig,
+  declarativeQueryConfigSchema,
+} from './schema'
+
+export type ValidateResult =
+  | { ok: true; config: DeclarativeQueryConfig }
+  | { ok: false; errors: string[] }
+
+/**
+ * Validate an unknown input against the declarative query-config schema.
+ *
+ * Returns `{ ok: true, config }` on success, or `{ ok: false, errors }` with
+ * a flat list of human-readable error strings that include the field path.
+ */
+export function validateDeclarativeConfig(input: unknown): ValidateResult {
+  const result = declarativeQueryConfigSchema.safeParse(input)
+
+  if (result.success) {
+    return { ok: true, config: result.data }
+  }
+
+  const errors = result.error.issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : '(root)'
+    return `${path}: ${issue.message}`
+  })
+
+  return { ok: false, errors }
+}


### PR DESCRIPTION
## What

Adds a new `apps/dashboard/src/lib/query-config/declarative/` directory with four files:

- **`schema.ts`** — Zod schema (`declarativeQueryConfigSchema`) covering the full serializable subset of `QueryConfig`, plus the inferred `DeclarativeQueryConfig` type
- **`validate.ts`** — `validateDeclarativeConfig(unknown)` returning `{ ok, config } | { ok, errors[] }` with flat, human-readable error strings
- **`index.ts`** — clean re-exports
- **`schema.test.ts`** — 17 `bun:test` assertions

## Why

Foundation for externalizing the ~79 TypeScript `QueryConfig`s into a community-contributable catalog (JSON/YAML). This PR (02a) defines the contract; the loader that maps `DeclarativeQueryConfig` → in-memory `QueryConfig` is Plan 02b.

## Scope

**Purely additive.** No existing file is touched. No loader, no migration of existing configs, no runtime or UI behaviour change.

## Schema coverage

| Field | Included | Notes |
|-------|----------|-------|
| `name`, `description`, `docs`, `suggestion` | ✅ | |
| `sql` string or `VersionedSql[]` | ✅ | `since` validated as `X.Y[.Z]` version string |
| `columns` | ✅ | |
| `columnFormats` | ✅ | enum string or `[enum, args]` tuple; args accept permissive record/array (TODO: tighten per-format args in 02b) |
| `columnDescriptions`, `columnSizing`, `tableBehavior` | ✅ | |
| `defaultParams`, `filterParamPresets` | ✅ | `filterParamPresets.icon` excluded (React ref) |
| `optional`, `tableCheck` | ✅ | `tableCheck` accepts string or string[] |
| `relatedCharts` | ✅ | string names or `[name, params]` tuples |
| `card`, `defaultView`, `bulkActions`, `bulkActionKey` | ✅ | |
| `sortingFns` | ✅ | validated against known `CustomSortingFnNames` values |
| `refreshInterval`, `disableSqlValidation` | ✅ | |
| `columnIcons` | ❌ | React component refs — not serializable |
| `rowClassName` | ❌ | function — not serializable |
| `expandable` | ❌ | function/ReactNode — not serializable |
| `permission` | ❌ | `FeaturePermission` app import — not serializable |
| `filterSchema` | ❌ | `FilterField.icon` is a React component ref |
| `variants` | ❌ | deprecated; use `sql: VersionedSql[]` |

## Verified

```
bunx biome check --write apps/dashboard/src/lib/query-config/declarative
→ Checked 4 files. Fixed 3 files (import ordering only). 0 errors.

bun test apps/dashboard/src/lib/query-config/declarative/
→ 17 pass, 0 fail (39 expect() calls)

cd apps/dashboard && bun run build
→ vite build ✓ built in 2.32s
→ tsc --noEmit ✓ built in 1.60s
→ exit 0
```

## Visual verification

N/A — pure library, no UI.

## Checklist

- [x] Purely additive (no existing file modified)
- [x] No loader, no config migration, no behaviour change
- [x] Biome clean
- [x] All tests pass
- [x] Build (vite + tsc) exits 0
- [x] Schema contract documented inline with excluded-fields comment