### PR TITLE
feat(telemetry): add opt-in daily instance ping (dark by default)

### DIFF
--- a/apps/dashboard/src/lib/context/app-context.tsx
+++ b/apps/dashboard/src/lib/context/app-context.tsx
@@ -10,7 +10,7 @@ import {
   useMemo,
   useState,
 } from 'react'
-import { getDeployTarget, track } from '@/lib/telemetry'
+import { getDeployTarget, maybePingInstance, track } from '@/lib/telemetry'
 
 export interface ContextValue {
   interval: ClickHouseInterval
@@ -89,6 +89,9 @@ export const AppProvider = ({
   // Fire-and-forget product telemetry — no-op unless enabled. Once per app load.
   useEffect(() => {
     track('app_loaded', { deploy_target: getDeployTarget() })
+    // Daily anonymous instance ping — no-op unless telemetry is explicitly
+    // enabled AND CHM_TELEMETRY_ENDPOINT is configured.
+    maybePingInstance()
   }, [])
 
   const value = useMemo<ContextValue>(

--- a/apps/dashboard/src/lib/telemetry/index.ts
+++ b/apps/dashboard/src/lib/telemetry/index.ts
@@ -25,6 +25,16 @@ export {
   type TelemetryProps,
   type TelemetryPropValue,
 } from './events'
+export {
+  buildPingPayload,
+  getPingEndpoint,
+  maybePingInstance,
+  PING_INTERVAL_MS,
+  type PingDeps,
+  type PingResult,
+  runInstancePing,
+  shouldPing,
+} from './instance-ping'
 export { isBlockedKey, looksSensitive, redactProps } from './redact'
 export {
   clearTelemetrySinks,

--- a/apps/dashboard/src/lib/telemetry/instance-ping.test.ts
+++ b/apps/dashboard/src/lib/telemetry/instance-ping.test.ts
@@ -1,0 +1,287 @@
+import {
+  buildPingPayload,
+  PING_INTERVAL_MS,
+  type PingDeps,
+  runInstancePing,
+  shouldPing,
+} from './instance-ping'
+import { describe, expect, test } from 'bun:test'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// shouldPing
+
+describe('shouldPing', () => {
+  const NOW = 1_000_000_000_000
+
+  test('returns true when never pinged (null lastPingAt)', () => {
+    expect(shouldPing(NOW, null)).toBe(true)
+  })
+
+  test('returns false when pinged just now', () => {
+    expect(shouldPing(NOW, NOW)).toBe(false)
+  })
+
+  test('returns false when less than interval has elapsed', () => {
+    expect(shouldPing(NOW, NOW - PING_INTERVAL_MS + 1)).toBe(false)
+  })
+
+  test('returns true when exactly interval has elapsed', () => {
+    expect(shouldPing(NOW, NOW - PING_INTERVAL_MS)).toBe(true)
+  })
+
+  test('returns true when more than interval has elapsed', () => {
+    expect(shouldPing(NOW, NOW - PING_INTERVAL_MS - 1)).toBe(true)
+  })
+
+  test('respects custom intervalMs', () => {
+    expect(shouldPing(NOW, NOW - 500, 1000)).toBe(false)
+    expect(shouldPing(NOW, NOW - 1000, 1000)).toBe(true)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildPingPayload
+
+describe('buildPingPayload', () => {
+  test('includes instance_hash and deploy_target', () => {
+    const payload = buildPingPayload({
+      instanceHash: 'abc123',
+      deployTarget: 'docker',
+    })
+    expect(payload.instance_hash).toBe('abc123')
+    expect(payload.deploy_target).toBe('docker')
+  })
+
+  test('includes ch_version truncated to major.minor', () => {
+    const payload = buildPingPayload({
+      instanceHash: 'abc123',
+      version: '24.8.1.2',
+      deployTarget: 'cf',
+    })
+    expect(payload.ch_version).toBe('24.8')
+  })
+
+  test('omits ch_version when version is undefined', () => {
+    const payload = buildPingPayload({
+      instanceHash: 'abc123',
+      deployTarget: 'docker',
+    })
+    expect('ch_version' in payload).toBe(false)
+  })
+
+  test('omits ch_version when version is unparseable', () => {
+    const payload = buildPingPayload({
+      instanceHash: 'abc123',
+      version: 'not-a-version',
+      deployTarget: 'docker',
+    })
+    expect('ch_version' in payload).toBe(false)
+  })
+
+  test('never includes raw instance id — only the provided hash', () => {
+    const rawId = 'raw-uuid-value'
+    const payload = buildPingPayload({
+      instanceHash: 'hashed-value',
+      deployTarget: 'docker',
+    })
+    // The raw id should not appear anywhere in the payload values
+    expect(Object.values(payload).includes(rawId)).toBe(false)
+    expect(payload.instance_hash).toBe('hashed-value')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fake deps factory
+
+function makeDeps(
+  overrides: Partial<PingDeps> & {
+    storageOverrides?: Record<string, string>
+    capturedPosts?: Array<{ url: string; body: string }>
+  } = {}
+): PingDeps & {
+  store: Record<string, string>
+  posts: Array<{ url: string; body: string }>
+} {
+  const store: Record<string, string> = {
+    ...(overrides.storageOverrides ?? {}),
+  }
+  const posts: Array<{ url: string; body: string }> =
+    overrides.capturedPosts ?? []
+
+  return {
+    enabled: true,
+    endpoint: 'https://example.com/ping',
+    now: 1_700_000_000_000,
+    getItem: (k) => store[k] ?? null,
+    setItem: (k, v) => {
+      store[k] = v
+    },
+    randomId: () => 'test-uuid-1234',
+    hash: async (s) => `hash:${s}`,
+    post: async (url, body) => {
+      posts.push({ url, body })
+    },
+    version: '24.8.1.2',
+    deployTarget: 'docker',
+    store,
+    posts,
+    ...overrides,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// runInstancePing — gate tests (MUST prove post is NOT called)
+
+describe('runInstancePing gates', () => {
+  test('returns skipped-disabled when enabled:false, post NOT called', async () => {
+    const deps = makeDeps({ enabled: false })
+    const result = await runInstancePing(deps)
+    expect(result).toBe('skipped-disabled')
+    expect(deps.posts).toHaveLength(0)
+  })
+
+  test('returns skipped-no-endpoint when endpoint is empty, post NOT called', async () => {
+    const deps = makeDeps({ endpoint: '' })
+    const result = await runInstancePing(deps)
+    expect(result).toBe('skipped-no-endpoint')
+    expect(deps.posts).toHaveLength(0)
+  })
+
+  test('returns skipped-too-soon when pinged recently, post NOT called', async () => {
+    const now = 1_700_000_000_000
+    const deps = makeDeps({
+      now,
+      storageOverrides: {
+        chm_telemetry_last_ping_at: String(now - 100), // 100ms ago — far below interval
+      },
+    })
+    const result = await runInstancePing(deps)
+    expect(result).toBe('skipped-too-soon')
+    expect(deps.posts).toHaveLength(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// runInstancePing — happy path
+
+describe('runInstancePing happy path', () => {
+  test('returns pinged and calls post exactly once when all conditions met', async () => {
+    const deps = makeDeps() // no lastPingAt → first ping
+    const result = await runInstancePing(deps)
+    expect(result).toBe('pinged')
+    expect(deps.posts).toHaveLength(1)
+  })
+
+  test('post receives correct endpoint URL', async () => {
+    const deps = makeDeps({ endpoint: 'https://collect.example.com/ping' })
+    await runInstancePing(deps)
+    expect(deps.posts[0].url).toBe('https://collect.example.com/ping')
+  })
+
+  test('payload contains hashed instance_id (not raw), ch_version (major.minor), deploy_target', async () => {
+    const deps = makeDeps({ version: '24.8.1.2', deployTarget: 'cf' })
+    await runInstancePing(deps)
+
+    const body = JSON.parse(deps.posts[0].body) as Record<string, string>
+    // instance_hash must be the hash of the instance id, never the raw id
+    expect(body.instance_hash).toBe('hash:test-uuid-1234')
+    expect(body.instance_hash).not.toBe('test-uuid-1234')
+    // version is truncated to major.minor
+    expect(body.ch_version).toBe('24.8')
+    expect(body.deploy_target).toBe('cf')
+  })
+
+  test('persists lastPingAt in storage after ping', async () => {
+    const now = 1_700_000_000_000
+    const deps = makeDeps({ now })
+    await runInstancePing(deps)
+    expect(deps.store.chm_telemetry_last_ping_at).toBe(String(now))
+  })
+
+  test('persists instance id in storage when not previously stored', async () => {
+    const deps = makeDeps()
+    await runInstancePing(deps)
+    expect(deps.store.chm_telemetry_instance_id).toBe('test-uuid-1234')
+  })
+
+  test('reuses existing stored instance id (does not regenerate)', async () => {
+    let randomCalled = 0
+    const deps = makeDeps({
+      storageOverrides: { chm_telemetry_instance_id: 'existing-stable-id' },
+      randomId: () => {
+        randomCalled++
+        return 'new-uuid'
+      },
+    })
+    await runInstancePing(deps)
+
+    // randomId must NOT have been called — the stored ID was reused
+    expect(randomCalled).toBe(0)
+    expect(deps.store.chm_telemetry_instance_id).toBe('existing-stable-id')
+    // The hash is of the EXISTING id
+    const body = JSON.parse(deps.posts[0].body) as Record<string, string>
+    expect(body.instance_hash).toBe('hash:existing-stable-id')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// runInstancePing — error resilience
+
+describe('runInstancePing error resilience', () => {
+  test('does not reject when post throws', async () => {
+    const deps = makeDeps({
+      post: async () => {
+        throw new Error('network failure')
+      },
+    })
+    await expect(runInstancePing(deps)).resolves.toBe('pinged')
+  })
+
+  test('still persists lastPingAt when post throws', async () => {
+    const now = 1_700_000_000_000
+    const deps = makeDeps({
+      now,
+      post: async () => {
+        throw new Error('network failure')
+      },
+    })
+    await runInstancePing(deps)
+    expect(deps.store.chm_telemetry_last_ping_at).toBe(String(now))
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// cadence: after a successful ping, skips until interval elapses
+
+describe('runInstancePing cadence', () => {
+  test('skips on second call within interval', async () => {
+    const now = 1_700_000_000_000
+    const deps = makeDeps({ now })
+
+    const first = await runInstancePing(deps)
+    expect(first).toBe('pinged')
+
+    // Advance time by less than interval and run again
+    const deps2 = makeDeps({
+      now: now + PING_INTERVAL_MS - 1,
+      storageOverrides: { ...deps.store },
+    })
+    const second = await runInstancePing(deps2)
+    expect(second).toBe('skipped-too-soon')
+    expect(deps2.posts).toHaveLength(0)
+  })
+
+  test('pings again once interval has elapsed', async () => {
+    const now = 1_700_000_000_000
+    const deps = makeDeps({ now })
+    await runInstancePing(deps)
+
+    const deps2 = makeDeps({
+      now: now + PING_INTERVAL_MS,
+      storageOverrides: { ...deps.store },
+    })
+    const second = await runInstancePing(deps2)
+    expect(second).toBe('pinged')
+    expect(deps2.posts).toHaveLength(1)
+  })
+})

--- a/apps/dashboard/src/lib/telemetry/instance-ping.ts
+++ b/apps/dashboard/src/lib/telemetry/instance-ping.ts
@@ -1,0 +1,240 @@
+// Opt-in, daily anonymous instance ping.
+//
+// Privacy contract (CRITICAL):
+//   - Completely inert unless BOTH conditions hold:
+//     1. Telemetry is explicitly enabled (CHM_TELEMETRY=on / VITE_TELEMETRY_ENABLED=true).
+//     2. A collection endpoint is explicitly configured (CHM_TELEMETRY_ENDPOINT / VITE_TELEMETRY_ENDPOINT).
+//   - NO network call is made if either condition is absent.
+//   - Only the HASH of a randomly-generated local ID is transmitted — the raw ID
+//     never leaves the device. The hash is stable across pings (re-hashes the same
+//     stored ID) so the server can count distinct instances without learning identity.
+//   - ClickHouse version is truncated to MAJOR.MINOR (e.g. '24.8') so it cannot
+//     be mistaken for an IPv4 address and cannot fingerprint a specific patch release.
+
+import { isTelemetryEnabled } from './config'
+import { getDeployTarget, parseMajorMinor } from './environment'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+
+export const PING_INTERVAL_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+const STORAGE_KEY_INSTANCE_ID = 'chm_telemetry_instance_id'
+const STORAGE_KEY_LAST_PING = 'chm_telemetry_last_ping_at'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure helpers (no globals — unit-testable in isolation)
+
+/**
+ * Returns true when a ping is due.
+ * - Always true when lastPingAt is null (never pinged).
+ * - True when >= intervalMs has elapsed since the last ping.
+ */
+export function shouldPing(
+  now: number,
+  lastPingAt: number | null,
+  intervalMs: number = PING_INTERVAL_MS
+): boolean {
+  if (lastPingAt === null) return true
+  return now - lastPingAt >= intervalMs
+}
+
+/**
+ * Builds the JSON payload sent to the collection endpoint.
+ * Only safe, non-identifying fields are included.
+ * Undefined values are omitted.
+ */
+export function buildPingPayload(input: {
+  instanceHash: string
+  version?: string
+  deployTarget: string
+}): Record<string, string> {
+  const { instanceHash, version, deployTarget } = input
+  const chVersion = version ? parseMajorMinor(version) : undefined
+  const payload: Record<string, string> = {
+    instance_hash: instanceHash,
+    deploy_target: deployTarget,
+  }
+  if (chVersion !== undefined) {
+    payload.ch_version = chVersion
+  }
+  return payload
+}
+
+/**
+ * Resolves the telemetry collection endpoint.
+ * Server: CHM_TELEMETRY_ENDPOINT from runtimeEnv.
+ * Client: VITE_TELEMETRY_ENDPOINT inlined at build time.
+ * Returns '' (empty string) when unset — callers treat '' as "no endpoint".
+ */
+export function getPingEndpoint(
+  runtimeEnv?: Record<string, string | undefined>
+): string {
+  if (runtimeEnv) {
+    return runtimeEnv.CHM_TELEMETRY_ENDPOINT ?? ''
+  }
+  // Client bundle: build-time inline
+  return import.meta.env.VITE_TELEMETRY_ENDPOINT ?? ''
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Orchestrator with injected dependencies (for testability)
+
+export type PingResult =
+  | 'skipped-disabled'
+  | 'skipped-no-endpoint'
+  | 'skipped-too-soon'
+  | 'pinged'
+
+export interface PingDeps {
+  /** isTelemetryEnabled(runtimeEnv) */
+  enabled: boolean
+  /** getPingEndpoint(runtimeEnv) */
+  endpoint: string
+  /** Date.now() */
+  now: number
+  /** localStorage.getItem */
+  getItem: (k: string) => string | null
+  /** localStorage.setItem */
+  setItem: (k: string, v: string) => void
+  /** crypto.randomUUID */
+  randomId: () => string
+  /** SHA-256 hex digest of s */
+  hash: (s: string) => Promise<string>
+  /** POST url with body (fire-and-forget at this layer; caller may catch) */
+  post: (url: string, body: string) => Promise<void>
+  /** Raw ClickHouse version string (optional) */
+  version?: string
+  /** Deploy target string */
+  deployTarget: string
+}
+
+/**
+ * Core ping orchestration.  All side-effects come through deps — unit tests
+ * pass fake implementations to exercise every branch without touching real
+ * browser globals or making real HTTP calls.
+ *
+ * Error contract: post() errors are caught internally — a failing POST does NOT
+ * cause runInstancePing to reject.  The app-facing maybePingInstance wrapper
+ * additionally swallows all errors from runInstancePing itself.
+ */
+export async function runInstancePing(deps: PingDeps): Promise<PingResult> {
+  const {
+    enabled,
+    endpoint,
+    now,
+    getItem,
+    setItem,
+    randomId,
+    hash,
+    post,
+    version,
+    deployTarget,
+  } = deps
+
+  if (!enabled) return 'skipped-disabled'
+  if (!endpoint) return 'skipped-no-endpoint'
+
+  const rawLastPing = getItem(STORAGE_KEY_LAST_PING)
+  const lastPingAt = rawLastPing !== null ? Number(rawLastPing) : null
+  if (!shouldPing(now, lastPingAt)) return 'skipped-too-soon'
+
+  // Get-or-create stable local instance ID (never transmitted raw)
+  let instanceId = getItem(STORAGE_KEY_INSTANCE_ID)
+  if (!instanceId) {
+    instanceId = randomId()
+    setItem(STORAGE_KEY_INSTANCE_ID, instanceId)
+  }
+
+  const instanceHash = await hash(instanceId)
+  const payload = buildPingPayload({ instanceHash, version, deployTarget })
+
+  try {
+    await post(endpoint, JSON.stringify(payload))
+  } catch {
+    // A failed network call must never crash the app — silently continue.
+  }
+
+  // Persist timestamp regardless of whether post succeeded.  This prevents
+  // hammering a broken endpoint every page load.
+  setItem(STORAGE_KEY_LAST_PING, String(now))
+
+  return 'pinged'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Browser entrypoint
+
+/**
+ * SHA-256 hex digest via SubtleCrypto.
+ */
+async function sha256hex(s: string): Promise<string> {
+  const enc = new TextEncoder()
+  const buf = await crypto.subtle.digest('SHA-256', enc.encode(s))
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/**
+ * Fire-and-forget instance ping for browser environments.
+ *
+ * - Safe to call unconditionally: returns immediately (no-op) when telemetry
+ *   is off or when no collection endpoint is configured.
+ * - Swallows ALL errors — a failed ping must never affect the app.
+ * - Guards against non-browser environments (SSR, prerender, unit tests).
+ */
+export function maybePingInstance(
+  runtimeEnv?: Record<string, string | undefined>
+): void {
+  // Guard: require browser globals before attempting anything.
+  if (
+    typeof window === 'undefined' ||
+    typeof localStorage === 'undefined' ||
+    typeof crypto === 'undefined' ||
+    typeof crypto.subtle === 'undefined' ||
+    typeof crypto.randomUUID !== 'function'
+  ) {
+    return
+  }
+
+  const enabled = isTelemetryEnabled(runtimeEnv)
+  const endpoint = getPingEndpoint(runtimeEnv)
+
+  // Quick synchronous bail-out avoids even building the deps object.
+  if (!enabled || !endpoint) return
+
+  const deps: PingDeps = {
+    enabled,
+    endpoint,
+    now: Date.now(),
+    getItem: (k) => {
+      try {
+        return localStorage.getItem(k)
+      } catch {
+        return null
+      }
+    },
+    setItem: (k, v) => {
+      try {
+        localStorage.setItem(k, v)
+      } catch {
+        // localStorage may be unavailable (private browsing, quota exceeded)
+      }
+    },
+    randomId: () => crypto.randomUUID(),
+    hash: sha256hex,
+    post: (url, body) =>
+      fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body,
+        keepalive: true,
+      }).then(() => undefined),
+    version: undefined, // caller may populate via a separate ClickHouse query
+    deployTarget: getDeployTarget(),
+  }
+
+  // Fire-and-forget — errors are swallowed by runInstancePing + this catch.
+  runInstancePing(deps).catch(() => {})
+}

--- a/apps/dashboard/src/vite-env.d.ts
+++ b/apps/dashboard/src/vite-env.d.ts
@@ -14,6 +14,8 @@ interface ImportMetaEnv {
   readonly VITE_TELEMETRY_ENABLED?: string
   // Deployment target for telemetry dimensions (docker | helm | cf | dev | unknown).
   readonly VITE_DEPLOY_TARGET?: string
+  // Collection endpoint for the daily instance ping. Empty = no-op.
+  readonly VITE_TELEMETRY_ENDPOINT?: string
   // Build metadata (injected by vite.config define / CI build step)
   readonly VITE_GIT_SHA?: string
   readonly VITE_GIT_REF?: string

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -64,6 +64,10 @@ const CLIENT_ENV = {
   // Deployment target (docker | helm | cf | dev | unknown). Set in CI build
   // steps so telemetry can distinguish deployment environments.
   VITE_DEPLOY_TARGET: e.VITE_DEPLOY_TARGET ?? 'unknown',
+  // Collection endpoint for the opt-in daily instance ping. Empty by default —
+  // no network call is made unless this is explicitly set. No production
+  // endpoint is provisioned yet (TODO for a human).
+  VITE_TELEMETRY_ENDPOINT: e.VITE_TELEMETRY_ENDPOINT ?? '',
   VITE_GIT_SHA:
     e.VITE_GIT_SHA ?? e.NEXT_PUBLIC_GIT_SHA ?? git('rev-parse HEAD'),
   VITE_GIT_REF:


### PR DESCRIPTION
## What

Adds a once-daily anonymous instance ping (`lib/telemetry/instance-ping.ts`) that collects ClickHouse version (major.minor only) and a hashed instance identifier.

## Why

Enables future understanding of deployment distribution (versions, targets) without any PII collection.

## Privacy / Scope

**This PR is completely inert in all current deployments.**

Two explicit opt-ins are required for any network call to occur:
1. Telemetry enabled: `CHM_TELEMETRY=on` (server) or `VITE_TELEMETRY_ENABLED=true` (build)
2. Endpoint configured: `CHM_TELEMETRY_ENDPOINT` (server) or `VITE_TELEMETRY_ENDPOINT` (build)

No production endpoint is provisioned — that is a TODO for a human. Until both conditions hold, `maybePingInstance()` is a synchronous no-op that returns before touching any globals.

Privacy protections:
- Raw instance ID never transmitted — only its SHA-256 hex hash
- ClickHouse version truncated to `MAJOR.MINOR` (e.g. `24.8`) — patch/build number dropped
- 24-hour cooldown via localStorage timestamp — no more than one ping per day
- All errors swallowed — a network failure cannot affect the app
- Browser-globals guard — SSR/prerender/unit-test environments are no-ops

## How verified

**Biome:** `bunx biome check --write --unsafe` → 0 errors, 0 warnings

**Tests:** `bun test apps/dashboard/src/lib/telemetry/` → **62 pass, 0 fail**

Key gate assertions (tests explicitly prove `post` is NOT called):
- `enabled:false` → `skipped-disabled`, post called 0 times ✓
- `endpoint:''` → `skipped-no-endpoint`, post called 0 times ✓
- `lastPingAt` within interval → `skipped-too-soon`, post called 0 times ✓
- Happy path: post called exactly once with `instance_hash` (hash, never raw id), `ch_version` (major.minor), `deploy_target` ✓
- Throwing `post` does not reject `runInstancePing` ✓
- Existing stored instance id is reused (randomId not called again) ✓

**Build:** `bun run build` → exit 0

## Visual

N/A — no UI changes. Feature is invisible until both opt-in conditions are met.

## Guardrails checklist

- [x] No network call unless `enabled && endpoint` (airtight gate, proven by tests)
- [x] No PII: hashed ID only, version truncated to major.minor
- [x] No production endpoint provisioned (TODO documented)
- [x] `maybePingInstance()` never throws
- [x] localStorage + crypto globals guarded for SSR safety
- [x] Daily throttle prevents repeated pings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daily anonymous instance telemetry transmission. Sends hashed instance identifiers, deployment details, and version information once per 24 hours when explicitly enabled via environment configuration. Completely optional with automatic fallback for unsupported environments and resilient error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->