### PR TITLE
feat(query-config): add declarative config loader behind CHM_CONFIG_SOURCE (default ts)

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/index.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/index.ts
@@ -1,4 +1,9 @@
 export {
+  type ConfigSource,
+  getConfigSource,
+  loadDeclarativeConfig,
+} from './loader'
+export {
   type DeclarativeQueryConfig,
   declarativeQueryConfigSchema,
   sqlSchema,

--- a/apps/dashboard/src/lib/query-config/declarative/loader.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/loader.test.ts
@@ -179,7 +179,7 @@ describe('loadDeclarativeConfig — golden fixture (warningsConfig)', () => {
 
     // Loaded config must contain all serializable fields with matching values.
     for (const [key, value] of Object.entries(serializable)) {
-      expect((loaded as Record<string, unknown>)[key]).toEqual(value)
+      expect((loaded as unknown as Record<string, unknown>)[key]).toEqual(value)
     }
   })
 })

--- a/apps/dashboard/src/lib/query-config/declarative/loader.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/loader.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for the declarative config loader (Plan 02b).
+ *
+ * Golden fixture: warningsConfig — the simplest real config with no ColumnFormat
+ * imports, no runtime functions (no expandable/rowClassName/permission), just
+ * name, sql (string), columns, optional, tableCheck, refreshInterval,
+ * description, card, defaultView.
+ */
+
+import { getConfigSource, loadDeclarativeConfig } from './loader'
+import { describe, expect, test } from 'bun:test'
+import { warningsConfig } from '@/lib/query-config/system/warnings'
+
+// ---------------------------------------------------------------------------
+// getConfigSource — flag behaviour
+// ---------------------------------------------------------------------------
+
+describe('getConfigSource', () => {
+  test('defaults to "ts" with no env set', () => {
+    expect(getConfigSource({})).toBe('ts')
+  })
+
+  test('returns "declarative" when CHM_CONFIG_SOURCE=declarative', () => {
+    expect(getConfigSource({ CHM_CONFIG_SOURCE: 'declarative' })).toBe(
+      'declarative'
+    )
+  })
+
+  test('returns "ts" for any value other than "declarative"', () => {
+    expect(getConfigSource({ CHM_CONFIG_SOURCE: 'json' })).toBe('ts')
+    expect(getConfigSource({ CHM_CONFIG_SOURCE: 'yaml' })).toBe('ts')
+    expect(getConfigSource({ CHM_CONFIG_SOURCE: '' })).toBe('ts')
+    expect(getConfigSource({ CHM_CONFIG_SOURCE: 'DECLARATIVE' })).toBe('ts') // case-sensitive
+  })
+
+  test('returns "ts" when runtimeEnv is empty', () => {
+    // import.meta.env.VITE_CONFIG_SOURCE is undefined in test — defaults to 'ts'
+    expect(getConfigSource({})).toBe('ts')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadDeclarativeConfig — error cases
+// ---------------------------------------------------------------------------
+
+describe('loadDeclarativeConfig — invalid input', () => {
+  test('throws on non-object input', () => {
+    expect(() => loadDeclarativeConfig('not an object')).toThrow(
+      'Invalid declarative query config'
+    )
+  })
+
+  test('throws on missing name', () => {
+    expect(() =>
+      loadDeclarativeConfig({ sql: 'SELECT 1', columns: ['x'] })
+    ).toThrow('Invalid declarative query config')
+  })
+
+  test('throws on missing sql', () => {
+    expect(() =>
+      loadDeclarativeConfig({ name: 'test', columns: ['x'] })
+    ).toThrow('Invalid declarative query config')
+  })
+
+  test('throws on empty columns array', () => {
+    expect(() =>
+      loadDeclarativeConfig({ name: 'test', sql: 'SELECT 1', columns: [] })
+    ).toThrow('Invalid declarative query config')
+  })
+
+  test('error message includes field-level details', () => {
+    let message = ''
+    try {
+      loadDeclarativeConfig({ sql: 'SELECT 1', columns: ['x'] })
+    } catch (err) {
+      message = (err as Error).message
+    }
+    expect(message).toContain('name')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Golden fixture: warningsConfig
+//
+// warningsConfig fields (all serializable — no runtime functions):
+//   name, description, optional, tableCheck, refreshInterval,
+//   sql (string), columns, card, defaultView
+//
+// Excluded from comparison (not in DeclarativeQueryConfig schema):
+//   none — warningsConfig has no runtime-only fields
+// ---------------------------------------------------------------------------
+
+// Declarative equivalent of warningsConfig, authored inline.
+// Must match declarativeQueryConfigSchema exactly.
+const warningsDeclarative = {
+  name: 'warnings',
+  description:
+    'Server-side warnings about potential configuration or operational issues',
+  optional: true,
+  tableCheck: 'system.warnings',
+  refreshInterval: 30_000,
+  sql: 'SELECT message FROM system.warnings',
+  columns: ['message'],
+  card: { primary: 'message' },
+  defaultView: 'auto' as const,
+}
+
+describe('loadDeclarativeConfig — golden fixture (warningsConfig)', () => {
+  test('produces a valid QueryConfig from the declarative equivalent', () => {
+    const loaded = loadDeclarativeConfig(warningsDeclarative)
+    expect(loaded).toBeDefined()
+    expect(typeof loaded).toBe('object')
+  })
+
+  test('name matches', () => {
+    const loaded = loadDeclarativeConfig(warningsDeclarative)
+    expect(loaded.name).toBe(warningsConfig.name)
+  })
+
+  test('sql matches', () => {
+    const loaded = loadDeclarativeConfig(warningsDeclarative)
+    expect(loaded.sql).toBe(warningsConfig.sql)
+  })
+
+  test('columns match', () => {
+    const loaded = loadDeclarativeConfig(warningsDeclarative)
+    expect(loaded.columns).toEqual(warningsConfig.columns)
+  })
+
+  test('optional matches', () => {
+    const loaded = loadDeclarativeConfig(warningsDeclarative)
+    // warningsConfig.optional is explicitly true; schema default is false
+    expect(loaded.optional).toBe(warningsConfig.optional)
+  })
+
+  test('tableCheck matches', () => {
+    const loaded = loadDeclarativeConfig(warningsDeclarative)
+    expect(loaded.tableCheck).toBe(warningsConfig.tableCheck)
+  })
+
+  test('refreshInterval matches', () => {
+    const loaded = loadDeclarativeConfig(warningsDeclarative)
+    expect(loaded.refreshInterval).toBe(warningsConfig.refreshInterval)
+  })
+
+  test('description matches', () => {
+    const loaded = loadDeclarativeConfig(warningsDeclarative)
+    expect(loaded.description).toBe(warningsConfig.description)
+  })
+
+  test('card matches', () => {
+    const loaded = loadDeclarativeConfig(warningsDeclarative)
+    expect(loaded.card).toEqual(warningsConfig.card)
+  })
+
+  test('defaultView matches', () => {
+    const loaded = loadDeclarativeConfig(warningsDeclarative)
+    expect(loaded.defaultView).toBe(warningsConfig.defaultView)
+  })
+
+  test('deep-equals on all serializable fields', () => {
+    const loaded = loadDeclarativeConfig(warningsDeclarative)
+
+    // Pick only the serializable fields present on warningsConfig for the
+    // comparison. Runtime-only fields (columnIcons, rowClassName, expandable,
+    // permission, filterSchema, clickhouseSettings, variants) are absent from
+    // warningsConfig so nothing to exclude here.
+    const serializable = {
+      name: warningsConfig.name,
+      sql: warningsConfig.sql,
+      columns: warningsConfig.columns,
+      optional: warningsConfig.optional,
+      tableCheck: warningsConfig.tableCheck,
+      refreshInterval: warningsConfig.refreshInterval,
+      description: warningsConfig.description,
+      card: warningsConfig.card,
+      defaultView: warningsConfig.defaultView,
+    }
+
+    // Loaded config must contain all serializable fields with matching values.
+    for (const [key, value] of Object.entries(serializable)) {
+      expect((loaded as Record<string, unknown>)[key]).toEqual(value)
+    }
+  })
+})

--- a/apps/dashboard/src/lib/query-config/declarative/loader.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/loader.ts
@@ -1,0 +1,144 @@
+/**
+ * Declarative config loader — Plan 02b.
+ *
+ * Converts a validated DeclarativeQueryConfig into the in-memory QueryConfig
+ * shape that the dashboard consumes at runtime.
+ *
+ * RUNTIME-ONLY FIELDS NOT PRESENT ON LOADED CONFIGS:
+ *   - columnIcons    — React component refs (Icon type)
+ *   - rowClassName   — function (row) => string | undefined
+ *   - expandable     — function-based ExpandableConfig
+ *   - permission     — FeaturePermission (app-level import)
+ *   - filterSchema   — FilterSchema (contains Icon refs and dynamic option fns)
+ *   - columnFilters  — ColumnFilterDef (UI sugar over filterSchema)
+ *   - clickhouseSettings — ClickHouseSettings (execution-time; not serializable declaratively)
+ *   - variants       — deprecated; use versioned sql[] in the declarative format
+ *
+ * These fields can be merged in by the caller after loading if needed.
+ */
+
+import type { QueryConfig } from '@/types/query-config'
+import type { DeclarativeQueryConfig } from './schema'
+
+import { validateDeclarativeConfig } from './validate'
+
+// ---------------------------------------------------------------------------
+// Config source flag
+// ---------------------------------------------------------------------------
+
+export type ConfigSource = 'ts' | 'declarative'
+
+/**
+ * Read the CHM_CONFIG_SOURCE flag.
+ *
+ * Server: CHM_CONFIG_SOURCE runtime env wins, then falls back to the
+ * build-time VITE_CONFIG_SOURCE (same pattern as getServerAuthProvider).
+ * Client: VITE_CONFIG_SOURCE build-time value only.
+ *
+ * Anything other than the literal string 'declarative' returns 'ts' —
+ * fail-safe to the current behaviour. Default is 'ts'.
+ *
+ * @param runtimeEnv - Pass the Cloudflare Worker `env` binding or
+ *   process.env; omit on the client (uses import.meta.env only).
+ */
+export function getConfigSource(
+  runtimeEnv?: Record<string, string | undefined>
+): ConfigSource {
+  const source =
+    runtimeEnv ?? (typeof process !== 'undefined' ? process.env : {})
+  const value =
+    (source as Record<string, string | undefined>).CHM_CONFIG_SOURCE ??
+    import.meta.env.VITE_CONFIG_SOURCE
+  return value === 'declarative' ? 'declarative' : 'ts'
+}
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+/**
+ * Load a declarative config object into the in-memory QueryConfig shape.
+ *
+ * Validates `input` against the declarative schema (throws on invalid), then
+ * maps all serializable fields to their QueryConfig equivalents. The mapping
+ * is 1-to-1: field names and value shapes are shared by design.
+ *
+ * Runtime-only fields absent from DeclarativeQueryConfig (columnIcons,
+ * rowClassName, expandable, permission, filterSchema, columnFilters,
+ * clickhouseSettings, variants) are simply omitted from the result. Callers
+ * that need those fields must merge them in after loading.
+ *
+ * @throws Error when `input` fails schema validation (message includes all
+ *   field-level errors joined by '; ').
+ */
+export function loadDeclarativeConfig(input: unknown): QueryConfig {
+  const result = validateDeclarativeConfig(input)
+  if (!result.ok) {
+    throw new Error(
+      `Invalid declarative query config: ${result.errors.join('; ')}`
+    )
+  }
+
+  const d: DeclarativeQueryConfig = result.config
+
+  // Build the QueryConfig, mapping only the serializable fields the schema
+  // carries. Undefined optional fields are omitted (no key set) so the result
+  // is a clean object — callers can spread-merge additional fields without
+  // accidental undefined overrides.
+  const config: QueryConfig = {
+    name: d.name,
+    sql: d.sql,
+    columns: d.columns as string[],
+  }
+
+  // Identity / display
+  if (d.description !== undefined) config.description = d.description
+  if (d.docs !== undefined) config.docs = d.docs
+  if (d.suggestion !== undefined) config.suggestion = d.suggestion
+
+  // Execution knobs
+  if (d.optional !== undefined) config.optional = d.optional
+  if (d.tableCheck !== undefined) config.tableCheck = d.tableCheck
+  if (d.disableSqlValidation !== undefined)
+    config.disableSqlValidation = d.disableSqlValidation
+  if (d.refreshInterval !== undefined)
+    config.refreshInterval = d.refreshInterval
+  if (d.defaultParams !== undefined) config.defaultParams = d.defaultParams
+
+  // Column display
+  if (d.columnFormats !== undefined) {
+    // DeclarativeQueryConfig.columnFormats uses the same string-enum values as
+    // ColumnFormat (the enum values ARE those strings). Cast is safe — schema
+    // validates the allowed strings to exactly the ColumnFormat enum domain.
+    config.columnFormats = d.columnFormats as QueryConfig['columnFormats']
+  }
+  if (d.columnDescriptions !== undefined)
+    config.columnDescriptions = d.columnDescriptions
+  if (d.columnSizing !== undefined) config.columnSizing = d.columnSizing
+  if (d.tableBehavior !== undefined) config.tableBehavior = d.tableBehavior
+
+  // Filters
+  if (d.filterParamPresets !== undefined)
+    config.filterParamPresets = d.filterParamPresets
+
+  // Related charts — schema: (string | [string, Record])[] which is a
+  // structural subset of QueryConfig's (string | [string, ChartProps])[].
+  if (d.relatedCharts !== undefined) {
+    config.relatedCharts = d.relatedCharts as QueryConfig['relatedCharts']
+  }
+
+  // Card / view
+  if (d.card !== undefined) config.card = d.card as QueryConfig['card']
+  if (d.defaultView !== undefined) config.defaultView = d.defaultView
+
+  // Bulk actions
+  if (d.bulkActions !== undefined) config.bulkActions = d.bulkActions
+  if (d.bulkActionKey !== undefined) config.bulkActionKey = d.bulkActionKey
+
+  // Sorting
+  if (d.sortingFns !== undefined) {
+    config.sortingFns = d.sortingFns as QueryConfig['sortingFns']
+  }
+
+  return config
+}

--- a/apps/dashboard/src/vite-env.d.ts
+++ b/apps/dashboard/src/vite-env.d.ts
@@ -19,6 +19,9 @@ interface ImportMetaEnv {
   readonly VITE_GIT_REF?: string
   readonly VITE_BUILD_TIMESTAMP?: string
   readonly VITE_CI?: string
+  // Query-config source flag. 'ts' = current TS configs (default); 'declarative'
+  // = load from external declarative catalog. See lib/query-config/declarative/loader.ts.
+  readonly VITE_CONFIG_SOURCE?: string
 }
 
 interface ImportMeta {

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -75,6 +75,11 @@ const CLIENT_ENV = {
     e.NEXT_PUBLIC_BUILD_TIMESTAMP ??
     new Date().toISOString(),
   VITE_CI: e.VITE_CI ?? e.NEXT_PUBLIC_CI ?? (e.CI ? 'true' : ''),
+  // Query-config source: 'ts' (default, current TS configs) | 'declarative'
+  // (load from external declarative catalog). Anything other than 'declarative'
+  // falls back to 'ts' — fail-safe to the current behaviour. DARK: no views
+  // use declarative configs yet.
+  VITE_CONFIG_SOURCE: e.VITE_CONFIG_SOURCE ?? 'ts',
 } as const
 
 // Explicit text-replacement of each `import.meta.env.VITE_*` read. Deterministic


### PR DESCRIPTION
## What

Add `loader.ts` — the runtime transform layer for Plan 02b of the declarative query-config externalization.

- **`getConfigSource(runtimeEnv?)`** — reads `CHM_CONFIG_SOURCE` (server runtime) falling back to `VITE_CONFIG_SOURCE` (build-time client). Returns `'declarative'` only for the exact literal string; any other value (including empty/missing) returns `'ts'`. Mirrors the `getServerAuthProvider` pattern from `lib/env.ts`.
- **`loadDeclarativeConfig(input)`** — validates via 02a's `validateDeclarativeConfig`, then maps all serializable `DeclarativeQueryConfig` fields to the in-memory `QueryConfig` shape. Throws with a clear error message (joined field paths) on invalid input.
- **`VITE_CONFIG_SOURCE`** added to `vite.config.ts` `CLIENT_ENV` (default `'ts'`) and typed in `vite-env.d.ts`.
- **`index.ts`** exports `ConfigSource`, `getConfigSource`, `loadDeclarativeConfig`.

## Why

02a shipped the schema and validator. This PR ships the in-memory transform — the minimum necessary to prove the schema round-trips correctly against a real config, with zero behaviour change at the default flag value.

## Scope (DARK — zero behaviour change)

- Flag defaults to `'ts'` at the current committed `VITE_CONFIG_SOURCE` value.
- No existing views or registries are switched to the declarative path.
- No file I/O — loader is a pure in-memory transform; catalog discovery is a later PR.

## How verified

```
bunx biome check --write apps/dashboard/src/lib/query-config/declarative apps/dashboard/vite.config.ts apps/dashboard/src/vite-env.d.ts
# → Checked 8 files in 26ms. Fixed 3 files.

bun test apps/dashboard/src/lib/query-config/declarative/
# → 37 pass, 0 fail (100ms)

cd apps/dashboard && bun run build
# → ✓ 6676 modules transformed. ✓ built in 2.05s — 0 TypeScript errors
```

**Golden test deep-equals assertion**: `loadDeclarativeConfig(warningsDeclarative)` produces values matching `warningsConfig` on all 9 serializable fields: `name`, `sql`, `columns`, `optional`, `tableCheck`, `refreshInterval`, `description`, `card`, `defaultView`. No fields excluded — `warningsConfig` has no runtime-only fields.

## Visual

N/A — no UI changes. Loader is unused at the default `'ts'` flag.

## Guardrails checklist

- [x] Flag default is `'ts'` — existing behaviour unchanged
- [x] `loadDeclarativeConfig` throws (not silently degrades) on invalid input
- [x] No auto-merge armed — leaving for owner
- [x] No views switched in this PR
- [x] Biome + tests + build all green