### PR TITLE
feat(edition): add open-core edition module (default community, fail-open)

### DIFF
--- a/apps/dashboard/src/lib/edition/edition.test.ts
+++ b/apps/dashboard/src/lib/edition/edition.test.ts
@@ -1,0 +1,129 @@
+import {
+  type EditionFeature,
+  ENTERPRISE_FEATURES,
+  getEdition,
+  isEnabled,
+  parseEdition,
+} from './edition'
+import { describe, expect, test } from 'bun:test'
+
+// ---------------------------------------------------------------------------
+// parseEdition
+// ---------------------------------------------------------------------------
+describe('parseEdition', () => {
+  test('undefined → community', () => {
+    expect(parseEdition(undefined)).toBe('community')
+  })
+
+  test('null → community', () => {
+    expect(parseEdition(null)).toBe('community')
+  })
+
+  test('empty string → community', () => {
+    expect(parseEdition('')).toBe('community')
+  })
+
+  test('whitespace-only → community', () => {
+    expect(parseEdition('   ')).toBe('community')
+  })
+
+  test('junk value → community', () => {
+    expect(parseEdition('garbage')).toBe('community')
+  })
+
+  test('uppercase COMMUNITY → community (not enterprise)', () => {
+    expect(parseEdition('COMMUNITY')).toBe('community')
+  })
+
+  test("'enterprise' (lowercase) → enterprise", () => {
+    expect(parseEdition('enterprise')).toBe('enterprise')
+  })
+
+  test("'ENTERPRISE' (uppercase) → enterprise", () => {
+    expect(parseEdition('ENTERPRISE')).toBe('enterprise')
+  })
+
+  test("' Enterprise ' (mixed-case, padded) → enterprise", () => {
+    expect(parseEdition(' Enterprise ')).toBe('enterprise')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getEdition
+// ---------------------------------------------------------------------------
+describe('getEdition', () => {
+  test('runtime CHM_EDITION=enterprise wins over build-time default', () => {
+    expect(getEdition({ CHM_EDITION: 'enterprise' })).toBe('enterprise')
+  })
+
+  test('runtime CHM_EDITION=community → community', () => {
+    expect(getEdition({ CHM_EDITION: 'community' })).toBe('community')
+  })
+
+  test('fail-open: junk CHM_EDITION → community', () => {
+    expect(getEdition({ CHM_EDITION: 'garbage' })).toBe('community')
+  })
+
+  test('fail-open: empty CHM_EDITION → community', () => {
+    expect(getEdition({ CHM_EDITION: '' })).toBe('community')
+  })
+
+  test('fail-open: empty env object → community', () => {
+    expect(getEdition({})).toBe('community')
+  })
+
+  test('no runtimeEnv argument does not throw', () => {
+    // Defaults to process.env; CHM_EDITION is not set in the test env
+    expect(() => getEdition()).not.toThrow()
+    // Must be community when CHM_EDITION is absent from the test process env
+    const result = getEdition({ CHM_EDITION: undefined })
+    expect(result).toBe('community')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isEnabled
+// ---------------------------------------------------------------------------
+describe('isEnabled', () => {
+  test('all enterprise features are false in community', () => {
+    const communityEnv = { CHM_EDITION: 'community' }
+    for (const feature of ENTERPRISE_FEATURES) {
+      expect(isEnabled(feature, communityEnv)).toBe(false)
+    }
+  })
+
+  test('all enterprise features are true in enterprise', () => {
+    const enterpriseEnv = { CHM_EDITION: 'enterprise' }
+    for (const feature of ENTERPRISE_FEATURES) {
+      expect(isEnabled(feature, enterpriseEnv)).toBe(true)
+    }
+  })
+
+  test('explicit spot-checks per feature in community', () => {
+    const env = { CHM_EDITION: 'community' }
+    const features: EditionFeature[] = [
+      'alerting',
+      'sso',
+      'rbac',
+      'fleet',
+      'cloud',
+    ]
+    for (const f of features) {
+      expect(isEnabled(f, env)).toBe(false)
+    }
+  })
+
+  test('explicit spot-checks per feature in enterprise', () => {
+    const env = { CHM_EDITION: 'enterprise' }
+    const features: EditionFeature[] = [
+      'alerting',
+      'sso',
+      'rbac',
+      'fleet',
+      'cloud',
+    ]
+    for (const f of features) {
+      expect(isEnabled(f, env)).toBe(true)
+    }
+  })
+})

--- a/apps/dashboard/src/lib/edition/edition.ts
+++ b/apps/dashboard/src/lib/edition/edition.ts
@@ -1,0 +1,73 @@
+// Open-core edition boundary.
+//
+// Core is GPL-3.0 and free forever. This module is the honest boundary between
+// community (OSS, self-hosted, single operator, fully functional) and enterprise
+// (paid features for large organisations: alerting, SSO, RBAC, fleet, cloud).
+//
+// Design invariant: FAIL-OPEN to community. An unset, empty, or unrecognised
+// CHM_EDITION / VITE_EDITION NEVER locks a self-hoster out. The free edition is
+// fully functional — enterprise gates only features that do not exist in community.
+
+export type Edition = 'community' | 'enterprise'
+
+/**
+ * All features that are gated to enterprise edition.
+ * Community edition will return false for these — they simply do not exist yet
+ * in the OSS build, so this does NOT degrade free functionality.
+ */
+export const ENTERPRISE_FEATURES = [
+  'alerting',
+  'sso',
+  'rbac',
+  'fleet',
+  'cloud',
+] as const
+
+export type EditionFeature = (typeof ENTERPRISE_FEATURES)[number]
+
+/**
+ * Normalise a raw env string to an Edition.
+ *
+ * Only the exact string 'enterprise' (case-insensitive, trimmed) maps to
+ * enterprise. Everything else — undefined, empty string, whitespace, junk —
+ * returns 'community'. Does NOT throw; callers always get a valid edition.
+ */
+export function parseEdition(value: string | null | undefined): Edition {
+  const normalized = value?.trim().toLowerCase()
+  if (normalized === 'enterprise') return 'enterprise'
+  return 'community'
+}
+
+/**
+ * Resolve the current edition at runtime.
+ *
+ * Resolution order:
+ *   1. runtimeEnv.CHM_EDITION   (Cloudflare Worker [vars] / process.env on Node)
+ *   2. import.meta.env.VITE_EDITION  (build-time inline, set in vite.config CLIENT_ENV)
+ *
+ * Pass the Cloudflare `env` binding on the edge; defaults to process.env on Node.
+ * Unknown or unset values always resolve to 'community' (fail-open).
+ */
+export function getEdition(
+  runtimeEnv?: Record<string, string | undefined>
+): Edition {
+  const source =
+    runtimeEnv ?? (typeof process !== 'undefined' ? process.env : {})
+  return parseEdition(source.CHM_EDITION ?? import.meta.env.VITE_EDITION)
+}
+
+/**
+ * Return true only when the given feature is available in the resolved edition.
+ *
+ * All ENTERPRISE_FEATURES return false in community — they are not degraded
+ * versions of community features, they simply do not exist in the OSS build.
+ */
+export function isEnabled(
+  feature: EditionFeature,
+  runtimeEnv?: Record<string, string | undefined>
+): boolean {
+  if (ENTERPRISE_FEATURES.includes(feature)) {
+    return getEdition(runtimeEnv) === 'enterprise'
+  }
+  return true
+}

--- a/apps/dashboard/src/lib/edition/index.ts
+++ b/apps/dashboard/src/lib/edition/index.ts
@@ -1,0 +1,8 @@
+export {
+  type Edition,
+  type EditionFeature,
+  ENTERPRISE_FEATURES,
+  getEdition,
+  isEnabled,
+  parseEdition,
+} from './edition'

--- a/apps/dashboard/src/vite-env.d.ts
+++ b/apps/dashboard/src/vite-env.d.ts
@@ -24,6 +24,9 @@ interface ImportMetaEnv {
   // Query-config source flag. 'ts' = current TS configs (default); 'declarative'
   // = load from external declarative catalog. See lib/query-config/declarative/loader.ts.
   readonly VITE_CONFIG_SOURCE?: string
+  // Edition flag. 'community' (default, OSS, fail-open) | 'enterprise' (paid).
+  // See lib/edition/. Unset or unrecognised → 'community'.
+  readonly VITE_EDITION?: string
 }
 
 interface ImportMeta {

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -58,6 +58,9 @@ const CLIENT_ENV = {
     e.VITE_RUNNING_QUERIES_REFRESH_MS ??
     e.NEXT_PUBLIC_RUNNING_QUERIES_REFRESH_MS ??
     '',
+  // Edition: 'community' (default, OSS, fail-open) | 'enterprise' (paid).
+  // Unset or unrecognised values always resolve to 'community' in parseEdition().
+  VITE_EDITION: e.VITE_EDITION ?? 'community',
   // Opt-in product telemetry: OFF by default — must be explicitly enabled.
   VITE_TELEMETRY_ENABLED:
     e.VITE_TELEMETRY_ENABLED ?? e.NEXT_PUBLIC_TELEMETRY_ENABLED ?? 'false',


### PR DESCRIPTION
## What

Adds `apps/dashboard/src/lib/edition/` — a clean, honest open-core boundary.

- `edition.ts`: `Edition` type, `ENTERPRISE_FEATURES` const, `EditionFeature` union, `parseEdition()` (fail-open), `getEdition()` (runtime `CHM_EDITION` ?? build-time `VITE_EDITION`), `isEnabled()`
- `index.ts`: re-exports all public symbols
- `edition.test.ts`: 19 `bun:test` assertions (parseEdition, getEdition, isEnabled + explicit fail-open case)
- `vite.config.ts` `CLIENT_ENV`: `VITE_EDITION` defaulting to `'community'`
- `src/vite-env.d.ts`: `readonly VITE_EDITION?: string`

## Why

Scaffold for future paid features (alerting, SSO, RBAC, fleet, cloud) without touching the free edition. The **fail-open invariant** ensures a self-hoster is never locked out: unknown/unset/invalid `CHM_EDITION` always resolves to `'community'`. Free edition remains fully functional.

## Scope

Scaffold only — no UI, no feature is yet behind a gate. Enterprise features that don't exist in community today simply return `false` from `isEnabled()`; they are not degraded versions of free features.

## How verified (all 4 gates passed locally)

1. **Biome**: `bunx biome check --write apps/dashboard/src/lib/edition apps/dashboard/vite.config.ts apps/dashboard/src/vite-env.d.ts` → `Checked 5 files in 6ms. No fixes applied.`
2. **Tests**: `bun test apps/dashboard/src/lib/edition/` → `19 pass, 0 fail, 36 expect() calls`
3. **Build**: `bun run build` → `✓ built in 2.19s` / `✓ built in 1.55s`
4. **type-check:test**: `bun run type-check:test` → exit 0, no errors

## Visual

N/A — scaffold only, no UI surface.

## Guardrails

- [x] Default is `'community'` — self-hosters are never locked out
- [x] `parseEdition()` does not throw — fail-open on any input
- [x] Enterprise features return `false` in community, not errors
- [x] No UI or behaviour changes in this PR
- [x] Auto-merge NOT armed

Plan: cowork/plans/06-open-core-foundation.md (PR 06a)