### PR TITLE
feat(query-config): migrate tables/ domain to declarative catalog (behind flag)

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/detached-parts.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/detached-parts.ts
@@ -1,0 +1,36 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const detachedPartsDeclarative: DeclarativeQueryConfig = {
+  name: 'detached_parts',
+  defaultView: 'auto',
+  card: { primary: 'table', badges: ['reason'] },
+  description: `Contains information about detached parts of MergeTree tables. The reason column specifies why the part was detached`,
+  optional: false,
+  tableCheck: 'system.detached_parts',
+  sql: `
+      SELECT *,
+             format('{}.{}', database, table) AS table,
+             formatReadableSize(bytes_on_disk) AS readable_bytes_on_disk
+      FROM system.detached_parts
+      WHERE table = {table:String}
+      ORDER BY table, name
+  `,
+  columns: [
+    'table',
+    'partition_id',
+    'name',
+    'readable_bytes_on_disk',
+    'modification_time',
+    'disk',
+    'path',
+    'reason',
+    'level',
+    'min_block_number',
+    'max_block_number',
+  ],
+  columnFormats: {},
+  defaultParams: {
+    table: 'default.default',
+  },
+  relatedCharts: [],
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/distributed-ddl-queue.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/distributed-ddl-queue.ts
@@ -1,0 +1,65 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const distributedDdlQueueDeclarative: DeclarativeQueryConfig = {
+  name: 'distributed-ddl-queue',
+  defaultView: 'auto',
+  card: { primary: 'query', badges: ['status'] },
+  description:
+    'Distributed ddl queries (ON CLUSTER clause) that were executed on a cluster',
+  optional: true,
+  suggestion: `To use Distributed DDL Queue:
+
+1. Set up cluster with replicas:
+CREATE TABLE t ON CLUSTER cluster_name
+(id Int32) ENGINE=ReplicatedMergeTree()
+
+2. Enable distributed DDL:
+SET distributed_ddl_queue_enabled = 1;
+
+3. Run DDL on cluster:
+CREATE TABLE ... ON CLUSTER cluster_name
+
+Requires: Cluster + Keeper/ZooKeeper
+
+Learn more:
+https://clickhouse.com/docs/en/operations/system-tables/distributed_ddl_queue`,
+  tableCheck: 'system.distributed_ddl_queue',
+  sql: `
+      SELECT
+        entry,
+        status,
+        entry_version,
+        format('{}:{}', initiator_host, toString(initiator_port)) AS initiator,
+        cluster,
+        query,
+        toString(settings) AS settings,
+        format('{}:{}', host, toString(port)) AS host,
+        exception_code,
+        exception_text,
+        query_finish_time,
+        query_duration_ms
+      FROM system.distributed_ddl_queue
+      ORDER BY entry DESC, host
+      LIMIT 10000
+    `,
+  columns: [
+    'entry',
+    'status',
+    'entry_version',
+    'initiator',
+    'cluster',
+    'query',
+    'settings',
+    'host',
+    'exception_code',
+    'exception_text',
+    'query_finish_time',
+    'query_duration_ms',
+  ],
+  columnFormats: {
+    status: 'colored-badge',
+    query: 'code-dialog',
+    settings: 'code-dialog',
+    exception_text: 'code-dialog',
+  },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/dropped-tables.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/dropped-tables.ts
@@ -1,0 +1,28 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const droppedTablesDeclarative: DeclarativeQueryConfig = {
+  name: 'dropped-tables',
+  defaultView: 'auto',
+  card: { primary: 'table', badges: ['engine'] },
+  refreshInterval: 30_000,
+  description:
+    'Tables awaiting final asynchronous drop (Atomic database engine)',
+  optional: true,
+  tableCheck: 'system.dropped_tables',
+  sql: `SELECT index, database, table, uuid, engine, metadata_dropped_path, table_dropped_time FROM system.dropped_tables ORDER BY table_dropped_time DESC`,
+  columns: [
+    'index',
+    'database',
+    'table',
+    'uuid',
+    'engine',
+    'metadata_dropped_path',
+    'table_dropped_time',
+  ],
+  columnFormats: {
+    database: 'colored-badge',
+    table: 'colored-badge',
+    engine: 'colored-badge',
+    table_dropped_time: 'related-time',
+  },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/moves.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/moves.ts
@@ -1,0 +1,23 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const movesDeclarative: DeclarativeQueryConfig = {
+  name: 'moves',
+  defaultView: 'auto',
+  card: { primary: 'table' },
+  description:
+    'In-progress part moves between disks and volumes (TTL / storage policy)',
+  refreshInterval: 30_000,
+  optional: true,
+  tableCheck: 'system.moves',
+  sql: `SELECT database, table, elapsed, formatReadableTimeDelta(elapsed) AS readable_elapsed, target_disk_name, target_disk_path, part_name, formatReadableSize(part_size) AS readable_part_size, thread_id FROM system.moves ORDER BY elapsed DESC`,
+  columns: [
+    'database',
+    'table',
+    'readable_elapsed',
+    'target_disk_name',
+    'target_disk_path',
+    'part_name',
+    'readable_part_size',
+    'thread_id',
+  ],
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/replicas.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/replicas.ts
@@ -1,0 +1,73 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const replicasDeclarative: DeclarativeQueryConfig = {
+  name: 'replicas',
+  defaultView: 'auto',
+  card: { primary: 'database_table', badges: ['is_readonly', 'is_leader'] },
+  refreshInterval: 30_000,
+  optional: false,
+  description: `Contains information and status for replicated tables residing on the local server`,
+  sql: `
+      SELECT *, (database || '.' || table) as database_table
+      FROM system.replicas
+      ORDER BY database, table
+    `,
+  columns: [
+    'database_table',
+    'future_parts',
+    'queue_size',
+    'absolute_delay',
+    'total_replicas',
+    'active_replicas',
+    'is_leader',
+    'can_become_leader',
+    'is_readonly',
+    'is_session_expired',
+    'parts_to_check',
+    'zookeeper_path',
+    'engine',
+    'replica_name',
+    'replica_path',
+    'columns_version',
+    'inserts_in_queue',
+    'merges_in_queue',
+    'part_mutations_in_queue',
+    'queue_oldest_time',
+    'inserts_oldest_time',
+    'merges_oldest_time',
+    'part_mutations_oldest_time',
+    'oldest_part_to_get',
+    'oldest_part_to_merge_to',
+    'oldest_part_to_mutate_to',
+    'log_max_index',
+    'log_pointer',
+    'last_queue_update',
+    'last_queue_update_exception',
+    'zookeeper_exception',
+  ],
+  columnFormats: {
+    database_table: [
+      'link',
+      { href: '/table?host=[ctx.hostId]&database=[database]&table=[table]' },
+    ],
+    engine: 'colored-badge',
+    is_leader: 'boolean',
+    can_become_leader: 'boolean',
+    is_readonly: 'boolean',
+    is_session_expired: 'boolean',
+  },
+  relatedCharts: [
+    [
+      'replication-queue-count',
+      {
+        title: 'Replication Status',
+      },
+    ],
+    [
+      'replication-summary-table',
+      {
+        title: 'Replication Summary',
+      },
+    ],
+  ],
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/replicated-fetches.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/replicated-fetches.ts
@@ -1,0 +1,42 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const replicatedFetchesDeclarative: DeclarativeQueryConfig = {
+  name: 'replicated-fetches',
+  defaultView: 'auto',
+  card: { primary: 'table' },
+  description:
+    'Currently executing background part downloads from replica sources',
+  optional: true,
+  tableCheck: 'system.replicated_fetches',
+  refreshInterval: 30_000,
+  sql: `
+      SELECT
+        database,
+        table,
+        elapsed,
+        formatReadableTimeDelta(elapsed) AS readable_elapsed,
+        round(progress * 100, 1) AS progress_pct,
+        result_part_name,
+        formatReadableSize(total_size_bytes_compressed) AS readable_size,
+        formatReadableSize(bytes_read_compressed) AS readable_read,
+        source_replica_hostname,
+        source_replica_port,
+        to_detached,
+        thread_id
+      FROM system.replicated_fetches
+      ORDER BY elapsed DESC
+    `,
+  columns: [
+    'database',
+    'table',
+    'readable_elapsed',
+    'progress_pct',
+    'result_part_name',
+    'readable_size',
+    'readable_read',
+    'source_replica_hostname',
+    'source_replica_port',
+    'to_detached',
+    'thread_id',
+  ],
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/replication-queue.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/replication-queue.ts
@@ -1,0 +1,69 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const replicationQueueDeclarative: DeclarativeQueryConfig = {
+  name: 'replication-queue',
+  defaultView: 'auto',
+  card: { primary: 'table', badges: ['type'] },
+  refreshInterval: 30_000,
+  description: `Contains information about tasks from replication queues stored in ClickHouse Keeper, or ZooKeeper, for tables in the ReplicatedMergeTree family`,
+  optional: false,
+  tableCheck: 'system.replication_queue',
+  sql: `
+      SELECT
+        * EXCEPT (table, parts_to_merge),
+        concat(database, '.', table) AS table,
+        arrayStringConcat(parts_to_merge, ', ') AS parts_to_merge
+      FROM system.replication_queue
+      ORDER BY is_currently_executing DESC, create_time DESC
+      LIMIT 1000
+    `,
+  columns: [
+    'table',
+    'replica_name',
+    'position',
+    'node_name',
+    'type',
+    'create_time',
+    'required_quorum',
+    'source_replica',
+    'new_part_name',
+    'parts_to_merge',
+    'is_detach',
+    'is_currently_executing',
+    'num_tries',
+    'last_exception',
+    'last_exception_time',
+    'last_attempt_time',
+    'num_postponed',
+    'postpone_reason',
+    'last_postpone_time',
+    'merge_type',
+  ],
+  columnFormats: {
+    table: 'colored-badge',
+    create_time: 'related-time',
+    last_exception_time: 'related-time',
+    last_attempt_time: 'related-time',
+    last_postpone_time: 'related-time',
+    type: 'colored-badge',
+    is_detach: 'boolean',
+    is_currently_executing: 'boolean',
+    required_quorum: 'boolean',
+    last_exception: 'code-dialog',
+    parts_to_merge: 'code-dialog',
+  },
+  relatedCharts: [
+    [
+      'replication-queue-count',
+      {
+        title: 'Replication Status',
+      },
+    ],
+    [
+      'replication-summary-table',
+      {
+        title: 'Replication Summary',
+      },
+    ],
+  ],
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/tables-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/tables-catalog.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Snapshot tests for the tables/ declarative catalog (Plan 02d).
+ *
+ * For each migrated config, we verify that loadDeclarativeConfig() round-trips
+ * the declarative object back to a QueryConfig that deep-equals the legacy TS
+ * config on every serializable field.
+ *
+ * Runtime-only fields absent from DeclarativeQueryConfig are excluded from
+ * comparison: columnIcons, rowClassName, expandable, permission, filterSchema,
+ * columnFilters, clickhouseSettings, variants.
+ *
+ * SKIPPED configs (non-serializable fields block migration):
+ *   - part-info        : sortingFns uses 'sort_column_using_actual_value'
+ *   - projections      : sortingFns uses 'sort_column_using_actual_value'
+ *   - readonly-tables  : expandable contains JSX (React component ref)
+ *   - tables-overview  : clickhouseSettings + sortingFns 'sort_column_using_actual_value'
+ *   - user-processes   : sortingFns uses 'sort_column_using_actual_value'
+ */
+
+import { loadDeclarativeConfig } from '../../loader'
+import { detachedPartsDeclarative } from './detached-parts'
+import { distributedDdlQueueDeclarative } from './distributed-ddl-queue'
+import { droppedTablesDeclarative } from './dropped-tables'
+import { movesDeclarative } from './moves'
+import { replicasDeclarative } from './replicas'
+import { replicatedFetchesDeclarative } from './replicated-fetches'
+import { replicationQueueDeclarative } from './replication-queue'
+import { viewRefreshesDeclarative } from './view-refreshes'
+import { describe, expect, test } from 'bun:test'
+import { detachedPartsConfig } from '@/lib/query-config/tables/detached-parts'
+import { distributedDdlQueueConfig } from '@/lib/query-config/tables/distributed-ddl-queue'
+import { droppedTablesConfig } from '@/lib/query-config/tables/dropped-tables'
+import { movesConfig } from '@/lib/query-config/tables/moves'
+import { replicasConfig } from '@/lib/query-config/tables/replicas'
+import { replicatedFetchesConfig } from '@/lib/query-config/tables/replicated-fetches'
+import { replicationQueueConfig } from '@/lib/query-config/tables/replication-queue'
+import { viewRefreshesConfig } from '@/lib/query-config/tables/view-refreshes'
+
+// ---------------------------------------------------------------------------
+// Helper: extract only the serializable fields from a QueryConfig for
+// comparison. Serializable = fields present in DeclarativeQueryConfig schema.
+// ---------------------------------------------------------------------------
+
+const SERIALIZABLE_KEYS = [
+  'name',
+  'description',
+  'docs',
+  'suggestion',
+  'sql',
+  'columns',
+  'columnFormats',
+  'columnDescriptions',
+  'columnSizing',
+  'tableBehavior',
+  'defaultParams',
+  'filterParamPresets',
+  'optional',
+  'tableCheck',
+  'disableSqlValidation',
+  'refreshInterval',
+  'relatedCharts',
+  'card',
+  'defaultView',
+  'bulkActions',
+  'bulkActionKey',
+  'sortingFns',
+] as const
+
+type SerializableKey = (typeof SERIALIZABLE_KEYS)[number]
+
+function pickSerializable(
+  config: Record<string, unknown>
+): Partial<Record<SerializableKey, unknown>> {
+  const result: Partial<Record<SerializableKey, unknown>> = {}
+  for (const key of SERIALIZABLE_KEYS) {
+    if (key in config) {
+      result[key] = config[key]
+    }
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Parametric test helper
+// ---------------------------------------------------------------------------
+
+function assertDeclarativeMatchesLegacy(
+  declarative: unknown,
+  legacy: Record<string, unknown>,
+  configName: string
+) {
+  describe(`${configName} — declarative catalog`, () => {
+    test('loadDeclarativeConfig succeeds', () => {
+      expect(() => loadDeclarativeConfig(declarative)).not.toThrow()
+    })
+
+    test('deep-equals legacy config on serializable fields', () => {
+      const loaded = loadDeclarativeConfig(declarative) as unknown as Record<
+        string,
+        unknown
+      >
+      const legacySerializable = pickSerializable(legacy)
+
+      for (const [key, value] of Object.entries(legacySerializable)) {
+        expect(loaded[key]).toEqual(value)
+      }
+    })
+
+    test('name matches', () => {
+      const loaded = loadDeclarativeConfig(declarative) as unknown as Record<
+        string,
+        unknown
+      >
+      expect(loaded.name).toBe(legacy.name)
+    })
+
+    test('sql matches', () => {
+      const loaded = loadDeclarativeConfig(declarative) as unknown as Record<
+        string,
+        unknown
+      >
+      expect(loaded.sql).toEqual(legacy.sql)
+    })
+
+    test('columns match', () => {
+      const loaded = loadDeclarativeConfig(declarative) as unknown as Record<
+        string,
+        unknown
+      >
+      expect(loaded.columns).toEqual(legacy.columns)
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// detached-parts
+// ---------------------------------------------------------------------------
+
+assertDeclarativeMatchesLegacy(
+  detachedPartsDeclarative,
+  detachedPartsConfig as unknown as Record<string, unknown>,
+  'detached-parts'
+)
+
+// ---------------------------------------------------------------------------
+// distributed-ddl-queue
+// ---------------------------------------------------------------------------
+
+assertDeclarativeMatchesLegacy(
+  distributedDdlQueueDeclarative,
+  distributedDdlQueueConfig as unknown as Record<string, unknown>,
+  'distributed-ddl-queue'
+)
+
+// ---------------------------------------------------------------------------
+// dropped-tables
+// ---------------------------------------------------------------------------
+
+assertDeclarativeMatchesLegacy(
+  droppedTablesDeclarative,
+  droppedTablesConfig as unknown as Record<string, unknown>,
+  'dropped-tables'
+)
+
+// ---------------------------------------------------------------------------
+// moves
+// ---------------------------------------------------------------------------
+
+assertDeclarativeMatchesLegacy(
+  movesDeclarative,
+  movesConfig as unknown as Record<string, unknown>,
+  'moves'
+)
+
+// ---------------------------------------------------------------------------
+// replicas
+// ---------------------------------------------------------------------------
+
+assertDeclarativeMatchesLegacy(
+  replicasDeclarative,
+  replicasConfig as unknown as Record<string, unknown>,
+  'replicas'
+)
+
+// ---------------------------------------------------------------------------
+// replicated-fetches
+// ---------------------------------------------------------------------------
+
+assertDeclarativeMatchesLegacy(
+  replicatedFetchesDeclarative,
+  replicatedFetchesConfig as unknown as Record<string, unknown>,
+  'replicated-fetches'
+)
+
+// ---------------------------------------------------------------------------
+// replication-queue
+// ---------------------------------------------------------------------------
+
+assertDeclarativeMatchesLegacy(
+  replicationQueueDeclarative,
+  replicationQueueConfig as unknown as Record<string, unknown>,
+  'replication-queue'
+)
+
+// ---------------------------------------------------------------------------
+// view-refreshes
+// ---------------------------------------------------------------------------
+
+assertDeclarativeMatchesLegacy(
+  viewRefreshesDeclarative,
+  viewRefreshesConfig as unknown as Record<string, unknown>,
+  'view-refreshes'
+)

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/view-refreshes.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/view-refreshes.ts
@@ -1,0 +1,59 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const viewRefreshesDeclarative: DeclarativeQueryConfig = {
+  name: 'view-refreshes',
+  defaultView: 'auto',
+  card: { primary: 'view', badges: ['status'] },
+  description: `Contains information about refresh operations for materialized views using the REFRESH keyword. https://clickhouse.com/docs/operations/system-tables/view_refreshes`,
+  suggestion: `Create a materialized view with REFRESH:
+
+CREATE MATERIALIZED VIEW my_view
+REFRESH EVERY 1 HOUR
+AS SELECT col1, col2 FROM my_table;
+
+The view will refresh automatically on schedule.
+Monitor status, failures, and performance here.
+
+Requires: ClickHouse 23.8+
+Only for views with explicit REFRESH intervals.
+
+Learn more:
+https://clickhouse.com/docs/en/sql-reference/statements/create/view#materialized-view`,
+  optional: false,
+  tableCheck: 'system.view_refreshes',
+  sql: `
+    SELECT *
+    FROM system.view_refreshes
+    ORDER BY next_refresh_time DESC
+  `,
+  columns: [
+    'database',
+    'view',
+    'last_success_time',
+    'last_refresh_time',
+    'next_refresh_time',
+    'progress',
+    'status',
+    'retry',
+    'last_success_duration_ms',
+    'total_rows',
+    'read_rows',
+    'written_rows',
+    'exception',
+  ],
+  columnFormats: {
+    last_refresh_time: 'related-time',
+    next_refresh_time: 'related-time',
+    database: 'text',
+    view: [
+      'link',
+      { href: '/table?host=[ctx.hostId]&database=[database]&view=[view]' },
+    ],
+    status: 'colored-badge',
+    total_rows: 'number',
+    read_rows: 'number',
+    written_rows: 'number',
+    exception: 'text',
+  },
+  relatedCharts: [],
+}


### PR DESCRIPTION
## What

Adds 8 declarative catalog entries under `apps/dashboard/src/lib/query-config/declarative/catalog/tables/` — one per eligible config from the `tables/` domain — plus a snapshot test suite (`tables-catalog.test.ts`).

## Why

Plan 02d: progressively migrate all `QueryConfig` domains to the declarative format so configs can live outside TypeScript files and be contributed without requiring runtime knowledge.

## Scope

**Migrated (8):**
- `detached-parts` — tableCheck, defaultParams, card, relatedCharts
- `distributed-ddl-queue` — optional, suggestion, tableCheck, columnFormats
- `dropped-tables` — optional, tableCheck, refreshInterval, columnFormats
- `moves` — optional, tableCheck, refreshInterval (no columnFormats)
- `replicas` — refreshInterval, columnFormats (link + boolean), relatedCharts
- `replicated-fetches` — optional, tableCheck, refreshInterval
- `replication-queue` — tableCheck, refreshInterval, columnFormats, relatedCharts
- `view-refreshes` — tableCheck, suggestion, columnFormats (link), relatedCharts

**Skipped (5) — non-serializable fields block migration:**
- `part-info` — `sortingFns` uses `'sort_column_using_actual_value'` (not in schema)
- `projections` — `sortingFns` uses `'sort_column_using_actual_value'` (not in schema)
- `readonly-tables` — `expandable` contains JSX (`<ReadonlyTableDetails row={row} />`)
- `tables-overview` — `clickhouseSettings` (not serializable) + `sortingFns` unsupported value
- `user-processes` — `sortingFns` uses `'sort_column_using_actual_value'` (not in schema)

## How verified

| Gate | Command | Result |
|------|---------|--------|
| 1. Biome | `bunx biome check --write apps/dashboard/src/lib/query-config/declarative` | exit 0, no errors |
| 2. Tests | `bun test apps/dashboard/src/lib/query-config/declarative/` | 77 pass, 0 fail |
| 3. Build | `bun run build` (apps/dashboard) | exit 0 |
| 4. Type-check:test | `bun run type-check:test` (apps/dashboard) | exit 0 |

## Visual

N/A — additive catalog-only change; legacy TS configs remain the default source (`CHM_CONFIG_SOURCE=ts`).

## Guardrails

- [ ] Additive only — no changes to existing files
- [ ] Legacy TS configs untouched — zero runtime change
- [ ] Behind `CHM_CONFIG_SOURCE=declarative` flag
- [ ] All 4 CI gates verified locally
- [ ] NOT armed for auto-merge