### PR TITLE
feat(query-config): migrate explorer/ domain to declarative catalog (behind flag)

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/columns.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/columns.ts
@@ -1,0 +1,16 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const explorerColumnsDeclarative: DeclarativeQueryConfig = {
+  name: 'explorer-columns',
+  description: 'Columns in a table',
+  sql: 'SELECT name, type, is_in_primary_key, is_in_sorting_key, is_in_partition_key FROM system.columns WHERE database = {database:String} AND table = {table:String} ORDER BY position',
+  columns: [
+    'name',
+    'type',
+    'is_in_primary_key',
+    'is_in_sorting_key',
+    'is_in_partition_key',
+  ],
+  optional: false,
+  defaultParams: { database: 'default', table: '' },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/databases.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/databases.ts
@@ -1,0 +1,21 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const explorerDatabasesDeclarative: DeclarativeQueryConfig = {
+  name: 'explorer-databases',
+  description: 'List of ClickHouse databases with table counts',
+  sql: `
+    SELECT
+      d.name,
+      d.engine,
+      d.data_path,
+      d.uuid,
+      count(t.name) AS item_count
+    FROM system.databases d
+    LEFT JOIN system.tables t ON d.name = t.database
+    WHERE d.name NOT IN ('INFORMATION_SCHEMA', 'information_schema')
+    GROUP BY d.name, d.engine, d.data_path, d.uuid
+    ORDER BY d.name
+  `,
+  columns: ['name', 'engine', 'data_path', 'uuid', 'item_count'],
+  optional: false,
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/ddl.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/ddl.ts
@@ -1,0 +1,10 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const explorerDdlDeclarative: DeclarativeQueryConfig = {
+  name: 'explorer-ddl',
+  description: 'DDL statement for a table',
+  sql: 'SELECT create_table_query FROM system.tables WHERE database = {database:String} AND name = {table:String}',
+  columns: ['create_table_query'],
+  optional: false,
+  defaultParams: { database: 'default', table: '' },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/dependencies.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/dependencies.ts
@@ -1,0 +1,510 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const explorerDatabaseDependenciesDeclarative: DeclarativeQueryConfig = {
+  name: 'explorer-database-dependencies',
+  description: 'All table dependencies within a database',
+  sql: `
+    WITH
+      -- Get all tables with their dependencies
+      table_deps AS (
+        SELECT
+          database,
+          name,
+          engine,
+          dependencies_database,
+          dependencies_table
+        FROM system.tables
+        WHERE database = {database:String}
+          AND is_temporary = 0
+          AND name NOT LIKE '.inner_%'
+      ),
+      -- Expand dependencies
+      expanded AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          engine AS source_engine,
+          arrayJoin(
+            if(empty(dependencies_database), [''], dependencies_database)
+          ) AS target_database,
+          arrayJoin(
+            if(empty(dependencies_table), [''], dependencies_table)
+          ) AS target_table
+        FROM table_deps
+      )
+    SELECT DISTINCT
+      source_database,
+      source_table,
+      source_engine,
+      target_database,
+      target_table
+    FROM expanded
+    WHERE target_table != ''
+      OR source_engine IN ('MaterializedView', 'View', 'Dictionary')
+    ORDER BY source_table, target_table
+  `,
+  columns: [
+    'source_database',
+    'source_table',
+    'source_engine',
+    'target_database',
+    'target_table',
+  ],
+  optional: false,
+  defaultParams: { database: 'default' },
+}
+
+export const explorerDictionarySourceDeclarative: DeclarativeQueryConfig = {
+  name: 'explorer-dictionary-source',
+  description: 'Source table for a dictionary',
+  sql: `
+    SELECT
+        database AS dict_database,
+        name AS dict_name,
+        source,
+        -- Extract source database from ClickHouse source string
+        extractAllGroups(source, 'db: ''([^'']+)''')[1][1] AS source_database,
+        -- Extract source table from ClickHouse source string
+        extractAllGroups(source, 'table: ''([^'']+)''')[1][1] AS source_table
+    FROM system.dictionaries
+    WHERE database = {database:String}
+      AND name = {table:String}
+  `,
+  columns: [
+    'dict_database',
+    'dict_name',
+    'source',
+    'source_database',
+    'source_table',
+  ],
+  optional: false,
+  defaultParams: { database: 'default', table: '' },
+}
+
+export const explorerDependenciesDownstreamDeclarative: DeclarativeQueryConfig =
+  {
+    name: 'explorer-dependencies-downstream',
+    description: 'Tables and views that depend on this table (downstream)',
+    sql: `
+    SELECT
+        database AS dependent_database,
+        name AS dependent_table,
+        engine,
+        if(engine = 'MaterializedView', 'Materialized View',
+           if(engine = 'View', 'View', 'Table')) AS type,
+        create_table_query
+    FROM system.tables
+    WHERE has(dependencies_database, {database:String})
+      AND has(dependencies_table, {table:String})
+    ORDER BY database, name
+  `,
+    columns: [
+      'dependent_database',
+      'dependent_table',
+      'engine',
+      'type',
+      'create_table_query',
+    ],
+    optional: false,
+    defaultParams: { database: 'default', table: '' },
+  }
+
+export const explorerDependenciesUpstreamDeclarative: DeclarativeQueryConfig = {
+  name: 'explorer-dependencies-upstream',
+  description: 'Tables that this table depends on (upstream)',
+  sql: `
+    SELECT
+        dep_db AS source_database,
+        dep_table AS source_table,
+        st.engine,
+        if(st.engine = 'MaterializedView', 'Materialized View',
+           if(st.engine = 'View', 'View', 'Table')) AS type
+    FROM (
+        SELECT
+            arrayJoin(dependencies_database) AS dep_db,
+            arrayJoin(dependencies_table) AS dep_table
+        FROM system.tables
+        WHERE database = {database:String}
+          AND name = {table:String}
+    ) AS deps
+    LEFT JOIN system.tables AS st ON st.database = deps.dep_db AND st.name = deps.dep_table
+    ORDER BY source_database, source_table
+  `,
+  columns: ['source_database', 'source_table', 'engine', 'type'],
+  optional: false,
+  defaultParams: { database: 'default', table: '' },
+}
+
+export const explorerAllDependenciesDeclarative: DeclarativeQueryConfig = {
+  name: 'explorer-all-dependencies',
+  description:
+    'All dependencies within a database including dictGet, joinGet, MV targets',
+  sql: `
+    WITH
+      -- 1. Standard dependencies from system.tables arrays
+      standard_deps AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          engine AS source_engine,
+          'dependency' AS dependency_type,
+          dep_db AS target_database,
+          dep_table AS target_table,
+          '' AS extra_info
+        FROM system.tables
+        ARRAY JOIN
+          dependencies_database AS dep_db,
+          dependencies_table AS dep_table
+        WHERE database = {database:String}
+          AND is_temporary = 0
+          AND name NOT LIKE '.inner_%'
+      ),
+
+      -- 2. dictGet() usage in table definitions
+      dictget_deps AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          engine AS source_engine,
+          'dictGet' AS dependency_type,
+          if(position(dict_ref, '.') > 0, splitByChar('.', dict_ref)[1], database) AS target_database,
+          if(position(dict_ref, '.') > 0, splitByChar('.', dict_ref)[2], dict_ref) AS target_table,
+          dict_ref AS extra_info
+        FROM (
+          SELECT database, name, engine, create_table_query,
+            arrayJoin(extractAll(create_table_query, 'dictGet[a-zA-Z]*\\s*\\(\\s*''([^'']+)''')) AS dict_ref
+          FROM system.tables
+          WHERE database = {database:String}
+            AND is_temporary = 0
+            AND create_table_query LIKE '%dictGet%'
+        )
+        WHERE dict_ref != ''
+      ),
+
+      -- 3. joinGet() usage
+      joinget_deps AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          engine AS source_engine,
+          'joinGet' AS dependency_type,
+          if(position(join_ref, '.') > 0, splitByChar('.', join_ref)[1], database) AS target_database,
+          if(position(join_ref, '.') > 0, splitByChar('.', join_ref)[2], join_ref) AS target_table,
+          join_ref AS extra_info
+        FROM (
+          SELECT database, name, engine, create_table_query,
+            arrayJoin(extractAll(create_table_query, 'joinGet\\s*\\(\\s*''([^'']+)''')) AS join_ref
+          FROM system.tables
+          WHERE database = {database:String}
+            AND is_temporary = 0
+            AND create_table_query LIKE '%joinGet%'
+        )
+        WHERE join_ref != ''
+      ),
+
+      -- 4. MV TO targets (MV writes to a different table)
+      mv_targets AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          engine AS source_engine,
+          'mv_target' AS dependency_type,
+          if(position(mv_target, '.') > 0, splitByChar('.', mv_target)[1], database) AS target_database,
+          if(position(mv_target, '.') > 0, splitByChar('.', mv_target)[2], mv_target) AS target_table,
+          'writes_to' AS extra_info
+        FROM (
+          SELECT database, name, engine, create_table_query,
+            extract(create_table_query, 'TO\\s+\`?([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)\`?\\s+') AS mv_target
+          FROM system.tables
+          WHERE database = {database:String}
+            AND engine = 'MaterializedView'
+            AND create_table_query LIKE '% TO %'
+        )
+        WHERE mv_target != ''
+      ),
+
+      -- 5. Dictionary sources (from system.dictionaries)
+      dict_sources AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          'Dictionary' AS source_engine,
+          'dict_source' AS dependency_type,
+          coalesce(extractAllGroups(source, 'db:\\s*''([^'']+)''')[1][1], database) AS target_database,
+          extractAllGroups(source, 'table:\\s*''([^'']+)''')[1][1] AS target_table,
+          source AS extra_info
+        FROM system.dictionaries
+        WHERE database = {database:String}
+          AND extractAllGroups(source, 'table:\\s*''([^'']+)''')[1][1] != ''
+      ),
+
+      -- 6. External engines (standalone nodes for display)
+      external_engines AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          engine AS source_engine,
+          'external' AS dependency_type,
+          '' AS target_database,
+          '' AS target_table,
+          engine_full AS extra_info
+        FROM system.tables
+        WHERE database = {database:String}
+          AND engine IN ('PostgreSQL', 'MySQL', 'S3', 'Kafka', 'MongoDB', 'HDFS', 'URL', 'ODBC', 'JDBC')
+      ),
+
+      -- 7. Standalone tables (no dependencies but should appear in graph)
+      standalone_tables AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          engine AS source_engine,
+          '' AS dependency_type,
+          '' AS target_database,
+          '' AS target_table,
+          '' AS extra_info
+        FROM system.tables
+        WHERE database = {database:String}
+          AND is_temporary = 0
+          AND name NOT LIKE '.inner_%'
+          AND length(dependencies_table) = 0
+          AND engine NOT IN ('PostgreSQL', 'MySQL', 'S3', 'Kafka', 'MongoDB', 'HDFS', 'URL', 'ODBC', 'JDBC')
+      )
+
+    SELECT * FROM standard_deps
+    UNION ALL SELECT * FROM dictget_deps
+    UNION ALL SELECT * FROM joinget_deps
+    UNION ALL SELECT * FROM mv_targets
+    UNION ALL SELECT * FROM dict_sources
+    UNION ALL SELECT * FROM external_engines
+    UNION ALL SELECT * FROM standalone_tables
+    ORDER BY source_table, dependency_type, target_table
+  `,
+  columns: [
+    'source_database',
+    'source_table',
+    'source_engine',
+    'dependency_type',
+    'target_database',
+    'target_table',
+    'extra_info',
+  ],
+  optional: false,
+  defaultParams: { database: 'default' },
+}
+
+export const explorerTableDependenciesDeclarative: DeclarativeQueryConfig = {
+  name: 'explorer-table-dependencies',
+  description:
+    'All dependencies for a specific table including dictGet, joinGet, MV targets',
+  sql: `
+    WITH
+      -- 1. Standard dependencies from system.tables arrays (where source is our table)
+      standard_deps_out AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          engine AS source_engine,
+          'dependency' AS dependency_type,
+          dep_db AS target_database,
+          dep_table AS target_table,
+          '' AS extra_info
+        FROM system.tables
+        ARRAY JOIN
+          dependencies_database AS dep_db,
+          dependencies_table AS dep_table
+        WHERE database = {database:String}
+          AND name = {table:String}
+      ),
+
+      -- 1b. Standard dependencies (where target is our table)
+      standard_deps_in AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          engine AS source_engine,
+          'dependency' AS dependency_type,
+          {database:String} AS target_database,
+          {table:String} AS target_table,
+          '' AS extra_info
+        FROM system.tables
+        WHERE has(dependencies_database, {database:String})
+          AND has(dependencies_table, {table:String})
+      ),
+
+      -- 2. dictGet() usage in table definitions (where source is our table)
+      dictget_deps_out AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          engine AS source_engine,
+          'dictGet' AS dependency_type,
+          if(position(dict_ref, '.') > 0, splitByChar('.', dict_ref)[1], database) AS target_database,
+          if(position(dict_ref, '.') > 0, splitByChar('.', dict_ref)[2], dict_ref) AS target_table,
+          dict_ref AS extra_info
+        FROM (
+          SELECT database, name, engine,
+            arrayJoin(extractAll(create_table_query, 'dictGet[a-zA-Z]*\\s*\\(\\s*''([^'']+)''')) AS dict_ref
+          FROM system.tables
+          WHERE database = {database:String}
+            AND name = {table:String}
+            AND create_table_query LIKE '%dictGet%'
+        )
+        WHERE dict_ref != ''
+      ),
+
+      -- 2b. dictGet() usage (where target dictionary is our table - i.e., what uses this dict)
+      dictget_deps_in AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          engine AS source_engine,
+          'dictGet' AS dependency_type,
+          {database:String} AS target_database,
+          {table:String} AS target_table,
+          {table:String} AS extra_info
+        FROM system.tables
+        WHERE database = {database:String}
+          AND is_temporary = 0
+          AND (
+            create_table_query LIKE concat('%dictGet%''', {table:String}, '''%')
+            OR create_table_query LIKE concat('%dictGet%''', {database:String}, '.', {table:String}, '''%')
+          )
+      ),
+
+      -- 3. joinGet() usage (where source is our table)
+      joinget_deps_out AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          engine AS source_engine,
+          'joinGet' AS dependency_type,
+          if(position(join_ref, '.') > 0, splitByChar('.', join_ref)[1], database) AS target_database,
+          if(position(join_ref, '.') > 0, splitByChar('.', join_ref)[2], join_ref) AS target_table,
+          join_ref AS extra_info
+        FROM (
+          SELECT database, name, engine,
+            arrayJoin(extractAll(create_table_query, 'joinGet\\s*\\(\\s*''([^'']+)''')) AS join_ref
+          FROM system.tables
+          WHERE database = {database:String}
+            AND name = {table:String}
+            AND create_table_query LIKE '%joinGet%'
+        )
+        WHERE join_ref != ''
+      ),
+
+      -- 4. MV TO targets (if this is an MV that writes TO a table)
+      mv_targets AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          engine AS source_engine,
+          'mv_target' AS dependency_type,
+          if(position(mv_target, '.') > 0, splitByChar('.', mv_target)[1], database) AS target_database,
+          if(position(mv_target, '.') > 0, splitByChar('.', mv_target)[2], mv_target) AS target_table,
+          'writes_to' AS extra_info
+        FROM (
+          SELECT database, name, engine,
+            extract(create_table_query, 'TO\\s+\`?([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)\`?\\s+') AS mv_target
+          FROM system.tables
+          WHERE database = {database:String}
+            AND name = {table:String}
+            AND engine = 'MaterializedView'
+            AND create_table_query LIKE '% TO %'
+        )
+        WHERE mv_target != ''
+      ),
+
+      -- 4b. MV TO targets (MVs that write TO this table)
+      mv_targets_in AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          engine AS source_engine,
+          'mv_target' AS dependency_type,
+          {database:String} AS target_database,
+          {table:String} AS target_table,
+          'writes_to' AS extra_info
+        FROM system.tables
+        WHERE database = {database:String}
+          AND engine = 'MaterializedView'
+          AND (
+            create_table_query LIKE concat('% TO ', {table:String}, ' %')
+            OR create_table_query LIKE concat('% TO \`', {table:String}, '\` %')
+            OR create_table_query LIKE concat('% TO ', {database:String}, '.', {table:String}, ' %')
+          )
+      ),
+
+      -- 5. Dictionary source (if this is a dictionary)
+      dict_sources AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          'Dictionary' AS source_engine,
+          'dict_source' AS dependency_type,
+          coalesce(extractAllGroups(source, 'db:\\s*''([^'']+)''')[1][1], database) AS target_database,
+          extractAllGroups(source, 'table:\\s*''([^'']+)''')[1][1] AS target_table,
+          source AS extra_info
+        FROM system.dictionaries
+        WHERE database = {database:String}
+          AND name = {table:String}
+          AND extractAllGroups(source, 'table:\\s*''([^'']+)''')[1][1] != ''
+      ),
+
+      -- 6. External engine info (if this is an external table)
+      external_engines AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          engine AS source_engine,
+          'external' AS dependency_type,
+          '' AS target_database,
+          '' AS target_table,
+          engine_full AS extra_info
+        FROM system.tables
+        WHERE database = {database:String}
+          AND name = {table:String}
+          AND engine IN ('PostgreSQL', 'MySQL', 'S3', 'Kafka', 'MongoDB', 'HDFS', 'URL', 'ODBC', 'JDBC')
+      ),
+
+      -- 7. Current table as standalone (if no other deps found)
+      current_table AS (
+        SELECT
+          database AS source_database,
+          name AS source_table,
+          engine AS source_engine,
+          '' AS dependency_type,
+          '' AS target_database,
+          '' AS target_table,
+          '' AS extra_info
+        FROM system.tables
+        WHERE database = {database:String}
+          AND name = {table:String}
+      )
+
+    SELECT DISTINCT * FROM (
+      SELECT * FROM standard_deps_out
+      UNION ALL SELECT * FROM standard_deps_in
+      UNION ALL SELECT * FROM dictget_deps_out
+      UNION ALL SELECT * FROM dictget_deps_in
+      UNION ALL SELECT * FROM joinget_deps_out
+      UNION ALL SELECT * FROM mv_targets
+      UNION ALL SELECT * FROM mv_targets_in
+      UNION ALL SELECT * FROM dict_sources
+      UNION ALL SELECT * FROM external_engines
+      UNION ALL SELECT * FROM current_table
+    )
+    ORDER BY source_table, dependency_type, target_table
+  `,
+  columns: [
+    'source_database',
+    'source_table',
+    'source_engine',
+    'dependency_type',
+    'target_database',
+    'target_table',
+    'extra_info',
+  ],
+  optional: false,
+  defaultParams: { database: 'default', table: '' },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/explorer-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/explorer-catalog.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Explorer catalog declarative parity tests — Plan 02e.
+ *
+ * For each eligible explorer/ config, asserts that loadDeclarativeConfig()
+ * applied to its declarative counterpart deep-equals the legacy config on all
+ * serializable fields.
+ *
+ * Runtime-only fields (rowClassName, expandable, columnIcons, permission,
+ * filterSchema) are absent from all explorer configs so nothing to exclude.
+ *
+ * Cast through unknown when indexing a QueryConfig to satisfy TS2352.
+ */
+
+import { loadDeclarativeConfig } from '../../loader'
+// Declarative counterparts
+import { explorerColumnsDeclarative } from './columns'
+import { explorerDatabasesDeclarative } from './databases'
+import { explorerDdlDeclarative } from './ddl'
+import {
+  explorerAllDependenciesDeclarative,
+  explorerDatabaseDependenciesDeclarative,
+  explorerDependenciesDownstreamDeclarative,
+  explorerDependenciesUpstreamDeclarative,
+  explorerDictionarySourceDeclarative,
+  explorerTableDependenciesDeclarative,
+} from './dependencies'
+import { explorerIndexesDeclarative } from './indexes'
+import { explorerProjectionsDeclarative } from './projections'
+import { explorerSkipIndexesDeclarative } from './skip-indexes'
+import { explorerTablesDeclarative } from './tables'
+import { describe, expect, test } from 'bun:test'
+// Legacy configs
+import { explorerColumnsConfig } from '@/lib/query-config/explorer/columns'
+import { explorerDatabasesConfig } from '@/lib/query-config/explorer/databases'
+import { explorerDdlConfig } from '@/lib/query-config/explorer/ddl'
+import {
+  explorerAllDependenciesConfig,
+  explorerDatabaseDependenciesConfig,
+  explorerDependenciesDownstreamConfig,
+  explorerDependenciesUpstreamConfig,
+  explorerDictionarySourceConfig,
+  explorerTableDependenciesConfig,
+} from '@/lib/query-config/explorer/dependencies'
+import { explorerIndexesConfig } from '@/lib/query-config/explorer/indexes'
+import { explorerProjectionsConfig } from '@/lib/query-config/explorer/projections'
+import { explorerSkipIndexesConfig } from '@/lib/query-config/explorer/skip-indexes'
+import { explorerTablesConfig } from '@/lib/query-config/explorer/tables'
+
+// ---------------------------------------------------------------------------
+// Helper: the serializable fields shared by QueryConfig and DeclarativeQueryConfig
+// ---------------------------------------------------------------------------
+
+const SERIALIZABLE_KEYS = [
+  'name',
+  'description',
+  'docs',
+  'suggestion',
+  'sql',
+  'columns',
+  'columnFormats',
+  'columnDescriptions',
+  'columnSizing',
+  'tableBehavior',
+  'defaultParams',
+  'filterParamPresets',
+  'optional',
+  'tableCheck',
+  'disableSqlValidation',
+  'refreshInterval',
+  'relatedCharts',
+  'card',
+  'defaultView',
+  'bulkActions',
+  'bulkActionKey',
+  'sortingFns',
+] as const
+
+type SerializableKey = (typeof SERIALIZABLE_KEYS)[number]
+
+function pickSerializable(
+  cfg: unknown
+): Partial<Record<SerializableKey, unknown>> {
+  const rec = cfg as unknown as Record<string, unknown>
+  const out: Partial<Record<SerializableKey, unknown>> = {}
+  for (const key of SERIALIZABLE_KEYS) {
+    if (rec[key] !== undefined) {
+      out[key] = rec[key]
+    }
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Per-config test suites
+// ---------------------------------------------------------------------------
+
+describe('explorer-catalog declarative parity', () => {
+  const cases: Array<{
+    name: string
+    legacy: unknown
+    declarative: unknown
+  }> = [
+    {
+      name: 'explorer-columns',
+      legacy: explorerColumnsConfig,
+      declarative: explorerColumnsDeclarative,
+    },
+    {
+      name: 'explorer-databases',
+      legacy: explorerDatabasesConfig,
+      declarative: explorerDatabasesDeclarative,
+    },
+    {
+      name: 'explorer-ddl',
+      legacy: explorerDdlConfig,
+      declarative: explorerDdlDeclarative,
+    },
+    {
+      name: 'explorer-database-dependencies',
+      legacy: explorerDatabaseDependenciesConfig,
+      declarative: explorerDatabaseDependenciesDeclarative,
+    },
+    {
+      name: 'explorer-dictionary-source',
+      legacy: explorerDictionarySourceConfig,
+      declarative: explorerDictionarySourceDeclarative,
+    },
+    {
+      name: 'explorer-dependencies-downstream',
+      legacy: explorerDependenciesDownstreamConfig,
+      declarative: explorerDependenciesDownstreamDeclarative,
+    },
+    {
+      name: 'explorer-dependencies-upstream',
+      legacy: explorerDependenciesUpstreamConfig,
+      declarative: explorerDependenciesUpstreamDeclarative,
+    },
+    {
+      name: 'explorer-all-dependencies',
+      legacy: explorerAllDependenciesConfig,
+      declarative: explorerAllDependenciesDeclarative,
+    },
+    {
+      name: 'explorer-table-dependencies',
+      legacy: explorerTableDependenciesConfig,
+      declarative: explorerTableDependenciesDeclarative,
+    },
+    {
+      name: 'explorer-indexes',
+      legacy: explorerIndexesConfig,
+      declarative: explorerIndexesDeclarative,
+    },
+    {
+      name: 'explorer-projections',
+      legacy: explorerProjectionsConfig,
+      declarative: explorerProjectionsDeclarative,
+    },
+    {
+      name: 'explorer-skip-indexes',
+      legacy: explorerSkipIndexesConfig,
+      declarative: explorerSkipIndexesDeclarative,
+    },
+    {
+      name: 'explorer-tables',
+      legacy: explorerTablesConfig,
+      declarative: explorerTablesDeclarative,
+    },
+  ]
+
+  for (const { name, legacy, declarative } of cases) {
+    describe(name, () => {
+      test('loadDeclarativeConfig succeeds', () => {
+        const loaded = loadDeclarativeConfig(declarative)
+        expect(loaded).toBeDefined()
+        expect(typeof loaded).toBe('object')
+      })
+
+      test('deep-equals legacy on all serializable fields', () => {
+        const loaded = loadDeclarativeConfig(declarative)
+        const legacySer = pickSerializable(legacy)
+
+        for (const [key, value] of Object.entries(legacySer)) {
+          expect((loaded as unknown as Record<string, unknown>)[key]).toEqual(
+            value
+          )
+        }
+      })
+    })
+  }
+})

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/indexes.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/indexes.ts
@@ -1,0 +1,17 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const explorerIndexesDeclarative: DeclarativeQueryConfig = {
+  name: 'explorer-indexes',
+  description: 'Index and key information for a table',
+  sql: 'SELECT partition_key, sorting_key, primary_key, sampling_key, engine, engine_full FROM system.tables WHERE database = {database:String} AND name = {table:String}',
+  columns: [
+    'partition_key',
+    'sorting_key',
+    'primary_key',
+    'sampling_key',
+    'engine',
+    'engine_full',
+  ],
+  optional: false,
+  defaultParams: { database: 'default', table: '' },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/projections.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/projections.ts
@@ -1,0 +1,31 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const explorerProjectionsDeclarative: DeclarativeQueryConfig = {
+  name: 'explorer-projections',
+  description: 'Projections for a specific table',
+  sql: `
+    SELECT
+        name,
+        formatReadableSize(sum(data_compressed_bytes)) AS compressed_size,
+        formatReadableSize(sum(data_uncompressed_bytes)) AS uncompressed_size,
+        round(sum(data_uncompressed_bytes) / nullIf(sum(data_compressed_bytes), 0), 2) AS compression_ratio,
+        formatReadableQuantity(sum(rows)) AS rows,
+        count() AS parts
+    FROM system.projection_parts
+    WHERE database = {database:String}
+      AND table = {table:String}
+      AND active
+    GROUP BY name
+    ORDER BY sum(data_compressed_bytes) DESC
+  `,
+  columns: [
+    'name',
+    'compressed_size',
+    'uncompressed_size',
+    'compression_ratio',
+    'rows',
+    'parts',
+  ],
+  optional: false,
+  defaultParams: { database: 'default', table: '' },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/skip-indexes.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/skip-indexes.ts
@@ -1,0 +1,34 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const explorerSkipIndexesDeclarative: DeclarativeQueryConfig = {
+  name: 'explorer-skip-indexes',
+  description: 'Data skipping indexes for a specific table',
+  optional: true,
+  tableCheck: 'system.data_skipping_indices',
+  sql: `
+    SELECT
+        name,
+        type,
+        type_full,
+        expr,
+        granularity,
+        formatReadableSize(data_compressed_bytes) AS compressed_size,
+        formatReadableSize(data_uncompressed_bytes) AS uncompressed_size,
+        if(data_compressed_bytes > 0, round(data_uncompressed_bytes / data_compressed_bytes, 2), 0) AS compression_ratio
+    FROM system.data_skipping_indices
+    WHERE database = {database:String}
+      AND table = {table:String}
+    ORDER BY data_compressed_bytes DESC
+  `,
+  columns: [
+    'name',
+    'type',
+    'type_full',
+    'expr',
+    'granularity',
+    'compressed_size',
+    'uncompressed_size',
+    'compression_ratio',
+  ],
+  defaultParams: { database: 'default', table: '' },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/tables.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/tables.ts
@@ -1,0 +1,10 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const explorerTablesDeclarative: DeclarativeQueryConfig = {
+  name: 'explorer-tables',
+  description: 'List of tables in a database',
+  sql: "SELECT name, engine, total_rows, total_bytes, formatReadableSize(total_bytes) as readable_size FROM system.tables WHERE database = {database:String} AND is_temporary = 0 AND name NOT LIKE '.inner_%' ORDER BY name",
+  columns: ['name', 'engine', 'total_rows', 'total_bytes', 'readable_size'],
+  optional: false,
+  defaultParams: { database: 'default' },
+}


### PR DESCRIPTION
## What

Add `DeclarativeQueryConfig` entries for all 11 configs in `apps/dashboard/src/lib/query-config/explorer/` under `declarative/catalog/explorer/`.

**Migrated (11 configs, 0 skipped):**

| Config | File |
|--------|------|
| `explorer-columns` | `columns.ts` |
| `explorer-databases` | `databases.ts` |
| `explorer-ddl` | `ddl.ts` |
| `explorer-database-dependencies` | `dependencies.ts` |
| `explorer-dictionary-source` | `dependencies.ts` |
| `explorer-dependencies-downstream` | `dependencies.ts` |
| `explorer-dependencies-upstream` | `dependencies.ts` |
| `explorer-all-dependencies` | `dependencies.ts` |
| `explorer-table-dependencies` | `dependencies.ts` |
| `explorer-indexes` | `indexes.ts` |
| `explorer-projections` | `projections.ts` |
| `explorer-skip-indexes` | `skip-indexes.ts` |
| `explorer-tables` | `tables.ts` |

**Skipped:** none — all explorer configs are fully serializable (no `rowClassName`, `expandable`, `columnIcons`, `permission`, or `filterSchema`).

## Why

Plan 02e of the externalize-query-configs plan. Migrates the explorer domain behind `CHM_CONFIG_SOURCE=declarative` flag — zero runtime change on the default `ts` path.

## Scope

9 new files only under `declarative/catalog/explorer/`. No changes to legacy `explorer/` configs or any runtime code.

## How verified (all 4 gates passed)

- [x] `bunx biome check --write apps/dashboard/src/lib/query-config/declarative` — no errors (1 auto-fix by formatter)
- [x] `bun test apps/dashboard/src/lib/query-config/declarative/` — **63 tests, 0 fail** (26 new tests from this PR)
- [x] `bun run build` — exit 0
- [x] `bun run type-check:test` — exit 0

## Visual

N/A — behind flag, no UI change.

## Guardrails

- [ ] NOT armed for auto-merge (per task instructions)
- [x] No changes to legacy `explorer/` configs
- [x] No changes to main branch
- [x] Committed only to `plan/02-migrate-explorer`