### PR TITLE
feat(query-config): migrate queries/ domain to declarative (behind flag)

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/queries/common-errors.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/queries/common-errors.ts
@@ -1,0 +1,40 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const commonErrorsDeclarative: DeclarativeQueryConfig = {
+  name: 'common-errors',
+  description:
+    'This table `system.errors` contains error codes and the number of times each error has been triggered. Furthermore, we can see when the error last occurred coupled with the exact error message',
+  defaultView: 'auto',
+  card: { primary: 'name', badges: ['remote'] },
+  tableCheck: 'system.errors',
+  optional: false,
+  sql: `
+      SELECT
+          name,
+          code,
+          value,
+          round(100 * value / max(value) OVER ()) AS pct_value,
+          last_error_time,
+          last_error_message,
+          toString(last_error_trace) AS remote
+      FROM system.errors
+      ORDER BY last_error_time DESC
+      LIMIT 1000
+    `,
+  columns: [
+    'name',
+    'code',
+    'value',
+    'last_error_time',
+    'last_error_message',
+    'remote',
+  ],
+  columnFormats: {
+    name: 'colored-badge',
+    code: 'colored-badge',
+    value: 'background-bar',
+    last_error_time: 'related-time',
+    remote: 'code-dialog',
+    last_error_message: ['code-dialog', { max_truncate: 100 }],
+  },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/queries/parallelization.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/queries/parallelization.ts
@@ -1,0 +1,48 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const parallelizationDeclarative: DeclarativeQueryConfig = {
+  name: 'parallelization',
+  description: 'Query parallelization efficiency analysis',
+  docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_thread_log',
+  defaultView: 'auto',
+  card: { primary: 'query_id' },
+  optional: true,
+  tableCheck: 'system.query_thread_log',
+  sql: `
+    SELECT
+      query_id,
+      count() as thread_count,
+      sum(read_rows) as total_read_rows,
+      sum(read_bytes) as total_read_bytes,
+      max(peak_memory_usage) as max_peak_memory,
+      sum(memory_usage) as total_memory,
+      formatReadableQuantity(total_read_rows) as readable_total_read_rows,
+      formatReadableSize(total_read_bytes) as readable_total_read_bytes,
+      formatReadableSize(max_peak_memory) as readable_max_peak_memory,
+      formatReadableSize(total_memory) as readable_total_memory,
+      min(event_time) as event_time
+    FROM system.query_thread_log
+    WHERE event_date >= today() - 1
+    GROUP BY query_id
+    ORDER BY thread_count DESC
+    LIMIT 500
+  `,
+  columns: [
+    'query_id',
+    'thread_count',
+    'readable_total_read_rows',
+    'readable_total_read_bytes',
+    'readable_max_peak_memory',
+    'readable_total_memory',
+    'event_time',
+  ],
+  columnFormats: {
+    event_time: 'related-time',
+    query_id: ['link', { href: '/query?query_id=[query_id]' }],
+    thread_count: 'number',
+    readable_total_read_rows: 'background-bar',
+    readable_total_read_bytes: 'background-bar',
+    readable_max_peak_memory: 'background-bar',
+  },
+  relatedCharts: ['parallelization-efficiency', 'thread-utilization'],
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/queries/profiler.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/queries/profiler.ts
@@ -1,0 +1,52 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const profilerDeclarative: DeclarativeQueryConfig = {
+  name: 'profiler',
+  description: 'Query processor profiling data',
+  docs: 'https://clickhouse.com/docs/en/operations/system-tables/processors_profile_log',
+  defaultView: 'auto',
+  card: { primary: 'processor_name' },
+  optional: true,
+  tableCheck: 'system.processors_profile_log',
+  sql: `
+    SELECT
+      query_id,
+      name as processor_name,
+      elapsed_us,
+      input_wait_elapsed_us,
+      output_wait_elapsed_us,
+      input_rows,
+      input_bytes,
+      output_rows,
+      output_bytes,
+      formatReadableQuantity(input_rows) as readable_input_rows,
+      formatReadableSize(input_bytes) as readable_input_bytes,
+      formatReadableQuantity(output_rows) as readable_output_rows,
+      formatReadableSize(output_bytes) as readable_output_bytes,
+      round(elapsed_us / 1000, 2) as elapsed_ms,
+      event_time
+    FROM system.processors_profile_log
+    WHERE event_date >= today() - 1
+    ORDER BY elapsed_us DESC
+    LIMIT 1000
+  `,
+  columns: [
+    'query_id',
+    'processor_name',
+    'elapsed_ms',
+    'readable_input_rows',
+    'readable_input_bytes',
+    'readable_output_rows',
+    'readable_output_bytes',
+    'event_time',
+  ],
+  columnFormats: {
+    event_time: 'related-time',
+    query_id: ['link', { href: '/query?query_id=[query_id]' }],
+    processor_name: 'colored-badge',
+    elapsed_ms: 'number',
+    readable_input_rows: 'background-bar',
+    readable_output_rows: 'background-bar',
+  },
+  relatedCharts: ['thread-utilization'],
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/queries/queries-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/queries/queries-catalog.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Snapshot tests for the queries/ domain declarative catalog (Plan 02i).
+ *
+ * For each migrated config, assert that loadDeclarativeConfig(declarativeObj)
+ * deep-equals the legacy TS config on its serializable fields.
+ *
+ * Runtime-only fields excluded from comparison:
+ *   rowClassName  — function (row) => string | undefined
+ *   expandable    — function-based ExpandableConfig
+ *   columnIcons   — React component refs
+ *   permission    — FeaturePermission
+ *   filterSchema  — contains Icon refs and dynamic option fns
+ *   columnFilters — UI sugar over filterSchema
+ *   clickhouseSettings — ClickHouseSettings (execution-time; not serializable)
+ *
+ * Skipped configs (runtime-only fields the schema cannot express):
+ *   expensive-queries          — rowClassName, expandable (JSX), columnIcons
+ *   expensive-queries-by-memory — expandable (JSX), columnIcons
+ *   failed-queries             — expandable (JSX), columnIcons
+ *   slow-queries               — rowClassName, expandable (JSX), columnIcons
+ *   history-queries            — rowClassName, expandable, filterSchema (icons + runtime env), clickhouseSettings
+ *   running-queries            — rowClassName, expandable (JSX), filterSchema (icons), columnFilters
+ *   query-detail               — permission (FeaturePermission)
+ *   query-cache                — docs is non-URL prose string (schema requires URL)
+ */
+
+import { loadDeclarativeConfig } from '../../loader'
+// Declarative catalog objects
+import { commonErrorsDeclarative } from './common-errors'
+import { parallelizationDeclarative } from './parallelization'
+import { profilerDeclarative } from './profiler'
+import { queryViewsLogDeclarative } from './query-views-log'
+import { threadAnalysisDeclarative } from './thread-analysis'
+import { describe, expect, test } from 'bun:test'
+// Legacy TS configs
+import { commonErrorsConfig } from '@/lib/query-config/queries/common-errors'
+import { parallelizationConfig } from '@/lib/query-config/queries/parallelization'
+import { profilerConfig } from '@/lib/query-config/queries/profiler'
+import { queryViewsLogConfig } from '@/lib/query-config/queries/query-views-log'
+import { threadAnalysisConfig } from '@/lib/query-config/queries/thread-analysis'
+
+// ---------------------------------------------------------------------------
+// Helper: compare serializable fields between loaded declarative config and
+// legacy TS config. Skips keys absent from the declarative schema.
+// ---------------------------------------------------------------------------
+
+const RUNTIME_ONLY_KEYS = new Set([
+  'rowClassName',
+  'expandable',
+  'columnIcons',
+  'permission',
+  'filterSchema',
+  'columnFilters',
+  'clickhouseSettings',
+  'variants',
+])
+
+function compareSerializable(
+  loaded: ReturnType<typeof loadDeclarativeConfig>,
+  legacy: ReturnType<typeof loadDeclarativeConfig>
+): void {
+  const legacyRec = legacy as unknown as Record<string, unknown>
+  const loadedRec = loaded as unknown as Record<string, unknown>
+
+  for (const key of Object.keys(legacyRec)) {
+    if (RUNTIME_ONLY_KEYS.has(key)) continue
+    expect(loadedRec[key]).toEqual(legacyRec[key])
+  }
+}
+
+// ---------------------------------------------------------------------------
+// common-errors
+// ---------------------------------------------------------------------------
+
+describe('common-errors declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(commonErrorsDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(commonErrorsDeclarative)
+    compareSerializable(loaded, commonErrorsConfig)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parallelization
+// ---------------------------------------------------------------------------
+
+describe('parallelization declarative', () => {
+  test('loads without error', () => {
+    expect(() =>
+      loadDeclarativeConfig(parallelizationDeclarative)
+    ).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(parallelizationDeclarative)
+    compareSerializable(loaded, parallelizationConfig)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// profiler
+// ---------------------------------------------------------------------------
+
+describe('profiler declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(profilerDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(profilerDeclarative)
+    compareSerializable(loaded, profilerConfig)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// query-views-log
+// ---------------------------------------------------------------------------
+
+describe('query-views-log declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(queryViewsLogDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(queryViewsLogDeclarative)
+    compareSerializable(loaded, queryViewsLogConfig)
+  })
+
+  test('versioned sql array length matches', () => {
+    const loaded = loadDeclarativeConfig(queryViewsLogDeclarative)
+    const legacySql = queryViewsLogConfig.sql
+    expect(Array.isArray(loaded.sql)).toBe(Array.isArray(legacySql))
+    if (Array.isArray(loaded.sql) && Array.isArray(legacySql)) {
+      expect(loaded.sql.length).toBe(legacySql.length)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// thread-analysis
+// ---------------------------------------------------------------------------
+
+describe('thread-analysis declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(threadAnalysisDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(threadAnalysisDeclarative)
+    compareSerializable(loaded, threadAnalysisConfig)
+  })
+})

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/queries/query-views-log.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/queries/query-views-log.ts
@@ -1,0 +1,100 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+import { QUERY_COMMENT } from '@chm/clickhouse-client/constants'
+
+export const queryViewsLogDeclarative: DeclarativeQueryConfig = {
+  name: 'query-views-log',
+  description:
+    'Materialized view execution log (target views, durations, read/written rows) with compatibility for old and new ClickHouse releases.',
+  docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_views_log',
+  defaultView: 'auto',
+  card: { primary: 'view_name', badges: ['status'] },
+  optional: true,
+  tableCheck: 'system.query_views_log',
+  sql: [
+    {
+      since: '22.8',
+      sql: `
+        ${QUERY_COMMENT}
+        SELECT
+          event_time,
+          initial_query_id,
+          view_name,
+          status,
+          exception_code,
+          exception,
+          round(view_duration_ms, 2) AS view_duration_ms,
+          read_rows,
+          formatReadableQuantity(read_rows) AS readable_read_rows,
+          round(read_rows * 100.0 / nullIf(max(read_rows) OVER (), 0), 2) AS pct_read_rows,
+          written_rows,
+          formatReadableQuantity(written_rows) AS readable_written_rows,
+          round(written_rows * 100.0 / nullIf(max(written_rows) OVER (), 0), 2) AS pct_written_rows,
+          NULL AS peak_memory_usage,
+          '-' AS readable_peak_memory_usage,
+          NULL AS pct_peak_memory_usage
+        FROM system.query_views_log
+        WHERE event_date >= today() - 7
+        ORDER BY event_time DESC
+        LIMIT 1000
+      `,
+    },
+    {
+      since: '23.2',
+      sql: `
+        ${QUERY_COMMENT}
+        SELECT
+          event_time,
+          initial_query_id,
+          view_name,
+          view_uuid,
+          status,
+          exception_code,
+          exception,
+          view_type,
+          round(view_duration_ms, 2) AS view_duration_ms,
+          read_rows,
+          formatReadableQuantity(read_rows) AS readable_read_rows,
+          round(read_rows * 100.0 / nullIf(max(read_rows) OVER (), 0), 2) AS pct_read_rows,
+          written_rows,
+          formatReadableQuantity(written_rows) AS readable_written_rows,
+          round(written_rows * 100.0 / nullIf(max(written_rows) OVER (), 0), 2) AS pct_written_rows,
+          peak_memory_usage,
+          formatReadableSize(peak_memory_usage) AS readable_peak_memory_usage,
+          round(peak_memory_usage * 100.0 / nullIf(max(peak_memory_usage) OVER (), 0), 2) AS pct_peak_memory_usage
+        FROM system.query_views_log
+        WHERE event_date >= today() - 7
+        ORDER BY event_time DESC
+        LIMIT 1000
+      `,
+    },
+  ],
+  columns: [
+    'event_time',
+    'initial_query_id',
+    'view_name',
+    'status',
+    'view_duration_ms',
+    'readable_read_rows',
+    'readable_written_rows',
+    'readable_peak_memory_usage',
+    'exception_code',
+    'exception',
+  ],
+  columnFormats: {
+    event_time: 'related-time',
+    initial_query_id: [
+      'link',
+      { href: '/query?host=[ctx.hostId]&query_id=[initial_query_id]' },
+    ],
+    view_name: 'colored-badge',
+    status: 'colored-badge',
+    view_duration_ms: 'number',
+    readable_read_rows: 'background-bar',
+    readable_written_rows: 'background-bar',
+    readable_peak_memory_usage: 'background-bar',
+    exception_code: 'number',
+    exception: 'text',
+  },
+  relatedCharts: ['query-duration-trend', 'top-query-fingerprints-perf'],
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/queries/thread-analysis.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/queries/thread-analysis.ts
@@ -1,0 +1,51 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const threadAnalysisDeclarative: DeclarativeQueryConfig = {
+  name: 'thread-analysis',
+  description: 'Per-thread query execution statistics',
+  docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_thread_log',
+  defaultView: 'auto',
+  card: { primary: 'thread_name' },
+  optional: true,
+  tableCheck: 'system.query_thread_log',
+  sql: `
+    SELECT
+      query_id,
+      thread_name,
+      thread_id,
+      read_rows,
+      read_bytes,
+      written_rows,
+      written_bytes,
+      memory_usage,
+      peak_memory_usage,
+      formatReadableSize(memory_usage) as readable_memory_usage,
+      formatReadableSize(peak_memory_usage) as readable_peak_memory_usage,
+      formatReadableQuantity(read_rows) as readable_read_rows,
+      formatReadableSize(read_bytes) as readable_read_bytes,
+      event_time
+    FROM system.query_thread_log
+    WHERE event_date >= today() - 1
+    ORDER BY event_time DESC
+    LIMIT 1000
+  `,
+  columns: [
+    'query_id',
+    'thread_name',
+    'thread_id',
+    'readable_memory_usage',
+    'readable_peak_memory_usage',
+    'readable_read_rows',
+    'readable_read_bytes',
+    'event_time',
+  ],
+  columnFormats: {
+    event_time: 'related-time',
+    query_id: ['link', { href: '/query?query_id=[query_id]' }],
+    thread_name: 'colored-badge',
+    readable_memory_usage: 'background-bar',
+    readable_peak_memory_usage: 'background-bar',
+    readable_read_rows: 'background-bar',
+  },
+  relatedCharts: ['thread-utilization', 'parallelization-efficiency'],
+}


### PR DESCRIPTION
## What

Adds declarative catalog entries for 5 of the 13 configs in `queries/`, behind the existing `CHM_CONFIG_SOURCE` flag. Zero runtime change — no existing import is touched.

New files under `apps/dashboard/src/lib/query-config/declarative/catalog/queries/`:
- `common-errors.ts`
- `parallelization.ts`
- `profiler.ts`
- `query-views-log.ts` (versioned SQL, 2 entries)
- `thread-analysis.ts`
- `queries-catalog.test.ts` (11 tests)

## Why

Part of Plan 02 (externalize query configs). Follows the same pattern as the merged `system/`, `tables/`, `explorer/`, and `keeper/` migrations.

## Scope

5 migrated, 8 skipped. Skipped configs and blocking fields:

| Config | Blocking field(s) |
|---|---|
| `expensive-queries` | `rowClassName`, `expandable` (JSX), `columnIcons` |
| `expensive-queries-by-memory` | `expandable` (JSX), `columnIcons` |
| `failed-queries` | `expandable` (JSX), `columnIcons` |
| `slow-queries` | `rowClassName`, `expandable` (JSX), `columnIcons` |
| `history-queries` | `rowClassName`, `expandable`, `filterSchema` (icons + runtime env), `clickhouseSettings` |
| `running-queries` | `rowClassName`, `expandable` (JSX), `filterSchema` (icons), `columnFilters` |
| `query-detail` | `permission` (FeaturePermission) |
| `query-cache` | `docs` is non-URL prose string (schema requires URL) |

## How verified

- [x] `bunx biome check --write apps/dashboard/src/lib/query-config/declarative` → no fixes applied
- [x] `bun test apps/dashboard/src/lib/query-config/declarative/` → 158 pass (11 new)
- [x] `bun run build` → exit 0
- [x] `bun run type-check:test` → exit 0

## Visual

N/A — catalog-only, no UI change.

## Guardrails

- [ ] Auto-merge NOT armed
- [ ] Only new files staged (no edits to existing configs or imports)
- [ ] Works on branch `plan/02-migrate-queries`, not `main`