### PR TITLE
feat(query-config): migrate logs/security/anomaly/merges domains to declarative (behind flag)

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/anomaly/anomaly-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/anomaly/anomaly-catalog.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Snapshot tests for the anomaly/ domain declarative catalog (Plan 02h).
+ *
+ * For each migrated config, assert that loadDeclarativeConfig(declarativeObj)
+ * deep-equals the legacy TS config on its serializable fields.
+ *
+ * Runtime-only fields excluded from comparison:
+ *   rowClassName  — function (row) => string | undefined
+ *   expandable    — function-based ExpandableConfig
+ *   columnIcons   — React component refs
+ *   permission    — FeaturePermission
+ *   filterSchema  — contains Icon refs and dynamic option fns
+ *   clickhouseSettings — execution-time settings
+ *
+ * All 7 configs in anomaly/ are eligible (no runtime-only fields).
+ */
+
+import { loadDeclarativeConfig } from '../../loader'
+import {
+  anomalySummaryDeclarative,
+  diskUsageChangeDeclarative,
+  errorRateBaselineDeclarative,
+  memoryUsageBaselineDeclarative,
+  mergePerformanceBaselineDeclarative,
+  queryCountBaselineDeclarative,
+  replicationLagBaselineDeclarative,
+} from './anomaly-queries'
+import { describe, expect, test } from 'bun:test'
+import {
+  anomalySummaryConfig,
+  diskUsageChangeConfig,
+  errorRateBaselineConfig,
+  memoryUsageBaselineConfig,
+  mergePerformanceBaselineConfig,
+  queryCountBaselineConfig,
+  replicationLagBaselineConfig,
+} from '@/lib/query-config/anomaly/anomaly-queries'
+
+// ---------------------------------------------------------------------------
+// Helper: compare serializable fields between loaded declarative config and
+// legacy TS config. Skips keys absent from the declarative schema.
+// ---------------------------------------------------------------------------
+
+const RUNTIME_ONLY_KEYS = new Set([
+  'rowClassName',
+  'expandable',
+  'columnIcons',
+  'permission',
+  'filterSchema',
+  'columnFilters',
+  'clickhouseSettings',
+  'variants',
+])
+
+function compareSerializable(
+  loaded: ReturnType<typeof loadDeclarativeConfig>,
+  legacy: ReturnType<typeof loadDeclarativeConfig>
+): void {
+  const legacyRec = legacy as unknown as Record<string, unknown>
+  const loadedRec = loaded as unknown as Record<string, unknown>
+
+  for (const key of Object.keys(legacyRec)) {
+    if (RUNTIME_ONLY_KEYS.has(key)) continue
+    expect(loadedRec[key]).toEqual(legacyRec[key])
+  }
+}
+
+// ---------------------------------------------------------------------------
+// query-count-baseline
+// ---------------------------------------------------------------------------
+
+describe('query-count-baseline declarative', () => {
+  test('loads without error', () => {
+    expect(() =>
+      loadDeclarativeConfig(queryCountBaselineDeclarative)
+    ).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(queryCountBaselineDeclarative)
+    compareSerializable(loaded, queryCountBaselineConfig)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// memory-usage-baseline
+// ---------------------------------------------------------------------------
+
+describe('memory-usage-baseline declarative', () => {
+  test('loads without error', () => {
+    expect(() =>
+      loadDeclarativeConfig(memoryUsageBaselineDeclarative)
+    ).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(memoryUsageBaselineDeclarative)
+    compareSerializable(loaded, memoryUsageBaselineConfig)
+  })
+
+  test('versioned sql array length matches', () => {
+    const loaded = loadDeclarativeConfig(memoryUsageBaselineDeclarative)
+    const legacySql = memoryUsageBaselineConfig.sql
+    expect(Array.isArray(loaded.sql)).toBe(Array.isArray(legacySql))
+    if (Array.isArray(loaded.sql) && Array.isArray(legacySql)) {
+      expect(loaded.sql.length).toBe(legacySql.length)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// merge-performance-baseline
+// ---------------------------------------------------------------------------
+
+describe('merge-performance-baseline declarative', () => {
+  test('loads without error', () => {
+    expect(() =>
+      loadDeclarativeConfig(mergePerformanceBaselineDeclarative)
+    ).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(mergePerformanceBaselineDeclarative)
+    compareSerializable(loaded, mergePerformanceBaselineConfig)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// replication-lag-baseline
+// ---------------------------------------------------------------------------
+
+describe('replication-lag-baseline declarative', () => {
+  test('loads without error', () => {
+    expect(() =>
+      loadDeclarativeConfig(replicationLagBaselineDeclarative)
+    ).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(replicationLagBaselineDeclarative)
+    compareSerializable(loaded, replicationLagBaselineConfig)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// error-rate-baseline
+// ---------------------------------------------------------------------------
+
+describe('error-rate-baseline declarative', () => {
+  test('loads without error', () => {
+    expect(() =>
+      loadDeclarativeConfig(errorRateBaselineDeclarative)
+    ).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(errorRateBaselineDeclarative)
+    compareSerializable(loaded, errorRateBaselineConfig)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// disk-usage-change
+// ---------------------------------------------------------------------------
+
+describe('disk-usage-change declarative', () => {
+  test('loads without error', () => {
+    expect(() =>
+      loadDeclarativeConfig(diskUsageChangeDeclarative)
+    ).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(diskUsageChangeDeclarative)
+    compareSerializable(loaded, diskUsageChangeConfig)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// anomaly-summary
+// ---------------------------------------------------------------------------
+
+describe('anomaly-summary declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(anomalySummaryDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(anomalySummaryDeclarative)
+    compareSerializable(loaded, anomalySummaryConfig)
+  })
+})

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/anomaly/anomaly-queries.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/anomaly/anomaly-queries.ts
@@ -1,0 +1,310 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const queryCountBaselineDeclarative: DeclarativeQueryConfig = {
+  name: 'query-count-baseline',
+  description: 'Historical query counts for baseline analysis',
+  sql: `
+    SELECT
+      toUnixTimestamp(toStartOfMinute(event_time)) * 1000 as timestamp,
+      toStartOfMinute(event_time) as time_bucket,
+      count() as query_count
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+      AND event_time >= now() - INTERVAL {baseline_hours: UInt32} HOUR
+    GROUP BY toStartOfMinute(event_time)
+    ORDER BY event_time ASC
+  `,
+  columns: ['timestamp', 'time_bucket', 'query_count'],
+  defaultParams: {
+    baseline_hours: 24,
+  },
+  optional: false,
+}
+
+export const memoryUsageBaselineDeclarative: DeclarativeQueryConfig = {
+  name: 'memory-usage-baseline',
+  description: 'Historical memory usage for baseline analysis',
+  sql: [
+    {
+      since: '23.8',
+      description: 'Memory usage without query_cache_usage',
+      sql: `
+        SELECT
+          toUnixTimestamp(toStartOfFiveMinutes(event_time)) * 1000 as timestamp,
+          toStartOfFiveMinutes(event_time) as time_bucket,
+          avg(memory_usage) as avg_memory,
+          max(memory_usage) as max_memory,
+          quantile(0.95)(memory_usage) as p95_memory,
+          quantile(0.99)(memory_usage) as p99_memory
+        FROM system.query_log
+        WHERE type = 'QueryFinish'
+          AND event_time >= now() - INTERVAL {baseline_hours: UInt32} HOUR
+        GROUP BY toStartOfFiveMinutes(event_time)
+        ORDER BY event_time ASC
+      `,
+    },
+    {
+      since: '24.1',
+      description: 'Added query_cache_usage column',
+      sql: `
+        SELECT
+          toUnixTimestamp(toStartOfFiveMinutes(event_time)) * 1000 as timestamp,
+          toStartOfFiveMinutes(event_time) as time_bucket,
+          avg(memory_usage) as avg_memory,
+          max(memory_usage) as max_memory,
+          quantile(0.95)(memory_usage) as p95_memory,
+          quantile(0.99)(memory_usage) as p99_memory,
+          avg(CASE WHEN query_cache_usage = 'hit' THEN memory_usage ELSE 0 END) as avg_cache_hit_memory
+        FROM system.query_log
+        WHERE type = 'QueryFinish'
+          AND event_time >= now() - INTERVAL {baseline_hours: UInt32} HOUR
+        GROUP BY toStartOfFiveMinutes(event_time)
+        ORDER BY event_time ASC
+      `,
+    },
+  ],
+  columns: [
+    'timestamp',
+    'time_bucket',
+    'avg_memory',
+    'max_memory',
+    'p95_memory',
+    'p99_memory',
+  ],
+  defaultParams: {
+    baseline_hours: 24,
+  },
+  columnFormats: {
+    avg_memory: 'number-short',
+    max_memory: 'number-short',
+    p95_memory: 'number-short',
+    p99_memory: 'number-short',
+  },
+  optional: false,
+}
+
+export const mergePerformanceBaselineDeclarative: DeclarativeQueryConfig = {
+  name: 'merge-performance-baseline',
+  description: 'Historical merge performance for baseline analysis',
+  sql: `
+    SELECT
+      toUnixTimestamp(toStartOfFiveMinutes(event_time)) * 1000 as timestamp,
+      toStartOfFiveMinutes(event_time) as time_bucket,
+      avg(elapsed) as avg_elapsed,
+      max(elapsed) as max_elapsed,
+      quantile(0.95)(elapsed) as p95_elapsed,
+      count() as merge_count
+    FROM system.part_log
+    WHERE event_type = 'MergeParts'
+      AND event_time >= now() - INTERVAL {baseline_hours: UInt32} HOUR
+    GROUP BY toStartOfFiveMinutes(event_time)
+    ORDER BY event_time ASC
+  `,
+  columns: [
+    'timestamp',
+    'time_bucket',
+    'avg_elapsed',
+    'max_elapsed',
+    'p95_elapsed',
+    'merge_count',
+  ],
+  tableCheck: 'system.part_log',
+  optional: true,
+  defaultParams: {
+    baseline_hours: 24,
+  },
+  columnFormats: {
+    avg_elapsed: 'duration',
+    max_elapsed: 'duration',
+    p95_elapsed: 'duration',
+  },
+}
+
+export const replicationLagBaselineDeclarative: DeclarativeQueryConfig = {
+  name: 'replication-lag-baseline',
+  description: 'Historical replication lag for baseline analysis',
+  sql: `
+    SELECT
+      toUnixTimestamp(toStartOfFiveMinutes(event_time)) * 1000 as timestamp,
+      toStartOfFiveMinutes(event_time) as time_bucket,
+      avg(replication_lag) as avg_lag,
+      max(replication_lag) as max_lag,
+      quantile(0.95)(replication_lag) as p95_lag,
+      count() as queue_entries
+    FROM system.replication_queue
+    WHERE event_time >= now() - INTERVAL {baseline_hours: UInt32} HOUR
+    GROUP BY toStartOfFiveMinutes(event_time)
+    ORDER BY event_time ASC
+  `,
+  columns: [
+    'timestamp',
+    'time_bucket',
+    'avg_lag',
+    'max_lag',
+    'p95_lag',
+    'queue_entries',
+  ],
+  tableCheck: 'system.replication_queue',
+  optional: true,
+  defaultParams: {
+    baseline_hours: 24,
+  },
+  columnFormats: {
+    avg_lag: 'duration',
+    max_lag: 'duration',
+    p95_lag: 'duration',
+  },
+}
+
+export const errorRateBaselineDeclarative: DeclarativeQueryConfig = {
+  name: 'error-rate-baseline',
+  description: 'Historical error rates for baseline analysis',
+  sql: `
+    SELECT
+      toUnixTimestamp(toStartOfFiveMinutes(event_time)) * 1000 as timestamp,
+      toStartOfFiveMinutes(event_time) as time_bucket,
+      countIf(type = 'ExceptionBeforeStart' OR type = 'ExceptionWhileProcessing') * 100.0 / count() as error_rate,
+      countIf(type = 'ExceptionBeforeStart') * 100.0 / count() as error_before_start_rate,
+      countIf(type = 'ExceptionWhileProcessing') * 100.0 / count() as error_while_processing_rate,
+      count() as total_queries
+    FROM system.query_log
+    WHERE type IN ('QueryFinish', 'ExceptionBeforeStart', 'ExceptionWhileProcessing')
+      AND event_time >= now() - INTERVAL {baseline_hours: UInt32} HOUR
+    GROUP BY toStartOfFiveMinutes(event_time)
+    ORDER BY event_time ASC
+  `,
+  columns: [
+    'timestamp',
+    'time_bucket',
+    'error_rate',
+    'error_before_start_rate',
+    'error_while_processing_rate',
+    'total_queries',
+  ],
+  defaultParams: {
+    baseline_hours: 24,
+  },
+  columnFormats: {
+    error_rate: 'number',
+    error_before_start_rate: 'number',
+    error_while_processing_rate: 'number',
+  },
+  optional: false,
+}
+
+export const diskUsageChangeDeclarative: DeclarativeQueryConfig = {
+  name: 'disk-usage-change',
+  description: 'Disk usage changes over time',
+  sql: `
+    SELECT
+      toUnixTimestamp(modification_time) * 1000 as timestamp,
+      disk_name,
+      database,
+      table,
+      sum(bytes_on_disk) as total_bytes,
+      formatReadableSize(sum(bytes_on_disk)) as readable_size,
+      sum(rows) as total_rows
+    FROM system.parts
+    WHERE active
+      AND modification_time >= now() - INTERVAL {baseline_hours: UInt32} HOUR
+    GROUP BY disk_name, database, table, modification_time
+    ORDER BY modification_time ASC, total_bytes DESC
+    LIMIT 10000
+  `,
+  columns: [
+    'timestamp',
+    'disk_name',
+    'database',
+    'table',
+    'total_bytes',
+    'readable_size',
+    'total_rows',
+  ],
+  defaultParams: {
+    baseline_hours: 24,
+  },
+  columnFormats: {
+    total_bytes: 'number-short',
+    readable_size: 'text',
+    total_rows: 'number',
+  },
+  optional: false,
+}
+
+export const anomalySummaryDeclarative: DeclarativeQueryConfig = {
+  name: 'anomaly-summary',
+  description: 'Quick overview of potential anomalies',
+  sql: `
+    WITH
+      -- Current query count (last 5 minutes)
+      current_queries AS (
+        SELECT count() as cnt
+        FROM system.query_log
+        WHERE type = 'QueryFinish'
+          AND event_time >= now() - INTERVAL 5 MINUTE
+      ),
+      -- Baseline query count (previous 5 minutes)
+      baseline_queries AS (
+        SELECT count() as cnt
+        FROM system.query_log
+        WHERE type = 'QueryFinish'
+          AND event_time >= now() - INTERVAL 10 MINUTE
+          AND event_time < now() - INTERVAL 5 MINUTE
+      ),
+      -- Current memory usage
+      current_memory AS (
+        SELECT avg(memory_usage) as avg_mem
+        FROM system.query_log
+        WHERE type = 'QueryFinish'
+          AND event_time >= now() - INTERVAL 5 MINUTE
+      ),
+      -- Baseline memory usage
+      baseline_memory AS (
+        SELECT avg(memory_usage) as avg_mem
+        FROM system.query_log
+        WHERE type = 'QueryFinish'
+          AND event_time >= now() - INTERVAL 10 MINUTE
+          AND event_time < now() - INTERVAL 5 MINUTE
+      )
+    SELECT
+      'query_spike' as anomaly_type,
+      toFloat64(current_queries.cnt) as current_value,
+      toFloat64(baseline_queries.cnt) as baseline_value,
+      ((toFloat64(current_queries.cnt) - toFloat64(baseline_queries.cnt)) / toFloat64(baseline_queries.cnt) * 100) as deviation_percent,
+      CASE
+        WHEN baseline_queries.cnt > 0 AND ((toFloat64(current_queries.cnt) - toFloat64(baseline_queries.cnt)) / toFloat64(baseline_queries.cnt)) > 1 THEN 'critical'
+        WHEN baseline_queries.cnt > 0 AND ((toFloat64(current_queries.cnt) - toFloat64(baseline_queries.cnt)) / toFloat64(baseline_queries.cnt)) > 0.5 THEN 'high'
+        WHEN baseline_queries.cnt > 0 AND ((toFloat64(current_queries.cnt) - toFloat64(baseline_queries.cnt)) / toFloat64(baseline_queries.cnt)) > 0.25 THEN 'medium'
+        ELSE 'normal'
+      END as severity
+    FROM current_queries, baseline_queries
+
+    UNION ALL
+
+    SELECT
+      'memory_anomaly' as anomaly_type,
+      current_memory.avg_mem as current_value,
+      baseline_memory.avg_mem as baseline_value,
+      ((current_memory.avg_mem - baseline_memory.avg_mem) / NULLIF(baseline_memory.avg_mem, 0) * 100) as deviation_percent,
+      CASE
+        WHEN baseline_memory.avg_mem > 0 AND ((current_memory.avg_mem - baseline_memory.avg_mem) / baseline_memory.avg_mem) > 1 THEN 'critical'
+        WHEN baseline_memory.avg_mem > 0 AND ((current_memory.avg_mem - baseline_memory.avg_mem) / baseline_memory.avg_mem) > 0.5 THEN 'high'
+        WHEN baseline_memory.avg_mem > 0 AND ((current_memory.avg_mem - baseline_memory.avg_mem) / baseline_memory.avg_mem) > 0.25 THEN 'medium'
+        ELSE 'normal'
+      END as severity
+    FROM current_memory, baseline_memory
+  `,
+  columns: [
+    'anomaly_type',
+    'current_value',
+    'baseline_value',
+    'deviation_percent',
+    'severity',
+  ],
+  columnFormats: {
+    current_value: 'number',
+    baseline_value: 'number',
+    deviation_percent: 'number',
+  },
+  optional: false,
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/logs/crashes.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/logs/crashes.ts
@@ -1,0 +1,50 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const crashLogDeclarative: DeclarativeQueryConfig = {
+  name: 'crash-log',
+  description: 'Server crash history and details',
+  docs: 'https://clickhouse.com/docs/en/operations/system-tables/crash_log',
+  optional: true,
+  tableCheck: 'system.crash_log',
+  sql: `
+    SELECT
+      event_time,
+      signal,
+      thread_id,
+      query_id,
+      arrayStringConcat(trace, '\\n') as trace_summary,
+      version,
+      revision
+    FROM system.crash_log
+    ORDER BY event_time DESC
+    LIMIT 100
+  `,
+  columns: [
+    'event_time',
+    'signal',
+    'thread_id',
+    'query_id',
+    'version',
+    'revision',
+    'trace_summary',
+  ],
+  columnFormats: {
+    event_time: 'related-time',
+    signal: 'colored-badge',
+    thread_id: 'number',
+    query_id: [
+      'link',
+      {
+        href: '/query?query_id=[query_id]&host=[ctx.hostId]',
+        className: 'max-w-24 truncate',
+      },
+    ],
+    trace_summary: [
+      'code-dialog',
+      { max_truncate: 40, dialog_title: 'Crash Trace' },
+    ],
+    version: 'text',
+    revision: 'number',
+  },
+  relatedCharts: ['crash-frequency'],
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/logs/logs-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/logs/logs-catalog.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Snapshot tests for the logs/ domain declarative catalog (Plan 02h).
+ *
+ * For each migrated config, assert that loadDeclarativeConfig(declarativeObj)
+ * deep-equals the legacy TS config on its serializable fields.
+ *
+ * Runtime-only fields excluded from comparison:
+ *   rowClassName  — function (row) => string | undefined
+ *   expandable    — function-based ExpandableConfig
+ *   columnIcons   — React component refs
+ *   permission    — FeaturePermission
+ *   filterSchema  — contains Icon refs and dynamic option fns
+ *   clickhouseSettings — execution-time settings
+ *
+ * Skipped configs (runtime-only fields that the schema cannot express):
+ *   stackTracesConfig — clickhouseSettings (allow_introspection_functions)
+ */
+
+import { loadDeclarativeConfig } from '../../loader'
+import { crashLogDeclarative } from './crashes'
+import { textLogDeclarative } from './text-log'
+import { describe, expect, test } from 'bun:test'
+import { crashLogConfig } from '@/lib/query-config/logs/crashes'
+import { textLogConfig } from '@/lib/query-config/logs/text-log'
+
+// ---------------------------------------------------------------------------
+// Helper: compare serializable fields between loaded declarative config and
+// legacy TS config. Skips keys absent from the declarative schema.
+// ---------------------------------------------------------------------------
+
+const RUNTIME_ONLY_KEYS = new Set([
+  'rowClassName',
+  'expandable',
+  'columnIcons',
+  'permission',
+  'filterSchema',
+  'columnFilters',
+  'clickhouseSettings',
+  'variants',
+])
+
+function compareSerializable(
+  loaded: ReturnType<typeof loadDeclarativeConfig>,
+  legacy: ReturnType<typeof loadDeclarativeConfig>
+): void {
+  const legacyRec = legacy as unknown as Record<string, unknown>
+  const loadedRec = loaded as unknown as Record<string, unknown>
+
+  for (const key of Object.keys(legacyRec)) {
+    if (RUNTIME_ONLY_KEYS.has(key)) continue
+    expect(loadedRec[key]).toEqual(legacyRec[key])
+  }
+}
+
+// ---------------------------------------------------------------------------
+// crashes
+// ---------------------------------------------------------------------------
+
+describe('crash-log declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(crashLogDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(crashLogDeclarative)
+    compareSerializable(loaded, crashLogConfig)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// text-log
+// ---------------------------------------------------------------------------
+
+describe('text-log declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(textLogDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(textLogDeclarative)
+    compareSerializable(loaded, textLogConfig)
+  })
+
+  test('filterParamPresets length matches legacy', () => {
+    const loaded = loadDeclarativeConfig(textLogDeclarative)
+    expect(loaded.filterParamPresets?.length).toBe(
+      textLogConfig.filterParamPresets?.length
+    )
+  })
+})

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/logs/text-log.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/logs/text-log.ts
@@ -1,0 +1,56 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const textLogDeclarative: DeclarativeQueryConfig = {
+  name: 'text-log',
+  description: 'Server log messages for debugging',
+  optional: true,
+  tableCheck: 'system.text_log',
+  docs: 'https://clickhouse.com/docs/en/operations/system-tables/text_log',
+  sql: `
+    SELECT
+      event_time,
+      level,
+      query_id,
+      thread_id,
+      message,
+      logger_name,
+      source_file,
+      source_line
+    FROM system.text_log
+    WHERE event_date >= today()
+    ORDER BY event_time DESC
+    LIMIT 1000
+  `,
+  columns: [
+    'event_time',
+    'level',
+    'query_id',
+    'thread_id',
+    'message',
+    'logger_name',
+    'source_file',
+    'source_line',
+  ],
+  columnFormats: {
+    event_time: 'related-time',
+    level: 'colored-badge',
+    query_id: [
+      'link',
+      {
+        href: '/query?query_id=[query_id]&host=[ctx.hostId]',
+        className: 'max-w-24 truncate',
+      },
+    ],
+    thread_id: 'number',
+    message: ['code-dialog', { max_truncate: 80, dialog_title: 'Log Message' }],
+    logger_name: 'colored-badge',
+    source_file: 'text',
+    source_line: 'number',
+  },
+  filterParamPresets: [
+    { name: 'Errors Only', key: 'level', value: 'Error' },
+    { name: 'Warnings+', key: 'level', value: 'Warning' },
+    { name: 'Debug', key: 'level', value: 'Debug' },
+  ],
+  relatedCharts: ['log-level-distribution', 'error-rate-over-time'],
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/merges/merges-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/merges/merges-catalog.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Snapshot tests for the merges/ domain declarative catalog (Plan 02h).
+ *
+ * For each migrated config, assert that loadDeclarativeConfig(declarativeObj)
+ * deep-equals the legacy TS config on its serializable fields.
+ *
+ * Runtime-only fields excluded from comparison:
+ *   rowClassName  — function (row) => string | undefined
+ *   expandable    — function-based ExpandableConfig
+ *   columnIcons   — React component refs
+ *   permission    — FeaturePermission
+ *   filterSchema  — contains Icon refs and dynamic option fns
+ *   clickhouseSettings — execution-time settings
+ *
+ * Skipped configs (runtime-only fields or non-serializable values):
+ *   mergePerformanceConfig — docs uses PART_LOG (non-URL string, fails url() validation)
+ *   mutationsConfig        — rowClassName function
+ */
+
+import { loadDeclarativeConfig } from '../../loader'
+import { mergesDeclarative } from './merges'
+import { describe, expect, test } from 'bun:test'
+import { mergesConfig } from '@/lib/query-config/merges/merges'
+
+// ---------------------------------------------------------------------------
+// Helper: compare serializable fields between loaded declarative config and
+// legacy TS config. Skips keys absent from the declarative schema.
+// ---------------------------------------------------------------------------
+
+const RUNTIME_ONLY_KEYS = new Set([
+  'rowClassName',
+  'expandable',
+  'columnIcons',
+  'permission',
+  'filterSchema',
+  'columnFilters',
+  'clickhouseSettings',
+  'variants',
+])
+
+function compareSerializable(
+  loaded: ReturnType<typeof loadDeclarativeConfig>,
+  legacy: ReturnType<typeof loadDeclarativeConfig>
+): void {
+  const legacyRec = legacy as unknown as Record<string, unknown>
+  const loadedRec = loaded as unknown as Record<string, unknown>
+
+  for (const key of Object.keys(legacyRec)) {
+    if (RUNTIME_ONLY_KEYS.has(key)) continue
+    expect(loadedRec[key]).toEqual(legacyRec[key])
+  }
+}
+
+// ---------------------------------------------------------------------------
+// merges
+// ---------------------------------------------------------------------------
+
+describe('merges declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(mergesDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(mergesDeclarative)
+    compareSerializable(loaded, mergesConfig)
+  })
+
+  test('refreshInterval matches legacy', () => {
+    const loaded = loadDeclarativeConfig(mergesDeclarative)
+    expect(loaded.refreshInterval).toBe(mergesConfig.refreshInterval)
+  })
+})

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/merges/merges.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/merges/merges.ts
@@ -1,0 +1,65 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const mergesDeclarative: DeclarativeQueryConfig = {
+  name: 'merges',
+  defaultView: 'auto',
+  card: { primary: 'table', badges: ['merge_type', 'is_mutation'] },
+  refreshInterval: 30000,
+  description:
+    'Merges and part mutations currently in process for tables in the MergeTree family',
+  sql: `
+      SELECT *,
+        database || '.' || table as table,
+        round(100 * num_parts / max(num_parts) OVER ()) as pct_num_parts,
+        round(progress * 100, 1) as pct_progress,
+        (cast(pct_progress, 'String') || '%') as readable_progress,
+        round(100 * rows_read / max(rows_read) OVER ()) as pct_rows_read,
+        formatReadableQuantity(rows_read) as readable_rows_read,
+        round(100 * rows_written / max(rows_written) OVER ()) as pct_rows_written,
+        formatReadableQuantity(rows_written) as readable_rows_written,
+        round(100 * memory_usage / max(memory_usage) OVER ()) as pct_memory_usage,
+        formatReadableSize(memory_usage) as readable_memory_usage
+      FROM system.merges
+      ORDER BY progress DESC
+    `,
+  columns: [
+    'table',
+    'partition_id',
+    'elapsed',
+    'readable_progress',
+    'num_parts',
+    'readable_rows_read',
+    'readable_rows_written',
+    'readable_memory_usage',
+    'is_mutation',
+    'merge_type',
+    'merge_algorithm',
+  ],
+  columnFormats: {
+    table: 'colored-badge',
+    elapsed: 'duration',
+    is_mutation: 'boolean',
+    num_parts: 'background-bar',
+    readable_progress: 'background-bar',
+    readable_memory_usage: 'background-bar',
+    readable_rows_read: 'background-bar',
+    readable_rows_written: 'background-bar',
+  },
+  relatedCharts: [
+    [
+      'summary-used-by-merges',
+      {
+        title: 'Merge Summary',
+      },
+    ],
+    [
+      'merge-count',
+      {
+        title: 'Merge/Mutations',
+        interval: 'toStartOfDay',
+        lastHours: 336,
+      },
+    ],
+  ],
+  optional: false,
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/security/login-attempts.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/security/login-attempts.ts
@@ -1,0 +1,46 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const loginAttemptsDeclarative: DeclarativeQueryConfig = {
+  name: 'login-attempts',
+  description: 'Login success and failure tracking',
+  optional: true,
+  tableCheck: 'system.session_log',
+  docs: 'https://clickhouse.com/docs/en/operations/system-tables/session_log',
+  sql: `
+    SELECT
+      event_time,
+      user,
+      auth_type,
+      client_hostname,
+      client_address,
+      type,
+      interface,
+      failure_reason
+    FROM system.session_log
+    WHERE type IN ('LoginSuccess', 'LoginFailure')
+    ORDER BY event_time DESC
+    LIMIT 1000
+  `,
+  columns: [
+    'event_time',
+    'user',
+    'type',
+    'auth_type',
+    'client_address',
+    'failure_reason',
+    'interface',
+  ],
+  columnFormats: {
+    event_time: 'related-time',
+    user: 'colored-badge',
+    type: 'colored-badge',
+    auth_type: 'colored-badge',
+    failure_reason: 'text',
+    interface: 'colored-badge',
+  },
+  filterParamPresets: [
+    { name: 'Failed Only', key: 'type', value: 'LoginFailure' },
+    { name: 'Success Only', key: 'type', value: 'LoginSuccess' },
+  ],
+  relatedCharts: ['login-success-rate', 'failed-login-by-user'],
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/security/security-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/security/security-catalog.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Snapshot tests for the security/ domain declarative catalog (Plan 02h).
+ *
+ * For each migrated config, assert that loadDeclarativeConfig(declarativeObj)
+ * deep-equals the legacy TS config on its serializable fields.
+ *
+ * Runtime-only fields excluded from comparison:
+ *   rowClassName  — function (row) => string | undefined
+ *   expandable    — function-based ExpandableConfig
+ *   columnIcons   — React component refs
+ *   permission    — FeaturePermission
+ *   filterSchema  — contains Icon refs and dynamic option fns
+ *   clickhouseSettings — execution-time settings
+ *
+ * All 2 configs in security/ are eligible (no runtime-only fields).
+ */
+
+import { loadDeclarativeConfig } from '../../loader'
+import { loginAttemptsDeclarative } from './login-attempts'
+import { sessionsDeclarative } from './sessions'
+import { describe, expect, test } from 'bun:test'
+import { loginAttemptsConfig } from '@/lib/query-config/security/login-attempts'
+import { sessionsConfig } from '@/lib/query-config/security/sessions'
+
+// ---------------------------------------------------------------------------
+// Helper: compare serializable fields between loaded declarative config and
+// legacy TS config. Skips keys absent from the declarative schema.
+// ---------------------------------------------------------------------------
+
+const RUNTIME_ONLY_KEYS = new Set([
+  'rowClassName',
+  'expandable',
+  'columnIcons',
+  'permission',
+  'filterSchema',
+  'columnFilters',
+  'clickhouseSettings',
+  'variants',
+])
+
+function compareSerializable(
+  loaded: ReturnType<typeof loadDeclarativeConfig>,
+  legacy: ReturnType<typeof loadDeclarativeConfig>
+): void {
+  const legacyRec = legacy as unknown as Record<string, unknown>
+  const loadedRec = loaded as unknown as Record<string, unknown>
+
+  for (const key of Object.keys(legacyRec)) {
+    if (RUNTIME_ONLY_KEYS.has(key)) continue
+    expect(loadedRec[key]).toEqual(legacyRec[key])
+  }
+}
+
+// ---------------------------------------------------------------------------
+// login-attempts
+// ---------------------------------------------------------------------------
+
+describe('login-attempts declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(loginAttemptsDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(loginAttemptsDeclarative)
+    compareSerializable(loaded, loginAttemptsConfig)
+  })
+
+  test('filterParamPresets length matches legacy', () => {
+    const loaded = loadDeclarativeConfig(loginAttemptsDeclarative)
+    expect(loaded.filterParamPresets?.length).toBe(
+      loginAttemptsConfig.filterParamPresets?.length
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sessions
+// ---------------------------------------------------------------------------
+
+describe('sessions declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(sessionsDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(sessionsDeclarative)
+    compareSerializable(loaded, sessionsConfig)
+  })
+})

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/security/sessions.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/security/sessions.ts
@@ -1,0 +1,46 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const sessionsDeclarative: DeclarativeQueryConfig = {
+  name: 'sessions',
+  description: 'Active and historical user sessions',
+  optional: true,
+  tableCheck: 'system.session_log',
+  docs: 'https://clickhouse.com/docs/en/operations/system-tables/session_log',
+  sql: `
+    SELECT
+      session_id,
+      user,
+      auth_type,
+      client_hostname,
+      client_address,
+      event_time,
+      type,
+      interface,
+      profiles,
+      roles
+    FROM system.session_log
+    ORDER BY event_time DESC
+    LIMIT 1000
+  `,
+  columns: [
+    'session_id',
+    'user',
+    'auth_type',
+    'client_hostname',
+    'client_address',
+    'event_time',
+    'type',
+    'interface',
+    'profiles',
+    'roles',
+  ],
+  columnFormats: {
+    event_time: 'related-time',
+    user: 'colored-badge',
+    type: 'colored-badge',
+    auth_type: 'colored-badge',
+    client_address: 'text',
+    interface: 'colored-badge',
+  },
+  relatedCharts: ['login-success-rate', 'active-sessions-count'],
+}


### PR DESCRIPTION
## What

Adds declarative catalog entries for 4 small domains: `logs/`, `security/`, `anomaly/`, `merges/`. Part of Plan 02h (externalize query configs).

## Why

Progresses the declarative catalog toward full coverage, enabling community contributions without TypeScript knowledge, all behind the `CHM_CONFIG_SOURCE` flag — zero runtime change.

## Scope

| Domain | Migrated | Skipped | Blocking field |
|--------|----------|---------|----------------|
| `logs/` | 2 (crash-log, text-log) | 1 (stack-traces) | `clickhouseSettings` |
| `security/` | 2 (login-attempts, sessions) | — | — |
| `anomaly/` | 7 (all) | — | — |
| `merges/` | 1 (merges) | 2 (merge-performance, mutations) | `docs` = non-URL string (PART_LOG); `rowClassName` |

**Total: 12 migrated, 3 skipped.**

New files (10):
- `declarative/catalog/logs/crashes.ts`
- `declarative/catalog/logs/text-log.ts`
- `declarative/catalog/logs/logs-catalog.test.ts`
- `declarative/catalog/security/login-attempts.ts`
- `declarative/catalog/security/sessions.ts`
- `declarative/catalog/security/security-catalog.test.ts`
- `declarative/catalog/anomaly/anomaly-queries.ts`
- `declarative/catalog/anomaly/anomaly-catalog.test.ts`
- `declarative/catalog/merges/merges.ts`
- `declarative/catalog/merges/merges-catalog.test.ts`

## How verified

- [x] Gate 1: `bunx biome check --write apps/dashboard/src/lib/query-config/declarative` → No fixes applied
- [x] Gate 2: `bun test apps/dashboard/src/lib/query-config/declarative/` → 175 pass, 0 fail (10 files)
- [x] Gate 3: `cd apps/dashboard && bun run build` → exit 0
- [x] Gate 4: `cd apps/dashboard && bun run type-check:test` → exit 0

## Visual

N/A — catalog-only change, no UI surface modified.

## Guardrails

- [ ] auto-merge NOT armed
- All new files only; no existing files modified
- No runtime path changed; flag-gated (`CHM_CONFIG_SOURCE=declarative`)