### PR TITLE
feat(rbac): add RBAC scaffold (community all-access, fail-open)

### DIFF
--- a/apps/dashboard/src/lib/rbac/index.ts
+++ b/apps/dashboard/src/lib/rbac/index.ts
@@ -1,0 +1,3 @@
+export type { Permission, Role } from './rbac'
+
+export { COMMUNITY_ROLE, canPerform, hasPermission } from './rbac'

--- a/apps/dashboard/src/lib/rbac/rbac.test.ts
+++ b/apps/dashboard/src/lib/rbac/rbac.test.ts
@@ -1,0 +1,184 @@
+// Tests for the RBAC scaffold.
+// Key invariant: community / RBAC-disabled = all-access (fail-open to free).
+// RBAC enforcement only activates under enterprise edition with rbac feature on.
+
+import {
+  COMMUNITY_ROLE,
+  canPerform,
+  hasPermission,
+  type Permission,
+  type Role,
+} from './rbac'
+import { describe, expect, test } from 'bun:test'
+
+// ---------------------------------------------------------------------------
+// hasPermission
+// ---------------------------------------------------------------------------
+describe('hasPermission', () => {
+  test("wildcard '*' permissions grant everything", () => {
+    const permissions: Permission[] = [
+      'query:read',
+      'query:kill',
+      'config:write',
+      'cluster:admin',
+      'table:read',
+      'table:write',
+      'metric:read',
+      'insight:write',
+    ]
+    for (const p of permissions) {
+      expect(hasPermission(COMMUNITY_ROLE, p)).toBe(true)
+    }
+  })
+
+  test('explicit allow-list includes a granted permission', () => {
+    const role: Role = {
+      id: 'viewer',
+      name: 'Viewer',
+      permissions: ['query:read', 'metric:read', 'table:read'],
+    }
+    expect(hasPermission(role, 'query:read')).toBe(true)
+    expect(hasPermission(role, 'metric:read')).toBe(true)
+    expect(hasPermission(role, 'table:read')).toBe(true)
+  })
+
+  test('explicit allow-list excludes a missing permission', () => {
+    const role: Role = {
+      id: 'viewer',
+      name: 'Viewer',
+      permissions: ['query:read', 'metric:read'],
+    }
+    expect(hasPermission(role, 'query:kill')).toBe(false)
+    expect(hasPermission(role, 'config:write')).toBe(false)
+    expect(hasPermission(role, 'cluster:admin')).toBe(false)
+  })
+
+  test('empty permission list denies everything', () => {
+    const role: Role = {
+      id: 'empty',
+      name: 'Empty',
+      permissions: [],
+    }
+    expect(hasPermission(role, 'query:read')).toBe(false)
+    expect(hasPermission(role, 'cluster:admin')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// canPerform — community / RBAC-disabled (fail-open to free)
+// ---------------------------------------------------------------------------
+describe('canPerform — community edition (rbac disabled)', () => {
+  const communityEnv = { CHM_EDITION: 'community' }
+
+  test('fail-open: default env → cluster:admin allowed', () => {
+    // The most critical assertion: no env = community = all-access.
+    expect(canPerform('cluster:admin')).toBe(true)
+  })
+
+  test('fail-open: community edition → all permissions allowed', () => {
+    const permissions: Permission[] = [
+      'query:read',
+      'query:kill',
+      'config:write',
+      'cluster:admin',
+      'table:read',
+      'table:write',
+      'metric:read',
+      'insight:write',
+    ]
+    for (const p of permissions) {
+      expect(canPerform(p, { runtimeEnv: communityEnv })).toBe(true)
+    }
+  })
+
+  test('fail-open: community edition + restrictive role → still allowed', () => {
+    // Even if a restrictive role is provided, community edition is all-access.
+    const restrictiveRole: Role = {
+      id: 'readonly',
+      name: 'Read Only',
+      permissions: ['query:read'],
+    }
+    expect(
+      canPerform('cluster:admin', {
+        role: restrictiveRole,
+        runtimeEnv: communityEnv,
+      })
+    ).toBe(true)
+    expect(
+      canPerform('config:write', {
+        role: restrictiveRole,
+        runtimeEnv: communityEnv,
+      })
+    ).toBe(true)
+  })
+
+  test('fail-open: junk/unset CHM_EDITION → all-access', () => {
+    expect(canPerform('cluster:admin', { runtimeEnv: {} })).toBe(true)
+    expect(
+      canPerform('cluster:admin', { runtimeEnv: { CHM_EDITION: 'junk' } })
+    ).toBe(true)
+    expect(
+      canPerform('cluster:admin', { runtimeEnv: { CHM_EDITION: '' } })
+    ).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// canPerform — enterprise edition with rbac enabled
+// ---------------------------------------------------------------------------
+describe('canPerform — enterprise edition (rbac enabled)', () => {
+  const enterpriseEnv = { CHM_EDITION: 'enterprise' }
+
+  test('COMMUNITY_ROLE (wildcard) grants everything under enterprise', () => {
+    expect(canPerform('cluster:admin', { runtimeEnv: enterpriseEnv })).toBe(
+      true
+    )
+    expect(canPerform('config:write', { runtimeEnv: enterpriseEnv })).toBe(true)
+  })
+
+  test('restrictive role denies a missing permission under enterprise', () => {
+    const viewerRole: Role = {
+      id: 'viewer',
+      name: 'Viewer',
+      permissions: ['query:read', 'metric:read', 'table:read'],
+    }
+    expect(
+      canPerform('cluster:admin', {
+        role: viewerRole,
+        runtimeEnv: enterpriseEnv,
+      })
+    ).toBe(false)
+    expect(
+      canPerform('config:write', {
+        role: viewerRole,
+        runtimeEnv: enterpriseEnv,
+      })
+    ).toBe(false)
+    expect(
+      canPerform('query:kill', {
+        role: viewerRole,
+        runtimeEnv: enterpriseEnv,
+      })
+    ).toBe(false)
+  })
+
+  test('restrictive role grants a listed permission under enterprise', () => {
+    const viewerRole: Role = {
+      id: 'viewer',
+      name: 'Viewer',
+      permissions: ['query:read', 'metric:read', 'table:read'],
+    }
+    expect(
+      canPerform('query:read', {
+        role: viewerRole,
+        runtimeEnv: enterpriseEnv,
+      })
+    ).toBe(true)
+    expect(
+      canPerform('metric:read', {
+        role: viewerRole,
+        runtimeEnv: enterpriseEnv,
+      })
+    ).toBe(true)
+  })
+})

--- a/apps/dashboard/src/lib/rbac/rbac.ts
+++ b/apps/dashboard/src/lib/rbac/rbac.ts
@@ -1,0 +1,103 @@
+// RBAC scaffold — community is single-operator all-access; enforcement is
+// enterprise-gated; fail-open to free (any ambiguity → allow).
+//
+// Community edition never gates anything. RBAC enforcement only activates
+// when edition=enterprise AND the 'rbac' feature flag is enabled. Outside
+// that narrow condition every hasPermission / canPerform call returns true.
+
+import { isEnabled } from '@/lib/edition'
+
+// ---------------------------------------------------------------------------
+// Permission union
+// ---------------------------------------------------------------------------
+// Coarse permission set that mirrors the app's actual action surface.
+// Expand as needed; the guard logic is O(1) regardless of set size.
+
+export type Permission =
+  | 'query:read' // View queries, query log, running queries
+  | 'query:kill' // Kill running queries
+  | 'config:write' // Modify settings / connection config
+  | 'cluster:admin' // Cluster-level operations (scaling, topology changes)
+  | 'table:read' // Browse tables, schemas, data explorer
+  | 'table:write' // DDL / DML modifications
+  | 'metric:read' // View metrics, charts, health panels
+  | 'insight:write' // Create / dismiss AI insights
+
+// ---------------------------------------------------------------------------
+// Role type
+// ---------------------------------------------------------------------------
+
+export type Role = {
+  id: string
+  name: string
+  /** '*' grants all permissions; an explicit array is an allow-list. */
+  permissions: readonly Permission[] | '*'
+}
+
+// ---------------------------------------------------------------------------
+// Built-in roles
+// ---------------------------------------------------------------------------
+
+/**
+ * The community single-operator role.
+ *
+ * Community (OSS) installs are single-operator: one person manages the whole
+ * ClickHouse cluster, so every permission is implicitly granted. This role is
+ * the default; it is also what enterprise resolves to when no role is provided,
+ * preserving the fail-open guarantee.
+ */
+export const COMMUNITY_ROLE: Role = {
+  id: 'operator',
+  name: 'Operator',
+  permissions: '*',
+}
+
+// ---------------------------------------------------------------------------
+// hasPermission
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure guard: does the given role grant the requested permission?
+ *
+ * - `'*'` permissions → always true (wildcard / all-access).
+ * - Explicit array → true iff the permission appears in it.
+ *
+ * Does NOT consult the edition; use `canPerform` for that.
+ */
+export function hasPermission(role: Role, permission: Permission): boolean {
+  if (role.permissions === '*') return true
+  return role.permissions.includes(permission)
+}
+
+// ---------------------------------------------------------------------------
+// canPerform — the guard the app calls
+// ---------------------------------------------------------------------------
+
+/**
+ * Application-level guard.
+ *
+ * Fail-open design:
+ *   1. If RBAC is not enabled for this edition → true (community all-access).
+ *   2. If an unexpected error occurs at any point → true (safe default).
+ *   3. If no role is supplied → fall back to COMMUNITY_ROLE (all-access).
+ *
+ * @param permission    The permission to check.
+ * @param opts.role       Role to evaluate (defaults to COMMUNITY_ROLE).
+ * @param opts.runtimeEnv Cloudflare Worker `env` binding or process.env override;
+ *                        forwarded to isEnabled for edition resolution.
+ */
+export function canPerform(
+  permission: Permission,
+  opts?: { role?: Role; runtimeEnv?: Record<string, string | undefined> }
+): boolean {
+  try {
+    if (!isEnabled('rbac', opts?.runtimeEnv)) {
+      // Community / feature-disabled → unconditionally allow.
+      return true
+    }
+    return hasPermission(opts?.role ?? COMMUNITY_ROLE, permission)
+  } catch {
+    // Unexpected error (e.g. import resolution failure in an edge case) → allow.
+    return true
+  }
+}


### PR DESCRIPTION
## What

Adds `apps/dashboard/src/lib/rbac/` — a pure Role/Permission type system and `canPerform` guard.

New files:
- `rbac.ts` — `Permission` union, `Role` type, `COMMUNITY_ROLE`, `hasPermission`, `canPerform`
- `index.ts` — re-exports
- `rbac.test.ts` — 11 tests, 37 assertions

## Why

Plan 06c of the open-core foundation. Establishes the RBAC type scaffold so future enterprise enforcement UI has a well-typed, tested foundation to build on, without touching any existing code paths.

## Scope

Scaffold only. No enforcement UI. No changes to existing files. Community edition remains single-operator all-access.

## How verified (4 gates)

- [x] `bunx biome check --write apps/dashboard/src/lib/rbac` — passes (2 formatting nits auto-fixed)
- [x] `bun test apps/dashboard/src/lib/rbac/` — 11 pass, 0 fail, 37 expect() calls
- [x] `bun run build` (apps/dashboard) — exit 0, built in ~2.9s
- [x] `bun run type-check:test` — exit 0, no errors

## Visual

N/A — no UI changes.

## Guardrails

- Community edition `canPerform('cluster:admin')` === `true` (explicit fail-open assertion present in test)
- Auto-merge NOT armed
- Only new files staged; no existing files modified
- Work done exclusively in `/private/tmp/chm-wt15` on branch `plan/06-rbac-scaffold`

Plan: cowork/plans/06-open-core-foundation.md (PR 06c)