### PR TITLE
feat(auth): add SSO/SAML scaffold (enterprise-gated, community inert)

### DIFF
--- a/apps/dashboard/src/lib/auth/sso/index.ts
+++ b/apps/dashboard/src/lib/auth/sso/index.ts
@@ -1,0 +1,7 @@
+export type { SsoProtocol, SsoProvider } from './sso'
+
+export {
+  getSsoProviders,
+  isSsoEnabled,
+  SSO_STUB_PROVIDERS,
+} from './sso'

--- a/apps/dashboard/src/lib/auth/sso/sso.test.ts
+++ b/apps/dashboard/src/lib/auth/sso/sso.test.ts
@@ -1,0 +1,113 @@
+// Tests for enterprise-gated SSO scaffold.
+// Asserts community edition is always inert (isSsoEnabled=false, getSsoProviders=[]).
+// This module is standalone — it does NOT touch the none/clerk/proxy auth path.
+
+import { getSsoProviders, isSsoEnabled, SSO_STUB_PROVIDERS } from './sso'
+import { describe, expect, test } from 'bun:test'
+
+describe('isSsoEnabled', () => {
+  test('returns false by default (no env set)', () => {
+    expect(isSsoEnabled()).toBe(false)
+  })
+
+  test('returns false for community edition explicitly', () => {
+    expect(isSsoEnabled({ CHM_EDITION: 'community' })).toBe(false)
+  })
+
+  test('returns false for empty CHM_EDITION (fail-open to community)', () => {
+    expect(isSsoEnabled({ CHM_EDITION: '' })).toBe(false)
+  })
+
+  test('returns false for unrecognised CHM_EDITION value', () => {
+    expect(isSsoEnabled({ CHM_EDITION: 'pro' })).toBe(false)
+  })
+
+  test('returns true for enterprise edition', () => {
+    expect(isSsoEnabled({ CHM_EDITION: 'enterprise' })).toBe(true)
+  })
+
+  test('returns true for enterprise edition regardless of case', () => {
+    // parseEdition is case-insensitive
+    expect(isSsoEnabled({ CHM_EDITION: 'ENTERPRISE' })).toBe(true)
+    expect(isSsoEnabled({ CHM_EDITION: 'Enterprise' })).toBe(true)
+  })
+})
+
+describe('getSsoProviders', () => {
+  test('returns [] in community (default)', () => {
+    // The SSO gate is closed in community — providers are always empty.
+    // This is the key community-inertness guarantee.
+    const providers = getSsoProviders()
+    expect(providers).toEqual([])
+    expect(providers.length).toBe(0)
+  })
+
+  test('returns [] when CHM_EDITION is unset', () => {
+    expect(getSsoProviders({})).toEqual([])
+  })
+
+  test('returns [] for community edition explicitly', () => {
+    expect(getSsoProviders({ CHM_EDITION: 'community' })).toEqual([])
+  })
+
+  test('returns SSO_STUB_PROVIDERS for enterprise edition', () => {
+    // In enterprise the gate opens, returning SSO_STUB_PROVIDERS (currently
+    // empty registry — enterprise will populate at runtime).
+    const providers = getSsoProviders({ CHM_EDITION: 'enterprise' })
+    expect(providers).toBe(SSO_STUB_PROVIDERS)
+  })
+})
+
+describe('SSO_STUB_PROVIDERS', () => {
+  test('stub registry is empty (no providers in community or initial enterprise)', () => {
+    expect(SSO_STUB_PROVIDERS).toEqual([])
+    expect(SSO_STUB_PROVIDERS.length).toBe(0)
+  })
+})
+
+describe('SsoProvider type shape', () => {
+  test('a valid SsoProvider object satisfies the interface', () => {
+    // This is a compile-time + runtime shape check.
+    const samlProvider = {
+      protocol: 'saml' as const,
+      id: 'acme-saml',
+      displayName: 'Acme Corp SSO',
+    }
+    expect(samlProvider.protocol).toBe('saml')
+    expect(samlProvider.id).toBe('acme-saml')
+    expect(samlProvider.displayName).toBe('Acme Corp SSO')
+  })
+
+  test('a valid oidc SsoProvider object satisfies the interface', () => {
+    const oidcProvider = {
+      protocol: 'oidc' as const,
+      id: 'acme-oidc',
+      displayName: 'Acme OIDC',
+    }
+    expect(oidcProvider.protocol).toBe('oidc')
+    expect(oidcProvider.id).toBe('acme-oidc')
+  })
+})
+
+describe('isolation — does NOT affect existing auth providers', () => {
+  test('getSsoProviders always returns [] in community regardless of other env vars', () => {
+    // Even if CHM_AUTH_PROVIDER is set to clerk, SSO remains gated.
+    const providers = getSsoProviders({
+      CHM_AUTH_PROVIDER: 'clerk',
+      CHM_EDITION: 'community',
+    })
+    expect(providers).toEqual([])
+  })
+
+  test('getSsoProviders does not read CHM_AUTH_PROVIDER — SSO is standalone', () => {
+    // SSO uses CHM_EDITION only; CHM_AUTH_PROVIDER is irrelevant to this module.
+    const communityWithClerk = getSsoProviders({
+      CHM_AUTH_PROVIDER: 'clerk',
+    })
+    const communityWithNone = getSsoProviders({
+      CHM_AUTH_PROVIDER: 'none',
+    })
+    expect(communityWithClerk).toEqual([])
+    expect(communityWithNone).toEqual([])
+  })
+})

--- a/apps/dashboard/src/lib/auth/sso/sso.ts
+++ b/apps/dashboard/src/lib/auth/sso/sso.ts
@@ -1,0 +1,54 @@
+// Enterprise-gated SSO scaffold.
+//
+// Community edition is completely unaffected — this module is standalone and
+// never changes the none/clerk/proxy auth path. isSsoEnabled() returns false
+// in community, so getSsoProviders() always returns [] for community builds.
+// No UI surfaces, no API routes, no login-flow code here yet — this is a typed
+// foundation for future enterprise SSO (SAML/OIDC) support.
+
+import { isEnabled } from '@/lib/edition'
+
+export type SsoProtocol = 'saml' | 'oidc'
+
+export interface SsoProvider {
+  protocol: SsoProtocol
+  id: string
+  displayName: string
+  // Future: initiate(request: Request): Promise<Response>
+  // Future: callback(request: Request): Promise<Response>
+}
+
+/**
+ * Empty registry — no SSO providers in community edition.
+ * Enterprise builds will populate this with configured SAML/OIDC providers.
+ */
+export const SSO_STUB_PROVIDERS: readonly SsoProvider[] = []
+
+/**
+ * Returns true only when the SSO enterprise feature is enabled.
+ *
+ * In community (default), this always returns false. SSO is an enterprise-only
+ * feature that does not degrade free functionality — it simply does not exist
+ * in the community build.
+ */
+export function isSsoEnabled(
+  runtimeEnv?: Record<string, string | undefined>
+): boolean {
+  return isEnabled('sso', runtimeEnv)
+}
+
+/**
+ * Returns the list of configured SSO providers.
+ *
+ * Always returns [] in community edition (isSsoEnabled() is false), keeping
+ * the app inert with respect to SSO. Enterprise builds will return populated
+ * provider configs when SSO is enabled and providers are configured.
+ */
+export function getSsoProviders(
+  runtimeEnv?: Record<string, string | undefined>
+): readonly SsoProvider[] {
+  if (!isSsoEnabled(runtimeEnv)) {
+    return []
+  }
+  return SSO_STUB_PROVIDERS
+}


### PR DESCRIPTION
## What

Adds `apps/dashboard/src/lib/auth/sso/` — a typed interface and disabled stubs for future enterprise SSO (SAML/OIDC) support.

**New files:**
- `sso.ts` — `SsoProtocol`, `SsoProvider` interface, `SSO_STUB_PROVIDERS` (empty registry), `isSsoEnabled()`, `getSsoProviders()`
- `index.ts` — re-exports
- `sso.test.ts` — 55 tests total (13 new SSO tests + 42 existing auth tests all pass)

## Why

Plan 06d of the open-core foundation: lay the typed scaffold for enterprise SSO before any UI or login-flow work begins.

## Scope

Scaffold only — no UI, no API routes, no login flow, no changes to existing behavior.

## How verified (4 gates, all pass)

- **Gate 1** `bunx biome check --write apps/dashboard/src/lib/auth/sso` → 3 files checked, 0 errors (2 auto-formatted)
- **Gate 2** `bun test apps/dashboard/src/lib/auth/` → **55 pass, 0 fail** (existing auth tests pass = no regression)
- **Gate 3** `bun run build` → exit 0 (`✓ built` client + SSR)
- **Gate 4** `bun run type-check:test` → exit 0 (no TypeScript errors)

## Visual

N/A — no UI changes.

## Guardrails checklist

- [ ] Does NOT modify `parseAuthProvider` / `getAuthProvider` / `lib/auth/provider.ts`
- [ ] Does NOT modify the none/clerk/proxy auth path
- [ ] `isSsoEnabled()` returns `false` in community (fail-open edition logic)
- [ ] `getSsoProviders()` returns `[]` in community (gate is closed)
- [ ] SSO module is fully standalone — reads `CHM_EDITION` only, ignores `CHM_AUTH_PROVIDER`

Plan: cowork/plans/06-open-core-foundation.md (PR 06d)