### PR TITLE
docs(editions): add Editions reference page

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ plus a short list of what you changed:
     - [Kubernetes Helm Chart](https://duyet.github.io/clickhouse-monitoring/deploy/k8s)
   - [Advanced](https://duyet.github.io/clickhouse-monitoring/advanced)
     - [Telemetry](docs/content/advanced/telemetry.mdx) — opt-in, privacy-first usage metrics (off by default)
+    - [Editions](docs/content/advanced/editions.mdx) — open-core model: GPL-3.0 community is free forever; enterprise features gated by `CHM_EDITION`
 
 ### AI Agent Access
 

--- a/docs/content/advanced/editions.mdx
+++ b/docs/content/advanced/editions.mdx
@@ -1,0 +1,77 @@
+# Editions
+
+chmonitor is **GPL-3.0 and free forever** for a single operator monitoring their own ClickHouse cluster. Nothing is crippled, nag-screened, or artificially limited in the community build.
+
+The edition system exists to gate features that only matter at team or enterprise scale — features that do not exist yet in the OSS build. A misconfigured or absent edition flag never locks a self-hoster out; the system always fails open to community.
+
+---
+
+## How the edition is selected
+
+The edition is resolved at runtime from one of two variables, checked in order:
+
+| Variable | Where it applies | When to use |
+|---|---|---|
+| `CHM_EDITION` | Server runtime (Cloudflare Worker `[vars]` / `process.env`) | Canonical; set this in production |
+| `VITE_EDITION` | Build-time inline (Vite `CLIENT_ENV`) | Use only if you need the edition baked into the client bundle |
+
+Valid values: `community` (default) or `enterprise`. Any other value — including unset, empty, or a typo — resolves to `community`. The parser never throws.
+
+**Fail-open guarantee:** if `CHM_EDITION` is missing or unrecognised, the edition is `community` and all community features remain fully accessible.
+
+---
+
+## Feature availability
+
+The table below maps STRATEGY §7 capabilities to edition. "Planned" means the feature is on the roadmap but not yet built; the scaffold exists in the codebase but is not functional.
+
+| Capability | Community | Team | Enterprise |
+|---|---|---|---|
+| All system-table views (health, queries, merges, storage, topology, explorer) | ✓ | ✓ | ✓ |
+| AI agent (BYO model key) | ✓ | ✓ | ✓ |
+| MCP server (read-only) | ✓ | ✓ | ✓ |
+| Single & multi-cluster (manual config) | ✓ | ✓ | ✓ |
+| Community config catalog | ✓ | ✓ | ✓ |
+| Alerting & notifications (Slack / PagerDuty / webhook) | basic | ✓ planned | ✓ planned |
+| Fleet view (many clusters, saved orgs) | — | ✓ planned | ✓ planned |
+| Hosted chmonitor Cloud (no deploy) | — | ✓ planned | ✓ planned |
+| SSO / SAML | — | — | scaffold (gated, not functional) |
+| RBAC | — | — | scaffold (gated, not functional) |
+| Audit log, SLA, priority support | — | — | planned |
+| Managed AI (hosted model, no BYO key) | — | add-on planned | ✓ planned |
+
+STRATEGY §7 defines the product intent. The "scaffold" rows reflect code that exists in the repository (`lib/auth/sso`, `lib/rbac`) but is behind an edition gate and not yet functional in any build.
+
+---
+
+## Enterprise feature gate
+
+The `isEnabled(feature)` function in `lib/edition/` is the only gate used throughout the codebase. Enterprise features currently gated:
+
+```
+alerting  ·  sso  ·  rbac  ·  fleet  ·  cloud
+```
+
+Community edition returns `false` for each of these. This does not degrade any community functionality — these features simply do not exist in the OSS build.
+
+---
+
+## Code isolation
+
+Enterprise-only code is isolated so the GPL core never depends on it. The planned boundary is a separate `packages/enterprise/` package that the community build does not import. Today's scaffolds (`lib/auth/sso`, `lib/rbac`) follow the same pattern: they are guarded by `isEnabled()` checks and are inert in community builds.
+
+---
+
+## Summary
+
+- **Community:** everything an individual operator needs to monitor their own cluster. Free, self-hosted, fully functional, no time limit.
+- **Team / Enterprise:** team-scale convenience and governance features (alerting, fleet, SSO, RBAC). Most are planned; the scaffolds exist but are not yet functional.
+- **Misconfiguration is safe:** an unset or wrong `CHM_EDITION` always falls back to community.
+
+---
+
+## Related
+
+- [Environment Variables](/docs/reference/environment-variables) — full reference for all configuration variables.
+- [Feature Permissions](/docs/advanced/feature-permissions) — per-feature access control within an edition.
+- [Telemetry](/docs/advanced/telemetry) — opt-in, privacy-first usage metrics (off by default).

--- a/docs/versions/v0.3/advanced/editions.mdx
+++ b/docs/versions/v0.3/advanced/editions.mdx
@@ -1,0 +1,77 @@
+# Editions
+
+chmonitor is **GPL-3.0 and free forever** for a single operator monitoring their own ClickHouse cluster. Nothing is crippled, nag-screened, or artificially limited in the community build.
+
+The edition system exists to gate features that only matter at team or enterprise scale — features that do not exist yet in the OSS build. A misconfigured or absent edition flag never locks a self-hoster out; the system always fails open to community.
+
+---
+
+## How the edition is selected
+
+The edition is resolved at runtime from one of two variables, checked in order:
+
+| Variable | Where it applies | When to use |
+|---|---|---|
+| `CHM_EDITION` | Server runtime (Cloudflare Worker `[vars]` / `process.env`) | Canonical; set this in production |
+| `VITE_EDITION` | Build-time inline (Vite `CLIENT_ENV`) | Use only if you need the edition baked into the client bundle |
+
+Valid values: `community` (default) or `enterprise`. Any other value — including unset, empty, or a typo — resolves to `community`. The parser never throws.
+
+**Fail-open guarantee:** if `CHM_EDITION` is missing or unrecognised, the edition is `community` and all community features remain fully accessible.
+
+---
+
+## Feature availability
+
+The table below maps STRATEGY §7 capabilities to edition. "Planned" means the feature is on the roadmap but not yet built; the scaffold exists in the codebase but is not functional.
+
+| Capability | Community | Team | Enterprise |
+|---|---|---|---|
+| All system-table views (health, queries, merges, storage, topology, explorer) | ✓ | ✓ | ✓ |
+| AI agent (BYO model key) | ✓ | ✓ | ✓ |
+| MCP server (read-only) | ✓ | ✓ | ✓ |
+| Single & multi-cluster (manual config) | ✓ | ✓ | ✓ |
+| Community config catalog | ✓ | ✓ | ✓ |
+| Alerting & notifications (Slack / PagerDuty / webhook) | basic | ✓ planned | ✓ planned |
+| Fleet view (many clusters, saved orgs) | — | ✓ planned | ✓ planned |
+| Hosted chmonitor Cloud (no deploy) | — | ✓ planned | ✓ planned |
+| SSO / SAML | — | — | scaffold (gated, not functional) |
+| RBAC | — | — | scaffold (gated, not functional) |
+| Audit log, SLA, priority support | — | — | planned |
+| Managed AI (hosted model, no BYO key) | — | add-on planned | ✓ planned |
+
+STRATEGY §7 defines the product intent. The "scaffold" rows reflect code that exists in the repository (`lib/auth/sso`, `lib/rbac`) but is behind an edition gate and not yet functional in any build.
+
+---
+
+## Enterprise feature gate
+
+The `isEnabled(feature)` function in `lib/edition/` is the only gate used throughout the codebase. Enterprise features currently gated:
+
+```
+alerting  ·  sso  ·  rbac  ·  fleet  ·  cloud
+```
+
+Community edition returns `false` for each of these. This does not degrade any community functionality — these features simply do not exist in the OSS build.
+
+---
+
+## Code isolation
+
+Enterprise-only code is isolated so the GPL core never depends on it. The planned boundary is a separate `packages/enterprise/` package that the community build does not import. Today's scaffolds (`lib/auth/sso`, `lib/rbac`) follow the same pattern: they are guarded by `isEnabled()` checks and are inert in community builds.
+
+---
+
+## Summary
+
+- **Community:** everything an individual operator needs to monitor their own cluster. Free, self-hosted, fully functional, no time limit.
+- **Team / Enterprise:** team-scale convenience and governance features (alerting, fleet, SSO, RBAC). Most are planned; the scaffolds exist but are not yet functional.
+- **Misconfiguration is safe:** an unset or wrong `CHM_EDITION` always falls back to community.
+
+---
+
+## Related
+
+- [Environment Variables](/docs/reference/environment-variables) — full reference for all configuration variables.
+- [Feature Permissions](/docs/advanced/feature-permissions) — per-feature access control within an edition.
+- [Telemetry](/docs/advanced/telemetry) — opt-in, privacy-first usage metrics (off by default).


### PR DESCRIPTION
## What changed

- `docs/content/advanced/editions.mdx` — new Editions reference page (new file)
- `docs/versions/v0.3/advanced/editions.mdx` — mirror for the live docs site (new file)
- `README.md` — one link added to the Advanced docs list

## Why (Plan 06e)

Plan 06e: document the open-core / edition boundary introduced by PR 06a. Operators deploying chmonitor need a single reference that explains:
- the GPL-3.0 core is free forever, fully functional for a single operator, no crippleware
- exactly which env var to set (`CHM_EDITION`) and what happens when it's unset (fail-open to community)
- which capabilities are community vs team vs enterprise, with honest "planned" labelling for features not yet built

## Scope

Docs-only. No application code changed. Two new `.mdx` files + one README line.

## How verified

- `bun run check` (biome): green, 1492 files, no fixes needed
- Frontmatter shape matches `docs/content/advanced/telemetry.mdx` exactly
- Mirror file at `docs/versions/v0.3/advanced/editions.mdx` is identical to the source, following the same pattern used by PR #1687 for `telemetry.mdx`
- Edition enum names (`community` | `enterprise`), env var (`CHM_EDITION` / `VITE_EDITION`), and fail-open behaviour verified directly from `apps/dashboard/src/lib/edition/edition.ts`
- Feature table sourced from STRATEGY §7; not-yet-built paid features labelled "planned" or "scaffold" — no false claims

https://claude.ai/code/session_012TwMqL4qgXSKBBvR1DZjoH