### PR TITLE
docs(catalog): add config/check contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ plus a short list of what you changed:
     - [Editions](docs/content/advanced/editions.mdx) — open-core model: GPL-3.0 community is free forever; enterprise features gated by `CHM_EDITION`
   - [Reference](https://duyet.github.io/clickhouse-monitoring/reference)
     - [Platform Support Matrix](docs/content/reference/support-matrix.mdx) — ClickHouse versions and distributions (supported / best-effort / untested)
+    - [Contributing a config / check](docs/content/reference/catalog-contributing.mdx) — how to add a declarative monitoring check to the catalog
 
 ### AI Agent Access
 

--- a/docs/content/reference/catalog-contributing.mdx
+++ b/docs/content/reference/catalog-contributing.mdx
@@ -1,0 +1,197 @@
+---
+title: Contributing a config / check
+description: How to add a declarative monitoring check to the chmonitor catalog.
+---
+
+# Contributing a config / check
+
+A **declarative query config** is a monitoring check expressed as data — a plain TypeScript object that the dashboard validates against a [Zod schema](../../../apps/dashboard/src/lib/query-config/declarative/schema.ts) and renders as a table or card view. No JSX, no functions, no component imports.
+
+> **Current status**: the declarative catalog is opt-in. Set `CHM_CONFIG_SOURCE=declarative` to route runtime lookups to it. The default (`CHM_CONFIG_SOURCE=ts`) still uses the TypeScript query configs. A drop-in community catalog directory (where contributions live outside the repo) is planned but not yet built. For now, contributing a check means adding a file to the repo's catalog directory and opening a PR.
+
+---
+
+## The contract
+
+Every declarative config must satisfy the schema in:
+
+```
+apps/dashboard/src/lib/query-config/declarative/schema.ts
+```
+
+**Required fields:**
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | `string` | Unique across the catalog. Used as the lookup key. |
+| `sql` | `string \| VersionedSql[]` | A plain SQL string, or an array of `{ since, sql }` entries for version-aware queries. |
+| `columns` | `string[]` | Column names returned by the query, in display order. Must have at least one entry. |
+
+**Commonly used optional fields:**
+
+| Field | Type | Notes |
+|---|---|---|
+| `description` | `string` | Short human-readable description shown in the dashboard. |
+| `columnFormats` | `Record<string, ColumnFormat>` | Display format per column. Allowed values: `badge`, `duration`, `number`, `number-short`, `background-bar`, `colored-badge`, `boolean`, `code`, `text`, `none`, and others — see schema for the full list. |
+| `columnDescriptions` | `Record<string, string>` | Tooltip text per column. |
+| `defaultParams` | `Record<string, string \| number \| boolean>` | Default values for `{param: Type}` placeholders in the SQL. |
+| `optional` | `boolean` | When `true`, the dashboard skips gracefully if the target table does not exist (default: `false`). |
+| `tableCheck` | `string \| string[]` | Table(s) to check for existence before running the query. Useful with `optional: true`. |
+| `refreshInterval` | `number` | Auto-refresh interval in milliseconds. |
+| `relatedCharts` | `(string \| [string, Record])[]` | Chart names (or `[name, params]` tuples) to render above the table. |
+| `card` | `{ primary?, badges?, metrics?, hidden? }` | Card view layout hints. |
+| `defaultView` | `'table' \| 'cards' \| 'auto'` | Default display mode. |
+
+**Fields intentionally absent from the declarative format** (runtime-only, cannot be serialized):
+`rowClassName`, `expandable`, `columnIcons`, `permission`, `filterSchema`.
+If your check needs any of these, it must stay as a TypeScript config for now.
+
+---
+
+## Safety rule: SELECT only
+
+All checks must be read-only. The schema validator and the SQL validator in
+`apps/dashboard/src/lib/api/shared/validators/sql.ts` reject DDL and DML
+(`CREATE`, `INSERT`, `DROP`, `ALTER`, `TRUNCATE`, etc.). Do not set
+`disableSqlValidation: true` on contributed checks.
+
+---
+
+## Worked example
+
+A minimal check that surfaces the last 100 slow queries. Based on the real `query-count-baseline` pattern in the anomaly catalog:
+
+```typescript
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const slowQueriesRecentDeclarative: DeclarativeQueryConfig = {
+  name: 'slow-queries-recent',
+  description: 'Queries that took longer than 5 seconds in the last hour',
+  sql: [
+    {
+      since: '23.8',
+      sql: `
+        SELECT
+          query_id,
+          user,
+          query_duration_ms,
+          formatReadableTimeDelta(query_duration_ms / 1000) AS readable_duration,
+          round(memory_usage / 1048576, 1) AS memory_mb,
+          left(query, 200) AS query_snippet,
+          event_time
+        FROM system.query_log
+        WHERE type = 'QueryFinish'
+          AND query_duration_ms > 5000
+          AND event_time >= now() - INTERVAL 1 HOUR
+        ORDER BY query_duration_ms DESC
+        LIMIT 100
+      `,
+    },
+  ],
+  columns: [
+    'query_id',
+    'user',
+    'query_duration_ms',
+    'readable_duration',
+    'memory_mb',
+    'query_snippet',
+    'event_time',
+  ],
+  columnFormats: {
+    query_duration_ms: 'number',
+    memory_mb: 'number',
+    query_snippet: 'code',
+  },
+  columnDescriptions: {
+    query_duration_ms: 'Wall-clock duration in milliseconds',
+    memory_mb: 'Peak memory usage in MiB',
+  },
+  defaultParams: {},
+  optional: false,
+}
+```
+
+The field names above (`name`, `sql[].since`, `sql[].sql`, `columns`,
+`columnFormats`, `columnDescriptions`, `optional`) map directly to
+`declarativeQueryConfigSchema` in `schema.ts`.
+
+---
+
+## Step-by-step: adding a check
+
+1. **Pick the right domain directory.** Existing domains under
+   `apps/dashboard/src/lib/query-config/declarative/catalog/`:
+   `anomaly`, `explorer`, `keeper`, `logs`, `merges`, `more`, `queries`,
+   `security`, `system`, `tables`. Add a new file to the closest domain, or
+   create a new subdirectory if the check doesn't fit any existing one.
+
+2. **Write the config.** Export a `const` typed as `DeclarativeQueryConfig`.
+   Use `sql: [{ since: 'X.Y', sql: '...' }]` when querying a system column
+   that was added in a specific ClickHouse version (check
+   `docs/clickhouse-schemas/tables/` for column availability). Use a plain
+   `sql: '...'` string when the query works across all supported versions.
+
+3. **Register it in the catalog index.** Import your export in
+   `apps/dashboard/src/lib/query-config/declarative/catalog/index.ts` and add
+   it to the `ALL_DECLARATIVE` array. The index enforces unique names at module
+   load time and throws if a duplicate is detected.
+
+4. **Validate locally.**
+   ```bash
+   # Validate schema + run declarative catalog tests
+   bun run test:query-config
+
+   # Biome lint (must pass before PR)
+   bun run check
+   ```
+   The `test:query-config` suite runs the schema validator against every catalog
+   entry and compares serializable fields against the legacy TS configs for
+   migrated checks.
+
+5. **Note the opt-in flag.** Your check is live in the catalog but the
+   dashboard only reads from it when `CHM_CONFIG_SOURCE=declarative` is set in
+   the environment. The default is `ts`. Document this in your PR if relevant.
+
+6. **Open a PR** against `main`. The CI `unit-tests` job runs the full bun test
+   suite including the declarative catalog tests.
+
+---
+
+## Version-aware SQL
+
+When a system table column was introduced in a specific ClickHouse release,
+use the `sql` array instead of a plain string. The loader picks the entry whose
+`since` version is the highest that is still ≤ the connected cluster's version.
+
+```typescript
+sql: [
+  {
+    since: '23.8',
+    sql: `SELECT col1 FROM system.query_log LIMIT 10`,
+  },
+  {
+    since: '24.1',
+    sql: `SELECT col1, new_col FROM system.query_log LIMIT 10`,
+    description: 'Added new_col (available from 24.1)',
+  },
+],
+```
+
+Version strings must match `X.Y` or `X.Y.Z` (e.g. `"23.8"`, `"24.1"`,
+`"25.6.0"`). The `description` field on each entry is optional but encouraged.
+
+---
+
+## Optional tables
+
+If your check queries a table that may not exist (e.g. `system.backup_log`,
+`system.zookeeper`, `system.error_log`), set `optional: true` and provide a
+`tableCheck`:
+
+```typescript
+optional: true,
+tableCheck: 'system.backup_log',
+```
+
+The dashboard will surface a graceful "table not available" message instead of
+an error.

--- a/docs/versions/v0.3/reference/catalog-contributing.mdx
+++ b/docs/versions/v0.3/reference/catalog-contributing.mdx
@@ -1,0 +1,197 @@
+---
+title: Contributing a config / check
+description: How to add a declarative monitoring check to the chmonitor catalog.
+---
+
+# Contributing a config / check
+
+A **declarative query config** is a monitoring check expressed as data — a plain TypeScript object that the dashboard validates against a [Zod schema](../../../apps/dashboard/src/lib/query-config/declarative/schema.ts) and renders as a table or card view. No JSX, no functions, no component imports.
+
+> **Current status**: the declarative catalog is opt-in. Set `CHM_CONFIG_SOURCE=declarative` to route runtime lookups to it. The default (`CHM_CONFIG_SOURCE=ts`) still uses the TypeScript query configs. A drop-in community catalog directory (where contributions live outside the repo) is planned but not yet built. For now, contributing a check means adding a file to the repo's catalog directory and opening a PR.
+
+---
+
+## The contract
+
+Every declarative config must satisfy the schema in:
+
+```
+apps/dashboard/src/lib/query-config/declarative/schema.ts
+```
+
+**Required fields:**
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | `string` | Unique across the catalog. Used as the lookup key. |
+| `sql` | `string \| VersionedSql[]` | A plain SQL string, or an array of `{ since, sql }` entries for version-aware queries. |
+| `columns` | `string[]` | Column names returned by the query, in display order. Must have at least one entry. |
+
+**Commonly used optional fields:**
+
+| Field | Type | Notes |
+|---|---|---|
+| `description` | `string` | Short human-readable description shown in the dashboard. |
+| `columnFormats` | `Record<string, ColumnFormat>` | Display format per column. Allowed values: `badge`, `duration`, `number`, `number-short`, `background-bar`, `colored-badge`, `boolean`, `code`, `text`, `none`, and others — see schema for the full list. |
+| `columnDescriptions` | `Record<string, string>` | Tooltip text per column. |
+| `defaultParams` | `Record<string, string \| number \| boolean>` | Default values for `{param: Type}` placeholders in the SQL. |
+| `optional` | `boolean` | When `true`, the dashboard skips gracefully if the target table does not exist (default: `false`). |
+| `tableCheck` | `string \| string[]` | Table(s) to check for existence before running the query. Useful with `optional: true`. |
+| `refreshInterval` | `number` | Auto-refresh interval in milliseconds. |
+| `relatedCharts` | `(string \| [string, Record])[]` | Chart names (or `[name, params]` tuples) to render above the table. |
+| `card` | `{ primary?, badges?, metrics?, hidden? }` | Card view layout hints. |
+| `defaultView` | `'table' \| 'cards' \| 'auto'` | Default display mode. |
+
+**Fields intentionally absent from the declarative format** (runtime-only, cannot be serialized):
+`rowClassName`, `expandable`, `columnIcons`, `permission`, `filterSchema`.
+If your check needs any of these, it must stay as a TypeScript config for now.
+
+---
+
+## Safety rule: SELECT only
+
+All checks must be read-only. The schema validator and the SQL validator in
+`apps/dashboard/src/lib/api/shared/validators/sql.ts` reject DDL and DML
+(`CREATE`, `INSERT`, `DROP`, `ALTER`, `TRUNCATE`, etc.). Do not set
+`disableSqlValidation: true` on contributed checks.
+
+---
+
+## Worked example
+
+A minimal check that surfaces the last 100 slow queries. Based on the real `query-count-baseline` pattern in the anomaly catalog:
+
+```typescript
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const slowQueriesRecentDeclarative: DeclarativeQueryConfig = {
+  name: 'slow-queries-recent',
+  description: 'Queries that took longer than 5 seconds in the last hour',
+  sql: [
+    {
+      since: '23.8',
+      sql: `
+        SELECT
+          query_id,
+          user,
+          query_duration_ms,
+          formatReadableTimeDelta(query_duration_ms / 1000) AS readable_duration,
+          round(memory_usage / 1048576, 1) AS memory_mb,
+          left(query, 200) AS query_snippet,
+          event_time
+        FROM system.query_log
+        WHERE type = 'QueryFinish'
+          AND query_duration_ms > 5000
+          AND event_time >= now() - INTERVAL 1 HOUR
+        ORDER BY query_duration_ms DESC
+        LIMIT 100
+      `,
+    },
+  ],
+  columns: [
+    'query_id',
+    'user',
+    'query_duration_ms',
+    'readable_duration',
+    'memory_mb',
+    'query_snippet',
+    'event_time',
+  ],
+  columnFormats: {
+    query_duration_ms: 'number',
+    memory_mb: 'number',
+    query_snippet: 'code',
+  },
+  columnDescriptions: {
+    query_duration_ms: 'Wall-clock duration in milliseconds',
+    memory_mb: 'Peak memory usage in MiB',
+  },
+  defaultParams: {},
+  optional: false,
+}
+```
+
+The field names above (`name`, `sql[].since`, `sql[].sql`, `columns`,
+`columnFormats`, `columnDescriptions`, `optional`) map directly to
+`declarativeQueryConfigSchema` in `schema.ts`.
+
+---
+
+## Step-by-step: adding a check
+
+1. **Pick the right domain directory.** Existing domains under
+   `apps/dashboard/src/lib/query-config/declarative/catalog/`:
+   `anomaly`, `explorer`, `keeper`, `logs`, `merges`, `more`, `queries`,
+   `security`, `system`, `tables`. Add a new file to the closest domain, or
+   create a new subdirectory if the check doesn't fit any existing one.
+
+2. **Write the config.** Export a `const` typed as `DeclarativeQueryConfig`.
+   Use `sql: [{ since: 'X.Y', sql: '...' }]` when querying a system column
+   that was added in a specific ClickHouse version (check
+   `docs/clickhouse-schemas/tables/` for column availability). Use a plain
+   `sql: '...'` string when the query works across all supported versions.
+
+3. **Register it in the catalog index.** Import your export in
+   `apps/dashboard/src/lib/query-config/declarative/catalog/index.ts` and add
+   it to the `ALL_DECLARATIVE` array. The index enforces unique names at module
+   load time and throws if a duplicate is detected.
+
+4. **Validate locally.**
+   ```bash
+   # Validate schema + run declarative catalog tests
+   bun run test:query-config
+
+   # Biome lint (must pass before PR)
+   bun run check
+   ```
+   The `test:query-config` suite runs the schema validator against every catalog
+   entry and compares serializable fields against the legacy TS configs for
+   migrated checks.
+
+5. **Note the opt-in flag.** Your check is live in the catalog but the
+   dashboard only reads from it when `CHM_CONFIG_SOURCE=declarative` is set in
+   the environment. The default is `ts`. Document this in your PR if relevant.
+
+6. **Open a PR** against `main`. The CI `unit-tests` job runs the full bun test
+   suite including the declarative catalog tests.
+
+---
+
+## Version-aware SQL
+
+When a system table column was introduced in a specific ClickHouse release,
+use the `sql` array instead of a plain string. The loader picks the entry whose
+`since` version is the highest that is still ≤ the connected cluster's version.
+
+```typescript
+sql: [
+  {
+    since: '23.8',
+    sql: `SELECT col1 FROM system.query_log LIMIT 10`,
+  },
+  {
+    since: '24.1',
+    sql: `SELECT col1, new_col FROM system.query_log LIMIT 10`,
+    description: 'Added new_col (available from 24.1)',
+  },
+],
+```
+
+Version strings must match `X.Y` or `X.Y.Z` (e.g. `"23.8"`, `"24.1"`,
+`"25.6.0"`). The `description` field on each entry is optional but encouraged.
+
+---
+
+## Optional tables
+
+If your check queries a table that may not exist (e.g. `system.backup_log`,
+`system.zookeeper`, `system.error_log`), set `optional: true` and provide a
+`tableCheck`:
+
+```typescript
+optional: true,
+tableCheck: 'system.backup_log',
+```
+
+The dashboard will surface a graceful "table not available" message instead of
+an error.


### PR DESCRIPTION
## What

Adds `docs/content/reference/catalog-contributing.mdx` — a contribution guide for the declarative query-config catalog. Mirrored to `docs/versions/v0.3/reference/catalog-contributing.mdx`. One README link added under the Reference section.

## Why (Plan 03c)

The declarative catalog (shipped in Plan 02) now has ~60 migrated configs but no documentation on how contributors add a new check. This guide closes that gap.

## Scope

Docs-only. No new code, no schema changes, no loader changes.

## What the guide covers (accurately, matching today's codebase)

- What a declarative config is and which fields are required (`name`, `sql`, `columns`) vs. optional
- The current opt-in status: `CHM_CONFIG_SOURCE=declarative` required; default remains `ts`; no user drop-in directory yet (explicitly called out as a future plan)
- A complete worked example (`slow-queries-recent`) whose field names were verified against `schema.ts`
- Where to place the file, how to register it in `catalog/index.ts`, and how to validate locally (`bun run test:query-config` + `bun run check`)
- Version-aware SQL (`sql[].since`) pattern
- Optional table handling (`optional: true` + `tableCheck`)
- SELECT-only safety rule (references existing SQL validator)

## How verified

- `bun run check` — `Checked 1495 files in 785ms. No fixes applied.`
- Example config field names cross-checked against `declarativeQueryConfigSchema` in `schema.ts`
- No `git add -A`; only the three doc files staged

https://claude.ai/code/session_012TwMqL4qgXSKBBvR1DZjoH