### PR TITLE
test(mcp): lock in read-only enforcement + document tool set

### DIFF
--- a/apps/dashboard/src/lib/__tests__/mcp-readonly-enforcement.test.ts
+++ b/apps/dashboard/src/lib/__tests__/mcp-readonly-enforcement.test.ts
@@ -1,0 +1,205 @@
+/**
+ * MCP read-only enforcement lock-in tests (Plan 05a)
+ *
+ * Imports the REAL `validateSqlQuery` guard from `@chm/sql-builder` — the same
+ * function the `query` MCP tool calls before executing any SQL — and asserts that
+ * every write/DDL/control statement is rejected and every legitimate read query is
+ * allowed. These tests are intentionally kept in the dashboard `src/` tree so
+ * `bun test src/ --isolate` (the CI `dashboard` job) always runs them.
+ *
+ * Guard contract: `validateSqlQuery(sql: string): void` — throws `Error` on
+ * reject, returns `undefined` on allow.
+ *
+ * @see packages/mcp-server/src/tools/query.ts  — the tool that calls the guard
+ * @see packages/sql-builder/src/sql-validator.ts — the guard implementation
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { validateSqlQuery } from '@chm/sql-builder'
+
+// ============================================================================
+// Rejected statements — every case below MUST throw
+// ============================================================================
+
+describe('MCP read-only enforcement: rejected statements', () => {
+  test('INSERT INTO', () => {
+    expect(() => validateSqlQuery('INSERT INTO t VALUES (1)')).toThrow()
+  })
+
+  test('ALTER TABLE', () => {
+    expect(() => validateSqlQuery('ALTER TABLE t ADD COLUMN x Int32')).toThrow()
+  })
+
+  test('DROP TABLE', () => {
+    expect(() => validateSqlQuery('DROP TABLE users')).toThrow()
+  })
+
+  test('TRUNCATE TABLE', () => {
+    expect(() => validateSqlQuery('TRUNCATE TABLE logs')).toThrow()
+  })
+
+  test('CREATE TABLE', () => {
+    expect(() =>
+      validateSqlQuery('CREATE TABLE x (id UInt32) ENGINE=MergeTree()')
+    ).toThrow()
+  })
+
+  test('CREATE USER', () => {
+    expect(() =>
+      validateSqlQuery("CREATE USER alice IDENTIFIED BY 'secret'")
+    ).toThrow()
+  })
+
+  test('RENAME TABLE', () => {
+    expect(() => validateSqlQuery('RENAME TABLE old TO new')).toThrow()
+  })
+
+  test('OPTIMIZE TABLE', () => {
+    // OPTIMIZE is a SYSTEM-level write operation — not a SELECT
+    // The guard rejects it because it does not start with SELECT/WITH/DESCRIBE/EXPLAIN
+    // and none of the dangerous keyword checks apply (it falls through to the
+    // statement-type check at the end of validateSqlQuery).
+    expect(() => validateSqlQuery('OPTIMIZE TABLE t FINAL')).toThrow()
+  })
+
+  test('SYSTEM RELOAD DICTIONARIES', () => {
+    expect(() => validateSqlQuery('SYSTEM RELOAD DICTIONARIES')).toThrow()
+  })
+
+  test('SYSTEM FLUSH LOGS', () => {
+    expect(() => validateSqlQuery('SYSTEM FLUSH LOGS')).toThrow()
+  })
+
+  test('GRANT privilege', () => {
+    expect(() => validateSqlQuery('GRANT SELECT ON db.t TO alice')).toThrow()
+  })
+
+  test('ATTACH TABLE', () => {
+    expect(() => validateSqlQuery('ATTACH TABLE t')).toThrow()
+  })
+
+  test('DETACH TABLE', () => {
+    expect(() => validateSqlQuery('DETACH TABLE t')).toThrow()
+  })
+
+  test('DELETE (standalone)', () => {
+    expect(() => validateSqlQuery('DELETE FROM t WHERE id = 1')).toThrow()
+  })
+
+  test('UPDATE (ClickHouse ALTER ... UPDATE)', () => {
+    // ClickHouse mutation syntax contains ALTER which is caught first
+    expect(() =>
+      validateSqlQuery('ALTER TABLE t UPDATE col = 1 WHERE id = 1')
+    ).toThrow()
+  })
+
+  test('ALTER TABLE DELETE (ClickHouse mutation)', () => {
+    expect(() =>
+      validateSqlQuery('ALTER TABLE t DELETE WHERE id > 100')
+    ).toThrow()
+  })
+
+  test('multi-statement: SELECT then DROP (sneaky)', () => {
+    expect(() => validateSqlQuery('SELECT 1; DROP TABLE users')).toThrow()
+  })
+
+  test('multi-statement: SELECT then INSERT', () => {
+    expect(() =>
+      validateSqlQuery('SELECT count() FROM t; INSERT INTO t VALUES (1)')
+    ).toThrow()
+  })
+
+  test('SET session variable', () => {
+    expect(() => validateSqlQuery('SET max_memory_usage = 0')).toThrow()
+  })
+
+  test('KILL QUERY', () => {
+    expect(() => validateSqlQuery('KILL QUERY WHERE query_id = 1')).toThrow()
+  })
+})
+
+// ============================================================================
+// Allowed statements — every case below MUST NOT throw
+// ============================================================================
+
+describe('MCP read-only enforcement: allowed statements', () => {
+  test('simple SELECT', () => {
+    expect(() => validateSqlQuery('SELECT 1')).not.toThrow()
+  })
+
+  test('SELECT from system table', () => {
+    expect(() =>
+      validateSqlQuery('SELECT * FROM system.tables LIMIT 10')
+    ).not.toThrow()
+  })
+
+  test('SELECT with WHERE and ORDER BY', () => {
+    expect(() =>
+      validateSqlQuery(
+        'SELECT query_id, elapsed FROM system.processes ORDER BY elapsed DESC'
+      )
+    ).not.toThrow()
+  })
+
+  test('WITH … SELECT (CTE)', () => {
+    expect(() =>
+      validateSqlQuery(
+        'WITH top AS (SELECT count() AS n FROM system.tables) SELECT n FROM top'
+      )
+    ).not.toThrow()
+  })
+
+  test('DESCRIBE TABLE', () => {
+    expect(() =>
+      validateSqlQuery('DESCRIBE TABLE system.query_log')
+    ).not.toThrow()
+  })
+
+  // NOTE: DESC (short alias) is NOT allowed — only the full DESCRIBE keyword
+  // passes the guard. Use DESCRIBE TABLE instead.
+
+  test('EXPLAIN SELECT', () => {
+    expect(() =>
+      validateSqlQuery('EXPLAIN SELECT count() FROM system.tables')
+    ).not.toThrow()
+  })
+
+  test('EXPLAIN PIPELINE SELECT', () => {
+    expect(() =>
+      validateSqlQuery('EXPLAIN PIPELINE SELECT * FROM system.processes')
+    ).not.toThrow()
+  })
+
+  test('EXPLAIN AST SELECT', () => {
+    expect(() => validateSqlQuery('EXPLAIN AST SELECT 1')).not.toThrow()
+  })
+
+  test('SELECT with a leading block comment (QUERY_COMMENT pattern)', () => {
+    expect(() =>
+      validateSqlQuery(
+        '/* { "client": "clickhouse-monitoring" } */ SELECT * FROM system.processes'
+      )
+    ).not.toThrow()
+  })
+
+  test('SELECT with inline comment', () => {
+    expect(() =>
+      validateSqlQuery('SELECT /* read-only */ count() FROM system.tables')
+    ).not.toThrow()
+  })
+
+  test('multiline SELECT', () => {
+    expect(() =>
+      validateSqlQuery(`
+        SELECT
+          user,
+          count() AS cnt
+        FROM system.query_log
+        WHERE type = 'QueryFinish'
+        GROUP BY user
+        ORDER BY cnt DESC
+        LIMIT 10
+      `)
+    ).not.toThrow()
+  })
+})

--- a/docs/content/ai-agent.mdx
+++ b/docs/content/ai-agent.mdx
@@ -138,6 +138,30 @@ curl -X POST https://your-host/api/v1/agent \
 
 `hostId` is a zero-based numeric index; defaults to `0`.
 
+## MCP Server
+
+The dashboard exposes an MCP (Model Context Protocol) endpoint at `/api/mcp`. The same implementation runs in the standalone Cloudflare MCP Worker (`apps/mcp`). All tools are read-only by design — write and DDL statements are rejected.
+
+### MCP tools
+
+| Tool | Purpose |
+|---|---|
+| `query` | Execute a read-only SQL query (SELECT / WITH / DESCRIBE / EXPLAIN only) |
+| `list_databases` | List all databases with their engines and comments |
+| `list_tables` | List tables in a database with row counts and sizes |
+| `get_table_schema` | Get column definitions for a table including types, defaults, and comments |
+| `get_metrics` | Key server metrics: version, uptime, active connections, memory usage |
+| `get_running_queries` | Currently running queries ordered by elapsed time |
+| `get_slow_queries` | Slowest completed queries from the query log |
+| `get_merge_status` | Currently running merge operations with progress and elapsed time |
+| `explore_table_schema` | Three-mode schema exploration: databases → tables → full schema with relationships |
+
+### Read-only enforcement
+
+The `query` tool — the only tool that accepts arbitrary SQL — validates every statement before execution via `validateSqlQuery` (`@chm/sql-builder`). It **throws** on any write or DDL statement and on dangerous ClickHouse commands. Allowed prefixes: `SELECT`, `WITH` (CTE), `DESCRIBE`, `EXPLAIN`. Rejected: `INSERT`, `ALTER`, `DROP`, `CREATE`, `TRUNCATE`, `RENAME`, `DELETE`, `UPDATE`, `SYSTEM RELOAD/FLUSH/KILL/SHUTDOWN`, `GRANT`, `REVOKE`, `ATTACH`, `DETACH`, `KILL`, `SET`, multi-statement payloads (`;` chaining), and dangerous table functions (`remote()`, `url()`, `s3()`, etc.).
+
+All other MCP tools run fixed SELECT queries and pass `readonly: '1'` to the ClickHouse connection — they cannot issue writes regardless of the validator.
+
 ## Security
 
 - Use a **read-only ClickHouse user** scoped to the system tables the dashboard needs.

--- a/docs/versions/v0.3/ai-agent.mdx
+++ b/docs/versions/v0.3/ai-agent.mdx
@@ -53,6 +53,30 @@ curl -X POST https://your-host/api/v1/agent \
 
 `hostId` is a zero-based numeric index; defaults to `0`.
 
+## MCP Server
+
+The dashboard exposes an MCP (Model Context Protocol) endpoint at `/api/mcp`. The same implementation runs in the standalone Cloudflare MCP Worker (`apps/mcp`). All tools are read-only by design — write and DDL statements are rejected.
+
+### MCP tools
+
+| Tool | Purpose |
+|---|---|
+| `query` | Execute a read-only SQL query (SELECT / WITH / DESCRIBE / EXPLAIN only) |
+| `list_databases` | List all databases with their engines and comments |
+| `list_tables` | List tables in a database with row counts and sizes |
+| `get_table_schema` | Get column definitions for a table including types, defaults, and comments |
+| `get_metrics` | Key server metrics: version, uptime, active connections, memory usage |
+| `get_running_queries` | Currently running queries ordered by elapsed time |
+| `get_slow_queries` | Slowest completed queries from the query log |
+| `get_merge_status` | Currently running merge operations with progress and elapsed time |
+| `explore_table_schema` | Three-mode schema exploration: databases → tables → full schema with relationships |
+
+### Read-only enforcement
+
+The `query` tool — the only tool that accepts arbitrary SQL — validates every statement before execution via `validateSqlQuery` (`@chm/sql-builder`). It **throws** on any write or DDL statement and on dangerous ClickHouse commands. Allowed prefixes: `SELECT`, `WITH` (CTE), `DESCRIBE`, `EXPLAIN`. Rejected: `INSERT`, `ALTER`, `DROP`, `CREATE`, `TRUNCATE`, `RENAME`, `DELETE`, `UPDATE`, `SYSTEM RELOAD/FLUSH/KILL/SHUTDOWN`, `GRANT`, `REVOKE`, `ATTACH`, `DETACH`, `KILL`, `SET`, multi-statement payloads (`;` chaining), and dangerous table functions (`remote()`, `url()`, `s3()`, etc.).
+
+All other MCP tools run fixed SELECT queries and pass `readonly: '1'` to the ClickHouse connection — they cannot issue writes regardless of the validator.
+
 ## Security
 
 - Use a **read-only ClickHouse user** scoped to the system tables the dashboard needs.


### PR DESCRIPTION
## What changed

- **New test file**: `apps/dashboard/src/lib/__tests__/mcp-readonly-enforcement.test.ts` — 31 lock-in assertions against the real `validateSqlQuery` guard
- **Docs**: `docs/content/ai-agent.mdx` and `docs/versions/v0.3/ai-agent.mdx` — new **MCP Server** section documenting the tool set and read-only enforcement

## Why (Plan 05a)

Audit and prove the MCP server is read-only, then lock it in with regression tests and document the tool set so the contract is visible and CI-enforced.

No runtime behavior was changed. This is tests + docs only.

## Traced tool list (9 MCP tools)

| Tool | Type | Read-only guarantee |
|---|---|---|
| `query` | arbitrary SQL | `validateSqlQuery` guard throws on write/DDL; `readonly: '1'` ClickHouse setting |
| `list_databases` | fixed SELECT | `readonly: '1'` |
| `list_tables` | fixed SELECT | `readonly: '1'` |
| `get_table_schema` | fixed SELECT | `readonly: '1'` |
| `get_metrics` | fixed SELECT | `readonly: '1'` |
| `get_running_queries` | fixed SELECT | `readonly: '1'` |
| `get_slow_queries` | fixed SELECT | `readonly: '1'` |
| `get_merge_status` | fixed SELECT | `readonly: '1'` |
| `explore_table_schema` | fixed SELECT | `readonly: '1'` |

The data catalog also lists `spot_issues`, `repair_query`, `analyze_query_optimization`, `recommend_table_design`, and `discover_data_sources` (AI-agent tools in `mcp-tools-data.ts`) — these are agent-side orchestration tools, not registered on the MCP server via `registerAllTools`; they are not reachable through the MCP endpoint.

## Security-critical guard

**Guard function**: `validateSqlQuery` in `packages/sql-builder/src/sql-validator.ts`  
**Called by**: `packages/mcp-server/src/tools/query.ts` — the `query` MCP tool  
**Contract**: throws `Error` on reject, returns `void` on allow

**Rejected statements asserted (20 cases)**:
`INSERT`, `ALTER TABLE`, `DROP TABLE`, `TRUNCATE TABLE`, `CREATE TABLE`, `CREATE USER`, `RENAME TABLE`, `OPTIMIZE TABLE`, `SYSTEM RELOAD`, `SYSTEM FLUSH LOGS`, `GRANT`, `ATTACH`, `DETACH`, `DELETE`, `ALTER ... UPDATE` (CH mutation), `ALTER ... DELETE` (CH mutation), `SELECT 1; DROP TABLE` (chained), `SELECT; INSERT` (chained), `SET` variable, `KILL QUERY`

**Allowed statements asserted (11 cases)**:
`SELECT 1`, `SELECT FROM system.*`, `SELECT` with WHERE/ORDER BY, `WITH ... SELECT` (CTE), `DESCRIBE TABLE`, `EXPLAIN SELECT`, `EXPLAIN PIPELINE`, `EXPLAIN AST`, SELECT with leading block comment, SELECT with inline comment, multiline SELECT

No reachable write path was found. STOP condition was not triggered.

## Verification

```
bun test src/lib/__tests__/mcp-readonly-enforcement.test.ts --isolate
→ 31 pass, 0 fail

bun test src/ --isolate
→ 1688 pass, 0 fail (full dashboard suite, stays green)

bun run type-check:test
→ no errors in touched files (pre-existing route-tree gen errors are unrelated)

bun run check (biome)
→ Checked 1496 files. No fixes applied.
```

https://claude.ai/code/session_012TwMqL4qgXSKBBvR1DZjoH