### PR TITLE
feat(deploy): add Railway/Render/Fly one-click templates

### DIFF
--- a/deploy/templates/fly.toml
+++ b/deploy/templates/fly.toml
@@ -1,0 +1,54 @@
+# fly.toml — community template for chmonitor on Fly.io
+# Not yet boot-verified in CI; verify before relying on it in production.
+#
+# Usage:
+#   1. Replace the placeholder env vars below (or set them as secrets:
+#        fly secrets set CLICKHOUSE_PASSWORD=your-password)
+#   2. fly launch --no-deploy  (to import this config)
+#   3. fly deploy
+
+app = "chmonitor"          # Replace with your Fly app name
+primary_region = "iad"     # Replace with your preferred region
+
+[build]
+  image = "ghcr.io/duyet/chmonitor:latest"
+
+[env]
+  # Required — point at your ClickHouse HTTP interface.
+  # Prefer secrets for sensitive values: `fly secrets set CLICKHOUSE_PASSWORD=...`
+  CLICKHOUSE_HOST     = "http://YOUR_CLICKHOUSE_HOST:8123"
+  CLICKHOUSE_USER     = "YOUR_CLICKHOUSE_USER"
+  PORT                = "3000"
+  HOST                = "0.0.0.0"
+
+# CLICKHOUSE_PASSWORD should be set as a Fly secret, not in plain text here:
+#   fly secrets set CLICKHOUSE_PASSWORD=your-password
+
+[[services]]
+  protocol    = "tcp"
+  internal_port = 3000
+
+  [[services.ports]]
+    port     = 443
+    handlers = ["tls", "http"]
+
+  [[services.ports]]
+    port     = 80
+    handlers = ["http"]
+
+  [services.concurrency]
+    type       = "connections"
+    hard_limit = 25
+    soft_limit = 20
+
+  [[services.http_checks]]
+    path              = "/api/healthz"
+    interval          = "10s"
+    timeout           = "5s"
+    grace_period      = "20s"
+    restart_limit     = 3
+
+[vm]
+  cpu_kind = "shared"
+  cpus     = 1
+  memory   = "512mb"

--- a/deploy/templates/railway.json
+++ b/deploy/templates/railway.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "IMAGE",
+    "image": "ghcr.io/duyet/chmonitor:latest"
+  },
+  "deploy": {
+    "numReplicas": 1,
+    "startCommand": "node server/index.mjs",
+    "healthcheckPath": "/api/healthz",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  },
+  "environments": {
+    "production": {
+      "CLICKHOUSE_HOST": {
+        "default": "http://YOUR_CLICKHOUSE_HOST:8123"
+      },
+      "CLICKHOUSE_USER": {
+        "default": "YOUR_CLICKHOUSE_USER"
+      },
+      "CLICKHOUSE_PASSWORD": {
+        "default": "YOUR_CLICKHOUSE_PASSWORD"
+      },
+      "PORT": {
+        "default": "3000"
+      },
+      "HOST": {
+        "default": "0.0.0.0"
+      }
+    }
+  }
+}

--- a/deploy/templates/render.yaml
+++ b/deploy/templates/render.yaml
@@ -1,0 +1,25 @@
+services:
+  - type: web
+    name: chmonitor
+    # Community template — not yet boot-verified in CI.
+    # Replace the placeholder values below before deploying.
+    image: ghcr.io/duyet/chmonitor:latest
+    # Render pulls the image from GHCR (public, no registry credentials needed).
+    plan: starter
+    numInstances: 1
+    healthCheckPath: /api/healthz
+    envVars:
+      - key: CLICKHOUSE_HOST
+        # Required — e.g. http://your-clickhouse-host:8123
+        value: http://YOUR_CLICKHOUSE_HOST:8123
+      - key: CLICKHOUSE_USER
+        value: YOUR_CLICKHOUSE_USER
+      - key: CLICKHOUSE_PASSWORD
+        value: YOUR_CLICKHOUSE_PASSWORD
+      - key: PORT
+        value: "3000"
+      - key: HOST
+        value: "0.0.0.0"
+    ports:
+      - port: 3000
+        protocol: TCP

--- a/docs/content/deploy/one-click.mdx
+++ b/docs/content/deploy/one-click.mdx
@@ -1,0 +1,101 @@
+# One-Click Deploy Templates
+
+Community templates for deploying chmonitor on Railway, Render, and Fly.io.
+
+> **Honest note:** These are starting-point templates, not verified CI pipelines. They have not been boot-tested end-to-end against a live ClickHouse instance in automated CI. Review the env var placeholders, substitute real values, and verify the deployment works in your environment before relying on it in production.
+
+All three templates run the published image `ghcr.io/duyet/chmonitor:latest`, expose port 3000, and define a health check against `/api/healthz`. You must supply three env vars:
+
+| Variable | Description |
+|---|---|
+| `CLICKHOUSE_HOST` | ClickHouse HTTP URL, e.g. `http://your-host:8123` |
+| `CLICKHOUSE_USER` | ClickHouse username |
+| `CLICKHOUSE_PASSWORD` | ClickHouse password (use your platform's secret store) |
+
+The template files live in [`deploy/templates/`](https://github.com/duyet/clickhouse-monitoring/tree/main/deploy/templates) in the repository.
+
+---
+
+## Railway
+
+Template: [`deploy/templates/railway.json`](https://github.com/duyet/clickhouse-monitoring/blob/main/deploy/templates/railway.json)
+
+1. In the Railway dashboard, choose **New Project → Deploy from image**.
+2. Set the image to `ghcr.io/duyet/chmonitor:latest`.
+3. Add the three env vars above (Railway → Variables tab). Use Railway's secret management for `CLICKHOUSE_PASSWORD`.
+4. Railway auto-assigns a public URL. The health check path is `/api/healthz`.
+
+Alternatively, copy `deploy/templates/railway.json` into your repository root as `railway.json` — Railway picks it up automatically on the next deploy.
+
+```json
+{
+  "build": {
+    "builder": "IMAGE",
+    "image": "ghcr.io/duyet/chmonitor:latest"
+  },
+  "deploy": {
+    "healthcheckPath": "/api/healthz"
+  }
+}
+```
+
+---
+
+## Render
+
+Template: [`deploy/templates/render.yaml`](https://github.com/duyet/clickhouse-monitoring/blob/main/deploy/templates/render.yaml)
+
+1. Fork or copy `deploy/templates/render.yaml` as `render.yaml` in your repository root.
+2. In the Render dashboard, choose **New → Blueprint** and point it at your repository.
+3. Render reads `render.yaml`, pulls `ghcr.io/duyet/chmonitor:latest`, and creates the service.
+4. Set `CLICKHOUSE_PASSWORD` as a **Secret** in the Render environment (do not store it in plain text in `render.yaml`).
+
+Key snippet:
+
+```yaml
+services:
+  - type: web
+    name: chmonitor
+    image: ghcr.io/duyet/chmonitor:latest
+    healthCheckPath: /api/healthz
+    envVars:
+      - key: CLICKHOUSE_HOST
+        value: http://YOUR_CLICKHOUSE_HOST:8123
+      - key: CLICKHOUSE_USER
+        value: YOUR_CLICKHOUSE_USER
+      - key: CLICKHOUSE_PASSWORD
+        value: YOUR_CLICKHOUSE_PASSWORD   # use Render secret instead
+```
+
+---
+
+## Fly.io
+
+Template: [`deploy/templates/fly.toml`](https://github.com/duyet/clickhouse-monitoring/blob/main/deploy/templates/fly.toml)
+
+1. Install the [Fly CLI](https://fly.io/docs/hands-on/install-flyctl/) and run `fly auth login`.
+2. Copy `deploy/templates/fly.toml` to your working directory.
+3. Edit `app`, `primary_region`, and `CLICKHOUSE_HOST` / `CLICKHOUSE_USER`.
+4. Store the password as a secret (not in `fly.toml`):
+
+```bash
+fly secrets set CLICKHOUSE_PASSWORD=your-password
+```
+
+5. Deploy:
+
+```bash
+fly launch --no-deploy   # imports fly.toml
+fly deploy
+```
+
+The health check polls `/api/healthz` every 10 seconds with a 20-second grace period on startup.
+
+---
+
+## After deploying
+
+- Open `https://your-app-url` — you should land on the overview page.
+- If the page loads but charts are empty, check that the ClickHouse user has `SELECT` on `system.*`.
+- If the health check fails, verify `CLICKHOUSE_HOST` is reachable from inside the container (use the private/internal hostname your platform provides, not `localhost`).
+- For additional configuration (authentication, AI agent, conversation store), see the [Docker deploy guide](/docs/deploy/docker) — the same env vars apply.

--- a/docs/versions/v0.3/deploy/one-click.mdx
+++ b/docs/versions/v0.3/deploy/one-click.mdx
@@ -1,0 +1,101 @@
+# One-Click Deploy Templates
+
+Community templates for deploying chmonitor on Railway, Render, and Fly.io.
+
+> **Honest note:** These are starting-point templates, not verified CI pipelines. They have not been boot-tested end-to-end against a live ClickHouse instance in automated CI. Review the env var placeholders, substitute real values, and verify the deployment works in your environment before relying on it in production.
+
+All three templates run the published image `ghcr.io/duyet/chmonitor:latest`, expose port 3000, and define a health check against `/api/healthz`. You must supply three env vars:
+
+| Variable | Description |
+|---|---|
+| `CLICKHOUSE_HOST` | ClickHouse HTTP URL, e.g. `http://your-host:8123` |
+| `CLICKHOUSE_USER` | ClickHouse username |
+| `CLICKHOUSE_PASSWORD` | ClickHouse password (use your platform's secret store) |
+
+The template files live in [`deploy/templates/`](https://github.com/duyet/clickhouse-monitoring/tree/main/deploy/templates) in the repository.
+
+---
+
+## Railway
+
+Template: [`deploy/templates/railway.json`](https://github.com/duyet/clickhouse-monitoring/blob/main/deploy/templates/railway.json)
+
+1. In the Railway dashboard, choose **New Project → Deploy from image**.
+2. Set the image to `ghcr.io/duyet/chmonitor:latest`.
+3. Add the three env vars above (Railway → Variables tab). Use Railway's secret management for `CLICKHOUSE_PASSWORD`.
+4. Railway auto-assigns a public URL. The health check path is `/api/healthz`.
+
+Alternatively, copy `deploy/templates/railway.json` into your repository root as `railway.json` — Railway picks it up automatically on the next deploy.
+
+```json
+{
+  "build": {
+    "builder": "IMAGE",
+    "image": "ghcr.io/duyet/chmonitor:latest"
+  },
+  "deploy": {
+    "healthcheckPath": "/api/healthz"
+  }
+}
+```
+
+---
+
+## Render
+
+Template: [`deploy/templates/render.yaml`](https://github.com/duyet/clickhouse-monitoring/blob/main/deploy/templates/render.yaml)
+
+1. Fork or copy `deploy/templates/render.yaml` as `render.yaml` in your repository root.
+2. In the Render dashboard, choose **New → Blueprint** and point it at your repository.
+3. Render reads `render.yaml`, pulls `ghcr.io/duyet/chmonitor:latest`, and creates the service.
+4. Set `CLICKHOUSE_PASSWORD` as a **Secret** in the Render environment (do not store it in plain text in `render.yaml`).
+
+Key snippet:
+
+```yaml
+services:
+  - type: web
+    name: chmonitor
+    image: ghcr.io/duyet/chmonitor:latest
+    healthCheckPath: /api/healthz
+    envVars:
+      - key: CLICKHOUSE_HOST
+        value: http://YOUR_CLICKHOUSE_HOST:8123
+      - key: CLICKHOUSE_USER
+        value: YOUR_CLICKHOUSE_USER
+      - key: CLICKHOUSE_PASSWORD
+        value: YOUR_CLICKHOUSE_PASSWORD   # use Render secret instead
+```
+
+---
+
+## Fly.io
+
+Template: [`deploy/templates/fly.toml`](https://github.com/duyet/clickhouse-monitoring/blob/main/deploy/templates/fly.toml)
+
+1. Install the [Fly CLI](https://fly.io/docs/hands-on/install-flyctl/) and run `fly auth login`.
+2. Copy `deploy/templates/fly.toml` to your working directory.
+3. Edit `app`, `primary_region`, and `CLICKHOUSE_HOST` / `CLICKHOUSE_USER`.
+4. Store the password as a secret (not in `fly.toml`):
+
+```bash
+fly secrets set CLICKHOUSE_PASSWORD=your-password
+```
+
+5. Deploy:
+
+```bash
+fly launch --no-deploy   # imports fly.toml
+fly deploy
+```
+
+The health check polls `/api/healthz` every 10 seconds with a 20-second grace period on startup.
+
+---
+
+## After deploying
+
+- Open `https://your-app-url` — you should land on the overview page.
+- If the page loads but charts are empty, check that the ClickHouse user has `SELECT` on `system.*`.
+- If the health check fails, verify `CLICKHOUSE_HOST` is reachable from inside the container (use the private/internal hostname your platform provides, not `localhost`).
+- For additional configuration (authentication, AI agent, conversation store), see the [Docker deploy guide](/docs/deploy/docker) — the same env vars apply.


### PR DESCRIPTION
## What changed

Adds three community deploy templates and a documentation page for deploying chmonitor on Railway, Render, and Fly.io.

## Why (plan reference)

Plan 04b — one-click deploy templates. Provides an honest starting-point for users who want to run `ghcr.io/duyet/chmonitor:latest` on common PaaS platforms without setting up Docker or Kubernetes.

## Scope

New files only — no existing files modified:
- `deploy/templates/railway.json` — Railway image deploy config with health check on `/api/healthz`
- `deploy/templates/render.yaml` — Render Blueprint with image deploy and health check
- `deploy/templates/fly.toml` — Fly.io config using the published image, health check, and secrets guidance
- `docs/content/deploy/one-click.mdx` — Documentation for all three templates with honest caveat
- `docs/versions/v0.3/deploy/one-click.mdx` — Identical mirror for v0.3 versioned docs

All templates use `ghcr.io/duyet/chmonitor:latest`, expose port 3000, define a health check against `/api/healthz`, and require `CLICKHOUSE_HOST` / `CLICKHOUSE_USER` / `CLICKHOUSE_PASSWORD` as clearly-marked placeholders. No deploy buttons requiring secrets. Cloudflare production path (wrangler/cloudflare.yml) is untouched.

## How verified

- `bun run check` (Biome): 1497 files checked, no fixes applied — clean.
- Templates manually reviewed against `docker-compose.yml` (port 3000, `/api/healthz` health check, same env vars).
- No `bun run build` / Vite invoked (as instructed).

https://claude.ai/code/session_012TwMqL4qgXSKBBvR1DZjoH