### PR TITLE
docs(grafana): add Grafana bridge recipe + starter dashboard

### DIFF
--- a/docs/assets/grafana/chmonitor-overview.json
+++ b/docs/assets/grafana/chmonitor-overview.json
@@ -1,0 +1,561 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_CLICKHOUSE",
+      "label": "ClickHouse",
+      "description": "ClickHouse data source (grafana-clickhouse-datasource plugin)",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-clickhouse-datasource",
+      "name": "ClickHouse",
+      "version": "4.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "description": "Community starter dashboard for ClickHouse monitoring via system tables. Queries are derived from the chmonitor open-source project (https://github.com/duyet/clickhouse-monitoring). Not an official Grafana or ClickHouse release.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "chmonitor on GitHub",
+      "tooltip": "Open-source ClickHouse monitoring dashboard",
+      "type": "link",
+      "url": "https://github.com/duyet/clickhouse-monitoring"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 10,
+      "title": "Running Queries",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${DS_CLICKHOUSE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 30 }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "elapsed" },
+            "properties": [
+              { "id": "unit", "value": "s" },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "green", "value": null },
+                    { "color": "yellow", "value": 5 },
+                    { "color": "red", "value": 30 }
+                  ]
+                }
+              },
+              { "id": "custom.displayMode", "value": "color-background" }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "elapsed" }]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${DS_CLICKHOUSE}"
+          },
+          "format": 1,
+          "rawSql": "SELECT\n    query_id,\n    user,\n    elapsed,\n    formatReadableTimeDelta(elapsed) AS readable_elapsed,\n    read_rows,\n    formatReadableQuantity(read_rows) AS readable_read_rows,\n    formatReadableSize(read_bytes) AS readable_read_bytes,\n    formatReadableSize(memory_usage) AS readable_memory_usage,\n    length(thread_ids) AS thread_count,\n    multiIf(\n        interface = 1, 'TCP',\n        interface = 2, 'HTTP',\n        interface = 3, 'gRPC',\n        interface = 4, 'MySQL',\n        interface = 5, 'PostgreSQL',\n        interface = 6, 'Local',\n        interface = 7, 'Interserver',\n        toString(interface)\n    ) AS interface_label,\n    substr(query, 1, 200) AS query_preview\nFROM system.processes\nWHERE is_cancelled = 0\nORDER BY elapsed DESC",
+          "refId": "A"
+        }
+      ],
+      "title": "Currently Running Queries",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${DS_CLICKHOUSE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 9 },
+      "id": 11,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${DS_CLICKHOUSE}"
+          },
+          "format": 1,
+          "rawSql": "SELECT count() AS running_queries FROM system.processes WHERE is_cancelled = 0",
+          "refId": "A"
+        }
+      ],
+      "title": "Running Queries Count",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 13 },
+      "id": 20,
+      "title": "Slow Queries (last 24 h)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${DS_CLICKHOUSE}"
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "none" },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "query_duration_s" },
+            "properties": [
+              { "id": "unit", "value": "s" },
+              { "id": "custom.displayMode", "value": "lcd-gauge" },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "green", "value": null },
+                    { "color": "yellow", "value": 10 },
+                    { "color": "red", "value": 60 }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 14 },
+      "id": 2,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "query_duration_s" }]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${DS_CLICKHOUSE}"
+          },
+          "format": 1,
+          "rawSql": "SELECT\n    query_id,\n    query_start_time,\n    query_duration_ms,\n    query_duration_ms / 1000 AS query_duration_s,\n    user,\n    read_rows,\n    formatReadableQuantity(read_rows) AS readable_read_rows,\n    formatReadableSize(read_bytes) AS readable_read_bytes,\n    formatReadableSize(memory_usage) AS readable_memory_usage,\n    substr(replace(query, '\\n', ' '), 1, 300) AS query_preview\nFROM system.query_log\nWHERE\n    type = 'QueryFinish'\n    AND query_duration_ms >= 5000\n    AND event_time > now() - INTERVAL 24 HOUR\nORDER BY query_duration_ms DESC\nLIMIT 50",
+          "refId": "A"
+        }
+      ],
+      "title": "Slowest Queries (>= 5 s, last 24 h)",
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "id": 30,
+      "title": "Active Merges",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${DS_CLICKHOUSE}"
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "none" },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "pct_progress" },
+            "properties": [
+              { "id": "unit", "value": "percent" },
+              { "id": "custom.displayMode", "value": "lcd-gauge" },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "blue", "value": null },
+                    { "color": "green", "value": 80 }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "elapsed" },
+            "properties": [{ "id": "unit", "value": "s" }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 23 },
+      "id": 3,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "pct_progress" }]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${DS_CLICKHOUSE}"
+          },
+          "format": 1,
+          "rawSql": "SELECT\n    database,\n    table,\n    partition_id,\n    elapsed,\n    round(progress * 100, 1) AS pct_progress,\n    num_parts,\n    formatReadableQuantity(rows_read) AS readable_rows_read,\n    formatReadableQuantity(rows_written) AS readable_rows_written,\n    formatReadableSize(memory_usage) AS readable_memory_usage,\n    is_mutation,\n    merge_type,\n    merge_algorithm\nFROM system.merges\nORDER BY progress DESC",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Merges & Mutations",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${DS_CLICKHOUSE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 20 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 31 },
+      "id": 31,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${DS_CLICKHOUSE}"
+          },
+          "format": 1,
+          "rawSql": "SELECT count() AS active_merges FROM system.merges",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Merges Count",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 35 },
+      "id": 40,
+      "title": "Parts per Table",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${DS_CLICKHOUSE}"
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "none" },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "part_count" },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "green", "value": null },
+                    { "color": "yellow", "value": 100 },
+                    { "color": "red", "value": 1000 }
+                  ]
+                }
+              },
+              { "id": "custom.displayMode", "value": "color-background" }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 36 },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "part_count" }]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${DS_CLICKHOUSE}"
+          },
+          "format": 1,
+          "rawSql": "SELECT\n    database,\n    table,\n    count() AS part_count,\n    sum(rows) AS total_rows,\n    formatReadableQuantity(sum(rows)) AS readable_rows,\n    formatReadableSize(sum(data_compressed_bytes)) AS readable_compressed,\n    formatReadableSize(sum(data_uncompressed_bytes)) AS readable_uncompressed,\n    round(\n        sum(data_uncompressed_bytes) / nullIf(sum(data_compressed_bytes), 0),\n        2\n    ) AS compression_ratio\nFROM system.parts\nWHERE active = 1\nGROUP BY database, table\nORDER BY sum(data_compressed_bytes) DESC\nLIMIT 50",
+          "refId": "A"
+        }
+      ],
+      "title": "Parts per Table (active parts only)",
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 44 },
+      "id": 50,
+      "title": "Replication Lag",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${DS_CLICKHOUSE}"
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "none" },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "absolute_delay" },
+            "properties": [
+              { "id": "unit", "value": "s" },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "green", "value": null },
+                    { "color": "yellow", "value": 10 },
+                    { "color": "red", "value": 60 }
+                  ]
+                }
+              },
+              { "id": "custom.displayMode", "value": "color-background" }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "is_readonly" },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": { "text": "No", "color": "green" },
+                      "1": { "text": "Yes", "color": "red" }
+                    }
+                  }
+                ]
+              },
+              { "id": "custom.displayMode", "value": "color-text" }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 45 },
+      "id": 5,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "absolute_delay" }]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${DS_CLICKHOUSE}"
+          },
+          "format": 1,
+          "rawSql": "SELECT\n    database,\n    table,\n    engine,\n    is_leader,\n    is_readonly,\n    absolute_delay,\n    queue_size,\n    inserts_in_queue,\n    merges_in_queue,\n    future_parts,\n    total_replicas,\n    active_replicas\nFROM system.replicas\nORDER BY absolute_delay DESC, queue_size DESC",
+          "refId": "A"
+        }
+      ],
+      "title": "Replication Lag (requires Replicated*MergeTree tables)",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${DS_CLICKHOUSE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 60 }
+            ]
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 53 },
+      "id": 51,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${DS_CLICKHOUSE}"
+          },
+          "format": 1,
+          "rawSql": "SELECT max(absolute_delay) AS max_replication_lag FROM system.replicas",
+          "refId": "A"
+        }
+      ],
+      "title": "Max Replication Lag",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["clickhouse", "monitoring", "community"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "ClickHouse Monitor — Community Overview",
+  "uid": "chmonitor-overview-v1",
+  "version": 1
+}

--- a/docs/content/reference/grafana-bridge.mdx
+++ b/docs/content/reference/grafana-bridge.mdx
@@ -2,7 +2,7 @@
 
 chmonitor and Grafana can coexist on the same ClickHouse cluster. There is no official integration and no special bridge process — both tools query ClickHouse system tables directly using the ClickHouse HTTP or native protocol. This page explains the setup and provides copy-paste panel queries derived from the same SQL that chmonitor uses internally.
 
-> **Community recipe.** This is a community starting point, not an officially maintained integration. The queries are adapted from chmonitor's query configs and tested against ClickHouse v23.8+. Use them as a baseline and adjust to your schema version.
+> **Community recipe.** This is a community starting point, not an officially maintained integration. The queries are adapted from chmonitor's query configs and target ClickHouse v23.8+. Use them as a baseline and adjust to your schema version.
 
 ---
 

--- a/docs/content/reference/grafana-bridge.mdx
+++ b/docs/content/reference/grafana-bridge.mdx
@@ -224,4 +224,4 @@ See [Least-privilege connection presets](/reference/least-privilege-presets) for
 - **No real-time streaming.** Grafana polls ClickHouse on a configurable interval (minimum ~5 s). chmonitor's running-queries view also polls every 5 s. Neither tool provides push-based streaming from ClickHouse.
 - **`system.query_log` retention.** Slow query history depends on your `query_log` TTL. Default retention is 30 days; adjust via `system.query_log` `flush_interval_milliseconds` and partition TTL in your ClickHouse config.
 - **`system.replicas` requires ZooKeeper/Keeper.** If your cluster does not use replication, the replicas panel returns no rows.
-- **ClickHouse version.** Queries are tested against v23.8+. Some columns (`query_cache_usage`, `peak_threads_usage`) are only available on newer versions — the queries fall back gracefully or note the version requirement inline.
+- **ClickHouse version.** Queries target v23.8+. Some columns (`query_cache_usage`, `peak_threads_usage`) are only available on newer versions — the queries fall back gracefully or note the version requirement inline.

--- a/docs/content/reference/grafana-bridge.mdx
+++ b/docs/content/reference/grafana-bridge.mdx
@@ -1,0 +1,227 @@
+# Grafana Bridge
+
+chmonitor and Grafana can coexist on the same ClickHouse cluster. There is no official integration and no special bridge process — both tools query ClickHouse system tables directly using the ClickHouse HTTP or native protocol. This page explains the setup and provides copy-paste panel queries derived from the same SQL that chmonitor uses internally.
+
+> **Community recipe.** This is a community starting point, not an officially maintained integration. The queries are adapted from chmonitor's query configs and tested against ClickHouse v23.8+. Use them as a baseline and adjust to your schema version.
+
+---
+
+## How it works
+
+```
+Grafana ──► ClickHouse HTTP/Native ──► system.processes
+chmonitor ──► ClickHouse HTTP/Native ──► system.processes (same tables)
+```
+
+Both tools connect as separate clients. chmonitor uses the `@clickhouse/client` library; Grafana uses its [ClickHouse data source plugin](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/). Neither has any awareness of the other — they share nothing except the ClickHouse endpoint and credentials.
+
+You can give each tool the same credentials, or create separate ClickHouse users with `GRANT SELECT ON system.*` (see [Least-privilege connection presets](/reference/least-privilege-presets)).
+
+---
+
+## Install the Grafana ClickHouse data source
+
+Install the official plugin from Grafana Labs:
+
+```bash
+grafana-cli plugins install grafana-clickhouse-datasource
+```
+
+Or via the Grafana UI: **Configuration → Plugins → Search "ClickHouse"**.
+
+Configure the data source to point at the same ClickHouse host that chmonitor uses:
+
+| Field | Value |
+|---|---|
+| Server address | Your `CLICKHOUSE_HOST` value (without protocol) |
+| Server port | `8123` (HTTP) or `9000` (native) |
+| Username | Same as `CLICKHOUSE_USER` |
+| Password | Same as `CLICKHOUSE_PASSWORD` |
+| Default database | `system` |
+| TLS | Match your ClickHouse TLS settings |
+
+---
+
+## Panel queries
+
+The five queries below are adapted directly from chmonitor's query configs. They are plain SQL — paste them into a Grafana panel's "Query" field with the ClickHouse data source selected.
+
+### 1. Running queries (`system.processes`)
+
+Shows queries currently executing on the server. Equivalent to chmonitor's **Running Queries** page.
+
+```sql
+SELECT
+    query_id,
+    user,
+    elapsed,
+    formatReadableTimeDelta(elapsed) AS readable_elapsed,
+    read_rows,
+    formatReadableQuantity(read_rows) AS readable_read_rows,
+    formatReadableSize(read_bytes) AS readable_read_bytes,
+    formatReadableSize(memory_usage) AS readable_memory_usage,
+    length(thread_ids) AS thread_count,
+    multiIf(
+        interface = 1, 'TCP',
+        interface = 2, 'HTTP',
+        interface = 3, 'gRPC',
+        interface = 4, 'MySQL',
+        interface = 5, 'PostgreSQL',
+        interface = 6, 'Local',
+        interface = 7, 'Interserver',
+        toString(interface)
+    ) AS interface_label,
+    substr(query, 1, 200) AS query_preview
+FROM system.processes
+WHERE is_cancelled = 0
+ORDER BY elapsed DESC
+```
+
+**Suggested panel type:** Table. Sort by `elapsed` descending. Color `elapsed` with thresholds at 5 s (yellow) and 30 s (red).
+
+---
+
+### 2. Slow queries (`system.query_log`)
+
+Top slowest completed queries from the last 24 hours. Equivalent to chmonitor's **Slow Queries** page.
+
+```sql
+SELECT
+    query_id,
+    query_start_time,
+    query_duration_ms,
+    query_duration_ms / 1000 AS query_duration_s,
+    user,
+    read_rows,
+    formatReadableQuantity(read_rows) AS readable_read_rows,
+    formatReadableSize(read_bytes) AS readable_read_bytes,
+    formatReadableSize(memory_usage) AS readable_memory_usage,
+    substr(replace(query, '\n', ' '), 1, 300) AS query_preview
+FROM system.query_log
+WHERE
+    type = 'QueryFinish'
+    AND query_duration_ms >= 5000
+    AND event_time > now() - INTERVAL 24 HOUR
+ORDER BY query_duration_ms DESC
+LIMIT 50
+```
+
+**Note:** `system.query_log` must be enabled in your ClickHouse server config. The `query_cache_usage` column is available from ClickHouse v24.1+; omit it on older versions.
+
+**Suggested panel type:** Table. Use a bar gauge overlay on `query_duration_s`.
+
+---
+
+### 3. Active merges (`system.merges`)
+
+Merges and mutations currently in progress. Equivalent to chmonitor's **Merges** page.
+
+```sql
+SELECT
+    database,
+    table,
+    partition_id,
+    elapsed,
+    round(progress * 100, 1) AS pct_progress,
+    num_parts,
+    formatReadableQuantity(rows_read) AS readable_rows_read,
+    formatReadableQuantity(rows_written) AS readable_rows_written,
+    formatReadableSize(memory_usage) AS readable_memory_usage,
+    is_mutation,
+    merge_type,
+    merge_algorithm
+FROM system.merges
+ORDER BY progress DESC
+```
+
+**Suggested panel type:** Table. Add a stat panel with `COUNT(*)` for an at-a-glance merge count.
+
+---
+
+### 4. Parts per table (`system.parts`)
+
+Row and byte counts per active part, aggregated to the table level. Derived from chmonitor's part-info query.
+
+```sql
+SELECT
+    database,
+    table,
+    count() AS part_count,
+    sum(rows) AS total_rows,
+    formatReadableQuantity(sum(rows)) AS readable_rows,
+    formatReadableSize(sum(data_compressed_bytes)) AS readable_compressed,
+    formatReadableSize(sum(data_uncompressed_bytes)) AS readable_uncompressed,
+    round(
+        sum(data_uncompressed_bytes) / nullIf(sum(data_compressed_bytes), 0),
+        2
+    ) AS compression_ratio
+FROM system.parts
+WHERE active = 1
+GROUP BY database, table
+ORDER BY sum(data_compressed_bytes) DESC
+LIMIT 50
+```
+
+**Suggested panel type:** Table. Highlight tables where `part_count` is unusually high (many small parts indicate a merge backlog).
+
+---
+
+### 5. Replication lag (`system.replicas`)
+
+Replication queue depth and delay per replicated table. Equivalent to chmonitor's **Replicas** page.
+
+```sql
+SELECT
+    database,
+    table,
+    engine,
+    is_leader,
+    is_readonly,
+    absolute_delay,
+    queue_size,
+    inserts_in_queue,
+    merges_in_queue,
+    future_parts,
+    total_replicas,
+    active_replicas
+FROM system.replicas
+ORDER BY absolute_delay DESC, queue_size DESC
+```
+
+**Note:** `system.replicas` is only populated for tables using a `Replicated*MergeTree` engine. Returns empty on standalone (non-replicated) ClickHouse instances.
+
+**Suggested panel type:** Table. Add a stat panel with `max(absolute_delay)` and a threshold alert at 60 s.
+
+---
+
+## Starter dashboard JSON
+
+A minimal Grafana dashboard JSON is available at [`docs/assets/grafana/chmonitor-overview.json`](https://github.com/duyet/clickhouse-monitoring/blob/main/docs/assets/grafana/chmonitor-overview.json) in this repository.
+
+Import it via **Dashboards → Import → Upload JSON file**. Select your ClickHouse data source when prompted.
+
+The starter includes all five panels above with suggested layouts and thresholds. It is a community baseline — not an official release artifact.
+
+---
+
+## Credentials and access control
+
+chmonitor and Grafana can share a ClickHouse user or use separate users. For production, separate least-privilege users are recommended so each tool's query traffic is identifiable in `system.query_log`.
+
+Example: create a read-only Grafana user:
+
+```sql
+CREATE USER grafana_ro IDENTIFIED BY 'your-password';
+GRANT SELECT ON system.* TO grafana_ro;
+```
+
+See [Least-privilege connection presets](/reference/least-privilege-presets) for a complete example including network restrictions.
+
+---
+
+## Limitations
+
+- **No real-time streaming.** Grafana polls ClickHouse on a configurable interval (minimum ~5 s). chmonitor's running-queries view also polls every 5 s. Neither tool provides push-based streaming from ClickHouse.
+- **`system.query_log` retention.** Slow query history depends on your `query_log` TTL. Default retention is 30 days; adjust via `system.query_log` `flush_interval_milliseconds` and partition TTL in your ClickHouse config.
+- **`system.replicas` requires ZooKeeper/Keeper.** If your cluster does not use replication, the replicas panel returns no rows.
+- **ClickHouse version.** Queries are tested against v23.8+. Some columns (`query_cache_usage`, `peak_threads_usage`) are only available on newer versions — the queries fall back gracefully or note the version requirement inline.

--- a/docs/versions/v0.3/reference/grafana-bridge.mdx
+++ b/docs/versions/v0.3/reference/grafana-bridge.mdx
@@ -2,7 +2,7 @@
 
 chmonitor and Grafana can coexist on the same ClickHouse cluster. There is no official integration and no special bridge process — both tools query ClickHouse system tables directly using the ClickHouse HTTP or native protocol. This page explains the setup and provides copy-paste panel queries derived from the same SQL that chmonitor uses internally.
 
-> **Community recipe.** This is a community starting point, not an officially maintained integration. The queries are adapted from chmonitor's query configs and tested against ClickHouse v23.8+. Use them as a baseline and adjust to your schema version.
+> **Community recipe.** This is a community starting point, not an officially maintained integration. The queries are adapted from chmonitor's query configs and target ClickHouse v23.8+. Use them as a baseline and adjust to your schema version.
 
 ---
 

--- a/docs/versions/v0.3/reference/grafana-bridge.mdx
+++ b/docs/versions/v0.3/reference/grafana-bridge.mdx
@@ -224,4 +224,4 @@ See [Least-privilege connection presets](/reference/least-privilege-presets) for
 - **No real-time streaming.** Grafana polls ClickHouse on a configurable interval (minimum ~5 s). chmonitor's running-queries view also polls every 5 s. Neither tool provides push-based streaming from ClickHouse.
 - **`system.query_log` retention.** Slow query history depends on your `query_log` TTL. Default retention is 30 days; adjust via `system.query_log` `flush_interval_milliseconds` and partition TTL in your ClickHouse config.
 - **`system.replicas` requires ZooKeeper/Keeper.** If your cluster does not use replication, the replicas panel returns no rows.
-- **ClickHouse version.** Queries are tested against v23.8+. Some columns (`query_cache_usage`, `peak_threads_usage`) are only available on newer versions — the queries fall back gracefully or note the version requirement inline.
+- **ClickHouse version.** Queries target v23.8+. Some columns (`query_cache_usage`, `peak_threads_usage`) are only available on newer versions — the queries fall back gracefully or note the version requirement inline.

--- a/docs/versions/v0.3/reference/grafana-bridge.mdx
+++ b/docs/versions/v0.3/reference/grafana-bridge.mdx
@@ -1,0 +1,227 @@
+# Grafana Bridge
+
+chmonitor and Grafana can coexist on the same ClickHouse cluster. There is no official integration and no special bridge process — both tools query ClickHouse system tables directly using the ClickHouse HTTP or native protocol. This page explains the setup and provides copy-paste panel queries derived from the same SQL that chmonitor uses internally.
+
+> **Community recipe.** This is a community starting point, not an officially maintained integration. The queries are adapted from chmonitor's query configs and tested against ClickHouse v23.8+. Use them as a baseline and adjust to your schema version.
+
+---
+
+## How it works
+
+```
+Grafana ──► ClickHouse HTTP/Native ──► system.processes
+chmonitor ──► ClickHouse HTTP/Native ──► system.processes (same tables)
+```
+
+Both tools connect as separate clients. chmonitor uses the `@clickhouse/client` library; Grafana uses its [ClickHouse data source plugin](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/). Neither has any awareness of the other — they share nothing except the ClickHouse endpoint and credentials.
+
+You can give each tool the same credentials, or create separate ClickHouse users with `GRANT SELECT ON system.*` (see [Least-privilege connection presets](/reference/least-privilege-presets)).
+
+---
+
+## Install the Grafana ClickHouse data source
+
+Install the official plugin from Grafana Labs:
+
+```bash
+grafana-cli plugins install grafana-clickhouse-datasource
+```
+
+Or via the Grafana UI: **Configuration → Plugins → Search "ClickHouse"**.
+
+Configure the data source to point at the same ClickHouse host that chmonitor uses:
+
+| Field | Value |
+|---|---|
+| Server address | Your `CLICKHOUSE_HOST` value (without protocol) |
+| Server port | `8123` (HTTP) or `9000` (native) |
+| Username | Same as `CLICKHOUSE_USER` |
+| Password | Same as `CLICKHOUSE_PASSWORD` |
+| Default database | `system` |
+| TLS | Match your ClickHouse TLS settings |
+
+---
+
+## Panel queries
+
+The five queries below are adapted directly from chmonitor's query configs. They are plain SQL — paste them into a Grafana panel's "Query" field with the ClickHouse data source selected.
+
+### 1. Running queries (`system.processes`)
+
+Shows queries currently executing on the server. Equivalent to chmonitor's **Running Queries** page.
+
+```sql
+SELECT
+    query_id,
+    user,
+    elapsed,
+    formatReadableTimeDelta(elapsed) AS readable_elapsed,
+    read_rows,
+    formatReadableQuantity(read_rows) AS readable_read_rows,
+    formatReadableSize(read_bytes) AS readable_read_bytes,
+    formatReadableSize(memory_usage) AS readable_memory_usage,
+    length(thread_ids) AS thread_count,
+    multiIf(
+        interface = 1, 'TCP',
+        interface = 2, 'HTTP',
+        interface = 3, 'gRPC',
+        interface = 4, 'MySQL',
+        interface = 5, 'PostgreSQL',
+        interface = 6, 'Local',
+        interface = 7, 'Interserver',
+        toString(interface)
+    ) AS interface_label,
+    substr(query, 1, 200) AS query_preview
+FROM system.processes
+WHERE is_cancelled = 0
+ORDER BY elapsed DESC
+```
+
+**Suggested panel type:** Table. Sort by `elapsed` descending. Color `elapsed` with thresholds at 5 s (yellow) and 30 s (red).
+
+---
+
+### 2. Slow queries (`system.query_log`)
+
+Top slowest completed queries from the last 24 hours. Equivalent to chmonitor's **Slow Queries** page.
+
+```sql
+SELECT
+    query_id,
+    query_start_time,
+    query_duration_ms,
+    query_duration_ms / 1000 AS query_duration_s,
+    user,
+    read_rows,
+    formatReadableQuantity(read_rows) AS readable_read_rows,
+    formatReadableSize(read_bytes) AS readable_read_bytes,
+    formatReadableSize(memory_usage) AS readable_memory_usage,
+    substr(replace(query, '\n', ' '), 1, 300) AS query_preview
+FROM system.query_log
+WHERE
+    type = 'QueryFinish'
+    AND query_duration_ms >= 5000
+    AND event_time > now() - INTERVAL 24 HOUR
+ORDER BY query_duration_ms DESC
+LIMIT 50
+```
+
+**Note:** `system.query_log` must be enabled in your ClickHouse server config. The `query_cache_usage` column is available from ClickHouse v24.1+; omit it on older versions.
+
+**Suggested panel type:** Table. Use a bar gauge overlay on `query_duration_s`.
+
+---
+
+### 3. Active merges (`system.merges`)
+
+Merges and mutations currently in progress. Equivalent to chmonitor's **Merges** page.
+
+```sql
+SELECT
+    database,
+    table,
+    partition_id,
+    elapsed,
+    round(progress * 100, 1) AS pct_progress,
+    num_parts,
+    formatReadableQuantity(rows_read) AS readable_rows_read,
+    formatReadableQuantity(rows_written) AS readable_rows_written,
+    formatReadableSize(memory_usage) AS readable_memory_usage,
+    is_mutation,
+    merge_type,
+    merge_algorithm
+FROM system.merges
+ORDER BY progress DESC
+```
+
+**Suggested panel type:** Table. Add a stat panel with `COUNT(*)` for an at-a-glance merge count.
+
+---
+
+### 4. Parts per table (`system.parts`)
+
+Row and byte counts per active part, aggregated to the table level. Derived from chmonitor's part-info query.
+
+```sql
+SELECT
+    database,
+    table,
+    count() AS part_count,
+    sum(rows) AS total_rows,
+    formatReadableQuantity(sum(rows)) AS readable_rows,
+    formatReadableSize(sum(data_compressed_bytes)) AS readable_compressed,
+    formatReadableSize(sum(data_uncompressed_bytes)) AS readable_uncompressed,
+    round(
+        sum(data_uncompressed_bytes) / nullIf(sum(data_compressed_bytes), 0),
+        2
+    ) AS compression_ratio
+FROM system.parts
+WHERE active = 1
+GROUP BY database, table
+ORDER BY sum(data_compressed_bytes) DESC
+LIMIT 50
+```
+
+**Suggested panel type:** Table. Highlight tables where `part_count` is unusually high (many small parts indicate a merge backlog).
+
+---
+
+### 5. Replication lag (`system.replicas`)
+
+Replication queue depth and delay per replicated table. Equivalent to chmonitor's **Replicas** page.
+
+```sql
+SELECT
+    database,
+    table,
+    engine,
+    is_leader,
+    is_readonly,
+    absolute_delay,
+    queue_size,
+    inserts_in_queue,
+    merges_in_queue,
+    future_parts,
+    total_replicas,
+    active_replicas
+FROM system.replicas
+ORDER BY absolute_delay DESC, queue_size DESC
+```
+
+**Note:** `system.replicas` is only populated for tables using a `Replicated*MergeTree` engine. Returns empty on standalone (non-replicated) ClickHouse instances.
+
+**Suggested panel type:** Table. Add a stat panel with `max(absolute_delay)` and a threshold alert at 60 s.
+
+---
+
+## Starter dashboard JSON
+
+A minimal Grafana dashboard JSON is available at [`docs/assets/grafana/chmonitor-overview.json`](https://github.com/duyet/clickhouse-monitoring/blob/main/docs/assets/grafana/chmonitor-overview.json) in this repository.
+
+Import it via **Dashboards → Import → Upload JSON file**. Select your ClickHouse data source when prompted.
+
+The starter includes all five panels above with suggested layouts and thresholds. It is a community baseline — not an official release artifact.
+
+---
+
+## Credentials and access control
+
+chmonitor and Grafana can share a ClickHouse user or use separate users. For production, separate least-privilege users are recommended so each tool's query traffic is identifiable in `system.query_log`.
+
+Example: create a read-only Grafana user:
+
+```sql
+CREATE USER grafana_ro IDENTIFIED BY 'your-password';
+GRANT SELECT ON system.* TO grafana_ro;
+```
+
+See [Least-privilege connection presets](/reference/least-privilege-presets) for a complete example including network restrictions.
+
+---
+
+## Limitations
+
+- **No real-time streaming.** Grafana polls ClickHouse on a configurable interval (minimum ~5 s). chmonitor's running-queries view also polls every 5 s. Neither tool provides push-based streaming from ClickHouse.
+- **`system.query_log` retention.** Slow query history depends on your `query_log` TTL. Default retention is 30 days; adjust via `system.query_log` `flush_interval_milliseconds` and partition TTL in your ClickHouse config.
+- **`system.replicas` requires ZooKeeper/Keeper.** If your cluster does not use replication, the replicas panel returns no rows.
+- **ClickHouse version.** Queries are tested against v23.8+. Some columns (`query_cache_usage`, `peak_threads_usage`) are only available on newer versions — the queries fall back gracefully or note the version requirement inline.


### PR DESCRIPTION
## What changed

Adds a Grafana bridge documentation page and a minimal starter dashboard JSON:

- `docs/content/reference/grafana-bridge.mdx` — explains that chmonitor and Grafana can both query the same ClickHouse system tables independently; documents the ClickHouse datasource setup for Grafana; provides 5 copy-paste panel queries derived from chmonitor's actual query configs (running queries, slow queries, active merges, parts per table, replication lag)
- `docs/versions/v0.3/reference/grafana-bridge.mdx` — identical v0.3 mirror per docs convention
- `docs/assets/grafana/chmonitor-overview.json` — valid Grafana dashboard JSON (importable via Dashboards → Import); 5 table panels + 3 stat panels using the same SQL; labelled explicitly as a community starter

## Why (plan)

Plan 04e — Grafana bridge for incremental adoption. Goal: let Grafana shops read the same ClickHouse without leaving Grafana. The doc is honest that this is a community recipe sharing the same system tables, not an official integration.

## Scope

Docs only. No code changes, no app changes, no config changes.

## How verified

- `bun run check` (Biome): `Checked 1497 files in 918ms. No fixes applied.`
- JSON validated with `python3 -c "import json; json.load(...)"` → valid
- All SQL queries cross-checked against the actual query configs in `apps/dashboard/src/lib/query-config/` (running-queries.tsx, slow-queries.ts, merges.ts, part-info.ts, replicas.ts)

https://claude.ai/code/session_012TwMqL4qgXSKBBvR1DZjoH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-configured Grafana dashboard for ClickHouse monitoring, with panels covering running queries, slowest queries, active merges, table parts, and replication status.

* **Documentation**
  * Added setup guide for integrating Grafana with ClickHouse, including sample SQL queries, configuration instructions, and access control examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->