### PR TITLE
docs(readme): badges, self-host/cloud framing, fix stale v0.2 deploy steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Build and Test](https://github.com/duyet/clickhouse-monitoring/actions/workflows/ci.yml/badge.svg)](https://github.com/duyet/clickhouse-monitoring/actions/workflows/ci.yml)
 [![All-time uptime](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fduyet%2Fuptime%2FHEAD%2Fapi%2Fclickhouse-monitoring-vercel-app%2Fuptime.json)](https://duyet.github.io/uptime/history/clickhouse-monitoring-vercel-app)
+[![Latest release](https://img.shields.io/github/v/release/duyet/clickhouse-monitoring?sort=semver&label=release)](https://github.com/duyet/clickhouse-monitoring/releases)
+[![Docker image](https://img.shields.io/badge/ghcr.io-duyet%2Fchmonitor-2496ED?logo=docker&logoColor=white)](https://github.com/duyet/clickhouse-monitoring/pkgs/container/chmonitor)
+[![License](https://img.shields.io/github/license/duyet/clickhouse-monitoring)](LICENSE)
 
 A modern dashboard (TanStack Start, as of **v0.3**) that provides real-time insights into ClickHouse clusters through system tables. Every page is pre-rendered at build time with client-side data fetching for optimal performance and CDN caching.
 
@@ -32,6 +35,17 @@ A modern dashboard (TanStack Start, as of **v0.3**) that provides real-time insi
 
 
 ## Deployment
+
+chmonitor is **self-hosted** — run it next to your ClickHouse with the same
+`CLICKHOUSE_*` connection vars on any of these targets:
+
+- **[Docker](#docker)** — one `docker run`; the fastest path to a live dashboard.
+- **[Cloudflare Workers](#cloudflare-workers)** — global edge deploy (how the
+  demo at [dash.chmonitor.dev](https://dash.chmonitor.dev/?ref=github) runs).
+- **[One-click templates](docs/content/deploy/one-click.mdx)** — Railway, Render, Fly.io.
+- **[Kubernetes (Helm)](https://duyet.github.io/clickhouse-monitoring/deploy/k8s)** — for clusters.
+
+Prefer to look before you install? Try the live demo above — no setup required.
 
 ### Cloudflare Workers
 
@@ -110,17 +124,17 @@ bun run cf:deploy
 **Manual Deployment Steps:**
 ```bash
 # Step by step (same as CI)
-bun run cf:config      # Set secrets from .env.prod
-bun run cf:build       # Next.js build + OpenNext
+bun run cf:config        # Set secrets from .env.prod
+cd apps/dashboard
+bun run build            # Vite build → native Workers bundle (+ tsc --noEmit)
 wrangler deploy --minify
-opennextjs-cloudflare populateCache remote
 ```
 
 **Important Notes:**
-- Build uses **Webpack** (not Turbopack) due to Cloudflare Workers compatibility
-- Next.js version pinned to **15.5.x** (React 19) for stability
-- Static pages are pre-rendered at edge for optimal performance
-- API routes run on Workers using Fetch API
+- Built with **Vite** + `@cloudflare/vite-plugin` into a **native Workers bundle** — no OpenNext, no KV/R2/D1 cache-population step
+- **TanStack Start** + React 19 (the v0.2 Next.js app was retired in v0.3)
+- Static shell is pre-rendered at build time; data is fetched client-side for edge CDN caching
+- API routes run on Workers using the Fetch API
 - Supports multi-host monitoring with query parameter routing (`?host=0`)
 
 ### Docker
@@ -139,8 +153,8 @@ docker run -d \
 Tagged releases are built by GitHub Actions from tags matching `v*`. The release page includes:
 
 - Docker images published to `ghcr.io/duyet/chmonitor` with the release version tag
-- a Next.js standalone archive for Node.js deployments
-- a Cloudflare Workers/OpenNext archive for manual inspection or deployment
+- a Node.js standalone archive (`*-standalone.tar.gz`, the Nitro node-server output) for self-hosted Node deployments
+- a Cloudflare Workers archive (`*-cloudflare.tar.gz`) for manual inspection or deployment
 - generated release notes with CLI command usage, Docker tags, deployment steps, and checksums
 
 For repeatable Docker deploys, prefer the versioned image tag from the release page instead of `latest`.


### PR DESCRIPTION
## What

Plan 04 PR **04f** — README polish. **README-only**, no runtime/UI/bundle change.

- **Badges:** add latest-release, GHCR image, and license (GPL-3.0) badges.
- **Clearer self-host vs cloud:** add a short deployment nav at the top of
  `## Deployment` that frames chmonitor as self-hosted and lists targets with
  Docker first (fastest path), plus a pointer to the live demo for "look first".
- **Fix stale v0.2 deploy instructions** (the main correctness win): the
  Cloudflare section still described the retired Next.js + OpenNext flow.
  - `cf:build # Next.js build + OpenNext` + `opennextjs-cloudflare populateCache`
    → `cd apps/dashboard && bun run build` (Vite → native Workers bundle), matching
    `apps/dashboard/package.json` (`cf:deploy = bun run build && wrangler deploy`).
  - "Important Notes" no longer claim Webpack / Next.js 15.5.x — now TanStack
    Start + Vite + `@cloudflare/vite-plugin`.
  - Releases archive wording corrected to match `release.yml`: `*-standalone.tar.gz`
    is the **Nitro node-server** output; `*-cloudflare.tar.gz` (not "OpenNext").

## Why

The README is the onboarding funnel (Plan 04 = distribution as adoption). The
documented self-host path referenced build steps that no longer exist in v0.3,
so anyone following it would fail. Verified every replacement against the actual
`package.json` scripts and `.github/workflows/release.yml`.

## Scope

`README.md` only. Support-matrix link was already added by #1702 (now sits under
Reference); this PR adds the badges + deploy-section accuracy that 04f still owed.

## How verified

- `git diff`: +23/−9, README.md only.
- All link targets exist: `LICENSE`, `docs/content/deploy/one-click.mdx`,
  `docs/content/reference/support-matrix.mdx`; `#docker` / `#cloudflare-workers`
  anchors resolve to existing `###` headings.
- Replacement deploy commands cross-checked against `apps/dashboard/package.json`
  and `release.yml` (no OpenNext/Webpack/populateCache remain anywhere they shouldn't).
- Pure docs → no build/visual gate needed (VISUAL-VERIFICATION §A: skip for
  docs with zero rendered output); CI lint/build still runs.

## Guardrails
- [x] Scope respected (only `README.md`)
- [x] Pure docs — no types/build/runtime impact
- [x] No UI change → visual verification N/A
- [x] Backward compatible (documentation only)
- [ ] auto-merge armed + babysit (next step)
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: `cowork/plans/04-quickstart-and-platforms.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced deployment documentation highlighting self-hosting capabilities and supported deployment platforms: Docker, Cloudflare Workers, Kubernetes Helm, and one-click installation templates
  * Updated release downloads with new archive options and clarified deployment guide instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->