### PR TITLE
docs(deploy): fix stale OpenNext/cf:build refs in cloudflare deploy doc

### DIFF
--- a/docs/content/advanced/telemetry.mdx
+++ b/docs/content/advanced/telemetry.mdx
@@ -63,7 +63,7 @@ The ClickHouse version is always truncated to `MAJOR.MINOR` (e.g. `24.8`) — ne
 CHM_TELEMETRY=on
 ```
 
-**Client build-time** (inlined at `cf:build` / `vite build`):
+**Client build-time** (inlined at `bun run build` / `vite build`):
 
 ```bash
 VITE_TELEMETRY_ENABLED=true

--- a/docs/content/deploy/cloudflare.mdx
+++ b/docs/content/deploy/cloudflare.mdx
@@ -45,7 +45,7 @@ There are two kinds of variables:
 
 | Kind | Where to set | Who reads it | Example |
 |---|---|---|---|
-| **Build-time client vars** | CI env / shell before `bun run cf:build` | Browser JS (VITE-inlined) | `VITE_AUTH_PROVIDER`, `VITE_CLERK_PUBLISHABLE_KEY` |
+| **Build-time client vars** | CI env / shell before `bun run build` | Browser JS (VITE-inlined) | `VITE_AUTH_PROVIDER`, `VITE_CLERK_PUBLISHABLE_KEY` |
 | **Runtime Worker vars** | `wrangler.toml` `[vars]` or `wrangler secret put` | Worker process only | `CLICKHOUSE_HOST`, `LLM_API_KEY`, `CLERK_SECRET_KEY` |
 
 `VITE_*` vars are baked into the JS bundle at build time. Setting them in `wrangler.toml [vars]` has no effect — they must be in the environment when `bun run build` runs (e.g. CI secrets).
@@ -302,7 +302,7 @@ HEALTH_ALERT_MIN_SEVERITY = "warning"
 
 ### Branding
 
-Set these in CI before running `bun run cf:build` (they are baked into the JS bundle):
+Set these in CI before running `bun run build` (they are baked into the JS bundle):
 
 ```bash
 VITE_TITLE_SHORT=MyCluster
@@ -350,8 +350,8 @@ For breaking changes between major versions, see [Migrating to v0.3](/docs/migra
 
 ## Troubleshooting
 
-**`.open-next/worker.js` not found:** `bun run cf:build` must run before `wrangler deploy`. Make sure CI runs `cf:build`, not just `build`.
+**`wrangler deploy` ships nothing or stale assets:** run `bun run build` (or `bun run cf:deploy`, which does both) before `wrangler deploy` — the Vite build must produce the Workers bundle first.
 
 **Runtime errors / blank pages:** check Workers logs in the Cloudflare dashboard. Verify secrets are set (`wrangler secret list`) and redeploy after any `wrangler secret put`.
 
-**Build-time client var not taking effect:** `VITE_*` vars must be set in the environment when `bun run cf:build` runs, not in `wrangler.toml [vars]`.
+**Build-time client var not taking effect:** `VITE_*` vars must be set in the environment when `bun run build` runs, not in `wrangler.toml [vars]`.


### PR DESCRIPTION
## What

The Cloudflare deploy guide (`docs/content/deploy/cloudflare.mdx`) contradicted
itself. Its intro (line 5) correctly states the app builds a **native Workers
bundle — no OpenNext adapter** via `bun run build && wrangler deploy`, but four
later spots still referenced the **removed `cf:build` script** and a
`.open-next/worker.js` artifact that cannot exist in v0.3.

- `cloudflare.mdx`: replace `bun run cf:build` → `bun run build` (3 spots) and
  **rewrite** the impossible `".open-next/worker.js not found"` troubleshooting
  bullet into the real native-bundle failure mode (build before `wrangler deploy`).
- `telemetry.mdx`: same `cf:build` → `bun run build` fix in the build-time note.

## Why

Following the documented steps would send a reader chasing a `cf:build` script
and an OpenNext artifact that no longer exist — a broken self-host path on the
primary deploy target. Same class of v0.2→v0.3 doc-rot fixed in the README by #1711.

## Scope

Two `docs/content/*.mdx` files. **Disjoint from README/landing** (independent of
the rest of Plan 04). Intentional legacy references elsewhere (`vercel.mdx`,
`migrating/v0-3.mdx`, `reference/environment-variables.mdx`) are deliberately
left as-is — they document the legacy path on purpose.

## How verified

- `grep -nE 'cf:build|open-next'` over both files after the edit → **0 residual**.
- Confirmed `cf:build` is defined in **no** `package.json` (root or
  `apps/dashboard`); the real script is `cf:deploy = bun run build && wrangler deploy`.
- Pure docs/MDX text (inline code spans only) → no MDX/structural change; `docs`
  CI job builds `apps/docs` to confirm.

## Guardrails
- [x] Scope respected (2 docs files only)
- [x] Pure docs — no types/build/runtime/bundle impact
- [x] No UI change → visual verification N/A
- [x] Backward compatible (documentation only)
- [ ] auto-merge armed + babysit (next step)
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: `cowork/plans/04-quickstart-and-platforms.md`