### PR TITLE
docs(readme): add 30-second Docker quickstart as the #1 path

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ A modern dashboard (TanStack Start, as of **v0.3**) that provides real-time insi
 - **Rust CLI**: Standalone terminal and TUI monitoring tool
 
 
+## Quick start
+
+One container, pointed at any reachable ClickHouse (OSS, Altinity, or ClickHouse Cloud):
+
+```bash
+docker run -d --name chmonitor -p 3000:3000 \
+  -e CLICKHOUSE_HOST=https://clickhouse.example.com:8443 \
+  -e CLICKHOUSE_USER=default \
+  -e CLICKHOUSE_PASSWORD=change-me \
+  ghcr.io/duyet/chmonitor:latest
+```
+
+Open **<http://localhost:3000>**. Pin a release tag instead of `latest` for production.
+
+> Just want to look first? The live demo is at **[dash.chmonitor.dev](https://dash.chmonitor.dev/?ref=github)** — no setup required.
+> Other targets (Cloudflare Workers, one-click Railway/Render/Fly, Kubernetes) are under [Deployment](#deployment).
+
 ## Deployment
 
 chmonitor is **self-hosted** — run it next to your ClickHouse with the same


### PR DESCRIPTION
## What

Plan 04 PR **04a (README half)** — add a top-level `## Quick start` section
above Deployment with a single `docker run` against any reachable ClickHouse.

## Why

The README is the onboarding funnel (Plan 04 = distribution as adoption). It had
no above-the-fold "run it now" command — the fastest path was buried mid-page.
This makes `docker run …ghcr.io/duyet/chmonitor:latest` the literal #1 path,
trimmed to the minimum env (host/user/password), then routes to the live demo
and the fuller Deployment section for other targets.

## Scope

`README.md` only. Complements #1711 (which added the self-host/cloud deploy nav
*inside* Deployment); this adds the prominent top-level quickstart. The landing's
docker path is handled separately (it already has terminal blocks; a follow-up
fixes its stale OpenNext copy).

## How verified

- `git diff`: +17, README.md only.
- Command matches the existing Docker section + landing terminal (same image,
  env, port 3000); `:8443` is the ClickHouse HTTPS port (avoids the no-port SSL trap).
- `#deployment` anchor + `dash.chmonitor.dev` link resolve.
- Pure docs → no build/visual gate (VISUAL-VERIFICATION §A).

## Guardrails
- [x] Scope respected (README.md only)
- [x] Pure docs — no types/build/runtime impact
- [x] No UI change → visual verification N/A
- [x] Backward compatible (documentation only)
- [ ] auto-merge armed + babysit (next step)
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: `cowork/plans/04-quickstart-and-platforms.md`