### PR TITLE
fix(landing): correct stale OpenNext deploy copy on the marketing page

### DIFF
--- a/apps/landing/src/components/OpenSource.astro
+++ b/apps/landing/src/components/OpenSource.astro
@@ -47,7 +47,7 @@
 
         <!-- Cloudflare Workers -->
         <div class="deploy-pane" data-pane="cf" data-on="true">
-          <p class="deploy-note">Edge hosting via the OpenNext adapter — no servers to run.</p>
+          <p class="deploy-note">Edge hosting as a native Cloudflare Workers bundle — no servers to run.</p>
           <div class="terminal">
             <div class="term-bar"><span class="lights"><i style="background:#ff5f57"></i><i style="background:#febc2e"></i><i style="background:#28c840"></i></span><span class="ttl">bash</span><button class="copy">Copy</button></div>
             <div class="term-body">
@@ -64,7 +64,7 @@
               <div>EOF</div>
               <div>&nbsp;</div>
               <div><span class="p">$</span> bun run cf:config&nbsp;&nbsp;&nbsp;<span class="c"># push secrets to the Worker</span></div>
-              <div><span class="p">$</span> bun run cf:deploy&nbsp;&nbsp;&nbsp;<span class="c"># build + deploy + populate cache</span></div>
+              <div><span class="p">$</span> bun run cf:deploy&nbsp;&nbsp;&nbsp;<span class="c"># build + deploy</span></div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What

The landing page's Cloudflare Workers deploy pane (the **default-visible** tab)
still advertised the retired Next.js stack:

- "Edge hosting via the **OpenNext adapter**" → "Edge hosting as a **native
  Cloudflare Workers bundle**"
- `bun run cf:deploy # build + deploy + **populate cache**` → `# build + deploy`

v0.3 builds a native Workers bundle via `@cloudflare/vite-plugin` — there is no
OpenNext adapter and no KV/R2/D1 cache-population step.

## Why

This is the public marketing page and the false copy sits in the first deploy
pane a visitor sees. Same v0.2→v0.3 rot already fixed in the README (#1711) and
the docs (#1712); this closes the landing surface.

## Scope

`apps/landing/src/components/OpenSource.astro`, 2 lines. **Deliberately did NOT**
change the default deploy tab (Cloudflare) or tab order — that's the maintainer's
product choice, out of scope for a copy-accuracy fix.

## How verified (VISUAL-VERIFICATION)

- `bun run build` (astro) — green, 2 pages built (same gate as the `landing` CI job).
- Built `dist/index.html` asserted: **0** "OpenNext" residual, **0** "populate
  cache" residual, new "native Cloudflare Workers bundle" copy **present**.
- Change is a pure text swap in a `<p class="deploy-note">` (reflows naturally;
  no structural/layout change). Live screenshot was attempted but the local
  browser extension denied localhost access; the build + built-HTML assertion
  covers the rendered output per VISUAL-VERIFICATION §F.

## Guardrails
- [x] Scope respected (1 landing file, 2 lines)
- [x] astro build green; built HTML asserted
- [x] No structural/layout change (text-only in default-visible pane)
- [x] Backward compatible (copy only)
- [ ] auto-merge armed + babysit (after #1713 merges — serial-arm)
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: `cowork/plans/04-quickstart-and-platforms.md`