### PR TITLE
docs: stop labeling current apps/dashboard as the removed Next.js app

### DIFF
--- a/docs/content/releases/v0-3.mdx
+++ b/docs/content/releases/v0-3.mdx
@@ -6,7 +6,7 @@ v0.3 rebuilds the dashboard on TanStack Start, ships a pluggable authentication 
 
 ## TanStack Start (new framework)
 
-The dashboard is rewritten on [TanStack Start](https://tanstack.com/start) with Vite. Every page is pre-rendered at build time so the initial shell loads from cache before ClickHouse is contacted. The legacy Next.js app (`apps/dashboard`) is removed.
+The dashboard is rewritten on [TanStack Start](https://tanstack.com/start) with Vite. Every page is pre-rendered at build time so the initial shell loads from cache before ClickHouse is contacted. The legacy Next.js app is removed.
 
 - Static prerender for all 75+ dashboard pages ([#1392](https://github.com/duyet/clickhouse-monitoring/issues/1392)).
 - TanStack Query replaces SWR for client-side data fetching ([#1562](https://github.com/duyet/clickhouse-monitoring/issues/1562)).

--- a/docs/content/settings.mdx
+++ b/docs/content/settings.mdx
@@ -114,7 +114,7 @@ VITE_LOGO=https://example.com/logo.svg
 VITE_MEASUREMENT_ID=G-XXXXXXXXXX
 ```
 
-> The Next.js legacy app (`apps/dashboard`) uses `NEXT_PUBLIC_*` equivalents for these client-side variables.
+> The legacy Next.js app (v0.2 and earlier) used `NEXT_PUBLIC_*` equivalents for these client-side variables.
 
 ## Related
 

--- a/docs/versions/v0.3/settings.mdx
+++ b/docs/versions/v0.3/settings.mdx
@@ -101,7 +101,7 @@ VITE_LOGO=https://example.com/logo.svg
 VITE_MEASUREMENT_ID=G-XXXXXXXXXX
 ```
 
-> The Next.js legacy app (`apps/dashboard`) uses `NEXT_PUBLIC_*` equivalents for these client-side variables.
+> The legacy Next.js app (v0.2 and earlier) used `NEXT_PUBLIC_*` equivalents for these client-side variables.
 
 ## Related
 


### PR DESCRIPTION
## What

`apps/dashboard` is the **current** TanStack Start app (v0.3); the legacy Next.js
app was removed. Two docs spots still attribute `apps/dashboard` to the Next.js /
legacy app:

- `settings.mdx` (+ `docs/versions/v0.3` mirror): "The Next.js legacy app
  (`apps/dashboard`) uses `NEXT_PUBLIC_*`" → "The legacy Next.js app (v0.2 and
  earlier) used `NEXT_PUBLIC_*`".
- `releases/v0-3.mdx`: "The legacy Next.js app (`apps/dashboard`) is removed" →
  drop the wrong parenthetical (apps/dashboard is the current app, not removed).

## Why

Calling the live app "the removed Next.js app" is actively confusing for anyone
reading the settings/release docs. Confirmed `apps/dashboard/package.json` has
`@tanstack/react-start` and no `next`.

## Scope

3 `docs/*.mdx` files, 3 lines. `deploy.mdx`'s "Vercel = Next.js legacy app" is
**accurate** (Vercel targets the v0.2 build) and intentionally left unchanged.
Independent of README/landing.

## How verified

- `grep` confirms the only remaining `apps/dashboard`+Next.js co-references are
  the intentional Vercel/migration ones.
- Pure docs/MDX text (inline code + prose) → `docs` CI job builds `apps/docs`.

## Guardrails
- [x] Scope respected (3 docs files)
- [x] Pure docs — no runtime/bundle impact
- [x] No UI change → visual verification N/A
- [x] Backward compatible (documentation only)
- [ ] auto-merge armed + babysit (serial — after #1713/#1714)
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: `cowork/plans/04-quickstart-and-platforms.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified release notes and settings documentation regarding the legacy Next.js app (v0.2 and earlier) and its client-side variable equivalents.
  * Removed internal path references while maintaining clarity about the transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->