### PR TITLE
feat(query-config): migrate part-info/projections/user-processes to declarative catalog

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/index.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/index.ts
@@ -94,9 +94,12 @@ import { detachedPartsDeclarative } from './tables/detached-parts'
 import { distributedDdlQueueDeclarative } from './tables/distributed-ddl-queue'
 import { droppedTablesDeclarative } from './tables/dropped-tables'
 import { movesDeclarative } from './tables/moves'
+import { partInfoDeclarative } from './tables/part-info'
+import { projectionsDeclarative } from './tables/projections'
 import { replicasDeclarative } from './tables/replicas'
 import { replicatedFetchesDeclarative } from './tables/replicated-fetches'
 import { replicationQueueDeclarative } from './tables/replication-queue'
+import { userProcessesDeclarative } from './tables/user-processes'
 import { viewRefreshesDeclarative } from './tables/view-refreshes'
 
 // ---------------------------------------------------------------------------
@@ -184,9 +187,12 @@ const ALL_DECLARATIVE: DeclarativeQueryConfig[] = [
   distributedDdlQueueDeclarative,
   droppedTablesDeclarative,
   movesDeclarative,
+  partInfoDeclarative,
+  projectionsDeclarative,
   replicasDeclarative,
   replicatedFetchesDeclarative,
   replicationQueueDeclarative,
+  userProcessesDeclarative,
   viewRefreshesDeclarative,
 ]
 

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/part-info.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/part-info.ts
@@ -1,0 +1,133 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const partInfoDeclarative: DeclarativeQueryConfig = {
+  name: 'part-info',
+  defaultView: 'auto',
+  card: { primary: 'name', badges: ['partition'] },
+  description:
+    'Information about currently active parts and levels for a table',
+  sql: [
+    {
+      since: '19.1',
+      description: 'Base query - primary_key_bytes_in_memory not available',
+      sql: `
+        WITH parts_data AS (
+          SELECT
+            *,
+            round(data_uncompressed_bytes / nullIf(data_compressed_bytes, 0), 2) AS compression_ratio
+          FROM system.parts
+          WHERE database = {database: String}
+            AND table = {table: String}
+            AND active = 1
+        )
+        SELECT
+          name,
+          partition,
+          level,
+          round(level * 100.0 / nullIf(max(level) OVER (), 0), 2) AS pct_level,
+          rows,
+          formatReadableQuantity(rows) as readable_rows,
+          round(rows * 100.0 / nullIf(max(rows) OVER (), 0), 2) AS pct_rows,
+          data_compressed_bytes,
+          formatReadableSize(data_compressed_bytes) AS readable_compressed,
+          round(data_compressed_bytes * 100.0 / nullIf(max(data_compressed_bytes) OVER (), 0), 2) AS pct_compressed,
+          data_uncompressed_bytes,
+          formatReadableSize(data_uncompressed_bytes) AS readable_uncompressed,
+          round(data_uncompressed_bytes * 100.0 / nullIf(max(data_uncompressed_bytes) OVER (), 0), 2) AS pct_uncompressed,
+          compression_ratio,
+          round(compression_ratio * 100.0 / nullIf(max(compression_ratio) OVER (), 0), 2) AS pct_compression_ratio,
+          marks,
+          0 AS primary_key_bytes_in_memory,
+          '-' AS readable_primary_key_size,
+          0 AS pct_primary_key_size,
+          modification_time,
+          min_date,
+          max_date,
+          disk_name,
+          path
+        FROM parts_data
+        ORDER BY name ASC
+      `,
+    },
+    {
+      since: '21.8',
+      description: 'Includes primary_key_bytes_in_memory columns',
+      sql: `
+        WITH parts_data AS (
+          SELECT
+            *,
+            round(data_uncompressed_bytes / nullIf(data_compressed_bytes, 0), 2) AS compression_ratio
+          FROM system.parts
+          WHERE database = {database: String}
+            AND table = {table: String}
+            AND active = 1
+        )
+        SELECT
+          name,
+          partition,
+          level,
+          round(level * 100.0 / nullIf(max(level) OVER (), 0), 2) AS pct_level,
+          rows,
+          formatReadableQuantity(rows) as readable_rows,
+          round(rows * 100.0 / nullIf(max(rows) OVER (), 0), 2) AS pct_rows,
+          data_compressed_bytes,
+          formatReadableSize(data_compressed_bytes) AS readable_compressed,
+          round(data_compressed_bytes * 100.0 / nullIf(max(data_compressed_bytes) OVER (), 0), 2) AS pct_compressed,
+          data_uncompressed_bytes,
+          formatReadableSize(data_uncompressed_bytes) AS readable_uncompressed,
+          round(data_uncompressed_bytes * 100.0 / nullIf(max(data_uncompressed_bytes) OVER (), 0), 2) AS pct_uncompressed,
+          compression_ratio,
+          round(compression_ratio * 100.0 / nullIf(max(compression_ratio) OVER (), 0), 2) AS pct_compression_ratio,
+          marks,
+          primary_key_bytes_in_memory,
+          formatReadableSize(primary_key_bytes_in_memory) AS readable_primary_key_size,
+          round(primary_key_bytes_in_memory * 100.0 / nullIf(max(primary_key_bytes_in_memory) OVER (), 0), 2) AS pct_primary_key_size,
+          modification_time,
+          min_date,
+          max_date,
+          disk_name,
+          path
+        FROM parts_data
+        ORDER BY name ASC
+      `,
+    },
+  ],
+  columns: [
+    'name',
+    'partition',
+    'level',
+    'readable_rows',
+    'readable_compressed',
+    'readable_uncompressed',
+    'compression_ratio',
+    'marks',
+    'readable_primary_key_size',
+    'modification_time',
+    'min_date',
+    'max_date',
+    'disk_name',
+  ],
+  columnFormats: {
+    name: 'code',
+    partition: 'code',
+    level: 'background-bar',
+    readable_rows: 'background-bar',
+    readable_compressed: 'background-bar',
+    readable_uncompressed: 'background-bar',
+    compression_ratio: 'background-bar',
+    marks: 'number',
+    readable_primary_key_size: 'background-bar',
+    modification_time: 'related-time',
+    disk_name: 'colored-badge',
+  },
+  sortingFns: {
+    readable_rows: 'sort_column_using_actual_value',
+    readable_compressed: 'sort_column_using_actual_value',
+    readable_uncompressed: 'sort_column_using_actual_value',
+  },
+  optional: false,
+  defaultParams: {
+    database: 'default',
+    table: '',
+  },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/projections.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/projections.ts
@@ -1,0 +1,56 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const projectionsDeclarative: DeclarativeQueryConfig = {
+  name: 'projections',
+  defaultView: 'auto',
+  card: { primary: 'name' },
+  description: `Projection size. https://clickhouse.com/docs/en/sql-reference/statements/alter/projection`,
+  sql: `
+      SELECT
+          database,
+          table,
+          name,
+          (sum(data_compressed_bytes) AS size) AS compressed,
+          (sum(data_uncompressed_bytes) AS usize) AS uncompressed,
+          formatReadableSize(compressed) AS readable_compressed,
+          formatReadableSize(uncompressed) AS readable_uncompressed,
+          round(100 * compressed / nullIf(max(compressed) OVER (), 0)) AS pct_compressed,
+          round(100 * uncompressed / nullIf(max(uncompressed) OVER (), 0)) AS pct_uncompressed,
+          round(uncompressed / nullIf(compressed, 0), 2) AS compr_rate,
+          round(100 * compr_rate / nullIf(max(compr_rate) OVER (), 0)) AS pct_compr_rate,
+          sum(rows) AS rows,
+          formatReadableQuantity(rows) AS readable_rows,
+          round(100 * rows / nullIf(max(rows) OVER (), 0)) AS pct_rows,
+          count() AS part_count,
+          round(100 * part_count / nullIf(max(part_count) OVER (), 0)) AS pct_part_count
+      FROM system.projection_parts
+      WHERE active
+      GROUP BY
+          database,
+          table,
+          name
+      ORDER BY compressed DESC
+  `,
+  columns: [
+    'database',
+    'table',
+    'name',
+    'readable_compressed',
+    'readable_uncompressed',
+    'compr_rate',
+    'readable_rows',
+    'part_count',
+  ],
+  columnFormats: {
+    readable_compressed: 'background-bar',
+    readable_uncompressed: 'background-bar',
+    compr_rate: 'background-bar',
+    readable_rows: 'background-bar',
+    part_count: 'background-bar',
+  },
+  optional: false,
+  defaultParams: {
+    table: 'default.default',
+  },
+  relatedCharts: [],
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/tables-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/tables-catalog.test.ts
@@ -10,11 +10,8 @@
  * columnFilters, clickhouseSettings, variants.
  *
  * SKIPPED configs (non-serializable fields block migration):
- *   - part-info        : sortingFns uses 'sort_column_using_actual_value'
- *   - projections      : sortingFns uses 'sort_column_using_actual_value'
  *   - readonly-tables  : expandable contains JSX (React component ref)
- *   - tables-overview  : clickhouseSettings + sortingFns 'sort_column_using_actual_value'
- *   - user-processes   : sortingFns uses 'sort_column_using_actual_value'
+ *   - tables-overview  : clickhouseSettings not serializable declaratively
  */
 
 import { loadDeclarativeConfig } from '../../loader'
@@ -22,18 +19,24 @@ import { detachedPartsDeclarative } from './detached-parts'
 import { distributedDdlQueueDeclarative } from './distributed-ddl-queue'
 import { droppedTablesDeclarative } from './dropped-tables'
 import { movesDeclarative } from './moves'
+import { partInfoDeclarative } from './part-info'
+import { projectionsDeclarative } from './projections'
 import { replicasDeclarative } from './replicas'
 import { replicatedFetchesDeclarative } from './replicated-fetches'
 import { replicationQueueDeclarative } from './replication-queue'
+import { userProcessesDeclarative } from './user-processes'
 import { viewRefreshesDeclarative } from './view-refreshes'
 import { describe, expect, test } from 'bun:test'
 import { detachedPartsConfig } from '@/lib/query-config/tables/detached-parts'
 import { distributedDdlQueueConfig } from '@/lib/query-config/tables/distributed-ddl-queue'
 import { droppedTablesConfig } from '@/lib/query-config/tables/dropped-tables'
 import { movesConfig } from '@/lib/query-config/tables/moves'
+import { partInfoConfig } from '@/lib/query-config/tables/part-info'
+import { projectionsConfig } from '@/lib/query-config/tables/projections'
 import { replicasConfig } from '@/lib/query-config/tables/replicas'
 import { replicatedFetchesConfig } from '@/lib/query-config/tables/replicated-fetches'
 import { replicationQueueConfig } from '@/lib/query-config/tables/replication-queue'
+import { userProcessesConfig } from '@/lib/query-config/tables/user-processes'
 import { viewRefreshesConfig } from '@/lib/query-config/tables/view-refreshes'
 
 // ---------------------------------------------------------------------------
@@ -210,4 +213,34 @@ assertDeclarativeMatchesLegacy(
   viewRefreshesDeclarative,
   viewRefreshesConfig as unknown as Record<string, unknown>,
   'view-refreshes'
+)
+
+// ---------------------------------------------------------------------------
+// part-info
+// ---------------------------------------------------------------------------
+
+assertDeclarativeMatchesLegacy(
+  partInfoDeclarative,
+  partInfoConfig as unknown as Record<string, unknown>,
+  'part-info'
+)
+
+// ---------------------------------------------------------------------------
+// projections
+// ---------------------------------------------------------------------------
+
+assertDeclarativeMatchesLegacy(
+  projectionsDeclarative,
+  projectionsConfig as unknown as Record<string, unknown>,
+  'projections'
+)
+
+// ---------------------------------------------------------------------------
+// user-processes
+// ---------------------------------------------------------------------------
+
+assertDeclarativeMatchesLegacy(
+  userProcessesDeclarative,
+  userProcessesConfig as unknown as Record<string, unknown>,
+  'user-processes'
 )

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/user-processes.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/user-processes.ts
@@ -1,0 +1,31 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const userProcessesDeclarative: DeclarativeQueryConfig = {
+  name: 'user-processes',
+  defaultView: 'auto',
+  card: { primary: 'user' },
+  description: 'Per-user memory usage and resource summary',
+  refreshInterval: 30_000,
+  optional: true,
+  tableCheck: 'system.user_processes',
+  sql: `
+    SELECT
+      user,
+      memory_usage,
+      formatReadableSize(memory_usage) AS readable_memory_usage,
+      round(memory_usage * 100.0 / nullIf(max(memory_usage) OVER (), 0), 2) AS pct_memory_usage,
+      peak_memory_usage,
+      formatReadableSize(peak_memory_usage) AS readable_peak_memory_usage
+    FROM system.user_processes
+    ORDER BY memory_usage DESC
+  `,
+  columns: ['user', 'readable_memory_usage', 'readable_peak_memory_usage'],
+  columnFormats: {
+    user: 'colored-badge',
+    readable_memory_usage: 'background-bar',
+  },
+  sortingFns: {
+    readable_memory_usage: 'sort_column_using_actual_value',
+    readable_peak_memory_usage: 'sort_column_using_actual_value',
+  },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/schema.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/schema.ts
@@ -162,6 +162,7 @@ const relatedChartSchema = z.union([
 const sortingFnValues = [
   'sort_column_using_pct',
   'sort_column_using_pct_inverted',
+  'sort_column_using_actual_value',
 ] as const
 
 const sortingFnsSchema = z.record(z.string(), z.enum(sortingFnValues))


### PR DESCRIPTION
## What

Plan 02 schema-ext (mechanical slice). Migrates 3 `tables/` configs that were
skipped from the declarative catalog **only** because the declarative schema's
`sortingFnValues` enum lacked one value.

- `schema.ts`: add `'sort_column_using_actual_value'` to `sortingFnValues` (the
  runtime sorting fn already exists — `data-table/sorting-fns.ts:14`; only the
  declarative enum was missing it).
- New declarative catalog files: `part-info`, `projections`, `user-processes`.
- Registered in `catalog/index.ts` (`ALL_DECLARATIVE`).
- Snapshot tests: each round-trips `loadDeclarativeConfig()` → deep-equals the
  legacy TS config on all serializable fields. Updated the SKIPPED doc comment.

## Why

Advances the Plan 02 declarative catalog (platform thesis). **Bundle-neutral and
dormant** — only active under `CHM_CONFIG_SOURCE=declarative` (default `ts`).

## Scope / safety

- `projections` had **no** `sortingFns` despite the old skip-comment claiming it
  did — migrated as-is (verified against the legacy file).
- Verified all 3 legacy configs have **zero** non-serializable fields
  (`rowClassName`/`expandable`/`columnIcons`/`filterSchema`/`permission`), so
  nothing is silently dropped at a future flip. `readonly-tables` (expandable JSX)
  and `tables-overview` (needs `clickhouseSettings`) remain correctly skipped.

## How verified

- `bun test apps/dashboard/src/lib/query-config/declarative/` → **219 pass, 0 fail**
  (tables-catalog.test.ts 40 → 55 assertions).
- `bun run type-check:test` → clean (only pre-existing `routeTree.gen.ts`/`next-compat.ts` noise).
- Manual diff review: schema change additive; no dropped fields.

## Guardrails
- [x] Scope respected (declarative catalog only; additive schema)
- [x] tests green (snapshot + schema + loader) + type-check:test
- [x] Backward compatible / dormant behind `CHM_CONFIG_SOURCE` flag
- [x] No UI change → visual N/A
- [ ] auto-merge armed + babysit (next step)
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: `cowork/plans/02-externalize-query-configs.md`