### PR TITLE
feat(query-config): declarative clickhouseSettings + migrate tables-overview/stack-traces

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/index.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/index.ts
@@ -46,6 +46,7 @@ import { keeperPresenceDeclarative } from './keeper/keeper-presence'
 import { keeperWatchesDeclarative } from './keeper/keeper-watches'
 // Logs
 import { crashLogDeclarative } from './logs/crashes'
+import { stackTracesDeclarative } from './logs/stack-traces'
 import { textLogDeclarative } from './logs/text-log'
 // Merges
 import { mergesDeclarative } from './merges/merges'
@@ -99,6 +100,7 @@ import { projectionsDeclarative } from './tables/projections'
 import { replicasDeclarative } from './tables/replicas'
 import { replicatedFetchesDeclarative } from './tables/replicated-fetches'
 import { replicationQueueDeclarative } from './tables/replication-queue'
+import { tablesOverviewDeclarative } from './tables/tables-overview'
 import { userProcessesDeclarative } from './tables/user-processes'
 import { viewRefreshesDeclarative } from './tables/view-refreshes'
 
@@ -141,6 +143,7 @@ const ALL_DECLARATIVE: DeclarativeQueryConfig[] = [
 
   // Logs
   crashLogDeclarative,
+  stackTracesDeclarative,
   textLogDeclarative,
 
   // Merges
@@ -192,6 +195,7 @@ const ALL_DECLARATIVE: DeclarativeQueryConfig[] = [
   replicasDeclarative,
   replicatedFetchesDeclarative,
   replicationQueueDeclarative,
+  tablesOverviewDeclarative,
   userProcessesDeclarative,
   viewRefreshesDeclarative,
 ]

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/logs/logs-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/logs/logs-catalog.test.ts
@@ -10,17 +10,15 @@
  *   columnIcons   — React component refs
  *   permission    — FeaturePermission
  *   filterSchema  — contains Icon refs and dynamic option fns
- *   clickhouseSettings — execution-time settings
- *
- * Skipped configs (runtime-only fields that the schema cannot express):
- *   stackTracesConfig — clickhouseSettings (allow_introspection_functions)
  */
 
 import { loadDeclarativeConfig } from '../../loader'
 import { crashLogDeclarative } from './crashes'
+import { stackTracesDeclarative } from './stack-traces'
 import { textLogDeclarative } from './text-log'
 import { describe, expect, test } from 'bun:test'
 import { crashLogConfig } from '@/lib/query-config/logs/crashes'
+import { stackTracesConfig } from '@/lib/query-config/logs/stack-traces'
 import { textLogConfig } from '@/lib/query-config/logs/text-log'
 
 // ---------------------------------------------------------------------------
@@ -35,7 +33,6 @@ const RUNTIME_ONLY_KEYS = new Set([
   'permission',
   'filterSchema',
   'columnFilters',
-  'clickhouseSettings',
   'variants',
 ])
 
@@ -85,6 +82,28 @@ describe('text-log declarative', () => {
     const loaded = loadDeclarativeConfig(textLogDeclarative)
     expect(loaded.filterParamPresets?.length).toBe(
       textLogConfig.filterParamPresets?.length
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// stack-traces (clickhouseSettings now serializable via schema-ext)
+// ---------------------------------------------------------------------------
+
+describe('stack-traces declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(stackTracesDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(stackTracesDeclarative)
+    compareSerializable(loaded, stackTracesConfig)
+  })
+
+  test('clickhouseSettings round-trips through the loader', () => {
+    const loaded = loadDeclarativeConfig(stackTracesDeclarative)
+    expect(loaded.clickhouseSettings).toEqual(
+      stackTracesConfig.clickhouseSettings
     )
   })
 })

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/logs/stack-traces.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/logs/stack-traces.ts
@@ -1,0 +1,40 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const stackTracesDeclarative: DeclarativeQueryConfig = {
+  name: 'stack-traces',
+  optional: false,
+  description: 'Current stack traces for all server threads',
+  docs: 'https://clickhouse.com/docs/en/operations/system-tables/stack_trace',
+  // system.stack_trace is always available, not optional
+  sql: `
+    SELECT
+      thread_name,
+      thread_id,
+      query_id,
+      arrayStringConcat(
+        arrayMap(x -> demangle(addressToSymbol(x)), trace),
+        '\\n'
+      ) as stack_trace
+    FROM system.stack_trace
+    ORDER BY thread_name
+  `,
+  clickhouseSettings: {
+    allow_introspection_functions: 1,
+  },
+  columns: ['thread_name', 'thread_id', 'query_id', 'stack_trace'],
+  columnFormats: {
+    thread_name: 'colored-badge',
+    thread_id: 'number',
+    query_id: [
+      'link',
+      {
+        href: '/query?query_id=[query_id]&host=[ctx.hostId]',
+        className: 'max-w-24 truncate',
+      },
+    ],
+    stack_trace: [
+      'code-dialog',
+      { max_truncate: 50, dialog_title: 'Stack Trace' },
+    ],
+  },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/tables-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/tables-catalog.test.ts
@@ -7,11 +7,10 @@
  *
  * Runtime-only fields absent from DeclarativeQueryConfig are excluded from
  * comparison: columnIcons, rowClassName, expandable, permission, filterSchema,
- * columnFilters, clickhouseSettings, variants.
+ * columnFilters, variants.
  *
  * SKIPPED configs (non-serializable fields block migration):
  *   - readonly-tables  : expandable contains JSX (React component ref)
- *   - tables-overview  : clickhouseSettings not serializable declaratively
  */
 
 import { loadDeclarativeConfig } from '../../loader'
@@ -24,6 +23,7 @@ import { projectionsDeclarative } from './projections'
 import { replicasDeclarative } from './replicas'
 import { replicatedFetchesDeclarative } from './replicated-fetches'
 import { replicationQueueDeclarative } from './replication-queue'
+import { tablesOverviewDeclarative } from './tables-overview'
 import { userProcessesDeclarative } from './user-processes'
 import { viewRefreshesDeclarative } from './view-refreshes'
 import { describe, expect, test } from 'bun:test'
@@ -36,6 +36,7 @@ import { projectionsConfig } from '@/lib/query-config/tables/projections'
 import { replicasConfig } from '@/lib/query-config/tables/replicas'
 import { replicatedFetchesConfig } from '@/lib/query-config/tables/replicated-fetches'
 import { replicationQueueConfig } from '@/lib/query-config/tables/replication-queue'
+import { tablesOverviewConfig } from '@/lib/query-config/tables/tables-overview'
 import { userProcessesConfig } from '@/lib/query-config/tables/user-processes'
 import { viewRefreshesConfig } from '@/lib/query-config/tables/view-refreshes'
 
@@ -67,6 +68,7 @@ const SERIALIZABLE_KEYS = [
   'bulkActions',
   'bulkActionKey',
   'sortingFns',
+  'clickhouseSettings',
 ] as const
 
 type SerializableKey = (typeof SERIALIZABLE_KEYS)[number]
@@ -243,4 +245,14 @@ assertDeclarativeMatchesLegacy(
   userProcessesDeclarative,
   userProcessesConfig as unknown as Record<string, unknown>,
   'user-processes'
+)
+
+// ---------------------------------------------------------------------------
+// tables-overview (clickhouseSettings now serializable via schema-ext)
+// ---------------------------------------------------------------------------
+
+assertDeclarativeMatchesLegacy(
+  tablesOverviewDeclarative,
+  tablesOverviewConfig as unknown as Record<string, unknown>,
+  'tables-overview'
 )

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/tables-overview.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/tables-overview.ts
@@ -1,0 +1,136 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const tablesOverviewDeclarative: DeclarativeQueryConfig = {
+  name: 'tables-overview',
+  optional: false,
+  defaultView: 'auto',
+  card: { primary: 'table', badges: ['engine'] },
+  sql: `
+      WITH
+        detached_parts AS
+        (
+            SELECT
+                format('{}.{}', database, \`table\`) AS \`table\`,
+                count() AS detached_parts_count,
+                sum(bytes_on_disk) AS detached_bytes_on_disk,
+                formatReadableSize(detached_bytes_on_disk) AS readable_detached_bytes_on_disk
+            FROM system.detached_parts
+            GROUP BY 1
+        ),
+        parts AS
+        (
+            SELECT
+                format('{}.{}', database, \`table\`) AS \`table\`,
+                sum(rows) AS total_rows,
+                formatReadableQuantity(total_rows) AS readable_total_rows,
+                round((100 * total_rows) / nullIf(max(total_rows) OVER (), 0)) AS pct_total_rows,
+                max(modification_time) AS latest_modification,
+
+                sum(data_compressed_bytes) AS compressed,
+                sum(data_uncompressed_bytes) AS uncompressed,
+                round(uncompressed / nullIf(compressed, 0), 2) AS compr_rate,
+                formatReadableSize(compressed) AS readable_compressed,
+                formatReadableSize(uncompressed) AS readable_uncompressed,
+                round((100 * compressed) / nullIf(max(compressed) OVER (), 0)) AS pct_compressed,
+                round((100 * uncompressed) / nullIf(max(uncompressed) OVER (), 0)) AS pct_uncompressed,
+                round((100 * compr_rate) / nullIf(max(compr_rate) OVER (), 0)) AS pct_compr_rate,
+
+                avg(data_compressed_bytes) AS avg_part_size_compressed,
+                avg(data_uncompressed_bytes) AS avg_part_size_uncompressed,
+                formatReadableSize(avg_part_size_compressed) AS readable_avg_part_size_compressed,
+                formatReadableSize(avg_part_size_uncompressed) AS readable_avg_part_size_uncompressed,
+                round((100 * avg_part_size_compressed) / nullIf(max(avg_part_size_compressed) OVER (), 0)) AS pct_avg_part_size_compressed,
+                round((100 * avg_part_size_uncompressed) / nullIf(max(avg_part_size_uncompressed) OVER (), 0)) AS pct_avg_part_size_uncompressed,
+
+                max(data_compressed_bytes) AS max_part_size_compressed,
+                max(data_uncompressed_bytes) AS max_part_size_uncompressed,
+                formatReadableSize(max_part_size_compressed) AS readable_max_part_size_compressed,
+                formatReadableSize(max_part_size_uncompressed) AS readable_max_part_size_uncompressed,
+                round((100 * max_part_size_compressed) / nullIf(max(max_part_size_compressed) OVER (), 0)) AS pct_max_part_size_compressed,
+                round((100 * max_part_size_uncompressed) / nullIf(max(max_part_size_uncompressed) OVER (), 0)) AS pct_max_part_size_uncompressed,
+
+                sum(primary_key_bytes_in_memory) AS primary_keys_size,
+                formatReadableSize(primary_keys_size) AS readable_primary_keys_size,
+                round((100 * primary_keys_size) / nullIf(max(primary_keys_size) OVER (), 0)) AS pct_primary_keys_size,
+                any(engine) AS engine,
+                count() AS parts_count,
+                round((100 * parts_count) / nullIf(max(parts_count) OVER (), 0)) AS pct_parts_count
+            FROM system.parts AS parts
+            WHERE active
+            GROUP BY 1
+            ORDER BY compressed DESC
+        )
+      SELECT
+        parts.*,
+        detached_parts.*,
+        splitByChar('.', parts.table)[1] AS _database,
+        splitByChar('.', parts.table)[2] AS _table
+      FROM parts
+      LEFT JOIN detached_parts USING (\`table\`)
+    `,
+  columns: [
+    'table',
+    'readable_compressed',
+    'readable_uncompressed',
+    'compr_rate',
+    'readable_avg_part_size_compressed',
+    'readable_avg_part_size_uncompressed',
+    'readable_max_part_size_compressed',
+    'readable_max_part_size_uncompressed',
+    'readable_total_rows',
+    'parts_count',
+    'latest_modification',
+    'readable_primary_keys_size',
+    'readable_detached_bytes_on_disk',
+    'engine',
+  ],
+  columnFormats: {
+    table: [
+      'link',
+      { href: '/table?host=[ctx.hostId]&database=[_database]&table=[_table]' },
+    ],
+    engine: 'colored-badge',
+    readable_total_rows: 'background-bar',
+    readable_compressed: 'background-bar',
+    readable_uncompressed: 'background-bar',
+    readable_avg_part_size_compressed: 'background-bar',
+    readable_avg_part_size_uncompressed: 'background-bar',
+    readable_primary_keys_size: 'background-bar',
+    compr_rate: 'background-bar',
+    parts_count: [
+      'link',
+      {
+        href: '/part-info?host=[ctx.hostId]&database=[_database]&table=[_table]',
+      },
+    ],
+    readable_max_part_size_compressed: 'background-bar',
+    readable_max_part_size_uncompressed: 'background-bar',
+  },
+  clickhouseSettings: {
+    allow_experimental_analyzer: 0,
+  },
+  columnSizing: {
+    table: { size: 280, minSize: 160 },
+    compressed: { size: 110, minSize: 80 },
+    uncompressed: { size: 110, minSize: 80 },
+    compr_rate: { size: 90, minSize: 70 },
+    avg_part_size_compressed: { size: 110, minSize: 80 },
+    avg_part_size_uncompressed: { size: 110, minSize: 80 },
+    max_part_size_compressed: { size: 110, minSize: 80 },
+    max_part_size_uncompressed: { size: 110, minSize: 80 },
+    total_rows: { size: 110, minSize: 80 },
+    parts_count: { size: 80, minSize: 60 },
+    latest_modification: { size: 150, minSize: 120 },
+    primary_keys_size: { size: 110, minSize: 80 },
+    detached_bytes_on_disk: { size: 110, minSize: 80 },
+    engine: { size: 130, minSize: 90 },
+  },
+  sortingFns: {
+    compressed: 'sort_column_using_actual_value',
+    uncompressed: 'sort_column_using_actual_value',
+    avg_part_size_compressed: 'sort_column_using_actual_value',
+    avg_part_size_uncompressed: 'sort_column_using_actual_value',
+    max_part_size_compressed: 'sort_column_using_actual_value',
+    max_part_size_uncompressed: 'sort_column_using_actual_value',
+  },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/loader.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/loader.test.ts
@@ -163,8 +163,8 @@ describe('loadDeclarativeConfig — golden fixture (warningsConfig)', () => {
 
     // Pick only the serializable fields present on warningsConfig for the
     // comparison. Runtime-only fields (columnIcons, rowClassName, expandable,
-    // permission, filterSchema, clickhouseSettings, variants) are absent from
-    // warningsConfig so nothing to exclude here.
+    // permission, filterSchema, variants) are absent from warningsConfig so
+    // nothing to exclude here.
     const serializable = {
       name: warningsConfig.name,
       sql: warningsConfig.sql,

--- a/apps/dashboard/src/lib/query-config/declarative/loader.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/loader.ts
@@ -11,7 +11,6 @@
  *   - permission     — FeaturePermission (app-level import)
  *   - filterSchema   — FilterSchema (contains Icon refs and dynamic option fns)
  *   - columnFilters  — ColumnFilterDef (UI sugar over filterSchema)
- *   - clickhouseSettings — ClickHouseSettings (execution-time; not serializable declaratively)
  *   - variants       — deprecated; use versioned sql[] in the declarative format
  *
  * These fields can be merged in by the caller after loading if needed.
@@ -65,8 +64,8 @@ export function getConfigSource(
  *
  * Runtime-only fields absent from DeclarativeQueryConfig (columnIcons,
  * rowClassName, expandable, permission, filterSchema, columnFilters,
- * clickhouseSettings, variants) are simply omitted from the result. Callers
- * that need those fields must merge them in after loading.
+ * variants) are simply omitted from the result. Callers that need those
+ * fields must merge them in after loading.
  *
  * @throws Error when `input` fails schema validation (message includes all
  *   field-level errors joined by '; ').
@@ -104,6 +103,12 @@ export function loadDeclarativeConfig(input: unknown): QueryConfig {
   if (d.refreshInterval !== undefined)
     config.refreshInterval = d.refreshInterval
   if (d.defaultParams !== undefined) config.defaultParams = d.defaultParams
+  if (d.clickhouseSettings !== undefined) {
+    // Schema validates values to serializable primitives; cast to the precise
+    // ClickHouseSettings type from @clickhouse/client.
+    config.clickhouseSettings =
+      d.clickhouseSettings as QueryConfig['clickhouseSettings']
+  }
 
   // Column display
   if (d.columnFormats !== undefined) {

--- a/apps/dashboard/src/lib/query-config/declarative/schema.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/schema.test.ts
@@ -254,6 +254,42 @@ describe('invalid configs', () => {
     expect(result.errors.some((e) => e.includes('docs'))).toBe(true)
   })
 
+  test('accepts clickhouseSettings with primitive values', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: 'SELECT 1',
+      columns: ['col1'],
+      clickhouseSettings: {
+        allow_introspection_functions: 1,
+        allow_experimental_analyzer: 0,
+        log_comment: 'chmonitor',
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.config.clickhouseSettings).toEqual({
+      allow_introspection_functions: 1,
+      allow_experimental_analyzer: 0,
+      log_comment: 'chmonitor',
+    })
+  })
+
+  test('rejects clickhouseSettings with non-primitive values', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: 'SELECT 1',
+      columns: ['col1'],
+      clickhouseSettings: { nested: { not: 'allowed' } },
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some((e) => e.includes('clickhouseSettings'))).toBe(
+      true
+    )
+  })
+
   test('rejects unknown columnFormat enum value', () => {
     const result = validateDeclarativeConfig({
       name: 'my-query',

--- a/apps/dashboard/src/lib/query-config/declarative/schema.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/schema.ts
@@ -19,6 +19,7 @@
  *   columnDescriptions, columnSizing, tableBehavior
  *   defaultParams, filterParamPresets (icon omitted — not serializable)
  *   optional, tableCheck, disableSqlValidation, refreshInterval
+ *   clickhouseSettings:  execution-time settings (serializable primitives)
  *   relatedCharts:  string[] | [string, params][]
  *   card, defaultView, bulkActions, bulkActionKey
  *   sortingFns
@@ -168,6 +169,18 @@ const sortingFnValues = [
 const sortingFnsSchema = z.record(z.string(), z.enum(sortingFnValues))
 
 // ---------------------------------------------------------------------------
+// clickhouseSettings — execution-time ClickHouse settings applied per query
+// (e.g. { allow_introspection_functions: 1 }). Mirrors the serializable subset
+// of ClickHouseSettings from @clickhouse/client; the loader casts to the
+// precise type. Values are limited to serializable primitives.
+// ---------------------------------------------------------------------------
+
+const clickhouseSettingsSchema = z.record(
+  z.string(),
+  z.union([z.string(), z.number(), z.boolean()])
+)
+
+// ---------------------------------------------------------------------------
 // Main declarative schema
 // ---------------------------------------------------------------------------
 
@@ -213,6 +226,9 @@ export const declarativeQueryConfigSchema = z.object({
 
   // Refresh
   refreshInterval: z.number().positive().optional(),
+
+  // Execution-time ClickHouse settings (applied per query)
+  clickhouseSettings: clickhouseSettingsSchema.optional(),
 
   // Related charts
   relatedCharts: z.array(relatedChartSchema).optional(),

--- a/apps/dashboard/src/lib/query-config/getQueryConfigByName.test.ts
+++ b/apps/dashboard/src/lib/query-config/getQueryConfigByName.test.ts
@@ -20,8 +20,8 @@ const TS_ENV = {} as const
 // Serializable fields — the intersection of DeclarativeQueryConfig and
 // QueryConfig that the loader carries through. Runtime-only fields
 // (columnIcons, rowClassName, expandable, permission, filterSchema,
-// columnFilters, clickhouseSettings, variants) are deliberately absent from
-// the declarative schema and must not be compared here.
+// columnFilters, variants) are deliberately absent from the declarative
+// schema and must not be compared here.
 const SERIALIZABLE_KEYS = [
   'name',
   'sql',
@@ -45,6 +45,7 @@ const SERIALIZABLE_KEYS = [
   'bulkActions',
   'bulkActionKey',
   'sortingFns',
+  'clickhouseSettings',
 ] as const
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Schema-ext slice of **Plan 02** (declarative config catalog). Adds a serializable `clickhouseSettings` field to the declarative config schema, wires it through the loader, and migrates the two configs that were previously skipped *solely* for needing per-query ClickHouse execution settings:

- `tables/tables-overview` → `{ allow_experimental_analyzer: 0 }`
- `logs/stack-traces` → `{ allow_introspection_functions: 1 }`

Both are registered in `DECLARATIVE_CATALOG` and snapshot-tested to deep-equal their legacy TS configs on every serializable field (including the new `clickhouseSettings`).

## Why
These were the only two configs blocked by a *fully serializable* feature — a primitive settings map. Unlike the remaining skips (`rowClassName`/`expandable`/`columnIcons`, which are functions/JSX needing a runtime DSL), this is a clean, mechanical migration. Continues the expand→migrate→contract march toward the 02L default-flip.

## Scope
- `declarative/schema.ts` (+ test): new `clickhouseSettings` field (record of string|number|boolean primitives)
- `declarative/loader.ts` (+ test): map `clickhouseSettings` through to `QueryConfig`
- `declarative/catalog/{logs/stack-traces,tables/tables-overview}.ts`: new catalog entries
- `declarative/catalog/index.ts`: register both
- `catalog/{logs,tables}/*-catalog.test.ts`, `getQueryConfigByName.test.ts`: snapshot assertions + comment accuracy

## Backward compatibility
**Dormant behind `CHM_CONFIG_SOURCE=ts` (default).** The catalog only resolves under the `declarative` flag, so prod rendering is byte-identical — no visual change. When 02L eventually flips the default, these two views will now carry their required settings (previously they'd have lost them).

## How verified
- `bun test src/lib/query-config/declarative …` → **309 pass / 0 fail**
- `bun run check` (biome) → clean
- `tsc --noEmit` → exit 0
- `bun run type-check:test` → exit 0

## Guardrails
- [x] Scope respected (Plan 02 query-config only)
- [x] build green (types + build)
- [x] check green (lint + format)
- [x] tests green (declarative + registry)
- [x] No UI render change (dormant behind flag) → VISUAL-VERIFICATION n/a
- [x] Backward compatible (default `ts` unchanged)
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: `cowork/plans/02-externalize-query-configs.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stack-traces query: view thread/query identifiers with demangled stack traces
  * Tables-overview query: aggregated table statistics including compression ratios, row counts, and part metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->