### PR TITLE
feat(query-config): declarative docs as plain string + migrate query-cache/merge-performance

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/index.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/index.ts
@@ -49,6 +49,7 @@ import { crashLogDeclarative } from './logs/crashes'
 import { stackTracesDeclarative } from './logs/stack-traces'
 import { textLogDeclarative } from './logs/text-log'
 // Merges
+import { mergePerformanceDeclarative } from './merges/merge-performance'
 import { mergesDeclarative } from './merges/merges'
 // More
 import { asynchronousMetricsDeclarative } from './more/asynchronous-metrics'
@@ -63,6 +64,7 @@ import { zookeeperDeclarative } from './more/zookeeper'
 import { commonErrorsDeclarative } from './queries/common-errors'
 import { parallelizationDeclarative } from './queries/parallelization'
 import { profilerDeclarative } from './queries/profiler'
+import { queryCacheDeclarative } from './queries/query-cache'
 import { queryViewsLogDeclarative } from './queries/query-views-log'
 import { threadAnalysisDeclarative } from './queries/thread-analysis'
 // Security
@@ -148,6 +150,7 @@ const ALL_DECLARATIVE: DeclarativeQueryConfig[] = [
 
   // Merges
   mergesDeclarative,
+  mergePerformanceDeclarative,
 
   // More
   asynchronousMetricsDeclarative,
@@ -163,6 +166,7 @@ const ALL_DECLARATIVE: DeclarativeQueryConfig[] = [
   commonErrorsDeclarative,
   parallelizationDeclarative,
   profilerDeclarative,
+  queryCacheDeclarative,
   queryViewsLogDeclarative,
   threadAnalysisDeclarative,
 

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/merges/merge-performance.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/merges/merge-performance.ts
@@ -1,0 +1,63 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const mergePerformanceDeclarative: DeclarativeQueryConfig = {
+  name: 'merge-performance',
+  description: 'Merge performance over day, avg duration, avg rows read',
+  // Inlined from table-notes PART_LOG (docs is now a plain string)
+  docs: `The required table 'part_log' may be missing. Please follow the documentation at https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings#part-log to ensure the necessary table is available.`,
+  tableCheck: 'system.part_log',
+  optional: true,
+  sql: `
+      SELECT
+          event_date,
+          merge_reason,
+
+          -- Merge Count
+          count() AS count,
+
+          -- Merge Duration
+          AVG(duration_ms) AS avg_duration_ms,
+          formatReadableTimeDelta(avg_duration_ms / 1000, 'minutes', 'milliseconds') AS readable_avg_duration,
+          round(100 * avg_duration_ms / max(avg_duration_ms) OVER ()) as pct_avg_duration,
+
+          -- Rows Read
+          SUM(read_rows) AS sum_read_rows,
+          formatReadableQuantity(sum_read_rows) AS readable_sum_read_rows,
+          round(100 * sum_read_rows / max(sum_read_rows) OVER ()) as pct_sum_read_rows,
+
+          bar(avg_duration_ms, 0, max(avg_duration_ms) OVER (), 30) AS bar_avg_duration,
+          bar(sum_read_rows, 0, max(sum_read_rows) OVER (), 30) AS bar_sum_read_rows
+      FROM merge('system', '^part_log')
+      WHERE toInt8(event_type) = 2
+        AND toInt8(merge_reason) = 1
+      GROUP BY 1, 2
+      ORDER BY 1, 2 ASC
+    `,
+  columns: [
+    'event_date',
+    'merge_reason',
+    'readable_avg_duration',
+    'readable_sum_read_rows',
+  ],
+  columnFormats: {
+    merge_reason: 'colored-badge',
+    readable_avg_duration: 'background-bar',
+    readable_sum_read_rows: 'background-bar',
+  },
+  relatedCharts: [
+    [
+      'merge-avg-duration',
+      {
+        title: 'Merge Avg Duration',
+        lastHours: 720,
+      },
+    ],
+    [
+      'merge-sum-read-rows',
+      {
+        title: 'Merge Total Read Rows',
+        lastHours: 720,
+      },
+    ],
+  ],
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/merges/merges-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/merges/merges-catalog.test.ts
@@ -13,13 +13,14 @@
  *   clickhouseSettings — execution-time settings
  *
  * Skipped configs (runtime-only fields or non-serializable values):
- *   mergePerformanceConfig — docs uses PART_LOG (non-URL string, fails url() validation)
- *   mutationsConfig        — rowClassName function
+ *   mutationsConfig — rowClassName function
  */
 
 import { loadDeclarativeConfig } from '../../loader'
+import { mergePerformanceDeclarative } from './merge-performance'
 import { mergesDeclarative } from './merges'
 import { describe, expect, test } from 'bun:test'
+import { mergePerformanceConfig } from '@/lib/query-config/merges/merge-performance'
 import { mergesConfig } from '@/lib/query-config/merges/merges'
 
 // ---------------------------------------------------------------------------
@@ -68,5 +69,27 @@ describe('merges declarative', () => {
   test('refreshInterval matches legacy', () => {
     const loaded = loadDeclarativeConfig(mergesDeclarative)
     expect(loaded.refreshInterval).toBe(mergesConfig.refreshInterval)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// merge-performance (docs now a plain string via schema-ext)
+// ---------------------------------------------------------------------------
+
+describe('merge-performance declarative', () => {
+  test('loads without error', () => {
+    expect(() =>
+      loadDeclarativeConfig(mergePerformanceDeclarative)
+    ).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(mergePerformanceDeclarative)
+    compareSerializable(loaded, mergePerformanceConfig)
+  })
+
+  test('docs (inlined PART_LOG) matches legacy', () => {
+    const loaded = loadDeclarativeConfig(mergePerformanceDeclarative)
+    expect(loaded.docs).toBe(mergePerformanceConfig.docs)
   })
 })

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/more/backups.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/more/backups.ts
@@ -6,7 +6,8 @@ export const backupsDeclarative: DeclarativeQueryConfig = {
   card: { primary: 'name', badges: ['status'] },
   description: `To restore a backup:
       RESTORE TABLE data_lake.events AS data_lake.events_restore FROM Disk('s3_backup', 'data_lake.events_20231212')`,
-  // docs: BACKUP_LOG — not a URL, cannot be expressed declaratively; omitted
+  // Inlined from table-notes BACKUP_LOG (docs is now a plain string)
+  docs: `The required table 'backup_log' may be missing. Please follow the documentation at https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings#backup_log to ensure the necessary table is available. Make sure you have at least one backup to have this table available.`,
   optional: true,
   tableCheck: 'system.backup_log',
   sql: `

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/more/more-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/more/more-catalog.test.ts
@@ -11,10 +11,10 @@
  *   permission    — FeaturePermission
  *   filterSchema  — contains Icon refs and dynamic option fns
  *
- * Non-URL docs fields excluded from comparison:
- *   docs — schema requires z.string().url(); BACKUP_LOG, QUERY_LOG, ZOOKEEPER
- *           are descriptive strings, not URLs; omitted from declarative objects
- *           and skipped here
+ * docs is now a plain string in the schema, so the descriptive table-missing
+ * help text (BACKUP_LOG, QUERY_LOG, ZOOKEEPER) is inlined into the declarative
+ * objects and IS compared here (verifies the inlined text matches the legacy
+ * table-notes constants).
  *
  * Skipped configs (runtime-only fields that the schema cannot express):
  *   mergetree-settings — permission field
@@ -59,9 +59,6 @@ const RUNTIME_ONLY_KEYS = new Set([
   'columnFilters',
   'clickhouseSettings',
   'variants',
-  // docs is a URL-only field in the schema; configs whose docs is a descriptive
-  // string (BACKUP_LOG, QUERY_LOG, ZOOKEEPER) cannot express it declaratively
-  'docs',
 ])
 
 function compareSerializable(

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/more/top-usage-columns.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/more/top-usage-columns.ts
@@ -5,7 +5,8 @@ export const topUsageColumnsDeclarative: DeclarativeQueryConfig = {
   defaultView: 'auto',
   card: { primary: 'column' },
   description: 'Most usage columns of table based on system.query_log',
-  // docs: QUERY_LOG — not a URL, cannot be expressed declaratively; omitted
+  // Inlined from table-notes QUERY_LOG (docs is now a plain string)
+  docs: `The required table 'query_log' may be missing. Please follow the documentation at https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings#query-log and https://clickhouse.com/docs/en/operations/system-tables/query_log to ensure the necessary table is available.`,
   optional: false,
   tableCheck: 'system.query_log',
   sql: [

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/more/top-usage-tables.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/more/top-usage-tables.ts
@@ -6,7 +6,8 @@ export const topUsageTablesDeclarative: DeclarativeQueryConfig = {
   card: { primary: 'table' },
   description:
     'Most usage tables, ignore system tables, based on system.query_log (top 50). Click on table name to see top usage columns.',
-  // docs: QUERY_LOG — not a URL, cannot be expressed declaratively; omitted
+  // Inlined from table-notes QUERY_LOG (docs is now a plain string)
+  docs: `The required table 'query_log' may be missing. Please follow the documentation at https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings#query-log and https://clickhouse.com/docs/en/operations/system-tables/query_log to ensure the necessary table is available.`,
   optional: false,
   tableCheck: 'system.query_log',
   sql: [

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/more/zookeeper.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/more/zookeeper.ts
@@ -6,7 +6,8 @@ export const zookeeperDeclarative: DeclarativeQueryConfig = {
   card: { primary: '_path' },
   description:
     'Exposes data from the Keeper cluster defined in the config. https://clickhouse.com/docs/en/operations/system-tables/zookeeper',
-  // docs: ZOOKEEPER — not a URL, cannot be expressed declaratively; omitted
+  // Inlined from table-notes ZOOKEEPER (docs is now a plain string)
+  docs: `Make sure that ZooKeeper or clickhouse-keeper has been configured. Please follow the documentation at https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings#server-settings_zookeeper`,
   optional: true,
   tableCheck: 'system.zookeeper',
   sql: `

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/queries/queries-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/queries/queries-catalog.test.ts
@@ -21,7 +21,6 @@
  *   history-queries            — rowClassName, expandable, filterSchema (icons + runtime env), clickhouseSettings
  *   running-queries            — rowClassName, expandable (JSX), filterSchema (icons), columnFilters
  *   query-detail               — permission (FeaturePermission)
- *   query-cache                — docs is non-URL prose string (schema requires URL)
  */
 
 import { loadDeclarativeConfig } from '../../loader'
@@ -29,6 +28,7 @@ import { loadDeclarativeConfig } from '../../loader'
 import { commonErrorsDeclarative } from './common-errors'
 import { parallelizationDeclarative } from './parallelization'
 import { profilerDeclarative } from './profiler'
+import { queryCacheDeclarative } from './query-cache'
 import { queryViewsLogDeclarative } from './query-views-log'
 import { threadAnalysisDeclarative } from './thread-analysis'
 import { describe, expect, test } from 'bun:test'
@@ -36,6 +36,7 @@ import { describe, expect, test } from 'bun:test'
 import { commonErrorsConfig } from '@/lib/query-config/queries/common-errors'
 import { parallelizationConfig } from '@/lib/query-config/queries/parallelization'
 import { profilerConfig } from '@/lib/query-config/queries/profiler'
+import { queryCacheConfig } from '@/lib/query-config/queries/query-cache'
 import { queryViewsLogConfig } from '@/lib/query-config/queries/query-views-log'
 import { threadAnalysisConfig } from '@/lib/query-config/queries/thread-analysis'
 
@@ -136,6 +137,26 @@ describe('query-views-log declarative', () => {
     if (Array.isArray(loaded.sql) && Array.isArray(legacySql)) {
       expect(loaded.sql.length).toBe(legacySql.length)
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// query-cache (docs now a plain string via schema-ext)
+// ---------------------------------------------------------------------------
+
+describe('query-cache declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(queryCacheDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(queryCacheDeclarative)
+    compareSerializable(loaded, queryCacheConfig)
+  })
+
+  test('docs (inlined QUERY_CACHE) matches legacy', () => {
+    const loaded = loadDeclarativeConfig(queryCacheDeclarative)
+    expect(loaded.docs).toBe(queryCacheConfig.docs)
   })
 })
 

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/queries/query-cache.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/queries/query-cache.ts
@@ -1,0 +1,56 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const queryCacheDeclarative: DeclarativeQueryConfig = {
+  name: 'query-cache',
+  optional: false,
+  defaultView: 'auto',
+  card: { primary: 'query', badges: ['stale', 'shared', 'compressed'] },
+  description:
+    'https://clickhouse.com/blog/introduction-to-the-clickhouse-query-cache-and-design',
+  suggestion: `Enable query cache with these settings:
+
+SET enable_query_result_cache = 1;
+SET query_cache_max_size_in_bytes = 1073741824;
+SET query_cache_min_query_duration_ms = 1000;
+
+Learn more:
+https://clickhouse.com/docs/en/operations/query-cache`,
+  // Inlined from table-notes QUERY_CACHE (docs is now a plain string)
+  docs: `The required table 'query_cache' may be missing. Please follow the documentation at https://clickhouse.com/docs/en/operations/query-cache to ensure the necessary table is available.`,
+  tableCheck: 'system.query_cache',
+  sql: `
+      SELECT
+          query,
+          result_size,
+          formatReadableSize(result_size) AS readable_result_size,
+          round(100 * result_size / max(result_size) OVER ()) AS pct_result_size,
+          stale,
+          shared,
+          compressed,
+          expires_at,
+          (expires_at - now()) AS expires_in,
+          key_hash
+      FROM system.query_cache
+      ORDER BY expires_at DESC
+      LIMIT 1000
+    `,
+  columns: [
+    'query',
+    'readable_result_size',
+    'stale',
+    'shared',
+    'compressed',
+    'expires_at',
+    'expires_in',
+    'key_hash',
+  ],
+  columnFormats: {
+    query: 'code-dialog',
+    readable_result_size: 'background-bar',
+    stale: 'boolean',
+    shared: 'boolean',
+    compressed: 'boolean',
+    expires_in: 'duration',
+  },
+  relatedCharts: [['query-cache', {}]],
+}

--- a/apps/dashboard/src/lib/query-config/declarative/schema.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/schema.test.ts
@@ -241,17 +241,19 @@ describe('invalid configs', () => {
     expect(result.errors.some((e) => e.includes('defaultView'))).toBe(true)
   })
 
-  test('rejects non-URL docs field', () => {
+  test('accepts non-URL docs field (table-missing help text)', () => {
+    // docs mirrors QueryConfig.docs (plain string) — a full sentence with an
+    // embedded URL is valid, not just a bare URL.
     const result = validateDeclarativeConfig({
       name: 'my-query',
       sql: 'SELECT 1',
       columns: ['col1'],
-      docs: 'not-a-url',
+      docs: "The 'query_log' table may be missing. See https://clickhouse.com/docs/en/operations/system-tables/query_log",
     })
 
-    expect(result.ok).toBe(false)
-    if (result.ok) return
-    expect(result.errors.some((e) => e.includes('docs'))).toBe(true)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.config.docs).toContain('query_log')
   })
 
   test('accepts clickhouseSettings with primitive values', () => {

--- a/apps/dashboard/src/lib/query-config/declarative/schema.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/schema.ts
@@ -188,7 +188,10 @@ export const declarativeQueryConfigSchema = z.object({
   // Identity
   name: z.string().min(1, 'name is required'),
   description: z.string().optional(),
-  docs: z.string().url().optional(),
+  // docs is help text shown when a table is missing — often a full sentence
+  // with embedded URLs (e.g. table-notes constants), not a bare URL. Mirrors
+  // QueryConfig.docs (plain string); do NOT constrain to .url().
+  docs: z.string().optional(),
   suggestion: z.string().optional(),
 
   // SQL

--- a/apps/dashboard/src/lib/query-config/getQueryConfigByName.test.ts
+++ b/apps/dashboard/src/lib/query-config/getQueryConfigByName.test.ts
@@ -115,16 +115,12 @@ describe('getQueryConfigByName — declarative path parity', () => {
 
       // Compare only fields where BOTH sides have a defined value.
       //
-      // Two intentional gaps exist between TS configs and the declarative schema:
-      //
-      // 1. Schema defaults: the declarative loader applies schema defaults
-      //    (e.g. optional: false) for keys the TS config leaves undefined.
-      //    Comparing those would be false-positives, so skip when ts is undefined.
-      //
-      // 2. Non-representable TS values: some TS configs set `docs` to a plain
-      //    human-readable message (not a URL). The declarative schema enforces
-      //    z.string().url() on `docs`, so those entries deliberately omit `docs`
-      //    in the catalog. Skip when decl is undefined to allow this known gap.
+      // One intentional gap remains between TS configs and the declarative
+      // schema: schema defaults — the declarative loader applies defaults
+      // (e.g. optional: false) for keys the TS config leaves undefined.
+      // Comparing those would be false-positives, so skip when either side is
+      // undefined. (`docs` is now a plain string in the schema, so non-URL
+      // help-text values round-trip and no longer need to be omitted.)
       //
       // The contract: for every field that both sides carry, the values must match.
       for (const key of SERIALIZABLE_KEYS) {


### PR DESCRIPTION
## What
Schema-ext slice of **Plan 02**. The declarative `docs` field was constrained to `z.string().url()`, but `QueryConfig.docs` is a plain string holding **table-missing help text** — full sentences with embedded URLs (the `table-notes` constants), not bare URLs. Loosen the schema to `z.string()` to match the runtime type.

This unlocks two things:
1. **Restores** the dropped non-URL `docs` on 4 already-migrated configs (`backups`/`BACKUP_LOG`, `zookeeper`/`ZOOKEEPER`, `top-usage-columns` + `top-usage-tables`/`QUERY_LOG`) — previously omitted to satisfy `.url()`, leaving the catalog lossy. Now inlined so help text survives the 02L flip.
2. **Migrates** the 2 configs blocked *solely* by non-URL docs: `queries/query-cache` (`QUERY_CACHE`) and `merges/merge-performance` (`PART_LOG`).

## Why
`.url()` was the wrong constraint for a help-text field. Aligning it with `QueryConfig.docs` is a strict relaxation that both fixes a fidelity gap and unblocks two clean migrations — no functions/JSX involved.

## Scope
- `declarative/schema.ts` (+ test): `docs` → `z.string()` (was `.url()`); test flipped from "rejects non-URL" to "accepts help text"
- `catalog/more/{backups,zookeeper,top-usage-columns,top-usage-tables}.ts`: restore inlined `docs`
- `catalog/queries/query-cache.ts`, `catalog/merges/merge-performance.ts`: new entries + registry
- `catalog/{more,merges,queries}/*-catalog.test.ts`, `getQueryConfigByName.test.ts`: now compare `docs`; snapshot-test inlined text byte-equals legacy `table-notes` constants

## Backward compatibility
**Dormant behind `CHM_CONFIG_SOURCE=ts` (default).** Catalog only resolves under the `declarative` flag → prod rendering byte-identical, no visual change.

## How verified
- `bun test src/lib/query-config/declarative …` → **317 pass / 0 fail** (inlined docs byte-match legacy consts)
- `bun run check` (biome) → clean
- `vite build && tsc --noEmit` → exit 0
- `bun run type-check:test` → exit 0

## Guardrails
- [x] Scope respected (Plan 02 query-config only)
- [x] build green (types + build)
- [x] check green (lint + format)
- [x] tests green (declarative + registry)
- [x] No UI render change (dormant behind flag) → VISUAL-VERIFICATION n/a
- [x] Backward compatible (default `ts` unchanged)
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: `cowork/plans/02-externalize-query-configs.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added merge-performance dashboard card displaying ClickHouse merge statistics.
  * Added query-cache dashboard card showing cached query details and metadata.

* **Documentation**
  * Enhanced dashboard configuration with inline help text for system table requirements and references.

* **Tests**
  * Expanded test coverage for new dashboard configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->