### PR TITLE
feat(query-config): declarative rowStyle (compiles to rowClassName) + migrate kafka-consumers

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/index.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/index.ts
@@ -86,6 +86,7 @@ import {
   databaseDiskSpaceDeclarative,
   diskSpaceDeclarative,
 } from './system/disks'
+import { kafkaConsumersDeclarative } from './system/kafka-consumers'
 import { queryMetricLogDeclarative } from './system/query-metric-log'
 import {
   clustersReplicasStatusDeclarative,
@@ -185,6 +186,7 @@ const ALL_DECLARATIVE: DeclarativeQueryConfig[] = [
   databaseDiskSpaceDeclarative,
   databaseDiskSpaceByDatabaseDeclarative,
   queryMetricLogDeclarative,
+  kafkaConsumersDeclarative,
   clustersReplicasStatusDeclarative,
   replicaTablesDeclarative,
   replicatedMergeTreeSettingsDeclarative,

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/system/kafka-consumers.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/system/kafka-consumers.ts
@@ -1,0 +1,60 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const kafkaConsumersDeclarative: DeclarativeQueryConfig = {
+  name: 'kafka-consumers',
+  defaultView: 'auto',
+  card: { primary: 'table', badges: ['consumer_id'] },
+  description:
+    'Kafka table engine consumer state: poll/commit activity, messages read, and last exception per consumer',
+  refreshInterval: 15_000,
+  // system.kafka_consumers only exists if Kafka table engines are configured
+  optional: true,
+  tableCheck: 'system.kafka_consumers',
+  sql: `
+      SELECT
+        database,
+        table,
+        consumer_id,
+        assignments.topic AS topics,
+        assignments.partition_id AS partitions,
+        last_poll_time,
+        num_messages_read,
+        last_commit_time,
+        num_commits,
+        last_exception_time,
+        last_exception
+      FROM system.kafka_consumers
+      ORDER BY table
+    `,
+  columns: [
+    'database',
+    'table',
+    'consumer_id',
+    'topics',
+    'partitions',
+    'last_poll_time',
+    'num_messages_read',
+    'last_commit_time',
+    'num_commits',
+    'last_exception_time',
+    'last_exception',
+  ],
+  columnFormats: {
+    database: 'colored-badge',
+    table: 'colored-badge',
+    num_messages_read: 'number-short',
+    num_commits: 'number-short',
+    last_exception: 'code-dialog',
+  },
+  // Replaces the legacy rowClassName: highlight rows with a non-empty
+  // last_exception. default '' matches the legacy no-match return.
+  rowStyle: {
+    rules: [
+      {
+        when: { column: 'last_exception', op: 'nonempty' },
+        className: 'bg-red-50 dark:bg-red-950/20',
+      },
+    ],
+    default: '',
+  },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/system/system-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/system/system-catalog.test.ts
@@ -4,16 +4,20 @@
  * For each migrated config, assert that loadDeclarativeConfig(declarativeObj)
  * deep-equals the legacy TS config on its serializable fields.
  *
- * Runtime-only fields excluded from comparison:
+ * Runtime-only fields excluded from deep-equal comparison (functions can't be
+ * compared by value):
  *   rowClassName  — function (row) => string | undefined
  *   expandable    — function-based ExpandableConfig
  *   columnIcons   — React component refs
  *   permission    — FeaturePermission
  *   filterSchema  — contains Icon refs and dynamic option fns
  *
+ * kafka-consumers migrates its rowClassName via the declarative `rowStyle`
+ * rules; rowClassName is excluded from the deep-equal (it's a function) but is
+ * verified separately by applying both functions to boundary rows.
+ *
  * Skipped configs (runtime-only fields that the schema cannot express):
- *   kafkaConsumersConfig    — rowClassName
- *   partLogConfig           — rowClassName
+ *   partLogConfig           — rowClassName (truthy on error) — see follow-up
  */
 
 import { loadDeclarativeConfig } from '../../loader'
@@ -33,6 +37,7 @@ import {
   databaseDiskSpaceDeclarative,
   diskSpaceDeclarative,
 } from './disks'
+import { kafkaConsumersDeclarative } from './kafka-consumers'
 import { queryMetricLogDeclarative } from './query-metric-log'
 import {
   clustersReplicasStatusDeclarative,
@@ -56,6 +61,7 @@ import {
   databaseDiskSpaceConfig,
   diskSpaceConfig,
 } from '@/lib/query-config/system/disks'
+import { kafkaConsumersConfig } from '@/lib/query-config/system/kafka-consumers'
 import { queryMetricLogConfig } from '@/lib/query-config/system/query-metric-log'
 import {
   clustersReplicasStatusConfig,
@@ -286,5 +292,44 @@ describe('replicated-merge-tree-settings declarative', () => {
   test('serializable fields match legacy', () => {
     const loaded = loadDeclarativeConfig(replicatedMergeTreeSettingsDeclarative)
     compareSerializable(loaded, replicatedMergeTreeSettingsConfig)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// kafka-consumers — rowClassName migrated to declarative rowStyle.
+// rowClassName is a function (excluded from deep-equal); verify behavioural
+// equivalence by applying both the compiled and legacy functions to rows that
+// cover every boundary of the last_exception condition.
+// ---------------------------------------------------------------------------
+
+describe('kafka-consumers declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(kafkaConsumersDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(kafkaConsumersDeclarative)
+    compareSerializable(loaded, kafkaConsumersConfig)
+  })
+
+  test('compiled rowClassName matches legacy across boundary rows', () => {
+    const loaded = loadDeclarativeConfig(kafkaConsumersDeclarative)
+    const compiled = loaded.rowClassName
+    const legacy = kafkaConsumersConfig.rowClassName
+    expect(typeof compiled).toBe('function')
+    expect(typeof legacy).toBe('function')
+    if (!compiled || !legacy) return
+
+    const rows: Record<string, unknown>[] = [
+      { last_exception: '' },
+      { last_exception: 'Cannot connect to broker' },
+      { last_exception: null },
+      { last_exception: undefined },
+      {}, // missing key
+      { last_exception: 0 }, // numeric falsy → String(0 || '') === ''
+    ]
+    for (const row of rows) {
+      expect(compiled(row)).toBe(legacy(row))
+    }
   })
 })

--- a/apps/dashboard/src/lib/query-config/declarative/loader.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/loader.ts
@@ -6,12 +6,14 @@
  *
  * RUNTIME-ONLY FIELDS NOT PRESENT ON LOADED CONFIGS:
  *   - columnIcons    — React component refs (Icon type)
- *   - rowClassName   — function (row) => string | undefined
  *   - expandable     — function-based ExpandableConfig
  *   - permission     — FeaturePermission (app-level import)
  *   - filterSchema   — FilterSchema (contains Icon refs and dynamic option fns)
  *   - columnFilters  — ColumnFilterDef (UI sugar over filterSchema)
  *   - variants       — deprecated; use versioned sql[] in the declarative format
+ *
+ * The declarative `rowStyle` field IS carried: it is compiled into a
+ * rowClassName function on the loaded config (see compileRowStyle).
  *
  * These fields can be merged in by the caller after loading if needed.
  */
@@ -19,6 +21,7 @@
 import type { QueryConfig } from '@/types/query-config'
 import type { DeclarativeQueryConfig } from './schema'
 
+import { compileRowStyle } from './row-style'
 import { validateDeclarativeConfig } from './validate'
 
 // ---------------------------------------------------------------------------
@@ -63,9 +66,9 @@ export function getConfigSource(
  * is 1-to-1: field names and value shapes are shared by design.
  *
  * Runtime-only fields absent from DeclarativeQueryConfig (columnIcons,
- * rowClassName, expandable, permission, filterSchema, columnFilters,
- * variants) are simply omitted from the result. Callers that need those
- * fields must merge them in after loading.
+ * expandable, permission, filterSchema, columnFilters, variants) are simply
+ * omitted from the result. Callers that need those fields must merge them in
+ * after loading. (rowClassName is produced from the declarative rowStyle rules.)
  *
  * @throws Error when `input` fails schema validation (message includes all
  *   field-level errors joined by '; ').
@@ -143,6 +146,11 @@ export function loadDeclarativeConfig(input: unknown): QueryConfig {
   // Sorting
   if (d.sortingFns !== undefined) {
     config.sortingFns = d.sortingFns as QueryConfig['sortingFns']
+  }
+
+  // Row styling — compile declarative rules into a rowClassName function.
+  if (d.rowStyle !== undefined) {
+    config.rowClassName = compileRowStyle(d.rowStyle)
   }
 
   return config

--- a/apps/dashboard/src/lib/query-config/declarative/row-style.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/row-style.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for the rowStyle compiler (compileRowStyle).
+ *
+ * These pin the exact semantics of every operator and the coercion rules,
+ * since rowStyle is a public contract compiled into a runtime function.
+ */
+
+import { compileRowStyle, type RowStyle } from './row-style'
+import { describe, expect, test } from 'bun:test'
+
+const RED = 'bg-red-50'
+const AMBER = 'bg-amber-50'
+
+function fn(rowStyle: RowStyle) {
+  return compileRowStyle(rowStyle)
+}
+
+describe('compileRowStyle — numeric comparisons', () => {
+  test('gt: strictly greater than', () => {
+    const f = fn({
+      rules: [{ when: { column: 'd', op: 'gt', value: 10 }, className: RED }],
+    })
+    expect(f({ d: 11 })).toBe(RED)
+    expect(f({ d: 10 })).toBeUndefined() // not strict-greater
+    expect(f({ d: 9 })).toBeUndefined()
+  })
+
+  test('gte / lt / lte boundaries', () => {
+    expect(
+      fn({
+        rules: [
+          { when: { column: 'd', op: 'gte', value: 10 }, className: RED },
+        ],
+      })({ d: 10 })
+    ).toBe(RED)
+    expect(
+      fn({
+        rules: [{ when: { column: 'd', op: 'lt', value: 10 }, className: RED }],
+      })({ d: 10 })
+    ).toBeUndefined()
+    expect(
+      fn({
+        rules: [
+          { when: { column: 'd', op: 'lte', value: 10 }, className: RED },
+        ],
+      })({ d: 10 })
+    ).toBe(RED)
+  })
+
+  test('coerces via Number(value || 0): missing/null/string', () => {
+    const f = fn({
+      rules: [{ when: { column: 'd', op: 'gt', value: 0 }, className: RED }],
+    })
+    expect(f({})).toBeUndefined() // Number(undefined||0)=0, not >0
+    expect(f({ d: null })).toBeUndefined()
+    expect(f({ d: '5' })).toBe(RED) // numeric string coerces
+  })
+})
+
+describe('compileRowStyle — truthiness & emptiness', () => {
+  test('truthy / falsy use numeric truthiness (Number(v||0) !== 0)', () => {
+    const truthy = fn({
+      rules: [{ when: { column: 'e', op: 'truthy' }, className: RED }],
+    })
+    expect(truthy({ e: 1 })).toBe(RED)
+    expect(truthy({ e: 0 })).toBeUndefined()
+    expect(truthy({ e: undefined })).toBeUndefined()
+
+    const falsy = fn({
+      rules: [{ when: { column: 'e', op: 'falsy' }, className: RED }],
+    })
+    expect(falsy({ e: 0 })).toBe(RED)
+    expect(falsy({ e: 1 })).toBeUndefined()
+    expect(falsy({})).toBe(RED) // Number(undefined||0)=0 → falsy
+  })
+
+  test('empty / nonempty use string emptiness (String(v||"") === "")', () => {
+    const nonempty = fn({
+      rules: [{ when: { column: 's', op: 'nonempty' }, className: RED }],
+    })
+    expect(nonempty({ s: 'boom' })).toBe(RED)
+    expect(nonempty({ s: '' })).toBeUndefined()
+    expect(nonempty({ s: null })).toBeUndefined()
+    expect(nonempty({ s: 0 })).toBeUndefined() // String(0||'') === ''
+
+    const empty = fn({
+      rules: [{ when: { column: 's', op: 'empty' }, className: RED }],
+    })
+    expect(empty({ s: '' })).toBe(RED)
+    expect(empty({ s: 'x' })).toBeUndefined()
+  })
+})
+
+describe('compileRowStyle — combinators & ordering', () => {
+  test('all = AND of sub-conditions', () => {
+    const f = fn({
+      rules: [
+        {
+          when: {
+            all: [
+              { column: 'is_done', op: 'falsy' },
+              { column: 'elapsed', op: 'gt', value: 600 },
+            ],
+          },
+          className: AMBER,
+        },
+      ],
+    })
+    expect(f({ is_done: 0, elapsed: 700 })).toBe(AMBER)
+    expect(f({ is_done: 1, elapsed: 700 })).toBeUndefined() // is_done truthy
+    expect(f({ is_done: 0, elapsed: 500 })).toBeUndefined() // elapsed too low
+  })
+
+  test('any = OR of sub-conditions', () => {
+    const f = fn({
+      rules: [
+        {
+          when: {
+            any: [
+              { column: 'a', op: 'truthy' },
+              { column: 'b', op: 'truthy' },
+            ],
+          },
+          className: RED,
+        },
+      ],
+    })
+    expect(f({ a: 1, b: 0 })).toBe(RED)
+    expect(f({ a: 0, b: 1 })).toBe(RED)
+    expect(f({ a: 0, b: 0 })).toBeUndefined()
+  })
+
+  test('first matching rule wins (priority order)', () => {
+    const f = fn({
+      rules: [
+        { when: { column: 'd', op: 'gt', value: 60 }, className: RED },
+        { when: { column: 'd', op: 'gt', value: 10 }, className: AMBER },
+      ],
+    })
+    expect(f({ d: 100 })).toBe(RED) // matches first
+    expect(f({ d: 30 })).toBe(AMBER) // only second
+    expect(f({ d: 5 })).toBeUndefined()
+  })
+
+  test('default is returned when no rule matches', () => {
+    const withDefault = fn({
+      rules: [{ when: { column: 'd', op: 'gt', value: 10 }, className: RED }],
+      default: '',
+    })
+    expect(withDefault({ d: 1 })).toBe('')
+
+    const noDefault = fn({
+      rules: [{ when: { column: 'd', op: 'gt', value: 10 }, className: RED }],
+    })
+    expect(noDefault({ d: 1 })).toBeUndefined()
+  })
+})

--- a/apps/dashboard/src/lib/query-config/declarative/row-style.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/row-style.ts
@@ -1,0 +1,86 @@
+/**
+ * rowStyle compiler — Plan 02 schema-ext.
+ *
+ * Compiles the declarative `rowStyle` rules into a RowClassNameFn, the runtime
+ * function the data-table consumes. This is the declarative replacement for a
+ * hand-written rowClassName: simple, data-driven row styling expressed as an
+ * ordered list of condition→className rules.
+ *
+ * Coercion mirrors the legacy rowClassName idioms EXACTLY so a compiled
+ * function is behaviourally identical to the TS function it replaces:
+ *   - numeric comparisons (gt/gte/lt/lte) and truthy/falsy use Number(v || 0)
+ *   - empty/nonempty use String(v || '')
+ * (Note: `|| ` not `?? ` — matches `Number(row.x || 0)` / `String(row.x || '')`
+ *  used across the legacy configs, which differ from `??` for falsy values.)
+ */
+
+import type { RowClassNameFn } from '@/types/query-config'
+import type { RowStyleCondition } from './schema'
+
+type Row = Record<string, unknown>
+
+// A declarative rowStyle as validated by the schema.
+export interface RowStyle {
+  rules: { when: RowStyleCondition; className: string }[]
+  default?: string
+}
+
+/**
+ * Compile a single condition into a predicate over a row.
+ */
+function compileCondition(cond: RowStyleCondition): (row: Row) => boolean {
+  if ('all' in cond) {
+    const subs = cond.all.map(compileCondition)
+    return (row) => subs.every((f) => f(row))
+  }
+  if ('any' in cond) {
+    const subs = cond.any.map(compileCondition)
+    return (row) => subs.some((f) => f(row))
+  }
+
+  const { column } = cond
+  switch (cond.op) {
+    case 'gt': {
+      const v = cond.value
+      return (row) => Number(row[column] || 0) > v
+    }
+    case 'gte': {
+      const v = cond.value
+      return (row) => Number(row[column] || 0) >= v
+    }
+    case 'lt': {
+      const v = cond.value
+      return (row) => Number(row[column] || 0) < v
+    }
+    case 'lte': {
+      const v = cond.value
+      return (row) => Number(row[column] || 0) <= v
+    }
+    case 'truthy':
+      return (row) => Number(row[column] || 0) !== 0
+    case 'falsy':
+      return (row) => Number(row[column] || 0) === 0
+    case 'nonempty':
+      return (row) => String(row[column] || '') !== ''
+    case 'empty':
+      return (row) => String(row[column] || '') === ''
+  }
+}
+
+/**
+ * Compile declarative rowStyle rules into a RowClassNameFn. The first matching
+ * rule's className is returned; if none match, `default` (or undefined).
+ */
+export function compileRowStyle(rowStyle: RowStyle): RowClassNameFn {
+  const compiled = rowStyle.rules.map((rule) => ({
+    test: compileCondition(rule.when),
+    className: rule.className,
+  }))
+  const fallback = rowStyle.default
+  return (row) => {
+    for (const rule of compiled) {
+      if (rule.test(row)) return rule.className
+    }
+    return fallback
+  }
+}

--- a/apps/dashboard/src/lib/query-config/declarative/schema.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/schema.test.ts
@@ -292,6 +292,62 @@ describe('invalid configs', () => {
     )
   })
 
+  test('accepts rowStyle with rules and nested all/any conditions', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: 'SELECT 1',
+      columns: ['col1'],
+      rowStyle: {
+        rules: [
+          {
+            when: { column: 'd', op: 'gt', value: 60 },
+            className: 'bg-red-50',
+          },
+          {
+            when: {
+              all: [
+                { column: 'is_done', op: 'falsy' },
+                { column: 'elapsed', op: 'gt', value: 600 },
+              ],
+            },
+            className: 'bg-amber-50',
+          },
+        ],
+        default: '',
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.config.rowStyle?.rules.length).toBe(2)
+  })
+
+  test('rejects rowStyle with empty rules array', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: 'SELECT 1',
+      columns: ['col1'],
+      rowStyle: { rules: [] },
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some((e) => e.includes('rowStyle'))).toBe(true)
+  })
+
+  test('rejects rowStyle comparison op without a numeric value', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: 'SELECT 1',
+      columns: ['col1'],
+      rowStyle: {
+        rules: [{ when: { column: 'd', op: 'gt' }, className: 'bg-red-50' }],
+      },
+    })
+
+    expect(result.ok).toBe(false)
+  })
+
   test('rejects unknown columnFormat enum value', () => {
     const result = validateDeclarativeConfig({
       name: 'my-query',

--- a/apps/dashboard/src/lib/query-config/declarative/schema.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/schema.ts
@@ -7,9 +7,11 @@
  *
  * The companion loader (Plan 02b) will map a DeclarativeQueryConfig into the
  * in-memory QueryConfig that the dashboard consumes at runtime. Fields that
- * are runtime functions (rowClassName, expandable, columnIcons, filterSchema
- * with Icon refs, FeaturePermission) are intentionally excluded here — they
- * cannot be expressed declaratively and must be wired up by the loader.
+ * are runtime functions (expandable, columnIcons, filterSchema with Icon refs,
+ * FeaturePermission) are intentionally excluded here — they cannot be expressed
+ * declaratively and must be wired up by the loader. The one exception is
+ * rowClassName: simple data-driven row styling is expressible via the
+ * declarative `rowStyle` rules, which the loader compiles into a RowClassNameFn.
  *
  * Serializable fields carried here:
  *   identity:       name, description, docs, suggestion
@@ -23,6 +25,7 @@
  *   relatedCharts:  string[] | [string, params][]
  *   card, defaultView, bulkActions, bulkActionKey
  *   sortingFns
+ *   rowStyle:       ordered condition→className rules (compiles to rowClassName)
  */
 
 import { z } from 'zod'
@@ -181,6 +184,57 @@ const clickhouseSettingsSchema = z.record(
 )
 
 // ---------------------------------------------------------------------------
+// rowStyle — declarative replacement for the rowClassName function.
+//
+// A serializable, ordered list of { when, className } rules. The loader
+// compiles them into a RowClassNameFn: the first matching rule's className is
+// returned; if none match, `default` (or undefined) is returned.
+//
+// Condition operators mirror the legacy rowClassName coercion idioms exactly:
+//   gt/gte/lt/lte   numeric comparison via Number(value || 0)
+//   truthy/falsy    numeric truthiness  (Number(value || 0) !== 0)
+//   empty/nonempty  string emptiness    (String(value || '') === '')
+//   all/any         combine sub-conditions (AND / OR)
+// ---------------------------------------------------------------------------
+
+const comparisonOpSchema = z.enum(['gt', 'gte', 'lt', 'lte'])
+const truthinessOpSchema = z.enum(['truthy', 'falsy', 'empty', 'nonempty'])
+
+// Recursive condition type (all/any nest conditions) — declared explicitly so
+// z.lazy can be given a precise type.
+export type RowStyleCondition =
+  | { column: string; op: 'gt' | 'gte' | 'lt' | 'lte'; value: number }
+  | { column: string; op: 'truthy' | 'falsy' | 'empty' | 'nonempty' }
+  | { all: RowStyleCondition[] }
+  | { any: RowStyleCondition[] }
+
+const rowStyleConditionSchema: z.ZodType<RowStyleCondition> = z.lazy(() =>
+  z.union([
+    z.object({
+      column: z.string().min(1),
+      op: comparisonOpSchema,
+      value: z.number(),
+    }),
+    z.object({ column: z.string().min(1), op: truthinessOpSchema }),
+    z.object({ all: z.array(rowStyleConditionSchema).min(1) }),
+    z.object({ any: z.array(rowStyleConditionSchema).min(1) }),
+  ])
+)
+
+const rowStyleSchema = z.object({
+  rules: z
+    .array(
+      z.object({
+        when: rowStyleConditionSchema,
+        className: z.string().min(1),
+      })
+    )
+    .min(1, 'rowStyle must have at least one rule'),
+  // className returned when no rule matches; omit for undefined (no class).
+  default: z.string().optional(),
+})
+
+// ---------------------------------------------------------------------------
 // Main declarative schema
 // ---------------------------------------------------------------------------
 
@@ -247,9 +301,12 @@ export const declarativeQueryConfigSchema = z.object({
   // Sorting
   sortingFns: sortingFnsSchema.optional(),
 
+  // Row styling — declarative replacement for rowClassName (loader compiles it)
+  rowStyle: rowStyleSchema.optional(),
+
   // Intentionally excluded (not serializable — require runtime code):
   //   columnIcons     — React component refs
-  //   rowClassName    — function (row) => string
+  //   rowClassName    — function (row) => string (use declarative rowStyle)
   //   expandable      — function (row, ctx) => ReactNode
   //   permission      — FeaturePermission (app-level import)
   //   variants        — deprecated; use versioned sql[] instead


### PR DESCRIPTION
## What
Schema-ext slice of **Plan 02**. Adds a declarative **`rowStyle`** construct — an ordered list of `{ when, className }` rules — that the loader compiles into a `RowClassNameFn`. This is the serializable replacement for hand-written `rowClassName` functions, the last *common* non-serializable field blocking the remaining config migrations.

Operators (coercion mirrors the legacy `rowClassName` idioms **exactly**):
| op | semantics |
|----|-----------|
| `gt`/`gte`/`lt`/`lte` | numeric comparison via `Number(v \|\| 0)` |
| `truthy`/`falsy` | numeric truthiness `Number(v \|\| 0) !== 0` |
| `empty`/`nonempty` | string emptiness `String(v \|\| '') === ''` |
| `all`/`any` | AND / OR of sub-conditions |

Migrates **`system/kafka-consumers`** (`rowClassName` was its only remaining blocker).

## Why
All six legacy `rowClassName` functions are the same simple shape: coerce a column, run ordered threshold/truthy checks, return a CSS class. `rowStyle` captures exactly that — the mechanism the project's own HANDOFF anticipated ("rowStyle for rowClassName"). It unblocks the `rowClassName`-only configs without touching the genuinely-runtime fields (`expandable`/`columnIcons`).

## Verification (note: different shape than prior slices)
A compiled function can't be deep-equaled, so equivalence is **behavioural**: both the compiled and legacy `rowClassName` are applied to rows covering *every boundary* of the condition (empty/non-empty/null/missing/numeric-falsy) and asserted identical. The compiler also has **exhaustive standalone unit tests** pinning each operator's semantics and ordering/default behaviour.

## Scope
- `declarative/schema.ts` (+ test): `rowStyle` schema (recursive `all`/`any` via `z.lazy`)
- `declarative/row-style.ts` (+ test): `compileRowStyle()` + 16 DSL unit tests
- `declarative/loader.ts`: compile `rowStyle` → `rowClassName`
- `catalog/system/kafka-consumers.ts` + registry + `system-catalog.test.ts`: migration + behavioural test

## Backward compatibility
**Dormant behind `CHM_CONFIG_SOURCE=ts` (default)** → prod rendering byte-identical. The contract has **no external consumers yet** (03a unshipped), so it stays freely revisable before the 02L default-flip.

## How verified
- `bun test src/lib/query-config/declarative …` → **333 pass / 0 fail**
- `bun run check` (biome) → clean
- `vite build && tsc --noEmit` → exit 0 · `bun run type-check:test` → exit 0

## Follow-ups (mechanical, same mechanism)
`system/part-log` (truthy on error), `merges/mutations` (compound `all` + inline SQL constant).

## Guardrails
- [x] Scope respected (Plan 02 query-config only)
- [x] build green · check green · tests green
- [x] No UI render change (dormant behind flag) → VISUAL-VERIFICATION n/a
- [x] Backward compatible (default `ts` unchanged)
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: `cowork/plans/02-externalize-query-configs.md`