### PR TITLE
feat(query-config): migrate part-log + mutations to declarative rowStyle

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/index.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/index.ts
@@ -51,6 +51,7 @@ import { textLogDeclarative } from './logs/text-log'
 // Merges
 import { mergePerformanceDeclarative } from './merges/merge-performance'
 import { mergesDeclarative } from './merges/merges'
+import { mutationsDeclarative } from './merges/mutations'
 // More
 import { asynchronousMetricsDeclarative } from './more/asynchronous-metrics'
 import { backupsDeclarative } from './more/backups'
@@ -87,6 +88,7 @@ import {
   diskSpaceDeclarative,
 } from './system/disks'
 import { kafkaConsumersDeclarative } from './system/kafka-consumers'
+import { partLogDeclarative } from './system/part-log'
 import { queryMetricLogDeclarative } from './system/query-metric-log'
 import {
   clustersReplicasStatusDeclarative,
@@ -152,6 +154,7 @@ const ALL_DECLARATIVE: DeclarativeQueryConfig[] = [
   // Merges
   mergesDeclarative,
   mergePerformanceDeclarative,
+  mutationsDeclarative,
 
   // More
   asynchronousMetricsDeclarative,
@@ -187,6 +190,7 @@ const ALL_DECLARATIVE: DeclarativeQueryConfig[] = [
   databaseDiskSpaceByDatabaseDeclarative,
   queryMetricLogDeclarative,
   kafkaConsumersDeclarative,
+  partLogDeclarative,
   clustersReplicasStatusDeclarative,
   replicaTablesDeclarative,
   replicatedMergeTreeSettingsDeclarative,

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/merges/merges-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/merges/merges-catalog.test.ts
@@ -12,16 +12,19 @@
  *   filterSchema  — contains Icon refs and dynamic option fns
  *   clickhouseSettings — execution-time settings
  *
- * Skipped configs (runtime-only fields or non-serializable values):
- *   mutationsConfig — rowClassName function
+ * mutations migrates its rowClassName via the declarative `rowStyle` rules;
+ * rowClassName is excluded from the deep-equal (it's a function) but is verified
+ * separately by applying both functions to boundary rows.
  */
 
 import { loadDeclarativeConfig } from '../../loader'
 import { mergePerformanceDeclarative } from './merge-performance'
 import { mergesDeclarative } from './merges'
+import { mutationsDeclarative } from './mutations'
 import { describe, expect, test } from 'bun:test'
 import { mergePerformanceConfig } from '@/lib/query-config/merges/merge-performance'
 import { mergesConfig } from '@/lib/query-config/merges/merges'
+import { mutationsConfig } from '@/lib/query-config/merges/mutations'
 
 // ---------------------------------------------------------------------------
 // Helper: compare serializable fields between loaded declarative config and
@@ -91,5 +94,46 @@ describe('merge-performance declarative', () => {
   test('docs (inlined PART_LOG) matches legacy', () => {
     const loaded = loadDeclarativeConfig(mergePerformanceDeclarative)
     expect(loaded.docs).toBe(mergePerformanceConfig.docs)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// mutations — rowClassName (is_stuck red; !is_done & elapsed>300 amber)
+// migrated to declarative rowStyle (compound `all` condition).
+// ---------------------------------------------------------------------------
+
+describe('mutations declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(mutationsDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(mutationsDeclarative)
+    compareSerializable(loaded, mutationsConfig)
+  })
+
+  test('compiled rowClassName matches legacy across boundary rows', () => {
+    const loaded = loadDeclarativeConfig(mutationsDeclarative)
+    const compiled = loaded.rowClassName
+    const legacy = mutationsConfig.rowClassName
+    expect(typeof compiled).toBe('function')
+    expect(typeof legacy).toBe('function')
+    if (!compiled || !legacy) return
+
+    // Cover the full truth table: is_stuck (red, highest priority),
+    // !is_done & elapsed boundaries (amber at >300), and the no-match default.
+    const rows: Record<string, unknown>[] = [
+      { is_stuck: 1, is_done: 0, elapsed: 0 }, // red wins over amber
+      { is_stuck: 1, is_done: 1, elapsed: 999 }, // red
+      { is_stuck: 0, is_done: 0, elapsed: 301 }, // amber (just over)
+      { is_stuck: 0, is_done: 0, elapsed: 300 }, // not strict-gt → default
+      { is_stuck: 0, is_done: 0, elapsed: 500 }, // amber
+      { is_stuck: 0, is_done: 1, elapsed: 999 }, // done → default
+      { is_stuck: 0, is_done: 0, elapsed: 0 }, // default
+      {}, // missing keys → default
+    ]
+    for (const row of rows) {
+      expect(compiled(row)).toBe(legacy(row))
+    }
   })
 })

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/merges/mutations.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/merges/mutations.ts
@@ -1,0 +1,98 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+// Inlined thresholds from the legacy config:
+//   STUCK_THRESHOLD_SECONDS = 600 (used in the SQL is_stuck expression)
+//   LONG_RUNNING_THRESHOLD_SECONDS = 300 (used in the rowStyle amber rule)
+export const mutationsDeclarative: DeclarativeQueryConfig = {
+  name: 'mutations',
+  optional: false,
+  defaultView: 'auto',
+  card: { primary: 'command', badges: ['is_done', 'is_stuck'] },
+  refreshInterval: 30_000,
+  description:
+    'Information about mutations of MergeTree tables and their progress',
+  sql: `
+      SELECT
+        database || '.' || table as table,
+        mutation_id,
+        command,
+        create_time,
+        now() - create_time AS elapsed,
+        parts_to_do,
+        formatReadableQuantity(parts_to_do) AS readable_parts_to_do,
+        round(100 * parts_to_do / nullIf(max(parts_to_do) OVER (), 0), 2) as pct_parts_to_do,
+        parts_to_do_names,
+        is_done,
+        if(is_done = 0 AND parts_to_do > 0 AND (now() - create_time) > 600, 1, 0) AS is_stuck,
+        latest_failed_part,
+        latest_fail_time,
+        latest_fail_reason
+      FROM system.mutations
+      ORDER BY is_done ASC, is_stuck DESC, create_time DESC
+    `,
+  columns: [
+    'is_done',
+    'is_stuck',
+    'table',
+    'mutation_id',
+    'command',
+    'create_time',
+    'elapsed',
+    'readable_parts_to_do',
+    'latest_failed_part',
+    'latest_fail_time',
+    'latest_fail_reason',
+  ],
+  columnFormats: {
+    table: 'colored-badge',
+    command: 'code-dialog',
+    is_done: 'boolean',
+    is_stuck: 'boolean',
+    elapsed: 'duration',
+    readable_parts_to_do: 'background-bar',
+  },
+  // Replaces the legacy rowClassName:
+  //   is_stuck truthy           -> red
+  //   !is_done AND elapsed > 300 -> amber
+  // default '' matches the legacy no-match return.
+  rowStyle: {
+    rules: [
+      {
+        when: { column: 'is_stuck', op: 'truthy' },
+        className: 'bg-red-50 dark:bg-red-950/20',
+      },
+      {
+        when: {
+          all: [
+            { column: 'is_done', op: 'falsy' },
+            { column: 'elapsed', op: 'gt', value: 300 },
+          ],
+        },
+        className: 'bg-amber-50 dark:bg-amber-950/20',
+      },
+    ],
+    default: '',
+  },
+  relatedCharts: [
+    [
+      'summary-stuck-mutations',
+      {
+        title: 'Stuck Mutations',
+      },
+    ],
+    [
+      'summary-used-by-mutations',
+      {
+        title: 'Mutations Summary',
+      },
+    ],
+    [
+      'merge-count',
+      {
+        title: 'Merge/Mutations',
+        interval: 'toStartOfDay',
+        lastHours: 336,
+      },
+    ],
+  ],
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/system/part-log.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/system/part-log.ts
@@ -1,0 +1,80 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const partLogDeclarative: DeclarativeQueryConfig = {
+  name: 'part-log',
+  defaultView: 'auto',
+  card: { primary: 'part_name', badges: ['event_type', 'merge_reason'] },
+  description:
+    'Part lifecycle timeline: creation, merges, mutations, downloads, and removals from system.part_log',
+  // Inlined from table-notes PART_LOG (docs is a plain string)
+  docs: `The required table 'part_log' may be missing. Please follow the documentation at https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings#part-log to ensure the necessary table is available.`,
+  refreshInterval: 30_000,
+  // system.part_log is opt-in and may not exist on every server / version
+  optional: true,
+  tableCheck: 'system.part_log',
+  sql: `
+      SELECT
+        event_time,
+        toUnixTimestamp(event_time) AS event_unixtime,
+        event_type,
+        database,
+        table AS table_name,
+        database || '.' || table AS table,
+        part_name,
+        partition_id,
+        merge_reason,
+        part_type,
+        toUInt32OrZero(splitByChar('_', part_name)[-1]) AS part_level,
+        size_in_bytes,
+        formatReadableSize(size_in_bytes) AS readable_size,
+        round(size_in_bytes * 100.0 / nullIf(max(size_in_bytes) OVER (), 0), 2) AS pct_size,
+        rows,
+        formatReadableQuantity(rows) AS readable_rows,
+        round(rows * 100.0 / nullIf(max(rows) OVER (), 0), 2) AS pct_rows,
+        read_rows,
+        duration_ms,
+        formatReadableTimeDelta(duration_ms / 1000) AS readable_duration,
+        round(duration_ms * 100.0 / nullIf(max(duration_ms) OVER (), 0), 2) AS pct_duration,
+        peak_memory_usage,
+        formatReadableSize(peak_memory_usage) AS readable_peak_memory,
+        error,
+        exception
+      FROM system.part_log
+      ORDER BY event_time DESC
+      LIMIT 1000
+    `,
+  columns: [
+    'event_time',
+    'event_type',
+    'table',
+    'part_name',
+    'partition_id',
+    'merge_reason',
+    'readable_size',
+    'readable_rows',
+    'readable_duration',
+    'readable_peak_memory',
+    'error',
+    'exception',
+  ],
+  columnFormats: {
+    event_type: 'colored-badge',
+    table: 'colored-badge',
+    merge_reason: 'colored-badge',
+    readable_size: 'background-bar',
+    readable_rows: 'background-bar',
+    readable_duration: 'background-bar',
+    exception: 'code-dialog',
+  },
+  // Replaces the legacy rowClassName: highlight rows with a non-zero error.
+  // default '' matches the legacy no-match return.
+  rowStyle: {
+    rules: [
+      {
+        when: { column: 'error', op: 'truthy' },
+        className: 'bg-red-50 dark:bg-red-950/20',
+      },
+    ],
+    default: '',
+  },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/system/system-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/system/system-catalog.test.ts
@@ -12,12 +12,10 @@
  *   permission    — FeaturePermission
  *   filterSchema  — contains Icon refs and dynamic option fns
  *
- * kafka-consumers migrates its rowClassName via the declarative `rowStyle`
- * rules; rowClassName is excluded from the deep-equal (it's a function) but is
- * verified separately by applying both functions to boundary rows.
- *
- * Skipped configs (runtime-only fields that the schema cannot express):
- *   partLogConfig           — rowClassName (truthy on error) — see follow-up
+ * kafka-consumers and part-log migrate their rowClassName via the declarative
+ * `rowStyle` rules; rowClassName is excluded from the deep-equal (it's a
+ * function) but is verified separately by applying both functions to boundary
+ * rows.
  */
 
 import { loadDeclarativeConfig } from '../../loader'
@@ -38,6 +36,7 @@ import {
   diskSpaceDeclarative,
 } from './disks'
 import { kafkaConsumersDeclarative } from './kafka-consumers'
+import { partLogDeclarative } from './part-log'
 import { queryMetricLogDeclarative } from './query-metric-log'
 import {
   clustersReplicasStatusDeclarative,
@@ -62,6 +61,7 @@ import {
   diskSpaceConfig,
 } from '@/lib/query-config/system/disks'
 import { kafkaConsumersConfig } from '@/lib/query-config/system/kafka-consumers'
+import { partLogConfig } from '@/lib/query-config/system/part-log'
 import { queryMetricLogConfig } from '@/lib/query-config/system/query-metric-log'
 import {
   clustersReplicasStatusConfig,
@@ -327,6 +327,42 @@ describe('kafka-consumers declarative', () => {
       { last_exception: undefined },
       {}, // missing key
       { last_exception: 0 }, // numeric falsy → String(0 || '') === ''
+    ]
+    for (const row of rows) {
+      expect(compiled(row)).toBe(legacy(row))
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// part-log — rowClassName (truthy on error) migrated to declarative rowStyle.
+// ---------------------------------------------------------------------------
+
+describe('part-log declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(partLogDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(partLogDeclarative)
+    compareSerializable(loaded, partLogConfig)
+  })
+
+  test('compiled rowClassName matches legacy across boundary rows', () => {
+    const loaded = loadDeclarativeConfig(partLogDeclarative)
+    const compiled = loaded.rowClassName
+    const legacy = partLogConfig.rowClassName
+    expect(typeof compiled).toBe('function')
+    expect(typeof legacy).toBe('function')
+    if (!compiled || !legacy) return
+
+    const rows: Record<string, unknown>[] = [
+      { error: 0 },
+      { error: 1 },
+      { error: 241 }, // non-zero error code
+      { error: null },
+      { error: undefined },
+      {}, // missing key
     ]
     for (const row of rows) {
       expect(compiled(row)).toBe(legacy(row))


### PR DESCRIPTION
## What
Follow-up to the `rowStyle` construct (#1719) — migrates the two remaining `rowClassName`-blocked configs using the same mechanism:

- **`system/part-log`** — `rowStyle: truthy(error) → red`. `docs` inlined (PART_LOG; `docs` became a plain string in #1718).
- **`merges/mutations`** — compound `rowStyle`: `truthy(is_stuck) → red`; `all([falsy(is_done), gt(elapsed, 300)]) → amber`. The SQL's `${STUCK_THRESHOLD_SECONDS}` template var is inlined to its constant `600`.

## Why
These were the last two configs whose *only* blocker was `rowClassName`. With `rowStyle` shipped, they migrate mechanically. **This completes the `rowClassName` migrations** — every config blocked solely by row styling is now declarative.

## Verification (behavioural)
Both compiled `rowClassName` functions are checked against the legacy ones across a **boundary truth table** (functions can't be deep-equaled):
- part-log: error 0 / 1 / 241 / null / undefined / missing
- mutations: full `is_stuck` × `is_done` × `elapsed` table, including the priority (red wins over amber), the strict-`gt` boundary at `elapsed=300`, and the no-match default.

Serializable fields are snapshot-tested against the legacy configs.

## Backward compatibility
**Dormant behind `CHM_CONFIG_SOURCE=ts` (default)** → prod rendering byte-identical.

## How verified
- `bun test src/lib/query-config/declarative …` → **341 pass / 0 fail**
- `bun run check` (biome) → clean
- `vite build && tsc --noEmit` → exit 0 · `bun run type-check:test` → exit 0

## Remaining (genuinely runtime — out of scope)
Configs still skipped need `expandable` (JSX), `columnIcons` (React refs), `filterSchema` (Icon refs), or `permission` (FeaturePermission) — none expressible as plain data.

## Guardrails
- [x] Scope respected (Plan 02 query-config only)
- [x] build green · check green · tests green
- [x] No UI render change (dormant behind flag) → VISUAL-VERIFICATION n/a
- [x] Backward compatible (default `ts` unchanged)
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: `cowork/plans/02-externalize-query-configs.md`