### PR TITLE
feat(query-config): declarative permission field + migrate query-detail/mergetree-settings/metrics

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/index.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/index.ts
@@ -57,6 +57,8 @@ import { asynchronousMetricsDeclarative } from './more/asynchronous-metrics'
 import { backupsDeclarative } from './more/backups'
 import { dictionariesDeclarative } from './more/dictionaries'
 import { errorsDeclarative } from './more/errors'
+import { mergeTreeSettingsDeclarative } from './more/mergetree-settings'
+import { metricsDeclarative } from './more/metrics'
 import { rolesDeclarative } from './more/roles'
 import { topUsageColumnsDeclarative } from './more/top-usage-columns'
 import { topUsageTablesDeclarative } from './more/top-usage-tables'
@@ -66,6 +68,7 @@ import { commonErrorsDeclarative } from './queries/common-errors'
 import { parallelizationDeclarative } from './queries/parallelization'
 import { profilerDeclarative } from './queries/profiler'
 import { queryCacheDeclarative } from './queries/query-cache'
+import { queryDetailDeclarative } from './queries/query-detail'
 import { queryViewsLogDeclarative } from './queries/query-views-log'
 import { threadAnalysisDeclarative } from './queries/thread-analysis'
 // Security
@@ -161,6 +164,8 @@ const ALL_DECLARATIVE: DeclarativeQueryConfig[] = [
   backupsDeclarative,
   dictionariesDeclarative,
   errorsDeclarative,
+  mergeTreeSettingsDeclarative,
+  metricsDeclarative,
   rolesDeclarative,
   topUsageColumnsDeclarative,
   topUsageTablesDeclarative,
@@ -171,6 +176,7 @@ const ALL_DECLARATIVE: DeclarativeQueryConfig[] = [
   parallelizationDeclarative,
   profilerDeclarative,
   queryCacheDeclarative,
+  queryDetailDeclarative,
   queryViewsLogDeclarative,
   threadAnalysisDeclarative,
 

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/more/mergetree-settings.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/more/mergetree-settings.ts
@@ -1,0 +1,33 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const mergeTreeSettingsDeclarative: DeclarativeQueryConfig = {
+  name: 'mergetree-settings',
+  optional: false,
+  defaultView: 'auto',
+  card: { primary: 'name', badges: ['changed', 'type'] },
+  permission: { feature: 'settings' },
+  tableCheck: 'system.merge_tree_settings',
+  sql: `
+      SELECT name, value, changed, description, readonly, min, max, type, is_obsolete
+      FROM system.merge_tree_settings
+      ORDER BY name
+    `,
+  columns: [
+    'name',
+    'value',
+    'changed',
+    'description',
+    'readonly',
+    'min',
+    'max',
+    'type',
+    'is_obsolete',
+  ],
+  columnFormats: {
+    changed: 'boolean',
+    readonly: 'boolean',
+    is_obsolete: 'boolean',
+    value: 'code',
+    type: 'colored-badge',
+  },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/more/metrics.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/more/metrics.ts
@@ -1,0 +1,22 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+export const metricsDeclarative: DeclarativeQueryConfig = {
+  name: 'metrics',
+  optional: false,
+  defaultView: 'auto',
+  card: { primary: 'metric' },
+  permission: { feature: 'metrics' },
+  description:
+    'Contains metrics which can be calculated instantly, or have a current value',
+  tableCheck: 'system.metrics',
+  sql: `
+      SELECT *
+      FROM system.metrics
+      ORDER BY metric
+    `,
+  columns: ['metric', 'value', 'description'],
+  columnFormats: {
+    metric: 'code',
+    value: 'code',
+  },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/more/more-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/more/more-catalog.test.ts
@@ -8,20 +8,15 @@
  *   rowClassName  — function (row) => string | undefined
  *   expandable    — function-based ExpandableConfig
  *   columnIcons   — React component refs
- *   permission    — FeaturePermission
  *   filterSchema  — contains Icon refs and dynamic option fns
  *
- * docs is now a plain string in the schema, so the descriptive table-missing
- * help text (BACKUP_LOG, QUERY_LOG, ZOOKEEPER) is inlined into the declarative
- * objects and IS compared here (verifies the inlined text matches the legacy
- * table-notes constants).
+ * docs (table-missing help text) and permission (FeaturePermission as plain
+ * data) are now serializable and ARE compared here.
  *
  * Skipped configs (runtime-only fields that the schema cannot express):
- *   mergetree-settings — permission field
- *   metrics            — permission field
- *   page-views         — tableCheck + SQL reference runtime EVENTS_TABLE env var
- *   settings           — expandable + permission fields
- *   users              — expandable field
+ *   page-views — tableCheck + SQL reference runtime EVENTS_TABLE env var
+ *   settings   — expandable field (also has permission, but expandable blocks it)
+ *   users      — expandable field
  */
 
 import { loadDeclarativeConfig } from '../../loader'
@@ -30,6 +25,8 @@ import { asynchronousMetricsDeclarative } from './asynchronous-metrics'
 import { backupsDeclarative } from './backups'
 import { dictionariesDeclarative } from './dictionaries'
 import { errorsDeclarative } from './errors'
+import { mergeTreeSettingsDeclarative } from './mergetree-settings'
+import { metricsDeclarative } from './metrics'
 import { rolesDeclarative } from './roles'
 import { topUsageColumnsDeclarative } from './top-usage-columns'
 import { topUsageTablesDeclarative } from './top-usage-tables'
@@ -40,6 +37,8 @@ import { asynchronousMetricsConfig } from '@/lib/query-config/more/asynchronous-
 import { backupsConfig } from '@/lib/query-config/more/backups'
 import { dictionariesConfig } from '@/lib/query-config/more/dictionaries'
 import { errorsConfig } from '@/lib/query-config/more/errors'
+import { mergeTreeSettingsConfig } from '@/lib/query-config/more/mergetree-settings'
+import { metricsConfig } from '@/lib/query-config/more/metrics'
 import { rolesConfig } from '@/lib/query-config/more/roles'
 import { topUsageColumnsConfig } from '@/lib/query-config/more/top-usage-columns'
 import { topUsageTablesConfig } from '@/lib/query-config/more/top-usage-tables'
@@ -54,7 +53,6 @@ const RUNTIME_ONLY_KEYS = new Set([
   'rowClassName',
   'expandable',
   'columnIcons',
-  'permission',
   'filterSchema',
   'columnFilters',
   'clickhouseSettings',
@@ -213,5 +211,47 @@ describe('zookeeper declarative', () => {
   test('serializable fields match legacy', () => {
     const loaded = loadDeclarativeConfig(zookeeperDeclarative)
     compareSerializable(loaded, zookeeperConfig)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// mergetree-settings — permission migrated to declarative `permission`
+// ---------------------------------------------------------------------------
+
+describe('mergetree-settings declarative', () => {
+  test('loads without error', () => {
+    expect(() =>
+      loadDeclarativeConfig(mergeTreeSettingsDeclarative)
+    ).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(mergeTreeSettingsDeclarative)
+    compareSerializable(loaded, mergeTreeSettingsConfig)
+  })
+
+  test('permission matches legacy', () => {
+    const loaded = loadDeclarativeConfig(mergeTreeSettingsDeclarative)
+    expect(loaded.permission).toEqual(mergeTreeSettingsConfig.permission)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// metrics — permission migrated to declarative `permission`
+// ---------------------------------------------------------------------------
+
+describe('metrics declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(metricsDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(metricsDeclarative)
+    compareSerializable(loaded, metricsConfig)
+  })
+
+  test('permission matches legacy', () => {
+    const loaded = loadDeclarativeConfig(metricsDeclarative)
+    expect(loaded.permission).toEqual(metricsConfig.permission)
   })
 })

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/queries/queries-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/queries/queries-catalog.test.ts
@@ -8,10 +8,12 @@
  *   rowClassName  — function (row) => string | undefined
  *   expandable    — function-based ExpandableConfig
  *   columnIcons   — React component refs
- *   permission    — FeaturePermission
  *   filterSchema  — contains Icon refs and dynamic option fns
  *   columnFilters — UI sugar over filterSchema
  *   clickhouseSettings — ClickHouseSettings (execution-time; not serializable)
+ *
+ * permission (FeaturePermission as plain data) is now serializable and IS
+ * compared (e.g. query-detail).
  *
  * Skipped configs (runtime-only fields the schema cannot express):
  *   expensive-queries          — rowClassName, expandable (JSX), columnIcons
@@ -20,7 +22,6 @@
  *   slow-queries               — rowClassName, expandable (JSX), columnIcons
  *   history-queries            — rowClassName, expandable, filterSchema (icons + runtime env), clickhouseSettings
  *   running-queries            — rowClassName, expandable (JSX), filterSchema (icons), columnFilters
- *   query-detail               — permission (FeaturePermission)
  */
 
 import { loadDeclarativeConfig } from '../../loader'
@@ -29,6 +30,7 @@ import { commonErrorsDeclarative } from './common-errors'
 import { parallelizationDeclarative } from './parallelization'
 import { profilerDeclarative } from './profiler'
 import { queryCacheDeclarative } from './query-cache'
+import { queryDetailDeclarative } from './query-detail'
 import { queryViewsLogDeclarative } from './query-views-log'
 import { threadAnalysisDeclarative } from './thread-analysis'
 import { describe, expect, test } from 'bun:test'
@@ -37,6 +39,7 @@ import { commonErrorsConfig } from '@/lib/query-config/queries/common-errors'
 import { parallelizationConfig } from '@/lib/query-config/queries/parallelization'
 import { profilerConfig } from '@/lib/query-config/queries/profiler'
 import { queryCacheConfig } from '@/lib/query-config/queries/query-cache'
+import { queryDetailConfig } from '@/lib/query-config/queries/query-detail'
 import { queryViewsLogConfig } from '@/lib/query-config/queries/query-views-log'
 import { threadAnalysisConfig } from '@/lib/query-config/queries/thread-analysis'
 
@@ -49,7 +52,6 @@ const RUNTIME_ONLY_KEYS = new Set([
   'rowClassName',
   'expandable',
   'columnIcons',
-  'permission',
   'filterSchema',
   'columnFilters',
   'clickhouseSettings',
@@ -157,6 +159,31 @@ describe('query-cache declarative', () => {
   test('docs (inlined QUERY_CACHE) matches legacy', () => {
     const loaded = loadDeclarativeConfig(queryCacheDeclarative)
     expect(loaded.docs).toBe(queryCacheConfig.docs)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// query-detail (permission + versioned SQL with inlined baseSelect)
+// ---------------------------------------------------------------------------
+
+describe('query-detail declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(queryDetailDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(queryDetailDeclarative)
+    compareSerializable(loaded, queryDetailConfig)
+  })
+
+  test('permission matches legacy', () => {
+    const loaded = loadDeclarativeConfig(queryDetailDeclarative)
+    expect(loaded.permission).toEqual(queryDetailConfig.permission)
+  })
+
+  test('versioned sql (inlined baseSelect) byte-matches legacy', () => {
+    const loaded = loadDeclarativeConfig(queryDetailDeclarative)
+    expect(loaded.sql).toEqual(queryDetailConfig.sql)
   })
 })
 

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/queries/query-detail.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/queries/query-detail.ts
@@ -1,0 +1,98 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+// baseSelect copied verbatim from the legacy queries/query-detail.ts so the
+// resolved SQL strings are byte-identical (verified by the snapshot test).
+const baseSelect = `
+    query_id,
+    type,
+    event_time,
+    query_duration_ms / 1000 as query_duration,
+    query,
+    formatted_query AS readable_query,
+    exception_code,
+    user,
+    query_kind,
+    read_rows,
+    formatReadableQuantity(read_rows) AS readable_read_rows,
+    round(100 * read_rows / MAX(read_rows) OVER ()) AS pct_read_rows,
+    written_rows,
+    formatReadableQuantity(written_rows) AS readable_written_rows,
+    round(100 * written_rows / MAX(written_rows) OVER ()) AS pct_written_rows,
+    result_rows,
+    formatReadableQuantity(result_rows) AS readable_result_rows,
+    memory_usage,
+    formatReadableSize(memory_usage) AS readable_memory_usage,
+    round(100 * memory_usage / MAX(memory_usage) OVER ()) AS pct_memory_usage`
+
+export const queryDetailDeclarative: DeclarativeQueryConfig = {
+  name: 'query-detail',
+  optional: false,
+  defaultView: 'auto',
+  card: { primary: 'query', badges: ['type', 'query_kind'] },
+  description: 'Detailed information about a specific query execution',
+  // Inlined from table-notes QUERY_LOG (docs is now a plain string)
+  docs: `The required table 'query_log' may be missing. Please follow the documentation at https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings#query-log and https://clickhouse.com/docs/en/operations/system-tables/query_log to ensure the necessary table is available.`,
+  permission: { feature: 'queries' },
+  tableCheck: 'system.query_log',
+  sql: [
+    {
+      since: '20.0',
+      description: 'Legacy: exception_text column, no query_cache_usage',
+      sql: `
+    SELECT
+      ${baseSelect},
+      exception_text
+    FROM system.query_log
+    WHERE query_id = {query_id: String}
+    ORDER BY event_time DESC
+    LIMIT 1
+  `,
+    },
+    {
+      since: '23.8',
+      description:
+        'exception column (renamed from exception_text), with query_cache_usage',
+      sql: `
+    SELECT
+      ${baseSelect},
+      exception AS exception_text,
+      query_cache_usage
+    FROM system.query_log
+    WHERE query_id = {query_id: String}
+    ORDER BY event_time DESC
+    LIMIT 1
+  `,
+    },
+  ],
+  columns: [
+    'query_id',
+    'type',
+    'event_time',
+    'query_duration',
+    'user',
+    'query_kind',
+    'query_cache_usage',
+    'readable_read_rows',
+    'readable_written_rows',
+    'readable_result_rows',
+    'readable_memory_usage',
+    'exception_code',
+    'exception_text',
+    'query',
+  ],
+  columnFormats: {
+    type: 'colored-badge',
+    query_kind: 'colored-badge',
+    query_cache_usage: 'colored-badge',
+    query_duration: 'duration',
+    readable_query: 'code',
+    query: ['code-dialog', { max_truncate: 200, hide_query_comment: true }],
+    event_time: 'related-time',
+    readable_read_rows: 'background-bar',
+    readable_written_rows: 'background-bar',
+    readable_memory_usage: 'background-bar',
+  },
+  defaultParams: {
+    query_id: '',
+  },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/loader.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/loader.ts
@@ -7,13 +7,13 @@
  * RUNTIME-ONLY FIELDS NOT PRESENT ON LOADED CONFIGS:
  *   - columnIcons    — React component refs (Icon type)
  *   - expandable     — function-based ExpandableConfig
- *   - permission     — FeaturePermission (app-level import)
  *   - filterSchema   — FilterSchema (contains Icon refs and dynamic option fns)
  *   - columnFilters  — ColumnFilterDef (UI sugar over filterSchema)
  *   - variants       — deprecated; use versioned sql[] in the declarative format
  *
  * The declarative `rowStyle` field IS carried: it is compiled into a
- * rowClassName function on the loaded config (see compileRowStyle).
+ * rowClassName function on the loaded config (see compileRowStyle). The
+ * `permission` field (plain FeaturePermission data) is also carried through.
  *
  * These fields can be merged in by the caller after loading if needed.
  */
@@ -151,6 +151,12 @@ export function loadDeclarativeConfig(input: unknown): QueryConfig {
   // Row styling — compile declarative rules into a rowClassName function.
   if (d.rowStyle !== undefined) {
     config.rowClassName = compileRowStyle(d.rowStyle)
+  }
+
+  // Feature-permission gate — plain data, structurally identical to
+  // FeaturePermission (schema validates feature/access/operation to its domain).
+  if (d.permission !== undefined) {
+    config.permission = d.permission as QueryConfig['permission']
   }
 
   return config

--- a/apps/dashboard/src/lib/query-config/declarative/schema.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/schema.test.ts
@@ -348,6 +348,47 @@ describe('invalid configs', () => {
     expect(result.ok).toBe(false)
   })
 
+  test('accepts permission with a valid feature id', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: 'SELECT 1',
+      columns: ['col1'],
+      permission: { feature: 'queries' },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.config.permission).toEqual({ feature: 'queries' })
+  })
+
+  test('accepts permission with optional access/operation', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: 'SELECT 1',
+      columns: ['col1'],
+      permission: {
+        feature: 'metrics',
+        defaultAccess: 'authenticated',
+        operation: 'read',
+      },
+    })
+
+    expect(result.ok).toBe(true)
+  })
+
+  test('rejects permission with an unknown feature id', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: 'SELECT 1',
+      columns: ['col1'],
+      permission: { feature: 'not-a-feature' },
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some((e) => e.includes('permission'))).toBe(true)
+  })
+
   test('rejects unknown columnFormat enum value', () => {
     const result = validateDeclarativeConfig({
       name: 'my-query',

--- a/apps/dashboard/src/lib/query-config/declarative/schema.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/schema.ts
@@ -7,11 +7,11 @@
  *
  * The companion loader (Plan 02b) will map a DeclarativeQueryConfig into the
  * in-memory QueryConfig that the dashboard consumes at runtime. Fields that
- * are runtime functions (expandable, columnIcons, filterSchema with Icon refs,
- * FeaturePermission) are intentionally excluded here — they cannot be expressed
- * declaratively and must be wired up by the loader. The one exception is
- * rowClassName: simple data-driven row styling is expressible via the
- * declarative `rowStyle` rules, which the loader compiles into a RowClassNameFn.
+ * are runtime functions (expandable, columnIcons, filterSchema with Icon refs)
+ * are intentionally excluded here — they cannot be expressed declaratively and
+ * must be wired up by the loader. Two exceptions: rowClassName (simple
+ * data-driven row styling via `rowStyle`, compiled into a RowClassNameFn) and
+ * FeaturePermission (plain data, carried via the `permission` field).
  *
  * Serializable fields carried here:
  *   identity:       name, description, docs, suggestion
@@ -26,6 +26,7 @@
  *   card, defaultView, bulkActions, bulkActionKey
  *   sortingFns
  *   rowStyle:       ordered condition→className rules (compiles to rowClassName)
+ *   permission:     FeaturePermission gate { feature, defaultAccess?, operation? }
  */
 
 import { z } from 'zod'
@@ -235,6 +236,42 @@ const rowStyleSchema = z.object({
 })
 
 // ---------------------------------------------------------------------------
+// permission — FeaturePermission as plain data (feature + access/operation).
+//
+// The values mirror FEATURE_IDS / FEATURE_ACCESS_VALUES / FEATURE_OPERATIONS in
+// lib/feature-permissions/types.ts. They are hardcoded here (not imported) to
+// keep the declarative schema decoupled from app code — keep this list in sync
+// if a new feature id is added. The loader casts back to FeaturePermission.
+// ---------------------------------------------------------------------------
+
+const featureIdSchema = z.enum([
+  'overview',
+  'agent',
+  'insights',
+  'health',
+  'queries',
+  'tables',
+  'metrics',
+  'dashboard',
+  'security',
+  'logs',
+  'settings',
+  'cluster',
+  'operations',
+  'actions',
+  'mcp',
+  'peerdb',
+  'docs',
+  'about',
+])
+
+const permissionSchema = z.object({
+  feature: featureIdSchema,
+  defaultAccess: z.enum(['public', 'authenticated']).optional(),
+  operation: z.enum(['read', 'write']).optional(),
+})
+
+// ---------------------------------------------------------------------------
 // Main declarative schema
 // ---------------------------------------------------------------------------
 
@@ -304,11 +341,13 @@ export const declarativeQueryConfigSchema = z.object({
   // Row styling — declarative replacement for rowClassName (loader compiles it)
   rowStyle: rowStyleSchema.optional(),
 
+  // Feature-permission gate (plain data; loader casts to FeaturePermission)
+  permission: permissionSchema.optional(),
+
   // Intentionally excluded (not serializable — require runtime code):
   //   columnIcons     — React component refs
   //   rowClassName    — function (row) => string (use declarative rowStyle)
   //   expandable      — function (row, ctx) => ReactNode
-  //   permission      — FeaturePermission (app-level import)
   //   variants        — deprecated; use versioned sql[] instead
 })
 

--- a/apps/dashboard/src/lib/query-config/getQueryConfigByName.test.ts
+++ b/apps/dashboard/src/lib/query-config/getQueryConfigByName.test.ts
@@ -19,9 +19,9 @@ const TS_ENV = {} as const
 
 // Serializable fields — the intersection of DeclarativeQueryConfig and
 // QueryConfig that the loader carries through. Runtime-only fields
-// (columnIcons, rowClassName, expandable, permission, filterSchema,
-// columnFilters, variants) are deliberately absent from the declarative
-// schema and must not be compared here.
+// (columnIcons, rowClassName, expandable, filterSchema, columnFilters,
+// variants) are deliberately absent from the declarative schema and must not
+// be compared here. (permission is carried as plain data and IS compared.)
 const SERIALIZABLE_KEYS = [
   'name',
   'sql',
@@ -46,6 +46,7 @@ const SERIALIZABLE_KEYS = [
   'bulkActionKey',
   'sortingFns',
   'clickhouseSettings',
+  'permission',
 ] as const
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Schema-ext slice of **Plan 02**. Adds a declarative **`permission`** field carrying `FeaturePermission` as plain data: `{ feature, defaultAccess?, operation? }`. The enum values mirror `lib/feature-permissions/types.ts` (`FEATURE_IDS` / access / operation) but are hardcoded in the schema to keep the declarative layer **decoupled** from app code — the same pattern as `columnFormats`/`clickhouseSettings`. The loader carries it straight through.

## Why
`FeaturePermission` was previously excluded as "not serializable" — but that conflated *coupling* (don't import app code into the schema) with *serializability* (the value is just `{ feature: 'queries' }`). Mirroring the enum values resolves both.

Migrates the 3 configs whose **only** remaining blocker was `permission`:
- `more/mergetree-settings` — `{ feature: 'settings' }`
- `more/metrics` — `{ feature: 'metrics' }`
- `queries/query-detail` — `{ feature: 'queries' }`; `docs` inlined (QUERY_LOG, now a plain string); versioned SQL with the `baseSelect` const inlined **verbatim** and byte-matched against the legacy resolved SQL by the snapshot test.

This is also a **fidelity** carry-through: when 02L flips the default, these views keep their feature-gating (a dropped `permission` would have silently un-gated them).

## Scope
- `declarative/schema.ts` (+ test): `permission` schema (feature enum + optional access/operation)
- `declarative/loader.ts`: carry `permission` through
- `catalog/more/{mergetree-settings,metrics}.ts`, `catalog/queries/query-detail.ts` + registry
- `more`/`queries` catalog tests + `getQueryConfigByName.test.ts`: `permission` removed from skip-sets, now compared

## Backward compatibility
**Dormant behind `CHM_CONFIG_SOURCE=ts` (default)** → prod rendering byte-identical.

## How verified
- `bun test src/lib/query-config/declarative …` → **357 pass / 0 fail**
- `bun run check` (biome) → clean
- `vite build && tsc --noEmit` → exit 0 · `bun run type-check:test` → exit 0

## Remaining (genuinely runtime)
`settings` (expandable JSX panel + permission), plus the `expandable`/`columnIcons`/`filterSchema` query configs — none expressible as plain data.

## Guardrails
- [x] Scope respected (Plan 02 query-config only)
- [x] build green · check green · tests green
- [x] No UI render change (dormant behind flag) → VISUAL-VERIFICATION n/a
- [x] Backward compatible (default `ts` unchanged)
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: `cowork/plans/02-externalize-query-configs.md`