### PR TITLE
docs(knowledge): add declarative config catalog spec

### DIFF
--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -38,6 +38,7 @@ Agents discover knowledge in this order:
 | **Specs** | [agent-conversation-storage.md](agent-conversation-storage.md) | spec | Runtime-selected agent chat persistence backends and fallback rules |
 | **Specs** | [agentstate-conversation-store.md](agentstate-conversation-store.md) | spec | AgentState backend: resolveStore priority, external_id/tag isolation, append-only upsert, AI enrichment, backend/follow-ups routes |
 | **Specs** | [query-config-format.md](query-config-format.md) | spec | QueryConfig type format, versioned SQL, BackgroundBar columns |
+| **Specs** | [declarative-config-catalog.md](declarative-config-catalog.md) | spec | Serializable query-config catalog: CHM_CONFIG_SOURCE flag, schema→loader→catalog pipeline, rowStyle/permission/clickhouseSettings, what stays TS-only (expandable) and why |
 | **Specs** | [og-images.md](og-images.md) | spec | OG/social images: Satori+resvg generator, vendored fonts, auto-regenerated on Cloudflare deploy, meta wiring |
 | **Specs** | [cluster-topology.md](cluster-topology.md) | spec | Cluster topology SVG: layout pipeline, constant contracts, OKLCH gotcha, shared component, verification harness |
 | **Specs** | [table-availability.md](table-availability.md) | spec | Sidebar muting (table availability), permission GRANT + version-mismatch errors, `toEmptyStateVariant` gotcha |

--- a/docs/knowledge/declarative-config-catalog.md
+++ b/docs/knowledge/declarative-config-catalog.md
@@ -1,0 +1,143 @@
+---
+id: declarative-config-catalog
+title: Declarative Config Catalog
+type: spec
+status: active
+updated: 2026-06-18
+tags:
+  - query-config
+  - declarative
+  - catalog
+  - platform
+related:
+  - query-config-format
+  - static-site-architecture
+  - table-availability
+---
+
+# Declarative Config Catalog
+
+The **declarative config catalog** is the serializable subset of `QueryConfig`
+expressed as plain data — objects that contain no JSX, no functions, and no
+component imports. It is the foundation for letting the community contribute
+monitoring checks without writing TypeScript, and it lives alongside the legacy
+TS query configs behind a flag.
+
+> This documents the *subsystem and contract*. For the per-field authoring
+> reference (the contributor-facing guide), see
+> `docs/content/reference/catalog-contributing.mdx`. For the in-memory
+> `QueryConfig` type itself, see [[query-config-format]].
+
+## Where it lives
+
+```
+apps/dashboard/src/lib/query-config/declarative/
+├── schema.ts        # Zod schema — the catalog contract (DeclarativeQueryConfig)
+├── validate.ts      # validateDeclarativeConfig() — safe parse → {ok, config|errors}
+├── loader.ts        # loadDeclarativeConfig() → in-memory QueryConfig; getConfigSource()
+├── row-style.ts     # compileRowStyle() — compiles rowStyle rules → RowClassNameFn
+└── catalog/
+    ├── index.ts     # DECLARATIVE_CATALOG: Record<name, DeclarativeQueryConfig>
+    └── <domain>/*.ts # one file per migrated config, grouped by domain
+```
+
+## The flag (opt-in)
+
+Resolution is gated by `CHM_CONFIG_SOURCE` (server runtime env, falling back to
+the build-time `VITE_CONFIG_SOURCE`). Anything other than the literal string
+`declarative` resolves to `ts` — **the default is `ts`**, i.e. the catalog is
+inert until explicitly turned on. `getQueryConfigByName(name, env)` in
+`lib/query-config/index.ts` is the central resolver: when the source is
+`declarative` it serves `DECLARATIVE_CATALOG[name]` (falling back to the TS
+config when a name is absent from the catalog); when `ts` it returns the TS
+config unchanged (by reference). The full default-flip to `declarative` is
+**deferred** (plan 02L) — it changes prod rendering for ~75 views and needs
+route-level visual verification against a live ClickHouse, which is not yet
+available.
+
+## Pipeline
+
+```
+DeclarativeQueryConfig (data)
+  → validateDeclarativeConfig (Zod)   # throws/returns errors on bad input
+  → loadDeclarativeConfig             # maps serializable fields 1:1 to QueryConfig
+  → QueryConfig (in-memory)           # consumed by the data-table + charts
+```
+
+The mapping is 1:1 by design — field names and value shapes are shared. Two
+fields are *derived* rather than copied: `rowStyle` is compiled into a
+`rowClassName` function, and `permission` is carried through as plain data.
+
+## What the schema can express
+
+The serializable contract (`declarativeQueryConfigSchema`) carries: `name`,
+`sql` (string or `VersionedSql[]` with `since`), `columns`, `columnFormats`,
+`columnDescriptions`, `columnSizing`, `tableBehavior`, `defaultParams`,
+`filterParamPresets` (icon omitted), `optional`, `tableCheck`,
+`disableSqlValidation`, `refreshInterval`, `relatedCharts`, `card`,
+`defaultView`, `bulkActions`/`bulkActionKey`, `description`, `suggestion`,
+`docs`, plus these incrementally-added fields:
+
+| Field | Added for | Notes |
+|---|---|---|
+| `sortingFns` | sort by underlying value | enum incl. `sort_column_using_actual_value` |
+| `clickhouseSettings` | per-query execution settings | `Record<string, string\|number\|boolean>` |
+| `docs` | table-missing help text | loosened from `.url()` to plain `string` |
+| `rowStyle` | conditional row classes | ordered `{ when, className }` rules → compiled to `rowClassName` |
+| `permission` | feature gating | plain `{ feature, defaultAccess?, operation? }` (enum mirrored from `lib/feature-permissions/types.ts`, not imported) |
+
+### rowStyle (the rowClassName replacement)
+
+`rowStyle.rules` is an ordered list; the first matching rule's `className`
+wins, else `default`. Condition operators — `gt`/`gte`/`lt`/`lte` (numeric),
+`truthy`/`falsy` (numeric truthiness), `empty`/`nonempty` (string), and
+`all`/`any` combinators — and their coercion (`Number(v || 0)` /
+`String(v || '')`) mirror the legacy `rowClassName` idioms **exactly**, so a
+compiled function is behaviourally identical to the TS function it replaced.
+
+## What stays TS-only (and why)
+
+These fields are intentionally **excluded** from the schema because they require
+runtime code, not data:
+
+- **`expandable`** — renders a per-row detail panel. The specs are actually
+  factory-driven (`createConfigExpandedDetails({ primaryColumns })` and
+  `createExpandedPanel({ sections })`), so the *spec* is serializable — but
+  wiring it would require the config-resolution loader to import React component
+  factories, coupling config resolution to rendering. That is an open
+  architecture decision, not a mechanical migration. This blocks the remaining
+  query configs (`expensive`/`slow`/`failed`/`history`/`running`) and
+  `settings`/`users`.
+- **`columnIcons`** — React component refs. (Migrating it alone unblocks no
+  config, since every config that uses it also uses `expandable`.)
+- **`filterSchema`** — contains `Icon` refs and dynamic option functions.
+- Runtime-templated SQL — e.g. `more/page-views` interpolates the runtime
+  `EVENTS_TABLE` env var into its SQL, which cannot be inlined as data.
+
+## Testing
+
+Each domain has a `<domain>-catalog.test.ts` snapshot suite that runs
+`loadDeclarativeConfig(decl)` and **deep-equals** the result against the legacy
+TS config on every serializable field (runtime-only fields are excluded from the
+comparison). `getQueryConfigByName.test.ts` additionally asserts declarative↔TS
+parity across the whole catalog. Two verification shapes:
+
+- **Data fields** (most) → deep-equal snapshot. Inlined values (e.g. `docs`
+  strings copied from `lib/table-notes`, or `query-detail`'s `baseSelect` SQL)
+  are byte-matched against the legacy source.
+- **`rowStyle`** → compiles to a function, which can't be deep-equaled, so it is
+  verified **behaviourally**: both the compiled and legacy `rowClassName` are
+  applied to rows covering every condition boundary and asserted identical.
+  `row-style.test.ts` separately pins each operator's semantics.
+
+`DECLARATIVE_CATALOG` (catalog/index.ts) also asserts unique `name`s at module
+load and throws on a duplicate.
+
+## Status
+
+Foundation + opt-in wiring complete; ~75 configs migrated across all 10 domains,
+all dormant behind `CHM_CONFIG_SOURCE=ts`. The catalog is bundled (imported by
+the registry) but tree-shaken from rendering paths until the flag flips. Adding
+a check is a single-file PR — see the contributor guide. There are no external
+catalog consumers yet, so the `rowStyle` and `permission` contracts remain
+freely revisable until the 02L default-flip.


### PR DESCRIPTION
## What
Adds `docs/knowledge/declarative-config-catalog.md` — a developer/agent-facing knowledge-graph spec for the declarative config catalog subsystem — and indexes it in `docs/knowledge/README.md`.

## Why
The declarative catalog is now a substantial subsystem (Plan 02, the "platform thesis"): ~75 migrated configs, a Zod schema with the recent schema-ext additions (`sortingFns`/`clickhouseSettings`/`docs`/`rowStyle`/`permission`), a loader, the `DECLARATIVE_CATALOG` registry, and the `CHM_CONFIG_SOURCE` flag. The knowledge graph had **no doc** for it — only `query-config-format.md`, which covers the in-memory `QueryConfig` *type*. `CLAUDE.md` directs architecture decisions to `docs/knowledge/`.

## Contents
- Where it lives + the opt-in `CHM_CONFIG_SOURCE` flag and central resolver
- The `schema → validate → loader → catalog` pipeline (and which fields are derived vs copied)
- The serializable field set, incl. the incrementally-added fields and `rowStyle` operator/coercion semantics
- **What stays TS-only and why** — `expandable` (the loader↔React-factory coupling decision), `columnIcons`, `filterSchema`, runtime-templated SQL (`page-views`)
- The two verification shapes (deep-equal snapshots for data; behavioural for `rowStyle`)
- Current status (foundation + opt-in complete; 02L flip deferred pending live CH)

## Scope
Docs-knowledge only — markdown under `docs/knowledge/`, which is **not consumed by any build** (the docs *site* reads `docs/content/`). Fully bundle-neutral; no UI/code change. Cross-links use the repo's `[[wikilink]]` convention; `related:` targets all exist.

## How verified
Markdown validity + link/anchor correctness; biome check clean on both files. No build consumes these files.

## Guardrails
- [x] Scope respected (docs/knowledge only)
- [x] No code/UI change → VISUAL-VERIFICATION n/a; bundle-neutral
- [x] Backward compatible
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: `cowork/plans/02-externalize-query-configs.md` (developer documentation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specifications for the declarative config catalog, detailing supported configuration fields, schema mapping, and the configuration loading pipeline.
  * Updated documentation index to reference the new declarative config catalog specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->