### PR TITLE
feat(ch-capabilities): capability-diff report formatter (Plan 10c offline)

### DIFF
--- a/apps/dashboard/src/lib/ch-capabilities/capabilities-report.test.ts
+++ b/apps/dashboard/src/lib/ch-capabilities/capabilities-report.test.ts
@@ -1,0 +1,167 @@
+import type { CapabilityDiff } from './capabilities'
+
+import { diffCapabilities, normalizeCapabilities } from './capabilities'
+import {
+  formatCapabilityDiff,
+  hasCapabilityChanges,
+  summarizeCapabilityDiff,
+} from './capabilities-report'
+import { describe, expect, it } from 'bun:test'
+
+// A diff with no structural changes and no version change.
+const EMPTY_DIFF: CapabilityDiff = {
+  addedTables: [],
+  removedTables: [],
+  addedColumns: {},
+  removedColumns: {},
+  versionChanged: false,
+}
+
+// Build a realistic diff via the real harness: baseline (24.3) → next (24.8)
+// adds a table + a column and removes a table + a column.
+function realisticDiff(): CapabilityDiff {
+  const baseline = normalizeCapabilities({
+    version: '24.3.1.1',
+    tables: [
+      { database: 'system', name: 'query_log' },
+      { database: 'system', name: 'old_table' },
+    ],
+    columns: [
+      { database: 'system', table: 'query_log', name: 'event_time' },
+      { database: 'system', table: 'query_log', name: 'legacy_col' },
+    ],
+  })
+  const next = normalizeCapabilities({
+    version: '24.8.1.1',
+    tables: [
+      { database: 'system', name: 'query_log' },
+      { database: 'system', name: 'new_table' },
+    ],
+    columns: [
+      { database: 'system', table: 'query_log', name: 'event_time' },
+      { database: 'system', table: 'query_log', name: 'shiny_col' },
+    ],
+  })
+  return diffCapabilities(baseline, next)
+}
+
+// ---------------------------------------------------------------------------
+// hasCapabilityChanges
+// ---------------------------------------------------------------------------
+
+describe('hasCapabilityChanges', () => {
+  it('is false for an empty diff', () => {
+    expect(hasCapabilityChanges(EMPTY_DIFF)).toBe(false)
+  })
+
+  it('is false when only the version changed (no structural change)', () => {
+    expect(hasCapabilityChanges({ ...EMPTY_DIFF, versionChanged: true })).toBe(
+      false
+    )
+  })
+
+  it('is true when a table is added', () => {
+    expect(
+      hasCapabilityChanges({ ...EMPTY_DIFF, addedTables: ['system.x'] })
+    ).toBe(true)
+  })
+
+  it('is true when a column is removed', () => {
+    expect(
+      hasCapabilityChanges({
+        ...EMPTY_DIFF,
+        removedColumns: { 'system.query_log': ['legacy_col'] },
+      })
+    ).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// summarizeCapabilityDiff
+// ---------------------------------------------------------------------------
+
+describe('summarizeCapabilityDiff', () => {
+  it('reports no changes for an empty diff', () => {
+    expect(summarizeCapabilityDiff(EMPTY_DIFF)).toBe('no capability changes')
+  })
+
+  it('notes a version change even with no structural changes', () => {
+    expect(
+      summarizeCapabilityDiff({ ...EMPTY_DIFF, versionChanged: true })
+    ).toBe('no capability changes (version changed)')
+  })
+
+  it('uses singular/plural correctly and orders parts tables→columns', () => {
+    const diff: CapabilityDiff = {
+      addedTables: ['system.a', 'system.b'],
+      removedTables: ['system.c'],
+      addedColumns: { 'system.query_log': ['x', 'y'] },
+      removedColumns: { 'system.query_log': ['z'] },
+      versionChanged: true,
+    }
+    expect(summarizeCapabilityDiff(diff)).toBe(
+      '+2 tables, -1 table, +2 columns, -1 column (version changed)'
+    )
+  })
+
+  it('summarizes a realistic harness-produced diff', () => {
+    expect(summarizeCapabilityDiff(realisticDiff())).toBe(
+      '+1 table, -1 table, +1 column, -1 column (version changed)'
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatCapabilityDiff
+// ---------------------------------------------------------------------------
+
+describe('formatCapabilityDiff', () => {
+  it('renders a no-changes report with a plain heading', () => {
+    const out = formatCapabilityDiff(EMPTY_DIFF)
+    expect(out).toContain('# Capability diff')
+    expect(out).toContain('_no capability changes_')
+    expect(out).toContain('No structural changes detected.')
+    // No section headers when nothing changed.
+    expect(out).not.toContain('## Tables added')
+  })
+
+  it('uses a baseline→next heading and version line when labels are given', () => {
+    const out = formatCapabilityDiff(realisticDiff(), {
+      baselineLabel: '24.3',
+      nextLabel: '24.8',
+    })
+    expect(out).toContain('# Capability diff: 24.3 → 24.8')
+    expect(out).toContain('Version changed: `24.3` → `24.8`.')
+  })
+
+  it('renders every section with backticked, sorted entries', () => {
+    const out = formatCapabilityDiff(realisticDiff(), {
+      baselineLabel: '24.3',
+      nextLabel: '24.8',
+    })
+    expect(out).toContain('## Tables added\n- `system.new_table`')
+    expect(out).toContain('## Tables removed\n- `system.old_table`')
+    expect(out).toContain('## Columns added\n- `system.query_log`: `shiny_col`')
+    expect(out).toContain(
+      '## Columns removed\n- `system.query_log`: `legacy_col`'
+    )
+  })
+
+  it('is deterministic regardless of object key insertion order', () => {
+    const a: CapabilityDiff = {
+      addedTables: [],
+      removedTables: [],
+      addedColumns: { 'system.b': ['c2'], 'system.a': ['c1'] },
+      removedColumns: {},
+      versionChanged: false,
+    }
+    const b: CapabilityDiff = {
+      addedTables: [],
+      removedTables: [],
+      addedColumns: { 'system.a': ['c1'], 'system.b': ['c2'] },
+      removedColumns: {},
+      versionChanged: false,
+    }
+    expect(formatCapabilityDiff(a)).toBe(formatCapabilityDiff(b))
+  })
+})

--- a/apps/dashboard/src/lib/ch-capabilities/capabilities-report.ts
+++ b/apps/dashboard/src/lib/ch-capabilities/capabilities-report.ts
@@ -1,0 +1,172 @@
+/**
+ * ClickHouse Capability Diff — human-readable reporting
+ *
+ * Turns the structured `CapabilityDiff` produced by `diffCapabilities()` into
+ * deterministic, human-readable output: a one-line summary, a boolean
+ * "anything changed?" predicate, and a full Markdown report.
+ *
+ * Seeds Plan 10:
+ *   10a — capabilities.ts (pure diff harness)
+ *   10c — this file (offline diff reporting; consumed by the 10b CI matrix and
+ *         by anyone comparing two discovered snapshots)
+ *
+ * Pure + tested. No live ClickHouse, no I/O — input is two already-computed
+ * snapshots' diff, output is a string.
+ */
+
+import type { CapabilityDiff } from './capabilities'
+
+// ---------------------------------------------------------------------------
+// Predicates
+// ---------------------------------------------------------------------------
+
+/**
+ * True when the diff contains any structural change — a table or column added
+ * or removed. A version string change alone does NOT count as a structural
+ * change (use `diff.versionChanged` directly for that), since a version bump
+ * with an identical capability surface is "no drift" for compatibility
+ * purposes.
+ */
+export function hasCapabilityChanges(diff: CapabilityDiff): boolean {
+  return (
+    diff.addedTables.length > 0 ||
+    diff.removedTables.length > 0 ||
+    Object.keys(diff.addedColumns).length > 0 ||
+    Object.keys(diff.removedColumns).length > 0
+  )
+}
+
+/** Sum of every column listed across all tables in a per-table column map. */
+function countColumns(map: Record<string, string[]>): number {
+  let total = 0
+  for (const cols of Object.values(map)) {
+    total += cols.length
+  }
+  return total
+}
+
+// ---------------------------------------------------------------------------
+// Summary (one line)
+// ---------------------------------------------------------------------------
+
+/**
+ * A compact one-line summary suitable for CI logs / status checks.
+ *
+ * Examples:
+ *   "no capability changes"
+ *   "+2 tables, -1 table, +3 columns (version changed)"
+ */
+export function summarizeCapabilityDiff(diff: CapabilityDiff): string {
+  const parts: string[] = []
+
+  const pluralTables = (n: number) => (n === 1 ? 'table' : 'tables')
+  const pluralColumns = (n: number) => (n === 1 ? 'column' : 'columns')
+
+  if (diff.addedTables.length > 0) {
+    parts.push(
+      `+${diff.addedTables.length} ${pluralTables(diff.addedTables.length)}`
+    )
+  }
+  if (diff.removedTables.length > 0) {
+    parts.push(
+      `-${diff.removedTables.length} ${pluralTables(diff.removedTables.length)}`
+    )
+  }
+
+  const addedCols = countColumns(diff.addedColumns)
+  const removedCols = countColumns(diff.removedColumns)
+  if (addedCols > 0) {
+    parts.push(`+${addedCols} ${pluralColumns(addedCols)}`)
+  }
+  if (removedCols > 0) {
+    parts.push(`-${removedCols} ${pluralColumns(removedCols)}`)
+  }
+
+  if (parts.length === 0) {
+    return diff.versionChanged
+      ? 'no capability changes (version changed)'
+      : 'no capability changes'
+  }
+
+  const summary = parts.join(', ')
+  return diff.versionChanged ? `${summary} (version changed)` : summary
+}
+
+// ---------------------------------------------------------------------------
+// Full Markdown report
+// ---------------------------------------------------------------------------
+
+export interface CapabilityReportOptions {
+  /** Label for the baseline snapshot (e.g. a version like "24.3"). */
+  baselineLabel?: string
+  /** Label for the next snapshot (e.g. a version like "24.8"). */
+  nextLabel?: string
+}
+
+/** Render a `table: [colA, colB]` map as sorted Markdown list items. */
+function renderColumnMap(map: Record<string, string[]>): string[] {
+  const lines: string[] = []
+  for (const table of Object.keys(map).sort()) {
+    lines.push(
+      `- \`${table}\`: ${map[table].map((c) => `\`${c}\``).join(', ')}`
+    )
+  }
+  return lines
+}
+
+/**
+ * Render a full Markdown drift report for a capability diff.
+ *
+ * Output is deterministic: tables and columns are already sorted by
+ * `diffCapabilities`, and object keys are re-sorted here for stability
+ * regardless of insertion order. Safe to commit as a CI artifact or paste into
+ * an issue.
+ */
+export function formatCapabilityDiff(
+  diff: CapabilityDiff,
+  options: CapabilityReportOptions = {}
+): string {
+  const { baselineLabel, nextLabel } = options
+
+  const heading =
+    baselineLabel && nextLabel
+      ? `# Capability diff: ${baselineLabel} → ${nextLabel}`
+      : '# Capability diff'
+
+  const lines: string[] = [heading, '', `_${summarizeCapabilityDiff(diff)}_`]
+
+  if (diff.versionChanged && baselineLabel && nextLabel) {
+    lines.push('', `Version changed: \`${baselineLabel}\` → \`${nextLabel}\`.`)
+  }
+
+  if (!hasCapabilityChanges(diff)) {
+    lines.push('', 'No structural changes detected.')
+    return lines.join('\n')
+  }
+
+  if (diff.addedTables.length > 0) {
+    lines.push('', '## Tables added')
+    for (const t of diff.addedTables) {
+      lines.push(`- \`${t}\``)
+    }
+  }
+
+  if (diff.removedTables.length > 0) {
+    lines.push('', '## Tables removed')
+    for (const t of diff.removedTables) {
+      lines.push(`- \`${t}\``)
+    }
+  }
+
+  if (Object.keys(diff.addedColumns).length > 0) {
+    lines.push('', '## Columns added')
+    lines.push(...renderColumnMap(diff.addedColumns))
+  }
+
+  if (Object.keys(diff.removedColumns).length > 0) {
+    lines.push('', '## Columns removed')
+    lines.push(...renderColumnMap(diff.removedColumns))
+  }
+
+  return lines.join('\n')
+}


### PR DESCRIPTION
## What
Adds a pure, human-readable reporting layer on top of 10a's `diffCapabilities()`:

- `hasCapabilityChanges(diff)` — structural-change predicate (a version-string change alone is **not** a structural change).
- `summarizeCapabilityDiff(diff)` — one-line CI-log summary, correct singular/plural, stable `tables→columns` ordering.
- `formatCapabilityDiff(diff, { baselineLabel, nextLabel })` — deterministic Markdown drift report, safe to commit as a CI artifact or paste into an issue.

## Why
10a (#1703) shipped `diffCapabilities()` returning a bare `CapabilityDiff` struct with **no human-readable output**. The 10b CI matrix and anyone comparing two `discoverCapabilities()` snapshots need a report. This fills that gap.

This is the **offline half of Plan 10c** (per-version diff reporting): it operates purely on two already-computed snapshots, so it needs **no live ClickHouse** and **no brittle schema-markdown parsing** (the part of 10c that remains gated). Matches 10a's "pure, tested, wire-later" pattern.

## Scope
- In: `apps/dashboard/src/lib/ch-capabilities/capabilities-report.ts` (+ test). New file only; does not touch the merged 10a `capabilities.ts`.
- Out: live discovery wiring, CI matrix (10b), committed-baseline parsing (10c-live).

## How verified
- `bun test capabilities-report.test.ts` → **12 pass / 0 fail**
- `biome check` → clean
- `tsc --noEmit` (src + `tsconfig.test.json`) → **no errors in changed files** (pre-existing route errors are the known gitignored `routeTree.gen.ts` artifact, resolved by CI's `vite build`)
- **Bundle-neutral**: lib imported only by tests → tree-shaken from the Worker bundle (same guarantee as 10a). No UI change → no visual-verify needed.

## Guardrails
- [x] Scope respected (one new lib + test)
- [x] types + build green (changed files clean)
- [x] biome clean
- [x] tests green (12)
- [x] No UI change → visual-verify N/A
- [x] Backward compatible (additive, unconsumed-until-wired)
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: cowork/plans/10-clickhouse-version-compat.md