### PR TITLE
feat(overview): break Query Activity Heatmap into compact per-month blocks

### DIFF
--- a/apps/dashboard/src/components/charts/query/query-count-calendar.test.ts
+++ b/apps/dashboard/src/components/charts/query/query-count-calendar.test.ts
@@ -2,6 +2,7 @@ import type { HeatmapDayRow } from './query-count-calendar'
 
 import {
   buildCalendarModel,
+  buildMonthBlocks,
   buildStatCards,
   formatCalendarDate,
   formatDurationMs,
@@ -157,6 +158,71 @@ describe('buildCalendarModel', () => {
       /^[A-Z][a-z]{2} \d{4} – [A-Z][a-z]{2} \d{4}$/
     )
     expect(model.rangeLabel.endsWith('Jun 2026')).toBe(true)
+  })
+})
+
+describe('buildMonthBlocks', () => {
+  const today = new Date(2026, 5, 17) // Wed Jun 17 2026
+
+  it('groups days into one block per month, in chronological order', () => {
+    // 12 weeks back from mid-June spans Apr→Jun 2026.
+    const model = buildCalendarModel([], today, QUERIES, 12)
+    const blocks = buildMonthBlocks(model)
+
+    // The start snaps back to a Sunday, so a partial leading month (Mar) shows.
+    const labels = blocks.map((b) => b.label)
+    expect(labels).toEqual(['Mar', 'Apr', 'May', 'Jun'])
+    // Keys carry the year so blocks stay distinct across a year boundary.
+    expect(blocks.map((b) => b.key)).toEqual([
+      '2026-2',
+      '2026-3',
+      '2026-4',
+      '2026-5',
+    ])
+    expect(blocks.every((b) => b.year === 2026)).toBe(true)
+  })
+
+  it('keeps every block self-contained: a block only holds its own days', () => {
+    const model = buildCalendarModel([], today, QUERIES, 12)
+    for (const block of buildMonthBlocks(model)) {
+      const month = Number(block.key.split('-')[1])
+      for (const week of block.weeks) {
+        for (const day of week) {
+          if (day) expect(day.date.getMonth()).toBe(month)
+        }
+      }
+    }
+  })
+
+  it('splits a boundary week across both months (masked each way)', () => {
+    // May 31 2026 is a Sunday; Jun 1 is the Monday in the same column. That one
+    // week column must appear in both the May and June blocks.
+    const model = buildCalendarModel([], today, QUERIES, 12)
+    const blocks = buildMonthBlocks(model)
+    const may = blocks.find((b) => b.key === '2026-4')!
+    const jun = blocks.find((b) => b.key === '2026-5')!
+
+    const mayHasMay31 = may.weeks.some((w) =>
+      w.some((d) => d?.iso === '2026-05-31')
+    )
+    const junHasJun1 = jun.weeks.some((w) =>
+      w.some((d) => d?.iso === '2026-06-01')
+    )
+    expect(mayHasMay31).toBe(true)
+    expect(junHasJun1).toBe(true)
+    // The June block must NOT leak May 31 into its masked copy of that week.
+    const junHasMay31 = jun.weeks.some((w) =>
+      w.some((d) => d?.iso === '2026-05-31')
+    )
+    expect(junHasMay31).toBe(false)
+  })
+
+  it('preserves each day cell value from the model', () => {
+    const rows: HeatmapDayRow[] = [row('2026-06-15', { query_count: 100 })]
+    const model = buildCalendarModel(rows, today, QUERIES, 4)
+    const jun = buildMonthBlocks(model).find((b) => b.key === '2026-5')!
+    const cell = jun.weeks.flat().find((d) => d?.iso === '2026-06-15')
+    expect(cell?.value).toBe(100)
   })
 })
 

--- a/apps/dashboard/src/components/charts/query/query-count-calendar.ts
+++ b/apps/dashboard/src/components/charts/query/query-count-calendar.ts
@@ -377,6 +377,68 @@ export function buildCalendarModel(
   }
 }
 
+/**
+ * A month's worth of day cells, grouped out of the continuous week grid for the
+ * "broken-down" year-calendar layout. Each `weeks` column keeps the Sunday-first
+ * row alignment of {@link CalendarModel.weeks}, but days belonging to a
+ * neighbouring month are masked to `null` so the block renders only its own
+ * days (partial first/last weeks, exactly like a wall calendar).
+ */
+export interface MonthBlock {
+  /** Stable key, `YYYY-M` (month 0-indexed). */
+  key: string
+  /** Short month name, e.g. "Jun". */
+  label: string
+  year: number
+  /** Week columns touching this month, oldest → newest, masked to this month. */
+  weeks: CalendarWeek[]
+}
+
+/**
+ * Re-group a {@link CalendarModel}'s continuous week columns into per-month
+ * blocks. A boundary week (one spanning two months) is emitted into both blocks,
+ * masked to the relevant month each time — so every block shows its own partial
+ * leading/trailing week. Pure derivation: no new date math, just a regrouping of
+ * the already-built cells, keeping the tested {@link buildCalendarModel} intact.
+ */
+export function buildMonthBlocks(model: CalendarModel): MonthBlock[] {
+  const blocks: MonthBlock[] = []
+  const byKey = new Map<string, MonthBlock>()
+  const keyOf = (d: Date) => `${d.getFullYear()}-${d.getMonth()}`
+
+  for (const week of model.weeks) {
+    // Distinct months this week touches, in chronological (Sun→Sat) order.
+    const monthsInWeek: string[] = []
+    for (const day of week) {
+      if (day) {
+        const k = keyOf(day.date)
+        if (!monthsInWeek.includes(k)) monthsInWeek.push(k)
+      }
+    }
+
+    for (const k of monthsInWeek) {
+      let block = byKey.get(k)
+      if (!block) {
+        const sample = week.find((d) => d && keyOf(d.date) === k) as CalendarDay
+        block = {
+          key: k,
+          label: MONTH_NAMES_SHORT[sample.date.getMonth()],
+          year: sample.date.getFullYear(),
+          weeks: [],
+        }
+        byKey.set(k, block)
+        blocks.push(block)
+      }
+      // Keep only this month's days in the column; others become gaps.
+      block.weeks.push(
+        week.map((day) => (day && keyOf(day.date) === k ? day : null))
+      )
+    }
+  }
+
+  return blocks
+}
+
 /** A single KPI/stat card shown above the calendar. */
 export interface StatCard {
   label: string

--- a/apps/dashboard/src/components/charts/query/query-count-heatmap.tsx
+++ b/apps/dashboard/src/components/charts/query/query-count-heatmap.tsx
@@ -6,10 +6,12 @@ import type {
   HeatmapDayRow,
   MetricConfig,
   MetricKey,
+  MonthBlock,
 } from './query-count-calendar'
 
 import {
   buildCalendarModel,
+  buildMonthBlocks,
   buildStatCards,
   CALENDAR_DAY_LABELS,
   formatCalendarDate,
@@ -24,6 +26,11 @@ import { cn } from '@/lib/utils'
 
 // Day-of-week rows that get a left-gutter label (GitHub shows Mon/Wed/Fri).
 const LABELLED_ROWS = new Set([1, 3, 5])
+
+// Fixed dot size for every day cell. Kept small so the full year stays compact
+// and the month blocks read as a calendar rather than a stretched strip.
+const CELL = 'size-[11px]'
+const CELL_GAP = 'gap-[2px]'
 
 interface HoverState {
   day: CalendarDay
@@ -131,6 +138,7 @@ function CalendarBody({
     () => buildStatCards(metric, model),
     [metric, model]
   )
+  const monthBlocks = useMemo(() => buildMonthBlocks(model), [model])
   const todayIso = isoDate(new Date())
 
   // Auto-focus the latest date: scroll the calendar to its right edge on mount
@@ -154,8 +162,49 @@ function CalendarBody({
     )
   }
 
-  const { weeks, monthLabels, max, rangeLabel } = model
+  const { max, rangeLabel } = model
   const hasTraffic = max > 0
+
+  // Render one day cell (or an empty spacer for masked/out-of-range slots).
+  const renderDay = (day: CalendarDay | null, dow: number) => {
+    if (!day) {
+      return <div key={dow} className={CELL} aria-hidden />
+    }
+    const intensity = getIntensityClass(day.value, max, metric.tiers)
+    const isToday = day.iso === todayIso
+    const href = buildDrilldownHref(hostId, day, mode)
+    const onEnter = (e: React.SyntheticEvent<HTMLElement>) => {
+      const rect = e.currentTarget.getBoundingClientRect()
+      const host = e.currentTarget.closest(
+        '[data-calendar-root]'
+      ) as HTMLElement | null
+      const hostRect = host?.getBoundingClientRect()
+      setHover({
+        day,
+        x: rect.left + rect.width / 2 - (hostRect?.left ?? 0),
+        y: rect.top - (hostRect?.top ?? 0),
+      })
+    }
+    return (
+      <Link
+        key={day.iso}
+        to={href}
+        aria-label={`${day.readable} on ${formatCalendarDate(day.date)}`}
+        onMouseEnter={onEnter}
+        onFocus={onEnter}
+        onMouseLeave={() => setHover(null)}
+        onBlur={() => setHover(null)}
+        className={cn(
+          CELL,
+          'rounded-[2px] transition-transform duration-100',
+          'hover:scale-125 hover:ring-1 hover:ring-foreground/40',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          intensity,
+          isToday && 'ring-1 ring-foreground/60'
+        )}
+      />
+    )
+  }
 
   return (
     <div
@@ -192,93 +241,45 @@ function CalendarBody({
         ))}
       </div>
 
-      {/* Calendar: month labels + weekday gutter + week columns. The columns are
-          fluid (flex-1) so the grid fills the card/dialog width; a min width
-          keeps it legible on phones (horizontal scroll, like GitHub). */}
+      {/* Year calendar: a weekday gutter plus one self-contained block per
+          month. Dots are a fixed small size (CELL) so the whole year stays
+          compact, and each month is its own mini-grid so month boundaries read
+          clearly. Horizontal scroll on narrow screens (auto-scrolled to the
+          latest month, like GitHub). */}
       <div ref={scrollRef} className="overflow-x-auto pb-1">
-        <div className="min-w-[680px]">
-          {/* Month labels, aligned to week columns (pl matches the gutter). */}
-          <div className="flex gap-[3px] pb-1.5 pl-9">
-            {monthLabels.map((label, i) => (
+        <div className="flex w-max items-start gap-3">
+          {/* Weekday gutter (Sun-first; GitHub shows Mon/Wed/Fri). The leading
+              spacer aligns the rows with each block's month label. */}
+          <div className={cn('flex flex-shrink-0 flex-col', CELL_GAP)}>
+            <div className="mb-1 h-[10px]" aria-hidden />
+            {CALENDAR_DAY_LABELS.map((label, dow) => (
               <div
-                key={weeks[i].find(Boolean)?.iso ?? `col-${i}`}
-                className="text-muted-foreground min-w-0 flex-1 text-[11px] leading-none"
+                key={label}
+                className="text-muted-foreground flex h-[11px] items-center justify-end pr-1 text-[9px] leading-none"
               >
-                {label ?? ''}
+                {LABELLED_ROWS.has(dow) ? label : ''}
               </div>
             ))}
           </div>
 
-          <div className="flex gap-[3px]">
-            {/* Weekday gutter */}
-            <div className="flex w-9 flex-shrink-0 flex-col gap-[3px]">
-              {CALENDAR_DAY_LABELS.map((label, dow) => (
-                <div
-                  key={label}
-                  className="text-muted-foreground flex aspect-square items-center justify-end pr-1.5 text-[10px] leading-none"
-                >
-                  {LABELLED_ROWS.has(dow) ? label : ''}
-                </div>
-              ))}
+          {/* One block per month */}
+          {monthBlocks.map((block: MonthBlock) => (
+            <div key={block.key} className="flex flex-col">
+              <div className="text-muted-foreground mb-1 h-[10px] text-[10px] leading-none">
+                {block.label}
+              </div>
+              <div className={cn('flex', CELL_GAP)}>
+                {block.weeks.map((week, wi) => (
+                  <div
+                    key={week.find(Boolean)?.iso ?? `${block.key}-w${wi}`}
+                    className={cn('flex flex-col', CELL_GAP)}
+                  >
+                    {week.map((day, dow) => renderDay(day, dow))}
+                  </div>
+                ))}
+              </div>
             </div>
-
-            {/* Week columns */}
-            {weeks.map((week, i) => (
-              <div
-                key={week.find(Boolean)?.iso ?? `week-${i}`}
-                className="flex min-w-0 flex-1 flex-col gap-[3px]"
-              >
-                {week.map((day, dow) => {
-                  if (!day) {
-                    return (
-                      <div
-                        key={dow}
-                        className="aspect-square w-full"
-                        aria-hidden
-                      />
-                    )
-                  }
-                  const intensity = getIntensityClass(
-                    day.value,
-                    max,
-                    metric.tiers
-                  )
-                  const isToday = day.iso === todayIso
-                  const href = buildDrilldownHref(hostId, day, mode)
-                  const onEnter = (e: React.SyntheticEvent<HTMLElement>) => {
-                    const rect = e.currentTarget.getBoundingClientRect()
-                    const host = e.currentTarget.closest(
-                      '[data-calendar-root]'
-                    ) as HTMLElement | null
-                    const hostRect = host?.getBoundingClientRect()
-                    setHover({
-                      day,
-                      x: rect.left + rect.width / 2 - (hostRect?.left ?? 0),
-                      y: rect.top - (hostRect?.top ?? 0),
-                    })
-                  }
-                  return (
-                    <Link
-                      key={day.iso}
-                      to={href}
-                      aria-label={`${day.readable} on ${formatCalendarDate(day.date)}`}
-                      onMouseEnter={onEnter}
-                      onFocus={onEnter}
-                      onMouseLeave={() => setHover(null)}
-                      onBlur={() => setHover(null)}
-                      className={cn(
-                        'aspect-square w-full rounded-[3px] transition-transform duration-100',
-                        'hover:scale-125 hover:ring-1 hover:ring-foreground/40',
-                        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                        intensity,
-                        isToday && 'ring-1 ring-foreground/60'
-                      )}
-                    />
-                  )
-                })}
-              </div>
-            ))}
-          </div>
+          ))}
         </div>
       </div>
 


### PR DESCRIPTION
## What

Make the **Query Activity Heatmap** smaller and more compact, and break the year down into per-month calendar blocks.

Before, the heatmap was a single full-width continuous 53-week strip. Because the card spans the full page width, each day cell stretched (`aspect-square w-full` inside `flex-1` columns) to ~30px — making the whole thing oversized and tall.

Now it renders as a **year calendar of self-contained month blocks** with **fixed small dots**, so the full year reads compactly and month boundaries are clear.

## Changes

- **`buildMonthBlocks()`** — new pure helper in `query-count-calendar.ts` that regroups the existing Sunday-first week grid into one block per month. A boundary week (e.g. May 31 / Jun 1 in the same column) is emitted into both blocks, masked to each month so every block only shows its own days. `buildCalendarModel` (and its tests) are untouched.
- **Fixed dot size** — cells switch from stretch-to-fill (`aspect-square w-full`) to a fixed `size-[11px]`, with tighter `gap-[2px]`.
- **Layout** — one shared weekday gutter (Mon/Wed/Fri) + one mini-grid per month, separated by `gap-3`, horizontally scrollable on narrow screens (auto-scrolled to the latest month, like GitHub).
- Extracted the day-cell rendering into a `renderDay` helper (shared by all blocks; behaviour, drilldown links, hover tooltip, and accessibility labels unchanged).

## Tests

Added `buildMonthBlocks` unit tests: chronological month ordering (incl. the partial leading month from the Sunday snap), per-block self-containment, boundary-week splitting without leakage, and value preservation. Full `query-count-calendar.test.ts` suite: **21 pass / 0 fail**.

Biome clean. Type-check clean for the touched files (remaining route-type errors are the known `routeTree.gen.ts` generation gap, resolved by `bun run build` in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)