### PR TITLE
test(ch-capabilities): cover discoverCapabilities via a mock ChClient

### DIFF
--- a/apps/dashboard/src/lib/ch-capabilities/capabilities.test.ts
+++ b/apps/dashboard/src/lib/ch-capabilities/capabilities.test.ts
@@ -1,5 +1,11 @@
+import type { ChClient } from './capabilities'
+
 import { detectChFlavor, parseMajorMinor } from '../telemetry/environment'
-import { diffCapabilities, normalizeCapabilities } from './capabilities'
+import {
+  diffCapabilities,
+  discoverCapabilities,
+  normalizeCapabilities,
+} from './capabilities'
 import { describe, expect, it } from 'bun:test'
 
 // ---------------------------------------------------------------------------
@@ -268,5 +274,118 @@ describe('import contract — detectChFlavor', () => {
 
   it('returns unknown for empty string', () => {
     expect(detectChFlavor('')).toBe('unknown')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// discoverCapabilities (mocked ChClient — exercises the live transform offline)
+// ---------------------------------------------------------------------------
+
+/**
+ * A fake ChClient that records every query and answers from canned payloads,
+ * routed by which system object the query references. Lets us cover the
+ * query-result → snapshot transform without a real ClickHouse.
+ */
+function mockClient(
+  responses: {
+    version?: unknown
+    tables?: unknown
+    columns?: unknown
+    buildOptions?: unknown
+  },
+  recorder?: string[]
+): ChClient {
+  return {
+    query: ({ query }) => {
+      recorder?.push(query)
+      let data: unknown
+      if (query.includes('version()')) data = responses.version
+      else if (query.includes('system.tables')) data = responses.tables
+      else if (query.includes('system.columns')) data = responses.columns
+      else if (query.includes('system.build_options'))
+        data = responses.buildOptions
+      else data = { data: [] }
+      return Promise.resolve({ json: () => Promise.resolve(data) })
+    },
+  }
+}
+
+describe('discoverCapabilities', () => {
+  it('maps the four query results into a normalized snapshot', async () => {
+    const snap = await discoverCapabilities(
+      mockClient({
+        version: { data: [{ version: '24.8.1.2' }] },
+        tables: {
+          data: [
+            { database: 'system', name: 'query_log' },
+            { database: 'system', name: 'metrics' },
+          ],
+        },
+        columns: {
+          data: [
+            { database: 'system', table: 'query_log', name: 'event_time' },
+            { database: 'system', table: 'query_log', name: 'query_id' },
+          ],
+        },
+        buildOptions: {
+          data: [{ name: 'BUILD_TYPE', value: 'RelWithDebInfo' }],
+        },
+      })
+    )
+
+    expect(snap.version).toBe('24.8.1.2')
+    expect(snap.majorMinor).toBe('24.8')
+    expect(snap.flavor).toBe('oss')
+    expect(Object.keys(snap.tables)).toEqual([
+      'system.metrics',
+      'system.query_log',
+    ])
+    expect(snap.tables['system.query_log']).toEqual(['event_time', 'query_id'])
+    expect(snap.buildFlags).toEqual({ BUILD_TYPE: 'RelWithDebInfo' })
+  })
+
+  it('falls back to an empty version when version() returns no rows', async () => {
+    const snap = await discoverCapabilities(
+      mockClient({
+        version: { data: [] },
+        tables: { data: [] },
+        columns: { data: [] },
+        buildOptions: { data: [] },
+      })
+    )
+
+    expect(snap.version).toBe('')
+    expect(snap.majorMinor).toBeUndefined()
+    expect(snap.flavor).toBe('unknown')
+    expect(snap.tables).toEqual({})
+    // Empty build options → buildFlags omitted entirely.
+    expect(snap.buildFlags).toBeUndefined()
+  })
+
+  it('issues exactly the four documented discovery queries', async () => {
+    const queries: string[] = []
+    await discoverCapabilities(
+      mockClient(
+        {
+          version: { data: [{ version: '24.3.1.1' }] },
+          tables: { data: [] },
+          columns: { data: [] },
+          buildOptions: { data: [] },
+        },
+        queries
+      )
+    )
+
+    expect(queries).toHaveLength(4)
+    expect(queries.some((q) => q.includes('version()'))).toBe(true)
+    expect(
+      queries.some((q) => q.includes("system.tables WHERE database = 'system'"))
+    ).toBe(true)
+    expect(
+      queries.some((q) =>
+        q.includes("system.columns WHERE database = 'system'")
+      )
+    ).toBe(true)
+    expect(queries.some((q) => q.includes('system.build_options'))).toBe(true)
   })
 })


### PR DESCRIPTION
## What
Adds 3 unit tests for `discoverCapabilities()` using a fake `ChClient`:
- maps the four query results into a normalized snapshot (version/majorMinor/flavor, table+column merge, buildFlags)
- falls back to an empty version when `version()` returns no rows
- issues exactly the four documented discovery queries

## Why
`discoverCapabilities()` shipped in 10a (#1703) with **zero unit coverage** — its doc comment defers verification to the **10b integration matrix**, which needs a live ClickHouse and doesn't exist yet. So the query-result → snapshot transform is untested today. 10a deliberately abstracted the client behind a minimal `ChClient` interface, so a fake returning canned `{ json() }` payloads exercises the real function offline — closing the gap now instead of waiting for gated CI ClickHouse.

## Scope
- In: `apps/dashboard/src/lib/ch-capabilities/capabilities.test.ts` (test-only).
- Out: no runtime change.

## How verified
- `bun test src/lib/ch-capabilities/` → **41 pass / 0 fail**
- `biome check` → clean
- `tsc -p tsconfig.test.json` → no errors in changed file
- **Test-only → guaranteed bundle-neutral** (no runtime file touched). No UI change.

## Guardrails
- [x] Scope respected (one test file)
- [x] tests green (41)
- [x] biome clean
- [x] No runtime/UI change → visual-verify N/A, bundle-neutral
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: cowork/plans/10-clickhouse-version-compat.md