### PR TITLE
feat(query-config): declarative expandable spec, migrate settings/users

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/index.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/index.ts
@@ -60,8 +60,10 @@ import { errorsDeclarative } from './more/errors'
 import { mergeTreeSettingsDeclarative } from './more/mergetree-settings'
 import { metricsDeclarative } from './more/metrics'
 import { rolesDeclarative } from './more/roles'
+import { settingsDeclarative } from './more/settings'
 import { topUsageColumnsDeclarative } from './more/top-usage-columns'
 import { topUsageTablesDeclarative } from './more/top-usage-tables'
+import { usersDeclarative } from './more/users'
 import { zookeeperDeclarative } from './more/zookeeper'
 // Queries
 import { commonErrorsDeclarative } from './queries/common-errors'
@@ -167,8 +169,10 @@ const ALL_DECLARATIVE: DeclarativeQueryConfig[] = [
   mergeTreeSettingsDeclarative,
   metricsDeclarative,
   rolesDeclarative,
+  settingsDeclarative,
   topUsageColumnsDeclarative,
   topUsageTablesDeclarative,
+  usersDeclarative,
   zookeeperDeclarative,
 
   // Queries

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/more/more-catalog.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/more/more-catalog.test.ts
@@ -13,11 +13,17 @@
  * docs (table-missing help text) and permission (FeaturePermission as plain
  * data) are now serializable and ARE compared here.
  *
+ * settings/users now migrate too: their factory-based `expandable` is expressed
+ * via the declarative `expandable` config-details spec. The compiled
+ * renderExpanded is a function (not deep-equalled by compareSerializable); a
+ * dedicated behavioral test asserts it binds the same factory + primaryColumns
+ * as the legacy config.
+ *
  * Skipped configs (runtime-only fields that the schema cannot express):
  *   page-views — tableCheck + SQL reference runtime EVENTS_TABLE env var
- *   settings   — expandable field (also has permission, but expandable blocks it)
- *   users      — expandable field
  */
+
+import type { ExpandableConfig } from '@/types/query-config'
 
 import { loadDeclarativeConfig } from '../../loader'
 // Declarative catalog objects
@@ -28,8 +34,10 @@ import { errorsDeclarative } from './errors'
 import { mergeTreeSettingsDeclarative } from './mergetree-settings'
 import { metricsDeclarative } from './metrics'
 import { rolesDeclarative } from './roles'
+import { settingsDeclarative } from './settings'
 import { topUsageColumnsDeclarative } from './top-usage-columns'
 import { topUsageTablesDeclarative } from './top-usage-tables'
+import { usersDeclarative } from './users'
 import { zookeeperDeclarative } from './zookeeper'
 import { describe, expect, test } from 'bun:test'
 // Legacy TS configs
@@ -40,8 +48,10 @@ import { errorsConfig } from '@/lib/query-config/more/errors'
 import { mergeTreeSettingsConfig } from '@/lib/query-config/more/mergetree-settings'
 import { metricsConfig } from '@/lib/query-config/more/metrics'
 import { rolesConfig } from '@/lib/query-config/more/roles'
+import { settingsConfig } from '@/lib/query-config/more/settings'
 import { topUsageColumnsConfig } from '@/lib/query-config/more/top-usage-columns'
 import { topUsageTablesConfig } from '@/lib/query-config/more/top-usage-tables'
+import { usersConfig } from '@/lib/query-config/more/users'
 import { zookeeperConfig } from '@/lib/query-config/more/zookeeper'
 
 // ---------------------------------------------------------------------------
@@ -70,6 +80,39 @@ function compareSerializable(
     if (RUNTIME_ONLY_KEYS.has(key)) continue
     expect(loadedRec[key]).toEqual(legacyRec[key])
   }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: a compiled `expandable` is a function, so it can't be deep-equalled.
+// createConfigExpandedDetails returns (row) => <ConfigExpandedDetails .../>, so
+// we inspect the React element it produces WITHOUT rendering: the same factory
+// yields the same element .type (component reference identity) and the same
+// `primaryColumns` prop. That proves the loader bound the same panel + columns.
+// ---------------------------------------------------------------------------
+
+function expectExpandableMatchesLegacy(
+  loaded: ReturnType<typeof loadDeclarativeConfig>,
+  legacyExpandable: ExpandableConfig
+): void {
+  expect(loaded.expandable).toBeDefined()
+  const loadedRenderer = (loaded.expandable as ExpandableConfig).renderExpanded
+  const sampleRow = { name: 'sample', extra_column: 'value' }
+  const ctx = { row: {} } as unknown as Parameters<typeof loadedRenderer>[1]
+
+  const loadedEl = loadedRenderer(sampleRow, ctx) as unknown as {
+    type: unknown
+    props: Record<string, unknown>
+  }
+  const legacyEl = legacyExpandable.renderExpanded(
+    sampleRow,
+    ctx
+  ) as unknown as {
+    type: unknown
+    props: Record<string, unknown>
+  }
+
+  expect(loadedEl.type).toBe(legacyEl.type)
+  expect(loadedEl.props.primaryColumns).toEqual(legacyEl.props.primaryColumns)
 }
 
 // ---------------------------------------------------------------------------
@@ -253,5 +296,56 @@ describe('metrics declarative', () => {
   test('permission matches legacy', () => {
     const loaded = loadDeclarativeConfig(metricsDeclarative)
     expect(loaded.permission).toEqual(metricsConfig.permission)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// settings — expandable (config-details) + permission migrated to declarative
+// ---------------------------------------------------------------------------
+
+describe('settings declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(settingsDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(settingsDeclarative)
+    compareSerializable(loaded, settingsConfig)
+  })
+
+  test('permission matches legacy', () => {
+    const loaded = loadDeclarativeConfig(settingsDeclarative)
+    expect(loaded.permission).toEqual(settingsConfig.permission)
+  })
+
+  test('expandable binds the same factory + primaryColumns as legacy', () => {
+    const loaded = loadDeclarativeConfig(settingsDeclarative)
+    expectExpandableMatchesLegacy(
+      loaded,
+      settingsConfig.expandable as ExpandableConfig
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// users — expandable (config-details) migrated to declarative
+// ---------------------------------------------------------------------------
+
+describe('users declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeConfig(usersDeclarative)).not.toThrow()
+  })
+
+  test('serializable fields match legacy', () => {
+    const loaded = loadDeclarativeConfig(usersDeclarative)
+    compareSerializable(loaded, usersConfig)
+  })
+
+  test('expandable binds the same factory + primaryColumns as legacy', () => {
+    const loaded = loadDeclarativeConfig(usersDeclarative)
+    expectExpandableMatchesLegacy(
+      loaded,
+      usersConfig.expandable as ExpandableConfig
+    )
   })
 })

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/more/settings.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/more/settings.ts
@@ -1,0 +1,39 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+const SETTINGS_COLUMNS = ['name', 'value', 'changed', 'description', 'default']
+
+export const settingsDeclarative: DeclarativeQueryConfig = {
+  name: 'settings',
+  optional: false,
+  defaultView: 'auto',
+  card: { primary: 'name', badges: ['changed'] },
+  permission: { feature: 'settings' },
+  tableCheck: 'system.settings',
+  sql: `
+      SELECT *
+      FROM system.settings
+      WHERE if({changed: String} != '', changed = {changed: String}, true)
+      ORDER BY name
+  `,
+  columns: SETTINGS_COLUMNS,
+  // Expand a row to reveal the columns system.settings exposes beyond the
+  // table view: type, min, max, readonly, tier, is_obsolete, alias_for, …
+  expandable: { type: 'config-details', primaryColumns: SETTINGS_COLUMNS },
+  columnFormats: {
+    name: 'code',
+    changed: 'boolean',
+    value: 'code',
+    default: 'code',
+    description: 'markdown',
+  },
+  defaultParams: {
+    changed: '',
+  },
+  filterParamPresets: [
+    {
+      name: 'Changed only',
+      key: 'changed',
+      value: '1',
+    },
+  ],
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/more/users.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/more/users.ts
@@ -1,0 +1,33 @@
+import type { DeclarativeQueryConfig } from '../../schema'
+
+const USERS_COLUMNS = [
+  'name',
+  'storage',
+  'auth_type',
+  'auth_params',
+  'host_ip',
+  'host_names',
+  'default_roles_all',
+  'default_roles_list',
+  'default_roles_except',
+  'default_database',
+]
+
+export const usersDeclarative: DeclarativeQueryConfig = {
+  name: 'users',
+  optional: false,
+  defaultView: 'auto',
+  card: { primary: 'name' },
+  description: 'Users account',
+  tableCheck: 'system.users',
+  sql: `
+      SELECT *,
+      FROM system.users
+      ORDER BY name
+    `,
+  columns: USERS_COLUMNS,
+  columnFormats: {},
+  // Expand a row to reveal the host/grantee/role-restriction columns that
+  // system.users exposes beyond the table view (grantees_*, host_regexp, …).
+  expandable: { type: 'config-details', primaryColumns: USERS_COLUMNS },
+}

--- a/apps/dashboard/src/lib/query-config/declarative/expandable.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/expandable.test.ts
@@ -1,0 +1,59 @@
+import type { DeclarativeExpandableSpec } from './schema'
+
+import { compileExpandable } from './expandable'
+import { describe, expect, test } from 'bun:test'
+
+// React element shape we inspect without rendering.
+type Element = { type: unknown; props: Record<string, unknown> }
+
+function renderFirst(
+  spec: DeclarativeExpandableSpec,
+  row: Record<string, unknown> = { name: 'x' }
+): Element {
+  const config = compileExpandable(spec)
+  const ctx = { row: {} } as unknown as Parameters<
+    typeof config.renderExpanded
+  >[1]
+  return config.renderExpanded(row, ctx) as unknown as Element
+}
+
+describe('compileExpandable — config-details', () => {
+  test('returns an ExpandableConfig with a renderExpanded function', () => {
+    const config = compileExpandable({
+      type: 'config-details',
+      primaryColumns: ['name'],
+    })
+    expect(typeof config.renderExpanded).toBe('function')
+  })
+
+  test('threads primaryColumns into the rendered element props', () => {
+    const el = renderFirst({
+      type: 'config-details',
+      primaryColumns: ['name', 'value'],
+    })
+    expect(el.props.primaryColumns).toEqual(['name', 'value'])
+  })
+
+  test('threads descriptionKey into the rendered element props', () => {
+    const el = renderFirst({
+      type: 'config-details',
+      primaryColumns: ['name'],
+      descriptionKey: 'comment',
+    })
+    expect(el.props.descriptionKey).toBe('comment')
+  })
+
+  test('omitting primaryColumns yields an undefined prop (factory default applies)', () => {
+    const el = renderFirst({ type: 'config-details' })
+    expect(el.props.primaryColumns).toBeUndefined()
+  })
+})
+
+describe('compileExpandable — unknown type', () => {
+  test('throws loud on an unknown spec type', () => {
+    // Force an off-schema type past the discriminated union to prove the
+    // loader fails loud rather than silently producing no panel.
+    const bad = { type: 'panel' } as unknown as DeclarativeExpandableSpec
+    expect(() => compileExpandable(bad)).toThrow(/Unknown expandable spec type/)
+  })
+})

--- a/apps/dashboard/src/lib/query-config/declarative/expandable.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/expandable.ts
@@ -1,0 +1,43 @@
+/**
+ * Compile a declarative `expandable` spec into a runtime ExpandableConfig.
+ *
+ * The serializable spec (DeclarativeExpandableSpec) carries only data; this
+ * module dispatches on its `type` and binds the matching row-detail factory.
+ * It mirrors row-style.ts (compileRowStyle): the loader stays declarative-in,
+ * runtime-out and never embeds JSX itself.
+ *
+ * Lives next to the loader (not in schema.ts) because it imports a `.tsx`
+ * factory — keeping that React dependency out of the pure schema module.
+ */
+
+import type { ExpandableConfig } from '@/types/query-config'
+import type { DeclarativeExpandableSpec } from './schema'
+
+import { createConfigExpandedDetails } from '@/components/data-table/cells/config-expanded-details'
+
+/**
+ * Compile a declarative expandable spec into the in-memory ExpandableConfig
+ * the data table consumes (`{ renderExpanded }`).
+ *
+ * Currently supports the `config-details` variant (an auto-grid of the row's
+ * non-primary columns). The discriminated union leaves room for the `panel`
+ * variant; an unknown `type` throws so a malformed spec fails loud at load.
+ */
+export function compileExpandable(
+  spec: DeclarativeExpandableSpec
+): ExpandableConfig {
+  switch (spec.type) {
+    case 'config-details':
+      return {
+        renderExpanded: createConfigExpandedDetails({
+          primaryColumns: spec.primaryColumns,
+          descriptionKey: spec.descriptionKey,
+        }),
+      }
+    default: {
+      // Exhaustiveness guard — a new union member must add a case above.
+      const exhaustive: never = spec.type
+      throw new Error(`Unknown expandable spec type: ${String(exhaustive)}`)
+    }
+  }
+}

--- a/apps/dashboard/src/lib/query-config/declarative/loader.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/loader.ts
@@ -6,14 +6,15 @@
  *
  * RUNTIME-ONLY FIELDS NOT PRESENT ON LOADED CONFIGS:
  *   - columnIcons    — React component refs (Icon type)
- *   - expandable     — function-based ExpandableConfig
  *   - filterSchema   — FilterSchema (contains Icon refs and dynamic option fns)
  *   - columnFilters  — ColumnFilterDef (UI sugar over filterSchema)
+ *   - inline-JSX expandable — bespoke per-row React (keep as a TS config)
  *   - variants       — deprecated; use versioned sql[] in the declarative format
  *
- * The declarative `rowStyle` field IS carried: it is compiled into a
- * rowClassName function on the loaded config (see compileRowStyle). The
- * `permission` field (plain FeaturePermission data) is also carried through.
+ * Compiled fields (declarative spec → runtime value on the loaded config):
+ *   - rowStyle    → rowClassName function (see compileRowStyle)
+ *   - permission  → FeaturePermission (plain data, carried through)
+ *   - expandable  → ExpandableConfig (see compileExpandable)
  *
  * These fields can be merged in by the caller after loading if needed.
  */
@@ -21,6 +22,7 @@
 import type { QueryConfig } from '@/types/query-config'
 import type { DeclarativeQueryConfig } from './schema'
 
+import { compileExpandable } from './expandable'
 import { compileRowStyle } from './row-style'
 import { validateDeclarativeConfig } from './validate'
 
@@ -157,6 +159,12 @@ export function loadDeclarativeConfig(input: unknown): QueryConfig {
   // FeaturePermission (schema validates feature/access/operation to its domain).
   if (d.permission !== undefined) {
     config.permission = d.permission as QueryConfig['permission']
+  }
+
+  // Expandable row-detail panel — compile the declarative spec into an
+  // ExpandableConfig by binding the matching row-detail factory.
+  if (d.expandable !== undefined) {
+    config.expandable = compileExpandable(d.expandable)
   }
 
   return config

--- a/apps/dashboard/src/lib/query-config/declarative/schema.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/schema.ts
@@ -5,13 +5,15 @@
  * a JSON / YAML / TOML file and be contributed by the community without
  * requiring TypeScript knowledge.
  *
- * The companion loader (Plan 02b) will map a DeclarativeQueryConfig into the
+ * The companion loader (Plan 02b) maps a DeclarativeQueryConfig into the
  * in-memory QueryConfig that the dashboard consumes at runtime. Fields that
- * are runtime functions (expandable, columnIcons, filterSchema with Icon refs)
- * are intentionally excluded here — they cannot be expressed declaratively and
- * must be wired up by the loader. Two exceptions: rowClassName (simple
- * data-driven row styling via `rowStyle`, compiled into a RowClassNameFn) and
- * FeaturePermission (plain data, carried via the `permission` field).
+ * are runtime functions (columnIcons, filterSchema with Icon refs, inline-JSX
+ * expandables) are intentionally excluded here — they cannot be expressed
+ * declaratively and must be wired up by the loader. Exceptions where a
+ * data-describable spec is compiled by the loader: rowClassName (via
+ * `rowStyle`, compiled into a RowClassNameFn), FeaturePermission (plain data,
+ * via `permission`), and the factory-based expandable panels (via `expandable`,
+ * compiled into an ExpandableConfig).
  *
  * Serializable fields carried here:
  *   identity:       name, description, docs, suggestion
@@ -27,6 +29,7 @@
  *   sortingFns
  *   rowStyle:       ordered condition→className rules (compiles to rowClassName)
  *   permission:     FeaturePermission gate { feature, defaultAccess?, operation? }
+ *   expandable:     row-detail panel spec (compiles to ExpandableConfig)
  */
 
 import { z } from 'zod'
@@ -272,6 +275,37 @@ const permissionSchema = z.object({
 })
 
 // ---------------------------------------------------------------------------
+// expandable — declarative row-detail panel spec.
+//
+// The two stable factory shapes are data-describable, so a serializable spec
+// can carry them and the loader compiles each back into an ExpandableConfig
+// (see compileExpandable). A discriminated union on `type` keeps room for the
+// `panel` (createExpandedPanel sections) variant as a follow-up.
+//
+//   config-details — createConfigExpandedDetails({ primaryColumns, descriptionKey }):
+//     an auto-grid of every row column NOT already in `primaryColumns`.
+//
+// Inline-JSX expandables (bespoke React per row, e.g. running-queries,
+// keeper-connections, readonly-tables) remain TS-only — genuinely not
+// serializable — and stay excluded.
+// ---------------------------------------------------------------------------
+
+const expandableConfigDetailsSchema = z.object({
+  type: z.literal('config-details'),
+  // Columns already shown in the table; skipped in the detail grid so the
+  // panel only adds new information. Mirrors CreateConfigExpandedDetailsOptions.
+  primaryColumns: z.array(z.string().min(1)).optional(),
+  // Column holding a long description to render as prose (default: description).
+  descriptionKey: z.string().min(1).optional(),
+})
+
+const expandableSpecSchema = z.discriminatedUnion('type', [
+  expandableConfigDetailsSchema,
+])
+
+export type DeclarativeExpandableSpec = z.infer<typeof expandableSpecSchema>
+
+// ---------------------------------------------------------------------------
 // Main declarative schema
 // ---------------------------------------------------------------------------
 
@@ -344,10 +378,15 @@ export const declarativeQueryConfigSchema = z.object({
   // Feature-permission gate (plain data; loader casts to FeaturePermission)
   permission: permissionSchema.optional(),
 
+  // Row-detail panel — declarative spec compiled into an ExpandableConfig by
+  // the loader (config-details variant; inline-JSX expandables stay TS-only).
+  expandable: expandableSpecSchema.optional(),
+
   // Intentionally excluded (not serializable — require runtime code):
   //   columnIcons     — React component refs
   //   rowClassName    — function (row) => string (use declarative rowStyle)
-  //   expandable      — function (row, ctx) => ReactNode
+  //   filterSchema    — FilterField.icon / dynamic-option fns
+  //   inline-JSX expandable — bespoke React per row (use a TS config)
   //   variants        — deprecated; use versioned sql[] instead
 })
 


### PR DESCRIPTION
## What
Makes the factory-based `expandable` row-detail panel **declaratively expressible**, and migrates the two configs it fully unblocks (`settings`, `users`) into the declarative catalog.

`expandable` was the last *common* blocker keeping configs TS-only. Both factory shapes (`createConfigExpandedDetails({primaryColumns})`, `createExpandedPanel({sections})`) take fully data-describable args — only inline-JSX expandables are genuinely non-serializable.

This PR ships the **`config-details` variant** (simplest: `primaryColumns` + optional `descriptionKey`) and migrates `settings` + `users`. The `panel` variant (sections + icon-name registry) is a clean follow-up; the 3 inline-JSX configs (running-queries, keeper-connections, readonly-tables) stay TS-only by design.

## Design
- **`schema.ts`** — `expandable` as a `z.discriminatedUnion('type', [...])` with the `config-details` member (room for `panel` later).
- **`expandable.ts`** (new) — `compileExpandable(spec) → ExpandableConfig`, binding `createConfigExpandedDetails`. Mirrors `row-style.ts`/`compileRowStyle`. Lives next to the loader (not in `schema.ts`) so the `.tsx` factory import stays out of the pure schema module. Throws loud on an unknown `type`.
- **`loader.ts`** — threads `expandable` through `compileExpandable`.
- **`catalog/more/{settings,users}.ts`** + index registration.

The loader importing a component factory is consistent with the codebase: **25 `lib/` files already import `@/components/`**, and depcruise has no `lib`→`components` prohibition. This was the coupling concern earlier sessions flagged — it's resolved empirically.

## Why bundle-neutral
The legacy `settings.ts`/`users.ts` already import the same `config-expanded-details.tsx` factory into the shipped TS registry, so the loader's new import edge points at an already-bundled module — no net-new code. The declarative catalog stays dormant behind `CHM_CONFIG_SOURCE=ts` (default).

## How verified
- `bun test declarative/` → **281 pass / 0 fail**: `settings`/`users` serializable fields deep-equal legacy; a **behavioral** test asserts the compiled `renderExpanded` binds the same factory (element `.type` identity) + same `primaryColumns` as the legacy config; `compileExpandable` unit tests incl. throw-on-unknown-type.
- `biome check` clean; `tsc` (src + `tsconfig.test.json`) clean.
- **`bun run build` EXIT=0** — all routes prerendered, zero TS errors. (Caught + fixed a missing required `optional` field before pushing.)
- Worker dry-run: gzip **~1.84 MiB**, no size warning.

## Scope
- In: declarative schema/loader/catalog for `expandable` config-details + `settings`/`users`.
- Out (deferred, noted): `panel` variant (sections); `expensive-queries` (also blocked by `columnIcons`); inline-JSX expandables (stay TS-only).

## Guardrails
- [x] Scope respected
- [x] bun run build green (types + build + prerender)
- [x] biome clean
- [x] tests green (281)
- [x] No UI render change (dormant behind flag) → visual-verify N/A
- [x] Backward compatible / behind flag (CHM_CONFIG_SOURCE=ts default)
- [x] Co-Authored-By: duyetbot <bot@duyet.net>

Plan: cowork/plans/02-externalize-query-configs.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Settings dashboard view with filterable system settings and expandable row details.
  * Added Users dashboard view with system user information and expandable rows revealing additional host/role restriction data.
  * Implemented expandable row functionality that displays additional configuration details in a dedicated panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->