### PR TITLE
fix(charts): degrade optional chart with missing table to empty 200

### DIFF
--- a/apps/dashboard/src/routes/api/v1/charts/$name.ts
+++ b/apps/dashboard/src/routes/api/v1/charts/$name.ts
@@ -21,244 +21,282 @@ import {
 } from '@/lib/api/query-executor'
 import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 
+/**
+ * GET handler for `/api/v1/charts/$name`, extracted as a named export so it can
+ * be unit-tested without the router. {@link Route} below delegates to it.
+ */
+export async function handler(
+  request: Request,
+  name: string
+): Promise<Response> {
+  const bindings = env as Record<string, string | undefined>
+  const { searchParams } = new URL(request.url)
+
+  // Validate hostId
+  const hostIdStr = searchParams.get('hostId') ?? '0'
+  const hostId = Number(hostIdStr)
+  if (!Number.isFinite(hostId)) {
+    return Response.json(
+      {
+        success: false,
+        error: { type: 'validation', message: 'Invalid hostId' },
+      },
+      { status: 400 }
+    )
+  }
+
+  // Check if chart exists
+  if (!hasChart(name)) {
+    return Response.json(
+      {
+        success: false,
+        error: {
+          type: 'table_not_found',
+          message: `Chart not found: ${name}`,
+          details: { availableCharts: getAvailableCharts().join(', ') },
+        },
+      },
+      { status: 404 }
+    )
+  }
+
+  // Parse query parameters
+  const intervalParam = searchParams.get('interval')
+  const interval =
+    intervalParam && isValidInterval(intervalParam) ? intervalParam : undefined
+
+  const lastHoursParam = searchParams.get('lastHours')
+  const lastHoursParsed = lastHoursParam ? Number(lastHoursParam) : undefined
+  const lastHours =
+    lastHoursParsed !== undefined &&
+    Number.isFinite(lastHoursParsed) &&
+    lastHoursParsed > 0
+      ? lastHoursParsed
+      : undefined
+
+  const paramStr = searchParams.get('params')
+  let chartParams: Record<string, unknown> | undefined
+  if (paramStr) {
+    try {
+      const parsed: unknown = JSON.parse(paramStr)
+      if (
+        parsed !== null &&
+        typeof parsed === 'object' &&
+        !Array.isArray(parsed)
+      ) {
+        chartParams = parsed as Record<string, unknown>
+      }
+    } catch {
+      // Ignore invalid params JSON
+    }
+  }
+
+  // Validate timezone
+  const timezoneParam = searchParams.get('timezone') || undefined
+  let timezone: string | undefined
+  if (timezoneParam) {
+    try {
+      new Intl.DateTimeFormat('en-US', {
+        timeZone: timezoneParam,
+      }).format(new Date())
+      timezone = timezoneParam
+    } catch {
+      // Invalid timezone, ignore
+    }
+  }
+
+  // Get chart query definition
+  const queryDef = getChartQuery(name, {
+    interval,
+    lastHours,
+    params: chartParams,
+  })
+
+  if (!queryDef) {
+    error(`[GET /api/v1/charts/${name}] Failed to build query`)
+    return Response.json(
+      {
+        success: false,
+        error: {
+          type: 'query_error',
+          message: `Failed to build query for chart: ${name}`,
+        },
+      },
+      { status: 500 }
+    )
+  }
+
+  // Enforce the chart's deployment-level feature gate (e.g. system
+  // metric charts carry METRICS_PERMISSION). Without this, direct
+  // requests like /api/v1/charts/memory-usage would bypass
+  // CHM_DISABLED_FEATURES / CHM_AUTH_REQUIRED_FEATURES. Matches the
+  // dashboard chart route.
+  const permissionResponse = await authorizeFeatureRequest(
+    queryDef.permission,
+    request
+  )
+  if (permissionResponse) return permissionResponse
+
+  try {
+    // Multi-query chart (summary charts)
+    if ('queries' in queryDef) {
+      const { results } = await executeMultiChartQuery(
+        queryDef.queries.map((q) => ({ key: q.key, query: q.query })),
+        hostId,
+        { bindings, timezone }
+      )
+
+      const combinedEntries: string[] = []
+      let firstError: { type: string; message: string } | undefined
+      for (const r of results) {
+        combinedEntries.push(`${JSON.stringify(r.key)}:${r.dataJson ?? 'null'}`)
+        if (r.error && !firstError) {
+          firstError = { type: 'query_error', message: r.error.message }
+        }
+      }
+
+      const metadata = {
+        queryId: '',
+        duration: 0,
+        rows: 0,
+        host: String(hostId),
+        sql: queryDef.queries
+          .map((q, i) => `-- Query ${i + 1}: ${q.key}\n${q.query.trim()}`)
+          .join('\n\n'),
+        timezone,
+      }
+
+      const errorJson = firstError
+        ? `,"error":${JSON.stringify(firstError)}`
+        : ''
+      const body = `{"success":${String(!firstError)},"data":{${combinedEntries.join(',')}},"metadata":${JSON.stringify(metadata)}${errorJson}}`
+
+      return new Response(body, {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    // Single-query chart
+    const result = await executeChartQuery(
+      name,
+      queryDef.sql ?? queryDef.query,
+      hostId,
+      queryDef.queryParams,
+      {
+        bindings,
+        timezone,
+        optional: queryDef.optional,
+        tableCheck: queryDef.tableCheck,
+      }
+    )
+
+    // Graceful degradation: an *optional* chart whose backing table is absent
+    // is not a server error — the data layer signals this with a benign
+    // `table_not_found`. Returning 200 with empty data (plus an `unavailable`
+    // note) lets the panel render its "not available" empty state instead of a
+    // red error, and stops use-chart-data from retrying the 500 three times.
+    if (
+      result.error &&
+      queryDef.optional &&
+      result.error.type === 'table_not_found'
+    ) {
+      const missingTables = Array.isArray(result.error.details?.missingTables)
+        ? result.error.details.missingTables
+        : []
+      const body = JSON.stringify({
+        success: true,
+        data: [],
+        metadata: {
+          queryId: '',
+          duration: 0,
+          rows: 0,
+          host: String(hostId),
+          unavailable: {
+            reason: 'table_not_found',
+            message: result.error.message,
+            missingTables,
+          },
+        },
+      })
+      return new Response(body, {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120',
+        },
+      })
+    }
+
+    if (result.error) {
+      return Response.json(
+        {
+          success: false,
+          error: {
+            type: 'query_error',
+            message: result.error.message,
+            details: result.error.details,
+          },
+        },
+        { status: 500 }
+      )
+    }
+
+    // Build API URL for metadata
+    const apiQueryParams = new URLSearchParams()
+    apiQueryParams.set('hostId', String(hostId))
+    if (interval) apiQueryParams.set('interval', interval)
+    if (lastHours !== undefined)
+      apiQueryParams.set('lastHours', String(lastHours))
+    if (chartParams) apiQueryParams.set('params', JSON.stringify(chartParams))
+    if (timezone) apiQueryParams.set('timezone', timezone)
+
+    const responseMetadata = {
+      queryId: String(result.metadata.queryId || ''),
+      duration: Number(result.metadata.duration || 0),
+      rows: Number(result.metadata.rows || 0),
+      host: String(hostId),
+      sql: result.executedSql.trim(),
+      clickhouseVersion: result.clickhouseVersion,
+      api: `/api/v1/charts/${name}?${apiQueryParams.toString()}`,
+      timezone,
+    }
+
+    const body = `{"success":true,"data":${result.dataJson ?? '[]'},"metadata":${JSON.stringify(responseMetadata)}}`
+
+    const cacheControl =
+      queryDef.cachePolicy === 'realtime'
+        ? 'public, s-maxage=10, stale-while-revalidate=30'
+        : queryDef.cachePolicy === 'historical'
+          ? 'public, s-maxage=120, stale-while-revalidate=300'
+          : 'public, s-maxage=30, stale-while-revalidate=60'
+
+    return new Response(body, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': cacheControl,
+      },
+    })
+  } catch (err) {
+    error(`[GET /api/v1/charts/${name}] Unhandled exception:`, err)
+    return Response.json(
+      {
+        success: false,
+        error: {
+          type: 'query_error',
+          message: err instanceof Error ? err.message : 'Unknown error',
+        },
+      },
+      { status: 500 }
+    )
+  }
+}
+
 export const Route = createFileRoute('/api/v1/charts/$name')({
   server: {
     handlers: {
-      GET: async ({ request, params }) => {
-        const { name } = params
-        const bindings = env as Record<string, string | undefined>
-        const { searchParams } = new URL(request.url)
-
-        // Validate hostId
-        const hostIdStr = searchParams.get('hostId') ?? '0'
-        const hostId = Number(hostIdStr)
-        if (!Number.isFinite(hostId)) {
-          return Response.json(
-            {
-              success: false,
-              error: { type: 'validation', message: 'Invalid hostId' },
-            },
-            { status: 400 }
-          )
-        }
-
-        // Check if chart exists
-        if (!hasChart(name)) {
-          return Response.json(
-            {
-              success: false,
-              error: {
-                type: 'table_not_found',
-                message: `Chart not found: ${name}`,
-                details: { availableCharts: getAvailableCharts().join(', ') },
-              },
-            },
-            { status: 404 }
-          )
-        }
-
-        // Parse query parameters
-        const intervalParam = searchParams.get('interval')
-        const interval =
-          intervalParam && isValidInterval(intervalParam)
-            ? intervalParam
-            : undefined
-
-        const lastHoursParam = searchParams.get('lastHours')
-        const lastHoursParsed = lastHoursParam
-          ? Number(lastHoursParam)
-          : undefined
-        const lastHours =
-          lastHoursParsed !== undefined &&
-          Number.isFinite(lastHoursParsed) &&
-          lastHoursParsed > 0
-            ? lastHoursParsed
-            : undefined
-
-        const paramStr = searchParams.get('params')
-        let chartParams: Record<string, unknown> | undefined
-        if (paramStr) {
-          try {
-            const parsed: unknown = JSON.parse(paramStr)
-            if (
-              parsed !== null &&
-              typeof parsed === 'object' &&
-              !Array.isArray(parsed)
-            ) {
-              chartParams = parsed as Record<string, unknown>
-            }
-          } catch {
-            // Ignore invalid params JSON
-          }
-        }
-
-        // Validate timezone
-        const timezoneParam = searchParams.get('timezone') || undefined
-        let timezone: string | undefined
-        if (timezoneParam) {
-          try {
-            new Intl.DateTimeFormat('en-US', {
-              timeZone: timezoneParam,
-            }).format(new Date())
-            timezone = timezoneParam
-          } catch {
-            // Invalid timezone, ignore
-          }
-        }
-
-        // Get chart query definition
-        const queryDef = getChartQuery(name, {
-          interval,
-          lastHours,
-          params: chartParams,
-        })
-
-        if (!queryDef) {
-          error(`[GET /api/v1/charts/${name}] Failed to build query`)
-          return Response.json(
-            {
-              success: false,
-              error: {
-                type: 'query_error',
-                message: `Failed to build query for chart: ${name}`,
-              },
-            },
-            { status: 500 }
-          )
-        }
-
-        // Enforce the chart's deployment-level feature gate (e.g. system
-        // metric charts carry METRICS_PERMISSION). Without this, direct
-        // requests like /api/v1/charts/memory-usage would bypass
-        // CHM_DISABLED_FEATURES / CHM_AUTH_REQUIRED_FEATURES. Matches the
-        // dashboard chart route.
-        const permissionResponse = await authorizeFeatureRequest(
-          queryDef.permission,
-          request
-        )
-        if (permissionResponse) return permissionResponse
-
-        try {
-          // Multi-query chart (summary charts)
-          if ('queries' in queryDef) {
-            const { results } = await executeMultiChartQuery(
-              queryDef.queries.map((q) => ({ key: q.key, query: q.query })),
-              hostId,
-              { bindings, timezone }
-            )
-
-            const combinedEntries: string[] = []
-            let firstError: { type: string; message: string } | undefined
-            for (const r of results) {
-              combinedEntries.push(
-                `${JSON.stringify(r.key)}:${r.dataJson ?? 'null'}`
-              )
-              if (r.error && !firstError) {
-                firstError = { type: 'query_error', message: r.error.message }
-              }
-            }
-
-            const metadata = {
-              queryId: '',
-              duration: 0,
-              rows: 0,
-              host: String(hostId),
-              sql: queryDef.queries
-                .map((q, i) => `-- Query ${i + 1}: ${q.key}\n${q.query.trim()}`)
-                .join('\n\n'),
-              timezone,
-            }
-
-            const errorJson = firstError
-              ? `,"error":${JSON.stringify(firstError)}`
-              : ''
-            const body = `{"success":${String(!firstError)},"data":{${combinedEntries.join(',')}},"metadata":${JSON.stringify(metadata)}${errorJson}}`
-
-            return new Response(body, {
-              status: 200,
-              headers: { 'Content-Type': 'application/json' },
-            })
-          }
-
-          // Single-query chart
-          const result = await executeChartQuery(
-            name,
-            queryDef.sql ?? queryDef.query,
-            hostId,
-            queryDef.queryParams,
-            {
-              bindings,
-              timezone,
-              optional: queryDef.optional,
-              tableCheck: queryDef.tableCheck,
-            }
-          )
-
-          if (result.error) {
-            return Response.json(
-              {
-                success: false,
-                error: {
-                  type: 'query_error',
-                  message: result.error.message,
-                  details: result.error.details,
-                },
-              },
-              { status: 500 }
-            )
-          }
-
-          // Build API URL for metadata
-          const apiQueryParams = new URLSearchParams()
-          apiQueryParams.set('hostId', String(hostId))
-          if (interval) apiQueryParams.set('interval', interval)
-          if (lastHours !== undefined)
-            apiQueryParams.set('lastHours', String(lastHours))
-          if (chartParams)
-            apiQueryParams.set('params', JSON.stringify(chartParams))
-          if (timezone) apiQueryParams.set('timezone', timezone)
-
-          const responseMetadata = {
-            queryId: String(result.metadata.queryId || ''),
-            duration: Number(result.metadata.duration || 0),
-            rows: Number(result.metadata.rows || 0),
-            host: String(hostId),
-            sql: result.executedSql.trim(),
-            clickhouseVersion: result.clickhouseVersion,
-            api: `/api/v1/charts/${name}?${apiQueryParams.toString()}`,
-            timezone,
-          }
-
-          const body = `{"success":true,"data":${result.dataJson ?? '[]'},"metadata":${JSON.stringify(responseMetadata)}}`
-
-          const cacheControl =
-            queryDef.cachePolicy === 'realtime'
-              ? 'public, s-maxage=10, stale-while-revalidate=30'
-              : queryDef.cachePolicy === 'historical'
-                ? 'public, s-maxage=120, stale-while-revalidate=300'
-                : 'public, s-maxage=30, stale-while-revalidate=60'
-
-          return new Response(body, {
-            status: 200,
-            headers: {
-              'Content-Type': 'application/json',
-              'Cache-Control': cacheControl,
-            },
-          })
-        } catch (err) {
-          error(`[GET /api/v1/charts/${name}] Unhandled exception:`, err)
-          return Response.json(
-            {
-              success: false,
-              error: {
-                type: 'query_error',
-                message: err instanceof Error ? err.message : 'Unknown error',
-              },
-            },
-            { status: 500 }
-          )
-        }
-      },
+      GET: ({ request, params }) => handler(request, params.name),
     },
   },
 })

--- a/apps/dashboard/src/routes/api/v1/charts/__tests__/name.test.ts
+++ b/apps/dashboard/src/routes/api/v1/charts/__tests__/name.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for the GET /api/v1/charts/$name handler, focused on graceful
+ * degradation when an *optional* chart's backing table is missing.
+ *
+ * Regression for the production bug where the overview page fired hard 500s
+ * (and use-chart-data retried each 3x) for charts like `thread-utilization`
+ * whenever `system.query_thread_log` was disabled on the target ClickHouse.
+ */
+
+import type { FetchDataError } from '@chm/clickhouse-client'
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+mock.module('cloudflare:workers', () => ({
+  env: {
+    CLICKHOUSE_HOST: 'http://localhost:8123',
+    CLICKHOUSE_USER: 'default',
+    CLICKHOUSE_PASSWORD: '',
+  },
+}))
+
+// Feature gate always allows in these tests.
+mock.module('@/lib/feature-permissions/server', () => ({
+  authorizeFeatureRequest: async () => null,
+}))
+
+// Controllable chart registry: an optional chart and a non-optional one. Spread
+// the real module first so other named exports (registerChartQuery, ...) survive
+// bun's global module mock.
+import * as realRegistry from '@/lib/api/chart-registry'
+
+mock.module('@/lib/api/chart-registry', () => ({
+  ...realRegistry,
+  hasChart: (n: string) => n === 'opt-chart' || n === 'plain-chart',
+  getAvailableCharts: () => ['opt-chart', 'plain-chart'],
+  getChartQuery: (n: string) =>
+    n === 'opt-chart'
+      ? {
+          query: 'SELECT 1 FROM system.query_thread_log',
+          optional: true,
+          tableCheck: 'system.query_thread_log',
+        }
+      : { query: 'SELECT 1', optional: false },
+}))
+
+// Controllable executor: real exports preserved, executeChartQuery overridden.
+import * as realExecutor from '@/lib/api/query-executor'
+
+const mockExecuteChartQuery = mock(
+  async (): Promise<{
+    dataJson: string | null
+    metadata: Record<string, string | number>
+    error?: FetchDataError
+    executedSql: string
+    clickhouseVersion: string | null
+  }> => ({
+    dataJson: '[]',
+    metadata: {},
+    error: undefined,
+    executedSql: 'SELECT 1',
+    clickhouseVersion: null,
+  })
+)
+mock.module('@/lib/api/query-executor', () => ({
+  ...realExecutor,
+  executeChartQuery: mockExecuteChartQuery,
+}))
+
+const tableNotFound: FetchDataError = {
+  type: 'table_not_found',
+  message: 'Missing required tables: system.query_thread_log',
+  details: { missingTables: ['system.query_thread_log'] },
+}
+
+const realQueryError: FetchDataError = {
+  type: 'query_error',
+  message:
+    '(total) memory limit exceeded: would use 1.35 GiB ... MEMORY_LIMIT_EXCEEDED',
+}
+
+async function call(name: string): Promise<Response> {
+  const { handler } = await import('../$name')
+  return handler(
+    new Request(`http://localhost/api/v1/charts/${name}?hostId=0`),
+    name
+  )
+}
+
+describe('GET /api/v1/charts/$name — optional table degradation', () => {
+  beforeEach(() => {
+    mockExecuteChartQuery.mockClear()
+  })
+
+  test('optional chart with missing table → 200 empty + unavailable note (not 500)', async () => {
+    mockExecuteChartQuery.mockResolvedValueOnce({
+      dataJson: null,
+      metadata: {},
+      error: tableNotFound,
+      executedSql: 'SELECT 1 FROM system.query_thread_log',
+      clickhouseVersion: null,
+    })
+
+    const response = await call('opt-chart')
+    expect(response.status).toBe(200)
+
+    const body = (await response.json()) as {
+      success: boolean
+      data: unknown[]
+      metadata: {
+        unavailable?: { reason: string; missingTables: string[] }
+      }
+    }
+    expect(body.success).toBe(true)
+    expect(body.data).toEqual([])
+    expect(body.metadata.unavailable?.reason).toBe('table_not_found')
+    expect(body.metadata.unavailable?.missingTables).toContain(
+      'system.query_thread_log'
+    )
+  })
+
+  test('optional chart with a REAL query error still → 500 (errors not swallowed)', async () => {
+    mockExecuteChartQuery.mockResolvedValueOnce({
+      dataJson: null,
+      metadata: {},
+      error: realQueryError,
+      executedSql: 'SELECT 1',
+      clickhouseVersion: null,
+    })
+
+    const response = await call('opt-chart')
+    expect(response.status).toBe(500)
+
+    const body = (await response.json()) as {
+      success: boolean
+      error: { type: string; message: string }
+    }
+    expect(body.success).toBe(false)
+    expect(body.error.type).toBe('query_error')
+  })
+
+  test('non-optional chart with table_not_found is NOT degraded → 500', async () => {
+    mockExecuteChartQuery.mockResolvedValueOnce({
+      dataJson: null,
+      metadata: {},
+      error: tableNotFound,
+      executedSql: 'SELECT 1',
+      clickhouseVersion: null,
+    })
+
+    const response = await call('plain-chart')
+    expect(response.status).toBe(500)
+  })
+
+  test('healthy optional chart returns data normally → 200', async () => {
+    mockExecuteChartQuery.mockResolvedValueOnce({
+      dataJson: '[{"x":1}]',
+      metadata: { rows: 1, duration: 5 },
+      error: undefined,
+      executedSql: 'SELECT 1 FROM system.query_thread_log',
+      clickhouseVersion: '24.1',
+    })
+
+    const response = await call('opt-chart')
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      success: boolean
+      data: { x: number }[]
+    }
+    expect(body.success).toBe(true)
+    expect(body.data).toEqual([{ x: 1 }])
+  })
+
+  test('unknown chart → 404', async () => {
+    const response = await call('does-not-exist')
+    expect(response.status).toBe(404)
+  })
+})


### PR DESCRIPTION
## Problem (found via live prod audit)

Auditing the live overview page (`dash.chmonitor.dev/overview?host=0`) with Chrome DevTools showed **dozens of console 500s** dragging the Lighthouse Best-Practices score and breaking panels. Network capture isolated the cause:

- `GET /api/v1/charts/thread-utilization` → **500** `Missing required tables: system.query_thread_log`

`thread-utilization` is already correctly marked `optional: true` + `tableCheck`. The data layer (`clickhouse-fetch.ts`) returns a **benign, structured `table_not_found`** for this case — the intent being "gracefully skip". But the route handler (`/api/v1/charts/$name`) collapsed *any* `result.error` into a hard **500**, defeating that path. Worse, `use-chart-data` retries 500s **3×**, so one disabled table produced ~4 failed requests per refresh and a red error panel instead of a friendly "not available" state.

## Fix

When an **optional** chart's error is `table_not_found`, return **200** with empty `data` and an `unavailable` metadata note, so the panel renders its empty/"not available" state and the client stops retrying. **Real** query errors (e.g. `MEMORY_LIMIT_EXCEEDED`) still surface as 500.

Extracted the GET logic into a testable `handler` export (mirrors the `menu-counts` route).

## Tests

`src/routes/api/v1/charts/__tests__/name.test.ts` — 5 cases:
- optional + missing table → 200 empty + `unavailable` note ✅
- optional + real query error → still 500 (errors not swallowed) ✅
- non-optional + table_not_found → 500 (guard) ✅
- healthy optional chart → 200 with data ✅
- unknown chart → 404 ✅

Verified locally: `bun test src/routes/api src/lib/api` → 440 pass, 0 fail (no mock contamination).

Co-Authored-By: duyetbot <bot@duyet.net>