### PR TITLE
fix(shell): resolve app-shell Lighthouse a11y failures

### DIFF
--- a/apps/dashboard/src/components/controls/command-palette.tsx
+++ b/apps/dashboard/src/components/controls/command-palette.tsx
@@ -120,8 +120,6 @@ export const CommandPalette = function CommandPalette({
         type="button"
         onClick={() => setOpen(true)}
         className="relative hidden h-8 w-30 items-center gap-2 rounded-md border bg-muted/30 px-2.5 text-xs transition-[border-color,box-shadow,background-color] hover:bg-muted/50 hover:ring-1 hover:ring-primary/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/30 md:inline-flex md:w-40"
-        aria-label="Search pages and commands"
-        aria-describedby="search-shortcut"
       >
         <Search
           aria-hidden="true"

--- a/apps/dashboard/src/components/host/host-switcher.tsx
+++ b/apps/dashboard/src/components/host/host-switcher.tsx
@@ -99,40 +99,33 @@ export function HostSwitcher() {
               <DropdownMenuTrigger asChild>
                 <SidebarMenuButton
                   size="lg"
-                  className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+                  className={cn(
+                    'data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground',
+                    !showExpanded && 'justify-center'
+                  )}
                   data-testid="host-switcher-empty"
                   aria-label={label}
-                  asChild
                 >
-                  <div
-                    className={cn(
-                      'flex gap-2',
-                      showExpanded
-                        ? 'items-center'
-                        : 'items-center justify-center'
-                    )}
-                  >
-                    <div className="relative">
-                      <ChmonitorLogo
-                        width={20}
-                        height={20}
-                        className="size-5 opacity-50"
-                      />
-                    </div>
-                    {showExpanded && (
-                      <>
-                        <div className="grid flex-1 text-left text-sm leading-tight">
-                          <span className="truncate font-medium text-muted-foreground">
-                            {label}
-                          </span>
-                          <span className="truncate text-xs text-muted-foreground/70">
-                            {hint}
-                          </span>
-                        </div>
-                        <ChevronsUpDown className="ml-auto size-4" />
-                      </>
-                    )}
+                  <div className="relative">
+                    <ChmonitorLogo
+                      width={20}
+                      height={20}
+                      className="size-5 opacity-50"
+                    />
                   </div>
+                  {showExpanded && (
+                    <>
+                      <div className="grid flex-1 text-left text-sm leading-tight">
+                        <span className="truncate font-medium text-muted-foreground">
+                          {label}
+                        </span>
+                        <span className="truncate text-xs text-muted-foreground/70">
+                          {hint}
+                        </span>
+                      </div>
+                      <ChevronsUpDown className="ml-auto size-4" />
+                    </>
+                  )}
                 </SidebarMenuButton>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start" sideOffset={4}>
@@ -163,49 +156,38 @@ export function HostSwitcher() {
               <DropdownMenuTrigger asChild>
                 <SidebarMenuButton
                   size="lg"
-                  className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+                  className={cn(
+                    'data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground',
+                    !showExpanded && 'justify-center'
+                  )}
                   data-testid="host-switcher"
                   aria-label={`Select ClickHouse host. Current: ${activeHost.name || getHost(activeHost.host)}`}
-                  asChild
                 >
-                  <div
-                    className={cn(
-                      'flex gap-2',
-                      showExpanded
-                        ? 'items-center'
-                        : 'items-center justify-center'
-                    )}
-                  >
-                    <div className="relative">
-                      <ChmonitorLogo
-                        width={20}
-                        height={20}
-                        className="size-5"
-                      />
-                      {!showExpanded && activeHost.source === 'env' && (
-                        <LogoStatusIndicator hostId={activeHost.id} />
-                      )}
-                    </div>
-                    {showExpanded && (
-                      <>
-                        <div className="grid flex-1 text-left text-sm leading-tight">
-                          <span className="truncate font-semibold">
-                            {activeHost.name || getHost(activeHost.host)}
-                          </span>
-                          {activeHost.source === 'env' ? (
-                            <HostVersionWithStatus hostId={activeHost.id} />
-                          ) : (
-                            <span className="truncate text-xs text-muted-foreground">
-                              {activeHost.source === 'database'
-                                ? 'Saved to server'
-                                : 'Saved in browser'}
-                            </span>
-                          )}
-                        </div>
-                        <ChevronsUpDown className="ml-auto size-4" />
-                      </>
+                  <div className="relative">
+                    <ChmonitorLogo width={20} height={20} className="size-5" />
+                    {!showExpanded && activeHost.source === 'env' && (
+                      <LogoStatusIndicator hostId={activeHost.id} />
                     )}
                   </div>
+                  {showExpanded && (
+                    <>
+                      <div className="grid flex-1 text-left text-sm leading-tight">
+                        <span className="truncate font-semibold">
+                          {activeHost.name || getHost(activeHost.host)}
+                        </span>
+                        {activeHost.source === 'env' ? (
+                          <HostVersionWithStatus hostId={activeHost.id} />
+                        ) : (
+                          <span className="truncate text-xs text-muted-foreground">
+                            {activeHost.source === 'database'
+                              ? 'Saved to server'
+                              : 'Saved in browser'}
+                          </span>
+                        )}
+                      </div>
+                      <ChevronsUpDown className="ml-auto size-4" />
+                    </>
+                  )}
                 </SidebarMenuButton>
               </DropdownMenuTrigger>
               <DropdownMenuContent

--- a/apps/dashboard/src/components/layout/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/layout/dashboard-shell.tsx
@@ -27,6 +27,12 @@ import { Toaster } from '@/components/ui/sonner'
 export function DashboardShell({ children }: { children: React.ReactNode }) {
   return (
     <>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        Skip to main content
+      </a>
       <Suspense fallback={null}>
         <DynamicTitle />
       </Suspense>
@@ -49,7 +55,11 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
               <HeaderActions />
             </div>
           </header>
-          <div className="flex min-w-0 flex-1 flex-col gap-3 overflow-y-auto p-3 pt-0 sm:gap-4 sm:p-4 sm:pt-0">
+          <div
+            id="main-content"
+            tabIndex={-1}
+            className="flex min-w-0 flex-1 flex-col gap-3 overflow-y-auto p-3 pt-0 outline-none sm:gap-4 sm:p-4 sm:pt-0"
+          >
             {children}
           </div>
         </SidebarInset>


### PR DESCRIPTION
## Measured baseline
Live-prod Lighthouse on `/overview` scored **Accessibility 88**. This PR fixes the three scored failures in the app shell. (The remaining `target-size` failure is the 11px query-heatmap cells — a deliberate calendar-heatmap density tradeoff, like GitHub's contribution graph — handled separately.)

## Fixes
1. **`aria-allowed-attr`** (weight 10 — the single biggest lever on the score, 1 element): the host switcher nested `DropdownMenuTrigger asChild` → `SidebarMenuButton asChild` → `<div>`, so Radix merged `aria-haspopup`/`aria-expanded` onto a `<div>` (implicit role `generic`, which disallows them) — and the trigger wasn't even a real `<button>`. Dropped the inner `asChild` + wrapper `<div>` so `SidebarMenuButton` renders a real button. The base variant already supplies `flex/gap/items-center`; only `justify-center` (collapsed) is re-added. Both trigger branches fixed.
2. **`label-content-name-mismatch`**: the command-palette search button's `aria-label="Search pages and commands"` didn't contain its visible "Search…" text (WCAG 2.5.3 Label in Name). Removed the override so the accessible name derives from visible content.
3. **Skip link**: added a "Skip to main content" link as the first focusable element + a focusable `#main-content` target (P1 from the navigation audit).

## Verification
- Biome clean on all 3 files; no existing host-switcher/command-palette tests to regress.
- Layout preserved (base `SidebarMenuButton` flex classes cover the removed wrapper).
- **Post-deploy**: will re-run Lighthouse on prod to confirm Accessibility climbs from 88.

Co-Authored-By: duyetbot <bot@duyet.net>