### PR TITLE
fix(charts): stop disks-usage query OOM by pre-filtering metrics

### DIFF
--- a/apps/dashboard/src/lib/api/__tests__/charts/system-charts.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/charts/system-charts.test.ts
@@ -57,5 +57,25 @@ describe('systemCharts', () => {
         }
       })
     }
+
+    if (name === 'disks-usage') {
+      // Regression: the chart used to sumMap() over every async metric for
+      // 30 days, materializing a hundreds-of-keys map per group and OOMing
+      // small instances (MEMORY_LIMIT_EXCEEDED). The query must pre-filter to
+      // only the two disk metrics it actually reads, before aggregation.
+      test('pre-filters to the two disk metrics before aggregating', () => {
+        const result = builder({ interval: 'toStartOfDay', lastHours: 720 })
+        if ('query' in result) {
+          expect(result.query).toContain('metric IN (')
+          expect(result.query).toContain('DiskAvailable_default')
+          expect(result.query).toContain('DiskUsed_default')
+          // The metric filter must precede GROUP BY (cuts rows + map width).
+          const whereIdx = result.query.indexOf('metric IN (')
+          const groupIdx = result.query.indexOf('GROUP BY')
+          expect(whereIdx).toBeGreaterThan(0)
+          expect(whereIdx).toBeLessThan(groupIdx)
+        }
+      })
+    }
   })
 })

--- a/apps/dashboard/src/lib/api/charts/system-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/system-charts.ts
@@ -85,7 +85,8 @@ export const systemCharts: Record<string, ChartQueryBuilder> = {
         formatReadableSize(DiskAvailable_default) as readable_DiskAvailable_default,
         formatReadableSize(DiskUsed_default) as readable_DiskUsed_default
     FROM merge('system', '^asynchronous_metric_log')
-    ${timeFilter ? `WHERE ${timeFilter}` : ''}
+    WHERE metric IN ('DiskAvailable_default', 'DiskUsed_default')
+    ${timeFilter ? `AND ${timeFilter}` : ''}
     GROUP BY 1
     ORDER BY 1 ASC
   `,


### PR DESCRIPTION
## Problem (verified live on prod)
`GET /api/v1/charts/disks-usage?interval=toStartOfDay&lastHours=720` returns **500** with `MEMORY_LIMIT_EXCEEDED` (code 241) on the overview page:
```
(total) memory limit exceeded ... While executing AggregatingTransform
```
The query does `sumMap(map(metric, value))` over the **entire** `asynchronous_metric_log` for 30 days, materializing a map of *every* async metric (hundreds of keys, ~per-second samples) per group — while only ever reading two keys (`DiskAvailable_default`, `DiskUsed_default`).

## Fix
Add `WHERE metric IN ('DiskAvailable_default', 'DiskUsed_default')` before the aggregation. Collapses both the rows scanned and the map width to two keys.

**Behavior-preserving**: the query already read only those two keys, so output values are identical — just far cheaper to compute. No semantic change.

## Tests
`system-charts.test.ts` — asserts the metric pre-filter is present and precedes `GROUP BY`. 72 pass.

## Post-deploy verification
Will curl the prod endpoint after deploy to confirm 200 + data (same loop used for the thread-utilization fix). This was the last consistent 500 on the overview page's console.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disk usage chart accuracy by refining metric filtering to ensure correct data retrieval.

* **Tests**
  * Added regression test to verify disk usage chart query correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->