### PR TITLE
fix(conversation-store): widen AgentState list scan to keep older history

### DIFF
--- a/apps/dashboard/src/lib/conversation-store/agentstate-store.test.ts
+++ b/apps/dashboard/src/lib/conversation-store/agentstate-store.test.ts
@@ -480,6 +480,55 @@ describe('list', () => {
     expect(cursors[0]).toBeUndefined()
     expect(cursors[1]).toBe('cursor-2')
   })
+
+  test('still returns a user conversation buried under >500 newer ones from others (regression)', async () => {
+    // 6 pages of 100. Pages 1-5 are all from other users (500 conversations);
+    // the target user's conversations only appear on page 6. The previous
+    // 5-page (500-conversation) cap dropped them entirely.
+    const totalPages = 6
+    let page = 0
+    impl.listConversations = () => {
+      page += 1
+      const isLast = page === totalPages
+      const data = isLast
+        ? [
+            conv('mine-1', 'user-a', 'user-a:mine-1'),
+            conv('mine-2', 'user-a', 'user-a:mine-2'),
+          ]
+        : Array.from({ length: 100 }, (_, i) =>
+            conv(`other-${page}-${i}`, 'other', `other:other-${page}-${i}`)
+          )
+      return {
+        data,
+        pagination: {
+          limit: 100,
+          next_cursor: isLast ? null : `cursor-${page + 1}`,
+        },
+      }
+    }
+    const store = new AgentStateStore({ apiKey: 'k' })
+    const result = await store.list('user-a')
+    expect(result.map((r) => r.id)).toEqual(['mine-1', 'mine-2'])
+  })
+
+  test('bounds the scan so a never-matching user terminates (cap = 5000 scanned)', async () => {
+    let calls = 0
+    impl.listConversations = () => {
+      calls += 1
+      return {
+        data: Array.from({ length: 100 }, (_, i) =>
+          conv(`o-${calls}-${i}`, 'other', `other:o-${calls}-${i}`)
+        ),
+        // next_cursor never null: without the scan cap this would loop forever.
+        pagination: { limit: 100, next_cursor: `cursor-${calls + 1}` },
+      }
+    }
+    const store = new AgentStateStore({ apiKey: 'k' })
+    const result = await store.list('nobody')
+    expect(result).toEqual([])
+    // 5000 scan budget / 100 per page = 50 pages, then it stops.
+    expect(calls).toBe(50)
+  })
 })
 
 // ============================================================================

--- a/apps/dashboard/src/lib/conversation-store/agentstate-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/agentstate-store.ts
@@ -57,15 +57,31 @@ const GENERIC_TITLES = new Set([
 ])
 
 /**
- * Maximum number of list pages to scan when filtering by user. Bounds the work
- * done for users with many conversations while still returning a full page.
- */
-const MAX_LIST_PAGES = 5
-
-/**
  * Page size used when paginating AgentState's conversation list.
  */
 const LIST_PAGE_SIZE = 100
+
+/**
+ * Maximum number of conversations to scan across pages when filtering by user.
+ *
+ * AgentState's list endpoint has no server-side user filter, so {@link
+ * AgentStateStore.list} pages newest-first through the shared project and keeps
+ * client-side only the requesting user's conversations. The previous bound of 5
+ * pages (500 conversations) meant that once a shared project accumulated more
+ * than 500 newer conversations from other users, an inactive user's own older
+ * conversations fell outside the scan window and silently vanished from their
+ * history.
+ *
+ * Scanning by conversation count (not page count) and raising the budget keeps
+ * the common case cheap — for an active user, their `limit` conversations are
+ * collected from the first page or two and the loop exits early — while still
+ * covering realistically large shared projects. The cap remains a deliberate,
+ * bounded trade-off: a user whose oldest conversations sit beneath more than
+ * {@link MAX_LIST_SCAN} newer global conversations can still miss the tail. The
+ * proper long-term fix is a server-side per-user filter (absent from the SDK)
+ * or a per-user conversation index.
+ */
+const MAX_LIST_SCAN = 5000
 
 /**
  * Constructor options for {@link AgentStateStore}.
@@ -370,9 +386,11 @@ export class AgentStateStore implements ConversationStore {
    *
    * AgentState's list endpoint has no server-side tag/user filter, so this
    * pages through results (newest first) and keeps only conversations whose
-   * stored `metadata.userId` matches, for defensive isolation. Scanning is
-   * bounded by {@link MAX_LIST_PAGES} and stops early once `limit` matches are
-   * collected or pagination is exhausted.
+   * stored `metadata.userId` matches, for defensive isolation. Scanning stops
+   * early once `limit` of the user's conversations are collected or pagination
+   * is exhausted, and is bounded overall by {@link MAX_LIST_SCAN} conversations
+   * scanned (not pages) so an inactive user's older conversations are not
+   * dropped just because newer conversations from other users precede them.
    *
    * @param userId - User ID to scope queries
    * @param limit - Maximum number of conversations to return (default: 50)
@@ -382,9 +400,9 @@ export class AgentStateStore implements ConversationStore {
     try {
       const matches: ConversationMeta[] = []
       let cursor: string | undefined
-      let pages = 0
+      let scanned = 0
 
-      while (pages < MAX_LIST_PAGES && matches.length < limit) {
+      while (matches.length < limit && scanned < MAX_LIST_SCAN) {
         const response = await this.client.listConversations({
           order: 'desc',
           limit: LIST_PAGE_SIZE,
@@ -392,6 +410,7 @@ export class AgentStateStore implements ConversationStore {
         })
 
         for (const conv of response.data) {
+          scanned += 1
           const metadata = (conv.metadata ??
             {}) as Partial<StoredConversationMetadata>
           if (metadata.userId !== userId) {
@@ -404,7 +423,6 @@ export class AgentStateStore implements ConversationStore {
         }
 
         cursor = response.pagination.next_cursor ?? undefined
-        pages += 1
         if (!cursor) {
           break
         }


### PR DESCRIPTION
## Problem
`AgentStateStore.list()` pages newest-first through the **whole** shared AgentState project and filters by `metadata.userId` client-side (the SDK exposes no server-side user/tag filter — `listConversations` takes only `{limit, cursor, order}`). The previous `MAX_LIST_PAGES=5` (500 conversations) bound meant that once the shared project held >500 newer conversations from **other** users, an inactive user's own older conversations fell outside the scan window and silently disappeared from `/api/v1/conversations`.

PR #1731 routed production conversations to this backend, making the limitation live (originally raised as Codex P2 finding "E" on that PR).

## Fix
Bound the scan by conversations **scanned** (`MAX_LIST_SCAN=5000`) instead of a fixed 5 pages, keeping the early-exit once `limit` of the user's conversations are collected:
- Active users return from the first page or two (early-exit, unchanged cost).
- Inactive users no longer lose their tail under other users' newer activity.
- Bounded, documented trade-off — proper long-term fix is a server-side per-user filter (absent from SDK) or a per-user index.

## Tests
- Regression: a user buried under >500 newer conversations from others is still returned.
- Termination guarantee: scan stops at the 5000-conversation cap even when the user never matches and `next_cursor` never ends. (33 pass.)

Co-Authored-By: duyetbot <bot@duyet.net>