### PR TITLE
fix(ui): raise contrast on muted labels and the New badge (WCAG AA)

### DIFF
--- a/apps/dashboard/src/components/controls/command-palette.tsx
+++ b/apps/dashboard/src/components/controls/command-palette.tsx
@@ -121,11 +121,8 @@ export const CommandPalette = function CommandPalette({
         onClick={() => setOpen(true)}
         className="relative hidden h-8 w-30 items-center gap-2 rounded-md border bg-muted/30 px-2.5 text-xs transition-[border-color,box-shadow,background-color] hover:bg-muted/50 hover:ring-1 hover:ring-primary/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/30 md:inline-flex md:w-40"
       >
-        <Search
-          aria-hidden="true"
-          className="size-3.5 text-muted-foreground/60"
-        />
-        <span className="text-muted-foreground/60">Search…</span>
+        <Search aria-hidden="true" className="size-3.5 text-muted-foreground" />
+        <span className="text-muted-foreground">Search…</span>
         <kbd
           id="search-shortcut"
           className="ml-auto rounded border bg-muted px-1.5 text-[10px] font-medium"

--- a/apps/dashboard/src/components/menu/components/new-badge.tsx
+++ b/apps/dashboard/src/components/menu/components/new-badge.tsx
@@ -17,7 +17,7 @@ export const NewBadge = function NewBadge({ href, isNew }: NewBadgeProps) {
   if (!showBadge) return null
 
   return (
-    <span className="inline-flex shrink-0 items-center rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400">
+    <span className="inline-flex shrink-0 items-center rounded-full bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-800 dark:bg-emerald-500/15 dark:text-emerald-300">
       New
     </span>
   )

--- a/apps/dashboard/src/components/navigation/nav-main/menu-group.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/menu-group.tsx
@@ -36,7 +36,7 @@ export const MenuGroup = function MenuGroup({
 
   return (
     <SidebarGroup>
-      <SidebarGroupLabel className="text-xs font-semibold uppercase tracking-wider text-muted-foreground/70 px-3 py-2">
+      <SidebarGroupLabel className="text-xs font-semibold uppercase tracking-wider text-muted-foreground px-3 py-2">
         {label}
       </SidebarGroupLabel>
       <SidebarMenu>


### PR DESCRIPTION
## Measured
Lighthouse on `/overview` flags `color-contrast` with 6 elements. This PR fixes the safe, isolated ones (real low-vision improvements), each from a low-opacity muted token on a light background:

| Element | Before | After |
|---|---|---|
| Sidebar group labels (`menu-group.tsx`) | `text-muted-foreground/70` (~3:1) | `text-muted-foreground` (~4.5:1) |
| Command-palette search text + icon | `text-muted-foreground/60` (~2.5:1) | `text-muted-foreground` |
| "New" menu badge (`new-badge.tsx`) | emerald-700 on emerald-500/15 (~3:1) | emerald-800 on emerald-100 (~6.5:1) |

Group labels keep their visual hierarchy via uppercase / tracking / size (not opacity).

## Not in this PR
The 6th element — the bar-list white-on-bar label — needs a fill-darkness change with visual review, tracked separately (won't guess at it blind).

## Verification
className-only; Biome clean. Will re-run prod Lighthouse post-deploy to confirm the contrast element count drops.

Co-Authored-By: duyetbot <bot@duyet.net>