### PR TITLE
fix(ui): name the icon-only query-row action links (a11y link-name)

### DIFF
--- a/apps/dashboard/src/components/expensive-queries/table/query-row.tsx
+++ b/apps/dashboard/src/components/expensive-queries/table/query-row.tsx
@@ -187,6 +187,7 @@ export const QueryRow = memo(function QueryRow({
                   variant="ghost"
                   size="icon"
                   className="hidden size-7 text-muted-foreground hover:text-foreground md:inline-flex"
+                  aria-label="Open in Explorer"
                   asChild
                 >
                   <Link href={buildExplorerQueryUrl(d.query, hostId)}>

--- a/apps/dashboard/src/components/running-queries/table/query-row.tsx
+++ b/apps/dashboard/src/components/running-queries/table/query-row.tsx
@@ -244,6 +244,7 @@ export const QueryRow = memo(function QueryRow({
                   variant="ghost"
                   size="icon"
                   className="hidden size-7 text-muted-foreground hover:text-foreground md:inline-flex"
+                  aria-label="Open in Explorer"
                   asChild
                 >
                   <Link href={buildExplorerQueryUrl(d.query, hostId)}>
@@ -259,6 +260,9 @@ export const QueryRow = memo(function QueryRow({
                   variant="ghost"
                   size="icon"
                   className="hidden size-7 text-muted-foreground hover:text-foreground md:inline-flex"
+                  aria-label={
+                    queryDetailUrl ? 'Query detail' : 'Query ID unavailable'
+                  }
                   asChild={Boolean(queryDetailUrl)}
                   disabled={!queryDetailUrl}
                 >


### PR DESCRIPTION
## Measured (Lighthouse on /running-queries)
`link-name` (weight 7) fails: 2 icon-only links with no discernible name. Pinpointed via DOM query to the per-row action toolbar — the "Open in Explorer" (`ExternalLink`) and "Query detail" (`ScanSearch`) buttons. They're `Button size="icon" asChild <Link>` relying on a Radix `TooltipContent` for their label, but a tooltip is a *description*, not an accessible *name*. Screen-reader/keyboard users got "link" with no purpose.

## Fix
Add `aria-label` on the `Button` (forwarded to the `Link` via `asChild`, and kept on the disabled `<button>` fallback) matching each tooltip:
- running-queries `query-row.tsx`: "Open in Explorer", "Query detail" / "Query ID unavailable"
- expensive-queries `query-row.tsx`: "Open in Explorer"

(`expanded-row` / `slow-queries` versions already have visible text labels, so they were fine; the Kill-query button already had an aria-label.)

## Verification
Biome clean. Will confirm `link-name` clears via prod Lighthouse post-deploy.

Co-Authored-By: duyetbot <bot@duyet.net>