### PR TITLE
fix(ui): explorer tree a11y — name toggle buttons, fix list nesting

### DIFF
--- a/apps/dashboard/src/components/explorer/tree/tree-node.tsx
+++ b/apps/dashboard/src/components/explorer/tree/tree-node.tsx
@@ -57,13 +57,16 @@ export const TreeNode = function TreeNode({
   const paddingLeft = level * 12
 
   return (
-    <Collapsible open={isExpanded} onOpenChange={onToggle}>
-      <SidebarMenuItem
-        className={cn(
-          'transition-colors',
-          isHighlighted && !isSelected && 'bg-sidebar-accent/50'
-        )}
-      >
+    // SidebarMenuItem (<li>) must be the direct child of its SidebarMenu (<ul>),
+    // so the Collapsible wrapper lives *inside* the <li> — which also gives the
+    // tree its correct semantics (a node's nested <ul> sits within its <li>).
+    <SidebarMenuItem
+      className={cn(
+        'transition-colors',
+        isHighlighted && !isSelected && 'bg-sidebar-accent/50'
+      )}
+    >
+      <Collapsible open={isExpanded} onOpenChange={onToggle}>
         <div
           className="flex items-center gap-1"
           style={{ paddingLeft: `${paddingLeft}px` }}
@@ -72,6 +75,7 @@ export const TreeNode = function TreeNode({
             <CollapsibleTrigger asChild>
               <button
                 type="button"
+                aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${label}`}
                 className="flex size-4 items-center justify-center rounded-sm hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                 onClick={(e) => {
                   e.stopPropagation()
@@ -141,7 +145,7 @@ export const TreeNode = function TreeNode({
             <SidebarMenuSub>{children}</SidebarMenuSub>
           </CollapsibleContent>
         )}
-      </SidebarMenuItem>
-    </Collapsible>
+      </Collapsible>
+    </SidebarMenuItem>
   )
 }


### PR DESCRIPTION
## Measured (Lighthouse on /explorer — A11y 87, the lowest page so far)
The database-tree browser failed three audits:

| Audit | Weight | Count | Cause |
|---|---|---|---|
| `button-name` | **10** | 14 | chevron expand/collapse triggers are icon-only buttons with no accessible name |
| `listitem` | 7 | 14 | each `SidebarMenuItem` (`<li>`) was wrapped in a `Collapsible` (`<div>`), so the `<li>` wasn't a direct child of its `<ul>` |
| `list` | 7 | 1 | the `SidebarMenu` (`<ul>`) therefore contained `<div>`s, not just `<li>`s |

## Fix (`tree/tree-node.tsx`)
- Add `aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${label}`}` to the toggle button — names it *and* says which node it controls.
- Move the `<Collapsible>` **inside** the `<SidebarMenuItem>` so the `<li>` is a direct `<ul>` child. This is also the correct tree semantics: a node's nested `<ul>` (its children) now lives within its own `<li>`.

Behavior unchanged: same Collapsible `open`/`onOpenChange`, same trigger/content, same visual nesting depth (just the two wrappers swapped order). Biome clean; no tree-node tests to regress.

## Verification
Will re-run prod Lighthouse on /explorer post-deploy — expect button-name + list/listitem to clear (A11y 87 → ~96).

Co-Authored-By: duyetbot <bot@duyet.net>