### PR TITLE
fix(ui): give data-table Select triggers accessible names

### DIFF
--- a/apps/dashboard/src/components/data-table/components/data-table-header.tsx
+++ b/apps/dashboard/src/components/data-table/components/data-table-header.tsx
@@ -358,7 +358,10 @@ export const DataTableHeader = memo(function DataTableHeader<
                           updateFilterDraft(draft.id, { columnId: val })
                         }
                       >
-                        <SelectTrigger className="h-8 flex-1 text-xs">
+                        <SelectTrigger
+                          aria-label="Filter column"
+                          className="h-8 flex-1 text-xs"
+                        >
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
@@ -383,7 +386,10 @@ export const DataTableHeader = memo(function DataTableHeader<
                           })
                         }
                       >
-                        <SelectTrigger className="h-8 w-[130px] text-xs">
+                        <SelectTrigger
+                          aria-label="Filter operator"
+                          className="h-8 w-[130px] text-xs"
+                        >
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>

--- a/apps/dashboard/src/components/data-table/pagination.tsx
+++ b/apps/dashboard/src/components/data-table/pagination.tsx
@@ -87,9 +87,11 @@ export function DataTablePagination({ table }: DataTablePaginationProps) {
         <Select
           value={`${table.getState().pagination.pageSize}`}
           onValueChange={handlePageSizeChange}
-          aria-label="Rows per page"
         >
-          <SelectTrigger className="h-10 sm:h-8 w-16 sm:w-[70px]">
+          <SelectTrigger
+            aria-label="Rows per page"
+            className="h-10 sm:h-8 w-16 sm:w-[70px]"
+          >
             <SelectValue placeholder={table.getState().pagination.pageSize} />
           </SelectTrigger>
           <SelectContent side="top">


### PR DESCRIPTION
## Measured (Lighthouse on /history-queries, A11y 88)
`button-name` (weight 10) failed on the data-table's **"Rows per page"** Select. Its `aria-label` was on the Radix `<Select>` root, which is **not** forwarded to the `<button>` trigger — so the accessible name was just the current value ("100"), with no context. Confirmed via live DOM (`button[role="combobox"]:not([aria-label])` → "Rows per page 100").

## Fix
- Move `aria-label="Rows per page"` onto the `SelectTrigger`.
- Also name the two filter-builder Selects in the table header (`Filter column`, `Filter operator`) — they had bare `<SelectValue/>` and were unnamed while empty (latent; only not flagged because the filter builder wasn't open during the audit).

These live in the shared `components/data-table` system, so the fix covers **all ~54 table-backed pages**.

## Verification
Biome clean; no data-table tests to regress. Will confirm `button-name` clears via prod Lighthouse post-deploy.

Co-Authored-By: duyetbot <bot@duyet.net>