### PR TITLE
fix(ui): host switcher accessible name matches visible label (WCAG 2.5.3)

### DIFF
--- a/apps/dashboard/src/components/host/host-switcher.tsx
+++ b/apps/dashboard/src/components/host/host-switcher.tsx
@@ -104,7 +104,7 @@ export function HostSwitcher() {
                     !showExpanded && 'justify-center'
                   )}
                   data-testid="host-switcher-empty"
-                  aria-label={label}
+                  aria-label={showExpanded ? undefined : label}
                 >
                   <div className="relative">
                     <ChmonitorLogo
@@ -161,7 +161,15 @@ export function HostSwitcher() {
                     !showExpanded && 'justify-center'
                   )}
                   data-testid="host-switcher"
-                  aria-label={`Select ClickHouse host. Current: ${activeHost.name || getHost(activeHost.host)}`}
+                  // When expanded the host name + version are visible, so the
+                  // accessible name comes from that content (WCAG 2.5.3 Label
+                  // in Name — a static aria-label can't include the live
+                  // version). When collapsed to an icon, supply the name.
+                  aria-label={
+                    showExpanded
+                      ? undefined
+                      : `Select ClickHouse host. Current: ${activeHost.name || getHost(activeHost.host)}`
+                  }
                 >
                   <div className="relative">
                     <ChmonitorLogo width={20} height={20} className="size-5" />


### PR DESCRIPTION
## Problem (appears on every page)
Lighthouse `label-content-name-mismatch` flags the host switcher button on all pages. When the sidebar is expanded it shows the host **name + live version**, but its static `aria-label` ("Select ClickHouse host. Current: {name}") omits the version — so the accessible name doesn't contain the full visible text (WCAG 2.5.3 Label in Name; matters for voice-control users who say "click {visible text}"). A static label can't include the live version component.

## Fix
Set the descriptive `aria-label` only when **collapsed** to an icon (no visible text). When **expanded**, let the accessible name derive from the visible content, which trivially contains the visible label. Applied to both the active-host and no-host states.

Weight-0 in the Lighthouse score, but a real fix for voice-control / screen-reader users, consistent across every page.

## Verification
Biome clean; no tests reference the old aria-label string.

Co-Authored-By: duyetbot <bot@duyet.net>