### PR TITLE
fix(ui): give Progress bars accessible names (aria-progressbar-name)

### DIFF
--- a/apps/dashboard/src/components/agents/agent-workflow-plan.tsx
+++ b/apps/dashboard/src/components/agents/agent-workflow-plan.tsx
@@ -70,7 +70,11 @@ export function AgentWorkflowPlan({
         </span>
       </div>
 
-      <Progress value={pct} className="mb-3 h-1.5" />
+      <Progress
+        value={pct}
+        aria-label="Workflow progress"
+        className="mb-3 h-1.5"
+      />
 
       <ol className="space-y-1.5">
         {steps.map((step) => (

--- a/apps/dashboard/src/components/ai-elements/context.tsx
+++ b/apps/dashboard/src/components/ai-elements/context.tsx
@@ -169,7 +169,11 @@ export const ContextContentHeader = ({
             </p>
           </div>
           <div className="space-y-2">
-            <Progress className="bg-muted" value={usedPercent * PERCENT_MAX} />
+            <Progress
+              aria-label="Model context usage"
+              className="bg-muted"
+              value={usedPercent * PERCENT_MAX}
+            />
           </div>
         </>
       )}

--- a/apps/dashboard/src/components/charts/system/disk-size.tsx
+++ b/apps/dashboard/src/components/charts/system/disk-size.tsx
@@ -94,6 +94,7 @@ export const ChartDiskSize = createCustomChart({
         <div className="mt-3.5 mb-4">
           <Progress
             value={primaryPct}
+            aria-label={`${primary.name} disk usage`}
             className={cn('h-2.5 bg-muted', {
               '[&>div]:bg-rose-500': primaryPct >= 90,
               '[&>div]:bg-amber-500': primaryPct >= 70 && primaryPct < 90,


### PR DESCRIPTION
## Measured (Lighthouse on /dashboard, A11y 96)
`aria-progressbar-name` (weight 7) failed: the disk-size chart's usage `Progress` has `role="progressbar"` but no accessible name — it announces only a bare percentage (or nothing while indeterminate during load). Confirmed via live DOM (`[role=progressbar]:not([aria-label])` → inside `disk-size-chart`). The disk-size chart renders on **overview, dashboard, and disks**.

## Fix
Add `aria-label` to the three shadcn `Progress` instances that lacked one:
- disk-size chart → `"{disk} disk usage"`
- AI context meter (`ai-elements/context`) → `"Model context usage"`
- agent workflow plan → `"Workflow progress"`

(The `disk-usage-bar` and the assistant context bar already had labels.)

## Verification
Biome clean. Will confirm `aria-progressbar-name` clears via prod Lighthouse post-deploy.

Co-Authored-By: duyetbot <bot@duyet.net>