### PR TITLE
fix(ui): raise contrast of data-table "N records" count (WCAG AA)

### DIFF
--- a/apps/dashboard/src/components/data-table/components/data-table-header.tsx
+++ b/apps/dashboard/src/components/data-table/components/data-table-header.tsx
@@ -484,7 +484,7 @@ export const DataTableHeader = memo(function DataTableHeader<
       {!filterBarSlot && (
         <div className="flex flex-wrap items-center justify-between gap-2.5 text-xs px-1 min-h-[24px]">
           {/* Count */}
-          <span className="text-[12.5px] font-semibold text-muted-foreground/80">
+          <span className="text-[12.5px] font-semibold text-muted-foreground">
             {table.getFilteredRowModel().rows.length} records
           </span>
 


### PR DESCRIPTION
## Measured (shared element, flagged on /settings and /clusters)
The "{N} records" count in every data-table header used `text-muted-foreground/80` (~3.7:1 on light backgrounds) — fails WCAG AA. Because it lives in the shared `data-table-header`, it failed `color-contrast` on multiple pages.

## Fix
Drop the `/80` so it uses the full `muted-foreground` token (~4.5:1). It stays visually muted via size/weight, not opacity. Helps every table-backed page.

## Verification
Biome clean. Will confirm via prod Lighthouse post-deploy.

Co-Authored-By: duyetbot <bot@duyet.net>