### PR TITLE
fix(helm): bootstrap gh-pages branch on first chart release

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -5,9 +5,11 @@ name: Helm Chart Release (GitHub Pages)
 # changes on main. chart-releaser detects version bumps in Chart.yaml and
 # only re-packages charts that changed since the last published release.
 #
-# Prerequisites (one-time):
-#   1. Create the gh-pages branch: git checkout --orphan gh-pages && git commit --allow-empty -m "init" && git push
-#   2. Go to Settings → Pages → Source = "Deploy from a branch" → Branch: gh-pages / root.
+# The gh-pages branch is auto-created on first run (see "Bootstrap gh-pages
+# branch" step) and GitHub Pages serving is enabled best-effort — no manual
+# one-time setup required. If Pages enablement is skipped (e.g. already
+# configured differently), set it manually: Settings → Pages →
+# Source = "Deploy from a branch" → Branch: gh-pages / root.
 #
 # Users install with:
 #   helm repo add chmonitor https://duyet.github.io/clickhouse-monitoring
@@ -19,9 +21,14 @@ on:
     paths:
       - 'deploy/helm/**'
       - '.github/cr.yaml'
+  # Manual trigger: lets us (re)publish without a chart bump — useful for
+  # bootstrapping the index after the gh-pages branch is first created, and
+  # for retroactively indexing a release whose cr index step failed.
+  workflow_dispatch:
 
 permissions:
   contents: write
+  pages: write
 
 jobs:
   release:
@@ -38,6 +45,36 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      # chart-releaser's `cr index` clones origin/gh-pages to regenerate
+      # index.yaml. On the very first release that branch does not exist yet,
+      # and cr fails with `fatal: invalid reference: origin/gh-pages`. Create
+      # an empty orphan branch ahead of time so cr always has a branch to clone.
+      # Uses commit-tree so the checked-out chart source is never touched.
+      - name: Bootstrap gh-pages branch (first run)
+        run: |
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            echo "gh-pages branch already exists — skipping bootstrap"
+            exit 0
+          fi
+          echo "gh-pages branch missing — creating empty orphan branch"
+          EMPTY_TREE="$(git mktree </dev/null)"
+          COMMIT="$(git commit-tree "$EMPTY_TREE" -m "Initialize gh-pages for Helm chart repository")"
+          git push origin "$COMMIT:refs/heads/gh-pages"
+
+      # Best-effort: serve gh-pages / root via GitHub Pages so the helm repo
+      # URL (https://duyet.github.io/clickhouse-monitoring) works. Never fails
+      # the build — Pages may already be configured or need manual enablement.
+      - name: Enable GitHub Pages serving (best-effort)
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api --method POST "repos/$GITHUB_REPOSITORY/pages" \
+            -f "source[branch]=gh-pages" -f "source[path]=/" 2>/dev/null \
+            || gh api --method PUT "repos/$GITHUB_REPOSITORY/pages" \
+                 -f "source[branch]=gh-pages" -f "source[path]=/" 2>/dev/null \
+            || echo "Pages enablement skipped — configure manually in Settings → Pages"
 
       - name: Install Helm
         uses: azure/setup-helm@v4


### PR DESCRIPTION
## Problem

The `Helm Chart Release (GitHub Pages)` workflow failed on its first run ([run 27762676345](https://github.com/duyet/clickhouse-monitoring/actions/runs/27762676345)) at `cr index`:

```
fatal: invalid reference: origin/gh-pages
Error: exit status 128
```

`chart-releaser`'s `cr index` clones `origin/gh-pages` to regenerate `index.yaml`. On the very first release that branch does not exist yet, so the git reference is invalid and the step dies. chart-releaser had already created the `helm-chmonitor-0.2.9` GitHub release/tag (its `release_charts` step ran before `cr index`) — so the chart exists as a release artifact but is **missing from the helm repo index** (`helm repo add` won't see it).

## Fix

`helm-release.yml` now self-bootstraps the `gh-pages` branch so no manual one-time setup is needed:

1. **Bootstrap `gh-pages` branch (first run)** — if `origin/gh-pages` is missing, create an empty orphan branch via `git commit-tree` (no working-tree disturbance) and push it. Idempotent: skips when the branch already exists.
2. **Enable GitHub Pages serving (best-effort)** — `gh api` to serve `gh-pages` / root so the repo URL (`https://duyet.github.io/clickhouse-monitoring`) resolves. `continue-on-error` so it never fails the build.
3. **`workflow_dispatch` trigger** — allows republishing without a chart bump.
4. Added `pages: write` permission for the Pages-enable API call.

## OCI publish (already correct, untouched)

The OCI job in `release.yml` (`helm-publish` → `oci://ghcr.io/duyet/chmonitor`) is structurally sound but never exercised live — the last `release.yml` run predates the commit that added it. It first fires on the next `vX.Y.Z` release. No change needed there.

> Note: the GHCR chart package will default to **private** on first publish — set it public under the package settings for anonymous `helm pull`.

## Verification plan

- [ ] CI green on this PR
- [ ] After merge, `gh workflow run helm-release.yml` → run completes **green** (the original `fatal: invalid reference: origin/gh-pages` is gone) and `origin/gh-pages` now exists. With no chart bump this run is a no-op for `cr index` ("Nothing to do") — expected, since `cr index` only runs when a chart changed.
- [ ] The next `Chart.yaml` version bump triggers the full pipeline; `cr index` rebuilds `index.yaml` from **all** `helm-*` releases, retroactively pulling in the already-released `0.2.9`.

Co-Authored-By: duyetbot <bot@duyet.net>