### PR TITLE
fix(helm): drop dead Pages-enable step that 403s every run

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -6,10 +6,10 @@ name: Helm Chart Release (GitHub Pages)
 # only re-packages charts that changed since the last published release.
 #
 # The gh-pages branch is auto-created on first run (see "Bootstrap gh-pages
-# branch" step) and GitHub Pages serving is enabled best-effort — no manual
-# one-time setup required. If Pages enablement is skipped (e.g. already
-# configured differently), set it manually: Settings → Pages →
-# Source = "Deploy from a branch" → Branch: gh-pages / root.
+# branch" step). One manual step remains: enable GitHub Pages serving —
+# Settings → Pages → Source = "Deploy from a branch" → Branch: gh-pages / root.
+# (This can't be automated: creating a Pages site requires administration:write,
+# which the default GITHUB_TOKEN doesn't hold.)
 #
 # Users install with:
 #   helm repo add chmonitor https://duyet.github.io/clickhouse-monitoring
@@ -21,14 +21,13 @@ on:
     paths:
       - 'deploy/helm/**'
       - '.github/cr.yaml'
-  # Manual trigger: lets us (re)publish without a chart bump — useful for
-  # bootstrapping the index after the gh-pages branch is first created, and
-  # for retroactively indexing a release whose cr index step failed.
+  # Manual trigger to (re)run chart-releaser without a chart bump — handy for
+  # bootstrapping the gh-pages branch. Note: cr index is a no-op when no chart
+  # changed, so actually populating index.yaml still requires a Chart.yaml bump.
   workflow_dispatch:
 
 permissions:
   contents: write
-  pages: write
 
 jobs:
   release:
@@ -61,20 +60,6 @@ jobs:
           EMPTY_TREE="$(git mktree </dev/null)"
           COMMIT="$(git commit-tree "$EMPTY_TREE" -m "Initialize gh-pages for Helm chart repository")"
           git push origin "$COMMIT:refs/heads/gh-pages"
-
-      # Best-effort: serve gh-pages / root via GitHub Pages so the helm repo
-      # URL (https://duyet.github.io/clickhouse-monitoring) works. Never fails
-      # the build — Pages may already be configured or need manual enablement.
-      - name: Enable GitHub Pages serving (best-effort)
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api --method POST "repos/$GITHUB_REPOSITORY/pages" \
-            -f "source[branch]=gh-pages" -f "source[path]=/" 2>/dev/null \
-            || gh api --method PUT "repos/$GITHUB_REPOSITORY/pages" \
-                 -f "source[branch]=gh-pages" -f "source[path]=/" 2>/dev/null \
-            || echo "Pages enablement skipped — configure manually in Settings → Pages"
 
       - name: Install Helm
         uses: azure/setup-helm@v4


### PR DESCRIPTION
## Problem (found during verification of #1745)

The "Enable GitHub Pages serving (best-effort)" step I added in #1745 403'd on its first real run:

```
{"message":"Resource not accessible by integration","status":"403"}
Pages enablement skipped — configure manually in Settings → Pages
```

Creating a GitHub Pages **site** requires `administration: write`; the `pages: write` permission I added is insufficient, and the default `GITHUB_TOKEN` cannot perform it. It was `continue-on-error`, so it never failed the build — but it printed two 403s + a fallback echo on **every run forever**.

## Fix

Remove the dead step and the now-unused `pages: write` permission. Keep a one-time manual note in the header comment (Pages serving is a repo-owner action that can't be automated with `GITHUB_TOKEN`).

The bootstrapping of the `gh-pages` branch (the actual fix for the original `fatal: invalid reference: origin/gh-pages`) is unaffected and verified working.

## Verification

- [ ] CI green
- [ ] After merge, the next `helm-release.yml` run logs no more 403 lines

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Helm release workflow documentation updated to clarify that GitHub Pages must be manually enabled for chart releases
  * Removed automated GitHub Pages configuration from the release process
  * Adjusted workflow permissions accordingly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->