### PR TITLE
feat(helm): serve chart repo via Cloudflare Pages at charts.chmonitor.dev

### DIFF
--- a/.github/cr.yaml
+++ b/.github/cr.yaml
@@ -2,4 +2,4 @@
 # Release tags are prefixed "helm-" to avoid colliding with app release tags (vX.Y.Z).
 release-name-template: "helm-{{ .Name }}-{{ .Version }}"
 pages-branch: gh-pages
-charts-repo-url: https://duyet.github.io/clickhouse-monitoring
+charts-repo-url: https://charts.chmonitor.dev

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -12,6 +12,18 @@
       "changelog-path": "CHANGELOG.md",
       "draft": false,
       "prerelease": false,
+      "extra-files": [
+        {
+          "type": "yaml",
+          "path": "deploy/helm/chmonitor/Chart.yaml",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "yaml",
+          "path": "deploy/helm/chmonitor/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        }
+      ],
       "changelog-sections": [
         { "type": "feat", "section": "✨ Features" },
         { "type": "fix", "section": "🐛 Bug Fixes" },

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,18 +1,21 @@
-name: Helm Chart Release (GitHub Pages)
+name: Helm Chart Release
 
-# Packages and publishes changed Helm charts to the gh-pages Helm repo
-# (https://duyet.github.io/clickhouse-monitoring) whenever the chart source
-# changes on main. chart-releaser detects version bumps in Chart.yaml and
-# only re-packages charts that changed since the last published release.
+# chart-releaser packages changed charts and pushes index.yaml + the .tgz
+# packages to the gh-pages branch; a follow-up job mirrors that branch to the
+# chmonitor-charts Cloudflare Pages project, served at charts.chmonitor.dev.
+# chart-releaser detects Chart.yaml version bumps and only re-packages charts
+# that changed since the last published release. Chart.yaml version + appVersion
+# are auto-bumped by release-please on each app release (see
+# .github/release-please-config.json extra-files), so the shipped image tag
+# (defaults to appVersion) tracks the release.
 #
 # The gh-pages branch is auto-created on first run (see "Bootstrap gh-pages
-# branch" step). One manual step remains: enable GitHub Pages serving —
-# Settings → Pages → Source = "Deploy from a branch" → Branch: gh-pages / root.
-# (This can't be automated: creating a Pages site requires administration:write,
-# which the default GITHUB_TOKEN doesn't hold.)
+# branch" step). charts.chmonitor.dev is bound to the chmonitor-charts Pages
+# project — set the custom domain once in the CF dashboard (Pages →
+# chmonitor-charts → Custom domains → charts.chmonitor.dev).
 #
 # Users install with:
-#   helm repo add chmonitor https://duyet.github.io/clickhouse-monitoring
+#   helm repo add chmonitor https://charts.chmonitor.dev
 #   helm install my-chm chmonitor/chmonitor --set clickhouse.host=http://ch:8123
 
 on:
@@ -71,3 +74,35 @@ jobs:
           config: .github/cr.yaml
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # chart-releaser pushes index.yaml + .tgz to the gh-pages BRANCH, but pushes
+  # made by GITHUB_TOKEN do not trigger downstream push workflows (anti-loop),
+  # so a separate on:push:gh-pages workflow would never fire. Deploy from this
+  # same run instead, right after chart-releaser has updated gh-pages.
+  deploy-pages:
+    name: deploy to Cloudflare Pages
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          fetch-depth: 1
+
+      # Mirror the gh-pages branch (index.yaml + .tgz) to the chmonitor-charts
+      # Cloudflare Pages project → https://charts.chmonitor.dev. --branch gh-pages
+      # is required so CF Pages promotes the deploy to the production URL.
+      # Skipped until the first chart release writes index.yaml to gh-pages.
+      - name: Deploy chart repo to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ ! -f index.yaml ]; then
+            echo "No index.yaml on gh-pages yet — nothing to deploy (expected until the first chart release)"
+            exit 0
+          fi
+          npx --yes --package=wrangler@4 wrangler pages deploy . \
+            --project-name=chmonitor-charts --branch gh-pages

--- a/deploy/helm/chmonitor/Chart.yaml
+++ b/deploy/helm/chmonitor/Chart.yaml
@@ -4,6 +4,9 @@ description: A Helm chart for the chmonitor dashboard
 type: application
 
 # version is the chart version. Bump on any chart change.
+# release-please auto-bumps both `version` and `appVersion` on each app
+# release (see .github/release-please-config.json extra-files), so the
+# shipped image tag (defaults to appVersion) tracks the release.
 version: 0.2.9
 
 # appVersion tracks the chmonitor app release this chart ships.

--- a/docs/content/deploy/k8s.mdx
+++ b/docs/content/deploy/k8s.mdx
@@ -8,13 +8,13 @@ The chart is published in two registries:
 
 | Registry | Install command |
 |----------|----------------|
-| **Helm repo** (GitHub Pages) | `helm repo add chmonitor https://duyet.github.io/clickhouse-monitoring` |
+| **Helm repo** (Cloudflare Pages) | `helm repo add chmonitor https://charts.chmonitor.dev` |
 | **OCI** (GHCR) | `helm install my-chm oci://ghcr.io/duyet/chmonitor --version X.Y.Z` |
 
 ### From the Helm repository
 
 ```bash
-helm repo add chmonitor https://duyet.github.io/clickhouse-monitoring
+helm repo add chmonitor https://charts.chmonitor.dev
 helm repo update
 
 helm install my-chm chmonitor/chmonitor \


### PR DESCRIPTION
Implements the chosen option (CF Pages → \`charts.chmonitor.dev\`) for serving the Helm chart repository. Addresses both "serve via charts.chmonitor.dev" and "make sure image version auto-adjusts on release".

## What changes

1. **`deploy-pages` job** in `helm-release.yml` — mirrors the `gh-pages` branch to the `chmonitor-charts` Cloudflare Pages project, served at `charts.chmonitor.dev`. Runs in the **same workflow run** as chart-releaser (a separate `on: push: gh-pages` workflow would never fire — `GITHUB_TOKEN` pushes don't trigger downstream workflows). Reuses the existing `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` secrets. Guards on `index.yaml` existing so it's a no-op until the first chart release.
2. **URL repoint** — `cr.yaml`, `k8s.mdx`, and the workflow comment now point at `https://charts.chmonitor.dev` instead of the stale `duyet.github.io` legacy Pages site.
3. **Image auto-tracks release** — added `Chart.yaml` `version` + `appVersion` to release-please's `extra-files` (typed `yaml` + jsonpath). On each app release, release-please bumps both fields → the chart's image tag (which defaults to `appVersion` per `_helpers.tpl`) follows the release automatically, on both the Pages and OCI publish paths.

## How it serves (static)

A Helm repo is just `index.yaml` + `.tgz` blobs over HTTPS. CF Pages serves them verbatim with correct content-types (verified: `index.yaml` → `text/yaml; charset=utf-8`). No backend.

## Already done outside this PR

- ✅ Created CF Pages project `chmonitor-charts` (direct-upload, production branch `gh-pages`).
- ✅ Proven the deploy locally: `https://chmonitor-charts.pages.dev/index.yaml` → 200, `text/yaml`.

## Verification plan

- [ ] CI green on this PR.
- [ ] On the next app release, release-please bumps `Chart.yaml` → chart-releaser writes `index.yaml` to `gh-pages` → `deploy-pages` pushes to CF Pages.
- [ ] Bind `charts.chmonitor.dev` custom domain in CF dashboard (Pages → chmonitor-charts → Custom domains) — one-time.
- [ ] `helm repo add chmonitor https://charts.chmonitor.dev && helm search repo chmonitor` finds the chart.

> Note: the `CLOUDFLARE_API_TOKEN` secret must have **Cloudflare Pages: Edit** scope. It currently deploys Workers; if the Pages deploy 403s, extend that token's scope.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Helm repository URL in deployment documentation to reflect new Cloudflare Pages location.

* **Chores**
  * Updated Helm chart repository URL configuration and release automation setup.
  * Enhanced deployment pipeline with Cloudflare Pages integration for chart releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->