### PR TITLE
fix(helm): skip existing releases so chart-releaser is idempotent

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -72,6 +72,11 @@ jobs:
         with:
           charts_dir: deploy/helm
           config: .github/cr.yaml
+          # Skip (not error) when a release for this chart version already
+          # exists — makes the workflow idempotent across re-runs and
+          # comment-only Chart.yaml touches, and still runs cr index so the
+          # repo index is rebuilt from existing releases.
+          skip_existing: true
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Problem

After #1747 merged, `helm-release.yml` fired (the Chart.yaml comment counts as a `deploy/helm/**` change) and **failed** ([run 27767234669](...)):

```
Error: error creating GitHub release helm-chmonitor-0.2.9: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists}]
```

chart-releaser's `cr upload` does not skip existing releases — it 422s. Since the chart version (0.2.9) was unchanged, it re-packaged 0.2.9 and collided with the existing `helm-chmonitor-0.2.9` release (created by the original failed run).

## Fix

Set `skip_existing: true` on the chart-releaser action → `cr upload` skips existing releases gracefully and proceeds to `cr index`, which rebuilds the repo index from existing releases.

This both **fixes the red CI** and **bootstraps the index**: on the next run, `cr index` rebuilds `index.yaml` (including the already-released 0.2.9) → `deploy-pages` mirrors it to Cloudflare Pages.

## Verification

- [ ] CI green
- [ ] After merge, `gh workflow run helm-release.yml` → run green; `index.yaml` written to `gh-pages` and deployed to CF Pages
- [ ] `curl https://charts.chmonitor.dev/index.yaml` returns a valid helm index containing `chmonitor-0.2.9`

Co-Authored-By: duyetbot <bot@duyet.net>