### PR TITLE
fix(healthz): bound /api/healthz ping + parameterize chart probes + dual-runtime guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ Developer-facing docs live in `docs/knowledge/` as a linked knowledge graph. Eac
 | Operations | [deployment.md](docs/knowledge/deployment.md) | Docker + Cloudflare Workers dual deployment |
 | Operations | [core-memory.md](docs/knowledge/core-memory.md) | Automation memory: code-smell scans, dead-code rules |
 | Operations | [secret-rotation.md](docs/knowledge/secret-rotation.md) | Redeploy after `wrangler secret put` |
+| Operations | [k8s-health-probes.md](docs/knowledge/k8s-health-probes.md) | /healthz (liveness, static) vs /api/healthz (readiness, CH-gated); startupProbe; :latest stale-image CrashLoop incident; non-helm manifest + migration prompt |
 | Specs | [ai-insights.md](docs/knowledge/ai-insights.md) | AI Insights engine: collect→enrich→persist (findings store), cron + manual generation, stable-key dismissal, overview panel |
 | Specs | [mcp-server.md](docs/knowledge/mcp-server.md) | MCP server at /api/mcp: tools, setup, security |
 | Specs | [agentstate-conversation-store.md](docs/knowledge/agentstate-conversation-store.md) | AgentState conversation backend: store priority, per-user external_id/tag isolation, append-only upsert, AI enrichment, backend/follow-ups routes |

--- a/apps/dashboard/src/lib/__tests__/cloudflare-workers-shim.test.ts
+++ b/apps/dashboard/src/lib/__tests__/cloudflare-workers-shim.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test'
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Dual-runtime guard. The Node build (Nitro `node-server`, i.e. the Docker/k8s
+// image) resolves the virtual module `cloudflare:workers` to
+// src/lib/cloudflare-workers-shim.ts, which only re-exports `env` (backed by
+// process.env). Any OTHER symbol imported from `cloudflare:workers`
+// (WorkerEntrypoint, DurableObject, ExecutionContext, QueueExporter, …) would
+// be `undefined` at runtime under Node and break the Node target silently —
+// while still building & passing on the Cloudflare Worker target.
+//
+// This test enforces the contract: across the whole app source, the only
+// permitted value import from `cloudflare:workers` is `{ env }`. If you
+// genuinely need another binding, re-export it from cloudflare-workers-shim.ts
+// first (and keep it Node-safe), then it is automatically allowed here.
+// See docs/knowledge/k8s-health-probes.md → "Dual-runtime" section.
+
+const SRC_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const ALLOWED = new Set(['env'])
+const IMPORT_RE = /import\s*\{([^}]*)\}\s*from\s*['"]cloudflare:workers['"]/g
+
+function listSourceFiles(): string[] {
+  const entries = readdirSync(SRC_ROOT, {
+    recursive: true,
+  }) as unknown as string[]
+  return entries.filter((f) => {
+    const s = String(f)
+    return (
+      (s.endsWith('.ts') || s.endsWith('.tsx')) &&
+      !s.includes('__tests__') &&
+      !s.endsWith('.test.ts') &&
+      !s.endsWith('.test.tsx') &&
+      // The shim is the alias TARGET for the Node build; it does not import the
+      // virtual module itself, so it is out of scope by construction.
+      !s.endsWith('cloudflare-workers-shim.ts')
+    )
+  })
+}
+
+describe('cloudflare:workers dual-runtime contract', () => {
+  test('only `env` may be imported from cloudflare:workers (Node-build guard)', () => {
+    const offenders: string[] = []
+
+    for (const rel of listSourceFiles()) {
+      const abs = join(SRC_ROOT, rel)
+      const src = readFileSync(abs, 'utf8')
+      for (const match of src.matchAll(IMPORT_RE)) {
+        const symbols = match[1]!
+          .split(',')
+          .map((raw) =>
+            raw
+              .replace(/\bas\s+\w+/g, '')
+              .replace(/\btype\b/g, '')
+              .trim()
+          )
+          .filter(Boolean)
+        for (const sym of symbols) {
+          if (!ALLOWED.has(sym)) {
+            offenders.push(
+              `${relative(SRC_ROOT, abs)} imports \`${sym}\` from cloudflare:workers — ` +
+                `re-export it from src/lib/cloudflare-workers-shim.ts (Node-safe) or remove the import.`
+            )
+          }
+        }
+      }
+    }
+
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
+})

--- a/apps/dashboard/src/routes/api/healthz.ts
+++ b/apps/dashboard/src/routes/api/healthz.ts
@@ -41,6 +41,20 @@ export const Route = createFileRoute('/api/healthz')({
           )
         }
 
+        // Per-host ping timeout (default 3s; override via CHM_HEALTHZ_TIMEOUT_MS).
+        // Without an explicit abort a hung ClickHouse host stalls this readiness
+        // check past the kubelet probe timeout — @clickhouse/client-web's fetch
+        // otherwise waits on the TCP timeout (often >30s). Keep this BELOW the
+        // chart's readinessProbe.timeoutSeconds (default 10s). abort_signal +
+        // AbortSignal.timeout() are supported on both runtimes (Node 18+ and
+        // workerd), so this route stays runtime-agnostic.
+        const pingTimeoutMs =
+          Number.parseInt(
+            (env as Record<string, string | undefined>)
+              .CHM_HEALTHZ_TIMEOUT_MS ?? '',
+            10
+          ) || 3000
+
         const hosts: HostHealth[] = await Promise.all(
           configs.map(async (config) => {
             const start = Date.now()
@@ -53,6 +67,7 @@ export const Route = createFileRoute('/api/healthz')({
               const resultSet = await client.query({
                 query: 'SELECT 1',
                 format: 'JSON',
+                abort_signal: AbortSignal.timeout(pingTimeoutMs),
               })
               // Drain the response so the ping is a real round-trip.
               await resultSet.text()

--- a/deploy/helm/chmonitor/templates/deployment.yaml
+++ b/deploy/helm/chmonitor/templates/deployment.yaml
@@ -65,33 +65,43 @@ spec:
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          # Startup probe gives the Nitro Node server up to 60s to bind before
+          {{- with .Values.probes }}
+          {{- if .startup.enabled }}
+          # Startup probe gives the Nitro Node server up to ~60s to bind before
           # liveness kicks in. Prevents kill-loops on slow-start nodes.
           startupProbe:
             httpGet:
-              path: /healthz
-              port: {{ .Values.containerPort }}
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 3
-            failureThreshold: 12
+              path: {{ .startup.path | quote }}
+              port: {{ $.Values.containerPort }}
+            initialDelaySeconds: {{ .startup.initialDelaySeconds }}
+            periodSeconds: {{ .startup.periodSeconds }}
+            timeoutSeconds: {{ .startup.timeoutSeconds }}
+            failureThreshold: {{ .startup.failureThreshold }}
+          {{- end }}
+          {{- if .liveness.enabled }}
           # Static liveness: /healthz always returns 200 while the process is up.
           livenessProbe:
             httpGet:
-              path: /healthz
-              port: {{ .Values.containerPort }}
-            periodSeconds: 15
-            timeoutSeconds: 5
-            failureThreshold: 3
+              path: {{ .liveness.path | quote }}
+              port: {{ $.Values.containerPort }}
+            initialDelaySeconds: {{ .liveness.initialDelaySeconds }}
+            periodSeconds: {{ .liveness.periodSeconds }}
+            timeoutSeconds: {{ .liveness.timeoutSeconds }}
+            failureThreshold: {{ .liveness.failureThreshold }}
+          {{- end }}
+          {{- if .readiness.enabled }}
           # Readiness gates on ClickHouse reachability: /api/healthz returns 503
-          # when no configured host is up.
+          # when no configured host is up (or a host's SELECT 1 ping times out).
           readinessProbe:
             httpGet:
-              path: /api/healthz
-              port: {{ .Values.containerPort }}
-            periodSeconds: 15
-            timeoutSeconds: 10
-            failureThreshold: 3
+              path: {{ .readiness.path | quote }}
+              port: {{ $.Values.containerPort }}
+            initialDelaySeconds: {{ .readiness.initialDelaySeconds }}
+            periodSeconds: {{ .readiness.periodSeconds }}
+            timeoutSeconds: {{ .readiness.timeoutSeconds }}
+            failureThreshold: {{ .readiness.failureThreshold }}
+          {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/deploy/helm/chmonitor/values.yaml
+++ b/deploy/helm/chmonitor/values.yaml
@@ -52,6 +52,39 @@ service:
 # Container port the app listens on (matches PORT=3000 in the Docker image).
 containerPort: 3000
 
+# Kubernetes health probes. Defaults match the container's health endpoints:
+#   liveness  -> GET /healthz     (static 200 while the Node/worker process is up)
+#   readiness -> GET /api/healthz (200 only when every configured ClickHouse host
+#                                 answers its SELECT 1 ping; 503 otherwise)
+#   startup   -> GET /healthz     (~60s grace before liveness can kill a slow boot)
+# Paths rarely need changing; the thresholds are exposed so tight-resource nodes
+# can tune without forking the chart into raw manifests. Keep
+# readiness.timeoutSeconds ABOVE the app's per-host ping timeout
+# (CHM_HEALTHZ_TIMEOUT_MS, default 3000ms in /api/healthz) or a slow ClickHouse
+# host will flap readiness.
+probes:
+  liveness:
+    enabled: true
+    path: /healthz
+    initialDelaySeconds: 0
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    path: /api/healthz
+    initialDelaySeconds: 0
+    periodSeconds: 15
+    timeoutSeconds: 10
+    failureThreshold: 3
+  startup:
+    enabled: true
+    path: /healthz
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 12
+
 ingress:
   enabled: false
   className: ""

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -32,6 +32,7 @@ Agents discover knowledge in this order:
 | **Operations** | [monorepo-refactor.md](monorepo-refactor.md) | operations | Bun-workspaces + Turborepo migration: status, workflow, gotchas, Phase 5 TODO |
 | **Operations** | [core-memory.md](core-memory.md) | workflow | Automation core memory: code-smell scans, dead-code rules |
 | **Operations** | [secret-rotation.md](secret-rotation.md) | workflow | Cloudflare Workers secret rotation: redeploy after wrangler secret put |
+| **Operations** | [k8s-health-probes.md](k8s-health-probes.md) | reference | /healthz (liveness, static) vs /api/healthz (readiness, CH-gated); startupProbe; :latest stale-image incident; non-helm manifest + migration prompt |
 | **Operations** | [release-automation.md](release-automation.md) | workflow | release-please + release.yml pipeline: versioning rules, PR-title guard, labeler, CHANGELOG ownership, migration prompt |
 | **Specs** | [ai-insights.md](ai-insights.md) | spec | AI Insights engine: collect→enrich→persist (findings store), cron + manual generation, stable-key dismissal, overview panel |
 | **Specs** | [mcp-server.md](mcp-server.md) | reference | MCP server at /api/mcp: tools, setup, security |

--- a/docs/knowledge/deployment.md
+++ b/docs/knowledge/deployment.md
@@ -18,6 +18,58 @@ related:
 
 Dual deployment support: Docker and Cloudflare Workers from the same codebase.
 
+> **Current architecture (TanStack Start, v0.3+):** the dual-runtime mechanism
+> below is authoritative. The Next.js / OpenNext content further down (`.next`,
+> `next build`, KV/R2/D1 cache populate) is **historical** and no longer applies
+> — the app now builds via Vite + Nitro. See `apps/dashboard/vite.config.ts`.
+
+## Dual-runtime compatibility (Node Docker + Cloudflare Workers)
+
+The TanStack Start app builds to **two targets** from one codebase, selected by
+`BUILD_TARGET` in `apps/dashboard/vite.config.ts`:
+
+| Target | Build | Runtime | `cloudflare:workers` resolves to |
+|--------|-------|---------|-----------------------------------|
+| `node` (Docker / k8s) | `bun run build:node:ci` → `.output/server/index.mjs` | Nitro `node-server` on `node:24-alpine` | `src/lib/cloudflare-workers-shim.ts` (`env` = `process.env`) |
+| `cloudflare` (default `bun run build` / `cf:build`) | `@cloudflare/vite-plugin` → workerd bundle | Cloudflare Workers | workerd built-in binding |
+
+### The contract (enforced by test)
+
+Server routes read config via `import { env } from 'cloudflare:workers'`. On the
+Node target that import is **aliased** to `cloudflare-workers-shim.ts`, which
+re-exports `env` backed by `process.env`. The shim re-exports **only `env`** —
+any other `cloudflare:workers` symbol (`WorkerEntrypoint`, `DurableObject`,
+`ExecutionContext`, …) would be `undefined` under Node and break the Node build
+**silently** (the Cloudflare target would still build and pass).
+
+Guarded by `apps/dashboard/src/lib/__tests__/cloudflare-workers-shim.test.ts`:
+the suite fails if any source file imports a symbol other than `env` from
+`cloudflare:workers`. To use a new binding under Node, re-export it (Node-safe)
+from the shim first.
+
+### Audit (2026-06-18)
+
+- Only `env` is imported from `cloudflare:workers` app-wide. ✅
+- `/api/healthz` host ping is bounded by `AbortSignal.timeout()` on both runtimes
+  (Node 18+ and workerd) — see [k8s-health-probes.md](k8s-health-probes.md).
+- Worker-critical paths (`/api/healthz`, `/api/v1/host-status`,
+  `/api/v1/notifications`) call `getClient({ web: true })` explicitly, so the
+  fetch-based `@clickhouse/client-web` is selected regardless of runtime
+  auto-detection.
+
+### Known follow-ups (not blocking either runtime)
+
+- `isCloudflareWorkers()` (`packages/clickhouse-client/.../runtime/cloudflare-workers.ts`)
+  gates its global-shape check behind `typeof process === 'undefined'`, which is
+  **false under `nodejs_compat`**. Auto-detection can mis-fire on a
+  nodejs_compat Worker; mitigated today by explicit `web: true` on critical
+  paths. Revisit (check `globalThis.caches` / `WebSocketPair` independently of
+  `process`) if a new route relies on auto-detection.
+- Most user-facing routes call `client.query()` with no client-side
+  `abort_signal` (they rely on server-side `max_execution_time`). A hung
+  ClickHouse host can stall those requests on both runtimes. Bounding them is a
+  latency-hardening pass, not a runtime-compat fix.
+
 ## Build Artifacts
 
 | Platform | Build Command | Entry Point |

--- a/docs/knowledge/k8s-health-probes.md
+++ b/docs/knowledge/k8s-health-probes.md
@@ -1,0 +1,141 @@
+---
+id: k8s-health-probes
+title: Kubernetes Health Probes — /healthz vs /api/healthz
+type: reference
+status: active
+updated: 2026-06-18
+tags:
+  - kubernetes
+  - healthz
+  - probes
+  - deployment
+  - helm
+related:
+  - deployment
+  - release-automation
+  - query-config-format
+---
+
+# Kubernetes Health Probes — `/healthz` vs `/api/healthz`
+
+The dashboard exposes **two** health endpoints with different semantics. Wiring
+them to the wrong kubelet probe is the #1 cause of chmonitor CrashLoopBackOff.
+
+| Endpoint | Route file | What it checks | Status when ClickHouse is down |
+|----------|------------|----------------|--------------------------------|
+| `GET /healthz` | `apps/dashboard/src/routes/healthz.ts` (+ `/heathz` typo alias) | **Process alive** — returns `200 OK` instantly, no I/O | **200** (process is still up) |
+| `GET /api/healthz` | `apps/dashboard/src/routes/api/healthz.ts` | **Ready to serve** — runs `SELECT 1` against every configured host | **503** (with `{ ok:false, hosts:[…] }`) |
+
+## Probe mapping (the contract)
+
+```
+startupProbe  -> /healthz       # ~60s grace for the Nitro Node server to bind
+livenessProbe -> /healthz       # static 200 = "don't kill me"
+readinessProbe-> /api/healthz   # 200 = "send me traffic"; 503 = "drop me from Service"
+```
+
+**Why split:** liveness must never depend on ClickHouse. If liveness gated on
+`/api/healthz`, a ClickHouse outage would make the kubelet **kill** every pod →
+CrashLoopBackOff on top of the CH outage. Liveness is process-only (`/healthz`);
+readiness is the only probe that pings ClickHouse, and readiness failure just
+removes the pod from the Service (no restart).
+
+## The `/api/healthz` timeout knob
+
+`/api/healthz` pings each host with a bounded abort so one slow/dead host can't
+hang the readiness check past the kubelet timeout:
+
+```ts
+abort_signal: AbortSignal.timeout(pingTimeoutMs) // default 3000ms
+```
+
+Override with the `CHM_HEALTHZ_TIMEOUT_MS` env var. **Constraint:**
+`readinessProbe.timeoutSeconds` MUST be `> CHM_HEALTHZ_TIMEOUT_MS` (default
+10s probe > 3s ping). `AbortSignal.timeout()` is supported on both runtimes
+(Node ≥18 and workerd), so the route is runtime-agnostic — see
+[deployment.md](deployment.md) for the dual Node/Worker target.
+
+## The `:latest` gotcha (real incident, 2026-06-18)
+
+The homelab deployed `image: ghcr.io/duyet/chmonitor:latest` with
+`imagePullPolicy: Always`. CI (`ci.yml`) rebuilds `:latest` on every `push:main`,
+but the image-build job had been **red for ~4 days** during a release-pipeline
+breakage. `:latest` still resolved to a 4-day-old image that **predated the
+`/healthz` route**. Result: liveness `/healthz` → **404** → 3 failures → kill →
+CrashLoopBackOff (`BackOff x37`).
+
+**Rules:**
+- In production, **pin the image** to a version tag or digest (`0.2.x`, or
+  `@sha256:…`), not `:latest`. The Helm chart defaults to the chart `appVersion`
+  for exactly this reason.
+- `:latest` + `Always` silently serves a stale image when CI is broken. If you
+  must use `:latest`, treat "liveness 404 on `/healthz`" as the signature of a
+  stale image — check when `:latest` was last built (`gh run list --workflow=ci.yml`).
+- Always include a `startupProbe` so a slow-booting Nitro server isn't killed
+  before it binds (liveness has no grace of its own once startup succeeds).
+
+## Non-Helm deployments (raw manifests / Kustomize)
+
+If you are **not** using the Helm chart, your Deployment `container` must include
+all three probes against the right paths. Minimal correct block:
+
+```yaml
+containers:
+  - name: chmonitor
+    image: ghcr.io/duyet/chmonitor:0.2.10   # PIN a version, do not use :latest
+    imagePullPolicy: IfNotPresent
+    ports:
+      - containerPort: 3000
+    # ~60s grace before liveness can kill a slow boot
+    startupProbe:
+      httpGet: { path: /healthz, port: 3000 }
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 12
+    # process-only — never gate on ClickHouse
+    livenessProbe:
+      httpGet: { path: /healthz, port: 3000 }
+      periodSeconds: 15
+      timeoutSeconds: 5
+      failureThreshold: 3
+    # readiness gates on ClickHouse; timeout MUST exceed CHM_HEALTHZ_TIMEOUT_MS (3s)
+    readinessProbe:
+      httpGet: { path: /api/healthz, port: 3000 }
+      periodSeconds: 15
+      timeoutSeconds: 10
+      failureThreshold: 3
+    resources:
+      requests: { cpu: 100m, memory: 256Mi }
+      limits:   { cpu: 500m, memory: 512Mi }   # TanStack Start SSR needs headroom
+```
+
+### Common mistakes → symptom
+
+| Mistake | Symptom |
+|---------|---------|
+| No `startupProbe` + slow boot | Liveness kills before bind → `BackOff` loop |
+| `livenessProbe` → `/api/healthz` | CH outage kills pods → CrashLoopBackOff |
+| `:latest` while CI is broken | Liveness `/healthz` → **404** (route missing in stale image) |
+| `readinessProbe.timeoutSeconds` ≤ ping timeout | Readiness flaps on slow CH even when healthy |
+| Memory limit < ~256Mi | OOMKilled during SSR → `BackOff` |
+
+## Adopting the Helm chart instead (preferred)
+
+The chart is published (OCI + GitHub Pages) and parameterizes all of the above.
+See [deployment.md](deployment.md). The probe block is overridable under
+`probes.{liveness,readiness,startup}` in `values.yaml` — you should not need raw
+manifests. If a deployment predates the chart (its comment says "no official helm
+chart"), migrate via the prompt below.
+
+## Migration prompt (hand to an agent)
+
+> Read `docs/knowledge/k8s-health-probes.md` in the clickhouse-monitoring repo.
+> Then update this Deployment's container so it matches the chart's probe
+> contract: add a `startupProbe` and `livenessProbe` to `/healthz`, point
+> `readinessProbe` at `/api/healthz` with `timeoutSeconds: 10`, replace
+> `image: …:latest` + `Always` with a pinned semver tag + `IfNotPresent`, and
+> raise the memory limit to ≥ 512Mi. Do NOT point liveness at `/api/healthz`.
+> After applying, run `kubectl rollout status deploy/<name>` and confirm
+> `/healthz` returns 200 and `/api/healthz` returns 200 (or 503 if ClickHouse is
+> intentionally down) — never 404.


### PR DESCRIPTION
## Why

The homelab chmonitor pod hit `CrashLoopBackOff` with liveness `/healthz` → **404**. Root cause: `ghcr.io/duyet/chmonitor:latest` was a **4-day-stale** image (built 2026-06-14 `ae78ad91`) that **predated the `/healthz` route** (added `e3886b63b` on 2026-06-18), while the CI image-build job had been red during the release-pipeline breakage (#1745/#1746). `:latest` has since rebuilt green and the pod self-heals, but this hardens the source + chart so the class of failure can't recur.

## Changes

- **`/api/healthz` bounded ping** (`apps/dashboard/src/routes/api/healthz.ts`): each host `SELECT 1` now runs with `abort_signal: AbortSignal.timeout(CHM_HEALTHZ_TIMEOUT_MS ?? 3000)`, so a dead/slow ClickHouse host can't hang the readiness probe past the kubelet `timeoutSeconds`. `AbortSignal.timeout()` works on **Node 18+ and workerd** → runtime-agnostic. **Back-compatible**: path, method, `200`/`503`, and JSON body are unchanged.
- **Parameterized Helm probes** (`values.yaml` + `deployment.yaml`): `probes.{liveness,readiness,startup}` paths + thresholds are now overridable. Defaults render **identically** to the previous hardcoded block (verified via `helm template`). Removes the reason deployments forked into raw manifests.
- **Dual-runtime guard test** (`cloudflare-workers-shim.test.ts`): enforces that only `{ env }` may be imported from `cloudflare:workers` app-wide, so the Node (Docker/k8s) build can't **silently break** when a second binding (`WorkerEntrypoint`, `DurableObject`, …) is imported. Proven non-vacuous (fails precisely on a planted offender).
- **Docs**: new `docs/knowledge/k8s-health-probes.md` (endpoint semantics, the `:latest` incident, non-helm manifest + migration prompt) and a dual-runtime section in `deployment.md`.

## Verification

- `bun run build` → `BUILD_EXIT=0`; `AbortSignal.timeout` present in the built `_ssr` bundle.
- `tsc -p tsconfig.test.json` → clean (switched the guard test off Bun-only `import.meta.dir` to portable `fileURLToPath`).
- Guard test: `1 pass`; negative control (planted `DurableObject` import) fails with a precise remediation message.
- `helm lint` clean; `helm template` confirms default parity + override behavior (e.g. `--set probes.startup.enabled=false` drops the startup block, `--set probes.readiness.timeoutSeconds=15` applies).

## Known follow-ups (documented, not blocking)

- `isCloudflareWorkers()` gates its global-shape check on `typeof process === 'undefined'`, which is false under `nodejs_compat`; mitigated by explicit `web:true` on critical paths.
- Most user-facing routes call `client.query()` without a client-side abort (latency hardening, not runtime-compat).

Co-Authored-By: duyetbot <bot@duyet.net>