### PR TITLE
docs(helm): point multiple-hosts install at charts.chmonitor.dev

### DIFF
--- a/docs/content/advanced/multiple-hosts.mdx
+++ b/docs/content/advanced/multiple-hosts.mdx
@@ -110,8 +110,8 @@ env:
 Install or upgrade:
 
 ```bash
-helm repo add duyet https://duyet.github.io/charts
-helm upgrade --install chmonitor duyet/clickhouse-monitoring -f values.yaml
+helm repo add chmonitor https://charts.chmonitor.dev
+helm upgrade --install chmonitor chmonitor/chmonitor -f values.yaml
 ```
 
 ---

--- a/docs/versions/v0.3/advanced/multiple-hosts.mdx
+++ b/docs/versions/v0.3/advanced/multiple-hosts.mdx
@@ -110,8 +110,8 @@ env:
 Install or upgrade:
 
 ```bash
-helm repo add duyet https://duyet.github.io/charts
-helm upgrade --install chmonitor duyet/clickhouse-monitoring -f values.yaml
+helm repo add chmonitor https://charts.chmonitor.dev
+helm upgrade --install chmonitor chmonitor/chmonitor -f values.yaml
 ```
 
 ---


### PR DESCRIPTION
Answer to "are the docs updated for the new helm charts domain?": **mostly — the main k8s doc was, but the multi-host guide was missed.**

## What was stale

`docs/content/advanced/multiple-hosts.mdx` (and its v0.3 versioned snapshot) still used the pre-rebrand chart path:

```diff
- helm repo add duyet https://duyet.github.io/charts
- helm upgrade --install chmonitor duyet/clickhouse-monitoring -f values.yaml
+ helm repo add chmonitor https://charts.chmonitor.dev
+ helm upgrade --install chmonitor chmonitor/chmonitor -f values.yaml
```

Now consistent with `deploy/k8s.mdx`. `docs/content` is the source `apps/docs` (docs.chmonitor.dev) regenerates from via `scripts/build-docs-content.ts`, so this also fixes the live docs site on next build.

## Separate (not in this PR)

`README.md` + `apps/dashboard/src/lib/error-utils.ts` still link to `duyet.github.io/clickhouse-monitoring/*` — but those are **docs-site** links (getting-started/deploy/etc.), not helm-repo links. The docs site moved to `docs.chmonitor.dev`; updating those is a separate docs-domain migration (~15 links), flagged for follow-up.

Co-Authored-By: duyetbot <bot@duyet.net>