### PR TITLE
fix(ci): publish chmonitor multi-arch manifest on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,17 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Publish the multi-arch manifest under BOTH the legacy image name and
+          # the new chmonitor brand (matches release.yml). Deployments (kustomize
+          # base, Helm chart, Dockerfile, docs) pull ghcr.io/duyet/chmonitor, but
+          # IMAGE_NAME (github.repository) is the legacy "clickhouse-monitoring".
+          # base.yml already dual-publishes the per-arch images; this mirrors the
+          # multi-arch manifest so chmonitor:latest/main/edge/sha move on each
+          # push to main. Without it, chmonitor:latest is frozen and the k8s
+          # liveness probe (/healthz) 404s on a stale image -> CrashLoopBackOff.
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/chmonitor
           tags: |
             type=ref,event=branch,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Why — this is the actual crash-loop root cause

PR #1749 fixed the source/chart, but the homelab pod **kept** CrashLoopBackOff-ing with liveness `/healthz` → 404 on a freshly-pulled `:latest`. Root cause:

- `IMAGE_NAME = github.repository` = **`clickhouse-monitoring`** (legacy).
- ci.yml's `docker-manifest` job published multi-arch tags (`latest`/`main`/`edge`/`sha`) **only** under `ghcr.io/duyet/clickhouse-monitoring`.
- **Every** deployment pulls the branded **`ghcr.io/duyet/chmonitor`** (kustomize base, Helm chart, Dockerfile, the migration doc in #1749, the homelab).
- So `chmonitor:latest` was **frozen** on a stale image that predated the `/healthz` route — CI was green, but the tag the world pulls never moved. The homelab's `imagePullPolicy: Always` faithfully re-pulled the same frozen digest (byte-identical 68010806) → `/healthz` 404 → kill loop.

`release.yml` already dual-publishes both names (on releases); ci.yml (push:main) was missing it, so `chmonitor:latest` drifted stale between releases.

## Fix

Add the `chmonitor` brand to ci.yml's `docker-manifest` metadata `images:` — exactly mirroring release.yml. The existing `imagetools create` loop then emits `chmonitor:latest/main/edge/sha` from the same per-arch images. `base.yml` already dual-publishes the per-arch images, so no arm64-job change is needed.

## Verification

- `/healthz` returns **200 on the Node Nitro target** (built locally with the same `build:node:ci` the image runs) — confirmed the source is correct; the only problem was image delivery.
- The merge-run manifest job showed it pushes `clickhouse-monitoring:latest` (digest `dd31a814…`) but **not** `chmonitor:latest` — this PR closes that gap.
- YAML validated; logic matches the proven release.yml pattern.

## After merge

The next push:main run will publish `chmonitor:latest`. The homelab (`imagePullPolicy: Always`) will then pull the fresh image with `/healthz` and recover. Immediate relief (optional, without waiting): point the homelab image at `ghcr.io/duyet/clickhouse-monitoring:latest` (the tag that already moves).

## Known follow-up (not in this PR)

The ARM64 cross-build uses a minimal Dockerfile with `CMD ["node", "server.js"]` — the wrong CMD (root Dockerfile fixed it to `server/index.mjs` in `e3886b63b`). Doesn't affect amd64 (duet-ubuntu) but breaks the ARM64 image at runtime. Worth a separate fix.

Co-Authored-By: duyetbot <bot@duyet.net>