### PR TITLE
feat(auth): add 'trusted' reverse-proxy auth mode with forwarded identity

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -93,6 +93,33 @@ OPENROUTER_APP_NAME=chmonitor
 # feature gate still 401s `authenticated` features. Truthy = 1/true/yes/on.
 # CHM_CLERK_PUBLIC_READ=
 
+# Trusted reverse-proxy auth (CHM_AUTH_PROVIDER=trusted) — use when an upstream
+# proxy (oauth2-proxy + Dex, Authelia, Traefik ForwardAuth, nginx auth-url)
+# forwards the user's full identity as HTTP headers. Builds a complete principal:
+# name, email, avatar, groups, custom claims.
+#
+# Trust gate — configure exactly one (app fails closed without either):
+#   CHM_TRUSTED_AUTH_SECRET       — shared secret the proxy sends per-request.
+#                                    Set via wrangler secret / k8s Secret; see below.
+#   CHM_TRUSTED_ALLOW_INSECURE    — skip secret check; only safe when the service
+#                                    is unreachable except via the proxy (k8s ClusterIP).
+# CHM_TRUSTED_ALLOW_INSECURE=false
+# CHM_TRUSTED_SHARED_SECRET_HEADER=X-Chm-Proxy-Secret
+#
+# Identity headers (defaults match oauth2-proxy --set-xauthrequest=false convention).
+# Override when your proxy uses different names — e.g. for oauth2-proxy with
+# --set-xauthrequest=true, set these to the X-Auth-Request-* equivalents:
+# CHM_TRUSTED_USER_HEADER=X-Forwarded-User
+# CHM_TRUSTED_EMAIL_HEADER=X-Forwarded-Email
+# CHM_TRUSTED_NAME_HEADER=X-Forwarded-Preferred-Username
+# CHM_TRUSTED_AVATAR_HEADER=X-Forwarded-Avatar
+# CHM_TRUSTED_GROUPS_HEADER=X-Forwarded-Groups
+# CHM_TRUSTED_ROLE_HEADER=X-Forwarded-Role
+# CHM_TRUSTED_CUSTOM_HEADERS=team:X-Forwarded-Team,dept:X-User-Dept
+#
+# Access control — optional; deny authenticated users not in the listed groups:
+# CHM_TRUSTED_ALLOWED_GROUPS=sre,ops,admin
+
 # ── 3. Secrets — server, sensitive (wrangler secret / CI) ───────────────────
 # NEVER commit real values. Comma-separated to match the HOST list above.
 CLICKHOUSE_PASSWORD=
@@ -109,6 +136,9 @@ AGENT_API_TOKEN=
 # Shared secret for proxy trusted-header auth (CHM_AUTH_PROVIDER=proxy). When
 # set, the proxy must send it in CHM_PROXY_SHARED_SECRET_HEADER.
 CHM_PROXY_AUTH_SECRET=
+# Shared secret for trusted forwarded-header auth (CHM_AUTH_PROVIDER=trusted).
+# The proxy must send it in CHM_TRUSTED_SHARED_SECRET_HEADER on every request.
+CHM_TRUSTED_AUTH_SECRET=
 # AI providers (set the one(s) you use).
 LLM_API_KEY=
 LLM_API_BASE=

--- a/apps/dashboard/src/components/nav-user.tsx
+++ b/apps/dashboard/src/components/nav-user.tsx
@@ -3,6 +3,7 @@ import { ChevronsUpDown, ExternalLink, Info, Settings } from 'lucide-react'
 import { ClerkNavWrapper as ClerkNavWrapperImpl } from './nav-user/clerk-nav'
 import { useState } from 'react'
 import { ClientOnly } from '@/components/client-only'
+import { useAuthIdentity } from '@/components/nav-user/use-auth-identity'
 import { useSettingsShortcut } from '@/components/nav-user/use-settings-shortcut'
 import { SettingsDialog } from '@/components/settings'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
@@ -44,6 +45,10 @@ export function NavUser({
 }) {
   const { isMobile } = useSidebar()
   const [settingsOpen, setSettingsOpen] = useState(false)
+  // Under reverse-proxy auth (`trusted`/`proxy`), show the forwarded identity
+  // instead of the static guest user. No-op for other providers.
+  const proxyIdentity = useAuthIdentity()
+  const displayUser = proxyIdentity ?? user
   const { config } = useFeaturePermissions()
   const canUseSettings = isFeatureAllowed(SETTINGS_FEATURE_PERMISSION, config)
   const openSettings = () => {
@@ -65,15 +70,15 @@ export function NavUser({
       data-testid="nav-user-trigger"
     >
       <Avatar className="avatar size-8 rounded-lg">
-        <AvatarImage src={user.avatar} alt={user.name} />
+        <AvatarImage src={displayUser.avatar} alt={displayUser.name} />
         <AvatarFallback className="rounded-lg">G</AvatarFallback>
       </Avatar>
       <div className="grid flex-1 text-left text-sm leading-tight">
         <span className="truncate font-medium" data-testid="nav-user-name">
-          {user.name}
+          {displayUser.name}
         </span>
         <span className="truncate text-xs" data-testid="nav-user-email">
-          {user.email}
+          {displayUser.email}
         </span>
       </div>
       <ChevronsUpDown className="ml-auto size-4" />
@@ -96,12 +101,19 @@ export function NavUser({
                 <DropdownMenuLabel className="p-0 font-normal">
                   <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
                     <Avatar className="avatar size-8 rounded-lg">
-                      <AvatarImage src={user.avatar} alt={user.name} />
+                      <AvatarImage
+                        src={displayUser.avatar}
+                        alt={displayUser.name}
+                      />
                       <AvatarFallback className="rounded-lg">G</AvatarFallback>
                     </Avatar>
                     <div className="grid flex-1 text-left text-sm leading-tight">
-                      <span className="truncate font-medium">{user.name}</span>
-                      <span className="truncate text-xs">{user.email}</span>
+                      <span className="truncate font-medium">
+                        {displayUser.name}
+                      </span>
+                      <span className="truncate text-xs">
+                        {displayUser.email}
+                      </span>
                     </div>
                   </div>
                 </DropdownMenuLabel>

--- a/apps/dashboard/src/components/nav-user/use-auth-identity.ts
+++ b/apps/dashboard/src/components/nav-user/use-auth-identity.ts
@@ -1,0 +1,67 @@
+/**
+ * Fetch the signed-in principal from `/api/v1/auth/me` so the sidebar user menu
+ * can show a real name / email / avatar under reverse-proxy auth.
+ *
+ * Only runs for the `trusted` and `proxy` providers — for `none` there is no
+ * principal, and `clerk` has its own `useUser()`-backed menu (clerk-nav.tsx).
+ * The provider is the build-time `VITE_AUTH_PROVIDER` constant, so the query is
+ * tree-shaken to a no-op in deployments that don't use proxy auth.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+
+export interface AuthIdentity {
+  name: string
+  email: string
+  avatar: string
+}
+
+interface MeResponse {
+  authenticated: boolean
+  principal: {
+    subject: string
+    name?: string
+    email?: string
+    avatarUrl?: string
+    roles?: string[]
+    custom?: Record<string, string>
+  } | null
+}
+
+const PROXY_PROVIDERS = new Set(['trusted', 'proxy'])
+
+function proxyAuthEnabled(): boolean {
+  return PROXY_PROVIDERS.has(import.meta.env.VITE_AUTH_PROVIDER ?? '')
+}
+
+async function fetchMe(): Promise<MeResponse | null> {
+  const res = await fetch('/api/v1/auth/me', {
+    headers: { accept: 'application/json' },
+  })
+  if (!res.ok) return null
+  return (await res.json()) as MeResponse
+}
+
+/**
+ * Returns the proxy-forwarded identity, or null when unavailable (other auth
+ * mode, anonymous, or still loading). Callers fall back to the guest user.
+ */
+export function useAuthIdentity(): AuthIdentity | null {
+  const enabled = proxyAuthEnabled()
+  const { data } = useQuery({
+    queryKey: ['auth', 'me'],
+    queryFn: fetchMe,
+    enabled,
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  })
+
+  if (!enabled || !data?.authenticated || !data.principal) return null
+
+  const { subject, name, email, avatarUrl } = data.principal
+  return {
+    name: name ?? email ?? subject,
+    email: email ?? subject,
+    avatar: avatarUrl ?? '',
+  }
+}

--- a/apps/dashboard/src/lib/auth/provider.test.ts
+++ b/apps/dashboard/src/lib/auth/provider.test.ts
@@ -29,6 +29,13 @@ describe('parseAuthProvider', () => {
     expect(parseAuthProvider(' CLERK ')).toBe('clerk')
   })
 
+  test('accepts proxy and trusted providers', () => {
+    expect(parseAuthProvider('proxy')).toBe('proxy')
+    expect(parseAuthProvider(' PROXY ')).toBe('proxy')
+    expect(parseAuthProvider('trusted')).toBe('trusted')
+    expect(parseAuthProvider(' Trusted ')).toBe('trusted')
+  })
+
   test('rejects unknown providers', () => {
     expect(() => parseAuthProvider('basic')).toThrow(AuthProviderConfigError)
   })

--- a/apps/dashboard/src/lib/auth/provider.ts
+++ b/apps/dashboard/src/lib/auth/provider.ts
@@ -6,7 +6,7 @@ export const AUTH_PROVIDER_ENV_VARS = [
   'VITE_AUTH_PROVIDER',
 ] as const
 
-export const AUTH_PROVIDERS = ['none', 'clerk', 'proxy'] as const
+export const AUTH_PROVIDERS = ['none', 'clerk', 'proxy', 'trusted'] as const
 
 export type AuthProvider = (typeof AUTH_PROVIDERS)[number]
 
@@ -15,7 +15,7 @@ export class AuthProviderConfigError extends Error {
     super(
       `Invalid auth provider value "${value}" in ${AUTH_PROVIDER_ENV_VARS.join(
         ' or '
-      )}. Expected one of: none, clerk, proxy.`
+      )}. Expected one of: none, clerk, proxy, trusted.`
     )
     this.name = 'AuthProviderConfigError'
   }
@@ -36,6 +36,10 @@ export function parseAuthProvider(
 
   if (normalized === 'proxy') {
     return 'proxy'
+  }
+
+  if (normalized === 'trusted') {
+    return 'trusted'
   }
 
   throw new AuthProviderConfigError(value ?? '')

--- a/apps/dashboard/src/lib/auth/providers/__tests__/trusted.test.ts
+++ b/apps/dashboard/src/lib/auth/providers/__tests__/trusted.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for the trusted reverse-proxy auth provider (trusted.ts).
+ *
+ * Covers the full surface:
+ *   - trust gate: shared-secret match, constant-time compare, insecure opt-in,
+ *     fail-closed when neither is configured
+ *   - identity extraction: subject (user→email fallback), name, email, avatar,
+ *     roles (groups + role header, de-duplicated), custom header mapping
+ *   - group gating: CHM_TRUSTED_ALLOWED_GROUPS intersection
+ *   - custom header names via env overrides
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { TrustedAuthProvider } from '@/lib/auth/providers/trusted'
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request('https://example.com/api/v1/test', { headers })
+}
+
+const originalEnv: Record<string, string | undefined> = {}
+const MANAGED_KEYS = [
+  'CHM_TRUSTED_AUTH_SECRET',
+  'CHM_TRUSTED_SHARED_SECRET_HEADER',
+  'CHM_TRUSTED_ALLOW_INSECURE',
+  'CHM_TRUSTED_USER_HEADER',
+  'CHM_TRUSTED_EMAIL_HEADER',
+  'CHM_TRUSTED_NAME_HEADER',
+  'CHM_TRUSTED_AVATAR_HEADER',
+  'CHM_TRUSTED_GROUPS_HEADER',
+  'CHM_TRUSTED_ROLE_HEADER',
+  'CHM_TRUSTED_CUSTOM_HEADERS',
+  'CHM_TRUSTED_ALLOWED_GROUPS',
+]
+
+beforeEach(() => {
+  for (const key of MANAGED_KEYS) {
+    originalEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+})
+
+afterEach(() => {
+  for (const key of MANAGED_KEYS) {
+    if (originalEnv[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = originalEnv[key]
+    }
+  }
+})
+
+const provider = new TrustedAuthProvider()
+
+// ---------------------------------------------------------------------------
+// Trust gate
+// ---------------------------------------------------------------------------
+
+describe('TrustedAuthProvider — trust gate', () => {
+  test('fails closed when neither secret nor insecure opt-in is set', async () => {
+    const result = await provider.authenticateRequest(
+      makeRequest({ 'X-Forwarded-User': 'alice@example.com' })
+    )
+    expect(result.authenticated).toBe(false)
+  })
+
+  test('authenticates with insecure opt-in (no secret)', async () => {
+    process.env.CHM_TRUSTED_ALLOW_INSECURE = 'true'
+    const result = await provider.authenticateRequest(
+      makeRequest({ 'X-Forwarded-User': 'alice@example.com' })
+    )
+    expect(result.authenticated).toBe(true)
+    expect(result.subject).toBe('alice@example.com')
+  })
+
+  test('requires the shared secret header when a secret is configured', async () => {
+    process.env.CHM_TRUSTED_AUTH_SECRET = 'correct-secret'
+    const result = await provider.authenticateRequest(
+      makeRequest({ 'X-Forwarded-User': 'alice@example.com' })
+    )
+    expect(result.authenticated).toBe(false)
+  })
+
+  test('authenticates when the shared secret matches', async () => {
+    process.env.CHM_TRUSTED_AUTH_SECRET = 'correct-secret'
+    const result = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'alice@example.com',
+        'X-Chm-Proxy-Secret': 'correct-secret',
+      })
+    )
+    expect(result.authenticated).toBe(true)
+    expect(result.subject).toBe('alice@example.com')
+  })
+
+  test('denies on secret mismatch (constant-time)', async () => {
+    process.env.CHM_TRUSTED_AUTH_SECRET = 'correct-secret'
+    for (const wrong of [
+      'correct-secreX',
+      'correct-secret!',
+      'correct-secre',
+    ]) {
+      const result = await provider.authenticateRequest(
+        makeRequest({
+          'X-Forwarded-User': 'alice@example.com',
+          'X-Chm-Proxy-Secret': wrong,
+        })
+      )
+      expect(result.authenticated).toBe(false)
+    }
+  })
+
+  test('uses a custom shared-secret header name', async () => {
+    process.env.CHM_TRUSTED_AUTH_SECRET = 'secret123'
+    process.env.CHM_TRUSTED_SHARED_SECRET_HEADER = 'X-Internal-Token'
+    const result = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'alice@example.com',
+        'X-Internal-Token': 'secret123',
+      })
+    )
+    expect(result.authenticated).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Identity extraction
+// ---------------------------------------------------------------------------
+
+describe('TrustedAuthProvider — identity extraction', () => {
+  beforeEach(() => {
+    process.env.CHM_TRUSTED_ALLOW_INSECURE = 'true'
+  })
+
+  test('denies when no identity header is present', async () => {
+    const result = await provider.authenticateRequest(makeRequest())
+    expect(result.authenticated).toBe(false)
+  })
+
+  test('falls back to the email header for the subject', async () => {
+    const result = await provider.authenticateRequest(
+      makeRequest({ 'X-Forwarded-Email': 'bob@example.com' })
+    )
+    expect(result.authenticated).toBe(true)
+    expect(result.subject).toBe('bob@example.com')
+    expect(result.principal?.email).toBe('bob@example.com')
+  })
+
+  test('builds a full principal from standard oauth2-proxy headers', async () => {
+    const result = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'alice',
+        'X-Forwarded-Email': 'alice@example.com',
+        'X-Forwarded-Preferred-Username': 'Alice Liddell',
+        'X-Forwarded-Avatar': 'https://cdn.example.com/alice.png',
+        'X-Forwarded-Groups': 'admins,sre,oncall',
+      })
+    )
+    expect(result.authenticated).toBe(true)
+    expect(result.principal).toEqual({
+      subject: 'alice',
+      name: 'Alice Liddell',
+      email: 'alice@example.com',
+      avatarUrl: 'https://cdn.example.com/alice.png',
+      roles: ['admins', 'sre', 'oncall'],
+    })
+  })
+
+  test('merges and de-duplicates groups + role header', async () => {
+    const result = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'alice',
+        'X-Forwarded-Groups': 'admins, sre',
+        'X-Forwarded-Role': 'admins',
+      })
+    )
+    expect(result.principal?.roles).toEqual(['admins', 'sre'])
+  })
+
+  test('maps custom headers into principal.custom', async () => {
+    process.env.CHM_TRUSTED_CUSTOM_HEADERS = 'team:X-Forwarded-Team,dept:X-Dept'
+    const result = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'alice',
+        'X-Forwarded-Team': 'platform',
+        'X-Dept': 'engineering',
+      })
+    )
+    expect(result.principal?.custom).toEqual({
+      team: 'platform',
+      dept: 'engineering',
+    })
+  })
+
+  test('honors custom identity header names', async () => {
+    process.env.CHM_TRUSTED_USER_HEADER = 'X-Auth-Request-User'
+    process.env.CHM_TRUSTED_EMAIL_HEADER = 'X-Auth-Request-Email'
+    const result = await provider.authenticateRequest(
+      makeRequest({
+        'X-Auth-Request-User': 'carol',
+        'X-Auth-Request-Email': 'carol@example.com',
+      })
+    )
+    expect(result.authenticated).toBe(true)
+    expect(result.subject).toBe('carol')
+    expect(result.principal?.email).toBe('carol@example.com')
+  })
+
+  test('omits optional fields when their headers are absent', async () => {
+    const result = await provider.authenticateRequest(
+      makeRequest({ 'X-Forwarded-User': 'alice' })
+    )
+    expect(result.principal).toEqual({ subject: 'alice' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Group gating (permission matrix combination)
+// ---------------------------------------------------------------------------
+
+describe('TrustedAuthProvider — group gating', () => {
+  beforeEach(() => {
+    process.env.CHM_TRUSTED_ALLOW_INSECURE = 'true'
+    process.env.CHM_TRUSTED_ALLOWED_GROUPS = 'sre, platform-admins'
+  })
+
+  test('allows a user in an allowed group (case-insensitive)', async () => {
+    const result = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'alice',
+        'X-Forwarded-Groups': 'developers,SRE',
+      })
+    )
+    expect(result.authenticated).toBe(true)
+  })
+
+  test('denies a user with no matching group', async () => {
+    const result = await provider.authenticateRequest(
+      makeRequest({
+        'X-Forwarded-User': 'mallory',
+        'X-Forwarded-Groups': 'interns',
+      })
+    )
+    expect(result.authenticated).toBe(false)
+  })
+
+  test('denies an authenticated user carrying no groups', async () => {
+    const result = await provider.authenticateRequest(
+      makeRequest({ 'X-Forwarded-User': 'alice' })
+    )
+    expect(result.authenticated).toBe(false)
+  })
+})

--- a/apps/dashboard/src/lib/auth/providers/constant-time.ts
+++ b/apps/dashboard/src/lib/auth/providers/constant-time.ts
@@ -1,0 +1,28 @@
+/**
+ * Timing-safe secret comparison, shared by the reverse-proxy auth providers
+ * (`proxy`, `trusted`).
+ *
+ * Both providers trust a proxy-supplied identity header ONLY when a shared
+ * secret header matches the configured secret. Comparing that secret with a
+ * normal `===` leaks length/prefix information through timing; a single
+ * constant-time comparator removes that and avoids the two providers drifting
+ * apart on a security-critical primitive.
+ */
+
+/** Constant-time byte comparison. Returns false immediately on length mismatch. */
+export function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false
+
+  let diff = 0
+  for (let index = 0; index < a.length; index += 1) {
+    diff |= a[index] ^ b[index]
+  }
+
+  return diff === 0
+}
+
+/** Constant-time string secret comparison (UTF-8 encoded). */
+export function secretsMatch(provided: string, expected: string): boolean {
+  const encoder = new TextEncoder()
+  return constantTimeEqual(encoder.encode(provided), encoder.encode(expected))
+}

--- a/apps/dashboard/src/lib/auth/providers/index.ts
+++ b/apps/dashboard/src/lib/auth/providers/index.ts
@@ -4,14 +4,16 @@ import type { ServerAuthProvider } from './types'
 import { ClerkAuthProvider } from './clerk'
 import { NoneAuthProvider } from './none'
 import { ProxyAuthProvider } from './proxy'
+import { TrustedAuthProvider } from './trusted'
 
-export type { AuthResult, ServerAuthProvider } from './types'
+export type { AuthPrincipal, AuthResult, ServerAuthProvider } from './types'
 
 // Provider implementations are stateless (config is read per request from
 // process.env / import.meta.env), so a single instance per kind is reused.
 const noneProvider = new NoneAuthProvider()
 const clerkProvider = new ClerkAuthProvider()
 const proxyProvider = new ProxyAuthProvider()
+const trustedProvider = new TrustedAuthProvider()
 
 /**
  * Resolve the server-side auth provider for the active `AuthProvider`.
@@ -28,6 +30,8 @@ export function resolveServerAuthProvider(
       return clerkProvider
     case 'proxy':
       return proxyProvider
+    case 'trusted':
+      return trustedProvider
     default:
       return noneProvider
   }

--- a/apps/dashboard/src/lib/auth/providers/proxy.ts
+++ b/apps/dashboard/src/lib/auth/providers/proxy.ts
@@ -22,6 +22,8 @@
 
 import type { AuthResult, ServerAuthProvider } from './types'
 
+import { constantTimeEqual } from './constant-time'
+
 const CF_ACCESS_JWT_HEADER = 'Cf-Access-Jwt-Assertion'
 const DEFAULT_SHARED_SECRET_HEADER = 'X-Chm-Proxy-Secret'
 const DEFAULT_IDENTITY_HEADER = 'X-Forwarded-User'
@@ -56,17 +58,6 @@ function unb64url(input: string): Uint8Array<ArrayBuffer> | null {
   } catch {
     return null
   }
-}
-
-function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.length !== b.length) return false
-
-  let diff = 0
-  for (let index = 0; index < a.length; index += 1) {
-    diff |= a[index] ^ b[index]
-  }
-
-  return diff === 0
 }
 
 interface JwtParts {

--- a/apps/dashboard/src/lib/auth/providers/trusted.ts
+++ b/apps/dashboard/src/lib/auth/providers/trusted.ts
@@ -1,0 +1,196 @@
+/**
+ * Trusted reverse-proxy auth provider.
+ *
+ * For deployments where chmonitor sits behind a proxy that performs the real
+ * login (oauth2-proxy + Dex, Authelia, Traefik forward-auth, an nginx SSO
+ * module, …) and forwards the authenticated user's identity as plain HTTP
+ * headers. The worker TRUSTS those headers and builds a rich principal from
+ * them: subject, name, email, avatar, roles/groups, plus arbitrary
+ * deployment-defined custom claims.
+ *
+ * Difference vs the `proxy` provider: `proxy` is Cloudflare-Access-centric (it
+ * verifies a signed `Cf-Access-Jwt-Assertion` JWT) and only extracts a bare
+ * subject. `trusted` is forwarded-header-centric and extracts a full profile,
+ * and can gate access on group/role membership (combining with the feature
+ * permission matrix).
+ *
+ * SECURITY — header forgery. Forwarded headers are only trustworthy when the
+ * worker is reachable EXCLUSIVELY through the proxy (the proxy overwrites the
+ * identity headers on every request, stripping any a client tried to inject).
+ * On a publicly-reachable worker any client could forge `X-Forwarded-User`. So
+ * this provider authenticates only when ONE of the following holds:
+ *
+ *   (a) `CHM_TRUSTED_AUTH_SECRET` is set and the request carries a matching
+ *       shared-secret header (constant-time compare) — the proxy proves itself
+ *       with a secret the public cannot know; or
+ *   (b) `CHM_TRUSTED_ALLOW_INSECURE=true` is set — an explicit operator
+ *       acknowledgement that the worker is network-isolated behind the proxy
+ *       (e.g. a Kubernetes ClusterIP service only reachable via the ingress).
+ *
+ * With neither, the provider FAILS CLOSED (denies every request) and warns, so
+ * a misconfigured public deployment never silently trusts forged headers.
+ */
+
+import type { AuthPrincipal, AuthResult, ServerAuthProvider } from './types'
+
+import { secretsMatch } from './constant-time'
+
+const DEFAULTS = {
+  userHeader: 'X-Forwarded-User',
+  emailHeader: 'X-Forwarded-Email',
+  nameHeader: 'X-Forwarded-Preferred-Username',
+  avatarHeader: 'X-Forwarded-Avatar',
+  groupsHeader: 'X-Forwarded-Groups',
+  roleHeader: 'X-Forwarded-Role',
+  secretHeader: 'X-Chm-Proxy-Secret',
+} as const
+
+function env(key: string): string | undefined {
+  if (typeof process === 'undefined' || !process.env) return undefined
+  const value = process.env[key]
+  return value === undefined || value === '' ? undefined : value
+}
+
+function header(request: Request, name: string): string | undefined {
+  const value = request.headers.get(name)
+  return value === null || value === '' ? undefined : value
+}
+
+function parseBoolean(value: string | undefined): boolean {
+  if (!value) return false
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase())
+}
+
+/** Split a delimited list header (comma- or space-separated) into trimmed items. */
+function parseList(value: string | undefined): string[] {
+  if (!value) return []
+  return value
+    .split(/[\s,]+/)
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+/**
+ * Parse `field:Header-Name` pairs from CHM_TRUSTED_CUSTOM_HEADERS into a map of
+ * principal-claim key → header name. Invalid pairs (missing colon or empty
+ * side) are skipped. e.g. `team:X-Forwarded-Team,dept:X-User-Dept`.
+ */
+function parseCustomHeaderMap(
+  value: string | undefined
+): Record<string, string> {
+  const map: Record<string, string> = {}
+  for (const pair of parseList(value).flatMap((v) => v.split(','))) {
+    const idx = pair.indexOf(':')
+    if (idx <= 0) continue
+    const field = pair.slice(0, idx).trim()
+    const headerName = pair.slice(idx + 1).trim()
+    if (field && headerName) map[field] = headerName
+  }
+  return map
+}
+
+/**
+ * Decide whether the proxy has proven itself for THIS request.
+ *
+ * Returns:
+ *  - `true`  → trust the forwarded headers (secret matched, or insecure opt-in)
+ *  - `false` → do not trust (no secret/opt-in, or secret mismatch/absent)
+ */
+function proxyIsTrusted(request: Request): boolean {
+  const sharedSecret = env('CHM_TRUSTED_AUTH_SECRET')
+
+  if (sharedSecret) {
+    const secretHeaderName =
+      env('CHM_TRUSTED_SHARED_SECRET_HEADER') ?? DEFAULTS.secretHeader
+    const provided = header(request, secretHeaderName)
+    if (!provided) return false
+    return secretsMatch(provided, sharedSecret)
+  }
+
+  if (parseBoolean(env('CHM_TRUSTED_ALLOW_INSECURE'))) return true
+
+  // No secret and no explicit insecure opt-in: refuse to trust headers.
+  console.warn(
+    '[auth:trusted] CHM_AUTH_PROVIDER=trusted but neither CHM_TRUSTED_AUTH_SECRET ' +
+      'nor CHM_TRUSTED_ALLOW_INSECURE is set. Forwarded identity headers are NOT ' +
+      'trusted (failing closed). Set a shared secret, or set ' +
+      'CHM_TRUSTED_ALLOW_INSECURE=true only when the worker is network-isolated behind the proxy.'
+  )
+  return false
+}
+
+/** Build a principal from forwarded identity headers, or null when no subject. */
+function readPrincipal(request: Request): AuthPrincipal | null {
+  const userHeader = env('CHM_TRUSTED_USER_HEADER') ?? DEFAULTS.userHeader
+  const emailHeader = env('CHM_TRUSTED_EMAIL_HEADER') ?? DEFAULTS.emailHeader
+
+  const user = header(request, userHeader)
+  const email = header(request, emailHeader)
+
+  // Subject identifies the principal: prefer the user header, fall back to
+  // email. Without either there is no usable identity → not authenticated.
+  const subject = user ?? email
+  if (!subject) return null
+
+  const nameHeader = env('CHM_TRUSTED_NAME_HEADER') ?? DEFAULTS.nameHeader
+  const avatarHeader = env('CHM_TRUSTED_AVATAR_HEADER') ?? DEFAULTS.avatarHeader
+  const groupsHeader = env('CHM_TRUSTED_GROUPS_HEADER') ?? DEFAULTS.groupsHeader
+  const roleHeader = env('CHM_TRUSTED_ROLE_HEADER') ?? DEFAULTS.roleHeader
+
+  // Roles come from the groups header plus an optional single-role header,
+  // de-duplicated while preserving order.
+  const roles = Array.from(
+    new Set([
+      ...parseList(header(request, groupsHeader)),
+      ...parseList(header(request, roleHeader)),
+    ])
+  )
+
+  const custom: Record<string, string> = {}
+  for (const [field, headerName] of Object.entries(
+    parseCustomHeaderMap(env('CHM_TRUSTED_CUSTOM_HEADERS'))
+  )) {
+    const value = header(request, headerName)
+    if (value !== undefined) custom[field] = value
+  }
+
+  const principal: AuthPrincipal = { subject }
+  const name = header(request, nameHeader)
+  if (name) principal.name = name
+  if (email) principal.email = email
+  const avatarUrl = header(request, avatarHeader)
+  if (avatarUrl) principal.avatarUrl = avatarUrl
+  if (roles.length > 0) principal.roles = roles
+  if (Object.keys(custom).length > 0) principal.custom = custom
+
+  return principal
+}
+
+/**
+ * Gate access on group/role membership. When `CHM_TRUSTED_ALLOWED_GROUPS` is
+ * set (comma list), the principal must carry at least one matching role/group
+ * (case-insensitive) — otherwise access is denied even though the proxy
+ * authenticated them. Unset → no group restriction (any authenticated user).
+ */
+function passesGroupGate(principal: AuthPrincipal): boolean {
+  const allowed = parseList(env('CHM_TRUSTED_ALLOWED_GROUPS')).map((g) =>
+    g.toLowerCase()
+  )
+  if (allowed.length === 0) return true
+
+  const have = new Set((principal.roles ?? []).map((r) => r.toLowerCase()))
+  return allowed.some((g) => have.has(g))
+}
+
+export class TrustedAuthProvider implements ServerAuthProvider {
+  async authenticateRequest(request: Request): Promise<AuthResult> {
+    if (!proxyIsTrusted(request)) return { authenticated: false }
+
+    const principal = readPrincipal(request)
+    if (!principal) return { authenticated: false }
+
+    if (!passesGroupGate(principal)) return { authenticated: false }
+
+    return { authenticated: true, subject: principal.subject, principal }
+  }
+}

--- a/apps/dashboard/src/lib/auth/providers/types.ts
+++ b/apps/dashboard/src/lib/auth/providers/types.ts
@@ -3,17 +3,45 @@
  *
  * A `ServerAuthProvider` answers one question for an incoming `/api/v1`
  * request: is the caller an authenticated principal? Each configured auth
- * provider (`none` / `clerk` / `proxy`) supplies one implementation; the guard
- * in `api-guard.ts` resolves the active one via `resolveServerAuthProvider`.
+ * provider (`none` / `clerk` / `proxy` / `trusted`) supplies one
+ * implementation; the guard in `api-guard.ts` resolves the active one via
+ * `resolveServerAuthProvider`.
  *
  * Every implementation MUST fail closed — any internal error or missing config
  * resolves to `{ authenticated: false }` rather than throwing, so a misconfig
  * never accidentally grants access.
  */
+
+/**
+ * Rich identity for an authenticated principal.
+ *
+ * Populated by providers that can extract a profile (notably `trusted`, which
+ * reads forwarded headers from a reverse proxy). `subject` is the only required
+ * field; everything else is best-effort and surfaced to the UI (avatar, name)
+ * and to the permission layer (`roles`). `custom` carries deployment-defined
+ * extra claims mapped from arbitrary headers.
+ */
+export interface AuthPrincipal {
+  /** Stable identifier for the principal (user id, email, …). */
+  subject: string
+  /** Human-readable display name, when the proxy forwards one. */
+  name?: string
+  /** Email address, when forwarded. */
+  email?: string
+  /** Avatar/picture URL, when forwarded. */
+  avatarUrl?: string
+  /** Roles or groups the principal belongs to (e.g. Dex/OIDC groups). */
+  roles?: string[]
+  /** Arbitrary deployment-defined claims mapped from custom headers. */
+  custom?: Record<string, string>
+}
+
 export interface AuthResult {
   authenticated: boolean
   /** Stable identifier for the principal (user id, email, …) when known. */
   subject?: string
+  /** Rich profile for the principal, when the provider can supply one. */
+  principal?: AuthPrincipal
 }
 
 export interface ServerAuthProvider {

--- a/apps/dashboard/src/lib/feature-permissions/server.ts
+++ b/apps/dashboard/src/lib/feature-permissions/server.ts
@@ -165,6 +165,20 @@ async function isAuthenticatedRequest(
     return true
   }
 
+  // Reverse-proxy providers authenticate by re-running their own header/JWT
+  // check against this request. Without this, `authenticated`-access features
+  // (agent, writes) would 401 even for a proxy-authenticated caller, because
+  // the matrix would treat every proxy request as anonymous. Dynamic import
+  // keeps the provider graph (and Clerk's SDK via the index) out of this
+  // module's static bundle.
+  if (config.authProvider === 'proxy' || config.authProvider === 'trusted') {
+    const { resolveServerAuthProvider } = await import('@/lib/auth/providers')
+    const result = await resolveServerAuthProvider(
+      config.authProvider
+    ).authenticateRequest(request)
+    return result.authenticated
+  }
+
   if (config.authProvider !== 'clerk') return false
 
   try {

--- a/apps/dashboard/src/lib/feature-permissions/shared.ts
+++ b/apps/dashboard/src/lib/feature-permissions/shared.ts
@@ -22,7 +22,7 @@ export const DEFAULT_FEATURE_STATE: FeatureState = {
  *
  *  - `none`                       → read + write   (everyone is authenticated)
  *  - `clerk` + CHM_CLERK_PUBLIC_READ → read only   (the dash / dash posture)
- *  - `clerk` (default) / `proxy`  → nothing        (sign in / proxy-auth required)
+ *  - `clerk` (default) / `proxy` / `trusted` → nothing (sign in / proxy-auth required)
  *
  * Authenticated callers always get read + write; this only describes the
  * anonymous baseline. Pure (publicRead passed in) so it is shared by the server

--- a/apps/dashboard/src/lib/feature-permissions/types.ts
+++ b/apps/dashboard/src/lib/feature-permissions/types.ts
@@ -82,7 +82,7 @@ export interface UserConnectionsPublicConfig {
 }
 
 export interface PublicFeaturePermissionConfig {
-  authProvider: 'none' | 'clerk' | 'proxy'
+  authProvider: 'none' | 'clerk' | 'proxy' | 'trusted'
   principal: Principal
   features: FeatureOverrides
   resolved?: ResolvedFeatureStates

--- a/apps/dashboard/src/routes/api/v1/auth/me.ts
+++ b/apps/dashboard/src/routes/api/v1/auth/me.ts
@@ -1,0 +1,78 @@
+/**
+ * Current-principal endpoint
+ * GET /api/v1/auth/me
+ *
+ * Returns the identity the active auth provider derives from the request, so
+ * the client (sidebar user menu) can show the signed-in user's name, email and
+ * avatar instead of the static "Guest" placeholder.
+ *
+ * This is the only place a rich principal is exposed to the browser: the
+ * `/api/v1/config` endpoint always reports `principal: 'anonymous'` (it cannot
+ * run per-request auth on workerd). Here we run the provider against the
+ * incoming request — under `trusted`/`proxy` the proxy has already attached the
+ * identity headers/JWT to THIS request, so the provider can read them.
+ *
+ * Response: `{ authenticated, provider, principal | null }`. Never cached
+ * (identity is per-request). Fails closed: any error → unauthenticated.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { AuthPrincipal } from '@/lib/auth/providers/types'
+
+import { getAuthProvider } from '@/lib/auth/provider'
+import { resolveServerAuthProvider } from '@/lib/auth/providers'
+
+interface MeResponse {
+  authenticated: boolean
+  provider: ReturnType<typeof getAuthProvider>
+  principal: AuthPrincipal | null
+}
+
+const NO_STORE = { 'Cache-Control': 'no-store' } as const
+
+async function handleGet(request: Request): Promise<Response> {
+  let provider: ReturnType<typeof getAuthProvider>
+  try {
+    provider = getAuthProvider()
+  } catch {
+    const body: MeResponse = {
+      authenticated: false,
+      provider: 'none',
+      principal: null,
+    }
+    return Response.json(body, { headers: NO_STORE })
+  }
+
+  // `none`: the dashboard is public; there is no principal to report.
+  if (provider === 'none') {
+    const body: MeResponse = { authenticated: true, provider, principal: null }
+    return Response.json(body, { headers: NO_STORE })
+  }
+
+  const result =
+    await resolveServerAuthProvider(provider).authenticateRequest(request)
+
+  // Prefer the rich principal; fall back to a subject-only principal for
+  // providers (clerk/proxy) that authenticate without a full profile.
+  const principal: AuthPrincipal | null = result.principal
+    ? result.principal
+    : result.subject
+      ? { subject: result.subject }
+      : null
+
+  const body: MeResponse = {
+    authenticated: result.authenticated,
+    provider,
+    principal: result.authenticated ? principal : null,
+  }
+  return Response.json(body, { headers: NO_STORE })
+}
+
+export const Route = createFileRoute('/api/v1/auth/me')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => handleGet(request),
+    },
+  },
+})

--- a/apps/docs/src/lib/nav-icons.ts
+++ b/apps/docs/src/lib/nav-icons.ts
@@ -116,6 +116,7 @@ const PAGE_ICONS: Record<string, NavIconName> = {
   'authentication/public': 'unlock',
   'authentication/cloudflare-access': 'shield-check',
   'authentication/trusted-header': 'badge-check',
+  'authentication/trusted-proxy': 'badge-check',
   'migrating/v0-3': 'arrow-right-left',
   'releases/v0-3': 'gift',
   faq: 'help-circle',

--- a/deploy/helm/chmonitor/README.md
+++ b/deploy/helm/chmonitor/README.md
@@ -46,6 +46,19 @@ helm uninstall my-chm
 | `clickhouse.password` | `""` | Comma-separated passwords; stored in a Secret (`CLICKHOUSE_PASSWORD`). |
 | `clickhouse.maxExecutionTime` | `"60"` | Query timeout in seconds (`CLICKHOUSE_MAX_EXECUTION_TIME`). |
 | `clickhouse.existingSecret` | `""` | Use an existing Secret (key `CLICKHOUSE_PASSWORD`) instead of `clickhouse.password`. |
+| `auth.provider` | `""` | Auth provider: `""` / `none` / `clerk` / `proxy` / `trusted`. Sets `CHM_AUTH_PROVIDER`. |
+| `auth.trusted.allowInsecure` | `false` | Trust forwarded headers with no shared secret (`CHM_TRUSTED_ALLOW_INSECURE`). Only safe on ClusterIP-isolated pods. |
+| `auth.trusted.secret` | `""` | Shared secret the proxy must send (`CHM_TRUSTED_AUTH_SECRET`). Stored in the chart Secret. Preferred over `allowInsecure`. |
+| `auth.trusted.existingSecret` | `""` | Existing Secret name with key `CHM_TRUSTED_AUTH_SECRET` (skips chart Secret creation for this key). |
+| `auth.trusted.sharedSecretHeader` | `""` | Header carrying the shared secret. App default: `X-Chm-Proxy-Secret`. |
+| `auth.trusted.userHeader` | `""` | Subject header. App default: `X-Forwarded-User`. |
+| `auth.trusted.emailHeader` | `""` | Email header. App default: `X-Forwarded-Email`. |
+| `auth.trusted.nameHeader` | `""` | Display-name header. App default: `X-Forwarded-Preferred-Username`. |
+| `auth.trusted.avatarHeader` | `""` | Avatar-URL header. App default: `X-Forwarded-Avatar`. |
+| `auth.trusted.groupsHeader` | `""` | Groups header (comma/space list). App default: `X-Forwarded-Groups`. |
+| `auth.trusted.roleHeader` | `""` | Single-role header merged into groups. App default: `X-Forwarded-Role`. |
+| `auth.trusted.customHeaders` | `""` | Comma list of `field:Header-Name` pairs for custom claims, e.g. `team:X-Forwarded-Team`. |
+| `auth.trusted.allowedGroups` | `""` | Comma list of groups/roles required for access (`CHM_TRUSTED_ALLOWED_GROUPS`). |
 | `extraEnv` | `[]` | Extra environment variables (e.g. `CLICKHOUSE_NAME`). |
 
 See [`values.yaml`](./values.yaml) for the full list.
@@ -55,6 +68,150 @@ See [`values.yaml`](./values.yaml) for the full list.
 - **Liveness** — `GET /healthz` (static, always `200` while the process runs).
 - **Readiness** — `GET /api/healthz` (returns `503` when no configured
   ClickHouse host is reachable, so traffic is only routed once a host is up).
+
+## Authentication (reverse proxy / trusted headers)
+
+The `trusted` auth provider lets a reverse proxy (e.g. Traefik + oauth2-proxy +
+Dex) authenticate users and forward their identity as HTTP headers. chmonitor
+reads those headers and trusts them — no Clerk account or API key needed.
+
+> **Note on build-time vs runtime:** The published `ghcr.io/duyet/chmonitor`
+> image is built with all auth providers compiled in. `auth.provider` (which sets
+> `CHM_AUTH_PROVIDER` at runtime) is enough to switch providers — no rebuild
+> required. The `VITE_AUTH_PROVIDER` build-time variable is baked into the
+> image and must not be set in the Helm chart.
+
+### Shared secret vs allowInsecure
+
+| Mode | Value | When to use |
+|---|---|---|
+| Shared secret | `auth.trusted.secret: "<random>"` | **Recommended.** The proxy sends the secret in a request header; the app validates it with a constant-time compare before trusting identity headers. |
+| Insecure | `auth.trusted.allowInsecure: true` | Only acceptable when the Service is `ClusterIP` and the pod is reachable **exclusively** through the ingress/oauth2-proxy path. No network-level guarantee = trust on the honour system. |
+
+You can combine both: set a secret AND leave `allowInsecure` false (the default).
+Do not set `allowInsecure: true` on a `NodePort` or `LoadBalancer` Service.
+
+### Env vars set by this chart (reference)
+
+| Env var | Source |
+|---|---|
+| `CHM_AUTH_PROVIDER` | `auth.provider` |
+| `CHM_TRUSTED_ALLOW_INSECURE` | `auth.trusted.allowInsecure` (only when `true`) |
+| `CHM_TRUSTED_AUTH_SECRET` | chart Secret / `auth.trusted.existingSecret` |
+| `CHM_TRUSTED_SHARED_SECRET_HEADER` | `auth.trusted.sharedSecretHeader` |
+| `CHM_TRUSTED_USER_HEADER` | `auth.trusted.userHeader` |
+| `CHM_TRUSTED_EMAIL_HEADER` | `auth.trusted.emailHeader` |
+| `CHM_TRUSTED_NAME_HEADER` | `auth.trusted.nameHeader` |
+| `CHM_TRUSTED_AVATAR_HEADER` | `auth.trusted.avatarHeader` |
+| `CHM_TRUSTED_GROUPS_HEADER` | `auth.trusted.groupsHeader` |
+| `CHM_TRUSTED_ROLE_HEADER` | `auth.trusted.roleHeader` |
+| `CHM_TRUSTED_CUSTOM_HEADERS` | `auth.trusted.customHeaders` |
+| `CHM_TRUSTED_ALLOWED_GROUPS` | `auth.trusted.allowedGroups` |
+
+All vars with empty values are omitted from the Deployment; the app uses its
+built-in defaults. The default header names are the generic `X-Forwarded-*` set.
+
+### Traefik + oauth2-proxy + Dex walkthrough
+
+oauth2-proxy with `--set-xauthrequest=true` emits `X-Auth-Request-*` headers
+(not the generic `X-Forwarded-*` defaults). Traefik's ForwardAuth Middleware
+must copy them back via `authResponseHeaders`. The chart header overrides map
+the two naming schemes together.
+
+**Step 1 — oauth2-proxy** (relevant flags):
+
+```
+--provider=oidc
+--oidc-issuer-url=https://dex.example.com
+--set-xauthrequest=true
+--scope=openid profile email groups
+--email-domain=*
+```
+
+**Step 2 — Traefik Middleware** (apply to the same namespace as chmonitor):
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: oauth2-proxy-auth
+  namespace: chmonitor
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.auth.svc.cluster.local/oauth2/auth
+    authResponseHeaders:
+      - X-Auth-Request-User
+      - X-Auth-Request-Email
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-Groups
+```
+
+**Step 3 — values.yaml**:
+
+```yaml
+auth:
+  provider: trusted
+  trusted:
+    # Generate with: openssl rand -hex 32
+    secret: "change-me-strong-random-value"
+
+    # Map oauth2-proxy's X-Auth-Request-* headers (not the X-Forwarded-* defaults)
+    userHeader:   "X-Auth-Request-User"
+    emailHeader:  "X-Auth-Request-Email"
+    nameHeader:   "X-Auth-Request-Preferred-Username"
+    groupsHeader: "X-Auth-Request-Groups"
+
+    # Optional: only members of these Dex groups can access chmonitor
+    allowedGroups: "chmonitor-admins,platform-team"
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations:
+    # Reference: <namespace>-<middleware-name>@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: chmonitor-oauth2-proxy-auth@kubernetescrd
+  hosts:
+    - host: chmonitor.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - chmonitor.example.com
+      secretName: chmonitor-tls
+```
+
+**Step 4 — install**:
+
+```bash
+helm install my-chm ./deploy/helm/chmonitor -f my-values.yaml
+```
+
+### Using a pre-existing Secret for the trusted auth secret
+
+If you manage secrets externally (e.g. via External Secrets Operator or Vault):
+
+```yaml
+auth:
+  provider: trusted
+  trusted:
+    existingSecret: my-chmonitor-secrets   # must contain key: CHM_TRUSTED_AUTH_SECRET
+```
+
+The chart will not create a Secret entry for the trusted auth key; it will
+mount it from your existing Secret.
+
+### Group-gating
+
+`auth.trusted.allowedGroups` (sets `CHM_TRUSTED_ALLOWED_GROUPS`) takes a
+comma-separated list of group or role names. Matching is case-insensitive.
+The user's forwarded groups (from `groupsHeader`) and role (from `roleHeader`)
+are merged and checked against this list. If the intersection is empty, the
+request is denied with 403.
+
+This works on top of the existing per-feature env vars:
+`CHM_FEATURE_<ID>_ACCESS`, `CHM_AUTH_REQUIRED_FEATURES`,
+`CHM_DISABLED_FEATURES`, and `CHM_API_KEY_SECRET` (set via `extraEnv`).
 
 ## Security
 

--- a/deploy/helm/chmonitor/templates/_helpers.tpl
+++ b/deploy/helm/chmonitor/templates/_helpers.tpl
@@ -82,3 +82,16 @@ when provided, otherwise the chart-managed one.
 {{- include "chmonitor.fullname" . }}
 {{- end }}
 {{- end }}
+
+{{/*
+The name of the Secret holding CHM_TRUSTED_AUTH_SECRET. Uses an existing Secret
+when auth.trusted.existingSecret is provided, otherwise the chart-managed one
+(same Secret object as the ClickHouse password, keyed separately).
+*/}}
+{{- define "chmonitor.trustedSecretName" -}}
+{{- if .Values.auth.trusted.existingSecret }}
+{{- .Values.auth.trusted.existingSecret }}
+{{- else }}
+{{- include "chmonitor.fullname" . }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/chmonitor/templates/deployment.yaml
+++ b/deploy/helm/chmonitor/templates/deployment.yaml
@@ -62,6 +62,61 @@ spec:
                 secretKeyRef:
                   name: {{ include "chmonitor.secretName" . }}
                   key: CLICKHOUSE_PASSWORD
+            {{- with .Values.auth }}
+            {{- if .provider }}
+            - name: CHM_AUTH_PROVIDER
+              value: {{ .provider | quote }}
+            {{- end }}
+            {{- with .trusted }}
+            {{- if .allowInsecure }}
+            - name: CHM_TRUSTED_ALLOW_INSECURE
+              value: "true"
+            {{- end }}
+            {{- if or .secret .existingSecret }}
+            - name: CHM_TRUSTED_AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "chmonitor.trustedSecretName" $ }}
+                  key: CHM_TRUSTED_AUTH_SECRET
+            {{- end }}
+            {{- if .sharedSecretHeader }}
+            - name: CHM_TRUSTED_SHARED_SECRET_HEADER
+              value: {{ .sharedSecretHeader | quote }}
+            {{- end }}
+            {{- if .userHeader }}
+            - name: CHM_TRUSTED_USER_HEADER
+              value: {{ .userHeader | quote }}
+            {{- end }}
+            {{- if .emailHeader }}
+            - name: CHM_TRUSTED_EMAIL_HEADER
+              value: {{ .emailHeader | quote }}
+            {{- end }}
+            {{- if .nameHeader }}
+            - name: CHM_TRUSTED_NAME_HEADER
+              value: {{ .nameHeader | quote }}
+            {{- end }}
+            {{- if .avatarHeader }}
+            - name: CHM_TRUSTED_AVATAR_HEADER
+              value: {{ .avatarHeader | quote }}
+            {{- end }}
+            {{- if .groupsHeader }}
+            - name: CHM_TRUSTED_GROUPS_HEADER
+              value: {{ .groupsHeader | quote }}
+            {{- end }}
+            {{- if .roleHeader }}
+            - name: CHM_TRUSTED_ROLE_HEADER
+              value: {{ .roleHeader | quote }}
+            {{- end }}
+            {{- if .customHeaders }}
+            - name: CHM_TRUSTED_CUSTOM_HEADERS
+              value: {{ .customHeaders | quote }}
+            {{- end }}
+            {{- if .allowedGroups }}
+            - name: CHM_TRUSTED_ALLOWED_GROUPS
+              value: {{ .allowedGroups | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/helm/chmonitor/templates/ingress.yaml
+++ b/deploy/helm/chmonitor/templates/ingress.yaml
@@ -7,6 +7,31 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "chmonitor.labels" . | nindent 4 }}
+  # -- Traefik + oauth2-proxy ForwardAuth example (add to ingress.annotations) --
+  # To protect chmonitor behind oauth2-proxy via Traefik ForwardAuth, create a
+  # Traefik Middleware in the same namespace and reference it here:
+  #
+  # ingress:
+  #   annotations:
+  #     traefik.ingress.kubernetes.io/router.middlewares: <namespace>-oauth2-proxy-auth@kubernetescrd
+  #
+  # The Middleware CRD (apply separately):
+  #   apiVersion: traefik.io/v1alpha1
+  #   kind: Middleware
+  #   metadata:
+  #     name: oauth2-proxy-auth
+  #   spec:
+  #     forwardAuth:
+  #       address: http://oauth2-proxy.<auth-namespace>.svc.cluster.local/oauth2/auth
+  #       authResponseHeaders:
+  #         - X-Auth-Request-User
+  #         - X-Auth-Request-Email
+  #         - X-Auth-Request-Preferred-Username
+  #         - X-Auth-Request-Groups
+  #
+  # Then set auth.provider=trusted and the matching header names in values.yaml.
+  # See README.md §Authentication for a complete walkthrough.
+  # -------------------------------------------------------------------------
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/deploy/helm/chmonitor/templates/secret.yaml
+++ b/deploy/helm/chmonitor/templates/secret.yaml
@@ -1,4 +1,6 @@
-{{- if not .Values.clickhouse.existingSecret }}
+{{- $needsClickhouseSecret := not .Values.clickhouse.existingSecret }}
+{{- $needsTrustedSecret := and .Values.auth.trusted.secret (not .Values.auth.trusted.existingSecret) }}
+{{- if or $needsClickhouseSecret $needsTrustedSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,5 +9,10 @@ metadata:
     {{- include "chmonitor.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  {{- if $needsClickhouseSecret }}
   CLICKHOUSE_PASSWORD: {{ .Values.clickhouse.password | quote }}
+  {{- end }}
+  {{- if $needsTrustedSecret }}
+  CHM_TRUSTED_AUTH_SECRET: {{ .Values.auth.trusted.secret | quote }}
+  {{- end }}
 {{- end }}

--- a/deploy/helm/chmonitor/values.yaml
+++ b/deploy/helm/chmonitor/values.yaml
@@ -126,6 +126,105 @@ clickhouse:
   # The secret must contain a key named `CLICKHOUSE_PASSWORD`.
   existingSecret: ""
 
+# Authentication configuration.
+#
+# auth.provider selects the server-side auth provider at runtime.
+# Valid values: "" (none), "none", "clerk", "proxy", "trusted".
+# The published image supports all providers; this value sets the
+# CHM_AUTH_PROVIDER env var — no rebuild needed.
+#
+# ── Traefik + oauth2-proxy + Dex homelab example ──────────────────────────────
+# oauth2-proxy forwards the authenticated identity as X-Auth-Request-* headers
+# (NOT the generic X-Forwarded-* defaults) when --set-xauthrequest=true is set.
+# The Traefik ForwardAuth Middleware must copy those headers back via
+# authResponseHeaders so chmonitor sees them.
+#
+# 1. oauth2-proxy flags (relevant subset):
+#      --provider=oidc
+#      --oidc-issuer-url=https://dex.example.com
+#      --set-xauthrequest=true
+#      --scope="openid profile email groups"
+#
+# 2. Traefik Middleware (middlewares.yaml or CRD):
+#      apiVersion: traefik.io/v1alpha1
+#      kind: Middleware
+#      metadata:
+#        name: oauth2-proxy-auth
+#        namespace: chmonitor
+#      spec:
+#        forwardAuth:
+#          address: http://oauth2-proxy.auth.svc.cluster.local/oauth2/auth
+#          authResponseHeaders:
+#            - X-Auth-Request-User
+#            - X-Auth-Request-Email
+#            - X-Auth-Request-Preferred-Username
+#            - X-Auth-Request-Groups
+#
+# 3. Ingress annotation to activate the middleware (add to ingress.annotations):
+#      traefik.ingress.kubernetes.io/router.middlewares: chmonitor-oauth2-proxy-auth@kubernetescrd
+#
+# 4. values.yaml snippet for this setup:
+#    auth:
+#      provider: trusted
+#      trusted:
+#        # RECOMMENDED: also set a shared secret so the app double-checks
+#        # the request came through the proxy, not a direct pod call.
+#        secret: "change-me-strong-random-value"
+#        userHeader: "X-Auth-Request-User"
+#        emailHeader: "X-Auth-Request-Email"
+#        nameHeader: "X-Auth-Request-Preferred-Username"
+#        groupsHeader: "X-Auth-Request-Groups"
+#        # Optional: restrict access to members of specific groups from Dex.
+#        allowedGroups: "chmonitor-admins,platform-team"
+# ──────────────────────────────────────────────────────────────────────────────
+auth:
+  # Auth provider: "" | none | clerk | proxy | trusted
+  provider: ""
+
+  trusted:
+    # allowInsecure: trust forwarded identity headers with NO shared secret.
+    # Safe ONLY when the pod is ClusterIP-isolated and reachable exclusively
+    # via the ingress/oauth2-proxy path. Prefer setting `secret` instead.
+    allowInsecure: false
+
+    # secret: shared secret string the proxy must send in the secret header.
+    # Sets CHM_TRUSTED_AUTH_SECRET; rendered into the chart Secret when non-empty
+    # and existingSecret is not set. RECOMMENDED over allowInsecure.
+    secret: ""
+
+    # existingSecret: name of a pre-existing Secret with key CHM_TRUSTED_AUTH_SECRET.
+    # When set, `secret` above is ignored and the chart Secret is not created for it.
+    existingSecret: ""
+
+    # sharedSecretHeader: header the proxy sends the shared secret in.
+    # Default in the app: "X-Chm-Proxy-Secret". Override here if needed.
+    sharedSecretHeader: ""
+
+    # Identity header overrides. Leave empty to use the app's built-in defaults
+    # (X-Forwarded-User, X-Forwarded-Email, X-Forwarded-Preferred-Username, etc.).
+    # When using Traefik + oauth2-proxy, set these to the X-Auth-Request-* names.
+
+    # userHeader: header carrying the user subject/ID. Default: X-Forwarded-User
+    userHeader: ""
+    # emailHeader: header carrying the user email. Default: X-Forwarded-Email
+    emailHeader: ""
+    # nameHeader: header carrying the display name. Default: X-Forwarded-Preferred-Username
+    nameHeader: ""
+    # avatarHeader: header carrying an avatar URL. Default: X-Forwarded-Avatar
+    avatarHeader: ""
+    # groupsHeader: header carrying comma/space-separated group list. Default: X-Forwarded-Groups
+    groupsHeader: ""
+    # roleHeader: header carrying a single role string merged into groups. Default: X-Forwarded-Role
+    roleHeader: ""
+    # customHeaders: comma-separated "field:Header-Name" pairs for custom claims.
+    # Example: "team:X-Forwarded-Team,dept:X-User-Dept"
+    customHeaders: ""
+
+    # allowedGroups: comma-separated list of groups/roles that are permitted access.
+    # If set, the user's forwarded groups must intersect (case-insensitive) or the
+    # request is denied. Works alongside CHM_FEATURE_<ID>_ACCESS and CHM_API_KEY_SECRET.
+    allowedGroups: ""
+
 # Extra environment variables injected into the container, e.g.
 # extraEnv:
 #   - name: CLICKHOUSE_NAME

--- a/docs/content/authentication.mdx
+++ b/docs/content/authentication.mdx
@@ -2,7 +2,7 @@
 
 chmonitor has two independent auth layers that work together on every `/api/v1/*` route:
 
-- **Auth provider** — one of `none`, `clerk`, or `proxy`. Controls whether browser sessions are authenticated. Set with `CHM_AUTH_PROVIDER` (server) and `VITE_AUTH_PROVIDER` (client, build-time inlined).
+- **Auth provider** — one of `none`, `clerk`, `proxy`, or `trusted`. Controls whether browser sessions are authenticated. Set with `CHM_AUTH_PROVIDER` (server) and `VITE_AUTH_PROVIDER` (client, build-time inlined).
 - **API key layer** — always active when `CHM_API_KEY_SECRET` is set. Authenticates programmatic clients (MCP, scripts, CI) with signed `chm_` Bearer tokens, independent of the provider.
 
 A request is allowed when either layer accepts it. The only fully public setup is `CHM_AUTH_PROVIDER=none` with no `CHM_API_KEY_SECRET`.
@@ -16,7 +16,8 @@ A request is allowed when either layer accepts it. The only fully public setup i
 | Clerk | `clerk` provider | Clerk `__session` cookie | Clerk token or `chm_` key |
 | Clerk OAuth (MCP only) | MCP server | — | OAuth bearer token |
 | Proxy → Cloudflare Access | `proxy` provider | `Cf-Access-Jwt-Assertion` JWT | — |
-| Proxy → trusted header | `proxy` provider | `X-Forwarded-User` + shared secret | shared secret header |
+| Proxy → trusted header (bare subject) | `proxy` provider | `X-Forwarded-User` + shared secret | shared secret header |
+| Proxy → trusted headers (full profile) | `trusted` provider | forwarded headers (oauth2-proxy / Dex / Authelia) | shared secret header |
 
 ## How enforcement decides
 
@@ -36,7 +37,9 @@ All paths fail closed: a missing config or verification error resolves to "not a
 |---|---|
 | Local dev or internal network, no login needed | Public (`none`) — default |
 | Hosted dashboard with user accounts and sign-in | Clerk |
-| Behind Cloudflare Access or nginx/SSO | Proxy (`cloudflare-access` or `trusted-header`) |
+| Behind Cloudflare Access | Proxy — `cloudflare-access` |
+| Behind nginx/SSO with a bare identity header | Proxy — `trusted-header` |
+| Behind oauth2-proxy / Dex / Authelia / Traefik ForwardAuth | Trusted (`trusted`) |
 | MCP clients, scripts, CI pipelines | API key (`CHM_API_KEY_SECRET`) — add alongside any provider |
 
 ## Provider pages
@@ -44,8 +47,9 @@ All paths fail closed: a missing config or verification error resolves to "not a
 - [Public / no auth](/docs/authentication/public) — default open dashboard
 - [API keys](/docs/authentication/api-keys) — `chm_` Bearer tokens for programmatic access
 - [Clerk](/docs/authentication/clerk) — browser sign-in with Clerk sessions
-- [Cloudflare Access](/docs/authentication/cloudflare-access) — reverse proxy JWT verification
-- [Trusted header](/docs/authentication/trusted-header) — reverse proxy with shared secret
+- [Cloudflare Access](/docs/authentication/cloudflare-access) — `proxy` provider; Cloudflare Access JWT verification
+- [Trusted header](/docs/authentication/trusted-header) — `proxy` provider; bare subject via shared secret
+- [Trusted proxy](/docs/authentication/trusted-proxy) — `trusted` provider; full profile from forwarded headers (oauth2-proxy, Dex, Authelia)
 
 ## Related
 

--- a/docs/content/authentication/trusted-proxy.mdx
+++ b/docs/content/authentication/trusted-proxy.mdx
@@ -1,0 +1,265 @@
+# Reverse proxy: trusted forwarded headers
+
+Use this when chmonitor sits behind a proxy that has already authenticated the user — oauth2-proxy with Dex, Authelia, Traefik ForwardAuth, nginx + auth-url, or similar. The proxy forwards the user's identity as HTTP headers; chmonitor trusts them and builds a full principal (name, email, avatar, groups) from those headers.
+
+## When to use
+
+| You have | Use |
+|---|---|
+| oauth2-proxy + Dex (or any OIDC provider) | `trusted` provider |
+| Authelia / Authentik in front of chmonitor | `trusted` provider |
+| Traefik ForwardAuth or nginx `auth_request` | `trusted` provider |
+| Cloudflare Access (signed JWT) | [`proxy` provider](/docs/authentication/cloudflare-access) |
+| nginx + a shared-secret header only (no full profile) | [`proxy` provider / trusted-header](/docs/authentication/trusted-header) |
+
+The `trusted` provider differs from the `proxy` provider:
+- `proxy` is Cloudflare Access-centric (verifies a `Cf-Access-Jwt-Assertion` JWT) or carries a bare subject via a single identity header.
+- `trusted` extracts a full profile (name, email, avatar, groups, custom claims) from multiple forwarded headers, supports group-based access gating, and exposes that profile in the sidebar and `/api/v1/auth/me`.
+
+## How it works
+
+1. The upstream proxy authenticates the user and copies their identity into request headers before forwarding to chmonitor.
+2. chmonitor checks the trust gate — either a shared secret header or an explicit allow-insecure flag. If the gate does not pass, the request is treated as unauthenticated regardless of what headers are present.
+3. If the gate passes, chmonitor reads the configured header names to build a principal: subject, email, display name, avatar URL, and groups/roles.
+4. Optional group gating: if `CHM_TRUSTED_ALLOWED_GROUPS` is set, the user's forwarded groups must intersect (case-insensitive) or access is denied.
+5. A trusted-authenticated user counts as `authenticated` for the feature permission matrix, which unlocks `authenticated`-access features (AI agent, writes) on that request.
+
+The identity is available at `GET /api/v1/auth/me` and displayed in the sidebar user menu.
+
+## Trust gate
+
+**You must configure exactly one of these.** Without a trust gate, the provider fails closed and denies all requests.
+
+| Variable | Default | Description |
+|---|---|---|
+| `CHM_TRUSTED_AUTH_SECRET` | — | Shared secret. The proxy must send it in `CHM_TRUSTED_SHARED_SECRET_HEADER`. Constant-time compared. **Recommended.** |
+| `CHM_TRUSTED_ALLOW_INSECURE` | `false` | When `true`, headers are trusted with no secret check. Only safe when the worker/Service is unreachable except via the proxy (e.g. k8s ClusterIP behind an ingress). |
+| `CHM_TRUSTED_SHARED_SECRET_HEADER` | `X-Chm-Proxy-Secret` | Header name carrying the shared secret. |
+
+Set the secret out-of-band — never in plaintext env files committed to source control:
+
+```bash
+wrangler secret put CHM_TRUSTED_AUTH_SECRET
+# or
+kubectl create secret generic chm-trusted-secret \
+  --from-literal=value=<secret>
+```
+
+## All environment variables
+
+### Provider activation
+
+| Variable | Default | Description |
+|---|---|---|
+| `CHM_AUTH_PROVIDER` | `none` | Set to `trusted`. Server-side. |
+| `VITE_AUTH_PROVIDER` | `none` | Set to `trusted`. Build-time client mirror. Must match `CHM_AUTH_PROVIDER`. |
+
+### Trust gate
+
+| Variable | Default | Description |
+|---|---|---|
+| `CHM_TRUSTED_AUTH_SECRET` | — | Shared secret value (runtime secret). |
+| `CHM_TRUSTED_ALLOW_INSECURE` | `false` | Skip secret check (network-isolation required). |
+| `CHM_TRUSTED_SHARED_SECRET_HEADER` | `X-Chm-Proxy-Secret` | Header name the proxy sends the secret in. |
+
+### Identity headers
+
+| Variable | Default header | What it populates |
+|---|---|---|
+| `CHM_TRUSTED_USER_HEADER` | `X-Forwarded-User` | Subject / user id. Falls back to the email header. Required for a usable identity. |
+| `CHM_TRUSTED_EMAIL_HEADER` | `X-Forwarded-Email` | Email address. |
+| `CHM_TRUSTED_NAME_HEADER` | `X-Forwarded-Preferred-Username` | Display name shown in the sidebar. |
+| `CHM_TRUSTED_AVATAR_HEADER` | `X-Forwarded-Avatar` | Avatar URL. |
+| `CHM_TRUSTED_GROUPS_HEADER` | `X-Forwarded-Groups` | Comma- or space-separated group/role list. |
+| `CHM_TRUSTED_ROLE_HEADER` | `X-Forwarded-Role` | Single role value; merged into the groups list. |
+| `CHM_TRUSTED_CUSTOM_HEADERS` | — | Extra claims. Comma-separated `field:Header-Name` pairs, e.g. `team:X-Forwarded-Team,dept:X-User-Dept`. Available in the principal's custom claims. |
+
+### Access control
+
+| Variable | Default | Description |
+|---|---|---|
+| `CHM_TRUSTED_ALLOWED_GROUPS` | — | Comma-separated group names. When set, the user's forwarded groups must include at least one (case-insensitive). Users with no matching group are treated as unauthenticated (`401`). |
+
+Combines with the existing per-feature vars:
+
+```bash
+CHM_FEATURE_AGENT_ACCESS=authenticated   # agent requires sign-in
+CHM_FEATURE_SETTINGS_ACCESS=authenticated
+CHM_TRUSTED_ALLOWED_GROUPS=sre,ops,admin
+```
+
+A trusted-authenticated user satisfies `authenticated`, so `CHM_FEATURE_*_ACCESS=authenticated` features are unlocked for them automatically.
+
+## Forwarded headers map
+
+What each header becomes in the principal:
+
+These are the fields of the JSON returned by `GET /api/v1/auth/me` (`principal`):
+
+| Header (default name) | Principal field |
+|---|---|
+| `X-Forwarded-User` | `subject` |
+| `X-Forwarded-Email` | `email` |
+| `X-Forwarded-Preferred-Username` | `name` |
+| `X-Forwarded-Avatar` | `avatarUrl` |
+| `X-Forwarded-Groups` | `roles[]` |
+| `X-Forwarded-Role` | merged into `roles[]` |
+| Custom headers (via `CHM_TRUSTED_CUSTOM_HEADERS`) | `custom.<field>` |
+
+## Homelab example: k3s + Traefik + oauth2-proxy + Dex
+
+**Critical detail:** With Traefik ForwardAuth, Traefik copies *oauth2-proxy's* response headers back to the upstream request via the middleware's `authResponseHeaders` list. oauth2-proxy uses `X-Auth-Request-*` headers, not `X-Forwarded-*`. Map accordingly.
+
+### oauth2-proxy flags
+
+oauth2-proxy must emit the auth-request headers and request the `groups` scope from Dex:
+
+```
+--set-xauthrequest=true
+--scope=openid email profile groups
+--pass-authorization-header=false
+```
+
+Dex must include `groups` in its connector config (e.g. an LDAP connector with `groupSearch`, or GitHub connector with `orgs`).
+
+### Traefik Middleware
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: oauth2-proxy-auth
+  namespace: monitoring
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.monitoring.svc.cluster.local/oauth2/auth
+    trustForwardHeader: true
+    authResponseHeaders:
+      - X-Auth-Request-User
+      - X-Auth-Request-Email
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-Groups
+```
+
+Apply the middleware to your chmonitor IngressRoute:
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: chmonitor
+  namespace: monitoring
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`chmonitor.example.com`)
+      kind: Rule
+      middlewares:
+        - name: oauth2-proxy-auth
+      services:
+        - name: chmonitor
+          port: 3000
+```
+
+### chmonitor env vars
+
+```bash
+CHM_AUTH_PROVIDER=trusted
+VITE_AUTH_PROVIDER=trusted
+
+# oauth2-proxy sends X-Auth-Request-* headers, not X-Forwarded-*
+CHM_TRUSTED_USER_HEADER=X-Auth-Request-User
+CHM_TRUSTED_EMAIL_HEADER=X-Auth-Request-Email
+CHM_TRUSTED_NAME_HEADER=X-Auth-Request-Preferred-Username
+CHM_TRUSTED_GROUPS_HEADER=X-Auth-Request-Groups
+
+# Secret (store in a k8s Secret, inject as env; not plaintext here)
+CHM_TRUSTED_AUTH_SECRET=<long-random-secret>
+CHM_TRUSTED_SHARED_SECRET_HEADER=X-Chm-Proxy-Secret
+
+# Gate access to the sre and admin groups only
+CHM_TRUSTED_ALLOWED_GROUPS=sre,admin
+```
+
+The proxy must set `X-Chm-Proxy-Secret: <long-random-secret>` on every forwarded request. In Traefik you can do this with a second middleware or a plugin that adds a static header from a Kubernetes Secret. Alternatively, run chmonitor as a `ClusterIP` only reachable by the oauth2-proxy pod and set `CHM_TRUSTED_ALLOW_INSECURE=true` instead of a shared secret.
+
+## nginx variant
+
+For nginx-ingress with `auth-url` / `auth-snippet`:
+
+```nginx
+# In your server block
+location / {
+  auth_request /oauth2/auth;
+  auth_request_set $auth_user     $upstream_http_x_auth_request_user;
+  auth_request_set $auth_email    $upstream_http_x_auth_request_email;
+  auth_request_set $auth_name     $upstream_http_x_auth_request_preferred_username;
+  auth_request_set $auth_groups   $upstream_http_x_auth_request_groups;
+
+  proxy_set_header X-Forwarded-User               $auth_user;
+  proxy_set_header X-Forwarded-Email              $auth_email;
+  proxy_set_header X-Forwarded-Preferred-Username $auth_name;
+  proxy_set_header X-Forwarded-Groups             $auth_groups;
+  proxy_set_header X-Chm-Proxy-Secret             "<same-secret>";
+
+  proxy_pass http://chmonitor_upstream;
+}
+
+location /oauth2/ {
+  proxy_pass http://oauth2-proxy_upstream;
+}
+```
+
+Or with nginx-ingress annotations:
+
+```yaml
+nginx.ingress.kubernetes.io/auth-url: "https://oauth2-proxy.example.com/oauth2/auth"
+nginx.ingress.kubernetes.io/auth-response-headers: >-
+  X-Auth-Request-User,
+  X-Auth-Request-Email,
+  X-Auth-Request-Preferred-Username,
+  X-Auth-Request-Groups
+nginx.ingress.kubernetes.io/configuration-snippet: |
+  proxy_set_header X-Forwarded-User               $http_x_auth_request_user;
+  proxy_set_header X-Forwarded-Email              $http_x_auth_request_email;
+  proxy_set_header X-Forwarded-Preferred-Username $http_x_auth_request_preferred_username;
+  proxy_set_header X-Forwarded-Groups             $http_x_auth_request_groups;
+  proxy_set_header X-Chm-Proxy-Secret             "<same-secret>";
+```
+
+Keep the default `CHM_TRUSTED_*_HEADER` names in this case (they match `X-Forwarded-*`).
+
+## Security notes
+
+**Header forgery.** Without a trust gate, any client that can reach the chmonitor service directly can send arbitrary headers and forge any identity. Always:
+- Use `CHM_TRUSTED_AUTH_SECRET` with a strong random value, **or**
+- Ensure the Service is network-isolated (k8s ClusterIP, not exposed externally) and set `CHM_TRUSTED_ALLOW_INSECURE=true`.
+
+**Fail closed.** If neither `CHM_TRUSTED_AUTH_SECRET` nor `CHM_TRUSTED_ALLOW_INSECURE=true` is configured, the `trusted` provider rejects all requests with `401`. There is no open fallback.
+
+**Secret hygiene.** Never put the secret value in YAML manifests, `.env` files, or source control. Use a k8s Secret (or `wrangler secret put`) and inject as an environment variable at runtime.
+
+**`CHM_TRUSTED_ALLOW_INSECURE`.** Only use this when the Worker or container is genuinely unreachable except through the proxy. If the port is exposed on a node or load balancer, use the shared secret instead.
+
+## Combining with API keys
+
+`CHM_API_KEY_SECRET` works alongside `CHM_AUTH_PROVIDER=trusted`. Programmatic clients (MCP, scripts, CI) can authenticate with a `chm_` Bearer token without going through the proxy:
+
+```bash
+CHM_API_KEY_SECRET=<secret>
+# mint a key
+curl -X POST https://chmonitor.example.com/api/v1/auth/api-key \
+  -H "Authorization: Bearer <secret>"
+```
+
+See [API keys](/docs/authentication/api-keys).
+
+## Related
+
+- [Authentication overview](/docs/authentication)
+- [Cloudflare Access](/docs/authentication/cloudflare-access)
+- [Trusted header (proxy provider)](/docs/authentication/trusted-header)
+- [API keys](/docs/authentication/api-keys)
+- [Feature Permissions](/docs/advanced/feature-permissions)
+- [Environment Variables — Authentication](/docs/reference/environment-variables#authentication)

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -107,7 +107,7 @@ The active server-side auth provider is set by `CHM_AUTH_PROVIDER`. See [Authent
 
 | Variable | Default | Description |
 |---|---|---|
-| `CHM_AUTH_PROVIDER` | `none` | Server auth provider: `none`, `clerk`, or `proxy`. |
+| `CHM_AUTH_PROVIDER` | `none` | Server auth provider: `none`, `clerk`, `proxy`, or `trusted`. |
 | `VITE_AUTH_PROVIDER` | `none` | Client-side mirror of `CHM_AUTH_PROVIDER`. Set to the same value. Build-time. |
 | `CHM_API_KEY_SECRET` | — | Shared secret for `chm_` API keys. When set, API-key auth is always on alongside the active provider. Issue keys at `/api/v1/auth/api-key`. |
 
@@ -130,7 +130,7 @@ Trust a reverse proxy that already authenticated the user. Either mechanism belo
 | `CHM_CF_ACCESS_TEAM_DOMAIN` | — | Cloudflare Access team URL (`https://<team>.cloudflareaccess.com`). Enables `Cf-Access-Jwt-Assertion` JWT verification. |
 | `CHM_CF_ACCESS_AUD` | — | Access application AUD tag the JWT must carry. |
 
-**Trusted header:**
+**Trusted header (bare subject):**
 
 | Variable | Default | Description |
 |---|---|---|
@@ -139,6 +139,38 @@ Trust a reverse proxy that already authenticated the user. Either mechanism belo
 | `CHM_PROXY_AUTH_HEADER` | `X-Forwarded-User` | Header the proxy sends containing the authenticated user identity. |
 
 > When `CHM_PROXY_AUTH_SECRET` is set, the identity header (`X-Forwarded-User` by default) is honored only when the request also carries a matching shared-secret header (constant-time compared). Without `CHM_PROXY_AUTH_SECRET`, the entire trusted-header mechanism is disabled and identity headers are ignored.
+
+### Trusted reverse proxy (`CHM_AUTH_PROVIDER=trusted`)
+
+Use when an upstream proxy (oauth2-proxy, Authelia, Traefik ForwardAuth, nginx auth-url) forwards the user's full identity as HTTP headers. Extracts a complete principal — name, email, avatar, groups, custom claims.
+
+**Trust gate** — configure exactly one:
+
+| Variable | Default | Description |
+|---|---|---|
+| `CHM_TRUSTED_AUTH_SECRET` | — | Shared secret (runtime secret). The proxy must send it in `CHM_TRUSTED_SHARED_SECRET_HEADER`. Constant-time compared. Recommended. |
+| `CHM_TRUSTED_ALLOW_INSECURE` | `false` | When `true`, trusts headers with no secret check. Only safe when the service is unreachable except via the proxy (e.g. k8s ClusterIP). |
+| `CHM_TRUSTED_SHARED_SECRET_HEADER` | `X-Chm-Proxy-Secret` | Header name carrying the shared secret. |
+
+**Identity headers** — all optional; defaults match common proxy conventions:
+
+| Variable | Default | Populates |
+|---|---|---|
+| `CHM_TRUSTED_USER_HEADER` | `X-Forwarded-User` | Subject / user id. Falls back to the email header. |
+| `CHM_TRUSTED_EMAIL_HEADER` | `X-Forwarded-Email` | Email address. |
+| `CHM_TRUSTED_NAME_HEADER` | `X-Forwarded-Preferred-Username` | Display name. |
+| `CHM_TRUSTED_AVATAR_HEADER` | `X-Forwarded-Avatar` | Avatar URL. |
+| `CHM_TRUSTED_GROUPS_HEADER` | `X-Forwarded-Groups` | Comma- or space-separated groups. |
+| `CHM_TRUSTED_ROLE_HEADER` | `X-Forwarded-Role` | Single role; merged into the groups list. |
+| `CHM_TRUSTED_CUSTOM_HEADERS` | — | Extra claims. Comma-separated `field:Header-Name` pairs, e.g. `team:X-Forwarded-Team`. |
+
+**Access control:**
+
+| Variable | Default | Description |
+|---|---|---|
+| `CHM_TRUSTED_ALLOWED_GROUPS` | — | Comma-separated group names. When set, users whose forwarded groups do not intersect are denied `403`. Case-insensitive. |
+
+See [Trusted proxy](/docs/authentication/trusted-proxy) for setup examples (oauth2-proxy + Dex + Traefik, nginx).
 
 ---
 


### PR DESCRIPTION
## What

Adds a new **`trusted`** auth provider for deployments where chmonitor sits behind a reverse proxy that already authenticated the user and forwards the identity as HTTP headers — oauth2-proxy + Dex, Authelia, Traefik ForwardAuth, nginx SSO.

Motivated by the homelab case: **k3s + Traefik + oauth2-proxy + Dex**, configured via the Helm chart.

### Why a new provider (not the existing `proxy`)
- `proxy` is **Cloudflare-Access-centric** (verifies a signed `Cf-Access-Jwt-Assertion` JWT) and only extracts a bare `subject`.
- `trusted` is **forwarded-header-centric**: it builds a full principal — subject, name, email, avatar, roles/groups, and arbitrary custom claims — and can gate access by group.

Both providers remain; pick by topology.

## How it works
1. **Trust gate (fail-closed).** Authenticates only when a shared-secret header matches `CHM_TRUSTED_AUTH_SECRET` (constant-time), **or** `CHM_TRUSTED_ALLOW_INSECURE=true` is set for a network-isolated service. With neither, every request is denied (and a warning logs).
2. **Identity extraction** from configurable headers (defaults shown): `X-Forwarded-User` → subject, `X-Forwarded-Email`, `X-Forwarded-Preferred-Username` → name, `X-Forwarded-Avatar`, `X-Forwarded-Groups`, `X-Forwarded-Role`, plus `CHM_TRUSTED_CUSTOM_HEADERS` (`field:Header` pairs).
3. **Group gating** via `CHM_TRUSTED_ALLOWED_GROUPS` — combines with the feature-permission matrix. A trusted user counts as `authenticated`, unlocking `authenticated`-access features (AI agent, writes).
4. Identity surfaces to the UI via `GET /api/v1/auth/me` → sidebar user menu shows the real name/email/avatar.

## Notable change
Closes a latent gap: `feature-permissions/server.ts:isAuthenticatedRequest` previously returned `false` for any non-`clerk`/`none` provider, so `proxy`/`trusted`-authenticated callers were let through by the guard but treated as **anonymous** by per-route feature checks. It now consults the provider.

## Changes
- **Auth core**: `TrustedAuthProvider`, `AuthResult.principal` (additive), shared constant-time comparator (also adopted by `proxy`), provider parser/resolver wiring.
- **Client**: `/api/v1/auth/me` route + `useAuthIdentity` hook + `NavUser` wiring.
- **Helm**: structured `auth:` values, secret wiring, deployment env, ingress example; Traefik + oauth2-proxy + Dex walkthrough in README.
- **Docs**: new `authentication/trusted-proxy.mdx`, updated `authentication.mdx`, `reference/environment-variables.mdx`, `.env.example`.

## Verification
- `bun run build` ✅ (Vite build + `tsc --noEmit`, route registered)
- `bun run type-check:test` ✅ (separate test-tsconfig CI gate)
- `bun test src/lib/auth src/lib/feature-permissions` ✅ 119 pass / 0 fail
- Biome lint ✅
- `helm template` ✅ across trusted+insecure, secret-path, and default (0 auth vars when unconfigured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a new trusted reverse-proxy authentication mode with forwarded identities and wire it through server, client, docs, and Helm configuration.

New Features:
- Add a `trusted` auth provider that authenticates via forwarded headers from a reverse proxy and builds a rich principal profile, including optional group-based access control.
- Expose a `/api/v1/auth/me` endpoint and a `useAuthIdentity` hook so the UI can display the authenticated user’s forwarded name, email, and avatar instead of a static guest.
- Extend Helm chart values to configure the auth provider (including trusted proxy options and secrets) and map reverse-proxy headers to application environment variables.

Bug Fixes:
- Ensure feature-permission authentication checks consult the active proxy-style provider so proxy/trusted-authenticated requests are treated as authenticated rather than anonymous.

Enhancements:
- Generalize auth types to include a rich `AuthPrincipal` structure and propagate it through the auth provider layer.
- Share a timing-safe secret comparison utility between proxy-style auth providers to harden shared-secret validation.
- Update navigation and feature-permission configs to support the new `trusted` provider alongside existing providers.

Build:
- Update Helm templates and helper functions to manage trusted auth secrets, inject the appropriate environment variables, and guide Traefik/oauth2-proxy configuration.

Documentation:
- Document the new trusted reverse-proxy auth mode, including environment variables, examples for Traefik + oauth2-proxy + Dex, and nginx-based setups.
- Update authentication and environment variable reference docs to describe the `trusted` provider and clarify when to use each auth mode.

Tests:
- Add comprehensive tests for the trusted auth provider covering trust gate logic, identity extraction, header overrides, custom claims, and group gating behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for trusted reverse-proxy authentication mode for deployments with upstream identity providers
  * New `/api/v1/auth/me` API endpoint to retrieve current authentication status and user identity

* **Documentation**
  * Added comprehensive documentation for configuring trusted reverse-proxy authentication with examples
  * Expanded environment variables reference with trusted proxy configuration options
  * Updated Helm chart with trusted proxy deployment guidance and configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->