### PR TITLE
docs(auth): surface authentication in Features, add Traefik page + raw .md routes

### DIFF
--- a/apps/docs/src/components/PageActions.astro
+++ b/apps/docs/src/components/PageActions.astro
@@ -1,0 +1,123 @@
+---
+// Top-right actions on each docs page: copy the page as Markdown, or open the
+// raw .md sibling (served by src/pages/[...slug].md.ts).
+interface Props {
+  currentSlug: string
+}
+const { currentSlug } = Astro.props
+const mdHref = `/${currentSlug || 'index'}.md`
+---
+
+<div class="page-actions" data-md-href={mdHref}>
+  <button
+    type="button"
+    class="page-actions__btn"
+    data-copy-page
+    aria-label="Copy this page as Markdown"
+  >
+    <svg
+      class="page-actions__icon"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <rect width="14" height="14" x="8" y="8" rx="2" ry="2"></rect>
+      <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path>
+    </svg>
+    <span data-copy-label>Copy page</span>
+  </button>
+  <a
+    class="page-actions__btn"
+    href={mdHref}
+    target="_blank"
+    rel="noopener"
+    aria-label="Open this page as Markdown"
+  >
+    <svg
+      class="page-actions__icon"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"></path>
+      <path d="M14 2v5h5"></path>
+      <path d="M12 18v-6"></path>
+      <path d="m9 15 3 3 3-3"></path>
+    </svg>
+    <span>Open as Markdown</span>
+  </a>
+</div>
+
+<style>
+  .page-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .page-actions__btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.25rem 0.625rem;
+    font-size: 0.8125rem;
+    line-height: 1.4;
+    color: var(--color-text-muted, #6b7280);
+    background: var(--color-surface, transparent);
+    border: 1px solid var(--color-border, #e5e7eb);
+    border-radius: 0.5rem;
+    cursor: pointer;
+    text-decoration: none;
+    transition:
+      color 0.15s ease,
+      border-color 0.15s ease,
+      background 0.15s ease;
+  }
+  .page-actions__btn:hover {
+    color: var(--color-text, #111827);
+    border-color: var(--color-border-strong, #d1d5db);
+    background: var(--color-surface-hover, rgba(0, 0, 0, 0.03));
+  }
+  .page-actions__icon {
+    flex-shrink: 0;
+  }
+</style>
+
+<script>
+  // Copy the raw markdown (fetched from the page's .md sibling) to the clipboard.
+  for (const el of document.querySelectorAll<HTMLElement>('.page-actions')) {
+    const href = el.dataset.mdHref
+    const btn = el.querySelector<HTMLButtonElement>('[data-copy-page]')
+    const label = el.querySelector<HTMLElement>('[data-copy-label]')
+    if (!href || !btn || !label) continue
+
+    btn.addEventListener('click', async () => {
+      const original = label.textContent
+      try {
+        const res = await fetch(href)
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const text = await res.text()
+        await navigator.clipboard.writeText(text)
+        label.textContent = 'Copied!'
+      } catch {
+        label.textContent = 'Copy failed'
+      }
+      window.setTimeout(() => {
+        label.textContent = original
+      }, 2000)
+    })
+  }
+</script>

--- a/apps/docs/src/layouts/MainLayout.astro
+++ b/apps/docs/src/layouts/MainLayout.astro
@@ -7,6 +7,7 @@ import '../styles/global.css'
 import { SITE } from '../config'
 import DocsMobileToolbar from '../components/DocsMobileToolbar.astro'
 import Header from '../components/Header.astro'
+import PageActions from '../components/PageActions.astro'
 import Sidebar from '../components/Sidebar.astro'
 import TableOfContents from '../components/TableOfContents.astro'
 
@@ -104,6 +105,7 @@ const ogImage = new URL('/og/og.png', Astro.site).toString()
           currentSlug={currentSlug}
           headings={headings}
         />
+        <PageActions currentSlug={currentSlug} />
         <article id="article" class="content" data-docs-prose>
           <slot />
         </article>

--- a/apps/docs/src/lib/header-nav.ts
+++ b/apps/docs/src/lib/header-nav.ts
@@ -28,7 +28,7 @@ export const HEADER_CATEGORIES: { label: string; groups: string[] }[] = [
   { label: 'Introduction', groups: ['Introduction', 'More'] },
   { label: 'Getting Started', groups: ['Getting Started'] },
   { label: 'Deploy', groups: ['Deployment', 'Authentication'] },
-  { label: 'Features', groups: ['Features'] },
+  { label: 'Features', groups: ['Features', 'Authentication'] },
   { label: 'AI Agent', groups: ['AI Agent'] },
   {
     label: 'Reference',

--- a/apps/docs/src/lib/nav-icons.ts
+++ b/apps/docs/src/lib/nav-icons.ts
@@ -77,6 +77,7 @@ const PAGE_ICONS: Record<string, NavIconName> = {
   'deploy/k8s': 'boxes',
   'deploy/production-checklist': 'layout-list',
   'deploy/self-host': 'server',
+  'deploy/traefik': 'network',
   'deploy/vercel': 'globe',
   features: 'layout-grid',
   'features/browser-connections': 'globe',

--- a/apps/docs/src/pages/[...slug].md.ts
+++ b/apps/docs/src/pages/[...slug].md.ts
@@ -1,0 +1,39 @@
+// Raw-markdown sibling of every docs page: /authentication/trusted-header ->
+// /authentication/trusted-header.md serves the source markdown as text/markdown.
+// Lets readers (and LLMs / agents) grab the plain source, and backs the
+// "Copy page" / "Open as Markdown" buttons in the page header.
+//
+// Static output, so paths are prerendered via getStaticPaths alongside the
+// HTML pages emitted by [...slug].astro.
+
+import type { CollectionEntry } from 'astro:content'
+import type { APIRoute, GetStaticPaths } from 'astro'
+
+import { getCollection } from 'astro:content'
+
+type DocEntry = CollectionEntry<'docs'>
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const entries = await getCollection('docs')
+  return entries.map((entry) => ({
+    // Root index ("") has no slug; expose it at /index.md.
+    params: { slug: entry.data.slug || 'index' },
+    props: { entry },
+  }))
+}
+
+export const GET: APIRoute = ({ props }) => {
+  const { entry } = props as { entry: DocEntry }
+
+  // sync-docs demotes the body's h1 to keep a single document title in
+  // frontmatter; restore a clean top-level heading from it for the raw file.
+  const body = (entry.body ?? '').trimStart()
+  const markdown = `# ${entry.data.title}\n\n${body}\n`
+
+  return new Response(markdown, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  })
+}

--- a/docs/content/deploy.mdx
+++ b/docs/content/deploy.mdx
@@ -32,4 +32,5 @@ Every platform shares the same configuration categories. The links below go to t
 - **Running Docker already?** → [Docker](/docs/deploy/docker)
 - **On Kubernetes?** → [Kubernetes](/docs/deploy/k8s)
 - **Want serverless edge?** → [Cloudflare Workers](/docs/deploy/cloudflare)
+- **Behind Traefik / a reverse proxy?** → [Traefik](/docs/deploy/traefik)
 - **Before going to production?** → [Production checklist](/docs/deploy/production-checklist)

--- a/docs/content/deploy/traefik.mdx
+++ b/docs/content/deploy/traefik.mdx
@@ -1,0 +1,128 @@
+# Traefik
+
+Run chmonitor behind [Traefik](https://traefik.io/) as your reverse proxy / ingress controller. Works the same on Kubernetes (IngressRoute CRD or the standard Ingress) and with plain Docker (container labels).
+
+Traefik handles TLS, routing, and — combined with [oauth2-proxy](/docs/authentication/trusted-proxy) — authentication, so chmonitor itself can stay on the `none` provider and trust the forwarded identity.
+
+## Kubernetes (IngressRoute)
+
+If you installed chmonitor with the [Helm chart](/docs/deploy/k8s), expose the Service with a Traefik `IngressRoute`:
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: chmonitor
+  namespace: monitoring
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`chmonitor.example.com`)
+      kind: Rule
+      services:
+        - name: chmonitor          # matches the chart's Service name
+          port: 3000               # service.port (default 3000)
+  tls:
+    certResolver: letsencrypt      # or a cert-manager-issued Secret via tls.secretName
+```
+
+Prefer the standard `Ingress`? Enable it in the chart and point the class at Traefik:
+
+```yaml
+# values.yaml
+ingress:
+  enabled: true
+  className: traefik
+  hosts:
+    - host: chmonitor.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts: [chmonitor.example.com]
+      secretName: chmonitor-tls
+```
+
+## Docker (labels)
+
+With `docker compose` and Traefik watching the Docker provider:
+
+```yaml
+services:
+  chmonitor:
+    image: ghcr.io/duyet/chmonitor:latest
+    environment:
+      CLICKHOUSE_HOST: http://clickhouse:8123
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: ""
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.chmonitor.rule=Host(`chmonitor.example.com`)
+      - traefik.http.routers.chmonitor.entrypoints=websecure
+      - traefik.http.routers.chmonitor.tls.certresolver=letsencrypt
+      - traefik.http.services.chmonitor.loadbalancer.server.port=3000
+```
+
+## Authentication via ForwardAuth
+
+Put chmonitor behind oauth2-proxy (with Dex, Google, GitHub, …) using a Traefik `ForwardAuth` middleware, and have chmonitor read the forwarded identity with the [`trusted` auth provider](/docs/authentication/trusted-proxy).
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: oauth2-proxy-auth
+  namespace: monitoring
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.monitoring.svc.cluster.local/oauth2/auth
+    trustForwardHeader: true
+    # Copy oauth2-proxy's identity headers back onto the upstream request.
+    authResponseHeaders:
+      - X-Auth-Request-User
+      - X-Auth-Request-Email
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-Groups
+```
+
+Attach the middleware to the route (`middlewares: [{ name: oauth2-proxy-auth }]` on the IngressRoute, or
+`traefik.http.routers.chmonitor.middlewares=...` on Docker), then configure chmonitor:
+
+```bash
+CHM_AUTH_PROVIDER=trusted
+VITE_AUTH_PROVIDER=trusted
+# oauth2-proxy forwards X-Auth-Request-* (not X-Forwarded-*) through ForwardAuth
+CHM_TRUSTED_USER_HEADER=X-Auth-Request-User
+CHM_TRUSTED_EMAIL_HEADER=X-Auth-Request-Email
+CHM_TRUSTED_NAME_HEADER=X-Auth-Request-Preferred-Username
+CHM_TRUSTED_GROUPS_HEADER=X-Auth-Request-Groups
+# Restrict to specific Dex groups (optional)
+CHM_TRUSTED_ALLOWED_GROUPS=sre,platform-admins
+```
+
+See [Trusted proxy](/docs/authentication/trusted-proxy) for the full header reference, the shared-secret vs `CHM_TRUSTED_ALLOW_INSECURE` tradeoff, and the Dex/oauth2-proxy flags.
+
+## Health checks
+
+chmonitor exposes `/healthz` (liveness, static) and `/api/healthz` (readiness, gated on ClickHouse). Traefik can health-check the service:
+
+```yaml
+# IngressRoute service entry
+services:
+  - name: chmonitor
+    port: 3000
+    healthCheck:
+      path: /healthz
+      intervalSeconds: 15
+```
+
+Make sure your ForwardAuth middleware does **not** guard `/healthz` and `/api/healthz`, or probes will be redirected to the login flow. Route those paths without the auth middleware (a separate, higher-priority router rule), or rely on the chart's Kubernetes probes which hit the pod directly and bypass Traefik.
+
+## Related
+
+- [Kubernetes deployment](/docs/deploy/k8s)
+- [Docker deployment](/docs/deploy/docker)
+- [Trusted proxy authentication](/docs/authentication/trusted-proxy)
+- [Authentication overview](/docs/authentication)
+- [Production checklist](/docs/deploy/production-checklist)

--- a/docs/content/features.mdx
+++ b/docs/content/features.mdx
@@ -26,6 +26,7 @@ All features are **public and enabled by default**. You only configure what you 
 | Browser Connections | Personal ad-hoc connections stored in the browser | — | [Browser Connections](/docs/features/browser-connections) |
 | Actions | Row-level actions across data pages (kill query, optimize, etc.) | `actions` | — |
 | Settings | In-app settings and configuration | `settings` | [Settings](/docs/settings) |
+| Authentication | Who can sign in and what each visitor may access | — | [Authentication](/docs/authentication) |
 
 ## Controlling features
 

--- a/docs/versions/v0.3/authentication.mdx
+++ b/docs/versions/v0.3/authentication.mdx
@@ -2,7 +2,7 @@
 
 chmonitor has two independent auth layers that work together on every `/api/v1/*` route:
 
-- **Auth provider** — one of `none`, `clerk`, or `proxy`. Controls whether browser sessions are authenticated. Set with `CHM_AUTH_PROVIDER` (server) and `VITE_AUTH_PROVIDER` (client, build-time inlined). Legacy Next.js app uses `NEXT_PUBLIC_AUTH_PROVIDER` instead of `VITE_AUTH_PROVIDER`.
+- **Auth provider** — one of `none`, `clerk`, `proxy`, or `trusted`. Controls whether browser sessions are authenticated. Set with `CHM_AUTH_PROVIDER` (server) and `VITE_AUTH_PROVIDER` (client, build-time inlined).
 - **API key layer** — always active when `CHM_API_KEY_SECRET` is set. Authenticates programmatic clients (MCP, scripts, CI) with signed `chm_` Bearer tokens, independent of the provider.
 
 A request is allowed when either layer accepts it. The only fully public setup is `CHM_AUTH_PROVIDER=none` with no `CHM_API_KEY_SECRET`.
@@ -16,7 +16,8 @@ A request is allowed when either layer accepts it. The only fully public setup i
 | Clerk | `clerk` provider | Clerk `__session` cookie | Clerk token or `chm_` key |
 | Clerk OAuth (MCP only) | MCP server | — | OAuth bearer token |
 | Proxy → Cloudflare Access | `proxy` provider | `Cf-Access-Jwt-Assertion` JWT | — |
-| Proxy → trusted header | `proxy` provider | `X-Forwarded-User` + shared secret | shared secret header |
+| Proxy → trusted header (bare subject) | `proxy` provider | `X-Forwarded-User` + shared secret | shared secret header |
+| Proxy → trusted headers (full profile) | `trusted` provider | forwarded headers (oauth2-proxy / Dex / Authelia) | shared secret header |
 
 ## How enforcement decides
 
@@ -36,7 +37,9 @@ All paths fail closed: a missing config or verification error resolves to "not a
 |---|---|
 | Local dev or internal network, no login needed | Public (`none`) — default |
 | Hosted dashboard with user accounts and sign-in | Clerk |
-| Behind Cloudflare Access or nginx/SSO | Proxy (`cloudflare-access` or `trusted-header`) |
+| Behind Cloudflare Access | Proxy — `cloudflare-access` |
+| Behind nginx/SSO with a bare identity header | Proxy — `trusted-header` |
+| Behind oauth2-proxy / Dex / Authelia / Traefik ForwardAuth | Trusted (`trusted`) |
 | MCP clients, scripts, CI pipelines | API key (`CHM_API_KEY_SECRET`) — add alongside any provider |
 
 ## Provider pages
@@ -44,8 +47,9 @@ All paths fail closed: a missing config or verification error resolves to "not a
 - [Public / no auth](/docs/authentication/public) — default open dashboard
 - [API keys](/docs/authentication/api-keys) — `chm_` Bearer tokens for programmatic access
 - [Clerk](/docs/authentication/clerk) — browser sign-in with Clerk sessions
-- [Cloudflare Access](/docs/authentication/cloudflare-access) — reverse proxy JWT verification
-- [Trusted header](/docs/authentication/trusted-header) — reverse proxy with shared secret
+- [Cloudflare Access](/docs/authentication/cloudflare-access) — `proxy` provider; Cloudflare Access JWT verification
+- [Trusted header](/docs/authentication/trusted-header) — `proxy` provider; bare subject via shared secret
+- [Trusted proxy](/docs/authentication/trusted-proxy) — `trusted` provider; full profile from forwarded headers (oauth2-proxy, Dex, Authelia)
 
 ## Related
 

--- a/docs/versions/v0.3/authentication/trusted-proxy.mdx
+++ b/docs/versions/v0.3/authentication/trusted-proxy.mdx
@@ -1,0 +1,265 @@
+# Reverse proxy: trusted forwarded headers
+
+Use this when chmonitor sits behind a proxy that has already authenticated the user — oauth2-proxy with Dex, Authelia, Traefik ForwardAuth, nginx + auth-url, or similar. The proxy forwards the user's identity as HTTP headers; chmonitor trusts them and builds a full principal (name, email, avatar, groups) from those headers.
+
+## When to use
+
+| You have | Use |
+|---|---|
+| oauth2-proxy + Dex (or any OIDC provider) | `trusted` provider |
+| Authelia / Authentik in front of chmonitor | `trusted` provider |
+| Traefik ForwardAuth or nginx `auth_request` | `trusted` provider |
+| Cloudflare Access (signed JWT) | [`proxy` provider](/docs/authentication/cloudflare-access) |
+| nginx + a shared-secret header only (no full profile) | [`proxy` provider / trusted-header](/docs/authentication/trusted-header) |
+
+The `trusted` provider differs from the `proxy` provider:
+- `proxy` is Cloudflare Access-centric (verifies a `Cf-Access-Jwt-Assertion` JWT) or carries a bare subject via a single identity header.
+- `trusted` extracts a full profile (name, email, avatar, groups, custom claims) from multiple forwarded headers, supports group-based access gating, and exposes that profile in the sidebar and `/api/v1/auth/me`.
+
+## How it works
+
+1. The upstream proxy authenticates the user and copies their identity into request headers before forwarding to chmonitor.
+2. chmonitor checks the trust gate — either a shared secret header or an explicit allow-insecure flag. If the gate does not pass, the request is treated as unauthenticated regardless of what headers are present.
+3. If the gate passes, chmonitor reads the configured header names to build a principal: subject, email, display name, avatar URL, and groups/roles.
+4. Optional group gating: if `CHM_TRUSTED_ALLOWED_GROUPS` is set, the user's forwarded groups must intersect (case-insensitive) or access is denied.
+5. A trusted-authenticated user counts as `authenticated` for the feature permission matrix, which unlocks `authenticated`-access features (AI agent, writes) on that request.
+
+The identity is available at `GET /api/v1/auth/me` and displayed in the sidebar user menu.
+
+## Trust gate
+
+**You must configure exactly one of these.** Without a trust gate, the provider fails closed and denies all requests.
+
+| Variable | Default | Description |
+|---|---|---|
+| `CHM_TRUSTED_AUTH_SECRET` | — | Shared secret. The proxy must send it in `CHM_TRUSTED_SHARED_SECRET_HEADER`. Constant-time compared. **Recommended.** |
+| `CHM_TRUSTED_ALLOW_INSECURE` | `false` | When `true`, headers are trusted with no secret check. Only safe when the worker/Service is unreachable except via the proxy (e.g. k8s ClusterIP behind an ingress). |
+| `CHM_TRUSTED_SHARED_SECRET_HEADER` | `X-Chm-Proxy-Secret` | Header name carrying the shared secret. |
+
+Set the secret out-of-band — never in plaintext env files committed to source control:
+
+```bash
+wrangler secret put CHM_TRUSTED_AUTH_SECRET
+# or
+kubectl create secret generic chm-trusted-secret \
+  --from-literal=value=<secret>
+```
+
+## All environment variables
+
+### Provider activation
+
+| Variable | Default | Description |
+|---|---|---|
+| `CHM_AUTH_PROVIDER` | `none` | Set to `trusted`. Server-side. |
+| `VITE_AUTH_PROVIDER` | `none` | Set to `trusted`. Build-time client mirror. Must match `CHM_AUTH_PROVIDER`. |
+
+### Trust gate
+
+| Variable | Default | Description |
+|---|---|---|
+| `CHM_TRUSTED_AUTH_SECRET` | — | Shared secret value (runtime secret). |
+| `CHM_TRUSTED_ALLOW_INSECURE` | `false` | Skip secret check (network-isolation required). |
+| `CHM_TRUSTED_SHARED_SECRET_HEADER` | `X-Chm-Proxy-Secret` | Header name the proxy sends the secret in. |
+
+### Identity headers
+
+| Variable | Default header | What it populates |
+|---|---|---|
+| `CHM_TRUSTED_USER_HEADER` | `X-Forwarded-User` | Subject / user id. Falls back to the email header. Required for a usable identity. |
+| `CHM_TRUSTED_EMAIL_HEADER` | `X-Forwarded-Email` | Email address. |
+| `CHM_TRUSTED_NAME_HEADER` | `X-Forwarded-Preferred-Username` | Display name shown in the sidebar. |
+| `CHM_TRUSTED_AVATAR_HEADER` | `X-Forwarded-Avatar` | Avatar URL. |
+| `CHM_TRUSTED_GROUPS_HEADER` | `X-Forwarded-Groups` | Comma- or space-separated group/role list. |
+| `CHM_TRUSTED_ROLE_HEADER` | `X-Forwarded-Role` | Single role value; merged into the groups list. |
+| `CHM_TRUSTED_CUSTOM_HEADERS` | — | Extra claims. Comma-separated `field:Header-Name` pairs, e.g. `team:X-Forwarded-Team,dept:X-User-Dept`. Available in the principal's custom claims. |
+
+### Access control
+
+| Variable | Default | Description |
+|---|---|---|
+| `CHM_TRUSTED_ALLOWED_GROUPS` | — | Comma-separated group names. When set, the user's forwarded groups must include at least one (case-insensitive). Users with no matching group are treated as unauthenticated (`401`). |
+
+Combines with the existing per-feature vars:
+
+```bash
+CHM_FEATURE_AGENT_ACCESS=authenticated   # agent requires sign-in
+CHM_FEATURE_SETTINGS_ACCESS=authenticated
+CHM_TRUSTED_ALLOWED_GROUPS=sre,ops,admin
+```
+
+A trusted-authenticated user satisfies `authenticated`, so `CHM_FEATURE_*_ACCESS=authenticated` features are unlocked for them automatically.
+
+## Forwarded headers map
+
+What each header becomes in the principal:
+
+These are the fields of the JSON returned by `GET /api/v1/auth/me` (`principal`):
+
+| Header (default name) | Principal field |
+|---|---|
+| `X-Forwarded-User` | `subject` |
+| `X-Forwarded-Email` | `email` |
+| `X-Forwarded-Preferred-Username` | `name` |
+| `X-Forwarded-Avatar` | `avatarUrl` |
+| `X-Forwarded-Groups` | `roles[]` |
+| `X-Forwarded-Role` | merged into `roles[]` |
+| Custom headers (via `CHM_TRUSTED_CUSTOM_HEADERS`) | `custom.<field>` |
+
+## Homelab example: k3s + Traefik + oauth2-proxy + Dex
+
+**Critical detail:** With Traefik ForwardAuth, Traefik copies *oauth2-proxy's* response headers back to the upstream request via the middleware's `authResponseHeaders` list. oauth2-proxy uses `X-Auth-Request-*` headers, not `X-Forwarded-*`. Map accordingly.
+
+### oauth2-proxy flags
+
+oauth2-proxy must emit the auth-request headers and request the `groups` scope from Dex:
+
+```
+--set-xauthrequest=true
+--scope=openid email profile groups
+--pass-authorization-header=false
+```
+
+Dex must include `groups` in its connector config (e.g. an LDAP connector with `groupSearch`, or GitHub connector with `orgs`).
+
+### Traefik Middleware
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: oauth2-proxy-auth
+  namespace: monitoring
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.monitoring.svc.cluster.local/oauth2/auth
+    trustForwardHeader: true
+    authResponseHeaders:
+      - X-Auth-Request-User
+      - X-Auth-Request-Email
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-Groups
+```
+
+Apply the middleware to your chmonitor IngressRoute:
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: chmonitor
+  namespace: monitoring
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`chmonitor.example.com`)
+      kind: Rule
+      middlewares:
+        - name: oauth2-proxy-auth
+      services:
+        - name: chmonitor
+          port: 3000
+```
+
+### chmonitor env vars
+
+```bash
+CHM_AUTH_PROVIDER=trusted
+VITE_AUTH_PROVIDER=trusted
+
+# oauth2-proxy sends X-Auth-Request-* headers, not X-Forwarded-*
+CHM_TRUSTED_USER_HEADER=X-Auth-Request-User
+CHM_TRUSTED_EMAIL_HEADER=X-Auth-Request-Email
+CHM_TRUSTED_NAME_HEADER=X-Auth-Request-Preferred-Username
+CHM_TRUSTED_GROUPS_HEADER=X-Auth-Request-Groups
+
+# Secret (store in a k8s Secret, inject as env; not plaintext here)
+CHM_TRUSTED_AUTH_SECRET=<long-random-secret>
+CHM_TRUSTED_SHARED_SECRET_HEADER=X-Chm-Proxy-Secret
+
+# Gate access to the sre and admin groups only
+CHM_TRUSTED_ALLOWED_GROUPS=sre,admin
+```
+
+The proxy must set `X-Chm-Proxy-Secret: <long-random-secret>` on every forwarded request. In Traefik you can do this with a second middleware or a plugin that adds a static header from a Kubernetes Secret. Alternatively, run chmonitor as a `ClusterIP` only reachable by the oauth2-proxy pod and set `CHM_TRUSTED_ALLOW_INSECURE=true` instead of a shared secret.
+
+## nginx variant
+
+For nginx-ingress with `auth-url` / `auth-snippet`:
+
+```nginx
+# In your server block
+location / {
+  auth_request /oauth2/auth;
+  auth_request_set $auth_user     $upstream_http_x_auth_request_user;
+  auth_request_set $auth_email    $upstream_http_x_auth_request_email;
+  auth_request_set $auth_name     $upstream_http_x_auth_request_preferred_username;
+  auth_request_set $auth_groups   $upstream_http_x_auth_request_groups;
+
+  proxy_set_header X-Forwarded-User               $auth_user;
+  proxy_set_header X-Forwarded-Email              $auth_email;
+  proxy_set_header X-Forwarded-Preferred-Username $auth_name;
+  proxy_set_header X-Forwarded-Groups             $auth_groups;
+  proxy_set_header X-Chm-Proxy-Secret             "<same-secret>";
+
+  proxy_pass http://chmonitor_upstream;
+}
+
+location /oauth2/ {
+  proxy_pass http://oauth2-proxy_upstream;
+}
+```
+
+Or with nginx-ingress annotations:
+
+```yaml
+nginx.ingress.kubernetes.io/auth-url: "https://oauth2-proxy.example.com/oauth2/auth"
+nginx.ingress.kubernetes.io/auth-response-headers: >-
+  X-Auth-Request-User,
+  X-Auth-Request-Email,
+  X-Auth-Request-Preferred-Username,
+  X-Auth-Request-Groups
+nginx.ingress.kubernetes.io/configuration-snippet: |
+  proxy_set_header X-Forwarded-User               $http_x_auth_request_user;
+  proxy_set_header X-Forwarded-Email              $http_x_auth_request_email;
+  proxy_set_header X-Forwarded-Preferred-Username $http_x_auth_request_preferred_username;
+  proxy_set_header X-Forwarded-Groups             $http_x_auth_request_groups;
+  proxy_set_header X-Chm-Proxy-Secret             "<same-secret>";
+```
+
+Keep the default `CHM_TRUSTED_*_HEADER` names in this case (they match `X-Forwarded-*`).
+
+## Security notes
+
+**Header forgery.** Without a trust gate, any client that can reach the chmonitor service directly can send arbitrary headers and forge any identity. Always:
+- Use `CHM_TRUSTED_AUTH_SECRET` with a strong random value, **or**
+- Ensure the Service is network-isolated (k8s ClusterIP, not exposed externally) and set `CHM_TRUSTED_ALLOW_INSECURE=true`.
+
+**Fail closed.** If neither `CHM_TRUSTED_AUTH_SECRET` nor `CHM_TRUSTED_ALLOW_INSECURE=true` is configured, the `trusted` provider rejects all requests with `401`. There is no open fallback.
+
+**Secret hygiene.** Never put the secret value in YAML manifests, `.env` files, or source control. Use a k8s Secret (or `wrangler secret put`) and inject as an environment variable at runtime.
+
+**`CHM_TRUSTED_ALLOW_INSECURE`.** Only use this when the Worker or container is genuinely unreachable except through the proxy. If the port is exposed on a node or load balancer, use the shared secret instead.
+
+## Combining with API keys
+
+`CHM_API_KEY_SECRET` works alongside `CHM_AUTH_PROVIDER=trusted`. Programmatic clients (MCP, scripts, CI) can authenticate with a `chm_` Bearer token without going through the proxy:
+
+```bash
+CHM_API_KEY_SECRET=<secret>
+# mint a key
+curl -X POST https://chmonitor.example.com/api/v1/auth/api-key \
+  -H "Authorization: Bearer <secret>"
+```
+
+See [API keys](/docs/authentication/api-keys).
+
+## Related
+
+- [Authentication overview](/docs/authentication)
+- [Cloudflare Access](/docs/authentication/cloudflare-access)
+- [Trusted header (proxy provider)](/docs/authentication/trusted-header)
+- [API keys](/docs/authentication/api-keys)
+- [Feature Permissions](/docs/advanced/feature-permissions)
+- [Environment Variables — Authentication](/docs/reference/environment-variables#authentication)

--- a/docs/versions/v0.3/deploy.mdx
+++ b/docs/versions/v0.3/deploy.mdx
@@ -32,4 +32,5 @@ Every platform shares the same configuration categories. The links below go to t
 - **Running Docker already?** → [Docker](/docs/deploy/docker)
 - **On Kubernetes?** → [Kubernetes](/docs/deploy/k8s)
 - **Want serverless edge?** → [Cloudflare Workers](/docs/deploy/cloudflare)
+- **Behind Traefik / a reverse proxy?** → [Traefik](/docs/deploy/traefik)
 - **Before going to production?** → [Production checklist](/docs/deploy/production-checklist)

--- a/docs/versions/v0.3/deploy/traefik.mdx
+++ b/docs/versions/v0.3/deploy/traefik.mdx
@@ -1,0 +1,128 @@
+# Traefik
+
+Run chmonitor behind [Traefik](https://traefik.io/) as your reverse proxy / ingress controller. Works the same on Kubernetes (IngressRoute CRD or the standard Ingress) and with plain Docker (container labels).
+
+Traefik handles TLS, routing, and — combined with [oauth2-proxy](/docs/authentication/trusted-proxy) — authentication, so chmonitor itself can stay on the `none` provider and trust the forwarded identity.
+
+## Kubernetes (IngressRoute)
+
+If you installed chmonitor with the [Helm chart](/docs/deploy/k8s), expose the Service with a Traefik `IngressRoute`:
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: chmonitor
+  namespace: monitoring
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`chmonitor.example.com`)
+      kind: Rule
+      services:
+        - name: chmonitor          # matches the chart's Service name
+          port: 3000               # service.port (default 3000)
+  tls:
+    certResolver: letsencrypt      # or a cert-manager-issued Secret via tls.secretName
+```
+
+Prefer the standard `Ingress`? Enable it in the chart and point the class at Traefik:
+
+```yaml
+# values.yaml
+ingress:
+  enabled: true
+  className: traefik
+  hosts:
+    - host: chmonitor.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts: [chmonitor.example.com]
+      secretName: chmonitor-tls
+```
+
+## Docker (labels)
+
+With `docker compose` and Traefik watching the Docker provider:
+
+```yaml
+services:
+  chmonitor:
+    image: ghcr.io/duyet/chmonitor:latest
+    environment:
+      CLICKHOUSE_HOST: http://clickhouse:8123
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: ""
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.chmonitor.rule=Host(`chmonitor.example.com`)
+      - traefik.http.routers.chmonitor.entrypoints=websecure
+      - traefik.http.routers.chmonitor.tls.certresolver=letsencrypt
+      - traefik.http.services.chmonitor.loadbalancer.server.port=3000
+```
+
+## Authentication via ForwardAuth
+
+Put chmonitor behind oauth2-proxy (with Dex, Google, GitHub, …) using a Traefik `ForwardAuth` middleware, and have chmonitor read the forwarded identity with the [`trusted` auth provider](/docs/authentication/trusted-proxy).
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: oauth2-proxy-auth
+  namespace: monitoring
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.monitoring.svc.cluster.local/oauth2/auth
+    trustForwardHeader: true
+    # Copy oauth2-proxy's identity headers back onto the upstream request.
+    authResponseHeaders:
+      - X-Auth-Request-User
+      - X-Auth-Request-Email
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-Groups
+```
+
+Attach the middleware to the route (`middlewares: [{ name: oauth2-proxy-auth }]` on the IngressRoute, or
+`traefik.http.routers.chmonitor.middlewares=...` on Docker), then configure chmonitor:
+
+```bash
+CHM_AUTH_PROVIDER=trusted
+VITE_AUTH_PROVIDER=trusted
+# oauth2-proxy forwards X-Auth-Request-* (not X-Forwarded-*) through ForwardAuth
+CHM_TRUSTED_USER_HEADER=X-Auth-Request-User
+CHM_TRUSTED_EMAIL_HEADER=X-Auth-Request-Email
+CHM_TRUSTED_NAME_HEADER=X-Auth-Request-Preferred-Username
+CHM_TRUSTED_GROUPS_HEADER=X-Auth-Request-Groups
+# Restrict to specific Dex groups (optional)
+CHM_TRUSTED_ALLOWED_GROUPS=sre,platform-admins
+```
+
+See [Trusted proxy](/docs/authentication/trusted-proxy) for the full header reference, the shared-secret vs `CHM_TRUSTED_ALLOW_INSECURE` tradeoff, and the Dex/oauth2-proxy flags.
+
+## Health checks
+
+chmonitor exposes `/healthz` (liveness, static) and `/api/healthz` (readiness, gated on ClickHouse). Traefik can health-check the service:
+
+```yaml
+# IngressRoute service entry
+services:
+  - name: chmonitor
+    port: 3000
+    healthCheck:
+      path: /healthz
+      intervalSeconds: 15
+```
+
+Make sure your ForwardAuth middleware does **not** guard `/healthz` and `/api/healthz`, or probes will be redirected to the login flow. Route those paths without the auth middleware (a separate, higher-priority router rule), or rely on the chart's Kubernetes probes which hit the pod directly and bypass Traefik.
+
+## Related
+
+- [Kubernetes deployment](/docs/deploy/k8s)
+- [Docker deployment](/docs/deploy/docker)
+- [Trusted proxy authentication](/docs/authentication/trusted-proxy)
+- [Authentication overview](/docs/authentication)
+- [Production checklist](/docs/deploy/production-checklist)

--- a/docs/versions/v0.3/features.mdx
+++ b/docs/versions/v0.3/features.mdx
@@ -26,6 +26,7 @@ All features are **public and enabled by default**. You only configure what you 
 | Browser Connections | Personal ad-hoc connections stored in the browser | — | [Browser Connections](/docs/features/browser-connections) |
 | Actions | Row-level actions across data pages (kill query, optimize, etc.) | `actions` | — |
 | Settings | In-app settings and configuration | `settings` | [Settings](/docs/settings) |
+| Authentication | Who can sign in and what each visitor may access | — | [Authentication](/docs/authentication) |
 
 ## Controlling features
 

--- a/docs/versions/v0.3/reference/environment-variables.mdx
+++ b/docs/versions/v0.3/reference/environment-variables.mdx
@@ -10,12 +10,12 @@ Browser-exposed variables are **build-time inlined**. The prefix depends on whic
 
 | App | Client prefix | Example |
 |---|---|---|
-| `apps/dashboard-tsr` (TanStack Start, current) | `VITE_*` | `VITE_AUTH_PROVIDER` |
-| `apps/dashboard` (Next.js, legacy) | `NEXT_PUBLIC_*` | `NEXT_PUBLIC_AUTH_PROVIDER` |
+| `apps/dashboard` (TanStack Start, current) | `VITE_*` | `VITE_AUTH_PROVIDER` |
+| Legacy Next.js (v0.2 and earlier) | `NEXT_PUBLIC_*` | `NEXT_PUBLIC_AUTH_PROVIDER` |
 
-The tables below use `VITE_*`. If you run the legacy Next.js app, substitute `NEXT_PUBLIC_` wherever you see `VITE_`. Server-side variables (`CLICKHOUSE_*`, `CHM_*`, `LLM_*`, `CLERK_SECRET_KEY`, etc.) are the same in both apps.
+The tables below use `VITE_*`. If you are migrating from v0.2, substitute `NEXT_PUBLIC_` wherever you see `VITE_`. Server-side variables (`CLICKHOUSE_*`, `CHM_*`, `LLM_*`, `CLERK_SECRET_KEY`, etc.) are the same.
 
-Authoritative example: [`apps/dashboard-tsr/.env.example`](https://github.com/duyet/clickhouse-monitoring/blob/main/apps/dashboard-tsr/.env.example).
+Authoritative example: [`apps/dashboard/.env.example`](https://github.com/duyet/clickhouse-monitoring/blob/main/apps/dashboard/.env.example).
 
 ---
 
@@ -107,7 +107,7 @@ The active server-side auth provider is set by `CHM_AUTH_PROVIDER`. See [Authent
 
 | Variable | Default | Description |
 |---|---|---|
-| `CHM_AUTH_PROVIDER` | `none` | Server auth provider: `none`, `clerk`, or `proxy`. |
+| `CHM_AUTH_PROVIDER` | `none` | Server auth provider: `none`, `clerk`, `proxy`, or `trusted`. |
 | `VITE_AUTH_PROVIDER` | `none` | Client-side mirror of `CHM_AUTH_PROVIDER`. Set to the same value. Build-time. |
 | `CHM_API_KEY_SECRET` | — | Shared secret for `chm_` API keys. When set, API-key auth is always on alongside the active provider. Issue keys at `/api/v1/auth/api-key`. |
 
@@ -117,6 +117,7 @@ The active server-side auth provider is set by `CHM_AUTH_PROVIDER`. See [Authent
 |---|---|---|
 | `VITE_CLERK_PUBLISHABLE_KEY` | — | Clerk publishable key (`pk_...`). Build-time — must be set before `bun run build`. |
 | `CLERK_SECRET_KEY` | — | Clerk secret key (`sk_...`). Runtime only. Never expose to the browser. |
+| `CHM_CLERK_PUBLIC_READ` | `false` | When `true`, anonymous visitors can view read-only monitoring content; writes (AI agent, control actions, arbitrary SQL) still require sign-in. Runtime only. See [Clerk → Public read-only mode](/docs/authentication/clerk#public-read-only-mode). |
 
 ### Reverse proxy (`CHM_AUTH_PROVIDER=proxy`)
 
@@ -129,7 +130,7 @@ Trust a reverse proxy that already authenticated the user. Either mechanism belo
 | `CHM_CF_ACCESS_TEAM_DOMAIN` | — | Cloudflare Access team URL (`https://<team>.cloudflareaccess.com`). Enables `Cf-Access-Jwt-Assertion` JWT verification. |
 | `CHM_CF_ACCESS_AUD` | — | Access application AUD tag the JWT must carry. |
 
-**Trusted header:**
+**Trusted header (bare subject):**
 
 | Variable | Default | Description |
 |---|---|---|
@@ -138,6 +139,38 @@ Trust a reverse proxy that already authenticated the user. Either mechanism belo
 | `CHM_PROXY_AUTH_HEADER` | `X-Forwarded-User` | Header the proxy sends containing the authenticated user identity. |
 
 > When `CHM_PROXY_AUTH_SECRET` is set, the identity header (`X-Forwarded-User` by default) is honored only when the request also carries a matching shared-secret header (constant-time compared). Without `CHM_PROXY_AUTH_SECRET`, the entire trusted-header mechanism is disabled and identity headers are ignored.
+
+### Trusted reverse proxy (`CHM_AUTH_PROVIDER=trusted`)
+
+Use when an upstream proxy (oauth2-proxy, Authelia, Traefik ForwardAuth, nginx auth-url) forwards the user's full identity as HTTP headers. Extracts a complete principal — name, email, avatar, groups, custom claims.
+
+**Trust gate** — configure exactly one:
+
+| Variable | Default | Description |
+|---|---|---|
+| `CHM_TRUSTED_AUTH_SECRET` | — | Shared secret (runtime secret). The proxy must send it in `CHM_TRUSTED_SHARED_SECRET_HEADER`. Constant-time compared. Recommended. |
+| `CHM_TRUSTED_ALLOW_INSECURE` | `false` | When `true`, trusts headers with no secret check. Only safe when the service is unreachable except via the proxy (e.g. k8s ClusterIP). |
+| `CHM_TRUSTED_SHARED_SECRET_HEADER` | `X-Chm-Proxy-Secret` | Header name carrying the shared secret. |
+
+**Identity headers** — all optional; defaults match common proxy conventions:
+
+| Variable | Default | Populates |
+|---|---|---|
+| `CHM_TRUSTED_USER_HEADER` | `X-Forwarded-User` | Subject / user id. Falls back to the email header. |
+| `CHM_TRUSTED_EMAIL_HEADER` | `X-Forwarded-Email` | Email address. |
+| `CHM_TRUSTED_NAME_HEADER` | `X-Forwarded-Preferred-Username` | Display name. |
+| `CHM_TRUSTED_AVATAR_HEADER` | `X-Forwarded-Avatar` | Avatar URL. |
+| `CHM_TRUSTED_GROUPS_HEADER` | `X-Forwarded-Groups` | Comma- or space-separated groups. |
+| `CHM_TRUSTED_ROLE_HEADER` | `X-Forwarded-Role` | Single role; merged into the groups list. |
+| `CHM_TRUSTED_CUSTOM_HEADERS` | — | Extra claims. Comma-separated `field:Header-Name` pairs, e.g. `team:X-Forwarded-Team`. |
+
+**Access control:**
+
+| Variable | Default | Description |
+|---|---|---|
+| `CHM_TRUSTED_ALLOWED_GROUPS` | — | Comma-separated group names. When set, users whose forwarded groups do not intersect are denied `403`. Case-insensitive. |
+
+See [Trusted proxy](/docs/authentication/trusted-proxy) for setup examples (oauth2-proxy + Dex + Traefik, nginx).
 
 ---
 


### PR DESCRIPTION
Follow-up to #1755. Three docs improvements requested by the owner.

## 1. Authentication in both Deploy and Features
The `Authentication` docs section now appears under **both** the Deploy and Features top-level nav categories (`header-nav.ts`), plus a row in the Features index table. No page moves — it's a nav-mapping change (the section already lived under Deploy).

## 2. Traefik deployment page
New `deploy/traefik.mdx`: running chmonitor behind Traefik on k8s (`IngressRoute` + standard `Ingress`) and Docker (labels), TLS, and a `ForwardAuth` + oauth2-proxy + Dex example that wires into the [`trusted`](/docs/authentication/trusted-proxy) provider (with the `X-Auth-Request-*` header detail and a health-probe caveat). Linked from the deploy index.

## 3. Raw `.md` routes + Copy/Open buttons
- Every docs page now has a raw-markdown sibling: `/authentication/trusted-header` → **`/authentication/trusted-header.md`**, served as `text/markdown` by a prerendered `[...slug].md.ts` endpoint (the `# Title` is restored from frontmatter).
- New `PageActions` component renders **"Copy page"** and **"Open as Markdown"** buttons top-right of every page. "Copy page" fetches the `.md` sibling and writes it to the clipboard.

## Publishing note (important)
The docs site builds from committed **`docs/versions/<v>`** snapshots (frozen by `snapshot-version.mjs`), not `docs/content`. I re-snapshotted **only the auth/deploy pages** touched here — which also publishes the `trusted-proxy.mdx` page from #1755 that was added to `docs/content` but never snapshotted, so it wasn't live.

⚠️ **Heads-up:** `docs/versions/v0.3` has drifted significantly from `docs/content` (≈18 other pages — ai-agent, k8s, clerk, cloudflare, etc. — were edited in `docs/content` by prior PRs but never re-snapshotted, so they aren't on the live site). I left those out to keep this PR scoped. Happy to do a full `snapshot-version.mjs v0.3 --force` re-snapshot in a separate PR to un-stale the whole site if you want.

## Verification
- `bun run build` (apps/docs: sync-docs → astro build → pagefind) ✅ 64 pages
- `.md` files emitted (`dist/authentication/trusted-header.md` etc., verified plain UTF-8 markdown) ✅
- Copy/Open buttons present in built HTML ✅
- Biome ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the new trusted reverse proxy auth provider, add Traefik deployment guidance, and improve docs usability with authentication surfacing and raw markdown access.

New Features:
- Expose raw markdown versions of docs pages alongside the HTML routes and provide UI actions to copy or open the markdown.
- Add dedicated documentation for running chmonitor behind Traefik across Kubernetes and Docker setups.
- Document the trusted reverse proxy (`trusted`) authentication provider and how to integrate it with common proxy stacks.

Enhancements:
- Surface the Authentication docs under both the Deploy and Features navigation categories and add it to the features overview table.
- Clarify environment variable guidance for dashboard app variants, including migrating from legacy Next.js to the current TanStack Start app, and update authentication-related env var docs with the new `trusted` provider and Clerk public-read flag.
- Add a navigation icon mapping for the new Traefik deployment docs page.

Documentation:
- Snapshot and publish updated authentication and deployment docs in the v0.3 docs version, including the new Traefik and trusted proxy pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Copy page" and "Open as Markdown" buttons to documentation pages for easy content access.
  * Added support for trusted proxy authentication provider with header-based identity forwarding.

* **Documentation**
  * New Traefik deployment guide covering Kubernetes, Docker, and reverse proxy authentication setup.
  * New trusted proxy authentication documentation with configuration examples and security guidance.
  * Updated features index and environment variable reference to reflect new authentication options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->