### PR TITLE
fix(sql-validator): stop rejecting legitimate read-only queries

### DIFF
--- a/apps/dashboard/src/lib/query-config/__tests__/shipped-sql-passes-validator.test.ts
+++ b/apps/dashboard/src/lib/query-config/__tests__/shipped-sql-passes-validator.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression: every shipped query-config SQL must pass the security validator.
+ *
+ * `validateSqlQuery` gates every free-form SQL entry point (AI agent tools, the
+ * MCP `query` tool, the explorer custom-query box, and the `/api/v1/data` and
+ * `/api/v1/explain` routes). If the dashboard itself ships a query the
+ * validator rejects, a user who copies that query into any of those surfaces is
+ * blocked from a query the product demonstrably considers safe.
+ *
+ * This previously failed for 8 shipped configs (false positives in the denylist
+ * for `UNION ALL SELECT`, the read-only `replace()` function, and disjunctive
+ * `col = 'A' OR col = 'B'` filters). The validator was tightened to keep
+ * blocking real DDL/DML and dangerous table functions while allowing these.
+ *
+ * This test is intentionally corpus-wide (not a fixed list) so any NEW shipped
+ * query that the validator would reject fails here immediately.
+ */
+
+import { queries } from '../index'
+import { describe, expect, test } from 'bun:test'
+import { getAllSqlStrings, validateSqlQuery } from '@chm/sql-builder'
+
+describe('shipped query-config SQL passes validateSqlQuery', () => {
+  test('every query-config SQL variant is accepted by the validator', () => {
+    const rejected: { name: string; error: string; sql: string }[] = []
+
+    for (const config of queries) {
+      for (const sql of getAllSqlStrings(config.sql)) {
+        try {
+          validateSqlQuery(sql)
+        } catch (error) {
+          rejected.push({
+            name: config.name,
+            error: (error as Error).message,
+            sql: sql.replace(/\s+/g, ' ').slice(0, 160),
+          })
+        }
+      }
+    }
+
+    if (rejected.length > 0) {
+      const report = rejected
+        .map((r) => `  - [${r.name}] ${r.error}\n      ${r.sql}`)
+        .join('\n')
+      throw new Error(
+        `${rejected.length} shipped query-config SQL string(s) rejected by validateSqlQuery:\n${report}`
+      )
+    }
+
+    expect(rejected).toHaveLength(0)
+  })
+
+  test('corpus is non-empty (guards against an empty/mis-imported registry)', () => {
+    const total = queries.reduce(
+      (sum, c) => sum + getAllSqlStrings(c.sql).length,
+      0
+    )
+    expect(total).toBeGreaterThan(50)
+  })
+})

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -36,6 +36,7 @@ Agents discover knowledge in this order:
 | **Operations** | [release-automation.md](release-automation.md) | workflow | release-please + release.yml pipeline: versioning rules, PR-title guard, labeler, CHANGELOG ownership, migration prompt |
 | **Specs** | [ai-insights.md](ai-insights.md) | spec | AI Insights engine: collect→enrich→persist (findings store), cron + manual generation, stable-key dismissal, overview panel |
 | **Specs** | [mcp-server.md](mcp-server.md) | reference | MCP server at /api/mcp: tools, setup, security |
+| **Security** | [sql-validator-threat-model.md](sql-validator-threat-model.md) | decision | validateSqlQuery gates all free-form SQL; whole-query (not fragment) threat model; UNION/replace()/OR-disjunction false-positive class + corpus regression guard |
 | **Specs** | [agent-conversation-storage.md](agent-conversation-storage.md) | spec | Runtime-selected agent chat persistence backends and fallback rules |
 | **Specs** | [agentstate-conversation-store.md](agentstate-conversation-store.md) | spec | AgentState backend: resolveStore priority, external_id/tag isolation, append-only upsert, AI enrichment, backend/follow-ups routes |
 | **Specs** | [query-config-format.md](query-config-format.md) | spec | QueryConfig type format, versioned SQL, BackgroundBar columns |

--- a/docs/knowledge/sql-validator-threat-model.md
+++ b/docs/knowledge/sql-validator-threat-model.md
@@ -1,0 +1,70 @@
+---
+id: sql-validator-threat-model
+title: SQL Validator Threat Model & False-Positive Class
+type: decision
+status: active
+updated: 2026-06-20
+tags:
+  - security
+  - sql
+  - validation
+  - mcp
+related:
+  - mcp-server
+  - query-config-format
+---
+
+# SQL Validator Threat Model & False-Positive Class
+
+`validateSqlQuery` (`packages/sql-builder/src/sql-validator.ts`) is the gate for
+**every free-form SQL entry point**: AI agent tools, the MCP `query` tool, the
+explorer custom-query box, and the `/api/v1/data` + `/api/v1/explain` routes.
+
+## Threat model (important)
+
+The validator receives the **entire query** as supplied by the caller — there is
+**no** "trusted query + untrusted fragment" string concatenation. So classic
+SQL-injection signatures that defend against *fragment* injection are the wrong
+model here and only generate false positives:
+
+- **UNION-append** (`… UNION SELECT secret …`) — pointless to block, because the
+  validator already permits `SELECT secret FROM system.users` on its own. UNION
+  of two SELECTs adds no read surface.
+- **OR-tautology on identifiers** (`col = 'A' OR col = 'B'`) — an ordinary
+  disjunctive filter, not an attack.
+- **Keyword/function collisions** — `REPLACE` (the read-only `replace()` string
+  function) collided with the `\bREPLACE\b` DDL keyword.
+
+The controls that actually matter (all retained):
+
+1. Statement must start with `SELECT` / `WITH` / `DESCRIBE` / `EXPLAIN`.
+2. DDL/DML keyword block (`DROP|DELETE|INSERT|UPDATE|ALTER|CREATE|TRUNCATE|RENAME`)
+   + `CHAINED_DANGEROUS` for `; <ddl>`.
+3. Dangerous **table-function** block (`remote|url|s3|file|executable|…`).
+4. ClickHouse-side readonly user + parameterized `{name:Type}` placeholders.
+
+## The false-positive incident (2026-06-20)
+
+8 **shipped** query-configs were rejected by their own validator
+(anomaly-summary, explorer-all/table-dependencies, expensive-queries,
+slow-queries, error-rate-baseline). Root causes + fixes:
+
+| Pattern | Was | Now |
+|---------|-----|-----|
+| `UNION_INJECTION` | enforced | kept as exported constant, **removed from enforcement array** |
+| `DANGEROUS_KEYWORDS` | included `REPLACE` | **`REPLACE` removed** (DDL form still blocked by prefix-check + `CHAINED_DANGEROUS`) |
+| `STRING_INJECTION_OR_SINGLE` / `_DOUBLE` | broad `'.*OR.*'.*=.*'` | precise `\bOR\s+('[^']*'?\|\d+)\s*=\s*('[^']*'?\|\d+)` — requires a **literal** (not identifier) on the left of `=` |
+
+The tightened OR-patterns are also **ReDoS-safe** (the old nested `.*` runs risked
+catastrophic backtracking).
+
+## Rule: keep shipped SQL and the validator in sync
+
+Any query the dashboard ships must pass `validateSqlQuery`. This is guarded by a
+corpus-wide regression test:
+`apps/dashboard/src/lib/query-config/__tests__/shipped-sql-passes-validator.test.ts`
+(runs **every** query-config SQL variant through the validator). If you add a
+config that uses a construct the validator blocks, fix the **validator's threat
+model**, not the query — and add a targeted case to
+`packages/sql-builder/src/__tests__/sql-validator.test.ts`. A throughput + ReDoS
+benchmark lives at `…/__tests__/sql-validator.bench.ts`.

--- a/packages/sql-builder/src/__tests__/sql-validator.bench.ts
+++ b/packages/sql-builder/src/__tests__/sql-validator.bench.ts
@@ -1,0 +1,71 @@
+/**
+ * SQL Validator benchmark
+ *
+ * Standalone throughput + ReDoS-safety benchmark for {@link validateSqlQuery}.
+ * Run with: `bun run src/__tests__/sql-validator.bench.ts` (from this package).
+ *
+ * Not part of the test suite — it prints timings for manual inspection and
+ * exits non-zero only if the adversarial case shows catastrophic backtracking,
+ * so it can double as a coarse CI smoke check if wired up.
+ */
+import { validateSqlQuery } from '../sql-validator'
+
+const LEGIT_CORPUS = [
+  "SELECT replace(query, 'a', 'b') FROM system.query_log",
+  "SELECT * FROM system.query_log WHERE type = 'ExceptionBeforeStart' OR type = 'ExceptionWhileProcessing'",
+  'SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3',
+  'WITH t AS (SELECT 1 AS x) SELECT * FROM t',
+  "SELECT formatReadableSize(sum(bytes_on_disk)) FROM system.parts WHERE active AND database = 'default'",
+  'SELECT count() FROM system.tables',
+]
+
+function bench(label: string, fn: () => void, iters: number): number {
+  // warmup
+  for (let i = 0; i < 1000; i++) fn()
+  const start = performance.now()
+  for (let i = 0; i < iters; i++) fn()
+  const elapsed = performance.now() - start
+  const perOp = (elapsed / iters) * 1000 // µs
+  console.log(
+    `${label.padEnd(28)} ${iters} ops in ${elapsed.toFixed(1)}ms  (${perOp.toFixed(3)} µs/op)`
+  )
+  return elapsed
+}
+
+console.log('=== validateSqlQuery benchmark ===\n')
+
+bench(
+  'legit corpus',
+  () => {
+    for (const sql of LEGIT_CORPUS) {
+      try {
+        validateSqlQuery(sql)
+      } catch {
+        /* ignore */
+      }
+    }
+  },
+  50_000
+)
+
+// ReDoS check: adversarial input that would explode under nested `.*` patterns.
+const adversarial = `SELECT * FROM t WHERE x = '${"a' OR 'a".repeat(5000)}`
+const adversarialMs = bench(
+  'adversarial (ReDoS)',
+  () => {
+    try {
+      validateSqlQuery(adversarial)
+    } catch {
+      /* ignore */
+    }
+  },
+  100
+)
+
+const perAdversarial = adversarialMs / 100
+console.log(`\nadversarial per-op: ${perAdversarial.toFixed(2)}ms`)
+if (perAdversarial > 50) {
+  console.error('FAIL: adversarial input shows super-linear behavior (ReDoS)')
+  process.exit(1)
+}
+console.log('OK: no catastrophic backtracking detected')

--- a/packages/sql-builder/src/__tests__/sql-validator.test.ts
+++ b/packages/sql-builder/src/__tests__/sql-validator.test.ts
@@ -94,10 +94,18 @@ describe('SQL_PATTERNS', () => {
       ).toBe(true)
     })
 
-    test('should match REPLACE keyword', () => {
+    // Regression: REPLACE is NOT a DANGEROUS_KEYWORD because it collides with
+    // ClickHouse's read-only `replace()` string function. DDL REPLACE is still
+    // blocked end-to-end (statement-prefix check + CHAINED_DANGEROUS) — see the
+    // "should reject REPLACE statements" / "should allow replace() function"
+    // tests below.
+    test('should NOT match REPLACE keyword (collides with replace() function)', () => {
       expect(SQL_PATTERNS.DANGEROUS_KEYWORDS.test('REPLACE TABLE t1')).toBe(
-        true
+        false
       )
+      expect(
+        SQL_PATTERNS.DANGEROUS_KEYWORDS.test("replace(query, 'a', 'b')")
+      ).toBe(false)
     })
 
     test('should not match SELECT', () => {
@@ -543,9 +551,24 @@ describe.skipIf(actuallyMocked)('validateSqlQuery', () => {
     })
 
     test('should reject REPLACE statements', () => {
-      expect(() => validateSqlQuery('REPLACE TABLE t1 (id UInt32)')).toThrow(
-        'Potentially dangerous SQL detected'
-      )
+      // Now caught by the statement-prefix check (does not start with
+      // SELECT/WITH/DESCRIBE/EXPLAIN) rather than the keyword denylist.
+      expect(() => validateSqlQuery('REPLACE TABLE t1 (id UInt32)')).toThrow()
+    })
+
+    test('should allow the read-only replace() string function', () => {
+      // Regression for shipped query-configs (expensive-queries, slow-queries)
+      // which use replace()/replaceRegexpAll() in SELECT projections.
+      expect(() =>
+        validateSqlQuery(
+          "SELECT replace(substr(query, 1, 100), '\\n', ' ') FROM system.query_log"
+        )
+      ).not.toThrow()
+      expect(() =>
+        validateSqlQuery(
+          "SELECT replaceRegexpAll(query, '\\\\d+', '?') FROM system.query_log"
+        )
+      ).not.toThrow()
     })
 
     test('should reject chained RENAME/REPLACE', () => {
@@ -613,17 +636,35 @@ describe.skipIf(actuallyMocked)('validateSqlQuery', () => {
       ).toThrow('Potentially dangerous SQL detected')
     })
 
-    test('should reject UNION injection', () => {
+    // Regression: UNION between SELECTs is legitimate read-only SQL and is used
+    // by several shipped query-configs (anomaly-summary, explorer dependency
+    // graphs). The validator already gates the whole query to SELECT/WITH, so
+    // the UNIONed SELECT is independently permitted and adds no read surface.
+    // It must NOT be rejected. See sql-validator.ts UNION_INJECTION docstring.
+    test('should allow UNION SELECT (no extra read surface over plain SELECT)', () => {
       expect(() =>
         validateSqlQuery(
           "SELECT * FROM users WHERE name = '' UNION SELECT * FROM passwords"
         )
+      ).not.toThrow()
+    })
+
+    test('should allow UNION ALL SELECT', () => {
+      expect(() =>
+        validateSqlQuery('SELECT 1 UNION ALL SELECT secret FROM system.users')
+      ).not.toThrow()
+    })
+
+    test('should still reject DDL chained after a UNION query', () => {
+      // UNION is allowed, but a chained dangerous statement is still caught.
+      expect(() =>
+        validateSqlQuery('SELECT 1 UNION ALL SELECT 2; DROP TABLE t')
       ).toThrow('Potentially dangerous SQL detected')
     })
 
-    test('should reject UNION ALL injection', () => {
+    test('should still reject dangerous table functions inside a UNION', () => {
       expect(() =>
-        validateSqlQuery('SELECT 1 UNION ALL SELECT secret FROM system.users')
+        validateSqlQuery("SELECT 1 UNION ALL SELECT * FROM remote('x', t)")
       ).toThrow('Potentially dangerous SQL detected')
     })
 
@@ -631,6 +672,41 @@ describe.skipIf(actuallyMocked)('validateSqlQuery', () => {
       expect(() =>
         validateSqlQuery("SELECT * FROM users WHERE name = '' OR '1'='1")
       ).toThrow('Potentially dangerous SQL detected')
+      // Also the fully-terminated variant.
+      expect(() =>
+        validateSqlQuery("SELECT * FROM users WHERE name = '' OR '1'='1'")
+      ).toThrow('Potentially dangerous SQL detected')
+    })
+
+    // Regression: the OR-comparison patterns must distinguish a tautology
+    // (literal = literal) from an ordinary disjunctive filter (column =
+    // literal). Several shipped query-configs (e.g. error-rate-baseline) use
+    // `col = 'A' OR col = 'B'`; the old broad `'.*OR.*'.*=.*'` pattern wrongly
+    // rejected them.
+    test('should allow disjunctive equality filters on columns', () => {
+      const ok = [
+        "SELECT * FROM system.query_log WHERE type = 'ExceptionBeforeStart' OR type = 'ExceptionWhileProcessing'",
+        "SELECT * FROM t WHERE db = 'default' OR db = 'system'",
+        `SELECT * FROM system.columns WHERE name = "id" OR name = "ts"`,
+        "SELECT a OR b FROM t WHERE x = 'y' OR z = 'w' OR q = 'r'",
+      ]
+      for (const sql of ok) {
+        expect(() => validateSqlQuery(sql)).not.toThrow()
+      }
+    })
+
+    test('should still reject literal=literal tautologies guarded by OR', () => {
+      const bad = [
+        "SELECT * FROM t WHERE x = '' OR 'a'='a",
+        "SELECT * FROM t WHERE x = '' OR 'a'='a'",
+        `SELECT * FROM t WHERE x = "" OR "a"="a`,
+        'SELECT * FROM t WHERE id = 0 OR 5=5',
+      ]
+      for (const sql of bad) {
+        expect(() => validateSqlQuery(sql)).toThrow(
+          'Potentially dangerous SQL detected'
+        )
+      }
     })
   })
 
@@ -721,6 +797,47 @@ describe.skipIf(actuallyMocked)('validateSqlQuery', () => {
       expect(() =>
         validateSqlQuery('/* multi\nline\ncomment */ SELECT 1')
       ).not.toThrow()
+    })
+  })
+
+  // Performance / ReDoS guard. The previous STRING_INJECTION_OR/DOUBLE patterns
+  // (`'.*OR.*'.*=.*'`) had nested unbounded `.*` runs that risk catastrophic
+  // backtracking on adversarial input. The tightened patterns are linear; this
+  // guard fails loudly if a future change reintroduces super-linear behavior.
+  describe('validation performance (ReDoS guard)', () => {
+    test('handles large adversarial input quickly', () => {
+      const adversarial = `SELECT * FROM t WHERE x = '${"a' OR 'a".repeat(2000)}`
+      const start = performance.now()
+      try {
+        validateSqlQuery(adversarial)
+      } catch {
+        // rejection is fine; we only care it returns fast
+      }
+      const elapsed = performance.now() - start
+      // Generous ceiling (typical < 1ms); catches pathological backtracking.
+      expect(elapsed).toBeLessThan(100)
+    })
+
+    test('validates a realistic query corpus quickly', () => {
+      const corpus = [
+        "SELECT replace(query, 'a', 'b') FROM system.query_log WHERE type = 'A' OR type = 'B'",
+        'SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3',
+        'WITH t AS (SELECT 1) SELECT * FROM t',
+        "SELECT * FROM system.parts WHERE active AND database = 'default' OR database = 'system'",
+      ]
+      const start = performance.now()
+      for (let i = 0; i < 1000; i++) {
+        for (const sql of corpus) {
+          try {
+            validateSqlQuery(sql)
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+      const elapsed = performance.now() - start
+      // 4000 validations; generous ceiling for CI variance.
+      expect(elapsed).toBeLessThan(500)
     })
   })
 })

--- a/packages/sql-builder/src/sql-validator.ts
+++ b/packages/sql-builder/src/sql-validator.ts
@@ -18,9 +18,17 @@
 export const SQL_PATTERNS = {
   /**
    * Dangerous SQL keywords that modify data or schema
+   *
+   * Note: `REPLACE` is intentionally NOT listed here. ClickHouse exposes a
+   * read-only `replace()` / `replaceRegexpAll()` string function, and the bare
+   * `replace(` call collides with a `\bREPLACE\b` keyword match. The dangerous
+   * DDL forms are still blocked: statement-level `REPLACE TABLE` fails the
+   * "must start with SELECT/WITH/DESCRIBE/EXPLAIN" check, `CREATE OR REPLACE`
+   * is caught by `CREATE`, and chained `; REPLACE` is caught by
+   * {@link SQL_PATTERNS.CHAINED_DANGEROUS}.
    */
   DANGEROUS_KEYWORDS:
-    /\b(DROP|DELETE|INSERT|UPDATE|ALTER|CREATE|TRUNCATE|RENAME|REPLACE)\b/i,
+    /\b(DROP|DELETE|INSERT|UPDATE|ALTER|CREATE|TRUNCATE|RENAME)\b/i,
 
   /**
    * SQL execution commands
@@ -42,10 +50,17 @@ export const SQL_PATTERNS = {
 
   /**
    * SQL injection via string manipulation
+   *
+   * The OR-comparison patterns detect a literal-to-literal comparison guarded
+   * by OR — the shape of a tautology bypass such as `' OR '1'='1` or
+   * `" OR "a"="a`. They deliberately require a quoted/numeric literal (not an
+   * identifier) on the left of `=` so that ordinary disjunctive filters like
+   * `type = 'A' OR type = 'B'` are NOT flagged. The standalone numeric
+   * tautology `OR 1=1` is covered by {@link SQL_PATTERNS.TAUTOLOGY}.
    */
   STRING_INJECTION_SINGLE: /';.*--/,
-  STRING_INJECTION_DOUBLE: /".*OR.*".*=.*"/i,
-  STRING_INJECTION_OR_SINGLE: /'.*OR.*'.*=.*'/i,
+  STRING_INJECTION_DOUBLE: /\bOR\s+("[^"]*"?|\d+)\s*=\s*("[^"]*"?|\d+)/i,
+  STRING_INJECTION_OR_SINGLE: /\bOR\s+('[^']*'?|\d+)\s*=\s*('[^']*'?|\d+)/i,
 
   /**
    * Tautology attacks (always true conditions)
@@ -54,6 +69,13 @@ export const SQL_PATTERNS = {
 
   /**
    * UNION-based injection attacks
+   *
+   * Kept for reference/back-compat but NOT enforced (see
+   * {@link SQL_INJECTION_PATTERNS}). This validator gates the whole query to
+   * SELECT/WITH/DESCRIBE/EXPLAIN, so `SELECT secret FROM system.users` is
+   * already permitted on its own — a `UNION ALL SELECT` of the same adds no
+   * read surface, while legitimate queries (and several shipped query-configs)
+   * use `UNION ALL SELECT` routinely.
    */
   UNION_INJECTION: /\bunion\s+(all\s+)?select\b/i,
 
@@ -91,7 +113,8 @@ const SQL_INJECTION_PATTERNS = [
   SQL_PATTERNS.STRING_INJECTION_OR_SINGLE,
   SQL_PATTERNS.STRING_INJECTION_DOUBLE,
   SQL_PATTERNS.TAUTOLOGY,
-  SQL_PATTERNS.UNION_INJECTION,
+  // UNION_INJECTION intentionally omitted: the query is already gated to
+  // SELECT/WITH and `UNION ALL SELECT` adds no read surface (see its docstring).
   SQL_PATTERNS.SET_COMMAND,
   SQL_PATTERNS.SYSTEM_COMMAND,
   SQL_PATTERNS.KILL_COMMAND,


### PR DESCRIPTION
## Problem

A realistic-scenario sweep ran **all shipped query-config SQL** through `validateSqlQuery` — the gate for every free-form SQL entry point (AI agent tools, MCP `query` tool, explorer custom query, `/api/v1/data`, `/api/v1/explain`). **8 shipped queries were rejected by the dashboard's own validator** (anomaly-summary, explorer-all/table-dependencies, expensive-queries, slow-queries, error-rate-baseline). A user copying any of these into the explorer/AI/MCP would be blocked from a query the product itself ships.

## Root cause: wrong threat model

The validator receives the **whole query** from the caller — there is no trusted-query + untrusted-fragment concatenation. So classic *fragment* SQLi signatures only generate false positives:

| Class | Example (legit, was rejected) | Fix |
|------|------|-----|
| `UNION ALL SELECT` | explorer dependency graphs | Removed `UNION_INJECTION` from enforcement. The query is already SELECT-gated, so a UNIONed SELECT adds **no** read surface (the second SELECT is independently allowed). |
| `replace()` | `replace(substr(query,…))` | Removed `REPLACE` from `DANGEROUS_KEYWORDS` (collided with the read-only string function). DDL `REPLACE` still blocked by the statement-prefix check + `CHAINED_DANGEROUS`. |
| `col = 'A' OR col = 'B'` | `type = 'ExceptionBeforeStart' OR type = 'ExceptionWhileProcessing'` | Tightened `STRING_INJECTION_OR/DOUBLE` to require a **literal** (not identifier) left of `=`. Tautologies (`' OR '1'='1`) still rejected; new patterns are ReDoS-safe. |

**Retained controls:** statement-prefix gate, all DDL/DML keywords, dangerous table functions (`remote`/`url`/`s3`/`file`/…), `SET`/`KILL`/`SYSTEM`/`ATTACH`/`GRANT`, numeric tautology, chained statements.

## Coverage

- **Corpus-wide regression** (`shipped-sql-passes-validator.test.ts`): every query-config SQL variant must pass the validator — fails immediately if a future config drifts.
- Targeted regressions + reconciled test intent in `sql-validator.test.ts` (122 pass).
- **ReDoS guard** test + standalone throughput **benchmark** (`sql-validator.bench.ts`, ~5.5µs/op; 0.69ms on 40k-char adversarial input).
- Threat-model decision doc in `docs/knowledge/`.

## Verification

- `packages/sql-builder` suite: 499 pass
- `packages/mcp-server` suite: 103 pass
- `apps/dashboard` query-config suite: 614 pass
- 29 dangerous queries still rejected, 6 representative legit queries allowed
- lint clean, `type-check:test` clean

https://claude.ai/code/session_01RtzX73qAeTQ9gUXgiLeMnJ

## Summary by Sourcery

Loosen SQL validator rules to avoid blocking legitimate read-only queries while preserving protections against dangerous operations and performance issues.

Bug Fixes:
- Allow UNION/UNION ALL between SELECT statements, REPLACE-based string functions, and common OR-based filters so shipped read-only queries are no longer rejected by the validator.
- Refine OR-tautology detection patterns to distinguish real injection-style tautologies from normal column equality disjunctions.

Enhancements:
- Remove REPLACE from the dangerous keyword list and document the adjusted threat model and validator behavior, including the rationale for not enforcing UNION-based injection patterns.
- Add performance and ReDoS guard tests plus a standalone benchmark to ensure validateSqlQuery remains fast and resistant to catastrophic regex backtracking.

Documentation:
- Document the SQL validator threat model, false-positive class, and regression strategy in the knowledge base.

Tests:
- Expand sql-validator test coverage with regressions for shipped queries, UNION handling, REPLACE function usage, refined OR-tautology detection, and performance guards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test suite validating all shipped SQL queries
  * Added performance benchmark tests for SQL validator

* **Documentation**
  * Added SQL validator threat model documentation detailing security controls and known edge cases

* **Bug Fixes**
  * Refined SQL validation rules: adjusted UNION, REPLACE, and OR-pattern detection to reduce false positives while maintaining security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->