### PR TITLE
fix(api): reject negative and fractional hostId at route boundary

### DIFF
--- a/apps/dashboard/src/lib/api/shared/validators/__tests__/host-id.bench.ts
+++ b/apps/dashboard/src/lib/api/shared/validators/__tests__/host-id.bench.ts
@@ -1,0 +1,70 @@
+/**
+ * hostId boundary parse+validate benchmark.
+ *
+ * This runs on EVERY API request (charts, tables, explorer, ...). The check is
+ * `const n = Number(raw); const ok = Number.isInteger(n) && n >= 0`. The bench
+ * guards that the hot-path parser stays O(1) and allocation-free across a
+ * realistic mix of valid, malformed, negative, and fractional inputs.
+ *
+ * Run: `bun run src/lib/api/shared/validators/__tests__/host-id.bench.ts`
+ */
+
+/** Mirrors the inline route boundary guard (non-negative integer). */
+function parseAndValidateHostId(raw: string): number | null {
+  const n = Number(raw)
+  return Number.isInteger(n) && n >= 0 ? n : null
+}
+
+// Realistic param distribution: mostly valid, plus the malformed cases the fix
+// now rejects (negative, fractional, garbage, overflow).
+const INPUTS = [
+  '0',
+  '1',
+  '2',
+  '0',
+  '1',
+  '3',
+  '10',
+  '0',
+  '1',
+  '2', // valid (hot path)
+  '-1',
+  '1.5',
+  '0.1',
+  'abc',
+  '1abc',
+  'NaN',
+  'Infinity',
+  '1e400',
+  '',
+  '   ',
+]
+
+function bench(label: string, iters: number): number {
+  let sink = 0
+  for (let i = 0; i < 1000; i++) {
+    for (const s of INPUTS) sink += parseAndValidateHostId(s) ?? 0
+  }
+  const start = performance.now()
+  for (let i = 0; i < iters; i++) {
+    for (const s of INPUTS) sink += parseAndValidateHostId(s) ?? 0
+  }
+  const elapsed = performance.now() - start
+  const ops = iters * INPUTS.length
+  console.log(
+    `${label.padEnd(24)} ${ops} validations in ${elapsed.toFixed(1)}ms ` +
+      `(${((elapsed / ops) * 1000).toFixed(4)} µs/op)  [sink=${sink}]`
+  )
+  return elapsed
+}
+
+console.log('=== hostId boundary parse+validate benchmark ===\n')
+const elapsed = bench('mixed param corpus', 100_000)
+const perOp = (elapsed / (100_000 * INPUTS.length)) * 1000 // µs
+if (perOp > 1) {
+  console.error(
+    `FAIL: hostId validation slower than 1µs/op (${perOp.toFixed(3)}µs)`
+  )
+  process.exit(1)
+}
+console.log(`\nOK: ${perOp.toFixed(4)} µs/op (well under 1µs ceiling)`)

--- a/apps/dashboard/src/routes/api/__tests__/hostid-validation-contract.test.ts
+++ b/apps/dashboard/src/routes/api/__tests__/hostid-validation-contract.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Cross-route contract guard: no API route may validate a `Number(...)`-parsed
+ * hostId with the loose `!Number.isFinite(hostId)` check.
+ *
+ * `Number.isFinite` accepts negative (`-1`) and fractional (`1.5`) values, both
+ * of which are invalid host-array indices that slip past the boundary and only
+ * fail later in `getAndValidateClientConfig` as a 500. The required check is
+ * `!Number.isInteger(hostId) || hostId < 0` (a non-negative integer), matching
+ * lib/api/shared/validators/host-id.ts and routes like /api/v1/overview.
+ *
+ * This is a structural guard so the whole class of routes — and any future
+ * route — stays consistent, complementing the behavioral test in
+ * charts/__tests__/hostid-validation.test.ts.
+ */
+import { describe, expect, test } from 'bun:test'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// `src/routes/api` — the directory above this `__tests__` folder. Uses the
+// portable import.meta.url form (tsc doesn't type Bun's import.meta.dir).
+const API_ROOT = fileURLToPath(new URL('..', import.meta.url))
+
+function walk(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__') continue
+      out.push(...walk(full))
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+describe('API hostId validation contract', () => {
+  const files = walk(API_ROOT)
+
+  test('discovers a meaningful number of route files', () => {
+    expect(files.length).toBeGreaterThan(20)
+  })
+
+  test('no route uses the loose !Number.isFinite(hostId) boundary check', () => {
+    const offenders = files.filter((f) =>
+      readFileSync(f, 'utf8').includes('!Number.isFinite(hostId)')
+    )
+    if (offenders.length > 0) {
+      const rel = offenders.map((f) => f.slice(API_ROOT.length + 1))
+      throw new Error(
+        `Routes using the loose hostId check (accepts -1 / 1.5). Use ` +
+          `\`!Number.isInteger(hostId) || hostId < 0\` instead:\n  ${rel.join('\n  ')}`
+      )
+    }
+    expect(offenders).toHaveLength(0)
+  })
+
+  test('routes that parse hostId reject negatives and non-integers', () => {
+    // Every file that derives `const hostId = Number(...)` must also guard with
+    // the non-negative-integer check (allowing for differing whitespace).
+    const parsing = files.filter((f) => {
+      const src = readFileSync(f, 'utf8')
+      return /const hostId = Number\(/.test(src)
+    })
+    expect(parsing.length).toBeGreaterThan(0)
+
+    const missingGuard = parsing.filter((f) => {
+      const src = readFileSync(f, 'utf8')
+      // Accept either the inline negated guard or a (local/shared)
+      // isValidHostId()-style helper, both of which enforce
+      // `Number.isInteger(hostId) && hostId >= 0`.
+      const hasInlineGuard =
+        /Number\.isInteger\(hostId\)\s*\|\|\s*hostId\s*<\s*0/.test(src)
+      const hasHelperGuard = /isValidHostId\s*\(/.test(src)
+      return !hasInlineGuard && !hasHelperGuard
+    })
+    if (missingGuard.length > 0) {
+      const rel = missingGuard.map((f) => f.slice(API_ROOT.length + 1))
+      throw new Error(
+        `Routes parse hostId via Number(...) but lack the ` +
+          `\`!Number.isInteger(hostId) || hostId < 0\` guard:\n  ${rel.join('\n  ')}`
+      )
+    }
+    expect(missingGuard).toHaveLength(0)
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/charts/$name.ts
+++ b/apps/dashboard/src/routes/api/v1/charts/$name.ts
@@ -35,7 +35,7 @@ export async function handler(
   // Validate hostId
   const hostIdStr = searchParams.get('hostId') ?? '0'
   const hostId = Number(hostIdStr)
-  if (!Number.isFinite(hostId)) {
+  if (!Number.isInteger(hostId) || hostId < 0) {
     return Response.json(
       {
         success: false,

--- a/apps/dashboard/src/routes/api/v1/charts/__tests__/hostid-validation.test.ts
+++ b/apps/dashboard/src/routes/api/v1/charts/__tests__/hostid-validation.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression: the chart data endpoint must reject malformed hostId at the
+ * request boundary with a 400 — not accept it (200) and let it flow to the
+ * data layer where `getAndValidateClientConfig` throws a 500.
+ *
+ * The boundary previously used `!Number.isFinite(hostId)`, which accepts
+ * negative (`-1`) and fractional (`1.5`) values — both invalid host indices.
+ * The contract (see lib/api/shared/validators/host-id.ts and the newer routes
+ * like /api/v1/overview) is: hostId must be a NON-NEGATIVE INTEGER.
+ */
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+mock.module('cloudflare:workers', () => ({
+  env: {
+    CLICKHOUSE_HOST: 'http://localhost:8123',
+    CLICKHOUSE_USER: 'default',
+    CLICKHOUSE_PASSWORD: '',
+  },
+}))
+
+mock.module('@/lib/feature-permissions/server', () => ({
+  authorizeFeatureRequest: async () => null,
+}))
+
+import * as realRegistry from '@/lib/api/chart-registry'
+
+mock.module('@/lib/api/chart-registry', () => ({
+  ...realRegistry,
+  hasChart: () => true,
+  getAvailableCharts: () => ['c'],
+  getChartQuery: () => ({ query: 'SELECT 1', optional: false }),
+}))
+
+import * as realExecutor from '@/lib/api/query-executor'
+
+// Benign executor: if validation is (incorrectly) skipped, the handler reaches
+// here and returns 200 — which is exactly what we assert must NOT happen for
+// malformed ids.
+const executeChartQuery = mock(async () => ({
+  dataJson: '[]',
+  metadata: {},
+  error: undefined,
+  executedSql: 'SELECT 1',
+  clickhouseVersion: null,
+}))
+
+mock.module('@/lib/api/query-executor', () => ({
+  ...realExecutor,
+  executeChartQuery,
+}))
+
+const { handler } = await import('@/routes/api/v1/charts/$name')
+
+async function status(hostId: string): Promise<number> {
+  const res = await handler(
+    new Request(`http://x/api/v1/charts/c?hostId=${hostId}`),
+    'c'
+  )
+  return res.status
+}
+
+describe('GET /api/v1/charts/$name — hostId boundary validation', () => {
+  beforeEach(() => executeChartQuery.mockClear())
+
+  test('rejects negative hostId with 400', async () => {
+    expect(await status('-1')).toBe(400)
+    expect(executeChartQuery).not.toHaveBeenCalled()
+  })
+
+  test('rejects fractional hostId with 400', async () => {
+    expect(await status('1.5')).toBe(400)
+    expect(await status('0.1')).toBe(400)
+    expect(executeChartQuery).not.toHaveBeenCalled()
+  })
+
+  test('rejects non-numeric hostId with 400', async () => {
+    expect(await status('abc')).toBe(400)
+    expect(await status('NaN')).toBe(400)
+    expect(await status('1abc')).toBe(400) // Number('1abc') === NaN
+  })
+
+  test('rejects Infinity hostId with 400', async () => {
+    expect(await status('Infinity')).toBe(400)
+    expect(await status('1e400')).toBe(400) // overflows to Infinity
+  })
+
+  test('accepts valid non-negative integer hostIds (reaches executor)', async () => {
+    expect(await status('0')).not.toBe(400)
+    expect(await status('2')).not.toBe(400)
+    expect(executeChartQuery).toHaveBeenCalled()
+  })
+
+  test('defaults to host 0 when hostId param is absent', async () => {
+    const res = await handler(new Request('http://x/api/v1/charts/c'), 'c')
+    expect(res.status).not.toBe(400)
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/explorer/preview.ts
+++ b/apps/dashboard/src/routes/api/v1/explorer/preview.ts
@@ -73,7 +73,7 @@ export const Route = createFileRoute('/api/v1/explorer/preview')({
           )
         }
         const hostId = Number(hostIdRaw)
-        if (!Number.isFinite(hostId)) {
+        if (!Number.isInteger(hostId) || hostId < 0) {
           return Response.json(
             {
               success: false,

--- a/apps/dashboard/src/routes/api/v1/explorer/projections.ts
+++ b/apps/dashboard/src/routes/api/v1/explorer/projections.ts
@@ -34,7 +34,7 @@ export const Route = createFileRoute('/api/v1/explorer/projections')({
           )
         }
         const hostId = Number(hostIdRaw)
-        if (!Number.isFinite(hostId)) {
+        if (!Number.isInteger(hostId) || hostId < 0) {
           return Response.json(
             {
               success: false,

--- a/apps/dashboard/src/routes/api/v1/explorer/query-log.ts
+++ b/apps/dashboard/src/routes/api/v1/explorer/query-log.ts
@@ -71,7 +71,7 @@ export const Route = createFileRoute('/api/v1/explorer/query-log')({
           )
         }
         const hostId = Number(hostIdRaw)
-        if (!Number.isFinite(hostId)) {
+        if (!Number.isInteger(hostId) || hostId < 0) {
           return Response.json(
             {
               success: false,

--- a/apps/dashboard/src/routes/api/v1/explorer/query.ts
+++ b/apps/dashboard/src/routes/api/v1/explorer/query.ts
@@ -224,7 +224,7 @@ export const Route = createFileRoute('/api/v1/explorer/query')({
           )
         }
         const hostId = Number(hostIdRaw)
-        if (!Number.isFinite(hostId)) {
+        if (!Number.isInteger(hostId) || hostId < 0) {
           return Response.json(
             {
               success: false,

--- a/apps/dashboard/src/routes/api/v1/explorer/skip-indexes.ts
+++ b/apps/dashboard/src/routes/api/v1/explorer/skip-indexes.ts
@@ -34,7 +34,7 @@ export const Route = createFileRoute('/api/v1/explorer/skip-indexes')({
           )
         }
         const hostId = Number(hostIdRaw)
-        if (!Number.isFinite(hostId)) {
+        if (!Number.isInteger(hostId) || hostId < 0) {
           return Response.json(
             {
               success: false,

--- a/apps/dashboard/src/routes/api/v1/explorer/tables.ts
+++ b/apps/dashboard/src/routes/api/v1/explorer/tables.ts
@@ -49,7 +49,7 @@ export const Route = createFileRoute('/api/v1/explorer/tables')({
           )
         }
         const hostId = Number(hostIdRaw)
-        if (!Number.isFinite(hostId)) {
+        if (!Number.isInteger(hostId) || hostId < 0) {
           return Response.json(
             {
               success: false,

--- a/apps/dashboard/src/routes/api/v1/health/checks.ts
+++ b/apps/dashboard/src/routes/api/v1/health/checks.ts
@@ -49,7 +49,7 @@ export const Route = createFileRoute('/api/v1/health/checks')({
 
         // Validate hostId
         const hostId = Number(searchParams.get('hostId') ?? '0')
-        if (!Number.isFinite(hostId)) {
+        if (!Number.isInteger(hostId) || hostId < 0) {
           return Response.json(
             {
               success: false,

--- a/apps/dashboard/src/routes/api/v1/tables/$name.ts
+++ b/apps/dashboard/src/routes/api/v1/tables/$name.ts
@@ -26,7 +26,7 @@ export const Route = createFileRoute('/api/v1/tables/$name')({
         // Validate hostId
         const hostIdStr = searchParams.get('hostId') ?? '0'
         const hostId = Number(hostIdStr)
-        if (!Number.isFinite(hostId)) {
+        if (!Number.isInteger(hostId) || hostId < 0) {
           return Response.json(
             {
               success: false,

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -37,6 +37,7 @@ Agents discover knowledge in this order:
 | **Specs** | [ai-insights.md](ai-insights.md) | spec | AI Insights engine: collect→enrich→persist (findings store), cron + manual generation, stable-key dismissal, overview panel |
 | **Specs** | [mcp-server.md](mcp-server.md) | reference | MCP server at /api/mcp: tools, setup, security |
 | **Security** | [sql-validator-threat-model.md](sql-validator-threat-model.md) | decision | validateSqlQuery gates all free-form SQL; whole-query (not fragment) threat model; UNION/replace()/OR-disjunction false-positive class + corpus regression guard |
+| **Development** | [api-hostid-validation.md](api-hostid-validation.md) | decision | API routes must validate hostId as non-negative integer (400); `!Number.isFinite` accepted -1/1.5 → 500-retry; 9 routes fixed + cross-route source guard |
 | **Specs** | [agent-conversation-storage.md](agent-conversation-storage.md) | spec | Runtime-selected agent chat persistence backends and fallback rules |
 | **Specs** | [agentstate-conversation-store.md](agentstate-conversation-store.md) | spec | AgentState backend: resolveStore priority, external_id/tag isolation, append-only upsert, AI enrichment, backend/follow-ups routes |
 | **Specs** | [query-config-format.md](query-config-format.md) | spec | QueryConfig type format, versioned SQL, BackgroundBar columns |

--- a/docs/knowledge/api-hostid-validation.md
+++ b/docs/knowledge/api-hostid-validation.md
@@ -1,0 +1,63 @@
+---
+id: api-hostid-validation
+title: API hostId Boundary Validation Contract
+type: decision
+status: active
+updated: 2026-06-20
+tags:
+  - api
+  - validation
+  - routes
+related:
+  - sql-validator-threat-model
+  - conventions
+---
+
+# API hostId Boundary Validation Contract
+
+**Contract:** every API route that reads a `hostId` query param must validate it
+as a **non-negative integer** at the request boundary and return **400** if not.
+
+The canonical check (matching `lib/api/shared/validators/host-id.ts` and routes
+like `/api/v1/overview`, `/api/v1/dashboard/settings`):
+
+```ts
+const hostId = Number(searchParams.get('hostId') ?? '0')
+if (!Number.isInteger(hostId) || hostId < 0) {
+  return Response.json(
+    { success: false, error: { type: 'validation', message: 'Invalid hostId' } },
+    { status: 400 }
+  )
+}
+```
+
+## The bug (2026-06-20)
+
+Nine routes used the looser guard `!Number.isFinite(hostId)`, which **accepts
+negative (`-1`) and fractional (`1.5`)** values — both invalid host-array
+indices. Such a request returned **200** and flowed to the data layer, where
+`getAndValidateClientConfig` (in `@chm/clickhouse-client`) throws on the
+out-of-range index → a **500** that `use-chart-data` then retries 3×.
+
+Verified against the real `/api/v1/charts/$name` handler: `?hostId=-1` and
+`?hostId=1.5` returned 200 before the fix, 400 after.
+
+Fixed routes: `charts/$name`, `tables/$name`, `health/checks`, and the
+`explorer/{tables,query,query-log,preview,projections,skip-indexes}` group.
+
+## Why `Number(...)` not `parseInt(...)`
+
+`Number('1abc')` is `NaN` (rejected — good), whereas `parseInt('1abc', 10)` is
+`1` (silently accepted). The route boundary deliberately uses `Number(...)`.
+Note `validateHostId` in the shared validators uses `parseInt` and is
+documented/tested to accept trailing junk (`'1abc' → 1`) — that leniency is
+intentional there, so do not "fix" it; the route boundary is the stricter gate.
+
+## Guard
+
+`src/routes/api/__tests__/hostid-validation-contract.test.ts` scans all route
+source and fails if any route uses `!Number.isFinite(hostId)`, or parses
+`const hostId = Number(...)` without the non-negative-integer guard (inline or
+via an `isValidHostId()` helper). Behavioral coverage:
+`src/routes/api/v1/charts/__tests__/hostid-validation.test.ts`. Hot-path
+throughput: `…/validators/__tests__/host-id.bench.ts` (~0.02 µs/op).


### PR DESCRIPTION
## Problem

Testing realistic API request scenarios: **9 routes validated the `hostId` query param with `!Number.isFinite(hostId)`**, which accepts negative (`-1`) and fractional (`1.5`) values — both invalid host-array indices.

Such a request returned **200** and flowed to the data layer, where `getAndValidateClientConfig` (`@chm/clickhouse-client`) throws on the out-of-range index → a **500** that `use-chart-data` then retries 3×.

**Verified against the real `/api/v1/charts/$name` handler:** `?hostId=-1` and `?hostId=1.5` returned **200 before**, **400 after**.

## Fix

Use the non-negative-integer guard already used by the newer routes (`/api/v1/overview`, `/api/v1/dashboard/settings`):

```ts
if (!Number.isInteger(hostId) || hostId < 0)  // -> 400
```

Routes fixed: `charts/$name`, `tables/$name`, `health/checks`, and `explorer/{tables,query,query-log,preview,projections,skip-indexes}`.

> `Number('1abc')` is `NaN` (already rejected); the boundary deliberately uses `Number(...)` not `parseInt(...)`. The shared `validateHostId` (parseInt, accepts `'1abc'→1`) is intentionally lenient and left unchanged — the route boundary is the stricter gate.

## Coverage

- **Behavioral** — `charts/__tests__/hostid-validation.test.ts`: runs the real handler, asserts `-1/1.5/0.1/NaN/Infinity/1e400` → 400, valid ids reach the executor.
- **Structural** — `routes/api/__tests__/hostid-validation-contract.test.ts`: scans **all** route source, fails if any route uses the loose `isFinite` form or parses `Number(hostId)` without the guard (inline or `isValidHostId()` helper). Protects the class + future routes. *(This guard surfaced a 10th route, `dashboard/settings`, which was already correct via a local helper.)*
- **Benchmark** — `validators/__tests__/host-id.bench.ts`: hot-path parse+validate, ~0.02 µs/op.
- **Doc** — `docs/knowledge/api-hostid-validation.md`.

## Verification

- API route + validator tests: 105 pass
- lint clean, `type-check:test` clean

https://claude.ai/code/session_01RtzX73qAeTQ9gUXgiLeMnJ

## Summary by Sourcery

Tighten API hostId validation across v1 routes and document and guard the non-negative-integer boundary contract.

Bug Fixes:
- Ensure charts, tables, health checks, and explorer API routes reject negative and fractional hostId values with a 400 instead of leaking invalid indices to the data layer.

Enhancements:
- Add a cross-route structural test that enforces consistent non-negative-integer hostId validation in all API routes that parse hostId.
- Introduce a micro-benchmark to track the performance of hostId parse-and-validate logic on realistic inputs.

Documentation:
- Document the API hostId boundary validation contract in the knowledge base and link it from the knowledge index.
- Describe the rationale for using Number-based parsing and the stricter route-boundary validation semantics for hostId.

Tests:
- Add behavioral tests for the charts hostId boundary validation to ensure malformed hostId values are rejected and valid ones reach the executor.
- Add a structural test that scans API route source files for incorrect hostId validation patterns and missing guards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened host ID validation across all API endpoints (charts, explorer, health checks, tables) to properly reject negative numbers, fractional values, and non-numeric strings with HTTP 400 responses.

* **Tests**
  * Added validation test suite covering edge cases and cross-route enforcement guardrails.
  * Added performance benchmark for host ID validation.

* **Documentation**
  * Added validation contract documentation defining host ID requirements for API routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->