### PR TITLE
refactor: remove deprecated variants property from QueryConfig type schema

### DIFF
--- a/apps/dashboard/src/lib/query-config/types.ts
+++ b/apps/dashboard/src/lib/query-config/types.ts
@@ -10,24 +10,19 @@
  * here. `filterSchema` IS included — it drives server-side WHERE injection
  * (see the table registry), and `@/lib/filters/types` is ported.
  *
- * VersionedSql / QueryConfigVariant / getAllSqlStrings come from
- * @chm/sql-builder (aliased to source in tsconfig.json) so this app never
- * depends on the dashboard package.
+ * VersionedSql / getAllSqlStrings come from @chm/sql-builder (aliased to
+ * source in tsconfig.json) so this app never depends on the dashboard package.
  */
 
 import type { ClickHouseSettings } from '@clickhouse/client'
 
-import type { QueryConfigVariant, VersionedSql } from '@chm/sql-builder'
+import type { VersionedSql } from '@chm/sql-builder'
 import type { FilterSchema } from '@/lib/filters/types'
 
 // Re-export the version-compat SQL primitives from the shared package so
 // `@/lib/query-config/types` consumers can import them from one place,
 // mirroring the dashboard's `@/types/query-config` re-export.
-export {
-  getAllSqlStrings,
-  type QueryConfigVariant,
-  type VersionedSql,
-} from '@chm/sql-builder'
+export { getAllSqlStrings, type VersionedSql } from '@chm/sql-builder'
 
 /**
  * Foundation QueryConfig.
@@ -35,7 +30,7 @@ export {
  * Generic over the column-name tuple, exactly like the dashboard. Only the
  * fields the executor / registry need are kept:
  * - identity + SQL (name, sql, columns)
- * - version compat (sql: VersionedSql[] | string, deprecated `variants`)
+ * - version compat (sql: VersionedSql[] | string)
  * - execution knobs (defaultParams, clickhouseSettings, optional, tableCheck)
  * - validation toggle (disableSqlValidation)
  *
@@ -90,11 +85,6 @@ export interface QueryConfig<TColumns extends readonly string[] = string[]> {
   disableSqlValidation?: boolean
   /** Optional docs URL surfaced on query error. */
   docs?: string
-  /**
-   * @deprecated Use `sql: VersionedSql[]`. Legacy min/max version variants,
-   * kept only so ported configs that still use it resolve correctly.
-   */
-  variants?: QueryConfigVariant[]
 }
 
 /** Map a column-name tuple to a permissive row-data shape. */

--- a/apps/dashboard/src/types/query-config.ts
+++ b/apps/dashboard/src/types/query-config.ts
@@ -1,7 +1,7 @@
 import type { Row } from '@tanstack/react-table'
 import type { ClickHouseSettings } from '@clickhouse/client'
 
-import type { QueryConfigVariant, VersionedSql } from '@chm/sql-builder'
+import type { VersionedSql } from '@chm/sql-builder'
 import type { Icon } from '@chm/types/icon'
 import type { ChartProps } from '@/components/charts/chart-props'
 import type { CustomSortingFnNames } from '@/components/data-table/sorting-fns'
@@ -202,15 +202,10 @@ export type ColumnNames<T extends string> = [T, ...T[]]
  * When using `merge()` across shards with different schemas, use `toInt8()`
  * for Enum columns to ensure compatibility.
  */
-// VersionedSql, QueryConfigVariant, and getAllSqlStrings now live in
-// @chm/sql-builder so lower-level packages can consume them without depending
-// on this web-app god-type. Re-exported here for backward compatibility with
-// the many existing `@/types/query-config` consumers.
-export {
-  getAllSqlStrings,
-  type QueryConfigVariant,
-  type VersionedSql,
-} from '@chm/sql-builder'
+// VersionedSql and getAllSqlStrings live in @chm/sql-builder so lower-level
+// packages can consume them without depending on this web-app god-type.
+// Re-exported here for backward compatibility with existing consumers.
+export { getAllSqlStrings, type VersionedSql } from '@chm/sql-builder'
 
 export interface QueryConfig<TColumns extends readonly string[] = string[]> {
   name: string
@@ -495,14 +490,6 @@ export interface QueryConfig<TColumns extends readonly string[] = string[]> {
    * Defaults to 'query_id' if not specified.
    */
   bulkActionKey?: string
-  /**
-   * @deprecated Use `sql: VersionedSql[]` instead. Will be removed in v0.3.0.
-   *
-   * Version-specific query variants (legacy format).
-   * Evaluated in order - first matching variant is used.
-   * Falls back to main `sql` if no variant matches.
-   */
-  variants?: QueryConfigVariant[]
 }
 
 /**

--- a/packages/clickhouse-client/src/__tests__/clickhouse-version.test.ts
+++ b/packages/clickhouse-client/src/__tests__/clickhouse-version.test.ts
@@ -5,10 +5,8 @@ const {
   compareVersions,
   meetsMinVersion,
   versionMatchesRange,
-  selectQueryVariant,
   parseSemverRange,
   matchesSemverRange,
-  selectQueryVariantSemver,
   selectVersionedSql,
   getTableInfoMessage,
   SYSTEM_TABLE_INFO,
@@ -274,100 +272,6 @@ describe('matchesSemverRange', () => {
   it('matches plain version 24.1 for 24.3.5', () => {
     const v = parseVersion('24.3.5')
     expect(matchesSemverRange(v, '24.1')).toBe(true) // >=24.1 <25.0
-  })
-})
-
-describe('selectQueryVariant', () => {
-  it('returns default query when no version provided', () => {
-    const result = selectQueryVariant(
-      {
-        query: 'SELECT 1',
-        variants: [{ versions: { minVersion: '24.1' }, query: 'SELECT 2' }],
-      },
-      null
-    )
-    expect(result).toBe('SELECT 1')
-  })
-
-  it('returns default query when no variants', () => {
-    const v = parseVersion('24.3.1')
-    const result = selectQueryVariant({ query: 'SELECT 1' }, v)
-    expect(result).toBe('SELECT 1')
-  })
-
-  it('returns matching variant', () => {
-    const v = parseVersion('24.3.1')
-    const result = selectQueryVariant(
-      {
-        query: 'SELECT 1',
-        variants: [
-          {
-            versions: { minVersion: '24.1', maxVersion: '25.0' },
-            query: 'SELECT 2',
-          },
-        ],
-      },
-      v
-    )
-    expect(result).toBe('SELECT 2')
-  })
-
-  it('returns default when no variant matches', () => {
-    const v = parseVersion('23.8.1')
-    const result = selectQueryVariant(
-      {
-        query: 'SELECT 1',
-        variants: [{ versions: { minVersion: '24.1' }, query: 'SELECT 2' }],
-      },
-      v
-    )
-    expect(result).toBe('SELECT 1')
-  })
-})
-
-describe('selectQueryVariantSemver', () => {
-  it('returns default query when no version', () => {
-    const result = selectQueryVariantSemver(
-      {
-        query: 'SELECT 1',
-        variants: [{ versions: '>=24.1', query: 'SELECT 2' }],
-      },
-      null
-    )
-    expect(result).toBe('SELECT 1')
-  })
-
-  it('returns matching variant by semver range', () => {
-    const v = parseVersion('24.3.1')
-    const result = selectQueryVariantSemver(
-      {
-        query: 'SELECT 1',
-        variants: [{ versions: '>=24.1', query: 'SELECT 2' }],
-      },
-      v
-    )
-    expect(result).toBe('SELECT 2')
-  })
-
-  it('returns default when no variants', () => {
-    const v = parseVersion('24.3.1')
-    const result = selectQueryVariantSemver({ query: 'SELECT 1' }, v)
-    expect(result).toBe('SELECT 1')
-  })
-
-  it('returns first matching variant when multiple match', () => {
-    const v = parseVersion('24.3.1')
-    const result = selectQueryVariantSemver(
-      {
-        query: 'DEFAULT',
-        variants: [
-          { versions: '>=24.1', query: 'FIRST' },
-          { versions: '>=24.3', query: 'SECOND' },
-        ],
-      },
-      v
-    )
-    expect(result).toBe('FIRST')
   })
 })
 

--- a/packages/clickhouse-client/src/clickhouse-version.ts
+++ b/packages/clickhouse-client/src/clickhouse-version.ts
@@ -340,41 +340,6 @@ export function versionMatchesRange(
 }
 
 /**
- * Select the appropriate query variant for the given ClickHouse version
- * Returns the first matching variant or the default query if no variant matches
- */
-export function selectQueryVariant<
-  T extends {
-    query: string
-    variants?: Array<{
-      versions: { minVersion?: string; maxVersion?: string }
-      query: string
-    }>
-  },
->(queryDef: T, version: ClickHouseVersion | null): string {
-  // If no version info or no variants, use default query
-  if (!version || !queryDef.variants || queryDef.variants.length === 0) {
-    return queryDef.query
-  }
-
-  // Find first matching variant
-  for (const variant of queryDef.variants) {
-    if (
-      versionMatchesRange(
-        version,
-        variant.versions.minVersion,
-        variant.versions.maxVersion
-      )
-    ) {
-      return variant.query
-    }
-  }
-
-  // No variant matched, use default
-  return queryDef.query
-}
-
-/**
  * Structured bounds for semver range parsing
  */
 export interface SemverRangeBounds {
@@ -538,60 +503,6 @@ export function matchesSemverRange(
   }
 
   return true
-}
-
-/**
- * Select query variant based on version using semver range strings
- *
- * Enhanced version of selectQueryVariant that accepts semver range strings
- * instead of separate minVersion/maxVersion parameters.
- *
- * @param queryDef - Query definition with default query and optional variants
- * @param version - ClickHouse version to match against (null-safe)
- * @returns Selected query string (default or first matching variant)
- *
- * @example
- * // Select with version range strings
- * const query = selectQueryVariantSemver({
- *   query: 'SELECT * FROM system.processes',
- *   variants: [
- *     { versions: '<24.1', query: 'SELECT a, b FROM system.processes' },
- *     { versions: '>=24.1', query: 'SELECT a, b, c FROM system.processes' }
- *   ]
- * }, version)
- *
- * @example
- * // Select with caret range
- * const query = selectQueryVariantSemver({
- *   query: 'SELECT * FROM system.query_log',
- *   variants: [
- *     { versions: '^24.1', query: 'SELECT a FROM system.query_log' }
- *   ]
- * }, version)
- */
-export function selectQueryVariantSemver<
-  T extends {
-    query: string
-    variants?: Array<{
-      versions: string
-      query: string
-    }>
-  },
->(queryDef: T, version: ClickHouseVersion | null): string {
-  // If no version info or no variants, use default query
-  if (!version || !queryDef.variants || queryDef.variants.length === 0) {
-    return queryDef.query
-  }
-
-  // Find first matching variant
-  for (const variant of queryDef.variants) {
-    if (matchesSemverRange(version, variant.versions)) {
-      return variant.query
-    }
-  }
-
-  // No variant matched, use default
-  return queryDef.query
 }
 
 /**

--- a/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
+++ b/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
@@ -8,11 +8,7 @@ import type { DataFormat, QueryParams } from '@clickhouse/client'
 import type { QueryConfigLike } from '@chm/sql-builder'
 import type { FetchDataErrorType, FetchDataResult } from './types'
 
-import {
-  getClickHouseVersion,
-  selectQueryVariantSemver,
-  selectVersionedSql,
-} from '../clickhouse-version'
+import { getClickHouseVersion, selectVersionedSql } from '../clickhouse-version'
 import { validateTableExistence } from '../table-validator'
 import { transformClickHouseJsonEachRowWasmJson } from '../wasm/monitor-core'
 import { getClient, releaseClient } from './clickhouse-client'
@@ -227,26 +223,6 @@ export const fetchData = async <
         // Simple string sql
         else if (typeof queryConfig.sql === 'string') {
           effectiveQuery = queryConfig.sql
-        }
-
-        // Deprecated: old variants format (backward compatibility)
-        if (queryConfig.variants && queryConfig.variants.length > 0) {
-          effectiveQuery = selectQueryVariantSemver(
-            {
-              query: typeof queryConfig.sql === 'string' ? queryConfig.sql : '',
-              variants: queryConfig.variants.map((v) => ({
-                versions: v.versions,
-                query: v.sql,
-              })),
-            },
-            clickhouseVersion
-          )
-
-          if (clickhouseVersion) {
-            debug(
-              `[fetchData] Using query for ClickHouse ${clickhouseVersion.raw} via variants (config: ${queryConfig.name})`
-            )
-          }
         }
       }
 

--- a/packages/sql-builder/src/__tests__/query-config-types.test.ts
+++ b/packages/sql-builder/src/__tests__/query-config-types.test.ts
@@ -4,11 +4,7 @@
  * Tests for version-aware SQL definition types and helpers.
  */
 
-import type {
-  QueryConfigLike,
-  QueryConfigVariant,
-  VersionedSql,
-} from '../query-config-types'
+import type { QueryConfigLike, VersionedSql } from '../query-config-types'
 
 import { getAllSqlStrings } from '../query-config-types'
 import { describe, expect, it } from 'bun:test'
@@ -121,15 +117,6 @@ describe('getAllSqlStrings', () => {
       expect(v.columns).toEqual(['1'])
     })
 
-    it('QueryConfigVariant should have required fields', () => {
-      const v: QueryConfigVariant = {
-        versions: '24.1',
-        sql: 'SELECT 1',
-      }
-      expect(v.versions).toBe('24.1')
-      expect(v.sql).toBe('SELECT 1')
-    })
-
     it('QueryConfigLike should accept string sql', () => {
       const config: QueryConfigLike = {
         name: 'test',
@@ -164,16 +151,6 @@ describe('getAllSqlStrings', () => {
         tableCheck: ['system.query_log', 'system.processes'],
       }
       expect(Array.isArray(config.tableCheck)).toBe(true)
-    })
-
-    it('QueryConfigLike should accept variants', () => {
-      const config: QueryConfigLike = {
-        name: 'test',
-        sql: 'SELECT 1',
-        variants: [{ versions: '24.1', sql: 'SELECT 1, 2' }],
-      }
-      expect(config.variants).toBeDefined()
-      expect(config.variants!.length).toBe(1)
     })
   })
 

--- a/packages/sql-builder/src/index.ts
+++ b/packages/sql-builder/src/index.ts
@@ -34,7 +34,6 @@
 
 export type {
   QueryConfigLike,
-  QueryConfigVariant,
   VersionedSql,
 } from './query-config-types'
 

--- a/packages/sql-builder/src/query-config-types.ts
+++ b/packages/sql-builder/src/query-config-types.ts
@@ -21,17 +21,6 @@ export interface VersionedSql {
 }
 
 /**
- * @deprecated Use `VersionedSql` instead. Will be removed in v0.3.0.
- */
-export interface QueryConfigVariant {
-  /** @deprecated Use VersionedSql.since instead */
-  versions: string
-  sql: string
-  description?: string
-  columns?: string[]
-}
-
-/**
  * Minimal shape of a query config consumed by `@chm/clickhouse-client`.
  *
  * The full `QueryConfig` interface lives in the web app; this captures only the
@@ -43,7 +32,6 @@ export interface QueryConfigLike {
   sql?: string | VersionedSql[]
   optional?: boolean
   tableCheck?: string | string[]
-  variants?: QueryConfigVariant[]
 }
 
 /**

--- a/plans/README.md
+++ b/plans/README.md
@@ -8,7 +8,7 @@ Plans 001–017 and 019–023 were completed, merged to `main`, and their plan f
 
 | Plan | Title | Priority | Effort | Depends on | Status |
 |------|-------|----------|--------|------------|--------|
-| [018](018-remove-deprecated-variants-query-config.md) | Remove Deprecated variants Property from QueryConfig Type Schema | P3 | S | — | TODO |
+| [018](018-remove-deprecated-variants-query-config.md) | Remove Deprecated variants Property from QueryConfig Type Schema | P3 | S | — | DONE |
 
 *Status values: TODO \| IN PROGRESS \| DONE \| BLOCKED (with one-line reason) \| REJECTED (with one-line rationale — finding fixed independently or approach abandoned)*
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -14,7 +14,7 @@ Plans 001–017 and 019–023 were completed, merged to `main`, and their plan f
 
 ## Dependency notes
 
-- **Plan 018 (Remove `variants`)** was coupled to **015** (now DONE). The legacy `apps/dashboard` (Next.js) has been deleted, removing that consumer. The remaining work is the runtime backward-compat shim in `packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts` (~L227–245, via `selectQueryVariantSemver`). Expand the in-scope list to include `clickhouse-fetch.ts` when executing 018.
+- **Plan 018 (Remove `variants`)** — DONE. It was coupled to **015** (DONE; legacy Next.js `apps/dashboard` deleted, removing that consumer). The final blocker — the runtime backward-compat shim in `packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts` (via `selectQueryVariantSemver`) — has been removed along with `QueryConfigVariant` and the `variants` property. No remaining work.
 
 ## Findings considered and rejected
 


### PR DESCRIPTION
## Summary

- Deletes `QueryConfigVariant` interface from `@chm/sql-builder` and removes its export from `index.ts`
- Removes `variants?` property from `QueryConfigLike` (sql-builder), `QueryConfig` (dashboard `types/query-config.ts` and `lib/query-config/types.ts`)
- Deletes the runtime backward-compat shim in `clickhouse-fetch.ts` that routed configs with a `variants` array through `selectQueryVariantSemver`
- Deletes `selectQueryVariantSemver` and `selectQueryVariant` from `clickhouse-version.ts` — no callers remain after shim removal
- Removes all associated tests for deleted code
- Updates `plans/README.md` — Plan 018 marked DONE

Closes plan 018

## Safety grep result

Zero live consumers of `QueryConfigVariant` or `.variants` on a query config found outside the modified files. The only other hits in `apps/dashboard/src/components/` reference a CSS-styles object (`chartCard.variants.normal`) — unrelated false positives, untouched.

## Verification

- Pre-commit type-check: ✅ exit 0 (turbo packages scope)
- Pre-push full check: ✅ 2073 dashboard tests pass, 855 package tests pass, 0 failures

## `selectQueryVariantSemver` decision

**Deleted.** After removing the shim in `clickhouse-fetch.ts`, `selectQueryVariantSemver` and `selectQueryVariant` had zero callers in the main codebase. Both functions are removed from `clickhouse-version.ts` and their tests removed from the test file.

https://claude.ai/code/session_01HcF2GhuJfJKVhCmSRFhbZD

## Summary by Sourcery

Remove legacy query variant support from query-config types and ClickHouse client codebase, consolidating on VersionedSql-based versioning only.

Enhancements:
- Remove deprecated QueryConfigVariant type and variants property from shared query-config schemas across dashboard and sql-builder packages
- Delete legacy ClickHouse query variant selection helpers and their associated tests
- Simplify ClickHouse fetch logic by dropping backward-compat handling for deprecated query variants

Documentation:
- Mark plan 018 as DONE in plans documentation

Tests:
- Remove tests covering deprecated query variant types and selection helpers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added semantic version range parsing and matching utilities for improved version compatibility checks.

* **Refactor**
  * Removed deprecated variant-based query configuration in favor of versioned SQL approach.
  * Simplified query version selection logic with updated utilities.

* **Tests**
  * Removed test coverage for deprecated variant selection functionality.

* **Chores**
  * Updated documentation to reflect completion of deprecated variant property removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->