### PR TITLE
feat(insights): configurable AI insight generation (model, prompt style, enrichment)

### DIFF
--- a/apps/dashboard/src/lib/insights/generate-insights.ts
+++ b/apps/dashboard/src/lib/insights/generate-insights.ts
@@ -7,6 +7,7 @@
  * so both the manual "Refresh" endpoint and the cron sweep can call it safely.
  */
 
+import type { InsightPromptStyle } from './prompts'
 import type { InsightCard } from './types'
 
 import { recordFinding } from '../findings/findings-store'
@@ -16,16 +17,35 @@ import { insightKey } from './types'
 
 const SOURCE = 'ai-insight'
 
+/** Per-request generation overrides (from the settings UI / generate API). */
+export interface GenerateInsightsOptions {
+  /** `false` skips LLM enrichment entirely (deterministic copy only). */
+  readonly enrich?: boolean
+  /** Validated `provider:model` id used for enrichment. */
+  readonly model?: string
+  /** Enrichment tone. */
+  readonly promptStyle?: InsightPromptStyle
+}
+
 /**
  * Generate, persist, and return AI insights for a host.
  * Never throws — returns an empty array on any unexpected failure.
  */
-export async function generateInsights(hostId: number): Promise<InsightCard[]> {
+export async function generateInsights(
+  hostId: number,
+  opts: GenerateInsightsOptions = {}
+): Promise<InsightCard[]> {
   try {
     const candidates = await collectInsights(hostId)
     if (candidates.length === 0) return []
 
-    const enriched = await enrichInsights(candidates)
+    const enriched =
+      opts.enrich === false
+        ? candidates
+        : await enrichInsights(candidates, {
+            model: opts.model,
+            promptStyle: opts.promptStyle,
+          })
     const generatedAt = new Date().toISOString()
 
     // Persist each insight (best-effort; failures are swallowed by recordFinding).

--- a/apps/dashboard/src/lib/insights/llm-enrich.ts
+++ b/apps/dashboard/src/lib/insights/llm-enrich.ts
@@ -10,6 +10,7 @@
 
 import { z } from 'zod'
 
+import type { InsightPromptStyle } from './prompts'
 import type { InsightCandidate } from './types'
 
 import {
@@ -17,18 +18,32 @@ import {
   resolveAgentChatModel,
 } from '../ai/agent/provider-chat-model'
 import { isProviderConfigured, resolveProvider } from '../ai/providers'
+import { promptSystemFor } from './prompts'
 import { ErrorLogger } from '@chm/logger'
 import { generateObject } from 'ai'
 
 const COMPONENT = 'insights-enrich'
 
-/** True when the default model's provider has an API key on this deployment. */
-export function isLlmAvailable(): boolean {
+/** Per-request overrides for enrichment. */
+export interface EnrichOptions {
+  /** Validated `provider:model` id; falls back to `DEFAULT_MODEL` when unset. */
+  readonly model?: string
+  /** Tone of the rewrite (see `prompts.ts`). */
+  readonly promptStyle?: InsightPromptStyle
+}
+
+/** True when the given model's provider has an API key on this deployment. */
+export function isModelAvailable(model: string): boolean {
   try {
-    return isProviderConfigured(resolveProvider(DEFAULT_MODEL).providerId)
+    return isProviderConfigured(resolveProvider(model).providerId)
   } catch {
     return false
   }
+}
+
+/** True when the default model's provider has an API key on this deployment. */
+export function isLlmAvailable(): boolean {
+  return isModelAvailable(DEFAULT_MODEL)
 }
 
 const EnrichedSchema = z.object({
@@ -53,20 +68,23 @@ const EnrichedSchema = z.object({
  * the human-facing copy.
  */
 export async function enrichInsights(
-  candidates: InsightCandidate[]
+  candidates: InsightCandidate[],
+  opts: EnrichOptions = {}
 ): Promise<InsightCandidate[]> {
-  if (candidates.length === 0 || !isLlmAvailable()) return candidates
+  if (candidates.length === 0) return candidates
+
+  const effectiveModel = opts.model?.trim() || DEFAULT_MODEL
+  if (!isModelAvailable(effectiveModel)) return candidates
 
   try {
-    const { model } = resolveAgentChatModel({ model: DEFAULT_MODEL })
+    const { model } = resolveAgentChatModel({ model: effectiveModel })
 
     const { object } = await generateObject({
       model,
       schema: EnrichedSchema,
       maxRetries: 1,
       abortSignal: AbortSignal.timeout(20_000),
-      system:
-        'You are a senior ClickHouse SRE. Rewrite each monitoring signal into a crisp, actionable insight for an operator. Keep the same meaning and severity. Be specific and avoid filler. Return exactly one entry per input, in order.',
+      system: promptSystemFor(opts.promptStyle),
       prompt: JSON.stringify(
         candidates.map((c) => ({
           severity: c.severity,

--- a/apps/dashboard/src/lib/insights/prompts.ts
+++ b/apps/dashboard/src/lib/insights/prompts.ts
@@ -1,0 +1,76 @@
+/**
+ * Prompt-style templates for AI insight enrichment.
+ *
+ * The deterministic collectors always produce a baseline title/detail. When LLM
+ * enrichment runs, the operator can choose the *tone* of the rewrite. Each style
+ * maps to a system prompt; the user prompt (the JSON candidate array) is the
+ * same regardless of style. Keeping the styles here — rather than inline in
+ * `llm-enrich.ts` — lets the settings UI list them and keeps the copy in one
+ * place.
+ */
+
+export type InsightPromptStyle = 'concise' | 'detailed' | 'beginner'
+
+/** The default style, matching the original inline prompt. */
+export const DEFAULT_PROMPT_STYLE: InsightPromptStyle = 'concise'
+
+interface PromptStyleDef {
+  /** Stable id used in settings + the generate API. */
+  readonly id: InsightPromptStyle
+  /** Short label for the settings UI. */
+  readonly label: string
+  /** One-line description for the settings UI. */
+  readonly description: string
+  /** System prompt sent to the model for this style. */
+  readonly system: string
+}
+
+const SHARED_RULES =
+  'Keep the same meaning and severity as each input signal. Be specific and avoid filler. Return exactly one entry per input, in order.'
+
+export const INSIGHT_PROMPT_STYLES: readonly PromptStyleDef[] = [
+  {
+    id: 'concise',
+    label: 'Concise',
+    description: 'Crisp, scannable one-liners for experienced operators.',
+    system: `You are a senior ClickHouse SRE. Rewrite each monitoring signal into a crisp, actionable insight for an operator. ${SHARED_RULES}`,
+  },
+  {
+    id: 'detailed',
+    label: 'Detailed',
+    description:
+      'Adds a likely root cause and a concrete next step for each signal.',
+    system: `You are a senior ClickHouse SRE writing an incident note. For each monitoring signal, write a clear title and a detail that names the most likely root cause and its operational impact, then give one concrete next step as the recommendation. ${SHARED_RULES}`,
+  },
+  {
+    id: 'beginner',
+    label: 'Beginner-friendly',
+    description:
+      'Plain language that explains the ClickHouse concept for newcomers.',
+    system: `You are a friendly ClickHouse mentor. Rewrite each monitoring signal in plain language for someone new to ClickHouse: explain what the metric means and why it matters before the recommendation, avoiding unexplained jargon. ${SHARED_RULES}`,
+  },
+] as const
+
+const STYLE_IDS = new Set<string>(INSIGHT_PROMPT_STYLES.map((s) => s.id))
+
+/** True when `value` is a known prompt-style id. */
+export function isInsightPromptStyle(
+  value: unknown
+): value is InsightPromptStyle {
+  return typeof value === 'string' && STYLE_IDS.has(value)
+}
+
+/** Resolve a style id to its definition, falling back to the default. */
+export function resolvePromptStyle(
+  style: string | null | undefined
+): PromptStyleDef {
+  return (
+    INSIGHT_PROMPT_STYLES.find((s) => s.id === style) ??
+    INSIGHT_PROMPT_STYLES.find((s) => s.id === DEFAULT_PROMPT_STYLE)!
+  )
+}
+
+/** Build the system prompt for a given style (default style when unknown). */
+export function promptSystemFor(style: string | null | undefined): string {
+  return resolvePromptStyle(style).system
+}

--- a/apps/dashboard/src/lib/insights/resolve-model.ts
+++ b/apps/dashboard/src/lib/insights/resolve-model.ts
@@ -1,0 +1,48 @@
+/**
+ * Server-only resolution of a user-requested insight model.
+ *
+ * The settings UI lets the operator pick any model from `/api/v1/agents/models`,
+ * but a request could still carry a stale or unconfigured id (provider key
+ * removed, typo in a deep-link, etc.). This validates the requested
+ * `provider:model` against the *configured* registry and returns:
+ *
+ * - the requested id when it maps to a known, key-configured provider, or
+ * - `undefined` to mean "use the deployment default" (`DEFAULT_MODEL`).
+ *
+ * Never throws — any failure resolves to the default, so generation degrades
+ * gracefully rather than erroring on a bad model id.
+ */
+
+import { getModelRegistry } from '../ai/agent-model-registry'
+import { isProviderConfigured } from '../ai/providers'
+
+/**
+ * Validate a requested `provider:model` id. Returns the id when it is a known,
+ * configured combination, otherwise `undefined` (caller falls back to the
+ * server default model).
+ */
+export function resolveInsightModel(
+  requested: string | null | undefined
+): string | undefined {
+  const id = requested?.trim()
+  if (!id) return undefined
+
+  const colon = id.indexOf(':')
+  if (colon <= 0) return undefined
+
+  const provider = id.slice(0, colon)
+  const modelId = id.slice(colon + 1)
+  if (!provider || !modelId) return undefined
+
+  try {
+    if (!isProviderConfigured(provider)) return undefined
+
+    const known = getModelRegistry().some(
+      (entry) =>
+        entry.id === modelId && (entry.providers?.includes(provider) ?? false)
+    )
+    return known ? id : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/apps/dashboard/src/lib/insights/resolve-model.ts
+++ b/apps/dashboard/src/lib/insights/resolve-model.ts
@@ -30,8 +30,8 @@ export function resolveInsightModel(
   const colon = id.indexOf(':')
   if (colon <= 0) return undefined
 
-  const provider = id.slice(0, colon)
-  const modelId = id.slice(colon + 1)
+  const provider = id.slice(0, colon).trim()
+  const modelId = id.slice(colon + 1).trim()
   if (!provider || !modelId) return undefined
 
   try {

--- a/apps/dashboard/src/lib/insights/settings.test.ts
+++ b/apps/dashboard/src/lib/insights/settings.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for the AI Insights settings model + prompt styles + server-side model
+ * resolution. Pure logic — no ClickHouse, no LLM.
+ */
+
+import {
+  DEFAULT_PROMPT_STYLE,
+  INSIGHT_PROMPT_STYLES,
+  isInsightPromptStyle,
+  promptSystemFor,
+  resolvePromptStyle,
+} from './prompts'
+import { resolveInsightModel } from './resolve-model'
+import {
+  DEFAULT_INSIGHTS_SETTINGS,
+  generateParamsFromSettings,
+  isInsightWindow,
+  sanitizeInsightsSettings,
+} from './settings'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+describe('prompt styles', () => {
+  it('exposes concise/detailed/beginner with distinct system prompts', () => {
+    const ids = INSIGHT_PROMPT_STYLES.map((s) => s.id)
+    expect(ids).toEqual(['concise', 'detailed', 'beginner'])
+    const systems = new Set(INSIGHT_PROMPT_STYLES.map((s) => s.system))
+    expect(systems.size).toBe(3)
+  })
+
+  it('validates known style ids', () => {
+    expect(isInsightPromptStyle('detailed')).toBe(true)
+    expect(isInsightPromptStyle('nope')).toBe(false)
+    expect(isInsightPromptStyle(null)).toBe(false)
+  })
+
+  it('falls back to the default style for unknown ids', () => {
+    expect(resolvePromptStyle('bogus').id).toBe(DEFAULT_PROMPT_STYLE)
+    expect(promptSystemFor(undefined)).toBe(
+      resolvePromptStyle(DEFAULT_PROMPT_STYLE).system
+    )
+  })
+
+  it('selects the requested style prompt when valid', () => {
+    expect(promptSystemFor('beginner')).toContain('plain language')
+    expect(promptSystemFor('detailed')).toContain('root cause')
+  })
+})
+
+describe('sanitizeInsightsSettings', () => {
+  it('returns defaults for null/garbage input', () => {
+    expect(sanitizeInsightsSettings(null)).toEqual(DEFAULT_INSIGHTS_SETTINGS)
+    expect(sanitizeInsightsSettings(undefined)).toEqual(
+      DEFAULT_INSIGHTS_SETTINGS
+    )
+    expect(sanitizeInsightsSettings('x' as unknown as null)).toEqual(
+      DEFAULT_INSIGHTS_SETTINGS
+    )
+  })
+
+  it('coerces partial / invalid fields to defaults', () => {
+    expect(
+      sanitizeInsightsSettings({
+        model: '   ',
+        promptStyle: 'weird',
+        enrich: 'yes',
+        window: '99 YEAR',
+      })
+    ).toEqual(DEFAULT_INSIGHTS_SETTINGS)
+  })
+
+  it('keeps valid fields', () => {
+    const s = sanitizeInsightsSettings({
+      model: 'anyrouter:google/gemma-4-26b-a4b-it',
+      promptStyle: 'detailed',
+      enrich: false,
+      window: '24 HOUR',
+    })
+    expect(s).toEqual({
+      model: 'anyrouter:google/gemma-4-26b-a4b-it',
+      promptStyle: 'detailed',
+      enrich: false,
+      window: '24 HOUR',
+    })
+  })
+
+  it('trims a model string and treats empty as null (server default)', () => {
+    expect(sanitizeInsightsSettings({ model: '  x:y  ' }).model).toBe('x:y')
+    expect(sanitizeInsightsSettings({ model: '' }).model).toBeNull()
+  })
+
+  it('coerces string booleans for enrich (query-param sourced)', () => {
+    expect(sanitizeInsightsSettings({ enrich: 'false' }).enrich).toBe(false)
+    expect(sanitizeInsightsSettings({ enrich: 'true' }).enrich).toBe(true)
+    // Unrecognized strings fall back to the default.
+    expect(sanitizeInsightsSettings({ enrich: 'maybe' }).enrich).toBe(
+      DEFAULT_INSIGHTS_SETTINGS.enrich
+    )
+  })
+
+  it('never returns the shared default object by reference', () => {
+    const a = sanitizeInsightsSettings(null)
+    expect(a).toEqual(DEFAULT_INSIGHTS_SETTINGS)
+    expect(a).not.toBe(DEFAULT_INSIGHTS_SETTINGS)
+  })
+})
+
+describe('isInsightWindow', () => {
+  it('accepts known windows only', () => {
+    expect(isInsightWindow('6 HOUR')).toBe(true)
+    expect(isInsightWindow('7 DAY')).toBe(true)
+    expect(isInsightWindow('1 MONTH')).toBe(false)
+    expect(isInsightWindow(null)).toBe(false)
+  })
+})
+
+describe('generateParamsFromSettings', () => {
+  it('omits defaults and host is always present', () => {
+    const params = generateParamsFromSettings(0, DEFAULT_INSIGHTS_SETTINGS)
+    expect(params).toBe('host=0')
+  })
+
+  it('includes model + promptStyle when enrichment is on', () => {
+    const params = generateParamsFromSettings(2, {
+      model: 'openrouter:qwen/qwen3-coder:free',
+      promptStyle: 'detailed',
+      enrich: true,
+      window: '6 HOUR',
+    })
+    const parsed = new URLSearchParams(params)
+    expect(parsed.get('host')).toBe('2')
+    expect(parsed.get('model')).toBe('openrouter:qwen/qwen3-coder:free')
+    expect(parsed.get('promptStyle')).toBe('detailed')
+    expect(parsed.get('enrich')).toBeNull()
+  })
+
+  it('sends enrich=false and drops model/style when enrichment is off', () => {
+    const params = generateParamsFromSettings(1, {
+      model: 'openrouter:qwen/qwen3-coder:free',
+      promptStyle: 'detailed',
+      enrich: false,
+      window: '6 HOUR',
+    })
+    const parsed = new URLSearchParams(params)
+    expect(parsed.get('enrich')).toBe('false')
+    expect(parsed.get('model')).toBeNull()
+    expect(parsed.get('promptStyle')).toBeNull()
+  })
+})
+
+describe('resolveInsightModel (server-side validation)', () => {
+  const KEY = 'OPENROUTER_API_KEY'
+  let prev: string | undefined
+
+  beforeEach(() => {
+    prev = process.env[KEY]
+  })
+  afterEach(() => {
+    if (prev === undefined) delete process.env[KEY]
+    else process.env[KEY] = prev
+  })
+
+  it('returns undefined for empty / malformed ids', () => {
+    expect(resolveInsightModel(undefined)).toBeUndefined()
+    expect(resolveInsightModel('')).toBeUndefined()
+    expect(resolveInsightModel('no-colon')).toBeUndefined()
+    expect(resolveInsightModel(':leading')).toBeUndefined()
+  })
+
+  it('accepts a known model when its provider key is configured', () => {
+    process.env[KEY] = 'sk-test'
+    expect(resolveInsightModel('openrouter:qwen/qwen3-coder:free')).toBe(
+      'openrouter:qwen/qwen3-coder:free'
+    )
+  })
+
+  it('rejects a known model when the provider key is missing', () => {
+    delete process.env[KEY]
+    delete process.env.LLM_API_KEY
+    expect(
+      resolveInsightModel('openrouter:qwen/qwen3-coder:free')
+    ).toBeUndefined()
+  })
+
+  it('rejects an unknown model id even with a configured provider', () => {
+    process.env[KEY] = 'sk-test'
+    expect(
+      resolveInsightModel('openrouter:totally/made-up-model')
+    ).toBeUndefined()
+  })
+})

--- a/apps/dashboard/src/lib/insights/settings.ts
+++ b/apps/dashboard/src/lib/insights/settings.ts
@@ -1,0 +1,124 @@
+/**
+ * AI Insights user settings — pure, isomorphic model.
+ *
+ * These are *per-user* preferences (persisted client-side in localStorage, like
+ * dismissals and the agent model picker) that tune how insights are generated
+ * and read:
+ *
+ * - `model`        — which LLM enriches the deterministic signals (null = the
+ *                    deployment's server default).
+ * - `promptStyle`  — the tone of the rewrite (see `prompts.ts`).
+ * - `enrich`       — master switch for LLM enrichment; off = deterministic copy.
+ * - `window`       — how far back the panel reads insights (maps to the read
+ *                    endpoint's `since`).
+ *
+ * This module has no React or server-only imports so it can be used by the
+ * client hook, the settings UI, and request-building helpers alike. The actual
+ * model validation (against the configured providers) is server-only and lives
+ * in `resolve-model.ts`.
+ */
+
+import {
+  DEFAULT_PROMPT_STYLE,
+  type InsightPromptStyle,
+  isInsightPromptStyle,
+} from './prompts'
+
+export interface InsightsSettings {
+  /** `provider:model` id, or null to use the deployment's server default. */
+  readonly model: string | null
+  /** Enrichment tone. */
+  readonly promptStyle: InsightPromptStyle
+  /** Master switch for LLM enrichment. */
+  readonly enrich: boolean
+  /** Read window (the panel's lookback), e.g. `6 HOUR`. */
+  readonly window: string
+}
+
+interface WindowOption {
+  readonly value: string
+  readonly label: string
+}
+
+/** Selectable lookback windows for the panel. The first entry is the default. */
+export const INSIGHT_WINDOWS: readonly WindowOption[] = [
+  { value: '6 HOUR', label: 'Last 6 hours' },
+  { value: '24 HOUR', label: 'Last 24 hours' },
+  { value: '3 DAY', label: 'Last 3 days' },
+  { value: '7 DAY', label: 'Last 7 days' },
+] as const
+
+const WINDOW_VALUES = new Set<string>(INSIGHT_WINDOWS.map((w) => w.value))
+
+export const DEFAULT_INSIGHTS_SETTINGS: InsightsSettings = {
+  model: null,
+  promptStyle: DEFAULT_PROMPT_STYLE,
+  enrich: true,
+  window: INSIGHT_WINDOWS[0].value,
+}
+
+/** True when `value` is a selectable read window. */
+export function isInsightWindow(value: unknown): value is string {
+  return typeof value === 'string' && WINDOW_VALUES.has(value)
+}
+
+/**
+ * Coerce arbitrary input (parsed localStorage, query params) into valid
+ * settings. Unknown / malformed fields fall back to their defaults, so a
+ * corrupt or partial payload never breaks generation.
+ */
+export function sanitizeInsightsSettings(
+  input: Partial<Record<keyof InsightsSettings, unknown>> | null | undefined
+): InsightsSettings {
+  // Spread so a null/garbage input never hands back the shared default object
+  // (callers must not be able to mutate the module-level constant).
+  if (!input || typeof input !== 'object') {
+    return { ...DEFAULT_INSIGHTS_SETTINGS }
+  }
+
+  const model =
+    typeof input.model === 'string' && input.model.trim().length > 0
+      ? input.model.trim()
+      : null
+
+  const promptStyle = isInsightPromptStyle(input.promptStyle)
+    ? input.promptStyle
+    : DEFAULT_PROMPT_STYLE
+
+  // Accept real booleans and the string forms that arrive from query params.
+  const enrich =
+    typeof input.enrich === 'boolean'
+      ? input.enrich
+      : input.enrich === 'true'
+        ? true
+        : input.enrich === 'false'
+          ? false
+          : DEFAULT_INSIGHTS_SETTINGS.enrich
+
+  const window = isInsightWindow(input.window)
+    ? input.window
+    : DEFAULT_INSIGHTS_SETTINGS.window
+
+  return { model, promptStyle, enrich, window }
+}
+
+/**
+ * Build the query string for `POST /api/v1/insights/generate` from settings.
+ * Only includes parameters that differ from the server default, keeping URLs
+ * clean and letting the server apply its own defaults when omitted.
+ */
+export function generateParamsFromSettings(
+  hostId: number,
+  settings: InsightsSettings
+): string {
+  const params = new URLSearchParams({ host: String(hostId) })
+  if (!settings.enrich) {
+    params.set('enrich', 'false')
+  } else {
+    if (settings.model) params.set('model', settings.model)
+    if (settings.promptStyle !== DEFAULT_PROMPT_STYLE) {
+      params.set('promptStyle', settings.promptStyle)
+    }
+  }
+  return params.toString()
+}

--- a/apps/dashboard/src/routes/api/v1/insights/generate.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/generate.ts
@@ -11,6 +11,10 @@
  *
  * Query parameters:
  * - host (optional, default 0): host to generate insights for
+ * - enrich (optional): "false" skips LLM enrichment (deterministic copy only)
+ * - model (optional): `provider:model` id for enrichment; validated server-side,
+ *   ignored when unknown/unconfigured (falls back to the deployment default)
+ * - promptStyle (optional): "concise" | "detailed" | "beginner" (default concise)
  */
 
 import { createFileRoute } from '@tanstack/react-router'
@@ -19,16 +23,16 @@ import { env } from 'cloudflare:workers'
 import { error, generateRequestId } from '@chm/logger'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { generateInsights } from '@/lib/insights/generate-insights'
+import { isInsightPromptStyle } from '@/lib/insights/prompts'
+import { resolveInsightModel } from '@/lib/insights/resolve-model'
 
 async function handlePost(request: Request): Promise<Response> {
   bridgeClickHouseEnv(env as Record<string, string | undefined>)
   const requestId = generateRequestId()
 
   try {
-    const hostId = Number.parseInt(
-      new URL(request.url).searchParams.get('host') ?? '0',
-      10
-    )
+    const searchParams = new URL(request.url).searchParams
+    const hostId = Number.parseInt(searchParams.get('host') ?? '0', 10)
     if (!Number.isInteger(hostId) || hostId < 0) {
       return Response.json(
         { error: 'Invalid host parameter: must be a non-negative integer' },
@@ -36,7 +40,20 @@ async function handlePost(request: Request): Promise<Response> {
       )
     }
 
-    const insights = await generateInsights(hostId)
+    // Optional generation overrides. All are best-effort: an unknown model or
+    // style is dropped server-side so a stale request never breaks generation.
+    const enrich = searchParams.get('enrich') !== 'false'
+    const model = resolveInsightModel(searchParams.get('model'))
+    const styleParam = searchParams.get('promptStyle')
+    const promptStyle = isInsightPromptStyle(styleParam)
+      ? styleParam
+      : undefined
+
+    const insights = await generateInsights(hostId, {
+      enrich,
+      model,
+      promptStyle,
+    })
 
     return Response.json(
       { insights, count: insights.length },


### PR DESCRIPTION
## Summary

First PR in a series making the **AI Insights** feature configurable and better-surfaced. Today, insight generation is entirely hardcoded — the model is the server `DEFAULT_MODEL`, the enrichment prompt is a single inline string, and there is no way to turn enrichment off or change its tone. This PR adds the **backend foundation** for per-user configuration; the settings UI and wider surfacing follow in subsequent PRs.

## What changed

- **`prompts.ts`** — three prompt-style templates (`concise` / `detailed` / `beginner`) replacing the single inline system prompt. Deterministic baseline copy is untouched.
- **`settings.ts`** — pure, isomorphic `InsightsSettings` model (`model`, `promptStyle`, `enrich`, `window`) + `sanitizeInsightsSettings` + `generateParamsFromSettings` (shared by the upcoming settings UI). No React/server imports.
- **`resolve-model.ts`** — server-only validation of a requested `provider:model` against the *configured* registry; unknown or unconfigured ids fall back to the deployment default, so a stale request never breaks generation.
- **`enrichInsights` / `generateInsights`** now accept `{ model, promptStyle, enrich }`.
- **`POST /api/v1/insights/generate`** parses + validates `model`, `promptStyle`, `enrich` query params. **Omitting them preserves the exact prior behavior** (default model, concise prompt, enrichment on).

## Safety / compatibility

- Fully backward compatible — every new param is optional; the cron sweep and existing Refresh button keep working unchanged.
- All overrides degrade gracefully: bad model → default, unknown style → concise, no provider key → deterministic copy (existing behavior).

## Tests

`bun test src/lib/insights/` → 22 pass. New coverage: prompt-style resolution, settings sanitization (garbage/partial input), the request-param builder (enrichment on/off), and server-side model validation (provider key present vs absent, unknown model id).

## Next PRs

2. Settings UI (model picker reuse, prompt style, enrich toggle, window) wired into the panel.
3. Surface insights beyond `/overview` + links to settings.
4. Docs sync.

https://claude.ai/code/session_01E43HCrarP9fhTHSr9UrKDo

## Summary by Sourcery

Make AI Insights enrichment configurable per request, including model selection, prompt style, and ability to disable enrichment, while adding a shared settings model and safer server-side model resolution.

New Features:
- Introduce configurable prompt styles for AI insight enrichment (concise, detailed, beginner) and centralize their definitions.
- Add per-request options for insight generation to toggle enrichment, select the LLM model, and choose enrichment tone via prompt style.
- Provide a shared InsightsSettings model with sanitization and helpers for building generate-insights API query parameters.
- Expose selectable insight lookback windows for the insights panel.

Enhancements:
- Refine LLM availability checks to work against an arbitrary model instead of only the default.
- Ensure the insights generate API validates and gracefully degrades invalid model and prompt-style overrides via server-side resolution.

Tests:
- Add tests for insights settings sanitization and URL parameter generation, including handling of malformed or partial input.
- Add coverage for prompt-style resolution and related helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced AI insights generation with per-request customization (enable/disable LLM enrichment).
  * Select a prompt style for how insights are generated: concise, detailed, or beginner-friendly.
  * Optionally choose an AI model; unrecognized or unavailable selections are safely ignored in favor of defaults.
* **Bug Fixes**
  * Avoids enrichment when there are no candidates or when the selected model can’t be used, keeping existing best-effort behavior.
* **Tests**
  * Added coverage for settings/prompt/style/model validation and enrichment parameter handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->