### PR TITLE
fix(agent): explore_table_schema query valid system.parts columns

### DIFF
--- a/apps/dashboard/src/lib/ai/agent/tools/__tests__/schema-tools.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/__tests__/schema-tools.test.ts
@@ -46,7 +46,7 @@ const indexes = [
   },
 ]
 
-const partitions = [{ partition: '202605', parts: 5, is_inactive: 0 }]
+const partitions = [{ partition: '202605', parts: 5, inactive_parts: 0 }]
 
 const constraints = [
   {
@@ -106,7 +106,10 @@ function setupSchemaMocks(overrides?: {
       if (query.includes('system.data_skipping_indexes'))
         return { data: indexes, error: null }
 
-      if (query.includes('system.parts') && query.includes('active = 1'))
+      if (
+        query.includes('system.parts') &&
+        query.includes('GROUP BY partition')
+      )
         return { data: partitions, error: null }
 
       if (query.includes('partition_key') && query.includes('primary_key'))

--- a/apps/dashboard/src/lib/ai/agent/tools/schema-tools.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/schema-tools.ts
@@ -178,7 +178,7 @@ export function createSchemaTools(hostId: number) {
           // Get partition info
           readOnlyQuery({
             query:
-              'SELECT partition, parts, is_inactive FROM system.parts WHERE database = {database:String} AND table = {table:String} AND active = 1 ORDER BY partition LIMIT 500',
+              'SELECT partition, count() AS parts, countIf(active = 0) AS inactive_parts FROM system.parts WHERE database = {database:String} AND table = {table:String} GROUP BY partition ORDER BY partition LIMIT 500',
             hostId: effectiveHostId,
             query_params: { database, table },
           }),


### PR DESCRIPTION
## Bug

`explore_table_schema` in `schema-tools.ts` ran this query to get partition info:

```sql
SELECT partition, parts, is_inactive FROM system.parts
WHERE database = ... AND table = ... AND active = 1
ORDER BY partition LIMIT 500
```

Neither `parts` nor `is_inactive` are columns in `system.parts`. The table has one row per *part*, not per partition — there is no `parts` count column, and the activity flag is `active` (not `is_inactive`). ClickHouse would error on this query; the outer `try/catch` swallowed it, so the tool silently returned empty partitions every time.

## Fix

Replaced the invalid query with a proper aggregation:

```sql
SELECT
  partition,
  count() AS parts,
  countIf(active = 0) AS inactive_parts
FROM system.parts
WHERE database = ... AND table = ...
GROUP BY partition
ORDER BY partition
LIMIT 500
```

The `is_inactive` alias became `inactive_parts` (more descriptive). The `partitions` value is passed through as raw query data to the AI response — no downstream typed consumers read individual fields by name, so no other code needed updating.

## Files changed

- `apps/dashboard/src/lib/ai/agent/tools/schema-tools.ts` — fixed SQL at line 181
- `apps/dashboard/src/lib/ai/agent/tools/__tests__/schema-tools.test.ts` — updated fixture shape (`is_inactive` → `inactive_parts`) and mock discriminator (`active = 1` → `GROUP BY partition`)

## Verification

- `grep` confirms zero remaining references to `is_inactive` or the bare `parts` column in agent source
- `bun run type-check` exits 0 (clean)
- Pre-push hook ran full test suite: **2073 pass, 0 fail**

Fixes #1777.

https://claude.ai/code/session_01HcF2GhuJfJKVhCmSRFhbZD

## Summary by Sourcery

Fix partition metadata retrieval in the schema exploration agent to use valid ClickHouse system.parts columns and aggregation.

Bug Fixes:
- Correct system.parts query in schema exploration to aggregate per-partition counts using existing columns instead of invalid fields that caused silent failures.

Tests:
- Update schema tools tests and mocks to match the new partition query shape and detection logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the AI agent's schema exploration capabilities by refining partition-data queries. The tool now independently counts inactive partitions while aggregating total partition metrics, offering more comprehensive insights into table structure and partition distribution.

* **Tests**
  * Updated test fixtures to align with partition-query changes and refined data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->