### PR TITLE
fix(agent): explain_query use EXPLAIN PLAN indexes=1 for indexes mode

### DIFF
--- a/apps/dashboard/src/lib/ai/agent/tools/__tests__/query-tools.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/__tests__/query-tools.test.ts
@@ -145,8 +145,30 @@ describe('createQueryTools', () => {
       expect(result[0].explain).toBeDefined()
     })
 
-    test('supports pipeline explain type', async () => {
-      setupQueryMock()
+    test('generates EXPLAIN PLAN for default/plan type', async () => {
+      let capturedQuery = ''
+      mockFetchData.mockImplementation(async ({ query }: { query: string }) => {
+        capturedQuery = query
+        return { data: queryResults.explain, error: null }
+      })
+
+      const tools = createQueryTools(0) as any
+      await tools.explain_query.execute({
+        sql: 'SELECT count() FROM system.tables',
+        type: 'plan',
+      })
+
+      expect(capturedQuery).toBe(
+        'EXPLAIN PLAN SELECT count() FROM system.tables'
+      )
+    })
+
+    test('generates EXPLAIN PIPELINE for pipeline type', async () => {
+      let capturedQuery = ''
+      mockFetchData.mockImplementation(async ({ query }: { query: string }) => {
+        capturedQuery = query
+        return { data: queryResults.explain, error: null }
+      })
 
       const tools = createQueryTools(0) as any
       const result = await tools.explain_query.execute({
@@ -155,10 +177,17 @@ describe('createQueryTools', () => {
       })
 
       expect(Array.isArray(result)).toBe(true)
+      expect(capturedQuery).toBe(
+        'EXPLAIN PIPELINE SELECT count() FROM system.tables'
+      )
     })
 
-    test('supports indexes explain type', async () => {
-      setupQueryMock()
+    test('generates EXPLAIN PLAN indexes=1 for indexes type (not EXPLAIN INDEXES)', async () => {
+      let capturedQuery = ''
+      mockFetchData.mockImplementation(async ({ query }: { query: string }) => {
+        capturedQuery = query
+        return { data: queryResults.explain, error: null }
+      })
 
       const tools = createQueryTools(0) as any
       const result = await tools.explain_query.execute({
@@ -167,6 +196,11 @@ describe('createQueryTools', () => {
       })
 
       expect(Array.isArray(result)).toBe(true)
+      // Must use PLAN setting, not the invalid top-level EXPLAIN INDEXES mode
+      expect(capturedQuery).toBe(
+        'EXPLAIN PLAN indexes=1 SELECT count() FROM system.tables'
+      )
+      expect(capturedQuery).not.toContain('EXPLAIN INDEXES')
     })
 
     test('propagates validation errors', async () => {

--- a/apps/dashboard/src/lib/ai/agent/tools/query-tools.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/query-tools.ts
@@ -136,7 +136,7 @@ export function createQueryTools(hostId: number) {
 
     explain_query: dynamicTool({
       description:
-        'Get the execution plan for a query (EXPLAIN PLAN/PIPELINE/INDEXES). Useful for understanding query optimization and identifying performance issues.',
+        'Get the execution plan for a query (EXPLAIN PLAN / PIPELINE / PLAN indexes=1). Useful for understanding query optimization and identifying performance issues.',
       inputSchema: z.object({
         sql: z.string().describe('SQL query to explain'),
         type: z
@@ -158,17 +158,19 @@ export function createQueryTools(hostId: number) {
         }
         const resolvedHostId = resolveHostId(toolHostId, hostId)
 
-        // Map type to ClickHouse EXPLAIN type
+        // Map type to ClickHouse EXPLAIN keyword.
+        // 'indexes' is not a standalone EXPLAIN mode; it is a PLAN setting.
         const typeMap: Record<string, string> = {
           plan: 'PLAN',
           pipeline: 'PIPELINE',
-          indexes: 'INDEXES',
         }
-        const explainType = typeMap[type]
 
         validateSqlQuery(sql)
 
-        const explainQuery = `EXPLAIN ${explainType} ${sql}`
+        const explainQuery =
+          type === 'indexes'
+            ? `EXPLAIN PLAN indexes=1 ${sql}`
+            : `EXPLAIN ${typeMap[type]} ${sql}`
 
         const result = await readOnlyQuery({
           query: explainQuery,


### PR DESCRIPTION
## Bug

`explain_query` tool mapped `type='indexes'` to `EXPLAIN INDEXES <sql>`, which is not a valid ClickHouse EXPLAIN mode. Valid top-level modes are `PLAN`, `PIPELINE`, `AST`, `SYNTAX`, `ESTIMATE`. Showing index usage is a PLAN setting: `EXPLAIN PLAN indexes=1 <sql>`.

## Fix

- Removed `indexes` from `typeMap` (which built `EXPLAIN ${mode} ${sql}`)
- Added a branch: `type === 'indexes'` now produces `EXPLAIN PLAN indexes=1 ${sql}`
- Updated tool description to remove the misleading `EXPLAIN PLAN/PIPELINE/INDEXES` wording
- Strengthened the `explain_query` tests to capture and assert the exact generated SQL per type, including a negative assertion that `EXPLAIN INDEXES` never appears

## Verification

```
bun run type-check   # exit 0
bun test src/lib/ai/agent/tools/__tests__/query-tools.test.ts  # 11 pass, 0 fail
```

Full pre-push suite: 2074 + 855 tests, 0 failures.

Fixes #1778.

https://claude.ai/code/session_01HcF2GhuJfJKVhCmSRFhbZD

## Summary by Sourcery

Adjust explain_query tool to use valid ClickHouse EXPLAIN modes and strengthen its tests.

Bug Fixes:
- Correct explain_query indexes mode to use EXPLAIN PLAN indexes=1 instead of the invalid EXPLAIN INDEXES mode.

Enhancements:
- Clarify explain_query tool description to reference EXPLAIN PLAN / PIPELINE / PLAN indexes=1 and document that indexes is a PLAN setting.
- Add tests that capture and assert the exact EXPLAIN SQL generated for plan, pipeline, and indexes types, including guarding against EXPLAIN INDEXES ever being emitted.

Tests:
- Extend explain_query tests to validate generated EXPLAIN queries for plan, pipeline, and indexes types and ensure the result shape remains an array.