### PR TITLE
feat(insights): AI Insights settings page + panel link, wired into generation

### DIFF
--- a/apps/dashboard/src/components/insights/insights-panel.tsx
+++ b/apps/dashboard/src/components/insights/insights-panel.tsx
@@ -1,11 +1,13 @@
-import { RefreshCw, Sparkles, X } from 'lucide-react'
+import { RefreshCw, Settings2, Sparkles, X } from 'lucide-react'
 
 import { useState } from 'react'
 import { InsightCard } from '@/components/insights/insight-card'
+import { AppLink } from '@/components/ui/app-link'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useInsights } from '@/lib/query/use-insights'
+import { buildUrl } from '@/lib/url/url-builder'
 import { cn } from '@/lib/utils'
 
 interface InsightsPanelProps {
@@ -52,19 +54,33 @@ export function InsightsPanel({ hostId, className }: InsightsPanelProps) {
             No AI insights right now. Generate a fresh analysis of this cluster.
           </span>
         </div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="gap-1.5"
-          onClick={generate}
-          disabled={isGenerating}
-        >
-          <RefreshCw
-            className={cn('size-3.5', isGenerating && 'animate-spin')}
-          />
-          {isGenerating ? 'Generating…' : 'Generate insights'}
-        </Button>
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={generate}
+            disabled={isGenerating}
+          >
+            <RefreshCw
+              className={cn('size-3.5', isGenerating && 'animate-spin')}
+            />
+            {isGenerating ? 'Generating…' : 'Generate insights'}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-8 text-muted-foreground hover:text-foreground"
+            aria-label="AI Insights settings"
+            asChild
+          >
+            <AppLink href={buildUrl('/insights-settings', { host: hostId })}>
+              <Settings2 className="size-3.5" />
+            </AppLink>
+          </Button>
+        </div>
       </section>
     )
   }
@@ -123,6 +139,18 @@ export function InsightsPanel({ hostId, className }: InsightsPanelProps) {
               Dismiss all
             </Button>
           ) : null}
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-7 text-muted-foreground hover:text-foreground"
+            aria-label="AI Insights settings"
+            asChild
+          >
+            <AppLink href={buildUrl('/insights-settings', { host: hostId })}>
+              <Settings2 className="size-3.5" />
+            </AppLink>
+          </Button>
         </div>
       </div>
 

--- a/apps/dashboard/src/components/insights/insights-settings-form.tsx
+++ b/apps/dashboard/src/components/insights/insights-settings-form.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+/**
+ * AI Insights settings form.
+ *
+ * Self-contained controls for the per-user insight preferences persisted by
+ * `useInsightsSettings`: enrichment on/off, which model enriches, the prompt
+ * tone, and the panel's read window. The available model list is read from the
+ * same source as the agent model picker (`/api/v1/agents/models`, configured
+ * providers only). Changes apply immediately — the overview panel reflects the
+ * new settings on its next refresh.
+ */
+
+import { RotateCcw, Sparkles } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Separator } from '@/components/ui/separator'
+import { Switch } from '@/components/ui/switch'
+import {
+  type ModelDisplayInfo,
+  useAgentModel,
+} from '@/lib/hooks/use-agent-model'
+import {
+  INSIGHT_PROMPT_STYLES,
+  resolvePromptStyle,
+} from '@/lib/insights/prompts'
+import { INSIGHT_WINDOWS } from '@/lib/insights/settings'
+import { useInsightsSettings } from '@/lib/query/use-insights-settings'
+import { cn } from '@/lib/utils'
+
+const DEFAULT_MODEL_VALUE = '__default__'
+
+export function InsightsSettingsForm({ className }: { className?: string }) {
+  const { settings, update, reset } = useInsightsSettings()
+  const { models } = useAgentModel()
+
+  // Group available models by provider for the dropdown.
+  const grouped = new Map<string, ModelDisplayInfo[]>()
+  for (const m of models) {
+    const list = grouped.get(m.provider) ?? []
+    list.push(m)
+    grouped.set(m.provider, list)
+  }
+
+  const enrichDisabled = !settings.enrich
+  const activeStyle = resolvePromptStyle(settings.promptStyle)
+
+  return (
+    <Card className={cn(className)}>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Sparkles className="size-4 text-sky-500" />
+          AI Insights
+        </CardTitle>
+        <CardDescription>
+          Tune how cluster insights are generated and how far back the overview
+          panel looks. Settings are stored in this browser.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-6">
+        {/* Enrichment toggle */}
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <Label htmlFor="insights-enrich" className="text-sm font-medium">
+              Enhance with AI
+            </Label>
+            <p className="text-muted-foreground text-sm">
+              Rewrite raw monitoring signals into clearer, actionable insights.
+              When off, the original deterministic copy is shown.
+            </p>
+          </div>
+          <Switch
+            id="insights-enrich"
+            checked={settings.enrich}
+            onCheckedChange={(checked) => update({ enrich: checked })}
+          />
+        </div>
+
+        <Separator />
+
+        {/* Model */}
+        <div
+          className={cn(
+            'space-y-2 transition-opacity',
+            enrichDisabled && 'pointer-events-none opacity-50'
+          )}
+        >
+          <Label className="text-sm font-medium">Model</Label>
+          <p className="text-muted-foreground text-sm">
+            Which model writes the insights. “Deployment default” uses the
+            server-configured model.
+          </p>
+          <Select
+            value={settings.model ?? DEFAULT_MODEL_VALUE}
+            onValueChange={(value) =>
+              update({ model: value === DEFAULT_MODEL_VALUE ? null : value })
+            }
+            disabled={enrichDisabled}
+          >
+            <SelectTrigger className="w-full max-w-md">
+              <SelectValue placeholder="Deployment default" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={DEFAULT_MODEL_VALUE}>
+                Deployment default
+              </SelectItem>
+              {Array.from(grouped.entries()).map(([provider, list]) => (
+                <SelectGroup key={provider}>
+                  <SelectLabel className="capitalize">{provider}</SelectLabel>
+                  {list.map((m) => (
+                    <SelectItem key={m.id} value={m.id}>
+                      <span className="font-mono text-xs">{m.name}</span>
+                      {m.isFree ? (
+                        <span className="text-emerald-600 dark:text-emerald-400">
+                          {' '}
+                          · free
+                        </span>
+                      ) : null}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Prompt style */}
+        <div
+          className={cn(
+            'space-y-2 transition-opacity',
+            enrichDisabled && 'pointer-events-none opacity-50'
+          )}
+        >
+          <Label className="text-sm font-medium">Prompt style</Label>
+          <p className="text-muted-foreground text-sm">
+            {activeStyle.description}
+          </p>
+          <Select
+            value={settings.promptStyle}
+            onValueChange={(value) =>
+              update({ promptStyle: value as typeof settings.promptStyle })
+            }
+            disabled={enrichDisabled}
+          >
+            <SelectTrigger className="w-full max-w-md">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {INSIGHT_PROMPT_STYLES.map((style) => (
+                <SelectItem key={style.id} value={style.id}>
+                  {style.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <Separator />
+
+        {/* Read window */}
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">Lookback window</Label>
+          <p className="text-muted-foreground text-sm">
+            How far back the overview panel reads insights before they age out.
+          </p>
+          <Select
+            value={settings.window}
+            onValueChange={(value) => update({ window: value })}
+          >
+            <SelectTrigger className="w-full max-w-md">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {INSIGHT_WINDOWS.map((w) => (
+                <SelectItem key={w.value} value={w.value}>
+                  {w.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <Separator />
+
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="gap-1.5 text-muted-foreground"
+            onClick={reset}
+          >
+            <RotateCcw className="size-3.5" />
+            Reset to defaults
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/dashboard/src/lib/query/use-insights-settings.ts
+++ b/apps/dashboard/src/lib/query/use-insights-settings.ts
@@ -1,0 +1,99 @@
+'use client'
+
+/**
+ * useInsightsSettings — per-user AI Insights preferences.
+ *
+ * Persists the operator's insight settings (model / prompt style / enrichment /
+ * window) to localStorage and broadcasts a CustomEvent so every consumer on the
+ * page (the panel, the settings page, any summary widget) stays in sync without
+ * a reload. Mirrors `useAgentModel` and the dismissed-insights store.
+ *
+ * The stored value is always run through `sanitizeInsightsSettings`, so a
+ * corrupt or partial payload degrades to defaults rather than breaking the UI.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import {
+  DEFAULT_INSIGHTS_SETTINGS,
+  type InsightsSettings,
+  sanitizeInsightsSettings,
+} from '@/lib/insights/settings'
+
+const STORAGE_KEY = 'clickhouse-monitor-insights-settings'
+const CHANGE_EVENT = 'clickhouse-monitor-insights-settings-changed'
+
+export function getSavedInsightsSettings(): InsightsSettings {
+  if (typeof window === 'undefined') return DEFAULT_INSIGHTS_SETTINGS
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return DEFAULT_INSIGHTS_SETTINGS
+    return sanitizeInsightsSettings(JSON.parse(raw))
+  } catch {
+    return DEFAULT_INSIGHTS_SETTINGS
+  }
+}
+
+function persist(settings: InsightsSettings): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+  } catch {
+    // localStorage may be full or disabled.
+  }
+}
+
+function emitChange(settings: InsightsSettings): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(
+    new CustomEvent<InsightsSettings>(CHANGE_EVENT, { detail: settings })
+  )
+}
+
+export interface UseInsightsSettingsResult {
+  readonly settings: InsightsSettings
+  /** Merge a partial update, persist, and broadcast. */
+  update: (patch: Partial<InsightsSettings>) => void
+  /** Reset to defaults. */
+  reset: () => void
+}
+
+export function useInsightsSettings(): UseInsightsSettingsResult {
+  const [settings, setSettings] = useState<InsightsSettings>(
+    getSavedInsightsSettings
+  )
+
+  // Keep in sync with other consumers + other tabs.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const onChange = (event: Event) => {
+      const detail = (event as CustomEvent<InsightsSettings>).detail
+      setSettings(detail ?? getSavedInsightsSettings())
+    }
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY) setSettings(getSavedInsightsSettings())
+    }
+    window.addEventListener(CHANGE_EVENT, onChange)
+    window.addEventListener('storage', onStorage)
+    return () => {
+      window.removeEventListener(CHANGE_EVENT, onChange)
+      window.removeEventListener('storage', onStorage)
+    }
+  }, [])
+
+  const update = useCallback((patch: Partial<InsightsSettings>) => {
+    setSettings((current) => {
+      const next = sanitizeInsightsSettings({ ...current, ...patch })
+      persist(next)
+      emitChange(next)
+      return next
+    })
+  }, [])
+
+  const reset = useCallback(() => {
+    persist(DEFAULT_INSIGHTS_SETTINGS)
+    emitChange(DEFAULT_INSIGHTS_SETTINGS)
+    setSettings(DEFAULT_INSIGHTS_SETTINGS)
+  }, [])
+
+  return { settings, update, reset }
+}

--- a/apps/dashboard/src/lib/query/use-insights.ts
+++ b/apps/dashboard/src/lib/query/use-insights.ts
@@ -20,6 +20,8 @@ import {
   dismissInsight,
   filterActiveInsights,
 } from '@/lib/insights/dismissed-insights'
+import { generateParamsFromSettings } from '@/lib/insights/settings'
+import { useInsightsSettings } from '@/lib/query/use-insights-settings'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { REFRESH_INTERVAL } from '@/lib/swr/config'
 
@@ -42,12 +44,23 @@ export interface UseInsightsResult {
 
 export function useInsights(hostId: number): UseInsightsResult {
   const queryClient = useQueryClient()
-  const queryKey = useMemo(() => [`/api/v1/insights?host=${hostId}`], [hostId])
+  const { settings } = useInsightsSettings()
+  const { window: readWindow } = settings
+
+  // The read window is part of the cache key so changing it refetches.
+  const queryKey = useMemo(
+    () => [`/api/v1/insights?host=${hostId}`, readWindow],
+    [hostId, readWindow]
+  )
 
   const { data, error, isLoading } = useQuery<InsightsResponse>({
     queryKey,
     queryFn: async () => {
-      const res = await apiFetch(`/api/v1/insights?host=${hostId}`)
+      const params = new URLSearchParams({
+        host: String(hostId),
+        since: readWindow,
+      })
+      const res = await apiFetch(`/api/v1/insights?${params.toString()}`)
       if (!res.ok) throw new Error('Failed to fetch insights')
       return res.json()
     },
@@ -63,7 +76,8 @@ export function useInsights(hostId: number): UseInsightsResult {
 
   const generateMutation = useMutation({
     mutationFn: async () => {
-      const res = await apiFetch(`/api/v1/insights/generate?host=${hostId}`, {
+      const params = generateParamsFromSettings(hostId, settings)
+      const res = await apiFetch(`/api/v1/insights/generate?${params}`, {
         method: 'POST',
       })
       if (!res.ok) throw new Error('Failed to generate insights')

--- a/apps/dashboard/src/routes/(dashboard)/insights-settings.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/insights-settings.tsx
@@ -1,0 +1,49 @@
+import { ArrowLeft, Sparkles } from 'lucide-react'
+import { createFileRoute } from '@tanstack/react-router'
+
+import { InsightsSettingsForm } from '@/components/insights/insights-settings-form'
+import { AppLink } from '@/components/ui/app-link'
+import { Button } from '@/components/ui/button'
+import { useHostId } from '@/lib/swr'
+import { buildUrl } from '@/lib/url/url-builder'
+
+function InsightsSettingsPage() {
+  const hostId = useHostId()
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 py-8">
+      <div className="space-y-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground -ml-2 h-7 gap-1.5"
+          asChild
+        >
+          <AppLink href={buildUrl('/overview', { host: hostId })}>
+            <ArrowLeft className="size-3.5" />
+            Back to overview
+          </AppLink>
+        </Button>
+        <div className="flex items-center gap-3">
+          <div className="flex size-11 items-center justify-center rounded-xl bg-sky-500/10">
+            <Sparkles className="size-5 text-sky-500" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">
+              AI Insights Settings
+            </h1>
+            <p className="text-muted-foreground text-sm">
+              Configure how the dashboard analyzes this cluster.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <InsightsSettingsForm />
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/(dashboard)/insights-settings')({
+  component: InsightsSettingsPage,
+})


### PR DESCRIPTION
## Summary

Second PR in the AI Insights series (follows #1767). Adds the **user-facing configuration UI** for the generation overrides the foundation PR introduced, and wires it into the panel.

## What changed

- **`use-insights-settings.ts`** — client hook persisting per-user insight prefs (model / prompt style / enrichment / window) to localStorage, with a `CustomEvent` + `storage` broadcast so every consumer stays in sync (mirrors `useAgentModel`). Always sanitized, so corrupt/partial payloads degrade to defaults.
- **`insights-settings-form.tsx`** — self-contained settings card: enrichment toggle, model picker (configured providers from `/api/v1/agents/models`), prompt style, lookback window, reset-to-defaults.
- **`/insights-settings` route** — dedicated settings page with a back-to-overview link.
- **`use-insights.ts`** — now reads the settings: `generate()` sends the chosen model/style/enrich flag; the read query passes the window as `since` (window is part of the cache key so changing it refetches).
- **`insights-panel.tsx`** — settings gear linking to `/insights-settings` from both the populated header and the empty-state CTA.

## Notes
- Builds on the validated generation overrides from #1767; the gear/settings only ever produce server-validated params.
- Type-checked locally (fixed a readonly-array grouping issue before push).

## Next
3. Global AI Insights header popover (cross-page surfacing) — stacked branch ready.
4. Docs/knowledge sync.

https://claude.ai/code/session_01E43HCrarP9fhTHSr9UrKDo

## Summary by Sourcery

Add a dedicated AI Insights settings experience and wire its per-user preferences into insights generation and retrieval.

New Features:
- Introduce a per-user AI Insights settings hook that persists model, prompt style, enrichment, and lookback window preferences with cross-tab syncing.
- Add an AI Insights settings form and dashboard route for configuring enrichment behavior, model selection, prompt tone, and lookback window with reset-to-defaults support.
- Expose AI Insights settings entry points from the insights panel via a settings icon in both empty and populated states.

Enhancements:
- Update insights fetching and generation to respect the configured lookback window and generation settings, including model, prompt style, and enrichment flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced dedicated AI Insights settings page with options to enable/disable enrichment, select preferred AI models, customize prompt styles, adjust data lookback windows, and reset preferences to defaults.
* Added settings icon button in the Insights panel for convenient access to configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->