### PR TITLE
docs(insights): config/settings/popover knowledge sync + authorize stale bot-review dismissal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,21 @@ watch CI, fix failures, confirm the merge and production deploy. Do NOT ask the
 user whether to babysit — just do it. Known non-required checks (`e2e-test`,
 `e2e-test-tsr`, `component-test`, `unit-tests`) do not block auto-merge.
 
+**Stale bot-review gate (authorized override).** When a bot reviewer
+(CodeRabbit / `coderabbitai[bot]`, Sourcery, Gemini) leaves a
+`CHANGES_REQUESTED` that blocks merge, you are authorized to dismiss it and merge
+**only when ALL of these hold**: every actionable point it raised is genuinely
+fixed (or was stale / referenced pre-fix code), **all required CI checks are
+green**, the branch is up to date with `main`, and the bot did not re-review
+after you triggered it (push a new commit, then `@coderabbitai review` /
+`@coderabbitai full review`, then a formal re-request — give it a few minutes).
+Dismiss with
+`gh api -X PUT repos/duyet/clickhouse-monitoring/pulls/<n>/reviews/<id>/dismissals -f event=DISMISS -f message="<why each point is addressed>"`
+(bot reviews use the `coderabbitai[bot]` login; there may be more than one to
+dismiss). Do NOT dismiss a human reviewer's changes-requested, and never dismiss
+to skip an unaddressed finding. To avoid the gate entirely, prefer
+`request_changes_workflow: false` in CodeRabbit config so it only comments.
+
 ## Project Overview
 
 This is a monorepo ClickHouse monitoring dashboard. The primary (and only) dashboard app is `apps/dashboard` (TanStack Start, as of v0.3). The Next.js migration is complete — the TanStack Start app has replaced the legacy Next.js app and is now at `apps/dashboard`. The application connects to ClickHouse instances and provides real-time insights into clusters through system tables — metrics, query performance, table information, and cluster health.

--- a/docs/knowledge/ai-insights.md
+++ b/docs/knowledge/ai-insights.md
@@ -53,7 +53,39 @@ is fragmented", "replication is lagging" — generated and **cached server-side*
   `generateInsights(hostId)` per host on the existing 5-minute Cloudflare trigger
   (`api/cron/health-sweep`). No new trigger.
 - **Manual**: `POST /api/v1/insights/generate?host=<id>` (the panel's Refresh
-  button).
+  button), optionally carrying the user's config (see below).
+
+## Configuration (per-user)
+
+Insight generation is configurable per-user, persisted client-side (localStorage,
+like dismissals + the agent model picker). All overrides are **optional and
+validated server-side** — omitting them reproduces the original behavior.
+
+- **Settings model** — `src/lib/insights/settings.ts` (`InsightsSettings`:
+  `model` | `promptStyle` | `enrich` | `window`), pure/isomorphic with
+  `sanitizeInsightsSettings` + `generateParamsFromSettings`. Hook:
+  `src/lib/query/use-insights-settings.ts` (localStorage + `CustomEvent`/`storage`
+  broadcast so the panel, settings page, and header popover stay in sync).
+- **Prompt styles** — `src/lib/insights/prompts.ts`: `concise` (default) /
+  `detailed` / `beginner`, each a distinct enrichment system prompt. The
+  deterministic baseline copy is unchanged.
+- **Model override** — validated server-side in
+  `src/lib/insights/resolve-model.ts` against the *configured* registry
+  (`getModelRegistry()` + `isProviderConfigured`); an unknown/unconfigured id
+  falls back to the deployment default (`DEFAULT_MODEL`).
+- **Generate API params** — `POST /api/v1/insights/generate` accepts
+  `enrich` (`false` skips LLM), `model` (`provider:model`), `promptStyle`. The
+  read endpoint (`GET /api/v1/insights`) takes `since` = the chosen window.
+- `enrichInsights(candidates, { model, promptStyle })` /
+  `generateInsights(hostId, { enrich, model, promptStyle })` thread the overrides.
+
+## Settings page
+
+- `/insights-settings` (`src/routes/(dashboard)/insights-settings.tsx`) renders
+  `InsightsSettingsForm` (`src/components/insights/insights-settings-form.tsx`):
+  enrichment toggle, model picker (configured providers from
+  `/api/v1/agents/models`), prompt style, lookback window, reset-to-defaults.
+- Reachable from the overview panel's settings gear and the header popover.
 
 ## Read + dismissal
 
@@ -74,6 +106,11 @@ is fragmented", "replication is lagging" — generated and **cached server-side*
 - `src/components/insights/insight-card.tsx` — shadcn `Card` wrapper (never edits
   `components/ui/`), severity-toned accent, dismiss `X`, and a derived action
   link (e.g. View tables / Open running queries / Ask the agent).
+- `src/components/insights/insights-popover.tsx` — **global header popover**
+  (mirrors `NotificationsPopover`), mounted in `header-actions.tsx` so insights
+  surface on every page: severity-toned count badge, top insights with deep
+  links, Refresh, and footer links to the overview panel + settings page. Reuses
+  `useInsights`, so counts/dismissals stay in sync with the panel.
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Docs/policy follow-up to the AI Insights series (#1767, #1782, #1783).

- **`docs/knowledge/ai-insights.md`** — documents the new **Configuration** (per-user settings model, prompt styles, server-side model validation, generate/read API params), the **`/insights-settings` page**, and the **global header popover**, keeping the knowledge graph in sync with the feature surface.
- **`CLAUDE.md` (PR Workflow)** — per maintainer request, authorizes dismissing a **bot** reviewer's stale `CHANGES_REQUESTED` to unblock merge under strict conditions (all points addressed/stale, all CI green, branch up to date, bot unresponsive after new-commit + `@coderabbitai review` + re-request triggers), including the exact dismissal command. Explicitly never applies to human reviewers or unaddressed findings.

Context: #1767 hit exactly this gate — CodeRabbit left `CHANGES_REQUESTED` on pre-fix code, every point was fixed, all CI was green, but it would not re-review after 5 triggers, blocking merge.

https://claude.ai/code/session_01E43HCrarP9fhTHSr9UrKDo

## Summary by Sourcery

Document new per-user AI Insights configuration and global insights popover, and update PR workflow to allow dismissing stale bot reviews under strict conditions.

Documentation:
- Expand AI Insights documentation to cover per-user configuration, including settings model, prompt styles, model validation, and generate/read API parameters.
- Document the new /insights-settings page and its relationship to the overview panel and global header popover.

Chores:
- Clarify CLAUDE PR workflow to authorize dismissing stale bot CHANGES_REQUESTED reviews when all issues are addressed and CI is green.