### PR TITLE
fix(api): harden actions/explain/explorer input & output handling

### DIFF
--- a/apps/dashboard/src/lib/api/shared/__tests__/sql-identifier.test.ts
+++ b/apps/dashboard/src/lib/api/shared/__tests__/sql-identifier.test.ts
@@ -1,0 +1,33 @@
+import { quoteTableIdentifier } from '../sql-identifier'
+import { describe, expect, it } from 'bun:test'
+
+describe('quoteTableIdentifier', () => {
+  it('quotes a bare table name', () => {
+    expect(quoteTableIdentifier('events')).toBe('`events`')
+  })
+
+  it('quotes a database.table identifier per component', () => {
+    expect(quoteTableIdentifier('analytics.events')).toBe(
+      '`analytics`.`events`'
+    )
+  })
+
+  it('normalizes an already-backtick-quoted identifier (no double-wrapping)', () => {
+    expect(quoteTableIdentifier('`events`')).toBe('`events`')
+    expect(quoteTableIdentifier('`analytics`.`events`')).toBe(
+      '`analytics`.`events`'
+    )
+  })
+
+  it('tolerates whitespace around the dot separator', () => {
+    expect(quoteTableIdentifier('analytics. events')).toBe(
+      '`analytics`.`events`'
+    )
+  })
+
+  it('escapes internal backticks so a quoted name cannot break out of the identifier', () => {
+    // A stray-backtick payload stays a single, safely-escaped identifier
+    // rather than executable SQL.
+    expect(quoteTableIdentifier('`a` DROP TABLE x`')).toBe('`a`` DROP TABLE x`')
+  })
+})

--- a/apps/dashboard/src/lib/api/shared/sql-identifier.ts
+++ b/apps/dashboard/src/lib/api/shared/sql-identifier.ts
@@ -1,0 +1,32 @@
+/**
+ * SQL identifier quoting helpers for safely interpolating table/database names
+ * into ClickHouse statements (e.g. `OPTIMIZE TABLE`) that cannot use bound
+ * parameters for identifiers.
+ *
+ * Kept dependency-free (no `cloudflare:workers` / route imports) so it is unit
+ * testable and reusable across API routes.
+ */
+
+/** Backtick-quote a single identifier, escaping any internal backticks. */
+export function quoteIdent(part: string): string {
+  const inner =
+    part.length >= 2 && part.startsWith('`') && part.endsWith('`')
+      ? part.slice(1, -1)
+      : part
+  return `\`${inner.replace(/`/g, '``')}\``
+}
+
+/**
+ * Safely quote a (pre-validated) `db.table` / `table` / `` `quoted` `` identifier
+ * so it can be interpolated into SQL. Each component is quoted independently and
+ * internal backticks are escaped. Mirrors `formatQualifiedTable` in the agent
+ * tools.
+ */
+export function quoteTableIdentifier(table: string): string {
+  const t = table.trim()
+  const m = t.match(
+    /^(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_]*)(?:\.\s*(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_]*))?$/
+  )
+  if (!m) return quoteIdent(t)
+  return m[2] ? `${quoteIdent(m[1])}.${quoteIdent(m[2])}` : quoteIdent(m[1])
+}

--- a/apps/dashboard/src/routes/api/v1/actions.ts
+++ b/apps/dashboard/src/routes/api/v1/actions.ts
@@ -13,6 +13,7 @@ import { env } from 'cloudflare:workers'
 import { fetchData } from '@chm/clickhouse-client'
 import { ErrorLogger, log } from '@chm/logger'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { quoteTableIdentifier } from '@/lib/api/shared/sql-identifier'
 import { ACTIONS_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
 import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 
@@ -113,7 +114,7 @@ async function handleOptimizeTable(
   }
 
   const { error } = await fetchData({
-    query: `OPTIMIZE TABLE ${table}`,
+    query: `OPTIMIZE TABLE ${quoteTableIdentifier(table)}`,
     hostId,
   })
 

--- a/apps/dashboard/src/routes/api/v1/explain.ts
+++ b/apps/dashboard/src/routes/api/v1/explain.ts
@@ -140,7 +140,7 @@ async function fetchExplainAsText(
     return {
       error: {
         type: 'query_error',
-        message: `${msg} (host: ${clientConfig.host})`,
+        message: `${msg} (host: ${hostId})`,
       },
     }
   }

--- a/apps/dashboard/src/routes/api/v1/explorer/query.ts
+++ b/apps/dashboard/src/routes/api/v1/explorer/query.ts
@@ -318,13 +318,13 @@ export const Route = createFileRoute('/api/v1/explorer/query')({
         }
 
         const hostId = Number(hostIdParam)
-        if (Number.isNaN(hostId)) {
+        if (!Number.isInteger(hostId) || hostId < 0) {
           return Response.json(
             {
               success: false,
               error: {
                 type: ApiErrorType.ValidationError,
-                message: `Invalid hostId: ${String(hostIdParam)}. Must be a valid number.`,
+                message: `Invalid hostId: ${String(hostIdParam)}. Must be a non-negative integer.`,
               },
             },
             { status: 400 }


### PR DESCRIPTION
Closes #1770.

Three small API hardening fixes (all verified against source):

1. **`actions.ts` — OPTIMIZE TABLE identifier quoting.** Replaced raw `OPTIMIZE TABLE ${table}` interpolation with a new `quoteTableIdentifier()` helper that backtick-quotes each `db`.`table` component and escapes internal backticks (mirrors `formatQualifiedTable` in the agent tools). Extracted to `lib/api/shared/sql-identifier.ts` (dependency-free, unit-testable) to avoid a route → agent-tools import.
2. **`explain.ts` — stop leaking the internal ClickHouse host.** Error messages used `${clientConfig.host}` (the raw `CLICKHOUSE_HOST`); now use the `hostId` integer.
3. **`explorer/query.ts` POST — hostId validation parity.** POST only checked `Number.isNaN`; now rejects fractional/negative like the GET handler and #1760.

## Verification
- `bun run type-check` → exit 0
- New `sql-identifier.test.ts` → 5 pass / 0 fail (covers bare, db.table, pre-quoted, whitespace, and a backtick-escape/injection-attempt case)
- `biome check` clean

https://claude.ai/code/session_01HcF2GhuJfJKVhCmSRFhbZD

## Summary by Sourcery

Harden API input and output handling around ClickHouse host identifiers and table name interpolation.

Bug Fixes:
- Validate explorer POST hostId as a non-negative integer, aligning with GET behavior and preventing invalid host values.
- Stop exposing the internal ClickHouse host URL in explain error responses by returning the numeric hostId instead.

Enhancements:
- Introduce shared SQL identifier helpers to safely quote table/database names and use them for OPTIMIZE TABLE queries to avoid unsafe string interpolation.

Tests:
- Add unit tests for the SQL identifier quoting helpers, covering common forms and edge cases of table identifiers.