### PR TITLE
feat(insights): preview generation with current settings on the settings page

### DIFF
--- a/apps/dashboard/src/components/insights/insights-preview.tsx
+++ b/apps/dashboard/src/components/insights/insights-preview.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+/**
+ * AI Insights settings preview.
+ *
+ * Runs insight generation with the operator's *current* settings (model / prompt
+ * style / enrichment) via an isolated mutation — it never touches the overview
+ * panel's TanStack Query cache, so the settings page acts as a sandbox for
+ * A/B-ing prompt styles and models before relying on them. Results render with
+ * the same `InsightCard` the overview panel uses.
+ */
+
+import { FlaskConical, RefreshCw } from 'lucide-react'
+import { useMutation } from '@tanstack/react-query'
+
+import type { InsightCard as InsightCardData } from '@/lib/insights/types'
+
+import { useState } from 'react'
+import { InsightCard } from '@/components/insights/insight-card'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { generateParamsFromSettings } from '@/lib/insights/settings'
+import { useInsightsSettings } from '@/lib/query/use-insights-settings'
+import { apiFetch } from '@/lib/swr/api-fetch'
+
+interface PreviewResponse {
+  insights: InsightCardData[]
+  count: number
+}
+
+export function InsightsPreview({ hostId }: { hostId: number }) {
+  const { settings } = useInsightsSettings()
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set())
+
+  const preview = useMutation({
+    mutationFn: async (): Promise<PreviewResponse> => {
+      const params = generateParamsFromSettings(hostId, settings)
+      const res = await apiFetch(`/api/v1/insights/generate?${params}`, {
+        method: 'POST',
+      })
+      if (!res.ok) throw new Error('Failed to generate preview')
+      return res.json()
+    },
+    onMutate: () => setDismissed(new Set()),
+  })
+
+  const results = (preview.data?.insights ?? []).filter(
+    (i) => !dismissed.has(i.key)
+  )
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <CardTitle className="flex items-center gap-2">
+              <FlaskConical className="size-4 text-violet-500" />
+              Preview
+            </CardTitle>
+            <CardDescription>
+              Generate insights with the settings above to see their effect.
+              This does not change the overview panel.
+            </CardDescription>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0 gap-1.5"
+            onClick={() => preview.mutate()}
+            disabled={preview.isPending}
+          >
+            <RefreshCw
+              className={
+                preview.isPending ? 'size-3.5 animate-spin' : 'size-3.5'
+              }
+            />
+            {preview.isPending ? 'Generating…' : 'Preview insights'}
+          </Button>
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        {preview.isError ? (
+          <p className="text-sm text-destructive">
+            Could not generate a preview. The cluster may be unreachable or
+            read-only.
+          </p>
+        ) : preview.isSuccess && results.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            No insights for this cluster right now — nothing notable to report.
+          </p>
+        ) : results.length > 0 ? (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {results.map((insight) => (
+              <InsightCard
+                key={insight.key}
+                insight={insight}
+                hostId={hostId}
+                onDismiss={(i) =>
+                  setDismissed((prev) => new Set(prev).add(i.key))
+                }
+              />
+            ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            Click “Preview insights” to run a one-off generation with your
+            current model and prompt style.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/dashboard/src/routes/(dashboard)/insights-settings.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/insights-settings.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft, Sparkles } from 'lucide-react'
 import { createFileRoute } from '@tanstack/react-router'
 
+import { InsightsPreview } from '@/components/insights/insights-preview'
 import { InsightsSettingsForm } from '@/components/insights/insights-settings-form'
 import { AppLink } from '@/components/ui/app-link'
 import { Button } from '@/components/ui/button'
@@ -40,6 +41,7 @@ function InsightsSettingsPage() {
       </div>
 
       <InsightsSettingsForm />
+      <InsightsPreview hostId={hostId} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Polish on the AI Insights settings UX (follows #1767/#1782/#1783): a **Preview** card on `/insights-settings` that runs a one-off generation with the operator's *current* settings, so they can see the effect of a model / prompt-style / enrichment change before relying on it.

## What changed
- **`insights-preview.tsx`** — `InsightsPreview` runs `POST /api/v1/insights/generate` with `generateParamsFromSettings(...)` via an **isolated `useMutation`** that never writes to the overview panel's TanStack Query cache (settings page = sandbox). Renders results with the same `InsightCard` the panel uses; loading / empty / error states handled; per-card dismiss is preview-local.
- **`/insights-settings` route** — renders `<InsightsPreview hostId={hostId} />` under the settings form.

## Notes
- Reuses existing primitives (`generateParamsFromSettings`, `InsightCard`, `apiFetch`) — small surface area.
- No backend changes; uses the generate endpoint shipped in #1767.

https://claude.ai/code/session_01E43HCrarP9fhTHSr9UrKDo

## Summary by Sourcery

Add an AI Insights preview panel to the insights settings page to let operators generate sample insights with their current configuration without affecting the main overview.

New Features:
- Introduce an InsightsPreview component that runs ad-hoc insight generation using the current settings and displays the results in preview-only InsightCards on the settings page.

Enhancements:
- Extend the insights settings route to render the new preview card beneath the settings form for immediate visual feedback on configuration changes.