### PR TITLE
feat(insights): surface enrichment availability + default model in settings

### DIFF
--- a/apps/dashboard/src/components/insights/insights-settings-form.tsx
+++ b/apps/dashboard/src/components/insights/insights-settings-form.tsx
@@ -11,7 +11,8 @@
  * new settings on its next refresh.
  */
 
-import { RotateCcw, Sparkles } from 'lucide-react'
+import { AlertTriangle, RotateCcw, Sparkles } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -43,13 +44,34 @@ import {
 } from '@/lib/insights/prompts'
 import { INSIGHT_WINDOWS } from '@/lib/insights/settings'
 import { useInsightsSettings } from '@/lib/query/use-insights-settings'
+import { apiFetch } from '@/lib/swr/api-fetch'
 import { cn } from '@/lib/utils'
 
 const DEFAULT_MODEL_VALUE = '__default__'
 
+interface InsightsStatus {
+  enrichmentAvailable: boolean
+  defaultModel: string
+}
+
 export function InsightsSettingsForm({ className }: { className?: string }) {
   const { settings, update, reset } = useInsightsSettings()
   const { models } = useAgentModel()
+
+  // Whether LLM enrichment is actually configured on this deployment, so the
+  // "Enhance with AI" toggle doesn't silently no-op on a key-less install.
+  const { data: status } = useQuery<InsightsStatus>({
+    queryKey: ['/api/v1/insights/status'],
+    queryFn: async () => {
+      const res = await apiFetch('/api/v1/insights/status')
+      if (!res.ok) throw new Error('Failed to fetch insights status')
+      return res.json()
+    },
+    staleTime: 5 * 60_000,
+    retry: 1,
+  })
+  const enrichmentUnavailable =
+    settings.enrich && status?.enrichmentAvailable === false
 
   // Group available models by provider for the dropdown.
   const grouped = new Map<string, ModelDisplayInfo[]>()
@@ -94,6 +116,18 @@ export function InsightsSettingsForm({ className }: { className?: string }) {
           />
         </div>
 
+        {enrichmentUnavailable ? (
+          <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-300">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+            <span>
+              No LLM provider is configured on this deployment, so enrichment is
+              unavailable — the original deterministic copy will be shown. Set a
+              provider API key (e.g. <code>OPENROUTER_API_KEY</code>) to enable
+              it.
+            </span>
+          </div>
+        ) : null}
+
         <Separator />
 
         {/* Model */}
@@ -106,7 +140,16 @@ export function InsightsSettingsForm({ className }: { className?: string }) {
           <Label className="text-sm font-medium">Model</Label>
           <p className="text-muted-foreground text-sm">
             Which model writes the insights. “Deployment default” uses the
-            server-configured model.
+            server-configured model
+            {status?.defaultModel ? (
+              <>
+                {' '}
+                (
+                <code className="font-mono text-xs">{status.defaultModel}</code>
+                )
+              </>
+            ) : null}
+            .
           </p>
           <Select
             value={settings.model ?? DEFAULT_MODEL_VALUE}

--- a/apps/dashboard/src/routes/api/v1/insights/status.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/status.ts
@@ -1,0 +1,45 @@
+/**
+ * AI Insights status endpoint — GET /api/v1/insights/status
+ *
+ * Lightweight, no-ClickHouse signal for the settings UI: whether LLM enrichment
+ * is actually available on this deployment (a provider key resolves for the
+ * default model) and which model is the server default. Lets the settings page
+ * tell the operator when "Enhance with AI" will have no effect (no provider key)
+ * rather than silently falling back to deterministic copy.
+ *
+ * Returns only booleans + the default model id — no secrets.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { error, generateRequestId } from '@chm/logger'
+import { DEFAULT_MODEL } from '@/lib/ai/agent/provider-chat-model'
+import { isLlmAvailable } from '@/lib/insights/llm-enrich'
+
+export const Route = createFileRoute('/api/v1/insights/status')({
+  server: {
+    handlers: {
+      GET: async () => {
+        const requestId = generateRequestId()
+        try {
+          return Response.json(
+            {
+              enrichmentAvailable: isLlmAvailable(),
+              defaultModel: DEFAULT_MODEL,
+            },
+            { headers: { 'X-Request-ID': requestId } }
+          )
+        } catch (err) {
+          error('[GET /api/v1/insights/status] Unexpected error:', err, {
+            requestId,
+          })
+          // Degrade to "available unknown → assume on" so the UI never blocks.
+          return Response.json(
+            { enrichmentAvailable: true, defaultModel: '' },
+            { headers: { 'X-Request-ID': requestId } }
+          )
+        }
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Polish on the AI Insights settings UX: make the "Enhance with AI" toggle honest on deployments without an LLM key, and show which model the default resolves to.

## What changed
- **`GET /api/v1/insights/status`** — lightweight endpoint (booleans only, no secrets, no ClickHouse): `enrichmentAvailable` (a provider key resolves for the default model via `isLlmAvailable()`) and `defaultModel`.
- **`insights-settings-form.tsx`** — consumes it to:
  - show an amber note when enrichment is **on** but no LLM provider is configured (so the toggle never silently no-ops on a key-less self-host), and
  - display which model **Deployment default** resolves to.

## Notes
- Independent of #1786 (different files); both land cleanly.
- No new env vars or agent tools, so `ai-agent.mdx` is unaffected.

https://claude.ai/code/session_01E43HCrarP9fhTHSr9UrKDo

## Summary by Sourcery

Expose AI Insights enrichment availability and default model via a new status endpoint and surface this information in the Insights settings UI.

New Features:
- Add GET /api/v1/insights/status endpoint returning enrichment availability and the server default model identifier.
- Show a warning in Insights settings when AI enrichment is enabled but no LLM provider is configured.
- Display the resolved default model identifier next to the "Deployment default" model option in Insights settings.