### PR TITLE
test(agent): cover AGENT_ENABLE_CONTROL_TOOLS control-tool gate

### DIFF
--- a/apps/dashboard/src/lib/ai/agent/tools/__tests__/create-all-tools-gate.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/__tests__/create-all-tools-gate.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for the destructive control-tool gate in createAllTools().
+ *
+ * Control tools (kill_query / optimize_table / kill_mutation) must be exposed to
+ * the LLM ONLY when BOTH the env var AGENT_ENABLE_CONTROL_TOOLS === 'true' AND
+ * the includeControlTools argument are set. A regression in this double gate
+ * would silently hand the agent cluster-mutating tools, so each combination is
+ * asserted explicitly.
+ *
+ * Mirrors mcp-tool-adapter.test.ts setup: mock server-only + @chm/clickhouse-client
+ * (the tools index pulls getClient at module-eval via findings-store).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+mock.module('server-only', () => ({}))
+mock.module('@chm/clickhouse-client', () => ({
+  getClient: async () => ({
+    command: async () => ({}),
+    insert: async () => ({}),
+    query: async () => ({ json: async () => [] }),
+  }),
+  fetchData: async () => ({ data: [], error: null }),
+}))
+
+const { createAllTools } = await import('../index')
+
+const CONTROL_TOOLS = ['kill_query', 'optimize_table', 'kill_mutation'] as const
+
+describe('createAllTools — control-tool gate', () => {
+  const original = process.env.AGENT_ENABLE_CONTROL_TOOLS
+
+  beforeEach(() => {
+    delete process.env.AGENT_ENABLE_CONTROL_TOOLS
+  })
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.AGENT_ENABLE_CONTROL_TOOLS
+    } else {
+      process.env.AGENT_ENABLE_CONTROL_TOOLS = original
+    }
+  })
+
+  test('excludes control tools when includeControlTools=false and env unset', () => {
+    const tools = createAllTools(0, false)
+    for (const name of CONTROL_TOOLS) expect(tools).not.toHaveProperty(name)
+  })
+
+  test('excludes control tools when includeControlTools=true but env unset', () => {
+    const tools = createAllTools(0, true)
+    for (const name of CONTROL_TOOLS) expect(tools).not.toHaveProperty(name)
+  })
+
+  test('includes control tools only when env=true AND includeControlTools=true', () => {
+    process.env.AGENT_ENABLE_CONTROL_TOOLS = 'true'
+    const tools = createAllTools(0, true)
+    for (const name of CONTROL_TOOLS) expect(tools).toHaveProperty(name)
+  })
+
+  test('excludes control tools when env=true but includeControlTools=false (arg takes priority)', () => {
+    process.env.AGENT_ENABLE_CONTROL_TOOLS = 'true'
+    const tools = createAllTools(0, false)
+    for (const name of CONTROL_TOOLS) expect(tools).not.toHaveProperty(name)
+  })
+
+  test('a non-truthy env value does not enable control tools', () => {
+    process.env.AGENT_ENABLE_CONTROL_TOOLS = '1'
+    const tools = createAllTools(0, true)
+    for (const name of CONTROL_TOOLS) expect(tools).not.toHaveProperty(name)
+  })
+
+  test('always exposes baseline (non-control) tools regardless of gate', () => {
+    const tools = createAllTools(0, false)
+    // sanity: schema tool is always present
+    expect(Object.keys(tools).length).toBeGreaterThan(0)
+    expect(tools).toHaveProperty('list_databases')
+  })
+})


### PR DESCRIPTION
Closes #1773.

Adds a dedicated test for the destructive control-tool gate in `createAllTools()`. Control tools (`kill_query` / `optimize_table` / `kill_mutation`) must be exposed to the LLM **only** when BOTH `process.env.AGENT_ENABLE_CONTROL_TOOLS === 'true'` AND the `includeControlTools` argument are set. This double gate was previously untested — a logic inversion would silently expose cluster-mutating tools to the agent.

Covers all combinations:
- `includeControlTools=false`, env unset → excluded
- `includeControlTools=true`, env unset → excluded
- env=`true` + `includeControlTools=true` → included
- env=`true`, `includeControlTools=false` → excluded (arg takes priority)
- non-truthy env (`'1'`) → excluded
- baseline non-control tools always present

Pure test addition, no production code changed. Mirrors `mcp-tool-adapter.test.ts` mock setup (server-only + @chm/clickhouse-client). `bun test` → 6 pass / 0 fail. (Local `type-check` shows pre-existing stale-routeTree errors in the unrelated insights routes; CI regenerates routeTree via build.)

https://claude.ai/code/session_01HcF2GhuJfJKVhCmSRFhbZD

## Summary by Sourcery

Add test coverage for the agent control-tool gating logic in createAllTools().

Tests:
- Add tests to verify control tools are exposed only when both the AGENT_ENABLE_CONTROL_TOOLS env var is 'true' and includeControlTools is enabled.
- Assert that baseline non-control tools remain available regardless of control-tool gate configuration.