### PR TITLE
refactor(clickhouse-client): remove dead query() helper (Workers trap)

### DIFF
--- a/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-fetch.test.ts
+++ b/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-fetch.test.ts
@@ -97,7 +97,6 @@ const {
   __testCountJsonEachRowRows,
   fetchData,
   fetchJsonEachRowAsNormalizedJson,
-  query,
 } = await import(
   new URL('../clickhouse-fetch.ts?test=clickhouse-fetch', import.meta.url).href
 )
@@ -595,54 +594,6 @@ describe('clickhouse-fetch', () => {
       expect(__testCountJsonEachRowRows('\n  \n\t\n')).toBe(0)
       expect(__testCountJsonEachRowRows('{"a":1}\n{"a":2}\n')).toBe(2)
       expect(__testCountJsonEachRowRows('{"a":1}\n\n{"a":2}')).toBe(2)
-    })
-  })
-
-  describe('query helper', () => {
-    it('should execute simple query', async () => {
-      await query('SELECT 1')
-
-      expect(mockCreateClient).toHaveBeenCalled()
-      expect(mockClientQuery).toHaveBeenCalledWith({
-        query: expect.stringContaining('SELECT 1'),
-        format: 'JSON',
-        query_params: {},
-      })
-    })
-
-    it('should accept params', async () => {
-      const params = { param1: 'value1' }
-      await query('SELECT :param1', params)
-
-      expect(mockClientQuery).toHaveBeenCalledWith(
-        expect.objectContaining({
-          query_params: params,
-        })
-      )
-    })
-
-    it('should accept custom format', async () => {
-      await query('SELECT 1', {}, 'CSV')
-
-      expect(mockClientQuery).toHaveBeenCalledWith(
-        expect.objectContaining({
-          format: 'CSV',
-        })
-      )
-    })
-
-    it('should pass web: false to getClient', async () => {
-      await query('SELECT 1')
-
-      expect(mockCreateClient).toHaveBeenCalled()
-      // getClient is called with web: false, which means createClient (not createClientWeb) is used
-      // We verify this by checking mockClientQuery was called (meaning the mock client was used)
-    })
-
-    it('should return resultSet', async () => {
-      const result = await query('SELECT 1')
-
-      expect(result).toBe(mockResultSet)
     })
   })
 })

--- a/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
+++ b/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
@@ -3,7 +3,7 @@
  * Main fetchData function for executing queries with error handling
  */
 
-import type { DataFormat, QueryParams } from '@clickhouse/client'
+import type { QueryParams } from '@clickhouse/client'
 
 import type { QueryConfigLike } from '@chm/sql-builder'
 import type { FetchDataErrorType, FetchDataResult } from './types'
@@ -714,78 +714,4 @@ function countJsonEachRowRows(input: string): number {
 
 export function __testCountJsonEachRowRows(input: string): number {
   return countJsonEachRowRows(input)
-}
-
-/**
- * Simple query helper for basic queries
- */
-export const query = async (
-  query: string,
-  params: Record<string, unknown> = {},
-  format: DataFormat = 'JSON'
-) => {
-  const client = await getClient({
-    web: false,
-    clickhouseSettings: {},
-  })
-  try {
-    const resultSet = await client.query({
-      query: QUERY_COMMENT + query,
-      format,
-      query_params: params,
-    })
-
-    let released = false
-    const releaseOnce = () => {
-      if (!released) {
-        released = true
-        releaseClient({ web: false })
-      }
-    }
-
-    // Intercept data consumption methods to release client after stream is consumed
-    const rs = resultSet as any
-    const originalJson = rs.json
-    const originalText = rs.text
-    const originalStream = rs.stream
-
-    if (typeof originalJson === 'function') {
-      rs.json = async function (this: any, ...args: any[]) {
-        try {
-          return await originalJson.apply(this, args)
-        } finally {
-          releaseOnce()
-        }
-      }
-    }
-
-    if (typeof originalText === 'function') {
-      rs.text = async function (this: any, ...args: any[]) {
-        try {
-          return await originalText.apply(this, args)
-        } finally {
-          releaseOnce()
-        }
-      }
-    }
-
-    if (typeof originalStream === 'function') {
-      rs.stream = function (this: any, ...args: any[]) {
-        const stream = originalStream.apply(this, args)
-        if (stream && typeof stream === 'object') {
-          if (typeof stream.on === 'function') {
-            stream.on('end', () => releaseOnce())
-            stream.on('close', () => releaseOnce())
-            stream.on('error', () => releaseOnce())
-          }
-        }
-        return stream
-      }
-    }
-
-    return resultSet
-  } catch (err) {
-    releaseClient({ web: false })
-    throw err
-  }
 }

--- a/packages/clickhouse-client/src/index.ts
+++ b/packages/clickhouse-client/src/index.ts
@@ -69,13 +69,6 @@ export async function fetchJsonEachRowAsNormalizedJson(
   return fetchJsonEachRowAsNormalizedJson(...args)
 }
 
-export async function query(
-  ...args: Parameters<ClickHouseFetchModule['query']>
-): ReturnType<ClickHouseFetchModule['query']> {
-  const { query } = await loadClickhouseFetchModule()
-  return query(...args)
-}
-
 export {
   cleanupStaleClients,
   getPooledClient,


### PR DESCRIPTION
Part of #1779 (the latent-trap half).

`query()` in `clickhouse-fetch.ts` called `getClient({ web: false })` → the node `@clickhouse/client`, which the dashboard build aliases to a throwing `empty.ts` stub. So it threw unconditionally on the Workers runtime. It had **zero callers** (verified across apps + packages) but was publicly re-exported from the package index, making it a latent trap for any downstream consumer.

Removes:
- the `query()` function (clickhouse-fetch.ts)
- its re-export wrapper (index.ts)
- the now-orphaned `DataFormat` type import
- its obsolete unit tests (clickhouse-fetch.test.ts)

Net −130 lines. Package tests: 215 pass / 0 fail. biome clean.

**Remaining in #1779 (kept open):** part 2 — `fetchJsonEachRowAsNormalizedJson` ignoring `queryConfig.sql` version selection (a separate, medium-confidence footgun; current callers pre-resolve so it's latent).

https://claude.ai/code/session_01HcF2GhuJfJKVhCmSRFhbZD

## Summary by Sourcery

Enhancements:
- Remove the deprecated query() helper from clickhouse-fetch along with its public index re-export and related type import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `query` helper function from the ClickHouse client package's public API exports. This function previously provided a convenient way to execute queries with parameter binding and format selection capabilities.
  * Updated test suites to remove all validation tests and coverage for the removed `query` helper function and its associated functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->