### PR TITLE
feat(insights): redesign settings — templates, icon grid, side-by-side live example

### DIFF
--- a/apps/dashboard/src/components/insights/insights-preview.tsx
+++ b/apps/dashboard/src/components/insights/insights-preview.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 /**
- * AI Insights settings preview.
+ * AI Insights settings example/preview.
  *
  * Runs insight generation with the operator's *current* settings (model / prompt
  * style / enrichment) via an isolated mutation — it never touches the overview
  * panel's TanStack Query cache, so the settings page acts as a sandbox for
- * A/B-ing prompt styles and models before relying on them. Results render with
- * the same `InsightCard` the overview panel uses.
+ * A/B-ing prompt styles and models before relying on them. With `autoRun` it
+ * generates one example on mount so the page shows a live sample immediately.
  */
 
 import { FlaskConical, RefreshCw } from 'lucide-react'
@@ -15,16 +15,11 @@ import { useMutation } from '@tanstack/react-query'
 
 import type { InsightCard as InsightCardData } from '@/lib/insights/types'
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { InsightCard } from '@/components/insights/insight-card'
 import { Button } from '@/components/ui/button'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { generateParamsFromSettings } from '@/lib/insights/settings'
 import { useInsightsSettings } from '@/lib/query/use-insights-settings'
 import { apiFetch } from '@/lib/swr/api-fetch'
@@ -34,7 +29,13 @@ interface PreviewResponse {
   count: number
 }
 
-export function InsightsPreview({ hostId }: { hostId: number }) {
+export function InsightsPreview({
+  hostId,
+  autoRun = false,
+}: {
+  hostId: number
+  autoRun?: boolean
+}) {
   const { settings } = useInsightsSettings()
   const [dismissed, setDismissed] = useState<Set<string>>(new Set())
 
@@ -50,54 +51,59 @@ export function InsightsPreview({ hostId }: { hostId: number }) {
     onMutate: () => setDismissed(new Set()),
   })
 
+  // Generate one example on mount when asked, so the page is never empty.
+  const mutate = preview.mutate
+  const didAutoRun = useRef(false)
+  useEffect(() => {
+    if (autoRun && !didAutoRun.current) {
+      didAutoRun.current = true
+      mutate()
+    }
+  }, [autoRun, mutate])
+
   const results = (preview.data?.insights ?? []).filter(
     (i) => !dismissed.has(i.key)
   )
 
   return (
     <Card>
-      <CardHeader>
-        <div className="flex items-start justify-between gap-3">
-          <div className="space-y-1">
-            <CardTitle className="flex items-center gap-2">
-              <FlaskConical className="size-4 text-violet-500" />
-              Preview
-            </CardTitle>
-            <CardDescription>
-              Generate insights with the settings above to see their effect.
-              This does not change the overview panel.
-            </CardDescription>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="shrink-0 gap-1.5"
-            onClick={() => preview.mutate()}
-            disabled={preview.isPending}
-          >
-            <RefreshCw
-              className={
-                preview.isPending ? 'size-3.5 animate-spin' : 'size-3.5'
-              }
-            />
-            {preview.isPending ? 'Generating…' : 'Preview insights'}
-          </Button>
-        </div>
+      <CardHeader className="flex flex-row items-center justify-between gap-2 space-y-0">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <FlaskConical className="size-4 text-violet-500" />
+          Example
+        </CardTitle>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 shrink-0 gap-1.5 px-2 text-xs"
+          onClick={() => preview.mutate()}
+          disabled={preview.isPending}
+          aria-label="Regenerate example"
+        >
+          <RefreshCw
+            className={preview.isPending ? 'size-3.5 animate-spin' : 'size-3.5'}
+          />
+          {preview.isPending ? 'Generating…' : 'Regenerate'}
+        </Button>
       </CardHeader>
 
       <CardContent>
-        {preview.isError ? (
+        {preview.isPending && results.length === 0 ? (
+          <div className="space-y-3">
+            <Skeleton className="h-24 w-full rounded-lg" />
+            <Skeleton className="h-24 w-full rounded-lg" />
+          </div>
+        ) : preview.isError ? (
           <p className="text-sm text-destructive">
-            Could not generate a preview. The cluster may be unreachable or
-            read-only.
+            Couldn’t generate — the cluster may be unreachable or read-only.
           </p>
         ) : preview.isSuccess && results.length === 0 ? (
-          <p className="text-muted-foreground text-sm">
-            No insights for this cluster right now — nothing notable to report.
+          <p className="text-sm text-muted-foreground">
+            Nothing notable on this cluster right now.
           </p>
         ) : results.length > 0 ? (
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div className="grid grid-cols-1 gap-3">
             {results.map((insight) => (
               <InsightCard
                 key={insight.key}
@@ -110,9 +116,8 @@ export function InsightsPreview({ hostId }: { hostId: number }) {
             ))}
           </div>
         ) : (
-          <p className="text-muted-foreground text-sm">
-            Click “Preview insights” to run a one-off generation with your
-            current model and prompt style.
+          <p className="text-sm text-muted-foreground">
+            Regenerate to preview insights with your current settings.
           </p>
         )}
       </CardContent>

--- a/apps/dashboard/src/components/insights/insights-settings-form.tsx
+++ b/apps/dashboard/src/components/insights/insights-settings-form.tsx
@@ -1,27 +1,31 @@
 'use client'
 
 /**
- * AI Insights settings form.
+ * AI Insights settings form — compact, icon-driven, template-first.
  *
- * Self-contained controls for the per-user insight preferences persisted by
- * `useInsightsSettings`: enrichment on/off, which model enriches, the prompt
- * tone, and the panel's read window. The available model list is read from the
- * same source as the agent model picker (`/api/v1/agents/models`, configured
- * providers only). Changes apply immediately — the overview panel reflects the
- * new settings on its next refresh.
+ * Per-user insight preferences persisted by `useInsightsSettings`: enrichment,
+ * model, prompt tone, and lookback window. Operators can one-click a template
+ * (Quick scan / Deep dive / Learning / Raw) or fine-tune the individual
+ * controls. The available model list comes from the same source as the agent
+ * model picker (configured providers only). Changes apply immediately.
  */
 
-import { AlertTriangle, RotateCcw, Sparkles } from 'lucide-react'
+import {
+  Activity,
+  AlertTriangle,
+  Clock,
+  Cpu,
+  FileText,
+  GraduationCap,
+  type LucideIcon,
+  RotateCcw,
+  Sparkles,
+  Zap,
+} from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 
 import { Button } from '@/components/ui/button'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import {
   Select,
@@ -32,7 +36,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
 import {
   type ModelDisplayInfo,
@@ -40,9 +43,14 @@ import {
 } from '@/lib/hooks/use-agent-model'
 import {
   INSIGHT_PROMPT_STYLES,
-  resolvePromptStyle,
+  type InsightPromptStyle,
 } from '@/lib/insights/prompts'
 import { INSIGHT_WINDOWS } from '@/lib/insights/settings'
+import {
+  INSIGHT_TEMPLATES,
+  type InsightTemplate,
+  matchTemplate,
+} from '@/lib/insights/templates'
 import { useInsightsSettings } from '@/lib/query/use-insights-settings'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { cn } from '@/lib/utils'
@@ -54,12 +62,23 @@ interface InsightsStatus {
   defaultModel: string
 }
 
+const TEMPLATE_ICONS: Record<InsightTemplate['icon'], LucideIcon> = {
+  Zap,
+  FileText,
+  GraduationCap,
+  Activity,
+}
+
+const STYLE_ICONS: Record<InsightPromptStyle, LucideIcon> = {
+  concise: Zap,
+  detailed: FileText,
+  beginner: GraduationCap,
+}
+
 export function InsightsSettingsForm({ className }: { className?: string }) {
   const { settings, update, reset } = useInsightsSettings()
   const { models } = useAgentModel()
 
-  // Whether LLM enrichment is actually configured on this deployment, so the
-  // "Enhance with AI" toggle doesn't silently no-op on a key-less install.
   const { data: status } = useQuery<InsightsStatus>({
     queryKey: ['/api/v1/insights/status'],
     queryFn: async () => {
@@ -73,7 +92,6 @@ export function InsightsSettingsForm({ className }: { className?: string }) {
   const enrichmentUnavailable =
     settings.enrich && status?.enrichmentAvailable === false
 
-  // Group available models by provider for the dropdown.
   const grouped = new Map<string, ModelDisplayInfo[]>()
   for (const m of models) {
     const list = grouped.get(m.provider) ?? []
@@ -81,33 +99,68 @@ export function InsightsSettingsForm({ className }: { className?: string }) {
     grouped.set(m.provider, list)
   }
 
-  const enrichDisabled = !settings.enrich
-  const activeStyle = resolvePromptStyle(settings.promptStyle)
+  const off = !settings.enrich
+  const activeTemplate = matchTemplate(settings)
 
   return (
     <Card className={cn(className)}>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Sparkles className="size-4 text-sky-500" />
-          AI Insights
-        </CardTitle>
-        <CardDescription>
-          Tune how cluster insights are generated and how far back the overview
-          panel looks. Settings are stored in this browser.
-        </CardDescription>
-      </CardHeader>
+      <CardContent className="space-y-5 pt-6">
+        {/* Templates — pick a vibe in one click */}
+        <div className="space-y-2">
+          <Label className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+            Templates
+          </Label>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+            {INSIGHT_TEMPLATES.map((t) => {
+              const Icon = TEMPLATE_ICONS[t.icon]
+              const active = activeTemplate === t.id
+              return (
+                <button
+                  key={t.id}
+                  type="button"
+                  onClick={() => update(t.settings)}
+                  aria-pressed={active}
+                  className={cn(
+                    'flex flex-col items-start gap-1 rounded-lg border p-2.5 text-left transition-colors',
+                    active
+                      ? 'border-sky-500/50 bg-sky-500/10'
+                      : 'border-border hover:bg-muted/50'
+                  )}
+                >
+                  <Icon
+                    className={cn(
+                      'size-4',
+                      active
+                        ? 'text-sky-600 dark:text-sky-400'
+                        : 'text-muted-foreground'
+                    )}
+                  />
+                  <span className="text-sm font-medium leading-none">
+                    {t.label}
+                  </span>
+                  <span className="text-[11px] text-muted-foreground">
+                    {t.hint}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
 
-      <CardContent className="space-y-6">
-        {/* Enrichment toggle */}
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1">
-            <Label htmlFor="insights-enrich" className="text-sm font-medium">
-              Enhance with AI
-            </Label>
-            <p className="text-muted-foreground text-sm">
-              Rewrite raw monitoring signals into clearer, actionable insights.
-              When off, the original deterministic copy is shown.
-            </p>
+        {/* Enhance with AI */}
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-border p-3">
+          <div className="flex items-center gap-2.5">
+            <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-sky-500/10">
+              <Sparkles className="size-4 text-sky-500" />
+            </span>
+            <div className="leading-tight">
+              <Label htmlFor="insights-enrich" className="text-sm font-medium">
+                Enhance with AI
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Rewrite signals into clear, actionable insights.
+              </p>
+            </div>
           </div>
           <Switch
             id="insights-enrich"
@@ -117,142 +170,140 @@ export function InsightsSettingsForm({ className }: { className?: string }) {
         </div>
 
         {enrichmentUnavailable ? (
-          <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-300">
-            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+          <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+            <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
             <span>
-              No LLM provider is configured on this deployment, so enrichment is
-              unavailable — the original deterministic copy will be shown. Set a
-              provider API key (e.g. <code>OPENROUTER_API_KEY</code>) to enable
-              it.
+              No LLM provider configured — deterministic copy will be shown. Set
+              a provider key (e.g. <code>OPENROUTER_API_KEY</code>).
             </span>
           </div>
         ) : null}
 
-        <Separator />
-
-        {/* Model */}
+        {/* Prompt style — segmented icon control */}
         <div
-          className={cn(
-            'space-y-2 transition-opacity',
-            enrichDisabled && 'pointer-events-none opacity-50'
-          )}
+          className={cn('space-y-2', off && 'pointer-events-none opacity-50')}
         >
-          <Label className="text-sm font-medium">Model</Label>
-          <p className="text-muted-foreground text-sm">
-            Which model writes the insights. “Deployment default” uses the
-            server-configured model
-            {status?.defaultModel ? (
-              <>
-                {' '}
-                (
-                <code className="font-mono text-xs">{status.defaultModel}</code>
-                )
-              </>
-            ) : null}
-            .
-          </p>
-          <Select
-            value={settings.model ?? DEFAULT_MODEL_VALUE}
-            onValueChange={(value) =>
-              update({ model: value === DEFAULT_MODEL_VALUE ? null : value })
-            }
-            disabled={enrichDisabled}
-          >
-            <SelectTrigger className="w-full max-w-md">
-              <SelectValue placeholder="Deployment default" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={DEFAULT_MODEL_VALUE}>
-                Deployment default
-              </SelectItem>
-              {Array.from(grouped.entries()).map(([provider, list]) => (
-                <SelectGroup key={provider}>
-                  <SelectLabel className="capitalize">{provider}</SelectLabel>
-                  {list.map((m) => (
-                    <SelectItem key={m.id} value={m.id}>
-                      <span className="font-mono text-xs">{m.name}</span>
-                      {m.isFree ? (
-                        <span className="text-emerald-600 dark:text-emerald-400">
-                          {' '}
-                          · free
-                        </span>
-                      ) : null}
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
-              ))}
-            </SelectContent>
-          </Select>
+          <Label className="flex items-center gap-1.5 text-sm font-medium">
+            <FileText className="size-3.5 text-muted-foreground" />
+            Prompt style
+          </Label>
+          <div className="grid grid-cols-3 gap-2">
+            {INSIGHT_PROMPT_STYLES.map((s) => {
+              const Icon = STYLE_ICONS[s.id]
+              const active = settings.promptStyle === s.id
+              return (
+                <button
+                  key={s.id}
+                  type="button"
+                  disabled={off}
+                  onClick={() => update({ promptStyle: s.id })}
+                  aria-pressed={active}
+                  className={cn(
+                    'flex flex-col items-center gap-1 rounded-lg border px-2 py-2.5 text-center transition-colors',
+                    active
+                      ? 'border-sky-500/50 bg-sky-500/10'
+                      : 'border-border hover:bg-muted/50'
+                  )}
+                >
+                  <Icon
+                    className={cn(
+                      'size-4',
+                      active
+                        ? 'text-sky-600 dark:text-sky-400'
+                        : 'text-muted-foreground'
+                    )}
+                  />
+                  <span className="text-xs font-medium">{s.label}</span>
+                </button>
+              )
+            })}
+          </div>
         </div>
 
-        {/* Prompt style */}
-        <div
-          className={cn(
-            'space-y-2 transition-opacity',
-            enrichDisabled && 'pointer-events-none opacity-50'
-          )}
-        >
-          <Label className="text-sm font-medium">Prompt style</Label>
-          <p className="text-muted-foreground text-sm">
-            {activeStyle.description}
-          </p>
-          <Select
-            value={settings.promptStyle}
-            onValueChange={(value) =>
-              update({ promptStyle: value as typeof settings.promptStyle })
-            }
-            disabled={enrichDisabled}
+        {/* Model + Window — 2-col grid */}
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div
+            className={cn(
+              'space-y-1.5',
+              off && 'pointer-events-none opacity-50'
+            )}
           >
-            <SelectTrigger className="w-full max-w-md">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {INSIGHT_PROMPT_STYLES.map((style) => (
-                <SelectItem key={style.id} value={style.id}>
-                  {style.label}
+            <Label className="flex items-center gap-1.5 text-sm font-medium">
+              <Cpu className="size-3.5 text-muted-foreground" />
+              Model
+            </Label>
+            <Select
+              value={settings.model ?? DEFAULT_MODEL_VALUE}
+              onValueChange={(value) =>
+                update({ model: value === DEFAULT_MODEL_VALUE ? null : value })
+              }
+              disabled={off}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Default" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={DEFAULT_MODEL_VALUE}>
+                  Default
+                  {status?.defaultModel ? (
+                    <span className="ml-1 font-mono text-[10px] text-muted-foreground">
+                      {status.defaultModel}
+                    </span>
+                  ) : null}
                 </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+                {Array.from(grouped.entries()).map(([provider, list]) => (
+                  <SelectGroup key={provider}>
+                    <SelectLabel className="capitalize">{provider}</SelectLabel>
+                    {list.map((m) => (
+                      <SelectItem key={m.id} value={m.id}>
+                        <span className="font-mono text-xs">{m.name}</span>
+                        {m.isFree ? (
+                          <span className="text-emerald-600 dark:text-emerald-400">
+                            {' '}
+                            · free
+                          </span>
+                        ) : null}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label className="flex items-center gap-1.5 text-sm font-medium">
+              <Clock className="size-3.5 text-muted-foreground" />
+              Lookback
+            </Label>
+            <Select
+              value={settings.window}
+              onValueChange={(value) => update({ window: value })}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {INSIGHT_WINDOWS.map((w) => (
+                  <SelectItem key={w.value} value={w.value}>
+                    {w.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
         </div>
-
-        <Separator />
-
-        {/* Read window */}
-        <div className="space-y-2">
-          <Label className="text-sm font-medium">Lookback window</Label>
-          <p className="text-muted-foreground text-sm">
-            How far back the overview panel reads insights before they age out.
-          </p>
-          <Select
-            value={settings.window}
-            onValueChange={(value) => update({ window: value })}
-          >
-            <SelectTrigger className="w-full max-w-md">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {INSIGHT_WINDOWS.map((w) => (
-                <SelectItem key={w.value} value={w.value}>
-                  {w.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <Separator />
 
         <div className="flex justify-end">
           <Button
             type="button"
             variant="ghost"
             size="sm"
-            className="gap-1.5 text-muted-foreground"
+            className="h-7 gap-1.5 text-xs text-muted-foreground"
             onClick={reset}
           >
-            <RotateCcw className="size-3.5" />
-            Reset to defaults
+            <RotateCcw className="size-3" />
+            Reset
           </Button>
         </div>
       </CardContent>

--- a/apps/dashboard/src/lib/insights/templates.test.ts
+++ b/apps/dashboard/src/lib/insights/templates.test.ts
@@ -1,0 +1,39 @@
+import { DEFAULT_INSIGHTS_SETTINGS } from './settings'
+import { INSIGHT_TEMPLATES, matchTemplate } from './templates'
+import { describe, expect, it } from 'bun:test'
+
+describe('insight templates', () => {
+  it('exposes the four expected presets with unique ids', () => {
+    const ids = INSIGHT_TEMPLATES.map((t) => t.id)
+    expect(ids).toEqual(['quick', 'deep', 'learn', 'raw'])
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('every template carries a model-agnostic (null) model', () => {
+    for (const t of INSIGHT_TEMPLATES) expect(t.settings.model).toBeNull()
+  })
+
+  it('matchTemplate round-trips each template bundle', () => {
+    for (const t of INSIGHT_TEMPLATES) {
+      expect(
+        matchTemplate({ ...DEFAULT_INSIGHTS_SETTINGS, ...t.settings })
+      ).toBe(t.id)
+    }
+  })
+
+  it('returns null for a custom combination', () => {
+    expect(
+      matchTemplate({
+        enrich: true,
+        promptStyle: 'detailed',
+        model: 'openrouter:qwen/qwen3-coder:free',
+        window: '7 DAY',
+      })
+    ).toBeNull()
+  })
+
+  it('default settings map to the Quick scan template', () => {
+    // DEFAULT = concise + enrich + 6 HOUR + null model → matches "quick".
+    expect(matchTemplate(DEFAULT_INSIGHTS_SETTINGS)).toBe('quick')
+  })
+})

--- a/apps/dashboard/src/lib/insights/templates.ts
+++ b/apps/dashboard/src/lib/insights/templates.ts
@@ -1,0 +1,96 @@
+/**
+ * AI Insights setting templates.
+ *
+ * One-click preset bundles that set enrichment + prompt style + window together,
+ * so operators can "pick a vibe" instead of tuning each control. Templates keep
+ * `model: null` (deployment default) so they work on any provider config. Pure
+ * module — the settings UI maps these to icons.
+ */
+
+import type { InsightsSettings } from './settings'
+
+export type InsightTemplateId = 'quick' | 'deep' | 'learn' | 'raw'
+
+export interface InsightTemplate {
+  readonly id: InsightTemplateId
+  readonly label: string
+  /** lucide-react icon name, resolved in the UI. */
+  readonly icon: 'Zap' | 'FileText' | 'GraduationCap' | 'Activity'
+  /** Short, scannable hint (<= ~24 chars). */
+  readonly hint: string
+  readonly settings: Pick<
+    InsightsSettings,
+    'enrich' | 'promptStyle' | 'model' | 'window'
+  >
+}
+
+export const INSIGHT_TEMPLATES: readonly InsightTemplate[] = [
+  {
+    id: 'quick',
+    label: 'Quick scan',
+    icon: 'Zap',
+    hint: 'Terse one-liners',
+    settings: {
+      enrich: true,
+      promptStyle: 'concise',
+      model: null,
+      window: '6 HOUR',
+    },
+  },
+  {
+    id: 'deep',
+    label: 'Deep dive',
+    icon: 'FileText',
+    hint: 'Root cause + fix',
+    settings: {
+      enrich: true,
+      promptStyle: 'detailed',
+      model: null,
+      window: '24 HOUR',
+    },
+  },
+  {
+    id: 'learn',
+    label: 'Learning',
+    icon: 'GraduationCap',
+    hint: 'Plain language',
+    settings: {
+      enrich: true,
+      promptStyle: 'beginner',
+      model: null,
+      window: '24 HOUR',
+    },
+  },
+  {
+    id: 'raw',
+    label: 'Raw signals',
+    icon: 'Activity',
+    hint: 'No AI, fastest',
+    settings: {
+      enrich: false,
+      promptStyle: 'concise',
+      model: null,
+      window: '6 HOUR',
+    },
+  },
+] as const
+
+/**
+ * The template whose bundle matches the current settings exactly, or null when
+ * the user has a custom combination. Used to highlight the active template.
+ */
+export function matchTemplate(
+  settings: Pick<
+    InsightsSettings,
+    'enrich' | 'promptStyle' | 'model' | 'window'
+  >
+): InsightTemplateId | null {
+  const found = INSIGHT_TEMPLATES.find(
+    (t) =>
+      t.settings.enrich === settings.enrich &&
+      t.settings.promptStyle === settings.promptStyle &&
+      t.settings.model === settings.model &&
+      t.settings.window === settings.window
+  )
+  return found?.id ?? null
+}

--- a/apps/dashboard/src/routes/(dashboard)/insights-settings.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/insights-settings.tsx
@@ -12,7 +12,7 @@ function InsightsSettingsPage() {
   const hostId = useHostId()
 
   return (
-    <div className="mx-auto max-w-3xl space-y-6 py-8">
+    <div className="mx-auto max-w-5xl space-y-6 py-8">
       <div className="space-y-3">
         <Button
           variant="ghost"
@@ -40,8 +40,13 @@ function InsightsSettingsPage() {
         </div>
       </div>
 
-      <InsightsSettingsForm />
-      <InsightsPreview hostId={hostId} />
+      {/* Settings left, live example right — stacks on mobile. */}
+      <div className="grid gap-5 lg:grid-cols-[1fr_minmax(320px,380px)]">
+        <InsightsSettingsForm />
+        <div className="lg:sticky lg:top-6 lg:self-start">
+          <InsightsPreview hostId={hostId} autoRun />
+        </div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Redesign of `/insights-settings` per feedback: **less text, icon-driven, grid layout, templates, an example on the page, side-by-side, better responsive.**

## What changed
- **Templates** (`lib/insights/templates.ts`, + tests) — one-click presets **Quick scan / Deep dive / Learning / Raw** that bundle enrich + prompt style + window. The active preset (matching current settings) is highlighted.
- **Compact icon controls** — enrichment as an icon row; **prompt style as a segmented 3-icon control** (Zap / FileText / GraduationCap); **model + lookback as a 2-column icon-labelled grid**. Verbose paragraphs trimmed to short hints.
- **Side-by-side layout** — settings left, a live **Example** panel right (sticky on desktop, stacks on mobile). The Example **auto-generates once on mount** (isolated mutation, never touches the overview panel) with a skeleton loading state, so the page shows a real sample immediately.

## Tests
`bun test src/lib/insights/templates.test.ts` → 5 pass (preset integrity, `matchTemplate` round-trip, defaults → "quick").

## Verify
Will Chrome-verify on production after deploy (settings page is auth-light, route already verified at 200).

https://claude.ai/code/session_01E43HCrarP9fhTHSr9UrKDo

## Summary by Sourcery

Redesign the Insights settings page with template-based presets, icon-driven controls, and a side-by-side live example preview.

New Features:
- Introduce reusable AI Insights setting templates that bundle enrichment, prompt style, model default, and lookback window selections.
- Add an auto-run option to the insights preview component to generate a sample on mount.
- Display a live Insights example panel alongside settings on the Insights settings page.

Enhancements:
- Refine the Insights settings form UI with compact, icon-based controls for enrichment, prompt style, model selection, and lookback window.
- Improve the Insights preview card with updated copy, a lighter regenerate action, and a simplified single-column layout.
- Make the Insights settings layout wider and responsive with a grid that keeps the example panel sticky on desktop.

Tests:
- Add unit tests to validate insight templates and template matching behavior.