### PR TITLE
fix(agent-api): gate unconditional debug logs behind AGENT_DEBUG_LOGS

### DIFF
--- a/apps/dashboard/src/routes/api/v1/agent.ts
+++ b/apps/dashboard/src/routes/api/v1/agent.ts
@@ -586,12 +586,14 @@ async function handlePost(request: Request): Promise<Response> {
               (inputTokenDetails.cacheReadTokens ||
                 inputTokenDetails.cacheWriteTokens)
             ) {
-              console.log('[Agent API] Cache token stats:', {
-                cacheReadTokens: inputTokenDetails.cacheReadTokens,
-                cacheWriteTokens: inputTokenDetails.cacheWriteTokens,
-                inputTokens: step.usage.inputTokens,
-                outputTokens: step.usage.outputTokens,
-              })
+              if (AGENT_DEBUG_LOGS) {
+                console.log('[Agent API] Cache token stats:', {
+                  cacheReadTokens: inputTokenDetails.cacheReadTokens,
+                  cacheWriteTokens: inputTokenDetails.cacheWriteTokens,
+                  inputTokens: step.usage.inputTokens,
+                  outputTokens: step.usage.outputTokens,
+                })
+              }
             }
           },
           timeout: {
@@ -670,7 +672,7 @@ async function handlePost(request: Request): Promise<Response> {
       return JSON.stringify(classified)
     },
     onFinish: () => {
-      if (usageSteps.length > 0) {
+      if (AGENT_DEBUG_LOGS && usageSteps.length > 0) {
         const stats = {
           ...aggregateUsageWithCost(usageSteps, model),
           model,


### PR DESCRIPTION
Part of #1776 (item 4).

`Cache token stats` (agent.ts:589) and `Session usage` (agent.ts:682) `console.log`s fired on **every** agent request in production (Cloudflare Workers log stream), leaking token counts/cost stats. Both are now gated behind the existing `AGENT_DEBUG_LOGS` flag (the pattern already used at lines 333/464/537). The Session-usage `stats` object is now only computed when logging is enabled.

(Correcting an earlier over-broad read in #1776: lines 465/538-539 were already gated; only these two were not.)

Verified: biome clean; type-check shows only the unrelated pre-existing stale-routeTree errors in the insights routes (CI regenerates routeTree via build).

https://claude.ai/code/session_01HcF2GhuJfJKVhCmSRFhbZD

## Summary by Sourcery

Gate noisy agent API usage and cache token debug logs behind the AGENT_DEBUG_LOGS flag to avoid unconditional logging in production.

Bug Fixes:
- Stop always logging cache token stats on every agent request by guarding logs with the AGENT_DEBUG_LOGS flag.
- Stop always logging session usage stats by computing and printing them only when AGENT_DEBUG_LOGS is enabled.