### PR TITLE
fix(insights): render generated insights immediately, independent of persistence

### DIFF
--- a/apps/dashboard/src/lib/query/use-insights.ts
+++ b/apps/dashboard/src/lib/query/use-insights.ts
@@ -14,7 +14,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import type { InsightCard } from '@/lib/insights/types'
 
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import {
   dismissAllInsights,
   dismissInsight,
@@ -74,8 +74,16 @@ export function useInsights(hostId: number): UseInsightsResult {
     [queryClient, queryKey]
   )
 
+  // Insights returned by the most recent manual generate(). The persisted read
+  // (findings store) is best-effort and silently no-ops on read-only clusters,
+  // so we render what `generate` just produced directly — otherwise a successful
+  // generation would show nothing when persistence is unavailable.
+  const [sessionInsights, setSessionInsights] = useState<
+    readonly InsightCard[]
+  >([])
+
   const generateMutation = useMutation({
-    mutationFn: async () => {
+    mutationFn: async (): Promise<InsightsResponse> => {
       const params = generateParamsFromSettings(hostId, settings)
       const res = await apiFetch(`/api/v1/insights/generate?${params}`, {
         method: 'POST',
@@ -83,11 +91,22 @@ export function useInsights(hostId: number): UseInsightsResult {
       if (!res.ok) throw new Error('Failed to generate insights')
       return res.json()
     },
-    onSuccess: invalidate,
+    onSuccess: (result) => {
+      setSessionInsights(result?.insights ?? [])
+      invalidate()
+    },
   })
 
-  // Filter dismissed cards (localStorage).
-  const insights = filterActiveInsights(data?.insights ?? [])
+  // Merge persisted (read) + freshly generated (session); de-dupe by stable key
+  // with the just-generated copy winning. Then drop user-dismissed cards.
+  const merged = useMemo(() => {
+    const byKey = new Map<string, InsightCard>()
+    for (const i of data?.insights ?? []) byKey.set(i.key, i)
+    for (const i of sessionInsights) byKey.set(i.key, i)
+    return Array.from(byKey.values())
+  }, [data, sessionInsights])
+
+  const insights = filterActiveInsights(merged)
 
   const counts = insights.reduce(
     (acc, i) => {
@@ -107,6 +126,7 @@ export function useInsights(hostId: number): UseInsightsResult {
 
   const dismissAll = useCallback(() => {
     dismissAllInsights(insights)
+    setSessionInsights([])
     invalidate()
   }, [insights, invalidate])
 


### PR DESCRIPTION
## Problem (repro on prod)

On `/overview`, clicking **Generate insights** returns `200` with a real insight, but the panel **stays empty** — "not working". Verified live:

```
POST /api/v1/insights/generate?host=0  → 200  {"insights":[{…"318 active parts"…}],"count":1}
GET  /api/v1/insights?host=0&since=…   → 200  {"insights":[],"count":0}   ← empty
```

## Root cause

The panel + header popover render **only** what's read back from the findings store (`GET /api/v1/insights`). That store is **best-effort** and silently no-ops when the ClickHouse connection is read-only (the normal monitoring setup) or the app-owned `monitoring_findings` table can't be created. So generation succeeds but nothing is ever persisted/read back. The settings-page **Preview** worked only because it renders the generate response directly.

## Fix

`useInsights` now merges the `generate()` response into the displayed set (de-duped by stable key, freshly generated wins). Generation always populates the panel/popover regardless of persistence; the periodic read still layers in cron-persisted insights when the store is writable. `dismissAll` clears the session set too.

## Tests
`bun test src/lib/insights/` → 29 pass. Will re-verify on prod after deploy (generate → panel shows the card).

## Note
Cross-reload / cron persistence still requires a writable findings table (writable CH user + a non-`system` `CLICKHOUSE_DATABASE`). This PR makes the on-demand UX correct regardless; persistence is a separate infra concern.

https://claude.ai/code/session_01E43HCrarP9fhTHSr9UrKDo

## Summary by Sourcery

Ensure generated insights appear immediately in the overview UI regardless of backend persistence availability.

New Features:
- Display newly generated insights directly from the generate API response in the insights panel and header popover.

Bug Fixes:
- Fix insights panel staying empty after a successful generate call when the findings store cannot persist or read insights.

Enhancements:
- Merge persisted insights with session-only generated insights, de-duplicating by stable key and preferring the most recently generated version.
- Clear session-scoped insights when dismissing all insights so the panel state resets consistently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Freshly generated insights now appear immediately instead of waiting for synchronization
  * Dismissed insights remain removed and no longer reappear after generating new insights
  * Improved handling of duplicate insight cards to prevent redundant displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->