### PR TITLE
test(agent): cover get_replication_status (params + hostId routing)

### DIFF
--- a/apps/dashboard/src/lib/ai/agent/tools/__tests__/replication-tools.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/__tests__/replication-tools.test.ts
@@ -1,0 +1,73 @@
+import { mockFetchData } from './shared-mocks'
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+const { createReplicationTools } = await import('../replication-tools')
+
+/**
+ * Captures the params passed to the (mocked) fetchData so we can assert on the
+ * query, query_params, and resolved hostId without a live ClickHouse.
+ */
+function captureFetch(rows: unknown[] = []) {
+  const calls: Array<Record<string, unknown>> = []
+  mockFetchData.mockImplementation(async (params: Record<string, unknown>) => {
+    calls.push(params)
+    return { data: rows, error: null }
+  })
+  return calls
+}
+
+describe('createReplicationTools', () => {
+  beforeEach(() => {
+    mockFetchData.mockReset()
+  })
+
+  test('exposes get_replication_status', () => {
+    const tools = createReplicationTools(0) as any
+    expect(tools.get_replication_status).toBeDefined()
+  })
+
+  test('default call targets system.replicas with no database filter', async () => {
+    const calls = captureFetch()
+    const tools = createReplicationTools(0) as any
+    await tools.get_replication_status.execute({})
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].query).toContain('system.replicas')
+    expect(calls[0].query_params).toEqual({ database: '' })
+  })
+
+  test('passes the database filter through to query_params', async () => {
+    const calls = captureFetch()
+    const tools = createReplicationTools(0) as any
+    await tools.get_replication_status.execute({ database: 'analytics' })
+
+    expect(calls[0].query_params).toEqual({ database: 'analytics' })
+  })
+
+  test('uses the factory hostId when no override is given', async () => {
+    const calls = captureFetch()
+    const tools = createReplicationTools(3) as any
+    await tools.get_replication_status.execute({})
+
+    expect(calls[0].hostId).toBe(3)
+  })
+
+  test('routes to the hostId override when provided (not the factory host)', async () => {
+    const calls = captureFetch()
+    const tools = createReplicationTools(3) as any
+    await tools.get_replication_status.execute({ hostId: 7 })
+
+    expect(calls[0].hostId).toBe(7)
+  })
+
+  test('returns the raw rows from the query result', async () => {
+    const rows = [
+      { database: 'db', table: 't', absolute_delay: 5, queue_size: 2 },
+    ]
+    captureFetch(rows)
+    const tools = createReplicationTools(0) as any
+    const result = await tools.get_replication_status.execute({})
+
+    expect(result).toEqual(rows)
+  })
+})


### PR DESCRIPTION
Part of #1774 (module 1 of 4).

Adds execute-level tests for `replication-tools.ts`'s `get_replication_status`, which previously had no coverage beyond an "is defined" assertion:
- default call → `query_params: { database: '' }` (all databases), targets `system.replicas`
- `database` filter passes through to `query_params`
- factory `hostId` used when no override
- `hostId` override routes to the override host (not the factory host)
- raw query rows returned unwrapped

Pure test addition (mirrors the `shared-mocks` pattern). `bun test` → 6 pass / 0 fail; biome clean.

Remaining #1774 modules (separate PRs): resolveStore branches, MemoryStore, dynamic-loader.

https://claude.ai/code/session_01HcF2GhuJfJKVhCmSRFhbZD

## Summary by Sourcery

Add execute-level tests for the get_replication_status tool in replication-tools to cover query parameters, host routing, and result handling.

Tests:
- Add tests ensuring the default get_replication_status call targets system.replicas with no database filter.
- Add tests verifying database filters are passed through to query_params for get_replication_status.
- Add tests confirming factory hostId is used by default and can be overridden per call for get_replication_status.
- Add tests ensuring get_replication_status returns raw query rows from the underlying fetch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for replication tool functionality with comprehensive test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->