### PR TITLE
test(agent): cover dynamic skill loader (parseFrontmatter + priority)

### DIFF
--- a/apps/dashboard/src/lib/ai/agent/skills/__tests__/dynamic-loader.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/skills/__tests__/dynamic-loader.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the dynamic skill loader.
+ *
+ * Focuses on the deterministic, high-risk logic:
+ *  - parseFrontmatter(): a broken parser silently drops user skills, so each
+ *    null-returning branch and the quote-stripping are asserted.
+ *  - registerSkill()/getAllSkills(): runtime skills must override builtin skills
+ *    of the same name (priority: runtime > user > builtin).
+ *
+ * loadDynamicSkills() reads the real filesystem (process.cwd()/.agents/skills),
+ * so it is exercised only indirectly via parseFrontmatter; we avoid a global
+ * node:fs mock that would leak across bun's shared test process.
+ */
+
+import {
+  getAllSkills,
+  parseFrontmatter,
+  registerSkill,
+} from '../dynamic-loader'
+import { describe, expect, test } from 'bun:test'
+
+describe('parseFrontmatter', () => {
+  test('parses name, description, and body from valid frontmatter', () => {
+    const parsed = parseFrontmatter(
+      '---\nname: my-skill\ndescription: does a thing\n---\nbody text here'
+    )
+    expect(parsed).toEqual({
+      name: 'my-skill',
+      description: 'does a thing',
+      body: 'body text here',
+    })
+  })
+
+  test('returns null when there is no frontmatter block', () => {
+    expect(parseFrontmatter('just some text, no dashes')).toBeNull()
+  })
+
+  test('returns null when name is missing', () => {
+    expect(
+      parseFrontmatter('---\ndescription: only a description\n---\nbody')
+    ).toBeNull()
+  })
+
+  test('returns null when description is missing', () => {
+    expect(parseFrontmatter('---\nname: only-a-name\n---\nbody')).toBeNull()
+  })
+
+  test('strips surrounding single and double quotes from values', () => {
+    const parsed = parseFrontmatter(
+      `---\nname: "quoted-name"\ndescription: 'quoted desc'\n---\nbody`
+    )
+    expect(parsed?.name).toBe('quoted-name')
+    expect(parsed?.description).toBe('quoted desc')
+  })
+
+  test('handles CRLF line endings', () => {
+    const parsed = parseFrontmatter(
+      '---\r\nname: crlf-skill\r\ndescription: windows\r\n---\r\nbody'
+    )
+    expect(parsed?.name).toBe('crlf-skill')
+    expect(parsed?.body).toBe('body')
+  })
+})
+
+describe('registerSkill / getAllSkills priority', () => {
+  test('a runtime-registered skill appears in getAllSkills tagged remote', () => {
+    const unique = `test-skill-${'x'.repeat(3)}-unique`
+    registerSkill({
+      name: unique,
+      description: 'a runtime skill',
+      content: 'runtime body',
+    })
+
+    const found = getAllSkills().find((s) => s.name === unique)
+    expect(found).toBeDefined()
+    expect(found?.source).toBe('remote')
+    expect(found?.content).toBe('runtime body')
+  })
+
+  test('a runtime skill overrides a builtin skill of the same name', () => {
+    registerSkill({
+      name: 'replication-guide', // an existing builtin skill name
+      description: 'overridden at runtime',
+      content: 'override body',
+      source: 'remote',
+    })
+
+    const matches = getAllSkills().filter((s) => s.name === 'replication-guide')
+    // Merged by name — exactly one entry, and it is the runtime override.
+    expect(matches).toHaveLength(1)
+    expect(matches[0].description).toBe('overridden at runtime')
+    expect(matches[0].source).toBe('remote')
+  })
+})

--- a/apps/dashboard/src/lib/ai/agent/skills/dynamic-loader.ts
+++ b/apps/dashboard/src/lib/ai/agent/skills/dynamic-loader.ts
@@ -22,7 +22,7 @@ const runtimeSkills: Map<string, Skill> = new Map()
  * Parse name, description, and body from a SKILL.md file.
  * Matches the pattern used in scripts/build-skills-registry.ts.
  */
-function parseFrontmatter(raw: string): {
+export function parseFrontmatter(raw: string): {
   name: string
   description: string
   body: string


### PR DESCRIPTION
Closes #1774 (final module, 4 of 4).

Covers the high-risk logic in `dynamic-loader.ts`:
- `parseFrontmatter`: valid parse, no-frontmatter→null, missing-name→null, missing-description→null, single/double quote stripping, CRLF line endings. (A broken parser silently drops user skills.)
- `registerSkill`/`getAllSkills`: a runtime skill appears tagged `remote`, and **overrides a builtin skill of the same name** (priority runtime > user > builtin, one merged entry).

`parseFrontmatter` is exported for testing (was module-internal). `loadDynamicSkills` reads the real filesystem, so it's exercised indirectly via `parseFrontmatter` rather than with a global `node:fs` mock (which would leak across bun's shared process). `bun test` → 8 pass / 0 fail; biome clean.

With this, **#1774 is fully covered**: replication-tools (#1793), resolveStore branches (#1794), MemoryStore (#1795), and dynamic-loader (this).

https://claude.ai/code/session_01HcF2GhuJfJKVhCmSRFhbZD

## Summary by Sourcery

Add tests for the dynamic skill loader and adjust its API to enable direct testing of frontmatter parsing.

Enhancements:
- Export the frontmatter parsing helper from the dynamic skill loader module to make it directly testable.

Tests:
- Add coverage for dynamic skill loader behavior, including frontmatter parsing and runtime skill priority over built-in skills.