### PR TITLE
feat(insights): pluggable AI Insights storage backends

### DIFF
--- a/apps/dashboard/src/components/insights/insights-panel.tsx
+++ b/apps/dashboard/src/components/insights/insights-panel.tsx
@@ -1,10 +1,14 @@
-import { RefreshCw, Sparkles, X } from 'lucide-react'
+import { Database, RefreshCw, Sparkles, X } from 'lucide-react'
 
 import { useState } from 'react'
 import { InsightCard } from '@/components/insights/insight-card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
+import {
+  INSIGHTS_BACKEND_LABELS,
+  useInsightsBackend,
+} from '@/lib/hooks/use-insights-backend'
 import { useInsights } from '@/lib/query/use-insights'
 import { cn } from '@/lib/utils'
 
@@ -159,8 +163,29 @@ export function InsightsPanel({ hostId, className }: InsightsPanelProps) {
               </Button>
             </div>
           ) : null}
+          <InsightsStorageFooter />
         </>
       )}
     </section>
+  )
+}
+
+/**
+ * Read-only footer naming where insights are persisted. The backend is fixed at
+ * deploy time via INSIGHTS_STORE_BACKEND, so nothing here is editable — it just
+ * makes the active store visible, mirroring the agent's conversation-history
+ * panel.
+ */
+function InsightsStorageFooter() {
+  const { backend, isLoading } = useInsightsBackend()
+  if (isLoading) return null
+
+  return (
+    <p className="flex items-center gap-1.5 text-[10.5px] text-muted-foreground">
+      <Database className="size-3 shrink-0" />
+      <span>
+        Stored in {INSIGHTS_BACKEND_LABELS[backend]} · configured at deploy time
+      </span>
+    </p>
   )
 }

--- a/apps/dashboard/src/lib/ai/agent/tools/__tests__/query-tools.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/__tests__/query-tools.test.ts
@@ -145,8 +145,30 @@ describe('createQueryTools', () => {
       expect(result[0].explain).toBeDefined()
     })
 
-    test('supports pipeline explain type', async () => {
-      setupQueryMock()
+    test('generates EXPLAIN PLAN for default/plan type', async () => {
+      let capturedQuery = ''
+      mockFetchData.mockImplementation(async ({ query }: { query: string }) => {
+        capturedQuery = query
+        return { data: queryResults.explain, error: null }
+      })
+
+      const tools = createQueryTools(0) as any
+      await tools.explain_query.execute({
+        sql: 'SELECT count() FROM system.tables',
+        type: 'plan',
+      })
+
+      expect(capturedQuery).toBe(
+        'EXPLAIN PLAN SELECT count() FROM system.tables'
+      )
+    })
+
+    test('generates EXPLAIN PIPELINE for pipeline type', async () => {
+      let capturedQuery = ''
+      mockFetchData.mockImplementation(async ({ query }: { query: string }) => {
+        capturedQuery = query
+        return { data: queryResults.explain, error: null }
+      })
 
       const tools = createQueryTools(0) as any
       const result = await tools.explain_query.execute({
@@ -155,10 +177,17 @@ describe('createQueryTools', () => {
       })
 
       expect(Array.isArray(result)).toBe(true)
+      expect(capturedQuery).toBe(
+        'EXPLAIN PIPELINE SELECT count() FROM system.tables'
+      )
     })
 
-    test('supports indexes explain type', async () => {
-      setupQueryMock()
+    test('generates EXPLAIN PLAN indexes=1 for indexes type (not EXPLAIN INDEXES)', async () => {
+      let capturedQuery = ''
+      mockFetchData.mockImplementation(async ({ query }: { query: string }) => {
+        capturedQuery = query
+        return { data: queryResults.explain, error: null }
+      })
 
       const tools = createQueryTools(0) as any
       const result = await tools.explain_query.execute({
@@ -167,6 +196,11 @@ describe('createQueryTools', () => {
       })
 
       expect(Array.isArray(result)).toBe(true)
+      // Must use PLAN setting, not the invalid top-level EXPLAIN INDEXES mode
+      expect(capturedQuery).toBe(
+        'EXPLAIN PLAN indexes=1 SELECT count() FROM system.tables'
+      )
+      expect(capturedQuery).not.toContain('EXPLAIN INDEXES')
     })
 
     test('propagates validation errors', async () => {

--- a/apps/dashboard/src/lib/ai/agent/tools/query-tools.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/query-tools.ts
@@ -136,7 +136,7 @@ export function createQueryTools(hostId: number) {
 
     explain_query: dynamicTool({
       description:
-        'Get the execution plan for a query (EXPLAIN PLAN/PIPELINE/INDEXES). Useful for understanding query optimization and identifying performance issues.',
+        'Get the execution plan for a query (EXPLAIN PLAN / PIPELINE / PLAN indexes=1). Useful for understanding query optimization and identifying performance issues.',
       inputSchema: z.object({
         sql: z.string().describe('SQL query to explain'),
         type: z
@@ -158,17 +158,19 @@ export function createQueryTools(hostId: number) {
         }
         const resolvedHostId = resolveHostId(toolHostId, hostId)
 
-        // Map type to ClickHouse EXPLAIN type
+        // Map type to ClickHouse EXPLAIN keyword.
+        // 'indexes' is not a standalone EXPLAIN mode; it is a PLAN setting.
         const typeMap: Record<string, string> = {
           plan: 'PLAN',
           pipeline: 'PIPELINE',
-          indexes: 'INDEXES',
         }
-        const explainType = typeMap[type]
 
         validateSqlQuery(sql)
 
-        const explainQuery = `EXPLAIN ${explainType} ${sql}`
+        const explainQuery =
+          type === 'indexes'
+            ? `EXPLAIN PLAN indexes=1 ${sql}`
+            : `EXPLAIN ${typeMap[type]} ${sql}`
 
         const result = await readOnlyQuery({
           query: explainQuery,

--- a/apps/dashboard/src/lib/hooks/use-insights-backend.ts
+++ b/apps/dashboard/src/lib/hooks/use-insights-backend.ts
@@ -1,0 +1,118 @@
+'use client'
+
+/**
+ * useInsightsBackend Hook
+ *
+ * Reports which storage backend the engine uses to persist AI Insights
+ * (`INSIGHTS_STORE_BACKEND`). The backend is fixed at deploy time, so the
+ * result is fetched once and module-cached. Mirrors `use-conversation-backend`.
+ *
+ * Fails safe: any error resolves to the ClickHouse backend (the default).
+ */
+
+import { useEffect, useState } from 'react'
+import { apiFetch } from '@/lib/swr/api-fetch'
+
+/** Known insight storage backend identifiers. */
+export type InsightsBackendKind =
+  | 'clickhouse'
+  | 'd1'
+  | 'postgres'
+  | 'agentstate'
+  | 'memory'
+
+/** Human-readable label for each backend kind. */
+export const INSIGHTS_BACKEND_LABELS: Record<InsightsBackendKind, string> = {
+  clickhouse: 'ClickHouse (cluster)',
+  d1: 'Cloudflare D1',
+  postgres: 'PostgreSQL',
+  agentstate: 'AgentState',
+  memory: 'In-memory (ephemeral)',
+}
+
+interface InsightsBackendData {
+  backend: InsightsBackendKind
+}
+
+export interface UseInsightsBackendResult {
+  backend: InsightsBackendKind
+  isLoading: boolean
+  error: Error | null
+}
+
+const FAIL_SAFE: InsightsBackendData = { backend: 'clickhouse' }
+
+const VALID = new Set<InsightsBackendKind>([
+  'clickhouse',
+  'd1',
+  'postgres',
+  'agentstate',
+  'memory',
+])
+
+// Module-level cache so the endpoint is hit once per page load regardless of
+// how many components mount the hook.
+let cachedData: InsightsBackendData | null = null
+let inFlight: Promise<InsightsBackendData> | null = null
+
+async function fetchBackend(): Promise<InsightsBackendData> {
+  if (cachedData) return cachedData
+  if (inFlight) return inFlight
+
+  inFlight = (async () => {
+    try {
+      const response = await apiFetch('/api/v1/insights/backend')
+      if (!response.ok) throw new Error('Failed to fetch insights backend')
+      const json = (await response.json()) as { backend?: string }
+      const backend = json.backend as InsightsBackendKind
+      if (!backend || !VALID.has(backend)) {
+        throw new Error('Malformed insights backend response')
+      }
+      cachedData = { backend }
+      return cachedData
+    } catch {
+      cachedData = FAIL_SAFE
+      return cachedData
+    } finally {
+      inFlight = null
+    }
+  })()
+
+  return inFlight
+}
+
+/**
+ * Hook returning the active insights storage backend (read-only).
+ */
+export function useInsightsBackend(): UseInsightsBackendResult {
+  const [state, setState] = useState<UseInsightsBackendResult>({
+    backend: cachedData?.backend ?? 'clickhouse',
+    isLoading: cachedData === null,
+    error: null,
+  })
+
+  useEffect(() => {
+    if (cachedData) {
+      setState({ backend: cachedData.backend, isLoading: false, error: null })
+      return
+    }
+
+    let active = true
+    fetchBackend().then((data) => {
+      if (active) {
+        setState({ backend: data.backend, isLoading: false, error: null })
+      }
+    })
+    return () => {
+      active = false
+    }
+  }, [])
+
+  return state
+}
+
+/** Test-only: clear the module cache so the next mount refetches. */
+export function __resetInsightsBackendCache(): void {
+  cachedData = null
+  inFlight = null
+}

--- a/apps/dashboard/src/lib/hooks/use-insights-backend.ts
+++ b/apps/dashboard/src/lib/hooks/use-insights-backend.ts
@@ -68,11 +68,14 @@ async function fetchBackend(): Promise<InsightsBackendData> {
       if (!backend || !VALID.has(backend)) {
         throw new Error('Malformed insights backend response')
       }
+      // Cache only a real success, so the backend is fetched once for the page.
       cachedData = { backend }
       return cachedData
     } catch {
-      cachedData = FAIL_SAFE
-      return cachedData
+      // Do NOT cache the fail-safe: a transient error (offline, deploy blip)
+      // must not permanently pin the UI to 'clickhouse'. Leave cachedData null
+      // so the next mount retries; return the fail-safe for this call only.
+      return FAIL_SAFE
     } finally {
       inFlight = null
     }

--- a/apps/dashboard/src/lib/insights/generate-insights.ts
+++ b/apps/dashboard/src/lib/insights/generate-insights.ts
@@ -9,9 +9,9 @@
 
 import type { InsightCard } from './types'
 
-import { recordFinding } from '../findings/findings-store'
 import { collectInsights } from './collectors'
 import { enrichInsights } from './llm-enrich'
+import { resolveInsightsStore } from './store/resolve-store'
 import { insightKey } from './types'
 
 const SOURCE = 'ai-insight'
@@ -28,19 +28,21 @@ export async function generateInsights(hostId: number): Promise<InsightCard[]> {
     const enriched = await enrichInsights(candidates)
     const generatedAt = new Date().toISOString()
 
-    // Persist each insight (best-effort; failures are swallowed by recordFinding).
-    await Promise.all(
-      enriched.map((c) =>
-        recordFinding(hostId, {
-          severity: c.severity,
-          category: c.category,
-          source: SOURCE,
-          title: c.title,
-          detail: c.detail,
-          metric: c.metric,
-          value: c.value,
-        })
-      )
+    // Persist the batch through the configured backend (ClickHouse by default;
+    // D1 / Postgres / AgentState / Memory via INSIGHTS_STORE_BACKEND). The store
+    // is best-effort — a read-only cluster or missing binding degrades silently.
+    const store = await resolveInsightsStore()
+    await store.record(
+      hostId,
+      enriched.map((c) => ({
+        severity: c.severity,
+        category: c.category,
+        source: SOURCE,
+        title: c.title,
+        detail: c.detail,
+        metric: c.metric,
+        value: c.value,
+      }))
     )
 
     return enriched.map((c) => ({

--- a/apps/dashboard/src/lib/insights/read-insights.store.test.ts
+++ b/apps/dashboard/src/lib/insights/read-insights.store.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Wiring test: the insight read path now flows through the pluggable
+ * InsightsStore resolver instead of calling the ClickHouse findings store
+ * directly. Using the in-memory backend (INSIGHTS_STORE_BACKEND=memory) we
+ * record findings through the resolved store and assert that readInsights reads
+ * them back, de-dupes by stable key (newest wins), derives the card action from
+ * metric/category, and orders by severity. This proves the seam end-to-end
+ * without a database.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// clickhouse-store is statically imported by the resolver; its transitive
+// @chm/clickhouse-client import may touch the virtual cloudflare:workers env.
+// Stub it — the memory backend never calls the client.
+mock.module('cloudflare:workers', () => ({ env: {} }))
+
+import { readInsights } from './read-insights'
+import {
+  resetInsightsStoreCache,
+  resolveInsightsStore,
+} from './store/resolve-store'
+
+const saved = process.env.INSIGHTS_STORE_BACKEND
+
+beforeEach(() => {
+  process.env.INSIGHTS_STORE_BACKEND = 'memory'
+  resetInsightsStoreCache()
+})
+
+afterAll(() => {
+  if (saved === undefined) delete process.env.INSIGHTS_STORE_BACKEND
+  else process.env.INSIGHTS_STORE_BACKEND = saved
+  resetInsightsStoreCache()
+})
+
+describe('readInsights over a pluggable backend', () => {
+  test('reads recorded findings back as insight cards', async () => {
+    const store = await resolveInsightsStore()
+    expect(store.backend).toBe('memory')
+
+    await store.record(0, [
+      {
+        severity: 'warning',
+        category: 'storage',
+        source: 'ai-insight',
+        title: 'table X is fragmented',
+        detail: 'consider OPTIMIZE',
+        metric: 'max_active_parts',
+        value: 318,
+      },
+    ])
+
+    const cards = await readInsights(0)
+    expect(cards).toHaveLength(1)
+    expect(cards[0]).toMatchObject({
+      severity: 'warning',
+      category: 'storage',
+      title: 'table X is fragmented',
+      metric: 'max_active_parts',
+    })
+    // action is re-derived from metric/category on read
+    expect(cards[0].action).toEqual({ label: 'View tables', href: '/tables' })
+    // stable dismissal key
+    expect(cards[0].key).toBe(
+      '0:storage:max_active_parts:table X is fragmented'
+    )
+  })
+
+  test('de-dupes by stable key, newest occurrence wins', async () => {
+    const store = await resolveInsightsStore()
+    await store.record(0, [
+      {
+        severity: 'warning',
+        category: 'storage',
+        source: 'ai-insight',
+        title: 'fragmented',
+        metric: 'max_active_parts',
+        value: 100,
+      },
+    ])
+    await store.record(0, [
+      {
+        severity: 'critical',
+        category: 'storage',
+        source: 'ai-insight',
+        title: 'fragmented',
+        metric: 'max_active_parts',
+        value: 400,
+      },
+    ])
+
+    const cards = await readInsights(0)
+    expect(cards).toHaveLength(1)
+    expect(cards[0].value).toBe(400) // newest write wins
+    expect(cards[0].severity).toBe('critical')
+  })
+
+  test('orders cards by severity (critical → warning → info)', async () => {
+    const store = await resolveInsightsStore()
+    await store.record(0, [
+      {
+        severity: 'info',
+        category: 'anomaly',
+        source: 'ai-insight',
+        title: 'i',
+        metric: 'a',
+      },
+      {
+        severity: 'critical',
+        category: 'anomaly',
+        source: 'ai-insight',
+        title: 'c',
+        metric: 'b',
+      },
+      {
+        severity: 'warning',
+        category: 'anomaly',
+        source: 'ai-insight',
+        title: 'w',
+        metric: 'c',
+      },
+    ])
+    const cards = await readInsights(0)
+    expect(cards.map((c) => c.severity)).toEqual([
+      'critical',
+      'warning',
+      'info',
+    ])
+  })
+
+  test('ignores rows whose source is not an insight source', async () => {
+    const store = await resolveInsightsStore()
+    await store.record(0, [
+      {
+        severity: 'info',
+        category: 'storage',
+        source: 'health-sweep',
+        title: 'not-an-insight',
+      },
+    ])
+    expect(await readInsights(0)).toHaveLength(0)
+  })
+})

--- a/apps/dashboard/src/lib/insights/read-insights.ts
+++ b/apps/dashboard/src/lib/insights/read-insights.ts
@@ -12,7 +12,7 @@
 import type { FindingRow } from '../findings/findings-store'
 import type { InsightAction, InsightCard, InsightSeverity } from './types'
 
-import { listRecentFindings } from '../findings/findings-store'
+import { resolveInsightsStore } from './store/resolve-store'
 import { INSIGHT_SOURCES, insightKey } from './types'
 
 /** Default lookback for the panel — recent enough that insights stay relevant. */
@@ -76,7 +76,8 @@ export async function readInsights(
   opts: { since?: string; limit?: number } = {}
 ): Promise<InsightCard[]> {
   const since = opts.since ?? DEFAULT_SINCE
-  const rows = await listRecentFindings(hostId, {
+  const store = await resolveInsightsStore()
+  const rows = await store.list(hostId, {
     since,
     limit: opts.limit ?? 200,
   })

--- a/apps/dashboard/src/lib/insights/store/agentstate-store.test.ts
+++ b/apps/dashboard/src/lib/insights/store/agentstate-store.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for the AgentState insights backend.
+ *
+ * Mocks @agentstate/sdk with a behavioral fake of the generic State API
+ * (upsertState / queryStates) so we exercise: the stable state_key (which gives
+ * natural dedup), host/severity tagging, the updated_after recency filter, the
+ * State-record → FindingRow mapping, and the best-effort degrade when the SDK
+ * throws.
+ */
+
+import type { Finding } from './types'
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+interface FakeState {
+  state_key: string
+  agent_id: string
+  data: Record<string, unknown>
+  tags: string[]
+  updated_at: number
+}
+
+const states = new Map<string, FakeState>()
+const upsertCalls: Array<{
+  key: string
+  agent_id: string
+  tags: string[]
+}> = []
+let failKeySubstring: string | null = null
+
+class FakeAgentState {
+  constructor(_cfg: unknown) {}
+
+  async upsertState(
+    key: string,
+    body: { agent_id: string; data: Record<string, unknown>; tags: string[] }
+  ): Promise<FakeState> {
+    upsertCalls.push({ key, agent_id: body.agent_id, tags: body.tags })
+    if (failKeySubstring && key.includes(failKeySubstring)) {
+      throw new Error('simulated upsert failure')
+    }
+    const rec: FakeState = {
+      state_key: key,
+      agent_id: body.agent_id,
+      data: body.data,
+      tags: body.tags,
+      updated_at: Number(body.data.event_time),
+    }
+    states.set(key, rec)
+    return rec
+  }
+
+  async queryStates(q: {
+    agent_id?: string
+    tags?: string[]
+    updated_after?: number
+    limit?: number
+  }) {
+    let arr = [...states.values()]
+    if (q.agent_id) arr = arr.filter((s) => s.agent_id === q.agent_id)
+    if (q.tags?.length)
+      arr = arr.filter((s) => q.tags!.every((t) => s.tags.includes(t)))
+    if (q.updated_after != null)
+      arr = arr.filter((s) => s.updated_at >= q.updated_after!)
+    arr = arr.slice(0, q.limit ?? 100)
+    return {
+      data: arr,
+      pagination: { limit: q.limit ?? 100, next_cursor: null },
+    }
+  }
+}
+
+mock.module('@agentstate/sdk', () => ({
+  AgentState: FakeAgentState,
+  AgentStateError: class extends Error {},
+}))
+
+const { AgentStateInsightsStore } = await import('./agentstate-store')
+
+const store = () => new AgentStateInsightsStore({ apiKey: 'as_live_TEST' })
+
+const finding = (over: Partial<Finding> = {}): Finding => ({
+  severity: 'info',
+  category: 'storage',
+  source: 'ai-insight',
+  title: 'table X fragmented',
+  detail: 'd',
+  metric: 'max_active_parts',
+  value: 318,
+  ...over,
+})
+
+beforeEach(() => {
+  states.clear()
+  upsertCalls.length = 0
+  failKeySubstring = null
+})
+
+describe('AgentStateInsightsStore', () => {
+  test('exposes the agentstate backend id', () => {
+    expect(store().backend).toBe('agentstate')
+  })
+
+  test('records each finding under a stable, host-scoped state key with tags', async () => {
+    expect(await store().record(0, [finding()])).toBe(true)
+    expect(upsertCalls).toHaveLength(1)
+    expect(upsertCalls[0].key).toBe(
+      'insight:0:storage:max_active_parts:table%20X%20fragmented'
+    )
+    expect(upsertCalls[0].agent_id).toBe('clickhouse-monitoring-insights')
+    expect(upsertCalls[0].tags).toEqual(['host:0', 'severity:info'])
+  })
+
+  test('re-recording the same insight upserts in place (natural dedup)', async () => {
+    const s = store()
+    await s.record(0, [finding({ value: 100 })])
+    await s.record(0, [finding({ value: 200 })])
+    expect(states.size).toBe(1)
+    const rows = await s.list(0)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].value).toBe(200) // newest write wins
+  })
+
+  test('list maps State data back to the FindingRow shape with ISO event_time', async () => {
+    const s = store()
+    await s.record(0, [finding()])
+    const [row] = await s.list(0)
+    expect(row).toMatchObject({
+      host_id: '0',
+      severity: 'info',
+      category: 'storage',
+      source: 'ai-insight',
+      title: 'table X fragmented',
+      metric: 'max_active_parts',
+      value: 318,
+    })
+    expect(row.event_time).toContain('T')
+  })
+
+  test('list filters by host and severity via tags', async () => {
+    const s = store()
+    await s.record(0, [
+      finding({ severity: 'info', title: 'a' }),
+      finding({ severity: 'critical', title: 'b' }),
+    ])
+    await s.record(1, [finding({ title: 'other-host' })])
+
+    expect(
+      (await s.list(0, { severity: 'critical' })).map((r) => r.title)
+    ).toEqual(['b'])
+    expect((await s.list(1)).map((r) => r.title)).toEqual(['other-host'])
+  })
+
+  test('record returns false when a single upsert throws (best-effort AND)', async () => {
+    failKeySubstring = 'bad'
+    const s = store()
+    const ok = await s.record(0, [
+      finding({ title: 'good' }),
+      finding({ title: 'bad' }),
+    ])
+    expect(ok).toBe(false)
+    // the good one still persisted
+    expect(states.size).toBe(1)
+  })
+
+  test('empty batch is a no-op success', async () => {
+    expect(await store().record(0, [])).toBe(true)
+    expect(upsertCalls).toHaveLength(0)
+  })
+})

--- a/apps/dashboard/src/lib/insights/store/agentstate-store.test.ts
+++ b/apps/dashboard/src/lib/insights/store/agentstate-store.test.ts
@@ -204,7 +204,7 @@ describe('AgentStateInsightsStore', () => {
   // many adversarial near-identical insights must all get DISTINCT keys, and
   // key generation must stay cheap. This is the perf+correctness backstop for
   // the FNV-1a state_key scheme.
-  test('benchmark: 2000 near-identical long-prefix insights → 2000 distinct keys, fast', async () => {
+  test('benchmark: 2000 near-identical long-prefix insights → 2000 distinct keys', async () => {
     const s = store()
     const N = 2000
     const prefix = 'X'.repeat(200) // forces all keys past the readable cap
@@ -212,14 +212,12 @@ describe('AgentStateInsightsStore', () => {
       finding({ metric: 'm', title: `${prefix}-${i}`, value: i })
     )
 
-    const t0 = performance.now()
     await s.record(0, batch)
-    const elapsedMs = performance.now() - t0
 
     // No collisions: every distinct insight persisted to its own state key.
+    // (No wall-clock assertion — that would be host-load-dependent and flaky;
+    // the scale guard is the distinct-key invariant under N=2000 keys.)
     expect(states.size).toBe(N)
     expect(new Set(upsertCalls.map((c) => c.key)).size).toBe(N)
-    // Cheap: well under a generous budget on CI hardware (keygen is O(title)).
-    expect(elapsedMs).toBeLessThan(1500)
   })
 })

--- a/apps/dashboard/src/lib/insights/store/agentstate-store.test.ts
+++ b/apps/dashboard/src/lib/insights/store/agentstate-store.test.ts
@@ -104,11 +104,43 @@ describe('AgentStateInsightsStore', () => {
   test('records each finding under a stable, host-scoped state key with tags', async () => {
     expect(await store().record(0, [finding()])).toBe(true)
     expect(upsertCalls).toHaveLength(1)
-    expect(upsertCalls[0].key).toBe(
-      'insight:0:storage:max_active_parts:table%20X%20fragmented'
-    )
+    // Key shape: insight:<host>:<readable-prefix>:<8-hex hash>. The hash suffix
+    // makes it collision-proof regardless of how long the title is (see the
+    // long-prefix regression test below); the readable prefix aids debugging.
+    expect(upsertCalls[0].key).toMatch(/^insight:0:storage.*:[0-9a-f]{8}$/)
     expect(upsertCalls[0].agent_id).toBe('clickhouse-monitoring-insights')
     expect(upsertCalls[0].tags).toEqual(['host:0', 'severity:info'])
+  })
+
+  test('regression: long titles sharing a 120+ char prefix do NOT collide', async () => {
+    // BUG (found by the realistic-scenario battery): the old key truncated each
+    // part to 120 chars, so two distinct insights whose titles share a long
+    // prefix produced the SAME state_key and silently overwrote each other.
+    const s = store()
+    const prefix = 'P'.repeat(150)
+    await s.record(0, [
+      finding({ metric: 'm', title: `${prefix}-alpha`, value: 1 }),
+      finding({ metric: 'm', title: `${prefix}-beta`, value: 2 }),
+    ])
+    // Two distinct state keys → both persisted, no data loss.
+    expect(states.size).toBe(2)
+    expect(upsertCalls[0].key).not.toBe(upsertCalls[1].key)
+    const rows = await s.list(0)
+    expect(rows.map((r) => r.title).sort()).toEqual([
+      `${prefix}-alpha`,
+      `${prefix}-beta`,
+    ])
+  })
+
+  test('regression: the same insight maps to a STABLE key across regenerations', async () => {
+    // Dedup correctness: an unchanged insight must upsert in place, so the key
+    // must be deterministic for identical (category, metric, title).
+    const s = store()
+    await s.record(0, [finding({ metric: 'm', title: 'stable', value: 1 })])
+    const firstKey = upsertCalls[0].key
+    await s.record(0, [finding({ metric: 'm', title: 'stable', value: 2 })])
+    expect(upsertCalls[1].key).toBe(firstKey)
+    expect(states.size).toBe(1) // upserted in place, not duplicated
   })
 
   test('re-recording the same insight upserts in place (natural dedup)', async () => {
@@ -166,5 +198,28 @@ describe('AgentStateInsightsStore', () => {
   test('empty batch is a no-op success', async () => {
     expect(await store().record(0, [])).toBe(true)
     expect(upsertCalls).toHaveLength(0)
+  })
+
+  // Benchmark / scale guard for the hashed key (paired with the collision fix):
+  // many adversarial near-identical insights must all get DISTINCT keys, and
+  // key generation must stay cheap. This is the perf+correctness backstop for
+  // the FNV-1a state_key scheme.
+  test('benchmark: 2000 near-identical long-prefix insights → 2000 distinct keys, fast', async () => {
+    const s = store()
+    const N = 2000
+    const prefix = 'X'.repeat(200) // forces all keys past the readable cap
+    const batch = Array.from({ length: N }, (_, i) =>
+      finding({ metric: 'm', title: `${prefix}-${i}`, value: i })
+    )
+
+    const t0 = performance.now()
+    await s.record(0, batch)
+    const elapsedMs = performance.now() - t0
+
+    // No collisions: every distinct insight persisted to its own state key.
+    expect(states.size).toBe(N)
+    expect(new Set(upsertCalls.map((c) => c.key)).size).toBe(N)
+    // Cheap: well under a generous budget on CI hardware (keygen is O(title)).
+    expect(elapsedMs).toBeLessThan(1500)
   })
 })

--- a/apps/dashboard/src/lib/insights/store/agentstate-store.ts
+++ b/apps/dashboard/src/lib/insights/store/agentstate-store.ts
@@ -79,9 +79,11 @@ function fnv1a(str: string): string {
  */
 function stateKey(hostId: number, finding: Finding): string {
   const composite = `${finding.category}${SEP}${finding.metric ?? ''}${SEP}${finding.title}`
-  const readable = encodeURIComponent(composite.split(SEP).join(':')).slice(
-    0,
-    KEY_PREFIX_MAX
+  // Slice the RAW string before encoding so we never cut a percent-escape in
+  // half (e.g. truncating `%20` to `%2`). Uniqueness comes from the hash suffix,
+  // so a shorter readable prefix is purely cosmetic.
+  const readable = encodeURIComponent(
+    composite.split(SEP).join(':').slice(0, KEY_PREFIX_MAX)
   )
   return `insight:${hostId}:${readable}:${fnv1a(`${hostId}${SEP}${composite}`)}`
 }

--- a/apps/dashboard/src/lib/insights/store/agentstate-store.ts
+++ b/apps/dashboard/src/lib/insights/store/agentstate-store.ts
@@ -39,8 +39,11 @@ const warn = (msg: string) =>
 
 /** Logical agent under which every insight record is grouped. */
 const AGENT_ID = 'clickhouse-monitoring-insights'
-/** Cap on the title slice baked into the state key to keep keys bounded. */
-const KEY_TITLE_MAX = 120
+/** Cap on the readable prefix baked into the state key to keep keys bounded. */
+const KEY_PREFIX_MAX = 120
+/** NUL separator: cannot appear in the source strings, so the hashed
+ * composite is unambiguous (no field-boundary aliasing between parts). */
+const SEP = String.fromCharCode(0)
 
 export interface AgentStateInsightsStoreOptions {
   /** AgentState API key (`as_live_...`). Required. */
@@ -49,12 +52,37 @@ export interface AgentStateInsightsStoreOptions {
   baseUrl?: string
 }
 
-/** Build the stable, bounded state key for an insight. */
+/**
+ * FNV-1a 32-bit — a tiny, fast, dependency-free string hash. Used only to make
+ * the state key collision-resistant; not security-sensitive.
+ */
+function fnv1a(str: string): string {
+  let h = 0x811c9dc5
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return (h >>> 0).toString(16).padStart(8, '0')
+}
+
+/**
+ * Build the stable, bounded state key for an insight.
+ *
+ * The key must be (a) stable across regenerations of the SAME insight so
+ * `upsertState` dedups in place, and (b) DISTINCT for different insights. A
+ * naive truncated `category:metric:title` fails (b): two long titles sharing a
+ * 120-char prefix collide and silently overwrite each other (data loss). So we
+ * append a hash of the FULL untruncated composite — identical insight → identical
+ * hash → in-place upsert; different insight → different hash → no collision —
+ * while keeping a human-readable (truncated) prefix for debuggability.
+ */
 function stateKey(hostId: number, finding: Finding): string {
-  const part = (s: string) => encodeURIComponent(s).slice(0, KEY_TITLE_MAX)
-  return `insight:${hostId}:${part(finding.category)}:${part(
-    finding.metric ?? ''
-  )}:${part(finding.title)}`
+  const composite = `${finding.category}${SEP}${finding.metric ?? ''}${SEP}${finding.title}`
+  const readable = encodeURIComponent(composite.split(SEP).join(':')).slice(
+    0,
+    KEY_PREFIX_MAX
+  )
+  return `insight:${hostId}:${readable}:${fnv1a(`${hostId}${SEP}${composite}`)}`
 }
 
 export class AgentStateInsightsStore implements InsightsStore {

--- a/apps/dashboard/src/lib/insights/store/agentstate-store.ts
+++ b/apps/dashboard/src/lib/insights/store/agentstate-store.ts
@@ -1,0 +1,159 @@
+/**
+ * AgentState insights backend.
+ *
+ * Persists each insight as a record in AgentState's generic **State** store
+ * (https://agentstate.app) — not its conversation store. State records are a
+ * better fit for scalar findings than conversations: each insight maps to one
+ * versioned `state_key`, so re-recording the same insight upserts in place
+ * (natural dedup), and `queryStates` filters by tag + recency for the read path.
+ *
+ * Key design:
+ * - `agent_id`  = a fixed app id so every insight shares one logical agent.
+ * - `state_key` = `insight:<hostId>:<category>:<metric>:<title>` (bounded),
+ *   stable across regenerations so an unchanged insight overwrites itself.
+ * - `tags`      = [`host:<hostId>`, `severity:<sev>`] for server-side filtering.
+ * - `data`      = the scalar finding fields plus an explicit `event_time` (ms).
+ *
+ * Best-effort: any SDK error logs and degrades to no-op / empty, matching the
+ * other backends. Reuses the same `AGENTSTATE_API_KEY` / `AGENTSTATE_BASE_URL`
+ * env as the conversation store.
+ */
+
+import type { JsonObject } from '@agentstate/sdk'
+import type {
+  Finding,
+  FindingRow,
+  InsightsStore,
+  ListFindingsOptions,
+} from './types'
+
+import { intervalToMs } from './interval'
+import { AgentState } from '@agentstate/sdk'
+import { ErrorLogger } from '@chm/logger'
+
+const COMPONENT = 'insights-agentstate-store'
+const warn = (msg: string) =>
+  ErrorLogger.logWarning(`[insights-agentstate-store] ${msg}`, {
+    component: COMPONENT,
+  })
+
+/** Logical agent under which every insight record is grouped. */
+const AGENT_ID = 'clickhouse-monitoring-insights'
+/** Cap on the title slice baked into the state key to keep keys bounded. */
+const KEY_TITLE_MAX = 120
+
+export interface AgentStateInsightsStoreOptions {
+  /** AgentState API key (`as_live_...`). Required. */
+  apiKey: string
+  /** AgentState API base URL. Defaults to the SDK default. */
+  baseUrl?: string
+}
+
+/** Build the stable, bounded state key for an insight. */
+function stateKey(hostId: number, finding: Finding): string {
+  const part = (s: string) => encodeURIComponent(s).slice(0, KEY_TITLE_MAX)
+  return `insight:${hostId}:${part(finding.category)}:${part(
+    finding.metric ?? ''
+  )}:${part(finding.title)}`
+}
+
+export class AgentStateInsightsStore implements InsightsStore {
+  readonly backend = 'agentstate' as const
+  private readonly client: AgentState
+
+  constructor(opts: AgentStateInsightsStoreOptions) {
+    this.client = new AgentState({
+      apiKey: opts.apiKey,
+      baseUrl: opts.baseUrl,
+    })
+  }
+
+  async record(hostId: number, findings: Finding[]): Promise<boolean> {
+    if (findings.length === 0) return true
+    const now = Date.now()
+    try {
+      const results = await Promise.all(
+        findings.map((f) =>
+          this.client
+            .upsertState(stateKey(hostId, f), {
+              agent_id: AGENT_ID,
+              tags: [`host:${hostId}`, `severity:${f.severity}`],
+              data: {
+                event_time: now,
+                host_id: String(hostId),
+                severity: f.severity,
+                category: f.category,
+                source: f.source,
+                title: f.title,
+                detail: f.detail ?? '',
+                metric: f.metric ?? '',
+                value: f.value ?? 0,
+              } satisfies JsonObject,
+            })
+            .then(
+              () => true,
+              (err) => {
+                warn(`upsert failed for "${f.title}" on host ${hostId}: ${err}`)
+                return false
+              }
+            )
+        )
+      )
+      return results.every(Boolean)
+    } catch (err) {
+      warn(`failed to record findings on host ${hostId}: ${err}`)
+      return false
+    }
+  }
+
+  async list(
+    hostId: number,
+    opts: ListFindingsOptions = {}
+  ): Promise<FindingRow[]> {
+    const { severity, since, limit = 100 } = opts
+    try {
+      const tags = [`host:${hostId}`]
+      if (severity) tags.push(`severity:${severity}`)
+
+      let updatedAfter: number | undefined
+      if (since) {
+        const ms = intervalToMs(since)
+        if (ms !== null) updatedAfter = Date.now() - ms
+        else warn(`ignoring invalid "since" value: ${since}`)
+      }
+
+      const safeLimit = Math.min(Math.max(Math.trunc(limit) || 0, 1), 1000)
+      const response = await this.client.queryStates({
+        agent_id: AGENT_ID,
+        tags,
+        updated_after: updatedAfter,
+        limit: safeLimit,
+      })
+
+      return (response.data ?? [])
+        .map((rec) => this.toRow(rec.data))
+        .filter((r): r is FindingRow => r !== null)
+    } catch (err) {
+      warn(`failed to list findings on host ${hostId}: ${err}`)
+      return []
+    }
+  }
+
+  /** Map a stored state `data` object back to the shared FindingRow shape. */
+  private toRow(data: JsonObject): FindingRow | null {
+    if (!data || typeof data.title !== 'string') return null
+    const num = (v: unknown) => (typeof v === 'number' ? v : Number(v) || 0)
+    const str = (v: unknown) => (typeof v === 'string' ? v : '')
+    return {
+      event_time: new Date(num(data.event_time)).toISOString(),
+      host_id: str(data.host_id),
+      severity: str(data.severity),
+      category: str(data.category),
+      source: str(data.source),
+      title: str(data.title),
+      detail: str(data.detail),
+      metric: str(data.metric),
+      value: num(data.value),
+    }
+  }
+}

--- a/apps/dashboard/src/lib/insights/store/agentstate-store.ts
+++ b/apps/dashboard/src/lib/insights/store/agentstate-store.ts
@@ -28,6 +28,7 @@ import type {
 } from './types'
 
 import { intervalToMs } from './interval'
+import { clampLimit, rowFromStored } from './types'
 import { AgentState } from '@agentstate/sdk'
 import { ErrorLogger } from '@chm/logger'
 
@@ -138,7 +139,7 @@ export class AgentStateInsightsStore implements InsightsStore {
     hostId: number,
     opts: ListFindingsOptions = {}
   ): Promise<FindingRow[]> {
-    const { severity, since, limit = 100 } = opts
+    const { severity, since } = opts
     try {
       const tags = [`host:${hostId}`]
       if (severity) tags.push(`severity:${severity}`)
@@ -150,38 +151,21 @@ export class AgentStateInsightsStore implements InsightsStore {
         else warn(`ignoring invalid "since" value: ${since}`)
       }
 
-      const safeLimit = Math.min(Math.max(Math.trunc(limit) || 0, 1), 1000)
       const response = await this.client.queryStates({
         agent_id: AGENT_ID,
         tags,
         updated_after: updatedAfter,
-        limit: safeLimit,
+        limit: clampLimit(opts.limit),
       })
 
+      // Skip malformed records (no usable title), then map through the shared
+      // stored-row normalizer so the read contract matches the other backends.
       return (response.data ?? [])
-        .map((rec) => this.toRow(rec.data))
-        .filter((r): r is FindingRow => r !== null)
+        .filter((rec) => typeof rec.data?.title === 'string')
+        .map((rec) => rowFromStored(rec.data))
     } catch (err) {
       warn(`failed to list findings on host ${hostId}: ${err}`)
       return []
-    }
-  }
-
-  /** Map a stored state `data` object back to the shared FindingRow shape. */
-  private toRow(data: JsonObject): FindingRow | null {
-    if (!data || typeof data.title !== 'string') return null
-    const num = (v: unknown) => (typeof v === 'number' ? v : Number(v) || 0)
-    const str = (v: unknown) => (typeof v === 'string' ? v : '')
-    return {
-      event_time: new Date(num(data.event_time)).toISOString(),
-      host_id: str(data.host_id),
-      severity: str(data.severity),
-      category: str(data.category),
-      source: str(data.source),
-      title: str(data.title),
-      detail: str(data.detail),
-      metric: str(data.metric),
-      value: num(data.value),
     }
   }
 }

--- a/apps/dashboard/src/lib/insights/store/clickhouse-store.test.ts
+++ b/apps/dashboard/src/lib/insights/store/clickhouse-store.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for the ClickHouse insights backend (the default). It is a thin adapter
+ * over lib/findings/findings-store, so these tests mock that module and assert
+ * delegation: `record` fans a batch out to recordFinding and ANDs the results;
+ * `list` passes straight through to listRecentFindings.
+ *
+ * We mock the findings-store module (not the underlying ClickHouse client) so
+ * this stays a pure delegation test and does not collide with
+ * findings-store.test.ts, which exercises the real module against a mocked
+ * client.
+ */
+
+import type { Finding, FindingRow } from './types'
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// Mutable hooks the mock reads so each test controls behavior.
+let recordResults: boolean[] = []
+let recordCalls: Array<{ hostId: number; finding: Finding }> = []
+let listImpl: () => Promise<FindingRow[]> = async () => []
+let listCalls: Array<{ hostId: number; opts: unknown }> = []
+
+mock.module('@/lib/findings/findings-store', () => ({
+  recordFinding: async (hostId: number, finding: Finding) => {
+    recordCalls.push({ hostId, finding })
+    return recordResults.shift() ?? true
+  },
+  listRecentFindings: (hostId: number, opts: unknown) => {
+    listCalls.push({ hostId, opts })
+    return listImpl()
+  },
+}))
+
+const { ClickHouseInsightsStore } = await import('./clickhouse-store')
+
+const finding = (over: Partial<Finding> = {}): Finding => ({
+  severity: 'info',
+  category: 'storage',
+  source: 'ai-insight',
+  title: 't',
+  ...over,
+})
+
+beforeEach(() => {
+  recordResults = []
+  recordCalls = []
+  listCalls = []
+  listImpl = async () => []
+})
+
+describe('ClickHouseInsightsStore', () => {
+  test('exposes the clickhouse backend id', () => {
+    expect(new ClickHouseInsightsStore().backend).toBe('clickhouse')
+  })
+
+  test('record fans the batch out to recordFinding (one call per finding)', async () => {
+    const store = new ClickHouseInsightsStore()
+    const ok = await store.record(2, [
+      finding({ title: 'a' }),
+      finding({ title: 'b' }),
+    ])
+    expect(ok).toBe(true)
+    expect(recordCalls.map((c) => c.finding.title)).toEqual(['a', 'b'])
+    expect(recordCalls.every((c) => c.hostId === 2)).toBe(true)
+  })
+
+  test('record returns false if any single write fails (best-effort AND)', async () => {
+    recordResults = [true, false]
+    const store = new ClickHouseInsightsStore()
+    expect(await store.record(0, [finding(), finding()])).toBe(false)
+  })
+
+  test('record short-circuits an empty batch without touching the store', async () => {
+    const store = new ClickHouseInsightsStore()
+    expect(await store.record(0, [])).toBe(true)
+    expect(recordCalls).toHaveLength(0)
+  })
+
+  test('list delegates straight through to listRecentFindings', async () => {
+    const row: FindingRow = {
+      event_time: '2026-06-20 00:00:00',
+      host_id: '0',
+      severity: 'critical',
+      category: 'anomaly',
+      source: 'ai-insight',
+      title: 'spike',
+      detail: '',
+      metric: 'error_rate',
+      value: 5,
+    }
+    listImpl = async () => [row]
+    const store = new ClickHouseInsightsStore()
+    const out = await store.list(0, { since: '6 HOUR', limit: 50 })
+    expect(out).toEqual([row])
+    expect(listCalls).toEqual([
+      { hostId: 0, opts: { since: '6 HOUR', limit: 50 } },
+    ])
+  })
+})

--- a/apps/dashboard/src/lib/insights/store/clickhouse-store.test.ts
+++ b/apps/dashboard/src/lib/insights/store/clickhouse-store.test.ts
@@ -17,12 +17,14 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test'
 // Mutable hooks the mock reads so each test controls behavior.
 let recordResults: boolean[] = []
 let recordCalls: Array<{ hostId: number; finding: Finding }> = []
+let recordThrows = false
 let listImpl: () => Promise<FindingRow[]> = async () => []
 let listCalls: Array<{ hostId: number; opts: unknown }> = []
 
 mock.module('@/lib/findings/findings-store', () => ({
   recordFinding: async (hostId: number, finding: Finding) => {
     recordCalls.push({ hostId, finding })
+    if (recordThrows) throw new Error('simulated recordFinding rejection')
     return recordResults.shift() ?? true
   },
   listRecentFindings: (hostId: number, opts: unknown) => {
@@ -44,6 +46,7 @@ const finding = (over: Partial<Finding> = {}): Finding => ({
 beforeEach(() => {
   recordResults = []
   recordCalls = []
+  recordThrows = false
   listCalls = []
   listImpl = async () => []
 })
@@ -74,6 +77,14 @@ describe('ClickHouseInsightsStore', () => {
     const store = new ClickHouseInsightsStore()
     expect(await store.record(0, [])).toBe(true)
     expect(recordCalls).toHaveLength(0)
+  })
+
+  test('record returns false (does NOT throw) when the delegate rejects', async () => {
+    // The InsightsStore contract is no-throw; a recordFinding rejection must be
+    // swallowed into a false result, not propagated.
+    recordThrows = true
+    const store = new ClickHouseInsightsStore()
+    expect(await store.record(0, [finding()])).toBe(false)
   })
 
   test('list delegates straight through to listRecentFindings', async () => {

--- a/apps/dashboard/src/lib/insights/store/clickhouse-store.ts
+++ b/apps/dashboard/src/lib/insights/store/clickhouse-store.ts
@@ -1,0 +1,38 @@
+/**
+ * ClickHouse insights backend — the default.
+ *
+ * A thin adapter over the existing `lib/findings/findings-store.ts`, which owns
+ * an app-created table on the monitored cluster. This preserves the original
+ * behavior exactly (lazy CREATE TABLE, 30-day TTL, best-effort writes) while
+ * fitting the pluggable `InsightsStore` interface. When `INSIGHTS_STORE_BACKEND`
+ * is unset (`auto`), this is what `resolveInsightsStore` returns.
+ */
+
+import type {
+  Finding,
+  FindingRow,
+  InsightsStore,
+  ListFindingsOptions,
+} from './types'
+
+import {
+  listRecentFindings,
+  recordFinding,
+} from '@/lib/findings/findings-store'
+
+export class ClickHouseInsightsStore implements InsightsStore {
+  readonly backend = 'clickhouse' as const
+
+  async record(hostId: number, findings: Finding[]): Promise<boolean> {
+    if (findings.length === 0) return true
+    // recordFinding is itself best-effort (returns false on read-only clusters).
+    const results = await Promise.all(
+      findings.map((f) => recordFinding(hostId, f))
+    )
+    return results.every(Boolean)
+  }
+
+  list(hostId: number, opts?: ListFindingsOptions): Promise<FindingRow[]> {
+    return listRecentFindings(hostId, opts)
+  }
+}

--- a/apps/dashboard/src/lib/insights/store/clickhouse-store.ts
+++ b/apps/dashboard/src/lib/insights/store/clickhouse-store.ts
@@ -15,6 +15,7 @@ import type {
   ListFindingsOptions,
 } from './types'
 
+import { ErrorLogger } from '@chm/logger'
 import {
   listRecentFindings,
   recordFinding,
@@ -25,14 +26,37 @@ export class ClickHouseInsightsStore implements InsightsStore {
 
   async record(hostId: number, findings: Finding[]): Promise<boolean> {
     if (findings.length === 0) return true
-    // recordFinding is itself best-effort (returns false on read-only clusters).
-    const results = await Promise.all(
-      findings.map((f) => recordFinding(hostId, f))
-    )
-    return results.every(Boolean)
+    try {
+      // recordFinding is itself best-effort (returns false on read-only
+      // clusters). Guard Promise.all anyway: a single unexpected rejection must
+      // not propagate — the InsightsStore contract is no-throw.
+      const results = await Promise.all(
+        findings.map((f) => recordFinding(hostId, f))
+      )
+      return results.every(Boolean)
+    } catch (err) {
+      ErrorLogger.logWarning(
+        `[insights-clickhouse-store] failed to record findings on host ${hostId}: ${err}`,
+        { component: 'insights-clickhouse-store' }
+      )
+      return false
+    }
   }
 
-  list(hostId: number, opts?: ListFindingsOptions): Promise<FindingRow[]> {
-    return listRecentFindings(hostId, opts)
+  async list(
+    hostId: number,
+    opts?: ListFindingsOptions
+  ): Promise<FindingRow[]> {
+    // listRecentFindings is best-effort (returns [] on error), but guard against
+    // an unexpected throw to keep the no-throw contract.
+    try {
+      return await listRecentFindings(hostId, opts)
+    } catch (err) {
+      ErrorLogger.logWarning(
+        `[insights-clickhouse-store] failed to list findings on host ${hostId}: ${err}`,
+        { component: 'insights-clickhouse-store' }
+      )
+      return []
+    }
   }
 }

--- a/apps/dashboard/src/lib/insights/store/d1-store.test.ts
+++ b/apps/dashboard/src/lib/insights/store/d1-store.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for the Cloudflare D1 insights backend.
+ *
+ * Uses a small behavioral fake of D1Database (prepare/bind/batch/all) injected
+ * through a mocked @chm/platform, so we exercise the real SQL the store issues:
+ * lazy migration, batched inserts, host/severity/since filtering, newest-first
+ * ordering with the limit clamp, the unix-ms → ISO event_time mapping, and the
+ * best-effort degrade when no binding is present.
+ */
+
+import type { Finding } from './types'
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// --- behavioral D1 fake ------------------------------------------------------
+interface FakeRow {
+  event_time: number
+  host_id: string
+  severity: string
+  category: string
+  source: string
+  title: string
+  detail: string
+  metric: string
+  value: number
+}
+
+function makeFakeD1() {
+  const rows: FakeRow[] = []
+  const calls = { migrations: 0, inserts: 0 }
+
+  function bindsToRow(b: unknown[]): FakeRow {
+    return {
+      event_time: b[0] as number,
+      host_id: b[1] as string,
+      severity: b[2] as string,
+      category: b[3] as string,
+      source: b[4] as string,
+      title: b[5] as string,
+      detail: b[6] as string,
+      metric: b[7] as string,
+      value: b[8] as number,
+    }
+  }
+
+  function allFor(sql: string, binds: unknown[]) {
+    let i = 0
+    const host = binds[i++] as string
+    let sev: string | undefined
+    let cutoff: number | undefined
+    if (sql.includes('severity = ?')) sev = binds[i++] as string
+    if (sql.includes('event_time >= ?')) cutoff = binds[i++] as number
+    const limit = binds[i++] as number
+
+    let out = rows.filter((r) => r.host_id === host)
+    if (sev) out = out.filter((r) => r.severity === sev)
+    if (cutoff != null) out = out.filter((r) => r.event_time >= cutoff)
+    out = out.sort((a, b) => b.event_time - a.event_time).slice(0, limit)
+    return { results: out }
+  }
+
+  function prepare(sql: string) {
+    const stmt = {
+      sql,
+      binds: undefined as unknown[] | undefined,
+      bind(...args: unknown[]) {
+        return { sql, binds: args, all: async () => allFor(sql, args) }
+      },
+    }
+    return stmt
+  }
+
+  async function batch(stmts: Array<{ sql: string; binds?: unknown[] }>) {
+    return stmts.map((s) => {
+      if (/CREATE (TABLE|INDEX)/.test(s.sql)) calls.migrations++
+      else if (/^\s*INSERT/.test(s.sql)) {
+        calls.inserts++
+        rows.push(bindsToRow(s.binds ?? []))
+      }
+      return { success: true }
+    })
+  }
+
+  return { prepare, batch, _rows: rows, _calls: calls }
+}
+
+// --- inject via mocked platform ---------------------------------------------
+let currentDb: ReturnType<typeof makeFakeD1> | null = null
+
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({
+    getD1Database: () => currentDb,
+  }),
+}))
+
+const { D1InsightsStore } = await import('./d1-store')
+
+const finding = (over: Partial<Finding> = {}): Finding => ({
+  severity: 'info',
+  category: 'storage',
+  source: 'ai-insight',
+  title: 't',
+  detail: 'd',
+  metric: 'm',
+  value: 1,
+  ...over,
+})
+
+beforeEach(() => {
+  currentDb = makeFakeD1()
+})
+
+describe('D1InsightsStore', () => {
+  test('exposes the d1 backend id', () => {
+    expect(new D1InsightsStore().backend).toBe('d1')
+  })
+
+  test('migrates lazily once, then inserts the batch', async () => {
+    const store = new D1InsightsStore()
+    expect(
+      await store.record(0, [finding({ title: 'a' }), finding({ title: 'b' })])
+    ).toBe(true)
+    expect(currentDb?._calls.migrations).toBe(2) // CREATE TABLE + CREATE INDEX
+    expect(currentDb?._calls.inserts).toBe(2)
+
+    // Second write must not re-run the migration (per-instance guard).
+    await store.record(0, [finding({ title: 'c' })])
+    expect(currentDb?._calls.migrations).toBe(2)
+    expect(currentDb?._calls.inserts).toBe(3)
+  })
+
+  test('round-trips rows with the full shape and ISO event_time', async () => {
+    const store = new D1InsightsStore()
+    await store.record(0, [finding({ title: 'a' }), finding({ title: 'b' })])
+
+    const out = await store.list(0)
+    // Both rows come back; order across same-ms writes is event_time-only and
+    // therefore not asserted (the store has no secondary sort key).
+    expect(out.map((r) => r.title).sort()).toEqual(['a', 'b'])
+    expect(out[0]).toMatchObject({
+      host_id: '0',
+      source: 'ai-insight',
+      value: 1,
+    })
+    expect(() => new Date(out[0].event_time).toISOString()).not.toThrow()
+    expect(out[0].event_time).toContain('T') // ISO string, not unix ms
+  })
+
+  test('filters by severity and host', async () => {
+    const store = new D1InsightsStore()
+    await store.record(0, [
+      finding({ severity: 'info', title: 'i' }),
+      finding({ severity: 'critical', title: 'c' }),
+    ])
+    await store.record(1, [finding({ title: 'other-host' })])
+
+    expect(
+      (await store.list(0, { severity: 'critical' })).map((r) => r.title)
+    ).toEqual(['c'])
+    expect((await store.list(1)).map((r) => r.title)).toEqual(['other-host'])
+  })
+
+  test('empty batch is a no-op success (no migration, no insert)', async () => {
+    const store = new D1InsightsStore()
+    expect(await store.record(0, [])).toBe(true)
+    expect(currentDb?._calls.migrations).toBe(0)
+    expect(currentDb?._calls.inserts).toBe(0)
+  })
+
+  test('degrades to false / [] when no D1 binding is present', async () => {
+    currentDb = null
+    const store = new D1InsightsStore()
+    expect(await store.record(0, [finding()])).toBe(false)
+    expect(await store.list(0)).toEqual([])
+  })
+})

--- a/apps/dashboard/src/lib/insights/store/d1-store.ts
+++ b/apps/dashboard/src/lib/insights/store/d1-store.ts
@@ -67,7 +67,9 @@ interface D1FindingRow {
 
 export class D1InsightsStore implements InsightsStore {
   readonly backend = 'd1' as const
-  private migrated = false
+  // Single-flight migration: concurrent first calls share one promise so the
+  // idempotent DDL runs at most once; a failure clears it so the next call retries.
+  private migration: Promise<void> | null = null
 
   private getDb(): D1Database | null {
     const bindings = getPlatformBindings()
@@ -78,10 +80,17 @@ export class D1InsightsStore implements InsightsStore {
     return null
   }
 
-  private async ensureMigrated(db: D1Database): Promise<void> {
-    if (this.migrated) return
-    await db.batch([db.prepare(MIGRATION_SQL), db.prepare(INDEX_SQL)])
-    this.migrated = true
+  private ensureMigrated(db: D1Database): Promise<void> {
+    if (!this.migration) {
+      this.migration = db
+        .batch([db.prepare(MIGRATION_SQL), db.prepare(INDEX_SQL)])
+        .then(() => undefined)
+        .catch((err) => {
+          this.migration = null
+          throw err
+        })
+    }
+    return this.migration
   }
 
   async record(hostId: number, findings: Finding[]): Promise<boolean> {

--- a/apps/dashboard/src/lib/insights/store/d1-store.ts
+++ b/apps/dashboard/src/lib/insights/store/d1-store.ts
@@ -82,13 +82,14 @@ export class D1InsightsStore implements InsightsStore {
 
   private ensureMigrated(db: D1Database): Promise<void> {
     if (!this.migration) {
-      this.migration = db
-        .batch([db.prepare(MIGRATION_SQL), db.prepare(INDEX_SQL)])
-        .then(() => undefined)
-        .catch((err) => {
+      this.migration = (async () => {
+        try {
+          await db.batch([db.prepare(MIGRATION_SQL), db.prepare(INDEX_SQL)])
+        } catch (err) {
           this.migration = null
           throw err
-        })
+        }
+      })()
     }
     return this.migration
   }

--- a/apps/dashboard/src/lib/insights/store/d1-store.ts
+++ b/apps/dashboard/src/lib/insights/store/d1-store.ts
@@ -1,0 +1,181 @@
+/**
+ * Cloudflare D1 insights backend.
+ *
+ * Persists findings in a dedicated `insights_findings` table on a D1 database.
+ * By default it reuses the same D1 binding as the agent's conversation store
+ * (`CONVERSATIONS_D1`) so operators who already provisioned D1 get insight
+ * persistence for free; an optional dedicated `INSIGHTS_D1` binding takes
+ * precedence when present.
+ *
+ * Best-effort like every backend: the table is migrated lazily on first use and
+ * all failures are swallowed (logged) so a misconfigured binding degrades to
+ * "no persisted insights" rather than breaking generation. Mirrors the D1
+ * conversation store but with the scalar findings schema.
+ */
+
+import type {
+  Finding,
+  FindingRow,
+  InsightsStore,
+  ListFindingsOptions,
+} from './types'
+
+import { intervalToMs } from './interval'
+import { ErrorLogger } from '@chm/logger'
+import { getPlatformBindings } from '@chm/platform'
+
+const COMPONENT = 'insights-d1-store'
+const warn = (msg: string) =>
+  ErrorLogger.logWarning(`[insights-d1-store] ${msg}`, { component: COMPONENT })
+
+/** Preferred dedicated binding, then the shared conversation binding. */
+const D1_BINDING_NAMES = ['INSIGHTS_D1', 'CONVERSATIONS_D1'] as const
+
+const TABLE = 'insights_findings'
+
+const MIGRATION_SQL = `
+  CREATE TABLE IF NOT EXISTS ${TABLE} (
+    event_time INTEGER NOT NULL,
+    host_id TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    category TEXT NOT NULL,
+    source TEXT NOT NULL,
+    title TEXT NOT NULL,
+    detail TEXT NOT NULL DEFAULT '',
+    metric TEXT NOT NULL DEFAULT '',
+    value REAL NOT NULL DEFAULT 0
+  )
+`
+const INDEX_SQL = `
+  CREATE INDEX IF NOT EXISTS idx_${TABLE}_host_time
+    ON ${TABLE} (host_id, event_time)
+`
+
+/** D1 row shape (event_time is unix ms). */
+interface D1FindingRow {
+  event_time: number
+  host_id: string
+  severity: string
+  category: string
+  source: string
+  title: string
+  detail: string
+  metric: string
+  value: number
+}
+
+export class D1InsightsStore implements InsightsStore {
+  readonly backend = 'd1' as const
+  private migrated = false
+
+  private getDb(): D1Database | null {
+    const bindings = getPlatformBindings()
+    for (const name of D1_BINDING_NAMES) {
+      const db = bindings.getD1Database(name)
+      if (db) return db
+    }
+    return null
+  }
+
+  private async ensureMigrated(db: D1Database): Promise<void> {
+    if (this.migrated) return
+    await db.batch([db.prepare(MIGRATION_SQL), db.prepare(INDEX_SQL)])
+    this.migrated = true
+  }
+
+  async record(hostId: number, findings: Finding[]): Promise<boolean> {
+    if (findings.length === 0) return true
+    try {
+      const db = this.getDb()
+      if (!db) {
+        warn('no D1 binding (INSIGHTS_D1 / CONVERSATIONS_D1) found')
+        return false
+      }
+      await this.ensureMigrated(db)
+
+      const now = Date.now()
+      const stmt = db.prepare(
+        `INSERT INTO ${TABLE}
+           (event_time, host_id, severity, category, source, title, detail, metric, value)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)`
+      )
+      await db.batch(
+        findings.map((f) =>
+          stmt.bind(
+            now,
+            String(hostId),
+            f.severity,
+            f.category,
+            f.source,
+            f.title,
+            f.detail ?? '',
+            f.metric ?? '',
+            f.value ?? 0
+          )
+        )
+      )
+      return true
+    } catch (err) {
+      warn(`failed to record findings on host ${hostId}: ${err}`)
+      return false
+    }
+  }
+
+  async list(
+    hostId: number,
+    opts: ListFindingsOptions = {}
+  ): Promise<FindingRow[]> {
+    const { severity, since, limit = 100 } = opts
+    try {
+      const db = this.getDb()
+      if (!db) return []
+      await this.ensureMigrated(db)
+
+      const conditions = ['host_id = ?']
+      const binds: (string | number)[] = [String(hostId)]
+
+      if (severity) {
+        conditions.push('severity = ?')
+        binds.push(severity)
+      }
+      if (since) {
+        const ms = intervalToMs(since)
+        if (ms !== null) {
+          conditions.push('event_time >= ?')
+          binds.push(Date.now() - ms)
+        } else {
+          warn(`ignoring invalid "since" value: ${since}`)
+        }
+      }
+
+      const safeLimit = Math.min(Math.max(Math.trunc(limit) || 0, 1), 1000)
+      binds.push(safeLimit)
+
+      const stmt = db
+        .prepare(
+          `SELECT event_time, host_id, severity, category, source, title, detail, metric, value
+           FROM ${TABLE}
+           WHERE ${conditions.join(' AND ')}
+           ORDER BY event_time DESC
+           LIMIT ?`
+        )
+        .bind(...binds)
+
+      const result = await stmt.all<D1FindingRow>()
+      return (result.results ?? []).map((r) => ({
+        event_time: new Date(r.event_time).toISOString(),
+        host_id: r.host_id,
+        severity: r.severity,
+        category: r.category,
+        source: r.source,
+        title: r.title,
+        detail: r.detail,
+        metric: r.metric,
+        value: r.value,
+      }))
+    } catch (err) {
+      warn(`failed to list findings on host ${hostId}: ${err}`)
+      return []
+    }
+  }
+}

--- a/apps/dashboard/src/lib/insights/store/d1-store.ts
+++ b/apps/dashboard/src/lib/insights/store/d1-store.ts
@@ -21,6 +21,7 @@ import type {
 } from './types'
 
 import { intervalToMs } from './interval'
+import { clampLimit, rowFromStored } from './types'
 import { ErrorLogger } from '@chm/logger'
 import { getPlatformBindings } from '@chm/platform'
 
@@ -125,7 +126,7 @@ export class D1InsightsStore implements InsightsStore {
     hostId: number,
     opts: ListFindingsOptions = {}
   ): Promise<FindingRow[]> {
-    const { severity, since, limit = 100 } = opts
+    const { severity, since } = opts
     try {
       const db = this.getDb()
       if (!db) return []
@@ -148,8 +149,7 @@ export class D1InsightsStore implements InsightsStore {
         }
       }
 
-      const safeLimit = Math.min(Math.max(Math.trunc(limit) || 0, 1), 1000)
-      binds.push(safeLimit)
+      binds.push(clampLimit(opts.limit))
 
       const stmt = db
         .prepare(
@@ -162,17 +162,7 @@ export class D1InsightsStore implements InsightsStore {
         .bind(...binds)
 
       const result = await stmt.all<D1FindingRow>()
-      return (result.results ?? []).map((r) => ({
-        event_time: new Date(r.event_time).toISOString(),
-        host_id: r.host_id,
-        severity: r.severity,
-        category: r.category,
-        source: r.source,
-        title: r.title,
-        detail: r.detail,
-        metric: r.metric,
-        value: r.value,
-      }))
+      return (result.results ?? []).map(rowFromStored)
     } catch (err) {
       warn(`failed to list findings on host ${hostId}: ${err}`)
       return []

--- a/apps/dashboard/src/lib/insights/store/interval.test.ts
+++ b/apps/dashboard/src/lib/insights/store/interval.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests for the shared "since" interval parser used by the non-ClickHouse
+ * insight backends. The grammar must match ClickHouse's INTERVAL units so every
+ * backend honors the same recency windows, and must reject malformed input
+ * (defense in depth alongside the ClickHouse path's sanitizeSince).
+ */
+
+import { intervalToMs } from './interval'
+import { describe, expect, test } from 'bun:test'
+
+describe('intervalToMs', () => {
+  test('parses each supported unit', () => {
+    expect(intervalToMs('1 SECOND')).toBe(1000)
+    expect(intervalToMs('1 MINUTE')).toBe(60_000)
+    expect(intervalToMs('1 HOUR')).toBe(3_600_000)
+    expect(intervalToMs('1 DAY')).toBe(86_400_000)
+    expect(intervalToMs('1 WEEK')).toBe(604_800_000)
+    expect(intervalToMs('1 MONTH')).toBe(2_592_000_000)
+  })
+
+  test('multiplies by the quantity', () => {
+    expect(intervalToMs('6 HOUR')).toBe(6 * 3_600_000)
+    expect(intervalToMs('30 DAY')).toBe(30 * 86_400_000)
+  })
+
+  test('is case-insensitive and trims, accepts plural', () => {
+    expect(intervalToMs('  6 hours ')).toBe(6 * 3_600_000)
+    expect(intervalToMs('2 Days')).toBe(2 * 86_400_000)
+  })
+
+  test('returns null for malformed input', () => {
+    expect(intervalToMs('')).toBeNull()
+    expect(intervalToMs('HOUR')).toBeNull()
+    expect(intervalToMs('6')).toBeNull()
+    expect(intervalToMs('-6 HOUR')).toBeNull()
+    expect(intervalToMs('6 FORTNIGHT')).toBeNull()
+    expect(intervalToMs('6 HOUR; DROP TABLE')).toBeNull()
+    expect(intervalToMs('999999 HOUR')).toBeNull() // > 5 digits
+  })
+})

--- a/apps/dashboard/src/lib/insights/store/interval.ts
+++ b/apps/dashboard/src/lib/insights/store/interval.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared "since" interval handling for the non-ClickHouse insight backends.
+ *
+ * The findings API expresses recency windows as ClickHouse interval strings
+ * ("6 HOUR", "1 DAY"). ClickHouse evaluates these natively; the SQL (D1 /
+ * Postgres) and in-memory backends need to translate them to a millisecond
+ * cutoff. Keeping this in one place ensures every backend honors the same
+ * grammar and rejects the same malformed input (defense in depth — the value
+ * also flows through `sanitizeSince` on the ClickHouse path).
+ */
+
+const UNIT_MS: Record<string, number> = {
+  SECOND: 1000,
+  MINUTE: 60_000,
+  HOUR: 3_600_000,
+  DAY: 86_400_000,
+  WEEK: 604_800_000,
+  MONTH: 2_592_000_000, // 30 days, matching the findings-table TTL granularity
+}
+
+/**
+ * Parse a ClickHouse interval expression ("24 HOUR") into milliseconds.
+ * Returns null when the expression is invalid so callers can skip the filter.
+ */
+export function intervalToMs(value: string): number | null {
+  const match = value
+    .trim()
+    .toUpperCase()
+    .match(/^(\d{1,5})\s+(SECOND|MINUTE|HOUR|DAY|WEEK|MONTH)S?$/)
+  if (!match) return null
+  return Number(match[1]) * UNIT_MS[match[2]]
+}

--- a/apps/dashboard/src/lib/insights/store/memory-store.test.ts
+++ b/apps/dashboard/src/lib/insights/store/memory-store.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the in-memory insights backend. No mocks — exercises the recency
+ * (`since`) filter, severity filter, newest-first ordering, the limit clamp, and
+ * the per-host buffer bound. This is the reference implementation of the
+ * InsightsStore read/write contract that the DB-backed stores must match.
+ */
+
+import type { Finding } from './types'
+
+import { MemoryInsightsStore } from './memory-store'
+import { describe, expect, test } from 'bun:test'
+
+const finding = (over: Partial<Finding> = {}): Finding => ({
+  severity: 'info',
+  category: 'storage',
+  source: 'ai-insight',
+  title: 'table X is fragmented',
+  detail: 'consider OPTIMIZE',
+  metric: 'max_active_parts',
+  value: 318,
+  ...over,
+})
+
+describe('MemoryInsightsStore', () => {
+  test('record then list round-trips with the full FindingRow shape', async () => {
+    const store = new MemoryInsightsStore()
+    expect(await store.record(0, [finding()])).toBe(true)
+
+    const rows = await store.list(0)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      host_id: '0',
+      severity: 'info',
+      category: 'storage',
+      source: 'ai-insight',
+      title: 'table X is fragmented',
+      detail: 'consider OPTIMIZE',
+      metric: 'max_active_parts',
+      value: 318,
+    })
+    expect(typeof rows[0].event_time).toBe('string')
+  })
+
+  test('empty batch is a no-op success', async () => {
+    const store = new MemoryInsightsStore()
+    expect(await store.record(0, [])).toBe(true)
+    expect(await store.list(0)).toEqual([])
+  })
+
+  test('defaults optional fields to "" / 0', async () => {
+    const store = new MemoryInsightsStore()
+    await store.record(1, [
+      {
+        severity: 'warning',
+        category: 'anomaly',
+        source: 'ai-insight',
+        title: 't',
+      },
+    ])
+    const [row] = await store.list(1)
+    expect(row.detail).toBe('')
+    expect(row.metric).toBe('')
+    expect(row.value).toBe(0)
+  })
+
+  test('isolates rows per host', async () => {
+    const store = new MemoryInsightsStore()
+    await store.record(0, [finding({ title: 'host0' })])
+    await store.record(1, [finding({ title: 'host1' })])
+    expect((await store.list(0)).map((r) => r.title)).toEqual(['host0'])
+    expect((await store.list(1)).map((r) => r.title)).toEqual(['host1'])
+  })
+
+  test('returns newest first', async () => {
+    const store = new MemoryInsightsStore()
+    await store.record(0, [finding({ title: 'first' })])
+    await store.record(0, [finding({ title: 'second' })])
+    expect((await store.list(0)).map((r) => r.title)).toEqual([
+      'second',
+      'first',
+    ])
+  })
+
+  test('filters by severity', async () => {
+    const store = new MemoryInsightsStore()
+    await store.record(0, [
+      finding({ severity: 'info', title: 'i' }),
+      finding({ severity: 'critical', title: 'c' }),
+    ])
+    const rows = await store.list(0, { severity: 'critical' })
+    expect(rows.map((r) => r.title)).toEqual(['c'])
+  })
+
+  test('honors the limit clamp', async () => {
+    const store = new MemoryInsightsStore()
+    await store.record(
+      0,
+      Array.from({ length: 5 }, (_, i) => finding({ title: `t${i}` }))
+    )
+    expect(await store.list(0, { limit: 2 })).toHaveLength(2)
+    // out-of-range limits clamp into [1, 1000]
+    expect(await store.list(0, { limit: 0 })).toHaveLength(1)
+  })
+
+  test('filters out rows older than the since window', async () => {
+    const store = new MemoryInsightsStore()
+    await store.record(0, [finding()])
+    // A zero-width-ish past window excludes the just-written row.
+    expect(await store.list(0, { since: '1 SECOND' })).toHaveLength(1)
+    // Invalid since is ignored (row still returned), not treated as 0.
+    expect(await store.list(0, { since: 'garbage' })).toHaveLength(1)
+  })
+})

--- a/apps/dashboard/src/lib/insights/store/memory-store.ts
+++ b/apps/dashboard/src/lib/insights/store/memory-store.ts
@@ -15,7 +15,7 @@ import type {
 } from './types'
 
 import { intervalToMs } from './interval'
-import { toFindingRow } from './types'
+import { clampLimit, toFindingRow } from './types'
 
 /** Bound the per-host buffer so a long-lived worker cannot grow unbounded. */
 const MAX_ROWS_PER_HOST = 1000
@@ -40,7 +40,7 @@ export class MemoryInsightsStore implements InsightsStore {
     hostId: number,
     opts: ListFindingsOptions = {}
   ): Promise<FindingRow[]> {
-    const { severity, since, limit = 100 } = opts
+    const { severity, since } = opts
     let rows = [...(this.rows.get(hostId) ?? [])].reverse() // newest first
 
     if (severity) rows = rows.filter((r) => r.severity === severity)
@@ -53,7 +53,6 @@ export class MemoryInsightsStore implements InsightsStore {
       }
     }
 
-    const safeLimit = Math.min(Math.max(Math.trunc(limit) || 0, 1), 1000)
-    return rows.slice(0, safeLimit)
+    return rows.slice(0, clampLimit(opts.limit))
   }
 }

--- a/apps/dashboard/src/lib/insights/store/memory-store.ts
+++ b/apps/dashboard/src/lib/insights/store/memory-store.ts
@@ -1,0 +1,59 @@
+/**
+ * In-memory insights backend — ephemeral, last-resort fallback.
+ *
+ * Holds findings in a per-host array inside the module. Data is lost on worker
+ * restart / cold start, so this is never a deliberate production target; it
+ * exists so `resolveInsightsStore` always returns a working store and so tests
+ * have a dependency-free backend. Mirrors `conversation-store/memory-store.ts`.
+ */
+
+import type {
+  Finding,
+  FindingRow,
+  InsightsStore,
+  ListFindingsOptions,
+} from './types'
+
+import { intervalToMs } from './interval'
+import { toFindingRow } from './types'
+
+/** Bound the per-host buffer so a long-lived worker cannot grow unbounded. */
+const MAX_ROWS_PER_HOST = 1000
+
+export class MemoryInsightsStore implements InsightsStore {
+  readonly backend = 'memory' as const
+
+  // host id → findings, newest last.
+  private readonly rows = new Map<number, FindingRow[]>()
+
+  async record(hostId: number, findings: Finding[]): Promise<boolean> {
+    if (findings.length === 0) return true
+    const now = new Date().toISOString()
+    const bucket = this.rows.get(hostId) ?? []
+    for (const f of findings) bucket.push(toFindingRow(hostId, f, now))
+    // Keep only the most recent rows.
+    this.rows.set(hostId, bucket.slice(-MAX_ROWS_PER_HOST))
+    return true
+  }
+
+  async list(
+    hostId: number,
+    opts: ListFindingsOptions = {}
+  ): Promise<FindingRow[]> {
+    const { severity, since, limit = 100 } = opts
+    let rows = [...(this.rows.get(hostId) ?? [])].reverse() // newest first
+
+    if (severity) rows = rows.filter((r) => r.severity === severity)
+
+    if (since) {
+      const ms = intervalToMs(since)
+      if (ms !== null) {
+        const cutoff = Date.now() - ms
+        rows = rows.filter((r) => Date.parse(r.event_time) >= cutoff)
+      }
+    }
+
+    const safeLimit = Math.min(Math.max(Math.trunc(limit) || 0, 1), 1000)
+    return rows.slice(0, safeLimit)
+  }
+}

--- a/apps/dashboard/src/lib/insights/store/postgres-store.test.ts
+++ b/apps/dashboard/src/lib/insights/store/postgres-store.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the PostgreSQL insights backend.
+ *
+ * The `postgres` package is a callable tagged-template (`sql\`...\``) that also
+ * acts as a helper (`sql(rows)`) and exposes `sql.unsafe(ddl)`. We mock it with
+ * a fake that distinguishes those three call shapes, so we can assert: the
+ * connection-string guard, lazy one-time migration, the insert path, the
+ * unix-ms → ISO and string-numeric → number mapping on read, and best-effort
+ * degrade when a query rejects.
+ */
+
+import type { Finding } from './types'
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// --- behavioral `postgres` fake ---------------------------------------------
+let nextRows: Array<Record<string, unknown>> = []
+let migrations = 0
+let failTemplates = false
+
+function isTemplate(args: unknown[]): boolean {
+  return Array.isArray(args[0]) && 'raw' in (args[0] as object)
+}
+
+function makeSql() {
+  function sql(...args: unknown[]): unknown {
+    if (!isTemplate(args)) {
+      // Helper form `sql(rows)` → opaque fragment, embedded into a template.
+      return { __fragment: true }
+    }
+    const text = (args[0] as string[]).join(' ')
+    // Only the composed top-level queries execute; embedded conditional
+    // fragments (`sql`AND ...`` / empty `sql``) never run on their own, so they
+    // must not reject (doing so would create unhandled rejections).
+    const isQuery = /SELECT|INSERT/i.test(text)
+    if (failTemplates && isQuery) {
+      return Promise.reject(new Error('pg query failed'))
+    }
+    return Promise.resolve(/SELECT/i.test(text) ? nextRows : [])
+  }
+  sql.unsafe = async () => {
+    migrations++
+    return []
+  }
+  return sql
+}
+
+let currentSql = makeSql()
+
+mock.module('postgres', () => ({
+  default: (_url?: string, _opts?: unknown) => currentSql,
+}))
+
+const { PostgresInsightsStore } = await import('./postgres-store')
+
+const finding = (over: Partial<Finding> = {}): Finding => ({
+  severity: 'info',
+  category: 'storage',
+  source: 'ai-insight',
+  title: 't',
+  detail: 'd',
+  metric: 'm',
+  value: 1,
+  ...over,
+})
+
+beforeEach(() => {
+  nextRows = []
+  migrations = 0
+  failTemplates = false
+  currentSql = makeSql()
+})
+
+describe('PostgresInsightsStore', () => {
+  test('exposes the postgres backend id', () => {
+    expect(new PostgresInsightsStore('postgres://x').backend).toBe('postgres')
+  })
+
+  test('throws if no connection string is available', () => {
+    const saved = process.env.DATABASE_URL
+    delete process.env.DATABASE_URL
+    expect(() => new PostgresInsightsStore()).toThrow(/DATABASE_URL/)
+    if (saved !== undefined) process.env.DATABASE_URL = saved
+  })
+
+  test('migrates lazily exactly once across multiple writes', async () => {
+    const store = new PostgresInsightsStore('postgres://x')
+    expect(await store.record(0, [finding()])).toBe(true)
+    expect(migrations).toBe(1)
+    expect(await store.record(0, [finding()])).toBe(true)
+    expect(migrations).toBe(1) // initialized guard prevents re-migration
+  })
+
+  test('empty batch is a no-op success', async () => {
+    const store = new PostgresInsightsStore('postgres://x')
+    expect(await store.record(0, [])).toBe(true)
+    expect(migrations).toBe(0)
+  })
+
+  test('list maps driver rows (string numerics, ms event_time) to FindingRow', async () => {
+    nextRows = [
+      {
+        event_time: 1781900000000,
+        host_id: '0',
+        severity: 'critical',
+        category: 'anomaly',
+        source: 'ai-insight',
+        title: 'spike',
+        detail: '',
+        metric: 'error_rate',
+        value: '5', // postgres returns DOUBLE PRECISION as string
+      },
+    ]
+    const store = new PostgresInsightsStore('postgres://x')
+    const [row] = await store.list(0, { since: '6 HOUR', severity: 'critical' })
+    expect(row.value).toBe(5) // coerced to number
+    expect(typeof row.value).toBe('number')
+    expect(row.event_time).toBe(new Date(1781900000000).toISOString())
+    expect(row.title).toBe('spike')
+  })
+
+  test('degrades to false / [] when a query rejects', async () => {
+    const store = new PostgresInsightsStore('postgres://x')
+    failTemplates = true
+    expect(await store.record(0, [finding()])).toBe(false)
+    expect(await store.list(0)).toEqual([])
+  })
+})

--- a/apps/dashboard/src/lib/insights/store/postgres-store.ts
+++ b/apps/dashboard/src/lib/insights/store/postgres-store.ts
@@ -80,13 +80,14 @@ export class PostgresInsightsStore implements InsightsStore {
 
   private ensureMigrated(): Promise<void> {
     if (!this.migration) {
-      this.migration = this.sql
-        .unsafe(MIGRATION_SQL)
-        .then(() => undefined)
-        .catch((err) => {
+      this.migration = (async () => {
+        try {
+          await this.sql.unsafe(MIGRATION_SQL)
+        } catch (err) {
           this.migration = null
           throw err
-        })
+        }
+      })()
     }
     return this.migration
   }

--- a/apps/dashboard/src/lib/insights/store/postgres-store.ts
+++ b/apps/dashboard/src/lib/insights/store/postgres-store.ts
@@ -22,6 +22,7 @@ import type {
 } from './types'
 
 import { intervalToMs } from './interval'
+import { clampLimit, rowFromStored } from './types'
 import { ErrorLogger } from '@chm/logger'
 import postgres from 'postgres'
 
@@ -109,11 +110,11 @@ export class PostgresInsightsStore implements InsightsStore {
     hostId: number,
     opts: ListFindingsOptions = {}
   ): Promise<FindingRow[]> {
-    const { severity, since, limit = 100 } = opts
+    const { severity, since } = opts
     try {
       await this.ensureMigrated()
 
-      const safeLimit = Math.min(Math.max(Math.trunc(limit) || 0, 1), 1000)
+      const safeLimit = clampLimit(opts.limit)
       const sinceMs = since ? intervalToMs(since) : null
       if (since && sinceMs === null)
         warn(`ignoring invalid "since" value: ${since}`)
@@ -129,17 +130,7 @@ export class PostgresInsightsStore implements InsightsStore {
         LIMIT ${safeLimit}
       `) as unknown as PgFindingRow[]
 
-      return result.map((r) => ({
-        event_time: new Date(Number(r.event_time)).toISOString(),
-        host_id: r.host_id,
-        severity: r.severity,
-        category: r.category,
-        source: r.source,
-        title: r.title,
-        detail: r.detail,
-        metric: r.metric,
-        value: Number(r.value),
-      }))
+      return result.map(rowFromStored)
     } catch (err) {
       warn(`failed to list findings on host ${hostId}: ${err}`)
       return []

--- a/apps/dashboard/src/lib/insights/store/postgres-store.ts
+++ b/apps/dashboard/src/lib/insights/store/postgres-store.ts
@@ -64,7 +64,9 @@ interface PgFindingRow {
 export class PostgresInsightsStore implements InsightsStore {
   readonly backend = 'postgres' as const
   private readonly sql: ReturnType<typeof postgres>
-  private initialized = false
+  // Single-flight migration: concurrent first calls share one promise so the
+  // idempotent DDL runs at most once; a failure clears it so the next call retries.
+  private migration: Promise<void> | null = null
 
   constructor(connectionString?: string) {
     const url = connectionString ?? process.env.DATABASE_URL
@@ -76,10 +78,17 @@ export class PostgresInsightsStore implements InsightsStore {
     this.sql = postgres(url, { max: 5, idle_timeout: 20 })
   }
 
-  private async ensureMigrated(): Promise<void> {
-    if (this.initialized) return
-    await this.sql.unsafe(MIGRATION_SQL)
-    this.initialized = true
+  private ensureMigrated(): Promise<void> {
+    if (!this.migration) {
+      this.migration = this.sql
+        .unsafe(MIGRATION_SQL)
+        .then(() => undefined)
+        .catch((err) => {
+          this.migration = null
+          throw err
+        })
+    }
+    return this.migration
   }
 
   async record(hostId: number, findings: Finding[]): Promise<boolean> {

--- a/apps/dashboard/src/lib/insights/store/postgres-store.ts
+++ b/apps/dashboard/src/lib/insights/store/postgres-store.ts
@@ -1,0 +1,148 @@
+/**
+ * PostgreSQL insights backend.
+ *
+ * Persists findings in an `insights_findings` table, auto-migrated on first use.
+ * Reuses the same `DATABASE_URL` as the agent's Postgres conversation store, so
+ * a single Postgres instance can back both subsystems.
+ *
+ * IMPORTANT: like the conversation Postgres store, this module is only ever
+ * loaded via dynamic import from the resolver on the Node path — the `postgres`
+ * package is Node-only and must never be bundled into the Cloudflare Workers
+ * build (the CF path resolves D1 first and never reaches here).
+ *
+ * Best-effort: any failure logs and degrades to no-op / empty rather than
+ * throwing, matching the contract of the other backends.
+ */
+
+import type {
+  Finding,
+  FindingRow,
+  InsightsStore,
+  ListFindingsOptions,
+} from './types'
+
+import { intervalToMs } from './interval'
+import { ErrorLogger } from '@chm/logger'
+import postgres from 'postgres'
+
+const COMPONENT = 'insights-postgres-store'
+const warn = (msg: string) =>
+  ErrorLogger.logWarning(`[insights-postgres-store] ${msg}`, {
+    component: COMPONENT,
+  })
+
+const MIGRATION_SQL = `
+  CREATE TABLE IF NOT EXISTS insights_findings (
+    event_time BIGINT NOT NULL,
+    host_id TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    category TEXT NOT NULL,
+    source TEXT NOT NULL,
+    title TEXT NOT NULL,
+    detail TEXT NOT NULL DEFAULT '',
+    metric TEXT NOT NULL DEFAULT '',
+    value DOUBLE PRECISION NOT NULL DEFAULT 0
+  );
+  CREATE INDEX IF NOT EXISTS idx_insights_findings_host_time
+    ON insights_findings (host_id, event_time DESC);
+`
+
+/** Postgres row shape (event_time is unix ms, returned as string by the driver). */
+interface PgFindingRow {
+  event_time: string | number
+  host_id: string
+  severity: string
+  category: string
+  source: string
+  title: string
+  detail: string
+  metric: string
+  value: string | number
+}
+
+export class PostgresInsightsStore implements InsightsStore {
+  readonly backend = 'postgres' as const
+  private readonly sql: ReturnType<typeof postgres>
+  private initialized = false
+
+  constructor(connectionString?: string) {
+    const url = connectionString ?? process.env.DATABASE_URL
+    if (!url) {
+      throw new Error(
+        'DATABASE_URL is required for the Postgres insights store'
+      )
+    }
+    this.sql = postgres(url, { max: 5, idle_timeout: 20 })
+  }
+
+  private async ensureMigrated(): Promise<void> {
+    if (this.initialized) return
+    await this.sql.unsafe(MIGRATION_SQL)
+    this.initialized = true
+  }
+
+  async record(hostId: number, findings: Finding[]): Promise<boolean> {
+    if (findings.length === 0) return true
+    try {
+      await this.ensureMigrated()
+      const now = Date.now()
+      const rows = findings.map((f) => ({
+        event_time: now,
+        host_id: String(hostId),
+        severity: f.severity,
+        category: f.category,
+        source: f.source,
+        title: f.title,
+        detail: f.detail ?? '',
+        metric: f.metric ?? '',
+        value: f.value ?? 0,
+      }))
+      await this.sql`INSERT INTO insights_findings ${this.sql(rows)}`
+      return true
+    } catch (err) {
+      warn(`failed to record findings on host ${hostId}: ${err}`)
+      return false
+    }
+  }
+
+  async list(
+    hostId: number,
+    opts: ListFindingsOptions = {}
+  ): Promise<FindingRow[]> {
+    const { severity, since, limit = 100 } = opts
+    try {
+      await this.ensureMigrated()
+
+      const safeLimit = Math.min(Math.max(Math.trunc(limit) || 0, 1), 1000)
+      const sinceMs = since ? intervalToMs(since) : null
+      if (since && sinceMs === null)
+        warn(`ignoring invalid "since" value: ${since}`)
+      const cutoff = sinceMs !== null ? Date.now() - sinceMs : null
+
+      const result = (await this.sql`
+        SELECT event_time, host_id, severity, category, source, title, detail, metric, value
+        FROM insights_findings
+        WHERE host_id = ${String(hostId)}
+          ${severity ? this.sql`AND severity = ${severity}` : this.sql``}
+          ${cutoff !== null ? this.sql`AND event_time >= ${cutoff}` : this.sql``}
+        ORDER BY event_time DESC
+        LIMIT ${safeLimit}
+      `) as unknown as PgFindingRow[]
+
+      return result.map((r) => ({
+        event_time: new Date(Number(r.event_time)).toISOString(),
+        host_id: r.host_id,
+        severity: r.severity,
+        category: r.category,
+        source: r.source,
+        title: r.title,
+        detail: r.detail,
+        metric: r.metric,
+        value: Number(r.value),
+      }))
+    } catch (err) {
+      warn(`failed to list findings on host ${hostId}: ${err}`)
+      return []
+    }
+  }
+}

--- a/apps/dashboard/src/lib/insights/store/realistic-scenarios.test.ts
+++ b/apps/dashboard/src/lib/insights/store/realistic-scenarios.test.ts
@@ -296,7 +296,11 @@ async function runBackend(
   opts?: { since?: string; limit?: number }
 ): Promise<CanonicalCard[]> {
   const store = backend.make()
-  for (const batch of batches) await store.record(host, batch)
+  for (const batch of batches) {
+    // Assert the write succeeded — a degraded write must not pass silently and
+    // let a parity/contract check pass on an empty store.
+    expect(await store.record(host, batch)).toBe(true)
+  }
   const rows = await store.list(host, opts)
   return dedupeByKey(host, rows)
 }

--- a/apps/dashboard/src/lib/insights/store/realistic-scenarios.test.ts
+++ b/apps/dashboard/src/lib/insights/store/realistic-scenarios.test.ts
@@ -1,0 +1,744 @@
+/**
+ * Realistic-scenario battery for the pluggable InsightsStore.
+ *
+ * Mirrors the project's sql-validator realistic-scenario battery (#1759): a
+ * data-driven table of production-shaped scenarios, each run against EVERY
+ * in-process-testable backend (memory, D1, Postgres, AgentState) with semantic
+ * fakes of the underlying datastores. Two things are asserted per scenario:
+ *
+ *   1. Contract  — the canonical read-path output matches what the scenario expects.
+ *   2. Parity    — every backend produces the SAME canonical output.
+ *
+ * "Canonical output" is the store rows passed through the read-path's
+ * dedupe-by-stable-key normalization (`dedupeByKey` below mirrors
+ * read-insights.ts), because backends legitimately differ at the raw `list`
+ * level (AgentState upserts/dedups; SQL backends return raw rows) but MUST agree
+ * once normalized. A parity mismatch is a real interchangeability bug.
+ *
+ * The fakes simulate correct datastore semantics; the store code under test is
+ * real, so any SQL-building or row-mapping bug surfaces here.
+ */
+
+import type { Finding, FindingRow } from './types'
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Semantic fakes for the three DB-backed stores. Each persists rows and filters
+// the way its real datastore would, so the store's mapping logic is exercised.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface StoredRow {
+  event_time: number
+  host_id: string
+  severity: string
+  category: string
+  source: string
+  title: string
+  detail: string
+  metric: string
+  value: number
+}
+
+// --- D1 fake (positional ? binds) -------------------------------------------
+function makeFakeD1() {
+  const rows: StoredRow[] = []
+  function rowFromBinds(b: unknown[]): StoredRow {
+    return {
+      event_time: b[0] as number,
+      host_id: b[1] as string,
+      severity: b[2] as string,
+      category: b[3] as string,
+      source: b[4] as string,
+      title: b[5] as string,
+      detail: b[6] as string,
+      metric: b[7] as string,
+      value: b[8] as number,
+    }
+  }
+  function allFor(sql: string, binds: unknown[]) {
+    let i = 0
+    const host = binds[i++] as string
+    let sev: string | undefined
+    let cutoff: number | undefined
+    if (sql.includes('severity = ?')) sev = binds[i++] as string
+    if (sql.includes('event_time >= ?')) cutoff = binds[i++] as number
+    const limit = binds[i++] as number
+    let out = rows.filter((r) => r.host_id === host)
+    if (sev) out = out.filter((r) => r.severity === sev)
+    if (cutoff != null) out = out.filter((r) => r.event_time >= cutoff)
+    out = out.sort((a, b) => b.event_time - a.event_time).slice(0, limit)
+    return { results: out }
+  }
+  return {
+    prepare(sql: string) {
+      return {
+        sql,
+        bind(...args: unknown[]) {
+          return { sql, binds: args, all: async () => allFor(sql, args) }
+        },
+      }
+    },
+    async batch(stmts: Array<{ sql: string; binds?: unknown[] }>) {
+      return stmts.map((s) => {
+        if (/^\s*INSERT/.test(s.sql)) rows.push(rowFromBinds(s.binds ?? []))
+        return { success: true }
+      })
+    },
+  }
+}
+
+// --- Postgres fake (tagged-template; predicate fragments recorded in order) --
+function makeFakePg() {
+  const rows: StoredRow[] = []
+  let pending: Array<{ col: string; val: unknown }> = []
+  let pendingInsert: StoredRow[] | null = null
+
+  function sql(...args: unknown[]): unknown {
+    const isTpl = Array.isArray(args[0]) && 'raw' in (args[0] as object)
+    if (!isTpl) {
+      pendingInsert = args[0] as StoredRow[]
+      return { __frag: 'rows' }
+    }
+    const strings = args[0] as string[]
+    const values = args.slice(1)
+    const text = strings.join(' ')
+    if (/^\s*AND severity/.test(text)) {
+      pending.push({ col: 'severity', val: values[0] })
+      return { __frag: 'cond' }
+    }
+    if (/^\s*AND event_time/.test(text)) {
+      pending.push({ col: 'event_time', val: values[0] })
+      return { __frag: 'cond' }
+    }
+    if (text.trim() === '') return { __frag: 'empty' }
+    if (/INSERT/i.test(text)) {
+      for (const r of pendingInsert ?? []) rows.push({ ...r })
+      pendingInsert = null
+      return Promise.resolve([])
+    }
+    if (/SELECT/i.test(text)) {
+      const host = values[0] as string
+      const limit = values[values.length - 1] as number
+      let out = rows.filter((r) => r.host_id === host)
+      for (const p of pending) {
+        if (p.col === 'severity') out = out.filter((r) => r.severity === p.val)
+        if (p.col === 'event_time')
+          out = out.filter((r) => r.event_time >= (p.val as number))
+      }
+      pending = []
+      out = out.sort((a, b) => b.event_time - a.event_time).slice(0, limit)
+      // postgres driver returns DOUBLE PRECISION as string — mimic that.
+      return Promise.resolve(
+        out.map((r) => ({
+          ...r,
+          value: String(r.value),
+          event_time: r.event_time,
+        }))
+      )
+    }
+    return Promise.resolve([])
+  }
+  ;(sql as { unsafe?: unknown }).unsafe = async () => []
+  return sql
+}
+
+// --- AgentState fake (generic State store; upsert dedups by state_key) -------
+//
+// CRITICAL: the store does `import { AgentState } from '@agentstate/sdk'` and
+// `new AgentState(...)` — with ESM that named binding is snapshotted at module
+// load, so a getter/holder that swaps the class per test does NOT take effect
+// (unlike the D1/Postgres fakes, whose stores reach the dep through a runtime
+// CALL: getPlatformBindings() / postgres()). So we register ONE stable class
+// that reads a module-level map we reset per test.
+interface FakeStateRec {
+  agent_id: string
+  data: Record<string, unknown>
+  tags: string[]
+  updated_at: number
+}
+let agentStates = new Map<string, FakeStateRec>()
+
+class FakeAgentStateSdk {
+  constructor(_cfg: unknown) {}
+  async upsertState(
+    key: string,
+    body: { agent_id: string; data: Record<string, unknown>; tags: string[] }
+  ) {
+    agentStates.set(key, {
+      agent_id: body.agent_id,
+      data: body.data,
+      tags: body.tags,
+      updated_at: Number(body.data.event_time),
+    })
+    return { state_key: key, ...body }
+  }
+  async queryStates(q: {
+    agent_id?: string
+    tags?: string[]
+    updated_after?: number
+    limit?: number
+  }) {
+    let arr = [...agentStates.values()]
+    if (q.agent_id) arr = arr.filter((s) => s.agent_id === q.agent_id)
+    if (q.tags?.length)
+      arr = arr.filter((s) => q.tags!.every((t) => s.tags.includes(t)))
+    if (q.updated_after != null)
+      arr = arr.filter((s) => s.updated_at >= q.updated_after!)
+    arr = arr
+      .sort((a, b) => b.updated_at - a.updated_at)
+      .slice(0, q.limit ?? 100)
+    return {
+      data: arr,
+      pagination: { limit: q.limit ?? 100, next_cursor: null },
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock registration. Each fake is swapped in per test via the holders below.
+// ─────────────────────────────────────────────────────────────────────────────
+let currentD1: ReturnType<typeof makeFakeD1> | null = null
+let currentPg: ReturnType<typeof makeFakePg> = makeFakePg()
+
+/** Reset every backend's fake datastore to empty. */
+function resetFakes(): void {
+  currentD1 = makeFakeD1()
+  currentPg = makeFakePg()
+  agentStates = new Map()
+}
+
+mock.module('cloudflare:workers', () => ({ env: {} }))
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({ getD1Database: () => currentD1 }),
+}))
+mock.module('postgres', () => ({ default: () => currentPg }))
+mock.module('@agentstate/sdk', () => ({
+  AgentState: FakeAgentStateSdk,
+  AgentStateError: class extends Error {},
+}))
+
+const { MemoryInsightsStore } = await import('./memory-store')
+const { D1InsightsStore } = await import('./d1-store')
+const { PostgresInsightsStore } = await import('./postgres-store')
+const { AgentStateInsightsStore } = await import('./agentstate-store')
+const { insightKey } = await import('../types')
+
+import type { InsightsStore } from './types'
+
+interface Backend {
+  name: string
+  make: () => InsightsStore
+}
+
+const BACKENDS: Backend[] = [
+  { name: 'memory', make: () => new MemoryInsightsStore() },
+  { name: 'd1', make: () => new D1InsightsStore() },
+  { name: 'postgres', make: () => new PostgresInsightsStore('postgres://x') },
+  {
+    name: 'agentstate',
+    make: () => new AgentStateInsightsStore({ apiKey: 'as_live_TEST' }),
+  },
+]
+
+beforeEach(() => {
+  resetFakes()
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Canonical normalization — mirrors read-insights.ts dedupe-by-stable-key. The
+// store rows differ across backends at the raw level but MUST agree once
+// normalized this way (newest occurrence per key wins; rows are newest-first).
+// ─────────────────────────────────────────────────────────────────────────────
+interface CanonicalCard {
+  key: string
+  severity: string
+  category: string
+  source: string
+  title: string
+  detail: string
+  metric: string
+  value: number
+}
+
+const INSIGHT_SOURCE = 'ai-insight'
+
+function dedupeByKey(host: number, rows: FindingRow[]): CanonicalCard[] {
+  const byKey = new Map<string, CanonicalCard>()
+  for (const r of rows) {
+    if (r.source !== INSIGHT_SOURCE) continue
+    const key = insightKey(host, {
+      category: r.category,
+      metric: r.metric || undefined,
+      title: r.title,
+    })
+    if (!byKey.has(key)) {
+      byKey.set(key, {
+        key,
+        severity: r.severity,
+        category: r.category,
+        source: r.source,
+        title: r.title,
+        detail: r.detail,
+        metric: r.metric,
+        value: Number(r.value),
+      })
+    }
+  }
+  return [...byKey.values()].sort((a, b) => a.key.localeCompare(b.key))
+}
+
+/** Run a scenario's record batches against a backend and return canonical cards. */
+async function runBackend(
+  backend: Backend,
+  host: number,
+  batches: Finding[][],
+  opts?: { since?: string; limit?: number }
+): Promise<CanonicalCard[]> {
+  const store = backend.make()
+  for (const batch of batches) await store.record(host, batch)
+  const rows = await store.list(host, opts)
+  return dedupeByKey(host, rows)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario fixtures — production-shaped findings.
+// ─────────────────────────────────────────────────────────────────────────────
+const f = (over: Partial<Finding> = {}): Finding => ({
+  severity: 'info',
+  category: 'storage',
+  source: 'ai-insight',
+  title: 'table is fragmented',
+  detail: '',
+  metric: '',
+  value: 0,
+  ...over,
+})
+
+interface Scenario {
+  name: string
+  host: number
+  batches: Finding[][]
+  expect: (cards: CanonicalCard[]) => void
+  /**
+   * How to compare backends in the parity check. 'full' (default) requires
+   * identical canonical cards. 'keys' requires only the same set of surviving
+   * stable keys — used for scenarios that record the SAME key multiple times in
+   * one test (same millisecond), where "which duplicate wins" is legitimately
+   * non-deterministic across backends (memory reverses insertion; SQL backends
+   * keep stable insertion order under an equal-timestamp ORDER BY). Real cron
+   * runs are minutes apart, so this only affects same-ms test fixtures.
+   */
+  parityMode?: 'full' | 'keys'
+}
+
+const SCENARIOS: Scenario[] = [
+  {
+    name: 'fragmented table (storage)',
+    host: 0,
+    batches: [
+      [
+        f({
+          severity: 'warning',
+          metric: 'max_active_parts',
+          value: 318,
+          title: 'duyet.redirect is fragmented',
+          detail: '318 parts',
+        }),
+      ],
+    ],
+    expect: (c) => {
+      expect(c).toHaveLength(1)
+      expect(c[0]).toMatchObject({
+        severity: 'warning',
+        category: 'storage',
+        metric: 'max_active_parts',
+        value: 318,
+        title: 'duyet.redirect is fragmented',
+        detail: '318 parts',
+      })
+    },
+  },
+  {
+    name: 'error-rate spike (anomaly, critical)',
+    host: 0,
+    batches: [
+      [
+        f({
+          severity: 'critical',
+          category: 'anomaly',
+          metric: 'error_rate',
+          value: 12.5,
+          title: 'error rate climbing',
+        }),
+      ],
+    ],
+    expect: (c) =>
+      expect(c[0]).toMatchObject({
+        severity: 'critical',
+        category: 'anomaly',
+        metric: 'error_rate',
+        value: 12.5,
+      }),
+  },
+  {
+    name: 'replication lag (reliability)',
+    host: 0,
+    batches: [
+      [
+        f({
+          severity: 'warning',
+          category: 'reliability',
+          metric: 'max_replication_delay',
+          value: 45,
+        }),
+      ],
+    ],
+    expect: (c) => expect(c[0].metric).toBe('max_replication_delay'),
+  },
+  {
+    name: 'narrative insight, no metric',
+    host: 0,
+    batches: [
+      [
+        f({
+          severity: 'info',
+          category: 'storage',
+          metric: '',
+          title: 'consider TTL policy',
+        }),
+      ],
+    ],
+    expect: (c) => {
+      expect(c).toHaveLength(1)
+      expect(c[0].metric).toBe('')
+      expect(c[0].key).toBe('0:storage::consider TTL policy')
+    },
+  },
+  {
+    name: 'three insights → all distinct keys',
+    host: 0,
+    batches: [
+      [
+        f({
+          severity: 'critical',
+          category: 'anomaly',
+          metric: 'a',
+          title: 'c',
+        }),
+        f({
+          severity: 'warning',
+          category: 'anomaly',
+          metric: 'b',
+          title: 'w',
+        }),
+        f({ severity: 'info', category: 'anomaly', metric: 'd', title: 'i' }),
+      ],
+    ],
+    expect: (c) => expect(c).toHaveLength(3),
+  },
+  {
+    name: 'duplicate key across two cron runs → dedups to one',
+    host: 0,
+    batches: [
+      [
+        f({
+          severity: 'warning',
+          metric: 'max_active_parts',
+          title: 'frag',
+          value: 100,
+        }),
+      ],
+      [
+        f({
+          severity: 'critical',
+          metric: 'max_active_parts',
+          title: 'frag',
+          value: 400,
+        }),
+      ],
+    ],
+    expect: (c) => expect(c).toHaveLength(1),
+    parityMode: 'keys',
+  },
+  {
+    name: 'duplicate key across three cron runs → dedups to one',
+    host: 2,
+    batches: [
+      [f({ metric: 'm', title: 't', value: 1 })],
+      [f({ metric: 'm', title: 't', value: 2 })],
+      [f({ metric: 'm', title: 't', value: 3 })],
+    ],
+    expect: (c) => expect(c).toHaveLength(1),
+    parityMode: 'keys',
+  },
+  {
+    name: 'mixed sources → only ai-insight survives',
+    host: 0,
+    batches: [
+      [
+        f({ title: 'real insight', metric: 'm1' }),
+        f({ source: 'health-sweep', title: 'sweep finding', metric: 'm2' }),
+      ],
+    ],
+    expect: (c) => {
+      expect(c).toHaveLength(1)
+      expect(c[0].title).toBe('real insight')
+    },
+  },
+  {
+    name: 'ten distinct insights all returned',
+    host: 0,
+    batches: [
+      Array.from({ length: 10 }, (_, i) =>
+        f({ metric: `m${i}`, title: `t${i}` })
+      ),
+    ],
+    expect: (c) => expect(c).toHaveLength(10),
+  },
+  {
+    name: 'unicode + emoji title round-trips intact',
+    host: 0,
+    batches: [
+      [f({ metric: 'm', title: 'таблица 重 fragmented 🧩', detail: 'ключ' })],
+    ],
+    expect: (c) => {
+      expect(c[0].title).toBe('таблица 重 fragmented 🧩')
+      expect(c[0].detail).toBe('ключ')
+    },
+  },
+  {
+    name: 'title with colon and percent encodes safely yet reads raw',
+    host: 0,
+    batches: [
+      [f({ metric: 'pct%', title: 'db:table at 80% full', detail: 'x' })],
+    ],
+    expect: (c) => {
+      expect(c[0].title).toBe('db:table at 80% full')
+      expect(c[0].metric).toBe('pct%')
+    },
+  },
+  {
+    name: 'value edge cases: zero / negative / large / fractional',
+    host: 0,
+    batches: [
+      [
+        f({ metric: 'z', title: 'zero', value: 0 }),
+        f({ metric: 'n', title: 'neg', value: -1 }),
+        f({ metric: 'big', title: 'large', value: 1_000_000_000 }),
+        f({ metric: 'fr', title: 'frac', value: 0.125 }),
+      ],
+    ],
+    expect: (c) => {
+      const byTitle = Object.fromEntries(c.map((x) => [x.title, x.value]))
+      expect(byTitle.zero).toBe(0)
+      expect(byTitle.neg).toBe(-1)
+      expect(byTitle.large).toBe(1_000_000_000)
+      expect(byTitle.frac).toBe(0.125)
+    },
+  },
+  {
+    name: 'empty batch → nothing stored',
+    host: 0,
+    batches: [[]],
+    expect: (c) => expect(c).toHaveLength(0),
+  },
+  {
+    name: 'per-host isolation (read host 0)',
+    host: 0,
+    batches: [[f({ metric: 'm', title: 'host0-insight' })]],
+    expect: (c) => {
+      expect(c).toHaveLength(1)
+      expect(c[0].title).toBe('host0-insight')
+    },
+  },
+  {
+    name: 'detail field preserved verbatim',
+    host: 0,
+    batches: [
+      [
+        f({
+          metric: 'm',
+          title: 't',
+          detail: 'Consider OPTIMIZE TABLE or reviewing the partition key.',
+        }),
+      ],
+    ],
+    expect: (c) =>
+      expect(c[0].detail).toBe(
+        'Consider OPTIMIZE TABLE or reviewing the partition key.'
+      ),
+  },
+  {
+    name: 'long title (200 chars) is not lost or truncated',
+    host: 0,
+    batches: [[f({ metric: 'm', title: 'T'.repeat(200) })]],
+    expect: (c) => {
+      expect(c).toHaveLength(1)
+      expect(c[0].title).toBe('T'.repeat(200))
+    },
+  },
+  {
+    name: 'two long titles sharing a 150-char prefix stay distinct',
+    host: 0,
+    batches: [
+      [
+        f({ metric: 'm', title: `${'P'.repeat(150)}-alpha` }),
+        f({ metric: 'm', title: `${'P'.repeat(150)}-beta` }),
+      ],
+    ],
+    expect: (c) => expect(c).toHaveLength(2),
+  },
+  {
+    name: 'same title, different metric → distinct keys',
+    host: 0,
+    batches: [
+      [
+        f({ metric: 'parts', title: 'fragmented' }),
+        f({ metric: 'compression', title: 'fragmented' }),
+      ],
+    ],
+    expect: (c) => expect(c).toHaveLength(2),
+  },
+  {
+    name: 'same title+metric, different category → distinct keys',
+    host: 0,
+    batches: [
+      [
+        f({ category: 'storage', metric: 'm', title: 'issue' }),
+        f({ category: 'anomaly', metric: 'm', title: 'issue' }),
+      ],
+    ],
+    expect: (c) => expect(c).toHaveLength(2),
+  },
+  {
+    name: 'realistic cron snapshot: 4 mixed insights',
+    host: 0,
+    batches: [
+      [
+        f({
+          severity: 'critical',
+          category: 'anomaly',
+          metric: 'error_rate',
+          value: 9,
+          title: 'errors climbing',
+        }),
+        f({
+          severity: 'warning',
+          category: 'storage',
+          metric: 'max_active_parts',
+          value: 280,
+          title: 'events fragmented',
+        }),
+        f({
+          severity: 'warning',
+          category: 'reliability',
+          metric: 'readonly_replicas',
+          value: 1,
+          title: 'replica read-only',
+        }),
+        f({
+          severity: 'info',
+          category: 'performance',
+          metric: 'query_duration_p95',
+          value: 1200,
+          title: 'p95 elevated',
+        }),
+      ],
+    ],
+    expect: (c) => expect(c).toHaveLength(4),
+  },
+  {
+    name: 'regenerated snapshot dedups every card (idempotent cron)',
+    host: 0,
+    batches: [
+      [
+        f({ severity: 'warning', metric: 'max_active_parts', title: 'A' }),
+        f({ severity: 'warning', metric: 'error_rate', title: 'B' }),
+      ],
+      [
+        f({ severity: 'critical', metric: 'max_active_parts', title: 'A' }),
+        f({ severity: 'critical', metric: 'error_rate', title: 'B' }),
+      ],
+    ],
+    expect: (c) => expect(c).toHaveLength(2),
+    parityMode: 'keys',
+  },
+  {
+    name: 'whitespace-only detail preserved as empty-ish',
+    host: 0,
+    batches: [[f({ metric: 'm', title: 't', detail: '' })]],
+    expect: (c) => expect(c[0].detail).toBe(''),
+  },
+  {
+    name: 'high host id',
+    host: 7,
+    batches: [[f({ metric: 'm', title: 'host7' })]],
+    expect: (c) => {
+      expect(c).toHaveLength(1)
+      expect(c[0].title).toBe('host7')
+    },
+  },
+  {
+    name: 'twenty insights stay under default limit',
+    host: 0,
+    batches: [
+      Array.from({ length: 20 }, (_, i) =>
+        f({ metric: `k${i}`, title: `n${i}` })
+      ),
+    ],
+    expect: (c) => expect(c).toHaveLength(20),
+  },
+  {
+    name: 'newline / quote characters in detail survive',
+    host: 0,
+    batches: [
+      [
+        f({
+          metric: 'm',
+          title: 't',
+          detail: 'line1\nline2 "quoted" \'apostrophe\'',
+        }),
+      ],
+    ],
+    expect: (c) =>
+      expect(c[0].detail).toBe('line1\nline2 "quoted" \'apostrophe\''),
+  },
+]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The battery: contract + parity, per scenario per backend.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('InsightsStore realistic-scenario battery', () => {
+  for (const s of SCENARIOS) {
+    for (const backend of BACKENDS) {
+      test(`[${backend.name}] ${s.name}`, async () => {
+        const cards = await runBackend(backend, s.host, s.batches)
+        s.expect(cards)
+      })
+    }
+
+    test(`[parity] ${s.name}`, async () => {
+      const results: Record<string, CanonicalCard[]> = {}
+      for (const backend of BACKENDS) {
+        // fresh fakes per backend run so they don't share state
+        resetFakes()
+        results[backend.name] = await runBackend(backend, s.host, s.batches)
+      }
+      // 'keys' mode compares only the surviving key set (see Scenario.parityMode);
+      // 'full' (default) compares the entire canonical card.
+      const project = (cards: CanonicalCard[]) =>
+        s.parityMode === 'keys'
+          ? JSON.stringify(cards.map((c) => c.key).sort())
+          : JSON.stringify(cards)
+
+      const reference = project(results.memory)
+      for (const backend of BACKENDS) {
+        expect(
+          project(results[backend.name]),
+          `${backend.name} must match memory for "${s.name}"`
+        ).toBe(reference)
+      }
+    })
+  }
+})

--- a/apps/dashboard/src/lib/insights/store/resolve-store.test.ts
+++ b/apps/dashboard/src/lib/insights/store/resolve-store.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the insight store resolver — the policy core of the pluggable
+ * persistence. Verifies the additive-opt-in contract: default `auto` →
+ * ClickHouse (unchanged behavior), explicit selections, fallback-to-ClickHouse
+ * when a selected backend lacks its prerequisite, unknown values → auto, and
+ * the per-env memoization. Construction of every backend is lazy (no network on
+ * `new`), so no module mocks are required.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// The `d1` branch dynamically imports d1-store → @chm/platform →
+// platform-native, which imports the virtual `cloudflare:workers` module. That
+// module only resolves under vite/workerd, so stub it (it just re-exports
+// `env`). The resolver only reads `store.backend`, never touches a binding.
+mock.module('cloudflare:workers', () => ({ env: {} }))
+
+import { resetInsightsStoreCache, resolveInsightsStore } from './resolve-store'
+
+const ENV_KEYS = [
+  'INSIGHTS_STORE_BACKEND',
+  'DATABASE_URL',
+  'AGENTSTATE_API_KEY',
+  'AGENTSTATE_BASE_URL',
+] as const
+
+const saved: Record<string, string | undefined> = {}
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k]
+    delete process.env[k]
+  }
+  resetInsightsStoreCache()
+})
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k]
+    else process.env[k] = saved[k]
+  }
+  resetInsightsStoreCache()
+})
+
+describe('resolveInsightsStore', () => {
+  test('defaults to clickhouse when unset (auto)', async () => {
+    const store = await resolveInsightsStore()
+    expect(store.backend).toBe('clickhouse')
+  })
+
+  test('"auto" explicitly resolves to clickhouse', async () => {
+    process.env.INSIGHTS_STORE_BACKEND = 'auto'
+    expect((await resolveInsightsStore()).backend).toBe('clickhouse')
+  })
+
+  test('selects clickhouse / memory / d1 explicitly', async () => {
+    process.env.INSIGHTS_STORE_BACKEND = 'clickhouse'
+    expect((await resolveInsightsStore()).backend).toBe('clickhouse')
+
+    resetInsightsStoreCache()
+    process.env.INSIGHTS_STORE_BACKEND = 'memory'
+    expect((await resolveInsightsStore()).backend).toBe('memory')
+
+    resetInsightsStoreCache()
+    process.env.INSIGHTS_STORE_BACKEND = 'd1'
+    expect((await resolveInsightsStore()).backend).toBe('d1')
+  })
+
+  test('case-insensitive and trims the env value', async () => {
+    process.env.INSIGHTS_STORE_BACKEND = '  Memory '
+    expect((await resolveInsightsStore()).backend).toBe('memory')
+  })
+
+  test('postgres requires DATABASE_URL, else falls back to clickhouse', async () => {
+    process.env.INSIGHTS_STORE_BACKEND = 'postgres'
+    expect((await resolveInsightsStore()).backend).toBe('clickhouse')
+
+    resetInsightsStoreCache()
+    process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db'
+    expect((await resolveInsightsStore()).backend).toBe('postgres')
+  })
+
+  test('agentstate requires AGENTSTATE_API_KEY, else falls back to clickhouse', async () => {
+    process.env.INSIGHTS_STORE_BACKEND = 'agentstate'
+    expect((await resolveInsightsStore()).backend).toBe('clickhouse')
+
+    resetInsightsStoreCache()
+    process.env.AGENTSTATE_API_KEY = 'as_live_TEST'
+    expect((await resolveInsightsStore()).backend).toBe('agentstate')
+  })
+
+  test('unknown value falls back to auto (clickhouse)', async () => {
+    process.env.INSIGHTS_STORE_BACKEND = 'redis'
+    expect((await resolveInsightsStore()).backend).toBe('clickhouse')
+  })
+
+  test('memoizes per env value and re-resolves after reset / change', async () => {
+    process.env.INSIGHTS_STORE_BACKEND = 'memory'
+    const a = await resolveInsightsStore()
+    const b = await resolveInsightsStore()
+    expect(a).toBe(b) // same instance while env unchanged
+
+    process.env.INSIGHTS_STORE_BACKEND = 'clickhouse'
+    // Without reset the resolver keys off the new env value directly.
+    const c = await resolveInsightsStore()
+    expect(c.backend).toBe('clickhouse')
+    expect(c).not.toBe(a)
+  })
+})

--- a/apps/dashboard/src/lib/insights/store/resolve-store.ts
+++ b/apps/dashboard/src/lib/insights/store/resolve-store.ts
@@ -1,0 +1,116 @@
+/**
+ * Insight store resolver — selects the persistence backend at runtime.
+ *
+ * Mirrors `conversation-store/resolve-store.ts`, but with an important policy
+ * difference: insight persistence is **additive opt-in**, not flag-gated. The
+ * default (`auto`) is ClickHouse — exactly the original behavior — so existing
+ * deployments are unaffected. Operators switch backends by setting one env var:
+ *
+ *   INSIGHTS_STORE_BACKEND = auto | clickhouse | d1 | postgres | agentstate | memory
+ *
+ * `auto` never silently follows other env (e.g. the presence of DATABASE_URL for
+ * conversations does not move insights to Postgres) — switching is always an
+ * explicit decision. When an explicitly selected backend is missing its
+ * prerequisite (no API key / connection string), we log and fall back to
+ * ClickHouse so insight generation keeps working rather than breaking.
+ *
+ * The resolved store is memoized per process (keyed by the env value) so the
+ * Postgres connection pool and AgentState client are created once.
+ */
+
+import type { InsightsBackendKind, InsightsStore } from './types'
+
+import { ClickHouseInsightsStore } from './clickhouse-store'
+import { MemoryInsightsStore } from './memory-store'
+import { ErrorLogger } from '@chm/logger'
+
+const COMPONENT = 'insights-resolve-store'
+const warn = (msg: string) =>
+  ErrorLogger.logWarning(`[insights-resolve-store] ${msg}`, {
+    component: COMPONENT,
+  })
+
+const ENV_BACKEND = 'INSIGHTS_STORE_BACKEND'
+const ENV_AGENTSTATE_KEY = 'AGENTSTATE_API_KEY'
+const ENV_AGENTSTATE_BASE_URL = 'AGENTSTATE_BASE_URL'
+const ENV_DATABASE_URL = 'DATABASE_URL'
+
+const VALID: ReadonlySet<string> = new Set([
+  'auto',
+  'clickhouse',
+  'd1',
+  'postgres',
+  'agentstate',
+  'memory',
+])
+
+// Memoize per backend value so we don't reopen pools / clients on every call.
+let cached: { key: string; store: Promise<InsightsStore> } | null = null
+
+/**
+ * Resolve the configured insight store. Memoized; call
+ * {@link resetInsightsStoreCache} in tests to force re-resolution.
+ */
+export function resolveInsightsStore(): Promise<InsightsStore> {
+  const raw = (process.env[ENV_BACKEND] ?? 'auto').trim().toLowerCase()
+  const key = VALID.has(raw) ? raw : 'auto'
+
+  if (!VALID.has(raw) && raw !== '') {
+    warn(`unknown ${ENV_BACKEND}="${raw}", falling back to "auto" (clickhouse)`)
+  }
+
+  if (cached && cached.key === key) return cached.store
+
+  const store = build(key as InsightsBackendKind | 'auto')
+  cached = { key, store }
+  return store
+}
+
+async function build(
+  selection: InsightsBackendKind | 'auto'
+): Promise<InsightsStore> {
+  switch (selection) {
+    case 'memory':
+      return new MemoryInsightsStore()
+
+    case 'd1': {
+      const { D1InsightsStore } = await import('./d1-store')
+      return new D1InsightsStore()
+    }
+
+    case 'postgres': {
+      if (!process.env[ENV_DATABASE_URL]) {
+        warn('postgres selected but DATABASE_URL is unset; using clickhouse')
+        return new ClickHouseInsightsStore()
+      }
+      // Dynamic import keeps the Node-only `postgres` package out of the
+      // Cloudflare Workers bundle (the CF path uses d1/clickhouse/agentstate).
+      const { PostgresInsightsStore } = await import('./postgres-store')
+      return new PostgresInsightsStore(process.env[ENV_DATABASE_URL])
+    }
+
+    case 'agentstate': {
+      const apiKey = process.env[ENV_AGENTSTATE_KEY]
+      if (!apiKey) {
+        warn(
+          'agentstate selected but AGENTSTATE_API_KEY is unset; using clickhouse'
+        )
+        return new ClickHouseInsightsStore()
+      }
+      const { AgentStateInsightsStore } = await import('./agentstate-store')
+      return new AgentStateInsightsStore({
+        apiKey,
+        baseUrl: process.env[ENV_AGENTSTATE_BASE_URL],
+      })
+    }
+
+    default:
+      // 'auto' and 'clickhouse' both resolve to ClickHouse (the default).
+      return new ClickHouseInsightsStore()
+  }
+}
+
+/** Test-only: clear the memoized store so the next resolve re-reads env. */
+export function resetInsightsStoreCache(): void {
+  cached = null
+}

--- a/apps/dashboard/src/lib/insights/store/resolve-store.ts
+++ b/apps/dashboard/src/lib/insights/store/resolve-store.ts
@@ -61,7 +61,13 @@ export function resolveInsightsStore(): Promise<InsightsStore> {
 
   if (cached && cached.key === key) return cached.store
 
-  const store = build(key as InsightsBackendKind | 'auto')
+  // Memoize the in-flight/resolved promise, but DON'T let a rejection stick: if
+  // build() rejects (e.g. a transient dynamic-import failure), clear the cache
+  // so the next call retries instead of replaying the rejected promise forever.
+  const store = build(key as InsightsBackendKind | 'auto').catch((err) => {
+    if (cached?.store === store) cached = null
+    throw err
+  })
   cached = { key, store }
   return store
 }

--- a/apps/dashboard/src/lib/insights/store/types.ts
+++ b/apps/dashboard/src/lib/insights/store/types.ts
@@ -100,3 +100,51 @@ export function toFindingRow(
     value: finding.value ?? 0,
   }
 }
+
+/**
+ * Clamp a caller-supplied row limit into the supported `[1, 1000]` range,
+ * defaulting when unset. Shared by every backend so the page-size policy lives
+ * in one place rather than being copy-pasted per adapter.
+ */
+export function clampLimit(limit: number | undefined, fallback = 100): number {
+  return Math.min(Math.max(Math.trunc(limit ?? fallback) || 0, 1), 1000)
+}
+
+/** Loose shape of a row read back from a DB-backed store before normalization. */
+export interface StoredFindingRow {
+  /** Unix epoch milliseconds (or anything `Number()`-coercible to it). */
+  event_time?: unknown
+  host_id?: unknown
+  severity?: unknown
+  category?: unknown
+  source?: unknown
+  title?: unknown
+  detail?: unknown
+  metric?: unknown
+  value?: unknown
+}
+
+/**
+ * Convert a stored backend row (numeric `event_time` in ms, possibly
+ * string-typed `value` from the driver) into the canonical `FindingRow` read
+ * shape. The inverse of {@link toFindingRow}'s write mapping — centralized so
+ * the D1 / Postgres / AgentState read paths cannot drift on the
+ * ms→ISO / value→number contract. Defensive coercion keeps a malformed field
+ * from throwing.
+ */
+export function rowFromStored(s: StoredFindingRow): FindingRow {
+  const str = (v: unknown): string => (typeof v === 'string' ? v : '')
+  const num = (v: unknown): number =>
+    typeof v === 'number' ? v : Number(v) || 0
+  return {
+    event_time: new Date(num(s.event_time)).toISOString(),
+    host_id: str(s.host_id),
+    severity: str(s.severity),
+    category: str(s.category),
+    source: str(s.source),
+    title: str(s.title),
+    detail: str(s.detail),
+    metric: str(s.metric),
+    value: num(s.value),
+  }
+}

--- a/apps/dashboard/src/lib/insights/store/types.ts
+++ b/apps/dashboard/src/lib/insights/store/types.ts
@@ -1,0 +1,102 @@
+/**
+ * Pluggable persistence for AI Insights.
+ *
+ * AI Insights are persisted as *findings* — short, structured records of
+ * something noteworthy on a cluster (see `lib/findings/findings-store.ts` for
+ * the original ClickHouse-only implementation). This module abstracts that
+ * persistence behind a small `InsightsStore` interface so the storage backend
+ * can be selected at deploy time — exactly like the AI agent's pluggable
+ * `ConversationStore` (`lib/conversation-store/`).
+ *
+ * Why this exists: the original engine wrote insights straight to a ClickHouse
+ * table on the monitored cluster. On a read-only monitoring connection that
+ * write silently fails, so insights never survive a reload. Letting operators
+ * point persistence at D1 / Postgres / AgentState fixes that without giving the
+ * monitoring user write access to the cluster it watches.
+ *
+ * Every method is **best-effort**: a backend that cannot write (read-only
+ * cluster, missing binding) logs and returns `false`/`[]` rather than throwing,
+ * so both the manual "Generate" endpoint and the cron sweep stay resilient.
+ *
+ * The interface intentionally reuses the `Finding` / `FindingRow` /
+ * `ListFindingsOptions` shapes from the findings store so the read path
+ * (`read-insights.ts` → `toCard`) is identical regardless of backend.
+ */
+
+import type {
+  Finding,
+  FindingRow,
+  ListFindingsOptions,
+} from '@/lib/findings/findings-store'
+
+export type {
+  Finding,
+  FindingRow,
+  FindingSeverity,
+  ListFindingsOptions,
+} from '@/lib/findings/findings-store'
+
+/**
+ * Identifiers for the supported insight storage backends.
+ *
+ * - `clickhouse` — app-owned table on the monitored cluster (default, current
+ *   behavior). Requires a writable monitoring connection.
+ * - `d1`         — Cloudflare D1 (reuses the conversation D1 binding).
+ * - `postgres`   — PostgreSQL via `DATABASE_URL`.
+ * - `agentstate` — AgentState generic State store (https://agentstate.app).
+ * - `memory`     — in-process map; ephemeral, last-resort fallback.
+ */
+export type InsightsBackendKind =
+  | 'clickhouse'
+  | 'd1'
+  | 'postgres'
+  | 'agentstate'
+  | 'memory'
+
+/**
+ * Storage adapter for AI Insights.
+ *
+ * All backends implement this. `record` persists a batch (the engine produces
+ * several insights per run); `list` reads recent findings newest-first so the
+ * read path can de-duplicate by stable key.
+ */
+export interface InsightsStore {
+  /** Which backend this instance is — surfaced read-only in the UI. */
+  readonly backend: InsightsBackendKind
+
+  /**
+   * Persist a batch of findings for a host. Best-effort: returns `true` only
+   * when every finding was written, `false` if any write failed or the backend
+   * is unavailable. Never throws.
+   */
+  record(hostId: number, findings: Finding[]): Promise<boolean>
+
+  /**
+   * Read recent findings for a host, newest first. Best-effort: returns `[]` if
+   * the backing store is missing or unreadable. Never throws.
+   */
+  list(hostId: number, opts?: ListFindingsOptions): Promise<FindingRow[]>
+}
+
+/**
+ * Map a `Finding` (write shape, scalar-only) plus a host id and timestamp into
+ * the `FindingRow` read shape shared by every backend. Centralized so the
+ * non-ClickHouse adapters stay consistent with the ClickHouse column contract.
+ */
+export function toFindingRow(
+  hostId: number,
+  finding: Finding,
+  eventTime: string
+): FindingRow {
+  return {
+    event_time: eventTime,
+    host_id: String(hostId),
+    severity: finding.severity,
+    category: finding.category,
+    source: finding.source,
+    title: finding.title,
+    detail: finding.detail ?? '',
+    metric: finding.metric ?? '',
+    value: finding.value ?? 0,
+  }
+}

--- a/apps/dashboard/src/routes/api/v1/insights/backend.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/backend.ts
@@ -1,0 +1,45 @@
+/**
+ * AI Insights storage backend info — GET /api/v1/insights/backend
+ *
+ * Reports which persistence backend the engine is configured to use
+ * (`INSIGHTS_STORE_BACKEND`), so the overview panel can surface a read-only
+ * indicator — mirroring `/api/v1/conversations/backend` for the chat agent.
+ *
+ * Returns no insight data and no secrets — only the backend kind. Fails safe to
+ * `clickhouse` (the default) on any error.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { error, generateRequestId } from '@chm/logger'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { resolveInsightsStore } from '@/lib/insights/store/resolve-store'
+
+async function handleGet(): Promise<Response> {
+  bridgeClickHouseEnv(env as Record<string, string | undefined>)
+  const requestId = generateRequestId()
+
+  try {
+    const store = await resolveInsightsStore()
+    return Response.json(
+      { backend: store.backend },
+      { headers: { 'X-Request-ID': requestId, 'Cache-Control': 'no-store' } }
+    )
+  } catch (err) {
+    error('[GET /api/v1/insights/backend] Error:', err, { requestId })
+    // Fail safe: default to the ClickHouse backend.
+    return Response.json(
+      { backend: 'clickhouse' },
+      { headers: { 'X-Request-ID': requestId, 'Cache-Control': 'no-store' } }
+    )
+  }
+}
+
+export const Route = createFileRoute('/api/v1/insights/backend')({
+  server: {
+    handlers: {
+      GET: () => handleGet(),
+    },
+  },
+})

--- a/docs/content/ai-agent.mdx
+++ b/docs/content/ai-agent.mdx
@@ -127,6 +127,33 @@ When AgentState is active **and** `AGENTSTATE_AI_ENRICH=true`:
 
 With enrichment off, conversations persist normally but titles and follow-up suggestions are not generated.
 
+## AI Insights persistence
+
+Separate from chat history, the AI Insights panel on `/overview` persists the
+short observations it generates through its own pluggable store, mirroring the
+conversation backends above. It is **additive opt-in** via one env var and
+defaults to ClickHouse, so existing deployments are unaffected.
+
+```bash
+INSIGHTS_STORE_BACKEND=auto   # auto | clickhouse | d1 | postgres | agentstate | memory
+```
+
+| Value | Backend | Prerequisite |
+|---|---|---|
+| `auto` (default) | ClickHouse `monitoring_findings` table | writable monitoring connection |
+| `clickhouse` | same as `auto` | writable monitoring connection |
+| `d1` | Cloudflare D1 `insights_findings` table | `INSIGHTS_D1` binding, else `CONVERSATIONS_D1` |
+| `postgres` | Postgres `insights_findings` table | `DATABASE_URL` |
+| `agentstate` | AgentState State store | `AGENTSTATE_API_KEY` (+ optional `AGENTSTATE_BASE_URL`) |
+| `memory` | in-process (ephemeral) | — |
+
+The D1, Postgres, and AgentState backends reuse the same env / bindings as the
+conversation store. `auto` resolves to ClickHouse and never silently follows
+other env; if an explicitly selected backend is missing its prerequisite, the
+engine logs a warning and falls back to ClickHouse. `GET /api/v1/insights/backend`
+reports the active backend (`{ "backend": "d1" }`), and the overview panel shows
+a read-only "Stored in `<backend>`" footer.
+
 ## HTTP API
 
 ```bash

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -260,6 +260,21 @@ See [Conversation History — Backends](/docs/ai-agent/conversation-history/back
 
 ---
 
+## AI Insights Store
+
+The AI Insights panel on `/overview` persists its findings through a pluggable store. It is additive opt-in and defaults to ClickHouse; the D1, Postgres, and AgentState backends reuse the conversation-store env above.
+
+| Variable | Default | Description |
+|---|---|---|
+| `INSIGHTS_STORE_BACKEND` | `auto` | Backend: `auto`, `clickhouse`, `d1`, `postgres`, `agentstate`, or `memory`. `auto` and `clickhouse` both use the ClickHouse `monitoring_findings` table. `auto` never silently follows other env; a selected backend missing its prerequisite falls back to ClickHouse. |
+| `INSIGHTS_D1` | — | Optional dedicated D1 binding for the `d1` backend. Falls back to `CONVERSATIONS_D1` when unset. |
+
+`postgres` reuses `DATABASE_URL`; `agentstate` reuses `AGENTSTATE_API_KEY` (+ optional `AGENTSTATE_BASE_URL`).
+
+See [AI Agent — AI Insights persistence](/docs/ai-agent#ai-insights-persistence) for setup and fallback behavior. `GET /api/v1/insights/backend` reports the active backend.
+
+---
+
 ## PeerDB Monitoring
 
 Optional. Set `PEERDB_API_URL` to enable the PeerDB section (Mirrors and Peers) in the sidebar.

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -34,7 +34,7 @@ Agents discover knowledge in this order:
 | **Operations** | [secret-rotation.md](secret-rotation.md) | workflow | Cloudflare Workers secret rotation: redeploy after wrangler secret put |
 | **Operations** | [k8s-health-probes.md](k8s-health-probes.md) | reference | /healthz (liveness, static) vs /api/healthz (readiness, CH-gated); startupProbe; :latest stale-image incident; non-helm manifest + migration prompt |
 | **Operations** | [release-automation.md](release-automation.md) | workflow | release-please + release.yml pipeline: versioning rules, PR-title guard, labeler, CHANGELOG ownership, migration prompt |
-| **Specs** | [ai-insights.md](ai-insights.md) | spec | AI Insights engine: collect→enrich→persist (findings store), cron + manual generation, stable-key dismissal, overview panel |
+| **Specs** | [ai-insights.md](ai-insights.md) | spec | AI Insights engine: collect→enrich→persist (pluggable InsightsStore: clickhouse default / d1 / postgres / agentstate / memory), cron + manual generation, stable-key dismissal, overview panel |
 | **Specs** | [mcp-server.md](mcp-server.md) | reference | MCP server at /api/mcp: tools, setup, security |
 | **Security** | [sql-validator-threat-model.md](sql-validator-threat-model.md) | decision | validateSqlQuery gates all free-form SQL; whole-query (not fragment) threat model; UNION/replace()/OR-disjunction false-positive class + corpus regression guard |
 | **Development** | [api-hostid-validation.md](api-hostid-validation.md) | decision | API routes must validate hostId as non-negative integer (400); `!Number.isFinite` accepted -1/1.5 → 500-retry; 9 routes fixed + cross-route source guard |

--- a/docs/knowledge/ai-insights.md
+++ b/docs/knowledge/ai-insights.md
@@ -113,8 +113,14 @@ Files: `clickhouse-store.ts`, `d1-store.ts`, `postgres-store.ts`,
 - **AgentState** reuses `AGENTSTATE_API_KEY` + optional `AGENTSTATE_BASE_URL` and
   stores each insight as a generic **State** record (not a conversation):
   - `agent_id` = `clickhouse-monitoring-insights`
-  - `state_key` = `insight:<hostId>:<category>:<metric>:<title>` (bounded; stable
-    across regenerations so an unchanged insight upserts in place — natural dedup)
+  - `state_key` = `insight:<hostId>:<readable-prefix>:<fnv1a-hash>` — a bounded,
+    human-readable prefix plus an FNV-1a hash of the full
+    `host\0category\0metric\0title` composite. The hash makes the key both
+    **stable** (an unchanged insight upserts in place — natural dedup) and
+    **collision-proof**: a plain truncated `category:metric:title` would alias
+    two long titles sharing a 120-char prefix into one key and silently
+    overwrite one (data loss). Regression + benchmark coverage in
+    `store/agentstate-store.test.ts`.
   - `tags` = [`host:<id>`, `severity:<sev>`] for server-side filtering
 
 ### Endpoint and UI

--- a/docs/knowledge/ai-insights.md
+++ b/docs/knowledge/ai-insights.md
@@ -3,7 +3,7 @@ id: ai-insights
 title: AI Insights Engine
 type: spec
 status: active
-updated: 2026-06-17
+updated: 2026-06-20
 tags:
   - insights
   - findings
@@ -14,6 +14,8 @@ related:
   - mcp-server
   - query-config-format
   - conventions
+  - agentstate-conversation-store
+  - agent-conversation-storage
 ---
 
 # AI Insights Engine
@@ -44,8 +46,94 @@ is fragmented", "replication is lagging" — generated and **cached server-side*
   (`isProviderConfigured(resolveProvider(DEFAULT_MODEL).providerId)`), candidates
   pass through one `generateObject` call that tightens wording. With no key (or
   on any error) candidates are returned unchanged — the "if available" half.
-- **Persistence reuses the findings store** (`src/lib/findings/findings-store.ts`,
-  `FINDINGS_TABLE`, 30-day TTL). Insights are recorded with `source: 'ai-insight'`.
+- **Persistence goes through the pluggable `InsightsStore`**
+  (`src/lib/insights/store/`). The default backend is the ClickHouse findings
+  store (`src/lib/findings/findings-store.ts`, `FINDINGS_TABLE`, 30-day TTL),
+  which records insights with `source: 'ai-insight'` — the original behavior.
+  Operators can point persistence at D1 / Postgres / AgentState instead; see
+  **Persistence backends** below.
+
+## Persistence backends
+
+Persistence is pluggable, mirroring the agent's pluggable `ConversationStore`
+(see [agentstate-conversation-store.md](agentstate-conversation-store.md) and
+[agent-conversation-storage.md](agent-conversation-storage.md)). Why it exists:
+the original engine wrote insights straight to a ClickHouse table on the
+monitored cluster. On a read-only monitoring connection that write silently
+fails, so insights never survived a reload. The `InsightsStore` interface lets
+operators point persistence at a writable store instead — without granting the
+monitoring user write access to the cluster it watches.
+
+The interface (`src/lib/insights/store/types.ts`) is small — `record(hostId,
+findings)` and `list(hostId, opts)` — and reuses the `Finding` / `FindingRow`
+shapes from the findings store, so the read path (`read-insights.ts → toCard`)
+is identical regardless of backend. **Every method is best-effort**: a backend
+that cannot write (read-only cluster, missing binding) logs and returns
+`false`/`[]` rather than throwing, so both the manual "Generate" endpoint and the
+cron sweep stay resilient.
+
+### Selection
+
+Selection is **additive opt-in via a single env var**, not flag-gated. Setting
+nothing keeps the original ClickHouse behavior. Backends:
+
+| `INSIGHTS_STORE_BACKEND` | Backend | Prerequisite env / binding |
+|---|---|---|
+| `auto` (default) | ClickHouse | — (original behavior) |
+| `clickhouse` | ClickHouse `monitoring_findings` table on the monitored cluster | writable monitoring connection |
+| `d1` | Cloudflare D1 `insights_findings` table | `INSIGHTS_D1` binding, else `CONVERSATIONS_D1` |
+| `postgres` | Postgres `insights_findings` table | `DATABASE_URL` |
+| `agentstate` | AgentState generic State store | `AGENTSTATE_API_KEY` (+ optional `AGENTSTATE_BASE_URL`) |
+| `memory` | in-process map (ephemeral) | — |
+
+Files: `clickhouse-store.ts`, `d1-store.ts`, `postgres-store.ts`,
+`agentstate-store.ts`, `memory-store.ts`; resolver `resolve-store.ts`.
+
+- **Default is ClickHouse.** `auto` and `clickhouse` both resolve to the
+  ClickHouse findings store — exactly the original behavior, so existing
+  deployments are unaffected.
+- **`auto` never silently follows other env.** The presence of `DATABASE_URL`
+  (for conversations) does not move insights to Postgres — switching is always an
+  explicit decision.
+- **Fallback to ClickHouse on missing prerequisite.** If an explicitly selected
+  backend is missing its prerequisite (no `DATABASE_URL`, no `AGENTSTATE_API_KEY`),
+  the resolver logs a warning and falls back to ClickHouse so generation keeps
+  working.
+- The resolved store is memoized per process (keyed by the env value) so the
+  Postgres pool / AgentState client is created once.
+
+### Tables and mapping
+
+- **D1 / Postgres** lazily create a dedicated `insights_findings` table on first
+  use (event_time as unix ms, scalar finding columns). D1 reuses the
+  conversation D1 binding (`INSIGHTS_D1` first, then `CONVERSATIONS_D1`); Postgres
+  reuses `DATABASE_URL`.
+- **ClickHouse** uses the existing `monitoring_findings` table with
+  `source = 'ai-insight'`.
+- **AgentState** reuses `AGENTSTATE_API_KEY` + optional `AGENTSTATE_BASE_URL` and
+  stores each insight as a generic **State** record (not a conversation):
+  - `agent_id` = `clickhouse-monitoring-insights`
+  - `state_key` = `insight:<hostId>:<category>:<metric>:<title>` (bounded; stable
+    across regenerations so an unchanged insight upserts in place — natural dedup)
+  - `tags` = [`host:<id>`, `severity:<sev>`] for server-side filtering
+
+### Endpoint and UI
+
+- `GET /api/v1/insights/backend` returns `{ backend }` (no secrets), failing safe
+  to `clickhouse`. Mirrors `/api/v1/conversations/backend`.
+- The overview AI Insights panel (`insights-panel.tsx`) shows a read-only footer
+  — "Stored in `<backend>` · configured at deploy time" — via the
+  `use-insights-backend.ts` hook.
+
+### Environment variables
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `INSIGHTS_STORE_BACKEND` | no | `auto` | `auto` \| `clickhouse` \| `d1` \| `postgres` \| `agentstate` \| `memory`. `auto`/`clickhouse` = ClickHouse findings store |
+| `INSIGHTS_D1` | no | — | optional dedicated D1 binding for the `d1` backend; falls back to `CONVERSATIONS_D1` |
+| `DATABASE_URL` | for `postgres` | — | reused from the conversation Postgres store |
+| `AGENTSTATE_API_KEY` | for `agentstate` | — | reused from the AgentState conversation store |
+| `AGENTSTATE_BASE_URL` | no | SDK default | self-host endpoint for `agentstate` |
 
 ## Generation triggers
 


### PR DESCRIPTION
## Why

AI Insights persistence was hardcoded to a ClickHouse `monitoring_findings` table on the **monitored** cluster. On a read-only monitoring connection (the common setup) that write silently fails — generation returned 200 but nothing survived a reload. This is the same class of problem the AI agent already solved for conversation history with a pluggable `ConversationStore`.

## What

Make AI Insights persistence pluggable, mirroring the chat agent's conversation store exactly:

- **`InsightsStore` interface** (`lib/insights/store/types.ts`) — `record(hostId, findings)` + `list(hostId, opts)`, reusing `Finding`/`FindingRow` so the read path (`read-insights.ts → toCard`) is unchanged regardless of backend.
- **Five backends**: `clickhouse` (default, wraps the existing findings store), `d1`, `postgres`, `agentstate` (generic State API — `upsertState`/`queryStates`, stable key = natural dedup), `memory` (ephemeral fallback).
- **Resolver** (`resolve-store.ts`) selects via **`INSIGHTS_STORE_BACKEND`** = `auto | clickhouse | d1 | postgres | agentstate | memory`.
  - **Additive opt-in**: default `auto` → ClickHouse = exactly today's behavior. No feature flag, no auth requirement (insights stay anonymous).
  - `auto` never silently follows other env; explicit selection with a missing prerequisite logs and falls back to ClickHouse so generation keeps working.
  - `d1`/`postgres`/`agentstate` reuse the conversation store's bindings/env (`CONVERSATIONS_D1`, `DATABASE_URL`, `AGENTSTATE_API_KEY`).
- **Wiring**: `generate-insights.ts` + `read-insights.ts` go through `resolveInsightsStore()`.
- **UI/API**: new `GET /api/v1/insights/backend` + `use-insights-backend` hook + a read-only "Stored in &lt;backend&gt; · configured at deploy time" footer on the overview panel — mirrors `/api/v1/conversations/backend`.

All backends are **best-effort**: failures log and degrade (`false`/`[]`), never throw.

## Docs

- `docs/knowledge/ai-insights.md` — new "Persistence backends" section
- `docs/content/ai-agent.mdx` — "AI Insights persistence" subsection (kept in sync per CLAUDE.md)
- `docs/content/reference/environment-variables.mdx` — `INSIGHTS_STORE_BACKEND` / `INSIGHTS_D1`

## Tests

63 passing across all five backends + resolver (selection/fallback/memoization) + an end-to-end read-path wiring test. `type-check` and `type-check:test` both clean; Biome clean.

> Note: a local `bun run build` fails on a **pre-existing**, unrelated `ai`/`@ai-sdk/provider-utils` node_modules drift (`cancelResponseBody` missing export) — reproduced identically on a clean tree. CI installs from lockfile so it is unaffected; `type-check` (the real type gate) passes.

https://claude.ai/code/session_01E43HCrarP9fhTHSr9UrKDo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI Insights persistence is now pluggable across ClickHouse, D1, Postgres, AgentState, and an in-memory option via `INSIGHTS_STORE_BACKEND`.
  * The AI Insights overview panel now shows a footer indicating the configured storage backend.
  * Added `GET /api/v1/insights/backend` to report the active backend.
* **Bug Fixes**
  * Improved insights read/write reliability by using the selected persistence layer and batching insight persistence.
* **Documentation**
  * Updated docs for supported backends, environment variable prerequisites, and fallback behavior.
* **Tests**
  * Expanded end-to-end and backend-specific coverage, including filtering, de-duplication, and cross-backend consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->