### PR TITLE
ci: teach issue resolver the 100-char PR title limit

### DIFF
--- a/.github/workflows/claude-issue-assign.yml
+++ b/.github/workflows/claude-issue-assign.yml
@@ -153,15 +153,23 @@ jobs:
                it passed.
             5. Commit with semantic format and the required co-author trailer:
                ```
-               <type>: <scope> - <subject> (#${{ github.event.issue.number }})
+               <type>(<scope>): <subject>
 
                Co-Authored-By: duyetbot <bot@duyet.net>
                ```
+               IMPORTANT: the subject line (everything before the first newline) MUST
+               be <= 100 characters. This repo's `commitlint.config.js` enforces
+               `header-max-length: 100`, and CI's `conventional-title` check FAILS
+               otherwise (squash-merge uses the PR title as the commit subject). Keep
+               it tight and do NOT pad it with `(#issue)` — the `Resolves #` keyword in
+               the PR body handles closing.
             6. Push the branch: `git push origin <branch-name>`.
 
             ## Phase 3 — Open the PR and link the issue
 
-            - `gh pr create --base main --title "<semantic title> (#${{ github.event.issue.number }})" --body "<body below>"`
+            - `gh pr create --base main --title "<semantic title, <= 100 chars>" --body "<body below>"`
+              The title must pass `conventional-title` CI: `<type>(<scope>): <subject>`
+              and <= 100 characters total. Do NOT append `(#issue)` to the title.
             - The PR body MUST contain a closing keyword so the issue auto-closes on
               merge: **`Resolves #${{ github.event.issue.number }}`**.
             - Per project policy, arm auto-merge after creating the PR:


### PR DESCRIPTION
The resolver's first successful run (#1799 → #1801) produced a **108-char** PR title that failed the `conventional-title` check (commitlint `header-max-length: 100`). This encodes the ≤100-char rule into the resolver prompt and stops it padding the title with `(#issue)` (the body's `Resolves #` already auto-closes). Follow-up to #1798/#1800.