### PR TITLE
ci(rust): fix cargo fmt drift in ch-json

### DIFF
--- a/rust/ch-json/src/lib.rs
+++ b/rust/ch-json/src/lib.rs
@@ -142,8 +142,8 @@ fn is_numeric_string(value: &str) -> bool {
     }
 
     let digits_start = index;
-    
-    // Check if the first digit is '0'. In JSON numbers, a leading zero is only valid 
+
+    // Check if the first digit is '0'. In JSON numbers, a leading zero is only valid
     // if it is the only digit or followed by a decimal point/exponent.
     if bytes.get(index) == Some(&b'0') {
         index += 1;
@@ -155,7 +155,7 @@ fn is_numeric_string(value: &str) -> bool {
             index += 1;
         }
     }
-    
+
     if index == digits_start {
         return false;
     }


### PR DESCRIPTION
## What

`rust/ch-json/src/lib.rs` had trailing whitespace on two blank lines, failing `cargo fmt --all -- --check`. This left the (non-required) `rust-cli` CI job red on every open PR (#1766, #1763, etc.).

Ran `cargo fmt --all`. Pure whitespace, no behavior change.

## Verify

```
cd rust && cargo fmt --all -- --check   # now clean
```

🤖 Filed by the agent-loop (keep-CI-green / DX cleanup).

https://claude.ai/code/session_01NUoGhuRYbd2q8QMrsiLz6k

## Summary by Sourcery

Enhancements:
- Normalize whitespace in rust/ch-json/src/lib.rs to satisfy cargo fmt and keep Rust CI formatting checks green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code cleanup and formatting improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->