### PR TITLE
ci(rust): fix cargo-publish skip-guard (User-Agent + 404-only publish)

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -53,13 +53,18 @@ jobs:
         run: |
           VERSION=$(grep -m 1 '^version = ' Cargo.toml | cut -d '"' -f 2)
           echo "Checking ch-json v$VERSION on crates.io..."
-          
-          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" https://crates.io/api/v1/crates/ch-json/$VERSION || true)
-          if [ "$STATUS_CODE" = "200" ]; then
-            echo "ch-json v$VERSION is already published on crates.io. Skipping publish."
-          else
+
+          # crates.io API requires a User-Agent header (returns 403 otherwise).
+          # Publish ONLY on a definitive 404; treat 200/403/5xx as "skip" so a
+          # transient API quirk never triggers a doomed `cargo publish`.
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "User-Agent: clickhouse-monitoring-ci (https://github.com/duyet/clickhouse-monitoring)" \
+            "https://crates.io/api/v1/crates/ch-json/$VERSION" || true)
+          if [ "$STATUS_CODE" = "404" ]; then
             echo "ch-json v$VERSION not found on crates.io. Publishing..."
             cargo publish
+          else
+            echo "ch-json v$VERSION already published or check inconclusive (HTTP $STATUS_CODE). Skipping publish."
           fi
 
       - name: Publish ch-pivot
@@ -70,11 +75,16 @@ jobs:
         run: |
           VERSION=$(grep -m 1 '^version = ' Cargo.toml | cut -d '"' -f 2)
           echo "Checking ch-pivot v$VERSION on crates.io..."
-          
-          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" https://crates.io/api/v1/crates/ch-pivot/$VERSION || true)
-          if [ "$STATUS_CODE" = "200" ]; then
-            echo "ch-pivot v$VERSION is already published on crates.io. Skipping publish."
-          else
+
+          # crates.io API requires a User-Agent header (returns 403 otherwise).
+          # Publish ONLY on a definitive 404; treat 200/403/5xx as "skip" so a
+          # transient API quirk never triggers a doomed `cargo publish`.
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "User-Agent: clickhouse-monitoring-ci (https://github.com/duyet/clickhouse-monitoring)" \
+            "https://crates.io/api/v1/crates/ch-pivot/$VERSION" || true)
+          if [ "$STATUS_CODE" = "404" ]; then
             echo "ch-pivot v$VERSION not found on crates.io. Publishing..."
             cargo publish
+          else
+            echo "ch-pivot v$VERSION already published or check inconclusive (HTTP $STATUS_CODE). Skipping publish."
           fi


### PR DESCRIPTION
## Problem

The **Publish Workspace Crates** workflow (`cargo-publish.yml`) turned **red on main** after #1803 (a fmt-only change to `ch-json`). Failure:

```
error: crate ch-json@0.1.0 already exists on crates.io index
```

## Root cause

The skip-guard checks crates.io before publishing:

```sh
STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" https://crates.io/api/v1/crates/ch-json/$VERSION || true)
if [ "$STATUS_CODE" = "200" ]; then skip; else cargo publish; fi
```

The curl call sends **no `User-Agent`**, and crates.io's API returns **403** without one. So the guard mis-read the already-published `0.1.0` as "not found (else branch)" and ran `cargo publish`, which the index correctly rejected.

It never surfaced before because the publish job only runs when `rust/ch-json/**` or `rust/ch-pivot/**` changes — and no such change had landed without a version bump until the fmt fix.

Verified live:

| Request | Result |
|---|---|
| no User-Agent | `403` |
| with User-Agent, published version | `200` |
| with User-Agent, absent version | `404` |

## Fix

- Send a `User-Agent` header on both crate checks (ch-json, ch-pivot).
- Publish **only on a definitive `404`**; treat `200/403/5xx` as *skip*, so a transient API quirk can never trigger a doomed `cargo publish` again.

🤖 Filed by the agent-loop (keep-main-green). Self-inflicted regression from #1803, now root-caused and hardened.

https://claude.ai/code/session_01NUoGhuRYbd2q8QMrsiLz6k

## Summary by Sourcery

CI:
- Update crates.io guard checks in the Rust cargo-publish workflow to send an explicit User-Agent header and only trigger publishing when the API returns 404 for ch-json and ch-pivot.