### PR TITLE
fix(clickhouse-client): honor versioned sql[] in fetchJsonEachRowAsNormalizedJson

### DIFF
--- a/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-fetch.test.ts
+++ b/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-fetch.test.ts
@@ -595,5 +595,31 @@ describe('clickhouse-fetch', () => {
       expect(__testCountJsonEachRowRows('{"a":1}\n{"a":2}\n')).toBe(2)
       expect(__testCountJsonEachRowRows('{"a":1}\n\n{"a":2}')).toBe(2)
     })
+
+    it('executes the version-selected sql from a versioned queryConfig.sql[], not the raw query arg', async () => {
+      // Single-entry array is always selected regardless of detected version,
+      // so this asserts the helper honors queryConfig.sql[] (mirroring fetchData)
+      // rather than silently running the raw `query` argument.
+      const queryConfig: QueryConfigLike = {
+        name: 'versioned',
+        sql: [{ since: '1.0', sql: 'SELECT only_variant' }],
+      } as QueryConfigLike
+
+      const result = await fetchJsonEachRowAsNormalizedJson({
+        ...defaultParams,
+        query: 'SELECT raw_ignored',
+        queryConfig,
+      })
+
+      const executed = mockClientQuery.mock.calls.map((c) => c[0].query)
+      expect(
+        executed.some((q: string) => q.includes('SELECT only_variant'))
+      ).toBe(true)
+      expect(executed.some((q: string) => q.includes('raw_ignored'))).toBe(
+        false
+      )
+      // metadata.sql should also reflect the executed (selected) query
+      expect(result.metadata.sql).toContain('SELECT only_variant')
+    })
   })
 })

--- a/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
+++ b/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
@@ -545,9 +545,24 @@ export const fetchJsonEachRowAsNormalizedJson = async ({
       clientConfig,
     })
 
+    // Select the version-appropriate SQL when a versioned queryConfig is
+    // provided, mirroring fetchData. Current callers pre-resolve the SQL and
+    // pass only a minimal queryConfig (for the optional-table check), so this
+    // is a no-op for them; it makes the helper correct for any caller that
+    // hands over a queryConfig with a versioned sql[] instead.
+    let effectiveQuery = query
+    if (queryConfig && Array.isArray(queryConfig.sql)) {
+      const clickhouseVersion = await getClickHouseVersion(currentHostId)
+      effectiveQuery = selectVersionedSql(queryConfig.sql, clickhouseVersion)
+      debug(
+        `[fetchJsonEachRowAsNormalizedJson] Version selection for ${queryConfig.name}: ` +
+          `detected=${clickhouseVersion?.raw ?? 'null'}`
+      )
+    }
+
     try {
       const resultSet = await client.query({
-        query: QUERY_COMMENT + query,
+        query: QUERY_COMMENT + effectiveQuery,
         format: 'JSONEachRow',
         query_params,
         clickhouse_settings,
@@ -561,7 +576,7 @@ export const fetchJsonEachRowAsNormalizedJson = async ({
 
       debug(
         `--> Query (${queryId}, host: ${clientConfig.host}):`,
-        query.replace(/(\n|\s+)/g, ' ').replace(/\s+/g, ' ')
+        effectiveQuery.replace(/(\n|\s+)/g, ' ').replace(/\s+/g, ' ')
       )
       debug(`<-- Response (${queryId}):`, { rows, duration, unit: 's' })
 
@@ -573,7 +588,7 @@ export const fetchJsonEachRowAsNormalizedJson = async ({
           duration,
           rows,
           host: clientConfig.host,
-          sql: query.replace(/\s+/g, ' ').trim(),
+          sql: effectiveQuery.replace(/\s+/g, ' ').trim(),
           rawResponseLength: rawText.length,
           rawResponsePreview:
             rawText.length <= 500 ? rawText : `${rawText.substring(0, 500)}...`,


### PR DESCRIPTION
Closes #1779 (part 2). Part 1 (removing the always-throwing `query()` helper) already landed via #1789.

## Problem

`fetchJsonEachRowAsNormalizedJson` accepts a `queryConfig` but **ignored its versioned `sql[]`**, always executing the raw `query` argument. `fetchData` does the opposite — it calls `selectVersionedSql` to pick the version-appropriate variant.

Latent today: the only caller (`apps/dashboard/src/lib/api/query-executor.ts`) pre-resolves the SQL via its own `selectVersionedSql` and passes only a minimal `queryConfig` (`{name, tableCheck, optional}`) for the optional-table check. But any future caller handing over a versioned `queryConfig` would silently run the wrong SQL.

## Fix

- Mirror `fetchData`: when `queryConfig.sql` is a `VersionedSql[]`, fetch the ClickHouse version and select the matching variant. **No-op for current callers** (their `queryConfig` carries no `sql[]`).
- Point the debug log and `metadata.sql` (surfaced in the Request Info dialog) at the **executed** query, not the raw arg.

## Test

Added a test asserting the version-selected SQL runs and the raw `query` arg does not. Verified it **fails without the fix** (38 pass / 1 fail) and passes with it (39 pass).

🤖 Filed by the agent-loop (improvement-scan).

https://claude.ai/code/session_01NUoGhuRYbd2q8QMrsiLz6k

## Summary by Sourcery

Ensure ClickHouse JSON row fetching uses the correct SQL when a versioned query configuration is provided.

Bug Fixes:
- Honor versioned queryConfig.sql[] in fetchJsonEachRowAsNormalizedJson so the executed query matches the selected versioned SQL instead of the raw query argument.

Enhancements:
- Align debug logging and returned metadata.sql to reflect the actually executed (version-selected) SQL query.

Tests:
- Add a test verifying that fetchJsonEachRowAsNormalizedJson executes the version-selected SQL from queryConfig.sql[] and that metadata.sql matches it.