### PR TITLE
chore(cache-manager): remove dead exports (#1776 item 2)

### DIFF
--- a/apps/dashboard/src/lib/api/data/cache-manager.ts
+++ b/apps/dashboard/src/lib/api/data/cache-manager.ts
@@ -25,30 +25,14 @@ let cacheTimestamp = 0
 /** Default cache TTL: 5 minutes */
 const DEFAULT_CACHE_TTL = 5 * 60 * 1000
 
-/** Current TTL value (can be configured) */
-let currentCacheTTL = DEFAULT_CACHE_TTL
+/** Current TTL value */
+const currentCacheTTL = DEFAULT_CACHE_TTL
 
 /**
  * Get the current cache TTL in milliseconds
  */
 export function getCacheTTL(): number {
   return currentCacheTTL
-}
-
-/**
- * Set a custom cache TTL (for testing or configuration)
- *
- * @param ttl - Time to live in milliseconds
- */
-export function setCacheTTL(ttl: number): void {
-  currentCacheTTL = ttl
-}
-
-/**
- * Reset the cache TTL to default
- */
-export function resetCacheTTL(): void {
-  currentCacheTTL = DEFAULT_CACHE_TTL
 }
 
 /**
@@ -122,20 +106,6 @@ export function updateDashboardQueryCache(
 }
 
 /**
- * Clear all cached dashboard queries
- * Useful for testing or manual cache invalidation
- *
- * @example
- * ```ts
- * clearAllCache()
- * ```
- */
-export function clearAllCache(): void {
-  cache.clear()
-  cacheTimestamp = Date.now()
-}
-
-/**
  * Clear cache for a specific host
  *
  * @param hostId - The host identifier
@@ -179,23 +149,4 @@ export function getCacheStats(): {
       queryCount: entry.queries.size,
     })),
   }
-}
-
-/**
- * Check if a specific query is cached for a host
- *
- * @param hostId - The host identifier
- * @param query - The query string to check
- * @returns True if the query is in the cache
- *
- * @example
- * ```ts
- * if (isQueryCached(0, 'SELECT count() FROM system.tables')) {
- *   // Query is cached
- * }
- * ```
- */
-export function isQueryCached(hostId: number, query: string): boolean {
-  const queries = getCachedDashboardQueries(hostId)
-  return queries?.has(query) ?? false
 }


### PR DESCRIPTION
Refs #1776 (item 2).

## What

`setCacheTTL`, `resetCacheTTL`, `clearAllCache`, `isQueryCached` in `apps/dashboard/src/lib/api/data/cache-manager.ts` have **zero callers** anywhere (verified via ripgrep across `src`, including tests). Only `getCachedDashboardQueries` / `updateDashboardQueryCache` / `getCacheTTL` / `clearHostCache` are consumed.

- Removed the four dead exports (−49 net lines).
- With both TTL setters gone, `currentCacheTTL` is never reassigned → changed `let` → `const` and corrected its now-stale comment.

No behavior change. Nothing imports the removed symbols, so type safety is unaffected.

## Note on the rest of #1776

- **Item 4** (gate the 2 agent-API `console.log`s) is **already done** — lines 589/680 in `agent.ts` are gated behind `AGENT_DEBUG_LOGS` (landed via #1791).
- Items 1 (formatDuration dedup) and 3 (data-table `any`) remain; items 5 (radio filter) and 6 (z.record schema) are design decisions for the owner.

🤖 Filed by the agent-loop (improvement-scan, tech-debt).

https://claude.ai/code/session_01NUoGhuRYbd2q8QMrsiLz6k

## Summary by Sourcery

Remove unused cache-manager exports and make the cache TTL configuration immutable.

Enhancements:
- Remove unused cache-manager APIs for setting/resetting TTL, clearing all cache, and checking if a query is cached.
- Treat cache TTL as a constant now that it is no longer mutated, updating its documentation accordingly.