### PR TITLE
chore(data-table): type TableHeader headerGroups (#1776 item 3, partial)

### DIFF
--- a/apps/dashboard/src/components/data-table/renderers/table-header.tsx
+++ b/apps/dashboard/src/components/data-table/renderers/table-header.tsx
@@ -1,5 +1,9 @@
 import { GripVertical } from 'lucide-react'
-import { flexRender, type Header } from '@tanstack/react-table'
+import {
+  flexRender,
+  type Header,
+  type HeaderGroup,
+} from '@tanstack/react-table'
 
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
@@ -341,7 +345,9 @@ export const TableHeaderRow = function TableHeaderRow({
  * Props for TableHeader component
  */
 export interface TableHeaderProps {
-  headerGroups: any
+  // HeaderGroup<any> matches this file's existing Header<any, unknown> convention
+  // and accepts the caller's generic HeaderGroup<TData>[] from table.getHeaderGroups().
+  headerGroups: HeaderGroup<any>[]
   /** Callback when double-clicking column resizer to auto-fit */
   onAutoFit?: (columnId: string) => void
   /** Enable column reordering with drag-and-drop */
@@ -368,7 +374,7 @@ export const TableHeader = function TableHeader({
 }: TableHeaderProps) {
   return (
     <>
-      {headerGroups.map((headerGroup: any) => (
+      {headerGroups.map((headerGroup) => (
         <TableHeaderRow
           key={headerGroup.id}
           headers={headerGroup.headers}


### PR DESCRIPTION
Refs #1776 (item 3, table-header half).

## What

- `headerGroups: any` → `HeaderGroup<any>[]`; dropped the `headerGroup: any` annotation in the `.map` (now inferred).
- `HeaderGroup<any>` matches this file's existing `Header<any, unknown>` convention and accepts the caller's generic `HeaderGroup<TData>[]` from `table.getHeaderGroups()`, so it's assignable by construction. No behavior change.

## Deferred (intentionally)

The `hover-card-format.tsx` `{... as any}` casts are **not** touched: an inline comment documents them as a workaround for a React 19 vs radix-ui `@types/react` skew (React 19's `ReactNode` includes `bigint`; radix's bundled types don't). Dropping them risks reintroducing a JSX-boundary type error that only surfaces in the full dashboard build. Left for a deliberate follow-up if/when the radix types catch up.

🤖 Filed by the agent-loop (improvement-scan, tech-debt). The `dashboard` CI check is the authoritative type gate for this app-level change.

https://claude.ai/code/session_01NUoGhuRYbd2q8QMrsiLz6k

## Summary by Sourcery

Enhancements:
- Replace the TableHeader headerGroups prop type from any to HeaderGroup<any>[] and rely on type inference within headerGroups.map to improve type safety without changing runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety in data table components through stronger type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->