### PR TITLE
perf(charts): use REFRESH_INTERVAL presets for refresh intervals (#1772)

### DIFF
--- a/apps/dashboard/src/components/charts/dictionary-count.tsx
+++ b/apps/dashboard/src/components/charts/dictionary-count.tsx
@@ -3,7 +3,7 @@ import type { ChartProps } from '@/components/charts/chart-props'
 import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { BarList } from '@/components/charts/primitives/bar-list'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 
 type DataRow = {
   status: string
@@ -18,7 +18,7 @@ export const ChartDictionaryCount = function ChartDictionaryCount({
   const swr = useChartData<DataRow>({
     chartName: 'dictionary-count',
     hostId,
-    refreshInterval: 30000,
+    refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
   })
 
   return (

--- a/apps/dashboard/src/components/charts/merge/new-parts-created.tsx
+++ b/apps/dashboard/src/components/charts/merge/new-parts-created.tsx
@@ -6,7 +6,7 @@ import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { BarChart } from '@/components/charts/primitives/bar/bar'
 import { resolveDateRangeConfig } from '@/components/date-range'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 import { cn } from '@/lib/utils'
 
 export const ChartNewPartsCreated = function ChartNewPartsCreated({
@@ -37,7 +37,7 @@ export const ChartNewPartsCreated = function ChartNewPartsCreated({
     hostId,
     interval: effectiveInterval,
     lastHours: effectiveLastHours,
-    refreshInterval: 30000,
+    refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
   })
 
   // Resolve date range config

--- a/apps/dashboard/src/components/charts/parts-per-table.tsx
+++ b/apps/dashboard/src/components/charts/parts-per-table.tsx
@@ -3,7 +3,7 @@ import type { ChartProps } from '@/components/charts/chart-props'
 import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { RankBars } from '@/components/charts/primitives/rank-bars'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 
 type DataRow = {
   table_path: string
@@ -21,7 +21,7 @@ export const ChartPartsPerTable = function ChartPartsPerTable({
   const swr = useChartData<DataRow>({
     chartName: 'parts-per-table',
     hostId,
-    refreshInterval: 30000,
+    refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
   })
 
   return (

--- a/apps/dashboard/src/components/charts/query-performance/top-inserters.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/top-inserters.tsx
@@ -3,7 +3,7 @@ import type { ChartProps } from '@/components/charts/chart-props'
 import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { BarList } from '@/components/charts/primitives/bar-list'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 
 type DataRow = {
   user: string
@@ -25,7 +25,7 @@ export const ChartTopInserters = function ChartTopInserters({
   const swr = useChartData<DataRow>({
     chartName: 'top-inserters',
     hostId,
-    refreshInterval: 60000,
+    refreshInterval: REFRESH_INTERVAL.DEFAULT_60S,
   })
 
   return (

--- a/apps/dashboard/src/components/charts/query-performance/top-query-fingerprints.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/top-query-fingerprints.tsx
@@ -2,7 +2,7 @@ import type { ChartProps } from '@/components/charts/chart-props'
 
 import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 
 type DataRow = {
   normalized_query_hash: string
@@ -25,7 +25,7 @@ export const ChartTopQueryFingerprints = function ChartTopQueryFingerprints({
   const swr = useChartData<DataRow>({
     chartName: 'top-query-fingerprints-perf',
     hostId,
-    refreshInterval: 60000,
+    refreshInterval: REFRESH_INTERVAL.DEFAULT_60S,
   })
 
   return (

--- a/apps/dashboard/src/components/charts/query/cancelled-queries.tsx
+++ b/apps/dashboard/src/components/charts/query/cancelled-queries.tsx
@@ -6,7 +6,7 @@ import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { BarChart } from '@/components/charts/primitives/bar/bar'
 import { DATE_RANGE_PRESETS } from '@/components/date-range'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 import { cn } from '@/lib/utils'
 
 // Human-readable labels for ClickHouse exception codes related to cancellation
@@ -48,7 +48,7 @@ export const ChartCancelledQueries = memo(function ChartCancelledQueries({
     hostId,
     interval: effectiveInterval,
     lastHours: effectiveLastHours,
-    refreshInterval: 30000,
+    refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
   })
 
   return (

--- a/apps/dashboard/src/components/charts/query/failed-query-count-by-user.tsx
+++ b/apps/dashboard/src/components/charts/query/failed-query-count-by-user.tsx
@@ -7,7 +7,7 @@ import { ChartContainer } from '@/components/charts/chart-container'
 import { BarChart } from '@/components/charts/primitives/bar/bar'
 import { DATE_RANGE_PRESETS } from '@/components/date-range'
 import { transformUserEventCounts } from '@/lib/chart-data-transforms'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 
 export const ChartFailedQueryCountByUser = memo(
   function ChartFailedQueryCountByUser({
@@ -37,7 +37,7 @@ export const ChartFailedQueryCountByUser = memo(
       hostId,
       interval: effectiveInterval,
       lastHours: effectiveLastHours,
-      refreshInterval: 30000,
+      refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
     })
 
     return (

--- a/apps/dashboard/src/components/charts/query/query-count-by-user.tsx
+++ b/apps/dashboard/src/components/charts/query/query-count-by-user.tsx
@@ -7,7 +7,7 @@ import { ChartContainer } from '@/components/charts/chart-container'
 import { BarChart } from '@/components/charts/primitives/bar/bar'
 import { resolveDateRangeConfig } from '@/components/date-range'
 import { transformUserEventCounts } from '@/lib/chart-data-transforms'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 import { chartTickFormatters, cn } from '@/lib/utils'
 
 export const ChartQueryCountByUser = memo(function ChartQueryCountByUser({
@@ -38,7 +38,7 @@ export const ChartQueryCountByUser = memo(function ChartQueryCountByUser({
     hostId,
     interval: effectiveInterval,
     lastHours: effectiveLastHours,
-    refreshInterval: 30000,
+    refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
   })
 
   // Resolve date range config

--- a/apps/dashboard/src/components/charts/query/slow-query-occurrences.tsx
+++ b/apps/dashboard/src/components/charts/query/slow-query-occurrences.tsx
@@ -6,7 +6,7 @@ import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { BarChart } from '@/components/charts/primitives/bar/bar'
 import { DATE_RANGE_PRESETS } from '@/components/date-range'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 import { chartTickFormatters, cn } from '@/lib/utils'
 
 export const ChartSlowQueryOccurrences = memo(
@@ -35,7 +35,7 @@ export const ChartSlowQueryOccurrences = memo(
       hostId,
       interval: effectiveInterval,
       lastHours: effectiveLastHours,
-      refreshInterval: 60000,
+      refreshInterval: REFRESH_INTERVAL.DEFAULT_60S,
     })
 
     return (

--- a/apps/dashboard/src/components/charts/query/top-query-fingerprints.tsx
+++ b/apps/dashboard/src/components/charts/query/top-query-fingerprints.tsx
@@ -6,7 +6,7 @@ import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { BarChart } from '@/components/charts/primitives/bar/bar'
 import { resolveDateRangeConfig } from '@/components/date-range'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 import { chartTickFormatters } from '@/lib/utils'
 
 interface FingerprintRow {
@@ -73,7 +73,7 @@ export const ChartTopQueryFingerprints = memo(
       hostId,
       interval: effectiveInterval,
       lastHours: effectiveLastHours,
-      refreshInterval: 60000,
+      refreshInterval: REFRESH_INTERVAL.DEFAULT_60S,
     })
 
     const dateRangeConfig = resolveDateRangeConfig('query-activity')

--- a/apps/dashboard/src/components/charts/replication/replication-lag.tsx
+++ b/apps/dashboard/src/components/charts/replication/replication-lag.tsx
@@ -13,7 +13,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 import { cn } from '@/lib/utils'
 import {
   STATUS_BADGE_CLASS,
@@ -52,7 +52,7 @@ export const ChartReplicationLag = function ChartReplicationLag({
     useChartData<ReplicationLagData>({
       chartName: 'replication-lag',
       hostId,
-      refreshInterval: 30000,
+      refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
     })
 
   const dataArray = Array.isArray(data) ? data : undefined

--- a/apps/dashboard/src/components/charts/replication/replication-summary-table.tsx
+++ b/apps/dashboard/src/components/charts/replication/replication-summary-table.tsx
@@ -12,7 +12,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 import { cn } from '@/lib/utils'
 
 export const ChartReplicationSummaryTable =
@@ -29,7 +29,7 @@ export const ChartReplicationSummaryTable =
     }>({
       chartName: 'replication-summary-table',
       hostId,
-      refreshInterval: 30000,
+      refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
     })
 
     const dataArray = Array.isArray(data) ? data : undefined

--- a/apps/dashboard/src/components/charts/summary-stuck-mutations.tsx
+++ b/apps/dashboard/src/components/charts/summary-stuck-mutations.tsx
@@ -6,7 +6,7 @@ import { ChartCard } from '@/components/cards/chart-card'
 import { ChartEmpty } from '@/components/charts/chart-empty'
 import { ChartError } from '@/components/charts/chart-error'
 import { ChartSkeleton } from '@/components/skeletons'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 import { cn } from '@/lib/utils'
 
 interface MutationMetrics extends ChartDataPoint {
@@ -38,7 +38,7 @@ export const ChartSummaryStuckMutations = function ChartSummaryStuckMutations({
     useChartData<MutationMetrics>({
       chartName: 'summary-stuck-mutations',
       hostId,
-      refreshInterval: 30000,
+      refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
     })
 
   const dataArray = Array.isArray(data) ? data : undefined

--- a/apps/dashboard/src/components/charts/summary-used-by-mutations.tsx
+++ b/apps/dashboard/src/components/charts/summary-used-by-mutations.tsx
@@ -5,7 +5,7 @@ import { ChartCard } from '@/components/cards/chart-card'
 import { ChartEmpty } from '@/components/charts/chart-empty'
 import { ChartError } from '@/components/charts/chart-error'
 import { ChartSkeleton } from '@/components/skeletons'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 
 export const ChartSummaryUsedByMutations =
   function ChartSummaryUsedByMutations({
@@ -18,7 +18,7 @@ export const ChartSummaryUsedByMutations =
     }>({
       chartName: 'summary-used-by-mutations',
       hostId,
-      refreshInterval: 30000,
+      refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
     })
 
     const dataArray = Array.isArray(data) ? data : undefined

--- a/apps/dashboard/src/components/charts/system/compression-ratio.tsx
+++ b/apps/dashboard/src/components/charts/system/compression-ratio.tsx
@@ -3,7 +3,7 @@ import type { ChartProps } from '@/components/charts/chart-props'
 import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { RankBars } from '@/components/charts/primitives/rank-bars'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 
 type DataRow = {
   table_path: string
@@ -21,7 +21,7 @@ export const ChartCompressionRatio = function ChartCompressionRatio({
   const swr = useChartData<DataRow>({
     chartName: 'compression-ratio',
     hostId,
-    refreshInterval: 300000,
+    refreshInterval: REFRESH_INTERVAL.VERY_SLOW_5M,
   })
 
   return (

--- a/apps/dashboard/src/components/charts/system/disk-io-throughput.tsx
+++ b/apps/dashboard/src/components/charts/system/disk-io-throughput.tsx
@@ -6,7 +6,7 @@ import { ChartContainer } from '@/components/charts/chart-container'
 import { ChartEmpty } from '@/components/charts/chart-empty'
 import { AreaChart } from '@/components/charts/primitives/area'
 import { pivotRows, type RawRow } from '@/lib/chart-utils'
-import { useChartData, useHostId } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData, useHostId } from '@/lib/swr'
 import { chartTickFormatters, cn, createDateTickFormatter } from '@/lib/utils'
 
 const CHART_NAME = 'disk-io-throughput'
@@ -28,7 +28,7 @@ export function ChartDiskIOThroughput({
     hostId,
     interval,
     lastHours,
-    refreshInterval: 30000,
+    refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
   })
 
   const { pivoted, categories } = (() => {

--- a/apps/dashboard/src/components/charts/system/disk-usage-by-database.tsx
+++ b/apps/dashboard/src/components/charts/system/disk-usage-by-database.tsx
@@ -5,7 +5,7 @@ import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { RankBars } from '@/components/charts/primitives/rank-bars'
 import { SegmentedControl } from '@/components/filters/segmented-control'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 
 type DataRow = {
   database: string
@@ -30,7 +30,7 @@ export const ChartDiskUsageByDatabase = function ChartDiskUsageByDatabase({
   const swr = useChartData<DataRow>({
     chartName: 'disk-usage-by-database',
     hostId,
-    refreshInterval: 60000,
+    refreshInterval: REFRESH_INTERVAL.DEFAULT_60S,
   })
 
   return (

--- a/apps/dashboard/src/components/charts/system/disk-usage-trend.tsx
+++ b/apps/dashboard/src/components/charts/system/disk-usage-trend.tsx
@@ -7,7 +7,7 @@ import { ChartEmpty } from '@/components/charts/chart-empty'
 import { AreaChart } from '@/components/charts/primitives/area'
 import { pivotRows, type RawRow } from '@/lib/chart-utils'
 import { formatReadableSize } from '@/lib/format-readable'
-import { useChartData, useHostId } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData, useHostId } from '@/lib/swr'
 import { chartTickFormatters, createDateTickFormatter } from '@/lib/utils'
 
 const CHART_NAME = 'disk-usage-trend'
@@ -40,7 +40,7 @@ export function ChartDiskUsageTrend({
     hostId,
     interval,
     lastHours,
-    refreshInterval: 30000,
+    refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
   })
 
   const { pivoted, categories } = (() => {

--- a/apps/dashboard/src/components/charts/system/disks-usage.tsx
+++ b/apps/dashboard/src/components/charts/system/disks-usage.tsx
@@ -8,7 +8,7 @@ import { ChartContainer } from '@/components/charts/chart-container'
 import { ChartEmpty } from '@/components/charts/chart-empty'
 import { AreaChart } from '@/components/charts/primitives/area'
 import { resolveDateRangeConfig } from '@/components/date-range'
-import { useChartData, useHostId } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData, useHostId } from '@/lib/swr'
 import { chartTickFormatters, createDateTickFormatter } from '@/lib/utils'
 
 const CHART_NAME = 'disks-usage'
@@ -51,7 +51,7 @@ export function ChartDisksUsage({
     hostId,
     interval: effectiveInterval,
     lastHours: effectiveLastHours,
-    refreshInterval: 60000,
+    refreshInterval: REFRESH_INTERVAL.DEFAULT_60S,
   })
 
   const tickFormatter = createDateTickFormatter(effectiveLastHours)

--- a/apps/dashboard/src/components/charts/system/keeper-requests.tsx
+++ b/apps/dashboard/src/components/charts/system/keeper-requests.tsx
@@ -6,7 +6,7 @@ import { ChartContainer } from '@/components/charts/chart-container'
 import { ChartEmpty } from '@/components/charts/chart-empty'
 import { AreaChart } from '@/components/charts/primitives/area'
 import { pivotRows, type RawRow } from '@/lib/chart-utils'
-import { useChartData, useHostId } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData, useHostId } from '@/lib/swr'
 import { createDateTickFormatter } from '@/lib/utils'
 
 const CHART_NAME = 'keeper-requests'
@@ -27,7 +27,7 @@ export function ChartKeeperRequests({
     hostId,
     interval,
     lastHours,
-    refreshInterval: 30000,
+    refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
   })
 
   const { pivoted, categories } = (() => {

--- a/apps/dashboard/src/components/charts/system/mutation-progress.tsx
+++ b/apps/dashboard/src/components/charts/system/mutation-progress.tsx
@@ -3,7 +3,7 @@ import type { ChartProps } from '@/components/charts/chart-props'
 import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { STUCK_THRESHOLD_SECONDS } from '@/lib/query-config/merges/mutations'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 import { cn } from '@/lib/utils'
 import {
   STATUS_BADGE_CLASS,
@@ -55,7 +55,7 @@ export const ChartMutationProgress = function ChartMutationProgress({
   const swr = useChartData<DataRow>({
     chartName: 'mutation-progress',
     hostId,
-    refreshInterval: 30000,
+    refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
   })
 
   return (

--- a/apps/dashboard/src/components/charts/system/partition-part-health.tsx
+++ b/apps/dashboard/src/components/charts/system/partition-part-health.tsx
@@ -2,7 +2,7 @@ import type { ChartProps } from '@/components/charts/chart-props'
 
 import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 
 type SummaryRow = {
   active_parts: number
@@ -26,7 +26,7 @@ export const ChartPartitionPartHealth = function ChartPartitionPartHealth({
   const swr = useChartData<SummaryRow>({
     chartName: 'partition-part-health-summary',
     hostId,
-    refreshInterval: 30000,
+    refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
   })
 
   return (

--- a/apps/dashboard/src/components/charts/system/replication-lag.tsx
+++ b/apps/dashboard/src/components/charts/system/replication-lag.tsx
@@ -3,7 +3,7 @@ import type { ChartProps } from '@/components/charts/chart-props'
 import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { BarList } from '@/components/charts/primitives/bar-list'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 
 type DataRow = {
   database: string
@@ -25,7 +25,7 @@ export const ChartReplicationLag = function ChartReplicationLag({
   const swr = useChartData<DataRow>({
     chartName: 'replication-lag',
     hostId,
-    refreshInterval: 30000,
+    refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
   })
 
   return (

--- a/apps/dashboard/src/components/charts/system/storage-policies.tsx
+++ b/apps/dashboard/src/components/charts/system/storage-policies.tsx
@@ -2,7 +2,7 @@ import type { ChartProps } from '@/components/charts/chart-props'
 
 import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
-import { useChartData, useHostId } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData, useHostId } from '@/lib/swr'
 
 type DataRow = {
   policy_name: string
@@ -64,7 +64,7 @@ export const ChartStoragePolicies = function ChartStoragePolicies({
   const swr = useChartData<DataRow>({
     chartName: CHART_NAME,
     hostId,
-    refreshInterval: 300000,
+    refreshInterval: REFRESH_INTERVAL.VERY_SLOW_5M,
   })
 
   return (

--- a/apps/dashboard/src/components/charts/system/top-memory-queries.tsx
+++ b/apps/dashboard/src/components/charts/system/top-memory-queries.tsx
@@ -3,7 +3,7 @@ import type { ChartProps } from '@/components/charts/chart-props'
 import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { BarList } from '@/components/charts/primitives/bar-list'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 
 type DataRow = {
   query_preview: string
@@ -23,7 +23,7 @@ export const ChartTopMemoryQueries = function ChartTopMemoryQueries({
   const swr = useChartData<DataRow>({
     chartName: 'top-memory-queries',
     hostId,
-    refreshInterval: 60000,
+    refreshInterval: REFRESH_INTERVAL.DEFAULT_60S,
   })
 
   return (

--- a/apps/dashboard/src/components/charts/top-table-size.tsx
+++ b/apps/dashboard/src/components/charts/top-table-size.tsx
@@ -5,7 +5,7 @@ import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { RankBars } from '@/components/charts/primitives/rank-bars'
 import { SegmentedControl } from '@/components/filters/segmented-control'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 
 type DataRow = {
   table: string
@@ -36,7 +36,7 @@ export const ChartTopTableSize = function ChartTopTableSize({
     chartName: 'top-table-size',
     hostId,
     params: { limit },
-    refreshInterval: 30000,
+    refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
   })
 
   return (

--- a/apps/dashboard/src/components/charts/zookeeper/zookeeper-summary-table.tsx
+++ b/apps/dashboard/src/components/charts/zookeeper/zookeeper-summary-table.tsx
@@ -11,7 +11,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 import { cn } from '@/lib/utils'
 
 export const ChartZookeeperSummaryTable = function ChartZookeeperSummaryTable({
@@ -26,7 +26,7 @@ export const ChartZookeeperSummaryTable = function ChartZookeeperSummaryTable({
   }>({
     chartName: 'zookeeper-summary-table',
     hostId,
-    refreshInterval: 30000,
+    refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
   })
 
   const dataArray = Array.isArray(data) ? data : undefined

--- a/apps/dashboard/src/components/charts/zookeeper/zookeeper-uptime.tsx
+++ b/apps/dashboard/src/components/charts/zookeeper/zookeeper-uptime.tsx
@@ -5,7 +5,7 @@ import type { ChartProps } from '@/components/charts/chart-props'
 import { CardMultiMetrics } from '@/components/cards/card-multi-metrics'
 import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
-import { useChartData } from '@/lib/swr'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 import { cn } from '@/lib/utils'
 
 export const ChartZookeeperUptime = function ChartZookeeperUptime({
@@ -18,7 +18,7 @@ export const ChartZookeeperUptime = function ChartZookeeperUptime({
   }>({
     chartName: 'zookeeper-uptime',
     hostId,
-    refreshInterval: 30000,
+    refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
   })
 
   return (


### PR DESCRIPTION
## Summary

Replaces raw `refreshInterval` numeric literals across **all 28 chart components** with the named `REFRESH_INTERVAL` presets from `lib/swr/config.ts`. The presets are value-identical to the literals, so this is a pure DRY cleanup with **no behavior change** — the win is a single source of truth, so a future retune of a cadence preset propagates instead of silently drifting on a stale literal.

| Literal | Preset |
|---------|--------|
| `30000` | `REFRESH_INTERVAL.MEDIUM_30S` |
| `60000` | `REFRESH_INTERVAL.DEFAULT_60S` |
| `300000` | `REFRESH_INTERVAL.VERY_SLOW_5M` |

#1772 listed 6 charts as examples; this PR extends the same swap to every chart still on a raw literal (22 more) so the codebase is consistent.

## Unmount-on-collapse audit (the issue's second ask)

CLAUDE.md requires collapsed chart sections to **unmount** (not CSS-hide), otherwise hidden charts keep polling ClickHouse. Audited the render paths:

- `layout/query-page/layout.tsx` gates the whole chart strip behind `{!isCollapsed && (...)}`.
- `layout/query-page/chart-row.tsx` renders the `DynamicChart` grid only when `!isCollapsed` (line 79) — inside `<CollapsibleContent>` but explicitly conditional, so the chart subtree is removed from the tree on collapse, not just hidden.
- `lib/query/use-chart-data.ts` additionally pauses `refetchInterval` when `document.hidden`.

**Result:** collapsing a section fully unmounts the charts and stops their polling. No CSS-hide offenders found (the one `className="hidden"` in `chart-row.tsx` is a layout spacer for the `break` directive, not a chart).

## Verification

- `bun run type-check` ✅
- `biome check` on all 28 changed files — no fixes needed ✅
- Value-identical swaps confirmed against `lib/swr/config.ts` presets ✅

Closes #1772

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_019AsZZdTQt5BCE1rG5mhQ8R
