### PR TITLE
ci: pin build/lint to single ClickHouse fixture to unblock latest publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,17 +27,26 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  # build/lint run `turbo build` (vite + tsc) and `turbo lint` (biome) — neither
+  # connects to ClickHouse, but base.yml attaches a clickhouse_<ver> service per
+  # matrix leg. Pin them to a single, actively-used fixture tag (25.1, same as the
+  # docker jobs) instead of the default ["24.5","24.6"] matrix: this halves their
+  # CI time and avoids a flaky `manifest unknown` GHCR pull of the unused 24.5
+  # image gating the Docker `latest` publish. (Fully decoupling the DB service
+  # from non-docker job-types is a follow-up.)
   build:
     name: build
     uses: ./.github/workflows/base.yml
     with:
       job-type: build
+      clickhouse-versions: '["25.1"]'
 
   lint:
     name: lint
     uses: ./.github/workflows/base.yml
     with:
       job-type: lint
+      clickhouse-versions: '["25.1"]'
 
   depcruise:
     name: depcruise


### PR DESCRIPTION
## Problem

The Docker `latest` image silently stopped publishing on `main`.

`build`/`lint` call the reusable `base.yml`, which attaches a
`clickhouse_<ver>` **service container** per matrix leg — defaulting to
`["24.5","24.6"]`. But `build` only runs `turbo build` (vite + tsc) and `lint`
only runs `turbo lint` (biome); **neither connects to ClickHouse**.

A transient GHCR `manifest unknown` while pulling the *unused* `clickhouse_24.5`
service image failed the `build` job. Since `build-docker-amd64` is
`needs: [build]`, the whole Docker publish chain
(`build-docker-amd64 → build-docker-arm64 → docker-manifest`) was **skipped**,
so `ghcr.io/duyet/chmonitor:latest` was never updated. Reproduced 4× on run
`27895410059` (the `24.5` leg fails in seconds; the `24.6` leg passes).

## Fix

Pin `build`/`lint` to `["25.1"]` — the same tag the docker jobs already use.
One matrix leg instead of two (≈half the CI time for these jobs) and no
dependency on the flaky `24.5` fixture pull.

Follow-up: fully decouple the DB service from non-docker `job-type`s in
`base.yml` (GitHub Actions `services:` can't be conditioned on a matrix, so this
needs a small restructure).

https://claude.ai/code/session_01GEqcxtXQZNQDDpauoSovNY

## Summary by Sourcery

CI:
- Configure build and lint workflows to use ClickHouse version 25.1 instead of the default multi-version matrix in the reusable base workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI pipeline configuration to improve build stability and reduce intermittent test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->