### PR TITLE
fix(query-config): query-metric-log 500 on modern ClickHouse (aggregate alias in WHERE)

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/system/query-metric-log.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/system/query-metric-log.ts
@@ -18,7 +18,10 @@ export const queryMetricLogDeclarative: DeclarativeQueryConfig = {
       WITH per_query AS (
         SELECT
           query_id,
-          max(event_time) AS event_time,
+          -- NOT "AS event_time": the new ClickHouse analyzer resolves the WHERE
+          -- column to this aggregate alias (it shadows the raw column) and rejects
+          -- "aggregate function in WHERE". Use a distinct name, re-alias below.
+          max(event_time) AS last_event_time,
           max(memory_usage) AS memory_usage,
           max(peak_memory_usage) AS peak_memory_usage,
           max(ProfileEvent_SelectedRows) AS selected_rows,
@@ -30,7 +33,7 @@ export const queryMetricLogDeclarative: DeclarativeQueryConfig = {
       )
       SELECT
         query_id,
-        event_time,
+        last_event_time AS event_time,
         formatReadableSize(memory_usage) AS readable_memory,
         round(memory_usage * 100.0 / nullIf(max(memory_usage) OVER (), 0), 2) AS pct_readable_memory,
         formatReadableSize(peak_memory_usage) AS readable_peak_memory,

--- a/apps/dashboard/src/lib/query-config/system/query-metric-log.ts
+++ b/apps/dashboard/src/lib/query-config/system/query-metric-log.ts
@@ -20,7 +20,10 @@ export const queryMetricLogConfig: QueryConfig = {
       WITH per_query AS (
         SELECT
           query_id,
-          max(event_time) AS event_time,
+          -- NOT "AS event_time": the new ClickHouse analyzer resolves the WHERE
+          -- column to this aggregate alias (it shadows the raw column) and rejects
+          -- "aggregate function in WHERE". Use a distinct name, re-alias below.
+          max(event_time) AS last_event_time,
           max(memory_usage) AS memory_usage,
           max(peak_memory_usage) AS peak_memory_usage,
           max(ProfileEvent_SelectedRows) AS selected_rows,
@@ -32,7 +35,7 @@ export const queryMetricLogConfig: QueryConfig = {
       )
       SELECT
         query_id,
-        event_time,
+        last_event_time AS event_time,
         formatReadableSize(memory_usage) AS readable_memory,
         round(memory_usage * 100.0 / nullIf(max(memory_usage) OVER (), 0), 2) AS pct_readable_memory,
         formatReadableSize(peak_memory_usage) AS readable_peak_memory,


### PR DESCRIPTION
## What
The **/query-metric-log** page returns **500** on ClickHouse 26.x:
> Aggregate function `max(event_time) AS event_time` is found in WHERE

## Why
The `per_query` CTE aliased `max(event_time) AS event_time`, which **shadows** the raw `event_time` column. The new ClickHouse analyzer resolves the CTE's `WHERE event_time >= now() - INTERVAL 1 HOUR` to that aggregate alias and rejects it.

## Fix
Rename the aggregate to `last_event_time` (so `WHERE` binds the raw column), re-alias it back to `event_time` in the outer `SELECT`. **Version-independent**, output schema unchanged. Applied to both the TS config and its declarative-catalog mirror.

## Verify
- Validated the corrected SQL against a live ClickHouse 26.3 cluster (no error).
- Endpoint now returns `200`; page renders with 0 console errors.
- `tsc --noEmit` ✅ + system-catalog tests 33/33 ✅.

Found via the headless-Chrome route audit (companion to #1814).

https://claude.ai/code/session_019AsZZdTQt5BCE1rG5mhQ8R

## Summary by Sourcery

Resolve ClickHouse 26.x analyzer error in query-metric-log by avoiding use of an aggregate alias in the WHERE clause while preserving the endpoint’s output schema.

Bug Fixes:
- Prevent /query-metric-log from returning 500 errors on modern ClickHouse by renaming the per_query max(event_time) aggregate and re-aliasing it in the outer query.
- Keep the declarative catalog and imperative query-metric-log configurations in sync with the corrected SQL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Addressed query analyzer compatibility constraints affecting metric logging operations. Refined timestamp aggregation handling in database queries to enhance system stability, reliability, and data consistency. All exported columns and downstream integrations remain fully backward compatible with zero impact to end-user-facing functionality and data outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->