### PR TITLE
fix(query-config): query-metric-log 500 on modern ClickHouse (aggregate alias in WHERE)

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/system/query-metric-log.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/system/query-metric-log.ts
@@ -18,7 +18,10 @@ export const queryMetricLogDeclarative: DeclarativeQueryConfig = {
       WITH per_query AS (
         SELECT
           query_id,
-          max(event_time) AS event_time,
+          -- NOT "AS event_time": the new ClickHouse analyzer resolves the WHERE
+          -- column to this aggregate alias (it shadows the raw column) and rejects
+          -- "aggregate function in WHERE". Use a distinct name, re-alias below.
+          max(event_time) AS last_event_time,
           max(memory_usage) AS memory_usage,
           max(peak_memory_usage) AS peak_memory_usage,
           max(ProfileEvent_SelectedRows) AS selected_rows,
@@ -30,7 +33,7 @@ export const queryMetricLogDeclarative: DeclarativeQueryConfig = {
       )
       SELECT
         query_id,
-        event_time,
+        last_event_time AS event_time,
         formatReadableSize(memory_usage) AS readable_memory,
         round(memory_usage * 100.0 / nullIf(max(memory_usage) OVER (), 0), 2) AS pct_readable_memory,
         formatReadableSize(peak_memory_usage) AS readable_peak_memory,

--- a/apps/dashboard/src/lib/query-config/system/query-metric-log.ts
+++ b/apps/dashboard/src/lib/query-config/system/query-metric-log.ts
@@ -20,7 +20,10 @@ export const queryMetricLogConfig: QueryConfig = {
       WITH per_query AS (
         SELECT
           query_id,
-          max(event_time) AS event_time,
+          -- NOT "AS event_time": the new ClickHouse analyzer resolves the WHERE
+          -- column to this aggregate alias (it shadows the raw column) and rejects
+          -- "aggregate function in WHERE". Use a distinct name, re-alias below.
+          max(event_time) AS last_event_time,
           max(memory_usage) AS memory_usage,
           max(peak_memory_usage) AS peak_memory_usage,
           max(ProfileEvent_SelectedRows) AS selected_rows,
@@ -32,7 +35,7 @@ export const queryMetricLogConfig: QueryConfig = {
       )
       SELECT
         query_id,
-        event_time,
+        last_event_time AS event_time,
         formatReadableSize(memory_usage) AS readable_memory,
         round(memory_usage * 100.0 / nullIf(max(memory_usage) OVER (), 0), 2) AS pct_readable_memory,
         formatReadableSize(peak_memory_usage) AS readable_peak_memory,


### PR DESCRIPTION
## Problem

The `/query-metric-log` page returned **500** on ClickHouse 26.x:

> Aggregate function `max(event_time) AS event_time` is found in WHERE

## Root cause

The `per_query` CTE aliased `max(event_time) AS event_time`, shadowing the raw
`event_time` column. The new ClickHouse analyzer resolves the CTE's
`WHERE event_time >= now() - INTERVAL 1 HOUR` to that aggregate alias and rejects
it ("aggregate function in WHERE").

## Fix

Rename the aggregate to `last_event_time` (so `WHERE` binds the raw column) and
re-alias it back to `event_time` in the outer `SELECT`. Version-independent fix;
output schema unchanged. Applied to both the TS config and its declarative-catalog
mirror.

Found via the headless-Chrome route audit (see #1814).

Co-Authored-By: duyetbot <bot@duyet.net>

https://claude.ai/code/session_019AsZZdTQt5BCE1rG5mhQ8R