### PR TITLE
fix(mutations): redesign sparse summary cards with denser hierarchy + empty state

### DIFF
--- a/apps/dashboard/src/components/charts/summary-stuck-mutations.tsx
+++ b/apps/dashboard/src/components/charts/summary-stuck-mutations.tsx
@@ -1,7 +1,8 @@
+import { CheckCircle2 } from 'lucide-react'
+
 import type { ChartProps } from '@/components/charts/chart-props'
 import type { ChartDataPoint } from '@/types/chart-data'
 
-import { CardMultiMetrics } from '@/components/cards/card-multi-metrics'
 import { ChartCard } from '@/components/cards/chart-card'
 import { ChartEmpty } from '@/components/charts/chart-empty'
 import { ChartError } from '@/components/charts/chart-error'
@@ -15,19 +16,29 @@ interface MutationMetrics extends ChartDataPoint {
   failed: number
 }
 
-const METRIC_CONFIGS = [
-  { key: 'active' as const, label: 'active', activeColor: '' },
-  {
-    key: 'stuck' as const,
-    label: 'stuck',
-    activeColor: 'text-red-600 dark:text-red-400',
-  },
-  {
-    key: 'failed' as const,
-    label: 'failed',
-    activeColor: 'text-amber-600 dark:text-amber-400',
-  },
-] satisfies { key: keyof MutationMetrics; label: string; activeColor: string }[]
+interface StatItemProps {
+  value: number
+  label: string
+  activeClassName: string
+}
+
+function StatItem({ value, label, activeClassName }: StatItemProps) {
+  return (
+    <div className="flex flex-col items-center gap-1 min-w-0">
+      <span
+        className={cn(
+          'text-3xl font-bold tabular-nums leading-none',
+          value > 0 ? activeClassName : 'text-foreground'
+        )}
+      >
+        {value}
+      </span>
+      <span className="text-xs text-muted-foreground tracking-wide uppercase">
+        {label}
+      </span>
+    </div>
+  )
+}
 
 export const ChartSummaryStuckMutations = function ChartSummaryStuckMutations({
   title,
@@ -52,6 +63,8 @@ export const ChartSummaryStuckMutations = function ChartSummaryStuckMutations({
   }
 
   const metrics = dataArray[0]
+  const allClear =
+    metrics.active === 0 && metrics.stuck === 0 && metrics.failed === 0
 
   return (
     <ChartCard
@@ -60,29 +73,39 @@ export const ChartSummaryStuckMutations = function ChartSummaryStuckMutations({
       data={dataArray}
       staleError={staleError}
       onRetry={mutate}
+      className={className}
     >
-      <div className="flex flex-col content-stretch items-center p-0">
-        <CardMultiMetrics
-          primary={
-            <span className="flex flex-row items-center gap-4 self-center text-center">
-              {METRIC_CONFIGS.map(({ key, label, activeColor }) => (
-                <span key={key}>
-                  <span
-                    className={cn(
-                      'text-2xl font-bold',
-                      metrics[key] > 0 && activeColor
-                    )}
-                  >
-                    {metrics[key]}
-                  </span>{' '}
-                  <span className="text-muted-foreground text-sm">{label}</span>
-                </span>
-              ))}
-            </span>
-          }
-          className="p-2"
-        />
-      </div>
+      {allClear ? (
+        <div className="flex flex-col items-center justify-center gap-2 py-3 text-center">
+          <CheckCircle2
+            className="size-6 text-emerald-500/70"
+            strokeWidth={1.5}
+          />
+          <span className="text-sm text-muted-foreground">
+            All clear — no stuck mutations
+          </span>
+        </div>
+      ) : (
+        <div className="flex items-center justify-around gap-2 py-3">
+          <StatItem
+            value={metrics.active}
+            label="active"
+            activeClassName="text-foreground"
+          />
+          <div className="h-8 w-px bg-border/50 shrink-0" aria-hidden />
+          <StatItem
+            value={metrics.stuck}
+            label="stuck"
+            activeClassName="text-amber-500 dark:text-amber-400"
+          />
+          <div className="h-8 w-px bg-border/50 shrink-0" aria-hidden />
+          <StatItem
+            value={metrics.failed}
+            label="failed"
+            activeClassName="text-destructive"
+          />
+        </div>
+      )}
     </ChartCard>
   )
 }

--- a/apps/dashboard/src/components/charts/summary-used-by-mutations.tsx
+++ b/apps/dashboard/src/components/charts/summary-used-by-mutations.tsx
@@ -1,6 +1,7 @@
+import { Activity } from 'lucide-react'
+
 import type { ChartProps } from '@/components/charts/chart-props'
 
-import { CardMultiMetrics } from '@/components/cards/card-multi-metrics'
 import { ChartCard } from '@/components/cards/chart-card'
 import { ChartEmpty } from '@/components/charts/chart-empty'
 import { ChartError } from '@/components/charts/chart-error'
@@ -40,18 +41,30 @@ export const ChartSummaryUsedByMutations =
     }
 
     const count = dataArray[0]
+    const isIdle = count.running_count === 0
 
     return (
       <ChartCard title={title} sql={sql} data={dataArray} className={className}>
-        <div className="flex flex-col content-stretch items-center p-0">
-          <CardMultiMetrics
-            primary={
-              <span className="flex flex-row items-center gap-2 self-center text-center">
-                {count.running_count} running mutations
-              </span>
-            }
-            className="p-2"
-          />
+        <div className="flex flex-col items-center justify-center gap-2 py-3">
+          <div className="flex items-baseline gap-2">
+            <span className="text-3xl font-bold tabular-nums leading-none text-foreground">
+              {count.running_count}
+            </span>
+            <span className="text-sm text-muted-foreground">running</span>
+          </div>
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <Activity
+              className={
+                isIdle
+                  ? 'size-3.5 text-muted-foreground/50'
+                  : 'size-3.5 text-emerald-500'
+              }
+              strokeWidth={1.5}
+            />
+            <span>
+              {isIdle ? 'no active mutations' : 'mutations in progress'}
+            </span>
+          </div>
         </div>
       </ChartCard>
     )


### PR DESCRIPTION
## Summary

- **Before**: Two summary cards rendered floating rows of zeros with too much vertical whitespace and no visual weight — `0 active   0 stuck   0 failed` on one line and `0 running mutations` on another.
- **After**: Dense stat-grid layout with large `text-3xl tabular-nums` numbers, semantic colour for alarm states (amber=stuck, destructive=failed), and a calm "All clear — no stuck mutations" empty state with a check icon when all counts are zero. The Mutations Summary card shows a bold count + an Activity icon that dims when idle.

## Changes

- `summary-stuck-mutations.tsx`: extracted `StatItem` component with vertical number+label layout; added `allClear` branch with `CheckCircle2` icon; vertical dividers between stats; removed `CardMultiMetrics` wrapper that added unneeded wrapping padding.
- `summary-used-by-mutations.tsx`: replaced inline running-count text with `text-3xl` number + secondary activity indicator row; removed `CardMultiMetrics` wrapper.

**Purely presentational** — no SQL, query-config, data-fetching, or type changes. No shadcn `components/ui/` files touched.

https://claude.ai/code/session_019AsZZdTQt5BCE1rG5mhQ8R

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Dashboard mutation charts now display with improved visual clarity
* "All clear" status indicator appears when all mutation metrics are zero
* Running mutations visualization enhanced with clearer idle/active messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->