### PR TITLE
feat(sql-console): multi-query results, DB picker, tree sidebar on /sql, buttons below editor

### DIFF
--- a/apps/dashboard/src/components/explorer/hooks/use-explorer-state.ts
+++ b/apps/dashboard/src/components/explorer/hooks/use-explorer-state.ts
@@ -33,6 +33,7 @@ export interface ExplorerState {
  */
 export function useExplorerState(): ExplorerState & {
   setDatabase: (database: string | null) => void
+  setDefaultDatabase: (database: string | null) => void
   setTable: (table: string | null, engine?: string | null) => void
   setDatabaseAndTable: (
     database: string,
@@ -131,6 +132,16 @@ export function useExplorerState(): ExplorerState & {
     [updateParams]
   )
 
+  // Set the default database WITHOUT clearing the selected table. Used by the
+  // SQL console's database picker, where switching the default DB for
+  // unqualified table names should not blow away the current query context.
+  const setDefaultDatabase = useCallback(
+    (database: string | null) => {
+      updateParams({ database })
+    },
+    [updateParams]
+  )
+
   const setTable = useCallback(
     (table: string | null, engine?: string | null) => {
       updateParams({ table, engine: engine ?? null })
@@ -168,6 +179,7 @@ export function useExplorerState(): ExplorerState & {
   return {
     ...state,
     setDatabase,
+    setDefaultDatabase,
     setTable,
     setDatabaseAndTable,
     setTab,

--- a/apps/dashboard/src/components/explorer/tabs/query-tab.tsx
+++ b/apps/dashboard/src/components/explorer/tabs/query-tab.tsx
@@ -14,7 +14,8 @@ import { useHostId } from '@/lib/swr/use-host'
  */
 export function QueryTab() {
   const hostId = useHostId()
-  const { database, table, customQuery, setCustomQuery } = useExplorerState()
+  const { database, table, customQuery, setCustomQuery, setDefaultDatabase } =
+    useExplorerState()
 
   const initialSql = useMemo(() => {
     if (customQuery) return customQuery
@@ -33,12 +34,15 @@ export function QueryTab() {
 
   return (
     <SqlConsole
-      // Reset editor/runner when the table context changes.
-      key={`${hostId}:${database ?? ''}.${table ?? ''}`}
+      // Reset editor/runner when the table context changes — but NOT when only
+      // the default database changes (the picker should preserve the query).
+      key={`${hostId}:${table ?? ''}`}
       hostId={hostId}
       initialSql={initialSql}
       variant="embedded"
       onQueryCommitted={onQueryCommitted}
+      database={database ?? undefined}
+      onDatabaseChange={(db) => setDefaultDatabase(db ?? null)}
     />
   )
 }

--- a/apps/dashboard/src/components/sql-console/database-combobox.tsx
+++ b/apps/dashboard/src/components/sql-console/database-combobox.tsx
@@ -1,0 +1,120 @@
+import { Check, ChevronsUpDown, Database } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { cn } from '@/lib/utils'
+
+interface DatabasesResponse {
+  data?: { name: string }[]
+}
+
+/**
+ * Current-database picker for the SQL console.
+ *
+ * Selecting a database makes unqualified table names (`FROM events`) resolve
+ * against it — the value is forwarded to the query API and threaded into the
+ * ClickHouse client. "Default (server)" clears the override. Searchable because
+ * a cluster can have many databases.
+ */
+export function DatabaseCombobox({
+  hostId,
+  value,
+  onChange,
+}: {
+  hostId: number
+  value?: string
+  onChange: (database: string | undefined) => void
+}) {
+  const [open, setOpen] = useState(false)
+
+  const { data } = useQuery<DatabasesResponse>({
+    queryKey: [`/api/v1/explorer/databases?hostId=${hostId}`],
+    queryFn: async () => {
+      const res = await apiFetch(`/api/v1/explorer/databases?hostId=${hostId}`)
+      if (!res.ok) throw new Error(`Failed to load databases (${res.status})`)
+      return res.json()
+    },
+    staleTime: 60_000,
+  })
+
+  const databases = data?.data ?? []
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          role="combobox"
+          aria-expanded={open}
+          aria-label="Current database"
+          className="gap-1.5 font-normal"
+        >
+          <Database className="size-3.5 opacity-70" />
+          <span className="max-w-[140px] truncate">
+            {value || 'Default database'}
+          </span>
+          <ChevronsUpDown className="size-3.5 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[240px] p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search database…" className="h-9" />
+          <CommandList>
+            <CommandEmpty>No database found.</CommandEmpty>
+            <CommandGroup>
+              <CommandItem
+                value="Default server database"
+                onSelect={() => {
+                  onChange(undefined)
+                  setOpen(false)
+                }}
+              >
+                <Check
+                  className={cn(
+                    'mr-2 size-4',
+                    !value ? 'opacity-100' : 'opacity-0'
+                  )}
+                />
+                <span className="text-muted-foreground">Default (server)</span>
+              </CommandItem>
+              {databases.map((db) => (
+                <CommandItem
+                  key={db.name}
+                  value={db.name}
+                  onSelect={() => {
+                    onChange(db.name)
+                    setOpen(false)
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      'mr-2 size-4',
+                      value === db.name ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
+                  <span className="truncate">{db.name}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/dashboard/src/components/sql-console/hooks/use-sql-runner.ts
+++ b/apps/dashboard/src/components/sql-console/hooks/use-sql-runner.ts
@@ -2,6 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import type { ApiError, ApiResponse } from '@/lib/api/types'
 
+import { splitSqlStatements } from '@chm/sql-builder'
 import { useCallback, useRef, useState } from 'react'
 import { apiFetch } from '@/lib/swr/api-fetch'
 
@@ -27,15 +28,32 @@ export interface SqlRunResult {
   host: string
 }
 
+/** Outcome of a single statement within a (possibly multi-statement) run. */
+export interface StatementOutcome {
+  /** The individual statement that was executed. */
+  sql: string
+  result: SqlRunResult | null
+  error: SqlRunError | null
+}
+
+/** Upper bound on statements per run, so a giant script can't hammer the server. */
+const MAX_STATEMENTS = 20
+
 async function runSql(
   hostId: number,
   sql: string,
-  signal: AbortSignal
+  signal: AbortSignal,
+  database?: string
 ): Promise<SqlRunResult> {
   const res = await apiFetch('/api/v1/explorer/query', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ sql, hostId, format: 'JSONEachRow' }),
+    body: JSON.stringify({
+      sql,
+      hostId,
+      format: 'JSONEachRow',
+      ...(database ? { database } : {}),
+    }),
     signal,
   })
   const json = (await res.json()) as ApiResponse<RowData[]>
@@ -60,20 +78,38 @@ async function runSql(
  * Owns SQL execution state for the console.
  *
  * `editorValue` is the live, uncommitted text. `committedSql` is what was last
- * Run — it drives the Results query and the secondary tabs (EXPLAIN, Query Log,
- * Analysis). A monotonically increasing `runToken` lets "Run" re-execute the
- * same SQL (cache-busting) without changing the query key shape.
+ * Run. On run, the committed text is split into individual statements (a
+ * trailing `;` is stripped, and `;`-separated statements each run) and executed
+ * sequentially — each statement's result/error is captured independently so one
+ * failure doesn't blank the others. The secondary tabs (EXPLAIN, Query Log,
+ * Analysis) follow the currently-selected statement via `activeStatement`.
+ *
+ * A monotonically increasing `runToken` lets "Run" re-execute the same SQL
+ * (cache-busting) without changing the query key shape. `database`, when set,
+ * is the default database for unqualified table names and participates in the
+ * key so switching it re-runs against the new context.
  */
-export function useSqlRunner(hostId: number, initialSql = '') {
+export function useSqlRunner(
+  hostId: number,
+  initialSql = '',
+  database?: string
+) {
   const queryClient = useQueryClient()
   const [editorValue, setEditorValue] = useState(initialSql)
   const [committedSql, setCommittedSql] = useState<string | null>(null)
   const [runToken, setRunToken] = useState(0)
+  const [activeIndex, setActiveIndex] = useState(0)
   const abortRef = useRef<AbortController | null>(null)
 
-  const queryKey = ['sql-console:run', hostId, committedSql, runToken] as const
+  const queryKey = [
+    'sql-console:run',
+    hostId,
+    committedSql,
+    runToken,
+    database ?? '',
+  ] as const
 
-  const query = useQuery<SqlRunResult, SqlRunError>({
+  const query = useQuery<StatementOutcome[], SqlRunError>({
     queryKey,
     enabled: Boolean(committedSql),
     gcTime: 5 * 60_000,
@@ -83,7 +119,41 @@ export function useSqlRunner(hostId: number, initialSql = '') {
       abortRef.current?.abort()
       const ctrl = new AbortController()
       abortRef.current = ctrl
-      return runSql(hostId, committedSql as string, ctrl.signal)
+
+      const all = splitSqlStatements(committedSql as string)
+      const statements = all.slice(0, MAX_STATEMENTS)
+      const outcomes: StatementOutcome[] = []
+
+      for (const stmt of statements) {
+        if (ctrl.signal.aborted) break
+        try {
+          const result = await runSql(hostId, stmt, ctrl.signal, database)
+          outcomes.push({ sql: stmt, result, error: null })
+        } catch (err) {
+          // An abort isn't a per-statement failure — let React Query mark the
+          // whole run as cancelled.
+          if (ctrl.signal.aborted) throw err
+          if (err instanceof SqlRunError) {
+            outcomes.push({ sql: stmt, result: null, error: err })
+          } else {
+            throw err
+          }
+        }
+      }
+
+      // Never silently drop statements past the cap — surface it as a result.
+      if (all.length > MAX_STATEMENTS) {
+        outcomes.push({
+          sql: `/* ${all.length - MAX_STATEMENTS} more statement(s) not run */`,
+          result: null,
+          error: new SqlRunError({
+            type: 'validation_error' as ApiError['type'],
+            message: `Only the first ${MAX_STATEMENTS} statements were executed (${all.length} submitted). Run the rest separately.`,
+          }),
+        })
+      }
+
+      return outcomes
     },
   })
 
@@ -92,6 +162,7 @@ export function useSqlRunner(hostId: number, initialSql = '') {
       const sql = (sqlArg ?? editorValue).trim()
       if (!sql) return
       if (sqlArg !== undefined) setEditorValue(sqlArg)
+      setActiveIndex(0)
       // Same SQL → bump token to force a re-run; new SQL → update committedSql.
       if (sql === committedSql) {
         setRunToken((t) => t + 1)
@@ -107,15 +178,28 @@ export function useSqlRunner(hostId: number, initialSql = '') {
     queryClient.cancelQueries({ queryKey })
   }, [queryClient, queryKey])
 
+  const statements = query.data ?? []
+  // Keep the selected tab in range if the result set shrinks between runs.
+  const safeActiveIndex = activeIndex < statements.length ? activeIndex : 0
+  const activeStatement = statements[safeActiveIndex] ?? null
+
   return {
     editorValue,
     setEditorValue,
+    /** Full committed text (drives history + URL sync). */
     committedSql,
+    /** Per-statement outcomes for the last run. */
+    statements,
+    activeIndex: safeActiveIndex,
+    setActiveIndex,
+    /** The statement whose result/EXPLAIN/log/analysis is currently shown. */
+    activeStatement,
     run,
     cancel,
-    result: query.data ?? null,
-    error: query.error ?? null,
     isRunning: query.isFetching,
     hasRun: Boolean(committedSql),
+    /** Convenience accessors for the active statement. */
+    result: activeStatement?.result ?? null,
+    error: activeStatement?.error ?? query.error ?? null,
   }
 }

--- a/apps/dashboard/src/components/sql-console/sql-console.tsx
+++ b/apps/dashboard/src/components/sql-console/sql-console.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertCircle,
   CheckCircle2,
   Clock,
   History,
@@ -8,6 +9,9 @@ import {
   X,
 } from 'lucide-react'
 
+import type { StatementOutcome } from './hooks/use-sql-runner'
+
+import { DatabaseCombobox } from './database-combobox'
 import { useQueryHistory } from './hooks/use-query-history'
 import { useSqlRunner } from './hooks/use-sql-runner'
 import { QueryHistoryPanel } from './query-history-panel'
@@ -30,6 +34,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { formatSql } from '@/lib/sql-format'
+import { cn } from '@/lib/utils'
 
 // CodeMirror lives here, ALWAYS mounted and visible at the top of the console —
 // never inside the result Tabs and never hidden via display:none. That is the
@@ -49,6 +54,10 @@ export interface SqlConsoleProps {
   variant?: 'page' | 'embedded'
   /** Called when the committed query changes, e.g. to sync the URL. */
   onQueryCommitted?: (sql: string) => void
+  /** Default database for unqualified table names (`FROM table`). */
+  database?: string
+  /** When provided, renders the current-database picker next to Format. */
+  onDatabaseChange?: (database: string | undefined) => void
 }
 
 type ResultTabValue = 'results' | 'explain' | 'query-log' | 'analysis'
@@ -58,8 +67,10 @@ export function SqlConsole({
   initialSql = '',
   variant = 'page',
   onQueryCommitted,
+  database,
+  onDatabaseChange,
 }: SqlConsoleProps) {
-  const runner = useSqlRunner(hostId, initialSql)
+  const runner = useSqlRunner(hostId, initialSql, database)
   const history = useQueryHistory()
   const [tab, setTab] = useState<ResultTabValue>('results')
   const [historyOpen, setHistoryOpen] = useState(false)
@@ -68,30 +79,41 @@ export function SqlConsole({
     editorValue,
     setEditorValue,
     committedSql,
+    statements,
+    activeIndex,
+    setActiveIndex,
+    activeStatement,
     run,
     cancel,
-    result,
-    error,
     isRunning,
     hasRun,
   } = runner
 
   // Log each completed run to local history exactly once (on the running→idle
-  // transition for the current committed query).
+  // transition for the current committed query). Aggregate across statements.
   const wasRunning = useRef(false)
   useEffect(() => {
     if (wasRunning.current && !isRunning && committedSql) {
+      const ok = statements.length > 0 && statements.every((s) => !s.error)
+      const rows = statements.reduce(
+        (sum, s) => sum + (s.result?.rowCount ?? 0),
+        0
+      )
+      const durationMs = statements.reduce(
+        (sum, s) => sum + (s.result?.durationMs ?? 0),
+        0
+      )
       history.add({
         sql: committedSql,
         hostId,
-        database: null,
-        ok: !error,
-        rows: result?.rowCount,
-        durationMs: result?.durationMs,
+        database: database ?? null,
+        ok,
+        rows,
+        durationMs,
       })
     }
     wasRunning.current = isRunning
-  }, [isRunning, committedSql, error, result, hostId, history])
+  }, [isRunning, committedSql, statements, hostId, history, database])
 
   // Notify parent when the committed query changes (URL sync, etc.).
   useEffect(() => {
@@ -106,8 +128,6 @@ export function SqlConsole({
     const formatted = await formatSql(editorValue, {
       language: 'sql',
       keywordCase: 'upper',
-      // Preserve the editor's prior behavior (sql-formatter library defaults)
-      // rather than the dialog-oriented helper defaults.
       identifierCase: 'preserve',
       tabWidth: 2,
       linesBetweenQueries: 1,
@@ -121,7 +141,9 @@ export function SqlConsole({
     if (runIt) run(sql)
   }
 
-  const queryId = result?.queryId ?? null
+  // Secondary tabs (EXPLAIN / Query Log / Analysis) follow the active statement.
+  const activeSql = activeStatement?.sql ?? committedSql
+  const activeQueryId = activeStatement?.result?.queryId ?? null
 
   return (
     <div
@@ -131,9 +153,21 @@ export function SqlConsole({
           : 'flex min-h-0 flex-col gap-3'
       }
     >
-      {/* Toolbar */}
+      {/* Editor — always mounted & visible, ABOVE the action bar */}
+      <ClientOnly fallback={<Skeleton className="h-[160px] rounded-md" />}>
+        <Suspense fallback={<Skeleton className="h-[160px] rounded-md" />}>
+          <SqlEditor
+            value={editorValue}
+            onChange={setEditorValue}
+            onRun={() => handleRun()}
+            placeholder="SELECT * FROM system.tables LIMIT 100"
+          />
+        </Suspense>
+      </ClientOnly>
+
+      {/* Action bar — moved BELOW the input area */}
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <Button
             size="sm"
             onClick={() => handleRun()}
@@ -162,6 +196,13 @@ export function SqlConsole({
           >
             <Sparkles className="mr-1.5 size-3.5" /> Format
           </Button>
+          {onDatabaseChange && (
+            <DatabaseCombobox
+              hostId={hostId}
+              value={database}
+              onChange={onDatabaseChange}
+            />
+          )}
         </div>
 
         <Sheet open={historyOpen} onOpenChange={setHistoryOpen}>
@@ -192,26 +233,12 @@ export function SqlConsole({
         </Sheet>
       </div>
 
-      {/* Editor — always mounted & visible */}
-      <ClientOnly fallback={<Skeleton className="h-[160px] rounded-md" />}>
-        <Suspense fallback={<Skeleton className="h-[160px] rounded-md" />}>
-          <SqlEditor
-            value={editorValue}
-            onChange={setEditorValue}
-            onRun={() => handleRun()}
-            placeholder="SELECT * FROM system.tables LIMIT 100"
-          />
-        </Suspense>
-      </ClientOnly>
-
       {/* Status bar */}
       <StatusBar
         isRunning={isRunning}
         hasRun={hasRun}
-        rows={result?.rowCount}
-        durationMs={result?.durationMs}
-        queryId={queryId}
-        hasError={Boolean(error)}
+        statements={statements}
+        activeIndex={activeIndex}
       />
 
       {/* Result tabs — no CodeMirror inside, safe to hide/show */}
@@ -229,9 +256,10 @@ export function SqlConsole({
 
         <ScrollArea className="mt-3 min-h-0 flex-1">
           <TabsContent value="results" className="mt-0">
-            <ResultsTab
-              result={result}
-              error={error}
+            <ResultsArea
+              statements={statements}
+              activeIndex={activeIndex}
+              setActiveIndex={setActiveIndex}
               isRunning={isRunning}
               hasRun={hasRun}
             />
@@ -239,22 +267,22 @@ export function SqlConsole({
           <TabsContent value="explain" className="mt-0">
             <ExplainTab
               hostId={hostId}
-              sql={committedSql}
+              sql={activeSql}
               active={tab === 'explain'}
             />
           </TabsContent>
           <TabsContent value="query-log" className="mt-0">
             <QueryLogTab
               hostId={hostId}
-              queryId={queryId}
+              queryId={activeQueryId}
               active={tab === 'query-log'}
             />
           </TabsContent>
           <TabsContent value="analysis" className="mt-0">
             <AnalysisTab
               hostId={hostId}
-              sql={committedSql}
-              queryId={queryId}
+              sql={activeSql}
+              queryId={activeQueryId}
               active={tab === 'analysis'}
             />
           </TabsContent>
@@ -264,22 +292,106 @@ export function SqlConsole({
   )
 }
 
+/**
+ * Results area. A single statement renders one table (unchanged behavior). A
+ * multi-statement run renders one selectable result tab per statement, each
+ * with its own rows/error.
+ */
+function ResultsArea({
+  statements,
+  activeIndex,
+  setActiveIndex,
+  isRunning,
+  hasRun,
+}: {
+  statements: StatementOutcome[]
+  activeIndex: number
+  setActiveIndex: (i: number) => void
+  isRunning: boolean
+  hasRun: boolean
+}) {
+  // Not run yet, or first run still in flight → defer to ResultsTab's own
+  // empty/skeleton states.
+  if (!hasRun || statements.length === 0) {
+    return (
+      <ResultsTab
+        result={null}
+        error={null}
+        isRunning={isRunning}
+        hasRun={hasRun}
+      />
+    )
+  }
+
+  if (statements.length === 1) {
+    const only = statements[0]
+    return (
+      <ResultsTab
+        result={only.result}
+        error={only.error}
+        isRunning={isRunning}
+        hasRun={hasRun}
+      />
+    )
+  }
+
+  const active = statements[activeIndex] ?? statements[0]
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap gap-1.5">
+        {statements.map((s, i) => (
+          <button
+            key={`${i}-${s.sql.slice(0, 16)}`}
+            type="button"
+            onClick={() => setActiveIndex(i)}
+            className={cn(
+              'flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs transition-colors',
+              i === activeIndex
+                ? 'border-primary bg-primary/10 text-foreground'
+                : 'border-border text-muted-foreground hover:bg-muted'
+            )}
+          >
+            <span className="font-medium">Result {i + 1}</span>
+            {s.error ? (
+              <AlertCircle className="size-3 text-destructive" />
+            ) : (
+              <span className="opacity-70">
+                {(s.result?.rowCount ?? 0).toLocaleString()}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+      <ResultsTab
+        result={active.result}
+        error={active.error}
+        isRunning={false}
+        hasRun
+      />
+    </div>
+  )
+}
+
 function StatusBar({
   isRunning,
   hasRun,
-  rows,
-  durationMs,
-  queryId,
-  hasError,
+  statements,
+  activeIndex,
 }: {
   isRunning: boolean
   hasRun: boolean
-  rows?: number
-  durationMs?: number
-  queryId: string | null
-  hasError: boolean
+  statements: StatementOutcome[]
+  activeIndex: number
 }) {
   if (!hasRun) return null
+
+  const active = statements[activeIndex] ?? statements[0] ?? null
+  const hasError = Boolean(active?.error)
+  const rows = active?.result?.rowCount
+  const durationMs = active?.result?.durationMs
+  const queryId = active?.result?.queryId ?? null
+  const multi = statements.length > 1
+
   return (
     <div className="text-muted-foreground flex flex-wrap items-center gap-3 text-xs">
       {isRunning ? (
@@ -293,6 +405,11 @@ function StatusBar({
       ) : (
         <span className="flex items-center gap-1.5 text-emerald-600 dark:text-emerald-400">
           <CheckCircle2 className="size-3" /> Success
+        </span>
+      )}
+      {multi && (
+        <span>
+          Statement {activeIndex + 1}/{statements.length}
         </span>
       )}
       {!isRunning && !hasError && rows !== undefined && (

--- a/apps/dashboard/src/routes/(dashboard)/sql.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/sql.tsx
@@ -1,59 +1,85 @@
+import { MenuIcon } from 'lucide-react'
 import { createFileRoute } from '@tanstack/react-router'
 
-import { useCallback } from 'react'
+import { useState } from 'react'
+import { ExplorerSidebar } from '@/components/explorer/explorer-sidebar'
+import { useExplorerState } from '@/components/explorer/hooks/use-explorer-state'
 import { SqlConsole } from '@/components/sql-console'
-import { usePathname, useRouter, useSearchParams } from '@/lib/next-compat'
+import { Button } from '@/components/ui/button'
+import { useIsMobile } from '@/hooks/use-mobile'
 import { useHostId } from '@/lib/swr'
 
-/** Decode the shareable base64 `q` param into SQL (mirrors the explorer). */
-function decodeQ(q: string | null): string {
-  if (!q) return ''
-  try {
-    return decodeURIComponent(atob(q))
-  } catch {
-    return ''
-  }
-}
-
+/**
+ * Standalone SQL Console. Mirrors the Explorer's left database-tree sidebar:
+ * clicking a table seeds a query and sets the current database, so the console
+ * shares the explorer's URL-driven state (`database`, `table`, `q`).
+ */
 function SqlConsolePage() {
   const hostId = useHostId()
-  const searchParams = useSearchParams()
-  const router = useRouter()
-  const pathname = usePathname()
+  const isMobile = useIsMobile()
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const { database, table, customQuery, setCustomQuery, setDefaultDatabase } =
+    useExplorerState()
 
   const initialSql =
-    decodeQ(searchParams.get('q')) || 'SELECT * FROM system.tables LIMIT 100'
+    customQuery ||
+    (database && table
+      ? `SELECT *\nFROM \`${database}\`.\`${table}\`\nLIMIT 100`
+      : 'SELECT * FROM system.tables LIMIT 100')
 
-  // Keep the committed query in the URL (?q=) so SQL Console links are shareable.
-  const onQueryCommitted = useCallback(
-    (sql: string) => {
-      const params = new URLSearchParams(searchParams.toString())
-      params.set('q', btoa(encodeURIComponent(sql)))
-      router.replace(`${pathname}?${params.toString()}`)
-    },
-    [searchParams, router, pathname]
+  const consoleEl = (
+    <SqlConsole
+      // Reset editor/runner when the table context changes, but not on a bare
+      // default-database switch (the picker should preserve the query).
+      key={`${hostId}:${table ?? ''}`}
+      hostId={hostId}
+      initialSql={initialSql}
+      variant="page"
+      onQueryCommitted={(sql) => setCustomQuery(sql)}
+      database={database ?? undefined}
+      onDatabaseChange={(db) => setDefaultDatabase(db ?? null)}
+    />
   )
 
-  return (
-    <div className="flex h-[calc(100dvh-6rem)] flex-col gap-3 p-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-semibold">SQL Console</h1>
-          <p className="text-muted-foreground text-sm">
-            Run read-only SQL with history, EXPLAIN, query log and scan
-            analysis.
-          </p>
-        </div>
+  const header = (
+    <div className="flex items-center gap-3">
+      {isMobile && (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => setSidebarOpen(true)}
+          aria-label="Open database browser"
+        >
+          <MenuIcon className="size-4" />
+        </Button>
+      )}
+      <div>
+        <h1 className="text-xl font-semibold">SQL Console</h1>
+        <p className="text-muted-foreground text-sm">
+          Run read-only SQL with history, EXPLAIN, query log and scan analysis.
+        </p>
       </div>
-      <div className="min-h-0 flex-1">
-        <SqlConsole
-          // Remount the console when the host changes so editor/runner state resets.
-          key={hostId}
-          hostId={hostId}
-          initialSql={initialSql}
-          variant="page"
-          onQueryCommitted={onQueryCommitted}
-        />
+    </div>
+  )
+
+  if (isMobile) {
+    return (
+      <div className="flex h-[calc(100dvh-6rem)] flex-col gap-3 p-4">
+        {header}
+        <div className="min-h-0 flex-1">{consoleEl}</div>
+        <ExplorerSidebar isOpen={sidebarOpen} onOpenChange={setSidebarOpen} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-[calc(100dvh-6rem)]">
+      <div className="w-64 shrink-0 overflow-auto lg:w-72">
+        <ExplorerSidebar />
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col gap-3 p-4">
+        {header}
+        <div className="min-h-0 flex-1">{consoleEl}</div>
       </div>
     </div>
   )

--- a/apps/dashboard/src/routes/api/v1/explorer/query.ts
+++ b/apps/dashboard/src/routes/api/v1/explorer/query.ts
@@ -67,6 +67,15 @@ function getSqlVerb(sql: string): string {
   return match ? match[1].toUpperCase() : 'UNKNOWN'
 }
 
+/**
+ * Identifier-safe ClickHouse database name. The value is passed to the client
+ * config (not concatenated into SQL), but we still gate it to plain identifiers
+ * to reject anything unexpected.
+ */
+function isValidDatabaseName(db: string): boolean {
+  return /^[A-Za-z0-9_]+$/.test(db) && db.length <= 255
+}
+
 async function executeQuery(params: {
   sql: string
   hostId: number
@@ -74,8 +83,23 @@ async function executeQuery(params: {
   timezone: string | null
   method: string
   maxLength: number
+  database?: string | null
 }): Promise<Response> {
-  const { sql, hostId, format, timezone, method, maxLength } = params
+  const { sql, hostId, format, timezone, method, maxLength, database } = params
+
+  if (database && !isValidDatabaseName(database)) {
+    return Response.json(
+      {
+        success: false,
+        error: {
+          type: ApiErrorType.ValidationError,
+          message: `Invalid database name: ${database}`,
+          details: { database },
+        },
+      },
+      { status: 400 }
+    )
+  }
 
   if (!sql) {
     return Response.json(
@@ -152,6 +176,7 @@ async function executeQuery(params: {
     hostId,
     format: format as DataFormat,
     clickhouse_settings,
+    ...(database ? { database } : {}),
   })
 
   if (result.error) {
@@ -240,6 +265,7 @@ export const Route = createFileRoute('/api/v1/explorer/query')({
         const sql = searchParams.get('sql') ?? ''
         const format = searchParams.get('format') ?? 'JSONEachRow'
         const timezone = searchParams.get('timezone')
+        const database = searchParams.get('database')
 
         debug('[GET /api/v1/explorer/query]', { hostId, format, timezone })
 
@@ -249,6 +275,7 @@ export const Route = createFileRoute('/api/v1/explorer/query')({
             hostId,
             format,
             timezone,
+            database,
             method: 'GET',
             maxLength: MAX_GET_QUERY_LENGTH,
           })
@@ -303,6 +330,8 @@ export const Route = createFileRoute('/api/v1/explorer/query')({
           typeof body.format === 'string' ? body.format : 'JSONEachRow'
         const timezone =
           typeof body.timezone === 'string' ? body.timezone : null
+        const database =
+          typeof body.database === 'string' ? body.database : null
 
         if (hostIdParam === undefined || hostIdParam === null) {
           return Response.json(
@@ -339,6 +368,7 @@ export const Route = createFileRoute('/api/v1/explorer/query')({
             hostId,
             format,
             timezone,
+            database,
             method: 'POST',
             maxLength: MAX_POST_QUERY_LENGTH,
           })

--- a/packages/clickhouse-client/src/clickhouse/clickhouse-client.ts
+++ b/packages/clickhouse-client/src/clickhouse/clickhouse-client.ts
@@ -57,6 +57,9 @@ export const getClient = async ({
       url: config.host,
       username: config.user ?? 'default',
       password: config.password ?? '',
+      // Default database for unqualified table names, when the config carries
+      // one. Pooling is already scoped per-database via getPoolKey.
+      ...(config.database ? { database: config.database } : {}),
       clickhouse_settings: {
         max_execution_time:
           validateClickHouseEnv().CLICKHOUSE_MAX_EXECUTION_TIME,

--- a/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
+++ b/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
@@ -71,6 +71,7 @@ export const fetchData = async <
   clickhouse_settings,
   hostId,
   queryConfig,
+  database,
 }: QueryParams & {
   hostId: number | string
   clickhouse_settings?: QueryParams['clickhouse_settings'] & {
@@ -78,6 +79,11 @@ export const fetchData = async <
     session_timezone?: string
   }
   queryConfig?: QueryConfigLike
+  /**
+   * Optional default database for unqualified table names. Scopes a pooled
+   * client per database; omit for the server's own default.
+   */
+  database?: string
 }): Promise<FetchDataResult<T>> => {
   const start = new Date()
 
@@ -149,6 +155,14 @@ export const fetchData = async <
     }
   }
 
+  // When a default database is requested, scope the pooled client to it so
+  // unqualified table names resolve against `database`. No-op otherwise, so
+  // existing callers keep their exact pooling behavior.
+  const effectiveConfig =
+    database && database.length > 0
+      ? { ...clientConfig, database }
+      : clientConfig
+
   try {
     // Perform table validation if queryConfig is provided and query is optional
     if (queryConfig?.optional) {
@@ -192,7 +206,7 @@ export const fetchData = async <
     // works on both Node/Docker and Cloudflare Workers. The node client is
     // stubbed out of this app's bundle, so no web flag is needed here.
     const client = await getClient({
-      clientConfig,
+      clientConfig: effectiveConfig,
     })
 
     try {
@@ -314,7 +328,7 @@ export const fetchData = async <
 
       return { data, metadata }
     } finally {
-      releaseClient({ clientConfig })
+      releaseClient({ clientConfig: effectiveConfig })
     }
   } catch (originalError) {
     const errorMessage =

--- a/packages/clickhouse-client/src/clickhouse/connection-pool.ts
+++ b/packages/clickhouse-client/src/clickhouse/connection-pool.ts
@@ -46,7 +46,10 @@ function startPeriodicCleanup(): void {
  * Generate a pool key from client configuration and web flag
  */
 export function getPoolKey(config: ClickHouseConfig, web: boolean): PoolKey {
-  return `${config.host}:${config.user}:${web}`
+  const base = `${config.host}:${config.user}:${web}`
+  // Scope a distinct pooled client per default database. Keys without a
+  // database are byte-identical to before, so existing pooling is unchanged.
+  return config.database ? `${base}:db=${config.database}` : base
 }
 
 /**

--- a/packages/clickhouse-client/src/clickhouse/types.ts
+++ b/packages/clickhouse-client/src/clickhouse/types.ts
@@ -11,6 +11,13 @@ export type ClickHouseConfig = {
   user: string
   password: string
   customName?: string
+  /**
+   * Optional default database for unqualified table names (e.g. `FROM events`
+   * resolves to `<database>.events`). When set, the connection pool keys a
+   * separate client per database. Omitted for normal queries — the server's
+   * own default database applies.
+   */
+  database?: string
 }
 
 /** @deprecated Reserved for future use */


### PR DESCRIPTION
Upgrades the SQL console (used by both `/sql` and the Explorer **Query** tab).

### What changed
1. **Run / Format moved below the editor** — the action bar now sits under the input.
2. **Run multiple queries → multiple result tabs** — `;`-separated statements each
   execute (sequentially, continue-on-error) and render in their own *Result N* tab.
   EXPLAIN / Query Log / Analysis follow the selected statement.
3. **Trailing `;` auto-stripped** — `SELECT … ;` runs cleanly.
4. **Current-database picker** (searchable) next to Format — so an unqualified
   `FROM table` resolves against the chosen database. Threaded through the query
   API and the ClickHouse client (connection pool keyed per-database;
   backward-compatible — no `database` ⇒ identical pooling as before).
5. **`/sql` gets the Explorer's left database-tree sidebar** — clicking a table
   seeds the query and updates the current database (shared URL state).
6. **Works on both Cloudflare Workers and Docker** — all changes are
   runtime-agnostic; the web ClickHouse client path is unchanged.

### Implementation notes
- New `splitSqlStatements` lexer in `@chm/sql-builder` (6-state: quotes / backtick
  identifiers / line + block comments / escapes) — dependency-free, runs in
  browser/Node/Workers. 14 unit tests.
- `useSqlRunner` now returns per-statement outcomes + an active-statement index;
  single-statement behavior is unchanged.
- New `setDefaultDatabase` explorer-state setter updates the DB without clearing
  the selected table (so the picker doesn't blow away the query).

Verified: `bun run build` (incl. prerender of `/sql`) ✓, `type-check:test` ✓,
`lint` ✓, splitter tests ✓.

Co-Authored-By: duyetbot <bot@duyet.net>

https://claude.ai/code/session_019AsZZdTQt5BCE1rG5mhQ8R