### PR TITLE
refactor: dedup formatDuration + tighten data-table types

### DIFF
--- a/apps/dashboard/src/components/assistant-ui/-thread/format.ts
+++ b/apps/dashboard/src/components/assistant-ui/-thread/format.ts
@@ -1,12 +1,3 @@
-/** Format a stream duration in milliseconds as a compact human string. */
-export function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`
-  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
-  const mins = Math.floor(ms / 60_000)
-  const secs = Math.round((ms % 60_000) / 1000)
-  return `${mins}m ${secs}s`
-}
-
 /** Format a Date as absolute readable string. */
 export function formatAbsolute(date: Date): string {
   return date.toLocaleString(undefined, {

--- a/apps/dashboard/src/components/assistant-ui/-thread/message-stats.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/message-stats.tsx
@@ -18,7 +18,7 @@ import {
   WrenchIcon,
 } from 'lucide-react'
 
-import { formatAbsolute, formatDuration, formatRelative } from './format'
+import { formatAbsolute, formatRelative } from './format'
 import { useMessage, useMessageTiming } from '@assistant-ui/react'
 import { Badge } from '@/components/ui/badge'
 import {
@@ -34,6 +34,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { extractMessageUsage } from '@/lib/ai/agent/message-metadata'
+import { formatDuration } from '@/lib/utils'
 
 /**
  * Detailed stats dialog content: full token breakdown, timing, model info,

--- a/apps/dashboard/src/components/data-table/cells/hover-card-format.tsx
+++ b/apps/dashboard/src/components/data-table/cells/hover-card-format.tsx
@@ -41,11 +41,9 @@ export const HoverCardFormat = function HoverCardFormat({
   return (
     <HoverCard openDelay={0}>
       <HoverCardTrigger aria-label="Show details">
-        {normalizedValue as any}
+        {normalizedValue}
       </HoverCardTrigger>
-      <HoverCardContent role="tooltip">
-        {processedContent as any}
-      </HoverCardContent>
+      <HoverCardContent role="tooltip">{processedContent}</HoverCardContent>
     </HoverCard>
   )
 }

--- a/apps/dashboard/src/components/data-table/renderers/table-header.tsx
+++ b/apps/dashboard/src/components/data-table/renderers/table-header.tsx
@@ -345,9 +345,7 @@ export const TableHeaderRow = function TableHeaderRow({
  * Props for TableHeader component
  */
 export interface TableHeaderProps {
-  // HeaderGroup<any> matches this file's existing Header<any, unknown> convention
-  // and accepts the caller's generic HeaderGroup<TData>[] from table.getHeaderGroups().
-  headerGroups: HeaderGroup<any>[]
+  headerGroups: HeaderGroup<unknown>[]
   /** Callback when double-clicking column resizer to auto-fit */
   onAutoFit?: (columnId: string) => void
   /** Enable column reordering with drag-and-drop */

--- a/apps/dashboard/src/components/filters/quick-filters.tsx
+++ b/apps/dashboard/src/components/filters/quick-filters.tsx
@@ -26,7 +26,6 @@ interface QuickFiltersProps {
  * Renders quick filter controls based on their display type.
  * - segmented: Row of pill buttons for selecting from options
  * - select: Dropdown for selecting from options
- * - radio: Radio buttons (future)
  */
 export function QuickFilters({
   configs,
@@ -111,10 +110,6 @@ export function QuickFilters({
               </div>
             )
           }
-
-          case 'radio':
-            // TODO: Implement radio button control
-            return null
 
           default:
             return null

--- a/apps/dashboard/src/components/layout/query-page/chart-format.ts
+++ b/apps/dashboard/src/components/layout/query-page/chart-format.ts
@@ -1,4 +1,5 @@
 import { formatReadableSize } from '@/lib/format-readable'
+import { formatDuration } from '@/lib/utils'
 
 export type ChartValueUnit = 'count' | 'bytes' | 'ms' | 'seconds' | 'percent'
 
@@ -8,19 +9,6 @@ export function formatCompact(n: number): string {
   if (Math.abs(n) >= 1_000) return `${(n / 1_000).toFixed(1)}K`
   if (Number.isInteger(n)) return n.toLocaleString()
   return n.toFixed(2)
-}
-
-/** Render a millisecond value with a sensible ms / s / m unit. */
-function formatDuration(ms: number): string {
-  const sign = ms < 0 ? '-' : ''
-  const abs = Math.abs(ms)
-  if (abs < 1000) {
-    return `${sign}${abs < 10 ? abs.toFixed(2) : Math.round(abs).toLocaleString()} ms`
-  }
-  const s = abs / 1000
-  if (s < 60) return `${sign}${s.toFixed(2)} s`
-  const m = Math.floor(s / 60)
-  return `${sign}${m}m ${Math.round(s % 60)}s`
 }
 
 export function formatChartValue(value: number, unit?: ChartValueUnit): string {

--- a/apps/dashboard/src/components/peerdb/partition-table.tsx
+++ b/apps/dashboard/src/components/peerdb/partition-table.tsx
@@ -1,11 +1,6 @@
 import type { QRepPartition } from '@/lib/peerdb/types'
 
-import {
-  durationMs,
-  formatDateTime,
-  formatDuration,
-  toNumber,
-} from './peerdb-utils'
+import { durationMs, formatDateTime, toNumber } from './peerdb-utils'
 import {
   Table,
   TableBody,
@@ -15,6 +10,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { formatReadableQuantity } from '@/lib/format-readable'
+import { formatDuration } from '@/lib/utils'
 
 interface PartitionTableProps {
   partitions: QRepPartition[]
@@ -50,6 +46,7 @@ export function PartitionTable({ partitions }: PartitionTableProps) {
         <TableBody>
           {partitions.map((p, index) => {
             const end = p.endTime ?? p.pullEndTime
+            const duration = durationMs(p.startTime, end)
             const rowsIn = toNumber(p.rowsInPartition ?? p.numRows)
             const rowsSynced = toNumber(p.rowsSynced)
             return (
@@ -58,7 +55,7 @@ export function PartitionTable({ partitions }: PartitionTableProps) {
                   {p.partitionId ?? '—'}
                 </TableCell>
                 <TableCell className="text-right tabular-nums">
-                  {formatDuration(durationMs(p.startTime, end))}
+                  {duration === null ? '—' : formatDuration(duration)}
                 </TableCell>
                 <TableCell className="text-xs">
                   {formatDateTime(p.startTime)}

--- a/apps/dashboard/src/components/peerdb/peerdb-utils.ts
+++ b/apps/dashboard/src/components/peerdb/peerdb-utils.ts
@@ -94,19 +94,6 @@ export function durationMs(start?: string, end?: string): number | null {
   return Math.max(0, e - s)
 }
 
-/** Compact human duration: "1.2s", "3m 4s", "1h 2m". */
-export function formatDuration(ms: number | null): string {
-  if (ms === null) return '—'
-  if (ms < 1000) return `${ms}ms`
-  const totalSeconds = Math.round(ms / 1000)
-  if (totalSeconds < 60) return `${(ms / 1000).toFixed(1)}s`
-  const minutes = Math.floor(totalSeconds / 60)
-  const seconds = totalSeconds % 60
-  if (minutes < 60) return `${minutes}m ${seconds}s`
-  const hours = Math.floor(minutes / 60)
-  return `${hours}h ${minutes % 60}m`
-}
-
 export function toNumber(value: unknown): number {
   const n = typeof value === 'string' ? Number(value) : (value as number)
   return Number.isFinite(n) ? n : 0

--- a/apps/dashboard/src/lib/filters/types.ts
+++ b/apps/dashboard/src/lib/filters/types.ts
@@ -101,7 +101,7 @@ export interface FilterPreset {
 }
 
 /** Quick filter display type. */
-export type QuickFilterDisplay = 'segmented' | 'select' | 'radio'
+export type QuickFilterDisplay = 'segmented' | 'select'
 
 /**
  * Quick filter: always-visible inline control for high-value filters.
@@ -115,7 +115,7 @@ export interface QuickFilterConfig {
   /** Override label (defaults to field.label). */
   label?: string
   /**
-   * For segmented/radio: options to show.
+   * For segmented: options to show.
    * Defaults to field.options (for select-type fields) or needs explicit options.
    */
   options?: { label: string; value: string }[]

--- a/apps/dashboard/src/lib/query-config/declarative/schema.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/schema.test.ts
@@ -99,6 +99,35 @@ describe('full-featured valid config', () => {
     expect(result.ok).toBe(true)
   })
 
+  test('accepts typed link and code-dialog column format args', () => {
+    const result = validateDeclarativeConfig({
+      name: 'query-detail',
+      sql: 'SELECT query_id, query FROM system.query_log',
+      columns: ['query_id', 'query'],
+      columnFormats: {
+        query_id: [
+          'link',
+          {
+            href: '/query?query_id=[query_id]',
+            title: 'Open query',
+            'data-testid': 'query-link',
+          },
+        ],
+        query: [
+          'code-dialog',
+          {
+            dialog_title: 'Query',
+            max_truncate: 200,
+            hide_query_comment: true,
+            show_query_plan: false,
+          },
+        ],
+      },
+    })
+
+    expect(result.ok).toBe(true)
+  })
+
   test('accepts tableCheck as string array', () => {
     const result = validateDeclarativeConfig({
       name: 'backup-log',
@@ -400,6 +429,43 @@ describe('invalid configs', () => {
     expect(result.ok).toBe(false)
     if (result.ok) return
     expect(result.errors.length).toBeGreaterThan(0)
+  })
+
+  test('rejects malformed link and code-dialog column format args', () => {
+    const linkResult = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: 'SELECT query_id FROM system.query_log',
+      columns: ['query_id'],
+      columnFormats: {
+        query_id: ['link', { href: 42 }],
+      },
+    })
+
+    expect(linkResult.ok).toBe(false)
+
+    const codeDialogResult = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: 'SELECT query FROM system.query_log',
+      columns: ['query'],
+      columnFormats: {
+        query: ['code-dialog', { max_truncate: '200' }],
+      },
+    })
+
+    expect(codeDialogResult.ok).toBe(false)
+  })
+
+  test('rejects array args for typed object column formats', () => {
+    const result = validateDeclarativeConfig({
+      name: 'my-query',
+      sql: 'SELECT query_id FROM system.query_log',
+      columns: ['query_id'],
+      columnFormats: {
+        query_id: ['link', ['not-an-object']],
+      },
+    })
+
+    expect(result.ok).toBe(false)
   })
 
   test('rejects non-object input', () => {

--- a/apps/dashboard/src/lib/query-config/declarative/schema.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/schema.ts
@@ -98,17 +98,73 @@ const columnFormatEnumSchema = z.enum(columnFormatValues)
 // For formats whose options are complex or component-coupled (RunningQuerySummary,
 // HoverCard), we accept a permissive record so contributors can still pass args;
 // the loader validates further at runtime.
-// TODO: tighten Action[], CodeDialogOptions, LinkFormatOptions shapes once
-//       those types are fully stable and independently importable.
 // ---------------------------------------------------------------------------
 
-const columnFormatArgsSchema = z.record(z.string(), z.unknown())
+const looseColumnFormatArgsSchema = z.record(z.string(), z.unknown())
+
+const linkFormatArgsSchema = z
+  .object({
+    href: z.string().optional(),
+    className: z.string().optional(),
+    title: z.string().optional(),
+  })
+  .passthrough()
+
+const codeDialogFormatArgsSchema = z.object({
+  dialog_title: z.string().optional(),
+  dialog_description: z.string().optional(),
+  trigger_classname: z.string().optional(),
+  max_truncate: z.number().optional(),
+  hide_query_comment: z.boolean().optional(),
+  json: z.boolean().optional(),
+  dialog_classname: z.string().optional(),
+  show_explorer_link: z.boolean().optional(),
+  force_dialog: z.boolean().optional(),
+  show_query_plan: z.boolean().optional(),
+})
+
+const columnFormatArgsByFormat = {
+  link: linkFormatArgsSchema,
+  'code-dialog': codeDialogFormatArgsSchema,
+} satisfies Partial<
+  Record<(typeof columnFormatValues)[number], z.ZodType<unknown>>
+>
+
+const columnFormatTupleWithArgsSchema = z
+  .tuple([columnFormatEnumSchema, looseColumnFormatArgsSchema])
+  .superRefine(([format, args], ctx) => {
+    const schema =
+      columnFormatArgsByFormat[format as keyof typeof columnFormatArgsByFormat]
+    if (!schema) return
+
+    const result = schema.safeParse(args)
+    if (result.success) return
+
+    for (const issue of result.error.issues) {
+      ctx.addIssue({
+        ...issue,
+        path: [1, ...issue.path],
+      })
+    }
+  })
+
+const columnFormatTupleWithArrayArgsSchema = z
+  .tuple([columnFormatEnumSchema, z.array(z.unknown())])
+  .superRefine(([format], ctx) => {
+    if (format !== 'link' && format !== 'code-dialog') return
+
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [1],
+      message: `${format} column format args must be an object`,
+    })
+  })
 
 // A column format is either a bare enum string, or a [enum, args] tuple.
 const columnFormatSpecSchema = z.union([
   columnFormatEnumSchema,
-  z.tuple([columnFormatEnumSchema, columnFormatArgsSchema]),
-  z.tuple([columnFormatEnumSchema, z.array(z.unknown())]),
+  columnFormatTupleWithArgsSchema,
+  columnFormatTupleWithArrayArgsSchema,
 ])
 
 // ---------------------------------------------------------------------------

--- a/apps/dashboard/src/lib/utils.test.ts
+++ b/apps/dashboard/src/lib/utils.test.ts
@@ -104,9 +104,9 @@ describe('formatCount', () => {
 })
 
 describe('formatDuration', () => {
-  test('invalid / negative collapse to dash', () => {
-    expect(formatDuration(-5)).toBe('-')
+  test('invalid values collapse to dash', () => {
     expect(formatDuration(Number.NaN)).toBe('-')
+    expect(formatDuration(Number.POSITIVE_INFINITY)).toBe('-')
   })
 
   test('chooses ms / s / m / h by magnitude', () => {
@@ -114,6 +114,13 @@ describe('formatDuration', () => {
     expect(formatDuration(1500)).toBe('1.5s')
     expect(formatDuration(90_000)).toBe('1.5m')
     expect(formatDuration(5_400_000)).toBe('1.5h')
+  })
+
+  test('preserves negative sign while formatting by absolute magnitude', () => {
+    expect(formatDuration(-5)).toBe('-5ms')
+    expect(formatDuration(-1500)).toBe('-1.5s')
+    expect(formatDuration(-90_000)).toBe('-1.5m')
+    expect(formatDuration(-5_400_000)).toBe('-1.5h')
   })
 })
 

--- a/apps/dashboard/src/lib/utils.ts
+++ b/apps/dashboard/src/lib/utils.ts
@@ -51,11 +51,12 @@ export function formatCount(count: number): string {
 
 export function formatDuration(ms: number): string {
   if (!Number.isFinite(ms) || Number.isNaN(ms)) return '-'
-  if (ms < 0) return '-'
-  if (ms < 1000) return `${Number(ms.toFixed(2))}ms`
-  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
-  if (ms < 3600000) return `${(ms / 60000).toFixed(1)}m`
-  return `${(ms / 3600000).toFixed(1)}h`
+  const sign = ms < 0 ? '-' : ''
+  const abs = Math.abs(ms)
+  if (abs < 1000) return `${sign}${Number(abs.toFixed(2))}ms`
+  if (abs < 60000) return `${sign}${(abs / 1000).toFixed(1)}s`
+  if (abs < 3600000) return `${sign}${(abs / 60000).toFixed(1)}m`
+  return `${sign}${(abs / 3600000).toFixed(1)}h`
 }
 
 export const chartTickFormatters = {

--- a/apps/dashboard/src/routes/api/v1/actions.ts
+++ b/apps/dashboard/src/routes/api/v1/actions.ts
@@ -77,7 +77,7 @@ async function handleKillQuery(
   queryId: string
 ): Promise<ActionResult> {
   const { error } = await fetchData({
-    query: `KILL QUERY WHERE query_id = {queryId: String}`,
+    query: `KILL QUERY WHERE query_id = {queryId:String}`,
     query_params: { queryId },
     hostId,
   })
@@ -138,7 +138,7 @@ async function handleQuerySettings(
   queryId: string
 ): Promise<ActionResult> {
   const { data, error } = await fetchData<{ Settings: string }[]>({
-    query: `SELECT Settings FROM system.processes WHERE query_id = {queryId: String}`,
+    query: `SELECT Settings FROM system.processes WHERE query_id = {queryId:String}`,
     query_params: { queryId },
     hostId,
   })


### PR DESCRIPTION
## Summary

This addresses the still-open items in the tech-debt tracker #1776. Items 2 and 4 already landed in PRs #1807 and #1791, so this PR covers the remainder: the duplicate `formatDuration` consolidation, the `any` types in the data-table surface, the silent `radio` quick-filter, the over-permissive declarative-config args schema, and the small `actions.ts` whitespace normalization the maintainer added in a follow-up.

The `formatDuration(ms)` work folds `chart-format.ts`'s negative-sign handling into the canonical implementation in `lib/utils.ts` (which already guards NaN/Infinity), then deletes the three divergent copies and re-imports the canonical one so every component renders a duration the same way. PeerDB's previous behaviour of showing `—` for a `null` duration is kept at the call site, since the canonical helper takes a non-null number. The differently-signatured helpers the issue marked out of scope (`format-duration.ts`, `formatDurationMs`, `formatDurationSeconds`) are left untouched.

For the data-table types, `TableHeaderProps.headerGroups` becomes `HeaderGroup<unknown>[]`, and the two `as any` casts in the hover-card cell are removed because the values are already `React.ReactNode` and the type-check is green without them. The `radio` quick-filter is removed from the `QuickFilterDisplay` union along with its dead switch branch, so a config can no longer reference a variant that renders nothing with no error.

The declarative-config schema previously accepted any args bag via a blanket record. This tightens the `link` and `code-dialog` formats to real Zod object schemas mirroring their `LinkFormatOptions` / `CodeDialogOptions` shapes, validated through a `superRefine` on the `[format, args]` tuple. The schemas are defined inline to avoid a component import cycle, and every other format keeps the permissive record, so configs that validated before still validate. The intent is that a malformed `link` or `code-dialog` args bag now fails at load-time Zod validation rather than surfacing later in the loader.

## Why this matters

These are the source-verified P3 cleanups you filed in #1776, each independent and low-risk. The `formatDuration` consolidation removes a real inconsistency where the same value rendered differently depending on which component displayed it. The type and schema changes move failures to the type / Zod boundary instead of letting malformed configs render nothing or fail at runtime, which is the behaviour the issue asks for in items 5 and 6.

## Testing

`bun run type-check` passes, including after dropping the `as any` casts. The touched unit suites (`lib/utils.test.ts` and `lib/query-config/declarative/schema.test.ts`) pass, with added cases for negative-sign formatting and for the tightened `link` / `code-dialog` args validation. `bun run build` for `apps/dashboard` passes, and `biome check` is clean on the touched files.

Refs #1776


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed negative duration formatting to display with sign (e.g., `-1.5s`) instead of a dash.

* **Refactor**
  * Centralized duration formatting utility across components.
  * Removed unsupported radio display option from quick filters.

* **Improvements**
  * Enhanced validation for column format configurations (link and code-dialog).
  * Improved null handling for duration displays in tables.
  * Strengthened type safety by removing unnecessary type casts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->