### PR TITLE
fix(sql-builder): only strip trailing FORMAT for known ClickHouse formats

### DIFF
--- a/packages/sql-builder/src/__tests__/split-statements.test.ts
+++ b/packages/sql-builder/src/__tests__/split-statements.test.ts
@@ -155,6 +155,38 @@ describe('stripTrailingFormat', () => {
     )
   })
 
+  it('does not strip a trailing `format` identifier followed by a keyword/alias', () => {
+    // `format` is a column here, not a FORMAT clause: DESC / f / ASC are not
+    // ClickHouse format names, so the tail must be preserved.
+    expect(stripTrailingFormat('SELECT * FROM t ORDER BY format DESC')).toBe(
+      'SELECT * FROM t ORDER BY format DESC'
+    )
+    expect(stripTrailingFormat('SELECT * FROM t ORDER BY format ASC')).toBe(
+      'SELECT * FROM t ORDER BY format ASC'
+    )
+    expect(stripTrailingFormat('SELECT format AS f')).toBe('SELECT format AS f')
+    expect(stripTrailingFormat('SELECT format f FROM t')).toBe(
+      'SELECT format f FROM t'
+    )
+  })
+
+  it('strips a variety of recognized ClickHouse formats', () => {
+    expect(stripTrailingFormat('SELECT 1 FORMAT CSV')).toBe('SELECT 1')
+    expect(stripTrailingFormat('SELECT 1 FORMAT Vertical')).toBe('SELECT 1')
+    expect(stripTrailingFormat('SELECT 1 FORMAT PrettyCompact')).toBe(
+      'SELECT 1'
+    )
+    expect(stripTrailingFormat('SELECT 1 FORMAT RowBinary')).toBe('SELECT 1')
+  })
+
+  it('does not strip an unrecognized FORMAT name', () => {
+    // Guard against truncating valid SQL whose trailing token only looks like a
+    // FORMAT clause; only known formats are removed.
+    expect(stripTrailingFormat('SELECT 1 FORMAT NotARealFormat')).toBe(
+      'SELECT 1 FORMAT NotARealFormat'
+    )
+  })
+
   it('handles a realistic copied console query', () => {
     expect(
       stripTrailingFormat(

--- a/packages/sql-builder/src/split-statements.ts
+++ b/packages/sql-builder/src/split-statements.ts
@@ -115,6 +115,107 @@ export function splitSqlStatements(sql: string): string[] {
 }
 
 /**
+ * Known ClickHouse output formats accepted by a trailing `FORMAT <name>` clause.
+ *
+ * A trailing `FORMAT <name>` is only stripped when `<name>` is one of these, so
+ * an identifier or alias that happens to follow a column named `format` — e.g.
+ * `ORDER BY format DESC` or `SELECT format AS f` — is never mistaken for a
+ * FORMAT clause and truncated. Names are matched case-sensitively because
+ * ClickHouse format names are themselves case-sensitive.
+ *
+ * @see https://clickhouse.com/docs/interfaces/formats
+ */
+const CLICKHOUSE_FORMATS = new Set<string>([
+  'TabSeparated',
+  'TabSeparatedRaw',
+  'TabSeparatedWithNames',
+  'TabSeparatedWithNamesAndTypes',
+  'TabSeparatedRawWithNames',
+  'TabSeparatedRawWithNamesAndTypes',
+  'TSV',
+  'TSVRaw',
+  'TSVWithNames',
+  'TSVWithNamesAndTypes',
+  'TSVRawWithNames',
+  'TSVRawWithNamesAndTypes',
+  'Template',
+  'TemplateIgnoreSpaces',
+  'CSV',
+  'CSVWithNames',
+  'CSVWithNamesAndTypes',
+  'CustomSeparated',
+  'CustomSeparatedWithNames',
+  'CustomSeparatedWithNamesAndTypes',
+  'SQLInsert',
+  'Values',
+  'Vertical',
+  'JSON',
+  'JSONAsString',
+  'JSONAsObject',
+  'JSONStrings',
+  'JSONColumns',
+  'JSONColumnsWithMetadata',
+  'JSONCompact',
+  'JSONCompactStrings',
+  'JSONCompactColumns',
+  'JSONEachRow',
+  'PrettyJSONEachRow',
+  'JSONEachRowWithProgress',
+  'JSONStringsEachRow',
+  'JSONStringsEachRowWithProgress',
+  'JSONCompactEachRow',
+  'JSONCompactEachRowWithNames',
+  'JSONCompactEachRowWithNamesAndTypes',
+  'JSONCompactStringsEachRow',
+  'JSONCompactStringsEachRowWithNames',
+  'JSONCompactStringsEachRowWithNamesAndTypes',
+  'JSONObjectEachRow',
+  'BSONEachRow',
+  'TSKV',
+  'Pretty',
+  'PrettyNoEscapes',
+  'PrettyMonoBlock',
+  'PrettyNoEscapesMonoBlock',
+  'PrettyCompact',
+  'PrettyCompactNoEscapes',
+  'PrettyCompactMonoBlock',
+  'PrettyCompactNoEscapesMonoBlock',
+  'PrettySpace',
+  'PrettySpaceNoEscapes',
+  'PrettySpaceMonoBlock',
+  'PrettySpaceNoEscapesMonoBlock',
+  'Prometheus',
+  'Protobuf',
+  'ProtobufSingle',
+  'ProtobufList',
+  'Avro',
+  'AvroConfluent',
+  'Parquet',
+  'ParquetMetadata',
+  'Arrow',
+  'ArrowStream',
+  'ORC',
+  'One',
+  'Npy',
+  'RowBinary',
+  'RowBinaryWithNames',
+  'RowBinaryWithNamesAndTypes',
+  'RowBinaryWithDefaults',
+  'Native',
+  'Null',
+  'XML',
+  'CapnProto',
+  'LineAsString',
+  'Regexp',
+  'RawBLOB',
+  'MsgPack',
+  'MySQLDump',
+  'DWARF',
+  'Markdown',
+  'Form',
+])
+
+/**
  * Strip a trailing ClickHouse `FORMAT <name>` clause and any trailing
  * semicolons from a single SQL statement.
  *
@@ -124,14 +225,16 @@ export function splitSqlStatements(sql: string): string[] {
  * safely embedded after `EXPLAIN ...` (e.g. when a query was copied straight
  * from the SQL console with `FORMAT JSONEachRow` still attached).
  *
- * Only a *trailing* FORMAT clause is removed (the one legal position for it in
- * ClickHouse). Occurrences elsewhere — the `formatDateTime` function, a column
- * aliased `format`, or a string literal containing "FORMAT" — are left intact.
+ * Only a *trailing* clause whose name is a recognized ClickHouse format is
+ * removed. This avoids truncating valid SQL where `format` is used as an
+ * identifier — `formatDateTime(...)`, `AS format`, `ORDER BY format DESC`,
+ * `SELECT format AS f` — since `DESC` / `f` / `FROM` are not format names.
  *
- * - `SELECT 1 FORMAT JSONEachRow`  → `SELECT 1`
- * - `SELECT 1 FORMAT JSONEachRow;` → `SELECT 1`
- * - `SELECT 1;`                    → `SELECT 1`
- * - `SELECT formatDateTime(now())` → `SELECT formatDateTime(now())`
+ * - `SELECT 1 FORMAT JSONEachRow`        → `SELECT 1`
+ * - `SELECT 1 FORMAT JSONEachRow;`       → `SELECT 1`
+ * - `SELECT 1;`                          → `SELECT 1`
+ * - `SELECT formatDateTime(now())`       → `SELECT formatDateTime(now())`
+ * - `SELECT * FROM t ORDER BY format DESC` → unchanged
  *
  * @param sql - A single SQL statement
  * @returns The statement without a trailing FORMAT clause or semicolons
@@ -142,8 +245,12 @@ export function stripTrailingFormat(sql: string): string {
     .trim()
     .replace(/;+\s*$/, '')
     .trimEnd()
-  // Remove a trailing `FORMAT <Identifier>` clause.
-  out = out.replace(/\s+FORMAT\s+[A-Za-z0-9_]+\s*$/i, '')
+  // Remove a trailing `FORMAT <name>` clause, but only when <name> is an actual
+  // ClickHouse format — never an identifier/alias that follows a `format` column.
+  const match = out.match(/\s+FORMAT\s+([A-Za-z0-9_]+)\s*$/i)
+  if (match && match.index !== undefined && CLICKHOUSE_FORMATS.has(match[1])) {
+    out = out.slice(0, match.index).trimEnd()
+  }
   // Strip again in case removing the FORMAT clause exposed another `;`.
   return out.replace(/;+\s*$/, '').trim()
 }


### PR DESCRIPTION
## Summary

Follow-up to #1826. Fixes a correctness bug in `stripTrailingFormat` (flagged by Gemini on that PR).

The previous implementation removed **any** trailing `… FORMAT <word>` pattern, which truncated valid SQL where `format` is used as an identifier:

- `SELECT * FROM t ORDER BY format DESC` → wrongly became `SELECT * FROM t ORDER BY`
- `SELECT format AS f` → wrongly became `SELECT format`

## Fix

Strip the trailing `FORMAT <name>` clause **only when `<name>` is a recognized ClickHouse output format** (a known-format allowlist, matched case-sensitively as ClickHouse does). So `DESC`, `ASC`, `FROM`, an alias, etc. are never mistaken for a FORMAT clause.

I chose an allowlist over a SQL-keyword denylist (Gemini's suggested approach) because a denylist can't anticipate every collision — `NULLS`/`FIRST`/`LAST`, function names, or arbitrary aliases would still slip through. The allowlist is closed: only real formats are ever removed.

Trade-off: an *unrecognized* format name (rare/uncommon format on the Explain page) is left in place rather than stripped — strictly safer than truncating valid SQL.

## Tests

Added regression cases (incl. the ones Gemini suggested):
- `ORDER BY format DESC` / `ASC`, `SELECT format AS f`, `SELECT format f FROM t` — left intact
- A variety of real formats (CSV, Vertical, PrettyCompact, RowBinary) — stripped
- An unrecognized `FORMAT NotARealFormat` — left intact

`bun run lint` clean · `bun test packages/sql-builder` 523/523 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016A7FNnUXnFH9a5doJPmhy6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL statement normalization to accurately handle trailing FORMAT clauses, ensuring only recognized ClickHouse output formats are removed while preserving FORMAT when used as identifiers or in other contexts.

* **Tests**
  * Extended test coverage for FORMAT clause handling in SQL statement processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->