### PR TITLE
fix(api): gate /api/health metadata on genuine auth, not public-read

### DIFF
--- a/apps/dashboard/scripts/verify-deploy.ts
+++ b/apps/dashboard/scripts/verify-deploy.ts
@@ -5,7 +5,9 @@
  * Runs two scenarios against a LIVE deployment:
  *
  *  UNAUTHENTICATED (always)
- *   1. GET /api/health           -> 200 + reports git sha / auth provider / build ts
+ *   1. GET /api/health (no token) -> 200 minimal liveness; deployment metadata
+ *      MUST be hidden from anonymous callers (#1768 — git sha / auth provider /
+ *      key prefix are security posture, not public).
  *   2. GET / and /overview?host=0 -> 200, HTML references the client entry bundle
  *   3. client entry bundle        -> contains the Clerk pk_ key when authProvider=clerk
  *      (guards the NEXT_PUBLIC_* -> VITE_* regression: a broken build ships NO key)
@@ -13,7 +15,9 @@
  *
  *  AUTHENTICATED (when CHM_API_KEY_SECRET is set)
  *   5. POST /api/v1/auth/api-key (Bearer secret) -> mints a chm_ token
- *   6. GET /api/v1/menu-counts?hostId=H (Bearer token) -> 200 success:true with live
+ *   6. GET /api/health (Bearer token) -> 200 + deployment metadata (git sha /
+ *      auth provider / build ts) is returned to authenticated callers
+ *   7. GET /api/v1/menu-counts?hostId=H (Bearer token) -> 200 success:true with live
  *      ClickHouse system-table counts === the worker reaches + queries ClickHouse
  *
  * Run:
@@ -90,30 +94,71 @@ async function http(
   return { status: res.status, text, json }
 }
 
+// ── Shared deployment probe ───────────────────────────────────────────────
+
+// `/api/health` hides deployment metadata from anonymous callers (#1768), so we
+// learn the deployed auth provider (for the Clerk-bundle regression check) by
+// minting a token up front and reading the AUTHENTICATED health response.
+// Without a secret (local --skip-auth runs), clerkExpected stays false and the
+// bundle check softens to informational — CI always provides the secret, so the
+// gate stays strict there.
+let clerkExpected = false
+let deployment: Record<string, unknown> | null = null
+let mintedToken = ''
+let mintStatus = 0
+
+async function probeDeployment() {
+  if (SKIP_AUTH || !SECRET) return
+  try {
+    const mint = await http('/api/v1/auth/api-key', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${SECRET}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ label: 'verify-deploy', days: 1 }),
+    })
+    mintStatus = mint.status
+    mintedToken =
+      (mint.json as { data?: { apiKey?: string } })?.data?.apiKey ?? ''
+    if (!mintedToken) return
+    const health = await http('/api/health', {
+      headers: { Authorization: `Bearer ${mintedToken}` },
+    })
+    deployment =
+      (health.json as { deployment?: Record<string, unknown> })?.deployment ??
+      null
+    clerkExpected =
+      deployment?.authProvider === 'clerk' ||
+      deployment?.clientAuthProvider === 'clerk'
+  } catch {
+    /* leave defaults; downstream checks soften */
+  }
+}
+
 // ── Unauthenticated scenario ──────────────────────────────────────────────
 
-let clerkExpected = false
-
 async function runUnauthenticated() {
-  // 1. health
+  // 1. health — anonymous callers get minimal liveness, NO deployment metadata.
   try {
     const { status, json } = await http('/api/health')
-    const d = (json as { deployment?: Record<string, unknown> })?.deployment
-    clerkExpected =
-      d?.authProvider === 'clerk' || d?.clientAuthProvider === 'clerk'
+    const body = json as { status?: string; deployment?: unknown }
+    const leaked = body?.deployment !== undefined
     record({
       scenario: 'unauthenticated',
-      name: 'GET /api/health',
-      ok: status === 200 && !!d,
+      name: 'GET /api/health (anonymous, no metadata leak)',
+      ok: status === 200 && body?.status === 'ok' && !leaked,
       detail:
-        status === 200 && d
-          ? `runtime=${d.runtime} authProvider=${d.authProvider} clientAuthProvider=${d.clientAuthProvider} sha=${String(d.gitSha).slice(0, 7)} clerkKey=${d.clerkPublishableKeyPrefix ?? 'none'}`
-          : `HTTP ${status}`,
+        status !== 200
+          ? `HTTP ${status}`
+          : leaked
+            ? 'LEAK — deployment metadata exposed to anonymous caller (#1768)'
+            : 'ok — minimal liveness; deployment metadata hidden from anonymous',
     })
   } catch (e) {
     record({
       scenario: 'unauthenticated',
-      name: 'GET /api/health',
+      name: 'GET /api/health (anonymous, no metadata leak)',
       ok: false,
       detail: String(e),
     })
@@ -212,38 +257,32 @@ async function runAuthenticated() {
     return
   }
 
-  // 5. mint a chm_ token
-  let token = ''
-  try {
-    const { status, json } = await http('/api/v1/auth/api-key', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${SECRET}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ label: 'verify-deploy', days: 1 }),
-    })
-    token = (json as { data?: { apiKey?: string } })?.data?.apiKey ?? ''
-    record({
-      scenario: 'authenticated',
-      name: 'POST /api/v1/auth/api-key (mint token)',
-      ok: status === 200 && token.startsWith('chm_'),
-      detail:
-        status === 200 && token
-          ? `minted ${token.slice(0, 10)}… (len=${token.length})`
-          : `HTTP ${status} ${(json as { error?: string })?.error ?? ''}`,
-    })
-  } catch (e) {
-    record({
-      scenario: 'authenticated',
-      name: 'mint token',
-      ok: false,
-      detail: String(e),
-    })
-  }
+  // 5. token mint (performed in probeDeployment so the authenticated health
+  //    read below can run; record the outcome here).
+  record({
+    scenario: 'authenticated',
+    name: 'POST /api/v1/auth/api-key (mint token)',
+    ok: mintStatus === 200 && mintedToken.startsWith('chm_'),
+    detail:
+      mintStatus === 200 && mintedToken
+        ? `minted ${mintedToken.slice(0, 10)}… (len=${mintedToken.length})`
+        : `HTTP ${mintStatus}`,
+  })
+  const token = mintedToken
   if (!token) return
 
-  // 6. real CH query per host via the registry endpoint
+  // 6. authenticated callers DO receive deployment metadata (the other half of
+  //    the #1768 contract: hidden from anonymous, visible once authenticated).
+  record({
+    scenario: 'authenticated',
+    name: 'GET /api/health (authenticated) returns metadata',
+    ok: !!deployment,
+    detail: deployment
+      ? `runtime=${deployment.runtime} authProvider=${deployment.authProvider} sha=${String(deployment.gitSha).slice(0, 7)} clerkKey=${deployment.clerkPublishableKeyPrefix ?? 'none'}`
+      : 'no deployment block returned to authenticated caller',
+  })
+
+  // 7. real CH query per host via the registry endpoint
   for (const h of HOSTS) {
     try {
       const { status, json } = await http(`/api/v1/menu-counts?hostId=${h}`, {
@@ -286,6 +325,7 @@ async function runAuthenticated() {
 
 async function main() {
   if (!JSON_OUTPUT) console.log(`\n🔎 Verifying ${BASE_URL}\n`)
+  await probeDeployment()
   await runUnauthenticated()
   await runAuthenticated()
 

--- a/apps/dashboard/src/lib/auth/__tests__/api-guard.test.ts
+++ b/apps/dashboard/src/lib/auth/__tests__/api-guard.test.ts
@@ -1,0 +1,75 @@
+import { enforceAuth, isAuthenticatedRequest } from '../api-guard'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { issueApiKey } from '@chm/mcp-server/auth'
+
+const TEST_SECRET = 'test-secret-key-for-unit-tests-at-least-32-chars'
+
+const ENV_KEYS = [
+  'CHM_AUTH_PROVIDER',
+  'VITE_AUTH_PROVIDER',
+  'CHM_API_KEY_SECRET',
+  'CHM_CLERK_PUBLIC_READ',
+  'CLERK_SECRET_KEY',
+] as const
+
+function anonReq(): Request {
+  return new Request('https://dash.example.com/api/health')
+}
+
+describe('isAuthenticatedRequest', () => {
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k]
+      delete process.env[k]
+    }
+  })
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k]
+      else process.env[k] = saved[k]
+    }
+  })
+
+  it('returns true for a fully-open deployment (provider=none, no API key)', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'none'
+    expect(await isAuthenticatedRequest(anonReq())).toBe(true)
+  })
+
+  it('returns true for a valid chm_ API key', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'none'
+    process.env.CHM_API_KEY_SECRET = TEST_SECRET
+    const key = await issueApiKey('test')
+    const req = new Request('https://dash.example.com/api/health', {
+      headers: { authorization: `Bearer ${key}` },
+    })
+    expect(await isAuthenticatedRequest(req)).toBe(true)
+  })
+
+  it('returns false for an anonymous request when api-key auth is on but no token is sent', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'none'
+    process.env.CHM_API_KEY_SECRET = TEST_SECRET
+    expect(await isAuthenticatedRequest(anonReq())).toBe(false)
+  })
+
+  // The core #1768 regression: public read-only mode lets anonymous users read
+  // dashboard DATA, but must NOT expose deployment metadata. isAuthenticatedRequest
+  // deliberately ignores publicReadEnabled(), unlike enforceAuth.
+  it('returns false for anonymous clerk requests even when public-read is enabled', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'clerk'
+    process.env.CHM_CLERK_PUBLIC_READ = 'true'
+    expect(await isAuthenticatedRequest(anonReq())).toBe(false)
+  })
+
+  // Contrast: in the exact same config, the data-access guard (enforceAuth)
+  // DOES let the anonymous request through (returns null = allow). This is what
+  // defeated the first #1768 fix on the public-read production deployment.
+  it('diverges from enforceAuth: enforceAuth allows the same anonymous public-read request', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'clerk'
+    process.env.CHM_CLERK_PUBLIC_READ = 'true'
+    expect(await enforceAuth(anonReq())).toBeNull()
+    expect(await isAuthenticatedRequest(anonReq())).toBe(false)
+  })
+})

--- a/apps/dashboard/src/lib/auth/api-guard.ts
+++ b/apps/dashboard/src/lib/auth/api-guard.ts
@@ -219,6 +219,49 @@ export async function enforceAuth(request: Request): Promise<Response | null> {
 }
 
 /**
+ * Whether a request is genuinely authenticated — a valid `chm_` API key OR an
+ * authenticated provider session (clerk/proxy). Use this to gate exposure of
+ * sensitive deployment/security metadata (e.g. `/api/health`), NOT data access.
+ *
+ * Deliberately stricter than {@link enforceAuth}: it does NOT honor
+ * `publicReadEnabled()`. Public read-only mode grants anonymous visitors access
+ * to dashboard *data*, but must never expose deployment posture (git SHA, auth
+ * provider, key prefixes) — that is a separate trust boundary (#1768).
+ *
+ * Returns `true` for a fully-open deployment (`none` provider, no API key),
+ * since such deployments have no security boundary to protect.
+ *
+ * `bridgeApiKeyEnv` must have been called before this so the env binding is
+ * visible to process.env-based helpers on Workers.
+ */
+export async function isAuthenticatedRequest(
+  request: Request
+): Promise<boolean> {
+  // Fully-open deployment (no provider, no API key): nothing to protect.
+  if (getAuthProvider() === 'none' && !apiKeyAuthEnabled()) return true
+
+  // 1. Programmatic clients: a valid `chm_` Bearer token.
+  const headerToken = getBearerToken(request.headers.get('authorization'))
+  if (headerToken) {
+    const result = await verifyApiKey(headerToken)
+    if (result.valid) return true
+  }
+
+  // 2. An authenticated provider session (clerk cookie, proxy identity, …).
+  const provider = getAuthProvider()
+  if (
+    provider !== 'none' &&
+    (await resolveServerAuthProvider(provider).authenticateRequest(request))
+      .authenticated
+  ) {
+    return true
+  }
+
+  // Intentionally NO publicReadEnabled() relaxation here — see doc comment.
+  return false
+}
+
+/**
  * Resolve the auth-guard response for a request, or `null` to proceed.
  *
  * Order mirrors the Next middleware:

--- a/apps/dashboard/src/routes/api/health.ts
+++ b/apps/dashboard/src/routes/api/health.ts
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { env } from 'cloudflare:workers'
-import { bridgeApiKeyEnv, enforceAuth } from '@/lib/auth/api-guard'
+import { bridgeApiKeyEnv, isAuthenticatedRequest } from '@/lib/auth/api-guard'
 
 function getDeploymentInfo(bindings: Record<string, string | undefined>) {
   // Determine runtime: in workerd the CLOUDFLARE_WORKERS binding is set to '1'
@@ -36,10 +36,12 @@ export const Route = createFileRoute('/api/health')({
           const timestamp = new Date().toISOString()
 
           // Deployment metadata (auth posture, git info) is only returned to
-          // authenticated callers. Anonymous callers get a minimal liveness
-          // response so uptime probes still work without leaking security posture.
-          const authFailure = await enforceAuth(request)
-          if (authFailure) {
+          // genuinely authenticated callers. Anonymous callers get a minimal
+          // liveness response so uptime probes still work without leaking
+          // security posture. Uses isAuthenticatedRequest (not enforceAuth) so
+          // public read-only mode — which lets anonymous users read dashboard
+          // data — does NOT also expose deployment metadata (#1768).
+          if (!(await isAuthenticatedRequest(request))) {
             return Response.json(
               { status: 'ok', timestamp },
               {


### PR DESCRIPTION
## Problem

The first fix for #1768 (#1829) gated `/api/health` deployment metadata behind `enforceAuth`. But `enforceAuth` honors **public read-only mode** (`CHM_CLERK_PUBLIC_READ`): in that mode anonymous callers pass the guard. Production (`dash.chmonitor.dev`) runs public-read, so the deployment block was **still leaked to anonymous callers** after #1829 deployed:

```
$ curl -s https://dash.chmonitor.dev/api/health
{"status":"ok","timestamp":"…","deployment":{"gitSha":"…","authProvider":"clerk","clerkPublishableKeyPrefix":"pk_live_",…}}
```

## Fix

Add `isAuthenticatedRequest()` — a stricter check that requires a valid `chm_` API key **or** an authenticated provider session, and **deliberately ignores `publicReadEnabled()`**. Public read grants anonymous access to dashboard *data*; it must not expose deployment/security posture — a separate trust boundary. `/api/health` now uses it.

- Fully-open deployments (`provider=none`, no API key) still return full info (no boundary to protect).
- `enforceAuth` is unchanged and still used for data routes in `start.ts`.

## Tests

`apps/dashboard/src/lib/auth/__tests__/api-guard.test.ts` (new) — covers the open-deployment path, valid API key, anonymous-with-key-on, the **public-read regression** (anon clerk + public-read → not authenticated), and an explicit divergence assertion that `enforceAuth` allows the same request while `isAuthenticatedRequest` denies it.

Resolves #1768

Co-Authored-By: duyetbot <bot@duyet.net>

https://claude.ai/code/session_019QdBMXQh87cm3SJWnwi95G