### PR TITLE
fix(ci): skip dashboard deploy steps for dependabot PRs

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -122,6 +122,14 @@ jobs:
           fi
 
       - name: Set secrets
+        # Dependabot PRs run with GitHub's isolated dependabot secret store, so
+        # the deployment secrets resolve empty and `set-secrets.ts --strict`
+        # exits 1 — structurally failing the required `dashboard` check on every
+        # dependency PR (#1809). Skip the secret/deploy/verify steps for
+        # dependabot; build + type-check above still verify the dependency bump.
+        # Production deploys (push to main) are unaffected — actor is never
+        # dependabot there.
+        if: github.actor != 'dependabot[bot]'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -154,7 +162,7 @@ jobs:
           fi
 
       - name: Deploy preview
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -168,6 +176,8 @@ jobs:
         run: bunx wrangler deploy --minify
 
       - name: Verify deployment
+        # Skip for dependabot PRs — no preview was deployed (see Set secrets).
+        if: github.actor != 'dependabot[bot]'
         env:
           CHM_API_KEY_SECRET: ${{ secrets.CHM_API_KEY_SECRET }}
         run: |


### PR DESCRIPTION
## Problem (#1809)

The required **`dashboard`** check fails on **every dependabot PR**. Dependabot runs with GitHub's isolated dependabot secret store, so the deployment secrets (`CLOUDFLARE_API_TOKEN`, etc.) resolve empty and `set-secrets.ts --strict` exits 1 — a structural failure unrelated to the dependency change. Result: dependency PRs can never go green and pile up needing manual admin merges.

## Fix

Gate the secret/deploy/verify steps in the `dashboard` job on `github.actor != 'dependabot[bot]'`:

- `Set secrets`, `Deploy preview`, `Verify deployment` → skipped for dependabot.
- **Build + type-check still run**, so the dependency bump is genuinely verified.
- The preview deploy can't work without secrets anyway, so nothing of value is lost.

### Safety

- **Production path untouched**: `Deploy production` / `Chart smoke test` are push-only; `github.actor` is never `dependabot[bot]` on a push to `main`.
- **Normal contributor PRs untouched**: their previews still deploy and verify.
- Only dependabot PRs change behavior: from *always red* → *build + type-check green, no preview deploy*.

Resolves #1809

Co-Authored-By: duyetbot <bot@duyet.net>

https://claude.ai/code/session_019QdBMXQh87cm3SJWnwi95G