### PR TITLE
feat(seo): complete docs favicon set + robots.txt for docs & dashboard

### DIFF
--- a/apps/dashboard/public/robots.txt
+++ b/apps/dashboard/public/robots.txt
@@ -1,0 +1,9 @@
+# chmonitor dashboard — https://dash.chmonitor.dev
+# This is the application UI (a SPA behind optional auth), not marketing
+# content. Allow crawling of the shell but keep crawlers out of the API and
+# health endpoints, which have no SEO value and only waste crawl budget.
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /healthz
+Disallow: /heathz

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -36,9 +36,40 @@ export default defineConfig({
         PageTitle: './src/components/PageTitle.astro',
       },
       head: [
+        // Open Graph / Twitter card image. Starlight emits canonical, og:title,
+        // og:description and twitter:card by default, but not the image tags —
+        // add the dimensions and an explicit twitter:image so the card renders
+        // a large preview instead of relying on the og:image fallback.
         {
           tag: 'meta',
           attrs: { property: 'og:image', content: 'https://docs.chmonitor.dev/og/og.png' },
+        },
+        {
+          tag: 'meta',
+          attrs: { property: 'og:image:width', content: '1200' },
+        },
+        {
+          tag: 'meta',
+          attrs: { property: 'og:image:height', content: '630' },
+        },
+        {
+          tag: 'meta',
+          attrs: { name: 'twitter:image', content: 'https://docs.chmonitor.dev/og/og.png' },
+        },
+        // Complete the icon set. Starlight's `favicon` option only emits the
+        // single SVG link; reference the PNG fallbacks (older browsers) and the
+        // apple-touch-icon (iOS home screen) that already ship in public/.
+        {
+          tag: 'link',
+          attrs: { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/favicon-32.png' },
+        },
+        {
+          tag: 'link',
+          attrs: { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/favicon-16.png' },
+        },
+        {
+          tag: 'link',
+          attrs: { rel: 'apple-touch-icon', sizes: '180x180', href: '/apple-touch-icon.png' },
         },
       ],
       // Curated top-level order; pages within each section are listed

--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -1,0 +1,7 @@
+# chmonitor docs — https://docs.chmonitor.dev
+# Astro's @astrojs/sitemap integration emits sitemap-index.xml but does not
+# write robots.txt, so the Sitemap directive lives here.
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.chmonitor.dev/sitemap-index.xml


### PR DESCRIPTION
## What

Favicons already shipped in #1661, but they were under-referenced and a few SEO basics were missing on **docs.chmonitor.dev** and **dash.chmonitor.dev**.

### docs (Astro Starlight)
- **Icons**: Starlight's `favicon` option only emits the single SVG `<link>`. The PNG fallbacks (`favicon-16/32.png`) and `apple-touch-icon.png` already shipped in `public/` but were never referenced — now wired via the `head` config so old browsers and iOS home-screen get an icon.
- **Social cards**: add `og:image:width`/`og:image:height` and an explicit `twitter:image` (Starlight emits `twitter:card=summary_large_image` but no image tags).
- **robots.txt**: added with a `Sitemap:` directive — `@astrojs/sitemap` writes `sitemap-index.xml` but not robots.txt, so the sitemap was previously undiscoverable from robots.

### dashboard (TanStack Start)
- **robots.txt**: there was none (live `/robots.txt` returned empty). Allow the app shell, disallow `/api/`, `/healthz`, `/heathz` — no SEO value, avoids wasted crawl budget on an auth-gated SPA.

## Verification
- `bun run build` in `apps/docs` passes; the built `dist/index.html` head contains the new icon + image tags and `dist/robots.txt` is emitted.

> Note: docs is fronted by Cloudflare's managed content-signals robots.txt; the edge feature may merge/override this origin file. The origin file is now correct regardless.

https://claude.ai/code/session_014qvWYkz1Zy1WCvmiX7rnxP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added crawler directives to improve search engine indexing for the dashboard and docs.
  * Enhanced social media sharing with additional meta tags and favicon configuration for the docs site.
  * Configured sitemap integration for better discoverability across search engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->