### PR TITLE
fix(seo): inject JSON-LD via effect to avoid hydration mismatch

### DIFF
--- a/apps/dashboard/src/routes/__root.tsx
+++ b/apps/dashboard/src/routes/__root.tsx
@@ -5,9 +5,8 @@ import {
   Scripts,
 } from '@tanstack/react-router'
 
-import type { ReactNode } from 'react'
-
 import appCss from '../styles.css?url'
+import { type ReactNode, useEffect } from 'react'
 import { ClerkAuthProvider } from '@/components/clerk/clerk-auth-provider'
 import { isClerkClientEnabled } from '@/lib/clerk/clerk-client'
 import { AppProvider } from '@/lib/context/app-context'
@@ -131,6 +130,25 @@ export const Route = createRootRoute({
   component: RootComponent,
 })
 
+// Inject schema.org JSON-LD via a client effect rather than as JSX in <head>.
+// The SPA prerender does not serialize a raw <script> into the static shell, so
+// rendering one in the React tree causes a hydration mismatch (React #418).
+// Appending to document.head post-mount keeps it out of the reconciled tree —
+// Googlebot executes effects and reads the structured data.
+function StructuredData() {
+  useEffect(() => {
+    const el = document.createElement('script')
+    el.type = 'application/ld+json'
+    el.text = JSON.stringify(STRUCTURED_DATA)
+    el.setAttribute('data-chm-jsonld', '')
+    document.head.appendChild(el)
+    return () => {
+      el.remove()
+    }
+  }, [])
+  return null
+}
+
 function RootComponent() {
   return (
     <RootDocument>
@@ -146,19 +164,9 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
     <html lang="en" suppressHydrationWarning>
       <head>
         <HeadContent />
-        {/*
-          Structured data (schema.org WebApplication). Rendered React-side (the
-          SPA prerender only serializes head() meta/links); Googlebot executes
-          JS and reads dynamically-injected JSON-LD. `alternateName` maps the
-          brand's keyword variations to chmonitor, supporting brand sitelinks.
-        */}
-        <script
-          type="application/ld+json"
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: static, build-time JSON-LD
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(STRUCTURED_DATA) }}
-        />
       </head>
       <body className="bg-background font-sans antialiased">
+        <StructuredData />
         <ClerkAuthProvider>
           <TimezoneProvider>
             <ThemeProvider>


### PR DESCRIPTION
## Urgent follow-up to #1838

#1838 auto-merged the moment the required `dashboard` check went green — but its first commit rendered the schema.org `<script>` as JSX in `<head>`, which the TanStack SPA prerender does not serialize into the static shell. The client tree therefore diverged from the server HTML → **React #418 hydration mismatch on every dashboard page**, breaking client interactivity (this is what failed the `navigation` / `host-switching` / `sidebar-navigation` e2e suites; `e2e-test` is non-required so it did not block the merge).

A fix commit existed but landed after the squash-merge had already deleted the branch, so it never reached main. This PR carries that fix.

## Fix
Move JSON-LD out of the reconciled React tree: a `StructuredData` component returns `null` (identical on server + client → no mismatch) and appends the script to `document.head` in a `useEffect`. Googlebot executes effects, so the structured data (and the `alternateName` keyword aliases) is still read.

Meta / keywords / OG / Twitter tags are unaffected — they go through `head()` and render into the static shell (verified in `dist/client/_shell.html`).

## Verification
- `bun run build` passes; static shell contains description/keywords/og:url and **no** `ld+json` script (confirmed).
- `type-check:test` passes.
- Restores the e2e navigation/host-switching/sidebar suites (hydration error removed).

https://claude.ai/code/session_014qvWYkz1Zy1WCvmiX7rnxP