### PR TITLE
fix(api): return 503/504 for unreachable ClickHouse upstream, not 500

### DIFF
--- a/apps/dashboard/src/lib/api/shared/__tests__/fetch-data-error.test.ts
+++ b/apps/dashboard/src/lib/api/shared/__tests__/fetch-data-error.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test'
+import { statusForFetchDataError } from '@/lib/api/shared/fetch-data-error'
+
+describe('statusForFetchDataError', () => {
+  // An unreachable upstream must NOT masquerade as a 500. Cloudflare 525/526
+  // are classified as ssl_error by the ClickHouse client; this is the exact
+  // case behind the production "api 500" report when the CH origin is down.
+  it('maps an unreachable upstream to 503, not 500', () => {
+    expect(statusForFetchDataError('ssl_error')).toBe(503)
+    expect(statusForFetchDataError('network_error')).toBe(503)
+  })
+
+  it('maps a slow upstream to 504', () => {
+    expect(statusForFetchDataError('timeout_error')).toBe(504)
+  })
+
+  it('keeps client-fault classifications', () => {
+    expect(statusForFetchDataError('validation_error')).toBe(400)
+    expect(statusForFetchDataError('permission_error')).toBe(403)
+    expect(statusForFetchDataError('table_not_found')).toBe(404)
+  })
+
+  it('treats a genuine query fault as 500', () => {
+    expect(statusForFetchDataError('query_error')).toBe(500)
+  })
+})

--- a/apps/dashboard/src/lib/api/shared/fetch-data-error.ts
+++ b/apps/dashboard/src/lib/api/shared/fetch-data-error.ts
@@ -1,0 +1,31 @@
+/**
+ * FetchDataError → HTTP status bridge
+ *
+ * The ClickHouse client (`@chm/clickhouse-client`) already classifies a failed
+ * query into a `FetchDataErrorType` (e.g. an unreachable upstream / Cloudflare
+ * 525/526 becomes `ssl_error`, a refused connection becomes `network_error`).
+ * Those string values are intentionally identical to {@link ApiErrorType}, so a
+ * route can map the client's verdict straight to the correct HTTP status instead
+ * of collapsing every failure into a blanket 500.
+ *
+ * Why this matters: an upstream that is *down* is a 503 (Service Unavailable),
+ * not a 500 (Internal Server Error). Hardcoding 500 made an infrastructure
+ * outage look like an application crash. This keeps `/api/v1/charts/*` and
+ * `/api/v1/overview` consistent with `/api/v1/data` and `/api/healthz`.
+ */
+
+import type { FetchDataError } from '@chm/clickhouse-client'
+import type { ApiErrorType } from '@/lib/api/types'
+
+import { getStatusCodeForErrorType } from '@/lib/api/error-handler'
+
+/**
+ * Map a {@link FetchDataError.type} to its HTTP status code.
+ *
+ * The cast is safe because every `FetchDataErrorType` literal has a matching
+ * {@link ApiErrorType} value; unknown values fall back to 500 inside
+ * {@link getStatusCodeForErrorType}.
+ */
+export function statusForFetchDataError(type: FetchDataError['type']): number {
+  return getStatusCodeForErrorType(type as unknown as ApiErrorType)
+}

--- a/apps/dashboard/src/routes/api/v1/charts/$name.ts
+++ b/apps/dashboard/src/routes/api/v1/charts/$name.ts
@@ -15,10 +15,15 @@ import {
   hasChart,
 } from '@/lib/api/chart-registry'
 import {
+  classifyError,
+  getStatusCodeForErrorType,
+} from '@/lib/api/error-handler'
+import {
   executeChartQuery,
   executeMultiChartQuery,
   isValidInterval,
 } from '@/lib/api/query-executor'
+import { statusForFetchDataError } from '@/lib/api/shared/fetch-data-error'
 import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 
 /**
@@ -151,7 +156,7 @@ export async function handler(
       for (const r of results) {
         combinedEntries.push(`${JSON.stringify(r.key)}:${r.dataJson ?? 'null'}`)
         if (r.error && !firstError) {
-          firstError = { type: 'query_error', message: r.error.message }
+          firstError = { type: r.error.type, message: r.error.message }
         }
       }
 
@@ -229,16 +234,19 @@ export async function handler(
     }
 
     if (result.error) {
+      // Preserve the client's classification (e.g. an unreachable upstream is
+      // ssl_error/network_error → 503) instead of flattening every failure to a
+      // 500. See statusForFetchDataError for the rationale.
       return Response.json(
         {
           success: false,
           error: {
-            type: 'query_error',
+            type: result.error.type,
             message: result.error.message,
             details: result.error.details,
           },
         },
-        { status: 500 }
+        { status: statusForFetchDataError(result.error.type) }
       )
     }
 
@@ -280,15 +288,15 @@ export async function handler(
     })
   } catch (err) {
     error(`[GET /api/v1/charts/${name}] Unhandled exception:`, err)
+    // Classify so an upstream connectivity exception surfaces as 503/504
+    // rather than a misleading 500.
+    const { type, message } = classifyError(err)
     return Response.json(
       {
         success: false,
-        error: {
-          type: 'query_error',
-          message: err instanceof Error ? err.message : 'Unknown error',
-        },
+        error: { type, message },
       },
-      { status: 500 }
+      { status: getStatusCodeForErrorType(type) }
     )
   }
 }

--- a/apps/dashboard/src/routes/api/v1/charts/__tests__/name.test.ts
+++ b/apps/dashboard/src/routes/api/v1/charts/__tests__/name.test.ts
@@ -78,6 +78,14 @@ const realQueryError: FetchDataError = {
     '(total) memory limit exceeded: would use 1.35 GiB ... MEMORY_LIMIT_EXCEEDED',
 }
 
+// The production "api 500" report: an unreachable upstream surfaces as a
+// Cloudflare 525, classified upstream as ssl_error.
+const upstreamDownError: FetchDataError = {
+  type: 'ssl_error',
+  message: 'error code: 525\n (host: https://ch.example:8443)',
+  details: { httpStatusCode: 525 },
+}
+
 async function call(name: string): Promise<Response> {
   const { handler } = await import('../$name')
   return handler(
@@ -138,7 +146,28 @@ describe('GET /api/v1/charts/$name — optional table degradation', () => {
     expect(body.error.type).toBe('query_error')
   })
 
-  test('non-optional chart with table_not_found is NOT degraded → 500', async () => {
+  test('unreachable upstream (525/ssl_error) → 503, not 500', async () => {
+    mockExecuteChartQuery.mockResolvedValueOnce({
+      dataJson: null,
+      metadata: {},
+      error: upstreamDownError,
+      executedSql: 'SELECT 1',
+      clickhouseVersion: null,
+    })
+
+    const response = await call('plain-chart')
+    // 503 (retryable) is correct for a down upstream — a 500 wrongly implies an
+    // application fault and is what the production report flagged.
+    expect(response.status).toBe(503)
+    const body = (await response.json()) as {
+      success: boolean
+      error: { type: string }
+    }
+    expect(body.success).toBe(false)
+    expect(body.error.type).toBe('ssl_error')
+  })
+
+  test('non-optional chart with table_not_found is NOT degraded → 404 (not swallowed)', async () => {
     mockExecuteChartQuery.mockResolvedValueOnce({
       dataJson: null,
       metadata: {},
@@ -148,7 +177,15 @@ describe('GET /api/v1/charts/$name — optional table degradation', () => {
     })
 
     const response = await call('plain-chart')
-    expect(response.status).toBe(500)
+    // A missing table is a non-retryable 404 (preserved error type), not the
+    // 200-empty degradation path reserved for *optional* charts.
+    expect(response.status).toBe(404)
+    const body = (await response.json()) as {
+      success: boolean
+      error: { type: string }
+    }
+    expect(body.success).toBe(false)
+    expect(body.error.type).toBe('table_not_found')
   })
 
   test('healthy optional chart returns data normally → 200', async () => {

--- a/apps/dashboard/src/routes/api/v1/host-status.ts
+++ b/apps/dashboard/src/routes/api/v1/host-status.ts
@@ -4,6 +4,10 @@ import { env } from 'cloudflare:workers'
 import { getClient } from '@chm/clickhouse-client'
 import { error } from '@chm/logger'
 import { getClickHouseConfigsFromEnv } from '@/lib/api/clickhouse-config'
+import {
+  classifyError,
+  getStatusCodeForErrorType,
+} from '@/lib/api/error-handler'
 
 const QUERY_COMMENT = '/* { "client": "clickhouse-monitoring" } */\n'
 
@@ -73,15 +77,14 @@ export const Route = createFileRoute('/api/v1/host-status')({
           })
         } catch (err) {
           error('[GET /api/v1/host-status] Error:', err)
+          // An unreachable upstream is a 503/504, not a 500.
+          const { type, message } = classifyError(err)
           return Response.json(
             {
               success: false,
-              error:
-                err instanceof Error
-                  ? err.message
-                  : 'Failed to fetch host status',
+              error: message || 'Failed to fetch host status',
             },
-            { status: 500 }
+            { status: getStatusCodeForErrorType(type) }
           )
         }
       },

--- a/apps/dashboard/src/routes/api/v1/overview.ts
+++ b/apps/dashboard/src/routes/api/v1/overview.ts
@@ -11,7 +11,12 @@ import { createFileRoute } from '@tanstack/react-router'
 import { env } from 'cloudflare:workers'
 import { fetchData } from '@chm/clickhouse-client'
 import { error } from '@chm/logger'
+import {
+  classifyError,
+  getStatusCodeForErrorType,
+} from '@/lib/api/error-handler'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { statusForFetchDataError } from '@/lib/api/shared/fetch-data-error'
 
 const ROUTE_CONTEXT = { route: '/api/v1/overview' }
 
@@ -120,12 +125,16 @@ export const Route = createFileRoute('/api/v1/overview')({
 
           if (result.error || !result.data) {
             error('[GET /api/v1/overview] Query error:', result.error)
+            // A down upstream (ssl_error/network_error) is a 503, not a 500.
+            const status = result.error
+              ? statusForFetchDataError(result.error.type)
+              : 500
             return Response.json(
               {
                 success: false,
                 error: result.error?.message || 'No data returned',
               },
-              { status: 500 }
+              { status }
             )
           }
 
@@ -182,13 +191,13 @@ export const Route = createFileRoute('/api/v1/overview')({
           })
         } catch (err) {
           error('[GET /api/v1/overview] Error:', err, ROUTE_CONTEXT)
+          const { type, message } = classifyError(err)
           return Response.json(
             {
               success: false,
-              error:
-                err instanceof Error ? err.message : 'Internal server error',
+              error: message,
             },
-            { status: 500 }
+            { status: getStatusCodeForErrorType(type) }
           )
         }
       },


### PR DESCRIPTION
## Problem

Live audit of https://dash.chmonitor.dev/overview?host=0 (host0 = duet-ubuntu):

- Page shell, `/healthz`, `/api/v1/config`, `/api/v1/hosts` → **200** (app healthy)
- Every ClickHouse-backed endpoint → **HTTP 500** with `type: "query_error"`:

```
GET /api/v1/charts/query-count?hostId=0
{"success":false,"error":{"type":"query_error","message":"error code: 525 ...","details":{"httpStatusCode":525}}}  [500]
```

Root cause of the data outage is **infrastructure**: Cloudflare's edge cannot complete the TLS handshake (525) to the Tailscale-Funnel ClickHouse origin. The origin itself is up (`/ping` → 200 from a normal client). That part needs an infra change and is **not** addressed here.

What *is* a code bug: the `@chm/clickhouse-client` already classifies a 525 as `ssl_error`, but the charts / overview / host-status routes **discarded** that and hardcoded `type:'query_error'` + status **500**, making a down upstream look like an application crash. This is the "api 500" that was reported.

## Fix

New shared `statusForFetchDataError` helper bridges the client's `FetchDataErrorType` to the correct HTTP status (the two enums are value-aligned):

| error type | status |
|---|---|
| `ssl_error`, `network_error` | **503** |
| `timeout_error` | **504** |
| `table_not_found` | **404** |
| `validation_error` | **400** |
| `query_error` | **500** |

Wired into `/api/v1/charts/$name`, `/api/v1/overview`, `/api/v1/host-status` (catch blocks classify via `classifyError`). Now consistent with `/api/v1/data` and `/api/healthz`, which already classified correctly.

Bonus: `use-chart-data` does not retry 4xx (except 429) but does retry 5xx — so a missing table (404) stops being retried 3× pointlessly, while a transient upstream (503) still retries.

## Tests
- New `statusForFetchDataError` unit test (all type→status mappings)
- New charts route test: `525/ssl_error → 503`
- Updated charts route test: non-optional `table_not_found → 404` (was 500), intent preserved (not swallowed, `success:false`)
- `type-check`, `type-check:test`, biome, full build all green

https://claude.ai/code/session_015TxP5Q3ZYHnVpUvLqJkzqk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * API endpoints now return appropriate HTTP status codes for different error types (e.g., 503 for upstream unavailability, 504 for timeouts, 404 for missing resources) instead of defaulting to 500.

* **Tests**
  * Added comprehensive test coverage for error handling and HTTP status code mapping across API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->