### PR TITLE
test(env): unit tests for env-utils environment helpers

### DIFF
--- a/apps/dashboard/src/lib/env-utils.test.ts
+++ b/apps/dashboard/src/lib/env-utils.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterEach } from 'bun:test'
+import {
+  isDevelopment,
+  isProduction,
+  isTest,
+  shouldShowDetailedErrors,
+  getEnvironment,
+} from './env-utils'
+
+const originalNodeEnv = process.env.NODE_ENV
+
+afterEach(() => {
+  process.env.NODE_ENV = originalNodeEnv
+})
+
+describe('getEnvironment', () => {
+  it('returns the current NODE_ENV value', () => {
+    process.env.NODE_ENV = 'production'
+    expect(getEnvironment()).toBe('production')
+  })
+
+  it('returns development when NODE_ENV is development', () => {
+    process.env.NODE_ENV = 'development'
+    expect(getEnvironment()).toBe('development')
+  })
+
+  it('returns test when NODE_ENV is test', () => {
+    process.env.NODE_ENV = 'test'
+    expect(getEnvironment()).toBe('test')
+  })
+
+  it('falls back to development when NODE_ENV is unset', () => {
+    // In bun test, typeof window === 'undefined' (server path), so fallback is 'development'
+    delete process.env.NODE_ENV
+    expect(getEnvironment()).toBe('development')
+  })
+})
+
+describe('isDevelopment', () => {
+  it('returns true when NODE_ENV is development', () => {
+    process.env.NODE_ENV = 'development'
+    expect(isDevelopment()).toBe(true)
+  })
+
+  it('returns false when NODE_ENV is production', () => {
+    process.env.NODE_ENV = 'production'
+    expect(isDevelopment()).toBe(false)
+  })
+
+  it('returns false when NODE_ENV is test', () => {
+    process.env.NODE_ENV = 'test'
+    expect(isDevelopment()).toBe(false)
+  })
+
+  it('returns true when NODE_ENV is unset (server-side fallback is development)', () => {
+    delete process.env.NODE_ENV
+    expect(isDevelopment()).toBe(true)
+  })
+})
+
+describe('isProduction', () => {
+  it('returns true when NODE_ENV is production', () => {
+    process.env.NODE_ENV = 'production'
+    expect(isProduction()).toBe(true)
+  })
+
+  it('returns false when NODE_ENV is development', () => {
+    process.env.NODE_ENV = 'development'
+    expect(isProduction()).toBe(false)
+  })
+
+  it('returns false when NODE_ENV is test', () => {
+    process.env.NODE_ENV = 'test'
+    expect(isProduction()).toBe(false)
+  })
+})
+
+describe('isTest', () => {
+  it('returns true when NODE_ENV is test', () => {
+    process.env.NODE_ENV = 'test'
+    expect(isTest()).toBe(true)
+  })
+
+  it('returns false when NODE_ENV is development', () => {
+    process.env.NODE_ENV = 'development'
+    expect(isTest()).toBe(false)
+  })
+
+  it('returns false when NODE_ENV is production', () => {
+    process.env.NODE_ENV = 'production'
+    expect(isTest()).toBe(false)
+  })
+})
+
+describe('shouldShowDetailedErrors', () => {
+  it('returns true when NODE_ENV is development', () => {
+    process.env.NODE_ENV = 'development'
+    expect(shouldShowDetailedErrors()).toBe(true)
+  })
+
+  it('returns false when NODE_ENV is production', () => {
+    process.env.NODE_ENV = 'production'
+    expect(shouldShowDetailedErrors()).toBe(false)
+  })
+
+  it('returns false when NODE_ENV is test', () => {
+    process.env.NODE_ENV = 'test'
+    expect(shouldShowDetailedErrors()).toBe(false)
+  })
+
+  it('mirrors isDevelopment', () => {
+    for (const env of ['development', 'production', 'test', 'staging']) {
+      process.env.NODE_ENV = env
+      expect(shouldShowDetailedErrors()).toBe(isDevelopment())
+    }
+  })
+})


### PR DESCRIPTION
## Summary
Adds co-located unit test coverage for a previously-untested pure utility module. No source changes — tests assert actual current behavior, locking it against regressions.

## Test
`bun test` on the new file passes locally.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for environment utilities, including fallback behavior validation across various configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->