### PR TITLE
docs: fix Next.js/env-var drift in README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -614,9 +614,8 @@ export const backupsConfig: QueryConfig = {
 
 - `CLICKHOUSE_NAME` - Custom names for hosts
 - `CLICKHOUSE_MAX_EXECUTION_TIME` - Query timeout (default: 60s)
-- `NEXT_PUBLIC_VERCEL_ANALYTICS_ENABLED` - Enable Vercel analytics
-- `NEXT_PUBLIC_MEASUREMENT_ID` - Google Analytics ID
-- `NEXT_PUBLIC_SELINE_ENABLED` - Enable Seline analytics
+- `VITE_TELEMETRY_ENABLED` - Enable opt-in product telemetry (off by default)
+- `VITE_DEPLOY_TARGET` - Deployment target dimension for telemetry (`docker|helm|cf|dev|unknown`)
 
 ## Common Tasks
 

--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ Optional API-key protection for `/api/v1/*` routes:
 CHM_API_KEY_SECRET=your-signing-secret
 ```
 
-Optional Clerk UI/session support:
+Optional Clerk UI/session support (set at build time; `NEXT_PUBLIC_*` is the v0.2 fallback):
 
 ```bash
 CHM_AUTH_PROVIDER=clerk
-NEXT_PUBLIC_AUTH_PROVIDER=clerk
-NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_your_key
+VITE_AUTH_PROVIDER=clerk
+VITE_CLERK_PUBLISHABLE_KEY=pk_live_your_key
 CLERK_SECRET_KEY=sk_live_your_key
 ```
 


### PR DESCRIPTION
Corrects stale v0.2 Next.js references in user-facing docs to match the current TanStack Start app: `VITE_*` env var names (with `NEXT_PUBLIC_*` noted as legacy fallback) in README and CLAUDE.md. Docs-only.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: duyetbot <bot@duyet.net>