### PR TITLE
fix(ui): prevent mobile horizontal overflow on toolbar + explain tabs

### DIFF
--- a/apps/dashboard/src/components/dashboard/saved-dashboards-toolbar.tsx
+++ b/apps/dashboard/src/components/dashboard/saved-dashboards-toolbar.tsx
@@ -76,10 +76,10 @@ export function SavedDashboardsToolbar({
   }
 
   return (
-    <div className="flex flex-row items-center gap-2">
+    <div className="flex flex-wrap items-center gap-2">
       <Select value={activeName} onValueChange={handleLoad}>
         <SelectTrigger
-          className="w-48"
+          className="w-full sm:w-48"
           aria-label={
             activeName
               ? `Saved dashboard: ${activeName}`

--- a/apps/dashboard/src/routes/(dashboard)/explain.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/explain.tsx
@@ -391,13 +391,15 @@ function ExplainContent() {
         </CardHeader>
         <CardContent className="space-y-4">
           <Tabs value={mode} onValueChange={setMode}>
-            <TabsList>
-              {EXPLAIN_MODES.map((m) => (
-                <TabsTrigger key={m.value} value={m.value}>
-                  {m.label}
-                </TabsTrigger>
-              ))}
-            </TabsList>
+            <div className="overflow-x-auto">
+              <TabsList>
+                {EXPLAIN_MODES.map((m) => (
+                  <TabsTrigger key={m.value} value={m.value}>
+                    {m.label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </div>
           </Tabs>
 
           {!mode && (
@@ -432,13 +434,15 @@ function ExplainContent() {
 
       {statements.length > 1 ? (
         <Tabs value={activeQuery} onValueChange={setActiveQuery}>
-          <TabsList>
-            {statements.map((_, i) => (
-              <TabsTrigger key={i} value={String(i)}>
-                Query {i + 1}
-              </TabsTrigger>
-            ))}
-          </TabsList>
+          <div className="overflow-x-auto">
+            <TabsList>
+              {statements.map((_, i) => (
+                <TabsTrigger key={i} value={String(i)}>
+                  Query {i + 1}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </div>
           {statements.map((stmt, i) => (
             <TabsContent key={i} value={String(i)} className="mt-4">
               <SingleExplain


### PR DESCRIPTION
Two mobile-only overflow fixes, desktop unchanged (uses sm:/md: prefixes):
- saved-dashboards-toolbar: `flex-row`→`flex-wrap`, select `w-48`→`w-full sm:w-48` so it stacks on phones.
- explain.tsx: wrap both `TabsList` strips in `overflow-x-auto` (mirrors the overview tab strip) so 5 mode tabs scroll instead of overflowing a 320px viewport.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: duyetbot <bot@duyet.net>