### PR TITLE
fix(ui): align chart skeleton min-height to loaded chart to cut CLS

### DIFF
--- a/apps/dashboard/src/components/skeletons/chart.tsx
+++ b/apps/dashboard/src/components/skeletons/chart.tsx
@@ -225,7 +225,7 @@ export const ChartSkeleton = function ChartSkeleton({
       className={cn(
         chartCard.base,
         chartCard.variants.normal,
-        'min-h-[160px]',
+        'min-h-[200px]',
         className
       )}
       role="status"


### PR DESCRIPTION
ChartSkeleton card floor was `min-h-[160px]` but DynamicChart and the chart grid enforce `min-h-[200px]`/`minmax(200px,auto)`, causing a guaranteed 40px upward jump per chart row on load. Raise the skeleton floor to `min-h-[200px]` so reserved space matches loaded space. `min-h` only sets a floor; loaded charts still expand naturally — loaded appearance unchanged.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: duyetbot <bot@duyet.net>