### PR TITLE
fix(a11y): add aria-labels to icon-only buttons

### DIFF
--- a/apps/dashboard/src/components/ai-elements/code-block.tsx
+++ b/apps/dashboard/src/components/ai-elements/code-block.tsx
@@ -176,6 +176,7 @@ export const CodeBlockCopyButton = ({
       onClick={copyToClipboard}
       size="icon"
       variant="ghost"
+      aria-label={isCopied ? 'Copied' : 'Copy code'}
       {...props}
     >
       {children ?? <Icon size={14} />}

--- a/apps/dashboard/src/components/ai-elements/conversation.tsx
+++ b/apps/dashboard/src/components/ai-elements/conversation.tsx
@@ -93,6 +93,7 @@ export const ConversationScrollButton = ({
         size="icon"
         type="button"
         variant="outline"
+        aria-label="Scroll to bottom"
         {...props}
       >
         <ArrowDownIcon className="size-4" />

--- a/apps/dashboard/src/components/dialogs/dialog-sql.tsx
+++ b/apps/dashboard/src/components/dialogs/dialog-sql.tsx
@@ -390,6 +390,7 @@ export function RequestInfoContent({
                       size="icon"
                       className="size-8 rounded-lg"
                       onClick={() => handleCopy(displaySQL)}
+                      aria-label={copied ? 'Copied!' : 'Copy SQL'}
                     >
                       {copied ? (
                         <Check className="size-4 text-green-500" />

--- a/apps/dashboard/src/components/explorer/explorer-layout.tsx
+++ b/apps/dashboard/src/components/explorer/explorer-layout.tsx
@@ -23,6 +23,7 @@ export function ExplorerLayout() {
             variant="ghost"
             size="icon"
             onClick={() => setIsSidebarOpen(true)}
+            aria-label="Open explorer sidebar"
           >
             <MenuIcon className="size-4" />
           </Button>

--- a/apps/dashboard/src/components/header/header-actions.tsx
+++ b/apps/dashboard/src/components/header/header-actions.tsx
@@ -74,7 +74,12 @@ export const HeaderActions = function HeaderActions({
           suppressHydrationWarning
         />
       ) : (
-        <Button variant="ghost" size="icon" className="inline-flex">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="inline-flex"
+          aria-label="Toggle theme"
+        >
           <Sun className="size-4" />
         </Button>
       )}

--- a/apps/dashboard/src/components/notifications/notifications-popover.tsx
+++ b/apps/dashboard/src/components/notifications/notifications-popover.tsx
@@ -131,6 +131,7 @@ export const NotificationsPopover = function NotificationsPopover() {
             size="icon"
             className="size-7"
             onClick={() => setIsOpen(false)}
+            aria-label="Close notifications"
           >
             <X className="size-3.5" />
           </Button>

--- a/apps/dashboard/src/components/settings/settings-dialog.tsx
+++ b/apps/dashboard/src/components/settings/settings-dialog.tsx
@@ -38,7 +38,7 @@ export function SettingsDialog({
       {!isControlled && (
         <DialogTrigger asChild>
           {children || (
-            <Button variant="ghost" size="icon">
+            <Button variant="ghost" size="icon" aria-label="Open settings">
               <Settings className="size-4" />
             </Button>
           )}


### PR DESCRIPTION
Adds accessible names to 6 icon-only buttons that previously had none (settings trigger, theme SSR placeholder, scroll-to-bottom, copy-code, explorer sidebar, close-notifications, copy-SQL) — each verified to lack aria-label/title/sr-only text. Screen-reader-only improvement; no visual/logic change.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: duyetbot <bot@duyet.net>