### PR TITLE
fix(ui): tabular-nums on live/columnar numeric displays

### DIFF
--- a/apps/dashboard/src/components/cards/animated-number.tsx
+++ b/apps/dashboard/src/components/cards/animated-number.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 
+import { cn } from '@/lib/utils'
+
 interface AnimatedNumberProps {
   value: string | number
   className?: string
@@ -88,7 +90,7 @@ export function AnimatedNumber({ value, className }: AnimatedNumberProps) {
   }, [targetNum])
 
   return (
-    <span className={className}>
+    <span className={cn('tabular-nums', className)}>
       {displayNum.toLocaleString()}
       {suffix}
     </span>

--- a/apps/dashboard/src/components/cards/card-multi-metrics.tsx
+++ b/apps/dashboard/src/components/cards/card-multi-metrics.tsx
@@ -79,14 +79,14 @@ export const CardMultiMetrics = function CardMultiMetrics({
 
           return (
             <div key={key} className="flex items-center gap-2 text-sm">
-              <span className="text-muted-foreground truncate flex-1 min-w-0">
+              <span className="text-muted-foreground truncate flex-1 min-w-0 tabular-nums">
                 {item.currentReadable}
               </span>
               <DottedLineProgress
                 percent={clampedPercent}
                 className="shrink-0"
               />
-              <span className="font-medium truncate flex-1 min-w-0 text-right">
+              <span className="font-medium truncate flex-1 min-w-0 text-right tabular-nums">
                 {item.targetReadable}
               </span>
             </div>

--- a/apps/dashboard/src/components/data-table/cells/background-bar-format.tsx
+++ b/apps/dashboard/src/components/data-table/cells/background-bar-format.tsx
@@ -67,7 +67,7 @@ export const BackgroundBarFormat = function BackgroundBarFormat({
         }}
         aria-hidden="true"
       />
-      <span className="relative inline-block min-w-0 truncate px-1.5">
+      <span className="relative inline-block min-w-0 truncate px-1.5 tabular-nums">
         {options?.numberFormat
           ? formatReadableQuantity(value as number, 'long')
           : value}

--- a/apps/dashboard/src/components/keeper/keeper-overview-kpis.tsx
+++ b/apps/dashboard/src/components/keeper/keeper-overview-kpis.tsx
@@ -156,9 +156,14 @@ export const KeeperOverviewKpis = memo(function KeeperOverviewKpis({
           label="Data Size"
           value={hasSummary ? s!.readable_data_size || DASH : DASH}
           sub={
-            hasSummary
-              ? `${Number(s!.znode_count).toLocaleString()} znodes`
-              : undefined
+            hasSummary ? (
+              <>
+                <span className="tabular-nums">
+                  {Number(s!.znode_count).toLocaleString()}
+                </span>{' '}
+                znodes
+              </>
+            ) : undefined
           }
           isLoading={summary.isLoading}
         />

--- a/apps/dashboard/src/components/sql-console/tabs/analysis-tab.tsx
+++ b/apps/dashboard/src/components/sql-console/tabs/analysis-tab.tsx
@@ -106,7 +106,7 @@ function MetricCard({
         <Icon className="size-3.5" />
         {label}
       </div>
-      <div className="mt-1 font-mono text-lg">{value}</div>
+      <div className="mt-1 font-mono text-lg tabular-nums">{value}</div>
       {sub && <div className="text-muted-foreground mt-0.5 text-xs">{sub}</div>}
     </div>
   )


### PR DESCRIPTION
Applies `tabular-nums` to animated counters, multi-metric cards, background-bar cells, SQL-console metric cards, and keeper KPIs so digits don't change width on update/refresh — removes horizontal jitter. className-only.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: duyetbot <bot@duyet.net>