### PR TITLE
fix(ci): label apps/dashboard as 'app: dashboard', not legacy

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,11 +1,7 @@
 # Path-based PR auto-labeling (actions/labeler v5). Labels must already exist in
 # the repo; see the label set created alongside this file.
 
-'app: dashboard-tsr':
-  - changed-files:
-      - any-glob-to-any-file: 'apps/dashboard-tsr/**'
-
-'app: dashboard (legacy)':
+'app: dashboard':
   - changed-files:
       - any-glob-to-any-file: 'apps/dashboard/**'
 


### PR DESCRIPTION
`apps/dashboard` is the current TanStack Start app (v0.3+) — the Next.js migration is complete — yet the PR labeler still tagged every dashboard change `app: dashboard (legacy)` and kept a dead `apps/dashboard-tsr/**` rule (that dir was renamed to `apps/dashboard`). This consolidates to one accurate `app: dashboard` rule. The `app: dashboard` label has been created in the repo.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: duyetbot <bot@duyet.net>