### PR TITLE
fix(security): constant-time CRON_SECRET comparison in health-sweep

### DIFF
--- a/apps/dashboard/src/routes/api/cron/__tests__/health-sweep.test.ts
+++ b/apps/dashboard/src/routes/api/cron/__tests__/health-sweep.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for CRON_SECRET authorization in health-sweep.ts
+ *
+ * The route's `isAuthorized()` is not exported, so we verify the security
+ * contract in two layers:
+ *
+ *   1. Structural — read the source and assert that:
+ *        - `secretsMatch` is imported from the constant-time module
+ *        - no bare `===` comparison against the secret remains
+ *        - both the Authorization header and `?secret=` query paths use it
+ *
+ *   2. Behavioral — test `secretsMatch` (the comparator used by the route)
+ *      directly: correct secret passes, wrong secret is rejected, empty
+ *      provided string is rejected.
+ *
+ * This approach mirrors other route tests in this repo (e.g.,
+ * routes/api/v1/browser-connections/__tests__/proxy.test.ts) that use source
+ * reading when the relevant function is not exported.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { secretsMatch } from '@/lib/auth/providers/constant-time'
+
+const SOURCE = readFileSync(
+  join((import.meta as any).dir, '..', 'health-sweep.ts'),
+  'utf-8'
+)
+
+// ---------------------------------------------------------------------------
+// Structural: verify the constant-time import and usage in the source
+// ---------------------------------------------------------------------------
+
+describe('health-sweep.ts CRON_SECRET authorization (structural)', () => {
+  test('imports secretsMatch from the constant-time module', () => {
+    expect(SOURCE).toContain(
+      "import { secretsMatch } from '@/lib/auth/providers/constant-time'"
+    )
+  })
+
+  test('uses secretsMatch for Authorization header comparison', () => {
+    expect(SOURCE).toMatch(
+      /secretsMatch\(authHeader,\s*`Bearer \$\{secret\}`\)/
+    )
+  })
+
+  test('uses secretsMatch for ?secret= query param comparison', () => {
+    expect(SOURCE).toMatch(/secretsMatch\(querySecret,\s*secret\)/)
+  })
+
+  test('does NOT use === to compare secrets (timing-safe check)', () => {
+    // The two replaced comparisons should be gone; only `=== 0` (inside
+    // constantTimeEqual) or `=== secret` outside isAuthorized must not appear.
+    // We look specifically for === with the secret variable — if either old
+    // branch remained the route would leak timing information.
+    expect(SOURCE).not.toMatch(/authHeader === `Bearer/)
+    expect(SOURCE).not.toMatch(/searchParams\.get\(['"]secret['"]\) ===/)
+  })
+
+  test('preserves the open-when-unset guard (if (!secret) return true)', () => {
+    // Intentional: when CRON_SECRET is not configured the endpoint is open.
+    expect(SOURCE).toMatch(/if\s*\(!secret\)\s*return true/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Behavioral: secretsMatch — the comparator the route delegates to
+// ---------------------------------------------------------------------------
+
+describe('secretsMatch (behavioral, from constant-time module)', () => {
+  test('returns true when provided and expected are identical', () => {
+    expect(secretsMatch('mysecret', 'mysecret')).toBe(true)
+  })
+
+  test('returns true for Authorization header format used by the route', () => {
+    const secret = 'my-cron-secret'
+    const header = `Bearer ${secret}`
+    expect(secretsMatch(header, `Bearer ${secret}`)).toBe(true)
+  })
+
+  test('returns false when provided differs from expected (wrong secret)', () => {
+    expect(secretsMatch('wrongsecret', 'correctsecret')).toBe(false)
+  })
+
+  test('returns false when provided is empty string (no secret supplied)', () => {
+    expect(secretsMatch('', 'correctsecret')).toBe(false)
+  })
+
+  test('returns false when secrets differ by one character', () => {
+    expect(secretsMatch('mysecretX', 'mysecretY')).toBe(false)
+  })
+
+  test('returns false on length mismatch (shorter provided)', () => {
+    expect(secretsMatch('short', 'longsecret')).toBe(false)
+  })
+
+  test('returns false on length mismatch (longer provided)', () => {
+    expect(secretsMatch('longsecret', 'short')).toBe(false)
+  })
+})

--- a/apps/dashboard/src/routes/api/cron/health-sweep.ts
+++ b/apps/dashboard/src/routes/api/cron/health-sweep.ts
@@ -27,6 +27,7 @@ import { env } from 'cloudflare:workers'
 import { error } from '@chm/logger'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { runHealthSweep } from '@/lib/health/server-sweep'
+import { secretsMatch } from '@/lib/auth/providers/constant-time'
 
 function isAuthorized(request: Request): boolean {
   const bindings = env as Record<string, string | undefined>
@@ -34,10 +35,11 @@ function isAuthorized(request: Request): boolean {
   if (!secret) return true
 
   const authHeader = request.headers.get('authorization')
-  if (authHeader === `Bearer ${secret}`) return true
+  if (authHeader && secretsMatch(authHeader, `Bearer ${secret}`)) return true
 
   const url = new URL(request.url)
-  if (url.searchParams.get('secret') === secret) return true
+  const querySecret = url.searchParams.get('secret')
+  if (querySecret && secretsMatch(querySecret, secret)) return true
 
   return false
 }


### PR DESCRIPTION
The cron health-sweep route compared the request secret with `===`, leaking length/prefix via timing. Now uses the existing `secretsMatch` constant-time comparator for both the Bearer header and `?secret=` paths. The open-when-unset guard is preserved. +12 tests.

Implements an `improve`-audit plan (see plans/).

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: duyetbot <bot@duyet.net>