### PR TITLE
fix(security): redact ClickHouse error details from action API responses

### DIFF
--- a/apps/dashboard/src/lib/api/error-handler/__tests__/sanitize-error.test.ts
+++ b/apps/dashboard/src/lib/api/error-handler/__tests__/sanitize-error.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for sanitizeClickHouseError
+ *
+ * Verifies:
+ *   - Each bucket maps representative raw messages to the correct constant
+ *   - Unknown messages fall back to the generic constant
+ *   - No bucket ever echoes any substring of the raw input to the output
+ *
+ * The no-echo invariant is the security guarantee: even if a ClickHouse error
+ * message contains a secret token (hostname, table name, internal path), it
+ * must never appear in the sanitized string returned to the client.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { SANITIZED_MESSAGES, sanitizeClickHouseError } from '../sanitize-error'
+
+describe('sanitizeClickHouseError — bucket classification', () => {
+  test('maps "Table does not exist" to NOT_FOUND', () => {
+    expect(
+      sanitizeClickHouseError('Table system.secret_table does not exist')
+    ).toBe(SANITIZED_MESSAGES.NOT_FOUND)
+  })
+
+  test('maps "doesn\'t exist" variant to NOT_FOUND', () => {
+    expect(sanitizeClickHouseError("Table system.users doesn't exist")).toBe(
+      SANITIZED_MESSAGES.NOT_FOUND
+    )
+  })
+
+  test('maps "not found" to NOT_FOUND', () => {
+    expect(sanitizeClickHouseError('Database not found: internal_db')).toBe(
+      SANITIZED_MESSAGES.NOT_FOUND
+    )
+  })
+
+  test('maps "unknown table" to NOT_FOUND', () => {
+    expect(
+      sanitizeClickHouseError('Unknown table expression in PREWHERE')
+    ).toBe(SANITIZED_MESSAGES.NOT_FOUND)
+  })
+
+  test('maps "no such" to NOT_FOUND', () => {
+    expect(
+      sanitizeClickHouseError('No such file or directory: /data/secret')
+    ).toBe(SANITIZED_MESSAGES.NOT_FOUND)
+  })
+
+  test('maps "Access denied" to PERMISSION', () => {
+    expect(sanitizeClickHouseError('Access denied for user default')).toBe(
+      SANITIZED_MESSAGES.PERMISSION
+    )
+  })
+
+  test('maps "not enough privileges" to PERMISSION', () => {
+    expect(
+      sanitizeClickHouseError(
+        'Not enough privileges. To execute this query, it is necessary to have the grant SELECT'
+      )
+    ).toBe(SANITIZED_MESSAGES.PERMISSION)
+  })
+
+  test('maps "permission denied" to PERMISSION', () => {
+    expect(
+      sanitizeClickHouseError('Permission denied: cannot read column salary')
+    ).toBe(SANITIZED_MESSAGES.PERMISSION)
+  })
+
+  test('maps "unauthorized" to PERMISSION', () => {
+    expect(
+      sanitizeClickHouseError('Unauthorized request to admin endpoint')
+    ).toBe(SANITIZED_MESSAGES.PERMISSION)
+  })
+
+  test('maps "timeout" to TIMEOUT', () => {
+    expect(
+      sanitizeClickHouseError('Query execution timeout exceeded: 30s')
+    ).toBe(SANITIZED_MESSAGES.TIMEOUT)
+  })
+
+  test('maps "timed out" to TIMEOUT', () => {
+    expect(
+      sanitizeClickHouseError('Connection timed out to 10.0.0.5:8123')
+    ).toBe(SANITIZED_MESSAGES.TIMEOUT)
+  })
+
+  test('maps "etimedout" to TIMEOUT', () => {
+    expect(sanitizeClickHouseError('ETIMEDOUT connecting to host')).toBe(
+      SANITIZED_MESSAGES.TIMEOUT
+    )
+  })
+
+  test('maps "syntax" to SYNTAX', () => {
+    expect(
+      sanitizeClickHouseError('Syntax error: unexpected token WHERE')
+    ).toBe(SANITIZED_MESSAGES.SYNTAX)
+  })
+
+  test('maps "cannot parse" to SYNTAX', () => {
+    expect(
+      sanitizeClickHouseError('Cannot parse expression: invalid column ref')
+    ).toBe(SANITIZED_MESSAGES.SYNTAX)
+  })
+
+  test('maps "parse error" to SYNTAX', () => {
+    expect(sanitizeClickHouseError('Parse error at position 42')).toBe(
+      SANITIZED_MESSAGES.SYNTAX
+    )
+  })
+
+  test('maps unknown message to GENERIC fallback', () => {
+    expect(
+      sanitizeClickHouseError(
+        'Some internal ClickHouse error we have never seen'
+      )
+    ).toBe(SANITIZED_MESSAGES.GENERIC)
+  })
+
+  test('empty string maps to GENERIC', () => {
+    expect(sanitizeClickHouseError('')).toBe(SANITIZED_MESSAGES.GENERIC)
+  })
+})
+
+describe('sanitizeClickHouseError — no-echo guarantee', () => {
+  const SECRETS = [
+    'system.secret_table',
+    'internal_db',
+    'salary',
+    '10.0.0.5:8123',
+    'sk-abc123secrettoken',
+  ]
+
+  const rawMessages: Array<{ raw: string; secret: string }> = [
+    {
+      raw: 'Table system.secret_table does not exist',
+      secret: 'system.secret_table',
+    },
+    {
+      raw: 'Permission denied: cannot read column salary from internal_db',
+      secret: 'salary',
+    },
+    {
+      raw: 'Connection timed out to 10.0.0.5:8123',
+      secret: '10.0.0.5',
+    },
+    {
+      raw: 'Unknown error: token sk-abc123secrettoken rejected',
+      secret: 'sk-abc123secrettoken',
+    },
+  ]
+
+  for (const { raw, secret } of rawMessages) {
+    test(`output does not contain "${secret}" from raw error`, () => {
+      const out = sanitizeClickHouseError(raw)
+      expect(out).not.toContain(secret)
+    })
+  }
+
+  test('no sanitized message contains any secret token', () => {
+    for (const secret of SECRETS) {
+      for (const msg of Object.values(SANITIZED_MESSAGES)) {
+        expect(msg).not.toContain(secret)
+      }
+    }
+  })
+})
+
+describe('sanitizeClickHouseError — case insensitivity', () => {
+  test('matches uppercase "DOES NOT EXIST"', () => {
+    expect(sanitizeClickHouseError('DOES NOT EXIST')).toBe(
+      SANITIZED_MESSAGES.NOT_FOUND
+    )
+  })
+
+  test('matches mixed case "Access Denied"', () => {
+    expect(sanitizeClickHouseError('Access Denied')).toBe(
+      SANITIZED_MESSAGES.PERMISSION
+    )
+  })
+
+  test('matches uppercase "TIMEOUT"', () => {
+    expect(sanitizeClickHouseError('TIMEOUT waiting for lock')).toBe(
+      SANITIZED_MESSAGES.TIMEOUT
+    )
+  })
+})

--- a/apps/dashboard/src/lib/api/error-handler/sanitize-error.ts
+++ b/apps/dashboard/src/lib/api/error-handler/sanitize-error.ts
@@ -1,0 +1,76 @@
+/**
+ * ClickHouse Error Sanitizer
+ *
+ * Returns a stable, classified human-readable message suitable for client
+ * HTTP responses. NEVER echoes any substring of the raw ClickHouse error
+ * message — internal details (table/column names, version strings, parser
+ * output) must not reach clients.
+ *
+ * The full original error continues to be logged server-side via
+ * ErrorLogger.logError before this function is called at each action site.
+ */
+
+/**
+ * Safe bucket messages returned to clients.
+ * Exported so tests can assert against the exact constant strings.
+ */
+export const SANITIZED_MESSAGES = {
+  NOT_FOUND: 'Resource not found',
+  PERMISSION: 'Permission denied',
+  TIMEOUT: 'Operation timed out',
+  SYNTAX: 'Invalid query',
+  GENERIC: 'Operation failed',
+} as const
+
+export type SanitizedMessage =
+  (typeof SANITIZED_MESSAGES)[keyof typeof SANITIZED_MESSAGES]
+
+/**
+ * Classifies a raw ClickHouse error message and returns a safe client-facing
+ * string. The raw message is NEVER included in the return value.
+ *
+ * @param raw - Raw error message from ClickHouse (logged server-side separately)
+ * @returns A stable, classified message safe for client HTTP responses
+ */
+export function sanitizeClickHouseError(raw: string): SanitizedMessage {
+  const lower = raw.toLowerCase()
+
+  if (
+    lower.includes('not found') ||
+    lower.includes("doesn't exist") ||
+    lower.includes('does not exist') ||
+    lower.includes('unknown table') ||
+    lower.includes('no such')
+  ) {
+    return SANITIZED_MESSAGES.NOT_FOUND
+  }
+
+  if (
+    lower.includes('access denied') ||
+    lower.includes('not enough privileges') ||
+    lower.includes('permission denied') ||
+    lower.includes('unauthorized') ||
+    lower.includes('forbidden')
+  ) {
+    return SANITIZED_MESSAGES.PERMISSION
+  }
+
+  if (
+    lower.includes('timeout') ||
+    lower.includes('timed out') ||
+    lower.includes('etimedout')
+  ) {
+    return SANITIZED_MESSAGES.TIMEOUT
+  }
+
+  if (
+    lower.includes('syntax') ||
+    lower.includes('cannot parse') ||
+    lower.includes('parse error') ||
+    lower.includes('syntax error')
+  ) {
+    return SANITIZED_MESSAGES.SYNTAX
+  }
+
+  return SANITIZED_MESSAGES.GENERIC
+}

--- a/apps/dashboard/src/routes/api/v1/__tests__/actions.test.ts
+++ b/apps/dashboard/src/routes/api/v1/__tests__/actions.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for routes/api/v1/actions.ts — error sanitization
+ *
+ * Verifies that each action handler (killQuery, optimizeTable, querySettings)
+ * redacts raw ClickHouse error details from client-visible response messages.
+ *
+ * Security guarantee: when ClickHouse throws an error whose message contains a
+ * secret token (e.g. an internal table name, host address, auth token), that
+ * token must NOT appear in the HTTP response body returned to the caller.
+ *
+ * The test plants a distinctive token ("system.secret_table does not exist")
+ * in the mocked ClickHouse error and asserts:
+ *   - The token is absent from response.message
+ *   - The sanitized bucket string IS present (proves redaction, not just silence)
+ *   - HTTP status is 500 (error path, unchanged by this fix)
+ *
+ * Mocking strategy (mirrors menu-counts/__tests__/index.test.ts):
+ *   - mock.module() for cloudflare:workers, @chm/clickhouse-client, @chm/logger,
+ *     @/lib/api/server-env, @/lib/feature-permissions/server
+ *   - All mocks are declared BEFORE the dynamic import of the Route module so
+ *     Bun's module registry sees the stubs.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// --- Module mocks (must be before any import of the Route module) ---
+
+mock.module('cloudflare:workers', () => ({
+  env: {
+    CLICKHOUSE_HOST: 'http://localhost:8123',
+    CLICKHOUSE_USER: 'default',
+    CLICKHOUSE_PASSWORD: '',
+  },
+}))
+
+// Permission gate: return null → request is allowed through
+mock.module('@/lib/feature-permissions/server', () => ({
+  authorizeFeatureRequest: mock(async () => null),
+}))
+
+mock.module('@/lib/api/server-env', () => ({
+  bridgeClickHouseEnv: mock(() => undefined),
+}))
+
+mock.module('@chm/logger', () => ({
+  ErrorLogger: { logError: mock(() => undefined) },
+  log: mock(() => undefined),
+}))
+
+// Mutable mock so each test can configure its own behavior
+const mockFetchData = mock(
+  async (
+    _args: unknown
+  ): Promise<{ data: unknown[] | null; error: unknown }> => ({
+    data: [],
+    error: null,
+  })
+)
+
+mock.module('@chm/clickhouse-client', () => ({
+  fetchData: mockFetchData,
+}))
+
+// --- Helpers ---
+
+/** Build a POST request to /api/v1/actions with a JSON body */
+function makeRequest(body: unknown, hostId = 0): Request {
+  return new Request(`http://localhost/api/v1/actions?hostId=${hostId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+type PostHandler = (ctx: { request: Request }) => Promise<Response>
+
+/**
+ * Extracts the POST handler from a TanStack Start server route.
+ *
+ * Route.options.server.handlers is typed as `Constrain<{POST: fn}, ...>` which
+ * is a union that TypeScript can't narrow further without a type assertion.
+ * At runtime the value is always the plain `{ POST: fn }` object shape;
+ * this cast is the minimal widening needed to access it.
+ */
+function getPostHandler(route: { options: { server?: unknown } }): PostHandler {
+  const handlers = (
+    route.options.server as { handlers?: { POST?: PostHandler } }
+  )?.handlers
+  const fn = handlers?.POST
+  if (!fn) throw new Error('Route has no POST handler')
+  return fn
+}
+
+/**
+ * Planted secret that must never appear in any client response.
+ * It contains an internal table name — exactly the kind of detail
+ * ClickHouse embeds in error messages that we must redact.
+ */
+const SECRET_TOKEN = 'system.secret_table'
+const RAW_CH_ERROR = `Table ${SECRET_TOKEN} does not exist`
+
+// --- Tests ---
+
+describe('actions route — killQuery error sanitization', () => {
+  beforeEach(() => {
+    mockFetchData.mockClear()
+  })
+
+  test('redacts ClickHouse error details from killQuery response', async () => {
+    mockFetchData.mockImplementation(async () => ({
+      data: null,
+      error: { message: RAW_CH_ERROR, type: 'query_error' },
+    }))
+
+    const { Route } = await import('../actions')
+    const handler = getPostHandler(Route)
+
+    const response = await handler({
+      request: makeRequest({
+        action: 'killQuery',
+        params: { queryId: 'abc-123' },
+      }),
+    })
+
+    expect(response.status).toBe(500)
+
+    const body = (await response.json()) as {
+      success: boolean
+      message: string
+    }
+    expect(body.success).toBe(false)
+
+    // Secret token must not be present in the client response
+    expect(body.message).not.toContain(SECRET_TOKEN)
+
+    // The sanitized bucket string must be present (proves active redaction)
+    expect(body.message).toContain('Resource not found')
+
+    // Context prefix is preserved
+    expect(body.message).toContain('Failed to kill query abc-123')
+  })
+
+  test('killQuery success path is unaffected', async () => {
+    mockFetchData.mockImplementation(async () => ({ data: [], error: null }))
+
+    const { Route } = await import('../actions')
+    const handler = getPostHandler(Route)
+    const response = await handler({
+      request: makeRequest({
+        action: 'killQuery',
+        params: { queryId: 'abc-123' },
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      success: boolean
+      message: string
+    }
+    expect(body.success).toBe(true)
+    expect(body.message).toContain('abc-123')
+  })
+})
+
+describe('actions route — optimizeTable error sanitization', () => {
+  beforeEach(() => {
+    mockFetchData.mockClear()
+  })
+
+  test('redacts ClickHouse error details from optimizeTable response', async () => {
+    mockFetchData.mockImplementation(async () => ({
+      data: null,
+      error: { message: RAW_CH_ERROR, type: 'query_error' },
+    }))
+
+    const { Route } = await import('../actions')
+    const handler = getPostHandler(Route)
+
+    const response = await handler({
+      request: makeRequest({
+        action: 'optimizeTable',
+        params: { table: 'my_table' },
+      }),
+    })
+
+    expect(response.status).toBe(500)
+
+    const body = (await response.json()) as {
+      success: boolean
+      message: string
+    }
+    expect(body.success).toBe(false)
+
+    // Secret token must not be in the client response
+    expect(body.message).not.toContain(SECRET_TOKEN)
+
+    // Sanitized bucket string must be present
+    expect(body.message).toContain('Resource not found')
+
+    // Context prefix preserved
+    expect(body.message).toContain('Failed to optimize table my_table')
+  })
+})
+
+describe('actions route — querySettings error sanitization', () => {
+  beforeEach(() => {
+    mockFetchData.mockClear()
+  })
+
+  test('redacts ClickHouse error details from querySettings response', async () => {
+    mockFetchData.mockImplementation(async () => ({
+      data: null,
+      error: { message: RAW_CH_ERROR, type: 'query_error' },
+    }))
+
+    const { Route } = await import('../actions')
+    const handler = getPostHandler(Route)
+
+    const response = await handler({
+      request: makeRequest({
+        action: 'querySettings',
+        params: { queryId: 'qid-456' },
+      }),
+    })
+
+    expect(response.status).toBe(500)
+
+    const body = (await response.json()) as {
+      success: boolean
+      message: string
+    }
+    expect(body.success).toBe(false)
+
+    // Secret token must not be in the client response
+    expect(body.message).not.toContain(SECRET_TOKEN)
+
+    // Sanitized bucket string must be present
+    expect(body.message).toContain('Resource not found')
+
+    // Context prefix preserved
+    expect(body.message).toContain('Failed to get query settings qid-456')
+  })
+
+  test('querySettings success path returns data and is unaffected', async () => {
+    mockFetchData.mockImplementation(async () => ({
+      data: [{ Settings: '{"max_threads":4}' }],
+      error: null,
+    }))
+
+    const { Route } = await import('../actions')
+    const handler = getPostHandler(Route)
+    const response = await handler({
+      request: makeRequest({
+        action: 'querySettings',
+        params: { queryId: 'qid-456' },
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      success: boolean
+      data: unknown
+    }
+    expect(body.success).toBe(true)
+  })
+})
+
+describe('actions route — PERMISSION error bucket is also redacted', () => {
+  beforeEach(() => {
+    mockFetchData.mockClear()
+  })
+
+  test('redacts "not enough privileges" to "Permission denied"', async () => {
+    const privilegeError =
+      'Not enough privileges. To execute killQuery, you need the SELECT grant on system.processes'
+
+    mockFetchData.mockImplementation(async () => ({
+      data: null,
+      error: { message: privilegeError, type: 'permission_error' },
+    }))
+
+    const { Route } = await import('../actions')
+    const handler = getPostHandler(Route)
+    const response = await handler({
+      request: makeRequest({
+        action: 'killQuery',
+        params: { queryId: 'abc-999' },
+      }),
+    })
+
+    const body = (await response.json()) as { message: string }
+
+    // The raw privileges error must not leak
+    expect(body.message).not.toContain('system.processes')
+    expect(body.message).not.toContain('SELECT grant')
+
+    // Sanitized to permission bucket
+    expect(body.message).toContain('Permission denied')
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/actions.ts
+++ b/apps/dashboard/src/routes/api/v1/actions.ts
@@ -13,6 +13,7 @@ import { env } from 'cloudflare:workers'
 import { fetchData } from '@chm/clickhouse-client'
 import { ErrorLogger, log } from '@chm/logger'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { sanitizeClickHouseError } from '@/lib/api/error-handler/sanitize-error'
 import { quoteTableIdentifier } from '@/lib/api/shared/sql-identifier'
 import { ACTIONS_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
 import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
@@ -90,7 +91,7 @@ async function handleKillQuery(
     })
     return {
       success: false,
-      message: `Failed to kill query ${queryId}: ${error.message}`,
+      message: `Failed to kill query ${queryId}: ${sanitizeClickHouseError(error.message)}`,
     }
   }
 
@@ -126,7 +127,7 @@ async function handleOptimizeTable(
     })
     return {
       success: false,
-      message: `Failed to optimize table ${table}: ${error.message}`,
+      message: `Failed to optimize table ${table}: ${sanitizeClickHouseError(error.message)}`,
     }
   }
 
@@ -151,7 +152,7 @@ async function handleQuerySettings(
     })
     return {
       success: false,
-      message: `Failed to get query settings ${queryId}: ${error.message}`,
+      message: `Failed to get query settings ${queryId}: ${sanitizeClickHouseError(error.message)}`,
     }
   }
 


### PR DESCRIPTION
kill-query / optimize-table / query-settings returned raw ClickHouse `error.message` to clients (backend recon). Adds `sanitizeClickHouseError` (5 safe buckets, never echoes input) applied at the 3 client-message sites; full errors still logged server-side via ErrorLogger. +31 tests. (Other leaking routes deferred per plan 025.)

Implements an `improve`-audit plan (see plans/).

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: duyetbot <bot@duyet.net>