### PR TITLE
docs: MCP security, agent tools reference, new guides + grants checklist

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -100,6 +100,7 @@ export default defineConfig({
       // automatically (alphabetically, Overview first via sidebar.order).
       sidebar: [
         { label: 'Getting Started', items: [{ autogenerate: { directory: 'getting-started' } }] },
+        { label: 'Guides', items: [{ autogenerate: { directory: 'guides' } }] },
         { label: 'Deployment', items: [{ autogenerate: { directory: 'deploy' } }] },
         { label: 'Features', items: [{ autogenerate: { directory: 'features' } }] },
         { label: 'AI Agent', items: [{ autogenerate: { directory: 'ai-agent' } }] },

--- a/docs/content/ai-agent/capabilities.mdx
+++ b/docs/content/ai-agent/capabilities.mdx
@@ -25,6 +25,32 @@ with a much smaller, more reliable tool surface.
 Control tools (`kill_query`, `kill_mutation`, `optimize_table`) are disabled unless
 `AGENT_ENABLE_CONTROL_TOOLS=true`. The agent always confirms before using them.
 
+### Tool reference
+
+| Tool | Description | Notes |
+|---|---|---|
+| `query` | Execute a read-only SQL query on ClickHouse. | SELECT / WITH / DESCRIBE / EXPLAIN only. Write statements are rejected. |
+| `list_databases` | List all databases with engine and comment metadata. | |
+| `list_tables` | List tables in a database with row counts and size. | |
+| `get_table_schema` | Get column definitions for a specific table. | |
+| `explore_table_schema` | Three-mode exploration: no args → databases; database only → tables; database + table → full schema with indexes and keys. | |
+| `get_running_queries` | Currently running queries ordered by elapsed time. | Reads `system.processes`. |
+| `get_slow_queries` | Slowest completed queries from the query log. | Reads `system.query_log`. |
+| `get_failed_queries` | Recent failed queries with error details. | Reads `system.query_log`. |
+| `explain_query` | EXPLAIN PLAN / PIPELINE / PLAN with indexes for a query. | |
+| `get_metrics` | Server health: version, uptime, active connections, memory. | Reads `system.metrics`. |
+| `get_disk_usage` | Per-disk free and total space. | Reads `system.disks`. |
+| `get_table_parts` | Part-level info for a table: rows, size, compression ratio. | Reads `system.parts`. |
+| `get_replication_status` | Per-table replication delay, queue size, and replica counts. | Reads `system.replicas`. |
+| `get_merge_status` | Currently running merges with progress and elapsed time. | Reads `system.merges`. |
+| `update_plan` | Create or update a step-by-step workflow plan for the current investigation. | Rendered as a live checklist in the UI. |
+| `load_skill` | Load an expert guide (skill) with SQL recipes for a specific domain. | |
+| `ask_user` | Ask the user a question to gather information before proceeding. | |
+| `query_and_visualize` | Run a SQL query and return an interactive chart config. | Chart type is auto-detected from result columns. |
+| `kill_query` | Kill a running query by `query_id`. | **DESTRUCTIVE.** Env-gated: requires `AGENT_ENABLE_CONTROL_TOOLS=true`. Agent always confirms first. |
+| `kill_mutation` | Cancel a running mutation on a table. | **DESTRUCTIVE.** Env-gated: requires `AGENT_ENABLE_CONTROL_TOOLS=true`. Agent always confirms first. |
+| `optimize_table` | Trigger an OPTIMIZE on a table to force merges. | **DESTRUCTIVE.** Env-gated: requires `AGENT_ENABLE_CONTROL_TOOLS=true`. Agent always confirms first. |
+
 ## Skills
 
 Skills are expert guides — with copy-pasteable SQL recipes against `system.*` — that

--- a/docs/content/features/mcp.mdx
+++ b/docs/content/features/mcp.mdx
@@ -28,6 +28,16 @@ See [MCP Server reference](/docs/reference/mcp-server) for the full tool list an
 
 ## Permissions & access
 
+:::caution[Secure by default]
+The MCP endpoint (`/api/mcp`) returns **401 Unauthorized** by default. It only opens when you explicitly configure at least one of:
+
+- **`CHM_API_KEY_SECRET`** — API key auth (recommended). See [API keys](/docs/authentication/api-keys).
+- **`CLERK_SECRET_KEY`** — Clerk OAuth token introspection. See [Clerk authentication](/docs/authentication/clerk).
+- **`CHM_MCP_PUBLIC=true`** — explicit opt-in for trusted private networks. A warning is logged on every request.
+
+Without one of these, every request — including from Claude Desktop, Cursor, and other MCP clients — is rejected with `401`.
+:::
+
 The MCP endpoint (`/api/mcp`) is **closed by default**. Anonymous requests receive a `401` response unless at least one of the following is true:
 
 - `CHM_API_KEY_SECRET` is set (API key auth — recommended for production)

--- a/docs/content/getting-started/clickhouse-requirements.mdx
+++ b/docs/content/getting-started/clickhouse-requirements.mdx
@@ -45,6 +45,94 @@ GRANT SELECT, INSERT
   TO monitoring;
 ```
 
+## Per-feature grants checklist
+
+`GRANT SELECT ON system.*` covers the majority of the dashboard. Some features read tables that require additional grants or depend on optional system tables that are only present when a subsystem is configured.
+
+### Always required
+
+| Dashboard feature | System tables used | Grant |
+|---|---|---|
+| Overview metrics | `system.metrics`, `system.asynchronous_metrics` | `SELECT ON system.*` |
+| Running queries | `system.processes` | `SELECT ON system.*` |
+| Active merges | `system.merges` | `SELECT ON system.*` |
+| Replica status | `system.replicas` | `SELECT ON system.*` |
+| Disks & storage | `system.disks`, `system.parts` | `SELECT ON system.*` |
+| Tables list | `system.tables`, `system.columns` | `SELECT ON system.*` |
+| Clusters | `system.clusters` | `SELECT ON system.*` |
+| Mutations | `system.mutations` | `SELECT ON system.*` |
+| Replication queue | `system.replication_queue` | `SELECT ON system.*` |
+| Settings / users / roles | `system.settings`, `system.users`, `system.roles` | `SELECT ON system.*` |
+| Warnings | `system.warnings` | `SELECT ON system.*` |
+| Errors | `system.errors` | `SELECT ON system.*` |
+| Dictionaries | `system.dictionaries` | `SELECT ON system.*` |
+
+### Requires `system.query_log` (enabled by default in most setups)
+
+| Feature | Tables | Grant |
+|---|---|---|
+| Query history | `system.query_log` | `SELECT ON system.*` |
+| Slow / expensive queries | `system.query_log` | `SELECT ON system.*` |
+| Failed queries | `system.query_log` | `SELECT ON system.*` |
+| Common errors | `system.errors` | `SELECT ON system.*` |
+| Top tables / columns by usage | `system.query_log` | `SELECT ON system.*` |
+
+### Optional — tables present only when the subsystem is configured
+
+These pages show a "table not available" notice when the underlying table does not exist. No error is raised.
+
+| Feature | Required table | Notes |
+|---|---|---|
+| Query thread analysis / parallelization | `system.query_thread_log` | Enable in ClickHouse server config |
+| Query profiler | `system.processors_profile_log` | Enable in ClickHouse server config |
+| Query views log | `system.query_views_log` | Available from ClickHouse 22.4+ |
+| Query cache | `system.query_cache` | Available from ClickHouse 23.5+ |
+| User processes | `system.user_processes` | Available from ClickHouse 23.3+ |
+| Merge performance | `system.part_log` | Enable `part_log` in server config |
+| Part log | `system.part_log` | Enable `part_log` in server config |
+| Query metric log | `system.query_metric_log` | Enable in ClickHouse server config |
+| Detached parts | `system.detached_parts` | Always exists; may be empty |
+| Dropped tables | `system.dropped_tables` | Available from ClickHouse 23.x+ |
+| Distributed DDL queue | `system.distributed_ddl_queue` | Only on clusters using DDL via ZooKeeper/Keeper |
+| Moves | `system.moves` | Only when tiered storage / volume moves are active |
+| Replicated fetches | `system.replicated_fetches` | Only on replicated clusters |
+| View refreshes | `system.view_refreshes` | Only when Refreshable Materialized Views are in use |
+| Skip indexes (Data Explorer) | `system.data_skipping_indices` | Available from ClickHouse 22.x+ |
+| Login attempts / sessions | `system.session_log` | Enable in ClickHouse server config |
+| Text log | `system.text_log` | Enable `text_log` in server config |
+| Crash log | `system.crash_log` | Always exists on supported versions |
+| **Backups** | `system.backup_log` | Optional. Only exists when backups are configured. |
+| **Error log** | `system.error_log` | Optional. Enable `error_log` in server config. |
+
+### ClickHouse Keeper / ZooKeeper (all optional)
+
+All Keeper pages are `optional: true` — they silently degrade to a notice when Keeper is not configured.
+
+| Feature | Required table | Notes |
+|---|---|---|
+| Keeper overview | `system.zookeeper_info` | Requires Keeper/ZooKeeper |
+| Keeper connections | `system.zookeeper_connection` | Requires Keeper/ZooKeeper |
+| Keeper watches | `system.zookeeper_watches` | Requires Keeper/ZooKeeper |
+| Keeper log | `system.zookeeper_log` | Requires Keeper/ZooKeeper |
+| Keeper connection log | `system.zookeeper_connection_log` | Available from ClickHouse 25.8+ |
+| ZooKeeper data browser | `system.zookeeper` | Requires Keeper/ZooKeeper |
+
+No special grants are needed for Keeper tables — `SELECT ON system.*` covers them. They simply do not exist when Keeper is not running.
+
+### Kafka (optional)
+
+| Feature | Required table | Notes |
+|---|---|---|
+| Kafka consumers | `system.kafka_consumers` | Only exists when Kafka engine tables are present |
+
+### Action grants (not SELECT)
+
+| Action | Grant needed |
+|---|---|
+| Kill Query (Running Queries page / AI agent) | `GRANT KILL QUERY ON *.* TO monitoring;` |
+| Optimize Table (Data Explorer / AI agent) | `GRANT OPTIMIZE ON *.* TO monitoring;` |
+| Create temporary tables (some merge queries) | `GRANT CREATE TEMPORARY TABLE ON *.* TO monitoring;` |
+
 ## Optional: ClickHouse Keeper / ZooKeeper access
 
 `system.zookeeper` is available only when ZooKeeper or ClickHouse Keeper is configured. No special grants are needed — `SELECT ON system.*` covers it.

--- a/docs/content/guides/proxy-auth-setup.mdx
+++ b/docs/content/guides/proxy-auth-setup.mdx
@@ -1,0 +1,333 @@
+# Proxy & SSO auth setup
+
+End-to-end setup guides for putting chmonitor behind a proxy that handles login. Three patterns are covered:
+
+- **Cloudflare Access + Tunnel** — Zero Trust, signed JWT, no shared secret needed.
+- **nginx + oauth2-proxy** — self-hosted OIDC login in front of nginx.
+- **Traefik ForwardAuth + OIDC** — Traefik middleware forwarding an OIDC session.
+
+All three use chmonitor's `trusted` or `proxy` auth provider. See [Authentication](/docs/authentication) for the full comparison.
+
+---
+
+## Quick comparison
+
+| Setup | chmonitor provider | Trust mechanism |
+|---|---|---|
+| Cloudflare Access + Tunnel | `proxy` | Signed `Cf-Access-Jwt-Assertion` JWT — no shared secret needed |
+| nginx + oauth2-proxy | `trusted` | Shared secret header (`X-Chm-Proxy-Secret`) |
+| Traefik ForwardAuth + OIDC | `trusted` | Shared secret header or network isolation |
+
+---
+
+## Cloudflare Access + Tunnel
+
+Cloudflare Access sits in front of chmonitor and issues a signed JWT on every authenticated request. chmonitor verifies the JWT cryptographically against Cloudflare's JWKS — no secret to share.
+
+### 1. Create an Access application
+
+In the Cloudflare Zero Trust dashboard:
+
+1. **Access → Applications → Add application → Self-hosted**.
+2. Set the **Application domain** to `your-chmonitor.example.com`.
+3. Under **Session duration**, pick a reasonable window (e.g. 24 hours).
+4. Add an **Access policy** (e.g. allow users in your team's email domain).
+5. Note the **Application Audience (AUD) tag** from the application overview page — it looks like a 64-character hex string.
+
+### 2. Create a Cloudflare Tunnel
+
+```bash
+cloudflared tunnel create chmonitor
+cloudflared tunnel route dns chmonitor your-chmonitor.example.com
+```
+
+Configure `~/.cloudflared/config.yml`:
+
+```yaml
+tunnel: chmonitor
+credentials-file: /root/.cloudflared/<tunnel-id>.json
+
+ingress:
+  - hostname: your-chmonitor.example.com
+    service: http://localhost:8080        # chmonitor container port
+  - service: http_status:404
+```
+
+Run the tunnel:
+
+```bash
+cloudflared tunnel run chmonitor
+```
+
+### 3. Configure chmonitor
+
+```bash
+CHM_AUTH_PROVIDER=trusted              # server-side
+VITE_AUTH_PROVIDER=trusted             # build-time client mirror
+
+# Cloudflare Access verification
+CHM_CF_ACCESS_TEAM_DOMAIN=yourteam.cloudflareaccess.com
+CHM_CF_ACCESS_AUD=<64-char-aud-tag>
+```
+
+Wait — actually chmonitor's Cloudflare Access support uses the `proxy` provider, not `trusted`. Use:
+
+```bash
+CHM_AUTH_PROVIDER=proxy
+VITE_AUTH_PROVIDER=proxy
+
+CHM_CF_ACCESS_TEAM_DOMAIN=yourteam.cloudflareaccess.com
+CHM_CF_ACCESS_AUD=<64-char-aud-tag>
+```
+
+The `proxy` provider verifies the `Cf-Access-Jwt-Assertion` header against the team's JWKS automatically. No shared secret is needed — the JWT signature is the proof.
+
+### 4. Verify
+
+```bash
+# Should return authenticated identity from Access
+curl -H "Cf-Access-Jwt-Assertion: <token>" \
+  https://your-chmonitor.example.com/api/v1/auth/me | jq .
+```
+
+Unauthenticated requests hit the Access login page (Cloudflare redirects them) before reaching chmonitor.
+
+---
+
+## nginx + oauth2-proxy
+
+oauth2-proxy sits alongside nginx and handles the OIDC login flow. After login it sets forwarded-identity headers that chmonitor's `trusted` provider reads.
+
+### Architecture
+
+```
+Browser → nginx → oauth2-proxy (login) → nginx → chmonitor
+```
+
+nginx uses `auth_request` to check with oauth2-proxy on every request. If the session is valid, oauth2-proxy sets identity headers; nginx forwards them to chmonitor along with a shared secret.
+
+### 1. Run oauth2-proxy
+
+Example with Google OIDC (replace with your provider):
+
+```bash
+docker run -d \
+  -p 4180:4180 \
+  quay.io/oauth2-proxy/oauth2-proxy \
+  --provider=google \
+  --client-id=YOUR_CLIENT_ID \
+  --client-secret=YOUR_CLIENT_SECRET \
+  --cookie-secret=$(openssl rand -base64 32) \
+  --email-domain=yourcompany.com \
+  --upstream=http://chmonitor:8080 \
+  --http-address=0.0.0.0:4180 \
+  --set-xauthrequest \          # emits X-Auth-Request-User, X-Auth-Request-Email
+  --pass-access-token=false
+```
+
+`--set-xauthrequest` makes oauth2-proxy emit `X-Auth-Request-User` and `X-Auth-Request-Email` on authenticated requests. Those map to chmonitor's default identity headers.
+
+### 2. Configure nginx
+
+```nginx
+server {
+  listen 443 ssl;
+  server_name chmonitor.yourcompany.com;
+
+  location /oauth2/ {
+    proxy_pass http://oauth2-proxy:4180;
+    proxy_set_header Host $host;
+  }
+
+  location = /oauth2/auth {
+    proxy_pass http://oauth2-proxy:4180;
+    proxy_pass_request_body off;
+    proxy_set_header Content-Length "";
+    proxy_set_header X-Original-URI $request_uri;
+  }
+
+  location / {
+    auth_request /oauth2/auth;
+    error_page 401 = /oauth2/sign_in;
+
+    # Forward identity from oauth2-proxy
+    auth_request_set $user  $upstream_http_x_auth_request_user;
+    auth_request_set $email $upstream_http_x_auth_request_email;
+
+    proxy_set_header X-Forwarded-User  $user;
+    proxy_set_header X-Forwarded-Email $email;
+
+    # Shared secret so chmonitor trusts these headers
+    proxy_set_header X-Chm-Proxy-Secret "your-shared-secret-here";
+
+    proxy_pass http://chmonitor:8080;
+  }
+}
+```
+
+### 3. Configure chmonitor
+
+```bash
+CHM_AUTH_PROVIDER=trusted
+VITE_AUTH_PROVIDER=trusted
+
+# Shared secret — must match the value in nginx
+CHM_TRUSTED_AUTH_SECRET=your-shared-secret-here
+
+# Optional: override header names if oauth2-proxy emits different ones
+# CHM_TRUSTED_USER_HEADER=X-Auth-Request-User   # default: X-Forwarded-User
+# CHM_TRUSTED_EMAIL_HEADER=X-Auth-Request-Email  # default: X-Forwarded-Email
+```
+
+oauth2-proxy's `--set-xauthrequest` emits `X-Auth-Request-User` and `X-Auth-Request-Email`. The nginx `auth_request_set` block copies them to `X-Forwarded-User` / `X-Forwarded-Email`, which are chmonitor's defaults.
+
+### 4. Verify
+
+```bash
+# Hit chmonitor directly (bypasses nginx) — should 401 (no shared secret)
+curl http://chmonitor:8080/api/v1/auth/me
+
+# Through nginx with a valid session cookie — should return authenticated principal
+curl -b "session=..." https://chmonitor.yourcompany.com/api/v1/auth/me | jq .
+```
+
+---
+
+## Traefik ForwardAuth + OIDC
+
+Traefik's `forwardAuth` middleware sends every request to an external auth server (e.g. Authelia, Authentik, or a custom endpoint) before proxying it. On success the auth server adds identity headers.
+
+### Architecture
+
+```
+Browser → Traefik → Authelia (forwardAuth) → Traefik → chmonitor
+```
+
+### 1. Configure Authelia (or Authentik)
+
+This example uses Authelia. Authelia adds `Remote-User`, `Remote-Name`, `Remote-Groups`, and `Remote-Email` headers on authenticated requests.
+
+`authelia/configuration.yml` (relevant section):
+
+```yaml
+access_control:
+  default_policy: deny
+  rules:
+    - domain: chmonitor.yourcompany.com
+      policy: one_factor
+```
+
+### 2. Configure Traefik
+
+`docker-compose.yml` (extract):
+
+```yaml
+services:
+  traefik:
+    image: traefik:v3
+    command:
+      - --providers.docker=true
+      - --entrypoints.websecure.address=:443
+
+  chmonitor:
+    image: ghcr.io/duyet/chmonitor:latest
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.chmonitor.rule: "Host(`chmonitor.yourcompany.com`)"
+      traefik.http.routers.chmonitor.entrypoints: "websecure"
+      traefik.http.routers.chmonitor.middlewares: "authelia@docker"
+
+  authelia:
+    image: authelia/authelia:latest
+    labels:
+      traefik.enable: "true"
+      traefik.http.middlewares.authelia.forwardauth.address: "http://authelia:9091/api/authz/forward-auth"
+      traefik.http.middlewares.authelia.forwardauth.trustForwardHeader: "true"
+      traefik.http.middlewares.authelia.forwardauth.authResponseHeaders: >-
+        Remote-User,Remote-Groups,Remote-Name,Remote-Email
+```
+
+Authelia sets `Remote-User`, `Remote-Name`, `Remote-Groups`, `Remote-Email`. Tell chmonitor to read those:
+
+### 3. Configure chmonitor
+
+```bash
+CHM_AUTH_PROVIDER=trusted
+VITE_AUTH_PROVIDER=trusted
+
+# Authelia headers differ from chmonitor's defaults — override them
+CHM_TRUSTED_USER_HEADER=Remote-User
+CHM_TRUSTED_EMAIL_HEADER=Remote-Email
+CHM_TRUSTED_NAME_HEADER=Remote-Name
+CHM_TRUSTED_GROUPS_HEADER=Remote-Groups
+
+# Trust gate: either set a shared secret or enable network-isolation mode.
+# Network isolation (chmonitor only reachable via Traefik inside Docker):
+CHM_TRUSTED_ALLOW_INSECURE=true
+
+# Or: set a shared secret (more secure; configure Traefik to add it)
+# CHM_TRUSTED_AUTH_SECRET=your-secret
+# CHM_TRUSTED_SHARED_SECRET_HEADER=X-Chm-Proxy-Secret
+```
+
+If you use `CHM_TRUSTED_ALLOW_INSECURE=true`, make sure chmonitor's port (8080) is not exposed on the host — only reachable via Traefik inside the Docker network.
+
+### 4. Optional: group-based access control
+
+Restrict chmonitor to specific Authelia groups:
+
+```bash
+# Only users in the "ops" or "admin" group can access chmonitor
+CHM_TRUSTED_ALLOWED_GROUPS=ops,admin
+```
+
+Authelia forwards groups as a comma-separated list in `Remote-Groups`; chmonitor checks intersection (case-insensitive).
+
+### 5. Verify
+
+```bash
+# Auth/me should show the identity forwarded by Authelia
+curl https://chmonitor.yourcompany.com/api/v1/auth/me | jq .
+```
+
+---
+
+## Trusted provider — full reference
+
+All env vars for `CHM_AUTH_PROVIDER=trusted`:
+
+### Trust gate
+
+| Variable | Default | Description |
+|---|---|---|
+| `CHM_TRUSTED_AUTH_SECRET` | — | Shared secret the proxy sends in the secret header. Constant-time compared. |
+| `CHM_TRUSTED_ALLOW_INSECURE` | `false` | Skip secret check when the worker is network-isolated behind the proxy. |
+| `CHM_TRUSTED_SHARED_SECRET_HEADER` | `X-Chm-Proxy-Secret` | Header name the proxy sends the secret in. |
+
+### Identity headers
+
+| Variable | Default header | Maps to |
+|---|---|---|
+| `CHM_TRUSTED_USER_HEADER` | `X-Forwarded-User` | User subject / id |
+| `CHM_TRUSTED_EMAIL_HEADER` | `X-Forwarded-Email` | Email address |
+| `CHM_TRUSTED_NAME_HEADER` | `X-Forwarded-Preferred-Username` | Display name |
+| `CHM_TRUSTED_AVATAR_HEADER` | `X-Forwarded-Avatar` | Avatar URL |
+| `CHM_TRUSTED_GROUPS_HEADER` | `X-Forwarded-Groups` | Comma-separated group list |
+| `CHM_TRUSTED_ROLE_HEADER` | `X-Forwarded-Role` | Single role (merged into groups) |
+| `CHM_TRUSTED_CUSTOM_HEADERS` | — | Extra claims: `field:Header-Name` pairs |
+
+### Access control
+
+| Variable | Default | Description |
+|---|---|---|
+| `CHM_TRUSTED_ALLOWED_GROUPS` | — | Comma-separated list of groups. If set, user must be in at least one. |
+
+---
+
+## Related
+
+- [Authentication overview](/docs/authentication)
+- [Trusted proxy docs](/docs/authentication/trusted-proxy)
+- [Cloudflare Access docs](/docs/authentication/cloudflare-access)
+- [Trusted header docs](/docs/authentication/trusted-header)
+- [API keys](/docs/authentication/api-keys)

--- a/docs/content/guides/troubleshooting.mdx
+++ b/docs/content/guides/troubleshooting.mdx
@@ -1,0 +1,268 @@
+# Troubleshooting
+
+Common issues and how to diagnose them.
+
+## Connection failures
+
+### Dashboard shows "Connection error" or blank charts
+
+**Check the ClickHouse URL:**
+
+```bash
+# Test the URL directly (replace with your values)
+curl -v "https://your-ch-host:8443/?query=SELECT+1" \
+  -u monitoring:password
+```
+
+Common mistakes:
+- Missing port (`8443` for HTTPS, `8123` for HTTP)
+- Wrong scheme — ClickHouse uses `https://` not `clickhouse://`
+- Trailing slash in `CLICKHOUSE_HOST` that the client double-appends
+
+**Check env var format for multi-host:**
+
+```bash
+# Correct: comma-separated, same position across all four vars
+CLICKHOUSE_HOST=https://host-a:8443,https://host-b:8443
+CLICKHOUSE_USER=monitoring,monitoring
+CLICKHOUSE_PASSWORD=secret-a,secret-b
+```
+
+If host count differs from user/password count, the second host silently falls back to the first credential.
+
+**TLS / certificate errors:**
+
+If ClickHouse uses a self-signed cert, set `CLICKHOUSE_VERIFY_CERT=false` or pass `?verify=false` in the URL. In production, install the CA cert instead.
+
+### Health endpoint returns 503
+
+`/healthz` always returns 200 (static liveness probe). `/api/healthz` returns 503 when the ClickHouse connection fails. Check:
+
+1. `CLICKHOUSE_HOST`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD` are set correctly.
+2. The ClickHouse host is reachable from the dashboard container / Worker.
+3. Network policy / firewall allows port 8443 (or 8123).
+
+```bash
+curl -s https://your-dashboard/api/healthz | jq .
+# {"status":"ok","clickhouse":"ok"} on success
+# {"status":"error","clickhouse":"error","message":"..."} on failure
+```
+
+### "Query timeout" on large tables
+
+Increase `CLICKHOUSE_MAX_EXECUTION_TIME` (default 60 seconds):
+
+```bash
+CLICKHOUSE_MAX_EXECUTION_TIME=120
+```
+
+For heavy queries (full query-log scans), the dashboard also respects ClickHouse-level query complexity limits. Consider raising `max_execution_time` on the monitoring user profile.
+
+---
+
+## Auth failures (401 / white screen)
+
+### Every page returns 401
+
+`CHM_AUTH_PROVIDER` is set to something other than `none` but is not configured properly:
+
+- `clerk` — check `CLERK_SECRET_KEY` and `VITE_AUTH_PROVIDER=clerk` (build-time).
+- `proxy` — check `CHM_CF_ACCESS_TEAM_DOMAIN` (Cloudflare Access) or `CHM_PROXY_AUTH_SECRET` (shared secret).
+- `trusted` — check `CHM_TRUSTED_AUTH_SECRET` or `CHM_TRUSTED_ALLOW_INSECURE`.
+
+Quick check:
+
+```bash
+curl -s https://your-dashboard/api/v1/auth/me | jq .
+# {"subject":"anonymous","provider":"none"} when no auth is configured
+# {"error":"Authentication required"} when auth is on but request is not authenticated
+```
+
+### White screen after login (Clerk)
+
+Clerk is a build-time client variable. If `VITE_AUTH_PROVIDER` was not set at build time, the client JS doesn't know about Clerk and may loop or blank out.
+
+Confirm the build included Clerk:
+
+```bash
+# On the deployed bundle, grep for the publishable key prefix
+curl https://your-dashboard/ | grep pk_live
+```
+
+If it is missing, rebuild with:
+```bash
+VITE_AUTH_PROVIDER=clerk NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_... bun run build
+```
+
+### API key returns 401
+
+- The token must be prefixed `chm_` — tokens issued by `/api/v1/auth/api-key`.
+- The token was issued against a specific `CHM_API_KEY_SECRET`. If the secret was rotated, old tokens are invalid.
+- Pass the token as `Authorization: Bearer chm_...` (not as `x-api-key`).
+
+```bash
+# Issue a new token
+curl -X POST https://your-dashboard/api/v1/auth/api-key \
+  -H "Authorization: Bearer $CHM_API_KEY_SECRET"
+```
+
+### MCP client returns 401
+
+The MCP endpoint is closed by default. One of `CHM_API_KEY_SECRET`, `CLERK_SECRET_KEY`, or `CHM_MCP_PUBLIC=true` must be set. See [MCP Server — Permissions](/docs/features/mcp#permissions--access).
+
+---
+
+## Performance / timeouts
+
+### Dashboard is slow to load
+
+Most dashboard pages are a static shell with client-side data fetching. A slow initial page usually means:
+- The static bundle is not cached at the edge (first request after a deploy).
+- The ClickHouse query itself is slow.
+
+To identify slow queries, open the AI agent and ask:
+> "What were the slowest queries in the last 5 minutes?"
+
+Or from the Queries → Slow Queries page.
+
+### Charts refresh too frequently
+
+Default refresh is 60 seconds for most charts. Reduce load by setting a longer interval:
+
+```bash
+# No per-chart env override is available; tune at the ClickHouse level:
+# Give the monitoring user a query-cache profile to avoid hitting ClickHouse on every refresh
+```
+
+Alternatively, enable query caching on the monitoring user profile (see [ClickHouse User & Grants](/docs/getting-started/clickhouse-requirements#recommended-clickhouse-profile)).
+
+### `max_query_size exceeded` errors
+
+Some dashboard queries on very large query logs can exceed ClickHouse's default `max_query_size`. Add to the monitoring user profile:
+
+```xml
+<max_query_size>1073741824</max_query_size>
+```
+
+---
+
+## AI agent / LLM failures
+
+### Agent returns "LLM API key not set"
+
+Set `LLM_API_KEY` to your OpenRouter, Anthropic, or OpenAI key:
+
+```bash
+LLM_API_KEY=sk-...
+```
+
+The agent uses OpenRouter by default. To switch provider:
+
+```bash
+LLM_BASE_URL=https://api.anthropic.com/v1
+LLM_MODEL=claude-opus-4-5
+```
+
+### Agent does not respond / hangs
+
+Check:
+1. `LLM_API_KEY` is a server-side variable (not `VITE_LLM_API_KEY`).
+2. The provider endpoint is reachable from the Worker / container.
+3. The model name is correct for the provider — OpenRouter uses `provider/model` format (e.g. `anthropic/claude-3-5-sonnet`).
+
+### Agent answers are vague or wrong
+
+The agent is bounded by the ClickHouse user's grants. If it cannot read `system.query_log` (the most data-rich source), answers will be shallow.
+
+Confirm grants:
+```sql
+SELECT count() FROM system.query_log;
+```
+
+If this returns a permission error, grant the monitoring user `SELECT ON system.*`.
+
+### Agent session metrics show high token usage
+
+Long conversations accumulate context. Start a new conversation to reset the context window. If you see large token counts on simple questions, the system prompt or a long skill is being included — this is expected and keeps answers accurate.
+
+---
+
+## Kubernetes / Helm health probes
+
+### Pod stuck in `CrashLoopBackOff`
+
+Common cause: the image pulled is stale (`latest` tag was not updated). Check the image digest:
+
+```bash
+kubectl describe pod <chmonitor-pod> | grep Image
+```
+
+If the digest matches an old build, force a re-pull:
+
+```bash
+kubectl rollout restart deployment chmonitor
+```
+
+### Liveness probe failing
+
+`/healthz` (liveness) should always return 200 — it is a static response. If it is failing, the container is not starting at all. Check container logs:
+
+```bash
+kubectl logs <pod> --previous
+```
+
+Common causes:
+- Missing required env vars (`CLICKHOUSE_HOST`)
+- Port mismatch — the Worker listens on `8080` by default; confirm the probe and container port match
+
+### Readiness probe failing
+
+`/api/healthz` (readiness) checks the ClickHouse connection. A 503 here means the pod is up but cannot reach ClickHouse. The pod will be removed from the Service endpoints until it recovers.
+
+Check:
+1. ClickHouse is running and the connection string is correct.
+2. NetworkPolicy allows port 8443 from the dashboard namespace.
+3. The monitoring user credentials work: `curl http://pod:8080/api/healthz`.
+
+Probe settings that work well:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 15
+  periodSeconds: 20
+readinessProbe:
+  httpGet:
+    path: /api/healthz
+    port: 8080
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 3
+startupProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  failureThreshold: 12
+  periodSeconds: 5
+```
+
+### Helm chart: dashboard can reach ClickHouse but shows no data
+
+The chart creates a `ConfigMap` for env vars. Confirm the values are correct:
+
+```bash
+kubectl get configmap chmonitor -o yaml | grep CLICKHOUSE
+```
+
+If the host uses `https://`, confirm TLS is allowed or `CLICKHOUSE_VERIFY_CERT=false` is set.
+
+---
+
+## Related
+
+- [ClickHouse User & Grants](/docs/getting-started/clickhouse-requirements)
+- [MCP Server — Permissions](/docs/features/mcp#permissions--access)
+- [Authentication](/docs/authentication)
+- [Upgrading ClickHouse](/docs/guides/upgrade-clickhouse)

--- a/docs/content/guides/upgrade-clickhouse.mdx
+++ b/docs/content/guides/upgrade-clickhouse.mdx
@@ -1,0 +1,148 @@
+# Upgrading ClickHouse
+
+Steps to safely upgrade ClickHouse when chmonitor is connected to it, including which system-table changes affect the dashboard and how to validate everything after the upgrade.
+
+## Before you upgrade
+
+### 1. Check your current version
+
+```bash
+curl -s "https://your-ch-host:8443?query=SELECT+version()" \
+  -u monitoring:password
+```
+
+Or from the dashboard: open the AI agent and ask "What ClickHouse version is this cluster running?"
+
+### 2. Check the support matrix
+
+chmonitor supports ClickHouse 22.x and later. Some features degrade gracefully on older versions — they show a "table not available" notice instead of an error. The minimum recommended version for full dashboard coverage is **23.8 LTS**.
+
+### 3. Back up critical tables before upgrading
+
+Backups that matter for the dashboard:
+
+```sql
+-- Save current merge-tree settings for comparison after upgrade
+SELECT * FROM system.merge_tree_settings INTO OUTFILE 'merge_tree_settings_before.csv' FORMAT CSV;
+-- Save current settings
+SELECT * FROM system.settings INTO OUTFILE 'settings_before.csv' FORMAT CSV;
+```
+
+### 4. Verify no stuck mutations or active merges
+
+The dashboard's Merges and Mutations pages show this at a glance. From SQL:
+
+```sql
+-- Any stuck mutations?
+SELECT database, table, command, parts_to_do, is_done
+FROM system.mutations
+WHERE is_done = 0
+ORDER BY create_time DESC;
+
+-- Long-running merges?
+SELECT database, table, round(progress * 100, 2) AS pct, elapsed
+FROM system.merges
+ORDER BY elapsed DESC;
+```
+
+Wait for mutations to complete or cancel them before upgrading a replica.
+
+### 5. Check replication health
+
+```sql
+SELECT database, table, replica_name,
+       is_leader, is_readonly, future_parts,
+       queue_size, last_queue_update_exception
+FROM system.replicas
+WHERE is_readonly = 1 OR queue_size > 10;
+```
+
+All replicas should be healthy with no read-only instances before the upgrade.
+
+## Version-by-version changes that affect the dashboard
+
+chmonitor uses versioned SQL (the `since` field in each query config) to automatically pick the right query for the connected ClickHouse version. No config changes are needed when upgrading, but the notes below explain what you gain.
+
+### 19.x → 22.x
+
+Basic monitoring (processes, merges, replicas, metrics, disks, settings, parts) works on any version the dashboard supports. Older versions are missing several tables entirely.
+
+### 22.x → 23.x
+
+- **`system.query_views_log`** — available from 22.4. The Query Views Log page becomes active.
+- **`system.moves`** — parts moving between volumes become visible.
+- **`system.dropped_tables`** — shows recently dropped tables with a retention window.
+- **`system.session_log`** — security: Login Attempts and Sessions pages become active.
+- **`system.processors_profile_log`** — Query Profiler page becomes active.
+
+### 23.x → 24.x
+
+- **`system.user_processes`** — per-user process tree (separate from `system.processes`). The User Processes page becomes active from 23.3.
+- **`system.part_log`** — part-level event history. Merge Performance anomaly detection becomes active.
+- **`system.query_metric_log`** — per-query resource metrics. Query Metric Log page becomes active.
+- **`system.query_cache`** — query result cache introspection. Query Cache page becomes active.
+- **`system.data_skipping_indices`** — skip index inspection in the Data Explorer becomes active.
+- **`system.view_refreshes`** — Refreshable Materialized Views become visible.
+- **`system.zookeeper_connection_log`** — detailed Keeper connection history (added in 25.8; dashboard shows a notice on older versions).
+
+### 24.x → 25.x
+
+- **`system.distributed_ddl_queue`** — Distributed DDL queue page becomes active.
+- **`system.asynchronous_metrics`** — extra background-metrics page becomes available.
+- **`system.replicated_merge_tree_settings`** — per-table replicated merge-tree settings page.
+
+### ClickHouse Keeper tables
+
+All Keeper-related pages (`system.zookeeper`, `system.zookeeper_connection`, `system.zookeeper_log`, `system.zookeeper_info`, `system.zookeeper_watches`) require ClickHouse Keeper or ZooKeeper to be configured. They appear as empty notices when Keeper is not set up.
+
+## After the upgrade
+
+### 1. Check the dashboard loads correctly
+
+Open `/overview` — if the page shows data, the basic connection and system-table grants are working.
+
+### 2. Check for new system tables
+
+The dashboard automatically picks up new tables if they become available. Look for pages that were previously showing "Table not available" notices:
+
+- **Merges → Merge Performance** — needs `system.part_log`
+- **Queries → Profiler** — needs `system.processors_profile_log`
+- **Security → Login Attempts** — needs `system.session_log`
+
+### 3. Validate from the AI agent
+
+Ask the agent:
+
+> "Compare the system tables available now with what the dashboard expects. Are any optional tables still missing?"
+
+The agent uses `list_tables` against `system` to enumerate available tables and the `system-tables-reference` skill to cross-check against the expected set.
+
+### 4. Re-check grants if you upgraded users
+
+ClickHouse sometimes changes system-table visibility across major versions. Confirm the monitoring user can still SELECT from the tables it uses:
+
+```sql
+-- Quick sanity check
+SELECT count() FROM system.query_log LIMIT 1;
+SELECT count() FROM system.processes LIMIT 1;
+SELECT count() FROM system.replicas LIMIT 1;
+```
+
+If any return a permission error, re-apply the grants from [ClickHouse User & Grants](/docs/getting-started/clickhouse-requirements).
+
+### 5. Check deprecated settings
+
+After a major upgrade, `system.settings` may contain settings marked deprecated. The Settings page flags these. Review and update your server config file accordingly.
+
+## Rolling upgrades on replicated clusters
+
+1. Upgrade one replica at a time.
+2. After each node upgrades, confirm it rejoins replication (`is_readonly = 0`, `queue_size` draining).
+3. The dashboard's Replication page shows per-table replica health across the cluster.
+4. Do not upgrade the next node until the previous one is fully caught up.
+
+## Related
+
+- [ClickHouse User & Grants](/docs/getting-started/clickhouse-requirements)
+- [Troubleshooting](/docs/guides/troubleshooting)
+- [Health probes](/docs/deploy/kubernetes#health-probes)


### PR DESCRIPTION
## Summary

- **#1939** — `features/mcp.mdx`: Add `:::caution[Secure by default]` aside documenting the 401-by-default behavior with explicit links to [API keys](/docs/authentication/api-keys) and [Clerk authentication](/docs/authentication/clerk).
- **#1940** — `ai-agent/capabilities.mdx`: Add per-tool reference table with each tool's exact name, description (sourced from `apps/dashboard/src/lib/ai/agent/tools/*.ts`), and destructive flag for `kill_query`, `kill_mutation`, `optimize_table`.
- **#1941** — New `docs/content/guides/upgrade-clickhouse.mdx`: pre-upgrade checklist (mutations, replication health, backups), version-by-version system-table availability changes from 22.x → 25.x, post-upgrade validation steps.
- **#1942** — New `docs/content/guides/troubleshooting.mdx`: connection failures, auth failures (401 / white screen), performance/timeouts, AI agent / LLM failures, k8s health probe debugging.
- **#1943** — New `docs/content/guides/proxy-auth-setup.mdx`: end-to-end setup for Cloudflare Access + Tunnel (`proxy` provider), nginx + oauth2-proxy (`trusted` provider), and Traefik ForwardAuth + Authelia (`trusted` provider). Env var names verified from `apps/dashboard/src/lib/auth/providers/proxy.ts` and `trusted.ts`.
- **#1944** — `getting-started/clickhouse-requirements.mdx`: per-feature grants checklist table (Feature | Required system tables | GRANT) derived from scanning `apps/dashboard/src/lib/query-config`. Includes optional tables (backup_log, error_log, session_log, Keeper tables, kafka_consumers) and action grants (KILL QUERY, OPTIMIZE).
- `apps/docs/astro.config.mjs`: Add Guides section to the sidebar (autogenerate from `guides/` directory).

## Test plan

- [ ] Verify `docs/content/guides/` pages render in `cd apps/docs && bun run dev`
- [ ] Check the Guides section appears in the sidebar
- [ ] Confirm the `:::caution` aside in mcp.mdx renders correctly (Starlight aside syntax)
- [ ] Spot-check tool names in capabilities.mdx against `apps/dashboard/src/lib/ai/agent/tools/index.ts`
- [ ] Verify grants table system table names against `apps/dashboard/src/lib/query-config/**/*.ts`

Closes #1939, #1940, #1941, #1942, #1943, #1944

https://claude.ai/code/session_01TnsycTkdMHJ4DXohpuz3oj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Guides” section to the docs navigation.
  * Published new guides for proxy authentication setup, troubleshooting, and safe ClickHouse upgrades.

* **Documentation**
  * Expanded the AI agent capabilities docs with a tool reference table.
  * Added clearer security and access notes for MCP availability.
  * Improved ClickHouse permissions guidance with a feature-by-feature grants checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->