### PR TITLE
fix(docs): correct deploy/env-var drift + add build-vs-runtime guide

### DIFF
--- a/docs/content/ai-agent/configuration.mdx
+++ b/docs/content/ai-agent/configuration.mdx
@@ -81,10 +81,10 @@ curl -H "Authorization: Bearer $AGENT_API_TOKEN" \
 
 ## Conversation persistence
 
-| Variable | Default | Purpose |
-|---|---|---|
-| `AGENT_CONVERSATION_PERSISTENCE` | `false` | Enable server-side conversation storage. |
-| `AGENT_CONVERSATION_STORE` | `auto` | Store backend. |
+| Variable | Type | Default | Purpose |
+|---|---|---|---|
+| `VITE_FEATURE_CONVERSATION_DB` | Build-time | `false` | Enable server-side conversation storage. Must be set before `bun run build`. Requires Clerk. |
+| `CONVERSATION_STORE_BACKEND` | Runtime | (auto) | Backend: `agentstate`, `d1`, `postgres`, or `memory`. Auto-selects when unset. |
 
 See [Conversation History](/docs/ai-agent/conversation-history) and [Store Backends](/docs/ai-agent/conversation-history/backends) for per-backend env vars and setup.
 

--- a/docs/content/ai-agent/conversation-history.mdx
+++ b/docs/content/ai-agent/conversation-history.mdx
@@ -6,7 +6,7 @@ Agent chat history is stored in **browser localStorage** by default. No server s
 
 ```mermaid
 flowchart TD
-    A[User sends message] --> B{Persistence enabled?}
+    A[User sends message] --> B{VITE_FEATURE_CONVERSATION_DB=true?}
     B -- No --> C[Browser localStorage]
     B -- Yes --> D{Authenticated?}
     D -- No --> C
@@ -23,12 +23,97 @@ flowchart TD
 
 ## Enable server persistence
 
+Server-side persistence requires two things:
+
+1. `VITE_FEATURE_CONVERSATION_DB=true` must be set **at build time** (before `bun run build`). This is a `VITE_*` variable — it is baked into the bundle and cannot be changed at runtime. It also requires Clerk auth to be active (`VITE_AUTH_PROVIDER=clerk`).
+2. A backend must be reachable at runtime.
+
 ```bash
-AGENT_CONVERSATION_PERSISTENCE=true
-AGENT_CONVERSATION_STORE=auto   # or a specific backend
+# In CI / build environment (before bun run build):
+VITE_FEATURE_CONVERSATION_DB=true
+VITE_AUTH_PROVIDER=clerk
+VITE_CLERK_PUBLISHABLE_KEY=pk_live_...
 ```
 
-With `auto`, the server picks the first available backend in priority order (AgentState → D1 → Durable Object → Postgres → ClickHouse). See [Store Backends](/docs/ai-agent/conversation-history/backends) for the full resolution order and per-backend setup.
+```bash
+# Runtime — select or force a backend:
+CONVERSATION_STORE_BACKEND=postgres   # or: agentstate, d1, memory
+DATABASE_URL=postgresql://user:pass@host:5432/db
+```
+
+When `CONVERSATION_STORE_BACKEND` is not set, the server auto-selects the first available backend in the order described below.
+
+## Backend resolution order
+
+When `CONVERSATION_STORE_BACKEND` is not set (or set to an unrecognized value), the server picks the first available backend in this order:
+
+1. **AgentState** — when `AGENTSTATE_API_KEY` is set and `CONVERSATION_STORE_BACKEND` is not `d1`, `postgres`, or `memory`.
+2. **Cloudflare D1** — when the `CONVERSATIONS_D1` binding is present (Cloudflare Workers only).
+3. **Postgres** — when `DATABASE_URL` is set.
+4. **Memory** — fallback in development/CI. Conversations are lost on process restart.
+
+You can force a specific backend by setting `CONVERSATION_STORE_BACKEND` to `agentstate`, `d1`, `postgres`, or `memory`.
+
+## AgentState self-host quickstart
+
+AgentState is a cloud-hosted conversation store. It works on any deployment target (Cloudflare Workers, Docker, Kubernetes, Vercel).
+
+1. Get an API key at [agentstate.app](https://agentstate.app).
+
+2. Set at build time:
+
+```bash
+VITE_FEATURE_CONVERSATION_DB=true
+VITE_AUTH_PROVIDER=clerk
+VITE_CLERK_PUBLISHABLE_KEY=pk_live_...
+```
+
+3. Set at runtime:
+
+```bash
+AGENTSTATE_API_KEY=as_live_...
+# CONVERSATION_STORE_BACKEND=agentstate  # optional — auto-selected when key is present
+```
+
+4. Optional: enable AI enrichment of stored conversation titles:
+
+```bash
+AGENTSTATE_AI_ENRICH=true
+```
+
+5. Deploy. No migrations needed — AgentState manages the schema.
+
+**Cloudflare Workers** — add via `wrangler secret put`:
+
+```bash
+wrangler secret put AGENTSTATE_API_KEY
+```
+
+```toml
+# wrangler.toml [vars]
+CONVERSATION_STORE_BACKEND = "agentstate"
+```
+
+**Docker:**
+
+```bash
+docker run -d --name chmonitor -p 3000:3000 \
+  -e AGENTSTATE_API_KEY='as_live_...' \
+  -e CONVERSATION_STORE_BACKEND='agentstate' \
+  ghcr.io/duyet/chmonitor:vX.Y.Z
+```
+
+**Kubernetes:**
+
+```bash
+kubectl create secret generic chmonitor-agentstate \
+  --from-literal=AGENTSTATE_API_KEY='as_live_...'
+```
+
+```yaml
+# in ConfigMap
+CONVERSATION_STORE_BACKEND: "agentstate"
+```
 
 ## Request / response flow
 
@@ -55,7 +140,7 @@ Server stores require an authenticated user identity to namespace threads. If th
 
 ## Deprecated alias
 
-`NEXT_PUBLIC_FEATURE_CONVERSATION_DB=true` is accepted as an alias for `AGENT_CONVERSATION_PERSISTENCE=true` but is deprecated. Do not use it for new deployments.
+`NEXT_PUBLIC_FEATURE_CONVERSATION_DB=true` is accepted as an alias for `VITE_FEATURE_CONVERSATION_DB=true` but is deprecated. Do not use it for new deployments.
 
 ## Next steps
 

--- a/docs/content/ai-agent/conversation-history/backends.mdx
+++ b/docs/content/ai-agent/conversation-history/backends.mdx
@@ -1,40 +1,35 @@
 # Conversation store backends
 
-Configure `AGENT_CONVERSATION_STORE` to one of the values below. All stores require `AGENT_CONVERSATION_PERSISTENCE=true`.
+All server-side backends require `VITE_FEATURE_CONVERSATION_DB=true` set at **build time** (before `bun run build`; this is a `VITE_*` build-time variable). Set `CONVERSATION_STORE_BACKEND` at runtime to force a specific backend, or leave it unset to auto-select.
 
 ## Platform recommendation
 
 | Platform | Recommended store | Why |
 |---|---|---|
 | Cloudflare Workers | `d1` | Managed SQL, easy to inspect/migrate/export |
-| Cloudflare Workers (per-user isolation) | `durable-object` | Strictly colocated per-user state |
-| Docker / self-hosted | `clickhouse` or `postgres` | Reuse existing infrastructure |
+| Docker / self-hosted | `postgres` | Reuse existing infrastructure |
 | Kubernetes | `postgres` | Standard managed database pattern |
-| Vercel | `postgres` | Works with Vercel Postgres or any external PG |
-| Local development | `local` or `memory` | No setup; data is ephemeral |
+| Any platform | `agentstate` | Cloud-hosted, no infrastructure to manage |
+| Local development | `memory` | No setup; data is ephemeral |
 
-## `auto` — automatic selection
+## Auto-selection order
 
-`auto` picks the first available backend in this order:
+When `CONVERSATION_STORE_BACKEND` is not set, the server picks the first available backend:
 
-1. **AgentState** — when `AGENTSTATE_API_KEY` is set
-2. **D1** — when the `CONVERSATIONS_D1` binding is present
-3. **Durable Object** — when the `AGENT_CONVERSATIONS_DO` binding is present
-4. **Postgres** — when `DATABASE_URL`, `POSTGRES_URL`, or `POSTGRES_PRISMA_URL` is set
-5. **ClickHouse** — only when `CLICKHOUSE_AGENT_CONVERSATIONS_TABLE` is explicitly set
-6. **Memory** — in development/test only
-
-In production, `auto` fails closed when no persistent backend is configured (does not silently fall through to memory).
+1. **AgentState** — when `AGENTSTATE_API_KEY` is set and `CONVERSATION_STORE_BACKEND` is not explicitly `d1`, `postgres`, or `memory`.
+2. **Cloudflare D1** — when the `CONVERSATIONS_D1` binding is present (Cloudflare Workers only).
+3. **Postgres** — when `DATABASE_URL` is set.
+4. **Memory** — fallback in development/CI.
 
 ## AgentState
 
-Cloud-hosted conversation store. Requires an `as_live_` prefixed key.
+Cloud-hosted conversation store. Works on all platforms. Requires an `as_live_` prefixed key.
 
 ```bash
-AGENT_CONVERSATION_PERSISTENCE=true
-AGENT_CONVERSATION_STORE=agentstate
 AGENTSTATE_API_KEY=as_live_xxx
-AGENTSTATE_API_BASE=https://agentstate.app/api
+# AGENTSTATE_BASE_URL=https://agentstate.app/api   # optional override
+# AGENTSTATE_AI_ENRICH=true                        # optional AI title enrichment
+# CONVERSATION_STORE_BACKEND=agentstate             # optional — auto-selected when key is present
 ```
 
 ## Cloudflare D1
@@ -42,8 +37,7 @@ AGENTSTATE_API_BASE=https://agentstate.app/api
 Cloudflare-only. Requires a provisioned D1 database and a Worker binding.
 
 ```bash
-AGENT_CONVERSATION_PERSISTENCE=true
-AGENT_CONVERSATION_STORE=d1
+CONVERSATION_STORE_BACKEND=d1
 CONVERSATIONS_D1_DATABASE_ID=<uuid>
 ```
 
@@ -60,72 +54,33 @@ Also accepts `AGENT_CONVERSATIONS_D1_DATABASE_ID` as an alias for `CONVERSATIONS
 
 **When to use:** standard Cloudflare deployments that want queryable, exportable conversation history.
 
-## Durable Object
-
-Cloudflare-only. Each user gets one Durable Object backed by SQLite.
-
-```bash
-AGENT_CONVERSATION_PERSISTENCE=true
-AGENT_CONVERSATION_STORE=durable-object
-AGENT_CONVERSATIONS_DO_BINDING=AGENT_CONVERSATIONS_DO
-```
-
-`AGENT_CONVERSATIONS_DO_BINDING` defaults to `AGENT_CONVERSATIONS_DO`; only set it to override. No migration step — the schema is created automatically inside the object.
-
-**When to use:** strictly colocated per-user state, or when you need transactional consistency within a user's history. For queryable history prefer D1.
-
-## ClickHouse
-
-Uses the same ClickHouse cluster the dashboard already connects to.
-
-```bash
-AGENT_CONVERSATION_PERSISTENCE=true
-AGENT_CONVERSATION_STORE=clickhouse
-CLICKHOUSE_AGENT_CONVERSATIONS_TABLE=system.agent_conversations
-CLICKHOUSE_AGENT_CONVERSATIONS_AUTO_CREATE=true
-```
-
-`CLICKHOUSE_AGENT_CONVERSATIONS_TABLE` defaults to `${CLICKHOUSE_DATABASE}.agent_conversations`. Set it explicitly to include ClickHouse in `auto` resolution. With `CLICKHOUSE_AGENT_CONVERSATIONS_AUTO_CREATE=true` the table is created on first write (requires `CREATE TABLE` privilege). The ClickHouse user needs `INSERT` and `SELECT` on the conversation table.
-
-The table uses `ReplacingMergeTree` with async inserts. Deletes are tombstone rows.
-
-**When to use:** Docker or self-hosted deployments that already run ClickHouse and want to avoid a second database.
-
 ## Postgres
 
 Any PostgreSQL-compatible database.
 
 ```bash
-AGENT_CONVERSATION_PERSISTENCE=true
-AGENT_CONVERSATION_STORE=postgres
+CONVERSATION_STORE_BACKEND=postgres
 DATABASE_URL=postgresql://user:password@host:5432/db
 ```
 
 Also accepts `POSTGRES_URL` or `POSTGRES_PRISMA_URL` instead of `DATABASE_URL`. The runtime creates the `conversations` table and indexes if they do not exist. The database user needs `CREATE TABLE`, `CREATE INDEX`, `SELECT`, `INSERT`, `UPDATE`, and `DELETE` on the target schema.
 
-**When to use:** Kubernetes, Vercel, or any deployment with an existing Postgres instance.
+**When to use:** Kubernetes, Docker, or any deployment with an existing Postgres instance.
 
 ## Memory
 
 Ephemeral in-process store. Lost on process restart.
 
 ```bash
-AGENT_CONVERSATION_PERSISTENCE=true
-AGENT_CONVERSATION_STORE=memory
+CONVERSATION_STORE_BACKEND=memory
 ```
 
-Use only in development or tests. Not accepted as production persistent storage.
+Use only in development or tests.
 
-## Local (browser)
+## Browser (default)
 
-Default when persistence is off. No server config needed.
-
-```bash
-AGENT_CONVERSATION_STORE=local
-```
-
-History is stored in browser localStorage. Clearing browser data loses history. Unauthenticated sessions always use this backend even when server persistence is on.
+Default when `VITE_FEATURE_CONVERSATION_DB` is not `true` or when the user is unauthenticated. No server config needed. History is stored in browser localStorage. Clearing browser data loses history.
 
 ## Deprecated alias
 
-`NEXT_PUBLIC_FEATURE_CONVERSATION_DB=true` is equivalent to `AGENT_CONVERSATION_PERSISTENCE=true` but is deprecated. Do not use it for new deployments.
+`NEXT_PUBLIC_FEATURE_CONVERSATION_DB=true` is equivalent to `VITE_FEATURE_CONVERSATION_DB=true` but is deprecated. Do not use it for new deployments.

--- a/docs/content/deploy/cloudflare.mdx
+++ b/docs/content/deploy/cloudflare.mdx
@@ -70,13 +70,11 @@ CLICKHOUSE_USER = "monitoring"
 CLICKHOUSE_NAME = "prod"
 CLICKHOUSE_MAX_EXECUTION_TIME = "30"
 CLICKHOUSE_TZ = "UTC"
-NEXT_QUERY_CACHE_TTL = "3600"
 CLICKHOUSE_POOL_SIZE = "10"
 CLOUDFLARE_WORKERS = "1"
 HEALTH_ALERT_ENABLED = "true"
 HEALTH_ALERT_MIN_SEVERITY = "warning"
-AGENT_CONVERSATION_STORE = "d1"
-AGENT_CONVERSATION_PERSISTENCE = "true"
+CONVERSATION_STORE_BACKEND = "d1"
 CHM_AUTH_PROVIDER = "none"
 LLM_API_BASE = "https://openrouter.ai/api/v1"
 LLM_MODEL = "openrouter/free"
@@ -133,7 +131,6 @@ CLICKHOUSE_NAME = "shard-1,shard-2"
 [vars]
 CLICKHOUSE_MAX_EXECUTION_TIME = "30"
 CLICKHOUSE_TZ = "UTC"
-NEXT_QUERY_CACHE_TTL = "3600"
 CLICKHOUSE_DATABASE = "system"
 CLICKHOUSE_POOL_SIZE = "10"
 CLICKHOUSE_POOL_TIMEOUT = "300000"
@@ -238,6 +235,8 @@ Never put `LLM_API_KEY` in a `VITE_*` var or `[vars]` — use `wrangler secret p
 
 ### Conversation store
 
+Server-side persistence requires `VITE_FEATURE_CONVERSATION_DB=true` set **at build time** (in CI before `bun run build`), plus Clerk auth. The backend is then selected at runtime.
+
 **D1 (Cloudflare-native, recommended):**
 
 Create a D1 database:
@@ -257,9 +256,15 @@ database_id = "<database-id-from-above>"
 
 ```toml
 [vars]
-AGENT_CONVERSATION_PERSISTENCE = "true"
-AGENT_CONVERSATION_STORE = "d1"
+CONVERSATION_STORE_BACKEND = "d1"
 CONVERSATIONS_D1_DATABASE_ID = "<database-id>"
+```
+
+In CI, also set `VITE_FEATURE_CONVERSATION_DB=true` before the build step:
+
+```bash
+# In your CI environment or GitHub Actions secrets:
+VITE_FEATURE_CONVERSATION_DB=true
 ```
 
 Run migrations:
@@ -268,15 +273,18 @@ Run migrations:
 bun run cf:migrate-conversations
 ```
 
-**Durable Object store:**
+**AgentState (cloud-hosted):**
 
 ```toml
 [vars]
-AGENT_CONVERSATION_STORE = "durable-object"
-AGENT_CONVERSATIONS_DO_BINDING = "AGENT_CONVERSATIONS_DO"
+CONVERSATION_STORE_BACKEND = "agentstate"
 ```
 
-**ClickHouse or Postgres:** also available on Cloudflare Workers via outbound HTTP.
+```bash
+wrangler secret put AGENTSTATE_API_KEY
+```
+
+**Postgres:** also available on Cloudflare Workers via outbound HTTP (`DATABASE_URL` runtime secret).
 
 ### Health alerting — Cron Trigger
 

--- a/docs/content/deploy/docker.mdx
+++ b/docs/content/deploy/docker.mdx
@@ -82,7 +82,6 @@ docker run -d --name chmonitor -p 3000:3000 \
 ```bash
 -e CLICKHOUSE_MAX_EXECUTION_TIME='30' \
 -e CLICKHOUSE_TZ='UTC' \
--e NEXT_QUERY_CACHE_TTL='3600' \
 -e CLICKHOUSE_DATABASE='system' \
 -e CLICKHOUSE_POOL_SIZE='10' \
 -e CLICKHOUSE_POOL_TIMEOUT='300000' \
@@ -93,7 +92,6 @@ docker run -d --name chmonitor -p 3000:3000 \
 |---|---|---|
 | `CLICKHOUSE_MAX_EXECUTION_TIME` | `60` | Query timeout in seconds |
 | `CLICKHOUSE_TZ` | — | Timezone for ClickHouse queries |
-| `NEXT_QUERY_CACHE_TTL` | `3600` | Query cache TTL in seconds |
 | `CLICKHOUSE_DATABASE` | `system` | Default database |
 | `CLICKHOUSE_POOL_SIZE` | `10` | Connection pool size |
 | `CLICKHOUSE_POOL_TIMEOUT` | `300000` | Pool acquire timeout (ms) |
@@ -205,38 +203,26 @@ Set `CHM_FEATURE_AGENT_ACCESS=authenticated` to require login before using the a
 
 ### Conversation store
 
-```bash
-# Enable server-side persistence (default: browser localStorage)
--e AGENT_CONVERSATION_PERSISTENCE='true' \
--e AGENT_CONVERSATION_STORE='auto'
-```
+Server-side persistence requires `VITE_FEATURE_CONVERSATION_DB=true` to be baked into the image at build time (it is a `VITE_*` build-time variable). The pre-built image from GHCR has this disabled by default. Build a custom image with this flag set if you need server-side persistence on Docker.
 
-Available stores on Docker: `auto`, `clickhouse`, `postgres`, `memory`, `agentstate`.
+At runtime, set the backend via `CONVERSATION_STORE_BACKEND`. Available backends on Docker: `postgres`, `agentstate`, `memory`.
 
-**ClickHouse store:**
+**Postgres store (recommended on Docker):**
 
 ```bash
--e AGENT_CONVERSATION_STORE='clickhouse' \
--e CLICKHOUSE_AGENT_CONVERSATIONS_TABLE='system.agent_conversations' \
--e CLICKHOUSE_AGENT_CONVERSATIONS_AUTO_CREATE='true'
-```
-
-**Postgres store:**
-
-```bash
--e AGENT_CONVERSATION_STORE='postgres' \
+-e CONVERSATION_STORE_BACKEND='postgres' \
 -e DATABASE_URL='postgresql://user:pass@host:5432/dbname'
 ```
 
 **AgentState store:**
 
 ```bash
--e AGENT_CONVERSATION_STORE='agentstate' \
+-e CONVERSATION_STORE_BACKEND='agentstate' \
 -e AGENTSTATE_API_KEY='as_live_...' \
--e AGENTSTATE_API_BASE='https://agentstate.app/api'
+-e AGENTSTATE_BASE_URL='https://agentstate.app/api'
 ```
 
-D1 and Durable Object stores are Cloudflare-only; use `clickhouse` or `postgres` on Docker.
+D1 and Durable Object stores are Cloudflare-only. When `CONVERSATION_STORE_BACKEND` is unset and `AGENTSTATE_API_KEY` is present, AgentState is selected automatically; if `DATABASE_URL` is set, Postgres is used instead.
 
 ### Health alerting
 

--- a/docs/content/deploy/k8s.mdx
+++ b/docs/content/deploy/k8s.mdx
@@ -35,8 +35,10 @@ helm uninstall my-chm
 
 ### From the OCI registry (GHCR)
 
+Replace `vX.Y.Z` with the latest release tag from [GitHub Releases](https://github.com/duyet/clickhouse-monitoring/releases).
+
 ```bash
-helm install my-chm oci://ghcr.io/duyet/chmonitor --version 0.2.9 \
+helm install my-chm oci://ghcr.io/duyet/chmonitor --version vX.Y.Z \
   --set clickhouse.host="https://clickhouse.example.com:8443" \
   --set clickhouse.user="monitoring" \
   --set clickhouse.password="change-me"
@@ -45,7 +47,7 @@ helm install my-chm oci://ghcr.io/duyet/chmonitor --version 0.2.9 \
 Pull and inspect the chart before installing:
 
 ```bash
-helm pull oci://ghcr.io/duyet/chmonitor --version 0.2.9 --untar
+helm pull oci://ghcr.io/duyet/chmonitor --version vX.Y.Z --untar
 helm show values ./chmonitor
 ```
 
@@ -73,7 +75,7 @@ Example `values.yaml`:
 
 ```yaml
 image:
-  tag: "0.2.9"
+  tag: "vX.Y.Z"   # use the latest release tag from https://github.com/duyet/clickhouse-monitoring/releases
 
 clickhouse:
   host: "https://clickhouse.example.com:8443"
@@ -203,7 +205,6 @@ metadata:
 data:
   CLICKHOUSE_MAX_EXECUTION_TIME: "30"
   CLICKHOUSE_TZ: "UTC"
-  NEXT_QUERY_CACHE_TTL: "3600"
   CLICKHOUSE_DATABASE: "system"
   CLICKHOUSE_POOL_SIZE: "10"
   CLICKHOUSE_POOL_TIMEOUT: "300000"
@@ -354,19 +355,11 @@ Set `CHM_FEATURE_AGENT_ACCESS=authenticated` in the ConfigMap to require login. 
 
 **Default:** browser localStorage — no server config needed.
 
-**Enable server-side persistence:**
+Server-side persistence requires `VITE_FEATURE_CONVERSATION_DB=true` baked into the image at build time (a `VITE_*` build-time variable). Build a custom image with this flag to enable it. At runtime, set the backend via `CONVERSATION_STORE_BACKEND` in a ConfigMap.
 
-```yaml
-# in ConfigMap
-AGENT_CONVERSATION_PERSISTENCE: "true"
-AGENT_CONVERSATION_STORE: "clickhouse"
-CLICKHOUSE_AGENT_CONVERSATIONS_TABLE: "system.agent_conversations"
-CLICKHOUSE_AGENT_CONVERSATIONS_AUTO_CREATE: "true"
-```
+On Kubernetes, use `postgres` or `agentstate` for the conversation store. D1 and Durable Object stores are Cloudflare-only.
 
-On Kubernetes, use `clickhouse` or `postgres` for the conversation store. D1 and Durable Object stores are Cloudflare-only.
-
-**Postgres store:**
+**Postgres store (recommended on Kubernetes):**
 
 ```bash
 kubectl create secret generic chmonitor-postgres \
@@ -375,7 +368,19 @@ kubectl create secret generic chmonitor-postgres \
 
 ```yaml
 # in ConfigMap
-AGENT_CONVERSATION_STORE: "postgres"
+CONVERSATION_STORE_BACKEND: "postgres"
+```
+
+**AgentState store:**
+
+```bash
+kubectl create secret generic chmonitor-agentstate \
+  --from-literal=AGENTSTATE_API_KEY='as_live_...'
+```
+
+```yaml
+# in ConfigMap
+CONVERSATION_STORE_BACKEND: "agentstate"
 ```
 
 ### Health alerting

--- a/docs/content/deploy/production-checklist.mdx
+++ b/docs/content/deploy/production-checklist.mdx
@@ -47,7 +47,6 @@ Review each section before exposing chmonitor to a team or the internet.
 
 - [ ] Set `CLICKHOUSE_MAX_EXECUTION_TIME` below your infrastructure's request timeout (30 s is a safe default).
 - [ ] Tune `CLICKHOUSE_POOL_SIZE` to match expected concurrent dashboard users.
-- [ ] Set `NEXT_QUERY_CACHE_TTL` to a value that balances freshness and query load (default `3600` s).
 
 ## Conversation store backups
 

--- a/docs/content/deploy/self-host.mdx
+++ b/docs/content/deploy/self-host.mdx
@@ -33,7 +33,6 @@ CLICKHOUSE_PASSWORD=change-me
 CLICKHOUSE_NAME=prod
 CLICKHOUSE_MAX_EXECUTION_TIME=30
 CLICKHOUSE_TZ=UTC
-NEXT_QUERY_CACHE_TTL=3600
 EOF
 
 bun run start
@@ -67,7 +66,6 @@ export CLICKHOUSE_NAME='shard-1,shard-2'
 |---|---|---|
 | `CLICKHOUSE_MAX_EXECUTION_TIME` | `60` | Query timeout in seconds |
 | `CLICKHOUSE_TZ` | — | Timezone for queries |
-| `NEXT_QUERY_CACHE_TTL` | `3600` | Query cache TTL in seconds |
 | `CLICKHOUSE_DATABASE` | `system` | Default database |
 | `CLICKHOUSE_POOL_SIZE` | `10` | Connection pool size |
 | `CLICKHOUSE_POOL_TIMEOUT` | `300000` | Pool acquire timeout (ms) |
@@ -184,23 +182,22 @@ Keep `LLM_API_KEY` server-side — never set it as a `VITE_*` variable.
 
 ### Conversation store
 
-**Default:** browser localStorage.
+**Default:** browser localStorage. No server config needed.
 
-**ClickHouse store:**
+Server-side persistence requires `VITE_FEATURE_CONVERSATION_DB=true` set at build time (a `VITE_*` build-time variable). Build a custom image or binary with this flag set. At runtime, select the backend:
+
+**Postgres store (recommended for self-host):**
 
 ```bash
-export AGENT_CONVERSATION_PERSISTENCE='true'
-export AGENT_CONVERSATION_STORE='clickhouse'
-export CLICKHOUSE_AGENT_CONVERSATIONS_TABLE='system.agent_conversations'
-export CLICKHOUSE_AGENT_CONVERSATIONS_AUTO_CREATE='true'
+export CONVERSATION_STORE_BACKEND='postgres'
+export DATABASE_URL='postgresql://user:pass@host:5432/dbname'
 ```
 
-**Postgres store:**
+**AgentState store:**
 
 ```bash
-export AGENT_CONVERSATION_PERSISTENCE='true'
-export AGENT_CONVERSATION_STORE='postgres'
-export DATABASE_URL='postgresql://user:pass@host:5432/dbname'
+export CONVERSATION_STORE_BACKEND='agentstate'
+export AGENTSTATE_API_KEY='as_live_...'
 ```
 
 D1 and Durable Object stores are Cloudflare-only.

--- a/docs/content/deploy/vercel.mdx
+++ b/docs/content/deploy/vercel.mdx
@@ -1,10 +1,12 @@
 # Vercel
 
-Deploy chmonitor to Vercel. This targets the legacy Next.js build (v0.2 and earlier). The current TanStack app (`apps/dashboard`) targets Cloudflare Workers; use [Cloudflare](/docs/deploy/cloudflare) for that.
+:::caution[Legacy guide — Next.js v0.2 only]
+This guide targets the **legacy Next.js build (v0.2 and earlier)**. The current app (`apps/dashboard`, TanStack Start, v0.3+) is designed for Cloudflare Workers. If you are running v0.3 or later, use [Cloudflare Workers](/docs/deploy/cloudflare) or [Docker](/docs/deploy/docker) instead.
+:::
 
 ## Quick start
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fduyet%2Fclickhouse-monitoring&env=CLICKHOUSE_HOST,CLICKHOUSE_USER,CLICKHOUSE_PASSWORD,CLICKHOUSE_MAX_EXECUTION_TIME,CLICKHOUSE_TZ,NEXT_QUERY_CACHE_TTL)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fduyet%2Fclickhouse-monitoring&env=CLICKHOUSE_HOST,CLICKHOUSE_USER,CLICKHOUSE_PASSWORD,CLICKHOUSE_MAX_EXECUTION_TIME,CLICKHOUSE_TZ)
 
 Or deploy manually:
 
@@ -62,7 +64,6 @@ CLICKHOUSE_NAME=primary,replica
 |---|---|---|
 | `CLICKHOUSE_MAX_EXECUTION_TIME` | `60` | Query timeout in seconds |
 | `CLICKHOUSE_TZ` | — | Timezone for queries |
-| `NEXT_QUERY_CACHE_TTL` | `3600` | Query cache TTL in seconds |
 | `CLICKHOUSE_DATABASE` | `system` | Default database |
 | `CLICKHOUSE_POOL_SIZE` | `10` | Connection pool size |
 | `CLICKHOUSE_POOL_TIMEOUT` | `300000` | Pool acquire timeout (ms) |
@@ -143,26 +144,16 @@ Never use `NEXT_PUBLIC_LLM_API_KEY` — keep the key server-side only.
 
 **Default:** browser localStorage — no server config needed.
 
-On Vercel, use `postgres` or `clickhouse` for server-side persistence. D1 and Durable Object stores are Cloudflare-only.
+On Vercel (Next.js v0.2), use `postgres` for server-side persistence. D1 and Durable Object stores are Cloudflare-only.
 
 **Postgres (recommended on Vercel):**
 
 ```
-AGENT_CONVERSATION_PERSISTENCE=true
-AGENT_CONVERSATION_STORE=postgres
+CONVERSATION_STORE_BACKEND=postgres
 DATABASE_URL=postgresql://user:pass@host:5432/dbname
 ```
 
 Vercel Postgres, Neon, and Supabase all work. Add `DATABASE_URL` in the Vercel dashboard.
-
-**ClickHouse store:**
-
-```
-AGENT_CONVERSATION_PERSISTENCE=true
-AGENT_CONVERSATION_STORE=clickhouse
-CLICKHOUSE_AGENT_CONVERSATIONS_TABLE=system.agent_conversations
-CLICKHOUSE_AGENT_CONVERSATIONS_AUTO_CREATE=true
-```
 
 ### Health alerting
 

--- a/docs/content/faq.mdx
+++ b/docs/content/faq.mdx
@@ -72,20 +72,18 @@ Check that `LLM_API_KEY` is set and that `LLM_API_BASE` points at a reachable Op
 
 **Agent conversation history disappears after I close the browser.**
 
-By default, history lives in browser `localStorage`. To persist it server-side, set:
+By default, history lives in browser `localStorage`. To persist it server-side:
 
-```bash
-AGENT_CONVERSATION_PERSISTENCE=true
-AGENT_CONVERSATION_STORE=auto
-```
+1. Set `VITE_FEATURE_CONVERSATION_DB=true` at build time (before `bun run build`). Also requires Clerk auth.
+2. Set `CONVERSATION_STORE_BACKEND` at runtime to `agentstate`, `d1`, `postgres`, or `memory`.
 
-Then configure a backend store (AgentState, D1, ClickHouse, Postgres). See [Store Backends](/docs/ai-agent/conversation-history/backends).
+See [Conversation History](/docs/ai-agent/conversation-history) and [Store Backends](/docs/ai-agent/conversation-history/backends).
 
 ## Data freshness
 
 **The dashboard shows stale data.**
 
-The app caches query results. Lower `NEXT_QUERY_CACHE_TTL` (default 3600 seconds) for fresher data at the cost of more ClickHouse queries. In the TanStack app, client-side SWR also revalidates on focus and on a polling interval.
+The TanStack app revalidates data on focus and on a polling interval. Reduce `CLICKHOUSE_MAX_EXECUTION_TIME` if queries are taking too long, or adjust the client-side refresh interval per chart.
 
 ## Deployment
 

--- a/docs/content/features/dashboard.mdx
+++ b/docs/content/features/dashboard.mdx
@@ -56,7 +56,6 @@ No feature-specific server configuration. The dashboard layout is stored in the 
 ```bash
 # Global query settings still apply to every chart on the dashboard
 CLICKHOUSE_MAX_EXECUTION_TIME=60
-NEXT_QUERY_CACHE_TTL=3600
 ```
 
 ## Notes & limitations

--- a/docs/content/features/operations.mdx
+++ b/docs/content/features/operations.mdx
@@ -59,7 +59,6 @@ No feature-specific configuration. Global settings apply:
 
 ```bash
 CLICKHOUSE_MAX_EXECUTION_TIME=60
-NEXT_QUERY_CACHE_TTL=3600
 ```
 
 ## Notes & limitations

--- a/docs/content/features/overview.mdx
+++ b/docs/content/features/overview.mdx
@@ -59,7 +59,6 @@ No feature-specific configuration. The refresh interval and caching behaviour fo
 
 ```bash
 CLICKHOUSE_MAX_EXECUTION_TIME=60   # query timeout in seconds
-NEXT_QUERY_CACHE_TTL=3600          # server-side cache TTL in seconds
 ```
 
 ## Notes & limitations

--- a/docs/content/features/queries.mdx
+++ b/docs/content/features/queries.mdx
@@ -69,7 +69,6 @@ No feature-specific configuration beyond the global query settings:
 
 ```bash
 CLICKHOUSE_MAX_EXECUTION_TIME=60   # per-query timeout in seconds
-NEXT_QUERY_CACHE_TTL=3600          # server-side cache TTL in seconds
 ```
 
 ## Notes & limitations

--- a/docs/content/migrating/v0-3.mdx
+++ b/docs/content/migrating/v0-3.mdx
@@ -250,7 +250,7 @@ v0.3 adds optional new configuration. None is required for the upgrade — set t
 | `CHM_CF_ACCESS_TEAM_DOMAIN` + `CHM_CF_ACCESS_AUD` | Cloudflare Access proxy auth |
 | `CHM_PROXY_AUTH_SECRET` | Trusted-header proxy auth |
 | `HEALTH_ALERT_ENABLED` + `HEALTH_ALERT_WEBHOOK_URL` | Health alerting cron sweep |
-| `AGENT_CONVERSATION_PERSISTENCE` + `AGENT_CONVERSATION_STORE` | Server-side conversation history |
+| `VITE_FEATURE_CONVERSATION_DB` (build-time) + `CONVERSATION_STORE_BACKEND` (runtime) | Server-side conversation history |
 
 See [Environment Variables](/docs/reference/environment-variables) for the full list.
 

--- a/docs/content/reference/configuration.mdx
+++ b/docs/content/reference/configuration.mdx
@@ -60,7 +60,7 @@ Full reference: [Environment Variables — ClickHouse Connection](/docs/referenc
 
 Controls timeouts, caching, and the connection pool. Defaults are sensible; override only if needed.
 
-Key variables: `CLICKHOUSE_MAX_EXECUTION_TIME` (60 s), `NEXT_QUERY_CACHE_TTL` (3600 s), `CLICKHOUSE_POOL_SIZE` (10).
+Key variables: `CLICKHOUSE_MAX_EXECUTION_TIME` (60 s), `CLICKHOUSE_POOL_SIZE` (10).
 
 Full reference: [Environment Variables — Query Execution](/docs/reference/environment-variables#query-execution).
 
@@ -119,11 +119,14 @@ Full reference: [AI Agent — Configuration](/docs/ai-agent/configuration).
 
 ### Conversation store
 
-Agent conversations default to browser localStorage. Enable server persistence with:
+Agent conversations default to browser localStorage. Enable server persistence:
 
 ```bash
-AGENT_CONVERSATION_PERSISTENCE=true
-AGENT_CONVERSATION_STORE=auto   # picks the best available backend
+# Build time (before bun run build); also requires VITE_AUTH_PROVIDER=clerk:
+VITE_FEATURE_CONVERSATION_DB=true
+
+# Runtime — force a backend (optional; auto-selects when unset):
+CONVERSATION_STORE_BACKEND=agentstate   # or: d1, postgres, memory
 ```
 
 Full reference: [Conversation History — Backends](/docs/ai-agent/conversation-history/backends).

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -19,6 +19,21 @@ Authoritative example: [`apps/dashboard/.env.example`](https://github.com/duyet/
 
 ---
 
+## Build-time vs runtime
+
+There are two categories of environment variables:
+
+| Category | When resolved | How to set | Example |
+|---|---|---|---|
+| **Build-time** | When `bun run build` runs | CI environment / shell before the build | `VITE_FEATURE_CONVERSATION_DB`, `VITE_AUTH_PROVIDER`, `VITE_CLERK_PUBLISHABLE_KEY` |
+| **Runtime** | When the server process starts per request | `wrangler.toml [vars]`, `wrangler secret put`, Docker `-e`, k8s ConfigMap/Secret | `CLICKHOUSE_HOST`, `CONVERSATION_STORE_BACKEND` |
+
+`VITE_*` vars are always build-time. They are inlined into the browser bundle and cannot be changed without a rebuild. Setting a `VITE_*` var in `wrangler.toml [vars]` or as a Docker `-e` flag has no effect on the running app — the bundle already has the value from when it was built.
+
+All other vars (unless noted) are runtime — read from `process.env` when the Worker or Node process handles a request.
+
+---
+
 ## ClickHouse Connection
 
 Required. Set at least `CLICKHOUSE_HOST`.
@@ -42,7 +57,6 @@ See [Multiple Hosts](/docs/advanced/multiple-hosts) and [Custom Name](/docs/adva
 |---|---|---|
 | `CLICKHOUSE_MAX_EXECUTION_TIME` | `60` | Query timeout in seconds. |
 | `CLICKHOUSE_TZ` | server default | Time zone for date/time display. |
-| `NEXT_QUERY_CACHE_TTL` | `3600` | Server-side query-result cache TTL in seconds. |
 | `CLICKHOUSE_DATABASE` | `system` | Database used for app-owned tables (self-tracking events, dashboards). |
 | `EVENTS_TABLE_NAME` | `system.monitoring_events` | Full table name override for self-tracking events. |
 
@@ -214,19 +228,23 @@ See [AI Agent — Configuration](/docs/ai-agent/configuration) for full details.
 
 ## Conversation Store
 
-Agent conversations default to browser localStorage. Enable server-side persistence with `AGENT_CONVERSATION_PERSISTENCE=true`.
+Agent conversations default to browser localStorage. Enable server-side persistence with two steps:
+
+1. Set `VITE_FEATURE_CONVERSATION_DB=true` at **build time** (this is a `VITE_*` variable — must be set before `bun run build`). Also requires Clerk auth (`VITE_AUTH_PROVIDER=clerk`).
+2. Configure a backend at runtime via `CONVERSATION_STORE_BACKEND`.
 
 | Variable | Default | Description |
 |---|---|---|
-| `AGENT_CONVERSATION_PERSISTENCE` | `false` | Enable server-side conversation persistence. |
-| `AGENT_CONVERSATION_STORE` | `auto` | Backend: `auto`, `agentstate`, `d1`, `durable-object`, `clickhouse`, `postgres`, `memory`, or `local`. |
+| `VITE_FEATURE_CONVERSATION_DB` | `false` | **Build-time.** Set `true` to enable server-side conversation persistence. Requires Clerk. Must be set before `bun run build`. |
+| `CONVERSATION_STORE_BACKEND` | (auto) | **Runtime.** Backend: `agentstate`, `d1`, `postgres`, or `memory`. When unset, the server auto-selects the first available backend (AgentState if key present → D1 binding → Postgres via `DATABASE_URL` → Memory). |
 
 **AgentState backend:**
 
 | Variable | Default | Description |
 |---|---|---|
-| `AGENTSTATE_API_KEY` | — | AgentState API key. Must start with `as_live_`. |
-| `AGENTSTATE_API_BASE` | `https://agentstate.app/api` | AgentState API base URL. |
+| `AGENTSTATE_API_KEY` | — | AgentState API key. Required when `CONVERSATION_STORE_BACKEND=agentstate`. |
+| `AGENTSTATE_BASE_URL` | `https://agentstate.app/api` | AgentState API base URL. |
+| `AGENTSTATE_AI_ENRICH` | `false` | Set `true` to enable AI enrichment of stored conversations. |
 
 **Cloudflare D1 backend:**
 
@@ -234,19 +252,6 @@ Agent conversations default to browser localStorage. Enable server-side persiste
 |---|---|---|
 | `CONVERSATIONS_D1_DATABASE_ID` | — | Cloudflare D1 database UUID for the `CONVERSATIONS_D1` binding. |
 | `AGENT_CONVERSATIONS_D1_DATABASE_ID` | — | Alias for `CONVERSATIONS_D1_DATABASE_ID`. |
-
-**Cloudflare Durable Object backend:**
-
-| Variable | Default | Description |
-|---|---|---|
-| `AGENT_CONVERSATIONS_DO_BINDING` | `AGENT_CONVERSATIONS_DO` | Durable Object binding name. |
-
-**ClickHouse backend:**
-
-| Variable | Default | Description |
-|---|---|---|
-| `CLICKHOUSE_AGENT_CONVERSATIONS_TABLE` | `${CLICKHOUSE_DATABASE}.agent_conversations` | ClickHouse table for conversation storage. In `auto` mode, ClickHouse is tried only when this is explicitly set. |
-| `CLICKHOUSE_AGENT_CONVERSATIONS_AUTO_CREATE` | `true` | Create the table at runtime if it does not exist. |
 
 **PostgreSQL backend:**
 
@@ -347,7 +352,7 @@ Injected at build time for the About page.
 |---|---|
 | `NEXT_PUBLIC_AUTH_PROVIDER` | Renamed to `VITE_AUTH_PROVIDER` in v0.3. Old name still works as a fallback. |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Renamed to `VITE_CLERK_PUBLISHABLE_KEY` in v0.3. |
-| `NEXT_PUBLIC_FEATURE_CONVERSATION_DB` | Deprecated alias for `AGENT_CONVERSATION_PERSISTENCE=true`. |
+| `NEXT_PUBLIC_FEATURE_CONVERSATION_DB` | Deprecated alias for `VITE_FEATURE_CONVERSATION_DB=true`. |
 | `NEXT_PUBLIC_AUTOCOMPLETE_LIMIT` | Renamed to `VITE_AUTOCOMPLETE_LIMIT` in v0.3. |
 | `NEXT_PUBLIC_RUNNING_QUERIES_REFRESH_MS` | Renamed to `VITE_RUNNING_QUERIES_REFRESH_MS` in v0.3. |
 | `CLICKHOUSE_EXCLUDE_USER_DEFAULT` | Comma-separated usernames excluded from history-queries by default. |

--- a/docs/content/settings.mdx
+++ b/docs/content/settings.mdx
@@ -70,7 +70,6 @@ CLICKHOUSE_NAME=prod-a,prod-b
 ```bash
 CLICKHOUSE_MAX_EXECUTION_TIME=60    # seconds
 CLICKHOUSE_TZ=UTC
-NEXT_QUERY_CACHE_TTL=3600           # seconds; lower for fresher data
 ```
 
 **Feature permissions**
@@ -99,11 +98,14 @@ LLM_API_BASE=https://openrouter.ai/api/v1
 LLM_MODEL=openrouter/free
 ```
 
-**Conversation persistence**
+**Conversation persistence** (build-time flag + runtime backend)
 
 ```bash
-AGENT_CONVERSATION_PERSISTENCE=true
-AGENT_CONVERSATION_STORE=auto
+# Set at build time (before bun run build):
+VITE_FEATURE_CONVERSATION_DB=true
+
+# Set at runtime:
+CONVERSATION_STORE_BACKEND=agentstate   # or: d1, postgres, memory
 ```
 
 **Branding (build-time, TanStack app)**


### PR DESCRIPTION
## Summary

Fixes 6 documentation issues where env var names drifted from the actual implementation.

- **#1934 (P0)**: Replace `AGENT_CONVERSATION_PERSISTENCE` / `AGENT_CONVERSATION_STORE` (which do not exist in the codebase) with the real vars: `VITE_FEATURE_CONVERSATION_DB=true` (build-time, requires Clerk) and `CONVERSATION_STORE_BACKEND=<backend>` (runtime). Verified by grepping `apps/dashboard/src/lib/conversation-store/resolve-store.ts` and `feature-flags.ts`. Updated all 18 affected docs files.

- **#1935 (P1)**: Remove obsolete `NEXT_QUERY_CACHE_TTL` from all deploy guides (cloudflare.mdx, docker.mdx, k8s.mdx, vercel.mdx, self-host.mdx) and feature/reference docs. Confirmed not used anywhere in `apps/dashboard/src`.

- **#1936 (P1)**: Add a `:::caution[Legacy guide — Next.js v0.2 only]` callout at the top of `deploy/vercel.mdx` with a prominent redirect to Cloudflare Workers / Docker for v0.3+ users.

- **#1937 (P2)**: Replace hardcoded `0.2.9` version examples in `deploy/k8s.mdx` (OCI install command, pull command, values.yaml) with `vX.Y.Z` placeholders and a link to GitHub Releases.

- **#1938 (P1)**: Add a "Build-time vs runtime" section to `reference/environment-variables.mdx` explaining the two categories; tag `VITE_*` vars as build-time throughout the conversation store section.

- **#1945 (P2)**: Document the actual backend resolution order from `resolve-store.ts` (AgentState → D1 → Postgres → Memory) in `ai-agent/conversation-history.mdx`; add an AgentState self-host quickstart subsection with per-platform instructions.

## Test plan

- [ ] All changed files are docs-only (`docs/content/**/*.mdx`) — no app code changed
- [ ] `grep -rn "AGENT_CONVERSATION_PERSISTENCE\|AGENT_CONVERSATION_STORE\b\|NEXT_QUERY_CACHE_TTL" docs/content/` returns no results
- [ ] `VITE_FEATURE_CONVERSATION_DB` and `CONVERSATION_STORE_BACKEND` appear correctly in env-var reference and all deploy guides
- [ ] Helm version placeholder `vX.Y.Z` replaces all `0.2.9` occurrences in k8s.mdx
- [ ] Vercel legacy callout is visible at top of vercel.mdx

Closes #1934, #1935, #1936, #1937, #1938, #1945

https://claude.ai/code/session_01TnsycTkdMHJ4DXohpuz3oj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated conversation persistence guidance across deployment, settings, FAQ, and reference docs to reflect the new build-time and runtime configuration flow.
  * Added clearer backend selection guidance for browser storage, AgentState, Postgres, D1, and memory.
  * Expanded setup instructions for self-hosting and cloud deployments, including new examples and migration notes.
  * Removed outdated cache TTL references and refreshed query/performance settings to match current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->