### PR TITLE
feat(monitoring): CH version detection + Keeper 26.6 deep-dive

### DIFF
--- a/apps/dashboard/src/lib/__tests__/server-version.test.ts
+++ b/apps/dashboard/src/lib/__tests__/server-version.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for server-version helpers.
+ *
+ * Tests the string-based wrappers (parseVersion, compareVersions) directly.
+ * meetsMinVersion is tested via mock.module since it calls getClickHouseVersion.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+// ---------------------------------------------------------------------------
+// parseVersion and compareVersions — pure functions, no mocking needed
+// ---------------------------------------------------------------------------
+
+const { parseVersion, compareVersions } = await import(
+  new URL('../server-version.ts?test=server-version', import.meta.url).href
+)
+
+describe('parseVersion', () => {
+  it('parses a 4-part CH version string', () => {
+    const v = parseVersion('24.3.1.1')
+    expect(v.major).toBe(24)
+    expect(v.minor).toBe(3)
+    expect(v.patch).toBe(1)
+    expect(v.raw).toBe('24.3.1.1')
+  })
+
+  it('parses a 2-part version string', () => {
+    const v = parseVersion('26.6')
+    expect(v.major).toBe(26)
+    expect(v.minor).toBe(6)
+    expect(v.patch).toBe(0)
+  })
+
+  it('parses a 3-part version string', () => {
+    const v = parseVersion('24.8.3')
+    expect(v.major).toBe(24)
+    expect(v.minor).toBe(8)
+    expect(v.patch).toBe(3)
+  })
+
+  it('returns zeroes for an empty string', () => {
+    const v = parseVersion('')
+    expect(v.major).toBe(0)
+    expect(v.minor).toBe(0)
+    expect(v.patch).toBe(0)
+  })
+})
+
+describe('compareVersions', () => {
+  it('returns -1 when first is older', () => {
+    expect(compareVersions('24.1.0.0', '24.3.0.0')).toBe(-1)
+  })
+
+  it('returns 0 when versions are equal', () => {
+    expect(compareVersions('26.6.1.0', '26.6.1.0')).toBe(0)
+  })
+
+  it('returns 1 when first is newer', () => {
+    expect(compareVersions('26.6.0.0', '24.3.0.0')).toBe(1)
+  })
+
+  it('compares across major versions', () => {
+    expect(compareVersions('26.1.0.0', '25.12.0.0')).toBe(1)
+    expect(compareVersions('25.12.0.0', '26.1.0.0')).toBe(-1)
+  })
+
+  it('compares minor versions with same major', () => {
+    expect(compareVersions('26.6.0.0', '26.5.0.0')).toBe(1)
+    expect(compareVersions('26.5.0.0', '26.6.0.0')).toBe(-1)
+  })
+
+  it('compares 2-part shorthand against 4-part full version', () => {
+    expect(compareVersions('26.6', '26.5.1.0')).toBe(1)
+    expect(compareVersions('26.5', '26.6.0.0')).toBe(-1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// meetsMinVersion — requires mocking getClickHouseVersion
+// ---------------------------------------------------------------------------
+
+const mockGetClickHouseVersion = mock(async (hostId: number) => ({
+  major: 26,
+  minor: 6,
+  patch: 1,
+  build: 0,
+  raw: '26.6.1.0',
+}))
+
+mock.module('@chm/clickhouse-client/clickhouse-version', () => ({
+  getClickHouseVersion: mockGetClickHouseVersion,
+  parseVersion: (s: string) => {
+    const parts = s.split('.')
+    return {
+      major: parseInt(parts[0] || '0', 10),
+      minor: parseInt(parts[1] || '0', 10),
+      patch: parseInt(parts[2] || '0', 10),
+      build: parts[3] ? parseInt(parts[3], 10) : undefined,
+      raw: s,
+    }
+  },
+  compareVersions: (
+    a: { major: number; minor: number; patch: number },
+    b: { major: number; minor: number; patch: number }
+  ) => {
+    if (a.major !== b.major) return a.major - b.major
+    if (a.minor !== b.minor) return a.minor - b.minor
+    if (a.patch !== b.patch) return a.patch - b.patch
+    return 0
+  },
+  meetsMinVersion: (
+    v: { major: number; minor: number; patch: number },
+    minMajor: number,
+    minMinor = 0,
+    minPatch = 0
+  ) => {
+    if (v.major !== minMajor) return v.major > minMajor
+    if (v.minor !== minMinor) return v.minor > minMinor
+    return v.patch >= minPatch
+  },
+}))
+
+const { meetsMinVersion } = await import(
+  new URL('../server-version.ts?test=meets', import.meta.url).href
+)
+
+describe('meetsMinVersion', () => {
+  beforeEach(() => {
+    mockGetClickHouseVersion.mockResolvedValue({
+      major: 26,
+      minor: 6,
+      patch: 1,
+      build: 0,
+      raw: '26.6.1.0',
+    })
+  })
+
+  afterEach(() => {
+    mockGetClickHouseVersion.mockReset()
+  })
+
+  it('returns true when host version meets minimum', async () => {
+    const result = await meetsMinVersion(0, '26.6')
+    expect(result).toBe(true)
+  })
+
+  it('returns true when host version exceeds minimum', async () => {
+    const result = await meetsMinVersion(0, '24.8')
+    expect(result).toBe(true)
+  })
+
+  it('returns false when host version is below minimum', async () => {
+    mockGetClickHouseVersion.mockResolvedValue({
+      major: 24,
+      minor: 8,
+      patch: 1,
+      build: 0,
+      raw: '24.8.1.0',
+    })
+    const result = await meetsMinVersion(0, '26.6')
+    expect(result).toBe(false)
+  })
+
+  it('returns false when version cannot be determined', async () => {
+    mockGetClickHouseVersion.mockResolvedValue(null)
+    const result = await meetsMinVersion(0, '26.6')
+    expect(result).toBe(false)
+  })
+})

--- a/apps/dashboard/src/lib/__tests__/server-version.test.ts
+++ b/apps/dashboard/src/lib/__tests__/server-version.test.ts
@@ -79,13 +79,23 @@ describe('compareVersions', () => {
 // meetsMinVersion — requires mocking getClickHouseVersion
 // ---------------------------------------------------------------------------
 
-const mockGetClickHouseVersion = mock(async (hostId: number) => ({
-  major: 26,
-  minor: 6,
-  patch: 1,
-  build: 0,
-  raw: '26.6.1.0',
-}))
+type MockVersion = {
+  major: number
+  minor: number
+  patch: number
+  build: number
+  raw: string
+} | null
+
+const mockGetClickHouseVersion = mock(
+  async (_hostId: number): Promise<MockVersion> => ({
+    major: 26,
+    minor: 6,
+    patch: 1,
+    build: 0,
+    raw: '26.6.1.0',
+  })
+)
 
 mock.module('@chm/clickhouse-client/clickhouse-version', () => ({
   getClickHouseVersion: mockGetClickHouseVersion,

--- a/apps/dashboard/src/lib/hooks/index.ts
+++ b/apps/dashboard/src/lib/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useDebounceWithPending } from './use-debounce'
+export { useServerVersion } from './use-server-version'
 export { useUserSettings } from './use-user-settings'

--- a/apps/dashboard/src/lib/hooks/use-server-version.ts
+++ b/apps/dashboard/src/lib/hooks/use-server-version.ts
@@ -1,0 +1,30 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/swr/api-fetch'
+
+interface HostStatusResponse {
+  success: boolean
+  data?: { version: string; uptime: string; hostname: string }
+}
+
+/**
+ * Fetches the ClickHouse server version string for the given host.
+ *
+ * Reuses the /api/v1/host-status endpoint (which already queries version()).
+ * Stale for 5 minutes — version only changes on server upgrade.
+ */
+export function useServerVersion(hostId: number) {
+  return useQuery({
+    queryKey: ['server-version', hostId],
+    queryFn: async () => {
+      const res = await apiFetch(`/api/v1/host-status?hostId=${hostId}`)
+      if (!res.ok) {
+        throw new Error(`Failed to fetch server version: ${res.status}`)
+      }
+      const json = (await res.json()) as HostStatusResponse
+      return json.data?.version ?? ''
+    },
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  })
+}

--- a/apps/dashboard/src/lib/query-config/keeper/index.ts
+++ b/apps/dashboard/src/lib/query-config/keeper/index.ts
@@ -7,10 +7,13 @@
  * on clusters (or ClickHouse versions) where the table is absent.
  */
 
+export { keeperChangelogsConfig } from './keeper-changelogs'
+export { keeperClusterConfig } from './keeper-cluster'
 export { keeperConnectionLogConfig } from './keeper-connection-log'
 export { keeperConnectionsConfig } from './keeper-connections'
 export { keeperInfoConfig } from './keeper-info'
 export { keeperLogConfig } from './keeper-log'
 export { keeperOverviewConfig } from './keeper-overview'
 export { keeperPresenceConfig } from './keeper-presence'
+export { keeperSnapshotsConfig } from './keeper-snapshots'
 export { keeperWatchesConfig } from './keeper-watches'

--- a/apps/dashboard/src/lib/query-config/keeper/keeper-changelogs.ts
+++ b/apps/dashboard/src/lib/query-config/keeper/keeper-changelogs.ts
@@ -1,0 +1,51 @@
+import type { QueryConfig } from '@/types/query-config'
+
+import { QUERY_COMMENT } from '@chm/clickhouse-client/constants'
+import { ColumnFormat } from '@/types/column-format'
+
+/**
+ * Keeper changelog (WAL) files — Raft write-ahead log metadata.
+ * Requires ClickHouse 26.6+ with Keeper co-located on this node.
+ */
+export const keeperChangelogsConfig: QueryConfig = {
+  name: 'keeper-changelogs',
+  defaultView: 'table',
+  description:
+    'Local Keeper changelog (WAL) files: log index range, creation time, and file size. Changelogs record every Raft log entry and are compacted once a snapshot covers their range.',
+  optional: true,
+  tableCheck: 'system.keeper_changelogs',
+  docs: 'https://clickhouse.com/docs/en/operations/system-tables/keeper_changelogs',
+  sql: [
+    {
+      since: '26.6',
+      sql: `
+        ${QUERY_COMMENT}
+        SELECT
+            path,
+            created_at,
+            first_log_index,
+            last_log_index,
+            file_size,
+            formatReadableSize(file_size) AS readable_file_size,
+            round(file_size * 100.0 / nullIf(max(file_size) OVER (), 0), 2) AS pct_file_size
+        FROM system.keeper_changelogs
+        ORDER BY first_log_index DESC
+        LIMIT 100
+      `,
+    },
+  ],
+  columns: [
+    'path',
+    'created_at',
+    'first_log_index',
+    'last_log_index',
+    'readable_file_size',
+  ],
+  columnFormats: {
+    path: ColumnFormat.Text,
+    created_at: ColumnFormat.RelatedTime,
+    first_log_index: ColumnFormat.Number,
+    last_log_index: ColumnFormat.Number,
+    readable_file_size: ColumnFormat.BackgroundBar,
+  },
+}

--- a/apps/dashboard/src/lib/query-config/keeper/keeper-cluster.ts
+++ b/apps/dashboard/src/lib/query-config/keeper/keeper-cluster.ts
@@ -1,0 +1,55 @@
+import type { QueryConfig } from '@/types/query-config'
+
+import { QUERY_COMMENT } from '@chm/clickhouse-client/constants'
+import { ColumnFormat } from '@/types/column-format'
+
+/**
+ * Keeper Raft cluster membership — one row per Keeper node.
+ * Requires ClickHouse 26.6+ with Keeper co-located on this node.
+ */
+export const keeperClusterConfig: QueryConfig = {
+  name: 'keeper-cluster',
+  defaultView: 'auto',
+  card: { primary: 'host', badges: ['role'] },
+  description:
+    'Raft cluster membership as seen from this Keeper node: server IDs, addresses, roles (leader/follower/learner), current term, and last log index.',
+  optional: true,
+  tableCheck: 'system.keeper_cluster',
+  docs: 'https://clickhouse.com/docs/en/operations/system-tables/keeper_cluster',
+  sql: [
+    {
+      since: '26.6',
+      sql: `
+        ${QUERY_COMMENT}
+        SELECT
+            server_id,
+            host,
+            port,
+            role,
+            term,
+            last_log_index,
+            state
+        FROM system.keeper_cluster
+        ORDER BY server_id ASC
+      `,
+    },
+  ],
+  columns: [
+    'server_id',
+    'host',
+    'port',
+    'role',
+    'term',
+    'last_log_index',
+    'state',
+  ],
+  columnFormats: {
+    server_id: ColumnFormat.Number,
+    host: ColumnFormat.Text,
+    port: ColumnFormat.Number,
+    role: ColumnFormat.ColoredBadge,
+    term: ColumnFormat.Number,
+    last_log_index: ColumnFormat.Number,
+    state: ColumnFormat.ColoredBadge,
+  },
+}

--- a/apps/dashboard/src/lib/query-config/keeper/keeper-snapshots.ts
+++ b/apps/dashboard/src/lib/query-config/keeper/keeper-snapshots.ts
@@ -1,0 +1,41 @@
+import type { QueryConfig } from '@/types/query-config'
+
+import { QUERY_COMMENT } from '@chm/clickhouse-client/constants'
+import { ColumnFormat } from '@/types/column-format'
+
+/**
+ * Keeper snapshot files — local snapshot metadata.
+ * Requires ClickHouse 26.6+ with Keeper co-located on this node.
+ */
+export const keeperSnapshotsConfig: QueryConfig = {
+  name: 'keeper-snapshots',
+  defaultView: 'table',
+  description:
+    'Local Keeper snapshot files: path, creation time, and file size. Snapshots are periodic full images of the Keeper znode tree used for recovery and log compaction.',
+  optional: true,
+  tableCheck: 'system.keeper_snapshots',
+  docs: 'https://clickhouse.com/docs/en/operations/system-tables/keeper_snapshots',
+  sql: [
+    {
+      since: '26.6',
+      sql: `
+        ${QUERY_COMMENT}
+        SELECT
+            path,
+            created_at,
+            file_size,
+            formatReadableSize(file_size) AS readable_file_size,
+            round(file_size * 100.0 / nullIf(max(file_size) OVER (), 0), 2) AS pct_file_size
+        FROM system.keeper_snapshots
+        ORDER BY created_at DESC
+        LIMIT 100
+      `,
+    },
+  ],
+  columns: ['path', 'created_at', 'readable_file_size'],
+  columnFormats: {
+    path: ColumnFormat.Text,
+    created_at: ColumnFormat.RelatedTime,
+    readable_file_size: ColumnFormat.BackgroundBar,
+  },
+}

--- a/apps/dashboard/src/lib/server-version.ts
+++ b/apps/dashboard/src/lib/server-version.ts
@@ -1,0 +1,57 @@
+/**
+ * Server-side ClickHouse version detection helpers.
+ *
+ * Thin wrapper around @chm/clickhouse-client/clickhouse-version that adds
+ * string-based convenience functions for route handlers and React hooks.
+ *
+ * The underlying implementation has a 24-hour per-host TTL cache so callers
+ * do not need their own caching layer.
+ */
+
+import {
+  type ClickHouseVersion,
+  compareVersions as compareParsed,
+  getClickHouseVersion,
+  meetsMinVersion as meetsParsed,
+  parseVersion,
+} from '@chm/clickhouse-client/clickhouse-version'
+
+export type { ClickHouseVersion }
+export { parseVersion }
+
+/**
+ * Return the raw version string (e.g. "26.6.1.0") for the given host.
+ * Returns an empty string if the version cannot be determined.
+ */
+export async function getServerVersion(hostId: number): Promise<string> {
+  const v = await getClickHouseVersion(hostId)
+  return v?.raw ?? ''
+}
+
+/**
+ * Compare two version strings.
+ * Returns -1 if v1 < v2, 0 if equal, 1 if v1 > v2.
+ */
+export function compareVersions(v1: string, v2: string): number {
+  const result = compareParsed(parseVersion(v1), parseVersion(v2))
+  if (result < 0) return -1
+  if (result > 0) return 1
+  return 0
+}
+
+/**
+ * Returns true if the given host's ClickHouse version meets the minimum.
+ * Returns false if the version cannot be determined.
+ *
+ * @param hostId - Host index (0-based)
+ * @param minVersion - Minimum required version string, e.g. "26.6"
+ */
+export async function meetsMinVersion(
+  hostId: number,
+  minVersion: string
+): Promise<boolean> {
+  const v = await getClickHouseVersion(hostId)
+  if (!v) return false
+  const min = parseVersion(minVersion)
+  return meetsParsed(v, min.major, min.minor, min.patch)
+}

--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -497,6 +497,14 @@ export const menuItemsConfig: MenuItem[] = [
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/zookeeper_watches',
         tableCheck: 'system.zookeeper_watches',
       },
+      {
+        title: 'Keeper Deep-dive',
+        href: '/keeper/deep-dive',
+        description:
+          'Keeper internals (CH 26.6+): Raft cluster membership, snapshot files, and changelog (WAL) disk footprint',
+        icon: LayersIcon,
+        isNew: true,
+      },
     ],
   },
   {

--- a/apps/dashboard/src/routes/(dashboard)/keeper/deep-dive.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/keeper/deep-dive.tsx
@@ -1,0 +1,68 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { Suspense } from 'react'
+import { InfoIcon } from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { PageLayout } from '@/components/layout/query-page'
+import { PageSkeleton } from '@/components/skeletons'
+import {
+  keeperChangelogsConfig,
+  keeperClusterConfig,
+  keeperSnapshotsConfig,
+} from '@/lib/query-config/keeper'
+import { useHostId } from '@/lib/swr/use-host'
+import { useServerVersion } from '@/lib/hooks/use-server-version'
+import { compareVersions } from '@/lib/server-version'
+
+const MIN_VERSION = '26.6'
+
+function VersionNotice({ version }: { version: string }) {
+  if (!version || compareVersions(version, MIN_VERSION) >= 0) return null
+  return (
+    <Alert>
+      <InfoIcon className="h-4 w-4" />
+      <AlertTitle>ClickHouse {MIN_VERSION}+ required</AlertTitle>
+      <AlertDescription>
+        This host is running ClickHouse {version}. The tables below
+        (keeper_snapshots, keeper_changelogs, keeper_cluster) require ClickHouse{' '}
+        {MIN_VERSION} or later. They will show as unavailable until the cluster
+        is upgraded.
+      </AlertDescription>
+    </Alert>
+  )
+}
+
+function KeeperDeepDiveContent() {
+  const hostId = useHostId()
+  const { data: version = '' } = useServerVersion(hostId)
+
+  return (
+    <div className="flex flex-col gap-4">
+      <VersionNotice version={version} />
+      <PageLayout
+        queryConfig={keeperClusterConfig}
+        title="Keeper Cluster (Raft Membership)"
+      />
+      <PageLayout
+        queryConfig={keeperSnapshotsConfig}
+        title="Keeper Snapshots"
+      />
+      <PageLayout
+        queryConfig={keeperChangelogsConfig}
+        title="Keeper Changelogs (WAL)"
+      />
+    </div>
+  )
+}
+
+function KeeperDeepDivePage() {
+  return (
+    <Suspense fallback={<PageSkeleton />}>
+      <KeeperDeepDiveContent />
+    </Suspense>
+  )
+}
+
+export const Route = createFileRoute('/(dashboard)/keeper/deep-dive')({
+  component: KeeperDeepDivePage,
+})


### PR DESCRIPTION
## Summary

- **#1910**: Add `getServerVersion(hostId)` / `meetsMinVersion(hostId, minVersion)` string-based helpers (`lib/server-version.ts`) as a thin wrapper over the existing `@chm/clickhouse-client/clickhouse-version` cache (24h TTL, no additional layer). Also adds `useServerVersion` React hook (via `/api/v1/host-status`) and unit tests for `parseVersion`, `compareVersions`, `meetsMinVersion`.
- **#1906**: Add three optional CH 26.6 query configs (`keeper-snapshots`, `keeper-changelogs`, `keeper-cluster`) with `optional: true` + `tableCheck` for graceful degradation. New `/keeper/deep-dive` route shows a version gate notice on sub-26.6 hosts and renders all three tables. Menu entry added under the Keeper section.

## Test plan

- [ ] `bun run test` — server-version unit tests (parseVersion, compareVersions, meetsMinVersion) pass
- [ ] `/keeper/deep-dive` shows a version-gate notice when host is below 26.6; tables show optional-unavailable message
- [ ] `/keeper/deep-dive` on CH 26.6+ renders keeper_cluster, keeper_snapshots, keeper_changelogs tables
- [ ] All three new configs have `optional: true` and correct `since: '26.6'` entry
- [ ] `bun run lint` passes

Closes #1910, Closes #1906

https://claude.ai/code/session_01TnsycTkdMHJ4DXohpuz3oj