### PR TITLE
feat(monitoring): blob_storage_log, storage economics, new part/merge cols

### DIFF
--- a/apps/dashboard/src/lib/query-config/index.ts
+++ b/apps/dashboard/src/lib/query-config/index.ts
@@ -81,6 +81,12 @@ import {
   databaseDiskSpaceConfig,
   diskSpaceConfig,
 } from './system/disks'
+import { blobStorageLogConfig } from './system/blob-storage-log'
+import {
+  storageCompressionConfig,
+  storagePoliciesConfig,
+  ttlStorageMovesConfig,
+} from './system/storage-economics'
 import { kafkaConsumersConfig } from './system/kafka-consumers'
 import { partLogConfig } from './system/part-log'
 import { queryMetricLogConfig } from './system/query-metric-log'
@@ -193,6 +199,10 @@ export const queries: Array<QueryConfig> = [
   tablesListConfig,
   warningsConfig,
   kafkaConsumersConfig,
+  blobStorageLogConfig,
+  storageCompressionConfig,
+  storagePoliciesConfig,
+  ttlStorageMovesConfig,
 
   // Security
   sessionsConfig,

--- a/apps/dashboard/src/lib/query-config/merges/merges.ts
+++ b/apps/dashboard/src/lib/query-config/merges/merges.ts
@@ -9,21 +9,60 @@ export const mergesConfig: QueryConfig = {
   refreshInterval: 30_000,
   description:
     'Merges and part mutations currently in process for tables in the MergeTree family',
-  sql: `
-      SELECT *,
-        database || '.' || table as table,
-        round(100 * num_parts / max(num_parts) OVER ()) as pct_num_parts,
-        round(progress * 100, 1) as pct_progress,
-        (cast(pct_progress, 'String') || '%') as readable_progress,
-        round(100 * rows_read / max(rows_read) OVER ()) as pct_rows_read,
-        formatReadableQuantity(rows_read) as readable_rows_read,
-        round(100 * rows_written / max(rows_written) OVER ()) as pct_rows_written,
-        formatReadableQuantity(rows_written) as readable_rows_written,
-        round(100 * memory_usage / max(memory_usage) OVER ()) as pct_memory_usage,
-        formatReadableSize(memory_usage) as readable_memory_usage
-      FROM system.merges
-      ORDER BY progress DESC
-    `,
+  // Version-aware queries (oldest → newest)
+  // 26.6 adds per-projection tracking: current_projection,
+  // current_projection_progress, projections_completed, projections_remaining.
+  sql: [
+    {
+      since: '19.1',
+      description: 'Base query — projection tracking columns not available',
+      sql: `
+        SELECT *,
+          database || '.' || table as table,
+          round(100 * num_parts / max(num_parts) OVER ()) as pct_num_parts,
+          round(progress * 100, 1) as pct_progress,
+          (cast(pct_progress, 'String') || '%') as readable_progress,
+          round(100 * rows_read / max(rows_read) OVER ()) as pct_rows_read,
+          formatReadableQuantity(rows_read) as readable_rows_read,
+          round(100 * rows_written / max(rows_written) OVER ()) as pct_rows_written,
+          formatReadableQuantity(rows_written) as readable_rows_written,
+          round(100 * memory_usage / max(memory_usage) OVER ()) as pct_memory_usage,
+          formatReadableSize(memory_usage) as readable_memory_usage,
+          '-' AS current_projection,
+          toFloat64(0) AS current_projection_progress,
+          '0%' AS readable_current_projection_progress,
+          toFloat64(0) AS pct_current_projection_progress,
+          toUInt64(0) AS projections_completed,
+          toUInt64(0) AS projections_remaining
+        FROM system.merges
+        ORDER BY progress DESC
+      `,
+    },
+    {
+      since: '26.6',
+      description:
+        'Includes projection tracking: current_projection, projections_completed/remaining',
+      sql: `
+        SELECT *,
+          database || '.' || table as table,
+          round(100 * num_parts / max(num_parts) OVER ()) as pct_num_parts,
+          round(progress * 100, 1) as pct_progress,
+          (cast(pct_progress, 'String') || '%') as readable_progress,
+          round(100 * rows_read / max(rows_read) OVER ()) as pct_rows_read,
+          formatReadableQuantity(rows_read) as readable_rows_read,
+          round(100 * rows_written / max(rows_written) OVER ()) as pct_rows_written,
+          formatReadableQuantity(rows_written) as readable_rows_written,
+          round(100 * memory_usage / max(memory_usage) OVER ()) as pct_memory_usage,
+          formatReadableSize(memory_usage) as readable_memory_usage,
+          concat(toString(round(current_projection_progress * 100, 1)), '%')
+            AS readable_current_projection_progress,
+          round(current_projection_progress * 100, 0)
+            AS pct_current_projection_progress
+        FROM system.merges
+        ORDER BY progress DESC
+      `,
+    },
+  ],
   columns: [
     'table',
     'partition_id',
@@ -36,6 +75,10 @@ export const mergesConfig: QueryConfig = {
     'is_mutation',
     'merge_type',
     'merge_algorithm',
+    'current_projection',
+    'readable_current_projection_progress',
+    'projections_completed',
+    'projections_remaining',
   ],
   columnFormats: {
     table: ColumnFormat.ColoredBadge,
@@ -46,6 +89,10 @@ export const mergesConfig: QueryConfig = {
     readable_memory_usage: ColumnFormat.BackgroundBar,
     readable_rows_read: ColumnFormat.BackgroundBar,
     readable_rows_written: ColumnFormat.BackgroundBar,
+    current_projection: ColumnFormat.Code,
+    readable_current_projection_progress: ColumnFormat.BackgroundBar,
+    projections_completed: ColumnFormat.Number,
+    projections_remaining: ColumnFormat.Number,
   },
   relatedCharts: [
     [

--- a/apps/dashboard/src/lib/query-config/merges/mutations.ts
+++ b/apps/dashboard/src/lib/query-config/merges/mutations.ts
@@ -14,25 +14,60 @@ export const mutationsConfig: QueryConfig = {
   refreshInterval: 30_000,
   description:
     'Information about mutations of MergeTree tables and their progress',
-  sql: `
-      SELECT
-        database || '.' || table as table,
-        mutation_id,
-        command,
-        create_time,
-        now() - create_time AS elapsed,
-        parts_to_do,
-        formatReadableQuantity(parts_to_do) AS readable_parts_to_do,
-        round(100 * parts_to_do / nullIf(max(parts_to_do) OVER (), 0), 2) as pct_parts_to_do,
-        parts_to_do_names,
-        is_done,
-        if(is_done = 0 AND parts_to_do > 0 AND (now() - create_time) > ${STUCK_THRESHOLD_SECONDS}, 1, 0) AS is_stuck,
-        latest_failed_part,
-        latest_fail_time,
-        latest_fail_reason
-      FROM system.mutations
-      ORDER BY is_done ASC, is_stuck DESC, create_time DESC
-    `,
+  // Version-aware queries (oldest → newest)
+  // 25.12 adds parts_in_progress_names: names of parts currently being mutated.
+  // The expanded row panel surfaces this field (expandable: true below).
+  sql: [
+    {
+      since: '19.1',
+      description: 'Base query — parts_in_progress_names not available',
+      sql: `
+        SELECT
+          database || '.' || table as table,
+          mutation_id,
+          command,
+          create_time,
+          now() - create_time AS elapsed,
+          parts_to_do,
+          formatReadableQuantity(parts_to_do) AS readable_parts_to_do,
+          round(100 * parts_to_do / nullIf(max(parts_to_do) OVER (), 0), 2) as pct_parts_to_do,
+          parts_to_do_names,
+          [] AS parts_in_progress_names,
+          is_done,
+          if(is_done = 0 AND parts_to_do > 0 AND (now() - create_time) > ${STUCK_THRESHOLD_SECONDS}, 1, 0) AS is_stuck,
+          latest_failed_part,
+          latest_fail_time,
+          latest_fail_reason
+        FROM system.mutations
+        ORDER BY is_done ASC, is_stuck DESC, create_time DESC
+      `,
+    },
+    {
+      since: '25.12',
+      description:
+        'Includes parts_in_progress_names: names of parts currently being mutated',
+      sql: `
+        SELECT
+          database || '.' || table as table,
+          mutation_id,
+          command,
+          create_time,
+          now() - create_time AS elapsed,
+          parts_to_do,
+          formatReadableQuantity(parts_to_do) AS readable_parts_to_do,
+          round(100 * parts_to_do / nullIf(max(parts_to_do) OVER (), 0), 2) as pct_parts_to_do,
+          parts_to_do_names,
+          parts_in_progress_names,
+          is_done,
+          if(is_done = 0 AND parts_to_do > 0 AND (now() - create_time) > ${STUCK_THRESHOLD_SECONDS}, 1, 0) AS is_stuck,
+          latest_failed_part,
+          latest_fail_time,
+          latest_fail_reason
+        FROM system.mutations
+        ORDER BY is_done ASC, is_stuck DESC, create_time DESC
+      `,
+    },
+  ],
   columns: [
     'is_done',
     'is_stuck',
@@ -54,6 +89,9 @@ export const mutationsConfig: QueryConfig = {
     elapsed: ColumnFormat.Duration,
     readable_parts_to_do: ColumnFormat.BackgroundBar,
   },
+  // Expanding a row surfaces parts_to_do_names and parts_in_progress_names
+  // (in CH 25.12+) in the full-width JSON detail panel.
+  expandable: true,
   rowClassName: (row) => {
     const isStuck = Number(row.is_stuck || 0)
     if (isStuck) return 'bg-red-50 dark:bg-red-950/20'

--- a/apps/dashboard/src/lib/query-config/system/blob-storage-log.ts
+++ b/apps/dashboard/src/lib/query-config/system/blob-storage-log.ts
@@ -1,0 +1,69 @@
+import type { QueryConfig } from '@/types/query-config'
+
+import { ColumnFormat } from '@/types/column-format'
+
+/**
+ * system.blob_storage_log — available since ClickHouse 23.11 when an S3/blob
+ * storage disk is configured. Tracks each read, write, delete, and list
+ * operation sent to object storage.
+ */
+export const blobStorageLogConfig: QueryConfig = {
+  name: 'blob-storage-log',
+  defaultView: 'auto',
+  card: { primary: 'remote_path', badges: ['event_type', 'disk_name'] },
+  description:
+    'Object storage operations (reads, writes, deletes) recorded in system.blob_storage_log',
+  refreshInterval: 30_000,
+  // system.blob_storage_log is opt-in: only exists when an S3/blob disk is
+  // configured and ClickHouse >= 23.11.
+  optional: true,
+  tableCheck: 'system.blob_storage_log',
+  sql: [
+    {
+      since: '23.11',
+      sql: `
+        SELECT
+          event_time,
+          event_type,
+          disk_name,
+          bucket,
+          remote_path,
+          data_size,
+          formatReadableSize(data_size) AS readable_data_size,
+          round(data_size * 100.0 / nullIf(max(data_size) OVER (), 0), 2) AS pct_data_size,
+          error,
+          query_id
+        FROM system.blob_storage_log
+        ORDER BY event_time DESC
+        LIMIT 1000
+      `,
+    },
+  ],
+  columns: [
+    'event_time',
+    'event_type',
+    'disk_name',
+    'bucket',
+    'remote_path',
+    'readable_data_size',
+    'error',
+    'query_id',
+  ],
+  columnFormats: {
+    event_time: ColumnFormat.RelatedTime,
+    event_type: ColumnFormat.ColoredBadge,
+    disk_name: ColumnFormat.ColoredBadge,
+    remote_path: ColumnFormat.Code,
+    readable_data_size: ColumnFormat.BackgroundBar,
+    error: ColumnFormat.CodeDialog,
+    query_id: [
+      ColumnFormat.Link,
+      { href: '/query?query_id=[query_id]&host=[ctx.hostId]' },
+    ],
+  },
+  rowClassName: (row) => {
+    if (row.error && String(row.error).length > 0)
+      return 'bg-red-50 dark:bg-red-950/20'
+    return ''
+  },
+}

--- a/apps/dashboard/src/lib/query-config/system/storage-economics.ts
+++ b/apps/dashboard/src/lib/query-config/system/storage-economics.ts
@@ -1,0 +1,208 @@
+import type { QueryConfig } from '@/types/query-config'
+
+import { ColumnFormat } from '@/types/column-format'
+
+/**
+ * Per-table compression and storage cost analysis.
+ *
+ * Uses system.parts (active parts only) to compute:
+ * - Compressed / uncompressed bytes and compression ratio
+ * - Total bytes on disk (may exceed uncompressed due to metadata / indices)
+ * - Top tables by storage cost
+ *
+ * Higher compression_ratio means data compresses well (less disk needed).
+ */
+export const storageCompressionConfig: QueryConfig = {
+  name: 'storage-compression',
+  description:
+    'Per-table compression ratios and storage cost from active parts in system.parts',
+  sql: `
+    WITH agg AS (
+      SELECT
+        database,
+        table,
+        database || '.' || table AS full_table,
+        count() AS parts,
+        sum(rows) AS rows,
+        sum(data_compressed_bytes) AS data_compressed_bytes,
+        sum(data_uncompressed_bytes) AS data_uncompressed_bytes,
+        round(
+          sum(data_uncompressed_bytes) / nullIf(sum(data_compressed_bytes), 0),
+          2
+        ) AS compression_ratio,
+        sum(bytes_on_disk) AS bytes_on_disk
+      FROM system.parts
+      WHERE active = 1
+      GROUP BY database, table
+    )
+    SELECT
+      full_table,
+      parts,
+      rows,
+      formatReadableQuantity(rows) AS readable_rows,
+      round(rows * 100.0 / nullIf(max(rows) OVER (), 0), 2) AS pct_rows,
+      data_compressed_bytes,
+      formatReadableSize(data_compressed_bytes) AS readable_compressed,
+      round(
+        data_compressed_bytes * 100.0 / nullIf(max(data_compressed_bytes) OVER (), 0),
+        2
+      ) AS pct_compressed,
+      data_uncompressed_bytes,
+      formatReadableSize(data_uncompressed_bytes) AS readable_uncompressed,
+      round(
+        data_uncompressed_bytes * 100.0 / nullIf(max(data_uncompressed_bytes) OVER (), 0),
+        2
+      ) AS pct_uncompressed,
+      compression_ratio,
+      round(
+        compression_ratio * 100.0 / nullIf(max(compression_ratio) OVER (), 0),
+        2
+      ) AS pct_compression_ratio,
+      bytes_on_disk,
+      formatReadableSize(bytes_on_disk) AS readable_bytes_on_disk,
+      round(
+        bytes_on_disk * 100.0 / nullIf(max(bytes_on_disk) OVER (), 0),
+        2
+      ) AS pct_bytes_on_disk
+    FROM agg
+    ORDER BY data_compressed_bytes DESC
+  `,
+  columns: [
+    'full_table',
+    'parts',
+    'readable_rows',
+    'readable_compressed',
+    'readable_uncompressed',
+    'compression_ratio',
+    'readable_bytes_on_disk',
+  ],
+  columnFormats: {
+    full_table: ColumnFormat.ColoredBadge,
+    readable_rows: ColumnFormat.BackgroundBar,
+    readable_compressed: ColumnFormat.BackgroundBar,
+    readable_uncompressed: ColumnFormat.BackgroundBar,
+    compression_ratio: ColumnFormat.BackgroundBar,
+    readable_bytes_on_disk: ColumnFormat.BackgroundBar,
+  },
+  sortingFns: {
+    readable_rows: 'sort_column_using_actual_value',
+    readable_compressed: 'sort_column_using_actual_value',
+    readable_uncompressed: 'sort_column_using_actual_value',
+    readable_bytes_on_disk: 'sort_column_using_actual_value',
+  },
+}
+
+/**
+ * Storage policy and volume tier configuration.
+ *
+ * Uses system.storage_policies to show which disks are assigned to each
+ * volume and what limits apply, enabling tiered-storage audits.
+ */
+export const storagePoliciesConfig: QueryConfig = {
+  name: 'storage-policies',
+  description:
+    'Storage policies and volume configurations from system.storage_policies',
+  sql: `
+    SELECT
+      policy_name,
+      volume_name,
+      volume_priority,
+      arrayStringConcat(disks, ', ') AS disk_list,
+      max_data_part_size,
+      if(
+        max_data_part_size > 0,
+        formatReadableSize(max_data_part_size),
+        '∞'
+      ) AS readable_max_part_size,
+      move_factor,
+      prefer_not_to_merge,
+      perform_ttl_move_on_insert
+    FROM system.storage_policies
+    ORDER BY policy_name, volume_priority
+  `,
+  columns: [
+    'policy_name',
+    'volume_name',
+    'volume_priority',
+    'disk_list',
+    'readable_max_part_size',
+    'move_factor',
+    'prefer_not_to_merge',
+    'perform_ttl_move_on_insert',
+  ],
+  columnFormats: {
+    policy_name: ColumnFormat.ColoredBadge,
+    prefer_not_to_merge: ColumnFormat.Boolean,
+    perform_ttl_move_on_insert: ColumnFormat.Boolean,
+  },
+}
+
+/**
+ * TTL-triggered part move activity.
+ *
+ * Filters system.part_log for MovePart events (event_type = 6) to show
+ * which tables are actively moving data between storage tiers via TTL rules.
+ * Requires system.part_log to be enabled.
+ */
+export const ttlStorageMovesConfig: QueryConfig = {
+  name: 'ttl-storage-moves',
+  defaultView: 'auto',
+  card: { primary: 'part_name', badges: ['event_type', 'disk_name'] },
+  description:
+    'Part moves triggered by TTL storage policies, from system.part_log',
+  optional: true,
+  tableCheck: 'system.part_log',
+  sql: `
+    SELECT
+      event_time,
+      database || '.' || table AS full_table,
+      part_name,
+      partition_id,
+      disk_name,
+      size_in_bytes,
+      formatReadableSize(size_in_bytes) AS readable_size,
+      round(
+        size_in_bytes * 100.0 / nullIf(max(size_in_bytes) OVER (), 0),
+        2
+      ) AS pct_size,
+      rows,
+      formatReadableQuantity(rows) AS readable_rows,
+      round(rows * 100.0 / nullIf(max(rows) OVER (), 0), 2) AS pct_rows,
+      duration_ms,
+      formatReadableTimeDelta(duration_ms / 1000) AS readable_duration,
+      round(duration_ms * 100.0 / nullIf(max(duration_ms) OVER (), 0), 2) AS pct_duration,
+      error,
+      exception
+    FROM system.part_log
+    WHERE toInt8(event_type) = 6
+    ORDER BY event_time DESC
+    LIMIT 500
+  `,
+  columns: [
+    'event_time',
+    'full_table',
+    'part_name',
+    'partition_id',
+    'disk_name',
+    'readable_size',
+    'readable_rows',
+    'readable_duration',
+    'error',
+    'exception',
+  ],
+  columnFormats: {
+    event_time: ColumnFormat.RelatedTime,
+    full_table: ColumnFormat.ColoredBadge,
+    part_name: ColumnFormat.Code,
+    disk_name: ColumnFormat.ColoredBadge,
+    readable_size: ColumnFormat.BackgroundBar,
+    readable_rows: ColumnFormat.BackgroundBar,
+    readable_duration: ColumnFormat.BackgroundBar,
+    exception: ColumnFormat.CodeDialog,
+  },
+  rowClassName: (row) => {
+    if (row.error && Number(row.error) !== 0)
+      return 'bg-red-50 dark:bg-red-950/20'
+    return ''
+  },
+}

--- a/apps/dashboard/src/lib/query-config/tables/part-info.ts
+++ b/apps/dashboard/src/lib/query-config/tables/part-info.ts
@@ -50,7 +50,10 @@ export const partInfoConfig: QueryConfig = {
           min_date,
           max_date,
           disk_name,
-          path
+          path,
+          toUInt64(0) AS files_count,
+          '0' AS readable_files_count,
+          toFloat64(0) AS pct_files_count
         FROM parts_data
         ORDER BY name ASC
       `,
@@ -92,7 +95,56 @@ export const partInfoConfig: QueryConfig = {
           min_date,
           max_date,
           disk_name,
-          path
+          path,
+          toUInt64(0) AS files_count,
+          '0' AS readable_files_count,
+          toFloat64(0) AS pct_files_count
+        FROM parts_data
+        ORDER BY name ASC
+      `,
+    },
+    {
+      since: '26.1',
+      description:
+        'Includes files column: number of files per part (high count may indicate fragmentation)',
+      sql: `
+        WITH parts_data AS (
+          SELECT
+            *,
+            round(data_uncompressed_bytes / nullIf(data_compressed_bytes, 0), 2) AS compression_ratio
+          FROM system.parts
+          WHERE database = {database: String}
+            AND table = {table: String}
+            AND active = 1
+        )
+        SELECT
+          name,
+          partition,
+          level,
+          round(level * 100.0 / nullIf(max(level) OVER (), 0), 2) AS pct_level,
+          rows,
+          formatReadableQuantity(rows) as readable_rows,
+          round(rows * 100.0 / nullIf(max(rows) OVER (), 0), 2) AS pct_rows,
+          data_compressed_bytes,
+          formatReadableSize(data_compressed_bytes) AS readable_compressed,
+          round(data_compressed_bytes * 100.0 / nullIf(max(data_compressed_bytes) OVER (), 0), 2) AS pct_compressed,
+          data_uncompressed_bytes,
+          formatReadableSize(data_uncompressed_bytes) AS readable_uncompressed,
+          round(data_uncompressed_bytes * 100.0 / nullIf(max(data_uncompressed_bytes) OVER (), 0), 2) AS pct_uncompressed,
+          compression_ratio,
+          round(compression_ratio * 100.0 / nullIf(max(compression_ratio) OVER (), 0), 2) AS pct_compression_ratio,
+          marks,
+          primary_key_bytes_in_memory,
+          formatReadableSize(primary_key_bytes_in_memory) AS readable_primary_key_size,
+          round(primary_key_bytes_in_memory * 100.0 / nullIf(max(primary_key_bytes_in_memory) OVER (), 0), 2) AS pct_primary_key_size,
+          modification_time,
+          min_date,
+          max_date,
+          disk_name,
+          path,
+          length(files) AS files_count,
+          formatReadableQuantity(files_count) AS readable_files_count,
+          round(files_count * 100.0 / nullIf(max(files_count) OVER (), 0), 2) AS pct_files_count
         FROM parts_data
         ORDER BY name ASC
       `,
@@ -109,6 +161,7 @@ export const partInfoConfig: QueryConfig = {
     'compression_ratio',
     'marks',
     'readable_primary_key_size',
+    'readable_files_count',
     'modification_time',
     'min_date',
     'max_date',
@@ -124,6 +177,8 @@ export const partInfoConfig: QueryConfig = {
     compression_ratio: ColumnFormat.BackgroundBar,
     marks: ColumnFormat.Number,
     readable_primary_key_size: ColumnFormat.BackgroundBar,
+    // CH 26.1+: number of files per part; high values may indicate fragmentation
+    readable_files_count: ColumnFormat.BackgroundBar,
     modification_time: ColumnFormat.RelatedTime,
     disk_name: ColumnFormat.ColoredBadge,
   },

--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -19,6 +19,7 @@ import {
   AlertTriangleIcon,
   BookOpenIcon,
   CircleDollarSignIcon,
+  CloudIcon,
   CombineIcon,
   CpuIcon,
   DownloadIcon,
@@ -668,6 +669,16 @@ export const menuItemsConfig: MenuItem[] = [
         tableCheck: 'system.disks',
       },
       {
+        title: 'Storage Economics',
+        href: '/storage-economics',
+        description:
+          'Per-table compression ratios, storage cost, storage policies, and TTL move activity',
+        icon: CircleDollarSignIcon,
+        isNew: true,
+        docs: 'https://clickhouse.com/docs/en/operations/system-tables/parts',
+        tableCheck: 'system.parts',
+      },
+      {
         title: 'Warnings',
         href: '/warnings',
         description:
@@ -728,6 +739,16 @@ export const menuItemsConfig: MenuItem[] = [
         icon: ArchiveIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/backup_log',
         tableCheck: 'system.backup_log',
+      },
+      {
+        title: 'Blob Storage Log',
+        href: '/blob-storage-log',
+        description:
+          'Object storage I/O operations (reads, writes, deletes) on S3/blob disks',
+        icon: CloudIcon,
+        isNew: true,
+        docs: 'https://clickhouse.com/docs/en/operations/system-tables/blob_storage_log',
+        tableCheck: 'system.blob_storage_log',
       },
       {
         title: 'Errors',

--- a/apps/dashboard/src/routes/(dashboard)/blob-storage-log.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/blob-storage-log.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { Suspense } from 'react'
+import { PageLayout } from '@/components/layout/query-page'
+import { PageSkeleton } from '@/components/skeletons'
+import { pageOgHead } from '@/lib/og'
+import { blobStorageLogConfig } from '@/lib/query-config/system/blob-storage-log'
+
+function BlobStorageLogPageContent() {
+  return (
+    <PageLayout queryConfig={blobStorageLogConfig} title="Blob Storage Log" />
+  )
+}
+
+function BlobStorageLogPage() {
+  return (
+    <Suspense fallback={<PageSkeleton />}>
+      <BlobStorageLogPageContent />
+    </Suspense>
+  )
+}
+
+export const Route = createFileRoute('/(dashboard)/blob-storage-log')({
+  component: BlobStorageLogPage,
+  head: () => pageOgHead('blob-storage-log'),
+})

--- a/apps/dashboard/src/routes/(dashboard)/storage-economics.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/storage-economics.tsx
@@ -1,0 +1,43 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { Suspense } from 'react'
+import { PageLayout } from '@/components/layout/query-page'
+import { PageSkeleton } from '@/components/skeletons'
+import { pageOgHead } from '@/lib/og'
+import {
+  storagePoliciesConfig,
+  storageCompressionConfig,
+  ttlStorageMovesConfig,
+} from '@/lib/query-config/system/storage-economics'
+
+function StorageEconomicsPageContent() {
+  return (
+    <div className="flex flex-col gap-6">
+      <PageLayout
+        queryConfig={storageCompressionConfig}
+        title="Compression by Table"
+      />
+      <PageLayout
+        queryConfig={storagePoliciesConfig}
+        title="Storage Policies"
+      />
+      <PageLayout
+        queryConfig={ttlStorageMovesConfig}
+        title="TTL Storage Moves"
+      />
+    </div>
+  )
+}
+
+function StorageEconomicsPage() {
+  return (
+    <Suspense fallback={<PageSkeleton />}>
+      <StorageEconomicsPageContent />
+    </Suspense>
+  )
+}
+
+export const Route = createFileRoute('/(dashboard)/storage-economics')({
+  component: StorageEconomicsPage,
+  head: () => pageOgHead('storage-economics'),
+})


### PR DESCRIPTION
## Summary

- **#1899 (P1) — Blob Storage Log**: New `system.blob_storage_log` view (optional, since CH 23.11). Shows object-storage I/O operations (reads, writes, deletes) with `event_type`/`bucket`/`remote_path` columns, `readable_data_size` BackgroundBar, error row-highlighting, and `query_id` → query-detail link. Route `/blob-storage-log` + menu entry under Operations.

- **#1912 (P0) — Storage Economics**: New `/storage-economics` route with three stacked sections: (1) `storageCompressionConfig` — per-table compressed/uncompressed bytes + compression ratio from `system.parts` with BackgroundBar; (2) `storagePoliciesConfig` — `system.storage_policies` volume/disk mappings; (3) `ttlStorageMovesConfig` — `system.part_log` `MovePart` events (optional). Menu entry under System.

- **#1907 (P2) — New background-op columns** (gated by `since`, no regression on older CH):
  - `merges.ts` → VersionedSql[]; since 26.6 adds `current_projection` (Code), `readable_current_projection_progress` (BackgroundBar), `projections_completed`/`projections_remaining` (Number).
  - `mutations.ts` → VersionedSql[]; since 25.12 adds `parts_in_progress_names` to SELECT; `expandable: true` surfaces it (plus `parts_to_do_names`) in the row expansion panel.
  - `part-info.ts` → third VersionedSql since 26.1: `length(files) AS files_count` with `readable_files_count` BackgroundBar; pre-26.1 variants use `0` placeholders.

## Test plan

- [ ] Lint + type-check pass in CI (`bun run lint && bun run build`)
- [ ] Query-config unit tests pass — all VersionedSql variants output the same columns as `columns[]`
- [ ] `/blob-storage-log` renders empty-state gracefully when `system.blob_storage_log` absent
- [ ] `/storage-economics` loads compression table; storage-policies + TTL-moves sections handle empty/absent tables
- [ ] Merges page shows new projection columns on CH 26.6+; shows placeholder `-`/`0` on older versions
- [ ] Mutations page row expansion shows `parts_in_progress_names` on CH 25.12+
- [ ] Part-info page shows `readable_files_count` BackgroundBar on CH 26.1+, shows `0` on older versions

> **Note**: `system.blob_storage_log` column names (`event_type`, `bucket`, `remote_path`, `data_size`, `disk_name`) need live verification against CH 23.11+. The `system.storage_policies` columns `perform_ttl_move_on_insert` may not exist on all CH versions — if CI fails, that column can be removed from `storagePoliciesConfig`.

Closes #1899, #1912, #1907

https://claude.ai/code/session_01TnsycTkdMHJ4DXohpuz3oj