### PR TITLE
fix(query-config): sync declarative parity for merges/mutations/part-info

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/merges/merges.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/merges/merges.ts
@@ -7,21 +7,60 @@ export const mergesDeclarative: DeclarativeQueryConfig = {
   refreshInterval: 30000,
   description:
     'Merges and part mutations currently in process for tables in the MergeTree family',
-  sql: `
-      SELECT *,
-        database || '.' || table as table,
-        round(100 * num_parts / max(num_parts) OVER ()) as pct_num_parts,
-        round(progress * 100, 1) as pct_progress,
-        (cast(pct_progress, 'String') || '%') as readable_progress,
-        round(100 * rows_read / max(rows_read) OVER ()) as pct_rows_read,
-        formatReadableQuantity(rows_read) as readable_rows_read,
-        round(100 * rows_written / max(rows_written) OVER ()) as pct_rows_written,
-        formatReadableQuantity(rows_written) as readable_rows_written,
-        round(100 * memory_usage / max(memory_usage) OVER ()) as pct_memory_usage,
-        formatReadableSize(memory_usage) as readable_memory_usage
-      FROM system.merges
-      ORDER BY progress DESC
-    `,
+  // Version-aware queries (oldest → newest)
+  // 26.6 adds per-projection tracking: current_projection,
+  // current_projection_progress, projections_completed, projections_remaining.
+  sql: [
+    {
+      since: '19.1',
+      description: 'Base query — projection tracking columns not available',
+      sql: `
+        SELECT *,
+          database || '.' || table as table,
+          round(100 * num_parts / max(num_parts) OVER ()) as pct_num_parts,
+          round(progress * 100, 1) as pct_progress,
+          (cast(pct_progress, 'String') || '%') as readable_progress,
+          round(100 * rows_read / max(rows_read) OVER ()) as pct_rows_read,
+          formatReadableQuantity(rows_read) as readable_rows_read,
+          round(100 * rows_written / max(rows_written) OVER ()) as pct_rows_written,
+          formatReadableQuantity(rows_written) as readable_rows_written,
+          round(100 * memory_usage / max(memory_usage) OVER ()) as pct_memory_usage,
+          formatReadableSize(memory_usage) as readable_memory_usage,
+          '-' AS current_projection,
+          toFloat64(0) AS current_projection_progress,
+          '0%' AS readable_current_projection_progress,
+          toFloat64(0) AS pct_current_projection_progress,
+          toUInt64(0) AS projections_completed,
+          toUInt64(0) AS projections_remaining
+        FROM system.merges
+        ORDER BY progress DESC
+      `,
+    },
+    {
+      since: '26.6',
+      description:
+        'Includes projection tracking: current_projection, projections_completed/remaining',
+      sql: `
+        SELECT *,
+          database || '.' || table as table,
+          round(100 * num_parts / max(num_parts) OVER ()) as pct_num_parts,
+          round(progress * 100, 1) as pct_progress,
+          (cast(pct_progress, 'String') || '%') as readable_progress,
+          round(100 * rows_read / max(rows_read) OVER ()) as pct_rows_read,
+          formatReadableQuantity(rows_read) as readable_rows_read,
+          round(100 * rows_written / max(rows_written) OVER ()) as pct_rows_written,
+          formatReadableQuantity(rows_written) as readable_rows_written,
+          round(100 * memory_usage / max(memory_usage) OVER ()) as pct_memory_usage,
+          formatReadableSize(memory_usage) as readable_memory_usage,
+          concat(toString(round(current_projection_progress * 100, 1)), '%')
+            AS readable_current_projection_progress,
+          round(current_projection_progress * 100, 0)
+            AS pct_current_projection_progress
+        FROM system.merges
+        ORDER BY progress DESC
+      `,
+    },
+  ],
   columns: [
     'table',
     'partition_id',
@@ -34,6 +73,10 @@ export const mergesDeclarative: DeclarativeQueryConfig = {
     'is_mutation',
     'merge_type',
     'merge_algorithm',
+    'current_projection',
+    'readable_current_projection_progress',
+    'projections_completed',
+    'projections_remaining',
   ],
   columnFormats: {
     table: 'colored-badge',
@@ -44,6 +87,10 @@ export const mergesDeclarative: DeclarativeQueryConfig = {
     readable_memory_usage: 'background-bar',
     readable_rows_read: 'background-bar',
     readable_rows_written: 'background-bar',
+    current_projection: 'code',
+    readable_current_projection_progress: 'background-bar',
+    projections_completed: 'number',
+    projections_remaining: 'number',
   },
   relatedCharts: [
     [

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/merges/mutations.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/merges/mutations.ts
@@ -11,25 +11,60 @@ export const mutationsDeclarative: DeclarativeQueryConfig = {
   refreshInterval: 30_000,
   description:
     'Information about mutations of MergeTree tables and their progress',
-  sql: `
-      SELECT
-        database || '.' || table as table,
-        mutation_id,
-        command,
-        create_time,
-        now() - create_time AS elapsed,
-        parts_to_do,
-        formatReadableQuantity(parts_to_do) AS readable_parts_to_do,
-        round(100 * parts_to_do / nullIf(max(parts_to_do) OVER (), 0), 2) as pct_parts_to_do,
-        parts_to_do_names,
-        is_done,
-        if(is_done = 0 AND parts_to_do > 0 AND (now() - create_time) > 600, 1, 0) AS is_stuck,
-        latest_failed_part,
-        latest_fail_time,
-        latest_fail_reason
-      FROM system.mutations
-      ORDER BY is_done ASC, is_stuck DESC, create_time DESC
-    `,
+  // Version-aware queries (oldest → newest)
+  // 25.12 adds parts_in_progress_names: names of parts currently being mutated.
+  // The expanded row panel surfaces this field (expandable below).
+  sql: [
+    {
+      since: '19.1',
+      description: 'Base query — parts_in_progress_names not available',
+      sql: `
+        SELECT
+          database || '.' || table as table,
+          mutation_id,
+          command,
+          create_time,
+          now() - create_time AS elapsed,
+          parts_to_do,
+          formatReadableQuantity(parts_to_do) AS readable_parts_to_do,
+          round(100 * parts_to_do / nullIf(max(parts_to_do) OVER (), 0), 2) as pct_parts_to_do,
+          parts_to_do_names,
+          [] AS parts_in_progress_names,
+          is_done,
+          if(is_done = 0 AND parts_to_do > 0 AND (now() - create_time) > ${600}, 1, 0) AS is_stuck,
+          latest_failed_part,
+          latest_fail_time,
+          latest_fail_reason
+        FROM system.mutations
+        ORDER BY is_done ASC, is_stuck DESC, create_time DESC
+      `,
+    },
+    {
+      since: '25.12',
+      description:
+        'Includes parts_in_progress_names: names of parts currently being mutated',
+      sql: `
+        SELECT
+          database || '.' || table as table,
+          mutation_id,
+          command,
+          create_time,
+          now() - create_time AS elapsed,
+          parts_to_do,
+          formatReadableQuantity(parts_to_do) AS readable_parts_to_do,
+          round(100 * parts_to_do / nullIf(max(parts_to_do) OVER (), 0), 2) as pct_parts_to_do,
+          parts_to_do_names,
+          parts_in_progress_names,
+          is_done,
+          if(is_done = 0 AND parts_to_do > 0 AND (now() - create_time) > ${600}, 1, 0) AS is_stuck,
+          latest_failed_part,
+          latest_fail_time,
+          latest_fail_reason
+        FROM system.mutations
+        ORDER BY is_done ASC, is_stuck DESC, create_time DESC
+      `,
+    },
+  ],
   columns: [
     'is_done',
     'is_stuck',
@@ -50,6 +85,24 @@ export const mutationsDeclarative: DeclarativeQueryConfig = {
     is_stuck: 'boolean',
     elapsed: 'duration',
     readable_parts_to_do: 'background-bar',
+  },
+  // Expanding a row surfaces parts_to_do_names and parts_in_progress_names
+  // (in CH 25.12+) in the full-width detail panel.
+  expandable: {
+    type: 'config-details',
+    primaryColumns: [
+      'is_done',
+      'is_stuck',
+      'table',
+      'mutation_id',
+      'command',
+      'create_time',
+      'elapsed',
+      'readable_parts_to_do',
+      'latest_failed_part',
+      'latest_fail_time',
+      'latest_fail_reason',
+    ],
   },
   // Replaces the legacy rowClassName:
   //   is_stuck truthy           -> red

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/part-info.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/part-info.ts
@@ -6,6 +6,10 @@ export const partInfoDeclarative: DeclarativeQueryConfig = {
   card: { primary: 'name', badges: ['partition'] },
   description:
     'Information about currently active parts and levels for a table',
+
+  // Version-aware SQL queries (oldest → newest)
+  // Note: 'marks' is the correct column (NOT 'marks_count')
+  // BackgroundBar requires pct_{column} for percentage-based rendering
   sql: [
     {
       since: '19.1',
@@ -44,7 +48,10 @@ export const partInfoDeclarative: DeclarativeQueryConfig = {
           min_date,
           max_date,
           disk_name,
-          path
+          path,
+          toUInt64(0) AS files_count,
+          '0' AS readable_files_count,
+          toFloat64(0) AS pct_files_count
         FROM parts_data
         ORDER BY name ASC
       `,
@@ -86,12 +93,62 @@ export const partInfoDeclarative: DeclarativeQueryConfig = {
           min_date,
           max_date,
           disk_name,
-          path
+          path,
+          toUInt64(0) AS files_count,
+          '0' AS readable_files_count,
+          toFloat64(0) AS pct_files_count
+        FROM parts_data
+        ORDER BY name ASC
+      `,
+    },
+    {
+      since: '26.1',
+      description:
+        'Includes files column: number of files per part (high count may indicate fragmentation)',
+      sql: `
+        WITH parts_data AS (
+          SELECT
+            *,
+            round(data_uncompressed_bytes / nullIf(data_compressed_bytes, 0), 2) AS compression_ratio
+          FROM system.parts
+          WHERE database = {database: String}
+            AND table = {table: String}
+            AND active = 1
+        )
+        SELECT
+          name,
+          partition,
+          level,
+          round(level * 100.0 / nullIf(max(level) OVER (), 0), 2) AS pct_level,
+          rows,
+          formatReadableQuantity(rows) as readable_rows,
+          round(rows * 100.0 / nullIf(max(rows) OVER (), 0), 2) AS pct_rows,
+          data_compressed_bytes,
+          formatReadableSize(data_compressed_bytes) AS readable_compressed,
+          round(data_compressed_bytes * 100.0 / nullIf(max(data_compressed_bytes) OVER (), 0), 2) AS pct_compressed,
+          data_uncompressed_bytes,
+          formatReadableSize(data_uncompressed_bytes) AS readable_uncompressed,
+          round(data_uncompressed_bytes * 100.0 / nullIf(max(data_uncompressed_bytes) OVER (), 0), 2) AS pct_uncompressed,
+          compression_ratio,
+          round(compression_ratio * 100.0 / nullIf(max(compression_ratio) OVER (), 0), 2) AS pct_compression_ratio,
+          marks,
+          primary_key_bytes_in_memory,
+          formatReadableSize(primary_key_bytes_in_memory) AS readable_primary_key_size,
+          round(primary_key_bytes_in_memory * 100.0 / nullIf(max(primary_key_bytes_in_memory) OVER (), 0), 2) AS pct_primary_key_size,
+          modification_time,
+          min_date,
+          max_date,
+          disk_name,
+          path,
+          length(files) AS files_count,
+          formatReadableQuantity(files_count) AS readable_files_count,
+          round(files_count * 100.0 / nullIf(max(files_count) OVER (), 0), 2) AS pct_files_count
         FROM parts_data
         ORDER BY name ASC
       `,
     },
   ],
+
   columns: [
     'name',
     'partition',
@@ -102,6 +159,7 @@ export const partInfoDeclarative: DeclarativeQueryConfig = {
     'compression_ratio',
     'marks',
     'readable_primary_key_size',
+    'readable_files_count',
     'modification_time',
     'min_date',
     'max_date',
@@ -117,6 +175,8 @@ export const partInfoDeclarative: DeclarativeQueryConfig = {
     compression_ratio: 'background-bar',
     marks: 'number',
     readable_primary_key_size: 'background-bar',
+    // CH 26.1+: number of files per part; high values may indicate fragmentation
+    readable_files_count: 'background-bar',
     modification_time: 'related-time',
     disk_name: 'colored-badge',
   },

--- a/apps/dashboard/src/lib/query-config/merges/mutations.test.ts
+++ b/apps/dashboard/src/lib/query-config/merges/mutations.test.ts
@@ -74,58 +74,70 @@ describe('card config', () => {
 // ---------------------------------------------------------------------------
 
 describe('SQL content', () => {
-  const sql = mutationsConfig.sql as string
+  // sql is now a versioned array (VersionedSql[]) — two entries: 19.1 base
+  // and 25.12 which adds parts_in_progress_names.
+  const sqlField = mutationsConfig.sql
+  const sqlEntries = sqlField as Array<{
+    since: string
+    sql: string
+    description?: string
+  }>
+  // Combined SQL for content assertions that apply across all versions
+  const allSql = sqlEntries.map((e) => e.sql).join('\n')
 
-  test('sql is a string', () => {
-    expect(typeof sql).toBe('string')
+  test('sql is a versioned array with 2 entries (19.1 base, 25.12 adds parts_in_progress_names)', () => {
+    expect(Array.isArray(sqlField)).toBe(true)
+    expect(sqlEntries.length).toBe(2)
+    expect(sqlEntries[0].since).toBe('19.1')
+    expect(sqlEntries[1].since).toBe('25.12')
   })
 
   test('queries system.mutations', () => {
-    expect(sql).toContain('system.mutations')
+    expect(allSql).toContain('system.mutations')
   })
 
   test('selects database and table as concatenated "table" column', () => {
-    expect(sql).toContain("database || '.' || table as table")
+    expect(allSql).toContain("database || '.' || table as table")
   })
 
   test('includes mutation_id', () => {
-    expect(sql).toContain('mutation_id')
+    expect(allSql).toContain('mutation_id')
   })
 
   test('includes command', () => {
-    expect(sql).toContain('command')
+    expect(allSql).toContain('command')
   })
 
   test('includes create_time and elapsed', () => {
-    expect(sql).toContain('create_time')
-    expect(sql).toContain('now() - create_time AS elapsed')
+    expect(allSql).toContain('create_time')
+    expect(allSql).toContain('now() - create_time AS elapsed')
   })
 
   test('includes parts_to_do with background-bar triple', () => {
-    expect(sql).toContain('parts_to_do')
-    expect(sql).toContain(
+    expect(allSql).toContain('parts_to_do')
+    expect(allSql).toContain(
       'formatReadableQuantity(parts_to_do) AS readable_parts_to_do'
     )
-    expect(sql).toContain('pct_parts_to_do')
+    expect(allSql).toContain('pct_parts_to_do')
   })
 
   test('includes is_done', () => {
-    expect(sql).toContain('is_done')
+    expect(allSql).toContain('is_done')
   })
 
   test('is_stuck derived using STUCK_THRESHOLD_SECONDS (600)', () => {
-    expect(sql).toContain('is_stuck')
-    expect(sql).toContain(String(STUCK_THRESHOLD_SECONDS))
+    expect(allSql).toContain('is_stuck')
+    expect(allSql).toContain(String(STUCK_THRESHOLD_SECONDS))
   })
 
   test('includes latest_failed_part, latest_fail_time, latest_fail_reason', () => {
-    expect(sql).toContain('latest_failed_part')
-    expect(sql).toContain('latest_fail_time')
-    expect(sql).toContain('latest_fail_reason')
+    expect(allSql).toContain('latest_failed_part')
+    expect(allSql).toContain('latest_fail_time')
+    expect(allSql).toContain('latest_fail_reason')
   })
 
   test('orders by is_done ASC, is_stuck DESC, create_time DESC', () => {
-    expect(sql).toContain(
+    expect(allSql).toContain(
       'ORDER BY is_done ASC, is_stuck DESC, create_time DESC'
     )
   })


### PR DESCRIPTION
## Summary

Hotfix: PR #1962 updated the legacy `merges/merges.ts`, `merges/mutations.ts`, and `tables/part-info.ts` query configs with new ClickHouse columns but did not sync their declarative-catalog mirrors, breaking the parity/flip-safety tests on `main`.

- **merges**: Switch declarative to versioned `sql[]` (19.1 base + 26.6 adds projection tracking columns); add `current_projection`, `readable_current_projection_progress`, `projections_completed`, `projections_remaining` to `columns` + `columnFormats`
- **mutations**: Switch declarative to versioned `sql[]` (19.1 base + 25.12 adds `parts_in_progress_names`); add `expandable: { type: 'config-details' }` so the behavior-field flip-safety assertion does not drop `expandable`
- **part-info**: Add `files_count` stub columns to 19.1 and 21.8 variants; add new 26.1 variant with `length(files)`; add `readable_files_count` to `columns` + `columnFormats`
- **mutations.test.ts**: Update the SQL content unit test block from single-string to versioned-array assertions (`sql` was changed to `VersionedSql[]` by #1962 but this test was not updated)

## Test plan

- `bun run test:query-config` → **880 pass, 0 fail** (verified locally)

https://claude.ai/code/session_01TnsycTkdMHJ4DXohpuz3oj