### PR TITLE
fix(routes): register OG metadata for 3 new monitoring pages

### DIFF
--- a/apps/dashboard/src/lib/og.ts
+++ b/apps/dashboard/src/lib/og.ts
@@ -59,6 +59,27 @@ export const OG_PAGES: Record<string, OgPage> = {
       'An AI agent that answers questions about queries, schema, performance and health.',
   },
 
+  // ── New monitoring pages (audit wave): registered so pageOgHead() does not
+  //    throw "Cannot read properties of undefined (reading 'headTitle')" at prerender.
+  'blob-storage-log': {
+    eyebrow: 'STORAGE',
+    title: 'Object Storage Operations',
+    description:
+      'Uploads, deletes and errors against S3/GCS/Azure object storage from system.blob_storage_log.',
+  },
+  'storage-economics': {
+    eyebrow: 'STORAGE',
+    title: 'Storage Economics',
+    description:
+      'Compression ratios, tier utilization and TTL moves to track storage cost and efficiency.',
+  },
+  'query-condition-cache': {
+    eyebrow: 'CACHE',
+    title: 'Query Condition Cache',
+    description:
+      'Usage of the query condition cache (ClickHouse 25.3+) that skips granules for filtered scans.',
+  },
+
   // ── New: key query / monitoring pages.
   'running-queries': {
     eyebrow: 'QUERIES',


### PR DESCRIPTION
The new routes from #1962/#1963 (blob-storage-log, storage-economics, query-condition-cache) called `pageOgHead()` with slugs not in `OG_PAGES`, causing 'Cannot read properties of undefined (reading headTitle)' prerender errors. Registers the three entries. `bun test og.test.ts` green (25 pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Open Graph page metadata for three additional dashboard pages, improving how they appear when shared or previewed.
  * These pages now have complete titles and descriptions, helping prevent missing preview details during prerendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->