### PR TITLE
feat(alerting): pluggable rule engine + repl-lag/slow-query/MV-refresh rules

### DIFF
--- a/apps/dashboard/src/components/alerting/mv-staleness-badge.tsx
+++ b/apps/dashboard/src/components/alerting/mv-staleness-badge.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+/**
+ * MV Staleness Badge (#1925)
+ *
+ * A badge that shows the count of stale/failed materialized view refreshes.
+ * Rendered in the view-refreshes page header. Dispatches an in-app alert
+ * when failed/stale views are detected.
+ */
+
+import { AlertTriangle } from 'lucide-react'
+
+import { useEffect } from 'react'
+import { Badge } from '@/components/ui/badge'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { dispatchAlert } from '@/lib/health/alert-dispatcher'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
+import { cn } from '@/lib/utils'
+import {
+  countMvIssues,
+  formatMvStaleness,
+  type MvRefreshRow,
+} from '@/lib/alerting/mv-refresh-staleness'
+
+interface MvStalenessBadgeProps {
+  hostId: number
+  className?: string
+}
+
+/**
+ * MvStalenessBadge — shows a count badge when failed/stale MV refreshes exist.
+ * Invisible when all views are healthy.
+ */
+export function MvStalenessBadge({ hostId, className }: MvStalenessBadgeProps) {
+  const { data, isLoading } = useChartData<MvRefreshRow>({
+    chartName: 'mv-staleness',
+    hostId,
+    refreshInterval: REFRESH_INTERVAL.MEDIUM_30S,
+  })
+
+  const rows: MvRefreshRow[] = Array.isArray(data) ? data : []
+  const { failed, stale } = countMvIssues(rows)
+  const total = failed + stale
+
+  // Dispatch alert when issues are found
+  useEffect(() => {
+    if (total === 0) return
+    void dispatchAlert({
+      checkId: 'mv-refresh-failures',
+      title: 'MV Refresh Failures',
+      severity: failed > 0 ? 'critical' : 'warning',
+      value: total,
+      label: `${failed} failed, ${stale} stale materialized view${total === 1 ? '' : 's'}`,
+      hostId,
+      incidentId: `mvr-${hostId}-${Math.floor(Date.now() / 300_000)}`,
+    })
+  }, [total, failed, stale, hostId])
+
+  if (isLoading || total === 0) return null
+
+  const label = [
+    failed > 0 && `${failed} failed`,
+    stale > 0 && `${stale} stale`,
+  ]
+    .filter(Boolean)
+    .join(', ')
+
+  const worstRow = rows
+    .filter(
+      (r) =>
+        r.status === 'Error' ||
+        r.status === 'Failed' ||
+        r.staleness_seconds > 3600
+    )
+    .sort(
+      (a, b) => Number(b.staleness_seconds) - Number(a.staleness_seconds)
+    )[0]
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge
+          variant="outline"
+          className={cn(
+            'inline-flex items-center gap-1 cursor-default select-none',
+            failed > 0
+              ? 'border-destructive/40 bg-destructive/10 text-destructive'
+              : 'border-amber-400 bg-amber-100 text-amber-700 dark:border-amber-600 dark:bg-amber-900/40 dark:text-amber-300',
+            className
+          )}
+        >
+          <AlertTriangle className="size-3" />
+          {label}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-60 text-xs">
+        {total} materialized view{total === 1 ? '' : 's'} need attention.
+        {worstRow && (
+          <span className="block mt-1 font-mono">
+            Worst: {worstRow.database}.{worstRow.view} (
+            {formatMvStaleness(Number(worstRow.staleness_seconds))} stale)
+          </span>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/dashboard/src/components/alerting/regression-panel.tsx
+++ b/apps/dashboard/src/components/alerting/regression-panel.tsx
@@ -32,7 +32,7 @@ export function RegressionPanel({ hostId, className }: RegressionPanelProps) {
   const { data, isLoading, error } = useChartData<SlowQueryRegression>({
     chartName: 'slow-query-regressions',
     hostId,
-    refreshInterval: REFRESH_INTERVAL.SLOW_60S,
+    refreshInterval: REFRESH_INTERVAL.DEFAULT_60S,
   })
 
   const rows: SlowQueryRegression[] = Array.isArray(data) ? data : []

--- a/apps/dashboard/src/components/alerting/regression-panel.tsx
+++ b/apps/dashboard/src/components/alerting/regression-panel.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+/**
+ * Slow Query Regression Panel (#1921)
+ *
+ * Fetches the regression-detection chart and surfaces any fingerprints
+ * whose P95 duration has degraded significantly vs the baseline window.
+ * Feeds the alert engine via dispatchAlert() when regressions are found.
+ */
+
+import { AlertTriangle, TrendingUp } from 'lucide-react'
+
+import { useEffect } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { dispatchAlert } from '@/lib/health/alert-dispatcher'
+import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
+import { cn } from '@/lib/utils'
+import type { SlowQueryRegression } from '@/lib/alerting/slow-query-regression'
+
+interface RegressionPanelProps {
+  hostId: number
+  className?: string
+}
+
+/**
+ * RegressionPanel — renders a card listing slow-query fingerprints that
+ * have regressed (current P95 ≥ 2× baseline P95). Dispatches an in-app
+ * alert whenever at least one regression is detected.
+ */
+export function RegressionPanel({ hostId, className }: RegressionPanelProps) {
+  const { data, isLoading, error } = useChartData<SlowQueryRegression>({
+    chartName: 'slow-query-regressions',
+    hostId,
+    refreshInterval: REFRESH_INTERVAL.SLOW_60S,
+  })
+
+  const rows: SlowQueryRegression[] = Array.isArray(data) ? data : []
+
+  // Fire an alert whenever regressions are detected, deduped by incidentId.
+  useEffect(() => {
+    if (rows.length === 0) return
+    const worst = rows.reduce((a, b) =>
+      a.regression_factor > b.regression_factor ? a : b
+    )
+    void dispatchAlert({
+      checkId: 'slow-query-regression',
+      title: 'Slow Query Regression Detected',
+      severity: worst.regression_factor >= 5 ? 'critical' : 'warning',
+      value: rows.length,
+      label: `${rows.length} fingerprint${rows.length === 1 ? '' : 's'} regressed — worst: ${worst.regression_factor}× slower`,
+      hostId,
+      incidentId: `sqr-${hostId}-${Math.floor(Date.now() / 60_000)}`,
+    })
+  }, [rows.length, hostId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (isLoading) return null
+  if (error || rows.length === 0) return null
+
+  return (
+    <Card
+      className={cn(
+        'border-amber-200 bg-amber-50/50 dark:border-amber-800 dark:bg-amber-950/20',
+        className
+      )}
+    >
+      <CardHeader className="pb-2 pt-3 px-4">
+        <CardTitle className="flex items-center gap-2 text-sm font-semibold text-amber-800 dark:text-amber-300">
+          <TrendingUp className="size-4" />
+          Slow Query Regressions
+          <Badge
+            variant="outline"
+            className="ml-auto h-5 border-amber-400 bg-amber-100 px-1.5 text-[10px] text-amber-700 dark:border-amber-600 dark:bg-amber-900/40 dark:text-amber-300"
+          >
+            {rows.length}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="px-4 pb-3">
+        <p className="mb-2 text-xs text-muted-foreground">
+          Fingerprints whose P95 duration has regressed ≥2× vs the prior 24h
+          baseline.
+        </p>
+        <div className="flex flex-col gap-1.5">
+          {rows.slice(0, 5).map((row, i) => (
+            <RegressionRow key={i} row={row} />
+          ))}
+          {rows.length > 5 && (
+            <p className="text-[11px] text-muted-foreground">
+              +{rows.length - 5} more regressions
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function RegressionRow({ row }: { row: SlowQueryRegression }) {
+  const factor = Number(row.regression_factor)
+  const isCritical = factor >= 5
+
+  return (
+    <div className="flex items-start gap-2 rounded-md bg-background/60 px-2.5 py-2 text-xs">
+      <AlertTriangle
+        className={cn(
+          'mt-0.5 size-3.5 shrink-0',
+          isCritical ? 'text-destructive' : 'text-amber-600'
+        )}
+      />
+      <div className="min-w-0 flex-1">
+        <p
+          className="truncate font-mono text-[11px] text-foreground"
+          title={row.fingerprint_short as string}
+        >
+          {row.fingerprint_short}
+        </p>
+        <p className="mt-0.5 text-muted-foreground">
+          P95: {Number(row.baseline_p95_ms).toLocaleString()}ms →{' '}
+          <span
+            className={cn(
+              'font-medium',
+              isCritical
+                ? 'text-destructive'
+                : 'text-amber-700 dark:text-amber-400'
+            )}
+          >
+            {Number(row.current_p95_ms).toLocaleString()}ms
+          </span>{' '}
+          ({factor}×)
+        </p>
+      </div>
+      <Badge
+        variant="outline"
+        className={cn(
+          'shrink-0 h-5 px-1.5 text-[10px]',
+          isCritical
+            ? 'border-destructive/40 bg-destructive/10 text-destructive'
+            : 'border-amber-400 bg-amber-100 text-amber-700 dark:border-amber-600 dark:bg-amber-900/40 dark:text-amber-300'
+        )}
+      >
+        {factor}×
+      </Badge>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/health/health-checks.ts
+++ b/apps/dashboard/src/components/health/health-checks.ts
@@ -418,4 +418,144 @@ WHERE error = 'KEEPER_EXCEPTION'
     sql: `SELECT round(max((total_space - free_space) * 100.0 / nullIf(total_space, 0)), 1) AS disk_percent
 FROM system.disks`,
   },
+  {
+    id: 'failed-mutations',
+    title: 'Failed Mutations',
+    icon: XCircle,
+    chartName: 'health-failed-mutations',
+    valueKey: 'failed_count',
+    defaults: { warning: 1, critical: 5 },
+    formatLabel: fmtCount('failed mutation'),
+    description:
+      'Mutations that are not done and have recorded a failure. Failed mutations block subsequent mutations on the same table.',
+    systemTables: ['system.mutations'],
+    commonCauses: [
+      'Mutation references a column that no longer exists',
+      'Disk full on a replica preventing part writes',
+      'Hardware / network fault during part rewrite',
+    ],
+    relatedLinks: [{ label: 'Mutations', href: '/mutations' }],
+    docsLinks: [
+      {
+        label: 'system.mutations',
+        url: 'https://clickhouse.com/docs/en/operations/system-tables/mutations',
+      },
+    ],
+    sql: `SELECT countIf(is_done = 0 AND isNotNull(latest_fail_time)) AS failed_count
+FROM system.mutations`,
+  },
+  {
+    id: 'stuck-merges',
+    title: 'Stuck Merges (>10m)',
+    icon: Timer,
+    chartName: 'health-stuck-merges',
+    valueKey: 'stuck_count',
+    defaults: { warning: 1, critical: 3 },
+    formatLabel: fmtCount('stuck merge'),
+    description:
+      'Merges that have been running for more than 10 minutes. Stuck merges hold disk space, consume background threads, and can block inserts.',
+    systemTables: ['system.merges'],
+    commonCauses: [
+      'Very large parts requiring many hours to merge',
+      'Disk I/O saturation or slow storage',
+      'Insufficient background_pool_size',
+    ],
+    relatedLinks: [{ label: 'Merges', href: '/merges' }],
+    docsLinks: [
+      {
+        label: 'system.merges',
+        url: 'https://clickhouse.com/docs/en/operations/system-tables/merges',
+      },
+    ],
+    sql: `SELECT count() AS stuck_count
+FROM system.merges
+WHERE elapsed > 600`,
+  },
+  {
+    id: 'query-timeout',
+    title: 'Query Timeout Breaches (1h)',
+    icon: Clock,
+    chartName: 'health-query-timeouts',
+    valueKey: 'timeout_count',
+    defaults: { warning: 1, critical: 10 },
+    formatLabel: (v) =>
+      `${(v ?? 0).toLocaleString()} timeout kills in last hour`,
+    description:
+      'Queries terminated by TIMEOUT_EXCEEDED in the last hour. Frequent timeouts may indicate missing indexes, under-provisioned resources, or runaway queries.',
+    systemTables: ['system.query_log'],
+    commonCauses: [
+      'max_execution_time set too low for heavy analytical queries',
+      'Missing sort key for the filter predicate',
+      'Cross-shard queries without proper distribution settings',
+    ],
+    relatedLinks: [
+      { label: 'Failed Queries', href: '/failed-queries' },
+      { label: 'Slow Queries', href: '/slow-queries' },
+    ],
+    docsLinks: [
+      {
+        label: 'max_execution_time',
+        url: 'https://clickhouse.com/docs/en/operations/settings/query-complexity#max-execution-time',
+      },
+    ],
+    sql: `SELECT count() AS timeout_count
+FROM system.query_log
+WHERE event_time > now() - INTERVAL 1 HOUR
+  AND type IN ('ExceptionWhileProcessing', 'ExceptionBeforeStart')
+  AND (exception_code = 159 OR exception LIKE '%TIMEOUT_EXCEEDED%')`,
+  },
+  {
+    id: 'failed-backups',
+    title: 'Failed Backups (24h)',
+    icon: HardDrive,
+    chartName: 'health-failed-backups',
+    valueKey: 'failed_count',
+    defaults: { warning: 1, critical: 3 },
+    formatLabel: fmtCount('failed backup'),
+    description:
+      'Backup operations that ended in FAILED status in the last 24 hours.',
+    systemTables: ['system.backup_log'],
+    commonCauses: [
+      'Remote storage unavailable or credentials expired',
+      'Disk full on backup destination',
+      'Network interruption during backup transfer',
+    ],
+    relatedLinks: [{ label: 'Backups', href: '/backups' }],
+    docsLinks: [
+      {
+        label: 'system.backup_log',
+        url: 'https://clickhouse.com/docs/en/operations/system-tables/backup_log',
+      },
+    ],
+    sql: `SELECT count() AS failed_count
+FROM system.backup_log
+WHERE event_time > now() - INTERVAL 24 HOUR
+  AND status = 'FAILED'`,
+  },
+  {
+    id: 'mv-refresh-failures',
+    title: 'MV Refresh Failures',
+    icon: ShieldAlert,
+    chartName: 'health-mv-refresh-failures',
+    valueKey: 'failed_count',
+    defaults: { warning: 1, critical: 3 },
+    formatLabel: fmtCount('failed MV refresh'),
+    description:
+      'Materialized views with REFRESH schedule that have failed or errored their last refresh cycle.',
+    systemTables: ['system.view_refreshes'],
+    commonCauses: [
+      'Source table schema changed incompatibly',
+      'MV query references a missing table or column',
+      'Resource exhaustion during refresh',
+    ],
+    relatedLinks: [{ label: 'View Refreshes', href: '/view-refreshes' }],
+    docsLinks: [
+      {
+        label: 'system.view_refreshes',
+        url: 'https://clickhouse.com/docs/en/operations/system-tables/view_refreshes',
+      },
+    ],
+    sql: `SELECT countIf(status IN ('Error', 'Failed')) AS failed_count
+FROM system.view_refreshes`,
+  },
 ] as const

--- a/apps/dashboard/src/components/slow-queries/slow-queries-view.tsx
+++ b/apps/dashboard/src/components/slow-queries/slow-queries-view.tsx
@@ -4,6 +4,7 @@ import type { SlowQueryRow } from '@/components/slow-queries/slow-queries-table'
 import type { CardError } from '@/lib/card-error-utils'
 
 import { useMemo, useState } from 'react'
+import { RegressionPanel } from '@/components/alerting/regression-panel'
 import { PageHeader } from '@/components/layout'
 import { RelatedCharts } from '@/components/layout/query-page/related-charts'
 import { QueryPageSkeleton } from '@/components/query-tables/query-page-skeleton'
@@ -262,6 +263,7 @@ export function SlowQueriesView() {
             ) : (
               <SlowQueriesTable rows={rows} />
             )}
+            <RegressionPanel hostId={hostId} />
           </>
         )}
       </div>

--- a/apps/dashboard/src/lib/alerting/__tests__/mv-refresh-staleness.test.ts
+++ b/apps/dashboard/src/lib/alerting/__tests__/mv-refresh-staleness.test.ts
@@ -1,0 +1,156 @@
+/**
+ * MV Refresh Staleness Tests
+ */
+
+import { describe, expect, test } from 'bun:test'
+import {
+  classifyMvRefresh,
+  countMvIssues,
+  formatMvStaleness,
+  type MvRefreshRow,
+} from '../mv-refresh-staleness'
+
+// ---------------------------------------------------------------------------
+// classifyMvRefresh
+// ---------------------------------------------------------------------------
+
+function makeRow(
+  overrides: Partial<MvRefreshRow> = {}
+): Pick<MvRefreshRow, 'status' | 'staleness_seconds' | 'is_failed'> {
+  return {
+    status: 'Scheduled',
+    staleness_seconds: 0,
+    is_failed: 0,
+    ...overrides,
+  }
+}
+
+describe('classifyMvRefresh', () => {
+  test('ok when recently refreshed', () => {
+    expect(classifyMvRefresh(makeRow({ staleness_seconds: 60 }))).toBe('ok')
+  })
+
+  test('failed when status is Error', () => {
+    expect(classifyMvRefresh(makeRow({ status: 'Error' }))).toBe('failed')
+  })
+
+  test('failed when status is Failed', () => {
+    expect(classifyMvRefresh(makeRow({ status: 'Failed' }))).toBe('failed')
+  })
+
+  test('failed when is_failed flag is set', () => {
+    expect(classifyMvRefresh(makeRow({ is_failed: 1 }))).toBe('failed')
+  })
+
+  test('stale when staleness_seconds exceeds threshold', () => {
+    expect(classifyMvRefresh(makeRow({ staleness_seconds: 3601 }))).toBe(
+      'stale'
+    )
+  })
+
+  test('ok when staleness_seconds is exactly at threshold', () => {
+    expect(classifyMvRefresh(makeRow({ staleness_seconds: 3600 }))).toBe('ok')
+  })
+
+  test('custom threshold: stale at 7200s with 7201s staleness', () => {
+    expect(classifyMvRefresh(makeRow({ staleness_seconds: 7201 }), 7200)).toBe(
+      'stale'
+    )
+  })
+
+  test('custom threshold: ok at 7200s with 7199s staleness', () => {
+    expect(classifyMvRefresh(makeRow({ staleness_seconds: 7199 }), 7200)).toBe(
+      'ok'
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// countMvIssues
+// ---------------------------------------------------------------------------
+
+const fullRow = (overrides: Partial<MvRefreshRow> = {}): MvRefreshRow => ({
+  database: 'db',
+  view: 'mv',
+  status: 'Scheduled',
+  last_success_time: null,
+  last_refresh_time: null,
+  next_refresh_time: null,
+  staleness_seconds: 0,
+  is_failed: 0,
+  exception: null,
+  ...overrides,
+})
+
+describe('countMvIssues', () => {
+  test('all ok → no issues', () => {
+    const rows = [
+      fullRow({ staleness_seconds: 100 }),
+      fullRow({ staleness_seconds: 200 }),
+    ]
+    const result = countMvIssues(rows)
+    expect(result.failed).toBe(0)
+    expect(result.stale).toBe(0)
+    expect(result.total).toBe(2)
+  })
+
+  test('counts failed views correctly', () => {
+    const rows = [
+      fullRow({ status: 'Error' }),
+      fullRow({ status: 'Failed' }),
+      fullRow({ staleness_seconds: 100 }),
+    ]
+    const result = countMvIssues(rows)
+    expect(result.failed).toBe(2)
+    expect(result.stale).toBe(0)
+    expect(result.total).toBe(3)
+  })
+
+  test('counts stale views correctly', () => {
+    const rows = [
+      fullRow({ staleness_seconds: 7200 }),
+      fullRow({ staleness_seconds: 3601 }),
+    ]
+    const result = countMvIssues(rows)
+    expect(result.stale).toBe(2)
+    expect(result.failed).toBe(0)
+  })
+
+  test('mixed failed and stale', () => {
+    const rows = [
+      fullRow({ status: 'Error' }),
+      fullRow({ staleness_seconds: 5000 }),
+      fullRow({ staleness_seconds: 100 }),
+    ]
+    const result = countMvIssues(rows)
+    expect(result.failed).toBe(1)
+    expect(result.stale).toBe(1)
+    expect(result.total).toBe(3)
+  })
+
+  test('empty array → all zeros', () => {
+    expect(countMvIssues([])).toEqual({ failed: 0, stale: 0, total: 0 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatMvStaleness
+// ---------------------------------------------------------------------------
+
+describe('formatMvStaleness', () => {
+  test('seconds for < 60s', () => {
+    expect(formatMvStaleness(45)).toBe('45s')
+  })
+
+  test('minutes for < 3600s', () => {
+    expect(formatMvStaleness(120)).toBe('2m')
+  })
+
+  test('hours for < 86400s', () => {
+    expect(formatMvStaleness(7200)).toBe('2h')
+  })
+
+  test('days for >= 86400s', () => {
+    expect(formatMvStaleness(172800)).toBe('2d')
+  })
+})

--- a/apps/dashboard/src/lib/alerting/__tests__/replication-lag-health.test.ts
+++ b/apps/dashboard/src/lib/alerting/__tests__/replication-lag-health.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Replication Lag Health Score Tests (#1914)
+ */
+
+import { describe, expect, test } from 'bun:test'
+import {
+  computeReplicaHealthScore,
+  getLagStatus,
+} from '../replication-lag-health'
+
+describe('getLagStatus', () => {
+  test('0s → synced', () => {
+    expect(getLagStatus(0)).toBe('synced')
+  })
+
+  test('1s → slight lag', () => {
+    expect(getLagStatus(1)).toBe('slight lag')
+  })
+
+  test('59s → slight lag', () => {
+    expect(getLagStatus(59)).toBe('slight lag')
+  })
+
+  test('60s → moderate lag', () => {
+    expect(getLagStatus(60)).toBe('moderate lag')
+  })
+
+  test('299s → moderate lag', () => {
+    expect(getLagStatus(299)).toBe('moderate lag')
+  })
+
+  test('300s → severe lag', () => {
+    expect(getLagStatus(300)).toBe('severe lag')
+  })
+
+  test('1000s → severe lag', () => {
+    expect(getLagStatus(1000)).toBe('severe lag')
+  })
+})
+
+describe('computeReplicaHealthScore', () => {
+  test('synced with empty queue → 100', () => {
+    expect(computeReplicaHealthScore(0, 0, 0)).toBe(100)
+  })
+
+  test('slight lag → 75', () => {
+    expect(computeReplicaHealthScore(30, 0, 0)).toBe(75)
+  })
+
+  test('moderate lag → 50', () => {
+    expect(computeReplicaHealthScore(120, 0, 0)).toBe(50)
+  })
+
+  test('severe lag → 0', () => {
+    expect(computeReplicaHealthScore(300, 0, 0)).toBe(0)
+  })
+
+  test('queue penalty: 100 items → -5 from base', () => {
+    // synced (100) - floor(100/100)*5 = 100 - 5 = 95
+    expect(computeReplicaHealthScore(0, 50, 50)).toBe(95)
+  })
+
+  test('queue penalty: 200 items → -10 from base', () => {
+    expect(computeReplicaHealthScore(0, 100, 100)).toBe(90)
+  })
+
+  test('score never drops below 0', () => {
+    // severe lag (0) - big queue penalty → still 0
+    expect(computeReplicaHealthScore(300, 10000, 10000)).toBe(0)
+  })
+
+  test('score never exceeds 100', () => {
+    expect(computeReplicaHealthScore(0, 0, 0)).toBe(100)
+  })
+
+  test('slight lag + large queue → penalized', () => {
+    // slight lag (75) - floor(500/100)*5 = 75 - 25 = 50
+    expect(computeReplicaHealthScore(30, 250, 250)).toBe(50)
+  })
+})

--- a/apps/dashboard/src/lib/alerting/__tests__/rule-registry.test.ts
+++ b/apps/dashboard/src/lib/alerting/__tests__/rule-registry.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Alert Rule Registry Tests
+ *
+ * For every built-in rule: asserts it fires (warning/critical) AND clears (ok).
+ * Also tests registry CRUD and classifyValue boundaries.
+ */
+
+import { describe, expect, test, beforeEach } from 'bun:test'
+import {
+  AlertRuleRegistry,
+  classifyValue,
+  ruleRegistry,
+} from '../rule-registry'
+import { BUILTIN_RULES, registerBuiltinRules } from '../builtin-rules'
+
+// ---------------------------------------------------------------------------
+// classifyValue (pure, no side effects)
+// ---------------------------------------------------------------------------
+
+describe('classifyValue', () => {
+  const thresholds = { warning: 10, critical: 100 }
+
+  test('null value → ok', () => {
+    expect(classifyValue(null, thresholds)).toBe('ok')
+  })
+
+  test('NaN / Infinity → ok', () => {
+    expect(classifyValue(Number.NaN, thresholds)).toBe('ok')
+    expect(classifyValue(Number.POSITIVE_INFINITY, thresholds)).toBe('ok')
+  })
+
+  test('below warning → ok', () => {
+    expect(classifyValue(0, thresholds)).toBe('ok')
+    expect(classifyValue(9, thresholds)).toBe('ok')
+  })
+
+  test('at warning boundary → warning', () => {
+    expect(classifyValue(10, thresholds)).toBe('warning')
+  })
+
+  test('between warning and critical → warning', () => {
+    expect(classifyValue(50, thresholds)).toBe('warning')
+    expect(classifyValue(99, thresholds)).toBe('warning')
+  })
+
+  test('at critical boundary → critical', () => {
+    expect(classifyValue(100, thresholds)).toBe('critical')
+  })
+
+  test('above critical → critical', () => {
+    expect(classifyValue(999, thresholds)).toBe('critical')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// AlertRuleRegistry CRUD
+// ---------------------------------------------------------------------------
+
+describe('AlertRuleRegistry', () => {
+  let registry: AlertRuleRegistry
+
+  beforeEach(() => {
+    registry = new AlertRuleRegistry()
+  })
+
+  test('starts empty', () => {
+    expect(registry.size()).toBe(0)
+    expect(registry.getAll()).toEqual([])
+  })
+
+  test('register and retrieve', () => {
+    const rule = {
+      id: 'test-rule',
+      type: 'custom' as const,
+      title: 'Test',
+      description: 'desc',
+      valueKey: 'val',
+      defaults: { warning: 1, critical: 5 },
+    }
+    registry.register(rule)
+    expect(registry.has('test-rule')).toBe(true)
+    expect(registry.get('test-rule')).toEqual(rule)
+    expect(registry.size()).toBe(1)
+  })
+
+  test('register overwrites same id', () => {
+    const base = {
+      id: 'r',
+      type: 'custom' as const,
+      title: 'A',
+      description: '',
+      valueKey: 'v',
+      defaults: { warning: 1, critical: 5 },
+    }
+    registry.register(base)
+    registry.register({ ...base, title: 'B' })
+    expect(registry.get('r')?.title).toBe('B')
+    expect(registry.size()).toBe(1)
+  })
+
+  test('unregister removes rule', () => {
+    registry.register({
+      id: 'x',
+      type: 'custom' as const,
+      title: 'X',
+      description: '',
+      valueKey: 'v',
+      defaults: { warning: 1, critical: 5 },
+    })
+    registry.unregister('x')
+    expect(registry.has('x')).toBe(false)
+    expect(registry.size()).toBe(0)
+  })
+
+  test('getAll returns all registered rules', () => {
+    for (const id of ['a', 'b', 'c']) {
+      registry.register({
+        id,
+        type: 'custom' as const,
+        title: id,
+        description: '',
+        valueKey: 'v',
+        defaults: { warning: 1, critical: 5 },
+      })
+    }
+    expect(
+      registry
+        .getAll()
+        .map((r) => r.id)
+        .sort()
+    ).toEqual(['a', 'b', 'c'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// registerBuiltinRules populates the global registry
+// ---------------------------------------------------------------------------
+
+describe('registerBuiltinRules', () => {
+  test('registers all BUILTIN_RULES into the singleton', () => {
+    registerBuiltinRules()
+    for (const rule of BUILTIN_RULES) {
+      expect(ruleRegistry.has(rule.id)).toBe(true)
+    }
+  })
+
+  test('all built-in rules have required fields', () => {
+    for (const rule of BUILTIN_RULES) {
+      expect(typeof rule.id).toBe('string')
+      expect(rule.id.length).toBeGreaterThan(0)
+      expect(typeof rule.title).toBe('string')
+      expect(typeof rule.valueKey).toBe('string')
+      expect(typeof rule.defaults.warning).toBe('number')
+      expect(typeof rule.defaults.critical).toBe('number')
+      expect(rule.defaults.warning).toBeLessThanOrEqual(rule.defaults.critical)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Per-rule trigger / clear tests
+// ---------------------------------------------------------------------------
+
+describe('readonly-replicas rule', () => {
+  const rule = BUILTIN_RULES.find((r) => r.id === 'readonly-replicas')!
+
+  test('fires warning at threshold', () => {
+    expect(classifyValue(rule.defaults.warning, rule.defaults)).toBe('warning')
+  })
+
+  test('fires critical at threshold', () => {
+    expect(classifyValue(rule.defaults.critical, rule.defaults)).toBe(
+      'critical'
+    )
+  })
+
+  test('clears when value is 0', () => {
+    expect(classifyValue(0, rule.defaults)).toBe('ok')
+  })
+
+  test('clears on null', () => {
+    expect(classifyValue(null, rule.defaults)).toBe('ok')
+  })
+})
+
+describe('replication-lag rule', () => {
+  const rule = BUILTIN_RULES.find((r) => r.id === 'replication-lag')!
+
+  test('clears below warning (29s)', () => {
+    expect(classifyValue(29, rule.defaults)).toBe('ok')
+  })
+
+  test('fires warning at 30s', () => {
+    expect(classifyValue(30, rule.defaults)).toBe('warning')
+  })
+
+  test('fires critical at 300s', () => {
+    expect(classifyValue(300, rule.defaults)).toBe('critical')
+  })
+
+  test('fires critical above 300s', () => {
+    expect(classifyValue(600, rule.defaults)).toBe('critical')
+  })
+})
+
+describe('disk-usage rule', () => {
+  const rule = BUILTIN_RULES.find((r) => r.id === 'disk-usage')!
+
+  test('ok at 79%', () => {
+    expect(classifyValue(79, rule.defaults)).toBe('ok')
+  })
+
+  test('warning at 80%', () => {
+    expect(classifyValue(80, rule.defaults)).toBe('warning')
+  })
+
+  test('critical at 95%', () => {
+    expect(classifyValue(95, rule.defaults)).toBe('critical')
+  })
+})
+
+describe('keeper-unavailable rule', () => {
+  const rule = BUILTIN_RULES.find((r) => r.id === 'keeper-unavailable')!
+
+  test('ok at 0 exceptions', () => {
+    expect(classifyValue(0, rule.defaults)).toBe('ok')
+  })
+
+  test('warning at 1 exception', () => {
+    expect(classifyValue(1, rule.defaults)).toBe('warning')
+  })
+
+  test('critical at 20 exceptions', () => {
+    expect(classifyValue(20, rule.defaults)).toBe('critical')
+  })
+})
+
+describe('failed-mutations rule', () => {
+  const rule = BUILTIN_RULES.find((r) => r.id === 'failed-mutations')!
+
+  test('ok when no failures', () => {
+    expect(classifyValue(0, rule.defaults)).toBe('ok')
+  })
+
+  test('fires warning on first failure', () => {
+    expect(classifyValue(1, rule.defaults)).toBe('warning')
+  })
+
+  test('fires critical at 5', () => {
+    expect(classifyValue(5, rule.defaults)).toBe('critical')
+  })
+
+  test('clears on null (table absent)', () => {
+    expect(classifyValue(null, rule.defaults)).toBe('ok')
+  })
+})
+
+describe('stuck-merges rule', () => {
+  const rule = BUILTIN_RULES.find((r) => r.id === 'stuck-merges')!
+
+  test('ok when no stuck merges', () => {
+    expect(classifyValue(0, rule.defaults)).toBe('ok')
+  })
+
+  test('warning at 1 stuck merge', () => {
+    expect(classifyValue(1, rule.defaults)).toBe('warning')
+  })
+
+  test('critical at 3 stuck merges', () => {
+    expect(classifyValue(3, rule.defaults)).toBe('critical')
+  })
+})
+
+describe('query-timeout rule', () => {
+  const rule = BUILTIN_RULES.find((r) => r.id === 'query-timeout')!
+
+  test('ok at 0 timeouts', () => {
+    expect(classifyValue(0, rule.defaults)).toBe('ok')
+  })
+
+  test('warning at 1 timeout', () => {
+    expect(classifyValue(1, rule.defaults)).toBe('warning')
+  })
+
+  test('critical at 10 timeouts', () => {
+    expect(classifyValue(10, rule.defaults)).toBe('critical')
+  })
+})
+
+describe('failed-backups rule', () => {
+  const rule = BUILTIN_RULES.find((r) => r.id === 'failed-backups')!
+
+  test('ok when no failures', () => {
+    expect(classifyValue(0, rule.defaults)).toBe('ok')
+  })
+
+  test('warning at 1 failure', () => {
+    expect(classifyValue(1, rule.defaults)).toBe('warning')
+  })
+
+  test('critical at 3 failures', () => {
+    expect(classifyValue(3, rule.defaults)).toBe('critical')
+  })
+})
+
+describe('mv-refresh-failures rule', () => {
+  const rule = BUILTIN_RULES.find((r) => r.id === 'mv-refresh-failures')!
+
+  test('ok when no failures', () => {
+    expect(classifyValue(0, rule.defaults)).toBe('ok')
+  })
+
+  test('warning at 1 failure', () => {
+    expect(classifyValue(1, rule.defaults)).toBe('warning')
+  })
+
+  test('critical at 3 failures', () => {
+    expect(classifyValue(3, rule.defaults)).toBe('critical')
+  })
+
+  test('clears on null (table absent)', () => {
+    expect(classifyValue(null, rule.defaults)).toBe('ok')
+  })
+})

--- a/apps/dashboard/src/lib/alerting/__tests__/slow-query-regression.test.ts
+++ b/apps/dashboard/src/lib/alerting/__tests__/slow-query-regression.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Slow Query Regression Tests
+ */
+
+import { describe, expect, test } from 'bun:test'
+import {
+  normalizeQueryFingerprint,
+  summarizeRegressions,
+  type SlowQueryRegression,
+} from '../slow-query-regression'
+
+// ---------------------------------------------------------------------------
+// normalizeQueryFingerprint
+// ---------------------------------------------------------------------------
+
+describe('normalizeQueryFingerprint', () => {
+  test('strips numeric literals', () => {
+    const q = 'SELECT * FROM t WHERE id = 42 AND age > 18'
+    const fp = normalizeQueryFingerprint(q)
+    expect(fp).not.toContain('42')
+    expect(fp).not.toContain('18')
+    expect(fp).toContain('?')
+  })
+
+  test('strips string literals', () => {
+    const q = "SELECT * FROM t WHERE name = 'Alice'"
+    const fp = normalizeQueryFingerprint(q)
+    expect(fp).not.toContain('Alice')
+    expect(fp).toContain("'?'")
+  })
+
+  test('strips bind parameters', () => {
+    const q = 'SELECT * FROM t WHERE host = {host:String} AND id = {id:UInt64}'
+    const fp = normalizeQueryFingerprint(q)
+    expect(fp).not.toContain('{host:String}')
+    expect(fp).not.toContain('{id:UInt64}')
+  })
+
+  test('collapses IN lists', () => {
+    const q = 'SELECT * FROM t WHERE id IN (1, 2, 3, 4, 5)'
+    const fp = normalizeQueryFingerprint(q)
+    expect(fp).toContain('in (?)')
+    expect(fp).not.toContain('1, 2, 3')
+  })
+
+  test('normalizes whitespace', () => {
+    const q = 'SELECT   *   FROM   t'
+    expect(normalizeQueryFingerprint(q)).toBe('select * from t')
+  })
+
+  test('lowercases output', () => {
+    const q = 'SELECT COUNT(*) FROM MyTable'
+    expect(normalizeQueryFingerprint(q)).toBe(
+      normalizeQueryFingerprint(q).toLowerCase()
+    )
+  })
+
+  test('same structure → same fingerprint regardless of literal values', () => {
+    const q1 = "SELECT * FROM t WHERE id = 1 AND name = 'foo'"
+    const q2 = "SELECT * FROM t WHERE id = 99 AND name = 'bar'"
+    expect(normalizeQueryFingerprint(q1)).toBe(normalizeQueryFingerprint(q2))
+  })
+
+  test('different structure → different fingerprint', () => {
+    const q1 = 'SELECT id FROM t'
+    const q2 = 'SELECT name FROM t'
+    expect(normalizeQueryFingerprint(q1)).not.toBe(
+      normalizeQueryFingerprint(q2)
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// summarizeRegressions
+// ---------------------------------------------------------------------------
+
+describe('summarizeRegressions', () => {
+  const makeRow = (
+    factor: number,
+    fp = 'select * from t'
+  ): SlowQueryRegression => ({
+    fingerprint: fp,
+    fingerprint_short: fp.slice(0, 200),
+    current_count: 10,
+    current_p95_ms: Math.round(1000 * factor),
+    current_avg_ms: Math.round(800 * factor),
+    baseline_count: 10,
+    baseline_p95_ms: 1000,
+    baseline_avg_ms: 800,
+    regression_factor: factor,
+  })
+
+  test('returns null for empty array', () => {
+    expect(summarizeRegressions([])).toBeNull()
+  })
+
+  test('returns summary for single regression', () => {
+    const summary = summarizeRegressions([makeRow(3)])
+    expect(summary).not.toBeNull()
+    expect(summary?.count).toBe(1)
+    expect(summary?.worst_factor).toBe(3)
+  })
+
+  test('picks worst factor across multiple regressions', () => {
+    const rows = [makeRow(2, 'q1'), makeRow(5, 'q2'), makeRow(3, 'q3')]
+    const summary = summarizeRegressions(rows)
+    expect(summary?.count).toBe(3)
+    expect(summary?.worst_factor).toBe(5)
+    expect(summary?.worst_fingerprint).toBe('q2')
+  })
+})

--- a/apps/dashboard/src/lib/alerting/builtin-rules.ts
+++ b/apps/dashboard/src/lib/alerting/builtin-rules.ts
@@ -1,0 +1,189 @@
+/**
+ * Built-in Alert Rules
+ *
+ * Registers all built-in rules into the global ruleRegistry.
+ * Call registerBuiltinRules() once at app startup (server-sweep.ts entry).
+ *
+ * Rules mirror the existing HEALTH_CHECKS where applicable so thresholds are
+ * shared. New rule types (failed-mutations, stuck-merges, query-timeout,
+ * failed-backups, mv-refresh-failures) extend the engine with rule IDs that
+ * the health page does not yet track.
+ */
+
+import type { AlertRuleDef } from './rule-registry'
+
+import { ruleRegistry } from './rule-registry'
+
+const fmtCount =
+  (singular: string, plural?: string) =>
+  (v: number | null): string => {
+    const n = v ?? 0
+    return `${n.toLocaleString()} ${n === 1 ? singular : (plural ?? `${singular}s`)}`
+  }
+
+/**
+ * All built-in alert rule definitions.
+ * Exported so they can be individually imported for tests.
+ */
+export const BUILTIN_RULES: readonly AlertRuleDef[] = [
+  // -------------------------------------------------------------------------
+  // Existing health-check parity rules (matching health-checks.ts IDs)
+  // -------------------------------------------------------------------------
+
+  {
+    id: 'readonly-replicas',
+    type: 'readonly-replicas',
+    title: 'Readonly Replicas',
+    description: 'Replicas in read-only mode cannot accept writes.',
+    sql: `SELECT count() AS readonly_count
+FROM system.replicas
+WHERE is_readonly = 1`,
+    valueKey: 'readonly_count',
+    defaults: { warning: 1, critical: 3 },
+    formatLabel: fmtCount('readonly replica'),
+    optional: true,
+    tableCheck: 'system.replicas',
+  },
+
+  {
+    id: 'replication-lag',
+    type: 'replication-lag',
+    title: 'Replication Lag',
+    description:
+      'Maximum absolute_delay across all replicas (seconds behind leader).',
+    sql: `SELECT max(absolute_delay) AS max_lag
+FROM system.replicas`,
+    valueKey: 'max_lag',
+    defaults: { warning: 30, critical: 300 },
+    formatLabel: (v) => `${(v ?? 0).toLocaleString()}s max delay`,
+    optional: true,
+    tableCheck: 'system.replicas',
+  },
+
+  {
+    id: 'disk-usage',
+    type: 'disk-usage',
+    title: 'Disk Usage',
+    description: 'Worst-case disk utilization across all configured volumes.',
+    sql: `SELECT round(max((total_space - free_space) * 100.0 / nullIf(total_space, 0)), 1) AS disk_percent
+FROM system.disks`,
+    valueKey: 'disk_percent',
+    defaults: { warning: 80, critical: 95 },
+    formatLabel: (v) => `${v ?? 0}% used (worst disk)`,
+    optional: true,
+    tableCheck: 'system.disks',
+  },
+
+  {
+    id: 'keeper-unavailable',
+    type: 'keeper-unavailable',
+    title: 'Keeper Exceptions',
+    description:
+      'Recent KEEPER_EXCEPTION events. Sustained exceptions indicate quorum issues.',
+    sql: `SELECT coalesce(max(value) - min(value), 0) AS exception_count
+FROM merge('system', '^error_log')
+WHERE error = 'KEEPER_EXCEPTION'
+  AND event_time > now() - INTERVAL 1 HOUR`,
+    valueKey: 'exception_count',
+    defaults: { warning: 1, critical: 20 },
+    formatLabel: fmtCount('exception'),
+    optional: true,
+    tableCheck: 'system.error_log',
+  },
+
+  // -------------------------------------------------------------------------
+  // New rule types (not yet tracked in HEALTH_CHECKS)
+  // -------------------------------------------------------------------------
+
+  {
+    id: 'failed-mutations',
+    type: 'failed-mutations',
+    title: 'Failed Mutations',
+    description:
+      'Mutations that are not complete and have recorded a failure. Failed mutations block subsequent mutations on the same table.',
+    sql: `SELECT countIf(is_done = 0 AND isNotNull(latest_fail_time)) AS failed_count
+FROM system.mutations`,
+    valueKey: 'failed_count',
+    defaults: { warning: 1, critical: 5 },
+    formatLabel: fmtCount('failed mutation'),
+    optional: true,
+    tableCheck: 'system.mutations',
+  },
+
+  {
+    id: 'stuck-merges',
+    type: 'stuck-merges',
+    title: 'Stuck Merges',
+    description:
+      'Merges running for more than 10 minutes. Stuck merges block table inserts and consume resources.',
+    sql: `SELECT count() AS stuck_count
+FROM system.merges
+WHERE elapsed > 600`,
+    valueKey: 'stuck_count',
+    defaults: { warning: 1, critical: 3 },
+    formatLabel: fmtCount('stuck merge'),
+    optional: true,
+    tableCheck: 'system.merges',
+  },
+
+  {
+    id: 'query-timeout',
+    type: 'query-timeout',
+    title: 'Query Timeout Breaches (1h)',
+    description:
+      'Queries killed due to timeout (TIMEOUT_EXCEEDED) in the last hour.',
+    sql: `SELECT count() AS timeout_count
+FROM system.query_log
+WHERE event_time > now() - INTERVAL 1 HOUR
+  AND type IN ('ExceptionWhileProcessing', 'ExceptionBeforeStart')
+  AND (exception_code = 159 OR exception LIKE '%TIMEOUT_EXCEEDED%')`,
+    valueKey: 'timeout_count',
+    defaults: { warning: 1, critical: 10 },
+    formatLabel: (v) =>
+      `${(v ?? 0).toLocaleString()} timeout kills in last hour`,
+    optional: true,
+    tableCheck: 'system.query_log',
+  },
+
+  {
+    id: 'failed-backups',
+    type: 'failed-backups',
+    title: 'Failed Backups (24h)',
+    description:
+      'Backup operations that ended in FAILED status in the last 24 hours.',
+    sql: `SELECT count() AS failed_count
+FROM system.backup_log
+WHERE event_time > now() - INTERVAL 24 HOUR
+  AND status = 'FAILED'`,
+    valueKey: 'failed_count',
+    defaults: { warning: 1, critical: 3 },
+    formatLabel: fmtCount('failed backup'),
+    optional: true,
+    tableCheck: 'system.backup_log',
+  },
+
+  {
+    id: 'mv-refresh-failures',
+    type: 'mv-refresh-failures',
+    title: 'MV Refresh Failures',
+    description:
+      'Materialized views with REFRESH schedule that have failed or errored their last refresh cycle.',
+    sql: `SELECT countIf(status IN ('Error', 'Failed')) AS failed_count
+FROM system.view_refreshes`,
+    valueKey: 'failed_count',
+    defaults: { warning: 1, critical: 3 },
+    formatLabel: fmtCount('failed MV refresh'),
+    optional: true,
+    tableCheck: 'system.view_refreshes',
+  },
+]
+
+/**
+ * Register all built-in rules into the global registry.
+ * Safe to call multiple times (idempotent: later call overwrites same ID).
+ */
+export function registerBuiltinRules(): void {
+  for (const rule of BUILTIN_RULES) {
+    ruleRegistry.register(rule)
+  }
+}

--- a/apps/dashboard/src/lib/alerting/mv-refresh-staleness.ts
+++ b/apps/dashboard/src/lib/alerting/mv-refresh-staleness.ts
@@ -1,0 +1,138 @@
+/**
+ * Materialized View Refresh Staleness (#1925)
+ *
+ * Computes staleness for MV refresh operations from system.view_refreshes.
+ * A view is considered stale when:
+ *   - status is 'Error' or 'Failed' (last refresh failed)
+ *   - OR last_success_time is older than a staleness threshold
+ *
+ * Provides SQL to run on ClickHouse and pure helper functions
+ * for threshold evaluation and badge rendering.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MvRefreshRow {
+  database: string
+  view: string
+  status: string
+  last_success_time: string | null
+  last_refresh_time: string | null
+  next_refresh_time: string | null
+  staleness_seconds: number
+  is_failed: number
+  exception: string | null
+  [key: string]: string | number | null
+}
+
+export type MvStalenessLevel = 'ok' | 'stale' | 'failed'
+
+export interface MvStalenessResult {
+  database: string
+  view: string
+  level: MvStalenessLevel
+  staleness_seconds: number
+  status: string
+  exception: string | null
+}
+
+// ---------------------------------------------------------------------------
+// SQL
+// ---------------------------------------------------------------------------
+
+/**
+ * SQL to surface stale/failed MV refreshes.
+ *
+ * Thresholds:
+ *   - failed: status IN ('Error', 'Failed') → always surfaced
+ *   - stale: last_success_time is NULL or older than staleAfterSeconds
+ *
+ * The staleAfterSeconds default (3600 = 1 hour) is conservative; operators
+ * with longer refresh intervals should increase it via the alert threshold.
+ */
+export function buildMvStalenessSQL(staleAfterSeconds = 3600): string {
+  return `
+SELECT
+  database,
+  view,
+  status,
+  last_success_time,
+  last_refresh_time,
+  next_refresh_time,
+  dateDiff('second', coalesce(last_success_time, toDateTime(0)), now()) AS staleness_seconds,
+  multiIf(
+    status IN ('Error', 'Failed'), 1,
+    isNull(last_success_time), 1,
+    dateDiff('second', last_success_time, now()) > ${staleAfterSeconds}, 1,
+    0
+  ) AS is_failed,
+  exception
+FROM system.view_refreshes
+WHERE status NOT IN ('Running', 'Scheduled')
+ORDER BY is_failed DESC, staleness_seconds DESC
+`
+}
+
+/**
+ * Count SQL — single row result used by the alert rule engine.
+ * Returns the number of views that are currently failed or overdue.
+ */
+export function buildMvFailedCountSQL(staleAfterSeconds = 3600): string {
+  return `
+SELECT countIf(
+  status IN ('Error', 'Failed')
+  OR isNull(last_success_time)
+  OR dateDiff('second', last_success_time, now()) > ${staleAfterSeconds}
+) AS failed_count
+FROM system.view_refreshes
+WHERE status NOT IN ('Running', 'Scheduled')
+`
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (no ClickHouse dependency — unit-testable)
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a single MV refresh row into a staleness level.
+ */
+export function classifyMvRefresh(
+  row: Pick<MvRefreshRow, 'status' | 'staleness_seconds' | 'is_failed'>,
+  staleAfterSeconds = 3600
+): MvStalenessLevel {
+  if (row.status === 'Error' || row.status === 'Failed') return 'failed'
+  if (row.is_failed === 1) return 'failed'
+  if (row.staleness_seconds > staleAfterSeconds) return 'stale'
+  return 'ok'
+}
+
+/**
+ * Count failed/stale views in a result set.
+ * Pure function — used in tests and the alert rule.
+ */
+export function countMvIssues(rows: MvRefreshRow[]): {
+  failed: number
+  stale: number
+  total: number
+} {
+  let failed = 0
+  let stale = 0
+  for (const row of rows) {
+    const level = classifyMvRefresh(row)
+    if (level === 'failed') failed++
+    else if (level === 'stale') stale++
+  }
+  return { failed, stale, total: rows.length }
+}
+
+/**
+ * Format a staleness duration for display.
+ */
+export function formatMvStaleness(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`
+  if (seconds < 86400) return `${Math.round(seconds / 3600)}h`
+  return `${Math.round(seconds / 86400)}d`
+}

--- a/apps/dashboard/src/lib/alerting/replication-lag-health.ts
+++ b/apps/dashboard/src/lib/alerting/replication-lag-health.ts
@@ -1,0 +1,110 @@
+/**
+ * Replication Lag Health Score (#1914)
+ *
+ * Per-replica health score: 0-100 scale that combines lag duration and
+ * queue depth. Used by the replication lag chart and alert rules.
+ *
+ * SQL for lag trend (time-series) is exported for use in chart queries.
+ */
+
+// ---------------------------------------------------------------------------
+// Per-replica health score
+// ---------------------------------------------------------------------------
+
+export type ReplicaLagStatus =
+  | 'synced'
+  | 'slight lag'
+  | 'moderate lag'
+  | 'severe lag'
+
+/**
+ * Map absolute_delay (seconds) to a categorical lag status.
+ * Boundaries match the existing replication-lag chart in replication-charts.ts.
+ */
+export function getLagStatus(absoluteDelaySeconds: number): ReplicaLagStatus {
+  if (absoluteDelaySeconds === 0) return 'synced'
+  if (absoluteDelaySeconds < 60) return 'slight lag'
+  if (absoluteDelaySeconds < 300) return 'moderate lag'
+  return 'severe lag'
+}
+
+/**
+ * Compute a 0-100 health score for a single replica.
+ *
+ * Base score by lag:
+ *   synced        → 100
+ *   slight lag    → 75
+ *   moderate lag  → 50
+ *   severe lag    → 0
+ *
+ * Queue depth penalty: -5 points per 100 items in the combined queue.
+ * Score is clamped to [0, 100].
+ */
+export function computeReplicaHealthScore(
+  absoluteDelaySeconds: number,
+  insertsInQueue = 0,
+  mergesInQueue = 0
+): number {
+  let base: number
+  if (absoluteDelaySeconds === 0) base = 100
+  else if (absoluteDelaySeconds < 60) base = 75
+  else if (absoluteDelaySeconds < 300) base = 50
+  else base = 0
+
+  const totalQueue = insertsInQueue + mergesInQueue
+  const queuePenalty = Math.floor(totalQueue / 100) * 5
+
+  return Math.max(0, Math.min(100, base - queuePenalty))
+}
+
+// ---------------------------------------------------------------------------
+// Lag trend SQL
+// ---------------------------------------------------------------------------
+
+/**
+ * SQL for the replication lag trend chart (time-series of max lag).
+ *
+ * Uses system.metric_log which records `CurrentMetric_ReplicasMaxAbsoluteDelay`
+ * every few seconds. Falls back to 0 when metric_log is absent.
+ *
+ * @param lastHours  How many hours back to query (default 24)
+ * @param interval   Time bucket interval function (default toStartOfFiveMinutes)
+ */
+export function buildLagTrendSQL(
+  lastHours = 24,
+  interval = 'toStartOfFiveMinutes'
+): string {
+  return `
+SELECT
+  ${interval}(event_time) AS ts,
+  max(CurrentMetric_ReplicasMaxAbsoluteDelay) AS max_lag_seconds,
+  avg(CurrentMetric_ReplicasMaxAbsoluteDelay) AS avg_lag_seconds
+FROM merge('system', '^metric_log')
+WHERE event_time > now() - INTERVAL ${lastHours} HOUR
+GROUP BY ts
+ORDER BY ts
+`
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ReplicaHealthRow {
+  database: string
+  table: string
+  replica_name: string
+  absolute_delay: number
+  inserts_in_queue: number
+  merges_in_queue: number
+  lag_status: ReplicaLagStatus
+  health_score: number
+  [key: string]: string | number
+}
+
+export interface LagTrendPoint {
+  ts: string
+  max_lag_seconds: number
+  avg_lag_seconds: number
+  [key: string]: string | number
+}

--- a/apps/dashboard/src/lib/alerting/rule-registry.ts
+++ b/apps/dashboard/src/lib/alerting/rule-registry.ts
@@ -1,0 +1,109 @@
+/**
+ * Pluggable Alert Rule Registry
+ *
+ * Central registry for alert rules. Rules can be registered at startup (built-in)
+ * or dynamically (plugins). The server sweep and client health hooks both iterate
+ * getAll() to evaluate all registered rules.
+ *
+ * Design goals:
+ * - Pure: classifyValue() has no side effects
+ * - Pluggable: any code can call ruleRegistry.register(rule)
+ * - Dedup-safe: rules have stable IDs; the dispatch layer handles incident dedup
+ */
+
+export type AlertRuleSeverity = 'ok' | 'warning' | 'critical'
+
+/**
+ * Taxonomy of alert rule types.
+ * Drives grouping in the notification center and log filtering.
+ */
+export type AlertRuleType =
+  | 'readonly-replicas'
+  | 'replication-lag'
+  | 'failed-mutations'
+  | 'stuck-merges'
+  | 'disk-usage'
+  | 'query-timeout'
+  | 'failed-backups'
+  | 'keeper-unavailable'
+  | 'mv-refresh-failures'
+  | 'slow-query-regression'
+  | 'custom'
+
+export interface AlertRuleDef {
+  /** Stable unique identifier (used for threshold lookup and dedup). */
+  id: string
+  type: AlertRuleType
+  title: string
+  description: string
+  /** SQL to evaluate on the server. Must return a single row with `valueKey`. */
+  sql?: string
+  /** Column name to read the numeric value from the SQL result row. */
+  valueKey: string
+  /** Default thresholds. Overridable via thresholds-storage. */
+  defaults: { warning: number; critical: number }
+  /** Human-readable label for the triggered value. */
+  formatLabel?: (value: number | null) => string
+  /** When true, skip this rule if the required table is missing. */
+  optional?: boolean
+  /** Table to check before running the SQL (e.g. 'system.backup_log'). */
+  tableCheck?: string
+}
+
+export interface AlertRuleThresholds {
+  warning: number
+  critical: number
+}
+
+/**
+ * Classify a numeric value against warning/critical thresholds.
+ *
+ * Pure function — no side effects, no imports, fully unit-testable.
+ * Matches the severity logic in server-sweep.ts and health-status.ts.
+ */
+export function classifyValue(
+  value: number | null,
+  thresholds: AlertRuleThresholds
+): AlertRuleSeverity {
+  if (value === null || !Number.isFinite(value)) return 'ok'
+  if (value >= thresholds.critical) return 'critical'
+  if (value >= thresholds.warning) return 'warning'
+  return 'ok'
+}
+
+/**
+ * Pluggable alert rule registry.
+ *
+ * Built-in rules are registered via `registerBuiltinRules()`.
+ * Downstream plugins call `ruleRegistry.register(rule)` to extend.
+ */
+export class AlertRuleRegistry {
+  private readonly rules = new Map<string, AlertRuleDef>()
+
+  register(rule: AlertRuleDef): void {
+    this.rules.set(rule.id, rule)
+  }
+
+  unregister(id: string): void {
+    this.rules.delete(id)
+  }
+
+  get(id: string): AlertRuleDef | undefined {
+    return this.rules.get(id)
+  }
+
+  getAll(): AlertRuleDef[] {
+    return [...this.rules.values()]
+  }
+
+  has(id: string): boolean {
+    return this.rules.has(id)
+  }
+
+  size(): number {
+    return this.rules.size
+  }
+}
+
+/** Global singleton. Built-in rules are registered in builtin-rules.ts. */
+export const ruleRegistry = new AlertRuleRegistry()

--- a/apps/dashboard/src/lib/alerting/slow-query-regression.ts
+++ b/apps/dashboard/src/lib/alerting/slow-query-regression.ts
@@ -1,0 +1,196 @@
+/**
+ * Slow Query Regression Detection (#1921)
+ *
+ * Detects query fingerprints whose P95 execution time has regressed
+ * significantly between a current window and a baseline window.
+ *
+ * Fingerprint normalization strips literals (numbers, strings, bind params)
+ * so that structurally identical queries are grouped regardless of values.
+ *
+ * The regression SQL runs entirely in ClickHouse — no client-side aggregation.
+ */
+
+// ---------------------------------------------------------------------------
+// Fingerprint normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a raw SQL string to a stable fingerprint for grouping.
+ *
+ * Strips:
+ * - Single-quoted string literals → '?'
+ * - Bare integer/float literals → ?
+ * - Named bind parameters {param:Type} → ?
+ * - IN (...) list values → IN (?)
+ * - Excess whitespace
+ */
+export function normalizeQueryFingerprint(sql: string): string {
+  return sql
+    .replace(/\{[^}]+\}/g, '?') // {param:Type} bind params
+    .replace(/'(?:[^'\\]|\\.)*'/g, "'?'") // single-quoted strings
+    .replace(/\b\d+(\.\d+)?\b/g, '?') // numeric literals
+    .replace(/\bIN\s*\([^)]+\)/gi, 'IN (?)') // IN (...) list collapsing
+    .replace(/\s+/g, ' ') // normalize whitespace
+    .trim()
+    .toLowerCase()
+}
+
+// ---------------------------------------------------------------------------
+// Regression SQL — runs in ClickHouse, no client aggregation needed
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the regression-detection SQL.
+ *
+ * Compares P95 `query_duration_ms` for each normalized fingerprint between:
+ *   - current_window_hours (most recent period)
+ *   - baseline_window_hours (older comparison period immediately before current)
+ *
+ * Returns fingerprints where the current P95 is >= regressionFactor × baseline.
+ * Excludes fingerprints with fewer than minSamples in either window to reduce noise.
+ */
+export function buildRegressionSQL(opts?: {
+  currentWindowHours?: number
+  baselineWindowHours?: number
+  regressionFactor?: number
+  minSamples?: number
+  maxResults?: number
+}): string {
+  const {
+    currentWindowHours = 1,
+    baselineWindowHours = 24,
+    regressionFactor = 2,
+    minSamples = 3,
+    maxResults = 20,
+  } = opts ?? {}
+
+  return `
+WITH
+  now() AS ref_time,
+  ref_time - INTERVAL ${currentWindowHours} HOUR AS current_start,
+  current_start - INTERVAL ${baselineWindowHours} HOUR AS baseline_start,
+  current_data AS (
+    SELECT
+      replaceRegexpAll(
+        replaceRegexpAll(
+          replaceRegexpAll(
+            lower(trimBoth(query)),
+            '(''[^'']*''|\\b\\d+(?:\\.\\d+)?\\b|\\{[^}]+\\})',
+            '?'
+          ),
+          '\\s+',
+          ' '
+        ),
+        'in\\s*\\([^)]+\\)',
+        'in (?)'
+      ) AS fingerprint,
+      query_duration_ms
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+      AND event_time >= current_start
+      AND event_time < ref_time
+      AND query NOT LIKE '%system.%'
+      AND is_initial_query = 1
+  ),
+  baseline_data AS (
+    SELECT
+      replaceRegexpAll(
+        replaceRegexpAll(
+          replaceRegexpAll(
+            lower(trimBoth(query)),
+            '(''[^'']*''|\\b\\d+(?:\\.\\d+)?\\b|\\{[^}]+\\})',
+            '?'
+          ),
+          '\\s+',
+          ' '
+        ),
+        'in\\s*\\([^)]+\\)',
+        'in (?)'
+      ) AS fingerprint,
+      query_duration_ms
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+      AND event_time >= baseline_start
+      AND event_time < current_start
+      AND query NOT LIKE '%system.%'
+      AND is_initial_query = 1
+  ),
+  current_stats AS (
+    SELECT
+      fingerprint,
+      count() AS current_count,
+      round(quantile(0.95)(query_duration_ms)) AS current_p95_ms,
+      round(avg(query_duration_ms)) AS current_avg_ms
+    FROM current_data
+    GROUP BY fingerprint
+    HAVING current_count >= ${minSamples}
+  ),
+  baseline_stats AS (
+    SELECT
+      fingerprint,
+      count() AS baseline_count,
+      round(quantile(0.95)(query_duration_ms)) AS baseline_p95_ms,
+      round(avg(query_duration_ms)) AS baseline_avg_ms
+    FROM baseline_data
+    GROUP BY fingerprint
+    HAVING baseline_count >= ${minSamples}
+  )
+SELECT
+  c.fingerprint,
+  c.current_count,
+  c.current_p95_ms,
+  c.current_avg_ms,
+  b.baseline_count,
+  b.baseline_p95_ms,
+  b.baseline_avg_ms,
+  round(c.current_p95_ms / nullIf(b.baseline_p95_ms, 0), 2) AS regression_factor,
+  substr(c.fingerprint, 1, 200) AS fingerprint_short
+FROM current_stats c
+INNER JOIN baseline_stats b USING (fingerprint)
+WHERE c.current_p95_ms >= b.baseline_p95_ms * ${regressionFactor}
+  AND b.baseline_p95_ms > 100
+ORDER BY regression_factor DESC
+LIMIT ${maxResults}
+`
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SlowQueryRegression {
+  fingerprint: string
+  fingerprint_short: string
+  current_count: number
+  current_p95_ms: number
+  current_avg_ms: number
+  baseline_count: number
+  baseline_p95_ms: number
+  baseline_avg_ms: number
+  regression_factor: number
+  [key: string]: string | number
+}
+
+export interface RegressionSummary {
+  count: number
+  worst_factor: number
+  worst_fingerprint: string
+}
+
+/**
+ * Summarize a list of regressions for alert threshold evaluation.
+ * Returns null when there are no regressions.
+ */
+export function summarizeRegressions(
+  rows: SlowQueryRegression[]
+): RegressionSummary | null {
+  if (rows.length === 0) return null
+  const worst = rows.reduce((a, b) =>
+    a.regression_factor > b.regression_factor ? a : b
+  )
+  return {
+    count: rows.length,
+    worst_factor: worst.regression_factor,
+    worst_fingerprint: worst.fingerprint_short,
+  }
+}

--- a/apps/dashboard/src/lib/api/charts/query-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/query-charts.ts
@@ -359,4 +359,105 @@ export const queryCharts: Record<string, ChartQueryBuilder> = {
   `,
     }
   },
+
+  /**
+   * Slow query regression detection (#1921).
+   *
+   * Compares P95 query_duration_ms per normalized fingerprint between the
+   * current window (last 1h) and the baseline (previous 24h). Returns
+   * fingerprints where P95 has grown by ≥2× with at least 3 samples in each
+   * window. Ordered worst regression first.
+   */
+  'slow-query-regressions': () => ({
+    query: `
+    WITH
+      now() AS ref_time,
+      ref_time - INTERVAL 1 HOUR AS current_start,
+      current_start - INTERVAL 24 HOUR AS baseline_start,
+      current_data AS (
+        SELECT
+          replaceRegexpAll(
+            replaceRegexpAll(lower(trimBoth(query)), '(''[^'']*''|\\b\\d+(?:\\.\\d+)?\\b|\\{[^}]+\\})', '?'),
+            '\\s+', ' '
+          ) AS fingerprint,
+          query_duration_ms
+        FROM system.query_log
+        WHERE type = 'QueryFinish'
+          AND event_time >= current_start AND event_time < ref_time
+          AND query NOT LIKE '%system.%' AND is_initial_query = 1
+      ),
+      baseline_data AS (
+        SELECT
+          replaceRegexpAll(
+            replaceRegexpAll(lower(trimBoth(query)), '(''[^'']*''|\\b\\d+(?:\\.\\d+)?\\b|\\{[^}]+\\})', '?'),
+            '\\s+', ' '
+          ) AS fingerprint,
+          query_duration_ms
+        FROM system.query_log
+        WHERE type = 'QueryFinish'
+          AND event_time >= baseline_start AND event_time < current_start
+          AND query NOT LIKE '%system.%' AND is_initial_query = 1
+      ),
+      current_stats AS (
+        SELECT fingerprint,
+               count() AS current_count,
+               round(quantile(0.95)(query_duration_ms)) AS current_p95_ms,
+               round(avg(query_duration_ms)) AS current_avg_ms
+        FROM current_data GROUP BY fingerprint HAVING current_count >= 3
+      ),
+      baseline_stats AS (
+        SELECT fingerprint,
+               count() AS baseline_count,
+               round(quantile(0.95)(query_duration_ms)) AS baseline_p95_ms,
+               round(avg(query_duration_ms)) AS baseline_avg_ms
+        FROM baseline_data GROUP BY fingerprint HAVING baseline_count >= 3
+      )
+    SELECT
+      c.fingerprint,
+      c.current_count,
+      c.current_p95_ms,
+      c.current_avg_ms,
+      b.baseline_count,
+      b.baseline_p95_ms,
+      b.baseline_avg_ms,
+      round(c.current_p95_ms / nullIf(b.baseline_p95_ms, 0), 2) AS regression_factor,
+      substr(c.fingerprint, 1, 200) AS fingerprint_short
+    FROM current_stats c
+    INNER JOIN baseline_stats b USING (fingerprint)
+    WHERE c.current_p95_ms >= b.baseline_p95_ms * 2 AND b.baseline_p95_ms > 100
+    ORDER BY regression_factor DESC
+    LIMIT 20
+  `,
+    optional: true,
+    tableCheck: 'system.query_log',
+  }),
+
+  /**
+   * MV refresh staleness (#1925).
+   * Returns all view_refreshes rows enriched with staleness_seconds.
+   */
+  'mv-staleness': () => ({
+    query: `
+    SELECT
+      database,
+      view,
+      status,
+      last_success_time,
+      last_refresh_time,
+      next_refresh_time,
+      dateDiff('second', coalesce(last_success_time, toDateTime(0)), now()) AS staleness_seconds,
+      multiIf(
+        status IN ('Error', 'Failed'), 1,
+        isNull(last_success_time), 1,
+        dateDiff('second', last_success_time, now()) > 3600, 1,
+        0
+      ) AS is_failed,
+      exception
+    FROM system.view_refreshes
+    WHERE status NOT IN ('Running', 'Scheduled')
+    ORDER BY is_failed DESC, staleness_seconds DESC
+  `,
+    optional: true,
+    tableCheck: 'system.view_refreshes',
+  }),
 }

--- a/apps/dashboard/src/lib/api/charts/replication-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/replication-charts.ts
@@ -60,11 +60,45 @@ export const replicationCharts: Record<string, ChartQueryBuilder> = {
       END AS lag_status,
       formatReadableTimeDelta(absolute_delay) AS readable_delay,
       inserts_in_queue,
-      merges_in_queue
+      merges_in_queue,
+      -- Per-replica health score (0-100): base from lag tier, -5 per 100 queue items
+      greatest(0, least(100,
+        multiIf(
+          absolute_delay = 0, 100,
+          absolute_delay < 60, 75,
+          absolute_delay < 300, 50,
+          0
+        ) - intDiv(inserts_in_queue + merges_in_queue, 100) * 5
+      )) AS health_score
     FROM system.replicas
     WHERE is_leader = 1 OR absolute_delay > 0
     ORDER BY absolute_delay DESC
     LIMIT 20
   `,
   }),
+
+  /**
+   * Replication lag trend — time-series of max and avg lag from metric_log.
+   * Used by the lag trend chart added in #1914.
+   */
+  'replication-lag-trend': ({
+    interval = 'toStartOfFiveMinutes',
+    lastHours = 24,
+  }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      query: `
+    SELECT
+      ${applyInterval(interval, 'event_time')},
+      max(CurrentMetric_ReplicasMaxAbsoluteDelay) AS max_lag_seconds,
+      avg(CurrentMetric_ReplicasMaxAbsoluteDelay) AS avg_lag_seconds
+    FROM merge('system', '^metric_log')
+    ${timeFilter ? `WHERE ${timeFilter}` : ''}
+    GROUP BY event_time
+    ORDER BY event_time
+  `,
+      optional: true,
+      tableCheck: 'system.metric_log',
+    }
+  },
 }

--- a/apps/dashboard/src/lib/api/charts/system-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/system-charts.ts
@@ -549,6 +549,59 @@ export const systemCharts: Record<string, ChartQueryBuilder> = {
     tableCheck: 'system.disks',
   }),
 
+  // New charts for #1911 alert rule types
+
+  'health-failed-mutations': () => ({
+    query: `
+    SELECT countIf(is_done = 0 AND isNotNull(latest_fail_time)) AS failed_count
+    FROM system.mutations
+  `,
+    optional: true,
+    tableCheck: 'system.mutations',
+  }),
+
+  'health-stuck-merges': () => ({
+    query: `
+    SELECT count() AS stuck_count
+    FROM system.merges
+    WHERE elapsed > 600
+  `,
+    optional: true,
+    tableCheck: 'system.merges',
+  }),
+
+  'health-query-timeouts': () => ({
+    query: `
+    SELECT count() AS timeout_count
+    FROM system.query_log
+    WHERE event_time > now() - INTERVAL 1 HOUR
+      AND type IN ('ExceptionWhileProcessing', 'ExceptionBeforeStart')
+      AND (exception_code = 159 OR exception LIKE '%TIMEOUT_EXCEEDED%')
+  `,
+    optional: true,
+    tableCheck: 'system.query_log',
+  }),
+
+  'health-failed-backups': () => ({
+    query: `
+    SELECT count() AS failed_count
+    FROM system.backup_log
+    WHERE event_time > now() - INTERVAL 24 HOUR
+      AND status = 'FAILED'
+  `,
+    optional: true,
+    tableCheck: 'system.backup_log',
+  }),
+
+  'health-mv-refresh-failures': () => ({
+    query: `
+    SELECT countIf(status IN ('Error', 'Failed')) AS failed_count
+    FROM system.view_refreshes
+  `,
+    optional: true,
+    tableCheck: 'system.view_refreshes',
+  }),
+
   'keeper-requests': ({
     interval = 'toStartOfFifteenMinutes',
     lastHours = 24,

--- a/apps/dashboard/src/lib/health/server-sweep.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.ts
@@ -5,6 +5,11 @@ import { fetchData, getClickHouseConfigs } from '@chm/clickhouse-client'
 import { debug, error } from '@chm/logger'
 import { HEALTH_CHECKS } from '@/components/health/health-checks'
 import { generateInsights } from '@/lib/insights/generate-insights'
+import { registerBuiltinRules } from '@/lib/alerting/builtin-rules'
+
+// Register pluggable alert rules into the global ruleRegistry once at module
+// load. HEALTH_CHECKS (same rule set) continue to drive the /health page UI.
+registerBuiltinRules()
 
 type Severity = 'ok' | 'warning' | 'critical'
 

--- a/apps/dashboard/src/routes/(dashboard)/view-refreshes.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/view-refreshes.tsx
@@ -1,12 +1,30 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import { createPage } from '@/lib/create-page'
+import { MvStalenessBadge } from '@/components/alerting/mv-staleness-badge'
+import { QueryPageLayout } from '@/components/layout/query-page'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { viewRefreshesConfig } from '@/lib/query-config/tables/view-refreshes'
+import { useHostId } from '@/lib/swr/use-host'
 
-const ViewRefreshesPage = createPage({
-  queryConfig: viewRefreshesConfig,
-  title: 'View Refreshes',
-})
+/**
+ * View Refreshes page — standard query layout with an MV staleness badge
+ * prepended above the table so failed/stale views are immediately visible.
+ */
+function ViewRefreshesPage() {
+  const hostId = useHostId()
+
+  return (
+    <TooltipProvider>
+      <div className="flex flex-col gap-3 sm:gap-4">
+        <MvStalenessBadge hostId={hostId} />
+        <QueryPageLayout
+          queryConfig={viewRefreshesConfig}
+          title="View Refreshes"
+        />
+      </div>
+    </TooltipProvider>
+  )
+}
 
 export const Route = createFileRoute('/(dashboard)/view-refreshes')({
   component: ViewRefreshesPage,


### PR DESCRIPTION
## Summary

- **#1911 (P0)** — Pluggable `AlertRuleRegistry` with 9 built-in rule types (readonly-replicas, replication-lag, disk-usage, keeper-unavailable — parity with existing health checks — plus 5 new: **failed-mutations**, **stuck-merges**, **query-timeout**, **failed-backups**, **mv-refresh-failures**). Each rule has stable ID, type taxonomy, configurable thresholds, SQL, and `formatLabel`. `classifyValue()` is a pure function. `registerBuiltinRules()` is called at server-sweep module load. Existing readonly-table alert migrated; all new rules auto-included in cron sweep via `HEALTH_CHECKS` extension. Dedup: in-app alerts use `incidentId` bucketed to 1-minute/5-minute windows.

- **#1914 (P1)** — `computeReplicaHealthScore(delay, insertsQ, mergesQ)` → 0–100 score (base from lag tier: synced=100/slight=75/moderate=50/severe=0, −5 per 100 queue items). `replication-lag` chart SQL extended with `health_score` column. New `replication-lag-trend` chart reads `system.metric_log` for time-series of `max_lag_seconds` / `avg_lag_seconds`.

- **#1921 (P1)** — `normalizeQueryFingerprint()` strips literals/bind-params/IN-lists. `slow-query-regressions` chart runs P95 comparison in ClickHouse (current 1h vs prior 24h baseline, factor ≥2×, ≥3 samples). `RegressionPanel` renders on `/slow-queries` and calls `dispatchAlert()` when regressions are found.

- **#1925 (P2)** — `classifyMvRefresh()` / `countMvIssues()` classify view refresh rows as ok/stale/failed. `mv-staleness` chart queries `system.view_refreshes`. `MvStalenessBadge` renders above the table on `/view-refreshes` and dispatches an in-app alert for failed/stale views.

## New files

| File | Purpose |
|------|---------|
| `lib/alerting/rule-registry.ts` | `AlertRuleRegistry` class + `classifyValue()` |
| `lib/alerting/builtin-rules.ts` | 9 built-in rule definitions + `registerBuiltinRules()` |
| `lib/alerting/slow-query-regression.ts` | Fingerprint normalization + regression SQL builder |
| `lib/alerting/mv-refresh-staleness.ts` | Staleness classification + SQL builders |
| `lib/alerting/replication-lag-health.ts` | Health score + lag trend SQL |
| `lib/alerting/__tests__/rule-registry.test.ts` | 50 tests: every rule trigger + clear + registry CRUD |
| `lib/alerting/__tests__/slow-query-regression.test.ts` | Fingerprint normalization + summarize |
| `lib/alerting/__tests__/mv-refresh-staleness.test.ts` | Classify + count + format |
| `lib/alerting/__tests__/replication-lag-health.test.ts` | Health score + lag status |
| `components/alerting/regression-panel.tsx` | Regression UI on /slow-queries |
| `components/alerting/mv-staleness-badge.tsx` | Staleness badge on /view-refreshes |

## Test plan

- [ ] `bun test src/lib/alerting` → 89 pass, 0 fail (verified locally)
- [ ] `bun test src/lib/health` → 107 pass, 0 fail (no regressions)
- [ ] `bun test src/lib/notifications` → 30 pass, 0 fail
- [ ] `/health` page shows 5 new cards (failed-mutations, stuck-merges, query-timeout, failed-backups, mv-refresh-failures) — optional ones gracefully skip when table absent
- [ ] `/slow-queries` shows `RegressionPanel` below the table when regressions exist
- [ ] `/view-refreshes` shows `MvStalenessBadge` when failed/stale MVs exist
- [ ] Bell popover shows alerts dispatched by regression/MV panels

`bun run test:query-config` was **not** run — no legacy query-config files under `lib/query-config/<area>/` were modified (only `lib/api/charts/` and `components/health/` were touched).

Closes #1911, #1914, #1921, #1925

https://claude.ai/code/session_01TnsycTkdMHJ4DXohpuz3oj