### PR TITLE
chore(telemetry): make opt-in telemetry inert + documented when no endpoint set

### DIFF
--- a/apps/dashboard/src/lib/telemetry/instance-ping.test.ts
+++ b/apps/dashboard/src/lib/telemetry/instance-ping.test.ts
@@ -1,5 +1,6 @@
 import {
   buildPingPayload,
+  getPingEndpoint,
   PING_INTERVAL_MS,
   type PingDeps,
   runInstancePing,
@@ -247,6 +248,35 @@ describe('runInstancePing error resilience', () => {
     })
     await runInstancePing(deps)
     expect(deps.store.chm_telemetry_last_ping_at).toBe(String(now))
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// No-op safety contract: when no endpoint is configured, fetch is never called.
+//
+// This is the critical invariant: the default build ships VITE_TELEMETRY_ENDPOINT=''
+// (see vite.config.ts), so even if a user sets VITE_TELEMETRY_ENABLED=true they
+// still make zero network calls until they also provide a collection endpoint.
+
+describe('no-op safety contract: no endpoint configured', () => {
+  test('getPingEndpoint returns empty string when runtimeEnv has no endpoint key', () => {
+    expect(getPingEndpoint({})).toBe('')
+    expect(getPingEndpoint({ UNRELATED: 'foo' })).toBe('')
+  })
+
+  test('runInstancePing never calls post when endpoint is empty — even with enabled:true', async () => {
+    const posts: Array<{ url: string; body: string }> = []
+    const result = await runInstancePing(
+      makeDeps({
+        enabled: true,
+        endpoint: getPingEndpoint({}), // '' — mirrors the default build config
+        post: async (url, body) => {
+          posts.push({ url, body })
+        },
+      })
+    )
+    expect(result).toBe('skipped-no-endpoint')
+    expect(posts).toHaveLength(0)
   })
 })
 

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -68,8 +68,9 @@ const CLIENT_ENV = {
   // steps so telemetry can distinguish deployment environments.
   VITE_DEPLOY_TARGET: e.VITE_DEPLOY_TARGET ?? 'unknown',
   // Collection endpoint for the opt-in daily instance ping. Empty by default —
-  // no network call is made unless this is explicitly set. No production
-  // endpoint is provisioned yet (TODO for a human).
+  // the ping is a hard no-op unless BOTH this and VITE_TELEMETRY_ENABLED are
+  // explicitly set. Set to a collection URL (e.g. your own ClickHouse ingest
+  // endpoint) to enable. See docs/content/advanced/telemetry.mdx.
   VITE_TELEMETRY_ENDPOINT: e.VITE_TELEMETRY_ENDPOINT ?? '',
   VITE_GIT_SHA:
     e.VITE_GIT_SHA ?? e.NEXT_PUBLIC_GIT_SHA ?? git('rev-parse HEAD'),

--- a/docs/content/advanced/telemetry.mdx
+++ b/docs/content/advanced/telemetry.mdx
@@ -81,7 +81,15 @@ Telemetry is off by default — you do not need to do anything to disable it. To
 
 ## Current transport status
 
-There is currently **no default network sink**. Events are typed, redacted, and emitted internally, but no transport is wired yet — meaning even when enabled, events go nowhere. A self-hosted sink (writing to your own ClickHouse) will be added in a later release. This means enabling telemetry today has no effect on data leaving your instance.
+Two separate systems exist, each with its own no-op guarantee:
+
+**Instance ping** (`maybePingInstance`) is wired to the app and runs once per day when due. It is a hard no-op unless **both** conditions hold simultaneously:
+1. Telemetry is explicitly enabled (`CHM_TELEMETRY=on` / `VITE_TELEMETRY_ENABLED=true`).
+2. A collection endpoint is explicitly configured (`CHM_TELEMETRY_ENDPOINT` / `VITE_TELEMETRY_ENDPOINT`).
+
+Neither variable is set by default. Because both are required, enabling just the flag makes zero network calls — the code short-circuits before any `fetch()` is invoked.
+
+**Event tracking** (`track()`) has no default transport sink. Events are typed and redacted internally, but with no sink registered they are silently dropped. A self-hosted sink (writing to your own ClickHouse) will be added in a later release. Enabling telemetry today produces no network traffic from event tracking.
 
 ---
 
@@ -101,7 +109,7 @@ A session is considered activated when a cluster is connected and the user viewe
 - **Self-hosted** — chmonitor is fully self-hostable; your ClickHouse data never leaves your network regardless of telemetry settings.
 - **No third-party trackers** — there are no analytics SDKs, beacon scripts, or third-party pixels in the application.
 - **No PII by design** — the event schema and redaction layer are written to make PII collection structurally impossible, not just policy-forbidden.
-- **Inert today** — no transport sink is wired, so enabling telemetry currently produces no network traffic.
+- **Inert by default** — both the telemetry flag and a collection endpoint must be explicitly set for any network call to occur. Enabling just the flag (without an endpoint) still makes zero network calls.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Decision**: Keep the opt-in telemetry scaffolding as a clean, inert feature — do not remove it. The instance ping already enforces a two-gate no-op (both `CHM_TELEMETRY=on` AND an endpoint must be set), so the codebase is already safe by construction.
- **`vite.config.ts`**: Removed the stale `TODO for a human` comment and replaced it with a self-documenting explanation of the double-gate requirement.
- **`docs/content/advanced/telemetry.mdx`**: Rewrote the "Current transport status" section to accurately describe both systems (instance ping double-gate; event track() with no sinks). Updated the privacy stance bullet.
- **`instance-ping.test.ts`**: Added a `no-op safety contract` test group — imports `getPingEndpoint`, asserts it returns `''` with no env set, and asserts `runInstancePing` with `endpoint: ''` never calls `post` even when `enabled: true`. 64 tests pass, 0 fail.

## Test plan

- [x] `bun test src/lib/telemetry/` — 64 pass, 0 fail
- [x] New tests explicitly assert no `fetch` when endpoint is unset

Closes #1951

https://claude.ai/code/session_01TnsycTkdMHJ4DXohpuz3oj