### PR TITLE
feat(ux): consistent global time-range, query favorites, bulk explain

### DIFF
--- a/apps/dashboard/src/components/charts/factory/create-area-chart.tsx
+++ b/apps/dashboard/src/components/charts/factory/create-area-chart.tsx
@@ -9,6 +9,7 @@ import { ChartContainer } from '@/components/charts/chart-container'
 import { ChartEmpty } from '@/components/charts/chart-empty'
 import { AreaChart } from '@/components/charts/primitives/area'
 import { resolveDateRangeConfig } from '@/components/date-range'
+import { useTimeRange } from '@/lib/context/time-range-context'
 import { useTimezone } from '@/lib/context/timezone-context'
 import { useChartData, useHostId } from '@/lib/swr'
 import { REFRESH_INTERVAL } from '@/lib/swr/config'
@@ -59,8 +60,8 @@ export function createAreaChart(
 
   return memo(function Chart({
     title = config.defaultTitle,
-    interval = config.defaultInterval,
-    lastHours = config.defaultLastHours,
+    interval,
+    lastHours,
     className,
     chartClassName,
     chartCardContentClassName,
@@ -71,15 +72,26 @@ export function createAreaChart(
     const routeHostId = useHostId()
     const hostId = hostIdProp ?? routeHostId
     const userTimezone = useTimezone()
+    const { timeRange } = useTimeRange()
 
     // Date range state (only used when dateRangeConfig is provided)
     const [rangeOverride, setRangeOverride] = useState<DateRangeValue | null>(
       null
     )
 
-    // Use override values when date range is selected, otherwise use props/defaults
-    const effectiveLastHours = rangeOverride?.lastHours ?? lastHours
-    const effectiveInterval = rangeOverride?.interval ?? interval
+    // Priority: per-chart date range override → explicit prop → global context → factory config default.
+    // Charts that pass an explicit lastHours prop keep their value; charts without one follow
+    // the global time-range picker so the header control affects all time-series charts.
+    const effectiveLastHours =
+      rangeOverride?.lastHours ??
+      lastHours ??
+      timeRange.lastHours ??
+      config.defaultLastHours
+    const effectiveInterval =
+      rangeOverride?.interval ??
+      interval ??
+      timeRange.interval ??
+      config.defaultInterval
 
     const swr = useChartData({
       chartName: config.chartName,

--- a/apps/dashboard/src/components/charts/factory/create-bar-chart.tsx
+++ b/apps/dashboard/src/components/charts/factory/create-bar-chart.tsx
@@ -9,6 +9,7 @@ import { ChartContainer } from '@/components/charts/chart-container'
 import { ChartEmpty } from '@/components/charts/chart-empty'
 import { BarChart } from '@/components/charts/primitives/bar/bar'
 import { resolveDateRangeConfig } from '@/components/date-range'
+import { useTimeRange } from '@/lib/context/time-range-context'
 import { useTimezone } from '@/lib/context/timezone-context'
 import { useChartData, useHostId } from '@/lib/swr'
 import { REFRESH_INTERVAL } from '@/lib/swr/config'
@@ -57,8 +58,8 @@ export function createBarChart(config: BarChartFactoryConfig): FC<ChartProps> {
 
   return memo(function Chart({
     title = config.defaultTitle,
-    interval = config.defaultInterval,
-    lastHours = config.defaultLastHours,
+    interval,
+    lastHours,
     className,
     chartClassName,
     chartCardContentClassName,
@@ -69,15 +70,24 @@ export function createBarChart(config: BarChartFactoryConfig): FC<ChartProps> {
     const routeHostId = useHostId()
     const hostId = hostIdProp ?? routeHostId
     const userTimezone = useTimezone()
+    const { timeRange } = useTimeRange()
 
     // Date range state (only used when dateRangeConfig is provided)
     const [rangeOverride, setRangeOverride] = useState<DateRangeValue | null>(
       null
     )
 
-    // Use override values when date range is selected, otherwise use props/defaults
-    const effectiveLastHours = rangeOverride?.lastHours ?? lastHours
-    const effectiveInterval = rangeOverride?.interval ?? interval
+    // Priority: per-chart date range override → explicit prop → global context → factory config default.
+    const effectiveLastHours =
+      rangeOverride?.lastHours ??
+      lastHours ??
+      timeRange.lastHours ??
+      config.defaultLastHours
+    const effectiveInterval =
+      rangeOverride?.interval ??
+      interval ??
+      timeRange.interval ??
+      config.defaultInterval
 
     const swr = useChartData({
       chartName: config.chartName,

--- a/apps/dashboard/src/components/expensive-queries/expensive-queries-view.tsx
+++ b/apps/dashboard/src/components/expensive-queries/expensive-queries-view.tsx
@@ -3,12 +3,14 @@ import {
   LayoutDashboardIcon,
   MinimizeIcon,
   RefreshCw,
+  ScanSearch,
 } from 'lucide-react'
 
 import type { ExpensiveQueryRow } from '@/components/expensive-queries/expensive-queries-table'
 import type { CardError } from '@/lib/card-error-utils'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
+import { BulkExplainDialog } from '@/components/explain/bulk-explain-dialog'
 import { ExpensiveQueriesTable } from '@/components/expensive-queries/expensive-queries-table'
 import { LoadSummary } from '@/components/expensive-queries/load-summary'
 import { PageHeader } from '@/components/layout'
@@ -25,9 +27,11 @@ import {
   getCardErrorTitle,
   toEmptyStateVariant,
 } from '@/lib/card-error-utils'
+import { useTimeRange } from '@/lib/context/time-range-context'
 import { useTableData } from '@/lib/query/use-table-data'
 import { expensiveQueriesConfig } from '@/lib/query-config/queries/expensive-queries'
 import { useHostId } from '@/lib/swr/use-host'
+import { truncateSql } from '@/lib/explain-heuristics'
 import { cn } from '@/lib/utils'
 
 // LoadingState is replaced by QueryPageSkeleton from @/components/query-tables/query-page-skeleton
@@ -44,12 +48,28 @@ import { cn } from '@/lib/utils'
  */
 export const ExpensiveQueriesView = function ExpensiveQueriesView() {
   const hostId = useHostId()
+  const { timeRange } = useTimeRange()
   const [chartsOpen, setChartsOpen] = useState(true)
+  const [explainOpen, setExplainOpen] = useState(false)
+
+  // Pass last_hours from global time-range context so the table respects the
+  // global picker. Falls back to the config default (24h) if context is absent.
+  const filterParams = useMemo(
+    () => ({ last_hours: String(timeRange.lastHours) }),
+    [timeRange.lastHours]
+  )
 
   const { data, error, isLoading, isValidating, refresh } =
-    useTableData<ExpensiveQueryRow>('expensive-queries', hostId)
+    useTableData<ExpensiveQueryRow>('expensive-queries', hostId, filterParams)
 
   const rows = data ?? []
+
+  const explainItems = rows.slice(0, 20).map((r) => ({
+    sql: String(r.query ?? ''),
+    title: truncateSql(String(r.query ?? ''), 60),
+    readRows: Number(r.read_rows ?? 0),
+    resultRows: Number(r.result_rows ?? 0),
+  }))
 
   return (
     <TooltipProvider>
@@ -65,7 +85,7 @@ export const ExpensiveQueriesView = function ExpensiveQueriesView() {
               </span>
             </div>
           }
-          description="Top query fingerprints by cost over the last 24 hours · aggregated from system.query_log"
+          description={`Top query fingerprints by cost over the last ${timeRange.label} · aggregated from system.query_log`}
           actions={
             <div className="flex flex-wrap items-center gap-1.5">
               {expensiveQueriesConfig.relatedCharts &&
@@ -79,6 +99,13 @@ export const ExpensiveQueriesView = function ExpensiveQueriesView() {
                     {chartsOpen ? 'Collapse charts' : 'Expand charts'}
                   </HeaderButton>
                 )}
+              <HeaderButton
+                onClick={() => setExplainOpen(true)}
+                disabled={rows.length === 0}
+              >
+                <ScanSearch className="size-3.5" />
+                Explain top N
+              </HeaderButton>
               <HeaderButton onClick={() => refresh()} disabled={isValidating}>
                 <RefreshCw
                   className={cn('size-3.5', isValidating && 'animate-spin')}
@@ -149,7 +176,7 @@ export const ExpensiveQueriesView = function ExpensiveQueriesView() {
                   <EmptyState
                     variant="no-data"
                     title="No expensive queries"
-                    description="No query activity recorded in the last 24 hours on this host."
+                    description={`No query activity recorded in the last ${timeRange.label} on this host.`}
                   />
                 </CardContent>
               </Card>
@@ -159,6 +186,13 @@ export const ExpensiveQueriesView = function ExpensiveQueriesView() {
           </>
         )}
       </div>
+
+      <BulkExplainDialog
+        queries={explainItems}
+        hostId={hostId}
+        open={explainOpen}
+        onOpenChange={setExplainOpen}
+      />
     </TooltipProvider>
   )
 }

--- a/apps/dashboard/src/components/explain/bulk-explain-dialog.tsx
+++ b/apps/dashboard/src/components/explain/bulk-explain-dialog.tsx
@@ -1,0 +1,281 @@
+import type { ExplainAnalysis } from '@/lib/explain-heuristics'
+
+import { useCallback, useState } from 'react'
+import { SuggestionChip } from '@/components/explain/suggestion-chip'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { analyzeExplain } from '@/lib/explain-heuristics'
+import { apiFetch } from '@/lib/swr/api-fetch'
+
+interface QueryItem {
+  sql: string
+  title: string
+  readRows?: number
+  resultRows?: number
+}
+
+interface BulkExplainDialogProps {
+  queries: QueryItem[]
+  hostId: number
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+interface ExplainApiResponse {
+  data: Array<{ explain: string }>
+  metadata: { sql: string }
+}
+
+const N_OPTIONS = [1, 3, 5, 10, 20] as const
+
+/**
+ * Sequentially EXPLAIN the top N queries and surface heuristic suggestions.
+ *
+ * Results are shown one by one as they arrive. "Ask AI about all findings"
+ * links to /agents with the context pre-populated in the URL.
+ */
+export function BulkExplainDialog({
+  queries,
+  hostId,
+  open,
+  onOpenChange,
+}: BulkExplainDialogProps) {
+  const [n, setN] = useState(5)
+  const [running, setRunning] = useState(false)
+  const [progress, setProgress] = useState<number | null>(null)
+  const [results, setResults] = useState<ExplainAnalysis[]>([])
+  const [expandedIdx, setExpandedIdx] = useState<Set<number>>(new Set())
+
+  const selected = queries.slice(0, n)
+
+  const runAnalysis = useCallback(async () => {
+    setRunning(true)
+    setResults([])
+    setProgress(0)
+    setExpandedIdx(new Set())
+
+    const collected: ExplainAnalysis[] = []
+
+    for (let i = 0; i < selected.length; i++) {
+      const item = selected[i]
+      setProgress(i + 1)
+
+      try {
+        const url = `/api/v1/explain?hostId=${hostId}&query=${encodeURIComponent(item.sql)}`
+        const res = await apiFetch(url)
+        if (!res.ok) {
+          const errData = (await res.json()) as { error?: { message?: string } }
+          collected.push({
+            sql: item.sql,
+            title: item.title,
+            planLines: [],
+            suggestions: [],
+            ok: false,
+            error: errData.error?.message ?? `HTTP ${res.status}`,
+          })
+        } else {
+          const json = (await res.json()) as ExplainApiResponse
+          const planLines = json.data.map((r) => r.explain)
+          const suggestions = analyzeExplain(
+            item.sql,
+            planLines,
+            item.readRows,
+            item.resultRows
+          )
+          collected.push({
+            sql: item.sql,
+            title: item.title,
+            planLines,
+            suggestions,
+            ok: true,
+          })
+        }
+      } catch (err) {
+        collected.push({
+          sql: item.sql,
+          title: item.title,
+          planLines: [],
+          suggestions: [],
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+
+      // Render each result as it arrives.
+      setResults([...collected])
+    }
+
+    setRunning(false)
+    setProgress(null)
+  }, [selected, hostId])
+
+  const totalSuggestions = results.reduce(
+    (acc, r) => acc + r.suggestions.length,
+    0
+  )
+
+  const agentUrl = (() => {
+    if (results.length === 0) return '/agents'
+    const summary = results
+      .map(
+        (r) =>
+          `Query: ${r.title}\nIssues: ${r.suggestions.map((s) => s.title).join(', ') || 'none'}`
+      )
+      .join('\n\n')
+    return `/agents?message=${encodeURIComponent(`Please help optimize these ClickHouse queries:\n\n${summary}`)}`
+  })()
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[85vh] w-full max-w-2xl flex-col gap-0 p-0">
+        <DialogHeader className="border-b px-5 py-4">
+          <DialogTitle className="text-base font-semibold">
+            Explain top N queries
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 overflow-hidden px-5 py-4">
+          {/* N selector + run button */}
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="text-sm text-muted-foreground">Analyze top</span>
+            <div className="flex items-center gap-1">
+              {N_OPTIONS.map((opt) => {
+                const disabled = opt > queries.length
+                return (
+                  <button
+                    key={opt}
+                    type="button"
+                    disabled={disabled}
+                    onClick={() => setN(opt)}
+                    className={[
+                      'rounded-md border px-2.5 py-1 text-[11.5px] font-medium tabular-nums transition-colors',
+                      disabled
+                        ? 'cursor-not-allowed opacity-40'
+                        : n === opt
+                          ? 'border-primary bg-primary/10 text-primary'
+                          : 'border-border text-muted-foreground hover:text-foreground',
+                    ].join(' ')}
+                  >
+                    {opt}
+                  </button>
+                )
+              })}
+            </div>
+            <span className="text-sm text-muted-foreground">queries</span>
+            <Button
+              size="sm"
+              className="ml-auto h-8 text-[12px]"
+              onClick={runAnalysis}
+              disabled={running || queries.length === 0}
+            >
+              {running ? 'Analyzing…' : 'Run Analysis'}
+            </Button>
+          </div>
+
+          {/* Progress */}
+          {running && progress !== null && (
+            <p className="text-[12px] text-muted-foreground">
+              Analyzing {progress} of {selected.length}…
+            </p>
+          )}
+
+          {/* Results */}
+          {results.length > 0 && (
+            <ScrollArea className="max-h-[55vh] rounded-md border">
+              <div className="divide-y">
+                {results.map((result, idx) => {
+                  const isExpanded = expandedIdx.has(idx)
+                  return (
+                    <div key={idx} className="px-4 py-3">
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="flex min-w-0 flex-col gap-1">
+                          <p className="truncate font-mono text-[11.5px] text-foreground">
+                            {result.title}
+                          </p>
+                          {result.ok ? (
+                            <div className="flex flex-wrap gap-1">
+                              {result.suggestions.length === 0 ? (
+                                <span className="text-[11px] text-muted-foreground">
+                                  No issues found
+                                </span>
+                              ) : (
+                                <TooltipProvider>
+                                  {result.suggestions.map((s) => (
+                                    <SuggestionChip
+                                      key={s.id}
+                                      suggestion={s}
+                                      sql={result.sql}
+                                    />
+                                  ))}
+                                </TooltipProvider>
+                              )}
+                            </div>
+                          ) : (
+                            <Badge
+                              variant="outline"
+                              className="w-fit border-red-300 bg-red-50 text-[11px] text-red-700 dark:border-red-700 dark:bg-red-950/30 dark:text-red-400"
+                            >
+                              Error: {result.error}
+                            </Badge>
+                          )}
+                        </div>
+                        {result.ok && result.planLines.length > 0 && (
+                          <button
+                            type="button"
+                            className="shrink-0 text-[11px] text-muted-foreground hover:text-foreground"
+                            onClick={() =>
+                              setExpandedIdx((prev) => {
+                                const next = new Set(prev)
+                                if (next.has(idx)) next.delete(idx)
+                                else next.add(idx)
+                                return next
+                              })
+                            }
+                          >
+                            {isExpanded ? 'Hide plan' : 'Show plan'}
+                          </button>
+                        )}
+                      </div>
+                      {isExpanded && result.planLines.length > 0 && (
+                        <pre className="mt-2 overflow-x-auto rounded bg-muted px-3 py-2 font-mono text-[10.5px] leading-relaxed text-foreground">
+                          {result.planLines.join('\n')}
+                        </pre>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            </ScrollArea>
+          )}
+
+          {/* Footer actions */}
+          {results.length > 0 && !running && (
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-[11.5px] text-muted-foreground">
+                {totalSuggestions === 0
+                  ? 'No issues found across all queries.'
+                  : `${totalSuggestions} suggestion${totalSuggestions === 1 ? '' : 's'} found.`}
+              </span>
+              <Button
+                asChild
+                variant="outline"
+                size="sm"
+                className="h-8 text-[12px]"
+              >
+                <a href={agentUrl}>Ask AI about all findings</a>
+              </Button>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/dashboard/src/components/explain/suggestion-chip.tsx
+++ b/apps/dashboard/src/components/explain/suggestion-chip.tsx
@@ -1,0 +1,95 @@
+import type { Suggestion } from '@/lib/explain-heuristics'
+
+import { useState } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+interface SuggestionChipProps {
+  suggestion: Suggestion
+  /** Called when the user clicks "Ask AI" — receives suggestion + originating SQL. */
+  onAskAgent?: (suggestion: Suggestion, sql: string) => void
+  sql: string
+}
+
+/**
+ * Inline heuristic chip: coloured badge with title. Click to expand the
+ * rationale and reveal an optional "Ask AI" shortcut.
+ */
+export function SuggestionChip({
+  suggestion,
+  onAskAgent,
+  sql,
+}: SuggestionChipProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const badgeClass =
+    suggestion.severity === 'warning'
+      ? 'border-amber-300 bg-amber-100 text-amber-800 dark:border-amber-700 dark:bg-amber-900/30 dark:text-amber-300'
+      : 'border-blue-300 bg-blue-100 text-blue-800 dark:border-blue-700 dark:bg-blue-900/30 dark:text-blue-300'
+
+  if (!expanded) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Badge
+            variant="outline"
+            className={cn('cursor-pointer text-[11px] font-medium', badgeClass)}
+            onClick={() => setExpanded(true)}
+          >
+            {suggestion.title}
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs text-xs">
+          {suggestion.rationale}
+          <p className="mt-1 text-[10px] opacity-70">Click to expand</p>
+        </TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-md border p-2.5 text-xs',
+        suggestion.severity === 'warning'
+          ? 'border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30'
+          : 'border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30'
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <Badge
+          variant="outline"
+          className={cn('shrink-0 text-[11px] font-medium', badgeClass)}
+        >
+          {suggestion.title}
+        </Badge>
+        <button
+          type="button"
+          onClick={() => setExpanded(false)}
+          className="text-[10px] text-muted-foreground hover:text-foreground"
+        >
+          ✕
+        </button>
+      </div>
+      <p className="mt-1.5 leading-relaxed text-muted-foreground">
+        {suggestion.rationale}
+      </p>
+      {onAskAgent && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="mt-1.5 h-6 px-2 text-[11px]"
+          onClick={() => onAskAgent(suggestion, sql)}
+        >
+          Ask AI
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/query-favorites/index.ts
+++ b/apps/dashboard/src/components/query-favorites/index.ts
@@ -1,0 +1,6 @@
+export { QueryFavoritesPanel } from './query-favorites-panel'
+export type { QueryFavoritesPanelProps } from './query-favorites-panel'
+export { SaveFavoriteButton } from './save-favorite-button'
+export type { SaveFavoriteButtonProps } from './save-favorite-button'
+export { SaveFavoriteDialog } from './save-favorite-dialog'
+export type { SaveFavoriteDialogProps } from './save-favorite-dialog'

--- a/apps/dashboard/src/components/query-favorites/query-favorites-panel.tsx
+++ b/apps/dashboard/src/components/query-favorites/query-favorites-panel.tsx
@@ -1,0 +1,288 @@
+import { Check, Copy, Pencil, Play, Trash2, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import type { QueryFavorite } from '@/lib/stores/use-query-favorites'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { useQueryFavorites } from '@/lib/stores/use-query-favorites'
+import { cn } from '@/lib/utils'
+
+function relTime(ts: number): string {
+  const s = Math.floor((Date.now() - ts) / 1000)
+  if (s < 60) return `${s}s ago`
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`
+  return `${Math.floor(s / 86400)}d ago`
+}
+
+function QueryLine({ sql }: { sql: string }) {
+  const oneLine = sql.replace(/\s+/g, ' ').trim()
+  return (
+    <code className="line-clamp-2 break-words font-mono text-xs leading-snug">
+      {oneLine}
+    </code>
+  )
+}
+
+interface EditRowState {
+  title: string
+  tags: string
+}
+
+function FavoriteItem({
+  fav,
+  onSelect,
+  onRemove,
+  onUpdate,
+}: {
+  fav: QueryFavorite
+  onSelect: (sql: string, run?: boolean) => void
+  onRemove: (id: string) => void
+  onUpdate: (
+    id: string,
+    patch: Partial<Pick<QueryFavorite, 'title' | 'tags'>>
+  ) => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const [edit, setEdit] = useState<EditRowState>({ title: '', tags: '' })
+  const [copied, setCopied] = useState(false)
+
+  const startEdit = () => {
+    setEdit({ title: fav.title, tags: fav.tags.join(', ') })
+    setEditing(true)
+  }
+
+  const commitEdit = () => {
+    const tags = edit.tags
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean)
+    onUpdate(fav.id, { title: edit.title.trim() || fav.title, tags })
+    setEditing(false)
+  }
+
+  const cancelEdit = () => setEditing(false)
+
+  const copyLink = async () => {
+    if (!fav.shareUrl) return
+    try {
+      await navigator.clipboard.writeText(fav.shareUrl)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // Clipboard unavailable — ignore silently.
+    }
+  }
+
+  return (
+    <li
+      className={cn(
+        'group hover:bg-muted/60 rounded-md border p-2 transition-colors',
+        editing && 'border-primary/40 bg-muted/40'
+      )}
+    >
+      {editing ? (
+        <div className="space-y-2">
+          <Input
+            value={edit.title}
+            onChange={(e) => setEdit((s) => ({ ...s, title: e.target.value }))}
+            placeholder="Name…"
+            className="h-7 text-xs"
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commitEdit()
+              if (e.key === 'Escape') cancelEdit()
+            }}
+          />
+          <Input
+            value={edit.tags}
+            onChange={(e) => setEdit((s) => ({ ...s, tags: e.target.value }))}
+            placeholder="Tags (comma-separated)…"
+            className="h-7 text-xs"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commitEdit()
+              if (e.key === 'Escape') cancelEdit()
+            }}
+          />
+          <div className="flex justify-end gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 text-xs"
+              onClick={cancelEdit}
+            >
+              <X className="mr-1 size-3" /> Cancel
+            </Button>
+            <Button size="sm" className="h-6 text-xs" onClick={commitEdit}>
+              <Check className="mr-1 size-3" /> Save
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <button
+            type="button"
+            className="block w-full text-left"
+            onClick={() => onSelect(fav.sql, false)}
+            title="Load into editor"
+          >
+            <p className="truncate text-xs font-medium">{fav.title}</p>
+            <QueryLine sql={fav.sql} />
+          </button>
+
+          {fav.tags.length > 0 && (
+            <div className="mt-1.5 flex flex-wrap gap-1">
+              {fav.tags.map((tag) => (
+                <Badge
+                  key={tag}
+                  variant="secondary"
+                  className="h-4 px-1.5 text-[10px]"
+                >
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          <div className="text-muted-foreground mt-1.5 flex items-center justify-between text-[11px]">
+            <span>{relTime(fav.createdAt)}</span>
+            <span className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+              {fav.shareUrl && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-6"
+                  title="Copy deep-link"
+                  onClick={copyLink}
+                >
+                  {copied ? (
+                    <Check className="size-3 text-emerald-500" />
+                  ) : (
+                    <Copy className="size-3" />
+                  )}
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-6"
+                title="Run"
+                onClick={() => onSelect(fav.sql, true)}
+              >
+                <Play className="size-3" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-6"
+                title="Edit name / tags"
+                onClick={startEdit}
+              >
+                <Pencil className="size-3" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-6"
+                title="Remove"
+                onClick={() => onRemove(fav.id)}
+              >
+                <Trash2 className="size-3" />
+              </Button>
+            </span>
+          </div>
+        </>
+      )}
+    </li>
+  )
+}
+
+export interface QueryFavoritesPanelProps {
+  onSelect: (sql: string, run?: boolean) => void
+}
+
+export function QueryFavoritesPanel({ onSelect }: QueryFavoritesPanelProps) {
+  const { favorites, remove, update } = useQueryFavorites()
+  const [search, setSearch] = useState('')
+  const [activeTag, setActiveTag] = useState<string | null>(null)
+
+  const allTags = useMemo(
+    () => Array.from(new Set(favorites.flatMap((f) => f.tags))).sort(),
+    [favorites]
+  )
+
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase().trim()
+    return favorites.filter((f) => {
+      if (activeTag && !f.tags.includes(activeTag)) return false
+      if (!q) return true
+      return (
+        f.title.toLowerCase().includes(q) ||
+        f.sql.toLowerCase().includes(q) ||
+        f.tags.some((t) => t.toLowerCase().includes(q))
+      )
+    })
+  }, [favorites, search, activeTag])
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="space-y-2 px-3 py-2">
+        <Input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search favorites…"
+          className="h-7 text-xs"
+        />
+        {allTags.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {allTags.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => setActiveTag(activeTag === tag ? null : tag)}
+                className={cn(
+                  'inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] transition-colors',
+                  activeTag === tag
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-border text-muted-foreground hover:bg-muted'
+                )}
+              >
+                {tag}
+              </button>
+            ))}
+          </div>
+        )}
+        <p className="text-muted-foreground text-[11px]">
+          {filtered.length} of {favorites.length} favorite
+          {favorites.length !== 1 ? 's' : ''}
+        </p>
+      </div>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <ul className="space-y-1 px-2 pb-4">
+          {favorites.length === 0 && (
+            <li className="text-muted-foreground p-4 text-center text-sm">
+              No saved favorites yet. Save queries from the SQL console or
+              EXPLAIN page.
+            </li>
+          )}
+          {favorites.length > 0 && filtered.length === 0 && (
+            <li className="text-muted-foreground p-4 text-center text-sm">
+              No favorites match your search.
+            </li>
+          )}
+          {filtered.map((fav) => (
+            <FavoriteItem
+              key={fav.id}
+              fav={fav}
+              onSelect={onSelect}
+              onRemove={remove}
+              onUpdate={update}
+            />
+          ))}
+        </ul>
+      </ScrollArea>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/query-favorites/save-favorite-button.tsx
+++ b/apps/dashboard/src/components/query-favorites/save-favorite-button.tsx
@@ -1,0 +1,71 @@
+import { Star } from 'lucide-react'
+import { useState } from 'react'
+import { SaveFavoriteDialog } from './save-favorite-dialog'
+import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { useQueryFavorites } from '@/lib/stores/use-query-favorites'
+import { cn } from '@/lib/utils'
+
+export interface SaveFavoriteButtonProps {
+  sql: string
+  hostId: number
+  database: string | null
+}
+
+export function SaveFavoriteButton({
+  sql,
+  hostId,
+  database,
+}: SaveFavoriteButtonProps) {
+  const { isFavorited } = useQueryFavorites()
+  const [open, setOpen] = useState(false)
+
+  const trimmed = sql.trim()
+  const already = trimmed ? isFavorited(trimmed) : false
+
+  return (
+    <>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={!trimmed}
+              onClick={() => {
+                if (!already) setOpen(true)
+              }}
+              className={cn(already && 'text-amber-500')}
+              aria-label={
+                already ? 'Already saved as favorite' : 'Save as favorite'
+              }
+            >
+              <Star
+                className={cn(
+                  'size-3.5',
+                  already && 'fill-amber-500 text-amber-500'
+                )}
+              />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {already ? 'Saved as favorite' : 'Save as favorite'}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+
+      <SaveFavoriteDialog
+        open={open}
+        onOpenChange={setOpen}
+        sql={sql}
+        hostId={hostId}
+        database={database}
+      />
+    </>
+  )
+}

--- a/apps/dashboard/src/components/query-favorites/save-favorite-dialog.tsx
+++ b/apps/dashboard/src/components/query-favorites/save-favorite-dialog.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useQueryFavorites } from '@/lib/stores/use-query-favorites'
+
+export interface SaveFavoriteDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  sql: string
+  hostId: number
+  database: string | null
+}
+
+export function SaveFavoriteDialog({
+  open,
+  onOpenChange,
+  sql,
+  hostId,
+  database,
+}: SaveFavoriteDialogProps) {
+  const { save } = useQueryFavorites()
+
+  const defaultTitle = sql.replace(/\s+/g, ' ').trim().slice(0, 60)
+  const [title, setTitle] = useState(defaultTitle)
+  const [tagsInput, setTagsInput] = useState('')
+
+  const handleSave = () => {
+    const tags = tagsInput
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean)
+    save({
+      title: title.trim() || defaultTitle,
+      sql: sql.trim(),
+      tags,
+      hostId,
+      database,
+      shareUrl: '',
+    })
+    onOpenChange(false)
+    // Reset for next open.
+    setTitle(defaultTitle)
+    setTagsInput('')
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      // Re-derive title each time the dialog opens so it reflects the current SQL.
+      setTitle(sql.replace(/\s+/g, ' ').trim().slice(0, 60))
+      setTagsInput('')
+    }
+    onOpenChange(next)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Save as Favorite</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="fav-title">Name</Label>
+            <Input
+              id="fav-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Query name…"
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleSave()
+              }}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="fav-tags">Tags</Label>
+            <Input
+              id="fav-tags"
+              value={tagsInput}
+              onChange={(e) => setTagsInput(e.target.value)}
+              placeholder="Comma-separated: perf, debug, daily…"
+            />
+            <p className="text-muted-foreground text-xs">
+              Optional. Separate multiple tags with commas.
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={!sql.trim()}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/dashboard/src/components/running-queries/running-queries-view.tsx
+++ b/apps/dashboard/src/components/running-queries/running-queries-view.tsx
@@ -285,7 +285,15 @@ export const RunningQueriesView = function RunningQueriesView() {
         ) : (
           <>
             {chartsOpen ? (
-              <RunningQueriesCharts rows={rows} />
+              <>
+                {/* Trend charts on this page use a fixed 14-day window for historical
+                    context and are not affected by the global time-range picker. */}
+                <p className="text-[11px] text-muted-foreground">
+                  Trend charts use a fixed 14-day window · not affected by the
+                  global time-range picker
+                </p>
+                <RunningQueriesCharts rows={rows} />
+              </>
             ) : (
               <CollapsedChartsRow
                 labels={[

--- a/apps/dashboard/src/components/slow-queries/slow-queries-view.tsx
+++ b/apps/dashboard/src/components/slow-queries/slow-queries-view.tsx
@@ -1,9 +1,10 @@
-import { ChevronDown, Gauge, RefreshCw, Timer } from 'lucide-react'
+import { ChevronDown, Gauge, RefreshCw, ScanSearch, Timer } from 'lucide-react'
 
 import type { SlowQueryRow } from '@/components/slow-queries/slow-queries-table'
 import type { CardError } from '@/lib/card-error-utils'
 
 import { useMemo, useState } from 'react'
+import { BulkExplainDialog } from '@/components/explain/bulk-explain-dialog'
 import { RegressionPanel } from '@/components/alerting/regression-panel'
 import { PageHeader } from '@/components/layout'
 import { RelatedCharts } from '@/components/layout/query-page/related-charts'
@@ -19,10 +20,12 @@ import {
   getCardErrorTitle,
   toEmptyStateVariant,
 } from '@/lib/card-error-utils'
+import { useTimeRange } from '@/lib/context/time-range-context'
 import { usePathname, useRouter, useSearchParams } from '@/lib/next-compat'
 import { useTableData } from '@/lib/query/use-table-data'
 import { slowQueriesConfig } from '@/lib/query-config/queries/slow-queries'
 import { useHostId } from '@/lib/swr/use-host'
+import { truncateSql } from '@/lib/explain-heuristics'
 import { cn } from '@/lib/utils'
 
 /** Refresh the slow-queries list every 60s — `query_log` is append-only. */
@@ -95,21 +98,31 @@ function FilterGroup({
  */
 export function SlowQueriesView() {
   const hostId = useHostId()
+  const { timeRange } = useTimeRange()
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const [chartsOpen, setChartsOpen] = useState(true)
+  const [explainOpen, setExplainOpen] = useState(false)
 
-  // Resolve the active value of each filter key: URL param → default.
+  // Resolve the active value of each filter key:
+  //   URL param → global time-range context (for last_hours) → config default.
+  // This means the global picker seeds the initial window, but explicit URL
+  // params (e.g. from a shared link or the filter chips) take priority.
   const filterParams = useMemo(() => {
     const params: Record<string, string> = {}
     for (const [key, value] of Object.entries(DEFAULTS)) {
       const fromUrl = searchParams.get(key)
-      const resolved = fromUrl ?? (value as string)
+      let resolved: string
+      if (key === 'last_hours') {
+        resolved = fromUrl ?? String(timeRange.lastHours)
+      } else {
+        resolved = fromUrl ?? (value as string)
+      }
       if (resolved !== '') params[key] = resolved
     }
     return params
-  }, [searchParams])
+  }, [searchParams, timeRange.lastHours])
 
   const { data, error, isLoading, isValidating, refresh } =
     useTableData<SlowQueryRow>(
@@ -120,6 +133,11 @@ export function SlowQueriesView() {
     )
 
   const rows = data ?? []
+
+  const explainItems = rows.slice(0, 20).map((r) => ({
+    sql: String(r.query ?? ''),
+    title: truncateSql(String(r.query ?? ''), 60),
+  }))
 
   // Slowest duration drives the header highlight.
   const slowest = useMemo(() => {
@@ -159,6 +177,16 @@ export function SlowQueriesView() {
           description="The slowest finished queries from the query log, worst first"
           actions={
             <div className="flex flex-wrap items-center gap-1.5">
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-8 gap-1.5 text-[12px]"
+                onClick={() => setExplainOpen(true)}
+                disabled={rows.length === 0}
+              >
+                <ScanSearch className="size-3.5" />
+                Explain top N
+              </Button>
               <Button
                 variant="outline"
                 size="sm"
@@ -267,6 +295,13 @@ export function SlowQueriesView() {
           </>
         )}
       </div>
+
+      <BulkExplainDialog
+        queries={explainItems}
+        hostId={hostId}
+        open={explainOpen}
+        onOpenChange={setExplainOpen}
+      />
     </TooltipProvider>
   )
 }

--- a/apps/dashboard/src/components/sql-console/sql-console.tsx
+++ b/apps/dashboard/src/components/sql-console/sql-console.tsx
@@ -1,5 +1,6 @@
 import {
   AlertCircle,
+  Bookmark,
   CheckCircle2,
   Clock,
   History,
@@ -13,6 +14,10 @@ import type { StatementOutcome } from './hooks/use-sql-runner'
 
 import { DatabaseCombobox } from './database-combobox'
 import { useQueryHistory } from './hooks/use-query-history'
+import {
+  QueryFavoritesPanel,
+  SaveFavoriteButton,
+} from '@/components/query-favorites'
 import { useSqlRunner } from './hooks/use-sql-runner'
 import { QueryHistoryPanel } from './query-history-panel'
 import { AnalysisTab } from './tabs/analysis-tab'
@@ -74,6 +79,7 @@ export function SqlConsole({
   const history = useQueryHistory()
   const [tab, setTab] = useState<ResultTabValue>('results')
   const [historyOpen, setHistoryOpen] = useState(false)
+  const [favoritesOpen, setFavoritesOpen] = useState(false)
 
   const {
     editorValue,
@@ -196,6 +202,11 @@ export function SqlConsole({
           >
             <Sparkles className="mr-1.5 size-3.5" /> Format
           </Button>
+          <SaveFavoriteButton
+            sql={committedSql}
+            hostId={hostId}
+            database={database ?? null}
+          />
           {onDatabaseChange && (
             <DatabaseCombobox
               hostId={hostId}
@@ -205,32 +216,59 @@ export function SqlConsole({
           )}
         </div>
 
-        <Sheet open={historyOpen} onOpenChange={setHistoryOpen}>
-          <SheetTrigger asChild>
-            <Button size="sm" variant="outline">
-              <History className="mr-1.5 size-3.5" /> History
-            </Button>
-          </SheetTrigger>
-          <SheetContent
-            side="right"
-            className="flex w-[380px] flex-col p-0 sm:w-[440px]"
-          >
-            <SheetHeader className="border-b px-4 py-3">
-              <SheetTitle>Query history</SheetTitle>
-            </SheetHeader>
-            <div className="min-h-0 flex-1">
-              <QueryHistoryPanel
-                hostId={hostId}
-                entries={history.entries}
-                onSelect={handleSelectHistory}
-                onRemove={history.remove}
-                onTogglePin={history.togglePin}
-                onClear={history.clear}
-                serverEnabled={historyOpen}
-              />
-            </div>
-          </SheetContent>
-        </Sheet>
+        <div className="flex items-center gap-2">
+          <Sheet open={historyOpen} onOpenChange={setHistoryOpen}>
+            <SheetTrigger asChild>
+              <Button size="sm" variant="outline">
+                <History className="mr-1.5 size-3.5" /> History
+              </Button>
+            </SheetTrigger>
+            <SheetContent
+              side="right"
+              className="flex w-[380px] flex-col p-0 sm:w-[440px]"
+            >
+              <SheetHeader className="border-b px-4 py-3">
+                <SheetTitle>Query history</SheetTitle>
+              </SheetHeader>
+              <div className="min-h-0 flex-1">
+                <QueryHistoryPanel
+                  hostId={hostId}
+                  entries={history.entries}
+                  onSelect={handleSelectHistory}
+                  onRemove={history.remove}
+                  onTogglePin={history.togglePin}
+                  onClear={history.clear}
+                  serverEnabled={historyOpen}
+                />
+              </div>
+            </SheetContent>
+          </Sheet>
+
+          <Sheet open={favoritesOpen} onOpenChange={setFavoritesOpen}>
+            <SheetTrigger asChild>
+              <Button size="sm" variant="outline">
+                <Bookmark className="mr-1.5 size-3.5" /> Favorites
+              </Button>
+            </SheetTrigger>
+            <SheetContent
+              side="right"
+              className="flex w-[380px] flex-col p-0 sm:w-[440px]"
+            >
+              <SheetHeader className="border-b px-4 py-3">
+                <SheetTitle>Saved favorites</SheetTitle>
+              </SheetHeader>
+              <div className="min-h-0 flex-1">
+                <QueryFavoritesPanel
+                  onSelect={(sql, run) => {
+                    setEditorValue(sql)
+                    setFavoritesOpen(false)
+                    if (run) handleRun(sql)
+                  }}
+                />
+              </div>
+            </SheetContent>
+          </Sheet>
+        </div>
       </div>
 
       {/* Status bar */}

--- a/apps/dashboard/src/components/sql-console/sql-console.tsx
+++ b/apps/dashboard/src/components/sql-console/sql-console.tsx
@@ -203,7 +203,7 @@ export function SqlConsole({
             <Sparkles className="mr-1.5 size-3.5" /> Format
           </Button>
           <SaveFavoriteButton
-            sql={committedSql}
+            sql={committedSql ?? ''}
             hostId={hostId}
             database={database ?? null}
           />

--- a/apps/dashboard/src/lib/explain-heuristics.test.ts
+++ b/apps/dashboard/src/lib/explain-heuristics.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  analyzeExplain,
+  checkFullScanWithoutPrewhere,
+  checkHighReadRowsToResultRatio,
+  checkLargeJoinWithoutKey,
+  checkMissingPartitionPruning,
+  checkNoIndexUsed,
+  truncateSql,
+} from './explain-heuristics'
+
+describe('truncateSql', () => {
+  test('collapses internal whitespace', () => {
+    expect(truncateSql('SELECT  *\n  FROM   events')).toBe(
+      'SELECT * FROM events'
+    )
+  })
+
+  test('trims surrounding whitespace', () => {
+    expect(truncateSql('  SELECT 1  ')).toBe('SELECT 1')
+  })
+
+  test('returns unchanged when within maxLen', () => {
+    const short = 'SELECT 1'
+    expect(truncateSql(short, 80)).toBe('SELECT 1')
+  })
+
+  test('truncates at maxLen and appends ellipsis', () => {
+    const sql =
+      'SELECT col1, col2, col3 FROM very_long_table_name WHERE condition = 1'
+    const result = truncateSql(sql, 30)
+    expect(result.length).toBe(31) // 30 chars + '…'
+    expect(result.endsWith('…')).toBe(true)
+  })
+
+  test('uses default maxLen of 80', () => {
+    const long = 'A'.repeat(100)
+    const result = truncateSql(long)
+    expect(result.length).toBe(81) // 80 + '…'
+  })
+})
+
+describe('checkFullScanWithoutPrewhere', () => {
+  test('returns suggestion when MergeTree scan has no PREWHERE', () => {
+    const plan = ['ReadFromMergeTree (default.events)', '  Columns: a, b, c']
+    const sql = 'SELECT * FROM events WHERE a = 1'
+    const result = checkFullScanWithoutPrewhere(sql, plan)
+    expect(result?.id).toBe('full-scan-no-prewhere')
+    expect(result?.severity).toBe('warning')
+  })
+
+  test('returns null when PREWHERE is present in plan lines', () => {
+    const plan = [
+      'ReadFromMergeTree (default.events)',
+      '  PREWHERE a = 1',
+      '  Columns: a, b',
+    ]
+    const sql = 'SELECT * FROM events PREWHERE a = 1 WHERE b = 2'
+    expect(checkFullScanWithoutPrewhere(sql, plan)).toBeNull()
+  })
+
+  test('returns null when PREWHERE is in the SQL but not the plan', () => {
+    const plan = ['ReadFromMergeTree (default.events)', '  Columns: a']
+    const sql = 'SELECT * FROM events PREWHERE a = 1'
+    expect(checkFullScanWithoutPrewhere(sql, plan)).toBeNull()
+  })
+
+  test('returns null when there is no MergeTree scan at all', () => {
+    const plan = ['ExpressionTransform', '  Expression: (a + b)']
+    expect(checkFullScanWithoutPrewhere('SELECT 1 + 1', plan)).toBeNull()
+  })
+})
+
+describe('checkMissingPartitionPruning', () => {
+  test('returns suggestion when selected parts > 100', () => {
+    const plan = ['ReadFromMergeTree', '  Parts: 450/500']
+    const result = checkMissingPartitionPruning('SELECT 1', plan)
+    expect(result?.id).toBe('missing-partition-pruning')
+  })
+
+  test('returns suggestion when selected/total ratio > 0.8', () => {
+    const plan = ['ReadFromMergeTree', '  Parts: 9/10']
+    expect(checkMissingPartitionPruning('SELECT 1', plan)?.id).toBe(
+      'missing-partition-pruning'
+    )
+  })
+
+  test('returns null when few parts are selected', () => {
+    const plan = ['ReadFromMergeTree', '  Parts: 2/500']
+    expect(checkMissingPartitionPruning('SELECT 1', plan)).toBeNull()
+  })
+
+  test('returns null when no Parts line is present', () => {
+    const plan = ['ReadFromMergeTree', '  Columns: a, b']
+    expect(checkMissingPartitionPruning('SELECT 1', plan)).toBeNull()
+  })
+
+  test('returns null when total is zero (avoids divide by zero)', () => {
+    const plan = ['Parts: 0/0']
+    expect(checkMissingPartitionPruning('SELECT 1', plan)).toBeNull()
+  })
+})
+
+describe('checkHighReadRowsToResultRatio', () => {
+  test('returns warning when ratio > 1000 and readRows > 1M', () => {
+    const result = checkHighReadRowsToResultRatio('SELECT 1', [], 2_000_000, 1)
+    expect(result?.id).toBe('high-read-rows-ratio')
+    expect(result?.severity).toBe('warning')
+  })
+
+  test('rationale includes formatted row counts', () => {
+    const result = checkHighReadRowsToResultRatio(
+      'SELECT 1',
+      [],
+      5_000_000,
+      100
+    )
+    expect(result?.rationale).toMatch(/5\.0M/)
+    expect(result?.rationale).toMatch(/100/)
+  })
+
+  test('returns null when readRows <= 1M', () => {
+    expect(
+      checkHighReadRowsToResultRatio('SELECT 1', [], 900_000, 1)
+    ).toBeNull()
+  })
+
+  test('returns null when resultRows is 0', () => {
+    expect(
+      checkHighReadRowsToResultRatio('SELECT 1', [], 2_000_000, 0)
+    ).toBeNull()
+  })
+
+  test('returns null when ratio <= 1000', () => {
+    expect(
+      checkHighReadRowsToResultRatio('SELECT 1', [], 2_000_000, 5_000)
+    ).toBeNull()
+  })
+
+  test('returns null when readRows is undefined', () => {
+    expect(checkHighReadRowsToResultRatio('SELECT 1', [])).toBeNull()
+  })
+})
+
+describe('checkLargeJoinWithoutKey', () => {
+  test('returns suggestion when SQL has JOIN and plan has Hash Join without key', () => {
+    const sql = 'SELECT * FROM a JOIN b ON a.id = b.id'
+    const plan = [
+      'Hash Join',
+      '  Left: ReadFromMergeTree (a)',
+      '  Right: ReadFromMergeTree (b)',
+    ]
+    expect(checkLargeJoinWithoutKey(sql, plan)?.id).toBe(
+      'large-join-without-key'
+    )
+  })
+
+  test('returns suggestion for Cross Join', () => {
+    const sql = 'SELECT * FROM a CROSS JOIN b'
+    const plan = ['Cross Join', '  Left: ReadFromMergeTree']
+    expect(checkLargeJoinWithoutKey(sql, plan)?.id).toBe(
+      'large-join-without-key'
+    )
+  })
+
+  test('returns null when SQL has no JOIN', () => {
+    const plan = ['Hash Join']
+    expect(checkLargeJoinWithoutKey('SELECT 1', plan)).toBeNull()
+  })
+
+  test('returns null when Hash Join line contains "key"', () => {
+    const sql = 'SELECT * FROM a JOIN b ON a.id = b.id'
+    const plan = ['Hash Join (key=a.id)']
+    expect(checkLargeJoinWithoutKey(sql, plan)).toBeNull()
+  })
+})
+
+describe('checkNoIndexUsed', () => {
+  test('returns info suggestion when MergeTree scan has no index hints', () => {
+    const plan = ['ReadFromMergeTree (default.events)', '  Columns: a, b']
+    const result = checkNoIndexUsed('SELECT * FROM events', plan)
+    expect(result?.id).toBe('no-index-hint')
+    expect(result?.severity).toBe('info')
+  })
+
+  test('returns null when Indexes: line is present', () => {
+    const plan = [
+      'ReadFromMergeTree (default.events)',
+      '  Indexes:',
+      '    PrimaryKey',
+    ]
+    expect(checkNoIndexUsed('SELECT * FROM events', plan)).toBeNull()
+  })
+
+  test('returns null when "Selected marks:" is present', () => {
+    const plan = ['ReadFromMergeTree (default.events)', '  Selected marks: 5']
+    expect(checkNoIndexUsed('SELECT * FROM events', plan)).toBeNull()
+  })
+
+  test('returns null when no MergeTree scan', () => {
+    const plan = ['ExpressionTransform']
+    expect(checkNoIndexUsed('SELECT 1', plan)).toBeNull()
+  })
+})
+
+describe('analyzeExplain', () => {
+  test('returns empty array for empty plan lines', () => {
+    expect(analyzeExplain('SELECT 1', [])).toEqual([])
+  })
+
+  test('returns multiple suggestions for a scan with no prewhere and no index', () => {
+    const plan = ['ReadFromMergeTree (default.events)', '  Columns: a, b']
+    const sql = 'SELECT * FROM events WHERE a = 1'
+    const results = analyzeExplain(sql, plan)
+    const ids = results.map((s) => s.id)
+    expect(ids).toContain('full-scan-no-prewhere')
+    expect(ids).toContain('no-index-hint')
+  })
+
+  test('deduplicates suggestions with the same id', () => {
+    // Both checkFullScanWithoutPrewhere and checkNoIndexUsed could trigger —
+    // verify IDs are unique across the returned array.
+    const plan = ['ReadFromMergeTree (default.events)', '  Columns: a']
+    const results = analyzeExplain('SELECT * FROM events', plan)
+    const ids = results.map((s) => s.id)
+    const uniqueIds = [...new Set(ids)]
+    expect(ids).toEqual(uniqueIds)
+  })
+
+  test('includes high-read-rows-ratio when row counts are extreme', () => {
+    const plan = ['ReadFromMergeTree', '  Columns: a']
+    const results = analyzeExplain('SELECT * FROM t', plan, 5_000_000, 1)
+    const ids = results.map((s) => s.id)
+    expect(ids).toContain('high-read-rows-ratio')
+  })
+
+  test('returns only info suggestions for clean plan with no rows threshold', () => {
+    const plan = ['ReadFromMergeTree', '  Columns: a']
+    const results = analyzeExplain('SELECT * FROM t', plan)
+    // Should only have no-index-hint (info) and full-scan-no-prewhere (warning)
+    expect(results.every((s) => ['warning', 'info'].includes(s.severity))).toBe(
+      true
+    )
+  })
+})

--- a/apps/dashboard/src/lib/explain-heuristics.ts
+++ b/apps/dashboard/src/lib/explain-heuristics.ts
@@ -1,0 +1,213 @@
+/**
+ * Lightweight heuristic checks on ClickHouse EXPLAIN PLAN text.
+ *
+ * These are UI-level heuristics — they pattern-match on plan text and SQL
+ * to surface likely performance issues as actionable suggestions. They are
+ * NOT a substitute for the AI agent's deeper analysis.
+ *
+ * All functions are pure: no side effects, no I/O, no browser APIs.
+ */
+
+export type HeuristicSeverity = 'warning' | 'info'
+
+export interface Suggestion {
+  /** Stable key for dedup / dismissal. */
+  id: string
+  severity: HeuristicSeverity
+  /** Short label for the chip. */
+  title: string
+  /** 1-2 sentence explanation. */
+  rationale: string
+}
+
+/** Full result for a single query. */
+export interface ExplainAnalysis {
+  sql: string
+  /** Truncated SQL for display. */
+  title: string
+  /** Raw EXPLAIN lines. */
+  planLines: string[]
+  suggestions: Suggestion[]
+  /** True if EXPLAIN fetch succeeded. */
+  ok: boolean
+  error?: string
+}
+
+// ─────────────────────────── helpers ───────────────────────────
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
+}
+
+/**
+ * Collapse internal whitespace and truncate at `maxLen`, appending '…' if cut.
+ */
+export function truncateSql(sql: string, maxLen = 80): string {
+  const collapsed = sql.replace(/\s+/g, ' ').trim()
+  if (collapsed.length <= maxLen) return collapsed
+  return `${collapsed.slice(0, maxLen)}…`
+}
+
+// ─────────────────────────── checks ───────────────────────────
+
+/**
+ * Detect a MergeTree scan with no PREWHERE filter applied.
+ */
+export function checkFullScanWithoutPrewhere(
+  sql: string,
+  planLines: string[]
+): Suggestion | null {
+  const hasMergeTreeScan = planLines.some((l) => /ReadFromMergeTree/i.test(l))
+  if (!hasMergeTreeScan) return null
+
+  const planHasPrewhere = planLines.some((l) => /PREWHERE/i.test(l))
+  const sqlHasPrewhere = /\bPREWHERE\b/i.test(sql)
+  if (planHasPrewhere || sqlHasPrewhere) return null
+
+  return {
+    id: 'full-scan-no-prewhere',
+    severity: 'warning',
+    title: 'No PREWHERE filter',
+    rationale:
+      'Query reads from MergeTree without a PREWHERE clause. Moving the most selective filter to PREWHERE can reduce IO by filtering granules early.',
+  }
+}
+
+/**
+ * Detect missing partition key pruning by checking the Parts: N/M ratio in the
+ * plan output.
+ */
+export function checkMissingPartitionPruning(
+  _sql: string,
+  planLines: string[]
+): Suggestion | null {
+  // Look for "Parts: N/M" — e.g. "Parts: 450/500" or "Selected parts: 450/500"
+  const partsPattern = /[Pp]arts:\s*(\d+)\/(\d+)/
+  for (const line of planLines) {
+    const m = partsPattern.exec(line)
+    if (!m) continue
+    const selected = parseInt(m[1], 10)
+    const total = parseInt(m[2], 10)
+    if (total === 0) continue
+    if (selected > 100 || selected / total > 0.8) {
+      return {
+        id: 'missing-partition-pruning',
+        severity: 'warning',
+        title: 'Partition not pruned',
+        rationale:
+          'The query may be scanning many partitions. Filtering on the partition key column reduces the data scanned.',
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Warn when a query reads vastly more rows than it returns.
+ */
+export function checkHighReadRowsToResultRatio(
+  _sql: string,
+  _planLines: string[],
+  readRows?: number,
+  resultRows?: number
+): Suggestion | null {
+  if (
+    readRows == null ||
+    resultRows == null ||
+    readRows <= 1_000_000 ||
+    resultRows <= 0
+  ) {
+    return null
+  }
+  const ratio = readRows / resultRows
+  if (ratio <= 1000) return null
+
+  return {
+    id: 'high-read-rows-ratio',
+    severity: 'warning',
+    title: 'High read:result row ratio',
+    rationale: `Reading ${formatNumber(readRows)} rows to return ${formatNumber(resultRows)}. Consider adding or improving index conditions to reduce the scanned range.`,
+  }
+}
+
+/**
+ * Detect hash or cross joins that may lack keyed conditions.
+ */
+export function checkLargeJoinWithoutKey(
+  sql: string,
+  planLines: string[]
+): Suggestion | null {
+  if (!/\bJOIN\b/i.test(sql)) return null
+
+  const hasUnkeyedJoin = planLines.some((line) => {
+    if (!/(Cross Join|Hash Join)/i.test(line)) return false
+    // If the same line or nearby context mentions "key" or "ON", likely fine.
+    return !/(key|ON\b)/i.test(line)
+  })
+  if (!hasUnkeyedJoin) return null
+
+  return {
+    id: 'large-join-without-key',
+    severity: 'warning',
+    title: 'Unkeyed JOIN detected',
+    rationale:
+      'A hash or cross join was found in the plan. Ensure JOIN conditions reference indexed or pre-sorted columns to avoid full table products.',
+  }
+}
+
+/**
+ * Surface when the plan has no index usage hints at all.
+ */
+export function checkNoIndexUsed(
+  _sql: string,
+  planLines: string[]
+): Suggestion | null {
+  const hasMergeTreeScan = planLines.some((l) => /ReadFromMergeTree/i.test(l))
+  if (!hasMergeTreeScan) return null
+
+  const hasIndexHint = planLines.some((l) =>
+    /(with index|Indexes:|Selected marks:)/i.test(l)
+  )
+  if (hasIndexHint) return null
+
+  return {
+    id: 'no-index-hint',
+    severity: 'info',
+    title: 'No index hints in plan',
+    rationale:
+      'No index usage was detected in the EXPLAIN output. Run EXPLAIN with indexes=1 to see index analysis.',
+  }
+}
+
+// ─────────────────────────── aggregate ───────────────────────────
+
+/**
+ * Run all heuristic checks and return deduplicated suggestions.
+ */
+export function analyzeExplain(
+  sql: string,
+  planLines: string[],
+  readRows?: number,
+  resultRows?: number
+): Suggestion[] {
+  const candidates = [
+    checkFullScanWithoutPrewhere(sql, planLines),
+    checkMissingPartitionPruning(sql, planLines),
+    checkHighReadRowsToResultRatio(sql, planLines, readRows, resultRows),
+    checkLargeJoinWithoutKey(sql, planLines),
+    checkNoIndexUsed(sql, planLines),
+  ]
+
+  const seen = new Set<string>()
+  const result: Suggestion[] = []
+  for (const s of candidates) {
+    if (s && !seen.has(s.id)) {
+      seen.add(s.id)
+      result.push(s)
+    }
+  }
+  return result
+}

--- a/apps/dashboard/src/lib/query-config/queries/expensive-queries.ts
+++ b/apps/dashboard/src/lib/query-config/queries/expensive-queries.ts
@@ -50,9 +50,19 @@ export const expensiveQueriesConfig: QueryConfig = {
       primaryColumns: ['action', 'query'],
     }),
   },
-  description: 'Most expensive queries finished over last 24 hours',
+  description: 'Most expensive queries finished over the selected time window',
   docs: QUERY_LOG,
   tableCheck: 'system.query_log',
+  defaultParams: {
+    last_hours: '24',
+  },
+  filterParamPresets: [
+    { name: 'Last 1h', key: 'last_hours', value: '1' },
+    { name: 'Last 6h', key: 'last_hours', value: '6' },
+    { name: 'Last 24h', key: 'last_hours', value: '24' },
+    { name: 'Last 7d', key: 'last_hours', value: '168' },
+    { name: 'Last 30d', key: 'last_hours', value: '720' },
+  ],
   sql: [
     {
       since: '23.8',
@@ -92,7 +102,7 @@ export const expensiveQueriesConfig: QueryConfig = {
             formatReadableSize(sum(written_bytes)) AS written_bytes,
             formatReadableSize(sum(result_bytes)) AS result_bytes
         FROM merge('system', '^query_log')
-        WHERE (event_time > (now() - interval 24 hours)) AND (type IN (2, 4))
+        WHERE (event_time > (now() - interval {last_hours:UInt64} hour)) AND (type IN (2, 4))
         GROUP BY normalized_query_hash
     )
     SELECT
@@ -152,7 +162,7 @@ export const expensiveQueriesConfig: QueryConfig = {
             formatReadableSize(sum(written_bytes)) AS written_bytes,
             formatReadableSize(sum(result_bytes)) AS result_bytes
         FROM merge('system', '^query_log')
-        WHERE (event_time > (now() - interval 24 hours)) AND (type IN (2, 4))
+        WHERE (event_time > (now() - interval {last_hours:UInt64} hour)) AND (type IN (2, 4))
         GROUP BY normalized_query_hash
     )
     SELECT
@@ -213,7 +223,7 @@ export const expensiveQueriesConfig: QueryConfig = {
             formatReadableSize(sum(written_bytes)) AS written_bytes,
             formatReadableSize(sum(result_bytes)) AS result_bytes
         FROM merge('system', '^query_log')
-        WHERE (event_time > (now() - interval 24 hours)) AND (type IN (2, 4))
+        WHERE (event_time > (now() - interval {last_hours:UInt64} hour)) AND (type IN (2, 4))
         GROUP BY normalized_query_hash
     )
     SELECT

--- a/apps/dashboard/src/lib/stores/use-query-favorites.test.ts
+++ b/apps/dashboard/src/lib/stores/use-query-favorites.test.ts
@@ -1,0 +1,160 @@
+import { LocalFavoritesBackend } from './use-query-favorites'
+import { describe, expect, test, beforeEach } from 'bun:test'
+
+// Mock localStorage — shared mutable store reset in beforeEach.
+let storage: Record<string, string> = {}
+const mockLocalStorage = {
+  getItem: (k: string) => storage[k] ?? null,
+  setItem: (k: string, v: string) => {
+    storage[k] = v
+  },
+  removeItem: (k: string) => {
+    delete storage[k]
+  },
+}
+
+describe('LocalFavoritesBackend', () => {
+  let backend: LocalFavoritesBackend
+
+  beforeEach(() => {
+    storage = {}
+    backend = new LocalFavoritesBackend(mockLocalStorage)
+  })
+
+  test('list returns empty initially', () => {
+    expect(backend.list()).toEqual([])
+  })
+
+  test('save persists a favorite', () => {
+    backend.save({
+      title: 'Top tables',
+      sql: 'SELECT * FROM system.tables LIMIT 10',
+      tags: ['perf'],
+      hostId: 0,
+      database: null,
+      shareUrl: 'http://localhost/sql?q=SELECT&host=0',
+    })
+
+    const list = backend.list()
+    expect(list).toHaveLength(1)
+    expect(list[0].title).toBe('Top tables')
+    expect(list[0].sql).toBe('SELECT * FROM system.tables LIMIT 10')
+    expect(list[0].tags).toEqual(['perf'])
+    expect(list[0].hostId).toBe(0)
+    expect(list[0].database).toBeNull()
+    expect(typeof list[0].createdAt).toBe('number')
+  })
+
+  test('remove deletes by id', () => {
+    backend.save({
+      title: 'A',
+      sql: 'SELECT 1',
+      tags: [],
+      hostId: 0,
+      database: null,
+      shareUrl: '',
+    })
+    backend.save({
+      title: 'B',
+      sql: 'SELECT 2',
+      tags: [],
+      hostId: 0,
+      database: null,
+      shareUrl: '',
+    })
+
+    const [second, first] = backend.list() // newest first
+    expect(backend.list()).toHaveLength(2)
+
+    backend.remove(first.id)
+    const remaining = backend.list()
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0].id).toBe(second.id)
+  })
+
+  test('update patches title and tags', () => {
+    backend.save({
+      title: 'Original',
+      sql: 'SELECT 1',
+      tags: ['old'],
+      hostId: 0,
+      database: null,
+      shareUrl: '',
+    })
+
+    const [fav] = backend.list()
+    backend.update(fav.id, { title: 'Updated', tags: ['new', 'tag'] })
+
+    const [updated] = backend.list()
+    expect(updated.title).toBe('Updated')
+    expect(updated.tags).toEqual(['new', 'tag'])
+    // other fields preserved
+    expect(updated.sql).toBe('SELECT 1')
+    expect(updated.id).toBe(fav.id)
+  })
+
+  test('save generates a stable id', () => {
+    backend.save({
+      title: 'Q1',
+      sql: 'SELECT now()',
+      tags: [],
+      hostId: 0,
+      database: null,
+      shareUrl: '',
+    })
+
+    const [fav] = backend.list()
+    expect(typeof fav.id).toBe('string')
+    expect(fav.id.length).toBeGreaterThan(0)
+    // A second save of different SQL should get a different id.
+    backend.save({
+      title: 'Q2',
+      sql: 'SELECT 1',
+      tags: [],
+      hostId: 0,
+      database: null,
+      shareUrl: '',
+    })
+    const [newest, oldest] = backend.list()
+    expect(newest.id).not.toBe(oldest.id)
+  })
+
+  test('isFavorited matches on trimmed sql', () => {
+    backend.save({
+      title: 'Q',
+      sql: 'SELECT 1',
+      tags: [],
+      hostId: 0,
+      database: null,
+      shareUrl: '',
+    })
+
+    expect(backend.isFavorited('SELECT 1')).toBe(true)
+    // Leading/trailing whitespace should still match.
+    expect(backend.isFavorited('  SELECT 1  ')).toBe(true)
+    expect(backend.isFavorited('SELECT 2')).toBe(false)
+  })
+
+  test('list is ordered newest-first', () => {
+    backend.save({
+      title: 'First',
+      sql: 'SELECT 1',
+      tags: [],
+      hostId: 0,
+      database: null,
+      shareUrl: '',
+    })
+    backend.save({
+      title: 'Second',
+      sql: 'SELECT 2',
+      tags: [],
+      hostId: 0,
+      database: null,
+      shareUrl: '',
+    })
+
+    const list = backend.list()
+    expect(list[0].title).toBe('Second')
+    expect(list[1].title).toBe('First')
+  })
+})

--- a/apps/dashboard/src/lib/stores/use-query-favorites.ts
+++ b/apps/dashboard/src/lib/stores/use-query-favorites.ts
@@ -1,0 +1,178 @@
+import { useCallback, useEffect, useState } from 'react'
+
+/**
+ * Query Favorites — local bookmark store for saved SQL queries.
+ *
+ * Deliberately separate from useQueryHistory: history is ephemeral (auto-evicts,
+ * records every run), favorites are intentional named bookmarks (never evicted,
+ * user-titled, tagged).
+ *
+ * The store is pluggable for future team-sharing: FavoritesBackend defines the
+ * contract; LocalFavoritesBackend fulfills it from localStorage.
+ */
+
+export interface QueryFavorite {
+  id: string
+  title: string
+  sql: string
+  tags: string[]
+  hostId: number
+  database: string | null
+  createdAt: number
+  /** Shareable URL. e.g. /sql?q=<encoded>&host=<hostId> */
+  shareUrl: string
+}
+
+export interface FavoritesBackend {
+  list(): QueryFavorite[]
+  save(entry: Omit<QueryFavorite, 'id' | 'createdAt'>): QueryFavorite
+  remove(id: string): void
+  update(
+    id: string,
+    patch: Partial<Pick<QueryFavorite, 'title' | 'tags'>>
+  ): void
+  isFavorited(sql: string): boolean
+}
+
+const STORAGE_KEY = 'chm.sql.favorites.v1'
+
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
+function defaultStorage(): StorageLike {
+  if (typeof window !== 'undefined') return window.localStorage
+  return {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  }
+}
+
+function buildShareUrl(sql: string, hostId: number): string {
+  if (typeof window === 'undefined') return ''
+  const base = `${window.location.origin}/sql`
+  const params = new URLSearchParams({ q: sql, host: String(hostId) })
+  return `${base}?${params.toString()}`
+}
+
+/** Tiny non-cryptographic hash for stable-ish ids. */
+function hashStr(s: string): number {
+  let h = 0
+  for (let i = 0; i < s.length; i++) {
+    h = (h << 5) - h + s.charCodeAt(i)
+    h |= 0
+  }
+  return h
+}
+
+export class LocalFavoritesBackend implements FavoritesBackend {
+  private s: StorageLike
+
+  constructor(storage?: StorageLike) {
+    this.s = storage ?? defaultStorage()
+  }
+
+  private read(): QueryFavorite[] {
+    try {
+      const raw = this.s.getItem(STORAGE_KEY)
+      if (!raw) return []
+      const parsed = JSON.parse(raw)
+      if (!Array.isArray(parsed)) return []
+      return parsed.filter(
+        (e): e is QueryFavorite =>
+          e &&
+          typeof e.id === 'string' &&
+          typeof e.sql === 'string' &&
+          typeof e.createdAt === 'number'
+      )
+    } catch {
+      return []
+    }
+  }
+
+  private write(entries: QueryFavorite[]): void {
+    try {
+      this.s.setItem(STORAGE_KEY, JSON.stringify(entries))
+    } catch {
+      // Quota or serialization failure — favorites are best-effort, ignore.
+    }
+  }
+
+  list(): QueryFavorite[] {
+    return this.read()
+  }
+
+  save(entry: Omit<QueryFavorite, 'id' | 'createdAt'>): QueryFavorite {
+    const createdAt = Date.now()
+    const id = `fav-${createdAt}-${Math.abs(hashStr(entry.sql)) % 100000}`
+    const shareUrl = entry.shareUrl || buildShareUrl(entry.sql, entry.hostId)
+    const fav: QueryFavorite = { ...entry, id, createdAt, shareUrl }
+    const prev = this.read()
+    this.write([fav, ...prev])
+    return fav
+  }
+
+  remove(id: string): void {
+    this.write(this.read().filter((e) => e.id !== id))
+  }
+
+  update(
+    id: string,
+    patch: Partial<Pick<QueryFavorite, 'title' | 'tags'>>
+  ): void {
+    this.write(this.read().map((e) => (e.id === id ? { ...e, ...patch } : e)))
+  }
+
+  isFavorited(sql: string): boolean {
+    const trimmed = sql.trim()
+    return this.read().some((e) => e.sql.trim() === trimmed)
+  }
+}
+
+const backend = new LocalFavoritesBackend()
+
+export function useQueryFavorites() {
+  const [favorites, setFavorites] = useState<QueryFavorite[]>(() =>
+    backend.list()
+  )
+
+  // Sync across tabs/windows.
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) setFavorites(backend.list())
+    }
+    window.addEventListener('storage', onStorage)
+    return () => window.removeEventListener('storage', onStorage)
+  }, [])
+
+  const refresh = useCallback(() => {
+    setFavorites(backend.list())
+  }, [])
+
+  const save = useCallback(
+    (entry: Omit<QueryFavorite, 'id' | 'createdAt'>) => {
+      backend.save(entry)
+      refresh()
+    },
+    [refresh]
+  )
+
+  const remove = useCallback(
+    (id: string) => {
+      backend.remove(id)
+      refresh()
+    },
+    [refresh]
+  )
+
+  const update = useCallback(
+    (id: string, patch: Partial<Pick<QueryFavorite, 'title' | 'tags'>>) => {
+      backend.update(id, patch)
+      refresh()
+    },
+    [refresh]
+  )
+
+  const isFavorited = useCallback((sql: string) => backend.isFavorited(sql), [])
+
+  return { favorites, save, remove, update, isFavorited }
+}

--- a/apps/dashboard/src/routes/(dashboard)/explain.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/explain.tsx
@@ -19,6 +19,7 @@ import { EmptyState } from '@/components/ui/empty-state'
 import { Label } from '@/components/ui/label'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { SaveFavoriteButton } from '@/components/query-favorites'
 import { usePathname, useRouter, useSearchParams } from '@/lib/next-compat'
 import { useHostId } from '@/lib/swr'
 import { apiFetch } from '@/lib/swr/api-fetch'
@@ -379,14 +380,21 @@ function ExplainContent() {
           <CardTitle className="flex items-center gap-2 text-lg">
             <InfoCircledIcon className="size-5" />
             Explain Query
-            <a
-              href="https://clickhouse.com/docs/sql-reference/statements/explain"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-muted-foreground hover:text-foreground ml-auto text-xs font-normal"
-            >
-              Docs <ExternalLinkIcon className="inline size-3" />
-            </a>
+            <div className="ml-auto flex items-center gap-2">
+              <SaveFavoriteButton
+                sql={committedQuery}
+                hostId={hostId}
+                database={null}
+              />
+              <a
+                href="https://clickhouse.com/docs/sql-reference/statements/explain"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted-foreground hover:text-foreground text-xs font-normal"
+              >
+                Docs <ExternalLinkIcon className="inline size-3" />
+              </a>
+            </div>
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">


### PR DESCRIPTION
## Summary

- **#1917 (global time-range)**: Chart factories (`create-area-chart`, `create-bar-chart`) now consume the global `TimeRangeContext` with priority: per-chart date range override → explicit prop → global context → factory config default. `expensive-queries` SQL parameterized with `{last_hours:UInt64}` + `filterParamPresets`; view seeds `filterParams` from `timeRange.lastHours`. `slow-queries` view seeds `last_hours` from global context (URL param overrides). Running Queries trend charts annotated as a fixed 14-day window.
- **#1918 (query favorites)**: `LocalFavoritesBackend` stores favorites in localStorage (`chm.sql.favorites.v1`) with tab-sync. `useQueryFavorites()` hook wraps the backend. `SaveFavoriteButton` (star icon, amber when saved), `SaveFavoriteDialog` (title + tags), `QueryFavoritesPanel` (search + tag filter chips + inline edit + copy deep-link + one-click rerun). Wired into SQL console (after Format button) and `/explain` page (CardHeader).
- **#1919 (bulk EXPLAIN + heuristics)**: Pure `explain-heuristics.ts` with 5 checks (full scan without PREWHERE, missing partition pruning, high read-rows:result ratio, large JOIN without key, no index used) and no React/I/O. `BulkExplainDialog` with N selector (1/3/5/10/20), sequential `/api/v1/explain` calls, per-query `SuggestionChip` inline results, and "Ask AI" agent handoff link. Wired into `ExpensiveQueriesView` and `SlowQueriesView`.

## Test plan

- [ ] 40/40 unit tests pass (`explain-heuristics` + `use-query-favorites`)
- [ ] 901/901 query-config tests pass (no regressions from `expensive-queries.ts` param change)
- [ ] CI lint + type-check
- [ ] Verify global time-range picker changes propagate to chart queries (area + bar factory charts)
- [ ] Verify expensive-queries table refreshes with new time window when picker changes
- [ ] Verify slow-queries `last_hours` chip defaults to global time-range on first load
- [ ] Save a favorite from SQL console; verify star fills amber, appears in panel
- [ ] Share deep-link from panel; verify URL decodes back to original SQL
- [ ] Open "Explain top N" on expensive/slow queries; verify suggestion chips appear for problematic queries

Closes #1917
Closes #1918
Closes #1919

https://claude.ai/code/session_01TnsycTkdMHJ4DXohpuz3oj