### PR TITLE
feat(docs): add chmonitor logo to docs nav

### DIFF
--- a/apps/docs/public/brand/logo-mark.svg
+++ b/apps/docs/public/brand/logo-mark.svg
@@ -1,0 +1,3 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="chmonitor">
+<rect x="3.3" y="13.05" width="3.8" height="15.45" fill="#f97316"/><rect x="8.7" y="3.5" width="3.8" height="25" fill="#f97316"/><rect x="14.1" y="13.25" width="3.8" height="15.25" fill="#f97316"/><rect x="19.5" y="6.25" width="3.8" height="22.25" fill="#f97316"/><rect x="24.9" y="16.8" width="3.8" height="11.7" fill="#f97316"/><rect x="3.3" y="9.75" width="3.8" height="3.3" fill="#10b981"/>
+</svg>

--- a/apps/docs/src/lib/layout.shared.tsx
+++ b/apps/docs/src/lib/layout.shared.tsx
@@ -4,7 +4,18 @@ import { appName, gitConfig } from './shared'
 export function baseOptions(): BaseLayoutProps {
   return {
     nav: {
-      title: appName,
+      title: (
+        <span className="inline-flex items-center gap-2 font-medium">
+          <img
+            src="/brand/logo-mark.svg"
+            alt=""
+            width={22}
+            height={22}
+            className="shrink-0"
+          />
+          {appName}
+        </span>
+      ),
     },
     githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
     links: [


### PR DESCRIPTION
Adds the chmonitor brand mark (orange bar-chart glyph, theme-agnostic) to the Fumadocs nav header next to the site title. Asset copied from `apps/landing/public/brand/logo-mark.svg` into `apps/docs/public/brand/`. CI verifies the docs build.

## Summary by Sourcery

Add the chmonitor logo mark to the docs navigation header next to the site title.

New Features:
- Display the chmonitor logo mark alongside the application name in the docs navigation header.

Enhancements:
- Include the shared logo-mark SVG asset in the docs public brand assets for consistent branding.