### PR TITLE
feat(docs): reorganize content tree + add cards, callouts, TOC, nav

### DIFF
--- a/apps/docs/scripts/sync-docs.mjs
+++ b/apps/docs/scripts/sync-docs.mjs
@@ -31,17 +31,21 @@ const SRC_DIR = resolve(REPO_ROOT, 'docs/content')
 const DEST_DIR = resolve(__dirname, '../content/docs')
 const RAW_BASE = 'https://raw.githubusercontent.com/duyet/clickhouse-monitoring/main'
 
-// Top-level sidebar order. Matches the order in the old astro.config.mjs.
+// Top-level sidebar order.
+// Groups: orientation → deployment → features → auth → AI → separator → advanced →
+// guides → reference → separator → meta → separator → utility.
 const ROOT_ORDER = [
   'index',
   'getting-started',
-  'guides',
   'deploy',
   'features',
-  'ai-agent',
   'authentication',
+  'ai-agent',
+  '---',
   'advanced',
+  'guides',
   'reference',
+  '---',
   'migrating',
   'releases',
   '---',
@@ -62,6 +66,84 @@ const SECTION_TITLES = {
   reference: 'Reference',
   migrating: 'Migrating',
   releases: 'Releases',
+}
+
+// Explicit page ordering within each section.
+// Entries are slug names relative to the section folder (no extension).
+// "index" refers to the section landing page (from a root-level .mdx with the
+// same name as the folder). Sections without a landing page omit "index".
+const SECTION_PAGE_ORDER = {
+  'getting-started': [
+    'index',
+    'clickhouse-requirements',
+    'clickhouse-enable-system-tables',
+    'local',
+  ],
+  guides: ['proxy-auth-setup', 'troubleshooting', 'upgrade-clickhouse'],
+  deploy: [
+    'index',
+    'docker',
+    'k8s',
+    'cloudflare',
+    'vercel',
+    'self-host',
+    'traefik',
+    'one-click',
+    'production-checklist',
+  ],
+  features: [
+    'index',
+    'overview',
+    'queries',
+    'tables',
+    'explorer',
+    'operations',
+    'cluster',
+    'metrics',
+    'insights',
+    'health',
+    'security',
+    'logs',
+    'dashboard',
+    'mcp',
+    'peerdb',
+    'browser-connections',
+    'user-connections',
+    'settings',
+  ],
+  'ai-agent': ['index', 'capabilities', 'configuration', 'conversation-history'],
+  authentication: [
+    'index',
+    'public',
+    'api-keys',
+    'clerk',
+    'cloudflare-access',
+    'trusted-header',
+    'trusted-proxy',
+  ],
+  advanced: [
+    'feature-permissions',
+    'multiple-hosts',
+    'editions',
+    'queries-history',
+    'self-tracking',
+    'telemetry',
+    'agent-conversation-storage',
+    'custom-name',
+    'peerdb-monitoring',
+  ],
+  reference: [
+    'environment-variables',
+    'configuration',
+    'mcp-server',
+    'mcp-clients',
+    'support-matrix',
+    'grafana-bridge',
+    'connection-presets',
+    'catalog-contributing',
+  ],
+  migrating: ['v0-3'],
+  releases: ['v0-3'],
 }
 
 async function walk(dir) {
@@ -191,13 +273,15 @@ async function main() {
     'utf8',
   )
 
-  // Per-section meta.json — sets display names for folder labels.
+  // Per-section meta.json — sets display name and explicit page ordering.
   for (const [slug, title] of Object.entries(SECTION_TITLES)) {
     const sectionDir = join(DEST_DIR, slug)
     if (existsSync(sectionDir)) {
+      const pages = SECTION_PAGE_ORDER[slug]
+      const meta = pages ? { title, pages } : { title }
       await writeFile(
         join(sectionDir, 'meta.json'),
-        JSON.stringify({ title }, null, 2) + '\n',
+        JSON.stringify(meta, null, 2) + '\n',
         'utf8',
       )
     }

--- a/apps/docs/src/components/mdx.tsx
+++ b/apps/docs/src/components/mdx.tsx
@@ -1,9 +1,18 @@
+import { Accordion, Accordions } from 'fumadocs-ui/components/accordion'
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs'
 import defaultMdxComponents from 'fumadocs-ui/mdx'
 import type { MDXComponents } from 'mdx/types'
 
 export function getMDXComponents(components?: MDXComponents) {
   return {
     ...defaultMdxComponents,
+    Accordion,
+    Accordions,
+    Step,
+    Steps,
+    Tab,
+    Tabs,
     ...components,
   } satisfies MDXComponents
 }

--- a/apps/docs/src/lib/layout.shared.tsx
+++ b/apps/docs/src/lib/layout.shared.tsx
@@ -20,9 +20,20 @@ export function baseOptions(): BaseLayoutProps {
     githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
     links: [
       {
+        text: 'Getting Started',
+        url: '/getting-started',
+        active: 'nested-url',
+      },
+      {
         text: 'Dashboard',
         url: 'https://dash.chmonitor.dev',
         active: 'none',
+        external: true,
+      },
+      {
+        text: 'Releases',
+        url: '/releases',
+        active: 'nested-url',
       },
     ],
   }

--- a/docs/content/ai-agent.mdx
+++ b/docs/content/ai-agent.mdx
@@ -37,11 +37,28 @@ For full configuration options see [Configuration](/docs/ai-agent/configuration)
 
 ## Child pages
 
-- [Configuration](/docs/ai-agent/configuration) — all env vars, providers, access control
-- [Capabilities](/docs/ai-agent/capabilities) — tools, skills, plan & verify, examples
-- [Conversation History](/docs/ai-agent/conversation-history) — how history works, how to enable server persistence
-  - [Store Backends](/docs/ai-agent/conversation-history/backends) — per-backend setup (D1, ClickHouse, Postgres, …)
-  - [AgentState](#conversation-history-backends) — managed/self-hosted persistence with AI enrichment (auto-titles, follow-ups)
+<Cards>
+  <Card
+    title="Capabilities"
+    href="/ai-agent/capabilities"
+    description="Full tool list, skills, plan & verify mode, and worked examples."
+  />
+  <Card
+    title="Configuration"
+    href="/ai-agent/configuration"
+    description="All environment variables, LLM providers, and access control."
+  />
+  <Card
+    title="Conversation History"
+    href="/ai-agent/conversation-history"
+    description="How chat history works and how to enable server-side persistence."
+  />
+  <Card
+    title="Store Backends"
+    href="/ai-agent/conversation-history/backends"
+    description="Per-backend setup: D1, ClickHouse, Postgres, AgentState, and more."
+  />
+</Cards>
 
 ## Conversation history backends
 
@@ -195,7 +212,11 @@ All other MCP tools run fixed SELECT queries and pass `readonly: '1'` to the Cli
 
 ## Security
 
+<Callout type="warn" title="Security guidelines">
+
 - Use a **read-only ClickHouse user** scoped to the system tables the dashboard needs.
 - Keep **control tools off** (`AGENT_ENABLE_CONTROL_TOOLS=false`, the default) unless you trust the user and need kill/optimize.
 - On public deployments, **require authentication**: `CHM_FEATURE_AGENT_ACCESS=authenticated`.
 - Keep LLM keys **server-side** — never in `VITE_*` variables (those are baked into browser JS at build time).
+
+</Callout>

--- a/docs/content/authentication.mdx
+++ b/docs/content/authentication.mdx
@@ -7,6 +7,52 @@ chmonitor has two independent auth layers that work together on every `/api/v1/*
 
 A request is allowed when either layer accepts it. The only fully public setup is `CHM_AUTH_PROVIDER=none` with no `CHM_API_KEY_SECRET`.
 
+## Choose an auth method
+
+<Cards>
+  <Card
+    title="Public / no auth"
+    href="/authentication/public"
+    description="Default open dashboard — any visitor can access all features. Best for local dev or trusted internal networks."
+  />
+  <Card
+    title="API keys"
+    href="/authentication/api-keys"
+    description="chm_ Bearer tokens for programmatic access — MCP clients, scripts, CI pipelines."
+  />
+  <Card
+    title="Clerk"
+    href="/authentication/clerk"
+    description="Browser sign-in with Clerk sessions. Best for hosted dashboards with user accounts."
+  />
+  <Card
+    title="Cloudflare Access"
+    href="/authentication/cloudflare-access"
+    description="proxy provider — Cloudflare Access JWT verification. Zero Trust, no shared secret needed."
+  />
+  <Card
+    title="Trusted header"
+    href="/authentication/trusted-header"
+    description="proxy provider — bare identity subject via shared secret. Works with nginx or any reverse proxy."
+  />
+  <Card
+    title="Trusted proxy"
+    href="/authentication/trusted-proxy"
+    description="trusted provider — full profile from forwarded headers. Works with oauth2-proxy, Dex, Authelia."
+  />
+</Cards>
+
+## Which one should I use?
+
+| Situation | Recommended setup |
+|---|---|
+| Local dev or internal network, no login needed | Public (`none`) — default |
+| Hosted dashboard with user accounts and sign-in | Clerk |
+| Behind Cloudflare Access | Proxy — `cloudflare-access` |
+| Behind nginx/SSO with a bare identity header | Proxy — `trusted-header` |
+| Behind oauth2-proxy / Dex / Authelia / Traefik ForwardAuth | Trusted (`trusted`) |
+| MCP clients, scripts, CI pipelines | API key (`CHM_API_KEY_SECRET`) — add alongside any provider |
+
 ## Summary
 
 | Method | Who reads it | Browser / proxy auth | curl / MCP auth |
@@ -21,6 +67,7 @@ A request is allowed when either layer accepts it. The only fully public setup i
 
 ## How enforcement decides
 
+<Callout type="info" title="Request evaluation order">
 For each `/api/v1/*` request, in order:
 
 1. If `CHM_AUTH_PROVIDER=none` and `CHM_API_KEY_SECRET` is not set → **allow** (public).
@@ -30,29 +77,10 @@ For each `/api/v1/*` request, in order:
 5. Otherwise → `401 { "error": "Authentication required" }`.
 
 All paths fail closed: a missing config or verification error resolves to "not authenticated".
-
-## Which one should I use?
-
-| Situation | Recommended setup |
-|---|---|
-| Local dev or internal network, no login needed | Public (`none`) — default |
-| Hosted dashboard with user accounts and sign-in | Clerk |
-| Behind Cloudflare Access | Proxy — `cloudflare-access` |
-| Behind nginx/SSO with a bare identity header | Proxy — `trusted-header` |
-| Behind oauth2-proxy / Dex / Authelia / Traefik ForwardAuth | Trusted (`trusted`) |
-| MCP clients, scripts, CI pipelines | API key (`CHM_API_KEY_SECRET`) — add alongside any provider |
-
-## Provider pages
-
-- [Public / no auth](/docs/authentication/public) — default open dashboard
-- [API keys](/docs/authentication/api-keys) — `chm_` Bearer tokens for programmatic access
-- [Clerk](/docs/authentication/clerk) — browser sign-in with Clerk sessions
-- [Cloudflare Access](/docs/authentication/cloudflare-access) — `proxy` provider; Cloudflare Access JWT verification
-- [Trusted header](/docs/authentication/trusted-header) — `proxy` provider; bare subject via shared secret
-- [Trusted proxy](/docs/authentication/trusted-proxy) — `trusted` provider; full profile from forwarded headers (oauth2-proxy, Dex, Authelia)
+</Callout>
 
 ## Related
 
-- [Environment Variables — Authentication](/docs/reference/environment-variables#authentication)
-- [Feature Permissions](/docs/advanced/feature-permissions)
-- [MCP Server](/docs/reference/mcp-server)
+- [Environment Variables — Authentication](/reference/environment-variables#authentication)
+- [Feature Permissions](/advanced/feature-permissions)
+- [MCP Server](/reference/mcp-server)

--- a/docs/content/deploy.mdx
+++ b/docs/content/deploy.mdx
@@ -4,13 +4,56 @@ Deploy chmonitor wherever your ClickHouse runs. Pick the platform that matches y
 
 ## Platforms
 
-| Platform | Best for | Auth options | Notes |
-|---|---|---|---|
-| [Docker](/docs/deploy/docker) | Single-server self-host | none / clerk / proxy | Fastest path; pin a release tag |
-| [Kubernetes](/docs/deploy/k8s) | Cluster-managed, multi-replica | none / clerk / proxy | Helm chart vendored in-repo; kustomize alternative |
-| [Cloudflare Workers](/docs/deploy/cloudflare) | Edge / serverless | none / clerk / Cloudflare Access | D1 + Durable Objects for conversation store; Cron Trigger for health sweep |
-| [Vercel](/docs/deploy/vercel) | Quick hosted preview (Next.js legacy app) | none / clerk / API key / reverse proxy | Use postgres or clickhouse for conversation store; no D1/DO |
-| [Node / standalone](/docs/deploy/self-host) | Custom server, systemd, bare VM | none / clerk / proxy | `bun run start` or `node server.js`; put behind nginx |
+<Cards>
+  <Card
+    title="Docker"
+    href="/deploy/docker"
+    description="Single-server self-host. Fastest path; pin a release tag. Supports none / clerk / proxy auth."
+  />
+  <Card
+    title="Kubernetes"
+    href="/deploy/k8s"
+    description="Cluster-managed, multi-replica. Helm chart vendored in-repo; kustomize alternative."
+  />
+  <Card
+    title="Cloudflare Workers"
+    href="/deploy/cloudflare"
+    description="Edge / serverless. D1 + Durable Objects for conversation store; Cron Trigger for health sweep."
+  />
+  <Card
+    title="Vercel"
+    href="/deploy/vercel"
+    description="Quick hosted preview. Supports postgres or clickhouse for conversation store."
+  />
+  <Card
+    title="Node / standalone"
+    href="/deploy/self-host"
+    description="Custom server, systemd, bare VM. Run bun run start or node server.js behind nginx."
+  />
+  <Card
+    title="Traefik"
+    href="/deploy/traefik"
+    description="Put chmonitor behind a Traefik reverse proxy with optional ForwardAuth."
+  />
+  <Card
+    title="One-click deploy"
+    href="/deploy/one-click"
+    description="Deploy to managed platforms with a single click."
+  />
+  <Card
+    title="Production checklist"
+    href="/deploy/production-checklist"
+    description="Steps to harden and validate your deployment before going to production."
+  />
+</Cards>
+
+<Callout type="info" title="Not sure where to start?">
+- **Running Docker already?** → [Docker](/deploy/docker)
+- **On Kubernetes?** → [Kubernetes](/deploy/k8s)
+- **Want serverless edge?** → [Cloudflare Workers](/deploy/cloudflare)
+- **Behind Traefik / a reverse proxy?** → [Traefik](/deploy/traefik)
+- **Before going to production?** → [Production checklist](/deploy/production-checklist)
+</Callout>
 
 ## Configuration categories
 
@@ -18,19 +61,11 @@ Every platform shares the same configuration categories. The links below go to t
 
 | Category | What it controls | Reference |
 |---|---|---|
-| ClickHouse connection | Hosts, credentials, query timeout, pool | [Configuration](/docs/reference/configuration) |
-| Query / pool tuning | Execution time, cache TTL, pool size | [Configuration](/docs/reference/configuration) |
-| Feature permissions | Enable/disable features; public vs authenticated access | [Features](/docs/features) |
-| Authentication | none / clerk / proxy (CF Access or trusted header) | [Authentication](/docs/authentication) |
-| AI agent | LLM key, model, control tools, agent API token | [AI Agent](/docs/ai-agent) |
-| Conversation store | Browser local / agentstate / D1 / postgres / clickhouse | [AI Agent](/docs/ai-agent) |
-| Health alerting | Cron sweep, webhook URL, severity threshold | [Configuration](/docs/reference/configuration) |
-| Branding / analytics | Title, logo, GA / PostHog / Seline | [Configuration](/docs/reference/configuration) |
-
-## Not sure where to start?
-
-- **Running Docker already?** → [Docker](/docs/deploy/docker)
-- **On Kubernetes?** → [Kubernetes](/docs/deploy/k8s)
-- **Want serverless edge?** → [Cloudflare Workers](/docs/deploy/cloudflare)
-- **Behind Traefik / a reverse proxy?** → [Traefik](/docs/deploy/traefik)
-- **Before going to production?** → [Production checklist](/docs/deploy/production-checklist)
+| ClickHouse connection | Hosts, credentials, query timeout, pool | [Configuration](/reference/configuration) |
+| Query / pool tuning | Execution time, cache TTL, pool size | [Configuration](/reference/configuration) |
+| Feature permissions | Enable/disable features; public vs authenticated access | [Features](/features) |
+| Authentication | none / clerk / proxy (CF Access or trusted header) | [Authentication](/authentication) |
+| AI agent | LLM key, model, control tools, agent API token | [AI Agent](/ai-agent) |
+| Conversation store | Browser local / agentstate / D1 / postgres / clickhouse | [AI Agent](/ai-agent) |
+| Health alerting | Cron sweep, webhook URL, severity threshold | [Configuration](/reference/configuration) |
+| Branding / analytics | Title, logo, GA / PostHog / Seline | [Configuration](/reference/configuration) |

--- a/docs/content/faq.mdx
+++ b/docs/content/faq.mdx
@@ -2,35 +2,57 @@
 
 ## Connection issues
 
-**The dashboard shows a connection error.**
+<Accordions type="multiple">
+
+<Accordion title="The dashboard shows a connection error.">
 
 Check that `CLICKHOUSE_HOST` is a full URL including scheme and port, e.g. `http://your-host:8123` or `https://your-host:8443`. Inside Docker, `localhost` points at the container itself — use the ClickHouse service name on the Docker network, or `host.docker.internal` (Mac/Windows) / `172.17.0.1` (Linux) to reach a process on the Docker host.
 
-**I changed ClickHouse credentials but the dashboard still fails.**
+</Accordion>
+
+<Accordion title="I changed ClickHouse credentials but the dashboard still fails.">
 
 Restart or redeploy the app after updating credentials. For Cloudflare Workers, run `bun run cf:config` to push the new secrets, then redeploy (`bun run cf:deploy`). The worker connection pool caches credentials at startup.
 
+</Accordion>
+
+</Accordions>
+
 ## System tables and empty pages
 
-**Some pages are empty or show "table not found".**
+<Accordions type="multiple">
 
-The page depends on a ClickHouse system table that is disabled or not present in your version. See [Enable system tables](/docs/getting-started/clickhouse-enable-system-tables) to check which tables are required and how to enable them.
+<Accordion title='Some pages are empty or show "table not found".'>
 
-**The query thread analysis page is empty.**
+The page depends on a ClickHouse system table that is disabled or not present in your version. See [Enable system tables](/getting-started/clickhouse-enable-system-tables) to check which tables are required and how to enable them.
 
-`system.query_thread_log` must be explicitly enabled in ClickHouse config and `log_query_threads=1` must be set in the profile used by the monitoring user. See the [Enable system tables](/docs/getting-started/clickhouse-enable-system-tables) guide.
+</Accordion>
 
-**ZooKeeper / Keeper pages are missing.**
+<Accordion title="The query thread analysis page is empty.">
+
+`system.query_thread_log` must be explicitly enabled in ClickHouse config and `log_query_threads=1` must be set in the profile used by the monitoring user. See the [Enable system tables](/getting-started/clickhouse-enable-system-tables) guide.
+
+</Accordion>
+
+<Accordion title="ZooKeeper / Keeper pages are missing.">
 
 `system.zookeeper` only exists when ClickHouse Keeper or ZooKeeper is configured. If you don't use a replicated setup, these pages will not show data.
 
+</Accordion>
+
+</Accordions>
+
 ## Authentication
 
-**How do I require login before anyone can use the dashboard?**
+<Accordions type="multiple">
 
-Set `CHM_AUTH_PROVIDER=clerk` and configure Clerk keys, then set `CHM_AUTH_REQUIRED_FEATURES=agent,mcp,settings,actions` (or use `CHM_FEATURE_{ID}_ACCESS=authenticated` per feature). See [Authentication](/docs/authentication).
+<Accordion title="How do I require login before anyone can use the dashboard?">
 
-**I want to protect specific features but not the whole dashboard.**
+Set `CHM_AUTH_PROVIDER=clerk` and configure Clerk keys, then set `CHM_AUTH_REQUIRED_FEATURES=agent,mcp,settings,actions` (or use `CHM_FEATURE_{ID}_ACCESS=authenticated` per feature). See [Authentication](/authentication).
+
+</Accordion>
+
+<Accordion title="I want to protect specific features but not the whole dashboard.">
 
 Use per-feature env vars:
 
@@ -39,13 +61,21 @@ CHM_FEATURE_AGENT_ACCESS=authenticated
 CHM_FEATURE_MCP_ACCESS=authenticated
 ```
 
-**The AI agent is accessible without login. Is that safe?**
+</Accordion>
+
+<Accordion title="The AI agent is accessible without login. Is that safe?">
 
 The agent uses the same ClickHouse grants as the configured monitoring user. If that user is read-only, the agent can only read. If you want to restrict it further, set `CHM_FEATURE_AGENT_ACCESS=authenticated`.
 
+</Accordion>
+
+</Accordions>
+
 ## Multi-host
 
-**How do I monitor multiple ClickHouse clusters?**
+<Accordions type="multiple">
+
+<Accordion title="How do I monitor multiple ClickHouse clusters?">
 
 Set `CLICKHOUSE_HOST` to a comma-separated list of host URLs. For credentials, you can provide a single value (applied to all hosts) or one value per host position. `CLICKHOUSE_NAME` is optional (hosts default to indexed labels):
 
@@ -58,40 +88,70 @@ CLICKHOUSE_NAME=prod-a,prod-b
 
 A host selector appears in the UI when more than one host is configured.
 
+</Accordion>
+
+</Accordions>
+
 ## AI agent
 
-**The agent returns errors or doesn't respond.**
+<Accordions type="multiple">
+
+<Accordion title="The agent returns errors or doesn't respond.">
 
 Check that `LLM_API_KEY` is set and that `LLM_API_BASE` points at a reachable OpenAI-compatible endpoint. The agent uses `https://openrouter.ai/api/v1` by default. Verify the key works by testing the endpoint directly. Also confirm the feature is not disabled (`CHM_FEATURE_AGENT_ENABLED=false` would silence it).
 
-**The agent can't kill queries or run OPTIMIZE.**
+</Accordion>
+
+<Accordion title="The agent can't kill queries or run OPTIMIZE.">
 
 `AGENT_ENABLE_CONTROL_TOOLS` defaults to `false`. Set it to `true` only if you intend to let the agent use those actions, and only when the ClickHouse user has the corresponding grants (`KILL QUERY`, `OPTIMIZE`).
 
+</Accordion>
+
+</Accordions>
+
 ## Conversation persistence
 
-**Agent conversation history disappears after I close the browser.**
+<Accordions type="multiple">
+
+<Accordion title="Agent conversation history disappears after I close the browser.">
 
 By default, history lives in browser `localStorage`. To persist it server-side:
 
 1. Set `VITE_FEATURE_CONVERSATION_DB=true` at build time (before `bun run build`). Also requires Clerk auth.
 2. Set `CONVERSATION_STORE_BACKEND` at runtime to `agentstate`, `d1`, `postgres`, or `memory`.
 
-See [Conversation History](/docs/ai-agent/conversation-history) and [Store Backends](/docs/ai-agent/conversation-history/backends).
+See [Conversation History](/ai-agent/conversation-history) and [Store Backends](/ai-agent/conversation-history/backends).
+
+</Accordion>
+
+</Accordions>
 
 ## Data freshness
 
-**The dashboard shows stale data.**
+<Accordions type="multiple">
+
+<Accordion title="The dashboard shows stale data.">
 
 The TanStack app revalidates data on focus and on a polling interval. Reduce `CLICKHOUSE_MAX_EXECUTION_TIME` if queries are taking too long, or adjust the client-side refresh interval per chart.
 
+</Accordion>
+
+</Accordions>
+
 ## Deployment
 
-**Which deployment should I use?**
+<Accordions type="multiple">
+
+<Accordion title="Which deployment should I use?">
 
 - **Docker** — simplest self-hosted path, works anywhere Docker runs.
 - **Kubernetes** — best when the dashboard is managed alongside your platform workloads.
 - **Cloudflare Workers** — edge hosting, no server to operate, works well with Cloudflare Access for auth.
 - **Vercel / self-host Node** — if you prefer a Node-based platform.
 
-See [Install & Configure](/docs/deploy) for platform-specific guides.
+See [Install & Configure](/deploy) for platform-specific guides.
+
+</Accordion>
+
+</Accordions>

--- a/docs/content/features.mdx
+++ b/docs/content/features.mdx
@@ -2,31 +2,98 @@
 
 chmonitor is organized around the operational questions you answer while running a ClickHouse cluster. Each feature maps to one or more routes in the UI and a feature id you can use to control access or disable it.
 
-All features are **public and enabled by default**. You only configure what you want to restrict or turn off.
+<Callout type="info" title="All features are public and enabled by default">
+You only configure what you want to restrict or turn off. The only exceptions are the AI agent (`agent`) and control actions (`actions`), which default to `authenticated` access.
+</Callout>
+
+## Feature overview
+
+<Cards>
+  <Card
+    title="Overview"
+    href="/features/overview"
+    description="Cluster health at a glance — active queries, memory, disk, and CPU."
+  />
+  <Card
+    title="Query Monitoring"
+    href="/features/queries"
+    description="Live, historical, failed, slow, and expensive query analysis."
+  />
+  <Card
+    title="Tables & Storage"
+    href="/features/tables"
+    description="Table sizes, disk usage, parts, and storage breakdown."
+  />
+  <Card
+    title="Data Explorer"
+    href="/features/explorer"
+    description="Browse column definitions, dependencies, and projections for any table."
+  />
+  <Card
+    title="Merges & Operations"
+    href="/features/operations"
+    description="Active merges, mutations, and background operation throughput."
+  />
+  <Card
+    title="Clusters & Replication"
+    href="/features/cluster"
+    description="Replication lag, queue size, and replica health across hosts."
+  />
+  <Card
+    title="Metrics & Profiler"
+    href="/features/metrics"
+    description="Server CPU, memory, IO metrics and ClickHouse profiling data."
+  />
+  <Card
+    title="Insights"
+    href="/features/insights"
+    description="AI-surfaced anomalies, performance patterns, and observations."
+  />
+  <Card
+    title="Health & Alerting"
+    href="/features/health"
+    description="Active alerts from the health sweep cron with severity thresholds."
+  />
+  <Card
+    title="Security & Audit"
+    href="/features/security"
+    description="Who is accessing ClickHouse, with what grants, and how often."
+  />
+  <Card
+    title="Logs"
+    href="/features/logs"
+    description="Server log entries from system.text_log and related tables."
+  />
+  <Card
+    title="MCP Server"
+    href="/features/mcp"
+    description="ClickHouse monitoring tools for AI clients via the Model Context Protocol."
+  />
+</Cards>
 
 ## Feature index
 
 | Feature | What it answers | Feature id | Page |
 |---|---|---|---|
-| Overview | Is my cluster healthy right now? | `overview` | [Overview](/docs/features/overview) |
-| Query Monitoring | What queries are running or slow? | `queries` | [Query Monitoring](/docs/features/queries) |
-| Tables & Storage | How big are my tables? Where is disk going? | `tables` | [Tables & Storage](/docs/features/tables) |
-| Data Explorer | What columns/dependencies does this table have? | `tables` | [Data Explorer](/docs/features/explorer) |
-| Merges & Operations | Are merges/mutations keeping up? | `operations` | [Merges & Operations](/docs/features/operations) |
-| Clusters & Replication | Is replication lagging? Are replicas healthy? | `cluster` | [Clusters & Replication](/docs/features/cluster) |
-| Metrics & Profiler | What are the server's CPU/memory/IO metrics? | `metrics` | [Metrics & Profiler](/docs/features/metrics) |
-| Insights | What patterns or anomalies does the AI surface? | `insights` | [Insights](/docs/features/insights) |
-| Health & Alerting | Are there active alerts? | `health` | [Health & Alerting](/docs/features/health) |
-| Security & Audit | Who is accessing ClickHouse and how? | `security` | [Security & Audit](/docs/features/security) |
-| Logs | What did the server log? | `logs` | [Logs](/docs/features/logs) |
-| Dashboard | Custom pinned metrics view | `dashboard` | [Dashboard](/docs/features/dashboard) |
-| AI Agent | Natural language questions about my cluster | `agent` | [AI Agent](/docs/ai-agent) |
-| MCP Server | ClickHouse monitoring tools for AI clients | `mcp` | [MCP Server](/docs/features/mcp) |
-| PeerDB | PeerDB replication pipeline status | `peerdb` | [PeerDB](/docs/features/peerdb) |
-| Browser Connections | Personal ad-hoc connections stored in the browser | — | [Browser Connections](/docs/features/browser-connections) |
+| Overview | Is my cluster healthy right now? | `overview` | [Overview](/features/overview) |
+| Query Monitoring | What queries are running or slow? | `queries` | [Query Monitoring](/features/queries) |
+| Tables & Storage | How big are my tables? Where is disk going? | `tables` | [Tables & Storage](/features/tables) |
+| Data Explorer | What columns/dependencies does this table have? | `tables` | [Data Explorer](/features/explorer) |
+| Merges & Operations | Are merges/mutations keeping up? | `operations` | [Merges & Operations](/features/operations) |
+| Clusters & Replication | Is replication lagging? Are replicas healthy? | `cluster` | [Clusters & Replication](/features/cluster) |
+| Metrics & Profiler | What are the server's CPU/memory/IO metrics? | `metrics` | [Metrics & Profiler](/features/metrics) |
+| Insights | What patterns or anomalies does the AI surface? | `insights` | [Insights](/features/insights) |
+| Health & Alerting | Are there active alerts? | `health` | [Health & Alerting](/features/health) |
+| Security & Audit | Who is accessing ClickHouse and how? | `security` | [Security & Audit](/features/security) |
+| Logs | What did the server log? | `logs` | [Logs](/features/logs) |
+| Dashboard | Custom pinned metrics view | `dashboard` | [Dashboard](/features/dashboard) |
+| AI Agent | Natural language questions about my cluster | `agent` | [AI Agent](/ai-agent) |
+| MCP Server | ClickHouse monitoring tools for AI clients | `mcp` | [MCP Server](/features/mcp) |
+| PeerDB | PeerDB replication pipeline status | `peerdb` | [PeerDB](/features/peerdb) |
+| Browser Connections | Personal ad-hoc connections stored in the browser | — | [Browser Connections](/features/browser-connections) |
 | Actions | Row-level actions across data pages (kill query, optimize, etc.) | `actions` | — |
-| Settings | In-app settings and configuration | `settings` | [Settings](/docs/settings) |
-| Authentication | Who can sign in and what each visitor may access | — | [Authentication](/docs/authentication) |
+| Settings | In-app settings and configuration | `settings` | [Settings](/settings) |
+| Authentication | Who can sign in and what each visitor may access | — | [Authentication](/authentication) |
 
 ## Controlling features
 
@@ -63,4 +130,4 @@ access = "authenticated"
 enabled = false
 ```
 
-See [Feature Permissions](/docs/advanced/feature-permissions) for the full reference.
+See [Feature Permissions](/advanced/feature-permissions) for the full reference.

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -1,14 +1,24 @@
 # Getting Started
 
-The fastest path: run chmonitor against an existing ClickHouse instance using Docker. You need three environment variables and one command.
+The fastest path: run chmonitor against an existing ClickHouse instance. You need three environment variables and one command.
 
 ## Prerequisites
 
 - A running ClickHouse instance reachable from where you deploy.
-- A ClickHouse user with `SELECT` on `system.*` (see [ClickHouse user & grants](/docs/getting-started/clickhouse-requirements)).
-- Docker installed locally.
+- A ClickHouse user with `SELECT` on `system.*` — see [ClickHouse user & grants](/getting-started/clickhouse-requirements).
+- Docker installed locally (for the Docker path below).
 
-## Run with Docker
+## Quick start
+
+<Tabs items={["Docker", "From source"]}>
+
+<Tab value="Docker">
+
+<Steps>
+
+<Step>
+
+### Pull and run
 
 Replace `vX.Y.Z` with a real release tag from [GitHub releases](https://github.com/duyet/clickhouse-monitoring/releases):
 
@@ -22,25 +32,117 @@ docker run -d \
   ghcr.io/duyet/chmonitor:vX.Y.Z
 ```
 
-Open [http://localhost:3000](http://localhost:3000).
+<Callout type="info" title="Docker host networking">
+If ClickHouse runs on the same Docker host, use the host gateway address instead of `localhost`. On Linux that is typically `172.17.0.1`; on Mac/Windows use `host.docker.internal`.
+</Callout>
 
-> **Note:** If ClickHouse runs on the same Docker host, use the host gateway address instead of `localhost`. On Linux that is typically `172.17.0.1`; on Mac/Windows use `host.docker.internal`.
+</Step>
 
-## Verify it works
+<Step>
 
-The overview page loads immediately. If pages are empty or show errors:
+### Open the dashboard
+
+Navigate to [http://localhost:3000](http://localhost:3000). The overview page loads immediately.
+
+</Step>
+
+<Step>
+
+### Verify it works
+
+If pages are empty or show errors:
 
 1. Check the container logs: `docker logs chmonitor`
 2. Confirm the ClickHouse user can query `system.query_log` directly.
-3. See [Enable system tables](/docs/getting-started/clickhouse-enable-system-tables) if some tables are missing.
+3. See [Enable system tables](/getting-started/clickhouse-enable-system-tables) if some tables are missing.
+
+</Step>
+
+</Steps>
+
+</Tab>
+
+<Tab value="From source">
+
+<Steps>
+
+<Step>
+
+### Clone and install
+
+```bash
+git clone https://github.com/duyet/clickhouse-monitoring
+cd clickhouse-monitoring
+bun install
+```
+
+</Step>
+
+<Step>
+
+### Configure environment
+
+Copy `.env.example` to `.env.local` and fill in your ClickHouse connection:
+
+```bash
+CLICKHOUSE_HOST=http://your-clickhouse-host:8123
+CLICKHOUSE_USER=monitoring
+CLICKHOUSE_PASSWORD=your-password
+```
+
+</Step>
+
+<Step>
+
+### Start the dev server
+
+```bash
+bun run dev
+```
+
+Open [http://localhost:3001](http://localhost:3001).
+
+</Step>
+
+</Steps>
+
+See the [Local development guide](/getting-started/local) for the complete setup including testing and building.
+
+</Tab>
+
+</Tabs>
 
 ## Next steps
 
-| Task | Guide |
-|---|---|
-| Create a safe read-only monitoring user | [ClickHouse user & grants](/docs/getting-started/clickhouse-requirements) |
-| Enable system log tables for full feature coverage | [Enable system tables](/docs/getting-started/clickhouse-enable-system-tables) |
-| Deploy to Kubernetes, Cloudflare, or Vercel | [Install & Configure](/docs/deploy) |
-| Require login before accessing the dashboard | [Authentication](/docs/authentication) |
-| Set up the AI agent | [AI Agent](/docs/ai-agent) |
-| Develop locally from source | [Local development](/docs/getting-started/local) |
+<Cards>
+  <Card
+    title="ClickHouse user & grants"
+    href="/getting-started/clickhouse-requirements"
+    description="Create a safe read-only monitoring user with the minimal grants needed."
+  />
+  <Card
+    title="Enable system tables"
+    href="/getting-started/clickhouse-enable-system-tables"
+    description="Enable system log tables for full feature coverage."
+  />
+  <Card
+    title="Install & Configure"
+    href="/deploy"
+    description="Deploy to Kubernetes, Cloudflare Workers, or another platform."
+  />
+  <Card
+    title="Authentication"
+    href="/authentication"
+    description="Require login before accessing the dashboard."
+  />
+  <Card
+    title="AI Agent"
+    href="/ai-agent"
+    description="Set up natural-language queries about your cluster."
+  />
+  <Card
+    title="Local development"
+    href="/getting-started/local"
+    description="Develop from source with hot reload."
+  />
+</Cards>

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -4,23 +4,47 @@ chmonitor is a client-rendered ClickHouse monitoring dashboard. The core dashboa
 
 It also ships an AI agent that can answer natural-language questions about your cluster, and an MCP server that exposes monitoring tools to external AI clients.
 
+<Callout type="info" title="Read-only by default">
+chmonitor does not manage schema, run DDL, or modify ClickHouse configuration. Optional action grants (kill query, optimize table) are off by default.
+</Callout>
+
 ## Who it's for
 
 - **Self-hosting teams** who run ClickHouse on their own infrastructure and need an operational dashboard they can deploy and own.
 - **Operators** who want to inspect running queries, track storage growth, monitor replication lag, or debug merge performance without writing ad-hoc queries by hand.
 - **Platform engineers** who want to integrate ClickHouse monitoring into their existing auth and deployment stack (Docker, Kubernetes, Cloudflare Workers).
 
-## What it is not
-
-chmonitor is read-only by default. It does not manage schema, run DDL, or modify ClickHouse configuration. Optional action grants (kill query, optimize table) are off by default.
-
 ## Pick your path
 
-| I want to… | Start here |
-|---|---|
-| Get a dashboard running in 5 minutes | [Getting Started](/docs/getting-started) |
-| Install on Docker, Kubernetes, or Cloudflare | [Install & Configure](/docs/deploy) |
-| Add authentication | [Authentication](/docs/authentication) |
-| Understand what pages do what | [Features](/docs/features) |
-| Set up the AI agent | [AI Agent](/docs/ai-agent) |
-| See all environment variables | [Reference](/docs/reference/environment-variables) |
+<Cards>
+  <Card
+    title="Getting Started"
+    href="/getting-started"
+    description="Get a monitoring dashboard running in 5 minutes with Docker."
+  />
+  <Card
+    title="Install & Configure"
+    href="/deploy"
+    description="Deploy on Docker, Kubernetes, Cloudflare Workers, or Vercel."
+  />
+  <Card
+    title="Features"
+    href="/features"
+    description="Understand what each dashboard page does and its feature id."
+  />
+  <Card
+    title="Authentication"
+    href="/authentication"
+    description="Add login and fine-grained access control."
+  />
+  <Card
+    title="AI Agent"
+    href="/ai-agent"
+    description="Ask natural-language questions about your ClickHouse cluster."
+  />
+  <Card
+    title="Reference"
+    href="/reference/environment-variables"
+    description="Every environment variable, grouped by category."
+  />
+</Cards>


### PR DESCRIPTION
## Summary

- **Reorg**: Improved sidebar order with logical groupings (orientation → deployment → features → auth → AI → advanced → reference → meta) and added explicit per-section page ordering for all 10 sections via `SECTION_PAGE_ORDER` in `sync-docs.mjs`
- **MDX components**: Registered `Tab/Tabs`, `Step/Steps`, `Accordion/Accordions` in `getMDXComponents` so they're globally available in all MDX pages
- **Cards on landing pages**: `index.mdx`, `getting-started.mdx`, `deploy.mdx`, `features.mdx`, `authentication.mdx`, `ai-agent.mdx` — all use `<Cards>/<Card>` to link child pages with descriptions
- **Callouts**: Added `<Callout>` for key notes (`info`) and security warnings (`warn`) across landing pages
- **Steps + Tabs**: `getting-started.mdx` wraps the quick-start flow in `<Tabs items={["Docker","From source"]}>` with nested `<Steps>/<Step>` for each path
- **Accordions**: `faq.mdx` converted from bold-question/paragraph format to `<Accordions type="multiple"><Accordion>` groups organized by topic
- **TOC**: Already enabled via `<DocsPage toc={toc}>` — verified renders correctly
- **Nav links**: Added "Getting Started" and "Releases" links alongside existing Dashboard link; retained logo from merged docs-logo PR

## Test plan

- [x] `bun run sync` — 68 pages generated, all meta.json files verified
- [x] `bun run build` — passes, 658/2288 modules transformed, no errors
- [x] `bun run types:check` — fumadocs-mdx + tsc --noEmit, zero errors
- [x] Generated content verified: Cards, Steps, Tabs, Accordions, Callouts all render in generated `.md` files
- [x] Rebased on latest main (picked up the docs-logo PR change to `layout.shared.tsx`)
- [x] No `apps/docs/src/lib/source.ts` or `og/**` files touched

https://claude.ai/code/session_01TnsycTkdMHJ4DXohpuz3oj