### PR TITLE
feat(docs): version switcher as dropdown menu

### DIFF
--- a/apps/docs/src/components/version-switcher.tsx
+++ b/apps/docs/src/components/version-switcher.tsx
@@ -1,19 +1,47 @@
-import { ChevronDown } from 'lucide-react'
+import { Check, ChevronDown } from 'lucide-react'
 
-import { docsVersion } from '@/lib/shared'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from 'fumadocs-ui/components/ui/popover'
+import { docsVersion, docsVersions } from '@/lib/shared'
 
-// Compact version indicator shown in the nav. Links to the release notes.
-// When a second docs version is cut, this can grow into a dropdown switcher;
-// for now it surfaces the current version and routes to the changelog.
+// Version switcher shown in the nav. A dropdown listing the published docs
+// versions; each entry links to that version's release notes. The current
+// version is marked with a check. Driven by `docsVersions` in lib/shared.
 export function VersionSwitcher() {
   return (
-    <a
-      href="/releases"
-      className="inline-flex items-center gap-1 rounded-full border bg-fd-secondary/50 px-2.5 py-0.5 text-xs font-medium text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
-      aria-label={`Documentation version ${docsVersion} — view release notes`}
-    >
-      {docsVersion}
-      <ChevronDown className="size-3 opacity-60" />
-    </a>
+    <Popover>
+      <PopoverTrigger
+        className="group inline-flex items-center gap-1 rounded-full border bg-fd-secondary/50 px-2.5 py-0.5 text-xs font-medium text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground data-[state=open]:bg-fd-accent data-[state=open]:text-fd-accent-foreground"
+        aria-label={`Documentation version ${docsVersion} — switch version`}
+      >
+        {docsVersion}
+        <ChevronDown className="size-3 opacity-60 transition-transform group-data-[state=open]:rotate-180" />
+      </PopoverTrigger>
+      <PopoverContent align="end" className="flex w-40 flex-col p-1">
+        {docsVersions.map((version) => (
+          <a
+            key={version.label}
+            href={version.href}
+            className={`flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground ${
+              version.current
+                ? 'text-fd-foreground'
+                : 'text-fd-muted-foreground'
+            }`}
+          >
+            {version.label}
+            {version.current ? <Check className="size-3.5" /> : null}
+          </a>
+        ))}
+        <a
+          href="/releases"
+          className="mt-1 border-t pt-1.5 px-2 py-1.5 text-xs text-fd-muted-foreground transition-colors hover:text-fd-accent-foreground"
+        >
+          All releases →
+        </a>
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/apps/docs/src/lib/shared.ts
+++ b/apps/docs/src/lib/shared.ts
@@ -6,6 +6,19 @@ export const appName = 'chmonitor'
 // version switcher. Bump this when a new docs version is cut.
 export const docsVersion = 'v0.3'
 
+// Published documentation versions, newest first. Drives the version-switcher
+// dropdown in the nav. Add an entry (and flip `current`) when a new version is
+// cut; `href` points at that version's release notes.
+export interface DocsVersionEntry {
+  label: string
+  href: string
+  current?: boolean
+}
+
+export const docsVersions: DocsVersionEntry[] = [
+  { label: 'v0.3', href: '/releases/v0-3', current: true },
+]
+
 // Docs are served at the site root (docs.chmonitor.dev/).
 // Empty string means the base URL for doc pages is '/'.
 export const docsRoute = ''


### PR DESCRIPTION
## What

Turn the docs nav version indicator (`v0.3`) into a real **dropdown menu** instead of a plain pill linking to `/releases`.

- New `docsVersions` array in `apps/docs/src/lib/shared.ts` is the single source of truth for published versions (newest first, with a `current` flag).
- `VersionSwitcher` now renders a Fumadocs `Popover` (Radix under the hood, themed with `fd-*` tokens):
  - Each version links to its release notes; the current one is marked with a check.
  - An "All releases →" footer links to `/releases`.
  - Chevron rotates on open.
- Adding a future version (e.g. `v0.4`) is a one-line data edit.

## Verify

- `bun run build` ✅
- `tsc --noEmit` (via `types:check`) ✅
- `biome check` on changed files ✅
- No runtime console errors

Note: the dev-server browser preview renders only the un-hydrated static shell in this harness (affects untouched pages too), so visual confirmation relies on the green build + type check + library-standard Popover usage.

https://claude.ai/code/session_01TnsycTkdMHJ4DXohpuz3oj

## Summary by Sourcery

Implement a dropdown-based documentation version switcher in the nav driven by a shared versions list.

New Features:
- Add a nav version switcher popover listing published documentation versions and linking to their release notes.

Enhancements:
- Introduce a centralized docsVersions configuration in shared lib as the single source of truth for published documentation versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded the docs version selector to a dropdown, making it easier to switch between published documentation versions.
  * Added a visible list of available docs releases, with the current version clearly marked.
  * Included a direct link to the full releases page from the version menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->