### PR TITLE
feat(docs): sidebar layout tabs as a dropdown

### DIFF
--- a/apps/docs/scripts/sync-docs.mjs
+++ b/apps/docs/scripts/sync-docs.mjs
@@ -53,6 +53,21 @@ const ROOT_ORDER = [
   'settings',
 ]
 
+// Sections promoted to Fumadocs "Layout Tabs" — root folders rendered as a
+// dropdown at the top of the sidebar (tabMode: 'auto'). Only the active tab's
+// pages show in the sidebar tree. Each entry maps 1:1 to an existing top-level
+// folder, so page URLs are unchanged. Trim/extend to change the dropdown set.
+const ROOT_TAB_SECTIONS = new Set([
+  'getting-started',
+  'features',
+  'ai-agent',
+  'deploy',
+  'authentication',
+  'advanced',
+  'reference',
+  'releases',
+])
+
 // Display title + sidebar icon (Lucide name, resolved by lucideIconsPlugin in
 // src/lib/source.ts) for each section folder. We set both explicitly so the
 // tree reads cleanly — e.g. "AI Agent" not "Ai Agent".
@@ -298,7 +313,12 @@ async function main() {
     const sectionDir = join(DEST_DIR, slug)
     if (existsSync(sectionDir)) {
       const pages = SECTION_PAGE_ORDER[slug]
-      const meta = { title, icon, defaultOpen: false }
+      const isRootTab = ROOT_TAB_SECTIONS.has(slug)
+      // Root tabs render as a sidebar dropdown (Fumadocs Layout Tabs). They are
+      // pulled out of the main tree, so `defaultOpen` is irrelevant for them.
+      const meta = isRootTab
+        ? { title, icon, root: true }
+        : { title, icon, defaultOpen: false }
       if (pages) meta.pages = pages
       await writeFile(
         join(sectionDir, 'meta.json'),

--- a/apps/docs/src/routes/$.tsx
+++ b/apps/docs/src/routes/$.tsx
@@ -75,6 +75,9 @@ function Page() {
     <DocsLayout
       {...baseOptions()}
       tree={pageTree}
+      // Root folders (meta.json `root: true`) render as a sidebar dropdown
+      // (Fumadocs Layout Tabs); only the active tab's pages show in the tree.
+      tabMode="auto"
       sidebar={{ footer: <SidebarFooter /> }}
     >
       <Suspense>


### PR DESCRIPTION
## What

Implement Fumadocs **Layout Tabs (Dropdown)** for the docs sidebar, per [the DocsLayout docs](https://fumadocs.dev/docs/ui/layouts/docs).

The main content sections become **root folders**, which Fumadocs renders as a dropdown at the top of the sidebar (`tabMode: 'auto'`). Only the active tab's pages show in the tree — decluttering the sidebar for a docs set this size.

**Tabs:** Getting Started · Features · AI Agent · Deployment · Authentication · Advanced · Reference · Releases

## How

- `apps/docs/scripts/sync-docs.mjs`: new `ROOT_TAB_SECTIONS` set writes `root: true` into each section's generated `meta.json`. Sections map **1:1 to existing folders, so all page URLs are unchanged**. Non-tab items (migrating, faq, settings, home) stay in the default tree.
- `apps/docs/src/routes/$.tsx`: set `tabMode="auto"` on `DocsLayout` explicitly (the dropdown variant; the default, made explicit).

To change which sections appear in the dropdown, edit the one `ROOT_TAB_SECTIONS` set.

## Verify

- `bun run build` ✅ · `tsc --noEmit` ✅
- Generated `meta.json` confirmed to carry `root: true` for each tab section.
- Mechanism confirmed against installed Fumadocs source: `getLayoutTabs` collects `root` folders; sidebar renders `SidebarTabsDropdown` when `tabs.length > 0 && tabMode === 'auto'`.

Note: live screenshot not captured — the browser harness fails to hydrate any docs page in this environment (reproduced on untouched pages), so verification rests on the green build/types + source-confirmed contract.

https://claude.ai/code/session_01TnsycTkdMHJ4DXohpuz3oj

## Summary by Sourcery

Promote selected top-level docs sections to Fumadocs layout tabs rendered as a dropdown in the sidebar and wire the docs app layout to use tab-based navigation.

New Features:
- Introduce a configurable set of root sections that render as Fumadocs layout tabs in the docs sidebar dropdown.
- Enable docs layout tab mode in the docs app so only the active tab’s pages appear in the sidebar tree.

Enhancements:
- Adjust docs sync script to mark chosen sections as root folders in generated metadata without changing existing URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selected top-level docs sections now appear as sidebar tabs/dropdowns instead of always showing in the expanded navigation tree.
  * Docs navigation now automatically shows only the pages for the active tab, making the sidebar easier to scan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->