### PR TITLE
fix(docs): restore Deploy & Operate tab (add tab landings)

### DIFF
--- a/apps/docs/scripts/sync-docs.mjs
+++ b/apps/docs/scripts/sync-docs.mjs
@@ -105,7 +105,7 @@ const FOLDER_META = {
     title: 'Deploy & Operate',
     icon: 'Ship',
     root: true,
-    pages: ['deploy', 'authentication', 'advanced'],
+    pages: ['index', 'deploy', 'authentication', 'advanced'],
   },
   'operate/deploy': {
     title: 'Deployment',
@@ -156,6 +156,7 @@ const FOLDER_META = {
     icon: 'BookMarked',
     root: true,
     pages: [
+      'index',
       'environment-variables',
       'configuration',
       'connection-presets',

--- a/docs/content/operate/index.mdx
+++ b/docs/content/operate/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Deploy & Operate
+description: Ship chmonitor to production, secure it, and tune advanced behaviour.
+---
+
+# Deploy & Operate
+
+Everything you need to run chmonitor in production — from the first deploy to
+authentication and advanced configuration.
+
+## Deployment
+
+Pick a target and ship: Docker, Kubernetes, Cloudflare Workers, Vercel, or a
+self-hosted Node server. See [Deployment](/operate/deploy) for the full matrix
+and a [production checklist](/operate/deploy/production-checklist).
+
+## Authentication
+
+chmonitor ships open by default and layers in auth when you need it — API keys,
+Clerk, Cloudflare Access, or a trusted reverse proxy. Start at
+[Authentication](/operate/authentication).
+
+## Advanced
+
+Multi-host setups, feature permissions, editions, self-tracking, telemetry, and
+other operational knobs live under [Advanced](/operate/advanced).

--- a/docs/content/reference/index.mdx
+++ b/docs/content/reference/index.mdx
@@ -1,0 +1,28 @@
+---
+title: Reference
+description: Configuration reference, MCP, integrations, releases, and project info.
+---
+
+# Reference
+
+Look up the details: environment variables, configuration files, the MCP server
+and clients, integrations, and release history.
+
+## Configuration
+
+Every setting chmonitor reads — see
+[Environment Variables](/reference/environment-variables),
+[Configuration](/reference/configuration), and
+[Connection Presets](/reference/connection-presets). The
+[Support Matrix](/reference/support-matrix) lists ClickHouse version coverage.
+
+## MCP
+
+Expose chmonitor to AI tools over the Model Context Protocol:
+[MCP Server](/reference/mcp-server) and [MCP Clients](/reference/mcp-clients).
+
+## Integrations & project
+
+[Grafana bridge](/reference/grafana-bridge),
+[catalog contributing](/reference/catalog-contributing),
+[releases](/reference/releases), and [migrating](/reference/migrating).


### PR DESCRIPTION
## Bug

After the 3-tab restructure (#1985), the live dropdown showed only **2 tabs** — Guide and Reference. **Deploy & Operate was missing.**

## Root cause

Fumadocs `getLayoutTabs` derives a tab's URL as `node.index?.url ?? node.children.find(n => n.type === 'page')?.url`. The `operate/` folder had **no index page and no direct page children** (only sub-folders: deploy, authentication, advanced), so its URL resolved to `undefined` and the tab was filtered out. Guide survived via its `index.mdx`; Reference via its direct pages.

## Fix

- Add `operate/index.mdx` — a "Deploy & Operate" landing linking to the three sub-sections.
- Add `reference/index.mdx` too, so the bare `/reference` URL has a landing (it previously had none).
- List `index` first in each tab's page order in `sync-docs.mjs`.

All three tabs now resolve a URL and render in the dropdown.

## Verify

- `bun run build` ✅ · `tsc` ✅ · both landings generated.
- Will confirm all 3 tabs in the live dropdown after deploy.

Found via live verification of #1985 (the dev server doesn't hydrate in the review harness, so this only surfaced on production).

https://claude.ai/code/session_01TnsycTkdMHJ4DXohpuz3oj

## Summary by Sourcery

Restore the Deploy & Operate and Reference top-level documentation tabs by adding landing pages and updating tab page ordering.

New Features:
- Add a Deploy & Operate landing page that links to deployment, authentication, and advanced operations docs.
- Add a Reference landing page that links to configuration, MCP, integrations, and project information sections.

Enhancements:
- Update docs sync configuration to prioritize new index pages in the Deploy & Operate and Reference tab page ordering.