### PR TITLE
fix(ci): pin rust-toolchain to real 1.94.0 (revert bogus 1.100.0)

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -105,7 +105,11 @@ jobs:
 
       - name: Setup Rust
         if: ${{ inputs.job-type == 'build' }}
-        uses: dtolnay/rust-toolchain@1.100.0
+        # NOTE: dtolnay/rust-toolchain uses its @ref AS the toolchain version
+        # (its tags are toolchain names, not action releases). Rust 1.100.0 does
+        # not exist; #1898's grouped bump to @1.100.0 404'd the Setup Rust step.
+        # Keep this pinned to a real, released stable toolchain.
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Download pre-built WASM
         if: ${{ inputs.skip-rust }}


### PR DESCRIPTION
## Problem

The **Image build and Push** workflow has been failing on `main` since #1898:

```
error: could not download nonexistent rust version `1.100.0-x86_64-unknown-linux-gnu`:
http request returned an unsuccessful status code: 404
```

## Root cause

#1898 (grouped github-actions bump) changed the Setup Rust step in `base.yml`:

```diff
- uses: dtolnay/rust-toolchain@1.94.0
+ uses: dtolnay/rust-toolchain@1.100.0
```

`dtolnay/rust-toolchain` is special: **its `@ref` IS the Rust toolchain version** (its git tags are toolchain names like `stable` / `1.94.0`, not action releases). Rust **1.100.0 does not exist**, so the step 404s and the image build fails on every run.

## Fix

Revert to the last-known-good pinned toolchain (`1.94.0`, which built green before #1898) and add a comment documenting the `@ref`-is-the-toolchain gotcha so a future grouped bump does not re-introduce it.

- Only `base.yml` used a pinned ref; the other three workflows use `@stable` (unaffected).
- The exact pin is intentional for reproducible WASM artifacts, so restoring the pin (not switching to `@stable`) is the correct fix.

## Follow-up for owner
Renovate/dependabot does not understand this action and will likely try to bump the ref again. Consider a renovate ignore rule for `dtolnay/rust-toolchain`, or switch `base.yml` to `@stable` to match the other workflows.

Co-Authored-By: duyetbot <bot@duyet.net>

https://claude.ai/code/session_01CEo32qJvyNDbn6XudnXuQ8

## Summary by Sourcery

Pin the CI base workflow Rust toolchain back to a valid released version to restore image build jobs.

Bug Fixes:
- Fix failing image build workflow by reverting the dtolnay/rust-toolchain reference from nonexistent 1.100.0 to released 1.94.0.

CI:
- Document the special behavior of dtolnay/rust-toolchain refs in the base workflow to prevent future automated bumps from breaking builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI setup to use a supported Rust toolchain version.
  * Improved workflow reliability by pinning to a released stable Rust version and adding clarification notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->