### PR TITLE
feat(insights): show created date on insight card

### DIFF
--- a/apps/dashboard/src/components/insights/insight-card.tsx
+++ b/apps/dashboard/src/components/insights/insight-card.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { buildUrl } from '@/lib/url/url-builder'
 import { cn } from '@/lib/utils'
+import { formatRelativeTime } from '@/lib/utils/format-relative-time'
 
 interface SeverityStyle {
   icon: LucideIcon
@@ -64,6 +65,11 @@ export function InsightCard({
   const style = SEVERITY[insight.severity]
   const Icon = style.icon
 
+  const generatedMs = insight.generatedAt
+    ? new Date(insight.generatedAt).getTime()
+    : Number.NaN
+  const hasGeneratedAt = Number.isFinite(generatedMs)
+
   const action = insight.action
   const actionHref = action?.href
     ? buildUrl(action.href, { host: hostId })
@@ -102,12 +108,23 @@ export function InsightCard({
       </p>
 
       <div className="mt-3 flex items-center justify-between gap-2">
-        <Badge
-          variant="outline"
-          className={cn('text-[10px] font-medium', style.badge)}
-        >
-          {style.badgeLabel}
-        </Badge>
+        <div className="flex min-w-0 items-center gap-2">
+          <Badge
+            variant="outline"
+            className={cn('text-[10px] font-medium', style.badge)}
+          >
+            {style.badgeLabel}
+          </Badge>
+          {hasGeneratedAt ? (
+            <time
+              dateTime={insight.generatedAt}
+              title={new Date(generatedMs).toLocaleString()}
+              className="truncate text-[10px] text-muted-foreground/70"
+            >
+              {formatRelativeTime(generatedMs)}
+            </time>
+          ) : null}
+        </div>
         {action && actionHref ? (
           <Button
             asChild


### PR DESCRIPTION
## What

Show the relative creation time (e.g. **"12h ago"**) on each AI insight card in the overview panel, next to the severity badge.

## Why

The Insights cards gave no sense of freshness — you couldn't tell whether an insight was generated minutes ago or days ago. This surfaces the age inline.

## How

- The `generatedAt` ISO timestamp is **already served** end-to-end: stamped in `generate-insights.ts`, mapped from the store's `event_time` in `read-insights.ts`, and exposed on the `InsightCard` type. This was a pure display gap.
- Reuse the existing `lib/utils/format-relative-time.ts` util (Unix-ms → "12h ago" / "3d ago" / short date). No new deps.
- Render as a semantic `<time dateTime>` element with a `title` tooltip showing the full local timestamp on hover.
- Guards against a missing/invalid `generatedAt` (renders nothing in that case).

Single-file, presentation-only change in `components/insights/insight-card.tsx`.

## Test

- `biome check` clean on the changed file.
- Type-check clean for the changed file (pre-existing unrelated `ai`-SDK/route-tree noise in the cold local checkout is resolved by CI's post-build type-check).

https://claude.ai/code/session_01CEo32qJvyNDbn6XudnXuQ8

## Summary by Sourcery

New Features:
- Show relative creation time for each insight card alongside the severity badge, with a tooltip revealing the full local timestamp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Insight cards now show an optional “generated at” timestamp next to the severity badge.
  * The timestamp is displayed in a relative format for easier scanning, with a tooltip showing the full date and time on hover.
  * Time information only appears when a valid value is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->