### PR TITLE
feat(site): docs homepage overview + landing polish

### DIFF
--- a/apps/docs/src/routes/index.tsx
+++ b/apps/docs/src/routes/index.tsx
@@ -1,11 +1,16 @@
+import type { LucideIcon } from 'lucide-react'
 import {
   ArrowRight,
+  BookOpen,
   Bot,
-  Boxes,
   Database,
-  Gauge,
+  FileText,
   Github,
+  LifeBuoy,
   Plug,
+  Rocket,
+  Server,
+  Settings,
   ShieldCheck,
 } from 'lucide-react'
 import { createFileRoute } from '@tanstack/react-router'
@@ -18,179 +23,259 @@ export const Route = createFileRoute('/')({
   component: HomePage,
 })
 
-const FEATURES = [
+interface DocLink {
+  title: string
+  href: string
+  desc: string
+}
+
+interface DocSection {
+  icon: LucideIcon
+  name: string
+  href: string
+  tagline: string
+  links: DocLink[]
+}
+
+const SECTIONS: DocSection[] = [
   {
-    icon: Gauge,
-    title: 'Real-time monitoring',
-    body: 'Live queries, memory, disk, and CPU read straight from system.* tables — no agents, no extra storage.',
+    icon: BookOpen,
+    name: 'Guide',
+    href: '/guide',
+    tagline: 'Install chmonitor, connect a cluster, and learn each feature.',
+    links: [
+      {
+        title: 'Getting started',
+        href: '/guide/getting-started',
+        desc: 'Run the dashboard against your first ClickHouse host.',
+      },
+      {
+        title: 'Features',
+        href: '/guide/features',
+        desc: 'Overview, queries, tables, cluster, explorer, and more.',
+      },
+      {
+        title: 'AI agent',
+        href: '/guide/ai-agent',
+        desc: 'Ask natural-language questions grounded in live data.',
+      },
+      {
+        title: 'Guides',
+        href: '/guide/guides/troubleshooting',
+        desc: 'Proxy auth, upgrades, and troubleshooting walkthroughs.',
+      },
+    ],
   },
   {
-    icon: Database,
-    title: 'Tables & storage',
-    body: 'Track table sizes, parts, compression, and disk growth across every database.',
+    icon: Server,
+    name: 'Operate',
+    href: '/operate',
+    tagline: 'Deploy, secure, and tune chmonitor for production.',
+    links: [
+      {
+        title: 'Deploy',
+        href: '/operate/deploy',
+        desc: 'Docker, Kubernetes, Cloudflare Workers, Vercel, Traefik.',
+      },
+      {
+        title: 'Authentication',
+        href: '/operate/authentication',
+        desc: 'Public, Clerk, Cloudflare Access, or trusted-header.',
+      },
+      {
+        title: 'Multiple hosts',
+        href: '/operate/advanced/multiple-hosts',
+        desc: 'Monitor several clusters from one deployment.',
+      },
+      {
+        title: 'Feature permissions',
+        href: '/operate/advanced/feature-permissions',
+        desc: 'Per-feature access control and editions.',
+      },
+    ],
   },
   {
-    icon: Boxes,
-    title: 'Cluster & replication',
-    body: 'Replication lag, queue depth, and replica health across every host in the cluster.',
+    icon: FileText,
+    name: 'Reference',
+    href: '/reference',
+    tagline: 'Configuration, APIs, integrations, and release history.',
+    links: [
+      {
+        title: 'Configuration',
+        href: '/reference/configuration',
+        desc: 'Every setting that shapes the dashboard.',
+      },
+      {
+        title: 'Environment variables',
+        href: '/reference/environment-variables',
+        desc: 'The full list of supported env vars.',
+      },
+      {
+        title: 'MCP server',
+        href: '/reference/mcp-server',
+        desc: 'Expose monitoring tools to MCP-compatible clients.',
+      },
+      {
+        title: 'Migrating to v0.3',
+        href: '/reference/migrating/v0-3',
+        desc: 'Upgrade notes from the Next.js-era app.',
+      },
+    ],
   },
-  {
-    icon: Bot,
-    title: 'AI agent',
-    body: 'Ask natural-language questions about your cluster and get answers grounded in live data.',
-  },
-  {
-    icon: Plug,
-    title: 'MCP server',
-    body: 'Expose monitoring tools to Claude, Cursor, and any MCP-compatible AI client.',
-  },
-  {
-    icon: ShieldCheck,
-    title: 'Pluggable auth',
-    body: 'Public, Clerk, Cloudflare Access, or trusted-header — with per-feature access control.',
-  },
+]
+
+const HIGHLIGHTS = [
+  { icon: Database, label: 'Reads system.* tables — no agents' },
+  { icon: Bot, label: 'Built-in AI agent' },
+  { icon: Plug, label: 'MCP server' },
+  { icon: ShieldCheck, label: 'Pluggable auth' },
 ]
 
 function HomePage() {
   return (
     <HomeLayout {...baseOptions()}>
-      <main className="flex flex-1 flex-col">
-        <Hero />
-        <FeatureGrid />
-        <ClosingCta />
+      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-14 sm:py-20">
+        <Intro />
+        <SectionGrid />
+        <HelpRow />
       </main>
     </HomeLayout>
   )
 }
 
-function Hero() {
+function Intro() {
   return (
-    <section className="relative overflow-hidden border-b">
-      {/* Visual art: layered radial glow + grid, in the fumadocs.dev spirit. */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_50%_-20%,var(--color-fd-primary)/18%,transparent_55%)]"
-      />
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 -z-10 [mask-image:radial-gradient(circle_at_50%_0%,black,transparent_70%)] bg-[linear-gradient(to_right,var(--color-fd-border)_1px,transparent_1px),linear-gradient(to_bottom,var(--color-fd-border)_1px,transparent_1px)] bg-[size:36px_36px] opacity-40"
-      />
-      <div className="mx-auto flex max-w-4xl flex-col items-center px-4 py-24 text-center sm:py-32">
-        <span className="mb-5 inline-flex items-center gap-2 rounded-full border bg-fd-secondary/40 px-3 py-1 text-xs font-medium text-fd-muted-foreground">
-          Open source · self-hostable · read-only by default
-        </span>
-        <h1 className="bg-gradient-to-b from-fd-foreground to-fd-foreground/70 bg-clip-text text-4xl font-bold tracking-tight text-transparent sm:text-6xl">
-          Monitor ClickHouse,
-          <br className="hidden sm:block" /> without the guesswork.
-        </h1>
-        <p className="mt-6 max-w-2xl text-balance text-lg text-fd-muted-foreground">
-          chmonitor is a client-rendered dashboard for ClickHouse — query
-          performance, storage, cluster health, and an AI agent, all reading
-          live from your <code className="text-fd-foreground">system.*</code>{' '}
-          tables.
-        </p>
-        <div className="mt-9 flex flex-wrap items-center justify-center gap-3">
-          <a
-            href="/guide/getting-started"
-            className="inline-flex items-center gap-2 rounded-lg bg-fd-primary px-5 py-2.5 text-sm font-semibold text-fd-primary-foreground transition-opacity hover:opacity-90"
+    <section className="mb-14 max-w-3xl">
+      <span className="inline-flex items-center gap-2 rounded-full border bg-fd-secondary/40 px-3 py-1 text-xs font-medium text-fd-muted-foreground">
+        Documentation
+      </span>
+      <h1 className="mt-4 text-3xl font-bold tracking-tight sm:text-4xl">
+        chmonitor documentation
+      </h1>
+      <p className="mt-4 text-balance text-lg text-fd-muted-foreground">
+        Everything to install, operate, and extend chmonitor — a read-only
+        ClickHouse dashboard powered by your{' '}
+        <code className="text-fd-foreground">system.*</code> tables. Pick a
+        section below, or jump straight to{' '}
+        <a
+          href="/guide/getting-started"
+          className="font-medium text-fd-primary underline underline-offset-4"
+        >
+          getting started
+        </a>
+        .
+      </p>
+      <div className="mt-6 flex flex-wrap items-center gap-x-5 gap-y-2">
+        {HIGHLIGHTS.map(({ icon: Icon, label }) => (
+          <span
+            key={label}
+            className="inline-flex items-center gap-2 text-sm text-fd-muted-foreground"
           >
-            Get started
-            <ArrowRight className="size-4" />
-          </a>
-          <a
-            href={dashboardUrl}
-            target="_blank"
-            rel="noreferrer noopener"
-            className="inline-flex items-center gap-2 rounded-lg border bg-fd-card px-5 py-2.5 text-sm font-semibold transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
-          >
-            Live demo
-          </a>
-          <a
-            href={`https://github.com/${gitConfig.user}/${gitConfig.repo}`}
-            target="_blank"
-            rel="noreferrer noopener"
-            className="inline-flex items-center gap-2 rounded-lg px-5 py-2.5 text-sm font-semibold text-fd-muted-foreground transition-colors hover:text-fd-foreground"
-          >
-            <Github className="size-4" />
-            Star on GitHub
-          </a>
-        </div>
-        <div className="mt-10 w-full max-w-xl">
-          <div className="overflow-hidden rounded-xl border bg-fd-card text-left shadow-sm">
-            <div className="flex items-center gap-1.5 border-b bg-fd-secondary/30 px-4 py-2.5">
-              <span className="size-2.5 rounded-full bg-red-400/70" />
-              <span className="size-2.5 rounded-full bg-yellow-400/70" />
-              <span className="size-2.5 rounded-full bg-green-400/70" />
-              <span className="ml-2 text-xs text-fd-muted-foreground">
-                docker
-              </span>
-            </div>
-            <pre className="overflow-x-auto px-4 py-4 text-sm leading-relaxed">
-              <code>
-                <span className="text-fd-muted-foreground">
-                  # one command to run the dashboard
-                </span>
-                {'\n'}docker run -p 3000:3000 \{'\n'}
-                {'  '}-e CLICKHOUSE_HOST=https://your-host:8443 \{'\n'}
-                {'  '}chmonitor/chmonitor
-              </code>
-            </pre>
-          </div>
-        </div>
-      </div>
-    </section>
-  )
-}
-
-function FeatureGrid() {
-  return (
-    <section className="mx-auto w-full max-w-6xl px-4 py-20">
-      <div className="mx-auto mb-12 max-w-2xl text-center">
-        <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">
-          Everything you need to operate ClickHouse
-        </h2>
-        <p className="mt-3 text-fd-muted-foreground">
-          One dashboard for queries, storage, replication, and the AI tooling on
-          top of it.
-        </p>
-      </div>
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {FEATURES.map(({ icon: Icon, title, body }) => (
-          <div
-            key={title}
-            className="group rounded-xl border bg-fd-card p-5 transition-colors hover:border-fd-primary/40"
-          >
-            <div className="mb-3 inline-flex rounded-lg border bg-fd-secondary/40 p-2 text-fd-primary">
-              <Icon className="size-5" />
-            </div>
-            <h3 className="font-semibold">{title}</h3>
-            <p className="mt-1.5 text-sm text-fd-muted-foreground">{body}</p>
-          </div>
+            <Icon className="size-4 text-fd-primary" />
+            {label}
+          </span>
         ))}
       </div>
     </section>
   )
 }
 
-function ClosingCta() {
+function SectionGrid() {
   return (
-    <section className="border-t">
-      <div className="mx-auto flex max-w-4xl flex-col items-center px-4 py-20 text-center">
-        <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">
-          Ready in five minutes
-        </h2>
-        <p className="mt-3 max-w-xl text-fd-muted-foreground">
-          Point it at a ClickHouse host and deploy on Docker, Kubernetes,
-          Cloudflare Workers, or Vercel.
-        </p>
-        <a
-          href="/guide/getting-started"
-          className="mt-7 inline-flex items-center gap-2 rounded-lg bg-fd-primary px-5 py-2.5 text-sm font-semibold text-fd-primary-foreground transition-opacity hover:opacity-90"
+    <section className="grid gap-5 lg:grid-cols-3">
+      {SECTIONS.map(({ icon: Icon, name, href, tagline, links }) => (
+        <div
+          key={name}
+          className="flex flex-col rounded-2xl border bg-fd-card p-6 transition-colors hover:border-fd-primary/40"
         >
-          Read the guide
-          <ArrowRight className="size-4" />
+          <a href={href} className="group flex items-center gap-3">
+            <span className="inline-flex rounded-lg border bg-fd-secondary/40 p-2 text-fd-primary">
+              <Icon className="size-5" />
+            </span>
+            <span className="text-lg font-semibold tracking-tight group-hover:text-fd-primary">
+              {name}
+            </span>
+            <ArrowRight className="size-4 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-primary" />
+          </a>
+          <p className="mt-3 text-sm text-fd-muted-foreground">{tagline}</p>
+          <ul className="mt-5 flex flex-col gap-1">
+            {links.map((link) => (
+              <li key={link.href}>
+                <a
+                  href={link.href}
+                  className="group block rounded-lg px-3 py-2 -mx-3 transition-colors hover:bg-fd-accent"
+                >
+                  <span className="flex items-center gap-1.5 text-sm font-medium group-hover:text-fd-accent-foreground">
+                    {link.title}
+                    <ArrowRight className="size-3.5 opacity-0 transition-opacity group-hover:opacity-100" />
+                  </span>
+                  <span className="mt-0.5 block text-xs text-fd-muted-foreground">
+                    {link.desc}
+                  </span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </section>
+  )
+}
+
+function HelpRow() {
+  const repo = `https://github.com/${gitConfig.user}/${gitConfig.repo}`
+  const cards = [
+    {
+      icon: Rocket,
+      title: 'Live demo',
+      desc: 'Open the hosted dashboard.',
+      href: dashboardUrl,
+      external: true,
+    },
+    {
+      icon: LifeBuoy,
+      title: 'Troubleshooting',
+      desc: 'Fixes for common setup issues.',
+      href: '/guide/guides/troubleshooting',
+      external: false,
+    },
+    {
+      icon: Settings,
+      title: 'FAQ',
+      desc: 'Answers to frequent questions.',
+      href: '/reference/faq',
+      external: false,
+    },
+    {
+      icon: Github,
+      title: 'GitHub',
+      desc: 'Source, issues, and discussions.',
+      href: repo,
+      external: true,
+    },
+  ]
+  return (
+    <section className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {cards.map(({ icon: Icon, title, desc, href, external }) => (
+        <a
+          key={title}
+          href={href}
+          {...(external
+            ? { target: '_blank', rel: 'noreferrer noopener' }
+            : {})}
+          className="group flex items-start gap-3 rounded-xl border bg-fd-card p-4 transition-colors hover:border-fd-primary/40"
+        >
+          <span className="inline-flex rounded-lg border bg-fd-secondary/40 p-2 text-fd-primary">
+            <Icon className="size-4" />
+          </span>
+          <span className="flex flex-col">
+            <span className="text-sm font-semibold group-hover:text-fd-primary">
+              {title}
+            </span>
+            <span className="text-xs text-fd-muted-foreground">{desc}</span>
+          </span>
         </a>
-      </div>
+      ))}
     </section>
   )
 }

--- a/apps/landing/src/components/SocialProof.astro
+++ b/apps/landing/src/components/SocialProof.astro
@@ -1,39 +1,8 @@
----
-let stars = '—'
-let forks = '—'
-try {
-  const res = await fetch('https://api.github.com/repos/chmonitor/chmonitor', {
-    headers: { 'Accept': 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28' }
-  })
-  if (res.ok) {
-    const data = await res.json()
-    const fmt = (n: number) => n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k' : String(n)
-    stars = fmt(data.stargazers_count ?? 0)
-    forks = fmt(data.forks_count ?? 0)
-  }
-} catch (_) { /* build-time fetch unavailable — show placeholders */ }
----
 <section class="band band-soft">
   <div class="wrap">
     <div class="sec-head reveal" style="text-align:center">
       <span class="eyebrow">Community</span>
       <h2>Open source, built in public</h2>
-      <p>chmonitor is developed openly on GitHub. Bug reports, feature requests and pull requests are all welcome.</p>
-    </div>
-
-    <div class="stat-grid reveal">
-      <div class="stat">
-        <div class="snum">{stars}</div>
-        <div class="slabel">GitHub stars</div>
-      </div>
-      <div class="stat">
-        <div class="snum">{forks}</div>
-        <div class="slabel">Forks</div>
-      </div>
-      <div class="stat">
-        <div class="snum">GPL-3.0</div>
-        <div class="slabel">Open source license</div>
-      </div>
     </div>
 
     <div class="stat-badges reveal">

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -119,12 +119,12 @@ const ogImage = new URL(image, Astro.site).toString()
     /* ── nav ── */
     header.nav{position:sticky;top:0;z-index:50;background:rgba(255,255,255,.78);
       backdrop-filter:saturate(160%) blur(12px);border-bottom:1px solid var(--border-soft)}
-    .nav-row{display:flex;align-items:center;justify-content:space-between;height:64px}
-    .brand{display:flex;align-items:center;gap:10px;font-weight:650;font-weight:600;font-size:16px;letter-spacing:-.01em}
-    .nav-links{display:flex;align-items:center;gap:30px}
-    .nav-links a{font-size:14px;color:var(--muted-fg);font-weight:500;transition:color .15s}
+    .nav-row{display:flex;align-items:center;justify-content:space-between;gap:28px;height:64px}
+    .brand{display:flex;align-items:center;gap:10px;flex:0 0 auto;font-weight:650;font-weight:600;font-size:16px;letter-spacing:-.01em}
+    .nav-links{display:flex;align-items:center;gap:22px}
+    .nav-links a{font-size:14px;color:var(--muted-fg);font-weight:500;white-space:nowrap;transition:color .15s}
     .nav-links a:hover{color:var(--fg)}
-    .nav-cta{display:flex;align-items:center;gap:10px}
+    .nav-cta{display:flex;align-items:center;gap:10px;flex:0 0 auto}
     .nav-toggle{display:none}
 
     /* ── hero ── */
@@ -339,8 +339,10 @@ const ogImage = new URL(image, Astro.site).toString()
     @media (prefers-reduced-motion:reduce){html.js .reveal{opacity:1;transform:none;transition:none}}
 
     /* ── responsive ── */
-    @media (max-width:880px){
+    @media (max-width:1024px){
       .nav-links{display:none}
+    }
+    @media (max-width:880px){
       .feature,.os{grid-template-columns:1fr;gap:34px}
       .feature.flip .feat-text{order:0}
       .feature + .feature{margin-top:72px}
@@ -356,13 +358,7 @@ const ogImage = new URL(image, Astro.site).toString()
     }
 
     /* ── social proof ── */
-    .stat-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:48px}
-    .stat{padding:28px 24px;border:1px solid var(--border);border-radius:var(--radius);background:#fff;text-align:center;box-shadow:var(--shadow-card)}
-    .stat .snum{font-size:36px;font-weight:700;letter-spacing:-.03em;line-height:1}
-    .stat .slabel{font-size:13.5px;color:var(--muted-fg);margin-top:8px}
-    .stat-badges{display:flex;justify-content:center;align-items:center;gap:10px;margin-top:22px;flex-wrap:wrap}
-    @media (max-width:640px){.stat-grid{grid-template-columns:1fr 1fr}}
-    @media (max-width:400px){.stat-grid{grid-template-columns:1fr}}
+    .stat-badges{display:flex;justify-content:center;align-items:center;gap:10px;margin-top:40px;flex-wrap:wrap}
 
     /* ── pricing ── */
     .pricing-grid{display:grid;grid-template-columns:1fr 1fr;gap:24px;margin-top:52px;align-items:stretch}

--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -28,28 +28,35 @@ function fmtDate(iso: string) {
   return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
 }
 
-// Convert basic GitHub markdown to HTML (just handle bold, code, links, headings, lists)
+// Render the changelog (git history) for a release as a short, image-free list.
+// Keeps only the actual change lines (`*`/`-`), strips images and the
+// "by @user in #PR" / footer noise, and caps each version to a few entries.
+const MAX_ITEMS = 5
 function mdToHtml(md: string): string {
   if (!md) return ''
-  return md
-    .split('\n')
-    .map((line) => {
-      // headings → skip (they're usually "What's Changed" etc)
-      if (/^#{1,3}\s/.test(line)) return ''
-      // list items → keep as-is with bullet
-      const li = line.replace(/^\*\s+/, '').replace(/^-\s+/, '')
-      const isLi = line !== li
-      let out = li
-        // inline code
-        .replace(/`([^`]+)`/g, '<code>$1</code>')
-        // bold
-        .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
-        // links [text](url)
-        .replace(/\[([^\]]+)\]\((https?:[^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>')
-      return isLi ? `<li>${out}</li>` : out ? `<span>${out}</span>` : ''
-    })
-    .filter(Boolean)
-    .join('\n')
+  const items: string[] = []
+  for (const raw of md.split('\n')) {
+    const line = raw.trim()
+    if (!line) continue
+    // Stop at trailing sections (New Contributors, Full Changelog link, etc.)
+    if (/^#{1,6}\s*(new contributors|full changelog)/i.test(line)) break
+    if (/^\*\*full changelog\*\*/i.test(line)) break
+    if (/^#{1,6}\s/.test(line)) continue // skip headings ("What's Changed")
+    const m = line.match(/^[*-]\s+(.*)/)
+    if (!m) continue // only keep list items = the changelog
+    const text = m[1]
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, '') // strip markdown images
+      .replace(/<img[^>]*>/gi, '') // strip raw <img> tags
+      .replace(/\s+by\s+@[\w-]+\s+in\s+\S+/i, '') // drop "by @user in #PR"
+      .replace(/`([^`]+)`/g, '<code>$1</code>')
+      .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+      .replace(/\[([^\]]+)\]\((https?:[^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>')
+      .trim()
+    if (!text) continue
+    items.push(`<li>${text}</li>`)
+    if (items.length >= MAX_ITEMS) break
+  }
+  return items.length ? `<ul>${items.join('')}</ul>` : ''
 }
 ---
 <Base


### PR DESCRIPTION
### Docs (docs.chmonitor.dev)
Homepage was a landing-page clone. Rewrote it as a **documentation overview** — three section panels (Guide / Operate / Reference), each linking to its section landing and key pages, plus a help row (live demo, troubleshooting, FAQ, GitHub). Builds + prerenders `/` clean.

### Landing (chmonitor.dev)
- **Nav fix**: links no longer wrap or overlap the Star button at medium widths — `white-space:nowrap`, tighter gap, row minimum-gap, non-shrinking CTA, hide links < 1024px.
- **Social proof**: removed the stars/forks/GPL stat grid + the "developed openly on GitHub" line (and the now-dead build-time fetch + orphaned CSS).
- **Changelog**: render git-history changelog only — strip images, drop `by @user in #PR` noise + footer sections, cap each version to 5 entries.

Both apps build locally.

Co-Authored-By: duyetbot <bot@duyet.net>