### PR TITLE
feat(docs): stacked version + section dropdowns in sidebar

### DIFF
--- a/apps/docs/src/components/sidebar-nav-header.tsx
+++ b/apps/docs/src/components/sidebar-nav-header.tsx
@@ -1,0 +1,112 @@
+import { Check, ChevronsUpDown } from 'lucide-react'
+
+import { usePathname } from 'fumadocs-core/framework'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from 'fumadocs-ui/components/ui/popover'
+import { useState } from 'react'
+import { docsSections, docsVersion, docsVersions } from '@/lib/shared'
+
+// Matches Fumadocs' SidebarTabsDropdown trigger styling so the two dropdowns
+// look visually consistent with each other and with the rest of the sidebar.
+const triggerCls =
+  'flex w-full items-center gap-2 rounded-lg p-2 border bg-fd-secondary/50 text-start text-fd-secondary-foreground transition-colors hover:bg-fd-accent data-[state=open]:bg-fd-accent data-[state=open]:text-fd-accent-foreground'
+
+// Version dropdown (sidebar variant). Full-width, matches section dropdown style.
+// Drives from docsVersions in lib/shared — add a new entry there when cutting a
+// new version; no changes needed here.
+function SidebarVersionDropdown() {
+  const [open, setOpen] = useState(false)
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        className={triggerCls}
+        aria-label={`Switch documentation version (current: ${docsVersion})`}
+      >
+        <span className="flex-1 text-sm font-medium">{docsVersion}</span>
+        <ChevronsUpDown className="ms-auto size-4 shrink-0 text-fd-muted-foreground" />
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="flex flex-col gap-1 p-1 w-(--radix-popover-trigger-width)"
+      >
+        {docsVersions.map((v) => (
+          <a
+            key={v.label}
+            href={v.href}
+            onClick={() => setOpen(false)}
+            className="flex items-center gap-2 rounded-lg p-1.5 text-sm hover:bg-fd-accent hover:text-fd-accent-foreground"
+          >
+            <span className="flex-1">{v.label}</span>
+            {v.current ? <Check className="size-3.5 text-fd-primary" /> : null}
+          </a>
+        ))}
+        <a
+          href="/reference/releases"
+          onClick={() => setOpen(false)}
+          className="mt-1 border-t pt-1.5 px-1.5 py-1 text-xs text-fd-muted-foreground hover:text-fd-accent-foreground"
+        >
+          All releases →
+        </a>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+// Section dropdown. Reads the current pathname to highlight the active section.
+// Replaces Fumadocs' built-in SidebarTabsDropdown (tabMode="auto") so that the
+// version can appear above it in the sidebar.
+function SidebarSectionDropdown() {
+  const [open, setOpen] = useState(false)
+  const pathname = usePathname()
+  // Find the most-specific matching prefix (longest wins).
+  const active =
+    [...docsSections]
+      .sort((a, b) => b.prefix.length - a.prefix.length)
+      .find((s) => pathname.startsWith(s.prefix)) ?? docsSections[0]
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger className={triggerCls}>
+        <span className="flex-1 text-sm font-medium">{active.title}</span>
+        <ChevronsUpDown className="ms-auto size-4 shrink-0 text-fd-muted-foreground" />
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="flex flex-col gap-1 p-1 w-(--radix-popover-trigger-width)"
+      >
+        {docsSections.map((section) => {
+          const isActive = section.prefix === active.prefix
+          return (
+            <a
+              key={section.url}
+              href={section.url}
+              onClick={() => setOpen(false)}
+              className="flex items-center gap-2 rounded-lg p-1.5 text-sm hover:bg-fd-accent hover:text-fd-accent-foreground"
+            >
+              <span className="flex-1">{section.title}</span>
+              {isActive ? <Check className="size-3.5 text-fd-primary" /> : null}
+            </a>
+          )
+        })}
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+// Two stacked sidebar navigation dropdowns:
+//   1. Version dropdown (top) — switches between published docs versions
+//   2. Section dropdown (below) — switches between Guide / Deploy & Operate / Reference
+//
+// Passed as `sidebar.banner` in DocsLayout. tabMode must NOT be "auto" so Fumadocs
+// does not also render its own section dropdown below the banner.
+export function SidebarNavHeader() {
+  return (
+    <div className="flex flex-col gap-2">
+      <SidebarVersionDropdown />
+      <SidebarSectionDropdown />
+    </div>
+  )
+}

--- a/apps/docs/src/lib/shared.ts
+++ b/apps/docs/src/lib/shared.ts
@@ -19,6 +19,22 @@ export const docsVersions: DocsVersionEntry[] = [
   { label: 'v0.3', href: '/reference/releases/v0-3', current: true },
 ]
 
+// Top-level documentation sections (matches ROOT_PAGES in scripts/sync-docs.mjs).
+// Drives the sidebar section dropdown. Keep in sync with FOLDER_META root entries.
+export interface DocsSectionEntry {
+  title: string
+  /** Index URL navigated to when the reader switches to this section. */
+  url: string
+  /** URL prefix used to detect which section is active. */
+  prefix: string
+}
+
+export const docsSections: DocsSectionEntry[] = [
+  { title: 'Guide', url: '/guide', prefix: '/guide' },
+  { title: 'Deploy & Operate', url: '/operate', prefix: '/operate' },
+  { title: 'Reference', url: '/reference', prefix: '/reference' },
+]
+
 // Docs are served at the site root (docs.chmonitor.dev/).
 // Empty string means the base URL for doc pages is '/'.
 export const docsRoute = ''

--- a/apps/docs/src/routes/$.tsx
+++ b/apps/docs/src/routes/$.tsx
@@ -15,6 +15,7 @@ import {
 import { Suspense } from 'react'
 import { useMDXComponents } from '@/components/mdx'
 import { SidebarFooter } from '@/components/sidebar-footer'
+import { SidebarNavHeader } from '@/components/sidebar-nav-header'
 import { baseOptions } from '@/lib/layout.shared'
 import { gitConfig } from '@/lib/shared'
 import { getPageImage, slugsToMarkdownPath, source } from '@/lib/source'
@@ -110,10 +111,14 @@ function Page() {
     <DocsLayout
       {...baseOptions()}
       tree={pageTree}
-      // Root folders (meta.json `root: true`) render as a sidebar dropdown
-      // (Fumadocs Layout Tabs); only the active tab's pages show in the tree.
-      tabMode="auto"
-      sidebar={{ footer: <SidebarFooter /> }}
+      // tabMode is intentionally omitted: the section dropdown is rendered
+      // manually in sidebar.banner (SidebarNavHeader) so that the version
+      // dropdown can sit above it. Root-folder filtering still works because
+      // it relies on `root: true` in meta.json via useTreeContext, not tabMode.
+      sidebar={{
+        banner: <SidebarNavHeader />,
+        footer: <SidebarFooter />,
+      }}
     >
       <Suspense>
         {clientLoader.useContent(path, { markdownUrl, path })}


### PR DESCRIPTION
## Summary

- Adds a two-level sidebar nav header: **version dropdown** (top) followed by **section dropdown** (Guide / Deploy & Operate / Reference), replacing Fumadocs' automatic `tabMode="auto"` section dropdown so the ordering is version-first as designed
- `lib/shared.ts`: adds `docsSections` constant (single source of truth for the three tab labels and URL prefixes)
- `components/sidebar-nav-header.tsx`: `SidebarVersionDropdown` + `SidebarSectionDropdown` styled to match Fumadocs' `SidebarTabsDropdown`; exported as `SidebarNavHeader`
- `routes/$.tsx`: removes `tabMode="auto"`, wires `SidebarNavHeader` as `sidebar.banner`

Root-folder filtering (`root: true` in meta.json, resolved by `useTreeContext`) is unaffected by `tabMode`, so only the active section's pages still appear in the sidebar tree.

## Test plan

- [x] `cd apps/docs && bun run build` passes (71 pages synced, Vite build ✓, prerender ✓)
- [x] `bunx biome check` clean on all 3 changed files
- [ ] Verify sidebar shows version dropdown above section dropdown on the live docs site after deploy

https://claude.ai/code/session_01DCLCwhodA6WbvkHm8jCjU4