### PR TITLE
refactor(docs): simplify nav dropdowns + finish rebrand misses

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,7 +11,7 @@
     "database",
     "observability"
   ],
-  "homepage": "https://github.com/duyet/clickhouse-monitor",
+  "homepage": "https://github.com/chmonitor/chmonitor",
   "repository": {
     "type": "git",
     "url": "https://github.com/chmonitor/chmonitor.git"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build and Test](https://github.com/chmonitor/chmonitor/actions/workflows/ci.yml/badge.svg)](https://github.com/chmonitor/chmonitor/actions/workflows/ci.yml)
 [![All-time uptime](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fduyet%2Fuptime%2FHEAD%2Fapi%2Fclickhouse-monitoring-vercel-app%2Fuptime.json)](https://duyet.github.io/uptime/history/clickhouse-monitoring-vercel-app)
 [![Latest release](https://img.shields.io/github/v/release/chmonitor/chmonitor?sort=semver&label=release)](https://github.com/chmonitor/chmonitor/releases)
-[![Docker image](https://img.shields.io/badge/ghcr.io-duyet%2Fchmonitor-2496ED?logo=docker&logoColor=white)](https://github.com/chmonitor/chmonitor/pkgs/container/chmonitor)
+[![Docker image](https://img.shields.io/badge/ghcr.io-chmonitor%2Fchmonitor-2496ED?logo=docker&logoColor=white)](https://github.com/chmonitor/chmonitor/pkgs/container/chmonitor)
 [![License](https://img.shields.io/github/license/chmonitor/chmonitor)](LICENSE)
 
 A modern dashboard (TanStack Start, as of **v0.3**) that provides real-time insights into ClickHouse clusters through system tables. Every page is pre-rendered at build time with client-side data fetching for optimal performance and CDN caching.

--- a/apps/docs/src/components/sidebar-nav-header.tsx
+++ b/apps/docs/src/components/sidebar-nav-header.tsx
@@ -1,5 +1,7 @@
 import { Check, ChevronsUpDown } from 'lucide-react'
 
+import type { ReactNode } from 'react'
+
 import { usePathname } from 'fumadocs-core/framework'
 import {
   Popover,
@@ -14,83 +16,50 @@ import { docsSections, docsVersion, docsVersions } from '@/lib/shared'
 const triggerCls =
   'flex w-full items-center gap-2 rounded-lg p-2 border bg-fd-secondary/50 text-start text-fd-secondary-foreground transition-colors hover:bg-fd-accent data-[state=open]:bg-fd-accent data-[state=open]:text-fd-accent-foreground'
 
-// Version dropdown (sidebar variant). Full-width, matches section dropdown style.
-// Drives from docsVersions in lib/shared — add a new entry there when cutting a
-// new version; no changes needed here.
-function SidebarVersionDropdown() {
+interface DropdownItem {
+  label: string
+  href: string
+  active?: boolean
+}
+
+// Generic full-width sidebar dropdown: a labelled trigger over a list of links,
+// a check on the active item, and an optional footer (e.g. "All releases →").
+function SidebarDropdown({
+  label,
+  ariaLabel,
+  items,
+  footer,
+}: {
+  label: string
+  ariaLabel?: string
+  items: DropdownItem[]
+  footer?: ReactNode
+}) {
   const [open, setOpen] = useState(false)
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger
-        className={triggerCls}
-        aria-label={`Switch documentation version (current: ${docsVersion})`}
-      >
-        <span className="flex-1 text-sm font-medium">{docsVersion}</span>
+      <PopoverTrigger className={triggerCls} aria-label={ariaLabel}>
+        <span className="flex-1 text-sm font-medium">{label}</span>
         <ChevronsUpDown className="ms-auto size-4 shrink-0 text-fd-muted-foreground" />
       </PopoverTrigger>
       <PopoverContent
         align="start"
         className="flex flex-col gap-1 p-1 w-(--radix-popover-trigger-width)"
       >
-        {docsVersions.map((v) => (
+        {items.map((item) => (
           <a
-            key={v.label}
-            href={v.href}
+            key={item.href}
+            href={item.href}
             onClick={() => setOpen(false)}
             className="flex items-center gap-2 rounded-lg p-1.5 text-sm hover:bg-fd-accent hover:text-fd-accent-foreground"
           >
-            <span className="flex-1">{v.label}</span>
-            {v.current ? <Check className="size-3.5 text-fd-primary" /> : null}
+            <span className="flex-1">{item.label}</span>
+            {item.active ? (
+              <Check className="size-3.5 text-fd-primary" />
+            ) : null}
           </a>
         ))}
-        <a
-          href="/reference/releases"
-          onClick={() => setOpen(false)}
-          className="mt-1 border-t pt-1.5 px-1.5 py-1 text-xs text-fd-muted-foreground hover:text-fd-accent-foreground"
-        >
-          All releases →
-        </a>
-      </PopoverContent>
-    </Popover>
-  )
-}
-
-// Section dropdown. Reads the current pathname to highlight the active section.
-// Replaces Fumadocs' built-in SidebarTabsDropdown (tabMode="auto") so that the
-// version can appear above it in the sidebar.
-function SidebarSectionDropdown() {
-  const [open, setOpen] = useState(false)
-  const pathname = usePathname()
-  // Find the most-specific matching prefix (longest wins).
-  const active =
-    [...docsSections]
-      .sort((a, b) => b.prefix.length - a.prefix.length)
-      .find((s) => pathname.startsWith(s.prefix)) ?? docsSections[0]
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger className={triggerCls}>
-        <span className="flex-1 text-sm font-medium">{active.title}</span>
-        <ChevronsUpDown className="ms-auto size-4 shrink-0 text-fd-muted-foreground" />
-      </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        className="flex flex-col gap-1 p-1 w-(--radix-popover-trigger-width)"
-      >
-        {docsSections.map((section) => {
-          const isActive = section.prefix === active.prefix
-          return (
-            <a
-              key={section.url}
-              href={section.url}
-              onClick={() => setOpen(false)}
-              className="flex items-center gap-2 rounded-lg p-1.5 text-sm hover:bg-fd-accent hover:text-fd-accent-foreground"
-            >
-              <span className="flex-1">{section.title}</span>
-              {isActive ? <Check className="size-3.5 text-fd-primary" /> : null}
-            </a>
-          )
-        })}
+        {footer}
       </PopoverContent>
     </Popover>
   )
@@ -98,15 +67,43 @@ function SidebarSectionDropdown() {
 
 // Two stacked sidebar navigation dropdowns:
 //   1. Version dropdown (top) — switches between published docs versions
-//   2. Section dropdown (below) — switches between Guide / Deploy & Operate / Reference
+//   2. Section dropdown (below) — Guide / Deploy & Operate / Reference
 //
-// Passed as `sidebar.banner` in DocsLayout. tabMode must NOT be "auto" so Fumadocs
-// does not also render its own section dropdown below the banner.
+// Passed as `sidebar.banner` in DocsLayout. tabMode must NOT be "auto" so
+// Fumadocs does not also render its own section dropdown below the banner.
 export function SidebarNavHeader() {
+  const pathname = usePathname()
+  // Only three non-overlapping top-level prefixes, so a plain find suffices.
+  const activeSection =
+    docsSections.find((s) => pathname.startsWith(s.url)) ?? docsSections[0]
+
   return (
     <div className="flex flex-col gap-2">
-      <SidebarVersionDropdown />
-      <SidebarSectionDropdown />
+      <SidebarDropdown
+        label={docsVersion}
+        ariaLabel={`Switch documentation version (current: ${docsVersion})`}
+        items={docsVersions.map((v) => ({
+          label: v.label,
+          href: v.href,
+          active: v.current,
+        }))}
+        footer={
+          <a
+            href="/reference/releases"
+            className="mt-1 border-t pt-1.5 px-1.5 py-1 text-xs text-fd-muted-foreground hover:text-fd-accent-foreground"
+          >
+            All releases →
+          </a>
+        }
+      />
+      <SidebarDropdown
+        label={activeSection.title}
+        items={docsSections.map((s) => ({
+          label: s.title,
+          href: s.url,
+          active: s.url === activeSection.url,
+        }))}
+      />
     </div>
   )
 }

--- a/apps/docs/src/lib/shared.ts
+++ b/apps/docs/src/lib/shared.ts
@@ -23,16 +23,14 @@ export const docsVersions: DocsVersionEntry[] = [
 // Drives the sidebar section dropdown. Keep in sync with FOLDER_META root entries.
 export interface DocsSectionEntry {
   title: string
-  /** Index URL navigated to when the reader switches to this section. */
+  /** Section index URL — also the prefix used to detect the active section. */
   url: string
-  /** URL prefix used to detect which section is active. */
-  prefix: string
 }
 
 export const docsSections: DocsSectionEntry[] = [
-  { title: 'Guide', url: '/guide', prefix: '/guide' },
-  { title: 'Deploy & Operate', url: '/operate', prefix: '/operate' },
-  { title: 'Reference', url: '/reference', prefix: '/reference' },
+  { title: 'Guide', url: '/guide' },
+  { title: 'Deploy & Operate', url: '/operate' },
+  { title: 'Reference', url: '/reference' },
 ]
 
 // Docs are served at the site root (docs.chmonitor.dev/).
@@ -44,7 +42,7 @@ export const dashboardUrl = 'https://dash.chmonitor.dev'
 
 // GitHub repository info — used for "Edit on GitHub" links.
 export const gitConfig = {
-  user: 'duyet',
-  repo: 'clickhouse-monitoring',
+  user: 'chmonitor',
+  repo: 'chmonitor',
   branch: 'main',
 }

--- a/docs/content/operate/deploy/vercel.mdx
+++ b/docs/content/operate/deploy/vercel.mdx
@@ -11,7 +11,7 @@ This guide targets the **legacy Next.js build (v0.2 and earlier)**. The current 
 
 ## Quick start
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fduyet%2Fclickhouse-monitoring&env=CLICKHOUSE_HOST,CLICKHOUSE_USER,CLICKHOUSE_PASSWORD,CLICKHOUSE_MAX_EXECUTION_TIME,CLICKHOUSE_TZ)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fchmonitor%2Fchmonitor&env=CLICKHOUSE_HOST,CLICKHOUSE_USER,CLICKHOUSE_PASSWORD,CLICKHOUSE_MAX_EXECUTION_TIME,CLICKHOUSE_TZ)
 
 Or deploy manually:
 


### PR DESCRIPTION
### /simplify cleanup of the merged docs-nav dropdowns (#2000)
- Extract a generic `SidebarDropdown` — removes ~70 lines of copy-paste between the version + section dropdowns.
- Drop the per-render `[...].sort()` in active-section detection — three non-overlapping prefixes only need a plain `find`.
- Merge the redundant `url`/`prefix` fields in `DocsSectionEntry` (they were always equal).

### Rebrand misses (split / percent-encoded strings the earlier `duyet/clickhouse-monitoring` sweep couldn't match)
- **`apps/docs` `gitConfig`**: `user`/`repo` → `chmonitor/chmonitor` — fixes every docs "Edit on GitHub" / GitHub link (built from these fields, incl. the new docs homepage).
- `.claude-plugin/plugin.json` homepage → `github.com/chmonitor/chmonitor`
- README Docker badge label `duyet%2Fchmonitor` → `chmonitor%2Fchmonitor`
- Vercel deploy-button repo URL (percent-encoded) → `chmonitor/chmonitor`

### Verified / intentionally kept
- `tabMode` removal is correct — Fumadocs sidebar tree filtering keys off `meta.json` `root:true`, not `tabMode` (confirmed against Fumadocs source).
- Separate repos untouched: `duyet/agentstate`, `duyet/llm-release-action`, `duyet/build-agent`, `duyet/docker-images`, `duyet/uptime`.

Biome clean on changed files; docs build + prerender pass.

Co-Authored-By: duyetbot <bot@duyet.net>