### PR TITLE
feat(saas): cloud mode — demo hosts, welcome/setup, connection-error help

### DIFF
--- a/.claude/skills/cloud-saas-mode/SKILL.md
+++ b/.claude/skills/cloud-saas-mode/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: cloud-saas-mode
+description: >-
+  Work on chmonitor's Cloud (SaaS) vs self-hosted (OSS) behaviour from ONE
+  codebase. Use when changing how dash.chmonitor.dev differs from Docker/K8s/OSS
+  builds: the cloud-mode flag, public read-only demo hosts, the welcome/setup
+  onboarding page, per-user (D1) ClickHouse connections, host visibility for
+  anonymous vs signed-in users, or the "Test connection" error classifier and
+  its docs links. Triggers: "cloud mode", "SaaS", "demo host", "welcome page",
+  "setup page", "first-run", "add host error", "connection error", "read-only
+  host", "hide hosts when signed in".
+metadata:
+  tags: saas, cloud, oss, self-hosted, onboarding, hosts, clerk, connection-errors
+---
+
+# chmonitor Cloud (SaaS) mode
+
+One codebase, two products. `dash.chmonitor.dev` = Cloud; Docker/K8s/self-built
+Worker = self-hosted (OSS). The difference is runtime config behind one flag.
+
+> This is a project skill kept under `.claude/skills/` (NOT `.agents/skills/`,
+> which the `build:skills` registry scans for end-user AI-agent skills). Keep dev
+> skills here so they never leak into the agent bundle.
+
+## Golden rule
+
+**Fail-closed to self-hosted.** Unset/junk `CHM_CLOUD_MODE` / `VITE_CLOUD_MODE`
+→ NOT cloud → OSS unchanged. Cloud behaviour is ADDITIVE only. Never gate a core
+monitoring feature behind cloud mode. (Mirrors `lib/edition` fail-open design.)
+
+## The flag
+
+- Resolver: `apps/dashboard/src/lib/cloud/cloud-mode.ts`
+  - `isCloudModeClient()` — build-time, React/hooks (reads `VITE_CLOUD_MODE`).
+  - `isCloudModeServer(env)` — runtime `CHM_CLOUD_MODE` wins over build-time.
+  - `parseCloudMode(v)` — only `'true'|'1'|'cloud'` (trim/case-insensitive) → true.
+- Build inline: `vite.config.ts` CLIENT_ENV + `src/vite-env.d.ts`.
+- Runtime: `wrangler.toml` `[vars]` and `[env.preview.vars]`.
+- Hosted deploy sets both `VITE_CLOUD_MODE=true` and
+  `VITE_FEATURE_USER_CONNECTIONS_DB=true` in `.github/workflows/cloudflare.yml`.
+
+## Behaviour
+
+| | Self-hosted | Cloud |
+|---|---|---|
+| Env hosts | real, full access | `source:'demo'`, read-only |
+| Anonymous | env hosts | the demo |
+| Signed-in | env hosts | demo HIDDEN → own D1 connections; zero → welcome/setup |
+
+Implemented in `lib/swr/use-merged-hosts.ts` (tag demo, hide-when-signed-in;
+returns `cloudMode`/`isSignedIn`). Switcher badges + `demo`-as-`env` status in
+`components/host/host-switcher.tsx`.
+
+## Welcome / setup page
+
+`components/host/first-run-empty-state.tsx` renders 3 variants by
+`(cloudMode, isSignedIn)`: cloud signed-in (Connect-your-host + Add-host dialog),
+cloud anon (sign-in + value prop), self-hosted (env-var guidance + browser add).
+Gate `ClerkSignInButton` behind `isClerkEnabled()`.
+
+## Connection-error help
+
+`lib/connection-errors.ts`:
+- `classifyConnectionError(raw)` → `{kind,title,explanation,fix,docsSlug,raw}`.
+  Kinds: host_not_allowed, invalid_url, auth_failed, access_denied, dns_error,
+  connection_refused, tls_error, timeout, mixed_content, unknown. Add new
+  patterns by extending `RULES` (first match wins, specific first).
+- `extractConnectionErrorMessage(body)` handles `{error:string}` (test route)
+  AND `{error:{message}}` (shared validation builder).
+- Rendered by `ConnectionErrorPanel` in `connection-form.tsx`.
+- Docs page slug: `guides/connection-errors`
+  (`docs/content/guide/guides/connection-errors.mdx`).
+
+## Build/test gotchas
+
+- `apps/dashboard` is NOT a root bun workspace → `cd apps/dashboard && bun install`.
+- Build inside `apps/dashboard`: `bun run build` (vite + tsc --noEmit).
+- Tests: `bun test src/lib/cloud src/lib/connection-errors.test.ts`.
+- Full reference: `docs/knowledge/cloud-saas-mode.md`.
+
+## Keep this skill current
+
+When you change cloud-mode behaviour, demo-host visibility, the welcome/setup
+page, per-user connections, or the connection-error classifier, UPDATE this file
+and `docs/knowledge/cloud-saas-mode.md` in the same change. See the
+"Auto-improve project skills" note in the root `CLAUDE.md`.

--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: product-design
+description: >-
+  chmonitor's product design system + UX conventions, so every new feature looks
+  and behaves consistent with the rest of the dashboard. Use BEFORE building or
+  reviewing any UI: new pages, charts, cards, dialogs, empty/error/loading
+  states, badges, onboarding, settings. Covers design tokens (OKLCH theme, dark
+  mode, radius, chart colors), shadcn/ui rules, the ChartCard/ChartContainer
+  pattern, data-table system, EmptyState variants, graceful error handling,
+  ?host routing + hooks-at-deepest-consumer, file/route organization, and brand.
+  Triggers: "new page", "add a chart", "build UI", "design", "component",
+  "empty state", "loading", "consistent", "follow-up feature", "match the design".
+metadata:
+  tags: design-system, ui, ux, tailwind, shadcn, charts, tokens, conventions, brand
+---
+
+# chmonitor product design system
+
+The rulebook for keeping new features visually + behaviourally consistent. When
+in doubt, COPY the closest existing component rather than inventing. Full token
+values and file paths: `docs/knowledge/product-design.md`.
+
+## Non-negotiables
+
+1. **Never edit `src/components/ui/*`** (shadcn primitives). Customise via the
+   `className` prop at the call site, or a wrapper in `src/components/` — never
+   in `ui/`. Always merge classes with `cn()` (`src/lib/utils.ts`), never
+   template-literal concatenation.
+2. **Tailwind v4, CSS-first.** Tokens live in `src/styles.css` `@theme` blocks —
+   there is no `tailwind.config.ts`. Use semantic tokens (`bg-card`,
+   `text-muted-foreground`, `border-border`), not raw colors. Theme is OKLCH.
+3. **Dark mode is `class`-based** (`next-themes`, `.dark`). Every surface must
+   read correctly in both themes — only use semantic tokens, which flip
+   automatically. Don't hardcode `bg-white` / `text-black`.
+4. **Hooks at the deepest consumer.** A component that needs data calls
+   `useHostId()` / `useChartData()` itself — do NOT prop-drill `hostId`.
+5. **`?host=N` routing**, never dynamic `/N/...` segments. Preserve other search
+   params with `buildUrl(pathname, { host }, searchParams)`.
+
+## Tokens (semantic — use these names, not hex/oklch literals)
+
+`background foreground card card-foreground popover muted muted-foreground
+primary secondary accent destructive border input ring`. Charts:
+`--chart-1..5` (OKLCH) for series. Radius: `rounded-md` (9px) default,
+`rounded-lg` (10px), `rounded-xl` (14px) for cards. Brand accents: **orange**
+(metrics) + **emerald** (health/live) — see `components/icons/chmonitor-logo.tsx`.
+
+## Canonical idioms (match these class strings)
+
+- **Card surface:** `rounded-xl border bg-card shadow-sm` (premium variant adds
+  `bg-gradient-to-b from-card/80 to-card/40 dark:from-card/60 dark:to-card/30
+  backdrop-blur-xl`). See `components/charts/chart-card-styles.ts`.
+- **Icons:** `lucide-react`, `size-4` standard / `size-3.5` compact / `strokeWidth={1.5}`.
+- **Dense text:** `text-[13px]` controls, `text-sm` body, `text-xs
+  text-muted-foreground` meta, `text-xl font-semibold tracking-tight` page/hero titles.
+- **Spacing:** `gap-1.5` compact, `gap-2` standard, `gap-4` generous; card content `p-4 pt-0`.
+- **Pill/secondary button link:** `inline-flex h-8 items-center gap-1.5 rounded-md
+  border border-border px-3 text-[13px] font-medium hover:bg-muted`.
+
+## Charts — always wrap state, never hand-roll it
+
+Use `ChartContainer` (renders skeleton / `ChartError` / empty) + `ChartCard`
+(title, SQL, metadata, stale indicator, retry). Fetch with `useChartData({
+chartName, hostId, interval })`. Header icon order:
+`[StaleIndicator] [DateRange] [LogScaleToggle] [CardToolbar]`. Copy an existing
+chart in `components/charts/` as the template — don't reinvent the wiring.
+
+## Loading / empty / error
+
+- **Loading:** a `Skeleton` that matches the final layout (`components/skeletons/`)
+  to avoid layout shift; gate with `Suspense` where used.
+- **Empty:** `EmptyState` (`components/ui/empty-state.tsx`) with the right
+  `variant` (`no-data | no-results | error | table-missing | timeout |
+  filtered-empty | offline | loading`), `icon`, `title`, `description`, optional
+  `action`/`onRefresh`.
+- **Error (graceful):** initial error (`error && !hasData`) → full `ChartError`
+  with retry. Revalidation error (`staleError`) → KEEP showing data + subtle
+  amber `ChartStaleIndicator` (hover-revealed), auto-clears on next success.
+  Never blank out good data on a refresh failure.
+- **First run (zero hosts):** `FirstRunGate` → `FirstRunEmptyState` (3 modes:
+  cloud signed-in / cloud anon / self-hosted). See the `cloud-saas-mode` skill.
+
+## Data tables
+
+Use the `components/data-table/` system (resizing, wrap toggle, sorting via
+`sorting-fns.ts`, pagination, faceted filters, row actions, SQL display).
+Synthetic column ids `__expand`, `select`, `action` are non-data — skip them in
+filter/search/sort/card wiring.
+
+## Adding a page
+
+1. `src/routes/(dashboard)/my-page.tsx` (`'use client'`, uses `useHostId()`).
+2. Add a `QueryConfig` in `src/lib/query-config/` if it needs data.
+3. Register in `src/menu.ts` (with feature gate / `tableCheck` if optional).
+4. Compose `ChartContainer` + `ChartCard`; reuse skeletons + empty/error states.
+
+## File & naming conventions
+
+kebab-case files; PascalCase components; `use*` camelCase hooks; props as
+`interface XProps` colocated; client components declare `'use client'`, server
+components don't; shared types in `src/types/` or `src/lib/api/types.ts`. Details
+in `docs/knowledge/conventions.md`.
+
+## Keep this skill current
+
+This skill is the source of truth for design consistency. When you introduce or
+change a durable UI pattern (a new token, a reusable component, an
+empty/error/onboarding convention), UPDATE this file + `docs/knowledge/
+product-design.md` in the SAME change. See the "Auto-improve project skills"
+note in the root `CLAUDE.md`.

--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -94,6 +94,11 @@ jobs:
           VITE_GIT_REF: ${{ github.head_ref || github.ref_name }}
           VITE_CI: 'true'
           VITE_DEPLOY_TARGET: cf
+          # Hosted product (dash.chmonitor.dev): cloud SaaS mode + per-user
+          # connection storage. Self-hosted/OSS builds leave both unset → env
+          # hosts are the operator's real hosts, no demo, fully functional.
+          VITE_CLOUD_MODE: 'true'
+          VITE_FEATURE_USER_CONNECTIONS_DB: 'true'
         run: bun run build
 
       - name: Type-check dashboard tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,45 @@ to skip an unaddressed finding. To avoid the gate entirely, prefer
 
 This is a monorepo ClickHouse monitoring dashboard. The primary (and only) dashboard app is `apps/dashboard` (TanStack Start, as of v0.3). The Next.js migration is complete — the TanStack Start app has replaced the legacy Next.js app and is now at `apps/dashboard`. The application connects to ClickHouse instances and provides real-time insights into clusters through system tables — metrics, query performance, table information, and cluster health.
 
+## One codebase: Self-hosted (OSS) + Cloud (SaaS)
+
+`dash.chmonitor.dev` is the **Cloud (SaaS)** product; Docker / Kubernetes / a
+self-built Cloudflare Worker are the **self-hosted (OSS)** product. They are the
+SAME codebase — the difference is purely runtime configuration. The split is the
+**cloud-mode** flag (`lib/cloud/cloud-mode.ts`).
+
+**Design invariant (fail-closed to self-hosted):** an unset/junk
+`CHM_CLOUD_MODE` / `VITE_CLOUD_MODE` resolves to NOT cloud, so the OSS build is
+never degraded. Cloud behaviour is purely additive. Mirrors `lib/edition` (which
+already lists `cloud` as an enterprise feature) and its fail-open philosophy.
+
+| Aspect | Self-hosted (default) | Cloud (`CHM_CLOUD_MODE=true`) |
+|--------|----------------------|-------------------------------|
+| `CLICKHOUSE_HOST` env hosts | The operator's real hosts, full access | A **public read-only demo** (`source: 'demo'`, e.g. `duet-ubuntu`) |
+| Anonymous visitor | Sees env hosts | Sees the read-only demo (explore without an account) |
+| Signed-in user | Sees env hosts | Demo is **hidden** ("empty it") → their own per-user (D1) connections only; zero → welcome/setup page |
+| Auth | usually `none` | Clerk, with `CHM_CLERK_PUBLIC_READ=true` (anon reads, writes need sign-in) |
+| Per-user connections | optional | on (`VITE_FEATURE_USER_CONNECTIONS_DB=true`) |
+
+**Where cloud mode is wired:**
+- `lib/cloud/cloud-mode.ts` — `isCloudModeClient()` / `isCloudModeServer()` / `parseCloudMode()`.
+- `vite.config.ts` CLIENT_ENV + `src/vite-env.d.ts` — inline `VITE_CLOUD_MODE` (build).
+- `wrangler.toml` (`[vars]` + `[env.preview.vars]`) — `CHM_CLOUD_MODE` (runtime).
+- `.github/workflows/cloudflare.yml` build step — sets `VITE_CLOUD_MODE=true` + `VITE_FEATURE_USER_CONNECTIONS_DB=true` for the hosted deploy ONLY.
+- `lib/swr/use-merged-hosts.ts` — demo tagging + hide-when-signed-in; returns `cloudMode` / `isSignedIn`.
+- `components/host/host-switcher.tsx` — "Demo / read-only" badges; treats `demo` like `env` for live status.
+- `components/host/first-run-empty-state.tsx` — the redesigned welcome/setup page (3 modes: cloud signed-in, cloud anon, self-hosted).
+
+**Connection-error help:** `lib/connection-errors.ts` classifies "Test connection"
+failures (host_not_allowed/SSRF, invalid_url, auth_failed, access_denied,
+dns/refused/tls/timeout) into title + cause + fix + docs slug. Rendered by
+`ConnectionErrorPanel` in `connection-form.tsx`. Docs page:
+`docs/content/guide/guides/connection-errors.mdx` (slug `guides/connection-errors`).
+
+**Self-hosted stays whole:** never gate a core monitoring feature behind cloud
+mode. Cloud-only behaviour = demo hosts + welcome framing + per-user storage,
+nothing that removes functionality from OSS.
+
 ## Claude Skills
 
 ### chmonitor Agent Skill
@@ -76,6 +115,35 @@ round(rows * 100.0 / nullIf(max(rows) OVER (), 0), 2) AS pct_rows       -- perce
 
 See `.claude/skills/clickhouse-query-config.md` for full patterns.
 
+## Project skills (Claude Code) & auto-improvement
+
+Project-local Claude Code skills live in `.claude/skills/` as real `SKILL.md`
+dirs (NOT `.agents/skills/`, which the `build:skills` registry scans for
+end-user AI-agent skills — keep dev/product skills out of there so they never
+leak into the agent bundle). Current dev skills:
+
+- **`product-design`** — design system + UX conventions; read it before building
+  or reviewing ANY UI so new features stay consistent. Backed by
+  `docs/knowledge/product-design.md`.
+- **`cloud-saas-mode`** — Cloud (SaaS) vs self-hosted behaviour, demo hosts,
+  welcome/setup, per-user connections, connection-error classifier. Backed by
+  `docs/knowledge/cloud-saas-mode.md`.
+
+**Auto-improve project skills (standing instruction).** These skills are living
+documents — keep them accurate as the codebase evolves, without being asked:
+
+1. Whenever you add or change a durable UI pattern, design token, reusable
+   component, onboarding/error convention, or cloud-vs-OSS behaviour, UPDATE the
+   relevant skill **and** its `docs/knowledge/*.md` backing doc **in the same
+   change** (treat a skill that drifts from the code as a bug).
+2. Bump the `updated:` date in the knowledge doc; keep the skill `description`
+   trigger list current so it still activates for the right requests.
+3. When you discover a new cross-cutting convention worth enforcing, add it to
+   the appropriate skill (or create a new `.claude/skills/<name>/SKILL.md`), then
+   link it from this section and the Knowledge Graph table below.
+4. Never commit a regenerated `apps/dashboard/src/lib/ai/agent/skills/registry.ts`
+   as a side effect of dev-skill work — that file tracks AI-agent skills only.
+
 ## Knowledge Graph
 
 Developer-facing docs live in `docs/knowledge/` as a linked knowledge graph. Each note has frontmatter (`id`, `type`, `related`, `tags`) and cross-links to connected notes.
@@ -91,6 +159,8 @@ Developer-facing docs live in `docs/knowledge/` as a linked knowledge graph. Eac
 | Operations | [core-memory.md](docs/knowledge/core-memory.md) | Automation memory: code-smell scans, dead-code rules |
 | Operations | [secret-rotation.md](docs/knowledge/secret-rotation.md) | Redeploy after `wrangler secret put` |
 | Operations | [k8s-health-probes.md](docs/knowledge/k8s-health-probes.md) | /healthz (liveness, static) vs /api/healthz (readiness, CH-gated); startupProbe; :latest stale-image CrashLoop incident; non-helm manifest + migration prompt |
+| Specs | [cloud-saas-mode.md](docs/knowledge/cloud-saas-mode.md) | One codebase, two products: cloud-mode flag, demo hosts for anon, welcome/setup, per-user D1 connections, connection-error classifier |
+| Design | [product-design.md](docs/knowledge/product-design.md) | Design system + UX conventions: OKLCH tokens, shadcn rules, ChartCard/Container, EmptyState, graceful errors, ?host routing, file org (source of truth for the `product-design` skill) |
 | Specs | [ai-insights.md](docs/knowledge/ai-insights.md) | AI Insights engine: collect→enrich→persist (findings store), cron + manual generation, stable-key dismissal, overview panel |
 | Specs | [mcp-server.md](docs/knowledge/mcp-server.md) | MCP server at /api/mcp: tools, setup, security |
 | Specs | [agentstate-conversation-store.md](docs/knowledge/agentstate-conversation-store.md) | AgentState conversation backend: store priority, per-user external_id/tag isolation, append-only upsert, AI enrichment, backend/follow-ups routes |

--- a/apps/dashboard/src/components/connections/connection-form.tsx
+++ b/apps/dashboard/src/components/connections/connection-form.tsx
@@ -1,4 +1,4 @@
-import { Check, Eye, EyeOff, Globe, Loader2, X } from 'lucide-react'
+import { ArrowUpRight, Check, Eye, EyeOff, Globe, Loader2 } from 'lucide-react'
 
 import type { BrowserConnection } from '@/lib/types/browser-connection'
 import type { HostStorageMode } from '@/lib/types/host-storage'
@@ -8,6 +8,10 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
+import {
+  classifyConnectionError,
+  extractConnectionErrorMessage,
+} from '@/lib/connection-errors'
 import { docsSiteUrl } from '@/lib/docs-site'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import {
@@ -117,7 +121,7 @@ export function ConnectionForm({
       } else {
         setTestStatus({
           state: 'error',
-          message: json.error ?? 'Connection failed',
+          message: extractConnectionErrorMessage(json),
         })
       }
     } catch (err) {
@@ -304,13 +308,13 @@ export function ConnectionForm({
             {testStatus.message}
           </span>
         )}
-        {testStatus.state === 'error' && (
-          <span className="flex items-center gap-1.5 text-xs text-destructive">
-            <X className="size-3.5" />
-            {testStatus.message}
-          </span>
-        )}
       </div>
+
+      {/* Rich, actionable error panel — classifies the raw ClickHouse / network
+          error into a cause + fix + docs link for the specific failure kind. */}
+      {testStatus.state === 'error' && (
+        <ConnectionErrorPanel message={testStatus.message} />
+      )}
 
       {/* Actions */}
       <div className="flex justify-end gap-2 pt-2">
@@ -321,6 +325,39 @@ export function ConnectionForm({
           {saving ? 'Saving…' : 'Save'}
         </Button>
       </div>
+    </div>
+  )
+}
+
+/**
+ * Renders a classified connection error: a clear title, why it likely happened,
+ * the concrete fix, the raw technical detail, and a docs link for that exact
+ * failure kind (host not allowed, auth failed, permissions, DNS, TLS, …).
+ */
+function ConnectionErrorPanel({ message }: { message?: string }) {
+  const e = classifyConnectionError(message)
+  return (
+    <div className="space-y-2 rounded-md border border-destructive/40 bg-destructive/5 p-3">
+      <p className="text-sm font-medium text-destructive">{e.title}</p>
+      <p className="text-xs text-muted-foreground">{e.explanation}</p>
+      <p className="text-xs">
+        <span className="font-medium">What to do: </span>
+        <span className="text-muted-foreground">{e.fix}</span>
+      </p>
+      {e.kind !== 'unknown' && e.raw && (
+        <pre className="overflow-x-auto rounded bg-muted/60 p-2 text-[11px] text-muted-foreground">
+          <code>{e.raw}</code>
+        </pre>
+      )}
+      <a
+        href={docsSiteUrl(e.docsSlug)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1 text-xs font-medium text-foreground underline-offset-2 hover:underline"
+      >
+        View troubleshooting docs
+        <ArrowUpRight className="size-3" />
+      </a>
     </div>
   )
 }

--- a/apps/dashboard/src/components/host/first-run-empty-state.tsx
+++ b/apps/dashboard/src/components/host/first-run-empty-state.tsx
@@ -1,71 +1,285 @@
-import { DatabaseZap } from 'lucide-react'
+import {
+  ArrowRight,
+  DatabaseZap,
+  KeyRound,
+  PlugZap,
+  ShieldCheck,
+  Terminal,
+} from 'lucide-react'
 
-import { EmptyState } from '@/components/ui/empty-state'
+import type { ReactNode } from 'react'
+
+import { useState } from 'react'
+import { ClerkSignInButton as ClerkSignInButtonImpl } from '@/components/clerk/clerk-sign-in-button'
+import { AddHostDialog } from '@/components/connections'
+import { ChmonitorLogo } from '@/components/icons/chmonitor-logo'
+import { Button } from '@/components/ui/button'
+import { isClerkEnabled } from '@/lib/clerk/clerk-client'
 import { docsSiteUrl } from '@/lib/docs-site'
+import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
+
+// Clerk's SignInButton needs a mounted <ClerkProvider>. Gate it behind the
+// build-time constant so non-Clerk (self-hosted) builds render null instead.
+const ClerkSignInButton:
+  | ((props: { children: ReactNode }) => ReactNode)
+  | null = isClerkEnabled() ? ClerkSignInButtonImpl : null
 
 /**
- * First-run onboarding surface.
+ * First-run onboarding / welcome surface.
  *
- * Rendered when ZERO ClickHouse hosts are configured (env + browser). Without
- * this, the host switcher collapses to null and the dashboard is a bare,
- * confusing surface. Guides the operator to set the required env vars with a
- * link to the docs.
+ * Rendered by `FirstRunGate` when the visitor has ZERO usable ClickHouse hosts.
+ * The exact framing depends on the deployment:
+ *
+ *  - Cloud (SaaS), signed in → "Connect your ClickHouse" setup page. The demo
+ *    was hidden once they signed in, so this is the moment to bring their own
+ *    host. Primary action opens the Add-host dialog (server storage).
+ *  - Cloud (SaaS), anonymous → "Sign in to connect" with the value prop.
+ *  - Self-hosted (OSS) → operator-oriented guidance: set CLICKHOUSE_HOST env
+ *    vars, or add a browser connection. Unchanged from the original behaviour.
  *
  * @see components/host/first-run-gate.tsx
  */
 export function FirstRunEmptyState() {
+  const { cloudMode, isSignedIn } = useMergedHosts()
+  const [addOpen, setAddOpen] = useState(false)
+
+  let body: ReactNode
+  if (cloudMode && isSignedIn) {
+    body = <ConnectYourHost onAddHost={() => setAddOpen(true)} />
+  } else if (cloudMode) {
+    body = <SignInToConnect />
+  } else {
+    body = <SelfHostedSetup onAddHost={() => setAddOpen(true)} />
+  }
+
   return (
-    <div className="flex flex-1 flex-col items-center justify-center gap-4 py-16">
-      <EmptyState
-        variant="no-data"
-        icon={
-          <DatabaseZap
-            className="h-10 w-10 text-muted-foreground/60"
-            strokeWidth={1.5}
-          />
-        }
-        title="Connect a ClickHouse host to get started"
-        description={
-          <span className="block">
-            No ClickHouse hosts are configured yet. Use the sidebar host
-            switcher → <strong>Add host…</strong> to connect from your browser,
-            or set{' '}
-            <code className="rounded bg-muted px-1 text-[11px]">
-              CLICKHOUSE_HOST
-            </code>
-            ,{' '}
-            <code className="rounded bg-muted px-1 text-[11px]">
-              CLICKHOUSE_USER
-            </code>{' '}
-            and{' '}
-            <code className="rounded bg-muted px-1 text-[11px]">
-              CLICKHOUSE_PASSWORD
-            </code>{' '}
-            (comma-separated for multiple hosts), then restart the app.
-          </span>
-        }
-        className="max-w-lg"
+    <>
+      <div className="flex flex-1 flex-col items-center justify-center px-4 py-16">
+        <div className="w-full max-w-xl">{body}</div>
+      </div>
+      <AddHostDialog open={addOpen} onOpenChange={setAddOpen} />
+    </>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/* Shared layout pieces                                                */
+/* ------------------------------------------------------------------ */
+
+function WelcomeHeader({
+  title,
+  subtitle,
+}: {
+  title: string
+  subtitle: ReactNode
+}) {
+  return (
+    <div className="flex flex-col items-center text-center">
+      <div className="mb-5 flex size-14 items-center justify-center rounded-2xl border bg-card shadow-sm">
+        <ChmonitorLogo width={28} height={28} className="size-7" />
+      </div>
+      <h1 className="text-balance text-xl font-semibold tracking-tight sm:text-2xl">
+        {title}
+      </h1>
+      <p className="mt-2 text-pretty text-sm text-muted-foreground">
+        {subtitle}
+      </p>
+    </div>
+  )
+}
+
+function SetupStep({
+  icon,
+  title,
+  children,
+}: {
+  icon: ReactNode
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <li className="flex gap-3">
+      <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg border bg-muted/40 text-muted-foreground">
+        {icon}
+      </span>
+      <span className="space-y-0.5">
+        <span className="block text-sm font-medium">{title}</span>
+        <span className="block text-sm text-muted-foreground">{children}</span>
+      </span>
+    </li>
+  )
+}
+
+function DocLink({ slug, children }: { slug: string; children: ReactNode }) {
+  return (
+    <a
+      href={docsSiteUrl(slug)}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-3 text-[13px] font-medium hover:bg-muted"
+    >
+      {children}
+    </a>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/* Cloud — signed in                                                   */
+/* ------------------------------------------------------------------ */
+
+function ConnectYourHost({ onAddHost }: { onAddHost: () => void }) {
+  return (
+    <div className="space-y-7">
+      <WelcomeHeader
+        title="Connect your ClickHouse"
+        subtitle="Your workspace is ready. Add a ClickHouse host to start monitoring queries, merges, replication and cluster health."
       />
 
-      {/* Doc links live outside EmptyState because its built-in actions are
-          onClick-only (no href) and its description is line-clamped. */}
+      <div className="rounded-xl border bg-card p-5 shadow-sm">
+        <ul className="space-y-4">
+          <SetupStep
+            icon={<DatabaseZap className="size-4" />}
+            title="1. Have your connection details"
+          >
+            The HTTP(S) endpoint (e.g.{' '}
+            <code className="rounded bg-muted px-1 text-[11px]">
+              https://host:8443
+            </code>
+            ), username and password.
+          </SetupStep>
+          <SetupStep
+            icon={<ShieldCheck className="size-4" />}
+            title="2. Use a read-only monitoring user"
+          >
+            A user with{' '}
+            <code className="rounded bg-muted px-1 text-[11px]">SELECT</code> on{' '}
+            <code className="rounded bg-muted px-1 text-[11px]">system.*</code>{' '}
+            is enough. No write access needed.
+          </SetupStep>
+          <SetupStep
+            icon={<PlugZap className="size-4" />}
+            title="3. Connect and explore"
+          >
+            Credentials are stored encrypted and synced to your account. Test
+            the connection before saving.
+          </SetupStep>
+        </ul>
+
+        <Button
+          className="mt-5 w-full"
+          size="lg"
+          onClick={onAddHost}
+          data-testid="welcome-add-host"
+        >
+          <PlugZap className="size-4" />
+          Add ClickHouse host
+          <ArrowRight className="ml-auto size-4" />
+        </Button>
+      </div>
+
       <div className="flex flex-wrap items-center justify-center gap-2">
-        <a
-          href={docsSiteUrl('getting-started')}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex h-8 items-center gap-1.5 rounded-md bg-foreground px-3 text-[13px] font-medium text-background hover:bg-foreground/90"
-        >
-          Getting started
-        </a>
-        <a
-          href={docsSiteUrl('reference/environment-variables')}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-3 text-[13px] font-medium hover:bg-muted"
-        >
+        <DocLink slug="getting-started">Getting started</DocLink>
+        <DocLink slug="getting-started/clickhouse-requirements">
+          Create a monitoring user
+        </DocLink>
+        <DocLink slug="guides/connection-errors">
+          Connection troubleshooting
+        </DocLink>
+      </div>
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/* Cloud — anonymous                                                   */
+/* ------------------------------------------------------------------ */
+
+function SignInToConnect() {
+  return (
+    <div className="space-y-7">
+      <WelcomeHeader
+        title="Monitor your ClickHouse"
+        subtitle="Sign in to connect your own ClickHouse cluster — query performance, merges, replication, cluster health and an AI agent, all in one place."
+      />
+
+      <div className="flex flex-col items-center gap-3 rounded-xl border bg-card p-5 shadow-sm">
+        {ClerkSignInButton ? (
+          <ClerkSignInButton>
+            <Button size="lg" className="w-full" data-testid="welcome-sign-in">
+              <KeyRound className="size-4" />
+              Sign in to get started
+            </Button>
+          </ClerkSignInButton>
+        ) : (
+          <Button size="lg" className="w-full" disabled>
+            Sign in unavailable
+          </Button>
+        )}
+        <p className="text-center text-xs text-muted-foreground">
+          Free to start. Your credentials are encrypted and scoped to your
+          account.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <DocLink slug="getting-started">Getting started</DocLink>
+        <DocLink slug="features/overview">What you get</DocLink>
+      </div>
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/* Self-hosted (OSS)                                                   */
+/* ------------------------------------------------------------------ */
+
+function SelfHostedSetup({ onAddHost }: { onAddHost: () => void }) {
+  return (
+    <div className="space-y-7">
+      <WelcomeHeader
+        title="Connect a ClickHouse host to get started"
+        subtitle="No ClickHouse hosts are configured yet. Set them once via environment variables, or add one from your browser."
+      />
+
+      <div className="rounded-xl border bg-card p-5 shadow-sm">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <Terminal className="size-4 text-muted-foreground" />
           Environment variables
-        </a>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Set these and restart the app (comma-separated for multiple hosts):
+        </p>
+        <pre className="mt-3 overflow-x-auto rounded-lg bg-muted p-3 text-[12px] leading-relaxed">
+          <code>{`CLICKHOUSE_HOST=https://host:8443
+CLICKHOUSE_USER=monitoring
+CLICKHOUSE_PASSWORD=••••••••`}</code>
+        </pre>
+
+        <div className="my-4 flex items-center gap-3 text-xs text-muted-foreground">
+          <span className="h-px flex-1 bg-border" />
+          or
+          <span className="h-px flex-1 bg-border" />
+        </div>
+
+        <Button
+          className="w-full"
+          variant="outline"
+          onClick={onAddHost}
+          data-testid="welcome-add-host"
+        >
+          <PlugZap className="size-4" />
+          Add a host from this browser
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <DocLink slug="getting-started">Getting started</DocLink>
+        <DocLink slug="reference/environment-variables">
+          Environment variables
+        </DocLink>
+        <DocLink slug="guides/connection-errors">
+          Connection troubleshooting
+        </DocLink>
       </div>
     </div>
   )

--- a/apps/dashboard/src/components/host/host-switcher.tsx
+++ b/apps/dashboard/src/components/host/host-switcher.tsx
@@ -26,7 +26,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton'
 import { usePathname, useRouter, useSearchParams } from '@/lib/next-compat'
 import { useHostId } from '@/lib/swr'
-import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
+import { type MergedHostInfo, useMergedHosts } from '@/lib/swr/use-merged-hosts'
 import { buildUrl } from '@/lib/url/url-builder'
 import { cn, getHost } from '@/lib/utils'
 
@@ -48,6 +48,12 @@ export function HostSwitcher() {
   const activeHost =
     hosts.find((h) => h.id === currentHostId) ?? hosts[0] ?? null
   const showExpanded = isMobile || state === 'expanded'
+
+  // `env` and `demo` hosts are both server-backed by numeric index, so they
+  // carry a live status/version indicator. `browser`/`database` connections are
+  // client-side and get a globe icon instead.
+  const isServerHost = (source: MergedHostInfo['source']) =>
+    source === 'env' || source === 'demo'
 
   const handleHostChange = (hostId: number) => {
     const url = buildUrl(pathname, { host: hostId }, searchParams)
@@ -173,18 +179,28 @@ export function HostSwitcher() {
                 >
                   <div className="relative">
                     <ChmonitorLogo width={20} height={20} className="size-5" />
-                    {!showExpanded && activeHost.source === 'env' && (
+                    {!showExpanded && isServerHost(activeHost.source) && (
                       <LogoStatusIndicator hostId={activeHost.id} />
                     )}
                   </div>
                   {showExpanded && (
                     <>
                       <div className="grid flex-1 text-left text-sm leading-tight">
-                        <span className="truncate font-semibold">
-                          {activeHost.name || getHost(activeHost.host)}
+                        <span className="flex items-center gap-1.5 truncate font-semibold">
+                          <span className="truncate">
+                            {activeHost.name || getHost(activeHost.host)}
+                          </span>
+                          {activeHost.source === 'demo' && (
+                            <span className="shrink-0 rounded bg-muted px-1 py-px text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                              Demo
+                            </span>
+                          )}
                         </span>
-                        {activeHost.source === 'env' ? (
-                          <HostVersionWithStatus hostId={activeHost.id} />
+                        {isServerHost(activeHost.source) ? (
+                          <span className="flex items-center gap-1 truncate text-xs text-muted-foreground">
+                            <HostVersionWithStatus hostId={activeHost.id} />
+                            {activeHost.readOnly && <span>· read-only</span>}
+                          </span>
                         ) : (
                           <span className="truncate text-xs text-muted-foreground">
                             {activeHost.source === 'database'
@@ -215,15 +231,20 @@ export function HostSwitcher() {
                     className="gap-2 p-2"
                     data-testid={`host-option-${host.id}`}
                   >
-                    {host.source !== 'env' && (
+                    {!isServerHost(host.source) && (
                       <GlobeIcon className="size-3 shrink-0 text-muted-foreground" />
                     )}
                     <HostMenuRow
-                      hostId={host.source === 'env' ? host.id : null}
+                      hostId={isServerHost(host.source) ? host.id : null}
                       hostName={host.name || getHost(host.host)}
                       isActive={host.id === currentHostId}
-                      skipStatus={host.source !== 'env'}
+                      skipStatus={!isServerHost(host.source)}
                     />
+                    {host.source === 'demo' && (
+                      <span className="ml-auto shrink-0 rounded bg-muted px-1 py-px text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                        Demo
+                      </span>
+                    )}
                   </DropdownMenuItem>
                 ))}
                 <DropdownMenuSeparator />

--- a/apps/dashboard/src/lib/cloud/cloud-mode.test.ts
+++ b/apps/dashboard/src/lib/cloud/cloud-mode.test.ts
@@ -1,0 +1,53 @@
+import { isCloudModeServer, parseCloudMode } from './cloud-mode'
+import { describe, expect, test } from 'bun:test'
+
+// ---------------------------------------------------------------------------
+// parseCloudMode — fail-closed to self-hosted (false) for anything unexpected.
+// ---------------------------------------------------------------------------
+describe('parseCloudMode', () => {
+  test('undefined → false', () => {
+    expect(parseCloudMode(undefined)).toBe(false)
+  })
+
+  test('null → false', () => {
+    expect(parseCloudMode(null)).toBe(false)
+  })
+
+  test('empty / whitespace → false', () => {
+    expect(parseCloudMode('')).toBe(false)
+    expect(parseCloudMode('   ')).toBe(false)
+  })
+
+  test('junk → false', () => {
+    expect(parseCloudMode('yes')).toBe(false)
+    expect(parseCloudMode('on')).toBe(false)
+    expect(parseCloudMode('enterprise')).toBe(false)
+  })
+
+  test('true / 1 / cloud (case-insensitive, trimmed) → true', () => {
+    expect(parseCloudMode('true')).toBe(true)
+    expect(parseCloudMode('TRUE')).toBe(true)
+    expect(parseCloudMode('  True  ')).toBe(true)
+    expect(parseCloudMode('1')).toBe(true)
+    expect(parseCloudMode('cloud')).toBe(true)
+    expect(parseCloudMode('CLOUD')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isCloudModeServer — runtime CHM_CLOUD_MODE wins over build-time inline.
+// ---------------------------------------------------------------------------
+describe('isCloudModeServer', () => {
+  test('runtime CHM_CLOUD_MODE=true → true', () => {
+    expect(isCloudModeServer({ CHM_CLOUD_MODE: 'true' })).toBe(true)
+  })
+
+  test('runtime unset → falls back to build-time (false in tests)', () => {
+    // VITE_CLOUD_MODE is unset in the test env, so the fallback is false.
+    expect(isCloudModeServer({})).toBe(false)
+  })
+
+  test('runtime junk → false (does not lock out self-hosted)', () => {
+    expect(isCloudModeServer({ CHM_CLOUD_MODE: 'maybe' })).toBe(false)
+  })
+})

--- a/apps/dashboard/src/lib/cloud/cloud-mode.ts
+++ b/apps/dashboard/src/lib/cloud/cloud-mode.ts
@@ -1,0 +1,50 @@
+// Cloud (SaaS) deployment mode.
+//
+// ONE codebase serves two products:
+//   - Self-hosted / OSS (Docker, Kubernetes, Cloudflare Workers): the operator's
+//     `CLICKHOUSE_HOST` env vars are THEIR real hosts, full access, no sign-in
+//     required. This is the default and is never degraded.
+//   - Cloud (dash.chmonitor.dev): the env hosts are a PUBLIC, READ-ONLY DEMO
+//     (e.g. `duet-ubuntu`) that anonymous visitors can explore. When a visitor
+//     signs in they get a clean, empty workspace — the demo is hidden and they
+//     connect their own ClickHouse via per-user (D1) connections.
+//
+// Design invariant (mirrors lib/edition): FAIL-CLOSED to self-hosted. An unset,
+// empty, or unrecognised CHM_CLOUD_MODE / VITE_CLOUD_MODE resolves to NOT cloud,
+// so the open-source build behaves exactly as before. Cloud behaviour is purely
+// additive and only switches on when a deployment explicitly opts in.
+
+/**
+ * Parse a raw env string into a cloud-mode boolean.
+ *
+ * Only the exact string `'true'` / `'1'` / `'cloud'` (case-insensitive, trimmed)
+ * enables cloud mode. Everything else — undefined, empty, whitespace, junk —
+ * resolves to `false`. Never throws.
+ */
+export function parseCloudMode(value: string | null | undefined): boolean {
+  const normalized = value?.trim().toLowerCase()
+  return normalized === 'true' || normalized === '1' || normalized === 'cloud'
+}
+
+/**
+ * Client-safe: resolved at build time from `VITE_CLOUD_MODE`
+ * (inlined in vite.config.ts CLIENT_ENV). Use in React components / hooks.
+ */
+export function isCloudModeClient(): boolean {
+  return parseCloudMode(import.meta.env.VITE_CLOUD_MODE)
+}
+
+/**
+ * Server-side: runtime `CHM_CLOUD_MODE` wins, falling back to the build-time
+ * `VITE_CLOUD_MODE`. Pass the Cloudflare `env` binding on the edge; defaults to
+ * `process.env` on Node.
+ */
+export function isCloudModeServer(
+  runtimeEnv?: Record<string, string | undefined>
+): boolean {
+  const source =
+    runtimeEnv ?? (typeof process !== 'undefined' ? process.env : {})
+  return parseCloudMode(
+    source.CHM_CLOUD_MODE ?? import.meta.env.VITE_CLOUD_MODE
+  )
+}

--- a/apps/dashboard/src/lib/connection-errors.test.ts
+++ b/apps/dashboard/src/lib/connection-errors.test.ts
@@ -1,0 +1,93 @@
+import {
+  classifyConnectionError,
+  extractConnectionErrorMessage,
+} from './connection-errors'
+import { describe, expect, test } from 'bun:test'
+
+describe('classifyConnectionError', () => {
+  test('SSRF / internal address → host_not_allowed', () => {
+    const e = classifyConnectionError(
+      'Connections to internal addresses are not allowed.'
+    )
+    expect(e.kind).toBe('host_not_allowed')
+    expect(e.docsSlug).toBe('guides/connection-errors')
+  })
+
+  test('invalid URL → invalid_url', () => {
+    const e = classifyConnectionError(
+      'Invalid host URL: "host". Must be a full URL (e.g., https://my.clickhouse.cloud:8443)'
+    )
+    expect(e.kind).toBe('invalid_url')
+  })
+
+  test('ClickHouse auth code 516 → auth_failed', () => {
+    const e = classifyConnectionError('Code: 516. Authentication failed')
+    expect(e.kind).toBe('auth_failed')
+  })
+
+  test('not enough privileges → access_denied', () => {
+    const e = classifyConnectionError(
+      'Code: 497. DB::Exception: monitoring: Not enough privileges'
+    )
+    expect(e.kind).toBe('access_denied')
+  })
+
+  test('DNS failure → dns_error', () => {
+    const e = classifyConnectionError('getaddrinfo ENOTFOUND nope.example')
+    expect(e.kind).toBe('dns_error')
+  })
+
+  test('refused → connection_refused', () => {
+    const e = classifyConnectionError('connect ECONNREFUSED 1.2.3.4:8443')
+    expect(e.kind).toBe('connection_refused')
+  })
+
+  test('TLS → tls_error', () => {
+    const e = classifyConnectionError('self signed certificate in chain')
+    expect(e.kind).toBe('tls_error')
+  })
+
+  test('timeout → timeout', () => {
+    const e = classifyConnectionError('connect ETIMEDOUT')
+    expect(e.kind).toBe('timeout')
+  })
+
+  test('unknown string → unknown with raw preserved', () => {
+    const e = classifyConnectionError('some weird error')
+    expect(e.kind).toBe('unknown')
+    expect(e.raw).toBe('some weird error')
+  })
+
+  test('empty / null → unknown, never throws', () => {
+    expect(classifyConnectionError('').kind).toBe('unknown')
+    expect(classifyConnectionError(null).kind).toBe('unknown')
+    expect(classifyConnectionError(undefined).kind).toBe('unknown')
+  })
+
+  test('every classification carries a docs slug', () => {
+    const e = classifyConnectionError('anything')
+    expect(e.docsSlug.length).toBeGreaterThan(0)
+  })
+})
+
+describe('extractConnectionErrorMessage', () => {
+  test('test-endpoint shape { error: string }', () => {
+    expect(extractConnectionErrorMessage({ ok: false, error: 'boom' })).toBe(
+      'boom'
+    )
+  })
+
+  test('validation shape { error: { message } }', () => {
+    expect(
+      extractConnectionErrorMessage({
+        success: false,
+        error: { type: 'validation_error', message: 'bad url' },
+      })
+    ).toBe('bad url')
+  })
+
+  test('unrecognised → fallback string', () => {
+    expect(extractConnectionErrorMessage({})).toBe('Connection failed')
+    expect(extractConnectionErrorMessage(null)).toBe('Connection failed')
+  })
+})

--- a/apps/dashboard/src/lib/connection-errors.ts
+++ b/apps/dashboard/src/lib/connection-errors.ts
@@ -1,0 +1,227 @@
+/**
+ * Connection-error classification for the "Test connection" flow.
+ *
+ * The test endpoint (`/api/v1/browser-connections/test`) returns a raw error
+ * string from either the SSRF/URL validator or the ClickHouse client. Those
+ * strings are accurate but cryptic ("Code: 516", "ECONNREFUSED", "Connections
+ * to internal addresses are not allowed."). This module maps them to an
+ * actionable kind with a human title, an explanation of the likely cause, a
+ * concrete next step, and a docs link — so "click connect → see a detailed
+ * error + link to the right docs page for each kind".
+ *
+ * Pure string heuristics: no dependency on the transport. Always returns a
+ * result (falls back to `unknown`), and never throws.
+ */
+
+export type ConnectionErrorKind =
+  | 'host_not_allowed'
+  | 'invalid_url'
+  | 'auth_failed'
+  | 'access_denied'
+  | 'dns_error'
+  | 'connection_refused'
+  | 'tls_error'
+  | 'timeout'
+  | 'mixed_content'
+  | 'unknown'
+
+export interface ClassifiedConnectionError {
+  kind: ConnectionErrorKind
+  /** Short, human title for the error banner. */
+  title: string
+  /** What likely went wrong, in plain language. */
+  explanation: string
+  /** The single most useful next step the user can take. */
+  fix: string
+  /** Docs slug (passed to docsSiteUrl) for the relevant troubleshooting page. */
+  docsSlug: string
+  /** The original, unmodified error string (shown as technical detail). */
+  raw: string
+}
+
+interface Rule {
+  kind: ConnectionErrorKind
+  /** Lowercased substrings; any match selects this rule (first rule wins). */
+  match: string[]
+  title: string
+  explanation: string
+  fix: string
+  docsSlug: string
+}
+
+// Order matters: more specific rules first. The first rule whose any-substring
+// matches the lowercased message wins.
+const RULES: Rule[] = [
+  {
+    kind: 'host_not_allowed',
+    match: [
+      'internal addresses are not allowed',
+      'not allowed',
+      'unable to resolve host safely',
+      'dns pinning',
+      'private',
+      'loopback',
+      'ssrf',
+    ],
+    title: 'Host not allowed',
+    explanation:
+      'The hosted service blocks connections to private, internal, or loopback addresses (SSRF protection). Cloud can only reach publicly routable ClickHouse endpoints.',
+    fix: 'Use a public HTTPS endpoint (e.g. ClickHouse Cloud, or your server exposed on a public host/port). To monitor a private cluster, self-host ClickHouse Monitor inside your network instead.',
+    docsSlug: 'guides/connection-errors',
+  },
+  {
+    kind: 'invalid_url',
+    match: ['invalid host url', 'must be a full url', 'unsupported protocol'],
+    title: 'Invalid host URL',
+    explanation:
+      'The host must be a full HTTP(S) URL including the scheme and port, not a bare hostname.',
+    fix: 'Enter the URL as https://host:8443 (HTTPS, default secure port) or http://host:8123.',
+    docsSlug: 'reference/connection-presets',
+  },
+  {
+    kind: 'auth_failed',
+    match: [
+      'authentication failed',
+      'auth failed',
+      'code: 516',
+      'password is incorrect',
+      'wrong password',
+      'invalid credentials',
+      'access denied for user',
+      '403',
+    ],
+    title: 'Authentication failed',
+    explanation:
+      'ClickHouse rejected the username or password. The endpoint was reachable, but the credentials were not accepted.',
+    fix: 'Double-check the username and password. If the user is restricted by IP, allow the dashboard egress address. Note ClickHouse usernames are case-sensitive.',
+    docsSlug: 'getting-started/clickhouse-requirements',
+  },
+  {
+    kind: 'access_denied',
+    match: [
+      'not enough privileges',
+      'access_denied',
+      'code: 497',
+      'not granted',
+      'requires a grant',
+    ],
+    title: 'Not enough permissions',
+    explanation:
+      'The credentials are valid but the user lacks the SELECT grants the dashboard needs on ClickHouse system tables.',
+    fix: 'Grant the monitoring user SELECT on system.* (e.g. GRANT SELECT ON system.* TO monitoring). A read-only monitoring user is recommended.',
+    docsSlug: 'getting-started/clickhouse-requirements',
+  },
+  {
+    kind: 'dns_error',
+    match: [
+      'enotfound',
+      'getaddrinfo',
+      'could not resolve',
+      'name or service not known',
+      'eai_again',
+    ],
+    title: 'Host not found',
+    explanation:
+      'The hostname could not be resolved via DNS. The address is likely misspelled or not publicly resolvable.',
+    fix: 'Verify the hostname is spelled correctly and resolves publicly. Internal/VPN-only DNS names are not reachable from the hosted service.',
+    docsSlug: 'guides/connection-errors',
+  },
+  {
+    kind: 'connection_refused',
+    match: ['econnrefused', 'connection refused', 'connect econnrefused'],
+    title: 'Connection refused',
+    explanation:
+      'The host resolved but refused the connection. ClickHouse may not be listening on that port, or a firewall is blocking it.',
+    fix: 'Confirm the port (8443 for HTTPS, 8123 for HTTP) and that ClickHouse accepts external connections (listen_host) and the firewall allows the dashboard.',
+    docsSlug: 'guides/connection-errors',
+  },
+  {
+    kind: 'tls_error',
+    match: [
+      'certificate',
+      'self signed',
+      'self-signed',
+      'ssl',
+      'tls',
+      'unable to verify',
+      'err_tls',
+      'depth_zero_self_signed_cert',
+    ],
+    title: 'TLS / certificate error',
+    explanation:
+      'The TLS handshake failed — typically a self-signed or untrusted certificate, or an HTTPS/HTTP port mismatch.',
+    fix: 'Use a valid, publicly trusted certificate on the ClickHouse HTTPS port. If the server is HTTP-only, use an http:// URL and the HTTP port (8123).',
+    docsSlug: 'guides/connection-errors',
+  },
+  {
+    kind: 'timeout',
+    match: ['etimedout', 'timeout', 'timed out', 'esockettimedout'],
+    title: 'Connection timed out',
+    explanation:
+      'The host did not respond in time. It may be unreachable from the public internet, or a firewall is silently dropping packets.',
+    fix: 'Confirm the endpoint is publicly reachable and the firewall/security group allows inbound traffic from the dashboard on the ClickHouse port.',
+    docsSlug: 'guides/connection-errors',
+  },
+  {
+    kind: 'mixed_content',
+    match: ['mixed content', 'blocked:mixed', 'insecure'],
+    title: 'Blocked insecure request',
+    explanation:
+      'The browser blocked an HTTP request made from an HTTPS page (mixed content).',
+    fix: 'Use an HTTPS endpoint for the ClickHouse host so the request is secure end to end.',
+    docsSlug: 'guides/connection-errors',
+  },
+]
+
+const FALLBACK: Omit<ClassifiedConnectionError, 'raw'> = {
+  kind: 'unknown',
+  title: 'Connection failed',
+  explanation:
+    'The connection could not be established. The error below is the raw message returned by ClickHouse or the network layer.',
+  fix: 'Check the host URL, port, and credentials. The troubleshooting guide lists the most common causes.',
+  docsSlug: 'guides/connection-errors',
+}
+
+/**
+ * Classify a raw connection-error string into an actionable error.
+ *
+ * @param raw - The error message from the test endpoint (or any thrown error).
+ */
+export function classifyConnectionError(
+  raw: string | null | undefined
+): ClassifiedConnectionError {
+  const message = (raw ?? '').trim()
+  const haystack = message.toLowerCase()
+
+  for (const rule of RULES) {
+    if (rule.match.some((m) => haystack.includes(m))) {
+      return {
+        kind: rule.kind,
+        title: rule.title,
+        explanation: rule.explanation,
+        fix: rule.fix,
+        docsSlug: rule.docsSlug,
+        raw: message,
+      }
+    }
+  }
+
+  return { ...FALLBACK, raw: message || 'Connection failed' }
+}
+
+/**
+ * Extract a human error string from a test-endpoint JSON body, handling both
+ * shapes: the test route's `{ ok:false, error: string }` and the shared error
+ * builder's `{ success:false, error: { message } }` (validation/SSRF).
+ */
+export function extractConnectionErrorMessage(body: unknown): string {
+  if (body && typeof body === 'object') {
+    const err = (body as { error?: unknown }).error
+    if (typeof err === 'string') return err
+    if (err && typeof err === 'object') {
+      const m = (err as { message?: unknown }).message
+      if (typeof m === 'string') return m
+    }
+  }
+  return 'Connection failed'
+}

--- a/apps/dashboard/src/lib/swr/use-merged-hosts.ts
+++ b/apps/dashboard/src/lib/swr/use-merged-hosts.ts
@@ -1,24 +1,41 @@
 import type { HostInfo } from '@chm/types/host-info'
 
 import { useHosts } from './use-hosts'
+import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
 import { useBrowserConnections } from '@/lib/hooks/use-browser-connections'
 import { useUserConnections } from '@/lib/hooks/use-user-connections'
 
 /**
  * Extended host info that includes the connection source.
- * Env hosts come from environment variables; browser hosts are stored in localStorage.
+ *
+ * - `env`      — operator-configured hosts (CLICKHOUSE_HOST). Self-hosted: real
+ *                hosts, full access.
+ * - `demo`     — in CLOUD mode the env hosts are a PUBLIC read-only demo shown
+ *                to anonymous visitors (e.g. `duet-ubuntu`).
+ * - `browser`  — connections stored in this browser (localStorage).
+ * - `database` — per-user connections stored encrypted on the server (D1).
  */
 export interface MergedHostInfo extends HostInfo {
-  source: 'env' | 'browser' | 'database'
+  source: 'env' | 'demo' | 'browser' | 'database'
+  /** True for the public cloud demo — writes/agent are disabled on it. */
+  readOnly?: boolean
   /** Server-stored connection UUID when source is database. */
   connectionId?: string
 }
 
 /**
- * Combines env-configured hosts with browser-stored connections into a
- * unified, ordered array: env hosts first, then browser connections.
+ * Combines env-configured hosts with browser- and server-stored connections into
+ * a unified, ordered array.
  *
- * @returns {Object} hosts array, loading state, error
+ * Cloud (SaaS) mode changes how the env hosts are treated:
+ *   - Anonymous visitor → env hosts surface as a read-only `demo` so the product
+ *     is explorable without an account.
+ *   - Signed-in user → the demo is HIDDEN ("empty it"); they see only their own
+ *     browser/database connections. Zero connections drives the welcome/setup
+ *     page (FirstRunGate).
+ *
+ * Self-hosted (default, cloud mode off) is unchanged: env hosts are `env`,
+ * always shown, full access.
  *
  * @example
  * ```typescript
@@ -33,11 +50,27 @@ export function useMergedHosts() {
     connections: dbConnections,
     isLoading: dbLoading,
     featureEnabled: dbFeatureEnabled,
-    isSignedIn: dbAuthReady,
+    isSignedIn,
   } = useUserConnections()
 
+  const cloudMode = isCloudModeClient()
+
+  // In cloud mode the env hosts are a public read-only demo, and once a user
+  // signs in we hide the demo so their workspace starts empty. Self-hosted mode
+  // keeps env hosts as-is for everyone.
+  const envSource: MergedHostInfo['source'] = cloudMode ? 'demo' : 'env'
+  const showEnvHosts = !(cloudMode && isSignedIn)
+
   const mergedHosts: MergedHostInfo[] = [
-    ...envHosts.map((h): MergedHostInfo => ({ ...h, source: 'env' })),
+    ...(showEnvHosts
+      ? envHosts.map(
+          (h): MergedHostInfo => ({
+            ...h,
+            source: envSource,
+            readOnly: cloudMode,
+          })
+        )
+      : []),
     ...connections.map(
       (c): MergedHostInfo => ({
         id: c.hostId,
@@ -47,7 +80,7 @@ export function useMergedHosts() {
         source: 'browser',
       })
     ),
-    ...(dbFeatureEnabled && dbAuthReady
+    ...(dbFeatureEnabled && isSignedIn
       ? dbConnections.map(
           (c): MergedHostInfo => ({
             id: c.hostId,
@@ -67,7 +100,11 @@ export function useMergedHosts() {
     // Only the env-host fetch can be unauthorized; browser connections are local.
     isUnauthorized: Boolean(isUnauthorized),
     isLoading:
-      isLoading || !mounted || (dbFeatureEnabled && dbAuthReady && dbLoading),
+      isLoading || !mounted || (dbFeatureEnabled && isSignedIn && dbLoading),
     getConnectionByHostId,
+    /** Cloud SaaS mode is active for this deployment. */
+    cloudMode,
+    /** Whether the visitor is signed in (always false outside Clerk builds). */
+    isSignedIn,
   }
 }

--- a/apps/dashboard/src/vite-env.d.ts
+++ b/apps/dashboard/src/vite-env.d.ts
@@ -27,6 +27,9 @@ interface ImportMetaEnv {
   // Edition flag. 'community' (default, OSS, fail-open) | 'enterprise' (paid).
   // See lib/edition/. Unset or unrecognised → 'community'.
   readonly VITE_EDITION?: string
+  // Cloud (SaaS) mode. 'true' on dash.chmonitor.dev; unset/junk → self-hosted.
+  // See lib/cloud/cloud-mode.ts. When on, env hosts are a public read-only demo.
+  readonly VITE_CLOUD_MODE?: string
 }
 
 interface ImportMeta {

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -61,6 +61,11 @@ const CLIENT_ENV = {
   // Edition: 'community' (default, OSS, fail-open) | 'enterprise' (paid).
   // Unset or unrecognised values always resolve to 'community' in parseEdition().
   VITE_EDITION: e.VITE_EDITION ?? 'community',
+  // Cloud (SaaS) mode: 'true' on dash.chmonitor.dev, unset everywhere else.
+  // When on, env hosts are a public read-only demo and signed-in users get a
+  // clean per-user workspace. Unset/junk → self-hosted (OSS) behaviour, never
+  // degraded. See lib/cloud/cloud-mode.ts.
+  VITE_CLOUD_MODE: e.VITE_CLOUD_MODE ?? '',
   // Opt-in product telemetry: OFF by default — must be explicitly enabled.
   VITE_TELEMETRY_ENABLED:
     e.VITE_TELEMETRY_ENABLED ?? e.NEXT_PUBLIC_TELEMETRY_ENABLED ?? 'false',

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -65,6 +65,12 @@ CHM_FEATURE_AGENT_ACCESS = "authenticated"
 # Public read-only mode: anonymous visitors can view monitoring data; writes
 # (AI agent, KILL QUERY / OPTIMIZE TABLE, arbitrary SQL) still require sign-in.
 CHM_CLERK_PUBLIC_READ = "true"
+# Cloud (SaaS) mode: this is the hosted product. Env CLICKHOUSE_HOST is a PUBLIC
+# read-only DEMO; signed-in users get a clean per-user workspace and connect
+# their own host. Self-hosted/OSS deployments leave this UNSET (→ env hosts are
+# the operator's real hosts, full access). The build also needs VITE_CLOUD_MODE
+# inlined (set in the CI/deploy build step). See lib/cloud/cloud-mode.ts.
+CHM_CLOUD_MODE = "true"
 
 # AgentState conversation-store backend. The AGENTSTATE_API_KEY secret (set via
 # set-secrets.ts) alone activates it — resolveStore picks AgentState ahead of the
@@ -147,6 +153,8 @@ OPENROUTER_APP_NAME = "chmonitor"
 CHM_AUTH_PROVIDER = "clerk"
 CHM_FEATURE_AGENT_ACCESS = "authenticated"
 CHM_CLERK_PUBLIC_READ = "true"
+# Preview mirrors the hosted product: cloud (SaaS) mode on. See production note.
+CHM_CLOUD_MODE = "true"
 
 # AgentState conversation-store backend. Preview only persists to AgentState if a
 # separate AGENTSTATE_API_KEY_TEST secret is provided (see set-secrets.ts) — it

--- a/docs/content/guide/guides/connection-errors.mdx
+++ b/docs/content/guide/guides/connection-errors.mdx
@@ -1,0 +1,122 @@
+---
+description: Fix "Test connection" failures in ClickHouse Monitor — host not allowed, authentication failed, missing permissions, DNS, TLS, refused, and timeout errors.
+icon: PlugZap
+---
+
+# Connection errors
+
+When you add a ClickHouse host and click **Test connection**, the dashboard
+classifies any failure into one of the kinds below and links you straight here.
+Find your error and follow the fix.
+
+## Host not allowed
+
+> _Connections to internal addresses are not allowed._
+
+The hosted service at **dash.chmonitor.dev** blocks connections to private,
+internal, or loopback addresses (SSRF protection). The Cloud build can only
+reach **publicly routable** ClickHouse endpoints.
+
+**Fix**
+
+- Use a public HTTPS endpoint — for example ClickHouse Cloud, or your own server
+  exposed on a public host and port.
+- To monitor a **private** cluster (VPC, homelab, `localhost`, `10.x`, `192.168.x`),
+  **self-host** ClickHouse Monitor inside your network instead. The self-hosted
+  build has no address restriction. See [Deploy](/operate/deploy/self-host).
+
+## Invalid host URL
+
+> _Must be a full URL (e.g. https://my.clickhouse.cloud:8443)_
+
+The host must be a complete HTTP(S) URL including the scheme and port — not a
+bare hostname.
+
+**Fix** — enter `https://host:8443` (secure, default HTTPS port) or
+`http://host:8123` (plain HTTP port). See [Connection presets](/reference/connection-presets).
+
+## Authentication failed
+
+> _Code: 516. Authentication failed_ · HTTP 403
+
+The endpoint was reachable but ClickHouse rejected the **username or password**.
+
+**Fix**
+
+- Re-check the username and password. ClickHouse usernames are **case-sensitive**.
+- If the user is restricted by source IP (`HOST IP` in its definition), allow the
+  dashboard's egress address.
+
+## Not enough permissions
+
+> _Code: 497. Not enough privileges_
+
+The credentials are valid, but the user is missing the `SELECT` grants the
+dashboard needs on ClickHouse **system tables**.
+
+**Fix** — grant a read-only monitoring user access to the system database:
+
+```sql
+CREATE USER monitoring IDENTIFIED BY 'strong-password';
+GRANT SELECT ON system.* TO monitoring;
+-- optional: let the agent read your data schema
+GRANT SHOW TABLES, SHOW COLUMNS ON *.* TO monitoring;
+```
+
+See [ClickHouse requirements](/getting-started/clickhouse-requirements).
+
+## Host not found (DNS)
+
+> _getaddrinfo ENOTFOUND_ · _could not resolve host_
+
+The hostname could not be resolved. It is likely misspelled or only resolvable
+on a private/VPN network.
+
+**Fix** — verify the spelling and that the name resolves on the **public**
+internet. Internal-only DNS names are not reachable from Cloud — self-host to use
+them.
+
+## Connection refused
+
+> _connect ECONNREFUSED_
+
+The host resolved but actively refused the connection — ClickHouse is not
+listening on that port, or a firewall is blocking it.
+
+**Fix**
+
+- Confirm the port: `8443` (HTTPS) or `8123` (HTTP).
+- Ensure ClickHouse accepts external connections (`<listen_host>0.0.0.0</listen_host>`).
+- Open the firewall / security group for the dashboard.
+
+## TLS / certificate error
+
+> _self signed certificate_ · _unable to verify the first certificate_
+
+The TLS handshake failed — usually a self-signed or untrusted certificate, or an
+HTTPS request sent to an HTTP-only port.
+
+**Fix**
+
+- Use a publicly trusted certificate on the ClickHouse HTTPS port.
+- If the server is HTTP-only, use an `http://` URL with the HTTP port (`8123`).
+
+## Connection timed out
+
+> _connect ETIMEDOUT_
+
+The host did not respond in time — commonly unreachable from the public
+internet, or a firewall silently dropping packets.
+
+**Fix** — confirm the endpoint is publicly reachable and inbound traffic from the
+dashboard is allowed on the ClickHouse port.
+
+## Still stuck?
+
+- Test the same URL and credentials with `curl`:
+  ```bash
+  echo 'SELECT version()' | curl "https://host:8443/?user=monitoring&password=…" --data-binary @-
+  ```
+- See the general [Troubleshooting guide](/guides/troubleshooting).
+- For private clusters, [self-host ClickHouse Monitor](/operate/deploy/self-host)
+  — the same dashboard, no public-network requirement.

--- a/docs/knowledge/cloud-saas-mode.md
+++ b/docs/knowledge/cloud-saas-mode.md
@@ -1,0 +1,76 @@
+---
+id: cloud-saas-mode
+title: Cloud (SaaS) mode — one codebase, two products
+type: spec
+status: active
+updated: 2026-06-29
+tags:
+  - saas
+  - cloud
+  - auth
+  - hosts
+  - onboarding
+related:
+  - deployment
+  - agentstate-conversation-store
+  - conventions
+---
+
+# Cloud (SaaS) mode
+
+`dash.chmonitor.dev` is the hosted product; Docker / Kubernetes / a self-built
+Cloudflare Worker are the self-hosted (OSS) product. **Same codebase** — the only
+difference is runtime configuration, gated by the **cloud-mode** flag.
+
+## The invariant
+
+FAIL-CLOSED to self-hosted. Unset/junk `CHM_CLOUD_MODE` (runtime) or
+`VITE_CLOUD_MODE` (build) → NOT cloud → OSS behaviour unchanged. Cloud is purely
+additive; it never removes a monitoring feature. Mirrors `lib/edition`'s
+fail-open design (edition already lists `cloud` as an enterprise feature).
+
+## Behaviour matrix
+
+| | Self-hosted (default) | Cloud (`CHM_CLOUD_MODE=true`) |
+|---|---|---|
+| Env `CLICKHOUSE_HOST` | operator's real hosts, full access | public **read-only demo** (`source:'demo'`) |
+| Anonymous | sees env hosts | sees the demo (explore, no account) |
+| Signed-in | sees env hosts | demo hidden → own D1 connections only; zero → welcome/setup |
+| Auth | usually `none` | Clerk + `CHM_CLERK_PUBLIC_READ=true` |
+| Per-user conns | optional | on (`VITE_FEATURE_USER_CONNECTIONS_DB=true`) |
+
+Read-only on the demo is *enforced* by the existing public-read gate: anonymous
+principals can only read, and signed-in users never see the demo. The `readOnly`
+flag on `MergedHostInfo` is the UI cue.
+
+## Files
+
+- `apps/dashboard/src/lib/cloud/cloud-mode.ts` — resolvers + `parseCloudMode`. Tested.
+- `vite.config.ts` CLIENT_ENV + `src/vite-env.d.ts` — `VITE_CLOUD_MODE` inline.
+- `wrangler.toml` `[vars]` + `[env.preview.vars]` — `CHM_CLOUD_MODE = "true"`.
+- `.github/workflows/cloudflare.yml` build step — `VITE_CLOUD_MODE` + `VITE_FEATURE_USER_CONNECTIONS_DB` (hosted deploy only).
+- `lib/swr/use-merged-hosts.ts` — demo tagging, hide-when-signed-in; exposes `cloudMode` / `isSignedIn`.
+- `components/host/host-switcher.tsx` — Demo / read-only badges; `demo` behaves like `env` for live status (server-backed by index).
+- `components/host/first-run-empty-state.tsx` — redesigned welcome/setup (cloud signed-in / cloud anon / self-hosted).
+
+## Connection-error help
+
+`lib/connection-errors.ts` → `classifyConnectionError(raw)` maps a raw "Test
+connection" error string to a kind (`host_not_allowed`, `invalid_url`,
+`auth_failed`, `access_denied`, `dns_error`, `connection_refused`, `tls_error`,
+`timeout`, `mixed_content`, `unknown`) with title + explanation + fix + docs
+slug. `extractConnectionErrorMessage(body)` handles both response shapes
+(`{error:string}` from the test route, `{error:{message}}` from the shared
+validation builder). Rendered by `ConnectionErrorPanel` in `connection-form.tsx`.
+Docs: `docs/content/guide/guides/connection-errors.mdx` (slug
+`guides/connection-errors`). Tested in `lib/connection-errors.test.ts`.
+
+## Gotchas
+
+- `apps/dashboard` is NOT a root bun workspace — run `bun install` *inside*
+  `apps/dashboard`, not just at the monorepo root.
+- The dashboard `build` script calls `vite` directly; run via `bun run build`
+  from inside `apps/dashboard` (its local `.bin`), not from the repo root.
+- Build needs `VITE_CLOUD_MODE`/`VITE_FEATURE_USER_CONNECTIONS_DB` inlined to
+  exercise cloud behaviour locally — they are build-time, not runtime, on the
+  client.

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -1,0 +1,103 @@
+---
+id: product-design
+title: Product design system & UX conventions
+type: reference
+status: active
+updated: 2026-06-29
+tags:
+  - design-system
+  - ui
+  - ux
+  - tailwind
+  - shadcn
+  - tokens
+related:
+  - conventions
+  - cluster-topology
+  - cloud-saas-mode
+---
+
+# Product design system
+
+The durable reference behind the `product-design` Claude skill
+(`.claude/skills/product-design/`). New features should match these patterns.
+
+## Theme tokens (OKLCH, CSS-first Tailwind v4)
+
+Defined in `apps/dashboard/src/styles.css` via `@theme` blocks — **no
+`tailwind.config.ts`**. Dark mode is `.dark` class (`next-themes`,
+`attribute="class"`, `defaultTheme="system"`). Always use semantic tokens; they
+flip automatically between themes.
+
+Semantic tokens: `background foreground card card-foreground popover
+popover-foreground primary primary-foreground secondary secondary-foreground
+muted muted-foreground accent accent-foreground destructive border input ring`.
+
+Light is a near-neutral grayscale (`--background: oklch(1 0 0)`, `--foreground:
+oklch(0.145 0 0)`, `--border: oklch(0.922 0 0)`, `--muted-foreground:
+oklch(0.556 0 0)`). Dark inverts (`--background: oklch(0.145 0 0)`, `--border:
+oklch(1 0 0 / 10%)`).
+
+Chart series: `--chart-1..5` in OKLCH (orange/blue/dark-blue/yellow-green/green),
+plus HSL extras `--chart-6..13`. Semantic badge pairs exist as
+`--badge-{purple,blue,green,amber,pink,slate}` + `*-bg`.
+
+Radius: `--radius: 0.625rem` (10px) → `rounded-sm` 6px / `rounded-md` 9px /
+`rounded-lg` 10px / `rounded-xl` 14px.
+
+Fonts: Geist Variable (sans) + Geist Mono.
+
+**OKLCH gotcha:** prefer `oklch(from var(--x) l c h)` for derived colors over
+`hsl(var(--x))` — see `cluster-topology.md` for the dynamic-color lightness bug.
+
+## shadcn/ui rule
+
+Never edit `src/components/ui/*`. Customise via `className` at the call site or a
+wrapper in `src/components/`. Merge with `cn()` (`src/lib/utils.ts` = clsx +
+tailwind-merge). Primitives available: accordion, alert, avatar, badge,
+breadcrumb, button, button-group, card, carousel, checkbox, collapsible, command,
+dialog, drawer, dropdown-menu, empty-state, form, hover-card, icon-button, input,
+input-group, label, popover, progress, resizable, scroll-area, select, separator,
+sheet, sidebar, skeleton, tabs, tooltip (+ more).
+
+## Component patterns
+
+- **Charts:** `ChartContainer` (`components/charts/chart-container.tsx`) handles
+  skeleton/error/empty; `ChartCard` (`components/cards/chart-card.tsx`) provides
+  title, SQL view, `CardToolbar` metadata (queryTime/rowsRead/data sizes), stale
+  indicator, retry, optional date-range + log-scale. Fetch with `useChartData`
+  (`lib/swr/use-chart-data.ts`). Card styles centralised in
+  `components/charts/chart-card-styles.ts`.
+- **Data tables:** `components/data-table/` — resizing, wrap toggle, sorting
+  (`sorting-fns.ts`), pagination, faceted filters, row actions, SQL display.
+  Synthetic ids `__expand`/`select`/`action` are non-data.
+- **Empty:** `components/ui/empty-state.tsx`, variants `no-data | no-results |
+  error | loading | offline | table-missing | timeout | filtered-empty`.
+- **Skeletons:** `components/skeletons/` — match final layout (no layout shift).
+- **First-run:** `components/host/first-run-gate.tsx` →
+  `first-run-empty-state.tsx` (cloud signed-in / cloud anon / self-hosted).
+
+## UX conventions
+
+- `?host=N` routing; `useHostId()` (`lib/swr`); preserve params via
+  `buildUrl(pathname, { host }, searchParams)`.
+- Hooks at deepest consumer — no `hostId` prop drilling.
+- Graceful revalidation: keep data on `staleError`, show hover-revealed amber
+  `ChartStaleIndicator`; only blank out on initial `error && !hasData`.
+- Icons: `lucide-react`, `size-4` / `size-3.5`, `strokeWidth={1.5}`.
+- Class idioms: card `rounded-xl border bg-card shadow-sm`; dense text
+  `text-[13px]`; meta `text-xs text-muted-foreground`; hero title `text-xl
+  font-semibold tracking-tight`.
+
+## Brand
+
+`components/icons/chmonitor-logo.tsx` — orange metric bars + emerald health cap.
+Name "chmonitor" / "ClickHouse Monitor". Accents: orange (metrics), emerald
+(live/health).
+
+## File / naming
+
+kebab-case files; PascalCase components; `use*` hooks; `'use client'` on
+interactive client components; shared types in `src/types/` or
+`src/lib/api/types.ts`; route pages under `src/routes/(dashboard)/`; nav in
+`src/menu.ts`. See `conventions.md`.


### PR DESCRIPTION
## What

Makes `dash.chmonitor.dev` a **SaaS product from the same codebase** as the self-hosted (OSS) Docker / Kubernetes / Cloudflare Workers build. Cloud behaviour is **purely additive behind a fail-closed flag**, so the OSS experience is never degraded.

## Why one flag, fail-closed

Mirrors the existing `lib/edition` open-core philosophy: an unset/junk `CHM_CLOUD_MODE` / `VITE_CLOUD_MODE` resolves to **self-hosted**, so Docker/K8s/OSS keep env hosts as the operator's real, fully-accessible hosts.

## Changes

- **cloud-mode flag** — `lib/cloud/cloud-mode.ts` (`isCloudModeClient/Server`, `parseCloudMode`), inlined via `VITE_CLOUD_MODE` (vite.config), runtime `CHM_CLOUD_MODE` (wrangler prod + preview), set on the hosted CF deploy only (workflow).
- **host visibility** — in cloud mode env hosts become a public **read-only demo** (`duet-ubuntu`); once a user signs in the demo is **hidden** so their workspace starts empty (own D1 connections only → welcome/setup). Switcher gains Demo / read-only badges and treats `demo` like `env` for live status.
- **redesigned welcome/setup page** — `first-run-empty-state.tsx`, 3 modes: cloud signed-in (Connect your ClickHouse + Add-host dialog), cloud anonymous (sign-in + value prop), self-hosted (env-var guidance + browser add).
- **connection-error help** — `lib/connection-errors.ts` + `ConnectionErrorPanel` classify "Test connection" failures (host not allowed/SSRF, invalid URL, auth, permissions, DNS, refused, TLS, timeout) into title + cause + fix + per-kind docs link. New docs page `guides/connection-errors`.
- **docs + skills** — `docs/knowledge/{cloud-saas-mode,product-design}.md`; project skills `.claude/skills/{cloud-saas-mode,product-design}` (kept out of the AI-agent registry); CLAUDE.md SaaS section + an **auto-improve project skills** standing instruction.

## Compatibility

OSS / Docker / K8s / self-built Workers: **unchanged** (flag defaults off). Cloud-only behaviour = demo hosts + welcome framing + per-user storage; no monitoring feature is gated behind cloud mode.

## Tests

- 22 new unit tests (`cloud-mode`, `connection-errors`) — pass.
- `bun run build` (vite + `tsc --noEmit`, 119 routes prerendered) — green.
- Biome — clean.

https://claude.ai/code/session_014Kb8VR1HQAutubTegzVcjz