### PR TITLE
feat(telemetry): collector + default-on opt-out + D1 forever-retention

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -255,6 +255,27 @@ jobs:
         run: |
           npx --yes --package=wrangler@4 wrangler deploy --minify
 
+      # Telemetry collector (apps/telemetry) — standalone, no deps, no secrets.
+      # Public write-only ingest → Analytics Engine (+ optional D1). The
+      # destination for the dashboard's anonymous instance ping.
+      - name: Deploy telemetry collector preview
+        if: github.event_name == 'pull_request'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/telemetry
+        run: |
+          npx --yes --package=wrangler@4 wrangler deploy --env preview --minify
+
+      - name: Deploy telemetry collector
+        if: github.event_name != 'pull_request'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/telemetry
+        run: |
+          npx --yes --package=wrangler@4 wrangler deploy --minify
+
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v9

--- a/apps/dashboard/src/lib/context/app-context.tsx
+++ b/apps/dashboard/src/lib/context/app-context.tsx
@@ -10,7 +10,12 @@ import {
   useMemo,
   useState,
 } from 'react'
-import { getDeployTarget, maybePingInstance, track } from '@/lib/telemetry'
+import {
+  getDeployTarget,
+  installTelemetryEventSink,
+  maybePingInstance,
+  track,
+} from '@/lib/telemetry'
 
 export interface ContextValue {
   interval: ClickHouseInterval
@@ -88,9 +93,12 @@ export const AppProvider = ({
 
   // Fire-and-forget product telemetry — no-op unless enabled. Once per app load.
   useEffect(() => {
+    // Install the event transport before the first track() so app_loaded is
+    // delivered. No-op unless telemetry is enabled and an endpoint resolves.
+    installTelemetryEventSink()
     track('app_loaded', { deploy_target: getDeployTarget() })
-    // Daily anonymous instance ping — no-op unless telemetry is explicitly
-    // enabled AND CHM_TELEMETRY_ENDPOINT is configured.
+    // Daily anonymous instance ping — no-op when telemetry is disabled or the
+    // endpoint is empty.
     maybePingInstance()
   }, [])
 

--- a/apps/dashboard/src/lib/telemetry/config.test.ts
+++ b/apps/dashboard/src/lib/telemetry/config.test.ts
@@ -1,27 +1,25 @@
-import { isDoNotTrack, isTelemetryEnabled, parseTelemetryFlag } from './config'
+import {
+  isDoNotTrack,
+  isTelemetryEnabled,
+  isTelemetryFlagDisabled,
+} from './config'
 import { describe, expect, test } from 'bun:test'
 
-describe('parseTelemetryFlag', () => {
-  test('unset / null / empty → false', () => {
-    expect(parseTelemetryFlag(undefined)).toBe(false)
-    expect(parseTelemetryFlag(null)).toBe(false)
-    expect(parseTelemetryFlag('')).toBe(false)
-    expect(parseTelemetryFlag('   ')).toBe(false)
+describe('isTelemetryFlagDisabled', () => {
+  test('unset / null / unrecognised → not disabled (on)', () => {
+    expect(isTelemetryFlagDisabled(undefined)).toBe(false)
+    expect(isTelemetryFlagDisabled(null)).toBe(false)
+    expect(isTelemetryFlagDisabled('')).toBe(false)
+    expect(isTelemetryFlagDisabled('on')).toBe(false)
+    expect(isTelemetryFlagDisabled('enabled')).toBe(false)
   })
 
-  test('canonical "on" and convenience truthy values → true', () => {
-    expect(parseTelemetryFlag('on')).toBe(true)
-    expect(parseTelemetryFlag(' ON ')).toBe(true)
-    expect(parseTelemetryFlag('true')).toBe(true)
-    expect(parseTelemetryFlag('1')).toBe(true)
-    expect(parseTelemetryFlag('yes')).toBe(true)
-  })
-
-  test('off / false / arbitrary strings → false', () => {
-    expect(parseTelemetryFlag('off')).toBe(false)
-    expect(parseTelemetryFlag('false')).toBe(false)
-    expect(parseTelemetryFlag('0')).toBe(false)
-    expect(parseTelemetryFlag('enabled')).toBe(false)
+  test('off / 0 / false / no → disabled', () => {
+    expect(isTelemetryFlagDisabled('off')).toBe(true)
+    expect(isTelemetryFlagDisabled(' OFF ')).toBe(true)
+    expect(isTelemetryFlagDisabled('0')).toBe(true)
+    expect(isTelemetryFlagDisabled('false')).toBe(true)
+    expect(isTelemetryFlagDisabled('no')).toBe(true)
   })
 })
 

--- a/apps/dashboard/src/lib/telemetry/config.test.ts
+++ b/apps/dashboard/src/lib/telemetry/config.test.ts
@@ -1,4 +1,4 @@
-import { isTelemetryEnabled, parseTelemetryFlag } from './config'
+import { isDoNotTrack, isTelemetryEnabled, parseTelemetryFlag } from './config'
 import { describe, expect, test } from 'bun:test'
 
 describe('parseTelemetryFlag', () => {
@@ -26,15 +26,61 @@ describe('parseTelemetryFlag', () => {
 })
 
 describe('isTelemetryEnabled', () => {
-  test('off by default when nothing enables it', () => {
-    expect(isTelemetryEnabled({})).toBe(false)
+  test('ON by default when nothing disables it', () => {
+    expect(isTelemetryEnabled({})).toBe(true)
   })
 
-  test('runtime CHM_TELEMETRY=on enables', () => {
+  test('runtime CHM_TELEMETRY=on stays enabled', () => {
     expect(isTelemetryEnabled({ CHM_TELEMETRY: 'on' })).toBe(true)
   })
 
-  test('runtime CHM_TELEMETRY=off stays disabled', () => {
+  test('runtime CHM_TELEMETRY=off disables', () => {
     expect(isTelemetryEnabled({ CHM_TELEMETRY: 'off' })).toBe(false)
+  })
+
+  test('off/0/false/no all disable; unrecognised stays on', () => {
+    expect(isTelemetryEnabled({ CHM_TELEMETRY: '0' })).toBe(false)
+    expect(isTelemetryEnabled({ CHM_TELEMETRY: 'false' })).toBe(false)
+    expect(isTelemetryEnabled({ CHM_TELEMETRY: 'no' })).toBe(false)
+    expect(isTelemetryEnabled({ CHM_TELEMETRY: 'whatever' })).toBe(true)
+  })
+
+  test('DO_NOT_TRACK hard-overrides an explicit enable', () => {
+    expect(
+      isTelemetryEnabled({ CHM_TELEMETRY: 'on', DO_NOT_TRACK: '1' })
+    ).toBe(false)
+    expect(
+      isTelemetryEnabled({ CHM_TELEMETRY: 'on', DO_NOT_TRACK: 'true' })
+    ).toBe(false)
+  })
+
+  test('DO_NOT_TRACK=0 / false does not opt out', () => {
+    expect(
+      isTelemetryEnabled({ CHM_TELEMETRY: 'on', DO_NOT_TRACK: '0' })
+    ).toBe(true)
+    expect(
+      isTelemetryEnabled({ CHM_TELEMETRY: 'on', DO_NOT_TRACK: 'false' })
+    ).toBe(true)
+  })
+})
+
+describe('isDoNotTrack', () => {
+  test('unset → false (no preference)', () => {
+    expect(isDoNotTrack(undefined)).toBe(false)
+    expect(isDoNotTrack(null)).toBe(false)
+    expect(isDoNotTrack('')).toBe(false)
+  })
+
+  test('any truthy value → opt out', () => {
+    expect(isDoNotTrack('1')).toBe(true)
+    expect(isDoNotTrack('true')).toBe(true)
+    expect(isDoNotTrack('yes')).toBe(true)
+    expect(isDoNotTrack('whatever')).toBe(true)
+  })
+
+  test('explicit disabled values → false', () => {
+    expect(isDoNotTrack('0')).toBe(false)
+    expect(isDoNotTrack('false')).toBe(false)
+    expect(isDoNotTrack('no')).toBe(false)
   })
 })

--- a/apps/dashboard/src/lib/telemetry/config.ts
+++ b/apps/dashboard/src/lib/telemetry/config.ts
@@ -1,19 +1,53 @@
-// Telemetry enablement gate. OFF by default — telemetry runs only when it is
-// explicitly turned on, and makes ZERO network calls otherwise.
+// Telemetry enablement gate. ON by default — anonymous, privacy-first product
+// telemetry runs unless the user explicitly turns it off. Opting out is always
+// honored and always wins.
 //
 // Dual-source, mirroring lib/env.ts so the on/off semantics survive both the
 // Node and the Cloudflare Worker runtime:
 //   - Server: runtime CHM_TELEMETRY (Worker binding / process.env).
 //   - Client: build-time VITE_TELEMETRY_ENABLED (inlined by vite.config.ts).
 //
-// Canonical enabling value is `on` (i.e. CHM_TELEMETRY=on). `true`/`1`/`yes`
-// are also accepted for convenience. Anything else — including unset — is OFF.
+// Toggle OFF with CHM_TELEMETRY=off (also `0`/`false`/`no`). `on`/`true`/`1`/
+// `yes`, an unrecognised value, or unset all keep telemetry ON.
+//
+// Opt-out also honors the cross-tool DO_NOT_TRACK standard
+// (https://consoledonottrack.com) as a HARD override: any truthy DO_NOT_TRACK
+// turns telemetry off regardless of CHM_TELEMETRY. Server reads DO_NOT_TRACK;
+// the client build mirrors it as VITE_DO_NOT_TRACK.
+//
+// Note: even when enabled, the instance ping makes ZERO network calls unless a
+// collection endpoint is resolved (see instance-ping.ts). Setting the endpoint
+// env to an empty string is therefore an additional hard kill-switch.
 
 const ENABLED_VALUES = new Set(['on', 'true', '1', 'yes'])
+// Values that explicitly turn telemetry OFF. Anything else (including unset or
+// an unrecognised value) leaves it ON.
+const DISABLED_VALUES = new Set(['off', '0', 'false', 'no'])
+// DO_NOT_TRACK is treated as opt-out unless explicitly disabled. Only these
+// values mean "tracking allowed"; anything else that is set opts out.
+const DNT_DISABLED_VALUES = new Set(['0', 'false', 'no', ''])
 
+/** True when the value is one of the recognised explicit enable tokens. */
 export function parseTelemetryFlag(value: string | null | undefined): boolean {
   if (value == null) return false
   return ENABLED_VALUES.has(value.trim().toLowerCase())
+}
+
+/** True when the value explicitly turns telemetry off (off/0/false/no). */
+export function isTelemetryFlagDisabled(
+  value: string | null | undefined
+): boolean {
+  if (value == null) return false
+  return DISABLED_VALUES.has(value.trim().toLowerCase())
+}
+
+/**
+ * Returns true when the DO_NOT_TRACK opt-out is active. Per the DNT convention
+ * any set, non-"0"/"false"/"no" value means opt out; unset means no preference.
+ */
+export function isDoNotTrack(value: string | null | undefined): boolean {
+  if (value == null) return false
+  return !DNT_DISABLED_VALUES.has(value.trim().toLowerCase())
 }
 
 export function isTelemetryEnabled(
@@ -21,7 +55,12 @@ export function isTelemetryEnabled(
 ): boolean {
   const source =
     runtimeEnv ?? (typeof process !== 'undefined' ? process.env : {})
-  return parseTelemetryFlag(
+  // Hard opt-out wins over everything.
+  if (isDoNotTrack(source.DO_NOT_TRACK ?? import.meta.env.VITE_DO_NOT_TRACK)) {
+    return false
+  }
+  // On by default: enabled unless explicitly disabled.
+  return !isTelemetryFlagDisabled(
     source.CHM_TELEMETRY ?? import.meta.env.VITE_TELEMETRY_ENABLED
   )
 }

--- a/apps/dashboard/src/lib/telemetry/config.ts
+++ b/apps/dashboard/src/lib/telemetry/config.ts
@@ -19,19 +19,12 @@
 // collection endpoint is resolved (see instance-ping.ts). Setting the endpoint
 // env to an empty string is therefore an additional hard kill-switch.
 
-const ENABLED_VALUES = new Set(['on', 'true', '1', 'yes'])
 // Values that explicitly turn telemetry OFF. Anything else (including unset or
 // an unrecognised value) leaves it ON.
 const DISABLED_VALUES = new Set(['off', '0', 'false', 'no'])
 // DO_NOT_TRACK is treated as opt-out unless explicitly disabled. Only these
 // values mean "tracking allowed"; anything else that is set opts out.
 const DNT_DISABLED_VALUES = new Set(['0', 'false', 'no', ''])
-
-/** True when the value is one of the recognised explicit enable tokens. */
-export function parseTelemetryFlag(value: string | null | undefined): boolean {
-  if (value == null) return false
-  return ENABLED_VALUES.has(value.trim().toLowerCase())
-}
 
 /** True when the value explicitly turns telemetry off (off/0/false/no). */
 export function isTelemetryFlagDisabled(

--- a/apps/dashboard/src/lib/telemetry/event-sink.test.ts
+++ b/apps/dashboard/src/lib/telemetry/event-sink.test.ts
@@ -1,0 +1,91 @@
+import {
+  getEventEndpoint,
+  installTelemetryEventSink,
+  uninstallTelemetryEventSink,
+} from './event-sink'
+import { clearTelemetrySinks, track } from './track'
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+
+const PING = 'https://telemetry.chmonitor.dev/v1/ping'
+const EVENT = 'https://telemetry.chmonitor.dev/v1/event'
+const ON = { CHM_TELEMETRY: 'on', CHM_TELEMETRY_ENDPOINT: PING }
+
+afterEach(() => {
+  uninstallTelemetryEventSink()
+  clearTelemetrySinks()
+})
+
+describe('getEventEndpoint', () => {
+  test('derives /v1/event from the default ping endpoint', () => {
+    expect(getEventEndpoint({})).toBe(EVENT)
+    expect(getEventEndpoint({ CHM_TELEMETRY_ENDPOINT: PING })).toBe(EVENT)
+  })
+
+  test('empty endpoint stays empty', () => {
+    expect(getEventEndpoint({ CHM_TELEMETRY_ENDPOINT: '' })).toBe('')
+  })
+
+  test('custom non-/v1/ping endpoint is returned unchanged', () => {
+    expect(
+      getEventEndpoint({ CHM_TELEMETRY_ENDPOINT: 'https://x.example/ingest' })
+    ).toBe('https://x.example/ingest')
+  })
+})
+
+describe('installTelemetryEventSink', () => {
+  test('POSTs tracked events to the event endpoint when enabled', () => {
+    const calls: Array<{ url: string; body: unknown }> = []
+    const fetchMock = mock((url: string, init?: RequestInit) => {
+      calls.push({ url, body: JSON.parse(String(init?.body)) })
+      return Promise.resolve(new Response(null, { status: 204 }))
+    })
+    const original = globalThis.fetch
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    try {
+      installTelemetryEventSink(ON)
+      track('cluster_connected', { ch_flavor: 'oss', num_hosts: 2 }, ON)
+    } finally {
+      globalThis.fetch = original
+    }
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe(EVENT)
+    expect(calls[0].body).toEqual({
+      event: 'cluster_connected',
+      props: { deploy_target: 'unknown', ch_flavor: 'oss', num_hosts: 2 },
+    })
+  })
+
+  test('no-op when telemetry is disabled — no sink, no POST', () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(new Response(null, { status: 204 }))
+    )
+    const original = globalThis.fetch
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    try {
+      installTelemetryEventSink({ CHM_TELEMETRY: 'off' })
+      track('app_loaded', {}, { CHM_TELEMETRY: 'off' })
+    } finally {
+      globalThis.fetch = original
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(0)
+  })
+
+  test('is idempotent — installing twice registers one sink', () => {
+    const calls: number[] = []
+    const fetchMock = mock(() => {
+      calls.push(1)
+      return Promise.resolve(new Response(null, { status: 204 }))
+    })
+    const original = globalThis.fetch
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    try {
+      installTelemetryEventSink(ON)
+      installTelemetryEventSink(ON)
+      track('health_viewed', {}, ON)
+    } finally {
+      globalThis.fetch = original
+    }
+    expect(calls).toHaveLength(1)
+  })
+})

--- a/apps/dashboard/src/lib/telemetry/event-sink.ts
+++ b/apps/dashboard/src/lib/telemetry/event-sink.ts
@@ -1,0 +1,73 @@
+// Telemetry event transport. Installs a sink that POSTs typed, redacted events
+// to the collector's /v1/event endpoint.
+//
+// track() already gates on isTelemetryEnabled and redacts props before calling
+// sinks, so this transport only has to deliver. It is a hard no-op when
+// telemetry is disabled, when no endpoint resolves, or when fetch is
+// unavailable (SSR / prerender / non-browser).
+
+import { isTelemetryEnabled } from './config'
+import { getDeployTarget } from './environment'
+import { getPingEndpoint } from './instance-ping'
+import { registerTelemetrySink, type TelemetryPayload } from './track'
+
+const PING_PATH = '/v1/ping'
+const EVENT_PATH = '/v1/event'
+
+/**
+ * Derives the event endpoint from the configured ping endpoint: the collector
+ * exposes /v1/ping and /v1/event under the same origin. A custom endpoint that
+ * does not use the /v1/ping suffix is returned unchanged (single-URL ingest).
+ */
+export function getEventEndpoint(
+  runtimeEnv?: Record<string, string | undefined>
+): string {
+  const ping = getPingEndpoint(runtimeEnv)
+  if (!ping) return ''
+  return ping.endsWith(PING_PATH)
+    ? `${ping.slice(0, -PING_PATH.length)}${EVENT_PATH}`
+    : ping
+}
+
+let unregister: (() => void) | null = null
+
+/**
+ * Install the telemetry event sink (idempotent). Fire-and-forget POST per event,
+ * with all errors swallowed — telemetry must never affect the app. No-op when
+ * telemetry is disabled, no endpoint resolves, or fetch is unavailable.
+ */
+export function installTelemetryEventSink(
+  runtimeEnv?: Record<string, string | undefined>
+): void {
+  if (unregister) return
+  if (typeof fetch !== 'function') return
+  if (!isTelemetryEnabled(runtimeEnv)) return
+
+  const endpoint = getEventEndpoint(runtimeEnv)
+  if (!endpoint) return
+
+  const deployTarget = getDeployTarget()
+  unregister = registerTelemetrySink((payload: TelemetryPayload) => {
+    const body = JSON.stringify({
+      event: payload.event,
+      // deploy_target is a useful default dimension; explicit props win.
+      props: { deploy_target: deployTarget, ...payload.props },
+    })
+    fetch(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+      keepalive: true,
+    }).catch(() => {
+      // A failed telemetry POST must never surface to the app.
+    })
+  })
+}
+
+/** Remove the event sink (teardown / tests). */
+export function uninstallTelemetryEventSink(): void {
+  if (unregister) {
+    unregister()
+    unregister = null
+  }
+}

--- a/apps/dashboard/src/lib/telemetry/event-sink.ts
+++ b/apps/dashboard/src/lib/telemetry/event-sink.ts
@@ -6,10 +6,12 @@
 // telemetry is disabled, when no endpoint resolves, or when fetch is
 // unavailable (SSR / prerender / non-browser).
 
+import type { TelemetryPayload } from './events'
+
 import { isTelemetryEnabled } from './config'
 import { getDeployTarget } from './environment'
 import { getPingEndpoint } from './instance-ping'
-import { registerTelemetrySink, type TelemetryPayload } from './track'
+import { registerTelemetrySink } from './track'
 
 const PING_PATH = '/v1/ping'
 const EVENT_PATH = '/v1/event'

--- a/apps/dashboard/src/lib/telemetry/index.ts
+++ b/apps/dashboard/src/lib/telemetry/index.ts
@@ -22,6 +22,11 @@ export {
   parseMajorMinor,
 } from './environment'
 export {
+  getEventEndpoint,
+  installTelemetryEventSink,
+  uninstallTelemetryEventSink,
+} from './event-sink'
+export {
   isTelemetryEvent,
   TELEMETRY_EVENTS,
   type TelemetryEvent,

--- a/apps/dashboard/src/lib/telemetry/index.ts
+++ b/apps/dashboard/src/lib/telemetry/index.ts
@@ -9,7 +9,12 @@ export {
   ACTIVATION_REQUIRED,
   isActivated,
 } from './activation'
-export { isTelemetryEnabled, parseTelemetryFlag } from './config'
+export {
+  isDoNotTrack,
+  isTelemetryEnabled,
+  isTelemetryFlagDisabled,
+  parseTelemetryFlag,
+} from './config'
 export {
   type ChFlavor,
   type DeployTarget,
@@ -27,6 +32,7 @@ export {
 } from './events'
 export {
   buildPingPayload,
+  DEFAULT_TELEMETRY_ENDPOINT,
   getPingEndpoint,
   maybePingInstance,
   PING_INTERVAL_MS,

--- a/apps/dashboard/src/lib/telemetry/index.ts
+++ b/apps/dashboard/src/lib/telemetry/index.ts
@@ -13,7 +13,6 @@ export {
   isDoNotTrack,
   isTelemetryEnabled,
   isTelemetryFlagDisabled,
-  parseTelemetryFlag,
 } from './config'
 export {
   type ChFlavor,

--- a/apps/dashboard/src/lib/telemetry/instance-ping.test.ts
+++ b/apps/dashboard/src/lib/telemetry/instance-ping.test.ts
@@ -1,5 +1,6 @@
 import {
   buildPingPayload,
+  DEFAULT_TELEMETRY_ENDPOINT,
   getPingEndpoint,
   PING_INTERVAL_MS,
   type PingDeps,
@@ -252,16 +253,27 @@ describe('runInstancePing error resilience', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// No-op safety contract: when no endpoint is configured, fetch is never called.
+// Endpoint resolution + kill-switch.
 //
-// This is the critical invariant: the default build ships VITE_TELEMETRY_ENDPOINT=''
-// (see vite.config.ts), so even if a user sets VITE_TELEMETRY_ENABLED=true they
-// still make zero network calls until they also provide a collection endpoint.
+// Telemetry is ON by default and the endpoint defaults to the project collector,
+// so getPingEndpoint({}) resolves to DEFAULT_TELEMETRY_ENDPOINT. Setting the env
+// to an explicit empty string is the hard kill-switch: '' is preserved and
+// runInstancePing makes zero network calls.
 
-describe('no-op safety contract: no endpoint configured', () => {
-  test('getPingEndpoint returns empty string when runtimeEnv has no endpoint key', () => {
-    expect(getPingEndpoint({})).toBe('')
-    expect(getPingEndpoint({ UNRELATED: 'foo' })).toBe('')
+describe('endpoint resolution and kill-switch', () => {
+  test('getPingEndpoint falls back to the default collector when unset', () => {
+    expect(getPingEndpoint({})).toBe(DEFAULT_TELEMETRY_ENDPOINT)
+    expect(getPingEndpoint({ UNRELATED: 'foo' })).toBe(DEFAULT_TELEMETRY_ENDPOINT)
+  })
+
+  test('explicit endpoint env overrides the default', () => {
+    expect(
+      getPingEndpoint({ CHM_TELEMETRY_ENDPOINT: 'https://t.example/v1/ping' })
+    ).toBe('https://t.example/v1/ping')
+  })
+
+  test('explicit empty endpoint is preserved as the hard kill-switch', () => {
+    expect(getPingEndpoint({ CHM_TELEMETRY_ENDPOINT: '' })).toBe('')
   })
 
   test('runInstancePing never calls post when endpoint is empty — even with enabled:true', async () => {
@@ -269,7 +281,7 @@ describe('no-op safety contract: no endpoint configured', () => {
     const result = await runInstancePing(
       makeDeps({
         enabled: true,
-        endpoint: getPingEndpoint({}), // '' — mirrors the default build config
+        endpoint: '', // explicit kill-switch
         post: async (url, body) => {
           posts.push({ url, body })
         },

--- a/apps/dashboard/src/lib/telemetry/instance-ping.ts
+++ b/apps/dashboard/src/lib/telemetry/instance-ping.ts
@@ -22,6 +22,12 @@ export const PING_INTERVAL_MS = 24 * 60 * 60 * 1000 // 24 hours
 const STORAGE_KEY_INSTANCE_ID = 'chm_telemetry_instance_id'
 const STORAGE_KEY_LAST_PING = 'chm_telemetry_last_ping_at'
 
+// Default collection endpoint (the project's hosted collector — apps/telemetry).
+// Overridable via CHM_TELEMETRY_ENDPOINT / VITE_TELEMETRY_ENDPOINT. Set the env
+// to an empty string to hard-disable the network call even with telemetry on.
+export const DEFAULT_TELEMETRY_ENDPOINT =
+  'https://telemetry.chmonitor.dev/v1/ping'
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Pure helpers (no globals — unit-testable in isolation)
 
@@ -65,16 +71,18 @@ export function buildPingPayload(input: {
  * Resolves the telemetry collection endpoint.
  * Server: CHM_TELEMETRY_ENDPOINT from runtimeEnv.
  * Client: VITE_TELEMETRY_ENDPOINT inlined at build time.
- * Returns '' (empty string) when unset — callers treat '' as "no endpoint".
+ * Falls back to DEFAULT_TELEMETRY_ENDPOINT when the env var is unset.
+ * An explicit empty string ('') is preserved and treated by callers as
+ * "no endpoint" — a hard kill-switch for the network call.
  */
 export function getPingEndpoint(
   runtimeEnv?: Record<string, string | undefined>
 ): string {
   if (runtimeEnv) {
-    return runtimeEnv.CHM_TELEMETRY_ENDPOINT ?? ''
+    return runtimeEnv.CHM_TELEMETRY_ENDPOINT ?? DEFAULT_TELEMETRY_ENDPOINT
   }
   // Client bundle: build-time inline
-  return import.meta.env.VITE_TELEMETRY_ENDPOINT ?? ''
+  return import.meta.env.VITE_TELEMETRY_ENDPOINT ?? DEFAULT_TELEMETRY_ENDPOINT
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/apps/dashboard/src/lib/telemetry/track.test.ts
+++ b/apps/dashboard/src/lib/telemetry/track.test.ts
@@ -12,8 +12,8 @@ describe('track', () => {
     const seen: TelemetryPayload[] = []
     registerTelemetrySink((payload) => seen.push(payload))
 
-    track('app_loaded', { num_hosts: 1 }, {}) // {} → disabled
-    track('health_viewed', {}, { CHM_TELEMETRY: 'off' })
+    track('app_loaded', { num_hosts: 1 }, { DO_NOT_TRACK: '1' }) // opt-out wins
+    track('health_viewed', {}, { CHM_TELEMETRY: 'off' }) // explicit off
 
     expect(seen).toHaveLength(0)
   })

--- a/apps/dashboard/src/vite-env.d.ts
+++ b/apps/dashboard/src/vite-env.d.ts
@@ -16,6 +16,9 @@ interface ImportMetaEnv {
   readonly VITE_DEPLOY_TARGET?: string
   // Collection endpoint for the daily instance ping. Empty = no-op.
   readonly VITE_TELEMETRY_ENDPOINT?: string
+  // DO_NOT_TRACK opt-out (https://consoledonottrack.com). Any truthy value
+  // forces telemetry off regardless of VITE_TELEMETRY_ENABLED.
+  readonly VITE_DO_NOT_TRACK?: string
   // Build metadata (injected by vite.config define / CI build step)
   readonly VITE_GIT_SHA?: string
   readonly VITE_GIT_REF?: string

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -61,17 +61,21 @@ const CLIENT_ENV = {
   // Edition: 'community' (default, OSS, fail-open) | 'enterprise' (paid).
   // Unset or unrecognised values always resolve to 'community' in parseEdition().
   VITE_EDITION: e.VITE_EDITION ?? 'community',
-  // Opt-in product telemetry: OFF by default — must be explicitly enabled.
+  // Anonymous product telemetry: ON by default — opt out with VITE_TELEMETRY_ENABLED=off
+  // (or 0/false/no), VITE_DO_NOT_TRACK / DO_NOT_TRACK, or an empty endpoint.
   VITE_TELEMETRY_ENABLED:
-    e.VITE_TELEMETRY_ENABLED ?? e.NEXT_PUBLIC_TELEMETRY_ENABLED ?? 'false',
+    e.VITE_TELEMETRY_ENABLED ?? e.NEXT_PUBLIC_TELEMETRY_ENABLED ?? 'on',
+  // DO_NOT_TRACK opt-out (https://consoledonottrack.com). Hard override — any
+  // truthy value forces telemetry off. Mirrors the server DO_NOT_TRACK var.
+  VITE_DO_NOT_TRACK: e.VITE_DO_NOT_TRACK ?? e.DO_NOT_TRACK ?? '',
   // Deployment target (docker | helm | cf | dev | unknown). Set in CI build
   // steps so telemetry can distinguish deployment environments.
   VITE_DEPLOY_TARGET: e.VITE_DEPLOY_TARGET ?? 'unknown',
-  // Collection endpoint for the opt-in daily instance ping. Empty by default —
-  // the ping is a hard no-op unless BOTH this and VITE_TELEMETRY_ENABLED are
-  // explicitly set. Set to a collection URL (e.g. your own ClickHouse ingest
-  // endpoint) to enable. See docs/content/advanced/telemetry.mdx.
-  VITE_TELEMETRY_ENDPOINT: e.VITE_TELEMETRY_ENDPOINT ?? '',
+  // Collection endpoint for the daily instance ping. Defaults to the project
+  // collector (must match DEFAULT_TELEMETRY_ENDPOINT in lib/telemetry/instance-ping.ts);
+  // set to a different URL to self-host, or to '' as a hard no-network kill-switch.
+  VITE_TELEMETRY_ENDPOINT:
+    e.VITE_TELEMETRY_ENDPOINT ?? 'https://telemetry.chmonitor.dev/v1/ping',
   VITE_GIT_SHA:
     e.VITE_GIT_SHA ?? e.NEXT_PUBLIC_GIT_SHA ?? git('rev-parse HEAD'),
   VITE_GIT_REF:

--- a/apps/telemetry/README.md
+++ b/apps/telemetry/README.md
@@ -58,6 +58,30 @@ bun run deploy:preview    # preview    → preview.telemetry.chmonitor.dev
 ```
 
 No secrets required. The Analytics Engine dataset is created on first write.
+CI deploys this automatically on push to `main` (see `.github/workflows/cloudflare.yml`).
+
+### Optional: forever retention with D1
+
+Analytics Engine keeps data for only **3 months**, then auto-deletes. To keep
+metrics indefinitely (CF-native, free tier, no cron, no API token), attach D1 —
+the worker then also writes one deduped row per install per UTC day, which D1
+keeps forever:
+
+```bash
+cd apps/telemetry
+wrangler d1 create chm_telemetry             # copy the database_id
+# paste it into the commented [[d1_databases]] block in wrangler.toml, then:
+wrangler d1 migrations apply chm_telemetry   # applies migrations/0001_init.sql
+bun run deploy
+```
+
+The D1 write is a no-op until the binding exists, so deploying without D1 is safe
+(AE-only). Query forever-retained installs:
+
+```sql
+SELECT day, deploy_target, ch_version, COUNT(*) AS installs
+FROM ping_daily GROUP BY day, deploy_target, ch_version ORDER BY day DESC;
+```
 
 ## Querying (active installs, by version / deploy target)
 
@@ -100,33 +124,27 @@ GROUP BY event ORDER BY n DESC
 > counts via `count(DISTINCT index1)` remain accurate because `index1` is the
 > sampling key.
 
-## Turning it on
+## On by default; how to opt out
 
-Telemetry stays **off by default**. To collect from a deployment, set both:
+Telemetry is **on by default**. The endpoint defaults to this collector
+(`https://telemetry.chmonitor.dev/v1/ping`) and is overridable via env. Users opt
+out with any of:
 
 ```bash
-CHM_TELEMETRY=on
-CHM_TELEMETRY_ENDPOINT=https://telemetry.chmonitor.dev/v1/ping
+CHM_TELEMETRY=off              # also 0 / false / no
+DO_NOT_TRACK=1                 # cross-tool opt-out standard
+CHM_TELEMETRY_ENDPOINT=""      # hard kill-switch: no endpoint, no network call
 ```
 
-### Decision for the maintainer: default endpoint
-
-For the project to receive adoption data, the **official** builds (the hosted
-`dash.chmonitor.dev` and the published Docker/Helm images) would need to ship
-with the endpoint pre-set. That is a deliberate posture change from today's
-"opt-in + no endpoint" to "endpoint baked into official builds, **opt-out** via
-`CHM_TELEMETRY=off` / `DO_NOT_TRACK`". This collector does not make that choice;
-it only provides the destination. Decide and wire the default separately.
+The client also makes zero calls in SSR/prerender/non-browser contexts. See
+[`config.ts`](../dashboard/src/lib/telemetry/config.ts) and
+[`instance-ping.ts`](../dashboard/src/lib/telemetry/instance-ping.ts).
 
 ## Follow-ups (not in this collector)
 
-1. **Default endpoint** for official builds (above) — the only step needed to
-   make the instance ping actually flow.
-2. **Event sink** — register a `TelemetrySink` in the dashboard that POSTs to
+1. **Event sink** — register a `TelemetrySink` in the dashboard that POSTs to
    `/v1/event`, so the five `track()` events reach the collector. The collector
    already accepts them.
-3. **Send `ch_version` in the ping** — `maybePingInstance()` currently passes
+2. **Send `ch_version` in the ping** — `maybePingInstance()` currently passes
    `version: undefined`; thread the connected cluster's version through for a
    per-version install breakdown.
-4. **Honor `DO_NOT_TRACK`** in `config.ts` alongside `CHM_TELEMETRY` if the
-   default-on posture is adopted.

--- a/apps/telemetry/README.md
+++ b/apps/telemetry/README.md
@@ -142,9 +142,7 @@ The client also makes zero calls in SSR/prerender/non-browser contexts. See
 
 ## Follow-ups (not in this collector)
 
-1. **Event sink** — register a `TelemetrySink` in the dashboard that POSTs to
-   `/v1/event`, so the five `track()` events reach the collector. The collector
-   already accepts them.
-2. **Send `ch_version` in the ping** — `maybePingInstance()` currently passes
+1. **Send `ch_version` in the ping** — `maybePingInstance()` currently passes
    `version: undefined`; thread the connected cluster's version through for a
-   per-version install breakdown.
+   per-version install breakdown. (The `cluster_connected` event already carries
+   `ch_version` in its props, so version data already flows via `/v1/event`.)

--- a/apps/telemetry/README.md
+++ b/apps/telemetry/README.md
@@ -1,0 +1,132 @@
+# `apps/telemetry` — anonymous telemetry collector
+
+The ingest endpoint that `CHM_TELEMETRY_ENDPOINT` points at. It receives the
+anonymous instance ping (and optional aggregate events) emitted by
+[`apps/dashboard/src/lib/telemetry`](../dashboard/src/lib/telemetry) and records
+them to **Cloudflare Analytics Engine**.
+
+This closes the gap described in
+[`docs/content/operate/advanced/telemetry.mdx`](../../docs/content/operate/advanced/telemetry.mdx):
+the dashboard already builds and (when enabled) sends the ping, but until now no
+endpoint existed to receive it. `track()` events still need a client-side sink
+registered before they flow — see *Follow-ups* below.
+
+## What it accepts
+
+Public, write-only. No auth (it cannot be read back over HTTP — only the
+project's Cloudflare account can query the dataset). Everything is validated
+against a closed shape; unknown fields are ignored.
+
+### `POST /v1/ping`
+```json
+{ "instance_hash": "<64-char sha256 hex>", "deploy_target": "docker", "ch_version": "24.8" }
+```
+- `instance_hash` — required, must be 64-char lowercase hex. Opaque per-install
+  id (SHA-256 of a random local UUID). Used only to count distinct installs.
+- `deploy_target` — one of `docker | helm | cf | dev | unknown` (else `unknown`).
+- `ch_version` — optional, `MAJOR.MINOR` only (e.g. `24.8`); anything else dropped.
+
+### `POST /v1/event`
+```json
+{ "event": "cluster_connected", "props": { "deploy_target": "docker", "ch_version": "24.8", "ch_flavor": "oss" } }
+```
+- `event` — one of the five names in `TELEMETRY_EVENTS` (else rejected).
+- `props` — only `deploy_target`, `ch_version`, `ch_flavor` are stored.
+
+### `GET /` or `/health`
+Returns `200` — liveness only.
+
+## Storage layout (Analytics Engine `chm_telemetry`)
+
+| column   | ping                | event                       |
+|----------|---------------------|-----------------------------|
+| `index1` | `instance_hash`     | event name                  |
+| `blob1`  | `ping`              | `event`                     |
+| `blob2`  | `deploy_target`     | event name                  |
+| `blob3`  | `ch_version`        | `deploy_target`             |
+| `blob4`  | —                   | `ch_version`                |
+| `blob5`  | —                   | `ch_flavor`                 |
+| `double1`| `1`                 | `1`                         |
+
+## Deploy
+
+```bash
+cd apps/telemetry
+bun install
+bun run deploy            # production → telemetry.chmonitor.dev
+bun run deploy:preview    # preview    → preview.telemetry.chmonitor.dev
+```
+
+No secrets required. The Analytics Engine dataset is created on first write.
+
+## Querying (active installs, by version / deploy target)
+
+Analytics Engine is read via the SQL API with a Cloudflare API token that has
+**Account Analytics: Read**:
+
+```bash
+curl "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/analytics_engine/sql" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -d "
+    SELECT
+      blob2 AS deploy_target,
+      blob3 AS ch_version,
+      count(DISTINCT index1) AS active_installs
+    FROM chm_telemetry
+    WHERE blob1 = 'ping' AND timestamp > now() - INTERVAL '30' DAY
+    GROUP BY deploy_target, ch_version
+    ORDER BY active_installs DESC
+  "
+```
+
+Total active installs in the last 30 days:
+```sql
+SELECT count(DISTINCT index1) AS active_installs
+FROM chm_telemetry
+WHERE blob1 = 'ping' AND timestamp > now() - INTERVAL '30' DAY
+```
+
+Event volume by name (when the event sink is wired):
+```sql
+SELECT blob2 AS event, sum(double1) AS n
+FROM chm_telemetry
+WHERE blob1 = 'event' AND timestamp > now() - INTERVAL '30' DAY
+GROUP BY event ORDER BY n DESC
+```
+
+> Note: Analytics Engine adaptively samples high-volume datasets. For a self-host
+> telemetry volume this is effectively exact; if it ever samples, multiply
+> `double1` sums by `_sample_interval` for unbiased counts. Distinct-install
+> counts via `count(DISTINCT index1)` remain accurate because `index1` is the
+> sampling key.
+
+## Turning it on
+
+Telemetry stays **off by default**. To collect from a deployment, set both:
+
+```bash
+CHM_TELEMETRY=on
+CHM_TELEMETRY_ENDPOINT=https://telemetry.chmonitor.dev/v1/ping
+```
+
+### Decision for the maintainer: default endpoint
+
+For the project to receive adoption data, the **official** builds (the hosted
+`dash.chmonitor.dev` and the published Docker/Helm images) would need to ship
+with the endpoint pre-set. That is a deliberate posture change from today's
+"opt-in + no endpoint" to "endpoint baked into official builds, **opt-out** via
+`CHM_TELEMETRY=off` / `DO_NOT_TRACK`". This collector does not make that choice;
+it only provides the destination. Decide and wire the default separately.
+
+## Follow-ups (not in this collector)
+
+1. **Default endpoint** for official builds (above) — the only step needed to
+   make the instance ping actually flow.
+2. **Event sink** — register a `TelemetrySink` in the dashboard that POSTs to
+   `/v1/event`, so the five `track()` events reach the collector. The collector
+   already accepts them.
+3. **Send `ch_version` in the ping** — `maybePingInstance()` currently passes
+   `version: undefined`; thread the connected cluster's version through for a
+   per-version install breakdown.
+4. **Honor `DO_NOT_TRACK`** in `config.ts` alongside `CHM_TELEMETRY` if the
+   default-on posture is adopted.

--- a/apps/telemetry/migrations/0001_init.sql
+++ b/apps/telemetry/migrations/0001_init.sql
@@ -1,0 +1,14 @@
+-- Forever-retention store for the anonymous instance ping.
+-- Analytics Engine keeps data for only 3 months; D1 keeps these rows
+-- indefinitely. One row per install per UTC day (INSERT OR IGNORE dedupes), so
+-- distinct installs per day = COUNT(*) grouped by day.
+
+CREATE TABLE IF NOT EXISTS ping_daily (
+  day           TEXT NOT NULL,            -- 'YYYY-MM-DD' (UTC)
+  instance_hash TEXT NOT NULL,            -- opaque SHA-256 install id
+  deploy_target TEXT NOT NULL DEFAULT 'unknown',
+  ch_version    TEXT,                     -- 'MAJOR.MINOR' or NULL
+  PRIMARY KEY (day, instance_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ping_daily_day ON ping_daily (day);

--- a/apps/telemetry/package.json
+++ b/apps/telemetry/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "telemetry",
+  "description": "Public write-only Cloudflare Worker that collects chmonitor's anonymous instance ping + aggregate events into Analytics Engine",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy --minify",
+    "deploy:preview": "wrangler deploy --minify --env preview",
+    "dev": "wrangler dev",
+    "typegen": "wrangler types"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260515.0",
+    "wrangler": "^4.97.0"
+  }
+}

--- a/apps/telemetry/src/index.ts
+++ b/apps/telemetry/src/index.ts
@@ -27,6 +27,10 @@ export interface Env {
 
 const MAX_BODY_BYTES = 2048
 
+// These enums intentionally mirror the dashboard's canonical definitions
+// (apps/dashboard/src/lib/telemetry/environment.ts → DeployTarget/ChFlavor,
+// events.ts → TELEMETRY_EVENTS). They are duplicated rather than imported to
+// keep this worker a zero-dependency standalone deploy unit; keep them in sync.
 const DEPLOY_TARGETS = new Set(['docker', 'helm', 'cf', 'dev', 'unknown'])
 const CH_FLAVORS = new Set(['oss', 'altinity', 'cloud', 'unknown'])
 const EVENTS = new Set([

--- a/apps/telemetry/src/index.ts
+++ b/apps/telemetry/src/index.ts
@@ -1,0 +1,132 @@
+// chmonitor telemetry collector — the ingest endpoint that CHM_TELEMETRY_ENDPOINT
+// points at. Receives the anonymous instance ping (and optional aggregate
+// events) emitted by apps/dashboard/src/lib/telemetry and records them to
+// Cloudflare Analytics Engine.
+//
+// Privacy contract (mirrors the dashboard client, defense-in-depth):
+//   - Accepts ONLY a closed, validated shape. Unknown fields are ignored.
+//   - instance_hash is a SHA-256 hex digest of a random local id — opaque, not
+//     reversible to any identity. It is the only per-instance value, used purely
+//     to count distinct installs.
+//   - ch_version is accepted only as MAJOR.MINOR (e.g. "24.8"); anything else is
+//     dropped. deploy_target / ch_flavor are coerced to a known enum or dropped.
+//   - No IPs, hostnames, query text, or free-text are stored. The request IP is
+//     never written to Analytics Engine.
+//
+// There is no auth: this is a public, write-only ingest. It cannot be read back
+// over HTTP — only the project's Cloudflare account can query the dataset.
+
+export interface Env {
+  TELEMETRY: AnalyticsEngineDataset
+}
+
+const MAX_BODY_BYTES = 2048
+
+const DEPLOY_TARGETS = new Set(['docker', 'helm', 'cf', 'dev', 'unknown'])
+const CH_FLAVORS = new Set(['oss', 'altinity', 'cloud', 'unknown'])
+const EVENTS = new Set([
+  'app_loaded',
+  'cluster_connected',
+  'health_viewed',
+  'queries_viewed',
+  'ai_query_sent',
+])
+
+const HEX64 = /^[0-9a-f]{64}$/
+const MAJOR_MINOR = /^\d{1,3}\.\d{1,3}$/
+
+const CORS: Record<string, string> = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'POST, OPTIONS',
+  'access-control-allow-headers': 'content-type',
+  'access-control-max-age': '86400',
+}
+
+const noContent = () => new Response(null, { status: 204, headers: CORS })
+const bad = (status: number, msg: string) =>
+  new Response(msg, { status, headers: CORS })
+
+/** Coerce to a known enum value or fall back. */
+function asEnum(v: unknown, set: Set<string>, fallback: string): string {
+  return typeof v === 'string' && set.has(v) ? v : fallback
+}
+
+/** Accept only a MAJOR.MINOR version string, else ''. */
+function asVersion(v: unknown): string {
+  return typeof v === 'string' && MAJOR_MINOR.test(v) ? v : ''
+}
+
+async function readBody(req: Request): Promise<unknown | null> {
+  const len = Number(req.headers.get('content-length') ?? '0')
+  if (len > MAX_BODY_BYTES) return null
+  const text = await req.text()
+  if (text.length > MAX_BODY_BYTES) return null
+  try {
+    return JSON.parse(text)
+  } catch {
+    return null
+  }
+}
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const { pathname } = new URL(req.url)
+
+    if (req.method === 'OPTIONS') return noContent()
+
+    if (req.method === 'GET' && (pathname === '/' || pathname === '/health')) {
+      return new Response('chmonitor telemetry collector\n', {
+        status: 200,
+        headers: { 'content-type': 'text/plain', ...CORS },
+      })
+    }
+
+    if (req.method !== 'POST') return bad(405, 'method not allowed')
+
+    const body = await readBody(req)
+    if (body === null || typeof body !== 'object') {
+      return bad(400, 'invalid body')
+    }
+    const data = body as Record<string, unknown>
+
+    if (pathname === '/v1/ping') {
+      const instanceHash = data.instance_hash
+      if (typeof instanceHash !== 'string' || !HEX64.test(instanceHash)) {
+        return bad(400, 'invalid instance_hash')
+      }
+      const deployTarget = asEnum(data.deploy_target, DEPLOY_TARGETS, 'unknown')
+      const chVersion = asVersion(data.ch_version)
+
+      env.TELEMETRY.writeDataPoint({
+        // index1 — distinct-install key. Count installs with uniqExact(index1).
+        indexes: [instanceHash],
+        // blob1=kind, blob2=deploy_target, blob3=ch_version
+        blobs: ['ping', deployTarget, chVersion],
+        doubles: [1],
+      })
+      return noContent()
+    }
+
+    if (pathname === '/v1/event') {
+      const event = data.event
+      if (typeof event !== 'string' || !EVENTS.has(event)) {
+        return bad(400, 'invalid event')
+      }
+      const props = (data.props ?? {}) as Record<string, unknown>
+      const deployTarget = asEnum(props.deploy_target, DEPLOY_TARGETS, 'unknown')
+      const chVersion = asVersion(props.ch_version)
+      const chFlavor = asEnum(props.ch_flavor, CH_FLAVORS, 'unknown')
+
+      env.TELEMETRY.writeDataPoint({
+        // events carry no instance identity — index by event name.
+        indexes: [event],
+        // blob1=kind, blob2=event, blob3=deploy_target, blob4=ch_version, blob5=ch_flavor
+        blobs: ['event', event, deployTarget, chVersion, chFlavor],
+        doubles: [1],
+      })
+      return noContent()
+    }
+
+    return bad(404, 'not found')
+  },
+}

--- a/apps/telemetry/src/index.ts
+++ b/apps/telemetry/src/index.ts
@@ -18,6 +18,11 @@
 
 export interface Env {
   TELEMETRY: AnalyticsEngineDataset
+  // Optional forever-retention store. Analytics Engine keeps data for only 3
+  // months; when a D1 binding is present we ALSO record one deduped row per
+  // install per UTC day, which D1 keeps indefinitely (CF-native, free tier).
+  // Deploy works without it (AE-only) until the binding is configured.
+  DB?: D1Database
 }
 
 const MAX_BODY_BYTES = 2048
@@ -69,7 +74,11 @@ async function readBody(req: Request): Promise<unknown | null> {
 }
 
 export default {
-  async fetch(req: Request, env: Env): Promise<Response> {
+  async fetch(
+    req: Request,
+    env: Env,
+    ctx: ExecutionContext
+  ): Promise<Response> {
     const { pathname } = new URL(req.url)
 
     if (req.method === 'OPTIONS') return noContent()
@@ -104,6 +113,23 @@ export default {
         blobs: ['ping', deployTarget, chVersion],
         doubles: [1],
       })
+
+      // Forever retention (optional): AE keeps only 3 months, so when a D1
+      // binding is present also record one deduped row per install per UTC day.
+      // INSERT OR IGNORE on (day, instance_hash) keeps storage to one row per
+      // install per day; D1 retains it indefinitely. Runs after the response.
+      if (env.DB) {
+        const day = new Date().toISOString().slice(0, 10) // YYYY-MM-DD (UTC)
+        ctx.waitUntil(
+          env.DB.prepare(
+            'INSERT OR IGNORE INTO ping_daily (day, instance_hash, deploy_target, ch_version) VALUES (?, ?, ?, ?)'
+          )
+            .bind(day, instanceHash, deployTarget, chVersion || null)
+            .run()
+            .then(() => undefined)
+            .catch(() => undefined)
+        )
+      }
       return noContent()
     }
 

--- a/apps/telemetry/tsconfig.json
+++ b/apps/telemetry/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "WebWorker"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["./src/**/*.ts"]
+}

--- a/apps/telemetry/wrangler.toml
+++ b/apps/telemetry/wrangler.toml
@@ -25,11 +25,25 @@ compatibility_flags = ["global_fetch_strictly_public"]
 [observability]
 enabled = true
 
-# Analytics Engine — the storage sink. No binding-side config needed beyond the
-# dataset name; rows are written via env.TELEMETRY.writeDataPoint().
+# Analytics Engine — hot store (3-month retention, ad-hoc SQL). No binding-side
+# config needed beyond the dataset name; rows go in via writeDataPoint().
 [[analytics_engine_datasets]]
 binding = "TELEMETRY"
 dataset = "chm_telemetry"
+
+# D1 — forever store (optional). AE auto-deletes after 3 months; D1 keeps one
+# deduped row per install per day indefinitely. The worker no-ops the D1 write
+# unless this binding exists, so it deploys AE-only until you create the DB:
+#
+#   wrangler d1 create chm_telemetry           # copy the printed database_id below
+#   wrangler d1 migrations apply chm_telemetry # applies migrations/0001_init.sql
+#
+# then uncomment:
+# [[d1_databases]]
+# binding = "DB"
+# database_name = "chm_telemetry"
+# database_id = "<paste id from `wrangler d1 create`>"
+# migrations_dir = "migrations"
 
 # Custom domain — auto-provisions DNS + cert on the chmonitor.dev zone.
 [[routes]]

--- a/apps/telemetry/wrangler.toml
+++ b/apps/telemetry/wrangler.toml
@@ -1,0 +1,51 @@
+# wrangler.toml — chmonitor telemetry collector
+#
+# Public, write-only ingest for the anonymous instance ping + aggregate events
+# emitted by apps/dashboard/src/lib/telemetry. Records to Cloudflare Analytics
+# Engine (no database to manage; queried via the AE SQL API from the project's
+# Cloudflare account only).
+#
+# Deploy:
+#   cd apps/telemetry && bun run deploy
+#
+# Point instances at it by setting, on the dashboard deployment:
+#   CHM_TELEMETRY=on
+#   CHM_TELEMETRY_ENDPOINT=https://telemetry.chmonitor.dev/v1/ping
+# (Both are required — telemetry is inert unless flag AND endpoint are set.)
+
+name = "chmonitor-telemetry"
+main = "src/index.ts"
+compatibility_date = "2026-05-28"
+
+minify = true
+upload_source_maps = false
+
+compatibility_flags = ["global_fetch_strictly_public"]
+
+[observability]
+enabled = true
+
+# Analytics Engine — the storage sink. No binding-side config needed beyond the
+# dataset name; rows are written via env.TELEMETRY.writeDataPoint().
+[[analytics_engine_datasets]]
+binding = "TELEMETRY"
+dataset = "chm_telemetry"
+
+# Custom domain — auto-provisions DNS + cert on the chmonitor.dev zone.
+[[routes]]
+pattern = "telemetry.chmonitor.dev"
+custom_domain = true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Preview environment
+# ─────────────────────────────────────────────────────────────────────────────
+[env.preview]
+name = "preview-chmonitor-telemetry"
+
+[[env.preview.analytics_engine_datasets]]
+binding = "TELEMETRY"
+dataset = "chm_telemetry_preview"
+
+[[env.preview.routes]]
+pattern = "preview.telemetry.chmonitor.dev"
+custom_domain = true

--- a/docs/content/operate/advanced/telemetry.mdx
+++ b/docs/content/operate/advanced/telemetry.mdx
@@ -104,7 +104,7 @@ The endpoint is received by the [telemetry collector](https://github.com/chmonit
 
 > **Retention:** Analytics Engine stores data for **3 months**, then auto-deletes. For permanent retention the collector can also write to D1 (Cloudflare's SQLite), which keeps one deduped row per install per day forever. See the collector README.
 
-**Event tracking** (`track()`) is typed and redacted but has no client-side sink registered yet, so the five events are dropped until a sink is wired (a follow-up). The collector already accepts them at `/v1/event`.
+**Event tracking** (`track()`) is typed and redacted, then delivered by the event sink to the collector's `/v1/event` endpoint. The sink installs once per app load and is a hard no-op when telemetry is disabled or no endpoint resolves.
 
 ---
 

--- a/docs/content/operate/advanced/telemetry.mdx
+++ b/docs/content/operate/advanced/telemetry.mdx
@@ -1,26 +1,32 @@
 ---
-description: Opt-in anonymous product telemetry — off by default, no PII, no third-party trackers, and inert until both a flag and an endpoint are set.
+description: Anonymous product telemetry — on by default, opt out anytime, no PII, no third-party trackers.
 icon: Radio
 ---
 
 # Product Telemetry
 
-chmonitor includes an opt-in, anonymous telemetry system. It is **off by default** — no data leaves your instance unless you explicitly enable it.
+chmonitor includes an anonymous, privacy-first telemetry system. It is **on by default** and you can turn it off at any time — with a single environment variable. It collects lightweight, aggregate product analytics (five events, three dimensions, no PII) to help the project understand how the dashboard is used at a high level.
 
-This is separate from [Self-Tracking](/operate/advanced/self-tracking), which writes dashboard usage events to your own ClickHouse instance. Telemetry is lightweight product analytics (five events, three dimensions, no PII) intended to help the project understand how the dashboard is used at a high level.
+This is separate from [Self-Tracking](/operate/advanced/self-tracking), which writes dashboard usage events to your own ClickHouse instance.
 
 ---
 
-## Off by default
+## On by default — how to opt out
 
-Telemetry is disabled unless you set one of the following environment variables:
+Telemetry runs unless you explicitly turn it off. Any **one** of these disables it:
 
-| Variable | Where it applies | Value to enable |
+| Variable | Where it applies | Value to disable |
 |---|---|---|
-| `CHM_TELEMETRY` | Server runtime (Worker binding / `process.env`) | `on` |
-| `VITE_TELEMETRY_ENABLED` | Client build-time (inlined by Vite) | `true` |
+| `CHM_TELEMETRY` | Server runtime (Worker binding / `process.env`) | `off` (also `0`, `false`, `no`) |
+| `VITE_TELEMETRY_ENABLED` | Client build-time (inlined by Vite) | `off` |
+| `DO_NOT_TRACK` | Server runtime — the cross-tool [opt-out standard](https://consoledonottrack.com) | `1` (any truthy value) |
+| `CHM_TELEMETRY_ENDPOINT` | Server runtime — collection endpoint | `""` (empty = hard kill-switch, no network call) |
 
-`CHM_TELEMETRY=on` is the canonical form. `true`, `1`, and `yes` are also accepted. Any other value — including unset — keeps telemetry off.
+`DO_NOT_TRACK` is a **hard override**: when set, telemetry is off regardless of `CHM_TELEMETRY`. Leaving everything unset keeps telemetry **on**.
+
+### Collection endpoint
+
+Data is sent to the project's collector at `https://telemetry.chmonitor.dev/v1/ping` by default. Point it elsewhere (e.g. your own [collector](https://github.com/chmonitor/chmonitor/tree/main/apps/telemetry)) by setting `CHM_TELEMETRY_ENDPOINT` (server) or `VITE_TELEMETRY_ENDPOINT` (client build). Setting it to an empty string disables the network call entirely.
 
 ---
 
@@ -60,44 +66,45 @@ The ClickHouse version is always truncated to `MAJOR.MINOR` (e.g. `24.8`) — ne
 
 ---
 
-## How to enable
+## How to disable
 
-<Tabs items={['Server-side', 'Client build-time']}>
+<Tabs items={['Server-side', 'Do Not Track', 'Client build-time']}>
 <Tab value="Server-side">
 ```bash
-CHM_TELEMETRY=on
+CHM_TELEMETRY=off
 ```
 
-Applies to Cloudflare Worker, Docker, and Kubernetes deployments.
+Applies to Cloudflare Worker, Docker, and Kubernetes deployments. `0`, `false`, and `no` are also accepted.
+</Tab>
+<Tab value="Do Not Track">
+```bash
+DO_NOT_TRACK=1
+```
+
+The cross-tool [opt-out standard](https://consoledonottrack.com). A hard override — telemetry is off regardless of `CHM_TELEMETRY`.
 </Tab>
 <Tab value="Client build-time">
 ```bash
-VITE_TELEMETRY_ENABLED=true
+VITE_TELEMETRY_ENABLED=off
+# or, to remove the endpoint entirely:
+VITE_TELEMETRY_ENDPOINT=""
 ```
 
-Inlined at `bun run build` / `vite build`. Both variables are independent — you can enable server-side telemetry without a client rebuild or vice versa.
+Inlined at `bun run build` / `vite build`.
 </Tab>
 </Tabs>
 
 ---
 
-## How to disable
+## Transport and storage
 
-Telemetry is off by default — you do not need to do anything to disable it. To confirm it is off, ensure neither `CHM_TELEMETRY` nor `VITE_TELEMETRY_ENABLED` is set (or set them to any value other than the accepted ones above).
+**Instance ping** (`maybePingInstance`) runs once per day when due, sending a hashed install id + deploy target + ClickHouse `MAJOR.MINOR` to the collection endpoint. It is a hard no-op when telemetry is disabled, when the endpoint is an empty string, or in non-browser contexts (SSR/prerender).
 
----
+The endpoint is received by the [telemetry collector](https://github.com/chmonitor/chmonitor/tree/main/apps/telemetry) — a public, write-only Cloudflare Worker that records to **Analytics Engine** (and, when D1 is attached, keeps a deduped daily row per install indefinitely). It cannot be read back over HTTP.
 
-## Current transport status
+> **Retention:** Analytics Engine stores data for **3 months**, then auto-deletes. For permanent retention the collector can also write to D1 (Cloudflare's SQLite), which keeps one deduped row per install per day forever. See the collector README.
 
-Two separate systems exist, each with its own no-op guarantee:
-
-**Instance ping** (`maybePingInstance`) is wired to the app and runs once per day when due. It is a hard no-op unless **both** conditions hold simultaneously:
-1. Telemetry is explicitly enabled (`CHM_TELEMETRY=on` / `VITE_TELEMETRY_ENABLED=true`).
-2. A collection endpoint is explicitly configured (`CHM_TELEMETRY_ENDPOINT` / `VITE_TELEMETRY_ENDPOINT`).
-
-Neither variable is set by default. Because both are required, enabling just the flag makes zero network calls — the code short-circuits before any `fetch()` is invoked.
-
-**Event tracking** (`track()`) has no default transport sink. Events are typed and redacted internally, but with no sink registered they are silently dropped. A self-hosted sink (writing to your own ClickHouse) will be added in a later release. Enabling telemetry today produces no network traffic from event tracking.
+**Event tracking** (`track()`) is typed and redacted but has no client-side sink registered yet, so the five events are dropped until a sink is wired (a follow-up). The collector already accepts them at `/v1/event`.
 
 ---
 
@@ -114,11 +121,12 @@ A session is considered activated when a cluster is connected and the user viewe
 ## Privacy stance
 
 <Callout type="info" title="Privacy by design">
-- **Opt-in only** — telemetry is off unless you set the env var.
-- **Self-hosted** — chmonitor is fully self-hostable; your ClickHouse data never leaves your network regardless of telemetry settings.
+- **One-switch opt-out** — `CHM_TELEMETRY=off` or `DO_NOT_TRACK=1` disables it completely, anytime.
+- **Self-hosted data stays put** — chmonitor is fully self-hostable; your ClickHouse data never leaves your network regardless of telemetry settings.
 - **No third-party trackers** — there are no analytics SDKs, beacon scripts, or third-party pixels in the application.
 - **No PII by design** — the event schema and redaction layer are written to make PII collection structurally impossible, not just policy-forbidden.
-- **Inert by default** — both the telemetry flag and a collection endpoint must be explicitly set for any network call to occur. Enabling just the flag (without an endpoint) still makes zero network calls.
+- **Anonymous** — only a hashed random install id is sent; it cannot be tied to an identity, and the collector never stores request IPs.
+- **Hard kill-switch** — setting the endpoint env to an empty string stops all network calls regardless of any other setting.
 </Callout>
 
 ---


### PR DESCRIPTION
Makes chmonitor's anonymous telemetry actually work end-to-end, with the **on-by-default, opt-out** posture.

## What's here

**Collector** (`apps/telemetry`) — the missing ingest the dashboard already pings. Public, write-only Cloudflare Worker → **Analytics Engine**; validates the existing payload defense-in-depth; can't be read back over HTTP.
- `POST /v1/ping` `{ instance_hash, deploy_target, ch_version? }`, `POST /v1/event`, `GET /health`.

**On by default, opt-out** (`config.ts`) — telemetry runs unless turned off:
- `CHM_TELEMETRY=off` (also `0`/`false`/`no`)
- `DO_NOT_TRACK=1` — the [cross-tool standard](https://consoledonottrack.com), a hard override
- `CHM_TELEMETRY_ENDPOINT=""` — hard kill-switch (no endpoint → no network call)

**ENV-configurable endpoint** (`instance-ping.ts`) — defaults to `https://telemetry.chmonitor.dev/v1/ping`, override via `CHM_TELEMETRY_ENDPOINT` / `VITE_TELEMETRY_ENDPOINT`. The deliberately-tested invariants were updated to the new posture (empty-string is still the no-network guarantee).

**Forever retention** (D1) — Analytics Engine auto-deletes after **3 months**. When a D1 binding is attached, the collector also writes one deduped row per install per UTC day, kept **indefinitely** (CF-native, free tier, no cron, no API token). Guarded — deploys AE-only until D1 is created. Migration included.

**CI deploy** — `cloudflare.yml` deploys `apps/telemetry` on push (prod) / PR (preview). No secrets needed.

**Docs** — `telemetry.mdx` rewritten: on-by-default, the opt-out switches, the collector, and 3-month AE vs permanent D1 retention.

## Querying

```sql
-- last 30d active installs (AE)
SELECT blob2 AS deploy_target, blob3 AS ch_version, count(DISTINCT index1) AS active_installs
FROM chm_telemetry WHERE blob1='ping' AND timestamp > now() - INTERVAL '30' DAY
GROUP BY deploy_target, ch_version ORDER BY active_installs DESC;

-- forever (D1)
SELECT day, deploy_target, ch_version, COUNT(*) AS installs
FROM ping_daily GROUP BY day, deploy_target, ch_version ORDER BY day DESC;
```

## Validation
- Telemetry unit tests: **44 pass**.
- Worker: `wrangler deploy --dry-run` clean.

## Deploy / setup notes
- `telemetry.chmonitor.dev` deploys via CI on merge to `main` (custom domain auto-provisioned).
- For forever-retention: `wrangler d1 create chm_telemetry`, paste the id into the commented block in `apps/telemetry/wrangler.toml`, `wrangler d1 migrations apply chm_telemetry`, redeploy.

https://claude.ai/code/session_01NU5HGzTVReykEVa7tzX78E