### PR TITLE
feat(saas): add reachable /setup "Connect a host" page

### DIFF
--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -64,6 +64,14 @@ export const menuItemsConfig: MenuItem[] = [
     permission: { feature: 'overview' },
   },
   {
+    // Standalone welcome/setup surface — add a ClickHouse host at any time.
+    // No permission gate: useful in every mode (cloud demo, signed-in, self-host).
+    title: 'Connect a host',
+    href: '/setup',
+    icon: UnplugIcon,
+    section: 'main',
+  },
+  {
     title: 'AI Agent',
     href: '/agents',
     icon: SparklesIcon,

--- a/apps/dashboard/src/routes/(dashboard)/setup.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/setup.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { FirstRunEmptyState } from '@/components/host/first-run-empty-state'
+
+/**
+ * Standalone setup / "Connect a host" page.
+ *
+ * Renders the same welcome/setup surface that `FirstRunGate` shows on first run,
+ * but as a permanently reachable route — so a signed-in cloud user can add
+ * another host at any time, and the onboarding design has a stable URL.
+ * `FirstRunEmptyState` adapts its content to the deployment + auth state
+ * (cloud signed-in / cloud anonymous / self-hosted).
+ */
+export const Route = createFileRoute('/(dashboard)/setup')({
+  component: FirstRunEmptyState,
+})


### PR DESCRIPTION
## What

Adds a permanent `/setup` route + a **Connect a host** item in the main nav, reusing the welcome/setup surface (`FirstRunEmptyState`) that previously only appeared via `FirstRunGate` on first run.

## Why

A SaaS user should be able to reach onboarding / add another host any time — not only when they have zero hosts. It also gives the redesigned welcome/setup design a stable URL.

## Behaviour

`FirstRunEmptyState` already adapts to the deployment + auth state, so `/setup` shows:
- **Cloud, signed-in** → "Connect your ClickHouse" + Add-host dialog
- **Cloud, anonymous** → sign-in + value prop
- **Self-hosted** → env-var guidance + browser add

No permission gate (useful in every mode). Frontend only — no infra/deploy-config change.

## Verification

`bun run build` (vite + `tsc --noEmit`, `/setup` prerendered) — green. Biome clean.

https://claude.ai/code/session_014Kb8VR1HQAutubTegzVcjz