### PR TITLE
refactor(saas): share isServerHost; dedup demo badge + docs footer

### DIFF
--- a/apps/dashboard/src/components/host/first-run-empty-state.tsx
+++ b/apps/dashboard/src/components/host/first-run-empty-state.tsx
@@ -110,16 +110,21 @@ function SetupStep({
   )
 }
 
-function DocLink({ slug, children }: { slug: string; children: ReactNode }) {
+function DocsFooter({ links }: { links: { slug: string; label: string }[] }) {
   return (
-    <a
-      href={docsSiteUrl(slug)}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-3 text-[13px] font-medium hover:bg-muted"
-    >
-      {children}
-    </a>
+    <div className="flex flex-wrap items-center justify-center gap-2">
+      {links.map(({ slug, label }) => (
+        <a
+          key={slug}
+          href={docsSiteUrl(slug)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-3 text-[13px] font-medium hover:bg-muted"
+        >
+          {label}
+        </a>
+      ))}
+    </div>
   )
 }
 
@@ -177,15 +182,19 @@ function ConnectYourHost({ onAddHost }: { onAddHost: () => void }) {
         </Button>
       </div>
 
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <DocLink slug="getting-started">Getting started</DocLink>
-        <DocLink slug="getting-started/clickhouse-requirements">
-          Create a monitoring user
-        </DocLink>
-        <DocLink slug="guides/connection-errors">
-          Connection troubleshooting
-        </DocLink>
-      </div>
+      <DocsFooter
+        links={[
+          { slug: 'getting-started', label: 'Getting started' },
+          {
+            slug: 'getting-started/clickhouse-requirements',
+            label: 'Create a monitoring user',
+          },
+          {
+            slug: 'guides/connection-errors',
+            label: 'Connection troubleshooting',
+          },
+        ]}
+      />
     </div>
   )
 }
@@ -221,10 +230,12 @@ function SignInToConnect() {
         </p>
       </div>
 
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <DocLink slug="getting-started">Getting started</DocLink>
-        <DocLink slug="features/overview">What you get</DocLink>
-      </div>
+      <DocsFooter
+        links={[
+          { slug: 'getting-started', label: 'Getting started' },
+          { slug: 'features/overview', label: 'What you get' },
+        ]}
+      />
     </div>
   )
 }
@@ -272,15 +283,19 @@ CLICKHOUSE_PASSWORD=••••••••`}</code>
         </Button>
       </div>
 
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <DocLink slug="getting-started">Getting started</DocLink>
-        <DocLink slug="reference/environment-variables">
-          Environment variables
-        </DocLink>
-        <DocLink slug="guides/connection-errors">
-          Connection troubleshooting
-        </DocLink>
-      </div>
+      <DocsFooter
+        links={[
+          { slug: 'getting-started', label: 'Getting started' },
+          {
+            slug: 'reference/environment-variables',
+            label: 'Environment variables',
+          },
+          {
+            slug: 'guides/connection-errors',
+            label: 'Connection troubleshooting',
+          },
+        ]}
+      />
     </div>
   )
 }

--- a/apps/dashboard/src/components/host/host-switcher.tsx
+++ b/apps/dashboard/src/components/host/host-switcher.tsx
@@ -26,7 +26,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton'
 import { usePathname, useRouter, useSearchParams } from '@/lib/next-compat'
 import { useHostId } from '@/lib/swr'
-import { type MergedHostInfo, useMergedHosts } from '@/lib/swr/use-merged-hosts'
+import { isServerHost, useMergedHosts } from '@/lib/swr/use-merged-hosts'
 import { buildUrl } from '@/lib/url/url-builder'
 import { cn, getHost } from '@/lib/utils'
 
@@ -48,12 +48,6 @@ export function HostSwitcher() {
   const activeHost =
     hosts.find((h) => h.id === currentHostId) ?? hosts[0] ?? null
   const showExpanded = isMobile || state === 'expanded'
-
-  // `env` and `demo` hosts are both server-backed by numeric index, so they
-  // carry a live status/version indicator. `browser`/`database` connections are
-  // client-side and get a globe icon instead.
-  const isServerHost = (source: MergedHostInfo['source']) =>
-    source === 'env' || source === 'demo'
 
   const handleHostChange = (hostId: number) => {
     const url = buildUrl(pathname, { host: hostId }, searchParams)
@@ -190,11 +184,7 @@ export function HostSwitcher() {
                           <span className="truncate">
                             {activeHost.name || getHost(activeHost.host)}
                           </span>
-                          {activeHost.source === 'demo' && (
-                            <span className="shrink-0 rounded bg-muted px-1 py-px text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                              Demo
-                            </span>
-                          )}
+                          {activeHost.source === 'demo' && <DemoBadge />}
                         </span>
                         {isServerHost(activeHost.source) ? (
                           <span className="flex items-center gap-1 truncate text-xs text-muted-foreground">
@@ -241,9 +231,7 @@ export function HostSwitcher() {
                       skipStatus={!isServerHost(host.source)}
                     />
                     {host.source === 'demo' && (
-                      <span className="ml-auto shrink-0 rounded bg-muted px-1 py-px text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                        Demo
-                      </span>
+                      <DemoBadge className="ml-auto" />
                     )}
                   </DropdownMenuItem>
                 ))}
@@ -287,5 +275,19 @@ export function HostSwitcher() {
       </SidebarMenu>
       <AddHostDialog open={addDialogOpen} onOpenChange={setAddDialogOpen} />
     </>
+  )
+}
+
+/** Small "Demo" pill marking the public read-only cloud demo host. */
+function DemoBadge({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        'shrink-0 rounded bg-muted px-1 py-px text-[10px] font-medium uppercase tracking-wide text-muted-foreground',
+        className
+      )}
+    >
+      Demo
+    </span>
   )
 }

--- a/apps/dashboard/src/lib/connection-errors.ts
+++ b/apps/dashboard/src/lib/connection-errors.ts
@@ -22,7 +22,6 @@ export type ConnectionErrorKind =
   | 'connection_refused'
   | 'tls_error'
   | 'timeout'
-  | 'mixed_content'
   | 'unknown'
 
 export interface ClassifiedConnectionError {
@@ -160,15 +159,6 @@ const RULES: Rule[] = [
     explanation:
       'The host did not respond in time. It may be unreachable from the public internet, or a firewall is silently dropping packets.',
     fix: 'Confirm the endpoint is publicly reachable and the firewall/security group allows inbound traffic from the dashboard on the ClickHouse port.',
-    docsSlug: 'guides/connection-errors',
-  },
-  {
-    kind: 'mixed_content',
-    match: ['mixed content', 'blocked:mixed', 'insecure'],
-    title: 'Blocked insecure request',
-    explanation:
-      'The browser blocked an HTTP request made from an HTTPS page (mixed content).',
-    fix: 'Use an HTTPS endpoint for the ClickHouse host so the request is secure end to end.',
     docsSlug: 'guides/connection-errors',
   },
 ]

--- a/apps/dashboard/src/lib/host-fetch/resolve-host-fetch.ts
+++ b/apps/dashboard/src/lib/host-fetch/resolve-host-fetch.ts
@@ -4,6 +4,7 @@ import type { BrowserConnection } from '@/lib/types/browser-connection'
 import { getBrowserConnectionSessionToken } from '@/lib/connection-sessions/session-manager'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { throwIfNotOk } from '@/lib/swr/fetch-error'
+import { isServerHost } from '@/lib/swr/use-merged-hosts'
 
 interface ApiEnvelope<T> {
   success: boolean
@@ -44,7 +45,7 @@ export async function fetchChartForHost<T>({
 }): Promise<{ data: T; metadata?: Record<string, unknown> }> {
   const host = findMergedHost(hosts, hostId)
 
-  if (!host || host.source === 'env') {
+  if (!host || isServerHost(host.source)) {
     const searchParams = new URLSearchParams()
     if (hostId !== undefined) searchParams.append('hostId', String(hostId))
     if (interval) searchParams.append('interval', interval)
@@ -125,7 +126,7 @@ export async function fetchTableForHost<T>({
 }): Promise<{ data: T[]; metadata?: Record<string, unknown> }> {
   const host = findMergedHost(hosts, hostId)
 
-  if (!host || host.source === 'env') {
+  if (!host || isServerHost(host.source)) {
     const params = new URLSearchParams()
     if (hostId !== undefined) params.append('hostId', String(hostId))
     if (searchParams) {

--- a/apps/dashboard/src/lib/swr/use-merged-hosts.ts
+++ b/apps/dashboard/src/lib/swr/use-merged-hosts.ts
@@ -24,6 +24,17 @@ export interface MergedHostInfo extends HostInfo {
 }
 
 /**
+ * Whether a host is backed by the server's env-configured list (addressed by
+ * numeric index): `env` (self-hosted) and `demo` (cloud) both are. `browser` /
+ * `database` connections carry their own credentials instead. Use this anywhere
+ * that routes by host source so a `demo` host is never treated as a missing
+ * connection — see resolve-host-fetch.ts and host-switcher.tsx.
+ */
+export function isServerHost(source: MergedHostInfo['source']): boolean {
+  return source === 'env' || source === 'demo'
+}
+
+/**
  * Combines env-configured hosts with browser- and server-stored connections into
  * a unified, ordered array.
  *


### PR DESCRIPTION
Cleanup pass over the cloud-mode work (from `/simplify`).

## Fixes

- **Altitude / shared mechanism (also fixes a real gap):** extract `isServerHost(source)` (`env || demo`) in `use-merged-hosts.ts` and use it in `resolve-host-fetch.ts`. Both `env` and `demo` hosts are server-backed by index, but the chart/table fetch router still gated on `source === 'env'` — so in cloud mode a `demo` host fell through to *"No connection available"* and couldn't load charts/tables. Now routed correctly. `host-switcher.tsx` uses the shared helper instead of a per-render local copy.
- **Dedup:** `DemoBadge` (was two identical spans), `DocsFooter` (was three identical doc-link blocks).
- **Dead code:** drop the unreachable `mixed_content` connection-error rule — the connection test runs server-side, so a browser mixed-content error never reaches the classifier.

## Verification

`bun run build` (vite + `tsc --noEmit`) green; 22 unit tests pass; Biome clean on changed files. No behaviour change except the demo-host fetch fix.

https://claude.ai/code/session_014Kb8VR1HQAutubTegzVcjz