### PR TITLE
fix(deploy): restore cloud anon read-only demo (emit concrete mode vars)

### DIFF
--- a/apps/dashboard/scripts/patch-wrangler-env.ts
+++ b/apps/dashboard/scripts/patch-wrangler-env.ts
@@ -67,6 +67,28 @@ const fileVars = isPreview
     }
   : parseDotenv(join(ROOT, '.env.production'))
 
+// Resolve CHM_DEPLOYMENT_MODE into CONCRETE worker [vars] at deploy time, so the
+// worker never depends on per-request runtime derivation (a missing/mismatched
+// runtime read would silently drop the cloud public-read posture → anon 401).
+// The .env file's explicit values still win over these mode defaults.
+// ►► Keep in sync with MODE_DEFAULTS in src/lib/config/deployment-mode.ts ◄◄
+// (this build script can't import the @/-aliased module).
+const deploymentMode =
+  (fileVars.CHM_DEPLOYMENT_MODE ?? '').trim().toLowerCase() === 'cloud'
+    ? 'cloud'
+    : 'oss'
+const MODE_DEFAULT_VARS: Record<'cloud' | 'oss', Record<string, string>> = {
+  cloud: {
+    CHM_CLOUD_MODE: 'true',
+    CHM_AUTH_PROVIDER: 'clerk',
+    CHM_CLERK_PUBLIC_READ: 'true',
+    CHM_FEATURE_USER_CONNECTIONS_DB: 'true',
+    CHM_FEATURE_CONVERSATION_DB: 'true',
+  },
+  oss: {},
+}
+const resolvedVars = { ...MODE_DEFAULT_VARS[deploymentMode], ...fileVars }
+
 // Worker [vars] = every non-VITE_ key from the cloud env file. Only the private
 // deployment topology is allowed to be overridden from process.env (CI injects
 // the real homelab values from repo secrets in the "Patch wrangler config" step;
@@ -81,7 +103,7 @@ const DEPLOY_OVERRIDE_KEYS = new Set([
   'CLICKHOUSE_NAME',
 ])
 const vars: Record<string, string> = {}
-for (const [k, v] of Object.entries(fileVars)) {
+for (const [k, v] of Object.entries(resolvedVars)) {
   if (k.startsWith('VITE_')) continue
   const override = DEPLOY_OVERRIDE_KEYS.has(k) ? process.env[k] : undefined
   vars[k] = override && override !== '' ? override : v


### PR DESCRIPTION
## Hotfix — prod regression

After #2011, `dash.chmonitor.dev` started returning **401 on all anonymous requests** (`/hosts`, `/api/v1/config`) — the public read-only demo broke.

**Cause:** the `CHM_DEPLOYMENT_MODE` refactor moved the cloud flags to runtime derivation. The deployed worker resolved `authProvider=clerk` (build-inlined `VITE_AUTH_PROVIDER`) but `publicReadEnabled()` derived `false` from the runtime `CHM_DEPLOYMENT_MODE` read → clerk + no-public-read → anon 401.

**Fix:** `patch-wrangler-env.ts` now resolves `CHM_DEPLOYMENT_MODE` at **deploy time** and emits the concrete per-mode flags (`CHM_CLOUD_MODE`, `CHM_AUTH_PROVIDER`, `CHM_CLERK_PUBLIC_READ`, feature flags) as worker `[vars]` — exactly the set the previously-working deploy had. The worker no longer depends on per-request derivation; `.env` stays simple (`CHM_DEPLOYMENT_MODE=cloud`); explicit `.env` values still win. Kept in sync with `MODE_DEFAULTS`.

https://claude.ai/code/session_01C7B3YKqB363AsKruARLXv8