### PR TITLE
feat(saas): CHM_CLOUD_DEMO_HOSTS — narrow public demo to named hosts

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -84,6 +84,9 @@ CHM_FEATURE_AGENT_ACCESS=public
 # Default follows the mode (cloud→on). Override here for a self-hosted clerk
 # instance that wants public browsing. Truthy = 1/true/yes/on.
 # CHM_CLERK_PUBLIC_READ=
+# Public-demo allowlist (cloud mode only): expose ONLY these env hosts (by
+# CLICKHOUSE_NAME, comma-separated) to anonymous visitors. Unset = all env hosts.
+# CHM_CLOUD_DEMO_HOSTS=
 
 # ── Feature storage — defaults follow the mode (cloud→on, self-hosted→off) ─
 # Override only to diverge from the mode default.

--- a/apps/dashboard/.env.production
+++ b/apps/dashboard/.env.production
@@ -48,6 +48,11 @@ CLICKHOUSE_HOST=http://localhost:8123
 CLICKHOUSE_USER=default
 CLICKHOUSE_NAME=localhost
 CLICKHOUSE_MAX_EXECUTION_TIME=60
+# Public-demo allowlist (cloud mode only): of the env hosts injected at deploy,
+# expose ONLY these (matched by CLICKHOUSE_NAME) to ANONYMOUS visitors as the
+# read-only demo. Any other bound host stays private. Unset = all env hosts are
+# the demo. See lib/cloud/demo-hosts.ts.
+CHM_CLOUD_DEMO_HOSTS=duet-ubuntu
 
 # ── Runtime / platform ──────────────────────────────────────────────────────
 # Marks the Cloudflare Worker runtime (set only in the worker, not Docker/Node).

--- a/apps/dashboard/src/lib/api/clickhouse-config.ts
+++ b/apps/dashboard/src/lib/api/clickhouse-config.ts
@@ -1,5 +1,7 @@
 import type { ClickHouseConfig } from '@chm/clickhouse-client'
 
+import { filterToDemoHosts } from '@/lib/cloud/demo-hosts'
+
 // Shared ClickHouse host-config resolver for server routes. Builds
 // ClickHouseConfig[] from the comma-separated env lists (the Cloudflare binding
 // or process.env), mirroring @chm/clickhouse-client getClickHouseConfigs() but
@@ -20,7 +22,7 @@ export function getClickHouseConfigsFromEnv(
   const passwords = splitByComma(bindings.CLICKHOUSE_PASSWORD)
   const customLabels = splitByComma(bindings.CLICKHOUSE_NAME)
 
-  return hosts.map((host, index) => {
+  const configs = hosts.map((host, index) => {
     // A single credential pair serves many hosts; otherwise index by position.
     let user: string
     let password: string
@@ -32,5 +34,14 @@ export function getClickHouseConfigsFromEnv(
       password = passwords[index] || ''
     }
     return { id: index, host, user, password, customName: customLabels[index] }
+  })
+
+  // In cloud mode, restrict to the public-demo allowlist (CHM_CLOUD_DEMO_HOSTS)
+  // so env-host surfaces (live status, health, notifications) reflect only the
+  // demo host. `id` is the original index, so per-host routing stays correct.
+  // No-op in self-hosted mode or when the var is unset.
+  return filterToDemoHosts(configs, bindings, {
+    name: (c) => c.customName,
+    host: (c) => c.host,
   })
 }

--- a/apps/dashboard/src/lib/cloud/demo-hosts.test.ts
+++ b/apps/dashboard/src/lib/cloud/demo-hosts.test.ts
@@ -1,0 +1,78 @@
+import { filterToDemoHosts, parseDemoHostAllowlist } from './demo-hosts'
+import { describe, expect, test } from 'bun:test'
+
+interface Host {
+  id: number
+  name?: string
+  host: string
+}
+
+const HOSTS: Host[] = [
+  { id: 0, name: 'duet-ubuntu', host: 'https://duet-ubuntu:8443' },
+  { id: 1, name: 'duyet-agent', host: 'https://openclaw' },
+]
+
+const accessors = {
+  name: (h: Host) => h.name,
+  host: (h: Host) => h.host,
+}
+
+// Cloud mode on for these bindings (CHM_CLOUD_MODE=true wins in isCloudModeServer).
+const cloud = (demo?: string): Record<string, string | undefined> => ({
+  CHM_CLOUD_MODE: 'true',
+  ...(demo !== undefined ? { CHM_CLOUD_DEMO_HOSTS: demo } : {}),
+})
+
+describe('parseDemoHostAllowlist', () => {
+  test('unset / empty → null (no restriction)', () => {
+    expect(parseDemoHostAllowlist({})).toBeNull()
+    expect(parseDemoHostAllowlist({ CHM_CLOUD_DEMO_HOSTS: '' })).toBeNull()
+    expect(parseDemoHostAllowlist({ CHM_CLOUD_DEMO_HOSTS: '  ' })).toBeNull()
+    expect(parseDemoHostAllowlist({ CHM_CLOUD_DEMO_HOSTS: ' , ' })).toBeNull()
+  })
+
+  test('parses comma list, lowercased + trimmed', () => {
+    const set = parseDemoHostAllowlist({
+      CHM_CLOUD_DEMO_HOSTS: ' Duet-Ubuntu , prod ',
+    })
+    expect(set).toEqual(new Set(['duet-ubuntu', 'prod']))
+  })
+})
+
+describe('filterToDemoHosts', () => {
+  test('cloud + allowlist → only matching hosts, ids preserved', () => {
+    const out = filterToDemoHosts(HOSTS, cloud('duet-ubuntu'), accessors)
+    expect(out).toEqual([
+      { id: 0, name: 'duet-ubuntu', host: 'https://duet-ubuntu:8443' },
+    ])
+  })
+
+  test('match is case-insensitive', () => {
+    const out = filterToDemoHosts(HOSTS, cloud('DUET-UBUNTU'), accessors)
+    expect(out.map((h) => h.id)).toEqual([0])
+  })
+
+  test('matches by host string too', () => {
+    const out = filterToDemoHosts(HOSTS, cloud('https://openclaw'), accessors)
+    expect(out.map((h) => h.id)).toEqual([1])
+  })
+
+  test('non-cloud → passthrough even with allowlist set', () => {
+    const out = filterToDemoHosts(
+      HOSTS,
+      { CHM_CLOUD_MODE: 'false', CHM_CLOUD_DEMO_HOSTS: 'duet-ubuntu' },
+      accessors
+    )
+    expect(out).toEqual(HOSTS)
+  })
+
+  test('cloud + no allowlist → passthrough', () => {
+    const out = filterToDemoHosts(HOSTS, cloud(), accessors)
+    expect(out).toEqual(HOSTS)
+  })
+
+  test('zero-match allowlist → fail-open passthrough (never empty the demo)', () => {
+    const out = filterToDemoHosts(HOSTS, cloud('typo-host'), accessors)
+    expect(out).toEqual(HOSTS)
+  })
+})

--- a/apps/dashboard/src/lib/cloud/demo-hosts.ts
+++ b/apps/dashboard/src/lib/cloud/demo-hosts.ts
@@ -1,0 +1,82 @@
+// Cloud (SaaS) PUBLIC DEMO host allowlist.
+//
+// In cloud mode the operator-configured `CLICKHOUSE_HOST` env list is the
+// PUBLIC, READ-ONLY demo an anonymous visitor explores (see cloud-mode.ts /
+// use-merged-hosts.ts). A deploy may bind more env hosts than it wants to expose
+// publicly, so `CHM_CLOUD_DEMO_HOSTS` narrows the demo to a named subset:
+//
+//   CHM_CLOUD_DEMO_HOSTS=duet-ubuntu   → anonymous visitors see ONLY that host.
+//
+// Match is by host NAME (CLICKHOUSE_NAME entry) or the sanitized host string,
+// case-insensitive. The original host `id` (index into CLICKHOUSE_HOST) is
+// preserved so `?host=<id>` routing and per-host queries keep resolving.
+//
+// Design invariants (mirror lib/cloud, lib/edition — fail-open, never degrade):
+//   - Only active in cloud mode. Self-hosted/OSS ignores the var entirely.
+//   - Unset / empty allowlist  → no restriction (all env hosts, unchanged).
+//   - Allowlist matches ZERO hosts → treated as misconfiguration; passthrough
+//     ALL hosts rather than black out the demo (an empty host list is a 503).
+
+import { isCloudModeServer } from '@/lib/cloud/cloud-mode'
+
+/**
+ * Parse `CHM_CLOUD_DEMO_HOSTS` into a lowercased name set, or `null` when unset
+ * /empty (meaning "no restriction"). Pure — pass any env getter.
+ */
+export function parseDemoHostAllowlist(
+  bindings: Record<string, string | undefined>
+): Set<string> | null {
+  const raw = bindings.CHM_CLOUD_DEMO_HOSTS
+  if (!raw?.trim()) return null
+  const names = raw
+    .split(',')
+    .map((n) => n.trim().toLowerCase())
+    .filter(Boolean)
+  return names.length > 0 ? new Set(names) : null
+}
+
+/** Does a host (by name and/or host string) match an allowlist entry? */
+function isAllowed(
+  allow: Set<string>,
+  name: string | undefined,
+  host: string | undefined
+): boolean {
+  const n = name?.trim().toLowerCase()
+  if (n && allow.has(n)) return true
+  const h = host?.trim().toLowerCase()
+  if (h && allow.has(h)) return true
+  return false
+}
+
+/**
+ * Filter an env-derived host list to the cloud public-demo allowlist.
+ *
+ * Returns the input unchanged when not in cloud mode or when no allowlist is
+ * set. When the allowlist matches at least one host, returns only the matches
+ * (original order/ids preserved). When it matches NONE, returns the input
+ * unchanged (fail-open — never empty the demo on a misconfigured name).
+ *
+ * Generic over any host shape via accessors so the same rule serves both the
+ * `/api/v1/hosts` list and the server `ClickHouseConfig[]` resolver.
+ */
+export function filterToDemoHosts<T>(
+  hosts: readonly T[],
+  bindings: Record<string, string | undefined>,
+  accessors: {
+    name: (h: T) => string | undefined
+    host: (h: T) => string | undefined
+  }
+): T[] {
+  const list = [...hosts]
+  if (!isCloudModeServer(bindings)) return list
+
+  const allow = parseDemoHostAllowlist(bindings)
+  if (!allow) return list
+
+  const matched = list.filter((h) =>
+    isAllowed(allow, accessors.name(h), accessors.host(h))
+  )
+  // Fail-open: an allowlist that matches nothing is almost certainly a typo;
+  // showing all hosts is far safer than serving a 503 "no hosts configured".
+  return matched.length > 0 ? matched : list
+}

--- a/apps/dashboard/src/routes/api/v1/hosts.ts
+++ b/apps/dashboard/src/routes/api/v1/hosts.ts
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { env } from 'cloudflare:workers'
+import { filterToDemoHosts } from '@/lib/cloud/demo-hosts'
 
 interface HostInfo {
   id: number
@@ -53,9 +54,13 @@ export const Route = createFileRoute('/api/v1/hosts')({
     handlers: {
       GET: () => {
         const bindings = env as Record<string, string | undefined>
-        const hosts = parseHosts(
-          bindings.CLICKHOUSE_HOST,
-          bindings.CLICKHOUSE_NAME
+        // In cloud mode, narrow the env hosts to the public-demo allowlist
+        // (CHM_CLOUD_DEMO_HOSTS) so anonymous visitors see only the intended
+        // demo host(s). No-op in self-hosted mode or when the var is unset.
+        const hosts = filterToDemoHosts(
+          parseHosts(bindings.CLICKHOUSE_HOST, bindings.CLICKHOUSE_NAME),
+          bindings,
+          { name: (h) => h.name, host: (h) => h.host }
         )
 
         if (hosts.length === 0) {

--- a/docs/knowledge/cloud-saas-mode.md
+++ b/docs/knowledge/cloud-saas-mode.md
@@ -43,6 +43,18 @@ Read-only on the demo is *enforced* by the existing public-read gate: anonymous
 principals can only read, and signed-in users never see the demo. The `readOnly`
 flag on `MergedHostInfo` is the UI cue.
 
+**Public-demo allowlist.** A deploy may bind more env hosts than it wants to
+show publicly. `CHM_CLOUD_DEMO_HOSTS` (comma list of `CLICKHOUSE_NAME` entries)
+narrows the demo to a named subset — e.g. `CHM_CLOUD_DEMO_HOSTS=duet-ubuntu`
+exposes only that host to anonymous visitors; any other bound host stays
+private. Cloud-mode only; unset = all env hosts are the demo. Filter is
+fail-open: a zero-match allowlist (typo) passes through ALL hosts rather than
+black out the demo (empty host list = 503). The host `id` (index into
+`CLICKHOUSE_HOST`) is preserved so `?host=<id>` routing keeps resolving.
+Implemented in `lib/cloud/demo-hosts.ts` (`filterToDemoHosts`), applied at
+`api/v1/hosts.ts` (the shown list) and `lib/api/clickhouse-config.ts`
+(`getClickHouseConfigsFromEnv` → live status / health / notifications).
+
 ## Files
 
 - `apps/dashboard/src/lib/cloud/cloud-mode.ts` — resolvers + `parseCloudMode`. Tested.


### PR DESCRIPTION
## What

In **cloud mode** the env `CLICKHOUSE_HOST` list is the public read-only demo anonymous visitors explore. `dash.chmonitor.dev` binds two hosts (`duet-ubuntu`, `duyet-agent`), so guests saw **both**. The spec for the hosted product is:

- **Guest (anonymous):** see only the read-only `duet-ubuntu` demo host.
- **Signed-in:** empty workspace + onboarding (already working).

This adds a committed, non-secret **public-demo allowlist** so only the named host(s) are exposed to anonymous visitors; any other bound host stays private. No secret edits required (safer than trimming the `CLICKHOUSE_HOST` secret, whose true value may embed credentials).

## How

- `lib/cloud/demo-hosts.ts` — `filterToDemoHosts()`: cloud-mode-gated, matches by `CLICKHOUSE_NAME` or host string, **preserves the original host `id`** so `?host=<id>` routing keeps resolving. **Fail-open**: a zero-match allowlist passes through all hosts (never 503 the demo on a typo).
- Applied at `api/v1/hosts.ts` (the shown list) and `getClickHouseConfigsFromEnv` (env-host live status / health / notifications).
- `.env.production` sets `CHM_CLOUD_DEMO_HOSTS=duet-ubuntu`; `.env.example` documents it. Injected into worker `[vars]` automatically (non-`VITE_` key) — no `patch-wrangler-env` change.
- Signed-in users unaffected: their D1/browser connections use **negative** hostIds, disjoint from env indices.

## Tests

- `demo-hosts.test.ts` (8 cases): cloud+allowlist filters by name/host preserving id; non-cloud passthrough; empty allowlist passthrough; zero-match fail-open.
- Full `src/lib/cloud` + `src/lib/api/__tests__` suite: 370 pass. `tsc --noEmit` clean.

https://claude.ai/code/session_011HCN3w7XRmbgPUjhxV9oSw