### PR TITLE
feat(landing): cloud pricing tiers + dark-mode polish

### DIFF
--- a/apps/dashboard/src/lib/billing/plans.test.ts
+++ b/apps/dashboard/src/lib/billing/plans.test.ts
@@ -1,0 +1,58 @@
+import {
+  BILLING_PLAN_LIST,
+  BILLING_PLANS,
+  monthlyEquivalentUsd,
+  planHasCapability,
+  yearlyMonthsFree,
+} from './plans'
+import { describe, expect, test } from 'bun:test'
+
+describe('billing plans', () => {
+  test('locked price points: Pro $29 / Max $99', () => {
+    expect(BILLING_PLANS.pro.priceMonthlyUsd).toBe(29)
+    expect(BILLING_PLANS.max.priceMonthlyUsd).toBe(99)
+  })
+
+  test('seats/hosts per tier match the deal', () => {
+    expect([BILLING_PLANS.pro.seats, BILLING_PLANS.pro.hosts]).toEqual([3, 3])
+    expect([BILLING_PLANS.max.seats, BILLING_PLANS.max.hosts]).toEqual([10, 10])
+  })
+
+  test('yearly = 10× monthly (≈2 months free)', () => {
+    expect(BILLING_PLANS.pro.priceYearlyUsd).toBe(290)
+    expect(BILLING_PLANS.max.priceYearlyUsd).toBe(990)
+    expect(yearlyMonthsFree(BILLING_PLANS.pro)).toBe(2)
+    expect(yearlyMonthsFree(BILLING_PLANS.max)).toBe(2)
+  })
+
+  test('monthlyEquivalentUsd: yearly shows per-month equivalent', () => {
+    expect(monthlyEquivalentUsd(BILLING_PLANS.pro, 'monthly')).toBe(29)
+    expect(monthlyEquivalentUsd(BILLING_PLANS.pro, 'yearly')).toBeCloseTo(
+      24.17,
+      1
+    )
+  })
+
+  test('enterprise is custom (null price, BYOK, unlimited)', () => {
+    const e = BILLING_PLANS.enterprise
+    expect(e.priceMonthlyUsd).toBeNull()
+    expect(e.aiMonthlyUsdBudget).toBeNull() // BYOK
+    expect(e.hosts).toBeNull()
+    expect(yearlyMonthsFree(e)).toBeNull()
+  })
+
+  test('capabilities form an increasing ladder', () => {
+    const counts = BILLING_PLAN_LIST.map((p) => p.capabilities.length)
+    for (let i = 1; i < counts.length; i++) {
+      expect(counts[i]).toBeGreaterThanOrEqual(counts[i - 1])
+    }
+  })
+
+  test('core monitoring is in every tier; SSO only in enterprise', () => {
+    for (const id of ['free', 'pro', 'max', 'enterprise'] as const) {
+      expect(planHasCapability(id, 'core_monitoring')).toBe(true)
+    }
+    expect(planHasCapability('max', 'sso_rbac_audit')).toBe(false)
+    expect(planHasCapability('enterprise', 'sso_rbac_audit')).toBe(true)
+  })
+})

--- a/apps/dashboard/src/lib/billing/plans.ts
+++ b/apps/dashboard/src/lib/billing/plans.ts
@@ -1,0 +1,198 @@
+/**
+ * Billing plans — the single source of truth for cloud (SaaS) tiers.
+ *
+ * Drives the landing pricing cards (apps/landing keeps its numbers in sync — see
+ * note below) AND server-side entitlement / limit checks (M3). OSS/self-host
+ * never reads this: when auth is `none` everything is authorized and unlimited,
+ * so plans are inert. Activates only under cloud mode + Clerk + billing config.
+ *
+ * ── Pricing strategy (see docs/knowledge + plan) ──────────────────────────────
+ * Deliberately below-market for early access: ~$10/host vs Datadog ~$15–23/host
+ * and pganalyze ~$100–149/host. Raise toward ~$49 Pro / ~$149 Max at GA and
+ * grandfather early-access accounts. Yearly = 10× monthly (≈2 months free).
+ *
+ * ⚠️ apps/landing/src/components/Pricing.astro is a standalone Astro app (pure,
+ * dependency-light) and cannot import this module without dragging app deps in.
+ * Keep the price / seats / hosts numbers there identical to here. A zero-dep
+ * `@chm/pricing` package is the clean follow-up if compile-time sync is wanted.
+ */
+
+export const PLAN_IDS = ['free', 'pro', 'max', 'enterprise'] as const
+export type PlanId = (typeof PLAN_IDS)[number]
+
+/**
+ * Capabilities a plan unlocks (the benefit ladder). Self-contained on purpose —
+ * mapped to the real gates (`lib/edition` ENTERPRISE_FEATURES + feature-permissions)
+ * during enforcement (M3), so this stays presentation-friendly and stable.
+ */
+export type PlanCapability =
+  | 'core_monitoring' // queries, merges, replication, cluster — in every tier
+  | 'ai_agent'
+  | 'ai_insights_scheduled'
+  | 'alerting_basic'
+  | 'alerting_advanced' // + Slack/PagerDuty
+  | 'fleet_view'
+  | 'api_mcp_access'
+  | 'sso_rbac_audit'
+  | 'priority_support'
+
+export interface Plan {
+  id: PlanId
+  name: string
+  /** One-line positioning shown under the plan name. */
+  tagline: string
+  /** USD/month on monthly billing. null = custom (Enterprise) or free. */
+  priceMonthlyUsd: number | null
+  /** USD/year on annual billing (10× monthly ⇒ ~2 months free). null = custom/free. */
+  priceYearlyUsd: number | null
+  seats: number | null // null = custom/unlimited
+  hosts: number | null // null = custom/unlimited; the BINDING meter
+  /** Monthly LLM spend allowance in USD. null = BYOK / unlimited (Enterprise). */
+  aiMonthlyUsdBudget: number | null
+  /** History retention for conversations / insights. null = custom. */
+  retentionDays: number | null
+  capabilities: PlanCapability[]
+  /** Human-facing bullet list for the pricing card. */
+  highlights: string[]
+  /** null until Polar products exist (M3). */
+  polarProductId?: { monthly: string; yearly: string } | null
+}
+
+const CORE: PlanCapability[] = ['core_monitoring']
+
+export const BILLING_PLANS: Record<PlanId, Plan> = {
+  free: {
+    id: 'free',
+    name: 'Free',
+    tagline: 'Try the hosted dashboard, no setup.',
+    priceMonthlyUsd: 0,
+    priceYearlyUsd: 0,
+    seats: 1,
+    hosts: 1,
+    aiMonthlyUsdBudget: 0.5,
+    retentionDays: 7,
+    capabilities: [...CORE, 'ai_agent'],
+    highlights: [
+      '1 ClickHouse host, 1 seat',
+      'Full monitoring dashboard',
+      'AI agent — daily trial limit',
+      '7-day history',
+      'Community support',
+    ],
+  },
+  pro: {
+    id: 'pro',
+    name: 'Pro',
+    tagline: 'For a small team running a few clusters.',
+    priceMonthlyUsd: 29,
+    priceYearlyUsd: 290,
+    seats: 3,
+    hosts: 3,
+    aiMonthlyUsdBudget: 5,
+    retentionDays: 30,
+    capabilities: [
+      ...CORE,
+      'ai_agent',
+      'ai_insights_scheduled',
+      'alerting_basic',
+    ],
+    highlights: [
+      'Everything in Free',
+      '3 hosts, 3 seats',
+      'AI agent + scheduled AI Insights',
+      'Basic alerting',
+      '30-day history',
+      'Email support',
+    ],
+  },
+  max: {
+    id: 'max',
+    name: 'Max',
+    tagline: 'For teams operating a fleet of clusters.',
+    priceMonthlyUsd: 99,
+    priceYearlyUsd: 990,
+    seats: 10,
+    hosts: 10,
+    aiMonthlyUsdBudget: 20,
+    retentionDays: 90,
+    capabilities: [
+      ...CORE,
+      'ai_agent',
+      'ai_insights_scheduled',
+      'alerting_advanced',
+      'fleet_view',
+      'api_mcp_access',
+      'priority_support',
+    ],
+    highlights: [
+      'Everything in Pro',
+      '10 hosts, 10 seats',
+      'Higher AI usage cap',
+      'Fleet view + advanced alerting (Slack, PagerDuty)',
+      'API / MCP access',
+      '90-day history',
+      'Priority support',
+    ],
+  },
+  enterprise: {
+    id: 'enterprise',
+    name: 'Enterprise',
+    tagline: 'For organisations with security & scale needs.',
+    priceMonthlyUsd: null,
+    priceYearlyUsd: null,
+    seats: null,
+    hosts: null,
+    aiMonthlyUsdBudget: null, // BYOK / unlimited
+    retentionDays: null,
+    capabilities: [
+      ...CORE,
+      'ai_agent',
+      'ai_insights_scheduled',
+      'alerting_advanced',
+      'fleet_view',
+      'api_mcp_access',
+      'sso_rbac_audit',
+      'priority_support',
+    ],
+    highlights: [
+      'Everything in Max',
+      'Unlimited hosts & seats',
+      'Bring-your-own LLM key (BYOK)',
+      'SSO / SAML, RBAC, audit logs',
+      'Custom retention',
+      'SLA & dedicated support',
+    ],
+  },
+}
+
+/** Ordered list for rendering (free → enterprise). */
+export const BILLING_PLAN_LIST: Plan[] = PLAN_IDS.map((id) => BILLING_PLANS[id])
+
+export function getPlan(id: PlanId): Plan {
+  return BILLING_PLANS[id]
+}
+
+/** Whether a plan grants a capability. Inert for OSS (callers gate on billing). */
+export function planHasCapability(id: PlanId, cap: PlanCapability): boolean {
+  return BILLING_PLANS[id].capabilities.includes(cap)
+}
+
+/**
+ * Effective monthly price for a billing period. Yearly returns the per-month
+ * equivalent (priceYearly / 12) for "$X/mo billed yearly" display.
+ */
+export function monthlyEquivalentUsd(
+  plan: Plan,
+  period: 'monthly' | 'yearly'
+): number | null {
+  if (period === 'monthly') return plan.priceMonthlyUsd
+  if (plan.priceYearlyUsd == null) return null
+  return Math.round((plan.priceYearlyUsd / 12) * 100) / 100
+}
+
+/** Months-free saved on yearly vs monthly (for the "save N months" badge). */
+export function yearlyMonthsFree(plan: Plan): number | null {
+  if (!plan.priceMonthlyUsd || !plan.priceYearlyUsd) return null
+  const monthsPaid = plan.priceYearlyUsd / plan.priceMonthlyUsd
+  return Math.round((12 - monthsPaid) * 10) / 10
+}

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -36,7 +36,6 @@ const galleryCards = [
     </div>
   </div>
 
-  <div class="wrap">
   <div class="gallery-strip reveal" style="margin-top:48px">
     <div class="marquee">
       {galleryCards.map((card) => (
@@ -52,6 +51,5 @@ const galleryCards = [
         </div>
       ))}
     </div>
-  </div>
   </div>
 </section>

--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -1,98 +1,168 @@
 ---
+// Cloud pricing tiers.
+// ⚠️ Keep price / seats / hosts in sync with the source of truth:
+// apps/dashboard/src/lib/billing/plans.ts (BILLING_PLANS). Yearly = 10× monthly.
 const checkSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="var(--emerald)" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg>`
+const arrowSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`
+
+interface Tier {
+  name: string
+  badge?: { label: string; cls: string }
+  highlight?: boolean
+  monthly: number | null // null = custom
+  yearlyTotal: number | null
+  yearlyPerMo: number | null
+  tagline: string
+  rows: string[]
+  cta: { label: string; href: string; primary?: boolean }
+}
+
+const tiers: Tier[] = [
+  {
+    name: 'Free',
+    badge: { label: 'Early access', cls: 'ptag-beta' },
+    monthly: 0,
+    yearlyTotal: 0,
+    yearlyPerMo: 0,
+    tagline: 'Try the hosted dashboard, no setup.',
+    rows: [
+      '1 ClickHouse host, 1 seat',
+      'Full monitoring dashboard',
+      'AI agent — daily trial limit',
+      '7-day history',
+      'Community support',
+    ],
+    cta: { label: 'Start free', href: 'https://dash.chmonitor.dev', primary: true },
+  },
+  {
+    name: 'Pro',
+    highlight: true,
+    monthly: 29,
+    yearlyTotal: 290,
+    yearlyPerMo: 24,
+    tagline: 'For a small team running a few clusters.',
+    rows: [
+      'Everything in Free',
+      '3 hosts, 3 seats',
+      'AI agent + scheduled AI Insights',
+      'Basic alerting',
+      '30-day history',
+      'Email support',
+    ],
+    cta: { label: 'Start free', href: 'https://dash.chmonitor.dev', primary: true },
+  },
+  {
+    name: 'Max',
+    monthly: 99,
+    yearlyTotal: 990,
+    yearlyPerMo: 83,
+    tagline: 'For teams operating a fleet of clusters.',
+    rows: [
+      'Everything in Pro',
+      '10 hosts, 10 seats',
+      'Higher AI usage cap',
+      'Fleet view + advanced alerting',
+      'API / MCP access',
+      '90-day history · priority support',
+    ],
+    cta: { label: 'Start free', href: 'https://dash.chmonitor.dev' },
+  },
+  {
+    name: 'Enterprise',
+    monthly: null,
+    yearlyTotal: null,
+    yearlyPerMo: null,
+    tagline: 'For organisations with security & scale needs.',
+    rows: [
+      'Everything in Max',
+      'Unlimited hosts & seats',
+      'Bring-your-own LLM key (BYOK)',
+      'SSO / SAML, RBAC, audit logs',
+      'Custom retention',
+      'SLA & dedicated support',
+    ],
+    cta: { label: 'Contact us', href: 'mailto:hello@chmonitor.dev' },
+  },
+]
 ---
 <section id="pricing" class="band">
   <div class="wrap">
     <div class="sec-head reveal" style="text-align:center">
       <span class="eyebrow">Pricing</span>
-      <h2>Self-host free. Try cloud instantly.</h2>
-      <p>chmonitor is open source. Self-hosting is always free under the GPL-3.0 license. The hosted cloud lets you connect a cluster without any setup.</p>
+      <h2>Self-host free. Cloud for teams.</h2>
+      <p>chmonitor is open source — self-hosting is always free under GPL-3.0. The hosted cloud connects a cluster without any setup. Cloud pricing is not finalised; <strong>early access is free to try</strong> and seats are limited.</p>
     </div>
 
-    <div class="pricing-grid reveal">
-      <!-- Self-host -->
-      <div class="price-card">
-        <div class="price-hd">
-          <div>
-            <span class="pname">Self-host</span>
-            <span class="ptag ptag-free">Free forever</span>
-          </div>
-          <div class="pamount">$0 <small>/ month</small></div>
-          <div class="pdesc">Run it on your own infrastructure. Docker, Cloudflare Workers, or Kubernetes, your choice, your data stays with you.</div>
-        </div>
-        <div class="price-body">
-          <ul class="price-rows">
-            <li class="price-row">
-              <span set:html={checkSvg} />
-              Full dashboard, all views, all features
-            </li>
-            <li class="price-row">
-              <span set:html={checkSvg} />
-              Connect unlimited ClickHouse clusters
-            </li>
-            <li class="price-row">
-              <span set:html={checkSvg} />
-              AI agent and MCP server
-            </li>
-            <li class="price-row">
-              <span set:html={checkSvg} />
-              Docker, Cloudflare Workers, Kubernetes
-            </li>
-            <li class="price-row">
-              <span set:html={checkSvg} />
-              GPL-3.0, modify and redistribute freely
-            </li>
-            <li class="price-row">
-              <span set:html={checkSvg} />
-              Community support via GitHub Issues
-            </li>
-          </ul>
-          <div class="price-cta">
-            <a class="btn btn-primary" style="width:100%;justify-content:center" href="https://docs.chmonitor.dev" target="_blank" rel="noopener">
-              Read the quickstart
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-            </a>
-          </div>
-        </div>
+    <!-- Self-host: always free -->
+    <div class="selfhost-banner reveal">
+      <div class="sh-text">
+        <span class="ptag ptag-free">Free forever</span>
+        <strong>Self-host</strong> — run it on your own infrastructure (Docker, Cloudflare Workers, Kubernetes). All features, unlimited clusters, your data stays with you.
       </div>
+      <a class="btn btn-ghost" href="https://docs.chmonitor.dev" target="_blank" rel="noopener">
+        Read the quickstart <span set:html={arrowSvg} />
+      </a>
+    </div>
 
-      <!-- Cloud -->
-      <div class="price-card price-card-highlight">
-        <div class="price-hd">
-          <div>
-            <span class="pname">Cloud</span>
-            <span class="ptag ptag-beta">Early access</span>
-          </div>
-          <div class="pamount" style="font-size:24px;margin-top:16px">No setup required</div>
-          <div class="pdesc">Connect a ClickHouse cluster directly at <strong>dash.chmonitor.dev</strong> without deploying anything. Cloud pricing is not finalised, early access is free to try.</div>
-        </div>
-        <div class="price-body">
-          <ul class="price-rows">
-            <li class="price-row">
-              <span set:html={checkSvg} />
-              Everything in Self-host
-            </li>
-            <li class="price-row">
-              <span set:html={checkSvg} />
-              No server to manage or maintain
-            </li>
-            <li class="price-row">
-              <span set:html={checkSvg} />
-              Connect with a read-only ClickHouse user
-            </li>
-            <li class="price-row">
-              <svg viewBox="0 0 24 24" fill="none" stroke="var(--amber)" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><path d="M12 9v4M12 17h.01"/></svg>
-              Pricing TBD, early access seats are limited
-            </li>
-          </ul>
-          <div class="price-cta">
-            <a class="btn btn-primary" style="width:100%;justify-content:center;background:var(--orange);border-color:var(--orange)" href="https://dash.chmonitor.dev" target="_blank" rel="noopener">
-              Try cloud now, free
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-            </a>
-          </div>
-        </div>
+    <!-- Cloud plans -->
+    <div class="cloud-head reveal">
+      <span class="ea-badge">Early access — free while in beta</span>
+      <div class="bill-toggle" role="tablist" aria-label="Billing period">
+        <button type="button" data-period="monthly" role="tab" aria-selected="false">Monthly</button>
+        <button type="button" data-period="yearly" role="tab" aria-selected="true" class="active">
+          Yearly <span class="save">2 months free</span>
+        </button>
       </div>
+    </div>
+
+    <div class="cloud-grid reveal" data-period="yearly">
+      {tiers.map((t) => (
+        <div class={`price-card${t.highlight ? ' price-card-highlight' : ''}`}>
+          <div class="price-hd">
+            <div>
+              <span class="pname">{t.name}</span>
+              {t.badge && <span class={`ptag ${t.badge.cls}`}>{t.badge.label}</span>}
+            </div>
+            <div class="pamount">
+              {t.monthly === null ? (
+                <span>Custom</span>
+              ) : t.monthly === 0 ? (
+                <span>$0 <small>/ mo</small></span>
+              ) : (
+                <>
+                  <span class="amt amt-monthly">${t.monthly} <small>/ mo</small></span>
+                  <span class="amt amt-yearly">${t.yearlyPerMo} <small>/ mo</small></span>
+                </>
+              )}
+            </div>
+            {(t.monthly ?? 0) > 0 && (
+              <div class="pbilled">
+                <span class="bill-monthly">billed monthly</span>
+                <span class="bill-yearly">${t.yearlyTotal}/yr · save 2 months</span>
+              </div>
+            )}
+            <div class="pdesc">{t.tagline}</div>
+          </div>
+          <div class="price-body">
+            <ul class="price-rows">
+              {t.rows.map((r) => (
+                <li class="price-row"><span set:html={checkSvg} />{r}</li>
+              ))}
+            </ul>
+            <div class="price-cta">
+              <a
+                class={`btn ${t.cta.primary ? 'btn-primary' : 'btn-ghost'}`}
+                style={t.cta.primary ? 'width:100%;justify-content:center;background:var(--orange);border-color:var(--orange)' : 'width:100%;justify-content:center'}
+                href={t.cta.href}
+                target="_blank"
+                rel="noopener"
+              >
+                {t.cta.label} <span set:html={arrowSvg} />
+              </a>
+            </div>
+          </div>
+        </div>
+      ))}
     </div>
 
     <div class="callout reveal" style="margin-top:28px">
@@ -100,4 +170,50 @@ const checkSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="var(--emerald)" s
       <div>chmonitor only reads from ClickHouse system tables. It never writes to your data. Connect using a least-privilege <code>SELECT</code>-only user for maximum safety.</div>
     </div>
   </div>
+
+  <style>
+    .selfhost-banner{display:flex;align-items:center;justify-content:space-between;gap:20px;flex-wrap:wrap;margin-top:44px;padding:18px 22px;border:1px solid var(--border);border-radius:var(--radius);background:var(--card);box-shadow:var(--shadow-card)}
+    .selfhost-banner .sh-text{font-size:14px;color:var(--muted-fg);text-wrap:pretty}
+    .selfhost-banner .sh-text strong{color:var(--fg)}
+    .cloud-head{display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-top:40px}
+    .ea-badge{display:inline-flex;align-items:center;gap:8px;font-size:13px;font-weight:600;color:var(--orange)}
+    .ea-badge::before{content:"";width:7px;height:7px;border-radius:999px;background:var(--orange)}
+    .bill-toggle{display:inline-flex;padding:4px;gap:2px;border:1px solid var(--border);border-radius:999px;background:var(--card)}
+    .bill-toggle button{display:inline-flex;align-items:center;gap:8px;font:inherit;font-size:13px;font-weight:600;color:var(--muted-fg);background:transparent;border:0;border-radius:999px;padding:7px 16px;cursor:pointer}
+    .bill-toggle button.active{background:var(--fg);color:var(--bg)}
+    .bill-toggle .save{font-size:11px;font-weight:600;color:var(--emerald)}
+    /* The active pill is var(--fg): near-black in light mode, near-white in dark
+       mode. So the accent must flip per theme to stay readable on it. */
+    .bill-toggle button.active .save{color:#34d399} /* light mode: black pill → light green */
+    :root[data-theme="dark"] .bill-toggle button.active .save{color:#047857} /* dark mode: white pill → dark green */
+    .cloud-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:18px;margin-top:22px;align-items:stretch}
+    .cloud-grid .pamount{display:flex;align-items:baseline;gap:6px}
+    .cloud-grid .amt{display:none}
+    .cloud-grid[data-period="monthly"] .amt-monthly{display:inline}
+    .cloud-grid[data-period="yearly"] .amt-yearly{display:inline}
+    .pbilled{font-size:12px;color:var(--muted-fg);margin-top:8px;min-height:16px}
+    .cloud-grid[data-period="monthly"] .bill-yearly{display:none}
+    .cloud-grid[data-period="yearly"] .bill-monthly{display:none}
+    @media (max-width:1000px){.cloud-grid{grid-template-columns:repeat(2,1fr)}}
+    @media (max-width:560px){.cloud-grid{grid-template-columns:1fr}.selfhost-banner{flex-direction:column;align-items:flex-start}}
+  </style>
+
+  <script is:inline>
+    (function () {
+      var grid = document.querySelector('.cloud-grid')
+      var buttons = document.querySelectorAll('.bill-toggle button')
+      if (!grid || !buttons.length) return
+      buttons.forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var period = btn.getAttribute('data-period')
+          grid.setAttribute('data-period', period)
+          buttons.forEach(function (b) {
+            var on = b === btn
+            b.classList.toggle('active', on)
+            b.setAttribute('aria-selected', on ? 'true' : 'false')
+          })
+        })
+      })
+    })()
+  </script>
 </section>

--- a/apps/landing/src/components/SocialProof.astro
+++ b/apps/landing/src/components/SocialProof.astro
@@ -1,3 +1,33 @@
+---
+// GitHub stats — fetched at build time and rendered as native, theme-aware chips
+// (the previous shields.io `?style=social` images were white pills that didn't
+// adapt to dark mode and rendered fuzzily). Fails open: if the API is
+// unreachable during the build, chips render without counts — never breaks CI.
+const REPO = 'chmonitor/chmonitor'
+let stars: number | null = null
+let forks: number | null = null
+let updated: string | null = null
+try {
+  const res = await fetch(`https://api.github.com/repos/${REPO}`, {
+    headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'chmonitor-landing' },
+  })
+  if (res.ok) {
+    const d = await res.json()
+    stars = typeof d.stargazers_count === 'number' ? d.stargazers_count : null
+    forks = typeof d.forks_count === 'number' ? d.forks_count : null
+    if (d.pushed_at) {
+      updated = new Date(d.pushed_at).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
+    }
+  }
+} catch {
+  // offline build — render chips without counts
+}
+const fmt = (n: number | null) => (n == null ? '' : n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n))
+
+const starIcon = `<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2.5l2.9 6.1 6.6.9-4.8 4.6 1.2 6.6L12 18.6 6.1 21.3l1.2-6.6L2.5 9.5l6.6-.9z"/></svg>`
+const forkIcon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="6" cy="6" r="2.4"/><circle cx="18" cy="6" r="2.4"/><circle cx="12" cy="19" r="2.4"/><path d="M6 8.4v2.1a3 3 0 0 0 3 3h6a3 3 0 0 0 3-3V8.4M12 13.5v3.1"/></svg>`
+const commitIcon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3.2"/><path d="M3 12h5.8M15.2 12H21"/></svg>`
+---
 <section class="band band-soft">
   <div class="wrap">
     <div class="sec-head reveal" style="text-align:center">
@@ -6,24 +36,21 @@
     </div>
 
     <div class="stat-badges reveal">
-      <img
-        src="https://img.shields.io/github/stars/chmonitor/chmonitor?style=social"
-        alt="GitHub stars"
-        width="120" height="20"
-        loading="lazy"
-      />
-      <img
-        src="https://img.shields.io/github/forks/chmonitor/chmonitor?style=social"
-        alt="GitHub forks"
-        width="100" height="20"
-        loading="lazy"
-      />
-      <img
-        src="https://img.shields.io/github/last-commit/chmonitor/chmonitor?color=orange"
-        alt="Last commit"
-        width="160" height="20"
-        loading="lazy"
-      />
+      <a class="gh-stat" href={`https://github.com/${REPO}/stargazers`} target="_blank" rel="noopener" aria-label={`${fmt(stars)} GitHub stars`}>
+        <span class="gh-ico" set:html={starIcon} />
+        <span class="gh-label">Stars</span>
+        {stars != null && <strong class="gh-num">{fmt(stars)}</strong>}
+      </a>
+      <a class="gh-stat" href={`https://github.com/${REPO}/forks`} target="_blank" rel="noopener" aria-label={`${fmt(forks)} GitHub forks`}>
+        <span class="gh-ico" set:html={forkIcon} />
+        <span class="gh-label">Forks</span>
+        {forks != null && <strong class="gh-num">{fmt(forks)}</strong>}
+      </a>
+      <a class="gh-stat" href={`https://github.com/${REPO}/commits`} target="_blank" rel="noopener" aria-label="Recent activity">
+        <span class="gh-ico" set:html={commitIcon} />
+        <span class="gh-label">Last commit</span>
+        {updated && <strong class="gh-num">{updated}</strong>}
+      </a>
     </div>
 
     <div style="text-align:center;margin-top:28px" class="reveal">
@@ -36,4 +63,13 @@
       </a>
     </div>
   </div>
+
+  <style>
+    .gh-stat{display:inline-flex;align-items:center;gap:8px;height:34px;padding:0 14px;border:1px solid var(--border);border-radius:999px;background:var(--card);box-shadow:var(--shadow-card);font-size:13.5px;font-weight:500;color:var(--fg-soft);text-decoration:none;transition:border-color .14s,color .14s}
+    .gh-stat:hover{border-color:var(--border-hover);color:var(--fg)}
+    .gh-stat .gh-ico{display:inline-flex;width:15px;height:15px;color:var(--muted-fg)}
+    .gh-stat .gh-ico svg{width:15px;height:15px}
+    .gh-stat:hover .gh-ico{color:var(--emerald)}
+    .gh-stat .gh-num{font-weight:700;color:var(--fg);font-variant-numeric:tabular-nums}
+  </style>
 </section>


### PR DESCRIPTION
## What

Adds the cloud (SaaS) pricing story to the landing page and a single source of truth for plans, plus three dark-mode fixes flagged on review.

### Pricing
- **`apps/dashboard/src/lib/billing/plans.ts`** — Free / **Pro $29** (3 seats, 3 hosts) / **Max $99** (10/10) / Enterprise. Monthly + yearly (10× = ~2 months free). Carries seats, hosts, AI USD budget, a capability ladder, and retention. Drives the landing cards now and server-side entitlement later (M3). **Inert for OSS** (auth=`none` → everything unlimited). Unit-tested (7 cases).
- **`Pricing.astro`** — 4-tier cards + monthly/yearly toggle (vanilla `is:inline`, defaults to yearly), early-access "free to try" badge, self-host-free banner. Numbers mirror `plans.ts` (cross-referenced — the Astro app can't import the dashboard without dragging React deps in).

### Dark-mode fixes
- **Toggle "2 months free"** flips accent per theme — the active pill is `var(--fg)` which inverts (near-black in light, near-white in dark), so the green needs opposite shades to stay readable.
- **Hero screenshot marquee** is now full browser width (full-bleed, lifted out of `.wrap`).
- **GitHub stat badges** — replace `shields.io` `?style=social` images (white pills, fuzzy in dark mode) with native theme-aware chips; counts come from a **build-time GitHub API fetch that fails open** (never breaks CI).

## Pricing rationale
Deliberately below-market for early access: ~$10/host vs Datadog ~$15–23/host and pganalyze ~$100–149/host (the closest analog). Raise toward ~$49/$149 at GA and grandfather early-access accounts.

## Verification
- `bun test plans.test.ts` → 7 pass; landing `bun run build` green (incl. live GitHub fetch).
- Verified in **dark mode** via browser: toggle contrast, full-width marquee, native badges (Stars 246 · Forks 40 · Last commit Jun 2026), monthly⇄yearly flips $24/$83 ⇄ $29/$99.
- OSS untouched: no dashboard behavior changed; `plans.ts` is new and unreferenced by runtime paths yet.

https://claude.ai/code/session_011HCN3w7XRmbgPUjhxV9oSw