### PR TITLE
style(landing): swap Inter → Geist typeface

### DIFF
--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -58,7 +58,7 @@ const ogImage = new URL(image, Astro.site).toString()
   })} />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
   <script is:inline>
     // Resolve theme before paint (no flash): saved choice wins, else OS pref.
     (function () {
@@ -129,9 +129,9 @@ const ogImage = new URL(image, Astro.site).toString()
     body{
       background:var(--bg);
       color:var(--fg);
-      font-family:'Inter',ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
-      font-feature-settings:"cv11","ss01";
+      font-family:'Geist',ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
       -webkit-font-smoothing:antialiased;
+      text-rendering:optimizeLegibility;
       line-height:1.5;
     }
 
@@ -345,7 +345,7 @@ const ogImage = new URL(image, Astro.site).toString()
     .deploy-lead code{font-family:'JetBrains Mono',monospace;font-size:13.5px;background:var(--muted);padding:1px 6px;border-radius:5px;color:var(--fg)}
     .deploy-tabbar{display:flex;gap:2px;border-bottom:1px solid var(--border)}
     .deploy-tab{display:inline-flex;align-items:center;justify-content:center;gap:7px;height:46px;padding:0 10px;background:none;border:none;flex:1 1 0;min-width:0;
-      border-bottom:2px solid transparent;cursor:pointer;font-family:'Inter';font-size:13.5px;font-weight:600;color:var(--muted-fg);
+      border-bottom:2px solid transparent;cursor:pointer;font-family:inherit;font-size:13.5px;font-weight:600;color:var(--muted-fg);
       white-space:nowrap;transition:.15s;margin-bottom:-1px}
     .deploy-tab svg{width:16px;height:16px;flex:0 0 auto}
     .deploy-tab:hover{color:var(--fg)}
@@ -444,7 +444,7 @@ const ogImage = new URL(image, Astro.site).toString()
     .price-hd .ptag{display:inline-block;font-size:11px;font-weight:600;padding:2px 9px;border-radius:999px;margin-left:8px}
     .ptag-free{background:#d1fae5;color:#065f46}
     .ptag-beta{background:#fef3c7;color:#92400e}
-    .price-hd .pamount{font-size:36px;font-weight:700;letter-spacing:-.03em;margin-top:16px;line-height:1}
+    .price-hd .pamount{font-size:36px;font-weight:700;letter-spacing:-.03em;margin-top:16px;line-height:1;font-variant-numeric:tabular-nums}
     .price-hd .pamount small{font-size:15px;font-weight:500;color:var(--muted-fg);letter-spacing:0}
     .price-hd .pdesc{font-size:14px;color:var(--muted-fg);margin-top:10px;text-wrap:pretty}
     .price-body{display:flex;flex-direction:column;flex:1;padding:22px 28px 28px}


### PR DESCRIPTION
## What

A redesign pass on the landing page. The audit found the design otherwise strong (single orange brand accent, clean zinc neutrals, real dark mode, favicon/OG/JSON-LD all present) — the one dominant generic fingerprint was **Inter**, the default font of nearly every AI-generated SaaS page.

- **Inter → Geist** (Vercel's typeface) across the site. Geist reads as "engineered" and pairs natively with the existing JetBrains Mono — a better fit for a developer/infra tool. One-line `<link>` + `font-family` swap = max visual delta, min risk.
- Dropped Inter-specific `cv11`/`ss01` OpenType features; added `text-rendering:optimizeLegibility`.
- Price amounts now use `tabular-nums` so digits don't shift when the monthly/yearly toggle swaps $24⇄$29 / $83⇄$99.
- JetBrains Mono retained for code/data.

## Verification
- `bun run build` green; built HTML requests `family=Geist`.
- Verified in browser: hero, nav, body, buttons all render Geist; full-width marquee intact.

Noted for later (not in this PR, kept focused): the feature-icon palette uses a 5-hue rainbow incl. an "AI-purple" `--violet` — could be unified to the brand accent in a follow-up.

https://claude.ai/code/session_011HCN3w7XRmbgPUjhxV9oSw