### PR TITLE
fix(landing): badge spacing + equal-height pricing headings

### DIFF
--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -135,12 +135,14 @@ const tiers: Tier[] = [
                 </>
               )}
             </div>
-            {(t.monthly ?? 0) > 0 && (
-              <div class="pbilled">
-                <span class="bill-monthly">billed monthly</span>
-                <span class="bill-yearly">${t.yearlyTotal}/yr · save 2 months</span>
-              </div>
-            )}
+            <div class="pbilled">
+              {(t.monthly ?? 0) > 0 && (
+                <>
+                  <span class="bill-monthly">billed monthly</span>
+                  <span class="bill-yearly">${t.yearlyTotal}/yr · save 2 months</span>
+                </>
+              )}
+            </div>
             <div class="pdesc">{t.tagline}</div>
           </div>
           <div class="price-body">

--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -174,6 +174,7 @@ const tiers: Tier[] = [
   <style>
     .selfhost-banner{display:flex;align-items:center;justify-content:space-between;gap:20px;flex-wrap:wrap;margin-top:44px;padding:18px 22px;border:1px solid var(--border);border-radius:var(--radius);background:var(--card);box-shadow:var(--shadow-card)}
     .selfhost-banner .sh-text{font-size:14px;color:var(--muted-fg);text-wrap:pretty}
+    .selfhost-banner .sh-text .ptag{margin-right:8px}
     .selfhost-banner .sh-text strong{color:var(--fg)}
     .cloud-head{display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-top:40px}
     .ea-badge{display:inline-flex;align-items:center;gap:8px;font-size:13px;font-weight:600;color:var(--orange)}

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -446,7 +446,7 @@ const ogImage = new URL(image, Astro.site).toString()
     .ptag-beta{background:#fef3c7;color:#92400e}
     .price-hd .pamount{font-size:36px;font-weight:700;letter-spacing:-.03em;margin-top:16px;line-height:1;font-variant-numeric:tabular-nums}
     .price-hd .pamount small{font-size:15px;font-weight:500;color:var(--muted-fg);letter-spacing:0}
-    .price-hd .pdesc{font-size:14px;color:var(--muted-fg);margin-top:10px;text-wrap:pretty}
+    .price-hd .pdesc{font-size:14px;line-height:1.4;color:var(--muted-fg);margin-top:10px;text-wrap:pretty;min-height:2.8em}
     .price-body{display:flex;flex-direction:column;flex:1;padding:22px 28px 28px}
     .price-rows{display:flex;flex-direction:column;gap:13px}
     .price-row{display:flex;gap:10px;font-size:14px;color:var(--fg-soft);list-style:none}


### PR DESCRIPTION
Two small landing-page polish fixes from design review:

1. **"Free forever" badge spacing** — the inline `.ptag` badge butted directly against **Self-host** ("Free foreverSelf-host"). Added an 8px right margin scoped to `.selfhost-banner .sh-text .ptag` so the standalone card badge is untouched.

2. **Equal-height pricing-card headings** — Free ($0) and Enterprise (Custom) skipped the "billed monthly / \$X/yr" line, and taglines wrapped to different line counts, so the four `.price-hd` blocks had different heights and the checkmark lists started at different Y positions. Now the billed-line row is reserved on every card and the tagline has a 2-line min-height, so all four headings match and the feature lists align.

Both are CSS/markup-only in `apps/landing`.

https://claude.ai/code/session_01JpgsS1E5egpPFGvBfb9fuE