### PR TITLE
fix(dashboard): route no-host users to /setup + tidy sidebar first-run UX

### DIFF
--- a/apps/dashboard/src/components/host/first-run-gate.tsx
+++ b/apps/dashboard/src/components/host/first-run-gate.tsx
@@ -1,4 +1,6 @@
-import { FirstRunEmptyState } from './first-run-empty-state'
+import { useEffect } from 'react'
+import { PageSkeleton } from '@/components/skeletons'
+import { usePathname, useRouter } from '@/lib/next-compat'
 import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
 
 /**
@@ -12,8 +14,12 @@ import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
  *
  * The one first-run surface we keep is genuine onboarding: zero ClickHouse hosts
  * configured — and only when that is the real state, not merely an auth failure
- * that left the host list empty. While hosts are still loading we render children
- * so existing skeletons / Suspense fallbacks keep showing.
+ * that left the host list empty. In that case we send the visitor to the stable
+ * `/setup` URL (which renders FirstRunEmptyState) rather than showing the empty
+ * state inline on whatever route they happened to land on. `/setup` is itself
+ * wrapped by this gate, so it renders children there instead of redirecting —
+ * no loop. While hosts are still loading we render children so existing
+ * skeletons / Suspense fallbacks keep showing.
  *
  * NOTE: `FirstRunUnauthorizedState` is intentionally no longer rendered here. The
  * component is kept for a possible future inline sign-in prompt rather than a
@@ -21,9 +27,20 @@ import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
  */
 export function FirstRunGate({ children }: { children: React.ReactNode }) {
   const { hosts, isLoading, isUnauthorized } = useMergedHosts()
+  const router = useRouter()
+  const pathname = usePathname()
 
-  if (!isLoading && !isUnauthorized && hosts.length === 0) {
-    return <FirstRunEmptyState />
+  const noHosts = !isLoading && !isUnauthorized && hosts.length === 0
+  const onSetup = pathname === '/setup'
+
+  useEffect(() => {
+    if (noHosts && !onSetup) {
+      router.replace('/setup')
+    }
+  }, [noHosts, onSetup, router])
+
+  if (noHosts && !onSetup) {
+    return <PageSkeleton />
   }
 
   return <>{children}</>

--- a/apps/dashboard/src/components/host/host-switcher.tsx
+++ b/apps/dashboard/src/components/host/host-switcher.tsx
@@ -71,7 +71,7 @@ export function HostSwitcher() {
                 {!showExpanded && <LogoStatusIndicatorSkeleton />}
               </div>
               {showExpanded && (
-                <div className="grid flex-1 text-left text-sm leading-tight">
+                <div className="grid flex-1 gap-1.5 text-left text-sm leading-tight">
                   <Skeleton className="h-4 w-24" />
                   <Skeleton className="h-3 w-16" />
                 </div>

--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -64,14 +64,6 @@ export const menuItemsConfig: MenuItem[] = [
     permission: { feature: 'overview' },
   },
   {
-    // Standalone welcome/setup surface — add a ClickHouse host at any time.
-    // No permission gate: useful in every mode (cloud demo, signed-in, self-host).
-    title: 'Connect a host',
-    href: '/setup',
-    icon: UnplugIcon,
-    section: 'main',
-  },
-  {
     title: 'AI Agent',
     href: '/agents',
     icon: SparklesIcon,


### PR DESCRIPTION
From design review on `/overview` and `/setup`. Three related first-run fixes — a signed-in user with no host configured should land on **/setup** by default.

### Changes
1. **No-host → `/setup` redirect.** `FirstRunGate` previously rendered `FirstRunEmptyState` *inline* (URL stayed `/overview`). It now redirects to the stable `/setup` URL when `hosts.length === 0`. `/setup` is wrapped by the same gate, so it renders its children there instead of redirecting again — no loop. The onboarding surface now has one canonical URL.
2. **Remove redundant "Connect a host" nav item.** No-host users are auto-routed to `/setup`, and users who already have hosts can add more via the host-switcher's **"Add host…"** action — so the sidebar entry was duplicate discoverability. The `/setup` route itself stays.
3. **Skeleton gap.** Added vertical gap (`gap-1.5`) between the two host-switcher loading skeleton lines, which were touching.

### Notes
- Redirect uses the existing client-side idiom (`useRouter().replace` in `useEffect`, render `PageSkeleton` while navigating) — same pattern as the legacy `/ai-chat → /agents` route.
- `FirstRunEmptyState` already adapts to cloud-signed-in / cloud-anon / self-hosted, so `/setup` shows the right content in every mode.

### Verify
- Signed-in cloud user with zero connections → any dashboard route redirects to `/setup`.
- Demo/anon (has demo host) and self-host (has env hosts) → unchanged.
- `/setup` renders the empty state without a redirect loop; "Add host…" in the switcher still opens the add dialog.

https://claude.ai/code/session_01JpgsS1E5egpPFGvBfb9fuE