### PR TITLE
feat(billing): Polar subscriptions + host-limit enforcement (cloud)

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -160,6 +160,13 @@ jobs:
           # store/crypto.ts), so user-connections works with no extra secret. Set
           # this only to use/rotate a data key independent of the Clerk secret.
           CHM_USER_CONNECTIONS_ENCRYPTION_KEY: ${{ secrets.CHM_USER_CONNECTIONS_ENCRYPTION_KEY }}
+          # Polar billing. Preview resolves the SANDBOX *_TEST variants
+          # (set-secrets.ts resolveValue); production uses the base names and stays
+          # inert (checkout 501s) until prod creds are set. Unset ⇒ skipped.
+          POLAR_ACCESS_TOKEN: ${{ secrets.POLAR_ACCESS_TOKEN }}
+          POLAR_ACCESS_TOKEN_TEST: ${{ secrets.POLAR_ACCESS_TOKEN_TEST }}
+          POLAR_WEBHOOK_SECRET: ${{ secrets.POLAR_WEBHOOK_SECRET }}
+          POLAR_WEBHOOK_SECRET_TEST: ${{ secrets.POLAR_WEBHOOK_SECRET_TEST }}
           CLICKHOUSE_TZ: ${{ secrets.CLICKHOUSE_TZ || 'UTC' }}
           CLICKHOUSE_EXCLUDE_USER_DEFAULT: ${{ secrets.CLICKHOUSE_EXCLUDE_USER_DEFAULT || '' }}
           NEXT_QUERY_CACHE_TTL: ${{ secrets.NEXT_QUERY_CACHE_TTL || '3600' }}

--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -93,7 +93,7 @@ CHM_FEATURE_AGENT_ACCESS=public
 # Persist agent conversations in D1/Postgres/AgentState instead of localStorage.
 # CHM_FEATURE_CONVERSATION_DB=false
 # Persist per-user ClickHouse connections (D1/Postgres). Requires Clerk auth +
-# CHM_USER_CONNECTIONS_ENCRYPTION_KEY + a database backend (CONVERSATIONS_D1 on
+# CHM_USER_CONNECTIONS_ENCRYPTION_KEY + a database backend (CHM_CLOUD_D1 on
 # Cloudflare, or DATABASE_URL/POSTGRES_URL elsewhere). All four must be present
 # or the server returns "User connections database storage is not enabled".
 # CHM_FEATURE_USER_CONNECTIONS_DB=false
@@ -165,6 +165,13 @@ CLERK_SECRET_KEY=
 # AES-256 key (32-byte base64) encrypting user connection credentials at rest.
 # Required when CHM_FEATURE_USER_CONNECTIONS_DB=true or browser session tokens.
 CHM_USER_CONNECTIONS_ENCRYPTION_KEY=
+# Polar billing — CLOUD (SaaS) ONLY; self-hosting is free forever, leave unset.
+# POLAR_ACCESS_TOKEN / POLAR_WEBHOOK_SECRET are secrets; CHM_POLAR_SERVER
+# (sandbox|production) and CHM_POLAR_PRODUCT_* are non-secret. See
+# lib/billing/polar-config.ts and scripts/polar-setup.ts.
+# POLAR_ACCESS_TOKEN=
+# POLAR_WEBHOOK_SECRET=
+# CHM_POLAR_SERVER=sandbox
 # Bearer token guarding the server-to-server agent API (/api/v1/agent).
 AGENT_API_TOKEN=
 # Shared secrets for proxy / trusted-header auth (see above).

--- a/apps/dashboard/.env.preview
+++ b/apps/dashboard/.env.preview
@@ -13,6 +13,17 @@
 
 # Cheaper, PUBLIC model for preview deploys (no private preset committed).
 LLM_MODEL=anyrouter:z-ai/glm-4.7-flash
+
+# ── Polar billing (preview → sandbox) ───────────────────────────────────────
+# Non-secret: server + sandbox product ids so PR previews exercise real Polar
+# checkout against the sandbox org. The token is a secret (POLAR_ACCESS_TOKEN_TEST
+# GitHub secret → resolved for preview by set-secrets.ts). Product ids are not
+# secret; they're sandbox-org-specific. Production keeps these unset (inert).
+CHM_POLAR_SERVER=sandbox
+CHM_POLAR_PRODUCT_PRO_MONTHLY=d7422418-56c2-412b-9fed-aef186cd0f7c
+CHM_POLAR_PRODUCT_PRO_YEARLY=2316bdd9-7d83-4b6b-839e-ff5d61e5fe41
+CHM_POLAR_PRODUCT_MAX_MONTHLY=aa8ed460-1da3-4a62-a1da-6e7f8bd3bc90
+CHM_POLAR_PRODUCT_MAX_YEARLY=204fdd04-4e4c-4230-9960-6324be3ef1d5
 # Preview Clerk publishable key (pk_test) is NOT committed — keeps the repo
 # generic/OSS. chmonitor's preview gets it from the GitHub Actions variable
 # CHM_CLERK_PUBLISHABLE_KEY_TEST; local preview builds read .env.preview.local.

--- a/apps/dashboard/.env.production
+++ b/apps/dashboard/.env.production
@@ -54,6 +54,17 @@ CLICKHOUSE_MAX_EXECUTION_TIME=60
 # the demo. See lib/cloud/demo-hosts.ts.
 CHM_CLOUD_DEMO_HOSTS=duet-ubuntu
 
+# ── Polar billing (cloud SaaS) ──────────────────────────────────────────────
+# Non-secret Polar config. Secrets (POLAR_ACCESS_TOKEN, POLAR_WEBHOOK_SECRET) are
+# set via scripts/set-secrets.ts, NOT here. server = sandbox|production; product
+# ids per paid plan/period come from `bun scripts/polar-setup.ts`. Unset product
+# ids ⇒ checkout returns 501 for that plan. See lib/billing/polar-config.ts.
+CHM_POLAR_SERVER=sandbox
+CHM_POLAR_PRODUCT_PRO_MONTHLY=
+CHM_POLAR_PRODUCT_PRO_YEARLY=
+CHM_POLAR_PRODUCT_MAX_MONTHLY=
+CHM_POLAR_PRODUCT_MAX_YEARLY=
+
 # ── Runtime / platform ──────────────────────────────────────────────────────
 # Marks the Cloudflare Worker runtime (set only in the worker, not Docker/Node).
 CLOUDFLARE_WORKERS=1

--- a/apps/dashboard/bun.lock
+++ b/apps/dashboard/bun.lock
@@ -35,6 +35,7 @@
         "@json-render/shadcn": "^0.19.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@openrouter/ai-sdk-provider": "^2.10.0",
+        "@polar-sh/sdk": "^0.48.1",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-use-controllable-state": "^1.2.2",
         "@shadcn/react": "^0.1.0",
@@ -418,6 +419,8 @@
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
+
+    "@polar-sh/sdk": ["@polar-sh/sdk@0.48.1", "", { "dependencies": { "standardwebhooks": "^1.0.0", "zod": "^3.25.65 || ^4.0.0" } }, "sha512-FmU6eLJRXJ6Zau0IkqscfkFta8xxYbFV1VD9zzS2Ki2btCuFmUyPZOkHOXU77R892h2zyBegLnHS7jrOhMN1Sw=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -63,6 +63,7 @@
     "@json-render/shadcn": "^0.19.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@openrouter/ai-sdk-provider": "^2.10.0",
+    "@polar-sh/sdk": "^0.48.1",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@shadcn/react": "^0.1.0",

--- a/apps/dashboard/scripts/patch-wrangler-env.ts
+++ b/apps/dashboard/scripts/patch-wrangler-env.ts
@@ -125,32 +125,30 @@ generated.vars = vars
 
 // --- Patch D1 databases ---
 const conversationsDbId = (
-  process.env.CONVERSATIONS_D1_DATABASE_ID ||
-  process.env.AGENT_CONVERSATIONS_D1_DATABASE_ID ||
+  process.env.CHM_CLOUD_D1_DATABASE_ID ||
+  process.env.AGENT_CHM_CLOUD_D1_DATABASE_ID ||
   ''
 ).trim()
 
 if (conversationsDbId) {
   generated.d1_databases = (generated.d1_databases ?? []).map((db: any) => {
-    if (db.binding === 'CONVERSATIONS_D1') {
+    if (db.binding === 'CHM_CLOUD_D1') {
       return { ...db, database_id: conversationsDbId }
     }
     return db
   })
   console.log(
-    `   d1_databases: injected database_id for CONVERSATIONS_D1 (${conversationsDbId})`
+    `   d1_databases: injected database_id for CHM_CLOUD_D1 (${conversationsDbId})`
   )
 } else {
-  // Strip CONVERSATIONS_D1 binding if database_id is not provided
+  // Strip CHM_CLOUD_D1 binding if database_id is not provided
   const beforeCount = (generated.d1_databases ?? []).length
   generated.d1_databases = (generated.d1_databases ?? []).filter(
-    (db: any) => db.binding !== 'CONVERSATIONS_D1'
+    (db: any) => db.binding !== 'CHM_CLOUD_D1'
   )
   const afterCount = (generated.d1_databases ?? []).length
   if (beforeCount !== afterCount) {
-    console.log(
-      '   d1_databases: removed unprovisioned CONVERSATIONS_D1 binding'
-    )
+    console.log('   d1_databases: removed unprovisioned CHM_CLOUD_D1 binding')
   }
 }
 

--- a/apps/dashboard/scripts/polar-setup.ts
+++ b/apps/dashboard/scripts/polar-setup.ts
@@ -1,0 +1,99 @@
+/**
+ * Create the Polar products for the paid plans, idempotently, and print the
+ * CHM_POLAR_PRODUCT_* env lines to paste into .env.production(.local).
+ *
+ * Usage (from repo root or apps/dashboard):
+ *   POLAR_ACCESS_TOKEN=polar_oat_... CHM_POLAR_SERVER=sandbox \
+ *     bun apps/dashboard/scripts/polar-setup.ts
+ *
+ * Prices come from BILLING_PLANS (single source of truth). Re-running matches
+ * existing products by name and reuses them instead of creating duplicates.
+ */
+
+import type { BillingPeriod, PaidPlanId } from '../src/lib/billing/polar-config'
+
+import { BILLING_PLANS } from '../src/lib/billing/plans'
+import { PAID_PLAN_IDS } from '../src/lib/billing/polar-config'
+import { Polar } from '@polar-sh/sdk'
+
+const token = process.env.POLAR_ACCESS_TOKEN
+if (!token) {
+  console.error('POLAR_ACCESS_TOKEN is required')
+  process.exit(1)
+}
+const server =
+  process.env.CHM_POLAR_SERVER === 'production' ? 'production' : 'sandbox'
+
+const polar = new Polar({ accessToken: token, server })
+
+function productName(planId: PaidPlanId, period: BillingPeriod): string {
+  const plan = BILLING_PLANS[planId]
+  const label = period === 'monthly' ? 'Monthly' : 'Yearly'
+  return `chmonitor ${plan.name} (${label})`
+}
+
+function priceCents(planId: PaidPlanId, period: BillingPeriod): number {
+  const plan = BILLING_PLANS[planId]
+  const usd = period === 'monthly' ? plan.priceMonthlyUsd : plan.priceYearlyUsd
+  if (usd == null) throw new Error(`No price for ${planId}/${period}`)
+  return Math.round(usd * 100)
+}
+
+async function listExistingProducts(): Promise<Map<string, string>> {
+  const byName = new Map<string, string>()
+  const pages = await polar.products.list({ limit: 100 })
+  for await (const page of pages) {
+    for (const product of page.result.items) {
+      byName.set(product.name, product.id)
+    }
+  }
+  return byName
+}
+
+async function ensureProduct(
+  planId: PaidPlanId,
+  period: BillingPeriod,
+  existing: Map<string, string>
+): Promise<{ envKey: string; id: string }> {
+  const name = productName(planId, period)
+  const envKey = `CHM_POLAR_PRODUCT_${planId.toUpperCase()}_${period.toUpperCase()}`
+  const found = existing.get(name)
+  if (found) {
+    console.log(`= reuse  ${name} → ${found}`)
+    return { envKey, id: found }
+  }
+  const created = await polar.products.create({
+    name,
+    recurringInterval: period === 'monthly' ? 'month' : 'year',
+    prices: [
+      {
+        amountType: 'fixed',
+        priceAmount: priceCents(planId, period),
+        priceCurrency: 'usd',
+      },
+    ],
+  })
+  console.log(`+ create ${name} → ${created.id}`)
+  return { envKey, id: created.id }
+}
+
+async function main() {
+  console.log(`Polar setup (server=${server})\n`)
+  const existing = await listExistingProducts()
+  const lines: string[] = []
+  for (const planId of PAID_PLAN_IDS) {
+    for (const period of ['monthly', 'yearly'] as const) {
+      const { envKey, id } = await ensureProduct(planId, period, existing)
+      lines.push(`${envKey}=${id}`)
+    }
+  }
+  console.log(
+    '\n# Paste into apps/dashboard/.env.production (or .env.production.local):'
+  )
+  console.log(lines.join('\n'))
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -14,13 +14,20 @@ import {
   SidebarMenuItem,
 } from '@/components/ui/sidebar'
 import { GUEST_USER } from '@/lib/clerk/guest-user'
+import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
 import { DOCS_SITE_URL } from '@/lib/docs-site'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { filterMenuItemsByPermissions } from '@/lib/feature-permissions/menu'
 
 export function AppSidebar() {
   const { config } = useFeaturePermissions()
-  const menuItems = filterMenuItemsByPermissions(menuItemsConfig, config)
+  const cloudMode = isCloudModeClient()
+  // Billing is a cloud-only surface — self-hosting is free forever, so the
+  // paid-plan page would only confuse self-hosters.
+  const menuItems = filterMenuItemsByPermissions(
+    menuItemsConfig,
+    config
+  ).filter((item) => cloudMode || item.href !== '/billing')
 
   return (
     <Sidebar collapsible="icon" variant="inset">

--- a/apps/dashboard/src/db/conversations-migrations/0003_user_subscriptions.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0003_user_subscriptions.sql
@@ -1,0 +1,22 @@
+-- Per-user billing subscription state (cloud SaaS only).
+-- One row per Clerk user; written by the Polar webhook, read by getUserPlan().
+-- Lives in the shared CHM_CLOUD_D1 database alongside conversations +
+-- user_connections (all keyed by user_id).
+CREATE TABLE IF NOT EXISTS user_subscriptions (
+  user_id TEXT PRIMARY KEY,
+  -- 'free' | 'pro' | 'max' | 'enterprise' — resolved from the Polar product id.
+  plan_id TEXT NOT NULL,
+  -- 'monthly' | 'yearly' | NULL (free).
+  billing_period TEXT,
+  -- Polar subscription status: active | trialing | past_due | canceled | etc.
+  status TEXT NOT NULL,
+  polar_subscription_id TEXT,
+  polar_customer_id TEXT,
+  -- Unix seconds; end of the current paid period (access valid until then).
+  current_period_end INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_subscriptions_plan
+  ON user_subscriptions(plan_id);

--- a/apps/dashboard/src/lib/billing/polar-config.ts
+++ b/apps/dashboard/src/lib/billing/polar-config.ts
@@ -1,0 +1,95 @@
+/**
+ * Polar billing — runtime config + product↔plan mapping.
+ *
+ * Cloud (SaaS) only. OSS/self-host never calls this (auth is `none` ⇒ unlimited,
+ * plans inert — see plans.ts). All values come from the environment so sandbox
+ * and production differ without code changes, matching the repo's "one canonical
+ * CHM_* name" philosophy (see CLAUDE.md):
+ *
+ *   POLAR_ACCESS_TOKEN          (secret)     org access token
+ *   POLAR_WEBHOOK_SECRET        (secret)     verifies inbound webhooks
+ *   CHM_POLAR_SERVER            sandbox|production (default sandbox)
+ *   CHM_POLAR_PRODUCT_<PLAN>_<PERIOD>        Polar product id per paid plan/period
+ *     e.g. CHM_POLAR_PRODUCT_PRO_MONTHLY, CHM_POLAR_PRODUCT_MAX_YEARLY
+ *
+ * Product ids live in env (not plans.ts) because they differ per Polar org /
+ * environment; plans.ts stays the pricing + capability source of truth.
+ *
+ * `nodejs_compat_populate_process_env` (wrangler.toml) mirrors Worker vars +
+ * secrets onto process.env, so reading process.env works in the Worker runtime.
+ */
+
+import type { PlanId } from './plans'
+
+import { Polar } from '@polar-sh/sdk'
+
+export type BillingPeriod = 'monthly' | 'yearly'
+
+/** Paid plans that map to a Polar product. free/enterprise are not self-serve. */
+export const PAID_PLAN_IDS = ['pro', 'max'] as const
+export type PaidPlanId = (typeof PAID_PLAN_IDS)[number]
+
+function readEnv(key: string): string | undefined {
+  const v = process.env[key]
+  return v === undefined || v === '' ? undefined : v
+}
+
+export function getPolarServer(): 'sandbox' | 'production' {
+  return readEnv('CHM_POLAR_SERVER') === 'production' ? 'production' : 'sandbox'
+}
+
+/**
+ * True when Polar is wired up enough to make API calls (token present). Routes
+ * use this to fail with a clear 501 instead of throwing on a missing token.
+ */
+export function isBillingConfigured(): boolean {
+  return Boolean(readEnv('POLAR_ACCESS_TOKEN'))
+}
+
+let cachedClient: Polar | null = null
+
+/** Lazily construct the Polar client. Throws if the token is missing. */
+export function getPolarClient(): Polar {
+  if (cachedClient) return cachedClient
+  const accessToken = readEnv('POLAR_ACCESS_TOKEN')
+  if (!accessToken) {
+    throw new Error('POLAR_ACCESS_TOKEN is not configured')
+  }
+  cachedClient = new Polar({ accessToken, server: getPolarServer() })
+  return cachedClient
+}
+
+export function getWebhookSecret(): string | undefined {
+  return readEnv('POLAR_WEBHOOK_SECRET')
+}
+
+function productEnvKey(planId: PaidPlanId, period: BillingPeriod): string {
+  return `CHM_POLAR_PRODUCT_${planId.toUpperCase()}_${period.toUpperCase()}`
+}
+
+/** Polar product id for a paid plan + period, or null when not configured. */
+export function productIdFor(
+  planId: PaidPlanId,
+  period: BillingPeriod
+): string | null {
+  return readEnv(productEnvKey(planId, period)) ?? null
+}
+
+/** Reverse map: resolve a Polar product id back to our plan + period. */
+export function planForProductId(
+  productId: string
+): { planId: PaidPlanId; period: BillingPeriod } | null {
+  for (const planId of PAID_PLAN_IDS) {
+    for (const period of ['monthly', 'yearly'] as const) {
+      if (productIdFor(planId, period) === productId) return { planId, period }
+    }
+  }
+  return null
+}
+
+/** Type guard usable by routes that accept a plan id from the client. */
+export function isPaidPlanId(value: string): value is PaidPlanId {
+  return (PAID_PLAN_IDS as readonly string[]).includes(value)
+}
+
+export type { PlanId }

--- a/apps/dashboard/src/lib/billing/subscription-store.ts
+++ b/apps/dashboard/src/lib/billing/subscription-store.ts
@@ -1,0 +1,121 @@
+/**
+ * Subscription store — D1 persistence for per-user billing state.
+ *
+ * Reads degrade gracefully: when the CHM_CLOUD_D1 binding is absent (local dev,
+ * self-host) or there is no row, `get()` returns null and the caller falls back
+ * to the free plan. Writes require D1 and are only exercised by the Polar webhook
+ * (cloud runtime), so they throw if the binding is missing.
+ */
+
+import type { PlanId } from './plans'
+
+import { getPlatformBindings } from '@chm/platform'
+
+export interface UserSubscription {
+  userId: string
+  planId: PlanId
+  billingPeriod: 'monthly' | 'yearly' | null
+  status: string
+  polarSubscriptionId: string | null
+  polarCustomerId: string | null
+  /** Unix seconds; access valid until then. null for free. */
+  currentPeriodEnd: number | null
+  createdAt: number
+  updatedAt: number
+}
+
+export interface UpsertSubscriptionInput {
+  userId: string
+  planId: PlanId
+  billingPeriod: 'monthly' | 'yearly' | null
+  status: string
+  polarSubscriptionId?: string | null
+  polarCustomerId?: string | null
+  currentPeriodEnd?: number | null
+}
+
+interface D1SubscriptionRow {
+  user_id: string
+  plan_id: string
+  billing_period: string | null
+  status: string
+  polar_subscription_id: string | null
+  polar_customer_id: string | null
+  current_period_end: number | null
+  created_at: number
+  updated_at: number
+}
+
+function rowToSubscription(row: D1SubscriptionRow): UserSubscription {
+  return {
+    userId: row.user_id,
+    planId: row.plan_id as PlanId,
+    billingPeriod: (row.billing_period as 'monthly' | 'yearly' | null) ?? null,
+    status: row.status,
+    polarSubscriptionId: row.polar_subscription_id,
+    polarCustomerId: row.polar_customer_id,
+    currentPeriodEnd: row.current_period_end,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+function getDb() {
+  return getPlatformBindings().getD1Database('CHM_CLOUD_D1')
+}
+
+/** Read a user's subscription, or null when none / no D1. */
+export async function getSubscription(
+  userId: string
+): Promise<UserSubscription | null> {
+  const db = getDb()
+  if (!db) return null
+  const row = await db
+    .prepare(
+      `SELECT user_id, plan_id, billing_period, status, polar_subscription_id,
+              polar_customer_id, current_period_end, created_at, updated_at
+       FROM user_subscriptions WHERE user_id = ?1`
+    )
+    .bind(userId)
+    .first<D1SubscriptionRow>()
+  return row ? rowToSubscription(row) : null
+}
+
+/** Insert or replace a user's subscription row (idempotent on user_id). */
+export async function upsertSubscription(
+  input: UpsertSubscriptionInput
+): Promise<void> {
+  const db = getDb()
+  if (!db) {
+    throw new Error(
+      'CHM_CLOUD_D1 binding not found; cannot persist subscription'
+    )
+  }
+  const now = Math.floor(Date.now() / 1000)
+  await db
+    .prepare(
+      `INSERT INTO user_subscriptions
+         (user_id, plan_id, billing_period, status, polar_subscription_id,
+          polar_customer_id, current_period_end, created_at, updated_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?8)
+       ON CONFLICT(user_id) DO UPDATE SET
+         plan_id = excluded.plan_id,
+         billing_period = excluded.billing_period,
+         status = excluded.status,
+         polar_subscription_id = excluded.polar_subscription_id,
+         polar_customer_id = excluded.polar_customer_id,
+         current_period_end = excluded.current_period_end,
+         updated_at = excluded.updated_at`
+    )
+    .bind(
+      input.userId,
+      input.planId,
+      input.billingPeriod,
+      input.status,
+      input.polarSubscriptionId ?? null,
+      input.polarCustomerId ?? null,
+      input.currentPeriodEnd ?? null,
+      now
+    )
+    .run()
+}

--- a/apps/dashboard/src/lib/billing/use-billing.ts
+++ b/apps/dashboard/src/lib/billing/use-billing.ts
@@ -1,0 +1,75 @@
+/**
+ * Client hooks for the billing surface.
+ *
+ * useBillingSubscription() reads the current plan; startCheckout()/openPortal()
+ * POST to the billing routes and redirect the browser to the Polar-hosted page.
+ */
+import { useQuery } from '@tanstack/react-query'
+
+import type { PlanId } from '@/lib/billing/plans'
+
+import { apiFetch } from '@/lib/swr/api-fetch'
+
+export interface BillingSubscription {
+  planId: PlanId
+  status: string
+  billingPeriod: 'monthly' | 'yearly' | null
+  currentPeriodEnd: number | null
+}
+
+interface Envelope<T> {
+  success: boolean
+  data?: T
+  error?: { message?: string }
+}
+
+/**
+ * apiFetch does NOT throw on a non-2xx JSON response (it treats application/json
+ * as a stream and returns it), so every billing call must check status + the
+ * envelope itself — otherwise an error response silently becomes `data:
+ * undefined` and the caller mistakes it for success.
+ */
+async function readEnvelope<T>(res: Response): Promise<T> {
+  const json = (await res.json().catch(() => null)) as Envelope<T> | null
+  if (!res.ok || !json?.success || json.data === undefined) {
+    throw new Error(json?.error?.message || `Request failed (${res.status})`)
+  }
+  return json.data
+}
+
+export function useBillingSubscription() {
+  return useQuery({
+    queryKey: ['billing', 'subscription'],
+    queryFn: async (): Promise<BillingSubscription> => {
+      const res = await apiFetch('/api/v1/billing/subscription')
+      return readEnvelope<BillingSubscription>(res)
+    },
+    staleTime: 60_000,
+  })
+}
+
+async function postForUrl(route: string, body?: unknown): Promise<string> {
+  const res = await apiFetch(route, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  const { url } = await readEnvelope<{ url: string }>(res)
+  if (!url) throw new Error('No redirect URL returned')
+  return url
+}
+
+/** Begin a checkout for a paid plan; redirects to Polar on success. */
+export async function startCheckout(
+  planId: 'pro' | 'max',
+  period: 'monthly' | 'yearly'
+): Promise<void> {
+  const url = await postForUrl('/api/v1/billing/checkout', { planId, period })
+  window.location.href = url
+}
+
+/** Open the Polar customer portal for the signed-in user. */
+export async function openBillingPortal(): Promise<void> {
+  const url = await postForUrl('/api/v1/billing/portal')
+  window.location.href = url
+}

--- a/apps/dashboard/src/lib/billing/user-subscription.ts
+++ b/apps/dashboard/src/lib/billing/user-subscription.ts
@@ -1,0 +1,40 @@
+/**
+ * Resolve a user's effective billing plan.
+ *
+ * The free plan is the floor: no subscription row, no D1, or a lapsed/canceled
+ * subscription all resolve to free. A paid plan only applies while its status is
+ * live and (when present) the current period has not ended — so access cleanly
+ * downgrades when a subscription expires without needing a separate cron.
+ */
+
+import type { Plan, PlanId } from './plans'
+import type { UserSubscription } from './subscription-store'
+
+import { BILLING_PLANS, getPlan } from './plans'
+import { getSubscription } from './subscription-store'
+
+/** Polar statuses that still grant the paid plan. */
+const LIVE_STATUSES = new Set(['active', 'trialing'])
+
+export function isSubscriptionLive(
+  sub: Pick<UserSubscription, 'status' | 'currentPeriodEnd'>,
+  nowSeconds: number = Math.floor(Date.now() / 1000)
+): boolean {
+  if (!LIVE_STATUSES.has(sub.status)) return false
+  if (sub.currentPeriodEnd != null && sub.currentPeriodEnd < nowSeconds) {
+    return false
+  }
+  return true
+}
+
+/** The user's current plan id, defaulting to free. */
+export async function getUserPlanId(userId: string): Promise<PlanId> {
+  const sub = await getSubscription(userId)
+  if (!sub || !isSubscriptionLive(sub)) return 'free'
+  return BILLING_PLANS[sub.planId] ? sub.planId : 'free'
+}
+
+/** The user's current Plan object, defaulting to the free plan. */
+export async function getUserPlan(userId: string): Promise<Plan> {
+  return getPlan(await getUserPlanId(userId))
+}

--- a/apps/dashboard/src/lib/connection-sessions/store.ts
+++ b/apps/dashboard/src/lib/connection-sessions/store.ts
@@ -35,7 +35,7 @@ function pruneMemorySessions(): void {
 
 function getD1(): D1Database | null {
   try {
-    return getPlatformBindings().getD1Database('CONVERSATIONS_D1') ?? null
+    return getPlatformBindings().getD1Database('CHM_CLOUD_D1') ?? null
   } catch {
     return null
   }

--- a/apps/dashboard/src/lib/connection-store/d1-store.ts
+++ b/apps/dashboard/src/lib/connection-store/d1-store.ts
@@ -37,10 +37,10 @@ function rowToMeta(row: D1UserConnectionRow): UserConnectionMeta {
 
 export class D1ConnectionStore implements ConnectionStore {
   private getDb(): D1Database {
-    const db = getPlatformBindings().getD1Database('CONVERSATIONS_D1')
+    const db = getPlatformBindings().getD1Database('CHM_CLOUD_D1')
     if (!db) {
       throw new ConnectionStoreError(
-        'CONVERSATIONS_D1 binding not found',
+        'CHM_CLOUD_D1 binding not found',
         'STORAGE_ERROR'
       )
     }

--- a/apps/dashboard/src/lib/connection-store/resolve-store.ts
+++ b/apps/dashboard/src/lib/connection-store/resolve-store.ts
@@ -5,7 +5,7 @@ import { getUserConnectionsServerConfig } from './server-feature'
 import { ConnectionStoreError } from './types'
 import { getPlatformBindings } from '@chm/platform'
 
-const D1_BINDING_NAME = 'CONVERSATIONS_D1'
+const D1_BINDING_NAME = 'CHM_CLOUD_D1'
 const DATABASE_URL = 'DATABASE_URL'
 
 export async function resolveConnectionStore(): Promise<ConnectionStore> {

--- a/apps/dashboard/src/lib/connection-store/server-feature.ts
+++ b/apps/dashboard/src/lib/connection-store/server-feature.ts
@@ -6,7 +6,7 @@ import { isEncryptionConfigured } from './crypto'
 import { getPlatformBindings } from '@chm/platform'
 import { parseDeploymentMode } from '@/lib/config/deployment-mode'
 
-const D1_BINDING_NAME = 'CONVERSATIONS_D1'
+const D1_BINDING_NAME = 'CHM_CLOUD_D1'
 const DATABASE_URL = 'DATABASE_URL'
 
 function readEnv(key: string): string | undefined {

--- a/apps/dashboard/src/lib/conversation-store/d1-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/d1-store.ts
@@ -51,11 +51,11 @@ interface D1ConversationRow {
  */
 export class D1Store implements ConversationStore {
   private getDb(): D1Database {
-    const db = getPlatformBindings().getD1Database('CONVERSATIONS_D1')
+    const db = getPlatformBindings().getD1Database('CHM_CLOUD_D1')
 
     if (!db) {
       throw new ConversationStoreError(
-        'CONVERSATIONS_D1 binding not found. Ensure D1 database is configured in wrangler.toml',
+        'CHM_CLOUD_D1 binding not found. Ensure D1 database is configured in wrangler.toml',
         'STORAGE_ERROR'
       )
     }

--- a/apps/dashboard/src/lib/conversation-store/implementation.md
+++ b/apps/dashboard/src/lib/conversation-store/implementation.md
@@ -9,7 +9,7 @@ D1-based conversation storage for AI agent chat history in Cloudflare Workers en
 ### 1. `/lib/conversation-store/d1-store.ts`
 - Implements `ConversationStore` interface
 - Uses `getCloudflareContext()` from `@opennextjs/cloudflare`
-- D1 binding name: `CONVERSATIONS_D1`
+- D1 binding name: `CHM_CLOUD_D1`
 
 ### 2. `/src/db/migrations/conversations/0001_conversations.sql`
 - Creates `conversations` table with indexes
@@ -23,14 +23,14 @@ Added D1 binding configuration:
 ```toml
 # D1 database for AI agent conversations
 [[d1_databases]]
-binding = "CONVERSATIONS_D1"
+binding = "CHM_CLOUD_D1"
 database_name = "clickhouse-monitor-conversations"
 ```
 
 Also added to `[env.preview]` section for PR deployments.
 
 ### 2. `cloudflare-env.d.ts`
-Added `CONVERSATIONS_D1: D1Database` to `Cloudflare.Env` interface.
+Added `CHM_CLOUD_D1: D1Database` to `Cloudflare.Env` interface.
 
 ## Database Schema
 

--- a/apps/dashboard/src/lib/conversation-store/resolve-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/resolve-store.ts
@@ -23,7 +23,7 @@ import { featureFlags } from '@/lib/feature-flags'
 /**
  * Environment variable names for database configuration.
  */
-const D1_BINDING_NAME = 'CONVERSATIONS_D1'
+const D1_BINDING_NAME = 'CHM_CLOUD_D1'
 const DATABASE_URL = 'DATABASE_URL'
 const AGENTSTATE_API_KEY = 'AGENTSTATE_API_KEY'
 const AGENTSTATE_BASE_URL = 'AGENTSTATE_BASE_URL'

--- a/apps/dashboard/src/lib/feature-permissions/types.ts
+++ b/apps/dashboard/src/lib/feature-permissions/types.ts
@@ -14,6 +14,7 @@ export const FEATURE_IDS = [
   'security',
   'logs',
   'settings',
+  'billing',
   'cluster',
   'operations',
   'actions',

--- a/apps/dashboard/src/lib/insights/store/d1-store.ts
+++ b/apps/dashboard/src/lib/insights/store/d1-store.ts
@@ -3,7 +3,7 @@
  *
  * Persists findings in a dedicated `insights_findings` table on a D1 database.
  * By default it reuses the same D1 binding as the agent's conversation store
- * (`CONVERSATIONS_D1`) so operators who already provisioned D1 get insight
+ * (`CHM_CLOUD_D1`) so operators who already provisioned D1 get insight
  * persistence for free; an optional dedicated `INSIGHTS_D1` binding takes
  * precedence when present.
  *
@@ -30,7 +30,7 @@ const warn = (msg: string) =>
   ErrorLogger.logWarning(`[insights-d1-store] ${msg}`, { component: COMPONENT })
 
 /** Preferred dedicated binding, then the shared conversation binding. */
-const D1_BINDING_NAMES = ['INSIGHTS_D1', 'CONVERSATIONS_D1'] as const
+const D1_BINDING_NAMES = ['INSIGHTS_D1', 'CHM_CLOUD_D1'] as const
 
 const TABLE = 'insights_findings'
 
@@ -99,7 +99,7 @@ export class D1InsightsStore implements InsightsStore {
     try {
       const db = this.getDb()
       if (!db) {
-        warn('no D1 binding (INSIGHTS_D1 / CONVERSATIONS_D1) found')
+        warn('no D1 binding (INSIGHTS_D1 / CHM_CLOUD_D1) found')
         return false
       }
       await this.ensureMigrated(db)

--- a/apps/dashboard/src/lib/migration/auto-migrate.ts
+++ b/apps/dashboard/src/lib/migration/auto-migrate.ts
@@ -1,7 +1,7 @@
 /**
  * Conversation-store auto-migration — TanStack Start / Cloudflare no-op.
  *
- * The Next/OpenNext app migrated the CONVERSATIONS_D1 schema programmatically at
+ * The Next/OpenNext app migrated the CHM_CLOUD_D1 schema programmatically at
  * request time (`@chm/platform` + a migration runner). On the TanStack Start worker
  * the D1 schema is instead applied out-of-band at deploy time via
  * `wrangler d1 migrations apply` (the `migrations_dir` declared on the binding), so

--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -698,6 +698,15 @@ export const menuItemsConfig: MenuItem[] = [
     ],
   },
   {
+    // Cloud (SaaS) plan + host limits. Hidden in self-host (filtered by cloud
+    // mode in app-sidebar.tsx) since self-hosting is free forever.
+    title: 'Billing',
+    href: '/billing',
+    icon: CircleDollarSignIcon,
+    section: 'others',
+    permission: { feature: 'billing' },
+  },
+  {
     title: 'System',
     href: '',
     icon: GearIcon,

--- a/apps/dashboard/src/routes/(dashboard)/billing.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/billing.tsx
@@ -1,0 +1,203 @@
+import { CheckIcon, ExternalLinkIcon } from 'lucide-react'
+import { toast } from 'sonner'
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { Plan } from '@/lib/billing/plans'
+
+import { useState } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  BILLING_PLAN_LIST,
+  getPlan,
+  monthlyEquivalentUsd,
+} from '@/lib/billing/plans'
+import {
+  openBillingPortal,
+  startCheckout,
+  useBillingSubscription,
+} from '@/lib/billing/use-billing'
+import { cn } from '@/lib/utils'
+
+type Period = 'monthly' | 'yearly'
+
+function priceLabel(plan: Plan, period: Period): string {
+  if (plan.priceMonthlyUsd === null) return 'Custom'
+  if (plan.priceMonthlyUsd === 0) return '$0'
+  const v = monthlyEquivalentUsd(plan, period)
+  return v === null ? 'Custom' : `$${v}`
+}
+
+function BillingPage() {
+  const { data: sub, isLoading } = useBillingSubscription()
+  const [period, setPeriod] = useState<Period>('yearly')
+  const [busy, setBusy] = useState<string | null>(null)
+
+  const currentPlanId = sub?.planId ?? 'free'
+  const currentPlan = getPlan(currentPlanId)
+  // 'none' means "never subscribed" — show it as the free plan, not a raw status.
+  const hasSubscription = Boolean(sub && sub.status !== 'none')
+  const statusLabel = hasSubscription ? sub?.status : 'free'
+
+  async function onCheckout(planId: 'pro' | 'max') {
+    setBusy(planId)
+    try {
+      await startCheckout(planId, period)
+    } catch (err) {
+      setBusy(null)
+      toast.error(err instanceof Error ? err.message : 'Checkout failed')
+    }
+  }
+
+  async function onPortal() {
+    setBusy('portal')
+    try {
+      await openBillingPortal()
+    } catch (err) {
+      setBusy(null)
+      toast.error(
+        err instanceof Error ? err.message : 'Could not open billing portal'
+      )
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-8 py-8">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">Billing</h1>
+        <p className="text-muted-foreground text-sm">
+          Manage your plan and host limits. Early access is free while in beta.
+        </p>
+      </div>
+
+      {/* Current plan */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-1">
+              <CardTitle className="flex items-center gap-2">
+                {currentPlan.name}
+                <Badge variant="secondary">
+                  {isLoading ? '…' : statusLabel}
+                </Badge>
+              </CardTitle>
+              <CardDescription>
+                {currentPlan.hosts === null
+                  ? 'Unlimited hosts'
+                  : `${currentPlan.hosts} host${currentPlan.hosts === 1 ? '' : 's'} included`}
+                {currentPlan.seats !== null &&
+                  ` · ${currentPlan.seats} seat${currentPlan.seats === 1 ? '' : 's'}`}
+              </CardDescription>
+            </div>
+            {hasSubscription && (
+              <Button
+                variant="outline"
+                onClick={onPortal}
+                disabled={busy !== null}
+              >
+                Manage billing <ExternalLinkIcon className="size-4" />
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+      </Card>
+
+      {/* Billing period toggle */}
+      <div className="flex items-center justify-center gap-2">
+        <div className="bg-muted inline-flex rounded-full p-1">
+          {(['monthly', 'yearly'] as const).map((p) => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => setPeriod(p)}
+              className={cn(
+                'rounded-full px-4 py-1.5 text-sm font-medium capitalize transition-colors',
+                period === p
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground'
+              )}
+            >
+              {p}
+              {p === 'yearly' && (
+                <span className="text-emerald-600 dark:text-emerald-400">
+                  {' '}
+                  · 2 months free
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Plan grid */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {BILLING_PLAN_LIST.map((plan) => {
+          const isCurrent = plan.id === currentPlanId
+          const paid = plan.id === 'pro' || plan.id === 'max'
+          return (
+            <Card
+              key={plan.id}
+              className={cn(
+                isCurrent && 'border-primary ring-primary/30 ring-1'
+              )}
+            >
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  {plan.name}
+                  {isCurrent && <Badge variant="secondary">Current</Badge>}
+                </CardTitle>
+                <div className="text-2xl font-bold tabular-nums">
+                  {priceLabel(plan, period)}
+                  {plan.priceMonthlyUsd != null && plan.priceMonthlyUsd > 0 ? (
+                    <span className="text-muted-foreground text-sm font-normal">
+                      {' '}
+                      / mo
+                    </span>
+                  ) : null}
+                </div>
+                <CardDescription>{plan.tagline}</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <ul className="space-y-2">
+                  {plan.highlights.map((h) => (
+                    <li key={h} className="flex gap-2 text-sm">
+                      <CheckIcon className="text-emerald-500 mt-0.5 size-4 shrink-0" />
+                      <span>{h}</span>
+                    </li>
+                  ))}
+                </ul>
+                {paid && !isCurrent && (
+                  <Button
+                    className="w-full"
+                    onClick={() => onCheckout(plan.id as 'pro' | 'max')}
+                    disabled={busy !== null}
+                  >
+                    {busy === plan.id
+                      ? 'Redirecting…'
+                      : `Upgrade to ${plan.name}`}
+                  </Button>
+                )}
+                {plan.id === 'enterprise' && (
+                  <Button variant="outline" className="w-full" asChild>
+                    <a href="mailto:hello@chmonitor.dev">Contact us</a>
+                  </Button>
+                )}
+              </CardContent>
+            </Card>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/(dashboard)/billing')({
+  component: BillingPage,
+})

--- a/apps/dashboard/src/routes/api/v1/billing/checkout.ts
+++ b/apps/dashboard/src/routes/api/v1/billing/checkout.ts
@@ -1,0 +1,107 @@
+/**
+ * POST /api/v1/billing/checkout — start a Polar checkout for a paid plan.
+ *
+ * Body: { planId: 'pro' | 'max', period: 'monthly' | 'yearly' }
+ * Returns: { url } — the Polar-hosted checkout URL to redirect the customer to.
+ *
+ * The Clerk userId is passed as `externalCustomerId`, so Polar stamps every
+ * resulting webhook with `customer.externalId` and we never keep a customer map.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+
+import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import { createSuccessResponse } from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import {
+  getPolarClient,
+  isBillingConfigured,
+  isPaidPlanId,
+  productIdFor,
+} from '@/lib/billing/polar-config'
+import { mapConnectionApiError } from '@/lib/connection-store/api-errors'
+import { resolveConnectionUserId } from '@/lib/connection-store/auth'
+
+const ROUTE = { route: '/api/v1/billing/checkout', method: 'POST' }
+
+async function handlePost(request: Request): Promise<Response> {
+  if (!isBillingConfigured()) {
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.PermissionError,
+        message: 'Billing is not enabled.',
+      },
+      501,
+      ROUTE
+    )
+  }
+
+  let body: { planId?: string; period?: string }
+  try {
+    body = (await request.json()) as { planId?: string; period?: string }
+  } catch {
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message: 'Body must be valid JSON',
+      },
+      400,
+      ROUTE
+    )
+  }
+
+  const { planId, period } = body
+  if (!planId || !isPaidPlanId(planId)) {
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message: 'planId must be one of: pro, max',
+      },
+      400,
+      ROUTE
+    )
+  }
+  if (period !== 'monthly' && period !== 'yearly') {
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message: 'period must be monthly or yearly',
+      },
+      400,
+      ROUTE
+    )
+  }
+
+  const productId = productIdFor(planId, period)
+  if (!productId) {
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.PermissionError,
+        message: `No Polar product configured for ${planId}/${period}.`,
+      },
+      501,
+      ROUTE
+    )
+  }
+
+  try {
+    const userId = await resolveConnectionUserId()
+    const origin = new URL(request.url).origin
+    const checkout = await getPolarClient().checkouts.create({
+      products: [productId],
+      externalCustomerId: userId,
+      successUrl: `${origin}/billing?status=success`,
+      metadata: { userId, planId, period },
+    })
+    return createSuccessResponse({ url: checkout.url })
+  } catch (error) {
+    return mapConnectionApiError(error, ROUTE)
+  }
+}
+
+export const Route = createFileRoute('/api/v1/billing/checkout')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/v1/billing/portal.ts
+++ b/apps/dashboard/src/routes/api/v1/billing/portal.ts
@@ -1,0 +1,48 @@
+/**
+ * POST /api/v1/billing/portal — open the Polar customer portal.
+ *
+ * Returns: { url } — a customer-session portal URL where the user can manage,
+ * upgrade, or cancel their subscription and update payment details. Polar hosts
+ * the whole UI; we just mint a session for the current user via externalId.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+
+import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import { createSuccessResponse } from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import { getPolarClient, isBillingConfigured } from '@/lib/billing/polar-config'
+import { mapConnectionApiError } from '@/lib/connection-store/api-errors'
+import { resolveConnectionUserId } from '@/lib/connection-store/auth'
+
+const ROUTE = { route: '/api/v1/billing/portal', method: 'POST' }
+
+async function handlePost(): Promise<Response> {
+  if (!isBillingConfigured()) {
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.PermissionError,
+        message: 'Billing is not enabled.',
+      },
+      501,
+      ROUTE
+    )
+  }
+
+  try {
+    const userId = await resolveConnectionUserId()
+    const session = await getPolarClient().customerSessions.create({
+      externalCustomerId: userId,
+    })
+    return createSuccessResponse({ url: session.customerPortalUrl })
+  } catch (error) {
+    return mapConnectionApiError(error, ROUTE)
+  }
+}
+
+export const Route = createFileRoute('/api/v1/billing/portal')({
+  server: {
+    handlers: {
+      POST: async () => handlePost(),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/v1/billing/subscription.ts
+++ b/apps/dashboard/src/routes/api/v1/billing/subscription.ts
@@ -1,0 +1,42 @@
+/**
+ * GET /api/v1/billing/subscription — the current user's plan + subscription.
+ *
+ * Returns { planId, status, billingPeriod, currentPeriodEnd }. Always resolves to
+ * at least the free plan (see getUserPlanId), so the billing UI can render even
+ * before a user has ever subscribed.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+
+import { createSuccessResponse } from '@/lib/api/shared/response-builder'
+import { getSubscription } from '@/lib/billing/subscription-store'
+import { getUserPlanId } from '@/lib/billing/user-subscription'
+import { mapConnectionApiError } from '@/lib/connection-store/api-errors'
+import { resolveConnectionUserId } from '@/lib/connection-store/auth'
+
+const ROUTE = { route: '/api/v1/billing/subscription', method: 'GET' }
+
+async function handleGet(): Promise<Response> {
+  try {
+    const userId = await resolveConnectionUserId()
+    const [planId, sub] = await Promise.all([
+      getUserPlanId(userId),
+      getSubscription(userId),
+    ])
+    return createSuccessResponse({
+      planId,
+      status: sub?.status ?? 'none',
+      billingPeriod: sub?.billingPeriod ?? null,
+      currentPeriodEnd: sub?.currentPeriodEnd ?? null,
+    })
+  } catch (error) {
+    return mapConnectionApiError(error, ROUTE)
+  }
+}
+
+export const Route = createFileRoute('/api/v1/billing/subscription')({
+  server: {
+    handlers: {
+      GET: async () => handleGet(),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/v1/user-connections.ts
+++ b/apps/dashboard/src/routes/api/v1/user-connections.ts
@@ -11,6 +11,7 @@ import type { CreateUserConnectionInput } from '@/lib/connection-store/types'
 import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
 import { createSuccessResponse } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
+import { getUserPlan } from '@/lib/billing/user-subscription'
 import { validateHostUrl } from '@/lib/browser-connections/host-url'
 import { queryConnection } from '@/lib/connection-query/connection-client'
 import { mapConnectionApiError } from '@/lib/connection-store/api-errors'
@@ -104,15 +105,6 @@ async function handlePost(request: Request): Promise<Response> {
     )
   }
 
-  const ssrfError = await validateHostUrl(host.trim())
-  if (ssrfError) {
-    return createApiErrorResponse(
-      { type: ApiErrorType.ValidationError, message: ssrfError },
-      400,
-      ROUTE_POST
-    )
-  }
-
   const credentials = {
     host: host.trim(),
     user: user.trim(),
@@ -120,21 +112,56 @@ async function handlePost(request: Request): Promise<Response> {
   }
 
   try {
-    await queryConnection(credentials, 'SELECT 1')
-  } catch (err) {
-    return createApiErrorResponse(
-      {
-        type: ApiErrorType.QueryError,
-        message: err instanceof Error ? err.message : 'Connection test failed',
-      },
-      400,
-      ROUTE_POST
-    )
-  }
-
-  try {
     const userId = await resolveConnectionUserId()
     const store = await resolveConnectionStore()
+
+    // Host-limit enforcement FIRST: paid plans cap how many connections a user
+    // keeps. plan.hosts === null means unlimited (Enterprise). Checking before
+    // the SSRF check + outbound connection test fails fast and avoids opening a
+    // network connection to an attacker-supplied host for a request we'll reject.
+    const plan = await getUserPlan(userId)
+    if (plan.hosts != null) {
+      const existing = await store.list(userId)
+      if (existing.length >= plan.hosts) {
+        return createApiErrorResponse(
+          {
+            type: ApiErrorType.PermissionError,
+            message: `Your ${plan.name} plan includes ${plan.hosts} host${plan.hosts === 1 ? '' : 's'}. Upgrade your plan to connect more.`,
+            details: {
+              planId: plan.id,
+              limit: plan.hosts,
+              reason: 'host_limit',
+            },
+          },
+          402,
+          ROUTE_POST
+        )
+      }
+    }
+
+    const ssrfError = await validateHostUrl(credentials.host)
+    if (ssrfError) {
+      return createApiErrorResponse(
+        { type: ApiErrorType.ValidationError, message: ssrfError },
+        400,
+        ROUTE_POST
+      )
+    }
+
+    try {
+      await queryConnection(credentials, 'SELECT 1')
+    } catch (err) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.QueryError,
+          message:
+            err instanceof Error ? err.message : 'Connection test failed',
+        },
+        400,
+        ROUTE_POST
+      )
+    }
+
     const input: CreateUserConnectionInput = {
       name: name.trim(),
       hostUrl: credentials.host,

--- a/apps/dashboard/src/routes/api/v1/webhooks/polar.ts
+++ b/apps/dashboard/src/routes/api/v1/webhooks/polar.ts
@@ -1,0 +1,124 @@
+/**
+ * POST /api/v1/webhooks/polar — Polar webhook receiver.
+ *
+ * Verifies the signature over the RAW body (validateEvent base64-encodes the
+ * secret internally), then upserts the user's subscription row keyed by
+ * `customer.externalId` (the Clerk userId we set as externalCustomerId at
+ * checkout). getUserPlan reads that row; access downgrades to free when a
+ * subscription is canceled/expired.
+ *
+ * Unauthenticated by design — the signature IS the auth. Always 2xx on a valid
+ * (even if ignored) event so Polar doesn't retry; 400 only on a bad signature.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+
+import { error as logError, log as logInfo } from '@chm/logger'
+import { validateEvent, WebhookVerificationError } from '@polar-sh/sdk/webhooks'
+import { getWebhookSecret, planForProductId } from '@/lib/billing/polar-config'
+import { upsertSubscription } from '@/lib/billing/subscription-store'
+
+/** Polar Subscription shape (subset) carried by subscription.* events. */
+interface PolarSubscriptionData {
+  id: string
+  status: string
+  recurringInterval?: string | null
+  currentPeriodEnd?: Date | string | null
+  productId: string
+  customerId: string
+  customer?: { externalId?: string | null } | null
+}
+
+function toUnixSeconds(value: Date | string | null | undefined): number | null {
+  if (!value) return null
+  const ms = value instanceof Date ? value.getTime() : Date.parse(value)
+  return Number.isFinite(ms) ? Math.floor(ms / 1000) : null
+}
+
+async function applySubscription(data: PolarSubscriptionData): Promise<void> {
+  const userId = data.customer?.externalId
+  if (!userId) {
+    logInfo('[polar-webhook] subscription without externalId; skipping', {
+      subscriptionId: data.id,
+    })
+    return
+  }
+  const mapped = planForProductId(data.productId)
+  if (!mapped) {
+    logInfo('[polar-webhook] unknown product id; skipping', {
+      productId: data.productId,
+    })
+    return
+  }
+  await upsertSubscription({
+    userId,
+    planId: mapped.planId,
+    billingPeriod: mapped.period,
+    status: data.status,
+    polarSubscriptionId: data.id,
+    polarCustomerId: data.customerId,
+    currentPeriodEnd: toUnixSeconds(data.currentPeriodEnd),
+  })
+  logInfo('[polar-webhook] applied subscription', {
+    userId,
+    planId: mapped.planId,
+    status: data.status,
+  })
+}
+
+async function handlePost(request: Request): Promise<Response> {
+  const secret = getWebhookSecret()
+  if (!secret) {
+    return Response.json(
+      { error: 'Billing webhook not configured' },
+      { status: 501 }
+    )
+  }
+
+  const body = await request.text()
+  const headers: Record<string, string> = {}
+  request.headers.forEach((value, key) => {
+    headers[key] = value
+  })
+
+  let event: ReturnType<typeof validateEvent>
+  try {
+    event = validateEvent(body, headers, secret)
+  } catch (err) {
+    if (err instanceof WebhookVerificationError) {
+      return Response.json({ error: 'Invalid signature' }, { status: 403 })
+    }
+    logError('[polar-webhook] failed to parse event', err)
+    return Response.json({ error: 'Bad request' }, { status: 400 })
+  }
+
+  try {
+    switch (event.type) {
+      case 'subscription.created':
+      case 'subscription.updated':
+      case 'subscription.active':
+      case 'subscription.canceled':
+      case 'subscription.uncanceled':
+      case 'subscription.revoked':
+      case 'subscription.past_due':
+        await applySubscription(event.data as unknown as PolarSubscriptionData)
+        break
+      default:
+        // Acknowledge unhandled events (checkout.*, order.*, etc.) without action.
+        break
+    }
+  } catch (err) {
+    // Persistence failed — 500 so Polar retries with backoff.
+    logError('[polar-webhook] handler error', err)
+    return Response.json({ error: 'Handler error' }, { status: 500 })
+  }
+
+  return Response.json({ received: true }, { status: 202 })
+}
+
+export const Route = createFileRoute('/api/v1/webhooks/polar')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -16,7 +16,7 @@ enabled = true
 
 # D1 database for AI agent conversations
 [[d1_databases]]
-binding = "CONVERSATIONS_D1"
+binding = "CHM_CLOUD_D1"
 database_name = "clickhouse-monitor-conversations"
 migrations_dir = "./src/db/conversations-migrations"
 
@@ -24,7 +24,7 @@ migrations_dir = "./src/db/conversations-migrations"
 # The legacy Next.js worker (same name, chmonitor-dash) registered two SQLite
 # Durable Objects: DOQueueHandler (OpenNext queue) and AgentConversationDurableObject
 # (agent chat history). The TanStack Start app uses neither — conversations now
-# live in CONVERSATIONS_D1 — so deploying over the existing worker requires an
+# live in CHM_CLOUD_D1 — so deploying over the existing worker requires an
 # explicit delete-class migration (Cloudflare refuses to silently drop a DO).
 # v1/v2 are the legacy worker's already-applied history (kept so wrangler can
 # sequence v3 after them); v3 removes both classes.
@@ -100,7 +100,7 @@ custom_domain = true
 
 # Reuse the same conversation D1 database once database_id is provisioned
 [[env.preview.d1_databases]]
-binding = "CONVERSATIONS_D1"
+binding = "CHM_CLOUD_D1"
 database_name = "clickhouse-monitor-conversations"
 migrations_dir = "./src/db/conversations-migrations"
 

--- a/apps/docs/src/content/docs/ai-agent/conversation-history/backends.md
+++ b/apps/docs/src/content/docs/ai-agent/conversation-history/backends.md
@@ -21,7 +21,7 @@ Configure `AGENT_CONVERSATION_STORE` to one of the values below. All stores requ
 `auto` picks the first available backend in this order:
 
 1. **AgentState** — when `AGENTSTATE_API_KEY` is set
-2. **D1** — when the `CONVERSATIONS_D1` binding is present
+2. **D1** — when the `CHM_CLOUD_D1` binding is present
 3. **Durable Object** — when the `AGENT_CONVERSATIONS_DO` binding is present
 4. **Postgres** — when `DATABASE_URL`, `POSTGRES_URL`, or `POSTGRES_PRISMA_URL` is set
 5. **ClickHouse** — only when `CLICKHOUSE_AGENT_CONVERSATIONS_TABLE` is explicitly set
@@ -47,7 +47,7 @@ Cloudflare-only. Requires a provisioned D1 database and a Worker binding.
 ```bash
 AGENT_CONVERSATION_PERSISTENCE=true
 AGENT_CONVERSATION_STORE=d1
-CONVERSATIONS_D1_DATABASE_ID=<uuid>
+CHM_CLOUD_D1_DATABASE_ID=<uuid>
 ```
 
 Provision and migrate:
@@ -57,9 +57,9 @@ bun run cf:setup-conversations
 bun run cf:migrate-conversations
 ```
 
-The setup script creates the D1 database, stores the UUID in `wrangler.toml`, and adds the `CONVERSATIONS_D1` binding. The migration script applies the schema. During CI deploys, set `CONVERSATIONS_D1_DATABASE_ID` as a secret so `wrangler deploy` includes the binding. Without it, the binding is excluded from the deploy.
+The setup script creates the D1 database, stores the UUID in `wrangler.toml`, and adds the `CHM_CLOUD_D1` binding. The migration script applies the schema. During CI deploys, set `CHM_CLOUD_D1_DATABASE_ID` as a secret so `wrangler deploy` includes the binding. Without it, the binding is excluded from the deploy.
 
-Also accepts `AGENT_CONVERSATIONS_D1_DATABASE_ID` as an alias for `CONVERSATIONS_D1_DATABASE_ID`.
+Also accepts `AGENT_CHM_CLOUD_D1_DATABASE_ID` as an alias for `CHM_CLOUD_D1_DATABASE_ID`.
 
 **When to use:** standard Cloudflare deployments that want queryable, exportable conversation history.
 

--- a/apps/docs/src/content/docs/ai-agent/index.md
+++ b/apps/docs/src/content/docs/ai-agent/index.md
@@ -148,7 +148,7 @@ INSIGHTS_STORE_BACKEND=auto   # auto | clickhouse | d1 | postgres | agentstate |
 |---|---|---|
 | `auto` (default) | ClickHouse `monitoring_findings` table | writable monitoring connection |
 | `clickhouse` | same as `auto` | writable monitoring connection |
-| `d1` | Cloudflare D1 `insights_findings` table | `INSIGHTS_D1` binding, else `CONVERSATIONS_D1` |
+| `d1` | Cloudflare D1 `insights_findings` table | `INSIGHTS_D1` binding, else `CHM_CLOUD_D1` |
 | `postgres` | Postgres `insights_findings` table | `DATABASE_URL` |
 | `agentstate` | AgentState State store | `AGENTSTATE_API_KEY` (+ optional `AGENTSTATE_BASE_URL`) |
 | `memory` | in-process (ephemeral) | — |

--- a/apps/docs/src/content/docs/deploy/cloudflare.md
+++ b/apps/docs/src/content/docs/deploy/cloudflare.md
@@ -253,7 +253,7 @@ Add the binding to `wrangler.toml`:
 
 ```toml
 [[d1_databases]]
-binding = "CONVERSATIONS_D1"
+binding = "CHM_CLOUD_D1"
 database_name = "chmonitor-conversations"
 database_id = "<database-id-from-above>"
 ```
@@ -262,7 +262,7 @@ database_id = "<database-id-from-above>"
 [vars]
 AGENT_CONVERSATION_PERSISTENCE = "true"
 AGENT_CONVERSATION_STORE = "d1"
-CONVERSATIONS_D1_DATABASE_ID = "<database-id>"
+CHM_CLOUD_D1_DATABASE_ID = "<database-id>"
 ```
 
 Run migrations:
@@ -336,7 +336,7 @@ The app uses these Cloudflare resources (configured in `wrangler.toml`):
 
 | Binding | Type | Purpose |
 |---|---|---|
-| `CONVERSATIONS_D1` | D1 Database | Conversation history (optional) |
+| `CHM_CLOUD_D1` | D1 Database | Conversation history (optional) |
 | `AGENT_CONVERSATIONS_DO` | Durable Object | Conversation history via Durable Objects (optional) |
 
 The TanStack Start build via `@cloudflare/vite-plugin` does not require KV, R2, or cache-tag bindings. Only conversation-store bindings need to be added if you enable server-side persistence.

--- a/apps/docs/src/content/docs/features/user-connections.md
+++ b/apps/docs/src/content/docs/features/user-connections.md
@@ -22,7 +22,7 @@ Browser-only storage remains available when server storage is disabled or the us
 
 1. Set auth to Clerk (`CHM_AUTH_PROVIDER=clerk`, `VITE_AUTH_PROVIDER=clerk`).
 2. Configure a database backend:
-   - **Cloudflare Workers**: `CONVERSATIONS_D1` binding (shared D1 database; migration `0002_user_connections.sql`).
+   - **Cloudflare Workers**: `CHM_CLOUD_D1` binding (shared D1 database; migration `0002_user_connections.sql`).
    - **Node / K8s**: `DATABASE_URL` or `POSTGRES_URL`.
 3. Set feature flags:
    ```bash

--- a/apps/docs/src/content/docs/reference/environment-variables.md
+++ b/apps/docs/src/content/docs/reference/environment-variables.md
@@ -235,8 +235,8 @@ Agent conversations default to browser localStorage. Enable server-side persiste
 
 | Variable | Default | Description |
 |---|---|---|
-| `CONVERSATIONS_D1_DATABASE_ID` | — | Cloudflare D1 database UUID for the `CONVERSATIONS_D1` binding. |
-| `AGENT_CONVERSATIONS_D1_DATABASE_ID` | — | Alias for `CONVERSATIONS_D1_DATABASE_ID`. |
+| `CHM_CLOUD_D1_DATABASE_ID` | — | Cloudflare D1 database UUID for the `CHM_CLOUD_D1` binding. |
+| `AGENT_CHM_CLOUD_D1_DATABASE_ID` | — | Alias for `CHM_CLOUD_D1_DATABASE_ID`. |
 
 **Cloudflare Durable Object backend:**
 
@@ -270,7 +270,7 @@ The AI Insights panel on `/overview` persists its findings through a pluggable s
 | Variable | Default | Description |
 |---|---|---|
 | `INSIGHTS_STORE_BACKEND` | `auto` | Backend: `auto`, `clickhouse`, `d1`, `postgres`, `agentstate`, or `memory`. `auto` and `clickhouse` both use the ClickHouse `monitoring_findings` table. `auto` never silently follows other env; a selected backend missing its prerequisite falls back to ClickHouse. |
-| `INSIGHTS_D1` | — | Optional dedicated D1 binding for the `d1` backend. Falls back to `CONVERSATIONS_D1` when unset. |
+| `INSIGHTS_D1` | — | Optional dedicated D1 binding for the `d1` backend. Falls back to `CHM_CLOUD_D1` when unset. |
 
 `postgres` reuses `DATABASE_URL`; `agentstate` reuses `AGENTSTATE_API_KEY` (+ optional `AGENTSTATE_BASE_URL`).
 

--- a/docs/content/guide/ai-agent.mdx
+++ b/docs/content/guide/ai-agent.mdx
@@ -176,7 +176,7 @@ INSIGHTS_STORE_BACKEND=auto   # auto | clickhouse | d1 | postgres | agentstate |
 |---|---|---|
 | `auto` (default) | ClickHouse `monitoring_findings` table | writable monitoring connection |
 | `clickhouse` | same as `auto` | writable monitoring connection |
-| `d1` | Cloudflare D1 `insights_findings` table | `INSIGHTS_D1` binding, else `CONVERSATIONS_D1` |
+| `d1` | Cloudflare D1 `insights_findings` table | `INSIGHTS_D1` binding, else `CHM_CLOUD_D1` |
 | `postgres` | Postgres `insights_findings` table | `DATABASE_URL` |
 | `agentstate` | AgentState State store | `AGENTSTATE_API_KEY` (+ optional `AGENTSTATE_BASE_URL`) |
 | `memory` | in-process (ephemeral) | — |

--- a/docs/content/guide/ai-agent/conversation-history.mdx
+++ b/docs/content/guide/ai-agent/conversation-history.mdx
@@ -51,7 +51,7 @@ When `CONVERSATION_STORE_BACKEND` is not set, the server auto-selects the first 
 When `CONVERSATION_STORE_BACKEND` is not set (or set to an unrecognized value), the server picks the first available backend in this order:
 
 1. **AgentState** — when `AGENTSTATE_API_KEY` is set and `CONVERSATION_STORE_BACKEND` is not `d1`, `postgres`, or `memory`.
-2. **Cloudflare D1** — when the `CONVERSATIONS_D1` binding is present (Cloudflare Workers only).
+2. **Cloudflare D1** — when the `CHM_CLOUD_D1` binding is present (Cloudflare Workers only).
 3. **Postgres** — when `DATABASE_URL` is set.
 4. **Memory** — fallback in development/CI. Conversations are lost on process restart.
 

--- a/docs/content/guide/ai-agent/conversation-history/backends.mdx
+++ b/docs/content/guide/ai-agent/conversation-history/backends.mdx
@@ -24,7 +24,7 @@ All server-side backends require `CHM_FEATURE_CONVERSATION_DB=true` set **before
 When `CONVERSATION_STORE_BACKEND` is not set, the server picks the first available backend:
 
 1. **AgentState** — when `AGENTSTATE_API_KEY` is set and `CONVERSATION_STORE_BACKEND` is not explicitly `d1`, `postgres`, or `memory`.
-2. **Cloudflare D1** — when the `CONVERSATIONS_D1` binding is present (Cloudflare Workers only).
+2. **Cloudflare D1** — when the `CHM_CLOUD_D1` binding is present (Cloudflare Workers only).
 3. **Postgres** — when `DATABASE_URL` is set.
 4. **Memory** — fallback in development/CI.
 
@@ -45,7 +45,7 @@ Cloudflare-only. Requires a provisioned D1 database and a Worker binding.
 
 ```bash
 CONVERSATION_STORE_BACKEND=d1
-CONVERSATIONS_D1_DATABASE_ID=<uuid>
+CHM_CLOUD_D1_DATABASE_ID=<uuid>
 ```
 
 Provision and migrate:
@@ -55,9 +55,9 @@ bun run cf:setup-conversations
 bun run cf:migrate-conversations
 ```
 
-The setup script creates the D1 database, stores the UUID in `wrangler.toml`, and adds the `CONVERSATIONS_D1` binding. The migration script applies the schema. During CI deploys, set `CONVERSATIONS_D1_DATABASE_ID` as a secret so `wrangler deploy` includes the binding. Without it, the binding is excluded from the deploy.
+The setup script creates the D1 database, stores the UUID in `wrangler.toml`, and adds the `CHM_CLOUD_D1` binding. The migration script applies the schema. During CI deploys, set `CHM_CLOUD_D1_DATABASE_ID` as a secret so `wrangler deploy` includes the binding. Without it, the binding is excluded from the deploy.
 
-Also accepts `AGENT_CONVERSATIONS_D1_DATABASE_ID` as an alias for `CONVERSATIONS_D1_DATABASE_ID`.
+Also accepts `AGENT_CHM_CLOUD_D1_DATABASE_ID` as an alias for `CHM_CLOUD_D1_DATABASE_ID`.
 
 **When to use:** standard Cloudflare deployments that want queryable, exportable conversation history.
 

--- a/docs/content/guide/features/user-connections.mdx
+++ b/docs/content/guide/features/user-connections.mdx
@@ -29,7 +29,7 @@ server returns *"User connections database storage is not enabled"* and the
 1. **`CHM_FEATURE_USER_CONNECTIONS_DB=true`** — the feature flag.
 2. **Clerk auth** (`CHM_AUTH_PROVIDER=clerk`) — connections are keyed by the signed-in Clerk `userId`.
 3. **`CHM_USER_CONNECTIONS_ENCRYPTION_KEY`** — a 32-byte base64 key used to encrypt credentials at rest (AES-256-GCM).
-4. **A database backend** — `CONVERSATIONS_D1` on Cloudflare, or `DATABASE_URL` / `POSTGRES_URL` on Docker / Kubernetes.
+4. **A database backend** — `CHM_CLOUD_D1` on Cloudflare, or `DATABASE_URL` / `POSTGRES_URL` on Docker / Kubernetes.
 
 <Callout type="info" title="One canonical name">
 Set the canonical `CHM_*` name once. The browser-side `VITE_FEATURE_USER_CONNECTIONS_DB` / `VITE_AUTH_PROVIDER` are **derived** from `CHM_FEATURE_USER_CONNECTIONS_DB` / `CHM_AUTH_PROVIDER` at build time (see `vite.config.ts`) — you don't set them separately. Because the client value is inlined at build time, set these before `bun run build` (or build a custom image), then keep them in the runtime env too.
@@ -49,7 +49,7 @@ CHM_AUTH_PROVIDER=clerk
 
 <Tabs items={['Cloudflare Workers (D1)', 'Node / Kubernetes (Postgres)']}>
 <Tab value="Cloudflare Workers (D1)">
-Use the `CONVERSATIONS_D1` binding (shared D1 database; migration `0002_user_connections.sql`).
+Use the `CHM_CLOUD_D1` binding (shared D1 database; migration `0002_user_connections.sql`).
 </Tab>
 <Tab value="Node / Kubernetes (Postgres)">
 Set `DATABASE_URL` or `POSTGRES_URL`.

--- a/docs/content/operate/deploy/cloudflare.mdx
+++ b/docs/content/operate/deploy/cloudflare.mdx
@@ -278,7 +278,7 @@ Add the binding to `wrangler.toml`:
 
 ```toml
 [[d1_databases]]
-binding = "CONVERSATIONS_D1"
+binding = "CHM_CLOUD_D1"
 database_name = "chmonitor-conversations"
 database_id = "<database-id-from-above>"
 ```
@@ -286,7 +286,7 @@ database_id = "<database-id-from-above>"
 ```toml
 [vars]
 CONVERSATION_STORE_BACKEND = "d1"
-CONVERSATIONS_D1_DATABASE_ID = "<database-id>"
+CHM_CLOUD_D1_DATABASE_ID = "<database-id>"
 ```
 
 In CI, also set `CHM_FEATURE_CONVERSATION_DB=true` before the build step (the client `VITE_FEATURE_CONVERSATION_DB` derives from it):
@@ -374,7 +374,7 @@ The app uses these Cloudflare resources (configured in `wrangler.toml`):
 
 | Binding | Type | Purpose |
 |---|---|---|
-| `CONVERSATIONS_D1` | D1 Database | Conversation history (optional) |
+| `CHM_CLOUD_D1` | D1 Database | Conversation history (optional) |
 | `AGENT_CONVERSATIONS_DO` | Durable Object | Conversation history via Durable Objects (optional) |
 
 The TanStack Start build via `@cloudflare/vite-plugin` does not require KV, R2, or cache-tag bindings. Only conversation-store bindings need to be added if you enable server-side persistence.

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -287,8 +287,8 @@ Agent conversations default to browser localStorage. Enable server-side persiste
 
 | Variable | Default | Description |
 |---|---|---|
-| `CONVERSATIONS_D1_DATABASE_ID` | — | Cloudflare D1 database UUID for the `CONVERSATIONS_D1` binding. |
-| `AGENT_CONVERSATIONS_D1_DATABASE_ID` | — | Alias for `CONVERSATIONS_D1_DATABASE_ID`. |
+| `CHM_CLOUD_D1_DATABASE_ID` | — | Cloudflare D1 database UUID for the `CHM_CLOUD_D1` binding. |
+| `AGENT_CHM_CLOUD_D1_DATABASE_ID` | — | Alias for `CHM_CLOUD_D1_DATABASE_ID`. |
 
 **PostgreSQL backend:**
 
@@ -315,7 +315,7 @@ storage is not enabled"*.
 | `CHM_AUTH_PROVIDER` | `none` | Must be `clerk` — connections are keyed by the Clerk `userId`. |
 | `CHM_USER_CONNECTIONS_ENCRYPTION_KEY` | — | 32-byte base64 key (secret) encrypting saved credentials at rest (AES-256-GCM). |
 
-Plus a database backend: the `CONVERSATIONS_D1` binding on Cloudflare, or
+Plus a database backend: the `CHM_CLOUD_D1` binding on Cloudflare, or
 `DATABASE_URL` / `POSTGRES_URL` on Docker / Kubernetes.
 
 See [User Connections](/guide/features/user-connections) for the full setup.
@@ -329,7 +329,7 @@ The AI Insights panel on `/overview` persists its findings through a pluggable s
 | Variable | Default | Description |
 |---|---|---|
 | `INSIGHTS_STORE_BACKEND` | `auto` | Backend: `auto`, `clickhouse`, `d1`, `postgres`, `agentstate`, or `memory`. `auto` and `clickhouse` both use the ClickHouse `monitoring_findings` table. `auto` never silently follows other env; a selected backend missing its prerequisite falls back to ClickHouse. |
-| `INSIGHTS_D1` | — | Optional dedicated D1 binding for the `d1` backend. Falls back to `CONVERSATIONS_D1` when unset. |
+| `INSIGHTS_D1` | — | Optional dedicated D1 binding for the `d1` backend. Falls back to `CHM_CLOUD_D1` when unset. |
 
 `postgres` reuses `DATABASE_URL`; `agentstate` reuses `AGENTSTATE_API_KEY` (+ optional `AGENTSTATE_BASE_URL`).
 

--- a/docs/knowledge/agent-conversation-storage.md
+++ b/docs/knowledge/agent-conversation-storage.md
@@ -38,11 +38,11 @@ after deployment.
   updates.
 - Require authenticated user identity for server stores. Unauthenticated
   sessions use local browser history.
-- Use `CONVERSATIONS_D1` only for conversation D1 migrations. Never fall back to
+- Use `CHM_CLOUD_D1` only for conversation D1 migrations. Never fall back to
   `NEXT_TAG_CACHE_D1`.
 - Active Wrangler D1 bindings need a concrete `database_id`. Deploys should use
   `scripts/prepare-dashboard-wrangler.ts` so unprovisioned optional
-  `CONVERSATIONS_D1` bindings are removed unless `CONVERSATIONS_D1_DATABASE_ID`
+  `CHM_CLOUD_D1` bindings are removed unless `CHM_CLOUD_D1_DATABASE_ID`
   is set.
 - Prefer D1 over Durable Objects for ordinary Cloudflare history because D1 is a
   managed queryable database. Use Durable Objects when per-user coordination is

--- a/docs/knowledge/ai-insights.md
+++ b/docs/knowledge/ai-insights.md
@@ -81,7 +81,7 @@ nothing keeps the original ClickHouse behavior. Backends:
 |---|---|---|
 | `auto` (default) | ClickHouse | — (original behavior) |
 | `clickhouse` | ClickHouse `monitoring_findings` table on the monitored cluster | writable monitoring connection |
-| `d1` | Cloudflare D1 `insights_findings` table | `INSIGHTS_D1` binding, else `CONVERSATIONS_D1` |
+| `d1` | Cloudflare D1 `insights_findings` table | `INSIGHTS_D1` binding, else `CHM_CLOUD_D1` |
 | `postgres` | Postgres `insights_findings` table | `DATABASE_URL` |
 | `agentstate` | AgentState generic State store | `AGENTSTATE_API_KEY` (+ optional `AGENTSTATE_BASE_URL`) |
 | `memory` | in-process map (ephemeral) | — |
@@ -106,7 +106,7 @@ Files: `clickhouse-store.ts`, `d1-store.ts`, `postgres-store.ts`,
 
 - **D1 / Postgres** lazily create a dedicated `insights_findings` table on first
   use (event_time as unix ms, scalar finding columns). D1 reuses the
-  conversation D1 binding (`INSIGHTS_D1` first, then `CONVERSATIONS_D1`); Postgres
+  conversation D1 binding (`INSIGHTS_D1` first, then `CHM_CLOUD_D1`); Postgres
   reuses `DATABASE_URL`.
 - **ClickHouse** uses the existing `monitoring_findings` table with
   `source = 'ai-insight'`.
@@ -136,7 +136,7 @@ Files: `clickhouse-store.ts`, `d1-store.ts`, `postgres-store.ts`,
 | Variable | Required | Default | Purpose |
 |---|---|---|---|
 | `INSIGHTS_STORE_BACKEND` | no | `auto` | `auto` \| `clickhouse` \| `d1` \| `postgres` \| `agentstate` \| `memory`. `auto`/`clickhouse` = ClickHouse findings store |
-| `INSIGHTS_D1` | no | — | optional dedicated D1 binding for the `d1` backend; falls back to `CONVERSATIONS_D1` |
+| `INSIGHTS_D1` | no | — | optional dedicated D1 binding for the `d1` backend; falls back to `CHM_CLOUD_D1` |
 | `DATABASE_URL` | for `postgres` | — | reused from the conversation Postgres store |
 | `AGENTSTATE_API_KEY` | for `agentstate` | — | reused from the AgentState conversation store |
 | `AGENTSTATE_BASE_URL` | no | SDK default | self-host endpoint for `agentstate` |

--- a/docs/knowledge/cloud-saas-mode.md
+++ b/docs/knowledge/cloud-saas-mode.md
@@ -78,6 +78,34 @@ validation builder). Rendered by `ConnectionErrorPanel` in `connection-form.tsx`
 Docs: `docs/content/guide/guides/connection-errors.mdx` (slug
 `guides/connection-errors`). Tested in `lib/connection-errors.test.ts`.
 
+## Billing (Polar) — cloud SaaS only
+
+M3 wires paid plans via [Polar](https://polar.sh). Cloud-only; OSS/self-host is
+free forever (auth `none` ⇒ unlimited, plans inert).
+
+- **Plans**: `lib/billing/plans.ts` (`BILLING_PLANS`) is the price/capability
+  source of truth; `apps/landing/Pricing.astro` mirrors the numbers.
+- **Config**: `lib/billing/polar-config.ts` — `getPolarClient()` (server
+  `sandbox|production` from `CHM_POLAR_SERVER`) + product↔plan mapping from
+  `CHM_POLAR_PRODUCT_<PLAN>_<PERIOD>` env vars. Product ids live in env (sandbox
+  vs production differ), NOT in `plans.ts`. `POLAR_ACCESS_TOKEN` is a secret.
+- **Storage**: one row per user in `user_subscriptions` (migration
+  `0003_user_subscriptions.sql`) in the shared `CHM_CLOUD_D1` database.
+  `subscription-store.ts` (D1 CRUD; degrades to null without D1),
+  `user-subscription.ts` `getUserPlan()` (defaults free; downgrades when status
+  not live or the period ended — no cron needed).
+- **Routes**: `api/v1/billing/checkout` (hosted checkout, `externalCustomerId =
+  Clerk userId` ⇒ no customer map), `…/portal`, `…/subscription` (GET),
+  `api/v1/webhooks/polar` (verifies via `validateEvent` over the RAW body).
+- **Enforcement**: `api/v1/user-connections` POST returns 402 at `plan.hosts`
+  (null = unlimited).
+- **UI**: `routes/(dashboard)/billing.tsx`, gated to cloud mode in
+  `app-sidebar.tsx`; `feature: 'billing'`.
+- **Setup**: `apps/dashboard/scripts/polar-setup.ts` creates Pro/Max
+  monthly+yearly products from `BILLING_PLANS` and prints the
+  `CHM_POLAR_PRODUCT_*` env lines. Sandbox/production tokens are distinct — a
+  production token 401s against `sandbox-api.polar.sh`.
+
 ## Gotchas
 
 - `apps/dashboard` is NOT a root bun workspace — run `bun install` *inside*

--- a/docs/knowledge/tsr-migration.md
+++ b/docs/knowledge/tsr-migration.md
@@ -211,7 +211,7 @@ data-dashboard pages** (render-delay collapses), but it's not universal.
   - **`--destructive-foreground` is mapped but undefined** in both apps'
     `globals.css` (`text-destructive-foreground` resolves to nothing; currently
     unused). Add the token to both files together if a consumer ever needs it.
-- Conversation **server-persistence** needs a provisioned `CONVERSATIONS_D1`
+- Conversation **server-persistence** needs a provisioned `CHM_CLOUD_D1`
   (`wrangler d1 create`) + binding in `wrangler.toml` + `patch-wrangler-env.ts`. Agent chat
   works via the client thread store until then.
 - Copied agent-subsystem **test files** are excluded from the production typecheck

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -10,7 +10,7 @@
  * ```typescript
  * import { getPlatformBindings } from '@chm/platform'
  *
- * const db = getPlatformBindings().getD1Database('CONVERSATIONS_D1')
+ * const db = getPlatformBindings().getD1Database('CHM_CLOUD_D1')
  * ```
  */
 

--- a/packages/platform/src/types.ts
+++ b/packages/platform/src/types.ts
@@ -19,7 +19,7 @@ export interface PlatformBindings {
   /**
    * Get a D1 database binding by name.
    *
-   * @param bindingName - The binding name (e.g. 'CONVERSATIONS_D1')
+   * @param bindingName - The binding name (e.g. 'CHM_CLOUD_D1')
    * @returns The D1Database instance, or null if not available
    */
   getD1Database(bindingName: string): D1Database | null

--- a/scripts/prepare-dashboard-wrangler.ts
+++ b/scripts/prepare-dashboard-wrangler.ts
@@ -5,9 +5,9 @@
  *
  * Conversation D1 storage is optional and disabled by default. Wrangler D1
  * bindings still need a concrete database_id at deploy time, so an active
- * CONVERSATIONS_D1 block without a UUID makes preview/prod deploys hit the D1
+ * CHM_CLOUD_D1 block without a UUID makes preview/prod deploys hit the D1
  * control plane even when the feature is off. This writes a deploy-only config
- * that either injects CONVERSATIONS_D1_DATABASE_ID or drops the unprovisioned
+ * that either injects CHM_CLOUD_D1_DATABASE_ID or drops the unprovisioned
  * optional binding.
  */
 
@@ -52,15 +52,15 @@ function parseArgs(argv: string[]): Args {
 
 function conversationD1DatabaseId(): string | null {
   const value =
-    process.env.CONVERSATIONS_D1_DATABASE_ID ??
-    process.env.AGENT_CONVERSATIONS_D1_DATABASE_ID ??
+    process.env.CHM_CLOUD_D1_DATABASE_ID ??
+    process.env.AGENT_CHM_CLOUD_D1_DATABASE_ID ??
     ''
   const trimmed = value.trim()
   if (!trimmed) return null
 
   if (!UUID_RE.test(trimmed)) {
     throw new Error(
-      'CONVERSATIONS_D1_DATABASE_ID must be a Cloudflare D1 database UUID.'
+      'CHM_CLOUD_D1_DATABASE_ID must be a Cloudflare D1 database UUID.'
     )
   }
 
@@ -137,7 +137,7 @@ function prepareWranglerConfig(
 
     const block = lines.slice(index, end)
     const isConversationD1 = block.some((blockLine) =>
-      /^\s*binding\s*=\s*"CONVERSATIONS_D1"\s*$/.test(blockLine)
+      /^\s*binding\s*=\s*"CHM_CLOUD_D1"\s*$/.test(blockLine)
     )
 
     if (!isConversationD1) {
@@ -184,7 +184,7 @@ function main(): void {
 
   if (!databaseId && hasExplicitD1Store()) {
     throw new Error(
-      'AGENT_CONVERSATION_STORE=d1 requires CONVERSATIONS_D1_DATABASE_ID before deploying.'
+      'AGENT_CONVERSATION_STORE=d1 requires CHM_CLOUD_D1_DATABASE_ID before deploying.'
     )
   }
 
@@ -194,27 +194,27 @@ function main(): void {
 
   if (databaseId) {
     console.log(
-      `Prepared ${args.output} with CONVERSATIONS_D1 database_id (${result.injected} block${result.injected === 1 ? '' : 's'}).`
+      `Prepared ${args.output} with CHM_CLOUD_D1 database_id (${result.injected} block${result.injected === 1 ? '' : 's'}).`
     )
     return
   }
 
   if (result.removed > 0) {
     console.log(
-      `Prepared ${args.output} without unprovisioned CONVERSATIONS_D1 (${result.removed} block${result.removed === 1 ? '' : 's'} removed).`
+      `Prepared ${args.output} without unprovisioned CHM_CLOUD_D1 (${result.removed} block${result.removed === 1 ? '' : 's'} removed).`
     )
     console.log(
-      'Set CONVERSATIONS_D1_DATABASE_ID to include the D1 conversation binding during deploy.'
+      'Set CHM_CLOUD_D1_DATABASE_ID to include the D1 conversation binding during deploy.'
     )
     return
   }
 
   if (result.foundConversationD1) {
     console.log(
-      `Prepared ${args.output}; CONVERSATIONS_D1 already has database_id.`
+      `Prepared ${args.output}; CHM_CLOUD_D1 already has database_id.`
     )
   } else {
-    console.log(`Prepared ${args.output}; no CONVERSATIONS_D1 block found.`)
+    console.log(`Prepared ${args.output}; no CHM_CLOUD_D1 block found.`)
   }
 }
 

--- a/scripts/set-secrets.ts
+++ b/scripts/set-secrets.ts
@@ -74,6 +74,11 @@ const DASHBOARD_SECRET_KEYS = [
   // (/api/v1/auth/api-key mints keys via issueApiKey) AND the MCP worker.
   'CHM_API_KEY_SECRET',
   'CHM_USER_CONNECTIONS_ENCRYPTION_KEY',
+  // Polar billing (cloud SaaS). Access token authorizes checkout/portal/product
+  // API calls; webhook secret verifies inbound subscription events. Non-secret
+  // Polar config (CHM_POLAR_SERVER, CHM_POLAR_PRODUCT_*) lives in .env.production.
+  'POLAR_ACCESS_TOKEN',
+  'POLAR_WEBHOOK_SECRET',
   'CLICKHOUSE_TZ',
   'CLICKHOUSE_EXCLUDE_USER_DEFAULT',
   'NEXT_QUERY_CACHE_TTL',
@@ -189,6 +194,15 @@ function resolveValue(
   // secret is skipped, so preview falls back to a non-AgentState backend.
   if (key === 'AGENTSTATE_API_KEY' && isPreview) {
     return src.AGENTSTATE_API_KEY_TEST ?? ''
+  }
+  // Polar billing: preview uses the SANDBOX token/secret (…_TEST) so PR previews
+  // never touch the production Polar org. Production uses the base name; while
+  // unset, billing is inert (checkout 501s) — safe until real prod creds exist.
+  if (key === 'POLAR_ACCESS_TOKEN' && isPreview) {
+    return src.POLAR_ACCESS_TOKEN_TEST ?? ''
+  }
+  if (key === 'POLAR_WEBHOOK_SECRET' && isPreview) {
+    return src.POLAR_WEBHOOK_SECRET_TEST ?? ''
   }
   return src[key] ?? DEFAULTS[key] ?? ''
 }

--- a/scripts/setup-conversations-db.ts
+++ b/scripts/setup-conversations-db.ts
@@ -44,7 +44,7 @@ function parseDatabaseId(output: string): string | null {
 }
 
 /**
- * Update wrangler.toml with the database_id for CONVERSATIONS_D1
+ * Update wrangler.toml with the database_id for CHM_CLOUD_D1
  */
 function updateWranglerToml(databaseId: string): boolean {
   try {
@@ -79,7 +79,7 @@ function updateWranglerToml(databaseId: string): boolean {
 
     // Update the main D1 database binding
     const updatedMain = content.replace(
-      /(# D1 database for AI agent conversations\s+\[\[d1_databases\]\]\s+binding = "CONVERSATIONS_D1"\s+database_name = "clickhouse-monitor-conversations"(?:\s+database_id = "[^"]*")?(?:\s+migrations_dir = "[^"]*")?)/g,
+      /(# D1 database for AI agent conversations\s+\[\[d1_databases\]\]\s+binding = "CHM_CLOUD_D1"\s+database_name = "clickhouse-monitor-conversations"(?:\s+database_id = "[^"]*")?(?:\s+migrations_dir = "[^"]*")?)/g,
       (block) => {
         matchedMain = true
         return withDatabaseId(block)
@@ -88,7 +88,7 @@ function updateWranglerToml(databaseId: string): boolean {
 
     // Update the preview environment binding
     const updatedPreview = updatedMain.replace(
-      /(# Reuse the same conversation D1 database once database_id is provisioned\s+\[\[env\.preview\.d1_databases\]\]\s+binding = "CONVERSATIONS_D1"\s+database_name = "clickhouse-monitor-conversations"(?:\s+database_id = "[^"]*")?(?:\s+migrations_dir = "[^"]*")?)/g,
+      /(# Reuse the same conversation D1 database once database_id is provisioned\s+\[\[env\.preview\.d1_databases\]\]\s+binding = "CHM_CLOUD_D1"\s+database_name = "clickhouse-monitor-conversations"(?:\s+database_id = "[^"]*")?(?:\s+migrations_dir = "[^"]*")?)/g,
       (block) => {
         matchedPreview = true
         return withDatabaseId(block)
@@ -97,7 +97,7 @@ function updateWranglerToml(databaseId: string): boolean {
 
     if (!matchedMain || !matchedPreview) {
       console.error(
-        `❌ Expected CONVERSATIONS_D1 blocks were not matched in wrangler.toml for database_id ${databaseId}`
+        `❌ Expected CHM_CLOUD_D1 blocks were not matched in wrangler.toml for database_id ${databaseId}`
       )
       return false
     }
@@ -252,7 +252,7 @@ async function main() {
     console.error(`  1. Run: wrangler d1 create ${DATABASE_NAME}`)
     console.error(`  2. Copy the database_id from the output`)
     console.error(
-      `  3. Add to wrangler.toml under [[d1_databases]] for CONVERSATIONS_D1:`
+      `  3. Add to wrangler.toml under [[d1_databases]] for CHM_CLOUD_D1:`
     )
     console.error(`     database_id = "<your-database-id>"`)
     process.exit(1)
@@ -265,7 +265,7 @@ async function main() {
       `\n❌ Failed to update wrangler.toml. Please update manually:`
     )
     console.error(
-      `   Add database_id = "${createResult.databaseId}" to the CONVERSATIONS_D1 section`
+      `   Add database_id = "${createResult.databaseId}" to the CHM_CLOUD_D1 section`
     )
     process.exit(1)
   }


### PR DESCRIPTION
Wires paid plans via [Polar](https://polar.sh) for the cloud (SaaS) product. OSS/self-host is untouched — auth `none` ⇒ unlimited, plans inert.

## What's included
- **SDK + config** — `@polar-sh/sdk` + `lib/billing/polar-config.ts`: client with `sandbox|production` switch (`CHM_POLAR_SERVER`), product↔plan map from `CHM_POLAR_PRODUCT_*` env (ids live in env, not `plans.ts`, since they differ per Polar org/env).
- **Storage** — `0003_user_subscriptions.sql` + `subscription-store.ts` (D1, degrades to null without D1) + `user-subscription.ts` `getUserPlan()` (defaults free; auto-downgrades when status not live or period ended — no cron).
- **Routes** — `api/v1/billing/{checkout,portal,subscription}` + `api/v1/webhooks/polar`. `externalCustomerId = Clerk userId` ⇒ **no customer-mapping table**; webhook verifies via `validateEvent` over the **raw** body.
- **Enforcement** — `user-connections` POST returns **402** at `plan.hosts` (`null` = unlimited), checked **before** the SSRF + outbound connection test so over-limit requests fail fast.
- **UI** — `routes/(dashboard)/billing.tsx` (plan grid, upgrade → checkout, manage → portal, toast on error); cloud-only nav gate; `billing` feature id.
- **Setup** — `apps/dashboard/scripts/polar-setup.ts` creates the Pro/Max monthly+yearly products from `BILLING_PLANS`.

## D1 rename
Renames the D1 **binding** `CONVERSATIONS_D1` → `CHM_CLOUD_D1` repo-wide (one shared cloud DB for conversations + user_connections + subscriptions). Physical `database_name` and `migrations_dir` unchanged — no data migration.

## Preview / CI
- `.env.preview` carries the **sandbox** product ids (non-secret). The sandbox token is the `POLAR_ACCESS_TOKEN_TEST` GitHub secret, resolved for preview by `set-secrets.ts` (`POLAR_ACCESS_TOKEN` base name stays prod, inert until set).
- Production stays inert (checkout 501s) until real prod creds + product ids are set.

## Verification
- ✅ Type-check + Biome clean.
- ✅ Code review (2 finder passes): falsy-zero `$00`, swallowed-API-error (apiFetch doesn't throw on JSON errors), checkout/portal error surfacing, `none` status badge, manage-billing for canceled users, and enforcement ordering — all fixed.
- ✅ **End-to-end**: created a real Polar **sandbox** checkout for Pro monthly → `$29.00`, valid `sandbox.polar.sh/checkout/...` URL returned.

After deploy, full e2e on preview: sign in → /billing → Upgrade → Polar checkout → webhook updates plan → host limit enforced.

https://claude.ai/code/session_01JpgsS1E5egpPFGvBfb9fuE