### PR TITLE
feat(billing): org-scoped billing (lazy org on paid) + org UI

### DIFF
--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -22,12 +22,13 @@ import { filterMenuItemsByPermissions } from '@/lib/feature-permissions/menu'
 export function AppSidebar() {
   const { config } = useFeaturePermissions()
   const cloudMode = isCloudModeClient()
-  // Billing is a cloud-only surface — self-hosting is free forever, so the
-  // paid-plan page would only confuse self-hosters.
+  // Billing + Organization are cloud-only surfaces — self-hosting is free
+  // forever and has no orgs, so these would only confuse self-hosters.
+  const cloudOnlyHrefs = new Set(['/billing', '/organization'])
   const menuItems = filterMenuItemsByPermissions(
     menuItemsConfig,
     config
-  ).filter((item) => cloudMode || item.href !== '/billing')
+  ).filter((item) => cloudMode || !cloudOnlyHrefs.has(item.href))
 
   return (
     <Sidebar collapsible="icon" variant="inset">

--- a/apps/dashboard/src/components/clerk/organization-members.tsx
+++ b/apps/dashboard/src/components/clerk/organization-members.tsx
@@ -1,0 +1,83 @@
+import { Building2, Sparkles } from 'lucide-react'
+
+import {
+  OrganizationProfile,
+  useOrganization,
+} from '@clerk/tanstack-react-start'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { isClerkEnabled } from '@/lib/clerk/clerk-client'
+import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
+
+/**
+ * Member management surface. Renders Clerk's <OrganizationProfile/> (members,
+ * roles, invitations) when the user has an active organization; otherwise an
+ * upgrade prompt, since orgs are provisioned on a paid plan.
+ *
+ * Clerk imports are static but inert until this renders — and it only renders on
+ * the cloud build (the route is cloud-gated in the sidebar), matching the
+ * lazy-Clerk pattern used across the app.
+ */
+export function OrganizationMembers() {
+  if (!isClerkEnabled() || !isCloudModeClient()) {
+    return <NoOrgState selfHosted />
+  }
+  return <OrgProfileGate />
+}
+
+function OrgProfileGate() {
+  const { organization, isLoaded } = useOrganization()
+
+  if (!isLoaded) {
+    return (
+      <div className="mx-auto max-w-4xl py-8">
+        <div className="bg-muted h-96 animate-pulse rounded-xl" />
+      </div>
+    )
+  }
+
+  if (!organization) {
+    return <NoOrgState />
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl py-8">
+      <OrganizationProfile routing="hash" />
+    </div>
+  )
+}
+
+function NoOrgState({ selfHosted = false }: { selfHosted?: boolean }) {
+  return (
+    <div className="mx-auto max-w-xl py-16">
+      <Card>
+        <CardHeader className="items-center text-center">
+          <div className="bg-primary/10 mb-2 flex size-12 items-center justify-center rounded-xl">
+            <Building2 className="text-primary size-6" />
+          </div>
+          <CardTitle>No organization yet</CardTitle>
+          <CardDescription>
+            {selfHosted
+              ? 'Organizations are a cloud feature.'
+              : 'Upgrade to Pro or Max to create a team workspace — invite members, assign roles, and share your plan.'}
+          </CardDescription>
+        </CardHeader>
+        {!selfHosted && (
+          <CardContent className="flex justify-center">
+            <Button asChild>
+              <a href="/billing">
+                <Sparkles className="size-4" /> View plans
+              </a>
+            </Button>
+          </CardContent>
+        )}
+      </Card>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/host/first-run-empty-state.tsx
+++ b/apps/dashboard/src/components/host/first-run-empty-state.tsx
@@ -1,11 +1,14 @@
 import {
   ArrowRight,
+  Check,
   DatabaseZap,
   KeyRound,
   PlugZap,
   ShieldCheck,
+  Sparkles,
   Terminal,
 } from 'lucide-react'
+import { toast } from 'sonner'
 
 import type { ReactNode } from 'react'
 
@@ -14,9 +17,15 @@ import { ClerkSignInButton as ClerkSignInButtonImpl } from '@/components/clerk/c
 import { AddHostDialog } from '@/components/connections'
 import { ChmonitorLogo } from '@/components/icons/chmonitor-logo'
 import { Button } from '@/components/ui/button'
+import { BILLING_PLAN_LIST, monthlyEquivalentUsd } from '@/lib/billing/plans'
+import {
+  startCheckout,
+  useBillingSubscription,
+} from '@/lib/billing/use-billing'
 import { isClerkEnabled } from '@/lib/clerk/clerk-client'
 import { docsSiteUrl } from '@/lib/docs-site'
 import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
+import { cn } from '@/lib/utils'
 
 // Clerk's SignInButton needs a mounted <ClerkProvider>. Gate it behind the
 // build-time constant so non-Clerk (self-hosted) builds render null instead.
@@ -133,6 +142,30 @@ function DocsFooter({ links }: { links: { slug: string; label: string }[] }) {
 /* ------------------------------------------------------------------ */
 
 function ConnectYourHost({ onAddHost }: { onAddHost: () => void }) {
+  const { data: sub } = useBillingSubscription()
+  const currentPlanId = sub?.planId ?? 'free'
+  const isPaid = currentPlanId === 'pro' || currentPlanId === 'max'
+  // Onboarding: pick a plan first, then connect a host. Paid users (or anyone
+  // who already chose) skip straight to connect.
+  const [step, setStep] = useState<'plan' | 'connect'>(
+    isPaid ? 'connect' : 'plan'
+  )
+
+  if (step === 'plan') {
+    return (
+      <div className="space-y-7">
+        <WelcomeHeader
+          title="Choose your plan"
+          subtitle="Start free, or pick a paid plan for more hosts, seats and history. You can upgrade anytime — no card needed for Free."
+        />
+        <OnboardingPlans
+          currentPlanId={currentPlanId}
+          onContinueFree={() => setStep('connect')}
+        />
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-7">
       <WelcomeHeader
@@ -195,6 +228,112 @@ function ConnectYourHost({ onAddHost }: { onAddHost: () => void }) {
           },
         ]}
       />
+    </div>
+  )
+}
+
+/** Onboarding plan picker: Free continues with no Polar; Pro/Max → checkout. */
+function OnboardingPlans({
+  currentPlanId,
+  onContinueFree,
+}: {
+  currentPlanId: string
+  onContinueFree: () => void
+}) {
+  const [busy, setBusy] = useState<string | null>(null)
+
+  async function choosePaid(planId: 'pro' | 'max') {
+    setBusy(planId)
+    try {
+      await startCheckout(planId, 'yearly')
+    } catch (err) {
+      setBusy(null)
+      toast.error(err instanceof Error ? err.message : 'Checkout failed')
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-3">
+        {BILLING_PLAN_LIST.filter((p) => p.id !== 'enterprise').map((plan) => {
+          const isFree = plan.id === 'free'
+          const price = isFree
+            ? '$0'
+            : `$${monthlyEquivalentUsd(plan, 'yearly') ?? ''}`
+          const isCurrent = plan.id === currentPlanId
+          return (
+            <div
+              key={plan.id}
+              className={cn(
+                'flex flex-col rounded-xl border bg-card p-4 shadow-sm',
+                plan.id === 'pro' && 'border-primary ring-primary/20 ring-1'
+              )}
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-semibold">{plan.name}</span>
+                {plan.id === 'pro' && (
+                  <span className="text-primary inline-flex items-center gap-1 text-[11px] font-medium">
+                    <Sparkles className="size-3" /> Popular
+                  </span>
+                )}
+              </div>
+              <div className="mt-1 text-2xl font-bold tabular-nums">
+                {price}
+                {!isFree && (
+                  <span className="text-muted-foreground text-xs font-normal">
+                    {' '}
+                    /mo
+                  </span>
+                )}
+              </div>
+              <p className="text-muted-foreground mt-1 text-xs">
+                {plan.tagline}
+              </p>
+              <ul className="mt-3 flex-1 space-y-1.5">
+                {plan.highlights.slice(0, 3).map((h) => (
+                  <li key={h} className="flex gap-1.5 text-xs">
+                    <Check className="text-emerald-500 mt-0.5 size-3.5 shrink-0" />
+                    <span>{h}</span>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-4">
+                {isFree ? (
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    onClick={onContinueFree}
+                    disabled={busy !== null}
+                    data-testid="onboarding-choose-free"
+                  >
+                    Continue with Free
+                  </Button>
+                ) : (
+                  <Button
+                    className="w-full"
+                    onClick={() => choosePaid(plan.id as 'pro' | 'max')}
+                    disabled={busy !== null || isCurrent}
+                    data-testid={`onboarding-choose-${plan.id}`}
+                  >
+                    {busy === plan.id
+                      ? 'Redirecting…'
+                      : isCurrent
+                        ? 'Current plan'
+                        : `Choose ${plan.name}`}
+                  </Button>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+      <button
+        type="button"
+        onClick={onContinueFree}
+        className="text-muted-foreground hover:text-foreground mx-auto block text-xs underline-offset-4 hover:underline"
+      >
+        Skip — I'll decide later
+      </button>
     </div>
   )
 }

--- a/apps/dashboard/src/components/nav-user/clerk-nav.tsx
+++ b/apps/dashboard/src/components/nav-user/clerk-nav.tsx
@@ -1,5 +1,7 @@
 import {
+  Building2,
   ChevronsUpDown,
+  CreditCard,
   ExternalLink,
   Info,
   LogOut,
@@ -8,11 +10,17 @@ import {
 } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 
-import { SignInButton, useClerk, useUser } from '@clerk/tanstack-react-start'
+import {
+  SignInButton,
+  useClerk,
+  useOrganization,
+  useUser,
+} from '@clerk/tanstack-react-start'
 import { useState } from 'react'
 import { useSettingsShortcut } from '@/components/nav-user/use-settings-shortcut'
 import { SettingsDialog } from '@/components/settings'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -29,6 +37,8 @@ import {
   useSidebar,
 } from '@/components/ui/sidebar'
 import { Skeleton } from '@/components/ui/skeleton'
+import { useBillingSubscription } from '@/lib/billing/use-billing'
+import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { SETTINGS_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
 import { isFeatureAllowed } from '@/lib/feature-permissions/shared'
@@ -44,11 +54,16 @@ import { clearUserConnectionsCache } from '@/lib/hooks/use-user-connections'
 export function ClerkNavWrapper() {
   const { user, isLoaded, isSignedIn } = useUser()
   const { openUserProfile, signOut } = useClerk()
+  const { organization } = useOrganization()
   const queryClient = useQueryClient()
   const { isMobile } = useSidebar()
   const [settingsOpen, setSettingsOpen] = useState(false)
   const { config } = useFeaturePermissions()
   const canUseSettings = isFeatureAllowed(SETTINGS_FEATURE_PERMISSION, config)
+  const cloudMode = isCloudModeClient()
+  // Billing is cloud-only; gate the query so self-host / OSS never calls it.
+  const { data: subscription } = useBillingSubscription()
+  const planLabel = cloudMode ? (subscription?.planId ?? 'free') : null
   const openSettings = () => {
     if (canUseSettings) setSettingsOpen(true)
   }
@@ -145,6 +160,24 @@ export function ClerkNavWrapper() {
                       <span className="truncate text-xs">
                         {user?.primaryEmailAddress?.emailAddress}
                       </span>
+                      <span className="mt-1 flex items-center gap-1.5">
+                        {organization && (
+                          <span className="text-muted-foreground flex min-w-0 items-center gap-1 text-[11px]">
+                            <Building2 className="size-3 shrink-0" />
+                            <span className="truncate">
+                              {organization.name}
+                            </span>
+                          </span>
+                        )}
+                        {planLabel && (
+                          <Badge
+                            variant="secondary"
+                            className="h-4 px-1.5 text-[10px] capitalize"
+                          >
+                            {planLabel}
+                          </Badge>
+                        )}
+                      </span>
                     </div>
                   </div>
                 </DropdownMenuLabel>
@@ -158,6 +191,36 @@ export function ClerkNavWrapper() {
                     <UserIcon className="size-4" />
                     <span>Account Settings</span>
                   </DropdownMenuItem>
+                  {cloudMode && (
+                    <>
+                      <DropdownMenuItem
+                        className="flex items-center gap-2"
+                        onClick={() => (window.location.href = '/billing')}
+                        data-testid="nav-user-billing"
+                      >
+                        <CreditCard className="size-4" />
+                        <span>Billing & plan</span>
+                        {planLabel && (
+                          <Badge
+                            variant="secondary"
+                            className="ml-auto h-4 px-1.5 text-[10px] capitalize"
+                          >
+                            {planLabel}
+                          </Badge>
+                        )}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        className="flex items-center gap-2"
+                        onClick={() => (window.location.href = '/organization')}
+                        data-testid="nav-user-organization"
+                      >
+                        <Building2 className="size-4" />
+                        <span>
+                          {organization ? 'Organization' : 'Create a team'}
+                        </span>
+                      </DropdownMenuItem>
+                    </>
+                  )}
                   <DropdownMenuItem
                     className="flex items-center gap-2"
                     onClick={() => (window.location.href = '/about')}

--- a/apps/dashboard/src/db/conversations-migrations/0004_subscription_owner.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0004_subscription_owner.sql
@@ -1,0 +1,8 @@
+-- Add owner_type column to user_subscriptions to distinguish org-owned from
+-- user-owned subscriptions.  The primary key column (user_id) now holds the
+-- billing-owner id — either a Clerk user id (user_*) or a Clerk org id (org_*).
+-- All existing rows remain valid: they are user-owned by default.
+ALTER TABLE user_subscriptions ADD COLUMN owner_type TEXT NOT NULL DEFAULT 'user';
+
+CREATE INDEX IF NOT EXISTS idx_user_subscriptions_owner_type
+  ON user_subscriptions(owner_type);

--- a/apps/dashboard/src/lib/billing/billing-owner.ts
+++ b/apps/dashboard/src/lib/billing/billing-owner.ts
@@ -1,0 +1,83 @@
+/**
+ * Billing owner resolution — org or user, whichever owns the subscription.
+ *
+ * Model:
+ * - FREE plan: user-scoped, no Clerk org. Owner = {type:'user', id:userId}
+ * - PAID (Pro/Max): on successful payment a Clerk org is lazily created for the
+ *   buyer. The org then owns the subscription permanently.
+ *   Owner = {type:'org', id:orgId}
+ *
+ * How orgId is exposed:
+ * `auth()` from @clerk/tanstack-react-start/server returns a `SessionAuthObject`
+ * (= SignedInAuthObject | SignedOutAuthObject). When signed in,
+ * `SignedInAuthObject` extends `SharedSignedInAuthObjectProperties` which
+ * carries `orgId: string | undefined` — the user's currently active Clerk org,
+ * taken directly from the session JWT claims (no extra API call). If the user
+ * has no active org, orgId is undefined or null.
+ *
+ * The billing owner is that active orgId when present; otherwise the userId.
+ * Callers use resolveBillingOwner() for plan lookups and subscription writes.
+ * Per-user resources (connections, conversations) always stay keyed by userId.
+ */
+
+import { auth } from '@clerk/tanstack-react-start/server'
+import { isClerkAuthProvider } from '@/lib/auth/provider'
+import { ConversationStoreError } from '@/lib/conversation-store/types'
+
+export interface BillingOwner {
+  type: 'org' | 'user'
+  id: string
+}
+
+const CLERK_SECRET_KEY = 'CLERK_SECRET_KEY'
+
+/**
+ * Resolve the billing owner for the current request session.
+ *
+ * Returns {type:'org', id:orgId} when the session has an active Clerk org;
+ * {type:'user', id:userId} otherwise.
+ *
+ * Throws ConversationStoreError('UNAUTHORIZED') — the same error shape as
+ * resolveUserId() — when Clerk is not configured or the session is invalid,
+ * so existing mapConnectionApiError() handlers produce correct 401 responses.
+ */
+export async function resolveBillingOwner(): Promise<BillingOwner> {
+  if (!isClerkAuthProvider() || !process.env[CLERK_SECRET_KEY]) {
+    throw new ConversationStoreError(
+      'Authentication is required for billing.',
+      'UNAUTHORIZED'
+    )
+  }
+
+  try {
+    const authResult = await auth()
+    const userId = authResult?.userId
+
+    if (!userId) {
+      throw new ConversationStoreError(
+        'Authentication is required for billing.',
+        'UNAUTHORIZED'
+      )
+    }
+
+    // orgId is set when the user has an active Clerk org in their session JWT.
+    const orgId = (authResult as { orgId?: string | null }).orgId
+    if (orgId) {
+      return { type: 'org', id: orgId }
+    }
+
+    return { type: 'user', id: userId }
+  } catch (error) {
+    if (error instanceof ConversationStoreError) throw error
+    throw new ConversationStoreError(
+      'Failed to validate authentication for billing.',
+      'UNAUTHORIZED',
+      error
+    )
+  }
+}
+
+/** Convenience wrapper — returns just the billing owner id string. */
+export async function resolveBillingOwnerId(): Promise<string> {
+  return (await resolveBillingOwner()).id
+}

--- a/apps/dashboard/src/lib/billing/subscription-store.ts
+++ b/apps/dashboard/src/lib/billing/subscription-store.ts
@@ -1,18 +1,28 @@
 /**
- * Subscription store — D1 persistence for per-user billing state.
+ * Subscription store — D1 persistence for billing state.
+ *
+ * The primary key column is named `user_id` for backward compatibility but now
+ * holds the BILLING-OWNER id, which is either a Clerk user id (user_*) or a
+ * Clerk org id (org_*). The `owner_type` column ('user'|'org') records which
+ * kind, added by migration 0004_subscription_owner.sql.
  *
  * Reads degrade gracefully: when the CHM_CLOUD_D1 binding is absent (local dev,
- * self-host) or there is no row, `get()` returns null and the caller falls back
- * to the free plan. Writes require D1 and are only exercised by the Polar webhook
- * (cloud runtime), so they throw if the binding is missing.
+ * self-host) or there is no row, `getSubscription()` returns null and the caller
+ * falls back to the free plan. Writes require D1 and are only exercised by the
+ * Polar webhook (cloud runtime), so they throw if the binding is missing.
  */
 
 import type { PlanId } from './plans'
 
 import { getPlatformBindings } from '@chm/platform'
 
+export type OwnerType = 'user' | 'org'
+
 export interface UserSubscription {
+  /** Billing-owner id — Clerk user id OR Clerk org id. */
   userId: string
+  /** 'user' for personal subscriptions; 'org' for org-owned paid plans. */
+  ownerType: OwnerType
   planId: PlanId
   billingPeriod: 'monthly' | 'yearly' | null
   status: string
@@ -25,7 +35,10 @@ export interface UserSubscription {
 }
 
 export interface UpsertSubscriptionInput {
+  /** Billing-owner id — Clerk user id OR Clerk org id. */
   userId: string
+  /** 'user' for personal subscriptions; 'org' for org-owned paid plans. Default 'user'. */
+  ownerType?: OwnerType
   planId: PlanId
   billingPeriod: 'monthly' | 'yearly' | null
   status: string
@@ -36,6 +49,7 @@ export interface UpsertSubscriptionInput {
 
 interface D1SubscriptionRow {
   user_id: string
+  owner_type: string | null
   plan_id: string
   billing_period: string | null
   status: string
@@ -49,6 +63,7 @@ interface D1SubscriptionRow {
 function rowToSubscription(row: D1SubscriptionRow): UserSubscription {
   return {
     userId: row.user_id,
+    ownerType: (row.owner_type as OwnerType | null) ?? 'user',
     planId: row.plan_id as PlanId,
     billingPeriod: (row.billing_period as 'monthly' | 'yearly' | null) ?? null,
     status: row.status,
@@ -64,24 +79,31 @@ function getDb() {
   return getPlatformBindings().getD1Database('CHM_CLOUD_D1')
 }
 
-/** Read a user's subscription, or null when none / no D1. */
+/**
+ * Read a subscription by billing-owner id (user id or org id), or null when
+ * none exists / no D1 binding.
+ */
 export async function getSubscription(
-  userId: string
+  ownerId: string
 ): Promise<UserSubscription | null> {
   const db = getDb()
   if (!db) return null
   const row = await db
     .prepare(
-      `SELECT user_id, plan_id, billing_period, status, polar_subscription_id,
-              polar_customer_id, current_period_end, created_at, updated_at
+      `SELECT user_id, owner_type, plan_id, billing_period, status,
+              polar_subscription_id, polar_customer_id, current_period_end,
+              created_at, updated_at
        FROM user_subscriptions WHERE user_id = ?1`
     )
-    .bind(userId)
+    .bind(ownerId)
     .first<D1SubscriptionRow>()
   return row ? rowToSubscription(row) : null
 }
 
-/** Insert or replace a user's subscription row (idempotent on user_id). */
+/**
+ * Insert or replace a subscription row (idempotent on owner id).
+ * `input.userId` is the billing-owner id (user or org).
+ */
 export async function upsertSubscription(
   input: UpsertSubscriptionInput
 ): Promise<void> {
@@ -92,13 +114,16 @@ export async function upsertSubscription(
     )
   }
   const now = Math.floor(Date.now() / 1000)
+  const ownerType: OwnerType = input.ownerType ?? 'user'
   await db
     .prepare(
       `INSERT INTO user_subscriptions
-         (user_id, plan_id, billing_period, status, polar_subscription_id,
-          polar_customer_id, current_period_end, created_at, updated_at)
-       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?8)
+         (user_id, owner_type, plan_id, billing_period, status,
+          polar_subscription_id, polar_customer_id, current_period_end,
+          created_at, updated_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9)
        ON CONFLICT(user_id) DO UPDATE SET
+         owner_type = excluded.owner_type,
          plan_id = excluded.plan_id,
          billing_period = excluded.billing_period,
          status = excluded.status,
@@ -109,6 +134,7 @@ export async function upsertSubscription(
     )
     .bind(
       input.userId,
+      ownerType,
       input.planId,
       input.billingPeriod,
       input.status,

--- a/apps/dashboard/src/lib/billing/user-subscription.ts
+++ b/apps/dashboard/src/lib/billing/user-subscription.ts
@@ -1,10 +1,16 @@
 /**
- * Resolve a user's effective billing plan.
+ * Resolve a billing owner's effective plan.
  *
  * The free plan is the floor: no subscription row, no D1, or a lapsed/canceled
  * subscription all resolve to free. A paid plan only applies while its status is
  * live and (when present) the current period has not ended — so access cleanly
  * downgrades when a subscription expires without needing a separate cron.
+ *
+ * Org-scoped billing: paid subscriptions are stored under the Clerk org id (org_*)
+ * as the billing-owner id. Use getPlanForOwner(ownerId) / getPlanIdForOwner(ownerId)
+ * with the resolved billing owner from resolveBillingOwner(). The legacy
+ * getUserPlan(userId) / getUserPlanId(userId) wrappers remain for call-sites that
+ * only have a user id (free path — no org).
  */
 
 import type { Plan, PlanId } from './plans'
@@ -27,14 +33,39 @@ export function isSubscriptionLive(
   return true
 }
 
-/** The user's current plan id, defaulting to free. */
-export async function getUserPlanId(userId: string): Promise<PlanId> {
-  const sub = await getSubscription(userId)
+/**
+ * Resolve the plan id for a billing owner (user or org), defaulting to free.
+ * Pass the id from resolveBillingOwner() — either a Clerk user id or org id.
+ */
+export async function getPlanIdForOwner(ownerId: string): Promise<PlanId> {
+  const sub = await getSubscription(ownerId)
   if (!sub || !isSubscriptionLive(sub)) return 'free'
   return BILLING_PLANS[sub.planId] ? sub.planId : 'free'
 }
 
-/** The user's current Plan object, defaulting to the free plan. */
+/**
+ * Resolve the Plan object for a billing owner (user or org), defaulting to free.
+ */
+export async function getPlanForOwner(ownerId: string): Promise<Plan> {
+  return getPlan(await getPlanIdForOwner(ownerId))
+}
+
+/**
+ * The user's current plan id, defaulting to free.
+ * Thin wrapper around getPlanIdForOwner — passes userId as the owner key.
+ * For routes that have a session context, prefer resolveBillingOwner() +
+ * getPlanIdForOwner() to handle org-scoped subscriptions correctly.
+ */
+export async function getUserPlanId(userId: string): Promise<PlanId> {
+  return getPlanIdForOwner(userId)
+}
+
+/**
+ * The user's current Plan object, defaulting to the free plan.
+ * Thin wrapper around getPlanForOwner — passes userId as the owner key.
+ * For routes that have a session context, prefer resolveBillingOwner() +
+ * getPlanForOwner() to handle org-scoped subscriptions correctly.
+ */
 export async function getUserPlan(userId: string): Promise<Plan> {
-  return getPlan(await getUserPlanId(userId))
+  return getPlanForOwner(userId)
 }

--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -699,6 +699,15 @@ export const menuItemsConfig: MenuItem[] = [
     permission: { feature: 'billing' },
   },
   {
+    // Cloud (SaaS) team management — members, roles, invitations. Cloud-only
+    // (filtered in app-sidebar.tsx). Org is created on a paid upgrade.
+    title: 'Organization',
+    href: '/organization',
+    icon: UsersIcon,
+    section: 'others',
+    permission: { feature: 'billing' },
+  },
+  {
     title: 'System',
     href: '',
     icon: GearIcon,

--- a/apps/dashboard/src/routes/(dashboard)/organization.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/organization.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { OrganizationMembers } from '@/components/clerk/organization-members'
+
+/**
+ * Organization management — members, roles, invitations.
+ *
+ * Cloud (SaaS) only and only meaningful once the user is in an organization
+ * (orgs are created lazily on a paid upgrade — see the Polar webhook). Renders
+ * Clerk's <OrganizationProfile/>, which provides the full members/roles/invite
+ * UI out of the box. Free/personal users see a prompt explaining that an org is
+ * created when they upgrade.
+ */
+export const Route = createFileRoute('/(dashboard)/organization')({
+  component: OrganizationMembers,
+})

--- a/apps/dashboard/src/routes/api/v1/billing/checkout.ts
+++ b/apps/dashboard/src/routes/api/v1/billing/checkout.ts
@@ -4,14 +4,18 @@
  * Body: { planId: 'pro' | 'max', period: 'monthly' | 'yearly' }
  * Returns: { url } — the Polar-hosted checkout URL to redirect the customer to.
  *
- * The Clerk userId is passed as `externalCustomerId`, so Polar stamps every
- * resulting webhook with `customer.externalId` and we never keep a customer map.
+ * `externalCustomerId` is set to the billing-owner id (Clerk org id when the
+ * user already has an active org; Clerk user id for a first-time upgrade). Polar
+ * stamps every resulting webhook with `customer.externalId`. The `metadata`
+ * always carries the actual Clerk userId so the webhook can lazily create a
+ * Clerk org for the buyer on first payment.
  */
 import { createFileRoute } from '@tanstack/react-router'
 
 import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
 import { createSuccessResponse } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
+import { resolveBillingOwnerId } from '@/lib/billing/billing-owner'
 import {
   getPolarClient,
   isBillingConfigured,
@@ -84,12 +88,20 @@ async function handlePost(request: Request): Promise<Response> {
   }
 
   try {
-    const userId = await resolveConnectionUserId()
+    // userId = the actual Clerk user (for org creation in the webhook).
+    // ownerId = billing owner: orgId when the user already has a paid org in
+    //           session, userId otherwise (first-time upgrade from free).
+    const [userId, ownerId] = await Promise.all([
+      resolveConnectionUserId(),
+      resolveBillingOwnerId(),
+    ])
     const origin = new URL(request.url).origin
     const checkout = await getPolarClient().checkouts.create({
       products: [productId],
-      externalCustomerId: userId,
+      externalCustomerId: ownerId,
       successUrl: `${origin}/billing?status=success`,
+      // userId in metadata lets the webhook lazily create a Clerk org for the
+      // buyer when externalCustomerId was still a user id (first payment).
       metadata: { userId, planId, period },
     })
     return createSuccessResponse({ url: checkout.url })

--- a/apps/dashboard/src/routes/api/v1/billing/subscription.ts
+++ b/apps/dashboard/src/routes/api/v1/billing/subscription.ts
@@ -1,32 +1,37 @@
 /**
  * GET /api/v1/billing/subscription — the current user's plan + subscription.
  *
- * Returns { planId, status, billingPeriod, currentPeriodEnd }. Always resolves to
- * at least the free plan (see getUserPlanId), so the billing UI can render even
- * before a user has ever subscribed.
+ * Returns { planId, status, billingPeriod, currentPeriodEnd, owner } where
+ * `owner` is { type: 'org'|'user', id: string } — the billing-owner entity
+ * so the UI can distinguish org vs personal billing. Plan and subscription data
+ * are always keyed by the billing owner, not necessarily the user id.
+ *
+ * Always resolves to at least the free plan (see getPlanIdForOwner), so the
+ * billing UI can render even before a user has ever subscribed.
  */
 import { createFileRoute } from '@tanstack/react-router'
 
 import { createSuccessResponse } from '@/lib/api/shared/response-builder'
+import { resolveBillingOwner } from '@/lib/billing/billing-owner'
 import { getSubscription } from '@/lib/billing/subscription-store'
-import { getUserPlanId } from '@/lib/billing/user-subscription'
+import { getPlanIdForOwner } from '@/lib/billing/user-subscription'
 import { mapConnectionApiError } from '@/lib/connection-store/api-errors'
-import { resolveConnectionUserId } from '@/lib/connection-store/auth'
 
 const ROUTE = { route: '/api/v1/billing/subscription', method: 'GET' }
 
 async function handleGet(): Promise<Response> {
   try {
-    const userId = await resolveConnectionUserId()
+    const owner = await resolveBillingOwner()
     const [planId, sub] = await Promise.all([
-      getUserPlanId(userId),
-      getSubscription(userId),
+      getPlanIdForOwner(owner.id),
+      getSubscription(owner.id),
     ])
     return createSuccessResponse({
       planId,
       status: sub?.status ?? 'none',
       billingPeriod: sub?.billingPeriod ?? null,
       currentPeriodEnd: sub?.currentPeriodEnd ?? null,
+      owner: { type: owner.type, id: owner.id },
     })
   } catch (error) {
     return mapConnectionApiError(error, ROUTE)

--- a/apps/dashboard/src/routes/api/v1/user-connections.ts
+++ b/apps/dashboard/src/routes/api/v1/user-connections.ts
@@ -11,7 +11,8 @@ import type { CreateUserConnectionInput } from '@/lib/connection-store/types'
 import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
 import { createSuccessResponse } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
-import { getUserPlan } from '@/lib/billing/user-subscription'
+import { resolveBillingOwner } from '@/lib/billing/billing-owner'
+import { getPlanForOwner } from '@/lib/billing/user-subscription'
 import { validateHostUrl } from '@/lib/browser-connections/host-url'
 import { queryConnection } from '@/lib/connection-query/connection-client'
 import { mapConnectionApiError } from '@/lib/connection-store/api-errors'
@@ -119,7 +120,13 @@ async function handlePost(request: Request): Promise<Response> {
     // keeps. plan.hosts === null means unlimited (Enterprise). Checking before
     // the SSRF check + outbound connection test fails fast and avoids opening a
     // network connection to an attacker-supplied host for a request we'll reject.
-    const plan = await getUserPlan(userId)
+    //
+    // Enforce against the BILLING OWNER's plan (org or user): if the user has an
+    // active Clerk org in their session the org's plan determines the limit.
+    // TODO: org-wide pooling (count connections across all org members vs the
+    // per-org host limit) is a follow-up. For now, count this user's connections.
+    const owner = await resolveBillingOwner()
+    const plan = await getPlanForOwner(owner.id)
     if (plan.hosts != null) {
       const existing = await store.list(userId)
       if (existing.length >= plan.hosts) {

--- a/apps/dashboard/src/routes/api/v1/webhooks/polar.ts
+++ b/apps/dashboard/src/routes/api/v1/webhooks/polar.ts
@@ -2,20 +2,33 @@
  * POST /api/v1/webhooks/polar — Polar webhook receiver.
  *
  * Verifies the signature over the RAW body (validateEvent base64-encodes the
- * secret internally), then upserts the user's subscription row keyed by
- * `customer.externalId` (the Clerk userId we set as externalCustomerId at
- * checkout). getUserPlan reads that row; access downgrades to free when a
- * subscription is canceled/expired.
+ * secret internally), then upserts the subscription row. The billing owner is
+ * resolved from `customer.externalId`:
  *
- * Unauthenticated by design — the signature IS the auth. Always 2xx on a valid
- * (even if ignored) event so Polar doesn't retry; 400 only on a bad signature.
+ * - externalId starts with 'user_' (first-time upgrade, no org yet):
+ *   1. Check if the user already has a Clerk org membership (idempotency).
+ *   2. If not, create a Clerk org lazily and add the user as admin.
+ *   3. Upsert the subscription keyed by orgId (owner_type='org').
+ *   4. Defensive fallback: if org creation fails, persist under userId so
+ *      billing is never lost (owner_type='user').
+ *
+ * - externalId starts with 'org_' (re-subscription or upgrade on paid account):
+ *   Upsert subscription keyed by orgId (owner_type='org') directly.
+ *
+ * Always 2xx on a valid (even ignored) event so Polar doesn't retry.
+ * 400 on bad signature only. 500 on persistence errors (Polar will retry).
+ *
+ * Unauthenticated by design — the signature IS the auth.
  */
 import { createFileRoute } from '@tanstack/react-router'
 
 import { error as logError, log as logInfo } from '@chm/logger'
 import { validateEvent, WebhookVerificationError } from '@polar-sh/sdk/webhooks'
 import { getWebhookSecret, planForProductId } from '@/lib/billing/polar-config'
-import { upsertSubscription } from '@/lib/billing/subscription-store'
+import {
+  type OwnerType,
+  upsertSubscription,
+} from '@/lib/billing/subscription-store'
 
 /** Polar Subscription shape (subset) carried by subscription.* events. */
 interface PolarSubscriptionData {
@@ -34,14 +47,67 @@ function toUnixSeconds(value: Date | string | null | undefined): number | null {
   return Number.isFinite(ms) ? Math.floor(ms / 1000) : null
 }
 
+/**
+ * Attempt to lazily create a Clerk org for a user on their first paid event.
+ * Returns the orgId if successful, null on any error (billing is saved under
+ * userId as a fallback so payment is never lost).
+ *
+ * Idempotent: if the user already has an org membership, returns that org's id
+ * without creating a duplicate.
+ */
+async function ensureOrgForUser(userId: string): Promise<string | null> {
+  try {
+    const { clerkClient } = await import('@clerk/tanstack-react-start/server')
+    const client = clerkClient()
+
+    // Check existing memberships first (idempotency guard).
+    const memberships = await client.users.getOrganizationMembershipList({
+      userId,
+    })
+    if (memberships.data.length > 0) {
+      const existingOrgId = memberships.data[0]?.organization?.id
+      if (existingOrgId) {
+        logInfo('[polar-webhook] user already has org; reusing', {
+          userId,
+          orgId: existingOrgId,
+        })
+        return existingOrgId
+      }
+    }
+
+    // Create a new Clerk org for the buyer.
+    const org = await client.organizations.createOrganization({
+      name: `${userId} workspace`,
+      createdBy: userId,
+    })
+    logInfo('[polar-webhook] created Clerk org for paid user', {
+      userId,
+      orgId: org.id,
+    })
+    return org.id
+  } catch (err) {
+    // Org creation is best-effort: Clerk orgs may be quota-limited or disabled.
+    // Log the error but do not lose the subscription — caller falls back to userId.
+    logError(
+      '[polar-webhook] org creation failed; falling back to user owner',
+      {
+        userId,
+        err,
+      }
+    )
+    return null
+  }
+}
+
 async function applySubscription(data: PolarSubscriptionData): Promise<void> {
-  const userId = data.customer?.externalId
-  if (!userId) {
+  const externalId = data.customer?.externalId
+  if (!externalId) {
     logInfo('[polar-webhook] subscription without externalId; skipping', {
       subscriptionId: data.id,
     })
     return
   }
+
   const mapped = planForProductId(data.productId)
   if (!mapped) {
     logInfo('[polar-webhook] unknown product id; skipping', {
@@ -49,8 +115,31 @@ async function applySubscription(data: PolarSubscriptionData): Promise<void> {
     })
     return
   }
+
+  // planForProductId only returns PaidPlanId ('pro'|'max'); check live status.
+  const isPaidPlan = new Set(['active', 'trialing']).has(data.status)
+
+  // Determine billing owner: org or user.
+  let ownerId = externalId
+  let ownerType: OwnerType = 'user'
+
+  if (externalId.startsWith('org_')) {
+    // Already org-scoped (user re-subscribing on an existing paid account).
+    ownerType = 'org'
+  } else if (externalId.startsWith('user_') && isPaidPlan) {
+    // First paid event for this user — lazily create a Clerk org.
+    const orgId = await ensureOrgForUser(externalId)
+    if (orgId) {
+      ownerId = orgId
+      ownerType = 'org'
+    }
+    // If orgId is null, fallback: keep ownerId=userId, ownerType='user'.
+    // Billing is preserved under userId; org creation can be retried manually.
+  }
+
   await upsertSubscription({
-    userId,
+    userId: ownerId,
+    ownerType,
     planId: mapped.planId,
     billingPeriod: mapped.period,
     status: data.status,
@@ -58,8 +147,11 @@ async function applySubscription(data: PolarSubscriptionData): Promise<void> {
     polarCustomerId: data.customerId,
     currentPeriodEnd: toUnixSeconds(data.currentPeriodEnd),
   })
+
   logInfo('[polar-webhook] applied subscription', {
-    userId,
+    externalId,
+    ownerId,
+    ownerType,
     planId: mapped.planId,
     status: data.status,
   })


### PR DESCRIPTION
Builds org-scoped billing on top of the Polar integration (#2018), per the "org only when they pay" model.

## Model
- **Free** → user-scoped, no Polar, no card, **no Clerk org** (keeps personal accounts; zero provisioning).
- **Pay for Pro/Max** → Polar checkout → on **payment success** the webhook lazily creates a Clerk org (buyer = `org:admin`), and the **org becomes the billing owner**.
- **Billing owner** = active Clerk org if present, else the user — drives `getPlan`, checkout, portal, host-limit.

## Backbone
- `lib/billing/billing-owner.ts` — `resolveBillingOwner()` from `auth().orgId`.
- `0004_subscription_owner.sql` — `owner_type` column.
- subscription-store / user-subscription rekeyed by owner (`getPlanForOwner`).
- checkout `externalCustomerId = owner`; webhook `ensureOrgForUser()` is idempotent (membership lookup) and falls back to user-keyed if org creation fails (no lost payment).
- host-limit enforced against the owner's plan.

## UI (cloud-only, Clerk-gated)
- `/organization` → Clerk `<OrganizationProfile/>` (members, roles, invitations); upgrade prompt when no org.
- Sidebar footer: org name + current-plan badge + **Billing** & **Organization** links.
- `menu` + `app-sidebar` gate `/billing` + `/organization` to cloud mode.

## Prerequisite to test
Enable **Organizations** in the Clerk dashboard (**keep Personal accounts ON**). Then full org e2e works on the preview.

## Verification
- Type-check + Biome clean. Route tree regenerated.
- Follow-ups on this branch: Clerk-aware Cypress e2e harness; setup-page plan picker; richer SVG visuals.

https://claude.ai/code/session_01JpgsS1E5egpPFGvBfb9fuE