### PR TITLE
feat(billing): production Polar config + e2e harness for billing/org flow

### DIFF
--- a/apps/dashboard/.env.production
+++ b/apps/dashboard/.env.production
@@ -59,11 +59,11 @@ CHM_CLOUD_DEMO_HOSTS=duet-ubuntu
 # set via scripts/set-secrets.ts, NOT here. server = sandbox|production; product
 # ids per paid plan/period come from `bun scripts/polar-setup.ts`. Unset product
 # ids ⇒ checkout returns 501 for that plan. See lib/billing/polar-config.ts.
-CHM_POLAR_SERVER=sandbox
-CHM_POLAR_PRODUCT_PRO_MONTHLY=
-CHM_POLAR_PRODUCT_PRO_YEARLY=
-CHM_POLAR_PRODUCT_MAX_MONTHLY=
-CHM_POLAR_PRODUCT_MAX_YEARLY=
+CHM_POLAR_SERVER=production
+CHM_POLAR_PRODUCT_PRO_MONTHLY=9f036dda-ce9f-4f21-8bfa-2097ceabe520
+CHM_POLAR_PRODUCT_PRO_YEARLY=8c1f511b-f334-4693-8459-8325a2a82694
+CHM_POLAR_PRODUCT_MAX_MONTHLY=90883973-1cac-43d0-9a19-64ca23d9ce11
+CHM_POLAR_PRODUCT_MAX_YEARLY=2dcdc758-d919-41af-a503-bc77e5b4f27f
 
 # ── Runtime / platform ──────────────────────────────────────────────────────
 # Marks the Cloudflare Worker runtime (set only in the worker, not Docker/Node).

--- a/apps/dashboard/bun.lock
+++ b/apps/dashboard/bun.lock
@@ -86,6 +86,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@clerk/testing": "^2.1.7",
         "@clickhouse/client": "^1.18.5",
         "@cloudflare/vite-plugin": "^1.39.2",
         "@cloudflare/workers-types": "^4.20260603.1",
@@ -182,13 +183,15 @@
 
     "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
-    "@clerk/backend": ["@clerk/backend@3.4.14", "", { "dependencies": { "@clerk/shared": "^4.14.0", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-0iaMT7k4wDk31QVC3HMaoeVFttblwsCECTHKNQpbRzIyD8j2gHdKEw/FNjffoyqyBqPw869IQlk1YokUlwVAqQ=="],
+    "@clerk/backend": ["@clerk/backend@3.8.4", "", { "dependencies": { "@clerk/shared": "^4.22.0", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-3G+kEu8kalqQokJ/n0IynhBh2i6TtiilRzuAg5UWMburkK658/elrG0Uqsapd5yKhmkNuvizHwOPWwKAMxP2EQ=="],
 
     "@clerk/react": ["@clerk/react@6.7.2", "", { "dependencies": { "@clerk/shared": "^4.14.0", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-tgRWWTfW+ejXj6WiZqx7iMbtvh45h0445uEvbSNVCyJBEOaBlCF0/ZfAfXlWAQNbRZ+bPIphEfNUmatadZgGOQ=="],
 
-    "@clerk/shared": ["@clerk/shared@4.14.0", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-StZCFJ2rg0ITE3fYjIN9CKuKq8ZACW6l2+5qGCFPPYd4hZphA+VDselmh/lHPsF1ex/WRVUSHvquykAHR8cQbQ=="],
+    "@clerk/shared": ["@clerk/shared@4.22.0", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-GZ56kzUB2UBb8MCF+Eo8WIey+W4RP1tAkyOL+geiHxrQxJlUcgD+xalY2YPJLH8WVFwtOnfIl8KPEo0M0e/DRg=="],
 
     "@clerk/tanstack-react-start": ["@clerk/tanstack-react-start@1.3.2", "", { "dependencies": { "@clerk/backend": "^3.4.14", "@clerk/react": "^6.7.2", "@clerk/shared": "^4.14.0", "tslib": "2.8.1" }, "peerDependencies": { "@tanstack/react-router": "^1.157.0", "@tanstack/react-start": "^1.157.0", "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-x+kxE1UlNnZYhoMIvjJKvITe5n6ZJx94xOvdE/vtvM+pS/UXtEyhGaZA6JMwN16yJFdhS2A01/LtNrPTPJtwPA=="],
+
+    "@clerk/testing": ["@clerk/testing@2.1.7", "", { "dependencies": { "@clerk/backend": "^3.8.4", "@clerk/shared": "^4.22.0", "dotenv": "17.2.2" }, "peerDependencies": { "@playwright/test": "^1", "cypress": "^13 || ^14" }, "optionalPeers": ["@playwright/test", "cypress"] }, "sha512-MllJQ/3ooEkxvZ5eqJfrwD57/s7MY1VUD5R4XDRXVyaeK+dONG1gyybeZLaMtDUJmofyloiWE3tGxqLn4qwFjw=="],
 
     "@clickhouse/client": ["@clickhouse/client@1.19.0", "", { "dependencies": { "@clickhouse/client-common": "1.19.0" } }, "sha512-R/35tIFZjwRyqtTN0cnlvd45zU+YREuQ/cnfi6c+KGGkVSCF+1cl8mZ9kkxshqHx2U4YjcmPVElJaRn2bEqJ4g=="],
 
@@ -1057,6 +1060,8 @@
     "discontinuous-range": ["discontinuous-range@1.0.0", "", {}, "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="],
 
     "dompurify": ["dompurify@3.4.8", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ=="],
+
+    "dotenv": ["dotenv@17.2.2", "", {}, "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -1930,7 +1935,13 @@
 
     "@clerk/backend/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@clerk/react/@clerk/shared": ["@clerk/shared@4.14.0", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-StZCFJ2rg0ITE3fYjIN9CKuKq8ZACW6l2+5qGCFPPYd4hZphA+VDselmh/lHPsF1ex/WRVUSHvquykAHR8cQbQ=="],
+
     "@clerk/react/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@clerk/tanstack-react-start/@clerk/backend": ["@clerk/backend@3.4.14", "", { "dependencies": { "@clerk/shared": "^4.14.0", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-0iaMT7k4wDk31QVC3HMaoeVFttblwsCECTHKNQpbRzIyD8j2gHdKEw/FNjffoyqyBqPw869IQlk1YokUlwVAqQ=="],
+
+    "@clerk/tanstack-react-start/@clerk/shared": ["@clerk/shared@4.14.0", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-StZCFJ2rg0ITE3fYjIN9CKuKq8ZACW6l2+5qGCFPPYd4hZphA+VDselmh/lHPsF1ex/WRVUSHvquykAHR8cQbQ=="],
 
     "@clerk/tanstack-react-start/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/apps/dashboard/cypress.config.ts
+++ b/apps/dashboard/cypress.config.ts
@@ -1,3 +1,4 @@
+import { clerkSetup } from '@clerk/testing/cypress'
 import { defineConfig } from 'cypress'
 
 /**
@@ -8,6 +9,9 @@ import { defineConfig } from 'cypress'
  * `CYPRESS_BASE_URL` so the same specs run against a local `vite preview`
  * (default :3000) or a live deployment (e.g. https://dash.chmonitor.dev)
  * for prod smoke/parity checks.
+ *
+ * Clerk testing: set CYPRESS_CLERK_PUBLISHABLE_KEY (pk_test_…) and
+ * CLERK_SECRET_KEY (sk_test_…) to enable the authenticated billing/org specs.
  */
 export default defineConfig({
   // 8s is enough for real assertions and prevents a hung test from burning the
@@ -21,6 +25,22 @@ export default defineConfig({
     baseUrl: process.env.CYPRESS_BASE_URL ?? 'http://localhost:3000',
     supportFile: 'cypress/support/e2e.ts',
     specPattern: 'cypress/e2e/**/*.cy.ts',
+    async setupNodeEvents(_on, config) {
+      // Wire @clerk/testing so the bot-protection bypass token is fetched
+      // once per run. Skips gracefully when the keys are absent (CI without
+      // Clerk credentials still runs anonymous specs without error).
+      const publishableKey =
+        process.env.CYPRESS_CLERK_PUBLISHABLE_KEY ??
+        process.env.CHM_CLERK_PUBLISHABLE_KEY_TEST
+      const secretKey = process.env.CLERK_SECRET_KEY
+      if (publishableKey && secretKey) {
+        await clerkSetup({
+          config,
+          options: { publishableKey, secretKey },
+        })
+      }
+      return config
+    },
   },
   component: {
     devServer: {

--- a/apps/dashboard/cypress/e2e/billing-org-flow.cy.ts
+++ b/apps/dashboard/cypress/e2e/billing-org-flow.cy.ts
@@ -1,0 +1,244 @@
+/// <reference types="cypress" />
+/**
+ * Billing + Org E2E harness — Polar checkout + Clerk org onboarding.
+ *
+ * Required env vars (all optional — tests degrade gracefully when absent):
+ *   CYPRESS_BASE_URL              Live deployment URL, e.g.
+ *                                   https://preview.dash.chmonitor.dev
+ *   CYPRESS_CLERK_PUBLISHABLE_KEY Clerk publishable key (pk_test_…) for test mode.
+ *                                 Becomes Cypress.env('CLERK_PUBLISHABLE_KEY').
+ *   CLERK_SECRET_KEY              Clerk secret key (sk_test_…); used by clerkSetup
+ *                                 (via cypress.config.ts) to fetch the per-run
+ *                                 testing token from the Clerk Backend API.
+ *   CYPRESS_CLERK_TEST_EMAIL      A +clerk_test subaddress for sign-in, e.g.
+ *                                   you+clerk_test@example.com
+ *                                 Clerk test mode accepts verification code 424242.
+ *                                 Becomes Cypress.env('CLERK_TEST_EMAIL').
+ *
+ * Graceful degradation:
+ *   - Anonymous suite always runs — verifies pages render without console crashes.
+ *   - Authenticated suite skips when CYPRESS_CLERK_PUBLISHABLE_KEY or
+ *     CYPRESS_CLERK_TEST_EMAIL is absent.
+ *   - Plan-picker assertions skip when the deployment is not in cloud mode
+ *     (self-hosted builds show a different setup surface).
+ *   - Checkout intercept asserts request shape only; no payment is attempted.
+ *
+ * Run against preview deployment:
+ *   CYPRESS_BASE_URL=https://preview.dash.chmonitor.dev \
+ *   CYPRESS_CLERK_PUBLISHABLE_KEY=pk_test_… \
+ *   CLERK_SECRET_KEY=sk_test_… \
+ *   CYPRESS_CLERK_TEST_EMAIL=you+clerk_test@example.com \
+ *   bun run test:e2e:billing
+ */
+
+import { setupClerkTestingToken } from '@clerk/testing/cypress'
+
+// Cypress strips the CYPRESS_ prefix: CYPRESS_CLERK_PUBLISHABLE_KEY →
+// Cypress.env('CLERK_PUBLISHABLE_KEY'). Likewise for CYPRESS_CLERK_TEST_EMAIL.
+const clerkConfigured = (): boolean =>
+  Boolean(Cypress.env('CLERK_PUBLISHABLE_KEY')) &&
+  Boolean(Cypress.env('CLERK_TEST_EMAIL'))
+
+const testEmail = (): string => Cypress.env('CLERK_TEST_EMAIL') as string
+
+describe('Billing + Org flow', () => {
+  // Suppress auth/network noise that is expected in CI (same as the global
+  // support/e2e.ts handler, but scoped to this suite for clarity).
+  Cypress.on('uncaught:exception', (err) => {
+    const msg = err.message || ''
+    if (
+      msg.includes('ECONNREFUSED') ||
+      msg.includes('fetch failed') ||
+      msg.includes('Failed to fetch') ||
+      msg.includes('NetworkError') ||
+      msg.includes('ClerkRuntimeError') ||
+      msg.includes('Hydration') ||
+      msg.includes('hydration') ||
+      msg.includes('timeout')
+    ) {
+      return false
+    }
+    return true
+  })
+
+  // ── Suite A: Anonymous (no Clerk auth required) ──────────────────────────
+  //
+  // These run on every CI invocation regardless of whether Clerk keys are
+  // present. They guard against import/route/render crashes on the billing
+  // surface.
+
+  describe('anonymous', () => {
+    it('/billing renders the heading and plan grid without a console crash', () => {
+      cy.visit('/billing')
+      cy.get('h1').should('contain.text', 'Billing')
+      // The plan grid renders four plan cards (Free / Pro / Max / Enterprise).
+      cy.contains('Free').should('exist')
+      cy.contains('Pro').should('exist')
+      cy.contains('Max').should('exist')
+    })
+
+    it('/setup renders a welcome / setup surface without a console crash', () => {
+      cy.visit('/setup')
+      // Any deployment mode should produce at least an <h1> — either the cloud
+      // "Choose your plan" / "Monitor your ClickHouse" heading, or the
+      // self-hosted "Connect a ClickHouse host" heading.
+      cy.get('h1').should('exist')
+    })
+
+    it('/organization renders without a console crash', () => {
+      cy.visit('/organization')
+      cy.get('body').should('exist')
+    })
+  })
+
+  // ── Suite B: Authenticated (requires Clerk test mode) ────────────────────
+  //
+  // Uses @clerk/testing cy.clerkSignIn with the email_code strategy.
+  // setupClerkTestingToken() must be called before cy.visit so the Clerk JS
+  // bundle picks up the bypass token for bot-protection.
+
+  describe('authenticated (cloud mode)', () => {
+    beforeEach(function () {
+      if (!clerkConfigured()) {
+        // eslint-disable-next-line no-console
+        cy.log(
+          'Skipping authenticated suite: CYPRESS_CLERK_PUBLISHABLE_KEY or ' +
+            'CYPRESS_CLERK_TEST_EMAIL is not set.'
+        )
+        this.skip()
+      }
+    })
+
+    it('/setup plan picker shows Free / Pro / Max for a signed-in free user', () => {
+      setupClerkTestingToken()
+      // Visit first so Clerk JS loads, then sign in.
+      cy.visit('/setup')
+      cy.clerkSignIn({ strategy: 'email_code', identifier: testEmail() })
+      cy.visit('/setup')
+
+      // The plan picker only shows in cloud mode + signed-in + free plan.
+      // In self-hosted mode the component renders a different surface; guard
+      // with a body check so the test passes gracefully in both environments.
+      cy.get('body').then(($body) => {
+        if ($body.find('[data-testid="onboarding-choose-free"]').length) {
+          cy.get('[data-testid="onboarding-choose-free"]')
+            .should('be.visible')
+            .and('contain.text', 'Continue with Free')
+          cy.get('[data-testid="onboarding-choose-pro"]').should('be.visible')
+          cy.get('[data-testid="onboarding-choose-max"]').should('be.visible')
+          cy.contains('Choose your plan').should('exist')
+        } else {
+          cy.log(
+            'Plan picker not shown (self-hosted mode or user already paid) — ' +
+              'skipping picker assertions.'
+          )
+        }
+      })
+    })
+
+    it('"Continue with Free" advances to the connect-host step', () => {
+      setupClerkTestingToken()
+      cy.visit('/setup')
+      cy.clerkSignIn({ strategy: 'email_code', identifier: testEmail() })
+      cy.visit('/setup')
+
+      cy.get('body').then(($body) => {
+        if (!$body.find('[data-testid="onboarding-choose-free"]').length) {
+          cy.log(
+            'Plan picker not shown — skipping connect-host step assertion.'
+          )
+          return
+        }
+        cy.get('[data-testid="onboarding-choose-free"]').click()
+        // After choosing Free the OnboardingPlans step calls onContinueFree()
+        // which sets step → 'connect', rendering the ConnectYourHost card.
+        cy.contains('Connect your ClickHouse', { timeout: 6000 }).should(
+          'be.visible'
+        )
+        cy.get('[data-testid="welcome-add-host"]').should('be.visible')
+      })
+    })
+
+    it('clicking Pro fires POST /api/v1/billing/checkout with planId=pro', () => {
+      // Intercept before the page loads so the stub is in place when the
+      // button is clicked. Stub the response with a same-origin URL to avoid
+      // triggering a cross-origin navigation that Cypress cannot follow.
+      // In production the real endpoint returns a polar.sh/sandbox URL; the
+      // request shape (planId + period) is what we are asserting here.
+      cy.intercept('POST', '/api/v1/billing/checkout', (req) => {
+        req.reply({
+          statusCode: 200,
+          body: {
+            success: true,
+            data: {
+              // Use a recognisable slug so assertions can verify the stub fired.
+              url:
+                (Cypress.config('baseUrl') as string) +
+                '/billing?status=checkout-intercepted&provider=polar',
+            },
+          },
+        })
+      }).as('checkoutReq')
+
+      setupClerkTestingToken()
+      cy.visit('/setup')
+      cy.clerkSignIn({ strategy: 'email_code', identifier: testEmail() })
+      cy.visit('/setup')
+
+      cy.get('body').then(($body) => {
+        if (!$body.find('[data-testid="onboarding-choose-pro"]').length) {
+          cy.log(
+            'Plan picker not shown — skipping checkout intercept assertion.'
+          )
+          return
+        }
+        cy.get('[data-testid="onboarding-choose-pro"]').click()
+
+        cy.wait('@checkoutReq').then((interception) => {
+          // The client sends { planId, period } in the POST body.
+          const body = interception.request.body as {
+            planId?: string
+            period?: string
+          }
+          expect(body).to.have.property('planId', 'pro')
+          expect(body).to.have.property('period', 'yearly')
+
+          // The stubbed response envelope has our recognisable URL.
+          const responseBody = interception.response?.body as {
+            data?: { url?: string }
+          }
+          expect(responseBody?.data?.url).to.include('polar')
+        })
+      })
+    })
+
+    it('/billing page reflects the plan state for an authenticated user', () => {
+      setupClerkTestingToken()
+      cy.visit('/billing')
+      cy.clerkSignIn({ strategy: 'email_code', identifier: testEmail() })
+      cy.visit('/billing')
+      cy.get('h1').should('contain.text', 'Billing')
+      // The current-plan card shows the plan name and a status badge.
+      // For a test account the plan is Free (status badge shows "free").
+      cy.contains(/free|pro|max/i).should('exist')
+    })
+
+    it('/organization renders the org profile or the upgrade prompt', () => {
+      setupClerkTestingToken()
+      cy.visit('/organization')
+      cy.clerkSignIn({ strategy: 'email_code', identifier: testEmail() })
+      cy.visit('/organization')
+      // Either <OrganizationProfile> (paid user in an org) or <NoOrgState>
+      // ("No organization yet" card + upgrade prompt) must be visible.
+      cy.get('body').then(($body) => {
+        const text = $body.text()
+        const hasOrgProfile =
+          $body.find('.cl-organizationProfile').length > 0 ||
+          $body.find('[data-clerk-component="OrganizationProfile"]').length > 0
+        const hasUpgradePrompt =
+          text.includes('No organization yet') || text.includes('organization')
+        expect(hasOrgProfile || hasUpgradePrompt).to.be.true
+      })
+    })
+  })
+})

--- a/apps/dashboard/cypress/support/e2e.ts
+++ b/apps/dashboard/cypress/support/e2e.ts
@@ -5,6 +5,10 @@
 // sweep spec collects errors per-route and reports them in bulk; other specs
 // use individual `cy.on('uncaught:exception')` handlers as needed.
 
+import { addClerkCommands } from '@clerk/testing/cypress'
+
+addClerkCommands({ Cypress, cy })
+
 Cypress.on('uncaught:exception', (err) => {
   const msg = err.message || ''
 
@@ -28,5 +32,3 @@ Cypress.on('uncaught:exception', (err) => {
   // Let other errors surface.
   return true
 })
-
-export {}

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -29,6 +29,7 @@
     "test:component:headless": "cypress run --component",
     "test:e2e": "cypress open --e2e",
     "test:e2e:headless": "cypress run --e2e",
+    "test:e2e:billing": "cypress run --spec 'cypress/e2e/billing-org-flow.cy.ts'",
     "smoke-test": "bun ../../scripts/smoke-test.ts --base-url https://dash.chmonitor.dev",
     "verify-deploy": "bun scripts/verify-deploy.ts"
   },
@@ -114,6 +115,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@clerk/testing": "^2.1.7",
     "@clickhouse/client": "^1.18.5",
     "@cloudflare/vite-plugin": "^1.39.2",
     "@cloudflare/workers-types": "^4.20260603.1",

--- a/scripts/sync-env-to-gh.ts
+++ b/scripts/sync-env-to-gh.ts
@@ -68,6 +68,18 @@ const SECRET_KEYS = [
   // here the MCP worker boots with an empty secret and 503s every /api/mcp
   // request ("MCP API key auth is not configured"). Must match across workers.
   'CHM_API_KEY_SECRET',
+  // Symmetric key for encrypting per-user connection credentials at rest in D1.
+  // When unset it is derived from CLERK_SECRET_KEY (lib/connection-store).
+  'CHM_USER_CONNECTIONS_ENCRYPTION_KEY',
+  // Polar billing (cloud SaaS). Access token authorizes checkout/portal/product
+  // API calls; webhook secret verifies inbound subscription events. Production
+  // uses the base names; preview/PR builds resolve the _TEST (sandbox) variants
+  // (see set-secrets.ts resolveValue + cloudflare.yml). Non-secret Polar config
+  // (CHM_POLAR_SERVER, CHM_POLAR_PRODUCT_*) lives in .env.production/.env.preview.
+  'POLAR_ACCESS_TOKEN',
+  'POLAR_ACCESS_TOKEN_TEST',
+  'POLAR_WEBHOOK_SECRET',
+  'POLAR_WEBHOOK_SECRET_TEST',
   // Misc runtime
   'NEXT_QUERY_CACHE_TTL',
 ] as const


### PR DESCRIPTION
## What

Configures **production** Polar billing (it was returning `501` — no products/token wired) and adds the Clerk-aware e2e test harness for the billing + org onboarding flow.

### Production Polar config
- `apps/dashboard/.env.production`: `CHM_POLAR_SERVER=production` + the four **production** Polar product ids (created idempotently via `apps/dashboard/scripts/polar-setup.ts` against the production org).
- Production Polar secrets (`POLAR_ACCESS_TOKEN`, `POLAR_WEBHOOK_SECRET`) set as GitHub repo secrets; CI's deploy pushes them onto the dashboard worker via `set-secrets.ts`. Webhook endpoint: `https://dash.chmonitor.dev/api/v1/webhooks/polar`.

### Secret-sync chain
- `scripts/sync-env-to-gh.ts`: add `POLAR_ACCESS_TOKEN(_TEST)`, `POLAR_WEBHOOK_SECRET(_TEST)`, `CHM_USER_CONNECTIONS_ENCRYPTION_KEY` to the GitHub-sync inventory so `.env*.local → GitHub Actions → Cloudflare Workers` carries billing secrets end-to-end.

### E2E harness
- `@clerk/testing` Cypress harness exercising the plan-picker → Polar checkout flow (runs against preview/prod via `CYPRESS_BASE_URL` + Clerk test mode).

## Verification
- **Preview (sandbox)** verified live: plan picker renders (Free/Pro/Max), "Choose Pro" → `POST /api/v1/billing/checkout` → redirect to `sandbox.polar.sh` checkout for *chmonitor Pro (Yearly) $290*. Webhook rejects bad signatures (`403`).
- **Production**: webhook currently `501` (pre-deploy); flips to signature-verifying once this merges and deploys.

https://claude.ai/code/session_016WK4LQxGfYisUATVaYvRua