### PR TITLE
feat(billing): shared, fancier plan cards across /billing + /setup

### DIFF
--- a/apps/dashboard/src/components/billing/plan-card.tsx
+++ b/apps/dashboard/src/components/billing/plan-card.tsx
@@ -1,0 +1,161 @@
+import { CheckIcon, SparklesIcon } from 'lucide-react'
+
+import type { ReactNode } from 'react'
+import type { Plan } from '@/lib/billing/plans'
+
+import { Badge } from '@/components/ui/badge'
+import { monthlyEquivalentUsd } from '@/lib/billing/plans'
+import { cn } from '@/lib/utils'
+
+/**
+ * Shared billing UI — the single source of truth for plan cards across the
+ * /billing page and the /setup onboarding plan picker, so the two surfaces stay
+ * visually identical. The card is a full-height flex column with the CTA pinned
+ * to the bottom (`mt-auto`), so every card's button lines up on the same
+ * baseline regardless of how many feature rows it has.
+ */
+
+export type BillingPeriod = 'monthly' | 'yearly'
+
+/** Display price (per-month equivalent) for a plan + period. */
+export function formatPlanPrice(plan: Plan, period: BillingPeriod): string {
+  if (plan.priceMonthlyUsd === null) return 'Custom'
+  if (plan.priceMonthlyUsd === 0) return '$0'
+  const v = monthlyEquivalentUsd(plan, period)
+  return v === null ? 'Custom' : `$${v}`
+}
+
+/** "Popular" pill shown on the featured (Pro) card. */
+export function PopularBadge() {
+  return (
+    <span className="bg-primary/10 text-primary inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium">
+      <SparklesIcon className="size-3" strokeWidth={2} />
+      Popular
+    </span>
+  )
+}
+
+interface PlanCardProps {
+  plan: Plan
+  period: BillingPeriod
+  /** Featured visual treatment (gradient + ring + lift). Use for the Pro tier. */
+  featured?: boolean
+  /** Top-right slot — e.g. <PopularBadge /> or a "Current" badge. */
+  badge?: ReactNode
+  /** Cap the number of feature rows (the picker shows 3; billing shows all). */
+  maxHighlights?: number
+  /** CTA button(s), rendered in the bottom-pinned footer. */
+  cta: ReactNode
+  className?: string
+}
+
+/**
+ * One plan card. Fancy, generous surface; featured cards get a gradient + ring.
+ * The footer is pushed to the bottom so CTAs align across a row of cards.
+ */
+export function PlanCard({
+  plan,
+  period,
+  featured = false,
+  badge,
+  maxHighlights,
+  cta,
+  className,
+}: PlanCardProps) {
+  const price = formatPlanPrice(plan, period)
+  const showSuffix = plan.priceMonthlyUsd != null && plan.priceMonthlyUsd > 0
+  const highlights =
+    maxHighlights != null
+      ? plan.highlights.slice(0, maxHighlights)
+      : plan.highlights
+
+  return (
+    <div
+      className={cn(
+        'group relative flex h-full flex-col rounded-2xl border bg-card p-6 shadow-sm transition-all duration-200',
+        'hover:-translate-y-0.5 hover:shadow-md',
+        featured &&
+          'border-primary/50 ring-primary/15 from-card to-primary/[0.04] dark:to-primary/[0.07] bg-gradient-to-b shadow-md ring-1',
+        className
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-base font-semibold tracking-tight">{plan.name}</h3>
+        {badge}
+      </div>
+
+      <div className="mt-3 flex items-baseline gap-1">
+        <span className="text-3xl font-bold tracking-tight tabular-nums">
+          {price}
+        </span>
+        {showSuffix && (
+          <span className="text-muted-foreground text-sm font-normal">/mo</span>
+        )}
+      </div>
+
+      <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+        {plan.tagline}
+      </p>
+
+      <ul className="mt-5 space-y-2.5">
+        {highlights.map((h) => (
+          <li key={h} className="flex gap-2.5 text-sm">
+            <CheckIcon
+              className="text-emerald-500 mt-0.5 size-4 shrink-0"
+              strokeWidth={2}
+            />
+            <span className="text-foreground/90">{h}</span>
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-auto pt-6">{cta}</div>
+    </div>
+  )
+}
+
+/** "Current" badge used on the user's active plan. */
+export function CurrentPlanBadge() {
+  return <Badge variant="secondary">Current</Badge>
+}
+
+interface BillingPeriodToggleProps {
+  value: BillingPeriod
+  onChange: (period: BillingPeriod) => void
+  className?: string
+}
+
+/** Monthly / Yearly segmented toggle, shared by both surfaces. */
+export function BillingPeriodToggle({
+  value,
+  onChange,
+  className,
+}: BillingPeriodToggleProps) {
+  return (
+    <div className={cn('flex items-center justify-center', className)}>
+      <div className="bg-muted inline-flex rounded-full p-1">
+        {(['monthly', 'yearly'] as const).map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => onChange(p)}
+            className={cn(
+              'rounded-full px-4 py-1.5 text-sm font-medium capitalize transition-colors',
+              value === p
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {p}
+            {p === 'yearly' && (
+              <span className="text-emerald-600 dark:text-emerald-400">
+                {' '}
+                · 2 months free
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/host/first-run-empty-state.tsx
+++ b/apps/dashboard/src/components/host/first-run-empty-state.tsx
@@ -1,11 +1,9 @@
 import {
   ArrowRight,
-  Check,
   DatabaseZap,
   KeyRound,
   PlugZap,
   ShieldCheck,
-  Sparkles,
   Terminal,
 } from 'lucide-react'
 import { toast } from 'sonner'
@@ -13,11 +11,12 @@ import { toast } from 'sonner'
 import type { ReactNode } from 'react'
 
 import { useState } from 'react'
+import { PlanCard, PopularBadge } from '@/components/billing/plan-card'
 import { ClerkSignInButton as ClerkSignInButtonImpl } from '@/components/clerk/clerk-sign-in-button'
 import { AddHostDialog } from '@/components/connections'
 import { ChmonitorLogo } from '@/components/icons/chmonitor-logo'
 import { Button } from '@/components/ui/button'
-import { BILLING_PLAN_LIST, monthlyEquivalentUsd } from '@/lib/billing/plans'
+import { BILLING_PLAN_LIST } from '@/lib/billing/plans'
 import {
   startCheckout,
   useBillingSubscription,
@@ -25,7 +24,6 @@ import {
 import { isClerkEnabled } from '@/lib/clerk/clerk-client'
 import { docsSiteUrl } from '@/lib/docs-site'
 import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
-import { cn } from '@/lib/utils'
 
 // Clerk's SignInButton needs a mounted <ClerkProvider>. Gate it behind the
 // build-time constant so non-Clerk (self-hosted) builds render null instead.
@@ -254,51 +252,20 @@ function OnboardingPlans({
 
   return (
     <div className="space-y-4">
-      <div className="grid gap-3 sm:grid-cols-3">
+      <div className="grid items-stretch gap-4 sm:grid-cols-3">
         {BILLING_PLAN_LIST.filter((p) => p.id !== 'enterprise').map((plan) => {
           const isFree = plan.id === 'free'
-          const price = isFree
-            ? '$0'
-            : `$${monthlyEquivalentUsd(plan, 'yearly') ?? ''}`
           const isCurrent = plan.id === currentPlanId
           return (
-            <div
+            <PlanCard
               key={plan.id}
-              className={cn(
-                'flex flex-col rounded-xl border bg-card p-4 shadow-sm',
-                plan.id === 'pro' && 'border-primary ring-primary/20 ring-1'
-              )}
-            >
-              <div className="flex items-center justify-between">
-                <span className="font-semibold">{plan.name}</span>
-                {plan.id === 'pro' && (
-                  <span className="text-primary inline-flex items-center gap-1 text-[11px] font-medium">
-                    <Sparkles className="size-3" /> Popular
-                  </span>
-                )}
-              </div>
-              <div className="mt-1 text-2xl font-bold tabular-nums">
-                {price}
-                {!isFree && (
-                  <span className="text-muted-foreground text-xs font-normal">
-                    {' '}
-                    /mo
-                  </span>
-                )}
-              </div>
-              <p className="text-muted-foreground mt-1 text-xs">
-                {plan.tagline}
-              </p>
-              <ul className="mt-3 flex-1 space-y-1.5">
-                {plan.highlights.slice(0, 3).map((h) => (
-                  <li key={h} className="flex gap-1.5 text-xs">
-                    <Check className="text-emerald-500 mt-0.5 size-3.5 shrink-0" />
-                    <span>{h}</span>
-                  </li>
-                ))}
-              </ul>
-              <div className="mt-4">
-                {isFree ? (
+              plan={plan}
+              period="yearly"
+              featured={plan.id === 'pro'}
+              badge={plan.id === 'pro' ? <PopularBadge /> : undefined}
+              maxHighlights={3}
+              cta={
+                isFree ? (
                   <Button
                     variant="outline"
                     className="w-full"
@@ -321,9 +288,9 @@ function OnboardingPlans({
                         ? 'Current plan'
                         : `Choose ${plan.name}`}
                   </Button>
-                )}
-              </div>
-            </div>
+                )
+              }
+            />
           )
         })}
       </div>

--- a/apps/dashboard/src/routes/(dashboard)/billing.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/billing.tsx
@@ -1,43 +1,33 @@
-import { CheckIcon, ExternalLinkIcon } from 'lucide-react'
+import { ExternalLinkIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { createFileRoute } from '@tanstack/react-router'
 
-import type { Plan } from '@/lib/billing/plans'
-
 import { useState } from 'react'
+import {
+  type BillingPeriod,
+  BillingPeriodToggle,
+  CurrentPlanBadge,
+  PlanCard,
+  PopularBadge,
+} from '@/components/billing/plan-card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   Card,
-  CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import {
-  BILLING_PLAN_LIST,
-  getPlan,
-  monthlyEquivalentUsd,
-} from '@/lib/billing/plans'
+import { BILLING_PLAN_LIST, getPlan } from '@/lib/billing/plans'
 import {
   openBillingPortal,
   startCheckout,
   useBillingSubscription,
 } from '@/lib/billing/use-billing'
-import { cn } from '@/lib/utils'
-
-type Period = 'monthly' | 'yearly'
-
-function priceLabel(plan: Plan, period: Period): string {
-  if (plan.priceMonthlyUsd === null) return 'Custom'
-  if (plan.priceMonthlyUsd === 0) return '$0'
-  const v = monthlyEquivalentUsd(plan, period)
-  return v === null ? 'Custom' : `$${v}`
-}
 
 function BillingPage() {
   const { data: sub, isLoading } = useBillingSubscription()
-  const [period, setPeriod] = useState<Period>('yearly')
+  const [period, setPeriod] = useState<BillingPeriod>('yearly')
   const [busy, setBusy] = useState<string | null>(null)
 
   const currentPlanId = sub?.planId ?? 'free'
@@ -110,70 +100,32 @@ function BillingPage() {
       </Card>
 
       {/* Billing period toggle */}
-      <div className="flex items-center justify-center gap-2">
-        <div className="bg-muted inline-flex rounded-full p-1">
-          {(['monthly', 'yearly'] as const).map((p) => (
-            <button
-              key={p}
-              type="button"
-              onClick={() => setPeriod(p)}
-              className={cn(
-                'rounded-full px-4 py-1.5 text-sm font-medium capitalize transition-colors',
-                period === p
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground'
-              )}
-            >
-              {p}
-              {p === 'yearly' && (
-                <span className="text-emerald-600 dark:text-emerald-400">
-                  {' '}
-                  · 2 months free
-                </span>
-              )}
-            </button>
-          ))}
-        </div>
-      </div>
+      <BillingPeriodToggle value={period} onChange={setPeriod} />
 
       {/* Plan grid */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <div className="grid items-stretch gap-4 md:grid-cols-2 lg:grid-cols-4">
         {BILLING_PLAN_LIST.map((plan) => {
           const isCurrent = plan.id === currentPlanId
           const paid = plan.id === 'pro' || plan.id === 'max'
           return (
-            <Card
+            <PlanCard
               key={plan.id}
-              className={cn(
-                isCurrent && 'border-primary ring-primary/30 ring-1'
-              )}
-            >
-              <CardHeader>
-                <CardTitle className="flex items-center justify-between">
-                  {plan.name}
-                  {isCurrent && <Badge variant="secondary">Current</Badge>}
-                </CardTitle>
-                <div className="text-2xl font-bold tabular-nums">
-                  {priceLabel(plan, period)}
-                  {plan.priceMonthlyUsd != null && plan.priceMonthlyUsd > 0 ? (
-                    <span className="text-muted-foreground text-sm font-normal">
-                      {' '}
-                      / mo
-                    </span>
-                  ) : null}
-                </div>
-                <CardDescription>{plan.tagline}</CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <ul className="space-y-2">
-                  {plan.highlights.map((h) => (
-                    <li key={h} className="flex gap-2 text-sm">
-                      <CheckIcon className="text-emerald-500 mt-0.5 size-4 shrink-0" />
-                      <span>{h}</span>
-                    </li>
-                  ))}
-                </ul>
-                {paid && !isCurrent && (
+              plan={plan}
+              period={period}
+              featured={plan.id === 'pro'}
+              badge={
+                isCurrent ? (
+                  <CurrentPlanBadge />
+                ) : plan.id === 'pro' ? (
+                  <PopularBadge />
+                ) : undefined
+              }
+              cta={
+                isCurrent ? (
+                  <Button variant="outline" className="w-full" disabled>
+                    Current plan
+                  </Button>
+                ) : paid ? (
                   <Button
                     className="w-full"
                     onClick={() => onCheckout(plan.id as 'pro' | 'max')}
@@ -183,14 +135,17 @@ function BillingPage() {
                       ? 'Redirecting…'
                       : `Upgrade to ${plan.name}`}
                   </Button>
-                )}
-                {plan.id === 'enterprise' && (
+                ) : plan.id === 'enterprise' ? (
                   <Button variant="outline" className="w-full" asChild>
                     <a href="mailto:hello@chmonitor.dev">Contact us</a>
                   </Button>
-                )}
-              </CardContent>
-            </Card>
+                ) : (
+                  <Button variant="outline" className="w-full" disabled>
+                    Free forever
+                  </Button>
+                )
+              }
+            />
           )
         })}
       </div>


### PR DESCRIPTION
Shared plan-card design between the **/billing** page and the **/setup** onboarding picker.

- New `components/billing/plan-card.tsx` — single source of truth: `PlanCard`, `BillingPeriodToggle`, `PopularBadge`, `CurrentPlanBadge`, `formatPlanPrice`.
- **Bigger, fancier**: `rounded-2xl`, `p-6`, 3xl price, hover lift; featured (Pro) card gets a gradient + primary ring.
- **CTAs bottom-aligned** (`mt-auto`) so every card's button sits on the same baseline regardless of feature count (fixes the misaligned Upgrade buttons).
- Both surfaces now render identical cards; preserves the `onboarding-choose-*` data-testids the billing e2e harness asserts.

Preview will show both `/billing` and `/setup`.

https://claude.ai/code/session_016WK4LQxGfYisUATVaYvRua