### PR TITLE
fix(billing): pull entitlement from Polar (resilient) + provision CHM_CLOUD_D1

### DIFF
--- a/apps/dashboard/src/components/clerk/organization-members.tsx
+++ b/apps/dashboard/src/components/clerk/organization-members.tsx
@@ -1,9 +1,10 @@
-import { Building2, Sparkles } from 'lucide-react'
+import { Building2, CreditCard, Sparkles } from 'lucide-react'
 
 import {
   OrganizationProfile,
   useOrganization,
 } from '@clerk/tanstack-react-start'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -12,6 +13,9 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { getPlan } from '@/lib/billing/plans'
+import { useBillingSubscription } from '@/lib/billing/use-billing'
 import { isClerkEnabled } from '@/lib/clerk/clerk-client'
 import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
 
@@ -28,28 +32,87 @@ export function OrganizationMembers() {
   if (!isClerkEnabled() || !isCloudModeClient()) {
     return <NoOrgState selfHosted />
   }
-  return <OrgProfileGate />
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 py-8">
+      <PlanSection />
+      <OrgProfileGate />
+    </div>
+  )
 }
 
 function OrgProfileGate() {
   const { organization, isLoaded } = useOrganization()
 
   if (!isLoaded) {
-    return (
-      <div className="mx-auto max-w-4xl py-8">
-        <div className="bg-muted h-96 animate-pulse rounded-xl" />
-      </div>
-    )
+    return <div className="bg-muted h-96 animate-pulse rounded-xl" />
   }
 
   if (!organization) {
     return <NoOrgState />
   }
 
+  return <OrganizationProfile routing="hash" />
+}
+
+/**
+ * Shows the user's current plan, renewal date (or cancellation warning), and a
+ * link to manage billing. Fetches subscription at this component (deepest consumer).
+ */
+function PlanSection() {
+  const { data: subscription, isLoading } = useBillingSubscription()
+
+  if (isLoading) {
+    return <Skeleton className="h-[72px] w-full rounded-xl" />
+  }
+
+  const planId = subscription?.planId ?? 'free'
+  const plan = getPlan(planId)
+  const currentPeriodEnd = subscription?.currentPeriodEnd
+  const cancelAtPeriodEnd = subscription?.cancelAtPeriodEnd
+  const status = subscription?.status
+  const isFree = planId === 'free'
+
+  const endDate = currentPeriodEnd
+    ? new Date(currentPeriodEnd * 1000).toLocaleDateString()
+    : null
+
   return (
-    <div className="mx-auto max-w-4xl py-8">
-      <OrganizationProfile routing="hash" />
-    </div>
+    <Card>
+      <CardContent className="flex items-center justify-between gap-4 p-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <CreditCard className="text-muted-foreground size-4 shrink-0" />
+            <span className="text-sm font-medium">{plan.name} plan</span>
+            {!isFree && status && (
+              <Badge variant="secondary" className="text-[11px] capitalize">
+                {status}
+              </Badge>
+            )}
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {isFree ? (
+              'Upgrade to unlock teams, more hosts, and scheduled AI Insights.'
+            ) : endDate ? (
+              cancelAtPeriodEnd ? (
+                <span className="text-amber-600 dark:text-amber-400">
+                  Cancels on {endDate}
+                </span>
+              ) : (
+                <>Renews {endDate}</>
+              )
+            ) : null}
+          </p>
+        </div>
+        <Button
+          asChild
+          size="sm"
+          variant={isFree ? 'default' : 'outline'}
+          className="shrink-0"
+        >
+          <a href="/billing">{isFree ? 'Upgrade' : 'Manage billing'}</a>
+        </Button>
+      </CardContent>
+    </Card>
   )
 }
 

--- a/apps/dashboard/src/components/host/first-run-gate.tsx
+++ b/apps/dashboard/src/components/host/first-run-gate.tsx
@@ -31,15 +31,22 @@ export function FirstRunGate({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
 
   const noHosts = !isLoading && !isUnauthorized && hosts.length === 0
-  const onSetup = pathname === '/setup'
+  // Account/billing pages stay reachable with zero hosts — a paying user with no
+  // host connected yet must still be able to view/manage their plan and org
+  // (otherwise they're trapped on /setup). /setup is itself exempt (no redirect
+  // loop, it renders the onboarding surface).
+  const onExemptPath =
+    pathname === '/setup' ||
+    pathname === '/billing' ||
+    pathname === '/organization'
 
   useEffect(() => {
-    if (noHosts && !onSetup) {
+    if (noHosts && !onExemptPath) {
       router.replace('/setup')
     }
-  }, [noHosts, onSetup, router])
+  }, [noHosts, onExemptPath, router])
 
-  if (noHosts && !onSetup) {
+  if (noHosts && !onExemptPath) {
     return <PageSkeleton />
   }
 

--- a/apps/dashboard/src/components/nav-user/clerk-nav.tsx
+++ b/apps/dashboard/src/components/nav-user/clerk-nav.tsx
@@ -62,8 +62,12 @@ export function ClerkNavWrapper() {
   const canUseSettings = isFeatureAllowed(SETTINGS_FEATURE_PERMISSION, config)
   const cloudMode = isCloudModeClient()
   // Billing is cloud-only; gate the query so self-host / OSS never calls it.
-  const { data: subscription } = useBillingSubscription()
-  const planLabel = cloudMode ? (subscription?.planId ?? 'free') : null
+  const { data: subscription, isLoading: billingLoading } =
+    useBillingSubscription()
+  // Null while loading (avoid briefly flashing "free" before the real plan loads)
+  // and when not in cloud mode (self-host has no billing).
+  const planLabel =
+    cloudMode && !billingLoading ? (subscription?.planId ?? 'free') : null
   const openSettings = () => {
     if (canUseSettings) setSettingsOpen(true)
   }
@@ -132,6 +136,29 @@ export function ClerkNavWrapper() {
                     >
                       {user?.primaryEmailAddress?.emailAddress}
                     </span>
+                    {planLabel && (
+                      <span
+                        className="mt-0.5 inline-flex cursor-pointer items-center"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          window.location.href = '/billing'
+                        }}
+                        data-testid="nav-user-plan-badge"
+                      >
+                        {planLabel === 'free' ? (
+                          <span className="text-[10px] text-muted-foreground hover:text-foreground">
+                            Upgrade →
+                          </span>
+                        ) : (
+                          <Badge
+                            variant="secondary"
+                            className="pointer-events-none h-4 px-1.5 text-[10px] capitalize"
+                          >
+                            {planLabel}
+                          </Badge>
+                        )}
+                      </span>
+                    )}
                   </div>
                   <ChevronsUpDown className="ml-auto size-4" />
                 </SidebarMenuButton>

--- a/apps/dashboard/src/lib/billing/polar-subscription.ts
+++ b/apps/dashboard/src/lib/billing/polar-subscription.ts
@@ -1,0 +1,91 @@
+/**
+ * Pull a billing owner's live entitlement straight from Polar — the source of
+ * truth, independent of the webhook + D1 cache.
+ *
+ * Why: webhooks can be missed (delivery 5xx, a cold D1, a replayed event) and
+ * the D1 row can drift. Reading the owner's CURRENT state from Polar by its
+ * `externalId` (= the Clerk user id or org id we stamped on checkout) makes the
+ * dashboard always reflect reality. The D1 row becomes a best-effort cache, not
+ * the authority.
+ *
+ * Cancel-grace is native: Polar's customer STATE `activeSubscriptions` only
+ * contains subscriptions that still grant access right now — a subscription set
+ * to cancel at period end stays here (status `active`, `cancelAtPeriodEnd:true`)
+ * until the period actually ends, then drops out. So "cancelled but paid through
+ * the cycle" keeps the plan until the cycle ends, with no extra logic.
+ */
+
+import type { PlanId } from './plans'
+
+import {
+  getPolarClient,
+  isBillingConfigured,
+  planForProductId,
+} from './polar-config'
+
+export interface OwnerSubscription {
+  planId: PlanId
+  billingPeriod: 'monthly' | 'yearly' | null
+  /** Polar status (active | trialing | …). Live by construction here. */
+  status: string
+  /** Unix seconds the current paid period runs until; access valid until then. */
+  currentPeriodEnd: number | null
+  /** True when the user cancelled but is still inside the paid period. */
+  cancelAtPeriodEnd: boolean
+}
+
+const PLAN_RANK: Record<string, number> = {
+  free: 0,
+  pro: 1,
+  max: 2,
+  enterprise: 3,
+}
+
+function toUnixSeconds(value: Date | string | null | undefined): number | null {
+  if (!value) return null
+  const ms = value instanceof Date ? value.getTime() : Date.parse(value)
+  return Number.isFinite(ms) ? Math.floor(ms / 1000) : null
+}
+
+/**
+ * The owner's current paid subscription per Polar, or null when they have none
+ * (free), Polar is not configured, or the call fails (caller falls back to the
+ * D1 cache / free). When several active subscriptions exist, the highest plan
+ * wins.
+ */
+export async function pullOwnerSubscriptionFromPolar(
+  externalId: string
+): Promise<OwnerSubscription | null> {
+  if (!isBillingConfigured()) return null
+  try {
+    const state = await getPolarClient().customers.getStateExternal({
+      externalId,
+    })
+    const active =
+      'activeSubscriptions' in state ? (state.activeSubscriptions ?? []) : []
+
+    let best: OwnerSubscription | null = null
+    for (const s of active) {
+      const mapped = planForProductId(s.productId)
+      if (!mapped) continue
+      const candidate: OwnerSubscription = {
+        planId: mapped.planId,
+        billingPeriod: mapped.period,
+        status: s.status,
+        currentPeriodEnd: toUnixSeconds(s.currentPeriodEnd),
+        cancelAtPeriodEnd: Boolean(s.cancelAtPeriodEnd),
+      }
+      if (
+        !best ||
+        (PLAN_RANK[candidate.planId] ?? 0) > (PLAN_RANK[best.planId] ?? 0)
+      ) {
+        best = candidate
+      }
+    }
+    return best
+  } catch {
+    // 404 ResourceNotFound (no Polar customer for this externalId yet) or a
+    // transient API error — treat as "no live subscription"; caller falls back.
+    return null
+  }
+}

--- a/apps/dashboard/src/lib/billing/subscription-store.ts
+++ b/apps/dashboard/src/lib/billing/subscription-store.ts
@@ -14,6 +14,7 @@
 
 import type { PlanId } from './plans'
 
+import { error as logError } from '@chm/logger'
 import { getPlatformBindings } from '@chm/platform'
 
 export type OwnerType = 'user' | 'org'
@@ -82,22 +83,36 @@ function getDb() {
 /**
  * Read a subscription by billing-owner id (user id or org id), or null when
  * none exists / no D1 binding.
+ *
+ * Degrades gracefully (returns null) on ANY D1 error — most importantly a
+ * missing `user_subscriptions` table when the binding is provisioned but
+ * migrations have not been applied yet. Without this, the raw SELECT throws
+ * "no such table" and 500s every billing read; the caller reconciles from
+ * Polar / falls back to free instead.
  */
 export async function getSubscription(
   ownerId: string
 ): Promise<UserSubscription | null> {
   const db = getDb()
   if (!db) return null
-  const row = await db
-    .prepare(
-      `SELECT user_id, owner_type, plan_id, billing_period, status,
-              polar_subscription_id, polar_customer_id, current_period_end,
-              created_at, updated_at
-       FROM user_subscriptions WHERE user_id = ?1`
-    )
-    .bind(ownerId)
-    .first<D1SubscriptionRow>()
-  return row ? rowToSubscription(row) : null
+  try {
+    const row = await db
+      .prepare(
+        `SELECT user_id, owner_type, plan_id, billing_period, status,
+                polar_subscription_id, polar_customer_id, current_period_end,
+                created_at, updated_at
+         FROM user_subscriptions WHERE user_id = ?1`
+      )
+      .bind(ownerId)
+      .first<D1SubscriptionRow>()
+    return row ? rowToSubscription(row) : null
+  } catch (err) {
+    logError('[subscription-store] read failed; treating as no subscription', {
+      ownerId,
+      err,
+    })
+    return null
+  }
 }
 
 /**

--- a/apps/dashboard/src/lib/billing/use-billing.ts
+++ b/apps/dashboard/src/lib/billing/use-billing.ts
@@ -47,11 +47,15 @@ export function useBillingSubscription() {
       return readEnvelope<BillingSubscription>(res)
     },
     staleTime: 60_000,
-    // The Clerk session can hydrate a beat after first paint; a query that fires
-    // during that window 401s and would otherwise cache "free". Always refetch
-    // on mount and retry so the real plan replaces the stale value promptly.
+    // The Clerk __session cookie is short-lived and is refreshed a few seconds
+    // after a cold load; a billing query that fires before the refresh 401s and
+    // would otherwise cache "free" for the whole session. Always refetch on
+    // mount and keep retrying (capped ~4s delay, ~15s total) so the request
+    // lands once the fresh cookie is in place and the real plan replaces the
+    // stale value.
     refetchOnMount: 'always',
-    retry: 2,
+    retry: 5,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 4000),
   })
 }
 

--- a/apps/dashboard/src/lib/billing/use-billing.ts
+++ b/apps/dashboard/src/lib/billing/use-billing.ts
@@ -47,6 +47,11 @@ export function useBillingSubscription() {
       return readEnvelope<BillingSubscription>(res)
     },
     staleTime: 60_000,
+    // The Clerk session can hydrate a beat after first paint; a query that fires
+    // during that window 401s and would otherwise cache "free". Always refetch
+    // on mount and retry so the real plan replaces the stale value promptly.
+    refetchOnMount: 'always',
+    retry: 2,
   })
 }
 

--- a/apps/dashboard/src/lib/billing/use-billing.ts
+++ b/apps/dashboard/src/lib/billing/use-billing.ts
@@ -15,6 +15,8 @@ export interface BillingSubscription {
   status: string
   billingPeriod: 'monthly' | 'yearly' | null
   currentPeriodEnd: number | null
+  /** True when cancelled but still within the paid period (grace). */
+  cancelAtPeriodEnd?: boolean
 }
 
 interface Envelope<T> {

--- a/apps/dashboard/src/lib/billing/user-subscription.ts
+++ b/apps/dashboard/src/lib/billing/user-subscription.ts
@@ -14,10 +14,12 @@
  */
 
 import type { Plan, PlanId } from './plans'
-import type { UserSubscription } from './subscription-store'
+import type { OwnerSubscription } from './polar-subscription'
+import type { OwnerType, UserSubscription } from './subscription-store'
 
 import { BILLING_PLANS, getPlan } from './plans'
-import { getSubscription } from './subscription-store'
+import { pullOwnerSubscriptionFromPolar } from './polar-subscription'
+import { getSubscription, upsertSubscription } from './subscription-store'
 
 /** Polar statuses that still grant the paid plan. */
 const LIVE_STATUSES = new Set(['active', 'trialing'])
@@ -33,14 +35,63 @@ export function isSubscriptionLive(
   return true
 }
 
+function validPlanId(id: PlanId): PlanId {
+  return BILLING_PLANS[id] ? id : 'free'
+}
+
+/**
+ * Resolve the live subscription for a billing owner, or null for free.
+ *
+ * D1 cache first (fast path once the webhook has synced), then reconcile against
+ * Polar as the source of truth — this catches missed/failed webhook deliveries
+ * and an empty/cold D1, and surfaces cancel-grace (Polar keeps a cancelled-at-
+ * period-end subscription "active" until the period ends). A Polar hit is
+ * written through to D1 best-effort so the next read takes the fast path.
+ */
+export async function resolveOwnerSubscription(
+  ownerId: string
+): Promise<OwnerSubscription | null> {
+  const cached = await getSubscription(ownerId)
+  if (cached && isSubscriptionLive(cached)) {
+    return {
+      planId: validPlanId(cached.planId),
+      billingPeriod: cached.billingPeriod,
+      status: cached.status,
+      currentPeriodEnd: cached.currentPeriodEnd,
+      cancelAtPeriodEnd: false,
+    }
+  }
+
+  const polar = await pullOwnerSubscriptionFromPolar(ownerId)
+  if (polar) {
+    // Write-through cache so the next read is a fast D1 hit. Best-effort: a
+    // missing/cold D1 must never break the (already-correct) Polar read.
+    const ownerType: OwnerType = ownerId.startsWith('org_') ? 'org' : 'user'
+    try {
+      await upsertSubscription({
+        userId: ownerId,
+        ownerType,
+        planId: polar.planId,
+        billingPeriod: polar.billingPeriod,
+        status: polar.status,
+        currentPeriodEnd: polar.currentPeriodEnd,
+      })
+    } catch {
+      // ignore — Polar already gave us the authoritative answer
+    }
+    return polar
+  }
+
+  return null
+}
+
 /**
  * Resolve the plan id for a billing owner (user or org), defaulting to free.
  * Pass the id from resolveBillingOwner() — either a Clerk user id or org id.
  */
 export async function getPlanIdForOwner(ownerId: string): Promise<PlanId> {
-  const sub = await getSubscription(ownerId)
-  if (!sub || !isSubscriptionLive(sub)) return 'free'
-  return BILLING_PLANS[sub.planId] ? sub.planId : 'free'
+  const sub = await resolveOwnerSubscription(ownerId)
+  return sub ? validPlanId(sub.planId) : 'free'
 }
 
 /**

--- a/apps/dashboard/src/routes/api/v1/billing/subscription.ts
+++ b/apps/dashboard/src/routes/api/v1/billing/subscription.ts
@@ -13,8 +13,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { createSuccessResponse } from '@/lib/api/shared/response-builder'
 import { resolveBillingOwner } from '@/lib/billing/billing-owner'
-import { getSubscription } from '@/lib/billing/subscription-store'
-import { getPlanIdForOwner } from '@/lib/billing/user-subscription'
+import { resolveOwnerSubscription } from '@/lib/billing/user-subscription'
 import { mapConnectionApiError } from '@/lib/connection-store/api-errors'
 
 const ROUTE = { route: '/api/v1/billing/subscription', method: 'GET' }
@@ -22,15 +21,14 @@ const ROUTE = { route: '/api/v1/billing/subscription', method: 'GET' }
 async function handleGet(): Promise<Response> {
   try {
     const owner = await resolveBillingOwner()
-    const [planId, sub] = await Promise.all([
-      getPlanIdForOwner(owner.id),
-      getSubscription(owner.id),
-    ])
+    // Source of truth is Polar (with a D1 cache) — see resolveOwnerSubscription.
+    const sub = await resolveOwnerSubscription(owner.id)
     return createSuccessResponse({
-      planId,
+      planId: sub?.planId ?? 'free',
       status: sub?.status ?? 'none',
       billingPeriod: sub?.billingPeriod ?? null,
       currentPeriodEnd: sub?.currentPeriodEnd ?? null,
+      cancelAtPeriodEnd: sub?.cancelAtPeriodEnd ?? false,
       owner: { type: owner.type, id: owner.id },
     })
   } catch (error) {

--- a/apps/dashboard/src/routes/api/v1/webhooks/polar.ts
+++ b/apps/dashboard/src/routes/api/v1/webhooks/polar.ts
@@ -137,16 +137,29 @@ async function applySubscription(data: PolarSubscriptionData): Promise<void> {
     // Billing is preserved under userId; org creation can be retried manually.
   }
 
-  await upsertSubscription({
-    userId: ownerId,
-    ownerType,
-    planId: mapped.planId,
-    billingPeriod: mapped.period,
-    status: data.status,
-    polarSubscriptionId: data.id,
-    polarCustomerId: data.customerId,
-    currentPeriodEnd: toUnixSeconds(data.currentPeriodEnd),
-  })
+  // Best-effort cache write. The dashboard reconciles entitlement from Polar
+  // (resolveOwnerSubscription), so a missing/cold D1 must NOT fail the webhook —
+  // otherwise Polar retries the event forever on a 500 even though the truth is
+  // already in Polar. Log and acknowledge.
+  try {
+    await upsertSubscription({
+      userId: ownerId,
+      ownerType,
+      planId: mapped.planId,
+      billingPeriod: mapped.period,
+      status: data.status,
+      polarSubscriptionId: data.id,
+      polarCustomerId: data.customerId,
+      currentPeriodEnd: toUnixSeconds(data.currentPeriodEnd),
+    })
+  } catch (err) {
+    logError('[polar-webhook] D1 cache write failed (non-fatal)', {
+      ownerId,
+      ownerType,
+      planId: mapped.planId,
+      err,
+    })
+  }
 
   logInfo('[polar-webhook] applied subscription', {
     externalId,

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -14,10 +14,12 @@ compatibility_flags = ["nodejs_compat", "nodejs_compat_populate_process_env"]
 [observability]
 enabled = true
 
-# D1 database for AI agent conversations
+# D1 database for AI agent conversations + per-user connections + billing
+# subscriptions (subscription-store / user-connections / conversation-store).
 [[d1_databases]]
 binding = "CHM_CLOUD_D1"
 database_name = "clickhouse-monitor-conversations"
+database_id = "971fc256-8c2e-4080-b162-3c30b7c56d89"
 migrations_dir = "./src/db/conversations-migrations"
 
 # Durable Object migrations.
@@ -98,10 +100,11 @@ name = "preview-chmonitor-dash"
 pattern = "preview.dash.chmonitor.dev"
 custom_domain = true
 
-# Reuse the same conversation D1 database once database_id is provisioned
+# Reuse the same conversation D1 database (shared preview/prod for now).
 [[env.preview.d1_databases]]
 binding = "CHM_CLOUD_D1"
 database_name = "clickhouse-monitor-conversations"
+database_id = "971fc256-8c2e-4080-b162-3c30b7c56d89"
 migrations_dir = "./src/db/conversations-migrations"
 
 # DO migrations are not inherited by named environments — repeat the chain that


### PR DESCRIPTION
## Root cause
"Paid in Polar but dashboard still shows Free" + webhook **500s** (12+ failed deliveries) were caused by the **`CHM_CLOUD_D1` database never being provisioned** — no `database_id` in `wrangler.toml`, so the binding was null at runtime. Every subscription upsert threw (→ webhook 500) and reads fell back to Free. (Same missing D1 also blocked host-adding.)

## Fix
- **Provision + wire `CHM_CLOUD_D1`** (`database_id 971fc256…`) for default + preview.
- **Pull-from-Polar** (`lib/billing/polar-subscription.ts`): entitlement reads live from Polar by `externalId` (Clerk user/org id) as the source of truth; D1 is a write-through cache. Billing is correct **even when the webhook/D1 is missed or cold**.
- **Cancel-grace, native**: Polar's customer-state only lists subs that still grant access → a cancelled-at-period-end plan stays until the period ends. `cancelAtPeriodEnd` surfaced to the client.
- **Webhook D1 write is best-effort** (logs instead of 500) so Polar stops retrying a delivered event forever.
- Host limits already enforced (`getPlanForOwner` → 402); they now resolve the real plan.

## Verified
- API pull from Polar confirmed (sub `6a842c0e` active, Pro Yearly, externalId `user_3E5Y9…`).
- Polar webhook delivery confirmed (endpoint correct; was 500 on our side — now fixed).

## Follow-ups
- Apply D1 migrations to the new DB: `wrangler d1 migrations apply clickhouse-monitor-conversations --remote` (creates `user_subscriptions` + connections tables).
- Sidebar/org **plan display** lands in a follow-up commit on this branch.
- Consider a CI step to auto-apply D1 migrations on deploy.

https://claude.ai/code/session_016WK4LQxGfYisUATVaYvRua