### PR TITLE
feat(dashboard): signed-out plans link + Add Host CTA for empty host state

### DIFF
--- a/apps/dashboard/src/components/host/host-switcher.tsx
+++ b/apps/dashboard/src/components/host/host-switcher.tsx
@@ -6,7 +6,7 @@ import {
   LogoStatusIndicator,
   LogoStatusIndicatorSkeleton,
 } from './logo-status-indicator'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { AddHostDialog } from '@/components/connections'
 import { ChmonitorLogo } from '@/components/icons/chmonitor-logo'
 import {
@@ -49,13 +49,29 @@ export function HostSwitcher() {
     hosts.find((h) => h.id === currentHostId) ?? hosts[0] ?? null
   const showExpanded = isMobile || state === 'expanded'
 
+  // Guard against a hung load (e.g. a signed-in user whose server-stored
+  // connections request never resolves) trapping the switcher on the skeleton
+  // forever. After a short grace period we fall through to the resolved state —
+  // which, for a user with no host yet, is the "Add Host" CTA below.
+  const [loadTimedOut, setLoadTimedOut] = useState(false)
+  useEffect(() => {
+    if (!isLoading) {
+      setLoadTimedOut(false)
+      return
+    }
+    const timer = setTimeout(() => setLoadTimedOut(true), 6000)
+    return () => clearTimeout(timer)
+  }, [isLoading])
+
   const handleHostChange = (hostId: number) => {
     const url = buildUrl(pathname, { host: hostId }, searchParams)
     router.push(url)
   }
 
-  // Show skeleton while loading hosts
-  if (isLoading) {
+  // Show the skeleton only while we still have nothing to render and the load
+  // hasn't timed out. If hosts already resolved from a faster source, render
+  // them instead of flashing a skeleton over a slow secondary fetch.
+  if (isLoading && hosts.length === 0 && !loadTimedOut) {
     return (
       <SidebarMenu>
         <SidebarMenuItem>
@@ -85,11 +101,47 @@ export function HostSwitcher() {
 
   // No active host: keep switcher shape and surface why
   if (!activeHost) {
+    // Genuine empty state — signed in, no host configured yet, and neither an
+    // auth nor a fetch error. Show a one-click "Add Host" CTA (opens the dialog
+    // directly) rather than a subtle dropdown, so getting started is obvious.
+    if (!isUnauthorized && !error) {
+      return (
+        <>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                size="lg"
+                onClick={() => setAddDialogOpen(true)}
+                className={cn(
+                  'data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground',
+                  !showExpanded && 'justify-center'
+                )}
+                data-testid="host-switcher-empty"
+                aria-label={showExpanded ? undefined : 'Add host'}
+              >
+                <div className="relative">
+                  <PlusIcon className="size-5" />
+                </div>
+                {showExpanded && (
+                  <div className="grid flex-1 text-left text-sm leading-tight">
+                    <span className="truncate font-medium">Add Host</span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      Connect a ClickHouse host
+                    </span>
+                  </div>
+                )}
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+          <AddHostDialog open={addDialogOpen} onOpenChange={setAddDialogOpen} />
+        </>
+      )
+    }
+
+    // Auth or fetch error: keep the informative dropdown shape.
     const { label, hint } = isUnauthorized
       ? { label: 'Sign in to load hosts', hint: 'Authentication required' }
-      : error
-        ? { label: "Couldn't load hosts", hint: 'Tap to retry from a page' }
-        : { label: 'No host', hint: 'Add a host to get started' }
+      : { label: "Couldn't load hosts", hint: 'Tap to retry from a page' }
 
     return (
       <>

--- a/apps/dashboard/src/components/host/host-switcher.tsx
+++ b/apps/dashboard/src/components/host/host-switcher.tsx
@@ -112,16 +112,11 @@ export function HostSwitcher() {
               <SidebarMenuButton
                 size="lg"
                 onClick={() => setAddDialogOpen(true)}
-                className={cn(
-                  'data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground',
-                  !showExpanded && 'justify-center'
-                )}
+                className={cn(!showExpanded && 'justify-center')}
                 data-testid="host-switcher-empty"
                 aria-label={showExpanded ? undefined : 'Add host'}
               >
-                <div className="relative">
-                  <PlusIcon className="size-5" />
-                </div>
+                <PlusIcon className="size-5" />
                 {showExpanded && (
                   <div className="grid flex-1 text-left text-sm leading-tight">
                     <span className="truncate font-medium">Add Host</span>

--- a/apps/dashboard/src/components/nav-user/clerk-nav.tsx
+++ b/apps/dashboard/src/components/nav-user/clerk-nav.tsx
@@ -81,6 +81,24 @@ export function ClerkNavWrapper() {
   return (
     <>
       <SidebarMenu>
+        {/* Not signed in - surface plans + a Sign In / Sign Up entry point.
+            The plans link sits above the account slot so Sign In stays the
+            bottom anchor (matching the signed-in user button position). */}
+        {!isSignedIn && (
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              asChild
+              size="sm"
+              tooltip="View plans"
+              data-testid="nav-user-plans"
+            >
+              <a href="/billing">
+                <CreditCard />
+                <span>View plans</span>
+              </a>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        )}
         <SidebarMenuItem>
           {/* Not signed in - show Sign In button */}
           {!isSignedIn && (
@@ -98,7 +116,7 @@ export function ClerkNavWrapper() {
                 <div className="grid flex-1 text-left text-sm leading-tight">
                   <span className="truncate font-medium">Sign In</span>
                   <span className="truncate text-xs text-muted-foreground">
-                    to access features
+                    or sign up to start
                   </span>
                 </div>
               </SidebarMenuButton>


### PR DESCRIPTION
Addresses two design-review notes on the dashboard sidebar (`dash.chmonitor.dev` / `/overview`).

## 1. Signed-out footer — surface plans + sign in/up
The footer previously showed only a Clerk "Sign In" modal button. Added a **"View plans" → `/billing`** link above it (reusing the existing Docs-link `asChild size="sm"` idiom) and changed the subtitle to "or sign up to start" so visitors can see plans and begin without guessing.

`/billing` renders `PlanCard`s for everyone (`useBillingSubscription()` falls back to `free`); checkout is the only auth-gated step.

## 2. Host switcher — clear empty state, no stuck skeleton
For a signed-in cloud user with **no host configured yet** (the demo is hidden once signed in), the switcher showed a subtle "No host" dropdown — and could sit on the loading skeleton if the server-stored connections fetch hung.

- **One-click "Add Host" CTA**: genuine empty state (signed in, not an auth/fetch error) now renders an `Add Host` button that opens `AddHostDialog` directly, instead of a two-click muted dropdown. Auth/error cases keep the informative dropdown.
- **Skeleton guard**: a 6s loading timeout falls through to the resolved state so a hung connections request can't trap the switcher on the skeleton; the skeleton is also skipped when hosts already resolved from a faster source.

## Files
- `apps/dashboard/src/components/nav-user/clerk-nav.tsx`
- `apps/dashboard/src/components/host/host-switcher.tsx`

## Validation
- `biome check` clean on both files.
- `tsc --noEmit`: no errors introduced by these files (pre-existing route-tree errors in billing/organization/polar route files are unrelated — `/billing` here is a plain `<a>`, not a typed route).

https://claude.ai/code/session_01YaNwY59Shdffk3qAgnziqP