### PR TITLE
chore(cloud): rename D1 database to chm-cloud

### DIFF
--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -18,8 +18,8 @@ enabled = true
 # subscriptions (subscription-store / user-connections / conversation-store).
 [[d1_databases]]
 binding = "CHM_CLOUD_D1"
-database_name = "clickhouse-monitor-conversations"
-database_id = "971fc256-8c2e-4080-b162-3c30b7c56d89"
+database_name = "chm-cloud"
+database_id = "cca247b6-9b25-41bd-b9ca-727b35bc6039"
 migrations_dir = "./src/db/conversations-migrations"
 
 # Durable Object migrations.
@@ -103,8 +103,8 @@ custom_domain = true
 # Reuse the same conversation D1 database (shared preview/prod for now).
 [[env.preview.d1_databases]]
 binding = "CHM_CLOUD_D1"
-database_name = "clickhouse-monitor-conversations"
-database_id = "971fc256-8c2e-4080-b162-3c30b7c56d89"
+database_name = "chm-cloud"
+database_id = "cca247b6-9b25-41bd-b9ca-727b35bc6039"
 migrations_dir = "./src/db/conversations-migrations"
 
 # DO migrations are not inherited by named environments — repeat the chain that

--- a/scripts/setup-conversations-db.ts
+++ b/scripts/setup-conversations-db.ts
@@ -18,7 +18,7 @@
 import { readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
-const DATABASE_NAME = 'clickhouse-monitor-conversations'
+const DATABASE_NAME = 'chm-cloud'
 const WRANGLER_TOML_PATH = join(process.cwd(), 'wrangler.toml')
 
 interface WranglerD1CreateOutput {
@@ -79,7 +79,7 @@ function updateWranglerToml(databaseId: string): boolean {
 
     // Update the main D1 database binding
     const updatedMain = content.replace(
-      /(# D1 database for AI agent conversations\s+\[\[d1_databases\]\]\s+binding = "CHM_CLOUD_D1"\s+database_name = "clickhouse-monitor-conversations"(?:\s+database_id = "[^"]*")?(?:\s+migrations_dir = "[^"]*")?)/g,
+      /(# D1 database for AI agent conversations\s+\[\[d1_databases\]\]\s+binding = "CHM_CLOUD_D1"\s+database_name = "chm-cloud"(?:\s+database_id = "[^"]*")?(?:\s+migrations_dir = "[^"]*")?)/g,
       (block) => {
         matchedMain = true
         return withDatabaseId(block)
@@ -88,7 +88,7 @@ function updateWranglerToml(databaseId: string): boolean {
 
     // Update the preview environment binding
     const updatedPreview = updatedMain.replace(
-      /(# Reuse the same conversation D1 database once database_id is provisioned\s+\[\[env\.preview\.d1_databases\]\]\s+binding = "CHM_CLOUD_D1"\s+database_name = "clickhouse-monitor-conversations"(?:\s+database_id = "[^"]*")?(?:\s+migrations_dir = "[^"]*")?)/g,
+      /(# Reuse the same conversation D1 database once database_id is provisioned\s+\[\[env\.preview\.d1_databases\]\]\s+binding = "CHM_CLOUD_D1"\s+database_name = "chm-cloud"(?:\s+database_id = "[^"]*")?(?:\s+migrations_dir = "[^"]*")?)/g,
       (block) => {
         matchedPreview = true
         return withDatabaseId(block)


### PR DESCRIPTION
Repoints the `CHM_CLOUD_D1` binding (production + preview) from the legacy `clickhouse-monitor-conversations` to a new **`chm-cloud`** D1 database.

## What changed
- `apps/dashboard/wrangler.toml` — `database_name` + `database_id` for both the prod and `env.preview` D1 blocks
- `scripts/setup-conversations-db.ts` — `DATABASE_NAME` constant + the two wrangler-patch regexes

## New database
- name: `chm-cloud`
- id: `cca247b6-9b25-41bd-b9ca-727b35bc6039`

## Safety
Schema (5 tables + indexes) and the `d1_migrations` ledger (0001–0004) were mirrored exactly into the new DB. **No row data needed migrating** — all data tables were empty because entitlement pulls from Polar at read time (the resilient billing design), so `user_subscriptions` held no rows. The legacy DB will be deleted after this deploys and is verified.

https://claude.ai/code/session_01DWVGDH6eVShfWqPwXH51RZ