### PR TITLE
feat(cloud): pop nav plan badge + add /sign-in,/sign-up routes

### DIFF
--- a/apps/dashboard/src/components/billing/plan-comparison.tsx
+++ b/apps/dashboard/src/components/billing/plan-comparison.tsx
@@ -1,0 +1,204 @@
+import { Check, Minus } from 'lucide-react'
+
+import {
+  BILLING_PLAN_LIST,
+  type Plan,
+  type PlanCapability,
+  type PlanId,
+  planHasCapability,
+} from '@/lib/billing/plans'
+import { cn } from '@/lib/utils'
+
+/**
+ * Side-by-side "what you get" matrix for the billing page. Derives entirely from
+ * BILLING_PLANS (the single source of truth) so it can never drift from the
+ * cards or the server-side limit checks. Two row groups: hard Limits (numeric)
+ * and Features (capability flags). The current plan's column is highlighted.
+ */
+
+type LimitRow = {
+  label: string
+  /** Cell value per plan. */
+  value: (plan: Plan) => string
+}
+
+type FeatureRow = {
+  label: string
+  /** Either a capability flag (✓/—) or a custom per-plan string. */
+  capability?: PlanCapability
+  value?: (plan: Plan) => string | boolean
+}
+
+function hosts(plan: Plan): string {
+  return plan.hosts === null ? 'Unlimited' : String(plan.hosts)
+}
+
+function seats(plan: Plan): string {
+  return plan.seats === null ? 'Unlimited' : String(plan.seats)
+}
+
+function retention(plan: Plan): string {
+  return plan.retentionDays === null ? 'Custom' : `${plan.retentionDays} days`
+}
+
+function aiBudget(plan: Plan): string {
+  if (plan.aiMonthlyUsdBudget === null) return 'BYOK'
+  if (plan.id === 'free') return 'Daily trial'
+  return `$${plan.aiMonthlyUsdBudget}/mo`
+}
+
+const LIMIT_ROWS: LimitRow[] = [
+  { label: 'ClickHouse hosts', value: hosts },
+  { label: 'Team seats', value: seats },
+  { label: 'History retention', value: retention },
+  { label: 'AI usage', value: aiBudget },
+]
+
+const FEATURE_ROWS: FeatureRow[] = [
+  { label: 'Full monitoring dashboard', capability: 'core_monitoring' },
+  { label: 'AI agent', capability: 'ai_agent' },
+  { label: 'Scheduled AI Insights', capability: 'ai_insights_scheduled' },
+  {
+    label: 'Alerting',
+    value: (plan) =>
+      planHasCapability(plan.id, 'alerting_advanced')
+        ? 'Advanced'
+        : planHasCapability(plan.id, 'alerting_basic')
+          ? 'Basic'
+          : false,
+  },
+  { label: 'Fleet view', capability: 'fleet_view' },
+  { label: 'API / MCP access', capability: 'api_mcp_access' },
+  { label: 'SSO / SAML, RBAC, audit logs', capability: 'sso_rbac_audit' },
+  { label: 'Priority support', capability: 'priority_support' },
+]
+
+function Cell({ value }: { value: string | boolean }) {
+  if (value === true) {
+    return (
+      <span className="inline-flex">
+        <Check
+          className="size-4 text-emerald-600 dark:text-emerald-400"
+          strokeWidth={2}
+          aria-label="Included"
+        />
+      </span>
+    )
+  }
+  if (value === false) {
+    return (
+      <Minus
+        className="text-muted-foreground/40 size-4"
+        strokeWidth={1.5}
+        aria-label="Not included"
+      />
+    )
+  }
+  return <span className="text-[13px] font-medium">{value}</span>
+}
+
+export function PlanComparison({ currentPlanId }: { currentPlanId: PlanId }) {
+  const plans = BILLING_PLAN_LIST
+
+  return (
+    <section className="space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold tracking-tight">Compare plans</h2>
+        <p className="text-muted-foreground text-sm">
+          Everything you get on each tier, side by side.
+        </p>
+      </div>
+
+      <div className="overflow-x-auto rounded-xl border bg-card shadow-sm">
+        <table className="w-full min-w-[640px] border-collapse text-sm">
+          <thead>
+            <tr className="border-b">
+              <th className="w-[30%] px-4 py-3 text-left font-medium text-muted-foreground">
+                Plan
+              </th>
+              {plans.map((plan) => (
+                <th
+                  key={plan.id}
+                  className={cn(
+                    'px-4 py-3 text-center font-semibold',
+                    plan.id === currentPlanId && 'bg-muted/50'
+                  )}
+                >
+                  <span className="flex flex-col items-center gap-0.5">
+                    <span>{plan.name}</span>
+                    {plan.id === currentPlanId && (
+                      <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                        Current
+                      </span>
+                    )}
+                  </span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            <RowGroup label="Limits" colSpan={plans.length + 1} />
+            {LIMIT_ROWS.map((row) => (
+              <tr key={row.label} className="border-b last:border-0">
+                <td className="px-4 py-2.5 text-left text-muted-foreground">
+                  {row.label}
+                </td>
+                {plans.map((plan) => (
+                  <td
+                    key={plan.id}
+                    className={cn(
+                      'px-4 py-2.5 text-center',
+                      plan.id === currentPlanId && 'bg-muted/30'
+                    )}
+                  >
+                    <Cell value={row.value(plan)} />
+                  </td>
+                ))}
+              </tr>
+            ))}
+
+            <RowGroup label="Features" colSpan={plans.length + 1} />
+            {FEATURE_ROWS.map((row) => (
+              <tr key={row.label} className="border-b last:border-0">
+                <td className="px-4 py-2.5 text-left text-muted-foreground">
+                  {row.label}
+                </td>
+                {plans.map((plan) => {
+                  const value: string | boolean = row.capability
+                    ? planHasCapability(plan.id, row.capability)
+                    : (row.value?.(plan) ?? false)
+                  return (
+                    <td
+                      key={plan.id}
+                      className={cn(
+                        'px-4 py-2.5 text-center',
+                        plan.id === currentPlanId && 'bg-muted/30'
+                      )}
+                    >
+                      <span className="inline-flex items-center justify-center">
+                        <Cell value={value} />
+                      </span>
+                    </td>
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}
+
+function RowGroup({ label, colSpan }: { label: string; colSpan: number }) {
+  return (
+    <tr className="bg-muted/40 border-b">
+      <td
+        colSpan={colSpan}
+        className="px-4 py-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"
+      >
+        {label}
+      </td>
+    </tr>
+  )
+}

--- a/apps/dashboard/src/components/nav-user/clerk-nav.tsx
+++ b/apps/dashboard/src/components/nav-user/clerk-nav.tsx
@@ -43,6 +43,25 @@ import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { SETTINGS_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
 import { isFeatureAllowed } from '@/lib/feature-permissions/shared'
 import { clearUserConnectionsCache } from '@/lib/hooks/use-user-connections'
+import { cn } from '@/lib/utils'
+
+/**
+ * Vivid, brand-accented styling for a paid plan badge so it stands out in the
+ * muted sidebar footer. Pro = amber→orange (brand), Max = violet→fuchsia, any
+ * other paid tier falls back to the solid primary. `free` is never rendered as a
+ * badge (it shows an "Upgrade →" link instead).
+ */
+const PLAN_BADGE_STYLES: Record<string, string> = {
+  pro: 'bg-gradient-to-r from-amber-400 to-orange-500 text-white dark:from-amber-500 dark:to-orange-600',
+  max: 'bg-gradient-to-r from-violet-500 to-fuchsia-500 text-white dark:from-violet-600 dark:to-fuchsia-600',
+}
+
+function planBadgeClassName(plan: string): string {
+  return cn(
+    'border-transparent font-semibold uppercase tracking-wide shadow-sm',
+    PLAN_BADGE_STYLES[plan] ?? 'bg-primary text-primary-foreground'
+  )
+}
 
 /**
  * Clerk-integrated navigation user menu.
@@ -142,39 +161,45 @@ export function ClerkNavWrapper() {
                     </AvatarFallback>
                   </Avatar>
                   <div className="grid flex-1 text-left text-sm leading-tight">
-                    <span
-                      className="truncate font-medium"
-                      data-testid="nav-user-name"
-                    >
-                      {user?.fullName ?? 'User'}
+                    <span className="flex min-w-0 items-center gap-1.5">
+                      <span
+                        className="truncate font-medium"
+                        data-testid="nav-user-name"
+                      >
+                        {user?.fullName ?? 'User'}
+                      </span>
+                      {planLabel && planLabel !== 'free' && (
+                        <Badge
+                          className={cn(
+                            'h-4 shrink-0 cursor-pointer px-1.5 text-[10px]',
+                            planBadgeClassName(planLabel)
+                          )}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            window.location.href = '/billing'
+                          }}
+                          data-testid="nav-user-plan-badge"
+                        >
+                          {planLabel}
+                        </Badge>
+                      )}
                     </span>
                     <span
-                      className="truncate text-xs"
+                      className="truncate text-xs text-muted-foreground"
                       data-testid="nav-user-email"
                     >
                       {user?.primaryEmailAddress?.emailAddress}
                     </span>
-                    {planLabel && (
+                    {planLabel === 'free' && (
                       <span
-                        className="mt-0.5 inline-flex cursor-pointer items-center"
+                        className="mt-0.5 inline-flex w-fit cursor-pointer items-center text-[10px] font-medium text-muted-foreground hover:text-foreground"
                         onClick={(e) => {
                           e.stopPropagation()
                           window.location.href = '/billing'
                         }}
                         data-testid="nav-user-plan-badge"
                       >
-                        {planLabel === 'free' ? (
-                          <span className="text-[10px] text-muted-foreground hover:text-foreground">
-                            Upgrade →
-                          </span>
-                        ) : (
-                          <Badge
-                            variant="secondary"
-                            className="pointer-events-none h-4 px-1.5 text-[10px] capitalize"
-                          >
-                            {planLabel}
-                          </Badge>
-                        )}
+                        Upgrade →
                       </span>
                     )}
                   </div>
@@ -214,10 +239,12 @@ export function ClerkNavWrapper() {
                             </span>
                           </span>
                         )}
-                        {planLabel && (
+                        {planLabel && planLabel !== 'free' && (
                           <Badge
-                            variant="secondary"
-                            className="h-4 px-1.5 text-[10px] capitalize"
+                            className={cn(
+                              'h-4 px-1.5 text-[10px]',
+                              planBadgeClassName(planLabel)
+                            )}
                           >
                             {planLabel}
                           </Badge>
@@ -245,10 +272,12 @@ export function ClerkNavWrapper() {
                       >
                         <CreditCard className="size-4" />
                         <span>Billing & plan</span>
-                        {planLabel && (
+                        {planLabel && planLabel !== 'free' && (
                           <Badge
-                            variant="secondary"
-                            className="ml-auto h-4 px-1.5 text-[10px] capitalize"
+                            className={cn(
+                              'ml-auto h-4 px-1.5 text-[10px]',
+                              planBadgeClassName(planLabel)
+                            )}
                           >
                             {planLabel}
                           </Badge>

--- a/apps/dashboard/src/routes/(dashboard)/billing.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/billing.tsx
@@ -10,6 +10,7 @@ import {
   PlanCard,
   PopularBadge,
 } from '@/components/billing/plan-card'
+import { PlanComparison } from '@/components/billing/plan-comparison'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -149,6 +150,9 @@ function BillingPage() {
           )
         })}
       </div>
+
+      {/* Full benefits matrix */}
+      <PlanComparison currentPlanId={currentPlanId} />
     </div>
   )
 }

--- a/apps/dashboard/src/routes/sign-in.tsx
+++ b/apps/dashboard/src/routes/sign-in.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+// Sign-in is modal-based (Clerk `<SignInButton mode="modal">`), so there is no
+// dedicated sign-in page. A direct visit to /sign-in (a bookmark, a deep link,
+// or Clerk's default redirect-to-sign-in fallback) used to 404. Redirect to the
+// app shell instead: anonymous visitors get the welcome/demo with the sign-in
+// button, signed-in users get the dashboard.
+export const Route = createFileRoute('/sign-in')({
+  beforeLoad: () => {
+    throw redirect({
+      to: '/overview',
+      search: {
+        host: 0,
+      },
+    })
+  },
+})

--- a/apps/dashboard/src/routes/sign-up.tsx
+++ b/apps/dashboard/src/routes/sign-up.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+// Sign-up is modal-based (Clerk `<SignUpButton mode="modal">`), so there is no
+// dedicated sign-up page. A direct visit to /sign-up (or Clerk's default
+// redirect-to-sign-up fallback) used to 404. Redirect to the app shell instead:
+// anonymous visitors get the welcome/demo with the sign-up button.
+export const Route = createFileRoute('/sign-up')({
+  beforeLoad: () => {
+    throw redirect({
+      to: '/overview',
+      search: {
+        host: 0,
+      },
+    })
+  },
+})


### PR DESCRIPTION
## Nav-user footer redesign
The plan badge was a cramped dull-gray third line. Now:
- Badge sits **inline next to the name**; email drops to its own line.
- Paid tiers get a **vivid brand-gradient badge** (Pro = amber→orange, Max = violet→fuchsia, uppercase) via a shared `planBadgeClassName()` helper — applied consistently in the collapsed footer, dropdown header, and "Billing & plan" item.
- Free keeps the subtle "Upgrade →" link.
- Per shadcn rules, styled via `className` + `cn()` at the call site — `ui/badge.tsx` untouched.

## /sign-in + /sign-up routes
Auth is modal-based (no dedicated page), so a direct visit to `/sign-in` (bookmark, deep link, or Clerk's redirect-to-sign-in fallback) **404'd**. Added redirect routes → `/overview` (anon sees welcome/demo with the sign-in button).

Verify on preview: nav footer plan badge + that `/sign-in` no longer 404s.

https://claude.ai/code/session_01DWVGDH6eVShfWqPwXH51RZ