### PR TITLE
fix(billing): route active subscribers to portal for plan changes

### DIFF
--- a/apps/dashboard/src/routes/(dashboard)/billing.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/billing.tsx
@@ -126,6 +126,18 @@ function BillingPage() {
                   <Button variant="outline" className="w-full" disabled>
                     Current plan
                   </Button>
+                ) : paid && hasSubscription ? (
+                  // Active subscribers can't start a fresh checkout (Polar blocks
+                  // it: "You already have an active subscription"). Plan changes
+                  // go through the customer portal, which prorates correctly.
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    onClick={onPortal}
+                    disabled={busy !== null}
+                  >
+                    {busy === 'portal' ? 'Opening…' : `Change to ${plan.name}`}
+                  </Button>
                 ) : paid ? (
                   <Button
                     className="w-full"


### PR DESCRIPTION
A subscribed user clicking "Upgrade to Max" (or any paid tier) started a fresh Polar checkout, which Polar **hard-blocks** with *"You already have an active subscription"* — a dead end (verified on preview sandbox).

Plan changes for active subscribers now open the **customer portal** (Polar prorates upgrade/downgrade there). New/Free users still go through checkout unchanged.

CTA matrix:
- Current plan → "Current plan" (disabled)
- Paid + already subscribed → "Change to {Plan}" → portal
- Paid + free/new → "Upgrade to {Plan}" → checkout
- Enterprise → Contact us · Free → Free forever

https://claude.ai/code/session_01DWVGDH6eVShfWqPwXH51RZ