### PR TITLE
feat(billing): centralize plan limit checks, enrich tiers, add /pricing page

### DIFF
--- a/apps/dashboard/src/components/billing/plan-comparison.tsx
+++ b/apps/dashboard/src/components/billing/plan-comparison.tsx
@@ -43,13 +43,20 @@ function retention(plan: Plan): string {
 
 function aiBudget(plan: Plan): string {
   if (plan.aiMonthlyUsdBudget === null) return 'BYOK'
-  if (plan.id === 'free') return 'Daily trial'
+  if (plan.id === 'free') return `${plan.aiRequestsPerDay}/day trial`
   return `$${plan.aiMonthlyUsdBudget}/mo`
+}
+
+function alertRules(plan: Plan): string {
+  if (plan.alertRules === null) return 'Unlimited'
+  if (plan.alertRules === 0) return '—'
+  return String(plan.alertRules)
 }
 
 const LIMIT_ROWS: LimitRow[] = [
   { label: 'ClickHouse hosts', value: hosts },
   { label: 'Team seats', value: seats },
+  { label: 'Alert rules', value: alertRules },
   { label: 'History retention', value: retention },
   { label: 'AI usage', value: aiBudget },
 ]
@@ -67,6 +74,10 @@ const FEATURE_ROWS: FeatureRow[] = [
           ? 'Basic'
           : false,
   },
+  { label: 'Anomaly detection', capability: 'anomaly_detection' },
+  { label: 'Data export & reports', capability: 'data_export' },
+  { label: 'Custom dashboards', capability: 'custom_dashboards' },
+  { label: 'Webhook integrations', capability: 'webhook_integrations' },
   { label: 'Fleet view', capability: 'fleet_view' },
   { label: 'API / MCP access', capability: 'api_mcp_access' },
   { label: 'SSO / SAML, RBAC, audit logs', capability: 'sso_rbac_audit' },

--- a/apps/dashboard/src/lib/billing/entitlements.test.ts
+++ b/apps/dashboard/src/lib/billing/entitlements.test.ts
@@ -1,0 +1,193 @@
+import {
+  checkAiBudget,
+  checkAiDailyLimit,
+  checkAlertRuleLimit,
+  checkHostLimit,
+  checkSeatLimit,
+  hasCapability,
+  isWithinRetention,
+  limitMessage,
+  retentionCutoffMs,
+} from './entitlements'
+import { BILLING_PLANS, PLAN_IDS } from './plans'
+import { describe, expect, test } from 'bun:test'
+
+const { free, pro, max, enterprise } = BILLING_PLANS
+
+describe('entitlements — host limit', () => {
+  test('Free (1 host): blocks the 2nd, allows the 1st', () => {
+    expect(checkHostLimit(free, 0).allowed).toBe(true)
+    expect(checkHostLimit(free, 1).allowed).toBe(false)
+    expect(checkHostLimit(free, 1).remaining).toBe(0)
+    expect(checkHostLimit(free, 0).remaining).toBe(1)
+  })
+
+  test('Pro (3) and Max (10) honor their caps at the boundary', () => {
+    expect(checkHostLimit(pro, 2).allowed).toBe(true)
+    expect(checkHostLimit(pro, 3).allowed).toBe(false)
+    expect(checkHostLimit(max, 9).allowed).toBe(true)
+    expect(checkHostLimit(max, 10).allowed).toBe(false)
+  })
+
+  test('Enterprise is unlimited', () => {
+    const c = checkHostLimit(enterprise, 9999)
+    expect(c.allowed).toBe(true)
+    expect(c.unlimited).toBe(true)
+    expect(c.limit).toBeNull()
+    expect(c.remaining).toBeNull()
+  })
+
+  test('carries plan identity + reason for the API error shape', () => {
+    const c = checkHostLimit(pro, 3)
+    expect(c.planId).toBe('pro')
+    expect(c.planName).toBe('Pro')
+    expect(c.reason).toBe('host_limit')
+  })
+})
+
+describe('entitlements — seat limit', () => {
+  test('caps match each tier', () => {
+    expect(checkSeatLimit(free, 1).allowed).toBe(false) // 1 seat used == cap
+    expect(checkSeatLimit(pro, 2).allowed).toBe(true)
+    expect(checkSeatLimit(pro, 3).allowed).toBe(false)
+    expect(checkSeatLimit(max, 10).allowed).toBe(false)
+    expect(checkSeatLimit(enterprise, 1_000).allowed).toBe(true)
+  })
+})
+
+describe('entitlements — alert rules', () => {
+  test('Free has zero rules — always blocked', () => {
+    const c = checkAlertRuleLimit(free, 0)
+    expect(c.limit).toBe(0)
+    expect(c.allowed).toBe(false)
+    expect(c.remaining).toBe(0)
+  })
+
+  test('Pro 10 / Max 50 boundaries; Enterprise unlimited', () => {
+    expect(checkAlertRuleLimit(pro, 9).allowed).toBe(true)
+    expect(checkAlertRuleLimit(pro, 10).allowed).toBe(false)
+    expect(checkAlertRuleLimit(max, 49).allowed).toBe(true)
+    expect(checkAlertRuleLimit(max, 50).allowed).toBe(false)
+    expect(checkAlertRuleLimit(enterprise, 9999).allowed).toBe(true)
+  })
+})
+
+describe('entitlements — AI daily trial (Free only)', () => {
+  test('Free caps at 25 requests/day', () => {
+    expect(checkAiDailyLimit(free, 24).allowed).toBe(true)
+    expect(checkAiDailyLimit(free, 25).allowed).toBe(false)
+    expect(checkAiDailyLimit(free, 25).remaining).toBe(0)
+  })
+
+  test('paid tiers have no daily cap (meter on USD budget instead)', () => {
+    for (const plan of [pro, max, enterprise]) {
+      const c = checkAiDailyLimit(plan, 10_000)
+      expect(c.allowed).toBe(true)
+      expect(c.unlimited).toBe(true)
+    }
+  })
+})
+
+describe('entitlements — AI monthly USD budget', () => {
+  test('blocks once the budget is spent', () => {
+    expect(checkAiBudget(free, 0.49).allowed).toBe(true)
+    expect(checkAiBudget(free, 0.5).allowed).toBe(false)
+    expect(checkAiBudget(pro, 4.99).allowed).toBe(true)
+    expect(checkAiBudget(pro, 5).allowed).toBe(false)
+    expect(checkAiBudget(max, 20).allowed).toBe(false)
+  })
+
+  test('remaining budget is reported and never negative', () => {
+    expect(checkAiBudget(pro, 2).remaining).toBe(3)
+    expect(checkAiBudget(pro, 99).remaining).toBe(0)
+  })
+
+  test('Enterprise BYOK is unlimited', () => {
+    const c = checkAiBudget(enterprise, 1_000)
+    expect(c.allowed).toBe(true)
+    expect(c.unlimited).toBe(true)
+  })
+})
+
+describe('entitlements — defensive usage handling', () => {
+  test('negative / NaN usage is treated as zero', () => {
+    expect(checkHostLimit(pro, -5).used).toBe(0)
+    expect(checkHostLimit(pro, Number.NaN).used).toBe(0)
+    expect(checkHostLimit(pro, Number.NaN).allowed).toBe(true)
+  })
+})
+
+describe('entitlements — capability gate', () => {
+  test('reflects the plan ladder', () => {
+    expect(hasCapability(free, 'core_monitoring')).toBe(true)
+    expect(hasCapability(free, 'data_export')).toBe(false)
+    expect(hasCapability(pro, 'data_export')).toBe(true)
+    expect(hasCapability(pro, 'anomaly_detection')).toBe(true)
+    expect(hasCapability(pro, 'fleet_view')).toBe(false)
+    expect(hasCapability(max, 'fleet_view')).toBe(true)
+    expect(hasCapability(max, 'custom_dashboards')).toBe(true)
+    expect(hasCapability(max, 'webhook_integrations')).toBe(true)
+    expect(hasCapability(max, 'sso_rbac_audit')).toBe(false)
+    expect(hasCapability(enterprise, 'sso_rbac_audit')).toBe(true)
+  })
+})
+
+describe('entitlements — retention window', () => {
+  const NOW = 1_700_000_000_000
+
+  test('cutoff is now minus retentionDays', () => {
+    expect(retentionCutoffMs(free, NOW)).toBe(NOW - 7 * 86_400_000)
+    expect(retentionCutoffMs(pro, NOW)).toBe(NOW - 30 * 86_400_000)
+    expect(retentionCutoffMs(max, NOW)).toBe(NOW - 90 * 86_400_000)
+  })
+
+  test('Enterprise (custom retention) has no cutoff', () => {
+    expect(retentionCutoffMs(enterprise, NOW)).toBeNull()
+    expect(isWithinRetention(enterprise, 0, NOW)).toBe(true)
+  })
+
+  test('isWithinRetention respects the window edge', () => {
+    const justInside = NOW - 7 * 86_400_000 + 1
+    const justOutside = NOW - 7 * 86_400_000 - 1
+    expect(isWithinRetention(free, justInside, NOW)).toBe(true)
+    expect(isWithinRetention(free, justOutside, NOW)).toBe(false)
+  })
+})
+
+describe('entitlements — messages', () => {
+  test('every reason produces a non-empty upgrade nudge', () => {
+    const checks = [
+      checkHostLimit(free, 1),
+      checkSeatLimit(free, 1),
+      checkAlertRuleLimit(free, 0),
+      checkAiDailyLimit(free, 25),
+      checkAiBudget(free, 0.5),
+    ]
+    for (const c of checks) {
+      expect(c.allowed).toBe(false)
+      expect(limitMessage(c).length).toBeGreaterThan(0)
+    }
+  })
+
+  test('alert-rule message differs when the plan grants zero rules', () => {
+    expect(limitMessage(checkAlertRuleLimit(free, 0))).toContain(
+      'not available'
+    )
+    expect(limitMessage(checkAlertRuleLimit(pro, 10))).toContain('10 alert')
+  })
+})
+
+describe('entitlements — coverage across all plans', () => {
+  test('each plan exposes a defined value for every metered dimension', () => {
+    for (const id of PLAN_IDS) {
+      const plan = BILLING_PLANS[id]
+      // null is a valid (unlimited) value; undefined would be a bug.
+      expect(plan.hosts !== undefined).toBe(true)
+      expect(plan.seats !== undefined).toBe(true)
+      expect(plan.alertRules !== undefined).toBe(true)
+      expect(plan.aiRequestsPerDay !== undefined).toBe(true)
+      expect(plan.aiMonthlyUsdBudget !== undefined).toBe(true)
+      expect(plan.retentionDays !== undefined).toBe(true)
+    }
+  })
+})

--- a/apps/dashboard/src/lib/billing/entitlements.ts
+++ b/apps/dashboard/src/lib/billing/entitlements.ts
@@ -1,0 +1,173 @@
+/**
+ * Entitlements — the single place that turns a {@link Plan} into yes/no limit
+ * decisions. Every server-side "can this owner do X right now?" check should go
+ * through one of these helpers instead of poking at `plan.hosts` inline, so the
+ * limit semantics (`null` = unlimited, boundary handling, the error shape the
+ * UI reads) stay identical across host caps, seat caps, alert-rule caps, and the
+ * two AI meters (daily request trial + monthly USD budget).
+ *
+ * Pure and synchronous: callers resolve the plan (see `user-subscription.ts`)
+ * and the current usage, then pass both in. OSS/self-host never reaches here —
+ * when auth is `none` everything is authorized and unlimited.
+ */
+
+import type { Plan, PlanCapability, PlanId } from './plans'
+
+import { planHasCapability } from './plans'
+
+/** Stable machine codes surfaced in API error `details.reason`. */
+export type LimitReason =
+  | 'host_limit'
+  | 'seat_limit'
+  | 'alert_rule_limit'
+  | 'ai_daily_limit'
+  | 'ai_budget_limit'
+
+export interface LimitCheck {
+  /** True when the next unit of usage is permitted. */
+  allowed: boolean
+  /** The cap, or null when the plan grants unlimited usage. */
+  limit: number | null
+  /** Usage counted so far (hosts kept, seats taken, USD spent, …). */
+  used: number
+  /** Units left before the cap, or null when unlimited. Never negative. */
+  remaining: number | null
+  /** True when the plan does not cap this dimension at all. */
+  unlimited: boolean
+  reason: LimitReason
+  planId: PlanId
+  planName: string
+}
+
+/**
+ * Core count-based check. `used` is the amount already consumed; the helper asks
+ * "is there room for one more?" — i.e. `used < limit`. A null limit is unlimited.
+ *
+ * For the AI USD budget the "unit" is a dollar and `used` is dollars already
+ * spent; the same `used < limit` test answers "is there budget left to spend?".
+ */
+function checkCount(
+  plan: Plan,
+  used: number,
+  limit: number | null,
+  reason: LimitReason
+): LimitCheck {
+  const safeUsed = Number.isFinite(used) && used > 0 ? used : 0
+  if (limit == null) {
+    return {
+      allowed: true,
+      limit: null,
+      used: safeUsed,
+      remaining: null,
+      unlimited: true,
+      reason,
+      planId: plan.id,
+      planName: plan.name,
+    }
+  }
+  return {
+    allowed: safeUsed < limit,
+    limit,
+    used: safeUsed,
+    remaining: Math.max(0, limit - safeUsed),
+    unlimited: false,
+    reason,
+    planId: plan.id,
+    planName: plan.name,
+  }
+}
+
+/** Can this owner keep one more ClickHouse connection? */
+export function checkHostLimit(plan: Plan, currentHosts: number): LimitCheck {
+  return checkCount(plan, currentHosts, plan.hosts, 'host_limit')
+}
+
+/** Can this owner add one more team seat? */
+export function checkSeatLimit(plan: Plan, currentSeats: number): LimitCheck {
+  return checkCount(plan, currentSeats, plan.seats, 'seat_limit')
+}
+
+/** Can this owner create one more alert rule? (`alertRules: 0` ⇒ never.) */
+export function checkAlertRuleLimit(
+  plan: Plan,
+  currentRules: number
+): LimitCheck {
+  return checkCount(plan, currentRules, plan.alertRules, 'alert_rule_limit')
+}
+
+/**
+ * Free-tier AI agent daily trial cap. Paid tiers have `aiRequestsPerDay: null`
+ * (no daily cap — they meter on the monthly USD budget instead) and are always
+ * allowed by this check.
+ */
+export function checkAiDailyLimit(
+  plan: Plan,
+  requestsToday: number
+): LimitCheck {
+  return checkCount(
+    plan,
+    requestsToday,
+    plan.aiRequestsPerDay,
+    'ai_daily_limit'
+  )
+}
+
+/**
+ * Monthly LLM spend meter. `spentUsd` is what has been spent this billing month;
+ * the check answers "is there budget left?". `aiMonthlyUsdBudget: null` is
+ * Enterprise BYOK / unlimited.
+ */
+export function checkAiBudget(plan: Plan, spentUsd: number): LimitCheck {
+  return checkCount(plan, spentUsd, plan.aiMonthlyUsdBudget, 'ai_budget_limit')
+}
+
+/** A human-readable upgrade nudge for a tripped limit. */
+export function limitMessage(check: LimitCheck): string {
+  const { planName } = check
+  switch (check.reason) {
+    case 'host_limit':
+      return `Your ${planName} plan includes ${check.limit} host${check.limit === 1 ? '' : 's'}. Upgrade your plan to connect more.`
+    case 'seat_limit':
+      return `Your ${planName} plan includes ${check.limit} seat${check.limit === 1 ? '' : 's'}. Upgrade your plan to invite more teammates.`
+    case 'alert_rule_limit':
+      return check.limit === 0
+        ? `Alert rules are not available on the ${planName} plan. Upgrade to start alerting.`
+        : `Your ${planName} plan includes ${check.limit} alert rule${check.limit === 1 ? '' : 's'}. Upgrade your plan to add more.`
+    case 'ai_daily_limit':
+      return `You've reached the ${planName} plan's daily AI limit of ${check.limit} requests. Upgrade for a higher allowance, or try again tomorrow.`
+    case 'ai_budget_limit':
+      return `You've used your ${planName} plan's monthly AI budget of $${check.limit}. Upgrade for a higher allowance, or wait for the next billing cycle.`
+  }
+}
+
+/**
+ * Capability gate. Returns true when the plan unlocks `capability`. Thin wrapper
+ * over {@link planHasCapability} so capability checks and limit checks share one
+ * import surface.
+ */
+export function hasCapability(plan: Plan, capability: PlanCapability): boolean {
+  return planHasCapability(plan.id, capability)
+}
+
+/**
+ * Oldest timestamp (ms epoch) a plan may read history back to. `retentionDays:
+ * null` is custom/unbounded and returns null (no cutoff — caller imposes none).
+ */
+export function retentionCutoffMs(
+  plan: Plan,
+  now: number = Date.now()
+): number | null {
+  if (plan.retentionDays == null) return null
+  return now - plan.retentionDays * 24 * 60 * 60 * 1000
+}
+
+/** Whether a timestamp (ms epoch) is within the plan's retention window. */
+export function isWithinRetention(
+  plan: Plan,
+  timestampMs: number,
+  now: number = Date.now()
+): boolean {
+  const cutoff = retentionCutoffMs(plan, now)
+  if (cutoff == null) return true
+  return timestampMs >= cutoff
+}

--- a/apps/dashboard/src/lib/billing/plans.test.ts
+++ b/apps/dashboard/src/lib/billing/plans.test.ts
@@ -55,4 +55,24 @@ describe('billing plans', () => {
     expect(planHasCapability('max', 'sso_rbac_audit')).toBe(false)
     expect(planHasCapability('enterprise', 'sso_rbac_audit')).toBe(true)
   })
+
+  test('new metered limits are set on every tier', () => {
+    // alert rules: 0 → 10 → 50 → unlimited
+    expect(BILLING_PLANS.free.alertRules).toBe(0)
+    expect(BILLING_PLANS.pro.alertRules).toBe(10)
+    expect(BILLING_PLANS.max.alertRules).toBe(50)
+    expect(BILLING_PLANS.enterprise.alertRules).toBeNull()
+    // daily AI trial caps Free only
+    expect(BILLING_PLANS.free.aiRequestsPerDay).toBe(25)
+    expect(BILLING_PLANS.pro.aiRequestsPerDay).toBeNull()
+  })
+
+  test('new feature capabilities sit on the right tiers', () => {
+    expect(planHasCapability('free', 'data_export')).toBe(false)
+    expect(planHasCapability('pro', 'data_export')).toBe(true)
+    expect(planHasCapability('pro', 'anomaly_detection')).toBe(true)
+    expect(planHasCapability('pro', 'custom_dashboards')).toBe(false)
+    expect(planHasCapability('max', 'custom_dashboards')).toBe(true)
+    expect(planHasCapability('max', 'webhook_integrations')).toBe(true)
+  })
 })

--- a/apps/dashboard/src/lib/billing/plans.ts
+++ b/apps/dashboard/src/lib/billing/plans.ts
@@ -31,7 +31,11 @@ export type PlanCapability =
   | 'ai_insights_scheduled'
   | 'alerting_basic'
   | 'alerting_advanced' // + Slack/PagerDuty
+  | 'data_export' // CSV/JSON export of query results & scheduled reports
+  | 'anomaly_detection' // automated anomaly / regression detection
   | 'fleet_view'
+  | 'custom_dashboards' // saved custom views / dashboards
+  | 'webhook_integrations' // outbound webhooks for alerts & events
   | 'api_mcp_access'
   | 'sso_rbac_audit'
   | 'priority_support'
@@ -49,6 +53,14 @@ export interface Plan {
   hosts: number | null // null = custom/unlimited; the BINDING meter
   /** Monthly LLM spend allowance in USD. null = BYOK / unlimited (Enterprise). */
   aiMonthlyUsdBudget: number | null
+  /**
+   * AI agent requests allowed per day. Used by the Free tier's "daily trial"
+   * cap (the binding meter when there is no monthly USD budget to spend). null =
+   * no daily cap (paid tiers meter on aiMonthlyUsdBudget instead).
+   */
+  aiRequestsPerDay: number | null
+  /** Max number of saved alert rules. 0 = none, null = unlimited (Enterprise). */
+  alertRules: number | null
   /** History retention for conversations / insights. null = custom. */
   retentionDays: number | null
   capabilities: PlanCapability[]
@@ -70,12 +82,14 @@ export const BILLING_PLANS: Record<PlanId, Plan> = {
     seats: 1,
     hosts: 1,
     aiMonthlyUsdBudget: 0.5,
+    aiRequestsPerDay: 25,
+    alertRules: 0,
     retentionDays: 7,
     capabilities: [...CORE, 'ai_agent'],
     highlights: [
       '1 ClickHouse host, 1 seat',
       'Full monitoring dashboard',
-      'AI agent — daily trial limit',
+      'AI agent — 25 requests/day trial',
       '7-day history',
       'Community support',
     ],
@@ -89,18 +103,23 @@ export const BILLING_PLANS: Record<PlanId, Plan> = {
     seats: 3,
     hosts: 3,
     aiMonthlyUsdBudget: 5,
+    aiRequestsPerDay: null,
+    alertRules: 10,
     retentionDays: 30,
     capabilities: [
       ...CORE,
       'ai_agent',
       'ai_insights_scheduled',
       'alerting_basic',
+      'data_export',
+      'anomaly_detection',
     ],
     highlights: [
       'Everything in Free',
       '3 hosts, 3 seats',
       'AI agent + scheduled AI Insights',
-      'Basic alerting',
+      'Basic alerting — up to 10 rules',
+      'Anomaly detection + data export',
       '30-day history',
       'Email support',
     ],
@@ -114,13 +133,19 @@ export const BILLING_PLANS: Record<PlanId, Plan> = {
     seats: 10,
     hosts: 10,
     aiMonthlyUsdBudget: 20,
+    aiRequestsPerDay: null,
+    alertRules: 50,
     retentionDays: 90,
     capabilities: [
       ...CORE,
       'ai_agent',
       'ai_insights_scheduled',
       'alerting_advanced',
+      'data_export',
+      'anomaly_detection',
       'fleet_view',
+      'custom_dashboards',
+      'webhook_integrations',
       'api_mcp_access',
       'priority_support',
     ],
@@ -129,6 +154,7 @@ export const BILLING_PLANS: Record<PlanId, Plan> = {
       '10 hosts, 10 seats',
       'Higher AI usage cap',
       'Fleet view + advanced alerting (Slack, PagerDuty)',
+      'Custom dashboards + webhook integrations',
       'API / MCP access',
       '90-day history',
       'Priority support',
@@ -143,13 +169,19 @@ export const BILLING_PLANS: Record<PlanId, Plan> = {
     seats: null,
     hosts: null,
     aiMonthlyUsdBudget: null, // BYOK / unlimited
+    aiRequestsPerDay: null,
+    alertRules: null, // unlimited
     retentionDays: null,
     capabilities: [
       ...CORE,
       'ai_agent',
       'ai_insights_scheduled',
       'alerting_advanced',
+      'data_export',
+      'anomaly_detection',
       'fleet_view',
+      'custom_dashboards',
+      'webhook_integrations',
       'api_mcp_access',
       'sso_rbac_audit',
       'priority_support',

--- a/apps/dashboard/src/routes/api/v1/user-connections.ts
+++ b/apps/dashboard/src/routes/api/v1/user-connections.ts
@@ -12,6 +12,7 @@ import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-h
 import { createSuccessResponse } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
 import { resolveBillingOwner } from '@/lib/billing/billing-owner'
+import { checkHostLimit, limitMessage } from '@/lib/billing/entitlements'
 import { getPlanForOwner } from '@/lib/billing/user-subscription'
 import { validateHostUrl } from '@/lib/browser-connections/host-url'
 import { queryConnection } from '@/lib/connection-query/connection-client'
@@ -129,15 +130,18 @@ async function handlePost(request: Request): Promise<Response> {
     const plan = await getPlanForOwner(owner.id)
     if (plan.hosts != null) {
       const existing = await store.list(userId)
-      if (existing.length >= plan.hosts) {
+      const check = checkHostLimit(plan, existing.length)
+      if (!check.allowed) {
         return createApiErrorResponse(
           {
             type: ApiErrorType.PermissionError,
-            message: `Your ${plan.name} plan includes ${plan.hosts} host${plan.hosts === 1 ? '' : 's'}. Upgrade your plan to connect more.`,
+            message: limitMessage(check),
             details: {
-              planId: plan.id,
-              limit: plan.hosts,
-              reason: 'host_limit',
+              planId: check.planId,
+              // Non-null inside this `plan.hosts != null` guard; coerce for the
+              // string|number details type (LimitCheck.limit is number | null).
+              limit: check.limit ?? plan.hosts,
+              reason: check.reason,
             },
           },
           402,

--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -15,7 +15,7 @@
             <h5>Product</h5>
             <a href="/#features">Features</a>
             <a href="/#capabilities">Capabilities</a>
-            <a href="/#pricing">Pricing</a>
+            <a href="/pricing">Pricing</a>
             <a href="https://dash.chmonitor.dev" target="_blank" rel="noopener">Dashboard</a>
             <a href="https://blog.chmonitor.dev" target="_blank" rel="noopener">Blog</a>
             <a href="/changelog">Changelog</a>

--- a/apps/landing/src/components/Nav.astro
+++ b/apps/landing/src/components/Nav.astro
@@ -20,7 +20,7 @@
           </div>
         </div>
         <a href="/#open-source">Open source</a>
-        <a href="/#pricing">Pricing</a>
+        <a href="/pricing">Pricing</a>
         <a href="https://docs.chmonitor.dev" target="_blank" rel="noopener">Docs</a>
         <div class="nav-group">
           <button type="button" class="nav-trigger" aria-haspopup="true" aria-expanded="false">

--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -1,97 +1,23 @@
 ---
-// Cloud pricing tiers.
-// ⚠️ Keep price / seats / hosts in sync with the source of truth:
-// apps/dashboard/src/lib/billing/plans.ts (BILLING_PLANS). Yearly = 10× monthly.
+// Cloud pricing tiers. Data is shared with the dedicated /pricing page via
+// src/data/pricing.ts (the single landing-side source). Keep those numbers in
+// sync with apps/dashboard/src/lib/billing/plans.ts. Yearly = 10× monthly.
+import { pricingTiers as tiers } from '../data/pricing'
+
 const checkSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="var(--emerald)" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 5 5L20 7"/></svg>`
 const arrowSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`
 
-interface Tier {
-  name: string
-  badge?: { label: string; cls: string }
-  highlight?: boolean
-  monthly: number | null // null = custom
-  yearlyTotal: number | null
-  yearlyPerMo: number | null
-  tagline: string
-  rows: string[]
-  cta: { label: string; href: string; primary?: boolean }
-}
-
-const tiers: Tier[] = [
-  {
-    name: 'Free',
-    badge: { label: 'Early access', cls: 'ptag-beta' },
-    monthly: 0,
-    yearlyTotal: 0,
-    yearlyPerMo: 0,
-    tagline: 'Try the hosted dashboard, no setup.',
-    rows: [
-      '1 ClickHouse host, 1 seat',
-      'Full monitoring dashboard',
-      'AI agent — daily trial limit',
-      '7-day history',
-      'Community support',
-    ],
-    cta: { label: 'Start free', href: 'https://dash.chmonitor.dev', primary: true },
-  },
-  {
-    name: 'Pro',
-    highlight: true,
-    monthly: 29,
-    yearlyTotal: 290,
-    yearlyPerMo: 24,
-    tagline: 'For a small team running a few clusters.',
-    rows: [
-      'Everything in Free',
-      '3 hosts, 3 seats',
-      'AI agent + scheduled AI Insights',
-      'Basic alerting',
-      '30-day history',
-      'Email support',
-    ],
-    cta: { label: 'Start free', href: 'https://dash.chmonitor.dev', primary: true },
-  },
-  {
-    name: 'Max',
-    monthly: 99,
-    yearlyTotal: 990,
-    yearlyPerMo: 83,
-    tagline: 'For teams operating a fleet of clusters.',
-    rows: [
-      'Everything in Pro',
-      '10 hosts, 10 seats',
-      'Higher AI usage cap',
-      'Fleet view + advanced alerting',
-      'API / MCP access',
-      '90-day history · priority support',
-    ],
-    cta: { label: 'Start free', href: 'https://dash.chmonitor.dev' },
-  },
-  {
-    name: 'Enterprise',
-    monthly: null,
-    yearlyTotal: null,
-    yearlyPerMo: null,
-    tagline: 'For organisations with security & scale needs.',
-    rows: [
-      'Everything in Max',
-      'Unlimited hosts & seats',
-      'Bring-your-own LLM key (BYOK)',
-      'SSO / SAML, RBAC, audit logs',
-      'Custom retention',
-      'SLA & dedicated support',
-    ],
-    cta: { label: 'Contact us', href: 'mailto:hello@chmonitor.dev' },
-  },
-]
+const { compact = false } = Astro.props
 ---
 <section id="pricing" class="band">
   <div class="wrap">
+    {!compact && (
     <div class="sec-head reveal" style="text-align:center">
       <span class="eyebrow">Pricing</span>
       <h2>Self-host free. Cloud for teams.</h2>
       <p>chmonitor is open source — self-hosting is always free under GPL-3.0. The hosted cloud connects a cluster without any setup. Cloud pricing is not finalised; <strong>early access is free to try</strong> and seats are limited.</p>
     </div>
+    )}
 
     <!-- Self-host: always free -->
     <div class="selfhost-banner reveal">
@@ -166,6 +92,14 @@ const tiers: Tier[] = [
         </div>
       ))}
     </div>
+
+    {!compact && (
+    <div class="compare-link reveal" style="text-align:center;margin-top:26px">
+      <a class="btn btn-ghost" href="/pricing">
+        Compare all plans &amp; features <span set:html={arrowSvg} />
+      </a>
+    </div>
+    )}
 
     <div class="callout reveal" style="margin-top:28px">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16h.01"/></svg>

--- a/apps/landing/src/data/pricing.ts
+++ b/apps/landing/src/data/pricing.ts
@@ -1,0 +1,199 @@
+/**
+ * Landing-side pricing data — the single source for the Pricing section AND the
+ * dedicated /pricing page (cards, comparison matrix, FAQ), so they can never
+ * drift from each other.
+ *
+ * ⚠️ These numbers MUST stay identical to the real source of truth:
+ * apps/dashboard/src/lib/billing/plans.ts (BILLING_PLANS). The landing app is a
+ * standalone, dependency-light Astro app and cannot import that module without
+ * dragging app deps in, so the values are mirrored here by hand. When you change
+ * a price / seat / host / limit / capability in plans.ts, update this file too.
+ */
+
+export interface PricingTier {
+  name: string
+  badge?: { label: string; cls: string }
+  highlight?: boolean
+  monthly: number | null // null = custom
+  yearlyTotal: number | null
+  yearlyPerMo: number | null
+  tagline: string
+  rows: string[]
+  cta: { label: string; href: string; primary?: boolean }
+}
+
+const DASH = 'https://dash.chmonitor.dev'
+
+export const pricingTiers: PricingTier[] = [
+  {
+    name: 'Free',
+    badge: { label: 'Early access', cls: 'ptag-beta' },
+    monthly: 0,
+    yearlyTotal: 0,
+    yearlyPerMo: 0,
+    tagline: 'Try the hosted dashboard, no setup.',
+    rows: [
+      '1 ClickHouse host, 1 seat',
+      'Full monitoring dashboard',
+      'AI agent — 25 requests/day trial',
+      '7-day history',
+      'Community support',
+    ],
+    cta: { label: 'Start free', href: DASH, primary: true },
+  },
+  {
+    name: 'Pro',
+    highlight: true,
+    monthly: 29,
+    yearlyTotal: 290,
+    yearlyPerMo: 24,
+    tagline: 'For a small team running a few clusters.',
+    rows: [
+      'Everything in Free',
+      '3 hosts, 3 seats',
+      'AI agent + scheduled AI Insights',
+      'Basic alerting — up to 10 rules',
+      'Anomaly detection + data export',
+      '30-day history',
+      'Email support',
+    ],
+    cta: { label: 'Start free', href: DASH, primary: true },
+  },
+  {
+    name: 'Max',
+    monthly: 99,
+    yearlyTotal: 990,
+    yearlyPerMo: 83,
+    tagline: 'For teams operating a fleet of clusters.',
+    rows: [
+      'Everything in Pro',
+      '10 hosts, 10 seats',
+      'Higher AI usage cap',
+      'Fleet view + advanced alerting',
+      'Custom dashboards + webhooks',
+      'API / MCP access · 50 alert rules',
+      '90-day history · priority support',
+    ],
+    cta: { label: 'Start free', href: DASH },
+  },
+  {
+    name: 'Enterprise',
+    monthly: null,
+    yearlyTotal: null,
+    yearlyPerMo: null,
+    tagline: 'For organisations with security & scale needs.',
+    rows: [
+      'Everything in Max',
+      'Unlimited hosts & seats',
+      'Bring-your-own LLM key (BYOK)',
+      'SSO / SAML, RBAC, audit logs',
+      'Custom retention',
+      'SLA & dedicated support',
+    ],
+    cta: { label: 'Contact us', href: 'mailto:hello@chmonitor.dev' },
+  },
+]
+
+/** A comparison cell: true (✓), false (—), or a literal string. */
+export type CompareCell = boolean | string
+
+export interface CompareRow {
+  label: string
+  /** [Free, Pro, Max, Enterprise] */
+  values: [CompareCell, CompareCell, CompareCell, CompareCell]
+}
+
+export interface CompareGroup {
+  group: string
+  rows: CompareRow[]
+}
+
+/** Plan column order for the matrix header. */
+export const compareColumns = ['Free', 'Pro', 'Max', 'Enterprise'] as const
+
+export const compareGroups: CompareGroup[] = [
+  {
+    group: 'Limits',
+    rows: [
+      { label: 'ClickHouse hosts', values: ['1', '3', '10', 'Unlimited'] },
+      { label: 'Team seats', values: ['1', '3', '10', 'Unlimited'] },
+      { label: 'Alert rules', values: ['—', '10', '50', 'Unlimited'] },
+      {
+        label: 'History retention',
+        values: ['7 days', '30 days', '90 days', 'Custom'],
+      },
+      {
+        label: 'AI usage',
+        values: ['25/day trial', '$5/mo', '$20/mo', 'BYOK'],
+      },
+    ],
+  },
+  {
+    group: 'Features',
+    rows: [
+      {
+        label: 'Full monitoring dashboard',
+        values: [true, true, true, true],
+      },
+      { label: 'AI agent', values: [true, true, true, true] },
+      {
+        label: 'Scheduled AI Insights',
+        values: [false, true, true, true],
+      },
+      {
+        label: 'Alerting',
+        values: [false, 'Basic', 'Advanced', 'Advanced'],
+      },
+      { label: 'Anomaly detection', values: [false, true, true, true] },
+      { label: 'Data export & reports', values: [false, true, true, true] },
+      { label: 'Custom dashboards', values: [false, false, true, true] },
+      { label: 'Webhook integrations', values: [false, false, true, true] },
+      { label: 'Fleet view', values: [false, false, true, true] },
+      { label: 'API / MCP access', values: [false, false, true, true] },
+      {
+        label: 'SSO / SAML, RBAC, audit logs',
+        values: [false, false, false, true],
+      },
+      {
+        label: 'Support',
+        values: ['Community', 'Email', 'Priority', 'SLA + dedicated'],
+      },
+    ],
+  },
+]
+
+export interface PricingFaq {
+  q: string
+  a: string
+}
+
+export const pricingFaqs: PricingFaq[] = [
+  {
+    q: 'Is self-hosting really free?',
+    a: 'Yes. chmonitor is open source under GPL-3.0. Run it on your own infrastructure (Docker, Cloudflare Workers, Kubernetes) with every feature, unlimited clusters, and your data never leaving your network — at no cost, forever.',
+  },
+  {
+    q: "What's a “host”?",
+    a: 'A host is a single ClickHouse connection (one cluster endpoint). Your plan caps how many hosts you can connect to the hosted dashboard at once. Self-hosting has no host limit.',
+  },
+  {
+    q: 'How does AI usage metering work?',
+    a: 'The Free plan includes a daily trial allowance of AI agent requests. Paid plans get a monthly LLM spend budget instead (Pro $5/mo, Max $20/mo). Enterprise brings its own LLM key (BYOK) for unlimited usage.',
+  },
+  {
+    q: 'What happens when I hit a plan limit?',
+    a: 'Limits fail gracefully — you keep full access to everything already in use and see a clear prompt to upgrade. Nothing is deleted or interrupted; you simply cannot add beyond the cap until you upgrade.',
+  },
+  {
+    q: 'Can I change plans or cancel anytime?',
+    a: 'Yes. Upgrade, downgrade, or cancel from the in-app billing portal at any time. Paid access continues until the end of the period you have already paid for, then cleanly returns to Free.',
+  },
+  {
+    q: 'Is annual billing cheaper?',
+    a: 'Yes — annual billing is 10× the monthly price, so you get roughly two months free versus paying month to month.',
+  },
+  {
+    q: 'Do you read or write my data?',
+    a: 'chmonitor only reads from ClickHouse system tables and never writes to your data. Connect with a least-privilege SELECT-only user for maximum safety.',
+  },
+]

--- a/apps/landing/src/pages/pricing.astro
+++ b/apps/landing/src/pages/pricing.astro
@@ -1,0 +1,140 @@
+---
+import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import Pricing from '../components/Pricing.astro'
+import FinalCta from '../components/FinalCta.astro'
+import Footer from '../components/Footer.astro'
+import { compareColumns, compareGroups, pricingFaqs } from '../data/pricing'
+
+const checkSvg = `<svg class="cmp-yes" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;display:inline-block;vertical-align:middle"><path d="m5 12 5 5L20 7"/></svg>`
+const crossSvg = `<svg class="cmp-no" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;display:inline-block;vertical-align:middle"><path d="m18 6-12 12M6 6l12 12"/></svg>`
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: pricingFaqs.map((f) => ({
+    '@type': 'Question',
+    name: f.q,
+    acceptedAnswer: { '@type': 'Answer', text: f.a },
+  })),
+}
+---
+<Base
+  title="Pricing, chmonitor"
+  description="chmonitor pricing — self-host free under GPL-3.0, or use the hosted cloud. Compare Free, Pro, Max and Enterprise plans, limits and features side by side."
+>
+  <Nav />
+  <main id="top">
+    <!-- Page header -->
+    <section class="band" style="padding-bottom:0">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">Pricing</span>
+          <h2>Simple pricing that scales with your fleet</h2>
+          <p>Self-hosting is always free under GPL-3.0. The hosted cloud connects a cluster in minutes — start free, upgrade when your team grows. <strong>Early access is free to try</strong> while in beta.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Plan cards (shared section, compact: no duplicate header) -->
+    <Pricing compact={true} />
+
+    <!-- Full feature comparison matrix -->
+    <section id="compare" class="band band-soft">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">Compare</span>
+          <h2>Every plan, side by side</h2>
+          <p>Limits and features across all four tiers. Self-hosting includes everything, with no caps.</p>
+        </div>
+
+        <div class="cmp-wrap reveal">
+          <div class="cmp-scroll">
+            <table class="cmp-table price-cmp">
+              <thead>
+                <tr>
+                  <th></th>
+                  {compareColumns.map((c) => (
+                    <th class={c === 'Pro' ? 'cmp-highlight' : ''}>{c}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {compareGroups.map((g) => (
+                  <>
+                    <tr class="cmp-group">
+                      <td colspan={compareColumns.length + 1}>{g.group}</td>
+                    </tr>
+                    {g.rows.map((row) => (
+                      <tr>
+                        <td>{row.label}</td>
+                        {row.values.map((v, i) => (
+                          <td class={compareColumns[i] === 'Pro' ? 'cmp-highlight' : ''}>
+                            {v === true ? (
+                              <span set:html={checkSvg} />
+                            ) : v === false ? (
+                              <span set:html={crossSvg} />
+                            ) : (
+                              <span class="cmp-val">{v}</span>
+                            )}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <p class="cmp-note reveal">All paid plans include the full monitoring dashboard. <a href="https://docs.chmonitor.dev" target="_blank" rel="noopener">Self-host</a> for unlimited everything, free forever.</p>
+      </div>
+    </section>
+
+    <!-- Pricing FAQ -->
+    <section id="pricing-faq" class="band">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">FAQ</span>
+          <h2>Pricing questions</h2>
+        </div>
+        <div class="pfaq reveal">
+          {pricingFaqs.map((f) => (
+            <details class="pfaq-item">
+              <summary>
+                {f.q}
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+              </summary>
+              <div class="pfaq-a">{f.a}</div>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <FinalCta />
+  </main>
+  <Footer />
+
+  <script type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} is:inline />
+
+  <style>
+    .price-cmp .cmp-yes{stroke:var(--emerald)}
+    .price-cmp .cmp-no{stroke:var(--muted-fg);opacity:.45}
+    .price-cmp .cmp-val{font-size:13px;font-weight:600}
+    .price-cmp td,.price-cmp th{text-align:center}
+    .price-cmp td:first-child,.price-cmp th:first-child{text-align:left}
+    .price-cmp .cmp-group td{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;color:var(--muted-fg);background:var(--card-soft, rgba(127,127,127,.06));padding-top:14px}
+    .cmp-note{margin-top:20px;text-align:center;font-size:13px;color:var(--muted-fg)}
+    .cmp-note a{color:var(--orange);text-decoration:underline;text-underline-offset:3px}
+
+    .pfaq{max-width:760px;margin:36px auto 0;display:flex;flex-direction:column;gap:10px}
+    .pfaq-item{border:1px solid var(--border);border-radius:var(--radius);background:var(--card);overflow:hidden}
+    .pfaq-item summary{display:flex;align-items:center;justify-content:space-between;gap:16px;cursor:pointer;padding:16px 20px;font-weight:600;font-size:15px;list-style:none}
+    .pfaq-item summary::-webkit-details-marker{display:none}
+    .pfaq-item summary svg{width:18px;height:18px;flex-shrink:0;transition:transform .2s ease;color:var(--muted-fg)}
+    .pfaq-item[open] summary svg{transform:rotate(180deg)}
+    .pfaq-a{padding:0 20px 18px;font-size:14px;line-height:1.6;color:var(--muted-fg);text-wrap:pretty}
+  </style>
+</Base>

--- a/docs/knowledge/cloud-saas-mode.md
+++ b/docs/knowledge/cloud-saas-mode.md
@@ -3,7 +3,7 @@ id: cloud-saas-mode
 title: Cloud (SaaS) mode — one codebase, two products
 type: spec
 status: active
-updated: 2026-06-29
+updated: 2026-06-30
 tags:
   - saas
   - cloud
@@ -83,8 +83,18 @@ Docs: `docs/content/guide/guides/connection-errors.mdx` (slug
 M3 wires paid plans via [Polar](https://polar.sh). Cloud-only; OSS/self-host is
 free forever (auth `none` ⇒ unlimited, plans inert).
 
-- **Plans**: `lib/billing/plans.ts` (`BILLING_PLANS`) is the price/capability
-  source of truth; `apps/landing/Pricing.astro` mirrors the numbers.
+- **Plans**: `lib/billing/plans.ts` (`BILLING_PLANS`) is the price/capability/
+  limit source of truth (hosts, seats, `alertRules`, `aiRequestsPerDay` daily
+  trial, `aiMonthlyUsdBudget`, `retentionDays`, `capabilities`). The landing app
+  mirrors the numbers via `apps/landing/src/data/pricing.ts` (shared by
+  `Pricing.astro` + the dedicated `/pricing` page).
+- **Entitlements**: `lib/billing/entitlements.ts` is the single place that turns
+  a `Plan` into yes/no limit decisions — `checkHostLimit` / `checkSeatLimit` /
+  `checkAlertRuleLimit` / `checkAiDailyLimit` / `checkAiBudget` (all `null` =
+  unlimited, return a `LimitCheck` with the API error shape), plus
+  `hasCapability`, `retentionCutoffMs` / `isWithinRetention`, and `limitMessage`
+  for the upgrade nudge. Server limit checks go through here, never `plan.hosts`
+  inline. Fully unit-tested in `entitlements.test.ts` (every plan × every limit).
 - **Config**: `lib/billing/polar-config.ts` — `getPolarClient()` (server
   `sandbox|production` from `CHM_POLAR_SERVER`) + product↔plan mapping from
   `CHM_POLAR_PRODUCT_<PLAN>_<PERIOD>` env vars. Product ids live in env (sandbox
@@ -97,8 +107,10 @@ free forever (auth `none` ⇒ unlimited, plans inert).
 - **Routes**: `api/v1/billing/checkout` (hosted checkout, `externalCustomerId =
   Clerk userId` ⇒ no customer map), `…/portal`, `…/subscription` (GET),
   `api/v1/webhooks/polar` (verifies via `validateEvent` over the RAW body).
-- **Enforcement**: `api/v1/user-connections` POST returns 402 at `plan.hosts`
-  (null = unlimited).
+- **Enforcement**: `api/v1/user-connections` POST returns 402 via
+  `checkHostLimit(plan, count)` + `limitMessage(check)` (null = unlimited). New
+  metered surfaces (alerts, AI) should reuse the matching `entitlements.ts`
+  helper for consistent boundary + error semantics.
 - **UI**: `routes/(dashboard)/billing.tsx`, gated to cloud mode in
   `app-sidebar.tsx`; `feature: 'billing'`.
 - **Setup**: `apps/dashboard/scripts/polar-setup.ts` creates Pro/Max


### PR DESCRIPTION
## Summary

Makes every cloud plan limit enforceable and testable through one module (not just the inline host check), enriches each tier with more features, and adds a dedicated `/pricing` page to the landing site with a full feature-comparison matrix and FAQ.

## Changes

**Plan limits — centralized & fully tested**
- New `lib/billing/entitlements.ts` — the single place that turns a `Plan` into yes/no decisions: `checkHostLimit`, `checkSeatLimit`, `checkAlertRuleLimit`, `checkAiDailyLimit`, `checkAiBudget` (all `null` = unlimited, shared `LimitCheck` shape with the API error fields + boundary handling), plus `hasCapability`, `retentionCutoffMs` / `isWithinRetention`, and `limitMessage` for the upgrade nudge.
- New `lib/billing/entitlements.test.ts` — covers **every plan × every limit**: boundaries (at/over/under the cap), unlimited (Enterprise), defensive `NaN`/negative usage, the retention window edges, and that every tripped limit yields a message.
- `routes/api/v1/user-connections.ts` POST now enforces via `checkHostLimit` + `limitMessage` instead of poking `plan.hosts` inline.

**Enriched plans (more features per tier)**
- New capabilities: `data_export`, `anomaly_detection` (Pro+), `custom_dashboards`, `webhook_integrations` (Max+).
- New metered limits on every tier: `alertRules` (0 / 10 / 50 / unlimited) and `aiRequestsPerDay` (Free daily trial = 25). Highlights, `plans.test.ts`, and the dashboard `plan-comparison.tsx` matrix updated to match.

**Landing — dedicated pricing page**
- New `apps/landing/src/pages/pricing.astro`: plan cards (shared section in compact mode) + full feature-comparison matrix + pricing FAQ (with `FAQPage` JSON-LD).
- Pricing data extracted to `apps/landing/src/data/pricing.ts` so the home section and the new page can never drift; `Pricing.astro` consumes it and gains a "Compare all plans & features" link. `Nav`/`Footer` now point to `/pricing`.

**Docs**
- `docs/knowledge/cloud-saas-mode.md` updated to document the entitlements module and the new limit fields.

## Test plan

- [x] `bun test src/lib/billing/` — 29 pass (plans + entitlements)
- [x] `bun run type-check` clean for all changed files (remaining errors are the pre-existing missing-`routeTree.gen.ts` environmental ones, generated during CI build)
- [x] `apps/landing` `bun run build` passes — `/pricing` generated
- [x] Biome clean on changed files
- [ ] CI full `bun run lint` + `bun run build`

## Notes for reviewer

- OSS/self-host is unaffected: when auth is `none` everything is unlimited and these checks are inert (cloud-mode only).
- The landing app stays dependency-light; `src/data/pricing.ts` mirrors `BILLING_PLANS` by hand (it can't import app modules). Numbers must stay in sync — both are noted in comments.
- Only the host limit is wired to an endpoint today; the seat/alert/AI helpers are ready for the surfaces that meter them next, with identical semantics.

---

Co-Authored-By: duyetbot <bot@duyet.net>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6zwZbtVtG9mmKzNtQ2RxV)_