### PR TITLE
fix(blog): change v0.3 post URL to /v0.3/

### DIFF
--- a/apps/blog/README.md
+++ b/apps/blog/README.md
@@ -32,7 +32,7 @@ draft: false          # optional — true hides it from the build
 ---
 ```
 
-The post URL is the file slug (e.g. `chmonitor-v0-3.md` → `/chmonitor-v0-3`).
+The post URL comes from the `version` frontmatter when set (e.g. `version: v0.3` → `/v0.3/`), falling back to the file slug otherwise. See `src/lib/slug.ts`.
 
 ### Embedding video
 

--- a/apps/blog/src/lib/slug.ts
+++ b/apps/blog/src/lib/slug.ts
@@ -1,0 +1,9 @@
+import type { CollectionEntry } from 'astro:content'
+
+// The public URL slug for a post. We prefer the explicit `version` frontmatter
+// (e.g. "v0.3" → /v0.3/) over the glob-loader `id`, because Astro slugifies the
+// filename and would strip the dot (v0.3 → v0-3). Falls back to `id` for posts
+// without a version.
+export function postSlug(post: CollectionEntry<'blog'>): string {
+  return post.data.version ?? post.id
+}

--- a/apps/blog/src/pages/[...slug].astro
+++ b/apps/blog/src/pages/[...slug].astro
@@ -3,10 +3,11 @@ import { getCollection, render } from 'astro:content'
 import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'
 import Footer from '../components/Footer.astro'
+import { postSlug } from '../lib/slug'
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data }) => !data.draft)
-  return posts.map((post) => ({ params: { slug: post.id }, props: { post } }))
+  return posts.map((post) => ({ params: { slug: postSlug(post) }, props: { post } }))
 }
 
 const { post } = Astro.props

--- a/apps/blog/src/pages/index.astro
+++ b/apps/blog/src/pages/index.astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content'
 import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'
 import Footer from '../components/Footer.astro'
+import { postSlug } from '../lib/slug'
 
 const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
   (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
@@ -25,7 +26,7 @@ function fmtDate(d: Date) {
     <section class="wrap">
       <div class="post-list">
         {posts.map((post) => (
-          <a class="post-card" href={`/${post.id}/`}>
+          <a class="post-card" href={`/${postSlug(post)}/`}>
             <div class="post-meta">
               <span class="post-tag">{post.data.version ?? post.data.tag}</span>
               <span class="post-date">{fmtDate(post.data.date)}</span>


### PR DESCRIPTION
Changes the v0.3 release post URL from `/chmonitor-v0-3/` → `/v0.3/`.

## What
- New `src/lib/slug.ts` — `postSlug()` derives the URL from the `version` frontmatter (`v0.3`), falling back to the glob-loader `id`.
- `[...slug].astro` route and `index.astro` card link both use the shared helper, so they can't drift.
- README updated.

## Why
Astro's `glob` loader slugifies filenames, so a `v0.3.md` file would emit `/v0-3/` (dot stripped). Deriving from frontmatter preserves the literal dot.

## Verify
Local `astro build` emits `dist/v0.3/index.html`; old `/chmonitor-v0-3/` route is gone. Sitemap regenerates automatically.

https://claude.ai/code/session_01QQzUGeMAJGhto3XXao35N7