### PR TITLE
fix(billing): route active subscribers to portal for plan changes

### DIFF
--- a/apps/dashboard/src/routes/(dashboard)/billing.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/billing.tsx
@@ -126,6 +126,18 @@ function BillingPage() {
                   <Button variant="outline" className="w-full" disabled>
                     Current plan
                   </Button>
+                ) : paid && hasSubscription ? (
+                  // Active subscribers can't start a fresh checkout (Polar blocks
+                  // it: "You already have an active subscription"). Plan changes
+                  // go through the customer portal, which prorates correctly.
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    onClick={onPortal}
+                    disabled={busy !== null}
+                  >
+                    {busy === 'portal' ? 'Opening…' : `Change to ${plan.name}`}
+                  </Button>
                 ) : paid ? (
                   <Button
                     className="w-full"


### PR DESCRIPTION
## Problem
A subscribed user clicking "Upgrade to Max" (or any other paid tier) started a fresh Polar checkout, which Polar hard-blocks with *"You already have an active subscription"* — a dead end.

## Fix
Plan changes for active subscribers now open the **customer portal** (Polar prorates the upgrade/downgrade there). New/Free users still go through checkout as before.

Single-file change in `billing.tsx`: when `paid && hasSubscription`, render a "Change to {plan}" button wired to `onPortal` instead of the checkout button.

## Context
Follow-up to the Polar billing work (PRs #2018/#2019/#2022). See the `polar-org-billing-handoff` notes.

https://claude.ai/code/session_01QQzUGeMAJGhto3XXao35N7