### PR TITLE
perf(billing): negative-cache free users' Polar entitlement reads

### DIFF
--- a/apps/dashboard/src/lib/billing/polar-subscription.test.ts
+++ b/apps/dashboard/src/lib/billing/polar-subscription.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+
+// Mock polar-config so we can drive getStateExternal and count calls. Billing is
+// "configured" so the function doesn't early-return.
+let getStateExternal = mock(async (_args: { externalId: string }) => ({
+  activeSubscriptions: [] as Array<{
+    productId: string
+    status: string
+    currentPeriodEnd: string | null
+    cancelAtPeriodEnd: boolean
+  }>,
+}))
+
+mock.module('./polar-config', () => ({
+  isBillingConfigured: () => true,
+  getPolarClient: () => ({ customers: { getStateExternal } }),
+  planForProductId: (productId: string) =>
+    productId === 'prod_pro'
+      ? { planId: 'pro', period: 'monthly' as const }
+      : null,
+}))
+
+const {
+  pullOwnerSubscriptionFromPolar,
+  __resetPolarSubscriptionCacheForTests,
+} = await import('./polar-subscription')
+
+afterEach(() => {
+  __resetPolarSubscriptionCacheForTests()
+  getStateExternal.mockClear()
+})
+
+describe('pullOwnerSubscriptionFromPolar negative cache', () => {
+  test('a 404 (no customer) is cached — second read skips Polar', async () => {
+    getStateExternal = mock(async () => {
+      throw Object.assign(new Error('not found'), { statusCode: 404 })
+    })
+
+    const first = await pullOwnerSubscriptionFromPolar('user_free')
+    const second = await pullOwnerSubscriptionFromPolar('user_free')
+
+    expect(first).toBeNull()
+    expect(second).toBeNull()
+    // Only the first read hit Polar; the second was served from the negative cache.
+    expect(getStateExternal).toHaveBeenCalledTimes(1)
+  })
+
+  test('a transient error is NOT cached — it retries Polar next read', async () => {
+    getStateExternal = mock(async () => {
+      throw Object.assign(new Error('upstream'), { statusCode: 503 })
+    })
+
+    await pullOwnerSubscriptionFromPolar('user_blip')
+    await pullOwnerSubscriptionFromPolar('user_blip')
+
+    // Both reads must reach Polar — caching a blip would strand a real sub.
+    expect(getStateExternal).toHaveBeenCalledTimes(2)
+  })
+
+  test('a paid user is never negatively cached — every read reaches Polar', async () => {
+    getStateExternal = mock(async () => ({
+      activeSubscriptions: [
+        {
+          productId: 'prod_pro',
+          status: 'active',
+          currentPeriodEnd: '2026-12-31T00:00:00Z',
+          cancelAtPeriodEnd: false,
+        },
+      ],
+    }))
+
+    const first = await pullOwnerSubscriptionFromPolar('user_pro')
+    const second = await pullOwnerSubscriptionFromPolar('user_pro')
+
+    expect(first?.planId).toBe('pro')
+    expect(second?.planId).toBe('pro')
+    // A positive result must never short-circuit a later read (no false "free").
+    expect(getStateExternal).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/dashboard/src/lib/billing/polar-subscription.ts
+++ b/apps/dashboard/src/lib/billing/polar-subscription.ts
@@ -48,6 +48,63 @@ function toUnixSeconds(value: Date | string | null | undefined): number | null {
 }
 
 /**
+ * Negative cache: externalIds Polar has confirmed have no active subscription
+ * (free users / no Polar customer). Without it, every entitlement read for a
+ * free user round-trips to Polar and 404s — the common case on a cloud deploy.
+ *
+ * Per-isolate and best-effort: the map lives only for the Worker isolate's
+ * lifetime, which is plenty to collapse the burst of reads a single page load
+ * fans out. A positive result clears the entry immediately (the user upgraded),
+ * and transient API failures are NOT cached — only a definitive "no customer /
+ * no active sub" — so a Polar blip never hides a real subscription.
+ */
+const NEGATIVE_TTL_MS = 60_000
+const NEGATIVE_CACHE_MAX = 1000
+const noActiveSubUntil = new Map<string, number>()
+
+function hasFreshNegative(externalId: string): boolean {
+  const until = noActiveSubUntil.get(externalId)
+  if (until === undefined) return false
+  if (until > Date.now()) return true
+  noActiveSubUntil.delete(externalId)
+  return false
+}
+
+function rememberNoActiveSub(externalId: string): void {
+  // Bound memory: drop expired entries before growing past the cap.
+  if (noActiveSubUntil.size >= NEGATIVE_CACHE_MAX) {
+    const now = Date.now()
+    for (const [id, until] of noActiveSubUntil) {
+      if (until <= now) noActiveSubUntil.delete(id)
+    }
+  }
+  noActiveSubUntil.set(externalId, Date.now() + NEGATIVE_TTL_MS)
+}
+
+/** True when the error is Polar's 404 "no customer for this externalId". */
+function isResourceNotFound(error: unknown): boolean {
+  const e = error as
+    | {
+        statusCode?: number
+        status?: number
+        response?: { status?: number }
+        name?: string
+      }
+    | null
+    | undefined
+  const status = e?.statusCode ?? e?.status ?? e?.response?.status
+  if (status === 404) return true
+  return (
+    typeof e?.name === 'string' && e.name.toLowerCase().includes('notfound')
+  )
+}
+
+/** Test-only: clear the negative cache so cases don't leak state across tests. */
+export function __resetPolarSubscriptionCacheForTests(): void {
+  noActiveSubUntil.clear()
+}
+
+/**
  * The owner's current paid subscription per Polar, or null when they have none
  * (free), Polar is not configured, or the call fails (caller falls back to the
  * D1 cache / free). When several active subscriptions exist, the highest plan
@@ -57,6 +114,9 @@ export async function pullOwnerSubscriptionFromPolar(
   externalId: string
 ): Promise<OwnerSubscription | null> {
   if (!isBillingConfigured()) return null
+  // Free users (no Polar customer) would otherwise 404 against Polar on every
+  // read — short-circuit those for a minute.
+  if (hasFreshNegative(externalId)) return null
   try {
     const state = await getPolarClient().customers.getStateExternal({
       externalId,
@@ -82,10 +142,14 @@ export async function pullOwnerSubscriptionFromPolar(
         best = candidate
       }
     }
+    if (best) noActiveSubUntil.delete(externalId)
+    else rememberNoActiveSub(externalId)
     return best
-  } catch {
-    // 404 ResourceNotFound (no Polar customer for this externalId yet) or a
-    // transient API error — treat as "no live subscription"; caller falls back.
+  } catch (error) {
+    // A definitive 404 (no Polar customer for this externalId yet) is cacheable
+    // as "free". A transient API error is NOT — caching it would hide a real
+    // subscription for the TTL — so only the 404 path remembers.
+    if (isResourceNotFound(error)) rememberNoActiveSub(externalId)
     return null
   }
 }


### PR DESCRIPTION
## Problem
Free cloud users have no Polar customer, so every entitlement read 404s against Polar's `getStateExternal`. On a cloud deploy that's the common case — a single page load fans out several reads, each a wasted Polar round-trip + 404. (Follow-up flagged in the `billing-d1-polar-pull` notes.)

## Change
A per-isolate negative cache in `polar-subscription.ts`:
- 60s TTL (matches the client React Query `staleTime`), bounded to 1000 entries with opportunistic expiry pruning.
- Remembers "no active subscription" and short-circuits repeat reads.

## Safety (why this can't strand a paying user)
- **Only definitive results are cached**: a 404 (no customer) or a successful empty response. **Transient API errors are never cached** — a Polar blip can't hide a real subscription.
- A **positive result clears** the entry immediately.
- **Fresh upgrades are unaffected**: `resolveOwnerSubscription` is D1-first (webhook-populated), so the Polar pull + this cache only ever serve genuinely-free / cold-D1 owners — and only for ≤60s.

## Tests
`polar-subscription.test.ts` (new): 404 is cached (2nd read skips Polar); transient error is **not** cached (retries); a paid user is never negatively cached. Full billing suite: 32 pass.

https://claude.ai/code/session_01QQzUGeMAJGhto3XXao35N7