### PR TITLE
ci(deploy): apply chm-cloud D1 migrations before production deploy

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -185,6 +185,21 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: bunx wrangler deploy --minify
 
+      - name: Apply D1 migrations (production)
+        # Bring the chm-cloud D1 schema up to date BEFORE the new worker goes
+        # live, so a cold/behind database can't 500 the billing webhook or block
+        # per-user connections (the incident behind migrations 0001–0004).
+        # Idempotent: wrangler records applied migrations in the d1_migrations
+        # ledger, so re-running every deploy is a no-op once applied. The
+        # migrations here are additive (CREATE TABLE), safe to apply pre-deploy.
+        # Production only — never from a PR, which could push an unmerged
+        # migration to the shared preview/prod D1.
+        if: github.event_name != 'pull_request'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bunx wrangler d1 migrations apply chm-cloud --remote
+
       - name: Deploy production
         if: github.event_name != 'pull_request'
         env:


### PR DESCRIPTION
## Problem
The `chm-cloud` D1 schema is applied **by hand**. A cold or behind database 500s the Polar billing webhook and blocks per-user connections — the exact incident behind migrations `0001–0004`. There's no CI step to keep it current (flagged as a pending follow-up in the `billing-d1-polar-pull` notes).

## Change
Add a **production-only** step that runs `wrangler d1 migrations apply chm-cloud --remote` **before** the worker deploy, so the schema is always current when new code goes live.

## Safety
- **Idempotent** — wrangler records applied migrations in the `d1_migrations` ledger, so re-running every deploy is a no-op once applied.
- **Additive** — all four migrations are `CREATE TABLE`, safe to apply pre-deploy.
- **Gated to non-PR events** (`if: github.event_name != 'pull_request'`) — preview and prod currently *share* `chm-cloud`, so running from a PR could push an unmerged migration into production. This prevents that.
- Uses the existing `CLOUDFLARE_API_TOKEN` (already has D1 edit, used for the manual provisioning).

## Note
This does **not** retroactively apply the currently-pending migrations to prod — it takes effect on the next production deploy. If you want them applied now, run the one-liner from the notes manually first; subsequent deploys keep it in sync automatically.

https://claude.ai/code/session_01QQzUGeMAJGhto3XXao35N7