### PR TITLE
feat(billing): theme Clerk components to shadcn design tokens

### DIFF
--- a/apps/dashboard/src/components/clerk/clerk-appearance.ts
+++ b/apps/dashboard/src/components/clerk/clerk-appearance.ts
@@ -1,0 +1,37 @@
+/**
+ * Theme Clerk's hosted UI (OrganizationProfile, UserButton, the sign-in/up
+ * modal, OrganizationSwitcher) to the dashboard's shadcn / OKLCH design tokens
+ * so the account surfaces match the rest of the app instead of Clerk's default
+ * blue.
+ *
+ * The values reference the SAME CSS variables defined in `styles.css`
+ * (`:root` + `.dark`). Clerk renders its components inside the app DOM — which
+ * carries the `.dark` class in dark mode — so `var(--primary)` resolves to the
+ * active theme automatically. One config themes both light and dark, and it
+ * tracks any future token change with no extra wiring.
+ *
+ * Passed to `<ClerkProvider appearance={…}>` (clerk-auth-provider.tsx), so it
+ * cascades to every Clerk component. Typed structurally against the provider's
+ * `appearance` prop at the usage site — no `@clerk/types` import needed.
+ */
+export const clerkAppearance = {
+  variables: {
+    colorPrimary: 'var(--primary)',
+    colorText: 'var(--foreground)',
+    colorTextSecondary: 'var(--muted-foreground)',
+    colorTextOnPrimaryBackground: 'var(--primary-foreground)',
+    colorBackground: 'var(--card)',
+    colorInputBackground: 'var(--background)',
+    colorInputText: 'var(--foreground)',
+    colorDanger: 'var(--destructive)',
+    borderRadius: 'var(--radius)',
+    fontFamily: 'inherit',
+  },
+  elements: {
+    // Match the flat shadcn card/button look (drop Clerk's gradient + heavy
+    // shadow). These utilities already exist app-wide, so Tailwind v4 emits them.
+    card: 'border border-border shadow-sm',
+    formButtonPrimary:
+      'bg-primary text-primary-foreground shadow-none hover:bg-primary/90',
+  },
+} as const

--- a/apps/dashboard/src/components/clerk/clerk-auth-provider.tsx
+++ b/apps/dashboard/src/components/clerk/clerk-auth-provider.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 
+import { clerkAppearance } from './clerk-appearance'
 import { ClerkProvider } from '@clerk/tanstack-react-start'
 import {
   CLERK_PUBLISHABLE_KEY,
@@ -34,7 +35,10 @@ export function ClerkAuthProvider({ children }: ClerkAuthProviderProps) {
   // value. Clerk also auto-reads VITE_CLERK_PUBLISHABLE_KEY, but being explicit
   // keeps the contract self-documenting and decoupled from Clerk's lookup order.
   return (
-    <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
+    <ClerkProvider
+      publishableKey={CLERK_PUBLISHABLE_KEY}
+      appearance={clerkAppearance}
+    >
       {children}
     </ClerkProvider>
   )


### PR DESCRIPTION
## What
Themes Clerk's hosted UI (`OrganizationProfile`, `UserButton`, sign-in/up modal, `OrganizationSwitcher`) to the dashboard's shadcn / OKLCH tokens, replacing Clerk's default blue. Closes the "theme Clerk org components to shadcn" follow-up from the `polar-org-billing-handoff` notes.

## How
- New `clerk-appearance.ts` — an `appearance` config mapping Clerk variables to the app's CSS variables (`var(--primary)`, `var(--card)`, `var(--radius)`, …).
- Wired once at `ClerkProvider`, so it cascades to every Clerk component.
- **Auto light/dark**: Clerk renders inside the `.dark`-classed tree, so the `var(--*)` references resolve to the active theme via the cascade — no JS theme sync.
- A couple of `elements` overrides flatten the card/primary button to the shadcn look.

## Verification
- `bun run build` (vite + tsc + prerender) passes — the `appearance` prop typechecks against the app-wide provider.
- **Visual polish should be eyeballed** on this PR's preview `/organization` page (light + dark) — appearance configs are best confirmed by eye.

## Risk
UI-only, additive, gated behind `isClerkClientEnabled()` (non-Clerk/OSS builds tree-shake the provider away entirely).

https://claude.ai/code/session_01QQzUGeMAJGhto3XXao35N7