### PR TITLE
feat(billing): pool host limit across org members

### DIFF
--- a/apps/dashboard/src/lib/billing/org-host-count.test.ts
+++ b/apps/dashboard/src/lib/billing/org-host-count.test.ts
@@ -1,0 +1,80 @@
+import type { ConnectionStore } from '@/lib/connection-store/types'
+
+import { describe, expect, mock, test } from 'bun:test'
+
+// Mock the Clerk backend client used in the org path.
+let getOrganizationMembershipList = mock(
+  async (_args: { organizationId: string; limit: number }) => ({
+    data: [] as Array<{ publicUserData?: { userId?: string | null } }>,
+  })
+)
+mock.module('@clerk/tanstack-react-start/server', () => ({
+  clerkClient: () => ({
+    organizations: { getOrganizationMembershipList },
+  }),
+}))
+
+const { countOwnerHosts } = await import('./org-host-count')
+
+// A fake store whose list() returns N placeholder rows per user, from a map.
+function fakeStore(counts: Record<string, number>): ConnectionStore {
+  return {
+    list: async (userId: string) =>
+      Array.from({ length: counts[userId] ?? 0 }, () => ({}) as never),
+  } as unknown as ConnectionStore
+}
+
+describe('countOwnerHosts', () => {
+  test('user owner counts only the acting user', async () => {
+    const store = fakeStore({ user_a: 2, user_b: 5 })
+    const n = await countOwnerHosts(
+      { type: 'user', id: 'user_a' },
+      store,
+      'user_a'
+    )
+    expect(n).toBe(2)
+  })
+
+  test('org owner pools connections across all current members', async () => {
+    getOrganizationMembershipList = mock(async () => ({
+      data: [
+        { publicUserData: { userId: 'user_a' } },
+        { publicUserData: { userId: 'user_b' } },
+      ],
+    }))
+    const store = fakeStore({ user_a: 2, user_b: 3, user_c: 9 })
+    // owner is the org; acting user is a member. Pool = a(2) + b(3) = 5.
+    const n = await countOwnerHosts(
+      { type: 'org', id: 'org_1' },
+      store,
+      'user_a'
+    )
+    expect(n).toBe(5)
+  })
+
+  test('acting user is counted even if not yet in the membership list', async () => {
+    getOrganizationMembershipList = mock(async () => ({
+      data: [{ publicUserData: { userId: 'user_b' } }],
+    }))
+    const store = fakeStore({ user_a: 4, user_b: 1 })
+    const n = await countOwnerHosts(
+      { type: 'org', id: 'org_1' },
+      store,
+      'user_a'
+    )
+    expect(n).toBe(5) // b(1) + a(4), a appended
+  })
+
+  test('org enumeration failure falls back to the acting user count', async () => {
+    getOrganizationMembershipList = mock(async () => {
+      throw new Error('clerk down')
+    })
+    const store = fakeStore({ user_a: 3 })
+    const n = await countOwnerHosts(
+      { type: 'org', id: 'org_1' },
+      store,
+      'user_a'
+    )
+    expect(n).toBe(3)
+  })
+})

--- a/apps/dashboard/src/lib/billing/org-host-count.ts
+++ b/apps/dashboard/src/lib/billing/org-host-count.ts
@@ -1,0 +1,53 @@
+import type { ConnectionStore } from '@/lib/connection-store/types'
+import type { BillingOwner } from './billing-owner'
+
+/**
+ * Count the hosts (saved per-user connections) that consume a billing owner's
+ * host limit — the value fed to `checkHostLimit`.
+ *
+ * - **User owner** → just that user's connections.
+ * - **Org owner** → the host limit is POOLED across the org: count connections
+ *   owned by every CURRENT member of the org. A removed member's connections
+ *   drop out of the pool automatically because they're no longer enumerated —
+ *   no `org_id` column, backfill, or cleanup needed. Member counts are small
+ *   (Pro 3 / Max 10 seats), so this is a handful of cheap reads.
+ *
+ * Fail-safe: ANY error in the org path (Clerk API down, unexpected shape) falls
+ * back to counting just the acting user's connections. It never throws, so a
+ * billing-count hiccup can't break adding a host, and the fallback can only
+ * UNDER-count (more permissive) — it will never wrongly 402 a paying org.
+ */
+export async function countOwnerHosts(
+  owner: BillingOwner,
+  store: ConnectionStore,
+  actingUserId: string
+): Promise<number> {
+  if (owner.type !== 'org') {
+    return (await store.list(actingUserId)).length
+  }
+
+  try {
+    const { clerkClient } = await import('@clerk/tanstack-react-start/server')
+    const memberships =
+      await clerkClient().organizations.getOrganizationMembershipList({
+        organizationId: owner.id,
+        limit: 100,
+      })
+
+    const memberIds = memberships.data
+      .map((m) => m.publicUserData?.userId)
+      .filter((id): id is string => Boolean(id))
+    // Count the acting user even if their membership row hasn't propagated yet.
+    if (!memberIds.includes(actingUserId)) memberIds.push(actingUserId)
+
+    const counts = await Promise.all(
+      memberIds.map((id) =>
+        store.list(id).then((connections) => connections.length)
+      )
+    )
+    return counts.reduce((sum, n) => sum + n, 0)
+  } catch {
+    // Permissive fallback — never block a paying org on an enumeration failure.
+    return (await store.list(actingUserId)).length
+  }
+}

--- a/apps/dashboard/src/routes/api/v1/user-connections.ts
+++ b/apps/dashboard/src/routes/api/v1/user-connections.ts
@@ -13,6 +13,7 @@ import { createSuccessResponse } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
 import { resolveBillingOwner } from '@/lib/billing/billing-owner'
 import { checkHostLimit, limitMessage } from '@/lib/billing/entitlements'
+import { countOwnerHosts } from '@/lib/billing/org-host-count'
 import { getPlanForOwner } from '@/lib/billing/user-subscription'
 import { validateHostUrl } from '@/lib/browser-connections/host-url'
 import { queryConnection } from '@/lib/connection-query/connection-client'
@@ -123,14 +124,16 @@ async function handlePost(request: Request): Promise<Response> {
     // network connection to an attacker-supplied host for a request we'll reject.
     //
     // Enforce against the BILLING OWNER's plan (org or user): if the user has an
-    // active Clerk org in their session the org's plan determines the limit.
-    // TODO: org-wide pooling (count connections across all org members vs the
-    // per-org host limit) is a follow-up. For now, count this user's connections.
+    // active Clerk org in their session the org's plan determines the limit, and
+    // the host count is POOLED across all current org members (countOwnerHosts).
+    // For a user owner it's just this user's connections. The count is fail-safe:
+    // an org-enumeration error falls back to the acting user's count, so it never
+    // blocks a paying org on a Clerk hiccup.
     const owner = await resolveBillingOwner()
     const plan = await getPlanForOwner(owner.id)
     if (plan.hosts != null) {
-      const existing = await store.list(userId)
-      const check = checkHostLimit(plan, existing.length)
+      const usedHosts = await countOwnerHosts(owner, store, userId)
+      const check = checkHostLimit(plan, usedHosts)
       if (!check.allowed) {
         return createApiErrorResponse(
           {


### PR DESCRIPTION
## What

Count saved per-user connections owned by **every current member** of the billing org against the org's host limit, instead of only the acting user's. Finishes the org-wide pooling follow-up left as a TODO in `user-connections.ts`.

## How

New `countOwnerHosts(owner, store, actingUserId)` (`lib/billing/org-host-count.ts`):

- **User owner** → just that user's connection count (unchanged behaviour).
- **Org owner** → enumerate current members via Clerk (`getOrganizationMembershipList`) and sum each member's connection count. The acting user is always included even if their membership row hasn't propagated.

Design notes:

- **Schema-free** — no `org_id` column, backfill, or cleanup. A removed member's hosts leave the pool automatically because they're no longer enumerated. Member counts are small (Pro 3 / Max 10 seats), so it's a handful of cheap reads.
- **Fail-safe** — any error in the org path falls back to the acting user's count. It never throws and can only *under-count*, so a Clerk hiccup can't wrongly 402 a paying org.

## Tests

`org-host-count.test.ts` — user owner, org pooling, acting-user-appended, and enumeration-failure fallback. All pass; `tsc --noEmit` clean.

Co-Authored-By: duyetbot <bot@duyet.net>