### PR TITLE
feat(billing): clearer AI label, yearly price summary, inherited-row highlight, signed-out state

### DIFF
--- a/apps/dashboard/src/components/billing/plan-card.tsx
+++ b/apps/dashboard/src/components/billing/plan-card.tsx
@@ -98,18 +98,91 @@ export function PlanCard({
       </p>
 
       <ul className="mt-5 space-y-2.5">
-        {highlights.map((h) => (
-          <li key={h} className="flex gap-2.5 text-sm">
-            <CheckIcon
-              className="text-emerald-500 mt-0.5 size-4 shrink-0"
-              strokeWidth={2}
-            />
-            <span className="text-foreground/90">{h}</span>
-          </li>
-        ))}
+        {highlights.map((h) => {
+          // The first bullet on paid tiers ("Everything in Free/Pro/Max") names
+          // the inherited tier — highlight it as a mini section header.
+          const inherited = /^Everything in /.test(h)
+          return (
+            <li
+              key={h}
+              className={cn(
+                'flex gap-2.5 text-sm',
+                inherited && 'border-border/60 mb-1 border-b pb-2.5 font-medium'
+              )}
+            >
+              <CheckIcon
+                className={cn(
+                  'mt-0.5 size-4 shrink-0',
+                  inherited ? 'text-primary' : 'text-emerald-500'
+                )}
+                strokeWidth={2}
+              />
+              <span
+                className={inherited ? 'text-foreground' : 'text-foreground/90'}
+              >
+                {h}
+              </span>
+            </li>
+          )
+        })}
       </ul>
 
-      <div className="mt-auto pt-6">{cta}</div>
+      <div className="mt-auto pt-6">
+        <PlanBillingSummary plan={plan} period={period} />
+        {cta}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Price summary shown right above the upgrade CTA. On yearly it makes the
+ * discount explicit — the annualized monthly price struck through, the actual
+ * yearly total, and the savings. On monthly it nudges toward yearly. Only
+ * renders for paid, fixed-price tiers (Free/Enterprise have nothing to compare).
+ */
+function PlanBillingSummary({
+  plan,
+  period,
+}: {
+  plan: Plan
+  period: BillingPeriod
+}) {
+  if (
+    plan.priceMonthlyUsd == null ||
+    plan.priceMonthlyUsd <= 0 ||
+    plan.priceYearlyUsd == null
+  ) {
+    return null
+  }
+  const annualIfMonthly = plan.priceMonthlyUsd * 12
+  const yearlyTotal = plan.priceYearlyUsd
+  const savings = annualIfMonthly - yearlyTotal
+
+  if (period === 'yearly') {
+    return (
+      <div className="bg-muted/50 mb-3 rounded-lg px-3 py-2 text-xs">
+        <div className="flex items-baseline gap-1.5">
+          <span className="text-muted-foreground tabular-nums line-through">
+            ${annualIfMonthly}
+          </span>
+          <span className="text-foreground font-semibold tabular-nums">
+            ${yearlyTotal}
+          </span>
+          <span className="text-muted-foreground">/ year</span>
+        </div>
+        <div className="mt-0.5 text-emerald-600 dark:text-emerald-400">
+          Save ${savings} with yearly billing
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-muted/50 text-muted-foreground mb-3 rounded-lg px-3 py-2 text-xs">
+      <span className="tabular-nums">${annualIfMonthly}</span> / year billed
+      monthly · <span className="text-foreground">save ${savings}</span> with
+      yearly
     </div>
   )
 }

--- a/apps/dashboard/src/routes/(dashboard)/billing.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/billing.tsx
@@ -1,8 +1,11 @@
-import { ExternalLinkIcon } from 'lucide-react'
+import { ExternalLinkIcon, SparklesIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { createFileRoute } from '@tanstack/react-router'
 
+import type { ReactNode } from 'react'
+
 import { useState } from 'react'
+import { useClerkIsSignedIn as useClerkIsSignedInImpl } from '@/components/assistant-ui/use-clerk-is-signed-in'
 import {
   type BillingPeriod,
   BillingPeriodToggle,
@@ -11,10 +14,12 @@ import {
   PopularBadge,
 } from '@/components/billing/plan-card'
 import { PlanComparison } from '@/components/billing/plan-comparison'
+import { ClerkSignInButton as ClerkSignInButtonImpl } from '@/components/clerk/clerk-sign-in-button'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   Card,
+  CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
@@ -25,11 +30,31 @@ import {
   startCheckout,
   useBillingSubscription,
 } from '@/lib/billing/use-billing'
+import { isClerkEnabled } from '@/lib/clerk/clerk-client'
+
+/**
+ * Sign-in primitives gated behind the build-time `isClerkEnabled()` constant —
+ * Clerk's `useUser()` / `SignInButton` need a mounted `<ClerkProvider />`. When
+ * Clerk is off (OSS / self-host) `useClerkIsSignedIn` returns true so the
+ * signed-out prompt never shows — billing is a cloud-only surface. Mirrors
+ * `agent-auth-gate.tsx`.
+ */
+const useClerkIsSignedIn: () => boolean = isClerkEnabled()
+  ? useClerkIsSignedInImpl
+  : () => true
+const ClerkSignInButton:
+  | ((props: { children: ReactNode }) => ReactNode)
+  | null = isClerkEnabled() ? ClerkSignInButtonImpl : null
 
 function BillingPage() {
+  const signedIn = useClerkIsSignedIn()
   const { data: sub, isLoading } = useBillingSubscription()
   const [period, setPeriod] = useState<BillingPeriod>('yearly')
   const [busy, setBusy] = useState<string | null>(null)
+
+  // Cloud visitors who aren't signed in get a sign-in prompt instead of a
+  // billing UI they can't act on. (Always signed-in in OSS, so never shown.)
+  if (!signedIn) return <BillingSignedOut />
 
   const currentPlanId = sub?.planId ?? 'free'
   const currentPlan = getPlan(currentPlanId)
@@ -165,6 +190,63 @@ function BillingPage() {
 
       {/* Full benefits matrix */}
       <PlanComparison currentPlanId={currentPlanId} />
+    </div>
+  )
+}
+
+/**
+ * Signed-out cloud view. Leads with a sign-in prompt (you can't check out or
+ * manage a subscription anonymously), then shows the full plan comparison so a
+ * visitor can still weigh the plans before creating an account.
+ */
+function BillingSignedOut() {
+  return (
+    <div className="mx-auto max-w-5xl space-y-8 py-8">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">Billing</h1>
+        <p className="text-muted-foreground text-sm">
+          Plans and host limits for the hosted cloud. Early access is free while
+          in beta.
+        </p>
+      </div>
+
+      <Card className="overflow-hidden">
+        <div className="from-primary/[0.06] bg-gradient-to-b to-transparent">
+          <CardContent className="flex flex-col items-center gap-4 px-6 py-12 text-center">
+            <div className="bg-primary/10 flex size-12 items-center justify-center rounded-full">
+              <SparklesIcon className="text-primary size-5" strokeWidth={2} />
+            </div>
+            <div className="space-y-1.5">
+              <h2 className="text-xl font-semibold tracking-tight">
+                Sign in to get started
+              </h2>
+              <p className="text-muted-foreground mx-auto max-w-md text-sm leading-relaxed">
+                Create a free account to connect your ClickHouse hosts, choose a
+                plan, and manage your subscription. No card required to start.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center justify-center gap-2 pt-1">
+              {ClerkSignInButton ? (
+                <ClerkSignInButton>
+                  <Button size="lg">Sign in / Create account</Button>
+                </ClerkSignInButton>
+              ) : null}
+              <Button variant="ghost" size="lg" asChild>
+                <a
+                  href="https://docs.chmonitor.dev"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Read the docs <ExternalLinkIcon className="size-4" />
+                </a>
+              </Button>
+            </div>
+          </CardContent>
+        </div>
+      </Card>
+
+      {/* Let signed-out visitors compare plans before committing. */}
+      <PlanComparison currentPlanId="free" />
     </div>
   )
 }

--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -77,7 +77,7 @@ const { compact = false } = Astro.props
           <div class="price-body">
             <ul class="price-rows">
               {t.rows.map((r) => (
-                <li class="price-row"><span set:html={checkSvg} />{r}</li>
+                <li class={`price-row${r.startsWith('Everything in') ? ' price-row-inherited' : ''}`}><span set:html={checkSvg} />{r}</li>
               ))}
             </ul>
             <div class="price-cta">

--- a/apps/landing/src/data/pricing.ts
+++ b/apps/landing/src/data/pricing.ts
@@ -176,7 +176,7 @@ export const pricingFaqs: PricingFaq[] = [
   },
   {
     q: 'How does AI usage metering work?',
-    a: 'Every plan includes a daily allowance of AI agent messages: Free 5/day, Pro 100/day, Max 1,000/day. On Pro and Max, usage past the daily allowance is billed as overage at $5 per 2,000 messages. Enterprise brings its own LLM key (BYOK) for unlimited usage.',
+    a: 'Every plan includes a daily allowance of AI agent messages: Free 5 messages / day, Pro 100 / day, Max 1,000 / day. On Pro and Max, usage past the daily allowance is billed as overage at $5 per 2,000 messages. Enterprise brings its own LLM key (BYOK) for unlimited usage.',
   },
   {
     q: 'What happens when I hit a plan limit?',

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -457,6 +457,10 @@ const ogImage = new URL(image, Astro.site).toString()
     .price-rows{display:flex;flex-direction:column;gap:13px}
     .price-row{display:flex;gap:10px;font-size:14px;color:var(--fg-soft);list-style:none}
     .price-row svg{width:17px;height:17px;flex:0 0 auto;margin-top:1px}
+    /* Inherited-tier row ("Everything in X") — a mini section header for the
+       benefits it builds on. */
+    .price-row-inherited{font-weight:600;color:var(--fg);padding-bottom:13px;border-bottom:1px solid var(--border)}
+    .price-row-inherited svg{stroke:var(--orange)}
     .price-cta{margin-top:auto;padding-top:24px}
     @media (max-width:640px){.pricing-grid{grid-template-columns:1fr}}
 

--- a/packages/pricing/src/display.ts
+++ b/packages/pricing/src/display.ts
@@ -34,14 +34,14 @@ export function planRetention(plan: Plan): string {
 /**
  * AI-usage cell. Daily included messages, plus the overage policy on metered
  * paid tiers. Enterprise (no daily cap) is BYOK.
- * - Free:  "5/day"
- * - Pro:   "100/day + $5/2,000"
- * - Max:   "1,000/day + $5/2,000"
+ * - Free:  "5 messages / day"
+ * - Pro:   "100 messages / day, then $5 / 2,000"
+ * - Max:   "1,000 messages / day, then $5 / 2,000"
  * - Ent:   "BYOK"
  */
 export function planAiUsage(plan: Plan): string {
   if (plan.aiRequestsPerDay === null) return 'BYOK'
-  const perDay = `${plan.aiRequestsPerDay.toLocaleString('en-US')}/day`
+  const perDay = `${plan.aiRequestsPerDay.toLocaleString('en-US')} messages / day`
   if (!plan.aiOverage) return perDay
-  return `${perDay} + $${plan.aiOverage.usdPer}/${plan.aiOverage.messages.toLocaleString('en-US')}`
+  return `${perDay}, then $${plan.aiOverage.usdPer} / ${plan.aiOverage.messages.toLocaleString('en-US')}`
 }

--- a/packages/pricing/src/plans.ts
+++ b/packages/pricing/src/plans.ts
@@ -102,7 +102,7 @@ export const BILLING_PLANS: Record<PlanId, Plan> = {
     highlights: [
       '1 ClickHouse host, 1 seat',
       'Full monitoring dashboard',
-      'AI agent — 5 messages/day',
+      'AI agent — 5 messages / day',
       '7-day conversation & insights history',
       'Community support',
     ],
@@ -131,7 +131,7 @@ export const BILLING_PLANS: Record<PlanId, Plan> = {
     highlights: [
       'Everything in Free',
       '3 hosts, 3 seats',
-      'AI agent — 100 messages/day, then $5 / 2,000',
+      'AI agent — 100 messages / day, then $5 / 2,000',
       'Scheduled AI Insights',
       'Basic alerting — up to 10 rules',
       'Anomaly detection + data export',
@@ -168,7 +168,7 @@ export const BILLING_PLANS: Record<PlanId, Plan> = {
     highlights: [
       'Everything in Pro',
       '10 hosts, 10 seats',
-      'AI agent — 1,000 messages/day, then $5 / 2,000',
+      'AI agent — 1,000 messages / day, then $5 / 2,000',
       'Fleet view + advanced alerting (Slack, PagerDuty)',
       'Custom dashboards + webhook integrations',
       'API / MCP access',


### PR DESCRIPTION
Follow-up polish on the cloud billing/pricing surface (all derive from the shared `@chm/pricing` source, so dashboard + landing stay in sync).

- **Clearer AI usage label** — reads `N messages / day, then $5 / 2,000` everywhere (shared helper + plan card bullets + landing FAQ), instead of the terse `5/day`.
- **Yearly price summary before the upgrade CTA** — on yearly the card strikes the annualized monthly price (`~~$348~~ $290 / year`) and states the savings; monthly nudges toward yearly.
- **Highlight the inherited "Everything in X" row** — rendered as a mini section header (bold + accent check + divider) on both the in-app cards and the landing cards.
- **Redesigned signed-out `/billing`** — cloud visitors who aren't signed in now get a designed "Sign in to get started" prompt + the plan comparison, instead of a billing UI they can't act on. Gated behind `isClerkEnabled()` (mirrors `agent-auth-gate.tsx`); OSS/self-host is unaffected (always signed-in).

Verified: dashboard `tsc` clean, billing tests 37/37, dashboard + landing builds green, rendered strings confirmed in built HTML.

Co-Authored-By: duyetbot <bot@duyet.net>