### PR TITLE
feat(billing): plan-benefits parity registry + private-host opt-in + blog polish

### DIFF
--- a/apps/blog/src/content/blog/chmonitor-v0-3.md
+++ b/apps/blog/src/content/blog/chmonitor-v0-3.md
@@ -20,12 +20,7 @@ Here's the ~28-second launch film — every scene is the real product:
   <figcaption>chmonitor v0.3 — launch film. Dashboard, AI agent, query monitoring, data explorer, topology, health & self-host.</figcaption>
 </figure>
 
-<div class="stat-row">
-  <div class="stat"><div class="n">8</div><div class="l">new features</div></div>
-  <div class="stat"><div class="n">70+</div><div class="l">fixes</div></div>
-  <div class="stat"><div class="n">13</div><div class="l">perf wins</div></div>
-  <div class="stat"><div class="n">71</div><div class="l">charts</div></div>
-</div>
+v0.3 lands 8 new features, more than 70 fixes, 13 performance wins, and 71 charts.
 
 ## Everything that's new
 

--- a/apps/blog/src/layouts/Base.astro
+++ b/apps/blog/src/layouts/Base.astro
@@ -234,11 +234,6 @@ const ogImage = new URL(image, Astro.site).toString()
     .hl span{font-size:13.5px;color:var(--muted-fg);margin-top:6px;display:block;line-height:1.55}
     @media (max-width:600px){.hl-grid{grid-template-columns:1fr}}
 
-    /* ── stat row ── */
-    .stat-row{display:flex;gap:14px;flex-wrap:wrap;margin:28px 0}
-    .stat{flex:1 1 120px;padding:18px;border:1px solid var(--border);border-radius:var(--radius);background:var(--card);text-align:center}
-    .stat .n{font-size:28px;font-weight:700;letter-spacing:-.02em;color:var(--fg);font-variant-numeric:tabular-nums}
-    .stat .l{font-size:12.5px;color:var(--muted-fg);margin-top:4px}
 
     /* ── footer ── */
     footer{border-top:1px solid var(--border-soft);padding:48px 0 40px;flex-shrink:0}

--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -98,6 +98,12 @@ CHM_FEATURE_AGENT_ACCESS=public
 # or the server returns "User connections database storage is not enabled".
 # CHM_FEATURE_USER_CONNECTIONS_DB=false
 
+# Allow connecting to private / LAN / loopback / Tailscale (100.64.0.0/10 CGNAT)
+# ClickHouse hosts through the connection form. SELF-HOST ONLY — it is forced OFF
+# in cloud mode (multi-tenant SSRF safety) regardless of this value. Default off,
+# so the SSRF guard blocks internal targets unless you opt in here.
+# CHM_ALLOW_PRIVATE_HOSTS=false
+
 # ── AI agent / LLM ──────────────────────────────────────────────────────────
 # Default AI model (provider:model or anyrouter:@preset/...).
 LLM_MODEL=anyrouter/free

--- a/apps/dashboard/src/lib/billing/plan-enforcement.test.ts
+++ b/apps/dashboard/src/lib/billing/plan-enforcement.test.ts
@@ -1,0 +1,117 @@
+import { checkHostLimit } from './entitlements'
+import {
+  CAPABILITY_ENFORCEMENT,
+  LIMIT_ENFORCEMENT,
+  type LimitKey,
+} from './plan-enforcement'
+import { describe, expect, test } from 'bun:test'
+import {
+  BILLING_PLAN_LIST,
+  BILLING_PLANS,
+  type PlanCapability,
+  planAiUsage,
+  planAlertRules,
+  planHosts,
+  planRetention,
+  planSeats,
+} from '@chm/pricing'
+
+/** Every capability that appears on any plan — the contract surface. */
+const usedCapabilities = new Set<PlanCapability>(
+  BILLING_PLAN_LIST.flatMap((p) => p.capabilities)
+)
+
+describe('plan-enforcement — anti-drift coverage', () => {
+  test('every advertised capability is classified', () => {
+    for (const cap of usedCapabilities) {
+      // If this fails, a capability was added to @chm/pricing without deciding
+      // whether/how it is enforced. Classify it in CAPABILITY_ENFORCEMENT.
+      expect(CAPABILITY_ENFORCEMENT[cap]).toBeDefined()
+    }
+  })
+
+  test('every numeric limit is classified', () => {
+    const limitKeys: LimitKey[] = [
+      'hosts',
+      'seats',
+      'alertRules',
+      'retentionDays',
+      'aiRequestsPerDay',
+    ]
+    for (const key of limitKeys) {
+      expect(LIMIT_ENFORCEMENT[key]).toBeDefined()
+    }
+  })
+
+  test('an "enforced" claim must name its gate', () => {
+    const all = [
+      ...Object.values(CAPABILITY_ENFORCEMENT),
+      ...Object.values(LIMIT_ENFORCEMENT),
+    ]
+    for (const e of all) {
+      if (e.status === 'enforced') {
+        expect(e.gate.length).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  test('the host cap is the one enforced limit today', () => {
+    // Documents the audited reality; flip deliberately as enforcement lands.
+    expect(LIMIT_ENFORCEMENT.hosts.status).toBe('enforced')
+    expect(LIMIT_ENFORCEMENT.seats.status).toBe('deferred')
+    expect(LIMIT_ENFORCEMENT.aiRequestsPerDay.status).toBe('deferred')
+  })
+})
+
+describe('plan-enforcement — host cap really blocks', () => {
+  test('Pro blocks at its host limit, allows below it', () => {
+    const pro = BILLING_PLANS.pro
+    expect(pro.hosts).toBe(3)
+    expect(checkHostLimit(pro, 2).allowed).toBe(true)
+    expect(checkHostLimit(pro, 3).allowed).toBe(false)
+  })
+
+  test('Enterprise (unlimited hosts) never blocks', () => {
+    const ent = BILLING_PLANS.enterprise
+    expect(ent.hosts).toBeNull()
+    expect(checkHostLimit(ent, 10_000).allowed).toBe(true)
+  })
+})
+
+describe('plan-enforcement — cross-surface render parity', () => {
+  // The landing comparison matrix and the in-app billing matrix both derive
+  // from these shared helpers. Pin the exact strings so a future change to the
+  // helper (which would silently change BOTH surfaces) is caught here.
+  test('limit cells render the agreed strings for every tier', () => {
+    expect(BILLING_PLAN_LIST.map(planHosts)).toEqual([
+      '1',
+      '3',
+      '10',
+      'Unlimited',
+    ])
+    expect(BILLING_PLAN_LIST.map(planSeats)).toEqual([
+      '1',
+      '3',
+      '10',
+      'Unlimited',
+    ])
+    expect(BILLING_PLAN_LIST.map(planAlertRules)).toEqual([
+      '—',
+      '10',
+      '50',
+      'Unlimited',
+    ])
+    expect(BILLING_PLAN_LIST.map(planRetention)).toEqual([
+      '7 days',
+      '30 days',
+      '90 days',
+      'Custom',
+    ])
+    expect(BILLING_PLAN_LIST.map(planAiUsage)).toEqual([
+      '5 messages / day',
+      '100 messages / day, then $5 / 2,000',
+      '1,000 messages / day, then $5 / 2,000',
+      'BYOK',
+    ])
+  })
+})

--- a/apps/dashboard/src/lib/billing/plan-enforcement.ts
+++ b/apps/dashboard/src/lib/billing/plan-enforcement.ts
@@ -1,0 +1,93 @@
+/**
+ * Plan-benefit enforcement registry — the single source of truth for *whether
+ * each advertised plan benefit is actually enforced in code yet*.
+ *
+ * Why this exists: `@chm/pricing` advertises limits + capabilities, but during
+ * **early access everything is free** ("Early access — free while in beta"), so
+ * per-tier feature gating is intentionally NOT switched on — turning it on now
+ * would remove capabilities current users already have. The risk is that the
+ * gap between "advertised" and "enforced" drifts silently and the marketing
+ * promise quietly becomes untrue.
+ *
+ * This registry makes the gap EXPLICIT and the tests (`plan-enforcement.test.ts`)
+ * make it impossible to add a benefit without classifying it. Flipping a benefit
+ * from `deferred` to `enforced` at GA is a one-line change here plus its wiring.
+ *
+ * See plans/02-plan-benefits-parity.md.
+ */
+
+import type { PlanCapability } from '@chm/pricing'
+
+export type Enforcement =
+  /** Gated in code today. `gate` names where (file / function). */
+  | { status: 'enforced'; gate: string }
+  /** Advertised but not gated yet (free during beta / GA roadmap). */
+  | { status: 'deferred'; reason: string }
+  /** Not software-gated by nature (e.g. support tier, core monitoring). */
+  | { status: 'inherent' }
+
+const BETA = 'Free during early access; gate when paid GA launches.'
+
+/**
+ * Enforcement status for every {@link PlanCapability}. The test suite asserts
+ * this covers the full union — adding a capability to `@chm/pricing` without a
+ * line here fails the build.
+ */
+export const CAPABILITY_ENFORCEMENT: Record<PlanCapability, Enforcement> = {
+  core_monitoring: { status: 'inherent' },
+  priority_support: { status: 'inherent' },
+  ai_agent: { status: 'deferred', reason: BETA },
+  ai_insights_scheduled: { status: 'deferred', reason: BETA },
+  alerting_basic: {
+    status: 'deferred',
+    reason: 'Alerting feature not built in this app yet.',
+  },
+  alerting_advanced: {
+    status: 'deferred',
+    reason: 'Alerting feature not built in this app yet.',
+  },
+  data_export: { status: 'deferred', reason: BETA },
+  anomaly_detection: { status: 'deferred', reason: BETA },
+  fleet_view: { status: 'deferred', reason: BETA },
+  custom_dashboards: { status: 'deferred', reason: BETA },
+  webhook_integrations: { status: 'deferred', reason: BETA },
+  api_mcp_access: { status: 'deferred', reason: BETA },
+  sso_rbac_audit: { status: 'deferred', reason: BETA },
+}
+
+/** Numeric limits advertised by every plan. */
+export type LimitKey =
+  | 'hosts'
+  | 'seats'
+  | 'alertRules'
+  | 'retentionDays'
+  | 'aiRequestsPerDay'
+
+/**
+ * Enforcement status for each numeric limit. Only the host cap is wired today.
+ */
+export const LIMIT_ENFORCEMENT: Record<LimitKey, Enforcement> = {
+  hosts: {
+    status: 'enforced',
+    gate: 'routes/api/v1/user-connections.ts handlePost → checkHostLimit (pooled by countOwnerHosts)',
+  },
+  seats: {
+    status: 'deferred',
+    reason:
+      'Needs a Clerk organizationMembership.created webhook to count members vs plan.seats.',
+  },
+  alertRules: {
+    status: 'deferred',
+    reason: 'No alert-rule create path exists yet.',
+  },
+  retentionDays: {
+    status: 'deferred',
+    reason:
+      'Conversations/insights are not pruned or read-filtered by plan retention yet.',
+  },
+  aiRequestsPerDay: {
+    status: 'deferred',
+    reason:
+      'Agent route needs a per-owner daily counter (D1) before checkAiDailyLimit can gate.',
+  },
+}

--- a/apps/dashboard/src/lib/browser-connections/host-url.test.ts
+++ b/apps/dashboard/src/lib/browser-connections/host-url.test.ts
@@ -1,0 +1,54 @@
+import { validateHostUrl } from './host-url'
+import { describe, expect, test } from 'bun:test'
+
+// Injected DNS resolvers (the 2nd param) so tests never hit the network.
+const resolveLoopback = async () => ['127.0.0.1']
+const resolvePublic = async () => ['93.184.216.34']
+
+describe('validateHostUrl — private-host SSRF guard', () => {
+  test('blocks private / LAN / CGNAT(Tailscale) / loopback by default', async () => {
+    // allowPrivate = false (the default everywhere, and forced in cloud).
+    expect(
+      await validateHostUrl('http://192.168.1.10:8123', resolvePublic, false)
+    ).not.toBeNull()
+    expect(
+      await validateHostUrl('http://10.0.0.5:8123', resolvePublic, false)
+    ).not.toBeNull()
+    expect(
+      // 100.64.0.0/10 is Tailscale's CGNAT range.
+      await validateHostUrl('http://100.64.0.1:8123', resolvePublic, false)
+    ).not.toBeNull()
+    expect(
+      await validateHostUrl('http://localhost:8123', resolveLoopback, false)
+    ).not.toBeNull()
+  })
+
+  test('allows them when allowPrivate = true (self-host opt-in)', async () => {
+    expect(
+      await validateHostUrl('http://192.168.1.10:8123', resolvePublic, true)
+    ).toBeNull()
+    expect(
+      await validateHostUrl('http://100.64.0.1:8123', resolvePublic, true)
+    ).toBeNull()
+    // A tailnet hostname that resolves to a loopback/private address.
+    expect(
+      await validateHostUrl('http://duet-ubuntu:8123', resolveLoopback, true)
+    ).toBeNull()
+  })
+
+  test('non-http(s) scheme is still rejected even with allowPrivate', async () => {
+    expect(
+      await validateHostUrl('ftp://192.168.1.10', resolvePublic, true)
+    ).not.toBeNull()
+  })
+
+  test('a public host is allowed regardless of the flag', async () => {
+    expect(
+      await validateHostUrl(
+        'https://my.clickhouse.cloud:8443',
+        resolvePublic,
+        false
+      )
+    ).toBeNull()
+  })
+})

--- a/apps/dashboard/src/lib/browser-connections/host-url.ts
+++ b/apps/dashboard/src/lib/browser-connections/host-url.ts
@@ -2,6 +2,18 @@ import type { Dispatcher, Agent as UndiciAgent } from 'undici'
 
 import { isCloudflareWorkers } from '@chm/clickhouse-client/runtime/cloudflare-workers'
 import { Address4, Address6 } from 'ip-address'
+import { resolveConfig } from '@/lib/config/deployment-mode'
+
+/**
+ * Whether private / LAN / loopback / Tailscale (CGNAT) hosts may be connected.
+ * Resolved from `CHM_ALLOW_PRIVATE_HOSTS`, but FORCED off in cloud mode by
+ * `resolveConfig` — so the hosted multi-tenant service can never be opted into
+ * SSRF-reachable internal targets. Default off; self-host opt-in only.
+ */
+function arePrivateHostsAllowed(): boolean {
+  const env = typeof process !== 'undefined' ? process.env : {}
+  return resolveConfig((k) => env[k]).allowPrivateHosts
+}
 
 const INTERNAL_ADDRESS_ERROR =
   'Connections to internal addresses are not allowed.'
@@ -32,16 +44,22 @@ export type ResolveHostAddresses = (
  */
 export async function validateHostUrl(
   host: string,
-  resolveHostAddresses: ResolveHostAddresses = resolveDnsAddresses
+  resolveHostAddresses: ResolveHostAddresses = resolveDnsAddresses,
+  allowPrivate: boolean = arePrivateHostsAllowed()
 ): Promise<string | null> {
-  const result = await resolveValidatedHostUrl(host, resolveHostAddresses)
+  const result = await resolveValidatedHostUrl(
+    host,
+    resolveHostAddresses,
+    allowPrivate
+  )
 
   return typeof result === 'string' ? result : null
 }
 
 async function resolveValidatedHostUrl(
   host: string,
-  resolveHostAddresses: ResolveHostAddresses = resolveDnsAddresses
+  resolveHostAddresses: ResolveHostAddresses = resolveDnsAddresses,
+  allowPrivate: boolean = arePrivateHostsAllowed()
 ): Promise<{ url: URL; addresses: readonly string[] } | string> {
   let url: URL
   try {
@@ -56,12 +74,17 @@ async function resolveValidatedHostUrl(
 
   const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, '')
 
-  if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
-    return INTERNAL_ADDRESS_ERROR
-  }
+  // SSRF guard: reject internal/private/loopback/CGNAT(Tailscale) targets —
+  // UNLESS a self-host operator opted in via CHM_ALLOW_PRIVATE_HOSTS (never in
+  // cloud). The scheme + DNS-resolution checks below stay unconditional.
+  if (!allowPrivate) {
+    if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
+      return INTERNAL_ADDRESS_ERROR
+    }
 
-  if (isInternalIp(hostname)) {
-    return INTERNAL_ADDRESS_ERROR
+    if (isInternalIp(hostname)) {
+      return INTERNAL_ADDRESS_ERROR
+    }
   }
 
   if (isIpLiteral(hostname)) {
@@ -75,7 +98,7 @@ async function resolveValidatedHostUrl(
     return DNS_RESOLUTION_ERROR
   }
 
-  if (addresses.some(isInternalIp)) {
+  if (!allowPrivate && addresses.some(isInternalIp)) {
     return INTERNAL_ADDRESS_ERROR
   }
 

--- a/apps/dashboard/src/lib/config/deployment-mode.test.ts
+++ b/apps/dashboard/src/lib/config/deployment-mode.test.ts
@@ -26,6 +26,7 @@ describe('modeDefaults — good defaults from the beginning', () => {
       clerkPublicRead: false,
       userConnectionsDb: false,
       conversationDb: false,
+      allowPrivateHosts: false,
     })
   })
   test('cloud: clerk + anon read-only demo + per-user storage', () => {
@@ -35,7 +36,32 @@ describe('modeDefaults — good defaults from the beginning', () => {
       clerkPublicRead: true,
       userConnectionsDb: true,
       conversationDb: true,
+      allowPrivateHosts: false,
     })
+  })
+})
+
+describe('resolveConfig — allowPrivateHosts (fail-closed in cloud)', () => {
+  const mock = (vars: Record<string, string>) => (k: string) => vars[k]
+
+  test('self-host respects CHM_ALLOW_PRIVATE_HOSTS', () => {
+    expect(
+      resolveConfig(mock({ CHM_ALLOW_PRIVATE_HOSTS: 'true' })).allowPrivateHosts
+    ).toBe(true)
+    expect(resolveConfig(mock({})).allowPrivateHosts).toBe(false)
+  })
+
+  test('cloud FORCES it off even when the flag is set', () => {
+    expect(
+      resolveConfig(
+        mock({ CHM_DEPLOYMENT_MODE: 'cloud', CHM_ALLOW_PRIVATE_HOSTS: 'true' })
+      ).allowPrivateHosts
+    ).toBe(false)
+    expect(
+      resolveConfig(
+        mock({ CHM_CLOUD_MODE: 'true', CHM_ALLOW_PRIVATE_HOSTS: '1' })
+      ).allowPrivateHosts
+    ).toBe(false)
   })
 })
 
@@ -51,6 +77,7 @@ describe('resolveConfig — profile default, explicit var overrides', () => {
       clerkPublicRead: true,
       userConnectionsDb: true,
       conversationDb: true,
+      allowPrivateHosts: false,
     })
   })
 

--- a/apps/dashboard/src/lib/config/deployment-mode.ts
+++ b/apps/dashboard/src/lib/config/deployment-mode.ts
@@ -51,6 +51,12 @@ export interface ModeDefaults {
   userConnectionsDb: boolean
   /** Server-side agent conversation persistence. */
   conversationDb: boolean
+  /**
+   * Allow connecting to private / LAN / loopback / Tailscale (CGNAT) ClickHouse
+   * hosts through the connection form. Self-host only — FORCED off in cloud mode
+   * (multi-tenant SSRF safety), regardless of the explicit flag.
+   */
+  allowPrivateHosts: boolean
 }
 
 /**
@@ -65,6 +71,7 @@ const MODE_DEFAULTS: Record<DeploymentMode, ModeDefaults> = {
     clerkPublicRead: false,
     userConnectionsDb: false,
     conversationDb: false,
+    allowPrivateHosts: false,
   },
   cloud: {
     cloudMode: true,
@@ -72,6 +79,7 @@ const MODE_DEFAULTS: Record<DeploymentMode, ModeDefaults> = {
     clerkPublicRead: true,
     userConnectionsDb: true,
     conversationDb: true,
+    allowPrivateHosts: false,
   },
 }
 
@@ -115,6 +123,10 @@ export function resolveConfig(getEnv: EnvGetter): ResolvedConfig {
     parseBool(getEnv('CHM_FEATURE_USER_CONNECTIONS_DB')) ?? d.userConnectionsDb
   const conversationDb =
     parseBool(getEnv('CHM_FEATURE_CONVERSATION_DB')) ?? d.conversationDb
+  // Fail-closed: cloud ALWAYS blocks private hosts, the flag can't override it.
+  const allowPrivateHosts =
+    !cloudMode &&
+    (parseBool(getEnv('CHM_ALLOW_PRIVATE_HOSTS')) ?? d.allowPrivateHosts)
 
   return {
     mode,
@@ -123,5 +135,6 @@ export function resolveConfig(getEnv: EnvGetter): ResolvedConfig {
     clerkPublicRead,
     userConnectionsDb,
     conversationDb,
+    allowPrivateHosts,
   }
 }

--- a/apps/dashboard/src/lib/connection-errors.ts
+++ b/apps/dashboard/src/lib/connection-errors.ts
@@ -65,7 +65,7 @@ const RULES: Rule[] = [
     title: 'Host not allowed',
     explanation:
       'The hosted service blocks connections to private, internal, or loopback addresses (SSRF protection). Cloud can only reach publicly routable ClickHouse endpoints.',
-    fix: 'Use a public HTTPS endpoint (e.g. ClickHouse Cloud, or your server exposed on a public host/port). To monitor a private cluster, self-host ClickHouse Monitor inside your network instead.',
+    fix: 'Use a public HTTPS endpoint (e.g. ClickHouse Cloud, or your server exposed on a public host/port). To monitor a private/LAN/Tailscale cluster, self-host ClickHouse Monitor inside your network and set CHM_ALLOW_PRIVATE_HOSTS=true (self-host only — the hosted cloud always blocks private addresses).',
     docsSlug: 'guides/connection-errors',
   },
   {

--- a/plans/01-allow-private-hosts.md
+++ b/plans/01-allow-private-hosts.md
@@ -1,0 +1,83 @@
+# 01 — Allow private/LAN/Tailscale hosts on self-host
+
+## Problem
+
+The SSRF guard `validateHostUrl` (`apps/dashboard/src/lib/browser-connections/host-url.ts`)
+rejects every internal address — private (RFC1918), loopback, link-local, and
+**CGNAT `100.64.0.0/10` (Tailscale)** — for ALL deployments. It is not gated by
+deployment mode. So a **self-hosted** operator on a homelab cannot add their own
+`duet-ubuntu`/LAN/tailnet ClickHouse host through the per-user connection form;
+only the trusted `CLICKHOUSE_HOST` env path reaches them.
+
+This violates the project invariant: *"self-hosted stays whole — never gate a
+core monitoring feature behind cloud mode."* SSRF protection is essential for the
+multi-tenant **cloud**, but on a single-tenant **self-host** the operator IS the
+trust boundary and should be able to monitor private clusters via the UI.
+
+## Goal
+
+A self-host operator can set **`CHM_ALLOW_PRIVATE_HOSTS=true`** and then add a
+private/LAN/Tailscale ClickHouse host through the connection form. The hosted
+**cloud stays locked down** (fail-closed): the flag is ignored when cloud mode is
+on, and defaults off everywhere.
+
+## Design (fail-closed)
+
+Add `arePrivateHostsAllowed()` resolved as:
+
+```
+allow = parseBool(CHM_ALLOW_PRIVATE_HOSTS) === true
+        && !isCloudModeServer()      // cloud ALWAYS blocks, flag can't override
+```
+
+- Default (unset) → `false` → current behaviour, OSS build never degraded.
+- Cloud mode → always `false` regardless of the flag (multi-tenant safety).
+- Self-host + flag true → internal-address rejection is skipped in
+  `resolveValidatedHostUrl`; DNS-rebinding/scheme checks still run.
+
+Thread it into `host-url.ts`: the internal-IP rejections (`localhost`,
+`isInternalIp(hostname)`, resolved-address check) become conditional on
+`!arePrivateHostsAllowed()`. Keep protocol + DNS-resolution + empty-result
+checks unconditional.
+
+Centralize via `lib/config/deployment-mode.ts` (it already resolves `CHM_*`
+flags) so the value is read once and the env name is documented next to the
+others.
+
+## Surfaces to update
+
+- `lib/browser-connections/host-url.ts` — gate the 3 internal-address returns.
+- `lib/config/deployment-mode.ts` — add `allowPrivateHosts` to the resolved
+  config + `modeDefaults` (oss: false, cloud: false).
+- `.env.example` — document `CHM_ALLOW_PRIVATE_HOSTS` (self-host only).
+- `lib/connection-errors.ts` — extend the `host_not_allowed` fix text to mention
+  the flag for self-hosters.
+- Docs: `docs/content/guide/guides/connection-errors.mdx` note.
+
+## Real test
+
+`host-url.test.ts` (extend existing or add):
+
+1. **Default blocks** — with the flag unset, `validateHostUrl('http://192.168.1.10:8123')`,
+   a `100.64.x` Tailscale IP, and `http://localhost:8123` all return the
+   internal-address error. (Locks current safety.)
+2. **Self-host + flag allows** — inject `allowPrivate=true` (via the resolver
+   seam, not real env) → the same three now resolve to a valid URL.
+3. **Cloud overrides flag** — `allowPrivate` resolver with cloud mode on + flag
+   true → still blocked. (This is the security-critical assertion; it must fail
+   if someone later lets the flag win in cloud.)
+
+The resolver is injected as a parameter/seam so the test needs no real env
+mutation (mirrors how `resolveHostAddresses` is already injected).
+
+## Verification
+
+```
+cd apps/dashboard && bun test src/lib/browser-connections/host-url.test.ts
+cd apps/dashboard && bun run type-check
+```
+
+## Out of scope
+
+- A UI toggle for the flag (it's an operator env decision, not per-user).
+- Changing cloud behaviour in any way.

--- a/plans/02-plan-benefits-parity.md
+++ b/plans/02-plan-benefits-parity.md
@@ -1,0 +1,135 @@
+# 02 — Plan-benefits parity: advertised ⟺ enforced (or explicitly deferred)
+
+## Current reality (audited)
+
+Only **one** advertised benefit is enforced in code: the **host cap**
+(`routes/api/v1/user-connections.ts` → `checkHostLimit` → pooled by
+`countOwnerHosts`). Everything else is advertised in `@chm/pricing` and
+unit-tested in isolation, but **wired to no runtime gate**:
+
+| Benefit | Advertised | Enforced today |
+|---|---|---|
+| `hosts` | yes | **YES** (`user-connections.ts`) |
+| `seats` | yes | no — `checkSeatLimit` has no caller |
+| `alertRules` | yes | no — no alert-rule route even exists |
+| `retentionDays` | yes | no — conversations/insights never pruned by plan |
+| `aiRequestsPerDay` | yes | no — agent route never counts/gates |
+| `aiMonthlyUsdBudget` / `aiOverage` | yes | no — spend never metered |
+| 13 `PlanCapability` flags | yes | no — none mapped to a gate; used only to render the matrix |
+
+`PlanCapability` (e.g. `alerting_basic`, `fleet_view`, `sso_rbac_audit`) and the
+existing gating systems (`lib/edition` `ENTERPRISE_FEATURES`,
+`lib/feature-permissions`) are **completely decoupled** — different string names,
+no mapping.
+
+## The product constraint that shapes this
+
+The pricing page states **"Early access — free while in beta"** and Free carries
+an "Early access" badge. Therefore **per-tier feature enforcement must NOT be
+switched on now** — doing so would remove features current users already enjoy,
+breaking the beta promise and the "self-hosted/OSS stays whole" + "never remove a
+feature" invariants. Host-cap enforcement is the deliberate exception (it caps a
+cost/abuse vector without removing a capability).
+
+So "parity" right now = **codify the contract and lock it with tests**, not
+"gate everything." Enforcement is *staged* behind an explicit, tested registry so
+it can be switched on at GA without a scavenger hunt.
+
+## Goal
+
+1. A single **capability/limit enforcement registry** is the source of truth for
+   *whether each advertised benefit is enforced yet* — every `PlanCapability`
+   and every numeric limit is classified `enforced | deferred | inherent`, with
+   a reason and (when enforced) a pointer to the gate.
+2. **Drift is impossible to ship silently**: tests fail if (a) a new capability
+   is added without classifying it, (b) the landing matrix and the in-app matrix
+   disagree, or (c) an "enforced" claim has no gate.
+3. The two surfaces (landing + dashboard) render benefits from the **same**
+   `@chm/pricing` data (already true after the centralization) — now *asserted*.
+
+This plan does NOT turn on feature gating (free beta). It makes the contract
+real, visible, and regression-proof, and implements the safe enforcement.
+
+## Implement now
+
+### A. Enforcement registry — `apps/dashboard/src/lib/billing/plan-enforcement.ts`
+
+```ts
+type Enforcement =
+  | { status: 'enforced'; gate: string }   // file:fn that enforces it
+  | { status: 'deferred'; reason: string } // advertised, GA/roadmap
+  | { status: 'inherent' }                 // not software-gated (support, core)
+
+export const CAPABILITY_ENFORCEMENT: Record<PlanCapability, Enforcement>
+export const LIMIT_ENFORCEMENT: Record<
+  'hosts'|'seats'|'alertRules'|'retentionDays'|'aiRequestsPerDay', Enforcement>
+```
+
+- `hosts` → `{ status:'enforced', gate:'user-connections.ts handlePost / checkHostLimit' }`
+- `core_monitoring`, `priority_support` → `inherent`
+- everything else → `deferred` with a one-line reason ("free during early
+  access; gate at GA") so the empty promise is explicit, not hidden.
+
+### B. Parity tests — `plan-enforcement.test.ts` + extend `plans.test.ts`
+
+Real tests (each fails if the contract regresses):
+
+1. **Total coverage** — `CAPABILITY_ENFORCEMENT` has an entry for *every*
+   `PlanCapability` (and the limit map for every limit key). Add a capability to
+   `@chm/pricing` without classifying it → **fails**. (This is the anti-drift
+   guard.)
+2. **Enforced claims are honest** — every `status:'enforced'` entry has a
+   non-empty `gate` string. (You can't mark something enforced without naming
+   where.)
+3. **Cross-surface parity** — assert the dashboard comparison rows and the
+   landing comparison rows produce identical strings for each shared limit, by
+   importing the shared `@chm/pricing` display helpers and comparing
+   `planHosts/planSeats/planAlertRules/planRetention/planAiUsage` for all four
+   tiers against the literal values the matrices claim. (Catches a future
+   hard-coded divergence.)
+4. **Host cap really blocks** (integration-ish, pure): given a Pro plan and
+   `usedHosts = plan.hosts`, `checkHostLimit(...).allowed === false`; at
+   `hosts-1` it's true. (Locks the one enforced path.)
+
+### C. Wire the next-safe limit: nothing that removes a feature
+
+The only enforcement safe to add in beta beyond hosts is **abuse/cost caps**, and
+the AI daily-message cap needs a per-owner per-day counter store that does not
+exist yet — that is its own feature (see roadmap). So **no new gating is switched
+on in this plan.** The registry marks `aiRequestsPerDay`, `seats`, `alertRules`,
+`retentionDays` as `deferred` with the concrete next step recorded below.
+
+## Staged enforcement roadmap (each: goal + real test, NOT built here)
+
+Recorded so they're tracked, not lost. Implement per-item when GA pricing turns on.
+
+- **AI daily message cap** — Goal: agent message route 429s once
+  `requestsToday >= plan.aiRequestsPerDay` for `deferred→enforced`. Needs a
+  per-owner daily counter (D1 `ai_usage_daily`). Test: route returns 429 at the
+  cap, 200 below; Pro/Max soft-cap (overage) returns 200 past cap.
+- **Seat cap** — Goal: block org-member invite past `plan.seats`. Needs a Clerk
+  `organizationMembership.created` webhook that counts members vs the owner's
+  plan. Test: webhook handler rejects/flags the (seats+1)th member.
+- **Retention** — Goal: conversations/insights older than `plan.retentionDays`
+  excluded from reads + pruned by cron. Test: a row older than the cutoff is not
+  returned for a Free (7-day) owner.
+- **Alert rules** — blocked on the alerting feature existing at all; classify
+  `deferred` until then.
+- **Capability gates (data_export, anomaly_detection, fleet_view, …)** — Goal: a
+  `requirePlanCapability(cap)` server gate + UI lock, switched on at GA. Test:
+  gate denies a Free owner, allows a Max owner. Map `PlanCapability` →
+  `feature-permissions` here.
+
+## Verification
+
+```
+cd apps/dashboard && bun test src/lib/billing/
+cd apps/dashboard && bun run type-check
+```
+
+## Why staged, not all-on (summary)
+
+Switching feature gates on during free early access removes capabilities from
+current users. The registry + tests make the *promise* truthful and
+drift-proof now; flipping `deferred→enforced` is a one-line registry change plus
+the per-item wiring above, each with its test, done when paid GA launches.

--- a/plans/03-blog-stat-strip.md
+++ b/plans/03-blog-stat-strip.md
@@ -1,0 +1,43 @@
+# 03 — Blog v0.3 stat strip: keep facts, drop deck-vibe
+
+## Problem
+
+`apps/blog/src/content/blog/chmonitor-v0-3.md` opens with a 4-up stat strip:
+`8 new features · 70+ fixes · 13 perf wins · 71 charts`. The numbers are real,
+but the bare big-number/label grid reads like a pitch-deck slide — the one
+"marketing-deck" tell the redesign audit flagged.
+
+## Goal
+
+Keep the factual numbers (they're true and useful) but present them as a calm,
+factual line rather than a hype stat-grid — consistent with the post's
+sentence-case, plain-language voice.
+
+## Decision needed (low stakes — default chosen)
+
+Default: **soften, don't delete.** Convert the stat-row into a single quiet
+sentence under the launch film caption, e.g.:
+
+> v0.3 lands 8 new features, 70+ fixes, 13 performance wins, and 71 charts.
+
+Drop the `.stat-row`/`.stat` block (and its now-unused CSS in the blog
+`Base.astro` if nothing else uses it — verify first, remove only our own orphan).
+
+## Real test
+
+This is prose; the "test" is a build + content assertion:
+- `cd apps/blog && bun run build` succeeds.
+- Built post HTML no longer contains `class="stat-row"` and DOES contain the new
+  sentence. (A grep assertion in the verification step, not a unit test.)
+
+## Verification
+
+```
+cd apps/blog && bun run build
+grep -c 'stat-row' apps/blog/dist/**/index.html   # → 0
+```
+
+## Note
+
+If the unused `.stat-row`/`.stat` CSS is shared/used elsewhere, leave it
+(surgical: remove only orphans we create).

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,35 @@
+# Plans — cloud plan-benefits parity & follow-ups
+
+This directory holds implementation plans for making the cloud (SaaS) **plan
+benefits real, consistent, and tested**, plus two standalone follow-ups raised
+in review.
+
+## North-star goal
+
+> Every benefit a plan advertises in `@chm/pricing` is (a) rendered identically
+> on the landing pricing page and the in-app billing page, and (b) actually
+> enforced at runtime — or explicitly, visibly marked "not yet enforced" with a
+> tracking test. No advertised benefit is silently unenforced; no surface drifts
+> from the canonical source.
+
+"Fail loud" applies: if a benefit can't be enforced yet, the plan says so and a
+test asserts the *current* contract so a future change can't regress it quietly.
+
+## Plans
+
+| # | Plan | Type | Risk |
+|---|------|------|------|
+| 01 | [allow-private-hosts.md](01-allow-private-hosts.md) | feature (self-host) | low |
+| 02 | [plan-benefits-parity.md](02-plan-benefits-parity.md) | correctness + tests | medium |
+| 03 | [blog-stat-strip.md](03-blog-stat-strip.md) | copy | trivial |
+
+## How "done" is judged (every plan)
+
+Each plan defines:
+- **Goal** — a single measurable outcome.
+- **Real test** — a test that *fails today* (or would fail if the behaviour
+  regressed) and passes after the change. Not a tautology.
+- **Verification** — the exact commands to prove it (build + targeted test).
+
+Testing note (CLAUDE.md): use **Bun test** for unit/logic and **Cypress** for
+component/e2e. Jest has known hanging issues — do not add Jest.


### PR DESCRIPTION
Plans written to `plans/` (each with a measurable **goal** and a **real test**), then implemented.

## plan 02 — plan-benefits parity *(the centerpiece)*
Audit finding: of everything the plans advertise in `@chm/pricing`, **only the host cap is actually enforced** — seats, alert rules, retention, AI daily/budget limits, and all 13 capabilities are advertised + unit-tested but wired to no runtime gate. Because the product is **free during early access**, switching feature gates on now would *remove* capabilities from current users — so the right move is to make the contract explicit and drift-proof, not gate everything.

- **`lib/billing/plan-enforcement.ts`** — a registry classifying every capability + numeric limit as `enforced | deferred | inherent`, with reasons and (for enforced) the gate location. Single source of truth for "is this advertised benefit real yet."
- **`plan-enforcement.test.ts`** — real anti-drift tests: (1) adding a capability without classifying it **fails the build**; (2) an `enforced` claim must name its gate; (3) the host cap really blocks (Pro at 3 → denied, at 2 → allowed); (4) **cross-surface render parity** — the landing matrix and the in-app matrix derive identical strings from the shared helpers.
- The staged enforcement roadmap (AI daily cap, seats, retention, capability gates) is documented in `plans/02-*` with a goal + test each, to flip on at paid GA.

## plan 01 — `CHM_ALLOW_PRIVATE_HOSTS` (self-host opt-in)
Self-hosters can now connect **private / LAN / Tailscale (CGNAT)** ClickHouse hosts via the connection form by setting `CHM_ALLOW_PRIVATE_HOSTS=true`. **Fail-closed**: `resolveConfig` forces it off in cloud mode regardless of the flag (multi-tenant SSRF safety). `host-url.ts` gates the internal-address rejections behind it; scheme + DNS-resolution checks stay unconditional. Resolves the Tailscale/homelab connection question. Documented in `.env.example` + the connection-error fix text.

## plan 03 — blog polish
Softened the v0.3 "stat grid" into a factual sentence; removed the now-orphaned `.stat-row` CSS.

## Verification
- Dashboard `tsc` clean; **58 tests pass** (billing + config + host-url); dashboard + landing + blog builds exit 0; blog HTML confirmed stat-row-free.

Co-Authored-By: duyetbot <bot@duyet.net>