### PR TITLE
feat(billing): enforce per-tier plan limits (AI cap, seats, retention, MCP)

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -178,6 +178,9 @@ CHM_USER_CONNECTIONS_ENCRYPTION_KEY=
 # POLAR_ACCESS_TOKEN=
 # POLAR_WEBHOOK_SECRET=
 # CHM_POLAR_SERVER=sandbox
+# Clerk webhook signing secret — from Clerk Dashboard → Webhooks → Signing Secret.
+# Required to verify organizationMembership.created seat-cap enforcement.
+# CLERK_WEBHOOK_SECRET=
 # Bearer token guarding the server-to-server agent API (/api/v1/agent).
 AGENT_API_TOKEN=
 # Shared secrets for proxy / trusted-header auth (see above).

--- a/apps/dashboard/src/db/conversations-migrations/0005_ai_usage_daily.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0005_ai_usage_daily.sql
@@ -1,0 +1,12 @@
+-- Per-owner daily AI request usage counter (cloud SaaS only).
+-- One row per (owner_id, day); written/incremented on every agent request,
+-- read by the plan-enforcement gate in the agent route.
+-- owner_id mirrors billing-owner ids (Clerk user_* or org_*).
+-- day is UTC date in 'YYYY-MM-DD' format.
+CREATE TABLE IF NOT EXISTS ai_usage_daily (
+  owner_id   TEXT    NOT NULL,
+  day        TEXT    NOT NULL,
+  count      INTEGER NOT NULL DEFAULT 0,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (owner_id, day)
+);

--- a/apps/dashboard/src/lib/billing/ai-usage-store.test.ts
+++ b/apps/dashboard/src/lib/billing/ai-usage-store.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for ai-usage-store.ts
+ *
+ * Uses a minimal in-memory D1 fake injected via mock.module('@chm/platform')
+ * — the same pattern as src/lib/insights/store/d1-store.test.ts — so the
+ * store's real SQL is exercised without requiring a Cloudflare Workers runtime.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// ---------------------------------------------------------------------------
+// In-memory D1 fake
+// ---------------------------------------------------------------------------
+
+/** Keyed by "owner_id::day" → count */
+type UsageStore = Map<string, number>
+
+function makeFakeD1(store: UsageStore) {
+  function prepare(sql: string) {
+    const isSelect = sql.trimStart().toUpperCase().startsWith('SELECT')
+
+    return {
+      bind(...values: unknown[]) {
+        const ownerId = values[0] as string
+        const day = values[1] as string
+        const key = `${ownerId}::${day}`
+
+        return {
+          async first<T>() {
+            if (!isSelect) return null
+            const count = store.get(key)
+            if (count == null) return null
+            return { count } as unknown as T
+          },
+          async run() {
+            if (!isSelect) {
+              // INSERT ... ON CONFLICT DO UPDATE SET count = count + 1
+              store.set(key, (store.get(key) ?? 0) + 1)
+            }
+            return { success: true, results: [], meta: {} }
+          },
+        }
+      },
+    }
+  }
+
+  return { prepare }
+}
+
+// ---------------------------------------------------------------------------
+// Inject via mocked platform (must happen before any import of the SUT)
+// ---------------------------------------------------------------------------
+
+let currentDb: ReturnType<typeof makeFakeD1> | null = null
+
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({
+    getD1Database: () => currentDb,
+    getDurableObjectNamespace: () => null,
+  }),
+}))
+
+// Dynamic import so the mock is already in place when the module initialises.
+const { utcDayKey, getAiUsageToday, incrementAiUsage } = await import(
+  './ai-usage-store'
+)
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const FIXED_DATE = new Date('2025-03-15T10:30:00Z')
+
+describe('utcDayKey (pure)', () => {
+  test('formats a known UTC date correctly', () => {
+    expect(utcDayKey(new Date('2025-01-01T00:00:00Z'))).toBe('2025-01-01')
+    expect(utcDayKey(new Date('2025-12-31T23:59:59Z'))).toBe('2025-12-31')
+    expect(utcDayKey(new Date('2025-03-15T10:30:00Z'))).toBe('2025-03-15')
+  })
+
+  test('returns the current UTC date when called without args', () => {
+    const today = new Date().toISOString().slice(0, 10)
+    expect(utcDayKey()).toBe(today)
+  })
+})
+
+describe('getAiUsageToday', () => {
+  beforeEach(() => {
+    currentDb = makeFakeD1(new Map())
+  })
+
+  test('returns 0 when no row exists', async () => {
+    expect(await getAiUsageToday('user_abc', FIXED_DATE)).toBe(0)
+  })
+
+  test('returns 0 when D1 binding is unavailable', async () => {
+    currentDb = null
+    expect(await getAiUsageToday('user_abc', FIXED_DATE)).toBe(0)
+  })
+})
+
+describe('incrementAiUsage + getAiUsageToday round-trip', () => {
+  let store: UsageStore
+
+  beforeEach(() => {
+    store = new Map()
+    currentDb = makeFakeD1(store)
+  })
+
+  test('count goes 0 → 1 after a single increment', async () => {
+    expect(await getAiUsageToday('user_abc', FIXED_DATE)).toBe(0)
+    await incrementAiUsage('user_abc', FIXED_DATE)
+    expect(await getAiUsageToday('user_abc', FIXED_DATE)).toBe(1)
+  })
+
+  test('count accumulates across multiple increments', async () => {
+    for (let i = 0; i < 5; i++) {
+      await incrementAiUsage('user_xyz', FIXED_DATE)
+    }
+    expect(await getAiUsageToday('user_xyz', FIXED_DATE)).toBe(5)
+  })
+
+  test('different owners are isolated', async () => {
+    await incrementAiUsage('user_a', FIXED_DATE)
+    await incrementAiUsage('user_a', FIXED_DATE)
+    await incrementAiUsage('user_b', FIXED_DATE)
+
+    expect(await getAiUsageToday('user_a', FIXED_DATE)).toBe(2)
+    expect(await getAiUsageToday('user_b', FIXED_DATE)).toBe(1)
+  })
+
+  test('different days are isolated for the same owner', async () => {
+    const day1 = new Date('2025-03-14T10:00:00Z')
+    const day2 = new Date('2025-03-15T10:00:00Z')
+
+    await incrementAiUsage('user_abc', day1)
+    await incrementAiUsage('user_abc', day1)
+    await incrementAiUsage('user_abc', day2)
+
+    expect(await getAiUsageToday('user_abc', day1)).toBe(2)
+    expect(await getAiUsageToday('user_abc', day2)).toBe(1)
+  })
+
+  test('increment is a no-op when D1 binding is unavailable', async () => {
+    currentDb = null
+    // Must not throw
+    await incrementAiUsage('user_abc', FIXED_DATE)
+  })
+})

--- a/apps/dashboard/src/lib/billing/ai-usage-store.ts
+++ b/apps/dashboard/src/lib/billing/ai-usage-store.ts
@@ -1,0 +1,71 @@
+/**
+ * AI daily usage store — D1 persistence for the per-owner per-day AI request
+ * counter consumed by the plan-enforcement gate in the agent route.
+ *
+ * Reads and writes degrade gracefully: when the CHM_CLOUD_D1 binding is absent
+ * (local dev, self-host) or the table does not yet exist, functions return safe
+ * defaults (0 / no-op) so OSS deployments are never gated.
+ *
+ * Schema: see src/db/conversations-migrations/0005_ai_usage_daily.sql
+ */
+
+import { getPlatformBindings } from '@chm/platform'
+
+/** Returns the UTC date string 'YYYY-MM-DD' for the given instant. */
+export function utcDayKey(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10)
+}
+
+function getDb() {
+  return getPlatformBindings().getD1Database('CHM_CLOUD_D1')
+}
+
+/**
+ * Return how many AI requests `ownerId` has made today (UTC).
+ * Returns 0 when D1 is unavailable or no row exists yet.
+ */
+export async function getAiUsageToday(
+  ownerId: string,
+  now: Date = new Date()
+): Promise<number> {
+  const db = getDb()
+  if (!db) return 0
+  try {
+    const row = await db
+      .prepare(
+        `SELECT count FROM ai_usage_daily WHERE owner_id = ?1 AND day = ?2`
+      )
+      .bind(ownerId, utcDayKey(now))
+      .first<{ count: number }>()
+    return row?.count ?? 0
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Atomically increment `ownerId`'s request count for today (UTC).
+ * No-op when D1 is unavailable.
+ */
+export async function incrementAiUsage(
+  ownerId: string,
+  now: Date = new Date()
+): Promise<void> {
+  const db = getDb()
+  if (!db) return
+  try {
+    const updatedAt = Math.floor(now.getTime() / 1000)
+    await db
+      .prepare(
+        `INSERT INTO ai_usage_daily (owner_id, day, count, updated_at)
+         VALUES (?1, ?2, 1, ?3)
+         ON CONFLICT(owner_id, day) DO UPDATE SET
+           count      = count + 1,
+           updated_at = excluded.updated_at`
+      )
+      .bind(ownerId, utcDayKey(now), updatedAt)
+      .run()
+  } catch {
+    // Swallow: a missing table or transient D1 error must not break the request.
+  }
+}

--- a/apps/dashboard/src/lib/billing/clerk-webhook-config.ts
+++ b/apps/dashboard/src/lib/billing/clerk-webhook-config.ts
@@ -1,0 +1,17 @@
+/**
+ * Clerk webhook — runtime config.
+ *
+ * CLERK_WEBHOOK_SECRET (secret) — signing secret used to verify inbound
+ * webhooks from Clerk's Dashboard → Webhooks configuration. Set it once
+ * and never commit the real value (only the commented-out key lives in
+ * .env.example). Mirror of getWebhookSecret() in polar-config.ts.
+ */
+
+function readEnv(key: string): string | undefined {
+  const v = process.env[key]
+  return v === undefined || v === '' ? undefined : v
+}
+
+export function getClerkWebhookSecret(): string | undefined {
+  return readEnv('CLERK_WEBHOOK_SECRET')
+}

--- a/apps/dashboard/src/lib/billing/plan-capability.test.ts
+++ b/apps/dashboard/src/lib/billing/plan-capability.test.ts
@@ -1,0 +1,68 @@
+import { planAllowsCapability } from './plan-capability'
+import { getPlan } from './plans'
+import { describe, expect, it } from 'bun:test'
+
+/**
+ * Pure unit tests for planAllowsCapability.
+ * requirePlanCapability is async + Clerk-dependent; integration-tested separately.
+ */
+
+describe('planAllowsCapability — sso_rbac_audit (Enterprise-only)', () => {
+  it('denies free plan', () => {
+    expect(planAllowsCapability(getPlan('free'), 'sso_rbac_audit')).toBe(false)
+  })
+
+  it('denies pro plan', () => {
+    expect(planAllowsCapability(getPlan('pro'), 'sso_rbac_audit')).toBe(false)
+  })
+
+  it('denies max plan', () => {
+    expect(planAllowsCapability(getPlan('max'), 'sso_rbac_audit')).toBe(false)
+  })
+
+  it('allows enterprise plan', () => {
+    expect(planAllowsCapability(getPlan('enterprise'), 'sso_rbac_audit')).toBe(
+      true
+    )
+  })
+})
+
+describe('planAllowsCapability — core_monitoring (all tiers)', () => {
+  it('allows free', () => {
+    expect(planAllowsCapability(getPlan('free'), 'core_monitoring')).toBe(true)
+  })
+
+  it('allows pro', () => {
+    expect(planAllowsCapability(getPlan('pro'), 'core_monitoring')).toBe(true)
+  })
+
+  it('allows max', () => {
+    expect(planAllowsCapability(getPlan('max'), 'core_monitoring')).toBe(true)
+  })
+
+  it('allows enterprise', () => {
+    expect(planAllowsCapability(getPlan('enterprise'), 'core_monitoring')).toBe(
+      true
+    )
+  })
+})
+
+describe('planAllowsCapability — api_mcp_access (gate applied at routes/api/mcp.ts POST+GET)', () => {
+  it('denies free plan', () => {
+    expect(planAllowsCapability(getPlan('free'), 'api_mcp_access')).toBe(false)
+  })
+
+  it('denies pro plan', () => {
+    expect(planAllowsCapability(getPlan('pro'), 'api_mcp_access')).toBe(false)
+  })
+
+  it('allows max plan', () => {
+    expect(planAllowsCapability(getPlan('max'), 'api_mcp_access')).toBe(true)
+  })
+
+  it('allows enterprise plan', () => {
+    expect(planAllowsCapability(getPlan('enterprise'), 'api_mcp_access')).toBe(
+      true
+    )
+  })
+})

--- a/apps/dashboard/src/lib/billing/plan-capability.ts
+++ b/apps/dashboard/src/lib/billing/plan-capability.ts
@@ -1,0 +1,83 @@
+/**
+ * Server-side plan-capability gate.
+ *
+ * requirePlanCapability(cap, request) mirrors the style of
+ * authorizeFeatureRequest (feature-permissions/server.ts): returns a Response to
+ * BLOCK, null to ALLOW.
+ *
+ * Self-hosted / OSS invariant (hard): when billing context is unavailable —
+ * Clerk not configured, no active session, or D1 unreachable — resolveBillingOwner()
+ * throws. We catch every resolution error and return null so OSS deployments are
+ * NEVER degraded by plan gating. Cloud behaviour is purely additive.
+ *
+ * Module design: billing-owner and user-subscription are dynamically imported
+ * inside requirePlanCapability (matching feature-permissions/server.ts' lazy Clerk
+ * import pattern) so that importing THIS module does NOT pull in cloudflare:workers
+ * at parse time — this keeps planAllowsCapability unit-testable in Bun.
+ */
+
+import type { Plan, PlanCapability } from './plans'
+
+import { hasCapability } from './entitlements'
+
+/**
+ * Pure helper: does `plan` grant `cap`? Unit-testable without async / Clerk.
+ * Thin alias of hasCapability so callers have a single billing import point.
+ */
+export function planAllowsCapability(plan: Plan, cap: PlanCapability): boolean {
+  return hasCapability(plan, cap)
+}
+
+function planCapabilityError(cap: PlanCapability, planId: string): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        code: 'plan_capability_required',
+        message: `Your current plan does not include the "${cap}" capability. Upgrade to unlock it.`,
+      },
+      details: { capability: cap, planId },
+    }),
+    {
+      status: 402,
+      headers: { 'content-type': 'application/json' },
+    }
+  )
+}
+
+/**
+ * Server-side capability gate. Returns a 402 Response to block, null to allow.
+ *
+ * Call this after any auth gate (e.g. authorizeFeatureRequest) — it assumes
+ * the caller is authenticated when billing context is available.
+ *
+ * OSS / self-hosted: if Clerk is not configured or the billing context cannot be
+ * resolved for any reason, returns null (open). Cloud-only behaviour is additive.
+ *
+ * @param cap - The {@link PlanCapability} required by the endpoint.
+ * @param _request - The incoming Web Request (accepted for API symmetry with
+ *   authorizeFeatureRequest; not forwarded to resolveBillingOwner which reads
+ *   the Clerk session from context, not from the request object directly).
+ */
+export async function requirePlanCapability(
+  cap: PlanCapability,
+  _request: Request
+): Promise<Response | null> {
+  let plan: Plan
+  try {
+    // Dynamic imports prevent cloudflare:workers from being pulled in at
+    // module parse time, keeping planAllowsCapability unit-testable in Bun.
+    const { resolveBillingOwner } = await import('./billing-owner')
+    const { getPlanForOwner } = await import('./user-subscription')
+
+    const owner = await resolveBillingOwner()
+    plan = await getPlanForOwner(owner.id)
+  } catch {
+    // Self-hosted, no Clerk key, cold D1, or any other resolution failure.
+    // Hard invariant: never gate OSS. Return null → allow.
+    return null
+  }
+
+  if (planAllowsCapability(plan, cap)) return null
+
+  return planCapabilityError(cap, plan.id)
+}

--- a/apps/dashboard/src/lib/billing/plan-enforcement.test.ts
+++ b/apps/dashboard/src/lib/billing/plan-enforcement.test.ts
@@ -55,11 +55,18 @@ describe('plan-enforcement — anti-drift coverage', () => {
     }
   })
 
-  test('the host cap is the one enforced limit today', () => {
-    // Documents the audited reality; flip deliberately as enforcement lands.
+  test('the cost/abuse-bounded limits are enforced; alertRules stays deferred', () => {
+    // Enforcement is live for the limits that cap a cost/abuse vector. alertRules
+    // stays deferred only because no alert-rule feature exists to gate yet.
     expect(LIMIT_ENFORCEMENT.hosts.status).toBe('enforced')
-    expect(LIMIT_ENFORCEMENT.seats.status).toBe('deferred')
-    expect(LIMIT_ENFORCEMENT.aiRequestsPerDay.status).toBe('deferred')
+    expect(LIMIT_ENFORCEMENT.seats.status).toBe('enforced')
+    expect(LIMIT_ENFORCEMENT.aiRequestsPerDay.status).toBe('enforced')
+    expect(LIMIT_ENFORCEMENT.retentionDays.status).toBe('enforced')
+    expect(LIMIT_ENFORCEMENT.alertRules.status).toBe('deferred')
+  })
+
+  test('api_mcp_access is the enforced capability gate', () => {
+    expect(CAPABILITY_ENFORCEMENT.api_mcp_access.status).toBe('enforced')
   })
 })
 

--- a/apps/dashboard/src/lib/billing/plan-enforcement.ts
+++ b/apps/dashboard/src/lib/billing/plan-enforcement.ts
@@ -2,16 +2,18 @@
  * Plan-benefit enforcement registry — the single source of truth for *whether
  * each advertised plan benefit is actually enforced in code yet*.
  *
- * Why this exists: `@chm/pricing` advertises limits + capabilities, but during
- * **early access everything is free** ("Early access — free while in beta"), so
- * per-tier feature gating is intentionally NOT switched on — turning it on now
- * would remove capabilities current users already have. The risk is that the
- * gap between "advertised" and "enforced" drifts silently and the marketing
- * promise quietly becomes untrue.
+ * Why this exists: `@chm/pricing` advertises limits + capabilities. This registry
+ * is the single source of truth for *whether each advertised benefit is actually
+ * gated in code*, so the gap between "advertised" and "enforced" can never drift
+ * silently (the tests in `plan-enforcement.test.ts` fail if a benefit is added
+ * without a classification, or if an `enforced` claim names no gate).
  *
- * This registry makes the gap EXPLICIT and the tests (`plan-enforcement.test.ts`)
- * make it impossible to add a benefit without classifying it. Flipping a benefit
- * from `deferred` to `enforced` at GA is a one-line change here plus its wiring.
+ * Per-tier enforcement is now LIVE for the cost/abuse-bounded benefits: host cap,
+ * AI daily-message cap, org seat cap, retention pruning, and the MCP capability.
+ * All gates are **fail-open for self-hosted/OSS** — owner/plan resolution throws
+ * without Clerk, and every call site swallows that to leave OSS ungated (the
+ * "self-hosted stays whole" invariant). Benefits still marked `deferred` either
+ * lack a feature to gate (alerting) or are intentionally free during beta.
  *
  * See plans/02-plan-benefits-parity.md.
  */
@@ -51,7 +53,10 @@ export const CAPABILITY_ENFORCEMENT: Record<PlanCapability, Enforcement> = {
   fleet_view: { status: 'deferred', reason: BETA },
   custom_dashboards: { status: 'deferred', reason: BETA },
   webhook_integrations: { status: 'deferred', reason: BETA },
-  api_mcp_access: { status: 'deferred', reason: BETA },
+  api_mcp_access: {
+    status: 'enforced',
+    gate: 'lib/billing/plan-capability.ts requirePlanCapability — routes/api/mcp.ts POST+GET',
+  },
   sso_rbac_audit: { status: 'deferred', reason: BETA },
 }
 
@@ -72,22 +77,19 @@ export const LIMIT_ENFORCEMENT: Record<LimitKey, Enforcement> = {
     gate: 'routes/api/v1/user-connections.ts handlePost → checkHostLimit (pooled by countOwnerHosts)',
   },
   seats: {
-    status: 'deferred',
-    reason:
-      'Needs a Clerk organizationMembership.created webhook to count members vs plan.seats.',
+    status: 'enforced',
+    gate: 'routes/api/v1/webhooks/clerk.ts organizationMembership.created → checkSeatLimit (rolls back over-limit member)',
   },
   alertRules: {
     status: 'deferred',
     reason: 'No alert-rule create path exists yet.',
   },
   retentionDays: {
-    status: 'deferred',
-    reason:
-      'Conversations/insights are not pruned or read-filtered by plan retention yet.',
+    status: 'enforced',
+    gate: 'conversation list read-filter (conversation-store list sinceMs) + routes/api/cron/retention-prune.ts → retentionCutoffMs',
   },
   aiRequestsPerDay: {
-    status: 'deferred',
-    reason:
-      'Agent route needs a per-owner daily counter (D1) before checkAiDailyLimit can gate.',
+    status: 'enforced',
+    gate: 'routes/api/v1/agent.ts handlePost → checkAiDailyLimit (counter: lib/billing/ai-usage-store.ts / ai_usage_daily)',
   },
 }

--- a/apps/dashboard/src/lib/billing/retention-enforcement.test.ts
+++ b/apps/dashboard/src/lib/billing/retention-enforcement.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Retention enforcement tests.
+ *
+ * Tests the pure helpers (retentionCutoffMs / isWithinRetention) and the
+ * MemoryStore sinceMs read-filter using the real plan data from @chm/pricing.
+ */
+
+import { MemoryStore } from '../conversation-store/memory-store'
+import { isWithinRetention, retentionCutoffMs } from './entitlements'
+import { getPlan } from './plans'
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plans
+// ─────────────────────────────────────────────────────────────────────────────
+
+const freePlan = getPlan('free') // retentionDays: 7
+const proPlan = getPlan('pro') // retentionDays: 30
+const maxPlan = getPlan('max') // retentionDays: 90
+const enterprisePlan = getPlan('enterprise') // retentionDays: null (unlimited)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// retentionCutoffMs
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('retentionCutoffMs', () => {
+  const NOW = Date.now()
+  const DAY_MS = 24 * 60 * 60 * 1000
+
+  test('free → 7-day cutoff', () => {
+    const cutoff = retentionCutoffMs(freePlan, NOW)
+    expect(cutoff).not.toBeNull()
+    expect(cutoff).toBe(NOW - 7 * DAY_MS)
+  })
+
+  test('pro → 30-day cutoff', () => {
+    const cutoff = retentionCutoffMs(proPlan, NOW)
+    expect(cutoff).not.toBeNull()
+    expect(cutoff).toBe(NOW - 30 * DAY_MS)
+  })
+
+  test('max → 90-day cutoff', () => {
+    const cutoff = retentionCutoffMs(maxPlan, NOW)
+    expect(cutoff).not.toBeNull()
+    expect(cutoff).toBe(NOW - 90 * DAY_MS)
+  })
+
+  test('enterprise → null (unlimited)', () => {
+    expect(retentionCutoffMs(enterprisePlan, NOW)).toBeNull()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isWithinRetention
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('isWithinRetention', () => {
+  const NOW = Date.now()
+  const DAY_MS = 24 * 60 * 60 * 1000
+
+  describe('free plan (7 days)', () => {
+    test('timestamp 6 days ago → within retention', () => {
+      const ts = NOW - 6 * DAY_MS
+      expect(isWithinRetention(freePlan, ts, NOW)).toBe(true)
+    })
+
+    test('timestamp 8 days ago → outside retention', () => {
+      const ts = NOW - 8 * DAY_MS
+      expect(isWithinRetention(freePlan, ts, NOW)).toBe(false)
+    })
+
+    test('exactly at the 7-day boundary → within retention', () => {
+      const ts = NOW - 7 * DAY_MS
+      expect(isWithinRetention(freePlan, ts, NOW)).toBe(true)
+    })
+  })
+
+  describe('enterprise plan (unlimited)', () => {
+    test('any timestamp → always within retention', () => {
+      const veryOld = NOW - 365 * 10 * DAY_MS // 10 years ago
+      expect(isWithinRetention(enterprisePlan, veryOld, NOW)).toBe(true)
+    })
+
+    test('retentionCutoffMs returns null', () => {
+      expect(retentionCutoffMs(enterprisePlan, NOW)).toBeNull()
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MemoryStore.list sinceMs read-filter
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('MemoryStore.list sinceMs filter', () => {
+  const USER = 'user-retention-test'
+  const NOW = Date.now()
+  const DAY_MS = 24 * 60 * 60 * 1000
+
+  beforeEach(async () => {
+    MemoryStore.clearAll()
+    const store = new MemoryStore()
+
+    // Insert a recent conversation (2 days ago)
+    await store.upsert({
+      id: 'conv-recent',
+      userId: USER,
+      title: 'Recent',
+      messages: [],
+      createdAt: NOW - 2 * DAY_MS,
+      updatedAt: NOW - 2 * DAY_MS,
+      messageCount: 0,
+    })
+
+    // Insert an old conversation (10 days ago)
+    await store.upsert({
+      id: 'conv-old',
+      userId: USER,
+      title: 'Old',
+      messages: [],
+      createdAt: NOW - 10 * DAY_MS,
+      updatedAt: NOW - 10 * DAY_MS,
+      messageCount: 0,
+    })
+  })
+
+  test('without sinceMs → returns both conversations', async () => {
+    const store = new MemoryStore()
+    const results = await store.list(USER)
+    expect(results.length).toBe(2)
+  })
+
+  test('with free-plan cutoff (7 days) → excludes the 10-day-old row', async () => {
+    const store = new MemoryStore()
+    const cutoff = retentionCutoffMs(freePlan, NOW)!
+    const results = await store.list(USER, 50, cutoff)
+    expect(results.length).toBe(1)
+    expect(results[0].id).toBe('conv-recent')
+  })
+
+  test('with enterprise (null cutoff) → no sinceMs applied, both rows returned', async () => {
+    const store = new MemoryStore()
+    const cutoff = retentionCutoffMs(enterprisePlan, NOW) // null
+    const results = await store.list(USER, 50, cutoff ?? undefined)
+    expect(results.length).toBe(2)
+  })
+
+  test('sinceMs that excludes all → empty list', async () => {
+    const store = new MemoryStore()
+    const futureCutoff = NOW + DAY_MS // everything is "too old"
+    const results = await store.list(USER, 50, futureCutoff)
+    expect(results.length).toBe(0)
+  })
+})

--- a/apps/dashboard/src/lib/billing/seat-enforcement.test.ts
+++ b/apps/dashboard/src/lib/billing/seat-enforcement.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Seat-enforcement unit tests — verifies that checkSeatLimit() correctly
+ * gates the `organizationMembership.created` webhook handler. The count
+ * passed in reflects the post-addition member total (after Clerk fires the
+ * webhook, memberships.data.length already includes the new member).
+ */
+
+import { checkSeatLimit } from './entitlements'
+import { BILLING_PLANS } from './plans'
+import { describe, expect, test } from 'bun:test'
+
+const { free, pro, enterprise } = BILLING_PLANS
+
+describe('seat-enforcement — checkSeatLimit', () => {
+  test('Free (seats=1): count=0 → allowed (no members yet)', () => {
+    expect(checkSeatLimit(free, 0).allowed).toBe(true)
+  })
+
+  test('Free (seats=1): count=1 → denied (at the cap — rollback new member)', () => {
+    const check = checkSeatLimit(free, 1)
+    expect(check.allowed).toBe(false)
+    expect(check.limit).toBe(1)
+    expect(check.remaining).toBe(0)
+    expect(check.reason).toBe('seat_limit')
+  })
+
+  test('Pro (seats=3): count=2 → allowed', () => {
+    expect(checkSeatLimit(pro, 2).allowed).toBe(true)
+  })
+
+  test('Pro (seats=3): count=3 → denied (at the cap)', () => {
+    expect(checkSeatLimit(pro, 3).allowed).toBe(false)
+  })
+
+  test('Enterprise (seats=null): any count → always allowed (unlimited)', () => {
+    const check = checkSeatLimit(enterprise, 1_000)
+    expect(check.allowed).toBe(true)
+    expect(check.unlimited).toBe(true)
+    expect(check.limit).toBeNull()
+    expect(check.remaining).toBeNull()
+  })
+})

--- a/apps/dashboard/src/lib/conversation-store/agentstate-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/agentstate-store.ts
@@ -396,7 +396,11 @@ export class AgentStateStore implements ConversationStore {
    * @param limit - Maximum number of conversations to return (default: 50)
    * @returns Array of conversation metadata (no messages)
    */
-  async list(userId: string, limit: number = 50): Promise<ConversationMeta[]> {
+  async list(
+    userId: string,
+    limit: number = 50,
+    sinceMs?: number
+  ): Promise<ConversationMeta[]> {
     try {
       const matches: ConversationMeta[] = []
       let cursor: string | undefined
@@ -414,6 +418,10 @@ export class AgentStateStore implements ConversationStore {
           const metadata = (conv.metadata ??
             {}) as Partial<StoredConversationMetadata>
           if (metadata.userId !== userId) {
+            continue
+          }
+          // Skip conversations outside the retention window
+          if (sinceMs != null && conv.updated_at < sinceMs) {
             continue
           }
           matches.push(this.toConversationMeta(conv, userId))

--- a/apps/dashboard/src/lib/conversation-store/browser-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/browser-store.ts
@@ -41,11 +41,15 @@ export class BrowserStore implements ConversationStore {
    * @param limit - Maximum number of conversations to return
    * @returns Array of conversation metadata, sorted by updatedAt DESC
    */
-  async list(_userId: string, limit?: number): Promise<ConversationMeta[]> {
+  async list(
+    _userId: string,
+    limit?: number,
+    sinceMs?: number
+  ): Promise<ConversationMeta[]> {
     try {
       const conversations = loadConversations()
 
-      const meta: ConversationMeta[] = conversations.map((conv) => ({
+      let meta: ConversationMeta[] = conversations.map((conv) => ({
         id: conv.id,
         userId: DEFAULT_USER_ID,
         title: conv.title,
@@ -53,6 +57,11 @@ export class BrowserStore implements ConversationStore {
         updatedAt: conv.updatedAt,
         messageCount: conv.messages.length,
       }))
+
+      // Apply retention cutoff when provided
+      if (sinceMs != null) {
+        meta = meta.filter((m) => m.updatedAt >= sinceMs)
+      }
 
       // Already sorted by updatedAt DESC from upsertConversation
       const result = limit ? meta.slice(0, limit) : meta

--- a/apps/dashboard/src/lib/conversation-store/d1-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/d1-store.ts
@@ -73,19 +73,34 @@ export class D1Store implements ConversationStore {
    * @param limit - Maximum number of conversations to return (default: 50)
    * @returns Array of conversation metadata
    */
-  async list(userId: string, limit: number = 50): Promise<ConversationMeta[]> {
+  async list(
+    userId: string,
+    limit: number = 50,
+    sinceMs?: number
+  ): Promise<ConversationMeta[]> {
     try {
       const db = this.getDb()
 
-      const stmt = db
-        .prepare(
-          `SELECT id, user_id, title, message_count, created_at, updated_at
+      const stmt =
+        sinceMs != null
+          ? db
+              .prepare(
+                `SELECT id, user_id, title, message_count, created_at, updated_at
+           FROM conversations
+           WHERE user_id = ?1 AND updated_at >= ?2
+           ORDER BY updated_at DESC
+           LIMIT ?3`
+              )
+              .bind(userId, sinceMs, limit)
+          : db
+              .prepare(
+                `SELECT id, user_id, title, message_count, created_at, updated_at
            FROM conversations
            WHERE user_id = ?1
            ORDER BY updated_at DESC
            LIMIT ?2`
-        )
-        .bind(userId, limit)
+              )
+              .bind(userId, limit)
 
       const result = await stmt.all<D1ConversationRow>()
 

--- a/apps/dashboard/src/lib/conversation-store/memory-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/memory-store.ts
@@ -35,11 +35,20 @@ export class MemoryStore implements ConversationStore {
    * @param limit - Maximum number of conversations to return
    * @returns Array of conversation metadata, sorted by updatedAt DESC
    */
-  async list(userId: string, limit?: number): Promise<ConversationMeta[]> {
+  async list(
+    userId: string,
+    limit?: number,
+    sinceMs?: number
+  ): Promise<ConversationMeta[]> {
     const conversations = storage.get(userId) || []
 
     // Sort by updatedAt DESC (most recent first)
-    const sorted = [...conversations].sort((a, b) => b.updatedAt - a.updatedAt)
+    let sorted = [...conversations].sort((a, b) => b.updatedAt - a.updatedAt)
+
+    // Apply retention cutoff when provided
+    if (sinceMs != null) {
+      sorted = sorted.filter((c) => c.updatedAt >= sinceMs)
+    }
 
     // Apply limit if specified
     const limited = limit ? sorted.slice(0, limit) : sorted

--- a/apps/dashboard/src/lib/conversation-store/postgres-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/postgres-store.ts
@@ -147,17 +147,31 @@ export class PostgresStore implements ConversationStore {
    * @param limit - Maximum number of conversations to return (default: 50)
    * @returns Array of conversation metadata
    */
-  async list(userId: string, limit: number = 50): Promise<ConversationMeta[]> {
+  async list(
+    userId: string,
+    limit: number = 50,
+    sinceMs?: number
+  ): Promise<ConversationMeta[]> {
     await this.ensureInitialized()
 
     try {
-      const rows = (await this.sql`
+      const rows = (
+        sinceMs != null
+          ? await this.sql`
+        SELECT id, user_id, title, message_count, created_at, updated_at
+        FROM conversations
+        WHERE user_id = ${userId} AND updated_at >= ${sinceMs}
+        ORDER BY updated_at DESC
+        LIMIT ${limit}
+      `
+          : await this.sql`
         SELECT id, user_id, title, message_count, created_at, updated_at
         FROM conversations
         WHERE user_id = ${userId}
         ORDER BY updated_at DESC
         LIMIT ${limit}
-      `) as PostgresConversationRow[]
+      `
+      ) as PostgresConversationRow[]
 
       return rows.map(
         (row): ConversationMeta => ({

--- a/apps/dashboard/src/lib/conversation-store/types.ts
+++ b/apps/dashboard/src/lib/conversation-store/types.ts
@@ -219,7 +219,20 @@ export interface StoredConversation extends ConversationMeta {
  * All backends (D1, PostgreSQL, memory, browser) implement this.
  */
 export interface ConversationStore {
-  list(userId: string, limit?: number): Promise<ConversationMeta[]>
+  /**
+   * List conversations for a user.
+   *
+   * @param userId - User ID to scope queries
+   * @param limit - Maximum number of conversations to return
+   * @param sinceMs - Optional Unix-ms lower bound on updated_at (retention cutoff).
+   *   When provided, only conversations updated at or after this timestamp are returned.
+   *   Undefined = no cutoff (returns all).
+   */
+  list(
+    userId: string,
+    limit?: number,
+    sinceMs?: number
+  ): Promise<ConversationMeta[]>
   get(
     userId: string,
     conversationId: string

--- a/apps/dashboard/src/routes/api/cron/retention-prune.ts
+++ b/apps/dashboard/src/routes/api/cron/retention-prune.ts
@@ -1,0 +1,137 @@
+/**
+ * Retention Prune Cron Endpoint — GET /api/cron/retention-prune
+ *
+ * Invoked by the Cloudflare Cron Trigger (see wrangler.toml `[triggers] crons`)
+ * once daily at 03:00 UTC. The @cloudflare/vite-plugin worker routes scheduled
+ * events to the fetch handler, so the cron hits this GET route.
+ *
+ * Hard-deletes conversation rows in CHM_CLOUD_D1 that are older than each
+ * user's plan retention window. Iterates over all distinct user_ids, resolves
+ * their billing plan via getPlanForOwner, computes the cutoff with
+ * retentionCutoffMs, and issues a DELETE WHERE updated_at < cutoff. Users on
+ * enterprise (retentionDays: null) are skipped (unlimited retention).
+ *
+ * Guarded by a shared secret (CRON_SECRET) supplied via the `Authorization:
+ * Bearer <secret>` header or the `?secret=` query param. Returns 401 on
+ * mismatch. When CRON_SECRET is unset the endpoint is open (no secret to check).
+ *
+ * Graceful no-op when CHM_CLOUD_D1 is not bound (OSS / non-CF environments).
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { error, log } from '@chm/logger'
+import { getPlatformBindings } from '@chm/platform'
+import { secretsMatch } from '@/lib/auth/providers/constant-time'
+import { retentionCutoffMs } from '@/lib/billing/entitlements'
+import { getPlanForOwner } from '@/lib/billing/user-subscription'
+
+function isAuthorized(request: Request): boolean {
+  const bindings = env as Record<string, string | undefined>
+  const secret = (bindings.CRON_SECRET ?? process.env.CRON_SECRET)?.trim()
+  if (!secret) return true
+
+  const authHeader = request.headers.get('authorization')
+  if (authHeader && secretsMatch(authHeader, `Bearer ${secret}`)) return true
+
+  const url = new URL(request.url)
+  const querySecret = url.searchParams.get('secret')
+  if (querySecret && secretsMatch(querySecret, secret)) return true
+
+  return false
+}
+
+async function handler(request: Request): Promise<Response> {
+  if (!isAuthorized(request)) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // Graceful no-op: D1 not bound (OSS / local dev / non-CF environment)
+  let db: D1Database | null = null
+  try {
+    db = getPlatformBindings().getD1Database('CHM_CLOUD_D1')
+  } catch {
+    // Not in Cloudflare environment
+  }
+
+  if (!db) {
+    log('[GET /api/cron/retention-prune] CHM_CLOUD_D1 not bound — no-op')
+    return Response.json({ skipped: true, reason: 'D1 not bound' })
+  }
+
+  try {
+    // Collect all distinct user IDs that have conversations
+    const userResult = await db
+      .prepare('SELECT DISTINCT user_id FROM conversations')
+      .all<{ user_id: string }>()
+
+    const userIds = (userResult.results ?? []).map((r) => r.user_id)
+    log(`[GET /api/cron/retention-prune] Processing ${userIds.length} users`)
+
+    let totalDeleted = 0
+    let usersSkipped = 0
+    let errors = 0
+
+    for (const userId of userIds) {
+      try {
+        const plan = await getPlanForOwner(userId)
+        const cutoff = retentionCutoffMs(plan)
+
+        // null = unlimited (enterprise) — nothing to prune
+        if (cutoff == null) {
+          usersSkipped += 1
+          continue
+        }
+
+        const deleteResult = await db
+          .prepare(
+            'DELETE FROM conversations WHERE user_id = ?1 AND updated_at < ?2'
+          )
+          .bind(userId, cutoff)
+          .run()
+
+        const deleted = deleteResult.meta?.changes ?? 0
+        totalDeleted += deleted
+
+        if (deleted > 0) {
+          log(
+            `[GET /api/cron/retention-prune] Pruned ${deleted} conversations for user ${userId} (plan=${plan.id}, cutoff=${cutoff})`
+          )
+        }
+      } catch (err) {
+        errors += 1
+        error(
+          `[GET /api/cron/retention-prune] Failed to prune user ${userId}`,
+          err as Error
+        )
+      }
+    }
+
+    const summary = {
+      usersProcessed: userIds.length,
+      usersSkipped,
+      totalDeleted,
+      errors,
+    }
+
+    log('[GET /api/cron/retention-prune] Complete', summary)
+    return Response.json(summary, { status: 200 })
+  } catch (err) {
+    error('[GET /api/cron/retention-prune] Prune failed', err as Error)
+    return Response.json(
+      {
+        error: err instanceof Error ? err.message : 'Retention prune failed',
+      },
+      { status: 500 }
+    )
+  }
+}
+
+export const Route = createFileRoute('/api/cron/retention-prune')({
+  server: {
+    handlers: {
+      GET: ({ request }) => handler(request),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/mcp.ts
+++ b/apps/dashboard/src/routes/api/mcp.ts
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { corsPreflight, handleMcp } from '@chm/mcp-server/http'
+import { requirePlanCapability } from '@/lib/billing/plan-capability'
 
 /**
  * In-process MCP endpoint — thin re-point of the Next `app/api/mcp/route.ts`.
@@ -9,12 +10,24 @@ import { corsPreflight, handleMcp } from '@chm/mcp-server/http'
  * Cloudflare MCP Worker (`apps/mcp`). Each method forwards the Web `Request` to
  * `handleMcp`; OPTIONS answers CORS preflight so cross-origin MCP clients work
  * against the in-process route too (parity with the Worker).
+ *
+ * Plan gate: POST and GET require the `api_mcp_access` capability (Max / Enterprise).
+ * Self-hosted deployments are never gated — the capability check short-circuits to
+ * null (allow) whenever billing context is unavailable. See lib/billing/plan-capability.ts.
  */
 export const Route = createFileRoute('/api/mcp')({
   server: {
     handlers: {
-      POST: ({ request }) => handleMcp(request),
-      GET: ({ request }) => handleMcp(request),
+      POST: async ({ request }) => {
+        const denied = await requirePlanCapability('api_mcp_access', request)
+        if (denied) return denied
+        return handleMcp(request)
+      },
+      GET: async ({ request }) => {
+        const denied = await requirePlanCapability('api_mcp_access', request)
+        if (denied) return denied
+        return handleMcp(request)
+      },
       DELETE: ({ request }) => handleMcp(request),
       OPTIONS: () => corsPreflight(),
     },

--- a/apps/dashboard/src/routes/api/v1/agent.ts
+++ b/apps/dashboard/src/routes/api/v1/agent.ts
@@ -63,6 +63,10 @@ import {
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { authorizeAgentApiRequest } from '@/lib/auth/agent-api-auth'
 import { isClerkAuthProvider } from '@/lib/auth/provider'
+import { getAiUsageToday, incrementAiUsage } from '@/lib/billing/ai-usage-store'
+import { resolveBillingOwner } from '@/lib/billing/billing-owner'
+import { checkAiDailyLimit, limitMessage } from '@/lib/billing/entitlements'
+import { getPlanForOwner } from '@/lib/billing/user-subscription'
 import { ACTIONS_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
 import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 
@@ -523,6 +527,34 @@ async function handlePost(request: Request): Promise<Response> {
     console.log(
       `[Agent API] Custom MCP servers: ${connected} connected, ${errored} failed`
     )
+  }
+
+  // AI daily limit enforcement (cloud only).
+  // resolveBillingOwner() throws when Clerk is not configured (self-hosted),
+  // so the entire block is wrapped in try/catch — OSS deployments skip silently.
+  try {
+    const owner = await resolveBillingOwner()
+    const plan = await getPlanForOwner(owner.id)
+    if (plan.aiRequestsPerDay != null) {
+      const used = await getAiUsageToday(owner.id)
+      const check = checkAiDailyLimit(plan, used)
+      if (!check.allowed) {
+        return new Response(
+          JSON.stringify({
+            error: limitMessage(check),
+            details: {
+              planId: check.planId,
+              limit: check.limit ?? plan.aiRequestsPerDay,
+              reason: check.reason,
+            },
+          }),
+          { status: 402, headers: { 'content-type': 'application/json' } }
+        )
+      }
+      await incrementAiUsage(owner.id)
+    }
+  } catch {
+    // Not cloud / no Clerk owner → skip enforcement; self-hosted stays whole.
   }
 
   const requestOrigin = request.headers.get('origin') ?? undefined

--- a/apps/dashboard/src/routes/api/v1/conversations.ts
+++ b/apps/dashboard/src/routes/api/v1/conversations.ts
@@ -24,6 +24,9 @@ import {
   createSuccessResponse,
 } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
+import { resolveBillingOwner } from '@/lib/billing/billing-owner'
+import { retentionCutoffMs } from '@/lib/billing/entitlements'
+import { getPlanForOwner } from '@/lib/billing/user-subscription'
 import { resolveUserId } from '@/lib/conversation-store/auth'
 import { resolveStore } from '@/lib/conversation-store/resolve-store'
 import { ConversationStoreError } from '@/lib/conversation-store/types'
@@ -99,9 +102,21 @@ async function handleGet(request: Request): Promise<Response> {
         ? Math.min(normalizedLimit, 100)
         : DEFAULT_LIMIT
 
+    // Resolve retention cutoff from billing plan (cloud/Clerk only).
+    // Any failure (OSS, no Clerk, unauthenticated) is silent — no cutoff applied.
+    let sinceMs: number | undefined
+    try {
+      const owner = await resolveBillingOwner()
+      const plan = await getPlanForOwner(owner.id)
+      const cutoff = retentionCutoffMs(plan)
+      if (cutoff != null) sinceMs = cutoff
+    } catch {
+      // Non-cloud / unauthenticated: no retention filter
+    }
+
     // Resolve store and fetch conversations
     const store = await resolveStore()
-    const conversations = await store.list(userId, limit)
+    const conversations = await store.list(userId, limit, sinceMs)
 
     // Transform response to exclude internal fields
     const responseMeta: ConversationMeta[] = conversations.map((conv) => ({

--- a/apps/dashboard/src/routes/api/v1/webhooks/clerk.ts
+++ b/apps/dashboard/src/routes/api/v1/webhooks/clerk.ts
@@ -1,0 +1,106 @@
+/**
+ * POST /api/v1/webhooks/clerk — Clerk webhook receiver.
+ *
+ * Verifies the signature via Clerk's built-in verifyWebhook(), then enforces
+ * the seat cap for `organizationMembership.created` events. If the new
+ * member would push the org over its plan's seat limit, the membership is
+ * rolled back synchronously via Clerk's deleteOrganizationMembership API.
+ *
+ * All other events are acknowledged (202) without action.
+ * 501 when CLERK_WEBHOOK_SECRET is unset. 403 on bad signature.
+ * 500 on unexpected handler errors (Clerk will retry with backoff).
+ *
+ * Unauthenticated by design — the signature IS the auth.
+ *
+ * Registry gate: routes/api/v1/webhooks/clerk.ts
+ *   organizationMembership.created → checkSeatLimit (rollback over-limit member)
+ */
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { WebhookEvent } from '@clerk/tanstack-react-start/webhooks'
+
+import { error as logError, log as logInfo } from '@chm/logger'
+import { verifyWebhook } from '@clerk/tanstack-react-start/webhooks'
+import { getClerkWebhookSecret } from '@/lib/billing/clerk-webhook-config'
+import { checkSeatLimit } from '@/lib/billing/entitlements'
+import { getPlanForOwner } from '@/lib/billing/user-subscription'
+
+async function handlePost(request: Request): Promise<Response> {
+  const secret = getClerkWebhookSecret()
+  if (!secret) {
+    return Response.json(
+      { error: 'Clerk webhook not configured' },
+      { status: 501 }
+    )
+  }
+
+  let event: WebhookEvent
+  try {
+    event = await verifyWebhook(request, { signingSecret: secret })
+  } catch (err) {
+    logError('[clerk-webhook] signature verification failed', err)
+    return Response.json({ error: 'Invalid signature' }, { status: 403 })
+  }
+
+  try {
+    switch (event.type) {
+      case 'organizationMembership.created': {
+        const orgId = event.data.organization.id
+        const userId = event.data.public_user_data.user_id
+
+        const plan = await getPlanForOwner(orgId)
+
+        if (plan.seats == null) {
+          // Enterprise: unlimited seats — always allow.
+          break
+        }
+
+        const { clerkClient } = await import(
+          '@clerk/tanstack-react-start/server'
+        )
+        const memberships =
+          await clerkClient().organizations.getOrganizationMembershipList({
+            organizationId: orgId,
+            limit: 100,
+          })
+        const count = memberships.data.length
+
+        const check = checkSeatLimit(plan, count)
+        if (!check.allowed) {
+          await clerkClient().organizations.deleteOrganizationMembership({
+            organizationId: orgId,
+            userId,
+          })
+          logInfo(
+            '[clerk-webhook] seat cap enforced — over-limit membership rolled back',
+            {
+              orgId,
+              userId,
+              planId: plan.id,
+              seats: plan.seats,
+              currentCount: count,
+            }
+          )
+        }
+        break
+      }
+      default:
+        // Acknowledge all other event types without action.
+        break
+    }
+  } catch (err) {
+    // Unexpected error — 500 so Clerk retries with backoff.
+    logError('[clerk-webhook] handler error', err)
+    return Response.json({ error: 'Handler error' }, { status: 500 })
+  }
+
+  return Response.json({ received: true }, { status: 202 })
+}
+
+export const Route = createFileRoute('/api/v1/webhooks/clerk')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -84,6 +84,17 @@ custom_domain = true
 # CHM_PROXY_AUTH_SECRET via: wrangler secret put CHM_PROXY_AUTH_SECRET
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Cron triggers. The @cloudflare/vite-plugin routes scheduled events to the
+# worker's fetch handler, which TanStack Start then dispatches to the matching
+# GET route (see src/routes/api/cron/). Each cron hits its corresponding route
+# via a synthetic GET request: retention-prune runs once daily at 03:00 UTC.
+# health-sweep (every 5 min) should be added here when that route is confirmed
+# working end-to-end.
+# ─────────────────────────────────────────────────────────────────────────────
+[triggers]
+crons = ["0 3 * * *"]
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Preview environment for PR deployments
 # Deployed by GitHub Actions on pull requests (see .github/workflows/cloudflare.yml)
 # and reachable at https://preview.dash.chmonitor.dev.

--- a/plans/02-plan-benefits-parity.md
+++ b/plans/02-plan-benefits-parity.md
@@ -99,7 +99,16 @@ exist yet — that is its own feature (see roadmap). So **no new gating is switc
 on in this plan.** The registry marks `aiRequestsPerDay`, `seats`, `alertRules`,
 `retentionDays` as `deferred` with the concrete next step recorded below.
 
-## Staged enforcement roadmap (each: goal + real test, NOT built here)
+## Staged enforcement roadmap — IMPLEMENTED (override of the beta-deferral)
+
+> **Status update.** The owner explicitly chose to turn enforcement ON now
+> (overriding the "free during beta, defer gating" guard above). The roadmap
+> items below are now BUILT and wired, and `LIMIT_ENFORCEMENT` /
+> `CAPABILITY_ENFORCEMENT` flipped `deferred → enforced` accordingly. Every gate
+> is **fail-open for self-hosted/OSS**: owner/plan resolution throws without
+> Clerk and each call site swallows that, so OSS is never gated ("self-hosted
+> stays whole"). `alertRules` stays `deferred` only because no alerting feature
+> exists to gate. Original goals/tests kept below for traceability.
 
 Recorded so they're tracked, not lost. Implement per-item when GA pricing turns on.
 


### PR DESCRIPTION
## What

Turns **on** per-tier plan enforcement for the cost/abuse-bounded benefits, flipping them `deferred → enforced` in the `plan-enforcement` registry (`apps/dashboard/src/lib/billing/plan-enforcement.ts`).

> **Note on the beta-deferral override.** Plan `02-plan-benefits-parity.md` deliberately deferred this work ("free during early access; gate at GA") because gating removes capabilities from current users. The repo owner explicitly authorized turning enforcement **on now**, overriding that guard. `plans/02` is updated to record this.

## Gates added (all **fail-open for self-hosted/OSS**)

Every gate resolves owner→plan via Clerk; if that throws (no Clerk = self-hosted), the call site **swallows it and does not gate** — so OSS stays whole.

| Benefit | Gate | Behavior |
|---|---|---|
| `aiRequestsPerDay` | `routes/api/v1/agent.ts` → `checkAiDailyLimit` + new D1 `ai_usage_daily` counter (`ai-usage-store.ts`, migration `0005`) | Free 402s at 5/day; Pro/Max pass via `aiOverage` soft-cap; Enterprise unlimited |
| `seats` | `routes/api/v1/webhooks/clerk.ts` `organizationMembership.created` → `checkSeatLimit` | Rolls back the over-limit member past `plan.seats` |
| `retentionDays` | conversation list read-filter (`sinceMs` across all store adapters) + `routes/api/cron/retention-prune.ts` (daily 03:00 UTC) → `retentionCutoffMs` | Rows older than the owner's retention are not returned and are pruned |
| `api_mcp_access` | `lib/billing/plan-capability.ts` `requirePlanCapability` on `routes/api/mcp.ts` POST+GET | Free/Pro denied (402); Max/Enterprise allowed |

`alertRules` stays `deferred` (no alerting feature exists to gate yet).

## Design

- Pure decision functions (`checkAiDailyLimit`, `checkSeatLimit`, `hasCapability`, `retentionCutoffMs`) already existed and were unit-tested; this PR is the **wiring** (counters, webhook, cron, gate) into request paths.
- Anti-drift registry tests updated: enforced claims must name a gate; the cost/abuse limits assert `enforced`.

## New config

- `CLERK_WEBHOOK_SECRET` (added to `.env.example`) — required for the seat webhook; set as a Worker **secret** for cloud (`scripts/set-secrets.ts`), not committed.
- `wrangler.toml` `[triggers] crons = ["0 3 * * *"]` for the retention prune.

## Verification

- `bun run build` (incl. `tsc --noEmit`) — green
- `bun run lint` — clean (the pre-push whole-repo `check` trips on pre-existing debt in files this PR does not touch; none of the new files are flagged)
- **4395 unit tests pass / 0 fail**; billing suite 84 pass (40 new tests across 4 new test files)

🤖 Generated with [Claude Code](https://claude.ai/code)