### PR TITLE
chore(secrets): add CLERK_WEBHOOK_SECRET and CRON_SECRET to deploy list

### DIFF
--- a/scripts/set-secrets.ts
+++ b/scripts/set-secrets.ts
@@ -65,6 +65,12 @@ const DASHBOARD_SECRET_KEYS = [
   // Clerk server-side secret. In preview the value comes from
   // CLERK_SECRET_KEY_TEST (see resolveValue).
   'CLERK_SECRET_KEY',
+  // Verifies inbound Clerk webhooks (Svix signature). Activates the seat-limit
+  // gate in webhooks/clerk.ts (organizationMembership.created).
+  'CLERK_WEBHOOK_SECRET',
+  // Guards the /api/cron/* endpoints (health-sweep, retention-prune) via a
+  // constant-time bearer compare. Reuses the CHM_API_KEY_SECRET value in prod.
+  'CRON_SECRET',
   // AgentState project key (as_live_...). Presence activates the AgentState
   // conversation-store backend (resolveStore picks it ahead of D1). Non-secret
   // AgentState knobs (base URL, AI-enrich, force-backend) live in


### PR DESCRIPTION
## What

Registers two secrets in the dashboard Worker secret-set list so deploys provision them:

- `CLERK_WEBHOOK_SECRET` — verifies inbound Clerk webhooks (Svix signature); activates the seat-limit gate in `webhooks/clerk.ts` (`organizationMembership.created`).
- `CRON_SECRET` — guards `/api/cron/*` (health-sweep, retention-prune) via a constant-time bearer compare; reuses `CHM_API_KEY_SECRET` in prod.

## Why

Without these in the secret list, the gates fall closed silently on deploy.

Co-Authored-By: duyetbot <bot@duyet.net>