### PR TITLE
fix(landing): remove duplicate $ on struck-through yearly price

### DIFF
--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -134,7 +134,6 @@ const { compact = false } = Astro.props
     .cloud-grid[data-period="yearly"] .amt-yearly{display:inline}
     /* Yearly: show the monthly price struck through so the saving is obvious. */
     .cloud-grid .amt-was{font-size:.5em;font-weight:600;color:var(--muted-fg);text-decoration:line-through;margin-right:4px}
-    .cloud-grid .amt-was::before{content:"$"}
     .pbilled{font-size:12px;color:var(--muted-fg);margin-top:8px;min-height:16px}
     .cloud-grid[data-period="monthly"] .bill-yearly{display:none}
     .cloud-grid[data-period="yearly"] .bill-monthly{display:none}


### PR DESCRIPTION
## Bug

On the landing pricing cards, the struck-through monthly price rendered as **`$$29`** / **`$$99`** (doubled `$`), while the actual price stayed single-`$` (`$24` / `$83`).

## Cause

The markup already prints a literal `$` before the expression:
```astro
<span class="amt-was">${t.monthly}</span>   <!-- $ + 29 = $29 -->
```
and a CSS pseudo-element added a **second** `$`:
```css
.cloud-grid .amt-was::before{content:"$"}   /* + $ = $$29 */
```
The actual price (`${t.yearlyPerMo}`) has no `::before`, hence only the struck price doubled.

## Fix

Remove the redundant `::before` so the struck price matches the monthly/actual prices (both use the inline literal `$`).

Co-Authored-By: duyetbot <bot@duyet.net>