### PR TITLE
feat(connections): docs help in Add-host dialog + permission & connectivity guides

### DIFF
--- a/apps/dashboard/src/components/connections/add-host-dialog.tsx
+++ b/apps/dashboard/src/components/connections/add-host-dialog.tsx
@@ -5,9 +5,11 @@ import { useState } from 'react'
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { docsSiteUrl } from '@/lib/docs-site'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { useBrowserConnections } from '@/lib/hooks/use-browser-connections'
 import {
@@ -57,6 +59,19 @@ export function AddHostDialog({ open, onOpenChange }: AddHostDialogProps) {
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Add ClickHouse host</DialogTitle>
+          <DialogDescription>
+            chmonitor needs a user with <code>SELECT</code> on{' '}
+            <code>system.*</code>. See{' '}
+            <a
+              href={docsSiteUrl('getting-started/clickhouse-requirements')}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline-offset-4 hover:underline"
+            >
+              required permissions &amp; firewall setup
+            </a>{' '}
+            for grants and how to allowlist the Cloud connection.
+          </DialogDescription>
         </DialogHeader>
         <ConnectionForm
           onSave={handleSave}

--- a/docs/content/guide/getting-started/clickhouse-requirements.mdx
+++ b/docs/content/guide/getting-started/clickhouse-requirements.mdx
@@ -7,6 +7,64 @@ icon: ListChecks
 
 chmonitor needs a ClickHouse user with at minimum `SELECT` on `system.*`. Do not use an admin account for a shared dashboard.
 
+<Callout type="tip" title="Connecting a firewalled ClickHouse to Cloud?">
+If your ClickHouse is behind a firewall and you use the hosted Cloud, see
+[Connect a firewalled ClickHouse](/guides/connect-firewalled-clickhouse) for how
+to reach it without a brittle IP allowlist (Cloudflare Tunnel, dedicated egress
+IPs, or a jump host).
+</Callout>
+
+## Copy & paste: pick a permission level
+
+Switch the tab to the level you want, then paste the whole block into a ClickHouse client (or drop the XML into `users.d/`). Replace `your-password` first.
+
+<Tabs items={['Read-only (SQL)', 'Read-only + actions (SQL)', 'users.xml']}>
+<Tab value="Read-only (SQL)">
+```sql
+-- View every monitoring page. Cannot kill queries, optimize, or mutate data.
+CREATE USER monitoring
+  IDENTIFIED WITH sha256_password BY 'your-password'
+  HOST ANY;
+
+GRANT SELECT ON system.* TO monitoring;
+GRANT CREATE TEMPORARY TABLE ON *.* TO monitoring;
+```
+</Tab>
+<Tab value="Read-only + actions (SQL)">
+```sql
+-- Read-only, plus the optional Kill Query and Optimize Table actions.
+-- The UI/agent still needs AGENT_ENABLE_CONTROL_TOOLS=true for kill/optimize.
+CREATE USER monitoring
+  IDENTIFIED WITH sha256_password BY 'your-password'
+  HOST ANY;
+
+GRANT SELECT ON system.* TO monitoring;
+GRANT CREATE TEMPORARY TABLE ON *.* TO monitoring;
+GRANT KILL QUERY ON *.* TO monitoring;
+GRANT OPTIMIZE ON *.* TO monitoring;
+```
+</Tab>
+<Tab value="users.xml">
+```xml
+<!-- /etc/clickhouse-server/users.d/monitoring.xml -->
+<clickhouse>
+  <users>
+    <monitoring>
+      <password_sha256_hex>REPLACE_WITH_SHA256_OF_YOUR_PASSWORD</password_sha256_hex>
+      <networks><ip>::/0</ip></networks>
+      <profile>monitoring_profile</profile>
+      <grants>
+        <query>GRANT SELECT ON system.*</query>
+        <query>GRANT CREATE TEMPORARY TABLE ON *.*</query>
+      </grants>
+    </monitoring>
+  </users>
+</clickhouse>
+```
+Generate the hash with `echo -n 'your-password' | sha256sum`. See the [recommended profile](#recommended-clickhouse-profile) for the `monitoring_profile` body.
+</Tab>
+</Tabs>
+
 ## Minimum: read-only monitoring user
 
 This user can view all monitoring pages. It cannot kill queries, run optimizations, or mutate data.

--- a/docs/content/guide/guides/connect-firewalled-clickhouse.mdx
+++ b/docs/content/guide/guides/connect-firewalled-clickhouse.mdx
@@ -1,0 +1,97 @@
+---
+description: Connect a firewalled ClickHouse to chmonitor Cloud — Cloudflare Tunnel (recommended), dedicated egress IPs for allowlisting, jump host, and why allowlisting Cloudflare's shared ranges does not work.
+icon: ShieldCheck
+---
+
+# Connect a firewalled ClickHouse (Cloud)
+
+chmonitor **Cloud** (`dash.chmonitor.dev`) runs entirely on Cloudflare Workers.
+When your ClickHouse is behind a firewall, the Worker has to reach it — and
+because Workers do **not** have a single fixed public IP by default, a plain
+"allowlist our IP" is not straightforward. This guide explains the options,
+ranked by how well they fit chmonitor.
+
+<Callout type="tip" title="Self-hosting? You don't need any of this">
+Self-hosted chmonitor (Docker / Kubernetes / your own Worker) runs inside your
+network, so it reaches ClickHouse directly. This page is only for connecting a
+firewalled ClickHouse to the **hosted Cloud**.
+</Callout>
+
+## Recommended: Cloudflare Tunnel + Access service token
+
+A [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-tunnel/) runs
+a small `cloudflared` connector next to your ClickHouse. It makes only
+**outbound** connections to Cloudflare, so you **open no inbound ports and
+allowlist no IPs**. You then protect the tunnel's public hostname with
+[Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/)
+and give chmonitor a **service token** so only chmonitor can reach it.
+
+**You do:**
+
+1. Install `cloudflared` (2025.7.0+) on a host that can reach ClickHouse and
+   create a tunnel with a public hostname pointing at ClickHouse's HTTP port
+   (`8123` / `8443`):
+   ```bash
+   cloudflared tunnel create chmonitor
+   # route a hostname → your ClickHouse HTTP endpoint
+   cloudflared tunnel route dns chmonitor ch.example.com
+   ```
+2. Add an **Access** application on `ch.example.com` with a **service token**
+   policy, and copy the generated **Client ID** and **Client Secret**.
+3. In chmonitor, add the host with URL `https://ch.example.com` and paste the
+   service-token Client ID / Secret into the connection's headers
+   (`CF-Access-Client-Id` / `CF-Access-Client-Secret`).
+
+**Why this is the default:** no inbound firewall hole, no IP allowlist to
+maintain, the token is per-connection and revocable, and traffic is TLS
+end-to-end. It works today (not beta) on free/standard Zero Trust tiers.
+
+## If you must allowlist an IP: dedicated egress IPs
+
+Some security teams require a literal firewall allowlist. chmonitor talks to
+ClickHouse over **HTTP** (`@clickhouse/client-web`, i.e. Worker `fetch()`), and
+Cloudflare's
+[Dedicated Egress IPs](https://developers.cloudflare.com/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/)
+**do apply to `fetch()`** (they do not apply to raw-TCP `connect()`). That gives
+the Worker a stable source IP you can allowlist.
+
+Caveats:
+
+- It is an **enterprise add-on** on chmonitor's Cloudflare account — contact us
+  if your deployment needs it.
+- The IP is shared across chmonitor's account egress, so the allowlist
+  authorizes "traffic from chmonitor," not a single tenant. Always pair it with
+  TLS + a least-privilege ClickHouse user.
+
+<Callout type="warn" title="Do not allowlist Cloudflare's public IP ranges">
+Cloudflare publishes its IP ranges, but Worker egress over those ranges is
+shared by **every** Cloudflare customer. Allowlisting them authorizes the entire
+Cloudflare fleet — it is not a real allowlist. Use a tunnel or dedicated egress
+IPs instead.
+</Callout>
+
+## Alternative: your own jump host / reverse proxy
+
+Run a small reverse proxy (nginx / HAProxy) on a VM with a **static public IP**
+that forwards to ClickHouse, and allowlist only that proxy. chmonitor then
+connects to the proxy over HTTPS with auth. This always works and is fully under
+your control, but you own the proxy's uptime, TLS, and hardening.
+
+## On the roadmap: Workers VPC
+
+[Workers VPC](https://developers.cloudflare.com/workers-vpc/) (currently beta)
+lets a Worker reach a private service through a Cloudflare Tunnel with **no
+public hostname at all** — the cleanest private-connectivity story. We will adopt
+it for Cloud once it reaches general availability.
+
+## Not supported
+
+[Cloudflare Hyperdrive](https://developers.cloudflare.com/hyperdrive/) only
+supports PostgreSQL and MySQL, so it cannot front a ClickHouse connection.
+
+## See also
+
+- [ClickHouse User & Grants](/getting-started/clickhouse-requirements) — the
+  least-privilege user chmonitor needs.
+- [Connection errors](/guides/connection-errors) — diagnosing "Test connection"
+  failures.


### PR DESCRIPTION
Addresses the onboarding/connection help asks.

## Add ClickHouse host dialog → docs help link
The dialog header now explains the minimum grant (`SELECT` on `system.*`) and links to the **ClickHouse User & Grants** doc, which covers permissions *and* firewall/allowlist setup.

## Docs: copy/paste permission toggle
The requirements doc gains a **"pick a permission level"** `<Tabs>` block — paste-ready blocks for:
- Read-only (SQL)
- Read-only + actions (SQL)
- `users.xml` (with hash + profile pointer)

## New guide: Connect a firewalled ClickHouse (Cloud)
Researched, ranked options for reaching a firewalled ClickHouse from the Cloud Worker:
1. **Cloudflare Tunnel + Access service token** (recommended) — no inbound hole, no IP allowlist, per-connection revocable token.
2. **Dedicated egress IPs** for teams that *must* allowlist — applies because chmonitor uses `fetch()` (`@clickhouse/client-web`), not raw `connect()`; enterprise add-on, coarse.
3. **Jump host / reverse proxy** with a static IP.
4. **Workers VPC** (roadmap, beta) — fully private, no public hostname.
- Notes why allowlisting Cloudflare's *shared* public ranges is not a real allowlist, and that Hyperdrive (Postgres/MySQL only) doesn't apply.

Sources verified against current Cloudflare docs.

Co-Authored-By: duyetbot <bot@duyet.net>