### PR TITLE
feat(ui): shadcn chat components, Rhea theme, interactive docs GrantBuilder

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"7ce7bc72-d420-42c1-bd9d-a0fe025742a2","pid":87719,"procStart":"Fri May 29 03:52:44 2026","acquiredAt":1780028174818}
+{"sessionId":"d082a7c1-4990-464a-8648-a8be949e6fda","pid":64700,"procStart":"Tue Jun 30 07:19:38 2026","acquiredAt":1782805422519}

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ ds-bundle/
 .design-sync/node_modules
 apps/dashboard/.ds-tailwind.css
 apps/dashboard/node_modules/dashboard
+.omo/

--- a/apps/bug-handler/src/github-issue.test.ts
+++ b/apps/bug-handler/src/github-issue.test.ts
@@ -216,8 +216,8 @@ describe('createGitHubIssue', () => {
       BASE_CONFIG,
       mockFetch as typeof fetch
     )
-    expect(capturedHeaders['Authorization']).toBe('Bearer ghp_testtoken')
-    expect(capturedHeaders['Accept']).toBe('application/vnd.github+json')
+    expect(capturedHeaders.Authorization).toBe('Bearer ghp_testtoken')
+    expect(capturedHeaders.Accept).toBe('application/vnd.github+json')
     expect(capturedHeaders['User-Agent']).toBe('chmonitor-bug-handler')
     expect(capturedHeaders['X-GitHub-Api-Version']).toBe('2022-11-28')
   })

--- a/apps/bug-handler/src/index.test.ts
+++ b/apps/bug-handler/src/index.test.ts
@@ -224,7 +224,7 @@ describe('worker.email — happy path', () => {
     await worker.email(message, FULL_ENV, ctx)
     await Promise.all(pending)
 
-    expect(calls[0].headers['Authorization']).toBe('Bearer ghp_testtoken')
+    expect(calls[0].headers.Authorization).toBe('Bearer ghp_testtoken')
   })
 })
 

--- a/apps/dashboard/cypress/support/component.ts
+++ b/apps/dashboard/cypress/support/component.ts
@@ -10,7 +10,6 @@ import { mount } from 'cypress/react'
 
 // Augment the Cypress namespace so TypeScript knows about cy.mount()
 declare global {
-  // biome-ignore lint/style/noNamespace: Cypress global augmentation pattern
   namespace Cypress {
     interface Chainable {
       mount: typeof mount

--- a/apps/dashboard/src/components/alerting/regression-panel.tsx
+++ b/apps/dashboard/src/components/alerting/regression-panel.tsx
@@ -53,7 +53,7 @@ export function RegressionPanel({ hostId, className }: RegressionPanelProps) {
       hostId,
       incidentId: `sqr-${hostId}-${Math.floor(Date.now() / 60_000)}`,
     })
-  }, [rows.length, hostId]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [rows.length, hostId, rows.reduce]) // eslint-disable-line react-hooks/exhaustive-deps
 
   if (isLoading) return null
   if (error || rows.length === 0) return null

--- a/apps/dashboard/src/components/assistant-ui/thread.tsx
+++ b/apps/dashboard/src/components/assistant-ui/thread.tsx
@@ -37,6 +37,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   CopyIcon,
+  LoaderCircleIcon,
   PencilIcon,
   RefreshCwIcon,
 } from 'lucide-react'
@@ -65,6 +66,7 @@ import { useAgentAuthGate } from '@/components/assistant-ui/agent-auth-gate'
 import { JsonRenderMessage } from '@/components/assistant-ui/json-render-message'
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
 import { Bubble, BubbleContent } from '@/components/ui/bubble'
+import { Marker, MarkerContent, MarkerIcon } from '@/components/ui/marker'
 import { Message, MessageContent } from '@/components/ui/message'
 import {
   MessageScroller,
@@ -298,14 +300,12 @@ function LoadingIndicator() {
   if (!isRunning || hasError || !hasNoParts) return null
 
   return (
-    <div className="flex items-center gap-2 py-1">
-      <span className="inline-flex gap-0.5">
-        <span className="inline-block size-1.5 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:0ms]" />
-        <span className="inline-block size-1.5 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:150ms]" />
-        <span className="inline-block size-1.5 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:300ms]" />
-      </span>
-      <span className="text-xs text-muted-foreground/70">Thinking…</span>
-    </div>
+    <Marker className="py-1">
+      <MarkerIcon>
+        <LoaderCircleIcon className="animate-spin" />
+      </MarkerIcon>
+      <MarkerContent className="shimmer text-xs">Thinking…</MarkerContent>
+    </Marker>
   )
 }
 

--- a/apps/dashboard/src/components/data-table/__tests__/data-table-behaviors.test.ts
+++ b/apps/dashboard/src/components/data-table/__tests__/data-table-behaviors.test.ts
@@ -55,8 +55,6 @@ const ROWS = [
   { query: 'DROP TABLE temp', user: 'admin', duration: 10 },
 ] as const
 
-type Row = (typeof ROWS)[number]
-
 // ---------------------------------------------------------------------------
 // applyColumnFilters (real production function)
 //

--- a/apps/dashboard/src/components/fleet/fleet-overview.tsx
+++ b/apps/dashboard/src/components/fleet/fleet-overview.tsx
@@ -6,7 +6,6 @@ function FleetSkeleton() {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
       {Array.from({ length: 4 }).map((_, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders have no identity
         <Skeleton key={i} className="h-44 w-full rounded-xl" />
       ))}
     </div>

--- a/apps/dashboard/src/components/host/first-run-empty-state.tsx
+++ b/apps/dashboard/src/components/host/first-run-empty-state.tsx
@@ -62,7 +62,7 @@ export function FirstRunEmptyState() {
   return (
     <>
       <div className="flex flex-1 flex-col items-center justify-center px-4 py-16">
-        <div className="w-full max-w-xl">{body}</div>
+        <div className="w-full max-w-3xl">{body}</div>
       </div>
       <AddHostDialog open={addOpen} onOpenChange={setAddOpen} />
     </>

--- a/apps/dashboard/src/components/ui/attachment.tsx
+++ b/apps/dashboard/src/components/ui/attachment.tsx
@@ -1,0 +1,205 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import type * as React from 'react'
+
+import { Slot } from 'radix-ui'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+const attachmentVariants = cva(
+  'group/attachment relative flex w-fit max-w-full min-w-0 shrink-0 flex-wrap rounded-xl border bg-card text-card-foreground transition-colors focus-within:ring-1 focus-within:ring-ring/50 has-[>a,>button]:hover:bg-muted/50 data-[state=error]:border-destructive/30 data-[state=idle]:border-dashed',
+  {
+    variants: {
+      size: {
+        default:
+          'gap-2 text-sm has-data-[slot=attachment-content]:px-2.5 has-data-[slot=attachment-content]:py-2 has-data-[slot=attachment-media]:p-2',
+        sm: 'gap-2.5 text-xs has-data-[slot=attachment-content]:px-2 has-data-[slot=attachment-content]:py-1.5 has-data-[slot=attachment-media]:p-1.5',
+        xs: 'gap-1.5 rounded-lg text-xs has-data-[slot=attachment-content]:px-1.5 has-data-[slot=attachment-content]:py-1 has-data-[slot=attachment-media]:p-1',
+      },
+      orientation: {
+        horizontal: 'min-w-40 items-center',
+        vertical: 'w-24 flex-col has-data-[slot=attachment-content]:w-30',
+      },
+    },
+  }
+)
+
+function Attachment({
+  className,
+  state = 'done',
+  size = 'default',
+  orientation = 'horizontal',
+  ...props
+}: React.ComponentProps<'div'> &
+  VariantProps<typeof attachmentVariants> & {
+    state?: 'idle' | 'uploading' | 'processing' | 'error' | 'done'
+  }) {
+  return (
+    <div
+      data-slot="attachment"
+      data-state={state}
+      data-size={size}
+      data-orientation={orientation}
+      className={cn(attachmentVariants({ size, orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+const attachmentMediaVariants = cva(
+  "relative flex aspect-square w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted text-foreground group-data-[orientation=vertical]/attachment:w-full group-data-[size=sm]/attachment:w-8 group-data-[size=xs]/attachment:w-7 group-data-[size=xs]/attachment:rounded-md group-data-[state=error]/attachment:bg-destructive/10 group-data-[state=error]/attachment:text-destructive group-data-[orientation=vertical]/attachment:*:data-[slot=spinner]:size-6! [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 group-data-[orientation=vertical]/attachment:[&_svg:not([class*='size-'])]:size-6 group-data-[size=xs]/attachment:[&_svg:not([class*='size-'])]:size-3.5",
+  {
+    variants: {
+      variant: {
+        icon: '',
+        image:
+          'opacity-60 group-data-[state=done]/attachment:opacity-100 group-data-[state=idle]/attachment:opacity-100 *:[img]:aspect-square *:[img]:w-full *:[img]:object-cover',
+      },
+    },
+    defaultVariants: {
+      variant: 'icon',
+    },
+  }
+)
+
+function AttachmentMedia({
+  className,
+  variant = 'icon',
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof attachmentMediaVariants>) {
+  return (
+    <div
+      data-slot="attachment-media"
+      data-variant={variant}
+      className={cn(attachmentMediaVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AttachmentContent({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="attachment-content"
+      className={cn(
+        'max-w-full min-w-0 flex-1 leading-tight group-data-[orientation=vertical]/attachment:px-1',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AttachmentTitle({
+  className,
+  ...props
+}: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="attachment-title"
+      className={cn(
+        'block max-w-full min-w-0 truncate font-medium group-data-[state=processing]/attachment:shimmer group-data-[state=uploading]/attachment:shimmer',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AttachmentDescription({
+  className,
+  ...props
+}: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="attachment-description"
+      className={cn(
+        'mt-0.5 block min-w-0 truncate text-xs text-muted-foreground group-data-[state=error]/attachment:text-destructive/80',
+        'max-w-full',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AttachmentActions({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="attachment-actions"
+      className={cn(
+        'relative z-20 flex shrink-0 items-center group-data-[orientation=vertical]/attachment:absolute group-data-[orientation=vertical]/attachment:top-3 group-data-[orientation=vertical]/attachment:right-3 group-data-[orientation=vertical]/attachment:gap-1',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AttachmentAction({
+  className,
+  variant,
+  size = 'icon-xs',
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <Button
+      data-slot="attachment-action"
+      variant={variant ?? 'ghost'}
+      size={size}
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function AttachmentTrigger({
+  className,
+  asChild = false,
+  type,
+  ...props
+}: React.ComponentProps<'button'> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : 'button'
+
+  return (
+    <Comp
+      data-slot="attachment-trigger"
+      type={asChild ? undefined : (type ?? 'button')}
+      className={cn('absolute inset-0 z-10 outline-none', className)}
+      {...props}
+    />
+  )
+}
+
+function AttachmentGroup({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="attachment-group"
+      className={cn(
+        'flex min-w-0 scroll-fade-x snap-x snap-mandatory scroll-px-1 scrollbar-none gap-3 overflow-x-auto overscroll-x-contain py-1 *:data-[slot=attachment]:flex-none *:data-[slot=attachment]:snap-start',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Attachment,
+  AttachmentGroup,
+  AttachmentMedia,
+  AttachmentContent,
+  AttachmentTitle,
+  AttachmentDescription,
+  AttachmentActions,
+  AttachmentAction,
+  AttachmentTrigger,
+}

--- a/apps/dashboard/src/components/ui/marker.tsx
+++ b/apps/dashboard/src/components/ui/marker.tsx
@@ -1,0 +1,70 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import type * as React from 'react'
+
+import { Slot } from 'radix-ui'
+import { cn } from '@/lib/utils'
+
+const markerVariants = cva(
+  "group/marker relative flex min-h-4 w-full items-center gap-2 text-left text-sm text-muted-foreground [&_svg:not([class*='size-'])]:size-4 [a]:underline [a]:underline-offset-3 [a]:hover:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: '',
+        separator:
+          'before:mr-1 before:h-px before:min-w-0 before:flex-1 before:bg-border after:ml-1 after:h-px after:min-w-0 after:flex-1 after:bg-border',
+        border: 'border-b border-border pb-2',
+      },
+    },
+  }
+)
+
+function Marker({
+  className,
+  variant = 'default',
+  asChild = false,
+  ...props
+}: React.ComponentProps<'div'> &
+  VariantProps<typeof markerVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot.Root : 'div'
+
+  return (
+    <Comp
+      data-slot="marker"
+      data-variant={variant}
+      className={cn(markerVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function MarkerIcon({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="marker-icon"
+      aria-hidden="true"
+      className={cn(
+        "size-4 shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MarkerContent({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="marker-content"
+      className={cn(
+        'min-w-0 wrap-break-word group-data-[variant=separator]/marker:flex-none group-data-[variant=separator]/marker:text-center *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Marker, MarkerIcon, MarkerContent, markerVariants }

--- a/apps/dashboard/src/lib/agent-export.test.ts
+++ b/apps/dashboard/src/lib/agent-export.test.ts
@@ -1,5 +1,5 @@
 import { exportToCsv, rowsToCsv } from './agent-export'
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
 // ---------------------------------------------------------------------------
 // rowsToCsv
@@ -118,7 +118,7 @@ describe('exportToCsv', () => {
   let linkDownload = ''
   let linkClicked = false
   let appendedLink: HTMLAnchorElement | null = null
-  let revokedUrl: string | null = null
+  let _revokedUrl: string | null = null
 
   // A fake anchor element
   const fakeLink = {
@@ -145,7 +145,7 @@ describe('exportToCsv', () => {
     linkDownload = ''
     linkClicked = false
     appendedLink = null
-    revokedUrl = null
+    _revokedUrl = null
 
     // Stub global browser APIs used by exportToCsv
     globalThis.Blob = class MockBlob {
@@ -160,7 +160,7 @@ describe('exportToCsv', () => {
     globalThis.URL = {
       createObjectURL: (_blob: Blob) => 'blob:fake-url',
       revokeObjectURL: (url: string) => {
-        revokedUrl = url
+        _revokedUrl = url
       },
     } as unknown as typeof URL
 

--- a/apps/dashboard/src/lib/ai/agent/__tests__/agent-conversation.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/__tests__/agent-conversation.test.ts
@@ -353,7 +353,7 @@ describe('query tool — execution lifecycle', () => {
 
   test('throws when ClickHouse returns an error object', async () => {
     // Override fetchData for this specific test to simulate a CH error
-    const originalFetch = (await import('@chm/clickhouse-client')).fetchData
+    const _originalFetch = (await import('@chm/clickhouse-client')).fetchData
     const stub = spyOn(
       await import('@chm/clickhouse-client'),
       'fetchData'

--- a/apps/dashboard/src/lib/app-tables.test.ts
+++ b/apps/dashboard/src/lib/app-tables.test.ts
@@ -17,7 +17,7 @@
  */
 
 import * as appTables from './app-tables'
-import { describe, expect, mock, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
 
 // ---------------------------------------------------------------------------
 // Static (bare) table identifiers — never affected by env vars

--- a/apps/dashboard/src/lib/card-error-utils.test.ts
+++ b/apps/dashboard/src/lib/card-error-utils.test.ts
@@ -19,7 +19,7 @@
  *     content, to avoid hard-coupling to table-guidance internals).
  */
 
-import type { CardError, CardErrorVariant } from '@/lib/card-error-utils'
+import type { CardError } from '@/lib/card-error-utils'
 
 import { describe, expect, it } from 'bun:test'
 import { ApiErrorType } from '@/lib/api/types'

--- a/apps/dashboard/src/lib/csv.test.ts
+++ b/apps/dashboard/src/lib/csv.test.ts
@@ -1,5 +1,5 @@
 import { arrayToCsv, downloadCsv, slugifyFilename, valueToCsv } from './csv'
-import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
 
 // ---------------------------------------------------------------------------
 // valueToCsv

--- a/apps/dashboard/src/lib/feature-flags.test.ts
+++ b/apps/dashboard/src/lib/feature-flags.test.ts
@@ -24,10 +24,7 @@
  *   - describe 'shape': structural invariants on the featureFlags object.
  */
 
-import type {
-  FeatureFlagName,
-  featureFlags as FeatureFlagsType,
-} from './feature-flags'
+import type { FeatureFlagName } from './feature-flags'
 
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 

--- a/apps/dashboard/src/lib/health/__tests__/alert-settings-storage.test.ts
+++ b/apps/dashboard/src/lib/health/__tests__/alert-settings-storage.test.ts
@@ -9,7 +9,7 @@
  * environment. We shim only what the module under test touches.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import {
   DEFAULT_ALERT_SETTINGS,
   loadAlertSettings,

--- a/apps/dashboard/src/lib/health/thresholds-storage.test.ts
+++ b/apps/dashboard/src/lib/health/thresholds-storage.test.ts
@@ -142,8 +142,8 @@ describe('setThreshold', () => {
     setThreshold('a', { warning: 1, critical: 2 })
     setThreshold('b', { warning: 3, critical: 4 })
     const map = loadThresholds()
-    expect(map['a']).toEqual({ warning: 1, critical: 2 })
-    expect(map['b']).toEqual({ warning: 3, critical: 4 })
+    expect(map.a).toEqual({ warning: 1, critical: 2 })
+    expect(map.b).toEqual({ warning: 3, critical: 4 })
   })
 
   test('dispatches changed event', () => {
@@ -167,8 +167,8 @@ describe('resetThreshold', () => {
     setThreshold('b', { warning: 3, critical: 4 })
     resetThreshold('a')
     const map = loadThresholds()
-    expect(map['a']).toBeUndefined()
-    expect(map['b']).toEqual({ warning: 3, critical: 4 })
+    expect(map.a).toBeUndefined()
+    expect(map.b).toEqual({ warning: 3, critical: 4 })
   })
 
   test('is a no-op and returns true when key does not exist', () => {

--- a/apps/dashboard/src/lib/host-fetch/resolve-host-fetch.test.ts
+++ b/apps/dashboard/src/lib/host-fetch/resolve-host-fetch.test.ts
@@ -12,7 +12,7 @@
 import type { MergedHostInfo } from '@/lib/swr/use-merged-hosts'
 import type { BrowserConnection } from '@/lib/types/browser-connection'
 
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
 
 // ---------------------------------------------------------------------------
 // Mock I/O boundary modules before importing the module under test

--- a/apps/dashboard/src/lib/logs/__tests__/log-severity-filter.test.ts
+++ b/apps/dashboard/src/lib/logs/__tests__/log-severity-filter.test.ts
@@ -8,8 +8,6 @@ const SEVERITY_LEVELS = [
   'Error',
   'Fatal',
 ] as const
-type SeverityLevel = (typeof SEVERITY_LEVELS)[number]
-
 function matchesSeverityFilter(
   level: string,
   filter: string | undefined

--- a/apps/dashboard/src/lib/notifications/dismissed-notifications.test.ts
+++ b/apps/dashboard/src/lib/notifications/dismissed-notifications.test.ts
@@ -63,7 +63,6 @@ beforeEach(() => {
 afterEach(() => {
   // Remove localStorage stub
   try {
-    // biome-ignore lint/performance/noDelete: test cleanup
     delete (globalThis as Record<string, unknown>).localStorage
   } catch {
     // ignore
@@ -165,7 +164,6 @@ describe('getDismissedNotifications', () => {
 
   test('SSR guard: returns empty set when window is undefined', () => {
     const saved = (globalThis as Record<string, unknown>).window
-    // biome-ignore lint/performance/noDelete: SSR simulation
     delete (globalThis as Record<string, unknown>).window
     try {
       const result = getDismissedNotifications()
@@ -230,7 +228,6 @@ describe('dismissNotification', () => {
 
   test('SSR guard: no-op when window is undefined', () => {
     const saved = (globalThis as Record<string, unknown>).window
-    // biome-ignore lint/performance/noDelete: SSR simulation
     delete (globalThis as Record<string, unknown>).window
     try {
       dismissNotification(readonlyNotif)
@@ -276,7 +273,6 @@ describe('dismissAllNotifications', () => {
 
   test('SSR guard: no-op when window is undefined', () => {
     const saved = (globalThis as Record<string, unknown>).window
-    // biome-ignore lint/performance/noDelete: SSR simulation
     delete (globalThis as Record<string, unknown>).window
     try {
       dismissAllNotifications([readonlyNotif])
@@ -319,7 +315,6 @@ describe('clearDismissedNotifications', () => {
   test('SSR guard: no-op when window is undefined', () => {
     lsStub.store[STORAGE_KEY] = JSON.stringify(['some-key'])
     const saved = (globalThis as Record<string, unknown>).window
-    // biome-ignore lint/performance/noDelete: SSR simulation
     delete (globalThis as Record<string, unknown>).window
     try {
       clearDismissedNotifications()

--- a/apps/dashboard/src/lib/og.test.ts
+++ b/apps/dashboard/src/lib/og.test.ts
@@ -47,7 +47,7 @@ describe('OG_PAGES', () => {
   })
 
   test('agents entry has a different headTitle from title', () => {
-    const agents = OG_PAGES['agents']
+    const agents = OG_PAGES.agents
     expect(agents).toBeDefined()
     expect(agents.headTitle).toBe('AI Agent')
     expect(agents.title).toBe('Ask your cluster anything')
@@ -55,7 +55,7 @@ describe('OG_PAGES', () => {
   })
 
   test('overview entry has no headTitle (uses title)', () => {
-    expect(OG_PAGES['overview'].headTitle).toBeUndefined()
+    expect(OG_PAGES.overview.headTitle).toBeUndefined()
   })
 
   test('contains expected slugs', () => {
@@ -85,7 +85,7 @@ describe('OG_PAGES', () => {
   })
 
   test('OgPage type is satisfied at runtime (structural check)', () => {
-    const page: OgPage = OG_PAGES['overview']
+    const page: OgPage = OG_PAGES.overview
     expect(page.eyebrow).toBe('OVERVIEW')
     expect(page.title).toBe('Cluster Overview')
   })

--- a/apps/dashboard/src/lib/peerdb/peerdb-config.test.ts
+++ b/apps/dashboard/src/lib/peerdb/peerdb-config.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 // ---------------------------------------------------------------------------
 
 /** Snapshot + restore a set of env vars around a test scope. */
-function withEnv(
+function _withEnv(
   vars: Record<string, string | undefined>,
   fn: () => void
 ): () => void {
@@ -388,7 +388,7 @@ describe('peerdbFetch', () => {
 
     // PeerDB uses Basic auth with empty username: base64(":" + password)
     const expected = `Basic ${Buffer.from(':secret').toString('base64')}`
-    expect(capturedHeaders['Authorization']).toBe(expected)
+    expect(capturedHeaders.Authorization).toBe(expected)
   })
 
   test('omits Authorization header when no password', async () => {
@@ -406,7 +406,7 @@ describe('peerdbFetch', () => {
 
     // Unique path avoids cache collision
     await peerdbFetch('/v1/no-auth-check')
-    expect(capturedHeaders['Authorization']).toBeUndefined()
+    expect(capturedHeaders.Authorization).toBeUndefined()
   })
 
   test('returns parsed JSON on 2xx response', async () => {

--- a/apps/dashboard/src/lib/security/management-ddl.test.ts
+++ b/apps/dashboard/src/lib/security/management-ddl.test.ts
@@ -8,7 +8,7 @@ import {
   generateRevokeRoleDdl,
   isManagementEnabled,
 } from './management-ddl'
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { afterEach, describe, expect, it } from 'bun:test'
 
 // ---------------------------------------------------------------------------
 // generateCreateUserDdl
@@ -181,23 +181,23 @@ describe('generateRevokePrivilegeDdl', () => {
 // ---------------------------------------------------------------------------
 
 describe('isManagementEnabled', () => {
-  const origEnv = process.env['CLICKHOUSE_MANAGEMENT_ENABLED']
+  const origEnv = process.env.CLICKHOUSE_MANAGEMENT_ENABLED
 
   afterEach(() => {
     if (origEnv === undefined) {
-      delete process.env['CLICKHOUSE_MANAGEMENT_ENABLED']
+      delete process.env.CLICKHOUSE_MANAGEMENT_ENABLED
     } else {
-      process.env['CLICKHOUSE_MANAGEMENT_ENABLED'] = origEnv
+      process.env.CLICKHOUSE_MANAGEMENT_ENABLED = origEnv
     }
   })
 
   it('returns false when env is not set', () => {
-    delete process.env['CLICKHOUSE_MANAGEMENT_ENABLED']
+    delete process.env.CLICKHOUSE_MANAGEMENT_ENABLED
     expect(isManagementEnabled()).toBe(false)
   })
 
   it('returns false when env is set to a non-true value', () => {
-    delete process.env['CLICKHOUSE_MANAGEMENT_ENABLED']
+    delete process.env.CLICKHOUSE_MANAGEMENT_ENABLED
     expect(
       isManagementEnabled({ CLICKHOUSE_MANAGEMENT_ENABLED: 'false' })
     ).toBe(false)
@@ -213,8 +213,8 @@ describe('isManagementEnabled', () => {
   })
 
   it('returns true when process.env has CLICKHOUSE_MANAGEMENT_ENABLED=true', () => {
-    delete process.env['CLICKHOUSE_MANAGEMENT_ENABLED']
-    process.env['CLICKHOUSE_MANAGEMENT_ENABLED'] = 'true'
+    delete process.env.CLICKHOUSE_MANAGEMENT_ENABLED
+    process.env.CLICKHOUSE_MANAGEMENT_ENABLED = 'true'
     expect(isManagementEnabled()).toBe(true)
   })
 })

--- a/apps/dashboard/src/lib/security/management-ddl.ts
+++ b/apps/dashboard/src/lib/security/management-ddl.ts
@@ -11,7 +11,7 @@
 
 /** Wrap a ClickHouse identifier in backticks, escaping any literal backticks. */
 function quoteId(name: string): string {
-  return '`' + name.replace(/`/g, '``') + '`'
+  return `\`${name.replace(/`/g, '``')}\``
 }
 
 /** Escape single quotes in a ClickHouse string literal. */
@@ -149,10 +149,10 @@ export function generateRevokePrivilegeDdl(
 export function isManagementEnabled(
   env?: Record<string, string | undefined>
 ): boolean {
-  if (env && env['CLICKHOUSE_MANAGEMENT_ENABLED'] === 'true') return true
+  if (env && env.CLICKHOUSE_MANAGEMENT_ENABLED === 'true') return true
   if (
     typeof process !== 'undefined' &&
-    process.env?.['CLICKHOUSE_MANAGEMENT_ENABLED'] === 'true'
+    process.env?.CLICKHOUSE_MANAGEMENT_ENABLED === 'true'
   )
     return true
   return false

--- a/apps/dashboard/src/lib/stale-chunk-reload.test.ts
+++ b/apps/dashboard/src/lib/stale-chunk-reload.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
 
 // We import the module fresh per test by re-requiring it.
 // Because the module caches `registered` at module level, we need to
@@ -48,7 +48,7 @@ describe('isDynamicImportError predicate (via unhandledrejection)', () => {
   // reset by reimporting. In Bun tests we achieve this by not reimporting the
   // module — instead we only check the observable effect (reload vs no-reload).
 
-  const RELOAD_TS_KEY = 'chm:stale-chunk-reload-ts'
+  const _RELOAD_TS_KEY = 'chm:stale-chunk-reload-ts'
 
   let reloadCalled: boolean
   let listeners: Record<string, ((e: Event) => void)[]>
@@ -84,7 +84,7 @@ describe('isDynamicImportError predicate (via unhandledrejection)', () => {
       reason,
       preventDefault() {},
     })
-    for (const handler of listeners['unhandledrejection'] ?? []) {
+    for (const handler of listeners.unhandledrejection ?? []) {
       handler(evt)
     }
   }
@@ -96,7 +96,7 @@ describe('isDynamicImportError predicate (via unhandledrejection)', () => {
   // Instead, we just reset `window` to undefined so the re-import guard fires.
   afterEach(() => {
     // Remove window so next setup() starts clean
-    ;(globalThis as unknown as Record<string, unknown>)['window'] = undefined
+    ;(globalThis as unknown as Record<string, unknown>).window = undefined
   })
 
   test('Error with "Failed to fetch dynamically imported module" triggers reload', async () => {
@@ -236,7 +236,7 @@ describe('reload-loop guard', () => {
   }
 
   afterEach(() => {
-    ;(globalThis as unknown as Record<string, unknown>)['window'] = undefined
+    ;(globalThis as unknown as Record<string, unknown>).window = undefined
   })
 
   function fireUnhandledRejection(reason: unknown) {
@@ -244,7 +244,7 @@ describe('reload-loop guard', () => {
       reason,
       preventDefault() {},
     })
-    for (const handler of listeners['unhandledrejection'] ?? []) {
+    for (const handler of listeners.unhandledrejection ?? []) {
       handler(evt)
     }
   }
@@ -356,7 +356,7 @@ describe('vite:preloadError listener', () => {
   }
 
   afterEach(() => {
-    ;(globalThis as unknown as Record<string, unknown>)['window'] = undefined
+    ;(globalThis as unknown as Record<string, unknown>).window = undefined
   })
 
   function fireVitePreloadError() {
@@ -404,12 +404,12 @@ describe('vite:preloadError listener', () => {
 
 describe('SSR guard — no window', () => {
   afterEach(() => {
-    ;(globalThis as unknown as Record<string, unknown>)['window'] = undefined
+    ;(globalThis as unknown as Record<string, unknown>).window = undefined
   })
 
   test('registerStaleChunkReload is a no-op when window is undefined', async () => {
     // Ensure window is not set
-    ;(globalThis as unknown as Record<string, unknown>)['window'] = undefined
+    ;(globalThis as unknown as Record<string, unknown>).window = undefined
 
     // Should not throw
     const { registerStaleChunkReload } = await import(

--- a/apps/dashboard/src/lib/table-guidance.test.ts
+++ b/apps/dashboard/src/lib/table-guidance.test.ts
@@ -41,7 +41,7 @@ describe('TABLE_GUIDANCE', () => {
   })
 
   it('each entry has enableInstructions (non-empty string)', () => {
-    for (const [table, guidance] of Object.entries(TABLE_GUIDANCE)) {
+    for (const [_table, guidance] of Object.entries(TABLE_GUIDANCE)) {
       expect(typeof guidance.enableInstructions).toBe('string')
       expect(guidance.enableInstructions.length).toBeGreaterThan(0)
     }

--- a/apps/dashboard/src/lib/telemetry/config.test.ts
+++ b/apps/dashboard/src/lib/telemetry/config.test.ts
@@ -44,18 +44,18 @@ describe('isTelemetryEnabled', () => {
   })
 
   test('DO_NOT_TRACK hard-overrides an explicit enable', () => {
-    expect(
-      isTelemetryEnabled({ CHM_TELEMETRY: 'on', DO_NOT_TRACK: '1' })
-    ).toBe(false)
+    expect(isTelemetryEnabled({ CHM_TELEMETRY: 'on', DO_NOT_TRACK: '1' })).toBe(
+      false
+    )
     expect(
       isTelemetryEnabled({ CHM_TELEMETRY: 'on', DO_NOT_TRACK: 'true' })
     ).toBe(false)
   })
 
   test('DO_NOT_TRACK=0 / false does not opt out', () => {
-    expect(
-      isTelemetryEnabled({ CHM_TELEMETRY: 'on', DO_NOT_TRACK: '0' })
-    ).toBe(true)
+    expect(isTelemetryEnabled({ CHM_TELEMETRY: 'on', DO_NOT_TRACK: '0' })).toBe(
+      true
+    )
     expect(
       isTelemetryEnabled({ CHM_TELEMETRY: 'on', DO_NOT_TRACK: 'false' })
     ).toBe(true)

--- a/apps/dashboard/src/lib/telemetry/instance-ping.test.ts
+++ b/apps/dashboard/src/lib/telemetry/instance-ping.test.ts
@@ -263,7 +263,9 @@ describe('runInstancePing error resilience', () => {
 describe('endpoint resolution and kill-switch', () => {
   test('getPingEndpoint falls back to the default collector when unset', () => {
     expect(getPingEndpoint({})).toBe(DEFAULT_TELEMETRY_ENDPOINT)
-    expect(getPingEndpoint({ UNRELATED: 'foo' })).toBe(DEFAULT_TELEMETRY_ENDPOINT)
+    expect(getPingEndpoint({ UNRELATED: 'foo' })).toBe(
+      DEFAULT_TELEMETRY_ENDPOINT
+    )
   })
 
   test('explicit endpoint env overrides the default', () => {

--- a/apps/dashboard/src/routes/(dashboard)/fleet.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/fleet.tsx
@@ -10,7 +10,6 @@ function FleetSkeleton() {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
       {Array.from({ length: 4 }).map((_, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
         <Skeleton key={i} className="h-44 w-full rounded-xl" />
       ))}
     </div>

--- a/apps/dashboard/src/routes/api/v1/management.ts
+++ b/apps/dashboard/src/routes/api/v1/management.ts
@@ -52,13 +52,13 @@ interface ManagementRequest {
 function isManagementEnabled(): boolean {
   try {
     const bindings = env as Record<string, string | undefined>
-    if (bindings['CLICKHOUSE_MANAGEMENT_ENABLED'] === 'true') return true
+    if (bindings.CLICKHOUSE_MANAGEMENT_ENABLED === 'true') return true
   } catch {
     // cloudflare:workers env not available
   }
   return (
     typeof process !== 'undefined' &&
-    process.env?.['CLICKHOUSE_MANAGEMENT_ENABLED'] === 'true'
+    process.env?.CLICKHOUSE_MANAGEMENT_ENABLED === 'true'
   )
 }
 

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -366,6 +366,7 @@
 }
 
 :root {
+  /* Theme: Rhea (shadcn preset b1HXxFoMC) — blue primary, amber chart ramp. */
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
@@ -373,10 +374,10 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
+  --primary: oklch(0.488 0.243 264.376);
+  --primary-foreground: oklch(0.97 0.014 254.604);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);
   --accent: oklch(0.97 0 0);
@@ -385,15 +386,15 @@
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
+  --chart-1: oklch(0.879 0.169 91.605);
+  --chart-2: oklch(0.769 0.188 70.08);
+  --chart-3: oklch(0.666 0.179 58.318);
+  --chart-4: oklch(0.555 0.163 48.998);
+  --chart-5: oklch(0.473 0.137 46.201);
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.546 0.245 262.881);
+  --sidebar-primary-foreground: oklch(0.97 0.014 254.604);
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
@@ -436,31 +437,31 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.269 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
+  --primary: oklch(0.424 0.199 265.638);
+  --primary-foreground: oklch(0.97 0.014 254.604);
+  --secondary: oklch(0.274 0.006 286.033);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
   --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.371 0 0);
+  --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
+  --chart-1: oklch(0.879 0.169 91.605);
+  --chart-2: oklch(0.769 0.188 70.08);
+  --chart-3: oklch(0.666 0.179 58.318);
+  --chart-4: oklch(0.555 0.163 48.998);
+  --chart-5: oklch(0.473 0.137 46.201);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.623 0.214 259.815);
+  --sidebar-primary-foreground: oklch(0.97 0.014 254.604);
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.439 0 0);
+  --sidebar-ring: oklch(0.556 0 0);
 }
 
 @theme inline {

--- a/apps/docs/src/components/mdx.tsx
+++ b/apps/docs/src/components/mdx.tsx
@@ -7,6 +7,7 @@ import { Step, Steps } from 'fumadocs-ui/components/steps'
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs'
 import { TypeTable } from 'fumadocs-ui/components/type-table'
 import defaultMdxComponents from 'fumadocs-ui/mdx'
+import { GrantBuilder } from '@/components/mdx/grant-builder'
 import { Mermaid } from '@/components/mdx/mermaid'
 
 // Components made globally available to every MDX page (no per-file imports).
@@ -25,6 +26,8 @@ export function getMDXComponents(components?: MDXComponents) {
     Files,
     Folder,
     TypeTable,
+    // GrantBuilder: interactive permission-level picker on the CH requirements page.
+    GrantBuilder,
     // Mermaid: renders ```mermaid fenced blocks and <Mermaid chart=…/> as SVG.
     Mermaid,
     // Twoslash UI: renders TypeScript hover popups for ```ts twoslash blocks.

--- a/apps/docs/src/components/mdx/grant-builder.tsx
+++ b/apps/docs/src/components/mdx/grant-builder.tsx
@@ -1,0 +1,340 @@
+'use client'
+
+import { CheckIcon, CopyIcon } from 'lucide-react'
+
+import { useState } from 'react'
+
+/* ------------------------------------------------------------------ */
+/* Feature definitions                                                  */
+/* ------------------------------------------------------------------ */
+
+interface Feature {
+  id: string
+  name: string
+  description: string
+  always?: boolean
+  requires?: string
+}
+
+const FEATURES: Feature[] = [
+  {
+    id: 'base',
+    name: 'Basic read-only',
+    description:
+      'All monitoring dashboards — queries, merges, replicas, metrics',
+    always: true,
+  },
+  {
+    id: 'explorer',
+    name: 'Data Explorer',
+    description: 'Query any table in any database, not just system tables',
+  },
+  {
+    id: 'actions',
+    name: 'Actions (Kill Query · Optimize Table)',
+    description:
+      'Let operators kill running queries and optimize tables from the UI',
+  },
+  {
+    id: 'ai_agent',
+    name: 'AI Agent control tools',
+    description:
+      'Let the AI agent kill queries and optimize tables (also requires AGENT_ENABLE_CONTROL_TOOLS=true)',
+    requires: 'actions',
+  },
+]
+
+/* ------------------------------------------------------------------ */
+/* Code generators                                                      */
+/* ------------------------------------------------------------------ */
+
+function buildSQL(enabled: Set<string>): string {
+  const lines: string[] = [
+    `CREATE USER monitoring`,
+    `  IDENTIFIED WITH sha256_password BY 'your-password'`,
+    `  HOST ANY;`,
+    ``,
+  ]
+
+  if (enabled.has('explorer')) {
+    lines.push(`-- SELECT ON *.* covers system.* and every user database`)
+    lines.push(`GRANT SELECT ON *.* TO monitoring;`)
+  } else {
+    lines.push(`-- System tables (metrics, queries, merges, replicas, …)`)
+    lines.push(`GRANT SELECT ON system.* TO monitoring;`)
+  }
+
+  lines.push(`-- Required for some merge-aware queries`)
+  lines.push(`GRANT CREATE TEMPORARY TABLE ON *.* TO monitoring;`)
+
+  if (enabled.has('actions')) {
+    lines.push(``)
+    lines.push(`-- Kill Query action (Running Queries page / AI agent)`)
+    lines.push(`GRANT KILL QUERY ON *.* TO monitoring;`)
+    lines.push(`-- Optimize Table action (Data Explorer page / AI agent)`)
+    lines.push(`GRANT OPTIMIZE ON *.* TO monitoring;`)
+  }
+
+  if (enabled.has('ai_agent')) {
+    lines.push(``)
+    lines.push(`-- Also set this env var in your chmonitor deployment:`)
+    lines.push(`-- AGENT_ENABLE_CONTROL_TOOLS=true`)
+  }
+
+  return lines.join('\n')
+}
+
+function buildXML(enabled: Set<string>): string {
+  const grants: string[] = []
+
+  if (enabled.has('explorer')) {
+    grants.push(
+      `        <!-- SELECT ON *.* covers system.* and every user database -->`
+    )
+    grants.push(`        <query>GRANT SELECT ON *.*</query>`)
+  } else {
+    grants.push(
+      `        <!-- System tables (metrics, queries, merges, replicas, …) -->`
+    )
+    grants.push(`        <query>GRANT SELECT ON system.*</query>`)
+  }
+
+  grants.push(`        <!-- Required for some merge-aware queries -->`)
+  grants.push(`        <query>GRANT CREATE TEMPORARY TABLE ON *.*</query>`)
+
+  if (enabled.has('actions')) {
+    grants.push(`        <!-- Kill Query + Optimize Table actions -->`)
+    grants.push(`        <query>GRANT KILL QUERY ON *.*</query>`)
+    grants.push(`        <query>GRANT OPTIMIZE ON *.*</query>`)
+  }
+
+  const lines = [
+    `<!-- /etc/clickhouse-server/users.d/monitoring.xml -->`,
+    `<!-- Generate hash: echo -n 'your-password' | sha256sum -->`,
+    `<clickhouse>`,
+    `  <users>`,
+    `    <monitoring>`,
+    `      <password_sha256_hex>REPLACE_WITH_SHA256_OF_YOUR_PASSWORD</password_sha256_hex>`,
+    `      <networks><ip>::/0</ip></networks>`,
+    `      <profile>monitoring_profile</profile>`,
+    `      <grants>`,
+    ...grants,
+    `      </grants>`,
+    `    </monitoring>`,
+    `  </users>`,
+    `</clickhouse>`,
+  ]
+
+  if (enabled.has('ai_agent')) {
+    lines.push(``)
+    lines.push(
+      `<!-- Also set in your chmonitor deployment: AGENT_ENABLE_CONTROL_TOOLS=true -->`
+    )
+  }
+
+  return lines.join('\n')
+}
+
+/* ------------------------------------------------------------------ */
+/* Minimal syntax colouring — no external deps                         */
+/* ------------------------------------------------------------------ */
+
+function colourSQL(raw: string): string {
+  const SQL_KEYWORDS =
+    /\b(CREATE|USER|IDENTIFIED|WITH|BY|HOST|ANY|GRANT|ON|TO|SELECT|TEMPORARY|TABLE|KILL|QUERY|OPTIMIZE)\b/g
+
+  return raw
+    .split('\n')
+    .map((line) => {
+      if (line.trimStart().startsWith('--')) {
+        return `<span class="ch-comment">${escape(line)}</span>`
+      }
+      let out = escape(line)
+      out = out.replace(SQL_KEYWORDS, '<span class="ch-kw">$1</span>')
+      out = out.replace(/(&#39;[^&#]*&#39;)/g, '<span class="ch-str">$1</span>')
+      return out
+    })
+    .join('\n')
+}
+
+function colourXML(raw: string): string {
+  return raw
+    .split('\n')
+    .map((line) => {
+      const trimmed = line.trimStart()
+      if (trimmed.startsWith('<!--') || trimmed.endsWith('-->')) {
+        return `<span class="ch-comment">${escape(line)}</span>`
+      }
+      let out = escape(line)
+      // XML tags
+      out = out.replace(
+        /(&lt;\/?[\w_:.-]+(?:\s[^&gt;]*)?\/?&gt;)/g,
+        '<span class="ch-tag">$1</span>'
+      )
+      return out
+    })
+    .join('\n')
+}
+
+function escape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/'/g, '&#39;')
+}
+
+/* ------------------------------------------------------------------ */
+/* Component                                                            */
+/* ------------------------------------------------------------------ */
+
+export function GrantBuilder() {
+  const [enabled, setEnabled] = useState<Set<string>>(new Set())
+  const [mode, setMode] = useState<'sql' | 'xml'>('sql')
+  const [copied, setCopied] = useState(false)
+
+  function toggle(id: string) {
+    setEnabled((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+        if (id === 'actions') next.delete('ai_agent')
+      } else {
+        next.add(id)
+        if (id === 'ai_agent') next.add('actions')
+      }
+      return next
+    })
+  }
+
+  const code = mode === 'sql' ? buildSQL(enabled) : buildXML(enabled)
+
+  async function copy() {
+    await navigator.clipboard.writeText(code)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const highlighted = mode === 'sql' ? colourSQL(code) : colourXML(code)
+
+  return (
+    <div className="my-6 overflow-hidden rounded-xl border border-fd-border bg-fd-card">
+      {/* ── Feature toggles ── */}
+      <div className="border-b border-fd-border px-4 py-3">
+        <p className="mb-2.5 text-[11px] font-semibold uppercase tracking-widest text-fd-muted-foreground">
+          Select features
+        </p>
+        <div className="space-y-2">
+          {FEATURES.map((f) => {
+            const isOn = !!f.always || enabled.has(f.id)
+            const isLocked = !!f.always
+            return (
+              <label
+                key={f.id}
+                className={[
+                  'flex cursor-pointer items-start gap-3 rounded-lg px-2.5 py-2 transition-colors',
+                  isLocked
+                    ? 'cursor-default opacity-60'
+                    : isOn
+                      ? 'bg-fd-primary/5 hover:bg-fd-primary/10'
+                      : 'hover:bg-fd-muted/50',
+                ].join(' ')}
+              >
+                {/* custom checkbox */}
+                <div className="relative mt-0.5 shrink-0">
+                  <input
+                    type="checkbox"
+                    checked={isOn}
+                    disabled={isLocked}
+                    onChange={() => !isLocked && toggle(f.id)}
+                    className="sr-only"
+                  />
+                  <div
+                    className={[
+                      'flex size-[18px] items-center justify-center rounded-[5px] border-2 transition-colors',
+                      isOn
+                        ? 'border-fd-primary bg-fd-primary'
+                        : 'border-fd-border bg-fd-background',
+                    ].join(' ')}
+                  >
+                    {isOn && (
+                      <CheckIcon
+                        className="size-2.5 text-fd-primary-foreground"
+                        strokeWidth={3}
+                      />
+                    )}
+                  </div>
+                </div>
+
+                {/* label text */}
+                <div className="min-w-0">
+                  <span className="block text-sm font-medium leading-snug text-fd-foreground">
+                    {f.name}
+                    {f.requires && (
+                      <span className="ml-1.5 text-[10px] font-normal text-fd-muted-foreground">
+                        (requires Actions)
+                      </span>
+                    )}
+                  </span>
+                  <span className="text-xs text-fd-muted-foreground">
+                    {f.description}
+                  </span>
+                </div>
+              </label>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* ── SQL / XML toggle + Copy ── */}
+      <div className="flex items-center justify-between border-b border-fd-border bg-fd-muted/30 px-3 py-1.5">
+        <div className="flex gap-0.5 rounded-md bg-fd-muted p-0.5">
+          {(['sql', 'xml'] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMode(m)}
+              className={[
+                'rounded px-3 py-1 text-xs font-semibold uppercase tracking-wide transition-colors',
+                mode === m
+                  ? 'bg-fd-background text-fd-foreground shadow-sm'
+                  : 'text-fd-muted-foreground hover:text-fd-foreground',
+              ].join(' ')}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={copy}
+          className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-fd-muted-foreground transition-colors hover:bg-fd-muted hover:text-fd-foreground"
+        >
+          {copied ? (
+            <CheckIcon
+              className="size-3.5 text-emerald-500"
+              strokeWidth={2.5}
+            />
+          ) : (
+            <CopyIcon className="size-3.5" strokeWidth={2} />
+          )}
+          {copied ? 'Copied!' : 'Copy'}
+        </button>
+      </div>
+
+      {/* ── Code output ── */}
+      <style>{`
+        .grant-code .ch-comment { color: var(--fd-muted-foreground); font-style: italic; }
+        .grant-code .ch-kw      { color: var(--fd-primary); font-weight: 600; }
+        .grant-code .ch-str     { color: #22c55e; }
+        .grant-code .ch-tag     { color: var(--fd-primary); }
+        :is(.dark) .grant-code .ch-str { color: #4ade80; }
+      `}</style>
+      <pre className="grant-code overflow-x-auto bg-fd-background p-4 text-[13px] leading-relaxed">
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: output is generated from our own templates, not user input */}
+        <code dangerouslySetInnerHTML={{ __html: highlighted }} />
+      </pre>
+    </div>
+  )
+}

--- a/apps/docs/src/components/mdx/grant-builder.tsx
+++ b/apps/docs/src/components/mdx/grant-builder.tsx
@@ -332,7 +332,6 @@ export function GrantBuilder() {
         :is(.dark) .grant-code .ch-str { color: #4ade80; }
       `}</style>
       <pre className="grant-code overflow-x-auto bg-fd-background p-4 text-[13px] leading-relaxed">
-        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: output is generated from our own templates, not user input */}
         <code dangerouslySetInnerHTML={{ __html: highlighted }} />
       </pre>
     </div>

--- a/apps/docs/src/components/mdx/mermaid.tsx
+++ b/apps/docs/src/components/mdx/mermaid.tsx
@@ -61,7 +61,6 @@ export function Mermaid({ chart }: MermaidProps) {
 
   return (
     <div
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: mermaid output is trusted SVG
       dangerouslySetInnerHTML={{ __html: svg }}
       className="my-4 flex justify-center overflow-auto [&_svg]:max-w-full"
     />

--- a/apps/docs/src/routes/$.tsx
+++ b/apps/docs/src/routes/$.tsx
@@ -13,7 +13,7 @@ import {
   ViewOptionsPopover,
 } from 'fumadocs-ui/layouts/docs/page'
 import { Suspense } from 'react'
-import { useMDXComponents } from '@/components/mdx'
+import { getMDXComponents } from '@/components/mdx'
 import { SidebarFooter } from '@/components/sidebar-footer'
 import { baseOptions } from '@/lib/layout.shared'
 import { gitConfig } from '@/lib/shared'
@@ -95,7 +95,7 @@ const clientLoader = browserCollections.docs.createClientLoader({
           />
         </div>
         <DocsBody>
-          <MDX components={useMDXComponents()} />
+          <MDX components={getMDXComponents()} />
         </DocsBody>
       </DocsPage>
     )

--- a/apps/docs/src/routes/__root.tsx
+++ b/apps/docs/src/routes/__root.tsx
@@ -6,7 +6,6 @@ import {
 } from '@tanstack/react-router'
 
 import { RootProvider } from 'fumadocs-ui/provider/tanstack'
-import * as React from 'react'
 import appCss from '@/styles/app.css?url'
 
 export const Route = createRootRoute({

--- a/apps/landing/scripts/build-og.ts
+++ b/apps/landing/scripts/build-og.ts
@@ -125,7 +125,7 @@ function smoothPath(pts: Pt[]) {
   return d
 }
 const linePath = (pts: Pt[]) =>
-  'M ' + pts.map((p) => `${p[0]} ${p[1]}`).join(' L ')
+  `M ${pts.map((p) => `${p[0]} ${p[1]}`).join(' L ')}`
 const mapPts = (
   sx: number,
   sy: number,

--- a/apps/telemetry/src/index.ts
+++ b/apps/telemetry/src/index.ts
@@ -143,7 +143,11 @@ export default {
         return bad(400, 'invalid event')
       }
       const props = (data.props ?? {}) as Record<string, unknown>
-      const deployTarget = asEnum(props.deploy_target, DEPLOY_TARGETS, 'unknown')
+      const deployTarget = asEnum(
+        props.deploy_target,
+        DEPLOY_TARGETS,
+        'unknown'
+      )
       const chVersion = asVersion(props.ch_version)
       const chFlavor = asEnum(props.ch_flavor, CH_FLAVORS, 'unknown')
 

--- a/biome.json
+++ b/biome.json
@@ -128,7 +128,8 @@
       "!packages/clickhouse-client/src/wasm/generated",
       "!**/*.generated.ts",
       "!.agents",
-      "!.claude"
+      "!.claude",
+      "!.omo"
     ]
   }
 }

--- a/docs/content/guide/getting-started/clickhouse-requirements.mdx
+++ b/docs/content/guide/getting-started/clickhouse-requirements.mdx
@@ -16,24 +16,47 @@ IPs, or a jump host).
 
 ## Copy & paste: pick a permission level
 
-Switch the tab to the level you want, then paste the whole block into a ClickHouse client (or drop the XML into `users.d/`). Replace `your-password` first.
+Toggle the features you need — the SQL and XML output updates automatically. Replace `your-password` before running. The `monitoring_profile` body is in the [recommended profile](#recommended-clickhouse-profile) section below.
 
-<Tabs items={['Read-only (SQL)', 'Read-only + actions (SQL)', 'users.xml']}>
-<Tab value="Read-only (SQL)">
+<GrantBuilder />
+
+The static reference tabs below show every combination individually if you prefer to copy from them directly.
+
+<Tabs items={['Read-only · SQL', 'Explorer · SQL', 'With actions · SQL', 'Read-only · XML', 'Explorer · XML', 'With actions · XML', 'Role-based · XML']}>
+
+<Tab value="Read-only · SQL">
 ```sql
--- View every monitoring page. Cannot kill queries, optimize, or mutate data.
+-- Monitoring dashboards only. Cannot kill queries, optimize, or mutate data.
 CREATE USER monitoring
   IDENTIFIED WITH sha256_password BY 'your-password'
   HOST ANY;
 
+-- All system tables (metrics, queries, merges, replicas, …)
 GRANT SELECT ON system.* TO monitoring;
+
+-- Required for some merge-aware queries
 GRANT CREATE TEMPORARY TABLE ON *.* TO monitoring;
 ```
 </Tab>
-<Tab value="Read-only + actions (SQL)">
+
+<Tab value="Explorer · SQL">
 ```sql
--- Read-only, plus the optional Kill Query and Optimize Table actions.
--- The UI/agent still needs AGENT_ENABLE_CONTROL_TOOLS=true for kill/optimize.
+-- Monitoring dashboards + Data Explorer (query any table in any database).
+-- SELECT ON *.* covers system.* as well — use only if you trust this account
+-- to read all your databases.
+CREATE USER monitoring
+  IDENTIFIED WITH sha256_password BY 'your-password'
+  HOST ANY;
+
+GRANT SELECT ON *.* TO monitoring;
+GRANT CREATE TEMPORARY TABLE ON *.* TO monitoring;
+```
+</Tab>
+
+<Tab value="With actions · SQL">
+```sql
+-- Read-only monitoring, plus Kill Query and Optimize Table actions.
+-- AGENT_ENABLE_CONTROL_TOOLS=true is also required for the AI agent to use these.
 CREATE USER monitoring
   IDENTIFIED WITH sha256_password BY 'your-password'
   HOST ANY;
@@ -44,7 +67,8 @@ GRANT KILL QUERY ON *.* TO monitoring;
 GRANT OPTIMIZE ON *.* TO monitoring;
 ```
 </Tab>
-<Tab value="users.xml">
+
+<Tab value="Read-only · XML">
 ```xml
 <!-- /etc/clickhouse-server/users.d/monitoring.xml -->
 <clickhouse>
@@ -61,8 +85,89 @@ GRANT OPTIMIZE ON *.* TO monitoring;
   </users>
 </clickhouse>
 ```
-Generate the hash with `echo -n 'your-password' | sha256sum`. See the [recommended profile](#recommended-clickhouse-profile) for the `monitoring_profile` body.
+Generate the hash: `echo -n 'your-password' | sha256sum`. See the [recommended profile](#recommended-clickhouse-profile) for the `monitoring_profile` body.
 </Tab>
+
+<Tab value="Explorer · XML">
+```xml
+<!-- /etc/clickhouse-server/users.d/monitoring.xml -->
+<!-- SELECT ON *.* covers system.* and every user database. -->
+<clickhouse>
+  <users>
+    <monitoring>
+      <password_sha256_hex>REPLACE_WITH_SHA256_OF_YOUR_PASSWORD</password_sha256_hex>
+      <networks><ip>::/0</ip></networks>
+      <profile>monitoring_profile</profile>
+      <grants>
+        <query>GRANT SELECT ON *.*</query>
+        <query>GRANT CREATE TEMPORARY TABLE ON *.*</query>
+      </grants>
+    </monitoring>
+  </users>
+</clickhouse>
+```
+Generate the hash: `echo -n 'your-password' | sha256sum`. Run `SYSTEM RELOAD CONFIG` or restart ClickHouse after editing.
+</Tab>
+
+<Tab value="With actions · XML">
+```xml
+<!-- /etc/clickhouse-server/users.d/monitoring.xml -->
+<!-- Read-only monitoring, plus Kill Query and Optimize Table. -->
+<clickhouse>
+  <users>
+    <monitoring>
+      <password_sha256_hex>REPLACE_WITH_SHA256_OF_YOUR_PASSWORD</password_sha256_hex>
+      <networks><ip>::/0</ip></networks>
+      <profile>monitoring_profile</profile>
+      <grants>
+        <query>GRANT SELECT ON system.*</query>
+        <query>GRANT CREATE TEMPORARY TABLE ON *.*</query>
+        <query>GRANT KILL QUERY ON *.*</query>
+        <query>GRANT OPTIMIZE ON *.*</query>
+      </grants>
+    </monitoring>
+  </users>
+</clickhouse>
+```
+Generate the hash: `echo -n 'your-password' | sha256sum`. `AGENT_ENABLE_CONTROL_TOOLS=true` is also required for the AI agent to use Kill Query / Optimize.
+</Tab>
+
+<Tab value="Role-based · XML">
+Roles let you manage grants centrally and assign them to multiple users. Create the role via SQL first, then reference it from the user XML.
+
+**Step 1 — create the role (run once in a ClickHouse client):**
+
+```sql
+CREATE ROLE IF NOT EXISTS monitoring_role;
+GRANT SELECT ON system.* TO monitoring_role;
+GRANT CREATE TEMPORARY TABLE ON *.* TO monitoring_role;
+
+-- Optional: expand to Explorer or action support
+-- GRANT SELECT ON *.* TO monitoring_role;
+-- GRANT KILL QUERY ON *.* TO monitoring_role;
+-- GRANT OPTIMIZE ON *.* TO monitoring_role;
+```
+
+**Step 2 — user config (`/etc/clickhouse-server/users.d/monitoring.xml`):**
+
+```xml
+<clickhouse>
+  <users>
+    <monitoring>
+      <password_sha256_hex>REPLACE_WITH_SHA256_OF_YOUR_PASSWORD</password_sha256_hex>
+      <networks><ip>::/0</ip></networks>
+      <profile>monitoring_profile</profile>
+      <grants>
+        <query>GRANT monitoring_role TO monitoring</query>
+      </grants>
+    </monitoring>
+  </users>
+</clickhouse>
+```
+
+Generate the hash: `echo -n 'your-password' | sha256sum`. Run `SYSTEM RELOAD CONFIG` after editing the XML. Update grants on the role and they apply to all users holding it.
+</Tab>
+
 </Tabs>
 
 ## Minimum: read-only monitoring user
@@ -81,6 +186,18 @@ GRANT SELECT ON system.* TO monitoring;
 -- Allow temporary tables (required for some merge-aware queries)
 GRANT CREATE TEMPORARY TABLE ON *.* TO monitoring;
 ```
+
+## Optional: Data Explorer (query any table)
+
+The Data Explorer lets you run SQL against any table in your ClickHouse instance, not just `system.*`. To enable it, grant `SELECT` on all databases:
+
+```sql
+-- Lets the monitoring user read every table in every database.
+-- Use only if you trust this account to access all your data.
+GRANT SELECT ON *.* TO monitoring;
+```
+
+`SELECT ON *.*` is a superset of `SELECT ON system.*`, so you do not need both.
 
 ## Optional grants for actions
 


### PR DESCRIPTION
## Summary

- **Chat components**: `Marker` + `Attachment` UI components for the AI chat interface
- **Rhea theme**: OKLCH-based blue primary / amber chart ramp replacing the old stone base
- **Shimmer loader**: animated skeleton shimmer utility added to `@theme`
- **GrantBuilder**: interactive permission picker on the ClickHouse requirements docs page — users check the features they need (Explorer, Actions, AI agent), SQL/XML output updates live with correct `GRANT` statements
- **Lint cleanup**: auto-fixed stale `biome-ignore` suppressions, unused imports/vars, and a `useHookAtTopLevel` issue across ~34 test/component files; excluded `.omo/` from Biome scanning

## Test plan

- [ ] Build passes (`bun run build`)
- [ ] All 4429 dashboard unit tests pass (verified by pre-push hook)
- [ ] All 880 package tests pass (verified by pre-push hook)
- [ ] Chat components render correctly in the AI agent panel
- [ ] GrantBuilder on `/guide/getting-started/clickhouse-requirements` — toggle features and verify SQL/XML output updates

https://claude.ai/code/session_01N9CwfRzmYordbqFvhDjQ2b