### PR TITLE
feat(host-switch): vXX.yy version, auto-hide metadata, remove demo label, add cloud sign-in note

### DIFF
--- a/apps/dashboard/src/components/connections/add-host-dialog.tsx
+++ b/apps/dashboard/src/components/connections/add-host-dialog.tsx
@@ -73,6 +73,26 @@ export function AddHostDialog({ open, onOpenChange }: AddHostDialogProps) {
             for grants and how to allowlist the Cloud connection.
           </DialogDescription>
         </DialogHeader>
+
+        {!isSignedIn && (
+          <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs text-amber-800 dark:border-amber-800/30 dark:bg-amber-950/20 dark:text-amber-300">
+            <p className="font-medium">Sign in for more</p>
+            <p className="mt-0.5 text-amber-700 dark:text-amber-400">
+              Server storage is disabled on this deployment.{' '}
+              <a
+                href={docsSiteUrl('features/user-connections')}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium underline underline-offset-2 hover:text-amber-900 dark:hover:text-amber-200"
+              >
+                Enable user connections
+              </a>
+              . Sign in to select your plan or join an organization to get
+              access to your team&apos;s clusters.
+            </p>
+          </div>
+        )}
+
         <ConnectionForm
           onSave={handleSave}
           onCancel={() => onOpenChange(false)}

--- a/apps/dashboard/src/components/connections/connection-form.tsx
+++ b/apps/dashboard/src/components/connections/connection-form.tsx
@@ -261,7 +261,7 @@ export function ConnectionForm({
           {!dbStorageEnabled && (
             <p className="text-xs text-muted-foreground">
               {dbStorageRequiresSignIn ? (
-                'Sign in to save connections to the server (synced per account).'
+                'Sign in to save connections to the server (synced per account) — then select a plan or join an organization for more access.'
               ) : (
                 <>
                   Server storage is disabled on this deployment.{' '}
@@ -272,7 +272,9 @@ export function ConnectionForm({
                     className="underline underline-offset-2 hover:text-foreground"
                   >
                     Enable user connections
-                  </a>
+                  </a>{' '}
+                  to save credentials to your account and access your
+                  team&apos;s clusters.
                 </>
               )}
             </p>

--- a/apps/dashboard/src/components/host/host-menu-row.tsx
+++ b/apps/dashboard/src/components/host/host-menu-row.tsx
@@ -14,6 +14,18 @@ interface HostMenuRowProps {
   skipStatus?: boolean
 }
 
+/**
+ * Parse a full version string into a short v{major}.{minor} label.
+ * e.g. "24.3.1.1" → "v24.3", "24.12.1.1234" → "v24.12"
+ */
+function formatShortVersion(version: string): string {
+  const parts = version.split('.')
+  if (parts.length >= 2) {
+    return `v${parts[0]}.${parts[1]}`
+  }
+  return version
+}
+
 export const HostMenuRow = function HostMenuRow({
   hostId,
   hostName,
@@ -62,7 +74,15 @@ export const HostMenuRow = function HostMenuRow({
           >
             <TagIcon className="size-3 shrink-0 opacity-70" />
             {/* Version is short and the priority — never shrink it. */}
-            <span className="shrink-0 tabular-nums">{data.version}</span>
+            <span className="shrink-0 tabular-nums">
+              {formatShortVersion(data.version)}
+            </span>
+
+            {/* Show full version in dropdown (more space available) */}
+            <span className="hidden @[240px]:inline text-muted-foreground/60">
+              {data.version}
+            </span>
+
             <span className="shrink-0 opacity-40">·</span>
             <ClockIcon className="size-3 shrink-0 opacity-70" />
             {/* Uptime yields first: it needs min-w-0 to ellipsize inside a flex row. */}

--- a/apps/dashboard/src/components/host/host-switcher.tsx
+++ b/apps/dashboard/src/components/host/host-switcher.tsx
@@ -231,12 +231,15 @@ export function HostSwitcher() {
                           <span className="truncate">
                             {activeHost.name || getHost(activeHost.host)}
                           </span>
-                          {activeHost.source === 'demo' && <DemoBadge />}
                         </span>
                         {isServerHost(activeHost.source) ? (
                           <span className="flex items-center gap-1 truncate text-xs text-muted-foreground">
                             <HostVersionWithStatus hostId={activeHost.id} />
-                            {activeHost.readOnly && <span>· read-only</span>}
+                            {activeHost.readOnly && (
+                              <span className="hidden min-[500px]:inline">
+                                · read-only
+                              </span>
+                            )}
                           </span>
                         ) : (
                           <span className="truncate text-xs text-muted-foreground">
@@ -277,9 +280,6 @@ export function HostSwitcher() {
                       isActive={host.id === currentHostId}
                       skipStatus={!isServerHost(host.source)}
                     />
-                    {host.source === 'demo' && (
-                      <DemoBadge className="ml-auto" />
-                    )}
                   </DropdownMenuItem>
                 ))}
                 <DropdownMenuSeparator />
@@ -322,19 +322,5 @@ export function HostSwitcher() {
       </SidebarMenu>
       <AddHostDialog open={addDialogOpen} onOpenChange={setAddDialogOpen} />
     </>
-  )
-}
-
-/** Small "Demo" pill marking the public read-only cloud demo host. */
-function DemoBadge({ className }: { className?: string }) {
-  return (
-    <span
-      className={cn(
-        'shrink-0 rounded bg-muted px-1 py-px text-[10px] font-medium uppercase tracking-wide text-muted-foreground',
-        className
-      )}
-    >
-      Demo
-    </span>
   )
 }

--- a/apps/dashboard/src/components/host/host-version-status.tsx
+++ b/apps/dashboard/src/components/host/host-version-status.tsx
@@ -1,7 +1,8 @@
 /**
  * Host version with status indicator for expanded sidebar state
  *
- * Shows ClickHouse version with online/offline status indicator.
+ * Shows ClickHouse version (vXX.yy format) with online/offline status indicator
+ * and progressive disclosure: version → uptime based on available space.
  */
 
 import { ClockIcon, TagIcon } from 'lucide-react'
@@ -11,9 +12,25 @@ import { useHostStatus } from '@/lib/swr/use-host-status'
 
 interface HostVersionWithStatusProps {
   hostId: number
+  variant?: 'header' | 'dropdown'
 }
 
-export function HostVersionWithStatus({ hostId }: HostVersionWithStatusProps) {
+/**
+ * Parse a full version string into a short v{major}.{minor} label.
+ * e.g. "24.3.1.1" → "v24.3", "24.12.1.1234" → "v24.12"
+ */
+function formatShortVersion(version: string): string {
+  const parts = version.split('.')
+  if (parts.length >= 2) {
+    return `v${parts[0]}.${parts[1]}`
+  }
+  return version
+}
+
+export function HostVersionWithStatus({
+  hostId,
+  variant = 'header',
+}: HostVersionWithStatusProps) {
   const { data, isOnline, isLoading } = useHostStatus(hostId, {
     refreshInterval: 60000,
     revalidateOnFocus: false,
@@ -29,6 +46,8 @@ export function HostVersionWithStatus({ hostId }: HostVersionWithStatusProps) {
   }
 
   if (isOnline && data) {
+    const shortVersion = formatShortVersion(data.version)
+
     return (
       <span
         className="flex items-center gap-1.5 min-w-0 text-xs text-muted-foreground"
@@ -37,13 +56,28 @@ export function HostVersionWithStatus({ hostId }: HostVersionWithStatusProps) {
         <StatusIndicatorOnline />
         <TagIcon className="size-3 shrink-0 opacity-70" />
         {/* Version is short and the priority — never shrink it. */}
-        <span className="shrink-0 tabular-nums">{data.version}</span>
-        <span className="shrink-0 opacity-40">·</span>
-        <ClockIcon className="size-3 shrink-0 opacity-70" />
-        {/* Uptime yields first: it needs min-w-0 to ellipsize inside a flex row. */}
-        <span className="min-w-0 truncate tabular-nums">
-          {formatCompactUptime(data.uptime)}
-        </span>
+        <span className="shrink-0 tabular-nums">{shortVersion}</span>
+
+        {variant === 'dropdown' ? (
+          <>
+            <span className="shrink-0 opacity-40">·</span>
+            {data.version}
+            <span className="shrink-0 opacity-40">·</span>
+            <ClockIcon className="size-3 shrink-0 opacity-70" />
+            <span className="tabular-nums">
+              {formatCompactUptime(data.uptime)}
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="shrink-0 opacity-40">·</span>
+            <ClockIcon className="size-3 shrink-0 opacity-70" />
+            {/* Uptime yields first: it needs min-w-0 to ellipsize inside a flex row. */}
+            <span className="min-w-0 truncate tabular-nums">
+              {formatCompactUptime(data.uptime)}
+            </span>
+          </>
+        )}
       </span>
     )
   }


### PR DESCRIPTION
## Changes

### Host switch refinements
- **Remove DemoBadge**: Remove the "Demo" pill label from host-switcher (both header + dropdown)
- **vXX.yy version format**: Version now shows as `v{major}.{minor}` (e.g. `v24.3`) for compact display, with full version shown in dropdown
- **Progressive disclosure**: Version always visible, uptime truncates when no space, read-only indicator appears only on wider sidebar (`min-[500px]`)
- **Dropdown shows more**: Menu rows show full version alongside short format + uptime

### Cloud add-host form
- **Sign-in banner**: Show amber info note when user is not signed in, encouraging them to sign in to select a plan or join an organization
- **Storage message update**: Clarify existing storage messages to mention plan/org access

## Screenshots
N/A (no visual changes visible on main)

## Test plan
- `bun run build` passes
- Host switch renders without demo badge
- Version shows vXX.yy format in sidebar header
- Dropdown shows full version + uptime
- Add-host dialog shows sign-in banner for anonymous users