### PR TITLE
fix(about): sync package.json version with release-please, remove read-only label

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -22,6 +22,11 @@
           "type": "yaml",
           "path": "deploy/helm/chmonitor/Chart.yaml",
           "jsonpath": "$.appVersion"
+        },
+        {
+          "type": "json",
+          "path": "apps/dashboard/src/package.json",
+          "jsonpath": "$.version"
         }
       ],
       "changelog-sections": [

--- a/apps/dashboard/src/components/host/host-switcher.tsx
+++ b/apps/dashboard/src/components/host/host-switcher.tsx
@@ -235,11 +235,6 @@ export function HostSwitcher() {
                         {isServerHost(activeHost.source) ? (
                           <span className="flex items-center gap-1 truncate text-xs text-muted-foreground">
                             <HostVersionWithStatus hostId={activeHost.id} />
-                            {activeHost.readOnly && (
-                              <span className="hidden min-[500px]:inline">
-                                · read-only
-                              </span>
-                            )}
                           </span>
                         ) : (
                           <span className="truncate text-xs text-muted-foreground">

--- a/apps/dashboard/src/package.json
+++ b/apps/dashboard/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.0.1",
+  "version": "0.2.11",
   "description": "ClickHouse Monitoring Dashboard — real-time insights into ClickHouse clusters via system tables.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Changes

1. **Fix about page version** —  was stuck at , so the about page showed the wrong version. Bumped to  (current release-please manifest) and registered it as an  in  so it stays in sync.

2. **Remove read-only label from host-switcher** — The header metadata line in the host switcher no longer shows "· read-only" next to the host name.

## Testing
- `bun run build` passes
- Unit tests pass (880 pass, 0 fail)