### PR TITLE
fix(landing): correct cd directory in deploy install snippets

### DIFF
--- a/apps/landing/src/components/OpenSource.astro
+++ b/apps/landing/src/components/OpenSource.astro
@@ -52,7 +52,7 @@
             <div class="term-bar"><span class="lights"><i style="background:#ff5f57"></i><i style="background:#febc2e"></i><i style="background:#28c840"></i></span><span class="ttl">bash</span><button class="copy">Copy</button></div>
             <div class="term-body">
               <div><span class="p">$</span> git clone https://github.com/chmonitor/chmonitor.git</div>
-              <div><span class="p">$</span> cd clickhouse-monitoring</div>
+              <div><span class="p">$</span> cd chmonitor</div>
               <div><span class="p">$</span> bun install</div>
               <div>&nbsp;</div>
               <div><span class="c"># production env + a token with Workers deploy permission</span></div>
@@ -88,7 +88,7 @@
             <div class="term-bar"><span class="lights"><i style="background:#ff5f57"></i><i style="background:#febc2e"></i><i style="background:#28c840"></i></span><span class="ttl">bash</span><button class="copy">Copy</button></div>
             <div class="term-body">
               <div><span class="p">$</span> git clone https://github.com/chmonitor/chmonitor.git</div>
-              <div><span class="p">$</span> cd clickhouse-monitoring</div>
+              <div><span class="p">$</span> cd chmonitor</div>
               <div><span class="p">$</span> docker compose up <span class="s">-d</span></div>
             </div>
           </div>
@@ -102,7 +102,7 @@
             <div class="term-bar"><span class="lights"><i style="background:#ff5f57"></i><i style="background:#febc2e"></i><i style="background:#28c840"></i></span><span class="ttl">bash</span><button class="copy">Copy</button></div>
             <div class="term-body">
               <div><span class="p">$</span> git clone https://github.com/chmonitor/chmonitor.git</div>
-              <div><span class="p">$</span> cd clickhouse-monitoring</div>
+              <div><span class="p">$</span> cd chmonitor</div>
               <div>&nbsp;</div>
               <div><span class="p">$</span> helm install my-chm ./deploy/helm/chmonitor <span class="f">\</span></div>
               <div>&nbsp;&nbsp;<span class="s">--set</span> clickhouse.host="https://clickhouse.example.com:8443" <span class="f">\</span></div>


### PR DESCRIPTION
Closes #2059

## Summary
All three deploy panes in `apps/landing/src/components/OpenSource.astro` (Cloudflare Workers, Docker trial, Kubernetes/Helm) clone with `git clone https://github.com/chmonitor/chmonitor.git` — which creates a `chmonitor/` directory — but then `cd clickhouse-monitoring`, a directory that does not exist. Anyone copy-pasting a snippet hits `cd: no such file or directory`.

This changes all three `cd clickhouse-monitoring` occurrences to `cd chmonitor`.

## Verification
- Confirmed no `clickhouse-monitoring` references remain in the file.
- The per-terminal copy button (in `layouts/Base.astro`) reads each `.term-body > div` innerText, strips the leading `$ ` prompt, and preserves the `cd ...` line verbatim — so the copied snippet now yields `cd chmonitor`, which is correct. (Base.astro not modified.)
- `cd apps/landing && bun run build` passes (all 5 static pages built).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb

---
_Generated by [Claude Code](https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb)_