### PR TITLE
fix(landing): add page h1 headings and polish copy

### DIFF
--- a/apps/landing/src/components/Capabilities.astro
+++ b/apps/landing/src/components/Capabilities.astro
@@ -1,7 +1,7 @@
   <section id="capabilities" class="band">
     <div class="wrap">
       <div class="sec-head reveal">
-        <span class="eyebrow">And a lot more</span>
+        <span class="eyebrow">Full coverage</span>
         <h2>One dashboard for the whole cluster</h2>
         <p>From a high-level overview down to ZooKeeper logs and replication mirrors, every system table you reach for, already laid out.</p>
       </div>
@@ -14,7 +14,7 @@
         <div class="cap reveal">
           <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="m3 17 6-6 4 4 8-8"/><path d="M14 7h7v7"/></svg></span>
           <h4>Cluster insights</h4>
-          <p>Record-breaking scans, busiest days, total rows read and storage, the highlights from all your data.</p>
+          <p>Record-breaking scans, busiest days, total rows read and storage, surfaced automatically from your query history.</p>
         </div>
         <div class="cap reveal">
           <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M6 8v3a3 3 0 0 0 3 3h6a3 3 0 0 0 3-3V8"/><path d="M12 14v2"/></svg></span>

--- a/apps/landing/src/components/Comparison.astro
+++ b/apps/landing/src/components/Comparison.astro
@@ -8,7 +8,7 @@ const partialSvg = `<svg class="cmp-partial" viewBox="0 0 24 24" fill="none" str
     <div class="sec-head reveal">
       <span class="eyebrow">Why chmonitor</span>
       <h2>Purpose-built for ClickHouse</h2>
-      <p>Generic monitoring tools work. Purpose-built tools work better. Here's how chmonitor stacks up against the most common alternatives.</p>
+      <p>General-purpose tools treat ClickHouse as one data source among many. chmonitor reads its system tables directly and tracks nothing else. Here's how it stacks up against the most common alternatives.</p>
     </div>
 
     <div class="cmp-wrap reveal">
@@ -63,7 +63,7 @@ const partialSvg = `<svg class="cmp-partial" viewBox="0 0 24 24" fill="none" str
               <td>Cost</td>
               <td class="cmp-highlight">Free self-host; cloud in early access</td>
               <td>Grafana OSS free; Grafana Cloud paid</td>
-              <td>~$15-30 per host per month (varies)</td>
+              <td>~$15–23 per host per month (varies)</td>
               <td>Free (bundled with ClickHouse)</td>
             </tr>
             <tr>

--- a/apps/landing/src/pages/brand.astro
+++ b/apps/landing/src/pages/brand.astro
@@ -107,7 +107,7 @@ const monoMark = `<svg viewBox="0 0 32 32" fill="currentColor" xmlns="http://www
         <div class="sec-head">
           <p class="eyebrow">Lockup</p>
           <h2>Mark + wordmark</h2>
-          <p>The wordmark is set lowercase in Inter SemiBold with tight tracking. Keep the mark roughly the cap-height of the word, with a gap of one bar's width.</p>
+          <p>The wordmark is set lowercase in Geist SemiBold with tight tracking. Keep the mark roughly the cap-height of the word, with a gap of one bar's width.</p>
         </div>
         <div class="lockups">
           <div class="lockup"><img src="/brand/logo.svg" alt="chmonitor logo" width="208" height="44" /></div>
@@ -158,7 +158,7 @@ const monoMark = `<svg viewBox="0 0 32 32" fill="currentColor" xmlns="http://www
             <li>Don't recolor the bars, add gradients, or restore the old tile / ping.</li>
             <li>Don't stretch, rotate, or reorder the bars — the heights are the identity.</li>
             <li>Don't pair the mark with the ClickHouse logo as if it were one brand.</li>
-            <li>Don't set the wordmark in any face other than Inter.</li>
+            <li>Don't set the wordmark in any face other than Geist.</li>
           </ul>
         </div>
       </div>

--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -69,7 +69,7 @@ function mdToHtml(md: string): string {
       <div class="wrap">
         <div class="sec-head" style="margin-bottom:0">
           <span class="eyebrow">What's new</span>
-          <h2>Changelog</h2>
+          <h1>Changelog</h1>
           <p>Release notes for chmonitor. Full history on <a href="https://github.com/chmonitor/chmonitor/releases" target="_blank" rel="noopener" style="color:var(--orange)">GitHub Releases</a>.</p>
         </div>
 
@@ -107,4 +107,10 @@ function mdToHtml(md: string): string {
     </section>
   </main>
   <Footer />
+
+  <style>
+    /* Promoted page title: match the global .sec-head h2 type scale so the
+       h1 renders identically to the previous heading. */
+    .sec-head h1{font-size:clamp(28px,3.4vw,40px);line-height:1.1;letter-spacing:-.025em;font-weight:700;margin-top:14px;text-wrap:balance}
+  </style>
 </Base>

--- a/apps/landing/src/pages/pricing.astro
+++ b/apps/landing/src/pages/pricing.astro
@@ -30,7 +30,7 @@ const faqJsonLd = {
       <div class="wrap">
         <div class="sec-head price-head reveal">
           <span class="eyebrow">Pricing</span>
-          <h2>Simple pricing that scales with your fleet</h2>
+          <h1>Simple pricing that scales with your fleet</h1>
           <p>Self-hosting is always free under GPL-3.0. The hosted cloud connects a cluster in minutes — start free, upgrade when your team grows. <strong>Early access is free to try</strong> while in beta.</p>
         </div>
       </div>
@@ -124,6 +124,9 @@ const faqJsonLd = {
        auto margins, so center it and the left-flex eyebrow explicitly. */
     .price-head{text-align:center}
     .price-head .eyebrow{justify-content:center}
+    /* Promoted page title: match the global .sec-head h2 type scale so the
+       h1 looks identical to the section headings below it. */
+    .price-head h1{font-size:clamp(28px,3.4vw,40px);line-height:1.1;letter-spacing:-.025em;font-weight:700;margin-top:14px;text-wrap:balance}
     .price-head p{margin-inline:auto}
 
     .price-cmp .cmp-yes{stroke:var(--emerald)}


### PR DESCRIPTION
Closes #2062

## Summary

Slice L5 — heading hierarchy + copy polish on the landing marketing pages.

1. **Heading hierarchy** — `pricing.astro` and `changelog.astro` topped out at `<h2>`. Promoted each page title to a real `<h1>` (exactly one per page) with a scoped style that replicates the global `.sec-head h2` type scale, so the visual appearance is unchanged.
2. **Copy polish** (tightened weak / "AI-slop" spots to concrete value statements, brand voice preserved):
   - `Capabilities.astro`: eyebrow `And a lot more` → `Full coverage`; card copy `…the highlights from all your data` → `…surfaced automatically from your query history`.
   - `Comparison.astro`: `Generic monitoring tools work. Purpose-built tools work better.` → a concrete claim about reading ClickHouse system tables directly.
3. **Cost reconciliation** — `Comparison.astro` Datadog figure `~$15-30 per host per month` reconciled with the source-of-truth comment in `packages/pricing/src/plans.ts` (`~$15–23/host`) → now `~$15–23 per host per month (varies)`.
4. **Brand font harmonization** — the logo SVG (`public/brand/logo.svg`) declares `font-family="Inter, …system-ui…"`, but the site ships/loads **Geist** (no Inter `@font-face`), so the wordmark actually renders in Geist/system-ui. Harmonized the `brand.astro` guidance ("set in Inter" / "no face other than Inter") to **Geist** to match the shipped font.

## Verify

- `cd apps/landing && bun run build` — passes; 5 pages built.
- Confirmed exactly one `<h1>` in each built page (`pricing`, `changelog`, `brand`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb

---
_Generated by [Claude Code](https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb)_