### PR TITLE
refactor(health): unify severity classification via classifyValue

### DIFF
--- a/apps/dashboard/src/lib/health/__tests__/health-status.test.ts
+++ b/apps/dashboard/src/lib/health/__tests__/health-status.test.ts
@@ -143,6 +143,20 @@ describe('computeStuckMutations', () => {
     expect(r.label).toBe('6 active · 0 stuck · 0 failed')
   })
 
+  test('exactly five active stays ok (boundary)', () => {
+    expect(
+      computeStuckMutations(state([{ active: 5, stuck: 0, failed: 0 }]), false)
+        .status
+    ).toBe('ok')
+  })
+
+  test('stuck outranks a high active count (worst-of wins)', () => {
+    expect(
+      computeStuckMutations(state([{ active: 9, stuck: 1, failed: 0 }]), false)
+        .status
+    ).toBe('critical')
+  })
+
   test('no data → healthy zero', () => {
     expect(computeStuckMutations(state([]), false).status).toBe('ok')
   })
@@ -159,6 +173,12 @@ describe('computeRunningMutations', () => {
     expect(
       computeRunningMutations(state([{ running_count: 10 }]), false).status
     ).toBe('critical')
+  })
+
+  test('non-finite running count is reported as error', () => {
+    const r = computeRunningMutations(state([{ running_count: 'oops' }]), false)
+    expect(r.status).toBe('error')
+    expect(r.value).toBe(0)
   })
 })
 

--- a/apps/dashboard/src/lib/health/health-status.ts
+++ b/apps/dashboard/src/lib/health/health-status.ts
@@ -14,6 +14,8 @@ import type { HealthCheckDef } from '@/components/health/health-checks'
 import type { HealthCheckState } from '@/components/health/use-health-checks'
 import type { Thresholds } from '@/lib/health/thresholds-storage'
 
+import { classifyValue } from '@/lib/alerting/rule-registry'
+
 export type HealthStatus = 'ok' | 'warning' | 'critical' | 'loading' | 'error'
 
 /** Sort order: worst first, then unknown (error/loading) last. */
@@ -76,9 +78,7 @@ export function computeCheckStatus(
     value = raw === null || raw === undefined ? 0 : Number(raw)
     label = check.formatLabel ? check.formatLabel(value) : String(value)
     if (Number.isFinite(value)) {
-      if (value >= thresholds.critical) status = 'critical'
-      else if (value >= thresholds.warning) status = 'warning'
-      else status = 'ok'
+      status = classifyValue(value, thresholds)
     } else {
       status = 'error'
       label = 'Invalid value'
@@ -143,9 +143,22 @@ export function computeStuckMutations(
       failed = 0
     } else {
       label = `${active} active · ${stuck} stuck · ${failed} failed`
-      if (stuck > 0 || failed > 0) status = 'critical'
-      else if (active > 5) status = 'warning'
-      else status = 'ok'
+      // Mutations-specific rules layered on the shared classifier: any stuck or
+      // failed mutation (count ≥ 1) is critical; more than five active is a
+      // warning. Counts are non-negative integers, so `> 0` ≡ `>= 1` and
+      // `> 5` ≡ `>= 6`. Take the worst of the two signals.
+      const blockingStatus = classifyValue(Math.max(stuck, failed), {
+        warning: Number.POSITIVE_INFINITY,
+        critical: 1,
+      })
+      const activeStatus = classifyValue(active, {
+        warning: 6,
+        critical: Number.POSITIVE_INFINITY,
+      })
+      status =
+        SEVERITY_RANK[blockingStatus] <= SEVERITY_RANK[activeStatus]
+          ? blockingStatus
+          : activeStatus
     }
   } else {
     status = 'ok'
@@ -182,7 +195,7 @@ export function computeRunningMutations(
       value = 0
     } else {
       label = `${value.toLocaleString()} running mutations`
-      status = value >= 10 ? 'critical' : value >= 3 ? 'warning' : 'ok'
+      status = classifyValue(value, { warning: 3, critical: 10 })
     }
   } else {
     label = '0 running mutations'


### PR DESCRIPTION
Closes #2081

## Summary (Slice A6 — pure refactor)

Unifies the health-page severity classification onto the shared `classifyValue()` from `src/lib/alerting/rule-registry.ts`, removing the duplicated inline `>=critical / >=warning / else ok` logic in `src/lib/health/health-status.ts`.

- **`computeCheckStatus`** — inside the existing `Number.isFinite(value)` branch, the three-line threshold ladder is replaced with `classifyValue(value, thresholds)`. The `Thresholds` type is structurally identical to `AlertRuleThresholds` (`{ warning, critical }`), so it passes directly. Non-finite → `error` handling is unchanged.
- **`computeStuckMutations`** — mutations-specific rules are **layered on top** of the shared classifier: any stuck/failed mutation (count ≥ 1) is critical, more than five active is a warning, taking the worst of the two `classifyValue` signals. Counts are non-negative integers so `> 0` ≡ `>= 1` and `> 5` ≡ `>= 6` (documented in a comment).
- **`computeRunningMutations`** — the standard `value >= 10 ? critical : value >= 3 ? warning : ok` ladder becomes `classifyValue(value, { warning: 3, critical: 10 })`.

Behavior is identical. Public function signatures are unchanged. No changes to `server-sweep.ts` or `rule-registry.ts` (`classifyValue` was already exported).

## Tests

Added boundary/equivalence cases to `health-status.test.ts`:
- `active = 5` stays `ok` (warning boundary)
- a stuck mutation outranks a high active count (worst-of wins)
- a non-finite running count reports `error`

## Verify

- `bun test src/lib/health/__tests__/health-status.test.ts` → **15 pass / 0 fail**
- `bun run type-check` → my touched files add **0** errors. The worktree shows 200 pre-existing errors from the un-generated `routeTree.gen.ts` (identical count with my changes stashed).
- Full `bun test` → 97 failures, **identical to the clean base** (all in unrelated modules: getHost, MCP tools, agent, insights). Zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb

---
_Generated by [Claude Code](https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb)_