### PR TITLE
fix(health): block SSRF in the alert webhook proxy

### DIFF
--- a/apps/dashboard/src/routes/api/v1/health/webhook.test.ts
+++ b/apps/dashboard/src/routes/api/v1/health/webhook.test.ts
@@ -1,0 +1,134 @@
+import { __handlePostForTests as handlePost } from './webhook'
+import { describe, expect, test } from 'bun:test'
+
+// Injected DNS resolver so tests never hit the network. A public address makes
+// hostname targets resolve to a non-internal IP (allowed); tests that must be
+// blocked use IP literals (blocked before DNS) or a resolver returning an
+// internal address.
+const resolvePublic = async () => ['93.184.216.34']
+const resolvePrivate = async () => ['10.0.0.5']
+
+function makeRequest(body: unknown): Request {
+  return new Request('https://dash.example.com/api/v1/health/webhook', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+/** A fetch stub that records the URL + body it was called with. */
+function stubFetch() {
+  const calls: { url: string; body: string }[] = []
+  const fetchImpl = (async (input: unknown, init?: RequestInit) => {
+    calls.push({
+      url: String(input),
+      body: typeof init?.body === 'string' ? init.body : '',
+    })
+    return new Response('ok', { status: 200 })
+  }) as unknown as typeof fetch
+  return { calls, fetchImpl }
+}
+
+describe('health webhook proxy — SSRF hardening', () => {
+  test('blocks the cloud metadata IP (169.254.169.254)', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const res = await handlePost(
+      makeRequest({
+        url: 'https://169.254.169.254/latest/meta-data/',
+        text: 'hi',
+      }),
+      { resolveHostAddresses: resolvePublic, fetchImpl }
+    )
+
+    expect(res.status).toBe(400)
+    // The outbound fetch must never run for a blocked target.
+    expect(calls).toHaveLength(0)
+  })
+
+  test('blocks an RFC1918 host that resolves to a private address', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const res = await handlePost(
+      makeRequest({ url: 'https://internal.corp.example', text: 'hi' }),
+      { resolveHostAddresses: resolvePrivate, fetchImpl }
+    )
+
+    expect(res.status).toBe(400)
+    expect(calls).toHaveLength(0)
+  })
+
+  test('blocks a raw RFC1918 IP literal (10.0.0.1)', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const res = await handlePost(
+      makeRequest({ url: 'https://10.0.0.1/webhook', text: 'hi' }),
+      { resolveHostAddresses: resolvePublic, fetchImpl }
+    )
+
+    expect(res.status).toBe(400)
+    expect(calls).toHaveLength(0)
+  })
+
+  test('allows a normal public HTTPS webhook and wraps text', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const res = await handlePost(
+      makeRequest({
+        url: 'https://hooks.slack.com/services/T000/B000/XXXX',
+        text: 'hello world',
+      }),
+      { resolveHostAddresses: resolvePublic, fetchImpl }
+    )
+
+    expect(res.status).toBe(200)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe('https://hooks.slack.com/services/T000/B000/XXXX')
+    // Backward-compatible default wrapper.
+    expect(JSON.parse(calls[0].body)).toEqual({
+      text: 'hello world',
+      content: 'hello world',
+    })
+  })
+
+  test('rejects non-https URLs', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const res = await handlePost(
+      makeRequest({ url: 'http://hooks.slack.com/x', text: 'hi' }),
+      { resolveHostAddresses: resolvePublic, fetchImpl }
+    )
+
+    expect(res.status).toBe(400)
+    expect(calls).toHaveLength(0)
+  })
+})
+
+describe('health webhook proxy — provider verbatim forwarding', () => {
+  test('forwards the payload verbatim when a provider hint is present', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const payload = { blocks: [{ type: 'section', text: 'custom' }] }
+    const res = await handlePost(
+      makeRequest({
+        url: 'https://hooks.slack.com/services/T000/B000/XXXX',
+        provider: 'slack',
+        payload,
+      }),
+      { resolveHostAddresses: resolvePublic, fetchImpl }
+    )
+
+    expect(res.status).toBe(200)
+    expect(calls).toHaveLength(1)
+    // Forwarded verbatim — NOT re-wrapped as { text, content }.
+    expect(JSON.parse(calls[0].body)).toEqual(payload)
+  })
+
+  test('requires a payload when provider is set', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const res = await handlePost(
+      makeRequest({
+        url: 'https://hooks.slack.com/services/T000/B000/XXXX',
+        provider: 'slack',
+      }),
+      { resolveHostAddresses: resolvePublic, fetchImpl }
+    )
+
+    expect(res.status).toBe(400)
+    expect(calls).toHaveLength(0)
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/health/webhook.ts
+++ b/apps/dashboard/src/routes/api/v1/health/webhook.ts
@@ -2,8 +2,16 @@
  * Health Webhook Proxy Endpoint
  * POST /api/v1/health/webhook
  *
- * Securely proxies Slack/Discord webhook requests from the server side to
+ * Securely proxies Slack/Discord/etc. webhook requests from the server side to
  * bypass browser CORS preflight restrictions.
+ *
+ * SECURITY (SSRF): this endpoint makes the server fetch a caller-supplied URL,
+ * so it is an SSRF sink. Every URL is run through `validateHostUrl` (the same
+ * guard used for ClickHouse connections) which rejects private / loopback /
+ * link-local / metadata targets (RFC1918 10/8, 172.16/12, 192.168/16,
+ * 127.0.0.0/8, 169.254.0.0/16, ::1, IPv6 ULA fc00::/7, CGNAT, …) — both raw IP
+ * literals and hostnames that resolve into those ranges. Errors are returned as
+ * a generic 400 so we never leak internal DNS/resolution detail.
  *
  * Ported from apps/dashboard/app/api/v1/health/webhook/route.ts.
  * - Per-route auth (authorizeFeatureRequest / SETTINGS_FEATURE_PERMISSION)
@@ -17,18 +25,49 @@ import { createFileRoute } from '@tanstack/react-router'
 import { debug, error } from '@chm/logger'
 import { createErrorResponse } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
+import {
+  type ResolveHostAddresses,
+  validateHostUrl,
+} from '@/lib/browser-connections/host-url'
 
 const ROUTE_CONTEXT = {
   route: '/api/v1/health/webhook',
   method: 'POST',
 } as const
 
-async function handlePost(request: Request): Promise<Response> {
+/** Generic, non-leaky message for a blocked/invalid destination URL. */
+const BLOCKED_URL_MESSAGE =
+  'The webhook URL is not allowed. Use a public HTTPS endpoint.'
+
+interface WebhookRequestBody {
+  url?: string
+  text?: string
+  /**
+   * Optional provider hint (e.g. "slack", "discord", "telegram", "pagerduty").
+   * When present, `payload` is forwarded to the webhook verbatim instead of the
+   * default `{ text, content }` wrapper — so callers can send provider-specific
+   * bodies (Slack blocks, Discord embeds, PagerDuty events, …).
+   */
+  provider?: string
+  /** Exact JSON body to forward when `provider` is set. */
+  payload?: unknown
+}
+
+/** Injectable dependencies (tests override the DNS resolver + fetch). */
+interface WebhookDeps {
+  resolveHostAddresses?: ResolveHostAddresses
+  fetchImpl?: typeof fetch
+}
+
+async function handlePost(
+  request: Request,
+  deps: WebhookDeps = {}
+): Promise<Response> {
   debug('[POST /api/v1/health/webhook] Proxying alert webhook')
 
-  let body: { url?: string; text?: string }
+  let body: WebhookRequestBody
   try {
-    body = (await request.json()) as { url?: string; text?: string }
+    body = (await request.json()) as WebhookRequestBody
   } catch {
     return createErrorResponse(
       {
@@ -40,7 +79,7 @@ async function handlePost(request: Request): Promise<Response> {
     )
   }
 
-  const { url, text } = body
+  const { url, text, provider, payload } = body
 
   if (!url || typeof url !== 'string' || !url.startsWith('https://')) {
     return createErrorResponse(
@@ -53,15 +92,58 @@ async function handlePost(request: Request): Promise<Response> {
     )
   }
 
-  if (!text || typeof text !== 'string') {
+  // SSRF guard: block private / loopback / link-local / metadata destinations.
+  // Reuses the shared ClickHouse connection guard so the block ranges stay in
+  // one place. On a blocked/invalid host we return a generic 400 and log the
+  // real reason server-side only (no leak of internal resolution detail).
+  const ssrfError = await validateHostUrl(url, deps.resolveHostAddresses)
+  if (ssrfError) {
+    error(
+      '[POST /api/v1/health/webhook] Blocked SSRF-unsafe webhook URL',
+      new Error(ssrfError)
+    )
     return createErrorResponse(
       {
         type: ApiErrorType.ValidationError,
-        message: 'Missing or invalid "text": expected a string payload',
+        message: BLOCKED_URL_MESSAGE,
       },
       400,
       ROUTE_CONTEXT
     )
+  }
+
+  // Determine the outgoing body. With a `provider` hint the caller controls the
+  // exact JSON (forwarded verbatim); otherwise keep the backward-compatible
+  // `{ text, content }` wrapper driven by `text`.
+  const usesProvider =
+    typeof provider === 'string' && provider.trim().length > 0
+
+  let outgoingBody: unknown
+  if (usesProvider) {
+    if (payload === undefined || payload === null) {
+      return createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message:
+            'Missing or invalid "payload": expected a JSON body when "provider" is set',
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+    }
+    outgoingBody = payload
+  } else {
+    if (!text || typeof text !== 'string') {
+      return createErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Missing or invalid "text": expected a string payload',
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+    }
+    outgoingBody = { text, content: text }
   }
 
   debug(
@@ -69,14 +151,15 @@ async function handlePost(request: Request): Promise<Response> {
     `${url.substring(0, 40)}...`
   )
 
+  const doFetch = deps.fetchImpl ?? fetch
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), 10_000)
 
   try {
-    const res = await fetch(url, {
+    const res = await doFetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text, content: text }),
+      body: JSON.stringify(outgoingBody),
       signal: controller.signal,
     })
 
@@ -121,3 +204,6 @@ export const Route = createFileRoute('/api/v1/health/webhook')({
     },
   },
 })
+
+// Exported for unit tests only.
+export { handlePost as __handlePostForTests }


### PR DESCRIPTION
Closes #2078

## Summary

The health webhook proxy (`POST /api/v1/health/webhook`) previously only checked `url.startsWith('https://')`, so any authenticated caller could make the Worker fetch arbitrary internal URLs — cloud metadata (`169.254.169.254`), RFC1918 hosts, loopback, etc. This is a server-side request forgery (SSRF) sink.

### Changes (`apps/dashboard/src/routes/api/v1/health/webhook.ts`)

- **SSRF block via the existing shared guard.** Every destination URL now runs through `validateHostUrl` (the same helper used for ClickHouse browser/user connections in `lib/browser-connections/host-url.ts`), which rejects private / loopback / link-local / metadata targets — RFC1918 (`10/8`, `172.16/12`, `192.168/16`), `127.0.0.0/8`, `169.254.0.0/16`, `::1`, IPv6 ULA `fc00::/7`, CGNAT — for both raw IP literals and hostnames that resolve into those ranges. Reused rather than reinvented so the block ranges stay in one place.
- **Safe errors.** A blocked/invalid URL returns a generic `400` ("The webhook URL is not allowed. Use a public HTTPS endpoint."); the real reason is logged server-side only, so no internal DNS/resolution detail leaks.
- **Provider hint.** Added an optional `provider` field. When present, the request's `payload` is forwarded to the webhook **verbatim** (Slack blocks, Discord embeds, PagerDuty events, …) instead of being re-wrapped as `{ text, content }`. Behaviour is unchanged and backward-compatible when `provider` is absent (still driven by `text`).

### Tests (`webhook.test.ts`, new)

Focused `bun test` unit tests using an injected DNS resolver + fetch stub (no network):
- blocked cloud-metadata IP (`169.254.169.254`)
- blocked RFC1918 hostname (resolves to `10.0.0.5`)
- blocked raw RFC1918 IP literal (`10.0.0.1`)
- allowed normal public HTTPS webhook (verifies the `{ text, content }` wrapper)
- non-https rejected
- provider verbatim forwarding + payload-required guard

## Verification

- `bun test src/routes/api/v1/health/` → **7 pass / 0 fail**.
- `bun run type-check` → the only diagnostic touching this file is the repo-wide `createFileRoute(...) not assignable to undefined` error, which affects **all ~200 route files** because the generated `src/routeTree.gen.ts` is absent in a fresh checkout (environmental; not introduced here). No other type errors in the changed files.
- Biome: changed files formatted/clean. (The whole-repo pre-push `biome check .` flags pre-existing lint issues in unrelated files, e.g. `components/alerting/regression-panel.tsx`, already on `main`.)

## Notes / deviations

- Branch uses the hyphen form `claude/landing-admin-redesign-g6axki-alert-webhook-ssrf` (matching sibling branches) because the requested slash form `.../alert-webhook-ssrf` collides with the existing `claude/landing-admin-redesign-g6axki` branch.
- The optional provider-domain allowlist (Slack/Discord/Telegram/PagerDuty) was intentionally not enforced — the primary control is the private-range block, and enforcing an allowlist would break legitimate custom webhooks in self-hosted (OSS) deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb

---
_Generated by [Claude Code](https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb)_