### PR TITLE
fix(health): dedup client alerts and emit recovery events

### DIFF
--- a/apps/dashboard/src/components/health/health-grid.tsx
+++ b/apps/dashboard/src/components/health/health-grid.tsx
@@ -12,7 +12,15 @@ import { RunningMutationsCard, StuckMutationsCard } from './mutations-cards'
 import { EMPTY_STATE, useHealthChecks } from './use-health-checks'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { dispatchAlert, isEscalation } from '@/lib/health/alert-dispatcher'
+import {
+  alertStatusKey,
+  dispatchAlert,
+  dispatchRecovery,
+  healthIncidentId,
+  isEscalation,
+  loadAlertStatuses,
+  saveAlertStatuses,
+} from '@/lib/health/alert-dispatcher'
 import {
   computeCheckStatus,
   computeRunningMutations,
@@ -209,17 +217,21 @@ export function HealthGrid() {
   }, [dataUpdatedAt, hostId, isLoading])
 
   // Dispatch alerts on escalation for ALL checks, independent of the filter, so
-  // hiding a card never silences (or, on remount, re-fires) its alert.
-  const lastStatusRef = useRef<
-    Record<string, 'ok' | 'warning' | 'critical' | null>
-  >({})
+  // hiding a card never silences its alert. Last-seen status is persisted per
+  // `host::checkId` in localStorage (not a per-instance ref), so escalation
+  // state survives component remount / navigation: returning to /health does
+  // NOT re-fire an alert whose status has not changed. On de-escalation back to
+  // `ok`, a recovery event is emitted so downstream consumers can clear it.
   useEffect(() => {
     // `dataUpdatedAt` re-runs this on each refresh; skip before the first fetch.
     if (isLoading || dataUpdatedAt === 0) return
+    const statuses = loadAlertStatuses()
+    let changed = false
     for (const item of itemsRef.current) {
       const s = item.status
       if (s !== 'ok' && s !== 'warning' && s !== 'critical') continue
-      const prev = lastStatusRef.current[item.id] ?? null
+      const key = alertStatusKey(hostId, item.id)
+      const prev = statuses[key] ?? null
       if (isEscalation(prev, s) && s !== 'ok') {
         void dispatchAlert({
           checkId: item.id,
@@ -228,10 +240,26 @@ export function HealthGrid() {
           value: item.alert.value,
           label: item.alert.label,
           hostId,
+          incidentId: healthIncidentId(hostId, item.id, s),
+        })
+      } else if (s === 'ok' && (prev === 'warning' || prev === 'critical')) {
+        // Recovered: report against the severity that just cleared.
+        void dispatchRecovery({
+          checkId: item.id,
+          title: item.alert.title,
+          severity: prev,
+          value: item.alert.value,
+          label: item.alert.label,
+          hostId,
+          incidentId: healthIncidentId(hostId, item.id, prev),
         })
       }
-      lastStatusRef.current[item.id] = s
+      if (statuses[key] !== s) {
+        statuses[key] = s
+        changed = true
+      }
     }
+    if (changed) saveAlertStatuses(statuses)
   }, [dataUpdatedAt, hostId, isLoading])
 
   const counts = useMemo<HealthCounts>(() => {

--- a/apps/dashboard/src/lib/health/alert-dispatcher.ts
+++ b/apps/dashboard/src/lib/health/alert-dispatcher.ts
@@ -1,5 +1,8 @@
 import { loadAlertSettings } from './alert-settings-storage'
 
+/** Actionable health severities used for escalation/recovery bookkeeping. */
+export type HealthAlertStatus = 'ok' | 'warning' | 'critical'
+
 export interface HealthAlertEvent {
   checkId: string
   title: string
@@ -7,11 +10,80 @@ export interface HealthAlertEvent {
   value: number | null
   label: string
   hostId: number
-  /** Monotonic id used to keep dismissed notifications from suppressing later incidents */
+  /**
+   * Monotonic id used to keep dismissed notifications from suppressing later
+   * incidents. Prefer a stable, windowed id (see {@link healthIncidentId}) so
+   * repeated dispatches within the same window dedup downstream.
+   */
   incidentId?: string
+  /**
+   * Whether this event raises an alert or clears one. Optional and defaults to
+   * `'alert'` so existing consumers that ignore it keep working unchanged.
+   */
+  kind?: 'alert' | 'recovery'
 }
 
 const HEALTH_ALERT_EVENT = 'health-alert'
+
+/**
+ * Persisted last-seen status per `host::checkId`, so escalation state survives
+ * component remount / navigation and {@link dispatchAlert} does not re-fire when
+ * the user returns to /health. Mirrors the storage shape of
+ * {@link file://./thresholds-storage.ts} / {@link file://./history-storage.ts}.
+ */
+const ALERT_STATUS_STORAGE_KEY = 'health-alert-status'
+
+/** Dedup window for stable health incident ids (1 minute). */
+const INCIDENT_WINDOW_MS = 60_000
+
+export type AlertStatusMap = Record<string, HealthAlertStatus>
+
+/** Storage key for a single check's last-seen status. */
+export function alertStatusKey(hostId: number, checkId: string): string {
+  return `${hostId}::${checkId}`
+}
+
+/**
+ * Stable, windowed incident id (same approach as regression-panel /
+ * mv-staleness-badge) so repeated escalations within a window dedup downstream.
+ */
+export function healthIncidentId(
+  hostId: number,
+  checkId: string,
+  severity: HealthAlertStatus
+): string {
+  return `hc-${hostId}-${checkId}-${severity}-${Math.floor(Date.now() / INCIDENT_WINDOW_MS)}`
+}
+
+export function loadAlertStatuses(): AlertStatusMap {
+  if (typeof window === 'undefined') return {}
+  try {
+    const raw = localStorage.getItem(ALERT_STATUS_STORAGE_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object') return {}
+    const sanitized: AlertStatusMap = {}
+    for (const [key, value] of Object.entries(
+      parsed as Record<string, unknown>
+    )) {
+      if (value === 'ok' || value === 'warning' || value === 'critical') {
+        sanitized[key] = value
+      }
+    }
+    return sanitized
+  } catch {
+    return {}
+  }
+}
+
+export function saveAlertStatuses(map: AlertStatusMap): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(ALERT_STATUS_STORAGE_KEY, JSON.stringify(map))
+  } catch {
+    // Quota or serialization failure — escalation dedup is best-effort, ignore.
+  }
+}
 
 export function emitInAppAlert(alert: HealthAlertEvent): void {
   if (typeof window === 'undefined') return
@@ -32,12 +104,17 @@ export function subscribeInAppAlerts(
   return () => window.removeEventListener(HEALTH_ALERT_EVENT, listener)
 }
 
+/** Notification/webhook label: severity for alerts, "RESOLVED" for recoveries. */
+function alertPrefix(alert: HealthAlertEvent): string {
+  return alert.kind === 'recovery' ? 'RESOLVED' : alert.severity.toUpperCase()
+}
+
 export function fireBrowserNotification(alert: HealthAlertEvent): void {
   if (typeof window === 'undefined') return
   if (!('Notification' in window)) return
   if (Notification.permission !== 'granted') return
   try {
-    new Notification(`[${alert.severity.toUpperCase()}] ${alert.title}`, {
+    new Notification(`[${alertPrefix(alert)}] ${alert.title}`, {
       body: alert.label,
       tag: `health:${alert.checkId}:${alert.severity}`,
     })
@@ -59,7 +136,7 @@ export async function fireWebhook(
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), 10_000)
   try {
-    const text = `[${alert.severity.toUpperCase()}] ${alert.title} — ${alert.label} (host ${alert.hostId})`
+    const text = `[${alertPrefix(alert)}] ${alert.title} — ${alert.label} (host ${alert.hostId})`
     const res = await fetch('/api/v1/health/webhook', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -79,26 +156,57 @@ export async function dispatchAlert(alert: HealthAlertEvent): Promise<void> {
     if (settings.minSeverity === 'critical' && alert.severity !== 'critical') {
       return
     }
-    const withIncident: HealthAlertEvent = {
+    const event: HealthAlertEvent = {
       ...alert,
+      kind: alert.kind ?? 'alert',
       incidentId: alert.incidentId ?? String(Date.now()),
     }
-    emitInAppAlert(withIncident)
+    emitInAppAlert(event)
     if (settings.browserNotificationsEnabled) {
-      fireBrowserNotification(withIncident)
+      fireBrowserNotification(event)
     }
     if (settings.webhookEnabled && settings.webhookUrl) {
-      await fireWebhook(withIncident)
+      await fireWebhook(event)
     }
   } catch (err) {
     console.error('[health] dispatchAlert failed', err)
   }
 }
 
+/**
+ * De-escalation: emit a recovery event when a check transitions back to `ok`.
+ * `severity` carries the severity that just cleared, so downstream consumers can
+ * match and clear the corresponding active alert. Honours the same `minSeverity`
+ * gate as {@link dispatchAlert} so a warning recovery stays silent when only
+ * critical alerts are enabled.
+ */
+export async function dispatchRecovery(alert: HealthAlertEvent): Promise<void> {
+  try {
+    const settings = loadAlertSettings()
+    if (settings.minSeverity === 'critical' && alert.severity !== 'critical') {
+      return
+    }
+    const event: HealthAlertEvent = {
+      ...alert,
+      kind: 'recovery',
+      incidentId: alert.incidentId ?? String(Date.now()),
+    }
+    emitInAppAlert(event)
+    if (settings.browserNotificationsEnabled) {
+      fireBrowserNotification(event)
+    }
+    if (settings.webhookEnabled && settings.webhookUrl) {
+      await fireWebhook(event)
+    }
+  } catch (err) {
+    console.error('[health] dispatchRecovery failed', err)
+  }
+}
+
 /** Severity ordering: ok < warning < critical. Returns true if `next` is more severe than `prev`. */
 export function isEscalation(
-  prev: 'ok' | 'warning' | 'critical' | null,
-  next: 'ok' | 'warning' | 'critical'
+  prev: HealthAlertStatus | null,
+  next: HealthAlertStatus
 ): boolean {
   const order = { ok: 0, warning: 1, critical: 2 } as const
   if (prev === null) {


### PR DESCRIPTION
Closes #2080

## Summary (Slice A5 — client-side alert dedup + recovery)

Client-side health alerts previously tracked last-seen status in a per-instance
`lastStatusRef` that reset on every mount. Because `isEscalation(null, …)` treats
a missing prior status as "alert if currently unhealthy", navigating away and
back to `/health` re-ran the escalation effect from scratch and **re-fired
`fireWebhook`** (and the in-app/browser notifications) for a still-unhealthy
check. The code comment even claimed remount does not re-fire, which was wrong.

### Changes
- **Persist last status per `host::checkId` in localStorage** (`health-alert-status`),
  reusing the existing storage-helper pattern (`thresholds-storage` /
  `history-storage`). Escalation state now survives component remount /
  navigation, so returning to `/health` no longer re-fires an unchanged alert.
  Replaces the per-instance `lastStatusRef` reset behaviour.
- **Recovery / de-escalation dispatch:** new `dispatchRecovery` emits a recovery
  event when a check transitions back to `ok`. `HealthAlertEvent` gains an
  **optional** `kind: 'alert' | 'recovery'` (defaults to `'alert'`), so existing
  consumers that ignore it keep working unchanged. Browser/webhook text shows
  `[RESOLVED]` for recoveries. Recovery honours the same `minSeverity` gate as
  alerts.
- **Stable windowed `incidentId`** via new `healthIncidentId(hostId, checkId,
  severity)` (`hc-<host>-<check>-<sev>-<floor(now/60s)>`), same approach as
  `regression-panel` / `mv-staleness-badge`, so downstream dedup works.
- **Fixed the misleading comment** in `health-grid.tsx` to accurately describe
  the new persisted, remount-safe behaviour.
- In-app notification behaviour is preserved (still emitted via
  `emitInAppAlert`).

### Files
- `apps/dashboard/src/lib/health/alert-dispatcher.ts`
- `apps/dashboard/src/components/health/health-grid.tsx`

### Verify
- `cd apps/dashboard && bun run type-check` → **0 errors** (after generating the
  gitignored `routeTree.gen.ts`; without it the fresh worktree shows unrelated
  route-codegen errors).
- `cd apps/dashboard && bun test src/lib/health` → **107 pass / 0 fail**.
- `bunx biome check` on both files → clean.
- Full `bun run test` shows 97 pre-existing failures (`ReferenceError: URL is not
  defined` in unrelated API-route / AI-agent-tool tests); identical count on the
  base commit, so this change introduces **zero** new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb)_