### PR TITLE
feat(landing): inline SVG topology and dependency-graph visuals

### DIFF
--- a/apps/landing/src/components/DataExplorer.astro
+++ b/apps/landing/src/components/DataExplorer.astro
@@ -9,7 +9,105 @@
         <div class="de-card reveal">
           <div class="feat-shot">
             <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
-            <img src="/landing-assets/data-explorer-graph.png" alt="chmonitor data explorer dependency graph" loading="lazy" decoding="async" />
+            <div class="dep-wrap">
+              <svg class="dep-svg" viewBox="0 0 760 470" role="img" aria-hidden="true" focusable="false" preserveAspectRatio="xMidYMid meet">
+                <defs>
+                  <pattern id="depDots" width="22" height="22" patternUnits="userSpaceOnUse">
+                    <circle cx="1.5" cy="1.5" r="1.4" fill="var(--fg)" opacity="0.05" />
+                  </pattern>
+                  <marker id="dep-blue" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="var(--blue)" /></marker>
+                  <marker id="dep-green" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="var(--emerald)" /></marker>
+                  <marker id="dep-orange" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="var(--orange)" /></marker>
+                  <marker id="dep-violet" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="var(--violet)" /></marker>
+                  <marker id="dep-gray" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="var(--muted-fg)" /></marker>
+                </defs>
+                <rect x="0" y="0" width="760" height="470" fill="url(#depDots)" />
+
+                <!-- edges -->
+                <g fill="none" stroke-width="2">
+                  <path d="M225 98 C225 140 145 140 145 178" stroke="var(--blue)" marker-end="url(#dep-blue)" />
+                  <path d="M225 98 C225 140 325 140 325 178" stroke="var(--blue)" marker-end="url(#dep-blue)" />
+                  <path d="M545 98 L545 168" stroke="var(--blue)" marker-end="url(#dep-blue)" />
+                  <path d="M545 218 L545 298" stroke="var(--emerald)" stroke-dasharray="6 5" marker-end="url(#dep-green)" />
+                  <path d="M325 298 L325 228" stroke="var(--orange)" marker-end="url(#dep-orange)" />
+                  <path d="M220 204 C250 244 250 282 250 318" stroke="var(--violet)" marker-end="url(#dep-violet)" />
+                  <path d="M210 324 C172 300 145 270 145 228" stroke="var(--muted-fg)" stroke-dasharray="4 5" opacity="0.7" marker-end="url(#dep-gray)" />
+                </g>
+
+                <!-- animated flow accents -->
+                <g fill="none" stroke-width="2.4" stroke-linecap="round">
+                  <path class="dep-comet" d="M225 98 C225 140 145 140 145 178" stroke="var(--blue)" />
+                  <path class="dep-comet" d="M225 98 C225 140 325 140 325 178" stroke="var(--blue)" style="animation-delay:.7s" />
+                  <path class="dep-comet" d="M545 98 L545 168" stroke="var(--blue)" style="animation-delay:1.3s" />
+                </g>
+
+                <!-- nodes -->
+                <g class="dep-node" transform="translate(150 52)">
+                  <rect width="150" height="46" rx="10" fill="var(--card)" stroke="var(--border)" stroke-width="1.5" />
+                  <g transform="translate(14 15)" stroke="var(--muted-fg)" stroke-width="1.4" fill="none"><rect width="16" height="16" rx="2.5" /><path d="M0 6 H16 M6 0 V16" opacity="0.75" /></g>
+                  <text x="40" y="21" font-size="12.5" font-weight="600" fill="var(--fg)">events_raw</text>
+                  <text x="40" y="35" font-size="9.5" fill="var(--muted-fg)">MergeTree</text>
+                </g>
+
+                <g class="dep-node" transform="translate(470 52)">
+                  <rect width="160" height="46" rx="10" fill="var(--card)" stroke="var(--border)" stroke-width="1.5" />
+                  <g transform="translate(14 15)" stroke="var(--muted-fg)" stroke-width="1.4" fill="none"><rect width="16" height="16" rx="2.5" /><path d="M0 6 H16 M6 0 V16" opacity="0.75" /></g>
+                  <text x="40" y="21" font-size="12.5" font-weight="600" fill="var(--fg)">cf_logs_raw</text>
+                  <text x="40" y="35" font-size="9.5" fill="var(--muted-fg)">ReplacingMergeTree</text>
+                </g>
+
+                <g class="dep-node" transform="translate(70 178)">
+                  <rect width="150" height="46" rx="10" fill="var(--card)" stroke="var(--border)" stroke-width="1.5" />
+                  <g transform="translate(14 15)" stroke="var(--muted-fg)" stroke-width="1.4" fill="none"><rect width="16" height="16" rx="2.5" /><path d="M0 6 H16 M6 0 V16" opacity="0.75" /></g>
+                  <text x="40" y="21" font-size="12.5" font-weight="600" fill="var(--fg)">events_hourly</text>
+                  <text x="40" y="35" font-size="9.5" fill="var(--blue)">MV / View</text>
+                </g>
+
+                <g class="dep-node" transform="translate(250 178)">
+                  <rect width="150" height="46" rx="10" fill="var(--card)" stroke="var(--border)" stroke-width="1.5" />
+                  <g transform="translate(14 15)" stroke="var(--muted-fg)" stroke-width="1.4" fill="none"><rect width="16" height="16" rx="2.5" /><path d="M0 6 H16 M6 0 V16" opacity="0.75" /></g>
+                  <text x="40" y="21" font-size="12.5" font-weight="600" fill="var(--fg)">events_daily</text>
+                  <text x="40" y="35" font-size="9.5" fill="var(--blue)">MV / View</text>
+                </g>
+
+                <g class="dep-node" transform="translate(470 168)">
+                  <rect width="160" height="46" rx="10" fill="var(--card)" stroke="var(--border)" stroke-width="1.5" />
+                  <g transform="translate(14 15)" stroke="var(--muted-fg)" stroke-width="1.4" fill="none"><rect width="16" height="16" rx="2.5" /><path d="M0 6 H16 M6 0 V16" opacity="0.75" /></g>
+                  <text x="40" y="21" font-size="12.5" font-weight="600" fill="var(--fg)">cf_daily</text>
+                  <text x="40" y="35" font-size="9.5" fill="var(--blue)">MV / View</text>
+                </g>
+
+                <g class="dep-node" transform="translate(470 298)">
+                  <rect width="160" height="46" rx="10" fill="var(--card)" stroke="var(--border)" stroke-width="1.5" />
+                  <g transform="translate(14 15)" stroke="var(--muted-fg)" stroke-width="1.4" fill="none"><rect width="16" height="16" rx="2.5" /><path d="M0 6 H16 M6 0 V16" opacity="0.75" /></g>
+                  <text x="40" y="21" font-size="12.5" font-weight="600" fill="var(--fg)">cf_rollup</text>
+                  <text x="40" y="35" font-size="9.5" fill="var(--emerald)">TO target</text>
+                </g>
+
+                <g class="dep-node" transform="translate(250 318)">
+                  <rect width="150" height="46" rx="10" fill="var(--card)" stroke="var(--border)" stroke-width="1.5" />
+                  <g transform="translate(14 15)" stroke="var(--orange)" stroke-width="1.4" fill="none"><rect width="16" height="16" rx="2.5" /><path d="M4 4 H12 M4 8 H12 M4 12 H9" opacity="0.85" /></g>
+                  <text x="40" y="21" font-size="12.5" font-weight="600" fill="var(--fg)">geo_dict</text>
+                  <text x="40" y="35" font-size="9.5" fill="var(--orange)">Dictionary · dictGet</text>
+                </g>
+
+                <g transform="translate(60 300)">
+                  <rect width="150" height="46" rx="10" fill="var(--card)" stroke="var(--muted-fg)" stroke-width="1.5" stroke-dasharray="5 5" opacity="0.85" />
+                  <g transform="translate(14 15)" stroke="var(--muted-fg)" stroke-width="1.4" fill="none"><rect width="16" height="16" rx="2.5" /><path d="M0 6 H16 M6 0 V16" opacity="0.6" /></g>
+                  <text x="40" y="21" font-size="12.5" font-weight="600" fill="var(--fg-soft)">s3_events</text>
+                  <text x="40" y="35" font-size="9.5" fill="var(--muted-fg)">external source</text>
+                </g>
+
+                <!-- legend -->
+                <g font-size="10" fill="var(--muted-fg)">
+                  <line x1="40" y1="446" x2="62" y2="446" stroke="var(--blue)" stroke-width="2" /><text x="68" y="450">MV / View</text>
+                  <line x1="150" y1="446" x2="172" y2="446" stroke="var(--orange)" stroke-width="2" /><text x="178" y="450">dictGet</text>
+                  <line x1="248" y1="446" x2="270" y2="446" stroke="var(--violet)" stroke-width="2" /><text x="276" y="450">joinGet</text>
+                  <line x1="344" y1="446" x2="366" y2="446" stroke="var(--emerald)" stroke-width="2" stroke-dasharray="5 4" /><text x="372" y="450">TO</text>
+                  <line x1="418" y1="446" x2="440" y2="446" stroke="var(--muted-fg)" stroke-width="1.5" stroke-dasharray="4 4" /><text x="446" y="450">external</text>
+                </g>
+              </svg>
+            </div>
           </div>
           <div class="de-cap">
             <span class="n">01</span>
@@ -19,7 +117,7 @@
         <div class="de-card reveal">
           <div class="feat-shot">
             <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
-            <img src="/landing-assets/data-explorer-query.png" alt="chmonitor data explorer SQL query editor" loading="lazy" decoding="async" />
+            <img src="/landing-assets/data-explorer-query.png" alt="chmonitor data explorer SQL query editor" width="3572" height="1972" loading="lazy" decoding="async" />
           </div>
           <div class="de-cap">
             <span class="n">02</span>
@@ -29,3 +127,13 @@
       </div>
     </div>
   </section>
+
+  <style>
+    .dep-wrap{background:var(--bg-soft)}
+    .dep-svg{display:block;width:100%;height:auto}
+    .dep-comet{stroke-dasharray:14 150;stroke-dashoffset:164;animation:dep-comet 2.6s linear infinite}
+    @keyframes dep-comet{to{stroke-dashoffset:0}}
+    @media (prefers-reduced-motion:reduce){
+      .dep-comet{display:none;animation:none}
+    }
+  </style>

--- a/apps/landing/src/components/Features.astro
+++ b/apps/landing/src/components/Features.astro
@@ -22,8 +22,8 @@
           <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
           <div class="carousel" data-autoplay="4600">
             <div class="ctrack">
-              <div class="cslide"><img src="/landing-assets/agent-chat.png" alt="chmonitor AI agent chat" loading="lazy" decoding="async" /></div>
-              <div class="cslide"><img src="/landing-assets/mcp-server.png" alt="chmonitor MCP server setup" loading="lazy" decoding="async" /></div>
+              <div class="cslide"><img src="/landing-assets/agent-chat.png" alt="chmonitor AI agent chat" width="3250" height="1938" loading="lazy" decoding="async" /></div>
+              <div class="cslide"><img src="/landing-assets/mcp-server.png" alt="chmonitor MCP server setup" width="2946" height="1956" loading="lazy" decoding="async" /></div>
             </div>
             <div class="cdots"></div>
           </div>
@@ -44,7 +44,7 @@
         </div>
         <div class="feat-shot reveal">
           <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
-          <img src="/landing-assets/queries-running.png" alt="chmonitor running queries with live charts and table" loading="lazy" decoding="async" />
+          <img src="/landing-assets/queries-running.png" alt="chmonitor running queries with live charts and table" width="3581" height="1996" loading="lazy" decoding="async" />
         </div>
       </div>
 
@@ -62,8 +62,113 @@
         </div>
         <div class="feat-shot reveal">
           <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
-          <img src="/landing-assets/topology.png" alt="chmonitor cluster topology map" loading="lazy" decoding="async" />
+          <div class="topo-wrap">
+            <svg class="topo-svg" viewBox="0 0 820 480" role="img" aria-hidden="true" focusable="false" preserveAspectRatio="xMidYMid meet">
+              <defs>
+                <pattern id="topoDots" width="22" height="22" patternUnits="userSpaceOnUse">
+                  <circle cx="1.5" cy="1.5" r="1.4" fill="var(--fg)" opacity="0.05" />
+                </pattern>
+              </defs>
+              <rect x="0" y="0" width="820" height="480" fill="url(#topoDots)" />
+
+              <!-- Keeper quorum hull -->
+              <rect x="288" y="44" width="244" height="188" rx="20" fill="var(--emerald)" opacity="0.05" />
+              <rect x="288" y="44" width="244" height="188" rx="20" fill="none" stroke="var(--emerald)" stroke-width="1.5" stroke-dasharray="5 6" opacity="0.5" />
+              <text x="410" y="36" text-anchor="middle" font-size="12" font-weight="600" fill="var(--emerald)" letter-spacing="0.02em">Keeper quorum · Raft</text>
+
+              <!-- coordination links -->
+              <g class="topo-coord" fill="none" stroke="var(--muted-fg)" stroke-width="1.5" stroke-dasharray="4 5" opacity="0.55">
+                <path d="M404 116 L344 152" />
+                <path d="M416 116 L476 152" />
+                <path d="M364 178 L456 178" />
+                <path d="M338 206 L338 316" />
+              </g>
+
+              <!-- leader keeper -->
+              <polygon points="397,64 423,64 436,92 423,120 397,120 384,92" fill="var(--card)" stroke="var(--orange)" stroke-width="2" />
+              <polygon points="410,85 412.2,91 418.6,91.2 413.5,95.1 415.3,101.3 410,97.7 404.7,101.3 406.5,95.1 401.4,91.2 407.8,91" fill="var(--orange)" />
+              <circle class="topo-dot" cx="428" cy="70" r="4" fill="var(--emerald)" />
+              <text x="410" y="136" text-anchor="middle" font-size="11" font-weight="600" fill="var(--fg-soft)">keeper-0</text>
+              <text x="410" y="149" text-anchor="middle" font-size="9.5" fill="var(--muted-fg)">leader · 0.3ms</text>
+
+              <!-- follower keepers -->
+              <polygon points="325,150 351,150 364,178 351,206 325,206 312,178" fill="var(--card)" stroke="var(--border-hover)" stroke-width="1.6" />
+              <circle cx="338" cy="178" r="5.5" fill="var(--muted-fg)" opacity="0.45" />
+              <circle class="topo-dot" cx="356" cy="156" r="3.6" fill="var(--emerald)" />
+              <text x="338" y="222" text-anchor="middle" font-size="10" fill="var(--muted-fg)">keeper-1 · follower</text>
+
+              <polygon points="469,150 495,150 508,178 495,206 469,206 456,178" fill="var(--card)" stroke="var(--border-hover)" stroke-width="1.6" />
+              <circle cx="482" cy="178" r="5.5" fill="var(--muted-fg)" opacity="0.45" />
+              <circle class="topo-dot" cx="500" cy="156" r="3.6" fill="var(--emerald)" />
+              <text x="482" y="222" text-anchor="middle" font-size="10" fill="var(--muted-fg)">keeper-2 · follower</text>
+
+              <!-- ClickHouse cluster hulls (overlapping virtual clusters) -->
+              <rect x="222" y="284" width="372" height="156" rx="22" fill="var(--orange)" opacity="0.05" />
+              <rect x="222" y="284" width="372" height="156" rx="22" fill="none" stroke="var(--orange)" stroke-width="1.4" stroke-dasharray="5 6" opacity="0.4" />
+              <rect x="300" y="300" width="300" height="140" rx="20" fill="var(--violet)" opacity="0.05" />
+              <rect x="300" y="300" width="300" height="140" rx="20" fill="none" stroke="var(--violet)" stroke-width="1.4" stroke-dasharray="5 6" opacity="0.4" />
+
+              <!-- replication link -->
+              <path d="M390 362 L470 374" fill="none" stroke="var(--blue)" stroke-width="2" opacity="0.5" />
+              <path class="topo-comet" d="M390 362 L470 374" fill="none" stroke="var(--blue)" stroke-width="2.4" stroke-linecap="round" />
+              <text x="430" y="352" text-anchor="middle" font-size="9.5" fill="var(--blue)">replication</text>
+
+              <!-- ClickHouse node 1 (local / leader) -->
+              <rect x="292" y="318" width="98" height="88" rx="13" fill="var(--card)" stroke="var(--emerald)" stroke-width="2" />
+              <g>
+                <rect x="312" y="376" width="6" height="14" rx="1.5" fill="var(--muted-fg)" opacity="0.6" />
+                <rect x="323" y="368" width="6" height="22" rx="1.5" fill="var(--muted-fg)" opacity="0.6" />
+                <rect x="334" y="380" width="6" height="10" rx="1.5" fill="var(--muted-fg)" opacity="0.6" />
+                <rect x="345" y="362" width="6" height="28" rx="1.5" fill="#f43f5e" />
+                <rect x="356" y="372" width="6" height="18" rx="1.5" fill="var(--muted-fg)" opacity="0.6" />
+              </g>
+              <rect x="316" y="332" width="34" height="14" rx="4" fill="var(--muted)" />
+              <text x="333" y="342" text-anchor="middle" font-size="8" font-weight="600" fill="var(--fg-soft)" letter-spacing="0.04em">LOCAL</text>
+              <circle class="topo-dot" cx="382" cy="326" r="4.5" fill="var(--emerald)" />
+              <text x="341" y="422" text-anchor="middle" font-size="10.5" font-weight="600" fill="var(--fg-soft)">clickhouse-0</text>
+              <text x="341" y="434" text-anchor="middle" font-size="9" fill="var(--muted-fg)">cpu 99% · mem 64%</text>
+
+              <!-- ClickHouse node 2 (remote) -->
+              <rect x="470" y="330" width="98" height="88" rx="13" fill="var(--card)" stroke="var(--emerald)" stroke-width="2" />
+              <g>
+                <rect x="490" y="388" width="6" height="14" rx="1.5" fill="var(--muted-fg)" opacity="0.6" />
+                <rect x="501" y="380" width="6" height="22" rx="1.5" fill="var(--muted-fg)" opacity="0.6" />
+                <rect x="512" y="392" width="6" height="10" rx="1.5" fill="var(--muted-fg)" opacity="0.6" />
+                <rect x="523" y="384" width="6" height="18" rx="1.5" fill="var(--muted-fg)" opacity="0.6" />
+                <rect x="534" y="376" width="6" height="26" rx="1.5" fill="var(--emerald)" opacity="0.7" />
+              </g>
+              <circle class="topo-dot" cx="560" cy="338" r="4.5" fill="var(--emerald)" />
+              <text x="519" y="434" text-anchor="middle" font-size="10.5" font-weight="600" fill="var(--fg-soft)">clickhouse-1</text>
+
+              <!-- legend -->
+              <g font-size="10" fill="var(--muted-fg)">
+                <circle cx="250" cy="464" r="4" fill="var(--emerald)" />
+                <text x="260" y="468">healthy</text>
+                <circle cx="322" cy="464" r="4" fill="var(--amber)" />
+                <text x="332" y="468">warn</text>
+                <line x1="392" y1="464" x2="416" y2="464" stroke="var(--blue)" stroke-width="2" />
+                <text x="422" y="468">replication</text>
+                <line x1="512" y1="464" x2="536" y2="464" stroke="var(--muted-fg)" stroke-width="1.5" stroke-dasharray="4 4" />
+                <text x="542" y="468">coordination</text>
+              </g>
+            </svg>
+          </div>
         </div>
       </div>
     </div>
   </section>
+
+  <style>
+    .topo-wrap{background:var(--bg-soft)}
+    .topo-svg{display:block;width:100%;height:auto}
+    .topo-coord{animation:topo-flow 1.7s linear infinite}
+    @keyframes topo-flow{to{stroke-dashoffset:-18}}
+    .topo-dot{transform-box:fill-box;transform-origin:center;animation:topo-pulse 2.6s ease-in-out infinite}
+    @keyframes topo-pulse{0%,100%{opacity:.45}50%{opacity:1}}
+    .topo-comet{stroke-dasharray:12 96;stroke-dashoffset:108;animation:topo-comet 2.2s linear infinite}
+    @keyframes topo-comet{to{stroke-dashoffset:0}}
+    @media (prefers-reduced-motion:reduce){
+      .topo-coord,.topo-dot,.topo-comet{animation:none}
+      .topo-comet{display:none}
+    }
+  </style>


### PR DESCRIPTION
Closes #2061

## Summary

Replaces two product screenshots on the landing page with premium, hand-crafted, theme-aware inline SVGs that echo the brand's metric-bar identity, and removes layout shift (CLS) from the remaining screenshots. Touches only the two files in scope.

### `apps/landing/src/components/Features.astro`
- Replaced the cluster **topology** screenshot (`topology.png`) with an inline SVG topology:
  - Keeper quorum (Raft) with an orange leader hex (star) + two follower hexes, coordination (dashed) links.
  - Overlapping virtual-cluster hulls (all-clusters / cluster) around two ClickHouse nodes.
  - ClickHouse nodes render mini metric bars (echoing the brand logo mark), a hot red CPU bar, `LOCAL` tag, and a solid replication link.
  - Status legend (healthy / warn / replication / coordination) and a subtle dot-grid background.
  - Lightly animated: coordination dash-flow, status-dot pulse, replication "comet" — all disabled under `prefers-reduced-motion`.
- Added intrinsic `width`/`height` to `agent-chat`, `mcp-server`, and `queries-running` screenshots to eliminate CLS.

### `apps/landing/src/components/DataExplorer.astro`
- Replaced the **dependency graph** screenshot (`data-explorer-graph.png`) with an inline SVG graph of tables / views / a dictionary / an external source, with directed, color-coded edges (MV/View, dictGet, joinGet, TO, external) and a dependency-type legend.
  - **Static hand-authored SVG chosen over d3** deliberately: the landing page is otherwise zero-JS static HTML; a d3 client island would add a runtime dependency and bundle weight for a purely decorative illustration. The static SVG stays theme-aware and weightless.
  - Animated flow accents on the primary edges, disabled under `prefers-reduced-motion`.
- Added intrinsic `width`/`height` to the `data-explorer-query` screenshot to eliminate CLS.

Both decorative SVGs are marked `aria-hidden`, are fully theme-aware via the existing CSS custom properties (light + dark), and add no new assets.

## Verify
- `cd apps/landing && bun run build` — passes (5 pages built).
- Confirmed built HTML drops the `/landing-assets/topology.png` and `/landing-assets/data-explorer-graph.png` refs and inlines the SVGs; CLS `width`/`height` attrs present; `prefers-reduced-motion` rules present.
- Rasterized both SVGs against the light and dark token sets to visually confirm layout, colors, and theme adaptation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb

---
_Generated by [Claude Code](https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb)_