### PR TITLE
feat(health): registry-driven sweep with dedup, cooldown, recovery

### DIFF
--- a/apps/dashboard/src/lib/health/alert-state-store.test.ts
+++ b/apps/dashboard/src/lib/health/alert-state-store.test.ts
@@ -1,0 +1,187 @@
+/**
+ * State-transition tests for the alert de-dup store. No mocks — exercises the
+ * pure decision function and the read/decide/persist wrapper against the memory
+ * backend, covering: new, escalated, cooldown-suppressed, reminder (post
+ * cooldown), and recovery.
+ */
+
+import type { AlertStateRecord } from './alert-state-store'
+
+import {
+  alertStateKey,
+  DEFAULT_ALERT_COOLDOWN_MS,
+  decideNotification,
+  evaluateAlert,
+  MemoryAlertStateStore,
+} from './alert-state-store'
+import { describe, expect, test } from 'bun:test'
+
+const rec = (over: Partial<AlertStateRecord> = {}): AlertStateRecord => ({
+  severity: 'warning',
+  updatedAt: 1_000,
+  notifiedAt: 1_000,
+  ...over,
+})
+
+describe('decideNotification', () => {
+  test('NEW: ok → warning notifies and records severity', () => {
+    const { decision, next } = decideNotification(undefined, 'warning', {
+      now: 5_000,
+    })
+    expect(decision.notify).toBe(true)
+    expect(decision.kind).toBe('new')
+    expect(decision.previousSeverity).toBe('ok')
+    expect(next).toEqual({
+      severity: 'warning',
+      updatedAt: 5_000,
+      notifiedAt: 5_000,
+    })
+  })
+
+  test('NEW: ok → critical notifies', () => {
+    const { decision } = decideNotification(undefined, 'critical')
+    expect(decision.notify).toBe(true)
+    expect(decision.kind).toBe('new')
+  })
+
+  test('ESCALATED: warning → critical notifies regardless of cooldown', () => {
+    const prev = rec({ severity: 'warning', notifiedAt: 4_900 })
+    const { decision, next } = decideNotification(prev, 'critical', {
+      now: 5_000, // 100ms later, well within any cooldown
+      cooldownMs: DEFAULT_ALERT_COOLDOWN_MS,
+    })
+    expect(decision.notify).toBe(true)
+    expect(decision.kind).toBe('escalated')
+    expect(decision.previousSeverity).toBe('warning')
+    expect(next?.severity).toBe('critical')
+    expect(next?.notifiedAt).toBe(5_000)
+  })
+
+  test('COOLDOWN-SUPPRESSED: same severity within window is suppressed', () => {
+    const prev = rec({ severity: 'critical', notifiedAt: 4_900 })
+    const { decision, next } = decideNotification(prev, 'critical', {
+      now: 5_000,
+      cooldownMs: 10_000,
+    })
+    expect(decision.notify).toBe(false)
+    expect(decision.kind).toBe('suppressed')
+    // Timestamps preserved so the cooldown keeps counting from the last notify.
+    expect(next).toEqual({
+      severity: 'critical',
+      updatedAt: 1_000,
+      notifiedAt: 4_900,
+    })
+  })
+
+  test('REMINDER: same severity past the cooldown re-notifies', () => {
+    const prev = rec({ severity: 'critical', notifiedAt: 1_000 })
+    const { decision, next } = decideNotification(prev, 'critical', {
+      now: 20_000,
+      cooldownMs: 10_000,
+    })
+    expect(decision.notify).toBe(true)
+    expect(decision.kind).toBe('reminder')
+    expect(next?.notifiedAt).toBe(20_000)
+  })
+
+  test('RECOVERY: firing → ok notifies once and clears state', () => {
+    const prev = rec({ severity: 'critical' })
+    const { decision, next } = decideNotification(prev, 'ok', { now: 9_000 })
+    expect(decision.notify).toBe(true)
+    expect(decision.kind).toBe('recovery')
+    expect(decision.previousSeverity).toBe('critical')
+    expect(next).toBeNull()
+  })
+
+  test('ok → ok is a silent no-op with no record kept', () => {
+    const { decision, next } = decideNotification(undefined, 'ok')
+    expect(decision.notify).toBe(false)
+    expect(decision.kind).toBe('suppressed')
+    expect(next).toBeNull()
+  })
+
+  test('DE-ESCALATION: critical → warning does not notify but lowers severity', () => {
+    const prev = rec({ severity: 'critical', notifiedAt: 4_000 })
+    const { decision, next } = decideNotification(prev, 'warning', {
+      now: 5_000,
+    })
+    expect(decision.notify).toBe(false)
+    expect(next?.severity).toBe('warning')
+    // Cooldown timer is not reset on a downgrade.
+    expect(next?.notifiedAt).toBe(4_000)
+  })
+})
+
+describe('evaluateAlert + MemoryAlertStateStore', () => {
+  test('full lifecycle: new → suppressed → reminder → recovery', () => {
+    const store = new MemoryAlertStateStore()
+    const base = {
+      hostId: 0,
+      ruleId: 'disk-usage',
+      cooldownMs: 10_000,
+    }
+
+    // First sighting fires.
+    expect(
+      evaluateAlert(store, { ...base, severity: 'critical', now: 1_000 }).kind
+    ).toBe('new')
+
+    // Persisting within cooldown is suppressed.
+    expect(
+      evaluateAlert(store, { ...base, severity: 'critical', now: 3_000 }).kind
+    ).toBe('suppressed')
+
+    // Past the cooldown it reminds.
+    expect(
+      evaluateAlert(store, { ...base, severity: 'critical', now: 12_000 }).kind
+    ).toBe('reminder')
+
+    // Recovery fires and clears the record.
+    const recovery = evaluateAlert(store, {
+      ...base,
+      severity: 'ok',
+      now: 13_000,
+    })
+    expect(recovery.kind).toBe('recovery')
+    expect(store.get(alertStateKey(0, 'disk-usage'))).toBeUndefined()
+  })
+
+  test('escalation fires even inside the cooldown window', () => {
+    const store = new MemoryAlertStateStore()
+    evaluateAlert(store, {
+      hostId: 1,
+      ruleId: 'replication-lag',
+      severity: 'warning',
+      now: 1_000,
+      cooldownMs: 100_000,
+    })
+    const decision = evaluateAlert(store, {
+      hostId: 1,
+      ruleId: 'replication-lag',
+      severity: 'critical',
+      now: 1_500,
+      cooldownMs: 100_000,
+    })
+    expect(decision.kind).toBe('escalated')
+    expect(decision.notify).toBe(true)
+  })
+
+  test('conditions on different hosts are isolated', () => {
+    const store = new MemoryAlertStateStore()
+    const a = evaluateAlert(store, {
+      hostId: 0,
+      ruleId: 'stuck-merges',
+      severity: 'warning',
+      now: 1,
+    })
+    const b = evaluateAlert(store, {
+      hostId: 1,
+      ruleId: 'stuck-merges',
+      severity: 'warning',
+      now: 1,
+    })
+    // Both are "new" because each host tracks its own state.
+    expect(a.kind).toBe('new')
+    expect(b.kind).toBe('new')
+  })
+})

--- a/apps/dashboard/src/lib/health/alert-state-store.ts
+++ b/apps/dashboard/src/lib/health/alert-state-store.ts
@@ -1,0 +1,254 @@
+/**
+ * Alert de-duplication state store.
+ *
+ * The autonomous health sweep (`server-sweep.ts`) runs every few minutes over
+ * every host. Without memory, a persistent unhealthy condition would webhook on
+ * *every* run — pure noise. This module remembers the last severity we alerted
+ * on per condition so the sweep only notifies when something is genuinely new:
+ *
+ *   - NEW        — a condition transitions ok → warning/critical
+ *   - ESCALATED  — a condition worsens warning → critical
+ *   - REMINDER   — a condition persists at the same severity past the cooldown
+ *   - RECOVERY   — a previously-firing condition returns to ok
+ *
+ * Anything else (same severity within the cooldown window, or ok → ok) is
+ * suppressed.
+ *
+ * Storage: an in-memory module singleton, mirroring the "memory fallback"
+ * pattern the insights subsystem uses (`insights/store/memory-store.ts`) and the
+ * table-existence cache. Alert dedup state is intentionally ephemeral — after a
+ * cold start the worst case is a single duplicate alert per active condition,
+ * which is acceptable. The pure {@link decideNotification} transition function
+ * is decoupled from the backend so it is fully unit-testable.
+ *
+ * The logical condition key is `host:ruleId`; the last-fired severity lives in
+ * the stored record (so the identity a record represents is
+ * `host:ruleId:severity`, per the alerting spec). Keeping severity in the record
+ * rather than the key is what lets us detect escalation and recovery, which both
+ * need to compare the new severity against the previously-fired one.
+ */
+
+import type { AlertRuleSeverity } from '@/lib/alerting/rule-registry'
+
+/** Default re-notify cooldown for a persistent condition: 60 minutes. */
+export const DEFAULT_ALERT_COOLDOWN_MS = 60 * 60 * 1000
+
+const SEVERITY_ORDER: Record<AlertRuleSeverity, number> = {
+  ok: 0,
+  warning: 1,
+  critical: 2,
+}
+
+/** Persisted per-condition state. */
+export interface AlertStateRecord {
+  /** Last severity we recorded/notified for this condition. */
+  severity: AlertRuleSeverity
+  /** Epoch ms when the severity last changed. */
+  updatedAt: number
+  /** Epoch ms of the last notification actually dispatched. */
+  notifiedAt: number
+}
+
+/** What kind of transition the current evaluation represents. */
+export type AlertDecisionKind =
+  | 'new'
+  | 'escalated'
+  | 'reminder'
+  | 'recovery'
+  | 'suppressed'
+
+export interface AlertDecision {
+  /** Whether the sweep should dispatch a notification. */
+  notify: boolean
+  kind: AlertDecisionKind
+  /** Current severity being evaluated. */
+  severity: AlertRuleSeverity
+  /** Severity previously on record (defaults to 'ok' when unseen). */
+  previousSeverity: AlertRuleSeverity
+}
+
+/** Minimal persistence contract; swap in a DB-backed store later if needed. */
+export interface AlertStateStore {
+  get(key: string): AlertStateRecord | undefined
+  set(key: string, record: AlertStateRecord): void
+  delete(key: string): void
+  clear(): void
+}
+
+/** Stable per-condition key. Severity is tracked in the record, not the key. */
+export function alertStateKey(hostId: number, ruleId: string): string {
+  return `${hostId}:${ruleId}`
+}
+
+/**
+ * In-memory alert-state backend. Ephemeral by design; lost on worker restart.
+ */
+export class MemoryAlertStateStore implements AlertStateStore {
+  private readonly records = new Map<string, AlertStateRecord>()
+
+  get(key: string): AlertStateRecord | undefined {
+    return this.records.get(key)
+  }
+
+  set(key: string, record: AlertStateRecord): void {
+    this.records.set(key, record)
+  }
+
+  delete(key: string): void {
+    this.records.delete(key)
+  }
+
+  clear(): void {
+    this.records.clear()
+  }
+}
+
+/** Process-wide singleton used by the sweep. */
+export const alertStateStore: AlertStateStore = new MemoryAlertStateStore()
+
+export interface DecideOptions {
+  /** Re-notify window for a persistent same-severity condition, in ms. */
+  cooldownMs?: number
+  /** Injectable clock for tests. Defaults to `Date.now()`. */
+  now?: number
+}
+
+/**
+ * Pure state transition: given the previous record and the current severity,
+ * decide whether to notify and compute the next record to persist.
+ *
+ * `next` is the record to store, or `null` when the condition is ok and no
+ * record should be kept (recovery clears it, ok→ok keeps nothing).
+ */
+export function decideNotification(
+  prev: AlertStateRecord | undefined,
+  current: AlertRuleSeverity,
+  opts: DecideOptions = {}
+): { decision: AlertDecision; next: AlertStateRecord | null } {
+  const now = opts.now ?? Date.now()
+  const cooldownMs = opts.cooldownMs ?? DEFAULT_ALERT_COOLDOWN_MS
+  const previousSeverity: AlertRuleSeverity = prev?.severity ?? 'ok'
+
+  // Condition is healthy now.
+  if (current === 'ok') {
+    if (previousSeverity !== 'ok') {
+      // A previously-firing condition recovered → emit RECOVERY, clear state.
+      return {
+        decision: {
+          notify: true,
+          kind: 'recovery',
+          severity: 'ok',
+          previousSeverity,
+        },
+        next: null,
+      }
+    }
+    // ok → ok: nothing to remember, nothing to send.
+    return {
+      decision: {
+        notify: false,
+        kind: 'suppressed',
+        severity: 'ok',
+        previousSeverity,
+      },
+      next: null,
+    }
+  }
+
+  // Condition is firing (warning | critical).
+  const rankCurrent = SEVERITY_ORDER[current]
+  const rankPrev = SEVERITY_ORDER[previousSeverity]
+
+  // NEW (ok → firing) or ESCALATED (warning → critical): always notify,
+  // regardless of cooldown — a worsening condition is important.
+  if (rankCurrent > rankPrev) {
+    return {
+      decision: {
+        notify: true,
+        kind: previousSeverity === 'ok' ? 'new' : 'escalated',
+        severity: current,
+        previousSeverity,
+      },
+      next: { severity: current, updatedAt: now, notifiedAt: now },
+    }
+  }
+
+  // Same severity persisting: re-notify only once the cooldown has elapsed.
+  if (rankCurrent === rankPrev) {
+    const elapsed = now - (prev?.notifiedAt ?? 0)
+    if (cooldownMs > 0 && elapsed >= cooldownMs) {
+      return {
+        decision: {
+          notify: true,
+          kind: 'reminder',
+          severity: current,
+          previousSeverity,
+        },
+        next: {
+          severity: current,
+          updatedAt: prev?.updatedAt ?? now,
+          notifiedAt: now,
+        },
+      }
+    }
+    // Still within cooldown → suppress, but keep the existing timestamps.
+    return {
+      decision: {
+        notify: false,
+        kind: 'suppressed',
+        severity: current,
+        previousSeverity,
+      },
+      next: {
+        severity: current,
+        updatedAt: prev?.updatedAt ?? now,
+        notifiedAt: prev?.notifiedAt ?? now,
+      },
+    }
+  }
+
+  // De-escalation but still firing (critical → warning): not a new alert.
+  // Lower the recorded severity so a later re-escalation is detected, but keep
+  // the last notify timestamp so we don't reset the cooldown.
+  return {
+    decision: {
+      notify: false,
+      kind: 'suppressed',
+      severity: current,
+      previousSeverity,
+    },
+    next: {
+      severity: current,
+      updatedAt: now,
+      notifiedAt: prev?.notifiedAt ?? now,
+    },
+  }
+}
+
+/**
+ * Read → decide → persist against a store. Returns the decision for the caller
+ * (the sweep) to act on. Keeps all mutation of the store in one place.
+ */
+export function evaluateAlert(
+  store: AlertStateStore,
+  params: {
+    hostId: number
+    ruleId: string
+    severity: AlertRuleSeverity
+    cooldownMs?: number
+    now?: number
+  }
+): AlertDecision {
+  const key = alertStateKey(params.hostId, params.ruleId)
+  const prev = store.get(key)
+  const { decision, next } = decideNotification(prev, params.severity, {
+    cooldownMs: params.cooldownMs,
+    now: params.now,
+  })
+  if (next === null) {
+    store.delete(key)
+  } else {
+    store.set(key, next)
+  }
+  return decision
+}

--- a/apps/dashboard/src/lib/health/server-alert-config.ts
+++ b/apps/dashboard/src/lib/health/server-alert-config.ts
@@ -1,3 +1,4 @@
+import type { AlertRuleThresholds } from '@/lib/alerting/rule-registry'
 import type { AlertSettings } from './alert-settings-storage'
 
 import { DEFAULT_ALERT_SETTINGS } from './alert-settings-storage'
@@ -13,6 +14,19 @@ import { DEFAULT_ALERT_SETTINGS } from './alert-settings-storage'
  *   - HEALTH_ALERT_MIN_SEVERITY → minSeverity    (default 'warning')
  *
  * Browser notifications never apply server-side, so it is always disabled.
+ *
+ * ## minSeverity default: intentionally 'warning' (differs from the client)
+ *
+ * The client default ({@link DEFAULT_ALERT_SETTINGS}) is `'critical'` — a
+ * conservative choice so a fresh browser session is not spammed with in-app
+ * toasts / OS notifications for every warning. The server sweep default is
+ * `'warning'` on purpose: the cron path is an operator-facing *outbound*
+ * channel (Slack/Discord webhook) where catching a warning early — before it
+ * escalates to critical — is the whole point, and the dedup state store (see
+ * `alert-state-store.ts`) already prevents a persistent warning from being
+ * re-sent every run. Operators who only want criticals set
+ * `HEALTH_ALERT_MIN_SEVERITY=critical`. This difference is deliberate and
+ * documented rather than "aligned", per issue #2077.
  */
 export function getServerAlertConfig(): AlertSettings {
   const webhookUrl = process.env.HEALTH_ALERT_WEBHOOK_URL?.trim() || ''
@@ -30,4 +44,84 @@ export function getServerAlertConfig(): AlertSettings {
     browserNotificationsEnabled: false,
     minSeverity,
   }
+}
+
+/** Per-rule threshold override (either bound may be omitted). */
+export type ThresholdOverride = Partial<AlertRuleThresholds>
+
+/**
+ * Convert a rule id to its env-var prefix: uppercased, dashes → underscores.
+ * e.g. `disk-usage` → `HEALTH_THRESHOLD_DISK_USAGE`.
+ */
+function thresholdEnvPrefix(ruleId: string): string {
+  return `HEALTH_THRESHOLD_${ruleId.toUpperCase().replace(/-/g, '_')}`
+}
+
+function parseThresholdEnv(value: string | undefined): number | null {
+  if (value === undefined) return null
+  const trimmed = value.trim()
+  if (trimmed === '') return null
+  const num = Number(trimmed)
+  return Number.isFinite(num) ? num : null
+}
+
+/**
+ * Resolve env-based threshold overrides for the given rule ids.
+ *
+ * Scheme (documented for operators): for a rule `<rule-id>`, set either or both
+ * of
+ *
+ *   HEALTH_THRESHOLD_<RULE_ID>_WARNING
+ *   HEALTH_THRESHOLD_<RULE_ID>_CRITICAL
+ *
+ * where `<RULE_ID>` is the rule id uppercased with dashes replaced by
+ * underscores. Example: raise the disk-usage critical threshold to 90 with
+ * `HEALTH_THRESHOLD_DISK_USAGE_CRITICAL=90`. Only finite numeric values are
+ * accepted; anything else is ignored (falls back to the rule's defaults).
+ *
+ * Returned as a partial map keyed by rule id — only rules with at least one
+ * override present appear. Callers merge these onto each rule's `defaults`.
+ *
+ * NOTE: exposed as a companion function rather than folded into
+ * {@link getServerAlertConfig}'s return value so that function keeps its exact
+ * {@link AlertSettings} shape (its unit tests assert the object deeply).
+ */
+export function getServerThresholdOverrides(
+  ruleIds: readonly string[]
+): Record<string, ThresholdOverride> {
+  const out: Record<string, ThresholdOverride> = {}
+  for (const id of ruleIds) {
+    const prefix = thresholdEnvPrefix(id)
+    const warning = parseThresholdEnv(process.env[`${prefix}_WARNING`])
+    const critical = parseThresholdEnv(process.env[`${prefix}_CRITICAL`])
+    if (warning === null && critical === null) continue
+    const override: ThresholdOverride = {}
+    if (warning !== null) override.warning = warning
+    if (critical !== null) override.critical = critical
+    out[id] = override
+  }
+  return out
+}
+
+/** Default cron re-notify cooldown, in minutes, when the env var is unset. */
+export const DEFAULT_ALERT_COOLDOWN_MINUTES = 60
+
+/**
+ * Re-notify cooldown for a persistent condition, in milliseconds.
+ *
+ * `HEALTH_ALERT_COOLDOWN_MINUTES` (default 60) controls how long the sweep waits
+ * before re-sending a webhook for a condition that stays at the same severity.
+ * `0` disables reminders entirely (a persistent condition alerts once until it
+ * escalates or recovers). Invalid / negative values fall back to the default.
+ */
+export function getServerAlertCooldownMs(): number {
+  const raw = process.env.HEALTH_ALERT_COOLDOWN_MINUTES?.trim()
+  if (raw === undefined || raw === '') {
+    return DEFAULT_ALERT_COOLDOWN_MINUTES * 60 * 1000
+  }
+  const minutes = Number(raw)
+  if (!Number.isFinite(minutes) || minutes < 0) {
+    return DEFAULT_ALERT_COOLDOWN_MINUTES * 60 * 1000
+  }
+  return minutes * 60 * 1000
 }

--- a/apps/dashboard/src/lib/health/server-sweep.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.ts
@@ -1,17 +1,27 @@
 import type { ClickHouseConfig } from '@chm/clickhouse-client'
+import type {
+  AlertRuleDef,
+  AlertRuleSeverity,
+} from '@/lib/alerting/rule-registry'
 
-import { getServerAlertConfig } from './server-alert-config'
+import { alertStateStore, evaluateAlert } from './alert-state-store'
+import {
+  getServerAlertConfig,
+  getServerAlertCooldownMs,
+  getServerThresholdOverrides,
+} from './server-alert-config'
 import { fetchData, getClickHouseConfigs } from '@chm/clickhouse-client'
 import { debug, error } from '@chm/logger'
-import { HEALTH_CHECKS } from '@/components/health/health-checks'
 import { registerBuiltinRules } from '@/lib/alerting/builtin-rules'
+import { classifyValue, ruleRegistry } from '@/lib/alerting/rule-registry'
 import { generateInsights } from '@/lib/insights/generate-insights'
 
 // Register pluggable alert rules into the global ruleRegistry once at module
-// load. HEALTH_CHECKS (same rule set) continue to drive the /health page UI.
+// load. The sweep drives itself from `ruleRegistry.getAll()`; the /health page
+// UI is driven independently by the (matching) HEALTH_CHECKS definitions.
 registerBuiltinRules()
 
-type Severity = 'ok' | 'warning' | 'critical'
+type Severity = AlertRuleSeverity
 
 const SEVERITY_ORDER: Record<Severity, number> = {
   ok: 0,
@@ -35,6 +45,8 @@ export interface SweepHostSummary {
   checksRun: number
   findings: number
   errored: number
+  /** Rules skipped because an optional table was absent on this host. */
+  skipped: number
 }
 
 export interface SweepSummary {
@@ -46,6 +58,10 @@ export interface SweepSummary {
   totalChecks: number
   totalFindings: number
   alertsDispatched: number
+  /** Alerts suppressed by the dedup state store (already-firing conditions). */
+  alertsSuppressed: number
+  /** Recovery notifications sent for conditions that returned to ok. */
+  recoveries: number
   /** Total AI insights generated and persisted across all hosts. */
   insightsGenerated: number
   hosts: SweepHostSummary[]
@@ -57,11 +73,11 @@ function hostLabel(config: ClickHouseConfig): string {
 }
 
 /**
- * Run a single health-check SQL on one host in read-only mode and read the
- * numeric value from the configured `valueKey`. Mirrors the client read path
+ * Run a single rule's SQL on one host in read-only mode and read the numeric
+ * value from the configured `valueKey`. Mirrors the client read path
  * (`readOnlyQuery`) so cron results match what the Health dashboard shows.
  */
-async function runHealthCheck(
+async function runRuleQuery(
   sql: string,
   valueKey: string,
   hostId: number
@@ -85,15 +101,43 @@ async function runHealthCheck(
   return Number.isFinite(num) ? num : null
 }
 
-function classify(
-  value: number | null,
-  warning: number,
-  critical: number
-): Severity {
-  if (value === null || !Number.isFinite(value)) return 'ok'
-  if (value >= critical) return 'critical'
-  if (value >= warning) return 'warning'
-  return 'ok'
+/**
+ * Best-effort set of `system.*` tables present on a host, used to honor each
+ * rule's `optional`/`tableCheck`. Returns `null` when the probe itself fails —
+ * callers then fall back to attempting every rule (the per-rule try/catch still
+ * protects against a missing table).
+ */
+async function getExistingSystemTables(
+  hostId: number
+): Promise<Set<string> | null> {
+  try {
+    const result = await fetchData<Array<{ full: string }>>({
+      query: `SELECT concat(database, '.', name) AS full FROM system.tables WHERE database = 'system'`,
+      hostId,
+      format: 'JSONEachRow',
+      clickhouse_settings: { readonly: '1' },
+    })
+    if (result.error) return null
+    const rows = result.data
+    if (!Array.isArray(rows)) return null
+    return new Set(rows.map((r) => String(r.full)))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Whether a rule should run on this host given the table-existence probe.
+ * Non-optional rules always run. Optional rules with a `tableCheck` are skipped
+ * only when we positively know the table is absent.
+ */
+function shouldRunRule(
+  rule: AlertRuleDef,
+  tables: Set<string> | null
+): boolean {
+  if (!rule.sql) return false
+  if (!rule.optional || !rule.tableCheck || tables === null) return true
+  return tables.has(rule.tableCheck)
 }
 
 /**
@@ -128,11 +172,14 @@ async function postWebhook(url: string, text: string): Promise<boolean> {
 }
 
 /**
- * Autonomous health sweep: runs every configured health check over ALL hosts,
- * classifies severity from each check's default thresholds, and dispatches a
- * webhook alert for any finding at or above the configured minimum severity.
+ * Autonomous health sweep: runs every registered alert rule over ALL hosts,
+ * classifies severity from each rule's thresholds (with env overrides), and
+ * dispatches a webhook alert for any finding at or above the configured minimum
+ * severity — but only when the dedup state store says the alert is genuinely
+ * new, escalated, past its cooldown, or a recovery. A persistent condition no
+ * longer webhooks on every run.
  *
- * Disabled (or no webhook URL) → checks still run, alerts are skipped.
+ * Disabled (or no webhook URL) → rules still run, alerts are skipped.
  */
 export async function runHealthSweep(): Promise<SweepSummary> {
   const ranAt = new Date().toISOString()
@@ -140,42 +187,89 @@ export async function runHealthSweep(): Promise<SweepSummary> {
   const webhookConfigured = Boolean(settings.webhookUrl)
   const canDispatch = settings.webhookEnabled && webhookConfigured
   const minRank = SEVERITY_ORDER[settings.minSeverity]
+  const cooldownMs = getServerAlertCooldownMs()
+
+  const rules = ruleRegistry.getAll()
+  const thresholdOverrides = getServerThresholdOverrides(rules.map((r) => r.id))
 
   const configs = getClickHouseConfigs()
 
   const hosts: SweepHostSummary[] = []
   const findings: SweepFinding[] = []
   let insightsGenerated = 0
+  let alertsDispatched = 0
+  let alertsSuppressed = 0
+  let recoveries = 0
 
   for (const config of configs) {
     const name = hostLabel(config)
     let checksRun = 0
     let errored = 0
+    let skipped = 0
 
-    for (const check of HEALTH_CHECKS) {
-      if (!check.sql) continue
+    const tables = await getExistingSystemTables(config.id)
+
+    for (const rule of rules) {
+      if (!rule.sql) continue
+      if (!shouldRunRule(rule, tables)) {
+        skipped++
+        continue
+      }
       checksRun++
       try {
-        const value = await runHealthCheck(check.sql, check.valueKey, config.id)
-        const severity = classify(
-          value,
-          check.defaults.warning,
-          check.defaults.critical
-        )
-        if (severity === 'ok') continue
-        findings.push({
-          hostId: config.id,
-          hostName: name,
-          checkId: check.id,
-          title: check.title,
-          severity,
-          value,
-          label: check.formatLabel ? check.formatLabel(value) : String(value),
-        })
+        const value = await runRuleQuery(rule.sql, rule.valueKey, config.id)
+        const thresholds = {
+          ...rule.defaults,
+          ...(thresholdOverrides[rule.id] ?? {}),
+        }
+        const severity = classifyValue(value, thresholds)
+
+        if (severity !== 'ok') {
+          findings.push({
+            hostId: config.id,
+            hostName: name,
+            checkId: rule.id,
+            title: rule.title,
+            severity,
+            value,
+            label: rule.formatLabel ? rule.formatLabel(value) : String(value),
+          })
+        }
+
+        // Dedup + dispatch. Sub-threshold severities count as 'ok' so the state
+        // store only tracks conditions the operator cares about (and a drop
+        // below the threshold reads as a recovery).
+        if (canDispatch) {
+          const effective: Severity =
+            SEVERITY_ORDER[severity] >= minRank ? severity : 'ok'
+          const decision = evaluateAlert(alertStateStore, {
+            hostId: config.id,
+            ruleId: rule.id,
+            severity: effective,
+            cooldownMs,
+          })
+          if (decision.notify) {
+            const label = rule.formatLabel
+              ? rule.formatLabel(value)
+              : String(value)
+            const text =
+              decision.kind === 'recovery'
+                ? `[RECOVERY] ${rule.title} — resolved (host ${name})`
+                : `[${effective.toUpperCase()}] ${rule.title} — ${label} (host ${name})`
+            const ok = await postWebhook(settings.webhookUrl, text)
+            if (ok) {
+              alertsDispatched++
+              if (decision.kind === 'recovery') recoveries++
+            }
+          } else if (SEVERITY_ORDER[severity] >= minRank) {
+            // A current finding that we chose not to re-send (deduped).
+            alertsSuppressed++
+          }
+        }
       } catch (err) {
         errored++
         debug(
-          `[health-sweep] check "${check.id}" failed on host ${config.id}`,
+          `[health-sweep] check "${rule.id}" failed on host ${config.id}`,
           err instanceof Error ? err.message : String(err)
         )
       }
@@ -187,6 +281,7 @@ export async function runHealthSweep(): Promise<SweepSummary> {
       checksRun,
       findings: findings.filter((f) => f.hostId === config.id).length,
       errored,
+      skipped,
     })
 
     // Generate + persist AI insights for this host (best-effort; never throws).
@@ -201,16 +296,6 @@ export async function runHealthSweep(): Promise<SweepSummary> {
     }
   }
 
-  let alertsDispatched = 0
-  if (canDispatch) {
-    for (const finding of findings) {
-      if (SEVERITY_ORDER[finding.severity] < minRank) continue
-      const text = `[${finding.severity.toUpperCase()}] ${finding.title} — ${finding.label} (host ${finding.hostName})`
-      const ok = await postWebhook(settings.webhookUrl, text)
-      if (ok) alertsDispatched++
-    }
-  }
-
   return {
     ranAt,
     enabled: settings.webhookEnabled,
@@ -220,6 +305,8 @@ export async function runHealthSweep(): Promise<SweepSummary> {
     totalChecks: hosts.reduce((sum, h) => sum + h.checksRun, 0),
     totalFindings: findings.length,
     alertsDispatched,
+    alertsSuppressed,
+    recoveries,
     insightsGenerated,
     hosts,
     findings,


### PR DESCRIPTION
Closes #2077

## Summary (Slice A2)

Makes the autonomous health sweep rule-driven and stops it from webhooking a persistent condition on every run.

- **Registry-driven sweep** (`server-sweep.ts`): the sweep now iterates `ruleRegistry.getAll()` instead of `HEALTH_CHECKS`. It honors each rule's `optional`/`tableCheck` via a per-host `system.*` table probe (skips optional rules whose table is absent; falls back to running everything if the probe itself fails), and classifies values with the shared `classifyValue` from `rule-registry.ts` (no duplicated threshold logic). Existing behavior for the previously-covered checks is preserved.
- **New `alert-state-store.ts`** — alert de-duplication state, keyed per condition (`host:ruleId`, with the last-fired severity stored in the record, i.e. `host:ruleId:severity`). Pure `decideNotification` transition + a `MemoryAlertStateStore` singleton (mirrors the insights `memory-store` pattern). Notifies only on:
  - **NEW** (ok → firing) / **ESCALATED** (warning → critical) — always, regardless of cooldown
  - **REMINDER** — a persistent same-severity condition, once the cooldown window elapses
  - **RECOVERY** — a previously-firing condition returns to ok
  - everything else (same severity within cooldown, ok → ok) is **suppressed**
- **Sweep consults the store** before dispatching, so persistent conditions no longer webhook every 5 minutes. Sub-threshold severities are treated as `ok` for dedup so state only tracks conditions above `minSeverity`. Summary gains `alertsSuppressed`, `recoveries`, and per-host `skipped` counts.
- **`server-alert-config.ts`**:
  - env-based per-rule threshold overrides: `HEALTH_THRESHOLD_<RULE_ID>_WARNING` / `_CRITICAL` (rule id uppercased, dashes → underscores), resolved by `getServerThresholdOverrides()`
  - configurable cooldown: `HEALTH_ALERT_COOLDOWN_MINUTES` (default 60; `0` disables reminders) via `getServerAlertCooldownMs()`
  - **minSeverity choice**: the server default stays `'warning'` (client default is `'critical'`). This is intentional and documented in the file — the cron path is an operator-facing outbound webhook where catching warnings early matters, and the new dedup store already prevents warning spam. Operators can set `HEALTH_ALERT_MIN_SEVERITY=critical`.

## Verify

- `bun run type-check` → clean (0 errors) after the vite build generates `routeTree.gen.ts` (a gitignored build artifact; a bare `tsc` shows only pre-existing route-tree errors, none in touched files).
- `bun test src/lib/health` → **118 pass / 0 fail** (includes the new `alert-state-store.test.ts`: new / escalated / cooldown-suppressed / reminder / recovery / de-escalation / host isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb)_