### PR TITLE
feat(health): capture incident system snapshot at fire time

### DIFF
--- a/apps/dashboard/src/lib/health/incident-snapshot.test.ts
+++ b/apps/dashboard/src/lib/health/incident-snapshot.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for captureIncidentSnapshot.
+ *
+ * `readOnlyQuery` (the only external I/O) is stubbed via mock.module so we
+ * exercise the snapshot's shape and its partial-failure resilience without
+ * hitting ClickHouse. The stub routes by which system table the SQL references,
+ * so each sub-collector can be made to succeed or fail independently.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// ── Stub external I/O before importing the module under test. ─────────────
+
+type QueryHandler = (sql: string) => unknown
+
+let handler: QueryHandler = () => []
+
+mock.module('../ai/agent/tools/helpers', () => ({
+  readOnlyQuery: async ({ query }: { query: string }) => handler(query),
+}))
+
+// ── Import AFTER the mock is registered. ──────────────────────────────────
+
+import { captureIncidentSnapshot } from './incident-snapshot'
+
+/** Route a query to the right fixture by the system table it selects from. */
+function routeBy(
+  sql: string
+): 'processes' | 'merges' | 'memory' | 'disks' | 'replicas' | 'unknown' {
+  if (sql.includes('system.processes')) return 'processes'
+  if (sql.includes('system.merges')) return 'merges'
+  if (sql.includes('system.disks')) return 'disks'
+  if (sql.includes('system.replicas')) return 'replicas'
+  if (sql.includes('asynchronous_metrics')) return 'memory'
+  return 'unknown'
+}
+
+beforeEach(() => {
+  handler = () => []
+})
+
+describe('captureIncidentSnapshot', () => {
+  test('returns a fully-populated snapshot when every query succeeds', async () => {
+    handler = (sql) => {
+      switch (routeBy(sql)) {
+        case 'processes':
+          return [
+            {
+              query_id: 'q1',
+              user: 'default',
+              elapsed: 12.5,
+              memory_mb: 256.4,
+              query: 'SELECT * FROM big_table',
+            },
+          ]
+        case 'merges':
+          return [{ active: 3, stuck: 1, max_elapsed: 900.2 }]
+        case 'memory':
+          return [{ value: 72.1 }]
+        case 'disks':
+          return [{ value: 88.5 }]
+        case 'replicas':
+          return [{ value: 42 }]
+        default:
+          return []
+      }
+    }
+
+    const snap = await captureIncidentSnapshot(0)
+
+    expect(snap.hostId).toBe(0)
+    expect(typeof snap.capturedAt).toBe('string')
+    expect(snap.topQueries).toEqual([
+      {
+        queryId: 'q1',
+        user: 'default',
+        elapsed: 12.5,
+        memoryMb: 256.4,
+        query: 'SELECT * FROM big_table',
+      },
+    ])
+    expect(snap.merges).toEqual({ active: 3, stuck: 1, maxElapsed: 900.2 })
+    expect(snap.memoryUsagePct).toBe(72.1)
+    expect(snap.diskUsagePct).toBe(88.5)
+    expect(snap.replicationLagSeconds).toBe(42)
+  })
+
+  test('threads hostId through to the snapshot', async () => {
+    const snap = await captureIncidentSnapshot(7)
+    expect(snap.hostId).toBe(7)
+  })
+
+  test('returns a partial snapshot when some sub-collectors fail', async () => {
+    // processes + disks throw; the rest resolve.
+    handler = (sql) => {
+      const kind = routeBy(sql)
+      if (kind === 'processes' || kind === 'disks') {
+        throw new Error('table not found')
+      }
+      if (kind === 'merges') return [{ active: 0, stuck: 0, max_elapsed: null }]
+      if (kind === 'memory') return [{ value: 10 }]
+      if (kind === 'replicas') return [{ value: 0 }]
+      return []
+    }
+
+    const snap = await captureIncidentSnapshot(1)
+
+    // Failed collectors → null; successful ones still populate.
+    expect(snap.topQueries).toBeNull()
+    expect(snap.diskUsagePct).toBeNull()
+    expect(snap.merges).toEqual({ active: 0, stuck: 0, maxElapsed: null })
+    expect(snap.memoryUsagePct).toBe(10)
+    expect(snap.replicationLagSeconds).toBe(0)
+  })
+
+  test('never throws even when every query fails', async () => {
+    handler = () => {
+      throw new Error('cluster unreachable')
+    }
+
+    const snap = await captureIncidentSnapshot(2)
+
+    expect(snap.hostId).toBe(2)
+    expect(snap.topQueries).toBeNull()
+    expect(snap.merges).toBeNull()
+    expect(snap.memoryUsagePct).toBeNull()
+    expect(snap.diskUsagePct).toBeNull()
+    expect(snap.replicationLagSeconds).toBeNull()
+  })
+
+  test('coerces string cells and handles empty result rows', async () => {
+    handler = (sql) => {
+      const kind = routeBy(sql)
+      if (kind === 'processes') {
+        return [
+          {
+            query_id: 'q9',
+            user: 'reader',
+            elapsed: '3.5', // string from JSON
+            memory_mb: '128',
+            query: 'OPTIMIZE TABLE t',
+          },
+        ]
+      }
+      if (kind === 'merges') return [] // empty rows → defaults
+      return [{ value: null }] // null value → null
+    }
+
+    const snap = await captureIncidentSnapshot(0)
+
+    expect(snap.topQueries?.[0]).toEqual({
+      queryId: 'q9',
+      user: 'reader',
+      elapsed: 3.5,
+      memoryMb: 128,
+      query: 'OPTIMIZE TABLE t',
+    })
+    expect(snap.merges).toEqual({ active: 0, stuck: 0, maxElapsed: null })
+    expect(snap.memoryUsagePct).toBeNull()
+  })
+})

--- a/apps/dashboard/src/lib/health/incident-snapshot.ts
+++ b/apps/dashboard/src/lib/health/incident-snapshot.ts
@@ -1,0 +1,209 @@
+/**
+ * Incident system snapshot.
+ *
+ * Captures a compact, point-in-time picture of a single host's runtime state
+ * so it can be attached to an incident/alert for context: the heaviest running
+ * queries, active/stuck merges, memory + disk pressure, and replication lag.
+ *
+ * Design goals:
+ * - **Resilient**: each sub-collector is wrapped so a single failing query
+ *   (missing table, read-only cluster, permission) yields `null` for that
+ *   field instead of aborting the whole snapshot. A partial snapshot is always
+ *   returned.
+ * - **Small payload**: only a few running-query rows (query text truncated),
+ *   scalar summaries for everything else. This is meant to be embedded, not
+ *   browsed.
+ * - **Read-only**: uses the same `readOnlyQuery` primitive the insight
+ *   collectors use, so it never mutates cluster state.
+ *
+ * This module is standalone/consumable — it does NOT wire itself into any
+ * alert payload; a later slice does that.
+ */
+
+import { readOnlyQuery } from '../ai/agent/tools/helpers'
+
+/** How many running queries to include (kept small on purpose). */
+const TOP_QUERY_LIMIT = 5
+/** Max query-text length retained per running query. */
+const QUERY_TEXT_MAX = 200
+/** A merge running longer than this (seconds) is flagged as "stuck". */
+const STUCK_MERGE_SECONDS = 600
+
+/** One heavy running query at incident time. */
+export interface RunningQuerySnapshot {
+  readonly queryId: string
+  readonly user: string
+  /** Seconds the query has been running. */
+  readonly elapsed: number
+  /** Memory used by the query, in MiB. */
+  readonly memoryMb: number
+  /** Truncated query text (up to QUERY_TEXT_MAX chars). */
+  readonly query: string
+}
+
+/** Aggregate view of active merges at incident time. */
+export interface MergeSnapshot {
+  /** Number of active merges. */
+  readonly active: number
+  /** Active merges running longer than STUCK_MERGE_SECONDS. */
+  readonly stuck: number
+  /** Longest-running merge in seconds (null when none). */
+  readonly maxElapsed: number | null
+}
+
+/** Compact system state captured at incident time. */
+export interface IncidentSnapshot {
+  readonly hostId: number
+  /** ISO timestamp the snapshot was captured. */
+  readonly capturedAt: string
+  /** Heaviest running queries, or null if the query failed. */
+  readonly topQueries: RunningQuerySnapshot[] | null
+  /** Active/stuck merge summary, or null if the query failed. */
+  readonly merges: MergeSnapshot | null
+  /** Memory usage as a percentage of total OS memory, or null. */
+  readonly memoryUsagePct: number | null
+  /** Disk usage as a percentage of total disk space, or null. */
+  readonly diskUsagePct: number | null
+  /** Most-delayed replica in seconds, or null. */
+  readonly replicationLagSeconds: number | null
+}
+
+/** Coerce a cell to a finite number, or null. */
+function num(val: unknown): number | null {
+  if (val === null || val === undefined) return null
+  const n = typeof val === 'number' ? val : Number(val)
+  return Number.isFinite(n) ? n : null
+}
+
+/** Coerce a cell to a string ('' when null/undefined). */
+function str(val: unknown): string {
+  return val === null || val === undefined ? '' : String(val)
+}
+
+/**
+ * Run a read-only query and return its rows, or null on any failure. Keeps
+ * every sub-collector best-effort so one failure never aborts the snapshot.
+ */
+async function safeRows(
+  sql: string,
+  hostId: number
+): Promise<Record<string, unknown>[] | null> {
+  try {
+    const rows = await readOnlyQuery({ query: sql, hostId })
+    return Array.isArray(rows) ? (rows as Record<string, unknown>[]) : null
+  } catch {
+    return null
+  }
+}
+
+/** Heaviest running queries by elapsed time. */
+async function collectTopQueries(
+  hostId: number
+): Promise<RunningQuerySnapshot[] | null> {
+  const rows = await safeRows(
+    `SELECT
+       query_id,
+       user,
+       round(elapsed, 2) AS elapsed,
+       round(memory_usage / 1048576, 1) AS memory_mb,
+       substring(query, 1, ${QUERY_TEXT_MAX}) AS query
+     FROM system.processes
+     ORDER BY elapsed DESC
+     LIMIT ${TOP_QUERY_LIMIT}`,
+    hostId
+  )
+  if (rows === null) return null
+  return rows.map((r) => ({
+    queryId: str(r.query_id),
+    user: str(r.user),
+    elapsed: num(r.elapsed) ?? 0,
+    memoryMb: num(r.memory_mb) ?? 0,
+    query: str(r.query),
+  }))
+}
+
+/** Active/stuck merge summary. */
+async function collectMerges(hostId: number): Promise<MergeSnapshot | null> {
+  const rows = await safeRows(
+    `SELECT
+       count() AS active,
+       countIf(elapsed > ${STUCK_MERGE_SECONDS}) AS stuck,
+       round(max(elapsed), 2) AS max_elapsed
+     FROM system.merges`,
+    hostId
+  )
+  if (rows === null) return null
+  const row = rows[0] ?? {}
+  return {
+    active: num(row.active) ?? 0,
+    stuck: num(row.stuck) ?? 0,
+    maxElapsed: num(row.max_elapsed),
+  }
+}
+
+/** Memory usage as a percentage of total OS memory. */
+async function collectMemoryUsagePct(hostId: number): Promise<number | null> {
+  const rows = await safeRows(
+    `SELECT round(
+       (SELECT value FROM system.asynchronous_metrics WHERE metric = 'MemoryResident')
+       * 100.0
+       / nullIf((SELECT value FROM system.asynchronous_metrics WHERE metric = 'OSMemoryTotal'), 0),
+       1) AS value`,
+    hostId
+  )
+  return rows ? num(rows[0]?.value) : null
+}
+
+/** Disk usage as a percentage of total disk space. */
+async function collectDiskUsagePct(hostId: number): Promise<number | null> {
+  const rows = await safeRows(
+    `SELECT round(
+       (sum(total_space) - sum(free_space)) * 100.0 / nullIf(sum(total_space), 0),
+       1) AS value
+     FROM system.disks`,
+    hostId
+  )
+  return rows ? num(rows[0]?.value) : null
+}
+
+/**
+ * Most-delayed replica in seconds. Mirrors the reliability collector's
+ * `max(absolute_delay)` query in lib/insights/collectors.ts.
+ */
+async function collectReplicationLag(hostId: number): Promise<number | null> {
+  const rows = await safeRows(
+    `SELECT max(absolute_delay) AS value FROM system.replicas`,
+    hostId
+  )
+  return rows ? num(rows[0]?.value) : null
+}
+
+/**
+ * Capture a compact snapshot of a host's system state at incident time.
+ *
+ * Never throws: each sub-collector is independent and best-effort, so the
+ * returned snapshot may carry `null` for any field whose query failed while
+ * the rest resolve normally.
+ */
+export async function captureIncidentSnapshot(
+  hostId: number
+): Promise<IncidentSnapshot> {
+  const [topQueries, merges, memoryUsagePct, diskUsagePct, replicationLag] =
+    await Promise.all([
+      collectTopQueries(hostId),
+      collectMerges(hostId),
+      collectMemoryUsagePct(hostId),
+      collectDiskUsagePct(hostId),
+      collectReplicationLag(hostId),
+    ])
+
+  return {
+    hostId,
+    capturedAt: new Date().toISOString(),
+    topQueries,
+    merges,
+    memoryUsagePct,
+    diskUsagePct,
+    replicationLagSeconds: replicationLag,
+  }
+}

--- a/apps/dashboard/src/routes/api/v1/health/snapshot.ts
+++ b/apps/dashboard/src/routes/api/v1/health/snapshot.ts
@@ -1,0 +1,65 @@
+/**
+ * Incident system-snapshot endpoint
+ * GET /api/v1/health/snapshot?hostId=0
+ *
+ * Returns a compact, point-in-time picture of a host's runtime state (top
+ * running queries, active/stuck merges, memory + disk usage %, replication
+ * lag) for attaching context to an incident/alert.
+ *
+ * Auth is centralized in middleware (#1397), same as the sibling
+ * /api/v1/health/* routes — this handler only validates input and shapes the
+ * response. The underlying snapshot is best-effort: individual fields may be
+ * null when their query fails, but the request still succeeds.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { error } from '@chm/logger'
+import { captureIncidentSnapshot } from '@/lib/health/incident-snapshot'
+
+export const Route = createFileRoute('/api/v1/health/snapshot')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const { searchParams } = new URL(request.url)
+
+        const hostId = Number(searchParams.get('hostId') ?? '0')
+        if (!Number.isInteger(hostId) || hostId < 0) {
+          return Response.json(
+            {
+              success: false,
+              error: { type: 'validation', message: 'Invalid hostId' },
+            },
+            { status: 400 }
+          )
+        }
+
+        try {
+          const snapshot = await captureIncidentSnapshot(hostId)
+          return Response.json(
+            { success: true, snapshot },
+            {
+              status: 200,
+              headers: {
+                'Cache-Control':
+                  'public, s-maxage=5, stale-while-revalidate=15',
+              },
+            }
+          )
+        } catch (err) {
+          error('[GET /api/v1/health/snapshot]', err)
+          return Response.json(
+            {
+              success: false,
+              error: {
+                type: 'query_error',
+                message: err instanceof Error ? err.message : 'Unknown error',
+              },
+            },
+            { status: 500 }
+          )
+        }
+      },
+    },
+  },
+})


### PR DESCRIPTION
Closes #2079.

Adds `captureIncidentSnapshot(hostId)` gathering top running queries, active/stuck merges, memory %, disk %, and replication lag at incident time (reusing insights collectors, resilient to partial failure), plus a `GET /api/v1/health/snapshot` endpoint. Standalone/consumable; payload wiring lands with the adapter/dispatch slices.

Files: `apps/dashboard/src/lib/health/incident-snapshot.ts` (+ test), `apps/dashboard/src/routes/api/v1/health/snapshot.ts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb)_