### PR TITLE
ci(pr-title): resolve commitlint from local deps to fix flaky title check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -28,9 +28,15 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
+      # Install so commitlint resolves from the repo's pinned devDependencies
+      # (incl. the conventional-changelog-conventionalcommits transitive dep),
+      # instead of a flaky `bunx --bun commitlint@latest` npm fetch at check time.
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Validate PR title is a conventional commit
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           echo "Validating PR title: $PR_TITLE"
-          echo "$PR_TITLE" | bunx --bun commitlint --config commitlint.config.js
+          echo "$PR_TITLE" | bunx commitlint --config commitlint.config.js


### PR DESCRIPTION
## Problem
The required `conventional-title` check runs `bunx --bun commitlint@latest`, which intermittently (now consistently) fails resolving the `conventional-changelog-conventionalcommits` transitive dependency from npm (`GET registry.npmjs.org/... 404`). This blocks unrelated PRs from merging.

## Fix
Install the repo's pinned commitlint devDependencies (`bun install --frozen-lockfile`, workspaces-only so it's fast) and run the local `commitlint` binary — matching how the husky `commit-msg` hook validates locally. Removes the flaky fresh-fetch path.

Once merged, other open PRs need their branch updated to inherit this workflow so their title check re-runs against the fixed version.

---
_Generated by [Claude Code](https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb)_