### PR TITLE
fix(billing): correct org seat cap off-by-one in Clerk webhook

### DIFF
--- a/apps/dashboard/src/lib/billing/seat-enforcement.test.ts
+++ b/apps/dashboard/src/lib/billing/seat-enforcement.test.ts
@@ -1,9 +1,15 @@
 /**
- * Seat-enforcement unit tests — verifies that checkSeatLimit() correctly
- * gates the `organizationMembership.created` webhook handler. The count
- * passed in reflects the post-addition member total (after Clerk fires the
- * webhook, memberships.data.length already includes the new member).
+ * Seat-enforcement unit tests — verifies that the `organizationMembership.created`
+ * webhook handler correctly gates new members against the plan seat cap.
+ *
+ * The webhook fires *after* Clerk creates the row, so `memberships.data.length`
+ * (`count`) already includes the new member (post-addition total). The handler
+ * passes the pre-addition count (`count - 1`) to `checkSeatLimit`, which uses
+ * `used < limit` ("is there room for one more?"). `admit()` below mirrors that
+ * exact call so the tests model the real webhook behaviour.
  */
+
+import type { Plan } from './plans'
 
 import { checkSeatLimit } from './entitlements'
 import { BILLING_PLANS } from './plans'
@@ -11,29 +17,33 @@ import { describe, expect, test } from 'bun:test'
 
 const { free, pro, enterprise } = BILLING_PLANS
 
-describe('seat-enforcement — checkSeatLimit', () => {
-  test('Free (seats=1): count=0 → allowed (no members yet)', () => {
-    expect(checkSeatLimit(free, 0).allowed).toBe(true)
+// Mirrors the webhook: `count` is the post-addition membership total; admission
+// asks whether the pre-addition roster had room for one more.
+const admit = (plan: Plan, count: number) => checkSeatLimit(plan, count - 1)
+
+describe('seat-enforcement — webhook admission (post-addition count)', () => {
+  test('Free (seats=1): count=1 → allowed (first member fits)', () => {
+    expect(admit(free, 1).allowed).toBe(true)
   })
 
-  test('Free (seats=1): count=1 → denied (at the cap — rollback new member)', () => {
-    const check = checkSeatLimit(free, 1)
+  test('Free (seats=1): count=2 → denied (over the cap — rollback new member)', () => {
+    const check = admit(free, 2)
     expect(check.allowed).toBe(false)
     expect(check.limit).toBe(1)
     expect(check.remaining).toBe(0)
     expect(check.reason).toBe('seat_limit')
   })
 
-  test('Pro (seats=3): count=2 → allowed', () => {
-    expect(checkSeatLimit(pro, 2).allowed).toBe(true)
+  test('Pro (seats=3): count=3 → allowed (fills the last seat)', () => {
+    expect(admit(pro, 3).allowed).toBe(true)
   })
 
-  test('Pro (seats=3): count=3 → denied (at the cap)', () => {
-    expect(checkSeatLimit(pro, 3).allowed).toBe(false)
+  test('Pro (seats=3): count=4 → denied (over the cap — rollback new member)', () => {
+    expect(admit(pro, 4).allowed).toBe(false)
   })
 
   test('Enterprise (seats=null): any count → always allowed (unlimited)', () => {
-    const check = checkSeatLimit(enterprise, 1_000)
+    const check = admit(enterprise, 1_000)
     expect(check.allowed).toBe(true)
     expect(check.unlimited).toBe(true)
     expect(check.limit).toBeNull()

--- a/apps/dashboard/src/routes/api/v1/webhooks/clerk.ts
+++ b/apps/dashboard/src/routes/api/v1/webhooks/clerk.ts
@@ -65,7 +65,11 @@ async function handlePost(request: Request): Promise<Response> {
           })
         const count = memberships.data.length
 
-        const check = checkSeatLimit(plan, count)
+        // The `organizationMembership.created` webhook fires after Clerk has
+        // already added the new member, so `count` is the post-addition total.
+        // `checkSeatLimit` uses `used < limit` ("is there room for one more?"),
+        // so pass the pre-addition count to ask whether this new member fits.
+        const check = checkSeatLimit(plan, count - 1)
         if (!check.allowed) {
           await clerkClient().organizations.deleteOrganizationMembership({
             organizationId: orgId,


### PR DESCRIPTION
Closes #2070

## Problem
The `organizationMembership.created` webhook fires *after* Clerk creates the membership row, so `memberships.data.length` already includes the new member (post-addition total). Passing that count to `checkSeatLimit` — which uses `used < limit` ("is there room for one more?") — effectively made the max `limit − 1`. A paying Pro org (`seats:3`) could only ever hold 2 members, and a Free org (`seats:1`) rejected its very first member.

## Fix
Pass the **pre-addition** count (`count - 1`) to `checkSeatLimit` so the new member is admitted up to (and including) the plan's seat limit. Enterprise (`seats:null`) stays unlimited.

Updated `seat-enforcement.test.ts` to model the webhook's post-addition count via an `admit(plan, count)` helper that mirrors the handler call:
- Free: `count=1` allowed, `count=2` rolled back
- Pro: `count=3` allowed, `count=4` rolled back
- Enterprise: any count allowed (unlimited)

## Files
- `apps/dashboard/src/routes/api/v1/webhooks/clerk.ts`
- `apps/dashboard/src/lib/billing/seat-enforcement.test.ts`

## Verify
- `bun test src/lib/billing/seat-enforcement.test.ts` → 5 pass / 0 fail
- `bun run type-check` → no new errors from this change. Pre-existing systemic errors across all route files come from the ungenerated `routeTree.gen.ts` (created at dev/build, gitignored) in this fresh worktree, not from the logic change (a numeric argument + test-only helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb)_