### PR TITLE
build(depcruise): broaden monorepo boundary rules

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -23,30 +23,31 @@ module.exports = {
     },
 
     // ── Apps must not import from other apps ──────────────────────────────
+    // Generalized: forbid ANY apps/X → apps/Y (X !== Y). Covers every app
+    // (blog, bug-handler, dashboard, docs, landing, mcp, telemetry, …) so new
+    // apps are guarded automatically. Intra-app imports (apps/X → apps/X) are
+    // allowed via the $1 back-reference to the captured app name.
     {
       name: 'no-cross-app-imports',
       severity: 'error',
-      comment: 'Apps must not import from other apps.',
-      from: { path: '^apps/dashboard/' },
-      to: { path: '^apps/mcp/' },
-    },
-    {
-      name: 'no-cross-app-imports-reverse',
-      severity: 'error',
-      comment: 'Apps must not import from other apps.',
-      from: { path: '^apps/mcp/' },
-      to: { path: '^apps/dashboard/' },
+      comment:
+        'Apps must not import from other apps. Extract shared code into a @chm/* package instead.',
+      from: { path: '^apps/([^/]+)/' },
+      to: {
+        path: '^apps/([^/]+)/',
+        pathNot: '^apps/$1/',
+      },
     },
 
     // ── Leaf packages must stay leaf-only ─────────────────────────────────
-    // @chm/types, @chm/sql-builder, @chm/logger, @chm/platform
+    // @chm/types, @chm/sql-builder, @chm/logger, @chm/platform, @chm/pricing
     {
       name: 'leaf-packages-no-internal-deps',
       severity: 'error',
       comment:
         'Leaf packages must not depend on higher-layer @chm/* packages.',
       from: {
-        path: '^packages/(types|sql-builder|logger|platform)/',
+        path: '^packages/(types|sql-builder|logger|platform|pricing)/',
       },
       to: {
         path: '^packages/(clickhouse-client|mcp-server)/',


### PR DESCRIPTION
Closes #2066

## Summary
Generalizes the dependency-cruiser boundary rules so every app and package layer is guarded, not just the `dashboard`↔`mcp` pair and a subset of packages.

- **`no-cross-app-imports` generalized to ANY `apps/X → apps/Y`** — replaced the two hard-coded `dashboard`/`mcp` rules with a single rule using an app-name capture + `$1` back-reference (`from.path: '^apps/([^/]+)/'`, `to.pathNot: '^apps/$1/'`). This now covers `blog`, `bug-handler`, `dashboard`, `docs`, `landing`, `mcp`, `telemetry`, and any future app automatically, while still allowing intra-app imports.
- **Leaf-layer rule updated** — added `@chm/pricing` (a true leaf, no `@chm/*` deps) to the leaf source group. `@chm/mcp-server` remains the forbidden higher-layer target (alongside `@chm/clickhouse-client`).
- **packages→apps** already covers all apps via `^packages/ → ^apps/` (`no-packages-to-apps`); confirmed, no change needed.

Only `.dependency-cruiser.cjs` is touched.

## Verify
- `bun run depcruise` → **PASS** on the current graph (2409 modules, 5741 dependencies, no violations).
- Negative test: a temporary `apps/telemetry → apps/blog` import was correctly flagged as `no-cross-app-imports` (previously unguarded), then removed — proving the `$1` back-reference enforces rather than silently passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb)_