### PR TITLE
feat(billing): usage read API + current-plan usage summary

### DIFF
--- a/apps/dashboard/src/components/billing/usage-summary.tsx
+++ b/apps/dashboard/src/components/billing/usage-summary.tsx
@@ -1,0 +1,182 @@
+import { AlertTriangleIcon, CalendarClockIcon } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+
+import { Progress } from '@/components/ui/progress'
+import { Skeleton } from '@/components/ui/skeleton'
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { cn } from '@/lib/utils'
+
+/**
+ * Current-plan usage summary — the used-vs-cap meters + renewal/cancel banner
+ * shown inside the billing current-plan card. Data comes from
+ * GET /api/v1/billing/usage (see routes/api/v1/billing/usage.ts).
+ *
+ * Cloud-only surface: in OSS the billing page is never gated (Clerk off), so the
+ * endpoint 401s and this component quietly renders nothing.
+ */
+
+interface UsageMeter {
+  used: number
+  limit: number | null
+  unlimited: boolean
+}
+
+interface BillingUsage {
+  planId: string
+  planName: string
+  hosts: UsageMeter
+  seats: UsageMeter
+  aiMessages: UsageMeter
+  renewal: {
+    currentPeriodEnd: number | null
+    cancelAtPeriodEnd: boolean
+    status: string
+    billingPeriod: 'monthly' | 'yearly' | null
+  }
+}
+
+interface Envelope<T> {
+  success: boolean
+  data?: T
+  error?: { message?: string }
+}
+
+async function fetchUsage(): Promise<BillingUsage> {
+  const res = await apiFetch('/api/v1/billing/usage')
+  const json = (await res
+    .json()
+    .catch(() => null)) as Envelope<BillingUsage> | null
+  if (!res.ok || !json?.success || json.data === undefined) {
+    throw new Error(json?.error?.message || `Request failed (${res.status})`)
+  }
+  return json.data
+}
+
+function useBillingUsage() {
+  return useQuery({
+    queryKey: ['billing', 'usage'],
+    queryFn: fetchUsage,
+    staleTime: 60_000,
+    // Match useBillingSubscription: the Clerk __session cookie is refreshed a few
+    // seconds after a cold load, so retry until the fresh cookie lands.
+    refetchOnMount: 'always',
+    retry: 5,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 4000),
+  })
+}
+
+/** "in 12 days" / "in 3 months"-style relative label for a unix-seconds instant. */
+function formatRenewalDate(unixSeconds: number): string {
+  return new Date(unixSeconds * 1000).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+export function UsageSummary() {
+  const { data, isLoading, isError } = useBillingUsage()
+
+  // OSS / signed-out / not-configured: the endpoint errors — render nothing so
+  // the card falls back to its plain entitlement description.
+  if (isError) return null
+
+  if (isLoading || !data) {
+    return (
+      <div className="space-y-4 pt-2">
+        <Skeleton className="h-4 w-40" />
+        <div className="space-y-3">
+          {[0, 1, 2].map((i) => (
+            <Skeleton key={i} className="h-8 w-full" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  const { hosts, seats, aiMessages, renewal } = data
+
+  return (
+    <div className="space-y-4 pt-2">
+      <div className="grid gap-4 sm:grid-cols-3">
+        <UsageMeterBar label="Hosts" meter={hosts} />
+        <UsageMeterBar label="Team seats" meter={seats} />
+        <UsageMeterBar label="AI messages today" meter={aiMessages} />
+      </div>
+      <RenewalBanner renewal={renewal} />
+    </div>
+  )
+}
+
+function UsageMeterBar({ label, meter }: { label: string; meter: UsageMeter }) {
+  const { used, limit, unlimited } = meter
+  // Percentage of the cap consumed (0 when unlimited — nothing to fill toward).
+  const pct =
+    unlimited || limit == null || limit <= 0
+      ? 0
+      : Math.min(100, Math.round((used / limit) * 100))
+  const atLimit = !unlimited && limit != null && used >= limit
+  const nearLimit = !unlimited && pct >= 80
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-muted-foreground text-xs font-medium">
+          {label}
+        </span>
+        <span className="text-sm font-semibold tabular-nums">
+          {used}
+          <span className="text-muted-foreground font-normal">
+            {unlimited || limit == null ? ' / ∞' : ` / ${limit}`}
+          </span>
+        </span>
+      </div>
+      <Progress
+        value={pct}
+        className={cn(
+          '[&>div]:transition-all',
+          atLimit
+            ? '[&>div]:bg-destructive'
+            : nearLimit
+              ? '[&>div]:bg-amber-500'
+              : undefined
+        )}
+      />
+    </div>
+  )
+}
+
+function RenewalBanner({ renewal }: { renewal: BillingUsage['renewal'] }) {
+  const { currentPeriodEnd, cancelAtPeriodEnd, status } = renewal
+
+  // Nothing meaningful to show for the free tier (no period, never subscribed).
+  if (status === 'none' || currentPeriodEnd == null) return null
+
+  const dateLabel = formatRenewalDate(currentPeriodEnd)
+
+  if (cancelAtPeriodEnd) {
+    return (
+      <div className="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+        <AlertTriangleIcon
+          className="mt-0.5 size-3.5 shrink-0"
+          strokeWidth={2}
+        />
+        <span>
+          Your subscription is cancelled and will end on{' '}
+          <span className="font-medium">{dateLabel}</span>. You keep access
+          until then — reactivate any time from the billing portal.
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="text-muted-foreground flex items-center gap-2 text-xs">
+      <CalendarClockIcon className="size-3.5 shrink-0" strokeWidth={2} />
+      <span>
+        Renews on{' '}
+        <span className="text-foreground font-medium">{dateLabel}</span>
+      </span>
+    </div>
+  )
+}

--- a/apps/dashboard/src/routes/(dashboard)/billing.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/billing.tsx
@@ -14,6 +14,7 @@ import {
   PopularBadge,
 } from '@/components/billing/plan-card'
 import { PlanComparison } from '@/components/billing/plan-comparison'
+import { UsageSummary } from '@/components/billing/usage-summary'
 import { ClerkSignInButton as ClerkSignInButtonImpl } from '@/components/clerk/clerk-sign-in-button'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -123,6 +124,9 @@ function BillingPage() {
             )}
           </div>
         </CardHeader>
+        <CardContent>
+          <UsageSummary />
+        </CardContent>
       </Card>
 
       {/* Billing period toggle */}

--- a/apps/dashboard/src/routes/api/v1/billing/usage.ts
+++ b/apps/dashboard/src/routes/api/v1/billing/usage.ts
@@ -1,0 +1,142 @@
+/**
+ * GET /api/v1/billing/usage — the current billing owner's usage vs. plan caps.
+ *
+ * Complements /api/v1/billing/subscription (which returns the plan + renewal
+ * metadata) by adding the actual consumption the current-plan card needs to
+ * render meters: hosts used/cap, seats used/cap, AI messages today/limit, plus
+ * the renewal date and cancel-grace state so the UI can surface a banner.
+ *
+ * Every meter is computed through the shared entitlement helpers
+ * ({@link checkHostLimit} / {@link checkSeatLimit} / {@link checkAiDailyLimit})
+ * so the used/limit/unlimited semantics match the server-side enforcement gates
+ * exactly (`limit: null` = unlimited). Each meter is resolved defensively — a
+ * store/Clerk hiccup degrades that one meter to `used: 0` rather than failing
+ * the whole summary, so the card still shows the plan and renewal state.
+ *
+ * Auth mirrors the other billing routes: resolveBillingOwner() throws
+ * UNAUTHORIZED (→ 401 via mapConnectionApiError) when Clerk is not configured.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { BillingOwner } from '@/lib/billing/billing-owner'
+import type { LimitCheck } from '@/lib/billing/entitlements'
+import type { Plan } from '@/lib/billing/plans'
+
+import { createSuccessResponse } from '@/lib/api/shared/response-builder'
+import { getAiUsageToday } from '@/lib/billing/ai-usage-store'
+import { resolveBillingOwner } from '@/lib/billing/billing-owner'
+import {
+  checkAiDailyLimit,
+  checkHostLimit,
+  checkSeatLimit,
+} from '@/lib/billing/entitlements'
+import { countOwnerHosts } from '@/lib/billing/org-host-count'
+import {
+  getPlanForOwner,
+  resolveOwnerSubscription,
+} from '@/lib/billing/user-subscription'
+import { mapConnectionApiError } from '@/lib/connection-store/api-errors'
+import { resolveConnectionUserId } from '@/lib/connection-store/auth'
+import { resolveConnectionStore } from '@/lib/connection-store/resolve-store'
+
+const ROUTE = { route: '/api/v1/billing/usage', method: 'GET' }
+
+/** A meter's shape as consumed by the UI. `limit: null` = unlimited. */
+interface UsageMeter {
+  used: number
+  limit: number | null
+  unlimited: boolean
+}
+
+function toMeter(check: LimitCheck): UsageMeter {
+  return { used: check.used, limit: check.limit, unlimited: check.unlimited }
+}
+
+/**
+ * Hosts consumed by the owner (pooled across org members for org owners). Falls
+ * back to 0 when the connection store can't be resolved so the summary survives.
+ */
+async function resolveHostsUsed(
+  owner: BillingOwner,
+  userId: string
+): Promise<number> {
+  try {
+    const store = await resolveConnectionStore()
+    return await countOwnerHosts(owner, store, userId)
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Seats consumed. A user-scoped (free) owner is always a single seat; an org
+ * owner counts its current Clerk members. Fail-safe to 1 so a Clerk hiccup can
+ * only under-count (never wrongly show an over-limit meter).
+ */
+async function resolveSeatsUsed(owner: BillingOwner): Promise<number> {
+  if (owner.type !== 'org') return 1
+  try {
+    const { clerkClient } = await import('@clerk/tanstack-react-start/server')
+    const memberships =
+      await clerkClient().organizations.getOrganizationMembershipList({
+        organizationId: owner.id,
+        limit: 100,
+      })
+    return memberships.data.length || 1
+  } catch {
+    return 1
+  }
+}
+
+async function resolveAiUsedToday(ownerId: string): Promise<number> {
+  try {
+    return await getAiUsageToday(ownerId)
+  } catch {
+    return 0
+  }
+}
+
+async function handleGet(): Promise<Response> {
+  try {
+    const owner = await resolveBillingOwner()
+    const userId = await resolveConnectionUserId()
+
+    const [plan, sub, hostsUsed, seatsUsed, aiUsedToday]: [
+      Plan,
+      Awaited<ReturnType<typeof resolveOwnerSubscription>>,
+      number,
+      number,
+      number,
+    ] = await Promise.all([
+      getPlanForOwner(owner.id),
+      resolveOwnerSubscription(owner.id),
+      resolveHostsUsed(owner, userId),
+      resolveSeatsUsed(owner),
+      resolveAiUsedToday(owner.id),
+    ])
+
+    return createSuccessResponse({
+      planId: plan.id,
+      planName: plan.name,
+      hosts: toMeter(checkHostLimit(plan, hostsUsed)),
+      seats: toMeter(checkSeatLimit(plan, seatsUsed)),
+      aiMessages: toMeter(checkAiDailyLimit(plan, aiUsedToday)),
+      renewal: {
+        currentPeriodEnd: sub?.currentPeriodEnd ?? null,
+        cancelAtPeriodEnd: sub?.cancelAtPeriodEnd ?? false,
+        status: sub?.status ?? 'none',
+        billingPeriod: sub?.billingPeriod ?? null,
+      },
+    })
+  } catch (error) {
+    return mapConnectionApiError(error, ROUTE)
+  }
+}
+
+export const Route = createFileRoute('/api/v1/billing/usage')({
+  server: {
+    handlers: {
+      GET: async () => handleGet(),
+    },
+  },
+})


### PR DESCRIPTION
Closes #2072

## Summary

The billing current-plan card showed entitlements ("N hosts included · M seats") but never actual usage, and the renewal date / `cancelAtPeriodEnd` grace state were fetched but never displayed. This slice surfaces all of it.

- **New `GET /api/v1/billing/usage`** — returns hosts used/cap, seats used/cap, AI messages today/limit, plus renewal date + cancel-grace. Metrics are computed through the shared entitlement helpers (`checkHostLimit` / `checkSeatLimit` / `checkAiDailyLimit`) so the `used`/`limit`/`unlimited` semantics match the server-side enforcement gates exactly (`limit: null` = unlimited). Hosts reuse `countOwnerHosts` (pooled across org members), seats count Clerk org members (1 for user-scoped/free), AI usage reads `getAiUsageToday`, renewal comes from `resolveOwnerSubscription`. Auth mirrors the other billing routes (`resolveBillingOwner` → 401 via `mapConnectionApiError` when Clerk is off). Each meter resolves defensively — a store/Clerk hiccup degrades that one meter to `0` rather than failing the whole summary.
- **New `UsageSummary` component** — a used-vs-cap meter block (`Progress` bars, amber near 80%, destructive at cap, `∞` for unlimited tiers) plus a renewal/cancel banner (calendar renewal line, or an amber "subscription ends on …" grace banner). Cloud-only surface: when the endpoint 401s (OSS / signed-out) it quietly renders nothing so the card falls back to its plain entitlement description.
- **Wired into `billing.tsx`** — rendered in a `CardContent` inside the existing current-plan `Card`.

Follows product-design conventions (muted labels, `tabular-nums`, OKLCH tokens, shadcn `Progress`/`Skeleton`); no `components/ui/` files were modified.

## Verify

- `cd apps/dashboard && bun run type-check` → passes (exit 0). Route tree regenerated via `bun run build` first, since `routeTree.gen.ts` is gitignored/generated.
- `biome check` clean on all three touched files.

## Files changed

- `apps/dashboard/src/routes/api/v1/billing/usage.ts` (new)
- `apps/dashboard/src/components/billing/usage-summary.tsx` (new)
- `apps/dashboard/src/routes/(dashboard)/billing.tsx` (wire-in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb

---
_Generated by [Claude Code](https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb)_