### PR TITLE
feat(agent): daily AI-quota indicator in chat UI

### DIFF
--- a/apps/dashboard/src/components/agents/welcome/agent-settings-sidebar.tsx
+++ b/apps/dashboard/src/components/agents/welcome/agent-settings-sidebar.tsx
@@ -39,6 +39,7 @@ import {
 } from '@/components/ui/drawer'
 import { Switch } from '@/components/ui/switch'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { useAiQuota } from '@/lib/ai/agent/use-ai-quota'
 import { useAgentSkills } from '@/lib/hooks/use-agent-skills'
 import {
   CONVERSATION_BACKEND_LABELS,
@@ -106,6 +107,9 @@ export function AgentSettingsSidebar({
       <SidebarSection label="Model">
         <AgentModelPicker variant="panel" />
       </SidebarSection>
+
+      {/* DAILY AI USAGE (cloud-only; renders nothing on OSS / unlimited) */}
+      <AiUsagePanel />
 
       {/* MCP SERVER */}
       <SidebarSection label="MCP Servers">
@@ -339,6 +343,62 @@ function ConversationHistoryPanel() {
         variables and cannot be changed here.
       </p>
     </div>
+  )
+}
+
+/**
+ * Compact "X / N messages today" meter for the daily AI allowance. Cloud-only:
+ * {@link useAiQuota} resolves `show: false` on OSS, for unlimited plans, and on
+ * any endpoint error/absence, so this renders nothing outside the cloud Free/Pro
+ * tiers with a bounded quota.
+ */
+function AiUsagePanel() {
+  const quota = useAiQuota()
+  if (!quota.show || quota.limit === null) return null
+
+  const { used, limit, remaining } = quota
+  const pct = limit > 0 ? Math.min(100, Math.round((used / limit) * 100)) : 0
+  const depleted = remaining !== null && remaining <= 0
+  const low = remaining !== null && remaining > 0 && remaining <= 1
+
+  return (
+    <SidebarSection
+      label="Daily AI usage"
+      right={
+        <span className="text-muted-foreground text-[10px] tabular-nums">
+          <span
+            className={cn(
+              'font-medium',
+              depleted
+                ? 'text-destructive'
+                : low
+                  ? 'text-amber-600 dark:text-amber-500'
+                  : 'text-foreground'
+            )}
+          >
+            {used}
+          </span>
+          /{limit}
+        </span>
+      }
+    >
+      <div className="space-y-1.5">
+        <div className="bg-muted h-1.5 w-full overflow-hidden rounded-full">
+          <div
+            className={cn(
+              'h-full rounded-full transition-all',
+              depleted ? 'bg-destructive' : low ? 'bg-amber-500' : 'bg-primary'
+            )}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <p className="text-muted-foreground text-[10.5px] leading-snug">
+          {depleted
+            ? "You've used all of today's messages. The limit resets tomorrow."
+            : `${remaining} message${remaining === 1 ? '' : 's'} left today`}
+        </p>
+      </div>
+    </SidebarSection>
   )
 }
 

--- a/apps/dashboard/src/components/agents/welcome/composer-toolbar.tsx
+++ b/apps/dashboard/src/components/agents/welcome/composer-toolbar.tsx
@@ -40,6 +40,7 @@ import {
 } from '@/components/ui/popover'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Switch } from '@/components/ui/switch'
+import { useAiQuota } from '@/lib/ai/agent/use-ai-quota'
 import { useAgentSkills } from '@/lib/hooks/use-agent-skills'
 import { useToolConfig } from '@/lib/hooks/use-tool-config'
 import { cn } from '@/lib/utils'
@@ -257,6 +258,9 @@ export function ComposerToolbar({
         </span>
       </Button>
 
+      {/* Daily AI usage — cloud-only, hidden on OSS / unlimited plans. */}
+      <AiQuotaIndicator />
+
       <SkillDetailDialog
         skill={skillDetail}
         open={skillDetail !== null}
@@ -275,5 +279,46 @@ export function ComposerToolbar({
         onRemove={(id) => onRemoveContext?.(id)}
       />
     </div>
+  )
+}
+
+/**
+ * Subtle "X / N today" chip pinned to the end of the composer toolbar, giving a
+ * Free-tier user forewarning of their daily AI-message allowance instead of only
+ * discovering it via a 402 mid-conversation. Cloud-only: {@link useAiQuota}
+ * resolves `show: false` on OSS, for unlimited plans, and on any endpoint
+ * error/absence, so nothing renders in those cases.
+ */
+function AiQuotaIndicator() {
+  const quota = useAiQuota()
+  if (!quota.show || quota.limit === null) return null
+
+  const { used, limit, remaining } = quota
+  const depleted = remaining !== null && remaining <= 0
+  const low = remaining !== null && remaining > 0 && remaining <= 1
+
+  return (
+    <span
+      className="text-muted-foreground ml-auto flex items-center gap-1 px-1 text-[11px] tabular-nums"
+      title={
+        depleted
+          ? "You've used all of today's AI messages. Resets tomorrow."
+          : `${remaining} of ${limit} daily AI messages left`
+      }
+    >
+      <span
+        className={cn(
+          'font-medium',
+          depleted
+            ? 'text-destructive'
+            : low
+              ? 'text-amber-600 dark:text-amber-500'
+              : 'text-foreground'
+        )}
+      >
+        {used}
+      </span>
+      <span>/{limit} today</span>
+    </span>
   )
 }

--- a/apps/dashboard/src/lib/ai/agent/use-ai-quota.ts
+++ b/apps/dashboard/src/lib/ai/agent/use-ai-quota.ts
@@ -1,0 +1,158 @@
+'use client'
+
+/**
+ * useAiQuota — client hook for the agent's daily AI-message allowance.
+ *
+ * Cloud (SaaS) only. Free-tier users get a small daily included-message quota
+ * (see `checkAiDailyLimit` in `lib/billing/entitlements.ts`); today that cap is
+ * only surfaced by a 402 mid-conversation, so a Free user has no forewarning of
+ * how many messages remain. This hook powers a subtle "X / N messages today"
+ * indicator in the agent chrome.
+ *
+ * Design:
+ * - Reads `GET /api/v1/billing/usage` (added by a sibling slice — B3). This hook
+ *   consumes it defensively: any error, absence, or malformed body resolves to
+ *   `show: false` so the indicator simply does not render. It never blocks or
+ *   degrades the agent, and it never throws.
+ * - OSS / self-hosted (not cloud mode) short-circuits to `show: false` and does
+ *   not even hit the endpoint — the daily meter is a Cloud concept.
+ * - Unlimited plans (Enterprise / BYOK, `limit == null`) also render nothing.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+
+import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
+import { apiFetch } from '@/lib/swr/api-fetch'
+
+export interface AiQuota {
+  /** Messages already sent today. */
+  used: number
+  /** Daily included-message cap, or null when the plan is unlimited. */
+  limit: number | null
+  /** Messages left before the cap, or null when unlimited. Never negative. */
+  remaining: number | null
+  /** True when the plan does not cap daily messages at all. */
+  unlimited: boolean
+}
+
+export interface UseAiQuotaResult extends AiQuota {
+  isLoading: boolean
+  error: Error | null
+  /**
+   * Whether the "X / N messages today" indicator should render at all. True only
+   * in cloud mode, when a bounded quota was resolved successfully. False on OSS,
+   * on any fetch/parse error, on absence of the endpoint, and for unlimited
+   * plans — so callers can `if (!quota.show) return null` unconditionally.
+   */
+  show: boolean
+}
+
+const HIDDEN: AiQuota = {
+  used: 0,
+  limit: null,
+  remaining: null,
+  unlimited: true,
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+/**
+ * Defensively extract the daily AI meter from the usage endpoint's response.
+ *
+ * The sibling slice owns the exact shape, so we accept a few plausible layouts:
+ * the meter fields at the top level of `data`, or nested under an `aiDaily` /
+ * `ai` key. Anything we cannot make sense of resolves to the hidden default.
+ */
+function parseQuota(payload: unknown): AiQuota {
+  if (!payload || typeof payload !== 'object') return HIDDEN
+
+  const root = payload as Record<string, unknown>
+  const candidates: unknown[] = [
+    root.data ?? root,
+    (root.data as Record<string, unknown> | undefined)?.aiDaily,
+    (root.data as Record<string, unknown> | undefined)?.ai,
+    root.aiDaily,
+    root.ai,
+  ]
+
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== 'object') continue
+    const meter = candidate as Record<string, unknown>
+    const used = toFiniteNumber(meter.used)
+    if (used === null) continue
+
+    const limit = toFiniteNumber(meter.limit)
+    const unlimited =
+      meter.unlimited === true || meter.limit === null || limit === null
+    if (unlimited)
+      return { used, limit: null, remaining: null, unlimited: true }
+
+    const remaining =
+      toFiniteNumber(meter.remaining) ?? Math.max(0, (limit ?? 0) - used)
+    return { used, limit, remaining, unlimited: false }
+  }
+
+  return HIDDEN
+}
+
+/**
+ * Reports the current user's daily AI-message allowance for the agent UI.
+ *
+ * Fails safe in every dimension: OSS builds and any endpoint error resolve to
+ * `show: false`, so the indicator is purely additive and can never break the
+ * agent.
+ */
+export function useAiQuota(): UseAiQuotaResult {
+  const cloud = isCloudModeClient()
+
+  const query = useQuery({
+    queryKey: ['billing', 'ai-usage'],
+    enabled: cloud,
+    staleTime: 30_000,
+    // Poll gently so the indicator ticks down as the user sends messages,
+    // without hammering the endpoint.
+    refetchInterval: 60_000,
+    refetchOnWindowFocus: true,
+    // The endpoint may not exist yet (sibling slice) or the session cookie may
+    // be briefly stale — do not spam retries; a single miss just hides it.
+    retry: 1,
+    queryFn: async (): Promise<AiQuota> => {
+      const res = await apiFetch('/api/v1/billing/usage')
+      if (!res.ok) throw new Error(`Usage request failed (${res.status})`)
+      const json = (await res.json().catch(() => null)) as unknown
+      // Envelope may report failure without an HTTP error status.
+      if (
+        json &&
+        typeof json === 'object' &&
+        'success' in json &&
+        (json as { success?: unknown }).success === false
+      ) {
+        throw new Error('Usage request unsuccessful')
+      }
+      return parseQuota(json)
+    },
+  })
+
+  const data = query.data ?? HIDDEN
+  const error = query.error instanceof Error ? query.error : null
+
+  const show =
+    cloud &&
+    !query.isLoading &&
+    error === null &&
+    query.data !== undefined &&
+    !data.unlimited &&
+    data.limit !== null
+
+  return {
+    used: data.used,
+    limit: data.limit,
+    remaining: data.remaining,
+    unlimited: data.unlimited,
+    isLoading: cloud && query.isLoading,
+    error,
+    show,
+  }
+}


### PR DESCRIPTION
Closes #2073

## Summary

The AI daily message cap was only surfaced via a 402 mid-conversation — a cloud Free user (5 msgs/day) had no forewarning of how many remained. This adds a subtle **"X / N messages today"** indicator to the agent chrome.

## Changes

- **New `lib/ai/agent/use-ai-quota.ts`** — a hook returning `{ used, limit, remaining, unlimited }` (+ `isLoading`, `error`, `show`). It reads `GET /api/v1/billing/usage` (added by sibling slice B3) via TanStack Query and parses the daily meter **defensively**, accepting a few plausible response shapes. It **fails safe** in every dimension:
  - OSS / self-hosted (`!isCloudModeClient()`) short-circuits — the endpoint is never even hit.
  - Any fetch error, endpoint absence, malformed body, or unlimited plan (`limit == null`) resolves to `show: false`.
- **`agent-settings-sidebar.tsx`** — adds a compact "Daily AI usage" section (progress bar + "N messages left today"), rendered only when `quota.show`. Amber near the cap, destructive when depleted.
- **`composer-toolbar.tsx`** — adds a subtle "X / N today" chip pinned to the end of the toolbar with a tooltip, same show-gating.

Cloud-only and additive: nothing renders on OSS, for unlimited plans, or when the usage endpoint is unavailable — so it can never break or degrade the agent. Does **not** create or edit the `/api/v1/billing/usage` endpoint (owned by B3).

## Verification

`bun run type-check` passes clean (0 errors) after generating the route tree. Biome formatting applied. Touched only the three files named in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb

---
_Generated by [Claude Code](https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb)_