### PR TITLE
feat(billing): enforce monthly AI USD budget and fix daily-usage accounting

### DIFF
--- a/apps/dashboard/src/lib/billing/ai-usage-store.ts
+++ b/apps/dashboard/src/lib/billing/ai-usage-store.ts
@@ -16,6 +16,11 @@ export function utcDayKey(now: Date = new Date()): string {
   return now.toISOString().slice(0, 10)
 }
 
+/** Returns the UTC month string 'YYYY-MM' for the given instant. */
+export function utcMonthKey(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 7)
+}
+
 function getDb() {
   return getPlatformBindings().getD1Database('CHM_CLOUD_D1')
 }
@@ -64,6 +69,153 @@ export async function incrementAiUsage(
            updated_at = excluded.updated_at`
       )
       .bind(ownerId, utcDayKey(now), updatedAt)
+      .run()
+  } catch {
+    // Swallow: a missing table or transient D1 error must not break the request.
+  }
+}
+
+/**
+ * Atomically reserve one AI request for `ownerId` today (UTC) and return the
+ * resulting post-increment count. The single INSERT … ON CONFLICT … RETURNING
+ * statement makes the read+increment atomic, closing the check-then-increment
+ * race where two concurrent requests could both pass the daily gate.
+ *
+ * Returns null when D1 is unavailable (local dev / self-host) so callers skip
+ * gating — the "self-hosted stays whole" invariant. A caller that finds the
+ * reservation exceeds the plan cap should immediately {@link releaseAiUsage} it.
+ */
+export async function reserveAiUsage(
+  ownerId: string,
+  now: Date = new Date()
+): Promise<number | null> {
+  const db = getDb()
+  if (!db) return null
+  try {
+    const updatedAt = Math.floor(now.getTime() / 1000)
+    const row = await db
+      .prepare(
+        `INSERT INTO ai_usage_daily (owner_id, day, count, updated_at)
+         VALUES (?1, ?2, 1, ?3)
+         ON CONFLICT(owner_id, day) DO UPDATE SET
+           count      = count + 1,
+           updated_at = excluded.updated_at
+         RETURNING count`
+      )
+      .bind(ownerId, utcDayKey(now), updatedAt)
+      .first<{ count: number }>()
+    return row?.count ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Release one previously reserved AI request for `ownerId` today (UTC). Used to
+ * roll back an over-limit reservation or a generation that failed before it
+ * started, so aborted requests never consume the user's quota. Never drops the
+ * counter below zero. No-op when D1 is unavailable.
+ */
+export async function releaseAiUsage(
+  ownerId: string,
+  now: Date = new Date()
+): Promise<void> {
+  const db = getDb()
+  if (!db) return
+  try {
+    const updatedAt = Math.floor(now.getTime() / 1000)
+    await db
+      .prepare(
+        `UPDATE ai_usage_daily
+            SET count      = MAX(0, count - 1),
+                updated_at = ?3
+          WHERE owner_id = ?1 AND day = ?2`
+      )
+      .bind(ownerId, utcDayKey(now), updatedAt)
+      .run()
+  } catch {
+    // Swallow: a rollback failure must not break the request.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Monthly LLM spend accumulator (per-owner USD, cloud SaaS only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Lazily ensure the monthly-spend table exists. Cached per worker instance so
+ * the DDL runs at most once. Mirrors the daily counter but keyed by UTC month
+ * and stores fractional USD (REAL). Kept in the store (not a migration) so this
+ * accumulator degrades gracefully everywhere the daily counter already does.
+ */
+let monthlyTableReady = false
+async function ensureMonthlyTable(
+  db: NonNullable<ReturnType<typeof getDb>>
+): Promise<void> {
+  if (monthlyTableReady) return
+  await db
+    .prepare(
+      `CREATE TABLE IF NOT EXISTS ai_usage_monthly (
+         owner_id   TEXT NOT NULL,
+         month      TEXT NOT NULL,
+         spent_usd  REAL NOT NULL DEFAULT 0,
+         updated_at INTEGER NOT NULL,
+         PRIMARY KEY (owner_id, month)
+       )`
+    )
+    .run()
+  monthlyTableReady = true
+}
+
+/**
+ * Return USD `ownerId` has spent on AI this month (UTC). Returns 0 when D1 is
+ * unavailable or no row exists yet, so OSS deployments are never gated.
+ */
+export async function getAiSpendThisMonth(
+  ownerId: string,
+  now: Date = new Date()
+): Promise<number> {
+  const db = getDb()
+  if (!db) return 0
+  try {
+    await ensureMonthlyTable(db)
+    const row = await db
+      .prepare(
+        `SELECT spent_usd FROM ai_usage_monthly WHERE owner_id = ?1 AND month = ?2`
+      )
+      .bind(ownerId, utcMonthKey(now))
+      .first<{ spent_usd: number }>()
+    return row?.spent_usd ?? 0
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Add `amountUsd` to `ownerId`'s monthly spend accumulator (UTC month). Fed by
+ * the already-computed `estimatedCostUsd` after a successful generation. Ignores
+ * non-positive / non-finite amounts. No-op when D1 is unavailable.
+ */
+export async function addAiSpend(
+  ownerId: string,
+  amountUsd: number,
+  now: Date = new Date()
+): Promise<void> {
+  if (!Number.isFinite(amountUsd) || amountUsd <= 0) return
+  const db = getDb()
+  if (!db) return
+  try {
+    await ensureMonthlyTable(db)
+    const updatedAt = Math.floor(now.getTime() / 1000)
+    await db
+      .prepare(
+        `INSERT INTO ai_usage_monthly (owner_id, month, spent_usd, updated_at)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(owner_id, month) DO UPDATE SET
+           spent_usd  = spent_usd + excluded.spent_usd,
+           updated_at = excluded.updated_at`
+      )
+      .bind(ownerId, utcMonthKey(now), amountUsd, updatedAt)
       .run()
   } catch {
     // Swallow: a missing table or transient D1 error must not break the request.

--- a/apps/dashboard/src/lib/billing/plan-enforcement.test.ts
+++ b/apps/dashboard/src/lib/billing/plan-enforcement.test.ts
@@ -1,4 +1,4 @@
-import { checkHostLimit } from './entitlements'
+import { checkAiBudget, checkHostLimit } from './entitlements'
 import {
   CAPABILITY_ENFORCEMENT,
   LIMIT_ENFORCEMENT,
@@ -37,6 +37,7 @@ describe('plan-enforcement — anti-drift coverage', () => {
       'alertRules',
       'retentionDays',
       'aiRequestsPerDay',
+      'aiMonthlyUsdBudget',
     ]
     for (const key of limitKeys) {
       expect(LIMIT_ENFORCEMENT[key]).toBeDefined()
@@ -61,12 +62,38 @@ describe('plan-enforcement — anti-drift coverage', () => {
     expect(LIMIT_ENFORCEMENT.hosts.status).toBe('enforced')
     expect(LIMIT_ENFORCEMENT.seats.status).toBe('enforced')
     expect(LIMIT_ENFORCEMENT.aiRequestsPerDay.status).toBe('enforced')
+    expect(LIMIT_ENFORCEMENT.aiMonthlyUsdBudget.status).toBe('enforced')
     expect(LIMIT_ENFORCEMENT.retentionDays.status).toBe('enforced')
     expect(LIMIT_ENFORCEMENT.alertRules.status).toBe('deferred')
   })
 
   test('api_mcp_access is the enforced capability gate', () => {
     expect(CAPABILITY_ENFORCEMENT.api_mcp_access.status).toBe('enforced')
+  })
+})
+
+describe('plan-enforcement — monthly AI USD budget really blocks', () => {
+  test('a bounded plan blocks once spend reaches the budget', () => {
+    const pro = BILLING_PLANS.pro
+    expect(pro.aiMonthlyUsdBudget).toBe(5)
+    // Under budget → allowed; at/over budget → denied.
+    expect(checkAiBudget(pro, 4.99).allowed).toBe(true)
+    expect(checkAiBudget(pro, 5).allowed).toBe(false)
+    expect(checkAiBudget(pro, 6).allowed).toBe(false)
+  })
+
+  test('the free plan enforces its small trial budget', () => {
+    const free = BILLING_PLANS.free
+    expect(free.aiMonthlyUsdBudget).toBe(0.5)
+    expect(checkAiBudget(free, 0).allowed).toBe(true)
+    expect(checkAiBudget(free, 0.5).allowed).toBe(false)
+  })
+
+  test('Enterprise (BYOK / unlimited budget) never blocks', () => {
+    const ent = BILLING_PLANS.enterprise
+    expect(ent.aiMonthlyUsdBudget).toBeNull()
+    expect(checkAiBudget(ent, 10_000).allowed).toBe(true)
+    expect(checkAiBudget(ent, 10_000).unlimited).toBe(true)
   })
 })
 

--- a/apps/dashboard/src/lib/billing/plan-enforcement.ts
+++ b/apps/dashboard/src/lib/billing/plan-enforcement.ts
@@ -67,6 +67,7 @@ export type LimitKey =
   | 'alertRules'
   | 'retentionDays'
   | 'aiRequestsPerDay'
+  | 'aiMonthlyUsdBudget'
 
 /**
  * Enforcement status for each numeric limit. Only the host cap is wired today.
@@ -90,6 +91,10 @@ export const LIMIT_ENFORCEMENT: Record<LimitKey, Enforcement> = {
   },
   aiRequestsPerDay: {
     status: 'enforced',
-    gate: 'routes/api/v1/agent.ts handlePost → checkAiDailyLimit (counter: lib/billing/ai-usage-store.ts / ai_usage_daily)',
+    gate: 'routes/api/v1/agent.ts handlePost → checkAiDailyLimit (atomic reserve/release: lib/billing/ai-usage-store.ts / ai_usage_daily)',
+  },
+  aiMonthlyUsdBudget: {
+    status: 'enforced',
+    gate: 'routes/api/v1/agent.ts handlePost → checkAiBudget (spend accumulator: lib/billing/ai-usage-store.ts / ai_usage_monthly, fed by estimatedCostUsd)',
   },
 }

--- a/apps/dashboard/src/routes/api/v1/agent.ts
+++ b/apps/dashboard/src/routes/api/v1/agent.ts
@@ -63,9 +63,18 @@ import {
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { authorizeAgentApiRequest } from '@/lib/auth/agent-api-auth'
 import { isClerkAuthProvider } from '@/lib/auth/provider'
-import { getAiUsageToday, incrementAiUsage } from '@/lib/billing/ai-usage-store'
+import {
+  addAiSpend,
+  getAiSpendThisMonth,
+  releaseAiUsage,
+  reserveAiUsage,
+} from '@/lib/billing/ai-usage-store'
 import { resolveBillingOwner } from '@/lib/billing/billing-owner'
-import { checkAiDailyLimit, limitMessage } from '@/lib/billing/entitlements'
+import {
+  checkAiBudget,
+  checkAiDailyLimit,
+  limitMessage,
+} from '@/lib/billing/entitlements'
 import { getPlanForOwner } from '@/lib/billing/user-subscription'
 import { ACTIONS_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
 import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
@@ -529,32 +538,71 @@ async function handlePost(request: Request): Promise<Response> {
     )
   }
 
-  // AI daily limit enforcement (cloud only).
+  // AI usage enforcement (cloud only): daily message meter + monthly USD budget.
   // resolveBillingOwner() throws when Clerk is not configured (self-hosted),
   // so the entire block is wrapped in try/catch — OSS deployments skip silently.
+  //
+  // billingOwnerId / reservedDailyUsage are hoisted so the stream can (a) charge
+  // the monthly spend accumulator with the actual estimatedCostUsd once the
+  // generation succeeds, and (b) roll back the daily reservation if generation
+  // fails before it produces any output.
+  let billingOwnerId: string | null = null
+  let reservedDailyUsage = false
   try {
     const owner = await resolveBillingOwner()
     const plan = await getPlanForOwner(owner.id)
-    if (plan.aiRequestsPerDay != null) {
-      const used = await getAiUsageToday(owner.id)
-      const check = checkAiDailyLimit(plan, used)
-      if (!check.allowed) {
+    billingOwnerId = owner.id
+
+    // Monthly LLM spend budget — hard cap (null = Enterprise BYOK / unlimited).
+    if (plan.aiMonthlyUsdBudget != null) {
+      const spentUsd = await getAiSpendThisMonth(owner.id)
+      const budget = checkAiBudget(plan, spentUsd)
+      if (!budget.allowed) {
         return new Response(
           JSON.stringify({
-            error: limitMessage(check),
+            error: limitMessage(budget),
             details: {
-              planId: check.planId,
-              limit: check.limit ?? plan.aiRequestsPerDay,
-              reason: check.reason,
+              planId: budget.planId,
+              limit: budget.limit ?? plan.aiMonthlyUsdBudget,
+              reason: budget.reason,
             },
           }),
           { status: 402, headers: { 'content-type': 'application/json' } }
         )
       }
-      await incrementAiUsage(owner.id)
+    }
+
+    // Daily message meter — reserve one slot atomically, then decide. The
+    // reservation (post-increment count) is rolled back below if it exceeds the
+    // hard cap, and again in the stream if generation fails before starting.
+    if (plan.aiRequestsPerDay != null) {
+      const reservedCount = await reserveAiUsage(owner.id)
+      if (reservedCount != null) {
+        reservedDailyUsage = true
+        // reservedCount is the count *after* this reservation; usage before this
+        // request is reservedCount - 1.
+        const check = checkAiDailyLimit(plan, reservedCount - 1)
+        if (!check.allowed) {
+          await releaseAiUsage(owner.id)
+          reservedDailyUsage = false
+          return new Response(
+            JSON.stringify({
+              error: limitMessage(check),
+              details: {
+                planId: check.planId,
+                limit: check.limit ?? plan.aiRequestsPerDay,
+                reason: check.reason,
+              },
+            }),
+            { status: 402, headers: { 'content-type': 'application/json' } }
+          )
+        }
+      }
     }
   } catch {
     // Not cloud / no Clerk owner → skip enforcement; self-hosted stays whole.
+    billingOwnerId = null
+    reservedDailyUsage = false
   }
 
   const requestOrigin = request.headers.get('origin') ?? undefined
@@ -723,6 +771,12 @@ async function handlePost(request: Request): Promise<Response> {
             type: 'data-usage',
             data: [stats],
           })
+
+          // Charge the monthly USD budget with the actual spend now that the
+          // generation succeeded (cloud only; no-op when D1/owner absent).
+          if (billingOwnerId && stats.estimatedCostUsd) {
+            await addAiSpend(billingOwnerId, stats.estimatedCostUsd)
+          }
         }
       } catch (error) {
         const classified = classifyError(error, {
@@ -735,17 +789,25 @@ async function handlePost(request: Request): Promise<Response> {
           data: [classified],
         })
         if (usageSteps.length > 0) {
+          const stats = {
+            ...aggregateUsageWithCost(usageSteps, model),
+            model,
+            provider: requestedProvider,
+            resolvedModel: lastStepModelId || model,
+          }
           writer.write({
             type: 'data-usage',
-            data: [
-              {
-                ...aggregateUsageWithCost(usageSteps, model),
-                model,
-                provider: requestedProvider,
-                resolvedModel: lastStepModelId || model,
-              },
-            ],
+            data: [stats],
           })
+          // Generation started and incurred cost before failing — still charge
+          // the monthly budget for what was actually spent.
+          if (billingOwnerId && stats.estimatedCostUsd) {
+            await addAiSpend(billingOwnerId, stats.estimatedCostUsd)
+          }
+        } else if (billingOwnerId && reservedDailyUsage) {
+          // Generation failed before producing any output — release the daily
+          // reservation so aborted requests don't consume the user's quota.
+          await releaseAiUsage(billingOwnerId)
         }
       }
     },


### PR DESCRIPTION
Closes #2071

## Problem

`checkAiBudget` had zero call sites, `aiMonthlyUsdBudget` was missing from the enforcement `LimitKey`, and there was no USD-spend accumulator. AI daily usage was check-then-increment (non-atomic, TOCTOU race) and incremented *before* streaming, so failed/aborted generations still consumed quota.

## Fix

- **`plan-enforcement.ts` (+test):** add `aiMonthlyUsdBudget` to the `LimitKey` union and `LIMIT_ENFORCEMENT` registry (marked `enforced` with its gate). Extend the anti-drift test's `limitKeys`/assertions and add a `checkAiBudget` block (bounded plan blocks at budget, free enforces its trial budget, Enterprise BYOK/unlimited never blocks).
- **`ai-usage-store.ts`:** add `reserveAiUsage` (atomic `INSERT … ON CONFLICT … RETURNING` — closes the read/increment race) and `releaseAiUsage` (roll back an over-limit reservation or a generation that never started). Add a per-owner monthly USD accumulator (`ai_usage_monthly`, lazily created) with `getAiSpendThisMonth` / `addAiSpend`, fed by the already-computed `estimatedCostUsd`.
- **`routes/api/v1/agent.ts`:** pre-check `checkAiBudget` alongside the daily check; reserve the daily slot atomically and roll it back when over the cap or when generation fails before producing output; charge the monthly budget with the real spend once generation succeeds.

OSS/self-hosted stays a **no-op**: enforcement is skipped when Clerk owner resolution throws, and the store degrades to safe defaults (0 / no-op) when D1 is absent.

## Verify

- `bun run type-check` — no new errors in touched files (pre-existing `createFileRoute` route-tree errors affect every route file because `routeTree.gen.ts` is generated at build time).
- `bun test src/lib/billing` — **87 pass, 0 fail**.

## Notes / deviation

Per the issue's file list, the monthly accumulator table (`ai_usage_monthly`) is created lazily inside the store (cached per worker instance via `CREATE TABLE IF NOT EXISTS`) rather than via a new migration file, so the change stays within the four listed files and degrades gracefully everywhere the daily counter already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb

---
_Generated by [Claude Code](https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb)_