### PR TITLE
fix(security): gate anonymous writes on settings + insights generate

### DIFF
--- a/apps/dashboard/src/routes/api/v1/dashboard/settings.ts
+++ b/apps/dashboard/src/routes/api/v1/dashboard/settings.ts
@@ -14,6 +14,7 @@ import { debug, error } from '@chm/logger'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { ApiErrorType } from '@/lib/api/types'
 import { DASHBOARD_SETTINGS_TABLE } from '@/lib/app-tables'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 
 const TABLE_SETTINGS = DASHBOARD_SETTINGS_TABLE
 
@@ -161,6 +162,24 @@ export const Route = createFileRoute('/api/v1/dashboard/settings')({
 
       POST: async ({ request }) => {
         bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        // Write gate: this POST runs `ALTER TABLE ... UPDATE`, a cluster
+        // mutation. The global /api/v1 middleware is a public passthrough
+        // under provider='none' / CHM_CLERK_PUBLIC_READ, so this route must
+        // self-enforce that anonymous callers cannot mutate settings. A valid
+        // `chm_` API key still authenticates programmatic clients. Mirrors the
+        // /api/v1/actions guard.
+        const permissionResponse = await authorizeFeatureRequest(
+          {
+            feature: 'settings',
+            defaultAccess: 'authenticated',
+            operation: 'write',
+          },
+          request,
+          { allowAgentBearerToken: true }
+        )
+        if (permissionResponse) return permissionResponse
+
         debug('[POST /api/v1/dashboard/settings] Updating settings')
 
         try {

--- a/apps/dashboard/src/routes/api/v1/insights/generate.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/generate.ts
@@ -22,6 +22,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { env } from 'cloudflare:workers'
 import { error, generateRequestId } from '@chm/logger'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 import { generateInsights } from '@/lib/insights/generate-insights'
 import { isInsightPromptStyle } from '@/lib/insights/prompts'
 import { resolveInsightModel } from '@/lib/insights/resolve-model'
@@ -29,6 +30,18 @@ import { resolveInsightModel } from '@/lib/insights/resolve-model'
 async function handlePost(request: Request): Promise<Response> {
   bridgeClickHouseEnv(env as Record<string, string | undefined>)
   const requestId = generateRequestId()
+
+  // Write gate: this POST runs the expensive collect → LLM enrich → persist
+  // pipeline. The global /api/v1 middleware is a public passthrough under
+  // provider='none' / CHM_CLERK_PUBLIC_READ, so this route must self-enforce
+  // that anonymous callers cannot trigger it. A valid `chm_` API key still
+  // authenticates programmatic clients. Mirrors the /api/v1/actions guard.
+  const permissionResponse = await authorizeFeatureRequest(
+    { feature: 'insights', defaultAccess: 'authenticated', operation: 'write' },
+    request,
+    { allowAgentBearerToken: true }
+  )
+  if (permissionResponse) return permissionResponse
 
   try {
     const searchParams = new URL(request.url).searchParams


### PR DESCRIPTION
Part of #2095 (SEC-A).

## Problem

In cloud mode (Clerk + `CHM_CLERK_PUBLIC_READ=true`) the `/api/v1/*` middleware lets anonymous requests through, so each **write** route must self-enforce authorization. Two POST handlers did not:

- `apps/dashboard/src/routes/api/v1/dashboard/settings.ts` — POST runs `ALTER TABLE … UPDATE` with no auth check (anonymous mutation of dashboard settings).
- `apps/dashboard/src/routes/api/v1/insights/generate.ts` — POST runs the expensive collect → LLM enrich → persist pipeline with no auth check (anonymous can trigger costly LLM work).

## Fix

Add a WRITE-scoped `authorizeFeatureRequest(...)` at the very top of each POST handler, **before any mutation/LLM work**, mirroring the existing guard in `apps/dashboard/src/routes/api/v1/actions.ts`:

- `settings` → `{ feature: 'settings', defaultAccess: 'authenticated', operation: 'write' }`
- `insights/generate` → `{ feature: 'insights', defaultAccess: 'authenticated', operation: 'write' }`

Both pass `{ allowAgentBearerToken: true }` (matching `actions.ts`) so a valid `chm_` API key still authenticates programmatic clients. Anonymous callers now receive `401` (or `404` when the feature is disabled); auth-disabled (`provider='none'`) deployments are unaffected since that mode authorizes everyone.

Only these two files are touched.

## Verify

`cd apps/dashboard && bun run type-check` → passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb

---
_Generated by [Claude Code](https://claude.ai/code/session_0181aiFr4G2boSNyUHoQPPSb)_