### PR TITLE
docs(advanced): rewrite permissions/hosts/editions/name pages

### DIFF
--- a/docs/content/operate/advanced/agent-conversation-storage.mdx
+++ b/docs/content/operate/advanced/agent-conversation-storage.mdx
@@ -1,13 +1,18 @@
 ---
+title: Agent Conversation Storage
 description: Conversation history persistence has moved — find backend setup, env vars, and store selection on the dedicated AI agent pages.
 icon: Database
 ---
 
-# Agent Conversation Storage
+This page has moved. Conversation history persistence is now documented on the dedicated AI agent pages.
 
-This page has moved. See the new dedicated pages:
+<Callout type="info" title="Content relocated">
+Backend-specific env vars, auto-selection order, Cloudflare setup commands, and Postgres connection strings are now fully covered on the two pages linked below.
+</Callout>
 
-- [Conversation History](/guide/ai-agent/conversation-history) — how history works, the persistence model, and how to enable server-side storage
-- [Store Backends](/guide/ai-agent/conversation-history/backends) — per-backend setup for AgentState, Cloudflare D1, Durable Object, ClickHouse, Postgres, memory, and localStorage
+## Related
 
-The content previously on this page (backend-specific env vars, auto-selection order, Cloudflare setup commands, Postgres connection strings) is now fully covered in those two pages.
+<Cards>
+  <Card title="Conversation History" href="/guide/ai-agent/conversation-history" description="How history works, the persistence model, and how to enable server-side storage." />
+  <Card title="Store Backends" href="/guide/ai-agent/conversation-history/backends" description="Per-backend setup for AgentState, Cloudflare D1, Durable Object, ClickHouse, Postgres, memory, and localStorage." />
+</Cards>

--- a/docs/content/operate/advanced/custom-name.mdx
+++ b/docs/content/operate/advanced/custom-name.mdx
@@ -1,31 +1,26 @@
 ---
+title: Custom Name
 description: Set CLICKHOUSE_NAME to give each monitored host a human-readable label in the dashboard host selector dropdown.
 icon: Tag
 ---
 
-# Custom Name
-
 Set `CLICKHOUSE_NAME` to give each ClickHouse host a human-readable label. The label appears in the host selector dropdown in the dashboard header.
 
----
+## Configure
 
-## Configuration
+Provide one comma-separated label per host. Position N in `CLICKHOUSE_NAME` labels host index N, so the number of values must match `CLICKHOUSE_HOST`.
 
 ```bash
 CLICKHOUSE_HOST=http://ch-1:8123,http://ch-2:8123,http://ch-3:8123
 CLICKHOUSE_NAME=Production,Staging,Dev
 ```
 
-The number of comma-separated values must match `CLICKHOUSE_HOST`. Position N in `CLICKHOUSE_NAME` labels host index N.
-
 <Callout type="info">
 If `CLICKHOUSE_NAME` is not set, hosts are labeled by index: **Host 0**, **Host 1**, etc.
 </Callout>
 
----
-
-## Docker
-
+<Tabs items={['Docker', 'Kubernetes / Helm']}>
+<Tab value="Docker">
 ```bash
 docker run -d \
   -e CLICKHOUSE_HOST='http://ch-1:8123,http://ch-2:8123' \
@@ -35,11 +30,8 @@ docker run -d \
   -p 3000:3000 \
   ghcr.io/chmonitor/chmonitor:vX.Y.Z
 ```
-
----
-
-## Kubernetes / Helm
-
+</Tab>
+<Tab value="Kubernetes / Helm">
 ```yaml
 env:
   - name: CLICKHOUSE_HOST
@@ -47,5 +39,12 @@ env:
   - name: CLICKHOUSE_NAME
     value: "Production,Staging"
 ```
+</Tab>
+</Tabs>
 
-See [Multiple Hosts](/operate/advanced/multiple-hosts) for full multi-host setup.
+## Related
+
+<Cards>
+  <Card title="Multiple Hosts" href="/operate/advanced/multiple-hosts" description="Full multi-host setup with the host selector and per-host credentials." />
+  <Card title="Environment Variables" href="/reference/environment-variables" description="Full reference for all connection variables." />
+</Cards>

--- a/docs/content/operate/advanced/editions.mdx
+++ b/docs/content/operate/advanced/editions.mdx
@@ -1,19 +1,16 @@
 ---
+title: Editions
 description: GPL-3.0 community build plus planned Team and Enterprise tiers — understand what each edition includes and how the edition flag works.
 icon: Layers
 ---
-
-# Editions
 
 chmonitor is **GPL-3.0 and free forever** for a single operator monitoring their own ClickHouse cluster. Nothing is crippled, nag-screened, or artificially limited in the community build.
 
 The edition system exists to gate features that only matter at team or enterprise scale — features that do not exist yet in the OSS build. A misconfigured or absent edition flag never locks a self-hoster out; the system always fails open to community.
 
----
-
 ## How the edition is selected
 
-The edition is resolved at runtime from one of two variables, checked in order:
+The edition is resolved at runtime from one of two variables, checked in order.
 
 | Variable | Where it applies | When to use |
 |---|---|---|
@@ -25,8 +22,6 @@ Valid values: `community` (default) or `enterprise`. Any other value — includi
 <Callout type="info" title="Fail-open guarantee">
 If `CHM_EDITION` is missing or unrecognised, the edition is `community` and all community features remain fully accessible.
 </Callout>
-
----
 
 ## Feature availability
 
@@ -49,25 +44,19 @@ The table below maps STRATEGY §7 capabilities to edition. "Planned" means the f
 
 STRATEGY §7 defines the product intent. The "scaffold" rows reflect code that exists in the repository (`lib/auth/sso`, `lib/rbac`) but is behind an edition gate and not yet functional in any build.
 
----
-
 ## Enterprise feature gate
 
 The `isEnabled(feature)` function in `lib/edition/` is the only gate used throughout the codebase. Enterprise features currently gated:
 
-```
+```text
 alerting  ·  sso  ·  rbac  ·  fleet  ·  cloud
 ```
 
 Community edition returns `false` for each of these. This does not degrade any community functionality — these features simply do not exist in the OSS build.
 
----
-
 ## Code isolation
 
 Enterprise-only code is isolated so the GPL core never depends on it. The planned boundary is a separate `packages/enterprise/` package that the community build does not import. Today's scaffolds (`lib/auth/sso`, `lib/rbac`) follow the same pattern: they are guarded by `isEnabled()` checks and are inert in community builds.
-
----
 
 ## Summary
 
@@ -80,10 +69,10 @@ Enterprise-only code is isolated so the GPL core never depends on it. The planne
 An unset or wrong `CHM_EDITION` always falls back to community.
 </Callout>
 
----
-
 ## Related
 
-- [Environment Variables](/reference/environment-variables) — full reference for all configuration variables.
-- [Feature Permissions](/operate/advanced/feature-permissions) — per-feature access control within an edition.
-- [Telemetry](/operate/advanced/telemetry) — opt-in, privacy-first usage metrics (off by default).
+<Cards>
+  <Card title="Environment Variables" href="/reference/environment-variables" description="Full reference for all configuration variables." />
+  <Card title="Feature Permissions" href="/operate/advanced/feature-permissions" description="Per-feature access control within an edition." />
+  <Card title="Telemetry" href="/operate/advanced/telemetry" description="Opt-in, privacy-first usage metrics (off by default)." />
+</Cards>

--- a/docs/content/operate/advanced/feature-permissions.mdx
+++ b/docs/content/operate/advanced/feature-permissions.mdx
@@ -1,15 +1,12 @@
 ---
+title: Feature Permissions
 description: Hide or protect specific dashboard sections per-feature using config files or environment variables, without changing application code.
 icon: Lock
 ---
 
-# Feature Permissions
-
 Feature permissions let you hide or protect specific dashboard sections without changing application code. Features are enabled and public by default — except the **AI agent** (`agent`) and **control actions** (`actions`), which default to `authenticated`. Configure only what needs different behavior.
 
 Permissions also carry a **read / write** classification. Reads are predefined monitoring data; writes are the AI agent, control actions, and arbitrary SQL execution. Under `auth=clerk` with [`CHM_CLERK_PUBLIC_READ`](/operate/authentication/clerk#public-read-only-mode), anonymous visitors may perform reads but never writes; with `auth=none` everyone may do both.
-
----
 
 ## Defaults
 
@@ -19,8 +16,6 @@ access  = "public"   (alias: "guest")
 ```
 
 A self-hosted deployment with no auth configured works out of the box. Every page is visible to any visitor.
-
----
 
 ## Access values
 
@@ -34,22 +29,18 @@ A self-hosted deployment with no auth configured works out of the box. Every pag
 v1 has no roles — only public and authenticated access levels.
 </Callout>
 
----
+## Configure
 
-## Configuration sources
+Configuration is layered. Later sources win over earlier ones:
 
-Later sources win over earlier ones:
-
-```
+```text
 built-in allow-all defaults
   → TypeScript config defaults
     → CHM_CONFIG_FILE (TOML or YAML)
       → environment variables
 ```
 
----
-
-## Config file (`CHM_CONFIG_FILE`)
+### Config file (`CHM_CONFIG_FILE`)
 
 Point `CHM_CONFIG_FILE` at a TOML or YAML file. Feature names are lowercase in the file.
 
@@ -87,9 +78,7 @@ features:
 </Tab>
 </Tabs>
 
----
-
-## Environment variable overrides
+### Environment variable overrides
 
 Env vars override the config file. Feature ids are uppercase in env var names.
 
@@ -105,8 +94,6 @@ CHM_FEATURE_AGENT_ACCESS=authenticated
 CHM_FEATURE_METRICS_ENABLED=false
 CHM_FEATURE_SETTINGS_ACCESS=authenticated
 ```
-
----
 
 ## Supported feature ids
 
@@ -133,12 +120,10 @@ Use these ids in TOML/YAML (lowercase) or env vars (uppercase):
 | `peerdb` | PeerDB Mirrors and Peers section |
 | `actions` | Row-level actions across data pages |
 
----
-
 ## Docker examples
 
-**With config file:**
-
+<Tabs items={['With config file', 'Env-only']}>
+<Tab value="With config file">
 ```bash
 docker run -d \
   -e CLICKHOUSE_HOST='http://clickhouse:8123' \
@@ -149,9 +134,8 @@ docker run -d \
   -p 3000:3000 \
   ghcr.io/chmonitor/chmonitor:vX.Y.Z
 ```
-
-**Env-only:**
-
+</Tab>
+<Tab value="Env-only">
 ```bash
 docker run -d \
   -e CLICKHOUSE_HOST='http://clickhouse:8123' \
@@ -162,15 +146,15 @@ docker run -d \
   -p 3000:3000 \
   ghcr.io/chmonitor/chmonitor:vX.Y.Z
 ```
-
----
+</Tab>
+</Tabs>
 
 ## Authentication for `authenticated` features
 
 Gating UI features with `access = "authenticated"` requires a user auth provider (for example, Clerk). Set one of:
 
-**Clerk:**
-
+<Tabs items={['Clerk', 'Agent API token']}>
+<Tab value="Clerk">
 ```bash
 CHM_AUTH_PROVIDER=clerk
 CHM_CLERK_PUBLISHABLE_KEY=pk_live_your_key
@@ -180,8 +164,9 @@ CLERK_SECRET_KEY=sk_live_your_key
 <Callout type="warn" title="Build-time vars">
 `VITE_*` vars are build-time inlined — set them before running `bun run build`. See [Migrate to v0.3](/reference/migrating/v0-3) if you are upgrading from the legacy Next.js app and need the old `NEXT_PUBLIC_*` names.
 </Callout>
-
-**Agent API token (agent API endpoints only — does not provide UI-level user authentication):**
+</Tab>
+<Tab value="Agent API token">
+Applies to agent API endpoints only — it does not provide UI-level user authentication.
 
 ```bash
 AGENT_API_TOKEN=your-shared-token
@@ -192,53 +177,50 @@ AGENT_API_TOKEN=your-shared-token
 curl -H "Authorization: Bearer your-shared-token" \
   https://your-deployment.example.com/api/v1/agent
 ```
+</Tab>
+</Tabs>
 
 See [Authentication](/operate/authentication) for the full auth model, including API keys and reverse-proxy options.
 
----
-
 ## Common policies
 
-**Gate AI agent behind login, keep everything else open:**
-
+<Accordions>
+<Accordion title="Gate AI agent behind login, keep everything else open">
 ```toml
 [features.agent]
 access = "authenticated"
 ```
-
-**Hide metrics completely:**
-
+</Accordion>
+<Accordion title="Hide metrics completely">
 ```toml
 [features.metrics]
 enabled = false
 ```
-
-**Require login for settings:**
-
+</Accordion>
+<Accordion title="Require login for settings">
 ```toml
 [features.settings]
 access = "authenticated"
 ```
-
-**Multiple env-var approach (no config file needed):**
-
+</Accordion>
+<Accordion title="Multiple env-var approach (no config file needed)">
 ```bash
 CHM_FEATURE_AGENT_ACCESS=authenticated
 CHM_FEATURE_SETTINGS_ACCESS=authenticated
 CHM_DISABLED_FEATURES=insights
 ```
-
----
+</Accordion>
+</Accordions>
 
 ## Behavior when a feature is disabled or gated
 
 - **Disabled** (`enabled = false`): removed from navigation and command search. Direct page visits show a disabled screen. API routes return a blocked response before querying ClickHouse or the agent.
 - **Authenticated** (`access = "authenticated"`): unauthenticated visitors see the feature in navigation (so they know to sign in) but cannot load data. API routes reject unauthenticated requests.
 
----
-
 ## Related
 
-- [Authentication](/operate/authentication) — auth providers and API keys.
-- [Environment Variables — Feature Permissions](/reference/environment-variables#feature-permissions) — full env var reference.
-- [Features](/guide/features) — what each feature does.
+<Cards>
+  <Card title="Authentication" href="/operate/authentication" description="Auth providers and API keys." />
+  <Card title="Environment Variables — Feature Permissions" href="/reference/environment-variables#feature-permissions" description="Full env var reference." />
+  <Card title="Features" href="/guide/features" description="What each feature does." />
+</Cards>

--- a/docs/content/operate/advanced/multiple-hosts.mdx
+++ b/docs/content/operate/advanced/multiple-hosts.mdx
@@ -1,17 +1,14 @@
 ---
+title: Multiple Hosts
 description: Monitor multiple ClickHouse clusters from a single deployment using comma-separated connection variables and the host selector.
 icon: Server
 ---
 
-# Multiple Hosts
-
-chmonitor can monitor multiple ClickHouse clusters from a single deployment. The host selector in the dashboard header lets you switch between them. The URL reflects the active host as `?host=N`.
-
----
+chmonitor can monitor multiple ClickHouse clusters from a single deployment. The host selector in the dashboard header lets you switch between them, and the URL reflects the active host as `?host=N`.
 
 ## How it works
 
-Set `CLICKHOUSE_HOST` to a comma-separated list of host URLs. Position N across all four connection variables maps to host index N:
+Set `CLICKHOUSE_HOST` to a comma-separated list of host URLs. Position N across all four connection variables maps to host index N.
 
 | Variable | Example |
 |---|---|
@@ -35,10 +32,12 @@ The URL parameter `?host=0` targets the first host, `?host=1` the second, and so
     R -->|hostId=1| CH2[ClickHouse ch-2]
   end`} />
 
----
+## Configure
 
-## Same credentials for all hosts
+Choose the credential strategy that matches your clusters.
 
+<Tabs items={['Same credentials', 'Different credentials']}>
+<Tab value="Same credentials">
 If all hosts share the same user and password, set a single value:
 
 ```bash
@@ -47,11 +46,8 @@ CLICKHOUSE_NAME=ch-1,ch-2
 CLICKHOUSE_USER=default
 CLICKHOUSE_PASSWORD=
 ```
-
----
-
-## Different credentials per host
-
+</Tab>
+<Tab value="Different credentials">
 Set a value per position:
 
 ```bash
@@ -60,10 +56,10 @@ CLICKHOUSE_NAME=Production,Staging
 CLICKHOUSE_USER=prod_user,staging_user
 CLICKHOUSE_PASSWORD=prod_pass,staging_pass
 ```
+</Tab>
+</Tabs>
 
----
-
-## Docker examples
+### Docker
 
 Replace `vX.Y.Z` with the release tag you want to run.
 
@@ -94,9 +90,7 @@ docker run -d \
 </Tab>
 </Tabs>
 
----
-
-## Kubernetes / Helm examples
+### Kubernetes / Helm
 
 <Tabs items={['Same credentials', 'Different credentials']}>
 <Tab value="Same credentials">
@@ -136,14 +130,15 @@ helm repo add chmonitor https://charts.chmonitor.dev
 helm upgrade --install chmonitor chmonitor/chmonitor -f values.yaml
 ```
 
----
-
-## Notes
-
-<Callout type="info">
+<Callout type="info" title="Notes">
 - Adding or removing a host requires a restart (env change).
 - Health alerts run over all configured hosts when `HEALTH_ALERT_ENABLED=true`.
 - The agent API accepts a `hostId` parameter to target a specific host.
 </Callout>
 
-See [Custom Name](/operate/advanced/custom-name) for display labels, and [Environment Variables](/reference/environment-variables) for the full connection reference.
+## Related
+
+<Cards>
+  <Card title="Custom Name" href="/operate/advanced/custom-name" description="Give each host a human-readable display label." />
+  <Card title="Environment Variables" href="/reference/environment-variables" description="Full connection variable reference." />
+</Cards>


### PR DESCRIPTION
## Summary

Full prose rewrite of the **Advanced A** docs unit (5 files) for one consistent Fumadocs voice and the shared page skeleton, with richer interactive components. Every technical fact (env vars, flags, edition names, feature ids) is preserved verbatim. No page added, removed, or renamed.

## Files

- `operate/advanced/feature-permissions.mdx` — `## Configure` section; `<Tabs>` for config sources / Docker / auth providers; `<Accordions>` for common policies; `<Cards>` Related block.
- `operate/advanced/multiple-hosts.mdx` — `## Configure` with credential `<Tabs>`; Docker/K8s tabs; Mermaid preserved.
- `operate/advanced/editions.mdx` — sentence-case headings; code-fenced gate list; `<Cards>` Related.
- `operate/advanced/custom-name.mdx` — `## Configure` + Docker/K8s tabs.
- `operate/advanced/agent-conversation-storage.mdx` — trimmed stub with frontmatter + `<Cards>` Related redirect.

## Verification

- Frontmatter uses `title` + `description` + `icon`; body starts at `##` (h1 stripped by sync).
- No component imports; all internal links root-based; every `<Card>` has a description; every page ends with `## Related`.
- Fact-preservation check: zero env vars / flags / edition names dropped across all 5 files.
- E2E: `bun run sync` + `bunx fumadocs-mdx` both exit 0.

Co-Authored-By: duyetbot <bot@duyet.net>