### PR TITLE
docs(features): rewrite core feature pages for consistent voice and richer UI

### DIFF
--- a/docs/content/guide/features.mdx
+++ b/docs/content/guide/features.mdx
@@ -1,17 +1,16 @@
 ---
-description: chmonitor features — query monitoring, table storage, cluster health, metrics, and AI-powered insights organized by operational question.
+description: Explore every chmonitor feature — query monitoring, storage, cluster health, metrics, and AI insights — with per-feature access control.
 icon: LayoutGrid
+title: Features
 ---
 
-# Features
-
-chmonitor is organized around the operational questions you answer while running a ClickHouse cluster. Each feature maps to one or more routes in the UI and a feature id you can use to control access or disable it.
+chmonitor is organized around the operational questions you answer while running a ClickHouse cluster. Each feature maps to one or more UI routes and a feature id you use to control access or disable it.
 
 <Callout type="info" title="All features are public and enabled by default">
-You only configure what you want to restrict or turn off. The only exceptions are the AI agent (`agent`) and control actions (`actions`), which default to `authenticated` access.
+You only configure what you want to restrict or turn off. The exceptions are the AI agent (`agent`) and control actions (`actions`), which default to `authenticated` access.
 </Callout>
 
-## Feature overview
+## Feature pages
 
 <Cards>
   <Card
@@ -20,32 +19,32 @@ You only configure what you want to restrict or turn off. The only exceptions ar
     description="Cluster health at a glance — active queries, memory, disk, and CPU."
   />
   <Card
-    title="Query Monitoring"
+    title="Query monitoring"
     href="/guide/features/queries"
     description="Live, historical, failed, slow, and expensive query analysis."
   />
   <Card
-    title="Tables & Storage"
+    title="Tables & storage"
     href="/guide/features/tables"
-    description="Table sizes, disk usage, parts, and storage breakdown."
+    description="Table sizes, disk usage, parts, replication, and storage breakdown."
   />
   <Card
-    title="Data Explorer"
+    title="Data explorer"
     href="/guide/features/explorer"
     description="Browse column definitions, dependencies, and projections for any table."
   />
   <Card
-    title="Merges & Operations"
+    title="Merges & operations"
     href="/guide/features/operations"
     description="Active merges, mutations, and background operation throughput."
   />
   <Card
-    title="Clusters & Replication"
+    title="Clusters & replication"
     href="/guide/features/cluster"
     description="Replication lag, queue size, and replica health across hosts."
   />
   <Card
-    title="Metrics & Profiler"
+    title="Metrics & profiler"
     href="/guide/features/metrics"
     description="Server CPU, memory, IO metrics and ClickHouse profiling data."
   />
@@ -55,12 +54,12 @@ You only configure what you want to restrict or turn off. The only exceptions ar
     description="AI-surfaced anomalies, performance patterns, and observations."
   />
   <Card
-    title="Health & Alerting"
+    title="Health & alerting"
     href="/guide/features/health"
     description="Active alerts from the health sweep cron with severity thresholds."
   />
   <Card
-    title="Security & Audit"
+    title="Security & audit"
     href="/guide/features/security"
     description="Who is accessing ClickHouse, with what grants, and how often."
   />
@@ -70,13 +69,20 @@ You only configure what you want to restrict or turn off. The only exceptions ar
     description="Server log entries from system.text_log and related tables."
   />
   <Card
-    title="MCP Server"
+    title="Dashboard"
+    href="/guide/features/dashboard"
+    description="Build a custom view by combining any built-in charts on one canvas."
+  />
+  <Card
+    title="MCP server"
     href="/guide/features/mcp"
     description="ClickHouse monitoring tools for AI clients via the Model Context Protocol."
   />
 </Cards>
 
 ## Feature index
+
+Every feature answers a specific operational question. Use the feature id to gate or disable it.
 
 | Feature | What it answers | Feature id | Page |
 |---|---|---|---|
@@ -136,3 +142,11 @@ enabled = false
 ```
 
 See [Feature Permissions](/operate/advanced/feature-permissions) for the full reference.
+
+## Related
+
+<Cards>
+  <Card title="Feature permissions" href="/operate/advanced/feature-permissions" description="Full reference for gating and disabling every feature." />
+  <Card title="Authentication" href="/operate/authentication" description="Who can sign in and what each visitor may access." />
+  <Card title="Settings reference" href="/reference/settings" description="Environment variables and in-app configuration." />
+</Cards>

--- a/docs/content/guide/features/dashboard.mdx
+++ b/docs/content/guide/features/dashboard.mdx
@@ -1,11 +1,10 @@
 ---
-description: Build and save custom monitoring dashboards by combining any built-in charts into a single layout, stored in the browser.
+description: Build and save a custom monitoring view by combining any built-in charts on one canvas, stored in the browser.
 icon: LayoutDashboard
+title: Dashboard
 ---
 
-# Dashboard
-
-> Build and save custom monitoring dashboards by combining any of the built-in charts into a single view.
+The Dashboard is a chart builder: pick charts from the built-in library, arrange them on a canvas, and the layout is saved to your browser for next time.
 
 | | |
 |---|---|
@@ -18,9 +17,7 @@ icon: LayoutDashboard
 
 ## What it does
 
-The Dashboard is a chart builder. You pick charts from the built-in library and arrange them on a canvas. The result is saved to the browser and reloaded on the next visit.
-
-Use it to:
+You pick charts from the built-in library and arrange them on a canvas. The result is saved to the browser and reloaded on the next visit. Use it to:
 
 - Combine query-rate, memory, merge count, and replication lag on one screen for an at-a-glance SRE view.
 - Create host-specific dashboards for different ClickHouse clusters.
@@ -28,11 +25,33 @@ Use it to:
 
 Each chart on the dashboard is the same chart used on other feature pages. It fetches data from the same API endpoints and respects the same `hostId` query parameter, so the dashboard works with the host selector.
 
-## Pages
-
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
 | Dashboard | `/dashboard` | User-composed chart grid; chart picker; saved layout | Depends on charts selected |
+
+## Using it
+
+<Steps>
+  <Step>
+    ### Open the dashboard
+    Navigate to `/dashboard`. On first visit the canvas is empty.
+  </Step>
+  <Step>
+    ### Add charts
+    Open the chart picker and add charts from the built-in library. Each chart reads from the same endpoints as its feature page.
+  </Step>
+  <Step>
+    ### Arrange and save
+    Position the charts into a grid. The layout is written to the browser's `localStorage` and reloaded on your next visit.
+  </Step>
+</Steps>
+
+<Callout type="warn" title="Layout is stored in the browser">
+- **Layout storage** — the dashboard layout is saved to `localStorage` in the browser. Clearing browser storage removes the saved layout. There is no server-side layout persistence in the current version.
+- **Per-host layouts** — layouts are not differentiated per host. If you switch the host selector, the same chart grid is shown but each chart fetches data from the newly selected host.
+- **Chart permissions** — if a chart reads a system table the connected ClickHouse user cannot access, that chart shows an error while the rest of the dashboard continues to load.
+- **System table availability** — optional system tables (e.g. `system.part_log`, `system.query_metric_log`) must be enabled in the ClickHouse server config for the corresponding charts to show data.
+</Callout>
 
 ## Permissions & access
 
@@ -54,26 +73,17 @@ access = "authenticated"
 
 When disabled, `/dashboard` is removed from the nav and shows a disabled screen on direct visit.
 
-## Configuration
-
-No feature-specific server configuration. The dashboard layout is stored in the browser's localStorage; no server-side persistence is required.
+There is no feature-specific server configuration. The dashboard layout is stored in the browser's localStorage; no server-side persistence is required. The global query settings still apply to every chart on the dashboard:
 
 ```bash
-# Global query settings still apply to every chart on the dashboard
 CLICKHOUSE_MAX_EXECUTION_TIME=60
 ```
 
-## Notes & limitations
-
-- **Layout storage** — the dashboard layout is saved to `localStorage` in the browser. Clearing browser storage removes the saved layout. There is no server-side layout persistence in the current version.
-- **Per-host layouts** — layouts are not differentiated per host. If you switch the host selector, the same chart grid is shown but each chart fetches data from the newly selected host.
-- **Chart permissions** — if a chart reads a system table the connected ClickHouse user cannot access, that chart shows an error while the rest of the dashboard continues to load.
-- **System table availability** — optional system tables (e.g. `system.part_log`, `system.query_metric_log`) must be enabled in the ClickHouse server config for the corresponding charts to show data.
-
 ## Related
 
-- [Overview](/guide/features/overview)
-- [Queries](/guide/features/queries)
-- [Operations](/guide/features/operations)
-- [Authentication](/operate/authentication)
-- [Settings reference](/reference/settings)
+<Cards>
+  <Card title="Overview" href="/guide/features/overview" description="The pre-built health page the dashboard charts are drawn from." />
+  <Card title="Query monitoring" href="/guide/features/queries" description="Query-rate and resource charts you can pin to the dashboard." />
+  <Card title="Merges & operations" href="/guide/features/operations" description="Merge and mutation charts for the dashboard canvas." />
+  <Card title="Settings reference" href="/reference/settings" description="Environment variables and in-app configuration." />
+</Cards>

--- a/docs/content/guide/features/explorer.mdx
+++ b/docs/content/guide/features/explorer.mdx
@@ -1,11 +1,10 @@
 ---
 description: Browse every database, table, column, index, projection, and dependency in your ClickHouse instance without writing SQL.
 icon: FolderTree
+title: Data Explorer
 ---
 
-# Data Explorer
-
-> Browse every database, table, column, index, projection, and dependency in your ClickHouse instance without writing SQL.
+The Data Explorer is a tree-browser for the entire schema of a ClickHouse host: every database, table, column, index, projection, and dependency, without writing SQL.
 
 | | |
 |---|---|
@@ -18,7 +17,7 @@ icon: FolderTree
 
 ## What it does
 
-The Data Explorer provides a tree-browser for the entire schema of a ClickHouse host. Select a database from the sidebar, then a table, to see:
+Select a database from the sidebar, then a table, to see:
 
 - **Column list** — name, type, and whether the column is part of the primary key, sorting key, or partition key.
 - **DDL** — the `CREATE TABLE` statement for the selected table.
@@ -31,14 +30,36 @@ The Data Explorer provides a tree-browser for the entire schema of a ClickHouse 
 All queries are read-only. No writes are issued.
 
 <Callout type="info" title="Read-only">
-  The explorer cannot create, alter, or drop objects. It only reads from system tables.
+The explorer cannot create, alter, or drop objects. It only reads from system tables.
 </Callout>
 
-## Pages
+## Using it
+
+<Steps>
+  <Step>
+    ### Pick a database
+    Select a database from the sidebar tree. The list comes from `system.databases`.
+  </Step>
+  <Step>
+    ### Select a table
+    Expand the database and choose a table to load its details.
+  </Step>
+  <Step>
+    ### Inspect the schema
+    Review columns, DDL, indexes, skip indexes, projections, dependencies, and table metadata in the detail panels.
+  </Step>
+</Steps>
 
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
 | Data Explorer | `/explorer` | Database tree; table details: columns, DDL, indexes, projections, skip indexes, dependencies | `system.databases`, `system.tables`, `system.columns`, `system.projection_parts`, `system.data_skipping_indices`, `system.dictionaries` |
+
+<Callout type="info" title="Version-dependent panels and behavior">
+- **`system.data_skipping_indices`** — available since ClickHouse 20.6. The skip-index panel is hidden on older versions.
+- **`system.projection_parts`** — projections were introduced in ClickHouse 21.6. The projections panel is hidden on older versions.
+- **Dependencies** — dependency tracking uses the `dependencies_database` and `dependencies_table` arrays in `system.tables`. These arrays are populated for materialized views and dictionaries. Direct table references in ad-hoc queries are not tracked.
+- On clusters with many databases (hundreds), the initial database list query against `system.databases` may be slow. Increase `CLICKHOUSE_MAX_EXECUTION_TIME` if needed.
+</Callout>
 
 ## Permissions & access
 
@@ -60,24 +81,16 @@ CHM_DISABLED_FEATURES=tables
 access = "authenticated"
 ```
 
-## Configuration
-
-No feature-specific configuration. Global query timeout applies:
+There is no feature-specific configuration. The global query timeout applies:
 
 ```bash
 CLICKHOUSE_MAX_EXECUTION_TIME=60
 ```
 
-## Notes & limitations
-
-- **`system.data_skipping_indices`** — available since ClickHouse 20.6. The skip-index panel is hidden on older versions.
-- **`system.projection_parts`** — projections were introduced in ClickHouse 21.6. The projections panel is hidden on older versions.
-- **Dependencies** — dependency tracking uses the `dependencies_database` and `dependencies_table` arrays in `system.tables`. These arrays are populated for materialized views and dictionaries. Direct table references in ad-hoc queries are not tracked.
-- The explorer is read-only.
-- On clusters with many databases (hundreds), the initial database list query against `system.databases` may be slow. Increase `CLICKHOUSE_MAX_EXECUTION_TIME` if needed.
-
 ## Related
 
-- [Tables](/guide/features/tables)
-- [Authentication](/operate/authentication)
-- [Settings reference](/reference/settings)
+<Cards>
+  <Card title="Tables & storage" href="/guide/features/tables" description="Storage, parts, and replication for the tables you explore." />
+  <Card title="Authentication" href="/operate/authentication" description="Who can sign in and what each visitor may access." />
+  <Card title="Settings reference" href="/reference/settings" description="Environment variables and in-app configuration." />
+</Cards>

--- a/docs/content/guide/features/overview.mdx
+++ b/docs/content/guide/features/overview.mdx
@@ -1,11 +1,10 @@
 ---
-description: Cluster health at a glance — active queries, memory, disk, and CPU pulled from live ClickHouse system tables.
+description: Read cluster health at a glance — active queries, memory, disk, and CPU pulled live from ClickHouse system tables.
 icon: Gauge
+title: Overview
 ---
 
-# Overview
-
-> The landing page for each ClickHouse host: instant health status, active queries, memory, disk, and CPU at a glance.
+The Overview page is where each ClickHouse host lands you: instant health status, active queries, memory, disk, and CPU at a glance.
 
 | | |
 |---|---|
@@ -18,16 +17,18 @@ icon: Gauge
 
 ## What it does
 
-Overview is the first page you land on. It pulls live numbers from several system tables to answer:
+Overview pulls live numbers from several system tables to answer, at a glance:
 
 - Is the server healthy right now?
 - How many queries are running?
 - How much memory and disk are in use?
 - What is CPU load?
 
-The page auto-refreshes on a short interval. There are no write operations.
+The page auto-refreshes on a short interval. It issues no write operations.
 
-### Tabs
+## Using it
+
+The page groups its live signals into five tabs.
 
 <Tabs items={['Connections', 'Queries', 'Merges', 'Replication', 'System']}>
   <Tab value="Connections">
@@ -47,26 +48,34 @@ The page auto-refreshes on a short interval. There are no write operations.
   </Tab>
 </Tabs>
 
-## Pages
-
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
 | Overview | `/overview` | CPU, memory, disk gauges; active query count; connection count; replication lag indicator | `system.asynchronous_metrics`, `system.metrics`, `system.processes`, `system.disks`, `system.tables` |
+
+<Callout type="info" title="Data freshness and behavior">
+- `system.asynchronous_metrics` values are recalculated by ClickHouse on a background interval (default ~1 s). The values shown are as fresh as that interval allows.
+- `system.disks` reports the disks ClickHouse knows about. If you use multiple storage policies or remote disks (S3, HDFS), all configured disks appear.
+- `system.tables` is queried to derive a table count. On clusters with many databases this can be slow; increase `CLICKHOUSE_MAX_EXECUTION_TIME` if overviews time out.
+- The Replication tab shows replication lag only when replicated tables exist on the host. The tab still appears even if there are none.
+</Callout>
 
 ## Permissions & access
 
 Overview is public by default. To restrict it:
 
-```bash
-# Env var
-CHM_FEATURE_OVERVIEW_ACCESS=authenticated
-```
-
-```toml
-# CHM_CONFIG_FILE (TOML)
-[features.overview]
-access = "authenticated"
-```
+<Tabs items={['Env var', 'Config file (TOML)']}>
+  <Tab value="Env var">
+    ```bash
+    CHM_FEATURE_OVERVIEW_ACCESS=authenticated
+    ```
+  </Tab>
+  <Tab value="Config file (TOML)">
+    ```toml
+    [features.overview]
+    access = "authenticated"
+    ```
+  </Tab>
+</Tabs>
 
 To disable the feature entirely:
 
@@ -78,23 +87,17 @@ CHM_FEATURE_OVERVIEW_ENABLED=false
 
 When disabled, the route is removed from the nav and a disabled screen is shown on direct visit.
 
-## Configuration
-
-No feature-specific configuration. The refresh interval and caching behaviour follow the global settings:
+There is no feature-specific configuration. The refresh interval and caching behaviour follow the global query settings:
 
 ```bash
 CLICKHOUSE_MAX_EXECUTION_TIME=60   # query timeout in seconds
 ```
 
-## Notes & limitations
-
-- `system.asynchronous_metrics` values are recalculated by ClickHouse on a background interval (default ~1 s). The values shown are as fresh as that interval allows.
-- `system.disks` reports the disks ClickHouse knows about. If you use multiple storage policies or remote disks (S3, HDFS), all configured disks appear.
-- `system.tables` is queried to derive a table count. On clusters with many databases this can be slow; increase `CLICKHOUSE_MAX_EXECUTION_TIME` if overviews time out.
-- The Replication tab shows replication lag only when replicated tables exist on the host. The tab still appears even if there are none.
-
 ## Related
 
-- [Authentication](/operate/authentication)
-- [Settings reference](/reference/settings)
-- [Health alerting](/guide/features/health)
+<Cards>
+  <Card title="Query monitoring" href="/guide/features/queries" description="Drill from active query counts into live and historical query analysis." />
+  <Card title="Health & alerting" href="/guide/features/health" description="Turn overview signals into alerts via the health sweep cron." />
+  <Card title="Authentication" href="/operate/authentication" description="Who can sign in and what each visitor may access." />
+  <Card title="Settings reference" href="/reference/settings" description="Environment variables and in-app configuration." />
+</Cards>

--- a/docs/content/guide/features/queries.mdx
+++ b/docs/content/guide/features/queries.mdx
@@ -1,11 +1,10 @@
 ---
 description: Monitor live, historical, failed, slow, and expensive queries with thread-level breakdown and per-user resource analysis.
 icon: Search
+title: Queries
 ---
 
-# Queries
-
-> Monitor and analyze all query activity: live execution, historical logs, failures, resource cost, thread-level breakdown, and per-user process summaries.
+The Queries feature covers the full lifecycle of query observability — live execution, historical logs, failures, resource cost, thread-level breakdown, and per-user process summaries.
 
 | | |
 |---|---|
@@ -18,7 +17,7 @@ icon: Search
 
 ## What it does
 
-The Queries feature covers the full lifecycle of query observability:
+The Queries feature answers the full lifecycle of query observability:
 
 - **Live** — what is running right now, elapsed time, memory, thread count.
 - **History** — finished queries with full metrics (CPU, memory, read/write rows and bytes, duration).
@@ -31,7 +30,9 @@ The Queries feature covers the full lifecycle of query observability:
 
 The Explain page does not query a log table; it runs `EXPLAIN` statements against the connected host interactively.
 
-## Pages
+## Using it
+
+Each question maps to a dedicated page.
 
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
@@ -45,6 +46,26 @@ The Explain page does not query a log table; it runs `EXPLAIN` statements agains
 | Thread & Parallelization | `/queries/thread-analysis` | Thread-level performance breakdown for individual query executions | `system.query_thread_log` |
 | User Processes | `/user-processes` | Per-user memory and resource summary from live processes | `system.user_processes` |
 | Query Metric Log | `/query-metric-log` | Per-query resource timeline sampled over each query's lifetime | `system.query_metric_log` |
+
+<Callout type="warn" title="KILL QUERY privilege required">
+The kill-query button on `/running-queries` issues `KILL QUERY`. The ClickHouse user configured via `CLICKHOUSE_USER` must have the `KILL QUERY` privilege. Without it, the button returns an error.
+</Callout>
+
+<Callout type="info" title="Optional system tables">
+Several pages depend on tables that must be explicitly enabled in the ClickHouse server config. Pages backed by a missing table show an empty state rather than an error.
+
+| Table | Config key | Default |
+|---|---|---|
+| `system.query_views_log` | `<query_views_log>` | disabled on many installs |
+| `system.query_thread_log` | `<query_thread_log>` | disabled on many installs |
+| `system.query_metric_log` | `<query_metric_log>` | disabled; high-cardinality on busy clusters |
+</Callout>
+
+Additional behavior to keep in mind:
+
+- **`system.query_log`** — ClickHouse writes asynchronously. Very recent queries (< a few seconds old) may not appear in history pages yet. Retention and flush intervals are set via `query_log.flush_interval_milliseconds` and `query_log.ttl` in the ClickHouse server config, not by chmonitor.
+- **`system.user_processes`** — available since ClickHouse 22.6. Earlier versions show a table-not-found notice.
+- **`system.errors`** — the Common Errors view reads `system.errors`, which is always present and contains aggregated error-code counts (not per-query).
 
 ## Permissions & access
 
@@ -68,36 +89,17 @@ access = "authenticated"
 
 When disabled, all sub-routes are removed from the nav and return a disabled screen on direct visit.
 
-## Configuration
-
-No feature-specific configuration beyond the global query settings:
+There is no feature-specific configuration beyond the global query settings:
 
 ```bash
 CLICKHOUSE_MAX_EXECUTION_TIME=60   # per-query timeout in seconds
 ```
 
-## Notes & limitations
-
-<Callout type="warn" title="KILL QUERY privilege required">
-  The kill-query button on `/running-queries` issues `KILL QUERY`. The ClickHouse user configured via `CLICKHOUSE_USER` must have the `KILL QUERY` privilege. Without it, the button returns an error.
-</Callout>
-
-<Callout type="info" title="Optional system tables">
-  Several pages depend on tables that must be explicitly enabled in the ClickHouse server config. Pages backed by a missing table show an empty state rather than an error.
-
-  | Table | Config key | Default |
-  |---|---|---|
-  | `system.query_views_log` | `<query_views_log>` | disabled on many installs |
-  | `system.query_thread_log` | `<query_thread_log>` | disabled on many installs |
-  | `system.query_metric_log` | `<query_metric_log>` | disabled; high-cardinality on busy clusters |
-</Callout>
-
-- **`system.query_log`** — ClickHouse writes asynchronously. Very recent queries (< a few seconds old) may not appear in history pages yet. Retention and flush intervals are set via `query_log.flush_interval_milliseconds` and `query_log.ttl` in the ClickHouse server config, not by chmonitor.
-- **`system.user_processes`** — available since ClickHouse 22.6. Earlier versions show a table-not-found notice.
-- **`system.errors`** — the Common Errors view reads `system.errors`, which is always present and contains aggregated error-code counts (not per-query).
-
 ## Related
 
-- [Authentication](/operate/authentication)
-- [Settings reference](/reference/settings)
-- [Operations (merges & mutations)](/guide/features/operations)
+<Cards>
+  <Card title="Merges & operations" href="/guide/features/operations" description="Merges and mutations behind slow or expensive queries." />
+  <Card title="Overview" href="/guide/features/overview" description="Live query counts and rate as a cluster-health signal." />
+  <Card title="Authentication" href="/operate/authentication" description="Who can sign in and what each visitor may access." />
+  <Card title="Settings reference" href="/reference/settings" description="Environment variables and in-app configuration." />
+</Cards>

--- a/docs/content/guide/features/tables.mdx
+++ b/docs/content/guide/features/tables.mdx
@@ -1,11 +1,10 @@
 ---
-description: Inspect table storage, replication health, schema, dictionaries, and background data-movement operations across all databases.
+description: Inspect table storage, replication health, schema, dictionaries, and background data-movement across all databases.
 icon: Table2
+title: Tables
 ---
 
-# Tables
-
-> Inspect table storage, replication health, schema details, dictionaries, and background data-movement operations across all databases.
+The Tables feature answers storage and replication questions across every database — sizes, parts, replica health, pending DDL, Kafka consumers, and dictionaries — without writing any SQL.
 
 | | |
 |---|---|
@@ -28,7 +27,9 @@ The Tables feature answers storage and replication questions without writing any
 
 All pages are read-only except for the OPTIMIZE TABLE action on the tables list, which requires an extra grant.
 
-## Pages
+## Using it
+
+Each question maps to a dedicated page.
 
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
@@ -42,6 +43,23 @@ All pages are read-only except for the OPTIMIZE TABLE action on the tables list,
 | Dictionaries | `/dictionaries` | External dictionary status, source type, memory usage | `system.dictionaries` |
 | Kafka Consumers | `/kafka-consumers` | Kafka table engine consumer lag, poll/commit counts, ingestion errors | `system.kafka_consumers` |
 | DDL Queue | `/distributed-ddl-queue` | Cluster-wide DDL task queue status and execution history | `system.distributed_ddl_queue` |
+
+<Callout type="warn" title="OPTIMIZE TABLE privilege required">
+The Tables page can issue `OPTIMIZE TABLE`. The ClickHouse user must have `ALTER TABLE ... OPTIMIZE` (or broader `ALTER`) privilege. Without it the action returns an error.
+</Callout>
+
+<Callout type="info" title="Optional and environment-dependent tables">
+Several pages are only relevant in specific configurations and show an informational empty state when their backing table is absent.
+
+| Page | Condition |
+|---|---|
+| Kafka Consumers | Requires at least one Kafka table engine to be configured |
+| Replicated Fetches | Only present on servers running replicated tables |
+| Dropped Tables | Requires Atomic database engine (default since ClickHouse 20.6) |
+| DDL Queue | Only meaningful on clusters using `ON CLUSTER` DDL |
+</Callout>
+
+- **Readonly Tables** — a replica enters read-only mode when it cannot reach Keeper/ZooKeeper. The `/readonly-tables` page is a filtered view of `system.replicas`; it shows a zero-row table when all replicas are healthy.
 
 ## Permissions & access
 
@@ -63,38 +81,19 @@ CHM_DISABLED_FEATURES=tables
 access = "authenticated"
 ```
 
-Note: the Data Explorer (`/explorer`) is also under the `tables` feature id. Gating tables also gates the explorer.
+The Data Explorer (`/explorer`) is also under the `tables` feature id, so gating tables also gates the explorer.
 
-## Configuration
-
-No feature-specific configuration. The global query timeout applies to all table queries:
+There is no feature-specific configuration. The global query timeout applies to all table queries:
 
 ```bash
 CLICKHOUSE_MAX_EXECUTION_TIME=60
 ```
 
-## Notes & limitations
-
-<Callout type="warn" title="OPTIMIZE TABLE privilege required">
-  The Tables page can issue `OPTIMIZE TABLE`. The ClickHouse user must have `ALTER TABLE ... OPTIMIZE` (or broader `ALTER`) privilege. Without it the action returns an error.
-</Callout>
-
-<Callout type="info" title="Optional and environment-dependent tables">
-  Several pages are only relevant in specific configurations and show an informational empty state when their backing table is absent.
-
-  | Page | Condition |
-  |---|---|
-  | Kafka Consumers | Requires at least one Kafka table engine to be configured |
-  | Replicated Fetches | Only present on servers running replicated tables |
-  | Dropped Tables | Requires Atomic database engine (default since ClickHouse 20.6) |
-  | DDL Queue | Only meaningful on clusters using `ON CLUSTER` DDL |
-</Callout>
-
-- **Readonly Tables** — a replica enters read-only mode when it cannot reach Keeper/ZooKeeper. The `/readonly-tables` page is a filtered view of `system.replicas`; it shows a zero-row table when all replicas are healthy.
-
 ## Related
 
-- [Data Explorer](/guide/features/explorer)
-- [Operations (merges & mutations)](/guide/features/operations)
-- [Authentication](/operate/authentication)
-- [Settings reference](/reference/settings)
+<Cards>
+  <Card title="Data explorer" href="/guide/features/explorer" description="Browse the schema of any table shown in the tables list." />
+  <Card title="Merges & operations" href="/guide/features/operations" description="Merges and mutations behind table part counts." />
+  <Card title="Authentication" href="/operate/authentication" description="Who can sign in and what each visitor may access." />
+  <Card title="Settings reference" href="/reference/settings" description="Environment variables and in-app configuration." />
+</Cards>


### PR DESCRIPTION
Full prose rewrite of the core **Features A** docs unit to one consistent, action-first voice and a shared Fumadocs page skeleton, with more interactive components. Every technical fact (routes, feature ids, env vars, system tables, grants, version numbers, `KILL QUERY` / `OPTIMIZE TABLE` privileges) is preserved verbatim. No page added, removed, or renamed.

## Pages rewritten
- `docs/content/guide/features.mdx` — section landing: intro + `<Cards>` grid linking every feature page, feature index table, controlling-features config, Related cards.
- `docs/content/guide/features/overview.mdx` — lead → What it does → Using it (`<Tabs>`) → Permissions & access → Related.
- `docs/content/guide/features/dashboard.mdx` — adds a `<Steps>` walkthrough; layout/limitation notes moved into a Callout.
- `docs/content/guide/features/queries.mdx` — pages table under Using it; KILL QUERY + optional-tables Callouts retained.
- `docs/content/guide/features/tables.mdx` — pages table; OPTIMIZE TABLE + env-dependent-tables Callouts retained.
- `docs/content/guide/features/explorer.mdx` — adds a `<Steps>` walkthrough; version-dependent notes in a Callout.

## Verification
- `cd apps/docs && bun run sync` → exit 0 (73 pages)
- `bunx fumadocs-mdx` → exit 0
- Bodies start at `##` (h1 stripped by frontmatter); all internal links root-based; no component imports added.

Co-Authored-By: duyetbot <bot@duyet.net>