### PR TITLE
docs(deploy): rewrite vercel/traefik/one-click/production-checklist guides

### DIFF
--- a/docs/content/operate/deploy/one-click.mdx
+++ b/docs/content/operate/deploy/one-click.mdx
@@ -1,15 +1,16 @@
 ---
 description: Deploy chmonitor to Railway, Render, or Fly.io in minutes using community-maintained templates.
 icon: MousePointerClick
+title: One-Click Deploy Templates
 ---
 
-# One-Click Deploy Templates
-
-Community templates for deploying chmonitor on Railway, Render, and Fly.io.
+Deploy chmonitor on Railway, Render, or Fly.io with community-maintained templates. Each template runs the published image and wires up a health check for you.
 
 <Callout type="warn" title="Starting-point templates, not verified pipelines">
 These are starting-point templates, not verified CI pipelines. They have not been boot-tested end-to-end against a live ClickHouse instance in automated CI. Review the env var placeholders, substitute real values, and verify the deployment works in your environment before relying on it in production.
 </Callout>
+
+## Prerequisites
 
 All three templates run the published image `ghcr.io/chmonitor/chmonitor:latest`, expose port 3000, and define a health check against `/api/healthz`. You must supply three env vars:
 
@@ -21,9 +22,12 @@ All three templates run the published image `ghcr.io/chmonitor/chmonitor:latest`
 
 The template files live in [`deploy/templates/`](https://github.com/chmonitor/chmonitor/tree/main/deploy/templates) in the repository.
 
----
+## Setup
 
-## Railway
+Pick your platform.
+
+<Tabs items={["Railway", "Render", "Fly.io"]}>
+<Tab value="Railway">
 
 Template: [`deploy/templates/railway.json`](https://github.com/chmonitor/chmonitor/blob/main/deploy/templates/railway.json)
 
@@ -60,10 +64,9 @@ Alternatively, copy `deploy/templates/railway.json` into your repository root as
   }
 }
 ```
+</Tab>
 
----
-
-## Render
+<Tab value="Render">
 
 Template: [`deploy/templates/render.yaml`](https://github.com/chmonitor/chmonitor/blob/main/deploy/templates/render.yaml)
 
@@ -103,10 +106,9 @@ services:
       - key: CLICKHOUSE_PASSWORD
         value: YOUR_CLICKHOUSE_PASSWORD   # use Render secret instead
 ```
+</Tab>
 
----
-
-## Fly.io
+<Tab value="Fly.io">
 
 Template: [`deploy/templates/fly.toml`](https://github.com/chmonitor/chmonitor/blob/main/deploy/templates/fly.toml)
 
@@ -145,12 +147,26 @@ fly deploy
 </Steps>
 
 The health check polls `/api/healthz` every 10 seconds with a 20-second grace period on startup.
+</Tab>
+</Tabs>
 
----
-
-## After deploying
+## Verify
 
 - Open `https://your-app-url` — you should land on the overview page.
 - If the page loads but charts are empty, check that the ClickHouse user has `SELECT` on `system.*`.
 - If the health check fails, verify `CLICKHOUSE_HOST` is reachable from inside the container (use the private/internal hostname your platform provides, not `localhost`).
-- For additional configuration (authentication, AI agent, conversation store), see the [Docker deploy guide](/operate/deploy/docker) — the same env vars apply.
+
+## Troubleshooting
+
+<Callout type="info" title="More configuration">
+For additional configuration (authentication, AI agent, conversation store), see the [Docker deploy guide](/operate/deploy/docker) — the same env vars apply.
+</Callout>
+
+## Related
+
+<Cards>
+  <Card title="Docker deployment" href="/operate/deploy/docker" description="Full env var reference — auth, AI agent, and conversation store apply the same way." />
+  <Card title="Cloudflare Workers" href="/operate/deploy/cloudflare" description="Serverless, global hosting for the current v0.3+ app." />
+  <Card title="Kubernetes deployment" href="/operate/deploy/k8s" description="Install chmonitor with the Helm chart." />
+  <Card title="Production checklist" href="/operate/deploy/production-checklist" description="Harden and validate before exposing to a team or the internet." />
+</Cards>

--- a/docs/content/operate/deploy/production-checklist.mdx
+++ b/docs/content/operate/deploy/production-checklist.mdx
@@ -1,11 +1,10 @@
 ---
 description: Steps to harden and validate a chmonitor deployment before exposing it to a team or the internet.
 icon: ClipboardCheck
+title: Production Checklist
 ---
 
-# Production Checklist
-
-Review each section before exposing chmonitor to a team or the internet.
+Work through each section before exposing chmonitor to a team or the internet. Every item is a hardening or validation step — skipping one leaves a gap.
 
 ## ClickHouse user and grants
 
@@ -18,7 +17,7 @@ Review each section before exposing chmonitor to a team or the internet.
 
 ## Authentication — do not leave fully public
 
-<Callout type="error" title="Open access is not safe on the internet">
+<Callout type="danger" title="Open access is not safe on the internet">
 `CHM_AUTH_PROVIDER=none` is only safe on a private network with no agent or MCP access. If chmonitor is reachable from the internet, use Clerk or a trusted-header proxy provider.
 </Callout>
 
@@ -71,3 +70,12 @@ Review each section before exposing chmonitor to a team or the internet.
 - [ ] Record where secrets are stored and who can rotate them.
 - [ ] Keep a rollback path: previous Docker tag, Helm release revision, or Worker version.
 - [ ] Watch app logs after deploy for ClickHouse connection errors or auth failures.
+
+## Related
+
+<Cards>
+  <Card title="Authentication" href="/operate/authentication" description="Choose and configure an auth provider: none, API key, Clerk, or trusted proxy." />
+  <Card title="Docker deployment" href="/operate/deploy/docker" description="Full env var reference for a self-hosted container." />
+  <Card title="Cloudflare Workers" href="/operate/deploy/cloudflare" description="Serverless hosting with D1 and Cron Trigger support." />
+  <Card title="Kubernetes deployment" href="/operate/deploy/k8s" description="Install chmonitor with the Helm chart, secrets, and probes." />
+</Cards>

--- a/docs/content/operate/deploy/traefik.mdx
+++ b/docs/content/operate/deploy/traefik.mdx
@@ -1,15 +1,27 @@
 ---
 description: Put chmonitor behind Traefik as a reverse proxy on Kubernetes or Docker, with optional ForwardAuth for SSO via oauth2-proxy.
 icon: Network
+title: Traefik
 ---
-
-# Traefik
 
 Run chmonitor behind [Traefik](https://traefik.io/) as your reverse proxy / ingress controller. Works the same on Kubernetes (IngressRoute CRD or the standard Ingress) and with plain Docker (container labels).
 
 Traefik handles TLS, routing, and — combined with [oauth2-proxy](/operate/authentication/trusted-proxy) — authentication, so chmonitor itself can stay on the `none` provider and trust the forwarded identity.
 
-## Kubernetes (IngressRoute)
+## Prerequisites
+
+<Callout type="info" title="What you need">
+- A running Traefik instance (ingress controller on Kubernetes, or Docker provider watching your containers)
+- chmonitor deployed via the [Helm chart](/operate/deploy/k8s) or [Docker](/operate/deploy/docker)
+- For SSO: an [oauth2-proxy](/operate/authentication/trusted-proxy) instance (Dex, Google, GitHub, …)
+</Callout>
+
+## Setup
+
+Pick your platform. chmonitor listens on port `3000` in every case.
+
+<Tabs items={["Kubernetes (IngressRoute)", "Kubernetes (Ingress)", "Docker (labels)"]}>
+<Tab value="Kubernetes (IngressRoute)">
 
 If you installed chmonitor with the [Helm chart](/operate/deploy/k8s), expose the Service with a Traefik `IngressRoute`:
 
@@ -31,6 +43,9 @@ spec:
   tls:
     certResolver: letsencrypt      # or a cert-manager-issued Secret via tls.secretName
 ```
+</Tab>
+
+<Tab value="Kubernetes (Ingress)">
 
 Prefer the standard `Ingress`? Enable it in the chart and point the class at Traefik:
 
@@ -48,8 +63,9 @@ ingress:
     - hosts: [chmonitor.example.com]
       secretName: chmonitor-tls
 ```
+</Tab>
 
-## Docker (labels)
+<Tab value="Docker (labels)">
 
 With `docker compose` and Traefik watching the Docker provider:
 
@@ -68,10 +84,16 @@ services:
       - traefik.http.routers.chmonitor.tls.certresolver=letsencrypt
       - traefik.http.services.chmonitor.loadbalancer.server.port=3000
 ```
+</Tab>
+</Tabs>
 
-## Authentication via ForwardAuth
+### Authentication via ForwardAuth
 
 Put chmonitor behind oauth2-proxy (with Dex, Google, GitHub, …) using a Traefik `ForwardAuth` middleware, and have chmonitor read the forwarded identity with the [`trusted` auth provider](/operate/authentication/trusted-proxy).
+
+<Steps>
+<Step>
+### Define the ForwardAuth middleware
 
 ```yaml
 apiVersion: traefik.io/v1alpha1
@@ -90,9 +112,16 @@ spec:
       - X-Auth-Request-Preferred-Username
       - X-Auth-Request-Groups
 ```
+</Step>
 
-Attach the middleware to the route (`middlewares: [{ name: oauth2-proxy-auth }]` on the IngressRoute, or
-`traefik.http.routers.chmonitor.middlewares=...` on Docker), then configure chmonitor:
+<Step>
+### Attach the middleware to the route
+
+Add `middlewares: [{ name: oauth2-proxy-auth }]` on the IngressRoute, or `traefik.http.routers.chmonitor.middlewares=...` on Docker.
+</Step>
+
+<Step>
+### Configure chmonitor's trusted provider
 
 ```bash
 CHM_AUTH_PROVIDER=trusted
@@ -104,10 +133,12 @@ CHM_TRUSTED_GROUPS_HEADER=X-Auth-Request-Groups
 # Restrict to specific Dex groups (optional)
 CHM_TRUSTED_ALLOWED_GROUPS=sre,platform-admins
 ```
+</Step>
+</Steps>
 
 See [Trusted proxy](/operate/authentication/trusted-proxy) for the full header reference, the shared-secret vs `CHM_TRUSTED_ALLOW_INSECURE` tradeoff, and the Dex/oauth2-proxy flags.
 
-## Health checks
+## Verify
 
 chmonitor exposes `/healthz` (liveness, static) and `/api/healthz` (readiness, gated on ClickHouse). Traefik can health-check the service:
 
@@ -125,10 +156,18 @@ services:
 Make sure your ForwardAuth middleware does **not** guard `/healthz` and `/api/healthz`, or probes will be redirected to the login flow. Route those paths without the auth middleware (a separate, higher-priority router rule), or rely on the chart's Kubernetes probes which hit the pod directly and bypass Traefik.
 </Callout>
 
+## Troubleshooting
+
+<Callout type="info" title="Probes redirected to login">
+If health probes fail after enabling ForwardAuth, the middleware is likely guarding `/healthz` / `/api/healthz`. Route those paths without the auth middleware, or lean on the chart's Kubernetes probes that hit the pod directly.
+</Callout>
+
 ## Related
 
-- [Kubernetes deployment](/operate/deploy/k8s)
-- [Docker deployment](/operate/deploy/docker)
-- [Trusted proxy authentication](/operate/authentication/trusted-proxy)
-- [Authentication overview](/operate/authentication)
-- [Production checklist](/operate/deploy/production-checklist)
+<Cards>
+  <Card title="Kubernetes deployment" href="/operate/deploy/k8s" description="Install chmonitor with the Helm chart." />
+  <Card title="Docker deployment" href="/operate/deploy/docker" description="Run the published container behind Traefik's Docker provider." />
+  <Card title="Trusted proxy authentication" href="/operate/authentication/trusted-proxy" description="Header reference, shared-secret tradeoff, and Dex/oauth2-proxy flags." />
+  <Card title="Authentication overview" href="/operate/authentication" description="Choose an auth provider for chmonitor." />
+  <Card title="Production checklist" href="/operate/deploy/production-checklist" description="Harden and validate before exposing to a team or the internet." />
+</Cards>

--- a/docs/content/operate/deploy/vercel.mdx
+++ b/docs/content/operate/deploy/vercel.mdx
@@ -1,19 +1,28 @@
 ---
 description: Deploy chmonitor to Vercel — legacy guide for the Next.js v0.2 build; v0.3+ targets Cloudflare Workers or Docker.
 icon: Triangle
+title: Vercel
 ---
 
-# Vercel
+Deploy chmonitor to Vercel using the legacy Next.js build. Vercel auto-deploys on every push to `main` and inlines client env vars at build time.
 
 <Callout type="warn" title="Legacy guide — Next.js v0.2 only">
 This guide targets the **legacy Next.js build (v0.2 and earlier)**. The current app (`apps/dashboard`, TanStack Start, v0.3+) is designed for Cloudflare Workers. If you are running v0.3 or later, use [Cloudflare Workers](/operate/deploy/cloudflare) or [Docker](/operate/deploy/docker) instead.
 </Callout>
 
-## Quick start
+## Prerequisites
+
+<Callout type="info" title="What you need">
+- A Vercel account
+- Node.js 22.x or later (build runtime)
+- A reachable ClickHouse endpoint with a monitoring user
+</Callout>
+
+## Setup
+
+Use the one-click button, or follow the manual steps.
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fchmonitor%2Fchmonitor&env=CLICKHOUSE_HOST,CLICKHOUSE_USER,CLICKHOUSE_PASSWORD,CLICKHOUSE_MAX_EXECUTION_TIME,CLICKHOUSE_TZ)
-
-Or deploy manually:
 
 <Steps>
 <Step>
@@ -23,9 +32,23 @@ Go to [vercel.com/new](https://vercel.com/new) and import the repository.
 </Step>
 
 <Step>
+### Set build settings
+
+Vercel detects Next.js automatically. Confirm the values below.
+
+| Setting | Value |
+|---|---|
+| Framework preset | Next.js |
+| Build command | `bun run build` (or `npm run build`) |
+| Output directory | `.next` |
+| Install command | `bun install` |
+| Node.js version | 22.x or later |
+</Step>
+
+<Step>
 ### Set environment variables
 
-In the Vercel dashboard, go to **Project → Settings → Environment Variables** and add the variables below.
+In the Vercel dashboard, go to **Project → Settings → Environment Variables** and add the variables from [Configure](#configure) below.
 </Step>
 
 <Step>
@@ -35,21 +58,11 @@ Click **Deploy** or push to `main` to trigger an automatic deploy.
 </Step>
 </Steps>
 
-## Build settings
-
-| Setting | Value |
-|---|---|
-| Framework preset | Next.js |
-| Build command | `bun run build` (or `npm run build`) |
-| Output directory | `.next` |
-| Install command | `bun install` |
-| Node.js version | 22.x or later |
-
-## Configure
+### Configure
 
 Set environment variables in Vercel dashboard → Project → Settings → Environment Variables.
 
-### Client vs server vars on Vercel
+#### Client vs server vars on Vercel
 
 On Vercel (Next.js), client-side vars use `NEXT_PUBLIC_*`. These are inlined at build time. Server-side vars are plain names. This differs from the TanStack app which uses `VITE_*`. For dual-surface settings you set the canonical `CHM_*` name once and the client var is derived from it at build time.
 
@@ -59,7 +72,7 @@ On Vercel (Next.js), client-side vars use `NEXT_PUBLIC_*`. These are inlined at 
 | `VITE_CLERK_PUBLISHABLE_KEY` | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Clerk publishable key (client) |
 | `VITE_TITLE_SHORT` | `NEXT_PUBLIC_TITLE_SHORT` | Branding (client) |
 
-### ClickHouse connection
+#### ClickHouse connection
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
@@ -68,9 +81,7 @@ On Vercel (Next.js), client-side vars use `NEXT_PUBLIC_*`. These are inlined at 
 | `CLICKHOUSE_PASSWORD` | No | `""` | Password(s), same count as HOST |
 | `CLICKHOUSE_NAME` | No | — | Friendly label(s) for host switcher |
 
-#### Multiple hosts
-
-All four variables must have the same count:
+For multiple hosts, all four variables must have the same count:
 
 ```
 CLICKHOUSE_HOST=https://ch1:8443,https://ch2:8443
@@ -79,7 +90,7 @@ CLICKHOUSE_PASSWORD=pass1,pass2
 CLICKHOUSE_NAME=primary,replica
 ```
 
-### Query / pool tuning
+#### Query / pool tuning
 
 | Variable | Default | Description |
 |---|---|---|
@@ -90,7 +101,7 @@ CLICKHOUSE_NAME=primary,replica
 | `CLICKHOUSE_POOL_TIMEOUT` | `300000` | Pool acquire timeout (ms) |
 | `CLICKHOUSE_POOL_CLEANUP_INTERVAL` | `60000` | Pool cleanup interval (ms) |
 
-### Feature permissions
+#### Feature permissions
 
 Add to Vercel env vars:
 
@@ -105,21 +116,28 @@ For a config file, set `CHM_CONFIG_FILE` to a path readable by the Vercel functi
 
 Feature ids: `overview`, `agent`, `insights`, `health`, `queries`, `tables`, `metrics`, `dashboard`, `security`, `logs`, `settings`, `cluster`, `operations`, `actions`, `mcp`, `docs`, `about`.
 
-### Authentication
+#### Authentication
 
-**None (default):**
+<Tabs items={["None", "API key", "Clerk", "Proxy — Cloudflare Access", "Proxy — trusted header"]}>
+<Tab value="None">
+
+Default provider — safe only on a private network.
 
 ```
 CHM_AUTH_PROVIDER=none
 ```
+</Tab>
 
-**API key layer:**
+<Tab value="API key">
+
+Add an API key layer:
 
 ```
 CHM_API_KEY_SECRET=a-long-random-secret
 ```
+</Tab>
 
-**Clerk:**
+<Tab value="Clerk">
 
 ```
 # Server-side (plain var)
@@ -130,16 +148,18 @@ CLERK_SECRET_KEY=sk_live_...
 NEXT_PUBLIC_AUTH_PROVIDER=clerk
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_...
 ```
+</Tab>
 
-**Proxy — Cloudflare Access:**
+<Tab value="Proxy — Cloudflare Access">
 
 ```
 CHM_AUTH_PROVIDER=proxy
 CHM_CF_ACCESS_TEAM_DOMAIN=https://yourteam.cloudflareaccess.com
 CHM_CF_ACCESS_AUD=<audience-tag>
 ```
+</Tab>
 
-**Proxy — trusted header:**
+<Tab value="Proxy — trusted header">
 
 ```
 CHM_AUTH_PROVIDER=proxy
@@ -148,8 +168,10 @@ CHM_PROXY_AUTH_SECRET=a-long-random-secret
 ```
 
 Put chmonitor behind a Vercel Edge Middleware or an upstream proxy that sets the header. See [Authentication](/operate/authentication).
+</Tab>
+</Tabs>
 
-### AI agent
+#### AI agent
 
 ```
 LLM_API_KEY=sk-...
@@ -159,15 +181,15 @@ AGENT_API_TOKEN=bearer-token-for-agent-api
 AGENT_ENABLE_CONTROL_TOOLS=false
 ```
 
+<Callout type="danger" title="Keep the LLM key server-side">
 Never use `NEXT_PUBLIC_LLM_API_KEY` — keep the key server-side only.
+</Callout>
 
-### Conversation store
+#### Conversation store
 
-**Default:** browser localStorage — no server config needed.
+The default is browser localStorage — no server config needed. On Vercel (Next.js v0.2), use `postgres` for server-side persistence. D1 and Durable Object stores are Cloudflare-only.
 
-On Vercel (Next.js v0.2), use `postgres` for server-side persistence. D1 and Durable Object stores are Cloudflare-only.
-
-**Postgres (recommended on Vercel):**
+Postgres is recommended on Vercel:
 
 ```
 CONVERSATION_STORE_BACKEND=postgres
@@ -176,9 +198,9 @@ DATABASE_URL=postgresql://user:pass@host:5432/dbname
 
 Vercel Postgres, Neon, and Supabase all work. Add `DATABASE_URL` in the Vercel dashboard.
 
-### Health alerting
+#### Health alerting
 
-The health sweep endpoint is `GET /api/cron/health-sweep`. Trigger it from a Vercel Cron Job or an external cron:
+The health sweep endpoint is `GET /api/cron/health-sweep`. Trigger it from a Vercel Cron Job or an external cron.
 
 In `vercel.json`:
 
@@ -200,7 +222,7 @@ HEALTH_ALERT_MIN_SEVERITY=warning
 CRON_SECRET=a-random-secret
 ```
 
-### Branding
+#### Branding
 
 ```
 NEXT_PUBLIC_TITLE_SHORT=MyCluster
@@ -209,17 +231,27 @@ NEXT_PUBLIC_MEASUREMENT_ID=G-XXXXXXXXXX
 NEXT_PUBLIC_POSTHOG_KEY=phc_...
 ```
 
-## Upgrading
+## Verify
 
-1. Push to `main` (or merge a PR). Vercel auto-deploys.
-2. For environment variable changes, update them in the dashboard and trigger a redeploy (Deployments → Redeploy).
+- Open the assigned Vercel URL — you should land on the overview page.
+- To upgrade, push to `main` (or merge a PR) and Vercel auto-deploys. For environment variable changes, update them in the dashboard and trigger a redeploy (Deployments → Redeploy).
 
 For breaking changes between major versions, see [Migrating to v0.3](/reference/migrating/v0-3).
 
-## Limitations
+## Troubleshooting
 
 <Callout type="info" title="Vercel limitations">
 - **No D1 / Durable Objects:** Cloudflare-only. Use postgres or clickhouse for conversation store.
 - **Function timeout:** Vercel Hobby plan limits function duration to 10 s. Use Pro or set `CLICKHOUSE_MAX_EXECUTION_TIME` below that limit.
 - **Cold starts:** Vercel serverless functions have cold starts. Set `CLICKHOUSE_POOL_SIZE` appropriately.
 </Callout>
+
+## Related
+
+<Cards>
+  <Card title="Cloudflare Workers" href="/operate/deploy/cloudflare" description="The current v0.3+ deployment target — serverless, global, D1 and Cron support." />
+  <Card title="Docker" href="/operate/deploy/docker" description="Run the published container anywhere Docker runs." />
+  <Card title="Authentication" href="/operate/authentication" description="Choose an auth provider: none, API key, Clerk, or trusted proxy." />
+  <Card title="Migrating to v0.3" href="/reference/migrating/v0-3" description="Breaking changes between major versions." />
+  <Card title="Production checklist" href="/operate/deploy/production-checklist" description="Harden and validate before exposing to a team or the internet." />
+</Cards>


### PR DESCRIPTION
## Summary

Full prose rewrite of the four **Deploy B** docs pages for one consistent voice + shared page skeleton + richer interactive components. **Every technical fact preserved verbatim** — no page added, removed, or renamed.

- `operate/deploy/vercel.mdx`
- `operate/deploy/traefik.mdx`
- `operate/deploy/one-click.mdx`
- `operate/deploy/production-checklist.mdx`

## Changes

- **Skeleton:** deploy pages now follow lead → Prerequisites → Setup → Verify → Troubleshooting → Related; checklist keeps grouped sections + Related.
- **Interactive:** `<Tabs>` for platform variants (Vercel auth methods; Traefik K8s/Docker; Railway/Render/Fly), `<Steps>` for ordered setup, `<Callout>` for prerequisites and warnings.
- **Consistency:** every page ends with a `## Related` `<Cards>` block (each Card has a description); sentence-case headings; root-based internal links; frontmatter normalized (`title`/`description`/`icon`).
- **Fidelity:** all env vars, ports, YAML/JSON snippets, commands, feature ids, health-check paths, and limitations carried over unchanged. The checklist's `Callout type="error"` was mapped to the allowed `danger` type (same high-severity intent).

## Verification

Ran the parallel-safe docs recipe (`bun run sync` + `bunx fumadocs-mdx`) — both exit 0; the four pages regenerate under `apps/docs/content/docs/operate/deploy/`.

Co-Authored-By: duyetbot <bot@duyet.net>