### PR TITLE
docs(features): rewrite ops/cluster/metrics/health/insights/security pages

### DIFF
--- a/docs/content/guide/features/cluster.mdx
+++ b/docs/content/guide/features/cluster.mdx
@@ -1,20 +1,21 @@
 ---
 description: Monitor distributed cluster topology, replication health, and Keeper/ZooKeeper coordination state across shards and replicas.
 icon: Boxes
+title: Cluster
 ---
 
-# Cluster
+See what nodes make up your cluster and how Keeper/ZooKeeper coordinates them — shard/replica topology, coordination health, the znode tree, and connection history.
 
-> Monitor distributed cluster topology, replication health, and Keeper/ZooKeeper coordination state.
-
-| | |
-|---|---|
-| **Routes** | `/clusters`, `/keeper/overview`, `/keeper`, `/keeper/info`, `/keeper/connections`, `/keeper/connection-log`, `/keeper/log`, `/keeper/watches` |
-| **Feature id** | `cluster` |
-| **Default access** | `public` |
-| **Requires auth** | No (set `CHM_FEATURE_CLUSTER_ACCESS=authenticated` to gate) |
-| **System tables** | `system.clusters`, `system.zookeeper`, `system.zookeeper_info`, `system.zookeeper_connection`, `system.zookeeper_connection_log`, `system.zookeeper_log`, `system.zookeeper_watches` |
-| **ClickHouse grants** | `SELECT` on the system tables above |
+<TypeTable
+  data={{
+    Routes: { type: "/clusters, /keeper/overview, /keeper, /keeper/info, /keeper/connections, /keeper/connection-log, /keeper/log, /keeper/watches", description: "Pages in this section" },
+    "Feature id": { type: "cluster", description: "Used by permission env vars and config" },
+    "Default access": { type: "public", description: "Set CHM_FEATURE_CLUSTER_ACCESS=authenticated to gate" },
+    "Requires auth": { type: "No", description: "Anonymous access allowed by default" },
+    "System tables": { type: "system.clusters, system.zookeeper*", description: "system.clusters plus the six system.zookeeper_* tables" },
+    "ClickHouse grants": { type: "SELECT", description: "SELECT on the system tables above" },
+  }}
+/>
 
 ## What it does
 
@@ -36,7 +37,7 @@ The **Clusters** page renders an interactive topology map of every shard and rep
 
 The **Keeper** sub-section shows the ZooKeeper/ClickHouse Keeper coordination layer: node health, liveness, request latency, the znode tree, active watches, and connection history. These pages are only available when your ClickHouse server has Keeper or ZooKeeper configured.
 
-## Pages
+### Pages
 
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
@@ -49,29 +50,45 @@ The **Keeper** sub-section shows the ZooKeeper/ClickHouse Keeper coordination la
 | Request Log | `/keeper/log` | Per-request log of Keeper operations and responses | `system.zookeeper_log` |
 | Watches | `/keeper/watches` | Currently active watches registered by this server | `system.zookeeper_watches` |
 
+## Using it
+
+- Open `/clusters` for the interactive topology map — confirm shard layouts, spot misconfigured hosts, or audit membership after scaling.
+- Start Keeper triage at `/keeper/overview` for liveness, request load, and latency across nodes.
+- Browse the znode tree at `/keeper?path=/`, and drill into per-node role and raft log at `/keeper/info`.
+- Check `/keeper/connections` for live connections, `/keeper/connection-log` for connect/disconnect history, `/keeper/log` for per-request operations, and `/keeper/watches` for active watches.
+
+Keeper pages appear automatically when `system.zookeeper_info` is accessible on the connected host. If the table is absent (no Keeper configured), pages show an empty state rather than an error.
+
 ## Permissions & access
 
 All Cluster pages use the `cluster` feature id.
 
-Disable the entire section:
-
-```bash
-CHM_FEATURE_CLUSTER_ENABLED=false
-```
-
-Require authentication:
+<Tabs items={["Gate to authenticated", "Disable", "Config file"]}>
+<Tab value="Gate to authenticated">
 
 ```bash
 CHM_FEATURE_CLUSTER_ACCESS=authenticated
 ```
 
-Using a config file (`CHM_CONFIG_FILE`):
+</Tab>
+<Tab value="Disable">
+
+```bash
+CHM_FEATURE_CLUSTER_ENABLED=false
+```
+
+</Tab>
+<Tab value="Config file">
 
 ```toml
+# CHM_CONFIG_FILE (TOML)
 [features.cluster]
 enabled = true
 access = "authenticated"
 ```
+
+</Tab>
+</Tabs>
 
 ## Configuration
 
@@ -89,7 +106,9 @@ No feature-specific configuration. Keeper pages appear automatically when `syste
 
 ## Related
 
-- [Authentication](/operate/authentication)
-- [Feature permissions](/operate/advanced/feature-permissions)
-- [ClickHouse system.clusters docs](https://clickhouse.com/docs/en/operations/system-tables/clusters)
-- [ClickHouse system.zookeeper docs](https://clickhouse.com/docs/en/operations/system-tables/zookeeper)
+<Cards>
+  <Card title="Authentication" href="/operate/authentication" description="Configure sign-in and access control." />
+  <Card title="Feature permissions" href="/operate/advanced/feature-permissions" description="Gate or disable features per section." />
+  <Card title="ClickHouse system.clusters" href="https://clickhouse.com/docs/en/operations/system-tables/clusters" description="Upstream reference for cluster topology." />
+  <Card title="ClickHouse system.zookeeper" href="https://clickhouse.com/docs/en/operations/system-tables/zookeeper" description="Upstream reference for the znode tree." />
+</Cards>

--- a/docs/content/guide/features/health.mdx
+++ b/docs/content/guide/features/health.mdx
@@ -1,20 +1,21 @@
 ---
 description: At-a-glance cluster health dashboard with automated headless health-sweep alerts via webhook and Cloudflare Cron.
 icon: HeartPulse
+title: Health
 ---
 
-# Health
+Get a single status grid of cluster health across replication, merges, errors, disks, load, and parts — plus a headless sweep endpoint that fires webhook alerts on a schedule.
 
-> At-a-glance cluster health dashboard and automated headless health-sweep alerts.
-
-| | |
-|---|---|
-| **Routes** | `/health` |
-| **Feature id** | `health` |
-| **Default access** | `public` |
-| **Requires auth** | No (set `CHM_FEATURE_HEALTH_ACCESS=authenticated` to gate) |
-| **System tables** | `system.metrics`, `system.asynchronous_metrics`, `system.replicas`, `system.merges`, `system.errors`, `system.disks`, `system.replication_queue`, `system.processes`, `system.query_log`, `system.parts` |
-| **ClickHouse grants** | `SELECT` on the system tables above |
+<TypeTable
+  data={{
+    Routes: { type: "/health", description: "The health status grid" },
+    "Feature id": { type: "health", description: "Used by permission env vars and config" },
+    "Default access": { type: "public", description: "Set CHM_FEATURE_HEALTH_ACCESS=authenticated to gate" },
+    "Requires auth": { type: "No", description: "Anonymous access allowed by default" },
+    "System tables": { type: "10 system tables", description: "metrics, asynchronous_metrics, replicas, merges, errors, disks, replication_queue, processes, query_log, parts" },
+    "ClickHouse grants": { type: "SELECT", description: "SELECT on the system tables above" },
+  }}
+/>
 
 ## What it does
 
@@ -31,33 +32,46 @@ Checks cover:
 
 In addition to the UI, chmonitor exposes a **headless health-sweep** endpoint (`GET /api/cron/health-sweep`) that runs the same checks and dispatches webhook alerts. This is designed to be called on a schedule (e.g., Cloudflare Cron every 5 minutes) without a browser.
 
-## Pages
+### Pages
 
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
 | Health | `/health` | Status grid with per-check severity and details | `system.metrics`, `system.asynchronous_metrics`, `system.replicas`, `system.merges`, `system.errors`, `system.disks`, `system.replication_queue`, `system.processes`, `system.query_log`, `system.parts` |
 
+## Using it
+
+Open `/health` for the status grid — each check reports ok / warning / critical with a summary. Start incident triage here, then drill into the linked feature sections for detail.
+
+To run the same checks without a browser, call the health-sweep endpoint (see below) on a schedule.
+
 ## Permissions & access
 
-Disable:
-
-```bash
-CHM_FEATURE_HEALTH_ENABLED=false
-```
-
-Require authentication:
+<Tabs items={["Gate to authenticated", "Disable", "Config file"]}>
+<Tab value="Gate to authenticated">
 
 ```bash
 CHM_FEATURE_HEALTH_ACCESS=authenticated
 ```
 
-Config file:
+</Tab>
+<Tab value="Disable">
+
+```bash
+CHM_FEATURE_HEALTH_ENABLED=false
+```
+
+</Tab>
+<Tab value="Config file">
 
 ```toml
+# CHM_CONFIG_FILE (TOML)
 [features.health]
 enabled = true
 access = "authenticated"
 ```
+
+</Tab>
+</Tabs>
 
 ## Configuration
 
@@ -89,12 +103,19 @@ The health-sweep endpoint runs checks over all configured hosts and sends a webh
 Without `CRON_SECRET`, the `/api/cron/health-sweep` endpoint is publicly accessible. Set it and pass it as `Authorization: Bearer <secret>` from your cron caller.
 </Callout>
 
+<Steps>
+<Step>
+### Set secrets
+
 Example for Cloudflare Workers (using `wrangler secret put`):
 
 ```bash
 wrangler secret put CRON_SECRET
 wrangler secret put HEALTH_ALERT_WEBHOOK_URL
 ```
+</Step>
+<Step>
+### Enable alerting
 
 Example environment block:
 
@@ -104,8 +125,9 @@ HEALTH_ALERT_MIN_SEVERITY=warning
 HEALTH_ALERT_WEBHOOK_URL=https://hooks.slack.com/services/...
 CRON_SECRET=<random-secret>
 ```
-
-To call the endpoint manually:
+</Step>
+<Step>
+### Call it manually
 
 ```bash
 curl -H "Authorization: Bearer $CRON_SECRET" \
@@ -113,6 +135,8 @@ curl -H "Authorization: Bearer $CRON_SECRET" \
 ```
 
 The endpoint returns a JSON array of check results. It always returns HTTP 200; alert dispatch happens server-side.
+</Step>
+</Steps>
 
 ### Scheduling (Cloudflare Cron)
 
@@ -134,7 +158,9 @@ The cron handler calls the health-sweep logic directly — no HTTP hop needed wh
 
 ## Related
 
-- [Metrics](/guide/features/metrics)
-- [Cluster](/guide/features/cluster)
-- [Feature permissions](/operate/advanced/feature-permissions)
-- [Authentication](/operate/authentication)
+<Cards>
+  <Card title="Metrics" href="/guide/features/metrics" description="Live counters, async metrics, and CPU profiling." />
+  <Card title="Cluster" href="/guide/features/cluster" description="Topology and Keeper/ZooKeeper coordination." />
+  <Card title="Feature permissions" href="/operate/advanced/feature-permissions" description="Gate or disable features per section." />
+  <Card title="Authentication" href="/operate/authentication" description="Configure sign-in and access control." />
+</Cards>

--- a/docs/content/guide/features/insights.mdx
+++ b/docs/content/guide/features/insights.mdx
@@ -1,20 +1,21 @@
 ---
 description: Aggregate query history from system.query_log to surface the most-queried tables, columns, and query patterns over time.
 icon: Lightbulb
+title: Insights
 ---
 
-# Insights
+Aggregate query history to see which tables and columns your workload hits most, and how activity trends over time.
 
-> Aggregated analytics over query history — most-used tables, columns, and query patterns.
-
-| | |
-|---|---|
-| **Routes** | `/insights` |
-| **Feature id** | `insights` |
-| **Default access** | `public` |
-| **Requires auth** | No (set `CHM_FEATURE_INSIGHTS_ACCESS=authenticated` to gate) |
-| **System tables** | `system.query_log` |
-| **ClickHouse grants** | `SELECT` on `system.query_log` |
+<TypeTable
+  data={{
+    Routes: { type: "/insights", description: "The insights analytics page" },
+    "Feature id": { type: "insights", description: "Used by permission env vars and config" },
+    "Default access": { type: "public", description: "Set CHM_FEATURE_INSIGHTS_ACCESS=authenticated to gate" },
+    "Requires auth": { type: "No", description: "Anonymous access allowed by default" },
+    "System tables": { type: "system.query_log", description: "Data source" },
+    "ClickHouse grants": { type: "SELECT", description: "SELECT on system.query_log" },
+  }}
+/>
 
 ## What it does
 
@@ -28,33 +29,44 @@ Use Insights to answer questions like:
 
 The page combines a stats grid (summary counts and rates) with chart sections that visualize trends over configurable time ranges.
 
-## Pages
+### Pages
 
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
 | Insights | `/insights` | Top tables, top columns, query activity charts | `system.query_log` |
 
+## Using it
+
+Open `/insights` for a stats grid of summary counts and rates alongside chart sections that visualize trends over configurable time ranges. Use it to find the most-read tables, the most-filtered columns, and shifts in query volume.
+
 ## Permissions & access
 
-Disable:
-
-```bash
-CHM_FEATURE_INSIGHTS_ENABLED=false
-```
-
-Require authentication:
+<Tabs items={["Gate to authenticated", "Disable", "Config file"]}>
+<Tab value="Gate to authenticated">
 
 ```bash
 CHM_FEATURE_INSIGHTS_ACCESS=authenticated
 ```
 
-Config file:
+</Tab>
+<Tab value="Disable">
+
+```bash
+CHM_FEATURE_INSIGHTS_ENABLED=false
+```
+
+</Tab>
+<Tab value="Config file">
 
 ```toml
+# CHM_CONFIG_FILE (TOML)
 [features.insights]
 enabled = true
 access = "authenticated"
 ```
+
+</Tab>
+</Tabs>
 
 ## Configuration
 
@@ -71,6 +83,8 @@ All data comes from `system.query_log`. If query logging is disabled on the Clic
 
 ## Related
 
-- [Queries](/guide/features/queries)
-- [Feature permissions](/operate/advanced/feature-permissions)
-- [ClickHouse system.query_log docs](https://clickhouse.com/docs/en/operations/system-tables/query_log)
+<Cards>
+  <Card title="Queries" href="/guide/features/queries" description="Monitor live, historical, and expensive queries." />
+  <Card title="Feature permissions" href="/operate/advanced/feature-permissions" description="Gate or disable features per section." />
+  <Card title="ClickHouse system.query_log" href="https://clickhouse.com/docs/en/operations/system-tables/query_log" description="Upstream reference for the query log." />
+</Cards>

--- a/docs/content/guide/features/metrics.mdx
+++ b/docs/content/guide/features/metrics.mdx
@@ -1,20 +1,21 @@
 ---
 description: Real-time and background-calculated server metrics, counters, and CPU profiling data from ClickHouse system tables.
 icon: Activity
+title: Metrics
 ---
 
-# Metrics
+See live server counters, background-calculated resource metrics, and per-processor CPU profiling — three views of server-level performance.
 
-> Real-time and background-calculated server metrics, counters, and CPU profiling data.
-
-| | |
-|---|---|
-| **Routes** | `/metrics`, `/asynchronous-metrics`, `/profiler` |
-| **Feature id** | `metrics` |
-| **Default access** | `public` |
-| **Requires auth** | No (set `CHM_FEATURE_METRICS_ACCESS=authenticated` to gate) |
-| **System tables** | `system.metrics`, `system.asynchronous_metrics`, `system.processors_profile_log` |
-| **ClickHouse grants** | `SELECT` on the system tables above |
+<TypeTable
+  data={{
+    Routes: { type: "/metrics, /asynchronous-metrics, /profiler", description: "Pages in this section" },
+    "Feature id": { type: "metrics", description: "Used by permission env vars and config" },
+    "Default access": { type: "public", description: "Set CHM_FEATURE_METRICS_ACCESS=authenticated to gate" },
+    "Requires auth": { type: "No", description: "Anonymous access allowed by default" },
+    "System tables": { type: "system.metrics, system.asynchronous_metrics, system.processors_profile_log", description: "Data sources" },
+    "ClickHouse grants": { type: "SELECT", description: "SELECT on the system tables above" },
+  }}
+/>
 
 ## What it does
 
@@ -26,7 +27,7 @@ The Metrics section exposes three views of server-level performance data.
 
 **Profiler** queries `system.processors_profile_log` to show CPU time broken down by query processor (pipeline step). Use it to find which stage of query execution is consuming the most CPU.
 
-## Pages
+### Pages
 
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
@@ -34,29 +35,42 @@ The Metrics section exposes three views of server-level performance data.
 | Async Metrics | `/asynchronous-metrics` | Background-calculated resource metrics | `system.asynchronous_metrics` |
 | Profiler | `/profiler` | CPU profiling data per query processor | `system.processors_profile_log` |
 
+## Using it
+
+- Open `/metrics` for live gauges — active connections, threads, in-flight merges. These reset on server restart.
+- Use `/asynchronous-metrics` for background-calculated resource stats (CPU load, memory, uptime, OS-level) suited to dashboards and alerting.
+- Open `/profiler` to break CPU time down by query processor and find the pipeline stage consuming the most CPU.
+
 ## Permissions & access
 
 All three pages share the `metrics` feature id.
 
-Disable:
-
-```bash
-CHM_FEATURE_METRICS_ENABLED=false
-```
-
-Require authentication:
+<Tabs items={["Gate to authenticated", "Disable", "Config file"]}>
+<Tab value="Gate to authenticated">
 
 ```bash
 CHM_FEATURE_METRICS_ACCESS=authenticated
 ```
 
-Config file:
+</Tab>
+<Tab value="Disable">
+
+```bash
+CHM_FEATURE_METRICS_ENABLED=false
+```
+
+</Tab>
+<Tab value="Config file">
 
 ```toml
+# CHM_CONFIG_FILE (TOML)
 [features.metrics]
 enabled = true
 access = "authenticated"
 ```
+
+</Tab>
+</Tabs>
 
 ## Configuration
 
@@ -73,7 +87,9 @@ No feature-specific configuration. The profiler page requires `system.processors
 
 ## Related
 
-- [Health](/guide/features/health)
-- [Feature permissions](/operate/advanced/feature-permissions)
-- [ClickHouse system.metrics docs](https://clickhouse.com/docs/en/operations/system-tables/metrics)
-- [ClickHouse system.asynchronous_metrics docs](https://clickhouse.com/docs/en/operations/system-tables/asynchronous_metrics)
+<Cards>
+  <Card title="Health" href="/guide/features/health" description="At-a-glance cluster health and alerting." />
+  <Card title="Feature permissions" href="/operate/advanced/feature-permissions" description="Gate or disable features per section." />
+  <Card title="ClickHouse system.metrics" href="https://clickhouse.com/docs/en/operations/system-tables/metrics" description="Upstream reference for live counters." />
+  <Card title="ClickHouse system.asynchronous_metrics" href="https://clickhouse.com/docs/en/operations/system-tables/asynchronous_metrics" description="Upstream reference for background metrics." />
+</Cards>

--- a/docs/content/guide/features/operations.mdx
+++ b/docs/content/guide/features/operations.mdx
@@ -1,20 +1,21 @@
 ---
 description: Track active merges, historical merge performance, mutations, part moves, and the part-event timeline for all MergeTree tables.
 icon: GitMerge
+title: Operations
 ---
 
-# Operations
+Watch the background work MergeTree engines do continuously — merges, mutations, part moves — and audit the full part-event timeline for every table.
 
-> Track active merges, historical merge performance, mutations, part moves, and the part-event timeline for all MergeTree tables.
-
-| | |
-|---|---|
-| **Routes** | `/merges`, `/merge-performance`, `/mutations`, `/moves`, `/part-log` |
-| **Feature id** | `operations` |
-| **Default access** | `public` |
-| **Requires auth** | No (set `CHM_FEATURE_OPERATIONS_ACCESS=authenticated` to gate) |
-| **System tables** | `system.merges`, `system.mutations`, `system.moves`, `system.part_log` |
-| **ClickHouse grants** | `SELECT` on the system tables above; `KILL MUTATION` for the kill-mutation action |
+<TypeTable
+  data={{
+    Routes: { type: "/merges, /merge-performance, /mutations, /moves, /part-log", description: "Pages in this section" },
+    "Feature id": { type: "operations", description: "Used by permission env vars and config" },
+    "Default access": { type: "public", description: "Set CHM_FEATURE_OPERATIONS_ACCESS=authenticated to gate" },
+    "Requires auth": { type: "No", description: "Anonymous access allowed by default" },
+    "System tables": { type: "system.merges, system.mutations, system.moves, system.part_log", description: "Data sources" },
+    "ClickHouse grants": { type: "SELECT + KILL MUTATION", description: "SELECT on the tables above; KILL MUTATION for the kill action" },
+  }}
+/>
 
 ## What it does
 
@@ -28,7 +29,7 @@ Operations covers the background work MergeTree engines do continuously:
 
 All pages are read-only except the kill-mutation action on `/mutations`.
 
-## Pages
+### Pages
 
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
@@ -38,25 +39,49 @@ All pages are read-only except the kill-mutation action on `/mutations`.
 | Moves | `/moves` | In-progress part moves: source/target disk, part name, size, elapsed | `system.moves` |
 | Part Log | `/part-log` | Part lifecycle events: NewPart, MergedPart, MutatedPart, DownloadedPart, RemovedPart | `system.part_log` |
 
+## Using it
+
+- Open `/merges` to see merges in flight — it doubles as the entry point for the Operations section in the nav (feature id `operations`).
+- Check `/merge-performance` for merge size and duration trends pulled from the part log.
+- Use `/mutations` to track `ALTER ... UPDATE/DELETE` progress, and stop a stuck mutation with the kill-mutation action.
+- Watch `/moves` during TTL or storage-policy migrations between disks and volumes.
+- Browse `/part-log` for the complete part lifecycle across every table.
+
 ## Permissions & access
 
-All sub-routes share the `operations` feature id:
+All sub-routes share the `operations` feature id.
+
+<Tabs items={["Gate to authenticated", "Disable", "Config file"]}>
+<Tab value="Gate to authenticated">
 
 ```bash
-# Gate to authenticated users
 CHM_FEATURE_OPERATIONS_ACCESS=authenticated
+```
 
-# Disable entirely
+</Tab>
+<Tab value="Disable">
+
+```bash
 CHM_FEATURE_OPERATIONS_ENABLED=false
 # or
 CHM_DISABLED_FEATURES=operations
 ```
+
+</Tab>
+<Tab value="Config file">
 
 ```toml
 # CHM_CONFIG_FILE (TOML)
 [features.operations]
 access = "authenticated"
 ```
+
+</Tab>
+</Tabs>
+
+<Callout type="warn" title="KILL MUTATION privilege required">
+  The kill-mutation button on `/mutations` issues `KILL MUTATION`. The ClickHouse user must have `ALTER TABLE` privilege (or specifically `KILL MUTATION`). Without it the action returns an error.
+</Callout>
 
 ## Configuration
 
@@ -68,10 +93,6 @@ CLICKHOUSE_MAX_EXECUTION_TIME=60
 
 ## Notes & limitations
 
-<Callout type="warn" title="KILL MUTATION privilege required">
-  The kill-mutation button on `/mutations` issues `KILL MUTATION`. The ClickHouse user must have `ALTER TABLE` privilege (or specifically `KILL MUTATION`). Without it the action returns an error.
-</Callout>
-
 <Callout type="info" title="part_log must be enabled">
   `system.part_log` requires `<part_log>` to be enabled in the ClickHouse server config. It is disabled by default on some distributions. If absent, `/merge-performance` and `/part-log` show a table-not-found notice.
 </Callout>
@@ -82,7 +103,9 @@ CLICKHOUSE_MAX_EXECUTION_TIME=60
 
 ## Related
 
-- [Tables](/guide/features/tables)
-- [Queries](/guide/features/queries)
-- [Authentication](/operate/authentication)
-- [Settings reference](/reference/settings)
+<Cards>
+  <Card title="Tables" href="/guide/features/tables" description="Inspect table sizes, parts, columns, and storage." />
+  <Card title="Queries" href="/guide/features/queries" description="Monitor live, historical, and expensive queries." />
+  <Card title="Authentication" href="/operate/authentication" description="Configure sign-in and access control." />
+  <Card title="Settings reference" href="/reference/settings" description="Every configuration setting in one place." />
+</Cards>

--- a/docs/content/guide/features/security.mdx
+++ b/docs/content/guide/features/security.mdx
@@ -1,20 +1,21 @@
 ---
 description: Audit ClickHouse users, roles, session history, login attempts, and security-relevant events from one place.
 icon: ShieldCheck
+title: Security
 ---
 
-# Security
+Audit who has access to ClickHouse and what they have been doing — user and role definitions, session history, login attempts, and security-relevant events.
 
-> Audit user sessions, login attempts, access control roles, and user definitions.
-
-| | |
-|---|---|
-| **Routes** | `/users`, `/roles`, `/security/sessions`, `/security/login-attempts`, `/security/audit-log` |
-| **Feature id** | `security` |
-| **Default access** | `public` |
-| **Requires auth** | No (set `CHM_FEATURE_SECURITY_ACCESS=authenticated` to gate) |
-| **System tables** | `system.users`, `system.roles`, `system.session_log` |
-| **ClickHouse grants** | `SELECT` on `system.users`, `system.roles`, `system.session_log`; or `SHOW ACCESS` |
+<TypeTable
+  data={{
+    Routes: { type: "/users, /roles, /security/sessions, /security/login-attempts, /security/audit-log", description: "Pages in this section" },
+    "Feature id": { type: "security", description: "Used by permission env vars and config" },
+    "Default access": { type: "public", description: "Set CHM_FEATURE_SECURITY_ACCESS=authenticated to gate" },
+    "Requires auth": { type: "No", description: "Anonymous access allowed by default" },
+    "System tables": { type: "system.users, system.roles, system.session_log", description: "Data sources" },
+    "ClickHouse grants": { type: "SELECT or SHOW ACCESS", description: "SELECT on the tables above, or SHOW ACCESS" },
+  }}
+/>
 
 ## What it does
 
@@ -30,7 +31,7 @@ The Security section gives operators visibility into who has access to ClickHous
 
 **Audit Log** is a filtered view of `system.session_log` focused on security-relevant events.
 
-## Pages
+### Pages
 
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
@@ -40,6 +41,13 @@ The Security section gives operators visibility into who has access to ClickHous
 | Login Attempts | `/security/login-attempts` | Auth events and failure reasons | `system.session_log` |
 | Audit Log | `/security/audit-log` | Security-relevant session events | `system.session_log` |
 
+## Using it
+
+- Open `/users` and `/roles` to review defined users (with auth methods and profiles) and roles.
+- Use `/security/sessions` for session history with authentication details.
+- Watch `/security/login-attempts` for auth failures — a signal for brute-force attempts or misconfigured client credentials.
+- Review `/security/audit-log` for a filtered view of security-relevant session events.
+
 ## Permissions & access
 
 All Security pages share the `security` feature id.
@@ -48,23 +56,32 @@ All Security pages share the `security` feature id.
 This section contains sensitive access-control data. It is recommended to gate it behind authentication in production.
 </Callout>
 
+<Tabs items={["Gate to authenticated", "Disable", "Config file"]}>
+<Tab value="Gate to authenticated">
+
 ```bash
 CHM_FEATURE_SECURITY_ACCESS=authenticated
 ```
 
-Disable entirely:
+</Tab>
+<Tab value="Disable">
 
 ```bash
 CHM_FEATURE_SECURITY_ENABLED=false
 ```
 
-Config file:
+</Tab>
+<Tab value="Config file">
 
 ```toml
+# CHM_CONFIG_FILE (TOML)
 [features.security]
 enabled = true
 access = "authenticated"
 ```
+
+</Tab>
+</Tabs>
 
 ## Configuration
 
@@ -89,6 +106,8 @@ Alternatively, `SHOW ACCESS` grants read access to all access-related system tab
 
 ## Related
 
-- [Authentication](/operate/authentication)
-- [Feature permissions](/operate/advanced/feature-permissions)
-- [ClickHouse system.session_log docs](https://clickhouse.com/docs/en/operations/system-tables/session_log)
+<Cards>
+  <Card title="Authentication" href="/operate/authentication" description="Configure sign-in and access control." />
+  <Card title="Feature permissions" href="/operate/advanced/feature-permissions" description="Gate or disable features per section." />
+  <Card title="ClickHouse system.session_log" href="https://clickhouse.com/docs/en/operations/system-tables/session_log" description="Upstream reference for the session log." />
+</Cards>


### PR DESCRIPTION
## Summary

Full prose rewrite of the six **Features B** documentation pages for one consistent voice and a shared page skeleton, with richer interactive Fumadocs components. Every technical fact is preserved verbatim — no page added, removed, or renamed.

Rewritten pages:
- `guide/features/operations`
- `guide/features/cluster`
- `guide/features/metrics`
- `guide/features/health`
- `guide/features/insights`
- `guide/features/security`

## What changed

- **Consistent voice + skeleton**: action-first lead sentence → `## What it does` → `## Using it` → `## Permissions & access` → `## Configuration` → `## Notes & limitations` → `## Related`.
- **Interactive components**: replaced the plain key/value metadata table with `<TypeTable>` (matching the convention already used by `browser-connections`/`user-connections`); wrapped the permission env/config variants in `<Tabs>`; converted the health-sweep setup into `<Steps>`.
- **Related Cards**: every page now ends with a `## Related` `<Cards>` block (each Card has a description).
- Removed the stripped leading `# h1`/blockquote; bodies start at `##`. Preserved all Callouts, Mermaid diagrams, tables, code blocks, env vars, grants, routes, and system-table facts.

## Verification

```
cd apps/docs && bun run sync && bunx fumadocs-mdx   # both exit 0
```

Co-Authored-By: duyetbot <bot@duyet.net>