### PR TITLE
docs(guides): rewrite how-to guides for consistent voice and richer UI

### DIFF
--- a/docs/content/guide/guides/connect-firewalled-clickhouse.mdx
+++ b/docs/content/guide/guides/connect-firewalled-clickhouse.mdx
@@ -1,97 +1,87 @@
 ---
+title: Connect a firewalled ClickHouse (Cloud)
 description: Connect a firewalled ClickHouse to chmonitor Cloud — Cloudflare Tunnel (recommended), dedicated egress IPs for allowlisting, jump host, and why allowlisting Cloudflare's shared ranges does not work.
 icon: ShieldCheck
 ---
 
-# Connect a firewalled ClickHouse (Cloud)
+chmonitor **Cloud** (`dash.chmonitor.dev`) runs entirely on Cloudflare Workers. When your ClickHouse is behind a firewall, the Worker has to reach it — and because Workers do **not** have a single fixed public IP by default, a plain "allowlist our IP" is not straightforward. Pick the option that fits, ranked below by how well it works with chmonitor.
 
-chmonitor **Cloud** (`dash.chmonitor.dev`) runs entirely on Cloudflare Workers.
-When your ClickHouse is behind a firewall, the Worker has to reach it — and
-because Workers do **not** have a single fixed public IP by default, a plain
-"allowlist our IP" is not straightforward. This guide explains the options,
-ranked by how well they fit chmonitor.
-
-<Callout type="tip" title="Self-hosting? You don't need any of this">
-Self-hosted chmonitor (Docker / Kubernetes / your own Worker) runs inside your
-network, so it reaches ClickHouse directly. This page is only for connecting a
-firewalled ClickHouse to the **hosted Cloud**.
+<Callout type="info" title="Self-hosting? You don't need any of this">
+Self-hosted chmonitor (Docker / Kubernetes / your own Worker) runs inside your network, so it reaches ClickHouse directly. This page is only for connecting a firewalled ClickHouse to the **hosted Cloud**.
 </Callout>
 
 ## Recommended: Cloudflare Tunnel + Access service token
 
-A [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-tunnel/) runs
-a small `cloudflared` connector next to your ClickHouse. It makes only
-**outbound** connections to Cloudflare, so you **open no inbound ports and
-allowlist no IPs**. You then protect the tunnel's public hostname with
-[Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/)
-and give chmonitor a **service token** so only chmonitor can reach it.
+A [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-tunnel/) runs a small `cloudflared` connector next to your ClickHouse. It makes only **outbound** connections to Cloudflare, so you **open no inbound ports and allowlist no IPs**. You then protect the tunnel's public hostname with [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/) and give chmonitor a **service token** so only chmonitor can reach it.
 
-**You do:**
+<Steps>
+<Step>
+### Create the tunnel
 
-1. Install `cloudflared` (2025.7.0+) on a host that can reach ClickHouse and
-   create a tunnel with a public hostname pointing at ClickHouse's HTTP port
-   (`8123` / `8443`):
-   ```bash
-   cloudflared tunnel create chmonitor
-   # route a hostname → your ClickHouse HTTP endpoint
-   cloudflared tunnel route dns chmonitor ch.example.com
-   ```
-2. Add an **Access** application on `ch.example.com` with a **service token**
-   policy, and copy the generated **Client ID** and **Client Secret**.
-3. In chmonitor, add the host with URL `https://ch.example.com` and paste the
-   service-token Client ID / Secret into the connection's headers
-   (`CF-Access-Client-Id` / `CF-Access-Client-Secret`).
+Install `cloudflared` (2025.7.0+) on a host that can reach ClickHouse, then create a tunnel with a public hostname pointing at ClickHouse's HTTP port (`8123` / `8443`):
 
-**Why this is the default:** no inbound firewall hole, no IP allowlist to
-maintain, the token is per-connection and revocable, and traffic is TLS
-end-to-end. It works today (not beta) on free/standard Zero Trust tiers.
+```bash
+cloudflared tunnel create chmonitor
+# route a hostname → your ClickHouse HTTP endpoint
+cloudflared tunnel route dns chmonitor ch.example.com
+```
+</Step>
+<Step>
+### Protect it with an Access service token
 
-## If you must allowlist an IP: dedicated egress IPs
+Add an **Access** application on `ch.example.com` with a **service token** policy, then copy the generated **Client ID** and **Client Secret**.
+</Step>
+<Step>
+### Add the host in chmonitor
 
-Some security teams require a literal firewall allowlist. chmonitor talks to
-ClickHouse over **HTTP** (`@clickhouse/client-web`, i.e. Worker `fetch()`), and
-Cloudflare's
-[Dedicated Egress IPs](https://developers.cloudflare.com/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/)
-**do apply to `fetch()`** (they do not apply to raw-TCP `connect()`). That gives
-the Worker a stable source IP you can allowlist.
+Add the host with URL `https://ch.example.com` and paste the service-token Client ID / Secret into the connection's headers (`CF-Access-Client-Id` / `CF-Access-Client-Secret`).
+</Step>
+</Steps>
+
+**Why this is the default:** no inbound firewall hole, no IP allowlist to maintain, the token is per-connection and revocable, and traffic is TLS end-to-end. It works today (not beta) on free/standard Zero Trust tiers.
+
+## Other options
+
+If a tunnel doesn't fit your environment, choose the path that matches your constraint.
+
+<Tabs items={["Dedicated egress IPs", "Jump host / reverse proxy", "Workers VPC (roadmap)"]}>
+<Tab value="Dedicated egress IPs">
+
+Use this when a security team **requires a literal firewall allowlist**. chmonitor talks to ClickHouse over **HTTP** (`@clickhouse/client-web`, i.e. Worker `fetch()`), and Cloudflare's [Dedicated Egress IPs](https://developers.cloudflare.com/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/) **do apply to `fetch()`** (they do not apply to raw-TCP `connect()`). That gives the Worker a stable source IP you can allowlist.
 
 Caveats:
 
-- It is an **enterprise add-on** on chmonitor's Cloudflare account — contact us
-  if your deployment needs it.
-- The IP is shared across chmonitor's account egress, so the allowlist
-  authorizes "traffic from chmonitor," not a single tenant. Always pair it with
-  TLS + a least-privilege ClickHouse user.
+- It is an **enterprise add-on** on chmonitor's Cloudflare account — contact us if your deployment needs it.
+- The IP is shared across chmonitor's account egress, so the allowlist authorizes "traffic from chmonitor," not a single tenant. Always pair it with TLS + a least-privilege ClickHouse user.
 
 <Callout type="warn" title="Do not allowlist Cloudflare's public IP ranges">
-Cloudflare publishes its IP ranges, but Worker egress over those ranges is
-shared by **every** Cloudflare customer. Allowlisting them authorizes the entire
-Cloudflare fleet — it is not a real allowlist. Use a tunnel or dedicated egress
-IPs instead.
+Cloudflare publishes its IP ranges, but Worker egress over those ranges is shared by **every** Cloudflare customer. Allowlisting them authorizes the entire Cloudflare fleet — it is not a real allowlist. Use a tunnel or dedicated egress IPs instead.
 </Callout>
 
-## Alternative: your own jump host / reverse proxy
+</Tab>
+<Tab value="Jump host / reverse proxy">
 
-Run a small reverse proxy (nginx / HAProxy) on a VM with a **static public IP**
-that forwards to ClickHouse, and allowlist only that proxy. chmonitor then
-connects to the proxy over HTTPS with auth. This always works and is fully under
-your control, but you own the proxy's uptime, TLS, and hardening.
+Run a small reverse proxy (nginx / HAProxy) on a VM with a **static public IP** that forwards to ClickHouse, and allowlist only that proxy. chmonitor then connects to the proxy over HTTPS with auth. This always works and is fully under your control, but you own the proxy's uptime, TLS, and hardening.
 
-## On the roadmap: Workers VPC
+</Tab>
+<Tab value="Workers VPC (roadmap)">
 
-[Workers VPC](https://developers.cloudflare.com/workers-vpc/) (currently beta)
-lets a Worker reach a private service through a Cloudflare Tunnel with **no
-public hostname at all** — the cleanest private-connectivity story. We will adopt
-it for Cloud once it reaches general availability.
+[Workers VPC](https://developers.cloudflare.com/workers-vpc/) (currently beta) lets a Worker reach a private service through a Cloudflare Tunnel with **no public hostname at all** — the cleanest private-connectivity story. We will adopt it for Cloud once it reaches general availability.
 
-## Not supported
+</Tab>
+</Tabs>
 
-[Cloudflare Hyperdrive](https://developers.cloudflare.com/hyperdrive/) only
-supports PostgreSQL and MySQL, so it cannot front a ClickHouse connection.
+## Troubleshooting
 
-## See also
+<Callout type="warn" title="Hyperdrive cannot front ClickHouse">
+[Cloudflare Hyperdrive](https://developers.cloudflare.com/hyperdrive/) only supports PostgreSQL and MySQL, so it cannot front a ClickHouse connection.
+</Callout>
 
-- [ClickHouse User & Grants](/getting-started/clickhouse-requirements) — the
-  least-privilege user chmonitor needs.
-- [Connection errors](/guides/connection-errors) — diagnosing "Test connection"
-  failures.
+## Related
+
+<Cards>
+<Card title="ClickHouse requirements" href="/guide/getting-started/clickhouse-requirements" description="The least-privilege monitoring user chmonitor needs." />
+<Card title="Connection errors" href="/guide/guides/connection-errors" description="Diagnose 'Test connection' failures kind by kind." />
+<Card title="Proxy & SSO auth setup" href="/guide/guides/proxy-auth-setup" description="Put chmonitor behind Cloudflare Access, oauth2-proxy, or Traefik." />
+<Card title="Self-host" href="/operate/deploy/self-host" description="Run inside your network and reach ClickHouse directly — no tunnel needed." />
+</Cards>

--- a/docs/content/guide/guides/connection-errors.mdx
+++ b/docs/content/guide/guides/connection-errors.mdx
@@ -1,58 +1,54 @@
 ---
-description: Fix "Test connection" failures in ClickHouse Monitor — host not allowed, authentication failed, missing permissions, DNS, TLS, refused, and timeout errors.
+title: Connection errors
+description: Fix "Test connection" failures in ClickHouse Monitor — host not allowed, invalid URL, authentication failed, missing permissions, DNS, refused, TLS, and timeout errors.
 icon: PlugZap
 ---
 
-# Connection errors
+When you add a ClickHouse host and click **Test connection**, the dashboard classifies any failure into one of the kinds below and links you straight here. Find your error and follow the fix.
 
-When you add a ClickHouse host and click **Test connection**, the dashboard
-classifies any failure into one of the kinds below and links you straight here.
-Find your error and follow the fix.
+## Fix your error
 
-## Host not allowed
+Each entry lists the message you saw (the symptom) and the fix. The dashboard shows the raw ClickHouse or network error as technical detail underneath the classified error.
 
-> _Connections to internal addresses are not allowed._
+<Accordions>
+<Accordion title="Host not allowed">
 
-The hosted service at **dash.chmonitor.dev** blocks connections to private,
-internal, or loopback addresses (SSRF protection). The Cloud build can only
-reach **publicly routable** ClickHouse endpoints.
+**Symptom** — _Connections to internal addresses are not allowed._
+
+The hosted service at **dash.chmonitor.dev** blocks connections to private, internal, or loopback addresses (SSRF protection). The Cloud build can only reach **publicly routable** ClickHouse endpoints.
 
 **Fix**
 
-- Use a public HTTPS endpoint — for example ClickHouse Cloud, or your own server
-  exposed on a public host and port.
-- To monitor a **private** cluster (VPC, homelab, `localhost`, `10.x`, `192.168.x`),
-  **self-host** ClickHouse Monitor inside your network instead. The self-hosted
-  build has no address restriction. See [Deploy](/operate/deploy/self-host).
+- Use a public HTTPS endpoint — for example ClickHouse Cloud, or your own server exposed on a public host and port.
+- To monitor a **private** cluster (VPC, homelab, `localhost`, `10.x`, `192.168.x`), **self-host** ClickHouse Monitor inside your network instead. The self-hosted build has no address restriction. See [Deploy](/operate/deploy/self-host).
 
-## Invalid host URL
+</Accordion>
+<Accordion title="Invalid host URL">
 
-> _Must be a full URL (e.g. https://my.clickhouse.cloud:8443)_
+**Symptom** — _Must be a full URL (e.g. https://my.clickhouse.cloud:8443)_
 
-The host must be a complete HTTP(S) URL including the scheme and port — not a
-bare hostname.
+The host must be a complete HTTP(S) URL including the scheme and port — not a bare hostname.
 
-**Fix** — enter `https://host:8443` (secure, default HTTPS port) or
-`http://host:8123` (plain HTTP port). See [Connection presets](/reference/connection-presets).
+**Fix** — enter `https://host:8443` (secure, default HTTPS port) or `http://host:8123` (plain HTTP port). See [Connection presets](/reference/connection-presets).
 
-## Authentication failed
+</Accordion>
+<Accordion title="Authentication failed">
 
-> _Code: 516. Authentication failed_ · HTTP 403
+**Symptom** — _Code: 516. Authentication failed_ · HTTP 403
 
 The endpoint was reachable but ClickHouse rejected the **username or password**.
 
 **Fix**
 
 - Re-check the username and password. ClickHouse usernames are **case-sensitive**.
-- If the user is restricted by source IP (`HOST IP` in its definition), allow the
-  dashboard's egress address.
+- If the user is restricted by source IP (`HOST IP` in its definition), allow the dashboard's egress address.
 
-## Not enough permissions
+</Accordion>
+<Accordion title="Not enough permissions">
 
-> _Code: 497. Not enough privileges_
+**Symptom** — _Code: 497. Not enough privileges_
 
-The credentials are valid, but the user is missing the `SELECT` grants the
-dashboard needs on ClickHouse **system tables**.
+The credentials are valid, but the user is missing the `SELECT` grants the dashboard needs on ClickHouse **system tables**.
 
 **Fix** — grant a read-only monitoring user access to the system database:
 
@@ -63,25 +59,23 @@ GRANT SELECT ON system.* TO monitoring;
 GRANT SHOW TABLES, SHOW COLUMNS ON *.* TO monitoring;
 ```
 
-See [ClickHouse requirements](/getting-started/clickhouse-requirements).
+See [ClickHouse requirements](/guide/getting-started/clickhouse-requirements).
 
-## Host not found (DNS)
+</Accordion>
+<Accordion title="Host not found (DNS)">
 
-> _getaddrinfo ENOTFOUND_ · _could not resolve host_
+**Symptom** — _getaddrinfo ENOTFOUND_ · _could not resolve host_
 
-The hostname could not be resolved. It is likely misspelled or only resolvable
-on a private/VPN network.
+The hostname could not be resolved. It is likely misspelled or only resolvable on a private/VPN network.
 
-**Fix** — verify the spelling and that the name resolves on the **public**
-internet. Internal-only DNS names are not reachable from Cloud — self-host to use
-them.
+**Fix** — verify the spelling and that the name resolves on the **public** internet. Internal-only DNS names are not reachable from Cloud — self-host to use them.
 
-## Connection refused
+</Accordion>
+<Accordion title="Connection refused">
 
-> _connect ECONNREFUSED_
+**Symptom** — _connect ECONNREFUSED_
 
-The host resolved but actively refused the connection — ClickHouse is not
-listening on that port, or a firewall is blocking it.
+The host resolved but actively refused the connection — ClickHouse is not listening on that port, or a firewall is blocking it.
 
 **Fix**
 
@@ -89,34 +83,47 @@ listening on that port, or a firewall is blocking it.
 - Ensure ClickHouse accepts external connections (`<listen_host>0.0.0.0</listen_host>`).
 - Open the firewall / security group for the dashboard.
 
-## TLS / certificate error
+</Accordion>
+<Accordion title="TLS / certificate error">
 
-> _self signed certificate_ · _unable to verify the first certificate_
+**Symptom** — _self signed certificate_ · _unable to verify the first certificate_
 
-The TLS handshake failed — usually a self-signed or untrusted certificate, or an
-HTTPS request sent to an HTTP-only port.
+The TLS handshake failed — usually a self-signed or untrusted certificate, or an HTTPS request sent to an HTTP-only port.
 
 **Fix**
 
 - Use a publicly trusted certificate on the ClickHouse HTTPS port.
 - If the server is HTTP-only, use an `http://` URL with the HTTP port (`8123`).
 
-## Connection timed out
+</Accordion>
+<Accordion title="Connection timed out">
 
-> _connect ETIMEDOUT_
+**Symptom** — _connect ETIMEDOUT_
 
-The host did not respond in time — commonly unreachable from the public
-internet, or a firewall silently dropping packets.
+The host did not respond in time — commonly unreachable from the public internet, or a firewall silently dropping packets.
 
-**Fix** — confirm the endpoint is publicly reachable and inbound traffic from the
-dashboard is allowed on the ClickHouse port.
+**Fix** — confirm the endpoint is publicly reachable and inbound traffic from the dashboard is allowed on the ClickHouse port.
+
+</Accordion>
+</Accordions>
 
 ## Still stuck?
 
-- Test the same URL and credentials with `curl`:
-  ```bash
-  echo 'SELECT version()' | curl "https://host:8443/?user=monitoring&password=…" --data-binary @-
-  ```
-- See the general [Troubleshooting guide](/guides/troubleshooting).
-- For private clusters, [self-host ClickHouse Monitor](/operate/deploy/self-host)
-  — the same dashboard, no public-network requirement.
+<Callout type="info" title="Reproduce the failure with curl">
+Test the same URL and credentials outside the dashboard to isolate whether it's a network or a credentials problem:
+
+```bash
+echo 'SELECT version()' | curl "https://host:8443/?user=monitoring&password=…" --data-binary @-
+```
+</Callout>
+
+For **private** clusters, [self-host ClickHouse Monitor](/operate/deploy/self-host) — the same dashboard, with no public-network requirement.
+
+## Related
+
+<Cards>
+<Card title="Troubleshooting" href="/guide/guides/troubleshooting" description="Diagnose connection, auth, performance, and Kubernetes probe failures." />
+<Card title="ClickHouse requirements" href="/guide/getting-started/clickhouse-requirements" description="The least-privilege monitoring user and grants the dashboard needs." />
+<Card title="Connect a firewalled ClickHouse" href="/guide/guides/connect-firewalled-clickhouse" description="Reach a firewalled cluster from Cloud with a tunnel or dedicated egress IPs." />
+<Card title="Self-host" href="/operate/deploy/self-host" description="Run ClickHouse Monitor inside your network with no public-address restriction." />
+</Cards>

--- a/docs/content/guide/guides/proxy-auth-setup.mdx
+++ b/docs/content/guide/guides/proxy-auth-setup.mdx
@@ -1,19 +1,14 @@
 ---
+title: Proxy & SSO auth setup
 description: Set up Cloudflare Access, nginx + oauth2-proxy, or Traefik ForwardAuth in front of chmonitor using the proxy or trusted auth provider.
 icon: ShieldCheck
 ---
 
-# Proxy & SSO auth setup
-
-End-to-end setup guides for putting chmonitor behind a proxy that handles login. Three patterns are covered:
+Put chmonitor behind a proxy that handles login. Three patterns are covered — pick the one that matches your stack. All three use chmonitor's `trusted` or `proxy` auth provider; see [Authentication](/operate/authentication) for the full comparison.
 
 - **Cloudflare Access + Tunnel** — Zero Trust, signed JWT, no shared secret needed.
 - **nginx + oauth2-proxy** — self-hosted OIDC login in front of nginx.
 - **Traefik ForwardAuth + OIDC** — Traefik middleware forwarding an OIDC session.
-
-All three use chmonitor's `trusted` or `proxy` auth provider. See [Authentication](/operate/authentication) for the full comparison.
-
----
 
 ## Quick comparison
 
@@ -23,9 +18,10 @@ All three use chmonitor's `trusted` or `proxy` auth provider. See [Authenticatio
 | nginx + oauth2-proxy | `trusted` | Shared secret header (`X-Chm-Proxy-Secret`) |
 | Traefik ForwardAuth + OIDC | `trusted` | Shared secret header or network isolation |
 
----
+## Set up your proxy
 
-## Cloudflare Access + Tunnel
+<Tabs items={["Cloudflare Access + Tunnel", "nginx + oauth2-proxy", "Traefik ForwardAuth + OIDC"]}>
+<Tab value="Cloudflare Access + Tunnel">
 
 Cloudflare Access sits in front of chmonitor and issues a signed JWT on every authenticated request. chmonitor verifies the JWT cryptographically against Cloudflare's JWKS — no secret to share.
 
@@ -98,19 +94,14 @@ Unauthenticated requests hit the Access login page (Cloudflare redirects them) b
 </Step>
 </Steps>
 
----
+</Tab>
+<Tab value="nginx + oauth2-proxy">
 
-## nginx + oauth2-proxy
-
-oauth2-proxy sits alongside nginx and handles the OIDC login flow. After login it sets forwarded-identity headers that chmonitor's `trusted` provider reads.
-
-### Architecture
+oauth2-proxy sits alongside nginx and handles the OIDC login flow. After login it sets forwarded-identity headers that chmonitor's `trusted` provider reads. nginx uses `auth_request` to check with oauth2-proxy on every request. If the session is valid, oauth2-proxy sets identity headers; nginx forwards them to chmonitor along with a shared secret.
 
 ```
 Browser → nginx → oauth2-proxy (login) → nginx → chmonitor
 ```
-
-nginx uses `auth_request` to check with oauth2-proxy on every request. If the session is valid, oauth2-proxy sets identity headers; nginx forwards them to chmonitor along with a shared secret.
 
 <Steps>
 <Step>
@@ -203,13 +194,10 @@ curl -b "session=..." https://chmonitor.yourcompany.com/api/v1/auth/me | jq .
 </Step>
 </Steps>
 
----
-
-## Traefik ForwardAuth + OIDC
+</Tab>
+<Tab value="Traefik ForwardAuth + OIDC">
 
 Traefik's `forwardAuth` middleware sends every request to an external auth server (e.g. Authelia, Authentik, or a custom endpoint) before proxying it. On success the auth server adds identity headers.
-
-### Architecture
 
 ```
 Browser → Traefik → Authelia (forwardAuth) → Traefik → chmonitor
@@ -262,7 +250,7 @@ services:
         Remote-User,Remote-Groups,Remote-Name,Remote-Email
 ```
 
-Authelia sets `Remote-User`, `Remote-Name`, `Remote-Groups`, `Remote-Email`. Tell chmonitor to read those:
+Authelia sets `Remote-User`, `Remote-Name`, `Remote-Groups`, `Remote-Email`. Tell chmonitor to read those.
 </Step>
 <Step>
 ### Configure chmonitor
@@ -311,44 +299,101 @@ curl https://chmonitor.yourcompany.com/api/v1/auth/me | jq .
 </Step>
 </Steps>
 
----
+</Tab>
+</Tabs>
 
 ## Trusted provider — full reference
 
-All env vars for `CHM_AUTH_PROVIDER=trusted`:
+All env vars for `CHM_AUTH_PROVIDER=trusted`.
 
 ### Trust gate
 
-| Variable | Default | Description |
-|---|---|---|
-| `CHM_TRUSTED_AUTH_SECRET` | — | Shared secret the proxy sends in the secret header. Constant-time compared. |
-| `CHM_TRUSTED_ALLOW_INSECURE` | `false` | Skip secret check when the worker is network-isolated behind the proxy. |
-| `CHM_TRUSTED_SHARED_SECRET_HEADER` | `X-Chm-Proxy-Secret` | Header name the proxy sends the secret in. |
+<TypeTable
+  type={{
+    CHM_TRUSTED_AUTH_SECRET: {
+      description: 'Shared secret the proxy sends in the secret header. Constant-time compared.',
+      type: 'string',
+      default: '—',
+    },
+    CHM_TRUSTED_ALLOW_INSECURE: {
+      description: 'Skip secret check when the worker is network-isolated behind the proxy.',
+      type: 'boolean',
+      default: 'false',
+    },
+    CHM_TRUSTED_SHARED_SECRET_HEADER: {
+      description: 'Header name the proxy sends the secret in.',
+      type: 'string',
+      default: 'X-Chm-Proxy-Secret',
+    },
+  }}
+/>
 
 ### Identity headers
 
-| Variable | Default header | Maps to |
-|---|---|---|
-| `CHM_TRUSTED_USER_HEADER` | `X-Forwarded-User` | User subject / id |
-| `CHM_TRUSTED_EMAIL_HEADER` | `X-Forwarded-Email` | Email address |
-| `CHM_TRUSTED_NAME_HEADER` | `X-Forwarded-Preferred-Username` | Display name |
-| `CHM_TRUSTED_AVATAR_HEADER` | `X-Forwarded-Avatar` | Avatar URL |
-| `CHM_TRUSTED_GROUPS_HEADER` | `X-Forwarded-Groups` | Comma-separated group list |
-| `CHM_TRUSTED_ROLE_HEADER` | `X-Forwarded-Role` | Single role (merged into groups) |
-| `CHM_TRUSTED_CUSTOM_HEADERS` | — | Extra claims: `field:Header-Name` pairs |
+<TypeTable
+  type={{
+    CHM_TRUSTED_USER_HEADER: {
+      description: 'Maps to: User subject / id.',
+      type: 'string',
+      default: 'X-Forwarded-User',
+    },
+    CHM_TRUSTED_EMAIL_HEADER: {
+      description: 'Maps to: Email address.',
+      type: 'string',
+      default: 'X-Forwarded-Email',
+    },
+    CHM_TRUSTED_NAME_HEADER: {
+      description: 'Maps to: Display name.',
+      type: 'string',
+      default: 'X-Forwarded-Preferred-Username',
+    },
+    CHM_TRUSTED_AVATAR_HEADER: {
+      description: 'Maps to: Avatar URL.',
+      type: 'string',
+      default: 'X-Forwarded-Avatar',
+    },
+    CHM_TRUSTED_GROUPS_HEADER: {
+      description: 'Maps to: Comma-separated group list.',
+      type: 'string',
+      default: 'X-Forwarded-Groups',
+    },
+    CHM_TRUSTED_ROLE_HEADER: {
+      description: 'Maps to: Single role (merged into groups).',
+      type: 'string',
+      default: 'X-Forwarded-Role',
+    },
+    CHM_TRUSTED_CUSTOM_HEADERS: {
+      description: 'Extra claims: field:Header-Name pairs.',
+      type: 'string',
+      default: '—',
+    },
+  }}
+/>
 
 ### Access control
 
-| Variable | Default | Description |
-|---|---|---|
-| `CHM_TRUSTED_ALLOWED_GROUPS` | — | Comma-separated list of groups. If set, user must be in at least one. |
+<TypeTable
+  type={{
+    CHM_TRUSTED_ALLOWED_GROUPS: {
+      description: 'Comma-separated list of groups. If set, user must be in at least one.',
+      type: 'string',
+      default: '—',
+    },
+  }}
+/>
 
----
+## Troubleshooting
+
+<Callout type="info" title="Every page returns 401">
+The `trusted` and `proxy` providers reject requests they can't verify. Confirm the trust gate: for `proxy`, `CHM_CF_ACCESS_TEAM_DOMAIN` and `CHM_CF_ACCESS_AUD`; for `trusted`, `CHM_TRUSTED_AUTH_SECRET` or `CHM_TRUSTED_ALLOW_INSECURE`. See [Troubleshooting → Auth failures](/guide/guides/troubleshooting).
+</Callout>
 
 ## Related
 
-- [Authentication overview](/operate/authentication)
-- [Trusted proxy docs](/operate/authentication/trusted-proxy)
-- [Cloudflare Access docs](/operate/authentication/cloudflare-access)
-- [Trusted header docs](/operate/authentication/trusted-header)
-- [API keys](/operate/authentication/api-keys)
+<Cards>
+<Card title="Authentication overview" href="/operate/authentication" description="Compare all chmonitor auth providers side by side." />
+<Card title="Trusted proxy docs" href="/operate/authentication/trusted-proxy" description="Reference for the trusted forwarded-identity provider." />
+<Card title="Cloudflare Access docs" href="/operate/authentication/cloudflare-access" description="Reference for the proxy JWT provider." />
+<Card title="Trusted header docs" href="/operate/authentication/trusted-header" description="Header mapping for forwarded identity." />
+<Card title="API keys" href="/operate/authentication/api-keys" description="Issue and use chmonitor API tokens." />
+</Cards>

--- a/docs/content/guide/guides/troubleshooting.mdx
+++ b/docs/content/guide/guides/troubleshooting.mdx
@@ -1,15 +1,15 @@
 ---
+title: Troubleshooting
 description: Diagnose and fix common chmonitor issues — connection failures, auth errors, performance problems, and Kubernetes probe failures.
 icon: Wrench
 ---
 
-# Troubleshooting
-
-Common issues and how to diagnose them.
+Common issues and how to diagnose them, grouped by symptom. Expand the entry that matches what you're seeing.
 
 ## Connection failures
 
-### Dashboard shows "Connection error" or blank charts
+<Accordions>
+<Accordion title='Dashboard shows "Connection error" or blank charts'>
 
 **Check the ClickHouse URL:**
 
@@ -41,7 +41,8 @@ If host count differs from user/password count, the second host silently falls b
 If ClickHouse uses a self-signed cert, set `CLICKHOUSE_VERIFY_CERT=false` or pass `?verify=false` in the URL. In production, install the CA cert instead.
 </Callout>
 
-### Health endpoint returns 503
+</Accordion>
+<Accordion title="Health endpoint returns 503">
 
 `/healthz` always returns 200 (static liveness probe). `/api/healthz` returns 503 when the ClickHouse connection fails. Check:
 
@@ -55,7 +56,8 @@ curl -s https://your-dashboard/api/healthz | jq .
 # {"status":"error","clickhouse":"error","message":"..."} on failure
 ```
 
-### "Query timeout" on large tables
+</Accordion>
+<Accordion title='"Query timeout" on large tables'>
 
 Increase `CLICKHOUSE_MAX_EXECUTION_TIME` (default 60 seconds):
 
@@ -65,11 +67,13 @@ CLICKHOUSE_MAX_EXECUTION_TIME=120
 
 For heavy queries (full query-log scans), the dashboard also respects ClickHouse-level query complexity limits. Consider raising `max_execution_time` on the monitoring user profile.
 
----
+</Accordion>
+</Accordions>
 
 ## Auth failures (401 / white screen)
 
-### Every page returns 401
+<Accordions>
+<Accordion title="Every page returns 401">
 
 `CHM_AUTH_PROVIDER` is set to something other than `none` but is not configured properly:
 
@@ -85,7 +89,8 @@ curl -s https://your-dashboard/api/v1/auth/me | jq .
 # {"error":"Authentication required"} when auth is on but request is not authenticated
 ```
 
-### White screen after login (Clerk)
+</Accordion>
+<Accordion title="White screen after login (Clerk)">
 
 The client auth value is derived from `CHM_AUTH_PROVIDER` and inlined at build time. If `CHM_AUTH_PROVIDER` was not set at build time, the client JS doesn't know about Clerk and may loop or blank out.
 
@@ -97,11 +102,13 @@ curl https://your-dashboard/ | grep pk_live
 ```
 
 If it is missing, rebuild with:
+
 ```bash
 CHM_AUTH_PROVIDER=clerk CHM_CLERK_PUBLISHABLE_KEY=pk_live_... bun run build
 ```
 
-### API key returns 401
+</Accordion>
+<Accordion title="API key returns 401">
 
 - The token must be prefixed `chm_` — tokens issued by `/api/v1/auth/api-key`.
 - The token was issued against a specific `CHM_API_KEY_SECRET`. If the secret was rotated, old tokens are invalid.
@@ -113,28 +120,33 @@ curl -X POST https://your-dashboard/api/v1/auth/api-key \
   -H "Authorization: Bearer $CHM_API_KEY_SECRET"
 ```
 
-### MCP client returns 401
+</Accordion>
+<Accordion title="MCP client returns 401">
 
 <Callout type="info" title="MCP endpoint is closed by default">
 One of `CHM_API_KEY_SECRET`, `CLERK_SECRET_KEY`, or `CHM_MCP_PUBLIC=true` must be set to open the endpoint. See [MCP Server — Permissions](/guide/features/mcp#permissions--access).
 </Callout>
 
----
+</Accordion>
+</Accordions>
 
 ## Performance / timeouts
 
-### Dashboard is slow to load
+<Accordions>
+<Accordion title="Dashboard is slow to load">
 
 Most dashboard pages are a static shell with client-side data fetching. A slow initial page usually means:
 - The static bundle is not cached at the edge (first request after a deploy).
 - The ClickHouse query itself is slow.
 
 To identify slow queries, open the AI agent and ask:
+
 > "What were the slowest queries in the last 5 minutes?"
 
 Or from the Queries → Slow Queries page.
 
-### Charts refresh too frequently
+</Accordion>
+<Accordion title="Charts refresh too frequently">
 
 Default refresh is 60 seconds for most charts. Reduce load by setting a longer interval:
 
@@ -145,7 +157,8 @@ Default refresh is 60 seconds for most charts. Reduce load by setting a longer i
 
 Alternatively, enable query caching on the monitoring user profile (see [ClickHouse User & Grants](/guide/getting-started/clickhouse-requirements#recommended-clickhouse-profile)).
 
-### `max_query_size exceeded` errors
+</Accordion>
+<Accordion title="max_query_size exceeded errors">
 
 Some dashboard queries on very large query logs can exceed ClickHouse's default `max_query_size`. Add to the monitoring user profile:
 
@@ -153,11 +166,13 @@ Some dashboard queries on very large query logs can exceed ClickHouse's default 
 <max_query_size>1073741824</max_query_size>
 ```
 
----
+</Accordion>
+</Accordions>
 
 ## AI agent / LLM failures
 
-### Agent returns "LLM API key not set"
+<Accordions>
+<Accordion title='Agent returns "LLM API key not set"'>
 
 Set `LLM_API_KEY` to your OpenRouter, Anthropic, or OpenAI key:
 
@@ -172,33 +187,40 @@ LLM_BASE_URL=https://api.anthropic.com/v1
 LLM_MODEL=claude-opus-4-5
 ```
 
-### Agent does not respond / hangs
+</Accordion>
+<Accordion title="Agent does not respond / hangs">
 
 Check:
+
 1. `LLM_API_KEY` is a server-side variable (not `VITE_LLM_API_KEY`).
 2. The provider endpoint is reachable from the Worker / container.
 3. The model name is correct for the provider — OpenRouter uses `provider/model` format (e.g. `anthropic/claude-3-5-sonnet`).
 
-### Agent answers are vague or wrong
+</Accordion>
+<Accordion title="Agent answers are vague or wrong">
 
 The agent is bounded by the ClickHouse user's grants. If it cannot read `system.query_log` (the most data-rich source), answers will be shallow.
 
 Confirm grants:
+
 ```sql
 SELECT count() FROM system.query_log;
 ```
 
 If this returns a permission error, grant the monitoring user `SELECT ON system.*`.
 
-### Agent session metrics show high token usage
+</Accordion>
+<Accordion title="Agent session metrics show high token usage">
 
 Long conversations accumulate context. Start a new conversation to reset the context window. If you see large token counts on simple questions, the system prompt or a long skill is being included — this is expected and keeps answers accurate.
 
----
+</Accordion>
+</Accordions>
 
 ## Kubernetes / Helm health probes
 
-### Pod stuck in `CrashLoopBackOff`
+<Accordions>
+<Accordion title="Pod stuck in CrashLoopBackOff">
 
 <Callout type="warn" title="Stale image tag">
 Common cause: the image pulled is stale (`latest` tag was not updated after a deploy). Check the image digest with `kubectl describe pod` and force a re-pull with `kubectl rollout restart deployment chmonitor`.
@@ -209,7 +231,8 @@ kubectl describe pod <chmonitor-pod> | grep Image
 kubectl rollout restart deployment chmonitor
 ```
 
-### Liveness probe failing
+</Accordion>
+<Accordion title="Liveness probe failing">
 
 `/healthz` (liveness) should always return 200 — it is a static response. If it is failing, the container is not starting at all. Check container logs:
 
@@ -221,11 +244,13 @@ Common causes:
 - Missing required env vars (`CLICKHOUSE_HOST`)
 - Port mismatch — the Worker listens on `8080` by default; confirm the probe and container port match
 
-### Readiness probe failing
+</Accordion>
+<Accordion title="Readiness probe failing">
 
 `/api/healthz` (readiness) checks the ClickHouse connection. A 503 here means the pod is up but cannot reach ClickHouse. The pod will be removed from the Service endpoints until it recovers.
 
 Check:
+
 1. ClickHouse is running and the connection string is correct.
 2. NetworkPolicy allows port 8443 from the dashboard namespace.
 3. The monitoring user credentials work: `curl http://pod:8080/api/healthz`.
@@ -254,7 +279,8 @@ startupProbe:
   periodSeconds: 5
 ```
 
-### Helm chart: dashboard can reach ClickHouse but shows no data
+</Accordion>
+<Accordion title="Helm chart: dashboard can reach ClickHouse but shows no data">
 
 The chart creates a `ConfigMap` for env vars. Confirm the values are correct:
 
@@ -264,11 +290,15 @@ kubectl get configmap chmonitor -o yaml | grep CLICKHOUSE
 
 If the host uses `https://`, confirm TLS is allowed or `CLICKHOUSE_VERIFY_CERT=false` is set.
 
----
+</Accordion>
+</Accordions>
 
 ## Related
 
-- [ClickHouse User & Grants](/guide/getting-started/clickhouse-requirements)
-- [MCP Server — Permissions](/guide/features/mcp#permissions--access)
-- [Authentication](/operate/authentication)
-- [Upgrading ClickHouse](/guide/guides/upgrade-clickhouse)
+<Cards>
+<Card title="ClickHouse User & Grants" href="/guide/getting-started/clickhouse-requirements" description="The least-privilege monitoring user and grants the dashboard needs." />
+<Card title="Connection errors" href="/guide/guides/connection-errors" description="Diagnose 'Test connection' failures kind by kind." />
+<Card title="MCP Server — Permissions" href="/guide/features/mcp#permissions--access" description="Open and secure the MCP endpoint." />
+<Card title="Authentication" href="/operate/authentication" description="Compare and configure chmonitor auth providers." />
+<Card title="Upgrading ClickHouse" href="/guide/guides/upgrade-clickhouse" description="Upgrade safely while chmonitor stays connected." />
+</Cards>

--- a/docs/content/guide/guides/upgrade-clickhouse.mdx
+++ b/docs/content/guide/guides/upgrade-clickhouse.mdx
@@ -1,11 +1,10 @@
 ---
+title: Upgrading ClickHouse
 description: Safely upgrade ClickHouse when chmonitor is connected — pre-upgrade checks, version-by-version dashboard changes, and post-upgrade validation.
 icon: ArrowUpCircle
 ---
 
-# Upgrading ClickHouse
-
-Steps to safely upgrade ClickHouse when chmonitor is connected to it, including which system-table changes affect the dashboard and how to validate everything after the upgrade.
+Upgrade ClickHouse safely while chmonitor stays connected to it: run the pre-upgrade checks, know which system-table changes affect the dashboard, then validate everything afterward.
 
 ## Before you upgrade
 
@@ -74,13 +73,15 @@ All replicas should be healthy with no read-only instances before the upgrade.
 
 ## Version-by-version changes that affect the dashboard
 
-chmonitor uses versioned SQL (the `since` field in each query config) to automatically pick the right query for the connected ClickHouse version. No config changes are needed when upgrading, but the notes below explain what you gain.
+chmonitor uses versioned SQL (the `since` field in each query config) to automatically pick the right query for the connected ClickHouse version. No config changes are needed when upgrading, but the notes below explain what you gain at each step.
 
-### 19.x → 22.x
+<Tabs items={["19.x → 22.x", "22.x → 23.x", "23.x → 24.x", "24.x → 25.x", "Keeper tables"]}>
+<Tab value="19.x → 22.x">
 
 Basic monitoring (processes, merges, replicas, metrics, disks, settings, parts) works on any version the dashboard supports. Older versions are missing several tables entirely.
 
-### 22.x → 23.x
+</Tab>
+<Tab value="22.x → 23.x">
 
 - **`system.query_views_log`** — available from 22.4. The Query Views Log page becomes active.
 - **`system.moves`** — parts moving between volumes become visible.
@@ -88,7 +89,8 @@ Basic monitoring (processes, merges, replicas, metrics, disks, settings, parts) 
 - **`system.session_log`** — security: Login Attempts and Sessions pages become active.
 - **`system.processors_profile_log`** — Query Profiler page becomes active.
 
-### 23.x → 24.x
+</Tab>
+<Tab value="23.x → 24.x">
 
 - **`system.user_processes`** — per-user process tree (separate from `system.processes`). The User Processes page becomes active from 23.3.
 - **`system.part_log`** — part-level event history. Merge Performance anomaly detection becomes active.
@@ -98,15 +100,20 @@ Basic monitoring (processes, merges, replicas, metrics, disks, settings, parts) 
 - **`system.view_refreshes`** — Refreshable Materialized Views become visible.
 - **`system.zookeeper_connection_log`** — detailed Keeper connection history (added in 25.8; dashboard shows a notice on older versions).
 
-### 24.x → 25.x
+</Tab>
+<Tab value="24.x → 25.x">
 
 - **`system.distributed_ddl_queue`** — Distributed DDL queue page becomes active.
 - **`system.asynchronous_metrics`** — extra background-metrics page becomes available.
 - **`system.replicated_merge_tree_settings`** — per-table replicated merge-tree settings page.
 
-### ClickHouse Keeper tables
+</Tab>
+<Tab value="Keeper tables">
 
 All Keeper-related pages (`system.zookeeper`, `system.zookeeper_connection`, `system.zookeeper_log`, `system.zookeeper_info`, `system.zookeeper_watches`) require ClickHouse Keeper or ZooKeeper to be configured. They appear as empty notices when Keeper is not set up.
+
+</Tab>
+</Tabs>
 
 ## After the upgrade
 
@@ -157,13 +164,39 @@ After a major upgrade, `system.settings` may contain settings marked deprecated.
 
 ## Rolling upgrades on replicated clusters
 
-1. Upgrade one replica at a time.
-2. After each node upgrades, confirm it rejoins replication (`is_readonly = 0`, `queue_size` draining).
-3. The dashboard's Replication page shows per-table replica health across the cluster.
-4. Do not upgrade the next node until the previous one is fully caught up.
+<Steps>
+<Step>
+### Upgrade one replica at a time
+
+Upgrade a single node before touching the next.
+</Step>
+<Step>
+### Confirm the node rejoins replication
+
+After each node upgrades, confirm it rejoins replication (`is_readonly = 0`, `queue_size` draining).
+</Step>
+<Step>
+### Watch the Replication page
+
+The dashboard's Replication page shows per-table replica health across the cluster.
+</Step>
+<Step>
+### Wait before the next node
+
+Do not upgrade the next node until the previous one is fully caught up.
+</Step>
+</Steps>
+
+## Troubleshooting
+
+<Callout type="info" title="A page still shows 'Table not available' after upgrading">
+The dashboard picks up new system tables automatically, but the table has to exist and the monitoring user must be able to SELECT from it. Re-check grants with the sanity queries above, and confirm the table exists for your version in the version-by-version notes. Keeper pages stay empty until ClickHouse Keeper or ZooKeeper is configured.
+</Callout>
 
 ## Related
 
-- [ClickHouse User & Grants](/guide/getting-started/clickhouse-requirements)
-- [Troubleshooting](/guide/guides/troubleshooting)
-- [Health probes](/operate/deploy/k8s#health-probes)
+<Cards>
+<Card title="ClickHouse User & Grants" href="/guide/getting-started/clickhouse-requirements" description="Re-apply the least-privilege grants the dashboard needs." />
+<Card title="Troubleshooting" href="/guide/guides/troubleshooting" description="Diagnose connection, auth, performance, and probe failures." />
+<Card title="Health probes" href="/operate/deploy/k8s#health-probes" description="Liveness and readiness probe settings for Kubernetes." />
+</Cards>


### PR DESCRIPTION
## Summary

Full prose rewrite of the five how-to guides under `docs/content/guide/guides/` for one consistent, action-first voice and a shared Fumadocs page skeleton (lead sentence → `<Steps>`/`<Tabs>` walkthrough → **Troubleshooting** → **Related** `<Cards>`), with more interactive components. **Every technical fact is preserved verbatim** — env vars, ports, SQL, shell commands, error strings, and code blocks are unchanged.

### Per-file changes
- **connection-errors** — each error cause is now an `<Accordion>` (symptom → fix). Keeps the `guides/connection-errors` slug that the app's connection-error classifier (`lib/connection-errors.ts`) links to.
- **connect-firewalled-clickhouse** — `<Steps>` for the recommended Cloudflare Tunnel path; `<Tabs>` for the dedicated-egress-IP / jump-host / Workers-VPC variants.
- **proxy-auth-setup** — `<Tabs>` for the three proxy patterns (Cloudflare Access, nginx + oauth2-proxy, Traefik ForwardAuth); `<TypeTable>` for the trusted-provider env reference.
- **troubleshooting** — symptoms grouped by area, each an `<Accordion>`.
- **upgrade-clickhouse** — `<Tabs>` for the version-by-version dashboard changes.

### Consistency fixes
- Frontmatter normalized to `title` + `description` + `icon`; `type="tip"` Callouts → `type="info"`.
- Every page ends with a `## Related` `<Cards>` block; every `<Card>` has a description.
- Fixed pre-existing broken `/getting-started/*` links to the correct `/guide/getting-started/*` root.

No pages were added, removed, or renamed.

## Verification
Ran the docs sync + MDX compile against a clean `origin/main` baseline:

```
cd apps/docs && bun run sync && bunx fumadocs-mdx
```

Both exit 0; all five pages regenerate cleanly under `apps/docs/content/docs/guide/guides/`.

Co-Authored-By: duyetbot <bot@duyet.net>