### PR TITLE
docs(guide): rewrite getting-started for consistency

### DIFF
--- a/docs/content/guide/getting-started.mdx
+++ b/docs/content/guide/getting-started.mdx
@@ -1,11 +1,10 @@
 ---
-description: Run chmonitor against your ClickHouse instance in minutes using Docker or from source — three environment variables and one command.
+title: Getting started
+description: Run chmonitor against your ClickHouse instance in minutes — three environment variables and one command, via Docker or from source.
 icon: Rocket
 ---
 
-# Getting Started
-
-The fastest path: run chmonitor against an existing ClickHouse instance. You need three environment variables and one command.
+Point chmonitor at an existing ClickHouse instance and you have a dashboard. You need three environment variables and one command. Pick Docker for the fastest path, or run from source to develop against it.
 
 ## Prerequisites
 
@@ -48,18 +47,6 @@ If ClickHouse runs on the same Docker host, use the host gateway address instead
 ### Open the dashboard
 
 Navigate to [http://localhost:3000](http://localhost:3000). The overview page loads immediately.
-
-</Step>
-
-<Step>
-
-### Verify it works
-
-If pages are empty or show errors:
-
-1. Check the container logs: `docker logs chmonitor`
-2. Confirm the ClickHouse user can query `system.query_log` directly.
-3. See [Enable system tables](/guide/getting-started/clickhouse-enable-system-tables) if some tables are missing.
 
 </Step>
 
@@ -111,13 +98,27 @@ Open [http://localhost:3001](http://localhost:3001).
 
 </Steps>
 
-See the [Local development guide](/guide/getting-started/local) for the complete setup including testing and building.
+See the [local development guide](/guide/getting-started/local) for the complete setup including testing and building.
 
 </Tab>
 
 </Tabs>
 
-## Next steps
+## Verify
+
+The overview page should render metrics right away. If pages are empty or show errors:
+
+1. Check the container logs: `docker logs chmonitor` (Docker path).
+2. Confirm the ClickHouse user can query `system.query_log` directly.
+3. See [Enable system tables](/guide/getting-started/clickhouse-enable-system-tables) if some tables are missing.
+
+## Troubleshooting
+
+<Callout type="warn" title="Empty pages or connection errors">
+An empty overview usually means the dashboard reached ClickHouse but the user lacks grants, or the connection itself failed. Verify the user has `SELECT` on `system.*` ([ClickHouse user & grants](/guide/getting-started/clickhouse-requirements)), then confirm `CLICKHOUSE_HOST` is reachable from the container or process.
+</Callout>
+
+## Related
 
 <Cards>
   <Card
@@ -131,7 +132,7 @@ See the [Local development guide](/guide/getting-started/local) for the complete
     description="Enable system log tables for full feature coverage."
   />
   <Card
-    title="Install & Configure"
+    title="Install & configure"
     href="/operate/deploy"
     description="Deploy to Kubernetes, Cloudflare Workers, or another platform."
   />
@@ -141,7 +142,7 @@ See the [Local development guide](/guide/getting-started/local) for the complete
     description="Require login before accessing the dashboard."
   />
   <Card
-    title="AI Agent"
+    title="AI agent"
     href="/guide/ai-agent"
     description="Set up natural-language queries about your cluster."
   />

--- a/docs/content/guide/getting-started/clickhouse-enable-system-tables.mdx
+++ b/docs/content/guide/getting-started/clickhouse-enable-system-tables.mdx
@@ -1,9 +1,8 @@
 ---
-description: Enable and configure ClickHouse system log tables required for full chmonitor feature coverage, including query_log, metric_log, and optional thread logs.
+title: Enable system tables
+description: Enable and configure ClickHouse system log tables for full chmonitor feature coverage, including query_log, metric_log, and optional thread logs.
 icon: TerminalSquare
 ---
-
-# Enable System Tables
 
 chmonitor reads from ClickHouse `system.*` log tables. Most are enabled by default in a fresh installation, but some deployments disable them with `<... remove="1"/>` to save disk. This page lists which tables are needed and how to enable them.
 
@@ -35,7 +34,13 @@ These unlock specific features. chmonitor handles their absence gracefully — t
 | `system.backup_log` | Backup/restore history | Not present | Only exists when backup is configured |
 | `system.zookeeper` | ZooKeeper / Keeper status | Not present | Only available when Keeper/ZooKeeper is configured |
 
-## Configuration
+## Enable the tables
+
+<Steps>
+
+<Step>
+
+### Add the config block
 
 Create or edit `/etc/clickhouse-server/config.d/system-logs.xml`:
 
@@ -163,7 +168,11 @@ Create or edit `/etc/clickhouse-server/config.d/system-logs.xml`:
 </clickhouse>
 ```
 
-## Enable `log_query_threads`
+</Step>
+
+<Step>
+
+### Enable `log_query_threads`
 
 For `query_thread_log` to collect data, set `log_query_threads=1` in the profile used by the monitoring user:
 
@@ -178,6 +187,25 @@ For `query_thread_log` to collect data, set `log_query_threads=1` in the profile
 </clickhouse>
 ```
 
+</Step>
+
+<Step>
+
+### Restart and verify
+
+After applying the config, restart ClickHouse and check which log tables are present:
+
+```bash
+sudo systemctl restart clickhouse-server
+
+clickhouse-client --query \
+  "SELECT name FROM system.tables WHERE database = 'system' AND name LIKE '%_log' ORDER BY name"
+```
+
+</Step>
+
+</Steps>
+
 ## Re-enabling disabled tables
 
 If your config has entries like:
@@ -189,18 +217,11 @@ If your config has entries like:
 <query_thread_log remove="1"/>
 ```
 
-Remove those lines and add the corresponding config block from the section above. The `remove="1"` attribute completely prevents the table from being created — removing the attribute alone is not enough if no config block exists.
+Remove those lines and add the corresponding config block from the section above.
 
-## Verify
-
-After applying the config, restart ClickHouse and check which log tables are present:
-
-```bash
-sudo systemctl restart clickhouse-server
-
-clickhouse-client --query \
-  "SELECT name FROM system.tables WHERE database = 'system' AND name LIKE '%_log' ORDER BY name"
-```
+<Callout type="warn" title="The remove attribute prevents table creation">
+The `remove="1"` attribute completely prevents the table from being created — removing the attribute alone is not enough if no config block exists.
+</Callout>
 
 ## Controlling disk usage
 
@@ -209,3 +230,23 @@ System log tables can grow large. Useful levers:
 - **`max_size_rows`**: Caps the table size (default ~1M rows). Rows are dropped when the limit is hit.
 - **TTL**: Configure a TTL to prune old rows automatically. This is set in `config.xml` (or a file in `config.d/`) under the relevant log block — for example, `<ttl>event_date + INTERVAL 30 DAY DELETE</ttl>`. Direct `ALTER TABLE` on system tables is generally restricted.
 - **`collect_interval_milliseconds`**: Higher values mean less frequent metric collection. `60000` (1 minute) is a reasonable default for most deployments.
+
+## Related
+
+<Cards>
+  <Card
+    title="ClickHouse user & grants"
+    href="/guide/getting-started/clickhouse-requirements"
+    description="Create a read-only monitoring user with the grants each feature needs."
+  />
+  <Card
+    title="Getting started"
+    href="/guide/getting-started"
+    description="Run chmonitor against your ClickHouse instance in minutes."
+  />
+  <Card
+    title="Features"
+    href="/guide/features"
+    description="See which dashboard page each system table powers."
+  />
+</Cards>

--- a/docs/content/guide/getting-started/clickhouse-requirements.mdx
+++ b/docs/content/guide/getting-started/clickhouse-requirements.mdx
@@ -1,13 +1,12 @@
 ---
+title: ClickHouse user & grants
 description: Create a minimal read-only ClickHouse user for chmonitor, with optional action grants and a recommended monitoring profile.
 icon: ListChecks
 ---
 
-# ClickHouse User & Grants
-
 chmonitor needs a ClickHouse user with at minimum `SELECT` on `system.*`. Do not use an admin account for a shared dashboard.
 
-<Callout type="tip" title="Connecting a firewalled ClickHouse to Cloud?">
+<Callout type="info" title="Connecting a firewalled ClickHouse to Cloud?">
 If your ClickHouse is behind a firewall and you use the hosted Cloud, see
 [Connect a firewalled ClickHouse](/guides/connect-firewalled-clickhouse) for how
 to reach it without a brittle IP allowlist (Cloudflare Tunnel, dedicated egress
@@ -359,3 +358,28 @@ Create a monitoring profile to enable query caching and the experimental analyze
   </users>
 </clickhouse>
 ```
+
+## Related
+
+<Cards>
+  <Card
+    title="Enable system tables"
+    href="/guide/getting-started/clickhouse-enable-system-tables"
+    description="Enable system log tables so every dashboard feature has data to read."
+  />
+  <Card
+    title="Getting started"
+    href="/guide/getting-started"
+    description="Run chmonitor against your ClickHouse instance in minutes."
+  />
+  <Card
+    title="Connect a firewalled ClickHouse"
+    href="/guides/connect-firewalled-clickhouse"
+    description="Reach a firewalled ClickHouse from the hosted Cloud without a brittle IP allowlist."
+  />
+  <Card
+    title="Environment variables"
+    href="/reference/environment-variables"
+    description="Every environment variable, grouped by category."
+  />
+</Cards>

--- a/docs/content/guide/getting-started/local.mdx
+++ b/docs/content/guide/getting-started/local.mdx
@@ -1,9 +1,8 @@
 ---
-description: Run the chmonitor dashboard from source using Bun and TanStack Start for local development and testing before deploying.
+title: Local development
+description: Run the chmonitor dashboard from source with Bun and TanStack Start to develop and test changes before deploying.
 icon: TerminalSquare
 ---
-
-# Local Development
 
 Run chmonitor from source for development or to test changes before deploying.
 
@@ -75,7 +74,7 @@ Client vars are inlined at build time and shipped to the browser.
 
 ### Configure ClickHouse
 
-Make sure the user you set in step 3 has the right grants. See:
+Make sure the user you set in the previous step has the right grants:
 
 - [ClickHouse user & grants](/guide/getting-started/clickhouse-requirements)
 - [Enable system tables](/guide/getting-started/clickhouse-enable-system-tables)
@@ -97,10 +96,41 @@ Open [http://localhost:3000](http://localhost:3000).
 
 </Steps>
 
-## Common issues
+## Verify
 
-**`localhost` connection refused** — If ClickHouse is not running locally, update `CLICKHOUSE_HOST` to point at your remote instance.
+The dashboard should hot-reload as you edit source, and the overview page should render live metrics from your ClickHouse instance.
 
-**Type errors on first run** — Run `bun run type-check` from the repo root. Some generated types require a build pass first.
+## Troubleshooting
 
-**Missing system tables** — See [Enable system tables](/guide/getting-started/clickhouse-enable-system-tables).
+<Callout type="warn" title="Common issues">
+
+- **`localhost` connection refused** — If ClickHouse is not running locally, update `CLICKHOUSE_HOST` to point at your remote instance.
+- **Type errors on first run** — Run `bun run type-check` from the repo root. Some generated types require a build pass first.
+- **Missing system tables** — See [Enable system tables](/guide/getting-started/clickhouse-enable-system-tables).
+
+</Callout>
+
+## Related
+
+<Cards>
+  <Card
+    title="Getting started"
+    href="/guide/getting-started"
+    description="Run chmonitor against your ClickHouse instance in minutes."
+  />
+  <Card
+    title="ClickHouse user & grants"
+    href="/guide/getting-started/clickhouse-requirements"
+    description="Create a safe read-only monitoring user with the minimal grants needed."
+  />
+  <Card
+    title="Enable system tables"
+    href="/guide/getting-started/clickhouse-enable-system-tables"
+    description="Enable system log tables for full feature coverage."
+  />
+  <Card
+    title="Install & configure"
+    href="/operate/deploy"
+    description="Deploy to Kubernetes, Cloudflare Workers, or another platform."
+  />
+</Cards>

--- a/docs/content/guide/index.mdx
+++ b/docs/content/guide/index.mdx
@@ -1,13 +1,10 @@
 ---
-description: chmonitor is a read-only ClickHouse monitoring dashboard with an AI agent and MCP server, deployable on Docker, Kubernetes, or Cloudflare Workers.
+title: Introduction
+description: A read-only ClickHouse monitoring dashboard with an AI agent and MCP server — deploy on Docker, Kubernetes, or Cloudflare Workers.
 icon: BookOpen
 ---
 
-# Introduction
-
-chmonitor is a client-rendered ClickHouse monitoring dashboard. The core dashboard reads from ClickHouse `system.*` tables and renders query performance, storage, cluster health, and operational metrics directly in the browser. No SSR of your ClickHouse data; no database writes except optional self-tracking events.
-
-It also ships an AI agent that can answer natural-language questions about your cluster, and an MCP server that exposes monitoring tools to external AI clients.
+chmonitor is a client-rendered ClickHouse monitoring dashboard. It reads from your ClickHouse `system.*` tables and renders query performance, storage, cluster health, and operational metrics directly in the browser. It does not SSR your ClickHouse data and writes nothing to the database except optional self-tracking events. An AI agent answers natural-language questions about your cluster, and an MCP server exposes the same monitoring tools to external AI clients.
 
 <Mermaid chart={`graph LR
   A[Browser] -->|fetch| B[chmonitor]
@@ -31,12 +28,12 @@ chmonitor does not manage schema, run DDL, or modify ClickHouse configuration. O
 
 <Cards>
   <Card
-    title="Getting Started"
+    title="Getting started"
     href="/guide/getting-started"
     description="Get a monitoring dashboard running in 5 minutes with Docker."
   />
   <Card
-    title="Install & Configure"
+    title="Install & configure"
     href="/operate/deploy"
     description="Deploy on Docker, Kubernetes, Cloudflare Workers, or Vercel."
   />
@@ -51,7 +48,7 @@ chmonitor does not manage schema, run DDL, or modify ClickHouse configuration. O
     description="Add login and fine-grained access control."
   />
   <Card
-    title="AI Agent"
+    title="AI agent"
     href="/guide/ai-agent"
     description="Ask natural-language questions about your ClickHouse cluster."
   />
@@ -59,5 +56,25 @@ chmonitor does not manage schema, run DDL, or modify ClickHouse configuration. O
     title="Reference"
     href="/reference/environment-variables"
     description="Every environment variable, grouped by category."
+  />
+</Cards>
+
+## Related
+
+<Cards>
+  <Card
+    title="ClickHouse user & grants"
+    href="/guide/getting-started/clickhouse-requirements"
+    description="Create a safe read-only monitoring user with the minimal grants needed."
+  />
+  <Card
+    title="Enable system tables"
+    href="/guide/getting-started/clickhouse-enable-system-tables"
+    description="Enable system log tables for full feature coverage."
+  />
+  <Card
+    title="Local development"
+    href="/guide/getting-started/local"
+    description="Run the dashboard from source with hot reload."
   />
 </Cards>


### PR DESCRIPTION
Rewrites the guide landing + getting-started unit for one consistent voice and a shared Fumadocs page skeleton, with richer interactive components. Every technical fact (env var names, commands, grants, SQL/XML, defaults) is preserved verbatim.

## Pages rewritten
- \`docs/content/guide/index.mdx\` — tighter intro, Cards grid, Related block
- \`docs/content/guide/getting-started.mdx\` — Docker/from-source Tabs + Steps, Verify + Troubleshooting sections
- \`docs/content/guide/getting-started/local.mdx\` — Steps, Verify + Troubleshooting + Related
- \`docs/content/guide/getting-started/clickhouse-requirements.mdx\` — Callout \`type="info"\` (was non-standard \`tip\`), Related block; keeps \`<GrantBuilder />\`
- \`docs/content/guide/getting-started/clickhouse-enable-system-tables.mdx\` — Steps walkthrough for enabling tables, Callouts, Related block

## Verification
- \`bun run sync\` and \`bunx fumadocs-mdx\` both exit 0; all 5 pages compile under \`apps/docs/content/docs/**\`.

Co-Authored-By: duyetbot <bot@duyet.net>