### PR TITLE
docs(features): rewrite logs/settings/mcp/peerdb/connections pages

### DIFF
--- a/docs/content/guide/features/browser-connections.mdx
+++ b/docs/content/guide/features/browser-connections.mdx
@@ -1,20 +1,21 @@
 ---
 description: Add personal ClickHouse connections in the browser with AES-256-GCM encrypted credentials and server-side proxy — no config changes needed.
 icon: Globe
+title: Browser Connections
 ---
 
-# Browser Connections
+Add personal ClickHouse connections directly in your browser and query them through the chmonitor proxy — without touching server config.
 
-> Add personal ClickHouse connections in the browser and query them via the chmonitor proxy — without touching server config.
-
-| | |
-|---|---|
-| **Routes** | (app shell, connection selector in header) |
-| **Feature id** | (none — part of the app shell, not a gated feature) |
-| **Default access** | `public` |
-| **Requires auth** | No |
-| **System tables** | None |
-| **ClickHouse grants** | Whatever the connection's user has |
+<TypeTable
+  data={{
+    Routes: { type: "App shell", description: "Connection selector in the header" },
+    "Feature id": { type: "None", description: "Part of the app shell, not a gated feature" },
+    "Default access": { type: "public", description: "Anonymous access allowed by default" },
+    "Requires auth": { type: "No", description: "No auth required" },
+    "System tables": { type: "None", description: "No ClickHouse system tables queried" },
+    "ClickHouse grants": { type: "Per connection", description: "Whatever the connection's user has" },
+  }}
+/>
 
 ## What it does
 
@@ -22,13 +23,36 @@ chmonitor normally connects to ClickHouse using the server-side `CLICKHOUSE_HOST
 
 When a user adds a connection, the credentials are stored in **encrypted browser localStorage** (AES-256-GCM with a device-bound key). When they query, chmonitor creates a short-lived **session token** server-side; subsequent chart/table requests use the token instead of sending the password on every request. All queries still proxy through the chmonitor server — the browser never opens a direct connection to ClickHouse.
 
+The connection selector in the header shows both server-configured hosts and browser-stored connections. Switching between them changes which host all dashboard pages query.
+
 This is useful for:
 
-- Personal development: quickly point chmonitor at a local ClickHouse instance
-- Testing: connect to a staging cluster without redeploying
-- Demos: show a read-only user's view without sharing admin credentials
+- **Personal development** — quickly point chmonitor at a local ClickHouse instance.
+- **Testing** — connect to a staging cluster without redeploying.
+- **Demos** — show a read-only user's view without sharing admin credentials.
 
-The connection selector in the header shows both server-configured hosts and browser-stored connections. Switching between them changes which host all dashboard pages query.
+## Using it
+
+<Steps>
+<Step>
+### Add a connection
+
+Open the connection selector in the header and add a ClickHouse host. Credentials are encrypted in browser localStorage with AES-256-GCM (device-bound key) — nothing is written to server config.
+
+</Step>
+<Step>
+### Query through the proxy
+
+On first query, chmonitor mints a short-lived session token server-side; later chart/table requests use the token instead of resending the password. All queries proxy through the chmonitor server.
+
+</Step>
+<Step>
+### Switch hosts
+
+Use the header selector to switch between server-configured and browser-stored hosts. The selected host applies to every dashboard page.
+
+</Step>
+</Steps>
 
 ## Permissions & access
 
@@ -40,7 +64,7 @@ If you want to prevent users from switching hosts at all, restrict access to the
 
 No server-side configuration. Browser connections are managed entirely in the client.
 
-For teams, configure hosts server-side:
+For teams, configure hosts server-side so all users share the same host list without any browser setup:
 
 ```bash
 CLICKHOUSE_HOST=https://host1.example.com:8443,https://host2.example.com:8443
@@ -65,6 +89,9 @@ Credentials are encrypted in browser localStorage, but XSS on the dashboard coul
 
 ## Related
 
-- [Getting started](/guide/getting-started)
-- [Authentication](/operate/authentication)
-- [Settings reference](/reference/settings)
+<Cards>
+  <Card title="User Connections (Server Storage)" href="/guide/features/user-connections" description="Sync personal connections across devices with Clerk." />
+  <Card title="Getting started" href="/guide/getting-started" description="Install and connect chmonitor to ClickHouse." />
+  <Card title="Authentication" href="/operate/authentication" description="Configure sign-in and access control." />
+  <Card title="Settings reference" href="/reference/settings" description="Every configuration setting in one place." />
+</Cards>

--- a/docs/content/guide/features/logs.mdx
+++ b/docs/content/guide/features/logs.mdx
@@ -1,32 +1,31 @@
 ---
 description: Browse structured server text logs, live thread stack traces, and historical crash reports without SSH access.
 icon: ScrollText
+title: Logs
 ---
 
-# Logs
+Read server-level diagnostics — structured text logs, live thread stack traces, and historical crash reports — straight from the dashboard, with no SSH access or log-file parsing.
 
-> Browse server text logs, crash reports, and live thread stack traces.
-
-| | |
-|---|---|
-| **Routes** | `/logs/text-log`, `/logs/stack-traces`, `/logs/crashes` |
-| **Feature id** | `logs` |
-| **Default access** | `public` |
-| **Requires auth** | No (set `CHM_FEATURE_LOGS_ACCESS=authenticated` to gate) |
-| **System tables** | `system.text_log`, `system.stack_trace`, `system.crash_log` |
-| **ClickHouse grants** | `SELECT` on the system tables above |
+<TypeTable
+  data={{
+    Routes: { type: "/logs/text-log, /logs/stack-traces, /logs/crashes", description: "Pages in this section" },
+    "Feature id": { type: "logs", description: "Used by permission env vars and config" },
+    "Default access": { type: "public", description: "Set CHM_FEATURE_LOGS_ACCESS=authenticated to gate" },
+    "Requires auth": { type: "No", description: "Anonymous access allowed by default" },
+    "System tables": { type: "system.text_log, system.stack_trace, system.crash_log", description: "Data sources" },
+    "ClickHouse grants": { type: "SELECT", description: "SELECT on the system tables above" },
+  }}
+/>
 
 ## What it does
 
 The Logs section surfaces server-level diagnostic information that would otherwise require SSH access or log file parsing.
 
-**Text Log** queries `system.text_log` to show structured server log entries with level, logger name, query context, and message. Filter by log level or message text to narrow down issues.
+- **Text Log** queries `system.text_log` to show structured server log entries with level, logger name, query context, and message. Filter by log level or message text to narrow down issues.
+- **Stack Traces** queries `system.stack_trace` for live stack traces of all running threads. Useful for diagnosing a hung or slow server without restarting it.
+- **Crashes** queries `system.crash_log` to show historical crash reports with diagnostics. The table is small — it only grows when the server crashes.
 
-**Stack Traces** queries `system.stack_trace` for live stack traces of all running threads. Useful for diagnosing a hung or slow server without restarting it.
-
-**Crashes** queries `system.crash_log` to show historical crash reports with diagnostics. The table is small — it only grows when the server crashes.
-
-## Pages
+### Pages
 
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
@@ -34,37 +33,56 @@ The Logs section surfaces server-level diagnostic information that would otherwi
 | Stack Traces | `/logs/stack-traces` | Live thread stack traces | `system.stack_trace` |
 | Crashes | `/logs/crashes` | Historical crash reports with diagnostics | `system.crash_log` |
 
+## Using it
+
+- Open `/logs/text-log` to read structured server log entries; filter by log level or message text to narrow down issues. On busy servers, apply a log-level or time filter to reduce scan size.
+- Open `/logs/stack-traces` to capture live stack traces of all running threads — a way to diagnose a hung or slow server without restarting it.
+- Open `/logs/crashes` for historical crash reports. An empty table is the normal state for a healthy server.
+
 ## Permissions & access
 
-All Logs pages share the `logs` feature id.
+All three Logs pages share the `logs` feature id.
 
 <Callout type="warn" title="Exposes server internals">
 This section exposes detailed server internals. Consider gating it in production.
 </Callout>
 
+<Tabs items={["Gate to authenticated", "Disable", "Config file"]}>
+<Tab value="Gate to authenticated">
+
 ```bash
 CHM_FEATURE_LOGS_ACCESS=authenticated
 ```
 
-Disable entirely:
+</Tab>
+<Tab value="Disable">
 
 ```bash
 CHM_FEATURE_LOGS_ENABLED=false
 ```
 
-Config file:
+</Tab>
+<Tab value="Config file">
 
 ```toml
+# CHM_CONFIG_FILE (TOML)
 [features.logs]
 enabled = true
 access = "authenticated"
 ```
+
+</Tab>
+</Tabs>
 
 ## Configuration
 
 No feature-specific configuration. All three tables must be enabled in the ClickHouse server config to produce data.
 
 ## Notes & limitations
+
+<Callout type="info" title="Some tables are optional or empty by design">
+`system.text_log` and `system.crash_log` may be empty depending on server config and crash history — an empty state here is often normal.
+</Callout>
 
 - **`system.text_log` is optional.** It requires `<text_log>` to be configured in the ClickHouse server config. Without it the Text Log page shows no rows. The table's retention TTL is also server-configured (default 30 days).
 - **`system.crash_log` is optional.** It exists on all ClickHouse servers but only contains rows after an actual crash. An empty table is the normal state for a healthy server.
@@ -74,7 +92,9 @@ No feature-specific configuration. All three tables must be enabled in the Click
 
 ## Related
 
-- [Health](/guide/features/health)
-- [Feature permissions](/operate/advanced/feature-permissions)
-- [ClickHouse system.text_log docs](https://clickhouse.com/docs/en/operations/system-tables/text_log)
-- [ClickHouse system.crash_log docs](https://clickhouse.com/docs/en/operations/system-tables/crash_log)
+<Cards>
+  <Card title="Health" href="/guide/features/health" description="At-a-glance cluster health and headless health-sweep alerts." />
+  <Card title="Feature permissions" href="/operate/advanced/feature-permissions" description="Gate or disable features per section." />
+  <Card title="ClickHouse system.text_log" href="https://clickhouse.com/docs/en/operations/system-tables/text_log" description="Upstream reference for the text log table." />
+  <Card title="ClickHouse system.crash_log" href="https://clickhouse.com/docs/en/operations/system-tables/crash_log" description="Upstream reference for the crash log table." />
+</Cards>

--- a/docs/content/guide/features/mcp.mdx
+++ b/docs/content/guide/features/mcp.mdx
@@ -1,19 +1,20 @@
 ---
 description: Expose your chmonitor instance as a Model Context Protocol server so AI assistants like Claude and Cursor can query ClickHouse directly.
 icon: Plug
+title: MCP Server
 ---
 
-# MCP Server
+Turn your chmonitor instance into a remote Model Context Protocol server so AI assistants — Claude Desktop, Cursor, or any MCP client — can run tools against your ClickHouse cluster without direct database access.
 
-> Expose your chmonitor instance as a Model Context Protocol server so AI assistants can query your ClickHouse cluster directly.
-
-| | |
-|---|---|
-| **Routes** | `/mcp` (UI info page) |
-| **Feature id** | `mcp` |
-| **Default access** | Closed (401) — requires `CHM_API_KEY_SECRET`, `CLERK_SECRET_KEY`, or `CHM_MCP_PUBLIC=true` |
-| **System tables** | None directly — the MCP server wraps the same tools available to the rest of the dashboard |
-| **ClickHouse grants** | Inherits grants of the configured `CLICKHOUSE_USER` |
+<TypeTable
+  data={{
+    Routes: { type: "/mcp", description: "UI info page (protocol endpoint is /api/mcp)" },
+    "Feature id": { type: "mcp", description: "Used by permission env vars and config" },
+    "Default access": { type: "Closed (401)", description: "Requires CHM_API_KEY_SECRET, CLERK_SECRET_KEY, or CHM_MCP_PUBLIC=true" },
+    "System tables": { type: "None directly", description: "Wraps the same tools available to the rest of the dashboard" },
+    "ClickHouse grants": { type: "Inherited", description: "Inherits grants of the configured CLICKHOUSE_USER" },
+  }}
+/>
 
 ## What it does
 
@@ -33,33 +34,22 @@ Tools available via MCP include schema exploration, query execution, metrics, he
   CH-->>MCP: results
   MCP-->>Client: tool response`} />
 
-See [MCP Server reference](/reference/mcp-server) for the full tool list and protocol details.
+See the [MCP Server reference](/reference/mcp-server) for the full tool list and protocol details.
 
-## Pages
+### Pages
 
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
 | MCP Info | `/mcp` | Connection URL, setup instructions, tool list | — |
 
-## Permissions & access
+## Using it
 
-<Callout type="warn" title="Secure by default">
-The MCP endpoint (`/api/mcp`) returns **401 Unauthorized** by default. It only opens when you explicitly configure at least one of:
+Pick an auth scheme, then point your MCP client at `/api/mcp`.
 
-- **`CHM_API_KEY_SECRET`** — API key auth (recommended). See [API keys](/operate/authentication/api-keys).
-- **`CLERK_SECRET_KEY`** — Clerk OAuth token introspection. See [Clerk authentication](/operate/authentication/clerk).
-- **`CHM_MCP_PUBLIC=true`** — explicit opt-in for trusted private networks. A warning is logged on every request.
+<Tabs items={["API key (recommended)", "Clerk OAuth", "Public (trusted networks)"]}>
+<Tab value="API key (recommended)">
 
-Without one of these, every request — including from Claude Desktop, Cursor, and other MCP clients — is rejected with `401`.
-</Callout>
-
-The MCP endpoint (`/api/mcp`) is **closed by default**. Anonymous requests receive a `401` response unless at least one of the following is true:
-
-- `CHM_API_KEY_SECRET` is set (API key auth — recommended for production)
-- `CLERK_SECRET_KEY` is set (Clerk OAuth)
-- `CHM_MCP_PUBLIC=true` is set (explicit opt-in for trusted private networks; a warning is logged on every request)
-
-**Production setup — API key auth:**
+Set a secret to enable API key auth for all `/api/v1/*` routes including `/api/mcp`:
 
 ```bash
 CHM_API_KEY_SECRET=<random-secret-min-32-chars>
@@ -79,31 +69,66 @@ Pass the token in MCP client requests:
 Authorization: Bearer chm_...
 ```
 
-**Production setup — Clerk OAuth (MCP OAuth flow):**
+</Tab>
+<Tab value="Clerk OAuth">
 
-When `CHM_AUTH_PROVIDER=clerk`, the `/api/mcp` endpoint also accepts Clerk OAuth bearer tokens. Clerk acts as the auth server; chmonitor verifies the token via REST introspection using `CLERK_SECRET_KEY`. No additional MCP-specific configuration needed.
+When `CHM_AUTH_PROVIDER=clerk`, the `/api/mcp` endpoint also accepts Clerk OAuth bearer tokens (the MCP OAuth flow). Clerk acts as the auth server; chmonitor verifies the token via REST introspection using `CLERK_SECRET_KEY`. No additional MCP-specific configuration is needed.
+
+</Tab>
+<Tab value="Public (trusted networks)">
+
+Allow anonymous access when no auth scheme is configured. Only appropriate for trusted private networks — a warning is logged on every request:
+
+```bash
+CHM_MCP_PUBLIC=true
+```
+
+</Tab>
+</Tabs>
+
+## Permissions & access
+
+<Callout type="warn" title="Secure by default">
+The MCP endpoint (`/api/mcp`) returns **401 Unauthorized** by default. It only opens when you explicitly configure at least one of:
+
+- **`CHM_API_KEY_SECRET`** — API key auth (recommended). See [API keys](/operate/authentication/api-keys).
+- **`CLERK_SECRET_KEY`** — Clerk OAuth token introspection. See [Clerk authentication](/operate/authentication/clerk).
+- **`CHM_MCP_PUBLIC=true`** — explicit opt-in for trusted private networks. A warning is logged on every request.
+
+Without one of these, every request — including from Claude Desktop, Cursor, and other MCP clients — is rejected with `401`.
+</Callout>
 
 Disable the MCP feature (removes it from the nav and blocks `/api/mcp`):
+
+<Tabs items={["Disable", "Config file"]}>
+<Tab value="Disable">
 
 ```bash
 CHM_FEATURE_MCP_ENABLED=false
 ```
 
-Config file:
+</Tab>
+<Tab value="Config file">
 
 ```toml
+# CHM_CONFIG_FILE (TOML)
 [features.mcp]
 enabled = true
 ```
 
+</Tab>
+</Tabs>
+
 ## Configuration
 
-| Variable | Description |
-|---|---|
-| `CHM_API_KEY_SECRET` | Enables API key authentication for all `/api/v1/*` routes including `/api/mcp`. Required for production use without Clerk. |
-| `CLERK_SECRET_KEY` | Enables Clerk OAuth token verification. Used for Clerk OAuth token introspection. |
-| `CHM_MCP_PUBLIC` | Set to `true` to allow anonymous access when no auth scheme is configured. Only appropriate for trusted private networks. A warning is logged on every request when this is active. |
-| `CHM_AUTH_PROVIDER` | `none` (default), `clerk`, or `proxy`. Controls how sessions are verified. |
+<TypeTable
+  data={{
+    CHM_API_KEY_SECRET: { type: "string", description: "Enables API key authentication for all /api/v1/* routes including /api/mcp. Required for production use without Clerk." },
+    CLERK_SECRET_KEY: { type: "string", description: "Enables Clerk OAuth token verification. Used for Clerk OAuth token introspection." },
+    CHM_MCP_PUBLIC: { type: "boolean", description: "Set to true to allow anonymous access when no auth scheme is configured. Only appropriate for trusted private networks. A warning is logged on every request when active." },
+    CHM_AUTH_PROVIDER: { type: "none | clerk | proxy", description: "Controls how sessions are verified. Defaults to none." },
+  }}
+/>
 
 The MCP endpoint is secure by default: it returns `401` when no auth is configured, unless `CHM_MCP_PUBLIC=true` is explicitly set.
 
@@ -116,7 +141,9 @@ The MCP endpoint is secure by default: it returns `401` when no auth is configur
 
 ## Related
 
-- [MCP Server reference](/reference/mcp-server)
-- [API keys](/operate/authentication/api-keys)
-- [Authentication](/operate/authentication)
-- [Feature permissions](/operate/advanced/feature-permissions)
+<Cards>
+  <Card title="MCP Server reference" href="/reference/mcp-server" description="Full tool list and protocol details." />
+  <Card title="API keys" href="/operate/authentication/api-keys" description="Issue and use API keys for programmatic access." />
+  <Card title="Authentication" href="/operate/authentication" description="Configure sign-in and access control." />
+  <Card title="Feature permissions" href="/operate/advanced/feature-permissions" description="Gate or disable features per section." />
+</Cards>

--- a/docs/content/guide/features/peerdb.mdx
+++ b/docs/content/guide/features/peerdb.mdx
@@ -1,75 +1,47 @@
 ---
 description: Monitor PeerDB replication mirrors and peers from within chmonitor — read-only, proxied, no direct database access required.
 icon: Replace
+title: PeerDB
 ---
 
-# PeerDB
+Monitor PeerDB replication mirrors and peers without leaving chmonitor — an optional, read-only integration that proxies the PeerDB API server-side.
 
-> Monitor PeerDB replication mirrors and peers from within chmonitor (optional, read-only).
-
-| | |
-|---|---|
-| **Routes** | `/peerdb`, `/peerdb/peers` |
-| **Feature id** | `peerdb` |
-| **Default access** | `public` |
-| **Requires auth** | No (set `CHM_FEATURE_PEERDB_ACCESS=authenticated` to gate) |
-| **System tables** | None — proxies the PeerDB REST API, not ClickHouse system tables |
-| **ClickHouse grants** | None required |
+<TypeTable
+  data={{
+    Routes: { type: "/peerdb, /peerdb/peers", description: "Pages in this section" },
+    "Feature id": { type: "peerdb", description: "Used by permission env vars and config" },
+    "Default access": { type: "public", description: "Set CHM_FEATURE_PEERDB_ACCESS=authenticated to gate" },
+    "Requires auth": { type: "No", description: "Anonymous access allowed by default" },
+    "System tables": { type: "None", description: "Proxies the PeerDB REST API, not ClickHouse system tables" },
+    "ClickHouse grants": { type: "None", description: "No ClickHouse grants required" },
+  }}
+/>
 
 ## What it does
 
 When you set `PEERDB_API_URL`, chmonitor adds a PeerDB section to the navigation. It proxies read-only calls to the PeerDB API so you can monitor replication without leaving the chmonitor UI.
 
-**Mirrors** (`/peerdb`) shows all configured replication mirrors with status, throughput, and per-table sync state.
-
-**Peers** (`/peerdb/peers`) lists source and destination peers, replication slot lag, and a mirror connectivity graph.
+- **Mirrors** (`/peerdb`) shows all configured replication mirrors with status, throughput, and per-table sync state.
+- **Peers** (`/peerdb/peers`) lists source and destination peers, replication slot lag, and a mirror connectivity graph.
 
 Mutation requests (create, delete, pause, resume) are blocked at the proxy layer and return HTTP 403. chmonitor only ever reads from PeerDB.
 
 The PeerDB section does not appear in the navigation when `PEERDB_API_URL` is unset.
 
-## Pages
+### Pages
 
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
 | Mirrors | `/peerdb` | Mirror status, throughput, per-table sync | — (PeerDB API) |
 | Peers | `/peerdb/peers` | Peer list, slot lag, mirror graph | — (PeerDB API) |
 
-## Permissions & access
+## Using it
 
-The `peerdb` feature id controls visibility.
+<Steps>
+<Step>
+### Point chmonitor at your PeerDB API
 
-Disable:
-
-```bash
-CHM_FEATURE_PEERDB_ENABLED=false
-```
-
-Require authentication:
-
-```bash
-CHM_FEATURE_PEERDB_ACCESS=authenticated
-```
-
-Config file:
-
-```toml
-[features.peerdb]
-enabled = true
-access = "authenticated"
-```
-
-## Configuration
-
-| Variable | Default | Description |
-|---|---|---|
-| `PEERDB_API_URL` | (unset) | PeerDB API base URL. Include the `/api` suffix for the UI API (e.g., `https://peerdb.example.com/api`). When unset, the PeerDB section is hidden entirely. |
-| `PEERDB_PASSWORD` | (unset) | HTTP Basic auth password. The username is left empty. |
-| `PEERDB_CACHE_TTL_MS` | `10000` | Response cache TTL in milliseconds. |
-| `PEERDB_CACHE_MAX_ENTRIES` | `500` | Maximum number of cached responses. |
-| `PEERDB_FETCH_TIMEOUT_MS` | `10000` | Timeout for proxied PeerDB API requests. |
-
-Example:
+Set `PEERDB_API_URL` (include the `/api` suffix for the UI API). Add `PEERDB_PASSWORD` if the API requires HTTP Basic auth:
 
 ```bash
 PEERDB_API_URL=https://peerdb.example.com/api
@@ -77,9 +49,70 @@ PEERDB_PASSWORD=my-peerdb-password
 PEERDB_CACHE_TTL_MS=15000
 ```
 
+</Step>
+<Step>
+### Open the PeerDB section
+
+Once `PEERDB_API_URL` is set, the PeerDB section appears in the nav. Open `/peerdb` for mirror status, throughput, and per-table sync state.
+
+</Step>
+<Step>
+### Inspect peers and lag
+
+Open `/peerdb/peers` to list source and destination peers, replication slot lag, and the mirror connectivity graph.
+
+</Step>
+</Steps>
+
+## Permissions & access
+
+The `peerdb` feature id controls visibility.
+
+<Tabs items={["Gate to authenticated", "Disable", "Config file"]}>
+<Tab value="Gate to authenticated">
+
+```bash
+CHM_FEATURE_PEERDB_ACCESS=authenticated
+```
+
+</Tab>
+<Tab value="Disable">
+
+```bash
+CHM_FEATURE_PEERDB_ENABLED=false
+```
+
+</Tab>
+<Tab value="Config file">
+
+```toml
+# CHM_CONFIG_FILE (TOML)
+[features.peerdb]
+enabled = true
+access = "authenticated"
+```
+
+</Tab>
+</Tabs>
+
+## Configuration
+
+<TypeTable
+  data={{
+    PEERDB_API_URL: { type: "string", description: "PeerDB API base URL. Include the /api suffix for the UI API (e.g. https://peerdb.example.com/api). When unset, the PeerDB section is hidden entirely. Default: unset." },
+    PEERDB_PASSWORD: { type: "string", description: "HTTP Basic auth password. The username is left empty. Default: unset." },
+    PEERDB_CACHE_TTL_MS: { type: "number", description: "Response cache TTL in milliseconds. Default: 10000." },
+    PEERDB_CACHE_MAX_ENTRIES: { type: "number", description: "Maximum number of cached responses. Default: 500." },
+    PEERDB_FETCH_TIMEOUT_MS: { type: "number", description: "Timeout for proxied PeerDB API requests. Default: 10000." },
+  }}
+/>
+
 ## Notes & limitations
 
-- This integration is **read-only**. Any PeerDB API call that would mutate state (create/delete/pause/resume mirrors or peers) is blocked at the chmonitor proxy layer and returns HTTP 403.
+<Callout type="info" title="Read-only by design">
+Any PeerDB API call that would mutate state (create/delete/pause/resume mirrors or peers) is blocked at the chmonitor proxy layer and returns HTTP 403.
+</Callout>
+
 - The PeerDB API URL must be reachable from the chmonitor server, not from the user's browser. All PeerDB requests are server-side proxied.
 - `PEERDB_API_URL` that points to the bare origin (without `/api`) is intended for direct flow-api use; the UI mirrors/peers pages expect the `/api`-suffixed URL.
 - PeerDB version compatibility is not guaranteed across major PeerDB releases. If the PeerDB API shape changes, some fields may not render correctly.
@@ -87,5 +120,7 @@ PEERDB_CACHE_TTL_MS=15000
 
 ## Related
 
-- [Feature permissions](/operate/advanced/feature-permissions)
-- [PeerDB documentation](https://docs.peerdb.io)
+<Cards>
+  <Card title="Feature permissions" href="/operate/advanced/feature-permissions" description="Gate or disable features per section." />
+  <Card title="PeerDB documentation" href="https://docs.peerdb.io" description="Upstream reference for PeerDB mirrors and peers." />
+</Cards>

--- a/docs/content/guide/features/settings.mdx
+++ b/docs/content/guide/features/settings.mdx
@@ -1,32 +1,34 @@
 ---
 description: View all ClickHouse server settings with non-default values highlighted, plus MergeTree and Replicated MergeTree engine settings.
 icon: Settings
+title: Settings
 ---
 
-# Settings
+Audit ClickHouse configuration without SQL — see every server setting with non-default values highlighted, plus MergeTree and Replicated MergeTree engine settings.
 
-> View server settings changed from defaults, MergeTree engine settings, and the in-app configuration UI.
-
-| | |
-|---|---|
-| **Routes** | `/settings`, `/mergetree-settings`, `/replicated-merge-tree-settings` |
-| **Feature id** | `settings` |
-| **Default access** | `public` |
-| **Requires auth** | No (set `CHM_FEATURE_SETTINGS_ACCESS=authenticated` to gate) |
-| **System tables** | `system.settings`, `system.merge_tree_settings`, `system.replicated_merge_tree_settings` |
-| **ClickHouse grants** | `SELECT` on the system tables above |
+<TypeTable
+  data={{
+    Routes: { type: "/settings, /mergetree-settings, /replicated-merge-tree-settings", description: "Pages in this section" },
+    "Feature id": { type: "settings", description: "Used by permission env vars and config" },
+    "Default access": { type: "public", description: "Set CHM_FEATURE_SETTINGS_ACCESS=authenticated to gate" },
+    "Requires auth": { type: "No", description: "Anonymous access allowed by default" },
+    "System tables": { type: "system.settings, system.merge_tree_settings, system.replicated_merge_tree_settings", description: "Data sources" },
+    "ClickHouse grants": { type: "SELECT", description: "SELECT on the system tables above" },
+  }}
+/>
 
 ## What it does
 
 The Settings section has two distinct purposes.
 
-**ClickHouse server settings** (at `/settings`) queries `system.settings` to list all server-level configuration values. The table highlights values that have been changed from their defaults, making it easy to audit non-default configuration. Use it to spot unexpected overrides or verify that a setting change took effect.
+- **ClickHouse server settings** (at `/settings`) queries `system.settings` to list all server-level configuration values. The table highlights values that have been changed from their defaults, making it easy to audit non-default configuration. Use it to spot unexpected overrides or verify that a setting change took effect.
+- **MergeTree settings** (at `/mergetree-settings`) queries `system.merge_tree_settings` to show engine-specific settings for MergeTree tables. The **Replicated MergeTree settings** page (at `/replicated-merge-tree-settings`) queries `system.replicated_merge_tree_settings`.
 
-**MergeTree settings** (at `/mergetree-settings`) queries `system.merge_tree_settings` to show engine-specific settings for MergeTree tables. Similarly, the **Replicated MergeTree settings** page (at `/replicated-merge-tree-settings`) queries `system.replicated_merge_tree_settings`.
+<Callout type="info" title="Two kinds of settings">
+This section covers **ClickHouse server** settings (read-only, from system tables). chmonitor also has an **application-level** settings page where operators configure the dashboard itself — connection details, theme preferences, and feature toggles. See the [Settings reference](/reference/settings) for that.
+</Callout>
 
-**In-app settings UI** — chmonitor also has an application-level settings page where operators configure the dashboard itself (connection details, theme preferences, and feature toggles). See [Settings](/reference/settings) for that reference.
-
-## Pages
+### Pages
 
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
@@ -34,29 +36,44 @@ The Settings section has two distinct purposes.
 | MergeTree Settings | `/mergetree-settings` | MergeTree engine settings and values | `system.merge_tree_settings` |
 | Replicated MergeTree Settings | `/replicated-merge-tree-settings` | Replicated MergeTree settings; flags changed-from-default | `system.replicated_merge_tree_settings` |
 
+## Using it
+
+- Open `/settings` to review all server settings; non-default values are highlighted so you can spot unexpected overrides or confirm a change took effect.
+- Open `/mergetree-settings` to inspect MergeTree engine settings, and `/replicated-merge-tree-settings` for Replicated MergeTree settings with changed-from-default values flagged.
+- To change a setting, use ClickHouse SQL (`SET`, `ALTER TABLE ... MODIFY SETTING`) or edit the server config — these pages are read-only.
+
 ## Permissions & access
 
 All three pages share the `settings` feature id.
 
-To gate this section behind authentication (recommended if settings values are sensitive):
+<Tabs items={["Gate to authenticated", "Disable", "Config file"]}>
+<Tab value="Gate to authenticated">
+
+Recommended if settings values are sensitive:
 
 ```bash
 CHM_FEATURE_SETTINGS_ACCESS=authenticated
 ```
 
-Disable entirely:
+</Tab>
+<Tab value="Disable">
 
 ```bash
 CHM_FEATURE_SETTINGS_ENABLED=false
 ```
 
-Config file:
+</Tab>
+<Tab value="Config file">
 
 ```toml
+# CHM_CONFIG_FILE (TOML)
 [features.settings]
 enabled = true
 access = "authenticated"
 ```
+
+</Tab>
+</Tabs>
 
 ## Configuration
 
@@ -70,7 +87,9 @@ No feature-specific environment variables. The pages are read-only — chmonitor
 
 ## Related
 
-- [Settings reference](/reference/settings)
-- [Feature permissions](/operate/advanced/feature-permissions)
-- [ClickHouse system.settings docs](https://clickhouse.com/docs/en/operations/system-tables/settings)
-- [ClickHouse system.merge_tree_settings docs](https://clickhouse.com/docs/en/operations/system-tables/merge_tree_settings)
+<Cards>
+  <Card title="Settings reference" href="/reference/settings" description="Every dashboard configuration setting in one place." />
+  <Card title="Feature permissions" href="/operate/advanced/feature-permissions" description="Gate or disable features per section." />
+  <Card title="ClickHouse system.settings" href="https://clickhouse.com/docs/en/operations/system-tables/settings" description="Upstream reference for server settings." />
+  <Card title="ClickHouse system.merge_tree_settings" href="https://clickhouse.com/docs/en/operations/system-tables/merge_tree_settings" description="Upstream reference for MergeTree settings." />
+</Cards>

--- a/docs/content/guide/features/user-connections.mdx
+++ b/docs/content/guide/features/user-connections.mdx
@@ -1,18 +1,19 @@
 ---
 description: Save personal ClickHouse connections to the server so they sync across devices when signed in with Clerk — encrypted at rest with AES-256-GCM.
 icon: Users
+title: User Connections (Server Storage)
 ---
 
-# User Connections (Server Storage)
+Save personal ClickHouse hosts to the server so they sync across devices when signed in with Clerk — encrypted at rest with AES-256-GCM.
 
-> Save personal ClickHouse hosts to the server so they sync across devices when signed in with Clerk.
-
-| | |
-|---|---|
-| **Feature id** | (none — gated by env flags) |
-| **Default access** | Authenticated Clerk users only |
-| **Requires auth** | Yes (Clerk) |
-| **Storage** | D1 (Cloudflare) or PostgreSQL |
+<TypeTable
+  data={{
+    "Feature id": { type: "None", description: "Gated by env flags, not a feature id" },
+    "Default access": { type: "Authenticated", description: "Clerk users only" },
+    "Requires auth": { type: "Yes (Clerk)", description: "Connections are keyed by the signed-in Clerk userId" },
+    Storage: { type: "D1 or PostgreSQL", description: "D1 (Cloudflare) or PostgreSQL backend" },
+  }}
+/>
 
 ## What it does
 
@@ -20,11 +21,9 @@ When enabled, users can choose **Save to server** in the Add Host dialog. Creden
 
 Browser-only storage remains available when server storage is disabled or the user prefers a local connection.
 
-## Enable server storage
+## Using it
 
-Server storage needs **four** things present together. If any one is missing the
-server returns *"User connections database storage is not enabled"* and the
-**Save to server** toggle stays hidden.
+Server storage needs **four** things present together. If any one is missing the server returns *"User connections database storage is not enabled"* and the **Save to server** toggle stays hidden.
 
 1. **`CHM_FEATURE_USER_CONNECTIONS_DB=true`** — the feature flag.
 2. **Clerk auth** (`CHM_AUTH_PROVIDER=clerk`) — connections are keyed by the signed-in Clerk `userId`.
@@ -74,7 +73,7 @@ The Add Host dialog shows an enabled **Save to server** toggle when all four req
 </Step>
 </Steps>
 
-## Security notes
+## Permissions & access
 
 <Callout type="info" title="Per-user isolation">
 Each connection row is keyed by the signed-in Clerk `userId`. List, read, update, delete, and chart/table proxy routes all resolve auth first and query with `WHERE user_id = ?`. Guessing another user's `connectionId` returns 404 — never their credentials.
@@ -89,6 +88,8 @@ Each connection row is keyed by the signed-in Clerk `userId`. List, read, update
 
 ## Related
 
-- [Browser Connections](/guide/features/browser-connections)
-- [Authentication](/operate/authentication)
-- [Environment variables](/reference/environment-variables)
+<Cards>
+  <Card title="Browser Connections" href="/guide/features/browser-connections" description="Add personal connections stored in the browser." />
+  <Card title="Authentication" href="/operate/authentication" description="Configure sign-in and access control." />
+  <Card title="Environment variables" href="/reference/environment-variables" description="Every env var chmonitor reads." />
+</Cards>


### PR DESCRIPTION
## What

Rewrite the **Features C** docs group (`docs/content/guide/features/*`) for one consistent voice and the shared Fumadocs feature-page skeleton, matching the already-rewritten sibling pages (`cluster.mdx`, `operations.mdx`).

Files:
- `logs.mdx`
- `settings.mdx`
- `mcp.mdx`
- `peerdb.mdx`
- `browser-connections.mdx`
- `user-connections.mdx`

## Changes

- Body starts at `##` (stripped H1 removed); blockquote lead replaced with a direct lead sentence.
- Meta-fact block rendered as `<TypeTable>` (routes, feature id, access, auth, system tables, grants).
- `## Permissions & access` uses `<Tabs>` (gate / disable / config file). Config env vars rendered as `<TypeTable>` for `mcp` and `peerdb`.
- Added `<Steps>` flows for `peerdb` and `browser-connections`; kept existing `<Steps>` for `user-connections`.
- Every page ends with a `## Related` `<Cards>` block, each card with a description.
- Frontmatter normalized to `description` + `icon` + `title`.

## Invariants

- No technical facts added, dropped, or altered (verified by token diff of env vars, system tables, routes, numeric defaults, HTTP codes).
- No pages added, removed, or renamed.
- Internal links are root-based; all targets verified to exist.

## Verification

Parallel-safe docs recipe (both exit 0):

```
cd apps/docs && bun run sync && bunx fumadocs-mdx
```

Co-Authored-By: duyetbot <bot@duyet.net>