### PR TITLE
docs(ai-agent): rewrite agent reference for consistency

### DIFF
--- a/docs/content/guide/ai-agent.mdx
+++ b/docs/content/guide/ai-agent.mdx
@@ -1,11 +1,10 @@
 ---
+title: AI Agent
 description: The AI Agent turns natural language into ClickHouse insights using read-only tools, expert skills, and plan-and-verify reasoning.
 icon: Bot
 ---
 
-# AI Agent
-
-The AI Agent turns natural language into ClickHouse insights. Ask a question and the agent plans a series of read-only tool calls — querying system tables, inspecting schema, comparing hosts, spotting anomalies — then streams back a concise answer with optional inline charts.
+Ask a question in plain English and the agent plans a series of read-only tool calls — querying system tables, inspecting schema, comparing hosts, spotting anomalies — then streams back a concise answer with optional inline charts.
 
 <Mermaid chart={`flowchart LR
   Q([User question]) --> A[Agent]
@@ -19,7 +18,7 @@ The AI Agent turns natural language into ClickHouse insights. Ask a question and
   P --> A
   A --> R([Streamed answer])`} />
 
-The agent connects through the **same ClickHouse host and user** as the rest of the dashboard. Its visibility is bounded by the grants on that user. By default it only runs read-only queries. Keep control tools off and use a restricted ClickHouse user for safe exposure.
+The agent connects through the **same ClickHouse host and user** as the rest of the dashboard, so its visibility is bounded by the grants on that user. By default it runs read-only queries only. Keep control tools off and use a restricted ClickHouse user for safe exposure.
 
 ## What it can do
 
@@ -34,9 +33,9 @@ The agent connects through the **same ClickHouse host and user** as the rest of 
 | Tuning & upgrades | Hardware-based settings, version-upgrade guidance |
 | Charts & visualization | Run SQL and render an interactive chart inline |
 
-A small set of tools delivers this: dedicated primitives for the common reads, and the `query` tool plus an expert **skill** recipe for everything else. See [Capabilities](/guide/ai-agent/capabilities) for the full list.
+A small set of tools delivers this: dedicated primitives for the common reads, plus the `query` tool and an expert **skill** recipe for everything else. See [Capabilities](/guide/ai-agent/capabilities) for the full list.
 
-**Skills** — when a question needs domain depth, the agent loads a bundled expert guide (a skill) with copy-pasteable SQL recipes before answering. Eighteen skills cover data analysis, anomaly detection, query tuning, schema & data-type design, hardware tuning, version upgrades, concept explanations, incident response, plan-and-verify, and the core domains (replication, cluster, storage, migration, security, best practices, troubleshooting, system tables). Available skills: `GET /api/v1/agent/skills`.
+**Skills** — when a question needs domain depth, the agent loads a bundled expert guide (a skill) with copy-pasteable SQL recipes before answering. Eighteen skills cover data analysis, anomaly detection, query tuning, schema & data-type design, hardware tuning, version upgrades, concept explanations, incident response, plan-and-verify, and the core domains (replication, cluster, storage, migration, security, best practices, troubleshooting, system tables). List available skills with `GET /api/v1/agent/skills`.
 
 **Plan and verify** — for multi-step tasks (incident triage, investigations, find-and-fix) the agent authors a live checklist with `update_plan`, keeps one step in progress, and verifies each result before stating it. Simple one-step questions skip the plan. See [Capabilities](/guide/ai-agent/capabilities) for details.
 
@@ -50,9 +49,9 @@ LLM_API_KEY=your-provider-key
 
 Then open `/agents` in the dashboard, pick a host, and start asking questions. The agent uses OpenRouter by default (`https://openrouter.ai/api/v1`) with the free model tier.
 
-For full configuration options see [Configuration](/guide/ai-agent/configuration).
+For the full set of options, see [Configuration](/guide/ai-agent/configuration).
 
-## Child pages
+## Explore the agent
 
 <Cards>
   <Card
@@ -66,12 +65,12 @@ For full configuration options see [Configuration](/guide/ai-agent/configuration
     description="All environment variables, LLM providers, and access control."
   />
   <Card
-    title="Conversation History"
+    title="Conversation history"
     href="/guide/ai-agent/conversation-history"
     description="How chat history works and how to enable server-side persistence."
   />
   <Card
-    title="Store Backends"
+    title="Store backends"
     href="/guide/ai-agent/conversation-history/backends"
     description="Per-backend setup: D1, ClickHouse, Postgres, AgentState, and more."
   />
@@ -92,13 +91,15 @@ Selection priority when persistence is enabled: **AgentState** (if `AGENTSTATE_A
 
 Server persistence requires `CHM_FEATURE_CONVERSATION_DB=true` and an authenticated user — configure Clerk (`CHM_AUTH_PROVIDER=clerk` + `CLERK_SECRET_KEY`) so history can be scoped per user. Unauthenticated sessions always fall back to browser history. See [Authentication](/operate/authentication).
 
+For per-backend setup, see [Conversation history](/guide/ai-agent/conversation-history) and [Store backends](/guide/ai-agent/conversation-history/backends).
+
 ### AgentState
 
 [AgentState](https://agentstate.app) is a conversation-history database-as-a-service for AI agents. Use it when you want managed (or self-hosted) persistence that survives browser clears and is shared across devices, plus optional **AI enrichment** — auto-generated conversation titles and follow-up question suggestions — and per-project analytics. It is self-hostable as a single Cloudflare Worker (see [duyet/agentstate](https://github.com/duyet/agentstate)) and ships an npm SDK (`@agentstate/sdk`).
 
 Per-user isolation is built in: each thread is namespaced by AgentState `external_id` as `<userId>:<conversationId>` and tagged `user:<userId>`, so one project key safely holds every user's history without cross-talk.
 
-**Environment variables** (all server-side):
+Environment variables (all server-side):
 
 | Variable | Required | Default | Purpose |
 |---|---|---|---|
@@ -109,7 +110,9 @@ Per-user isolation is built in: each thread is namespaced by AgentState `externa
 
 Still requires `CHM_FEATURE_CONVERSATION_DB=true` and a Clerk auth provider (`CHM_AUTH_PROVIDER=clerk` + `CLERK_SECRET_KEY`).
 
-#### Setup (hosted)
+<Tabs items={["Hosted", "Self-host", "Local dev"]}>
+
+<Tab value="Hosted">
 
 1. Sign in at [agentstate.app](https://agentstate.app) and create a project.
 2. Create an API key — it is prefixed `as_live_` and shown **once**, so copy it immediately.
@@ -122,7 +125,9 @@ AGENTSTATE_API_KEY=as_live_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 AGENTSTATE_AI_ENRICH=true
 ```
 
-#### Setup (self-host)
+</Tab>
+
+<Tab value="Self-host">
 
 Run your own AgentState Worker per [duyet/agentstate](https://github.com/duyet/agentstate), then point the dashboard at it:
 
@@ -132,7 +137,9 @@ AGENTSTATE_API_KEY=as_live_your_self_hosted_key
 AGENTSTATE_BASE_URL=https://your-agentstate-host/api
 ```
 
-#### Local dev
+</Tab>
+
+<Tab value="Local dev">
 
 Against a locally running AgentState instance, use the seed test key:
 
@@ -142,7 +149,11 @@ AGENTSTATE_BASE_URL=http://localhost:8787
 AGENTSTATE_API_KEY=as_live_TEST_KEY_FOR_LOCAL_DEV_ONLY_1234567890ab
 ```
 
-#### Verify it's active
+</Tab>
+
+</Tabs>
+
+**Verify it's active:**
 
 - **Settings sidebar** — the agent settings sidebar shows a read-only **Conversation History** section naming the active backend (e.g. `AgentState`).
 - **Endpoint** — `GET /api/v1/conversations/backend` reports the active backend and whether enrichment is available:
@@ -152,9 +163,7 @@ curl https://your-host/api/v1/conversations/backend
 # => { "backend": "agentstate", "supportsAiEnrichment": true }
 ```
 
-#### AI enrichment
-
-When AgentState is active **and** `AGENTSTATE_AI_ENRICH=true`:
+**AI enrichment** — when AgentState is active **and** `AGENTSTATE_AI_ENRICH=true`:
 
 - **Auto-title** — new conversations get a concise generated title instead of a placeholder.
 - **Follow-ups** — the chat suggests follow-up questions after a turn. The dashboard reads them from `GET /api/v1/conversations/$id/follow-ups`.
@@ -163,10 +172,7 @@ With enrichment off, conversations persist normally but titles and follow-up sug
 
 ## AI Insights persistence
 
-Separate from chat history, the AI Insights panel on `/overview` persists the
-short observations it generates through its own pluggable store, mirroring the
-conversation backends above. It is **additive opt-in** via one env var and
-defaults to ClickHouse, so existing deployments are unaffected.
+Separate from chat history, the AI Insights panel on `/overview` persists the short observations it generates through its own pluggable store, mirroring the conversation backends above. It is **additive opt-in** via one env var and defaults to ClickHouse, so existing deployments are unaffected.
 
 ```bash
 INSIGHTS_STORE_BACKEND=auto   # auto | clickhouse | d1 | postgres | agentstate | memory
@@ -181,14 +187,11 @@ INSIGHTS_STORE_BACKEND=auto   # auto | clickhouse | d1 | postgres | agentstate |
 | `agentstate` | AgentState State store | `AGENTSTATE_API_KEY` (+ optional `AGENTSTATE_BASE_URL`) |
 | `memory` | in-process (ephemeral) | — |
 
-The D1, Postgres, and AgentState backends reuse the same env / bindings as the
-conversation store. `auto` resolves to ClickHouse and never silently follows
-other env; if an explicitly selected backend is missing its prerequisite, the
-engine logs a warning and falls back to ClickHouse. `GET /api/v1/insights/backend`
-reports the active backend (`{ "backend": "d1" }`), and the overview panel shows
-a read-only "Stored in `<backend>`" footer.
+The D1, Postgres, and AgentState backends reuse the same env / bindings as the conversation store. `auto` resolves to ClickHouse and never silently follows other env; if an explicitly selected backend is missing its prerequisite, the engine logs a warning and falls back to ClickHouse. `GET /api/v1/insights/backend` reports the active backend (`{ "backend": "d1" }`), and the overview panel shows a read-only "Stored in `<backend>`" footer.
 
 ## HTTP API
+
+Call the agent directly over HTTP:
 
 ```bash
 curl -X POST https://your-host/api/v1/agent \
@@ -197,9 +200,9 @@ curl -X POST https://your-host/api/v1/agent \
   -d '{"message": "Which queries are running right now?", "hostId": 0}'
 ```
 
-`hostId` is a zero-based numeric index; defaults to `0`.
+`hostId` is a zero-based numeric index; it defaults to `0`.
 
-## MCP Server
+## MCP server
 
 The dashboard exposes an MCP (Model Context Protocol) endpoint at `/api/mcp`. The same implementation runs in the standalone Cloudflare MCP Worker (`apps/mcp`). All tools are read-only by design — write and DDL statements are rejected.
 
@@ -213,7 +216,7 @@ You can connect additional MCP servers from the agent settings sidebar. Click **
 
 **How tools are named.** Each tool from a custom server is prefixed `mcp_<server-name>_<tool-name>` (server name is lowercased and non-alphanumeric characters replaced with `_`, truncated to 20 chars). This keeps custom tools distinct from built-in ones.
 
-**Requirements and limits:**
+Requirements and limits:
 
 - Endpoint URL must use `https:`. `http:` is allowed only for `localhost` / `127.0.0.1` / `[::1]` (local development).
 - Private IP ranges are blocked (10.x, 172.16–31.x, 192.168.x, 127.x, 169.254.x). This includes the AWS/GCP instance metadata endpoint (`169.254.169.254`).
@@ -252,3 +255,23 @@ All other MCP tools run fixed SELECT queries and pass `readonly: '1'` to the Cli
 - Keep LLM keys **server-side** — never in `VITE_*` variables (those are baked into browser JS at build time).
 
 </Callout>
+
+## Related
+
+<Cards>
+  <Card
+    title="Capabilities"
+    href="/guide/ai-agent/capabilities"
+    description="Full tool list, skills, plan & verify mode, and worked examples."
+  />
+  <Card
+    title="Configuration"
+    href="/guide/ai-agent/configuration"
+    description="All environment variables, LLM providers, and access control."
+  />
+  <Card
+    title="Conversation history"
+    href="/guide/ai-agent/conversation-history"
+    description="How chat history works and how to enable server-side persistence."
+  />
+</Cards>

--- a/docs/content/guide/ai-agent/capabilities.mdx
+++ b/docs/content/guide/ai-agent/capabilities.mdx
@@ -1,14 +1,10 @@
 ---
+title: Capabilities
 description: Full reference for the agent's 18+ tools, 18 expert skills, plan-and-verify mode, and worked example questions.
 icon: Sparkles
 ---
 
-# Agent capabilities
-
-The agent exposes a small set of **powerful primitives** (18 tools, plus 3
-env-gated control tools). Anything without a dedicated tool is done by writing SQL
-with the `query` tool, guided by a **skill** recipe. You never call tools
-directly — the agent picks and chains them automatically.
+The agent exposes a small set of **powerful primitives** (18 tools, plus 3 env-gated control tools). Anything without a dedicated tool is done by writing SQL with the `query` tool, guided by a **skill** recipe. You never call tools directly — the agent picks and chains them automatically.
 
 ## Tools
 
@@ -22,13 +18,11 @@ directly — the agent picks and chains them automatically.
 | Charts & visualization | Run SQL and return an interactive chart | `query_and_visualize` |
 | Control actions (env-gated) | Kill query/mutation, optimize table | `kill_query`, `kill_mutation`, `optimize_table` |
 
-Everything else (expensive-query rankings, query patterns, anomalies, table-design
-advice, capacity forecasts, settings, logs, replication queue, ZooKeeper, users…) is
-done with `query` plus the relevant skill recipe — so the agent keeps full reach
-with a much smaller, more reliable tool surface.
+Everything else (expensive-query rankings, query patterns, anomalies, table-design advice, capacity forecasts, settings, logs, replication queue, ZooKeeper, users…) is done with `query` plus the relevant skill recipe — so the agent keeps full reach with a much smaller, more reliable tool surface.
 
-Control tools (`kill_query`, `kill_mutation`, `optimize_table`) are disabled unless
-`AGENT_ENABLE_CONTROL_TOOLS=true`. The agent always confirms before using them.
+<Callout type="warn" title="Control tools are off by default">
+Control tools (`kill_query`, `kill_mutation`, `optimize_table`) are disabled unless `AGENT_ENABLE_CONTROL_TOOLS=true`. The agent always confirms before using them.
+</Callout>
 
 ### Tool reference
 
@@ -58,9 +52,7 @@ Control tools (`kill_query`, `kill_mutation`, `optimize_table`) are disabled unl
 
 ## Skills
 
-Skills are expert guides — with copy-pasteable SQL recipes against `system.*` — that
-the agent loads on demand. Because the toolset is lean, **skills are how the agent
-stays powerful**. Eighteen skills are included:
+Skills are expert guides — with copy-pasteable SQL recipes against `system.*` — that the agent loads on demand. Because the toolset is lean, **skills are how the agent stays powerful**. Eighteen skills are included:
 
 | Skill | Covers |
 |---|---|
@@ -83,17 +75,11 @@ stays powerful**. Eighteen skills are included:
 | `incident-response` | Structured triage recipes (disk full, errors, replication lag, health sweep) |
 | `plan-and-verify` | Decompose with `update_plan` and verify each result before concluding |
 
-List available skills: `GET /api/v1/agent/skills`.
+List available skills with `GET /api/v1/agent/skills`.
 
 ## Plan and verify
 
-For multi-step tasks the agent authors a live checklist with `update_plan`, keeps
-exactly one step in progress, and adapts the plan as results come in. Crucially, it
-**verifies each result before stating it** — re-querying or cross-checking a second
-system table for a finding, running `explain_query` on both versions before claiming
-a rewrite is faster, and separating what is verified from what is a hypothesis. The
-`plan-and-verify` and `incident-response` skills encode the recipes. Simple one-step
-questions skip the plan entirely.
+For multi-step tasks the agent authors a live checklist with `update_plan`, keeps exactly one step in progress, and adapts the plan as results come in. Crucially, it **verifies each result before stating it** — re-querying or cross-checking a second system table for a finding, running `explain_query` on both versions before claiming a rewrite is faster, and separating what is verified from what is a hypothesis. The `plan-and-verify` and `incident-response` skills encode the recipes. Simple one-step questions skip the plan entirely.
 
 <Mermaid chart={`flowchart TD
     Q([Multi-step question]) --> P[update_plan: draft steps]
@@ -112,20 +98,29 @@ questions skip the plan entirely.
 
 Ask in plain English:
 
-- **"Which queries are running right now and how long have they been executing?"**
-  — lists query id, user, elapsed time, and memory, sorted by duration.
+- **"Which queries are running right now and how long have they been executing?"** — lists query id, user, elapsed time, and memory, sorted by duration.
+- **"What were the 10 slowest queries in the last 24 hours?"** — fetches from the query log and offers to EXPLAIN any of them.
+- **"What's the largest data scan ever performed on this cluster?"** — loads `data-analysis` and runs the `system.query_log` recipe.
+- **"Anything abnormal in the last hour versus baseline?"** — loads `anomaly-detection` and compares recent activity to the preceding window.
+- **"Show me query volume per hour over the last day as a chart."** — runs the aggregation and renders a line chart inline.
+- **"Suggest a better ORDER BY and which columns should be LowCardinality for `analytics.events`."** — loads `schema-design-advisor`, inspects the schema and parts, and recommends changes.
 
-- **"What were the 10 slowest queries in the last 24 hours?"**
-  — fetches from the query log and offers to EXPLAIN any of them.
+## Related
 
-- **"What's the largest data scan ever performed on this cluster?"**
-  — loads `data-analysis` and runs the `system.query_log` recipe.
-
-- **"Anything abnormal in the last hour versus baseline?"**
-  — loads `anomaly-detection` and compares recent activity to the preceding window.
-
-- **"Show me query volume per hour over the last day as a chart."**
-  — runs the aggregation and renders a line chart inline.
-
-- **"Suggest a better ORDER BY and which columns should be LowCardinality for `analytics.events`."**
-  — loads `schema-design-advisor`, inspects the schema and parts, and recommends changes.
+<Cards>
+  <Card
+    title="AI Agent"
+    href="/guide/ai-agent"
+    description="Overview of the agent, its architecture, and quick start."
+  />
+  <Card
+    title="Configuration"
+    href="/guide/ai-agent/configuration"
+    description="All environment variables, LLM providers, and access control."
+  />
+  <Card
+    title="Conversation history"
+    href="/guide/ai-agent/conversation-history"
+    description="How chat history works and how to enable server-side persistence."
+  />
+</Cards>

--- a/docs/content/guide/ai-agent/configuration.mdx
+++ b/docs/content/guide/ai-agent/configuration.mdx
@@ -1,9 +1,10 @@
 ---
+title: Configuration
 description: All environment variables for configuring the AI Agent — LLM provider, model picker, access control, and conversation persistence.
 icon: SlidersHorizontal
 ---
 
-# Configure the AI Agent
+Configure the agent entirely through environment variables. Start with the core LLM settings, then add provider keys, access control, and persistence as you need them.
 
 ## Core LLM settings
 
@@ -50,7 +51,7 @@ provider:modelId[|contextLength][|description]
 - `contextLength` — optional integer token count; defaults to `128000`
 - `description` — optional display label; defaults to `modelId`
 
-Comma-separated for multiple models:
+Comma-separate multiple models:
 
 ```bash
 LLM_EXTRA_MODELS="nvidia:meta/llama-3.3-70b|131072|Llama 3.3 70B,openrouter:x-ai/grok-2"
@@ -91,7 +92,7 @@ curl -H "Authorization: Bearer $AGENT_API_TOKEN" \
 | `VITE_FEATURE_CONVERSATION_DB` | Build-time | `false` | Enable server-side conversation storage. Derived from canonical `CHM_FEATURE_CONVERSATION_DB` — set that one before `bun run build`. Requires Clerk. |
 | `CONVERSATION_STORE_BACKEND` | Runtime | (auto) | Backend: `agentstate`, `d1`, `postgres`, or `memory`. Auto-selects when unset. |
 
-See [Conversation History](/guide/ai-agent/conversation-history) and [Store Backends](/guide/ai-agent/conversation-history/backends) for per-backend env vars and setup.
+For per-backend env vars and setup, see [Conversation history](/guide/ai-agent/conversation-history) and [Store backends](/guide/ai-agent/conversation-history/backends).
 
 ## Where to set these
 
@@ -103,3 +104,23 @@ See [Conversation History](/guide/ai-agent/conversation-history) and [Store Back
 <Callout type="warn" title="Keep LLM keys server-side">
 Never put LLM API keys in `VITE_*` variables. Anything prefixed `VITE_` is baked into browser JavaScript at build time and is visible to anyone who opens DevTools. Use plain (non-VITE) variables for all keys — they stay on the server.
 </Callout>
+
+## Related
+
+<Cards>
+  <Card
+    title="AI Agent"
+    href="/guide/ai-agent"
+    description="Overview of the agent, its architecture, and quick start."
+  />
+  <Card
+    title="Capabilities"
+    href="/guide/ai-agent/capabilities"
+    description="Full tool list, skills, plan & verify mode, and worked examples."
+  />
+  <Card
+    title="Conversation history"
+    href="/guide/ai-agent/conversation-history"
+    description="How chat history works and how to enable server-side persistence."
+  />
+</Cards>

--- a/docs/content/guide/ai-agent/conversation-history.mdx
+++ b/docs/content/guide/ai-agent/conversation-history.mdx
@@ -1,11 +1,10 @@
 ---
+title: Conversation history
 description: How agent chat history works, how to enable server-side persistence, and which authentication is required.
 icon: MessagesSquare
 ---
 
-# Conversation history
-
-Agent chat history is stored in **browser localStorage** by default. No server setup is needed. Enable server-side persistence when you want history shared across devices, preserved after a browser clear, or visible to multiple users.
+Agent chat history is stored in **browser localStorage** by default — no server setup needed. Enable server-side persistence when you want history shared across devices, preserved after a browser clear, or visible to multiple users.
 
 ## How persistence works
 
@@ -50,10 +49,41 @@ When `CONVERSATION_STORE_BACKEND` is not set, the server auto-selects the first 
 
 When `CONVERSATION_STORE_BACKEND` is not set (or set to an unrecognized value), the server picks the first available backend in this order:
 
-1. **AgentState** — when `AGENTSTATE_API_KEY` is set and `CONVERSATION_STORE_BACKEND` is not `d1`, `postgres`, or `memory`.
-2. **Cloudflare D1** — when the `CHM_CLOUD_D1` binding is present (Cloudflare Workers only).
-3. **Postgres** — when `DATABASE_URL` is set.
-4. **Memory** — fallback in development/CI. Conversations are lost on process restart.
+<Steps>
+
+<Step>
+
+### AgentState
+
+Selected when `AGENTSTATE_API_KEY` is set and `CONVERSATION_STORE_BACKEND` is not `d1`, `postgres`, or `memory`.
+
+</Step>
+
+<Step>
+
+### Cloudflare D1
+
+Selected when the `CHM_CLOUD_D1` binding is present (Cloudflare Workers only).
+
+</Step>
+
+<Step>
+
+### Postgres
+
+Selected when `DATABASE_URL` is set.
+
+</Step>
+
+<Step>
+
+### Memory
+
+Fallback in development/CI. Conversations are lost on process restart.
+
+</Step>
+
+</Steps>
 
 You can force a specific backend by setting `CONVERSATION_STORE_BACKEND` to `agentstate`, `d1`, `postgres`, or `memory`.
 
@@ -61,9 +91,21 @@ You can force a specific backend by setting `CONVERSATION_STORE_BACKEND` to `age
 
 AgentState is a cloud-hosted conversation store. It works on any deployment target (Cloudflare Workers, Docker, Kubernetes, Vercel).
 
-1. Get an API key at [agentstate.app](https://agentstate.app).
+<Steps>
 
-2. Set at build time (the client `VITE_*` values are derived from these):
+<Step>
+
+### Get an API key
+
+Get an API key at [agentstate.app](https://agentstate.app).
+
+</Step>
+
+<Step>
+
+### Set build-time variables
+
+The client `VITE_*` values are derived from these:
 
 ```bash
 CHM_FEATURE_CONVERSATION_DB=true
@@ -71,22 +113,48 @@ CHM_AUTH_PROVIDER=clerk
 CHM_CLERK_PUBLISHABLE_KEY=pk_live_...
 ```
 
-3. Set at runtime:
+</Step>
+
+<Step>
+
+### Set runtime variables
 
 ```bash
 AGENTSTATE_API_KEY=as_live_...
 # CONVERSATION_STORE_BACKEND=agentstate  # optional — auto-selected when key is present
 ```
 
-4. Optional: enable AI enrichment of stored conversation titles:
+</Step>
+
+<Step>
+
+### Optional: enable AI enrichment
+
+Enrich stored conversation titles:
 
 ```bash
 AGENTSTATE_AI_ENRICH=true
 ```
 
-5. Deploy. No migrations needed — AgentState manages the schema.
+</Step>
 
-**Cloudflare Workers** — add via `wrangler secret put`:
+<Step>
+
+### Deploy
+
+No migrations needed — AgentState manages the schema.
+
+</Step>
+
+</Steps>
+
+Per-platform wiring:
+
+<Tabs items={["Cloudflare Workers", "Docker", "Kubernetes"]}>
+
+<Tab value="Cloudflare Workers">
+
+Add the key via `wrangler secret put`:
 
 ```bash
 wrangler secret put AGENTSTATE_API_KEY
@@ -97,7 +165,9 @@ wrangler secret put AGENTSTATE_API_KEY
 CONVERSATION_STORE_BACKEND = "agentstate"
 ```
 
-**Docker:**
+</Tab>
+
+<Tab value="Docker">
 
 ```bash
 docker run -d --name chmonitor -p 3000:3000 \
@@ -106,7 +176,9 @@ docker run -d --name chmonitor -p 3000:3000 \
   ghcr.io/chmonitor/chmonitor:vX.Y.Z
 ```
 
-**Kubernetes:**
+</Tab>
+
+<Tab value="Kubernetes">
 
 ```bash
 kubectl create secret generic chmonitor-agentstate \
@@ -117,6 +189,10 @@ kubectl create secret generic chmonitor-agentstate \
 # in ConfigMap
 CONVERSATION_STORE_BACKEND: "agentstate"
 ```
+
+</Tab>
+
+</Tabs>
 
 ## Request / response flow
 
@@ -143,6 +219,22 @@ Server stores require an authenticated user identity to namespace threads. If th
 
 `NEXT_PUBLIC_FEATURE_CONVERSATION_DB=true` is accepted as an alias for `VITE_FEATURE_CONVERSATION_DB=true` but is deprecated. Do not use it for new deployments.
 
-## Next steps
+## Related
 
-- [Store Backends](/guide/ai-agent/conversation-history/backends) — exact config for each backend with platform recommendations
+<Cards>
+  <Card
+    title="Store backends"
+    href="/guide/ai-agent/conversation-history/backends"
+    description="Exact config for each backend with platform recommendations."
+  />
+  <Card
+    title="Configuration"
+    href="/guide/ai-agent/configuration"
+    description="All environment variables, LLM providers, and access control."
+  />
+  <Card
+    title="AI Agent"
+    href="/guide/ai-agent"
+    description="Overview of the agent, its architecture, and quick start."
+  />
+</Cards>

--- a/docs/content/guide/ai-agent/conversation-history/backends.mdx
+++ b/docs/content/guide/ai-agent/conversation-history/backends.mdx
@@ -1,9 +1,10 @@
 ---
+title: Store backends
 description: Per-backend setup for conversation history — AgentState, Cloudflare D1, Postgres, Memory, and Browser defaults.
 icon: Database
 ---
 
-# Conversation store backends
+Pick the conversation store that fits your platform. Each backend uses the same build-time flag and a runtime backend selector.
 
 <Callout type="info" title="Build-time flag required">
 All server-side backends require `CHM_FEATURE_CONVERSATION_DB=true` set **before** `bun run build`. Its client `VITE_FEATURE_CONVERSATION_DB` is derived from it at build time and baked into the bundle, so it cannot be changed without a rebuild. `CONVERSATION_STORE_BACKEND` is a runtime variable and can be set or changed without rebuilding.
@@ -28,7 +29,11 @@ When `CONVERSATION_STORE_BACKEND` is not set, the server picks the first availab
 3. **Postgres** — when `DATABASE_URL` is set.
 4. **Memory** — fallback in development/CI.
 
-## AgentState
+## Backend setup
+
+<Tabs items={["AgentState", "Cloudflare D1", "Postgres", "Memory", "Browser"]}>
+
+<Tab value="AgentState">
 
 Cloud-hosted conversation store. Works on all platforms. Requires an `as_live_` prefixed key.
 
@@ -39,7 +44,9 @@ AGENTSTATE_API_KEY=as_live_xxx
 # CONVERSATION_STORE_BACKEND=agentstate             # optional — auto-selected when key is present
 ```
 
-## Cloudflare D1
+</Tab>
+
+<Tab value="Cloudflare D1">
 
 Cloudflare-only. Requires a provisioned D1 database and a Worker binding.
 
@@ -61,7 +68,9 @@ Also accepts `AGENT_CHM_CLOUD_D1_DATABASE_ID` as an alias for `CHM_CLOUD_D1_DATA
 
 **When to use:** standard Cloudflare deployments that want queryable, exportable conversation history.
 
-## Postgres
+</Tab>
+
+<Tab value="Postgres">
 
 Any PostgreSQL-compatible database.
 
@@ -74,7 +83,9 @@ Also accepts `POSTGRES_URL` or `POSTGRES_PRISMA_URL` instead of `DATABASE_URL`. 
 
 **When to use:** Kubernetes, Docker, or any deployment with an existing Postgres instance.
 
-## Memory
+</Tab>
+
+<Tab value="Memory">
 
 Ephemeral in-process store. Lost on process restart.
 
@@ -84,10 +95,36 @@ CONVERSATION_STORE_BACKEND=memory
 
 Use only in development or tests.
 
-## Browser (default)
+</Tab>
+
+<Tab value="Browser">
 
 Default when `VITE_FEATURE_CONVERSATION_DB` is not `true` or when the user is unauthenticated. No server config needed. History is stored in browser localStorage. Clearing browser data loses history.
+
+</Tab>
+
+</Tabs>
 
 ## Deprecated alias
 
 `NEXT_PUBLIC_FEATURE_CONVERSATION_DB=true` is equivalent to `VITE_FEATURE_CONVERSATION_DB=true` but is deprecated. Do not use it for new deployments.
+
+## Related
+
+<Cards>
+  <Card
+    title="Conversation history"
+    href="/guide/ai-agent/conversation-history"
+    description="How chat history works and how to enable server-side persistence."
+  />
+  <Card
+    title="Configuration"
+    href="/guide/ai-agent/configuration"
+    description="All environment variables, LLM providers, and access control."
+  />
+  <Card
+    title="AI Agent"
+    href="/guide/ai-agent"
+    description="Overview of the agent, its architecture, and quick start."
+  />
+</Cards>


### PR DESCRIPTION
## Summary

Full prose rewrite of the **AI Agent** documentation unit (5 files) for one consistent voice and the shared Fumadocs page skeleton. Style-only — every agent tool, skill, capability, env var, endpoint, and code sample is preserved verbatim.

Files:
- `docs/content/guide/ai-agent.mdx` — section landing: intro → architecture Mermaid → cards grid → history backends (AgentState detail now uses Tabs for hosted/self-host/local-dev)
- `docs/content/guide/ai-agent/capabilities.mdx` — tool & skill tables kept verbatim; added Related
- `docs/content/guide/ai-agent/configuration.mdx` — env-var tables verbatim; added Related
- `docs/content/guide/ai-agent/conversation-history.mdx` — Steps for resolution order, Tabs for per-platform wiring
- `docs/content/guide/ai-agent/conversation-history/backends.mdx` — Tabs for per-backend setup

## Consistency changes
- Removed stripped `# h1`; bodies start at `##`, sentence-case headings
- Every page ends with a `## Related` `<Cards>` block; every Card has a description
- Root-based internal links; no component imports; Callout types limited to info/warn
- Frontmatter trimmed to `title`/`description`/`icon`

## Fact preservation
Verified backticked-token parity between each file and `main` — zero tools, skills, or env vars added, dropped, or renamed.

## Verification
- `cd apps/docs && bun run sync` → exit 0 (73 pages)
- `bunx fumadocs-mdx` → exit 0

Co-Authored-By: duyetbot <bot@duyet.net>