### PR TITLE
docs(deploy): rewrite docker/k8s/cloudflare/self-host guides

### DIFF
--- a/docs/content/operate/deploy.mdx
+++ b/docs/content/operate/deploy.mdx
@@ -1,11 +1,10 @@
 ---
+title: Deploy
 description: Deploy chmonitor on Docker, Kubernetes, Cloudflare Workers, Vercel, or any Node.js server — each platform page is self-contained.
 icon: Ship
 ---
 
-# Choosing a Platform
-
-Deploy chmonitor wherever your ClickHouse runs. Pick the platform that matches your infrastructure; each platform page is self-contained with install steps, all config categories, and migration notes.
+Deploy chmonitor wherever your ClickHouse runs. Pick the platform that matches your infrastructure — each page below is self-contained, with install steps, every config category, and migration notes.
 
 <Mermaid chart={`flowchart LR
   U[Browser] --> W[chmonitor\\nWorker / Container / Node]
@@ -80,3 +79,14 @@ Every platform shares the same configuration categories. The links below go to t
 | Conversation store | Browser local / agentstate / D1 / postgres / clickhouse | [AI Agent](/guide/ai-agent) |
 | Health alerting | Cron sweep, webhook URL, severity threshold | [Configuration](/reference/configuration) |
 | Branding / analytics | Title, logo, GA / PostHog / Seline | [Configuration](/reference/configuration) |
+
+## Related
+
+<Cards>
+  <Card title="Docker" href="/operate/deploy/docker" description="Run chmonitor as a container or Compose service." />
+  <Card title="Kubernetes" href="/operate/deploy/k8s" description="Deploy with the vendored Helm chart or kustomize." />
+  <Card title="Cloudflare Workers" href="/operate/deploy/cloudflare" description="Serverless edge hosting with D1 and Cron Triggers." />
+  <Card title="Self-host (Node)" href="/operate/deploy/self-host" description="Run on a bare VM with systemd behind nginx." />
+  <Card title="Production checklist" href="/operate/deploy/production-checklist" description="Harden and validate before going live." />
+  <Card title="Authentication" href="/operate/authentication" description="Configure none / clerk / proxy auth providers." />
+</Cards>

--- a/docs/content/operate/deploy/cloudflare.mdx
+++ b/docs/content/operate/deploy/cloudflare.mdx
@@ -1,19 +1,12 @@
 ---
+title: Cloudflare Workers
 description: Deploy chmonitor to Cloudflare Workers for globally distributed, serverless hosting with D1 and Cron Trigger support.
 icon: Cloud
 ---
 
-# Cloudflare Workers
-
-Deploy chmonitor to Cloudflare Workers. Best for globally cached, serverless hosting with no servers to manage.
+Deploy chmonitor to Cloudflare Workers — best for globally cached, serverless hosting with no servers to manage.
 
 The dashboard app (`apps/dashboard`) uses the `@cloudflare/vite-plugin` to build a native Cloudflare Workers bundle — no OpenNext adapter required. The deploy script is just `bun run build && wrangler deploy`.
-
-## One-click deploy
-
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/chmonitor/chmonitor/tree/main/apps/dashboard)
-
-This deploys the `apps/dashboard` worker (TanStack Start). You will be prompted to connect your Cloudflare account and configure variables. See the [environment variable reference](#configure) below and the [dashboard README](https://github.com/chmonitor/chmonitor/tree/main/apps/dashboard#deploy-your-own) for the full variable list.
 
 ## Prerequisites
 
@@ -23,7 +16,13 @@ This deploys the `apps/dashboard` worker (TanStack Start). You will be prompted 
 - `CLOUDFLARE_API_TOKEN` with Workers deploy permissions (or run `wrangler login` for OAuth)
 </Callout>
 
-## Quick start
+### One-click deploy
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/chmonitor/chmonitor/tree/main/apps/dashboard)
+
+This deploys the `apps/dashboard` worker (TanStack Start). You will be prompted to connect your Cloudflare account and configure variables. See the [environment variable reference](#configure) below and the [dashboard README](https://github.com/chmonitor/chmonitor/tree/main/apps/dashboard#deploy-your-own) for the full variable list.
+
+## Setup
 
 <Steps>
 <Step>
@@ -59,6 +58,14 @@ bun run cf:deploy   # vite build → wrangler deploy
 Open your Workers URL or set a custom domain in the Cloudflare dashboard.
 </Step>
 </Steps>
+
+## Verify
+
+Open your Workers URL. To confirm from the shell, hit the readiness endpoint:
+
+```bash
+curl -sf https://<your-worker-url>/api/healthz && echo OK
+```
 
 ## How configuration works on Cloudflare
 
@@ -184,20 +191,23 @@ Feature ids: `overview`, `agent`, `insights`, `health`, `queries`, `tables`, `me
 
 ### Authentication
 
-**None (default):**
+<Tabs items={["None (default)", "API key layer", "Clerk", "Proxy — CF Access", "Proxy — trusted header"]}>
+<Tab value="None (default)">
 
 ```toml
 [vars]
 CHM_AUTH_PROVIDER = "none"
 ```
 
-**API key layer:**
+</Tab>
+<Tab value="API key layer">
 
 ```bash
 wrangler secret put CHM_API_KEY_SECRET
 ```
 
-**Clerk:**
+</Tab>
+<Tab value="Clerk">
 
 Set the canonical names at build time in CI (the client `VITE_AUTH_PROVIDER` / `VITE_CLERK_PUBLISHABLE_KEY` derive from them):
 
@@ -218,9 +228,10 @@ wrangler secret put CLERK_SECRET_KEY   # sk_live_...
 CHM_AUTH_PROVIDER = "clerk"
 ```
 
-**Proxy — Cloudflare Access (native option):**
+</Tab>
+<Tab value="Proxy — CF Access">
 
-Put chmonitor behind a Cloudflare Access application. The Worker verifies `Cf-Access-Jwt-Assertion` JWT from the Access JWKS.
+Native option. Put chmonitor behind a Cloudflare Access application. The Worker verifies `Cf-Access-Jwt-Assertion` JWT from the Access JWKS.
 
 ```toml
 [vars]
@@ -229,7 +240,8 @@ CHM_CF_ACCESS_TEAM_DOMAIN = "https://yourteam.cloudflareaccess.com"
 CHM_CF_ACCESS_AUD = "<audience-tag>"
 ```
 
-**Proxy — trusted header:**
+</Tab>
+<Tab value="Proxy — trusted header">
 
 ```toml
 [vars]
@@ -243,6 +255,9 @@ wrangler secret put CHM_PROXY_AUTH_SECRET
 ```
 
 Without `CHM_PROXY_AUTH_SECRET`, trusted-header auth is disabled.
+
+</Tab>
+</Tabs>
 
 ### AI agent
 
@@ -266,9 +281,10 @@ Never put `LLM_API_KEY` in a `VITE_*` var or `[vars]` — use `wrangler secret p
 
 Server-side persistence requires `CHM_FEATURE_CONVERSATION_DB=true` set **at build time** (in CI before `bun run build`; the client `VITE_FEATURE_CONVERSATION_DB` derives from it), plus Clerk auth. The backend is then selected at runtime.
 
-**D1 (Cloudflare-native, recommended):**
+<Tabs items={["D1 (recommended)", "AgentState", "Postgres"]}>
+<Tab value="D1 (recommended)">
 
-Create a D1 database:
+Cloudflare-native. Create a D1 database:
 
 ```bash
 wrangler d1 create chmonitor-conversations
@@ -302,7 +318,10 @@ Run migrations:
 bun run cf:migrate-conversations
 ```
 
-**AgentState (cloud-hosted):**
+</Tab>
+<Tab value="AgentState">
+
+Cloud-hosted:
 
 ```toml
 [vars]
@@ -313,7 +332,13 @@ CONVERSATION_STORE_BACKEND = "agentstate"
 wrangler secret put AGENTSTATE_API_KEY
 ```
 
-**Postgres:** also available on Cloudflare Workers via outbound HTTP (`DATABASE_URL` runtime secret).
+</Tab>
+<Tab value="Postgres">
+
+Also available on Cloudflare Workers via outbound HTTP (`DATABASE_URL` runtime secret).
+
+</Tab>
+</Tabs>
 
 ### Health alerting — Cron Trigger
 
@@ -362,7 +387,7 @@ This runs: `vite build` (produces the Cloudflare Workers bundle) → `wrangler d
 The chmonitor monorepo's own `wrangler.toml` declares **no** `[vars]`. Its non-secret hosted config lives in committed `apps/dashboard/.env.production` (+ `.env.preview` for PR previews), which feeds both the client build and the Worker runtime vars (injected by `scripts/patch-wrangler-env.ts`). If you fork this repo, edit `.env.production` rather than re-adding a `[vars]` block. When deploying your own standalone Worker from scratch, the `[vars]` examples above are the simplest path.
 </Callout>
 
-## Preview locally
+### Preview locally
 
 ```bash
 bun run cf:preview
@@ -413,8 +438,23 @@ For breaking changes between major versions, see [Migrating to v0.3](/reference/
 
 ## Troubleshooting
 
-**`wrangler deploy` ships nothing or stale assets:** run `bun run build` (or `bun run cf:deploy`, which does both) before `wrangler deploy` — the Vite build must produce the Workers bundle first.
+<Accordions>
+<Accordion title="wrangler deploy ships nothing or stale assets">
+Run `bun run build` (or `bun run cf:deploy`, which does both) before `wrangler deploy` — the Vite build must produce the Workers bundle first.
+</Accordion>
+<Accordion title="Runtime errors / blank pages">
+Check Workers logs in the Cloudflare dashboard. Verify secrets are set (`wrangler secret list`) and redeploy after any `wrangler secret put`.
+</Accordion>
+<Accordion title="Build-time client var not taking effect">
+`VITE_*` vars must be set in the environment when `bun run build` runs, not in `wrangler.toml [vars]`.
+</Accordion>
+</Accordions>
 
-**Runtime errors / blank pages:** check Workers logs in the Cloudflare dashboard. Verify secrets are set (`wrangler secret list`) and redeploy after any `wrangler secret put`.
+## Related
 
-**Build-time client var not taking effect:** `VITE_*` vars must be set in the environment when `bun run build` runs, not in `wrangler.toml [vars]`.
+<Cards>
+  <Card title="Production checklist" href="/operate/deploy/production-checklist" description="Harden and validate before going live." />
+  <Card title="Authentication" href="/operate/authentication" description="Configure none / clerk / proxy auth providers." />
+  <Card title="Docker" href="/operate/deploy/docker" description="Single-container self-host on one server." />
+  <Card title="Migrating to v0.3" href="/reference/migrating/v0-3" description="Breaking changes between major versions." />
+</Cards>

--- a/docs/content/operate/deploy/docker.mdx
+++ b/docs/content/operate/deploy/docker.mdx
@@ -1,18 +1,27 @@
 ---
+title: Docker
 description: Run chmonitor as a Docker container or Compose service — the fastest path to a self-hosted ClickHouse dashboard.
 icon: Container
 ---
 
-# Docker
+Run chmonitor as a Docker container — the fastest path to a self-hosted ClickHouse dashboard. The image is published to GitHub Container Registry.
 
-Run chmonitor as a Docker container. The image is published to GitHub Container Registry.
+## Prerequisites
 
-**Image:** `ghcr.io/chmonitor/chmonitor:vX.Y.Z` — replace `vX.Y.Z` with a real release tag.  
-All releases: https://github.com/chmonitor/chmonitor/pkgs/container/chmonitor
+- Docker installed and running.
+- A reachable ClickHouse endpoint with a monitoring user (`SELECT` on `system.*`).
+- A release tag to pin.
+
+<Callout type="info" title="Image and tags">
+**Image:** `ghcr.io/chmonitor/chmonitor:vX.Y.Z` — replace `vX.Y.Z` with a real release tag. Browse [all releases](https://github.com/chmonitor/chmonitor/pkgs/container/chmonitor).
 
 The legacy name `ghcr.io/chmonitor/chmonitor` also works and points at the same build.
+</Callout>
 
-## Quick start
+## Setup
+
+<Tabs items={["docker run", "Docker Compose"]}>
+<Tab value="docker run">
 
 <Steps>
 <Step>
@@ -33,17 +42,10 @@ Open `http://localhost:3000`.
 `--add-host=host.docker.internal:host-gateway` is needed on Linux when ClickHouse runs on the Docker host. It is not needed on Docker Desktop for Mac/Windows.
 </Callout>
 </Step>
-
-<Step>
-### Verify
-
-```bash
-curl -sf http://localhost:3000/api/healthz && echo OK
-```
-</Step>
 </Steps>
 
-## Docker Compose
+</Tab>
+<Tab value="Docker Compose">
 
 ```yaml
 services:
@@ -64,6 +66,15 @@ services:
 ```
 
 If ClickHouse runs in the same Compose project, use the service name as the host. If it runs on the Docker host machine, use `host.docker.internal` and add `--add-host=host.docker.internal:host-gateway` to the service's `extra_hosts`.
+
+</Tab>
+</Tabs>
+
+## Verify
+
+```bash
+curl -sf http://localhost:3000/api/healthz && echo OK
+```
 
 ## Configure
 
@@ -122,7 +133,8 @@ docker run -d --name chmonitor -p 3000:3000 \
 
 Features are all public and enabled by default. Override only what differs.
 
-**Via env vars:**
+<Tabs items={["Env vars", "Mounted config file (TOML)"]}>
+<Tab value="Env vars">
 
 ```bash
 # Disable a feature entirely
@@ -136,7 +148,8 @@ Features are all public and enabled by default. Override only what differs.
 -e CHM_FEATURE_SETTINGS_ENABLED='false'
 ```
 
-**Via a mounted config file (TOML):**
+</Tab>
+<Tab value="Mounted config file (TOML)">
 
 ```bash
 docker run -d --name chmonitor -p 3000:3000 \
@@ -161,17 +174,26 @@ enabled = false
 access = "authenticated"
 ```
 
+</Tab>
+</Tabs>
+
 Feature ids: `overview`, `agent`, `insights`, `health`, `queries`, `tables`, `metrics`, `dashboard`, `security`, `logs`, `settings`, `cluster`, `operations`, `actions`, `mcp`, `docs`, `about`.
 
 ### Authentication
 
-**None (default) — open access:**
+<Tabs items={["None (default)", "API key layer", "Clerk", "Proxy — CF Access", "Proxy — trusted header"]}>
+<Tab value="None (default)">
+
+Open access:
 
 ```bash
 -e CHM_AUTH_PROVIDER='none'
 ```
 
-**API key layer (can combine with any provider):**
+</Tab>
+<Tab value="API key layer">
+
+Can combine with any provider:
 
 ```bash
 -e CHM_API_KEY_SECRET='a-long-random-secret'
@@ -179,7 +201,8 @@ Feature ids: `overview`, `agent`, `insights`, `health`, `queries`, `tables`, `me
 
 Issue tokens at `POST /api/v1/auth/api-key`. Use `Authorization: Bearer chm_...` on API calls.
 
-**Clerk:**
+</Tab>
+<Tab value="Clerk">
 
 ```bash
 -e CHM_AUTH_PROVIDER='clerk' \
@@ -193,7 +216,10 @@ Set the canonical `CHM_*` names once — the client `VITE_AUTH_PROVIDER` / `VITE
 The client half of these (`CHM_AUTH_PROVIDER`, `CHM_CLERK_PUBLISHABLE_KEY`) is inlined at build time. The pre-built GHCR image is built with auth `none`, so enabling Clerk requires building a custom image with these set at build time, then passing them (plus `CLERK_SECRET_KEY`) at runtime. See [Authentication](/operate/authentication).
 </Callout>
 
-**Proxy — Cloudflare Access:**
+</Tab>
+<Tab value="Proxy — CF Access">
+
+Cloudflare Access:
 
 ```bash
 -e CHM_AUTH_PROVIDER='proxy' \
@@ -201,7 +227,10 @@ The client half of these (`CHM_AUTH_PROVIDER`, `CHM_CLERK_PUBLISHABLE_KEY`) is i
 -e CHM_CF_ACCESS_AUD='<audience-tag>'
 ```
 
-**Proxy — trusted header (nginx/k8s sidecar):**
+</Tab>
+<Tab value="Proxy — trusted header">
+
+nginx / k8s sidecar:
 
 ```bash
 -e CHM_AUTH_PROVIDER='proxy' \
@@ -210,6 +239,9 @@ The client half of these (`CHM_AUTH_PROVIDER`, `CHM_CLERK_PUBLISHABLE_KEY`) is i
 ```
 
 Without `CHM_PROXY_AUTH_SECRET`, the trusted-header provider is disabled. Put chmonitor behind a reverse proxy that sets the header.
+
+</Tab>
+</Tabs>
 
 ### AI agent
 
@@ -233,20 +265,25 @@ Server-side persistence requires `CHM_FEATURE_CONVERSATION_DB=true` baked into t
 
 At runtime, set the backend via `CONVERSATION_STORE_BACKEND`. Available backends on Docker: `postgres`, `agentstate`, `memory`.
 
-**Postgres store (recommended on Docker):**
+<Tabs items={["Postgres (recommended)", "AgentState"]}>
+<Tab value="Postgres (recommended)">
 
 ```bash
 -e CONVERSATION_STORE_BACKEND='postgres' \
 -e DATABASE_URL='postgresql://user:pass@host:5432/dbname'
 ```
 
-**AgentState store:**
+</Tab>
+<Tab value="AgentState">
 
 ```bash
 -e CONVERSATION_STORE_BACKEND='agentstate' \
 -e AGENTSTATE_API_KEY='as_live_...' \
 -e AGENTSTATE_BASE_URL='https://agentstate.app/api'
 ```
+
+</Tab>
+</Tabs>
 
 D1 and Durable Object stores are Cloudflare-only. When `CONVERSATION_STORE_BACKEND` is unset and `AGENTSTATE_API_KEY` is present, AgentState is selected automatically; if `DATABASE_URL` is set, Postgres is used instead.
 
@@ -310,7 +347,7 @@ Or with Compose: update the `image:` tag, then `docker compose up -d --force-rec
 
 For breaking changes between major versions, see [Migrating to v0.3](/reference/migrating/v0-3).
 
-## Common problems
+## Troubleshooting
 
 <Callout type="info" title="localhost resolves to the container">
 `localhost` inside the container resolves to the container itself, not the host. Use `host.docker.internal`.
@@ -318,3 +355,12 @@ For breaking changes between major versions, see [Migrating to v0.3](/reference/
 
 - Empty pages usually mean the ClickHouse user lacks grants on system tables. Grant `SELECT` on `system.*`.
 - If pages load but charts are empty, check `CLICKHOUSE_MAX_EXECUTION_TIME` — the default is 60 s.
+
+## Related
+
+<Cards>
+  <Card title="Production checklist" href="/operate/deploy/production-checklist" description="Harden and validate before going live." />
+  <Card title="Authentication" href="/operate/authentication" description="Configure none / clerk / proxy auth providers." />
+  <Card title="Kubernetes" href="/operate/deploy/k8s" description="Move from a single container to a managed cluster." />
+  <Card title="Migrating to v0.3" href="/reference/migrating/v0-3" description="Breaking changes between major versions." />
+</Cards>

--- a/docs/content/operate/deploy/k8s.mdx
+++ b/docs/content/operate/deploy/k8s.mdx
@@ -1,9 +1,8 @@
 ---
+title: Kubernetes
 description: Deploy chmonitor on Kubernetes with the vendored Helm chart or kustomize overlays, with health probes, autoscaling, and secrets management.
 icon: Hexagon
 ---
-
-# Kubernetes
 
 Run chmonitor on Kubernetes with the vendored Helm chart or raw kustomize manifests. Both use the same image (`ghcr.io/chmonitor/chmonitor:vX.Y.Z`), expose port `3000`, run as the non-root `app` user (uid/gid `1001`), and wire the same health probes.
 
@@ -14,7 +13,11 @@ Run chmonitor on Kubernetes with the vendored Helm chart or raw kustomize manife
   P --> DB[(postgres / agentstate)]
   CJ[CronJob] -->|health-sweep| S`} />
 
-## Quick start with Helm
+## Prerequisites
+
+- A Kubernetes cluster and `kubectl` context.
+- Helm 3 (for the chart) or `kubectl` with kustomize (for raw manifests).
+- A reachable ClickHouse endpoint with a monitoring user.
 
 The chart is published in two registries:
 
@@ -23,7 +26,10 @@ The chart is published in two registries:
 | **Helm repo** (Cloudflare Pages) | `helm repo add chmonitor https://charts.chmonitor.dev` |
 | **OCI** (GHCR) | `helm install my-chm oci://ghcr.io/chmonitor/chmonitor --version X.Y.Z` |
 
-### From the Helm repository
+## Setup
+
+<Tabs items={["Helm repo", "Helm OCI", "Helm from source", "kustomize"]}>
+<Tab value="Helm repo">
 
 <Steps>
 <Step>
@@ -41,55 +47,7 @@ helm install my-chm chmonitor/chmonitor \
 </Step>
 
 <Step>
-### Verify
-
-```bash
-kubectl port-forward svc/my-chm-chmonitor 3000:3000
-# open http://localhost:3000
-```
-</Step>
-</Steps>
-
-Upgrade and uninstall:
-
-```bash
-helm upgrade my-chm chmonitor/chmonitor -f values.yaml
-helm uninstall my-chm
-```
-
-### From the OCI registry (GHCR)
-
-Replace `vX.Y.Z` with the latest release tag from [GitHub Releases](https://github.com/chmonitor/chmonitor/releases).
-
-```bash
-helm install my-chm oci://ghcr.io/chmonitor/chmonitor --version vX.Y.Z \
-  --set clickhouse.host="https://clickhouse.example.com:8443" \
-  --set clickhouse.user="monitoring" \
-  --set clickhouse.password="change-me"
-```
-
-Pull and inspect the chart before installing:
-
-```bash
-helm pull oci://ghcr.io/chmonitor/chmonitor --version vX.Y.Z --untar
-helm show values ./chmonitor
-```
-
-### From source (vendored chart)
-
-Alternatively, clone the repo and install the chart directly — useful when you want to patch the chart before installing:
-
-```bash
-git clone https://github.com/chmonitor/chmonitor.git
-cd clickhouse-monitoring
-
-helm install my-chm ./deploy/helm/chmonitor \
-  --set clickhouse.host="https://clickhouse.example.com:8443" \
-  --set clickhouse.user="monitoring" \
-  --set clickhouse.password="change-me"
-```
-
-### With a values file
+### Install with a values file (optional)
 
 ```bash
 helm install my-chm chmonitor/chmonitor -f values.yaml
@@ -123,8 +81,52 @@ resources:
     cpu: 500m
     memory: 512Mi
 ```
+</Step>
+</Steps>
 
-## Quick start with kustomize
+Upgrade and uninstall:
+
+```bash
+helm upgrade my-chm chmonitor/chmonitor -f values.yaml
+helm uninstall my-chm
+```
+
+</Tab>
+<Tab value="Helm OCI">
+
+Replace `vX.Y.Z` with the latest release tag from [GitHub Releases](https://github.com/chmonitor/chmonitor/releases).
+
+```bash
+helm install my-chm oci://ghcr.io/chmonitor/chmonitor --version vX.Y.Z \
+  --set clickhouse.host="https://clickhouse.example.com:8443" \
+  --set clickhouse.user="monitoring" \
+  --set clickhouse.password="change-me"
+```
+
+Pull and inspect the chart before installing:
+
+```bash
+helm pull oci://ghcr.io/chmonitor/chmonitor --version vX.Y.Z --untar
+helm show values ./chmonitor
+```
+
+</Tab>
+<Tab value="Helm from source">
+
+Clone the repo and install the chart directly — useful when you want to patch the chart before installing:
+
+```bash
+git clone https://github.com/chmonitor/chmonitor.git
+cd clickhouse-monitoring
+
+helm install my-chm ./deploy/helm/chmonitor \
+  --set clickhouse.host="https://clickhouse.example.com:8443" \
+  --set clickhouse.user="monitoring" \
+  --set clickhouse.password="change-me"
+```
+
+</Tab>
+<Tab value="kustomize">
 
 ```bash
 # Review rendered output first
@@ -151,6 +153,16 @@ images:
 replicas:
   - name: chmonitor
     count: 2
+```
+
+</Tab>
+</Tabs>
+
+## Verify
+
+```bash
+kubectl port-forward svc/my-chm-chmonitor 3000:3000
+# open http://localhost:3000
 ```
 
 ## Configure
@@ -249,7 +261,8 @@ envFrom:
 
 ### Feature permissions
 
-**Via env in ConfigMap:**
+<Tabs items={["Env in ConfigMap", "Mounted config file (recommended)"]}>
+<Tab value="Env in ConfigMap">
 
 ```yaml
 # chmonitor-config ConfigMap additions
@@ -258,9 +271,10 @@ CHM_AUTH_REQUIRED_FEATURES: "agent,settings,mcp"
 CHM_FEATURE_AGENT_ACCESS: "authenticated"
 ```
 
-**Via mounted config file (recommended for complex rules):**
+</Tab>
+<Tab value="Mounted config file (recommended)">
 
-Create a ConfigMap with a TOML file:
+Recommended for complex rules. Create a ConfigMap with a TOML file:
 
 ```yaml
 apiVersion: v1
@@ -301,25 +315,35 @@ volumes:
       name: chmonitor-features
 ```
 
+</Tab>
+</Tabs>
+
 Feature ids: `overview`, `agent`, `insights`, `health`, `queries`, `tables`, `metrics`, `dashboard`, `security`, `logs`, `settings`, `cluster`, `operations`, `actions`, `mcp`, `docs`, `about`.
 
 ### Authentication
 
-**None (default) — open access:**
+<Tabs items={["None (default)", "API key layer", "Clerk", "Proxy — CF Access", "Proxy — trusted header"]}>
+<Tab value="None (default)">
+
+Open access:
 
 ```yaml
 # in ConfigMap
 CHM_AUTH_PROVIDER: "none"
 ```
 
-**API key layer (can combine with any provider):**
+</Tab>
+<Tab value="API key layer">
+
+Can combine with any provider:
 
 ```bash
 kubectl create secret generic chmonitor-auth \
   --from-literal=CHM_API_KEY_SECRET='a-long-random-secret'
 ```
 
-**Clerk:**
+</Tab>
+<Tab value="Clerk">
 
 ```bash
 kubectl create secret generic chmonitor-clerk \
@@ -338,7 +362,10 @@ The client `VITE_AUTH_PROVIDER` / `VITE_CLERK_PUBLISHABLE_KEY` derive from these
 The client half of these settings is inlined at build time. The pre-built GHCR image is built with auth `none`, so enabling Clerk means building a custom image with `CHM_AUTH_PROVIDER` / `CHM_CLERK_PUBLISHABLE_KEY` set at build time, then setting them (plus the `CLERK_SECRET_KEY` Secret) at runtime. See [Authentication](/operate/authentication).
 </Callout>
 
-**Proxy — Cloudflare Access:**
+</Tab>
+<Tab value="Proxy — CF Access">
+
+Cloudflare Access:
 
 ```yaml
 # in ConfigMap
@@ -347,7 +374,10 @@ CHM_CF_ACCESS_TEAM_DOMAIN: "https://yourteam.cloudflareaccess.com"
 CHM_CF_ACCESS_AUD: "<audience-tag>"
 ```
 
-**Proxy — trusted header (nginx ingress / sidecar):**
+</Tab>
+<Tab value="Proxy — trusted header">
+
+nginx ingress / sidecar:
 
 ```bash
 kubectl create secret generic chmonitor-proxy \
@@ -362,6 +392,9 @@ CHM_PROXY_SHARED_SECRET_HEADER: "X-Chm-Proxy-Secret"
 ```
 
 Without `CHM_PROXY_AUTH_SECRET`, the trusted-header provider is disabled. Configure your ingress to set the header and the secret. See [Authentication](/operate/authentication).
+
+</Tab>
+</Tabs>
 
 ### AI agent
 
@@ -388,7 +421,8 @@ Server-side persistence requires `CHM_FEATURE_CONVERSATION_DB=true` baked into t
 
 On Kubernetes, use `postgres` or `agentstate` for the conversation store. D1 and Durable Object stores are Cloudflare-only.
 
-**Postgres store (recommended on Kubernetes):**
+<Tabs items={["Postgres (recommended)", "AgentState"]}>
+<Tab value="Postgres (recommended)">
 
 ```bash
 kubectl create secret generic chmonitor-postgres \
@@ -400,7 +434,8 @@ kubectl create secret generic chmonitor-postgres \
 CONVERSATION_STORE_BACKEND: "postgres"
 ```
 
-**AgentState store:**
+</Tab>
+<Tab value="AgentState">
 
 ```bash
 kubectl create secret generic chmonitor-agentstate \
@@ -411,6 +446,9 @@ kubectl create secret generic chmonitor-agentstate \
 # in ConfigMap
 CONVERSATION_STORE_BACKEND: "agentstate"
 ```
+
+</Tab>
+</Tabs>
 
 ### Health alerting
 
@@ -541,10 +579,21 @@ kubectl rollout status deployment/chmonitor
 
 For breaking changes between major versions, see [Migrating to v0.3](/reference/migrating/v0-3).
 
-## Validation
+## Troubleshooting
+
+Validate the chart and manifests before applying:
 
 ```bash
 helm lint ./deploy/helm/chmonitor
 helm template release ./deploy/helm/chmonitor | kubeconform -strict -summary
 kubectl kustomize deploy/kubernetes/base | kubeconform -strict -summary
 ```
+
+## Related
+
+<Cards>
+  <Card title="Production checklist" href="/operate/deploy/production-checklist" description="Harden and validate before going live." />
+  <Card title="Authentication" href="/operate/authentication" description="Configure none / clerk / proxy auth providers." />
+  <Card title="Docker" href="/operate/deploy/docker" description="Single-container self-host on one server." />
+  <Card title="Migrating to v0.3" href="/reference/migrating/v0-3" description="Breaking changes between major versions." />
+</Cards>

--- a/docs/content/operate/deploy/self-host.mdx
+++ b/docs/content/operate/deploy/self-host.mdx
@@ -1,13 +1,18 @@
 ---
+title: Self-host (Node / standalone)
 description: Run chmonitor on any server using Node.js or Bun — bare VMs, dedicated servers, or any environment where you manage the process directly.
 icon: Server
 ---
 
-# Self-host (Node / standalone)
+Run chmonitor on any server using Node.js or Bun — best for bare VMs, dedicated servers, or any environment where you manage the process directly.
 
-Run chmonitor on any server using Node.js or Bun. Best for bare VMs, dedicated servers, or any environment where you manage the process directly.
+## Prerequisites
 
-## Quick start
+- Bun installed on the server.
+- A reachable ClickHouse endpoint with a monitoring user.
+- A process supervisor (systemd) and, optionally, a reverse proxy (nginx).
+
+## Setup
 
 <Steps>
 <Step>
@@ -42,7 +47,7 @@ Open `http://localhost:3000`.
 </Step>
 </Steps>
 
-## Using .env
+### Using .env
 
 Put env vars in `.env.local` in the project root (Next.js) or `.env` for the TanStack app. Never commit credentials.
 
@@ -57,6 +62,12 @@ CLICKHOUSE_TZ=UTC
 EOF
 
 bun run start
+```
+
+## Verify
+
+```bash
+curl -sf http://localhost:3000/api/healthz && echo OK
 ```
 
 ## Configure
@@ -94,7 +105,8 @@ export CLICKHOUSE_NAME='shard-1,shard-2'
 
 ### Feature permissions
 
-**Via env vars:**
+<Tabs items={["Env vars", "Config file (TOML)"]}>
+<Tab value="Env vars">
 
 ```bash
 export CHM_DISABLED_FEATURES='peerdb,actions'
@@ -103,7 +115,8 @@ export CHM_FEATURE_AGENT_ACCESS='authenticated'
 export CHM_FEATURE_SETTINGS_ENABLED='false'
 ```
 
-**Via a config file (TOML):**
+</Tab>
+<Tab value="Config file (TOML)">
 
 ```bash
 export CHM_CONFIG_FILE='/etc/chmonitor/config.toml'
@@ -121,23 +134,29 @@ enabled = false
 access = "authenticated"
 ```
 
+</Tab>
+</Tabs>
+
 Feature ids: `overview`, `agent`, `insights`, `health`, `queries`, `tables`, `metrics`, `dashboard`, `security`, `logs`, `settings`, `cluster`, `operations`, `actions`, `mcp`, `docs`, `about`.
 
 ### Authentication
 
-**None (default):**
+<Tabs items={["None (default)", "API key layer", "Clerk", "Proxy — CF Access", "Proxy — trusted header"]}>
+<Tab value="None (default)">
 
 ```bash
 export CHM_AUTH_PROVIDER='none'
 ```
 
-**API key layer:**
+</Tab>
+<Tab value="API key layer">
 
 ```bash
 export CHM_API_KEY_SECRET='a-long-random-secret'
 ```
 
-**Clerk:**
+</Tab>
+<Tab value="Clerk">
 
 ```bash
 # Build with the canonical names (the client VITE_* derive from them):
@@ -148,7 +167,10 @@ export CLERK_SECRET_KEY='sk_live_...'
 
 Set `CHM_AUTH_PROVIDER` / `CHM_CLERK_PUBLISHABLE_KEY` before `bun run build` (the client values are inlined at build time), then keep `CHM_AUTH_PROVIDER` and the `CLERK_SECRET_KEY` secret in the runtime env.
 
-**Proxy — Cloudflare Access:**
+</Tab>
+<Tab value="Proxy — CF Access">
+
+Cloudflare Access:
 
 ```bash
 export CHM_AUTH_PROVIDER='proxy'
@@ -156,9 +178,10 @@ export CHM_CF_ACCESS_TEAM_DOMAIN='https://yourteam.cloudflareaccess.com'
 export CHM_CF_ACCESS_AUD='<audience-tag>'
 ```
 
-**Proxy — trusted header (nginx):**
+</Tab>
+<Tab value="Proxy — trusted header">
 
-Put chmonitor behind nginx. Configure nginx to set an auth header and pass the secret.
+nginx. Put chmonitor behind nginx. Configure nginx to set an auth header and pass the secret.
 
 ```bash
 export CHM_AUTH_PROVIDER='proxy'
@@ -191,6 +214,9 @@ server {
 }
 ```
 
+</Tab>
+</Tabs>
+
 ### AI agent
 
 ```bash
@@ -209,19 +235,24 @@ Keep `LLM_API_KEY` server-side — never set it as a `VITE_*` variable.
 
 Server-side persistence requires `CHM_FEATURE_CONVERSATION_DB=true` set at build time (its client `VITE_FEATURE_CONVERSATION_DB` is derived at build). Build with this flag set. At runtime, select the backend:
 
-**Postgres store (recommended for self-host):**
+<Tabs items={["Postgres (recommended)", "AgentState"]}>
+<Tab value="Postgres (recommended)">
 
 ```bash
 export CONVERSATION_STORE_BACKEND='postgres'
 export DATABASE_URL='postgresql://user:pass@host:5432/dbname'
 ```
 
-**AgentState store:**
+</Tab>
+<Tab value="AgentState">
 
 ```bash
 export CONVERSATION_STORE_BACKEND='agentstate'
 export AGENTSTATE_API_KEY='as_live_...'
 ```
+
+</Tab>
+</Tabs>
 
 D1 and Durable Object stores are Cloudflare-only.
 
@@ -298,3 +329,12 @@ systemctl restart chmonitor
 ```
 
 For breaking changes between major versions, see [Migrating to v0.3](/reference/migrating/v0-3).
+
+## Related
+
+<Cards>
+  <Card title="Production checklist" href="/operate/deploy/production-checklist" description="Harden and validate before going live." />
+  <Card title="Authentication" href="/operate/authentication" description="Configure none / clerk / proxy auth providers." />
+  <Card title="Traefik" href="/operate/deploy/traefik" description="Front chmonitor with a Traefik reverse proxy." />
+  <Card title="Docker" href="/operate/deploy/docker" description="Containerize instead of running the process directly." />
+</Cards>


### PR DESCRIPTION
## What

Full prose rewrite of the Deploy A unit for one consistent voice and the shared page skeleton, part of the docs consistency + interactive-UI pass. No pages added, removed, or renamed.

Rewritten:
- `operate/deploy.mdx` (section landing / platform selector)
- `operate/deploy/docker.mdx`
- `operate/deploy/k8s.mdx`
- `operate/deploy/cloudflare.mdx`
- `operate/deploy/self-host.mdx`

## Changes

- Apply the shared skeleton: lead → **Prerequisites** → **Setup** → **Verify** → **Configure** → **Upgrading** → **Troubleshooting** → **Related**.
- Move variant splits into `<Tabs>`: docker run vs Compose, Helm repo/OCI/source vs kustomize, the five auth providers, and conversation-store backends (postgres / agentstate / D1).
- Cloudflare troubleshooting → `<Accordions>`.
- Every page now ends with a `## Related` `<Cards>` block.
- Action-first, direct voice; sentence-case headings starting at `##`; frontmatter `title` added, Callouts limited to info/warn.
- Added explicit `Verify` curl commands (`/api/healthz`) to the Cloudflare and self-host pages, matching the docker/k8s pattern.

## Fact preservation

Verified by diff against `HEAD`: every env-var token, code-fence line, image tag, port, command, and external URL is **identical** to the pre-rewrite source. The only code/URL additions are the two `curl .../api/healthz` verify commands noted above.

## Verification

Parallel-safe docs E2E recipe (no full build):

```
cd apps/docs && bun run sync && bunx fumadocs-mdx
```

Both exit 0; all five pages regenerate under `apps/docs/content/docs/operate/deploy/**` (landing → `deploy/index.mdx`) with correct frontmatter and h1 stripped.

Co-Authored-By: duyetbot <bot@duyet.net>