### PR TITLE
docs(operate): rewrite advanced pages + operate landing for consistency

### DIFF
--- a/docs/content/operate/advanced/peerdb-monitoring.mdx
+++ b/docs/content/operate/advanced/peerdb-monitoring.mdx
@@ -1,9 +1,8 @@
 ---
 description: Read-only PeerDB Mirrors and Peers section — configure PEERDB_API_URL to surface replication status, throughput, and lag without mutating PeerDB.
 icon: Replace
+title: PeerDB Monitoring
 ---
-
-# PeerDB Monitoring
 
 CHM includes an optional, **view-only** PeerDB section (Mirrors and Peers) that
 surfaces replication status, throughput, lag, and per-mirror detail from a
@@ -11,24 +10,34 @@ surfaces replication status, throughput, lag, and per-mirror detail from a
 proxies a read-only allowlist of the PeerDB REST API.
 
 <Callout type="info">
-Open it at `/peerdb` once configured. The section is hidden until `PEERDB_API_URL` is set.
+Open it at `/peerdb` once configured. The section is hidden until
+`PEERDB_API_URL` is set.
 </Callout>
 
----
+## Configure
 
-## Enable
+<Steps>
+<Step>
+### Set the API URL and password
 
 Set `PEERDB_API_URL` (and `PEERDB_PASSWORD` if your PeerDB API requires auth),
 then restart the app.
 
+For the PeerDB **UI** behind NextAuth, include the `/api` suffix:
+
 ```bash
-# PeerDB UI behind NextAuth — include the /api suffix
 PEERDB_API_URL=https://peerdb.example.com/api
 PEERDB_PASSWORD=your-peerdb-ui-password
+```
 
-# OR a raw flow-api with no auth — use the bare origin
+For a raw **flow-api** with no auth, use the bare origin:
+
+```bash
 PEERDB_API_URL=http://localhost:8113
 ```
+</Step>
+<Step>
+### Tune caching and timeouts
 
 | Variable | Default | Description |
 |---|---|---|
@@ -39,8 +48,8 @@ PEERDB_API_URL=http://localhost:8113
 | `PEERDB_FETCH_TIMEOUT_MS` | `10000` | Upstream request timeout. |
 
 See the full list in [Environment Variables](/reference/environment-variables).
-
----
+</Step>
+</Steps>
 
 ## Connection status
 
@@ -52,8 +61,6 @@ The header shows a status pill that distinguishes:
 - **Unreachable** — wrong `PEERDB_API_URL` or a network/DNS issue.
 - **Not configured** — `PEERDB_API_URL` is unset.
 
----
-
 ## Security
 
 CHM proxies only a **read-only allowlist** of PeerDB endpoints
@@ -62,12 +69,11 @@ config, maintenance) are rejected with `403`. The PeerDB credential is attached
 server-side and never reaches the browser bundle, and secret-shaped peer config
 fields are masked in the UI.
 
-The section also respects [Feature Permissions](/operate/advanced/feature-permissions)
-— gate it with `CHM_FEATURE_PEERDB_ACCESS=authenticated` or disable it with
+The section also respects
+[Feature Permissions](/operate/advanced/feature-permissions) — gate it with
+`CHM_FEATURE_PEERDB_ACCESS=authenticated` or disable it with
 `CHM_FEATURE_PEERDB_ENABLED=false`. The proxy enforces the same gate, so it
 cannot be reached directly when the feature is disabled or restricted.
-
----
 
 ## Local development (mock)
 
@@ -79,8 +85,6 @@ bun run peerdb:mock                                  # serves :8113
 PEERDB_API_URL=http://localhost:8113 bun run dev     # → /peerdb
 ```
 
----
-
 ## Troubleshooting
 
 | Symptom | Likely cause |
@@ -89,3 +93,18 @@ PEERDB_API_URL=http://localhost:8113 bun run dev     # → /peerdb
 | Pill shows **Unreachable** | `PEERDB_API_URL` host/port wrong, or the API is not reachable from the CHM server. |
 | Mirrors load but charts are empty | The mirror has no recent CDC graph/batch data yet, or the PeerDB version doesn't expose those endpoints. |
 | Large fleets show partial KPI totals | Per-row metrics load lazily above 24 mirrors; the Throughput/Rows-synced cards label how many mirrors are loaded. Expand a row to load its metrics. |
+
+## Related
+
+<Cards>
+  <Card
+    title="Feature Permissions"
+    href="/operate/advanced/feature-permissions"
+    description="Gate or disable the PeerDB section with CHM_FEATURE_PEERDB_ACCESS and CHM_FEATURE_PEERDB_ENABLED."
+  />
+  <Card
+    title="Environment Variables"
+    href="/reference/environment-variables"
+    description="Full reference for all PeerDB and connection variables."
+  />
+</Cards>

--- a/docs/content/operate/advanced/queries-history.mdx
+++ b/docs/content/operate/advanced/queries-history.mdx
@@ -1,17 +1,18 @@
 ---
 description: History, failed, expensive, and slow query pages read from system.query_log — configure retention, grants, and default user exclusions.
 icon: History
+title: Query History
 ---
 
-# Query History
-
-The query history pages (`/history-queries`, `/failed-queries`, `/expensive-queries`, `/slow-queries`) read from `system.query_log`. This table is built into ClickHouse and records every completed query.
-
----
+The query history pages (`/history-queries`, `/failed-queries`,
+`/expensive-queries`, `/slow-queries`) read from `system.query_log`. This table
+is built into ClickHouse and records every completed query.
 
 ## Requirements
 
-`system.query_log` must be enabled in your ClickHouse configuration. It is enabled by default in most installations. If the table is empty or missing, history pages show no data.
+`system.query_log` must be enabled in your ClickHouse configuration. It is
+enabled by default in most installations. If the table is empty or missing,
+history pages show no data.
 
 The configured `CLICKHOUSE_USER` needs `SELECT` on `system.query_log`:
 
@@ -19,11 +20,15 @@ The configured `CLICKHOUSE_USER` needs `SELECT` on `system.query_log`:
 GRANT SELECT ON system.query_log TO monitoring_user;
 ```
 
----
+## Configure
 
-## Retention
+<Steps>
+<Step>
+### Set retention
 
-ClickHouse flushes query log entries every 7.5 seconds by default and retains them for 30 days. To change retention, set `flush_interval_milliseconds` and `partition_by` / `ttl` in `system.query_log` config:
+ClickHouse flushes query log entries every 7.5 seconds by default and retains
+them for 30 days. To change retention, set `flush_interval_milliseconds` and
+`partition_by` / `ttl` in `system.query_log` config:
 
 ```xml
 <!-- config.xml or conf.d/query_log.xml -->
@@ -36,20 +41,23 @@ ClickHouse flushes query log entries every 7.5 seconds by default and retains th
 ```
 
 <Callout type="info">
-Shorter retention reduces disk usage but limits how far back history pages can look.
+Shorter retention reduces disk usage but limits how far back history pages can
+look.
 </Callout>
+</Step>
+<Step>
+### Filter out monitoring users
 
----
-
-## Filtering out monitoring users
-
-By default, history pages show queries from all users including the monitoring user itself. This creates noise. Filter out specific users using `CLICKHOUSE_EXCLUDE_USER_DEFAULT`:
+By default, history pages show queries from all users including the monitoring
+user itself. This creates noise. Filter out specific users using
+`CLICKHOUSE_EXCLUDE_USER_DEFAULT`:
 
 ```bash
 CLICKHOUSE_EXCLUDE_USER_DEFAULT=monitoring,healthcheck
 ```
 
-Set this to a comma-separated list of usernames to exclude from history page defaults. Users can still remove the filter in the UI.
+Set this to a comma-separated list of usernames to exclude from history page
+defaults. Users can still remove the filter in the UI.
 
 <Tabs items={['Docker', 'Kubernetes / Helm']}>
 <Tab value="Docker">
@@ -77,8 +85,8 @@ env:
 ```
 </Tab>
 </Tabs>
-
----
+</Step>
+</Steps>
 
 ## What each history page shows
 
@@ -89,18 +97,30 @@ env:
 | Expensive | `/expensive-queries` | `system.query_log` | Queries ranked by memory usage or read bytes. |
 | Slow | `/slow-queries` | `system.query_log` | Queries ranked by elapsed time. |
 
----
-
 ## Notes
 
 - History pages respect the global time range selector.
-- If `system.query_log` is partitioned by day, queries crossing midnight may appear split across rows.
-- The AI agent can analyze query history and surface patterns or anomalies — see [AI Agent](/guide/ai-agent).
-
----
+- If `system.query_log` is partitioned by day, queries crossing midnight may
+  appear split across rows.
+- The AI agent can analyze query history and surface patterns or anomalies — see
+  [AI Agent](/guide/ai-agent).
 
 ## Related
 
-- [Features — Queries](/guide/features/queries) — full overview of all query pages.
-- [Environment Variables](/reference/environment-variables) — `CLICKHOUSE_EXCLUDE_USER_DEFAULT` and connection settings.
-- [Self-Tracking](/operate/advanced/self-tracking) — the dashboard's own event table.
+<Cards>
+  <Card
+    title="Features — Queries"
+    href="/guide/features/queries"
+    description="Full overview of all query pages."
+  />
+  <Card
+    title="Environment Variables"
+    href="/reference/environment-variables"
+    description="CLICKHOUSE_EXCLUDE_USER_DEFAULT and connection settings."
+  />
+  <Card
+    title="Self-Tracking"
+    href="/operate/advanced/self-tracking"
+    description="The dashboard's own event table."
+  />
+</Cards>

--- a/docs/content/operate/advanced/self-tracking.mdx
+++ b/docs/content/operate/advanced/self-tracking.mdx
@@ -1,11 +1,12 @@
 ---
 description: chmonitor writes its own usage events to a ClickHouse table — configure the target table, required grants, and how to suppress writes.
 icon: LineChart
+title: Self-Tracking
 ---
 
-# Self-Tracking
-
-chmonitor writes events to a ClickHouse table as users interact with the dashboard. This self-tracking data lets you audit dashboard usage, debug unexpected behavior, and see which pages and queries are most active.
+chmonitor writes events to a ClickHouse table as users interact with the
+dashboard. This self-tracking data lets you audit dashboard usage, debug
+unexpected behavior, and see which pages and queries are most active.
 
 <Mermaid chart={`flowchart LR
   U[User action] --> D[Dashboard]
@@ -14,26 +15,48 @@ chmonitor writes events to a ClickHouse table as users interact with the dashboa
   E --> Q[Query / Audit]
   F --> A[AI agent findings]`} />
 
----
-
 ## What it records
 
-Every page visit, query execution, and action in the dashboard writes a row to the events table. Recorded fields include the event type, page path, host index, timestamp, and relevant metadata (e.g. query fingerprint, table name).
+Every page visit, query execution, and action in the dashboard writes a row to
+the events table. Recorded fields include the event type, page path, host index,
+timestamp, and relevant metadata (e.g. query fingerprint, table name).
 
-A companion `monitoring_findings` table stores persistent findings recorded by the AI agent across sessions.
+A companion `monitoring_findings` table stores persistent findings recorded by
+the AI agent across sessions.
 
----
+## Configure
 
-## Configuration
+<Steps>
+<Step>
+### Set the target table
+
+Point self-tracking at whichever database and table you want.
 
 | Variable | Default | Description |
 |---|---|---|
 | `EVENTS_TABLE_NAME` | `system.monitoring_events` | Full table name for self-tracking events. Override to use a different database or table. |
 | `CLICKHOUSE_DATABASE` | `system` | Default database for app-owned tables when `EVENTS_TABLE_NAME` is not explicitly set. |
 
-The table is created automatically on first use if it does not exist and the configured ClickHouse user has `CREATE TABLE` permission on the target database.
+The table is created automatically on first use if it does not exist and the
+configured ClickHouse user has `CREATE TABLE` permission on the target database.
+</Step>
+<Step>
+### Grant the required permissions
 
----
+The configured `CLICKHOUSE_USER` needs `INSERT` on the events table:
+
+```sql
+GRANT INSERT ON system.monitoring_events TO monitoring_user;
+-- Or on the custom table if EVENTS_TABLE_NAME is overridden:
+GRANT CREATE TABLE, INSERT ON my_db.* TO monitoring_user;
+```
+</Step>
+</Steps>
+
+<Callout type="info">
+If the user lacks `INSERT` permission, event writes fail silently and the
+dashboard continues to work normally.
+</Callout>
 
 ## Change the table location
 
@@ -41,8 +64,9 @@ To write events to a non-system database:
 
 ```bash
 CLICKHOUSE_DATABASE=chmonitor
-# EVENTS_TABLE_NAME defaults to chmonitor.monitoring_events
 ```
+
+`EVENTS_TABLE_NAME` then defaults to `chmonitor.monitoring_events`.
 
 Or set the full table name directly:
 
@@ -50,11 +74,10 @@ Or set the full table name directly:
 EVENTS_TABLE_NAME=my_db.dashboard_events
 ```
 
----
-
 ## Disable self-tracking
 
-chmonitor does not currently have a single flag to disable all event writes. To suppress writes, point `EVENTS_TABLE_NAME` at a Null-engine table:
+chmonitor does not currently have a single flag to disable all event writes. To
+suppress writes, point `EVENTS_TABLE_NAME` at a Null-engine table:
 
 ```sql
 CREATE TABLE my_db.monitoring_events_null AS system.monitoring_events
@@ -67,25 +90,17 @@ EVENTS_TABLE_NAME=my_db.monitoring_events_null
 
 Inserts succeed instantly and no data is retained.
 
----
-
-## ClickHouse grants required
-
-The configured `CLICKHOUSE_USER` needs:
-
-```sql
-GRANT INSERT ON system.monitoring_events TO monitoring_user;
--- Or on the custom table if EVENTS_TABLE_NAME is overridden:
-GRANT CREATE TABLE, INSERT ON my_db.* TO monitoring_user;
-```
-
-<Callout type="info">
-If the user lacks `INSERT` permission, event writes fail silently and the dashboard continues to work normally.
-</Callout>
-
----
-
 ## Related
 
-- [Environment Variables — Query Execution](/reference/environment-variables#query-execution) — `EVENTS_TABLE_NAME` and `CLICKHOUSE_DATABASE`.
-- [Queries History](/operate/advanced/queries-history) — how the dashboard reads `system.query_log` for history pages.
+<Cards>
+  <Card
+    title="Environment Variables — Query Execution"
+    href="/reference/environment-variables#query-execution"
+    description="Reference for EVENTS_TABLE_NAME and CLICKHOUSE_DATABASE."
+  />
+  <Card
+    title="Query History"
+    href="/operate/advanced/queries-history"
+    description="How the dashboard reads system.query_log for history pages."
+  />
+</Cards>

--- a/docs/content/operate/advanced/telemetry.mdx
+++ b/docs/content/operate/advanced/telemetry.mdx
@@ -1,17 +1,19 @@
 ---
 description: Anonymous product telemetry — on by default, opt out anytime, no PII, no third-party trackers.
 icon: Radio
+title: Product Telemetry
 ---
 
-# Product Telemetry
+chmonitor includes an anonymous, privacy-first telemetry system. It is **on by
+default** and you can turn it off at any time — with a single environment
+variable. It collects lightweight, aggregate product analytics (five events,
+three dimensions, no PII) to help the project understand how the dashboard is
+used at a high level.
 
-chmonitor includes an anonymous, privacy-first telemetry system. It is **on by default** and you can turn it off at any time — with a single environment variable. It collects lightweight, aggregate product analytics (five events, three dimensions, no PII) to help the project understand how the dashboard is used at a high level.
+This is separate from [Self-Tracking](/operate/advanced/self-tracking), which
+writes dashboard usage events to your own ClickHouse instance.
 
-This is separate from [Self-Tracking](/operate/advanced/self-tracking), which writes dashboard usage events to your own ClickHouse instance.
-
----
-
-## On by default — how to opt out
+## Opt out — on by default
 
 Telemetry runs unless you explicitly turn it off. Any **one** of these disables it:
 
@@ -22,13 +24,50 @@ Telemetry runs unless you explicitly turn it off. Any **one** of these disables 
 | `DO_NOT_TRACK` | Server runtime — the cross-tool [opt-out standard](https://consoledonottrack.com) | `1` (any truthy value) |
 | `CHM_TELEMETRY_ENDPOINT` | Server runtime — collection endpoint | `""` (empty = hard kill-switch, no network call) |
 
-`DO_NOT_TRACK` is a **hard override**: when set, telemetry is off regardless of `CHM_TELEMETRY`. Leaving everything unset keeps telemetry **on**.
+<Callout type="info">
+`DO_NOT_TRACK` is a **hard override**: when set, telemetry is off regardless of
+`CHM_TELEMETRY`. Leaving everything unset keeps telemetry **on**.
+</Callout>
+
+<Tabs items={['Server-side', 'Do Not Track', 'Client build-time']}>
+<Tab value="Server-side">
+```bash
+CHM_TELEMETRY=off
+```
+
+Applies to Cloudflare Worker, Docker, and Kubernetes deployments. `0`, `false`,
+and `no` are also accepted.
+</Tab>
+<Tab value="Do Not Track">
+```bash
+DO_NOT_TRACK=1
+```
+
+The cross-tool [opt-out standard](https://consoledonottrack.com). A hard
+override — telemetry is off regardless of `CHM_TELEMETRY`.
+</Tab>
+<Tab value="Client build-time">
+```bash
+VITE_TELEMETRY_ENABLED=off
+```
+
+Or, to remove the endpoint entirely:
+
+```bash
+VITE_TELEMETRY_ENDPOINT=""
+```
+
+Inlined at `bun run build` / `vite build`.
+</Tab>
+</Tabs>
 
 ### Collection endpoint
 
-Data is sent to the project's collector at `https://telemetry.chmonitor.dev/v1/ping` by default. Point it elsewhere (e.g. your own [collector](https://github.com/chmonitor/chmonitor/tree/main/apps/telemetry)) by setting `CHM_TELEMETRY_ENDPOINT` (server) or `VITE_TELEMETRY_ENDPOINT` (client build). Setting it to an empty string disables the network call entirely.
-
----
+Data is sent to the project's collector at
+`https://telemetry.chmonitor.dev/v1/ping` by default. Point it elsewhere (e.g.
+your own [collector](https://github.com/chmonitor/chmonitor/tree/main/apps/telemetry))
+by setting `CHM_TELEMETRY_ENDPOINT` (server) or `VITE_TELEMETRY_ENDPOINT`
+(client build). Setting it to an empty string disables the network call entirely.
 
 ## What is collected
 
@@ -50,8 +89,6 @@ Data is sent to the project's collector at `https://telemetry.chmonitor.dev/v1/p
 | `ch_version` | `MAJOR.MINOR` only | `24.8` |
 | `ch_flavor` | `oss`, `altinity`, `cloud`, `unknown` | `oss` |
 
----
-
 ## What is NOT collected
 
 - Query text, SQL statements, or fingerprints
@@ -60,53 +97,37 @@ Data is sent to the project's collector at `https://telemetry.chmonitor.dev/v1/p
 - Table names, database names, or schema information
 - Any free-text or user-generated content
 
-A defensive redaction layer (`redact.ts`) runs before every event is emitted. It drops any prop whose key name implies sensitive content (`host`, `ip`, `url`, `query`, `sql`, `email`, `token`, …) and any string value that matches an email, IPv4/IPv6 address, or URL pattern. When in doubt, it drops.
+A defensive redaction layer (`redact.ts`) runs before every event is emitted. It
+drops any prop whose key name implies sensitive content (`host`, `ip`, `url`,
+`query`, `sql`, `email`, `token`, …) and any string value that matches an email,
+IPv4/IPv6 address, or URL pattern. When in doubt, it drops.
 
-The ClickHouse version is always truncated to `MAJOR.MINOR` (e.g. `24.8`) — never the full four-part string — to avoid matching the IPv4 redaction pattern.
-
----
-
-## How to disable
-
-<Tabs items={['Server-side', 'Do Not Track', 'Client build-time']}>
-<Tab value="Server-side">
-```bash
-CHM_TELEMETRY=off
-```
-
-Applies to Cloudflare Worker, Docker, and Kubernetes deployments. `0`, `false`, and `no` are also accepted.
-</Tab>
-<Tab value="Do Not Track">
-```bash
-DO_NOT_TRACK=1
-```
-
-The cross-tool [opt-out standard](https://consoledonottrack.com). A hard override — telemetry is off regardless of `CHM_TELEMETRY`.
-</Tab>
-<Tab value="Client build-time">
-```bash
-VITE_TELEMETRY_ENABLED=off
-# or, to remove the endpoint entirely:
-VITE_TELEMETRY_ENDPOINT=""
-```
-
-Inlined at `bun run build` / `vite build`.
-</Tab>
-</Tabs>
-
----
+<Callout type="info">
+The ClickHouse version is always truncated to `MAJOR.MINOR` (e.g. `24.8`) — never
+the full four-part string — to avoid matching the IPv4 redaction pattern.
+</Callout>
 
 ## Transport and storage
 
-**Instance ping** (`maybePingInstance`) runs once per day when due, sending a hashed install id + deploy target + ClickHouse `MAJOR.MINOR` to the collection endpoint. It is a hard no-op when telemetry is disabled, when the endpoint is an empty string, or in non-browser contexts (SSR/prerender).
+**Instance ping** (`maybePingInstance`) runs once per day when due, sending a
+hashed install id + deploy target + ClickHouse `MAJOR.MINOR` to the collection
+endpoint. It is a hard no-op when telemetry is disabled, when the endpoint is an
+empty string, or in non-browser contexts (SSR/prerender).
 
-The endpoint is received by the [telemetry collector](https://github.com/chmonitor/chmonitor/tree/main/apps/telemetry) — a public, write-only Cloudflare Worker that records to **Analytics Engine** (and, when D1 is attached, keeps a deduped daily row per install indefinitely). It cannot be read back over HTTP.
+The endpoint is received by the [telemetry collector](https://github.com/chmonitor/chmonitor/tree/main/apps/telemetry)
+— a public, write-only Cloudflare Worker that records to **Analytics Engine**
+(and, when D1 is attached, keeps a deduped daily row per install indefinitely).
+It cannot be read back over HTTP.
 
-> **Retention:** Analytics Engine stores data for **3 months**, then auto-deletes. For permanent retention the collector can also write to D1 (Cloudflare's SQLite), which keeps one deduped row per install per day forever. See the collector README.
+<Callout type="info" title="Retention">
+Analytics Engine stores data for **3 months**, then auto-deletes. For permanent
+retention the collector can also write to D1 (Cloudflare's SQLite), which keeps
+one deduped row per install per day forever. See the collector README.
+</Callout>
 
-**Event tracking** (`track()`) is typed and redacted, then delivered by the event sink to the collector's `/v1/event` endpoint. The sink installs once per app load and is a hard no-op when telemetry is disabled or no endpoint resolves.
-
----
+**Event tracking** (`track()`) is typed and redacted, then delivered by the event
+sink to the collector's `/v1/event` endpoint. The sink installs once per app load
+and is a hard no-op when telemetry is disabled or no endpoint resolves.
 
 ## Activation metric
 
@@ -114,9 +135,10 @@ The project tracks a single derived metric called "activation":
 
 > activation = `cluster_connected` AND (`health_viewed` OR `queries_viewed`)
 
-A session is considered activated when a cluster is connected and the user viewed either the Health or Queries page in that session. This definition lives in `activation.ts` and is the same across the client, any analytics query over the telemetry store, and this documentation.
-
----
+A session is considered activated when a cluster is connected and the user viewed
+either the Health or Queries page in that session. This definition lives in
+`activation.ts` and is the same across the client, any analytics query over the
+telemetry store, and this documentation.
 
 ## Privacy stance
 
@@ -129,9 +151,17 @@ A session is considered activated when a cluster is connected and the user viewe
 - **Hard kill-switch** — setting the endpoint env to an empty string stops all network calls regardless of any other setting.
 </Callout>
 
----
-
 ## Related
 
-- [Self-Tracking](/operate/advanced/self-tracking) — writes dashboard usage events (page visits, query executions) to your own ClickHouse instance. A different system, entirely within your infrastructure.
-- [Environment Variables](/reference/environment-variables) — full reference for all configuration variables.
+<Cards>
+  <Card
+    title="Self-Tracking"
+    href="/operate/advanced/self-tracking"
+    description="Writes dashboard usage events (page visits, query executions) to your own ClickHouse instance. A different system, entirely within your infrastructure."
+  />
+  <Card
+    title="Environment Variables"
+    href="/reference/environment-variables"
+    description="Full reference for all configuration variables."
+  />
+</Cards>

--- a/docs/content/operate/index.mdx
+++ b/docs/content/operate/index.mdx
@@ -3,24 +3,28 @@ title: Deploy & Operate
 description: Ship chmonitor to production, secure it, and tune advanced behaviour.
 ---
 
-# Deploy & Operate
-
 Everything you need to run chmonitor in production — from the first deploy to
 authentication and advanced configuration.
 
-## Deployment
-
-Pick a target and ship: Docker, Kubernetes, Cloudflare Workers, Vercel, or a
-self-hosted Node server. See [Deployment](/operate/deploy) for the full matrix
-and a [production checklist](/operate/deploy/production-checklist).
-
-## Authentication
-
-chmonitor ships open by default and layers in auth when you need it — API keys,
-Clerk, Cloudflare Access, or a trusted reverse proxy. Start at
-[Authentication](/operate/authentication).
-
-## Advanced
-
-Multi-host setups, feature permissions, editions, self-tracking, telemetry, and
-other operational knobs live under [Advanced](/operate/advanced).
+<Cards>
+  <Card
+    title="Deployment"
+    href="/operate/deploy"
+    description="Pick a target and ship: Docker, Kubernetes, Cloudflare Workers, Vercel, or a self-hosted Node server."
+  />
+  <Card
+    title="Production checklist"
+    href="/operate/deploy/production-checklist"
+    description="Verify the essentials before you go live."
+  />
+  <Card
+    title="Authentication"
+    href="/operate/authentication"
+    description="Open by default; layer in API keys, Clerk, Cloudflare Access, or a trusted reverse proxy when you need it."
+  />
+  <Card
+    title="Advanced"
+    href="/operate/advanced"
+    description="Multi-host setups, feature permissions, editions, self-tracking, telemetry, and other operational knobs."
+  />
+</Cards>


### PR DESCRIPTION
## What

Full prose rewrite of the operate section landing and the **Advanced B** pages for one consistent voice and the shared Fumadocs page skeleton, with richer interactive components. **Every technical fact is preserved verbatim** (env vars, defaults, grants, routes, endpoints).

Pages rewritten (5):
- `operate/index.mdx` — section landing: intro + `<Cards>` grid (deploy, production checklist, authentication, advanced)
- `operate/advanced/self-tracking.mdx`
- `operate/advanced/telemetry.mdx`
- `operate/advanced/peerdb-monitoring.mdx`
- `operate/advanced/queries-history.mdx`

## How

- Advanced pages follow the skeleton: lead → concept → `## Configure` (`<Steps>`, env vars as tables) → `<Callout>` gotchas → `## Related` (`<Cards>`).
- Bodies start at `##` (h1 stripped), sentence-case headings, every `<Card>` has a description, Callout types limited to info/warn/danger.
- Added explicit `title:` frontmatter and moved fenced `# ` bash comments into prose. The `sync-docs.mjs` `extractTitle` step strips the first `^# ` body line, which was silently dropping fact-bearing bash comments (e.g. the PeerDB UI `/api` suffix note, the telemetry endpoint-removal note, the `EVENTS_TABLE_NAME` default note) — now preserved.

## Verify

```
cd apps/docs && bun run sync && bunx fumadocs-mdx   # both exit 0
```

Co-Authored-By: duyetbot <bot@duyet.net>