### PR TITLE
docs(reference): rewrite releases + v0.3 migration

### DIFF
--- a/docs/content/reference/migrating/v0-3.mdx
+++ b/docs/content/reference/migrating/v0-3.mdx
@@ -1,13 +1,10 @@
 ---
+title: Migrate to v0.3
 description: Upgrade chmonitor from v0.2 (Next.js) to v0.3 (TanStack Start) — platform steps and the VITE_* variable rename.
 icon: ArrowRightLeft
 ---
 
-# Migrate to v0.3
-
-v0.3 introduces a migration update. The dashboard is rebuilt on TanStack Start. Features, routes, and ClickHouse setup are unchanged. Browser-exposed environment variables are now standardized on the `VITE_*` prefix, with `NEXT_PUBLIC_*` kept as a compatibility fallback.
-
----
+v0.3 rebuilds the dashboard on TanStack Start. Features, routes, and ClickHouse setup are unchanged. Browser-exposed environment variables now standardize on the `VITE_*` prefix, with `NEXT_PUBLIC_*` kept as a compatibility fallback. For most deployments, the upgrade is a redeploy plus an optional rename.
 
 ## What changed
 
@@ -23,13 +20,13 @@ Variables exposed to the browser now use the `VITE_` prefix. Server-side and sec
 | `NEXT_PUBLIC_AUTOCOMPLETE_LIMIT` | `VITE_AUTOCOMPLETE_LIMIT` |
 | `NEXT_PUBLIC_RUNNING_QUERIES_REFRESH_MS` | `VITE_RUNNING_QUERIES_REFRESH_MS` |
 
-> The old `NEXT_PUBLIC_*` names still work as a fallback. The rename is recommended but not required — nothing breaks if you skip it.
+<Callout type="info" title="The rename is optional">
+The old `NEXT_PUBLIC_*` names still work as a fallback. The rename is recommended but not required — nothing breaks if you skip it.
+</Callout>
 
 <Callout type="warn" title="Browser variables are build-time only">
 Browser variables must be set **at build time** (in your CI build step or build config), not only as runtime environment variables.
 </Callout>
-
----
 
 ## Upgrade steps by platform
 
@@ -242,8 +239,6 @@ Verify Overview loads with live data.
 </Tab>
 </Tabs>
 
----
-
 ## Automate it with an AI assistant
 
 Don't want to hand-edit env files? Paste your current configuration (`.env`,
@@ -281,21 +276,37 @@ plus a short list of what you changed:
 6. Flag anything that has no v0.3 equivalent instead of silently dropping it.
 ```
 
-> This same prompt is published in the v0.3 GitHub release notes, kept in sync
-> from `.github/release-migration-prompt.md`.
-
----
+<Callout type="info" title="Kept in sync with the release notes">
+This same prompt is published in the v0.3 GitHub release notes, kept in sync
+from `.github/release-migration-prompt.md`.
+</Callout>
 
 ## Verify
 
 After upgrading on any platform:
 
-1. Open the dashboard — Overview should render charts with live data.
-2. If authentication is enabled, sign in and confirm data loads.
-3. If the AI agent is configured, open `/agents` and send a message.
-4. Check `/about` — the build timestamp and version should reflect the new release.
+<Steps>
+<Step>
+### Load the dashboard
 
----
+Open the dashboard — Overview should render charts with live data.
+</Step>
+<Step>
+### Confirm authentication
+
+If authentication is enabled, sign in and confirm data loads.
+</Step>
+<Step>
+### Test the AI agent
+
+If the AI agent is configured, open `/agents` and send a message.
+</Step>
+<Step>
+### Check the build
+
+Check `/about` — the build timestamp and version should reflect the new release.
+</Step>
+</Steps>
 
 ## New variables in v0.3
 
@@ -312,6 +323,26 @@ v0.3 adds optional new configuration. None is required for the upgrade — set t
 
 See [Environment Variables](/reference/environment-variables) for the full list.
 
----
+<Callout type="info" title="ClickHouse setup carries over">
+ClickHouse hosts, credentials, and feature permissions carry over unchanged. No ClickHouse schema changes are required.
+</Callout>
 
-_ClickHouse hosts, credentials, and feature permissions carry over unchanged. No ClickHouse schema changes are required._
+## Related
+
+<Cards>
+  <Card
+    title="v0.3 — What's New"
+    href="/reference/releases/v0-3"
+    description="The full list of features and changes in this release."
+  />
+  <Card
+    title="Environment variables"
+    href="/reference/environment-variables"
+    description="Every configuration option, including new v0.3 vars."
+  />
+  <Card
+    title="Authentication"
+    href="/operate/authentication"
+    description="Set up the new pluggable auth providers."
+  />
+</Cards>

--- a/docs/content/reference/releases.mdx
+++ b/docs/content/reference/releases.mdx
@@ -4,9 +4,7 @@ description: Version history and release notes for chmonitor — what shipped in
 icon: Tag
 ---
 
-# Releases
-
-chmonitor follows a single rolling documentation set that tracks the latest version. Each release note summarizes what shipped; the migration guides cover the steps to move between versions.
+chmonitor ships a single rolling documentation set that tracks the latest version. Each release note tells you what shipped; the migration guides walk you through moving between versions.
 
 <Callout type="info" title="Current version: v0.3">
 You are reading the docs for **v0.3**. The version badge in the top navigation links back here.
@@ -29,6 +27,30 @@ You are reading the docs for **v0.3**. The version badge in the top navigation l
 
 ## Release cadence
 
-- **Stable images** are published to `chmonitor/chmonitor:latest` on every push to `main`.
-- **Tagged releases** (`vX.Y.Z`) are cut periodically and mirrored to the Helm chart and Docker tags.
-- Follow [GitHub Releases](https://github.com/chmonitor/chmonitor/releases) for the full per-tag changelog.
+Three channels track chmonitor at different speeds — pick the one that matches how fast you want changes.
+
+| Channel | What it is | Where to find it |
+|---|---|---|
+| Stable images | Published to `chmonitor/chmonitor:latest` on every push to `main` | Docker registry |
+| Tagged releases | `vX.Y.Z` cut periodically, mirrored to the Helm chart and Docker tags | Docker tags + Helm |
+| Full changelog | The complete per-tag history | [GitHub Releases](https://github.com/chmonitor/chmonitor/releases) |
+
+## Related
+
+<Cards>
+  <Card
+    title="v0.3 — What's New"
+    href="/reference/releases/v0-3"
+    description="Full feature list for the current release."
+  />
+  <Card
+    title="Migrate to v0.3"
+    href="/reference/migrating/v0-3"
+    description="Step-by-step upgrade guide from v0.2."
+  />
+  <Card
+    title="Environment variables"
+    href="/reference/environment-variables"
+    description="Every configuration option, including new v0.3 vars."
+  />
+</Cards>

--- a/docs/content/reference/releases/v0-3.mdx
+++ b/docs/content/reference/releases/v0-3.mdx
@@ -1,17 +1,18 @@
 ---
+title: v0.3 — What's New
 description: What's new in chmonitor v0.3 — TanStack Start framework, pluggable auth, MCP server, AI agent improvements, and new monitoring views.
 icon: Tag
 ---
 
-# v0.3 — What's New
+v0.3 rebuilds the dashboard on TanStack Start, ships a pluggable authentication system, and delivers the monitoring and UI improvements accumulated during the v0.2 cycle.
 
-v0.3 rebuilds the dashboard on TanStack Start, ships a pluggable authentication system, and delivers monitoring and UI improvements accumulated during the v0.2 cycle.
-
----
+<Callout type="warn" title="Upgrading from v0.2?">
+For most self-hosters, the only required action is a redeploy. The `NEXT_PUBLIC_*` → `VITE_*` rename is optional — old names still work. See [Migrate to v0.3](/reference/migrating/v0-3) for the full walkthrough.
+</Callout>
 
 ## TanStack Start (new framework)
 
-The dashboard is rewritten on [TanStack Start](https://tanstack.com/start) with Vite. Every page is pre-rendered at build time so the initial shell loads from cache before ClickHouse is contacted. The legacy Next.js app is removed.
+The dashboard is rewritten on [TanStack Start](https://tanstack.com/start) with Vite. Every page is pre-rendered at build time, so the initial shell loads from cache before ClickHouse is contacted. The legacy Next.js app is removed.
 
 - Static prerender for all 75+ dashboard pages ([#1392](https://github.com/chmonitor/chmonitor/issues/1392)).
 - TanStack Query replaces SWR for client-side data fetching ([#1562](https://github.com/chmonitor/chmonitor/issues/1562)).
@@ -24,8 +25,6 @@ The dashboard is rewritten on [TanStack Start](https://tanstack.com/start) with 
 - Collapsed chart rows unmounted to stop background polling ([#1580](https://github.com/chmonitor/chmonitor/issues/1580)).
 
 See [Migrate to v0.3](/reference/migrating/v0-3) for upgrade steps.
-
----
 
 ## Pluggable authentication
 
@@ -41,12 +40,10 @@ Additional auth features:
 
 - Read/write permission model + `CHM_CLERK_PUBLIC_READ` for public read access ([#1535](https://github.com/chmonitor/chmonitor/issues/1535), [#1536](https://github.com/chmonitor/chmonitor/issues/1536)).
 - Always-on API key layer (`CHM_API_KEY_SECRET`) issues signed `chm_` Bearer tokens for scripts and MCP clients, independent of the active provider.
-- `auth=none` opens everything; backend still enforces per-endpoint ([#1533](https://github.com/chmonitor/chmonitor/issues/1533)).
+- `auth=none` opens everything; the backend still enforces per-endpoint ([#1533](https://github.com/chmonitor/chmonitor/issues/1533)).
 - Auth on `/api/v1/clean`, `/api/v1/init`, `/api/v1/pageview` endpoints ([#1602](https://github.com/chmonitor/chmonitor/issues/1602)).
 
 See [Authentication](/operate/authentication) for setup details.
-
----
 
 ## Cluster topology visualization
 
@@ -56,8 +53,6 @@ The `/cluster` page now shows a live topology diagram.
 - Physical cluster groupings shown with labeled hull overlays.
 - Nodes sized and colored by live metrics.
 - Nodes can be toggled on/off; the diagram adjusts height to the data.
-
----
 
 ## AI agent
 
@@ -71,15 +66,11 @@ The built-in AI agent runs on the [Vercel AI SDK](https://sdk.vercel.ai/) `ToolL
 - Multi-provider LLM config (`LLM_API_KEY`, `LLM_API_BASE`, `LLM_MODEL`) plus a redesigned chat UI with model selector.
 - Hover-prefetch and lazy provider init for lower interaction latency ([#1544](https://github.com/chmonitor/chmonitor/issues/1544)).
 
----
-
 ## MCP server
 
 - MCP endpoint at `/api/mcp` — Streamable HTTP, stateless, no separate worker required.
 - Clerk OAuth login/consent flow for MCP clients — authenticate with a browser OAuth flow instead of a `chm_` key.
 - In-process MCP route in the TanStack app.
-
----
 
 ## Query page improvements
 
@@ -89,8 +80,6 @@ The built-in AI agent runs on the [Vercel AI SDK](https://sdk.vercel.ai/) `ToolL
 - **Request Info dialog** redesigned with formatted SQL and metadata badges.
 - Menu counts batched into a single query per page load ([#1591](https://github.com/chmonitor/chmonitor/issues/1591)).
 
----
-
 ## Table/card layout for all data pages
 
 Every data table now has a card grid view alongside the standard table view. Toggle between them per page; cards default on narrow screens.
@@ -99,23 +88,21 @@ Every data table now has a card grid view alongside the standard table view. Tog
 - Rich expandable rows for SQL, metadata, and related actions inline.
 - Mobile layout uses SQL-hero cards.
 
----
-
 ## New monitoring views
 
 Added from ClickHouse system tables:
 
-- **Kafka consumers** — `system.kafka_consumers` at `/kafka-consumers`.
-- **Part log** — `system.part_log` redesigned with lifecycle charts, KPIs, and a filterable events table.
-- **Query metric log** — `system.query_metric_log` at `/query-metric-log`.
-- **User processes** — `system.user_processes` with formatted badges and memory bars.
-- **Moves** — `system.moves` at `/moves`.
-- **Dropped tables** — `system.dropped_tables` at `/dropped-tables`.
-- **Warnings** — `system.warnings` at `/warnings`.
-- **Replicated fetches** — `system.replicated_fetches` at `/replicated-fetches`.
-- **Replicated MergeTree settings** — at `/replicated-merge-tree-settings`.
-
----
+| View | System table | Route |
+|---|---|---|
+| Kafka consumers | `system.kafka_consumers` | `/kafka-consumers` |
+| Part log | `system.part_log` | redesigned with lifecycle charts, KPIs, and a filterable events table |
+| Query metric log | `system.query_metric_log` | `/query-metric-log` |
+| User processes | `system.user_processes` | formatted badges and memory bars |
+| Moves | `system.moves` | `/moves` |
+| Dropped tables | `system.dropped_tables` | `/dropped-tables` |
+| Warnings | `system.warnings` | `/warnings` |
+| Replicated fetches | `system.replicated_fetches` | `/replicated-fetches` |
+| Replicated MergeTree settings | — | `/replicated-merge-tree-settings` |
 
 ## Deployment
 
@@ -125,8 +112,30 @@ Added from ClickHouse system tables:
 - **Auto-refresh interval** persisted to localStorage across reloads.
 - **Time range** persisted to localStorage and synced to the URL.
 
----
-
 ## Breaking changes
 
-See [Migrate to v0.3](/reference/migrating/v0-3) for upgrade steps. The only required action for most self-hosters is a redeploy. The `NEXT_PUBLIC_*` → `VITE_*` rename is optional — old names still work.
+<Callout type="warn" title="NEXT_PUBLIC_* → VITE_* rename (optional)">
+The `NEXT_PUBLIC_*` → `VITE_*` rename is optional — old names still work as a fallback. The only required action for most self-hosters is a redeploy.
+</Callout>
+
+See [Migrate to v0.3](/reference/migrating/v0-3) for upgrade steps.
+
+## Related
+
+<Cards>
+  <Card
+    title="Migrate to v0.3"
+    href="/reference/migrating/v0-3"
+    description="Step-by-step upgrade guide, including the VITE_* rename."
+  />
+  <Card
+    title="Authentication"
+    href="/operate/authentication"
+    description="Set up the new pluggable auth providers."
+  />
+  <Card
+    title="Environment variables"
+    href="/reference/environment-variables"
+    description="Every configuration option, including new v0.3 vars."
+  />
+</Cards>


### PR DESCRIPTION
## Summary

Consistent-voice rewrite of the three release/migration docs, part of the docs-wide consistency pass. Unifies voice and page skeleton while preserving every technical fact verbatim.

- **`reference/releases.mdx`** — lead → versions cards → release-cadence table (was a bullet list) → `## Related`.
- **`reference/releases/v0-3.mdx`** — grouped changes with an upgrade `<Callout type="warn">` up top and a breaking-changes callout; new-monitoring-views bullet list converted to a table; `## Related`.
- **`reference/migrating/v0-3.mdx`** — same `<Steps>`/`<Tabs>` walkthrough, verify checklist converted to `<Steps>`, gotchas moved into `<Callout>`s, `## Related`.

## Facts preserved (verified against `main`)

- All 17 GitHub issue links identical.
- All `system.*` table names identical.
- All env var names (`NEXT_PUBLIC_*` / `VITE_*` / `CHM_*` / `CLICKHOUSE_*` / `CLERK_*` / `LLM_*` / `HEALTH_*` / `CONVERSATION_*`) identical.
- All routes identical across the three pages.
- The AI-assistant migration prompt is kept byte-for-byte.

## Validation

Ran the parallel-safe docs recipe (`bun run sync` + `bunx fumadocs-mdx`) — both exit 0; the three pages regenerate under `apps/docs/content/docs/**`.

Co-Authored-By: duyetbot <bot@duyet.net>