### PR TITLE
fix(billing): resolve BE-2..BE-6 edge cases from epic #2097

### DIFF
--- a/apps/dashboard/src/components/assistant-ui/-thread/session-stats.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/session-stats.tsx
@@ -97,7 +97,8 @@ function useSessionTotals(): SessionTotals {
     // Tool-call count (same predicate as the per-message footer).
     totals.toolCount +=
       (content as { type?: string }[]).filter(
-        (p) => p?.type === 'tool-call' || (p?.type?.startsWith('tool-') ?? false)
+        (p) =>
+          p?.type === 'tool-call' || (p?.type?.startsWith('tool-') ?? false)
       ).length ?? 0
 
     if (messageTokens > 0) totals.messageCount += 1

--- a/apps/dashboard/src/db/conversations-migrations/0008_subscription_cancel_and_event_guard.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0008_subscription_cancel_and_event_guard.sql
@@ -1,0 +1,16 @@
+-- Persist cancel-at-period-end state and add a monotonic write guard to
+-- user_subscriptions.
+--
+-- cancel_at_period_end: previously hard-coded to false on the D1 fast path
+-- (resolveOwnerSubscription only set it correctly on the Polar-pull path),
+-- so a cancelled-but-still-in-grace-period subscription read from cache never
+-- showed the "cancels on <date>" state. 0/1 (SQLite has no native boolean).
+--
+-- event_timestamp: Polar webhook deliveries can arrive out of order (retries,
+-- at-least-once delivery). Without an ordering guard, a late/replayed older
+-- event can overwrite newer state (e.g. a stale "canceled" landing after a
+-- fresher "active" from an uncancel). Unix seconds from the webhook envelope's
+-- `timestamp`; NULL for existing rows (treated as "always older" so the next
+-- webhook write always wins and backfills it).
+ALTER TABLE user_subscriptions ADD COLUMN cancel_at_period_end INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE user_subscriptions ADD COLUMN event_timestamp INTEGER;

--- a/apps/dashboard/src/lib/billing/org-host-count.test.ts
+++ b/apps/dashboard/src/lib/billing/org-host-count.test.ts
@@ -27,12 +27,13 @@ function fakeStore(counts: Record<string, number>): ConnectionStore {
 describe('countOwnerHosts', () => {
   test('user owner counts only the acting user', async () => {
     const store = fakeStore({ user_a: 2, user_b: 5 })
-    const n = await countOwnerHosts(
+    const usage = await countOwnerHosts(
       { type: 'user', id: 'user_a' },
       store,
       'user_a'
     )
-    expect(n).toBe(2)
+    expect(usage.count).toBe(2)
+    expect(usage.memberUserIds).toEqual(['user_a'])
   })
 
   test('org owner pools connections across all current members', async () => {
@@ -44,12 +45,13 @@ describe('countOwnerHosts', () => {
     }))
     const store = fakeStore({ user_a: 2, user_b: 3, user_c: 9 })
     // owner is the org; acting user is a member. Pool = a(2) + b(3) = 5.
-    const n = await countOwnerHosts(
+    const usage = await countOwnerHosts(
       { type: 'org', id: 'org_1' },
       store,
       'user_a'
     )
-    expect(n).toBe(5)
+    expect(usage.count).toBe(5)
+    expect(usage.memberUserIds).toEqual(['user_a', 'user_b'])
   })
 
   test('acting user is counted even if not yet in the membership list', async () => {
@@ -57,12 +59,13 @@ describe('countOwnerHosts', () => {
       data: [{ publicUserData: { userId: 'user_b' } }],
     }))
     const store = fakeStore({ user_a: 4, user_b: 1 })
-    const n = await countOwnerHosts(
+    const usage = await countOwnerHosts(
       { type: 'org', id: 'org_1' },
       store,
       'user_a'
     )
-    expect(n).toBe(5) // b(1) + a(4), a appended
+    expect(usage.count).toBe(5) // b(1) + a(4), a appended
+    expect(usage.memberUserIds).toEqual(['user_b', 'user_a'])
   })
 
   test('org enumeration failure falls back to the acting user count', async () => {
@@ -70,11 +73,12 @@ describe('countOwnerHosts', () => {
       throw new Error('clerk down')
     })
     const store = fakeStore({ user_a: 3 })
-    const n = await countOwnerHosts(
+    const usage = await countOwnerHosts(
       { type: 'org', id: 'org_1' },
       store,
       'user_a'
     )
-    expect(n).toBe(3)
+    expect(usage.count).toBe(3)
+    expect(usage.memberUserIds).toEqual(['user_a'])
   })
 })

--- a/apps/dashboard/src/lib/billing/org-host-count.ts
+++ b/apps/dashboard/src/lib/billing/org-host-count.ts
@@ -1,6 +1,20 @@
 import type { ConnectionStore } from '@/lib/connection-store/types'
 import type { BillingOwner } from './billing-owner'
 
+/** Pooled host usage for a billing owner: the count plus the member id set it was computed from. */
+export interface OwnerHostUsage {
+  /** Hosts counted so far — the value fed to `checkHostLimit`. */
+  count: number
+  /**
+   * The user_ids whose connections were counted. `[actingUserId]` for a user
+   * owner, or the pooled Clerk org member id list (including the acting user)
+   * for an org owner. Callers pass this through to `store.create()`'s atomic
+   * limit enforcement so the insert-time recount uses the SAME member set the
+   * pre-check used.
+   */
+  memberUserIds: string[]
+}
+
 /**
  * Count the hosts (saved per-user connections) that consume a billing owner's
  * host limit — the value fed to `checkHostLimit`.
@@ -21,9 +35,10 @@ export async function countOwnerHosts(
   owner: BillingOwner,
   store: ConnectionStore,
   actingUserId: string
-): Promise<number> {
+): Promise<OwnerHostUsage> {
   if (owner.type !== 'org') {
-    return (await store.list(actingUserId)).length
+    const count = (await store.list(actingUserId)).length
+    return { count, memberUserIds: [actingUserId] }
   }
 
   try {
@@ -45,9 +60,13 @@ export async function countOwnerHosts(
         store.list(id).then((connections) => connections.length)
       )
     )
-    return counts.reduce((sum, n) => sum + n, 0)
+    return {
+      count: counts.reduce((sum, n) => sum + n, 0),
+      memberUserIds: memberIds,
+    }
   } catch {
     // Permissive fallback — never block a paying org on an enumeration failure.
-    return (await store.list(actingUserId)).length
+    const count = (await store.list(actingUserId)).length
+    return { count, memberUserIds: [actingUserId] }
   }
 }

--- a/apps/dashboard/src/lib/billing/polar-subscription.test.ts
+++ b/apps/dashboard/src/lib/billing/polar-subscription.test.ts
@@ -11,17 +11,34 @@ let getStateExternal = mock(async (_args: { externalId: string }) => ({
   }>,
 }))
 
+// Mocks the FULL real export surface of polar-config.ts (not just what this
+// file needs): bun's mock.module() registers per resolved module specifier,
+// and routes/api/v1/webhooks/polar.test.ts also mocks this same module (via
+// the `@/` alias, which resolves to the same file) with a different export
+// subset. Both files can run in one `bun test` process, so an incomplete mock
+// here risks "export not found" if the OTHER file's factory wins the
+// registration race. A superset covering every real export — including
+// `customers.update`, needed by the webhook test — is resilient regardless of
+// load order.
 mock.module('./polar-config', () => ({
+  PAID_PLAN_IDS: ['pro', 'max'] as const,
+  getPolarServer: () => 'sandbox' as const,
   isBillingConfigured: () => true,
-  getPolarClient: () => ({ customers: { getStateExternal } }),
+  getPolarClient: () => ({
+    customers: { getStateExternal, update: async () => ({}) },
+  }),
+  getWebhookSecret: () => 'whsec_test',
+  productIdFor: () => null,
   planForProductId: (productId: string) =>
     productId === 'prod_pro'
       ? { planId: 'pro', period: 'monthly' as const }
       : null,
+  isPaidPlanId: (value: string) => value === 'pro' || value === 'max',
 }))
 
 const {
   pullOwnerSubscriptionFromPolar,
+  invalidateNegativeCache,
   __resetPolarSubscriptionCacheForTests,
 } = await import('./polar-subscription')
 
@@ -76,5 +93,41 @@ describe('pullOwnerSubscriptionFromPolar negative cache', () => {
     expect(second?.planId).toBe('pro')
     // A positive result must never short-circuit a later read (no false "free").
     expect(getStateExternal).toHaveBeenCalledTimes(2)
+  })
+
+  test('invalidateNegativeCache clears a cached negative — the next read reaches Polar', async () => {
+    getStateExternal = mock(async () => {
+      throw Object.assign(new Error('not found'), { statusCode: 404 })
+    })
+
+    // Cache the negative result (simulates a free-user entitlement check).
+    const first = await pullOwnerSubscriptionFromPolar('user_justpaid')
+    expect(first).toBeNull()
+    expect(getStateExternal).toHaveBeenCalledTimes(1)
+
+    // Still within the TTL, an uninvalidated read would be served from cache.
+    const stillCached = await pullOwnerSubscriptionFromPolar('user_justpaid')
+    expect(stillCached).toBeNull()
+    expect(getStateExternal).toHaveBeenCalledTimes(1)
+
+    // Webhook fires (subscription became active) and invalidates the entry.
+    invalidateNegativeCache('user_justpaid')
+
+    // Polar now reports an active subscription — the next read must reach it.
+    getStateExternal = mock(async () => ({
+      activeSubscriptions: [
+        {
+          productId: 'prod_pro',
+          status: 'active',
+          currentPeriodEnd: '2026-12-31T00:00:00Z',
+          cancelAtPeriodEnd: false,
+        },
+      ],
+    }))
+
+    const afterInvalidate =
+      await pullOwnerSubscriptionFromPolar('user_justpaid')
+    expect(afterInvalidate?.planId).toBe('pro')
+    expect(getStateExternal).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/dashboard/src/lib/billing/polar-subscription.ts
+++ b/apps/dashboard/src/lib/billing/polar-subscription.ts
@@ -105,6 +105,21 @@ export function __resetPolarSubscriptionCacheForTests(): void {
 }
 
 /**
+ * Invalidate a negative-cache entry for an externalId, if one exists.
+ *
+ * Why: the webhook path (subscription.created/updated/active/...) writes the
+ * D1 cache directly and never calls pullOwnerSubscriptionFromPolar, so a
+ * negative entry recorded moments earlier (e.g. an entitlement check that ran
+ * just before checkout completed) would otherwise survive until its TTL and
+ * shadow the fresh D1 row whenever resolveOwnerSubscription's D1 read misses
+ * or races the write — gating a just-paid user as free for up to a minute.
+ * Call this from the webhook whenever a subscription becomes live/paid.
+ */
+export function invalidateNegativeCache(externalId: string): void {
+  noActiveSubUntil.delete(externalId)
+}
+
+/**
  * The owner's current paid subscription per Polar, or null when they have none
  * (free), Polar is not configured, or the call fails (caller falls back to the
  * D1 cache / free). When several active subscriptions exist, the highest plan

--- a/apps/dashboard/src/lib/billing/subscription-store.test.ts
+++ b/apps/dashboard/src/lib/billing/subscription-store.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for subscription-store.ts's monotonic write guard and
+ * cancel_at_period_end persistence (epic #2097 BE-4).
+ *
+ * Uses a small behavioral fake of D1Database (prepare/bind/run/first) injected
+ * through a mocked @chm/platform, so we exercise the REAL guarded SQL rather
+ * than re-implementing it in JS — mirrors the pattern in
+ * connection-store/__tests__/d1-store-limit.test.ts. The fake evaluates the
+ * upsert's ON CONFLICT ... WHERE guard the way SQLite/D1 actually would: the
+ * UPDATE only applies when the incoming event_timestamp is null, the stored
+ * one is null, or the incoming one is >= the stored one.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+interface FakeSubscriptionRow {
+  user_id: string
+  owner_type: string
+  plan_id: string
+  billing_period: string | null
+  status: string
+  polar_subscription_id: string | null
+  polar_customer_id: string | null
+  current_period_end: number | null
+  cancel_at_period_end: number
+  event_timestamp: number | null
+  created_at: number
+  updated_at: number
+}
+
+function makeFakeD1() {
+  const rowsByOwner = new Map<string, FakeSubscriptionRow>()
+
+  function prepare(sql: string) {
+    return {
+      bind(...binds: unknown[]) {
+        return {
+          async first() {
+            const ownerId = binds[0] as string
+            return rowsByOwner.get(ownerId) ?? null
+          },
+          async run() {
+            const isUpsert = /INSERT INTO user_subscriptions/.test(sql)
+            if (!isUpsert) throw new Error(`Unexpected statement: ${sql}`)
+
+            const [
+              userId,
+              ownerType,
+              planId,
+              billingPeriod,
+              status,
+              polarSubscriptionId,
+              polarCustomerId,
+              currentPeriodEnd,
+              cancelAtPeriodEnd,
+              eventTimestamp,
+              now,
+            ] = binds as [
+              string,
+              string,
+              string,
+              string | null,
+              string,
+              string | null,
+              string | null,
+              number | null,
+              number,
+              number | null,
+              number,
+            ]
+
+            const existing = rowsByOwner.get(userId)
+            if (
+              existing &&
+              existing.event_timestamp !== null &&
+              eventTimestamp !== null &&
+              eventTimestamp < existing.event_timestamp
+            ) {
+              // Guard rejects: an older event must not overwrite newer state.
+              return { success: true, meta: { changes: 0 } }
+            }
+
+            rowsByOwner.set(userId, {
+              user_id: userId,
+              owner_type: ownerType,
+              plan_id: planId,
+              billing_period: billingPeriod,
+              status,
+              polar_subscription_id: polarSubscriptionId,
+              polar_customer_id: polarCustomerId,
+              current_period_end: currentPeriodEnd,
+              cancel_at_period_end: cancelAtPeriodEnd,
+              event_timestamp: eventTimestamp,
+              created_at: existing?.created_at ?? now,
+              updated_at: now,
+            })
+            return { success: true, meta: { changes: 1 } }
+          },
+        }
+      },
+    }
+  }
+
+  return { prepare, _rows: rowsByOwner }
+}
+
+let currentDb: ReturnType<typeof makeFakeD1> | null = null
+
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({
+    getD1Database: () => currentDb,
+  }),
+}))
+
+const { getSubscription, upsertSubscription } = await import(
+  './subscription-store'
+)
+
+beforeEach(() => {
+  currentDb = makeFakeD1()
+})
+
+const baseInput = {
+  userId: 'org_1',
+  ownerType: 'org' as const,
+  planId: 'pro' as const,
+  billingPeriod: 'monthly' as const,
+  status: 'active',
+  polarSubscriptionId: 'sub_1',
+  polarCustomerId: 'cus_1',
+  currentPeriodEnd: 1_800_000_000,
+}
+
+describe('subscription-store — cancel_at_period_end persistence', () => {
+  test('persists cancelAtPeriodEnd:true and reads it back', async () => {
+    await upsertSubscription({ ...baseInput, cancelAtPeriodEnd: true })
+    const sub = await getSubscription('org_1')
+    expect(sub?.cancelAtPeriodEnd).toBe(true)
+  })
+
+  test('defaults to false when omitted', async () => {
+    await upsertSubscription(baseInput)
+    const sub = await getSubscription('org_1')
+    expect(sub?.cancelAtPeriodEnd).toBe(false)
+  })
+})
+
+describe('subscription-store — monotonic write guard', () => {
+  test('a newer eventTimestamp overwrites older state', async () => {
+    await upsertSubscription({
+      ...baseInput,
+      status: 'active',
+      eventTimestamp: 1000,
+    })
+    await upsertSubscription({
+      ...baseInput,
+      status: 'canceled',
+      eventTimestamp: 2000,
+    })
+
+    const sub = await getSubscription('org_1')
+    expect(sub?.status).toBe('canceled')
+  })
+
+  test('an older/stale eventTimestamp is rejected — newer state is not overwritten', async () => {
+    await upsertSubscription({
+      ...baseInput,
+      status: 'active',
+      eventTimestamp: 2000,
+    })
+    // A late-arriving retry/replay of an OLDER event must not stomp the
+    // fresher "active" state written above.
+    await upsertSubscription({
+      ...baseInput,
+      status: 'canceled',
+      eventTimestamp: 1000,
+    })
+
+    const sub = await getSubscription('org_1')
+    expect(sub?.status).toBe('active')
+  })
+
+  test('an equal eventTimestamp is accepted (idempotent replay of the same event)', async () => {
+    await upsertSubscription({
+      ...baseInput,
+      status: 'active',
+      eventTimestamp: 1000,
+    })
+    await upsertSubscription({
+      ...baseInput,
+      status: 'past_due',
+      eventTimestamp: 1000,
+    })
+
+    const sub = await getSubscription('org_1')
+    expect(sub?.status).toBe('past_due')
+  })
+
+  test('a write without eventTimestamp always wins (e.g. the Polar-truth write-through cache)', async () => {
+    await upsertSubscription({
+      ...baseInput,
+      status: 'active',
+      eventTimestamp: 5000,
+    })
+    // A caller with no event ordering (reads Polar's CURRENT state) must not
+    // be blocked by a webhook-sourced timestamp already on the row.
+    await upsertSubscription({
+      ...baseInput,
+      status: 'canceled',
+    })
+
+    const sub = await getSubscription('org_1')
+    expect(sub?.status).toBe('canceled')
+  })
+
+  test('the first write ever (no existing row) always applies regardless of eventTimestamp', async () => {
+    await upsertSubscription({
+      ...baseInput,
+      status: 'active',
+      eventTimestamp: 1000,
+    })
+    const sub = await getSubscription('org_1')
+    expect(sub?.status).toBe('active')
+  })
+})

--- a/apps/dashboard/src/lib/billing/subscription-store.ts
+++ b/apps/dashboard/src/lib/billing/subscription-store.ts
@@ -4,12 +4,23 @@
  * The primary key column is named `user_id` for backward compatibility but now
  * holds the BILLING-OWNER id, which is either a Clerk user id (user_*) or a
  * Clerk org id (org_*). The `owner_type` column ('user'|'org') records which
- * kind, added by migration 0004_subscription_owner.sql.
+ * kind, added by migration 0004_subscription_owner.sql. `cancel_at_period_end`
+ * and `event_timestamp` were added by migration
+ * 0008_subscription_cancel_and_event_guard.sql.
  *
  * Reads degrade gracefully: when the CHM_CLOUD_D1 binding is absent (local dev,
  * self-host) or there is no row, `getSubscription()` returns null and the caller
  * falls back to the free plan. Writes require D1 and are only exercised by the
  * Polar webhook (cloud runtime), so they throw if the binding is missing.
+ *
+ * Monotonic write guard: `upsertSubscription` takes an optional
+ * `eventTimestamp` (unix seconds from the Polar webhook envelope). Webhook
+ * deliveries are at-least-once and can arrive out of order (retries, replays);
+ * without a guard a late/older event can stomp newer state written by a
+ * fresher one. The upsert only applies when the incoming `eventTimestamp` is
+ * `>=` the stored value (or either side is null/unset — first write, or a
+ * caller that doesn't carry an event timestamp, e.g. the Polar-truth
+ * write-through cache path, always wins so it never gets silently ignored).
  */
 
 import type { PlanId } from './plans'
@@ -31,6 +42,8 @@ export interface UserSubscription {
   polarCustomerId: string | null
   /** Unix seconds; access valid until then. null for free. */
   currentPeriodEnd: number | null
+  /** True when the owner cancelled but is still inside the paid period. */
+  cancelAtPeriodEnd: boolean
   createdAt: number
   updatedAt: number
 }
@@ -46,6 +59,16 @@ export interface UpsertSubscriptionInput {
   polarSubscriptionId?: string | null
   polarCustomerId?: string | null
   currentPeriodEnd?: number | null
+  /** Default false. */
+  cancelAtPeriodEnd?: boolean
+  /**
+   * Unix seconds from the source event (e.g. the Polar webhook envelope's
+   * `timestamp`). When set, the write is rejected if a later event has
+   * already been applied — see the monotonic write guard note above. Leave
+   * unset for callers without an event ordering (e.g. the Polar-truth
+   * write-through cache), which always win.
+   */
+  eventTimestamp?: number | null
 }
 
 interface D1SubscriptionRow {
@@ -57,6 +80,7 @@ interface D1SubscriptionRow {
   polar_subscription_id: string | null
   polar_customer_id: string | null
   current_period_end: number | null
+  cancel_at_period_end: number | null
   created_at: number
   updated_at: number
 }
@@ -71,6 +95,7 @@ function rowToSubscription(row: D1SubscriptionRow): UserSubscription {
     polarSubscriptionId: row.polar_subscription_id,
     polarCustomerId: row.polar_customer_id,
     currentPeriodEnd: row.current_period_end,
+    cancelAtPeriodEnd: Boolean(row.cancel_at_period_end),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
@@ -100,7 +125,7 @@ export async function getSubscription(
       .prepare(
         `SELECT user_id, owner_type, plan_id, billing_period, status,
                 polar_subscription_id, polar_customer_id, current_period_end,
-                created_at, updated_at
+                cancel_at_period_end, created_at, updated_at
          FROM user_subscriptions WHERE user_id = ?1`
       )
       .bind(ownerId)
@@ -118,6 +143,14 @@ export async function getSubscription(
 /**
  * Insert or replace a subscription row (idempotent on owner id).
  * `input.userId` is the billing-owner id (user or org).
+ *
+ * Monotonic on `event_timestamp` when `input.eventTimestamp` is provided: the
+ * `DO UPDATE ... WHERE` clause only applies the update when the existing row
+ * has no event_timestamp yet or the incoming one is `>=` it, so an
+ * out-of-order/replayed older webhook delivery can never stomp state written
+ * by a newer one. When `input.eventTimestamp` is omitted (e.g. the Polar-truth
+ * write-through cache, which reads Polar's CURRENT state rather than replaying
+ * a specific event), the guard is bypassed — that path is always authoritative.
  */
 export async function upsertSubscription(
   input: UpsertSubscriptionInput
@@ -130,13 +163,14 @@ export async function upsertSubscription(
   }
   const now = Math.floor(Date.now() / 1000)
   const ownerType: OwnerType = input.ownerType ?? 'user'
+  const eventTimestamp = input.eventTimestamp ?? null
   await db
     .prepare(
       `INSERT INTO user_subscriptions
          (user_id, owner_type, plan_id, billing_period, status,
           polar_subscription_id, polar_customer_id, current_period_end,
-          created_at, updated_at)
-       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9)
+          cancel_at_period_end, event_timestamp, created_at, updated_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?11)
        ON CONFLICT(user_id) DO UPDATE SET
          owner_type = excluded.owner_type,
          plan_id = excluded.plan_id,
@@ -145,7 +179,12 @@ export async function upsertSubscription(
          polar_subscription_id = excluded.polar_subscription_id,
          polar_customer_id = excluded.polar_customer_id,
          current_period_end = excluded.current_period_end,
-         updated_at = excluded.updated_at`
+         cancel_at_period_end = excluded.cancel_at_period_end,
+         event_timestamp = excluded.event_timestamp,
+         updated_at = excluded.updated_at
+       WHERE excluded.event_timestamp IS NULL
+          OR user_subscriptions.event_timestamp IS NULL
+          OR excluded.event_timestamp >= user_subscriptions.event_timestamp`
     )
     .bind(
       input.userId,
@@ -156,6 +195,8 @@ export async function upsertSubscription(
       input.polarSubscriptionId ?? null,
       input.polarCustomerId ?? null,
       input.currentPeriodEnd ?? null,
+      input.cancelAtPeriodEnd ? 1 : 0,
+      eventTimestamp,
       now
     )
     .run()

--- a/apps/dashboard/src/lib/billing/user-subscription.ts
+++ b/apps/dashboard/src/lib/billing/user-subscription.ts
@@ -58,7 +58,7 @@ export async function resolveOwnerSubscription(
       billingPeriod: cached.billingPeriod,
       status: cached.status,
       currentPeriodEnd: cached.currentPeriodEnd,
-      cancelAtPeriodEnd: false,
+      cancelAtPeriodEnd: cached.cancelAtPeriodEnd,
     }
   }
 
@@ -75,6 +75,7 @@ export async function resolveOwnerSubscription(
         billingPeriod: polar.billingPeriod,
         status: polar.status,
         currentPeriodEnd: polar.currentPeriodEnd,
+        cancelAtPeriodEnd: polar.cancelAtPeriodEnd,
       })
     } catch {
       // ignore — Polar already gave us the authoritative answer

--- a/apps/dashboard/src/lib/connection-store/__tests__/api-errors.test.ts
+++ b/apps/dashboard/src/lib/connection-store/__tests__/api-errors.test.ts
@@ -29,4 +29,12 @@ describe('mapConnectionApiError', () => {
     )
     expect(response.status).toBe(401)
   })
+
+  it('maps ConnectionStoreError LIMIT_EXCEEDED to 402', async () => {
+    const response = mapConnectionApiError(
+      new ConnectionStoreError('Host limit reached', 'LIMIT_EXCEEDED'),
+      CONTEXT
+    )
+    expect(response.status).toBe(402)
+  })
 })

--- a/apps/dashboard/src/lib/connection-store/__tests__/d1-store-limit.test.ts
+++ b/apps/dashboard/src/lib/connection-store/__tests__/d1-store-limit.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Tests for D1ConnectionStore.create()'s atomic host-limit enforcement — the
+ * fix for the count-then-insert TOCTOU race (epic #2097 BE-6).
+ *
+ * Uses a small behavioral fake of D1Database (prepare/bind/run) injected
+ * through a mocked @chm/platform, so we exercise the REAL SQL the store
+ * issues rather than re-implementing the guard in JS: the fake parses out
+ * whether a statement is the guarded `INSERT ... SELECT ... WHERE (SELECT
+ * COUNT(*) ...) < ?` form or the plain unconditional INSERT, and reports
+ * `meta.changes` the way SQLite/D1 actually would (0 rows changed when the
+ * WHERE's SELECT produces no row).
+ *
+ * What this validates:
+ *  - a single INSERT...SELECT...WHERE statement inserts when under the cap
+ *    and no-ops (throws LIMIT_EXCEEDED) when at/over the cap — in ONE D1
+ *    round trip, not a separate count then insert.
+ *  - the count is scoped to the given memberUserIds (pooled org semantics),
+ *    not just the acting user's own rows.
+ *  - concurrent creates that race past a stale pre-check cannot both land:
+ *    only one atomic statement observes room under the cap.
+ *  - limit: null (unlimited plan) skips the guard and always inserts.
+ *
+ * What this does NOT validate: real SQLite/D1 transaction semantics under
+ * true network concurrency — there is no D1 emulator in this test suite.
+ * The fake's `run()` calls are synchronous-per-row-set, which mirrors D1's
+ * documented guarantee that a single prepared statement executes atomically,
+ * but a real Workers-runtime integration test would be needed to verify that
+ * guarantee end-to-end.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+interface FakeRow {
+  id: string
+  user_id: string
+  name: string
+  host_url: string
+  ch_user: string
+  host_id: number
+  encrypted_payload: string
+  created_at: number
+  updated_at: number
+}
+
+function makeFakeD1() {
+  const rows: FakeRow[] = []
+
+  function bindsToRow(b: unknown[]): FakeRow {
+    return {
+      id: b[0] as string,
+      user_id: b[1] as string,
+      name: b[2] as string,
+      host_url: b[3] as string,
+      ch_user: b[4] as string,
+      host_id: b[5] as number,
+      encrypted_payload: b[6] as string,
+      created_at: b[7] as number,
+      updated_at: b[8] as number,
+    }
+  }
+
+  function prepare(sql: string) {
+    return {
+      bind(...binds: unknown[]) {
+        return {
+          async all() {
+            // Only `list()` uses `.all()` in this store.
+            const userId = binds[0] as string
+            return { results: rows.filter((r) => r.user_id === userId) }
+          },
+          async run() {
+            const isGuardedInsert =
+              /INSERT INTO user_connections[\s\S]*SELECT[\s\S]*WHERE[\s\S]*COUNT\(\*\)/.test(
+                sql
+              )
+
+            if (!isGuardedInsert) {
+              // Plain unconditional INSERT (unlimited plan / no limit passed).
+              rows.push(bindsToRow(binds.slice(0, 9)))
+              return { success: true, meta: { changes: 1 } }
+            }
+
+            // Guarded INSERT...SELECT...WHERE (SELECT COUNT(*) ... IN (...)) < ?
+            // binds = [9 insert values, ...memberUserIds, limit]
+            const insertValues = binds.slice(0, 9)
+            const memberUserIds = binds.slice(9, binds.length - 1) as string[]
+            const limit = binds[binds.length - 1] as number
+
+            const count = rows.filter((r) =>
+              memberUserIds.includes(r.user_id)
+            ).length
+
+            if (count < limit) {
+              rows.push(bindsToRow(insertValues))
+              return { success: true, meta: { changes: 1 } }
+            }
+            return { success: true, meta: { changes: 0 } }
+          },
+        }
+      },
+    }
+  }
+
+  return { prepare, _rows: rows }
+}
+
+let currentDb: ReturnType<typeof makeFakeD1> | null = null
+
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({
+    getD1Database: () => currentDb,
+  }),
+}))
+
+const { D1ConnectionStore } = await import('../d1-store')
+const { ConnectionStoreError } = await import('../types')
+
+const originalKey = process.env.CHM_USER_CONNECTIONS_ENCRYPTION_KEY
+
+const creds = (host: string) => ({ host, user: 'default', password: 'p' })
+const input = (name: string, host = 'https://a.example.com') => ({
+  name,
+  hostUrl: host,
+  chUser: 'default',
+  credentials: creds(host),
+})
+
+beforeEach(() => {
+  currentDb = makeFakeD1()
+  process.env.CHM_USER_CONNECTIONS_ENCRYPTION_KEY =
+    'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+})
+
+describe('D1ConnectionStore.create() atomic host limit', () => {
+  test('inserts when the pooled member count is under the limit', async () => {
+    const store = new D1ConnectionStore()
+    const created = await store.create('user_a', input('A'), {
+      memberUserIds: ['user_a'],
+      limit: 3,
+    })
+    expect(created.name).toBe('A')
+    expect(currentDb?._rows).toHaveLength(1)
+  })
+
+  test('throws LIMIT_EXCEEDED and does not insert when at the cap', async () => {
+    const store = new D1ConnectionStore()
+    await store.create('user_a', input('A1'), {
+      memberUserIds: ['user_a'],
+      limit: 1,
+    })
+    expect(currentDb?._rows).toHaveLength(1)
+
+    await expect(
+      store.create('user_a', input('A2'), {
+        memberUserIds: ['user_a'],
+        limit: 1,
+      })
+    ).rejects.toMatchObject({ code: 'LIMIT_EXCEEDED' })
+    // The rejected insert must not have landed a second row.
+    expect(currentDb?._rows).toHaveLength(1)
+  })
+
+  test('pools the count across memberUserIds (org semantics)', async () => {
+    const store = new D1ConnectionStore()
+    await store.create('user_a', input('A1'), {
+      memberUserIds: ['user_a', 'user_b'],
+      limit: 2,
+    })
+    await store.create('user_b', input('B1'), {
+      memberUserIds: ['user_a', 'user_b'],
+      limit: 2,
+    })
+    expect(currentDb?._rows).toHaveLength(2)
+
+    // Pool is now at the cap (2); a third create from EITHER member must fail,
+    // even though user_c individually has zero connections of their own.
+    await expect(
+      store.create('user_a', input('A2'), {
+        memberUserIds: ['user_a', 'user_b'],
+        limit: 2,
+      })
+    ).rejects.toMatchObject({ code: 'LIMIT_EXCEEDED' })
+
+    // A user OUTSIDE the pool is unaffected.
+    const outside = await store.create('user_c', input('C1'), {
+      memberUserIds: ['user_c'],
+      limit: 2,
+    })
+    expect(outside.name).toBe('C1')
+  })
+
+  test('concurrent creates racing past a stale pre-check: only one lands', async () => {
+    const store = new D1ConnectionStore()
+    const limitArg = { memberUserIds: ['user_a'], limit: 1 }
+
+    // Two "requests" both believe (from an earlier, now-stale pre-check) that
+    // the pool has room. Only the atomic INSERT...SELECT...WHERE decides.
+    const results = await Promise.allSettled([
+      store.create('user_a', input('Race1'), limitArg),
+      store.create('user_a', input('Race2'), limitArg),
+    ])
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled')
+    const rejected = results.filter((r) => r.status === 'rejected')
+    expect(fulfilled).toHaveLength(1)
+    expect(rejected).toHaveLength(1)
+    expect((rejected[0] as PromiseRejectedResult).reason).toMatchObject({
+      code: 'LIMIT_EXCEEDED',
+    })
+    expect(currentDb?._rows).toHaveLength(1)
+  })
+
+  test('limit: null (unlimited plan) always inserts unconditionally', async () => {
+    const store = new D1ConnectionStore()
+    for (let i = 0; i < 5; i++) {
+      await store.create('user_a', input(`H${i}`), {
+        memberUserIds: ['user_a'],
+        limit: null,
+      })
+    }
+    expect(currentDb?._rows).toHaveLength(5)
+  })
+
+  test('omitting the limit argument entirely inserts unconditionally', async () => {
+    const store = new D1ConnectionStore()
+    const created = await store.create('user_a', input('NoLimitArg'))
+    expect(created.name).toBe('NoLimitArg')
+    expect(currentDb?._rows).toHaveLength(1)
+  })
+
+  test('LIMIT_EXCEEDED is a ConnectionStoreError instance', async () => {
+    const store = new D1ConnectionStore()
+    await store.create('user_a', input('A1'), {
+      memberUserIds: ['user_a'],
+      limit: 1,
+    })
+    try {
+      await store.create('user_a', input('A2'), {
+        memberUserIds: ['user_a'],
+        limit: 1,
+      })
+      throw new Error('expected LIMIT_EXCEEDED to throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectionStoreError)
+      expect((err as InstanceType<typeof ConnectionStoreError>).code).toBe(
+        'LIMIT_EXCEEDED'
+      )
+    }
+  })
+})
+
+// Restore encryption key env after this file's tests.
+if (originalKey === undefined) {
+  delete process.env.CHM_USER_CONNECTIONS_ENCRYPTION_KEY
+} else {
+  process.env.CHM_USER_CONNECTIONS_ENCRYPTION_KEY = originalKey
+}

--- a/apps/dashboard/src/lib/connection-store/api-errors.ts
+++ b/apps/dashboard/src/lib/connection-store/api-errors.ts
@@ -20,7 +20,9 @@ export function mapConnectionApiError(
           ? 404
           : error.code === 'NOT_CONFIGURED'
             ? 501
-            : 500
+            : error.code === 'LIMIT_EXCEEDED'
+              ? 402
+              : 500
     return createApiErrorResponse(
       { type: ApiErrorType.PermissionError, message: error.message },
       status,

--- a/apps/dashboard/src/lib/connection-store/d1-store.ts
+++ b/apps/dashboard/src/lib/connection-store/d1-store.ts
@@ -1,5 +1,6 @@
 import type {
   ConnectionStore,
+  CreateLimitEnforcement,
   CreateUserConnectionInput,
   StoredUserConnection,
   UpdateUserConnectionInput,
@@ -83,7 +84,8 @@ export class D1ConnectionStore implements ConnectionStore {
 
   async create(
     userId: string,
-    input: CreateUserConnectionInput
+    input: CreateUserConnectionInput,
+    limit?: CreateLimitEnforcement
   ): Promise<UserConnectionMeta> {
     const db = this.getDb()
     const existing = await this.list(userId)
@@ -91,25 +93,57 @@ export class D1ConnectionStore implements ConnectionStore {
     const id = crypto.randomUUID()
     const hostId = allocateDbHostId(existing.map((c) => c.hostId))
     const encryptedPayload = await encryptCredentials(input.credentials)
+    const insertValues = [
+      id,
+      userId,
+      input.name,
+      input.hostUrl,
+      input.chUser,
+      hostId,
+      encryptedPayload,
+      now,
+      now,
+    ]
 
-    await db
-      .prepare(
-        `INSERT INTO user_connections
-         (id, user_id, name, host_url, ch_user, host_id, encrypted_payload, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)`
-      )
-      .bind(
-        id,
-        userId,
-        input.name,
-        input.hostUrl,
-        input.chUser,
-        hostId,
-        encryptedPayload,
-        now,
-        now
-      )
-      .run()
+    // D1 statements are individually ACID, but the count-then-insert pattern
+    // is still a TOCTOU race across two round trips: two concurrent requests
+    // can both read a count under the cap before either has inserted. Folding
+    // the count check into the INSERT's own SELECT collapses both steps into
+    // ONE statement, so there's no window for a second request to interleave.
+    // A capped plan gets `INSERT ... SELECT ... WHERE <count> < <limit>`; the
+    // SELECT (and therefore the insert) evaluates against the row set as it
+    // stands at that single statement's execution, so only one of two racing
+    // requests can ever observe room under the cap and insert.
+    if (limit && limit.limit != null && limit.memberUserIds.length > 0) {
+      const memberPlaceholders = limit.memberUserIds
+        .map((_, i) => `?${insertValues.length + i + 1}`)
+        .join(', ')
+      const limitParamIndex =
+        insertValues.length + limit.memberUserIds.length + 1
+
+      const result = await db
+        .prepare(
+          `INSERT INTO user_connections
+           (id, user_id, name, host_url, ch_user, host_id, encrypted_payload, created_at, updated_at)
+           SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9
+           WHERE (SELECT COUNT(*) FROM user_connections WHERE user_id IN (${memberPlaceholders})) < ?${limitParamIndex}`
+        )
+        .bind(...insertValues, ...limit.memberUserIds, limit.limit)
+        .run()
+
+      if ((result.meta.changes ?? 0) === 0) {
+        throw new ConnectionStoreError('Host limit reached', 'LIMIT_EXCEEDED')
+      }
+    } else {
+      await db
+        .prepare(
+          `INSERT INTO user_connections
+           (id, user_id, name, host_url, ch_user, host_id, encrypted_payload, created_at, updated_at)
+           VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)`
+        )
+        .bind(...insertValues)
+        .run()
+    }
 
     return {
       id,

--- a/apps/dashboard/src/lib/connection-store/postgres-store.ts
+++ b/apps/dashboard/src/lib/connection-store/postgres-store.ts
@@ -1,5 +1,6 @@
 import type {
   ConnectionStore,
+  CreateLimitEnforcement,
   CreateUserConnectionInput,
   StoredUserConnection,
   UpdateUserConnectionInput,
@@ -116,7 +117,8 @@ export class PostgresConnectionStore implements ConnectionStore {
 
   async create(
     userId: string,
-    input: CreateUserConnectionInput
+    input: CreateUserConnectionInput,
+    limit?: CreateLimitEnforcement
   ): Promise<UserConnectionMeta> {
     await this.ensureInitialized()
     const existing = await this.list(userId)
@@ -125,12 +127,42 @@ export class PostgresConnectionStore implements ConnectionStore {
     const hostId = allocateDbHostId(existing.map((c) => c.hostId))
     const encryptedPayload = await encryptCredentials(input.credentials)
 
-    await this.sql`
-      INSERT INTO user_connections
-        (id, user_id, name, host_url, ch_user, host_id, encrypted_payload, created_at, updated_at)
-      VALUES
-        (${id}, ${userId}, ${input.name}, ${input.hostUrl}, ${input.chUser}, ${hostId}, ${encryptedPayload}, ${now}, ${now})
-    `
+    if (limit && limit.limit != null && limit.memberUserIds.length > 0) {
+      // Same TOCTOU concern as the D1 store, but a bare `INSERT ... SELECT
+      // ... WHERE (subquery count)` is NOT enough here: under Postgres's
+      // default READ COMMITTED isolation, two concurrent transactions each
+      // take their own snapshot for the subquery and neither sees the
+      // other's uncommitted insert, so both can pass the check (D1 has no
+      // such gap — Cloudflare serializes all statements against a single
+      // SQLite connection). Take a transaction-scoped advisory lock keyed on
+      // the billing owner FIRST so concurrent creates for the SAME owner
+      // queue up instead of racing; creates for different owners are
+      // unaffected (different lock key, no contention). The lock is released
+      // automatically when the transaction commits/rolls back.
+      const ownerLockKey = limit.memberUserIds.slice().sort().join(',')
+      const rows = await this.sql.begin(async (tx) => {
+        await tx`SELECT pg_advisory_xact_lock(hashtext(${ownerLockKey}))`
+        return tx<{ id: string }[]>`
+          INSERT INTO user_connections
+            (id, user_id, name, host_url, ch_user, host_id, encrypted_payload, created_at, updated_at)
+          SELECT ${id}, ${userId}, ${input.name}, ${input.hostUrl}, ${input.chUser}, ${hostId}, ${encryptedPayload}, ${now}, ${now}
+          WHERE (
+            SELECT COUNT(*) FROM user_connections WHERE user_id IN ${tx(limit.memberUserIds)}
+          ) < ${limit.limit}
+          RETURNING id
+        `
+      })
+      if (rows.length === 0) {
+        throw new ConnectionStoreError('Host limit reached', 'LIMIT_EXCEEDED')
+      }
+    } else {
+      await this.sql`
+        INSERT INTO user_connections
+          (id, user_id, name, host_url, ch_user, host_id, encrypted_payload, created_at, updated_at)
+        VALUES
+          (${id}, ${userId}, ${input.name}, ${input.hostUrl}, ${input.chUser}, ${hostId}, ${encryptedPayload}, ${now}, ${now})
+      `
+    }
 
     return {
       id,

--- a/apps/dashboard/src/lib/connection-store/types.ts
+++ b/apps/dashboard/src/lib/connection-store/types.ts
@@ -32,6 +32,22 @@ export interface CreateUserConnectionInput {
   credentials: ConnectionCredentials
 }
 
+/**
+ * Atomic host-limit enforcement inputs for `create()`. The store folds the
+ * "is there room for one more?" count check into the same SQL statement as
+ * the row insert, so a second concurrent request can't slip through the gap
+ * between a separate pre-check and the insert (TOCTOU).
+ *
+ * `memberUserIds` is the full set of user_ids whose connections count toward
+ * the limit — just `[userId]` for a user-owned plan, or the pooled Clerk org
+ * member id list for an org-owned plan (see `countOwnerHosts`). `limit` is
+ * the plan's host cap; `null` means unlimited and skips enforcement entirely.
+ */
+export interface CreateLimitEnforcement {
+  memberUserIds: string[]
+  limit: number | null
+}
+
 export interface UpdateUserConnectionInput {
   name?: string
   hostUrl?: string
@@ -45,9 +61,17 @@ export interface ConnectionStore {
     userId: string,
     connectionId: string
   ): Promise<StoredUserConnection | null>
+  /**
+   * `limit` (optional) enforces the plan's host cap atomically with the
+   * insert — see {@link CreateLimitEnforcement}. Omit it (or pass
+   * `limit: null`) to insert unconditionally, e.g. for unlimited plans.
+   * Throws `ConnectionStoreError('LIMIT_EXCEEDED')` when the cap is already
+   * met at insert time, even if a caller's earlier pre-check passed.
+   */
   create(
     userId: string,
-    input: CreateUserConnectionInput
+    input: CreateUserConnectionInput,
+    limit?: CreateLimitEnforcement
   ): Promise<UserConnectionMeta>
   update(
     userId: string,
@@ -69,7 +93,8 @@ export class ConnectionStoreError extends Error {
       | 'UNAUTHORIZED'
       | 'STORAGE_ERROR'
       | 'VALIDATION_ERROR'
-      | 'NOT_CONFIGURED',
+      | 'NOT_CONFIGURED'
+      | 'LIMIT_EXCEEDED',
     public readonly cause?: unknown
   ) {
     super(message)

--- a/apps/dashboard/src/routes/api/v1/billing/portal.ts
+++ b/apps/dashboard/src/routes/api/v1/billing/portal.ts
@@ -3,16 +3,21 @@
  *
  * Returns: { url } — a customer-session portal URL where the user can manage,
  * upgrade, or cancel their subscription and update payment details. Polar hosts
- * the whole UI; we just mint a session for the current user via externalId.
+ * the whole UI; we just mint a session for the billing owner via externalId.
+ *
+ * Must use the BILLING OWNER's id (org or user, from resolveBillingOwner()),
+ * not the raw session user id — paid subscriptions are stamped with the org's
+ * externalId, so an org member requesting a session under their own user id
+ * 404s against Polar (no customer exists for that externalId).
  */
 import { createFileRoute } from '@tanstack/react-router'
 
 import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
 import { createSuccessResponse } from '@/lib/api/shared/response-builder'
 import { ApiErrorType } from '@/lib/api/types'
+import { resolveBillingOwner } from '@/lib/billing/billing-owner'
 import { getPolarClient, isBillingConfigured } from '@/lib/billing/polar-config'
 import { mapConnectionApiError } from '@/lib/connection-store/api-errors'
-import { resolveConnectionUserId } from '@/lib/connection-store/auth'
 
 const ROUTE = { route: '/api/v1/billing/portal', method: 'POST' }
 
@@ -29,9 +34,9 @@ async function handlePost(): Promise<Response> {
   }
 
   try {
-    const userId = await resolveConnectionUserId()
+    const owner = await resolveBillingOwner()
     const session = await getPolarClient().customerSessions.create({
-      externalCustomerId: userId,
+      externalCustomerId: owner.id,
     })
     return createSuccessResponse({ url: session.customerPortalUrl })
   } catch (error) {

--- a/apps/dashboard/src/routes/api/v1/billing/usage.ts
+++ b/apps/dashboard/src/routes/api/v1/billing/usage.ts
@@ -62,7 +62,8 @@ async function resolveHostsUsed(
 ): Promise<number> {
   try {
     const store = await resolveConnectionStore()
-    return await countOwnerHosts(owner, store, userId)
+    const usage = await countOwnerHosts(owner, store, userId)
+    return usage.count
   } catch {
     return 0
   }

--- a/apps/dashboard/src/routes/api/v1/user-connections.ts
+++ b/apps/dashboard/src/routes/api/v1/user-connections.ts
@@ -6,6 +6,7 @@
 
 import { createFileRoute } from '@tanstack/react-router'
 
+import type { LimitCheck } from '@/lib/billing/entitlements'
 import type { CreateUserConnectionInput } from '@/lib/connection-store/types'
 
 import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
@@ -21,6 +22,7 @@ import { mapConnectionApiError } from '@/lib/connection-store/api-errors'
 import { resolveConnectionUserId } from '@/lib/connection-store/auth'
 import { resolveConnectionStore } from '@/lib/connection-store/resolve-store'
 import { getUserConnectionsServerConfig } from '@/lib/connection-store/server-feature'
+import { ConnectionStoreError } from '@/lib/connection-store/types'
 
 const ROUTE_GET = { route: '/api/v1/user-connections', method: 'GET' }
 const ROUTE_POST = { route: '/api/v1/user-connections', method: 'POST' }
@@ -63,6 +65,29 @@ interface CreateRequest {
   host: string
   user: string
   password: string
+}
+
+/**
+ * The 402 response shape for a tripped host-limit check (pre-check or atomic
+ * recheck). Both call sites only reach this with a plan that caps hosts, so
+ * `check.limit` is always non-null there — but `LimitCheck.limit` is typed
+ * `number | null` (it doubles as the unlimited-plan shape), so the caller
+ * passes the known-non-null cap explicitly rather than us re-deriving it.
+ */
+function hostLimitResponse(check: LimitCheck, limit: number): Response {
+  return createApiErrorResponse(
+    {
+      type: ApiErrorType.PermissionError,
+      message: limitMessage(check),
+      details: {
+        planId: check.planId,
+        limit,
+        reason: check.reason,
+      },
+    },
+    402,
+    ROUTE_POST
+  )
 }
 
 async function handlePost(request: Request): Promise<Response> {
@@ -129,27 +154,23 @@ async function handlePost(request: Request): Promise<Response> {
     // For a user owner it's just this user's connections. The count is fail-safe:
     // an org-enumeration error falls back to the acting user's count, so it never
     // blocks a paying org on a Clerk hiccup.
+    //
+    // This is a UX fast-path only, not the authoritative guard: two concurrent
+    // requests (two tabs, or two org members) can both pass this check before
+    // either has inserted. The authoritative guard is the atomic INSERT-with-
+    // count `store.create()` performs below — see CreateLimitEnforcement.
+    // Unlimited plans (plan.hosts === null) skip the count entirely — no
+    // Clerk member enumeration needed when there's no cap to check against.
     const owner = await resolveBillingOwner()
     const plan = await getPlanForOwner(owner.id)
+    const usage =
+      plan.hosts != null
+        ? await countOwnerHosts(owner, store, userId)
+        : { count: 0, memberUserIds: [] as string[] }
     if (plan.hosts != null) {
-      const usedHosts = await countOwnerHosts(owner, store, userId)
-      const check = checkHostLimit(plan, usedHosts)
+      const check = checkHostLimit(plan, usage.count)
       if (!check.allowed) {
-        return createApiErrorResponse(
-          {
-            type: ApiErrorType.PermissionError,
-            message: limitMessage(check),
-            details: {
-              planId: check.planId,
-              // Non-null inside this `plan.hosts != null` guard; coerce for the
-              // string|number details type (LimitCheck.limit is number | null).
-              limit: check.limit ?? plan.hosts,
-              reason: check.reason,
-            },
-          },
-          402,
-          ROUTE_POST
-        )
+        return hostLimitResponse(check, plan.hosts)
       }
     }
 
@@ -182,7 +203,28 @@ async function handlePost(request: Request): Promise<Response> {
       chUser: credentials.user,
       credentials,
     }
-    const created = await store.create(userId, input)
+    let created
+    try {
+      created = await store.create(userId, input, {
+        memberUserIds: usage.memberUserIds,
+        limit: plan.hosts,
+      })
+    } catch (err) {
+      if (
+        err instanceof ConnectionStoreError &&
+        err.code === 'LIMIT_EXCEEDED'
+      ) {
+        // Lost the race: another concurrent request filled the last slot
+        // between our fast-path check above and this atomic insert. The
+        // store only throws LIMIT_EXCEEDED when it was given a non-null
+        // limit, so plan.hosts is guaranteed non-null here; `used: plan.hosts`
+        // reflects that the pool was already at (or past) the cap when the
+        // atomic recheck ran.
+        const limit = plan.hosts as number
+        return hostLimitResponse(checkHostLimit(plan, limit), limit)
+      }
+      throw err
+    }
     return createSuccessResponse({
       id: created.id,
       name: created.name,

--- a/apps/dashboard/src/routes/api/v1/webhooks/polar.test.ts
+++ b/apps/dashboard/src/routes/api/v1/webhooks/polar.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for the Polar webhook's applySubscription() owner-resolution +
+ * persistence logic (BE-3 of epic #2097):
+ *  - the Polar customer's externalId is re-keyed to the org on lazy org
+ *    creation, so the Polar-truth fallback can find it by orgId later.
+ *  - a D1 write that fails once is retried before being treated as failed.
+ *  - an unmapped Polar product is skipped without touching D1.
+ *
+ * All external collaborators (Clerk, Polar client, D1-backed subscription
+ * store) are mocked so this stays a pure unit test — mirrors the mock.module
+ * style in polar-subscription.test.ts and org-host-count.test.ts. Each
+ * mocked export is a stable wrapper function that delegates to the current
+ * per-test `let` binding, so reassigning the binding inside a test takes
+ * effect (a bare re-exported const would be captured once at module-eval
+ * time and never see later reassignments). `@tanstack/react-router`'s
+ * `createFileRoute` is left un-mocked (matches the existing
+ * routes/api/v1/health/webhook.test.ts convention) — it runs for real at
+ * import time but route registration isn't under test here.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+let getOrganizationMembershipList = mock(async (_args: { userId: string }) => ({
+  data: [] as Array<{ organization?: { id?: string | null } }>,
+}))
+let createOrganization = mock(
+  async (_args: { name: string; createdBy: string }) => ({ id: 'org_new' })
+)
+mock.module('@clerk/tanstack-react-start/server', () => ({
+  clerkClient: () => ({
+    users: {
+      getOrganizationMembershipList: (args: { userId: string }) =>
+        getOrganizationMembershipList(args),
+    },
+    organizations: {
+      createOrganization: (args: { name: string; createdBy: string }) =>
+        createOrganization(args),
+    },
+  }),
+}))
+
+let updateCustomer = mock(
+  async (_args: { id: string; customerUpdate: { externalId: string } }) => ({})
+)
+// Mocks the FULL real export surface of polar-config.ts (not just what this
+// file needs): bun's mock.module() registers per module specifier, and
+// polar-subscription.test.ts also mocks this same specifier with a different
+// export subset. Both files can run in one `bun test` process, so an
+// incomplete mock here risks "export not found" if the OTHER file's factory
+// wins the registration race. A superset covering every real export is
+// resilient regardless of load order.
+mock.module('@/lib/billing/polar-config', () => ({
+  PAID_PLAN_IDS: ['pro', 'max'] as const,
+  getPolarServer: () => 'sandbox' as const,
+  isBillingConfigured: () => true,
+  getPolarClient: () => ({
+    customers: {
+      update: (args: { id: string; customerUpdate: { externalId: string } }) =>
+        updateCustomer(args),
+    },
+  }),
+  getWebhookSecret: () => 'whsec_test',
+  productIdFor: () => null,
+  planForProductId: (productId: string) =>
+    productId === 'prod_pro'
+      ? { planId: 'pro', period: 'monthly' as const }
+      : null,
+  isPaidPlanId: (value: string) => value === 'pro' || value === 'max',
+}))
+
+let upsertSubscription = mock(async (_input: unknown) => {})
+mock.module('@/lib/billing/subscription-store', () => ({
+  upsertSubscription: (input: unknown) => upsertSubscription(input),
+}))
+
+let invalidateNegativeCache = mock((_externalId: string) => {})
+mock.module('@/lib/billing/polar-subscription', () => ({
+  invalidateNegativeCache: (externalId: string) =>
+    invalidateNegativeCache(externalId),
+}))
+
+const { __applySubscriptionForTests: applySubscription } = await import(
+  './polar'
+)
+
+function subData(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'sub_1',
+    status: 'active',
+    productId: 'prod_pro',
+    customerId: 'cus_1',
+    customer: { externalId: 'user_alice' },
+    ...overrides,
+  } as Parameters<typeof applySubscription>[0]
+}
+
+beforeEach(() => {
+  getOrganizationMembershipList = mock(async () => ({ data: [] }))
+  createOrganization = mock(async () => ({ id: 'org_new' }))
+  updateCustomer = mock(async () => ({}))
+  upsertSubscription = mock(async () => {})
+  invalidateNegativeCache = mock(() => {})
+})
+
+describe('applySubscription — org re-keying', () => {
+  test('first paid event for a user re-keys the Polar customer externalId to the new org', async () => {
+    await applySubscription(subData())
+
+    expect(createOrganization).toHaveBeenCalledTimes(1)
+    expect(updateCustomer).toHaveBeenCalledTimes(1)
+    expect(updateCustomer.mock.calls[0]?.[0]).toEqual({
+      id: 'cus_1',
+      customerUpdate: { externalId: 'org_new' },
+    })
+    expect(upsertSubscription).toHaveBeenCalledTimes(1)
+    expect(
+      (upsertSubscription.mock.calls[0]?.[0] as { userId: string }).userId
+    ).toBe('org_new')
+  })
+
+  test('org creation failure keeps the user owner and never attempts re-key', async () => {
+    getOrganizationMembershipList = mock(async () => {
+      throw new Error('clerk down')
+    })
+
+    await applySubscription(subData())
+
+    expect(updateCustomer).not.toHaveBeenCalled()
+    expect(
+      (upsertSubscription.mock.calls[0]?.[0] as { userId: string }).userId
+    ).toBe('user_alice')
+  })
+
+  test('an already org-scoped externalId is never re-keyed (no first-payment transition)', async () => {
+    await applySubscription(
+      subData({ customer: { externalId: 'org_existing' } })
+    )
+
+    expect(createOrganization).not.toHaveBeenCalled()
+    expect(updateCustomer).not.toHaveBeenCalled()
+  })
+})
+
+describe('applySubscription — D1 write retry', () => {
+  test('retries once on a transient D1 failure and succeeds', async () => {
+    let calls = 0
+    upsertSubscription = mock(async () => {
+      calls += 1
+      if (calls === 1) throw new Error('D1 blip')
+    })
+
+    await applySubscription(subData({ customer: { externalId: 'org_x' } }))
+
+    expect(upsertSubscription).toHaveBeenCalledTimes(2)
+  })
+
+  test('a write that fails twice does not throw (Polar remains source of truth)', async () => {
+    upsertSubscription = mock(async () => {
+      throw new Error('D1 down')
+    })
+
+    await expect(
+      applySubscription(subData({ customer: { externalId: 'org_x' } }))
+    ).resolves.toBeUndefined()
+    expect(upsertSubscription).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('applySubscription — unknown product', () => {
+  test('an unmapped product id is skipped without writing D1', async () => {
+    await applySubscription(subData({ productId: 'prod_unknown' }))
+
+    expect(upsertSubscription).not.toHaveBeenCalled()
+    expect(updateCustomer).not.toHaveBeenCalled()
+  })
+})
+
+describe('applySubscription — negative cache invalidation', () => {
+  test('a live paid subscription invalidates both the raw and resolved owner keys', async () => {
+    await applySubscription(subData())
+
+    expect(invalidateNegativeCache).toHaveBeenCalledWith('user_alice')
+    expect(invalidateNegativeCache).toHaveBeenCalledWith('org_new')
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/webhooks/polar.ts
+++ b/apps/dashboard/src/routes/api/v1/webhooks/polar.ts
@@ -8,15 +8,36 @@
  * - externalId starts with 'user_' (first-time upgrade, no org yet):
  *   1. Check if the user already has a Clerk org membership (idempotency).
  *   2. If not, create a Clerk org lazily and add the user as admin.
- *   3. Upsert the subscription keyed by orgId (owner_type='org').
- *   4. Defensive fallback: if org creation fails, persist under userId so
+ *   3. Re-key the Polar customer's externalId to the orgId (customers.update
+ *      by internal customer id) so `pullOwnerSubscriptionFromPolar(orgId)` —
+ *      the "Polar is source of truth" fallback — can find this customer by
+ *      org id from now on. Without this, the Polar lookup 404s forever for
+ *      org owners and entitlement silently depends on the D1 cache never
+ *      drifting.
+ *   4. Upsert the subscription keyed by orgId (owner_type='org').
+ *   5. Defensive fallback: if org creation fails, persist under userId so
  *      billing is never lost (owner_type='user').
  *
  * - externalId starts with 'org_' (re-subscription or upgrade on paid account):
  *   Upsert subscription keyed by orgId (owner_type='org') directly.
  *
- * Always 2xx on a valid (even ignored) event so Polar doesn't retry.
- * 400 on bad signature only. 500 on persistence errors (Polar will retry).
+ * The D1 cache write is retried once on failure (transient D1 blips) before
+ * giving up — a silently lost row would otherwise gate a paying owner as free
+ * until their next Polar reconciliation read, which is user-visible for an
+ * otherwise-live subscription.
+ *
+ * `cancelAtPeriodEnd` and the envelope's `timestamp` (unix seconds) are
+ * persisted on every write. The timestamp feeds subscription-store.ts's
+ * monotonic write guard: webhook delivery is at-least-once and can arrive out
+ * of order, so a late/replayed older event must never overwrite state written
+ * by a newer one (e.g. a stale "canceled" landing after a fresher "active"
+ * from an uncancel).
+ *
+ * Always 2xx on a valid, handled event so Polar doesn't retry. 400 on bad
+ * signature. An unmapped/unknown Polar product is logged as an ERROR (not
+ * silently dropped at info level) and skipped — we can't apply a plan we
+ * don't recognize, but the event must stay visible/alertable instead of
+ * vanishing into routine logs.
  *
  * Unauthenticated by design — the signature IS the auth.
  */
@@ -24,7 +45,12 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { error as logError, log as logInfo } from '@chm/logger'
 import { validateEvent, WebhookVerificationError } from '@polar-sh/sdk/webhooks'
-import { getWebhookSecret, planForProductId } from '@/lib/billing/polar-config'
+import {
+  getPolarClient,
+  getWebhookSecret,
+  planForProductId,
+} from '@/lib/billing/polar-config'
+import { invalidateNegativeCache } from '@/lib/billing/polar-subscription'
 import {
   type OwnerType,
   upsertSubscription,
@@ -36,6 +62,7 @@ interface PolarSubscriptionData {
   status: string
   recurringInterval?: string | null
   currentPeriodEnd?: Date | string | null
+  cancelAtPeriodEnd?: boolean | null
   productId: string
   customerId: string
   customer?: { externalId?: string | null } | null
@@ -99,7 +126,67 @@ async function ensureOrgForUser(userId: string): Promise<string | null> {
   }
 }
 
-async function applySubscription(data: PolarSubscriptionData): Promise<void> {
+/**
+ * Re-key the Polar customer's externalId from the buyer's userId to the newly
+ * created orgId. Best-effort: on failure the D1 row is still correct (keyed
+ * by orgId), but `pullOwnerSubscriptionFromPolar(orgId)` will 404 until this
+ * is retried — logged as an error so it's alertable, not lost silently.
+ */
+async function rekeyCustomerToOrg(
+  customerId: string,
+  orgId: string
+): Promise<void> {
+  try {
+    await getPolarClient().customers.update({
+      id: customerId,
+      customerUpdate: { externalId: orgId },
+    })
+    logInfo('[polar-webhook] re-keyed Polar customer externalId to org', {
+      customerId,
+      orgId,
+    })
+  } catch (err) {
+    logError(
+      '[polar-webhook] failed to re-key Polar customer externalId to org; ' +
+        'Polar-truth fallback will 404 for this org until retried',
+      { customerId, orgId, err }
+    )
+  }
+}
+
+/** Retry a D1 write once before giving up — smooths over transient blips. */
+async function upsertSubscriptionWithRetry(
+  input: Parameters<typeof upsertSubscription>[0]
+): Promise<void> {
+  try {
+    await upsertSubscription(input)
+  } catch (firstErr) {
+    logError('[polar-webhook] D1 cache write failed; retrying once', {
+      ownerId: input.userId,
+      ownerType: input.ownerType,
+      err: firstErr,
+    })
+    await upsertSubscription(input)
+  }
+}
+
+/** Test-only export — exercises the full owner-resolution + persistence path. */
+export async function __applySubscriptionForTests(
+  data: PolarSubscriptionData,
+  eventTimestamp?: number | null
+): Promise<void> {
+  return applySubscription(data, eventTimestamp ?? null)
+}
+
+/**
+ * @param eventTimestamp Unix seconds from the webhook envelope's `timestamp`
+ *   — feeds the monotonic write guard in subscription-store.ts so an
+ *   out-of-order/replayed older delivery can't overwrite newer state.
+ */
+async function applySubscription(
+  data: PolarSubscriptionData,
+  eventTimestamp: number | null
+): Promise<void> {
   const externalId = data.customer?.externalId
   if (!externalId) {
     logInfo('[polar-webhook] subscription without externalId; skipping', {
@@ -110,9 +197,13 @@ async function applySubscription(data: PolarSubscriptionData): Promise<void> {
 
   const mapped = planForProductId(data.productId)
   if (!mapped) {
-    logInfo('[polar-webhook] unknown product id; skipping', {
-      productId: data.productId,
-    })
+    // Not silently dropped: an unmapped product is a config/deploy mismatch
+    // (a new Polar product without a CHM_POLAR_PRODUCT_* env mapping) and
+    // must be visible/alertable, not buried at info level.
+    logError(
+      '[polar-webhook] unknown Polar product id; no plan mapping — skipping',
+      { productId: data.productId, subscriptionId: data.id, externalId }
+    )
     return
   }
 
@@ -132,17 +223,25 @@ async function applySubscription(data: PolarSubscriptionData): Promise<void> {
     if (orgId) {
       ownerId = orgId
       ownerType = 'org'
+      // Re-key the Polar customer to the org so the Polar-truth fallback
+      // (pullOwnerSubscriptionFromPolar) can find it by orgId going forward —
+      // otherwise every future entitlement reconciliation for this org 404s
+      // against Polar and depends entirely on the D1 cache never drifting.
+      await rekeyCustomerToOrg(data.customerId, orgId)
     }
     // If orgId is null, fallback: keep ownerId=userId, ownerType='user'.
     // Billing is preserved under userId; org creation can be retried manually.
   }
 
-  // Best-effort cache write. The dashboard reconciles entitlement from Polar
-  // (resolveOwnerSubscription), so a missing/cold D1 must NOT fail the webhook —
-  // otherwise Polar retries the event forever on a 500 even though the truth is
-  // already in Polar. Log and acknowledge.
+  // Cache write, retried once on transient failure. The dashboard also
+  // reconciles entitlement straight from Polar (resolveOwnerSubscription), so
+  // a write that still fails after retry must NOT fail the whole webhook —
+  // otherwise Polar retries the event forever on a 500 even though the truth
+  // is already in Polar (and, once re-keyed above, reachable by ownerId too).
+  // Still logged loudly: a lost row means the next read pays the Polar
+  // round-trip instead of hitting the D1 fast path, so it should be visible.
   try {
-    await upsertSubscription({
+    await upsertSubscriptionWithRetry({
       userId: ownerId,
       ownerType,
       planId: mapped.planId,
@@ -151,14 +250,29 @@ async function applySubscription(data: PolarSubscriptionData): Promise<void> {
       polarSubscriptionId: data.id,
       polarCustomerId: data.customerId,
       currentPeriodEnd: toUnixSeconds(data.currentPeriodEnd),
+      cancelAtPeriodEnd: Boolean(data.cancelAtPeriodEnd),
+      eventTimestamp,
     })
   } catch (err) {
-    logError('[polar-webhook] D1 cache write failed (non-fatal)', {
-      ownerId,
-      ownerType,
-      planId: mapped.planId,
-      err,
-    })
+    logError(
+      '[polar-webhook] D1 cache write failed after retry (non-fatal — Polar remains source of truth)',
+      {
+        ownerId,
+        ownerType,
+        planId: mapped.planId,
+        err,
+      }
+    )
+  }
+
+  // The subscription just became live/paid — clear any negative-cache entry
+  // so the next entitlement read reaches Polar instead of a stale "free"
+  // short-circuit. Invalidate both the raw externalId (what an entitlement
+  // check may have cached before checkout completed) and the resolved
+  // ownerId (an org, once org re-keying applies) since they can differ.
+  if (isPaidPlan) {
+    invalidateNegativeCache(externalId)
+    if (ownerId !== externalId) invalidateNegativeCache(ownerId)
   }
 
   logInfo('[polar-webhook] applied subscription', {
@@ -205,7 +319,10 @@ async function handlePost(request: Request): Promise<Response> {
       case 'subscription.uncanceled':
       case 'subscription.revoked':
       case 'subscription.past_due':
-        await applySubscription(event.data as unknown as PolarSubscriptionData)
+        await applySubscription(
+          event.data as unknown as PolarSubscriptionData,
+          toUnixSeconds(event.timestamp)
+        )
         break
       default:
         // Acknowledge unhandled events (checkout.*, order.*, etc.) without action.


### PR DESCRIPTION
## Summary

Implements the remaining slices (BE-2 through BE-6) of #2097 "[Epic] Billing edge cases". BE-1 (owner-aware retention prune) was already merged in #2112.

- [x] **BE-2** — `POST /api/v1/billing/portal` resolved the Polar customer-portal session under `resolveConnectionUserId()` (the raw Clerk user id) instead of the billing owner. Org customers 404'd on the portal since paid subscriptions are stamped with the org's `externalId`. Fixed by using `resolveBillingOwner()`, the same owner resolution BE-1 and the subscription-lookup path already use.

- [x] **BE-3** — Polar webhook (`api/v1/webhooks/polar.ts`) had three issues in the lazy-org-creation path:
  - The Polar customer's `externalId` was never re-keyed from the buyer's userId to the newly created orgId, so the "Polar is source of truth" fallback (`pullOwnerSubscriptionFromPolar(orgId)`) 404'd forever for org-owned subscriptions. Now re-keys via `customers.update()`.
  - The D1 cache write was best-effort with no retry — a transient blip silently dropped a row. Now retried once (still non-fatal after retry — Polar remains authoritative, and is now reachable by ownerId after re-keying).
  - An unmapped Polar product id logged at info level and silently no-opped. Now logged as an error so a missing `CHM_POLAR_PRODUCT_*` mapping is visible/alertable.

- [x] **BE-4** — `cancelAtPeriodEnd` was hard-coded `false` on the D1 fast path (only the Polar-pull fallback read it correctly), so a cancelled-but-in-grace-period subscription read from cache never showed the "cancels on \<date\>" state. Added migration `0008_subscription_cancel_and_event_guard.sql` (`cancel_at_period_end`, `event_timestamp` columns), persist it on both write paths, and added a monotonic write guard so an out-of-order/replayed webhook delivery can't overwrite newer state.

- [x] **BE-5** — The 60s negative subscription cache (marks an owner "confirmed free") was never invalidated on upgrade — only a later positive Polar read cleared it, and the webhook path writes D1 directly without ever calling the Polar-pull function. A just-paid user could be gated as free for up to a minute. Added `invalidateNegativeCache()`, called from the webhook whenever a subscription becomes live/paid.

- [x] **BE-6** — The host-limit check was count-then-insert TOCTOU: two concurrent requests (two tabs, or two org members hitting the pooled org limit) could both pass the pre-check before either inserted, exceeding the cap. `ConnectionStore.create()` now takes an optional `{ memberUserIds, limit }` and folds the count into the insert as one atomic `INSERT ... SELECT ... WHERE (count) < limit` statement. D1's single prepared statement is atomic by construction; Postgres additionally needed a transaction-scoped `pg_advisory_xact_lock` keyed on the owner, since a bare `INSERT...SELECT...WHERE` does **not** serialize against a concurrent transaction under READ COMMITTED.

Also includes one unrelated one-line formatting fix (`session-stats.tsx`) needed to satisfy the pre-push Biome check — pre-existing drift on `main`, not part of this epic.

## Test plan

- [x] `bun test src/lib/billing src/lib/connection-store src/routes/api/v1/webhooks --isolate` — 123 tests, 0 failures
- [x] `bun test src/ --isolate` (full dashboard suite) — 4525 tests, 0 failures
- [x] `bun run lint` — clean (2 pre-existing unrelated warnings in `regression-panel.tsx`)
- [x] `bun x biome check` on all touched/new files — clean
- [x] Targeted `tsc --noEmit` diff on touched files — no new errors (only pre-existing repo-wide `createFileRoute` codegen noise from an ungenerated `routeTree.gen.ts`, present on every route file)
- [x] New unit tests: `webhooks/polar.test.ts` (org re-key, D1 retry, unknown product, negative-cache invalidation), `billing/subscription-store.test.ts` (cancel_at_period_end persistence, monotonic write guard), `connection-store/__tests__/d1-store-limit.test.ts` (atomic host-limit enforcement)

Refs #2097