### PR TITLE
test(query): align withQueryParams escaping tests with quote-doubling

### DIFF
--- a/apps/dashboard/src/lib/__tests__/clickhouse-query.test.ts
+++ b/apps/dashboard/src/lib/__tests__/clickhouse-query.test.ts
@@ -151,7 +151,7 @@ describe('withQueryParams', () => {
     const result = withQueryParams('SELECT {name:String}', {
       name: "O'Brien",
     })
-    expect(result).toContain("SET param_name='O\\'Brien'")
+    expect(result).toContain("SET param_name='O''Brien'")
   })
 
   test('escapes a single backslash in string values', () => {
@@ -160,11 +160,11 @@ describe('withQueryParams', () => {
   })
 
   test('escapes a backslash immediately followed by a quote (injection case)', () => {
-    // Naive quote-doubling would let this trailing backslash "consume" the
-    // escaped quote, breaking out of the string literal. Backslash-first
-    // escaping must render "\\\'" so the literal stays closed correctly.
+    // Backslashes are escaped first (\\ -> \\\\), then single quotes are doubled
+    // ('' ), so a trailing backslash cannot "consume" the escaped quote and break
+    // out of the string literal: "evil\'; --" renders as 'evil\\''; --'.
     const result = withQueryParams('SELECT {s:String}', { s: "evil\\'; --" })
-    expect(result).toBe("SET param_s='evil\\\\\\'; --';\nSELECT {s:String}")
+    expect(result).toBe("SET param_s='evil\\\\''; --';\nSELECT {s:String}")
   })
 
   test('escapes backslashes so a trailing one cannot break out of the literal', () => {

--- a/apps/dashboard/src/lib/clickhouse-query.test.ts
+++ b/apps/dashboard/src/lib/clickhouse-query.test.ts
@@ -228,12 +228,12 @@ describe('withQueryParams', () => {
 
   test('escapes single quotes in string values', () => {
     const result = withQueryParams('SELECT {s:String}', { s: "O'Brien" })
-    expect(result).toBe("SET param_s='O\\'Brien';\nSELECT {s:String}")
+    expect(result).toBe("SET param_s='O''Brien';\nSELECT {s:String}")
   })
 
   test('escapes multiple single quotes in string values', () => {
     const result = withQueryParams('SELECT {s:String}', { s: "it's a 'test'" })
-    expect(result).toBe("SET param_s='it\\'s a \\'test\\'';\nSELECT {s:String}")
+    expect(result).toBe("SET param_s='it''s a ''test''';\nSELECT {s:String}")
   })
 
   test('serialises boolean true as 1', () => {


### PR DESCRIPTION
## Problem

#2129 (query edge-cases) landed `clickhouse-query` tests asserting backslash single-quote escaping (`\'`), but the merged `withQueryParams` — from the security PR #2131 — escapes single quotes by **doubling** (`''`) after backslash-escaping. Result: 2+ failing unit tests on `main` (`unit-tests` is non-blocking, so #2129 auto-merged with them red).

## Fix

Align the four affected assertions in both `clickhouse-query.test.ts` copies (primary + `__tests__`) to the `''` behavior, and correct the injection-case comment.

Both escapings are valid, safe ClickHouse string escaping; the merged `''` form is authoritative. The trailing-backslash injection case stays safe because backslashes are escaped **first** (`\\` → `\\\\`), so a trailing backslash cannot consume the doubled quote and break out of the literal — verified: `evil\'; --` → `'evil\\''; --'`.

## Verification

`bun test` both files locally: **81 pass / 0 fail**.

Refs #2096.