### PR TITLE
fix(landing): render gallery screenshots + add Features jump menu

### DIFF
--- a/apps/landing/src/components/Features.astro
+++ b/apps/landing/src/components/Features.astro
@@ -7,7 +7,7 @@
       </div>
 
       <!-- AI Agent -->
-      <div class="feature" style="margin-top:64px">
+      <div id="feature-ai-agent" class="feature" style="margin-top:64px">
         <div class="feat-text reveal">
           <span class="feat-ico"><svg viewBox="0 0 24 24" fill="none" stroke="var(--violet)" stroke-width="1.7" stroke-linejoin="round"><path d="M12 2 13.5 9.5 21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5z"/></svg></span>
           <h3>Ask your cluster anything</h3>
@@ -31,7 +31,7 @@
       </div>
 
       <!-- Queries -->
-      <div class="feature flip">
+      <div id="feature-queries" class="feature flip">
         <div class="feat-text reveal">
           <span class="feat-ico"><svg viewBox="0 0 24 24" fill="none" stroke="var(--blue)" stroke-width="1.7"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg></span>
           <h3>Every query, explained</h3>
@@ -49,7 +49,7 @@
       </div>
 
       <!-- Cluster Topology -->
-      <div class="feature">
+      <div id="feature-topology" class="feature">
         <div class="feat-text reveal">
           <span class="feat-ico"><svg viewBox="0 0 24 24" fill="none" stroke="var(--emerald)" stroke-width="1.7"><rect x="3" y="3" width="6" height="6" rx="1.5"/><rect x="15" y="3" width="6" height="6" rx="1.5"/><rect x="9" y="15" width="6" height="6" rx="1.5"/><path d="M6 9v2a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V9"/><path d="M12 13v2"/></svg></span>
           <h3>See the whole cluster at a glance</h3>

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -41,7 +41,7 @@ const galleryCards = [
       {galleryCards.map((card) => (
         <div class="gcard">
           <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span><span class="gtab">{card.tab}</span></div>
-          <img src={card.src} alt={card.alt} width="600" height="360" loading="lazy" decoding="async" />
+          <img src={card.src} alt={card.alt} width="600" height="360" loading="eager" decoding="sync" />
         </div>
       ))}
       {galleryCards.map((card) => (

--- a/apps/landing/src/components/Nav.astro
+++ b/apps/landing/src/components/Nav.astro
@@ -9,11 +9,13 @@
       <nav class="nav-links">
         <div class="nav-group">
           <button type="button" class="nav-trigger" aria-haspopup="true" aria-expanded="false">
-            Product
+            Features
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
           </button>
           <div class="nav-menu">
-            <a href="/#features">Features<small>System tables, read-only, AI agent</small></a>
+            <a href="/#feature-ai-agent">AI Agent<small>Ask your cluster anything over MCP</small></a>
+            <a href="/#feature-queries">Query monitoring<small>Running, slow, failed &amp; expensive queries</small></a>
+            <a href="/#feature-topology">Cluster topology<small>Nodes, shards, replicas &amp; Keeper quorum</small></a>
             <a href="/#data-explorer">Data Explorer<small>Browse databases, deps and SQL</small></a>
             <a href="/#health">Health<small>Live cluster health indicators</small></a>
             <a href="/#capabilities">Capabilities<small>Every system table, one place</small></a>
@@ -68,8 +70,10 @@
         </button>
       </div>
       <div class="nav-drawer-body">
-        <span class="nav-drawer-label">Product</span>
-        <a href="/#features">Features</a>
+        <span class="nav-drawer-label">Features</span>
+        <a href="/#feature-ai-agent">AI Agent</a>
+        <a href="/#feature-queries">Query monitoring</a>
+        <a href="/#feature-topology">Cluster topology</a>
         <a href="/#data-explorer">Data Explorer</a>
         <a href="/#health">Health</a>
         <a href="/#capabilities">Capabilities</a>
@@ -165,6 +169,40 @@
         if (e.key === 'Escape' && drawer.getAttribute('data-open') === 'true') closeDrawer()
       })
     }
+    // In-page jump links (#feature-*, #pricing, …). `scroll-behavior:smooth` on
+    // <html> makes browsers skip the automatic scroll-to-fragment on load, so we
+    // run it ourselves after layout settles, and intercept same-page anchor
+    // clicks so every "jump to feature" link lands reliably. :target's
+    // scroll-margin-top keeps the destination clear of the sticky nav.
+    // Use window.scrollTo with behavior:'instant', not el.scrollIntoView or CSS
+    // smooth: an overflow-x:hidden wrapper makes scrollIntoView hit the wrong
+    // scroll container, and behavior:'auto' defers to scroll-behavior:smooth
+    // which that wrapper silently cancels. 72px clears the sticky nav (matches
+    // :target scroll-margin-top). Instant is fine for a "jump to feature" link.
+    var NAV_OFFSET = 72
+    var scrollToHash = function (hash) {
+      if (!hash || hash === '#') return false
+      var el = document.getElementById(decodeURIComponent(hash.slice(1)))
+      if (!el) return false
+      var top = el.getBoundingClientRect().top + window.scrollY - NAV_OFFSET
+      window.scrollTo({ top: top < 0 ? 0 : top, behavior: 'instant' })
+      return true
+    }
+    if (location.hash) {
+      window.addEventListener('load', function () {
+        requestAnimationFrame(function () { scrollToHash(location.hash) })
+      })
+    }
+    document.addEventListener('click', function (e) {
+      var a = e.target.closest && e.target.closest('a[href*="#"]')
+      if (!a) return
+      var url = new URL(a.href, location.href)
+      if (url.pathname !== location.pathname || url.search !== location.search || !url.hash) return
+      if (!scrollToHash(url.hash)) return
+      e.preventDefault()
+      history.pushState(null, '', url.hash)
+    })
+
     // Follow OS changes only while the user hasn't picked a theme.
     try {
       window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -132,6 +132,8 @@ const ogImage = new URL(image, Astro.site).toString()
     }
     *{margin:0;padding:0;box-sizing:border-box}
     html{scroll-behavior:smooth}
+    /* keep in-page jump targets clear of the sticky 64px nav */
+    :target{scroll-margin-top:84px}
     body{
       background:var(--bg);
       color:var(--fg);


### PR DESCRIPTION
## What & why

Two landing-page fixes.

### 1. Gallery screenshots rendered blank / broken (image height too tall)
The hero gallery marquee showed **tall empty cards** — the browser-bar header
rendered but the screenshot body stayed blank, so cards looked broken.

Root cause: the marquee `<img>`s used `loading="lazy"` + `decoding="async"`
inside a **continuously-animating** marquee. The images loaded (`complete:true`,
valid `naturalWidth`) but the bitmap never painted during the decode window
while the marquee translated — leaving a tall box (`aspect-ratio:16/9.6`
reserves height before paint) with no image.

**Fix:** load the visible marquee set eagerly with synchronous decode
(`loading="eager" decoding="sync"`). The `aria-hidden` duplicate set stays lazy
and is served from HTTP cache (same URLs), so no extra bandwidth.

### 2. New "Features" menu with jump links
Replaced the `Product` nav dropdown with a comprehensive **Features** menu
listing every feature and linking to it: AI Agent, Query monitoring, Cluster
topology, Data Explorer, Health, Capabilities. Added anchor ids
(`#feature-ai-agent`, `#feature-queries`, `#feature-topology`) to the feature
blocks. Mirrored in the mobile drawer.

**In-page jump reliability fix:** `scroll-behavior:smooth` on `<html>` makes
browsers skip the on-load scroll-to-fragment, and an `overflow-x:hidden` wrapper
makes `scrollIntoView` / `behavior:'auto'` target the wrong scroll container (a
silent no-op). Added a small handler that scrolls explicitly
(`window.scrollTo`, instant, 72px nav offset) on load and on same-page anchor
clicks, plus `:target{scroll-margin-top}` as a CSS fallback.

## Verification (Chrome)
- All gallery cards (Overview, Cluster Topology, Health Summary, AI Agent,
  Cluster Insights, Running Queries, …) render their screenshots — no blank
  cards.
- Features dropdown shows all 6 features with descriptions.
- Cold-load `/#feature-topology` lands exactly on "See the whole cluster at a
  glance" (target top = 72px, below sticky nav).
- In-page click on Features → Health scrolls to the Health section correctly.
- `bun run build` (landing) passes; `bun run lint` clean for changed files.

Note: repo-wide `bun run test` has 4 pre-existing `withQueryParams` failures
(`@chm/sql-builder`, from #2131) unrelated to this landing-only change.

Co-Authored-By: duyetbot <bot@duyet.net>