### PR TITLE
fix(cron): fail closed when CRON_SECRET is unset

### DIFF
--- a/apps/dashboard/src/routes/api/cron/__tests__/health-sweep.test.ts
+++ b/apps/dashboard/src/routes/api/cron/__tests__/health-sweep.test.ts
@@ -1,13 +1,14 @@
 /**
  * Tests for CRON_SECRET authorization in health-sweep.ts
  *
- * The route's `isAuthorized()` is not exported, so we verify the security
+ * The route's `authorizeCron()` is not exported, so we verify the security
  * contract in two layers:
  *
  *   1. Structural — read the source and assert that:
  *        - `secretsMatch` is imported from the constant-time module
  *        - no bare `===` comparison against the secret remains
  *        - both the Authorization header and `?secret=` query paths use it
+ *        - the endpoint fails closed (503) when CRON_SECRET is unset
  *
  *   2. Behavioral — test `secretsMatch` (the comparator used by the route)
  *      directly: correct secret passes, wrong secret is rejected, empty
@@ -58,9 +59,15 @@ describe('health-sweep.ts CRON_SECRET authorization (structural)', () => {
     expect(SOURCE).not.toMatch(/searchParams\.get\(['"]secret['"]\) ===/)
   })
 
-  test('preserves the open-when-unset guard (if (!secret) return true)', () => {
-    // Intentional: when CRON_SECRET is not configured the endpoint is open.
-    expect(SOURCE).toMatch(/if\s*\(!secret\)\s*return true/)
+  test('fails closed when CRON_SECRET is unset (503, not open)', () => {
+    // Security (issue #2135): when CRON_SECRET is not configured the endpoint
+    // must DENY the request, not allow it. The old insecure guard
+    // (`if (!secret) return true`) must be gone.
+    expect(SOURCE).not.toMatch(/if\s*\(!secret\)\s*return true/)
+    // The unset branch returns a 503 with a JSON error body.
+    expect(SOURCE).toMatch(/if\s*\(!secret\)/)
+    expect(SOURCE).toContain("error: 'CRON_SECRET not configured'")
+    expect(SOURCE).toMatch(/status:\s*503/)
   })
 })
 

--- a/apps/dashboard/src/routes/api/cron/health-sweep.ts
+++ b/apps/dashboard/src/routes/api/cron/health-sweep.ts
@@ -9,7 +9,15 @@
  *
  * Guarded by a shared secret (CRON_SECRET) supplied via the `Authorization:
  * Bearer <secret>` header or the `?secret=` query param. Returns 401 on
- * mismatch. When CRON_SECRET is unset the endpoint is open (no secret to check).
+ * mismatch.
+ *
+ * CRON_SECRET is REQUIRED for this route: when it is unset/empty the endpoint
+ * FAILS CLOSED with HTTP 503 (it does NOT run). The platform routes Cloudflare
+ * scheduled events to the fetch handler as a plain GET with no distinguishable,
+ * trusted in-request signal, so there is no safe "internal cron only" path — an
+ * unauthenticated caller would otherwise trigger the sweep and its webhook
+ * fan-out. Operators MUST configure CRON_SECRET and pass it from their scheduler
+ * (see docs).
  *
  * Ported from apps/dashboard/app/api/cron/health-sweep/route.ts (Next.js).
  * Differences from the Next version:
@@ -24,30 +32,48 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { env } from 'cloudflare:workers'
-import { error } from '@chm/logger'
+import { error, warn } from '@chm/logger'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { secretsMatch } from '@/lib/auth/providers/constant-time'
 import { runHealthSweep } from '@/lib/health/server-sweep'
 
-function isAuthorized(request: Request): boolean {
+/**
+ * Authorize a cron request. Returns a short-circuit `Response` when the request
+ * must be rejected, or `null` when it is authorized to proceed.
+ *
+ * Fail-closed: when CRON_SECRET is unset/empty we return 503 (not configured)
+ * instead of allowing the request through.
+ */
+function authorizeCron(request: Request): Response | null {
   const bindings = env as Record<string, string | undefined>
   const secret = (bindings.CRON_SECRET ?? process.env.CRON_SECRET)?.trim()
-  if (!secret) return true
+
+  // Fail closed: without a configured secret this endpoint is disabled rather
+  // than left open to unauthenticated callers (which could trigger the sweep
+  // and its webhook fan-out).
+  if (!secret) {
+    warn(
+      '[GET /api/cron/health-sweep] CRON_SECRET not configured — refusing (503). Set CRON_SECRET to enable this endpoint.'
+    )
+    return Response.json(
+      { error: 'CRON_SECRET not configured' },
+      { status: 503 }
+    )
+  }
 
   const authHeader = request.headers.get('authorization')
-  if (authHeader && secretsMatch(authHeader, `Bearer ${secret}`)) return true
+  if (authHeader && secretsMatch(authHeader, `Bearer ${secret}`)) return null
 
   const url = new URL(request.url)
   const querySecret = url.searchParams.get('secret')
-  if (querySecret && secretsMatch(querySecret, secret)) return true
+  if (querySecret && secretsMatch(querySecret, secret)) return null
 
-  return false
+  return Response.json({ error: 'Unauthorized' }, { status: 401 })
 }
 
 async function handler(request: Request): Promise<Response> {
-  if (!isAuthorized(request)) {
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const denied = authorizeCron(request)
+  if (denied) return denied
 
   // Copy CLICKHOUSE_* from the Worker binding onto process.env so
   // getClickHouseConfigs() (inside runHealthSweep) can resolve hosts.

--- a/apps/dashboard/src/routes/api/cron/retention-prune.ts
+++ b/apps/dashboard/src/routes/api/cron/retention-prune.ts
@@ -18,7 +18,15 @@
  *
  * Guarded by a shared secret (CRON_SECRET) supplied via the `Authorization:
  * Bearer <secret>` header or the `?secret=` query param. Returns 401 on
- * mismatch. When CRON_SECRET is unset the endpoint is open (no secret to check).
+ * mismatch.
+ *
+ * CRON_SECRET is REQUIRED for this route: when it is unset/empty the endpoint
+ * FAILS CLOSED with HTTP 503 (it does NOT run). This is a destructive endpoint
+ * (it DELETEs conversation rows), and the platform routes Cloudflare scheduled
+ * events to the fetch handler as a plain GET with no distinguishable, trusted
+ * in-request signal, so there is no way to safely allow an "internal cron only"
+ * path — an unauthenticated caller would otherwise trigger deletion. Operators
+ * MUST configure CRON_SECRET and pass it from their scheduler (see docs).
  *
  * Graceful no-op when CHM_CLOUD_D1 is not bound (OSS / non-CF environments).
  */
@@ -26,31 +34,48 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { env } from 'cloudflare:workers'
-import { error, log } from '@chm/logger'
+import { error, log, warn } from '@chm/logger'
 import { getPlatformBindings } from '@chm/platform'
 import { secretsMatch } from '@/lib/auth/providers/constant-time'
 import { retentionCutoffMs } from '@/lib/billing/entitlements'
 import { resolveRetentionPlanForUser } from '@/lib/billing/retention-owner'
 
-function isAuthorized(request: Request): boolean {
+/**
+ * Authorize a cron request. Returns a short-circuit `Response` when the request
+ * must be rejected, or `null` when it is authorized to proceed.
+ *
+ * Fail-closed: when CRON_SECRET is unset/empty we return 503 (not configured)
+ * instead of allowing the request through.
+ */
+function authorizeCron(request: Request): Response | null {
   const bindings = env as Record<string, string | undefined>
   const secret = (bindings.CRON_SECRET ?? process.env.CRON_SECRET)?.trim()
-  if (!secret) return true
+
+  // Fail closed: without a configured secret this destructive endpoint is
+  // disabled rather than left open to unauthenticated callers.
+  if (!secret) {
+    warn(
+      '[GET /api/cron/retention-prune] CRON_SECRET not configured — refusing (503). Set CRON_SECRET to enable this endpoint.'
+    )
+    return Response.json(
+      { error: 'CRON_SECRET not configured' },
+      { status: 503 }
+    )
+  }
 
   const authHeader = request.headers.get('authorization')
-  if (authHeader && secretsMatch(authHeader, `Bearer ${secret}`)) return true
+  if (authHeader && secretsMatch(authHeader, `Bearer ${secret}`)) return null
 
   const url = new URL(request.url)
   const querySecret = url.searchParams.get('secret')
-  if (querySecret && secretsMatch(querySecret, secret)) return true
+  if (querySecret && secretsMatch(querySecret, secret)) return null
 
-  return false
+  return Response.json({ error: 'Unauthorized' }, { status: 401 })
 }
 
 async function handler(request: Request): Promise<Response> {
-  if (!isAuthorized(request)) {
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const denied = authorizeCron(request)
+  if (denied) return denied
 
   // Graceful no-op: D1 not bound (OSS / local dev / non-CF environment)
   let db: D1Database | null = null

--- a/docs/content/guide/features/health.mdx
+++ b/docs/content/guide/features/health.mdx
@@ -94,13 +94,13 @@ The health-sweep endpoint runs checks over all configured hosts and sends a webh
 
 | Variable | Default | Description |
 |---|---|---|
-| `CRON_SECRET` | (unset = open) | Guards `GET /api/cron/health-sweep`. Pass as `Authorization: Bearer <secret>`. **Setting this is strongly recommended** — without it the endpoint is publicly accessible to anyone who can reach your deployment. |
+| `CRON_SECRET` | (unset = **endpoint disabled**) | **Required.** Guards `GET /api/cron/health-sweep` and `GET /api/cron/retention-prune`. Pass as `Authorization: Bearer <secret>` (or `?secret=<secret>`). When it is **unset/empty the endpoints fail closed and return HTTP 503** — they do not run. Note that `retention-prune` is **destructive** (it deletes conversation rows past each plan's retention window), which is why these routes refuse to run unauthenticated. |
 | `HEALTH_ALERT_ENABLED` | `false` | Set to `true` to enable webhook dispatch. |
 | `HEALTH_ALERT_WEBHOOK_URL` | (required if enabled) | Slack or Discord incoming webhook URL. Payload is a JSON object with a `text` field. |
 | `HEALTH_ALERT_MIN_SEVERITY` | `warning` | Minimum severity that triggers a notification. Values: `warning` or `critical`. |
 
-<Callout type="warn" title="Secure the sweep endpoint">
-Without `CRON_SECRET`, the `/api/cron/health-sweep` endpoint is publicly accessible. Set it and pass it as `Authorization: Bearer <secret>` from your cron caller.
+<Callout type="warn" title="CRON_SECRET is required">
+`CRON_SECRET` is **required** for the cron endpoints. When it is unset, `/api/cron/health-sweep` and `/api/cron/retention-prune` **fail closed and return HTTP 503** (they do not run) — `retention-prune` is destructive, so it must never be reachable unauthenticated. Set `CRON_SECRET` and pass it as `Authorization: Bearer <secret>` from your cron caller.
 </Callout>
 
 <Steps>
@@ -147,7 +147,7 @@ In `wrangler.toml`:
 crons = ["*/5 * * * *"]
 ```
 
-The cron handler calls the health-sweep logic directly — no HTTP hop needed when running inside the same Worker.
+The Cloudflare scheduled trigger is routed to the route's `GET` handler. Because that handler now **requires** `CRON_SECRET` (it returns HTTP 503 when unset), make sure the secret is configured before relying on the schedule, and invoke the endpoint with the `Authorization: Bearer <secret>` header (or `?secret=<secret>`) so the request is authorized — e.g. from an external scheduler, or a Worker Cron that forwards the secret. An unauthenticated scheduled hit will be rejected by design.
 
 ## Notes & limitations
 

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -113,7 +113,7 @@ browser tab open.
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `CRON_SECRET` | — | Shared secret guarding `/api/cron/health-sweep`. Send as `Authorization: Bearer <secret>`. When unset, the endpoint is open. |
+| `CRON_SECRET` | — | **Required** shared secret guarding the cron endpoints `/api/cron/health-sweep` and `/api/cron/retention-prune`. Send as `Authorization: Bearer <secret>` (or `?secret=<secret>`). When unset/empty the endpoints **fail closed and return HTTP 503** (they do not run) — `retention-prune` is destructive, so it must not be reachable unauthenticated. |
 | `HEALTH_ALERT_ENABLED` | `false` | Set `true` to POST webhook alerts. Checks run regardless; alerts only fire when `true`. |
 | `HEALTH_ALERT_WEBHOOK_URL` | — | Slack- or Discord-compatible webhook URL. Required for alerts to be dispatched. |
 | `HEALTH_ALERT_MIN_SEVERITY` | `warning` | Minimum severity to alert: `warning` (warning + critical) or `critical` (critical only). |


### PR DESCRIPTION
## Summary

The cron routes previously treated an **unset `CRON_SECRET` as authorized** (`if (!secret) return true`), leaving the destructive `retention-prune` DELETE and the `health-sweep` webhook fan-out reachable unauthenticated. They now **fail closed**. Closes #2135.

## Changes

- `apps/dashboard/src/routes/api/cron/retention-prune.ts` & `health-sweep.ts`: when `CRON_SECRET` is unset/empty, return `503 { error: 'CRON_SECRET not configured' }` + a warning log instead of running. Behavior with the secret set (Bearer header / `?secret=` via constant-time `secretsMatch`) is unchanged; the D1-not-bound no-op is preserved. Misleading docstrings rewritten.
- `docs/content/guide/features/health.mdx`, `docs/content/reference/environment-variables.mdx`: document that `CRON_SECRET` is now **required** for these routes and that `retention-prune` is destructive.

## Test plan

- [ ] `bun run lint`
- [ ] `bun run build` (`tsc --noEmit`) — not run in the authoring env (no `node_modules`)
- [ ] `bun run test:unit` (updated `__tests__/health-sweep.test.ts`)

## Notes for reviewer

⚠️ **Behavior change — needs a deploy decision before merge.** The `@cloudflare/vite-plugin` routes the `[triggers]` cron to the fetch handler as a plain GET with no trusted "internal scheduled" signal, so `CRON_SECRET` is now effectively required and the scheduled invocation must carry it (external scheduler, or a Worker that forwards `Authorization: Bearer <secret>`). Deployments that never set `CRON_SECRET` will get 503 until they configure it. Please confirm how the production trigger will pass the secret (or add a dedicated `scheduled()` handler) before merging.

---

Co-Authored-By: duyetbot <bot@duyet.net>

---
_Generated by [Claude Code](https://claude.ai/code/session_0192Hi19HxYxuqr95RYS2kh5)_