### PR TITLE
fix(security): add readonly to browser-connection proxy + report-only CSP

### DIFF
--- a/apps/dashboard/src/lib/security-headers.test.ts
+++ b/apps/dashboard/src/lib/security-headers.test.ts
@@ -13,8 +13,17 @@ describe('SECURITY_HEADERS', () => {
     )
   })
 
-  test('has exactly 4 entries (no accidental additions)', () => {
-    expect(Object.keys(SECURITY_HEADERS)).toHaveLength(4)
+  test('ships CSP in report-only mode (never enforced)', () => {
+    const csp = SECURITY_HEADERS['Content-Security-Policy-Report-Only']
+    expect(csp).toBeDefined()
+    expect(csp).toContain("default-src 'self'")
+    expect(csp).toContain("frame-ancestors 'none'")
+    // Enforcing CSP must NOT be set — report-only only, pending validation.
+    expect(SECURITY_HEADERS['Content-Security-Policy']).toBeUndefined()
+  })
+
+  test('has exactly 5 entries (no accidental additions)', () => {
+    expect(Object.keys(SECURITY_HEADERS)).toHaveLength(5)
   })
 })
 

--- a/apps/dashboard/src/lib/security-headers.ts
+++ b/apps/dashboard/src/lib/security-headers.ts
@@ -2,17 +2,42 @@
  * Security response headers applied to every response.
  *
  * Covers MIME-sniffing protection, clickjacking prevention, referrer
- * information leakage, and feature gating. CSP is intentionally omitted —
- * the app loads remote scripts (Clerk, analytics) and constructing a strict
- * CSP would require ongoing maintenance that outweighs the benefit at this
- * stage.
+ * information leakage, and feature gating.
+ *
+ * CSP is shipped in **report-only** mode (`Content-Security-Policy-Report-Only`)
+ * on purpose: report-only never blocks a resource, so it cannot break the app.
+ * It lets us observe (via the browser console) whether this policy would flag
+ * any legitimate resource before we ever switch to an enforcing
+ * `Content-Security-Policy`. The policy is deliberately conservative:
+ *   - Users connect to arbitrary ClickHouse hosts and we load Clerk + Sentry,
+ *     so `connect-src` allows any https/wss origin to avoid false positives.
+ *   - `script-src`/`style-src` allow `'unsafe-inline'` (and `'unsafe-eval'`)
+ *     because the Vite/React runtime and Clerk currently need them.
+ *   - `frame-ancestors 'none'` mirrors `X-Frame-Options: DENY`.
+ * TODO: tighten and promote to an enforcing header once report-only shows the
+ * policy does not flag legitimate resources in production.
  */
+const CSP_REPORT_ONLY = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https:",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data:",
+  "connect-src 'self' https: wss:",
+  "worker-src 'self' blob:",
+  "frame-src 'self' https:",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+].join('; ')
 
 export const SECURITY_HEADERS: Record<string, string> = {
   'X-Content-Type-Options': 'nosniff',
   'X-Frame-Options': 'DENY',
   'Referrer-Policy': 'strict-origin-when-cross-origin',
   'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+  // Report-only: observed, never enforced — safe to ship (see comment above).
+  'Content-Security-Policy-Report-Only': CSP_REPORT_ONLY,
 }
 
 /**

--- a/apps/dashboard/src/routes/api/v1/browser-connections/proxy.ts
+++ b/apps/dashboard/src/routes/api/v1/browser-connections/proxy.ts
@@ -136,6 +136,11 @@ async function handlePost(request: Request): Promise<Response> {
       query,
       query_params,
       format: format as DataFormat,
+      // SECURITY: Enforce readonly mode to prevent DML/DDL even if SQL
+      // validation is bypassed — defense-in-depth, matching /api/v1/data.
+      clickhouse_settings: {
+        readonly: '1',
+      },
     })
 
     const rows = await result.json<unknown[]>()


### PR DESCRIPTION
## Summary

Two defense-in-depth hardening changes. Closes #2136.

## Changes

- `apps/dashboard/src/routes/api/v1/browser-connections/proxy.ts`: add `clickhouse_settings: { readonly: '1' }` to the caller-SQL `client.query(...)` call (matches `/api/v1/data`), so a validator bypass still can't mutate.
- `apps/dashboard/src/lib/security-headers.ts`: add a **`Content-Security-Policy-Report-Only`** header (non-enforcing, cannot break the app) with a conservative policy (`default-src 'self'`; inline styles/scripts for Vite/React/Clerk; `img-src data:/blob:/https:`; `connect-src 'self' https: wss:` to cover arbitrary user ClickHouse hosts + Sentry + Clerk; `frame-ancestors 'none'`).
- `apps/dashboard/src/lib/security-headers.test.ts`: updated header-count assertion + report-only checks.

## Test plan

- [ ] `bun run lint`
- [ ] `bun run build` — not run locally
- [ ] `bun run test:unit`
- [ ] Manual: proxy still returns SELECT results with readonly set; CSP report-only reports no violations for legitimate resources

## Notes for reviewer

Best-effort hardening (per issue). The CSP is intentionally **report-only** — validate in a real browser session (Clerk/Sentry/fonts/inline/ClickHouse connections) before promoting to an enforcing `Content-Security-Policy`. No `report-uri`/`report-to` is configured yet, so violations surface only in the browser console.

---

Co-Authored-By: duyetbot <bot@duyet.net>

---
_Generated by [Claude Code](https://claude.ai/code/session_0192Hi19HxYxuqr95RYS2kh5)_