### PR TITLE
fix(alerting): re-fire slow-query regression alerts each minute

### DIFF
--- a/apps/dashboard/src/components/alerting/regression-panel.tsx
+++ b/apps/dashboard/src/components/alerting/regression-panel.tsx
@@ -38,22 +38,26 @@ export function RegressionPanel({ hostId, className }: RegressionPanelProps) {
 
   const rows: SlowQueryRegression[] = Array.isArray(data) ? data : []
 
+  // Per-minute bucket so an ongoing regression re-alerts each minute, and a
+  // content signature so the effect re-runs when the worst factor changes.
+  const minuteBucket = Math.floor(Date.now() / 60_000)
+  const worstFactor = rows.length
+    ? Math.max(...rows.map((r) => r.regression_factor))
+    : 0
+
   // Fire an alert whenever regressions are detected, deduped by incidentId.
   useEffect(() => {
     if (rows.length === 0) return
-    const worst = rows.reduce((a, b) =>
-      a.regression_factor > b.regression_factor ? a : b
-    )
     void dispatchAlert({
       checkId: 'slow-query-regression',
       title: 'Slow Query Regression Detected',
-      severity: worst.regression_factor >= 5 ? 'critical' : 'warning',
+      severity: worstFactor >= 5 ? 'critical' : 'warning',
       value: rows.length,
-      label: `${rows.length} fingerprint${rows.length === 1 ? '' : 's'} regressed — worst: ${worst.regression_factor}× slower`,
+      label: `${rows.length} fingerprint${rows.length === 1 ? '' : 's'} regressed — worst: ${worstFactor}× slower`,
       hostId,
-      incidentId: `sqr-${hostId}-${Math.floor(Date.now() / 60_000)}`,
+      incidentId: `sqr-${hostId}-${minuteBucket}`,
     })
-  }, [rows.length, hostId, rows.reduce]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [hostId, rows.length, worstFactor, minuteBucket])
 
   if (isLoading) return null
   if (error || rows.length === 0) return null


### PR DESCRIPTION
## Summary

The slow-query regression alert only fired once at mount because its `useEffect` dep array included `rows.reduce` (a stable `Array.prototype` reference — a dead dep), so it never re-ran across the per-minute `incidentId` buckets it was designed for. Closes #2137.

## Changes

- `apps/dashboard/src/components/alerting/regression-panel.tsx`: hoist `minuteBucket = Math.floor(Date.now()/60_000)` and `worstFactor` above the effect; deps are now `[hostId, rows.length, worstFactor, minuteBucket]`; dropped the meaningless `rows.reduce` and the `eslint-disable exhaustive-deps` comment. Alert content/behavior otherwise identical.

## Test plan

- [ ] `bun run lint`
- [ ] `bun run build` — not run locally
- [ ] `bun run test:unit`

## Notes for reviewer

No co-located test existed for this component. `worstFactor` reproduces the previous `reduce`-derived worst value (`regression_factor` is a number).

---

Co-Authored-By: duyetbot <bot@duyet.net>

---
_Generated by [Claude Code](https://claude.ai/code/session_0192Hi19HxYxuqr95RYS2kh5)_