### PR TITLE
fix(query-config): drop unverified last_error_* columns from errors 25.12 variant

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/more/errors.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/more/errors.ts
@@ -13,6 +13,19 @@ export const errorsDeclarative: DeclarativeQueryConfig = {
   description: 'System error logs and history',
   optional: true,
   tableCheck: 'system.error_log',
+  // NOTE (issue #2138): A previous `since: '25.12'` variant SELECTed
+  // last_error_time / last_error_message / last_error_query_id /
+  // last_error_trace FROM system.error_log. In verified ClickHouse versions
+  // those `last_error_*` columns belong to the AGGREGATED system.errors table
+  // (see queries/common-errors.ts), NOT the per-event system.error_log
+  // (hostname, event_date, event_time, code, error, value, remote). A
+  // non-existent column makes ClickHouse fail the ENTIRE query on servers, and
+  // the table-validator checks table existence, not columns, so it cannot save
+  // this. The variant was removed as a conservative fix (a broken variant is
+  // worse than a missing feature). If a maintainer confirms on a live 25.12+
+  // server that system.error_log actually exposes these `last_error_*` columns,
+  // the variant may be re-added here (sourced from the correct table).
+  // Keep this file in sync with more/errors.ts (the imperative mirror).
   sql: [
     {
       since: '23.8',
@@ -29,26 +42,6 @@ export const errorsDeclarative: DeclarativeQueryConfig = {
       ${errorsTail}
   `,
     },
-    {
-      since: '25.12',
-      description:
-        'Added last_error_time, last_error_message, last_error_query_id, last_error_trace (CH 25.12+)',
-      sql: `
-      SELECT
-          event_time,
-          event_date,
-          code,
-          error,
-          value,
-          remote,
-          hostname,
-          last_error_time,
-          last_error_message,
-          last_error_query_id,
-          last_error_trace
-      ${errorsTail}
-  `,
-    },
   ],
   columns: [
     'event_time',
@@ -58,30 +51,12 @@ export const errorsDeclarative: DeclarativeQueryConfig = {
     'value',
     'remote',
     'hostname',
-    'last_error_time',
-    'last_error_message',
-    'last_error_query_id',
   ],
   columnFormats: {
     error: ['link', { href: `?error=[error]` }],
     remote: 'boolean',
-    last_error_query_id: [
-      'link',
-      {
-        href: '/query?query_id=[last_error_query_id]&host=[ctx.hostId]',
-        className: 'truncate max-w-48',
-        title: 'View query detail',
-      },
-    ],
-    last_error_time: 'related-time',
   },
   defaultParams: { error: '' },
-  // config-details expandable: auto-renders all non-primary columns in a detail grid,
-  // including last_error_message and last_error_trace from CH 25.12+.
-  expandable: {
-    type: 'config-details',
-    primaryColumns: ['event_time', 'code', 'error', 'value', 'remote'],
-  },
   filterParamPresets: [
     { name: 'KEEPER_EXCEPTION', key: 'error', value: 'KEEPER_EXCEPTION' },
     {

--- a/apps/dashboard/src/lib/query-config/more/errors.ts
+++ b/apps/dashboard/src/lib/query-config/more/errors.ts
@@ -1,6 +1,5 @@
 import type { QueryConfig, VersionedSql } from '@/types/query-config'
 
-import { createExpandedPanel } from '@/components/data-table/cells/expanded-panel'
 import { ColumnFormat } from '@/types/column-format'
 
 /** Base WHERE predicate shared across all version variants. */
@@ -17,6 +16,18 @@ export const errorsConfig: QueryConfig = {
   description: 'System error logs and history',
   optional: true,
   tableCheck: 'system.error_log',
+  // NOTE (issue #2138): A previous `since: '25.12'` variant SELECTed
+  // last_error_time / last_error_message / last_error_query_id /
+  // last_error_trace FROM system.error_log. In verified ClickHouse versions
+  // those `last_error_*` columns belong to the AGGREGATED system.errors table
+  // (see queries/common-errors.ts), NOT the per-event system.error_log
+  // (hostname, event_date, event_time, code, error, value, remote). A
+  // non-existent column makes ClickHouse fail the ENTIRE query on servers, and
+  // the table-validator checks table existence, not columns, so it cannot save
+  // this. The variant was removed as a conservative fix (a broken variant is
+  // worse than a missing feature). If a maintainer confirms on a live 25.12+
+  // server that system.error_log actually exposes these `last_error_*` columns,
+  // the variant may be re-added here (sourced from the correct table).
   sql: [
     {
       since: '23.8',
@@ -33,26 +44,6 @@ export const errorsConfig: QueryConfig = {
       ${errorsTail}
   `,
     },
-    {
-      since: '25.12',
-      description:
-        'Added last_error_time, last_error_message, last_error_query_id, last_error_trace (CH 25.12+)',
-      sql: `
-      SELECT
-          event_time,
-          event_date,
-          code,
-          error,
-          value,
-          remote,
-          hostname,
-          last_error_time,
-          last_error_message,
-          last_error_query_id,
-          last_error_trace
-      ${errorsTail}
-  `,
-    },
   ] as VersionedSql[],
   columns: [
     'event_time',
@@ -62,49 +53,12 @@ export const errorsConfig: QueryConfig = {
     'value',
     'remote',
     'hostname',
-    'last_error_time',
-    'last_error_message',
-    'last_error_query_id',
   ],
   columnFormats: {
     error: [ColumnFormat.Link, { href: `?error=[error]` }],
     remote: ColumnFormat.Boolean,
-    last_error_query_id: [
-      ColumnFormat.Link,
-      {
-        href: '/query?query_id=[last_error_query_id]&host=[ctx.hostId]',
-        className: 'truncate max-w-48',
-        title: 'View query detail',
-      },
-    ],
-    last_error_time: ColumnFormat.RelatedTime,
   },
   defaultParams: { error: '' },
-  // Row expansion shows last error message + trace + query link (CH 25.12+ only)
-  expandable: {
-    renderExpanded: createExpandedPanel({
-      sections: [
-        {
-          type: 'fields',
-          title: 'Last Error Details',
-          columns: [
-            { key: 'last_error_time', label: 'Last error time' },
-            { key: 'last_error_query_id', label: 'Query ID' },
-          ],
-        },
-        {
-          type: 'code',
-          title: 'Last error message',
-          column: 'last_error_message',
-        },
-        {
-          type: 'code',
-          title: 'Stack trace',
-          column: 'last_error_trace',
-        },
-      ],
-    }),
-  },
   // Common ClickHouse error types for quick filtering
   // These are frequently occurring errors in production environments
   // Future improvement: fetch distinct error types dynamically from system.error_log


### PR DESCRIPTION
## Summary

The `errors` config's `since: '25.12'` variant selected `last_error_time/_message/_query_id/_trace` **FROM `system.error_log`**, but those columns belong to the aggregated `system.errors` table — a non-existent column fails the whole query on servers ≥ 25.12 (the table-validator checks table existence, not columns). Closes #2138.

## Changes

- `apps/dashboard/src/lib/query-config/more/errors.ts` and its `declarative/catalog/more/errors.ts` mirror: removed the `25.12` variant (leaving the base `23.8` variant valid on all versions), removed the four `last_error_*` names from `columns`, dropped the now-dead column formats / expandable panel, and added a comment referencing this issue.

## Test plan

- [ ] `bun run lint`
- [ ] `bun run build` — not run locally
- [ ] `bun run test:query-config` (`more-catalog.test.ts` asserts declarative≡imperative; both files changed identically)

## Notes for reviewer

⚠️ **Best-effort, verification needed.** There is no `docs/clickhouse-schemas/tables/error_log.md` to confirm the schema. Corroborating evidence: `queries/common-errors.ts` selects `last_error_*` explicitly `FROM system.errors`. If a maintainer confirms `system.error_log` *does* expose these at 25.12, re-add the variant sourced from the correct table.

---

Co-Authored-By: duyetbot <bot@duyet.net>

---
_Generated by [Claude Code](https://claude.ai/code/session_0192Hi19HxYxuqr95RYS2kh5)_