### PR TITLE
fix(chart-scale): report hasZeroOrNegative correctly and remove dead branch

### DIFF
--- a/apps/dashboard/src/lib/chart-scale.test.ts
+++ b/apps/dashboard/src/lib/chart-scale.test.ts
@@ -121,12 +121,13 @@ describe('analyzeDataForLogScale', () => {
   test('all values zero or negative — maxValue reflects actual max, no log scale', () => {
     const data = [{ v: 0 }, { v: -5 }, { v: -1 }]
     const result = analyzeDataForLogScale(data, ['v'])
-    // minPositive stays Infinity → first branch triggers
+    // minPositive stays Infinity → edge-case branch triggers
     expect(result.shouldUseLog).toBe(false)
     expect(result.minValue).toBe(0)
     expect(result.maxValue).toBe(0)
     expect(result.ratio).toBe(1)
-    expect(result.hasZeroOrNegative).toBe(false) // first branch returns this
+    // The loop set hasZeroOrNegative=true; the edge-case branch now reports it
+    expect(result.hasZeroOrNegative).toBe(true)
   })
 
   test('multiple categories are all analyzed', () => {

--- a/apps/dashboard/src/lib/chart-scale.ts
+++ b/apps/dashboard/src/lib/chart-scale.ts
@@ -47,25 +47,16 @@ export function analyzeDataForLogScale(
     }
   }
 
-  // Handle edge cases
+  // Handle edge cases: no positive values (all zero/negative) or no numeric
+  // values at all. Report the actual accumulated hasZeroOrNegative so all-zero/
+  // negative input is not mislabelled as false.
   if (minPositive === Infinity || maxValue === -Infinity) {
     return {
       shouldUseLog: false,
       minValue: 0,
       maxValue: 0,
       ratio: 1,
-      hasZeroOrNegative: false,
-    }
-  }
-
-  // If all values are zero or negative, don't use log scale
-  if (minPositive === Infinity) {
-    return {
-      shouldUseLog: false,
-      minValue: 0,
-      maxValue,
-      ratio: 1,
-      hasZeroOrNegative: true,
+      hasZeroOrNegative,
     }
   }
 


### PR DESCRIPTION
## Summary

`analyzeDataForLogScale` returned `hasZeroOrNegative: false` for all-zero/negative input (the early edge-case branch hard-coded it), and contained an unreachable `if (minPositive === Infinity)` block already covered by the earlier `||` condition. Closes #2140.

## Changes

- `apps/dashboard/src/lib/chart-scale.ts`: early edge-case branch now returns the accumulated `hasZeroOrNegative`; deleted the unreachable second branch. Return shape unchanged.
- `apps/dashboard/src/lib/chart-scale.test.ts`: all-zero/negative case now asserts `hasZeroOrNegative: true`.

## Test plan

- [ ] `bun run lint`
- [ ] `bun run build` — not run locally
- [ ] `bun run test:unit`

## Notes for reviewer

The flag is currently unread outside tests, so this fixes a latent correctness bug before a future consumer relies on it.

---

Co-Authored-By: duyetbot <bot@duyet.net>

---
_Generated by [Claude Code](https://claude.ai/code/session_0192Hi19HxYxuqr95RYS2kh5)_