### PR TITLE
docs(claude): add apps/dashboard/CLAUDE.md, fix ai-agent.mdx path and toolset description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,11 +321,11 @@ of local files.
 - `cd apps/docs && bun run build` - Full build (sync-docs → generate-og → `vite build`)
 - Edit only `docs/content/**`; the generated `apps/docs/content/docs/**` is regenerated and gitignored.
 
-**IMPORTANT — keep the AI Agent docs in sync**: `docs/content/ai-agent.mdx` is
+**IMPORTANT — keep the AI Agent docs in sync**: `docs/content/guide/ai-agent.mdx` is
 the user-facing reference for the agent's tools, skills, and configuration.
 Whenever you add, rename, or remove an agent tool (`lib/ai/agent/tools/*.ts`), a
 skill (`.agents/skills/*/SKILL.md`), or an agent env var, update
-`docs/content/ai-agent.mdx` in the same change so the docs do not drift.
+`docs/content/guide/ai-agent.mdx` in the same change so the docs do not drift.
 
 ## Architecture
 
@@ -606,6 +606,6 @@ For the app's file layout (routes, data layer, query configs, types), see `apps/
 
 ## AI Agents
 
-The agent subsystem lives at `apps/dashboard/src/lib/ai/agent/` and is built on the **Vercel AI SDK** (not LangGraph). It has 29+ tool categories (schema, query, diagnostics, anomaly, cluster, visualization, etc.) assembled by `tools/index.ts`. Agent prompts are in `lib/ai/agent/prompts/`, skills in `lib/ai/agent/skills/`, and workflows in `lib/ai/agent/workflows/`.
+The agent subsystem lives at `apps/dashboard/src/lib/ai/agent/` and is built on the **Vercel AI SDK** (not LangGraph). It intentionally exposes a lean set of ~21 tools (18 by default; 3 destructive control tools are env-gated off) across 11 tool modules assembled by `tools/index.ts`: `schema-tools`, `query-tools`, `health-tools`, `storage-tools`, `replication-tools`, `merge-tools`, `plan-tools`, `skill-tools`, `ask-user-tools`, `visualization-tools`, and `control-tools`. Anything not covered by a primitive is done with the `query` tool plus a `load_skill` recipe. Agent prompts are in `lib/ai/agent/prompts/`, and the skill registry/loader is in `lib/ai/agent/skills/` (the skills themselves live at repo-root `.agents/skills/`).
 
-For the agent environment variables and configuration, see `apps/dashboard/src/lib/ai/agent/` or `docs/content/ai-agent.mdx`.
+For the agent environment variables and configuration, see `apps/dashboard/src/lib/ai/agent/` or `docs/content/guide/ai-agent.mdx`.

--- a/apps/dashboard/CLAUDE.md
+++ b/apps/dashboard/CLAUDE.md
@@ -1,0 +1,177 @@
+# apps/dashboard — Claude context (app internals)
+
+This is the **primary dashboard app** — a TanStack Start application (React 19 +
+Vite + `@cloudflare/vite-plugin`) that replaced the legacy Next.js app in v0.3.
+It connects to ClickHouse instances and renders real-time monitoring views.
+
+This file documents the **app-internal layout and patterns**. For repo-wide
+conventions (commit style, cloud-vs-OSS mode, deploy, testing, ClickHouse
+version compatibility, the knowledge graph), read the **root
+[`../../CLAUDE.md`](../../CLAUDE.md)** first, and see **[`../../docs/PRD.md`](../../docs/PRD.md)**
+(§10.2) for the product/architecture spec. Package name: `dashboard`; package
+manager is `bun`.
+
+## Directory map (`src/`)
+
+```
+src/
+  router.tsx            TanStack Router instance
+  start.ts              TanStack Start server entry
+  routes/               file-based routes (see below)
+  components/           UI (data-table, charts, host, layout, assistant-ui, …)
+  lib/                  data layer, query configs, AI agent, cloud mode, utils
+  hooks/                app-level React hooks (use-mobile, use-layout-view)
+  db/                   D1 / persistence helpers
+  types/                shared types (query-config.ts, charts.ts, column-format.ts, …)
+  menu.ts               navigation menu configuration
+  styles.css            Tailwind v4 entry
+```
+
+### Routes — `src/routes/`
+
+- **Dashboard pages** live under `src/routes/(dashboard)/` as file-based routes
+  (e.g. `merges.tsx`, `overview.tsx`, `mutations.tsx`, plus nested groups like
+  `queries/`, `keeper/`, `logs/`, `clusters/`). There are 60+ page routes.
+- **API routes** live under `src/routes/api/` (`health.ts`, `mcp.ts`,
+  `version.ts`, `cron/`, `v1/`, …).
+- `__root.tsx`, `index.tsx`, `sign-in.tsx`, `sign-up.tsx`, and `healthz.ts` sit
+  at the routes root.
+- **Multi-host routing** uses the `?host=0` query param (index into the
+  comma-separated `CLICKHOUSE_*` env lists).
+
+Most monitoring pages are thin: they import a `QueryConfig` and hand it to a
+shared `PageLayout` (`components/layout/query-page/`), wrapped in `<Suspense>`
+with a `PageSkeleton`. Example (`routes/(dashboard)/merges.tsx`):
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { Suspense } from 'react'
+import { PageLayout } from '@/components/layout/query-page'
+import { PageSkeleton } from '@/components/skeletons'
+import { pageOgHead } from '@/lib/og'
+import { mergesConfig } from '@/lib/query-config/merges/merges'
+
+function MergesPage() {
+  return (
+    <Suspense fallback={<PageSkeleton />}>
+      <PageLayout queryConfig={mergesConfig} />
+    </Suspense>
+  )
+}
+
+export const Route = createFileRoute('/(dashboard)/merges')({
+  component: MergesPage,
+  head: () => pageOgHead('merges'),
+})
+```
+
+### Data layer — `src/lib/`
+
+- **`lib/clickhouse-helpers.ts`** — `fetchDataWithHost(...)` is the app entry
+  point for running a query. It validates/normalizes `hostId` and delegates to
+  `fetchData` from the workspace client `@chm/clickhouse-client`. **`hostId` is
+  required** for any query (defaults to host `0`); never drop it.
+- **`lib/clickhouse-query.ts`** — query-building helpers (`buildTimeFilter`,
+  `applyInterval`, `withQueryParams`, `fillStep`, …).
+- **Client hooks** — server-state is fetched with TanStack Query hooks:
+  - `lib/swr/` — host/config/data hooks (`use-hosts`, `use-host`,
+    `use-host-status`, `use-merged-hosts`, `api-fetch`, `host-context`, …).
+    `use-merged-hosts.ts` implements cloud demo-host tagging (see root CLAUDE.md
+    "cloud mode").
+  - `lib/hooks/` — feature hooks (agent, MCP config, user connections, settings,
+    performance, keyboard shortcut, …).
+- **`lib/table-validator.ts` + `lib/table-existence-cache.ts`** — guard optional
+  system tables (`system.backup_log`, `system.error_log`, `system.zookeeper`, …)
+  via `optional: true` / `tableCheck` on a `QueryConfig`.
+
+### Query configs — `src/lib/query-config/`
+
+Each data view is a `QueryConfig` (type in **`src/types/query-config.ts`**;
+runtime types re-exported from `lib/query-config/types.ts`). Configs are grouped
+by domain (`merges/`, `queries/`, `tables/`, `system/`, `logs/`, `keeper/`,
+`security/`, `explorer/`, `anomaly/`, `more/`, plus a `declarative/` catalog) and
+registered centrally in **`lib/query-config/index.ts`**. A config carries the
+SQL (a string or a versioned `{ since, sql }[]` array — see the root CLAUDE.md
+ClickHouse-version section), column formatting, sorting/filtering, and row
+actions.
+
+### Components — `src/components/`
+
+- **`components/data-table/`** — the table system: `column-defs/`, `cells/`,
+  `formatters/`, `sorting-fns.ts`, filters, pagination, row-expand, toolbar.
+  Synthetic column ids `__expand`, `select`, `action` are non-data columns.
+- **`components/charts/`** — chart system. `chart-container.tsx`,
+  `chart-card-styles.ts`, `chart-error.tsx`, `chart-stale-indicator.tsx`,
+  `chart-registry.tsx`, plus per-domain chart folders (`merge/`, `query/`,
+  `logs/`, `query-performance/`, `primitives/`, `factory/`). Follow the
+  graceful-error / stale-indicator pattern documented in the root CLAUDE.md.
+- **`components/host/`** — host switcher and first-run/welcome state
+  (`host-switcher.tsx`, `first-run-empty-state.tsx`).
+- **`components/assistant-ui/`** — the AI chat thread UI (message stats footer,
+  dialogs).
+- Base shadcn/ui primitives are in **`components/ui/`** — **never edit these
+  directly** (see root CLAUDE.md); style at the usage site or via a wrapper.
+
+### AI agent — `src/lib/ai/agent/`
+
+Built on the **Vercel AI SDK** (not LangGraph). `clickhouse-agent.ts` is the
+runner; prompts in `prompts/`; the skill registry/loader in `skills/` (the
+skills themselves live at repo-root `.agents/skills/`); MCP glue in `mcp/`.
+
+Tools are assembled by **`tools/index.ts`** (`createAllTools`). It composes 11
+tool modules exposing ~21 tools total (18 by default; the 3 destructive
+`control-tools` are gated off unless `AGENT_ENABLE_CONTROL_TOOLS=true`):
+
+| Module | Tools |
+|--------|-------|
+| `schema-tools` | `query`, `list_databases`, `list_tables`, `get_table_schema`, `explore_table_schema` |
+| `query-tools` | `get_running_queries`, `get_slow_queries`, `get_failed_queries`, `explain_query` |
+| `health-tools` | `get_metrics`, `get_disk_usage` |
+| `storage-tools` | `get_table_parts` |
+| `replication-tools` | `get_replication_status` |
+| `merge-tools` | `get_merge_status` |
+| `plan-tools` | `update_plan` |
+| `skill-tools` | `load_skill` |
+| `ask-user-tools` | `ask_user` |
+| `visualization-tools` | `query_and_visualize` |
+| `control-tools` (gated) | `kill_query`, `optimize_table`, `kill_mutation` |
+
+`helpers.ts` and `sql-analysis.ts` are shared helpers, not tool modules. The
+design is a deliberately lean set of primitives — anything not covered is done
+with the `query` tool plus a `load_skill` recipe. **Keep the user-facing docs at
+`../../docs/content/guide/ai-agent.mdx` in sync** whenever you add/rename/remove
+a tool, skill, or agent env var.
+
+## How to add …
+
+### … a dashboard route
+1. Add `src/routes/(dashboard)/<name>.tsx` exporting a `Route` via
+   `createFileRoute('/(dashboard)/<name>')`.
+2. For a standard table view, create/point to a `QueryConfig` and render
+   `<PageLayout queryConfig={...} />` inside `<Suspense fallback={<PageSkeleton />}>`.
+3. Add an OG head with `pageOgHead('<name>')` and wire navigation in `src/menu.ts`.
+
+### … a query config
+1. Add the config under the matching `src/lib/query-config/<domain>/` folder,
+   typed as `QueryConfig` (from `@/types/query-config`).
+2. Use a versioned `sql: [{ since, sql }]` array if columns differ across
+   ClickHouse versions; mark `optional: true` + `tableCheck` for optional tables.
+3. Register/export it via `lib/query-config/index.ts` and reference it from the
+   route.
+
+### … a chart
+1. Add the chart component under `src/components/charts/` (or a domain
+   subfolder), consuming data via a TanStack Query hook.
+2. Use `ChartContainer` / `ChartCard` and the graceful-error + stale-indicator
+   pattern (`useChartData` → `staleError` / `hasData`); register it where the
+   page's chart strip is assembled.
+
+### … an agent tool
+1. Add or extend a module in `src/lib/ai/agent/tools/` returning a
+   `dynamicTool({...})` map, and wire it into `tools/index.ts`.
+2. Update `../../docs/content/guide/ai-agent.mdx` in the same change.
+
+## Verification
+
+Run `bun run build` (Vite build + `tsc --noEmit`) after changes; `bun run lint`
+for Biome. See the root CLAUDE.md for the full test/deploy commands.


### PR DESCRIPTION
## Summary

Fix three factual inaccuracies in the root `CLAUDE.md` that pointed readers/agents at nonexistent files. Closes #2142.

## Changes

- Created `apps/dashboard/CLAUDE.md` (referenced 3× but missing) documenting the real app layout — routes, data layer (`fetchDataWithHost`, hostId required), TanStack Query hooks, query configs, data-table/charts, the AI agent — plus a "how to add a route/query config/chart/tool" section.
- Root `CLAUDE.md`: `docs/content/ai-agent.mdx` → `docs/content/guide/ai-agent.mdx` (3×).
- Root `CLAUDE.md`: replaced "29+ tool categories (…diagnostics, anomaly, cluster…)" with the real breakdown (~21 tools / 18 default across 11 modules; dropped the non-existent categories and the wrong `workflows/` reference).

## Test plan

- [ ] `bun run lint` (docs-only; no build impact)

## Notes for reviewer

The root CLAUDE.md still references `lib/clickhouse.ts`/`fetchData` elsewhere while the app file is `lib/clickhouse-helpers.ts`/`fetchDataWithHost` — documented accurately in the new app doc; left the root cross-cutting reference to stay in scope for a follow-up.

---

Co-Authored-By: duyetbot <bot@duyet.net>

---
_Generated by [Claude Code](https://claude.ai/code/session_0192Hi19HxYxuqr95RYS2kh5)_