### PR TITLE
docs: correct stale crate/script paths and README doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # chmonitor Dashboard
 
 [![Build and Test](https://github.com/chmonitor/chmonitor/actions/workflows/ci.yml/badge.svg)](https://github.com/chmonitor/chmonitor/actions/workflows/ci.yml)
+<!-- NOTE: this uptime badge still uses the pre-rebrand `clickhouse-monitoring-vercel-app` slug and may be stale; verify against the live uptime source before relying on it. -->
 [![All-time uptime](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fduyet%2Fuptime%2FHEAD%2Fapi%2Fclickhouse-monitoring-vercel-app%2Fuptime.json)](https://duyet.github.io/uptime/history/clickhouse-monitoring-vercel-app)
 [![Latest release](https://img.shields.io/github/v/release/chmonitor/chmonitor?sort=semver&label=release)](https://github.com/chmonitor/chmonitor/releases)
 [![Docker image](https://img.shields.io/badge/ghcr.io-chmonitor%2Fchmonitor-2496ED?logo=docker&logoColor=white)](https://github.com/chmonitor/chmonitor/pkgs/container/chmonitor)
@@ -59,7 +60,7 @@ chmonitor is **self-hosted** — run it next to your ClickHouse with the same
 - **[Docker](#docker)** — one `docker run`; the fastest path to a live dashboard.
 - **[Cloudflare Workers](#cloudflare-workers)** — global edge deploy (how the
   demo at [dash.chmonitor.dev](https://dash.chmonitor.dev/?ref=github) runs).
-- **[One-click templates](docs/content/deploy/one-click.mdx)** — Railway, Render, Fly.io.
+- **[One-click templates](docs/content/operate/deploy/one-click.mdx)** — Railway, Render, Fly.io.
 - **[Kubernetes (Helm)](https://docs.chmonitor.dev/deploy/k8s)** — for clusters.
 
 Prefer to look before you install? Try the live demo above — no setup required.
@@ -243,10 +244,10 @@ plus a short list of what you changed:
     - [Vercel](https://docs.chmonitor.dev/deploy/vercel)
     - [Docker](https://docs.chmonitor.dev/deploy/docker)
     - [Kubernetes Helm Chart](https://docs.chmonitor.dev/deploy/k8s)
-    - [One-Click Deploy](docs/content/deploy/one-click.mdx) — Railway / Render / Fly.io community templates
+    - [One-Click Deploy](docs/content/operate/deploy/one-click.mdx) — Railway / Render / Fly.io community templates
   - [Advanced](https://docs.chmonitor.dev/advanced)
-    - [Telemetry](docs/content/advanced/telemetry.mdx) — opt-in, privacy-first usage metrics (off by default)
-    - [Editions](docs/content/advanced/editions.mdx) — open-core model: GPL-3.0 community is free forever; enterprise features gated by `CHM_EDITION`
+    - [Telemetry](docs/content/operate/advanced/telemetry.mdx) — opt-in, privacy-first usage metrics (off by default)
+    - [Editions](docs/content/operate/advanced/editions.mdx) — open-core model: GPL-3.0 community is free forever; enterprise features gated by `CHM_EDITION`
   - [Reference](https://docs.chmonitor.dev/reference)
     - [Platform Support Matrix](docs/content/reference/support-matrix.mdx) — ClickHouse versions and distributions (supported / best-effort / untested)
     - [Connection Presets](docs/content/reference/connection-presets.mdx) — least-privilege read-only user setup for ClickHouse OSS, Altinity, and Cloud

--- a/docs/knowledge/rust-wasm-performance.md
+++ b/docs/knowledge/rust-wasm-performance.md
@@ -32,10 +32,10 @@ Benchmark evidence from PR #1021 showed:
 
 ## How to Apply
 
-- Re-run `bun run bench:wasm` after changing `rust/monitor-core`, `lib/wasm/monitor-core.ts`, or `scripts/bench-wasm.ts`
+- Re-run `bun run scripts/bench-wasm.ts` after changing `rust/monitor-core`, `packages/clickhouse-client/src/wasm/monitor-core.ts`, or `scripts/bench-wasm.ts`
 - Keep the promotion threshold at 1.20x
 - Preserve lazy loading for the WASM bundle — do not add it to default dashboard or client bundles
-- For `tools/ch-monitor-cli`, keep TUI refresh cadence bounded (one chart fetch every 5s)
+- For `rust/ch-monitor-cli`, keep TUI refresh cadence bounded (one chart fetch every 5s)
 
 ## Latest Benchmark (May 1, 2026)
 
@@ -51,5 +51,5 @@ Benchmark evidence from PR #1021 showed:
 - `scripts/bench-wasm.ts` — benchmark runner
 - `scripts/build-wasm.ts` — WASM build script
 - `rust/monitor-core` — Rust source
-- `lib/wasm/monitor-core.ts` — JS bindings
-- `lib/wasm/generated/monitor_core_bg.wasm` — compiled WASM
+- `packages/clickhouse-client/src/wasm/monitor-core.ts` — JS bindings
+- `packages/clickhouse-client/src/wasm/generated/monitor_core_bg.wasm` — compiled WASM

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -16,7 +16,7 @@ related:
 
 # Standalone chmonitor CLI (Rust)
 
-`tools/ch-monitor-cli` provides a standalone CLI that talks to the existing API.
+`rust/ch-monitor-cli` provides a standalone CLI that talks to the existing API.
 
 ## Config Loading
 
@@ -36,10 +36,10 @@ default_chart = "query-count"
 ## Commands
 
 ```bash
-cargo run --manifest-path tools/ch-monitor-cli/Cargo.toml -- hosts
-cargo run --manifest-path tools/ch-monitor-cli/Cargo.toml -- chart query-count --limit 50
-cargo run --manifest-path tools/ch-monitor-cli/Cargo.toml -- table running-queries --limit 30
-cargo run --manifest-path tools/ch-monitor-cli/Cargo.toml -- tui query-count
+cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- hosts
+cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- chart query-count --limit 50
+cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- table running-queries --limit 30
+cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- tui query-count
 ```
 
 ## API Key Support


### PR DESCRIPTION
## Summary

Fix doc commands/links that no longer resolve. Every changed path was verified to exist. Closes #2143.

## Changes

- `docs/knowledge/standalone-cli.md`: `tools/ch-monitor-cli` → `rust/ch-monitor-cli` (5×).
- `docs/knowledge/rust-wasm-performance.md`: `bun run bench:wasm` → `bun run scripts/bench-wasm.ts`; `tools/ch-monitor-cli` → `rust/ch-monitor-cli`; wasm artifact paths → `packages/clickhouse-client/src/wasm/...`.
- `README.md`: `docs/content/deploy/one-click.mdx` → `.../operate/deploy/one-click.mdx` (2×); telemetry & editions links → `.../operate/advanced/...`; added an HTML comment noting the pre-rebrand uptime badge slug may be stale (left the URL, can't verify the live service).

## Test plan

- [ ] `bun run lint` (docs-only)

## Notes for reviewer

Uptime badge URL left unchanged (external, unverifiable) with a stale-slug note.

---

Co-Authored-By: duyetbot <bot@duyet.net>

---
_Generated by [Claude Code](https://claude.ai/code/session_0192Hi19HxYxuqr95RYS2kh5)_