### PR TITLE
refactor(types): replace any with generics in data-table and chart tooltip

### DIFF
--- a/apps/dashboard/src/components/charts/primitives/area-chart-tooltip.tsx
+++ b/apps/dashboard/src/components/charts/primitives/area-chart-tooltip.tsx
@@ -4,8 +4,6 @@
  * Provides standard and breakdown tooltip variants.
  */
 
-import type { DefaultTooltipContentProps } from 'recharts'
-
 import type { ChartConfig } from '@/components/ui/chart'
 
 import { BreakdownSection } from './tooltip-breakdown-section'
@@ -13,9 +11,8 @@ import { parseBreakdownData } from './tooltip-data-parser'
 import { StandardTooltipRow, SummaryRow } from './tooltip-row'
 import { ChartTooltip, ChartTooltipContent } from '@/components/ui/chart'
 
-type TooltipPayload = NonNullable<
-  DefaultTooltipContentProps<any, any>['payload']
->
+/** Raw data row backing a tooltip (Recharts passes the row object as `payload`). */
+type TooltipDataRecord = Record<string, unknown>
 
 export interface RenderChartTooltipOptions {
   breakdown?: string
@@ -68,7 +65,7 @@ function renderStandardTooltip(chartConfig: ChartConfig) {
       content={
         <ChartTooltipContent
           className="max-w-[300px] [font-variant-numeric:tabular-nums]"
-          formatter={(value, name, item, index, _payload: TooltipPayload) => {
+          formatter={(value, name, item, index) => {
             return (
               <StandardTooltipRow
                 key={`${name}${index}`}
@@ -106,13 +103,13 @@ function renderBreakdownTooltip({
       content={
         <ChartTooltipContent
           className="max-w-[320px] [font-variant-numeric:tabular-nums]"
-          formatter={(value, name, item, _index, payload: any) => {
+          formatter={(value, name, item, _index, payload) => {
             return (
               <BreakdownTooltipContent
                 name={name as string}
                 value={value}
                 item={item}
-                payload={payload}
+                payload={payload as unknown as TooltipDataRecord}
                 breakdown={breakdown}
                 breakdownLabel={breakdownLabel}
                 breakdownValue={breakdownValue}
@@ -143,9 +140,9 @@ function BreakdownTooltipContent({
   chartConfig,
 }: {
   name: string
-  value: any
-  item: any
-  payload: any
+  value: unknown
+  item: unknown
+  payload: TooltipDataRecord
   breakdown?: string
   breakdownLabel?: string
   breakdownValue?: string
@@ -153,7 +150,7 @@ function BreakdownTooltipContent({
   chartConfig: ChartConfig
 }) {
   const breakdownDataMap = parseBreakdownData(
-    payload[breakdown as keyof typeof payload] as Array<any>,
+    payload[breakdown as string] as Array<unknown>,
     breakdownLabel,
     breakdownValue
   )

--- a/apps/dashboard/src/components/data-table/buttons/column-visibility.tsx
+++ b/apps/dashboard/src/components/data-table/buttons/column-visibility.tsx
@@ -1,5 +1,5 @@
 import { MixerHorizontalIcon } from '@radix-ui/react-icons'
-import type { Table } from '@tanstack/react-table'
+import type { RowData, Table } from '@tanstack/react-table'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -9,15 +9,15 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 
-interface ColumnVisibilityButtonProps {
-  // Using 'any' since the component only uses table methods that don't depend on TData
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  table: Table<any>
+interface ColumnVisibilityButtonProps<TData extends RowData = RowData> {
+  table: Table<TData>
 }
 
-export const ColumnVisibilityButton = function ColumnVisibilityButton({
+export const ColumnVisibilityButton = function ColumnVisibilityButton<
+  TData extends RowData = RowData,
+>({
   table,
-}: ColumnVisibilityButtonProps) {
+}: ColumnVisibilityButtonProps<TData>) {
   const handleSelect = (event: Event) => {
     event.preventDefault()
     // Prevent default selection behavior to avoid

--- a/apps/dashboard/src/components/data-table/buttons/csv-export-button.tsx
+++ b/apps/dashboard/src/components/data-table/buttons/csv-export-button.tsx
@@ -11,10 +11,8 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { downloadCsv, valueToCsv } from '@/lib/csv'
 
-interface CsvExportButtonProps {
-  // Using 'any' since the component only uses table methods that don't depend on TData
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  table: Table<any>
+interface CsvExportButtonProps<TData extends RowData = RowData> {
+  table: Table<TData>
   /** Optional filename for the download (without extension) */
   filename?: string
 }
@@ -61,10 +59,12 @@ function generateCsvContent<TData extends RowData>(
  * - Generates filename with timestamp
  * - Shows toast notifications
  */
-export const CsvExportButton = function CsvExportButton({
+export const CsvExportButton = function CsvExportButton<
+  TData extends RowData = RowData,
+>({
   table,
   filename = 'export',
-}: CsvExportButtonProps) {
+}: CsvExportButtonProps<TData>) {
   const handleExportCurrentPage = () => {
     const csvContent = generateCsvContent(table)
 

--- a/apps/dashboard/src/components/data-table/cells/background-bar-format.tsx
+++ b/apps/dashboard/src/components/data-table/cells/background-bar-format.tsx
@@ -1,4 +1,4 @@
-import type { Row, Table } from '@tanstack/react-table'
+import type { Row, RowData, Table } from '@tanstack/react-table'
 
 import { getBarStyle, getColorFromBank, getShade } from '@/lib/color-bank'
 import { formatReadableQuantity } from '@/lib/format-readable'
@@ -7,29 +7,33 @@ export interface BackgroundBarOptions {
   numberFormat?: boolean
 }
 
-interface BackgroundBarFormatProps {
-  table: Table<any>
-  row: Row<any>
+interface BackgroundBarFormatProps<TData extends RowData = RowData> {
+  table: Table<TData>
+  row: Row<TData>
   columnName: string
   value: React.ReactNode
   options?: BackgroundBarOptions
 }
 
-export const BackgroundBarFormat = function BackgroundBarFormat({
+export const BackgroundBarFormat = function BackgroundBarFormat<
+  TData extends RowData = RowData,
+>({
   table,
   row,
   columnName,
   value,
   options,
-}: BackgroundBarFormatProps): React.ReactNode {
+}: BackgroundBarFormatProps<TData>): React.ReactNode {
   // Disable if row count <= 1
   if (table.getCoreRowModel()?.rows?.length <= 1) return value
 
   // Looking at pct_{columnName} for the value
   const colName = columnName.replace('readable_', '')
   const pctColName = `pct_${colName}`
-  const pct = row.original[pctColName]
-  const orgValue = row.original[colName]
+  // row.original is generic (TData); read dynamic keys via a narrow record cast.
+  const original = row.original as Record<string, unknown>
+  const pct = original[pctColName]
+  const orgValue = original[colName]
 
   if (pct === undefined || pct === null || !Number.isFinite(Number(pct))) {
     // Column pct_{columnName} is not defined in the query

--- a/apps/dashboard/src/components/data-table/cells/code-toggle-format.tsx
+++ b/apps/dashboard/src/components/data-table/cells/code-toggle-format.tsx
@@ -1,4 +1,4 @@
-import type { Row } from '@tanstack/react-table'
+import type { Row, RowData } from '@tanstack/react-table'
 
 import {
   Accordion,
@@ -13,19 +13,21 @@ export interface CodeToggleOptions {
   hide_query_comment?: boolean
 }
 
-interface CodeToggleFormatProps {
-  row: Row<any>
+interface CodeToggleFormatProps<TData extends RowData = RowData> {
+  row: Row<TData>
   value: string
   options?: CodeToggleOptions
 }
 
 const CODE_TRUNCATE_LENGTH = 50
 
-export const CodeToggleFormat = function CodeToggleFormat({
+export const CodeToggleFormat = function CodeToggleFormat<
+  TData extends RowData = RowData,
+>({
   row,
   value,
   options,
-}: CodeToggleFormatProps): React.ReactNode {
+}: CodeToggleFormatProps<TData>): React.ReactNode {
   const truncate_length = options?.max_truncate || CODE_TRUNCATE_LENGTH
 
   const handleValueChange = (accordionValue: string) => {

--- a/apps/dashboard/src/components/data-table/cells/hover-card-format.tsx
+++ b/apps/dashboard/src/components/data-table/cells/hover-card-format.tsx
@@ -1,4 +1,4 @@
-import type { Row } from '@tanstack/react-table'
+import type { Row, RowData } from '@tanstack/react-table'
 
 import {
   HoverCard,
@@ -13,22 +13,24 @@ export type HoverCardOptions = {
   content: HoverCardContent
 }
 
-interface HoverCardProps {
-  row: Row<any>
+interface HoverCardProps<TData extends RowData = RowData> {
+  row: Row<TData>
   value: React.ReactNode
   options?: HoverCardOptions
 }
 
-export const HoverCardFormat = function HoverCardFormat({
+export const HoverCardFormat = function HoverCardFormat<
+  TData extends RowData = RowData,
+>({
   row,
   value,
   options,
-}: HoverCardProps): React.ReactNode {
+}: HoverCardProps<TData>): React.ReactNode {
   const { content } = options || {}
 
   // Extract row data for template replacement
   // Uses row.getValue() for each column to get the value
-  const rowData = extractRowData(content, row)
+  const rowData = extractRowData(content, row as Row<unknown>)
 
   // Content replacement, e.g. "Hover content: [column_name]"
   const processedContent = replaceTemplateInReactNode(content, rowData)

--- a/apps/dashboard/src/components/data-table/footnote.tsx
+++ b/apps/dashboard/src/components/data-table/footnote.tsx
@@ -1,12 +1,14 @@
-import type { Table } from '@tanstack/react-table'
+import type { RowData, Table } from '@tanstack/react-table'
 
-export interface FootnoteProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  table: Table<any>
+export interface FootnoteProps<TData extends RowData = RowData> {
+  table: Table<TData>
   footnote?: string | React.ReactNode
 }
 
-export const Footnote = function Footnote({ table, footnote }: FootnoteProps) {
+export const Footnote = function Footnote<TData extends RowData = RowData>({
+  table,
+  footnote,
+}: FootnoteProps<TData>) {
   return (
     <div className="min-w-0 flex-1 text-wrap break-words text-sm text-muted-foreground">
       {footnote ? (

--- a/apps/dashboard/src/components/data-table/pagination.tsx
+++ b/apps/dashboard/src/components/data-table/pagination.tsx
@@ -4,7 +4,7 @@ import {
   DoubleArrowLeftIcon,
   DoubleArrowRightIcon,
 } from '@radix-ui/react-icons'
-import type { Table } from '@tanstack/react-table'
+import type { RowData, Table } from '@tanstack/react-table'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -17,9 +17,8 @@ import {
 import { formatNumber } from '@/lib/format-number'
 import { cn } from '@/lib/utils'
 
-interface DataTablePaginationProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  table: Table<any>
+interface DataTablePaginationProps<TData extends RowData = RowData> {
+  table: Table<TData>
 }
 
 const pageSizeOptions = [10, 25, 50, 100, 200, 500, 1000]
@@ -28,7 +27,9 @@ const pageSizeOptions = [10, 25, 50, 100, 200, 500, 1000]
  * Memoized pagination info displaying row range (desktop) or page number (mobile).
  * Uses cached Intl.NumberFormat from @/lib/format-number.
  */
-function PaginationInfo({ table }: DataTablePaginationProps) {
+function PaginationInfo<TData extends RowData = RowData>({
+  table,
+}: DataTablePaginationProps<TData>) {
   const { pageIndex, pageSize } = table.getState().pagination
   const totalRows = table.getPrePaginationRowModel().rows.length
   const pageCount = table.getPageCount()
@@ -50,7 +51,9 @@ function PaginationInfo({ table }: DataTablePaginationProps) {
   )
 }
 
-export function DataTablePagination({ table }: DataTablePaginationProps) {
+export function DataTablePagination<TData extends RowData = RowData>({
+  table,
+}: DataTablePaginationProps<TData>) {
   // Memoized pagination handlers to prevent recreation on every render
   const handleFirstPage = () => {
     table.setPageIndex(0)


### PR DESCRIPTION
## Summary

Remove `any` from the chart tooltip and data-table components, restoring type safety. Closes #2147.

## Changes

- `components/charts/primitives/area-chart-tooltip.tsx`: dropped the `any` tooltip alias; typed the raw row as `Record<string, unknown>`; forwarded values as `unknown`; narrowed the breakdown read.
- Data-table: threaded `<TData extends RowData = RowData>` so `Table<TData>`/`Row<TData>` replace `Table<any>`/`Row<any>` in `cells/background-bar-format.tsx`, `footnote.tsx`, `pagination.tsx`, `cells/code-toggle-format.tsx`, `cells/hover-card-format.tsx`, `buttons/column-visibility.tsx`, `buttons/csv-export-button.tsx`. Dynamic reads use `(row.original as Record<string, unknown>)[key]`. The `= RowData` defaults keep all existing callers compiling.

## Test plan

- [ ] `bun run lint`
- [ ] `bun run build` (`tsc --noEmit`) — **please verify**: this is type-only and could not be type-checked in the authoring env (no `node_modules`)

## Notes for reviewer

⚠️ Type-check not run locally — CI `bun run build` is the real gate. Deep Recharts `Payload<ValueType,NameType>` generics were intentionally avoided in favor of `unknown`+narrow to dodge unverifiable deep-import assignability. Helper files (`tooltip-*`) still contain `any` and were left out of scope.

---

Co-Authored-By: duyetbot <bot@duyet.net>

---
_Generated by [Claude Code](https://claude.ai/code/session_0192Hi19HxYxuqr95RYS2kh5)_