### PR TITLE
refactor(mcp-server): extract shared runReadonlyQuery helper for tools

### DIFF
--- a/packages/mcp-server/src/tools/databases.ts
+++ b/packages/mcp-server/src/tools/databases.ts
@@ -1,38 +1,18 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
-import { fetchData } from '@chm/clickhouse-client'
-import { z } from 'zod/v3'
+import { hostIdSchema, runReadonlyQuery } from './helpers'
 
 export function registerDatabasesTool(server: McpServer) {
   server.tool(
     'list_databases',
     'List all databases on the ClickHouse server with their engines and comments.',
     {
-      hostId: z.number().optional().describe('Host index (default: 0)'),
+      hostId: hostIdSchema,
     },
-    async ({ hostId }) => {
-      const result = await fetchData({
-        query:
-          'SELECT name, engine, comment FROM system.databases ORDER BY name',
-        hostId: hostId ?? 0,
-        format: 'JSONEachRow',
-        clickhouse_settings: { readonly: '1' },
-      })
-
-      if (result.error) {
-        return {
-          content: [
-            { type: 'text' as const, text: `Error: ${result.error.message}` },
-          ],
-          isError: true,
-        }
-      }
-
-      return {
-        content: [
-          { type: 'text' as const, text: JSON.stringify(result.data, null, 2) },
-        ],
-      }
-    }
+    async ({ hostId }) =>
+      runReadonlyQuery(
+        'SELECT name, engine, comment FROM system.databases ORDER BY name',
+        hostId
+      )
   )
 }

--- a/packages/mcp-server/src/tools/explore-table-schema.ts
+++ b/packages/mcp-server/src/tools/explore-table-schema.ts
@@ -1,6 +1,12 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
-import { fetchData } from '@chm/clickhouse-client'
+import {
+  hostIdSchema,
+  runReadonlyFetch,
+  runReadonlyQuery,
+  toErrorResult,
+  toJsonResult,
+} from './helpers'
 import { z } from 'zod/v3'
 
 export function registerExploreTableSchemaTool(server: McpServer) {
@@ -18,98 +24,48 @@ export function registerExploreTableSchemaTool(server: McpServer) {
         .describe(
           'Table name (requires database. If provided, returns full schema with relationships)'
         ),
-      hostId: z.number().optional().describe('Host index (default: 0)'),
+      hostId: hostIdSchema,
     },
     async ({ database, table, hostId }) => {
-      const effectiveHostId = hostId ?? 0
-      const fetchOpts = {
-        hostId: effectiveHostId,
-        format: 'JSONEachRow' as const,
-        clickhouse_settings: { readonly: '1' as const },
-      }
-
       // Mode 1: No params — list databases
       if (!database) {
-        const result = await fetchData({
-          ...fetchOpts,
-          query:
-            'SELECT name, engine, comment FROM system.databases ORDER BY name',
-        })
-
-        if (result.error) {
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: `Error: ${result.error.message}`,
-              },
-            ],
-            isError: true,
-          }
-        }
-
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify(result.data, null, 2),
-            },
-          ],
-        }
+        return runReadonlyQuery(
+          'SELECT name, engine, comment FROM system.databases ORDER BY name',
+          hostId
+        )
       }
 
       // Mode 2: Database only — list tables with details
       if (!table) {
-        const result = await fetchData({
-          ...fetchOpts,
-          query: `SELECT name, engine, partition_key, sorting_key, total_rows, formatReadableSize(total_bytes) AS size FROM system.tables WHERE database = {database:String} AND is_temporary = 0 AND name NOT LIKE '.inner_%' ORDER BY total_bytes DESC`,
-          query_params: { database },
-        })
-
-        if (result.error) {
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: `Error: ${result.error.message}`,
-              },
-            ],
-            isError: true,
-          }
-        }
-
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify(result.data, null, 2),
-            },
-          ],
-        }
+        return runReadonlyQuery(
+          `SELECT name, engine, partition_key, sorting_key, total_rows, formatReadableSize(total_bytes) AS size FROM system.tables WHERE database = {database:String} AND is_temporary = 0 AND name NOT LIKE '.inner_%' ORDER BY total_bytes DESC`,
+          hostId,
+          { query_params: { database } }
+        )
       }
 
       // Mode 3: Database + table — full schema with relationships
       const [metadataResult, columnsResult, upstreamResult, downstreamResult] =
         await Promise.all([
-          fetchData({
-            ...fetchOpts,
+          runReadonlyFetch({
             query: `SELECT database, name, engine, partition_key, sorting_key, primary_key, total_rows, formatReadableSize(total_bytes) AS size FROM system.tables WHERE database = {database:String} AND name = {table:String}`,
             query_params: { database, table },
+            hostId,
           }),
-          fetchData({
-            ...fetchOpts,
+          runReadonlyFetch({
             query: `SELECT name, type, is_in_primary_key, is_in_sorting_key, is_in_partition_key FROM system.columns WHERE database = {database:String} AND table = {table:String} ORDER BY position`,
             query_params: { database, table },
+            hostId,
           }),
-          fetchData({
-            ...fetchOpts,
+          runReadonlyFetch({
             query: `SELECT t2.database AS dep_database, t2.name AS dep_table, t2.engine FROM system.tables AS t1 INNER JOIN system.tables AS t2 ON t1.create_table_query LIKE concat('%', t2.database, '.', t2.name, '%') WHERE t1.database = {database:String} AND t1.name = {table:String} AND t2.database != '' AND NOT (t2.database = {database:String} AND t2.name = {table:String})`,
             query_params: { database, table },
+            hostId,
           }),
-          fetchData({
-            ...fetchOpts,
+          runReadonlyFetch({
             query: `SELECT t2.database AS dependent_database, t2.name AS dependent_table, t2.engine FROM system.tables AS t1 INNER JOIN system.tables AS t2 ON t2.create_table_query LIKE concat('%', t1.database, '.', t1.name, '%') WHERE t1.database = {database:String} AND t1.name = {table:String} AND t2.database != '' AND NOT (t2.database = {database:String} AND t2.name = {table:String})`,
             query_params: { database, table },
+            hostId,
           }),
         ])
 
@@ -123,15 +79,7 @@ export function registerExploreTableSchemaTool(server: McpServer) {
         .map((r) => r.error!.message)
 
       if (errors.length > 0) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: `Errors: ${errors.join('; ')}`,
-            },
-          ],
-          isError: true,
-        }
+        return toErrorResult(`Errors: ${errors.join('; ')}`)
       }
 
       const tableMetadata = Array.isArray(metadataResult.data)
@@ -145,14 +93,7 @@ export function registerExploreTableSchemaTool(server: McpServer) {
         downstream_dependencies: downstreamResult.data,
       }
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(combined, null, 2),
-          },
-        ],
-      }
+      return toJsonResult(combined)
     }
   )
 }

--- a/packages/mcp-server/src/tools/helpers.ts
+++ b/packages/mcp-server/src/tools/helpers.ts
@@ -1,0 +1,92 @@
+import type { DataFormat } from '@clickhouse/client'
+
+import type { FetchDataResult } from '@chm/clickhouse-client'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+
+import { fetchData } from '@chm/clickhouse-client'
+import { z } from 'zod/v3'
+
+/**
+ * Shared Zod schema for the optional `hostId` argument used by every tool.
+ * Selects which configured ClickHouse host to query (default: index 0).
+ */
+export const hostIdSchema = z
+  .number()
+  .optional()
+  .describe('Host index (default: 0)')
+
+/** Build an error result envelope with the given (already-formatted) message. */
+export function toErrorResult(text: string): CallToolResult {
+  return {
+    content: [{ type: 'text' as const, text }],
+    isError: true,
+  }
+}
+
+/** Build a success result envelope from data serialized as pretty JSON. */
+export function toJsonResult(data: unknown): CallToolResult {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+  }
+}
+
+type FetchableData =
+  | unknown[]
+  | object[]
+  | Record<string, unknown>
+  | { length: number; rows: number; statistics: Record<string, unknown> }
+
+interface ReadonlyFetchOptions {
+  query: string
+  hostId?: number
+  query_params?: Record<string, unknown>
+  format?: DataFormat
+}
+
+function buildFetchArgs(options: ReadonlyFetchOptions) {
+  return {
+    query: options.query,
+    hostId: options.hostId ?? 0,
+    format: options.format ?? ('JSONEachRow' as DataFormat),
+    clickhouse_settings: { readonly: '1' as const },
+    ...(options.query_params ? { query_params: options.query_params } : {}),
+  }
+}
+
+/**
+ * Run a read-only ClickHouse query and return the raw fetch result.
+ *
+ * Applies the shared boilerplate used by every MCP tool: `format` defaults to
+ * `JSONEachRow`, `clickhouse_settings.readonly` is forced to `'1'`, and
+ * `hostId` defaults to `0`. Use this when a tool needs to combine several
+ * queries; use {@link runReadonlyQuery} for the common single-query case.
+ */
+export function runReadonlyFetch<
+  T extends FetchableData = Array<Record<string, unknown>>,
+>(options: ReadonlyFetchOptions): Promise<FetchDataResult<T>> {
+  return fetchData<T>(buildFetchArgs(options))
+}
+
+/**
+ * Run a single read-only ClickHouse query and map it to the MCP result
+ * envelope: on error, `{ isError: true }` with `Error: <message>`; otherwise the
+ * pretty-printed JSON rows.
+ */
+export async function runReadonlyQuery(
+  query: string,
+  hostId?: number,
+  options: { query_params?: Record<string, unknown>; format?: DataFormat } = {}
+): Promise<CallToolResult> {
+  const result = await runReadonlyFetch({
+    query,
+    hostId,
+    query_params: options.query_params,
+    format: options.format,
+  })
+
+  if (result.error) {
+    return toErrorResult(`Error: ${result.error.message}`)
+  }
+
+  return toJsonResult(result.data)
+}

--- a/packages/mcp-server/src/tools/merges.ts
+++ b/packages/mcp-server/src/tools/merges.ts
@@ -1,38 +1,18 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
-import { fetchData } from '@chm/clickhouse-client'
-import { z } from 'zod/v3'
+import { hostIdSchema, runReadonlyQuery } from './helpers'
 
 export function registerMergesTool(server: McpServer) {
   server.tool(
     'get_merge_status',
     'Get currently running merge operations with progress, size, and elapsed time.',
     {
-      hostId: z.number().optional().describe('Host index (default: 0)'),
+      hostId: hostIdSchema,
     },
-    async ({ hostId }) => {
-      const result = await fetchData({
-        query:
-          'SELECT database, table, round(progress * 100, 2) AS progress_pct, formatReadableSize(total_size_bytes_compressed) AS size, elapsed FROM system.merges ORDER BY elapsed DESC',
-        hostId: hostId ?? 0,
-        format: 'JSONEachRow',
-        clickhouse_settings: { readonly: '1' },
-      })
-
-      if (result.error) {
-        return {
-          content: [
-            { type: 'text' as const, text: `Error: ${result.error.message}` },
-          ],
-          isError: true,
-        }
-      }
-
-      return {
-        content: [
-          { type: 'text' as const, text: JSON.stringify(result.data, null, 2) },
-        ],
-      }
-    }
+    async ({ hostId }) =>
+      runReadonlyQuery(
+        'SELECT database, table, round(progress * 100, 2) AS progress_pct, formatReadableSize(total_size_bytes_compressed) AS size, elapsed FROM system.merges ORDER BY elapsed DESC',
+        hostId
+      )
   )
 }

--- a/packages/mcp-server/src/tools/metrics.ts
+++ b/packages/mcp-server/src/tools/metrics.ts
@@ -1,37 +1,30 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
-import { fetchData } from '@chm/clickhouse-client'
-import { z } from 'zod/v3'
+import {
+  hostIdSchema,
+  runReadonlyFetch,
+  toErrorResult,
+  toJsonResult,
+} from './helpers'
 
 export function registerMetricsTool(server: McpServer) {
   server.tool(
     'get_metrics',
     'Get key ClickHouse server metrics: version, uptime, active connections, and memory usage.',
     {
-      hostId: z.number().optional().describe('Host index (default: 0)'),
+      hostId: hostIdSchema,
     },
     async ({ hostId }) => {
-      const effectiveHostId = hostId ?? 0
-
       const [versionResult, uptimeResult, metricsResult] = await Promise.all([
-        fetchData({
-          query: 'SELECT version() AS version',
-          hostId: effectiveHostId,
-          format: 'JSONEachRow',
-          clickhouse_settings: { readonly: '1' },
-        }),
-        fetchData({
+        runReadonlyFetch({ query: 'SELECT version() AS version', hostId }),
+        runReadonlyFetch({
           query: 'SELECT uptime() AS uptime_seconds',
-          hostId: effectiveHostId,
-          format: 'JSONEachRow',
-          clickhouse_settings: { readonly: '1' },
+          hostId,
         }),
-        fetchData({
+        runReadonlyFetch({
           query:
             "SELECT metric, value FROM system.metrics WHERE metric IN ('TCPConnection', 'HTTPConnection', 'MemoryTracking') ORDER BY metric",
-          hostId: effectiveHostId,
-          format: 'JSONEachRow',
-          clickhouse_settings: { readonly: '1' },
+          hostId,
         }),
       ])
 
@@ -40,15 +33,7 @@ export function registerMetricsTool(server: McpServer) {
         .map((r) => r.error!.message)
 
       if (errors.length > 0) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: `Errors: ${errors.join('; ')}`,
-            },
-          ],
-          isError: true,
-        }
+        return toErrorResult(`Errors: ${errors.join('; ')}`)
       }
 
       const versionRow = (
@@ -68,11 +53,7 @@ export function registerMetricsTool(server: McpServer) {
         metrics: metricsResult.data,
       }
 
-      return {
-        content: [
-          { type: 'text' as const, text: JSON.stringify(combined, null, 2) },
-        ],
-      }
+      return toJsonResult(combined)
     }
   )
 }

--- a/packages/mcp-server/src/tools/performance.ts
+++ b/packages/mcp-server/src/tools/performance.ts
@@ -1,6 +1,11 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
-import { fetchData } from '@chm/clickhouse-client'
+import {
+  hostIdSchema,
+  runReadonlyFetch,
+  toErrorResult,
+  toJsonResult,
+} from './helpers'
 import { z } from 'zod/v3'
 
 type Severity = 'OK' | 'WARNING' | 'CRITICAL'
@@ -81,7 +86,7 @@ export function registerPerformanceTool(server: McpServer) {
     'analyze_performance',
     'Get a structured performance analysis snapshot with severity ratings. Returns slow queries, high part counts, merge backlog, memory pressure, and disk utilization in one call.',
     {
-      hostId: z.number().optional().describe('Host index (default: 0)'),
+      hostId: hostIdSchema,
       lastHours: z
         .number()
         .optional()
@@ -93,7 +98,7 @@ export function registerPerformanceTool(server: McpServer) {
 
       const [slowQueries, partCounts, merges, memory, disks] =
         await Promise.all([
-          fetchData({
+          runReadonlyFetch({
             query: `SELECT
                 query_id,
                 user,
@@ -109,10 +114,8 @@ export function registerPerformanceTool(server: McpServer) {
               LIMIT 5`,
             query_params: { hours: hours.toString() },
             hostId: h,
-            format: 'JSONEachRow',
-            clickhouse_settings: { readonly: '1' },
           }),
-          fetchData({
+          runReadonlyFetch({
             query: `SELECT
                 database,
                 table,
@@ -124,19 +127,15 @@ export function registerPerformanceTool(server: McpServer) {
               ORDER BY part_count DESC
               LIMIT 5`,
             hostId: h,
-            format: 'JSONEachRow',
-            clickhouse_settings: { readonly: '1' },
           }),
-          fetchData({
+          runReadonlyFetch({
             query: `SELECT
                 count() AS active_merges,
                 formatReadableSize(sum(total_size_bytes_compressed)) AS total_merge_size
               FROM system.merges`,
             hostId: h,
-            format: 'JSONEachRow',
-            clickhouse_settings: { readonly: '1' },
           }),
-          fetchData({
+          runReadonlyFetch({
             query: `SELECT
                 metric,
                 value,
@@ -146,10 +145,8 @@ export function registerPerformanceTool(server: McpServer) {
               FROM system.metrics
               WHERE metric = 'MemoryTracking'`,
             hostId: h,
-            format: 'JSONEachRow',
-            clickhouse_settings: { readonly: '1' },
           }),
-          fetchData({
+          runReadonlyFetch({
             query: `SELECT
                 name,
                 path,
@@ -158,8 +155,6 @@ export function registerPerformanceTool(server: McpServer) {
                 round(free_space * 100.0 / nullIf(total_space, 0), 2) AS free_pct
               FROM system.disks`,
             hostId: h,
-            format: 'JSONEachRow',
-            clickhouse_settings: { readonly: '1' },
           }),
         ])
 
@@ -167,15 +162,7 @@ export function registerPerformanceTool(server: McpServer) {
       const errors = results.filter((r) => r.error).map((r) => r.error!.message)
 
       if (errors.length === 5) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: `All queries failed: ${errors.join('; ')}`,
-            },
-          ],
-          isError: true,
-        }
+        return toErrorResult(`All queries failed: ${errors.join('; ')}`)
       }
 
       const asArray = (data: unknown): Array<Record<string, unknown>> =>
@@ -215,14 +202,7 @@ export function registerPerformanceTool(server: McpServer) {
         ...(errors.length > 0 ? { errors } : {}),
       }
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(report, null, 2),
-          },
-        ],
-      }
+      return toJsonResult(report)
     }
   )
 }

--- a/packages/mcp-server/src/tools/queries.ts
+++ b/packages/mcp-server/src/tools/queries.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
-import { fetchData } from '@chm/clickhouse-client'
+import { hostIdSchema, runReadonlyQuery } from './helpers'
 import { z } from 'zod/v3'
 
 /**
@@ -17,32 +17,13 @@ export function registerQueryTools(server: McpServer) {
     'get_running_queries',
     'List currently running queries on the ClickHouse server, ordered by elapsed time.',
     {
-      hostId: z.number().optional().describe('Host index (default: 0)'),
+      hostId: hostIdSchema,
     },
-    async ({ hostId }) => {
-      const result = await fetchData({
-        query:
-          'SELECT query_id, user, elapsed, read_rows, memory_usage, substring(query, 1, 200) AS query FROM system.processes ORDER BY elapsed DESC',
-        hostId: hostId ?? 0,
-        format: 'JSONEachRow',
-        clickhouse_settings: { readonly: '1' },
-      })
-
-      if (result.error) {
-        return {
-          content: [
-            { type: 'text' as const, text: `Error: ${result.error.message}` },
-          ],
-          isError: true,
-        }
-      }
-
-      return {
-        content: [
-          { type: 'text' as const, text: JSON.stringify(result.data, null, 2) },
-        ],
-      }
-    }
+    async ({ hostId }) =>
+      runReadonlyQuery(
+        'SELECT query_id, user, elapsed, read_rows, memory_usage, substring(query, 1, 200) AS query FROM system.processes ORDER BY elapsed DESC',
+        hostId
+      )
   )
 
   server.tool(
@@ -56,34 +37,13 @@ export function registerQueryTools(server: McpServer) {
         .max(1000)
         .default(10)
         .describe('Max number of queries to return (default: 10)'),
-      hostId: z.number().optional().describe('Host index (default: 0)'),
+      hostId: hostIdSchema,
     },
-    async ({ limit, hostId }) => {
-      const effectiveLimit = limit
-
-      const result = await fetchData({
-        query:
-          "SELECT query_id, user, query_duration_ms, read_rows, memory_usage, substring(query, 1, 200) AS query, event_time FROM system.query_log WHERE type = 'QueryFinish' AND is_initial_query = 1 ORDER BY query_duration_ms DESC LIMIT {limit:UInt32}",
-        query_params: { limit: effectiveLimit },
-        hostId: hostId ?? 0,
-        format: 'JSONEachRow',
-        clickhouse_settings: { readonly: '1' },
-      })
-
-      if (result.error) {
-        return {
-          content: [
-            { type: 'text' as const, text: `Error: ${result.error.message}` },
-          ],
-          isError: true,
-        }
-      }
-
-      return {
-        content: [
-          { type: 'text' as const, text: JSON.stringify(result.data, null, 2) },
-        ],
-      }
-    }
+    async ({ limit, hostId }) =>
+      runReadonlyQuery(
+        "SELECT query_id, user, query_duration_ms, read_rows, memory_usage, substring(query, 1, 200) AS query, event_time FROM system.query_log WHERE type = 'QueryFinish' AND is_initial_query = 1 ORDER BY query_duration_ms DESC LIMIT {limit:UInt32}",
+        hostId,
+        { query_params: { limit } }
+      )
   )
 }

--- a/packages/mcp-server/src/tools/query.ts
+++ b/packages/mcp-server/src/tools/query.ts
@@ -2,7 +2,7 @@ import type { DataFormat } from '@clickhouse/client'
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
-import { fetchData } from '@chm/clickhouse-client'
+import { hostIdSchema, runReadonlyQuery, toErrorResult } from './helpers'
 import { validateSqlQuery } from '@chm/sql-builder'
 import { z } from 'zod/v3'
 
@@ -12,7 +12,7 @@ export function registerQueryTool(server: McpServer) {
     'Execute a read-only SQL query against ClickHouse. Only SELECT and WITH (CTE) queries are allowed.',
     {
       sql: z.string().describe('SQL query to execute (SELECT only)'),
-      hostId: z.number().optional().describe('Host index (default: 0)'),
+      hostId: hostIdSchema,
       format: z
         .string()
         .optional()
@@ -22,38 +22,14 @@ export function registerQueryTool(server: McpServer) {
       try {
         validateSqlQuery(sql)
       } catch (err) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: `Validation error: ${err instanceof Error ? err.message : String(err)}`,
-            },
-          ],
-          isError: true,
-        }
+        return toErrorResult(
+          `Validation error: ${err instanceof Error ? err.message : String(err)}`
+        )
       }
 
-      const result = await fetchData({
-        query: sql,
-        hostId: hostId ?? 0,
+      return runReadonlyQuery(sql, hostId, {
         format: (format ?? 'JSONEachRow') as DataFormat,
-        clickhouse_settings: { readonly: '1' },
       })
-
-      if (result.error) {
-        return {
-          content: [
-            { type: 'text' as const, text: `Error: ${result.error.message}` },
-          ],
-          isError: true,
-        }
-      }
-
-      return {
-        content: [
-          { type: 'text' as const, text: JSON.stringify(result.data, null, 2) },
-        ],
-      }
     }
   )
 }

--- a/packages/mcp-server/src/tools/tables.ts
+++ b/packages/mcp-server/src/tools/tables.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
-import { fetchData } from '@chm/clickhouse-client'
+import { hostIdSchema, runReadonlyQuery } from './helpers'
 import { z } from 'zod/v3'
 
 export function registerTableTools(server: McpServer) {
@@ -9,33 +9,14 @@ export function registerTableTools(server: McpServer) {
     'List tables in a ClickHouse database with row counts and sizes, ordered by size descending.',
     {
       database: z.string().describe('Database name'),
-      hostId: z.number().optional().describe('Host index (default: 0)'),
+      hostId: hostIdSchema,
     },
-    async ({ database, hostId }) => {
-      const result = await fetchData({
-        query:
-          'SELECT name, engine, total_rows, formatReadableSize(total_bytes) AS size FROM system.tables WHERE database = {database:String} ORDER BY total_bytes DESC',
-        query_params: { database },
-        hostId: hostId ?? 0,
-        format: 'JSONEachRow',
-        clickhouse_settings: { readonly: '1' },
-      })
-
-      if (result.error) {
-        return {
-          content: [
-            { type: 'text' as const, text: `Error: ${result.error.message}` },
-          ],
-          isError: true,
-        }
-      }
-
-      return {
-        content: [
-          { type: 'text' as const, text: JSON.stringify(result.data, null, 2) },
-        ],
-      }
-    }
+    async ({ database, hostId }) =>
+      runReadonlyQuery(
+        'SELECT name, engine, total_rows, formatReadableSize(total_bytes) AS size FROM system.tables WHERE database = {database:String} ORDER BY total_bytes DESC',
+        hostId,
+        { query_params: { database } }
+      )
   )
 
   server.tool(
@@ -44,32 +25,13 @@ export function registerTableTools(server: McpServer) {
     {
       database: z.string().describe('Database name'),
       table: z.string().describe('Table name'),
-      hostId: z.number().optional().describe('Host index (default: 0)'),
+      hostId: hostIdSchema,
     },
-    async ({ database, table, hostId }) => {
-      const result = await fetchData({
-        query:
-          'SELECT name, type, default_kind, default_expression, comment FROM system.columns WHERE database = {database:String} AND table = {table:String} ORDER BY position',
-        query_params: { database, table },
-        hostId: hostId ?? 0,
-        format: 'JSONEachRow',
-        clickhouse_settings: { readonly: '1' },
-      })
-
-      if (result.error) {
-        return {
-          content: [
-            { type: 'text' as const, text: `Error: ${result.error.message}` },
-          ],
-          isError: true,
-        }
-      }
-
-      return {
-        content: [
-          { type: 'text' as const, text: JSON.stringify(result.data, null, 2) },
-        ],
-      }
-    }
+    async ({ database, table, hostId }) =>
+      runReadonlyQuery(
+        'SELECT name, type, default_kind, default_expression, comment FROM system.columns WHERE database = {database:String} AND table = {table:String} ORDER BY position',
+        hostId,
+        { query_params: { database, table } }
+      )
   )
 }


### PR DESCRIPTION
## Summary

Collapse the ~44 copies of the identical readonly-fetch + MCP-envelope boilerplate across the 8 mcp-server tool files into a shared helper. The MCP tool surface (names, descriptions, schemas) is unchanged. Closes #2148.

## Changes

- New `packages/mcp-server/src/tools/helpers.ts`: `hostIdSchema`, `runReadonlyQuery(query, hostId, opts?)`, `runReadonlyFetch(opts)`, `toErrorResult` / `toJsonResult` (typed as the SDK `CallToolResult`).
- Refactored `databases/merges/tables/queries/query` to one-line query + helper; `metrics/performance/explore-table-schema` (multi-query) keep their combining logic but use `runReadonlyFetch` + the envelope builders. Net −344/+196.

## Test plan

- [ ] `bun run lint`
- [ ] `bun run build` — not run locally
- [ ] `bun run test:unit` (`tools.test.ts`, `performance.test.ts` rely on the fetchData arg shape + envelope, both preserved)

## Notes for reviewer

Behavior preserved byte-for-byte (same SQL, `readonly:'1'`, `hostId ?? 0`, error/JSON output, custom error prefixes). Not build-verified locally; main residual risks are Biome import-ordering and the `CallToolResult` import path.

---

Co-Authored-By: duyetbot <bot@duyet.net>

---
_Generated by [Claude Code](https://claude.ai/code/session_0192Hi19HxYxuqr95RYS2kh5)_