### PR TITLE
fix(rust): return errors instead of panicking on bad input

### DIFF
--- a/rust/monitor-core/src/lib.rs
+++ b/rust/monitor-core/src/lib.rs
@@ -35,9 +35,13 @@ pub fn transform_user_event_counts_v3(
 /// Legacy export returning JSON string (kept for backward compat).
 #[wasm_bindgen]
 pub fn transform_user_event_counts_json(input: &str, time_field: &str) -> String {
+    // On parse/serialize failure return a valid JSON object ("{}") instead of an
+    // empty string, which is not valid JSON. The successful output is an object
+    // (`{ data, users, chartData }`), so an empty object matches that shape and
+    // lets callers `JSON.parse` the result without a syntax error.
     ch_pivot::transform_user_event_counts(input, time_field)
         .and_then(|result| serde_json::to_string(&result))
-        .unwrap_or_default()
+        .unwrap_or_else(|_| "{}".to_string())
 }
 
 #[cfg(test)]

--- a/rust/user-events-rs/src/main.rs
+++ b/rust/user-events-rs/src/main.rs
@@ -74,20 +74,30 @@ fn transform(rows: Vec<Row>, time_field: &str) -> Output {
 }
 
 fn main() {
+    if let Err(err) = run() {
+        eprintln!("{err}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
     let mut input = String::new();
-    io::stdin().read_to_string(&mut input).unwrap();
-    let mut payload: Value = serde_json::from_str(&input).expect("invalid json payload");
+    io::stdin().read_to_string(&mut input)?;
+    let mut payload: Value =
+        serde_json::from_str(&input).map_err(|e| format!("invalid json payload: {e}"))?;
 
     let data_val = payload.get_mut("data").map(|v| v.take());
     let rows: Vec<Row> = serde_json::from_value(data_val.unwrap_or(Value::Array(vec![])))
-        .expect("data must be array");
+        .map_err(|e| format!("data must be array: {e}"))?;
     let time_field = payload
         .get("timeField")
         .and_then(|v| v.as_str())
         .unwrap_or("event_time");
 
     let out = transform(rows, time_field);
-    println!("{}", serde_json::to_string(&out).unwrap());
+    println!("{}", serde_json::to_string(&out)?);
+
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Two Rust error-handling fixes. Closes #2149.

## Changes

- `rust/user-events-rs/src/main.rs`: introduced `run() -> Result<(), Box<dyn Error>>` (mirroring `monitor-core/src/main.rs`); replaced the stdin `unwrap()`/`expect()` calls (`read_to_string`, JSON parse, "data must be array", serialize) with `?` + context, and `main()` prints the error and exits 1. No more panics on malformed stdin.
- `rust/monitor-core/src/lib.rs`: legacy `transform_user_event_counts_json` now returns valid `"{}"` on error instead of `""` (invalid JSON), so callers can parse the result. Signature unchanged.

## Test plan

- [ ] `cargo build` / `cargo test` (Rust CI) — not run locally (deps unavailable)

## Notes for reviewer

Verified by inspection; imports unchanged and still used. `?` relies on `Box<dyn Error>` conversion (idiomatic).

---

Co-Authored-By: duyetbot <bot@duyet.net>

---
_Generated by [Claude Code](https://claude.ai/code/session_0192Hi19HxYxuqr95RYS2kh5)_