### PR TITLE
chore(wasm): remove dead object-pivot TS wrapper; mark rust exports benchmark-only

### DIFF
--- a/docs/knowledge/rust-wasm-performance.md
+++ b/docs/knowledge/rust-wasm-performance.md
@@ -3,7 +3,7 @@ id: rust-wasm-performance
 title: Rust and WASM Performance
 type: decision
 status: active
-updated: 2026-05-09
+updated: 2026-07-02
 source_pr: 1021
 tags:
   - rust
@@ -20,6 +20,8 @@ related:
 ## Decision
 
 Keep object-heavy transforms in TypeScript. Use Rust/WASM only for JSON-preserving or byte/string-heavy paths where data can stay serialized across the JS/WASM boundary.
+
+> **Object-pivot WASM path is benchmark-only (issue #2150).** The user-event pivot runs in pure TS (`apps/dashboard/src/lib/chart-data-transforms/transforms/user-events.ts` → `transformUserEventCounts`). The dead TS wrapper `transformUserEventCountsWasm` was removed; the Rust exports `transform_user_event_counts_v2` / `_v3` remain only for `scripts/benchmarks/` and are not called by the app. Fully removing them requires rebuilding the committed `.wasm` binary — a follow-up for a maintainer who can run the wasm build.
 
 Do not promote native Rust subprocess transforms into hot API paths. Process startup and IPC overhead dominate the benchmark for small and medium inputs.
 

--- a/packages/clickhouse-client/src/wasm/monitor-core.ts
+++ b/packages/clickhouse-client/src/wasm/monitor-core.ts
@@ -54,30 +54,6 @@ async function loadMonitorCore(): Promise<MonitorCoreModule> {
   return modulePromise
 }
 
-function toPlainObjects(value: unknown): unknown {
-  if (
-    value instanceof Map ||
-    Object.prototype.toString.call(value) === '[object Map]'
-  ) {
-    const map = value as Map<unknown, unknown>
-    return Object.fromEntries(
-      [...map.entries()].map(([key, entry]) => [key, toPlainObjects(entry)])
-    )
-  }
-
-  if (Array.isArray(value)) {
-    return value.map(toPlainObjects)
-  }
-
-  if (value && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, entry]) => [key, toPlainObjects(entry)])
-    )
-  }
-
-  return value
-}
-
 export async function transformClickHouseJsonEachRowWasmJson(
   input: string
 ): Promise<string> {
@@ -125,17 +101,4 @@ export async function transformClickHouseDataWasm<
 >(input: T[]): Promise<T[]> {
   const jsonEachRow = input.map((row) => JSON.stringify(row)).join('\n')
   return transformClickHouseJsonEachRowWasm<T>(jsonEachRow)
-}
-
-export async function transformUserEventCountsWasm<
-  T extends string = 'event_time',
->(input: readonly Record<string, unknown>[], timeField: T = 'event_time' as T) {
-  const mod = await loadMonitorCore()
-  return toPlainObjects(
-    mod.transform_user_event_counts_v3(input, timeField)
-  ) as {
-    data: Record<T, Record<string, number>>
-    users: string[]
-    chartData: Array<Record<T, string> & Record<string, number>>
-  }
 }

--- a/rust/monitor-core/src/lib.rs
+++ b/rust/monitor-core/src/lib.rs
@@ -12,6 +12,14 @@ pub fn transform_clickhouse_json_each_row(input: &str) -> String {
 }
 
 /// WASM export returning JsValue directly — avoids JSON string intermediate.
+///
+/// BENCHMARK-ONLY / NOT USED BY THE APP (see issue #2150). The user-event pivot
+/// runs in pure TypeScript (`apps/dashboard/src/lib/chart-data-transforms/transforms/user-events.ts`,
+/// `transformUserEventCounts`) per `docs/knowledge/rust-wasm-performance.md`
+/// ("keep object transforms in TS"). This export is retained only for the WASM
+/// benchmarks in `scripts/benchmarks/`. Fully removing it requires rebuilding the
+/// committed `.wasm` binary, which is out of scope for issue #2150 — leave to a
+/// maintainer who can run the wasm build.
 #[wasm_bindgen(js_name = transform_user_event_counts_v2)]
 pub fn transform_user_event_counts_v2(input: &str, time_field: &str) -> Result<JsValue, JsValue> {
     let result = ch_pivot::transform_user_event_counts(input, time_field)
@@ -21,6 +29,14 @@ pub fn transform_user_event_counts_v2(input: &str, time_field: &str) -> Result<J
 
 /// WASM export accepting JsValue input and returning JsValue output — zero JSON string overhead.
 /// JS side: pass pre-parsed array directly, get result object directly.
+///
+/// BENCHMARK-ONLY / NOT USED BY THE APP (see issue #2150). The dead TS wrapper
+/// (`transformUserEventCountsWasm`) that used to call this was removed; the
+/// object-pivot runs in pure TypeScript (`transformUserEventCounts`) per
+/// `docs/knowledge/rust-wasm-performance.md`. This export is retained only for the
+/// WASM benchmarks in `scripts/benchmarks/`. Fully removing it requires rebuilding
+/// the committed `.wasm` binary, which is out of scope for issue #2150 — leave to a
+/// maintainer who can run the wasm build.
 #[wasm_bindgen(js_name = transform_user_event_counts_v3)]
 pub fn transform_user_event_counts_v3(
     input: JsValue,


### PR DESCRIPTION
## Summary

The user-event object-pivot runs in TS (per `rust-wasm-performance.md`); the WASM object-pivot surface is dead. Closes #2150.

## Changes

- `packages/clickhouse-client/src/wasm/monitor-core.ts`: removed the unused `transformUserEventCountsWasm` wrapper + its only-caller helper `toPlainObjects` (verified unreferenced: `rg` matched only the definition; the benchmark script calls the raw wasm fns directly).
- `rust/monitor-core/src/lib.rs`: added "benchmark-only / not used by the app (#2150)" doc-comments above `transform_user_event_counts_v2`/`_v3` (kept, to avoid desyncing from the committed `.wasm`).
- `docs/knowledge/rust-wasm-performance.md`: one-line note that the object-pivot wasm path is benchmark-only; bumped `updated:`.

## Test plan

- [ ] `bun run build` / `bun run test:unit` — not run locally

## Notes for reviewer

Fully removing the Rust `_v2`/`_v3` exports + regenerating `.wasm` is a maintainer follow-up (needs the wasm build). The generated bindings under `wasm/generated/` were not touched.

---

Co-Authored-By: duyetbot <bot@duyet.net>

---
_Generated by [Claude Code](https://claude.ai/code/session_0192Hi19HxYxuqr95RYS2kh5)_