### PR TITLE
feat(connections): two-column Add ClickHouse host dialog with help panel

### DIFF
--- a/apps/dashboard/src/components/connections/add-host-dialog.tsx
+++ b/apps/dashboard/src/components/connections/add-host-dialog.tsx
@@ -1,6 +1,7 @@
 import type { HostStorageMode } from '@/lib/types/host-storage'
 
 import { ConnectionForm, type ConnectionFormData } from './connection-form'
+import { ConnectionHelpPanel } from './connection-help-panel'
 import { useState } from 'react'
 import {
   Dialog,
@@ -56,51 +57,52 @@ export function AddHostDialog({ open, onOpenChange }: AddHostDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-3xl">
         <DialogHeader>
           <DialogTitle>Add ClickHouse host</DialogTitle>
           <DialogDescription>
-            chmonitor needs a user with <code>SELECT</code> on{' '}
-            <code>system.*</code>. See{' '}
-            <a
-              href={docsSiteUrl('getting-started/clickhouse-requirements')}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary underline-offset-4 hover:underline"
-            >
-              required permissions &amp; firewall setup
-            </a>{' '}
-            for grants and how to allowlist the Cloud connection.
+            Point chmonitor at a ClickHouse cluster to start monitoring. It
+            needs a user with <code>SELECT</code> on <code>system.*</code> — see
+            the guidance on the right for grants, firewall setup, and how your
+            credentials are stored.
           </DialogDescription>
         </DialogHeader>
 
-        {!isSignedIn && (
-          <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs text-amber-800 dark:border-amber-800/30 dark:bg-amber-950/20 dark:text-amber-300">
-            <p className="font-medium">Sign in for more</p>
-            <p className="mt-0.5 text-amber-700 dark:text-amber-400">
-              Server storage is disabled on this deployment.{' '}
-              <a
-                href={docsSiteUrl('features/user-connections')}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-medium underline underline-offset-2 hover:text-amber-900 dark:hover:text-amber-200"
-              >
-                Enable user connections
-              </a>
-              . Sign in to select your plan or join an organization to get
-              access to your team&apos;s clusters.
-            </p>
-          </div>
-        )}
+        {/* Two columns on md+ (form left, guidance right); stacks with the form
+            on top on narrow screens. */}
+        <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_17rem]">
+          <div className="space-y-4">
+            {!isSignedIn && (
+              <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs text-amber-800 dark:border-amber-800/30 dark:bg-amber-950/20 dark:text-amber-300">
+                <p className="font-medium">Sign in for more</p>
+                <p className="mt-0.5 text-amber-700 dark:text-amber-400">
+                  Server storage is disabled on this deployment.{' '}
+                  <a
+                    href={docsSiteUrl('features/user-connections')}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-medium underline underline-offset-2 hover:text-amber-900 dark:hover:text-amber-200"
+                  >
+                    Enable user connections
+                  </a>
+                  . Sign in to select your plan or join an organization to get
+                  access to your team&apos;s clusters.
+                </p>
+              </div>
+            )}
 
-        <ConnectionForm
-          onSave={handleSave}
-          onCancel={() => onOpenChange(false)}
-          storageMode={storageMode}
-          onStorageModeChange={setStorageMode}
-          dbStorageEnabled={dbStorageEnabled}
-          dbStorageRequiresSignIn={dbStorageConfigured && !isSignedIn}
-        />
+            <ConnectionForm
+              onSave={handleSave}
+              onCancel={() => onOpenChange(false)}
+              storageMode={storageMode}
+              onStorageModeChange={setStorageMode}
+              dbStorageEnabled={dbStorageEnabled}
+              dbStorageRequiresSignIn={dbStorageConfigured && !isSignedIn}
+            />
+          </div>
+
+          <ConnectionHelpPanel />
+        </div>
       </DialogContent>
     </Dialog>
   )

--- a/apps/dashboard/src/components/connections/connection-help-panel.tsx
+++ b/apps/dashboard/src/components/connections/connection-help-panel.tsx
@@ -1,0 +1,235 @@
+import {
+  ArrowUpRight,
+  Database,
+  KeyRound,
+  Lock,
+  MonitorSmartphone,
+  Network,
+  ShieldCheck,
+} from 'lucide-react'
+
+import { ChmonitorLogo } from '@/components/icons/chmonitor-logo'
+import { docsSiteUrl } from '@/lib/docs-site'
+import { cn } from '@/lib/utils'
+
+/**
+ * Guidance sidebar for the "Add ClickHouse host" dialog. Explains what chmonitor
+ * needs to connect (a read-only `SELECT` user, a firewall allowlist), how
+ * credentials are protected, and links to the same docs the form references —
+ * so the operator has the requirements in view while filling in the form.
+ *
+ * Purely presentational (no state / no behaviour); the flow diagram and lists
+ * are built from design-token divs + `lucide-react` icons.
+ */
+export function ConnectionHelpPanel({ className }: { className?: string }) {
+  return (
+    <aside
+      className={cn(
+        'flex flex-col gap-5 rounded-xl border bg-gradient-to-b from-muted/40 to-muted/10 p-4 text-sm dark:from-muted/20 dark:to-muted/5',
+        'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-right-2 motion-safe:duration-300',
+        className
+      )}
+    >
+      <ConnectionFlowDiagram />
+
+      <Section
+        icon={<KeyRound className="size-4 text-orange-500" strokeWidth={1.5} />}
+        title="What chmonitor needs"
+      >
+        <ul className="space-y-2 text-xs text-muted-foreground">
+          <RequirementItem
+            icon={
+              <ShieldCheck
+                className="size-3.5 text-muted-foreground"
+                strokeWidth={1.5}
+              />
+            }
+          >
+            A ClickHouse user with{' '}
+            <code className="text-foreground">SELECT</code> on{' '}
+            <code className="text-foreground">system.*</code> — read-only is
+            enough.
+          </RequirementItem>
+          <RequirementItem
+            icon={
+              <Network
+                className="size-3.5 text-muted-foreground"
+                strokeWidth={1.5}
+              />
+            }
+          >
+            The HTTP interface reachable from chmonitor (allowlist the Cloud
+            connection in your firewall).
+          </RequirementItem>
+        </ul>
+        <a
+          href={docsSiteUrl('getting-started/clickhouse-requirements')}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-foreground underline-offset-2 hover:underline"
+        >
+          Required permissions &amp; firewall setup
+          <ArrowUpRight className="size-3" />
+        </a>
+      </Section>
+
+      <Section
+        icon={<Lock className="size-4 text-emerald-500" strokeWidth={1.5} />}
+        title="Your credentials are safe"
+      >
+        <p className="text-xs text-muted-foreground">
+          Credentials are encrypted in this browser. Short-lived session tokens
+          are used for API requests, so your password is not sent on every
+          query.
+        </p>
+        <a
+          href={docsSiteUrl('features/user-connections')}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-foreground underline-offset-2 hover:underline"
+        >
+          Sync connections across devices
+          <ArrowUpRight className="size-3" />
+        </a>
+      </Section>
+    </aside>
+  )
+}
+
+/** A titled block: small icon + label heading, then arbitrary content. */
+function Section({
+  icon,
+  title,
+  children,
+}: {
+  icon: React.ReactNode
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        {icon}
+        <h3 className="text-[13px] font-semibold tracking-tight">{title}</h3>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function RequirementItem({
+  icon,
+  children,
+}: {
+  icon: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <li className="flex items-start gap-2">
+      <span className="mt-0.5 shrink-0">{icon}</span>
+      <span className="leading-relaxed">{children}</span>
+    </li>
+  )
+}
+
+/**
+ * A compact "your browser → chmonitor → ClickHouse" flow, so operators can see
+ * at a glance where the connection sits. Built from token-driven divs; the
+ * connectors are an inline SVG that flips gracefully in dark mode.
+ */
+function ConnectionFlowDiagram() {
+  return (
+    <div className="rounded-lg border bg-card/60 p-3">
+      <div className="flex items-center justify-between gap-1">
+        <FlowNode
+          label="Your browser"
+          icon={
+            <MonitorSmartphone
+              className="size-5 text-muted-foreground"
+              strokeWidth={1.5}
+            />
+          }
+        />
+        <FlowConnector />
+        <FlowNode
+          label="chmonitor"
+          icon={<ChmonitorLogo width={20} height={20} />}
+          emphasized
+        />
+        <FlowConnector />
+        <FlowNode
+          label="ClickHouse"
+          icon={
+            <Database
+              className="size-5 text-muted-foreground"
+              strokeWidth={1.5}
+            />
+          }
+        />
+      </div>
+      <p className="mt-2.5 text-center text-[11px] text-muted-foreground">
+        chmonitor reads your cluster over the ClickHouse HTTP interface.
+      </p>
+    </div>
+  )
+}
+
+function FlowNode({
+  label,
+  icon,
+  emphasized = false,
+}: {
+  label: string
+  icon: React.ReactNode
+  emphasized?: boolean
+}) {
+  return (
+    <div className="flex min-w-0 flex-1 flex-col items-center gap-1.5 text-center">
+      <div
+        className={cn(
+          'flex size-10 items-center justify-center rounded-lg border bg-background',
+          emphasized &&
+            'border-orange-500/40 shadow-sm ring-1 ring-orange-500/10'
+        )}
+      >
+        {icon}
+      </div>
+      <span className="text-[10px] font-medium text-muted-foreground">
+        {label}
+      </span>
+    </div>
+  )
+}
+
+/**
+ * A dashed connector with a subtle flow dot. The dot uses the CSS
+ * `flow-dot` keyframe via `motion-safe:` so it is disabled under
+ * `prefers-reduced-motion` (SMIL would ignore that preference).
+ */
+function FlowConnector() {
+  return (
+    <svg
+      viewBox="0 0 40 8"
+      className="h-2 w-8 shrink-0 text-border"
+      fill="none"
+      aria-hidden="true"
+    >
+      <line
+        x1="1"
+        y1="4"
+        x2="39"
+        y2="4"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeDasharray="3 3"
+        strokeLinecap="round"
+      />
+      <circle
+        cx="6"
+        cy="4"
+        r="1.75"
+        className="fill-orange-500 motion-safe:animate-flow-dot"
+      />
+    </svg>
+  )
+}

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -18,6 +18,7 @@
   --animate-scale-in: scale-in 0.2s ease-out;
   --animate-pulse-subtle: pulse-subtle 3s ease-in-out infinite;
   --animate-progress-fill: progress-fill 0.8s ease-out forwards;
+  --animate-flow-dot: flow-dot 3s cubic-bezier(0.4, 0, 0.2, 1) infinite;
 
   @keyframes shimmer {
     100% {
@@ -73,6 +74,18 @@
     }
     100% {
       width: var(--progress-width);
+    }
+  }
+  /* Dot travelling along the "browser → chmonitor → ClickHouse" connector in the
+     Add-host dialog. Applied via `motion-safe:animate-flow-dot`, so it is off
+     under prefers-reduced-motion. */
+  @keyframes flow-dot {
+    0%,
+    100% {
+      transform: translateX(0);
+    }
+    50% {
+      transform: translateX(26px);
     }
   }
 }


### PR DESCRIPTION
## What
Redesigns the **Add ClickHouse host** dialog from a cramped single column into a wider two-column layout.

- **Left column**: the existing `ConnectionForm` (Name, Host URL, Username, Password, Save-to-server toggle, Test Connection, `ConnectionErrorPanel`, Cancel/Save) — moved verbatim, not rewritten.
- **Right column**: new `ConnectionHelpPanel` — a `browser → chmonitor → ClickHouse` flow diagram, "what chmonitor needs" (SELECT on `system.*`, firewall/allowlist) and "your credentials are safe" notes, reusing the existing docs links. lucide icons.

## Design notes
- `DialogContent` widened `sm:max-w-md → sm:max-w-3xl`; `grid gap-6 md:grid-cols-[minmax(0,1fr)_17rem]`, stacks to one column below `md`.
- `ConnectionForm` left **unchanged** because it's shared with the narrower `ConnectionManagerDialog` — columns live in `AddHostDialog`, not the shared form.
- Flow-dot animation is a `motion-safe:` CSS keyframe (not SVG SMIL) so it respects `prefers-reduced-motion`.
- No `components/ui/*` modified. Biome + type-check clean on touched files.

## Not yet visually verified
Pure layout/visual change; reaching the live dialog needs auth. Recommend an eyeball of the flow-diagram spacing at the `md` breakpoint post-merge.

https://claude.ai/code/session_01GdkqiuL4a4KTPceGsbxvtN