### PR TITLE
fix(agent): add outermost error boundary to /api/v1/agent (opaque 500 -> error card)

### DIFF
--- a/apps/dashboard/src/lib/ai/__tests__/providers.test.ts
+++ b/apps/dashboard/src/lib/ai/__tests__/providers.test.ts
@@ -50,6 +50,23 @@ describe('parseModelId', () => {
       model: 'openrouter/free',
     })
   })
+
+  // Regression: the reported 500 came from `anyrouter:google/gemma-4-26b`.
+  // The model id itself contains a slash, so only the FIRST ':' may be treated
+  // as the provider separator — the slash must stay part of the model name.
+  test('parses anyrouter provider with a slash in the model id', () => {
+    expect(parseModelId('anyrouter:google/gemma-4-26b')).toEqual({
+      provider: 'anyrouter',
+      model: 'google/gemma-4-26b',
+    })
+  })
+
+  test('keeps a trailing :free tag on a prefixed slash model', () => {
+    expect(parseModelId('anyrouter:qwen/qwen3-coder:free')).toEqual({
+      provider: 'anyrouter',
+      model: 'qwen/qwen3-coder:free',
+    })
+  })
 })
 
 describe('resolveProvider', () => {
@@ -99,6 +116,17 @@ describe('resolveProvider', () => {
     expect(resolved.apiKey).toBe('ar-test-key')
     expect(resolved.baseURL).toBe('https://anyrouter.dev/api/v1')
     expect(resolved.sdk).toBe('openai')
+  })
+
+  // Regression for the reported 500 model id (slash inside the model name).
+  test('resolves anyrouter provider for a slash-containing model id', () => {
+    setEnv({ ANYROUTER_API_KEY: 'ar-test-key' })
+    const resolved = resolveProvider('anyrouter:google/gemma-4-26b')
+    expect(resolved.providerId).toBe('anyrouter')
+    expect(resolved.apiKey).toBe('ar-test-key')
+    expect(resolved.baseURL).toBe('https://anyrouter.dev/api/v1')
+    expect(resolved.sdk).toBe('openai')
+    expect(resolved.isOpenRouter).toBe(false)
   })
 
   test('unprefixed free model uses OpenRouter key cascade', () => {

--- a/apps/dashboard/src/lib/ai/agent/__tests__/errors.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/__tests__/errors.test.ts
@@ -75,4 +75,28 @@ describe('agent error classification', () => {
       message: 'Provider unavailable',
     })
   })
+
+  // The agent route's outermost boundary passes any uncaught throw through
+  // classifyError. Whatever escapes must still become a renderable AgentError
+  // (round-trippable via parseAgentError) instead of an opaque HTML 500.
+  test('classifies an arbitrary uncaught throw into a renderable AgentError', () => {
+    const classified = classifyError(
+      new Error('Cannot read properties of undefined')
+    )
+
+    expect(classified.type).toBe('unknown')
+    expect(classified.message).toBe('Cannot read properties of undefined')
+    expect(typeof classified.suggestion).toBe('string')
+    expect(classified.suggestion.length).toBeGreaterThan(0)
+    expect(typeof classified.timestamp).toBe('number')
+
+    // The boundary serialises `{ error: classified }`; the client re-parses it.
+    const roundTripped = parseAgentError(
+      new Error(JSON.stringify({ error: classified }))
+    )
+    expect(roundTripped).toMatchObject({
+      type: 'unknown',
+      message: 'Cannot read properties of undefined',
+    })
+  })
 })

--- a/apps/dashboard/src/routes/api/v1/agent.ts
+++ b/apps/dashboard/src/routes/api/v1/agent.ts
@@ -867,10 +867,41 @@ async function handlePost(request: Request): Promise<Response> {
   })
 }
 
+/**
+ * Outermost error boundary for the agent endpoint.
+ *
+ * `handlePost` guards every individual step (auth, MCP connect, billing, the
+ * stream body) but the pre-stream setup — `createClickHouseAgent`,
+ * `connectCustomMcpServers`, `authorizeAgentApiRequest` — runs before the
+ * streaming Response is built. If any of those throws (e.g. a provider/runtime
+ * edge case), the rejection would otherwise escape to the framework, which
+ * serves a bare `text/html` 500. The client's `apiFetch` then surfaces that as
+ * the opaque "Request failed (500 Error)". Wrapping the handler converts any
+ * uncaught throw into a structured, classified `application/json` error the chat
+ * UI can render (title, cause, suggestion) and logs the raw cause so the true
+ * origin is visible in worker logs / Sentry.
+ */
+async function handlePostWithBoundary(request: Request): Promise<Response> {
+  try {
+    return await handlePost(request)
+  } catch (error) {
+    const classified = classifyError(error)
+    console.error('[Agent API] Unhandled error:', classified, error)
+    const status =
+      typeof classified.statusCode === 'number' && classified.statusCode >= 400
+        ? classified.statusCode
+        : 500
+    return new Response(JSON.stringify({ error: classified }), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+}
+
 export const Route = createFileRoute('/api/v1/agent')({
   server: {
     handlers: {
-      POST: async ({ request }) => handlePost(request),
+      POST: async ({ request }) => handlePostWithBoundary(request),
     },
   },
 })


### PR DESCRIPTION
## Symptom
On `/agents`, sending a chat message returned an opaque **"Request failed (500 Error)"** with no message and nothing logged.

## Root cause (traced with evidence)
- The exact string comes from `lib/swr/api-fetch.ts:31`, which only fires for a **`text/html` non-ok** response — i.e. a framework HTML 500 from an *uncaught* throw. The route's own structured JSON errors (503/402/400) are `application/json` and render as normal error cards.
- `routes/api/v1/agent.ts` `handlePost` guards each step individually (auth, parse, MCP connect, billing, stream body) but has **no outermost boundary**. A throw in pre-stream setup (`createClickHouseAgent` / `connectCustomMcpServers` / `authorizeAgentApiRequest`) escapes to TanStack Start → bare HTML 500.
- Model-id parsing was **ruled out** via a repro: `anyrouter:google/gemma-4-26b` parses correctly (slash stays in model name), AnyRouter loads its key lazily so construction doesn't throw synchronously.

## Fix
- `handlePostWithBoundary` wraps `handlePost`: any uncaught throw → `classifyError()` → structured `application/json` error card **and** `console.error('[Agent API] Unhandled error:', …)` so the real stack surfaces in `wrangler tail` / Sentry. Surgical; the individual guards are untouched.

## Tests (24 pass)
- `lib/ai/__tests__/providers.test.ts`: `parseModelId`/`resolveProvider` for `anyrouter:google/gemma-4-26b` + `qwen/…:free`.
- `lib/ai/agent/__tests__/errors.test.ts`: arbitrary throw classifies into a renderable AgentError and round-trips through the client parser.

## Honest caveat
The *exact* throwing statement in workerd is not statically pinned; it couldn't be safely reproduced against prod. This change makes the failure **loud and diagnosable** — after deploy, the new `console.error` line will print the real stack for a definitive fix if it recurs.

https://claude.ai/code/session_01GdkqiuL4a4KTPceGsbxvtN