### PR TITLE
fix(cloud): stop signed-in zero-connection users seeing demo host data

### DIFF
--- a/apps/dashboard/src/components/host/first-run-decision.test.ts
+++ b/apps/dashboard/src/components/host/first-run-decision.test.ts
@@ -1,0 +1,147 @@
+import type { FirstRunInput } from './first-run-decision'
+
+import { resolveFirstRunAction } from './first-run-decision'
+import { describe, expect, it } from 'bun:test'
+
+/**
+ * Encodes the cloud-mode host-resolution invariant (docs/knowledge/cloud-saas-mode.md):
+ * a signed-in user must NEVER be served the read-only demo host. The demo is
+ * hidden from their merged host list, so a stale `?host=0` (carried over from
+ * browsing the demo while anonymous) resolves to no visible host — and must not
+ * fall through to rendering demo-backed charts.
+ */
+
+// Sensible defaults; each test overrides only what it exercises.
+function input(overrides: Partial<FirstRunInput> = {}): FirstRunInput {
+  return {
+    isLoading: false,
+    isUnauthorized: false,
+    onExemptPath: false,
+    hostCount: 1,
+    cloudMode: false,
+    isSignedIn: false,
+    hasVisibleResolvedHost: true,
+    firstVisibleHostId: 0,
+    ...overrides,
+  }
+}
+
+describe('resolveFirstRunAction — cloud + signed-in (the bug)', () => {
+  it('signed-in cloud user with ZERO connections and stale ?host=0 → setup, not demo data', () => {
+    // Demo hidden ⇒ hostCount 0, and the stale ?host=0 resolves to nothing.
+    const action = resolveFirstRunAction(
+      input({
+        cloudMode: true,
+        isSignedIn: true,
+        hostCount: 0,
+        hasVisibleResolvedHost: false,
+        firstVisibleHostId: null,
+      })
+    )
+    expect(action).toEqual({ type: 'setup' })
+  })
+
+  it('does NOT render (leak demo) while their own connections are still loading', () => {
+    // The regression: previously the gate rendered children during this window,
+    // so demo charts mounted and fetched ?host=0. Must wait instead.
+    const action = resolveFirstRunAction(
+      input({
+        cloudMode: true,
+        isSignedIn: true,
+        isLoading: true,
+        hostCount: 0,
+        hasVisibleResolvedHost: false,
+        firstVisibleHostId: null,
+      })
+    )
+    expect(action).toEqual({ type: 'wait' })
+  })
+
+  it('signed-in cloud user WITH own host but stale ?host=0 → re-point to their host', () => {
+    const action = resolveFirstRunAction(
+      input({
+        cloudMode: true,
+        isSignedIn: true,
+        hostCount: 1,
+        hasVisibleResolvedHost: false, // ?host=0 is the hidden demo, not theirs
+        firstVisibleHostId: -1000, // db connections use negative ids
+      })
+    )
+    expect(action).toEqual({ type: 'repoint', hostId: -1000 })
+  })
+
+  it('signed-in cloud user on their OWN host (?host=-1000) → render', () => {
+    const action = resolveFirstRunAction(
+      input({
+        cloudMode: true,
+        isSignedIn: true,
+        hostCount: 1,
+        hasVisibleResolvedHost: true,
+        firstVisibleHostId: -1000,
+      })
+    )
+    expect(action).toEqual({ type: 'render' })
+  })
+})
+
+describe('resolveFirstRunAction — anonymous cloud (demo is intended)', () => {
+  it('anonymous cloud visitor sees the demo → render', () => {
+    const action = resolveFirstRunAction(
+      input({
+        cloudMode: true,
+        isSignedIn: false,
+        hostCount: 1,
+        hasVisibleResolvedHost: true, // demo is visible to anon
+        firstVisibleHostId: 0,
+      })
+    )
+    expect(action).toEqual({ type: 'render' })
+  })
+})
+
+describe('resolveFirstRunAction — self-hosted (OSS) unchanged', () => {
+  it('OSS with configured env hosts → render', () => {
+    expect(resolveFirstRunAction(input())).toEqual({ type: 'render' })
+  })
+
+  it('OSS with zero hosts once resolved → setup', () => {
+    const action = resolveFirstRunAction(
+      input({ hostCount: 0, hasVisibleResolvedHost: false })
+    )
+    expect(action).toEqual({ type: 'setup' })
+  })
+
+  it('OSS while hosts are still loading → render children (skeletons/Suspense)', () => {
+    const action = resolveFirstRunAction(
+      input({ isLoading: true, hostCount: 0, hasVisibleResolvedHost: false })
+    )
+    expect(action).toEqual({ type: 'render' })
+  })
+})
+
+describe('resolveFirstRunAction — exemptions & auth', () => {
+  it('exempt paths (/setup, /billing, /organization) always render', () => {
+    const action = resolveFirstRunAction(
+      input({
+        onExemptPath: true,
+        cloudMode: true,
+        isSignedIn: true,
+        hostCount: 0,
+        hasVisibleResolvedHost: false,
+        firstVisibleHostId: null,
+      })
+    )
+    expect(action).toEqual({ type: 'render' })
+  })
+
+  it('a 401/403 host fetch does not wall the app (renders, not setup)', () => {
+    const action = resolveFirstRunAction(
+      input({
+        isUnauthorized: true,
+        hostCount: 0,
+        hasVisibleResolvedHost: false,
+      })
+    )
+    expect(action).toEqual({ type: 'render' })
+  })
+})

--- a/apps/dashboard/src/components/host/first-run-decision.ts
+++ b/apps/dashboard/src/components/host/first-run-decision.ts
@@ -1,0 +1,110 @@
+/**
+ * Pure decision logic for {@link FirstRunGate}, extracted so the cloud-mode
+ * host-resolution invariant can be unit-tested without a React/router harness.
+ *
+ * ## Why this exists (the bug it fixes)
+ *
+ * In cloud (SaaS) mode the env `CLICKHOUSE_HOST` surfaces as a public read-only
+ * `demo`. Once a user signs in, {@link useMergedHosts} HIDES that demo so their
+ * workspace starts empty. But the active host for data fetching comes from the
+ * `?host=` search param (default `0`) via `useHostId()`, which is decoupled from
+ * the visible host list. A stale `?host=0` — carried over from browsing the demo
+ * while anonymous — then points at the now-hidden demo.
+ *
+ * `resolve-host-fetch.ts` treats a host id that is NOT in the merged list as
+ * "server host" and falls back to `/api/v1/charts/...?hostId=0`, which serves the
+ * demo. So a signed-in, zero-connection user could still see real demo data,
+ * violating the documented invariant (demo hidden → own connections only → zero
+ * ⇒ welcome/setup). See docs/knowledge/cloud-saas-mode.md.
+ *
+ * The discriminator is deterministic: user connections (browser/database) always
+ * use NEGATIVE host ids (`DB_CONNECTION_HOST_ID_START = -1000`, browser ids count
+ * down from -1), while env/demo hosts use non-negative indices `0, 1, 2, …`. So a
+ * non-negative `?host` for a signed-in cloud user can only ever be the hidden
+ * demo — never one of their own hosts. We key off "is the resolved host actually
+ * visible" rather than the raw id, which stays correct for every source.
+ */
+
+/** What FirstRunGate should do this render. */
+export type FirstRunAction =
+  /** Render the routed page. */
+  | { type: 'render' }
+  /** Render a skeleton and do not navigate (hosts still resolving). */
+  | { type: 'wait' }
+  /** Navigate to the /setup welcome surface, render a skeleton meanwhile. */
+  | { type: 'setup' }
+  /**
+   * Re-point `?host` at a real, visible host id (the current selection is a
+   * stale demo pointer) and render a skeleton meanwhile.
+   */
+  | { type: 'repoint'; hostId: number }
+
+export interface FirstRunInput {
+  /** Merged host list is still loading (env + browser + database). */
+  isLoading: boolean
+  /** The env-host fetch returned 401/403 (an auth failure, not a real empty). */
+  isUnauthorized: boolean
+  /** Current path is exempt (/setup, /billing, /organization). */
+  onExemptPath: boolean
+  /** Number of VISIBLE merged hosts. */
+  hostCount: number
+  /** Cloud (SaaS) mode is active for this deployment. */
+  cloudMode: boolean
+  /** Visitor is signed in (always false outside Clerk builds). */
+  isSignedIn: boolean
+  /** Whether the active `?host` id resolves to a currently-VISIBLE host. */
+  hasVisibleResolvedHost: boolean
+  /** First visible host id, if any (used to re-point a stale selection). */
+  firstVisibleHostId: number | null
+}
+
+/**
+ * Decide what FirstRunGate renders / navigates to.
+ *
+ * OSS and anonymous-cloud behaviour is unchanged: the only new branch is
+ * "cloud + signed-in + the active host is not one of the user's visible hosts",
+ * which must never fall through to rendering demo-backed charts.
+ */
+export function resolveFirstRunAction(input: FirstRunInput): FirstRunAction {
+  const {
+    isLoading,
+    isUnauthorized,
+    onExemptPath,
+    hostCount,
+    cloudMode,
+    isSignedIn,
+    hasVisibleResolvedHost,
+    firstVisibleHostId,
+  } = input
+
+  // The frontend is a rendering layer, not the security boundary: a 401/403 is
+  // not something the visitor resolves here, so we don't wall the app — pages
+  // render and individual data calls surface their own states. (Unchanged.)
+  if (isUnauthorized) return { type: 'render' }
+
+  // Account/billing/setup pages stay reachable with zero hosts and must not be
+  // re-pointed. (Unchanged.)
+  if (onExemptPath) return { type: 'render' }
+
+  // Cloud + signed-in: the env host is a hidden read-only demo. If the active
+  // `?host` does not resolve to one of the user's OWN visible hosts, rendering
+  // the routed page would leak demo data (resolve-host-fetch falls back to the
+  // server/demo host for an unresolved id). Guard BEFORE we ever render charts,
+  // and independently of whether their connections have finished loading.
+  const cloudDemoLeakRisk = cloudMode && isSignedIn && !hasVisibleResolvedHost
+  if (cloudDemoLeakRisk) {
+    // Wait for their own connections rather than briefly flashing demo charts.
+    if (isLoading) return { type: 'wait' }
+    // Genuinely empty workspace → welcome/setup.
+    if (hostCount === 0 || firstVisibleHostId === null) return { type: 'setup' }
+    // They have their own host(s), but `?host` is a stale demo pointer — send
+    // them to a real host instead of leaking the demo.
+    return { type: 'repoint', hostId: firstVisibleHostId }
+  }
+
+  // Genuine first run for OSS / anonymous cloud: no hosts at all once resolved.
+  // (While still loading we render children so existing skeletons/Suspense show.)
+  if (!isLoading && hostCount === 0) return { type: 'setup' }
+
+  return { type: 'render' }
+}

--- a/apps/dashboard/src/components/host/first-run-gate.tsx
+++ b/apps/dashboard/src/components/host/first-run-gate.tsx
@@ -1,7 +1,10 @@
+import { resolveFirstRunAction } from './first-run-decision'
 import { useEffect } from 'react'
 import { PageSkeleton } from '@/components/skeletons'
-import { usePathname, useRouter } from '@/lib/next-compat'
+import { usePathname, useRouter, useSearchParams } from '@/lib/next-compat'
+import { useHostId } from '@/lib/swr'
 import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
+import { buildUrl } from '@/lib/url/url-builder'
 
 /**
  * The frontend is a pure rendering layer; the backend is the security boundary
@@ -12,25 +15,36 @@ import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
  * Pages render; individual data calls surface their own auth / empty / error
  * states (and in `none` mode the API allows everything, so they just succeed).
  *
- * The one first-run surface we keep is genuine onboarding: zero ClickHouse hosts
- * configured — and only when that is the real state, not merely an auth failure
- * that left the host list empty. In that case we send the visitor to the stable
- * `/setup` URL (which renders FirstRunEmptyState) rather than showing the empty
- * state inline on whatever route they happened to land on. `/setup` is itself
- * wrapped by this gate, so it renders children there instead of redirecting —
- * no loop. While hosts are still loading we render children so existing
- * skeletons / Suspense fallbacks keep showing.
+ * Two first-run surfaces are kept:
+ *
+ *  1. Zero ClickHouse hosts configured (genuine onboarding) — send the visitor to
+ *     the stable `/setup` URL (which renders FirstRunEmptyState) rather than
+ *     showing the empty state inline. `/setup` is itself wrapped by this gate, so
+ *     it renders children there instead of redirecting — no loop.
+ *  2. Cloud (SaaS) + signed-in, where the env host is a HIDDEN read-only demo. A
+ *     stale `?host=0` (carried over from browsing the demo while anonymous) points
+ *     at that hidden demo, and resolve-host-fetch would fall back to the server
+ *     (demo) host for the unresolved id — leaking demo data into a signed-in
+ *     user's workspace. We refuse to render the routed page until the active
+ *     `?host` resolves to one of their OWN visible hosts: with none we go to
+ *     `/setup`; with some we re-point `?host` at a real host. See
+ *     first-run-decision.ts and docs/knowledge/cloud-saas-mode.md.
+ *
+ * While hosts are still loading (outside the cloud demo-leak case) we render
+ * children so existing skeletons / Suspense fallbacks keep showing.
  *
  * NOTE: `FirstRunUnauthorizedState` is intentionally no longer rendered here. The
  * component is kept for a possible future inline sign-in prompt rather than a
  * full-page wall.
  */
 export function FirstRunGate({ children }: { children: React.ReactNode }) {
-  const { hosts, isLoading, isUnauthorized } = useMergedHosts()
+  const { hosts, isLoading, isUnauthorized, cloudMode, isSignedIn } =
+    useMergedHosts()
   const router = useRouter()
   const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const hostId = useHostId()
 
-  const noHosts = !isLoading && !isUnauthorized && hosts.length === 0
   // Account/billing pages stay reachable with zero hosts — a paying user with no
   // host connected yet must still be able to view/manage their plan and org
   // (otherwise they're trapped on /setup). /setup is itself exempt (no redirect
@@ -40,13 +54,34 @@ export function FirstRunGate({ children }: { children: React.ReactNode }) {
     pathname === '/billing' ||
     pathname === '/organization'
 
-  useEffect(() => {
-    if (noHosts && !onExemptPath) {
-      router.replace('/setup')
-    }
-  }, [noHosts, onExemptPath, router])
+  const action = resolveFirstRunAction({
+    isLoading,
+    isUnauthorized: Boolean(isUnauthorized),
+    onExemptPath,
+    hostCount: hosts.length,
+    cloudMode,
+    isSignedIn,
+    hasVisibleResolvedHost: hosts.some((h) => h.id === hostId),
+    firstVisibleHostId: hosts[0]?.id ?? null,
+  })
 
-  if (noHosts && !onExemptPath) {
+  // Drive the one navigation each action implies. Both targets self-terminate:
+  // reaching /setup makes the path exempt (→ 'render'); a re-point changes the
+  // resolved host so it becomes visible (→ 'render'). Read only primitives here
+  // so the effect is keyed on the resolved intent, not `action`'s identity.
+  const goSetup = action.type === 'setup'
+  const repointHostId = action.type === 'repoint' ? action.hostId : null
+  useEffect(() => {
+    if (goSetup) {
+      router.replace('/setup')
+    } else if (repointHostId !== null) {
+      router.replace(buildUrl(pathname, { host: repointHostId }, searchParams))
+    }
+  }, [goSetup, repointHostId, pathname, searchParams, router])
+
+  // Render a skeleton (never the routed page's demo-backed charts) whenever we
+  // are waiting on host resolution or a pending navigation.
+  if (action.type !== 'render') {
     return <PageSkeleton />
   }
 

--- a/docs/knowledge/cloud-saas-mode.md
+++ b/docs/knowledge/cloud-saas-mode.md
@@ -3,7 +3,7 @@ id: cloud-saas-mode
 title: Cloud (SaaS) mode — one codebase, two products
 type: spec
 status: active
-updated: 2026-06-30
+updated: 2026-07-02
 tags:
   - saas
   - cloud
@@ -65,6 +65,7 @@ Implemented in `lib/cloud/demo-hosts.ts` (`filterToDemoHosts`), applied at
 - `lib/swr/use-merged-hosts.ts` — demo tagging, hide-when-signed-in; exposes `cloudMode` / `isSignedIn`.
 - `components/host/host-switcher.tsx` — Demo / read-only badges; `demo` behaves like `env` for live status (server-backed by index).
 - `components/host/first-run-empty-state.tsx` — redesigned welcome/setup (cloud signed-in / cloud anon / self-hosted).
+- `components/host/first-run-gate.tsx` + `first-run-decision.ts` — enforce the "signed-in ⇒ no demo data" invariant at the render boundary. The active host for data comes from `?host=` (`useHostId`), which is DECOUPLED from the visible host list; a stale `?host=0` (carried over from browsing the demo while anonymous) points at the now-hidden demo, and `resolve-host-fetch.ts` falls back to the server/demo host for an id not in the merged list — so a signed-in, zero-connection user could otherwise see demo data. The gate refuses to render the routed page (its charts fetch `?host` directly) until the active host resolves to one of the user's OWN visible hosts: while their connections load it shows a skeleton (never demo charts); with zero it routes to `/setup`; with some it re-points `?host` at a real host. Discriminator is deterministic — user connections use NEGATIVE ids (`DB_CONNECTION_HOST_ID_START = -1000`), env/demo use `0,1,2…`, so a non-negative `?host` for a signed-in user is always the demo. OSS + anonymous-cloud behaviour is unchanged. Invariant covered by `first-run-decision.test.ts`.
 
 ## Connection-error help
 


### PR DESCRIPTION
## The bug
In cloud (SaaS) mode a user who is **signed in** and has added **no** ClickHouse hosts still saw the read-only **demo** host's data (e.g. Health page with 215 failed queries / 83% disk) — violating the documented invariant: *demo hidden after sign-in → own connections only → zero connections ⇒ welcome/setup, never demo data.*

## Root cause
The **visible** host list (`useMergedHosts`, which hides the demo after sign-in) and the **active** host (`?host=0` via `useHostId`) are decoupled. A stale `?host=0` carried over from browsing the demo while anonymous points at the now-hidden demo; `resolve-host-fetch` treats an unresolved id as "server host" and falls back to `?hostId=0` → the demo.

## Fix
- Extract pure `resolveFirstRunAction()` (`first-run-decision.ts`) so the invariant is unit-testable without a React/router harness.
- `FirstRunGate`: for `cloudMode && isSignedIn`, if the active `?host` does **not** resolve to one of the user's own **visible** hosts → `wait` while loading, `/setup` when empty, else **re-point** `?host` at a real host. Never renders demo-backed charts. Both navigations self-terminate (no loop).
- Keys off "is the resolved host visible" rather than the raw id, so it's correct for every host source (user connections use negative ids; env/demo use `0,1,2…`).

## Safety
- OSS/self-hosted and **anonymous-cloud** (demo still shown to logged-out visitors) paths are **unchanged** — the new branch only fires for `cloudMode && isSignedIn`.
- Tests: `first-run-decision.test.ts` — **10 pass / 0 fail** (verified locally).
- Updated `docs/knowledge/cloud-saas-mode.md` to document the host-resolution invariant.

https://claude.ai/code/session_01GdkqiuL4a4KTPceGsbxvtN