### PR TITLE
perf(swr): make always-mounted polling hooks visibility-aware

### DIFF
--- a/apps/dashboard/src/components/menu/hooks/use-menu-count.ts
+++ b/apps/dashboard/src/components/menu/hooks/use-menu-count.ts
@@ -15,7 +15,7 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { apiFetch } from '@/lib/swr/api-fetch'
-import { REFRESH_INTERVAL } from '@/lib/swr/config'
+import { REFRESH_INTERVAL, visibilityAwareInterval } from '@/lib/swr/config'
 
 interface MenuCountResult {
   count: number | null
@@ -57,7 +57,7 @@ export function useMenuCounts(hostId: number): {
       }
       return res.json()
     },
-    refetchInterval: REFRESH_INTERVAL.SLOW_2M,
+    refetchInterval: visibilityAwareInterval(REFRESH_INTERVAL.SLOW_2M),
     staleTime: 60_000, // 1 minute deduping
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,

--- a/apps/dashboard/src/components/menu/hooks/use-table-availability.ts
+++ b/apps/dashboard/src/components/menu/hooks/use-table-availability.ts
@@ -13,7 +13,7 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { apiFetch } from '@/lib/swr/api-fetch'
-import { REFRESH_INTERVAL } from '@/lib/swr/config'
+import { REFRESH_INTERVAL, visibilityAwareInterval } from '@/lib/swr/config'
 
 interface TableAvailabilityResponse {
   success: boolean
@@ -43,7 +43,7 @@ export function useTableAvailability(hostId: number): {
       }
       return res.json()
     },
-    refetchInterval: REFRESH_INTERVAL.SLOW_2M,
+    refetchInterval: visibilityAwareInterval(REFRESH_INTERVAL.SLOW_2M),
     staleTime: 60_000, // 1 minute deduping
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,

--- a/apps/dashboard/src/lib/ai/agent/use-ai-quota.ts
+++ b/apps/dashboard/src/lib/ai/agent/use-ai-quota.ts
@@ -23,6 +23,7 @@ import { useQuery } from '@tanstack/react-query'
 
 import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
 import { apiFetch } from '@/lib/swr/api-fetch'
+import { visibilityAwareInterval } from '@/lib/swr/config'
 
 export interface AiQuota {
   /** Messages already sent today. */
@@ -113,7 +114,7 @@ export function useAiQuota(): UseAiQuotaResult {
     staleTime: 30_000,
     // Poll gently so the indicator ticks down as the user sends messages,
     // without hammering the endpoint.
-    refetchInterval: 60_000,
+    refetchInterval: visibilityAwareInterval(60_000),
     refetchOnWindowFocus: true,
     // The endpoint may not exist yet (sibling slice) or the session cookie may
     // be briefly stale — do not spam retries; a single miss just hides it.

--- a/apps/dashboard/src/lib/query/use-insights.ts
+++ b/apps/dashboard/src/lib/query/use-insights.ts
@@ -28,7 +28,7 @@ import {
 import { generateParamsFromSettings } from '@/lib/insights/settings'
 import { useInsightsSettings } from '@/lib/query/use-insights-settings'
 import { apiFetch } from '@/lib/swr/api-fetch'
-import { REFRESH_INTERVAL } from '@/lib/swr/config'
+import { REFRESH_INTERVAL, visibilityAwareInterval } from '@/lib/swr/config'
 
 interface InsightsResponse {
   insights: InsightCard[]
@@ -69,7 +69,7 @@ export function useInsights(hostId: number): UseInsightsResult {
       if (!res.ok) throw new Error('Failed to fetch insights')
       return res.json()
     },
-    refetchInterval: REFRESH_INTERVAL.SLOW_2M,
+    refetchInterval: visibilityAwareInterval(REFRESH_INTERVAL.SLOW_2M),
     staleTime: 60_000,
     retry: 1,
   })

--- a/apps/dashboard/src/lib/swr/config.test.ts
+++ b/apps/dashboard/src/lib/swr/config.test.ts
@@ -1,0 +1,40 @@
+import { REFRESH_INTERVAL, visibilityAwareInterval } from './config'
+import { afterEach, describe, expect, it } from 'bun:test'
+
+// `document` is not defined in the bun test runtime by default; each test that
+// needs it sets a minimal stub and restores afterwards.
+const originalDocument = (globalThis as { document?: unknown }).document
+
+afterEach(() => {
+  if (originalDocument === undefined) {
+    delete (globalThis as { document?: unknown }).document
+  } else {
+    ;(globalThis as { document?: unknown }).document = originalDocument
+  }
+})
+
+describe('visibilityAwareInterval', () => {
+  it('returns a function, not a raw number, so hidden tabs can pause polling', () => {
+    expect(typeof visibilityAwareInterval(REFRESH_INTERVAL.MEDIUM_30S)).toBe(
+      'function'
+    )
+  })
+
+  it('resolves to the interval ms when the tab is visible', () => {
+    ;(globalThis as { document?: unknown }).document = { hidden: false }
+    const resolve = visibilityAwareInterval(REFRESH_INTERVAL.SLOW_2M)
+    expect(resolve()).toBe(REFRESH_INTERVAL.SLOW_2M)
+  })
+
+  it('resolves to false (paused) when the tab is hidden', () => {
+    ;(globalThis as { document?: unknown }).document = { hidden: true }
+    const resolve = visibilityAwareInterval(REFRESH_INTERVAL.MEDIUM_30S)
+    expect(resolve()).toBe(false)
+  })
+
+  it('resolves to the interval ms when document is unavailable (SSR)', () => {
+    delete (globalThis as { document?: unknown }).document
+    const resolve = visibilityAwareInterval(60_000)
+    expect(resolve()).toBe(60_000)
+  })
+})

--- a/apps/dashboard/src/lib/swr/use-cluster-count.ts
+++ b/apps/dashboard/src/lib/swr/use-cluster-count.ts
@@ -11,7 +11,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { apiFetch } from './api-fetch'
-import { REFRESH_INTERVAL } from '@/lib/swr/config'
+import { REFRESH_INTERVAL, visibilityAwareInterval } from '@/lib/swr/config'
 
 interface ClusterCountResult {
   count: number | null
@@ -60,7 +60,7 @@ export function useClusterCount(
       return res.json()
     },
     enabled: Boolean(countKey && cluster),
-    refetchInterval: REFRESH_INTERVAL.MEDIUM_30S,
+    refetchInterval: visibilityAwareInterval(REFRESH_INTERVAL.MEDIUM_30S),
     staleTime: 15_000, // 15 seconds deduping
     refetchOnWindowFocus: true, // Revalidate on focus for critical metrics
     refetchOnReconnect: true, // Revalidate on reconnect

--- a/apps/dashboard/src/lib/swr/use-notifications.ts
+++ b/apps/dashboard/src/lib/swr/use-notifications.ts
@@ -25,7 +25,7 @@ import {
   filterActiveNotifications,
   getNotificationKey,
 } from '@/lib/notifications/dismissed-notifications'
-import { REFRESH_INTERVAL } from '@/lib/swr/config'
+import { REFRESH_INTERVAL, visibilityAwareInterval } from '@/lib/swr/config'
 
 // Extended notification with required key for UI
 export interface NotificationWithKey extends Omit<Notification, 'key'> {
@@ -78,7 +78,7 @@ export function useNotifications(hostId: number): NotificationsResult {
       }
       return res.json()
     },
-    refetchInterval: REFRESH_INTERVAL.MEDIUM_30S,
+    refetchInterval: visibilityAwareInterval(REFRESH_INTERVAL.MEDIUM_30S),
     staleTime: 15_000, // 15 seconds deduping
     refetchOnWindowFocus: true, // Revalidate on focus for critical metrics
     refetchOnReconnect: true, // Revalidate on reconnect


### PR DESCRIPTION
## Problem

Six always-mounted hooks passed a raw numeric `refetchInterval` to TanStack Query, so they kept polling in hidden/background tabs — burning request cost with zero user benefit.

## Fix

Wrap each interval in the existing `visibilityAwareInterval(ms)` helper (`apps/dashboard/src/lib/swr/config.ts`) — the same pattern `use-chart-data.ts` / `use-host-status.ts` already use. It returns `() => document.hidden ? false : ms`, so polling pauses when the tab is hidden and resumes on focus. **Interval durations are unchanged.**

Hooks updated:
- `lib/swr/use-notifications.ts` (30s)
- `lib/swr/use-cluster-count.ts` (30s)
- `lib/ai/agent/use-ai-quota.ts` (60s)
- `components/menu/hooks/use-menu-count.ts` (2m)
- `components/menu/hooks/use-table-availability.ts` (2m)
- `lib/query/use-insights.ts` (2m)

## Test

Adds `lib/swr/config.test.ts` covering `visibilityAwareInterval`: returns a function (not a raw number), resolves to ms when visible, `false` when hidden, and ms under SSR (no `document`). `bun test src/lib/swr/config.test.ts` → 4 pass.

Closes #2176

https://claude.ai/code/session_01GdkqiuL4a4KTPceGsbxvtN