### PR TITLE
perf(feature-permissions): memoize AppConfig per isolate

### DIFF
--- a/apps/dashboard/src/lib/feature-permissions/__tests__/app-config-cache.test.ts
+++ b/apps/dashboard/src/lib/feature-permissions/__tests__/app-config-cache.test.ts
@@ -1,0 +1,68 @@
+/**
+ * getAppConfig() is called on every gated request via authorizeFeatureRequest.
+ * It reads only immutable-at-runtime env vars, so it must parse once per isolate
+ * and return the cached value thereafter. These tests pin that behavior: the
+ * cache survives an env change and only re-parses after the test-only reset.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// readEnv() in server.ts prefers the cloudflare:workers `env` binding, then
+// falls back to process.env. Mock the binding empty so the tests drive config
+// purely through process.env.
+mock.module('cloudflare:workers', () => ({ env: {} }))
+
+const FEATURE_ENV_KEYS = [
+  'CHM_AUTH_PROVIDER',
+  'CHM_DISABLED_FEATURES',
+  'CHM_AUTH_REQUIRED_FEATURES',
+  'NEXT_PUBLIC_AUTH_PROVIDER',
+]
+
+function clearFeatureEnv(): void {
+  for (const key of FEATURE_ENV_KEYS) delete process.env[key]
+}
+
+describe('getAppConfig cache', () => {
+  beforeEach(async () => {
+    clearFeatureEnv()
+    const { _resetAppConfigCache } = await import('../server')
+    _resetAppConfigCache()
+  })
+
+  afterEach(async () => {
+    clearFeatureEnv()
+    const { _resetAppConfigCache } = await import('../server')
+    _resetAppConfigCache()
+  })
+
+  test('parses once, then returns the cached instance', async () => {
+    const { getAppConfig } = await import('../server')
+
+    process.env.CHM_DISABLED_FEATURES = 'agent'
+    const first = getAppConfig()
+    expect(first.features).toEqual({ agent: { enabled: false } })
+
+    const second = getAppConfig()
+    // Same object reference → no re-parse happened.
+    expect(second).toBe(first)
+  })
+
+  test('cached value ignores later env changes until reset', async () => {
+    const { getAppConfig, _resetAppConfigCache } = await import('../server')
+
+    process.env.CHM_DISABLED_FEATURES = 'agent'
+    const cached = getAppConfig()
+    expect(cached.features).toEqual({ agent: { enabled: false } })
+
+    // Mutating env after the first parse must NOT change the cached result.
+    process.env.CHM_DISABLED_FEATURES = 'tables'
+    expect(getAppConfig()).toBe(cached)
+    expect(getAppConfig().features).toEqual({ agent: { enabled: false } })
+
+    // After reset it re-parses and reflects the new env.
+    _resetAppConfigCache()
+    const reparsed = getAppConfig()
+    expect(reparsed).not.toBe(cached)
+    expect(reparsed.features).toEqual({ tables: { enabled: false } })
+  })
+})

--- a/apps/dashboard/src/lib/feature-permissions/server.ts
+++ b/apps/dashboard/src/lib/feature-permissions/server.ts
@@ -127,13 +127,35 @@ interface AppConfig {
   features: FeatureOverrides
 }
 
-function getAppConfig(): AppConfig {
+let _cachedAppConfig: AppConfig | null = null
+
+/**
+ * Resolve the app's feature-permission config from env.
+ *
+ * Cached after the first call: `getAppConfig()` takes no per-request inputs
+ * (auth provider + feature overrides come only from env vars, which are
+ * immutable at runtime on Workers), and it is called on every gated request
+ * via `authorizeFeatureRequest`. Re-parsing ~40 env lookups per request is
+ * wasted work. Mirrors the `_cachedEnv` pattern in
+ * `packages/clickhouse-client/src/clickhouse/env-schema.ts`.
+ */
+export function getAppConfig(): AppConfig {
+  if (_cachedAppConfig) return _cachedAppConfig
+
   const authProvider = parseAuthProvider(
     readEnv('CHM_AUTH_PROVIDER') ??
       import.meta.env.VITE_AUTH_PROVIDER ??
       readEnv('NEXT_PUBLIC_AUTH_PROVIDER')
   )
-  return { authProvider, features: parseEnvFeatureOverrides() }
+  _cachedAppConfig = { authProvider, features: parseEnvFeatureOverrides() }
+  return _cachedAppConfig
+}
+
+/**
+ * Reset the cached AppConfig — for use in tests only.
+ */
+export function _resetAppConfigCache(): void {
+  _cachedAppConfig = null
 }
 
 /**


### PR DESCRIPTION
## Summary

`getAppConfig()` (`apps/dashboard/src/lib/feature-permissions/server.ts`) re-parsed 19 feature overrides (~40 env lookups via `parseEnvFeatureOverrides()`) on **every** gated request — it is called from `authorizeFeatureRequest`, which runs on every chart/table/API request.

Env is immutable at runtime on Workers, so this parses to the same result every time. This memoizes the parsed `AppConfig` once per isolate.

## Changes

- Cache `AppConfig` in a module-scope `_cachedAppConfig`; `getAppConfig()` returns it on subsequent calls. `getAppConfig()` takes no per-request inputs (auth provider + feature overrides come only from env), so the whole config is a safe cache key.
- Add test-only `_resetAppConfigCache()` — mirrors the `_cachedEnv` / `_resetEnvCache()` pattern in `packages/clickhouse-client/src/clickhouse/env-schema.ts`.
- Export `getAppConfig` for direct testing.
- New test `__tests__/app-config-cache.test.ts`: parses once (same object reference), ignores later env changes while cached, and re-parses after reset.

## Testing

`bun test src/lib/feature-permissions/` → 51 pass, 0 fail. Biome clean.

Closes #2178

https://claude.ai/code/session_01GdkqiuL4a4KTPceGsbxvtN