### PR TITLE
perf(query): cap retries on non-critical always-on polls (#2180)

### DIFF
--- a/apps/dashboard/src/lib/ai/agent/use-ai-quota.ts
+++ b/apps/dashboard/src/lib/ai/agent/use-ai-quota.ts
@@ -23,7 +23,7 @@ import { useQuery } from '@tanstack/react-query'
 
 import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
 import { apiFetch } from '@/lib/swr/api-fetch'
-import { visibilityAwareInterval } from '@/lib/swr/config'
+import { NON_CRITICAL_RETRY, visibilityAwareInterval } from '@/lib/swr/config'
 
 export interface AiQuota {
   /** Messages already sent today. */
@@ -118,7 +118,8 @@ export function useAiQuota(): UseAiQuotaResult {
     refetchOnWindowFocus: true,
     // The endpoint may not exist yet (sibling slice) or the session cookie may
     // be briefly stale — do not spam retries; a single miss just hides it.
-    retry: 1,
+    // Non-critical always-on poll: share the reduced retry budget.
+    retry: NON_CRITICAL_RETRY,
     queryFn: async (): Promise<AiQuota> => {
       const res = await apiFetch('/api/v1/billing/usage')
       if (!res.ok) throw new Error(`Usage request failed (${res.status})`)

--- a/apps/dashboard/src/lib/swr/__tests__/non-critical-retry.test.ts
+++ b/apps/dashboard/src/lib/swr/__tests__/non-critical-retry.test.ts
@@ -1,0 +1,40 @@
+import { NON_CRITICAL_RETRY } from '../config'
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const here = fileURLToPath(new URL('.', import.meta.url))
+
+/**
+ * Non-critical, always-on polling hooks must cap retries via the shared
+ * NON_CRITICAL_RETRY constant instead of inheriting the global `retry: 3`
+ * default (src/lib/query/provider.tsx). Otherwise a single transient blip or a
+ * missing optional table amplifies into 4 Worker→ClickHouse round-trips per
+ * poll. See issue #2180.
+ */
+describe('NON_CRITICAL_RETRY', () => {
+  test('is a low, bounded retry budget below the global default of 3', () => {
+    expect(NON_CRITICAL_RETRY).toBeLessThan(3)
+    expect(NON_CRITICAL_RETRY).toBeGreaterThanOrEqual(0)
+    expect(NON_CRITICAL_RETRY).toBe(1)
+  })
+
+  // Each always-on hook that inherited (or over-set) retries must now source its
+  // retry budget from the shared constant — asserting intent, not a literal.
+  const targets = [
+    '../use-host-status.ts',
+    '../use-cluster-count.ts',
+    '../use-notifications.ts',
+    '../../ai/agent/use-ai-quota.ts',
+  ]
+
+  for (const rel of targets) {
+    test(`${rel} passes retry: NON_CRITICAL_RETRY`, () => {
+      const src = readFileSync(new URL(rel, `file://${here}`), 'utf8')
+      expect(src).toContain('NON_CRITICAL_RETRY')
+      expect(src).toMatch(/retry:\s*NON_CRITICAL_RETRY/)
+      // Guard against a stray hardcoded retry override sneaking back in.
+      expect(src).not.toMatch(/retry:\s*\d/)
+    })
+  }
+})

--- a/apps/dashboard/src/lib/swr/config.ts
+++ b/apps/dashboard/src/lib/swr/config.ts
@@ -25,6 +25,20 @@ export type RefreshInterval =
   (typeof REFRESH_INTERVAL)[keyof typeof REFRESH_INTERVAL]
 
 /**
+ * Retry count for NON-CRITICAL, always-on polling hooks (host status,
+ * notifications, cluster counts, AI quota). These run continuously in the
+ * background regardless of the current page, so the global `retry: 3` default
+ * (see src/lib/query/provider.tsx) turns a single transient blip or a missing
+ * optional table into 4 Worker→ClickHouse round-trips per poll — pure cost with
+ * no user-facing benefit, since the next scheduled refetch recovers anyway.
+ * One retry absorbs a one-off network hiccup without amplifying load.
+ *
+ * Primary data hooks keep their own retry policy (e.g. use-chart-data.ts stops
+ * on 4xx); do NOT apply this to them.
+ */
+export const NON_CRITICAL_RETRY = 1
+
+/**
  * Visibility-aware refresh interval. Returns `false` (paused) when the tab is
  * hidden, otherwise the given interval — shape matches TanStack Query's
  * `refetchInterval: number | false | (() => number | false)`.

--- a/apps/dashboard/src/lib/swr/use-cluster-count.ts
+++ b/apps/dashboard/src/lib/swr/use-cluster-count.ts
@@ -11,7 +11,11 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { apiFetch } from './api-fetch'
-import { REFRESH_INTERVAL, visibilityAwareInterval } from '@/lib/swr/config'
+import {
+  NON_CRITICAL_RETRY,
+  REFRESH_INTERVAL,
+  visibilityAwareInterval,
+} from '@/lib/swr/config'
 
 interface ClusterCountResult {
   count: number | null
@@ -64,7 +68,9 @@ export function useClusterCount(
     staleTime: 15_000, // 15 seconds deduping
     refetchOnWindowFocus: true, // Revalidate on focus for critical metrics
     refetchOnReconnect: true, // Revalidate on reconnect
-    retry: 2, // Retry on error for critical data, limit retries
+    // Non-critical always-on poll: cap retries to avoid amplifying a transient
+    // blip into extra Worker→ClickHouse round-trips (next poll recovers).
+    retry: NON_CRITICAL_RETRY,
   })
 
   return {

--- a/apps/dashboard/src/lib/swr/use-host-status.ts
+++ b/apps/dashboard/src/lib/swr/use-host-status.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { apiFetch } from './api-fetch'
-import { visibilityAwareInterval } from './config'
+import { NON_CRITICAL_RETRY, visibilityAwareInterval } from './config'
 
 /** API response format for host status */
 type HostStatusApiResponse = {
@@ -84,6 +84,10 @@ export function useHostStatus(
       refreshInterval > 0 ? visibilityAwareInterval(refreshInterval) : false,
     refetchOnWindowFocus: revalidateOnFocus,
     refetchOnReconnect: true,
+    // Non-critical always-on poll: cap retries so a transient blip doesn't
+    // amplify into repeated Worker→ClickHouse round-trips (the next scheduled
+    // refetch recovers anyway). See NON_CRITICAL_RETRY.
+    retry: NON_CRITICAL_RETRY,
   })
 
   return {

--- a/apps/dashboard/src/lib/swr/use-notifications.ts
+++ b/apps/dashboard/src/lib/swr/use-notifications.ts
@@ -18,6 +18,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import type { Notification } from '@/lib/notifications/dismissed-notifications'
 
 import { apiFetch } from './api-fetch'
+import { NON_CRITICAL_RETRY } from './config'
 import { useEffect, useState } from 'react'
 import { subscribeInAppAlerts } from '@/lib/health/alert-dispatcher'
 import {
@@ -82,7 +83,9 @@ export function useNotifications(hostId: number): NotificationsResult {
     staleTime: 15_000, // 15 seconds deduping
     refetchOnWindowFocus: true, // Revalidate on focus for critical metrics
     refetchOnReconnect: true, // Revalidate on reconnect
-    retry: 2, // Retry on error for critical data, limit retries
+    // Non-critical always-on poll: cap retries to avoid amplifying a transient
+    // blip into extra Worker→ClickHouse round-trips (next poll recovers).
+    retry: NON_CRITICAL_RETRY,
   })
 
   const mutate = () => queryClient.invalidateQueries({ queryKey })


### PR DESCRIPTION
## Problem

The global `retry: 3` default in `apps/dashboard/src/lib/query/provider.tsx` applies to every query that doesn't set its own retry policy. The **non-critical, always-on** background polling hooks inherit it, so a single transient network blip or a missing optional ClickHouse system table amplifies into **4 Worker→ClickHouse round-trips per poll** — pure cost with no user benefit, since the next scheduled refetch recovers anyway.

## Fix

Add a shared `NON_CRITICAL_RETRY = 1` constant in `lib/swr/config.ts` and apply it to the non-critical always-on hooks:

| Hook | Before | After |
|------|--------|-------|
| `use-host-status` | inherited global `3` | `NON_CRITICAL_RETRY` (1) |
| `use-cluster-count` | `2` | `NON_CRITICAL_RETRY` (1) |
| `use-notifications` | `2` | `NON_CRITICAL_RETRY` (1) |
| `use-ai-quota` | `1` | `NON_CRITICAL_RETRY` (1, via constant) |

One retry still absorbs a one-off hiccup without amplifying background load.

## What is NOT touched

Primary data hooks keep their own retry policy. In particular `use-chart-data.ts`'s **4xx-stop** retry (stop retrying on non-429 4xx) is untouched, and the global default for primary data hooks is unchanged.

## Tests

New `lib/swr/__tests__/non-critical-retry.test.ts` asserts the constant is a low bounded budget (< global 3) and that each target hook sources its retry from the shared constant (no stray hardcoded override).

```
5 pass / 0 fail — bun test src/lib/swr/__tests__/non-critical-retry.test.ts
```

Closes #2180

https://claude.ai/code/session_01GdkqiuL4a4KTPceGsbxvtN