### PR TITLE
perf(clickhouse-client): skip eager JSON.stringify & config redaction in hot path

### DIFF
--- a/apps/dashboard/src/lib/ai/agent/__tests__/tool-logging.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/__tests__/tool-logging.test.ts
@@ -23,6 +23,7 @@ mock.module('@chm/logger', () => ({
   error: (msg: string, err: unknown, ctx: unknown) => {
     errorCalls.push([msg, err, ctx])
   },
+  isDebugEnabled: () => false,
 }))
 
 const { wrapToolsWithLogging } = await import('../tool-logging')

--- a/apps/dashboard/src/lib/api/error-handler/error-response-builder.test.ts
+++ b/apps/dashboard/src/lib/api/error-handler/error-response-builder.test.ts
@@ -26,6 +26,7 @@ mock.module('@chm/logger', () => ({
   warn: () => {},
   log: () => {},
   debug: () => {},
+  isDebugEnabled: () => false,
 }))
 
 import {

--- a/apps/dashboard/src/lib/clickhouse-helpers.test.ts
+++ b/apps/dashboard/src/lib/clickhouse-helpers.test.ts
@@ -33,6 +33,7 @@ mock.module('@chm/logger', () => ({
       logWarningCalls.push(args)
     },
   },
+  isDebugEnabled: () => false,
 }))
 
 // ── Import AFTER mocks are registered ────────────────────────────────────

--- a/apps/dashboard/src/routes/api/v1/__tests__/actions.test.ts
+++ b/apps/dashboard/src/routes/api/v1/__tests__/actions.test.ts
@@ -45,6 +45,7 @@ mock.module('@/lib/api/server-env', () => ({
 mock.module('@chm/logger', () => ({
   ErrorLogger: { logError: mock(() => undefined) },
   log: mock(() => undefined),
+  isDebugEnabled: mock(() => false),
 }))
 
 // Mutable mock so each test can configure its own behavior

--- a/packages/clickhouse-client/src/__tests__/clickhouse-fetch.test.ts
+++ b/packages/clickhouse-client/src/__tests__/clickhouse-fetch.test.ts
@@ -3,11 +3,13 @@ import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
 const mockDebug = mock(() => {})
 const mockError = mock(() => {})
 const mockWarn = mock(() => {})
+const mockIsDebugEnabled = mock(() => false)
 
 mock.module('@chm/logger', () => ({
   debug: mockDebug,
   error: mockError,
   warn: mockWarn,
+  isDebugEnabled: mockIsDebugEnabled,
 }))
 
 const mockCreateClient = mock(() => ({}))

--- a/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-client.test.ts
+++ b/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-client.test.ts
@@ -15,6 +15,7 @@ mock.module('@chm/logger', () => ({
   debug: mock(() => {}),
   error: mock(() => {}),
   warn: mock(() => {}),
+  isDebugEnabled: mock(() => false),
 }))
 
 // Mock the cloudflare-workers runtime detection

--- a/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-config.test.ts
+++ b/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-config.test.ts
@@ -1,10 +1,16 @@
 import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
 
 // Mock logger so tests don't pollute stdout
+const mockDebug = mock(() => {})
+// Simulate DEBUG unset / production: the redaction + debug logging blocks in
+// getClickHouseConfigs() are guarded behind isDebugEnabled().
+const mockIsDebugEnabled = mock(() => false)
+
 mock.module('@chm/logger', () => ({
-  debug: mock(() => {}),
+  debug: mockDebug,
   error: mock(() => {}),
   warn: mock(() => {}),
+  isDebugEnabled: mockIsDebugEnabled,
 }))
 
 // _resetEnvCache is re-exported from clickhouse-config so it resets the SAME
@@ -170,6 +176,48 @@ describe('getClickHouseConfigs', () => {
 
     const configs = getClickHouseConfigs()
     expect(configs.map((c) => c.id)).toEqual([0, 1, 2])
+  })
+
+  it('memoizes the parsed configs across calls (same reference)', () => {
+    process.env.CLICKHOUSE_HOST = 'host1,host2'
+
+    const first = getClickHouseConfigs()
+    const second = getClickHouseConfigs()
+    // Memoized: parsing runs once, later calls return the same array instance.
+    expect(second).toBe(first)
+  })
+
+  it('_resetEnvCache re-parses configs from the current env', () => {
+    process.env.CLICKHOUSE_HOST = 'host1'
+    const first = getClickHouseConfigs()
+    expect(first.map((c) => c.host)).toEqual(['host1'])
+
+    // Without a reset, a changed env is ignored (still memoized).
+    process.env.CLICKHOUSE_HOST = 'host2,host3'
+    expect(getClickHouseConfigs()).toBe(first)
+
+    // After reset, the new env is parsed fresh.
+    _resetEnvCache()
+    const reparsed = getClickHouseConfigs()
+    expect(reparsed).not.toBe(first)
+    expect(reparsed.map((c) => c.host)).toEqual(['host2', 'host3'])
+  })
+
+  it('does not redact host credentials or debug-log when debug is disabled', () => {
+    process.env.CLICKHOUSE_HOST = 'http://admin:secret@clickhouse.prod:8123'
+
+    mockDebug.mockClear()
+    getClickHouseConfigs()
+
+    // isDebugEnabled() is false, so the credential-redaction debug blocks are
+    // skipped — no URL parsing/redaction work is spent on discarded log output.
+    const redactionLogged = mockDebug.mock.calls.some(
+      (call) =>
+        typeof call[0] === 'string' &&
+        (call[0].includes('CLICKHOUSE_HOST:') ||
+          call[0].startsWith('[ClickHouse Config] Host '))
+    )
+    expect(redactionLogged).toBe(false)
   })
 })
 

--- a/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-fetch.test.ts
+++ b/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-fetch.test.ts
@@ -4,7 +4,15 @@
 
 import type { QueryConfigLike } from '@chm/sql-builder'
 
-import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from 'bun:test'
 
 // Mock dependencies — all mock.module calls are hoisted by bun before imports.
 // We use dynamic import (await import) instead of static import to guarantee
@@ -13,11 +21,13 @@ import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
 const mockDebug = mock(() => {})
 const mockError = mock(() => {})
 const mockWarn = mock(() => {})
+const mockIsDebugEnabled = mock(() => false)
 
 mock.module('@chm/logger', () => ({
   debug: mockDebug,
   error: mockError,
   warn: mockWarn,
+  isDebugEnabled: mockIsDebugEnabled,
 }))
 
 // Mock @clickhouse/client and @clickhouse/client-web at the package level so
@@ -175,6 +185,25 @@ describe('clickhouse-fetch', () => {
         expect(result.metadata.rawResponseLength).toBeGreaterThan(0)
         expect(result.metadata.rawResponsePreview).toBeDefined()
         expect(result.error).toBeUndefined()
+      })
+
+      it('does not JSON.stringify the result set when debug is disabled', async () => {
+        // isDebugEnabled() is mocked false (simulating DEBUG unset / prod).
+        const mockData = [{ big: 'payload' }]
+        mockResultSetJson.mockResolvedValue(mockData)
+
+        const stringifySpy = spyOn(JSON, 'stringify')
+        try {
+          const result = await fetchData(defaultParams)
+          // The parsed result set must never be serialized while debug is off
+          // and the lazy rawResponse* getters are untouched.
+          const serializedResultSet = stringifySpy.mock.calls.some(
+            (call) => call[0] === result.data
+          )
+          expect(serializedResultSet).toBe(false)
+        } finally {
+          stringifySpy.mockRestore()
+        }
       })
 
       it('should handle array data', async () => {

--- a/packages/clickhouse-client/src/clickhouse/__tests__/connection-pool.test.ts
+++ b/packages/clickhouse-client/src/clickhouse/__tests__/connection-pool.test.ts
@@ -4,6 +4,7 @@ mock.module('@chm/logger', () => ({
   debug: mock(() => {}),
   error: mock(() => {}),
   warn: mock(() => {}),
+  isDebugEnabled: mock(() => false),
 }))
 
 const {

--- a/packages/clickhouse-client/src/clickhouse/__tests__/env-schema.test.ts
+++ b/packages/clickhouse-client/src/clickhouse/__tests__/env-schema.test.ts
@@ -5,6 +5,7 @@ mock.module('@chm/logger', () => ({
   debug: mock(() => {}),
   error: mock(() => {}),
   warn: mock(() => {}),
+  isDebugEnabled: mock(() => false),
 }))
 
 const { clickhouseEnvSchema, validateClickHouseEnv, _resetEnvCache } =

--- a/packages/clickhouse-client/src/clickhouse/clickhouse-config.ts
+++ b/packages/clickhouse-client/src/clickhouse/clickhouse-config.ts
@@ -3,16 +3,29 @@
  * Parses environment variables and creates ClickHouse configurations
  */
 
+import type { ClickHouseEnv } from './env-schema'
 import type { ClickHouseConfig } from './types'
 
 import { _resetEnvCache, validateClickHouseEnv } from './env-schema'
-import { debug, error } from '@chm/logger'
+import { debug, error, isDebugEnabled } from '@chm/logger'
 
 /**
  * Re-export env cache reset so tests can reset the SAME env-schema instance
- * that this module's getClickHouseConfigs() uses internally.
+ * that this module's getClickHouseConfigs() uses internally. Resetting it also
+ * invalidates the parsed-config memo below, because validateClickHouseEnv()
+ * then returns a fresh env object whose reference no longer matches _cachedEnv.
  */
 export { _resetEnvCache }
+
+/**
+ * Memoized parsed configs, keyed by the env object reference returned by
+ * validateClickHouseEnv(). Env vars don't change at runtime, so parsing once
+ * avoids re-splitting/re-building configs on every getClickHouseConfigs() call.
+ * When _resetEnvCache() runs, validateClickHouseEnv() returns a new reference on
+ * its next call, so `_cachedEnv !== env` and we re-parse automatically.
+ */
+let _cachedEnv: ClickHouseEnv | null = null
+let _cachedConfigs: ClickHouseConfig[] | null = null
 
 /**
  * Redacts username and password credentials from a ClickHouse host URL string
@@ -82,6 +95,7 @@ function splitByComma(value: string) {
 
 export const getClickHouseConfigs = (): ClickHouseConfig[] => {
   const env = validateClickHouseEnv()
+  if (_cachedConfigs && _cachedEnv === env) return _cachedConfigs
 
   const hostEnv = env.CLICKHOUSE_HOST
   const userEnv = env.CLICKHOUSE_USER
@@ -97,7 +111,9 @@ export const getClickHouseConfigs = (): ClickHouseConfig[] => {
       '[ClickHouse Config] Available env keys:',
       Object.keys(process.env).filter((k) => k.includes('CLICK'))
     )
-  } else {
+  } else if (isDebugEnabled()) {
+    // Only build the redacted host string when debug logging is active — the
+    // per-host URL redaction is otherwise discarded work in production.
     const redactedHostEnv = splitByComma(hostEnv)
       .map(redactHostCredentials)
       .join(',')
@@ -125,7 +141,7 @@ export const getClickHouseConfigs = (): ClickHouseConfig[] => {
     return []
   }
 
-  return hosts.map((host, index) => {
+  const configs = hosts.map((host, index) => {
     // User and password fallback to the first value,
     // supporting multiple hosts with the same user/password
     let user, password
@@ -145,14 +161,20 @@ export const getClickHouseConfigs = (): ClickHouseConfig[] => {
       customName: customLabels[index],
     }
 
-    debug(`[ClickHouse Config] Host ${index}:`, {
-      id: config.id,
-      host: redactHostCredentials(config.host),
-      user: config.user,
-      hasPassword: !!config.password,
-      customName: config.customName,
-    })
+    if (isDebugEnabled()) {
+      debug(`[ClickHouse Config] Host ${index}:`, {
+        id: config.id,
+        host: redactHostCredentials(config.host),
+        user: config.user,
+        hasPassword: !!config.password,
+        customName: config.customName,
+      })
+    }
 
     return config
   })
+
+  _cachedEnv = env
+  _cachedConfigs = configs
+  return configs
 }

--- a/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
+++ b/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
@@ -14,7 +14,7 @@ import { transformClickHouseJsonEachRowWasmJson } from '../wasm/monitor-core'
 import { getClient, releaseClient } from './clickhouse-client'
 import { getClickHouseConfigs } from './clickhouse-config'
 import { QUERY_COMMENT } from './constants'
-import { debug, error, warn } from '@chm/logger'
+import { debug, error, isDebugEnabled, warn } from '@chm/logger'
 
 type FetchJsonEachRowTextResult = FetchDataResult<never> & {
   dataJson: string | null
@@ -252,14 +252,27 @@ export const fetchData = async <
       // Use the client's json() method which handles format-specific parsing
       const data = (await resultSet.json()) as T
 
-      // For debugging: serialize the parsed data to see what we got
-      const rawText = JSON.stringify(data)
-      debug(`[fetchData] ClickHouse response (${query_id}):`, {
-        dataType: typeof data,
-        isArray: Array.isArray(data),
-        length: Array.isArray(data) ? data.length : 'N/A',
-        preview: rawText.substring(0, 500),
-      })
+      // Lazily serialize the parsed data — only needed for debug logging and the
+      // rawResponse* metadata getters below, so avoid JSON.stringify in prod.
+      let cachedRawText: string | undefined
+      const getRawText = () => {
+        if (cachedRawText === undefined) {
+          cachedRawText = JSON.stringify(data)
+        }
+        return cachedRawText
+      }
+
+      // For debugging: serialize the parsed data to see what we got. Guarded so
+      // the (potentially large) JSON.stringify never runs unless debug is on.
+      if (isDebugEnabled()) {
+        const rawText = getRawText()
+        debug(`[fetchData] ClickHouse response (${query_id}):`, {
+          dataType: typeof data,
+          isArray: Array.isArray(data),
+          length: Array.isArray(data) ? data.length : 'N/A',
+          preview: rawText.substring(0, 500),
+        })
+      }
 
       const end = new Date()
       const duration = (end.getTime() - start.getTime()) / 1000
@@ -295,14 +308,6 @@ export const fetchData = async <
         clickhouseVersion: clickhouseVersion?.raw ?? 'unknown',
         // Include the actual SQL that was executed (normalized for readability)
         sql: effectiveQuery.replace(/\s+/g, ' ').trim(),
-      }
-
-      let cachedRawText: string | undefined
-      const getRawText = () => {
-        if (cachedRawText === undefined) {
-          cachedRawText = JSON.stringify(data)
-        }
-        return cachedRawText
       }
 
       // Include raw response for debugging (lazily evaluated to avoid performance overhead)

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -26,6 +26,13 @@ const isDevelopment =
 const debugEnabled =
   typeof process !== 'undefined' && process.env?.DEBUG === 'true'
 
+/**
+ * Whether debug/info logging is active (development or DEBUG=true).
+ * Exposed so callers can guard expensive work (e.g. serialization) that is
+ * only needed to build debug log payloads, avoiding it entirely in production.
+ */
+export const isDebugEnabled = (): boolean => isDevelopment || debugEnabled
+
 // ============================================================================
 // Types
 // ============================================================================


### PR DESCRIPTION
## Summary

Removes two pieces of eager work on the ClickHouse fetch/config hot path that only feed no-op debug logging in production (issue #2174).

### 1. `clickhouse-fetch.ts` — no `JSON.stringify` of the result set unless debug is on
`const rawText = JSON.stringify(data)` ran on **every** query result just to build a `debug()` preview that is discarded unless `DEBUG=true` / `NODE_ENV=development`. The debug block is now guarded by `isDebugEnabled()` and reuses the existing lazy `getRawText()` closure (hoisted up so both the guarded debug log and the lazy `rawResponse*` metadata getters share one cached serialization). Non-debug behavior is unchanged: the `rawResponseLength` / `rawResponsePreview` metadata getters remain lazy.

### 2. `clickhouse-config.ts` — memoize parsed configs, redact only under debug
`getClickHouseConfigs()` re-parsed env and eagerly built `redactHostCredentials()` output on every call (discarded in prod). Now:
- The parsed `ClickHouseConfig[]` is memoized, keyed by the env object reference returned by `validateClickHouseEnv()`. The existing `_resetEnvCache` invalidates it transitively (a reset makes `validateClickHouseEnv()` return a fresh reference, so `_cachedEnv !== env` and configs re-parse) — this keeps both `_resetEnvCache` importers (config re-export and the direct env-schema import) correct.
- Per-host credential redaction + debug logging is guarded by `isDebugEnabled()`, so no URL parsing/redaction work is spent building discarded log output in production.

### 3. `logger` — new `isDebugEnabled()` export
Exposes the logger's existing `isDevelopment || DEBUG` check so callers can guard expensive debug-only work.

## Tests
- `clickhouse-config.test.ts`: asserts configs are memoized (same reference across calls), that `_resetEnvCache` re-parses from the current env, and that no credential redaction / debug logging happens when debug is disabled.
- `clickhouse-fetch.test.ts`: asserts the parsed result set is never passed to `JSON.stringify` when debug is disabled.
- Added `isDebugEnabled` to existing `@chm/logger` mocks that fully replace the module (required now that config/fetch statically import it).

All narrow suites pass: `@chm/clickhouse-client` (227 pass) and the touched dashboard mock tests (83 pass). Biome clean.

## Risk
Low. Non-debug runtime behavior is unchanged; the only observable difference is that debug-only serialization/redaction now runs solely when `DEBUG=true`/dev. The config memo is invalidated by the same `_resetEnvCache` already used everywhere.

Closes #2174

https://claude.ai/code/session_01GdkqiuL4a4KTPceGsbxvtN