### PR TITLE
fix(ci): pin dtolnay/rust-toolchain to @stable, not a numeric tag

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -106,10 +106,11 @@ jobs:
       - name: Setup Rust
         if: ${{ inputs.job-type == 'build' }}
         # NOTE: dtolnay/rust-toolchain uses its @ref AS the toolchain version
-        # (its tags are toolchain names, not action releases). Rust 1.100.0 does
-        # not exist; #1898's grouped bump to @1.100.0 404'd the Setup Rust step.
-        # Keep this pinned to a real, released stable toolchain.
-        uses: dtolnay/rust-toolchain@1.100.0
+        # (its tags are toolchain names, not action releases). Pin to the
+        # `stable` branch tag, NOT a version number — a numeric tag (e.g.
+        # `@1.100.0`) invites dependabot to "bump" it to a nonexistent Rust
+        # release, which 404s the Setup Rust step (see #1898).
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Download pre-built WASM
         if: ${{ inputs.skip-rust }}


### PR DESCRIPTION
## Problem
Every `build` CI job has been failing with:

```
error: could not download nonexistent rust version `1.100.0-...`: ... 404
```

`.github/workflows/base.yml` pinned the Setup Rust step to `dtolnay/rust-toolchain@1.100.0`. That action uses its `@ref` **as the toolchain name** (its tags are Rust toolchain names, not action releases), and Rust `1.100.0` does not exist. A dependabot grouped bump (#1898) had rewritten the tag to `@1.100.0`, 404-ing the step.

## Fix
Pin to the `stable` branch tag — `dtolnay/rust-toolchain@stable` — which always resolves and is not a version number for dependabot to bump. This matches the three other workflows (`cli-rust-ci`, `cli-rust-release`, `cargo-publish`) that already use `@stable`.

Surfaced while merging the open-PR backlog: #2196's `build` failure was this bug, not the dependabot change itself.

https://claude.ai/code/session_017wcPrFyKK1aRFFLJoe5nZg