### PR TITLE
fix(findings): avoid event_time alias shadowing in findings query

### DIFF
--- a/apps/dashboard/src/lib/findings/findings-store.test.ts
+++ b/apps/dashboard/src/lib/findings/findings-store.test.ts
@@ -141,4 +141,32 @@ describe('listRecentFindings', () => {
     fetchDataImpl = async () => ({ error: { message: 'boom' } })
     expect(await listRecentFindings(1)).toEqual([])
   })
+
+  // Regression: #2173 — filtering/ordering must run on the real DateTime
+  // `event_time` column inside a subquery, and the string formatting must live
+  // only in the OUTER select. Otherwise `toString(event_time) AS event_time`
+  // shadows the DateTime column and `WHERE event_time >= now() - INTERVAL ...`
+  // / `ORDER BY event_time` compare String vs DateTime → Code 386
+  // NO_COMMON_TYPE.
+  test('filters and orders inside a subquery on the real DateTime column (#2173)', async () => {
+    await listRecentFindings(1, { since: '24 HOUR' })
+
+    // The query wraps an inner SELECT.
+    const innerStart = lastQuery.indexOf('FROM (')
+    expect(innerStart).toBeGreaterThan(-1)
+
+    // The WHERE (host filter + since) and ORDER BY live inside the subquery,
+    // i.e. after the `FROM (` that opens it.
+    const wherePos = lastQuery.indexOf('WHERE host_id')
+    const sincePos = lastQuery.indexOf('event_time >= now() - INTERVAL 24 HOUR')
+    const orderPos = lastQuery.indexOf('ORDER BY event_time DESC')
+    expect(wherePos).toBeGreaterThan(innerStart)
+    expect(sincePos).toBeGreaterThan(innerStart)
+    expect(orderPos).toBeGreaterThan(innerStart)
+
+    // The string formatting is in the OUTER select, before the subquery opens.
+    const toStringPos = lastQuery.indexOf('toString(event_time) AS event_time')
+    expect(toStringPos).toBeGreaterThan(-1)
+    expect(toStringPos).toBeLessThan(innerStart)
+  })
 })

--- a/apps/dashboard/src/lib/findings/findings-store.ts
+++ b/apps/dashboard/src/lib/findings/findings-store.ts
@@ -183,6 +183,11 @@ export async function listRecentFindings(
 
   const safeLimit = Math.min(Math.max(Math.trunc(limit) || 0, 1), 1000)
 
+  // Filter and order on the real DateTime `event_time` column inside a
+  // subquery, then format it to a string in the outer SELECT. Formatting in
+  // the same SELECT that filters/orders would shadow the DateTime column with
+  // a String alias, so `event_time >= now() - INTERVAL ...` and
+  // `ORDER BY event_time` compare String vs DateTime → Code 386 NO_COMMON_TYPE.
   const sql = `
     SELECT
       toString(event_time) AS event_time,
@@ -194,10 +199,22 @@ export async function listRecentFindings(
       detail,
       metric,
       value
-    FROM ${FINDINGS_TABLE}
-    WHERE ${conditions.join(' AND ')}
-    ORDER BY event_time DESC
-    LIMIT ${safeLimit}
+    FROM (
+      SELECT
+        event_time,
+        host_id,
+        severity,
+        category,
+        source,
+        title,
+        detail,
+        metric,
+        value
+      FROM ${FINDINGS_TABLE}
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY event_time DESC
+      LIMIT ${safeLimit}
+    )
   `
 
   const result = await fetchData<FindingRow[]>({

--- a/apps/dashboard/src/routes/api/v1/findings.ts
+++ b/apps/dashboard/src/routes/api/v1/findings.ts
@@ -84,6 +84,11 @@ async function listRecentFindings(
 
   const safeLimit = Math.min(Math.max(Math.trunc(limit) || 0, 1), 1000)
 
+  // Filter and order on the real DateTime `event_time` column inside a
+  // subquery, then format it to a string in the outer SELECT. Formatting in
+  // the same SELECT that filters/orders would shadow the DateTime column with
+  // a String alias, so `event_time >= now() - INTERVAL ...` and
+  // `ORDER BY event_time` compare String vs DateTime → Code 386 NO_COMMON_TYPE.
   const sql = `
     SELECT
       toString(event_time) AS event_time,
@@ -95,10 +100,22 @@ async function listRecentFindings(
       detail,
       metric,
       value
-    FROM ${FINDINGS_TABLE}
-    WHERE ${conditions.join(' AND ')}
-    ORDER BY event_time DESC
-    LIMIT ${safeLimit}
+    FROM (
+      SELECT
+        event_time,
+        host_id,
+        severity,
+        category,
+        source,
+        title,
+        detail,
+        metric,
+        value
+      FROM ${FINDINGS_TABLE}
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY event_time DESC
+      LIMIT ${safeLimit}
+    )
   `
 
   const result = await fetchData<FindingRow[]>({


### PR DESCRIPTION
Resolves #2173

## Problem
`GET /api/v1/findings` (and the shared `findings-store.ts` reader) build a query that does `toString(event_time) AS event_time` in the same SELECT that filters and orders on `event_time`. Because the alias shadows the original `DateTime` column, ClickHouse resolves `event_time` in `WHERE event_time >= now() - INTERVAL ...` and `ORDER BY event_time` to the **String** alias, so the comparison is String vs DateTime and the query fails:

```
Code: 386. DB::Exception: There is no supertype for types String, DateTime ... (NO_COMMON_TYPE)
```

This is reproducible on the public demo (`/failed-queries?host=0`), which loads `system.monitoring_findings`.

## Fix
Wrap the SELECT in a subquery so the **inner** query filters/orders/limits on the real `DateTime event_time` column, and the **outer** SELECT only does `toString(event_time) AS event_time`. The output field name stays `event_time` (a string), so the API contract is unchanged. `query_params`, `clickhouse_settings`, and the `fetchData` call are untouched. Applied to both call sites:

- `apps/dashboard/src/routes/api/v1/findings.ts`
- `apps/dashboard/src/lib/findings/findings-store.ts`

`prefer_column_name_to_alias` was intentionally **not** used — it changes alias resolution globally and could break other queries (as the reporter noted).

## Tests
Added a regression test in `apps/dashboard/src/lib/findings/findings-store.test.ts` asserting the filter/`since`/`ORDER BY` live inside the subquery (`FROM (`) and that `toString(event_time) AS event_time` is only in the outer select. Verified locally: `bun test findings-store.test.ts` (10 pass), `bun run build` (tsc clean), `bun run lint` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2rKX3JQBHPtTceWzog19d)_