### PR TITLE
perf(query): drop volatile host-list dim from server-host query keys (#2184)

### DIFF
--- a/apps/dashboard/src/lib/query/host-query-key.test.ts
+++ b/apps/dashboard/src/lib/query/host-query-key.test.ts
@@ -1,0 +1,35 @@
+import { hostConnectionKey } from './host-query-key'
+import { describe, expect, test } from 'bun:test'
+
+describe('hostConnectionKey', () => {
+  test('server hosts contribute no host-list state to the key', () => {
+    // id >= 0 and the default host are fully identified by the request URL, so
+    // the key part is a constant `undefined` regardless of whether the merged
+    // host list has settled — this is what stops the cold-load double-fetch.
+    expect(hostConnectionKey(0, null)).toBeUndefined()
+    expect(hostConnectionKey(1, null)).toBeUndefined()
+    expect(hostConnectionKey(undefined, null)).toBeUndefined()
+  })
+
+  test('a browser connection keys on its stable connection id', () => {
+    expect(hostConnectionKey(-1, { id: 'conn-a' })).toBe('conn-a')
+    expect(hostConnectionKey(-1000, { id: 'conn-b' })).toBe('conn-b')
+  })
+
+  test('two connections sharing a negative slot never collide', () => {
+    // Negative id slots are reused as connections are added/removed. If the key
+    // dropped the connection id, connection B at slot -1 would read connection
+    // A's cached data. The stable id keeps their cache entries distinct.
+    const a = hostConnectionKey(-1, { id: 'conn-a' })
+    const b = hostConnectionKey(-1, { id: 'conn-b' })
+    expect(a).not.toBe(b)
+  })
+
+  test('an unresolved browser connection defers, then refetches on resolve', () => {
+    // Before useMergedHosts() settles the connection is null → undefined key
+    // part; once it resolves the id enters the key, triggering one refetch.
+    expect(hostConnectionKey(-1, null)).toBeUndefined()
+    expect(hostConnectionKey(-1, undefined)).toBeUndefined()
+    expect(hostConnectionKey(-1, { id: 'conn-a' })).toBe('conn-a')
+  })
+})

--- a/apps/dashboard/src/lib/query/host-query-key.ts
+++ b/apps/dashboard/src/lib/query/host-query-key.ts
@@ -1,0 +1,25 @@
+/**
+ * The host-disambiguation element of a server-data TanStack Query key.
+ *
+ * The request URL for a chart/table query always carries `hostId`, so for
+ * server hosts (id >= 0) and the default host (`undefined`) the URL *fully*
+ * identifies the response. Host-list state (e.g. `hosts.length`) must therefore
+ * NOT enter the key: `useMergedHosts()` settles asynchronously, so keying on it
+ * makes every server-host query fire once at `length:0`, orphan, then refetch
+ * at `length:N` on first paint — duplicate network + ClickHouse load for the
+ * ~28-30 overview queries, merely hidden by `placeholderData`.
+ *
+ * Browser connections (id < 0) are the exception. Their negative id slots are
+ * reused as connections are added/removed, so `?hostId=-1` does not uniquely
+ * identify the connection. The stable connection id MUST stay in the key, or a
+ * new connection at the same slot could read a prior connection's cached data
+ * (cross-connection leak). It returns `undefined` until the connection resolves,
+ * which correctly triggers a single refetch once `useMergedHosts()` settles.
+ */
+export function hostConnectionKey(
+  numericHostId: number | undefined,
+  browserConnection: { id: string } | null | undefined
+): string | undefined {
+  const isBrowserConnection = numericHostId !== undefined && numericHostId < 0
+  return isBrowserConnection ? browserConnection?.id : undefined
+}

--- a/apps/dashboard/src/lib/query/use-chart-data.ts
+++ b/apps/dashboard/src/lib/query/use-chart-data.ts
@@ -7,6 +7,7 @@ import {
   fetchChartForHost,
   isCustomHost,
 } from '@/lib/host-fetch/resolve-host-fetch'
+import { hostConnectionKey } from '@/lib/query/host-query-key'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { REFRESH_INTERVAL, type RefreshInterval } from '@/lib/swr/config'
 import { throwIfNotOk } from '@/lib/swr/fetch-error'
@@ -98,8 +99,7 @@ export function useChartData<T extends ChartDataPoint = ChartDataPoint>({
     lastHours,
     JSON.stringify(params ?? null),
     timezone,
-    hosts.length,
-    browserConnection?.id,
+    hostConnectionKey(numericHostId, browserConnection),
   ] as const
 
   const resolvedRefetchInterval =

--- a/apps/dashboard/src/lib/query/use-table-data.ts
+++ b/apps/dashboard/src/lib/query/use-table-data.ts
@@ -8,6 +8,7 @@ import {
   fetchTableForHost,
   isCustomHost,
 } from '@/lib/host-fetch/resolve-host-fetch'
+import { hostConnectionKey } from '@/lib/query/host-query-key'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { throwIfNotOk } from '@/lib/swr/fetch-error'
 import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
@@ -67,8 +68,7 @@ export function useTableData<T = unknown>(
     hostId,
     JSON.stringify(searchParams ?? {}),
     timezone,
-    hosts.length,
-    browserConnection?.id,
+    hostConnectionKey(hostId, browserConnection),
   ] as const
 
   const resolvedRefetchInterval =


### PR DESCRIPTION
Closes #2184

## Problem
`useChartData` / `useTableData` keyed their TanStack Query cache on
`hosts.length`, which settles asynchronously via `useMergedHosts()`. On cold
load every server-host query fired once at `length:0`, orphaned, then refetched
at `length:N` — duplicate network + ClickHouse load for the ~28-30 overview
queries (hidden from the eye by `placeholderData`).

## Fix
The request URL already carries `hostId`, so for **server hosts (id ≥ 0)** and
the default host it fully identifies the response — host-list state must not
enter the key. Removed `hosts.length` from both hooks.

**Browser connections (id < 0) are deliberately kept keyed on their connection
id.** Their negative id slots are reused as connections are added/removed, so
`?hostId=-1` does not uniquely identify the connection; without the stable id a
new connection at the same slot could read a prior connection's cached data.
That conditional lives in a small pure `hostConnectionKey()` helper so the
invariant is explicit and unit-tested.

## Tests (`host-query-key.test.ts`)
- server / default host → constant key part (no host-list state) → no cold-load refetch
- browser connection → keys on its stable id
- **two connections sharing a negative slot never collide** (the cross-connection guarantee from the issue's acceptance line)
- unresolved connection defers, then refetches once on resolve

`bun test`, `bun run type-check`, and Biome all green on the changed files.

## Merge note
This touches a **cross-connection data-isolation** boundary (Tier 2,
review-first per the issue). Opened **review-ready, not auto-merged** — please
eyeball the diff before merging. CI-green is being babysat.

Co-Authored-By: duyetbot <bot@duyet.net>