### PR TITLE
fix(conversations): scope upsert to owner to close cross-tenant IDOR

### DIFF
--- a/apps/dashboard/src/lib/conversation-store/agentstate-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/agentstate-store.ts
@@ -496,8 +496,13 @@ export class AgentStateStore implements ConversationStore {
    * a best-effort `generateTitle` call is made (failures are swallowed).
    *
    * @param conversation - Full conversation to upsert
+   * @returns `written: true` — this backend is namespaced per user via the
+   *   deterministic `${userId}:${conversationId}` external id, so a write
+   *   always either creates or updates the caller's own conversation
    */
-  async upsert(conversation: StoredConversation): Promise<void> {
+  async upsert(
+    conversation: StoredConversation
+  ): Promise<{ written: boolean }> {
     try {
       const externalId = this.externalId(conversation.userId, conversation.id)
       const metadata = this.buildMetadata(conversation)
@@ -544,6 +549,7 @@ export class AgentStateStore implements ConversationStore {
       }
 
       await this.maybeEnrichTitle(internalId, conversation)
+      return { written: true }
     } catch (err) {
       logError('[AgentStateStore.upsert] Failed to upsert conversation', err)
       throw this.wrap('Failed to upsert conversation', err)

--- a/apps/dashboard/src/lib/conversation-store/browser-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/browser-store.ts
@@ -117,8 +117,12 @@ export class BrowserStore implements ConversationStore {
    * Create or update a conversation.
    *
    * @param conversation - Full conversation to upsert
+   * @returns `written: true` — localStorage is single-user per browser, so a
+   *   write always succeeds
    */
-  async upsert(conversation: StoredConversation): Promise<void> {
+  async upsert(
+    conversation: StoredConversation
+  ): Promise<{ written: boolean }> {
     try {
       const conversations = loadConversations()
 
@@ -144,6 +148,7 @@ export class BrowserStore implements ConversationStore {
       conversations.sort((a, b) => b.updatedAt - a.updatedAt)
 
       saveConversations(conversations)
+      return { written: true }
     } catch (error) {
       throw new ConversationStoreError(
         'Failed to upsert conversation to localStorage',

--- a/apps/dashboard/src/lib/conversation-store/d1-store.sql.test.ts
+++ b/apps/dashboard/src/lib/conversation-store/d1-store.sql.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Proves the production D1 upsert SQL enforces the ownership guard.
+ *
+ * {@link MemoryStore} is a `Map` and exercises none of the actual fix — the
+ * `WHERE conversations.user_id = excluded.user_id` guard and the
+ * `changes === 0` semantics that the `written` flag depends on live only in
+ * {@link D1_UPSERT_CONVERSATION_SQL}. This runs that exact string against
+ * `bun:sqlite` (SQLite is D1's underlying engine), so the fix is actually
+ * executed rather than re-derived.
+ */
+
+import { Database } from 'bun:sqlite'
+import { describe, expect, mock, test } from 'bun:test'
+
+// d1-store.ts imports `getPlatformBindings` from '@chm/platform', which
+// resolves (via the tsconfig path alias) to platform-native.ts's
+// `import { env } from 'cloudflare:workers'` — a virtual module `bun test`
+// doesn't provide (only Vite/workerd do). Mock it before importing, mirroring
+// resolve-store.test.ts's established pattern. The D1 binding value is
+// irrelevant here — this file only needs the exported SQL string constant.
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({
+    getD1Database: () => undefined,
+  }),
+}))
+
+const { D1_UPSERT_CONVERSATION_SQL } = await import('./d1-store')
+
+function seed() {
+  const db = new Database(':memory:')
+  // PK is `id` alone — mirrors db/conversations-migrations/0001_conversations.sql
+  db.run(`CREATE TABLE conversations (
+    id TEXT PRIMARY KEY, user_id TEXT NOT NULL, title TEXT, messages TEXT,
+    message_count INTEGER, created_at INTEGER, updated_at INTEGER)`)
+  db.run(`INSERT INTO conversations VALUES ('c1','u1','orig','[1]',1,1,1)`)
+  return db
+}
+// Bind order must match the ?1..?7 order in the SQL:
+// (id, user_id, title, messages, message_count, created_at, updated_at)
+
+describe('d1 upsert ownership guard (real SQL)', () => {
+  test('a foreign owner cannot overwrite/seize the row; changes === 0', () => {
+    const db = seed()
+    const res = db
+      .query(D1_UPSERT_CONVERSATION_SQL)
+      .run('c1', 'u2', 'hijacked', '[]', 0, 2, 2)
+    expect(res.changes).toBe(0) // guard blocked the update
+    const row = db
+      .query(`SELECT user_id, title, messages FROM conversations WHERE id='c1'`)
+      .get() as { user_id: string; title: string; messages: string }
+    expect(row.user_id).toBe('u1') // ownership intact
+    expect(row.title).toBe('orig') // content intact
+    expect(row.messages).toBe('[1]')
+  })
+
+  test('the owner can update; changes === 1', () => {
+    const db = seed()
+    const res = db
+      .query(D1_UPSERT_CONVERSATION_SQL)
+      .run('c1', 'u1', 'new', '[1,2]', 2, 1, 3)
+    expect(res.changes).toBe(1)
+    expect(
+      (
+        db.query(`SELECT title FROM conversations WHERE id='c1'`).get() as {
+          title: string
+        }
+      ).title
+    ).toBe('new')
+  })
+
+  test('a new id inserts; changes === 1', () => {
+    const db = seed()
+    expect(
+      db.query(D1_UPSERT_CONVERSATION_SQL).run('c2', 'u2', 'x', '[]', 0, 4, 4)
+        .changes
+    ).toBe(1)
+  })
+})

--- a/apps/dashboard/src/lib/conversation-store/d1-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/d1-store.ts
@@ -30,6 +30,28 @@ interface D1ConversationRow {
 }
 
 /**
+ * Upsert SQL for the `conversations` table.
+ *
+ * The `ON CONFLICT` update deliberately excludes `user_id` from the `SET`
+ * list and guards the update with a `WHERE` clause so a conflicting row
+ * owned by a different user is never touched: SQLite's `DO UPDATE ... WHERE`
+ * evaluates the guard per matched row and leaves it unchanged (0 `changes`)
+ * when the guard is false, instead of reassigning ownership to the caller.
+ *
+ * Exported so `d1-store.sql.test.ts` can run this exact string against
+ * `bun:sqlite` (SQLite is D1's engine) and prove the guard behaves as
+ * expected, rather than re-deriving it in the test.
+ */
+export const D1_UPSERT_CONVERSATION_SQL = `INSERT INTO conversations (id, user_id, title, messages, message_count, created_at, updated_at)
+   VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+   ON CONFLICT (id) DO UPDATE SET
+     title = excluded.title,
+     messages = excluded.messages,
+     message_count = excluded.message_count,
+     updated_at = excluded.updated_at
+   WHERE conversations.user_id = excluded.user_id`
+
+/**
  * D1-based conversation storage implementation.
  *
  * Uses Cloudflare D1 (SQLite) for persistent storage of AI agent conversations.
@@ -188,12 +210,20 @@ export class D1Store implements ConversationStore {
    * Create or update a conversation.
    *
    * Uses UPSERT (INSERT OR REPLACE) semantics:
-   * - If conversation exists: replaces all fields including messages
+   * - If conversation exists and is owned by the caller: replaces all fields
+   *   including messages
    * - If conversation doesn't exist: creates new conversation
+   * - If conversation exists but is owned by a different user: the `WHERE`
+   *   guard in {@link D1_UPSERT_CONVERSATION_SQL} blocks the update (0 rows
+   *   changed) rather than reassigning ownership to the caller
    *
    * @param conversation - Full conversation to upsert
+   * @returns `written: true` if a row was inserted or updated; `written:
+   *   false` when the id belongs to another user and the write was blocked
    */
-  async upsert(conversation: StoredConversation): Promise<void> {
+  async upsert(
+    conversation: StoredConversation
+  ): Promise<{ written: boolean }> {
     try {
       const db = this.getDb()
 
@@ -201,16 +231,7 @@ export class D1Store implements ConversationStore {
       const messagesJson = JSON.stringify(conversation.messages)
 
       const stmt = db
-        .prepare(
-          `INSERT INTO conversations (id, user_id, title, messages, message_count, created_at, updated_at)
-           VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-           ON CONFLICT (id) DO UPDATE SET
-             user_id = excluded.user_id,
-             title = excluded.title,
-             messages = excluded.messages,
-             message_count = excluded.message_count,
-             updated_at = excluded.updated_at`
-        )
+        .prepare(D1_UPSERT_CONVERSATION_SQL)
         .bind(
           conversation.id,
           conversation.userId,
@@ -221,7 +242,8 @@ export class D1Store implements ConversationStore {
           conversation.updatedAt
         )
 
-      await stmt.run()
+      const res = await stmt.run()
+      return { written: (res.meta?.changes ?? 0) > 0 }
     } catch (error) {
       throw new ConversationStoreError(
         `Failed to upsert conversation: ${error instanceof Error ? error.message : 'Unknown error'}`,

--- a/apps/dashboard/src/lib/conversation-store/memory-store.test.ts
+++ b/apps/dashboard/src/lib/conversation-store/memory-store.test.ts
@@ -9,6 +9,7 @@
  * so we MemoryStore.clearAll() before each test to avoid cross-test leakage.
  */
 
+import type { UIMessage } from 'ai'
 import type { StoredConversation } from './types'
 
 import { MemoryStore } from './memory-store'
@@ -67,6 +68,51 @@ describe('MemoryStore', () => {
     expect(list[0].title).toBe('second')
   })
 
+  test('upsert by the owner reports written:true and applies the update', async () => {
+    await store.upsert(makeConv({ id: 'c1', userId: 'u1', title: 'first' }))
+    const result = await store.upsert(
+      makeConv({ id: 'c1', userId: 'u1', title: 'new' })
+    )
+
+    expect(result).toEqual({ written: true })
+    expect((await store.get('u1', 'c1'))?.title).toBe('new')
+  })
+
+  test('foreign write is blocked (regression test for the cross-tenant IDOR)', async () => {
+    await store.upsert(
+      makeConv({
+        id: 'c1',
+        userId: 'u1',
+        title: 'orig',
+        messages: [{ id: 'm1', role: 'user', parts: [] } as UIMessage],
+      })
+    )
+
+    const result = await store.upsert(
+      makeConv({ id: 'c1', userId: 'u2', title: 'hijacked', messages: [] })
+    )
+
+    expect(result).toEqual({ written: false })
+
+    // Victim's conversation is untouched: same title, messages, and owner.
+    const victim = await store.get('u1', 'c1')
+    expect(victim?.title).toBe('orig')
+    expect(victim?.messages).toEqual([
+      { id: 'm1', role: 'user', parts: [] } as UIMessage,
+    ])
+    expect(victim?.userId).toBe('u1')
+
+    // The attacker never gains a readable copy of the row either.
+    expect(await store.get('u2', 'c1')).toBeNull()
+  })
+
+  test('upsert with an unused id reports written:true and is retrievable by its owner', async () => {
+    const result = await store.upsert(makeConv({ id: 'c2', userId: 'u2' }))
+
+    expect(result).toEqual({ written: true })
+    expect((await store.get('u2', 'c2'))?.id).toBe('c2')
+  })
+
   test('get returns the conversation with messages, or null when unknown', async () => {
     await store.upsert(makeConv({ id: 'a', userId: 'u1' }))
     const found = await store.get('u1', 'a')
@@ -94,8 +140,11 @@ describe('MemoryStore', () => {
   })
 
   test('conversations are isolated per user', async () => {
+    // Distinct ids: `id` is a global key (mirrors the D1/Postgres `id TEXT
+    // PRIMARY KEY` schema), not scoped per user — see the "foreign write
+    // blocked" test below for the same-id-across-users case.
     await store.upsert(makeConv({ id: 'a', userId: 'u1' }))
-    await store.upsert(makeConv({ id: 'a', userId: 'u2' }))
+    await store.upsert(makeConv({ id: 'b', userId: 'u2' }))
 
     expect((await store.list('u1')).map((c) => c.id)).toEqual(['a'])
     expect(MemoryStore.getUserIds().sort()).toEqual(['u1', 'u2'])

--- a/apps/dashboard/src/lib/conversation-store/memory-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/memory-store.ts
@@ -83,10 +83,27 @@ export class MemoryStore implements ConversationStore {
   /**
    * Create or update a conversation.
    *
+   * Mirrors the D1/Postgres ownership guard: `id` is a global primary key
+   * (not scoped per user), so if another user already owns this id, the
+   * write is refused rather than reassigning ownership to the caller.
+   *
    * @param conversation - Full conversation to upsert
+   * @returns `written: true` if the conversation was created or updated;
+   *   `written: false` when the id belongs to another user and the write
+   *   was blocked
    */
-  async upsert(conversation: StoredConversation): Promise<void> {
+  async upsert(
+    conversation: StoredConversation
+  ): Promise<{ written: boolean }> {
     const { userId, id } = conversation
+
+    // Global id collision check: refuse the write if a different user
+    // already owns a conversation with this id.
+    for (const [ownerId, conversations] of storage) {
+      if (ownerId !== userId && conversations.some((c) => c.id === id)) {
+        return { written: false }
+      }
+    }
 
     // Get user's conversations or initialize empty array
     let conversations = storage.get(userId) || []
@@ -115,6 +132,7 @@ export class MemoryStore implements ConversationStore {
 
     // Save back to storage
     storage.set(userId, conversations)
+    return { written: true }
   }
 
   /**

--- a/apps/dashboard/src/lib/conversation-store/postgres-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/postgres-store.ts
@@ -253,22 +253,30 @@ export class PostgresStore implements ConversationStore {
    * Create or update a conversation.
    *
    * Uses PostgreSQL's INSERT ... ON CONFLICT (upsert) semantics:
-   * - If conversation exists: replaces all fields including messages
+   * - If conversation exists and is owned by the caller: replaces all fields
+   *   including messages
    * - If conversation doesn't exist: creates new conversation
+   * - If conversation exists but is owned by a different user: the `WHERE`
+   *   guard blocks the update (0 rows affected) rather than reassigning
+   *   ownership to the caller
    *
    * Messages are serialized to JSONB (Postgres automatically converts
    * JavaScript objects to JSONB).
    *
    * @param conversation - Full conversation to upsert
+   * @returns `written: true` if a row was inserted or updated; `written:
+   *   false` when the id belongs to another user and the write was blocked
    */
-  async upsert(conversation: StoredConversation): Promise<void> {
+  async upsert(
+    conversation: StoredConversation
+  ): Promise<{ written: boolean }> {
     await this.ensureInitialized()
 
     try {
       // Serialize messages to JSON string for safe parameter passing
       const messagesJson = JSON.stringify(conversation.messages)
 
-      await this.sql`
+      const res = await this.sql`
         INSERT INTO conversations (
           id, user_id, title, messages, message_count, created_at, updated_at
         )
@@ -282,12 +290,13 @@ export class PostgresStore implements ConversationStore {
           ${conversation.updatedAt}
         )
         ON CONFLICT (id) DO UPDATE SET
-          user_id = EXCLUDED.user_id,
           title = EXCLUDED.title,
           messages = EXCLUDED.messages,
           message_count = EXCLUDED.message_count,
           updated_at = EXCLUDED.updated_at
+        WHERE conversations.user_id = EXCLUDED.user_id
       `
+      return { written: res.count > 0 }
     } catch (error) {
       throw new ConversationStoreError(
         `Failed to upsert conversation: ${error instanceof Error ? error.message : 'Unknown error'}`,

--- a/apps/dashboard/src/lib/conversation-store/types.ts
+++ b/apps/dashboard/src/lib/conversation-store/types.ts
@@ -237,7 +237,7 @@ export interface ConversationStore {
     userId: string,
     conversationId: string
   ): Promise<StoredConversation | null>
-  upsert(conversation: StoredConversation): Promise<void>
+  upsert(conversation: StoredConversation): Promise<{ written: boolean }>
   delete(userId: string, conversationId: string): Promise<void>
   deleteAll(userId: string): Promise<void>
 }

--- a/apps/dashboard/src/routes/api/v1/conversations.ts
+++ b/apps/dashboard/src/routes/api/v1/conversations.ts
@@ -276,9 +276,23 @@ async function handlePost(request: Request): Promise<Response> {
       messages,
     }
 
-    // Save to store
+    // Save to store. The id is freshly minted above (crypto.randomUUID()),
+    // so `written` should always be true; handle `false` defensively as an
+    // unexpected id collision rather than returning a misleading 200.
     const store = await resolveStore()
-    await store.upsert(storedConversation)
+    const { written } = await store.upsert(storedConversation)
+
+    if (!written) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Conversation ID collision. Please retry.',
+          details: { timestamp: new Date().toISOString() },
+        },
+        409,
+        ROUTE_CONTEXT_POST
+      )
+    }
 
     // Build response
     const responseData: CreateConversationResponse = {

--- a/apps/dashboard/src/routes/api/v1/conversations/$id.ts
+++ b/apps/dashboard/src/routes/api/v1/conversations/$id.ts
@@ -291,8 +291,26 @@ async function handlePut(request: Request, id: string): Promise<Response> {
       updatedAt: now,
     }
 
-    // Save to store
-    await store.upsert(updatedConversation)
+    // Save to store. The store enforces ownership at the write layer (see
+    // conversation-store/*.ts): a foreign-owned id is refused rather than
+    // reassigned to the caller, surfaced here as `written: false`.
+    const { written } = await store.upsert(updatedConversation)
+
+    // existingConversation came from a user-scoped read, so it is null both
+    // for a genuinely new id (write always succeeds) and for an id owned by
+    // another user (write is blocked). Only the latter yields `written:
+    // false` here, so this precisely detects the blocked cross-tenant case.
+    if (!written && existingConversation === null) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Conversation ID belongs to another user.',
+          details: { timestamp: new Date().toISOString() },
+        },
+        409,
+        ROUTE_CONTEXT_PUT
+      )
+    }
 
     // Create response with standardized builder
     const response = createSuccessResponse(


### PR DESCRIPTION
## Summary
Implements **plan 04** from the Round-2 repo audit (`plans/04-*.md`), executed by the overnight autonomous swarm.

A `PUT /api/v1/conversations/$id` authorized with a user-scoped read but then did an **unscoped** `ON CONFLICT (id) DO UPDATE SET user_id = excluded.user_id` — letting an authenticated user overwrite **and seize ownership of** another user's conversation (cross-tenant IDOR on the D1 + Postgres backends). This adds a `WHERE conversations.user_id = excluded.user_id` guard, drops `user_id` from the SET list, makes `upsert` report `{ written }`, and fails loud (409) on a foreign-id write.

## Test evidence
Verified on the combined swarm tree via the orchestrator's central CI-parity gate:
- `biome lint .` → clean (1914 files)
- `tsc --noEmit` (dashboard) → clean
- full `bun test src/ --isolate` → **4692 pass / 0 fail** (243 files, single process — no mock/env cross-contamination)

The plan's real test is included and passes on this branch (it fails on `main`).

## Self-review (runbook §5)
- [x] Real test fails on `main`, passes on this branch
- [x] No core monitoring feature gated behind cloud mode (self-hosted stays whole)
- [x] Fail-closed to OSS (unset/junk `CHM_*`/`VITE_*` env → OSS defaults)
- [x] No destructive/DDL auto-apply by the agent; recommendations only
- [x] No secrets in committed `.env*`; no `[vars]` re-added to `wrangler.toml`
- [x] Docs updated in the same PR if user-facing
- [x] Diff scoped to the plan; no drive-by refactors

🤖 Part of the overnight audit swarm (one plan = one branch = one PR).

Co-Authored-By: duyetbot <bot@duyet.net>