### PR TITLE
fix(security): require write-auth on health/webhook SSRF proxy

### DIFF
--- a/apps/dashboard/src/routes/api/v1/health/webhook.test.ts
+++ b/apps/dashboard/src/routes/api/v1/health/webhook.test.ts
@@ -1,5 +1,51 @@
-import { __handlePostForTests as handlePost } from './webhook'
-import { describe, expect, test } from 'bun:test'
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// The health/webhook route self-gates writes via authorizeFeatureRequest
+// (feature 'settings', operation 'write') so anonymous callers cannot drive
+// the outbound SSRF-capable fetch. Mocked here so the SSRF/provider tests
+// below exercise fetch/SSRF logic without exercising real auth; the gate
+// itself is covered by the "auth gate" describe block further down.
+//
+// Mocks the FULL real export surface of feature-permissions/server.ts (not
+// just what this file needs): bun's mock.module() registers per module
+// specifier, and actions.test.ts / charts/__tests__/*.test.ts also mock this
+// same specifier (with a different, partial export subset). All these files
+// can run in one `bun test` process, so a superset covering every real
+// export is resilient regardless of load order. Hand-written stubs (rather
+// than spreading the real module, as some other files do for other
+// specifiers) are required here: server.ts imports `cloudflare:workers`,
+// which is unavailable outside a Worker, so importing the real module here
+// would crash. Each mocked export is a stable wrapper delegating to a
+// per-test `let` binding (mirrors the mock.module style in
+// routes/api/v1/webhooks/polar.test.ts:21-74), so a test can flip
+// `authorizeFeatureRequest` mid-file. `@tanstack/react-router`'s
+// `createFileRoute` is left un-mocked — it runs for real at import time but
+// route registration isn't under test here.
+let authorizeFeatureRequest = mock(
+  async (
+    _permission: unknown,
+    _request: Request,
+    _options?: { allowAgentBearerToken?: boolean }
+  ): Promise<Response | null> => null
+)
+mock.module('@/lib/feature-permissions/server', () => ({
+  getAppConfig: () => ({ authProvider: 'none' as const, features: {} }),
+  _resetAppConfigCache: () => {},
+  publicReadEnabled: () => true,
+  authorizeFeatureRequest: (
+    permission: unknown,
+    request: Request,
+    options?: { allowAgentBearerToken?: boolean }
+  ) => authorizeFeatureRequest(permission, request, options),
+}))
+
+const { __handlePostForTests: handlePost } = await import('./webhook')
+
+beforeEach(() => {
+  // Default to authorized so the pre-existing SSRF/provider-forwarding tests
+  // below keep passing unchanged; only the "auth gate" tests override this.
+  authorizeFeatureRequest = mock(async () => null)
+})
 
 // Injected DNS resolver so tests never hit the network. A public address makes
 // hostname targets resolve to a non-internal IP (allowed); tests that must be
@@ -130,5 +176,35 @@ describe('health webhook proxy — provider verbatim forwarding', () => {
 
     expect(res.status).toBe(400)
     expect(calls).toHaveLength(0)
+  })
+})
+
+describe('health webhook proxy — auth gate', () => {
+  test('anonymous is blocked, no egress', async () => {
+    authorizeFeatureRequest = mock(
+      async () => new Response(null, { status: 401 })
+    )
+    const { calls, fetchImpl } = stubFetch()
+    const res = await handlePost(
+      makeRequest({ url: 'https://hooks.slack.com/x', text: 'hi' }),
+      { resolveHostAddresses: resolvePublic, fetchImpl }
+    )
+
+    expect(res.status).toBe(401)
+    // The outbound fetch must never run for an unauthorized caller.
+    expect(calls).toHaveLength(0)
+  })
+
+  test('authorized passes through to the outbound fetch', async () => {
+    authorizeFeatureRequest = mock(async () => null)
+    const { calls, fetchImpl } = stubFetch()
+    const res = await handlePost(
+      makeRequest({ url: 'https://hooks.slack.com/x', text: 'hi' }),
+      { resolveHostAddresses: resolvePublic, fetchImpl }
+    )
+
+    expect(res.status).toBe(200)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe('https://hooks.slack.com/x')
   })
 })

--- a/apps/dashboard/src/routes/api/v1/health/webhook.ts
+++ b/apps/dashboard/src/routes/api/v1/health/webhook.ts
@@ -14,8 +14,12 @@
  * a generic 400 so we never leak internal DNS/resolution detail.
  *
  * Ported from apps/dashboard/app/api/v1/health/webhook/route.ts.
- * - Per-route auth (authorizeFeatureRequest / SETTINGS_FEATURE_PERMISSION)
- *   dropped; centralized in middleware (#1397).
+ * - Per-route auth (authorizeFeatureRequest, feature 'settings') restored:
+ *   the global /api/v1 middleware is a public passthrough, so this route
+ *   must self-enforce that anonymous callers cannot trigger the outbound
+ *   fetch (see the write gate in handlePost below). Was previously dropped
+ *   in favor of centralized middleware (#1397); that middleware turned out
+ *   to be a passthrough for writes, so the gate is back.
  * - NextResponse replaced with standard Response / Response.json.
  * - @/lib/api/error-handler exists in this app and is imported directly.
  */
@@ -29,6 +33,7 @@ import {
   type ResolveHostAddresses,
   validateHostUrl,
 } from '@/lib/browser-connections/host-url'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
 
 const ROUTE_CONTEXT = {
   route: '/api/v1/health/webhook',
@@ -63,6 +68,20 @@ async function handlePost(
   request: Request,
   deps: WebhookDeps = {}
 ): Promise<Response> {
+  // Write gate: this POST makes the server issue an outbound fetch to a
+  // caller-supplied URL — a state-changing, SSRF-capable egress. The global
+  // /api/v1 middleware is a public passthrough under provider='none' /
+  // CHM_CLERK_PUBLIC_READ, so this route must self-enforce that anonymous
+  // callers cannot trigger it. A valid `chm_` API key still authenticates
+  // programmatic clients (e.g. alert integrations). Mirrors the
+  // /api/v1/actions guard.
+  const permissionResponse = await authorizeFeatureRequest(
+    { feature: 'settings', defaultAccess: 'authenticated', operation: 'write' },
+    request,
+    { allowAgentBearerToken: true }
+  )
+  if (permissionResponse) return permissionResponse
+
   debug('[POST /api/v1/health/webhook] Proxying alert webhook')
 
   let body: WebhookRequestBody


### PR DESCRIPTION
## Summary
Implements **plan 05** from the Round-2 repo audit (`plans/05-*.md`), executed by the overnight autonomous swarm.

`POST /api/v1/health/webhook` makes the server issue an outbound POST to a caller-supplied URL/body but had **no write-auth gate** — an anonymous caller could drive server-side egress (confused-deputy/relay). Adds the `authorizeFeatureRequest({feature:'settings', operation:'write'})` self-gate as the first statement in `handlePost`, mirroring the sibling write routes. The SSRF `fetch` is unchanged; DNS-rebinding hardening stays a separate follow-up.

## Test evidence
Verified on the combined swarm tree via the orchestrator's central CI-parity gate:
- `biome lint .` → clean (1914 files)
- `tsc --noEmit` (dashboard) → clean
- full `bun test src/ --isolate` → **4692 pass / 0 fail** (243 files, single process — no mock/env cross-contamination)

The plan's real test is included and passes on this branch (it fails on `main`).

## Self-review (runbook §5)
- [x] Real test fails on `main`, passes on this branch
- [x] No core monitoring feature gated behind cloud mode (self-hosted stays whole)
- [x] Fail-closed to OSS (unset/junk `CHM_*`/`VITE_*` env → OSS defaults)
- [x] No destructive/DDL auto-apply by the agent; recommendations only
- [x] No secrets in committed `.env*`; no `[vars]` re-added to `wrangler.toml`
- [x] Docs updated in the same PR if user-facing
- [x] Diff scoped to the plan; no drive-by refactors

🤖 Part of the overnight audit swarm (one plan = one branch = one PR).

Co-Authored-By: duyetbot <bot@duyet.net>