### PR TITLE
fix(alerting): commit dedup state only after webhook delivery to stop dropped alerts

### DIFF
--- a/apps/dashboard/src/lib/health/alert-state-store.test.ts
+++ b/apps/dashboard/src/lib/health/alert-state-store.test.ts
@@ -122,19 +122,31 @@ describe('evaluateAlert + MemoryAlertStateStore', () => {
     }
 
     // First sighting fires.
-    expect(
-      evaluateAlert(store, { ...base, severity: 'critical', now: 1_000 }).kind
-    ).toBe('new')
+    const first = evaluateAlert(store, {
+      ...base,
+      severity: 'critical',
+      now: 1_000,
+    })
+    first.commit()
+    expect(first.decision.kind).toBe('new')
 
     // Persisting within cooldown is suppressed.
-    expect(
-      evaluateAlert(store, { ...base, severity: 'critical', now: 3_000 }).kind
-    ).toBe('suppressed')
+    const second = evaluateAlert(store, {
+      ...base,
+      severity: 'critical',
+      now: 3_000,
+    })
+    second.commit()
+    expect(second.decision.kind).toBe('suppressed')
 
     // Past the cooldown it reminds.
-    expect(
-      evaluateAlert(store, { ...base, severity: 'critical', now: 12_000 }).kind
-    ).toBe('reminder')
+    const third = evaluateAlert(store, {
+      ...base,
+      severity: 'critical',
+      now: 12_000,
+    })
+    third.commit()
+    expect(third.decision.kind).toBe('reminder')
 
     // Recovery fires and clears the record.
     const recovery = evaluateAlert(store, {
@@ -142,26 +154,29 @@ describe('evaluateAlert + MemoryAlertStateStore', () => {
       severity: 'ok',
       now: 13_000,
     })
-    expect(recovery.kind).toBe('recovery')
+    recovery.commit()
+    expect(recovery.decision.kind).toBe('recovery')
     expect(store.get(alertStateKey(0, 'disk-usage'))).toBeUndefined()
   })
 
   test('escalation fires even inside the cooldown window', () => {
     const store = new MemoryAlertStateStore()
-    evaluateAlert(store, {
+    const first = evaluateAlert(store, {
       hostId: 1,
       ruleId: 'replication-lag',
       severity: 'warning',
       now: 1_000,
       cooldownMs: 100_000,
     })
-    const decision = evaluateAlert(store, {
+    first.commit()
+    const { decision, commit } = evaluateAlert(store, {
       hostId: 1,
       ruleId: 'replication-lag',
       severity: 'critical',
       now: 1_500,
       cooldownMs: 100_000,
     })
+    commit()
     expect(decision.kind).toBe('escalated')
     expect(decision.notify).toBe(true)
   })
@@ -174,14 +189,45 @@ describe('evaluateAlert + MemoryAlertStateStore', () => {
       severity: 'warning',
       now: 1,
     })
+    a.commit()
     const b = evaluateAlert(store, {
       hostId: 1,
       ruleId: 'stuck-merges',
       severity: 'warning',
       now: 1,
     })
+    b.commit()
     // Both are "new" because each host tracks its own state.
-    expect(a.kind).toBe('new')
-    expect(b.kind).toBe('new')
+    expect(a.decision.kind).toBe('new')
+    expect(b.decision.kind).toBe('new')
+  })
+
+  test('a failed delivery (no commit) does not suppress the next sweep', () => {
+    const store = new MemoryAlertStateStore()
+    const base = { hostId: 1, ruleId: 'cpu', cooldownMs: 60_000 }
+
+    const first = evaluateAlert(store, {
+      ...base,
+      severity: 'critical',
+      now: 1_000,
+    })
+    expect(first.decision.notify).toBe(true) // new critical → notify
+    // simulate delivery FAILURE: do NOT commit
+
+    const second = evaluateAlert(store, {
+      ...base,
+      severity: 'critical',
+      now: 2_000,
+    })
+    expect(second.decision.notify).toBe(true) // retried, NOT suppressed
+    second.commit() // delivery now succeeds
+
+    const third = evaluateAlert(store, {
+      ...base,
+      severity: 'critical',
+      now: 3_000,
+    })
+    // within cooldown after a committed notify → suppressed
+    expect(third.decision.notify).toBe(false)
   })
 })

--- a/apps/dashboard/src/lib/health/alert-state-store.ts
+++ b/apps/dashboard/src/lib/health/alert-state-store.ts
@@ -226,8 +226,11 @@ export function decideNotification(
 }
 
 /**
- * Read → decide → persist against a store. Returns the decision for the caller
- * (the sweep) to act on. Keeps all mutation of the store in one place.
+ * Read → decide against a store, returning the decision plus a deferred
+ * `commit` thunk. The store is **not** written until the caller invokes
+ * `commit()` — for the sweep, that means only after a confirmed webhook
+ * delivery, so a failed send doesn't get remembered as "notified" and is
+ * retried on the next sweep instead of suppressed by the cooldown.
  */
 export function evaluateAlert(
   store: AlertStateStore,
@@ -238,17 +241,19 @@ export function evaluateAlert(
     cooldownMs?: number
     now?: number
   }
-): AlertDecision {
+): { decision: AlertDecision; commit: () => void } {
   const key = alertStateKey(params.hostId, params.ruleId)
   const prev = store.get(key)
   const { decision, next } = decideNotification(prev, params.severity, {
     cooldownMs: params.cooldownMs,
     now: params.now,
   })
-  if (next === null) {
-    store.delete(key)
-  } else {
-    store.set(key, next)
+  const commit = () => {
+    if (next === null) {
+      store.delete(key)
+    } else {
+      store.set(key, next)
+    }
   }
-  return decision
+  return { decision, commit }
 }

--- a/apps/dashboard/src/lib/health/server-sweep.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.ts
@@ -242,7 +242,7 @@ export async function runHealthSweep(): Promise<SweepSummary> {
         if (canDispatch) {
           const effective: Severity =
             SEVERITY_ORDER[severity] >= minRank ? severity : 'ok'
-          const decision = evaluateAlert(alertStateStore, {
+          const { decision, commit } = evaluateAlert(alertStateStore, {
             hostId: config.id,
             ruleId: rule.id,
             severity: effective,
@@ -258,12 +258,21 @@ export async function runHealthSweep(): Promise<SweepSummary> {
                 : `[${effective.toUpperCase()}] ${rule.title} — ${label} (host ${name})`
             const ok = await postWebhook(settings.webhookUrl, text)
             if (ok) {
+              // Persist "notified" only now — a failed delivery leaves no
+              // record, so the next sweep retries instead of suppressing.
+              commit()
               alertsDispatched++
               if (decision.kind === 'recovery') recoveries++
             }
-          } else if (SEVERITY_ORDER[severity] >= minRank) {
-            // A current finding that we chose not to re-send (deduped).
-            alertsSuppressed++
+          } else {
+            // Non-notify decisions (dedup/de-escalation/recovery-cleared
+            // bookkeeping) still commit — only the notify path gates on
+            // delivery.
+            commit()
+            if (SEVERITY_ORDER[severity] >= minRank) {
+              // A current finding that we chose not to re-send (deduped).
+              alertsSuppressed++
+            }
           }
         }
       } catch (err) {


### PR DESCRIPTION
## Summary
Implements **plan 06** from the Round-2 repo audit (`plans/06-*.md`), executed by the overnight autonomous swarm.

The health sweep recorded an alert as "notified" (`notifiedAt = now`) **before** confirming webhook delivery, so a failed first POST for a new/escalated critical was suppressed by the cooldown for up to an hour. `evaluateAlert` now returns `{ decision, commit }`; the sweep commits only after a successful `postWebhook` on the notify path (and always for non-notify bookkeeping). `decideNotification` is untouched.

## Test evidence
Verified on the combined swarm tree via the orchestrator's central CI-parity gate:
- `biome lint .` → clean (1914 files)
- `tsc --noEmit` (dashboard) → clean
- full `bun test src/ --isolate` → **4692 pass / 0 fail** (243 files, single process — no mock/env cross-contamination)

The plan's real test is included and passes on this branch (it fails on `main`).

## Self-review (runbook §5)
- [x] Real test fails on `main`, passes on this branch
- [x] No core monitoring feature gated behind cloud mode (self-hosted stays whole)
- [x] Fail-closed to OSS (unset/junk `CHM_*`/`VITE_*` env → OSS defaults)
- [x] No destructive/DDL auto-apply by the agent; recommendations only
- [x] No secrets in committed `.env*`; no `[vars]` re-added to `wrangler.toml`
- [x] Docs updated in the same PR if user-facing
- [x] Diff scoped to the plan; no drive-by refactors

🤖 Part of the overnight audit swarm (one plan = one branch = one PR).

Co-Authored-By: duyetbot <bot@duyet.net>