### PR TITLE
perf(connections): run multi-query charts in parallel on user connections

### DIFF
--- a/apps/dashboard/src/lib/connection-query/execute-connection-chart.test.ts
+++ b/apps/dashboard/src/lib/connection-query/execute-connection-chart.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for the multi-query branch of executeConnectionChartQuery — the perf
+ * fix that swaps a serial `for await` loop for `Promise.all` so multi-query
+ * charts on user/browser connections run in parallel, like the env-host
+ * equivalent (`executeMultiChartQuery` in `query-executor.ts`).
+ *
+ * `queryConnection` is the only I/O boundary here, so only
+ * `./connection-client` is mocked (full export surface — mirrors the
+ * mock.module style in
+ * apps/dashboard/src/routes/api/v1/webhooks/polar.test.ts). The chart
+ * registry (`@/lib/api/chart-registry`) is pure in-memory data with no I/O,
+ * so these tests register real synthetic charts through its real
+ * `registerChartQuery` instead of mocking it, keeping them decoupled from any
+ * real production chart's query count.
+ */
+
+import type { ConnectionCredentials } from '@/lib/connection-store/types'
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { registerChartQuery } from '@/lib/api/chart-registry'
+
+type QueryConnectionResult = {
+  data: Record<string, unknown>[]
+  queryId: string | undefined
+  duration: number
+}
+
+let queryConnection = mock(
+  async (
+    _credentials: ConnectionCredentials,
+    query: string,
+    _options?: unknown
+  ): Promise<QueryConnectionResult> => ({
+    data: [{ query }],
+    queryId: undefined,
+    duration: 0,
+  })
+)
+mock.module('./connection-client', () => ({
+  createConnectionClient: () => ({}),
+  getConnectionVersion: async () => null,
+  queryConnection: (
+    credentials: ConnectionCredentials,
+    query: string,
+    options?: unknown
+  ) => queryConnection(credentials, query, options),
+}))
+
+const { executeConnectionChartQuery } = await import(
+  './execute-connection-chart'
+)
+
+const credentials: ConnectionCredentials = {
+  host: 'https://example.com:8443',
+  user: 'default',
+  password: 'secret',
+}
+
+beforeEach(() => {
+  queryConnection = mock(
+    async (
+      _credentials: ConnectionCredentials,
+      query: string,
+      _options?: unknown
+    ): Promise<QueryConnectionResult> => ({
+      data: [{ query }],
+      queryId: undefined,
+      duration: 0,
+    })
+  )
+})
+
+describe('executeConnectionChartQuery — multi-query branch (Promise.all)', () => {
+  test('assembles data keyed by each query key, in queries order regardless of resolution order', async () => {
+    registerChartQuery('__test_multi_assembly__', () => ({
+      queries: [
+        { key: 'a', query: 'SELECT 1 AS a' },
+        { key: 'b', query: 'SELECT 2 AS b' },
+        { key: 'c', query: 'SELECT 3 AS c' },
+      ],
+    }))
+
+    // 'a' resolves last, 'c' resolves first — proves the result is ordered
+    // by the `queries` array (a Promise.all guarantee), not by completion
+    // order, which is what keeps `executedSql` deterministic after
+    // parallelizing.
+    const delayTicks: Record<string, number> = {
+      'SELECT 1 AS a': 3,
+      'SELECT 2 AS b': 2,
+      'SELECT 3 AS c': 1,
+    }
+    queryConnection = mock(
+      async (
+        _credentials: ConnectionCredentials,
+        query: string,
+        _options?: unknown
+      ): Promise<QueryConnectionResult> => {
+        for (let i = 0; i < (delayTicks[query] ?? 0); i++) {
+          await Promise.resolve()
+        }
+        return { data: [{ query }], queryId: undefined, duration: 0 }
+      }
+    )
+
+    const result = await executeConnectionChartQuery(
+      '__test_multi_assembly__',
+      credentials
+    )
+
+    expect(result.data).toEqual({
+      a: [{ query: 'SELECT 1 AS a' }],
+      b: [{ query: 'SELECT 2 AS b' }],
+      c: [{ query: 'SELECT 3 AS c' }],
+    })
+    expect(result.metadata.rows).toBe(3)
+    expect(result.executedSql).toBe(
+      'a: SELECT 1 AS a\nb: SELECT 2 AS b\nc: SELECT 3 AS c\n'
+    )
+    expect(queryConnection).toHaveBeenCalledTimes(3)
+  })
+
+  test('starts all queries concurrently instead of awaiting them one at a time', async () => {
+    registerChartQuery('__test_multi_concurrency__', () => ({
+      queries: [
+        { key: 'a', query: 'SELECT a' },
+        { key: 'b', query: 'SELECT b' },
+        { key: 'c', query: 'SELECT c' },
+      ],
+    }))
+
+    let inFlight = 0
+    let maxInFlight = 0
+    queryConnection = mock(
+      async (
+        _credentials: ConnectionCredentials,
+        _query: string,
+        _options?: unknown
+      ): Promise<QueryConnectionResult> => {
+        inFlight++
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        // A serial `for await` loop would never let `inFlight` exceed 1,
+        // since it awaits each call before starting the next; Promise.all
+        // starts every mapped call before any of them can resume.
+        await Promise.resolve()
+        await Promise.resolve()
+        inFlight--
+        return { data: [], queryId: undefined, duration: 0 }
+      }
+    )
+
+    await executeConnectionChartQuery('__test_multi_concurrency__', credentials)
+
+    expect(maxInFlight).toBe(3)
+  })
+})

--- a/apps/dashboard/src/lib/connection-query/execute-connection-chart.ts
+++ b/apps/dashboard/src/lib/connection-query/execute-connection-chart.ts
@@ -38,22 +38,28 @@ export async function executeConnectionChartQuery(
   }
 
   if ('queries' in queryDef) {
-    const combined: Record<string, unknown[]> = {}
-    let executedSql = ''
     const start = Date.now()
 
-    for (const q of queryDef.queries) {
-      const { data } = await queryConnection<Record<string, unknown>>(
-        credentials,
-        q.query,
-        {
-          clickhouse_settings: timezone
-            ? { session_timezone: timezone }
-            : undefined,
-        }
-      )
-      combined[q.key] = data
-      executedSql += `${q.key}: ${q.query}\n`
+    const entries = await Promise.all(
+      queryDef.queries.map(async (q) => {
+        const { data } = await queryConnection<Record<string, unknown>>(
+          credentials,
+          q.query,
+          {
+            clickhouse_settings: timezone
+              ? { session_timezone: timezone }
+              : undefined,
+          }
+        )
+        return [q.key, data, q.query] as const
+      })
+    )
+
+    const combined: Record<string, unknown[]> = {}
+    let executedSql = ''
+    for (const [key, data, query] of entries) {
+      combined[key] = data
+      executedSql += `${key}: ${query}\n`
     }
 
     return {


### PR DESCRIPTION
## Summary
Implements **plan 07** from the Round-2 repo audit (`plans/07-*.md`), executed by the overnight autonomous swarm.

Multi-query charts on user/browser-stored connections ran **sequentially** (a `for … await` loop) while the env-host path uses `Promise.all` — every 30s poll of a 4-query card paid the sum of latencies instead of the max. Replaces the serial loop with `Promise.all`, preserving the exact return shape and throw-on-first-failure behaviour.

## Test evidence
Verified on the combined swarm tree via the orchestrator's central CI-parity gate:
- `biome lint .` → clean (1914 files)
- `tsc --noEmit` (dashboard) → clean
- full `bun test src/ --isolate` → **4692 pass / 0 fail** (243 files, single process — no mock/env cross-contamination)

The plan's real test is included and passes on this branch (it fails on `main`).

## Self-review (runbook §5)
- [x] Real test fails on `main`, passes on this branch
- [x] No core monitoring feature gated behind cloud mode (self-hosted stays whole)
- [x] Fail-closed to OSS (unset/junk `CHM_*`/`VITE_*` env → OSS defaults)
- [x] No destructive/DDL auto-apply by the agent; recommendations only
- [x] No secrets in committed `.env*`; no `[vars]` re-added to `wrangler.toml`
- [x] Docs updated in the same PR if user-facing
- [x] Diff scoped to the plan; no drive-by refactors

🤖 Part of the overnight audit swarm (one plan = one branch = one PR).

Co-Authored-By: duyetbot <bot@duyet.net>