### PR TITLE
fix(security): escape literals and validate privilege/target in management DDL

### DIFF
--- a/apps/dashboard/src/lib/security/management-ddl.test.ts
+++ b/apps/dashboard/src/lib/security/management-ddl.test.ts
@@ -161,6 +161,32 @@ describe('generateGrantPrivilegeDdl', () => {
     )
     expect(sql).toContain('WITH GRANT OPTION')
   })
+
+  it('quotes a validated db.table target', () => {
+    const sql = generateGrantPrivilegeDdl(
+      { privilege: 'SELECT', on: 'db.events' },
+      'u'
+    )
+    expect(sql).toBe('GRANT SELECT ON `db`.`events` TO `u`')
+  })
+
+  it('accepts *.* without quoting the wildcard', () => {
+    const sql = generateGrantPrivilegeDdl({ privilege: 'ALL', on: '*.*' }, 'u')
+    expect(sql).toBe('GRANT ALL ON *.* TO `u`')
+  })
+
+  it('accepts a column-list privilege', () => {
+    const sql = generateGrantPrivilegeDdl(
+      { privilege: 'SELECT(col1, col2)', on: 'db.t' },
+      'u'
+    )
+    expect(sql).toContain('SELECT(col1, col2)')
+  })
+
+  it('accepts a digit-containing source privilege like S3', () => {
+    const sql = generateGrantPrivilegeDdl({ privilege: 'S3', on: '*.*' }, 'u')
+    expect(sql).toBe('GRANT S3 ON *.* TO `u`')
+  })
 })
 
 describe('generateRevokePrivilegeDdl', () => {
@@ -171,7 +197,8 @@ describe('generateRevokePrivilegeDdl', () => {
     )
     expect(sql).toStartWith('REVOKE')
     expect(sql).toContain('INSERT')
-    expect(sql).toContain('mydb.*')
+    // 'mydb' is a validated identifier, so it is rebuilt quoted; '*' stays bare
+    expect(sql).toContain('`mydb`.*')
     expect(sql).toContain('`carol`')
   })
 })
@@ -246,5 +273,32 @@ describe('SQL injection safety', () => {
     // Must not produce a valid injection — single quote is escaped
     expect(sql).not.toContain("IDENTIFIED BY 'evil'")
     expect(sql).toContain("\\'")
+  })
+
+  it('neutralizes a trailing backslash in a password so it cannot break out of the literal', () => {
+    const sql = generateCreateUserDdl({
+      username: 'u',
+      password: 'a\\',
+      defaultRole: 'analyst',
+    })
+    // The backslash is doubled, not left dangling before the closing quote
+    expect(sql).toContain("IDENTIFIED BY 'a\\\\'")
+    // The literal closed correctly, so the next clause follows intact (not truncated)
+    expect(sql).toEndWith('DEFAULT ROLE `analyst`')
+  })
+
+  it('rejects SQL injection via the grant target', () => {
+    expect(() =>
+      generateGrantPrivilegeDdl(
+        { privilege: 'SELECT', on: 'a TO attacker; --' },
+        'victim'
+      )
+    ).toThrow('Invalid grant target')
+  })
+
+  it('rejects SQL injection via the privilege token', () => {
+    expect(() =>
+      generateGrantPrivilegeDdl({ privilege: "SELECT'; DROP", on: 'db.t' }, 'u')
+    ).toThrow('Invalid privilege')
   })
 })

--- a/apps/dashboard/src/lib/security/management-ddl.ts
+++ b/apps/dashboard/src/lib/security/management-ddl.ts
@@ -2,8 +2,11 @@
  * management-ddl.ts
  *
  * Pure functions for generating ClickHouse DDL statements for RBAC management.
- * No React, no app imports — safe for both server and client contexts.
+ * No React; only imports `@/lib/sql-utils` (also dependency-free) — safe for
+ * both server and client contexts.
  */
+
+import { validateIdentifier } from '@/lib/sql-utils'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -14,9 +17,9 @@ function quoteId(name: string): string {
   return `\`${name.replace(/`/g, '``')}\``
 }
 
-/** Escape single quotes in a ClickHouse string literal. */
+/** Escape backslashes and single quotes in a ClickHouse string literal. */
 function escapeLiteral(s: string): string {
-  return s.replace(/'/g, "\\'")
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
 }
 
 // ---------------------------------------------------------------------------
@@ -118,12 +121,56 @@ export type PrivilegeTarget = {
   withGrantOption?: boolean
 }
 
+/**
+ * Conservative pattern for a privilege keyword with an optional column list.
+ * Digits are allowed after the first letter so source privileges like 'S3'
+ * (under the SOURCES group, e.g. `GRANT S3 ON *.* TO user`) still validate —
+ * quotes/semicolons/backticks/backslashes remain rejected either way.
+ */
+const PRIVILEGE_PATTERN = /^[A-Za-z][A-Za-z0-9 ]*(\([A-Za-z0-9_, ]+\))?$/
+
+/** Validate a privilege token, e.g. 'SELECT', 'ALTER UPDATE', 'SELECT(col1, col2)'. */
+function validatePrivilege(privilege: string): string {
+  if (typeof privilege !== 'string' || !PRIVILEGE_PATTERN.test(privilege)) {
+    throw new Error('Invalid privilege')
+  }
+  return privilege
+}
+
+/**
+ * Validate a grant target ('*', '*.*', 'db.*', or 'db.table') and rebuild it
+ * from the validated parts, quoting non-'*' parts with quoteId instead of
+ * interpolating the raw string.
+ */
+function validateGrantTarget(on: string): string {
+  if (typeof on !== 'string') {
+    throw new Error('Invalid grant target')
+  }
+  const parts = on.split('.')
+  if (parts.length > 2) {
+    throw new Error('Invalid grant target')
+  }
+  return parts
+    .map((part) => {
+      if (part === '*') return '*'
+      try {
+        validateIdentifier(part)
+      } catch {
+        throw new Error('Invalid grant target')
+      }
+      return quoteId(part)
+    })
+    .join('.')
+}
+
 export function generateGrantPrivilegeDdl(
   target: PrivilegeTarget,
   toUser: string
 ): string {
   const { privilege, on, withGrantOption } = target
-  let ddl = `GRANT ${privilege} ON ${on} TO ${quoteId(toUser)}`
+  const validPrivilege = validatePrivilege(privilege)
+  const validOn = validateGrantTarget(on)
+  let ddl = `GRANT ${validPrivilege} ON ${validOn} TO ${quoteId(toUser)}`
   if (withGrantOption) {
     ddl += ' WITH GRANT OPTION'
   }
@@ -135,7 +182,9 @@ export function generateRevokePrivilegeDdl(
   fromUser: string
 ): string {
   const { privilege, on } = target
-  return `REVOKE ${privilege} ON ${on} FROM ${quoteId(fromUser)}`
+  const validPrivilege = validatePrivilege(privilege)
+  const validOn = validateGrantTarget(on)
+  return `REVOKE ${validPrivilege} ON ${validOn} FROM ${quoteId(fromUser)}`
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements **plan 09** from the Round-2 repo audit (`plans/09-*.md`), executed by the overnight autonomous swarm.

The RBAC management DDL builder had incomplete escaping: `escapeLiteral` missed backslashes (literal-breakout in `IDENTIFIED BY '…'`) and `generateGrantPrivilegeDdl` interpolated `privilege`/`on` raw. Escapes backslashes, validates the grant target via the existing `validateIdentifier` (rebuilt with `quoteId`), and allowlists the privilege token (widened only to permit digits like `S3`; quotes/semicolons/backticks/backslashes always rejected). Feature gate unchanged.

## Test evidence
Verified on the combined swarm tree via the orchestrator's central CI-parity gate:
- `biome lint .` → clean (1914 files)
- `tsc --noEmit` (dashboard) → clean
- full `bun test src/ --isolate` → **4692 pass / 0 fail** (243 files, single process — no mock/env cross-contamination)

The plan's real test is included and passes on this branch (it fails on `main`).

## Self-review (runbook §5)
- [x] Real test fails on `main`, passes on this branch
- [x] No core monitoring feature gated behind cloud mode (self-hosted stays whole)
- [x] Fail-closed to OSS (unset/junk `CHM_*`/`VITE_*` env → OSS defaults)
- [x] No destructive/DDL auto-apply by the agent; recommendations only
- [x] No secrets in committed `.env*`; no `[vars]` re-added to `wrangler.toml`
- [x] Docs updated in the same PR if user-facing
- [x] Diff scoped to the plan; no drive-by refactors

🤖 Part of the overnight audit swarm (one plan = one branch = one PR).

Co-Authored-By: duyetbot <bot@duyet.net>