### PR TITLE
style(format): apply biome formatting to 6 drifted files

### DIFF
--- a/apps/dashboard/src/components/data-table/buttons/column-visibility.tsx
+++ b/apps/dashboard/src/components/data-table/buttons/column-visibility.tsx
@@ -15,9 +15,7 @@ interface ColumnVisibilityButtonProps<TData extends RowData = RowData> {
 
 export const ColumnVisibilityButton = function ColumnVisibilityButton<
   TData extends RowData = RowData,
->({
-  table,
-}: ColumnVisibilityButtonProps<TData>) {
+>({ table }: ColumnVisibilityButtonProps<TData>) {
   const handleSelect = (event: Event) => {
     event.preventDefault()
     // Prevent default selection behavior to avoid

--- a/apps/dashboard/src/components/data-table/buttons/csv-export-button.tsx
+++ b/apps/dashboard/src/components/data-table/buttons/csv-export-button.tsx
@@ -61,10 +61,7 @@ function generateCsvContent<TData extends RowData>(
  */
 export const CsvExportButton = function CsvExportButton<
   TData extends RowData = RowData,
->({
-  table,
-  filename = 'export',
-}: CsvExportButtonProps<TData>) {
+>({ table, filename = 'export' }: CsvExportButtonProps<TData>) {
   const handleExportCurrentPage = () => {
     const csvContent = generateCsvContent(table)
 

--- a/apps/dashboard/src/components/data-table/cells/code-toggle-format.tsx
+++ b/apps/dashboard/src/components/data-table/cells/code-toggle-format.tsx
@@ -23,11 +23,7 @@ const CODE_TRUNCATE_LENGTH = 50
 
 export const CodeToggleFormat = function CodeToggleFormat<
   TData extends RowData = RowData,
->({
-  row,
-  value,
-  options,
-}: CodeToggleFormatProps<TData>): React.ReactNode {
+>({ row, value, options }: CodeToggleFormatProps<TData>): React.ReactNode {
   const truncate_length = options?.max_truncate || CODE_TRUNCATE_LENGTH
 
   const handleValueChange = (accordionValue: string) => {

--- a/apps/dashboard/src/components/data-table/cells/hover-card-format.tsx
+++ b/apps/dashboard/src/components/data-table/cells/hover-card-format.tsx
@@ -21,11 +21,7 @@ interface HoverCardProps<TData extends RowData = RowData> {
 
 export const HoverCardFormat = function HoverCardFormat<
   TData extends RowData = RowData,
->({
-  row,
-  value,
-  options,
-}: HoverCardProps<TData>): React.ReactNode {
+>({ row, value, options }: HoverCardProps<TData>): React.ReactNode {
   const { content } = options || {}
 
   // Extract row data for template replacement

--- a/apps/dashboard/src/lib/query-config/background-bar-companions.test.ts
+++ b/apps/dashboard/src/lib/query-config/background-bar-companions.test.ts
@@ -18,7 +18,8 @@
  * configs so it cannot fail on unrelated, unaudited configs.
  */
 
-import { getAllSqlStrings } from './types'
+import type { QueryConfig } from '@/types/query-config'
+
 import { dictionariesConfig } from './more/dictionaries'
 import { parallelizationConfig } from './queries/parallelization'
 import { profilerConfig } from './queries/profiler'
@@ -32,8 +33,8 @@ import {
   clustersReplicasStatusConfig,
   replicaTablesConfig,
 } from './system/replicas-status'
+import { getAllSqlStrings } from './types'
 import { describe, expect, test } from 'bun:test'
-import type { QueryConfig } from '@/types/query-config'
 import { ColumnFormat } from '@/types/column-format'
 
 // Normalize a columnFormats value (which may be `ColumnFormat` or

--- a/apps/dashboard/src/lib/query-config/version-compatibility.test.ts
+++ b/apps/dashboard/src/lib/query-config/version-compatibility.test.ts
@@ -40,19 +40,19 @@
  * quoted aliases), so checks (c)/(d) only fire on unambiguous columns.
  */
 
+import type { QueryConfig } from '../../types/query-config'
+
+import { queries } from './index'
+import { describe, expect, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-
-import { queries } from './index'
-import type { QueryConfig } from '../../types/query-config'
-import { describe, expect, test } from 'bun:test'
-import { getAllSqlStrings, type VersionedSql } from '@chm/sql-builder'
 import {
   compareVersions,
   parseVersion,
   selectVersionedSql,
 } from '@chm/clickhouse-client/clickhouse-version'
+import { getAllSqlStrings, type VersionedSql } from '@chm/sql-builder'
 
 // ---------------------------------------------------------------------------
 // Supported ClickHouse versions
@@ -94,9 +94,8 @@ const SUPPORTED_VERSIONS = [
 // Helpers
 // ---------------------------------------------------------------------------
 
-const isVersionedArray = (
-  sql: QueryConfig['sql']
-): sql is VersionedSql[] => Array.isArray(sql)
+const isVersionedArray = (sql: QueryConfig['sql']): sql is VersionedSql[] =>
+  Array.isArray(sql)
 
 /** A version string is valid if it is 1–4 dot-separated numbers. */
 const VERSION_RE = /^\d+(\.\d+){0,3}$/
@@ -244,10 +243,7 @@ function primarySystemTable(config: QueryConfig): string | null {
 // This file lives at apps/dashboard/src/lib/query-config/ — the schema docs are
 // at the repo root under docs/clickhouse-schemas/tables/.
 const SCHEMA_TABLES_DIR = fileURLToPath(
-  new URL(
-    '../../../../../docs/clickhouse-schemas/tables/',
-    import.meta.url
-  )
+  new URL('../../../../../docs/clickhouse-schemas/tables/', import.meta.url)
 )
 
 /** Normalize a matrix header/cell like "24.1+" / "19.x" into a version string. */
@@ -300,7 +296,10 @@ function parseMatrixTable(md: string): Map<string, string> | null {
         const bucket = bucketVersions[ci]
         if (!bucket) continue // "Notes" or unparseable header
         if (/^yes$/i.test(rc[ci])) {
-          if (!min || compareVersions(parseVersion(bucket), parseVersion(min)) < 0)
+          if (
+            !min ||
+            compareVersions(parseVersion(bucket), parseVersion(min)) < 0
+          )
             min = bucket
         }
       }
@@ -343,7 +342,9 @@ describe('QueryConfig cross-version schema compatibility', () => {
         try {
           sql = selectVersionedSql(config.sql, parseVersion(v))
         } catch (err) {
-          failures.push(`[${config.name}] @${v}: threw ${(err as Error).message}`)
+          failures.push(
+            `[${config.name}] @${v}: threw ${(err as Error).message}`
+          )
           continue
         }
         if (typeof sql !== 'string' || sql.trim().length === 0) {
@@ -381,7 +382,8 @@ describe('QueryConfig cross-version schema compatibility', () => {
       const valid = sinces.filter((s: string) => VERSION_RE.test(s))
       for (let k = 1; k < valid.length; k++) {
         if (
-          compareVersions(parseVersion(valid[k]), parseVersion(valid[k - 1])) <= 0
+          compareVersions(parseVersion(valid[k]), parseVersion(valid[k - 1])) <=
+          0
         ) {
           failures.push(
             `[${config.name}] since not strictly ascending: '${valid[k - 1]}' → '${valid[k]}'`


### PR DESCRIPTION
## Summary
Fixes pre-existing formatting drift (line-wrapping + import order) on 6 files that fail the `.husky/pre-push` gate (`bun run check` = biome **check**) but not CI's `bun run lint` (biome **lint** only). Blocks every local `git push` until fixed. No behavior change — runs the project's own `biome check --write`.

Files: data-table `column-visibility`/`csv-export-button`/`code-toggle-format`/`hover-card-format`, query-config `background-bar-companions.test`/`version-compatibility.test`.

## Verification
- `bunx biome check .` → clean (1911 files, 0 errors)
- Full pre-push hook ran on push: `check` clean · `test:unit` pass · `test:packages` 891 pass/0 fail

Co-Authored-By: duyetbot <bot@duyet.net>