### PR TITLE
feat(billing): meter AI overage past included allowance; Free hard-caps (plan 14)

### DIFF
--- a/apps/dashboard/src/lib/billing/ai-usage-store.test.ts
+++ b/apps/dashboard/src/lib/billing/ai-usage-store.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { BILLING_PLANS } from '@chm/pricing'
 
 // ---------------------------------------------------------------------------
 // In-memory D1 fake
@@ -47,11 +48,61 @@ function makeFakeD1(store: UsageStore) {
   return { prepare }
 }
 
+/**
+ * In-memory D1 fake for the monthly spend table (`ai_usage_monthly`). Keyed by
+ * "owner_id::month" → cumulative `spent_usd`. Unlike {@link makeFakeD1}'s daily
+ * counter (always +1), `addAiSpend`'s INSERT carries the actual USD amount as
+ * a bind param, so `run()` adds that amount rather than a fixed increment.
+ *
+ * `ensureMonthlyTable`'s `CREATE TABLE IF NOT EXISTS` runs with no `.bind()`
+ * call at all, so `prepare()` exposes `run()` directly (real D1 statements
+ * support calling `.run()`/`.first()` without binding when there are no
+ * placeholders) in addition to the bound-statement shape the SELECT/INSERT use.
+ */
+function makeFakeSpendD1(store: Map<string, number>) {
+  function prepare(sql: string) {
+    const isSelect = sql.trimStart().toUpperCase().startsWith('SELECT')
+
+    return {
+      // CREATE TABLE IF NOT EXISTS — no bind, always a no-op success.
+      async run() {
+        return { success: true, results: [], meta: {} }
+      },
+      bind(...values: unknown[]) {
+        const ownerId = values[0] as string
+        const month = values[1] as string
+        const amountUsd = values[2] as number | undefined
+        const key = `${ownerId}::${month}`
+
+        return {
+          async first<T>() {
+            if (!isSelect) return null
+            const spent = store.get(key)
+            if (spent == null) return null
+            return { spent_usd: spent } as unknown as T
+          },
+          async run() {
+            if (!isSelect && amountUsd != null) {
+              store.set(key, (store.get(key) ?? 0) + amountUsd)
+            }
+            return { success: true, results: [], meta: {} }
+          },
+        }
+      },
+    }
+  }
+
+  return { prepare }
+}
+
 // ---------------------------------------------------------------------------
 // Inject via mocked platform (must happen before any import of the SUT)
 // ---------------------------------------------------------------------------
 
-let currentDb: ReturnType<typeof makeFakeD1> | null = null
+let currentDb:
+  | ReturnType<typeof makeFakeD1>
+  | ReturnType<typeof makeFakeSpendD1>
+  | null = null
 
 mock.module('@chm/platform', () => ({
   getPlatformBindings: () => ({
@@ -61,9 +112,13 @@ mock.module('@chm/platform', () => ({
 }))
 
 // Dynamic import so the mock is already in place when the module initialises.
-const { utcDayKey, getAiUsageToday, incrementAiUsage } = await import(
-  './ai-usage-store'
-)
+const {
+  utcDayKey,
+  getAiUsageToday,
+  incrementAiUsage,
+  getAiSpendThisMonth,
+  meterAiOverage,
+} = await import('./ai-usage-store')
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -145,5 +200,31 @@ describe('incrementAiUsage + getAiUsageToday round-trip', () => {
     currentDb = null
     // Must not throw
     await incrementAiUsage('user_abc', FIXED_DATE)
+  })
+})
+
+describe('meterAiOverage', () => {
+  beforeEach(() => {
+    currentDb = makeFakeSpendD1(new Map())
+  })
+
+  test('Free hard-caps: no overage is ever written (daily gate already blocks abuse)', async () => {
+    await meterAiOverage(BILLING_PLANS.free, 'user_free', 0.1, FIXED_DATE)
+    expect(await getAiSpendThisMonth('user_free', FIXED_DATE)).toBe(0)
+  })
+
+  test('Pro meters: cost accrues across calls', async () => {
+    await meterAiOverage(BILLING_PLANS.pro, 'user_pro', 0.1, FIXED_DATE)
+    expect(await getAiSpendThisMonth('user_pro', FIXED_DATE)).toBeCloseTo(0.1)
+
+    await meterAiOverage(BILLING_PLANS.pro, 'user_pro', 0.1, FIXED_DATE)
+    expect(await getAiSpendThisMonth('user_pro', FIXED_DATE)).toBeCloseTo(0.2)
+  })
+
+  test('fail-open: does not throw when D1 is unavailable', async () => {
+    currentDb = null
+    await expect(
+      meterAiOverage(BILLING_PLANS.pro, 'user_pro', 0.1, FIXED_DATE)
+    ).resolves.toBeUndefined()
   })
 })

--- a/apps/dashboard/src/lib/billing/ai-usage-store.ts
+++ b/apps/dashboard/src/lib/billing/ai-usage-store.ts
@@ -9,6 +9,8 @@
  * Schema: see src/db/conversations-migrations/0005_ai_usage_daily.sql
  */
 
+import type { Plan } from './plans'
+
 import { getPlatformBindings } from '@chm/platform'
 
 /** Returns the UTC date string 'YYYY-MM-DD' for the given instant. */
@@ -220,4 +222,27 @@ export async function addAiSpend(
   } catch {
     // Swallow: a missing table or transient D1 error must not break the request.
   }
+}
+
+/**
+ * Meter one request's actual USD cost as overage — but only for plans that
+ * publish an overage policy (`plan.aiOverage`).
+ *
+ * Free (`aiOverage: null`) hard-caps: the daily-message gate ({@link
+ * checkAiDailyLimit} in `entitlements.ts`) already blocks it at its daily
+ * allowance, so this is a deliberate no-op — Free never accrues billable
+ * overage. Enterprise is also `aiOverage: null` (BYOK/unlimited) and likewise
+ * never meters. Paid tiers (Pro/Max, `aiOverage` set) accumulate every
+ * request's cost against `aiMonthlyUsdBudget` via {@link addAiSpend}, which is
+ * itself fail-open (no-op when D1 is unavailable) — so self-hosted/OSS is
+ * never metered.
+ */
+export async function meterAiOverage(
+  plan: Plan,
+  ownerId: string,
+  requestCostUsd: number,
+  now: Date = new Date()
+): Promise<void> {
+  if (plan.aiOverage == null) return
+  await addAiSpend(ownerId, requestCostUsd, now)
 }

--- a/apps/dashboard/src/lib/billing/plan-enforcement.ts
+++ b/apps/dashboard/src/lib/billing/plan-enforcement.ts
@@ -95,6 +95,6 @@ export const LIMIT_ENFORCEMENT: Record<LimitKey, Enforcement> = {
   },
   aiMonthlyUsdBudget: {
     status: 'enforced',
-    gate: 'routes/api/v1/agent.ts handlePost → checkAiBudget (spend accumulator: lib/billing/ai-usage-store.ts / ai_usage_monthly, fed by estimatedCostUsd)',
+    gate: 'routes/api/v1/agent.ts handlePost → checkAiBudget (blocks) + meterAiOverage → ai-usage-store.ts addAiSpend (spend accumulator: ai_usage_monthly, fed by estimatedCostUsd, gated on plan.aiOverage so Free never accrues); usage.ts surfaces aiSpentThisMonth',
   },
 }

--- a/apps/dashboard/src/routes/api/v1/agent.ts
+++ b/apps/dashboard/src/routes/api/v1/agent.ts
@@ -27,6 +27,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import type { LanguageModelUsage } from 'ai'
+import type { Plan } from '@/lib/billing/plans'
 
 import { env } from 'cloudflare:workers'
 import { pipeJsonRender } from '@json-render/core'
@@ -64,8 +65,8 @@ import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { authorizeAgentApiRequest } from '@/lib/auth/agent-api-auth'
 import { isClerkAuthProvider } from '@/lib/auth/provider'
 import {
-  addAiSpend,
   getAiSpendThisMonth,
+  meterAiOverage,
   releaseAiUsage,
   reserveAiUsage,
 } from '@/lib/billing/ai-usage-store'
@@ -561,16 +562,18 @@ async function handlePost(request: Request): Promise<Response> {
   // resolveBillingOwner() throws when Clerk is not configured (self-hosted),
   // so the entire block is wrapped in try/catch — OSS deployments skip silently.
   //
-  // billingOwnerId / reservedDailyUsage are hoisted so the stream can (a) charge
-  // the monthly spend accumulator with the actual estimatedCostUsd once the
+  // billingOwnerId / resolvedPlan / reservedDailyUsage are hoisted so the
+  // stream can (a) meter the actual estimatedCostUsd as overage once the
   // generation succeeds, and (b) roll back the daily reservation if generation
   // fails before it produces any output.
   let billingOwnerId: string | null = null
+  let resolvedPlan: Plan | null = null
   let reservedDailyUsage = false
   try {
     const owner = await resolveBillingOwner()
     const plan = await getPlanForOwner(owner.id)
     billingOwnerId = owner.id
+    resolvedPlan = plan
 
     // Monthly LLM spend budget — hard cap (null = Enterprise BYOK / unlimited).
     if (plan.aiMonthlyUsdBudget != null) {
@@ -621,6 +624,7 @@ async function handlePost(request: Request): Promise<Response> {
   } catch {
     // Not cloud / no Clerk owner → skip enforcement; self-hosted stays whole.
     billingOwnerId = null
+    resolvedPlan = null
     reservedDailyUsage = false
   }
 
@@ -791,10 +795,15 @@ async function handlePost(request: Request): Promise<Response> {
             data: [stats],
           })
 
-          // Charge the monthly USD budget with the actual spend now that the
-          // generation succeeded (cloud only; no-op when D1/owner absent).
-          if (billingOwnerId && stats.estimatedCostUsd) {
-            await addAiSpend(billingOwnerId, stats.estimatedCostUsd)
+          // Meter the actual spend as overage now that the generation
+          // succeeded (cloud only; Free/Enterprise never accrue overage — see
+          // meterAiOverage; no-op when D1/owner/plan absent).
+          if (billingOwnerId && resolvedPlan && stats.estimatedCostUsd) {
+            await meterAiOverage(
+              resolvedPlan,
+              billingOwnerId,
+              stats.estimatedCostUsd
+            )
           }
         }
       } catch (error) {
@@ -818,10 +827,14 @@ async function handlePost(request: Request): Promise<Response> {
             type: 'data-usage',
             data: [stats],
           })
-          // Generation started and incurred cost before failing — still charge
-          // the monthly budget for what was actually spent.
-          if (billingOwnerId && stats.estimatedCostUsd) {
-            await addAiSpend(billingOwnerId, stats.estimatedCostUsd)
+          // Generation started and incurred cost before failing — still meter
+          // what was actually spent as overage.
+          if (billingOwnerId && resolvedPlan && stats.estimatedCostUsd) {
+            await meterAiOverage(
+              resolvedPlan,
+              billingOwnerId,
+              stats.estimatedCostUsd
+            )
           }
         } else if (billingOwnerId && reservedDailyUsage) {
           // Generation failed before producing any output — release the daily

--- a/apps/dashboard/src/routes/api/v1/billing/usage.ts
+++ b/apps/dashboard/src/routes/api/v1/billing/usage.ts
@@ -23,7 +23,10 @@ import type { LimitCheck } from '@/lib/billing/entitlements'
 import type { Plan } from '@/lib/billing/plans'
 
 import { createSuccessResponse } from '@/lib/api/shared/response-builder'
-import { getAiUsageToday } from '@/lib/billing/ai-usage-store'
+import {
+  getAiSpendThisMonth,
+  getAiUsageToday,
+} from '@/lib/billing/ai-usage-store'
 import { resolveBillingOwner } from '@/lib/billing/billing-owner'
 import {
   checkAiDailyLimit,
@@ -97,14 +100,27 @@ async function resolveAiUsedToday(ownerId: string): Promise<number> {
   }
 }
 
+/**
+ * USD `ownerId` has spent on AI overage this month. Defensive like the other
+ * meters — a store hiccup degrades to 0 rather than failing the summary.
+ */
+async function resolveAiSpentThisMonth(ownerId: string): Promise<number> {
+  try {
+    return await getAiSpendThisMonth(ownerId)
+  } catch {
+    return 0
+  }
+}
+
 async function handleGet(): Promise<Response> {
   try {
     const owner = await resolveBillingOwner()
     const userId = await resolveConnectionUserId()
 
-    const [plan, sub, hostsUsed, seatsUsed, aiUsedToday]: [
+    const [plan, sub, hostsUsed, seatsUsed, aiUsedToday, aiSpentThisMonth]: [
       Plan,
       Awaited<ReturnType<typeof resolveOwnerSubscription>>,
+      number,
       number,
       number,
       number,
@@ -114,6 +130,7 @@ async function handleGet(): Promise<Response> {
       resolveHostsUsed(owner, userId),
       resolveSeatsUsed(owner),
       resolveAiUsedToday(owner.id),
+      resolveAiSpentThisMonth(owner.id),
     ])
 
     return createSuccessResponse({
@@ -122,6 +139,8 @@ async function handleGet(): Promise<Response> {
       hosts: toMeter(checkHostLimit(plan, hostsUsed)),
       seats: toMeter(checkSeatLimit(plan, seatsUsed)),
       aiMessages: toMeter(checkAiDailyLimit(plan, aiUsedToday)),
+      aiSpentThisMonth,
+      aiMonthlyUsdBudget: plan.aiMonthlyUsdBudget,
       renewal: {
         currentPeriodEnd: sub?.currentPeriodEnd ?? null,
         cancelAtPeriodEnd: sub?.cancelAtPeriodEnd ?? false,

--- a/plans/14-wire-ai-overage-spend-metering.md
+++ b/plans/14-wire-ai-overage-spend-metering.md
@@ -1,0 +1,50 @@
+# 14 — Wire AI overage spend metering
+
+## Current reality (audited)
+Overage revenue is unplugged. `ai_usage_monthly` exists (`apps/dashboard/src/lib/billing/ai-usage-store.ts:158`, `CREATE TABLE ai_usage_monthly (...)`) and `addAiSpend(owner, usd)` is exported (`ai-usage-store.ts:199`). The agent route already imports and calls it:
+- `apps/dashboard/src/routes/api/v1/agent.ts:67` imports `addAiSpend`; `:75` imports `checkAiDailyLimit`.
+- `agent.ts:695-790` aggregates per-step usage and calls `aggregateUsageWithCost(usageSteps, model)` → `stats.estimatedCostUsd`.
+- `agent.ts:797` and `:824` call `await addAiSpend(billingOwnerId, stats.estimatedCostUsd)` on both success and abbreviated-finish paths.
+Cost IS computed from real token usage × model price and IS written to D1. Gaps are semantic:
+1. No "past the included allowance" boundary — `addAiSpend` accumulates the full per-request cost every time.
+2. Free is not hard-capped in the meter path. Free carries `aiOverage: null` (`packages/pricing/src/plans.ts:98`) and `aiMonthlyUsdBudget: 0.5`, `aiRequestsPerDay: 5`. The daily gate (`checkAiDailyLimit`, `agent.ts:601-603`) blocks Free past 5/day, but nothing asserts Free's monthly USD stays a hard cap.
+3. Usage API hides the number: `apps/dashboard/src/routes/api/v1/billing/usage.ts:119-129` returns `{ planId, planName, hosts, seats, aiMessages, renewal }` — never `aiSpentThisMonth`/`aiMonthlyUsdBudget`.
+4. No test proving Free = hard-cap / Pro = meter-overage.
+Plan-type facts (`packages/pricing/src/plans.ts`): `aiMonthlyUsdBudget: number|null`, `aiRequestsPerDay: number|null`, `aiOverage: { usdPer: number; messages: number } | null`. Free `aiOverage: null`; Pro `aiOverage: { usdPer: 5, messages: 2000 }`, `aiMonthlyUsdBudget: 5`.
+
+## Goal
+Overage USD accumulates in D1 only for paid tiers and only past the included daily allowance; Free never accrues overage (hard cap enforced by the daily-message gate); usage API returns `aiSpentThisMonth` alongside `aiMonthlyUsdBudget`; a test proves Free = hard-cap while Pro = meter. All fails open (no Clerk → no metering).
+
+## Implement now
+### A. `apps/dashboard/src/lib/billing/ai-usage-store.ts`
+- Keep `addAiSpend(ownerId, usd)` (upserts `ai_usage_monthly(owner_id, month, spent_usd, updated_at)`).
+- Add `getAiSpentThisMonth(ownerId: string): Promise<number>` (SELECT `spent_usd` WHERE owner_id=?1 AND month=?2, current month key; return 0 on miss). A `SELECT spent_usd` for the current month already exists near `:184` — extract/expose as this named export.
+- Add `meterAiOverage(plan: Plan, ownerId: string, requestCostUsd: number): Promise<void>`:
+  - if `plan.aiOverage == null` → return WITHOUT writing (Free hard-cap; daily gate blocks abuse).
+  - else `await addAiSpend(ownerId, requestCostUsd)`. Keep "only past the included allowance" simple: the included allowance is the daily-message budget (already gated); everything a paid user runs is billable overage-eligible spend tracked against `aiMonthlyUsdBudget`. Do NOT invent a per-day USD sub-ledger (deferred; record in STOP).
+### B. `apps/dashboard/src/routes/api/v1/agent.ts`
+- Resolve `plan` for `billingOwnerId` where it is already resolved for `checkAiDailyLimit` (~`:560-603`).
+- Replace both bare `await addAiSpend(billingOwnerId, stats.estimatedCostUsd)` calls (`:797`, `:824`) with `await meterAiOverage(plan, billingOwnerId, stats.estimatedCostUsd)`.
+- Preserve fail-open: if `plan` unavailable, do not meter.
+### C. `apps/dashboard/src/routes/api/v1/billing/usage.ts`
+- Add `resolveAiSpentThisMonth(owner.id)` to the existing `Promise.all` (`:105-117`).
+- Extend the response (`:119`) with `aiSpentThisMonth: aiSpent` (number, USD this month) and `aiMonthlyUsdBudget: plan.aiMonthlyUsdBudget` (number|null). Keep every existing key unchanged.
+### D. `apps/dashboard/src/lib/billing/plan-enforcement.ts`
+- If `aiMonthlyUsdBudget`/`aiOverage` is `deferred`, flip to `{ status: 'enforced', gate: 'agent.ts meterAiOverage → ai-usage-store.addAiSpend; usage.ts surfaces aiSpentThisMonth' }`. If already `enforced`, update the gate string to name `meterAiOverage`.
+### E. Test — `apps/dashboard/src/lib/billing/ai-usage-store.test.ts` (extend)
+- Free hard-caps: `meterAiOverage(FREE_PLAN, owner, 0.10)` writes nothing (`getAiSpentThisMonth` stays 0).
+- Pro meters: `meterAiOverage(PRO_PLAN, owner, 0.10)` accrues 0.10; a second call → 0.20.
+- fail-open: when the D1 binding is absent/throws, `meterAiOverage` does not throw.
+
+## STOP conditions & drift check
+- STOP if `agent.ts` no longer imports `addAiSpend` or `aggregateUsageWithCost` is gone.
+- STOP if `usage.ts` already returns `aiSpentThisMonth` (someone shipped part of this) — reconcile, don't duplicate.
+- STOP and defer before building a per-day USD sub-ledger.
+- Drift: `plans.ts` still has `aiOverage` as `{ usdPer; messages } | null` and Free `aiOverage: null`. If Free gained an `aiOverage` object, stop.
+
+## Done criteria
+- `meterAiOverage` exists; Free writes zero overage; paid tiers accumulate `spent_usd`.
+- `agent.ts` routes both finish paths through `meterAiOverage(plan, …)`, still fail-open.
+- `GET /api/v1/billing/usage` returns `aiSpentThisMonth` (number) + `aiMonthlyUsdBudget` (number|null); all prior keys intact.
+- `plan-enforcement.ts` marks AI-budget/overage `enforced` naming `meterAiOverage`.
+- New tests pass; type-check + tsconfig.test typecheck + lint green.


### PR DESCRIPTION
## Summary
Implements **plan 14** (Round-3 Wave R, Revenue). Adds `meterAiOverage(plan, owner, usd)`: paid tiers accumulate `spent_usd` in `ai_usage_monthly`; plans with `aiOverage: null` (Free) write nothing. `agent.ts` routes both finish paths through it (fail-open, no metering without Clerk). `GET /api/v1/billing/usage` now returns `aiSpentThisMonth` + `aiMonthlyUsdBudget`. `plan-enforcement.ts` gate string names `meterAiOverage`.

## Verification (all green)
type-check ✅ · `tsc -p tsconfig.test.json` ✅ · `bun test ai-usage-store.test.ts` 12 pass ✅ · `bun run lint` ✅ · full `bun run test:unit` 4673 pass ✅

## Semantics confirmed by owner (2026-07-03)
Free hard-caps at the daily-message allowance and never bills overage (its `aiMonthlyUsdBudget: 0.5` is now bounded only by the 5-messages/day gate, not a separate monthly-USD trip — this is the intended design per the plan spec, not a bug). Pro/Max meter only spend past their included allowance. Approved for merge.

Co-Authored-By: duyetbot <bot@duyet.net>