### PR TITLE
test(query-config): prove declarative≡TS parity + fail-closed loader (plan 53)

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -232,3 +232,8 @@ AGENTSTATE_API_KEY=
 # POSTGRES_URL=
 # Redis-backed ClickHouse version cache (optional; falls back to in-memory).
 # REDIS_URL=
+# Query-config source: ts (default — hand-written TS configs) | declarative
+# (opt-in catalog path validated against the same schema; see
+# docs/content/reference/catalog-contributing.mdx). Leave unset/`ts` — do not
+# ship `declarative` as your default, it is not yet the default anywhere.
+# CHM_CONFIG_SOURCE=ts

--- a/apps/dashboard/src/lib/query-config/__tests__/declarative-parity.test.ts
+++ b/apps/dashboard/src/lib/query-config/__tests__/declarative-parity.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Declarative ≡ TS parity, for a representative sample of configs — Plan 53.
+ *
+ * The catalog-wide sweeps (`declarative/catalog/flip-safety.test.ts`,
+ * `getQueryConfigByName.test.ts`) already assert declarative≡TS on every
+ * catalog entry (91 of the 107 shipped TS configs map into the 93-entry
+ * catalog; the other 2 catalog entries are direct-import-only). This file is
+ * deliberately narrower and answers a different question those sweeps
+ * don't: does the
+ * *resolved* SQL — the string `selectVersionedSql` actually picks for a given
+ * ClickHouse server version — match between the two sources, not just the raw
+ * `sql` field/array? For a `VersionedSql[]` config the raw-array deep-equal
+ * used elsewhere implies this (same array in, same resolver, same output) but
+ * this suite checks it directly and explicitly, per-version, for a curated set
+ * spanning multiple domains and both plain-string and versioned-array SQL.
+ *
+ * Gap recorded (plan 53 STOP condition — "don't fabricate configs"):
+ * `running-queries`, one of the plan's suggested examples, has NO declarative
+ * catalog equivalent — its row-expansion panel is bespoke inline JSX, which
+ * the declarative schema cannot express (see
+ * docs/knowledge/declarative-config-catalog.md, "What stays TS-only"). It is
+ * swapped below for `query-detail` and `query-cache` (both queries-domain,
+ * both present in the catalog) so every name in REPRESENTATIVE_NAMES actually
+ * exists on both sides.
+ */
+
+import { DECLARATIVE_CATALOG } from '../declarative/catalog'
+import { getQueryConfigByName } from '../index'
+import { describe, expect, test } from 'bun:test'
+import {
+  parseVersion,
+  selectVersionedSql,
+} from '@chm/clickhouse-client/clickhouse-version'
+
+const TS_ENV = { CHM_CONFIG_SOURCE: 'ts' } as const
+const DECLARATIVE_ENV = { CHM_CONFIG_SOURCE: 'declarative' } as const
+
+// Representative sample spanning merges/tables/system/queries/more domains.
+// Every name here is confirmed present in BOTH `queries` (TS) and
+// `DECLARATIVE_CATALOG` as of this writing.
+const REPRESENTATIVE_NAMES = [
+  'merges', // merges domain, versioned sql (2 variants)
+  'replicas', // tables domain, plain string sql
+  'disks', // system domain, plain string sql
+  'part-info', // tables domain, versioned sql (3 variants)
+  'errors', // more domain, versioned sql (2 variants)
+  'query-detail', // queries domain, versioned sql (2 variants) — substitute for running-queries
+  'query-cache', // queries domain, plain string sql — substitute for running-queries
+  'clusters', // system domain, plain string sql
+  'kafka-consumers', // system domain, versioned sql (2 variants)
+  'tables-overview', // tables domain, plain string sql
+] as const
+
+// A version at (or just below) every real `since` boundary in the sample, so
+// selectVersionedSql is exercised at every switch point. Mirrors the spirit of
+// version-compatibility.test.ts's SUPPORTED_VERSIONS without duplicating its
+// full corpus-wide sweep.
+const SAMPLE_VERSIONS = [
+  '19.8',
+  '22.8',
+  '23.8',
+  '24.1',
+  '24.8',
+  '25.1',
+] as const
+
+describe('declarative ≡ TS parity — representative sample (plan 53)', () => {
+  test('every representative name exists on both sides (no fabricated configs)', () => {
+    for (const name of REPRESENTATIVE_NAMES) {
+      expect(
+        getQueryConfigByName(name, TS_ENV),
+        `${name} missing from TS`
+      ).toBeDefined()
+      expect(
+        DECLARATIVE_CATALOG[name],
+        `${name} missing from DECLARATIVE_CATALOG`
+      ).toBeDefined()
+    }
+  })
+
+  test('running-queries is confirmed TS-only (the recorded gap, not silently dropped)', () => {
+    expect(getQueryConfigByName('running-queries', TS_ENV)).toBeDefined()
+    expect(DECLARATIVE_CATALOG['running-queries']).toBeUndefined()
+  })
+
+  for (const name of REPRESENTATIVE_NAMES) {
+    describe(name, () => {
+      const tsConfig = getQueryConfigByName(name, TS_ENV)
+      const declConfig = getQueryConfigByName(name, DECLARATIVE_ENV)
+
+      test('columns match', () => {
+        expect(declConfig?.columns).toEqual(tsConfig?.columns)
+      })
+
+      test('columnFormats match', () => {
+        expect(declConfig?.columnFormats).toEqual(tsConfig?.columnFormats)
+      })
+
+      test('resolved SQL matches for every sampled ClickHouse version', () => {
+        for (const v of SAMPLE_VERSIONS) {
+          const version = parseVersion(v)
+          const tsSql = selectVersionedSql(tsConfig?.sql ?? '', version)
+          const declSql = selectVersionedSql(declConfig?.sql ?? '', version)
+
+          expect(declSql, `mismatch at CH ${v}`).toEqual(tsSql)
+        }
+      })
+    })
+  }
+})

--- a/apps/dashboard/src/lib/query-config/getQueryConfigByName.test.ts
+++ b/apps/dashboard/src/lib/query-config/getQueryConfigByName.test.ts
@@ -10,9 +10,11 @@
  *   5. A known name ('merges') is present in the catalog.
  */
 
+import type { DeclarativeQueryConfig } from './declarative/schema'
+
 import { DECLARATIVE_CATALOG } from './declarative/catalog'
 import { getQueryConfigByName, queries } from './index'
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, spyOn, test } from 'bun:test'
 
 const DECLARATIVE_ENV = { CHM_CONFIG_SOURCE: 'declarative' } as const
 const TS_ENV = {} as const
@@ -176,5 +178,43 @@ describe('DECLARATIVE_CATALOG integrity', () => {
     const knownName = 'merges'
     expect(DECLARATIVE_CATALOG[knownName]).toBeDefined()
     expect(DECLARATIVE_CATALOG[knownName].name).toBe(knownName)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 5. Fail-closed: a malformed declarative entry must never crash the
+//    resolver — it must log and fall back to the TS default instead.
+// ---------------------------------------------------------------------------
+
+describe('getQueryConfigByName — fails closed on a malformed declarative entry', () => {
+  // Mutate a real, dual-sided catalog entry ('merges' has both a TS config
+  // and a catalog entry) to a shape that fails schema validation, restoring
+  // it after every test so the mutation never leaks into other suites.
+  const targetName = 'merges'
+  const original = DECLARATIVE_CATALOG[targetName]
+
+  afterEach(() => {
+    DECLARATIVE_CATALOG[targetName] = original
+  })
+
+  test('does not throw, logs, and falls back to the TS config', () => {
+    // Missing required `sql` / `columns` fields — fails
+    // declarativeQueryConfigSchema validation inside loadDeclarativeConfig.
+    DECLARATIVE_CATALOG[targetName] = {
+      name: targetName,
+    } as unknown as DeclarativeQueryConfig
+
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {})
+
+    let result: ReturnType<typeof getQueryConfigByName>
+    expect(() => {
+      result = getQueryConfigByName(targetName, DECLARATIVE_ENV)
+    }).not.toThrow()
+
+    expect(result).toBeDefined()
+    expect(result).toBe(getQueryConfigByName(targetName, TS_ENV)) // same TS reference
+    expect(errorSpy).toHaveBeenCalled()
+
+    errorSpy.mockRestore()
   })
 })

--- a/apps/dashboard/src/lib/query-config/index.ts
+++ b/apps/dashboard/src/lib/query-config/index.ts
@@ -2,6 +2,7 @@ import type { QueryConfig } from '@/types/query-config'
 
 import { DECLARATIVE_CATALOG } from './declarative/catalog'
 import { getConfigSource, loadDeclarativeConfig } from './declarative/loader'
+import { error } from '@chm/logger'
 
 export type { QueryConfig } from './types'
 
@@ -265,7 +266,19 @@ export const getQueryConfigByName = (
 
   if (getConfigSource(runtimeEnv) === 'declarative') {
     const decl = DECLARATIVE_CATALOG[name]
-    if (decl) return loadDeclarativeConfig(decl)
+    if (decl) {
+      // Fail-closed: a malformed catalog entry must never crash the
+      // dashboard. Log it and fall through to the TS default below instead
+      // of propagating the loader's validation error.
+      try {
+        return loadDeclarativeConfig(decl)
+      } catch (err) {
+        error(
+          `[query-config] Malformed declarative config for "${name}"; falling back to TS config`,
+          err
+        )
+      }
+    }
   }
 
   return queries.find((q) => q.name === name)

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -429,6 +429,12 @@ Injected at build time for the About page.
 | `VITE_BUILD_TIMESTAMP` | ISO build timestamp. |
 | `VITE_CI` | Set to `true` in CI environments. |
 
+## Query config source
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `CHM_CONFIG_SOURCE` | `ts` | Query-config resolution path: `ts` (hand-written TypeScript configs, current default everywhere) or `declarative` (opt-in data-only catalog, validated against the same schema and kept at parity — see [Catalog contributing](/reference/catalog-contributing)). Any value other than the literal string `declarative` resolves to `ts`. A malformed declarative entry logs an error and falls back to the `ts` config rather than crashing. |
+
 ## Legacy / migration
 
 | Variable | Notes |
@@ -451,4 +457,5 @@ See [Migrate to v0.3](/reference/migrating/v0-3) for the full rename list.
 <Card title="Feature permissions" href="/operate/advanced/feature-permissions" description="Config-file and env-override details." />
 <Card title="Authentication" href="/operate/authentication" description="Choose and configure an auth provider." />
 <Card title="Migrate to v0.3" href="/reference/migrating/v0-3" description="Full rename list from the Next.js era." />
+<Card title="Catalog contributing" href="/reference/catalog-contributing" description="The declarative query-config catalog CHM_CONFIG_SOURCE opts into." />
 </Cards>

--- a/docs/knowledge/declarative-config-catalog.md
+++ b/docs/knowledge/declarative-config-catalog.md
@@ -3,7 +3,7 @@ id: declarative-config-catalog
 title: Declarative Config Catalog
 type: spec
 status: active
-updated: 2026-06-18
+updated: 2026-07-03
 tags:
   - query-config
   - declarative
@@ -50,7 +50,20 @@ inert until explicitly turned on. `getQueryConfigByName(name, env)` in
 `lib/query-config/index.ts` is the central resolver: when the source is
 `declarative` it serves `DECLARATIVE_CATALOG[name]` (falling back to the TS
 config when a name is absent from the catalog); when `ts` it returns the TS
-config unchanged (by reference). The full default-flip to `declarative` is
+config unchanged (by reference).
+
+**Fail-closed on a malformed entry.** A second, distinct fallback path exists
+for a name that IS present in the catalog but fails `loadDeclarativeConfig`'s
+schema validation (a hand-authoring bug): the resolver catches the error, logs
+it via `@chm/logger`'s `error()`, and falls through to the TS config for that
+name — it never lets a bad catalog entry throw out of `getQueryConfigByName`
+and crash the dashboard. Every shipped catalog entry already passes validation
+(enforced by `flip-safety.test.ts`'s "every catalog entry loads without
+throwing"), so this path only fires for a future authoring mistake; it is
+tested directly in `getQueryConfigByName.test.ts` by mutating a live catalog
+entry to an invalid shape.
+
+The full default-flip to `declarative` is
 **deferred** (plan 02L) — it changes prod rendering for ~75 views and needs
 route-level visual verification against a live ClickHouse, which is not yet
 available.
@@ -159,11 +172,25 @@ catalog-wide what the per-domain suites can't, gating the 02L default flip:
 
 ## Status
 
-Foundation + opt-in wiring complete; ~80 configs migrated across all 10 domains
-(including `settings`/`users` via the `config-details` expandable, #1728), all
-dormant behind `CHM_CONFIG_SOURCE=ts`. The catalog is bundled (imported by the
-registry) but tree-shaken from rendering paths until the flag flips. Adding a
-check is a single-file PR — see the contributor guide. There are no external
-catalog consumers yet, so the `rowStyle`, `permission`, and `expandable`
-contracts remain freely revisable until the 02L default-flip — whose safety is
-now machine-enforced by the flip-safety invariants above.
+Foundation + opt-in wiring complete; `DECLARATIVE_CATALOG` has 93 entries — 91
+map to a same-named config in the 107-entry TS `queries` registry, plus 2
+catalog-only entries (`keeper-presence`, `cluster-live-metrics-all`) consumed
+by direct import (see orphan guard above) — across all 10 domains, including
+`settings`/`users` via the `config-details` expandable (#1728), all dormant
+behind `CHM_CONFIG_SOURCE=ts`. Of the 16 TS configs with no catalog entry: 3
+are inline-JSX expandables (`running-queries`, `keeper-connections`,
+`readonly-tables`), 5 are blocked on the not-yet-implemented `panel` expandable
+variant (`expensive-queries`, `expensive-queries-by-memory`, `slow-queries`,
+`failed-queries`, `history-queries`), 1 has runtime-templated SQL
+(`page-views`) — see "What stays TS-only" above — and the remaining 7
+(`explorer-table-overview`, `explorer-table-usage`, `warnings`,
+`blob-storage-log`, `storage-compression`, `storage-policies`,
+`ttl-storage-moves`) simply haven't been migrated yet; there is no principled
+blocker recorded for them. The catalog is bundled (imported by the registry) but
+tree-shaken from rendering paths until the flag flips. Adding a check is a
+single-file PR — see the contributor guide. There are no external catalog
+consumers yet, so the `rowStyle`, `permission`, and `expandable` contracts
+remain freely revisable until the 02L default-flip — whose safety is now
+machine-enforced by the flip-safety invariants above, plus a representative
+`__tests__/declarative-parity.test.ts` sample that additionally cross-checks
+`selectVersionedSql`-resolved SQL per ClickHouse version (plan 53).

--- a/plans/53-activate-declarative-queries.md
+++ b/plans/53-activate-declarative-queries.md
@@ -1,0 +1,65 @@
+# 53 — Activate the declarative query-config path
+
+## Current reality (audited)
+The declarative engine is built but dormant: `apps/dashboard/src/lib/query-config/declarative/{schema,loader}.ts` are feature-complete, a parallel `declarative/catalog/` mirrors the hand-rolled configs, and `apps/dashboard/src/lib/query-config/index.ts` selects the source via `getConfigSource()` — which defaults to `ts`. Nothing exercises the declarative path in CI, so it can rot.
+
+## Goal
+Flip-ready declarative path: `CHM_CONFIG_SOURCE=declarative` routes all query lookups through the validated catalog, a parity test proves declarative ≡ TS for a representative set, and the env var is documented. TS remains the default.
+
+## Implement now (depth F)
+- Add `apps/dashboard/src/lib/query-config/__tests__/declarative-parity.test.ts`:
+  - For ≥10 representative configs (running-queries, merges, replicas, disks, parts, errors, …), load both the TS config and its declarative equivalent and assert the resolved SQL (per supported CH version), columns, and formats match.
+- Confirm `getConfigSource()` reads `CHM_CONFIG_SOURCE` (`ts` default) and that the loader validates + fails closed to defaults on a malformed entry (add a test for a deliberately-bad declarative config → falls back, logs, does not throw).
+- Document the flag in `docs/` (deployment/config reference) and `apps/dashboard/.env.example`.
+- Do NOT change the default; this plan makes the path trustworthy, not the default.
+
+## STOP conditions & drift check
+- STOP if the declarative catalog is materially out of sync with the TS catalog — record the gap and scope the parity test to the configs that exist on both sides (don't fabricate configs).
+- Drift: confirm `getConfigSource()` and the catalog directory still exist and are named as above.
+
+## Done criteria
+- `CHM_CONFIG_SOURCE=declarative` routes all lookups through the catalog; TS remains default.
+- Parity test covers ≥10 configs (SQL/columns/formats) and passes.
+- A malformed declarative config fails closed to defaults (tested); flag documented.
+
+---
+
+## Audit notes (added during implementation, 2026-07-03)
+
+Before implementing, the current codebase was audited against this plan's
+"Current reality" section. Findings:
+
+- **The declarative path is far more built-out than "dormant."** The catalog
+  (`DECLARATIVE_CATALOG`) has 93 entries: 91 map to a same-named config in the
+  107-entry TS `queries` registry, plus 2 catalog-only entries
+  (`keeper-presence`, `cluster-live-metrics-all`) consumed by direct import.
+  16 TS configs have no catalog entry (9 for a documented reason — inline-JSX
+  expandables, the pending `panel` expandable variant, or runtime-templated
+  SQL; 7 simply not yet migrated, no principled blocker). ~85% coverage is not
+  materially out of sync (drift check passes; no STOP triggered). Extensive
+  parity coverage already exists and passes: `declarative/loader.test.ts`,
+  every `declarative/catalog/*/*-catalog.test.ts` domain suite,
+  `declarative/catalog/flip-safety.test.ts` (all 93 entries, via the real
+  `getQueryConfigByName` resolver, both env sources), and
+  `query-config/getQueryConfigByName.test.ts` (all 107 TS names). This already
+  exceeds the "≥10 representative configs" done-criterion.
+- **`running-queries` is confirmed TS-only** (inline-JSX expandable, per
+  `docs/knowledge/declarative-config-catalog.md`) — it has no declarative
+  catalog equivalent. The plan's example representative list is swapped
+  accordingly in the new parity test (see file), per the STOP condition's
+  instruction to scope to configs present on both sides and record the gap.
+- **The one genuine gap: the resolver did NOT fail closed.**
+  `getQueryConfigByName` called `loadDeclarativeConfig(decl)` with no
+  try/catch — a malformed catalog entry would throw out of the resolver
+  instead of falling back to the TS default, violating the task's
+  non-negotiable invariant ("fail-closed to defaults on a bad config, never
+  crash the dashboard"). Fixed in this change (see `index.ts` diff) with a
+  logged fallback, plus a new test that mutates a live catalog entry to a
+  malformed shape and asserts no-throw + TS fallback + logged.
+- **Docs gap: `CHM_CONFIG_SOURCE` was undocumented in the two "official
+  reference" surfaces** (`apps/dashboard/.env.example` and
+  `docs/content/reference/environment-variables.mdx`), despite being
+  documented narratively in `docs/content/reference/catalog-contributing.mdx`
+  and `docs/knowledge/declarative-config-catalog.md`. Closed in this change.
+  `.env.example` documents the var as commented-out with default `ts` — it
+  must never ship `declarative` as the self-hosted default.


### PR DESCRIPTION
## Summary
Implements **plan 53** (Round-3 Wave D). Makes the dormant declarative query-config path trustworthy: (1) **fail-closed fix** — `getQueryConfigByName` now catches a malformed declarative catalog entry, logs, and falls back to the TS default instead of throwing; (2) parity test (10 representative configs cross-checking resolved SQL/columns/formats); (3) documents `CHM_CONFIG_SOURCE` (`ts` stays default). Catalog was more built-out than expected (91/107 configs already mirror TS; pre-existing tests cover all 91).

## Verification
`bun test src/lib/query-config --isolate` → 1018 pass / 0 fail ✅ · `bun run lint` ✅ · TS default path unchanged (back-compat).
Note: `tsc -p tsconfig.test.json` is green in CI (has optional deps + route-tree gen); the new test file uses the same `bun:test` pattern as the 516 existing test files.

Co-Authored-By: duyetbot <bot@duyet.net>