### PR TITLE
feat(metrics): cached feature-gated Prometheus /metrics exporter (plan 35)

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -150,6 +150,12 @@ OPENROUTER_APP_NAME=chmonitor
 # SENTRY_ORG=
 # SENTRY_PROJECT=
 
+# ── Prometheus metrics exporter — GET /api/v1/metrics ───────────────────────
+# Default follows deployment: ON self-hosted, OFF in cloud mode. Set explicitly
+# to override either default (e.g. to opt a cloud deploy in, or turn it off
+# self-hosted). Never gated on Clerk/billing.
+# CHM_FEATURE_PROMETHEUS_ENABLED=true
+
 # ── Proxy / trusted-header auth (CHM_AUTH_PROVIDER=proxy | trusted) ─────────
 # Front the app with nginx / k8s ingress / oauth2-proxy / Cloudflare Access.
 # Cloudflare Access JWT verification (validates Cf-Access-Jwt-Assertion):

--- a/apps/dashboard/src/lib/health/alert-state-store.ts
+++ b/apps/dashboard/src/lib/health/alert-state-store.ts
@@ -73,6 +73,8 @@ export interface AlertStateStore {
   set(key: string, record: AlertStateRecord): void
   delete(key: string): void
   clear(): void
+  /** Read-only enumeration of all current condition keys and records. */
+  entries(): IterableIterator<[string, AlertStateRecord]>
 }
 
 /** Stable per-condition key. Severity is tracked in the record, not the key. */
@@ -100,6 +102,10 @@ export class MemoryAlertStateStore implements AlertStateStore {
 
   clear(): void {
     this.records.clear()
+  }
+
+  entries(): IterableIterator<[string, AlertStateRecord]> {
+    return this.records.entries()
   }
 }
 

--- a/apps/dashboard/src/lib/metrics/prometheus-exporter.test.ts
+++ b/apps/dashboard/src/lib/metrics/prometheus-exporter.test.ts
@@ -1,12 +1,26 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, mock, test } from 'bun:test'
 
+// ── Stub ClickHouse I/O before importing the module under test, so the
+// single-flight/cache tests below never hit a real network call. ──────────
+let getClientCallCount = 0
+
+mock.module('@chm/clickhouse-client', () => ({
+  getClient: async () => {
+    getClientCallCount++
+    return { query: async () => ({ json: async () => [] as unknown[] }) }
+  },
+}))
+
+import type { ClickHouseConfig } from '@chm/clickhouse-client'
 import { MemoryAlertStateStore } from '@/lib/health/alert-state-store'
 
 import {
   buildPrometheusText,
   countFiringAlertsByHost,
+  getPrometheusMetricsText,
   type HostMetricsInput,
   isPrometheusExporterEnabled,
+  __resetPrometheusMetricsCacheForTests,
 } from './prometheus-exporter'
 
 // ---------------------------------------------------------------------------
@@ -267,5 +281,43 @@ describe('isPrometheusExporterEnabled', () => {
     expect(
       isPrometheusExporterEnabled({ SOME_UNRELATED_VAR: 'x' })
     ).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getPrometheusMetricsText — 30s cache + single-flight rebuild.
+// ---------------------------------------------------------------------------
+
+describe('getPrometheusMetricsText', () => {
+  afterEach(() => {
+    __resetPrometheusMetricsCacheForTests()
+    getClientCallCount = 0
+  })
+
+  const configs: ClickHouseConfig[] = [
+    { id: 0, host: 'http://localhost:8123', user: 'default', password: '' },
+  ]
+
+  test('concurrent scrapes share one in-flight build (single query batch)', async () => {
+    // Two calls fired back-to-back, neither awaited before the other starts —
+    // exactly what a scrape storm looks like. If each triggered its own
+    // rebuild, getClient would be called 4 times (2 queries x 2 builds)
+    // instead of 2 (2 queries x 1 build).
+    const [a, b] = await Promise.all([
+      getPrometheusMetricsText(configs),
+      getPrometheusMetricsText(configs),
+    ])
+
+    expect(a).toBe(b)
+    expect(getClientCallCount).toBe(2)
+  })
+
+  test('a call within the 30s cache TTL reuses the cached body (no new queries)', async () => {
+    await getPrometheusMetricsText(configs)
+    expect(getClientCallCount).toBe(2)
+
+    await getPrometheusMetricsText(configs)
+    // Still within the TTL — zero additional ClickHouse queries.
+    expect(getClientCallCount).toBe(2)
   })
 })

--- a/apps/dashboard/src/lib/metrics/prometheus-exporter.test.ts
+++ b/apps/dashboard/src/lib/metrics/prometheus-exporter.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, test } from 'bun:test'
+
+import { MemoryAlertStateStore } from '@/lib/health/alert-state-store'
+
+import {
+  buildPrometheusText,
+  countFiringAlertsByHost,
+  type HostMetricsInput,
+  isPrometheusExporterEnabled,
+} from './prometheus-exporter'
+
+// ---------------------------------------------------------------------------
+// buildPrometheusText
+// ---------------------------------------------------------------------------
+
+/** Parse Prometheus text exposition format into HELP/TYPE/sample lines. */
+function parsePrometheusText(text: string) {
+  const lines = text.split('\n').filter((l) => l.length > 0)
+  const help = new Map<string, string>()
+  const type = new Map<string, string>()
+  const samples: { name: string; labels: string; value: string }[] = []
+
+  for (const line of lines) {
+    if (line.startsWith('# HELP ')) {
+      const [, , name, ...rest] = line.split(' ')
+      help.set(name, rest.join(' '))
+    } else if (line.startsWith('# TYPE ')) {
+      const [, , name, kind] = line.split(' ')
+      type.set(name, kind)
+    } else {
+      const match = line.match(/^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{[^}]*\})?\s+(\S+)$/)
+      expect(match).not.toBeNull()
+      const [, name, labels = '', value] = match as RegExpMatchArray
+      samples.push({ name, labels, value })
+    }
+  }
+
+  return { lines, help, type, samples }
+}
+
+describe('buildPrometheusText', () => {
+  test('emits system.metrics + asynchronous_metrics with host labels', () => {
+    const inputs: HostMetricsInput[] = [
+      {
+        hostId: 0,
+        metrics: [{ metric: 'Query', value: '42' }], // Int64 -> JSON string
+        asynchronousMetrics: [
+          { metric: 'AsynchronousMetricsCalculationTimeSpent', value: 0.5 }, // Float64 -> number
+        ],
+        alertsFiring: 2,
+      },
+    ]
+
+    const text = buildPrometheusText(inputs, 0.123)
+    const { help, type, samples } = parsePrometheusText(text)
+
+    expect(help.has('clickhouse_query')).toBe(true)
+    expect(type.get('clickhouse_query')).toBe('gauge')
+
+    const querySample = samples.find((s) => s.name === 'clickhouse_query')
+    expect(querySample?.labels).toBe('{host="0"}')
+    expect(Number(querySample?.value)).toBe(42)
+
+    const asyncSample = samples.find(
+      (s) => s.name === 'clickhouse_asynchronousmetricscalculationtimespent'
+    )
+    expect(asyncSample?.labels).toBe('{host="0"}')
+    expect(Number(asyncSample?.value)).toBe(0.5)
+  })
+
+  test('every sample carries a host label, including chmonitor series', () => {
+    const inputs: HostMetricsInput[] = [
+      { hostId: 0, metrics: [], asynchronousMetrics: [], alertsFiring: 1 },
+      { hostId: 1, metrics: [], asynchronousMetrics: [], alertsFiring: 0 },
+    ]
+
+    const { samples } = parsePrometheusText(buildPrometheusText(inputs, 0.01))
+
+    const firing = samples.filter((s) => s.name === 'chmonitor_alerts_firing')
+    expect(firing).toHaveLength(2)
+    expect(firing.find((s) => s.labels === '{host="0"}')?.value).toBe('1')
+    expect(firing.find((s) => s.labels === '{host="1"}')?.value).toBe('0')
+
+    // Scrape-duration is a single process-wide gauge, not per-host.
+    const scrapeDuration = samples.filter(
+      (s) => s.name === 'chmonitor_scrape_duration_seconds'
+    )
+    expect(scrapeDuration).toHaveLength(1)
+    expect(scrapeDuration[0].labels).toBe('')
+  })
+
+  test('never emits chmonitor_alerts_dispatched_total (honest omission)', () => {
+    const inputs: HostMetricsInput[] = [
+      { hostId: 0, metrics: [], asynchronousMetrics: [], alertsFiring: 0 },
+    ]
+    const text = buildPrometheusText(inputs, 0.01)
+    expect(text).not.toContain('chmonitor_alerts_dispatched_total')
+  })
+
+  test('HELP/TYPE lines are unique per metric name', () => {
+    const inputs: HostMetricsInput[] = [
+      {
+        hostId: 0,
+        metrics: [{ metric: 'Query', value: '1' }],
+        asynchronousMetrics: [],
+        alertsFiring: 0,
+      },
+      {
+        hostId: 1,
+        metrics: [{ metric: 'Query', value: '2' }],
+        asynchronousMetrics: [],
+        alertsFiring: 0,
+      },
+    ]
+
+    const text = buildPrometheusText(inputs, 0.01)
+    const helpCount = text
+      .split('\n')
+      .filter((l) => l === '# HELP clickhouse_query ClickHouse system.metrics.Query')
+      .length
+    const typeCount = text
+      .split('\n')
+      .filter((l) => l === '# TYPE clickhouse_query gauge')
+      .length
+    expect(helpCount).toBe(1)
+    expect(typeCount).toBe(1)
+  })
+
+  test('full series (name+labels) are unique across the whole output', () => {
+    // Two distinct raw ClickHouse metric names that collapse to the same
+    // snake_cased series name on the SAME host — must not produce two
+    // identical `name{labels}` lines (Prometheus would reject that scrape).
+    const inputs: HostMetricsInput[] = [
+      {
+        hostId: 0,
+        metrics: [
+          { metric: 'My.Metric', value: '1' },
+          { metric: 'My-Metric', value: '2' },
+        ],
+        asynchronousMetrics: [],
+        alertsFiring: 0,
+      },
+    ]
+
+    const text = buildPrometheusText(inputs, 0.01)
+    const sampleLines = text
+      .split('\n')
+      .filter((l) => l && !l.startsWith('#'))
+    const seriesKeys = sampleLines.map((l) => l.split(' ')[0])
+    expect(new Set(seriesKeys).size).toBe(seriesKeys.length)
+  })
+
+  test('skips non-finite / unparsable values instead of emitting garbage', () => {
+    const inputs: HostMetricsInput[] = [
+      {
+        hostId: 0,
+        metrics: [
+          { metric: 'Good', value: '10' },
+          { metric: 'Bad', value: 'not-a-number' },
+        ],
+        asynchronousMetrics: [],
+        alertsFiring: 0,
+      },
+    ]
+
+    const text = buildPrometheusText(inputs, 0.01)
+    expect(text).toContain('clickhouse_good')
+    expect(text).not.toContain('clickhouse_bad')
+  })
+
+  test('null metrics/asynchronousMetrics (failed host query) are treated as empty, not fatal', () => {
+    const inputs: HostMetricsInput[] = [
+      { hostId: 0, metrics: null, asynchronousMetrics: null, alertsFiring: 0 },
+    ]
+
+    const text = buildPrometheusText(inputs, 0.01)
+    // Still emits the process-wide + per-host gauges even with zero CH data.
+    expect(text).toContain('chmonitor_scrape_duration_seconds')
+    expect(text).toContain('chmonitor_alerts_firing{host="0"} 0')
+  })
+
+  test('all sample values are numeric', () => {
+    const inputs: HostMetricsInput[] = [
+      {
+        hostId: 0,
+        metrics: [{ metric: 'Query', value: '42' }],
+        asynchronousMetrics: [{ metric: 'Uptime', value: 99.5 }],
+        alertsFiring: 3,
+      },
+    ]
+    const { samples } = parsePrometheusText(buildPrometheusText(inputs, 0.5))
+    for (const sample of samples) {
+      expect(Number.isFinite(Number(sample.value))).toBe(true)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// countFiringAlertsByHost
+// ---------------------------------------------------------------------------
+
+describe('countFiringAlertsByHost', () => {
+  test('groups firing conditions by host id, ignoring ok records', () => {
+    const store = new MemoryAlertStateStore()
+    store.set('0:disk-usage', {
+      severity: 'critical',
+      updatedAt: 1,
+      notifiedAt: 1,
+    })
+    store.set('0:cpu-usage', {
+      severity: 'warning',
+      updatedAt: 1,
+      notifiedAt: 1,
+    })
+    store.set('1:disk-usage', {
+      severity: 'warning',
+      updatedAt: 1,
+      notifiedAt: 1,
+    })
+    // Defensive: an 'ok' record should never really be persisted, but the
+    // count must still exclude it if one somehow is.
+    store.set('2:stray-ok', { severity: 'ok', updatedAt: 1, notifiedAt: 1 })
+
+    const counts = countFiringAlertsByHost(store)
+    expect(counts.get(0)).toBe(2)
+    expect(counts.get(1)).toBe(1)
+    expect(counts.has(2)).toBe(false)
+  })
+
+  test('empty store yields an empty map', () => {
+    const store = new MemoryAlertStateStore()
+    expect(countFiringAlertsByHost(store).size).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isPrometheusExporterEnabled — fail-open self-host default, opt-in cloud.
+// ---------------------------------------------------------------------------
+
+describe('isPrometheusExporterEnabled', () => {
+  test('self-hosted default (no cloud mode) → enabled', () => {
+    expect(isPrometheusExporterEnabled({})).toBe(true)
+  })
+
+  test('cloud mode default (no explicit flag) → disabled', () => {
+    expect(isPrometheusExporterEnabled({ CHM_CLOUD_MODE: 'true' })).toBe(false)
+  })
+
+  test('explicit flag wins over self-hosted default', () => {
+    expect(
+      isPrometheusExporterEnabled({ CHM_FEATURE_PROMETHEUS_ENABLED: 'false' })
+    ).toBe(false)
+  })
+
+  test('explicit flag wins over cloud default (opt-in)', () => {
+    expect(
+      isPrometheusExporterEnabled({
+        CHM_CLOUD_MODE: 'true',
+        CHM_FEATURE_PROMETHEUS_ENABLED: 'true',
+      })
+    ).toBe(true)
+  })
+
+  test('never gates on billing/plan — only cloud-mode + explicit flag inputs', () => {
+    // No plan/entitlement fields are read at all; passing unrelated keys must
+    // not change the outcome (fail-open, no billing dependency).
+    expect(
+      isPrometheusExporterEnabled({ SOME_UNRELATED_VAR: 'x' })
+    ).toBe(true)
+  })
+})

--- a/apps/dashboard/src/lib/metrics/prometheus-exporter.ts
+++ b/apps/dashboard/src/lib/metrics/prometheus-exporter.ts
@@ -1,0 +1,314 @@
+/**
+ * Prometheus metrics exporter.
+ *
+ * Serves `system.metrics` + `system.asynchronous_metrics` from every
+ * configured ClickHouse host, plus chmonitor's own alert-firing gauge, as
+ * Prometheus text exposition format. Backs `GET /api/v1/metrics` (see
+ * `routes/api/v1/metrics.ts`).
+ *
+ * Design:
+ * - Reads go through `@chm/clickhouse-client` (`getClient`), the same
+ *   DNS-pinned/SSRF-guarded per-host transport every other CH-querying route
+ *   uses. No new outbound fetch surface.
+ * - Per-host queries are best-effort: a failing host is skipped, never fails
+ *   the whole scrape (mirrors `notifications.ts`'s fan-out).
+ * - Honest series only: `chmonitor_alerts_dispatched_total` is intentionally
+ *   NOT emitted — no server-side persistence tracks a running dispatch total
+ *   (the client-side history ring buffer in `history-storage.ts` is
+ *   localStorage-only and invisible to the Worker). Fabricating a counter
+ *   would violate the "no fabricated series" invariant, so it's omitted.
+ * - Cached for 30s with single-flight rebuild so a scrape storm triggers one
+ *   query batch, not one per concurrent scraper.
+ */
+
+import type { ClickHouseConfig } from '@chm/clickhouse-client'
+import { getClient } from '@chm/clickhouse-client'
+import { error as logError } from '@chm/logger'
+
+import { isCloudModeServer } from '@/lib/cloud/cloud-mode'
+import type { AlertStateStore } from '@/lib/health/alert-state-store'
+import { alertStateStore } from '@/lib/health/alert-state-store'
+
+const CACHE_TTL_MS = 30_000
+
+const METRICS_QUERY = 'SELECT metric, value FROM system.metrics'
+const ASYNC_METRICS_QUERY =
+  'SELECT metric, value FROM system.asynchronous_metrics'
+
+/** One row as returned by ClickHouse (JSONEachRow). */
+export interface RawMetricRow {
+  metric: string
+  /** Int64 columns (system.metrics) serialize as strings; Float64 as numbers. */
+  value: string | number
+}
+
+/** Per-host inputs to the text builder. `null` marks a failed/skipped query. */
+export interface HostMetricsInput {
+  /** Stable numeric host id — NEVER the raw host string (may carry creds). */
+  hostId: number
+  metrics: RawMetricRow[] | null
+  asynchronousMetrics: RawMetricRow[] | null
+  /** Currently-firing alert count for this host, from the in-memory alert state. */
+  alertsFiring: number
+}
+
+// ---------------------------------------------------------------------------
+// Pure text building (unit-tested directly — no ClickHouse/env dependency).
+// ---------------------------------------------------------------------------
+
+interface MetricFamily {
+  help: string
+  type: 'gauge'
+  /** seriesKey (labels string) -> full sample line. Last write wins on collision. */
+  samples: Map<string, string>
+}
+
+/** `Query` / `jemalloc.metadata` -> `clickhouse_query` / `clickhouse_jemalloc_metadata`. */
+function toMetricName(rawMetric: string): string {
+  const snake = rawMetric.toLowerCase().replace(/[^a-z0-9_]+/g, '_')
+  return `clickhouse_${snake}`
+}
+
+/** Escape a label value per the Prometheus text exposition format rules. */
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n')
+}
+
+function formatLabels(labels: Record<string, string>): string {
+  const entries = Object.entries(labels)
+  if (entries.length === 0) return ''
+  const parts = entries.map(([k, v]) => `${k}="${escapeLabelValue(v)}"`)
+  return `{${parts.join(',')}}`
+}
+
+function toFiniteNumber(value: string | number): number | null {
+  const n = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+function addSample(
+  families: Map<string, MetricFamily>,
+  name: string,
+  help: string,
+  labels: Record<string, string>,
+  value: number
+): void {
+  let family = families.get(name)
+  if (!family) {
+    family = { help, type: 'gauge', samples: new Map() }
+    families.set(name, family)
+  }
+  const labelStr = formatLabels(labels)
+  // Keyed by labels alone (name is already the map key) so two source metrics
+  // that collapse to the same name+labels never emit an invalid duplicate
+  // series — last write wins rather than producing unparsable output.
+  family.samples.set(labelStr, `${name}${labelStr} ${value}`)
+}
+
+/**
+ * Build the full Prometheus text body from per-host inputs. Pure — no I/O.
+ */
+export function buildPrometheusText(
+  inputs: readonly HostMetricsInput[],
+  scrapeDurationSeconds: number
+): string {
+  const families = new Map<string, MetricFamily>()
+
+  for (const input of inputs) {
+    const labels = { host: String(input.hostId) }
+
+    for (const row of input.metrics ?? []) {
+      const value = toFiniteNumber(row.value)
+      if (value === null) continue
+      addSample(
+        families,
+        toMetricName(row.metric),
+        `ClickHouse system.metrics.${row.metric}`,
+        labels,
+        value
+      )
+    }
+
+    for (const row of input.asynchronousMetrics ?? []) {
+      const value = toFiniteNumber(row.value)
+      if (value === null) continue
+      addSample(
+        families,
+        toMetricName(row.metric),
+        `ClickHouse system.asynchronous_metrics.${row.metric}`,
+        labels,
+        value
+      )
+    }
+
+    addSample(
+      families,
+      'chmonitor_alerts_firing',
+      'Number of chmonitor alert conditions currently firing (warning or critical) for this host.',
+      labels,
+      input.alertsFiring
+    )
+  }
+
+  addSample(
+    families,
+    'chmonitor_scrape_duration_seconds',
+    'Time taken to build this chmonitor /metrics scrape, in seconds.',
+    {},
+    scrapeDurationSeconds
+  )
+
+  const lines: string[] = []
+  for (const [name, family] of families) {
+    lines.push(`# HELP ${name} ${family.help}`)
+    lines.push(`# TYPE ${name} ${family.type}`)
+    for (const sample of family.samples.values()) {
+      lines.push(sample)
+    }
+  }
+  return `${lines.join('\n')}\n`
+}
+
+// ---------------------------------------------------------------------------
+// Alert-firing counts from the in-memory alert-state store.
+// ---------------------------------------------------------------------------
+
+/**
+ * Count currently-firing conditions (any severity above `ok`) per host from
+ * the alert dedup state. Every record the store holds already represents a
+ * firing (non-ok) condition — recoveries delete their entry — so this is a
+ * plain group-count over `entries()`.
+ *
+ * Caveat: `alertStateStore` is an in-memory, per-isolate singleton. On Node
+ * (Docker/K8s self-host) the sweep and this exporter share the same process,
+ * so counts are accurate. On Workerd, the isolate serving a scrape may differ
+ * from the isolate that last ran the cron sweep, in which case this reads 0 —
+ * a freshness gap, not a fabricated value. A cross-isolate store would need a
+ * new persistence layer, which is out of scope (see plan STOP conditions).
+ */
+export function countFiringAlertsByHost(
+  store: AlertStateStore
+): Map<number, number> {
+  const counts = new Map<number, number>()
+  for (const [key, record] of store.entries()) {
+    if (record.severity === 'ok') continue // defensive; store never persists 'ok'
+    const hostId = Number(key.split(':')[0])
+    if (!Number.isInteger(hostId)) continue
+    counts.set(hostId, (counts.get(hostId) ?? 0) + 1)
+  }
+  return counts
+}
+
+// ---------------------------------------------------------------------------
+// Feature gate.
+// ---------------------------------------------------------------------------
+
+function parseBoolEnv(value: string | undefined): boolean | undefined {
+  if (value === undefined || value === '') return undefined
+  const normalized = value.trim().toLowerCase()
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false
+  return undefined
+}
+
+/**
+ * Prometheus exporter feature gate. `CHM_FEATURE_PROMETHEUS_ENABLED` always
+ * wins when set; otherwise defaults ON for self-hosted deployments and OFF in
+ * cloud mode. Fail-open: resolves purely from cloud-mode detection, never a
+ * billing/plan check, so a Clerk-less OSS instance always gets it on by
+ * default.
+ */
+export function isPrometheusExporterEnabled(
+  bindings: Record<string, string | undefined>
+): boolean {
+  const explicit = parseBoolEnv(bindings.CHM_FEATURE_PROMETHEUS_ENABLED)
+  if (explicit !== undefined) return explicit
+  return !isCloudModeServer(bindings)
+}
+
+// ---------------------------------------------------------------------------
+// ClickHouse querying + 30s single-flight cache.
+// ---------------------------------------------------------------------------
+
+async function queryHostRows(
+  clientConfig: ClickHouseConfig,
+  query: string
+): Promise<RawMetricRow[] | null> {
+  try {
+    const client = await getClient({ web: true, clientConfig })
+    const resultSet = await client.query({ query, format: 'JSONEachRow' })
+    return await resultSet.json<RawMetricRow>()
+  } catch (err) {
+    logError('[metrics] host metric query failed', err, {
+      hostId: clientConfig.id,
+    })
+    return null
+  }
+}
+
+async function collectHostMetrics(
+  clientConfig: ClickHouseConfig,
+  alertCounts: Map<number, number>
+): Promise<HostMetricsInput> {
+  const [metrics, asynchronousMetrics] = await Promise.all([
+    queryHostRows(clientConfig, METRICS_QUERY),
+    queryHostRows(clientConfig, ASYNC_METRICS_QUERY),
+  ])
+
+  return {
+    hostId: clientConfig.id,
+    metrics,
+    asynchronousMetrics,
+    alertsFiring: alertCounts.get(clientConfig.id) ?? 0,
+  }
+}
+
+async function buildScrape(configs: readonly ClickHouseConfig[]): Promise<string> {
+  const startedAt = Date.now()
+  const alertCounts = countFiringAlertsByHost(alertStateStore)
+  const perHost = await Promise.all(
+    configs.map((config) => collectHostMetrics(config, alertCounts))
+  )
+  const scrapeDurationSeconds = (Date.now() - startedAt) / 1000
+  return buildPrometheusText(perHost, scrapeDurationSeconds)
+}
+
+interface CacheEntry {
+  builtAt: number
+  body: string
+}
+
+let cache: CacheEntry | null = null
+let inFlight: Promise<string> | null = null
+
+/**
+ * Cached (~30s) Prometheus scrape body for the given host configs. Concurrent
+ * calls during a rebuild share the same in-flight promise, so a scrape storm
+ * triggers exactly one query batch.
+ */
+export async function getPrometheusMetricsText(
+  configs: readonly ClickHouseConfig[]
+): Promise<string> {
+  if (cache && Date.now() - cache.builtAt < CACHE_TTL_MS) {
+    return cache.body
+  }
+
+  if (!inFlight) {
+    inFlight = buildScrape(configs)
+      .then((body) => {
+        cache = { builtAt: Date.now(), body }
+        return body
+      })
+      .finally(() => {
+        inFlight = null
+      })
+  }
+
+  return inFlight
+}
+
+/** Test-only: reset module-level cache/in-flight state between test cases. */
+export function __resetPrometheusMetricsCacheForTests(): void {
+  cache = null
+  inFlight = null
+}

--- a/apps/dashboard/src/routes/api/v1/metrics.ts
+++ b/apps/dashboard/src/routes/api/v1/metrics.ts
@@ -1,0 +1,51 @@
+/**
+ * Prometheus metrics exporter endpoint.
+ * GET /api/v1/metrics
+ *
+ * Serves `system.metrics` + `system.asynchronous_metrics` for every
+ * configured ClickHouse host, plus chmonitor's own alert-firing gauge, as
+ * Prometheus text exposition format. Cached ~30s (see prometheus-exporter.ts).
+ *
+ * Feature-gated by CHM_FEATURE_PROMETHEUS_ENABLED: on by default self-hosted,
+ * off by default in cloud mode. Disabled -> 404 (not 403) so cloud never
+ * advertises the surface. No `/metrics` alias: that path is already the
+ * dashboard's system.metrics browsing page (routes/(dashboard)/metrics.tsx).
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { getClickHouseConfigsFromEnv } from '@/lib/api/clickhouse-config'
+import {
+  getPrometheusMetricsText,
+  isPrometheusExporterEnabled,
+} from '@/lib/metrics/prometheus-exporter'
+
+export const Route = createFileRoute('/api/v1/metrics')({
+  server: {
+    handlers: {
+      GET: async () => {
+        const bindings = env as Record<string, string | undefined>
+
+        // Fail-open, no billing/plan gate: purely cloud-mode derived.
+        if (!isPrometheusExporterEnabled(bindings)) {
+          return new Response('Not Found', {
+            status: 404,
+            headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+          })
+        }
+
+        const configs = getClickHouseConfigsFromEnv(bindings)
+        const body = await getPrometheusMetricsText(configs)
+
+        return new Response(body, {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/plain; version=0.0.4; charset=utf-8',
+            'Cache-Control': 'no-cache, no-store, must-revalidate',
+          },
+        })
+      },
+    },
+  },
+})

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -126,6 +126,33 @@ HEALTH_ALERT_WEBHOOK_URL=https://hooks.slack.com/services/T000/B000/XXXX
 HEALTH_ALERT_MIN_SEVERITY=warning
 ```
 
+## Prometheus metrics exporter
+
+`GET /api/v1/metrics` serves `system.metrics` + `system.asynchronous_metrics`
+for every configured host (labeled `host="<id>"`), plus a
+`chmonitor_alerts_firing` gauge from the in-memory alert-dedup state, as
+Prometheus text exposition format. Cached ~30s; concurrent scrapes share one
+query batch.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `CHM_FEATURE_PROMETHEUS_ENABLED` | mode (self-hosted→`true`, cloud→`false`) | **Canonical**, server-only (no client bundle exposure needed). Set explicitly to override either default. Never gated on Clerk/billing — disabled returns `404` rather than `403` so cloud never advertises the surface. |
+
+```bash
+# Scrape this instance from Prometheus
+CHM_FEATURE_PROMETHEUS_ENABLED=true
+```
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: chmonitor
+    scrape_interval: 30s
+    metrics_path: /api/v1/metrics
+    static_configs:
+      - targets: ['dash.example.com']
+```
+
 ## Feature permissions
 
 All features are public and enabled by default. Override only what needs

--- a/plans/35-prometheus-metrics-exporter.md
+++ b/plans/35-prometheus-metrics-exporter.md
@@ -1,0 +1,41 @@
+# 35 — Prometheus metrics exporter
+
+## Goal
+A cached, feature-gated `/metrics` endpoint returns valid Prometheus text (`# HELP`/`# TYPE` + samples), labeled by `host`, covering `system.metrics`, `system.asynchronous_metrics`, and chmonitor's own alert counters — scrapeable at 30s with no surprise query load, fail-open for OSS.
+
+## Current reality (audited)
+There is no `/metrics` endpoint. Pointers (verify at head):
+- ClickHouse access: `packages/clickhouse-client` (`@chm/clickhouse-client`) — reuse the existing per-host query transport; already DNS-pinned/SSRF-guarded. Do NOT open a new socket.
+- Alert counters: health/alerting subsystem under `apps/dashboard/src/lib/health/` (adapters, sweep, dedup state). Surface counts from the in-memory alert state / dedup store (verify exact module).
+- Route convention: TanStack Start API routes under `apps/dashboard/src/routes/api/v1/`.
+
+## Implement now (depth F — file-level)
+### A. Endpoint — `apps/dashboard/src/routes/api/v1/metrics.ts` (verify final path)
+- Serve at `/api/v1/metrics`; optionally add a top-level `/metrics` alias via a thin re-export route if the router allows (verify). Prometheus accepts any path, so `/api/v1/metrics` is acceptable.
+- `GET`; `Content-Type: text/plain; version=0.0.4; charset=utf-8`.
+- Feature gate: read `CHM_FEATURE_PROMETHEUS_ENABLED`. Default = on when self-hosted (no Clerk), off in cloud unless explicitly enabled. Resolve via the existing edition/self-host detection (verify helper); when disabled return `404` (not 403 — don't advertise the surface in cloud).
+- Fail-open: never call a billing/plan gate. Owner/host resolution best-effort; if Clerk absent (OSS), enumerate configured host(s) from the stored connection source and emit for all.
+### B. Exporter — `apps/dashboard/src/lib/metrics/prometheus-exporter.ts` (new)
+- Query per host, in parallel: `SELECT metric, value FROM system.metrics` and `SELECT metric, value FROM system.asynchronous_metrics`.
+- Emit one gauge per metric. Name = `clickhouse_` + snake_cased metric (lowercased, non-alnum → `_`). Escape label values per Prometheus rules (`\`, `"`, `\n`).
+- Every sample carries `host="<hostId or label>"`. Add static `# HELP` (generic, honest) and `# TYPE <name> gauge` once per metric name (dedupe HELP/TYPE lines).
+- chmonitor alert counters (append after CH metrics): `chmonitor_alerts_firing{host}` (current firing from alert state); `chmonitor_alerts_dispatched_total{host}` (from dedup/history store if a total is available, else omit — honest); `chmonitor_scrape_duration_seconds` (self-observed build time gauge).
+### C. Cache — 30s TTL
+- Module-level `{ builtAt: number; body: string }`. If `Date.now() - builtAt < 30_000` return cached; else rebuild. Guard concurrent rebuilds with a single in-flight promise so a scrape storm triggers ONE query set. (Workerd: module state is per-isolate; 30s TTL still an effective damper.) NOTE: `Date.now()` is fine in production runtime code; only workflow scripts forbid it.
+### D. Env gate + docs
+- Add `CHM_FEATURE_PROMETHEUS_ENABLED` to the env schema/defaults (verify env module) and document it in the self-host env docs. Note default-on-self-host / off-in-cloud.
+
+## STOP conditions & drift check
+- STOP if a `/metrics` (or equivalent Prometheus exporter) route already exists — reconcile.
+- STOP if emitting alert counters requires a NEW persistence layer — emit only counters already available in memory/store; note the gap.
+- DRIFT: if `@chm/clickhouse-client` exposes no way to run an ad-hoc SELECT against a host without a billing-gated path, STOP and surface the real entrypoint rather than adding a bypass.
+- Do NOT introduce any new outbound fetch. Do NOT gate on plan/billing.
+
+## Test — `src/lib/metrics/prometheus-exporter.test.ts` (new)
+Feed a mocked `system.metrics` / `asynchronous_metrics` result set; assert the emitted text parses as valid Prometheus (`# HELP`/`# TYPE` present, unique per name, `host` label on every sample, values numeric).
+
+## Done criteria
+- `GET /api/v1/metrics` returns valid Prometheus text with `host` labels when enabled; `404` when the gate is off.
+- Scrapes cached ~30s; concurrent scrapes trigger a single query batch.
+- chmonitor alert counters emit from real state (or are honestly omitted).
+- Exporter unit test passes; type-check + tsconfig.test typecheck + lint green.


### PR DESCRIPTION
## Summary
Implements **plan 35** (Round-3 Wave I, Integrations). Adds `GET /api/v1/metrics` — a cached (30s, single-flight), feature-gated (`CHM_FEATURE_PROMETHEUS_ENABLED`) Prometheus-text exporter over `system.metrics` + `system.asynchronous_metrics` (labeled by host) plus `chmonitor_alerts_firing`. On (no Clerk) by default self-hosted, `404` in cloud unless enabled. Reuses the existing DNS-pinned `@chm/clickhouse-client` transport — **no new outbound fetch**; fail-open (never touches billing/plan/Clerk).

## Verification (worker, all green)
type-check ✅ · `tsc -p tsconfig.test.json` ✅ · `bun test src/lib/metrics` 17 pass ✅ · `bun run lint` ✅ · health suite 155 pass (no regression from the read-only `AlertStateStore.entries()` addition).

## Honest scope
`chmonitor_alerts_dispatched_total` is **omitted** (no server-side dispatch persistence exists; only client localStorage) rather than faked — a test asserts it's never emitted. Documented caveat: `alerts_firing` is per-isolate on Workerd (accurate on Node self-host).

Co-Authored-By: duyetbot <bot@duyet.net>