### PR TITLE
feat(alerting): email alert adapter — Mailgun/SendGrid (plan 25)

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -279,6 +279,9 @@ AGENTSTATE_API_KEY=
 # list services for that tab's picker — never to create/modify PagerDuty config.
 # HEALTH_ALERT_PAGERDUTY_ROUTING_KEY=
 # HEALTH_ALERT_PAGERDUTY_API_KEY=
+# Email alerting (additive to the webhook above; opt-in, fail-open when unset).
+# HEALTH_ALERT_EMAIL_ENABLED=false / HEALTH_ALERT_EMAIL_TO= / HEALTH_ALERT_EMAIL_FROM=
+# HEALTH_ALERT_EMAIL_PROVIDER_URL= (mailgun://KEY@DOMAIN | sendgrid://KEY | smtp://user:pass@host:port)
 # PeerDB monitoring.
 # PEERDB_API_URL= / PEERDB_PASSWORD=
 # User-connections / conversation store backend on non-Cloudflare targets

--- a/apps/dashboard/src/components/health/health-settings-dialog.tsx
+++ b/apps/dashboard/src/components/health/health-settings-dialog.tsx
@@ -175,6 +175,23 @@ export function HealthSettingsDialog() {
     }
   }
 
+  const handleTestEmail = async () => {
+    try {
+      const res = await fetch('/api/v1/health/email-test', { method: 'POST' })
+      const data = (await res.json().catch(() => null)) as {
+        success?: boolean
+        error?: { message?: string }
+      } | null
+      if (res.ok && data?.success) {
+        toast.success('Test email sent')
+      } else {
+        toast.error(data?.error?.message || 'Failed to send test email')
+      }
+    } catch {
+      toast.error('Failed to send test email')
+    }
+  }
+
   const handleTestBrowser = () => {
     if (!('Notification' in window)) {
       toast.error('Browser notifications are not supported in this browser')
@@ -360,6 +377,24 @@ export function HealthSettingsDialog() {
                   disabled={!alerts.webhookUrl}
                 >
                   Send test
+                </Button>
+              </div>
+            </div>
+
+            <Separator />
+
+            <div className="flex flex-col gap-2 rounded-md border p-3">
+              <div className="flex items-center justify-between">
+                <div className="flex flex-col">
+                  <Label className="text-sm font-medium">Email alerts</Label>
+                  <span className="text-xs text-muted-foreground">
+                    Configured by the server operator via{' '}
+                    <code className="text-xs">HEALTH_ALERT_EMAIL_*</code>{' '}
+                    environment variables (Mailgun, SendGrid, or SMTP)
+                  </span>
+                </div>
+                <Button variant="ghost" size="sm" onClick={handleTestEmail}>
+                  Send test email
                 </Button>
               </div>
             </div>

--- a/apps/dashboard/src/lib/health/adapters/__tests__/__snapshots__/adapters.test.ts.snap
+++ b/apps/dashboard/src/lib/health/adapters/__tests__/__snapshots__/adapters.test.ts.snap
@@ -198,7 +198,7 @@ exports[`generic-json adapter snapshot 1`] = `
 exports[`opsgenie adapter snapshot 1`] = `
 {
   "alias": "chmonitor:2:failed-mutations",
-  "description": 
+  "description":
 "Runbooks:
 https://docs.example.com/runbook/mutations"
 ,
@@ -218,5 +218,26 @@ https://docs.example.com/runbook/mutations"
     "metric:failed-mutations",
     "chmonitor",
   ],
+}
+`;
+
+exports[`email adapter snapshot 1`] = `
+{
+  "html": "<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#111827;max-width:480px;"><div style="background:#dc2626;color:#ffffff;padding:12px 16px;border-radius:6px 6px 0 0;font-size:16px;font-weight:600;">CRITICAL: Failed mutations</div><table style="width:100%;border-collapse:collapse;border:1px solid #e5e7eb;border-top:none;font-size:14px;"><tr><td style="color:#6b7280;padding:6px 8px;">Host</td><td style="padding:6px 8px;">prod-1 (id 2)</td></tr><tr><td style="color:#6b7280;padding:6px 8px;">Metric</td><td style="padding:6px 8px;">failed-mutations</td></tr><tr><td style="color:#6b7280;padding:6px 8px;">Value</td><td style="padding:6px 8px;">7</td></tr><tr><td style="color:#6b7280;padding:6px 8px;">Thresholds</td><td style="padding:6px 8px;">warn 1 | crit 5</td></tr><tr><td style="color:#6b7280;padding:6px 8px;">Detail</td><td style="padding:6px 8px;">7 failed mutations</td></tr><tr><td style="color:#6b7280;padding:6px 8px;">Runbooks</td><td style="padding:6px 8px;"><a href="https://docs.example.com/runbook/mutations" style="color:#2563eb;">https://docs.example.com/runbook/mutations</a></td></tr></table><div style="color:#9ca3af;font-size:12px;margin-top:8px;">2026-07-02T10:00:00.000Z</div></div>",
+  "subject": "[CRITICAL] failed-mutations on prod-1",
+  "text":
+"CRITICAL: Failed mutations
+
+Host: prod-1 (id 2)
+Metric: failed-mutations
+Value: 7
+Thresholds: warn 1 | crit 5
+Detail: 7 failed mutations
+
+Runbooks:
+- https://docs.example.com/runbook/mutations
+
+2026-07-02T10:00:00.000Z"
+,
 }
 `;

--- a/apps/dashboard/src/lib/health/adapters/__tests__/__snapshots__/adapters.test.ts.snap
+++ b/apps/dashboard/src/lib/health/adapters/__tests__/__snapshots__/adapters.test.ts.snap
@@ -172,6 +172,32 @@ exports[`pagerduty adapter snapshot 1`] = `
 }
 `;
 
+exports[`opsgenie adapter snapshot 1`] = `
+{
+  "alias": "chmonitor:2:failed-mutations",
+  "description": 
+"Runbooks:
+https://docs.example.com/runbook/mutations"
+,
+  "details": {
+    "critThreshold": "5",
+    "hostId": "2",
+    "metric": "failed-mutations",
+    "timestamp": "2026-07-02T10:00:00.000Z",
+    "value": "7",
+    "warnThreshold": "1",
+  },
+  "message": "Failed mutations — 7 failed mutations (host prod-1)",
+  "priority": "P1",
+  "source": "chmonitor",
+  "tags": [
+    "host:prod-1",
+    "metric:failed-mutations",
+    "chmonitor",
+  ],
+}
+`;
+
 exports[`generic-json adapter snapshot 1`] = `
 {
   "host": {
@@ -195,37 +221,11 @@ exports[`generic-json adapter snapshot 1`] = `
 }
 `;
 
-exports[`opsgenie adapter snapshot 1`] = `
-{
-  "alias": "chmonitor:2:failed-mutations",
-  "description":
-"Runbooks:
-https://docs.example.com/runbook/mutations"
-,
-  "details": {
-    "critThreshold": "5",
-    "hostId": "2",
-    "metric": "failed-mutations",
-    "timestamp": "2026-07-02T10:00:00.000Z",
-    "value": "7",
-    "warnThreshold": "1",
-  },
-  "message": "Failed mutations — 7 failed mutations (host prod-1)",
-  "priority": "P1",
-  "source": "chmonitor",
-  "tags": [
-    "host:prod-1",
-    "metric:failed-mutations",
-    "chmonitor",
-  ],
-}
-`;
-
 exports[`email adapter snapshot 1`] = `
 {
   "html": "<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#111827;max-width:480px;"><div style="background:#dc2626;color:#ffffff;padding:12px 16px;border-radius:6px 6px 0 0;font-size:16px;font-weight:600;">CRITICAL: Failed mutations</div><table style="width:100%;border-collapse:collapse;border:1px solid #e5e7eb;border-top:none;font-size:14px;"><tr><td style="color:#6b7280;padding:6px 8px;">Host</td><td style="padding:6px 8px;">prod-1 (id 2)</td></tr><tr><td style="color:#6b7280;padding:6px 8px;">Metric</td><td style="padding:6px 8px;">failed-mutations</td></tr><tr><td style="color:#6b7280;padding:6px 8px;">Value</td><td style="padding:6px 8px;">7</td></tr><tr><td style="color:#6b7280;padding:6px 8px;">Thresholds</td><td style="padding:6px 8px;">warn 1 | crit 5</td></tr><tr><td style="color:#6b7280;padding:6px 8px;">Detail</td><td style="padding:6px 8px;">7 failed mutations</td></tr><tr><td style="color:#6b7280;padding:6px 8px;">Runbooks</td><td style="padding:6px 8px;"><a href="https://docs.example.com/runbook/mutations" style="color:#2563eb;">https://docs.example.com/runbook/mutations</a></td></tr></table><div style="color:#9ca3af;font-size:12px;margin-top:8px;">2026-07-02T10:00:00.000Z</div></div>",
   "subject": "[CRITICAL] failed-mutations on prod-1",
-  "text":
+  "text": 
 "CRITICAL: Failed mutations
 
 Host: prod-1 (id 2)

--- a/apps/dashboard/src/lib/health/adapters/__tests__/adapters.test.ts
+++ b/apps/dashboard/src/lib/health/adapters/__tests__/adapters.test.ts
@@ -14,7 +14,9 @@ import type { AlertPayload } from '@/lib/health/adapters'
 
 import { describe, expect, test } from 'bun:test'
 import {
+  ALL_ADAPTERS,
   buildDiscordBody,
+  buildEmailBody,
   buildGenericJsonBody,
   buildOpsgenieBody,
   buildPagerDutyBody,
@@ -22,7 +24,9 @@ import {
   buildTelegramBody,
   buildTelegramText,
   detectAdapter,
+  detectEmailProvider,
   discordAdapter,
+  emailAdapter,
   escapeMarkdownV2,
   genericJsonAdapter,
   opsgenieAdapter,
@@ -63,6 +67,18 @@ const RECOVERY: AlertPayload = {
   severity: 'recovery',
   value: 0,
   label: 'recovered',
+}
+
+/** Exercises HTML-escaping: markup, ampersands, quotes, and an unsafe link scheme. */
+const XSS_ATTEMPT: AlertPayload = {
+  ...CRITICAL,
+  hostLabel: '<b>prod</b> & co',
+  title: 'Mutation <script>alert(1)</script>',
+  label: '"quoted" label \'value\'',
+  runbookUrls: [
+    'https://docs.example.com/runbook?x=1&y=2',
+    'javascript:alert(1)',
+  ],
 }
 
 // ---------------------------------------------------------------------------
@@ -379,6 +395,100 @@ describe('generic-json adapter', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Email
+// ---------------------------------------------------------------------------
+
+describe('email adapter', () => {
+  test('subject uses uppercase severity and metric/host', () => {
+    expect(buildEmailBody(CRITICAL).subject).toBe(
+      '[CRITICAL] failed-mutations on prod-1'
+    )
+    expect(buildEmailBody(WARNING).subject).toBe(
+      '[WARNING] failed-mutations on prod-1'
+    )
+  })
+
+  test('recovery subject reads RESOLVED, not RECOVERY', () => {
+    expect(buildEmailBody(RECOVERY).subject).toBe(
+      '[RESOLVED] failed-mutations on prod-1'
+    )
+  })
+
+  test('html includes host, metric, value, thresholds, timestamp, and a runbook link', () => {
+    const { html } = buildEmailBody(CRITICAL)
+    expect(html).toContain('prod-1 (id 2)')
+    expect(html).toContain('failed-mutations')
+    expect(html).toContain('>7<')
+    expect(html).toContain('warn 1 | crit 5')
+    expect(html).toContain('2026-07-02T10:00:00.000Z')
+    expect(html).toContain(
+      '<a href="https://docs.example.com/runbook/mutations"'
+    )
+  })
+
+  test('null value renders n/a in both html and text', () => {
+    const body = buildEmailBody({ ...CRITICAL, value: null })
+    expect(body.html).toContain('>n/a<')
+    expect(body.text).toContain('Value: n/a')
+  })
+
+  test('text mirrors the html content in plaintext', () => {
+    const { text } = buildEmailBody(CRITICAL)
+    expect(text).toContain('CRITICAL: Failed mutations')
+    expect(text).toContain('Host: prod-1 (id 2)')
+    expect(text).toContain('Runbooks:')
+    expect(text).toContain('- https://docs.example.com/runbook/mutations')
+  })
+
+  test('escapes HTML-special characters in host label, title, and label', () => {
+    const { html } = buildEmailBody(XSS_ATTEMPT)
+    expect(html).toContain('&lt;b&gt;prod&lt;/b&gt; &amp; co')
+    expect(html).toContain('Mutation &lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(html).toContain('&quot;quoted&quot; label &#39;value&#39;')
+    expect(html).not.toContain('<script>alert(1)</script>')
+    expect(html).not.toContain('<b>prod</b>')
+  })
+
+  test('escapes ampersands in runbook href attributes', () => {
+    const { html } = buildEmailBody(XSS_ATTEMPT)
+    expect(html).toContain(
+      'href="https://docs.example.com/runbook?x=1&amp;y=2"'
+    )
+  })
+
+  test('does not render a javascript: runbook url as a clickable link', () => {
+    const { html } = buildEmailBody(XSS_ATTEMPT)
+    expect(html).not.toContain('href="javascript:alert(1)"')
+    // still shown as inert escaped text, not silently dropped
+    expect(html).toContain('javascript:alert(1)')
+  })
+
+  test('snapshot', () => {
+    expect(buildEmailBody(CRITICAL)).toMatchSnapshot()
+  })
+})
+
+describe('detectEmailProvider', () => {
+  test('maps mailgun/sendgrid/smtp(s) schemes', () => {
+    expect(detectEmailProvider('mailgun://key@domain.example')).toBe('mailgun')
+    expect(detectEmailProvider('sendgrid://key')).toBe('sendgrid')
+    expect(detectEmailProvider('smtp://user:pass@host:25')).toBe('smtp')
+    expect(detectEmailProvider('smtps://user:pass@host:465')).toBe('smtp')
+  })
+
+  test('is case-insensitive on the scheme', () => {
+    expect(detectEmailProvider('MAILGUN://key@domain.example')).toBe('mailgun')
+  })
+
+  test('returns null for unknown schemes, including http(s)', () => {
+    expect(detectEmailProvider('https://hooks.slack.com/services/x')).toBe(null)
+    expect(detectEmailProvider('http://example.com')).toBe(null)
+    expect(detectEmailProvider('ftp://example.com')).toBe(null)
+    expect(detectEmailProvider('not a url')).toBe(null)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Registry + detectAdapter
 // ---------------------------------------------------------------------------
 
@@ -418,6 +528,7 @@ describe('detectAdapter', () => {
     expect(pagerDutyAdapter.id).toBe('pagerduty')
     expect(opsgenieAdapter.id).toBe('opsgenie')
     expect(genericJsonAdapter.id).toBe('generic-json')
+    expect(emailAdapter.id).toBe('email')
   })
 
   test('adapter.buildBody returns something for each channel', () => {
@@ -428,8 +539,53 @@ describe('detectAdapter', () => {
       pagerDutyAdapter,
       opsgenieAdapter,
       genericJsonAdapter,
+      emailAdapter,
     ]) {
       expect(adapter.buildBody(CRITICAL)).toBeDefined()
     }
+  })
+
+  test('ALL_ADAPTERS includes every channel adapter plus generic-json and email', () => {
+    const ids = ALL_ADAPTERS.map((a) => a.id).sort()
+    expect(ids).toEqual(
+      [
+        'telegram',
+        'slack',
+        'discord',
+        'pagerduty',
+        'generic-json',
+        'email',
+      ].sort()
+    )
+  })
+
+  test('email adapter.detect matches only provider config URL schemes, never http(s)', () => {
+    expect(emailAdapter.detect?.('mailgun://key@domain.example')).toBe(true)
+    expect(emailAdapter.detect?.('sendgrid://key')).toBe(true)
+    expect(emailAdapter.detect?.('smtp://user:pass@host:25')).toBe(true)
+    expect(emailAdapter.detect?.('smtps://user:pass@host:465')).toBe(true)
+    expect(emailAdapter.detect?.('https://hooks.slack.com/services/x')).toBe(
+      false
+    )
+    expect(emailAdapter.detect?.('http://example.com')).toBe(false)
+  })
+
+  test('email is NOT in the URL-detection registry, so detectAdapter routing for existing http(s) webhook URLs is unaffected', () => {
+    // Same assertions as the "routes known webhook hosts" test above, re-run
+    // after the email adapter's registration — a regression guard for the
+    // explicit STOP condition in plans/25-email-alert-adapter.md.
+    expect(detectAdapter('https://example.com/webhook').id).toBe('generic-json')
+    expect(detectAdapter('https://hooks.slack.com/services/T/B/x').id).toBe(
+      'slack'
+    )
+    expect(detectAdapter('https://events.pagerduty.com/v2/enqueue').id).toBe(
+      'pagerduty'
+    )
+    // Provider config URLs never match a channel adapter either — they fall
+    // back to generic-json via detectAdapter (email is dispatched explicitly,
+    // not through this URL registry).
+    expect(detectAdapter('mailgun://key@domain.example').id).toBe(
+      'generic-json'
+    )
   })
 })

--- a/apps/dashboard/src/lib/health/adapters/__tests__/adapters.test.ts
+++ b/apps/dashboard/src/lib/health/adapters/__tests__/adapters.test.ts
@@ -553,6 +553,7 @@ describe('detectAdapter', () => {
         'slack',
         'discord',
         'pagerduty',
+        'opsgenie',
         'generic-json',
         'email',
       ].sort()

--- a/apps/dashboard/src/lib/health/adapters/email.ts
+++ b/apps/dashboard/src/lib/health/adapters/email.ts
@@ -1,0 +1,177 @@
+/**
+ * Email notification adapter (pure formatter).
+ *
+ * Renders a clean HTML + plaintext alert email (host, check, value,
+ * thresholds, runbook links). The provider (Mailgun / SendGrid / SMTP) is
+ * detected from a config URL scheme; the actual transport (API key, SMTP
+ * credentials, sending) is applied by the dispatch layer — this module only
+ * shapes `{ subject, html, text }` from an {@link AlertPayload}.
+ */
+
+import type { AlertPayload, AlertSeverity, NotificationAdapter } from './types'
+
+/** Supported email transport providers. */
+export type EmailProvider = 'mailgun' | 'sendgrid' | 'smtp'
+
+/** Caller-supplied email transport config (secrets resolved by the dispatch layer). */
+export interface EmailConfig {
+  provider: EmailProvider
+  from: string
+  to: readonly string[]
+}
+
+/** PURE: normalized email parts for a payload. No network. */
+export interface EmailBody {
+  /** e.g. `[CRITICAL] failed-mutations on prod-01`. */
+  subject: string
+  /** Rendered HTML alert (inline styles only — email clients strip `<style>`). */
+  html: string
+  /** Plaintext mirror for the multipart alternative. */
+  text: string
+}
+
+/** Severity → banner colour and subject/heading label. `recovery` reads "RESOLVED". */
+const SEVERITY_STYLE: Record<
+  AlertSeverity,
+  { color: string; heading: string }
+> = {
+  critical: { color: '#dc2626', heading: 'CRITICAL' },
+  warning: { color: '#f59e0b', heading: 'WARNING' },
+  recovery: { color: '#16a34a', heading: 'RESOLVED' },
+}
+
+/**
+ * HTML-encode a string for use in both element text content and a
+ * double-quoted attribute value. Escaping all five reserved characters keeps
+ * a single helper safe for both contexts, as long as attributes are always
+ * double-quoted (which every attribute below is).
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/** Only `http(s)` runbook URLs render as clickable links; anything else (e.g. `javascript:`) renders as inert escaped text. */
+function isSafeLinkUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url)
+}
+
+function thresholdText(payload: AlertPayload): string {
+  const parts: string[] = []
+  if (payload.warnThreshold !== undefined && payload.warnThreshold !== null) {
+    parts.push(`warn ${payload.warnThreshold}`)
+  }
+  if (payload.critThreshold !== undefined && payload.critThreshold !== null) {
+    parts.push(`crit ${payload.critThreshold}`)
+  }
+  return parts.length > 0 ? parts.join(' | ') : '—'
+}
+
+function valueText(payload: AlertPayload): string {
+  return payload.value === null ? 'n/a' : String(payload.value)
+}
+
+/** Build the HTML alert body: a coloured banner + a simple info table. */
+function buildHtml(payload: AlertPayload): string {
+  const style = SEVERITY_STYLE[payload.severity]
+  const rows: string[] = [
+    `<tr><td style="color:#6b7280;padding:6px 8px;">Host</td><td style="padding:6px 8px;">${escapeHtml(payload.hostLabel)} (id ${payload.hostId})</td></tr>`,
+    `<tr><td style="color:#6b7280;padding:6px 8px;">Metric</td><td style="padding:6px 8px;">${escapeHtml(payload.metric)}</td></tr>`,
+    `<tr><td style="color:#6b7280;padding:6px 8px;">Value</td><td style="padding:6px 8px;">${escapeHtml(valueText(payload))}</td></tr>`,
+    `<tr><td style="color:#6b7280;padding:6px 8px;">Thresholds</td><td style="padding:6px 8px;">${escapeHtml(thresholdText(payload))}</td></tr>`,
+    `<tr><td style="color:#6b7280;padding:6px 8px;">Detail</td><td style="padding:6px 8px;">${escapeHtml(payload.label)}</td></tr>`,
+  ]
+
+  if (payload.runbookUrls && payload.runbookUrls.length > 0) {
+    const links = payload.runbookUrls
+      .map((url) => {
+        const safeText = escapeHtml(url)
+        return isSafeLinkUrl(url)
+          ? `<a href="${safeText}" style="color:#2563eb;">${safeText}</a>`
+          : safeText
+      })
+      .join('<br />')
+    rows.push(
+      `<tr><td style="color:#6b7280;padding:6px 8px;">Runbooks</td><td style="padding:6px 8px;">${links}</td></tr>`
+    )
+  }
+
+  return [
+    '<div style="font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;color:#111827;max-width:480px;">',
+    `<div style="background:${style.color};color:#ffffff;padding:12px 16px;border-radius:6px 6px 0 0;font-size:16px;font-weight:600;">${style.heading}: ${escapeHtml(payload.title)}</div>`,
+    `<table style="width:100%;border-collapse:collapse;border:1px solid #e5e7eb;border-top:none;font-size:14px;">${rows.join('')}</table>`,
+    `<div style="color:#9ca3af;font-size:12px;margin-top:8px;">${escapeHtml(payload.timestamp)}</div>`,
+    '</div>',
+  ].join('')
+}
+
+/** Build the plaintext mirror of the HTML body. */
+function buildText(payload: AlertPayload): string {
+  const style = SEVERITY_STYLE[payload.severity]
+  const lines: string[] = [
+    `${style.heading}: ${payload.title}`,
+    '',
+    `Host: ${payload.hostLabel} (id ${payload.hostId})`,
+    `Metric: ${payload.metric}`,
+    `Value: ${valueText(payload)}`,
+    `Thresholds: ${thresholdText(payload)}`,
+    `Detail: ${payload.label}`,
+  ]
+
+  if (payload.runbookUrls && payload.runbookUrls.length > 0) {
+    lines.push('', 'Runbooks:')
+    for (const url of payload.runbookUrls) {
+      lines.push(`- ${url}`)
+    }
+  }
+
+  lines.push('', payload.timestamp)
+
+  return lines.join('\n')
+}
+
+/**
+ * Build the email `{ subject, html, text }` for a payload. PURE — no network,
+ * no provider secrets. `subject` uses the uppercase severity heading, except
+ * `recovery` which reads "RESOLVED" (rather than "RECOVERY", to read naturally
+ * as an email subject line).
+ */
+export function buildEmailBody(payload: AlertPayload): EmailBody {
+  const style = SEVERITY_STYLE[payload.severity]
+  return {
+    subject: `[${style.heading}] ${payload.metric} on ${payload.hostLabel}`,
+    html: buildHtml(payload),
+    text: buildText(payload),
+  }
+}
+
+/**
+ * Detect the email provider from a config URL scheme:
+ * `mailgun://`, `sendgrid://`, `smtp://`, or `smtps://`. Returns `null` for
+ * anything else (including `http(s)://` webhook URLs) so this never hijacks
+ * webhook routing.
+ */
+export function detectEmailProvider(url: string): EmailProvider | null {
+  const match = /^(mailgun|sendgrid|smtps?):\/\//i.exec(url.trim())
+  if (!match) return null
+  const scheme = match[1]?.toLowerCase()
+  if (scheme === 'mailgun') return 'mailgun'
+  if (scheme === 'sendgrid') return 'sendgrid'
+  if (scheme === 'smtp' || scheme === 'smtps') return 'smtp'
+  return null
+}
+
+/**
+ * Email adapter. `detect` only matches provider config URL schemes (never
+ * `http(s)`), so registering it never changes `detectAdapter`'s routing for
+ * existing webhook URLs.
+ */
+export const emailAdapter: NotificationAdapter = {
+  id: 'email',
+  detect: (url: string) => detectEmailProvider(url) !== null,
+  buildBody: (payload: AlertPayload) => buildEmailBody(payload),
+}

--- a/apps/dashboard/src/lib/health/adapters/index.ts
+++ b/apps/dashboard/src/lib/health/adapters/index.ts
@@ -10,6 +10,7 @@
  */
 
 export type { DiscordWebhookBody } from './discord'
+export type { EmailBody, EmailConfig, EmailProvider } from './email'
 export type { GenericJsonBody } from './generic-json'
 export type {
   OpsgenieConfig,
@@ -30,6 +31,7 @@ export type {
 } from './types'
 
 export { buildDiscordBody, discordAdapter } from './discord'
+export { buildEmailBody, detectEmailProvider, emailAdapter } from './email'
 export { buildGenericJsonBody, genericJsonAdapter } from './generic-json'
 export { buildOpsgenieBody, opsgenieAdapter, opsgenieAlias } from './opsgenie'
 export {
@@ -48,6 +50,7 @@ export {
 import type { NotificationAdapter } from './types'
 
 import { discordAdapter } from './discord'
+import { emailAdapter } from './email'
 import { genericJsonAdapter } from './generic-json'
 import { opsgenieAdapter } from './opsgenie'
 import { pagerDutyAdapter } from './pagerduty'
@@ -55,9 +58,16 @@ import { slackAdapter } from './slack'
 import { telegramAdapter } from './telegram'
 
 /**
- * Channel-specific adapters, in detection priority order. `genericJsonAdapter`
- * is intentionally excluded here — it is the fallback returned by
+ * Channel-specific adapters, in detection priority order, for
+ * {@link detectAdapter}'s webhook-URL routing. `genericJsonAdapter` is
+ * intentionally excluded here — it is the fallback returned by
  * {@link detectAdapter} when nothing else matches.
+ *
+ * `emailAdapter` is ALSO intentionally excluded: email is selected by env
+ * config (`getServerEmailConfig`), not by detecting a webhook URL, so it is
+ * dispatched explicitly rather than through this URL-based registry. This
+ * keeps `detectAdapter`'s routing for existing http(s) webhook URLs provably
+ * unaffected by the email adapter's existence.
  */
 export const ADAPTERS: readonly NotificationAdapter[] = [
   telegramAdapter,
@@ -67,10 +77,11 @@ export const ADAPTERS: readonly NotificationAdapter[] = [
   opsgenieAdapter,
 ]
 
-/** All adapters including the generic-json fallback. */
+/** All adapters, including the generic-json fallback and email. */
 export const ALL_ADAPTERS: readonly NotificationAdapter[] = [
   ...ADAPTERS,
   genericJsonAdapter,
+  emailAdapter,
 ]
 
 /**

--- a/apps/dashboard/src/lib/health/email-transport.test.ts
+++ b/apps/dashboard/src/lib/health/email-transport.test.ts
@@ -1,0 +1,223 @@
+import type { EmailBody, EmailConfig } from './adapters/email'
+
+import { sendAlertEmail } from './email-transport'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+/**
+ * Exercises the REAL `sendViaMailgun` / `sendViaSendGrid` request construction
+ * (URL, auth header, body encoding) against a stubbed `fetch` — nothing here
+ * is mocked at the module level, so a bug in the actual outbound request shape
+ * would fail these tests (unlike the email-test.test.ts route tests, which
+ * stub `sendAlertEmail` itself and so never exercise this file).
+ */
+
+const ENV_KEY = 'HEALTH_ALERT_EMAIL_PROVIDER_URL'
+const originalFetch = globalThis.fetch
+
+const BODY: EmailBody = {
+  subject: '[CRITICAL] failed-mutations on prod-1',
+  html: '<div>alert</div>',
+  text: 'alert',
+}
+
+interface FetchCall {
+  url: string
+  init: RequestInit | undefined
+}
+
+function stubFetch(response: Response | (() => Response)): {
+  calls: FetchCall[]
+} {
+  const calls: FetchCall[] = []
+  globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+    calls.push({ url: String(input), init })
+    return typeof response === 'function' ? response() : response
+  }) as typeof fetch
+  return { calls }
+}
+
+describe('sendAlertEmail — mailgun', () => {
+  let savedEnv: string | undefined
+
+  beforeEach(() => {
+    savedEnv = process.env[ENV_KEY]
+  })
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY]
+    else process.env[ENV_KEY] = savedEnv
+    globalThis.fetch = originalFetch
+  })
+
+  const config: EmailConfig = {
+    provider: 'mailgun',
+    from: 'alerts@example.com',
+    to: ['ops@example.com', 'oncall@example.com'],
+  }
+
+  test('POSTs to the Mailgun messages API with Basic auth and form-encoded body', async () => {
+    process.env[ENV_KEY] = 'mailgun://key123@mg.example.com'
+    const { calls } = stubFetch(new Response('ok', { status: 200 }))
+
+    const ok = await sendAlertEmail(config, BODY)
+
+    expect(ok).toBe(true)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe(
+      'https://api.mailgun.net/v3/mg.example.com/messages'
+    )
+    expect(calls[0].init?.method).toBe('POST')
+    const headers = calls[0].init?.headers as Record<string, string>
+    expect(headers.Authorization).toBe(`Basic ${btoa('api:key123')}`)
+    expect(headers['Content-Type']).toBe('application/x-www-form-urlencoded')
+
+    const form = new URLSearchParams(calls[0].init?.body as string)
+    expect(form.getAll('to')).toEqual(['ops@example.com', 'oncall@example.com'])
+    expect(form.get('from')).toBe('alerts@example.com')
+    expect(form.get('subject')).toBe(BODY.subject)
+    expect(form.get('html')).toBe(BODY.html)
+    expect(form.get('text')).toBe(BODY.text)
+  })
+
+  test('returns false and never fetches when the provider url is malformed', async () => {
+    process.env[ENV_KEY] = 'mailgun://mg.example.com' // missing "key@"
+    const { calls } = stubFetch(new Response('ok', { status: 200 }))
+
+    const ok = await sendAlertEmail(config, BODY)
+
+    expect(ok).toBe(false)
+    expect(calls).toHaveLength(0)
+  })
+
+  test('returns false (does not throw) on a non-OK response', async () => {
+    process.env[ENV_KEY] = 'mailgun://key123@mg.example.com'
+    stubFetch(new Response('bad request', { status: 400 }))
+
+    const ok = await sendAlertEmail(config, BODY)
+
+    expect(ok).toBe(false)
+  })
+
+  test('returns false (does not throw) when fetch rejects', async () => {
+    process.env[ENV_KEY] = 'mailgun://key123@mg.example.com'
+    globalThis.fetch = (async () => {
+      throw new Error('network down')
+    }) as typeof fetch
+
+    const ok = await sendAlertEmail(config, BODY)
+
+    expect(ok).toBe(false)
+  })
+})
+
+describe('sendAlertEmail — sendgrid', () => {
+  let savedEnv: string | undefined
+
+  beforeEach(() => {
+    savedEnv = process.env[ENV_KEY]
+  })
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY]
+    else process.env[ENV_KEY] = savedEnv
+    globalThis.fetch = originalFetch
+  })
+
+  const config: EmailConfig = {
+    provider: 'sendgrid',
+    from: 'alerts@example.com',
+    to: ['ops@example.com'],
+  }
+
+  test('POSTs to the SendGrid mail/send API with Bearer auth and JSON body', async () => {
+    process.env[ENV_KEY] = 'sendgrid://sg-key-456'
+    const { calls } = stubFetch(new Response('', { status: 202 }))
+
+    const ok = await sendAlertEmail(config, BODY)
+
+    expect(ok).toBe(true)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe('https://api.sendgrid.com/v3/mail/send')
+    const headers = calls[0].init?.headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer sg-key-456')
+    expect(headers['Content-Type']).toBe('application/json')
+
+    const payload = JSON.parse(calls[0].init?.body as string)
+    expect(payload.from).toEqual({ email: 'alerts@example.com' })
+    expect(payload.personalizations).toEqual([
+      { to: [{ email: 'ops@example.com' }] },
+    ])
+    expect(payload.subject).toBe(BODY.subject)
+    expect(payload.content).toEqual([
+      { type: 'text/plain', value: BODY.text },
+      { type: 'text/html', value: BODY.html },
+    ])
+  })
+
+  test('returns false on a non-OK response without throwing', async () => {
+    process.env[ENV_KEY] = 'sendgrid://sg-key-456'
+    stubFetch(new Response('unauthorized', { status: 401 }))
+
+    const ok = await sendAlertEmail(config, BODY)
+
+    expect(ok).toBe(false)
+  })
+})
+
+describe('sendAlertEmail — smtp (deferred transport)', () => {
+  let savedEnv: string | undefined
+
+  beforeEach(() => {
+    savedEnv = process.env[ENV_KEY]
+  })
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY]
+    else process.env[ENV_KEY] = savedEnv
+    globalThis.fetch = originalFetch
+  })
+
+  test('fails gracefully (returns false, never fetches) — SMTP send is not implemented yet', async () => {
+    process.env[ENV_KEY] = 'smtp://user:pass@smtp.example.com:587'
+    const { calls } = stubFetch(new Response('ok', { status: 200 }))
+
+    const ok = await sendAlertEmail(
+      { provider: 'smtp', from: 'alerts@example.com', to: ['ops@example.com'] },
+      BODY
+    )
+
+    expect(ok).toBe(false)
+    expect(calls).toHaveLength(0)
+  })
+})
+
+describe('sendAlertEmail — unconfigured', () => {
+  let savedEnv: string | undefined
+
+  beforeEach(() => {
+    savedEnv = process.env[ENV_KEY]
+    delete process.env[ENV_KEY]
+  })
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY]
+    else process.env[ENV_KEY] = savedEnv
+    globalThis.fetch = originalFetch
+  })
+
+  test('returns false and never fetches when the provider url env var is unset', async () => {
+    const { calls } = stubFetch(new Response('ok', { status: 200 }))
+
+    const ok = await sendAlertEmail(
+      {
+        provider: 'mailgun',
+        from: 'alerts@example.com',
+        to: ['ops@example.com'],
+      },
+      BODY
+    )
+
+    expect(ok).toBe(false)
+    expect(calls).toHaveLength(0)
+  })
+})

--- a/apps/dashboard/src/lib/health/email-transport.ts
+++ b/apps/dashboard/src/lib/health/email-transport.ts
@@ -1,0 +1,209 @@
+/**
+ * Email dispatch (transport) layer — the ONLY place that knows the provider
+ * secret and actually sends over the network. `buildEmailBody` (the pure
+ * adapter) never touches this file's imports; this module is the caller that
+ * applies transport to a body already built by the adapter.
+ *
+ * Outbound requests go ONLY to the fixed, hardcoded provider API endpoint
+ * (Mailgun / SendGrid); recipients/from/provider come from server env
+ * (`getServerEmailConfig` / `HEALTH_ALERT_EMAIL_PROVIDER_URL`), never from a
+ * user-controlled URL — there is no SSRF surface here (contrast with
+ * `/api/v1/health/webhook`, which does proxy a caller-supplied URL).
+ *
+ * `sendAlertEmail` never throws — every failure is caught and logged so a
+ * misconfigured or unreachable provider cannot break the health sweep.
+ */
+
+import type { EmailBody, EmailConfig } from './adapters/email'
+
+import { debug, error } from '@chm/logger'
+
+const SEND_TIMEOUT_MS = 10_000
+
+function withTimeout(): { signal: AbortSignal; clear: () => void } {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), SEND_TIMEOUT_MS)
+  return { signal: controller.signal, clear: () => clearTimeout(timer) }
+}
+
+/** Extract `{ apiKey, domain }` from `mailgun://KEY@DOMAIN`. */
+function parseMailgunUrl(
+  url: string
+): { apiKey: string; domain: string } | null {
+  const match = /^mailgun:\/\/([^@]+)@(.+)$/i.exec(url.trim())
+  if (!match) return null
+  const apiKey = match[1]
+  const domain = match[2]
+  if (!apiKey || !domain) return null
+  return { apiKey, domain }
+}
+
+/** Extract `{ apiKey }` from `sendgrid://KEY`. */
+function parseSendGridUrl(url: string): { apiKey: string } | null {
+  const match = /^sendgrid:\/\/(.+)$/i.exec(url.trim())
+  const apiKey = match?.[1]
+  return apiKey ? { apiKey } : null
+}
+
+async function sendViaMailgun(
+  config: EmailConfig,
+  body: EmailBody,
+  providerUrl: string
+): Promise<boolean> {
+  const parsed = parseMailgunUrl(providerUrl)
+  if (!parsed) {
+    error(
+      '[health-email] HEALTH_ALERT_EMAIL_PROVIDER_URL is not a valid mailgun://KEY@DOMAIN url',
+      new Error('invalid mailgun provider url')
+    )
+    return false
+  }
+
+  const form = new URLSearchParams()
+  form.set('from', config.from)
+  for (const to of config.to) form.append('to', to)
+  form.set('subject', body.subject)
+  form.set('html', body.html)
+  form.set('text', body.text)
+
+  const { signal, clear } = withTimeout()
+  try {
+    const res = await fetch(
+      `https://api.mailgun.net/v3/${parsed.domain}/messages`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${btoa(`api:${parsed.apiKey}`)}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: form.toString(),
+        signal,
+      }
+    )
+    if (!res.ok) {
+      error(
+        '[health-email] Mailgun send returned non-OK status',
+        new Error(`Status ${res.status}`)
+      )
+    }
+    return res.ok
+  } catch (err) {
+    error('[health-email] Mailgun send failed', err)
+    return false
+  } finally {
+    clear()
+  }
+}
+
+async function sendViaSendGrid(
+  config: EmailConfig,
+  body: EmailBody,
+  providerUrl: string
+): Promise<boolean> {
+  const parsed = parseSendGridUrl(providerUrl)
+  if (!parsed) {
+    error(
+      '[health-email] HEALTH_ALERT_EMAIL_PROVIDER_URL is not a valid sendgrid://KEY url',
+      new Error('invalid sendgrid provider url')
+    )
+    return false
+  }
+
+  const payload = {
+    personalizations: [{ to: config.to.map((email) => ({ email })) }],
+    from: { email: config.from },
+    subject: body.subject,
+    content: [
+      { type: 'text/plain', value: body.text },
+      { type: 'text/html', value: body.html },
+    ],
+  }
+
+  const { signal, clear } = withTimeout()
+  try {
+    const res = await fetch('https://api.sendgrid.com/v3/mail/send', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${parsed.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal,
+    })
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      error(
+        '[health-email] SendGrid send returned non-OK status',
+        new Error(`Status ${res.status}`),
+        { text }
+      )
+    }
+    return res.ok
+  } catch (err) {
+    error('[health-email] SendGrid send failed', err)
+    return false
+  } finally {
+    clear()
+  }
+}
+
+/**
+ * SMTP transport is NOT implemented: this app runs primarily on Cloudflare
+ * Workers (`nodejs_compat` does not provide reliable raw TCP sockets there),
+ * there is no mail-sending dependency in the repo, and hand-rolling a
+ * SMTP/STARTTLS client would be unreliable on the primary deploy target.
+ * Config/detection for `smtp://` / `smtps://` is fully supported (see
+ * `detectEmailProvider`) so operators can select it, but sending fails
+ * gracefully with a clear log until a real SMTP transport lands.
+ */
+function sendViaSmtp(): Promise<boolean> {
+  error(
+    '[health-email] SMTP transport is not implemented yet — configure HEALTH_ALERT_EMAIL_PROVIDER_URL with mailgun:// or sendgrid:// to send real alert emails',
+    new Error('smtp transport not implemented')
+  )
+  return Promise.resolve(false)
+}
+
+/**
+ * Send a pre-built alert email via the provider selected by
+ * `config.provider` (from {@link getServerEmailConfig}). Reads the transport
+ * secret directly from `HEALTH_ALERT_EMAIL_PROVIDER_URL` — never threaded
+ * through the pure {@link EmailConfig} — and never throws: every failure path
+ * is caught and logged, returning `false` so a misconfigured or unreachable
+ * provider cannot break the health sweep.
+ */
+export async function sendAlertEmail(
+  config: EmailConfig,
+  body: EmailBody
+): Promise<boolean> {
+  try {
+    const providerUrl =
+      process.env.HEALTH_ALERT_EMAIL_PROVIDER_URL?.trim() || ''
+    if (!providerUrl) {
+      error(
+        '[health-email] sendAlertEmail called without HEALTH_ALERT_EMAIL_PROVIDER_URL',
+        new Error('missing provider url')
+      )
+      return false
+    }
+
+    debug('[health-email] Sending alert email', {
+      provider: config.provider,
+      to: config.to.length,
+    })
+
+    switch (config.provider) {
+      case 'mailgun':
+        return await sendViaMailgun(config, body, providerUrl)
+      case 'sendgrid':
+        return await sendViaSendGrid(config, body, providerUrl)
+      case 'smtp':
+        return await sendViaSmtp()
+      default:
+        return false
+    }
+  } catch (err) {
+    error('[health-email] sendAlertEmail failed unexpectedly', err)
+    return false
+  }
+}

--- a/apps/dashboard/src/lib/health/server-alert-config.test.ts
+++ b/apps/dashboard/src/lib/health/server-alert-config.test.ts
@@ -1,5 +1,6 @@
 import {
   getServerAlertConfig,
+  getServerEmailConfig,
   getServerOpsgenieConfig,
 } from './server-alert-config'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
@@ -8,6 +9,13 @@ const ENV_KEYS = [
   'HEALTH_ALERT_ENABLED',
   'HEALTH_ALERT_WEBHOOK_URL',
   'HEALTH_ALERT_MIN_SEVERITY',
+] as const
+
+const EMAIL_ENV_KEYS = [
+  'HEALTH_ALERT_EMAIL_ENABLED',
+  'HEALTH_ALERT_EMAIL_TO',
+  'HEALTH_ALERT_EMAIL_FROM',
+  'HEALTH_ALERT_EMAIL_PROVIDER_URL',
 ] as const
 
 describe('getServerAlertConfig', () => {
@@ -200,5 +208,152 @@ describe('getServerOpsgenieConfig', () => {
     process.env.HEALTH_ALERT_OPSGENIE_API_KEY = 'my-key'
     process.env.HEALTH_ALERT_OPSGENIE_REGION = 'apac'
     expect(getServerOpsgenieConfig()?.region).toBe('us')
+  })
+})
+
+describe('getServerEmailConfig', () => {
+  let saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const key of EMAIL_ENV_KEYS) {
+      saved[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    for (const key of EMAIL_ENV_KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = saved[key]
+      }
+    }
+    saved = {}
+  })
+
+  it('returns null when no env vars are set (fail-open)', () => {
+    expect(getServerEmailConfig()).toBeNull()
+  })
+
+  it('returns null when HEALTH_ALERT_EMAIL_ENABLED is not exactly "true"', () => {
+    process.env.HEALTH_ALERT_EMAIL_ENABLED = '1'
+    process.env.HEALTH_ALERT_EMAIL_TO = 'ops@example.com'
+    process.env.HEALTH_ALERT_EMAIL_FROM = 'alerts@example.com'
+    process.env.HEALTH_ALERT_EMAIL_PROVIDER_URL = 'mailgun://key@example.com'
+
+    expect(getServerEmailConfig()).toBeNull()
+  })
+
+  it('returns null when enabled but the provider URL is missing', () => {
+    process.env.HEALTH_ALERT_EMAIL_ENABLED = 'true'
+    process.env.HEALTH_ALERT_EMAIL_TO = 'ops@example.com'
+    process.env.HEALTH_ALERT_EMAIL_FROM = 'alerts@example.com'
+
+    expect(getServerEmailConfig()).toBeNull()
+  })
+
+  it('returns null when the provider URL scheme is unrecognized', () => {
+    process.env.HEALTH_ALERT_EMAIL_ENABLED = 'true'
+    process.env.HEALTH_ALERT_EMAIL_TO = 'ops@example.com'
+    process.env.HEALTH_ALERT_EMAIL_FROM = 'alerts@example.com'
+    process.env.HEALTH_ALERT_EMAIL_PROVIDER_URL = 'https://example.com/hook'
+
+    expect(getServerEmailConfig()).toBeNull()
+  })
+
+  it('returns null when enabled but "from" is missing', () => {
+    process.env.HEALTH_ALERT_EMAIL_ENABLED = 'true'
+    process.env.HEALTH_ALERT_EMAIL_TO = 'ops@example.com'
+    process.env.HEALTH_ALERT_EMAIL_PROVIDER_URL = 'sendgrid://key'
+
+    expect(getServerEmailConfig()).toBeNull()
+  })
+
+  it('returns null when enabled but there are no recipients', () => {
+    process.env.HEALTH_ALERT_EMAIL_ENABLED = 'true'
+    process.env.HEALTH_ALERT_EMAIL_FROM = 'alerts@example.com'
+    process.env.HEALTH_ALERT_EMAIL_PROVIDER_URL = 'sendgrid://key'
+
+    expect(getServerEmailConfig()).toBeNull()
+  })
+
+  it('returns null when recipients are only whitespace/commas', () => {
+    process.env.HEALTH_ALERT_EMAIL_ENABLED = 'true'
+    process.env.HEALTH_ALERT_EMAIL_TO = ' , , '
+    process.env.HEALTH_ALERT_EMAIL_FROM = 'alerts@example.com'
+    process.env.HEALTH_ALERT_EMAIL_PROVIDER_URL = 'sendgrid://key'
+
+    expect(getServerEmailConfig()).toBeNull()
+  })
+
+  it('parses a fully configured mailgun setup', () => {
+    process.env.HEALTH_ALERT_EMAIL_ENABLED = 'true'
+    process.env.HEALTH_ALERT_EMAIL_TO = 'ops@example.com, oncall@example.com'
+    process.env.HEALTH_ALERT_EMAIL_FROM = 'alerts@example.com'
+    process.env.HEALTH_ALERT_EMAIL_PROVIDER_URL = 'mailgun://key@mg.example.com'
+
+    expect(getServerEmailConfig()).toEqual({
+      provider: 'mailgun',
+      from: 'alerts@example.com',
+      to: ['ops@example.com', 'oncall@example.com'],
+    })
+  })
+
+  it('parses a fully configured sendgrid setup', () => {
+    process.env.HEALTH_ALERT_EMAIL_ENABLED = 'true'
+    process.env.HEALTH_ALERT_EMAIL_TO = 'ops@example.com'
+    process.env.HEALTH_ALERT_EMAIL_FROM = 'alerts@example.com'
+    process.env.HEALTH_ALERT_EMAIL_PROVIDER_URL = 'sendgrid://key'
+
+    expect(getServerEmailConfig()).toEqual({
+      provider: 'sendgrid',
+      from: 'alerts@example.com',
+      to: ['ops@example.com'],
+    })
+  })
+
+  it('parses a fully configured smtp(s) setup', () => {
+    process.env.HEALTH_ALERT_EMAIL_ENABLED = 'true'
+    process.env.HEALTH_ALERT_EMAIL_TO = 'ops@example.com'
+    process.env.HEALTH_ALERT_EMAIL_FROM = 'alerts@example.com'
+    process.env.HEALTH_ALERT_EMAIL_PROVIDER_URL =
+      'smtps://user:pass@smtp.example.com:465'
+
+    expect(getServerEmailConfig()).toEqual({
+      provider: 'smtp',
+      from: 'alerts@example.com',
+      to: ['ops@example.com'],
+    })
+  })
+
+  it('trims whitespace around recipients and from address', () => {
+    process.env.HEALTH_ALERT_EMAIL_ENABLED = 'true'
+    process.env.HEALTH_ALERT_EMAIL_TO =
+      '  ops@example.com  ,  oncall@example.com  '
+    process.env.HEALTH_ALERT_EMAIL_FROM = '  alerts@example.com  '
+    process.env.HEALTH_ALERT_EMAIL_PROVIDER_URL = 'sendgrid://key'
+
+    expect(getServerEmailConfig()).toEqual({
+      provider: 'sendgrid',
+      from: 'alerts@example.com',
+      to: ['ops@example.com', 'oncall@example.com'],
+    })
+  })
+
+  it('does not change getServerAlertConfig behaviour when email env vars are set', () => {
+    process.env.HEALTH_ALERT_EMAIL_ENABLED = 'true'
+    process.env.HEALTH_ALERT_EMAIL_TO = 'ops@example.com'
+    process.env.HEALTH_ALERT_EMAIL_FROM = 'alerts@example.com'
+    process.env.HEALTH_ALERT_EMAIL_PROVIDER_URL = 'sendgrid://key'
+
+    const config = getServerAlertConfig()
+
+    expect(config).toEqual({
+      webhookEnabled: false,
+      webhookUrl: '',
+      minSeverity: 'warning',
+      browserNotificationsEnabled: false,
+    })
   })
 })

--- a/apps/dashboard/src/lib/health/server-alert-config.ts
+++ b/apps/dashboard/src/lib/health/server-alert-config.ts
@@ -1,6 +1,8 @@
 import type { AlertRuleThresholds } from '@/lib/alerting/rule-registry'
+import type { EmailConfig } from './adapters/email'
 import type { AlertSettings } from './alert-settings-storage'
 
+import { detectEmailProvider } from './adapters/email'
 import { DEFAULT_ALERT_SETTINGS } from './alert-settings-storage'
 
 /**
@@ -44,6 +46,49 @@ export function getServerAlertConfig(): AlertSettings {
     browserNotificationsEnabled: false,
     minSeverity,
   }
+}
+
+/**
+ * Server-side email alert configuration, sourced from environment variables:
+ *
+ *   - HEALTH_ALERT_EMAIL_ENABLED       → boolean (default false)
+ *   - HEALTH_ALERT_EMAIL_TO            → comma-separated recipients (default '')
+ *   - HEALTH_ALERT_EMAIL_FROM          → from address (default '')
+ *   - HEALTH_ALERT_EMAIL_PROVIDER_URL  → mailgun://KEY@DOMAIN | sendgrid://KEY |
+ *                                        smtp://user:pass@host:port | smtps://...
+ *
+ * Returns `null` when disabled or unconfigured — missing/invalid provider URL,
+ * no `from` address, or no recipients — so an unconfigured deployment fails
+ * OPEN: the sweep behaves exactly as it did before email support existed.
+ *
+ * The provider transport secret (API key / SMTP credentials) is intentionally
+ * NOT part of the returned {@link EmailConfig} — it stays in
+ * `HEALTH_ALERT_EMAIL_PROVIDER_URL` and is resolved by the dispatch layer that
+ * actually sends the email, mirroring how `buildEmailBody` stays pure.
+ *
+ * NOTE: exposed as a companion function rather than folded into
+ * {@link getServerAlertConfig}'s return value so that function keeps its exact
+ * {@link AlertSettings} shape (its unit tests assert the object deeply) —
+ * exactly as {@link getServerThresholdOverrides} is a companion today.
+ */
+export function getServerEmailConfig(): EmailConfig | null {
+  const enabled = process.env.HEALTH_ALERT_EMAIL_ENABLED === 'true'
+  if (!enabled) return null
+
+  const providerUrl = process.env.HEALTH_ALERT_EMAIL_PROVIDER_URL?.trim() || ''
+  const provider = providerUrl ? detectEmailProvider(providerUrl) : null
+  if (!provider) return null
+
+  const from = process.env.HEALTH_ALERT_EMAIL_FROM?.trim() || ''
+  if (!from) return null
+
+  const to = (process.env.HEALTH_ALERT_EMAIL_TO ?? '')
+    .split(',')
+    .map((addr) => addr.trim())
+    .filter((addr) => addr.length > 0)
+  if (to.length === 0) return null
+
+  return { provider, from, to }
 }
 
 /** Per-rule threshold override (either bound may be omitted). */

--- a/apps/dashboard/src/lib/health/server-sweep.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.ts
@@ -13,7 +13,7 @@ import type { AlertEventRecord } from './alert-history-store'
 import type { AlertRoute } from './alert-routing'
 import type { AlertDecision } from './alert-state-store'
 
-import { buildPagerDutyBody, detectAdapter } from './adapters'
+import { buildEmailBody, buildPagerDutyBody, detectAdapter } from './adapters'
 import { clearAck, isAcked, listActiveAcks } from './alert-ack-store'
 import { recordAlertEvent } from './alert-history-store'
 import {
@@ -23,6 +23,7 @@ import {
 } from './alert-routing'
 import { alertStateStore, evaluateAlert } from './alert-state-store'
 import { loadCustomRulesIntoRegistry } from './custom-rules-store'
+import { sendAlertEmail } from './email-transport'
 import { isSuppressed, listWindows } from './maintenance-windows'
 import { dispatchOpsgenie } from './opsgenie-dispatch'
 import {
@@ -32,6 +33,7 @@ import {
 import {
   getServerAlertConfig,
   getServerAlertCooldownMs,
+  getServerEmailConfig,
   getServerOpsgenieConfig,
   getServerThresholdOverrides,
 } from './server-alert-config'
@@ -84,6 +86,8 @@ export interface SweepSummary {
   ranAt: string
   enabled: boolean
   webhookConfigured: boolean
+  /** Whether `HEALTH_ALERT_EMAIL_*` env vars resolve to a usable email config. */
+  emailConfigured: boolean
   minSeverity: 'warning' | 'critical'
   hostsChecked: number
   totalChecks: number
@@ -97,6 +101,8 @@ export interface SweepSummary {
   ackedSuppressed: number
   /** Recovery notifications sent for conditions that returned to ok. */
   recoveries: number
+  /** Emails successfully sent (only counted when email is configured). */
+  emailsDispatched: number
   /** Total AI insights generated and persisted across all hosts. */
   insightsGenerated: number
   hosts: SweepHostSummary[]
@@ -338,9 +344,12 @@ const SWEEP_ROUTING_OWNER_ID = ''
  * matches — so deployments that never configure a route behave exactly as
  * before. Routes are best-effort (D1-backed; degrade to `[]` when D1 isn't
  * configured), so a routing-table hiccup never blocks the legacy fallback.
+ * Opsgenie/PagerDuty/email are each an independent env-configured channel
+ * (like Opsgenie/PagerDuty above) — none of them requires the webhook to also
+ * be configured; every channel is attempted and audited on its own.
  *
- * Disabled (or no webhook URL and no routes) → rules still run, alerts are
- * skipped.
+ * Disabled (or no webhook URL and no routes and no Opsgenie/PagerDuty/email) →
+ * rules still run, alerts are skipped.
  */
 export async function runHealthSweep(): Promise<SweepSummary> {
   const ranAt = new Date().toISOString()
@@ -349,12 +358,14 @@ export async function runHealthSweep(): Promise<SweepSummary> {
   const routes: AlertRoute[] = await listRoutes(SWEEP_ROUTING_OWNER_ID)
   const pagerDutyFallbackKey = getPagerDutyFallbackRoutingKey()
   const opsgenieConfig = getServerOpsgenieConfig()
+  const emailConfig = getServerEmailConfig()
   const canDispatch =
     settings.webhookEnabled &&
     (webhookConfigured ||
       routes.length > 0 ||
       Boolean(pagerDutyFallbackKey) ||
-      Boolean(opsgenieConfig))
+      Boolean(opsgenieConfig) ||
+      Boolean(emailConfig))
   const minRank = SEVERITY_ORDER[settings.minSeverity]
   const cooldownMs = getServerAlertCooldownMs()
 
@@ -399,6 +410,7 @@ export async function runHealthSweep(): Promise<SweepSummary> {
   let maintenanceSuppressed = 0
   let ackedSuppressed = 0
   let recoveries = 0
+  let emailsDispatched = 0
 
   // Active operator ACKs (plan 29), loaded once for the whole sweep.
   // `listActiveAcks` never throws — a missing/misconfigured D1 binding
@@ -700,12 +712,66 @@ export async function runHealthSweep(): Promise<SweepSummary> {
         }
       }
 
+      // Email (plan 25): a single global env-configured destination, same
+      // shape as Opsgenie above — no per-route resolution yet. Fires whenever
+      // `emailConfig` is set, independent of every other channel.
+      // `sendAlertEmail` never throws (fails open): Mailgun/SendGrid send for
+      // real over authenticated HTTPS; the `smtp` provider is not implemented
+      // yet (Cloudflare Workers has no raw TCP) and always resolves `false`
+      // with its own log line — never a silent fake "sent".
+      if (emailConfig) {
+        const alertSeverity: AlertSeverity =
+          decision.kind === 'recovery'
+            ? 'recovery'
+            : (effective as 'warning' | 'critical')
+        const emailBody = buildEmailBody({
+          severity: alertSeverity,
+          hostLabel: name,
+          hostId,
+          metric: ruleId,
+          value,
+          warnThreshold,
+          critThreshold,
+          title: ruleTitle,
+          label,
+          timestamp: new Date().toISOString(),
+        })
+        const ok = await sendAlertEmail(emailConfig, emailBody)
+        if (ok) {
+          anyDelivered = true
+          emailsDispatched++
+        }
+
+        try {
+          await recordAlertEvent(
+            buildAlertEventRecord({
+              hostId,
+              hostLabel: name,
+              ruleId,
+              decision,
+              value,
+              delivered: ok,
+              error: ok ? undefined : 'Email dispatch failed',
+              channel: 'email',
+            })
+          )
+        } catch (err) {
+          debug(
+            `[health-sweep] alert-history record failed for host ${hostId} rule ${ruleId}`,
+            err instanceof Error ? err.message : String(err)
+          )
+        }
+      }
+
       // Persist "notified" only when there was nothing to deliver (no
       // targets at all across every channel — not a failure) or at least one
       // channel succeeded. A failed delivery with no successes leaves no
       // record, so the next sweep retries instead of suppressing.
       if (
-        targets.length + pagerDutyTargets.length + (opsgenieConfig ? 1 : 0) ===
+        targets.length +
+          pagerDutyTargets.length +
+          (opsgenieConfig ? 1 : 0) +
+          (emailConfig ? 1 : 0) ===
           0 ||
         anyDelivered
       ) {
@@ -884,6 +950,7 @@ export async function runHealthSweep(): Promise<SweepSummary> {
     ranAt,
     enabled: settings.webhookEnabled,
     webhookConfigured,
+    emailConfigured: emailConfig !== null,
     minSeverity: settings.minSeverity,
     hostsChecked: configs.length,
     totalChecks: hosts.reduce((sum, h) => sum + h.checksRun, 0),
@@ -893,6 +960,7 @@ export async function runHealthSweep(): Promise<SweepSummary> {
     maintenanceSuppressed,
     ackedSuppressed,
     recoveries,
+    emailsDispatched,
     insightsGenerated,
     hosts,
     findings,

--- a/apps/dashboard/src/routes/api/v1/health/email-test.test.ts
+++ b/apps/dashboard/src/routes/api/v1/health/email-test.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// Same auth-gate mocking approach as webhook.test.ts: this route self-gates
+// writes via authorizeFeatureRequest (feature 'settings', operation 'write'),
+// so anonymous callers cannot trigger the outbound send. Mocked here so the
+// dispatch tests below exercise config/send logic without exercising real
+// auth; the gate itself is covered by the "auth gate" describe block.
+let authorizeFeatureRequest = mock(
+  async (
+    _permission: unknown,
+    _request: Request,
+    _options?: { allowAgentBearerToken?: boolean }
+  ): Promise<Response | null> => null
+)
+mock.module('@/lib/feature-permissions/server', () => ({
+  getAppConfig: () => ({ authProvider: 'none' as const, features: {} }),
+  _resetAppConfigCache: () => {},
+  publicReadEnabled: () => true,
+  authorizeFeatureRequest: (
+    permission: unknown,
+    request: Request,
+    options?: { allowAgentBearerToken?: boolean }
+  ) => authorizeFeatureRequest(permission, request, options),
+}))
+
+// getServerEmailConfig reads env directly; stub it so tests control the
+// "configured" state without mutating process.env (mirrors how the route's
+// only external dependencies — config + transport — are isolated below).
+let emailConfig: {
+  provider: 'mailgun' | 'sendgrid' | 'smtp'
+  from: string
+  to: readonly string[]
+} | null = null
+mock.module('@/lib/health/server-alert-config', () => ({
+  getServerEmailConfig: () => emailConfig,
+}))
+
+// sendAlertEmail performs the real outbound fetch (Mailgun/SendGrid); stub it
+// so no test hits the network. Records the config/body it was called with.
+let sendResult = true
+const sendCalls: unknown[] = []
+mock.module('@/lib/health/email-transport', () => ({
+  sendAlertEmail: async (config: unknown, body: unknown) => {
+    sendCalls.push({ config, body })
+    return sendResult
+  },
+}))
+
+const { __handlePostForTests: handlePost } = await import('./email-test')
+
+beforeEach(() => {
+  // Default to authorized + configured + successful send so each describe
+  // block only needs to override what it's testing.
+  authorizeFeatureRequest = mock(async () => null)
+  emailConfig = {
+    provider: 'sendgrid',
+    from: 'alerts@example.com',
+    to: ['ops@example.com'],
+  }
+  sendResult = true
+  sendCalls.length = 0
+})
+
+function makeRequest(): Request {
+  return new Request('https://dash.example.com/api/v1/health/email-test', {
+    method: 'POST',
+  })
+}
+
+describe('health email test-send — auth gate', () => {
+  test('anonymous is blocked, no send attempted', async () => {
+    authorizeFeatureRequest = mock(
+      async () => new Response(null, { status: 401 })
+    )
+    const res = await handlePost(makeRequest())
+
+    expect(res.status).toBe(401)
+    expect(sendCalls).toHaveLength(0)
+  })
+
+  test('authorized passes through to the send attempt', async () => {
+    const res = await handlePost(makeRequest())
+
+    expect(res.status).toBe(200)
+    expect(sendCalls).toHaveLength(1)
+  })
+})
+
+describe('health email test-send — fail-open when unconfigured', () => {
+  test('returns 400 and never attempts a send when email is not configured', async () => {
+    emailConfig = null
+    const res = await handlePost(makeRequest())
+
+    expect(res.status).toBe(400)
+    expect(sendCalls).toHaveLength(0)
+    const body = (await res.json()) as { error?: { message?: string } }
+    expect(body.error?.message).toContain('not configured')
+  })
+})
+
+describe('health email test-send — dispatch result', () => {
+  test('returns success when sendAlertEmail resolves true', async () => {
+    sendResult = true
+    const res = await handlePost(makeRequest())
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { success?: boolean }
+    expect(body.success).toBe(true)
+  })
+
+  test('returns a 502 error when sendAlertEmail resolves false (fails gracefully)', async () => {
+    sendResult = false
+    const res = await handlePost(makeRequest())
+
+    expect(res.status).toBe(502)
+    const body = (await res.json()) as { error?: { message?: string } }
+    expect(body.error?.message).toBeDefined()
+  })
+
+  test('sends the built email body to the configured recipients', async () => {
+    await handlePost(makeRequest())
+
+    expect(sendCalls).toHaveLength(1)
+    const call = sendCalls[0] as {
+      config: unknown
+      body: { subject: string; html: string; text: string }
+    }
+    expect(call.config).toEqual(emailConfig)
+    expect(call.body.subject).toContain('test-alert')
+    expect(call.body.subject).toContain('Test host')
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/health/email-test.ts
+++ b/apps/dashboard/src/routes/api/v1/health/email-test.ts
@@ -1,0 +1,104 @@
+/**
+ * Health Email Test-Send Endpoint
+ * POST /api/v1/health/email-test
+ *
+ * Sends a test alert email using the server-configured email settings
+ * (`HEALTH_ALERT_EMAIL_*`, read via `getServerEmailConfig`). Unlike
+ * `/api/v1/health/webhook`, this route has NO SSRF surface: it never fetches a
+ * caller-supplied URL — the request body carries no destination at all, only
+ * the operator's already-configured provider/recipients are used. This mirrors
+ * the "send test webhook" affordance in the health settings dialog.
+ *
+ * Auth: same write-gate as the webhook proxy — the global /api/v1 middleware
+ * is a public passthrough under provider='none' / CHM_CLERK_PUBLIC_READ, so
+ * this route self-enforces that anonymous callers cannot trigger the outbound
+ * send. A valid `chm_` API key still authenticates programmatic clients.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { error } from '@chm/logger'
+import { createErrorResponse } from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
+import { buildEmailBody } from '@/lib/health/adapters'
+import { sendAlertEmail } from '@/lib/health/email-transport'
+import { getServerEmailConfig } from '@/lib/health/server-alert-config'
+
+const ROUTE_CONTEXT = {
+  route: '/api/v1/health/email-test',
+  method: 'POST',
+} as const
+
+async function handlePost(request: Request): Promise<Response> {
+  // Write gate: this POST triggers a real outbound send. Mirrors the webhook
+  // proxy's guard (see webhook.ts) — anonymous callers cannot trigger it, a
+  // valid `chm_` API key can.
+  const permissionResponse = await authorizeFeatureRequest(
+    { feature: 'settings', defaultAccess: 'authenticated', operation: 'write' },
+    request,
+    { allowAgentBearerToken: true }
+  )
+  if (permissionResponse) return permissionResponse
+
+  const emailConfig = getServerEmailConfig()
+  if (!emailConfig) {
+    return createErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message:
+          'Email alerts are not configured. Set HEALTH_ALERT_EMAIL_ENABLED, HEALTH_ALERT_EMAIL_TO, HEALTH_ALERT_EMAIL_FROM, and HEALTH_ALERT_EMAIL_PROVIDER_URL.',
+      },
+      400,
+      ROUTE_CONTEXT
+    )
+  }
+
+  const body = buildEmailBody({
+    severity: 'warning',
+    hostLabel: 'Test host',
+    hostId: 0,
+    metric: 'test-alert',
+    value: 0,
+    title: 'Test Alert',
+    label: 'This is a test alert from chmonitor',
+    timestamp: new Date().toISOString(),
+  })
+
+  try {
+    const ok = await sendAlertEmail(emailConfig, body)
+    if (!ok) {
+      return createErrorResponse(
+        {
+          type: ApiErrorType.NetworkError,
+          message:
+            'Failed to send test email. Check server logs and HEALTH_ALERT_EMAIL_PROVIDER_URL.',
+        },
+        502,
+        ROUTE_CONTEXT
+      )
+    }
+    return Response.json({ success: true }, { status: 200 })
+  } catch (err) {
+    error('[POST /api/v1/health/email-test] Unexpected failure', err)
+    return createErrorResponse(
+      {
+        type: ApiErrorType.NetworkError,
+        message: 'Failed to send test email due to an unexpected error.',
+      },
+      502,
+      ROUTE_CONTEXT
+    )
+  }
+}
+
+export const Route = createFileRoute('/api/v1/health/email-test')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})
+
+// Exported for unit tests only.
+export { handlePost as __handlePostForTests }

--- a/plans/25-email-alert-adapter.md
+++ b/plans/25-email-alert-adapter.md
@@ -1,0 +1,48 @@
+# 25 — Email alert adapter (Mailgun / SendGrid / SMTP)
+
+## Current reality (audited)
+- Email is the universal alert channel; adapters cover Slack/Discord/Telegram/PagerDuty/generic but NOT email.
+- Adapter layer: `apps/dashboard/src/lib/health/adapters/` — `types.ts` defines the PURE `NotificationAdapter` (`id`, `detect?(url)`, `buildBody(payload)`) and `AlertPayload`; `index.ts` holds `ADAPTERS`, `ALL_ADAPTERS`, `detectAdapter(url)`. Existing adapters (`slack.ts`, `discord.ts`, `telegram.ts`, `pagerduty.ts`, `generic-json.ts`) are pure formatters; transport is applied by `alert-dispatcher.ts`.
+- Server env config: `apps/dashboard/src/lib/health/server-alert-config.ts` reads `process.env.HEALTH_ALERT_*` (trimmed; finite-number helpers) → `AlertSettings`. Follow this exact style.
+- Settings UI: `apps/dashboard/src/components/health/health-settings-dialog.tsx` (verify filename).
+
+## Goal
+An email adapter renders a clean HTML alert (host, check, value, thresholds, runbook link), detects a provider from a config URL/env (`mailgun://`, `sendgrid://`, SMTP), the server reads recipients + from-address from env, and operators can send a test email from health settings — same PURE-builder + registry parity as existing adapters.
+
+## Implement now
+**A. Adapter — new `apps/dashboard/src/lib/health/adapters/email.ts`** (mirror `pagerduty.ts`):
+```ts
+export type EmailProvider = 'mailgun' | 'sendgrid' | 'smtp'
+export interface EmailConfig { provider: EmailProvider; from: string; to: readonly string[] }
+export interface EmailBody { subject: string; html: string; text: string }
+export function buildEmailBody(payload: AlertPayload): EmailBody
+export function detectEmailProvider(url: string): EmailProvider | null
+export const emailAdapter: NotificationAdapter // id:'email', buildBody → buildEmailBody
+```
+- `subject`: `[SEVERITY] {metric} on {hostLabel}` (uppercase severity; `recovery` → `[RESOLVED]`).
+- `html`: table with host label/id, check title + metric, observed value, warn/crit thresholds, timestamp, runbook links (`payload.runbookUrls`) as `<a>`. HTML-encode all interpolated values. Inline styles only; small + client-safe.
+- `text`: plaintext mirror.
+- `emailAdapter.detect` matches provider config URLs (mailgun/sendgrid/smtp/smtps) and returns false for http(s) so it never hijacks webhook routing.
+
+**B. Register — `adapters/index.ts`**: export `buildEmailBody`, `emailAdapter`, and the `EmailProvider`/`EmailConfig`/`EmailBody` types. Add `emailAdapter` to `ADAPTERS` (or keep out of URL-detection list and dispatch explicitly if email is env-selected — decide with the dispatch layer). Update the adapter snapshot test.
+
+**C. Server config — `server-alert-config.ts`** (match `process.env.HEALTH_ALERT_*` + `.trim()` style): add `HEALTH_ALERT_EMAIL_ENABLED` (bool, default false), `HEALTH_ALERT_EMAIL_TO` (comma-sep, ''), `HEALTH_ALERT_EMAIL_FROM` ('') , `HEALTH_ALERT_EMAIL_PROVIDER_URL` (mailgun://KEY@DOMAIN | sendgrid://KEY | smtp://user:pass@host:port). Add `getServerEmailConfig(): EmailConfig | null` (null when disabled/unconfigured → fail-open). Keep `getServerAlertConfig`'s `AlertSettings` shape untouched (add email as a companion fn, like `getServerThresholdOverrides`).
+
+**D. Dispatch — `alert-dispatcher.ts`** (verify): when email enabled, send the built body via the detected provider's HTTP API (Mailgun/SendGrid REST) or SMTP. Provider secret resolution stays in dispatch, not the pure adapter. Handle send failure gracefully (log; do not throw into the sweep).
+
+**E. Settings UI — `health-settings-dialog.tsx`** (verify filename): add recipient/from fields + a "Send test email" button posting to the test-send path, surfacing success/failure (mirror existing webhook test).
+
+## STOP conditions & drift check
+- STOP if pure `buildEmailBody` starts doing network/transport (belongs in dispatch).
+- STOP if adding `emailAdapter` to `ADAPTERS` changes `detectAdapter` routing for existing http(s) webhook URLs — email `detect` must not match webhook URLs.
+- Drift: if the adapter registry / `NotificationAdapter` shape changed, match the current contract; if `health-settings-dialog.tsx` moved/renamed, find the real settings surface.
+- No Postgres; don't touch AI/DDL behaviour.
+
+## Done criteria
+- `buildEmailBody(payload)` returns `{subject, html, text}` with escaped values, thresholds, runbook links (unit test + snapshot).
+- `detectEmailProvider` maps mailgun/sendgrid/smtp(s) correctly; unknown → null.
+- `emailAdapter` satisfies `NotificationAdapter` and passes the adapter-parity test.
+- `getServerEmailConfig` reads `HEALTH_ALERT_EMAIL_*`, null when unconfigured (fail-open); `AlertSettings` unchanged.
+- Dispatch sends via detected provider, fails gracefully.
+- Health settings has recipient config + working "Send test email".
+- No Postgres; type-check, targeted tests, lint green.


### PR DESCRIPTION
## Summary
Implements **plan 25** (Round-3 Wave A). Adds a pure email `NotificationAdapter` (`buildEmailBody` → `{subject, html, text}`, HTML-escaped), provider detection (`mailgun://`/`sendgrid://`/`smtp://`), env config (`HEALTH_ALERT_EMAIL_*`, fail-open when unconfigured), a "Send test email" affordance in health settings, and dispatch wired additively into the real cron sweep (`server-sweep.ts`).

## Verification (worker)
type-check ✅ · `tsc -p tsconfig.test.json` ✅ · `src/lib/health` + `routes/api/v1/health` 205 pass ✅ · lint ✅. `buildEmailBody` is pure (no network); `emailAdapter` kept out of `ADAPTERS` so `detectAdapter` webhook routing is provably unchanged (regression test); fail-open confirmed.

## ⚠️ HELD FOR HUMAN REVIEW — two material limitations (documented, not silent)
1. **SMTP transport is a no-op stub.** Config/detection works, but sending returns `false` with a log — Cloudflare Workers `nodejs_compat` has no reliable raw TCP and there's no mail dep in the repo. **Mailgun and SendGrid send for real** (authenticated HTTPS `fetch`, verified). Decide whether shipping without SMTP is acceptable or whether SMTP should block.
2. **Cron-sweep email requires a webhook to also be configured.** Email dispatch reuses the existing per-rule/host `evaluateAlert`/`commit()` dedup gate, which is triggered by webhook dispatch. So an operator who enables email but configures **no webhook** gets emails only from the "Send test" button, not the automatic sweep. True standalone multi-channel fan-out is plan 30 (per-rule routing). Confirm this partial delivery is acceptable, or sequence plan 30 first — and ensure landing/pricing copy doesn't advertise standalone email until then (advertised ⟺ enforced).

No auth/billing surface; additive + fail-open (webhook alerts unchanged).

Co-Authored-By: duyetbot <bot@duyet.net>