### PR TITLE
feat(analytics): privacy-respecting PostHog funnel instrumentation, off by default (plan 62)

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -150,6 +150,16 @@ OPENROUTER_APP_NAME=chmonitor
 # SENTRY_ORG=
 # SENTRY_PROJECT=
 
+# ── Product analytics (PostHog) — opt-in, OFF by default ────────────────────
+# DISTINCT from VITE_TELEMETRY_ENABLED above (anonymous, on-by-default OSS
+# instance telemetry). This is SaaS funnel/conversion tracking (signup, cluster
+# connect, upgrade, checkout) and stays OFF — a hard no-op — until you set a
+# key. Nothing is sent anywhere by default. See docs/operate/advanced/
+# product-analytics.mdx and apps/dashboard/src/lib/analytics/.
+# CHM_ANALYTICS_KEY=phc_<your-posthog-project-key>
+# Self-hostable: point at your own PostHog instance. Empty = PostHog Cloud (US).
+# CHM_ANALYTICS_HOST=https://us.i.posthog.com
+
 # ── Prometheus metrics exporter — GET /api/v1/metrics ───────────────────────
 # Default follows deployment: ON self-hosted, OFF in cloud mode. Set explicitly
 # to override either default (e.g. to opt a cloud deploy in, or turn it off

--- a/apps/dashboard/bun.lock
+++ b/apps/dashboard/bun.lock
@@ -80,6 +80,7 @@
         "motion": "^12.40.0",
         "next-themes": "^0.4.6",
         "postgres": "^3.4.9",
+        "posthog-js": "^1.396.5",
         "radix-ui": "^1.4.3",
         "react": "^19",
         "react-dom": "^19",
@@ -683,6 +684,10 @@
     "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
+    "@posthog/core": ["@posthog/core@1.39.6", "", { "dependencies": { "@posthog/types": "^1.392.0" } }, "sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw=="],
+
+    "@posthog/types": ["@posthog/types@1.392.0", "", {}, "sha512-nctNujXL3FC1v99FktaTMSugSD9ZOZekEpahUSafkU2TSvW+XGKNkQZbokuJtiWvPBK208dwMJva8UfBkChqpw=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -1344,6 +1349,8 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
+    "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
+
     "core-util-is": ["core-util-is@1.0.2", "", {}, "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
@@ -1561,6 +1568,8 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetchdts": ["fetchdts@0.1.7", "", {}, "sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA=="],
+
+    "fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
@@ -2030,6 +2039,10 @@
 
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
 
+    "posthog-js": ["posthog-js@1.396.5", "", { "dependencies": { "@posthog/core": "^1.39.5", "@posthog/types": "^1.392.0", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.29.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.3.0" } }, "sha512-huW/8R151I08i/tkOaAv3Q/yWVqzhqPj3SxyhpgNLB/xysaNeV1ibp6DHzbRWV5D7FRM48Zg6Icxsm4q0irEtg=="],
+
+    "preact": ["preact@10.29.3", "", {}, "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw=="],
+
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
     "pretty-bytes": ["pretty-bytes@5.6.0", "", {}, "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="],
@@ -2047,6 +2060,8 @@
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
+    "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "radix-ui": ["radix-ui@1.4.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-accessible-icon": "1.1.7", "@radix-ui/react-accordion": "1.2.12", "@radix-ui/react-alert-dialog": "1.1.15", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-aspect-ratio": "1.1.7", "@radix-ui/react-avatar": "1.1.10", "@radix-ui/react-checkbox": "1.3.3", "@radix-ui/react-collapsible": "1.1.12", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-context-menu": "2.2.16", "@radix-ui/react-dialog": "1.1.15", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-dropdown-menu": "2.1.16", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-form": "0.1.8", "@radix-ui/react-hover-card": "1.1.15", "@radix-ui/react-label": "2.1.7", "@radix-ui/react-menu": "2.1.16", "@radix-ui/react-menubar": "1.1.16", "@radix-ui/react-navigation-menu": "1.2.14", "@radix-ui/react-one-time-password-field": "0.1.8", "@radix-ui/react-password-toggle-field": "0.1.3", "@radix-ui/react-popover": "1.1.15", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-progress": "1.1.7", "@radix-ui/react-radio-group": "1.3.8", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-scroll-area": "1.2.10", "@radix-ui/react-select": "2.2.6", "@radix-ui/react-separator": "1.1.7", "@radix-ui/react-slider": "1.3.6", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-switch": "1.2.6", "@radix-ui/react-tabs": "1.1.13", "@radix-ui/react-toast": "1.2.15", "@radix-ui/react-toggle": "1.1.10", "@radix-ui/react-toggle-group": "1.1.11", "@radix-ui/react-toolbar": "1.1.11", "@radix-ui/react-tooltip": "1.2.8", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-escape-keydown": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA=="],
 
@@ -2349,6 +2364,8 @@
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
+
+    "web-vitals": ["web-vitals@5.3.0", "", {}, "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -113,6 +113,7 @@
     "motion": "^12.40.0",
     "next-themes": "^0.4.6",
     "postgres": "^3.4.9",
+    "posthog-js": "^1.396.5",
     "radix-ui": "^1.4.3",
     "react": "^19",
     "react-dom": "^19",

--- a/apps/dashboard/src/components/assistant-ui/agent-runtime-provider.tsx
+++ b/apps/dashboard/src/components/assistant-ui/agent-runtime-provider.tsx
@@ -23,12 +23,26 @@ import {
 import { useChatRuntime } from '@assistant-ui/react-ai-sdk'
 import { DefaultChatTransport } from 'ai'
 import { type ReactNode, useMemo } from 'react'
+import { trackEvent } from '@/lib/analytics/analytics'
 import { resolveThreadListAdapter } from '@/lib/conversation-store/adapter/resolve-thread-list-adapter'
 import { useAgentModel } from '@/lib/hooks/use-agent-model'
 import { useMcpConfig } from '@/lib/hooks/use-mcp-config'
 import { useToolConfig } from '@/lib/hooks/use-tool-config'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { useHostId } from '@/lib/swr/use-host'
+
+/**
+ * Wraps apiFetch to fire the `agent_message` funnel event whenever the chat
+ * transport sends a request to the agent route — i.e. whenever a message is
+ * sent to the AI agent.
+ */
+function trackedAgentFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): Promise<Response> {
+  trackEvent('agent_message')
+  return apiFetch(input, init)
+}
 
 /**
  * Per-thread chat runtime. assistant-ui invokes this hook once per active
@@ -57,7 +71,7 @@ function useAgentChatRuntime() {
     () =>
       new DefaultChatTransport({
         api: '/api/v1/agent',
-        fetch: apiFetch as typeof globalThis.fetch,
+        fetch: trackedAgentFetch as typeof globalThis.fetch,
         body: { hostId, model, disabledTools, sessionId, mcpServers },
       }),
     // mcpServers is a derived array — include it directly so the transport

--- a/apps/dashboard/src/components/charts/chart-container.tsx
+++ b/apps/dashboard/src/components/charts/chart-container.tsx
@@ -13,12 +13,19 @@ import {
   cloneElement,
   isValidElement,
   useCallback,
+  useEffect,
   useMemo,
   useState,
 } from 'react'
 import { ChartSkeleton } from '@/components/skeletons'
 import { FadeIn } from '@/components/ui/fade-in'
+import { trackEvent } from '@/lib/analytics/analytics'
 import { cn } from '@/lib/utils'
+
+// Fires at most once per page load — an activation signal for "the user saw a
+// live chart render with real data," not a per-chart-mount counter (this
+// component mounts 30+ times across the app).
+let firstChartRenderTracked = false
 
 export interface ChartContainerProps<
   TData extends ChartDataPoint = ChartDataPoint,
@@ -97,6 +104,14 @@ export function ChartContainer<TData extends ChartDataPoint = ChartDataPoint>({
   const { data, isLoading, error, mutate, sql, metadata, hasData, staleError } =
     swr
   const [zoomOpen, setZoomOpen] = useState(false)
+
+  const hasRenderableData = Boolean(data && data.length > 0)
+  useEffect(() => {
+    if (hasRenderableData && !firstChartRenderTracked) {
+      firstChartRenderTracked = true
+      trackEvent('first_chart_render')
+    }
+  }, [hasRenderableData])
 
   // Resolve skeleton type: explicit prop, or dynamic lookup from registry, or fallback
   const skeletonType = (() => {

--- a/apps/dashboard/src/components/connections/add-host-dialog.tsx
+++ b/apps/dashboard/src/components/connections/add-host-dialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { trackEvent } from '@/lib/analytics/analytics'
 import { docsSiteUrl } from '@/lib/docs-site'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { useBrowserConnections } from '@/lib/hooks/use-browser-connections'
@@ -52,6 +53,7 @@ export function AddHostDialog({ open, onOpenChange }: AddHostDialogProps) {
       const url = buildUrl(pathname, { host: created.hostId }, searchParams)
       router.push(url)
     }
+    trackEvent('cluster_connect', { storage_mode: storageMode })
     onOpenChange(false)
   }
 

--- a/apps/dashboard/src/components/host/first-run-empty-state.tsx
+++ b/apps/dashboard/src/components/host/first-run-empty-state.tsx
@@ -16,6 +16,7 @@ import { ClerkSignInButton as ClerkSignInButtonImpl } from '@/components/clerk/c
 import { AddHostDialog } from '@/components/connections'
 import { ChmonitorLogo } from '@/components/icons/chmonitor-logo'
 import { Button } from '@/components/ui/button'
+import { trackEvent } from '@/lib/analytics/analytics'
 import { BILLING_PLAN_LIST } from '@/lib/billing/plans'
 import {
   startCheckout,
@@ -258,6 +259,7 @@ function OnboardingPlans({
 
   async function choosePaid(planId: 'pro' | 'max') {
     setBusy(planId)
+    trackEvent('upgrade_click', { plan_id: planId, source: 'welcome' })
     try {
       await startCheckout(planId, 'yearly')
     } catch (err) {

--- a/apps/dashboard/src/lib/analytics/analytics.client.ts
+++ b/apps/dashboard/src/lib/analytics/analytics.client.ts
@@ -1,0 +1,90 @@
+// Browser-side PostHog init. Imported ONLY behind a `typeof document` guard +
+// dynamic import() in analytics.ts, so posthog-js never lands in the
+// size-constrained Cloudflare Worker SSR bundle (#1393) — mirrors
+// lib/observability/sentry.client.ts.
+//
+// Disabled (no-op) unless VITE_ANALYTICS_KEY is set — analytics is OFF by
+// default for self-hosted instances. Also a hard no-op when the browser's Do
+// Not Track signal is set, or the DO_NOT_TRACK env convention opts out.
+//
+// Locked-down PostHog config: no autocapture (would capture form/input/text
+// content — a PII vector), no automatic pageview/pageleave capture (funnel
+// pages are tracked explicitly), no session recording, cookieless
+// (localStorage) persistence so there is no cookie-banner requirement.
+// distinct_id stays PostHog's anonymous default — this app never calls
+// identify() with anything user-derived.
+
+import type { AnalyticsEvent, AnalyticsProps } from './events'
+
+import { isAnalyticsEnabled } from './config'
+import { redactProps } from '@/lib/telemetry/redact'
+
+interface PendingEvent {
+  event: AnalyticsEvent
+  props: AnalyticsProps
+}
+
+type PostHogModule = typeof import('posthog-js').default
+
+let posthogInstance: PostHogModule | null = null
+let initStarted = false
+let disabled = false
+// Bounded so a caller that fires events before init resolves (or when
+// analytics is never initialized at all) cannot grow this unboundedly.
+const MAX_PENDING = 20
+const pending: PendingEvent[] = []
+
+/** Initialize the browser SDK once. Safe to call repeatedly. */
+export async function initAnalyticsClient(): Promise<void> {
+  if (initStarted) return
+  initStarted = true
+  // Never run on the server — the isomorphic wrapper in analytics.ts already
+  // guarantees this, but guard defensively since this module can be imported
+  // directly in tests.
+  if (typeof document === 'undefined') return
+
+  const key = import.meta.env.VITE_ANALYTICS_KEY
+  if (
+    !isAnalyticsEnabled({
+      key,
+      envDoNotTrack: import.meta.env.VITE_DO_NOT_TRACK,
+    })
+  ) {
+    disabled = true
+    return
+  }
+
+  const { default: posthog } = await import('posthog-js')
+  posthog.init(key as string, {
+    api_host:
+      import.meta.env.VITE_ANALYTICS_HOST || 'https://us.i.posthog.com',
+    persistence: 'localStorage',
+    autocapture: false,
+    capture_pageview: false,
+    capture_pageleave: false,
+    disable_session_recording: true,
+  })
+  posthogInstance = posthog
+
+  for (const { event, props } of pending.splice(0)) {
+    posthog.capture(event, redactProps(props))
+  }
+}
+
+/**
+ * Track a funnel event. A no-op when analytics is disabled, so call sites
+ * need no guard of their own. If init hasn't resolved yet, the event is
+ * queued and flushed once PostHog is ready. Props are redacted defensively
+ * (reusing the telemetry redactor) before leaving the process.
+ */
+export function trackAnalyticsEvent(
+  event: AnalyticsEvent,
+  props: AnalyticsProps = {}
+): void {
+  if (disabled) return
+  if (posthogInstance) {
+    posthogInstance.capture(event, redactProps(props))
+    return
+  }
+  if (pending.length < MAX_PENDING) pending.push({ event, props })
+}

--- a/apps/dashboard/src/lib/analytics/analytics.ts
+++ b/apps/dashboard/src/lib/analytics/analytics.ts
@@ -1,0 +1,29 @@
+// Isomorphic entry points for browser-side product analytics (PostHog). The
+// real implementation lives in `analytics.client.ts` (the `.client` suffix
+// marks it browser-only). Importing a `.client` module directly from
+// server-reachable code trips TanStack Start's import-protection, so every
+// caller goes through these `createIsomorphicFn().client()` wrappers instead:
+// the client body — including the dynamic import of posthog-js — is stripped
+// from the SERVER build, keeping it out of the size-constrained Worker SSR
+// bundle (#1393). Mirrors lib/observability/sentry.ts.
+
+import { createIsomorphicFn } from '@tanstack/react-start'
+
+import type { AnalyticsEvent, AnalyticsProps } from './events'
+
+/** Initialize PostHog as early as possible. No-op on the server. */
+export const initAnalyticsClient = createIsomorphicFn().client(() => {
+  void import('./analytics.client').then((m) => m.initAnalyticsClient())
+})
+
+/**
+ * Track a funnel event. No-op on the server, and a no-op client-side unless
+ * analytics is configured (VITE_ANALYTICS_KEY) and Do Not Track is not set.
+ */
+export const trackEvent = createIsomorphicFn().client(
+  (event: AnalyticsEvent, props?: AnalyticsProps) => {
+    void import('./analytics.client').then((m) =>
+      m.trackAnalyticsEvent(event, props)
+    )
+  }
+)

--- a/apps/dashboard/src/lib/analytics/config.ts
+++ b/apps/dashboard/src/lib/analytics/config.ts
@@ -1,0 +1,36 @@
+// Product analytics enablement gate. OFF by default — a hard no-op unless an
+// analytics key is configured (key-presence gating, mirroring
+// lib/observability/sentry-options.ts) rather than lib/telemetry/config.ts's
+// "on unless explicitly disabled" — this is a marketing/growth capability, not
+// aggregate OSS telemetry, so a self-hosted instance must never phone home to
+// a third-party analytics platform without an explicit opt-in key.
+//
+// Respects the browser Do Not Track signal (navigator.doNotTrack) as required,
+// and additionally honors the cross-tool DO_NOT_TRACK env convention already
+// wired for telemetry (reused via isDoNotTrack, not duplicated) as a hard
+// override.
+
+import { isDoNotTrack } from '@/lib/telemetry/config'
+
+/** True when a PostHog project key is configured (non-empty after trim). */
+export function isAnalyticsConfigured(key: string | undefined): boolean {
+  return Boolean(key?.trim())
+}
+
+/** True when the browser's Do Not Track signal is set. False outside a browser. */
+export function isBrowserDoNotTrack(): boolean {
+  if (typeof navigator === 'undefined') return false
+  // DNT values are '1' (opt out), '0' (allowed), or unspecified — only '1'
+  // means opt out.
+  return navigator.doNotTrack === '1'
+}
+
+export function isAnalyticsEnabled(input: {
+  key: string | undefined
+  envDoNotTrack?: string | undefined
+}): boolean {
+  if (!isAnalyticsConfigured(input.key)) return false
+  if (isBrowserDoNotTrack()) return false
+  if (isDoNotTrack(input.envDoNotTrack)) return false
+  return true
+}

--- a/apps/dashboard/src/lib/analytics/events.ts
+++ b/apps/dashboard/src/lib/analytics/events.ts
@@ -1,0 +1,32 @@
+// Product analytics event schema — a closed, typed set of funnel event names
+// plus a flat, non-identifying props bag.
+//
+// This is a DIFFERENT system from lib/telemetry/ (anonymous, on-by-default OSS
+// instance telemetry sent to chmonitor's own collector) and from self-tracking
+// (writes usage events to the operator's own ClickHouse instance). Product
+// analytics tracks the SaaS conversion funnel (landing → signup → activation →
+// upgrade) via PostHog, and is OFF by default — a hard no-op unless an
+// analytics key is configured. See docs/operate/advanced/product-analytics.mdx.
+//
+// Privacy contract: props carry only counts, enums, and booleans — no PII,
+// query text, hostnames, IPs, connection strings, or emails. redactProps
+// (reused from lib/telemetry/redact) enforces this defensively before any
+// event leaves the process.
+
+export const ANALYTICS_EVENTS = [
+  'signup',
+  'cluster_connect',
+  'first_chart_render',
+  'agent_message',
+  'upgrade_click',
+  'checkout_started',
+] as const
+
+export type AnalyticsEvent = (typeof ANALYTICS_EVENTS)[number]
+
+export type AnalyticsPropValue = string | number | boolean | undefined
+export type AnalyticsProps = Record<string, AnalyticsPropValue>
+
+export function isAnalyticsEvent(value: string): value is AnalyticsEvent {
+  return (ANALYTICS_EVENTS as readonly string[]).includes(value)
+}

--- a/apps/dashboard/src/lib/analytics/signup-tracker.tsx
+++ b/apps/dashboard/src/lib/analytics/signup-tracker.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useUser } from '@clerk/tanstack-react-start'
+import { trackEvent } from './analytics'
+
+// A freshly created Clerk account is treated as "signup" if the session
+// starts within this window of account creation — distinguishes a brand-new
+// signup from a returning sign-in without needing a server-side webhook hop.
+// Approximate by design; fine for a funnel signal.
+const RECENT_SIGNUP_WINDOW_MS = 2 * 60 * 1000
+const SESSION_FLAG = 'chm_signup_tracked'
+
+/**
+ * Fires the `signup` funnel event once per browser session when a Clerk user
+ * whose account was JUST created loads the app — i.e. this is their first
+ * session, not a returning sign-in.
+ *
+ * IMPORTANT: calls Clerk's `useUser()`, which requires a mounted
+ * `<ClerkProvider />`. Only render this when `isClerkClientEnabled()` is true
+ * (mirrors `UserConnectionsCacheGuard` in __root.tsx).
+ */
+export function SignupAnalyticsTracker() {
+  const { isSignedIn, user } = useUser()
+  const checked = useRef(false)
+
+  useEffect(() => {
+    if (!isSignedIn || !user?.createdAt || checked.current) return
+    checked.current = true
+
+    if (sessionStorage.getItem(SESSION_FLAG)) return
+
+    const age = Date.now() - user.createdAt.getTime()
+    if (age >= 0 && age < RECENT_SIGNUP_WINDOW_MS) {
+      trackEvent('signup')
+    }
+    sessionStorage.setItem(SESSION_FLAG, '1')
+  }, [isSignedIn, user])
+
+  return null
+}

--- a/apps/dashboard/src/lib/billing/use-billing.ts
+++ b/apps/dashboard/src/lib/billing/use-billing.ts
@@ -8,6 +8,7 @@ import { useQuery } from '@tanstack/react-query'
 
 import type { PlanId } from '@/lib/billing/plans'
 
+import { trackEvent } from '@/lib/analytics/analytics'
 import { apiFetch } from '@/lib/swr/api-fetch'
 
 export interface BillingSubscription {
@@ -76,6 +77,7 @@ export async function startCheckout(
   period: 'monthly' | 'yearly'
 ): Promise<void> {
   const url = await postForUrl('/api/v1/billing/checkout', { planId, period })
+  trackEvent('checkout_started', { plan_id: planId, billing_period: period })
   window.location.href = url
 }
 

--- a/apps/dashboard/src/router.tsx
+++ b/apps/dashboard/src/router.tsx
@@ -1,5 +1,6 @@
 import { createRouter as createTanstackRouter } from '@tanstack/react-router'
 
+import { initAnalyticsClient } from './lib/analytics/analytics'
 import { initSentryClient } from './lib/observability/sentry'
 import { registerStaleChunkReload } from './lib/stale-chunk-reload'
 import { routeTree } from './routeTree.gen'
@@ -15,6 +16,10 @@ export function getRouter() {
 
   // Browser-only Sentry init (no-op on the server). See lib/observability/sentry.
   initSentryClient()
+
+  // Browser-only product analytics init (no-op on the server, and a no-op
+  // client-side without VITE_ANALYTICS_KEY). See lib/analytics/analytics.
+  initAnalyticsClient()
 
   return createTanstackRouter({
     routeTree,

--- a/apps/dashboard/src/routes/(dashboard)/billing.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/billing.tsx
@@ -25,6 +25,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { trackEvent } from '@/lib/analytics/analytics'
 import { BILLING_PLAN_LIST, getPlan } from '@/lib/billing/plans'
 import {
   openBillingPortal,
@@ -65,6 +66,7 @@ function BillingPage() {
 
   async function onCheckout(planId: 'pro' | 'max') {
     setBusy(planId)
+    trackEvent('upgrade_click', { plan_id: planId, source: 'billing_page' })
     try {
       await startCheckout(planId, period)
     } catch (err) {

--- a/apps/dashboard/src/routes/__root.tsx
+++ b/apps/dashboard/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import {
 import appCss from '../styles.css?url'
 import { type ReactNode, useEffect } from 'react'
 import { ClerkAuthProvider } from '@/components/clerk/clerk-auth-provider'
+import { SignupAnalyticsTracker } from '@/lib/analytics/signup-tracker'
 import { isClerkClientEnabled } from '@/lib/clerk/clerk-client'
 import { AppProvider } from '@/lib/context/app-context'
 import { BrowserConnectionsProvider } from '@/lib/context/browser-connections-context'
@@ -173,7 +174,10 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
               <TimeRangeProvider>
                 <QueryProvider>
                   {isClerkClientEnabled() ? (
-                    <UserConnectionsCacheGuard />
+                    <>
+                      <UserConnectionsCacheGuard />
+                      <SignupAnalyticsTracker />
+                    </>
                   ) : null}
                   <BrowserConnectionsProvider>
                     <AppProvider>

--- a/apps/dashboard/src/vite-env.d.ts
+++ b/apps/dashboard/src/vite-env.d.ts
@@ -37,6 +37,11 @@ interface ImportMetaEnv {
   // See lib/config/deployment-mode.ts. Drives the defaults for cloud mode, auth provider,
   // public-read, and per-user storage. The VITE_*/CHM_* vars above override it.
   readonly VITE_DEPLOYMENT_MODE?: string
+  // Product analytics (PostHog). OFF unless set — see lib/analytics/. Distinct
+  // from VITE_TELEMETRY_ENABLED (anonymous OSS instance telemetry).
+  readonly VITE_ANALYTICS_KEY?: string
+  // Self-hosted PostHog host override. Empty = PostHog Cloud (US) default.
+  readonly VITE_ANALYTICS_HOST?: string
 }
 
 interface ImportMeta {

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -186,6 +186,15 @@ const CLIENT_ENV = {
   // Browser tracing sample rate (0..1). Empty → SDK default in sentry-options.ts.
   VITE_SENTRY_TRACES_SAMPLE_RATE:
     e.VITE_SENTRY_TRACES_SAMPLE_RATE ?? e.CHM_SENTRY_TRACES_SAMPLE_RATE ?? '',
+  // Product analytics (PostHog) — SaaS funnel/conversion tracking, DISTINCT
+  // from VITE_TELEMETRY_ENABLED (anonymous OSS instance telemetry, on by
+  // default). OFF unless a key is set — self-hosted instances never phone
+  // home to a third-party analytics platform by default. See
+  // docs/operate/advanced/product-analytics.mdx and lib/analytics/.
+  VITE_ANALYTICS_KEY: e.VITE_ANALYTICS_KEY ?? e.CHM_ANALYTICS_KEY ?? '',
+  // Self-hostable: point at your own PostHog instance. Empty = PostHog Cloud
+  // (US) default (see lib/analytics/analytics.client.ts).
+  VITE_ANALYTICS_HOST: e.VITE_ANALYTICS_HOST ?? e.CHM_ANALYTICS_HOST ?? '',
 } as const
 
 // Explicit text-replacement of each `import.meta.env.VITE_*` read. Deterministic

--- a/apps/landing/bun.lock
+++ b/apps/landing/bun.lock
@@ -9,6 +9,7 @@
         "@astrojs/sitemap": "^3.3.0",
         "@paper-design/shaders-react": "0.0.76",
         "astro": "^7.0.0",
+        "posthog-js": "^1.396.5",
         "react": "^19",
         "react-dom": "^19",
       },
@@ -266,6 +267,10 @@
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
+    "@posthog/core": ["@posthog/core@1.39.6", "", { "dependencies": { "@posthog/types": "^1.392.0" } }, "sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw=="],
+
+    "@posthog/types": ["@posthog/types@1.392.0", "", {}, "sha512-nctNujXL3FC1v99FktaTMSugSD9ZOZekEpahUSafkU2TSvW+XGKNkQZbokuJtiWvPBK208dwMJva8UfBkChqpw=="],
+
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.3", "", { "os": "android", "cpu": "arm64" }, "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw=="],
@@ -398,6 +403,8 @@
 
     "@types/sax": ["@types/sax@1.2.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
@@ -454,6 +461,8 @@
 
     "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
 
+    "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
+
     "crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
@@ -488,6 +497,8 @@
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
+    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
+
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "dset": ["dset@3.1.4", "", {}, "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="],
@@ -517,6 +528,8 @@
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
     "flattie": ["flattie@1.1.1", "", {}, "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="],
 
@@ -672,11 +685,17 @@
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
+    "posthog-js": ["posthog-js@1.396.5", "", { "dependencies": { "@posthog/core": "^1.39.5", "@posthog/types": "^1.392.0", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.29.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.3.0" } }, "sha512-huW/8R151I08i/tkOaAv3Q/yWVqzhqPj3SxyhpgNLB/xysaNeV1ibp6DHzbRWV5D7FRM48Zg6Icxsm4q0irEtg=="],
+
+    "preact": ["preact@10.29.3", "", {}, "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw=="],
+
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
     "process-ancestry": ["process-ancestry@0.1.0", "", {}, "sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg=="],
 
     "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
+
+    "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "radix3": ["radix3@1.1.2", "", {}, "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="],
 
@@ -793,6 +812,8 @@
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
+
+    "web-vitals": ["web-vitals@5.3.0", "", {}, "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="],
 
     "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
 

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -16,6 +16,7 @@
     "@astrojs/sitemap": "^3.3.0",
     "@paper-design/shaders-react": "0.0.76",
     "astro": "^7.0.0",
+    "posthog-js": "^1.396.5",
     "react": "^19",
     "react-dom": "^19"
   },

--- a/apps/landing/src/components/FinalCta.astro
+++ b/apps/landing/src/components/FinalCta.astro
@@ -13,7 +13,7 @@ import HeroHalftone from './HeroHalftone.tsx'
         <h2>Start monitoring in minutes</h2>
         <p>Open the hosted dashboard and connect a cluster, or grab the source and run it yourself. Self-hosting is always free.</p>
         <div class="hero-actions">
-          <a class="btn btn-primary" href="https://dash.chmonitor.dev" target="_blank" rel="noopener">
+          <a class="btn btn-primary" href="https://dash.chmonitor.dev" target="_blank" rel="noopener" data-cta="final-primary">
             Open dashboard
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
           </a>

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -35,7 +35,7 @@ const galleryCards = [
         answers questions about your data. <strong>Self-host it, or use the hosted dashboard.</strong>
       </p>
       <div class="ehero-actions">
-        <a class="btn btn-primary" href="https://dash.chmonitor.dev" target="_blank" rel="noopener">
+        <a class="btn btn-primary" href="https://dash.chmonitor.dev" target="_blank" rel="noopener" data-cta="hero-primary">
           Open dashboard
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
         </a>

--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -91,6 +91,7 @@ const { compact = false } = Astro.props
                 href={t.cta.href}
                 target="_blank"
                 rel="noopener"
+                data-cta={`pricing-${t.name.toLowerCase().replace(/\s+/g, '-')}`}
               >
                 {t.cta.label} <span set:html={arrowSvg} />
               </a>

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -759,8 +759,11 @@ const ogImage = new URL(image, Astro.site).toString()
     import { initAnalytics, trackCtaClick, trackEvent } from '../lib/analytics'
 
     initAnalytics().then(function () {
-      if (location.pathname === '/') trackEvent('landing_view')
-      else if (location.pathname === '/pricing') trackEvent('pricing_view')
+      // Normalize a trailing slash — static-asset serving may resolve
+      // /pricing as /pricing/ depending on host configuration.
+      var path = location.pathname.replace(/\/+$/, '') || '/'
+      if (path === '/') trackEvent('landing_view')
+      else if (path === '/pricing') trackEvent('pricing_view')
     })
 
     // Delegated CTA tracking: add data-cta="<short-id>" to any link/button to

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -751,5 +751,27 @@ const ogImage = new URL(image, Astro.site).toString()
       });
     })();
   </script>
+  <script>
+    // Opt-in, off-by-default product analytics (PostHog) — see
+    // ../lib/analytics.ts for the full privacy contract. A no-op without
+    // PUBLIC_ANALYTICS_KEY, so this never runs for anyone who hasn't
+    // configured it.
+    import { initAnalytics, trackCtaClick, trackEvent } from '../lib/analytics'
+
+    initAnalytics().then(function () {
+      if (location.pathname === '/') trackEvent('landing_view')
+      else if (location.pathname === '/pricing') trackEvent('pricing_view')
+    })
+
+    // Delegated CTA tracking: add data-cta="<short-id>" to any link/button to
+    // have its click tracked automatically.
+    document.addEventListener('click', function (e) {
+      var target = e.target
+      var el =
+        target && target.closest ? target.closest('[data-cta]') : null
+      var cta = el ? el.getAttribute('data-cta') : null
+      if (cta) trackCtaClick(cta)
+    })
+  </script>
 </body>
 </html>

--- a/apps/landing/src/lib/analytics.ts
+++ b/apps/landing/src/lib/analytics.ts
@@ -1,0 +1,76 @@
+// Product analytics (PostHog) for the marketing site. OFF by default — a hard
+// no-op unless PUBLIC_ANALYTICS_KEY is set. Respects the browser Do Not Track
+// signal. Cookieless (localStorage persistence) — no cookie-banner required.
+// Autocapture, session recording, and automatic pageview capture are all
+// disabled; every event sent by this app is one of the explicit, allowlisted
+// calls below.
+//
+// Counterpart to apps/dashboard/src/lib/analytics/ (same privacy posture, same
+// event-catalog philosophy, separate PostHog project). See
+// docs/content/operate/advanced/product-analytics.mdx.
+
+export type LandingAnalyticsEvent = 'landing_view' | 'pricing_view' | 'cta_click'
+
+type LandingAnalyticsProps = Record<string, string>
+
+type PostHogModule = typeof import('posthog-js').default
+
+let posthogInstance: PostHogModule | null = null
+let disabled = false
+const MAX_PENDING = 20
+const pending: { event: LandingAnalyticsEvent; props: LandingAnalyticsProps }[] =
+  []
+
+function isBrowserDoNotTrack(): boolean {
+  return typeof navigator !== 'undefined' && navigator.doNotTrack === '1'
+}
+
+/** Initialize PostHog once. A no-op without a key, or when DNT is set. */
+export async function initAnalytics(): Promise<void> {
+  const key = import.meta.env.PUBLIC_ANALYTICS_KEY as string | undefined
+  if (!key?.trim() || isBrowserDoNotTrack()) {
+    disabled = true
+    return
+  }
+
+  const { default: posthog } = await import('posthog-js')
+  posthog.init(key, {
+    api_host:
+      (import.meta.env.PUBLIC_ANALYTICS_HOST as string | undefined) ||
+      'https://us.i.posthog.com',
+    persistence: 'localStorage',
+    autocapture: false,
+    capture_pageview: false,
+    capture_pageleave: false,
+    disable_session_recording: true,
+  })
+  posthogInstance = posthog
+
+  for (const { event, props } of pending.splice(0)) {
+    posthog.capture(event, props)
+  }
+}
+
+/** Track a funnel event. A no-op when analytics is disabled. */
+export function trackEvent(
+  event: LandingAnalyticsEvent,
+  props: LandingAnalyticsProps = {}
+): void {
+  if (disabled) return
+  if (posthogInstance) {
+    posthogInstance.capture(event, props)
+    return
+  }
+  if (pending.length < MAX_PENDING) pending.push({ event, props })
+}
+
+// Only short static identifiers are accepted — e.g. a `data-cta` attribute
+// value authored directly in the marketing site's markup. Never derived from
+// user input, URLs, or DOM text, so there is nothing to redact.
+const SAFE_TARGET_RE = /^[a-z0-9_-]{1,64}$/i
+
+/** Track a CTA click. `target` must be a short static identifier. */
+export function trackCtaClick(target: string): void {
+  if (!SAFE_TARGET_RE.test(target)) return
+  trackEvent('cta_click', { target })
+}

--- a/docs/content/operate/advanced/product-analytics.mdx
+++ b/docs/content/operate/advanced/product-analytics.mdx
@@ -1,0 +1,105 @@
+---
+description: Opt-in PostHog funnel analytics for the SaaS product — off by default, no PII, Do Not Track respected, cookieless.
+icon: TrendingUp
+title: Product Analytics
+---
+
+chmonitor can optionally send **conversion funnel events** (landing page views,
+signups, cluster connects, upgrades, checkouts) to [PostHog](https://posthog.com)
+for the hosted SaaS product's growth/business side. It is **OFF by default** —
+a hard no-op — until you configure an analytics key.
+
+This is a different system from [Product Telemetry](/operate/advanced/telemetry)
+(anonymous, on-by-default, aggregate OSS instance telemetry to chmonitor's own
+collector) and from [Self-Tracking](/operate/advanced/self-tracking) (writes
+usage events to your own ClickHouse instance). Product analytics exists purely
+to measure the marketing/signup/upgrade funnel and is never required to run
+chmonitor.
+
+## Opt in — off by default
+
+<Callout type="info" title="No key, no network call">
+Without `CHM_ANALYTICS_KEY` (dashboard) / `PUBLIC_ANALYTICS_KEY` (landing site)
+set, none of this code makes a network call, loads PostHog, or sets a cookie.
+Self-hosted instances stay completely untouched by default.
+</Callout>
+
+| Variable | Surface | Purpose |
+|---|---|---|
+| `CHM_ANALYTICS_KEY` | Dashboard (derives client `VITE_ANALYTICS_KEY`) | PostHog project key. Empty = disabled. |
+| `CHM_ANALYTICS_HOST` | Dashboard (derives client `VITE_ANALYTICS_HOST`) | PostHog ingestion host. Empty = PostHog Cloud (US). |
+| `PUBLIC_ANALYTICS_KEY` | Landing site (Astro) | PostHog project key. Empty = disabled. |
+| `PUBLIC_ANALYTICS_HOST` | Landing site (Astro) | PostHog ingestion host. Empty = PostHog Cloud (US). |
+
+Both `*_HOST` variables let you point at a **self-hosted PostHog** instance
+instead of PostHog Cloud, keeping the whole stack self-hostable in spirit.
+
+## Do Not Track
+
+The browser [`navigator.doNotTrack`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack)
+signal is checked before analytics initializes — when set, init is skipped
+entirely. The dashboard additionally honors the cross-tool `DO_NOT_TRACK`/
+`VITE_DO_NOT_TRACK` convention already used by telemetry.
+
+## Events
+
+### Landing site
+
+| Event | When it fires |
+|---|---|
+| `landing_view` | The marketing home page (`/`) loads |
+| `pricing_view` | The `/pricing` page loads |
+| `cta_click` | A tracked call-to-action link is clicked (`target` = a static identifier, e.g. `hero-primary`) |
+
+### Dashboard
+
+| Event | When it fires |
+|---|---|
+| `signup` | A Clerk account created within the last 2 minutes loads the app (approximates "just signed up") |
+| `cluster_connect` | A ClickHouse connection is added and saved |
+| `first_chart_render` | The first chart renders with real data (once per page load) |
+| `agent_message` | A message is sent to the AI agent |
+| `upgrade_click` | An "Upgrade" call-to-action is clicked |
+| `checkout_started` | A Polar checkout session is created, right before redirect |
+
+## What is NOT collected
+
+- Query text, SQL statements, hostnames, IP addresses, or connection strings
+- Email addresses, names, or any other user-identifying field
+- Form input or free text — **autocapture is disabled**
+- Session recordings — **disabled**
+- Automatic pageview/pageleave capture — **disabled**; only the explicit events above are sent
+
+Dashboard-side events are redacted defensively before leaving the process,
+reusing the same `redactProps` allowlist [Product Telemetry](/operate/advanced/telemetry)
+uses (drops any prop whose key implies sensitive content, or whose value looks
+like an email/IP/URL). Landing-side `cta_click` targets are static identifiers
+authored in the marketing site's own markup, never derived from user input.
+
+PostHog is configured cookieless (`persistence: 'localStorage'`), so no cookie
+banner is required for this feature.
+
+<Callout type="info" title="Anonymous by design">
+No call site ever calls PostHog's `identify()` with anything user-derived —
+every distinct id stays PostHog's anonymous default.
+</Callout>
+
+## Related
+
+<Cards>
+  <Card
+    title="Product Telemetry"
+    href="/operate/advanced/telemetry"
+    description="Anonymous, on-by-default, aggregate OSS instance telemetry — a different system, own collector."
+  />
+  <Card
+    title="Self-Tracking"
+    href="/operate/advanced/self-tracking"
+    description="Writes dashboard usage events (page visits, query executions) to your own ClickHouse instance."
+  />
+  <Card
+    title="Environment Variables"
+    href="/reference/environment-variables"
+    description="Full reference for all configuration variables."
+  />
+</Cards>

--- a/docs/content/operate/advanced/telemetry.mdx
+++ b/docs/content/operate/advanced/telemetry.mdx
@@ -11,7 +11,10 @@ three dimensions, no PII) to help the project understand how the dashboard is
 used at a high level.
 
 This is separate from [Self-Tracking](/operate/advanced/self-tracking), which
-writes dashboard usage events to your own ClickHouse instance.
+writes dashboard usage events to your own ClickHouse instance, and from
+[Product Analytics](/operate/advanced/product-analytics), an opt-in,
+off-by-default PostHog integration used for the hosted SaaS product's
+conversion funnel.
 
 ## Opt out — on by default
 
@@ -145,7 +148,7 @@ telemetry store, and this documentation.
 <Callout type="info" title="Privacy by design">
 - **One-switch opt-out** — `CHM_TELEMETRY=off` or `DO_NOT_TRACK=1` disables it completely, anytime.
 - **Self-hosted data stays put** — chmonitor is fully self-hostable; your ClickHouse data never leaves your network regardless of telemetry settings.
-- **No third-party trackers** — there are no analytics SDKs, beacon scripts, or third-party pixels in the application.
+- **No third-party trackers in this system** — telemetry uses only chmonitor's own collector, never a third-party analytics SDK. (chmonitor separately offers an opt-in, *off-by-default* [Product Analytics](/operate/advanced/product-analytics) integration that sends funnel events to PostHog — only if you explicitly configure a key.)
 - **No PII by design** — the event schema and redaction layer are written to make PII collection structurally impossible, not just policy-forbidden.
 - **Anonymous** — only a hashed random install id is sent; it cannot be tied to an identity, and the collector never stores request IPs.
 - **Hard kill-switch** — setting the endpoint env to an empty string stops all network calls regardless of any other setting.
@@ -158,6 +161,11 @@ telemetry store, and this documentation.
     title="Self-Tracking"
     href="/operate/advanced/self-tracking"
     description="Writes dashboard usage events (page visits, query executions) to your own ClickHouse instance. A different system, entirely within your infrastructure."
+  />
+  <Card
+    title="Product Analytics"
+    href="/operate/advanced/product-analytics"
+    description="Opt-in, off-by-default PostHog funnel analytics for the hosted SaaS product."
   />
   <Card
     title="Environment Variables"

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -431,8 +431,8 @@ legacy Next.js.
 | `VITE_MEASUREMENT_ID` | — | Google Analytics measurement ID (`G-...`). |
 | `VITE_SELINE_ENABLED` | `false` | Enable Seline analytics. |
 | `VITE_VERCEL_ANALYTICS` | `false` | Enable Vercel Analytics. |
-| `VITE_POSTHOG_KEY` | — | PostHog project API key. |
-| `VITE_POSTHOG_HOST` | `https://us.i.posthog.com` | PostHog ingest host URL. |
+| `VITE_ANALYTICS_KEY` (derived from `CHM_ANALYTICS_KEY`) | — | PostHog project key for opt-in [Product Analytics](/operate/advanced/product-analytics) (SaaS funnel tracking). Empty = disabled. |
+| `VITE_ANALYTICS_HOST` (derived from `CHM_ANALYTICS_HOST`) | `https://us.i.posthog.com` | PostHog ingest host — point at a self-hosted PostHog instance. |
 
 ## Runtime & build
 
@@ -483,6 +483,7 @@ See [Migrate to v0.3](/reference/migrating/v0-3) for the full rename list.
 <Card title="Connection presets" href="/reference/connection-presets" description="Create a least-privilege read-only ClickHouse user." />
 <Card title="Feature permissions" href="/operate/advanced/feature-permissions" description="Config-file and env-override details." />
 <Card title="Authentication" href="/operate/authentication" description="Choose and configure an auth provider." />
+<Card title="Product Analytics" href="/operate/advanced/product-analytics" description="Opt-in, off-by-default PostHog funnel analytics." />
 <Card title="Migrate to v0.3" href="/reference/migrating/v0-3" description="Full rename list from the Next.js era." />
 <Card title="Catalog contributing" href="/reference/catalog-contributing" description="The declarative query-config catalog CHM_CONFIG_SOURCE opts into." />
 </Cards>

--- a/plans/62-product-analytics-funnel.md
+++ b/plans/62-product-analytics-funnel.md
@@ -1,0 +1,26 @@
+# 62 — Product analytics & funnel instrumentation
+
+## Goal
+A single analytics provider (default: PostHog, self-hostable) wired into landing + dashboard behind an env flag, capturing ~6 funnel events with no PII, DNT-respecting, negligible page-load cost.
+
+## Current reality (audited)
+No product analytics exist anywhere — no PostHog/Segment/GA in landing or dashboard, no funnel/conversion tracking. Revenue decisions are blind. (No analytics library in `apps/landing/src/layouts/Base.astro` or `apps/dashboard/src/root.tsx`.)
+
+## Implement now (depth F)
+- Choose PostHog (self-hostable, aligns with OSS) or Segment; add the snippet to `apps/landing/src/layouts/Base.astro` and `apps/dashboard/src/root.tsx`, gated by `PUBLIC_ANALYTICS_KEY` / `VITE_ANALYTICS_KEY` (absent ⇒ no-op; self-host stays clean).
+- Events (no PII; ids anonymous/hashed):
+  - Landing: `landing_view`, `cta_click{target}`, `pricing_view`, `comparison_expand`.
+  - Dashboard: `signup`, `cluster_connect`, `first_chart_render`, `agent_message`, `upgrade_click`, `checkout_started`.
+- Respect DNT (skip init when `navigator.doNotTrack`); exclude internal IPs via provider config.
+- Load async/deferred; assert <50ms added to landing load.
+- Document the env flags + event catalog in `docs/`.
+
+## STOP conditions & drift check
+- STOP before capturing any connection string, host, query text, email, or token — event props are allowlisted primitives only.
+- STOP if a provider requires a cookie banner in target regions — prefer cookieless config.
+- Drift: confirm `Base.astro` + `root.tsx` are the right injection points.
+
+## Done criteria
+- ≥5 funnel events fire across landing + dashboard; analytics is a no-op without the env key.
+- No PII/secrets in any event (reviewed); DNT respected.
+- Event catalog + env flags documented.


### PR DESCRIPTION
## Summary
Implements **plan 62** (Round-3 Wave G). Adds PostHog funnel instrumentation to landing + dashboard behind an env flag. **New separate `lib/analytics/` module** (NOT the always-on OSS `lib/telemetry/` pipe — deliberately, so self-hosted instances never emit business data by default). Isomorphic dynamic `import('posthog-js')`, dead-code-eliminated from the server bundle and entirely absent when no key is set.

## Privacy (confirmed — no PII/secrets)
8 events; every prop is a closed enum or static string I control at the source (never user input/query/host/email/token): `landing_view`, `pricing_view`, `cta_click{target}`, `signup`, `cluster_connect{storage_mode}`, `first_chart_render`, `agent_message`, `upgrade_click{plan_id,source}`, `checkout_started{plan_id,billing_period}`. Dashboard props also pass a `redactProps` allowlist. **DNT respected** (both apps); **no-op without the key** (verified via DCE — zero `posthog-js` bytes shipped); **cookieless** (localStorage); autocapture/session-recording/pageview **disabled**; no `identify()`.

## Verification
dashboard type-check ✅ · `tsc -p tsconfig.test.json` ✅ · landing `bun run build` ✅ (built both with key unset → DCE confirmed, and with a throwaway key → init path confirmed) · lint ✅.

## Activation (deliberate human step, like Sentry)
Ships fully wired but **inert** — no PostHog project/key committed. Set `CHM_ANALYTICS_KEY`/`PUBLIC_ANALYTICS_KEY` to activate. Note for whoever activates: PostHog localStorage persistence, though cookieless, may warrant an EU ePrivacy/GDPR consent review at that point (activation-time legal decision, not a code issue).

Co-Authored-By: duyetbot <bot@duyet.net>