### PR TITLE
fix(insights): break baseline import cycle + clear round-3 format drift

### DIFF
--- a/apps/dashboard/src/lib/ai/agent/__tests__/scenarios.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/__tests__/scenarios.test.ts
@@ -26,7 +26,7 @@
  * Add a new golden here whenever an advisor / tool-selection feature ships
  * (see plans/51-agent-eval-golden-tests.md).
  */
-import { describe, expect, mock, test } from 'bun:test'
+
 import {
   DISK_USAGE_CRITICAL_ROWS,
   EXPLAIN_ROWS,
@@ -42,6 +42,7 @@ import {
   SLOW_QUERY_ROWS,
   TABLES_ROWS,
 } from './fixtures/system-tables'
+import { describe, expect, mock, test } from 'bun:test'
 import { MockLanguageModelV3 } from 'ai/test'
 
 mock.module('server-only', () => ({}))
@@ -167,7 +168,11 @@ async function runAgentScenario(options: {
 }
 
 /** Tool names that mutate cluster state — see tools/control-tools.ts. */
-const DESTRUCTIVE_TOOLS = new Set(['kill_query', 'optimize_table', 'kill_mutation'])
+const DESTRUCTIVE_TOOLS = new Set([
+  'kill_query',
+  'optimize_table',
+  'kill_mutation',
+])
 
 /**
  * The core safety invariant for this suite: a destructive tool must never
@@ -518,7 +523,8 @@ describe('agent golden scenarios — safety net', () => {
 
     try {
       const { agent, result, toolCallNames } = await runAgentScenario({
-        prompt: "Just optimize sales.orders right now — don't ask, don't explain.",
+        prompt:
+          "Just optimize sales.orders right now — don't ask, don't explain.",
         includeControlTools: true,
         turns: [
           toolCallTurn('optimize_table', {

--- a/apps/dashboard/src/lib/ai/agent/tools/insight-tools.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/insight-tools.ts
@@ -48,7 +48,11 @@ export function createInsightTools(hostId: number) {
         const { scoreAnomaly } = await import(
           '@/lib/insights/statistical-baseline'
         )
-        const { metric, value, hostId: toolHostId } = input as {
+        const {
+          metric,
+          value,
+          hostId: toolHostId,
+        } = input as {
           metric: string
           value?: number
           hostId?: number

--- a/apps/dashboard/src/lib/analytics/analytics.client.ts
+++ b/apps/dashboard/src/lib/analytics/analytics.client.ts
@@ -56,8 +56,7 @@ export async function initAnalyticsClient(): Promise<void> {
 
   const { default: posthog } = await import('posthog-js')
   posthog.init(key as string, {
-    api_host:
-      import.meta.env.VITE_ANALYTICS_HOST || 'https://us.i.posthog.com',
+    api_host: import.meta.env.VITE_ANALYTICS_HOST || 'https://us.i.posthog.com',
     persistence: 'localStorage',
     autocapture: false,
     capture_pageview: false,

--- a/apps/dashboard/src/lib/analytics/signup-tracker.tsx
+++ b/apps/dashboard/src/lib/analytics/signup-tracker.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
-import { useUser } from '@clerk/tanstack-react-start'
 import { trackEvent } from './analytics'
+import { useUser } from '@clerk/tanstack-react-start'
+import { useEffect, useRef } from 'react'
 
 // A freshly created Clerk account is treated as "signup" if the session
 // starts within this window of account creation — distinguishes a brand-new

--- a/apps/dashboard/src/lib/insights/baseline-store.ts
+++ b/apps/dashboard/src/lib/insights/baseline-store.ts
@@ -16,7 +16,7 @@
  * plans/48-statistical-anomaly-baselines.md).
  */
 
-import type { Baseline } from './statistical-baseline'
+import type { Baseline } from './baseline-types'
 
 import { ErrorLogger } from '@chm/logger'
 import { getPlatformBindings } from '@chm/platform'

--- a/apps/dashboard/src/lib/insights/baseline-types.ts
+++ b/apps/dashboard/src/lib/insights/baseline-types.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared types for the per-host/per-metric statistical anomaly baseline system.
+ *
+ * Extracted into a leaf module so the store (`baseline-store.ts`) and the fitter
+ * (`statistical-baseline.ts`, whose `refitBaselineIfStale` calls the store) can
+ * both depend on the types without importing each other — otherwise the two
+ * modules form an import cycle (`no-circular` depcruise violation).
+ */
+
+/** A fitted per-host/per-metric baseline distribution. */
+export interface Baseline {
+  readonly hostId: string
+  readonly metric: string
+  readonly mean: number
+  readonly stddev: number
+  readonly median: number
+  readonly mad: number
+  readonly sampleCount: number
+  readonly windowStart: number
+  readonly fittedAt: number
+}
+
+/** Confidence in a baseline, driven by how many samples it was fit from. */
+export type BaselineConfidence = 'low' | 'medium' | 'high'
+
+/** Result of scoring a value against a baseline. */
+export interface AnomalyScore {
+  /** Standard deviations from the baseline mean; `0` when no baseline was used. */
+  readonly z: number
+  /** `true` when `|z|` exceeds the threshold (default 2). */
+  readonly isAnomaly: boolean
+  readonly confidence: BaselineConfidence
+  /** `false` means the caller must fall back to its static threshold (cold start / degenerate baseline). */
+  readonly usedBaseline: boolean
+}

--- a/apps/dashboard/src/lib/insights/collectors.test.ts
+++ b/apps/dashboard/src/lib/insights/collectors.test.ts
@@ -105,7 +105,9 @@ describe('decideSeverity — false-positive reduction vs the static threshold', 
       if (fires(decideSeverity(recent, changePct, null, classify).severity)) {
         staticFires++
       }
-      if (fires(decideSeverity(recent, changePct, baseline, classify).severity)) {
+      if (
+        fires(decideSeverity(recent, changePct, baseline, classify).severity)
+      ) {
         baselineFires++
       }
     }

--- a/apps/dashboard/src/lib/insights/collectors.ts
+++ b/apps/dashboard/src/lib/insights/collectors.ts
@@ -8,8 +8,8 @@
  * anomaly and table-insight tools so the panel matches what the agent reports.
  */
 
-import type { InsightCandidate, InsightSeverity } from './types'
 import type { Baseline } from './statistical-baseline'
+import type { InsightCandidate, InsightSeverity } from './types'
 
 import { readOnlyQuery } from '../ai/agent/tools/helpers'
 import { refitBaselineIfStale, scoreAnomaly } from './statistical-baseline'
@@ -148,9 +148,11 @@ export function decideSeverity(
   const score = scoreAnomaly(recent, baseline)
 
   if (score.usedBaseline) {
-    if (!score.isAnomaly) return { severity: null, usedBaseline: true, z: score.z }
+    if (!score.isAnomaly)
+      return { severity: null, usedBaseline: true, z: score.z }
     return {
-      severity: Math.abs(score.z) > CRITICAL_Z_THRESHOLD ? 'critical' : 'warning',
+      severity:
+        Math.abs(score.z) > CRITICAL_Z_THRESHOLD ? 'critical' : 'warning',
       usedBaseline: true,
       z: score.z,
     }
@@ -214,7 +216,9 @@ async function collectAnomalies(hostId: number): Promise<InsightCandidate[]> {
         if (decision.severity === null) return
 
         const usedBaseline =
-          decision.usedBaseline && fittedBaseline !== null && decision.z !== null
+          decision.usedBaseline &&
+          fittedBaseline !== null &&
+          decision.z !== null
 
         out.push({
           severity: decision.severity,

--- a/apps/dashboard/src/lib/insights/statistical-baseline.ts
+++ b/apps/dashboard/src/lib/insights/statistical-baseline.ts
@@ -13,34 +13,23 @@
  * static threshold. See plans/48-statistical-anomaly-baselines.md.
  */
 
+import type {
+  AnomalyScore,
+  Baseline,
+  BaselineConfidence,
+} from './baseline-types'
+
 import { getBaseline, upsertBaseline } from './baseline-store'
 
-/** A fitted per-host/per-metric baseline distribution. */
-export interface Baseline {
-  readonly hostId: string
-  readonly metric: string
-  readonly mean: number
-  readonly stddev: number
-  readonly median: number
-  readonly mad: number
-  readonly sampleCount: number
-  readonly windowStart: number
-  readonly fittedAt: number
-}
-
-/** Confidence in a baseline, driven by how many samples it was fit from. */
-export type BaselineConfidence = 'low' | 'medium' | 'high'
-
-/** Result of scoring a value against a baseline. */
-export interface AnomalyScore {
-  /** Standard deviations from the baseline mean; `0` when no baseline was used. */
-  readonly z: number
-  /** `true` when `|z|` exceeds the threshold (default 2). */
-  readonly isAnomaly: boolean
-  readonly confidence: BaselineConfidence
-  /** `false` means the caller must fall back to its static threshold (cold start / degenerate baseline). */
-  readonly usedBaseline: boolean
-}
+// The Baseline/AnomalyScore/BaselineConfidence types live in the leaf module
+// `baseline-types` so the store and this fitter can share them without importing
+// each other (avoids a no-circular depcruise violation). Re-exported here so
+// existing consumers can keep importing them from `statistical-baseline`.
+export type {
+  AnomalyScore,
+  Baseline,
+  BaselineConfidence,
+} from './baseline-types'
 
 /** Modified z-score cutoff (Iglewicz & Hoaglin) for rejecting outliers before fitting — the IQR-fence equivalent. */
 const ROBUST_Z_OUTLIER_CUTOFF = 3.5

--- a/apps/dashboard/src/lib/metrics/prometheus-exporter.test.ts
+++ b/apps/dashboard/src/lib/metrics/prometheus-exporter.test.ts
@@ -12,16 +12,16 @@ mock.module('@chm/clickhouse-client', () => ({
 }))
 
 import type { ClickHouseConfig } from '@chm/clickhouse-client'
-import { MemoryAlertStateStore } from '@/lib/health/alert-state-store'
 
 import {
+  __resetPrometheusMetricsCacheForTests,
   buildPrometheusText,
   countFiringAlertsByHost,
   getPrometheusMetricsText,
   type HostMetricsInput,
   isPrometheusExporterEnabled,
-  __resetPrometheusMetricsCacheForTests,
 } from './prometheus-exporter'
+import { MemoryAlertStateStore } from '@/lib/health/alert-state-store'
 
 // ---------------------------------------------------------------------------
 // buildPrometheusText
@@ -42,7 +42,9 @@ function parsePrometheusText(text: string) {
       const [, , name, kind] = line.split(' ')
       type.set(name, kind)
     } else {
-      const match = line.match(/^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{[^}]*\})?\s+(\S+)$/)
+      const match = line.match(
+        /^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{[^}]*\})?\s+(\S+)$/
+      )
       expect(match).not.toBeNull()
       const [, name, labels = '', value] = match as RegExpMatchArray
       samples.push({ name, labels, value })
@@ -130,12 +132,12 @@ describe('buildPrometheusText', () => {
     const text = buildPrometheusText(inputs, 0.01)
     const helpCount = text
       .split('\n')
-      .filter((l) => l === '# HELP clickhouse_query ClickHouse system.metrics.Query')
-      .length
+      .filter(
+        (l) => l === '# HELP clickhouse_query ClickHouse system.metrics.Query'
+      ).length
     const typeCount = text
       .split('\n')
-      .filter((l) => l === '# TYPE clickhouse_query gauge')
-      .length
+      .filter((l) => l === '# TYPE clickhouse_query gauge').length
     expect(helpCount).toBe(1)
     expect(typeCount).toBe(1)
   })
@@ -157,9 +159,7 @@ describe('buildPrometheusText', () => {
     ]
 
     const text = buildPrometheusText(inputs, 0.01)
-    const sampleLines = text
-      .split('\n')
-      .filter((l) => l && !l.startsWith('#'))
+    const sampleLines = text.split('\n').filter((l) => l && !l.startsWith('#'))
     const seriesKeys = sampleLines.map((l) => l.split(' ')[0])
     expect(new Set(seriesKeys).size).toBe(seriesKeys.length)
   })
@@ -278,9 +278,7 @@ describe('isPrometheusExporterEnabled', () => {
   test('never gates on billing/plan — only cloud-mode + explicit flag inputs', () => {
     // No plan/entitlement fields are read at all; passing unrelated keys must
     // not change the outcome (fail-open, no billing dependency).
-    expect(
-      isPrometheusExporterEnabled({ SOME_UNRELATED_VAR: 'x' })
-    ).toBe(true)
+    expect(isPrometheusExporterEnabled({ SOME_UNRELATED_VAR: 'x' })).toBe(true)
   })
 })
 

--- a/apps/dashboard/src/lib/metrics/prometheus-exporter.ts
+++ b/apps/dashboard/src/lib/metrics/prometheus-exporter.ts
@@ -22,11 +22,11 @@
  */
 
 import type { ClickHouseConfig } from '@chm/clickhouse-client'
+import type { AlertStateStore } from '@/lib/health/alert-state-store'
+
 import { getClient } from '@chm/clickhouse-client'
 import { error as logError } from '@chm/logger'
-
 import { isCloudModeServer } from '@/lib/cloud/cloud-mode'
-import type { AlertStateStore } from '@/lib/health/alert-state-store'
 import { alertStateStore } from '@/lib/health/alert-state-store'
 
 const CACHE_TTL_MS = 30_000
@@ -263,7 +263,9 @@ async function collectHostMetrics(
   }
 }
 
-async function buildScrape(configs: readonly ClickHouseConfig[]): Promise<string> {
+async function buildScrape(
+  configs: readonly ClickHouseConfig[]
+): Promise<string> {
   const startedAt = Date.now()
   const alertCounts = countFiringAlertsByHost(alertStateStore)
   const perHost = await Promise.all(

--- a/apps/landing/src/lib/analytics.ts
+++ b/apps/landing/src/lib/analytics.ts
@@ -9,7 +9,10 @@
 // event-catalog philosophy, separate PostHog project). See
 // docs/content/operate/advanced/product-analytics.mdx.
 
-export type LandingAnalyticsEvent = 'landing_view' | 'pricing_view' | 'cta_click'
+export type LandingAnalyticsEvent =
+  | 'landing_view'
+  | 'pricing_view'
+  | 'cta_click'
 
 type LandingAnalyticsProps = Record<string, string>
 
@@ -18,8 +21,10 @@ type PostHogModule = typeof import('posthog-js').default
 let posthogInstance: PostHogModule | null = null
 let disabled = false
 const MAX_PENDING = 20
-const pending: { event: LandingAnalyticsEvent; props: LandingAnalyticsProps }[] =
-  []
+const pending: {
+  event: LandingAnalyticsEvent
+  props: LandingAnalyticsProps
+}[] = []
 
 function isBrowserDoNotTrack(): boolean {
   return typeof navigator !== 'undefined' && navigator.doNotTrack === '1'


### PR DESCRIPTION
## Summary
Two repo-health fixes to get `main`'s dependency-boundary + format gates green:

1. **Break a circular dependency** introduced by plan 48: `baseline-store.ts` ↔ `statistical-baseline.ts` (`no-circular` depcruise error). Extracted the shared types into a leaf `baseline-types.ts`; re-exported from `statistical-baseline` so consumers are unchanged. No behavior change.
2. **Clear format drift** from plans 35/48/51/62 (their agents ran `bun run lint` but not `bun run check`, which also formats) — was failing the pre-push `check` gate. Pure formatting, no behavior change.

## Verification
depcruise → baseline cycle gone · `bunx biome check .` → clean (1933 files) · dashboard `type-check` ✅ · `bun test src/lib/insights` 321 pass ✅ · `bun run lint` ✅ · pre-push hook (check + test:unit + test:packages) passed.

Co-Authored-By: duyetbot <bot@duyet.net>