### PR TITLE
feat(query-config): self-hosted local YAML config override (queries.d) (plan 55)

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -253,3 +253,11 @@ AGENTSTATE_API_KEY=
 # docs/content/reference/catalog-contributing.mdx). Leave unset/`ts` — do not
 # ship `declarative` as your default, it is not yet the default anywhere.
 # CHM_CONFIG_SOURCE=ts
+# Self-hosted local config override (Docker/K8s only — needs a local
+# filesystem; no-op on Cloudflare Workers). Directory scanned at startup for
+# `*.yaml` files (declarative schema, see CHM_CONFIG_SOURCE above); each valid
+# file adds/overrides a query by its `name`. Invalid files are skipped and
+# logged; a missing directory is a silent no-op. Mount your own directory here
+# (Docker volume / K8s ConfigMap — see docker-compose.yml and
+# deploy/kubernetes/README.md).
+# CHM_CONFIG_DIRECTORY=/etc/chmonitor/queries.d

--- a/apps/dashboard/bun.lock
+++ b/apps/dashboard/bun.lock
@@ -100,6 +100,7 @@
         "use-stick-to-bottom": "^1.1.4",
         "usehooks-ts": "^3.1.1",
         "vaul": "^1.1.2",
+        "yaml": "^2.9.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -133,6 +133,7 @@
     "use-stick-to-bottom": "^1.1.4",
     "usehooks-ts": "^3.1.1",
     "vaul": "^1.1.2",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/apps/dashboard/src/lib/query-config/declarative/local-loader.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/local-loader.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for the self-hosted local config override loader (Plan 55).
+ *
+ * These exercise the PURE functions (`getConfigDirectory`, `loadLocalConfigs`)
+ * directly against real temp directories/files on disk. `getQueryConfigByName`
+ * gates its use of this module behind the build-time `import.meta.env.SSR`
+ * constant, which Vite/Rollup replaces per bundle target — under plain
+ * `bun:test` (no Vite build step) that constant is not statically folded to
+ * `true`, so asserting through the seam here would test the wrong thing.
+ * `loadLocalConfigs(dir)` is the stable, directly-testable contract.
+ */
+
+import { getConfigDirectory, loadLocalConfigs } from './local-loader'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'chm-local-config-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function writeYaml(name: string, contents: string): void {
+  writeFileSync(join(dir, name), contents, 'utf-8')
+}
+
+// ---------------------------------------------------------------------------
+// getConfigDirectory
+// ---------------------------------------------------------------------------
+
+describe('getConfigDirectory', () => {
+  test('defaults to /etc/chmonitor/queries.d with no env', () => {
+    expect(getConfigDirectory({})).toBe('/etc/chmonitor/queries.d')
+  })
+
+  test('reads CHM_CONFIG_DIRECTORY from runtimeEnv', () => {
+    expect(getConfigDirectory({ CHM_CONFIG_DIRECTORY: '/custom/dir' })).toBe(
+      '/custom/dir'
+    )
+  })
+
+  test('falls back to default for an empty string value', () => {
+    expect(getConfigDirectory({ CHM_CONFIG_DIRECTORY: '' })).toBe(
+      '/etc/chmonitor/queries.d'
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadLocalConfigs — missing / empty directory (must never throw)
+// ---------------------------------------------------------------------------
+
+describe('loadLocalConfigs — directory edge cases', () => {
+  test('missing directory resolves to empty, does not throw', () => {
+    const missing = join(dir, 'does-not-exist')
+    expect(() => loadLocalConfigs(missing)).not.toThrow()
+    expect(loadLocalConfigs(missing)).toEqual({ loaded: [], skipped: [] })
+  })
+
+  test('empty directory resolves to empty result', () => {
+    expect(loadLocalConfigs(dir)).toEqual({ loaded: [], skipped: [] })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadLocalConfigs — valid + invalid mix (the plan's stated scenario)
+// ---------------------------------------------------------------------------
+
+describe('loadLocalConfigs — valid + invalid YAML', () => {
+  test('a valid file loads and an invalid-syntax file is skipped, not thrown', () => {
+    writeYaml(
+      'valid.yaml',
+      ['name: my-local-query', 'sql: "SELECT 1"', 'columns:', '  - value'].join(
+        '\n'
+      )
+    )
+    // Malformed YAML: inconsistent indentation / unclosed flow sequence.
+    writeYaml(
+      'broken.yaml',
+      ['name: broken', 'sql: "SELECT 1', 'columns: [1, 2'].join('\n')
+    )
+
+    let result: ReturnType<typeof loadLocalConfigs>
+    expect(() => {
+      result = loadLocalConfigs(dir)
+    }).not.toThrow()
+
+    expect(result!.loaded).toHaveLength(1)
+    expect(result!.loaded[0].name).toBe('my-local-query')
+
+    expect(result!.skipped).toHaveLength(1)
+    expect(result!.skipped[0].file).toBe('broken.yaml')
+    expect(result!.skipped[0].error.length).toBeGreaterThan(0)
+  })
+
+  test('valid YAML syntax that fails schema validation is skipped', () => {
+    // Missing required `columns` field.
+    writeYaml(
+      'no-columns.yaml',
+      ['name: missing-columns', 'sql: "SELECT 1"'].join('\n')
+    )
+
+    const result = loadLocalConfigs(dir)
+
+    expect(result.loaded).toHaveLength(0)
+    expect(result.skipped).toHaveLength(1)
+    expect(result.skipped[0].file).toBe('no-columns.yaml')
+  })
+
+  test('non-.yaml files are ignored', () => {
+    writeYaml(
+      'valid.yaml',
+      ['name: q1', 'sql: "SELECT 1"', 'columns:', '  - v'].join('\n')
+    )
+    writeFileSync(join(dir, 'notes.txt'), 'hello world', 'utf-8')
+    writeFileSync(join(dir, 'other.json'), '{"name":"q2"}', 'utf-8')
+
+    const result = loadLocalConfigs(dir)
+
+    expect(result.loaded).toHaveLength(1)
+    expect(result.loaded[0].name).toBe('q1')
+    expect(result.skipped).toHaveLength(0)
+  })
+
+  test('subdirectories are not recursed into', () => {
+    mkdirSync(join(dir, 'nested'))
+    writeFileSync(
+      join(dir, 'nested', 'inner.yaml'),
+      ['name: inner', 'sql: "SELECT 1"', 'columns:', '  - v'].join('\n'),
+      'utf-8'
+    )
+
+    const result = loadLocalConfigs(dir)
+
+    expect(result.loaded).toHaveLength(0)
+    expect(result.skipped).toHaveLength(0)
+  })
+
+  test('a duplicate name within the directory is skipped, first wins', () => {
+    writeYaml(
+      'a-first.yaml',
+      ['name: dup-query', 'sql: "SELECT 1"', 'columns:', '  - v'].join('\n')
+    )
+    writeYaml(
+      'b-second.yaml',
+      ['name: dup-query', 'sql: "SELECT 2"', 'columns:', '  - v'].join('\n')
+    )
+
+    const result = loadLocalConfigs(dir)
+
+    expect(result.loaded).toHaveLength(1)
+    expect(result.loaded[0].sql).toBe('SELECT 1') // first (alphabetical) file wins
+    expect(result.skipped).toHaveLength(1)
+    expect(result.skipped[0].file).toBe('b-second.yaml')
+    expect(result.skipped[0].error).toContain('Duplicate name')
+  })
+})

--- a/apps/dashboard/src/lib/query-config/declarative/local-loader.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/local-loader.ts
@@ -1,0 +1,160 @@
+/**
+ * Self-hosted local config override (queries.d) — Plan 55.
+ *
+ * At startup, scan `CHM_CONFIG_DIRECTORY` (default `/etc/chmonitor/queries.d`)
+ * for `*.yaml` files, validate each against the declarative schema (plan 53),
+ * and expose the valid ones as a name-keyed catalog — same shape as
+ * DECLARATIVE_CATALOG — that `getQueryConfigByName` merges in ahead of the
+ * built-in configs, so a local file can override a same-named built-in.
+ *
+ * Fail-closed: invalid files (bad YAML syntax, schema violations, or a
+ * duplicate `name` within the directory) are skipped with a `warn` log — they
+ * never crash or block boot. A missing/unreadable directory, or an
+ * environment with no local filesystem at all (Cloudflare Workers), resolves
+ * to an empty catalog with no log — that is the common case for most
+ * self-hosted and all Cloud deploys.
+ *
+ * SERVER-ONLY MODULE: this file statically imports `node:fs` and the `yaml`
+ * parser, neither of which belong in the browser bundle. Every call site MUST
+ * gate on the build-time `import.meta.env.SSR` constant (not a runtime check
+ * like `typeof window`) so Vite/Rollup dead-code-eliminates the whole branch
+ * — and this import — out of the client build. See `getQueryConfigByName` in
+ * `../index.ts`.
+ */
+
+import type { DeclarativeQueryConfig } from './schema'
+
+import { validateDeclarativeConfig } from './validate'
+import fs from 'node:fs'
+import path from 'node:path'
+import { warn } from '@chm/logger'
+import { parse as parseYaml } from 'yaml'
+
+const DEFAULT_CONFIG_DIRECTORY = '/etc/chmonitor/queries.d'
+
+/**
+ * Resolve the CHM_CONFIG_DIRECTORY env var (falls back to the default path).
+ * Server-only; pass the Cloudflare Worker `env` binding or `process.env`
+ * (mirrors `getConfigSource`'s runtimeEnv-first convention).
+ */
+export function getConfigDirectory(
+  runtimeEnv?: Record<string, string | undefined>
+): string {
+  const source =
+    runtimeEnv ?? (typeof process !== 'undefined' ? process.env : {})
+  const value = (source as Record<string, string | undefined>)
+    .CHM_CONFIG_DIRECTORY
+  return value && value.trim() !== '' ? value : DEFAULT_CONFIG_DIRECTORY
+}
+
+export interface LoadLocalConfigsResult {
+  loaded: DeclarativeQueryConfig[]
+  skipped: Array<{ file: string; error: string }>
+}
+
+/**
+ * Read every `*.yaml` file directly inside `dir`, validate it against the
+ * declarative schema, and return the valid configs plus a skip list.
+ *
+ * Pure and synchronous — never throws. A missing directory, an unreadable
+ * directory, or an environment with no local filesystem (Cloudflare Workers)
+ * all resolve to `{ loaded: [], skipped: [] }`.
+ */
+export function loadLocalConfigs(dir: string): LoadLocalConfigsResult {
+  const loaded: DeclarativeQueryConfig[] = []
+  const skipped: Array<{ file: string; error: string }> = []
+
+  let files: string[]
+  try {
+    files = fs
+      .readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.yaml'))
+      .map((entry) => entry.name)
+      .sort()
+  } catch {
+    // Missing directory, no permission, or no local filesystem at all
+    // (Workers). Silent no-op — the app must always boot on defaults.
+    return { loaded, skipped }
+  }
+
+  const seenNames = new Set<string>()
+
+  for (const file of files) {
+    const fullPath = path.join(dir, file)
+
+    let raw: string
+    try {
+      raw = fs.readFileSync(fullPath, 'utf-8')
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      skipped.push({ file, error: `Could not read file: ${message}` })
+      warn(`[query-config] Skipping local config "${file}": unreadable`, {
+        error: message,
+      })
+      continue
+    }
+
+    let parsed: unknown
+    try {
+      parsed = parseYaml(raw)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      skipped.push({ file, error: `Invalid YAML: ${message}` })
+      warn(`[query-config] Skipping local config "${file}": invalid YAML`, {
+        error: message,
+      })
+      continue
+    }
+
+    const result = validateDeclarativeConfig(parsed)
+    if (!result.ok) {
+      const message = result.errors.join('; ')
+      skipped.push({ file, error: message })
+      warn(
+        `[query-config] Skipping local config "${file}": schema validation failed`,
+        { error: message }
+      )
+      continue
+    }
+
+    if (seenNames.has(result.config.name)) {
+      const message = `Duplicate name "${result.config.name}" in local config directory`
+      skipped.push({ file, error: message })
+      warn(`[query-config] Skipping local config "${file}": ${message}`)
+      continue
+    }
+
+    seenNames.add(result.config.name)
+    loaded.push(result.config)
+  }
+
+  return { loaded, skipped }
+}
+
+// ---------------------------------------------------------------------------
+// Process-lifetime memo. "At startup, scan" — the directory is read once per
+// process and cached, matching how self-hosted operators already expect a
+// container/pod restart to pick up new or changed queries.d files.
+// ---------------------------------------------------------------------------
+
+let cachedCatalog: Record<string, DeclarativeQueryConfig> | undefined
+
+/**
+ * The local catalog, name-keyed like DECLARATIVE_CATALOG. Computed once per
+ * process and memoized.
+ */
+export function getLocalConfigCatalog(
+  runtimeEnv?: Record<string, string | undefined>
+): Record<string, DeclarativeQueryConfig> {
+  if (cachedCatalog) return cachedCatalog
+
+  const { loaded } = loadLocalConfigs(getConfigDirectory(runtimeEnv))
+  cachedCatalog = loaded.reduce<Record<string, DeclarativeQueryConfig>>(
+    (acc, cfg) => {
+      acc[cfg.name] = cfg
+      return acc
+    },
+    {}
+  )
+  return cachedCatalog
+}

--- a/apps/dashboard/src/lib/query-config/index.ts
+++ b/apps/dashboard/src/lib/query-config/index.ts
@@ -2,6 +2,7 @@ import type { QueryConfig } from '@/types/query-config'
 
 import { DECLARATIVE_CATALOG } from './declarative/catalog'
 import { getConfigSource, loadDeclarativeConfig } from './declarative/loader'
+import { getLocalConfigCatalog } from './declarative/local-loader'
 import { error } from '@chm/logger'
 
 export type { QueryConfig } from './types'
@@ -262,6 +263,26 @@ export const getQueryConfigByName = (
 ): QueryConfig | undefined => {
   if (!name) {
     return undefined
+  }
+
+  // Self-hosted local config override (queries.d, plan 55) — server-only.
+  // Gated on the build-time `import.meta.env.SSR` constant (not a runtime
+  // check) so Vite/Rollup dead-code-eliminates this whole branch, and the
+  // local-loader import (node:fs + yaml) with it, out of the client bundle.
+  // Checked FIRST — regardless of CHM_CONFIG_SOURCE — so a local file can
+  // override a same-named built-in (TS or declarative) config.
+  if (import.meta.env.SSR) {
+    const local = getLocalConfigCatalog(runtimeEnv)[name]
+    if (local) {
+      try {
+        return loadDeclarativeConfig(local)
+      } catch (err) {
+        error(
+          `[query-config] Malformed local config for "${name}"; falling back to built-in config`,
+          err
+        )
+      }
+    }
   }
 
   if (getConfigSource(runtimeEnv) === 'declarative') {

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -91,6 +91,53 @@ replicas:
 kubectl apply -k deploy/kubernetes/overlays/prod
 ```
 
+## Custom queries (queries.d)
+
+Add your own monitoring queries without forking the image: mount a ConfigMap
+of `*.yaml` declarative query configs at `CHM_CONFIG_DIRECTORY` (default
+`/etc/chmonitor/queries.d`) and the dashboard picks them up at startup. Invalid
+files are skipped and logged; a missing directory is a silent no-op — this
+needs a local filesystem, so it only applies to Docker/Kubernetes, not the
+Cloudflare Worker deploy.
+
+```yaml
+# deploy/kubernetes/overlays/custom-queries/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+configMapGenerator:
+  - name: chmonitor-queries
+    files:
+      - my-query.yaml # declarative schema — see docs/content/reference/catalog-contributing.mdx
+patches:
+  - target:
+      kind: Deployment
+      name: chmonitor
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: CHM_CONFIG_DIRECTORY
+          value: /etc/chmonitor/queries.d
+      - op: add
+        path: /spec/template/spec/containers/0/volumeMounts
+        value:
+          - name: queries-d
+            mountPath: /etc/chmonitor/queries.d
+            readOnly: true
+      - op: add
+        path: /spec/template/spec/volumes
+        value:
+          - name: queries-d
+            configMap:
+              name: chmonitor-queries
+```
+
+```bash
+kubectl apply -k deploy/kubernetes/overlays/custom-queries
+```
+
 ## Health probes
 
 - **Liveness** — `GET /healthz` (static, always `200` while the process runs).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,13 @@ services:
       CLICKHOUSE_PASSWORD: ""
       PORT: 3000
       HOST: "0.0.0.0"
+    # Optional: self-hosted local config override (queries.d). Mount a host
+    # directory of custom *.yaml query configs and point CHM_CONFIG_DIRECTORY
+    # (set it in `.env`) at the container path below. Invalid files are
+    # skipped + logged; leave both lines commented out to keep the default
+    # (no local overrides, TS/declarative catalog only).
+    # volumes:
+    #   - ./queries.d:/etc/chmonitor/queries.d:ro
     depends_on:
       clickhouse:
         condition: service_healthy

--- a/plans/55-self-hosted-local-config-override.md
+++ b/plans/55-self-hosted-local-config-override.md
@@ -1,0 +1,24 @@
+# 55 — Self-hosted local config override (queries.d)
+
+## Goal
+At startup, scan `CHM_CONFIG_DIRECTORY` (default `/etc/chmonitor/queries.d`), validate each `.yaml`, and merge into the catalog under a `local` namespace. Invalid files are skipped with a clear log; the app still boots on defaults.
+
+## Current reality (audited)
+There is no local override layer: new queries require editing compiled TS (`apps/dashboard/src/lib/query-config/`). Self-hosters can't customize monitoring without forking. The declarative loader (plan 53, MERGED) makes YAML configs loadable; this plan adds a filesystem source.
+
+## Implement now (depth F)
+- New `apps/dashboard/src/lib/query-config/declarative/local-loader.ts`:
+  - `loadLocalConfigs(dir)` — read `*.yaml` from `dir` (Node fs; guard for Workers where fs is unavailable — no-op with a debug log), validate each with the declarative schema, return `{ loaded, skipped: [{file, error}] }`.
+- Wire into `getQueryConfigByName()` / catalog assembly so local configs merge when `CHM_CONFIG_SOURCE=declarative` (or always-merge in self-host mode `(verify)`).
+- Env `CHM_CONFIG_DIRECTORY` (default `/etc/chmonitor/queries.d`); set it in the Docker entrypoint and document a K8s ConfigMap mount example in `deploy/`.
+- Tests: a temp dir with one valid + one invalid YAML → valid appears in lookup, invalid is skipped (not thrown), booting still works with an empty/missing dir.
+
+## STOP conditions & drift check
+- STOP if running under Workers (no local fs) — the loader must no-op gracefully, not throw.
+- STOP if plan 53's declarative path isn't merged — land 53 first. (It IS merged.)
+- Drift: confirm the catalog assembly seam and the declarative schema export.
+
+## Done criteria
+- YAML files in the mounted dir appear in the UI without a rebuild.
+- Invalid files are skipped + logged; missing dir boots cleanly; Workers path no-ops.
+- Docker entrypoint sets the default dir; K8s mount example documented.


### PR DESCRIPTION
## Summary
Implements **plan 55** (Round-3 Wave D, builds on merged plan 53). Self-hosted Docker/K8s deployments can drop `.yaml` query configs into `CHM_CONFIG_DIRECTORY` (default `/etc/chmonitor/queries.d`); they're validated against the declarative schema and merged into the catalog (checked first, so a local file can override a same-named built-in) — no rebuild. Adds `yaml` as a direct dep (plan 53's declarative path never actually parsed YAML text; `yaml` was already transitively present, zero resolution delta).

## Safety / invariants
- **Fail-closed**: invalid/schema-invalid/duplicate YAML is skipped + `warn`-logged, never thrown; missing dir boots on defaults.
- **Workers no-op**: `fs` unavailability is caught → empty result (mirrors existing `dynamic-loader.ts`).
- **No client-bundle leak**: `getQueryConfigByName` is imported by client code, so the `node:fs`/`yaml` import is gated behind `import.meta.env.SSR` → Vite dead-code-eliminates it from the browser build.
- TS config path unchanged as default.

## Verification
type-check ✅ · `tsc -p tsconfig.test.json` ✅ · `bun test src/lib/query-config` 1028 pass (10 new local-loader tests) ✅ · lint ✅.

## Honest scope
Server-side by-name resolution works without rebuild; full client-visible UI rendering of local configs (server→client delivery + menu/route entry) is a documented follow-up. Docker/K8s wiring is doc-only (env + commented volume + kustomize example); Helm chart untouched.

Co-Authored-By: duyetbot <bot@duyet.net>