### PR TITLE
feat(dashboards): D1 persistence + read-only sharing, owner-scoped (plan 56)

### DIFF
--- a/apps/dashboard/src/components/dashboard/saved-dashboards-toolbar.tsx
+++ b/apps/dashboard/src/components/dashboard/saved-dashboards-toolbar.tsx
@@ -1,8 +1,11 @@
 /**
  * SavedDashboardsToolbar
  *
- * Toolbar for managing saved dashboard configurations in localStorage.
- * Provides load, save, and delete operations via simple UI controls.
+ * Toolbar for managing saved dashboard configurations. Persists to D1 (per
+ * signed-in owner, synced across devices) when server-side dashboard storage
+ * is enabled, else falls back to localStorage — see
+ * `@/lib/dashboard-storage`. Provides load, save, and delete operations via
+ * simple UI controls.
  */
 
 import { BookmarkIcon, TrashIcon } from '@radix-ui/react-icons'
@@ -37,42 +40,56 @@ export function SavedDashboardsToolbar({
   const [savedNames, setSavedNames] = useState<string[]>([])
   const [activeName, setActiveName] = useState<string>('')
 
-  // Refresh the list from localStorage (runs client-side only)
-  const refreshList = () => {
-    setSavedNames(listDashboards())
+  // Refresh the list (D1 or localStorage, depending on backend).
+  const refreshList = async () => {
+    setSavedNames(await listDashboards())
   }
 
   // Load the saved list on mount (inline to keep an empty dependency array).
   useEffect(() => {
-    setSavedNames(listDashboards())
+    let cancelled = false
+    listDashboards().then((names) => {
+      if (!cancelled) setSavedNames(names)
+    })
+    return () => {
+      cancelled = true
+    }
   }, [])
 
-  function handleLoad(name: string) {
-    const charts = loadDashboard(name)
+  async function handleLoad(name: string) {
+    const charts = await loadDashboard(name)
     if (charts) {
       setActiveName(name)
       onLoad(charts)
     }
   }
 
-  function handleSave() {
+  async function handleSave() {
     if (selectedCharts.length === 0) {
       alert('Add at least one chart before saving.')
       return
     }
     const name = window.prompt('Dashboard name:')?.trim()
     if (!name) return
-    saveDashboard(name, selectedCharts)
-    setActiveName(name)
-    refreshList()
+    try {
+      await saveDashboard(name, selectedCharts)
+      setActiveName(name)
+      await refreshList()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to save dashboard.')
+    }
   }
 
-  function handleDelete() {
+  async function handleDelete() {
     if (!activeName) return
     if (!window.confirm(`Delete "${activeName}"?`)) return
-    deleteDashboard(activeName)
-    setActiveName('')
-    refreshList()
+    try {
+      await deleteDashboard(activeName)
+      setActiveName('')
+      await refreshList()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to delete dashboard.')
+    }
   }
 
   return (

--- a/apps/dashboard/src/db/conversations-migrations/0010_dashboards.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0010_dashboards.sql
@@ -1,0 +1,32 @@
+-- Per-owner saved dashboards (Chart Builder layouts) with optional read-only
+-- sharing. Mirrors the conversations table's ownership model: `id` is the
+-- globally-unique internal primary key (never client-supplied — minted
+-- server-side), `owner_id` scopes every read/write, and `(owner_id, name)` is
+-- unique so a save-by-name upsert can look up the existing row efficiently
+-- (preserving the localStorage-era "same name overwrites" behavior).
+--
+-- `share_slug` is a high-entropy random token (crypto.randomUUID()), never
+-- derived from `id`/`name`. The partial unique index guarantees two shared
+-- dashboards can never collide on the same slug (NULL slugs — the common,
+-- unshared case — are excluded from the uniqueness check).
+-- See plans/56-dashboard-d1-persistence-sharing.md.
+
+CREATE TABLE IF NOT EXISTS dashboards (
+  id TEXT PRIMARY KEY,
+  owner_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  layout_json TEXT NOT NULL,
+  is_shared INTEGER NOT NULL DEFAULT 0,
+  share_slug TEXT,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_dashboards_owner_id
+  ON dashboards(owner_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_dashboards_owner_name
+  ON dashboards(owner_id, name);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_dashboards_share_slug
+  ON dashboards(share_slug)
+  WHERE share_slug IS NOT NULL;

--- a/apps/dashboard/src/lib/dashboard-storage/auth.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/auth.ts
@@ -1,0 +1,37 @@
+/**
+ * Authentication for dashboard storage (server-only).
+ * Dashboards are scoped to the signed-in Clerk user — never shared org-wide.
+ *
+ * Mirrors `connection-store/auth.ts`: a thin wrapper around
+ * `conversation-store/auth.ts`'s `resolveUserId`, translating its error type
+ * to this domain's `DashboardStoreError`. Reused rather than forked — see
+ * plans/56-dashboard-d1-persistence-sharing.md.
+ */
+
+import { DashboardStoreError } from './types'
+import { resolveUserId } from '@/lib/conversation-store/auth'
+import { ConversationStoreError } from '@/lib/conversation-store/types'
+
+/**
+ * Resolves the current Clerk user id for dashboard store operations.
+ * Fails closed when auth is missing or invalid.
+ */
+export async function resolveDashboardOwnerId(
+  request?: Request
+): Promise<string> {
+  try {
+    return await resolveUserId(request)
+  } catch (error) {
+    if (
+      error instanceof ConversationStoreError &&
+      error.code === 'UNAUTHORIZED'
+    ) {
+      throw new DashboardStoreError(
+        'Authentication is required for dashboard storage.',
+        'UNAUTHORIZED',
+        error
+      )
+    }
+    throw error
+  }
+}

--- a/apps/dashboard/src/lib/dashboard-storage/d1-store.sql.test.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/d1-store.sql.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Proves the production D1 SQL for dashboards enforces owner scoping on both
+ * the write path (upsert) and the read path (get-by-name), and that the
+ * public share-slug read only ever returns a dashboard that is actually
+ * shared.
+ *
+ * Mirrors `conversation-store/d1-store.sql.test.ts`: runs the exact exported
+ * SQL strings against `bun:sqlite` (SQLite is D1's underlying engine) rather
+ * than re-deriving the guard logic in the test.
+ */
+
+import { Database } from 'bun:sqlite'
+import { describe, expect, mock, test } from 'bun:test'
+
+// d1-store.ts imports `getPlatformBindings` from '@chm/platform', which
+// resolves (via the tsconfig path alias) to a Cloudflare-only virtual module
+// `bun test` doesn't provide. Mock it before importing, mirroring
+// conversation-store's established pattern. The D1 binding value is
+// irrelevant here — this file only needs the exported SQL string constants.
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({
+    getD1Database: () => undefined,
+  }),
+}))
+
+const {
+  D1_UPSERT_DASHBOARD_SQL,
+  D1_GET_DASHBOARD_BY_NAME_SQL,
+  D1_GET_DASHBOARD_BY_SLUG_SQL,
+} = await import('./d1-store')
+
+function seed() {
+  const db = new Database(':memory:')
+  // Mirrors db/conversations-migrations/0010_dashboards.sql
+  db.run(`CREATE TABLE dashboards (
+    id TEXT PRIMARY KEY, owner_id TEXT NOT NULL, name TEXT NOT NULL,
+    layout_json TEXT NOT NULL, is_shared INTEGER NOT NULL DEFAULT 0,
+    share_slug TEXT, updated_at INTEGER NOT NULL)`)
+  db.run(
+    `INSERT INTO dashboards VALUES ('d1','owner-a','Overview','["chart1","chart2"]',0,NULL,1)`
+  )
+  return db
+}
+// Bind order for the upsert must match ?1..?7:
+// (id, owner_id, name, layout_json, is_shared, share_slug, updated_at)
+
+describe('dashboards — write-path IDOR guard (real SQL)', () => {
+  test('a foreign owner cannot overwrite/seize the row; changes === 0', () => {
+    const db = seed()
+    const res = db
+      .query(D1_UPSERT_DASHBOARD_SQL)
+      .run('d1', 'owner-b', 'hijacked', '["evil"]', 0, null, 2)
+    expect(res.changes).toBe(0) // guard blocked the update
+
+    const row = db
+      .query(`SELECT owner_id, name, layout_json FROM dashboards WHERE id='d1'`)
+      .get() as { owner_id: string; name: string; layout_json: string }
+    expect(row.owner_id).toBe('owner-a') // ownership intact
+    expect(row.name).toBe('Overview') // content intact
+    expect(row.layout_json).toBe('["chart1","chart2"]')
+  })
+
+  test('the owner can update; changes === 1', () => {
+    const db = seed()
+    const res = db
+      .query(D1_UPSERT_DASHBOARD_SQL)
+      .run(
+        'd1',
+        'owner-a',
+        'Overview',
+        '["chart1","chart2","chart3"]',
+        0,
+        null,
+        3
+      )
+    expect(res.changes).toBe(1)
+    expect(
+      (
+        db.query(`SELECT layout_json FROM dashboards WHERE id='d1'`).get() as {
+          layout_json: string
+        }
+      ).layout_json
+    ).toBe('["chart1","chart2","chart3"]')
+  })
+
+  test('a new id inserts; changes === 1', () => {
+    const db = seed()
+    expect(
+      db
+        .query(D1_UPSERT_DASHBOARD_SQL)
+        .run('d2', 'owner-b', 'My Dash', '[]', 0, null, 4).changes
+    ).toBe(1)
+  })
+})
+
+describe('dashboards — read-path IDOR guard (real SQL)', () => {
+  test('owner A cannot read owner B-owned dashboard, even by the right name', () => {
+    const db = seed() // 'Overview' is owned by owner-a
+    const row = db
+      .query(D1_GET_DASHBOARD_BY_NAME_SQL)
+      .get('owner-b', 'Overview') // owner-b queries for owner-a's dashboard name
+    expect(row).toBeNull()
+  })
+
+  test('the owner can read their own dashboard by name', () => {
+    const db = seed()
+    const row = db
+      .query(D1_GET_DASHBOARD_BY_NAME_SQL)
+      .get('owner-a', 'Overview') as { name: string; owner_id: string } | null
+    expect(row).not.toBeNull()
+    expect(row?.name).toBe('Overview')
+    expect(row?.owner_id).toBe('owner-a')
+  })
+
+  test('a name that does not exist for that owner returns null', () => {
+    const db = seed()
+    const row = db
+      .query(D1_GET_DASHBOARD_BY_NAME_SQL)
+      .get('owner-a', 'Nonexistent')
+    expect(row).toBeNull()
+  })
+})
+
+describe('dashboards — public share-slug read (real SQL)', () => {
+  test('an unshared dashboard is never returned by slug, even if the slug is known', () => {
+    const db = seed()
+    db.run(`UPDATE dashboards SET share_slug = 'guessed-slug' WHERE id = 'd1'`) // slug set but is_shared stays 0
+    const row = db.query(D1_GET_DASHBOARD_BY_SLUG_SQL).get('guessed-slug')
+    expect(row).toBeNull()
+  })
+
+  test('a shared dashboard is returned by its slug with only name + layout_json', () => {
+    const db = seed()
+    db.run(
+      `UPDATE dashboards SET is_shared = 1, share_slug = 'real-slug' WHERE id = 'd1'`
+    )
+    const row = db
+      .query(D1_GET_DASHBOARD_BY_SLUG_SQL)
+      .get('real-slug') as Record<string, unknown> | null
+    expect(row).not.toBeNull()
+    expect(row?.name).toBe('Overview')
+    expect(row?.layout_json).toBe('["chart1","chart2"]')
+    // The projection must never leak owner identity.
+    expect(Object.keys(row ?? {}).sort()).toEqual(['layout_json', 'name'])
+  })
+
+  test('revoking (is_shared=0) makes the old slug resolve to nothing', () => {
+    const db = seed()
+    db.run(
+      `UPDATE dashboards SET is_shared = 1, share_slug = 'was-shared' WHERE id = 'd1'`
+    )
+    db.run(`UPDATE dashboards SET is_shared = 0 WHERE id = 'd1'`) // revoke, slug left stale for this test
+    const row = db.query(D1_GET_DASHBOARD_BY_SLUG_SQL).get('was-shared')
+    expect(row).toBeNull()
+  })
+
+  test('an unknown slug returns null', () => {
+    const db = seed()
+    const row = db.query(D1_GET_DASHBOARD_BY_SLUG_SQL).get('does-not-exist')
+    expect(row).toBeNull()
+  })
+})

--- a/apps/dashboard/src/lib/dashboard-storage/d1-store.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/d1-store.ts
@@ -1,0 +1,304 @@
+/**
+ * D1-based dashboard storage for Cloudflare Workers (server-only).
+ *
+ * Server-only: imports `@chm/platform`, which resolves to
+ * `cloudflare:workers` bindings. Never import this module from client code —
+ * `dashboard-storage/index.ts` (the client-facing entrypoint) must reach it
+ * only indirectly, through the `/api/dashboards/*` route handlers.
+ */
+
+import type {
+  DashboardStore,
+  PublicSharedDashboard,
+  StoredDashboard,
+} from './types'
+
+import { DashboardStoreError } from './types'
+import { getPlatformBindings } from '@chm/platform'
+
+const D1_BINDING_NAME = 'CHM_CLOUD_D1'
+
+/**
+ * D1 database row shape.
+ */
+interface D1DashboardRow {
+  id: string
+  owner_id: string
+  name: string
+  layout_json: string
+  is_shared: number
+  share_slug: string | null
+  updated_at: number
+}
+
+/**
+ * Upsert SQL for the `dashboards` table.
+ *
+ * Mirrors `conversation-store/d1-store.ts`'s `D1_UPSERT_CONVERSATION_SQL`:
+ * the `ON CONFLICT` update excludes `owner_id` from `SET` and guards the
+ * update with a `WHERE` clause so a conflicting row owned by a different
+ * owner is never touched (0 `changes`) rather than reassigned to the caller.
+ *
+ * In practice the `id` passed in is never client-supplied (see
+ * `saveByName`/`setSharing` below), so this guard is defense-in-depth rather
+ * than the primary protection — kept to match the reused, already-proven
+ * pattern rather than fork a weaker one.
+ *
+ * Exported so `d1-store.sql.test.ts` can run this exact string against
+ * `bun:sqlite` (SQLite is D1's engine).
+ */
+export const D1_UPSERT_DASHBOARD_SQL = `INSERT INTO dashboards (id, owner_id, name, layout_json, is_shared, share_slug, updated_at)
+   VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+   ON CONFLICT (id) DO UPDATE SET
+     name = excluded.name,
+     layout_json = excluded.layout_json,
+     is_shared = excluded.is_shared,
+     share_slug = excluded.share_slug,
+     updated_at = excluded.updated_at
+   WHERE dashboards.owner_id = excluded.owner_id`
+
+/**
+ * Owner-scoped single-row read by name. Exported so `d1-store.sql.test.ts`
+ * can prove a foreign owner's row is never returned (the IDOR read-scoping
+ * requirement) by running this exact string, not a re-derived guess.
+ */
+export const D1_GET_DASHBOARD_BY_NAME_SQL = `SELECT id, owner_id, name, layout_json, is_shared, share_slug, updated_at
+   FROM dashboards
+   WHERE owner_id = ?1 AND name = ?2`
+
+/**
+ * Public, unauthenticated read by share slug. Deliberately has NO owner_id
+ * in the WHERE clause or projection beyond what's needed — this is the one
+ * intentionally owner-unscoped query in this module. `is_shared = 1` means a
+ * revoked link (which also clears `share_slug` — see `setSharing`) can never
+ * match even if the slug value were somehow guessed.
+ */
+export const D1_GET_DASHBOARD_BY_SLUG_SQL = `SELECT name, layout_json
+   FROM dashboards
+   WHERE share_slug = ?1 AND is_shared = 1`
+
+function rowToDashboard(row: D1DashboardRow): StoredDashboard {
+  let charts: string[]
+  try {
+    const parsed = JSON.parse(row.layout_json)
+    charts = Array.isArray(parsed) ? (parsed as string[]) : []
+  } catch {
+    charts = []
+  }
+
+  return {
+    id: row.id,
+    ownerId: row.owner_id,
+    name: row.name,
+    charts,
+    isShared: row.is_shared === 1,
+    shareSlug: row.share_slug,
+    updatedAt: row.updated_at,
+  }
+}
+
+/**
+ * D1-based dashboard storage implementation. Mirrors
+ * `conversation-store/d1-store.ts`'s shape and guarantees.
+ */
+export class D1DashboardStore implements DashboardStore {
+  private getDb(): D1Database {
+    const db = getPlatformBindings().getD1Database(D1_BINDING_NAME)
+
+    if (!db) {
+      throw new DashboardStoreError(
+        'CHM_CLOUD_D1 binding not found. Ensure D1 database is configured in wrangler.toml',
+        'STORAGE_ERROR'
+      )
+    }
+
+    return db
+  }
+
+  async list(ownerId: string): Promise<StoredDashboard[]> {
+    try {
+      const db = this.getDb()
+
+      const result = await db
+        .prepare(
+          `SELECT id, owner_id, name, layout_json, is_shared, share_slug, updated_at
+           FROM dashboards
+           WHERE owner_id = ?1
+           ORDER BY name ASC`
+        )
+        .bind(ownerId)
+        .all<D1DashboardRow>()
+
+      return (result.results || []).map(rowToDashboard)
+    } catch (error) {
+      if (error instanceof DashboardStoreError) throw error
+      throw new DashboardStoreError(
+        `Failed to list dashboards: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        'STORAGE_ERROR',
+        error
+      )
+    }
+  }
+
+  async get(ownerId: string, name: string): Promise<StoredDashboard | null> {
+    try {
+      const db = this.getDb()
+
+      const row = await db
+        .prepare(D1_GET_DASHBOARD_BY_NAME_SQL)
+        .bind(ownerId, name)
+        .first<D1DashboardRow>()
+
+      return row ? rowToDashboard(row) : null
+    } catch (error) {
+      if (error instanceof DashboardStoreError) throw error
+      throw new DashboardStoreError(
+        `Failed to get dashboard: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        'STORAGE_ERROR',
+        error
+      )
+    }
+  }
+
+  async upsert(dashboard: StoredDashboard): Promise<{ written: boolean }> {
+    try {
+      const db = this.getDb()
+
+      const res = await db
+        .prepare(D1_UPSERT_DASHBOARD_SQL)
+        .bind(
+          dashboard.id,
+          dashboard.ownerId,
+          dashboard.name,
+          JSON.stringify(dashboard.charts),
+          dashboard.isShared ? 1 : 0,
+          dashboard.shareSlug,
+          dashboard.updatedAt
+        )
+        .run()
+
+      return { written: (res.meta?.changes ?? 0) > 0 }
+    } catch (error) {
+      throw new DashboardStoreError(
+        `Failed to upsert dashboard: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        'STORAGE_ERROR',
+        error
+      )
+    }
+  }
+
+  async saveByName(
+    ownerId: string,
+    name: string,
+    charts: string[]
+  ): Promise<StoredDashboard> {
+    const existing = await this.get(ownerId, name)
+    const now = Date.now()
+
+    const dashboard: StoredDashboard = existing
+      ? { ...existing, charts, updatedAt: now }
+      : {
+          id: crypto.randomUUID(),
+          ownerId,
+          name,
+          charts,
+          isShared: false,
+          shareSlug: null,
+          updatedAt: now,
+        }
+
+    const { written } = await this.upsert(dashboard)
+    if (!written) {
+      // Only reachable if the id (freshly minted or from an owner-scoped
+      // read) somehow belongs to another owner — should never happen, but
+      // fail loudly rather than silently return a record that wasn't saved.
+      throw new DashboardStoreError(
+        'Dashboard save was blocked (id ownership mismatch).',
+        'STORAGE_ERROR'
+      )
+    }
+
+    return dashboard
+  }
+
+  async delete(ownerId: string, name: string): Promise<void> {
+    try {
+      const db = this.getDb()
+
+      await db
+        .prepare(`DELETE FROM dashboards WHERE owner_id = ?1 AND name = ?2`)
+        .bind(ownerId, name)
+        .run()
+    } catch (error) {
+      throw new DashboardStoreError(
+        `Failed to delete dashboard: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        'STORAGE_ERROR',
+        error
+      )
+    }
+  }
+
+  async setSharing(
+    ownerId: string,
+    name: string,
+    shared: boolean
+  ): Promise<StoredDashboard | null> {
+    const existing = await this.get(ownerId, name)
+    if (!existing) return null
+
+    // Enabling is idempotent — an already-shared dashboard keeps its slug.
+    if (shared && existing.isShared && existing.shareSlug) {
+      return existing
+    }
+
+    const updated: StoredDashboard = {
+      ...existing,
+      isShared: shared,
+      // Revoking clears the slug in the same write as isShared=false, so a
+      // revoked link can never resurface. Enabling mints a fresh
+      // high-entropy slug — never derived from id/name.
+      shareSlug: shared ? crypto.randomUUID() : null,
+      updatedAt: Date.now(),
+    }
+
+    const { written } = await this.upsert(updated)
+    if (!written) {
+      throw new DashboardStoreError(
+        'Dashboard sharing update was blocked (id ownership mismatch).',
+        'STORAGE_ERROR'
+      )
+    }
+
+    return updated
+  }
+
+  async getByShareSlug(slug: string): Promise<PublicSharedDashboard | null> {
+    try {
+      const db = this.getDb()
+
+      const row = await db
+        .prepare(D1_GET_DASHBOARD_BY_SLUG_SQL)
+        .bind(slug)
+        .first<Pick<D1DashboardRow, 'name' | 'layout_json'>>()
+
+      if (!row) return null
+
+      let charts: string[]
+      try {
+        const parsed = JSON.parse(row.layout_json)
+        charts = Array.isArray(parsed) ? (parsed as string[]) : []
+      } catch {
+        charts = []
+      }
+
+      return { name: row.name, charts }
+    } catch (error) {
+      if (error instanceof DashboardStoreError) throw error
+      throw new DashboardStoreError(
+        `Failed to get shared dashboard: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        'STORAGE_ERROR',
+        error
+      )
+    }
+  }
+}

--- a/apps/dashboard/src/lib/dashboard-storage/index.test.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/index.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for the public `dashboard-storage` entrypoint's backend resolution:
+ *   - `featureFlags.conversationDb()` false (or throwing) → localStorage,
+ *     never calls the remote (D1-backed) API — the "D1-absent falls back to
+ *     localStorage" requirement.
+ *   - `featureFlags.conversationDb()` true → remote (D1-backed) API.
+ *   - Sharing is unavailable (throws) on the local-only backend, since a
+ *     single browser's localStorage has no server to serve a public link.
+ *
+ * Mirrors `conversation-store/resolve-store.test.ts`'s mock.module pattern:
+ * `./local-store` and `./remote-store` are mocked wholesale so this file
+ * tests only the resolution branch, not localStorage/fetch behavior (those
+ * are covered by `local-store.test.ts` and exercised end-to-end by the
+ * routes).
+ */
+
+import { describe, expect, mock, test } from 'bun:test'
+
+const mockConversationDb = mock(() => true)
+mock.module('@/lib/feature-flags', () => ({
+  featureFlags: {
+    conversationDb: mockConversationDb,
+  },
+}))
+
+const localCalls = {
+  list: mock(() => ['local-a', 'local-b']),
+  load: mock((_name: string) => ['chart-local']),
+  save: mock((_name: string, _charts: string[]) => {}),
+  del: mock((_name: string) => {}),
+}
+mock.module('./local-store', () => ({
+  listDashboardsLocal: localCalls.list,
+  loadDashboardLocal: localCalls.load,
+  saveDashboardLocal: localCalls.save,
+  deleteDashboardLocal: localCalls.del,
+}))
+
+const remoteCalls = {
+  list: mock(async () => ['remote-a']),
+  load: mock(async (_name: string) => ['chart-remote']),
+  save: mock(async (_name: string, _charts: string[]) => {}),
+  del: mock(async (_name: string) => {}),
+  share: mock(async (_name: string) => 'slug-123'),
+  unshare: mock(async (_name: string) => {}),
+}
+mock.module('./remote-store', () => ({
+  listDashboardsRemote: remoteCalls.list,
+  loadDashboardRemote: remoteCalls.load,
+  saveDashboardRemote: remoteCalls.save,
+  deleteDashboardRemote: remoteCalls.del,
+  shareDashboardRemote: remoteCalls.share,
+  unshareDashboardRemote: remoteCalls.unshare,
+}))
+
+const {
+  resolveDashboardBackend,
+  listDashboards,
+  loadDashboard,
+  saveDashboard,
+  deleteDashboard,
+  shareDashboard,
+  unshareDashboard,
+} = await import('./index')
+
+function resetMocks() {
+  mockConversationDb.mockReset()
+  mockConversationDb.mockReturnValue(true)
+  for (const fn of Object.values(localCalls)) fn.mockClear()
+  for (const fn of Object.values(remoteCalls)) fn.mockClear()
+}
+
+describe('resolveDashboardBackend', () => {
+  test('returns "d1" when conversationDb() is true', () => {
+    resetMocks()
+    expect(resolveDashboardBackend()).toBe('d1')
+  })
+
+  test('returns "local" when conversationDb() is false', () => {
+    resetMocks()
+    mockConversationDb.mockReturnValue(false)
+    expect(resolveDashboardBackend()).toBe('local')
+  })
+
+  test('returns "local" when conversationDb() throws (fail-open)', () => {
+    resetMocks()
+    mockConversationDb.mockImplementation(() => {
+      throw new Error('Clerk enablement check failed')
+    })
+    expect(resolveDashboardBackend()).toBe('local')
+  })
+})
+
+describe('D1-absent falls back to localStorage', () => {
+  test('listDashboards() uses the local store and never calls remote', async () => {
+    resetMocks()
+    mockConversationDb.mockReturnValue(false)
+    const result = await listDashboards()
+    expect(result).toEqual(['local-a', 'local-b'])
+    expect(localCalls.list).toHaveBeenCalledTimes(1)
+    expect(remoteCalls.list).not.toHaveBeenCalled()
+  })
+
+  test('loadDashboard() uses the local store and never calls remote', async () => {
+    resetMocks()
+    mockConversationDb.mockReturnValue(false)
+    const result = await loadDashboard('myDash')
+    expect(result).toEqual(['chart-local'])
+    expect(localCalls.load).toHaveBeenCalledWith('myDash')
+    expect(remoteCalls.load).not.toHaveBeenCalled()
+  })
+
+  test('saveDashboard() uses the local store and never calls remote', async () => {
+    resetMocks()
+    mockConversationDb.mockReturnValue(false)
+    await saveDashboard('myDash', ['c1'])
+    expect(localCalls.save).toHaveBeenCalledWith('myDash', ['c1'])
+    expect(remoteCalls.save).not.toHaveBeenCalled()
+  })
+
+  test('deleteDashboard() uses the local store and never calls remote', async () => {
+    resetMocks()
+    mockConversationDb.mockReturnValue(false)
+    await deleteDashboard('myDash')
+    expect(localCalls.del).toHaveBeenCalledWith('myDash')
+    expect(remoteCalls.del).not.toHaveBeenCalled()
+  })
+})
+
+describe('D1-enabled uses the remote store', () => {
+  test('listDashboards() calls remote, not local', async () => {
+    resetMocks()
+    const result = await listDashboards()
+    expect(result).toEqual(['remote-a'])
+    expect(remoteCalls.list).toHaveBeenCalledTimes(1)
+    expect(localCalls.list).not.toHaveBeenCalled()
+  })
+
+  test('saveDashboard() calls remote, not local', async () => {
+    resetMocks()
+    await saveDashboard('myDash', ['c1'])
+    expect(remoteCalls.save).toHaveBeenCalledWith('myDash', ['c1'])
+    expect(localCalls.save).not.toHaveBeenCalled()
+  })
+})
+
+describe('sharing requires the D1 backend', () => {
+  test('shareDashboard() resolves via remote when D1-enabled', async () => {
+    resetMocks()
+    const slug = await shareDashboard('myDash')
+    expect(slug).toBe('slug-123')
+    expect(remoteCalls.share).toHaveBeenCalledWith('myDash')
+  })
+
+  test('shareDashboard() throws (does not silently no-op) on the local backend', async () => {
+    resetMocks()
+    mockConversationDb.mockReturnValue(false)
+    await expect(shareDashboard('myDash')).rejects.toThrow()
+    expect(remoteCalls.share).not.toHaveBeenCalled()
+  })
+
+  test('unshareDashboard() throws on the local backend', async () => {
+    resetMocks()
+    mockConversationDb.mockReturnValue(false)
+    await expect(unshareDashboard('myDash')).rejects.toThrow()
+    expect(remoteCalls.unshare).not.toHaveBeenCalled()
+  })
+})

--- a/apps/dashboard/src/lib/dashboard-storage/index.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/index.ts
@@ -1,0 +1,127 @@
+/**
+ * Dashboard Storage — public entrypoint.
+ *
+ * Provides save/load/list/delete/share operations for Chart Builder
+ * configurations ("dashboards": a named, ordered list of chart ids).
+ *
+ * Backend selection mirrors
+ * `conversation-store/adapter/resolve-thread-list-adapter.ts`:
+ *   - D1 available (Cloudflare deployment with conversation/dashboard
+ *     storage enabled) → persisted server-side per owner, synced across
+ *     devices, with optional read-only sharing.
+ *   - Otherwise (self-hosted/Docker, or D1 disabled) → localStorage, scoped
+ *     to the browser profile.
+ *
+ * Deliberately reuses `featureFlags.conversationDb()` rather than adding a
+ * dedicated `dashboardDb` flag: both features persist into the same
+ * `CHM_CLOUD_D1` database behind the same Clerk-required gate, so a second
+ * flag would just duplicate this check without changing its meaning. See
+ * plans/56-dashboard-d1-persistence-sharing.md.
+ *
+ * Client-safe: this module (and everything it imports) must never pull in
+ * `d1-store.ts` / `auth.ts` (server-only — they import `@chm/platform` and
+ * the Clerk server SDK). The D1 backend is reached only indirectly, through
+ * the `/api/dashboards/*` routes called by `remote-store.ts`.
+ */
+
+import {
+  deleteDashboardLocal,
+  listDashboardsLocal,
+  loadDashboardLocal,
+  saveDashboardLocal,
+} from './local-store'
+import {
+  deleteDashboardRemote,
+  listDashboardsRemote,
+  loadDashboardRemote,
+  saveDashboardRemote,
+  shareDashboardRemote,
+  unshareDashboardRemote,
+} from './remote-store'
+import { featureFlags } from '@/lib/feature-flags'
+
+export type DashboardBackend = 'd1' | 'local'
+
+/**
+ * Returns `'d1'` when server-side dashboard storage is enabled, otherwise
+ * `'local'`.
+ */
+export function resolveDashboardBackend(): DashboardBackend {
+  try {
+    return featureFlags.conversationDb() ? 'd1' : 'local'
+  } catch {
+    return 'local'
+  }
+}
+
+/**
+ * List all saved dashboard names, sorted alphabetically.
+ */
+export async function listDashboards(): Promise<string[]> {
+  return resolveDashboardBackend() === 'd1'
+    ? listDashboardsRemote()
+    : listDashboardsLocal()
+}
+
+/**
+ * Load a saved dashboard by name. Returns null if the dashboard does not
+ * exist.
+ */
+export async function loadDashboard(name: string): Promise<string[] | null> {
+  return resolveDashboardBackend() === 'd1'
+    ? loadDashboardRemote(name)
+    : loadDashboardLocal(name)
+}
+
+/**
+ * Save a dashboard configuration under the given name. Overwrites any
+ * existing dashboard with the same name.
+ */
+export async function saveDashboard(
+  name: string,
+  charts: string[]
+): Promise<void> {
+  if (resolveDashboardBackend() === 'd1') {
+    await saveDashboardRemote(name, charts)
+  } else {
+    saveDashboardLocal(name, charts)
+  }
+}
+
+/**
+ * Delete a saved dashboard by name.
+ */
+export async function deleteDashboard(name: string): Promise<void> {
+  if (resolveDashboardBackend() === 'd1') {
+    await deleteDashboardRemote(name)
+  } else {
+    deleteDashboardLocal(name)
+  }
+}
+
+/**
+ * Enable read-only sharing for a dashboard, returning its public share slug.
+ * Sharing requires server-side (D1) storage — there is no meaningful "share"
+ * concept for a single browser's localStorage, so this throws when the
+ * local backend is active rather than silently no-op'ing.
+ */
+export async function shareDashboard(name: string): Promise<string> {
+  if (resolveDashboardBackend() !== 'd1') {
+    throw new Error(
+      'Sharing requires server-side dashboard storage, which is not enabled for this deployment.'
+    )
+  }
+  return shareDashboardRemote(name)
+}
+
+/**
+ * Revoke read-only sharing for a dashboard.
+ */
+export async function unshareDashboard(name: string): Promise<void> {
+  if (resolveDashboardBackend() !== 'd1') {
+    throw new Error(
+      'Sharing requires server-side dashboard storage, which is not enabled for this deployment.'
+    )
+  }
+  await unshareDashboardRemote(name)
+}

--- a/apps/dashboard/src/lib/dashboard-storage/local-store.test.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/local-store.test.ts
@@ -1,9 +1,9 @@
 import {
-  deleteDashboard,
-  listDashboards,
-  loadDashboard,
-  saveDashboard,
-} from './dashboard-storage'
+  deleteDashboardLocal,
+  listDashboardsLocal,
+  loadDashboardLocal,
+  saveDashboardLocal,
+} from './local-store'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 
 const STORAGE_KEY = 'clickhouse-monitor-dashboards'
@@ -33,7 +33,7 @@ function makeLocalStorageMock() {
   }
 }
 
-describe('dashboard-storage — SSR guard', () => {
+describe('local-store — SSR guard', () => {
   it('returns empty list when window is undefined', () => {
     // Bun runs in Node; window is undefined by default
     const savedWindow = globalThis.window
@@ -43,18 +43,18 @@ describe('dashboard-storage — SSR guard', () => {
     delete globalThis.localStorage
 
     try {
-      expect(listDashboards()).toEqual([])
-      expect(loadDashboard('any')).toBeNull()
-      // saveDashboard and deleteDashboard should be no-ops (no throw)
-      expect(() => saveDashboard('x', ['a'])).not.toThrow()
-      expect(() => deleteDashboard('x')).not.toThrow()
+      expect(listDashboardsLocal()).toEqual([])
+      expect(loadDashboardLocal('any')).toBeNull()
+      // saveDashboardLocal and deleteDashboardLocal should be no-ops (no throw)
+      expect(() => saveDashboardLocal('x', ['a'])).not.toThrow()
+      expect(() => deleteDashboardLocal('x')).not.toThrow()
     } finally {
       globalThis.window = savedWindow
     }
   })
 })
 
-describe('dashboard-storage — with localStorage mock', () => {
+describe('local-store — with localStorage mock', () => {
   let lsMock: ReturnType<typeof makeLocalStorageMock>
 
   beforeEach(() => {
@@ -71,115 +71,115 @@ describe('dashboard-storage — with localStorage mock', () => {
     delete globalThis.localStorage
   })
 
-  describe('saveDashboard / loadDashboard round-trip', () => {
+  describe('saveDashboardLocal / loadDashboardLocal round-trip', () => {
     it('saves and loads a dashboard by name', () => {
-      saveDashboard('myDash', ['chart1', 'chart2'])
-      expect(loadDashboard('myDash')).toEqual(['chart1', 'chart2'])
+      saveDashboardLocal('myDash', ['chart1', 'chart2'])
+      expect(loadDashboardLocal('myDash')).toEqual(['chart1', 'chart2'])
     })
 
     it('saves an empty chart list', () => {
-      saveDashboard('empty', [])
-      expect(loadDashboard('empty')).toEqual([])
+      saveDashboardLocal('empty', [])
+      expect(loadDashboardLocal('empty')).toEqual([])
     })
 
     it('overwrites an existing dashboard with the same name', () => {
-      saveDashboard('dash', ['old'])
-      saveDashboard('dash', ['new1', 'new2'])
-      expect(loadDashboard('dash')).toEqual(['new1', 'new2'])
+      saveDashboardLocal('dash', ['old'])
+      saveDashboardLocal('dash', ['new1', 'new2'])
+      expect(loadDashboardLocal('dash')).toEqual(['new1', 'new2'])
     })
 
     it('preserves other dashboards when saving a new one', () => {
-      saveDashboard('a', ['x'])
-      saveDashboard('b', ['y'])
-      expect(loadDashboard('a')).toEqual(['x'])
-      expect(loadDashboard('b')).toEqual(['y'])
+      saveDashboardLocal('a', ['x'])
+      saveDashboardLocal('b', ['y'])
+      expect(loadDashboardLocal('a')).toEqual(['x'])
+      expect(loadDashboardLocal('b')).toEqual(['y'])
     })
   })
 
-  describe('loadDashboard', () => {
+  describe('loadDashboardLocal', () => {
     it('returns null for a non-existent dashboard', () => {
-      expect(loadDashboard('nonexistent')).toBeNull()
+      expect(loadDashboardLocal('nonexistent')).toBeNull()
     })
   })
 
-  describe('listDashboards', () => {
+  describe('listDashboardsLocal', () => {
     it('returns empty array when no dashboards saved', () => {
-      expect(listDashboards()).toEqual([])
+      expect(listDashboardsLocal()).toEqual([])
     })
 
     it('returns sorted dashboard names', () => {
-      saveDashboard('zebra', [])
-      saveDashboard('alpha', [])
-      saveDashboard('middle', [])
-      expect(listDashboards()).toEqual(['alpha', 'middle', 'zebra'])
+      saveDashboardLocal('zebra', [])
+      saveDashboardLocal('alpha', [])
+      saveDashboardLocal('middle', [])
+      expect(listDashboardsLocal()).toEqual(['alpha', 'middle', 'zebra'])
     })
 
     it('reflects names after deletion', () => {
-      saveDashboard('a', [])
-      saveDashboard('b', [])
-      deleteDashboard('a')
-      expect(listDashboards()).toEqual(['b'])
+      saveDashboardLocal('a', [])
+      saveDashboardLocal('b', [])
+      deleteDashboardLocal('a')
+      expect(listDashboardsLocal()).toEqual(['b'])
     })
   })
 
-  describe('deleteDashboard', () => {
+  describe('deleteDashboardLocal', () => {
     it('removes a dashboard by name', () => {
-      saveDashboard('toDelete', ['c1'])
-      deleteDashboard('toDelete')
-      expect(loadDashboard('toDelete')).toBeNull()
+      saveDashboardLocal('toDelete', ['c1'])
+      deleteDashboardLocal('toDelete')
+      expect(loadDashboardLocal('toDelete')).toBeNull()
     })
 
     it('is a no-op for a non-existent dashboard', () => {
-      saveDashboard('keep', ['x'])
-      expect(() => deleteDashboard('ghost')).not.toThrow()
+      saveDashboardLocal('keep', ['x'])
+      expect(() => deleteDashboardLocal('ghost')).not.toThrow()
       // kept dashboard unaffected
-      expect(loadDashboard('keep')).toEqual(['x'])
+      expect(loadDashboardLocal('keep')).toEqual(['x'])
     })
 
     it('does not remove other dashboards', () => {
-      saveDashboard('a', ['1'])
-      saveDashboard('b', ['2'])
-      deleteDashboard('a')
-      expect(loadDashboard('b')).toEqual(['2'])
+      saveDashboardLocal('a', ['1'])
+      saveDashboardLocal('b', ['2'])
+      deleteDashboardLocal('a')
+      expect(loadDashboardLocal('b')).toEqual(['2'])
     })
   })
 
   describe('malformed JSON fallback', () => {
     it('treats invalid JSON as an empty store', () => {
       lsMock.setItem(STORAGE_KEY, 'not-json{{{')
-      expect(listDashboards()).toEqual([])
-      expect(loadDashboard('x')).toBeNull()
+      expect(listDashboardsLocal()).toEqual([])
+      expect(loadDashboardLocal('x')).toBeNull()
     })
 
     it('treats a JSON array as an empty store', () => {
       lsMock.setItem(STORAGE_KEY, JSON.stringify(['a', 'b']))
-      expect(listDashboards()).toEqual([])
+      expect(listDashboardsLocal()).toEqual([])
     })
 
     it('treats null JSON value as an empty store', () => {
       lsMock.setItem(STORAGE_KEY, 'null')
-      expect(listDashboards()).toEqual([])
+      expect(listDashboardsLocal()).toEqual([])
     })
 
     it('treats a JSON primitive as an empty store', () => {
       lsMock.setItem(STORAGE_KEY, '42')
-      expect(listDashboards()).toEqual([])
+      expect(listDashboardsLocal()).toEqual([])
     })
 
     it('still allows saving after a malformed store', () => {
       lsMock.setItem(STORAGE_KEY, 'bad')
-      saveDashboard('fresh', ['chart'])
-      expect(loadDashboard('fresh')).toEqual(['chart'])
+      saveDashboardLocal('fresh', ['chart'])
+      expect(loadDashboardLocal('fresh')).toEqual(['chart'])
     })
   })
 
   describe('default / missing key', () => {
     it('returns empty list when localStorage key is absent', () => {
-      expect(listDashboards()).toEqual([])
+      expect(listDashboardsLocal()).toEqual([])
     })
 
     it('returns null load when localStorage key is absent', () => {
-      expect(loadDashboard('anything')).toBeNull()
+      expect(loadDashboardLocal('anything')).toBeNull()
     })
   })
 })

--- a/apps/dashboard/src/lib/dashboard-storage/local-store.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/local-store.ts
@@ -3,6 +3,12 @@
  *
  * Provides save/load/list/delete operations for Chart Builder configurations.
  * Data is stored under a single JSON key in localStorage.
+ *
+ * This is the OSS/self-hosted default (no owner/sharing concept — a single
+ * browser profile IS the scope) and the fail-open fallback for cloud
+ * deployments where D1 storage is unavailable or disabled. Logic is
+ * unchanged from the original `dashboard-storage.ts` (see `index.ts` for the
+ * async wrapper that picks between this and the D1-backed remote store).
  */
 
 const STORAGE_KEY = 'clickhouse-monitor-dashboards'
@@ -41,7 +47,7 @@ function writeStore(store: DashboardStore): void {
  * Save a dashboard configuration under the given name.
  * Overwrites any existing dashboard with the same name.
  */
-export function saveDashboard(name: string, charts: string[]): void {
+export function saveDashboardLocal(name: string, charts: string[]): void {
   const store = readStore()
   store[name] = charts
   writeStore(store)
@@ -51,7 +57,7 @@ export function saveDashboard(name: string, charts: string[]): void {
  * Load a saved dashboard by name.
  * Returns null if the dashboard does not exist.
  */
-export function loadDashboard(name: string): string[] | null {
+export function loadDashboardLocal(name: string): string[] | null {
   const store = readStore()
   return store[name] ?? null
 }
@@ -59,14 +65,14 @@ export function loadDashboard(name: string): string[] | null {
 /**
  * List all saved dashboard names, sorted alphabetically.
  */
-export function listDashboards(): string[] {
+export function listDashboardsLocal(): string[] {
   return Object.keys(readStore()).sort()
 }
 
 /**
  * Delete a saved dashboard by name.
  */
-export function deleteDashboard(name: string): void {
+export function deleteDashboardLocal(name: string): void {
   const store = readStore()
   delete store[name]
   writeStore(store)

--- a/apps/dashboard/src/lib/dashboard-storage/remote-store.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/remote-store.ts
@@ -1,0 +1,120 @@
+/**
+ * Client-side fetch wrappers for the D1-backed dashboard API
+ * (`/api/dashboards/*`). Used by `index.ts` when the D1 backend is active
+ * (see `resolveDashboardBackend`). Client-safe: no `@chm/platform` / D1
+ * import here — only `fetch` against the app's own API routes, mirroring
+ * `conversation-store/adapter/d1-thread-list-adapter.tsx`.
+ */
+
+import { apiFetch } from '@/lib/swr/api-fetch'
+
+const BASE = '/api/dashboards'
+
+interface DashboardListItem {
+  name: string
+  charts: string[]
+}
+
+function unwrap(json: unknown): Record<string, unknown> {
+  if (json && typeof json === 'object') {
+    const record = json as Record<string, unknown>
+    if (record.data && typeof record.data === 'object') {
+      return record.data as Record<string, unknown>
+    }
+    return record
+  }
+  return {}
+}
+
+/** List saved dashboard names (sorted server-side). */
+export async function listDashboardsRemote(): Promise<string[]> {
+  const res = await apiFetch(`${BASE}/list`)
+  if (!res.ok) {
+    throw new Error(`Failed to list dashboards (${res.status})`)
+  }
+  const body = unwrap(await res.json().catch(() => ({})))
+  const dashboards = body.dashboards
+  if (!Array.isArray(dashboards)) return []
+  return dashboards
+    .filter(
+      (d): d is DashboardListItem =>
+        !!d &&
+        typeof d === 'object' &&
+        typeof (d as DashboardListItem).name === 'string'
+    )
+    .map((d) => d.name)
+}
+
+/** Load a saved dashboard's chart list by name. Returns null if not found. */
+export async function loadDashboardRemote(
+  name: string
+): Promise<string[] | null> {
+  const res = await apiFetch(`${BASE}/list`)
+  if (!res.ok) {
+    throw new Error(`Failed to load dashboard (${res.status})`)
+  }
+  const body = unwrap(await res.json().catch(() => ({})))
+  const dashboards = body.dashboards
+  if (!Array.isArray(dashboards)) return null
+  const match = dashboards.find(
+    (d): d is DashboardListItem =>
+      !!d && typeof d === 'object' && (d as DashboardListItem).name === name
+  )
+  return match ? match.charts : null
+}
+
+/** Save (create or overwrite) a dashboard by name. */
+export async function saveDashboardRemote(
+  name: string,
+  charts: string[]
+): Promise<void> {
+  const res = await apiFetch(`${BASE}/save`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name, charts }),
+  })
+  if (!res.ok) {
+    throw new Error(
+      `Dashboard save failed (${res.status}): ${await res.text().catch(() => 'unknown')}`
+    )
+  }
+}
+
+/** Delete a dashboard by name. */
+export async function deleteDashboardRemote(name: string): Promise<void> {
+  const res = await apiFetch(
+    `${BASE}/delete?name=${encodeURIComponent(name)}`,
+    { method: 'DELETE' }
+  )
+  if (!res.ok) {
+    throw new Error(`Dashboard delete failed (${res.status})`)
+  }
+}
+
+/** Enable read-only sharing for a dashboard. Returns the public share slug. */
+export async function shareDashboardRemote(name: string): Promise<string> {
+  const res = await apiFetch(`${BASE}/share`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name }),
+  })
+  if (!res.ok) {
+    throw new Error(`Dashboard share failed (${res.status})`)
+  }
+  const body = unwrap(await res.json().catch(() => ({})))
+  const slug = body.shareSlug
+  if (typeof slug !== 'string') {
+    throw new Error('Dashboard share response missing shareSlug')
+  }
+  return slug
+}
+
+/** Revoke read-only sharing for a dashboard. */
+export async function unshareDashboardRemote(name: string): Promise<void> {
+  const res = await apiFetch(`${BASE}/share?name=${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+  })
+  if (!res.ok) {
+    throw new Error(`Dashboard unshare failed (${res.status})`)
+  }
+}

--- a/apps/dashboard/src/lib/dashboard-storage/types.ts
+++ b/apps/dashboard/src/lib/dashboard-storage/types.ts
@@ -1,0 +1,100 @@
+/**
+ * Dashboard storage types.
+ *
+ * A "dashboard" here is a saved Chart Builder layout: a named, ordered list
+ * of chart identifiers (`charts: string[]`). Schema design mirrors
+ * `conversation-store/types.ts`:
+ *   - `id` is the server-minted, globally-unique primary key. It is never
+ *     accepted from a client — routes resolve/mint it internally via an
+ *     owner-scoped `(ownerId, name)` lookup — so there is no id-collision
+ *     surface for an upsert guard to defend against on the write path (unlike
+ *     conversations, whose `id` IS client-supplied). The guard is kept anyway
+ *     as defense-in-depth (see `d1-store.ts`).
+ *   - `ownerId` scopes every read/write.
+ *   - Sharing is read-only: a shared dashboard exposes only `name` + `charts`
+ *     to anonymous viewers via `shareSlug`, never `ownerId` or any other
+ *     owner-identifying field.
+ */
+
+export interface StoredDashboard {
+  id: string
+  ownerId: string
+  name: string
+  charts: string[]
+  isShared: boolean
+  shareSlug: string | null
+  updatedAt: number
+}
+
+/**
+ * Minimal projection served by the public, unauthenticated share-link GET.
+ * Deliberately excludes `id`, `ownerId`, `isShared`, `shareSlug`, `updatedAt`
+ * — an anonymous viewer must never learn anything beyond the dashboard's
+ * own content.
+ */
+export interface PublicSharedDashboard {
+  name: string
+  charts: string[]
+}
+
+/**
+ * Dashboard storage adapter interface. `D1DashboardStore` (server-only) is
+ * the sole persistent backend today (Postgres is explicitly out of scope —
+ * see plans/56-dashboard-d1-persistence-sharing.md); the client-side
+ * fallback when D1 is unavailable is `local-store.ts` (localStorage), which
+ * does not implement this interface (it has no owner/sharing concept).
+ */
+export interface DashboardStore {
+  list(ownerId: string): Promise<StoredDashboard[]>
+  get(ownerId: string, name: string): Promise<StoredDashboard | null>
+  /**
+   * Create-or-update by name (mirrors the localStorage "same name
+   * overwrites" behavior). Mints a new `id` on first save; reuses the
+   * existing one on subsequent saves. Never takes a client-supplied id.
+   */
+  saveByName(
+    ownerId: string,
+    name: string,
+    charts: string[]
+  ): Promise<StoredDashboard>
+  /**
+   * Low-level upsert primitive, mirroring
+   * `conversation-store/d1-store.ts`'s `D1_UPSERT_CONVERSATION_SQL`: the
+   * `ON CONFLICT ... WHERE owner_id = excluded.owner_id` guard blocks a
+   * write from reassigning a row owned by a different owner.
+   */
+  upsert(dashboard: StoredDashboard): Promise<{ written: boolean }>
+  delete(ownerId: string, name: string): Promise<void>
+  /**
+   * Enable or revoke read-only sharing. Enabling is idempotent (an
+   * already-shared dashboard keeps its existing slug rather than rotating
+   * it). Revoking clears `shareSlug` in the same write as `isShared = false`
+   * so a revoked link can never resurface.
+   */
+  setSharing(
+    ownerId: string,
+    name: string,
+    shared: boolean
+  ): Promise<StoredDashboard | null>
+  /**
+   * Public, unauthenticated read by share slug. Returns `null` when the
+   * slug is unknown OR sharing was revoked — callers must not distinguish
+   * the two (avoids leaking whether a slug ever existed).
+   */
+  getByShareSlug(slug: string): Promise<PublicSharedDashboard | null>
+}
+
+export class DashboardStoreError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | 'NOT_FOUND'
+      | 'UNAUTHORIZED'
+      | 'STORAGE_ERROR'
+      | 'VALIDATION_ERROR',
+    public readonly cause?: unknown
+  ) {
+    super(message)
+    this.name = 'DashboardStoreError'
+  }
+}

--- a/apps/dashboard/src/routes/api/dashboards/delete.ts
+++ b/apps/dashboard/src/routes/api/dashboards/delete.ts
@@ -1,0 +1,133 @@
+/**
+ * DELETE /api/dashboards/delete?name=... - Delete the caller's dashboard by
+ * name. Owner-scoped: the DELETE statement filters on `owner_id AND name`,
+ * so this can never affect another owner's row regardless of what `name` is
+ * supplied.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { debug, error, generateRequestId } from '@chm/logger'
+import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import {
+  CacheControl,
+  createSuccessResponse,
+} from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import { resolveDashboardOwnerId } from '@/lib/dashboard-storage/auth'
+import { D1DashboardStore } from '@/lib/dashboard-storage/d1-store'
+import { DashboardStoreError } from '@/lib/dashboard-storage/types'
+import { isFeatureEnabled } from '@/lib/feature-flags'
+import { autoMigrate } from '@/lib/migration/auto-migrate'
+
+const ROUTE_CONTEXT = { route: '/api/dashboards/delete', method: 'DELETE' }
+
+async function handleDelete(request: Request): Promise<Response> {
+  const requestId = generateRequestId()
+  debug('[DELETE /api/dashboards/delete] Deleting dashboard', { requestId })
+
+  try {
+    await autoMigrate()
+
+    if (!isFeatureEnabled('conversationDb')) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.PermissionError,
+          message: 'Dashboard storage is not enabled.',
+          details: { timestamp: new Date().toISOString() },
+        },
+        501,
+        ROUTE_CONTEXT
+      )
+    }
+
+    const ownerId = await resolveDashboardOwnerId()
+    debug('[DELETE /api/dashboards/delete] Owner resolved', {
+      ownerId,
+      requestId,
+    })
+
+    const url = new URL(request.url)
+    const name = url.searchParams.get('name')
+    if (!name) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Missing required query parameter: name',
+          details: { timestamp: new Date().toISOString() },
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+    }
+
+    const store = new D1DashboardStore()
+    const existing = await store.get(ownerId, name)
+    if (!existing) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Dashboard not found',
+          details: { timestamp: new Date().toISOString(), name },
+        },
+        404,
+        ROUTE_CONTEXT
+      )
+    }
+
+    await store.delete(ownerId, name)
+
+    const response = createSuccessResponse(
+      { deleted: true, name },
+      { queryId: 'dashboard-delete', rows: 1 }
+    )
+
+    const headers = new Headers(response.headers)
+    headers.set('X-Request-ID', requestId)
+    headers.set('Cache-Control', CacheControl.NONE)
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    })
+  } catch (err) {
+    const errorMessage =
+      err instanceof Error ? err.message : 'Unknown error occurred'
+    error('[DELETE /api/dashboards/delete] Error:', err, { requestId })
+
+    if (err instanceof DashboardStoreError) {
+      const status = err.code === 'UNAUTHORIZED' ? 403 : 500
+      return createApiErrorResponse(
+        {
+          type:
+            err.code === 'UNAUTHORIZED'
+              ? ApiErrorType.PermissionError
+              : ApiErrorType.QueryError,
+          message: err.message,
+          details: { timestamp: new Date().toISOString() },
+        },
+        status,
+        ROUTE_CONTEXT
+      )
+    }
+
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.QueryError,
+        message: errorMessage,
+        details: { timestamp: new Date().toISOString() },
+      },
+      500,
+      ROUTE_CONTEXT
+    )
+  }
+}
+
+export const Route = createFileRoute('/api/dashboards/delete')({
+  server: {
+    handlers: {
+      DELETE: ({ request }) => handleDelete(request),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/dashboards/list.ts
+++ b/apps/dashboard/src/routes/api/dashboards/list.ts
@@ -1,0 +1,110 @@
+/**
+ * GET /api/dashboards/list - List the signed-in owner's saved dashboards.
+ *
+ * Mirrors the guard/response shape of `routes/api/v1/conversations.ts`
+ * (feature-flag check → resolve owner → resolve store → respond), reusing
+ * the same `conversationDb` flag (see `lib/dashboard-storage/index.ts` for
+ * why a dedicated flag isn't needed).
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { debug, error, generateRequestId } from '@chm/logger'
+import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import {
+  CacheControl,
+  createSuccessResponse,
+} from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import { resolveDashboardOwnerId } from '@/lib/dashboard-storage/auth'
+import { D1DashboardStore } from '@/lib/dashboard-storage/d1-store'
+import { DashboardStoreError } from '@/lib/dashboard-storage/types'
+import { isFeatureEnabled } from '@/lib/feature-flags'
+import { autoMigrate } from '@/lib/migration/auto-migrate'
+
+const ROUTE_CONTEXT = { route: '/api/dashboards/list', method: 'GET' }
+
+async function handleGet(): Promise<Response> {
+  const requestId = generateRequestId()
+  debug('[GET /api/dashboards/list] Listing dashboards', { requestId })
+
+  try {
+    await autoMigrate()
+
+    if (!isFeatureEnabled('conversationDb')) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.PermissionError,
+          message: 'Dashboard storage is not enabled.',
+          details: { timestamp: new Date().toISOString() },
+        },
+        501,
+        ROUTE_CONTEXT
+      )
+    }
+
+    const ownerId = await resolveDashboardOwnerId()
+    debug('[GET /api/dashboards/list] Owner resolved', { ownerId, requestId })
+
+    const store = new D1DashboardStore()
+    const dashboards = await store.list(ownerId)
+
+    const responseData = dashboards.map((d) => ({
+      name: d.name,
+      charts: d.charts,
+    }))
+
+    const response = createSuccessResponse(
+      { dashboards: responseData },
+      { queryId: 'dashboards-list', rows: responseData.length }
+    )
+
+    const headers = new Headers(response.headers)
+    headers.set('X-Request-ID', requestId)
+    headers.set('Cache-Control', CacheControl.NONE)
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    })
+  } catch (err) {
+    const errorMessage =
+      err instanceof Error ? err.message : 'Unknown error occurred'
+    error('[GET /api/dashboards/list] Error:', err, { requestId })
+
+    if (err instanceof DashboardStoreError) {
+      const status = err.code === 'UNAUTHORIZED' ? 403 : 500
+      return createApiErrorResponse(
+        {
+          type:
+            err.code === 'UNAUTHORIZED'
+              ? ApiErrorType.PermissionError
+              : ApiErrorType.QueryError,
+          message: err.message,
+          details: { timestamp: new Date().toISOString() },
+        },
+        status,
+        ROUTE_CONTEXT
+      )
+    }
+
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.QueryError,
+        message: errorMessage,
+        details: { timestamp: new Date().toISOString() },
+      },
+      500,
+      ROUTE_CONTEXT
+    )
+  }
+}
+
+export const Route = createFileRoute('/api/dashboards/list')({
+  server: {
+    handlers: {
+      GET: () => handleGet(),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/dashboards/save.ts
+++ b/apps/dashboard/src/routes/api/dashboards/save.ts
@@ -1,0 +1,161 @@
+/**
+ * POST /api/dashboards/save - Create or overwrite the caller's dashboard by
+ * name (matches the pre-D1 localStorage "same name overwrites" behavior).
+ *
+ * The request body carries only `{ name, charts }` — never an `id`. The
+ * dashboard's internal `id` is resolved/minted server-side
+ * (`D1DashboardStore.saveByName`, owner-scoped), so there is no
+ * client-supplied identifier for an attacker to collide with another
+ * owner's row.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { debug, error, generateRequestId } from '@chm/logger'
+import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import {
+  CacheControl,
+  createSuccessResponse,
+} from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import { resolveDashboardOwnerId } from '@/lib/dashboard-storage/auth'
+import { D1DashboardStore } from '@/lib/dashboard-storage/d1-store'
+import { DashboardStoreError } from '@/lib/dashboard-storage/types'
+import { isFeatureEnabled } from '@/lib/feature-flags'
+import { autoMigrate } from '@/lib/migration/auto-migrate'
+
+const ROUTE_CONTEXT = { route: '/api/dashboards/save', method: 'POST' }
+
+interface SaveDashboardRequest {
+  name?: unknown
+  charts?: unknown
+}
+
+function validateBody(
+  body: SaveDashboardRequest
+): { name: string; charts: string[] } | { error: string } {
+  if (typeof body.name !== 'string' || body.name.trim().length === 0) {
+    return { error: 'Invalid field: name must be a non-empty string' }
+  }
+  if (
+    !Array.isArray(body.charts) ||
+    !body.charts.every((c) => typeof c === 'string')
+  ) {
+    return { error: 'Invalid field: charts must be an array of strings' }
+  }
+  return { name: body.name, charts: body.charts }
+}
+
+async function handlePost(request: Request): Promise<Response> {
+  const requestId = generateRequestId()
+  debug('[POST /api/dashboards/save] Saving dashboard', { requestId })
+
+  try {
+    await autoMigrate()
+
+    if (!isFeatureEnabled('conversationDb')) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.PermissionError,
+          message: 'Dashboard storage is not enabled.',
+          details: { timestamp: new Date().toISOString() },
+        },
+        501,
+        ROUTE_CONTEXT
+      )
+    }
+
+    const ownerId = await resolveDashboardOwnerId()
+    debug('[POST /api/dashboards/save] Owner resolved', {
+      ownerId,
+      requestId,
+    })
+
+    const body = (await request.json()) as SaveDashboardRequest
+    const validated = validateBody(body)
+    if ('error' in validated) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: validated.error,
+          details: { timestamp: new Date().toISOString() },
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+    }
+
+    const store = new D1DashboardStore()
+    const saved = await store.saveByName(
+      ownerId,
+      validated.name,
+      validated.charts
+    )
+
+    const response = createSuccessResponse(
+      { name: saved.name, charts: saved.charts },
+      { queryId: 'dashboard-save', rows: 1 },
+      200
+    )
+
+    const headers = new Headers(response.headers)
+    headers.set('X-Request-ID', requestId)
+    headers.set('Cache-Control', CacheControl.NONE)
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    })
+  } catch (err) {
+    const errorMessage =
+      err instanceof Error ? err.message : 'Unknown error occurred'
+    error('[POST /api/dashboards/save] Error:', err, { requestId })
+
+    if (err instanceof DashboardStoreError) {
+      const status = err.code === 'UNAUTHORIZED' ? 403 : 500
+      return createApiErrorResponse(
+        {
+          type:
+            err.code === 'UNAUTHORIZED'
+              ? ApiErrorType.PermissionError
+              : ApiErrorType.QueryError,
+          message: err.message,
+          details: { timestamp: new Date().toISOString() },
+        },
+        status,
+        ROUTE_CONTEXT
+      )
+    }
+
+    if (err instanceof SyntaxError && errorMessage.includes('JSON')) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Invalid JSON in request body',
+          details: { timestamp: new Date().toISOString() },
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+    }
+
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.QueryError,
+        message: errorMessage,
+        details: { timestamp: new Date().toISOString() },
+      },
+      500,
+      ROUTE_CONTEXT
+    )
+  }
+}
+
+export const Route = createFileRoute('/api/dashboards/save')({
+  server: {
+    handlers: {
+      POST: ({ request }) => handlePost(request),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/dashboards/share.$slug.ts
+++ b/apps/dashboard/src/routes/api/dashboards/share.$slug.ts
@@ -14,6 +14,11 @@
  *     probe dashboard existence.
  *   - `Cache-Control: NONE` — a revoked share must stop resolving
  *     immediately, not after a cached copy expires.
+ *   - Rate-limited by client IP (`checkRateLimit`/`getApiRateLimitPerMin`),
+ *     the same guard `routes/api/v1/charts/$name.ts` applies to its public
+ *     GET route — a defense-in-depth throttle on top of the slug's
+ *     `crypto.randomUUID()` entropy, which already makes brute-forcing a
+ *     valid slug computationally infeasible.
  *
  * Kept as a separate file/route from `share.ts` (the authenticated
  * mint/revoke endpoint) so the public, unauthenticated surface is never
@@ -24,6 +29,12 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { debug, error, generateRequestId } from '@chm/logger'
 import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import {
+  checkRateLimit,
+  clientIpKey,
+  getApiRateLimitPerMin,
+  rateLimitResponse,
+} from '@/lib/api/rate-limiter'
 import {
   CacheControl,
   createSuccessResponse,
@@ -36,11 +47,20 @@ import { autoMigrate } from '@/lib/migration/auto-migrate'
 
 const ROUTE_CONTEXT = { route: '/api/dashboards/share/$slug', method: 'GET' }
 
-async function handleGet(slug: string): Promise<Response> {
+async function handleGet(request: Request, slug: string): Promise<Response> {
   const requestId = generateRequestId()
   debug('[GET /api/dashboards/share/$slug] Fetching shared dashboard', {
     requestId,
   })
+
+  // Rate-limit by client IP before doing any work — this is a public,
+  // unauthenticated route, so it's the only abuse guard available.
+  const ip = clientIpKey(request)
+  const rlResult = checkRateLimit(
+    `dashboards-share:ip:${ip}`,
+    getApiRateLimitPerMin()
+  )
+  if (!rlResult.allowed) return rateLimitResponse(rlResult.retryAfterSec)
 
   try {
     await autoMigrate()
@@ -131,7 +151,7 @@ async function handleGet(slug: string): Promise<Response> {
 export const Route = createFileRoute('/api/dashboards/share/$slug')({
   server: {
     handlers: {
-      GET: ({ params }) => handleGet(params.slug),
+      GET: ({ request, params }) => handleGet(request, params.slug),
     },
   },
 })

--- a/apps/dashboard/src/routes/api/dashboards/share.$slug.ts
+++ b/apps/dashboard/src/routes/api/dashboards/share.$slug.ts
@@ -1,0 +1,137 @@
+/**
+ * GET /api/dashboards/share/$slug - PUBLIC, UNAUTHENTICATED read-only view of
+ * a shared dashboard.
+ *
+ * SECURITY: deliberately takes no auth and performs no owner check — that is
+ * the point of a share link. The only guards are:
+ *   - `D1DashboardStore.getByShareSlug` queries `WHERE share_slug = ? AND
+ *     is_shared = 1` and projects ONLY `{ name, charts }` (see
+ *     `d1-store.ts`'s `D1_GET_DASHBOARD_BY_SLUG_SQL`) — never `ownerId`,
+ *     `id`, or any other owner-identifying field.
+ *   - An unknown OR revoked slug both resolve to a generic 404 — the
+ *     response never distinguishes "never existed" from "was revoked" from
+ *     "wrong token", so a caller can't use this endpoint to enumerate or
+ *     probe dashboard existence.
+ *   - `Cache-Control: NONE` — a revoked share must stop resolving
+ *     immediately, not after a cached copy expires.
+ *
+ * Kept as a separate file/route from `share.ts` (the authenticated
+ * mint/revoke endpoint) so the public, unauthenticated surface is never
+ * accidentally reachable through a code path that also handles owner auth.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { debug, error, generateRequestId } from '@chm/logger'
+import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import {
+  CacheControl,
+  createSuccessResponse,
+} from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import { D1DashboardStore } from '@/lib/dashboard-storage/d1-store'
+import { DashboardStoreError } from '@/lib/dashboard-storage/types'
+import { isFeatureEnabled } from '@/lib/feature-flags'
+import { autoMigrate } from '@/lib/migration/auto-migrate'
+
+const ROUTE_CONTEXT = { route: '/api/dashboards/share/$slug', method: 'GET' }
+
+async function handleGet(slug: string): Promise<Response> {
+  const requestId = generateRequestId()
+  debug('[GET /api/dashboards/share/$slug] Fetching shared dashboard', {
+    requestId,
+  })
+
+  try {
+    await autoMigrate()
+
+    // Sharing is only possible when server-side (D1) storage is enabled —
+    // if it's off, no shared dashboard could ever have been minted, so this
+    // is a clean "not available" rather than an attempt to reach D1.
+    if (!isFeatureEnabled('conversationDb')) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Shared dashboard not found.',
+          details: { timestamp: new Date().toISOString() },
+        },
+        404,
+        ROUTE_CONTEXT
+      )
+    }
+
+    if (!slug) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Missing share slug',
+          details: { timestamp: new Date().toISOString() },
+        },
+        400,
+        ROUTE_CONTEXT
+      )
+    }
+
+    const store = new D1DashboardStore()
+    const dashboard = await store.getByShareSlug(slug)
+
+    if (!dashboard) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Shared dashboard not found.',
+          details: { timestamp: new Date().toISOString() },
+        },
+        404,
+        ROUTE_CONTEXT
+      )
+    }
+
+    const response = createSuccessResponse(
+      { dashboard },
+      { queryId: 'dashboard-share-view', rows: 1 }
+    )
+    const headers = new Headers(response.headers)
+    headers.set('X-Request-ID', requestId)
+    headers.set('Cache-Control', CacheControl.NONE)
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    })
+  } catch (err) {
+    error('[GET /api/dashboards/share/$slug] Error:', err, { requestId })
+
+    if (err instanceof DashboardStoreError) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.QueryError,
+          message: err.message,
+          details: { timestamp: new Date().toISOString() },
+        },
+        500,
+        ROUTE_CONTEXT
+      )
+    }
+
+    const errorMessage =
+      err instanceof Error ? err.message : 'Unknown error occurred'
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.QueryError,
+        message: errorMessage,
+        details: { timestamp: new Date().toISOString() },
+      },
+      500,
+      ROUTE_CONTEXT
+    )
+  }
+}
+
+export const Route = createFileRoute('/api/dashboards/share/$slug')({
+  server: {
+    handlers: {
+      GET: ({ params }) => handleGet(params.slug),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/dashboards/share.ts
+++ b/apps/dashboard/src/routes/api/dashboards/share.ts
@@ -1,0 +1,229 @@
+/**
+ * POST   /api/dashboards/share        - Enable read-only sharing (owner-scoped).
+ * DELETE /api/dashboards/share?name=  - Revoke read-only sharing (owner-scoped).
+ *
+ * Both operations require authentication and only ever act on the caller's
+ * own dashboard (`D1DashboardStore.setSharing` reads/writes are owner-scoped).
+ * The actual anonymous read lives at the separate `share/$slug` route, which
+ * takes no auth and is intentionally a different file — keeping the
+ * authenticated mint/revoke path and the public read path unmixed.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { debug, error, generateRequestId } from '@chm/logger'
+import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import {
+  CacheControl,
+  createSuccessResponse,
+} from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import { resolveDashboardOwnerId } from '@/lib/dashboard-storage/auth'
+import { D1DashboardStore } from '@/lib/dashboard-storage/d1-store'
+import { DashboardStoreError } from '@/lib/dashboard-storage/types'
+import { isFeatureEnabled } from '@/lib/feature-flags'
+import { autoMigrate } from '@/lib/migration/auto-migrate'
+
+const ROUTE_CONTEXT_POST = { route: '/api/dashboards/share', method: 'POST' }
+const ROUTE_CONTEXT_DELETE = {
+  route: '/api/dashboards/share',
+  method: 'DELETE',
+}
+
+function featureDisabledResponse(context: {
+  route: string
+  method: string
+}): Response {
+  return createApiErrorResponse(
+    {
+      type: ApiErrorType.PermissionError,
+      message: 'Dashboard storage is not enabled.',
+      details: { timestamp: new Date().toISOString() },
+    },
+    501,
+    context
+  )
+}
+
+function notFoundResponse(
+  name: string,
+  context: { route: string; method: string }
+): Response {
+  return createApiErrorResponse(
+    {
+      type: ApiErrorType.ValidationError,
+      message: 'Dashboard not found',
+      details: { timestamp: new Date().toISOString(), name },
+    },
+    404,
+    context
+  )
+}
+
+function storeErrorResponse(
+  err: DashboardStoreError,
+  context: { route: string; method: string }
+): Response {
+  const status = err.code === 'UNAUTHORIZED' ? 403 : 500
+  return createApiErrorResponse(
+    {
+      type:
+        err.code === 'UNAUTHORIZED'
+          ? ApiErrorType.PermissionError
+          : ApiErrorType.QueryError,
+      message: err.message,
+      details: { timestamp: new Date().toISOString() },
+    },
+    status,
+    context
+  )
+}
+
+/** Enable read-only sharing; returns the (idempotent) public share slug. */
+async function handlePost(request: Request): Promise<Response> {
+  const requestId = generateRequestId()
+  debug('[POST /api/dashboards/share] Enabling sharing', { requestId })
+
+  try {
+    await autoMigrate()
+
+    if (!isFeatureEnabled('conversationDb')) {
+      return featureDisabledResponse(ROUTE_CONTEXT_POST)
+    }
+
+    const ownerId = await resolveDashboardOwnerId()
+
+    const body = (await request.json()) as { name?: unknown }
+    if (typeof body.name !== 'string' || body.name.trim().length === 0) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Invalid field: name must be a non-empty string',
+          details: { timestamp: new Date().toISOString() },
+        },
+        400,
+        ROUTE_CONTEXT_POST
+      )
+    }
+
+    const store = new D1DashboardStore()
+    const updated = await store.setSharing(ownerId, body.name, true)
+    if (!updated) {
+      return notFoundResponse(body.name, ROUTE_CONTEXT_POST)
+    }
+
+    const response = createSuccessResponse(
+      { name: updated.name, shareSlug: updated.shareSlug },
+      { queryId: 'dashboard-share-enable', rows: 1 }
+    )
+    const headers = new Headers(response.headers)
+    headers.set('X-Request-ID', requestId)
+    headers.set('Cache-Control', CacheControl.NONE)
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    })
+  } catch (err) {
+    error('[POST /api/dashboards/share] Error:', err, { requestId })
+    if (err instanceof DashboardStoreError) {
+      return storeErrorResponse(err, ROUTE_CONTEXT_POST)
+    }
+    const errorMessage =
+      err instanceof Error ? err.message : 'Unknown error occurred'
+    if (err instanceof SyntaxError && errorMessage.includes('JSON')) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Invalid JSON in request body',
+          details: { timestamp: new Date().toISOString() },
+        },
+        400,
+        ROUTE_CONTEXT_POST
+      )
+    }
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.QueryError,
+        message: errorMessage,
+        details: { timestamp: new Date().toISOString() },
+      },
+      500,
+      ROUTE_CONTEXT_POST
+    )
+  }
+}
+
+/** Revoke read-only sharing. */
+async function handleDelete(request: Request): Promise<Response> {
+  const requestId = generateRequestId()
+  debug('[DELETE /api/dashboards/share] Revoking sharing', { requestId })
+
+  try {
+    await autoMigrate()
+
+    if (!isFeatureEnabled('conversationDb')) {
+      return featureDisabledResponse(ROUTE_CONTEXT_DELETE)
+    }
+
+    const ownerId = await resolveDashboardOwnerId()
+
+    const url = new URL(request.url)
+    const name = url.searchParams.get('name')
+    if (!name) {
+      return createApiErrorResponse(
+        {
+          type: ApiErrorType.ValidationError,
+          message: 'Missing required query parameter: name',
+          details: { timestamp: new Date().toISOString() },
+        },
+        400,
+        ROUTE_CONTEXT_DELETE
+      )
+    }
+
+    const store = new D1DashboardStore()
+    const updated = await store.setSharing(ownerId, name, false)
+    if (!updated) {
+      return notFoundResponse(name, ROUTE_CONTEXT_DELETE)
+    }
+
+    const response = createSuccessResponse(
+      { name: updated.name, shared: false },
+      { queryId: 'dashboard-share-revoke', rows: 1 }
+    )
+    const headers = new Headers(response.headers)
+    headers.set('X-Request-ID', requestId)
+    headers.set('Cache-Control', CacheControl.NONE)
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    })
+  } catch (err) {
+    error('[DELETE /api/dashboards/share] Error:', err, { requestId })
+    if (err instanceof DashboardStoreError) {
+      return storeErrorResponse(err, ROUTE_CONTEXT_DELETE)
+    }
+    const errorMessage =
+      err instanceof Error ? err.message : 'Unknown error occurred'
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.QueryError,
+        message: errorMessage,
+        details: { timestamp: new Date().toISOString() },
+      },
+      500,
+      ROUTE_CONTEXT_DELETE
+    )
+  }
+}
+
+export const Route = createFileRoute('/api/dashboards/share')({
+  server: {
+    handlers: {
+      POST: ({ request }) => handlePost(request),
+      DELETE: ({ request }) => handleDelete(request),
+    },
+  },
+})

--- a/docs/knowledge/cloud-saas-mode.md
+++ b/docs/knowledge/cloud-saas-mode.md
@@ -3,7 +3,7 @@ id: cloud-saas-mode
 title: Cloud (SaaS) mode — one codebase, two products
 type: spec
 status: active
-updated: 2026-07-02
+updated: 2026-07-03
 tags:
   - saas
   - cloud
@@ -66,6 +66,7 @@ Implemented in `lib/cloud/demo-hosts.ts` (`filterToDemoHosts`), applied at
 - `components/host/host-switcher.tsx` — Demo / read-only badges; `demo` behaves like `env` for live status (server-backed by index).
 - `components/host/first-run-empty-state.tsx` — redesigned welcome/setup (cloud signed-in / cloud anon / self-hosted).
 - `components/host/first-run-gate.tsx` + `first-run-decision.ts` — enforce the "signed-in ⇒ no demo data" invariant at the render boundary. The active host for data comes from `?host=` (`useHostId`), which is DECOUPLED from the visible host list; a stale `?host=0` (carried over from browsing the demo while anonymous) points at the now-hidden demo, and `resolve-host-fetch.ts` falls back to the server/demo host for an id not in the merged list — so a signed-in, zero-connection user could otherwise see demo data. The gate refuses to render the routed page (its charts fetch `?host` directly) until the active host resolves to one of the user's OWN visible hosts: while their connections load it shows a skeleton (never demo charts); with zero it routes to `/setup`; with some it re-points `?host` at a real host. Discriminator is deterministic — user connections use NEGATIVE ids (`DB_CONNECTION_HOST_ID_START = -1000`), env/demo use `0,1,2…`, so a non-negative `?host` for a signed-in user is always the demo. OSS + anonymous-cloud behaviour is unchanged. Invariant covered by `first-run-decision.test.ts`.
+- `lib/dashboard-storage/` — saved Chart Builder dashboards. Client entrypoint (`index.ts`) picks D1 (per-owner, cross-device, optional read-only sharing) vs. localStorage the same way conversations do — via `featureFlags.conversationDb()` (same `CHM_CLOUD_D1` + Clerk gate, no dedicated flag) — so OSS/self-host and cloud-signed-out always get the localStorage path. `d1-store.ts` + `auth.ts` are server-only (never imported by client code — reached only through `routes/api/dashboards/*`); the public `share/$slug` read is the one deliberately owner-unscoped query, projecting only `{name, charts}`. See `plans/56-dashboard-d1-persistence-sharing.md`.
 
 ## Connection-error help
 

--- a/plans/56-dashboard-d1-persistence-sharing.md
+++ b/plans/56-dashboard-d1-persistence-sharing.md
@@ -1,0 +1,24 @@
+# 56 — Dashboard D1 persistence & sharing
+
+## Goal
+Dashboards persist to D1 per owner with an optional share link/ACL; localStorage remains a fallback when D1 is unavailable (self-host/offline). Reads/writes are owner-scoped (no IDOR).
+
+## Current reality (audited)
+Dashboards persist in localStorage only (`apps/dashboard/src/lib/dashboard-storage.ts`); the chart list is JSON-serializable. A D1 store pattern exists for conversations (`apps/dashboard/src/lib/conversation-store/d1-store.ts`, incl. an IDOR-guarded upsert) but is not wired to dashboards — no cross-device sync, no sharing, no team defaults.
+
+## Implement now (depth F)
+- Add a D1 migration `apps/dashboard/src/db/conversations-migrations/NNNN_dashboards.sql`: `dashboards(id TEXT PK, owner_id TEXT, name TEXT, layout_json TEXT, is_shared INT, share_slug TEXT, updated_at INT)` + index on `owner_id`.
+- New store `apps/dashboard/src/lib/dashboard-storage/d1-store.ts` mirroring the conversation D1 store (lazy `CREATE TABLE IF NOT EXISTS`, owner-scoped reads/writes, IDOR guard on upsert).
+- Extend `dashboard-storage.ts` to prefer D1 when the binding is present, else localStorage.
+- Routes `apps/dashboard/src/routes/api/dashboards/{list,save,delete,share}.ts` — owner-resolved, fail-open for self-host; `share` mints a `share_slug` and a read-only public GET (gated per plan via `plan-enforcement`/`entitlements` — mark `deferred` if sharing is a GA gate).
+- Tests: owner A cannot read owner B's dashboard (IDOR); D1-absent falls back to localStorage; share link resolves read-only.
+
+## STOP conditions & drift check
+- STOP if the conversation D1 store contract changed — reuse its patterns, don't fork them.
+- STOP before enforcing a sharing paywall while in free beta — classify it in `plan-enforcement` (`enforced` vs `deferred`) explicitly.
+- Drift: confirm `dashboard-storage.ts` shape and the migrations directory numbering.
+
+## Done criteria
+- Dashboards persist to D1 per owner and sync across devices; localStorage fallback works.
+- Share link is read-only and owner-scoped; IDOR test passes.
+- Sharing gate classified in `plan-enforcement` (enforced or deferred).


### PR DESCRIPTION
## Summary
Implements **plan 56** (Round-3 Wave D). Persists saved dashboards to D1 per owner (mirrors the conversation store), with localStorage fallback when D1 is absent (self-host/offline) and an optional read-only share link. Migration `0010_dashboards.sql`.

## Security (owner-scoped, no IDOR)
- Reuses the **hardened** conversation-store IDOR guard: upsert `ON CONFLICT(id) DO UPDATE … WHERE dashboards.owner_id = excluded.owner_id` (cross-owner overwrite → `changes=0`); `get`/`delete` `WHERE owner_id AND name`; `list` `WHERE owner_id`.
- Dashboard `id` is **never client-supplied** (server-minted `crypto.randomUUID()` / owner-scoped lookup).
- The **one** public query (share-by-slug) is `WHERE share_slug=?1 AND is_shared=1`, projecting only `{name, charts}` — never `owner_id`/other owners' data; unknown & revoked slugs both return a generic 404 (no enumeration); revoke nulls `share_slug` + sets `is_shared=0`. Partial `UNIQUE(share_slug)` prevents collisions.
- Client/server layering: public `share.$slug.ts` split from authenticated `share.ts`; `d1-store`/`auth` (server-only, pull in `@chm/platform`) reached only from route handlers — **verified by CI's client build** (not run locally).

## Verification
type-check ✅ · `tsc -p tsconfig.test.json` ✅ · `bun test src/lib/dashboard-storage` **41 pass** (IDOR read + write-guard + D1-absent fallback + read-only share-slug) ✅ · lint ✅ · biome check ✅ · depcruise no new violation.

## Honest scope / paywall
`custom_dashboards` was **already** `deferred` in `plan-enforcement.ts` (free during early access) — exact match; no gate added, beta-free preserved. **Scope cut (not oversight)**: store + routes + client wrappers (`shareDashboard`/`unshareDashboard`) exist and are tested, but there is **no share/unshare UI button yet** and no 'view shared dashboard' page — underlying API only, per the plan's checklist.

## ⚠️ HELD FOR HUMAN REVIEW
Adds a **public unauthenticated share endpoint** + touches the billing/entitlement surface (classification only). Please review the share-endpoint scoping + confirm CI's client build proves the server-only modules don't leak into the browser bundle before merge.

Co-Authored-By: duyetbot <bot@duyet.net>