### PR TITLE
feat(onboarding): 'Try with sample ClickHouse' preset + convert CTA (plan 66)

### DIFF
--- a/.claude/skills/cloud-saas-mode/SKILL.md
+++ b/.claude/skills/cloud-saas-mode/SKILL.md
@@ -5,12 +5,13 @@ description: >-
   codebase. Use when changing how dash.chmonitor.dev differs from Docker/K8s/OSS
   builds: the cloud-mode flag, public read-only demo hosts, the welcome/setup
   onboarding page, per-user (D1) ClickHouse connections, host visibility for
-  anonymous vs signed-in users, or the "Test connection" error classifier and
-  its docs links. Triggers: "cloud mode", "SaaS", "demo host", "welcome page",
-  "setup page", "first-run", "add host error", "connection error", "read-only
-  host", "hide hosts when signed in".
+  anonymous vs signed-in users, the "Test connection" error classifier and its
+  docs links, or the "Try with sample ClickHouse" onboarding preset. Triggers:
+  "cloud mode", "SaaS", "demo host", "welcome page", "setup page", "first-run",
+  "add host error", "connection error", "read-only host", "hide hosts when
+  signed in", "sample cluster", "sample ClickHouse", "try sample".
 metadata:
-  tags: saas, cloud, oss, self-hosted, onboarding, hosts, clerk, connection-errors
+  tags: saas, cloud, oss, self-hosted, onboarding, hosts, clerk, connection-errors, sample-cluster
 ---
 
 # chmonitor Cloud (SaaS) mode
@@ -62,6 +63,23 @@ returns `cloudMode`/`isSignedIn`). Switcher badges + `demo`-as-`env` status in
 `(cloudMode, isSignedIn)`: cloud signed-in (Connect-your-host + Add-host dialog),
 cloud anon (sign-in + value prop), self-hosted (env-var guidance + browser add).
 Gate `ClerkSignInButton` behind `isClerkEnabled()`.
+
+**"Try with sample ClickHouse" preset** — a DIFFERENT thing from the `demo` host
+above (server env-configured, cloud-only): a one-click preset any user (OSS or
+cloud signed-in) can add through the NORMAL add-host path, for the "must own a
+cluster to try it" barrier. Not shown to cloud anon visitors (they already get
+the automatic demo). `components/connections/sample-preset.ts` is the single
+constant (`SAMPLE_CLUSTER_PRESET` + `isSampleClusterHost`) — currently the
+public ClickHouse Playground (`play.clickhouse.com`/`explorer`, non-secret,
+DDL/INSERT rejected server-side); that shared demo also denies several
+`system.*` tables chmonitor needs (query_log, parts, merges, processes,
+replicas, mutations, disks, errors), so operational pages show their normal
+empty/error states against it — schema browsing, metrics/settings/functions,
+and SQL/AI chat work. `add-host-dialog.tsx`'s `initialPreset?: 'sample'` must be
+set explicitly (incl. `undefined`) on every open — the dialog is reused, not
+remounted per-CTA. `components/host/sample-cluster-banner.tsx` is the
+dismissible "Connect your own cluster" convert nudge shown once the sample is
+connected. Full detail: `docs/knowledge/cloud-saas-mode.md`.
 
 ## Connection-error help
 

--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -2,6 +2,7 @@ import { BookOpenIcon } from 'lucide-react'
 import { menuItemsConfig } from '@/menu'
 
 import { HostSwitcher } from '@/components/host/host-switcher'
+import { SampleClusterBanner } from '@/components/host/sample-cluster-banner'
 import { NavUser } from '@/components/nav-user'
 import { NavMain } from '@/components/navigation/nav-main'
 import {
@@ -34,6 +35,7 @@ export function AppSidebar() {
     <Sidebar collapsible="icon" variant="inset">
       <SidebarHeader>
         <HostSwitcher />
+        <SampleClusterBanner />
       </SidebarHeader>
 
       <SidebarContent>

--- a/apps/dashboard/src/components/connections/add-host-dialog.tsx
+++ b/apps/dashboard/src/components/connections/add-host-dialog.tsx
@@ -33,12 +33,20 @@ interface AddHostDialogProps {
    * Still goes through the normal test/save validation — prefill only.
    */
   initialPreset?: 'sample'
+  /**
+   * Show the in-form "Use sample" quick-fill chip. Defaults on for the
+   * regular "Add host" entry points; the sample-cluster convert banner opens
+   * this dialog specifically to connect a REAL cluster, so it turns this off
+   * to avoid re-offering the sample there.
+   */
+  showSamplePreset?: boolean
 }
 
 export function AddHostDialog({
   open,
   onOpenChange,
   initialPreset,
+  showSamplePreset = true,
 }: AddHostDialogProps) {
   const router = useRouter()
   const pathname = usePathname()
@@ -135,7 +143,7 @@ export function AddHostDialog({
               onStorageModeChange={setStorageMode}
               dbStorageEnabled={dbStorageEnabled}
               dbStorageRequiresSignIn={dbStorageConfigured && !isSignedIn}
-              showSamplePreset
+              showSamplePreset={showSamplePreset}
             />
           </div>
 

--- a/apps/dashboard/src/components/connections/add-host-dialog.tsx
+++ b/apps/dashboard/src/components/connections/add-host-dialog.tsx
@@ -2,6 +2,7 @@ import type { HostStorageMode } from '@/lib/types/host-storage'
 
 import { ConnectionForm, type ConnectionFormData } from './connection-form'
 import { ConnectionHelpPanel } from './connection-help-panel'
+import { isSampleClusterHost, SAMPLE_CLUSTER_PRESET } from './sample-preset'
 import { useState } from 'react'
 import {
   Dialog,
@@ -24,16 +25,33 @@ import { buildUrl } from '@/lib/url/url-builder'
 interface AddHostDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
+  /**
+   * Pre-fill the form with the read-only sample ClickHouse preset — e.g. from
+   * the first-run "Try with sample ClickHouse" CTA. The parent must pass this
+   * explicitly on every open (including `undefined` for a plain "Add host")
+   * since this dialog instance is reused/toggled, not remounted per-CTA.
+   * Still goes through the normal test/save validation — prefill only.
+   */
+  initialPreset?: 'sample'
 }
 
-export function AddHostDialog({ open, onOpenChange }: AddHostDialogProps) {
+export function AddHostDialog({
+  open,
+  onOpenChange,
+  initialPreset,
+}: AddHostDialogProps) {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const { config } = useFeaturePermissions()
-  const { addConnection } = useBrowserConnections()
+  const { addConnection, connections: browserConnections } =
+    useBrowserConnections()
   const { createConnection } = useUserConnectionsMutations()
-  const { refetch: refetchDb, isSignedIn } = useUserConnections()
+  const {
+    refetch: refetchDb,
+    isSignedIn,
+    connections: dbConnections,
+  } = useUserConnections()
   const [storageMode, setStorageMode] = useState<HostStorageMode>('browser')
 
   const dbStorageConfigured = config.userConnections?.dbStorageEnabled === true
@@ -53,9 +71,25 @@ export function AddHostDialog({ open, onOpenChange }: AddHostDialogProps) {
       const url = buildUrl(pathname, { host: created.hostId }, searchParams)
       router.push(url)
     }
+
+    // Sample-cluster funnel: distinguish "connected the sample" from
+    // "converted from sample to a real cluster" (had the sample already,
+    // this new host is not it). Checked against the pre-save connection
+    // list, so this fires once per transition.
+    if (isSampleClusterHost(data.host)) {
+      trackEvent('sample_cluster_connected')
+    } else if (
+      browserConnections.some((c) => isSampleClusterHost(c.host)) ||
+      dbConnections.some((c) => isSampleClusterHost(c.host))
+    ) {
+      trackEvent('sample_to_real_converted')
+    }
     trackEvent('cluster_connect', { storage_mode: storageMode })
     onOpenChange(false)
   }
+
+  const initialValues =
+    initialPreset === 'sample' ? SAMPLE_CLUSTER_PRESET : undefined
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -96,10 +130,12 @@ export function AddHostDialog({ open, onOpenChange }: AddHostDialogProps) {
             <ConnectionForm
               onSave={handleSave}
               onCancel={() => onOpenChange(false)}
+              initialValues={initialValues}
               storageMode={storageMode}
               onStorageModeChange={setStorageMode}
               dbStorageEnabled={dbStorageEnabled}
               dbStorageRequiresSignIn={dbStorageConfigured && !isSignedIn}
+              showSamplePreset
             />
           </div>
 

--- a/apps/dashboard/src/components/connections/connection-form.tsx
+++ b/apps/dashboard/src/components/connections/connection-form.tsx
@@ -1,4 +1,12 @@
-import { ArrowUpRight, Check, Eye, EyeOff, Globe, Loader2 } from 'lucide-react'
+import {
+  ArrowUpRight,
+  Check,
+  Eye,
+  EyeOff,
+  FlaskConical,
+  Globe,
+  Loader2,
+} from 'lucide-react'
 
 import type { BrowserConnection } from '@/lib/types/browser-connection'
 import type { HostStorageMode } from '@/lib/types/host-storage'
@@ -9,6 +17,7 @@ import {
   CLOUD_HOST_PLACEHOLDER,
   SELF_HOSTED_HOST_PLACEHOLDER,
 } from './connection-presets'
+import { SAMPLE_CLUSTER_PRESET } from './sample-preset'
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -49,6 +58,13 @@ interface ConnectionFormProps {
   dbStorageEnabled?: boolean
   /** Server storage is configured but the user must sign in first. */
   dbStorageRequiresSignIn?: boolean
+  /**
+   * Show a "Try sample ClickHouse (read-only)" quick-fill affordance that
+   * loads `SAMPLE_CLUSTER_PRESET` into the form. Only appropriate for an "add
+   * new host" context (`AddHostDialog`) — never passed when editing an
+   * existing connection.
+   */
+  showSamplePreset?: boolean
 }
 
 function isValidUrl(value: string): boolean {
@@ -76,6 +92,7 @@ export function ConnectionForm({
   onStorageModeChange,
   dbStorageEnabled = false,
   dbStorageRequiresSignIn = false,
+  showSamplePreset = false,
 }: ConnectionFormProps) {
   const [form, setForm] = useState<ConnectionFormData>({
     name: initialValues?.name ?? '',
@@ -117,6 +134,11 @@ export function ConnectionForm({
       const next = applyCloudHostDefaults(prev.host)
       return next === prev.host ? prev : { ...prev, host: next }
     })
+  }
+
+  const handleUseSample = () => {
+    setForm({ ...SAMPLE_CLUSTER_PRESET })
+    setTestStatus({ state: 'idle' })
   }
 
   const handleTest = async () => {
@@ -197,6 +219,29 @@ export function ConnectionForm({
           </TabsList>
         </Tabs>
       </div>
+
+      {showSamplePreset && (
+        <div className="flex items-center justify-between gap-3 rounded-md border border-dashed border-border bg-muted/40 px-3 py-2.5">
+          <div className="min-w-0">
+            <p className="text-xs font-medium">No cluster handy?</p>
+            <p className="text-xs text-muted-foreground">
+              Try the public, read-only ClickHouse Playground — schema browsing
+              and SQL, no setup.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            onClick={handleUseSample}
+            data-testid="use-sample-preset"
+          >
+            <FlaskConical className="size-3.5" />
+            Use sample
+          </Button>
+        </div>
+      )}
 
       {/* Name */}
       <div className="space-y-1.5">

--- a/apps/dashboard/src/components/connections/index.ts
+++ b/apps/dashboard/src/components/connections/index.ts
@@ -1,3 +1,4 @@
 export { AddHostDialog } from './add-host-dialog'
 export { ConnectionForm } from './connection-form'
 export { ConnectionManagerDialog } from './connection-manager-dialog'
+export { isSampleClusterHost, SAMPLE_CLUSTER_PRESET } from './sample-preset'

--- a/apps/dashboard/src/components/connections/sample-preset.test.ts
+++ b/apps/dashboard/src/components/connections/sample-preset.test.ts
@@ -1,0 +1,33 @@
+import { isSampleClusterHost, SAMPLE_CLUSTER_PRESET } from './sample-preset'
+import { describe, expect, it } from 'bun:test'
+
+describe('SAMPLE_CLUSTER_PRESET', () => {
+  it('is a valid, non-secret https connection preset', () => {
+    expect(SAMPLE_CLUSTER_PRESET.name.length).toBeGreaterThan(0)
+    expect(() => new URL(SAMPLE_CLUSTER_PRESET.host)).not.toThrow()
+    expect(new URL(SAMPLE_CLUSTER_PRESET.host).protocol).toBe('https:')
+    expect(SAMPLE_CLUSTER_PRESET.user.length).toBeGreaterThan(0)
+    // Genuinely non-secret: the whole point is that this is safe to embed.
+    expect(SAMPLE_CLUSTER_PRESET.password).toBe('')
+  })
+})
+
+describe('isSampleClusterHost', () => {
+  it('matches the exact preset host', () => {
+    expect(isSampleClusterHost(SAMPLE_CLUSTER_PRESET.host)).toBe(true)
+  })
+
+  it('matches when the value has incidental surrounding whitespace', () => {
+    expect(isSampleClusterHost(`  ${SAMPLE_CLUSTER_PRESET.host}  `)).toBe(true)
+  })
+
+  it('does not match a different host', () => {
+    expect(isSampleClusterHost('https://clickhouse.example.com:8443')).toBe(
+      false
+    )
+  })
+
+  it('does not match an empty string', () => {
+    expect(isSampleClusterHost('')).toBe(false)
+  })
+})

--- a/apps/dashboard/src/components/connections/sample-preset.ts
+++ b/apps/dashboard/src/components/connections/sample-preset.ts
@@ -1,0 +1,44 @@
+import type { BrowserConnection } from '@/lib/types/browser-connection'
+
+// Structurally identical to `ConnectionFormData` (connection-form.tsx), but
+// sourced from the shared type module instead — importing from
+// connection-form.tsx directly would create a circular import, since it in
+// turn imports SAMPLE_CLUSTER_PRESET from this file.
+type SampleClusterPreset = Pick<
+  BrowserConnection,
+  'name' | 'host' | 'user' | 'password'
+>
+
+/**
+ * "Try with sample ClickHouse" onboarding preset — the public ClickHouse
+ * Playground (https://clickhouse.com/docs/getting-started/playground),
+ * operated by ClickHouse, Inc. `explorer` is a genuinely public, non-secret,
+ * read-only account documented in ClickHouse's own docs — safe to embed in
+ * client code (there is no separate secret to leak).
+ *
+ * Read-only is enforced server-side by ClickHouse's own grants (DDL/INSERT are
+ * rejected for `explorer`), not by anything in this app. IMPORTANT: this
+ * shared public demo also restricts SELECT on several `system.*` tables
+ * chmonitor relies on (query_log, parts, merges, processes, replicas,
+ * mutations, disks, errors) — verified via direct query, ACCESS_DENIED on all
+ * of those. Schema browsing (`system.tables`/`databases`), `system.metrics`,
+ * `system.settings`/`functions`, and the SQL explorer/AI chat work fine; the
+ * operational monitoring pages (queries, merges, replication, disk, errors)
+ * will show their normal empty/error states against this endpoint. Copy
+ * referencing this preset should not overpromise a full monitoring demo.
+ *
+ * A single named constant so the endpoint can be swapped in one place (e.g.
+ * for a differently-provisioned public demo with broader `system.*` access)
+ * without touching call sites.
+ */
+export const SAMPLE_CLUSTER_PRESET: SampleClusterPreset = {
+  name: 'Sample ClickHouse (read-only)',
+  host: 'https://play.clickhouse.com',
+  user: 'explorer',
+  password: '',
+}
+
+/** True when `host` (as saved/entered) matches the sample preset's endpoint. */
+export function isSampleClusterHost(host: string): boolean {
+  return host.trim() === SAMPLE_CLUSTER_PRESET.host
+}

--- a/apps/dashboard/src/components/host/first-run-empty-state.tsx
+++ b/apps/dashboard/src/components/host/first-run-empty-state.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowRight,
   DatabaseZap,
+  FlaskConical,
   KeyRound,
   PlugZap,
   ShieldCheck,
@@ -50,14 +51,24 @@ const ClerkSignInButton:
 export function FirstRunEmptyState() {
   const { cloudMode, isSignedIn } = useMergedHosts()
   const [addOpen, setAddOpen] = useState(false)
+  const [addPreset, setAddPreset] = useState<'sample' | undefined>(undefined)
+
+  // Every open sets the preset explicitly (including `undefined`) — this
+  // dialog instance is reused/toggled, not remounted per CTA, so leaving the
+  // previous preset in place would leak "sample" into a later plain
+  // "Add host" click.
+  const openAddHost = (preset?: 'sample') => {
+    setAddPreset(preset)
+    setAddOpen(true)
+  }
 
   let body: ReactNode
   if (cloudMode && isSignedIn) {
-    body = <ConnectYourHost onAddHost={() => setAddOpen(true)} />
+    body = <ConnectYourHost onAddHost={openAddHost} />
   } else if (cloudMode) {
     body = <SignInToConnect />
   } else {
-    body = <SelfHostedSetup onAddHost={() => setAddOpen(true)} />
+    body = <SelfHostedSetup onAddHost={openAddHost} />
   }
 
   return (
@@ -65,7 +76,11 @@ export function FirstRunEmptyState() {
       <div className="flex flex-1 flex-col items-center justify-center px-4 py-16">
         <div className="w-full max-w-3xl">{body}</div>
       </div>
-      <AddHostDialog open={addOpen} onOpenChange={setAddOpen} />
+      <AddHostDialog
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        initialPreset={addPreset}
+      />
     </>
   )
 }
@@ -140,7 +155,11 @@ function DocsFooter({ links }: { links: { slug: string; label: string }[] }) {
 /* Cloud — signed in                                                   */
 /* ------------------------------------------------------------------ */
 
-function ConnectYourHost({ onAddHost }: { onAddHost: () => void }) {
+function ConnectYourHost({
+  onAddHost,
+}: {
+  onAddHost: (preset?: 'sample') => void
+}) {
   const { data: sub } = useBillingSubscription()
   const currentPlanId = sub?.planId ?? 'free'
   const isPaid = currentPlanId === 'pro' || currentPlanId === 'max'
@@ -205,13 +224,28 @@ function ConnectYourHost({ onAddHost }: { onAddHost: () => void }) {
         <Button
           className="mt-5 w-full"
           size="lg"
-          onClick={onAddHost}
+          onClick={() => onAddHost()}
           data-testid="welcome-add-host"
         >
           <PlugZap className="size-4" />
           Add ClickHouse host
           <ArrowRight className="ml-auto size-4" />
         </Button>
+
+        <Button
+          className="mt-2 w-full"
+          size="lg"
+          variant="outline"
+          onClick={() => onAddHost('sample')}
+          data-testid="welcome-try-sample"
+        >
+          <FlaskConical className="size-4" />
+          Try with sample ClickHouse
+        </Button>
+        <p className="mt-1.5 text-center text-xs text-muted-foreground">
+          A public, read-only demo — explore schema &amp; SQL, no setup
+          required.
+        </p>
 
         <p className="text-muted-foreground mt-3 text-center text-xs">
           Not sure where to start?{' '}
@@ -368,7 +402,11 @@ function SignInToConnect() {
 /* Self-hosted (OSS)                                                   */
 /* ------------------------------------------------------------------ */
 
-function SelfHostedSetup({ onAddHost }: { onAddHost: () => void }) {
+function SelfHostedSetup({
+  onAddHost,
+}: {
+  onAddHost: (preset?: 'sample') => void
+}) {
   return (
     <div className="space-y-7">
       <WelcomeHeader
@@ -399,12 +437,26 @@ CLICKHOUSE_PASSWORD=••••••••`}</code>
         <Button
           className="w-full"
           variant="outline"
-          onClick={onAddHost}
+          onClick={() => onAddHost()}
           data-testid="welcome-add-host"
         >
           <PlugZap className="size-4" />
           Add a host from this browser
         </Button>
+
+        <Button
+          className="mt-2 w-full"
+          variant="outline"
+          onClick={() => onAddHost('sample')}
+          data-testid="welcome-try-sample"
+        >
+          <FlaskConical className="size-4" />
+          Try with sample ClickHouse
+        </Button>
+        <p className="mt-1.5 text-center text-xs text-muted-foreground">
+          A public, read-only demo — explore schema &amp; SQL, no setup
+          required.
+        </p>
       </div>
 
       <DocsFooter

--- a/apps/dashboard/src/components/host/sample-cluster-banner-dismissed.test.ts
+++ b/apps/dashboard/src/components/host/sample-cluster-banner-dismissed.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for sample-cluster-banner-dismissed.ts
+ *
+ * Mocks localStorage via globalThis to cover the SSR guard, the dismiss flag
+ * round-trip, and a disabled/throwing localStorage.
+ */
+
+import {
+  dismissSampleClusterBanner,
+  isSampleClusterBannerDismissed,
+} from './sample-cluster-banner-dismissed'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+function makeLocalStorageStub() {
+  const store: Record<string, string> = {}
+  return {
+    store,
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+  }
+}
+
+type LocalStorageStub = ReturnType<typeof makeLocalStorageStub>
+
+let lsStub: LocalStorageStub
+
+beforeEach(() => {
+  lsStub = makeLocalStorageStub()
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: lsStub,
+    writable: true,
+    configurable: true,
+  })
+  if (typeof globalThis.window === 'undefined') {
+    Object.defineProperty(globalThis, 'window', {
+      value: globalThis,
+      writable: true,
+      configurable: true,
+    })
+  }
+})
+
+afterEach(() => {
+  try {
+    delete (globalThis as Record<string, unknown>).localStorage
+  } catch {
+    // ignore
+  }
+})
+
+describe('isSampleClusterBannerDismissed', () => {
+  test('false when never dismissed', () => {
+    expect(isSampleClusterBannerDismissed()).toBe(false)
+  })
+
+  test('true after dismissSampleClusterBanner()', () => {
+    dismissSampleClusterBanner()
+    expect(isSampleClusterBannerDismissed()).toBe(true)
+  })
+
+  test('false when localStorage throws on read', () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: {
+        getItem: () => {
+          throw new Error('disabled')
+        },
+      },
+      writable: true,
+      configurable: true,
+    })
+    expect(isSampleClusterBannerDismissed()).toBe(false)
+  })
+})
+
+describe('dismissSampleClusterBanner', () => {
+  test('silently fails when localStorage.setItem throws', () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: {
+        getItem: () => null,
+        setItem: () => {
+          throw new Error('quota exceeded')
+        },
+      },
+      writable: true,
+      configurable: true,
+    })
+    expect(() => dismissSampleClusterBanner()).not.toThrow()
+  })
+})

--- a/apps/dashboard/src/components/host/sample-cluster-banner-dismissed.ts
+++ b/apps/dashboard/src/components/host/sample-cluster-banner-dismissed.ts
@@ -1,0 +1,30 @@
+/**
+ * Dismissed "Connect your own cluster" banner storage.
+ *
+ * A single per-browser flag — unlike `lib/notifications/dismissed-notifications.ts`
+ * there is only ever one banner to dismiss, so no key set is needed.
+ */
+
+const STORAGE_KEY = 'chm-sample-cluster-banner-dismissed'
+
+/** Whether the visitor already dismissed the sample-cluster convert banner. */
+export function isSampleClusterBannerDismissed(): boolean {
+  if (typeof window === 'undefined') return false
+
+  try {
+    return localStorage.getItem(STORAGE_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+/** Dismiss the sample-cluster convert banner for this browser. */
+export function dismissSampleClusterBanner(): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    localStorage.setItem(STORAGE_KEY, '1')
+  } catch {
+    // Silently fail if localStorage is full or disabled
+  }
+}

--- a/apps/dashboard/src/components/host/sample-cluster-banner.tsx
+++ b/apps/dashboard/src/components/host/sample-cluster-banner.tsx
@@ -85,7 +85,11 @@ export function SampleClusterBanner() {
           <ArrowRight className="size-3.5" />
         </Button>
       </div>
-      <AddHostDialog open={addOpen} onOpenChange={setAddOpen} />
+      <AddHostDialog
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        showSamplePreset={false}
+      />
     </>
   )
 }

--- a/apps/dashboard/src/components/host/sample-cluster-banner.tsx
+++ b/apps/dashboard/src/components/host/sample-cluster-banner.tsx
@@ -1,0 +1,91 @@
+import { ArrowRight, X } from 'lucide-react'
+
+import {
+  dismissSampleClusterBanner,
+  isSampleClusterBannerDismissed,
+} from './sample-cluster-banner-dismissed'
+import { useEffect, useState } from 'react'
+import { AddHostDialog, isSampleClusterHost } from '@/components/connections'
+import { Button } from '@/components/ui/button'
+import { useSidebar } from '@/components/ui/sidebar'
+import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
+
+/**
+ * Persistent, dismissible "Connect your own cluster" convert nudge.
+ *
+ * Shown right below the host switcher once the sample ClickHouse preset
+ * (`sample-preset.ts`) is connected and no real (non-sample) host has been
+ * added yet. Dismissing it is remembered per-browser
+ * (`sample-cluster-banner-dismissed.ts`); connecting a real cluster also
+ * retires it for good (no non-sample host left to convert from).
+ *
+ * Collapsed (icon-only) sidebar has no room for a text banner, so this
+ * renders nothing in that state — same gating `HostSwitcher` uses.
+ */
+export function SampleClusterBanner() {
+  const { hosts, isLoading } = useMergedHosts()
+  const { isMobile, state } = useSidebar()
+  const [dismissed, setDismissed] = useState(true)
+  const [mounted, setMounted] = useState(false)
+  const [addOpen, setAddOpen] = useState(false)
+
+  // Read the dismissal flag only after mount (localStorage is unavailable
+  // during SSR/prerender) — mirrors useBrowserConnections' `mounted` guard.
+  useEffect(() => {
+    setDismissed(isSampleClusterBannerDismissed())
+    setMounted(true)
+  }, [])
+
+  const showExpanded = isMobile || state === 'expanded'
+  const hasSampleHost = hosts.some((h) => isSampleClusterHost(h.host))
+  const hasConvertedToReal = hosts.some((h) => !isSampleClusterHost(h.host))
+
+  if (
+    !mounted ||
+    isLoading ||
+    dismissed ||
+    !hasSampleHost ||
+    hasConvertedToReal ||
+    !showExpanded
+  ) {
+    return null
+  }
+
+  const handleDismiss = () => {
+    dismissSampleClusterBanner()
+    setDismissed(true)
+  }
+
+  return (
+    <>
+      <div
+        className="relative rounded-lg border bg-muted/40 p-3 text-xs"
+        data-testid="sample-cluster-banner"
+      >
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss"
+          className="absolute right-1.5 top-1.5 text-muted-foreground hover:text-foreground"
+        >
+          <X className="size-3.5" />
+        </button>
+        <p className="pr-4 font-medium">You're exploring the sample</p>
+        <p className="mt-0.5 text-muted-foreground">
+          Connect your own ClickHouse cluster for real monitoring.
+        </p>
+        <Button
+          size="sm"
+          variant="outline"
+          className="mt-2 h-7 w-full text-xs"
+          onClick={() => setAddOpen(true)}
+          data-testid="sample-banner-connect-real"
+        >
+          Connect your cluster
+          <ArrowRight className="size-3.5" />
+        </Button>
+      </div>
+      <AddHostDialog open={addOpen} onOpenChange={setAddOpen} />
+    </>
+  )
+}

--- a/apps/dashboard/src/lib/analytics/events.ts
+++ b/apps/dashboard/src/lib/analytics/events.ts
@@ -20,6 +20,8 @@ export const ANALYTICS_EVENTS = [
   'agent_message',
   'upgrade_click',
   'checkout_started',
+  'sample_cluster_connected',
+  'sample_to_real_converted',
 ] as const
 
 export type AnalyticsEvent = (typeof ANALYTICS_EVENTS)[number]

--- a/docs/content/operate/advanced/product-analytics.mdx
+++ b/docs/content/operate/advanced/product-analytics.mdx
@@ -57,6 +57,8 @@ entirely. The dashboard additionally honors the cross-tool `DO_NOT_TRACK`/
 |---|---|
 | `signup` | A Clerk account created within the last 2 minutes loads the app (approximates "just signed up") |
 | `cluster_connect` | A ClickHouse connection is added and saved |
+| `sample_cluster_connected` | The "Try with sample ClickHouse" read-only preset is connected |
+| `sample_to_real_converted` | A non-sample host is added after the sample was connected |
 | `first_chart_render` | The first chart renders with real data (once per page load) |
 | `agent_message` | A message is sent to the AI agent |
 | `upgrade_click` | An "Upgrade" call-to-action is clicked |

--- a/docs/knowledge/cloud-saas-mode.md
+++ b/docs/knowledge/cloud-saas-mode.md
@@ -68,6 +68,48 @@ Implemented in `lib/cloud/demo-hosts.ts` (`filterToDemoHosts`), applied at
 - `components/host/first-run-gate.tsx` + `first-run-decision.ts` — enforce the "signed-in ⇒ no demo data" invariant at the render boundary. The active host for data comes from `?host=` (`useHostId`), which is DECOUPLED from the visible host list; a stale `?host=0` (carried over from browsing the demo while anonymous) points at the now-hidden demo, and `resolve-host-fetch.ts` falls back to the server/demo host for an id not in the merged list — so a signed-in, zero-connection user could otherwise see demo data. The gate refuses to render the routed page (its charts fetch `?host` directly) until the active host resolves to one of the user's OWN visible hosts: while their connections load it shows a skeleton (never demo charts); with zero it routes to `/setup`; with some it re-points `?host` at a real host. Discriminator is deterministic — user connections use NEGATIVE ids (`DB_CONNECTION_HOST_ID_START = -1000`), env/demo use `0,1,2…`, so a non-negative `?host` for a signed-in user is always the demo. OSS + anonymous-cloud behaviour is unchanged. Invariant covered by `first-run-decision.test.ts`.
 - `lib/dashboard-storage/` — saved Chart Builder dashboards. Client entrypoint (`index.ts`) picks D1 (per-owner, cross-device, optional read-only sharing) vs. localStorage the same way conversations do — via `featureFlags.conversationDb()` (same `CHM_CLOUD_D1` + Clerk gate, no dedicated flag) — so OSS/self-host and cloud-signed-out always get the localStorage path. `d1-store.ts` + `auth.ts` are server-only (never imported by client code — reached only through `routes/api/dashboards/*`); the public `share/$slug` read is the one deliberately owner-unscoped query, projecting only `{name, charts}`. See `plans/56-dashboard-d1-persistence-sharing.md`.
 
+## Sample-cluster onboarding preset
+
+A DIFFERENT concept from the cloud `demo` host above (that one is server
+env-configured and cloud-only): "Try with sample ClickHouse" is a preset users
+of EITHER product add through the normal add-host flow, so it works in
+self-hosted OSS too — the main barrier it removes is "must own a ClickHouse
+cluster to try the product at all" (self-hosted zero-host first-run, and cloud
+signed-in users whose demo is hidden). Cloud anonymous visitors already get an
+automatic demo, so they don't see this CTA.
+
+- `components/connections/sample-preset.ts` — the single constant
+  (`SAMPLE_CLUSTER_PRESET`: name/host/user/password) + `isSampleClusterHost`
+  matcher. Points at the public ClickHouse Playground (`play.clickhouse.com`,
+  user `explorer`, no password) — genuinely public/non-secret creds, DDL/INSERT
+  rejected server-side (verified). **Caveat**: that shared public demo also
+  denies SELECT on several `system.*` tables chmonitor relies on (`query_log`,
+  `parts`, `merges`, `processes`, `replicas`, `mutations`, `disks`, `errors`,
+  `storage_policies` — verified via direct query); schema browsing
+  (`tables`/`databases`), `system.metrics`/`settings`/`functions`, and the SQL
+  explorer/AI chat work. Operational monitoring pages will show their normal
+  empty/error states against it. Swapping to a differently-provisioned public
+  demo (broader `system.*` access) is a one-constant change.
+- `components/connections/connection-form.tsx` — `showSamplePreset` prop
+  renders a "Use sample" quick-fill button (only passed by `AddHostDialog`, so
+  it never appears in the edit-connection flow).
+- `components/connections/add-host-dialog.tsx` — `initialPreset?: 'sample'`
+  prefills the form when opened from a sample CTA; parents MUST pass it
+  explicitly (including `undefined`) on every open since the dialog instance is
+  reused/toggled, not remounted per-CTA. Prefill only — same test/save
+  validation and host-limit path as any manual entry, no bypass. Also fires
+  `sample_cluster_connected` / `sample_to_real_converted` (see
+  `lib/analytics/events.ts`) by comparing the saved host against
+  `isSampleClusterHost`.
+- `components/host/first-run-empty-state.tsx` — secondary "Try with sample
+  ClickHouse" CTA in `ConnectYourHost` (cloud signed-in) and `SelfHostedSetup`;
+  not in `SignInToConnect` (redundant with the automatic demo).
+- `components/host/sample-cluster-banner.tsx` (+ `sample-cluster-banner-
+  dismissed.ts`) — persistent, dismissible "Connect your own cluster" convert
+  nudge rendered in `app-sidebar.tsx`'s `SidebarHeader` below `HostSwitcher`.
+  Shows only once a sample host is connected and no real (non-sample) host
+  exists yet; dismissal persists per-browser via localStorage.
+
 ## Connection-error help
 
 `lib/connection-errors.ts` → `classifyConnectionError(raw)` maps a raw "Test

--- a/plans/66-onboarding-sample-cluster-preset.md
+++ b/plans/66-onboarding-sample-cluster-preset.md
@@ -1,0 +1,33 @@
+# 66 — Onboarding: sample-cluster preset ("Try with sample ClickHouse")
+
+## Goal
+Add a "Try with sample ClickHouse" one-click preset to the dashboard first-run empty state + add-host dialog that autofills a read-only demo endpoint, plus a "connect your own cluster" convert CTA once the sample is connected. Track sample→real conversion.
+
+## Current reality (audited)
+First-run requires connecting a real cluster before the product does anything — a hard activation barrier. Pointers (verify at head):
+- First-run: `apps/dashboard/src/components/host/first-run-empty-state.tsx` (siblings `first-run-gate.tsx`, `first-run-unauthorized-state.tsx`).
+- Connection dialog: `apps/dashboard/src/components/connections/add-host-dialog.tsx` (also `connection-form.tsx`, `connection-manager-dialog.tsx`, `connection-help-panel.tsx`).
+- Sample endpoint is a read-only demo ClickHouse (non-secret demo creds, not a committed secret).
+- Connection persistence + host limit live in the connections store / `user-connections` route (verify); the preset just prefills the form — go through the normal add-host path, not a bypass.
+
+## Implement now (depth F — file-level)
+### A. First-run CTA — `first-run-empty-state.tsx`
+- Add a secondary "Try with sample ClickHouse" action next to the existing primary CTA (keep primary unchanged + first). Clicking either opens `add-host-dialog` pre-filled with the sample preset, or initiates the sample connection through the normal add-host flow (pick the path reusing the most existing validation). Copy: *read-only sample dataset*.
+### B. Sample preset in `add-host-dialog.tsx`
+- Add a "Sample ClickHouse (read-only)" preset autofilling host/port/TLS/user for the demo endpoint (from a preset constant/env, not hand-typed). Runs the dialog's normal connectivity validation before saving; on success appears like any other connection. Do NOT expose control/kill actions for the sample host in copy.
+### C. Convert CTA — after sample connected
+- Once the sample host is active, surface a persistent, dismissible "Connect your own cluster" affordance (banner/card near host switcher or empty-state follow-up) opening `add-host-dialog` on the standard manual preset.
+### D. Tracking — via plan-62 analytics wrapper
+- Fire `sample_cluster_connected` when the sample connects and `sample_to_real_converted` when a non-sample host is subsequently added. Async, DNT-respecting, no PII (never log endpoint creds).
+
+## STOP conditions & drift check
+- STOP if a sample/demo preset already exists — reconcile/extend.
+- STOP if wiring the preset requires bypassing normal add-host validation or the host-limit check — must use the same path (prefill only).
+- DRIFT: if a preset abstraction already exists in `add-host-dialog.tsx`, extend it; don't add a second preset system.
+- Don't gate first-run/preset behind Clerk/billing; fail open. Don't commit real customer creds.
+
+## Done criteria
+- "Try with sample ClickHouse" preset on first-run + add-host dialog autofills a read-only demo endpoint through the normal path.
+- "Connect your own cluster" convert CTA appears after the sample is connected.
+- `sample_cluster_connected`/`sample_to_real_converted` fire (DNT, no PII).
+- Copy honestly states read-only; OSS first-run unchanged when unused; type-check/targeted test/lint green.


### PR DESCRIPTION
## Summary
Implements **plan 66** (Round-3 Wave G). Adds an opt-in 'Try with sample ClickHouse' preset to the first-run empty state + add-host dialog (autofills a read-only demo endpoint through the **normal** add-host validation path, no bypass), a dismissible 'Connect your own cluster' convert banner once the sample is active, and `sample_cluster_connected`/`sample_to_real_converted` tracking via the existing plan-62 analytics wrapper (DNT, no PII).

## Verification
type-check ✅ · `tsc -p tsconfig.test.json` ✅ · targeted tests 19/19 ✅ · lint ✅ · biome-check ✅ · **depcruise ✅** (agent caught + fixed a circular import in its own draft) · plus a live end-to-end browser smoke test. Additive/fail-open (primary CTAs unchanged + first); honest read-only copy; normal `addConnection` path (no host-limit bypass, verified live).

## ⚠️ HELD FOR HUMAN REVIEW — product decision on the demo endpoint
Live testing found the sample endpoint (`play.clickhouse.com`/`explorer`) is **read-only AND access-limited**: `system.tables/databases/metrics/settings/functions` work, but `query_log/parts/merges/processes/replicas/mutations/disks/errors` are ACCESS_DENIED — so **most core monitoring pages render empty/denied** against it, undercutting the feature's 'reach value in one click' goal. The code is correct + safe to merge; the decision is whether to (a) ship the CTA now with the limited demo, (b) point `sample-preset.ts` at a broader-access demo (one-line change, if one exists), or (c) accept a 'schema/SQL-only' sample framing. Please decide before this goes live.

Pre-existing (not regressions, flagged for follow-up): `/setup` doesn't navigate away after connecting; `useBrowserConnections()` isn't reactive across call sites (host switcher needs a reload) — both affect the existing manual add-host flow too.

Co-Authored-By: duyetbot <bot@duyet.net>