### PR TITLE
docs(plans): accurate status table + persist Round-2/backlog specs

### DIFF
--- a/plans/04-conversation-upsert-idor.md
+++ b/plans/04-conversation-upsert-idor.md
@@ -1,0 +1,288 @@
+# Plan 04: Scope the conversation upsert so a PUT/POST cannot overwrite or seize another user's conversation
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan in
+> `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat c5b2ae41c..HEAD -- apps/dashboard/src/lib/conversation-store apps/dashboard/src/routes/api/v1/conversations`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: none
+- **Category**: security
+- **Planned at**: commit `c5b2ae41c`, 2026-07-03
+
+## Why this matters
+
+The conversation store's write path is a cross-tenant IDOR. `PUT /api/v1/conversations/$id`
+authorizes with a **user-scoped read** (`store.get(userId, id)`) but then does an
+**unscoped upsert** whose SQL is `ON CONFLICT (id) DO UPDATE SET user_id = excluded.user_id, …`
+— conflict key is `id` alone and the update reassigns ownership to the caller. So an
+authenticated user who PUTs another user's conversation `id` overwrites that row's
+`title`/`messages` **and takes ownership of it** — the victim loses the conversation
+and its content is replaced. This affects the **D1** and **Postgres** backends (both
+first-class in `resolve-store.ts`); the AgentState backend is namespaced-safe and OSS
+single-user mode collapses everyone to `guest` (unaffected). Random-UUID ids are a
+mitigation, not a control (they leak via shared links, logs, referrers). The fix makes
+the write enforce ownership like the read already does.
+
+## Current state
+
+Files:
+- `apps/dashboard/src/lib/conversation-store/d1-store.ts` — D1 (Cloudflare) backend. Vulnerable upsert.
+- `apps/dashboard/src/lib/conversation-store/postgres-store.ts` — Postgres (Node) backend. Vulnerable upsert.
+- `apps/dashboard/src/lib/conversation-store/memory-store.ts` — in-memory reference impl (used in tests). Fix here too so it can carry the regression test.
+- `apps/dashboard/src/lib/conversation-store/agentstate-store.ts` — namespaced-safe backend; only needs the return-type change.
+- `apps/dashboard/src/lib/conversation-store/browser-store.ts` — client-side localStorage, single-user; only needs the return-type change.
+- `apps/dashboard/src/lib/conversation-store/types.ts` — the `ConversationStore` interface (`:221`), `upsert` signature (`:240`).
+- `apps/dashboard/src/routes/api/v1/conversations/$id.ts` — `handlePut` (create-or-update). Caller at `:295`.
+- `apps/dashboard/src/routes/api/v1/conversations.ts` — `handlePost` (create). Caller at `:281`.
+
+The vulnerable D1 SQL (`d1-store.ts:203-224`):
+
+```ts
+const stmt = db.prepare(
+  `INSERT INTO conversations (id, user_id, title, messages, message_count, created_at, updated_at)
+   VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+   ON CONFLICT (id) DO UPDATE SET
+     user_id = excluded.user_id,          -- ⚠ reassigns ownership
+     title = excluded.title,
+     messages = excluded.messages,
+     message_count = excluded.message_count,
+     updated_at = excluded.updated_at`     -- ⚠ no ownership guard on the update
+).bind(conversation.id, conversation.userId, conversation.title, messagesJson,
+       conversation.messageCount, conversation.createdAt, conversation.updatedAt)
+await stmt.run()
+```
+
+The identical Postgres flaw (`postgres-store.ts:271-290`) uses `EXCLUDED.user_id` and the same `ON CONFLICT (id)`.
+
+The route that discards its own auth check (`conversations/$id.ts:277-295`):
+
+```ts
+const store = await resolveStore()
+const existingConversation = await store.get(userId, id)   // scoped read — returns null for a foreign row
+// Build create-or-update conversation (needed for localStorage migration PUT uploads)
+const updatedConversation: StoredConversation = { id, userId /* caller */, title: …, messages: …, … }
+await store.upsert(updatedConversation)                    // ⚠ unconditional; ignores the scoped read
+```
+
+Conventions to match:
+- `userId` comes from `resolveUserId()` (`$id.ts:228`) — real per-user under Clerk, `'guest'` in OSS.
+- Error responses use `createApiErrorResponse({ type: ApiErrorType.X, message, details:{timestamp} }, <status>, ROUTE_CONTEXT_PUT)` — see `$id.ts:236-244` for the exact shape. Reuse it; do not invent a new error helper.
+- The store interface returns typed results; keep `StoredConversation` unchanged.
+- Tests use **Bun test** (`bun:test`) — see `apps/dashboard/src/lib/conversation-store/memory-store.test.ts` for the exact structure to mirror. Do NOT add Jest.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Typecheck | `cd apps/dashboard && bun run type-check` | exit 0, no errors |
+| Unit test (store) | `cd apps/dashboard && bun test src/lib/conversation-store --isolate` | all pass |
+| Lint | `bun run lint` | exit 0 |
+| Grep guard | `rg -n "user_id = excluded.user_id\|user_id = EXCLUDED.user_id" apps/dashboard/src/lib/conversation-store` | no matches after fix |
+
+## Scope
+
+**In scope** (the only files you may modify):
+- `apps/dashboard/src/lib/conversation-store/d1-store.ts`
+- `apps/dashboard/src/lib/conversation-store/postgres-store.ts`
+- `apps/dashboard/src/lib/conversation-store/memory-store.ts`
+- `apps/dashboard/src/lib/conversation-store/agentstate-store.ts`
+- `apps/dashboard/src/lib/conversation-store/browser-store.ts`
+- `apps/dashboard/src/lib/conversation-store/types.ts`
+- `apps/dashboard/src/routes/api/v1/conversations/$id.ts`
+- `apps/dashboard/src/routes/api/v1/conversations.ts`
+- `apps/dashboard/src/lib/conversation-store/memory-store.test.ts` (extend)
+- `apps/dashboard/src/lib/conversation-store/d1-store.sql.test.ts` (create — runs the real SQL via `bun:sqlite`)
+
+**Out of scope** (do NOT touch):
+- The `StoredConversation` type / DB schema / migration SQL — the fix is query-level, no schema change.
+- The `get`/`delete` methods — already correctly scoped (`WHERE id=? AND user_id=?`).
+- Any other route or the AgentState key-namespacing logic beyond adapting the return type.
+
+## Git workflow
+
+- Branch: `advisor/04-conversation-upsert-idor`
+- Conventional commits; include `Co-Authored-By: duyetbot <bot@duyet.net>`. Example: `fix(conversations): scope upsert to owner to close cross-tenant IDOR`.
+- Do NOT push or open a PR unless the operator instructed it.
+
+## Steps
+
+### Step 1: Close the D1 hole (security-critical — this alone stops the takeover)
+
+In `d1-store.ts` `upsert`: **(1) extract** the full `INSERT … ON CONFLICT …`
+statement into an exported module constant so the Step 4b test can run the exact
+string — `export const D1_UPSERT_CONVERSATION_SQL = \`…\`` — and pass it to
+`db.prepare(D1_UPSERT_CONVERSATION_SQL)`. **(2)** change the `ON CONFLICT` clause to
+**remove** the `user_id = excluded.user_id` line and add a trailing `WHERE` guard so
+a row owned by someone else is never updated:
+
+```sql
+ON CONFLICT (id) DO UPDATE SET
+  title = excluded.title,
+  messages = excluded.messages,
+  message_count = excluded.message_count,
+  updated_at = excluded.updated_at
+WHERE conversations.user_id = excluded.user_id
+```
+
+**Verify**: `cd apps/dashboard && bun run type-check` → exit 0.
+
+### Step 2: Close the Postgres hole identically
+
+In `postgres-store.ts` `upsert`, remove `user_id = EXCLUDED.user_id` and append
+`WHERE conversations.user_id = EXCLUDED.user_id` to the `DO UPDATE`.
+
+**Verify**: `rg -n "user_id = excluded.user_id|user_id = EXCLUDED.user_id" apps/dashboard/src/lib/conversation-store` → **no matches**.
+
+### Step 3: Make `upsert` report whether it wrote a row (fail-loud plumbing)
+
+The DB guard now makes a foreign-owned PUT a silent no-op. To fail loud instead of
+returning a misleading `200`, surface a written/not-written signal. This step is
+**atomic** — change the interface and ALL six impls and BOTH callers together, or the
+build breaks.
+
+1. `types.ts:240` — change `upsert(conversation: StoredConversation): Promise<void>` to
+   `upsert(conversation: StoredConversation): Promise<{ written: boolean }>`.
+2. `d1-store.ts` — `const res = await stmt.run(); return { written: (res.meta?.changes ?? 0) > 0 }`
+   (SQLite `changes()` is 0 when the `DO UPDATE … WHERE` guard fails).
+3. `postgres-store.ts` — capture the result of the tagged-template query
+   (`const res = await this.sql\`…\``) and `return { written: res.count > 0 }`
+   (`postgres.js` exposes `.count` = rows affected).
+4. `memory-store.ts` — see Step 4 (add the owner guard there, return `{ written }`).
+5. `agentstate-store.ts` and `browser-store.ts` — these are namespaced-safe / single-user;
+   after their existing write, `return { written: true }`.
+
+**Verify**: `cd apps/dashboard && bun run type-check` → exit 0 (this proves all impls + callers were updated).
+
+### Step 4: Give the in-memory reference impl the same ownership semantics + a regression test
+
+`memory-store.ts` `upsert` uses a `Map`. Add the owner guard so it matches production
+semantics and can be tested without a live DB: if a conversation with `conversation.id`
+already exists under a **different** `userId`, do NOT overwrite it — `return { written: false }`.
+Otherwise write and `return { written: true }`.
+
+**Verify**: `cd apps/dashboard && bun test src/lib/conversation-store/memory-store.test.ts --isolate` → all pass (including the new cases from the Test plan).
+
+### Step 4b: Prove the REAL D1 SQL enforces ownership (bun:sqlite — the security gate)
+
+`memory-store` is a `Map` and exercises **none** of the actual fix — the
+`WHERE … = excluded.user_id` guard and the `changes === 0` semantics that the
+`written` flag depends on live only in the SQL string. Test that string directly
+against in-memory SQLite (SQLite **is** D1's engine), so the fix is actually executed.
+Create `d1-store.sql.test.ts`:
+
+```ts
+import { Database } from 'bun:sqlite'
+import { describe, expect, test } from 'bun:test'
+import { D1_UPSERT_CONVERSATION_SQL } from './d1-store' // exported in Step 1
+
+function seed() {
+  const db = new Database(':memory:')
+  // PK is `id` alone — mirror db/conversations-migrations/0001_conversations.sql
+  db.run(`CREATE TABLE conversations (
+    id TEXT PRIMARY KEY, user_id TEXT NOT NULL, title TEXT, messages TEXT,
+    message_count INTEGER, created_at INTEGER, updated_at INTEGER)`)
+  db.run(`INSERT INTO conversations VALUES ('c1','u1','orig','[1]',1,1,1)`)
+  return db
+}
+// Bind order must match the ?1..?7 order in the SQL:
+// (id, user_id, title, messages, message_count, created_at, updated_at)
+
+describe('d1 upsert ownership guard (real SQL)', () => {
+  test('a foreign owner cannot overwrite/seize the row; changes === 0', () => {
+    const db = seed()
+    const res = db.query(D1_UPSERT_CONVERSATION_SQL).run('c1','u2','hijacked','[]',0,2,2)
+    expect(res.changes).toBe(0)                    // guard blocked the update
+    const row = db.query(`SELECT user_id, title, messages FROM conversations WHERE id='c1'`).get() as any
+    expect(row.user_id).toBe('u1')                 // ownership intact
+    expect(row.title).toBe('orig')                 // content intact
+    expect(row.messages).toBe('[1]')
+  })
+  test('the owner can update; changes === 1', () => {
+    const db = seed()
+    const res = db.query(D1_UPSERT_CONVERSATION_SQL).run('c1','u1','new','[1,2]',2,1,3)
+    expect(res.changes).toBe(1)
+    expect((db.query(`SELECT title FROM conversations WHERE id='c1'`).get() as any).title).toBe('new')
+  })
+  test('a new id inserts; changes === 1', () => {
+    const db = seed()
+    expect(db.query(D1_UPSERT_CONVERSATION_SQL).run('c2','u2','x','[]',0,4,4).changes).toBe(1)
+  })
+})
+```
+
+If `?1`-style numbered binding doesn't accept positional `.run(...)` args in this
+`bun:sqlite` version, bind by object (`{ 1: 'c1', 2: 'u2', … }`) or match the SQL's
+param style — do NOT change the production SQL to suit the test.
+
+**Verify**: `cd apps/dashboard && bun test src/lib/conversation-store/d1-store.sql.test.ts --isolate` → all pass; the foreign-owner test proves `changes === 0` and the victim row is byte-for-byte unchanged.
+
+### Step 5: Fail loud in the routes
+
+- `conversations/$id.ts` `handlePut` (`:295`): change to
+  `const { written } = await store.upsert(updatedConversation)` and, when
+  `!written && existingConversation === null`, return a **409** with
+  `ApiErrorType.ValidationError` (or a Conflict type if one exists) and message
+  `'Conversation ID belongs to another user.'` — reusing the `createApiErrorResponse`
+  shape at `$id.ts:236-244`. When `existingConversation` was non-null the write always
+  succeeds (owned update), so the existing 200 path is unchanged.
+- `conversations.ts` `handlePost` (`:281`): adapt to the new return type. If this route
+  mints a fresh server-side id, `written` is always true; still handle `!written` by
+  returning a 409 (unexpected id collision) rather than a misleading 200.
+
+**Verify**: `cd apps/dashboard && bun run build` → exit 0, and `bun run lint` → exit 0.
+
+## Test plan
+
+Extend `apps/dashboard/src/lib/conversation-store/memory-store.test.ts` (mirror its existing `describe`/`test` structure):
+
+1. **owner update** — `upsert({id:'c1', userId:'u1', …})` then `upsert({id:'c1', userId:'u1', title:'new'})` → second returns `{written:true}`; `get('u1','c1').title === 'new'`.
+2. **foreign write blocked (the regression test for this IDOR)** — `upsert({id:'c1', userId:'u1', title:'orig', messages:[…]})`, then `upsert({id:'c1', userId:'u2', title:'hijacked', messages:[]})` → returns `{written:false}`; `get('u1','c1')` still has `title:'orig'`, original messages, and `userId:'u1'` (unchanged); `get('u2','c1')` returns `null`.
+3. **new id** — `upsert({id:'c2', userId:'u2', …})` → `{written:true}`; retrievable by `u2`.
+
+**Plus the real-SQL gate** (`d1-store.sql.test.ts`, Step 4b): the production
+`D1_UPSERT_CONVERSATION_SQL` run under `bun:sqlite` proves a foreign-owner PUT yields
+`changes === 0` and leaves the victim's row intact. This — not the memory-store test —
+is what proves the security fix actually works; the memory-store test only locks the
+reference-impl semantics. (Postgres shares the identical guard pattern and is verified by
+review + type-check; SQLite is the semantic anchor.)
+
+Verification: `cd apps/dashboard && bun test src/lib/conversation-store --isolate` → all pass, including the new memory-store cases and the `d1-store.sql.test.ts` gate.
+
+## Done criteria
+
+ALL must hold:
+- [ ] `cd apps/dashboard && bun run type-check` exits 0
+- [ ] `cd apps/dashboard && bun test src/lib/conversation-store --isolate` passes, including the memory-store "foreign write blocked" test AND the `d1-store.sql.test.ts` real-SQL gate
+- [ ] `d1-store.sql.test.ts` runs `D1_UPSERT_CONVERSATION_SQL` under `bun:sqlite` and asserts the foreign-owner case yields `changes === 0` with the victim's row unchanged
+- [ ] `rg -n "user_id = excluded.user_id|user_id = EXCLUDED.user_id" apps/dashboard/src/lib/conversation-store` returns no matches
+- [ ] `cd apps/dashboard && bun run build` exits 0
+- [ ] `bun run lint` exits 0
+- [ ] No files outside the in-scope list modified (`git status`)
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report (do not improvise) if:
+- The `ON CONFLICT (id) DO UPDATE` excerpts don't match the live D1/Postgres code (drift).
+- Changing `upsert`'s return type reveals a **caller not listed** in Scope (more than the two routes + six impls).
+- The `d1-store.sql.test.ts` gate shows the guarded foreign-owner upsert does **NOT** yield `changes === 0` (i.e. the `DO UPDATE … WHERE` guard doesn't behave as expected in SQLite/D1) — STOP and report; the whole `written`→409 design rests on this, and shipping without it re-opens the IDOR.
+- `res.meta?.changes` is not available on the live D1 result object in the Worker runtime (the `bun:sqlite` test proves the SQL, but the impl reads `changes` off the real D1 result — confirm the field name).
+- `postgres.js`'s result has no `.count` field in the installed version.
+
+## Maintenance notes
+
+- Reviewer: confirm the `WHERE … = excluded.user_id` guard is present on **both** SQL backends and that `user_id` is never in a `SET` list again.
+- If a future feature legitimately transfers conversation ownership, it must be an explicit, separately-authorized operation — never a side effect of `upsert`.
+- The security fix is proven by `d1-store.sql.test.ts` (real SQL under `bun:sqlite`); `memory-store.test.ts` only locks the reference-impl semantics. Postgres shares the guard pattern but isn't dialect-testable with `bun:sqlite` — if a Postgres integration harness is added later, port the foreign-owner case there too.

--- a/plans/05-health-webhook-auth-gate.md
+++ b/plans/05-health-webhook-auth-gate.md
@@ -1,0 +1,164 @@
+# Plan 05: Add the missing write-auth self-gate to the anonymously-reachable health/webhook SSRF proxy
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving on. If a
+> "STOP condition" occurs, stop and report — do not improvise. When done, update
+> this plan's row in `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat c5b2ae41c..HEAD -- apps/dashboard/src/routes/api/v1/health/webhook.ts apps/dashboard/src/routes/api/v1/health/webhook.test.ts apps/dashboard/src/routes/api/v1/insights/generate.ts`
+> On any change, compare "Current state" against live code before proceeding; mismatch = STOP.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: security
+- **Planned at**: commit `c5b2ae41c`, 2026-07-03
+
+## Why this matters
+
+`POST /api/v1/health/webhook` makes the **server** issue an outbound `POST` to a
+caller-supplied URL with a caller-supplied body (`provider` + `payload` forwarded
+verbatim). It is a state-changing, SSRF-capable egress route — but it has **no
+write-auth gate**. The route file's own comment (`webhook.ts:17-18`) says per-route auth
+was "dropped; centralized in middleware (#1397)", yet the codebase's documented contract
+(see `insights/generate.ts:37-41`) is that *"the global /api/v1 middleware is a public
+passthrough under provider='none' / CHM_CLERK_PUBLIC_READ, so this route must self-enforce
+that anonymous callers cannot trigger it."* Sibling write routes (`insights/generate.ts`,
+`actions.ts`, `dashboard/settings.ts`) all self-gate with `authorizeFeatureRequest`;
+`health/webhook.ts` does not. Result: an **unauthenticated** caller can drive the server
+to POST arbitrary bodies to arbitrary public HTTPS endpoints (confused-deputy / relay
+abuse from the deployment's egress IP), and on Node self-hosts the SSRF host guard is
+additionally defeatable via DNS-rebinding. This plan adds the auth gate — the certain,
+cross-platform defect. (The DNS-rebinding hardening is deliberately a **separate** plan;
+see Out of scope.)
+
+## Current state
+
+Files:
+- `apps/dashboard/src/routes/api/v1/health/webhook.ts` — the proxy route. `handlePost` starts at `:62`; the `POST` handler is `:200-206`. No auth call anywhere (grep for `authorize` finds only the comment on `:17`).
+- `apps/dashboard/src/routes/api/v1/insights/generate.ts` — the **exemplar** to copy. Its self-gate (`:28`, `:42-47`):
+
+```ts
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
+// …
+// Write gate: … the global /api/v1 middleware is a public passthrough under
+// provider='none' / CHM_CLERK_PUBLIC_READ, so this route must self-enforce
+// that anonymous callers cannot trigger it. A valid `chm_` API key still
+// authenticates programmatic clients. Mirrors the /api/v1/actions guard.
+const permissionResponse = await authorizeFeatureRequest(
+  { feature: 'insights', defaultAccess: 'authenticated', operation: 'write' },
+  request,
+  { allowAgentBearerToken: true },
+)
+if (permissionResponse) return permissionResponse
+```
+
+- `apps/dashboard/src/routes/api/v1/health/webhook.test.ts` — existing test. It calls
+  `__handlePostForTests(request, { resolveHostAddresses, fetchImpl })` with **no auth**;
+  adding a gate will make these existing tests return the gate's response unless the gate
+  is mocked to pass.
+
+The route handler as it exists (`webhook.ts:200-206`):
+
+```ts
+export const Route = createFileRoute('/api/v1/health/webhook')({
+  server: { handlers: { POST: async ({ request }) => handlePost(request) } },
+})
+```
+
+Convention: pick the correct feature key. The webhook proxy backs the **alerting/settings**
+surface (its port note at `:17` names `SETTINGS_FEATURE_PERMISSION`). Check
+`apps/dashboard/src/lib/feature-permissions/permissions.ts` for the existing feature keys
+(e.g. `settings`, `insights`, `actions`) and use the one that already governs health/alert
+settings. Do NOT invent a new feature key unless none fits — if none fits, STOP and report.
+
+## Commands you will need
+
+| Purpose | Command | Expected |
+|---|---|---|
+| Typecheck | `cd apps/dashboard && bun run type-check` | exit 0 |
+| Unit test | `cd apps/dashboard && bun test src/routes/api/v1/health/webhook.test.ts --isolate` | all pass |
+| Lint | `bun run lint` | exit 0 |
+| Grep gate present | `rg -n "authorizeFeatureRequest" apps/dashboard/src/routes/api/v1/health/webhook.ts` | ≥1 match |
+
+## Scope
+
+**In scope**:
+- `apps/dashboard/src/routes/api/v1/health/webhook.ts`
+- `apps/dashboard/src/routes/api/v1/health/webhook.test.ts`
+
+**Out of scope** (do NOT touch):
+- The `fetch` call at `webhook.ts:154-164` — the DNS-rebinding/socket-pinning hardening is **plan 13's SSRF-test companion + a separate follow-up**, and on Cloudflare Workers `createHostValidationFetch` throws for hostname targets (Slack/Discord are hostnames), so swapping it here would break the feature. Leave the outbound fetch exactly as-is.
+- The `validateHostUrl` SSRF check (`:99`) — keep it; it stays as defense-in-depth.
+- Any other route.
+
+## Git workflow
+
+- Branch: `advisor/05-health-webhook-auth-gate`
+- Conventional commits + `Co-Authored-By: duyetbot <bot@duyet.net>`. Example: `fix(security): require write-auth on health/webhook SSRF proxy`.
+- Do NOT push/PR unless instructed.
+
+## Steps
+
+### Step 1: Add the self-gate at the top of `handlePost`
+
+In `webhook.ts`, import `authorizeFeatureRequest` from `@/lib/feature-permissions/server`
+and, as the **first** thing inside `handlePost` (before reading the body at `:68`), add
+the gate mirroring `insights/generate.ts:42-47`, using the feature key you selected from
+`permissions.ts` and `operation: 'write'`, `{ allowAgentBearerToken: true }`. Return the
+permission response immediately if present. Keep the explanatory comment.
+
+**Verify**: `rg -n "authorizeFeatureRequest" apps/dashboard/src/routes/api/v1/health/webhook.ts` → ≥1 match; `cd apps/dashboard && bun run type-check` → exit 0.
+
+### Step 2: Keep the test harness able to inject an authorized/anonymous state
+
+The gate reads auth from the `request`, not from injected deps, so the existing tests
+would now fail (blocked before the SSRF logic). Mock the gate in `webhook.test.ts` with
+`mock.module('@/lib/feature-permissions/server', …)` — mirror the `mock.module` style in
+`apps/dashboard/src/routes/api/v1/webhooks/polar.test.ts:21-74` (stable wrapper delegating
+to a per-test `let` binding so a test can flip it). Default the mock to **authorized**
+(returns `null`) so all existing SSRF tests keep passing unchanged.
+
+**Verify**: `cd apps/dashboard && bun test src/routes/api/v1/health/webhook.test.ts --isolate` → all existing tests pass.
+
+### Step 3: Add the auth-gate regression tests
+
+Add a `describe('health webhook proxy — auth gate', …)` with:
+1. **anonymous is blocked, no egress** — set the mocked `authorizeFeatureRequest` to return a `401`/`403` `Response`; call `__handlePostForTests(makeRequest({url:'https://hooks.slack.com/x', text:'hi'}), { resolveHostAddresses: resolvePublic, fetchImpl })`; assert the returned status is the gate's status **and** `calls.length === 0` (the outbound `fetch` never ran).
+2. **authorized passes through** — mocked gate returns `null`; the same request reaches the outbound fetch (`calls.length === 1`, `calls[0].url` is the Slack URL) and returns 200.
+
+Reuse the existing `makeRequest`, `stubFetch`, `resolvePublic` helpers at `webhook.test.ts:8-30`.
+
+**Verify**: `cd apps/dashboard && bun test src/routes/api/v1/health/webhook.test.ts --isolate` → all pass, including the 2 new tests; `bun run lint` → exit 0.
+
+## Test plan
+
+- New tests in `webhook.test.ts` per Step 3: anonymous→blocked+no-egress, authorized→forwarded.
+- Structural pattern: the existing `webhook.test.ts` for request/fetch stubbing; `polar.test.ts:21-74` for `mock.module`.
+- Verification: `cd apps/dashboard && bun test src/routes/api/v1/health/webhook.test.ts --isolate` → all pass.
+
+## Done criteria
+
+- [ ] `rg -n "authorizeFeatureRequest" apps/dashboard/src/routes/api/v1/health/webhook.ts` → ≥1 match
+- [ ] `cd apps/dashboard && bun test src/routes/api/v1/health/webhook.test.ts --isolate` passes incl. the "anonymous blocked, no egress" test
+- [ ] `cd apps/dashboard && bun run type-check` exits 0
+- [ ] `cd apps/dashboard && bun run build` exits 0
+- [ ] `bun run lint` exits 0
+- [ ] The outbound `fetch` at `webhook.ts:154-164` is unchanged (`git diff` shows no edit there)
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- No existing feature key in `permissions.ts` fits a health/alert-settings write (don't invent one silently — report the options).
+- `authorizeFeatureRequest`'s signature differs from the `insights/generate.ts` exemplar (drift).
+- Making the test authorized-by-default still breaks a pre-existing SSRF test for a reason other than the gate.
+
+## Maintenance notes
+
+- Reviewer: confirm the gate is `operation: 'write'` and runs **before** any body parse or egress; confirm no change to the SSRF `fetch`.
+- Deferred out of this plan (own follow-up): DNS-rebinding hardening (pin the outbound socket to the validated address on Node; note the Workers hostname-pinning limitation). Plan 13 adds the missing tests for the pinning primitive (`createHostValidationFetch`) that a future rebinding fix would build on.
+- If more `/api/v1` write routes are added, they must self-gate too until/unless the global middleware is changed to fail-closed on writes.

--- a/plans/06-alert-commit-after-delivery.md
+++ b/plans/06-alert-commit-after-delivery.md
@@ -1,0 +1,211 @@
+# Plan 06: Persist alert dedup state only after the webhook delivery succeeds
+
+> **Executor instructions**: Follow step by step, running each verification
+> command and confirming its expected result before moving on. If a "STOP
+> condition" occurs, stop and report. When done, update this plan's row in
+> `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat c5b2ae41c..HEAD -- apps/dashboard/src/lib/health/alert-state-store.ts apps/dashboard/src/lib/health/server-sweep.ts apps/dashboard/src/lib/health/alert-state-store.test.ts`
+> On any change, compare "Current state" against live code; mismatch = STOP.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: bug
+- **Planned at**: commit `c5b2ae41c`, 2026-07-03
+
+## Why this matters
+
+The autonomous health sweep (cron, every ~5 min) records an alert as "notified"
+**before** it confirms the webhook actually delivered. `evaluateAlert` persists the
+dedup record (`notifiedAt = now`) as a side effect of *deciding*
+(`alert-state-store.ts:248-253`), and the sweep only then calls `postWebhook`
+(`server-sweep.ts:245-263`) — whose `false` return (Slack/Discord 5xx, timeout, network
+error) bumps no counter and rolls nothing back. So when a **new** or **escalated** critical
+alert's first delivery fails, the store already says "notified now", and the next sweep
+sees the same severity within the cooldown (`DEFAULT_ALERT_COOLDOWN_MS`, ~60 min) and
+**suppresses** it. A critical alert whose first POST fails is silently dropped for up to
+an hour — and lost entirely if the condition drops below threshold in the meantime. The
+fix commits the "notified" timestamp only after a confirmed delivery, so a failed send is
+retried on the next sweep.
+
+## Current state
+
+Files:
+- `apps/dashboard/src/lib/health/alert-state-store.ts` — `MemoryAlertStateStore` (`:86`), the module singleton `alertStateStore` (`:107`), `decideNotification` (pure decider, returns `{ decision, next }`), and `evaluateAlert` (`:232-254`) which reads → decides → **persists** → returns only the decision.
+- `apps/dashboard/src/lib/health/server-sweep.ts` — the sweep loop; the only non-test caller of `evaluateAlert` (`:245`).
+- `apps/dashboard/src/lib/health/alert-state-store.test.ts` — existing tests; `describe('evaluateAlert + MemoryAlertStateStore')` (`:115`) constructs `new MemoryAlertStateStore()` and reads `evaluateAlert(store, {...}).kind`.
+
+`evaluateAlert` today (`alert-state-store.ts:232-254`) — note it persists unconditionally:
+
+```ts
+export function evaluateAlert(store, params): AlertDecision {
+  const key = alertStateKey(params.hostId, params.ruleId)
+  const prev = store.get(key)
+  const { decision, next } = decideNotification(prev, params.severity, {
+    cooldownMs: params.cooldownMs, now: params.now,
+  })
+  if (next === null) store.delete(key)
+  else store.set(key, next)          // ⚠ persists notifiedAt=now BEFORE delivery
+  return decision
+}
+```
+
+The sweep today (`server-sweep.ts:242-267`) — delivery failure changes nothing:
+
+```ts
+const decision = evaluateAlert(alertStateStore, { hostId: config.id, ruleId: rule.id, severity: effective, cooldownMs })
+if (decision.notify) {
+  const text = decision.kind === 'recovery' ? `[RECOVERY] …` : `[${effective.toUpperCase()}] …`
+  const ok = await postWebhook(settings.webhookUrl, text)
+  if (ok) { alertsDispatched++; if (decision.kind === 'recovery') recoveries++ }
+  // ⚠ ok === false → nothing rolls back; state already says "notified"
+} else if (SEVERITY_ORDER[severity] >= minRank) {
+  alertsSuppressed++
+}
+```
+
+Convention: keep `decideNotification` **pure** and unchanged — it already returns the
+correct `next` record (with `notifiedAt`); only *when* that record is persisted changes.
+
+## Commands you will need
+
+| Purpose | Command | Expected |
+|---|---|---|
+| Typecheck | `cd apps/dashboard && bun run type-check` | exit 0 |
+| Unit test | `cd apps/dashboard && bun test src/lib/health/alert-state-store.test.ts --isolate` | all pass |
+| Lint | `bun run lint` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `apps/dashboard/src/lib/health/alert-state-store.ts`
+- `apps/dashboard/src/lib/health/server-sweep.ts`
+- `apps/dashboard/src/lib/health/alert-state-store.test.ts`
+
+**Out of scope**:
+- `decideNotification` and the `AlertDecision`/`AlertStateRecord` types — do not change the decision logic or record shape, only the persistence timing.
+- The cooldown value, severity ordering, recovery logic.
+- Any other consumer of the alert system.
+
+## Git workflow
+
+- Branch: `advisor/06-alert-commit-after-delivery`
+- Conventional commits + `Co-Authored-By: duyetbot <bot@duyet.net>`. Example: `fix(alerting): commit dedup state only after webhook delivery to stop dropped alerts`.
+- Do NOT push/PR unless instructed.
+
+## Steps
+
+### Step 1: Make `evaluateAlert` return a deferred `commit`, not persist eagerly
+
+Change `evaluateAlert` so it computes the decision + pending record but does **not** write;
+it returns a `commit` thunk the caller invokes when it wants the state to land:
+
+```ts
+export function evaluateAlert(
+  store: AlertStateStore,
+  params: { hostId: number; ruleId: string; severity: AlertRuleSeverity; cooldownMs?: number; now?: number },
+): { decision: AlertDecision; commit: () => void } {
+  const key = alertStateKey(params.hostId, params.ruleId)
+  const prev = store.get(key)
+  const { decision, next } = decideNotification(prev, params.severity, {
+    cooldownMs: params.cooldownMs, now: params.now,
+  })
+  const commit = () => { if (next === null) store.delete(key); else store.set(key, next) }
+  return { decision, commit }
+}
+```
+
+**Verify**: `cd apps/dashboard && bun run type-check` → will FAIL until Step 2 + Step 3 update the caller and tests. That's expected; proceed.
+
+### Step 2: In the sweep, commit only after a successful delivery
+
+Restructure the `server-sweep.ts` dispatch block (`:245-267`):
+
+```ts
+const { decision, commit } = evaluateAlert(alertStateStore, {
+  hostId: config.id, ruleId: rule.id, severity: effective, cooldownMs,
+})
+if (decision.notify) {
+  const label = rule.formatLabel ? rule.formatLabel(value) : String(value)
+  const text = decision.kind === 'recovery'
+    ? `[RECOVERY] ${rule.title} — resolved (host ${name})`
+    : `[${effective.toUpperCase()}] ${rule.title} — ${label} (host ${name})`
+  const ok = await postWebhook(settings.webhookUrl, text)
+  if (ok) {
+    commit()                            // persist notifiedAt ONLY after confirmed delivery
+    alertsDispatched++
+    if (decision.kind === 'recovery') recoveries++
+  }
+  // ok === false → do NOT commit → next sweep re-evaluates and retries
+} else {
+  commit()                              // record dedup/de-escalation/recovery-cleared bookkeeping
+  if (SEVERITY_ORDER[severity] >= minRank) alertsSuppressed++
+}
+```
+
+Note: `commit()` moves into the `else` branch too (every non-notify decision still records
+its state — only the *notify* path gates on delivery).
+
+**Verify**: `cd apps/dashboard && bun run type-check` → exit 0 (proves caller updated).
+
+### Step 3: Update existing tests to the new return shape and add the regression test
+
+In `alert-state-store.test.ts`, every existing `evaluateAlert(store, {...})` now returns
+`{ decision, commit }`. Mechanically: capture the result, read `.decision.kind` /
+`.decision.notify` instead of `.kind` / `.notify`, and call `.commit()` **immediately after
+each existing call** so the prior "always-persisted" behaviour (which the cooldown
+assertions depend on) is reproduced exactly.
+
+Then add the regression test in the same `describe`:
+
+```ts
+test('a failed delivery (no commit) does not suppress the next sweep', () => {
+  const store = new MemoryAlertStateStore()
+  const base = { hostId: 1, ruleId: 'cpu', cooldownMs: 60_000 }
+  const first = evaluateAlert(store, { ...base, severity: 'critical', now: 1_000 })
+  expect(first.decision.notify).toBe(true)          // new critical → notify
+  // simulate delivery FAILURE: do NOT commit
+  const second = evaluateAlert(store, { ...base, severity: 'critical', now: 2_000 })
+  expect(second.decision.notify).toBe(true)         // retried, NOT suppressed
+  second.commit()                                   // delivery now succeeds
+  const third = evaluateAlert(store, { ...base, severity: 'critical', now: 3_000 })
+  expect(third.decision.notify).toBe(false)         // within cooldown after a committed notify → suppressed
+})
+```
+
+**Verify**: `cd apps/dashboard && bun test src/lib/health/alert-state-store.test.ts --isolate` → all pass; `bun run lint` → exit 0.
+
+## Test plan
+
+- Update all existing `evaluateAlert` usages in `alert-state-store.test.ts` to `.decision` + `.commit()`.
+- Add the "failed delivery does not suppress next sweep" regression test (above) — it fails on the current code (which suppresses) and passes after the fix.
+- Structural pattern: the existing `describe('evaluateAlert + MemoryAlertStateStore')` block.
+- Verification: `cd apps/dashboard && bun test src/lib/health/alert-state-store.test.ts --isolate` → all pass.
+
+## Done criteria
+
+- [ ] `evaluateAlert` returns `{ decision, commit }` and performs no store write itself
+- [ ] `server-sweep.ts` calls `commit()` inside `if (ok)` for the notify path and in the non-notify `else`
+- [ ] `cd apps/dashboard && bun test src/lib/health/alert-state-store.test.ts --isolate` passes, incl. the new regression test
+- [ ] `cd apps/dashboard && bun run type-check` exits 0
+- [ ] `cd apps/dashboard && bun run build` exits 0
+- [ ] `bun run lint` exits 0
+- [ ] No files outside scope modified (`git status`)
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- `rg -n "evaluateAlert" apps/dashboard/src` reveals a **non-test caller other than `server-sweep.ts`** — update it too, but if its shape is unclear, STOP and report.
+- `decideNotification` does not already return a `next` record containing `notifiedAt` (drift from the excerpt).
+- After the change, an existing cooldown/reminder test fails for a reason other than the mechanical `.decision` / `.commit()` update.
+
+## Maintenance notes
+
+- Reviewer: confirm `commit()` is unreachable on the `postWebhook` failure path for a notify decision, and reachable on every non-notify path.
+- `alertStateStore` is a warm module singleton — the retry is per-process; a cold start still worst-cases to one duplicate (documented at `alert-state-store.ts:20-22`). This fix does not change that trade-off.
+- If delivery is ever made to fan out to multiple channels, "success" for commit should mean "all required channels delivered" (or per-channel commit) — revisit then.

--- a/plans/07-parallel-connection-chart-queries.md
+++ b/plans/07-parallel-connection-chart-queries.md
@@ -1,0 +1,170 @@
+# Plan 07: Run multi-query charts on user/browser connections in parallel
+
+> **Executor instructions**: Follow step by step; verify each step before the
+> next. On a "STOP condition", stop and report. When done, update this plan's
+> row in `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat c5b2ae41c..HEAD -- apps/dashboard/src/lib/connection-query/execute-connection-chart.ts`
+> On any change, compare "Current state" against live code; mismatch = STOP.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: perf
+- **Planned at**: commit `c5b2ae41c`, 2026-07-03
+
+## Why this matters
+
+Multi-query charts (summary cards that issue several keyed queries) run **sequentially**
+on user-added / browser-stored ClickHouse connections, while the env-host path runs the
+same queries in parallel. `executeConnectionChartQuery` uses a `for … await` loop
+(`execute-connection-chart.ts:45-57`); the env equivalent `executeMultiChartQuery` uses
+`Promise.all` (`query-executor.ts:232-254`). So every 30-second poll of a 4-query card on
+a "bring-your-own ClickHouse" connection pays the **sum** of query latencies (~600 ms at
+150 ms each) instead of the **max** (~150 ms). This regression only hits self-added
+connections — exactly the cloud "connect your own cluster" path. The fix parallelizes the
+loop while preserving the existing all-or-nothing error behaviour (no downstream change).
+
+## Current state
+
+File: `apps/dashboard/src/lib/connection-query/execute-connection-chart.ts` —
+`executeConnectionChartQuery` (`:24`). The serial multi-query branch (`:40-64`):
+
+```ts
+if ('queries' in queryDef) {
+  const combined: Record<string, unknown[]> = {}
+  let executedSql = ''
+  const start = Date.now()
+  for (const q of queryDef.queries) {                          // ⚠ serial
+    const { data } = await queryConnection<Record<string, unknown>>(
+      credentials, q.query,
+      { clickhouse_settings: timezone ? { session_timezone: timezone } : undefined },
+    )
+    combined[q.key] = data
+    executedSql += `${q.key}: ${q.query}\n`
+  }
+  return { data: combined, metadata: { duration: Date.now() - start, rows: queryDef.queries.length }, executedSql }
+}
+```
+
+`queryConnection` is imported from `./connection-client` (`:4`). The two consumers —
+`routes/api/v1/user-connections/charts/$name.ts:102` and
+`routes/api/v1/browser-connections/charts/$name.ts:77` — just `await` the result and read
+`.data` / `.metadata` / `.executedSql`; the return shape must not change.
+
+Exemplar to mirror (`query-executor.ts:232-254`): `Promise.all(queries.map(async (q) => …))`.
+
+## Commands you will need
+
+| Purpose | Command | Expected |
+|---|---|---|
+| Typecheck | `cd apps/dashboard && bun run type-check` | exit 0 |
+| Unit test | `cd apps/dashboard && bun test src/lib/connection-query --isolate` | all pass |
+| Lint | `bun run lint` | exit 0 |
+| Grep no serial loop | `rg -n "for \(const q of queryDef.queries\)" apps/dashboard/src/lib/connection-query/execute-connection-chart.ts` | no matches after fix |
+
+## Scope
+
+**In scope**:
+- `apps/dashboard/src/lib/connection-query/execute-connection-chart.ts`
+- `apps/dashboard/src/lib/connection-query/execute-connection-chart.test.ts` (create)
+
+**Out of scope** (do NOT touch):
+- The single-query branch (`:66+`) and `selectSqlForConnection`.
+- The env-host path `query-executor.ts` — it is already parallel; this plan only aligns the connection path to it.
+- The two consumer routes — the return shape is unchanged, so they need no edits.
+- **Do not** add per-query error isolation / partial-result semantics here — the current
+  loop throws on the first failing query, and preserving that keeps the consumers unchanged.
+  (A per-key error contract like `executeMultiChartQuery`'s is a separate, larger change.)
+
+## Git workflow
+
+- Branch: `advisor/07-parallel-connection-chart-queries`
+- Conventional commits + `Co-Authored-By: duyetbot <bot@duyet.net>`. Example: `perf(connections): run multi-query charts in parallel on user connections`.
+- Do NOT push/PR unless instructed.
+
+## Steps
+
+### Step 1: Replace the serial loop with `Promise.all`, preserving throw-on-first-failure
+
+Rewrite the multi-query branch so all queries start together. `Promise.all` rejects on the
+first rejection — matching the current loop's "throws on first failing query" behaviour, so
+no consumer change is needed:
+
+```ts
+if ('queries' in queryDef) {
+  const start = Date.now()
+  const entries = await Promise.all(
+    queryDef.queries.map(async (q) => {
+      const { data } = await queryConnection<Record<string, unknown>>(
+        credentials, q.query,
+        { clickhouse_settings: timezone ? { session_timezone: timezone } : undefined },
+      )
+      return [q.key, data, q.query] as const
+    }),
+  )
+  const combined: Record<string, unknown[]> = {}
+  let executedSql = ''
+  for (const [key, data, query] of entries) {
+    combined[key] = data
+    executedSql += `${key}: ${query}\n`
+  }
+  return { data: combined, metadata: { duration: Date.now() - start, rows: queryDef.queries.length }, executedSql }
+}
+```
+
+(The trailing `for` only assembles already-resolved results — it does no I/O, so ordering
+of `executedSql` stays deterministic in `queries` order.)
+
+**Verify**: `cd apps/dashboard && bun run type-check` → exit 0; `rg -n "for \(const q of queryDef.queries\)" apps/dashboard/src/lib/connection-query/execute-connection-chart.ts` → no matches.
+
+### Step 2: Add a test proving correctness + concurrency
+
+Create `execute-connection-chart.test.ts` mocking `queryConnection` from `./connection-client`
+(`mock.module('./connection-client', …)`, mirroring the `mock.module` style in
+`apps/dashboard/src/routes/api/v1/webhooks/polar.test.ts:21-74`). Cover:
+1. **Result assembly** — a 3-query chart returns `data` keyed by each `q.key` with the
+   mocked rows, and `metadata.rows === 3`.
+2. **Concurrency** — the mock increments a shared `inFlight` counter on entry, yields
+   (`await Promise.resolve()` a couple of times), records `maxInFlight`, decrements on
+   exit. Assert `maxInFlight === queries.length` (all ran concurrently). If this proves
+   flaky in the runtime, downgrade it to asserting `queryConnection` was called once per
+   key and remove the timing element — but keep case 1.
+
+**Verify**: `cd apps/dashboard && bun test src/lib/connection-query/execute-connection-chart.test.ts --isolate` → all pass; `bun run lint` → exit 0.
+
+## Test plan
+
+- New file `execute-connection-chart.test.ts`: result-assembly test + concurrency test (above).
+- Structural pattern: `polar.test.ts` for `mock.module`.
+- Verification: `cd apps/dashboard && bun test src/lib/connection-query --isolate` → all pass, including the new file.
+
+## Done criteria
+
+- [ ] `rg -n "for \(const q of queryDef.queries\)" apps/dashboard/src/lib/connection-query/execute-connection-chart.ts` → no matches
+- [ ] The multi-query branch uses `Promise.all`; return shape (`data`/`metadata`/`executedSql`) unchanged
+- [ ] `cd apps/dashboard && bun test src/lib/connection-query --isolate` passes, incl. the new test
+- [ ] `cd apps/dashboard && bun run type-check` exits 0
+- [ ] `cd apps/dashboard && bun run build` exits 0
+- [ ] `bun run lint` exits 0
+- [ ] Consumer routes unchanged (`git status` lists no `charts/$name.ts`)
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- The multi-query branch has changed since the excerpt (drift), or `queryConnection`'s call
+  signature differs.
+- A consumer turns out to depend on queries executing in order (search shows any reliance on
+  sequential side effects) — parallelizing would change behaviour; report instead.
+
+## Maintenance notes
+
+- Reviewer: confirm error behaviour is unchanged (first rejection still fails the whole
+  call) and the return shape is identical.
+- If per-query error isolation (partial charts) is later wanted here, mirror
+  `executeMultiChartQuery`'s `{ key, dataJson, error }` contract — that is a deliberate
+  follow-up, not this plan, because it changes what the consumer routes receive.

--- a/plans/08-retention-prune-characterization-tests.md
+++ b/plans/08-retention-prune-characterization-tests.md
@@ -1,0 +1,150 @@
+# Plan 08: Characterize the retention-prune cron (destructive DELETE + auth gate) with tests
+
+> **Executor instructions**: Follow step by step; verify each step before the
+> next. On a "STOP condition", stop and report. When done, update this plan's
+> row in `plans/README.md`. This plan adds tests and one tiny test-only export;
+> it must NOT change the prune behaviour.
+>
+> **Drift check (run first)**:
+> `git diff --stat c5b2ae41c..HEAD -- apps/dashboard/src/routes/api/cron/retention-prune.ts`
+> On any change, compare "Current state" against live code; mismatch = STOP.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: tests
+- **Planned at**: commit `c5b2ae41c`, 2026-07-03
+
+## Why this matters
+
+`GET /api/cron/retention-prune` is the only endpoint that **hard-deletes user data** by
+plan (`DELETE FROM conversations WHERE user_id=?1 AND updated_at<?2`), and it is now an
+*enforced* gate (`lib/billing/plan-enforcement.ts` classifies `retentionDays` as
+`enforced`, naming this file). Yet the handler and its `authorizeCron` gate have **no
+test** — `routes/api/cron/__tests__/` holds only `health-sweep.test.ts`. A regression that
+breaks the auth (deletes for anyone) or inverts the cutoff (`<` → `>`, deleting *recent*
+data) would ship green. The retention *math* (`retentionCutoffMs`,
+`resolveRetentionPlanForUser`) is already covered elsewhere; this plan characterizes the
+**handler**: the auth gate, the D1-unbound no-op, and the per-user delete/skip loop.
+
+## Current state
+
+File: `apps/dashboard/src/routes/api/cron/retention-prune.ts`. Neither `authorizeCron`
+(`:50`) nor `handler` (`:76`) is exported today — only `Route` (`:163`). Behaviour to lock:
+
+- `authorizeCron`: **503** when `CRON_SECRET` unset/empty (`:56-64`, fail-closed);
+  authorized when `Authorization: Bearer <secret>` matches via `secretsMatch` (`:67`) or
+  `?secret=<secret>` matches (`:71`); **401** otherwise (`:73`). Secret is read as
+  `(env.CRON_SECRET ?? process.env.CRON_SECRET)?.trim()`.
+- `handler`: if `getPlatformBindings().getD1Database('CHM_CLOUD_D1')` throws or returns
+  falsy → `{ skipped: true, reason: 'D1 not bound' }` 200 (`:88-91`). Else: select distinct
+  `user_id`s, and per user resolve `plan = resolveRetentionPlanForUser(userId)`,
+  `cutoff = retentionCutoffMs(plan)`; **skip** (no delete) when `cutoff == null`
+  (enterprise, `:114-117`); else `DELETE … WHERE user_id=?1 AND updated_at<?2` (`:119-124`).
+  A user whose resolution/delete throws is counted in `errors` and **skipped, never
+  deleted** (`:134-140`). Returns `{ usersProcessed, usersSkipped, totalDeleted, errors }`.
+
+Collaborators to mock: `@chm/platform` (`getPlatformBindings`), `@/lib/billing/retention-owner`
+(`resolveRetentionPlanForUser`), `@/lib/billing/entitlements` (`retentionCutoffMs` — may be
+used real if convenient). `CRON_SECRET` is controlled via `process.env.CRON_SECRET`.
+
+Test conventions: **Bun test** (`bun:test`), `mock.module` for collaborators — mirror the
+mocking style in `apps/dashboard/src/routes/api/v1/webhooks/polar.test.ts:21-74` (stable
+wrapper delegating to a per-test `let` binding). The sibling `health-sweep.test.ts` shows
+the constant-time-auth expectations and the source-reading fallback.
+
+## Commands you will need
+
+| Purpose | Command | Expected |
+|---|---|---|
+| Typecheck | `cd apps/dashboard && bun run type-check` | exit 0 |
+| Run new test | `cd apps/dashboard && bun test src/routes/api/cron/__tests__/retention-prune.test.ts --isolate` | all pass |
+| Lint | `bun run lint` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `apps/dashboard/src/routes/api/cron/retention-prune.ts` (add ONLY a test-only export; no behaviour change)
+- `apps/dashboard/src/routes/api/cron/__tests__/retention-prune.test.ts` (create)
+
+**Out of scope**:
+- The prune logic, the cutoff math, `resolveRetentionPlanForUser`, `retentionCutoffMs` — do not modify behaviour.
+- `health-sweep.ts` and its test.
+- `packages/platform` internals (mock it, don't change it).
+
+## Git workflow
+
+- Branch: `advisor/08-retention-prune-tests`
+- Conventional commits + `Co-Authored-By: duyetbot <bot@duyet.net>`. Example: `test(cron): characterize retention-prune auth + delete loop`.
+- Do NOT push/PR unless instructed.
+
+## Steps
+
+### Step 1: Expose the handler for tests (test-only export, no behaviour change)
+
+At the bottom of `retention-prune.ts`, add `export { handler as __handlerForTests }`
+(mirrors the `__handlePostForTests` convention in
+`apps/dashboard/src/routes/api/v1/health/webhook.ts:209`). Do not change `handler` or `Route`.
+
+**Verify**: `cd apps/dashboard && bun run type-check` → exit 0.
+
+### Step 2: Write the behavioural characterization test
+
+Create `retention-prune.test.ts`. If `cloudflare:workers` must be stubbed for the import
+to resolve under bun, add `mock.module('cloudflare:workers', () => ({ env: {} }))` at the
+top. Build a fake D1 whose `prepare(sql)` returns an object with `.all()` (for the
+`SELECT DISTINCT user_id`) and `.bind().run()` (for the DELETE, returning
+`{ meta: { changes: N } }`), recording the SQL + bound args so tests can assert them.
+Control `CRON_SECRET` via `process.env.CRON_SECRET` (set in `beforeEach`, delete for the
+503 case). Cases:
+
+1. **503 fail-closed** — `delete process.env.CRON_SECRET`; call the handler → status 503, no D1 access.
+2. **401 bad secret** — secret set; request with `Authorization: Bearer wrong` → 401; also `?secret=wrong` → 401.
+3. **authorized, D1 unbound no-op** — secret set + correct; mock `getPlatformBindings().getD1Database` to throw (or return null) → 200 `{ skipped: true }`, no DELETE issued.
+4. **authorized, prunes with cutoff** — D1 returns 2 distinct users; `resolveRetentionPlanForUser` → a Free plan; `retentionCutoffMs` → a fixed number; assert a `DELETE … updated_at < ?2` is issued **per user** with that cutoff bound, and `totalDeleted` reflects the fake `changes`.
+5. **enterprise skipped** — a user whose plan yields `retentionCutoffMs == null` → **no DELETE** for that user; `usersSkipped` incremented.
+6. **resolution error → skip, never delete** — `resolveRetentionPlanForUser` throws for one user → that user is counted in `errors`, **no DELETE** issued for them, and the loop continues to the next user.
+
+Assert the correct-secret path via **both** the `Authorization` header and `?secret=`.
+
+**Verify**: `cd apps/dashboard && bun test src/routes/api/cron/__tests__/retention-prune.test.ts --isolate` → all pass; `bun run lint` → exit 0.
+
+### Step 3 (fallback, only if Step 2's import can't be made to work)
+
+If `retention-prune.ts` cannot be imported/mocked in bun (e.g. an unresolvable
+`cloudflare:workers` or platform binding), fall back to the structural approach of
+`health-sweep.test.ts`: read the source and assert the auth contract (`secretsMatch`
+used for both header and query; 503 fail-closed present; DELETE uses `< ?2` not `> ?2`),
+and behaviourally test `secretsMatch` directly. Note in the test file header WHY the
+behavioural approach was not used. Prefer Step 2 — only use this if Step 2 genuinely can't run.
+
+## Test plan
+
+- New file `retention-prune.test.ts` with the 6 behavioural cases (or the structural fallback).
+- Structural pattern: `polar.test.ts` (mocking) + `health-sweep.test.ts` (auth expectations / fallback).
+- Verification: `cd apps/dashboard && bun test src/routes/api/cron --isolate` → all pass.
+
+## Done criteria
+
+- [ ] `retention-prune.ts` exports `__handlerForTests` (or the fallback note explains why not) and its runtime behaviour is unchanged (`git diff` shows only the export line added)
+- [ ] `cd apps/dashboard && bun test src/routes/api/cron/__tests__/retention-prune.test.ts --isolate` passes with ≥6 assertions covering 503 / 401 / no-op / delete / enterprise-skip / error-skip (or the structural equivalent)
+- [ ] `cd apps/dashboard && bun run type-check` exits 0
+- [ ] `bun run lint` exits 0
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- The handler's behaviour excerpts don't match the live code (drift).
+- Neither Step 2 (behavioural) nor Step 3 (structural) can produce a passing test — report the blocker (likely a module-resolution issue) rather than deleting the finding.
+- Writing the test would require changing prune *behaviour* to make it testable — STOP; behaviour must not change.
+
+## Maintenance notes
+
+- Reviewer: confirm the only production change is the `__handlerForTests` export; the DELETE
+  still uses `updated_at < cutoff` and skips on `cutoff == null` and on resolution error.
+- If a real D1/integration harness is added, promote case 4/6 to run against it.
+- Companion gap noted in the audit: `packages/platform`'s bindings resolver is untested. A
+  minimal `getPlatformBindings` adapter test is a reasonable follow-up but is out of scope here.

--- a/plans/09-management-ddl-injection.md
+++ b/plans/09-management-ddl-injection.md
@@ -1,0 +1,156 @@
+# Plan 09: Escape literals and validate privilege/target in RBAC management DDL
+
+> **Executor instructions**: Follow step by step; verify each step. On a "STOP
+> condition", stop and report. When done, update this plan's row in
+> `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat c5b2ae41c..HEAD -- apps/dashboard/src/lib/security/management-ddl.ts apps/dashboard/src/routes/api/v1/management.ts`
+> On any change, compare "Current state" against live code; mismatch = STOP.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: none
+- **Category**: security
+- **Planned at**: commit `c5b2ae41c`, 2026-07-03
+
+## Why this matters
+
+The RBAC management DDL builder interpolates request-supplied values into ClickHouse
+statements with incomplete escaping. `escapeLiteral` (`management-ddl.ts:18-20`) escapes
+only `'`, **not** `\` — so a value ending in a backslash breaks out of an
+`IDENTIFIED BY '…'` / `HOST IP '…'` literal. And `generateGrantPrivilegeDdl`
+(`:121-131`) interpolates `${privilege}` and `${on}` **raw**, with no allowlist or
+identifier check, straight from the request body (`management.ts:166-180`). This is a
+DDL-injection primitive against the monitored cluster's access-control model. It is
+**bounded** — the route requires `CLICKHOUSE_MANAGEMENT_ENABLED=true` (off by default,
+`management.ts:52-63`) and passes `authorizeFeatureRequest(ACTIONS…)`, and the caller is
+already an RBAC admin — so this is defensive hardening, not a pre-auth hole. The fix:
+escape backslashes, and validate the privilege token and grant target instead of
+interpolating them raw.
+
+## Current state
+
+Files:
+- `apps/dashboard/src/lib/security/management-ddl.ts` — the pure DDL builders. `escapeLiteral` (`:18-20`), `generateGrantPrivilegeDdl` (`:121-131`), `generateRevokePrivilegeDdl` (`:133+`), `quoteId` (`:13-15`, already correctly backtick-escapes).
+- `apps/dashboard/src/routes/api/v1/management.ts` — the route. `grant_privilege`/`revoke_privilege` read `getString(params,'privilege')` and `getString(params,'on')` from the request and pass them into the builders (`:166-192`).
+- `apps/dashboard/src/lib/sql-utils.ts:21` — **existing** `validateIdentifier(name)` — reuse it for the grant-target parts (do not write a new identifier validator).
+- `apps/dashboard/src/lib/security/management-ddl.test.ts` — existing tests (uses `bun:test`, `it`, imports the `generate*` fns). Extend it.
+
+The two defects:
+
+```ts
+// management-ddl.ts:18 — misses backslash, so `x\` breaks out of the '…' literal
+function escapeLiteral(s: string): string { return s.replace(/'/g, "\\'") }
+
+// management-ddl.ts:126 — privilege and on interpolated raw
+let ddl = `GRANT ${privilege} ON ${on} TO ${quoteId(toUser)}`
+```
+
+## Commands you will need
+
+| Purpose | Command | Expected |
+|---|---|---|
+| Typecheck | `cd apps/dashboard && bun run type-check` | exit 0 |
+| Run test | `cd apps/dashboard && bun test src/lib/security/management-ddl.test.ts --isolate` | all pass |
+| Lint | `bun run lint` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `apps/dashboard/src/lib/security/management-ddl.ts`
+- `apps/dashboard/src/lib/security/management-ddl.test.ts`
+
+**Out of scope**:
+- `management.ts` route wiring — the builders throw on invalid input; the route already
+  wraps operations in try/catch and returns an error response, so no route edit is needed.
+  (If you find the route swallows the throw silently, note it and STOP — do not refactor it here.)
+- `quoteId` — already correct; don't touch.
+- Turning management on by default / the feature gate.
+
+## Git workflow
+
+- Branch: `advisor/09-management-ddl-injection`
+- Conventional commits + `Co-Authored-By: duyetbot <bot@duyet.net>`. Example: `fix(security): escape literals and validate privilege/target in management DDL`.
+- Do NOT push/PR unless instructed.
+
+## Steps
+
+### Step 1: Fix `escapeLiteral` to escape backslashes before quotes
+
+```ts
+function escapeLiteral(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+}
+```
+
+Order matters: backslash first, then quote (so the quote's escape backslash isn't doubled).
+
+**Verify**: `cd apps/dashboard && bun run type-check` → exit 0.
+
+### Step 2: Validate the grant target (`on`) and privilege token
+
+Add two guards used by `generateGrantPrivilegeDdl` and `generateRevokePrivilegeDdl`:
+
+- **`on`** — split on `.`; each part must be `*` or pass `validateIdentifier` (imported from
+  `@/lib/sql-utils`). Accept the forms `*`, `*.*`, `db.*`, `db.table` (1 or 2 parts). Throw
+  `Error('Invalid grant target')` otherwise. Rebuild `on` from the validated parts (quote
+  non-`*` parts with `quoteId`) rather than interpolating the raw string.
+- **`privilege`** — must match a conservative pattern for a ClickHouse privilege keyword with
+  an optional column list: `^[A-Za-z][A-Za-z ]*(\([A-Za-z0-9_, ]+\))?$` (e.g. `SELECT`,
+  `ALTER UPDATE`, `SELECT(col1, col2)`, `ALL`). Throw `Error('Invalid privilege')` otherwise.
+  (Reject anything containing quotes, semicolons, backticks, or backslashes.)
+
+Apply both in `generateGrantPrivilegeDdl` (and the revoke variant) before building the string.
+
+**Verify**: `cd apps/dashboard && bun run type-check` → exit 0.
+
+### Step 3: Extend the tests
+
+In `management-ddl.test.ts` add cases:
+
+1. **backslash literal is neutralized** — `generateCreateUserDdl({ username:'u', password:"a\\" })`
+   (a password ending in a backslash) produces a statement whose `IDENTIFIED BY '…'` literal
+   is properly closed (the generated string contains `\\\\` for the backslash and does not
+   end the literal early). Assert the doubled backslash is present and the DDL still ends with
+   the expected trailing clause, not truncated.
+2. **injection in `on` is rejected** — `generateGrantPrivilegeDdl({ privilege:'SELECT', on:"a TO attacker; --" }, 'victim')` throws `Invalid grant target`.
+3. **injection in `privilege` is rejected** — `generateGrantPrivilegeDdl({ privilege:"SELECT'; DROP", on:'db.t' }, 'u')` throws `Invalid privilege`.
+4. **valid inputs still work** — `{ privilege:'SELECT', on:'db.events' }` → `GRANT SELECT ON \`db\`.\`events\` TO \`u\``; `{ privilege:'ALL', on:'*.*' }` → `GRANT ALL ON *.* TO \`u\``; a column-list privilege `SELECT(col1, col2)` is accepted.
+
+**Verify**: `cd apps/dashboard && bun test src/lib/security/management-ddl.test.ts --isolate` → all pass; `bun run lint` → exit 0.
+
+## Test plan
+
+- Extend `management-ddl.test.ts` with the 4 cases above (mirror its existing `describe`/`it` blocks).
+- Verification: `cd apps/dashboard && bun test src/lib/security/management-ddl.test.ts --isolate` → all pass, incl. the new cases.
+
+## Done criteria
+
+- [ ] `escapeLiteral` escapes `\` then `'`
+- [ ] `generateGrantPrivilegeDdl`/`generateRevokePrivilegeDdl` reject malformed `privilege`/`on` and quote the target via `quoteId`
+- [ ] New tests cover backslash-breakout, `on` injection, `privilege` injection, and valid inputs
+- [ ] `cd apps/dashboard && bun test src/lib/security/management-ddl.test.ts --isolate` passes
+- [ ] `cd apps/dashboard && bun run type-check` exits 0 and `bun run build` exits 0
+- [ ] `bun run lint` exits 0
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- The management route or UI legitimately sends privilege/target strings that the Step 2
+  patterns reject (check `management.ts` callers and any admin UI that builds these params).
+  If a real, valid input is rejected, widen the pattern minimally and note it — do not
+  loosen it to allow quotes/semicolons/backticks.
+- `validateIdentifier` is not at `@/lib/sql-utils` or has a different contract (drift).
+- The route swallows a thrown builder error without surfacing it (would hide the validation).
+
+## Maintenance notes
+
+- Reviewer: confirm no request-derived value reaches a DDL string without going through
+  `quoteId` (identifiers) or `escapeLiteral` (literals) or the new privilege/target guards.
+- ClickHouse has many privilege keywords; the pattern is intentionally conservative. If a
+  new legitimate privilege form is needed later, extend the regex with a test, don't remove it.
+- This does not change the `CLICKHOUSE_MANAGEMENT_ENABLED` gate — management stays off by default.

--- a/plans/10-data-table-body-render-key.md
+++ b/plans/10-data-table-body-render-key.md
@@ -1,0 +1,207 @@
+# Plan 10: Stop serializing the full table state on every DataTable render
+
+> **Executor instructions**: Follow step by step; verify each step. On a "STOP
+> condition", stop and report. When done, update this plan's row in
+> `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat c5b2ae41c..HEAD -- apps/dashboard/src/components/data-table/data-table.tsx`
+> On any change, compare "Current state" against live code; mismatch = STOP.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: MED
+- **Depends on**: none
+- **Category**: perf
+- **Planned at**: commit `c5b2ae41c`, 2026-07-03
+
+## Why this matters
+
+`DataTable` computes its memo-busting key by `JSON.stringify`-ing **nine** state objects on
+**every render** (`data-table.tsx:562-573`), including the `rowSelection` and `expanded` maps
+that grow with the number of selected/expanded rows. Because `columnResizeMode` defaults to
+`'onChange'` (`resolve-table-behavior.ts:37`), a column-resize drag re-renders on **every
+mousemove**, re-stringifying the entire state graph each frame. This is the same class of
+hot-path serialization that was removed from the ClickHouse client in #2194, now on the
+client render path. The fix replaces the whole-object `JSON.stringify` with a pure helper
+that builds a cheap key from primitives — preserving the exact memo-busting contract (the
+existing comment enumerates what must bust the memo) while avoiding the per-frame
+serialization.
+
+## Current state
+
+File: `apps/dashboard/src/components/data-table/data-table.tsx`. The key (`:556-573`):
+
+```tsx
+// … DataTable re-renders on every controlled state change (sorting, expanded,
+// columnSizing, rowSelection, ...) whereas DataTableContent's props are otherwise
+// stable — so a state change like `expanded` would never reach the memo and row
+// expansion would silently no-op. Passing this down guarantees the body memo busts
+// when rows change.
+const tableState = table.getState()
+const bodyRenderKey = JSON.stringify([
+  tableState.sorting, tableState.pagination, tableState.expanded,
+  tableState.columnSizing, tableState.columnOrder, tableState.columnVisibility,
+  tableState.rowSelection, globalSearch, advancedFilters,
+])
+```
+
+`bodyRenderKey` is passed to the memoized `<DataTableContent … />` (`:685`) to bust its memo.
+The **contract**: the key MUST change whenever any of those 9 values changes, or the body
+goes stale (the comment's "silently no-op" warning). `columnResizeMode` comes from
+`resolve-table-behavior.ts:37` (`behavior.columnResizeMode ?? 'onChange'`).
+
+Conventions: TanStack Table types (`SortingState`, `PaginationState`, `ExpandedState`,
+`ColumnSizingState`, `ColumnOrderState`, `VisibilityState`, `RowSelectionState`) come from
+`@tanstack/react-table`. Tests are **Bun test**. Data-table has no existing unit test, so the
+new helper's test is the machine-checkable gate for the busting contract.
+
+## Commands you will need
+
+| Purpose | Command | Expected |
+|---|---|---|
+| Typecheck | `cd apps/dashboard && bun run type-check` | exit 0 |
+| Run helper test | `cd apps/dashboard && bun test src/components/data-table/utils/body-render-key.test.ts --isolate` | all pass |
+| Lint | `bun run lint` | exit 0 |
+| Grep old key gone | `rg -n "JSON.stringify\(\[" apps/dashboard/src/components/data-table/data-table.tsx` | no matches after fix |
+
+## Scope
+
+**In scope**:
+- `apps/dashboard/src/components/data-table/utils/body-render-key.ts` (create — pure helper)
+- `apps/dashboard/src/components/data-table/utils/body-render-key.test.ts` (create — unit test)
+- `apps/dashboard/src/components/data-table/data-table.tsx` (wire the helper in; optional memo split)
+
+**Out of scope**:
+- `resolve-table-behavior.ts` / `columnResizeMode` default — do NOT change resize UX to `'onEnd'` (that would remove the live-resize feature).
+- `DataTableContent` and its memo comparator.
+- Any other data-table behaviour.
+
+## Git workflow
+
+- Branch: `advisor/10-data-table-body-render-key`
+- Conventional commits + `Co-Authored-By: duyetbot <bot@duyet.net>`. Example: `perf(data-table): build body render key from primitives instead of JSON.stringify`.
+- Do NOT push/PR unless instructed.
+
+## Steps
+
+### Step 1: Create the pure helper
+
+`body-render-key.ts` exports `computeTableBodyRenderKey(input)` taking the 9 values and
+returning a string that changes iff any input changes, without JSON-serializing whole objects:
+
+```ts
+import type {
+  ColumnOrderState, ColumnSizingState, ExpandedState, PaginationState,
+  RowSelectionState, SortingState, VisibilityState,
+} from '@tanstack/react-table'
+
+export function computeTableBodyRenderKey(input: {
+  sorting: SortingState; pagination: PaginationState; expanded: ExpandedState
+  columnSizing: ColumnSizingState; columnOrder: ColumnOrderState
+  columnVisibility: VisibilityState; rowSelection: RowSelectionState
+  globalSearch: string; advancedFilters: unknown
+}): string {
+  const { sorting, pagination, expanded, columnSizing, columnOrder, columnVisibility, rowSelection, globalSearch, advancedFilters } = input
+  const sort = sorting.map((s) => `${s.id}:${s.desc ? 1 : 0}`).join(',')
+  const page = `${pagination.pageIndex}:${pagination.pageSize}`
+  const exp = expanded === true ? 'all' : Object.keys(expanded).sort().map((k) => `${k}:${(expanded as Record<string, boolean>)[k] ? 1 : 0}`).join(',')
+  const sizing = Object.keys(columnSizing).sort().map((k) => `${k}:${columnSizing[k]}`).join(',')
+  const order = columnOrder.join(',')
+  const vis = Object.keys(columnVisibility).sort().map((k) => `${k}:${columnVisibility[k] ? 1 : 0}`).join(',')
+  const sel = Object.keys(rowSelection).sort().map((k) => `${k}:${rowSelection[k] ? 1 : 0}`).join(',')
+  // advancedFilters is small app-defined config; JSON is fine and safe here.
+  return [sort, page, exp, sizing, order, vis, sel, globalSearch, JSON.stringify(advancedFilters)].join('|')
+}
+```
+
+**Verify**: `cd apps/dashboard && bun run type-check` → exit 0.
+
+### Step 2: Unit-test the busting contract (this is the machine-checkable gate)
+
+In `body-render-key.test.ts`, assert with a `base` input that the key **differs** after each
+mutation and is **identical** for equal inputs:
+- identical inputs → identical key;
+- change sort direction / add a sort → differs;
+- change `pagination.pageIndex` and `pageSize` → differs;
+- expand a row (add a key to `expanded`) → differs; `expanded: true` differs from `{}`;
+- resize a column (change a `columnSizing` value) → differs;
+- reorder columns / toggle visibility → differs;
+- select a row (add to `rowSelection`) / deselect a different one at same count → differs;
+- change `globalSearch` / `advancedFilters` → differs.
+
+**Verify**: `cd apps/dashboard && bun test src/components/data-table/utils/body-render-key.test.ts --isolate` → all pass.
+
+### Step 3: Wire it into DataTable
+
+Replace the `JSON.stringify([...])` at `data-table.tsx:562-573` with:
+
+```tsx
+const tableState = table.getState()
+const bodyRenderKey = computeTableBodyRenderKey({
+  sorting: tableState.sorting, pagination: tableState.pagination, expanded: tableState.expanded,
+  columnSizing: tableState.columnSizing, columnOrder: tableState.columnOrder,
+  columnVisibility: tableState.columnVisibility, rowSelection: tableState.rowSelection,
+  globalSearch, advancedFilters,
+})
+```
+
+**Verify**: `rg -n "JSON.stringify\(\[" apps/dashboard/src/components/data-table/data-table.tsx` → no matches; `cd apps/dashboard && bun run build` → exit 0.
+
+### Step 4 (OPTIONAL — only if confident): memoize the resize-stable part
+
+To make column resize (the per-mousemove case) cheapest, split the key so the parts that do
+NOT change during a resize are memoized and only the sizing term recomputes per frame:
+
+```tsx
+const stableKey = useMemo(() => computeTableBodyRenderKey({
+  sorting: tableState.sorting, pagination: tableState.pagination, expanded: tableState.expanded,
+  columnSizing: {}, columnOrder: tableState.columnOrder, columnVisibility: tableState.columnVisibility,
+  rowSelection: tableState.rowSelection, globalSearch, advancedFilters,
+}), [tableState.sorting, tableState.pagination, tableState.expanded, tableState.columnOrder, tableState.columnVisibility, tableState.rowSelection, globalSearch, advancedFilters])
+const sizingKey = useMemo(() => Object.keys(tableState.columnSizing).sort().map((k) => `${k}:${tableState.columnSizing[k]}`).join(','), [tableState.columnSizing])
+const bodyRenderKey = `${stableKey}|${sizingKey}`
+```
+
+Only do this if you can confirm (via the manual checklist) that every interaction still
+updates the body. If unsure, SKIP Step 4 — Step 3 alone is a valid, safe win.
+
+**Verify**: `cd apps/dashboard && bun run build` → exit 0.
+
+### Step 5: Manual interaction check (required — no unit test covers the wiring)
+
+Run `cd apps/dashboard && bun run dev`, open a data-heavy table (e.g. a query history page),
+and confirm the body updates correctly for each: **sort** a column, **change page** &
+**page size**, **expand** a row, **select** rows (and select-all), **resize** a column,
+**search**, and apply an **advanced filter**. The body must reflect each change (no stale
+rows). Record the result in the PR description.
+
+## Test plan
+
+- New `body-render-key.test.ts` covering the busting contract (Step 2) — machine-checkable.
+- Manual interaction checklist (Step 5) for the wiring — documented, not automated.
+- Verification: `cd apps/dashboard && bun test src/components/data-table --isolate` → all pass.
+
+## Done criteria
+
+- [ ] `rg -n "JSON.stringify\(\[" apps/dashboard/src/components/data-table/data-table.tsx` → no matches
+- [ ] `body-render-key.ts` + its test exist; `cd apps/dashboard && bun test src/components/data-table/utils/body-render-key.test.ts --isolate` passes
+- [ ] `cd apps/dashboard && bun run type-check` and `bun run build` exit 0; `bun run lint` exits 0
+- [ ] Manual interaction checklist (Step 5) completed and recorded
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- The `bodyRenderKey` code doesn't match the excerpt (drift), or the key is consumed
+  somewhere other than the `DataTableContent` memo.
+- Any manual interaction (Step 5) shows a stale body after the change — revert to the
+  original `JSON.stringify` key and report; a correct-but-slow key beats a fast-but-stale one.
+
+## Maintenance notes
+
+- Reviewer: verify the helper's key changes for every one of the 9 inputs (the unit test
+  encodes this) and exercise column resize + row selection together in the running app.
+- If a new controlled state is added to the table (e.g. grouping), it must be added to BOTH
+  the helper input and its test, or the body will go stale for that dimension.

--- a/plans/11-clerk-webhook-handler-tests.md
+++ b/plans/11-clerk-webhook-handler-tests.md
@@ -1,0 +1,142 @@
+# Plan 11: Test the Clerk webhook handler end-to-end (seat enforcement + rollback)
+
+> **Executor instructions**: Follow step by step; verify each step. On a "STOP
+> condition", stop and report. When done, update this plan's row in
+> `plans/README.md`. This plan adds tests + one test-only export; it must NOT
+> change handler behaviour.
+>
+> **Drift check (run first)**:
+> `git diff --stat c5b2ae41c..HEAD -- apps/dashboard/src/routes/api/v1/webhooks/clerk.ts`
+> On any change, compare "Current state" against live code; mismatch = STOP.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: tests
+- **Planned at**: commit `c5b2ae41c`, 2026-07-03
+
+## Why this matters
+
+`POST /api/v1/webhooks/clerk` enforces the paid-plan **seat cap**: when an
+`organizationMembership.created` event would push an org over `plan.seats`, it rolls the new
+member back via Clerk's `deleteOrganizationMembership`. This money-path handler has **no
+test** — and the seat off-by-one that decides whether a paying org gets over-provisioned is
+currently guarded only by `lib/billing/seat-enforcement.test.ts`, which tests a **re-implemented
+copy** (`admit = (plan, count) => checkSeatLimit(plan, count - 1)`) and never imports
+`clerk.ts`. So changing the real `clerk.ts:72` (dropping the `- 1`) leaves the suite green.
+This plan tests the **real handler**, locking the signature check, the config gate, the
+enterprise bypass, and the exact seat boundary.
+
+## Current state
+
+File: `apps/dashboard/src/routes/api/v1/webhooks/clerk.ts`. `handlePost` (`:28`) — not yet
+exported for tests. Behaviour to lock:
+- `getClerkWebhookSecret()` unset → **501** (`:29-35`).
+- `verifyWebhook(request, { signingSecret })` throws → **403** (`:38-43`).
+- `organizationMembership.created`: `getPlanForOwner(orgId)`; if `plan.seats == null`
+  (enterprise) → allow, no membership list, no delete (`:53-56`).
+- Else list memberships (`clerkClient().organizations.getOrganizationMembershipList`,
+  `limit:100`), `count = memberships.data.length`, then `check = checkSeatLimit(plan, count - 1)`
+  (the webhook fires *after* Clerk added the member, so `count` is post-addition and
+  `count - 1` is "does the new member fit?"). If `!check.allowed` →
+  `deleteOrganizationMembership({ organizationId: orgId, userId })` (`:72-77`).
+
+Collaborators to mock (external I/O only — keep `checkSeatLimit` **real** so the off-by-one
+is exercised): `@clerk/tanstack-react-start/webhooks` (`verifyWebhook`),
+`@/lib/billing/clerk-webhook-config` (`getClerkWebhookSecret`),
+`@/lib/billing/user-subscription` (`getPlanForOwner`), and
+`@clerk/tanstack-react-start/server` (`clerkClient` — the handler `import()`s it lazily).
+
+Test conventions: **Bun test**, `mock.module` — `apps/dashboard/src/routes/api/v1/webhooks/polar.test.ts`
+is the exact template (it mocks `@clerk/tanstack-react-start/server` the same way). Note its
+guidance: mock the **full** export surface of each specifier (a superset) so cross-file mock
+registration in one `bun test` process is order-independent, and leave `createFileRoute` un-mocked.
+
+## Commands you will need
+
+| Purpose | Command | Expected |
+|---|---|---|
+| Typecheck | `cd apps/dashboard && bun run type-check` | exit 0 |
+| Run new test | `cd apps/dashboard && bun test src/routes/api/v1/webhooks/clerk.test.ts --isolate` | all pass |
+| Lint | `bun run lint` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `apps/dashboard/src/routes/api/v1/webhooks/clerk.ts` (add ONLY a test-only export)
+- `apps/dashboard/src/routes/api/v1/webhooks/clerk.test.ts` (create)
+
+**Out of scope**:
+- The handler logic and the `count - 1` computation — do NOT change behaviour; the test
+  documents the current contract (the seat boundary) so a future change is caught.
+- `checkSeatLimit` (`lib/billing/entitlements`) and `seat-enforcement.test.ts` — leave both;
+  this plan adds the missing *handler* coverage, it does not replace the unit test.
+- `polar.ts` webhook.
+
+## Git workflow
+
+- Branch: `advisor/11-clerk-webhook-handler-tests`
+- Conventional commits + `Co-Authored-By: duyetbot <bot@duyet.net>`. Example: `test(billing): cover the Clerk webhook seat-enforcement handler`.
+- Do NOT push/PR unless instructed.
+
+## Steps
+
+### Step 1: Export the handler for tests
+
+Add `export { handlePost as __handlePostForTests }` at the bottom of `clerk.ts` (mirrors
+`health/webhook.ts:209`). No other production change.
+
+**Verify**: `cd apps/dashboard && bun run type-check` → exit 0.
+
+### Step 2: Write the handler test
+
+Create `clerk.test.ts`. Mock the four specifiers above with per-test `let` bindings. A helper
+builds a `organizationMembership.created` event (`verifyWebhook` returns it):
+`{ type:'organizationMembership.created', data:{ organization:{ id:'org_1' }, public_user_data:{ user_id:'user_new' } } }`.
+`getPlanForOwner` returns a plan with a concrete `seats` (e.g. `{ id:'pro', seats:3 }`).
+`getOrganizationMembershipList` returns `{ data: Array.from({length: count}) }` to simulate
+the post-addition member count. Cases:
+
+1. **501 unconfigured** — `getClerkWebhookSecret` → `undefined` → status 501, `verifyWebhook` not called.
+2. **403 bad signature** — `verifyWebhook` throws → status 403.
+3. **enterprise bypass** — `getPlanForOwner` → `{ seats: null }` → 2xx, `getOrganizationMembershipList` and `deleteOrganizationMembership` **not** called.
+4. **at cap, member fits** — `seats:3`, `count:3` (post-addition, so pre-addition 2 fits) → `deleteOrganizationMembership` **not** called. *(This is the boundary the parallel-copy test can't protect.)*
+5. **over cap, rolled back** — `seats:3`, `count:4` → `deleteOrganizationMembership` called **once** with `{ organizationId:'org_1', userId:'user_new' }`.
+6. **other event acknowledged** — `type:'user.created'` → 2xx, no membership calls.
+
+**Verify**: `cd apps/dashboard && bun test src/routes/api/v1/webhooks/clerk.test.ts --isolate` → all pass; `bun run lint` → exit 0.
+
+## Test plan
+
+- New `clerk.test.ts` with the 6 cases; keep `checkSeatLimit` real so case 4/5 exercise the actual off-by-one.
+- Structural pattern: `polar.test.ts` (mock.module + Clerk server mock).
+- Verification: `cd apps/dashboard && bun test src/routes/api/v1/webhooks/clerk.test.ts --isolate` → all pass.
+
+## Done criteria
+
+- [ ] `clerk.ts` exports `__handlePostForTests`; runtime behaviour unchanged (`git diff` shows only the export line)
+- [ ] `clerk.test.ts` covers 501 / 403 / enterprise-bypass / at-cap-allowed / over-cap-rolledback / other-event
+- [ ] Case 4 (count === seats → NOT rolled back) and case 5 (count === seats+1 → rolled back) both assert `deleteOrganizationMembership`'s call count
+- [ ] `cd apps/dashboard && bun test src/routes/api/v1/webhooks/clerk.test.ts --isolate` passes
+- [ ] `cd apps/dashboard && bun run type-check` exits 0; `bun run lint` exits 0
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- The handler's seat logic differs from the excerpt (drift) — especially if `count - 1` has
+  already changed; if so, write the test against the CURRENT behaviour and flag the change.
+- `verifyWebhook` / `clerkClient` cannot be mocked via `mock.module` in this runtime — report
+  the blocker (check how `polar.test.ts` handles the same specifiers).
+- The lazy `import('@clerk/tanstack-react-start/server')` resolves to a real network call in
+  test despite the mock — STOP and report.
+
+## Maintenance notes
+
+- Reviewer: confirm cases 4 and 5 pin the seat boundary (`count === seats` vs `count === seats + 1`)
+  — this is the regression the existing `seat-enforcement.test.ts` cannot catch because it
+  tests a copy of the logic, not `clerk.ts`.
+- If seat enforcement moves to a different event or the `count - 1` reasoning changes, update
+  these cases in lockstep.

--- a/plans/12-ai-agent-doc-tool-sync.md
+++ b/plans/12-ai-agent-doc-tool-sync.md
@@ -1,0 +1,150 @@
+# Plan 12: Sync the ai-agent.mdx tool list with the code, and add an anti-drift test
+
+> **Executor instructions**: Follow step by step; verify each step. On a "STOP
+> condition", stop and report. When done, update this plan's row in
+> `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat c5b2ae41c..HEAD -- apps/dashboard/src/lib/ai/agent/tools/index.ts docs/content/guide/ai-agent.mdx`
+> On any change, compare "Current state" against live code; mismatch = STOP.
+
+## Status
+
+- **Priority**: P3
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: docs
+- **Planned at**: commit `c5b2ae41c`, 2026-07-03
+
+## Why this matters
+
+`apps/dashboard/CLAUDE.md` mandates that `docs/content/guide/ai-agent.mdx` stay in sync with
+the agent tools whenever a tool is added/renamed/removed. It has drifted: `createAllTools`
+(`tools/index.ts`) assembles **18 default + 3 gated** tools, but the doc's tool table
+(`ai-agent.mdx:227-237`) lists only **9**. Missing from the doc: `get_failed_queries`,
+`explain_query`, `get_disk_usage`, `get_table_parts`, `get_replication_status`,
+`update_plan`, `load_skill`, `ask_user`, `query_and_visualize`, plus the three gated control
+tools. Users of the documented agent surface can't see ~half its capabilities. The fix
+updates the doc and adds a test so it can't silently drift again.
+
+## Current state
+
+Source of truth — `apps/dashboard/src/lib/ai/agent/tools/index.ts`, `createAllTools(hostId, includeControlTools)`.
+Its doc-comment (`:25-38`) lists the full set:
+- **Schema & exploration**: `query`, `list_databases`, `list_tables`, `get_table_schema`, `explore_table_schema`
+- **Query analysis**: `get_running_queries`, `get_slow_queries`, `get_failed_queries`, `explain_query`
+- **Health**: `get_metrics`, `get_disk_usage`
+- **Storage**: `get_table_parts`
+- **Replication**: `get_replication_status`
+- **Merges**: `get_merge_status`
+- **Planning**: `update_plan`
+- **Knowledge**: `load_skill`
+- **Interaction**: `ask_user`
+- **Visualization**: `query_and_visualize`
+- **Control (destructive, env-gated `AGENT_ENABLE_CONTROL_TOOLS=true`)**: `kill_query`, `optimize_table`, `kill_mutation`
+
+The doc — `docs/content/guide/ai-agent.mdx`. The table under `### MCP tools` (`:227-237`)
+lists only 9 names. `AGENT_ENABLE_CONTROL_TOOLS` is already documented (`:250`), so only tool
+rows are missing.
+
+**Important nuance (verify before editing):** the table is titled *"MCP tools"*. Confirm
+whether it is meant to describe the in-app **agent** tools (what CLAUDE.md governs) or the
+**MCP server** (`routes/api/mcp.ts` / `packages/mcp-server`) subset, which may legitimately
+expose fewer. If the MCP server is a deliberate subset, do NOT force all 21 into that table —
+instead document the full **agent** toolset (a clearly-labelled section) and keep the MCP
+subset accurate. The CLAUDE.md mandate is about the agent tools in `lib/ai/agent/tools`.
+
+Convention: the repo already uses anti-drift coverage tests — see
+`apps/dashboard/src/lib/billing/plan-enforcement.test.ts` (asserts every capability is
+classified). Model the new test on it. Tests are **Bun test**.
+
+## Commands you will need
+
+| Purpose | Command | Expected |
+|---|---|---|
+| Run new test | `cd apps/dashboard && bun test src/lib/ai/agent/tools/tool-docs-sync.test.ts --isolate` | all pass |
+| Docs build (optional) | `cd apps/docs && bun run build` | exit 0 |
+| Lint | `bun run lint` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `docs/content/guide/ai-agent.mdx` (the committed docs source of truth)
+- `apps/dashboard/src/lib/ai/agent/tools/tool-docs-sync.test.ts` (create — anti-drift test)
+
+**Out of scope**:
+- `tools/index.ts` and the tool modules — the code is the source of truth; do not change tools.
+- `apps/docs/content/**` (generated from `docs/content/**` at build; do not edit the generated copy).
+- Renaming/reorganising the whole guide — only reconcile the tool list + add the gated section.
+
+## Git workflow
+
+- Branch: `advisor/12-ai-agent-doc-tool-sync`
+- Conventional commits + `Co-Authored-By: duyetbot <bot@duyet.net>`. Example: `docs(agent): sync ai-agent.mdx tool list with code + add anti-drift test`.
+- Do NOT push/PR unless instructed.
+
+## Steps
+
+### Step 1: Decide the doc surface (agent vs MCP-server)
+
+Read `routes/api/mcp.ts` and/or `packages/mcp-server` to see which tools the MCP server
+exposes. If it is the same set as `createAllTools`, the `### MCP tools` table is simply
+stale → update it. If it is a deliberate subset, add a new subsection (e.g. `### Agent tools`)
+listing the full agent set, keep the MCP table accurate, and cross-reference. Write down which
+case applies (it drives Step 2 and the test target).
+
+**Verify**: note the decision in the PR description.
+
+### Step 2: Update the doc to list every agent tool (+ gated control tools)
+
+Add rows for the missing default tools (`get_failed_queries`, `explain_query`,
+`get_disk_usage`, `get_table_parts`, `get_replication_status`, `update_plan`, `load_skill`,
+`ask_user`, `query_and_visualize`) with a one-line purpose each (derive purpose from each
+tool module's `description` in `lib/ai/agent/tools/*.ts`). Add a clearly-labelled row/section
+for the three gated control tools (`kill_query`, `optimize_table`, `kill_mutation`) noting
+they require `AGENT_ENABLE_CONTROL_TOOLS=true`.
+
+**Verify**: `rg -c "get_failed_queries|explain_query|get_disk_usage|get_table_parts|get_replication_status|update_plan|load_skill|ask_user|query_and_visualize|kill_query|optimize_table|kill_mutation" docs/content/guide/ai-agent.mdx` → all 12 names present (count ≥ 12).
+
+### Step 3: Add the anti-drift test
+
+Create `tool-docs-sync.test.ts` that reads `docs/content/guide/ai-agent.mdx` (via
+`readFileSync` with a path relative to the test file) and asserts every tool name from the
+code appears in it. Prefer deriving names from the code:
+`Object.keys(createAllTools(0, true))` with `process.env.AGENT_ENABLE_CONTROL_TOOLS='true'`
+set so the control tools are included. If importing `createAllTools` pulls in unmanageable
+deps in the test runtime, fall back to a hardcoded list of the 21 names with a comment that
+it must track `tools/index.ts`. Assert: for each tool name, the mdx contains it.
+
+**Verify**: `cd apps/dashboard && bun test src/lib/ai/agent/tools/tool-docs-sync.test.ts --isolate` → passes; deleting a tool row from the mdx makes it fail (sanity-check once, then restore).
+
+## Test plan
+
+- New `tool-docs-sync.test.ts`: every `createAllTools(0, true)` key appears in `ai-agent.mdx`.
+- Structural pattern: `plan-enforcement.test.ts` (coverage/anti-drift assertion) + `health-sweep.test.ts` (readFileSync of a sibling doc/source).
+- Verification: `cd apps/dashboard && bun test src/lib/ai/agent/tools --isolate` → all pass.
+
+## Done criteria
+
+- [ ] All 12 previously-missing tool names appear in `docs/content/guide/ai-agent.mdx`
+- [ ] `tool-docs-sync.test.ts` exists and passes, and fails if a tool row is removed
+- [ ] `cd apps/dashboard && bun test src/lib/ai/agent/tools/tool-docs-sync.test.ts --isolate` passes
+- [ ] `bun run lint` exits 0
+- [ ] Only `docs/content/**` (not the generated `apps/docs/content/**`) edited
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- The MCP server is a deliberate subset AND reconciling would require restructuring the guide
+  beyond adding a section — report the structural choice rather than guessing.
+- `createAllTools` cannot be imported in the test runtime and a hardcoded list would be the
+  only option — that's acceptable, but note it as a maintenance cost in the test comment.
+- The tool set in `tools/index.ts` differs from the excerpt (drift) — document the current set.
+
+## Maintenance notes
+
+- Reviewer: confirm the anti-drift test derives from `createAllTools` (or, if hardcoded, that
+  the list matches). This test is what keeps the CLAUDE.md doc-sync mandate enforceable.
+- When a tool is added/renamed/removed in `lib/ai/agent/tools/*`, this test fails until the
+  doc is updated — that is the intended behaviour.

--- a/plans/13-ssrf-guard-ipv6-pinning-tests.md
+++ b/plans/13-ssrf-guard-ipv6-pinning-tests.md
@@ -1,0 +1,144 @@
+# Plan 13: Add characterization tests for the untested halves of the SSRF host guard
+
+> **Executor instructions**: Follow step by step; verify each step. On a "STOP
+> condition", stop and report. When done, update this plan's row in
+> `plans/README.md`. This plan adds tests only — do NOT change `host-url.ts`.
+>
+> **Drift check (run first)**:
+> `git diff --stat c5b2ae41c..HEAD -- apps/dashboard/src/lib/browser-connections/host-url.ts apps/dashboard/src/lib/browser-connections/host-url.test.ts`
+> On any change, compare "Current state" against live code; mismatch = STOP.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: tests
+- **Planned at**: commit `c5b2ae41c`, 2026-07-03
+
+## Why this matters
+
+`host-url.ts` is the security-critical SSRF guard for every user-supplied host (ClickHouse
+connections, the health/webhook proxy, custom MCP servers). Two of its most important pieces
+have **zero test coverage**: `createHostValidationFetch` (`:112-137`) — the DNS-pinning fetch
+wrapper that is the actual runtime egress defense (resolve-then-pin against DNS rebinding,
+plus the Cloudflare-Worker hostname guard) — is imported by no test; and the entire **IPv6**
+branch of `isInternalIp` (`:309-337`, handling ULA / link-local / IPv4-mapped / 6to4 /
+Teredo) is never entered, because `host-url.test.ts` only drives `validateHostUrl` with IPv4
+resolver stubs. A future refactor could drop the mapped4/6to4 checks or the pin-to-validated
+step and no test would catch it. This plan adds the missing coverage. (It characterizes
+current behaviour — it does not assert a new bypass.)
+
+## Current state
+
+Files:
+- `apps/dashboard/src/lib/browser-connections/host-url.ts` — exports `validateHostUrl`,
+  `createHostValidationFetch` (`:112`), `isInternalIp` (`:309`, IPv6 matrix at `:309-337`),
+  and constants incl. `WORKER_DNS_PINNING_ERROR`. `createHostValidationFetch(resolver)` takes
+  an injectable resolver; on `isCloudflareWorkers()` it throws `WORKER_DNS_PINNING_ERROR` for
+  a non-IP-literal hostname (`:118-123`), otherwise resolves+validates and (on Node) pins the
+  socket to the validated address via an undici `Agent` (`:135`, `createPinnedDispatcher :241`).
+- `apps/dashboard/src/lib/browser-connections/host-url.test.ts` — existing suite; drives
+  `validateHostUrl(url, resolver)` with **IPv4** resolvers (`127.0.0.1`, `93.184.216.34`).
+
+Discover before writing: the exact import path of `isCloudflareWorkers` (grep
+`rg -n "isCloudflareWorkers" apps/dashboard/src/lib/browser-connections/host-url.ts` and its
+import line) and whether `isInternalIp` / `WORKER_DNS_PINNING_ERROR` are exported (grep
+`rg -n "export" apps/dashboard/src/lib/browser-connections/host-url.ts`). Mock
+`isCloudflareWorkers` via `mock.module` on its real specifier (mirror `polar.test.ts`'s
+`mock.module` style).
+
+Convention: **Bun test**; the existing `host-url.test.ts` shows the injected-resolver pattern.
+
+## Commands you will need
+
+| Purpose | Command | Expected |
+|---|---|---|
+| Typecheck | `cd apps/dashboard && bun run type-check` | exit 0 |
+| Run test | `cd apps/dashboard && bun test src/lib/browser-connections/host-url.test.ts --isolate` | all pass |
+| Lint | `bun run lint` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `apps/dashboard/src/lib/browser-connections/host-url.test.ts` (extend; or add a sibling `host-url-ipv6.test.ts` / `host-validation-fetch.test.ts` if cleaner)
+
+**Out of scope**:
+- `host-url.ts` itself — do NOT modify the guard; this plan only adds tests. If a test reveals
+  an actual bypass, STOP and report it as a security finding rather than "fixing" it here.
+- Any route that consumes the guard.
+
+## Git workflow
+
+- Branch: `advisor/13-ssrf-guard-tests`
+- Conventional commits + `Co-Authored-By: duyetbot <bot@duyet.net>`. Example: `test(security): cover IPv6 internal ranges + DNS-pinning fetch in host guard`.
+- Do NOT push/PR unless instructed.
+
+## Steps
+
+### Step 1: IPv6 internal-range coverage
+
+Add tests that drive `validateHostUrl(url, resolver)` (and/or `isInternalIp` directly if
+exported) with **IPv6** resolvers, asserting BLOCK for each internal class and ALLOW for a
+public v6:
+- `::1` (loopback) → blocked
+- `fc00::/7` ULA, e.g. `fd00::1` → blocked
+- `fe80::1` (link-local) → blocked
+- `::ffff:127.0.0.1` (IPv4-mapped loopback) → blocked
+- a 6to4 address wrapping a private v4 (e.g. `2002:0a00:0001::` for `10.0.0.1`) → blocked
+- a public v6, e.g. `2606:4700:4700::1111` → allowed (resolves to a valid `{ url, addresses }`)
+
+Use the existing injected-resolver approach: a resolver returning the target IPv6 string.
+
+**Verify**: `cd apps/dashboard && bun test src/lib/browser-connections/host-url.test.ts --isolate` → all pass, incl. the new IPv6 cases.
+
+### Step 2: `createHostValidationFetch` behaviour
+
+Add tests for the fetch wrapper:
+1. **Workers hostname guard** — `mock.module` `isCloudflareWorkers` → `true`; call
+   `createHostValidationFetch(resolvePublic)('https://hooks.slack.com/x')` and assert it
+   **rejects** with `WORKER_DNS_PINNING_ERROR` (Workers can't pin a hostname's DNS).
+2. **Validation runs at fetch time** — with `isCloudflareWorkers` → `false` and a resolver
+   returning an **internal** address (e.g. `10.0.0.5`), the returned fetch **rejects** before
+   any socket dispatch (proving the guard re-validates on the pinned path). Assert it throws
+   and that no real network call is attempted (the internal address is rejected first).
+
+If mocking `isCloudflareWorkers` is not feasible (e.g. it reads a runtime global that can't be
+overridden), cover at least Step 2.2 (which needs only the injected resolver) and document the
+Workers-guard case as needing an integration test.
+
+**Verify**: `cd apps/dashboard && bun test src/lib/browser-connections/host-url.test.ts --isolate` → all pass; `bun run lint` → exit 0.
+
+## Test plan
+
+- New IPv6 block/allow cases + `createHostValidationFetch` cases (above).
+- Structural pattern: existing `host-url.test.ts` (injected resolver) + `polar.test.ts` (mock.module for `isCloudflareWorkers`).
+- Verification: `cd apps/dashboard && bun test src/lib/browser-connections --isolate` → all pass.
+
+## Done criteria
+
+- [ ] IPv6 internal ranges (loopback, ULA, link-local, IPv4-mapped, 6to4) are asserted blocked; a public v6 is asserted allowed
+- [ ] `createHostValidationFetch` has ≥1 test (the internal-address rejection at fetch time; ideally also the Workers hostname-guard throw)
+- [ ] `host-url.ts` is unchanged (`git diff` shows no edit to the source)
+- [ ] `cd apps/dashboard && bun test src/lib/browser-connections/host-url.test.ts --isolate` passes
+- [ ] `cd apps/dashboard && bun run type-check` exits 0; `bun run lint` exits 0
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- `isInternalIp` / `WORKER_DNS_PINNING_ERROR` are not exported and cannot be reached even via
+  `validateHostUrl` — report which surface is testable.
+- A test shows an internal IPv6 range is **NOT** blocked (a real bypass) — STOP and report it
+  as a security finding; do not paper over it by weakening the test.
+- The Node pinning path (`createPinnedDispatcher`) attempts a real network connection in the
+  test and can't be avoided — cover the pre-dispatch rejection only and note the integration gap.
+
+## Maintenance notes
+
+- Reviewer: confirm the tests assert BLOCK (not just "no throw") for each IPv6 class, and that
+  the public-v6 case proves the guard isn't simply blocking all v6.
+- Fully asserting socket-level pinning (that the dialed IP equals the validated IP) needs an
+  integration harness; this plan covers the observable pre-dispatch contract. That integration
+  test is a reasonable follow-up and is the foundation any future DNS-rebinding hardening of
+  `health/webhook.ts` (see plan 05's deferred note) should build on.

--- a/plans/15-upgrade-paywall-modal.md
+++ b/plans/15-upgrade-paywall-modal.md
@@ -1,0 +1,93 @@
+# 15 — Upgrade paywall modal
+
+## Kickoff prompt
+
+```text
+Execute plans/15-upgrade-paywall-modal.md ALONE (do not touch other plans).
+Goal: when a billing limit returns HTTP 402 (host/seat/ai_daily/ai_budget), stop
+showing raw JSON — intercept it, classify the reason, and show a PaywallModal with
+current-vs-next-tier caps and an "Upgrade" button that opens Polar checkout.
+Invariants you must not violate:
+  - Self-hosted/OSS stays whole: no 402s are emitted without Clerk, so the modal
+    simply never fires on OSS. Do not add any gate; only react to existing 402s.
+  - Honest paywalls: advertised ⟺ enforced (or `deferred`). Copy MUST distinguish a
+    truly `enforced` limit from a `deferred` one — read lib/billing/plan-enforcement.ts;
+    never claim a cap is enforced when the registry says deferred.
+  - AI recommends DDL, never auto-applies (untouched).
+  - Postgres/multi-DB: NO for 2026 H2.
+Reuse lib/billing/entitlements.ts:limitMessage for copy and POST /api/v1/billing/checkout
+for the upgrade action. End by running the Verification block and pasting results.
+```
+
+## Current reality (audited)
+
+A 402 from any billing gate returns raw JSON that surfaces to the user as an error toast, not a conversion surface — the single biggest CVR leak.
+
+- The gates that emit 402 already exist: `checkHostLimit` (`apps/dashboard/src/routes/api/v1/user-connections.ts` via `entitlements.ts:81`), `checkSeatLimit` (`entitlements.ts:86`), `checkAiDailyLimit` and `checkAiBudget` (`entitlements.ts:111`,`:131`; enforced in `agent.ts` around `:560–603`).
+- Human-readable copy exists: `apps/dashboard/src/lib/billing/entitlements.ts:136` `limitMessage(check)`.
+- The client error pipeline is a **directory**: `apps/dashboard/src/lib/api/error-handler/` (`error-classifier.ts`, `error-response-builder.ts`, `sanitize-error.ts`, `index.ts`, `types.ts`) — this is where a 402 must be classified into a `reason`.
+- Checkout is one POST: `apps/dashboard/src/routes/api/v1/billing/checkout.ts` — `POST` with body `{ planId?, period? }` returns `{ url }` (`checkout.ts:99–107`, `createFileRoute('/api/v1/billing/checkout')`).
+- **No** `paywall-modal.tsx` exists in `apps/dashboard/src/components/billing/` (present: `plan-card.tsx`, `plan-comparison.tsx`, `usage-summary.tsx`). This component is genuinely new.
+- Plan caps to display come from `packages/pricing/src/plans.ts` (`hosts`, `seats`, `aiRequestsPerDay`, `aiMonthlyUsdBudget`).
+
+## Goal
+
+A 402 anywhere in the app opens a `PaywallModal` (not an error toast) that names the hit limit, shows current-tier vs next-tier caps, uses honest copy for `enforced` vs `deferred`, and routes "Upgrade" to the Polar checkout URL. Dismiss is clean; nothing fires on OSS (no 402s without Clerk).
+
+## Implement now
+
+### A. Classify 402 → reason — `apps/dashboard/src/lib/api/error-handler/error-classifier.ts`
+- Ensure billing 402 responses carry a machine `reason`. The gate responses should already include a `reason` in their JSON body; if not present, standardize the four values: `'host' | 'seat' | 'ai_daily' | 'ai_budget'`.
+- Add/extend a classifier export, e.g. `classifyBillingLimit(status: number, body: unknown): { reason: 'host'|'seat'|'ai_daily'|'ai_budget'; message: string } | null` — returns non-null only for `status === 402`. Fall back to `limitMessage`-style text when body has no `message`.
+- Export the reason type from `error-handler/types.ts`.
+
+### B. New component — `apps/dashboard/src/components/billing/paywall-modal.tsx`
+```tsx
+export function PaywallModal(props: {
+  open: boolean
+  reason: 'host' | 'seat' | 'ai_daily' | 'ai_budget'
+  message: string                 // from limitMessage / classifier
+  currentPlanId: string
+  onClose: () => void
+}): JSX.Element
+```
+- Render title from `reason` ("Host limit reached", "Seat limit reached", "Daily AI limit reached", "Monthly AI budget reached").
+- Show a **current vs next tier** mini-table for the relevant metric only, read from `@chm/pricing` plans (`hosts`/`seats`/`aiRequestsPerDay`/`aiMonthlyUsdBudget`). Pick "next tier" as the first plan whose relevant cap exceeds current.
+- **Honest copy:** import the enforcement registry (`apps/dashboard/src/lib/billing/plan-enforcement.ts`); if the mapped limit is `deferred`, render "This limit isn't billed during early access" language instead of an upgrade-required hard sell. Only show the hard upgrade CTA when the limit is `enforced`.
+- "Upgrade" button → `POST /api/v1/billing/checkout` with `{ planId: <nextTierId> }`, then `window.location.assign(url)`. Use the existing dashboard API client (`apps/dashboard/src/lib/api/dashboard-api-client.ts`) so auth/headers match.
+- Use the existing dialog primitive already used by other `components/billing/*` / shadcn dialogs; do not introduce a new modal library.
+
+### C. Wire into the global error surface — `apps/dashboard/src/root.tsx` (or the existing error boundary/toast host)
+- Add a small provider/hook `usePaywall()` that holds `{ open, reason, message, currentPlanId }` and a `showPaywall(...)` setter.
+- In the central fetch/error handler (where 402 toasts are raised today), call `classifyBillingLimit`; when non-null, call `showPaywall(...)` and **suppress** the raw error toast. Non-402 errors keep existing behavior.
+- Render `<PaywallModal … />` once at the app root, driven by the provider.
+
+### D. Do NOT add new gates
+This plan is UX only. It reacts to 402s that `entitlements.ts` already produces. No enforcement is added or changed (keeps the honest-paywall + fail-open invariants trivially true).
+
+### E. Tests — `apps/dashboard/src/components/billing/paywall-modal.test.tsx` (Bun for logic; Cypress for interaction)
+- Logic (Bun): `classifyBillingLimit` returns the right `reason` for each 402 shape and `null` for 200/500.
+- Per-reason render (Cypress component test): each of the four reasons renders the correct title + current/next caps; an `enforced` limit shows the Upgrade CTA; a `deferred` limit shows the "not billed in beta" copy and no hard CTA.
+- Upgrade path: clicking Upgrade POSTs to `/api/v1/billing/checkout` and navigates to the returned `url` (stub the client). Dismiss calls `onClose`.
+
+## STOP conditions & drift check
+- **STOP if** `checkout.ts` no longer returns `{ url }` or its body contract changed from `{ planId?, period? }` — adjust the Upgrade call and re-verify.
+- **STOP if** the gates don't put a `reason` in their 402 body and you'd have to change server contracts broadly — scope it: add `reason` to the four gate responses in a minimal edit, don't refactor the error system.
+- **STOP and ask** if `plan-enforcement.ts` marks all of host/seat/ai as `deferred` — then the modal is informational only and the Upgrade CTA must be hidden everywhere; confirm the desired copy.
+- **Drift check:** `entitlements.ts` still exports `limitMessage`, `checkHostLimit`, `checkSeatLimit`, `checkAiDailyLimit`, `checkAiBudget`. If any is renamed/removed, the reason set changed — stop.
+
+## Verification
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/components/billing/paywall-modal.test.tsx --isolate
+bun run lint
+```
+
+## Done criteria
+- A 402 with reason ∈ {host, seat, ai_daily, ai_budget} opens `PaywallModal`; no raw JSON/error toast for that case.
+- Modal shows current-vs-next-tier caps for the hit metric, honest `enforced`/`deferred` copy, and an Upgrade button that opens the Polar checkout URL.
+- Dismiss closes cleanly; nothing renders on OSS (no 402 without Clerk).
+- Per-reason tests pass; type-check, build, lint green.
+
+Priority: P0 · Effort M · Depth: F · Wave: R (Revenue) · Lever: Revenue/Adoption (convert limit-hits)

--- a/plans/16-billing-usage-dashboard-card.md
+++ b/plans/16-billing-usage-dashboard-card.md
@@ -1,0 +1,124 @@
+# 16 — Billing usage dashboard card
+
+## Kickoff prompt
+
+```text
+Execute plans/16-billing-usage-dashboard-card.md ALONE (do not touch other plans).
+Goal: build the in-app billing surface — a card that renders the current plan,
+usage meters (hosts, seats, AI-daily, AI-monthly-USD), the renewal date, a
+cancel-grace banner, and CTAs to Polar checkout / Polar portal — all from
+GET /api/v1/billing/usage.
+Invariants you must not violate:
+  - Self-hosted/OSS stays whole: /billing/usage fails open without Clerk; the card
+    must render a graceful "billing not configured" empty state on OSS, never crash.
+  - Honest paywalls: advertised ⟺ enforced (or `deferred`) in lib/billing/plan-enforcement.ts;
+    a meter for a `deferred` limit is shown as informational, not "upgrade to unlock".
+  - AI recommends DDL, never auto-applies (untouched).
+  - Postgres/multi-DB: NO for 2026 H2.
+The AI-monthly-USD meter depends on plan 14 surfacing aiSpentThisMonth in /billing/usage;
+if that field is absent, degrade that one meter gracefully (do not block the card).
+End by running the Verification block and pasting results.
+```
+
+## Current reality (audited)
+
+There is no in-app surface for plan/usage/renewal — billing is invisible and so is the upgrade path.
+
+- The route shell already exists: `apps/dashboard/src/routes/(dashboard)/billing.tsx` (present in the route tree). This plan **fills** it, not creates it.
+- The data source exists: `apps/dashboard/src/routes/api/v1/billing/usage.ts` returns:
+  ```
+  { planId, planName,
+    hosts:    { used, limit, unlimited },
+    seats:    { used, limit, unlimited },
+    aiMessages:{ used, limit, unlimited },
+    renewal:  { currentPeriodEnd, cancelAtPeriodEnd, status, billingPeriod } }
+  ```
+  (see `usage.ts:119–129`). After plan 14 it also returns `aiSpentThisMonth` and `aiMonthlyUsdBudget`.
+- Checkout/portal actions exist: `POST /api/v1/billing/checkout` → `{ url }`; `POST /api/v1/billing/portal` → `{ url }` (customer portal, `portal.ts:41`).
+- Existing billing components to reuse/compose: `apps/dashboard/src/components/billing/{plan-card.tsx, plan-comparison.tsx, usage-summary.tsx}`. The spec's three new files below are additive; check whether `usage-summary.tsx` already covers meters and extend it rather than duplicating.
+- A billing hook exists: `apps/dashboard/src/lib/billing/use-billing.ts` (reuse for fetching).
+
+## Goal
+
+`/billing` renders one coherent card: current plan name + price, four usage meters (hosts, seats, AI messages/day, AI USD/month) that turn red past 80%, the renewal date, a cancel-at-period-end grace banner, and two CTAs — "Upgrade" (→ checkout) and "Manage billing" (→ Polar portal). It works for Free, Pro, and over-limit states, and degrades gracefully on OSS.
+
+## Implement now
+
+### A. Data hook
+- Reuse `apps/dashboard/src/lib/billing/use-billing.ts` (or add `useBillingUsage()`) to `GET /api/v1/billing/usage` via TanStack Query (the app's data layer). Return typed `{ planId, planName, hosts, seats, aiMessages, aiSpentThisMonth?, aiMonthlyUsdBudget?, renewal }`.
+- On error/empty (OSS: no Clerk → route fails open with a null/empty body), expose `isBillingUnavailable = true` so the card renders the empty state.
+
+### B. Meters — `apps/dashboard/src/components/billing/usage-meters.tsx` (new; or extend `usage-summary.tsx`)
+```tsx
+export function UsageMeters(props: {
+  hosts: { used: number; limit: number|null; unlimited: boolean }
+  seats: { used: number; limit: number|null; unlimited: boolean }
+  aiMessages: { used: number; limit: number|null; unlimited: boolean }
+  aiSpentThisMonth?: number
+  aiMonthlyUsdBudget?: number|null
+}): JSX.Element
+```
+- One meter row per metric: label, `used / limit` (or "Unlimited" when `unlimited`), a progress bar.
+- **Red state** when `limit != null && used/limit >= 0.8`; amber ≥ 0.6 (optional); normal otherwise.
+- AI-USD meter: `aiSpentThisMonth / aiMonthlyUsdBudget` formatted as USD. If `aiSpentThisMonth` is undefined (plan 14 not yet merged), render "—" and hide the bar — never throw.
+- For any metric whose enforcement is `deferred` (read `plan-enforcement.ts`), append a small "(not billed in early access)" note so the meter is honest.
+
+### C. Current-plan card — `apps/dashboard/src/components/billing/current-plan-card.tsx` (new)
+```tsx
+export function CurrentPlanCard(props: {
+  planId: string; planName: string
+  priceMonthlyUsd: number|null      // from @chm/pricing plans
+  onUpgrade: () => void             // POST /billing/checkout → assign url
+  onManage: () => void              // POST /billing/portal   → assign url
+}): JSX.Element
+```
+- Show plan name + price (from `@chm/pricing`). "Upgrade"/"Change plan" CTA → checkout; "Manage billing" CTA → portal. Hide "Upgrade" on the top tier; hide both on OSS.
+
+### D. Renewal / cancel-grace banner — `apps/dashboard/src/components/billing/renewal-banner.tsx` (new)
+```tsx
+export function RenewalBanner(props: {
+  currentPeriodEnd: string|null
+  cancelAtPeriodEnd: boolean
+  status: string
+}): JSX.Element | null
+```
+- If `cancelAtPeriodEnd` → warning banner: "Your plan ends on <date>. Reactivate in the billing portal." with a "Manage billing" link.
+- Else if `currentPeriodEnd` → subtle "Renews on <date>".
+- Returns `null` when there's nothing to show (e.g. Free/OSS).
+
+### E. Assemble the route — `apps/dashboard/src/routes/(dashboard)/billing.tsx`
+- Compose `<RenewalBanner/>`, `<CurrentPlanCard/>`, `<UsageMeters/>`, and (optionally) the existing `<PlanComparison/>` below for upsell.
+- Empty state when `isBillingUnavailable`: a plain "Billing is managed by your self-hosted deployment / not configured" panel — no CTAs, no crash. (Fail-open invariant.)
+- `onUpgrade`: `POST /api/v1/billing/checkout` `{ planId: nextTierId }` → `window.location.assign(url)`.
+- `onManage`: `POST /api/v1/billing/portal` → `window.location.assign(url)`.
+
+### F. Tests — `apps/dashboard/src/components/billing/*.test.tsx`
+- **Free**: meters show Free caps; "Upgrade" visible; no cancel banner.
+- **Pro**: shows Pro caps + renewal date; "Manage billing" visible.
+- **Over-limit**: a metric at/above 80% renders the red state.
+- **Cancel-grace**: `cancelAtPeriodEnd: true` → banner shows end date + reactivate link.
+- **OSS/unavailable**: empty state renders, no CTA, no throw.
+- Logic-only assertions (meter color thresholds, next-tier selection) in Bun; component render in Cypress.
+
+## STOP conditions & drift check
+- **STOP if** `/api/v1/billing/usage` response keys differ from the audited shape (`hosts/seats/aiMessages/renewal`) — align the hook types to the real response; don't hardcode a stale shape.
+- **STOP if** `usage-summary.tsx` already renders full meters — extend it and drop the duplicate `usage-meters.tsx` to avoid two meter components.
+- **STOP and ask** if `aiSpentThisMonth` is still absent AND plan 14 is not scheduled — ship the card with the AI-USD meter degraded (documented), don't block.
+- **Drift check:** `checkout.ts`/`portal.ts` still return `{ url }`. If the portal moved to GET or the field renamed, fix the CTAs.
+
+## Verification
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/components/billing/ --isolate
+bun run lint
+```
+
+## Done criteria
+- `/billing` shows plan, four meters (hosts/seats/AI-daily/AI-USD), renewal date, and cancel-grace banner.
+- Meters turn red past 80%; unlimited caps render "Unlimited"; deferred limits are labeled informational.
+- "Upgrade" opens checkout URL; "Manage billing" opens Polar portal URL.
+- OSS/unavailable state renders a graceful empty panel with no CTAs and no crash.
+- Free / Pro / over-limit / cancel-grace tests pass; type-check, build, lint green.
+
+Priority: P0 · Effort M · Depth: F · Wave: R (Revenue) · Lever: Revenue/Adoption (visible plan + upgrade path)

--- a/plans/17-checkout-webhook-e2e-tests.md
+++ b/plans/17-checkout-webhook-e2e-tests.md
@@ -1,0 +1,83 @@
+# 17 — Checkout → webhook → D1 → plan e2e tests + runbook
+
+## Kickoff prompt
+
+```text
+Execute plans/17-checkout-webhook-e2e-tests.md ALONE (do not touch other plans).
+Goal: lock the revenue critical path with tests + a runbook — checkout URL
+creation, Polar webhook signature/idempotency/monotonic-write guard, and D1
+cache-miss → Polar reconciliation. This is TEST + DOCS work; do not change
+billing behavior except to make it testable (extract a pure helper if needed).
+Invariants you must not violate:
+  - Self-hosted/OSS stays whole: billing resolution FAILS OPEN without Clerk/Polar.
+    Tests must include a fail-open case (no Clerk → no plan resolution error surfaced).
+  - Honest paywalls: advertised ⟺ enforced (or `deferred`). Don't assert a benefit is
+    enforced that plan-enforcement.ts marks deferred.
+  - AI recommends DDL, never auto-applies (untouched).
+  - Postgres/multi-DB: NO for 2026 H2 — the store is D1 only; do not add a DB.
+Use Bun test (NOT Jest — it hangs per CLAUDE.md). End by running the Verification
+block and pasting results.
+```
+
+## Current reality (audited)
+
+The checkout → webhook → D1 → plan-resolution path is the revenue critical path and is under-tested.
+
+- Checkout: `apps/dashboard/src/routes/api/v1/billing/checkout.ts` — `POST` body `{ planId?, period? }`, resolves the Polar product for `planId/period`, calls `getPolarClient().checkouts.create(...)`, returns `{ url }` (`checkout.ts:44–107`). Errors: `No Polar product configured for {planId}/{period}` (`:83`). **No `checkout.test.ts` exists.**
+- Webhook: `apps/dashboard/src/routes/api/v1/webhooks/polar.ts` — verifies the signature over the RAW body via `validateEvent` (`polar.ts:47`,`:302–307`; invalid → 403); idempotency guard via existing Clerk-membership check (`:90`); a **monotonic write guard** lives in `subscription-store.ts` (`polar.ts:183` comment). A `polar.test.ts` **already exists** (extend it, don't replace).
+- Subscription store: `apps/dashboard/src/lib/billing/subscription-store.ts` (+ `subscription-store.test.ts`) — the monotonic guard and D1 cache live here.
+- Plan resolution: `getPlanForOwner` (`apps/dashboard/src/lib/billing/user-subscription.ts`; also referenced from `retention-owner.ts`, `plan-capability.ts`) reads the D1 cache and, on miss, should reconcile against Polar.
+- Polar config/client: `apps/dashboard/src/lib/billing/polar-config.ts`, `polar-subscription.ts` (`polar-subscription.test.ts` exists).
+
+## Goal
+
+Three tiers of coverage plus a committed recovery runbook: (1) checkout URL creation is correct and errors cleanly on an unknown product; (2) the webhook rejects bad signatures, is idempotent under duplicate delivery, and never regresses a newer subscription state with an older out-of-order event; (3) a D1 cache miss reconciles from Polar and resolves the right plan. All fail-open without Clerk.
+
+## Implement now
+
+### A. Checkout tests — `apps/dashboard/src/routes/api/v1/billing/checkout.test.ts` (new)
+- `valid product → { url }`: stub `getPolarClient().checkouts.create` to return `{ url: 'https://polar…' }`; POST `{ planId:'pro', period:'monthly' }` → 200, body `{ url }` matches; assert `successUrl`/origin derivation from `request.url` (`checkout.ts:98`).
+- `unknown product → clean error`: POST `{ planId:'nope' }` → the `No Polar product configured…` path (`:83`), correct status, sanitized (no stack leak).
+- `bad body → 4xx`: missing/invalid JSON body handled (`checkout.ts:44`).
+- `fail-open`: no Clerk/owner context → route does not 500 with a raw auth error (matches the OSS invariant); assert the mapped response.
+
+### B. Webhook tests — `apps/dashboard/src/routes/api/v1/webhooks/polar.test.ts` (extend)
+- `invalid signature → 403`: tamper the body/signature so `validateEvent` throws `WebhookVerificationError` → 403 (`polar.ts:304–307`).
+- `idempotency`: deliver the same `subscription.created`/`updated` event twice → D1 is written **once** (no double-membership, no double subscription row). Assert via the store spy.
+- `monotonic guard`: deliver an out-of-order event (older `modifiedAt`/revision after a newer one) → the store **does not** overwrite the newer state (`subscription-store.ts` guard; `polar.ts:183`). Add the matching unit test in `subscription-store.test.ts` for the guard predicate itself.
+- `unknown product → logged, not crashed`: an event for an unmapped Polar product is logged as ERROR and returns 2xx without writing garbage (`polar.ts:37` behavior).
+
+### C. Reconciliation e2e — `apps/dashboard/src/lib/billing/__tests__/checkout-e2e.test.ts` (new)
+- `cache miss → reconcile`: with an empty D1 subscription cache, `getPlanForOwner(owner)` triggers a Polar lookup (stub `polar-subscription.ts`) and resolves the correct paid plan, then populates the cache; a second call is a cache hit (no second Polar call).
+- `cache hit → no Polar call`: pre-seed D1; assert Polar client is not called.
+- `fail-open`: no Clerk owner → `getPlanForOwner` resolves to the Free/OSS default without throwing (self-hosted-whole invariant).
+
+### D. Runbook — `docs/knowledge/billing-checkout-flow.md` (new)
+- Diagram the flow: client → `POST /billing/checkout` → Polar hosted checkout → `POST /webhooks/polar` (signature-verified) → `subscription-store` (monotonic guard) → D1 cache → `getPlanForOwner`.
+- **Recovery procedures**: (a) webhook missed/failed → how the next `getPlanForOwner` cache-miss reconciliation self-heals; (b) out-of-order delivery → monotonic guard behavior; (c) manual reconciliation steps (re-fetch subscription from Polar, re-seed D1); (d) how OSS fails open (no Clerk → Free default). Cross-link `checkout.ts`, `polar.ts`, `subscription-store.ts`, `user-subscription.ts`.
+
+### E. Only-if-needed refactor
+- If a path can't be tested without executing Polar, extract a **pure** helper (e.g. `resolveProductFor(planId, period)`, or `applySubscriptionEvent(state, event)` for the monotonic guard) and test that directly. Do not change externally observable behavior.
+
+## STOP conditions & drift check
+- **STOP if** `polar.ts` no longer uses `validateEvent` for signature auth, or the monotonic guard moved out of `subscription-store.ts` — update the test targets to the real location before writing assertions.
+- **STOP if** `checkout.ts` return shape is no longer `{ url }` or the product-mapping error text changed — align assertions to current code.
+- **STOP and ask** before adding any new production dependency for mocking; use Bun's built-in mocking + local stubs. Never add Jest.
+- **Drift check:** `getPlanForOwner` still lives in `user-subscription.ts` and reconciles on cache miss. If reconciliation moved or was removed, the e2e test target changed — stop and re-locate.
+
+## Verification
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/routes/api/v1/billing/checkout.test.ts src/routes/api/v1/webhooks/polar.test.ts src/lib/billing/__tests__/checkout-e2e.test.ts --isolate
+bun run lint
+```
+
+## Done criteria
+- `checkout.test.ts` proves valid → `{ url }`, unknown product → clean error, and fail-open.
+- `polar.test.ts` proves bad signature → 403, duplicate delivery writes once, and out-of-order events don't regress state; `subscription-store.test.ts` covers the monotonic guard predicate.
+- `checkout-e2e.test.ts` proves D1 cache-miss reconciliation, cache-hit skips Polar, and fail-open to Free without Clerk.
+- `docs/knowledge/billing-checkout-flow.md` committed with the flow diagram + recovery procedures.
+- All targeted tests, type-check, build, and lint green.
+
+Priority: P1 · Effort M · Depth: F · Wave: R (Revenue) · Lever: Revenue (protect the money path)

--- a/plans/18-per-host-overage-billing.md
+++ b/plans/18-per-host-overage-billing.md
@@ -1,0 +1,115 @@
+# 18 — Per-host overage billing
+
+## Kickoff prompt
+
+```text
+Execute plans/18-per-host-overage-billing.md ALONE (do not touch other plans).
+Goal: implement the advertised $15–19/host overage. Paid tiers SOFT-CAP hosts
+(add a 4th+ host without a 402) and meter each over-limit host into a monthly bill;
+Free stays HARD-CAPPED. Mirror the AI-overage model (plan 14).
+Invariants you must not violate:
+  - Self-hosted/OSS stays whole: host gating FAILS OPEN without Clerk. No Clerk →
+    unlimited hosts, no metering. Verify the fail-open path stays intact.
+  - Honest paywalls: advertised ⟺ enforced (or `deferred`) in lib/billing/plan-enforcement.ts.
+    Only advertise host-overage as enforced once the meter + Polar reporting are wired;
+    until Polar usage reporting is confirmed, mark it `deferred` with a reason — do NOT
+    claim revenue you can't bill.
+  - AI recommends DDL, never auto-applies (untouched).
+  - Postgres/multi-DB: NO for 2026 H2 — new table is D1 only.
+Polar usage-based reporting is the one uncertain integration: if the SDK/product
+setup isn't confirmed, land the local meter (D1 host_usage_monthly) + soft-cap and
+mark the Polar push as a follow-up. End by running Verification and pasting results.
+```
+
+## Current reality (audited)
+
+The advertised $15–19/host overage (the GA land-and-expand lever) has **no code path** — paid hosts hard-cap instead of expanding.
+
+- Host gate: `apps/dashboard/src/routes/api/v1/user-connections.ts` calls `checkHostLimit(plan, currentHosts)` (`entitlements.ts:81`) and 402s at the cap for **all** tiers. Host counting is pooled via org-host-count.
+- Host pooling: `apps/dashboard/src/lib/billing/org-host-count.ts` (+ `org-host-count.test.ts`) — `countOwnerHosts`-style pooled count.
+- Plan type: `packages/pricing/src/plans.ts` has `hosts: number|null` (`plans.ts:57`, "the BINDING meter") and an **AI** overage (`aiOverage: { usdPer; messages } | null`, `:73`) but **no `hostOverage` field**. Free `hosts: 1`; Pro `hosts: 3`; there is no per-host price field yet.
+- The AI-overage model to mirror: `apps/dashboard/src/lib/billing/ai-usage-store.ts` (`ai_usage_monthly` table, `addAiSpend`) — plan 14 formalizes `meterAiOverage`.
+- Enforcement registry: `apps/dashboard/src/lib/billing/plan-enforcement.ts` (`LIMIT_ENFORCEMENT`) currently marks `hosts` enforced (hard cap). This plan changes host semantics for paid tiers, so the registry entry must be updated honestly.
+
+## Goal
+
+Paid tiers soft-cap hosts: adding a host beyond the included count succeeds (no 402) and records an over-limit host-month that meters into the monthly bill at the plan's per-host price; the monthly total resolves as `base + (overage hosts × per-host price)`. Free stays hard-capped. OSS is unlimited and never metered.
+
+## Implement now
+
+### A. Add the pricing field — `packages/pricing/src/plans.ts`
+- Extend the `Plan` type with:
+  ```ts
+  hostOverage: { usdPer: number } | null   // null = hard-cap (no expansion)
+  ```
+- Set Free `hostOverage: null` (hard cap at 1). Set Pro/Max `hostOverage: { usdPer: <15..19> }` per the advertised range (confirm the exact number against `apps/landing/src/data/pricing.ts` so the landing claim and code match — honest-paywall invariant).
+- Update `packages/pricing` tests (`plans.test.ts`) for the new field's presence per tier.
+
+### B. Soft-cap the gate — `apps/dashboard/src/lib/billing/entitlements.ts`
+- Add `checkHostSoftCap(plan, currentHosts): { allowed: boolean; overageHosts: number }`:
+  - if `currentHosts < plan.hosts` → `{ allowed: true, overageHosts: 0 }`.
+  - else if `plan.hostOverage != null` → `{ allowed: true, overageHosts: currentHosts - plan.hosts + 1 }` (paid soft-cap; the new host is billable overage).
+  - else → `{ allowed: false, overageHosts: 0 }` (Free hard cap; caller 402s).
+- Keep `checkHostLimit` for callers that still want the hard boundary; this is additive.
+
+### C. New meter store — `apps/dashboard/src/lib/billing/host-usage-store.ts` (new) + D1 migration
+- D1 table `host_usage_monthly`:
+  ```sql
+  CREATE TABLE IF NOT EXISTS host_usage_monthly (
+    owner_id   TEXT NOT NULL,
+    month      TEXT NOT NULL,      -- 'YYYY-MM'
+    host_count INTEGER NOT NULL,   -- peak billable overage hosts this month
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (owner_id, month)
+  );
+  ```
+- Exports (mirror `ai-usage-store.ts`):
+  - `recordHostOverage(ownerId: string, overageHosts: number): Promise<void>` — upsert the **peak** billable overage count for the month (`host_count = MAX(existing, overageHosts)`), so removing/re-adding within a month doesn't multiply the charge.
+  - `getHostOverageThisMonth(ownerId: string): Promise<number>`.
+- Add the migration to the app's D1 migrations dir (same location as the `ai_usage_monthly`/subscription migrations).
+
+### D. Wire the connection route — `apps/dashboard/src/routes/api/v1/user-connections.ts`
+- Replace the hard `checkHostLimit` gate on host-add with `checkHostSoftCap(plan, currentHosts)`:
+  - if `!allowed` → 402 (Free) with `reason: 'host'` (feeds the plan-15 paywall).
+  - if `allowed && overageHosts > 0` → allow the add **and** `await recordHostOverage(owner.id, overageHosts)`.
+- Preserve the fail-open path: if plan/owner resolution throws (no Clerk), allow the add and do not meter (OSS unlimited).
+
+### E. Fold into the monthly bill — `apps/dashboard/src/routes/api/v1/billing/usage.ts` + Polar reporting
+- Surface it: add `hostOverageThisMonth` (count) and `hostOverageUsd = count × plan.hostOverage.usdPer` to the `/billing/usage` response (so plan 16's card can show it).
+- **Polar usage-based reporting (uncertain — gate carefully):** if Polar usage-based/metered billing is configured for the account, report `host_count` to Polar's meter/usage API (via `polar-subscription.ts`/`polar-config.ts`) on a monthly cron or at record time. If the Polar product/SDK path is **not** confirmed, DO NOT fake it — land steps A–E's local meter + surface, and mark host-overage `deferred` in the registry (below) with reason "local meter live; Polar usage reporting pending product setup". This keeps the paywall honest.
+
+### F. Enforcement registry — `apps/dashboard/src/lib/billing/plan-enforcement.ts`
+- Update `LIMIT_ENFORCEMENT.hosts`:
+  - If Polar reporting is wired → `{ status:'enforced', gate:'user-connections.ts checkHostSoftCap → host-usage-store.recordHostOverage → Polar usage report' }`.
+  - If only the local meter landed → keep `hosts` enforced for the *hard cap* aspect but add an explicit note/entry that host **overage billing** is `deferred` pending Polar reporting. Never mark overage `enforced` without a billing path.
+
+### G. Tests — `apps/dashboard/src/lib/billing/host-usage-store.test.ts` (new) + extend `entitlements.test.ts`
+- `Free hard-caps`: `checkHostSoftCap(FREE, 1).allowed === false`.
+- `Pro soft-caps`: `checkHostSoftCap(PRO, 3).allowed === true`, `overageHosts === 1`; at 4 hosts → `overageHosts === 2`.
+- `peak meter`: `recordHostOverage(owner, 1)` then `recordHostOverage(owner, 2)` → `getHostOverageThisMonth === 2`; a later `recordHostOverage(owner, 1)` keeps it at `2` (peak, not additive).
+- `monthly math`: `hostOverageUsd = count × plan.hostOverage.usdPer` for Pro and Max.
+- `fail-open`: no Clerk → `recordHostOverage` does not throw and the add is allowed.
+
+## STOP conditions & drift check
+- **STOP if** `packages/pricing` already defines `hostOverage` — reconcile with the existing field instead of redefining.
+- **STOP if** the advertised per-host price in `apps/landing/src/data/pricing.ts` differs from what you're about to set in `plans.ts` — reconcile to ONE number (honest-paywall) before wiring.
+- **STOP and mark `deferred`** (do not fabricate) if Polar usage-based reporting cannot be confirmed for the account/product — land the local meter and surface only.
+- **STOP and ask** before changing `checkHostLimit`'s existing callers beyond the connection route; other routes may rely on the hard boundary.
+- **Drift check:** `user-connections.ts` still gates via `checkHostLimit` and pools via `org-host-count.ts`. If host counting moved, update the soft-cap wiring to the real counter.
+
+## Verification
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/billing/host-usage-store.test.ts src/lib/billing/entitlements.test.ts --isolate
+bun run lint
+```
+
+## Done criteria
+- Paid tiers add a 4th+ host without a 402; Free still 402s at its cap.
+- Over-limit host-months recorded as a **peak** count in `host_usage_monthly`; `/billing/usage` returns `hostOverageThisMonth` and `hostOverageUsd`.
+- Monthly total computes as `base + overageHosts × plan.hostOverage.usdPer`; tests cover Pro and Max math.
+- `plan-enforcement.ts` reflects reality: overage `enforced` only if Polar reporting is wired, else `deferred` with a reason.
+- Fail-open verified (no Clerk → unlimited, unmetered); type-check, build, lint green.
+
+Priority: P1 · Effort L · Depth: F · Wave: R (Revenue) · Lever: Revenue (land-and-expand)

--- a/plans/19-downgrade-protection.md
+++ b/plans/19-downgrade-protection.md
@@ -1,0 +1,100 @@
+# 19 — Downgrade protection
+
+## Kickoff prompt
+
+```text
+Execute plans/19-downgrade-protection.md ALONE (do not touch other plans).
+Goal: before sending a user to the Polar portal to downgrade, compare their CURRENT
+usage to the TARGET plan's limits; if current usage exceeds the target, warn with the
+exact exceeded limits and offer "Stay on <current>" vs "Downgrade anyway".
+Invariants you must not violate:
+  - Self-hosted/OSS stays whole: usage/plan resolution FAILS OPEN without Clerk; on
+    OSS the check returns "ok" (nothing to protect) and never blocks.
+  - Honest paywalls: advertised ⟺ enforced (or `deferred`). Only warn on limits that
+    are actually enforced per lib/billing/plan-enforcement.ts; a `deferred` limit must
+    not manufacture a scary warning.
+  - AI recommends DDL, never auto-applies (untouched).
+  - Postgres/multi-DB: NO for 2026 H2.
+Reuse the same usage source as the billing card (GET /api/v1/billing/usage) and the
+existing check* helpers in lib/billing/entitlements.ts. End by running Verification.
+```
+
+## Current reality (audited)
+
+Users can downgrade below their current usage and silently lose access to hosts/seats — a retention/quality hole.
+
+- Usage is available: `apps/dashboard/src/routes/api/v1/billing/usage.ts` returns `hosts`, `seats`, `aiMessages` (each `{ used, limit, unlimited }`) plus `renewal`.
+- Limit helpers exist: `apps/dashboard/src/lib/billing/entitlements.ts` — `checkHostLimit`, `checkSeatLimit`, `checkAiDailyLimit`, `checkAiBudget`, and `limitMessage` (`entitlements.ts:81–136`).
+- Plan catalog: `packages/pricing/src/plans.ts` (per-tier `hosts`, `seats`, `aiRequestsPerDay`, `aiMonthlyUsdBudget`, `retentionDays`).
+- Downgrade is initiated by opening the Polar portal: `apps/dashboard/src/routes/api/v1/billing/portal.ts` → `{ url }`. There is **no pre-portal check** and **no confirm modal**.
+- No `can-downgrade.ts` route and no downgrade confirm component exist yet.
+
+## Goal
+
+A `can-downgrade` check compares current usage against a target plan; the UI blocks the "downgrade" affordance behind a warning modal listing every exceeded limit, offering "Stay" vs "Downgrade anyway" (which proceeds to the portal and logs the choice). It only warns on enforced limits and is a no-op on OSS.
+
+## Implement now
+
+### A. Route — `apps/dashboard/src/routes/api/v1/billing/can-downgrade.ts` (new)
+```ts
+// POST /api/v1/billing/can-downgrade
+// body: { targetPlanId: string }
+// returns: { ok: boolean; exceeded: Array<{ metric: 'hosts'|'seats'|'aiRequestsPerDay'|'retentionDays'; used: number; targetLimit: number|null; message: string }> }
+```
+- Resolve the owner's current usage (reuse the internal resolvers behind `usage.ts`: pooled hosts, seats/member count, AI usage) and the **target** plan from `@chm/pricing`.
+- For each metric that is **enforced** (consult `plan-enforcement.ts` `LIMIT_ENFORCEMENT`), compare `used > targetLimit` (respect `unlimited`/`null`). Build `exceeded[]` with `limitMessage`-style copy.
+- `ok = exceeded.length === 0`.
+- **Fail-open:** if plan/usage resolution throws (no Clerk), return `{ ok: true, exceeded: [] }` — OSS has nothing to protect.
+- Use `createFileRoute('/api/v1/billing/can-downgrade')` with a `POST` handler, mirroring `checkout.ts`/`portal.ts` structure and the shared error mapper.
+
+### B. Confirm modal — `apps/dashboard/src/components/billing/downgrade-confirm-modal.tsx` (new)
+```tsx
+export function DowngradeConfirmModal(props: {
+  open: boolean
+  targetPlanId: string
+  exceeded: Array<{ metric: string; used: number; targetLimit: number|null; message: string }>
+  onStay: () => void            // close, no-op
+  onProceed: () => void         // open Polar portal + log
+  onClose: () => void
+}): JSX.Element
+```
+- If `exceeded` is non-empty: warn ("Downgrading to <target> will exceed its limits:") and list each exceeded metric with `used` vs `targetLimit`. Primary action "Stay on current plan"; secondary/destructive "Downgrade anyway".
+- If `exceeded` is empty: this modal shouldn't be shown (the caller proceeds straight to the portal).
+- Reuse the app's existing dialog primitive (same one the other `components/billing/*` dialogs use).
+
+### C. Wire the downgrade affordance — billing UI
+- Wherever a "downgrade" / "change to a lower plan" action exists (the billing card from plan 16, or the Polar-portal CTA), intercept: first `POST /api/v1/billing/can-downgrade { targetPlanId }`.
+  - `ok === true` → proceed directly to `POST /api/v1/billing/portal` → `window.location.assign(url)`.
+  - `ok === false` → open `DowngradeConfirmModal` with `exceeded`. "Downgrade anyway" → portal + a client log/telemetry event `billing.downgrade.override` (which limits were exceeded); "Stay" → close.
+
+### D. Logging
+- Record the override decision (who, target plan, exceeded metrics) via the app's existing logging/telemetry path used elsewhere in billing; if none is wired, a structured `console.info` gated behind the existing debug flag is acceptable (mirror the agent-route logging discipline). No PII beyond owner id.
+
+### E. Tests — `apps/dashboard/src/routes/api/v1/billing/can-downgrade.test.ts` (new)
+- **Free→Pro** (an *upgrade* target above current usage) → `ok: true`, empty `exceeded`.
+- **Max→Pro with 5 hosts** where Pro caps at 3 → `ok: false`, `exceeded` includes `hosts` with `used: 5, targetLimit: 3`.
+- **Seats**: current members > target seats → seats appears in `exceeded`.
+- **deferred metric ignored**: a metric marked `deferred` in `plan-enforcement.ts` never appears in `exceeded` even if numerically over.
+- **fail-open**: no Clerk → `{ ok: true, exceeded: [] }`, no throw.
+
+## STOP conditions & drift check
+- **STOP if** there is no downgrade/lower-plan affordance in the UI yet (plan 16 not merged) — still ship the `can-downgrade` route + modal and wire them behind the portal CTA; note the dependency.
+- **STOP if** usage resolution can't be reused from `usage.ts` without duplicating logic — extract a shared `resolveOwnerUsage(owner)` helper used by both routes rather than copy-paste.
+- **STOP and ask** if the desired behavior is to *hard-block* downgrades over usage (vs. warn-and-allow) — this plan implements warn-and-allow ("Downgrade anyway"); confirm before making it a hard block.
+- **Drift check:** `entitlements.ts` still exports `checkHostLimit/checkSeatLimit/limitMessage`. If renamed, update the comparison logic.
+
+## Verification
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/routes/api/v1/billing/can-downgrade.test.ts --isolate
+bun run lint
+```
+
+## Done criteria
+- `POST /api/v1/billing/can-downgrade` returns `{ ok, exceeded[] }`, comparing current usage to the target plan on enforced limits only, and fails open on OSS.
+- Over-limit downgrades open a warning modal listing exceeded limits with "Stay" vs "Downgrade anyway"; anyway proceeds to the Polar portal and logs the override.
+- Downgrades within target limits skip the modal and go straight to the portal.
+- Free→Pro and Max→Pro tests pass; deferred-metric and fail-open cases covered; type-check, build, lint green.
+
+Priority: P1 · Effort S · Depth: F · Wave: R (Revenue) · Lever: Revenue (retention)

--- a/plans/20-seat-cap-invite-time-gate.md
+++ b/plans/20-seat-cap-invite-time-gate.md
@@ -1,0 +1,91 @@
+# 20 — Seat-cap invite-time gate
+
+## Kickoff prompt
+
+```text
+Execute plans/20-seat-cap-invite-time-gate.md ALONE (do not touch other plans).
+Goal: enforce the seat cap PRE-EMPTIVELY at invite time (402 + paywall before the
+member is added) instead of only post-hoc via the Clerk webhook rollback. Keep the
+webhook rollback as defense-in-depth.
+Invariants you must not violate:
+  - Self-hosted/OSS stays whole: seat resolution FAILS OPEN without Clerk — no Clerk
+    org context → no gate, invite proceeds. Verify this path.
+  - Honest paywalls: advertised ⟺ enforced (or `deferred`) in lib/billing/plan-enforcement.ts.
+    seats must be `enforced` after this (it becomes a real pre-check); update the gate string.
+  - AI recommends DDL, never auto-applies (untouched).
+  - Postgres/multi-DB: NO for 2026 H2.
+The 402 you return must carry reason:'seat' so the plan-15 PaywallModal can render it.
+End by running the Verification block and pasting results.
+```
+
+## Current reality (audited)
+
+The seat limit is enforced **post-hoc**: Clerk adds the member, then the `organizationMembership.created` webhook counts members and rolls the over-limit member back — confusing UX (a user is added, then removed).
+
+- Post-hoc path: `apps/dashboard/src/routes/api/v1/webhooks/clerk.ts` handles `organizationMembership.created` (`clerk.ts:47`), resolves the owner's plan, and calls `checkSeatLimit(plan, count - 1)` (`clerk.ts:72`) — note the `count - 1` because the webhook fires *after* Clerk has already added the member (`clerk.ts:68–70` comment). Over-limit members are rolled back.
+- Seat helper: `apps/dashboard/src/lib/billing/entitlements.ts:86` `checkSeatLimit(plan, currentSeats)` — semantics: `used < limit` ("room for one more?").
+- Plan resolution: `getPlanForOwner` lives in `apps/dashboard/src/lib/billing/user-subscription.ts` (also imported by `retention-owner.ts`, `plan-capability.ts`) — **not** in `entitlements.ts` (spec pointer refined). `(verify import path)`.
+- **The invite endpoint is not yet its own route.** A repo scan found invitation logic only referenced from `webhooks/clerk.ts`; there is no dedicated `routes/api/v1/**/invite*.ts`. Invites are likely issued client-side via Clerk's `<OrganizationProfile>` / `useOrganization().inviteMember`, or via a thin server proxy that must be located. **First task: locate where an invite is issued** (grep `createOrganizationInvitation`, `inviteMember`, `invitations`), because the pre-check must live at that call.
+- Seat-enforcement tests already exist: `apps/dashboard/src/lib/billing/seat-enforcement.test.ts` — extend, don't duplicate.
+
+## Goal
+
+Seat limit is checked **before** the invite is created: at seats-full, the invite is rejected with a 402 (`reason: 'seat'`) that drives the paywall, so no member is ever added-then-removed. The Clerk webhook rollback stays as a belt-and-suspenders fallback.
+
+## Implement now
+
+### A. Locate / create the invite server path
+- Grep for the invite issuance: `createOrganizationInvitation`, `inviteMember`, `organization.inviteMember`, `/invitations`.
+- **If a server route exists** (e.g. a proxy that calls Clerk's Backend API `createOrganizationInvitation`): add the pre-check there.
+- **If invites are purely client-side** (Clerk components/`useOrganization`): add a thin server route `apps/dashboard/src/routes/api/v1/org/invite.ts` (`POST { emailAddress, role }`) that (1) runs the seat pre-check, (2) on pass calls Clerk's Backend API `createOrganizationInvitation`, (3) returns the invitation. Point the UI's invite action at this route instead of calling Clerk directly. `(verify the invite mechanism before choosing a branch)`.
+
+### B. Pre-check helper — `apps/dashboard/src/lib/billing/entitlements.ts`
+- Reuse `checkSeatLimit(plan, currentSeats)`. At invite time the current member count has **not** been incremented yet, so pass the **live** member count (no `-1`): `checkSeatLimit(plan, currentMembers)` returns `allowed=false` when `currentMembers >= plan.seats`.
+- Resolve current members with the same counting used by `usage.ts`/`clerk.ts` (Clerk org membership count for the owner org). Resolve plan via `getPlanForOwner(owner.id)` from `user-subscription.ts`.
+
+### C. Wire the gate at invite time
+- In the invite path (A):
+  ```
+  const plan = await getPlanForOwner(owner.id)         // fail-open: throws w/o Clerk
+  const members = await countOrgMembers(owner.id)
+  const check = checkSeatLimit(plan, members)
+  if (!check.allowed) return 402 { reason: 'seat', message: limitMessage(check) }
+  // else: proceed to create the Clerk invitation
+  ```
+- **Fail-open:** wrap plan/member resolution so that if it throws (no Clerk), the invite proceeds ungated (OSS/self-hosted-whole).
+- The 402 body MUST include `reason: 'seat'` so the plan-15 `PaywallModal` classifies it.
+
+### D. Keep the webhook rollback — `apps/dashboard/src/routes/api/v1/webhooks/clerk.ts`
+- **Do not remove** the `organizationMembership.created` → `checkSeatLimit(plan, count - 1)` rollback (`clerk.ts:47–72`). It stays as defense-in-depth for any invite path that bypasses the pre-check (e.g. direct Clerk Dashboard adds). Add a code comment noting the pre-check is primary and this is the fallback.
+
+### E. Enforcement registry — `apps/dashboard/src/lib/billing/plan-enforcement.ts`
+- Update `LIMIT_ENFORCEMENT.seats` to `{ status:'enforced', gate:'org/invite.ts pre-check checkSeatLimit; webhooks/clerk.ts rollback as fallback' }`. (Honest-paywall invariant — seats is now genuinely pre-enforced.)
+
+### F. Tests — extend `apps/dashboard/src/lib/billing/seat-enforcement.test.ts` (+ a route test if a route was added)
+- **At seats** (`currentMembers === plan.seats`): pre-check `allowed === false` → invite path returns 402 with `reason: 'seat'`.
+- **At seats−1**: `allowed === true` → invite proceeds (Clerk create called).
+- **fail-open**: plan/member resolution throws (no Clerk) → invite proceeds, no 402.
+- **webhook still guards**: existing rollback test remains green (the post-hoc `count - 1` path unchanged).
+
+## STOP conditions & drift check
+- **STOP and locate first**: do not assume an invite route exists. Confirm the invite mechanism (server route vs client Clerk component) before adding the gate; choose branch A accordingly.
+- **STOP if** `checkSeatLimit`'s semantics are `used <= limit` rather than `used < limit` — the pre-check arg (no `-1`) depends on "room for one more"; verify at `entitlements.ts:86` and adjust the off-by-one to match.
+- **STOP if** `getPlanForOwner` is not importable from `user-subscription.ts` — re-locate it (it is also referenced from `retention-owner.ts`/`plan-capability.ts`) before wiring.
+- **Drift check:** `webhooks/clerk.ts` still calls `checkSeatLimit(plan, count - 1)` on `organizationMembership.created`. If that rollback is gone, don't remove the fallback — restore/keep it.
+
+## Verification
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/billing/seat-enforcement.test.ts --isolate
+bun run lint
+```
+
+## Done criteria
+- An over-cap invite returns 402 (`reason: 'seat'`) **before** any member is added; the paywall (plan 15) can render it.
+- An at-cap-minus-one invite proceeds and creates the Clerk invitation.
+- The Clerk `organizationMembership.created` rollback remains intact as defense-in-depth.
+- `plan-enforcement.ts` marks `seats` `enforced` with a gate string naming the invite pre-check.
+- Fail-open verified (no Clerk → invite proceeds ungated); tests at seats and seats−1 pass; type-check, build, lint green.
+
+Priority: P1 · Effort S · Depth: F · Wave: R (Revenue) · Lever: Adoption (clean seat UX + upgrade prompt)

--- a/plans/21-sso-saml-enterprise.md
+++ b/plans/21-sso-saml-enterprise.md
@@ -1,0 +1,120 @@
+# 21 — SSO / SAML for Enterprise
+
+## Kickoff prompt
+
+```text
+Execute plans/21-sso-saml-enterprise.md ALONE (Wave E, Enterprise, Depth E — do light
+discovery first). Add SAML/OIDC SSO for enterprise orgs, preferring Clerk enterprise
+connections, with domain-verified JIT org+user provisioning.
+
+Invariants (do not violate):
+- Self-hosted/OSS stays WHOLE; every auth/plan gate FAILS OPEN without Clerk (no Clerk →
+  SSO code path is inert, normal login unaffected).
+- SSO is an ENTERPRISE-edition feature: gate via lib/edition; it must NOT degrade or remove
+  any capability for the OSS/community edition.
+- AI recommends DDL, never auto-applies (not touched here, keep it true).
+- Postgres = NO. Identity/domain mapping persists in D1 only.
+
+Resolve the OPEN QUESTIONS in this file before writing app code. End by running the
+Verification commands and pasting results.
+```
+
+## Current reality (audited)
+
+- **Why (spec 21):** SSO/SAML is table-stakes for enterprise deals. `edition` *flags* an
+  enterprise tier but **nothing enforces or provisions SSO** — there is no SAML metadata
+  handling, no assertion validation, no JIT provisioning.
+- Edition gating exists: `apps/dashboard/src/lib/edition/edition.ts` (+ `index.ts`,
+  `edition.test.ts`) defines the enterprise-feature surface (`ENTERPRISE_FEATURES` per the
+  Round-2 audit). No `sso` capability is wired to it yet.
+- Auth is Clerk-based; billing owner / org resolution lives under
+  `apps/dashboard/src/lib/billing/` (`user-subscription.ts`, `org-host-count.ts`) and the
+  Clerk webhook at `apps/dashboard/src/routes/api/v1/webhooks/clerk.ts`.
+- No `apps/dashboard/src/lib/auth/sso/` directory exists yet.
+
+## Goal
+
+Enterprise admins configure an IdP (SAML or OIDC) for a **verified domain**; a user logging
+in via that IdP is **JIT-provisioned** into the correct Clerk org + chmonitor user, their
+session resolves to the **Enterprise** edition/plan, and IdP group claims map to roles
+(handoff to plan 23 RBAC). Community/self-hosted logs in exactly as today.
+
+## Implement now
+
+> Depth **E**: settle the open questions, then build. Prefer **Clerk enterprise
+> connections** over hand-rolling SAML XML validation — Clerk already handles metadata,
+> signature validation, and the ACS endpoint, which removes the highest-risk crypto code.
+
+**Approach & key files**
+- New `apps/dashboard/src/lib/auth/sso/` — thin module: IdP-connection config resolution,
+  verified-domain lookup, and JIT provisioning orchestration. If Clerk owns assertion
+  validation, this module holds *mapping* logic (domain → org, IdP groups → roles), not XML
+  parsing.
+- New `apps/dashboard/src/routes/api/v1/auth/sso-callback.ts` — post-auth hook that reads the
+  Clerk-verified session, resolves/creates the org for the verified domain, and links the
+  user (JIT). `(verify)` whether Clerk's hosted callback removes the need for a custom route;
+  if so, this becomes a webhook/`session.created` handler instead.
+- `apps/dashboard/src/lib/edition/edition.ts` — add an `sso` enterprise capability and gate
+  the config/admin surface on it. Community edition: capability absent → SSO admin hidden,
+  normal login untouched.
+- Domain-verification + IdP-connection metadata persisted in a new D1 table
+  (e.g. `sso_connections`: `org_id`, `domain`, `provider`, `clerk_connection_id`,
+  `default_role`, `created_at`) — migration under
+  `apps/dashboard/src/db/conversations-migrations/` (next sequential number, `.sql`).
+- Group→role mapping is the seam to **plan 23** (`lib/rbac/rbac.ts`): store the claim→role map
+  with the connection; on provisioning, set the Clerk org-role so 23's gates read it.
+
+**Fail-open wiring:** every entry point resolves the owner/org via the existing billing-owner
+helpers; when Clerk is absent those throw and the call site swallows it (the established OSS
+pattern), so the SSO path never runs and normal auth is unaffected.
+
+**Open questions to resolve during discovery (answer in the PR description):**
+1. **Clerk capability:** does the project's Clerk plan expose SAML/OIDC *enterprise
+   connections* via API, or only dashboard-configured? Determines whether admin config is
+   in-app or a documented Clerk-dashboard step. `(verify)`
+2. **Domain verification source of truth:** Clerk-verified domains vs. a chmonitor-owned DNS
+   TXT check. Prefer Clerk's if available.
+3. **JIT org strategy:** one Clerk org per verified domain, or map to an existing org chosen
+   by the admin? Affects the `sso_connections` unique key.
+4. **Callback shape:** custom `/auth/sso-callback` route vs. `session.created`/`user.created`
+   Clerk webhook extension in `webhooks/clerk.ts`. Pick one; don't build both.
+5. **Group→role claim path:** exact claim name per provider (Okta/Azure AD/Google) — record
+   the mapping table shape for plan 23.
+
+## STOP conditions & drift check
+
+- **STOP** if implementing SAML assertion signature validation *by hand* becomes necessary
+  (Clerk not viable) — that is a security-critical scope change; surface it and get a decision
+  before writing XML/crypto code.
+- **STOP** if any change would gate a currently-free capability for community/self-hosted, or
+  make normal (non-SSO) login depend on Clerk being present.
+- **Drift check:** if `edition.ts` no longer exposes an enterprise-feature registry, or Clerk
+  is no longer the auth provider, STOP and reconcile with the current code before proceeding.
+- Do not touch AI/DDL paths; do not add Postgres.
+
+## Verification
+
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/auth/sso --isolate
+cd apps/dashboard && bun test src/lib/edition/edition.test.ts --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+
+- [ ] `sso` is a named enterprise capability in `lib/edition`; disabled outside enterprise
+  edition (asserted by a test).
+- [ ] A verified-domain SSO login **JIT-provisions** a Clerk user + org and the session
+  resolves to Enterprise (integration-style test with Clerk mocked).
+- [ ] IdP group claims map to a role stored for plan 23 to consume (unit test on the mapping).
+- [ ] Community/self-hosted (no Clerk) login path is unchanged and SSO code is inert
+  (fail-open test).
+- [ ] D1 migration for `sso_connections` committed; no Postgres introduced.
+- [ ] All five open questions answered in the PR description.
+- [ ] type-check, build, targeted tests, lint all green.
+
+---
+
+Priority P2 · Effort L · Depth E · Wave E (Enterprise) · Lever Enterprise/Revenue

--- a/plans/22-audit-log-export.md
+++ b/plans/22-audit-log-export.md
@@ -1,0 +1,139 @@
+# 22 — Audit log + org-scoped CSV export
+
+## Kickoff prompt
+
+```text
+Execute plans/22-audit-log-export.md ALONE (Wave E, Enterprise, Depth F — file-level spec
+below). Add an append-only audit_logs D1 table, a logEvent() helper, and an org-scoped,
+date-filtered CSV export route, wired to member / billing / connection mutations.
+Enterprise-edition-gated.
+
+Invariants (do not violate):
+- Self-hosted/OSS stays WHOLE; the audit gate FAILS OPEN without Clerk (no owner/org → logging
+  is best-effort/no-op, never blocks the underlying mutation).
+- Audit is ENTERPRISE-edition-gated (via lib/edition) and must NOT degrade OSS.
+- AI recommends DDL, never auto-applies (unaffected).
+- Postgres = NO. The log is a D1 table; export is CSV.
+
+End with the Verification commands + results.
+```
+
+## Current reality (audited)
+
+- **Why (spec 22):** SOC2/ISO buyers need an audit trail + export; **none exists**. No
+  `audit_logs` table, no `lib/audit/`, no export route.
+- Wiring targets confirmed present: Clerk webhook
+  `apps/dashboard/src/routes/api/v1/webhooks/clerk.ts` (member add/remove); billing mutations
+  under `apps/dashboard/src/routes/api/v1/billing/` (checkout/portal/webhooks) and Polar
+  webhook; connection mutations `apps/dashboard/src/routes/api/v1/user-connections.ts`.
+- D1 migrations are `.sql` files under `apps/dashboard/src/db/conversations-migrations/`
+  (latest examples: `0005_ai_usage_daily.sql`, `0006_auth_identities.sql`). New migration =
+  next sequential number.
+- Edition gating: `apps/dashboard/src/lib/edition/edition.ts`.
+
+## Goal
+
+Every state-changing action (member, billing, connection mutations) appends an immutable row to
+`audit_logs`; an enterprise admin can `GET` a **CSV export filtered by date and scoped to their
+org only**. Logging never blocks the underlying mutation and is inert for OSS/self-hosted.
+
+## Implement now
+
+**A. Migration — new `apps/dashboard/src/db/conversations-migrations/NNNN_audit_logs.sql`**
+(next sequential number). Append-only table:
+
+```sql
+CREATE TABLE IF NOT EXISTS audit_logs (
+  id           TEXT PRIMARY KEY,              -- uuid / crypto.randomUUID()
+  event_time   TEXT NOT NULL,                 -- ISO-8601 UTC
+  org_id       TEXT NOT NULL,                 -- scoping key (Clerk org id)
+  user_id      TEXT,                          -- actor Clerk user id (nullable: system/webhook)
+  event        TEXT NOT NULL,                 -- e.g. 'member.invited', 'billing.checkout', 'connection.created'
+  resource     TEXT,                          -- affected resource id/label
+  action       TEXT NOT NULL,                 -- 'create' | 'update' | 'delete' | 'invite' | ...
+  result       TEXT NOT NULL,                 -- 'success' | 'denied' | 'error'
+  ip           TEXT,                          -- request IP when available
+  metadata     TEXT                           -- optional JSON string, small
+);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_org_time ON audit_logs (org_id, event_time);
+```
+
+**B. Helper — new `apps/dashboard/src/lib/audit/index.ts` (+ `logEvent.ts`)**
+
+```ts
+export interface AuditEvent {
+  orgId: string
+  userId?: string | null
+  event: string
+  resource?: string | null
+  action: 'create' | 'update' | 'delete' | 'invite' | 'export' | string
+  result: 'success' | 'denied' | 'error'
+  ip?: string | null
+  metadata?: Record<string, unknown>
+}
+// Best-effort append. MUST NOT throw into the caller: wrap the D1 write in
+// try/catch and swallow on failure (audit is observational, never blocking).
+// No-op when edition != enterprise OR org/owner cannot be resolved (fail-open).
+export async function logEvent(env, e: AuditEvent): Promise<void>
+```
+
+- `event_time` = `new Date().toISOString()`; `id` = `crypto.randomUUID()`.
+- Insert via the existing D1 binding used by other conversation-DB stores (`(verify)` the
+  binding name, e.g. the same one `ai_usage_daily` uses).
+
+**C. Export route — new `apps/dashboard/src/routes/api/v1/audit/export.ts`**
+- Method: `GET`. Auth: enterprise-gated; requires an authenticated org admin (compose with
+  plan 23 `member:manage` if present, else org-admin check).
+- Query params: `from` (ISO date), `to` (ISO date). Both optional; default to last 30 days.
+- **Org scoping is mandatory and server-derived** — the org id comes from the session, never
+  from a query param, so a caller can only export their own org.
+- Response: `text/csv` with `Content-Disposition: attachment; filename="audit-<org>-<from>-<to>.csv"`.
+  Header row: `event_time,user_id,event,resource,action,result,ip`. Escape/quote fields (CSV
+  injection + comma/quote safety).
+- Emits its own `audit.export` event (`action:'export'`).
+
+**D. Wire mutations to `logEvent`** (add a `logEvent(...)` call after the state change,
+best-effort):
+- `webhooks/clerk.ts` — member created/deleted (`member.invited` / `member.removed`).
+- `billing/` mutations + Polar webhook — `billing.checkout`, `billing.plan_changed`,
+  `billing.canceled`.
+- `user-connections.ts` — `connection.created` / `connection.updated` / `connection.deleted`.
+- Include `result:'denied'` on 402/403 rejections where cheap (optional but valuable for SOC2).
+
+**E. Edition gate:** add an `audit` (or reuse `audit_log`) capability in `lib/edition`; the
+export route 404/403s outside enterprise, and `logEvent` no-ops outside enterprise.
+
+## STOP conditions & drift check
+
+- **STOP** if a `logEvent` failure could ever surface to or roll back the underlying mutation —
+  audit must be strictly non-blocking.
+- **STOP** if org scoping could be influenced by a request param — the org id must be
+  session-derived only.
+- **Drift check:** if an `audit_logs` table or `lib/audit/` already exists, extend rather than
+  recreate; if the D1 binding name differs from other stores, match the existing one.
+- No Postgres; do not touch AI/DDL behaviour.
+
+## Verification
+
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/audit --isolate
+cd apps/dashboard && bun test src/routes/api/v1/audit --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+
+- [ ] `NNNN_audit_logs.sql` migration committed (append-only, `org_id`+`event_time` index).
+- [ ] `logEvent` appends a row, never throws into the caller, no-ops outside enterprise / when
+  org unresolved (unit tests cover success, swallow-on-error, and no-op).
+- [ ] Member, billing, and connection mutations each produce an audit row (coverage test).
+- [ ] `GET /api/v1/audit/export` returns org-scoped CSV filtered by `from`/`to`; org id is
+  session-derived; a caller cannot export another org (scoping test).
+- [ ] CSV fields are escaped/quoted (no CSV injection).
+- [ ] No Postgres. type-check, build, targeted tests, lint all green.
+
+---
+
+Priority P2 · Effort M · Depth F · Wave E (Enterprise) · Lever Enterprise

--- a/plans/23-rbac-roles-enterprise.md
+++ b/plans/23-rbac-roles-enterprise.md
@@ -1,0 +1,119 @@
+# 23 — RBAC roles for Enterprise (viewer / operator / admin)
+
+## Kickoff prompt
+
+```text
+Execute plans/23-rbac-roles-enterprise.md ALONE (Wave E, Enterprise, Depth E — light
+discovery first). Turn lib/rbac/rbac.ts from "community all-access" into a real
+role→permission matrix (viewer/operator/admin) mapped from Clerk org roles, and gate write
+routes (control tools, connections, alert rules).
+
+Invariants (do not violate):
+- Self-hosted/OSS stays WHOLE: when edition != enterprise (or no Clerk), RBAC FAILS OPEN to a
+  single all-access operator — community behaviour is byte-for-byte unchanged.
+- RBAC is ENTERPRISE-edition-gated and must NOT degrade OSS.
+- AI recommends DDL, never auto-applies — do not weaken that; RBAC only decides who may
+  *invoke* a write/control route.
+- Postgres = NO. Roles come from Clerk org roles; any cache is D1.
+
+Resolve the OPEN QUESTIONS before writing app code. End with the Verification commands +
+results.
+```
+
+## Current reality (audited)
+
+- **Why (spec 23):** `lib/rbac/rbac.ts` is effectively **all-access** (community
+  single-operator). Real teams need viewer / operator / admin scoping. Confirmed present:
+  `apps/dashboard/src/lib/rbac/rbac.ts`, `rbac/index.ts`, `rbac/rbac.test.ts`.
+- Edition gating: `apps/dashboard/src/lib/edition/edition.ts` (enterprise-feature surface).
+- A separate `apps/dashboard/src/lib/feature-permissions/` (`server.ts`, `types.ts`) already
+  gates some feature access — RBAC must **compose with**, not duplicate, it. `(verify)` the
+  boundary between the two during discovery.
+- Write/control surfaces to protect (locate exact routes during discovery): control/management
+  tools (query kill / DDL execution endpoints), connection mutations
+  (`apps/dashboard/src/routes/api/v1/user-connections.ts`), and any alert-rule mutation routes
+  (alert-rule routes are thin today — the alerting-config surfaces from Wave A, e.g. plans
+  26/27, are the write targets).
+
+## Goal
+
+Define **viewer / operator / admin** with an explicit permission matrix, map **Clerk org
+roles** onto them, enforce on write paths server-side (viewer cannot kill queries or edit
+connections; admin can), surface a role-management UI — and keep community/self-hosted
+**all-access** and unchanged.
+
+## Implement now
+
+> Depth **E**: resolve open questions, then build. Keep the permission vocabulary small and
+> explicit; enforcement is a server gate, never client-only.
+
+**Approach & key files**
+- `apps/dashboard/src/lib/rbac/rbac.ts` — define `Role = 'viewer' | 'operator' | 'admin'` and
+  a static `Role → Permission[]` matrix (permissions like `connection:write`,
+  `query:kill`, `control:execute`, `alert:configure`, `member:manage`). Export a pure
+  `can(role, permission)` and a server helper `requirePermission(permission)` that resolves the
+  caller's role from the Clerk org membership.
+- **Clerk org-role mapping:** map Clerk org roles (e.g. `org:admin`, `org:member`) → chmonitor
+  roles. Consume the group→role hint produced by **plan 21** (SSO) when present. `(verify)` the
+  exact Clerk role identifiers in this project.
+- **Enforce on write routes:** add `requirePermission(...)` at the top of each mutation handler
+  — connections (`user-connections.ts`), control/management tools, and alert-config routes.
+  Return 403 (not 402 — this is authz, not billing) when denied.
+- **Fail-open:** `requirePermission` returns "allow / operator" when `edition != enterprise`
+  **or** owner/org resolution throws (no Clerk). Community stays all-access. This is the single
+  most important test.
+- **UI:** minimal role-management surface (list members + role) gated on enterprise + the
+  `member:manage` permission. Reads/writes Clerk org roles. `(verify)` whether an existing
+  members UI can host it.
+- No new persistence required if roles live in Clerk; if a role cache is needed, D1 only (new
+  migration under `apps/dashboard/src/db/conversations-migrations/`). **No Postgres.**
+
+**Open questions to resolve during discovery:**
+1. **rbac vs feature-permissions boundary:** which decisions belong to `lib/rbac` (who: role
+   on a write action) vs `lib/feature-permissions` (what: plan/edition capability)? Draw the
+   line and avoid overlap. `(verify)`
+2. **Exact Clerk org-role identifiers** available in this project and how membership role is
+   read server-side.
+3. **Canonical write-route inventory:** enumerate every mutation route that must be gated
+   (control tools, connection CRUD, alert config) — produce the list before wiring.
+4. **Denied-response contract:** confirm 403 + shape is consistent with the app's error
+   handler (`lib/api/error-handler/`).
+5. **Interaction with plan 21:** does SSO group→role fully drive roles, or can an admin
+   override in-app? Decide precedence.
+
+## STOP conditions & drift check
+
+- **STOP** if enforcing a permission would block a community/self-hosted user from an action
+  they can do today — RBAC must be invisible outside enterprise.
+- **STOP** if the write-route inventory can't be enumerated confidently — an unguarded write
+  route is a silent authz hole; list them all first.
+- **Drift check:** if `rbac.ts` has already gained a real matrix, or `feature-permissions`
+  now owns role logic, reconcile before adding a parallel system.
+- Do not alter AI/DDL auto-apply behaviour; do not add Postgres.
+
+## Verification
+
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/rbac --isolate
+cd apps/dashboard && bun test src/lib/edition/edition.test.ts --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+
+- [ ] `Role → Permission[]` matrix + pure `can(role, permission)` in `lib/rbac/rbac.ts`
+  (unit-tested per role).
+- [ ] `requirePermission` gates every enumerated write/control route; **viewer** is denied
+  `query:kill` / `connection:write`, **admin** allowed (route-level test).
+- [ ] Clerk org roles map to chmonitor roles (unit test on the mapping).
+- [ ] Community/self-hosted (edition != enterprise or no Clerk) is **all-access** and unchanged
+  (fail-open test).
+- [ ] Denied writes return 403 via the shared error handler; no 402/paywall confusion.
+- [ ] No Postgres; any cache is D1.
+- [ ] type-check, build, targeted tests, lint all green.
+
+---
+
+Priority P2 · Effort L · Depth E · Wave E (Enterprise) · Lever Enterprise

--- a/plans/24-enterprise-multi-org-pooling.md
+++ b/plans/24-enterprise-multi-org-pooling.md
@@ -1,0 +1,113 @@
+# 24 — Enterprise multi-org pooling (one subscription, pooled limits)
+
+## Kickoff prompt
+
+```text
+Execute plans/24-enterprise-multi-org-pooling.md ALONE (Wave E, Enterprise, Depth E — light
+discovery first). Let a large customer run multiple Clerk orgs under ONE subscription with
+POOLED limits (hosts / seats / AI / retention), billed to a designated parent org.
+
+Invariants (do not violate):
+- Self-hosted/OSS stays WHOLE; billing/plan resolution already FAILS OPEN without Clerk — keep
+  it so (no Clerk → no pooling, unlimited local, unchanged).
+- Pooling is an ENTERPRISE-edition feature; must NOT degrade OSS or change single-org
+  behaviour when no org-group is configured.
+- AI recommends DDL, never auto-applies (untouched here).
+- Postgres = NO. The org-group mapping is a D1 table.
+
+Resolve the OPEN QUESTIONS before writing app code. End with the Verification commands +
+results.
+```
+
+## Current reality (audited)
+
+- **Why (spec 24):** large customers run multiple Clerk orgs but want **one subscription +
+  pooled limits**. Today plan/limit resolution is **per-org**.
+- Billing-owner resolution + per-org limits live under `apps/dashboard/src/lib/billing/`.
+  Confirmed files: `user-subscription.ts` (plan for owner), `org-host-count.ts` (host pooling
+  within an org), `entitlements.ts` (limit checks). The spec's `billing-owner.ts` path is
+  **`(verify)`** — the owner-resolution seam exists in `user-subscription.ts` /
+  `org-host-count.ts`; confirm the exact function to override during discovery.
+- Host counting is already "pooled by owner" for the single-org case
+  (`countOwnerHosts` per the plan-02 audit) — this plan generalises *owner* from "one org" to
+  "an org-group parent".
+
+## Goal
+
+Designate a **parent org**; child orgs **resolve the parent's plan**; hosts / seats / AI /
+retention **pool across the group** and bill once to the parent; the portal shows unified
+usage. With no org-group configured, behaviour is identical to today (single org).
+
+## Implement now
+
+> Depth **E**: the crux is a single **owner-resolution** indirection — "given a Clerk org,
+> what billing owner do I count/limit/bill against?" Introduce an `org_group` lookup at that
+> one seam and let existing pooling logic ride on top.
+
+**Approach & key files**
+- New D1 table `org_group` (e.g. `parent_org_id`, `child_org_id`, `created_at`;
+  child unique) — migration under `apps/dashboard/src/db/conversations-migrations/` (next
+  sequential `.sql`). A child with no row resolves to itself (no-op default).
+- **Parent resolution helper** — the seam the spec calls `billing-owner.ts`: a
+  `resolveBillingOwner(orgId)` that returns the parent when a group row exists, else the org
+  itself. Locate the current per-org resolver in `user-subscription.ts` /
+  `org-host-count.ts` and route it through this helper. `(verify)` exact function name/file.
+- **Plan by parent:** `user-subscription.ts` resolves the plan for the *billing owner* (parent),
+  so child orgs inherit the parent's tier.
+- **Pool limits:** host/seat/AI/retention counts sum across all child orgs of the owner.
+  `org-host-count.ts` already pools by owner — extend the owner set to "all children of the
+  parent." AI usage + retention counters key on the billing owner.
+- **Unified portal usage:** the billing usage surface reports the pooled totals for the group.
+  (`(verify)` the usage route — `routes/api/v1/billing/usage.ts` exists.)
+- **Edition gate:** org-group creation/management is enterprise-only; outside enterprise the
+  table is never populated and every resolver returns the org itself.
+
+**Fail-open:** owner resolution already throws without Clerk and call sites swallow it (OSS
+pattern). The new `resolveBillingOwner` must preserve that — no Clerk → resolve to self →
+unlimited local. This is a required test.
+
+**Open questions to resolve during discovery:**
+1. **Exact owner-resolution function** to indirect (`billing-owner.ts` is `(verify)`; the real
+   seam is in `user-subscription.ts` / `org-host-count.ts`). Name it before wiring.
+2. **Group topology:** flat parent→children only, or nested? Recommend flat (one level) for
+   this plan; record the decision.
+3. **Who may create a group** and how a parent is designated (enterprise admin action; ties to
+   plan 23 `member:manage`).
+4. **Seat pooling semantics:** sum of members across all child orgs vs. distinct users? Define
+   the counting rule and test it.
+5. **Portal reporting:** does Polar/portal show one subscription for the parent while chmonitor
+   renders the pooled breakdown? Confirm the usage route surfaces group totals.
+
+## STOP conditions & drift check
+
+- **STOP** if introducing the group indirection changes single-org (no-group) results in any
+  test — the default path must be a pure no-op.
+- **STOP** if pooling would let a group exceed the parent plan silently — over-limit must still
+  surface (402/paywall) against the *pooled* total.
+- **Drift check:** if owner resolution has been refactored away from `user-subscription.ts` /
+  `org-host-count.ts`, find the new seam before adding the group lookup.
+- Do not add Postgres; do not touch AI/DDL behaviour.
+
+## Verification
+
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/billing --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+
+- [ ] `org_group` D1 migration committed; a child org with no row resolves to itself.
+- [ ] `resolveBillingOwner(orgId)` returns the parent for grouped children (unit test).
+- [ ] Child orgs resolve the **parent's plan**; hosts/seats/AI/retention **pool** across the
+  group (pooling-math tests: e.g. two children summing hosts hit the parent cap).
+- [ ] Single-org (no group) behaviour is byte-for-byte unchanged (regression test).
+- [ ] Pooled over-limit still triggers the paywall/402 against the group total.
+- [ ] Fail-open preserved (no Clerk → self-resolution, unlimited local).
+- [ ] No Postgres. type-check, build, targeted tests, lint all green.
+
+---
+
+Priority P2 · Effort L · Depth E · Wave E (Enterprise) · Lever Enterprise/TAM

--- a/plans/26-opsgenie-adapter.md
+++ b/plans/26-opsgenie-adapter.md
@@ -1,0 +1,147 @@
+# 26 — Opsgenie alert adapter
+
+## Kickoff prompt
+
+```text
+Execute plans/26-opsgenie-adapter.md ALONE (Wave A, Alerting, Depth F — file-level spec below).
+Add an Opsgenie notification adapter with parity to the existing PagerDuty adapter: a PURE body
+builder that targets the Opsgenie Alert API, severity mapping, a stable dedup/alias key,
+host/rule tags, URL detection, registry registration, and a settings test-send.
+
+Invariants (do not violate):
+- Self-hosted/OSS stays WHOLE: Opsgenie is opt-in via env; unconfigured = no behaviour change.
+  No Clerk required (alerting works on every deployment).
+- Enterprise features are edition-gated and must NOT degrade OSS — Opsgenie is a core alerting
+  channel, NOT enterprise-gated.
+- AI recommends DDL, never auto-applies (unaffected).
+- Postgres = NO.
+
+Keep the body builder PURE (no transport), exactly like adapters/pagerduty.ts. End with the
+Verification commands + results.
+```
+
+## Current reality (audited)
+
+- **Why (spec 26):** Opsgenie is a major on-call vendor with **no adapter**. PagerDuty is the
+  closest analog and is a clean template.
+- Reference adapter: `apps/dashboard/src/lib/health/adapters/pagerduty.ts` — pure
+  `buildPagerDutyBody(payload, config)`, `SEVERITY_MAP` (`critical→critical`, `warning→warning`,
+  `recovery→info`), `pagerDutyDedupKey(payload)` = `` `chmonitor:${hostId}:${metric}` ``, and
+  `pagerDutyAdapter` with `detect: /events\.pagerduty\.com/`. Mirror this structure.
+- Registry: `apps/dashboard/src/lib/health/adapters/index.ts` (`ADAPTERS`, `detectAdapter`).
+- Env config style: `apps/dashboard/src/lib/health/server-alert-config.ts`
+  (`process.env.HEALTH_ALERT_*`, trimmed).
+- Settings UI: `apps/dashboard/src/components/health/health-settings-dialog.tsx` `(verify)`.
+
+## Goal
+
+An Opsgenie adapter posts a well-formed **Alert API** create/close request, maps our severity to
+Opsgenie priority, uses a stable `alias` so repeat firings collapse to one Opsgenie alert (and
+`recovery` closes it), tags the alert with host + rule, is detected from an Opsgenie URL, and is
+test-sendable from settings — parity with PagerDuty.
+
+## Implement now
+
+**A. Adapter — new `apps/dashboard/src/lib/health/adapters/opsgenie.ts`** (mirror `pagerduty.ts`)
+
+Target the Opsgenie Alert API v2 (`https://api.opsgenie.com/v2/alerts`; EU:
+`https://api.eu.opsgenie.com/v2/alerts`). Auth is `Authorization: GenieKey <API_KEY>` (applied
+by the dispatch layer, not the pure builder).
+
+```ts
+export type OpsgeniePriority = 'P1' | 'P2' | 'P3' | 'P4' | 'P5'
+
+const SEVERITY_MAP: Record<AlertSeverity, OpsgeniePriority> = {
+  critical: 'P1',
+  warning:  'P2',
+  recovery: 'P3', // used only for the close path label; recovery closes the alias
+}
+
+export interface OpsgenieConfig { apiKey: string }   // resolved by dispatch layer
+
+export interface OpsgenieCreateBody {
+  message: string          // "{title} — {label} (host {hostLabel})"
+  alias: string            // stable dedup: opsgenieAlias(payload)
+  priority: OpsgeniePriority
+  source: string           // 'chmonitor'
+  tags: string[]           // ['host:{hostLabel}', 'metric:{metric}', 'chmonitor']
+  details: Record<string, string> // hostId, metric, value, thresholds, timestamp
+  description?: string     // includes runbook URLs
+}
+
+/** Stable alias so repeat firings collapse to one Opsgenie alert. */
+export function opsgenieAlias(payload: AlertPayload): string {
+  return `chmonitor:${payload.hostId}:${payload.metric}`
+}
+
+export function buildOpsgenieBody(payload: AlertPayload): OpsgenieCreateBody
+export const opsgenieAdapter: NotificationAdapter // id: 'opsgenie'
+```
+
+- `recovery` maps to a **close** action on the alias, not a create — expose enough for the
+  dispatch layer to choose create vs. `POST /v2/alerts/{alias}/close?identifierType=alias`
+  (mirror PagerDuty's `trigger`/`resolve` split). Keep the builder pure; return an intent the
+  dispatcher acts on, or a discriminated body.
+- `opsgenieAdapter.detect`: `` /(?:^|\/\/)api(?:\.eu)?\.opsgenie\.com\//i `` so `detectAdapter`
+  can route an Opsgenie URL.
+- Escape/normalize interpolated fields; `details` values must be strings (Opsgenie requirement).
+
+**B. Register — `apps/dashboard/src/lib/health/adapters/index.ts`**
+- Export `buildOpsgenieBody`, `opsgenieAdapter`, `opsgenieAlias`, and the Opsgenie types.
+- Add `opsgenieAdapter` to `ADAPTERS` **before** the generic fallback. Update the adapter
+  snapshot test.
+
+**C. Server config — `apps/dashboard/src/lib/health/server-alert-config.ts`**
+Add (matching existing style):
+```
+HEALTH_ALERT_OPSGENIE_API_KEY   → string (default '') ; empty ⇒ disabled (fail-open no-op)
+HEALTH_ALERT_OPSGENIE_REGION    → 'us' | 'eu' (default 'us')  # picks api base host
+```
+Expose `getServerOpsgenieConfig(): OpsgenieConfig | null` as a companion function; do not alter
+`getServerAlertConfig`'s `AlertSettings` shape.
+
+**D. Dispatch (transport)** — `apps/dashboard/src/lib/health/alert-dispatcher.ts` (`(verify)`):
+when configured, `POST` create on trigger and close on recovery, with the `GenieKey` header and
+the region-appropriate base URL. Fail gracefully (log; never throw into the sweep).
+
+**E. Settings UI** — add an Opsgenie API-key field and a **"Send test alert"** button to
+`health-settings-dialog.tsx` (`(verify)` filename), mirroring the existing test affordance.
+
+## STOP conditions & drift check
+
+- **STOP** if the pure builder starts making network calls or embedding the API key — auth +
+  transport belong to the dispatch layer (parity invariant).
+- **STOP** if adding `opsgenieAdapter` to `ADAPTERS` breaks `detectAdapter` for existing URLs —
+  the detect regex must match only Opsgenie hosts.
+- **Drift check:** if `NotificationAdapter`/registry changed, match the current contract; if the
+  settings dialog moved, find the real surface first.
+- No Postgres; do not touch AI/DDL behaviour.
+
+## Verification
+
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/health/adapters --isolate
+cd apps/dashboard && bun test src/lib/health/server-alert-config.test.ts --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+
+- [ ] `buildOpsgenieBody(payload)` returns a well-formed Alert API body: message, `alias`,
+  `priority` (P1/P2 mapped), `source:'chmonitor'`, host+metric tags, string `details`, runbook
+  in description (unit test; snapshot added).
+- [ ] `opsgenieAlias` = `chmonitor:{hostId}:{metric}`; repeated firings share it; `recovery`
+  closes the alias (dedup test).
+- [ ] `opsgenieAdapter` satisfies `NotificationAdapter`, `detect` matches
+  `api.opsgenie.com` / `api.eu.opsgenie.com`, and passes the adapter-parity test.
+- [ ] `getServerOpsgenieConfig` reads `HEALTH_ALERT_OPSGENIE_API_KEY`, null when empty
+  (fail-open); `AlertSettings` shape unchanged.
+- [ ] Dispatch posts create/close correctly and fails gracefully.
+- [ ] Health settings has an Opsgenie key field + working "Send test alert".
+- [ ] No Postgres. type-check, build, targeted tests, lint all green.
+
+---
+
+Priority P1 · Effort M · Depth F · Wave A (Alerting) · Lever Adoption/Revenue

--- a/plans/27-alert-history-audit-log.md
+++ b/plans/27-alert-history-audit-log.md
@@ -1,0 +1,149 @@
+# 27 — Alert history (persisted alert_events + filtered API + UI card)
+
+## Kickoff prompt
+
+```text
+Execute plans/27-alert-history-audit-log.md ALONE (Wave A, Alerting, Depth F — file-level spec
+below). Persist every dispatched alert to a D1 alert_events table, expose a filtered read API,
+and add a recent-history card to health settings. Hook the write into the sweep right after a
+successful delivery.
+
+Invariants (do not violate):
+- Self-hosted/OSS stays WHOLE: history persistence is best-effort; a D1 write failure must NEVER
+  break the sweep or the outbound alert. Alerting works on every deployment (no Clerk required).
+- Enterprise features are edition-gated and must NOT degrade OSS — alert history is a CORE
+  alerting capability, NOT enterprise-gated.
+- AI recommends DDL, never auto-applies (unaffected).
+- Postgres = NO. History is a D1 table.
+
+End with the Verification commands + results.
+```
+
+## Current reality (audited)
+
+- **Why (spec 27):** dedup/cooldown state is **in-memory only** (lost on restart) and there is
+  **no queryable record** of dispatched alerts for audit/debugging.
+- Confirmed seam: `apps/dashboard/src/lib/health/alert-state-store.ts` exports
+  `evaluateAlert(store, …)` returning a decision (`decision.notify: boolean`,
+  `decision.kind: 'recovery' | …`), plus `decideNotification`, `alertStateStore`
+  (`MemoryAlertStateStore`), `alertStateKey(hostId, ruleId)`.
+- `apps/dashboard/src/lib/health/server-sweep.ts` calls
+  `const decision = evaluateAlert(alertStateStore, {…})` (~line 245) and, inside
+  `if (decision.notify) { … }` (~line 251), dispatches and tracks `recoveries` when
+  `decision.kind === 'recovery'` (~line 262). **The history write hooks here, after a
+  successful delivery.**
+- D1 migrations are `.sql` under `apps/dashboard/src/db/conversations-migrations/`
+  (e.g. `0005_ai_usage_daily.sql`); new migration = next sequential number. `(verify)` the D1
+  binding name used by existing stores and reuse it.
+- History card target: `apps/dashboard/src/components/health/health-settings-dialog.tsx`
+  `(verify)` filename.
+
+## Goal
+
+After each successful alert delivery, a row is appended to `alert_events` capturing the
+decision + delivery outcome; a `GET` history API returns rows filtered by host and/or day; a
+health-settings card lists recent alerts. Persistence is strictly non-blocking and works on all
+editions/deployments.
+
+## Implement now
+
+**A. Migration — new `apps/dashboard/src/db/conversations-migrations/NNNN_alert_events.sql`**
+(next sequential):
+
+```sql
+CREATE TABLE IF NOT EXISTS alert_events (
+  id             TEXT PRIMARY KEY,       -- crypto.randomUUID()
+  event_time     TEXT NOT NULL,          -- ISO-8601 UTC (payload.timestamp or now)
+  host_id        INTEGER NOT NULL,
+  host_label     TEXT,
+  rule           TEXT NOT NULL,          -- metric / rule id
+  severity       TEXT NOT NULL,          -- 'warning' | 'critical' | 'recovery'
+  prev_severity  TEXT,                   -- prior severity from the decision, if any
+  decision_kind  TEXT NOT NULL,          -- decision.kind (e.g. 'fire' | 'recovery' | 're-notify')
+  delivered      INTEGER NOT NULL,       -- 1 delivered, 0 attempted-but-failed
+  error          TEXT,                   -- delivery error message when delivered = 0
+  value          REAL,                   -- observed value (payload.value)
+  channel        TEXT                    -- adapter id ('slack'|'email'|'opsgenie'|…), when known
+);
+CREATE INDEX IF NOT EXISTS idx_alert_events_host_time ON alert_events (host_id, event_time);
+```
+
+**B. Store — new `apps/dashboard/src/lib/health/alert-history-store.ts`**
+
+```ts
+export interface AlertEventRecord {
+  eventTime: string
+  hostId: number
+  hostLabel?: string | null
+  rule: string
+  severity: 'warning' | 'critical' | 'recovery'
+  prevSeverity?: 'warning' | 'critical' | 'recovery' | null
+  decisionKind: string
+  delivered: boolean
+  error?: string | null
+  value?: number | null
+  channel?: string | null
+}
+
+// Best-effort append; wrap the D1 write in try/catch and swallow — MUST NOT throw
+// into the sweep. No-op when the D1 binding is unavailable (self-host fail-open).
+export async function recordAlertEvent(env, e: AlertEventRecord): Promise<void>
+
+export interface AlertHistoryQuery { hostId?: number; day?: string; limit?: number }
+export async function queryAlertEvents(env, q: AlertHistoryQuery): Promise<AlertEventRecord[]>
+```
+- `id` = `crypto.randomUUID()`; `event_time` from the payload timestamp (fallback `now`).
+- `day` filter matches on the `event_time` date prefix (`YYYY-MM-DD`); `limit` defaults to a
+  sane cap (e.g. 100/200).
+
+**C. Hook the sweep — `apps/dashboard/src/lib/health/server-sweep.ts`**
+Inside the existing `if (decision.notify) { … }` block, **after** the dispatch resolves, call
+`recordAlertEvent(env, {…})` with the payload + `decision.kind` + `prev_severity` from the
+decision + `delivered`/`error` from the dispatch result + `channel` = the adapter id used. Do
+**not** await in a way that lets a failure abort the sweep loop — best-effort, swallow errors.
+
+**D. Read API — new `apps/dashboard/src/routes/api/v1/health/history.ts`**
+- Method `GET`. Query params: `hostId?`, `day?` (`YYYY-MM-DD`), `limit?`.
+- Returns JSON `{ events: AlertEventRecord[] }` via `queryAlertEvents`.
+- Same auth posture as the other `health/*` read routes (`(verify)` — align with
+  `health/checks.ts`).
+
+**E. UI card — `health-settings-dialog.tsx`** (`(verify)` filename): a "Recent alerts" card
+listing the latest events (time, host, rule, severity, delivered/failed) with an optional
+host/day filter, reading `GET /api/v1/health/history`.
+
+## STOP conditions & drift check
+
+- **STOP** if the history write can throw into or slow the sweep — it must be strictly
+  best-effort and non-blocking (a failed D1 write must not drop or delay the outbound alert).
+- **STOP** if `evaluateAlert` / `server-sweep.ts` no longer exposes the `decision.notify` block
+  described above — find the current post-delivery point before hooking.
+- **Drift check:** if an `alert_events` table or history store already exists, extend it; match
+  the existing D1 binding name rather than inventing one.
+- No Postgres; do not touch AI/DDL behaviour.
+
+## Verification
+
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/health/alert-history-store --isolate
+cd apps/dashboard && bun test src/routes/api/v1/health --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+
+- [ ] `NNNN_alert_events.sql` migration committed (with `host_id`+`event_time` index).
+- [ ] `recordAlertEvent` appends a row, never throws into the sweep, no-ops without the D1
+  binding (unit tests: success, swallow-on-error, no-op).
+- [ ] A dispatched alert produces exactly one `alert_events` row with correct
+  `decision_kind` / `prev_severity` / `delivered` / `channel` (sweep-integration test).
+- [ ] `GET /api/v1/health/history` filters by `hostId` and `day` and honours `limit`
+  (route test).
+- [ ] Health settings shows a "Recent alerts" card sourced from the history API.
+- [ ] No Postgres. type-check, build, targeted tests, lint all green.
+
+---
+
+Priority P1 · Effort M · Depth F · Wave A (Alerting) · Lever Adoption/Revenue (audit)

--- a/plans/28-maintenance-windows-suppression.md
+++ b/plans/28-maintenance-windows-suppression.md
@@ -1,0 +1,160 @@
+# 28 — Maintenance windows (alert suppression)
+
+## Kickoff prompt
+
+```text
+Execute plans/28-maintenance-windows-suppression.md alone (zero prior context).
+Goal: suppress health-sweep alerts during planned maintenance (deploys/backups).
+Add a D1-backed maintenance_windows store, a CRUD API, a settings UI, and a
+suppression check inside the sweep's dispatch loop.
+Invariants you MUST hold:
+- Self-hosted/OSS stays whole; every plan/billing gate fails OPEN without Clerk
+  (missing D1 binding / owner-resolution throw ⇒ degrade to "no windows", never crash).
+- AI/alerts RECOMMEND actions but NEVER auto-apply destructive DDL; suppression is
+  passive (it only stops a notification) — remediation stays ACK-gated (see plan 29/33).
+- Honest paywalls: this feature is free/OSS; do not gate it behind a plan.
+- Postgres = NO. D1 only (mirror insights/store/d1-store.ts).
+Build ONLY what §"Implement now" lists. Respect STOP conditions. Then run every
+command in §Verification and paste the output. Do not touch app features unrelated
+to maintenance windows.
+```
+
+## Current reality (audited)
+
+**Why (spec):** there is no way to suppress alerts during deploys/backups — a top
+alert-fatigue complaint. The autonomous sweep webhooks on every genuinely-new
+finding with no notion of "planned work in progress."
+
+File pointers (verified at audit):
+- Rules: `apps/dashboard/src/lib/alerting/rule-registry.ts` (`AlertRuleDef`,
+  `classifyValue`, `ruleRegistry`) and `.../builtin-rules.ts` (`registerBuiltinRules`).
+  *(Note: these live under `lib/alerting/`, not `lib/health/`.)*
+- Dedup/decision: `apps/dashboard/src/lib/health/alert-state-store.ts`
+  (`evaluateAlert`, `decideNotification`, `AlertDecisionKind`).
+- Sweep + dispatch loop: `apps/dashboard/src/lib/health/server-sweep.ts`
+  (`runHealthSweep`; the dispatch block is the `if (canDispatch) { … evaluateAlert …
+  if (decision.notify) { postWebhook(...) } }` section, ~L242–268).
+- Cron entry: `apps/dashboard/src/routes/api/cron/health-sweep.ts` (`GET`,
+  `CRON_SECRET` fail-closed → 503).
+- Adapters: `apps/dashboard/src/lib/health/adapters/*` (+ `index.ts`,
+  `detectAdapter`). `AlertPayload` in `adapters/types.ts`.
+- D1 pattern to mirror: `apps/dashboard/src/lib/insights/store/d1-store.ts`
+  (bindings `['INSIGHTS_D1','CHM_CLOUD_D1']` via `getPlatformBindings()`, lazy
+  `CREATE TABLE IF NOT EXISTS`, single-flight migration, **swallow all failures**).
+- Migrations dir: `apps/dashboard/src/db/conversations-migrations/NNNN_*.sql`
+  (highest existing = `0006_auth_identities.sql`; add the next number).
+- Suppression must be recorded in the alert history log from plan 27
+  (`alert_events`, `alert-history-store.ts`) — **soft dependency**: if plan 27 is
+  not yet merged, log the suppression via `debug()` and leave a `TODO(27)` hook.
+
+## Goal
+
+An operator can declare a maintenance window (one host or all hosts, with
+start/end + reason); while `now` is inside a window that targets a finding's host,
+the sweep **suppresses the notification** (records decision kind `maintenance`),
+still runs the rule and reports the finding in the summary, and — when plan 27 is
+present — writes a `maintenance`-kind row to the alert history. Windows are managed
+via a CRUD API + a settings dialog. Fails open (no D1 ⇒ no windows ⇒ normal behavior).
+
+## Implement now
+
+### D1 — new migration `src/db/conversations-migrations/0007_maintenance_windows.sql`
+```sql
+CREATE TABLE IF NOT EXISTS maintenance_windows (
+  id         TEXT    NOT NULL PRIMARY KEY,   -- uuid
+  owner_id   TEXT    NOT NULL,               -- billing-owner id (Clerk user_*/org_*); '' for OSS single-tenant
+  host_id    INTEGER,                        -- NULL ⇒ applies to ALL hosts
+  reason     TEXT    NOT NULL DEFAULT '',
+  starts_at  INTEGER NOT NULL,               -- unix ms
+  ends_at    INTEGER NOT NULL,               -- unix ms
+  created_by TEXT    NOT NULL DEFAULT '',
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_maint_windows_active
+  ON maintenance_windows (owner_id, ends_at);
+```
+
+### Store — `src/lib/health/maintenance-windows.ts` (mirror insights d1-store)
+- Bindings order `['MAINTENANCE_D1','CHM_CLOUD_D1']`; lazy migrate; single-flight;
+  swallow+log failures (fail-open).
+- `interface MaintenanceWindow { id; ownerId; hostId: number|null; reason; startsAt; endsAt; createdBy; createdAt }`.
+- `listWindows(ownerId): Promise<MaintenanceWindow[]>`
+- `createWindow(input): Promise<MaintenanceWindow>` (generate uuid; validate `endsAt > startsAt`)
+- `deleteWindow(ownerId, id): Promise<void>` (owner-scoped WHERE)
+- **Pure, unit-testable core** `isSuppressed(windows, hostId, now): boolean` —
+  true iff any window matches (`hostId === null || w.hostId === hostId`) AND
+  `w.startsAt <= now < w.endsAt`. Export this separately for tests (no D1 needed).
+- Optional 30s in-memory cache of active windows keyed by owner to avoid a D1 read
+  every sweep tick (mirror the table-existence cache pattern).
+
+### Route — `src/routes/api/v1/health/maint-windows.ts` (TanStack `createFileRoute`)
+- Follow the existing `createFileRoute('/api/v1/health/…')({ server:{ handlers:{…} } })`
+  shape (see `health-sweep.ts` for the pattern).
+- `GET` → `listWindows(owner)`; `POST` (create, validate body with the store's zod/parse);
+  `DELETE ?id=` (delete). Resolve owner via the existing billing-owner helper used by
+  other `/api/v1/*` routes; **wrap owner resolution in try/catch → treat as OSS single
+  tenant (`ownerId=''`)** so it fails open without Clerk. Auth-gate writes like other
+  mutating health routes.
+
+### Sweep hook — `src/lib/health/server-sweep.ts`
+- Before the per-host loop, load `const windows = await listWindows(ownerForSweep)`
+  once (best-effort; on throw ⇒ `[]`). *(Sweep is currently owner-agnostic; resolve
+  the sweep's owner the same way the cron route resolves ClickHouse configs, or pass
+  `''` for OSS — `(verify)` the exact owner source and keep fail-open.)*
+- Inside the dispatch block, **after** `evaluateAlert(...)` returns `decision.notify`
+  === true but **before** `postWebhook(...)`, insert:
+  ```ts
+  if (decision.notify && isSuppressed(windows, config.id, Date.now())) {
+    alertsSuppressed++                 // reuse existing counter
+    // TODO(27): historyStore.record({ ..., decisionKind: 'maintenance', delivered: false })
+    continue                            // skip postWebhook
+  }
+  ```
+  Do NOT mutate the dedup state store differently — suppression must not reset the
+  cooldown (the condition is still "known firing"; `evaluateAlert` already persisted
+  the record). Add a `maintenanceSuppressed` field to `SweepSummary` for observability.
+
+### UI — `src/components/health/maintenance-windows-dialog.tsx` `(verify dir)`
+- No `components/health/` dir was found at audit — locate where the existing health
+  settings dialog lives (grep `health-settings` / the /health route) and colocate.
+- List active + upcoming windows; create form (host picker incl. "All hosts", reason,
+  start, end); delete button. Use existing dialog/table primitives + TanStack Query.
+
+### History integration (soft dep on plan 27)
+- If `alert-history-store.ts` exists, record suppressed events with
+  `decisionKind:'maintenance'`, `delivered:false`. Otherwise leave the `TODO(27)` hook.
+
+## STOP conditions & drift check
+- If **no D1 binding** resolves at runtime, the store must degrade to "no windows"
+  (empty list) — never throw into the sweep or the route. Verify by unit-testing
+  `isSuppressed` with a hand-built array (no D1) and by confirming the store
+  swallows a null-binding.
+- Do **not** add a new webhook/transport, new adapter, or any auto-remediation here.
+- Do **not** change dedup semantics (`decideNotification`) — suppression is a gate
+  layered *after* the decision, not a new decision kind inside the pure transition.
+- If the sweep's owner cannot be resolved cleanly, ship with `ownerId=''` (OSS
+  single-tenant) and mark the multi-tenant owner wiring `(verify)` — do not block.
+- If `components/health/` truly doesn't exist, colocate the dialog with the found
+  health settings component; don't invent a new top-level route.
+
+## Verification
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/health/maintenance-windows.test.ts --isolate
+cd apps/dashboard && bun test src/lib/health/ --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+- `0007_maintenance_windows.sql` migration added; store + pure `isSuppressed` shipped
+  with tests covering in-window / out-of-window / all-hosts / per-host.
+- CRUD route returns owner-scoped windows; create validates `endsAt > startsAt`;
+  writes auth-gated; owner resolution fails open (OSS ⇒ `ownerId=''`).
+- Sweep suppresses matching alerts inside a window (increments a suppressed counter,
+  skips `postWebhook`), still reports the finding, does not reset cooldown.
+- Suppressed events recorded to `alert_events` when plan 27 present (else `TODO(27)`).
+- Settings dialog can create/list/delete windows.
+- All four verification commands pass.
+
+Priority: P1 · Effort: M · Depth: F · Wave: A (Alerting) · Lever: Adoption

--- a/plans/29-alert-ack-manual-resolution.md
+++ b/plans/29-alert-ack-manual-resolution.md
@@ -1,0 +1,153 @@
+# 29 — Alert ACK / manual resolution (snooze)
+
+## Kickoff prompt
+
+```text
+Execute plans/29-alert-ack-manual-resolution.md alone (zero prior context).
+Goal: let an operator ACK/snooze a firing alert so it stops re-dispatching for a
+chosen duration, without waiting for the condition to clear. Add a D1 alert_acks
+store, a POST /ack route, a suppression check in the sweep, and an Active Alerts panel.
+Invariants you MUST hold:
+- Self-hosted/OSS stays whole; every gate fails OPEN without Clerk (no D1 binding /
+  owner-resolution throw ⇒ degrade to "no acks", never crash the sweep or route).
+- AI/alerts RECOMMEND but NEVER auto-apply destructive DDL. An ACK only suppresses a
+  NOTIFICATION for a bounded window — it performs no cluster action; remediation stays
+  ACK-gated (see plan 33).
+- Honest paywalls: ACK/snooze is free/OSS; do not gate behind a plan.
+- Postgres = NO. D1 only (mirror insights/store/d1-store.ts).
+Build ONLY §"Implement now". Respect STOP conditions. Then run every command in
+§Verification and paste output.
+```
+
+## Current reality (audited)
+
+**Why (spec):** an operator can't ACK/snooze a firing alert; it only stops when the
+condition itself clears. Persistent-but-known incidents keep hitting the cooldown
+`reminder` path forever.
+
+File pointers (verified):
+- Dedup engine: `apps/dashboard/src/lib/health/alert-state-store.ts` —
+  `evaluateAlert(store, {hostId, ruleId, severity, cooldownMs, now})` returns an
+  `AlertDecision { notify, kind, severity, previousSeverity }`. `decideNotification`
+  is the pure transition; `MemoryAlertStateStore` is the process singleton.
+- Sweep dispatch loop: `apps/dashboard/src/lib/health/server-sweep.ts` — the
+  `if (canDispatch) { … const decision = evaluateAlert(...) ; if (decision.notify) {
+  postWebhook(...) } }` block (~L242–268). `alertsSuppressed` counter already exists.
+- Rules: `apps/dashboard/src/lib/alerting/rule-registry.ts` (`AlertRuleDef.id/title`),
+  `.../builtin-rules.ts`. Condition identity is `hostId:ruleId` (see `alertStateKey`).
+- Cron entry: `apps/dashboard/src/routes/api/cron/health-sweep.ts`.
+- Adapters: `apps/dashboard/src/lib/health/adapters/*`.
+- D1 pattern: `apps/dashboard/src/lib/insights/store/d1-store.ts` (bindings
+  `['INSIGHTS_D1','CHM_CLOUD_D1']`, lazy `CREATE TABLE IF NOT EXISTS`, swallow failures).
+- Migrations: `src/db/conversations-migrations/NNNN_*.sql` (next after `0006`).
+- The Active Alerts panel needs the current firing set — the sweep already builds
+  `SweepSummary.findings`; expose the latest sweep (or re-derive) for the panel. If a
+  live "current findings" API doesn't exist, add a thin read (`(verify)`).
+
+## Goal
+
+An ACK on a `(hostId, ruleId)` condition suppresses dispatch for a chosen duration
+(5 / 15 / 60 / 240 minutes), recording who ACKed and when. The sweep, when about to
+notify, checks for an active ACK and suppresses (kind `acked`) instead of posting. An
+**Active Alerts** panel lists currently-firing conditions with ACK controls and shows
+ACK state (actor + expiry). Fails open (no D1 ⇒ ACK is a no-op, alerts behave as today).
+
+## Implement now
+
+### D1 — new migration `src/db/conversations-migrations/0008_alert_acks.sql`
+```sql
+CREATE TABLE IF NOT EXISTS alert_acks (
+  owner_id    TEXT    NOT NULL,   -- billing-owner id; '' for OSS single-tenant
+  host_id     INTEGER NOT NULL,
+  rule_id     TEXT    NOT NULL,
+  acked_by    TEXT    NOT NULL DEFAULT '',
+  acked_at    INTEGER NOT NULL,   -- unix ms
+  expires_at  INTEGER NOT NULL,   -- unix ms; suppress while now < expires_at
+  note        TEXT    NOT NULL DEFAULT '',
+  PRIMARY KEY (owner_id, host_id, rule_id)   -- one active ack per condition; re-ACK upserts
+);
+CREATE INDEX IF NOT EXISTS idx_alert_acks_expiry ON alert_acks (owner_id, expires_at);
+```
+*(Use `0008` if plan 28 took `0007`; otherwise `0007`. Pick the next free number.)*
+
+### Store — `src/lib/health/alert-ack-store.ts` (mirror insights d1-store)
+- `ACK_DURATIONS_MS = { '5m':300000, '15m':900000, '60m':3_600_000, '240m':14_400_000 }`.
+- `interface AlertAck { ownerId; hostId; ruleId; ackedBy; ackedAt; expiresAt; note }`.
+- `ackAlert({ownerId, hostId, ruleId, durationKey, ackedBy, note, now?}): Promise<AlertAck>`
+  — upsert (`INSERT … ON CONFLICT(owner_id,host_id,rule_id) DO UPDATE`).
+- `listActiveAcks(ownerId, now?): Promise<AlertAck[]>` — `WHERE expires_at > now`.
+- `clearAck(ownerId, hostId, ruleId): Promise<void>` (manual un-ACK).
+- **Pure core** `isAcked(acks: AlertAck[], hostId, ruleId, now): boolean` — export
+  separately for tests (no D1). Optional ~15–30s in-memory cache keyed by owner.
+- Every D1 failure swallowed+logged ⇒ `isAcked` sees `[]` ⇒ fail-open.
+
+### Route — `src/routes/api/v1/health/ack.ts` (TanStack `createFileRoute`)
+- `POST` body `{ hostId:number, ruleId:string, duration:'5m'|'15m'|'60m'|'240m',
+  note?:string }` → `ackAlert(...)`, `ackedBy` from the session user (best-effort).
+- `GET` → `listActiveAcks(owner)` (feeds the panel).
+- `DELETE ?hostId=&ruleId=` → `clearAck`.
+- Owner + user resolution wrapped in try/catch → OSS single-tenant (`ownerId=''`,
+  `ackedBy='operator'`); auth-gate writes like other mutating health routes.
+
+### Sweep hook — `src/lib/health/server-sweep.ts`
+- Load `const acks = await listActiveAcks(ownerForSweep)` once before the host loop
+  (best-effort ⇒ `[]` on throw). Owner source `(verify)` — `''` for OSS is acceptable.
+- In the dispatch block, after `evaluateAlert(...)` yields `decision.notify === true`
+  and after the plan-28 maintenance check (if present), add:
+  ```ts
+  if (decision.notify && isAcked(acks, config.id, rule.id, Date.now())) {
+    alertsSuppressed++
+    // TODO(27): historyStore.record({ ..., decisionKind: 'acked', delivered: false })
+    continue                            // skip postWebhook
+  }
+  ```
+  Do NOT alter `decideNotification` or reset the cooldown — the dedup record was
+  already persisted by `evaluateAlert`; ACK is a post-decision dispatch gate.
+- Add `ackedSuppressed` to `SweepSummary` for observability.
+- **Recovery override:** if `decision.kind === 'recovery'`, do NOT suppress (an
+  operator should always learn a condition resolved) and clear any active ACK for
+  that `(hostId, ruleId)` via `clearAck(...)` (best-effort).
+
+### UI — `src/components/health/active-alerts-panel.tsx` `(verify dir)`
+- `components/health/` was not found at audit — colocate with the existing health
+  settings component (grep `health-settings`). Panel lists currently-firing
+  conditions from the latest `SweepSummary.findings` (or a thin "current findings"
+  read), each with an "Acknowledge" control (duration dropdown) → `POST /ack`, and
+  shows active-ACK state (who / expires in) from `GET /ack`. TanStack Query for
+  fetch + invalidation on ACK.
+
+### History integration (soft dep on plan 27)
+- If `alert-history-store.ts` exists, record ACK-suppressed events with
+  `decisionKind:'acked'`, `delivered:false`; else `TODO(27)` hook.
+
+## STOP conditions & drift check
+- No D1 binding ⇒ ACK store is a no-op; `isAcked` returns false everywhere; sweep +
+  route never throw. Prove with a pure `isAcked` unit test (hand-built array).
+- ACK suppresses **notifications only**. It must not run any query or cluster action
+  (no auto-remediation — invariant).
+- Never suppress a `recovery`; clear the ACK on recovery.
+- Do not change dedup transition logic or cooldown reset behavior.
+- Duration is whitelisted to the four values; reject others with 400.
+- If owner/user can't resolve, ship OSS single-tenant (`ownerId=''`) and mark
+  multi-tenant wiring `(verify)`; don't block.
+
+## Verification
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/health/alert-ack-store.test.ts --isolate
+cd apps/dashboard && bun test src/lib/health/ --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+- Migration + `alert-ack-store.ts` (with pure `isAcked`) shipped; tests cover
+  active / expired / wrong-condition / re-ACK upsert.
+- `POST /api/v1/health/ack` records actor + expiry; `GET` lists active; `DELETE`
+  clears; duration whitelist enforced; owner resolution fails open.
+- Sweep suppresses dispatch while an ACK is active (skips `postWebhook`, increments a
+  suppressed counter), never suppresses recovery, and clears ACK on recovery.
+- Active Alerts panel shows firing conditions + ACK state and can ACK/snooze.
+- All four verification commands pass.
+
+Priority: P1 · Effort: M · Depth: F · Wave: A (Alerting) · Lever: Adoption

--- a/plans/30-per-rule-alert-routing.md
+++ b/plans/30-per-rule-alert-routing.md
@@ -1,0 +1,120 @@
+# 30 — Per-rule / per-host alert routing
+
+## Kickoff prompt
+
+```text
+Execute plans/30-per-rule-alert-routing.md alone (zero prior context). This is an
+EPIC brief — do light discovery first (resolve the "(verify)" paths below), then build.
+Goal: replace the single global webhook with per-rule/per-host routing to one or more
+channels, with multi-channel fan-out and a legacy fallback to the global URL.
+Invariants you MUST hold:
+- Self-hosted/OSS stays whole; fail OPEN without Clerk (no D1 / owner throw ⇒ fall back
+  to the legacy global HEALTH_ALERT_WEBHOOK_URL; never crash the sweep).
+- AI/alerts RECOMMEND but NEVER auto-apply destructive DDL; routing only decides WHERE a
+  notification goes — remediation stays ACK-gated (plans 29/33).
+- Honest paywalls: if routing is positioned as a paid capability, gate it via
+  lib/billing/plan-enforcement.ts and mark it enforced|deferred honestly; otherwise ship
+  free. Default this plan to FREE unless the pricing table says routing is Pro+.
+- Postgres = NO. D1 only (mirror insights/store/d1-store.ts).
+Build ONLY §"Implement now". Respect STOP conditions. Then run every command in
+§Verification and paste output.
+```
+
+## Current reality (audited)
+
+**Why (spec):** there is one global webhook for all rules/hosts; teams need per-rule
+and per-host routing to different channels.
+
+File pointers (verified):
+- Sweep + dispatch: `apps/dashboard/src/lib/health/server-sweep.ts` — `runHealthSweep`
+  reads a single `settings.webhookUrl` (`getServerAlertConfig`) and `postWebhook(url,
+  text)` posts one flat message per notifying finding (dispatch block ~L242–268).
+- Config: `apps/dashboard/src/lib/health/server-alert-config.ts`
+  (`HEALTH_ALERT_WEBHOOK_URL/_ENABLED/_MIN_SEVERITY`).
+- Dedup: `apps/dashboard/src/lib/health/alert-state-store.ts` (`evaluateAlert`,
+  key `hostId:ruleId`). Adapters + `detectAdapter`: `adapters/index.ts`; `AlertPayload`
+  in `adapters/types.ts`. Rules: `lib/alerting/rule-registry.ts` (`AlertRuleDef.id/type`).
+- D1 pattern: `insights/store/d1-store.ts`. Migrations:
+  `src/db/conversations-migrations/NNNN_*.sql` (next after `0006`).
+- Health UI dir: **not found** at audit — `components/health/*` is `(verify)`; colocate
+  with the existing health-settings component.
+
+## Goal
+
+An operator defines routes that match a rule id/type and/or host (glob or `*`) to one
+or more channel webhook URLs. When a finding notifies, the sweep dispatches to **all
+matching routes** (fan-out), records each delivery, and falls back to the legacy global
+webhook when no route matches — preserving today's behavior for existing deployments.
+
+## Implement now (approach + key files)
+
+- **D1 schema** `0007_alert_routes.sql`: `alert_routes(id TEXT PK, owner_id TEXT,
+  match_rule TEXT, match_host TEXT, channel_url TEXT, enabled INTEGER, created_at INTEGER)`.
+  `match_rule` / `match_host` accept `*` or a glob (`match_host` matches host id or
+  name). Index on `(owner_id, enabled)`.
+- **Routing module** `src/lib/health/alert-routing.ts`:
+  - `interface AlertRoute { id; ownerId; matchRule; matchHost; channelUrl; enabled }`.
+  - D1-backed CRUD (`listRoutes/createRoute/deleteRoute`, mirror insights store, swallow
+    failures ⇒ fail-open to `[]`).
+  - **Pure core** `matchRoutes(routes, { ruleId, ruleType, hostId, hostName }):
+    AlertRoute[]` — export separately, unit-test the glob/`*`/id-vs-name matching.
+  - `resolveTargets(routes, finding, legacyGlobalUrl): string[]` — matched channel URLs,
+    or `[legacyGlobalUrl]` when none match (and the global URL is configured).
+- **Route API** `src/routes/api/v1/health/routes.ts`: GET/POST/DELETE, owner-scoped,
+  writes auth-gated, owner resolution try/catch → OSS single-tenant (`ownerId=''`).
+- **Sweep dispatch** `server-sweep.ts`: load `routes` once before the host loop; in the
+  dispatch block, replace the single `postWebhook(settings.webhookUrl, text)` with a
+  loop over `resolveTargets(routes, finding, settings.webhookUrl)` — build the body per
+  channel via `detectAdapter(url).buildBody(payload)` (`(verify)` whether to keep the
+  flat `{text,content}` for back-compat or switch to adapter bodies; if switching is too
+  broad, fan out the flat text to each URL and mark adapter-per-channel `(verify)`).
+  Count each successful delivery; record each (delivered/error) to plan-27 history if
+  present. Preserve dedup: run `evaluateAlert` **once** per finding (not per route) so a
+  single condition doesn't multiply cooldown state.
+- **UI** `src/components/health/alert-routing-dialog.tsx` `(verify dir)`: list/create/
+  delete routes (rule picker or `*`, host picker or `*`, channel URL); "test route"
+  reuses the existing settings test-send.
+
+## Open questions (resolve during discovery)
+1. **Adapter bodies vs flat text in the sweep** — does the cron sweep already build
+   `AlertPayload`/adapter bodies, or only flat `{text,content}`? (Audit says flat.) If
+   flat, decide: fan out flat text now (smaller change) vs. wire adapter bodies (nicer,
+   broader). Ship flat + `(verify)` if time-boxed.
+2. **Dedup granularity** — keep dedup at `hostId:ruleId` (condition-level, recommended)
+   so fan-out to N channels is one decision, OR make it per-route? Default: condition-level.
+3. **Owner source for the sweep** — the sweep is currently owner-agnostic; how does it
+   learn whose routes to load? (`''` OSS single-tenant is acceptable for self-host.)
+4. **Free vs paid** — is per-rule routing advertised as Pro+ in `@chm/pricing`? If yes,
+   gate via `plan-enforcement.ts`; if not, ship free. Do not invent a paywall.
+5. **Channel secret storage** — channel URLs may contain secrets; confirm D1-at-rest is
+   acceptable (it already stores connection secrets) or reference an env indirection.
+
+## STOP conditions & drift check
+- No D1 / owner throw ⇒ `matchRoutes` sees `[]` ⇒ `resolveTargets` returns the legacy
+  global URL ⇒ **today's behavior exactly**. Prove with a pure test (no D1).
+- Run `evaluateAlert` once per finding; fan-out must not reset cooldown per channel.
+- Do not add auto-remediation; routing only chooses destinations.
+- Reuse the SSRF-guarded outbound post path already used by the sweep/webhook proxy —
+  do not introduce a new unguarded `fetch` to arbitrary URLs.
+- If pricing doesn't mark routing paid, do NOT gate it (honest paywalls).
+
+## Verification
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/health/alert-routing.test.ts --isolate
+cd apps/dashboard && bun test src/lib/health/ --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+- `alert_routes` D1 + `alert-routing.ts` (pure `matchRoutes`/`resolveTargets`) shipped
+  with tests for `*` / glob / id-vs-name / no-match-fallback.
+- CRUD route owner-scoped, writes auth-gated, fails open to legacy global URL.
+- Sweep fans out to all matched channels, records each delivery, dedups once per
+  condition, and falls back to the global webhook when nothing matches.
+- Back-compat: deployments with only `HEALTH_ALERT_WEBHOOK_URL` behave unchanged.
+- Routing dialog can create/list/delete/test routes.
+- All four verification commands pass; open questions answered in the PR description.
+
+Priority: P1 · Effort: L · Depth: E · Wave: A (Alerting) · Lever: Revenue/Adoption

--- a/plans/31-compound-alert-rules.md
+++ b/plans/31-compound-alert-rules.md
@@ -1,0 +1,123 @@
+# 31 — Compound alert rules (AND/OR correlation)
+
+## Kickoff prompt
+
+```text
+Execute plans/31-compound-alert-rules.md alone (zero prior context). This is an EPIC
+brief — do light discovery first, then build.
+Goal: add compound alert rules that combine BASE-rule outputs with a predicate (e.g.
+replication-lag>60 AND readonly-replicas>0) to cut single-metric false positives.
+Evaluate base rules first, then compound rules over their results, in dependency order.
+Invariants you MUST hold:
+- Self-hosted/OSS stays whole; compound rules run fully OSS (they need no Clerk/D1 —
+  they're pure logic over base-rule severities). Fail OPEN: a broken compound rule must
+  never break the base sweep.
+- AI/alerts RECOMMEND but NEVER auto-apply destructive DDL; a compound rule only raises
+  a correlated alert — remediation stays ACK-gated (plans 29/33).
+- Honest paywalls: ship free/OSS unless pricing marks correlation as paid.
+- Postgres = NO.
+Build ONLY §"Implement now". Respect STOP conditions. Then run every command in
+§Verification and paste output.
+```
+
+## Current reality (audited)
+
+**Why (spec):** all rules are single-metric; false positives need AND/OR correlation
+(e.g. `lag>60 AND readonly>0`). Nothing today combines two signals.
+
+File pointers (verified):
+- Rule registry: `apps/dashboard/src/lib/alerting/rule-registry.ts` — `AlertRuleDef`
+  (`{ id, type, sql?, valueKey, defaults, … }`), `classifyValue`, `ruleRegistry`
+  (Map, `register/getAll/get`). **No `depends` field today.**
+- Built-ins: `apps/dashboard/src/lib/alerting/builtin-rules.ts` (`registerBuiltinRules`).
+- Sweep: `apps/dashboard/src/lib/health/server-sweep.ts` — the per-host loop runs each
+  rule's SQL, computes `severity = classifyValue(value, thresholds)`, pushes findings,
+  and dispatches via `evaluateAlert` (dedup key `hostId:ruleId`). Rules are iterated in
+  `ruleRegistry.getAll()` order.
+- Dedup: `apps/dashboard/src/lib/health/alert-state-store.ts` (`evaluateAlert`).
+- No compound/DAG layer exists. Spec targets `src/lib/alerting/compound-rules.ts` (new).
+
+## Goal
+
+Define compound rules that depend on ≥2 base rules and fire based on a custom predicate
+over those base rules' evaluated severities/values on the same host. The sweep evaluates
+base rules first, then compound rules in dependency order (no cycles), with each compound
+rule getting its own dedup identity (`hostId:compoundRuleId`) and severity.
+
+## Implement now (approach + key files)
+
+- **Types** in `src/lib/alerting/compound-rules.ts` (new):
+  ```ts
+  export interface CompoundRuleDef {
+    id: string
+    title: string
+    description: string
+    depends: string[]                     // base rule ids this rule reads
+    // pure predicate over per-host base results → this rule's severity
+    evaluate(inputs: Record<string, { value: number | null; severity: AlertRuleSeverity }>):
+      AlertRuleSeverity
+    formatLabel?(inputs: …): string
+  }
+  export const compoundRuleRegistry = new Map<string, CompoundRuleDef>()
+  ```
+- **Dependency ordering** (pure, unit-tested): `topoSortCompound(compoundRules,
+  baseRuleIds): CompoundRuleDef[]` — validate every `depends` id exists as a base rule
+  (or an already-ordered compound), and **throw/skip on cycles** (compound-on-compound
+  allowed only if acyclic; simplest v1: compound rules depend on BASE rules only —
+  document that constraint and defer compound-on-compound).
+- **Example rules** shipped with built-ins registration:
+  - `replica-split-brain` = `replication-lag` severity≥warning AND `readonly-replicas`>0.
+  - `merge-pressure` = `stuck-merges`≥warning AND `disk-usage`≥warning.
+- **Sweep integration** `server-sweep.ts`:
+  - While looping base rules per host, collect `perHost[ruleId] = { value, severity }`.
+  - After base rules for a host, iterate ordered compound rules: call `evaluate(perHost
+    subset)`; if it returns non-ok, push a `SweepFinding` (checkId = compound id) and run
+    `evaluateAlert(alertStateStore, { hostId, ruleId: compoundId, severity, cooldownMs })`
+    then dispatch on `decision.notify` (respecting plan-28/29 suppression if present).
+  - Wrap each compound `evaluate` in try/catch → count `errored`, never break the host loop.
+- Keep the existing single-metric dispatch untouched; compound is additive.
+
+## Open questions (resolve during discovery)
+1. **Where do compound results dispatch?** Reuse `postWebhook`/routing (plan 30) exactly
+   like base rules — confirm the dispatch path is shared, not duplicated.
+2. **Compound-on-compound** — allow (full DAG) or restrict v1 to compound-depends-on-base
+   only? Recommended: base-only for v1; note the constraint; the topo sort still guards.
+3. **User-defined compounds** — this plan ships built-in compound rules in TS. Do custom
+   compound rules belong here or in plan 32 (custom rule builder)? Recommended: built-ins
+   here; custom compound authoring is a plan-32 follow-up.
+4. **Thresholds** — do compound rules need their own threshold overrides
+   (`server-alert-config` env), or is the predicate self-contained? Default: self-contained
+   predicate reading base severities (which already honor env overrides).
+5. **Severity of a compound** — max of inputs, or explicitly returned by `evaluate`?
+   Recommended: `evaluate` returns it explicitly (most flexible).
+
+## STOP conditions & drift check
+- A throwing/misconfigured compound rule must NOT break base-rule evaluation or dispatch
+  (per-rule try/catch, like base rules). Prove with a test where `evaluate` throws.
+- Cycles must be rejected by `topoSortCompound` (unit-tested) — never infinite-loop the
+  sweep.
+- Each compound rule dedups under its own `hostId:compoundId` key — do not reuse a base
+  rule's dedup identity.
+- No auto-remediation; a compound rule only raises a correlated alert.
+- Do not modify `decideNotification` semantics; reuse `evaluateAlert` as-is.
+- Keep base-rule behavior byte-for-byte unchanged (compound is purely additive).
+
+## Verification
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/alerting/compound-rules.test.ts --isolate
+cd apps/dashboard && bun test src/lib/alerting/ --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+- `compound-rules.ts` with `CompoundRuleDef`, registry, and pure `topoSortCompound`
+  (tests: valid order, missing-dependency, cycle rejection, throwing-evaluate isolation).
+- ≥2 example compound rules registered and evaluated after their base dependencies.
+- Sweep evaluates base → compound in dependency order; each compound dedups under its own
+  key and dispatches via the shared path.
+- Base-rule behavior unchanged; a broken compound rule never breaks the base sweep.
+- All four verification commands pass; open questions answered in the PR description.
+
+Priority: P2 · Effort: L · Depth: E · Wave: A (Alerting) · Lever: Adoption

--- a/plans/32-custom-alert-rule-builder.md
+++ b/plans/32-custom-alert-rule-builder.md
@@ -1,0 +1,137 @@
+# 32 — Custom alert rule builder (no-code, whitelisted)
+
+## Kickoff prompt
+
+```text
+Execute plans/32-custom-alert-rule-builder.md alone (zero prior context). This is an
+EPIC brief — do light discovery first, then build.
+Goal: let users define alert rules WITHOUT editing TypeScript — "alert when [metric]
+[op] [threshold]" — via a builder that compiles to SAFE whitelisted SQL, persists in D1,
+and registers the rule into the sweep at startup.
+Invariants you MUST hold (this plan is a SQL-injection surface — hold the line):
+- The builder NEVER accepts free-form SQL. Metric/op/threshold come from server-side
+  WHITELISTS only; the generated SQL is assembled from vetted fragments, never string-
+  concatenated user text. Reject anything off-whitelist.
+- Self-hosted/OSS stays whole; fail OPEN without Clerk (no D1 / owner throw ⇒ no custom
+  rules loaded, built-ins run normally; never crash the sweep).
+- AI/alerts RECOMMEND but NEVER auto-apply destructive DDL; a custom rule only classifies
+  a read-only metric — remediation stays ACK-gated (plans 29/33). Generated SQL is
+  read-only (readonly=1); the deny-list from plan 33 (assertReadOnlyAction) applies.
+- Honest paywalls: ship free/OSS unless pricing marks custom rules as paid.
+- Postgres = NO. D1 only (mirror insights/store/d1-store.ts).
+Build ONLY §"Implement now". Respect STOP conditions. Then run every command in
+§Verification and paste output.
+```
+
+## Current reality (audited)
+
+**Why (spec):** users can't define rules without editing TS, which blocks self-service
+alerting.
+
+File pointers (verified):
+- Rule shape + registry: `apps/dashboard/src/lib/alerting/rule-registry.ts`
+  (`AlertRuleDef`, `ruleRegistry.register/getAll`, `classifyValue`). Built-ins:
+  `.../builtin-rules.ts` (`registerBuiltinRules`) — the sweep calls this once at module
+  load (`server-sweep.ts` top).
+- Sweep: `apps/dashboard/src/lib/health/server-sweep.ts` — drives off `ruleRegistry.getAll()`;
+  runs each rule's `sql` read-only (`runRuleQuery`, `clickhouse_settings:{readonly:'1'}`),
+  reads `valueKey`, classifies, dispatches via `evaluateAlert`.
+- D1 pattern: `apps/dashboard/src/lib/insights/store/d1-store.ts`. Migrations:
+  `src/db/conversations-migrations/NNNN_*.sql` (next after `0006`).
+- Health UI dir `(verify)` — colocate the builder with the existing health-settings component.
+- **Soft dep on plan 33:** reuse its `assertReadOnlyAction`/deny-list validator for the
+  generated SQL. If 33 isn't merged, port the same deny-list here.
+
+## Goal
+
+A user builds a numeric-threshold rule from whitelisted building blocks (a known metric →
+a vetted SQL template, an operator, warning/critical thresholds). The builder compiles a
+**safe read-only** SQL string, persists the rule in `custom_alert_rules`, and the sweep
+registers all persisted custom rules at startup so they evaluate alongside built-ins.
+
+## Implement now (approach + key files)
+
+- **Metric whitelist** `src/lib/health/rule-builder-schema.ts` (new): a fixed catalog
+  mapping each selectable metric → a vetted, parameterized read-only SQL template +
+  `valueKey`, e.g.
+  ```ts
+  export const METRIC_CATALOG = {
+    'active-mutations': { sql: `SELECT count() AS v FROM system.mutations WHERE is_done = 0`, valueKey: 'v', unit: 'count' },
+    'parts-per-partition-max': { sql: `SELECT max(cnt) AS v FROM (SELECT count() cnt FROM system.parts WHERE active GROUP BY partition, table)`, valueKey: 'v', unit: 'parts' },
+    'readonly-replicas': { sql: `SELECT count() AS v FROM system.replicas WHERE is_readonly`, valueKey: 'v', unit: 'count' },
+    // …a curated set; NO user SQL, NO interpolated identifiers
+  } as const
+  ```
+  - Zod schema: `{ name, metric: keyof METRIC_CATALOG, op: '>'|'>='|'<'|'<=', warning: number,
+    critical: number }`. The threshold is a **number bound at classify time**, not injected
+    into SQL — the SQL only *reads the metric*; comparison happens in `classifyValue`
+    (extend `classifyValue`/add a comparator to honor `<`/`<=` if needed, or normalize so
+    higher = worse).
+  - `compileCustomRule(input): AlertRuleDef` — pure; picks the template from the catalog,
+    sets `id = 'custom:' + slug(name)`, `type:'custom'`, `defaults:{warning,critical}`.
+    **No string interpolation of user input into SQL.** Unit-test that off-catalog metrics
+    and non-numeric thresholds are rejected, and that output SQL === the catalog template.
+  - Defense-in-depth: run the generated SQL through the plan-33 `assertReadOnlyAction`
+    deny-list before persisting AND before registering.
+- **D1 store** `custom_alert_rules(id TEXT PK, owner_id TEXT, name TEXT, metric TEXT,
+  op TEXT, warning REAL, critical REAL, enabled INTEGER, created_at INTEGER)` +
+  `src/lib/health/custom-rules-store.ts` (mirror insights store; CRUD; swallow failures).
+- **API** `src/routes/api/v1/health/custom-rules.ts`: GET/POST/DELETE, owner-scoped,
+  writes auth-gated, owner try/catch → OSS single-tenant. POST validates with the zod
+  schema and rejects off-catalog metrics with 400.
+- **Sweep registration** `server-sweep.ts`: at sweep start (or module load, `(verify)`
+  timing — the sweep runs per cron tick, so loading custom rules per-sweep is fine and
+  picks up edits), fetch enabled custom rules for the owner, `compileCustomRule` each,
+  and `ruleRegistry.register(...)` (unregister stale custom ids first to avoid drift).
+  On D1 failure ⇒ skip (built-ins still run).
+- **UI** `src/components/health/rule-builder.tsx` `(verify dir)`: dropdown metric +
+  operator + warning/critical inputs + name; live preview of the compiled (read-only)
+  SQL; save/list/delete via the API; "test" runs the metric read-only against a host.
+
+## Open questions (resolve during discovery)
+1. **Registration lifetime** — register custom rules per-sweep (simplest, picks up edits,
+   recommended) or once at boot with a reload hook? The sweep is cron-driven; per-sweep
+   load is cheap. Confirm no double-register (unregister-then-register by id).
+2. **Operator direction** — the catalog is authored so "higher = worse"; do we need `<`/`<=`
+   (e.g. "cache hit ratio < 0.9")? If yes, extend `classifyValue` with a comparator field
+   rather than inverting SQL. Decide and document.
+3. **Per-owner isolation in the sweep** — the sweep is owner-agnostic today; whose custom
+   rules load? `''` OSS single-tenant is acceptable for self-host; multi-tenant `(verify)`.
+4. **Catalog size** — start with ~6–10 curated metrics; adding metrics is a code change
+   (deliberate: keeps the SQL surface vetted). Confirm that's acceptable product-wise.
+5. **Free vs paid** — is custom rule authoring advertised as paid? Gate via
+   `plan-enforcement.ts` only if pricing says so; else free.
+
+## STOP conditions & drift check
+- If you are ever concatenating user-supplied text into a SQL string — STOP. The only
+  user inputs that reach SQL selection are an enum key (metric) resolved server-side to a
+  fixed template; thresholds are numbers compared in `classifyValue`, never in SQL.
+- Generated SQL must be read-only and pass the plan-33 deny-list at both persist and
+  register time.
+- No D1 / owner throw ⇒ zero custom rules loaded, built-ins unaffected; sweep never
+  crashes. Prove with a pure `compileCustomRule` test (no D1) and a store-failure path.
+- Unregister stale custom rule ids before re-registering to prevent orphan rules.
+- No auto-remediation; custom rules only classify a metric.
+- Do not expose a free-form SQL field anywhere in the builder or API.
+
+## Verification
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/health/rule-builder-schema.test.ts --isolate
+cd apps/dashboard && bun test src/lib/health/ --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+- `rule-builder-schema.ts` with `METRIC_CATALOG` + zod + pure `compileCustomRule`
+  (tests: off-catalog metric rejected, non-numeric threshold rejected, output SQL equals
+  the catalog template, deny-list passes).
+- `custom_alert_rules` D1 + store + owner-scoped CRUD route (writes auth-gated, POST
+  rejects off-catalog with 400, fails open).
+- Sweep registers enabled custom rules (unregistering stale ids) and evaluates them with
+  built-ins; D1 failure degrades to built-ins only.
+- Builder UI compiles/preview/save/list/delete/test; no free-form SQL field exists.
+- All four verification commands pass; open questions answered in the PR description.
+
+Priority: P2 · Effort: M · Depth: E · Wave: A (Alerting) · Lever: Adoption

--- a/plans/33-remediation-action-links.md
+++ b/plans/33-remediation-action-links.md
@@ -1,0 +1,150 @@
+# 33 — Remediation action links (runbook + read-only actions)
+
+## Kickoff prompt
+
+```text
+Execute plans/33-remediation-action-links.md alone (zero prior context).
+Goal: give alerts a runbook/action affordance to cut MTTR — labeled runbook links
+and a SMALL set of READ-ONLY diagnostic actions, surfaced as Slack buttons/links and
+executable via an auth-gated endpoint. Rules declare their own actions.
+Invariants you MUST hold (this plan is where they bite hardest):
+- AI/alerts RECOMMEND actions but NEVER auto-apply destructive DDL. The action
+  endpoint runs ONLY read-only SQL (readonly=1) or records intent; it NEVER executes
+  ALTER/DROP/mutations. Any state-changing remediation stays ACK-gated and manual.
+- Self-hosted/OSS stays whole; the endpoint fails OPEN without Clerk BUT still
+  requires the same auth the other mutating health routes require (a read-only query
+  is still a cluster call — auth-gate it).
+- Honest paywalls: action links are free/OSS; do not gate behind a plan.
+- Postgres = NO.
+Build ONLY §"Implement now". Respect STOP conditions. Then run every command in
+§Verification and paste output.
+```
+
+## Current reality (audited)
+
+**Why (spec):** alerts carry no runbook/action affordance, so MTTR suffers. Advisor
+auto-exec is explicitly out of scope (invariant). Today an alert is a one-line text
+webhook with, at most, runbook URLs rendered by the Slack adapter.
+
+File pointers (verified):
+- Rule shape: `apps/dashboard/src/lib/alerting/rule-registry.ts` — `AlertRuleDef`
+  currently has `{ id, type, title, description, sql?, valueKey, defaults,
+  formatLabel?, optional?, tableCheck? }`. **No `remediationActions` field yet.**
+  Built-ins in `.../builtin-rules.ts` (`registerBuiltinRules`).
+- Slack adapter: `apps/dashboard/src/lib/health/adapters/slack.ts` — `buildSlackBody`
+  emits Block Kit blocks; it already renders a `*Runbooks:*` section from
+  `payload.runbookUrls`. `AlertPayload` (with `runbookUrls?`) in `adapters/types.ts`.
+  Registry + `detectAdapter` in `adapters/index.ts`.
+- Sweep: `apps/dashboard/src/lib/health/server-sweep.ts` posts a plain
+  `{ text, content }` webhook via `postWebhook`; it does NOT currently build an
+  `AlertPayload` per finding (`(verify)` — the richer adapters exist as a pure layer
+  but the sweep still posts flat text). Wiring the sweep to `buildSlackBody` is a
+  prerequisite for buttons to appear from cron; if that's too broad, ship the
+  action-declaration + endpoint and render buttons where the adapter payload is
+  already used, marking the sweep wiring `(verify)`.
+- Cron entry: `apps/dashboard/src/routes/api/cron/health-sweep.ts`.
+- SSRF-guarded read path: rules run via `fetchData({ …, clickhouse_settings:{ readonly:'1' } })`
+  (see `runRuleQuery` in server-sweep). Reuse that read-only transport.
+- D1 pattern (for recording action intent): `insights/store/d1-store.ts`.
+
+## Goal
+
+Rules can declare labeled `remediationActions` (a runbook link, or a read-only
+"get diagnostics" query). Adapters render them (Slack action buttons for executable
+actions, link sections for runbooks). An auth-gated `POST /api/v1/health/actions`
+executes a **whitelisted read-only** action for a `(hostId, ruleId, actionId)` and
+returns its result (or records intent) — and **never** runs destructive DDL.
+
+## Implement now
+
+### Rule schema — `src/lib/alerting/rule-registry.ts`
+Add an optional field to `AlertRuleDef`:
+```ts
+export type RemediationActionKind = 'runbook' | 'diagnostic'
+export interface RemediationAction {
+  id: string                 // stable, unique within the rule (e.g. 'top-mutations')
+  label: string              // button/link text
+  kind: RemediationActionKind
+  url?: string               // required when kind==='runbook'
+  sql?: string               // required when kind==='diagnostic'; MUST be read-only SELECT
+  description?: string
+}
+// on AlertRuleDef:
+remediationActions?: RemediationAction[]
+```
+- Add a pure validator `assertReadOnlyAction(a: RemediationAction)` in this file (or a
+  sibling) that rejects a `diagnostic` whose `sql` matches a deny-list
+  (`/\b(ALTER|DROP|DELETE|INSERT|UPDATE|TRUNCATE|OPTIMIZE|ATTACH|DETACH|CREATE|RENAME|GRANT|REVOKE|SYSTEM)\b/i`)
+  or lacks a leading `SELECT`/`SHOW`/`EXPLAIN`/`DESCRIBE`. Unit-test it.
+
+### Declare actions on a few built-ins — `src/lib/alerting/builtin-rules.ts`
+- Add `remediationActions` to ~4 high-value rules, each with a `runbook` link and one
+  `diagnostic` read-only query, e.g.:
+  - `failed-mutations` → diagnostic `SELECT * FROM system.mutations WHERE is_done=0 …`
+  - `stuck-merges` → diagnostic `SELECT * FROM system.merges ORDER BY elapsed DESC …`
+  - `replication-lag` → diagnostic `SELECT * FROM system.replicas WHERE … ORDER BY absolute_delay DESC`
+  - `disk-usage` → runbook link only (TTL/partition guidance) — no destructive action.
+- Every diagnostic SQL must pass `assertReadOnlyAction`.
+
+### Adapter payload — `src/lib/health/adapters/types.ts` + `adapters/slack.ts`
+- Extend `AlertPayload` with `actions?: readonly { id; label; kind; url? }[]`
+  (channel-agnostic; omit raw SQL from the payload — the button carries only ids).
+- In `buildSlackBody`, when `payload.actions?.length`, append an `actions` block:
+  runbook actions → Block Kit `button` with `url` (link-out, no interaction round-trip);
+  diagnostic actions → `button` with `action_id: "chm_action:<ruleId>:<actionId>"` and
+  a `value` carrying `{hostId, ruleId, actionId}` (the interaction handler / native
+  Slack app in plan 37 will POST it; for non-Slack-app installs, render diagnostics as
+  a labeled link to the in-app Active Alerts panel instead of an interactive button).
+- Keep the existing `*Runbooks:*` `runbookUrls` section for back-compat.
+
+### Execute endpoint — `src/routes/api/v1/health/actions.ts` (TanStack `createFileRoute`)
+- `POST` body `{ hostId:number, ruleId:string, actionId:string }`.
+- Resolve the rule from `ruleRegistry.get(ruleId)`; find the action by `actionId`;
+  if `kind==='runbook'` return `{ url }` (nothing to execute). If `kind==='diagnostic'`:
+  re-run `assertReadOnlyAction`, then execute via the read-only transport
+  `fetchData({ query: action.sql, hostId, format:'JSONEachRow',
+  clickhouse_settings:{ readonly:'1' } })` and return the rows (capped, e.g. first 50).
+- **Auth-gate** exactly like the other mutating health routes (this hits the cluster).
+  Owner resolution fails open (OSS ⇒ proceed), but the auth gate stays. Record the
+  action invocation (best-effort) to the alert history (plan 27) or via `debug()`.
+- Return 400 for unknown rule/action; 422 if `assertReadOnlyAction` rejects (defense
+  in depth even though declaration-time validation should have caught it).
+
+### (Optional) intent log
+- If `alert-history-store.ts` (plan 27) exists, record `{ decisionKind:'action',
+  ruleId, actionId, hostId, actor, result:'ok'|'error' }`. Otherwise `TODO(27)`.
+
+## STOP conditions & drift check
+- The endpoint runs **read-only SQL only** (`readonly=1`) or returns a runbook URL. If
+  you find yourself wanting to run `ALTER`/`OPTIMIZE`/a mutation to "fix" the alert —
+  STOP. That is the exact invariant this plan protects; remediation stays manual/ACK-
+  gated. No DDL execution, ever.
+- `assertReadOnlyAction` must run at BOTH declaration time (rule registration/test) and
+  request time (endpoint). Do not trust the client-supplied `actionId` to carry SQL —
+  the SQL is looked up server-side from the rule, never taken from the request body.
+- Do not remove the existing `runbookUrls` rendering (back-compat).
+- If the sweep doesn't yet build `AlertPayload` per finding, ship the schema + endpoint
+  + adapter support and mark the sweep→adapter wiring `(verify)`; don't rewrite the
+  whole sweep dispatch path in this plan.
+- Keep the action set tiny and diagnostic; this is affordance, not automation.
+
+## Verification
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/health/adapters/ --isolate
+cd apps/dashboard && bun test src/lib/alerting/ --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+- `AlertRuleDef.remediationActions` + `RemediationAction` type shipped; `assertReadOnlyAction`
+  validator with unit tests (accepts SELECT/SHOW/EXPLAIN, rejects ALTER/DROP/mutations/SYSTEM).
+- ≥4 built-in rules declare a runbook link and/or a read-only diagnostic action.
+- Slack adapter renders action buttons/links; `runbookUrls` section preserved.
+- `POST /api/v1/health/actions` executes only whitelisted read-only SQL (server-looked-up),
+  auth-gated, capped output; rejects unknown/destructive with 400/422; no DDL auto-exec.
+- Action invocations recorded when plan 27 present (else `TODO(27)`).
+- All four verification commands pass.
+
+Priority: P2 · Effort: M · Depth: F · Wave: A (Alerting) · Lever: Adoption

--- a/plans/34-pagerduty-escalation-oncall.md
+++ b/plans/34-pagerduty-escalation-oncall.md
@@ -1,0 +1,138 @@
+# 34 — PagerDuty escalation & on-call routing
+
+## Kickoff prompt
+
+```text
+Execute plans/34-pagerduty-escalation-oncall.md alone (zero prior context). This is an
+EPIC brief — do light discovery first, then build.
+Goal: route alerts to specific PagerDuty SERVICES (per rule/host) so PagerDuty's own
+escalation policies + on-call schedules take over, with one incident per (host,rule)
+via a stable dedup key. Today the PagerDuty adapter posts a single event and ignores
+service/escalation routing.
+Invariants you MUST hold:
+- Self-hosted/OSS stays whole; fail OPEN without Clerk (no D1 / owner throw ⇒ fall back
+  to the single env routing key / legacy behavior; never crash the sweep).
+- AI/alerts RECOMMEND but NEVER auto-apply destructive DDL; routing to PagerDuty only
+  pages a human — remediation stays ACK-gated (plans 29/33). PagerDuty owns escalation;
+  chmonitor does NOT auto-run any fix.
+- Honest paywalls: if per-service routing is advertised as paid, gate via
+  lib/billing/plan-enforcement.ts (enforced|deferred honestly); else ship free.
+- Postgres = NO. D1 only (mirror insights/store/d1-store.ts).
+Build ONLY §"Implement now". Respect STOP conditions. Then run every command in
+§Verification and paste output.
+```
+
+## Current reality (audited)
+
+**Why (spec):** the PagerDuty adapter posts events but ignores escalation policies /
+on-call routing. Every alert goes to one integration key regardless of rule or host.
+
+File pointers (verified):
+- PagerDuty adapter: `apps/dashboard/src/lib/health/adapters/pagerduty.ts` — Events API
+  v2 enqueue (`https://events.pagerduty.com/v2/enqueue`); `buildPagerDutyBody(payload,
+  { routingKey })`; `pagerDutyDedupKey(payload) = 'chmonitor:' + hostId + ':' + metric`;
+  `recovery → event_action:'resolve'`. The exported `pagerDutyAdapter.buildBody` uses a
+  `'<routing_key>'` placeholder — **the dispatch layer substitutes the real key**.
+- Adapters registry + `detectAdapter` (`events.pagerduty.com`): `adapters/index.ts`.
+- Sweep + dispatch: `apps/dashboard/src/lib/health/server-sweep.ts` (`runHealthSweep`,
+  `postWebhook`, `evaluateAlert` dedup key `hostId:ruleId`).
+- Config: `apps/dashboard/src/lib/health/server-alert-config.ts` (`HEALTH_ALERT_*`).
+- D1 pattern: `insights/store/d1-store.ts`. Migrations:
+  `src/db/conversations-migrations/NNNN_*.sql` (next after `0006`).
+- **Depends on plan 30 (per-rule routing):** this plan EXTENDS `alert-routing.ts` /
+  `alert_routes` to carry a PagerDuty service target. If plan 30 is not yet merged, build
+  the minimal routing table here and note the merge overlap `(verify)`.
+- Health UI dir `(verify)` — colocate the setup dialog with the health-settings component.
+
+## Goal
+
+An operator maps rule/host patterns → a PagerDuty **service** (its integration/routing
+key). When a matching finding notifies, the sweep enqueues a PagerDuty `trigger` (or
+`resolve` on recovery) to that service's routing key, letting PagerDuty apply the
+service's escalation policy + on-call schedule. Dedup ensures **one open incident per
+(host, rule)**; a stale env key remains a fallback so existing setups keep working.
+
+## Implement now (approach + key files)
+
+- **Config module** `src/lib/health/pagerduty-config.ts` (new): read the account-level
+  PagerDuty REST API token from env (`HEALTH_ALERT_PAGERDUTY_API_KEY`) — used ONLY to
+  *list services* for the setup UI (never to mutate PagerDuty). Also expose the legacy
+  single integration key (`HEALTH_ALERT_PAGERDUTY_ROUTING_KEY`) as the fallback.
+- **D1 schema** `0007_pagerduty_routing.sql` (or extend plan-30 `alert_routes`):
+  `pagerduty_routing(id TEXT PK, owner_id TEXT, match_rule TEXT, match_host TEXT,
+  service_name TEXT, routing_key TEXT, enabled INTEGER, created_at INTEGER)`. Store the
+  integration/routing key per service (secret-at-rest, like connection secrets).
+- **Routing extension** `alert-routing.ts` (plan 30) or a sibling: `resolvePagerDutyTargets(
+  routes, { ruleId, ruleType, hostId, hostName }): { serviceName; routingKey }[]` — pure,
+  unit-tested glob/`*` matching (reuse plan-30 `matchRoutes` if present). No match ⇒
+  `[{ routingKey: envFallbackKey }]` when the env key is set, else `[]`.
+- **Route API** `src/routes/api/v1/health/pagerduty-routes.ts` (or fold into plan-30
+  `routes.ts`): GET/POST/DELETE owner-scoped; a `GET .../pagerduty/services` helper lists
+  PagerDuty services via the REST token for the picker. Writes auth-gated; owner try/catch
+  → OSS single-tenant.
+- **Sweep dispatch** `server-sweep.ts`: when a finding notifies and its target resolves to
+  PagerDuty (URL `events.pagerduty.com` or a routing rule), build the body with the
+  **real** key: `buildPagerDutyBody(payload, { routingKey })` for each matched service, and
+  POST to the Events API. Preserve `recovery → resolve` and the `chmonitor:{hostId}:{metric}`
+  dedup key so PagerDuty collapses/auto-resolves one incident per (host, rule). Run
+  `evaluateAlert` once per finding (not per service). Respect plan-28/29 suppression.
+- **UI** `src/components/health/pagerduty-setup-dialog.tsx` `(verify dir)`: pick a service
+  (from the listed services or paste an integration key), set rule/host match, save/list/
+  delete; a "send test event" path to the selected service.
+
+## Open questions (resolve during discovery)
+1. **Overlap with plan 30** — does `alert_routes` already model channel targets? If so,
+   add `provider:'webhook'|'pagerduty'` + `service_name`/`routing_key` columns there
+   instead of a second table. Decide before writing the migration to avoid two schemas.
+2. **REST token scope** — the API key is for *reading* services only (list for the picker).
+   Confirm we never call PagerDuty write endpoints (creating services/policies is the
+   operator's job in PagerDuty). Events API uses the per-service integration/routing key,
+   not the REST token.
+3. **Dedup identity** — keep `pagerDutyDedupKey = chmonitor:{hostId}:{metric}` (recommended;
+   PagerDuty auto-resolves on the `resolve` event). Confirm `metric` == rule id semantics so
+   `hostId:ruleId` (sweep dedup) and the PagerDuty dedup key stay aligned.
+4. **Escalation "honored"** — chmonitor does nothing special for escalation; it just routes
+   to the right service and lets PagerDuty escalate. Confirm that's the intended contract
+   (no chmonitor-side escalation timers).
+5. **Free vs paid** — is per-service routing advertised as Pro+/Enterprise? Gate via
+   `plan-enforcement.ts` only if pricing says so.
+6. **Secret storage** — routing keys at rest in D1 (as connection secrets are) vs env-only?
+   Default: D1, matching existing secret handling; `(verify)`.
+
+## STOP conditions & drift check
+- No D1 / owner throw ⇒ fall back to the single env routing key (or no PagerDuty dispatch
+  if unset) — existing single-key setups behave unchanged. Prove with a pure resolver test.
+- The REST API token is **read-only usage** (list services). Never call PagerDuty write/
+  mutation endpoints. chmonitor pages humans; it does not manage PagerDuty config or run
+  remediation.
+- Preserve `recovery → resolve` and the stable dedup key so incidents don't duplicate and
+  auto-resolve correctly.
+- Run `evaluateAlert` once per finding; fan-out to multiple services must not multiply
+  cooldown state.
+- Coordinate the schema with plan 30 (one routes table if possible) — flag the overlap in
+  the PR rather than silently shipping two.
+- Do not gate behind a paywall unless pricing marks it paid.
+
+## Verification
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/health/adapters/ --isolate
+cd apps/dashboard && bun test src/lib/health/ --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+- `pagerduty-config.ts` (REST token for service listing + env fallback key) shipped.
+- `pagerduty_routing` D1 (or extended `alert_routes`) + pure `resolvePagerDutyTargets`
+  with tests for `*` / glob / no-match-fallback.
+- Sweep enqueues per-service `trigger`/`resolve` with the real routing key, preserving the
+  `chmonitor:{hostId}:{metric}` dedup key and running `evaluateAlert` once per finding.
+- Setup dialog lists services (or accepts an integration key), maps rule/host → service,
+  and can send a test event.
+- Legacy single-key setups behave unchanged; no PagerDuty write/mutation calls; no paywall
+  unless pricing dictates.
+- All four verification commands pass; open questions (esp. the plan-30 schema overlap)
+  answered in the PR description.
+
+Priority: P1 · Effort: L · Depth: E · Wave: A (Alerting) · Lever: Revenue/Adoption

--- a/plans/36-inbound-event-bus-queues.md
+++ b/plans/36-inbound-event-bus-queues.md
@@ -1,0 +1,126 @@
+# 36 — Inbound event bus (Cloudflare Queues)
+
+## Kickoff prompt
+
+```text
+Execute plans/36-inbound-event-bus-queues.md ALONE (do not read other plans).
+Goal: add an INBOUND event bus so chmonitor can ingest Alertmanager/Datadog/generic
+events, normalize + dedup them, retain ~30d in D1, and optionally re-emit to the
+existing outbound alert routes. Ingest is async via Cloudflare Queues.
+
+Invariants (do not violate):
+- Self-hosted/OSS stays WHOLE and FAILS OPEN: Cloudflare Queues are cloud-only. On
+  self-host (no Queue binding) the ingest endpoint must degrade to a synchronous
+  inline path (or a clearly-disabled 501) — never crash, never require Clerk.
+- SSRF: any re-emit / outbound delivery MUST go through the existing SSRF-guarded
+  webhook proxy — do not add a raw fetch to attacker-suppliable URLs.
+- Honest claims: only surface event sources you actually normalize.
+- Postgres/multi-DB: NO. Storage is Cloudflare D1 only.
+
+External setup required (document, don't assume): a Cloudflare Queue must be created
+and bound in wrangler.toml before the consumer runs.
+
+When done, run the Verification block and paste the output.
+```
+
+## Current reality (audited)
+
+Why (roadmap §4/36, P1/L/E): alerting today is **outbound-only** — chmonitor fans alerts
+*out* to Slack/Discord/Telegram/PagerDuty/generic webhooks, but there is **no way to ingest**
+Alertmanager/Datadog/generic events *in* for correlation and fan-out. Per strategy §1
+("meet teams in their stack"), an inbound bus lets chmonitor sit in an existing alerting
+mesh rather than replace it.
+
+Pointers (verify at head):
+- `apps/dashboard/wrangler.toml` — currently declares `[[d1_databases]]` + `[[migrations]]`
+  but **no** `[[queues.*]]`. This plan adds a producer binding + `[[queues.consumers]]`.
+- Outbound delivery + SSRF guard live under `apps/dashboard/src/lib/health/` (the webhook
+  proxy the alert adapters already use) `(verify exact module)` — reuse it for re-emit.
+- Route convention: `apps/dashboard/src/routes/api/…`; D1 migrations live alongside the
+  existing migrations referenced from `wrangler.toml`.
+
+## Goal
+
+`POST /api/events/ingest` accepts an event, enqueues it (cloud) or handles it inline
+(self-host), a consumer normalizes Alertmanager/Datadog/generic shapes into one schema,
+dedups by content hash, upserts into an `event_log` D1 table retained ~30d, optionally
+re-emits to configured outbound routes, and an "Inbound Events" page lists/filters them.
+
+## Implement now (depth E — approach + key files + open questions)
+
+### Approach
+1. **Ingest** — `apps/dashboard/src/routes/api/events/ingest.ts` (new). Accept POST body;
+   validate size/shape; if a Queue binding is present, `env.QUEUE.send(raw)` and return
+   `202 Accepted`. If **no** binding (self-host), run the normalize+store path inline and
+   return `200`. Authenticate the endpoint with a per-source shared token/header — do **not**
+   require Clerk (fail-open for OSS). Rate-limit.
+2. **Consumer** — a queue handler that normalizes + upserts. Detect source by payload
+   signature: Alertmanager (`{alerts:[…], commonLabels}`), Datadog (`{alert_type, aggreg_key}`),
+   else generic. Normalize to `{ id, source, received_at, severity, resource, title, body,
+   labels, dedup_hash }`.
+3. **Dedup** — hash on `(source, resource, title, severity)` (verify fields); upsert so a
+   repeat within the retention window updates `last_seen`/`count` rather than duplicating.
+4. **Retain 30d** — prune via the existing retention cron pattern `(verify cron route)` or a
+   `WHERE received_at > now()-30d` read filter + periodic delete.
+5. **Re-emit (optional)** — if configured, forward the normalized event to the existing
+   outbound alert routes **through the SSRF-guarded proxy**. Off by default.
+6. **UI** — new "Inbound Events" page under the dashboard routes with source/severity/date
+   filters, reading a `GET /api/events` list endpoint.
+
+### Key files
+- `apps/dashboard/wrangler.toml` — add producer binding + `[[queues.consumers]]` (queue
+  name, `max_batch_size`, `max_retries`, dead-letter queue). Mirror for `env.preview`.
+- `apps/dashboard/src/routes/api/events/ingest.ts` (new) + `…/api/events/index.ts` (list).
+- `apps/dashboard/src/lib/events/normalize.ts` (new) — source detection + normalization.
+- `apps/dashboard/src/lib/events/event-store.ts` (new) — D1 upsert/list/prune.
+- New D1 migration for `event_log` (added to the migrations list in `wrangler.toml`).
+- New "Inbound Events" route/page under `apps/dashboard/src/routes/(dashboard)/` `(verify group)`.
+
+### Open questions
+- Does the platform expose a single ClickHouse-side or D1-only path for the list query, and
+  is there an existing "events"-like table to avoid name collision? (Grep `event_log`.)
+- Is there an existing generic-webhook auth token convention to reuse for the source token,
+  or does this introduce a new secret? (Reuse if present.)
+- Queue consumer entrypoint wiring in a TanStack-Start-on-Workers app — confirm where the
+  `queue()` export lives relative to `fetch()` `(verify worker entry)`.
+
+### External setup (must be documented in the plan output / docs)
+- Create the Queue: `wrangler queues create chmonitor-inbound-events` (+ a DLQ).
+- Bind producer + consumer in `wrangler.toml`; redeploy.
+- Self-host has no Queues → inline path is the supported mode; document that clearly.
+
+## STOP conditions & drift check
+
+- STOP if `wrangler.toml` already binds a Queue for another purpose — reconcile naming; do
+  not repurpose an unrelated queue.
+- STOP if re-emit would require a raw `fetch` to a user-supplied URL outside the existing
+  SSRF guard — route it through the guard or defer re-emit.
+- DRIFT: if the self-host build has no way to reach the inline path (e.g. the route assumes a
+  binding), fix the fail-open path before shipping. OSS must not 500.
+- Do NOT introduce Postgres. Do NOT gate ingest behind Clerk/billing.
+
+## Verification
+
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/events --isolate
+cd apps/dashboard && bun run lint
+```
+
+Targeted test (`src/lib/events/normalize.test.ts`): feed representative Alertmanager,
+Datadog, and generic payloads; assert each normalizes to the common schema and that two
+identical payloads produce the same `dedup_hash`. Add a store test asserting upsert updates
+`count`/`last_seen` rather than inserting a duplicate.
+
+## Done criteria
+
+- `POST /api/events/ingest` enqueues in cloud (202) and handles inline on self-host (200,
+  no crash without a Queue binding).
+- Consumer normalizes all three sources, dedups, and upserts into `event_log` with 30d
+  retention.
+- Optional re-emit goes through the SSRF-guarded proxy and is off by default.
+- Inbound Events page lists + filters; normalize/store tests pass; monorepo `bun run build`
+  is green.
+
+Priority: P1 · Effort: L · Depth: E · Wave: I (Integrations) · Lever: Revenue / Ecosystem

--- a/plans/37-slack-app-native-oauth.md
+++ b/plans/37-slack-app-native-oauth.md
@@ -1,0 +1,133 @@
+# 37 — Native Slack app (OAuth + slash + ACK buttons)
+
+## Kickoff prompt
+
+```text
+Execute plans/37-slack-app-native-oauth.md ALONE (do not read other plans).
+Goal: ship a native Slack app for chmonitor — OAuth install, /chmonitor slash
+commands (status|query|alert) with rich blocks, a Home tab summary, and alert
+messages carrying an "Acknowledge" button that updates chmonitor alert state.
+
+Invariants (do not violate):
+- Self-hosted/OSS stays WHOLE and FAILS OPEN: the Slack app is optional. Absent
+  Slack env/credentials the feature is simply off; no route may crash and none may
+  require Clerk/billing to function for OSS.
+- SSRF: outbound calls to Slack go to the fixed api.slack.com host — that's fine —
+  but any URL derived from Slack payloads (e.g. response_url) must be validated as a
+  Slack-owned URL before fetching, or routed through the existing SSRF guard.
+- Honest claims: only wire slash subcommands you actually implement this round.
+- Postgres/multi-DB: NO. Install/state storage is Cloudflare D1 only.
+- Signature verification: verify Slack request signatures (X-Slack-Signature +
+  timestamp) on every inbound Slack request; reject stale/invalid.
+
+External setup required: a Slack app + manifest, OAuth client id/secret, signing
+secret. Document these; do not hardcode.
+
+When done, run the Verification block and paste the output.
+```
+
+## Current reality (audited)
+
+Why (roadmap §4/37, P1/L/E): today chmonitor only pushes **outbound webhooks** to Slack
+(the `slack.ts` adapter under `apps/dashboard/src/lib/health/adapters/`). A **native Slack
+app** — OAuth, slash commands, Home tab, and interactive ACK buttons — is a headline
+adoption lever and a Pro differentiator, and the ACK button is the natural front-end for the
+alert-ACK state (roadmap 29). Per strategy §1, this meets teams **in Slack**, where on-call
+already lives.
+
+Pointers (verify at head):
+- Existing outbound Slack adapter: `apps/dashboard/src/lib/health/adapters/slack.ts` — the
+  message/block-building code is a reuse candidate for command responses and alert posts.
+- Alert state / dedup store under `apps/dashboard/src/lib/health/` — the ACK button must
+  write to the same state model roadmap 29 defines `(verify module)`.
+- Route convention: `apps/dashboard/src/routes/api/v1/`; D1 migrations alongside the
+  existing set in `apps/dashboard/wrangler.toml`.
+- `@chm/clickhouse-client` for the `/chmonitor query` and `status` data.
+
+## Goal
+
+An installable Slack app: OAuth install persists a workspace token in D1; `/chmonitor
+status|query|alert` return rich blocks within Slack's 3s ack budget; a Home tab shows a
+cluster summary; and alert messages include an "Acknowledge" button that updates chmonitor
+alert state (ties to roadmap 29). Everything is optional and fail-open for OSS.
+
+## Implement now (depth E — approach + key files + open questions + external setup)
+
+### Approach
+1. **OAuth install** — `routes/api/v1/slack/oauth.ts`: start + callback. Exchange `code` for
+   an access token via `oauth.v2.access`; store `{ team_id, bot_token, installed_by,
+   installed_at, owner_ref }` in a D1 `slack_installations` table (encrypt/scope the token).
+2. **Signature verify** — shared middleware verifying `X-Slack-Signature` + timestamp on all
+   inbound Slack requests; reject if timestamp skew > 5m or signature mismatch.
+3. **Slash commands** — `routes/api/v1/slack/commands.ts`: ack within 3s (return an empty
+   200 or a "working…" block immediately), then post the full result to `response_url`.
+   - `status` → cluster health summary (reuse health/insights data).
+   - `query` → run a **read-only** query via `@chm/clickhouse-client` and render results as a
+     block table; enforce a row/time cap.
+   - `alert` → list currently firing alerts.
+4. **Interactivity** — `routes/api/v1/slack/interactions.ts`: handle the "Acknowledge"
+   button `block_actions` payload → write an ACK (actor = Slack user, duration) to alert
+   state, then `chat.update` the original message to show "Acked by @user".
+5. **Events / Home tab** — `routes/api/v1/slack/events.ts`: handle the `url_verification`
+   challenge and `app_home_opened` → publish a Home tab view (summary + quick actions).
+6. **Alert bridge** — extend the outbound Slack alert path so posts include the ACK button
+   `action_id` and reference the alert's dedup key.
+
+### Key files
+- `docs/slack/manifest.yml` (new) — app manifest (scopes, slash command, interactivity URL,
+  events, Home tab). Publish-ready.
+- `routes/api/v1/slack/{oauth,commands,interactions,events}.ts` (new).
+- `apps/dashboard/src/lib/slack/{verify-signature,blocks,install-store}.ts` (new).
+- New D1 migration: `slack_installations` (+ referenced in `wrangler.toml` migrations list).
+- Extend `apps/dashboard/src/lib/health/adapters/slack.ts` for ACK-button blocks.
+
+### Open questions
+- Bolt vs. raw HTTP handlers on Workers: Bolt's Node adapters are awkward on workerd —
+  prefer **raw HTTP** handlers with a small verify/blocks lib unless a Workers-compatible
+  Bolt receiver is already a dep `(verify package.json)`.
+- Where does `owner_ref` come from at install time for OSS (no Clerk)? Define a fallback
+  (single-tenant install) so OSS works.
+- Slack's 3s ack constraint vs. ClickHouse query latency → confirm the deferred-response
+  (`response_url`) pattern is acceptable for `query`.
+
+### External setup (document; do not assume)
+- Create a Slack app from `docs/slack/manifest.yml`; set OAuth scopes (`commands`,
+  `chat:write`, `app_home`, etc.), the slash command, interactivity request URL, and event
+  subscription URL to the deployed routes.
+- Provide `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_SIGNING_SECRET` via env; document
+  the OAuth redirect URL.
+
+## STOP conditions & drift check
+
+- STOP if a Slack install store / native-app route already exists — reconcile rather than
+  duplicate.
+- STOP if `query` cannot be made read-only + capped through the existing client — do not
+  expose an unbounded query surface to a chat command.
+- DRIFT: if the ACK-state model roadmap 29 assumes isn't present yet, land a minimal ACK
+  write here and note the coupling; do not invent a parallel state store.
+- Do NOT require Clerk for the app to function. Do NOT skip signature verification.
+
+## Verification
+
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/slack --isolate
+cd apps/dashboard && bun run lint
+```
+
+Targeted test (`src/lib/slack/verify-signature.test.ts`): assert a correctly-signed request
+passes and a tampered body / stale timestamp is rejected. Add a `blocks.test.ts` asserting
+the slash-command and alert-ACK block payloads are well-formed JSON with the expected
+`action_id`.
+
+## Done criteria
+
+- OAuth install persists a token in D1; the manifest in `docs/slack/` is publish-ready.
+- `/chmonitor status|query|alert` acknowledge within 3s and post rich blocks; `query` is
+  read-only + capped.
+- The "Acknowledge" button updates chmonitor alert state and edits the Slack message.
+- Signature verification rejects invalid/stale requests; OSS runs fine with Slack env absent.
+- Slack unit tests pass; monorepo `bun run build` is green.
+
+Priority: P1 · Effort: L · Depth: E · Wave: I (Integrations) · Lever: Adoption / Revenue

--- a/plans/38-grafana-datasource-plugin.md
+++ b/plans/38-grafana-datasource-plugin.md
@@ -1,0 +1,139 @@
+# 38 — Grafana datasource plugin
+
+## Kickoff prompt
+
+```text
+Execute plans/38-grafana-datasource-plugin.md ALONE (do not read other plans).
+Goal: build an OFFICIAL Grafana datasource plugin (NEW top-level package
+apps/grafana-plugin/) that wraps chmonitor's ClickHouse query API and ships
+ClickHouse-specific alert-rule templates + advisor panel templates — the thing a
+generic ClickHouse datasource does NOT give you.
+
+This plan BOOTSTRAPS A NEW PACKAGE with its OWN build/test (Grafana plugin
+scaffold: `npm run build` / plugin sign/validate). It must NOT be added to the
+monorepo `bun run build` graph in a way that breaks it.
+
+Invariants (do not violate):
+- Self-hosted/OSS stays WHOLE / fail-open: the plugin talks to a chmonitor instance
+  over its existing HTTP API using a chmonitor API key; it must work against a
+  self-hosted instance and must not require chmonitor Cloud. Enterprise-only panels
+  are edition-gated on the chmonitor side, degrading gracefully if absent.
+- SSRF: the plugin's backend makes outbound calls to the user-configured chmonitor
+  base URL only; validate it's an absolute http(s) URL. No chmonitor-side change adds
+  a new unguarded outbound fetch.
+- Honest claims: ship only panel/alert templates backed by real chmonitor endpoints.
+- Postgres/multi-DB: NO.
+
+External setup: Grafana plugin SDK toolchain (create-plugin scaffold, Mage/Go for
+the backend datasource, a signing/registry step for publish). Document it.
+
+When done, run the Verification block and paste the output.
+```
+
+## Current reality (audited)
+
+Why (roadmap §4/38, P1/L/E): today the Grafana story is a **copy-paste recipe** only.
+Grafana + the Altinity plugin (16.6M downloads) already own generic ClickHouse dashboards
+(strategy §1) — so a chmonitor plugin must **not** compete on raw metrics. It differentiates
+by shipping **ClickHouse-aware alert-rule templates + advisor panels** (projections,
+skip-indexes, replication lag, part counts) that a generic datasource can't express.
+
+Pointers (verify at head):
+- chmonitor query API: `apps/dashboard/src/routes/api/v1/clickhouse/query` (verify exact
+  path) — the plugin's datasource backend calls this with a `chm_` API key.
+- API-key auth path already exists for programmatic access `(verify the key middleware)` —
+  reuse it; do not invent a new auth scheme.
+- `apps/grafana-plugin/` does **NOT** exist yet — this plan creates it as a NEW top-level
+  package outside the Workers app.
+- Edition gating: `apps/dashboard/src/lib/edition/` — enterprise panels/queries are gated
+  there; the plugin must degrade if an endpoint 402/403s.
+
+## Goal
+
+An installable Grafana datasource plugin (via `grafana-cli` / a published tarball) that
+queries a chmonitor instance, exposes template variables, ships ~10 prebuilt
+ClickHouse-specific alert/advisor panels, imports as a dashboard in < 10 min, and is
+marketplace-ready — with enterprise features edition-gated on the chmonitor side and
+graceful degradation otherwise.
+
+## Implement now (depth E — approach + key files + open questions + external setup)
+
+### Approach
+1. **Scaffold** the plugin in `apps/grafana-plugin/` with the Grafana `create-plugin`
+   toolchain: a **frontend** (datasource config editor + query editor, TS/React) and a
+   **backend** datasource (Go, via Mage) that proxies queries to the chmonitor API. A
+   backend datasource is required for alerting support.
+2. **Datasource config** — base URL + chmonitor API key (`chm_…`), secured as a Grafana
+   secret. Validate the URL is absolute http(s).
+3. **Query path** — the Go backend forwards the panel's ClickHouse query to
+   `/api/v1/clickhouse/query`, maps the JSON result into Grafana data frames, and supports
+   template variables (host, database, table) via a variables query.
+4. **Bundled templates** — ship ~10 ClickHouse panels + alert rules as provisioning
+   JSON/YAML (replication lag, readonly replicas, part counts, merges in progress, slow
+   queries, disk usage, mutations stuck, and advisor-flavored panels tied to chmonitor
+   endpoints). Enterprise/advisor panels call endpoints that may be edition-gated; on
+   402/403 the panel shows an honest "requires chmonitor Enterprise" note rather than
+   erroring.
+5. **Publish** — build a signed tarball; document `grafana-cli plugins install` from a local
+   tarball and the marketplace-submission checklist.
+
+### Key files (new package)
+- `apps/grafana-plugin/src/` — `plugin.json`, `datasource.ts`, `ConfigEditor.tsx`,
+  `QueryEditor.tsx`.
+- `apps/grafana-plugin/pkg/` — Go backend datasource (`main.go`, query handler, frame
+  mapping), `Magefile.go`.
+- `apps/grafana-plugin/provisioning/` — bundled dashboards + alert-rule templates.
+- `apps/grafana-plugin/package.json` + `go.mod` — **its own** build/test scripts.
+- README with install + setup (< 10 min) instructions.
+- chmonitor side: confirm/adjust the API-key middleware allows the query endpoint; no new
+  outbound fetch is added.
+
+### Open questions
+- Exact chmonitor query endpoint contract (request/response JSON) the backend must map to
+  Grafana frames — capture it precisely before writing the Go mapper `(verify)`.
+- Which of the 10 panels require enterprise endpoints vs. OSS endpoints — label each so free
+  users get a working subset.
+- Grafana plugin **signing**: unsigned plugins need `allow_loading_unsigned_plugins`;
+  marketplace requires signing. Document both paths.
+
+### External setup (document; do not assume)
+- Install Grafana plugin toolchain: `npx @grafana/create-plugin`, Go + Mage for the backend.
+- Build: frontend `npm run build`; backend `mage -v build:linux` (+ other targets).
+- Sign + package for the catalog; provide a chmonitor API key with read scope.
+
+### Monorepo boundary (critical)
+- Add `apps/grafana-plugin/` as a package the monorepo **ignores for `bun run build`** (it is
+  Go + Grafana-toolchain, not Vite). Ensure workspace globs / turbo (if any) don't try to
+  `bun build` it. Verify `bun run build` at the repo root is unaffected.
+
+## STOP conditions & drift check
+
+- STOP if the chmonitor query endpoint or API-key auth path can't be located — the plugin is
+  useless without them; surface the real contract first.
+- STOP if scaffolding pulls the new package into the root `bun run build` and breaks it —
+  isolate it before proceeding.
+- DRIFT: do not embed chmonitor Cloud assumptions; the plugin must point at any base URL.
+- Do NOT ship panels for endpoints that don't exist (honest claims).
+
+## Verification
+
+```
+# monorepo must stay green (the new package must not join the bun build graph):
+bun run build            # repo root — unaffected by apps/grafana-plugin
+cd apps/dashboard && bun run type-check   # if the API-key/query route was touched
+
+# the NEW package builds/tests on its own toolchain:
+cd apps/grafana-plugin && npm ci && npm run build   # frontend
+cd apps/grafana-plugin && mage -v test              # backend datasource (Go)
+```
+
+## Done criteria
+
+- `apps/grafana-plugin/` scaffolds, builds (frontend `npm run build` + backend Mage), and
+  installs into Grafana via a tarball; setup is < 10 min.
+- Queries render against a self-hosted chmonitor instance using a `chm_` API key.
+- ~10 ClickHouse alert/advisor panel templates import; enterprise panels degrade gracefully
+  when the endpoint is gated.
+- Root `bun run build` is unaffected; new-package build/test pass.
+
+Priority: P1 · Effort: L · Depth: E · Wave: I (Integrations) · Lever: Adoption / Ecosystem

--- a/plans/39-otel-trace-export.md
+++ b/plans/39-otel-trace-export.md
@@ -1,0 +1,114 @@
+# 39 — OTel trace export
+
+## Kickoff prompt
+
+```text
+Execute plans/39-otel-trace-export.md ALONE (do not read other plans).
+Goal: emit chmonitor's OWN query traces as OpenTelemetry spans and export them to
+an external OTLP collector (Jaeger/Tempo/etc.), OPT-IN via CHM_OTEL_EXPORTER_URL.
+Span tree per request: dashboard-request -> clickhouse-query -> system-table-read,
+with query_id / user / read_bytes attributes; batch export; no measurable latency.
+
+Invariants (do not violate):
+- Self-hosted/OSS stays WHOLE / fail-open: export is OFF unless CHM_OTEL_EXPORTER_URL
+  is set. Absent the env var, zero spans are exported and there is zero added latency.
+  The feature must never require Clerk/billing.
+- SSRF: CHM_OTEL_EXPORTER_URL is an operator-set collector endpoint (trusted, like a
+  logging sink), NOT user-suppliable per-request — validate it's an absolute http(s)
+  URL at startup. Do not derive the export target from request data.
+- Honest claims: only attach attributes you actually populate.
+- Postgres/multi-DB: NO.
+
+When done, run the Verification block and paste the output.
+```
+
+## Current reality (audited)
+
+Why (roadmap §4/39, P2/M/F): chmonitor already **reads** OTel spans (the OTel span *viewer*
+integration) but **cannot export its own** query traces to a collector for correlation. Per
+strategy §1, exporting into a team's existing tracing stack is another "meet them where they
+are" integration — and it makes chmonitor's query path observable alongside app traces.
+
+Pointers (verify at head):
+- ClickHouse query execution goes through `@chm/clickhouse-client` /
+  `packages/clickhouse-client`; the dashboard's query routes call into it. Wrap the
+  execution boundary there (or at the route handler) to create spans `(verify seam)`.
+- Env schema/defaults module (where other `CHM_*` flags live) `(verify)` — add
+  `CHM_OTEL_EXPORTER_URL`.
+- Note: runs on Cloudflare Workers (workerd). Use an OTLP/HTTP exporter (not gRPC) and a
+  batch processor compatible with the Workers runtime.
+
+## Goal
+
+When `CHM_OTEL_EXPORTER_URL` is set, chmonitor emits a span tree per query request
+(`dashboard-request` → `clickhouse-query` → `system-table-read`) with `query_id`, `user`,
+and `read_bytes` attributes, batch-exports over OTLP/HTTP to the collector, spans appear in
+Jaeger/Tempo with durations matching real query time, and there is no measurable latency add
+when the feature is off.
+
+## Implement now (depth F — file-level)
+
+### A. Exporter setup — `apps/dashboard/src/lib/otel/exporter.ts` (new)
+- Dependency: `@opentelemetry/exporter-trace-otlp-http` + the SDK trace core (verify exact
+  package names/versions against what's installable; the roadmap names
+  `@opentelemetry/exporter-trace-http`).
+- Initialize a `TracerProvider` **once**, guarded by `CHM_OTEL_EXPORTER_URL`:
+  - If unset → export a no-op tracer (spans become cheap no-ops; **zero** network, **zero**
+    added latency). This is the OSS/default path.
+  - If set → configure an `OTLPTraceExporter({ url })` behind a `BatchSpanProcessor`
+    (batch size + scheduled delay tuned so export never blocks the request path).
+- Validate `CHM_OTEL_EXPORTER_URL` is an absolute http(s) URL at init; on invalid, log once
+  and fall back to no-op (fail-open, don't crash).
+- Resource attributes: `service.name = chmonitor`, version, deployment edition.
+
+### B. Instrument the query path — wrap the execution seam
+- Create spans around the request → query → system-table-read boundary. Prefer a small
+  helper `withSpan(name, attrs, fn)` in `src/lib/otel/` used at:
+  - the dashboard query route handler → `dashboard-request` (root span).
+  - the `@chm/clickhouse-client` execution call → `clickhouse-query` (child).
+  - the system-table read within a query → `system-table-read` (child) `(verify this seam
+    is distinguishable; if not, collapse to two levels and note it)`.
+- Attributes (only if actually available — honest claims): `query_id`, `user`/owner ref,
+  `read_bytes` (from ClickHouse response stats), `host`, `duration_ms` (implicit in span).
+- Ensure spans **end** in a `finally` so errors still close them; record exceptions on the
+  span.
+
+### C. Env gate + docs
+- Add `CHM_OTEL_EXPORTER_URL` (optional) to the env schema/defaults `(verify module)` and
+  document it in the self-host env docs as opt-in, with a Jaeger/Tempo example endpoint.
+- Document the workerd constraint (OTLP/HTTP only).
+
+## STOP conditions & drift check
+
+- STOP if an OTel *export* pipeline already exists (vs. the span *viewer*) — reconcile, don't
+  duplicate.
+- STOP if the installable OTel exporter packages don't run under workerd — surface the
+  blocker and propose the nearest Workers-compatible exporter rather than shipping something
+  that no-ops silently in production.
+- DRIFT: if wrapping the query path measurably adds latency when the feature is OFF, that
+  violates the invariant — make the disabled path a true no-op (guard before span creation).
+- Do NOT derive the collector URL from request data. Do NOT gate on Clerk/billing.
+
+## Verification
+
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/otel --isolate
+cd apps/dashboard && bun run lint
+```
+
+Targeted test (`src/lib/otel/exporter.test.ts`): with `CHM_OTEL_EXPORTER_URL` unset, assert
+the tracer is a no-op (no exporter constructed); with it set to a fake URL, assert a
+`BatchSpanProcessor`/exporter is configured and `withSpan` produces a span with the expected
+name + attributes (use an in-memory span exporter to capture).
+
+## Done criteria
+
+- With `CHM_OTEL_EXPORTER_URL` set, the 3-level span tree exports over OTLP/HTTP and is
+  visible in a collector; durations match query time.
+- With it unset, zero spans export and there is no measurable added latency (no-op path).
+- Attributes (`query_id`/`user`/`read_bytes`) populate only when available.
+- OTel unit test passes; monorepo `bun run build` is green.
+
+Priority: P2 · Effort: M · Depth: F · Wave: I (Integrations) · Lever: Adoption / Enterprise

--- a/plans/40-terraform-provider.md
+++ b/plans/40-terraform-provider.md
@@ -1,0 +1,141 @@
+# 40 — Terraform provider
+
+## Kickoff prompt
+
+```text
+Execute plans/40-terraform-provider.md ALONE (do not read other plans).
+Goal: ship a Terraform provider (NEW top-level package terraform-provider-chmonitor/)
+that manages chmonitor Cloud resources via the chmonitor HTTP API + a chm_ API key:
+chmonitor_{subscription,user,host,alert_rule} with clean plan/apply/destroy and a
+registry publish.
+
+This plan BOOTSTRAPS A NEW GO PACKAGE with its OWN build/test
+(terraform-plugin-framework, `go build`, `go test`, `terraform-plugin-docs`). It must
+NOT be added to the monorepo `bun run build` graph or break it.
+
+Invariants (do not violate):
+- Self-hosted/OSS stays WHOLE / fail-open: the provider targets a chmonitor instance
+  over its API using a chm_ API key. It must work against a self-hosted base URL and
+  must not require chmonitor Cloud. Resources that only exist in Cloud (subscriptions)
+  simply error clearly against an OSS instance.
+- SSRF: the provider makes outbound calls to the operator-configured chmonitor base
+  URL only; validate it's an absolute http(s) URL. No chmonitor-side change introduces
+  a new unguarded outbound fetch.
+- Honest claims: only implement resources backed by real chmonitor CRUD APIs.
+- Postgres/multi-DB: NO.
+
+External setup: Go toolchain, terraform-plugin-framework, a Terraform Registry
+account + GPG signing for publish. Document it.
+
+When done, run the Verification block and paste the output.
+```
+
+## Current reality (audited)
+
+Why (roadmap §4/40, P2/XL/E): enterprise teams want **GitOps** for their chmonitor Cloud
+resources (subscriptions, hosts, alert rules, MCP servers) — a sticky, high-touch,
+revenue-positive integration. There is no provider today. Per strategy §1, this meets
+enterprise teams **in their IaC stack** (Terraform) rather than forcing click-ops.
+
+Pointers (verify at head):
+- `terraform-provider-chmonitor/` does **NOT** exist — this plan creates it as a NEW
+  top-level Go package outside the Workers app.
+- Backing APIs already exist as D1-backed routes: connections/hosts
+  (`routes/api/v1/user-connections.ts`), alert config/rules, subscription/plan resolution,
+  and MCP server registration (roadmap 43). The provider is a thin CRUD client over these
+  `(verify each endpoint + method)`.
+- API-key auth (`chm_…`) path for programmatic access `(verify the key middleware)` — reuse
+  it; do not invent a new auth scheme.
+
+## Goal
+
+A Terraform provider that CRUDs `chmonitor_subscription`, `chmonitor_user`, `chmonitor_host`,
+and `chmonitor_alert_rule` (and, if the endpoint is ready, `chmonitor_mcp_server`) against a
+chmonitor instance via a `chm_` API key, produces stable plans (no spurious refresh diffs),
+cleans up on `destroy`, ships docs + examples, and is published to the Terraform Registry.
+
+## Implement now (depth E — approach + key files + open questions + external setup)
+
+### Approach
+1. **Scaffold** with HashiCorp's `terraform-plugin-framework` (Go). Provider config: `base_url`
+   (default chmonitor Cloud, overridable for self-host) + `api_key` (`chm_…`, from env
+   `CHMONITOR_API_KEY` or config). Validate `base_url` is absolute http(s).
+2. **HTTP client** — a small typed client wrapping the chmonitor REST endpoints (create /
+   read / update / delete) for each resource, with proper error surfacing (map non-2xx to
+   Terraform diagnostics; a `404` on read → resource removed from state).
+3. **Resources** (each = schema + CRUD + import):
+   - `chmonitor_host` — backed by user-connections CRUD.
+   - `chmonitor_alert_rule` — backed by alert-config/rule CRUD.
+   - `chmonitor_subscription` — backed by plan/subscription resolution (Cloud-only; error
+     clearly against OSS).
+   - `chmonitor_user` — backed by the user/member API `(verify it supports create/delete)`.
+   - `chmonitor_mcp_server` (optional) — only if roadmap-43's registry API exists.
+4. **State fidelity** — implement `Read` to reflect server truth so `plan` is empty after
+   `apply` (no perpetual diffs). Normalize any server-defaulted/computed fields as
+   `Computed`. Support `terraform import`.
+5. **Docs + examples** — generate with `terraform-plugin-docs`; ship `examples/` per resource.
+6. **Publish** — GPG-sign, tag, and publish to the Terraform Registry (GoReleaser flow).
+
+### Key files (new package)
+- `terraform-provider-chmonitor/main.go`, `internal/provider/provider.go`.
+- `internal/provider/resource_{host,alert_rule,subscription,user}.go` (+ `_test.go` each).
+- `internal/client/` — chmonitor API client.
+- `examples/`, `docs/` (generated), `go.mod`, `.goreleaser.yml`, `README.md`.
+- chmonitor side: confirm the CRUD endpoints + API-key scope cover create/read/update/delete
+  for each resource; no new outbound fetch is added.
+
+### Open questions
+- Which resources actually support full CRUD via API today vs. read-only? Any read-only
+  resource should ship as a **data source**, not a managed resource (honest claims).
+- API-key **scope/permissions** — does a `chm_` key allow mutating hosts/alert rules, and is
+  it org-scoped? Confirm before implementing writes.
+- `chmonitor_subscription` semantics against Polar-backed billing — is it truly mutable via
+  API, or should it be a data source? `(verify)`
+- Terraform acceptance tests (`TF_ACC`) need a live/mock chmonitor — decide mock vs. a
+  disposable test instance.
+
+### External setup (document; do not assume)
+- Go toolchain + `terraform-plugin-framework` + `terraform-plugin-docs` + GoReleaser.
+- A `chm_` API key with write scope; a chmonitor base URL (Cloud or self-host).
+- Terraform Registry namespace + GPG key for signed releases.
+
+### Monorepo boundary (critical)
+- Add `terraform-provider-chmonitor/` as a package the monorepo **ignores for `bun run
+  build`** (Go, separate toolchain). Ensure workspace globs / turbo (if any) don't try to
+  build it. Verify root `bun run build` is unaffected.
+
+## STOP conditions & drift check
+
+- STOP if the chmonitor CRUD endpoints / API-key write scope for a resource can't be
+  confirmed — ship that resource as a data source or defer it; do not fake writes.
+- STOP if scaffolding pulls the Go package into the root `bun run build` and breaks it —
+  isolate first.
+- DRIFT: do not hardcode Cloud-only assumptions into provider config; `base_url` must accept
+  a self-hosted instance.
+- Do NOT introduce Postgres. Do NOT bypass the existing API-key auth.
+
+## Verification
+
+```
+# monorepo must stay green (the new Go package must not join the bun build graph):
+bun run build            # repo root — unaffected by terraform-provider-chmonitor
+cd apps/dashboard && bun run type-check   # only if an API route/auth was touched
+
+# the NEW package builds/tests on its own toolchain:
+cd terraform-provider-chmonitor && go build ./...
+cd terraform-provider-chmonitor && go test ./...        # unit; TF_ACC gated separately
+cd terraform-provider-chmonitor && go vet ./...
+```
+
+## Done criteria
+
+- `terraform-provider-chmonitor/` builds (`go build`) and tests (`go test`) on its own
+  toolchain; docs generate.
+- `terraform apply` creates hosts/alert-rules (and subscription/user where API-backed)
+  against a chmonitor instance; `plan` is empty after apply (no refresh diffs); `destroy`
+  cleans up.
+- Read-only-only resources ship as data sources (honest claims).
+- Provider is publishable to the Terraform Registry (signed release flow documented).
+- Root `bun run build` is unaffected.
+
+Priority: P2 · Effort: XL · Depth: E · Wave: I (Integrations) · Lever: Revenue / Enterprise

--- a/plans/41-clickhouse-cloud-connect-wizard.md
+++ b/plans/41-clickhouse-cloud-connect-wizard.md
@@ -1,0 +1,118 @@
+# 41 — ClickHouse Cloud connect wizard
+
+## Kickoff prompt
+
+```text
+Execute plans/41-clickhouse-cloud-connect-wizard.md ALONE (do not read other plans).
+Goal: add a ClickHouse Cloud connection preset to the add-host flow — TLS on, port
+8443, service-hostname hints, first-try connect — plus an OPTIONAL Cloud cost sync
+that populates a cost-aware card. Give Cloud users a clear onboarding path distinct
+from self-host.
+
+Invariants (do not violate):
+- Self-hosted/OSS stays WHOLE / fail-open: the Cloud preset is additive UI; the
+  existing self-host/Docker/K8s connect paths are untouched and remain the default.
+  Nothing here requires Clerk/billing. The optional cost sync is off unless configured.
+- SSRF: connecting to a user-supplied ClickHouse host already flows through the
+  existing DNS-pinned/SSRF-guarded connection path — REUSE it; do not add a new
+  unguarded fetch. If the optional Cloud billing sync calls a ClickHouse Cloud API,
+  route it through the existing SSRF guard and validate the endpoint.
+- Honest claims: the cost card only shows data the sync actually retrieves.
+- Postgres/multi-DB: NO. ClickHouse-only.
+
+When done, run the Verification block and paste the output.
+```
+
+## Current reality (audited)
+
+Why (roadmap §4/41, P1/M/F): there is **no Cloud-vs-self-host onboarding path** — a new user
+must hand-configure TLS/port/hostname for a ClickHouse Cloud service. ClickHouse Cloud users
+are a **prime paying segment** (strategy §1: the advisor+alerting work on *every* deployment,
+incl. Cloud). A one-click Cloud preset with correct TLS defaults removes first-run friction
+for the segment most likely to convert.
+
+Pointers (verify at head):
+- Add-host UI: `apps/dashboard/src/components/connections/add-host-dialog.tsx` (confirmed to
+  exist) — this is where the preset toggle + field hints live.
+- Connection creation + validation route:
+  `apps/dashboard/src/routes/api/v1/user-connections.ts` (verify) — already SSRF/DNS-guarded;
+  reuse for the Cloud test-connect.
+- Optional cost sync (new): `apps/dashboard/src/lib/ch-cloud/billing-sync.ts` (new) — only if
+  a Cloud billing/usage source is available.
+
+## Goal
+
+The add-host dialog offers a "ClickHouse Cloud" preset that pre-fills TLS-on, port 8443, and
+service-hostname hints so a Cloud service connects on the first try; validation confirms
+reachability through the existing guarded path; and an **optional** Cloud cost sync populates
+a cost-aware card used by cost-aware alerts. Self-host paths are unchanged.
+
+## Implement now (depth F — file-level)
+
+### A. Cloud preset in the dialog — `components/connections/add-host-dialog.tsx`
+- Add a connection-type selector (or preset button): **Self-hosted** (default, current
+  behavior) vs. **ClickHouse Cloud**.
+- When "ClickHouse Cloud" is chosen, apply these **TLS presets** to the form defaults:
+  - `secure = true` (TLS/HTTPS on) — non-negotiable for Cloud.
+  - `port = 8443` (HTTPS native/interface port; verify the app's port field semantics — HTTP
+    interface vs. native — and set the correct Cloud default, 8443 for HTTPS).
+  - Hostname hint/placeholder for the Cloud service pattern (e.g.
+    `<service-id>.<region>.<cloud>.clickhouse.cloud`) with helper text: "Paste your Cloud
+    service hostname; username is usually `default`."
+  - Disable/hide the "allow insecure" affordance for the Cloud preset (Cloud requires TLS).
+- Keep all existing self-host fields and behavior intact when the self-host preset is active.
+
+### B. Validation — reuse the guarded connect path
+- On "Test / Add", call the existing `user-connections` create/validate route (verify path)
+  **unchanged** so the connection still flows through DNS-pinning/SSRF guard. Surface a
+  Cloud-specific error hint if the failure looks like a TLS/port mismatch (e.g. "ClickHouse
+  Cloud requires TLS on port 8443").
+- Do NOT special-case the network path to bypass the guard — only the *defaults* and *hints*
+  differ for Cloud.
+
+### C. Optional Cloud cost sync — `src/lib/ch-cloud/billing-sync.ts` (new)
+- Gate behind explicit configuration (env/flag; off by default — fail-open, OSS untouched).
+- If enabled and credentials present, fetch usage/cost from the ClickHouse Cloud API through
+  the existing SSRF-guarded fetch, cache it, and expose it to a cost card used by cost-aware
+  alerts. Validate the API endpoint URL.
+- If disabled or unauthenticated: the cost card is simply absent — **honest claims** (no
+  placeholder numbers).
+
+### D. Docs
+- Document the Cloud preset (TLS/8443/hostname) and the optional cost sync
+  (env + what it populates) in the connect/onboarding docs.
+
+## STOP conditions & drift check
+
+- STOP if a Cloud preset already exists in the dialog — reconcile, don't duplicate.
+- STOP if adding the cost sync would require an unguarded outbound fetch — defer the sync and
+  ship the preset alone rather than bypassing the SSRF guard.
+- DRIFT: verify the port-field semantics before hardcoding 8443 — if the field is the native
+  secure port (9440) vs. HTTPS interface (8443), set the value that matches how the app's
+  client actually connects. Do not guess; `(verify)` against `@chm/clickhouse-client`.
+- Do NOT alter the self-host default path. Do NOT gate the preset behind Clerk/billing.
+
+## Verification
+
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/components/connections --isolate
+cd apps/dashboard && bun run lint
+```
+
+Targeted test: assert selecting the ClickHouse Cloud preset sets `secure=true` + the correct
+Cloud port + the hostname placeholder, and that the self-host preset leaves current defaults
+unchanged. If a cost-sync module is added, add
+`src/lib/ch-cloud/billing-sync.test.ts` asserting it is a no-op when unconfigured.
+
+## Done criteria
+
+- The add-host dialog offers a ClickHouse Cloud preset with TLS-on + correct port +
+  hostname hints; a Cloud service connects on the first try through the existing guarded path.
+- Self-host connect behavior is unchanged and remains the default.
+- Optional Cloud cost sync (when configured) populates a cost card via the SSRF-guarded
+  fetch; absent config, no card and no fake data.
+- Preset test passes; monorepo `bun run build` is green.
+
+Priority: P1 · Effort: M · Depth: F · Wave: I (Integrations) · Lever: Revenue / Adoption

--- a/plans/42-kafka-consumer-control.md
+++ b/plans/42-kafka-consumer-control.md
@@ -1,0 +1,181 @@
+# 42 — Kafka Consumer Control (gated pause/resume/offset via SSRF-guarded broker admin proxy)
+
+> **Executor instructions**: Follow this plan step by step. Run every verification
+> command and confirm the expected result before moving on. If a STOP condition
+> occurs, stop and report — do not improvise. When done, update this plan's status
+> row in `plans/README.md`.
+
+## Kickoff prompt
+
+```text
+Execute plans/42-kafka-consumer-control.md ALONE (Wave I, integrations).
+Goal: turn the read-only Kafka UI into a gated control surface — pause/resume a
+consumer group and reset its offsets — only when an admin broker is explicitly
+configured. Invariants you MUST hold:
+- Self-hosted/OSS stays whole; the feature is OFF by default and fails open
+  (no admin env ⇒ read-only UI exactly as today, no 500s).
+- Controls are DESTRUCTIVE ops → keep them ACK-gated (confirm dialog) and
+  auth-gated (server route), and AUDIT every action (who/what/when/result).
+- New outbound (broker admin) MUST route through the existing SSRF guard
+  (createHostValidationFetch / host-validation), same as user-connections.
+- Honest claims: controls render ONLY when KAFKA_ADMIN_BROKER is set; otherwise
+  the endpoint returns 403 and the UI shows read-only state.
+- Postgres/multi-DB: NO. Do not add a DB backend.
+Files: routes/(dashboard)/kafka-consumers.tsx, new
+routes/api/v1/kafka/consumers/$group.ts, SSRF-guarded broker admin client, env
+KAFKA_ADMIN_BROKER. End by running: cd apps/dashboard && bun run type-check &&
+bun run build && bun test src/lib/kafka --isolate && bun run lint.
+```
+
+## Current reality (audited)
+
+Per ROADMAP §2 (Integrations) and §4 spec 42: the Kafka UI is **read-only** today —
+it shows consumer groups, lag, and members but exposes no control affordances. Ops
+teams routinely need to **pause/resume** a stuck consumer or **reset offsets** after a
+bad deploy, and today they must drop to `kafka-consumer-groups.sh` on a bastion. The
+read path already exists; this plan adds a *conditional, audited* control path.
+
+Pointers (confirm exact paths with `rg`, mark `(verify)` if they differ):
+- `apps/dashboard/src/routes/(dashboard)/kafka-consumers.tsx` — the read-only page. (verify)
+- Existing Kafka read client / data loader under `src/lib/kafka/` or an integrations
+  dir — reuse its broker connection config for the read side. (verify)
+- SSRF guard: `createHostValidationFetch` / host-validation helper already used by
+  `routes/api/v1/user-connections.ts` and the browser-connection proxy. Reuse it. (verify)
+- Audit sink: reuse whatever plan 22 (`audit_logs` / `lib/audit/logEvent`) lands, if
+  present; otherwise write a structured `console`/log line + return the action record
+  in the response so the UI can show it. Do NOT invent a new D1 table here. (verify)
+
+## Goal
+
+When (and only when) an operator sets `KAFKA_ADMIN_BROKER`, expose three gated,
+audited consumer-group actions — **pause**, **resume**, **reset-offset** — behind an
+authenticated server route that proxies to the Kafka admin API through the SSRF guard,
+with a confirm (ACK) dialog in the UI. With no admin broker configured, behavior is
+byte-for-byte the current read-only experience.
+
+## Implement now (F — file-level)
+
+### Env / feature gate
+
+- New server env `KAFKA_ADMIN_BROKER` (host:port of the admin bootstrap broker;
+  comma-list allowed). Read it in `server-*` config the same way other server-only
+  secrets are read (never expose to the client bundle).
+- Optional `KAFKA_ADMIN_SASL_*` / `KAFKA_ADMIN_TLS` passthrough envs for auth if the
+  read client already supports them — mirror its option shape, don't reinvent.
+- Derive a boolean `isKafkaAdminEnabled()` = `KAFKA_ADMIN_BROKER` is set. Export it so
+  both the route (to 403 early) and a client-safe capability flag can use it.
+
+### Broker admin client — `src/lib/kafka/admin-client.ts` (new)
+
+Signatures (KafkaJS-style admin, adapt to the installed client):
+
+```ts
+export interface KafkaAdminAction {
+  group: string
+  action: 'pause' | 'resume' | 'reset-offset'
+  // reset-offset only:
+  topic?: string
+  to?: 'earliest' | 'latest' | { partition: number; offset: string }[]
+}
+export interface KafkaAdminResult {
+  ok: boolean
+  group: string
+  action: KafkaAdminAction['action']
+  applied?: { topic: string; partition: number; offset: string }[]
+  error?: string
+}
+export async function runKafkaAdminAction(a: KafkaAdminAction): Promise<KafkaAdminResult>
+```
+
+- Resolve broker(s) from `KAFKA_ADMIN_BROKER`; **validate each host through the SSRF
+  guard** before connecting (reject private/link-local unless `CHM_ALLOW_PRIVATE_HOSTS`
+  — mirror `user-connections` exactly). If validation fails → `{ ok:false, error }`.
+- `pause`/`resume`: KafkaJS has no server-side "pause a group"; implement as the
+  supported analog — for `reset-offset` use `admin.setOffsets` / `resetOffsets`; for
+  pause/resume, if the installed client can't do it broker-side, **return a typed
+  `not-supported` error** rather than faking it (honest claims). (verify against the
+  installed Kafka client's capabilities.)
+- Always `admin.disconnect()` in a `finally`.
+
+### Server route — `routes/api/v1/kafka/consumers/$group.ts` (new)
+
+- `POST` handler. Steps, in order:
+  1. Resolve user (`resolveUserId()` / existing auth helper). Unauthenticated → 401.
+  2. `if (!isKafkaAdminEnabled()) return 403` with `createApiErrorResponse` (match the
+     shape used elsewhere, e.g. `conversations/$id.ts:236`) — message
+     `'Kafka admin controls are not enabled on this server.'`.
+  3. Parse + validate body (Zod): `{ action, topic?, to? }`; whitelist `action` to the
+     three literals; reject anything else with 400.
+  4. `const result = await runKafkaAdminAction({ group, ...body })`.
+  5. **Audit** the attempt AND outcome: `logEvent({ user, event:'kafka.consumer.'+action,
+     resource: group, action, result: result.ok ? 'ok':'error', details:{ topic, to } })`
+     (or structured log if plan 22 not present).
+  6. Return `result` (200 on ok, 502 on broker error with sanitized message — do not
+     leak raw broker stack traces; reuse `sanitizeClickHouseError`-style helper or a
+     local sanitizer). (verify)
+- No `GET` here (reads stay on the existing loader).
+
+### UI — extend `routes/(dashboard)/kafka-consumers.tsx`
+
+- Fetch a client-safe capability flag (`kafkaAdminEnabled`) from the loader/root data;
+  do NOT read the broker env in the client.
+- When `!kafkaAdminEnabled`: render exactly as today (read-only). Optionally a subtle
+  "Controls disabled — set `KAFKA_ADMIN_BROKER` to enable" hint.
+- When enabled: per consumer-group row add a small actions menu → **Pause**, **Resume**,
+  **Reset offset…**. Each opens a **confirm (ACK) dialog** stating the group, the action,
+  and (for reset) the target (`earliest`/`latest`); on confirm `POST` to the route.
+- Show the returned `KafkaAdminResult` (applied offsets or error) inline; refetch the
+  read loader after a successful action.
+
+### Tests — `src/lib/kafka/admin-client.test.ts` (new, Bun test)
+
+- Mock the admin client. Assert:
+  - `runKafkaAdminAction` rejects a private/link-local broker via the SSRF guard
+    (returns `{ ok:false }`, never connects) when private hosts disallowed.
+  - `reset-offset` calls the underlying `setOffsets`/`resetOffsets` with the mapped args.
+  - `disconnect()` is always called (even on throw).
+- Route test (optional, if a route-test harness exists): 403 when `KAFKA_ADMIN_BROKER`
+  unset; 400 on an unknown `action`.
+
+## STOP conditions & drift check
+
+Drift check (run first):
+`git diff --stat -- apps/dashboard/src/routes/(dashboard)/kafka-consumers.tsx apps/dashboard/src/lib/kafka` — if the read page or Kafka lib changed materially since this
+plan was written, reconcile the pointers before coding.
+
+STOP and report if:
+- There is **no** existing SSRF host-validation helper to reuse (do NOT ship broker
+  admin without it — that's a new unguarded outbound).
+- The installed Kafka client cannot perform even offset reset server-side (then the
+  whole control surface is `not-supported`; report rather than fake it).
+- Enabling the route would change behavior when `KAFKA_ADMIN_BROKER` is unset (the
+  OSS/self-host fail-open invariant must hold).
+- More than the listed files must change (e.g. a new D1 migration is required) — the
+  spec scopes this to route + client + UI + env only.
+
+## Verification
+
+```bash
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/kafka --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+
+ALL must hold:
+- [ ] With `KAFKA_ADMIN_BROKER` unset: page is read-only; the route returns 403; no
+      behavior change vs today (fail-open verified).
+- [ ] With it set: pause/resume/reset-offset work via the route, each behind a confirm
+      (ACK) dialog and each **audited** (actor/action/result recorded).
+- [ ] All outbound broker connections pass through the SSRF guard; private/link-local
+      hosts rejected unless explicitly allowed.
+- [ ] **Safety**: no action auto-applies without the confirm dialog; the endpoint is
+      auth-gated; no existing read path or query plan is altered; no destructive default.
+- [ ] `type-check`, `build`, `bun test src/lib/kafka --isolate`, `lint` all exit 0.
+- [ ] No files outside the listed scope modified; `plans/README.md` row updated.
+
+---
+
+Priority **P2** · Effort **M** · Depth **F** · Wave **I** · Lever **Adoption/Enterprise**

--- a/plans/43-mcp-custom-server-registry.md
+++ b/plans/43-mcp-custom-server-registry.md
@@ -1,0 +1,170 @@
+# 43 — MCP Custom Server Registry (register external MCP servers, per-user, usable in the agent)
+
+> **Executor instructions**: Follow this plan step by step. Run every verification
+> command and confirm the expected result before moving on. If a STOP condition
+> occurs, stop and report — do not improvise. When done, update this plan's status
+> row in `plans/README.md`.
+
+## Kickoff prompt
+
+```text
+Execute plans/43-mcp-custom-server-registry.md ALONE (Wave I, integrations).
+Goal: let a user register external MCP servers (URL + auth + transport), persist
+them in D1, validate connectivity/capabilities, and load them per-user alongside
+the built-in tools at conversation start — with a template library
+(Slack/GitHub/Datadog). Invariants you MUST hold:
+- Self-hosted/OSS stays whole; feature fails open — no Clerk ⇒ single-user 'guest'
+  scope still works; a bad/unreachable custom server degrades gracefully (agent
+  runs with built-ins only, never 500s the conversation).
+- SSRF-guard the new outbound: every registered MCP URL is validated through the
+  existing host-validation guard before connect (this is exactly SEC-04's concern —
+  do NOT ship an unguarded fetch/transport).
+- Per-user isolation: one user's servers/credentials are never loaded for another.
+- Honest claims: capabilities shown are what the server actually advertised on a
+  successful validate; on failure say so.
+- Postgres/multi-DB: NO new backend beyond the existing D1 store pattern.
+Files: new routes/api/v1/mcp/{connect,servers}.ts, extend
+src/lib/ai/agent/mcp/connect-custom-servers.ts, new D1 table
+mcp_server_registrations, routes/(dashboard)/agents/mcp-server-manager.tsx.
+End by running: cd apps/dashboard && bun run type-check && bun run build &&
+bun test src/lib/ai/agent/mcp --isolate && bun run lint.
+```
+
+## Current reality (audited)
+
+Per ROADMAP §2 and §4 spec 43: a **placeholder UI exists** but users cannot actually
+register external MCP servers — the agentic-ecosystem play is unfinished. The audit
+also flags **SEC-04** (custom-server transport unpinned) and **DOC-01** (a stale
+"custom MCP not yet wired" comment) — both live in this surface, so wire it correctly
+(SSRF-guarded) and fix the comment while here.
+
+Pointers (confirm with `rg`, mark `(verify)`):
+- `src/lib/ai/agent/mcp/connect-custom-servers.ts` — the connect path (SEC-04 notes
+  unpinned transport around `:110,287`). Reuse/extend this, don't fork it. (verify)
+- Agent tool assembly at conversation start (`src/lib/ai/agent/…` / `routes/api/v1/agent.ts`
+  around `:50`) — where built-in tools are gathered; inject per-user custom tools here. (verify)
+- Conversation/D1 store pattern (`src/lib/conversation-store/d1-store.ts` and its
+  migration under `db/…-migrations/`) — mirror it for the new table + migration. (verify)
+- SSRF guard: `createHostValidationFetch` / host-validation (same as `user-connections`). (verify)
+- Placeholder UI: `components/agents/welcome/agent-mcp-panel.tsx` (holds the DOC-01
+  stale comment at `:18`) and/or an `mcp-server-manager` route. (verify)
+
+## Goal
+
+A user registers an external MCP server (name, URL, transport, optional auth header/token);
+chmonitor validates connectivity + lists the server's tools, stores the registration in
+D1 scoped to that user, and at each conversation start loads the user's *enabled* servers
+through the SSRF-guarded transport so their tools are callable by the agent — with a
+one-click template library for common servers.
+
+## Implement now (F — file-level)
+
+### D1 table — `mcp_server_registrations` (new migration)
+
+Mirror the conversations migration style. Columns:
+`id TEXT PK, user_id TEXT NOT NULL, name TEXT NOT NULL, url TEXT NOT NULL,
+transport TEXT NOT NULL /* 'http' | 'sse' */, auth_kind TEXT /* 'none'|'bearer'|'header' */,
+auth_secret TEXT /* encrypted-at-rest or stored per existing secret convention */,
+auth_header_name TEXT, enabled INTEGER NOT NULL DEFAULT 1,
+capabilities_json TEXT /* cached tool list from last successful validate */,
+last_validated_at INTEGER, created_at INTEGER, updated_at INTEGER`.
+Index on `user_id`. **Do not** store secrets in plaintext if the repo has a secret
+convention — follow it. (verify)
+
+### Store — `src/lib/ai/agent/mcp/registration-store.ts` (new)
+
+CRUD scoped by `userId` (mirror `d1-store.ts` scoping — every read/write `WHERE user_id=?`;
+this is the per-user isolation control):
+```ts
+listForUser(userId): Promise<McpRegistration[]>
+get(userId, id): Promise<McpRegistration | null>
+upsert(reg: McpRegistration): Promise<{ written: boolean }>   // owner-guarded, like plan 04
+remove(userId, id): Promise<{ deleted: boolean }>
+```
+
+### Validate/connect — extend `connect-custom-servers.ts`
+
+- `validateServer(reg): Promise<{ ok: boolean; tools?: McpToolInfo[]; error?: string }>`:
+  1. **SSRF-guard** `reg.url` (reject private/link-local unless `CHM_ALLOW_PRIVATE_HOSTS`).
+  2. Open the MCP client over `reg.transport` **using the host-validated fetch** (this
+     closes SEC-04 — the transport must be pinned/guarded, not a raw fetch).
+  3. List tools; return them; **always close the client** (fixes the BUG-03 class here —
+     close on success AND on throw, in `finally`).
+- `loadUserCustomServers(userId): Promise<LoadedMcpTool[]>`: read enabled registrations,
+  connect each guarded, collect tools; **on any single-server failure, skip it and
+  continue** (graceful degrade — the conversation still runs with built-ins).
+
+### Agent wiring
+
+At conversation start, after gathering built-in tools, append
+`await loadUserCustomServers(userId)`. Namespace custom tool names to avoid collision
+with built-ins. Ensure every opened custom client is closed when the agent
+request ends OR throws (including the 402/pre-stream path — the BUG-03 concern).
+
+### Routes
+
+- `routes/api/v1/mcp/connect.ts` (new): `POST { url, transport, auth… }` → runs
+  `validateServer` and returns `{ ok, tools }` **without persisting** (a "test before
+  save" probe). 401 if unauthenticated.
+- `routes/api/v1/mcp/servers.ts` (new): `GET` list (user-scoped), `POST` create
+  (validate then `upsert`), `PATCH` enable/disable/rename, `DELETE` remove. All
+  user-scoped; all reuse `createApiErrorResponse` shape.
+
+### UI — `routes/(dashboard)/agents/mcp-server-manager.tsx`
+
+- List the user's servers with status (enabled, last-validated, tool count).
+- "Add server" form (name/URL/transport/auth) with a **Test connection** button
+  (calls `/mcp/connect`) that shows the advertised tools before saving.
+- **Template library**: buttons that prefill the form for Slack / GitHub / Datadog MCP
+  endpoints (URL + expected auth kind), user still supplies their own token.
+- Remove the DOC-01 stale "not yet wired" comment in the placeholder panel.
+
+### Tests — `src/lib/ai/agent/mcp/*.test.ts` (Bun)
+
+- `registration-store`: per-user isolation (user B cannot read/modify user A's rows);
+  owner-guarded upsert returns `{written:false}` on foreign id.
+- `connect-custom-servers`: private-host URL is rejected by the SSRF guard (no connect);
+  a failing server is skipped by `loadUserCustomServers` (built-ins still returned);
+  client is closed on throw.
+
+## STOP conditions & drift check
+
+Drift check (run first):
+`git diff --stat -- apps/dashboard/src/lib/ai/agent/mcp apps/dashboard/src/routes/api/v1/agent.ts` — reconcile pointers if this area changed.
+
+STOP and report if:
+- No SSRF host-validation helper exists to guard the MCP transport (do not ship an
+  unguarded custom-server fetch — that is SEC-04 unresolved).
+- The MCP client library in use cannot be driven over a host-validated fetch/transport
+  (report the constraint rather than dropping the guard).
+- Registering a server can leak one user's tools/credentials into another user's
+  conversation (isolation must hold) — stop and fix the scoping first.
+- The change requires more than the listed files (e.g. altering the built-in tool set).
+
+## Verification
+
+```bash
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/ai/agent/mcp --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+
+ALL must hold:
+- [ ] A user can register, test, enable/disable, and remove external MCP servers; rows
+      are D1-persisted and **strictly user-scoped**.
+- [ ] Registered servers' tools are usable by the agent at conversation start; a broken
+      server degrades gracefully (built-ins still work; no 500).
+- [ ] Every registered MCP URL is SSRF-guarded before connect; clients are always closed
+      (success and throw), including the pre-stream/402 path.
+- [ ] Template library prefills Slack/GitHub/Datadog; DOC-01 stale comment removed.
+- [ ] **Safety**: no custom server auto-loads for a user who didn't register it; no
+      unguarded outbound; validation claims reflect the server's real advertised tools.
+- [ ] `type-check`, `build`, `bun test src/lib/ai/agent/mcp --isolate`, `lint` all exit 0.
+- [ ] No files outside scope modified; `plans/README.md` row updated.
+
+---
+
+Priority **P1** · Effort **M** · Depth **F** · Wave **I** · Lever **Adoption/Ecosystem**

--- a/plans/44-webhook-event-bus-outbound.md
+++ b/plans/44-webhook-event-bus-outbound.md
@@ -1,0 +1,179 @@
+# 44 — Outbound Webhook Event Bus (subscribe by event type, HMAC-signed, retried, SSRF-guarded)
+
+> **Executor instructions**: Follow this plan step by step. Run every verification
+> command and confirm the expected result before moving on. If a STOP condition
+> occurs, stop and report — do not improvise. When done, update this plan's status
+> row in `plans/README.md`.
+
+## Kickoff prompt
+
+```text
+Execute plans/44-webhook-event-bus-outbound.md ALONE (Wave I, integrations).
+Goal: generalize outbound webhooks from "alerts only" to a configurable bus — a
+user subscribes a URL to one or more event types (findings/insights/alerts/
+connections), and chmonitor delivers HMAC-signed payloads with retry/backoff and a
+dead-letter log. Invariants you MUST hold:
+- Self-hosted/OSS stays whole; feature fails open — no subscriptions ⇒ no behavior
+  change; delivery failures never break the emitting request path.
+- SSRF-guard the new outbound: every subscription URL is validated through the
+  existing host-validation guard before delivery (reuse the alert webhook proxy's
+  guard — do NOT add a raw fetch).
+- Honest claims: only event types actually emitted are offered in the UI.
+- Signed + verifiable: HMAC-SHA256 over the raw body with a per-subscription secret;
+  include timestamp + signature headers so receivers can verify and dedupe.
+- Postgres/multi-DB: NO new backend beyond the existing D1 store pattern.
+Files: new src/lib/events/outbound-bus.ts, D1 table webhook_subscriptions, new
+routes/api/v1/webhooks/subscriptions.ts (CRUD), emit hooks across
+findings/insights/alerts/connections, reuse the existing SSRF guard.
+End by running: cd apps/dashboard && bun run type-check && bun run build &&
+bun test src/lib/events --isolate && bun run lint.
+```
+
+## Current reality (audited)
+
+Per ROADMAP §2 and §4 spec 44: outbound webhooks fire **only for alerts** today (via
+the SSRF-guarded alert webhook proxy). A configurable bus that can fire on *any* event
+unlocks integrations without bespoke code per consumer. The alert delivery path already
+proves the pattern (SSRF guard + adapters); this plan factors an event-type-subscribed,
+signed, retried delivery layer over it.
+
+Pointers (confirm with `rg`, mark `(verify)`):
+- Existing alert webhook delivery + SSRF-guarded proxy under `src/lib/health/` (adapters,
+  the generic webhook adapter, and the outbound proxy route). Reuse the guard + the
+  signing/HTTP helpers. (verify)
+- SSRF guard: `createHostValidationFetch` / host-validation. (verify)
+- D1 store + migration pattern: `src/lib/conversation-store/d1-store.ts` +
+  `db/…-migrations/`. Mirror for `webhook_subscriptions`. (verify)
+- Event emission sites: the alert sweep (`evaluateAlert`), the insights engine
+  (`src/lib/insights/…`), connection mutations (`routes/api/v1/user-connections.ts`).
+  These are where `emit(...)` hooks go. (verify)
+
+## Goal
+
+A user subscribes a destination URL to a filtered set of event types; chmonitor emits
+those events onto an outbound bus that delivers **HMAC-signed** payloads with
+**retry/backoff**, records failures in a **dead-letter** log, and is **SSRF-guarded** —
+all without touching or slowing the code paths that produce the events.
+
+## Implement now (F — file-level)
+
+### D1 tables (new migration)
+
+`webhook_subscriptions`:
+`id TEXT PK, user_id TEXT NOT NULL, url TEXT NOT NULL, secret TEXT NOT NULL,
+event_types TEXT NOT NULL /* JSON array, e.g. ["alert.fired","finding.created"] */,
+enabled INTEGER NOT NULL DEFAULT 1, created_at INTEGER, updated_at INTEGER`
+(index on `user_id`).
+
+`webhook_deliveries` (dead-letter + audit):
+`id TEXT PK, subscription_id TEXT NOT NULL, event_type TEXT NOT NULL,
+status TEXT NOT NULL /* 'delivered'|'failed'|'dead' */, attempts INTEGER NOT NULL,
+last_status_code INTEGER, last_error TEXT, event_time INTEGER, delivered_at INTEGER`
+(index on `subscription_id, event_time`).
+
+### Event taxonomy — `src/lib/events/event-types.ts` (new)
+
+Enumerate the emittable types as a const union so UI + validation share one source:
+`'alert.fired' | 'alert.resolved' | 'finding.created' | 'insight.created' |
+'connection.created' | 'connection.deleted'` (extend to match real producers — only
+list ones actually wired). Export a typed `EventPayload<T>` envelope:
+`{ id, type, occurred_at, host_id?, data: unknown }`.
+
+### Bus — `src/lib/events/outbound-bus.ts` (new)
+
+```ts
+export async function emitEvent(userId: string, evt: EventPayload): Promise<void>
+// look up enabled subscriptions for userId whose event_types include evt.type;
+// for each, enqueue/deliver (see below). Must NEVER throw into the caller —
+// wrap in try/catch; log + record dead-letter on failure. Fire-and-forget from
+// the producer's perspective (do not block/slow the emitting request).
+
+async function deliver(sub, evt): Promise<void>
+// 1. SSRF-guard sub.url (reject private/link-local unless CHM_ALLOW_PRIVATE_HOSTS).
+// 2. body = JSON.stringify(evt); sig = HMAC_SHA256(sub.secret, body).
+// 3. POST with headers:
+//    X-Chmonitor-Event: evt.type
+//    X-Chmonitor-Delivery: evt.id
+//    X-Chmonitor-Timestamp: <ms>
+//    X-Chmonitor-Signature: sha256=<hex>
+// 4. Retry on network error / 5xx / 429 with exponential backoff (e.g. 3 tries:
+//    0s, 2s, 8s — bounded; do NOT retry 4xx except 429). Respect Workers time limits.
+// 5. Record final outcome in webhook_deliveries (status delivered/failed/dead).
+```
+
+On Cloudflare Workers, use `ctx.waitUntil(...)` (or the existing alert-delivery
+mechanism) so delivery outlives the response without blocking it. (verify the exact
+mechanism the alert path uses and reuse it.)
+
+### Emit hooks (thin, non-blocking)
+
+At each producer, after the primary write succeeds, call `emitEvent(userId, {...})`:
+- alert sweep on fire/resolve → `alert.fired` / `alert.resolved`.
+- insights engine on new finding/insight → `finding.created` / `insight.created`.
+- connection create/delete → `connection.created` / `connection.deleted`.
+Guard each call so a bus failure cannot fail the producer (the invariant).
+
+### Routes — `routes/api/v1/webhooks/subscriptions.ts` (new)
+
+`GET` list (user-scoped), `POST` create (validate URL via SSRF guard **at create time**
+too, generate a secret, persist), `PATCH` (enable/disable, edit event_types/url),
+`DELETE`. Optional `POST /:id/test` sends a signed `ping` event so the user can verify
+their receiver. All user-scoped; reuse `createApiErrorResponse`.
+
+### UI
+
+Add a "Webhook subscriptions" surface (in the existing integrations/health settings area,
+`(verify)` best home): list subscriptions with last-delivery status, add/edit form
+(URL + multi-select event types), reveal-once secret, "Send test" button, and a
+recent-deliveries / dead-letter view sourced from `webhook_deliveries`.
+
+### Tests — `src/lib/events/*.test.ts` (Bun)
+
+- HMAC signature is computed over the exact raw body and matches an independent verify.
+- SSRF guard rejects a private-host subscription URL (no POST attempted).
+- Retry/backoff: a mocked 500-then-200 delivers on retry and records `attempts=2`;
+  a persistent 500 records `status='dead'`.
+- `emitEvent` never throws even when delivery fails (producer isolation).
+- Subscription store is user-scoped (owner-guarded upsert like plan 04).
+
+## STOP conditions & drift check
+
+Drift check (run first):
+`git diff --stat -- apps/dashboard/src/lib/health apps/dashboard/src/lib/insights apps/dashboard/src/routes/api/v1/user-connections.ts` — reconcile pointers if these changed.
+
+STOP and report if:
+- No SSRF host-validation helper exists to reuse (do not add an unguarded outbound bus).
+- The alert path's delivery/`waitUntil` mechanism can't be reused for generic events
+  (report before inventing a divergent one).
+- Adding an emit hook would block or can throw into a producer's critical path (the
+  non-blocking, fail-open invariant must hold) — fix the isolation first.
+- The work needs more than the listed files (e.g. a queue consumer — that's plan 36's
+  *inbound* bus; keep this one direct-delivery unless the alert path already queues).
+
+## Verification
+
+```bash
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/events --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+
+ALL must hold:
+- [ ] A user can subscribe a URL to specific event types; enabled subscriptions receive
+      **HMAC-signed** payloads for those events with verifiable signature + timestamp headers.
+- [ ] Delivery retries with bounded backoff; persistent failures land in a dead-letter
+      log surfaced in the UI.
+- [ ] Every delivery is SSRF-guarded; private/link-local URLs rejected at create and send.
+- [ ] Producers are unaffected: with no subscriptions there is zero behavior change, and
+      a delivery failure never fails or slows the emitting request.
+- [ ] **Safety**: the bus only sends; it triggers no destructive action and applies no
+      DDL; subscriptions are strictly user-scoped; no plan/query path altered.
+- [ ] `type-check`, `build`, `bun test src/lib/events --isolate`, `lint` all exit 0.
+- [ ] No files outside scope modified; `plans/README.md` row updated.
+
+---
+
+Priority **P1** · Effort **M** · Depth **F** · Wave **I** · Lever **Ecosystem/Adoption**

--- a/plans/45-github-deploy-correlation.md
+++ b/plans/45-github-deploy-correlation.md
@@ -1,0 +1,149 @@
+# 45 — GitHub Deploy Correlation (ingest deployment webhooks, overlay deploy markers on the query-volume timeline)
+
+> **Executor instructions**: Follow this plan step by step. Run every verification
+> command and confirm the expected result before moving on. If a STOP condition
+> occurs, stop and report — do not improvise. When done, update this plan's status
+> row in `plans/README.md`. This is an **epic-brief (E)**: do the discovery in
+> "Open questions" *before* writing code, then implement.
+
+## Kickoff prompt
+
+```text
+Execute plans/45-github-deploy-correlation.md ALONE (Wave I, integrations).
+Goal: ingest GitHub deployment webhooks, store repo/env/version/timestamp in D1,
+and overlay deploy markers on the query-volume timeline so SREs can correlate query
+spikes / replication lag with releases. Invariants you MUST hold:
+- Self-hosted/OSS stays whole; feature fails open — no webhook configured ⇒ no
+  markers, no behavior change.
+- SSRF is inbound here, so the control is INBOUND AUTH: verify the GitHub webhook
+  HMAC signature (X-Hub-Signature-256) and reject unsigned/mismatched payloads.
+- Honest claims: markers reflect only verified, stored deployments.
+- Recommend/observe only — this feature never triggers or changes deployments.
+- Postgres/multi-DB: NO new backend beyond the existing D1 store pattern.
+This is depth E: FIRST resolve the open questions (which timeline chart, how deploys
+map to a host/org, secret storage) against the live repo, then build:
+new routes/api/v1/webhooks/github.ts, D1 table github_deployments, a timeline
+overlay in the query-history charts. End by running:
+cd apps/dashboard && bun run type-check && bun run build &&
+bun test src/lib/deployments --isolate && bun run lint.
+```
+
+## Current reality (audited)
+
+Per ROADMAP §2 and §4 spec 45: correlating query spikes / lag with releases is
+high-value SRE context that chmonitor doesn't offer yet. The building blocks exist —
+signature-verified webhooks (the Polar and Clerk webhook handlers already do HMAC/verify),
+a D1 store pattern, and query-history/volume charts — so this is assembly + a chart overlay,
+not new infra.
+
+Pointers (confirm with `rg`, mark `(verify)`):
+- Existing verified webhook handlers to mirror for signature checking:
+  `routes/api/v1/webhooks/polar.ts` (signature + idempotency) and `…/clerk.ts`
+  (`verifyWebhook`). Copy the verify-then-act shape. (verify)
+- D1 store + migration pattern: `src/lib/conversation-store/d1-store.ts` +
+  `db/…-migrations/`. Mirror for `github_deployments`. (verify)
+- Query-volume / query-history timeline chart component(s) under
+  `components/charts/…` or the query-history route — the overlay target. **Identify the
+  exact chart before coding** (see Open questions). (verify)
+
+## Goal
+
+GitHub POSTs deployment (or deployment_status) events → chmonitor verifies the signature,
+stores `{repo, environment, version/ref, sha, created_at}` in D1 → the query-volume
+timeline renders vertical deploy markers (hover shows repo/env/version) and offers a
+"filter to this deploy window" affordance; a small API lists recent deployments.
+
+## Implement now (E — approach + key files + open questions)
+
+### Approach
+
+1. **Ingest** `routes/api/v1/webhooks/github.ts` (new, `POST`):
+   - Read the raw body; compute `HMAC_SHA256(secret, rawBody)`; compare in constant time
+     to the `X-Hub-Signature-256` header (`sha256=` prefix). Reject (401) on
+     missing/mismatch — mirror the Polar/Clerk verify path exactly. Secret from env
+     `GITHUB_WEBHOOK_SECRET`.
+   - Handle the `deployment` and/or `deployment_status` events (ignore others with 204).
+     Extract `repository.full_name`, `deployment.environment`,
+     `deployment.ref`/`payload.version`, `deployment.sha`, `created_at`.
+   - Idempotency: dedupe on GitHub's `deployment.id` (unique) so redeliveries don't
+     double-insert — mirror the Polar idempotency guard.
+   - `upsert` into `github_deployments`.
+
+2. **Store** — D1 migration `github_deployments`:
+   `id TEXT PK /* github deployment id */, owner_scope TEXT /* org/user or host mapping */,
+   repo TEXT NOT NULL, environment TEXT, ref TEXT, sha TEXT, version TEXT,
+   created_at INTEGER NOT NULL, received_at INTEGER NOT NULL` (index on
+   `owner_scope, created_at`).
+
+3. **Read API** — a `GET` (in the same route file or `routes/api/v1/deployments.ts`)
+   returning recent deployments filtered by time range + scope, for the chart overlay.
+
+4. **Overlay** — in the identified query-volume timeline chart: fetch deployments for the
+   visible time range and render vertical reference lines/markers at each `created_at`
+   (hover tooltip: repo · env · version/sha). Add a "filter to deploy window" control
+   that sets the chart's time range to [deploy, deploy+N min] (reuse the chart's existing
+   time-range mechanism — do not build a new one).
+
+### Open questions (resolve against the live repo BEFORE coding)
+
+- **Which chart is "the query-volume timeline"?** Find the concrete component that plots
+  query volume over time (likely a factory chart on the query-history page). The overlay
+  must attach to *that* chart's axis/time-range, not a new canvas. Name it in the plan
+  before editing. (verify)
+- **How does a GitHub deployment map to a chmonitor scope?** Options: (a) a global/env
+  marker shown on every timeline; (b) map `repository`/`environment` → an owner/org or a
+  specific host via a small config. Pick the simplest that's honest — likely per-owner
+  (`owner_scope`) with all repos shown, and refine later. Decide and record.
+- **Secret storage & multi-tenant:** is `GITHUB_WEBHOOK_SECRET` a single server secret
+  (self-host / single-org) or per-org? For this plan use a single env secret (fail-open,
+  self-host-first); note per-org as a follow-up if Clerk orgs each need their own.
+- **Chart lib overlay API:** does the charting lib (recharts/xyflow/etc.) support
+  reference lines out of the box, or does the overlay need a sibling SVG layer? Confirm
+  and use the native mechanism if present.
+
+### Tests — `src/lib/deployments/*.test.ts` (Bun)
+
+- Signature verify: a correctly-signed body is accepted; a tampered body / wrong secret
+  is rejected (401); missing signature rejected.
+- Idempotency: the same `deployment.id` delivered twice inserts once.
+- Store read returns deployments within a time-range filter (used by the overlay).
+
+## STOP conditions & drift check
+
+Drift check (run first):
+`git diff --stat -- apps/dashboard/src/routes/api/v1/webhooks apps/dashboard/src/components/charts` — reconcile pointers if these changed.
+
+STOP and report if:
+- You cannot identify a single concrete query-volume timeline chart to overlay onto
+  (the E-plan's core open question) — report options rather than guessing wrong.
+- The webhook cannot be signature-verified with an available HMAC helper (do not accept
+  unsigned GitHub payloads — that's the inbound-auth invariant).
+- Correlating deployments to a host/scope requires schema or auth changes beyond the
+  listed files — report the scope creep.
+
+## Verification
+
+```bash
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/deployments --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+
+ALL must hold:
+- [ ] GitHub deployment webhooks are **signature-verified** and stored (idempotently) in
+      `github_deployments`; unsigned/mismatched payloads are rejected 401.
+- [ ] The identified query-volume timeline renders deploy markers with hover detail and a
+      filter-to-deploy-window control; with no deployments the chart is unchanged.
+- [ ] A read API lists recent deployments by time range for the overlay.
+- [ ] **Safety**: the feature is observe-only — it never triggers, changes, or rolls back
+      a deployment, applies no DDL, and does not alter any query plan; fails open when no
+      webhook is configured.
+- [ ] `type-check`, `build`, `bun test src/lib/deployments --isolate`, `lint` all exit 0.
+- [ ] No files outside scope modified; `plans/README.md` row updated.
+
+---
+
+Priority **P2** · Effort **M** · Depth **E** · Wave **I** · Lever **Adoption/Ecosystem**

--- a/plans/46-query-advisor-engine.md
+++ b/plans/46-query-advisor-engine.md
@@ -1,0 +1,217 @@
+# 46 — Query Advisor Engine (slow query → ranked skip-index / projection / partition / PREWHERE DDL, recommend-only)
+
+> **Executor instructions**: Follow this plan step by step. Run every verification
+> command and confirm the expected result before moving on. If a STOP condition
+> occurs, stop and report — do not improvise. When done, update this plan's status
+> row in `plans/README.md`. This is an **epic-brief (E)** and the **strategic wedge**:
+> do the discovery in "Open questions" *before* coding, then implement.
+
+## Kickoff prompt
+
+```text
+Execute plans/46-query-advisor-engine.md ALONE (Wave AI — THE WEDGE, highest
+strategic priority). Goal: build the "pganalyze for ClickHouse" advisor — given a
+slow query (id or SQL) + EXPLAIN + schema, produce RANKED DDL recommendations
+(skip-indexes, projections, partition keys, PREWHERE) with estimated impact and
+risk. Invariants you MUST hold (non-negotiable):
+- THE ADVISOR RECOMMENDS DDL AND NEVER AUTO-APPLIES. Output is ranked DDL text +
+  risk + impact ONLY. No ALTER/CREATE is ever executed. No auto-apply button, no
+  "apply for me" tool. This is the load-bearing safety invariant of the whole wedge.
+- Recommendations must never break existing query plans: validate with EXPLAIN
+  before/after where possible; if a candidate could regress other queries, say so
+  in its risk field rather than suppressing it.
+- Self-hosted/OSS stays whole; the advisor runs read-only against system.* and
+  degrades gracefully (no crash if a system table is absent / permission-denied).
+- Meter as premium usage (billing meter) via the existing AI-usage/entitlements
+  path; fail open for self-host.
+- Honest claims: every impact number is an ESTIMATE and labeled as such.
+- SSRF-guard any new outbound (there should be none — this is CH-local + LLM).
+- Postgres/multi-DB: NO.
+This is depth E: resolve the open questions first, then build:
+new src/lib/ai/advisor/{recommendation-engine,impact-estimator,sql-rewriter}.ts,
+src/lib/ai/agent/tools/advisor-tools.ts (get_optimization_recommendations),
+packages/mcp-server/src/tools/advisor.ts, routes/(dashboard)/advisor.tsx, and
+advisor __tests__. End by running:
+cd apps/dashboard && bun run type-check && bun run build &&
+bun test src/lib/ai/advisor/__tests__ --isolate && bun run lint.
+```
+
+## Current reality (audited)
+
+Per ROADMAP §1 (positioning) and §4 spec 46: **this is the reason to choose chmonitor
+over `system.query_log` + Grafana.** Today the agent is a Tier-2 "collector + skill
+guide" — 11 real tool groups, 18 skills that give projection/index guidance **in prose
+only**, and deterministic insights with static thresholds (ROADMAP §2, AI advisor row).
+There is **no programmatic DDL recommender**. ClickHouse Cloud's "Ask AI"/"Agents" are
+Cloud-locked and analytics-first (§1) — none is an *operational advisor for self-hosted
+clusters*. Closing this gap is the wedge.
+
+Pointers (confirm with `rg`, mark `(verify)`):
+- New home: `src/lib/ai/advisor/` (create). (verify — nothing there yet)
+- Agent tools live in `src/lib/ai/agent/tools/` — add `advisor-tools.ts` alongside the
+  existing query/storage/etc. tool groups. (verify)
+- MCP server tools: `packages/mcp-server/src/tools/` — add `advisor.ts` so the advisor is
+  reachable from the built-in MCP server too. (verify)
+- Insights collectors (`src/lib/insights/collectors.ts`) — a model for reading `system.*`
+  read-only; the advisor reads similarly. (verify)
+- ClickHouse client: `@chm/clickhouse-client` — used read-only for EXPLAIN / schema /
+  `system.parts` / `system.columns` / `system.query_log`. (verify)
+- Optional: `rust/monitor-core` WASM if any scoring is better done there (optional; the
+  spec says "optionally reuse"). (verify)
+
+## Goal
+
+Given a slow query (by `query_id` from `system.query_log`, or raw SQL) plus its EXPLAIN
+plan and the table schema, the engine scores candidate optimizations across four
+ClickHouse-specific techniques, ranks them by estimated granules/bytes saved, and emits
+**ranked DDL text + risk + effort + estimated impact** — surfaced via an agent tool, an
+MCP tool, and an `/advisor` page. It **recommends only**; nothing is applied.
+
+## Implement now (E — approach + key files + heuristics + open questions)
+
+### Inputs the engine gathers (all read-only)
+
+- The query: raw SQL (given) or resolved from `system.query_log` by `query_id`
+  (text, `read_rows`, `read_bytes`, `memory_usage`, duration).
+- `EXPLAIN indexes = 1` / `EXPLAIN PLAN` / `EXPLAIN ESTIMATE` for the query → granules
+  scanned, parts, index usage, PREWHERE presence.
+- Schema for referenced tables: `CREATE TABLE` (engine, ORDER BY / primary key,
+  PARTITION BY, existing skip-indexes/projections), plus `system.columns`
+  (per-column compressed/uncompressed size, type), `system.parts` (active parts, rows,
+  bytes) for the target table.
+
+### Scoring heuristics (spell these out in code; each candidate carries an estimate)
+
+Implement one scorer per technique in `recommendation-engine.ts`, each returning a
+`Recommendation { kind, ddl, rationale, estImpact, risk, effort }`:
+
+- **Skip-index** — recommend `ALTER TABLE … ADD INDEX … TYPE {minmax|set|bloom_filter} …
+  GRANULARITY g` when a query has a **selective predicate on a column that is NOT a
+  prefix of the sorting/primary key** (so the sparse PK index can't prune it). Score by
+  the predicate's **selectivity off the PK prefix**: estimate fraction of granules the
+  skip-index could skip = `1 − selectivity`; impact = granules/bytes saved. Pick index
+  type by predicate shape (equality/IN → `set`/`bloom_filter`; range → `minmax`).
+- **Projection** — recommend `ALTER TABLE … ADD PROJECTION … (SELECT … GROUP BY / ORDER
+  BY …)` when the query's **GROUP BY or ORDER BY mismatches the table ORDER BY** (so the
+  base part ordering forces a full scan/sort). Score by the cost of the mismatched
+  sort/aggregate vs. serving it from a projection whose ORDER BY matches the query.
+- **Partition key** — recommend a PARTITION BY change (as a **rebuild recommendation**,
+  clearly marked high-effort/high-risk since it can't be `ALTER`ed in place) when there
+  is a **range filter on a non-partition column** (typically time) that currently prunes
+  no parts. Score by parts skippable if that column were the partition key.
+- **PREWHERE** — recommend moving a **selective column predicate into PREWHERE** (query
+  rewrite via `sql-rewriter.ts`, not DDL) when a highly selective condition sits in
+  WHERE and the column is cheap to read; impact = rows filtered before reading wide
+  columns. This is the one "no DDL" recommendation — a rewrite suggestion.
+
+**Ranking:** normalize each candidate's estimate to **estimated granules (and bytes)
+saved** and sort descending; break ties by lower risk/effort. Target: produce at least
+one actionable recommendation for **>70%** of analyzed slow queries (the accept bar).
+
+### Impact estimation — `impact-estimator.ts`
+
+- Combine EXPLAIN granule/part counts with `system.columns` sizes to translate
+  "granules saved" → "bytes read saved" → a rough time delta. Everything is an
+  **estimate**, labeled as such (honest claims). Where feasible, run `EXPLAIN` on a
+  **candidate rewrite** (for PREWHERE) to show before/after granules — this is the
+  "validate no plan breakage" evidence. DDL candidates that can't be safely simulated
+  carry a risk note instead of a false-precision number.
+
+### SQL rewriter — `sql-rewriter.ts`
+
+- Only for the PREWHERE recommendation (and any read-only rewrite the engine suggests).
+  Produces a rewritten SELECT for the user to review; **never executes it** beyond an
+  optional `EXPLAIN` to measure impact.
+
+### Recommend-only + billing (both mandatory)
+
+- The output type is **ranked DDL strings + risk + effort + estimated impact**. There is
+  **no execution path** — do not add an "apply" tool/endpoint/button anywhere. (Contrast
+  the ACK-gated *control* tools, which are a different, env-gated surface.)
+- Each advisor invocation **meters as premium AI usage** through the existing usage/
+  entitlements path (mirror how agent generations meter; wire `addAiSpend`/usage the same
+  way plan 14 describes). Fail open for self-host (no Clerk ⇒ not metered, still works).
+
+### Surfaces
+
+- Agent tool `src/lib/ai/agent/tools/advisor-tools.ts` →
+  `get_optimization_recommendations({ query_id? | sql?, host? })` returning the ranked
+  recommendations (structured), so the agent can present them in chat.
+- MCP tool `packages/mcp-server/src/tools/advisor.ts` exposing the same, for external MCP
+  clients.
+- `routes/(dashboard)/advisor.tsx` — a page: paste SQL or pick a slow query from
+  `query_log`, run analysis, show the ranked cards (DDL, estimated impact, risk, effort,
+  a "copy DDL" button — **copy, not apply**).
+
+### Tests — `src/lib/ai/advisor/__tests__/*.test.ts` (Bun)
+
+Use fixtures (mock EXPLAIN output + `system.columns`/`parts` + a query). Assert:
+- A selective non-PK-prefix predicate yields a **skip-index** recommendation with the
+  right index type and a granules-saved estimate.
+- A GROUP BY/ORDER BY mismatch yields a **projection** recommendation.
+- A time range filter on a non-partition column yields a **partition** recommendation
+  marked high-effort (rebuild).
+- A selective WHERE predicate yields a **PREWHERE rewrite** and the rewriter never mutates.
+- **No code path executes DDL** — assert the engine's public surface has no execute
+  function and the recommendation objects are inert text.
+- Coverage: on a fixture set of slow queries, ≥70% produce ≥1 recommendation.
+- (Ties into plan 51 golden tests — keep fixtures reusable.)
+
+### Open questions (resolve against the live repo BEFORE coding)
+
+- **How does the agent currently meter usage?** Find the generation post-hook / usage
+  store (plan 14's `addAiSpend`) and reuse it verbatim for advisor metering. (verify)
+- **Selectivity source:** can we get column cardinality cheaply (e.g. `uniqCombined` on a
+  sample, or `system.columns`/`system.parts` stats) without a heavy scan? Decide the
+  estimate source; prefer EXPLAIN-derived + parts stats over ad-hoc scans (no surprise
+  query load). Record the choice.
+- **WASM reuse:** does `rust/monitor-core` already have granule/selectivity math worth
+  reusing? If not, keep scoring in TS. Decide and note.
+- **Which slow-query source** feeds `/advisor` (a `query_log` reader that already exists
+  vs. a new query)? Reuse the existing reader if present. (verify)
+
+## STOP conditions & drift check
+
+Drift check (run first):
+`git diff --stat -- apps/dashboard/src/lib/ai apps/dashboard/src/lib/insights packages/mcp-server/src` — reconcile pointers if these changed.
+
+STOP and report (do NOT improvise) if:
+- Implementing any recommendation would require an **execute/apply** code path — the
+  recommend-only invariant is absolute; there must be zero DDL-execution surface.
+- You cannot obtain EXPLAIN/schema/parts data read-only without risking heavy scan load
+  on the target cluster (report the query-load concern before shipping a scanner).
+- Metering can't be wired without changing billing internals beyond reusing the existing
+  usage path (report the coupling).
+- The needed change exceeds the listed files (e.g. a new billing table) — report scope creep.
+
+## Verification
+
+```bash
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/ai/advisor/__tests__ --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+
+ALL must hold:
+- [ ] For a slow query (id or SQL) the engine returns **ranked** skip-index / projection /
+      partition / PREWHERE recommendations with DDL text, risk, effort, and an estimated
+      impact; ≥70% of analyzed slow queries get ≥1 recommendation.
+- [ ] Exposed via the agent tool `get_optimization_recommendations`, an MCP advisor tool,
+      and the `/advisor` page (copy-DDL, not apply).
+- [ ] Each invocation meters as premium usage on paid tiers; fails open for self-host.
+- [ ] **Safety (load-bearing)**: the advisor RECOMMENDS DDL and NEVER auto-applies — there
+      is no execute/apply surface anywhere; recommendations are inert text and are
+      validated (EXPLAIN before/after where feasible) to not break existing query plans;
+      candidates that could regress other queries carry an explicit risk note.
+- [ ] All impact numbers are labeled estimates (honest claims); advisor is read-only vs
+      `system.*` and degrades gracefully.
+- [ ] `type-check`, `build`, `bun test src/lib/ai/advisor/__tests__ --isolate`, `lint`
+      all exit 0.
+- [ ] No files outside scope modified; `plans/README.md` row updated.
+
+---
+
+Priority **P0** · Effort **XL** · Depth **E** · Wave **AI (THE WEDGE)** · Lever **Revenue + AI-differentiation + Adoption**

--- a/plans/47-mv-projection-designer.md
+++ b/plans/47-mv-projection-designer.md
@@ -1,0 +1,177 @@
+# 47 — MV / Projection Designer (design MV/projection DDL from frequent aggregations, size-estimated, recommend-only)
+
+> **Executor instructions**: Follow this plan step by step. Run every verification
+> command and confirm the expected result before moving on. If a STOP condition
+> occurs, stop and report — do not improvise. When done, update this plan's status
+> row in `plans/README.md`. This is an **epic-brief (E)**: resolve the open
+> questions *before* coding, then implement.
+
+## Kickoff prompt
+
+```text
+Execute plans/47-mv-projection-designer.md ALONE (Wave AI — extends THE WEDGE).
+Goal: from frequent aggregation queries in system.query_log, design materialized-
+view / projection DDL (Summing/Aggregating MergeTree) with a SIZE ESTIMATE, and
+recommend it — never apply it. Invariants you MUST hold (non-negotiable):
+- THE ADVISOR RECOMMENDS DDL AND NEVER AUTO-APPLIES. Output is DDL text + size
+  estimate + risk + impact ONLY. No CREATE MATERIALIZED VIEW / ADD PROJECTION is
+  ever executed. No apply surface. This is the load-bearing safety invariant.
+- Recommendations must not break existing query plans (an MV/projection adds a
+  write-path cost; surface that trade-off in the risk field, never hide it).
+- Self-hosted/OSS stays whole; runs read-only against system.* and degrades
+  gracefully.
+- Meter as premium usage (billing meter) via the existing usage path; fail open
+  for self-host.
+- Honest claims: the size estimate is an ESTIMATE (target within ~10%) and labeled.
+- SSRF-guard any new outbound (there should be none — CH-local + LLM).
+- Postgres/multi-DB: NO.
+Depends on / shares scoring with plan 46 (query-advisor-engine); reuse its
+system.* readers and recommendation types where present.
+This is depth E: resolve open questions first, then build:
+new src/lib/ai/advisor/mv-designer.ts, agent tool recommend_materialized_view,
+and mv-designer __tests__. End by running:
+cd apps/dashboard && bun run type-check && bun run build &&
+bun test src/lib/ai/advisor/__tests__ --isolate && bun run lint.
+```
+
+## Current reality (audited)
+
+Per ROADMAP §4 spec 47: this **extends the wedge to aggregation workloads.** The advisor
+today explains aggregations in prose but does not *design* MV/projection DDL. This plan
+mines the real aggregation shapes from `query_log` and proposes a Summing/Aggregating
+MergeTree MV or a projection, with a size estimate — recommend-only, like plan 46.
+
+Pointers (confirm with `rg`, mark `(verify)`):
+- Home: `src/lib/ai/advisor/mv-designer.ts` (new), alongside plan 46's engine. Reuse plan
+  46's `Recommendation` type and its `system.*` readers if already landed; otherwise add
+  minimal readers here. (verify — 46 may or may not be merged first)
+- Agent tools: `src/lib/ai/agent/tools/` → add/extend with `recommend_materialized_view`. (verify)
+- `system.query_log` reader + `system.parts` for size math; `@chm/clickhouse-client`. (verify)
+- Insights collectors as a read-only `system.*` model. (verify)
+
+## Goal
+
+Mine the top aggregation shapes (frequent `GROUP BY` + aggregate functions) from
+`system.query_log`, propose an appropriate **MV (Summing/Aggregating MergeTree) or
+projection** that pre-aggregates them, **estimate the resulting size** from
+`system.parts` × aggregation ratio, and emit the **DDL + size estimate + risk + impact**
+as a recommendation surfaced via an agent tool — applied by nobody.
+
+## Implement now (E — approach + key files + heuristics + open questions)
+
+### Approach
+
+1. **Mine aggregation shapes** from `system.query_log` over a window: group similar
+   queries by normalized `(table, GROUP BY keys, aggregate functions, filters)`; rank by
+   frequency × cost (`read_bytes`/duration). Keep the top-N high-cost aggregation shapes.
+2. **Choose the engine** per shape:
+   - Sums/counts only → **SummingMergeTree** MV.
+   - Mixed aggregates (avg, uniq, quantile…) → **AggregatingMergeTree** MV with
+     `-State`/`-Merge` (`AggregateFunction` columns).
+   - If the aggregation can be served from the base table with a matching ORDER BY and
+     the workload is read-mostly on one table → prefer a **PROJECTION** over a separate
+     MV (simpler, no second table). Decide per shape and note why in the rationale.
+3. **Generate DDL** (text only): `CREATE MATERIALIZED VIEW … ENGINE = {Summing|
+   Aggregating}MergeTree ORDER BY (…) AS SELECT … GROUP BY …`, or `ALTER TABLE … ADD
+   PROJECTION … (SELECT … GROUP BY …)`.
+
+### Size-estimate heuristic (spell out; label as estimate)
+
+- **MV/projection size ≈ source parts size × aggregation ratio**, where the aggregation
+  ratio = estimated `(distinct grouping-key combinations) / (source rows)`. Derive:
+  - source rows/bytes from `system.parts` for the base table (active parts);
+  - distinct grouping-key combinations from a cheap cardinality estimate (e.g.
+    `uniqCombined` over a sample, or existing column-cardinality stats) — **not** a full
+    scan (no surprise load).
+- Report estimated on-disk size and estimated rows for the MV/projection. Accept bar:
+  **within ~10%** on the test fixtures. Everything labeled "estimate".
+
+### Impact & risk
+
+- Impact: estimated read reduction for the mined aggregation queries if served from the
+  MV/projection (bytes/granules saved), reusing plan 46's impact-estimator if present.
+- Risk (must be explicit): an MV/projection **adds write-path/merge cost and storage** —
+  state that trade-off; note that AggregatingMergeTree requires `-State`/`-Merge` query
+  changes; note projections rebuild on `ALTER`. Never hide the downside.
+
+### Recommend-only + billing (mandatory, same as plan 46)
+
+- Output is **DDL + size estimate + risk + impact**. **No execute/apply surface.**
+- **Meter as premium usage** via the existing usage/entitlements path; fail open for
+  self-host.
+
+### Surface
+
+- Agent tool `recommend_materialized_view({ table? , host?, window? })` returning the
+  ranked MV/projection recommendations (structured). Optionally surface on the `/advisor`
+  page from plan 46 if that page exists (copy-DDL, not apply). (verify)
+
+### Tests — `src/lib/ai/advisor/__tests__/mv-designer.test.ts` (Bun)
+
+Fixtures: a synthetic `query_log` with repeated `GROUP BY` shapes + `system.parts` sizes.
+Assert:
+- Sum/count-only shape → **SummingMergeTree** DDL; mixed-aggregate shape →
+  **AggregatingMergeTree** with `-State` columns.
+- A single-table read-mostly shape prefers a **projection** and says why.
+- Size estimate is within ~10% of the fixture's expected size (source parts × ratio).
+- Risk field names the write-path/storage trade-off.
+- **No execute path** — the designer exposes no apply function; recommendations are inert
+  text.
+- Coverage: ≥60% of high-cost aggregation shapes in the fixture yield a recommendation
+  (the accept bar).
+
+### Open questions (resolve against the live repo BEFORE coding)
+
+- **Is plan 46 merged?** If yes, import its `Recommendation` type, `system.*` readers, and
+  impact-estimator instead of duplicating. If not, add the *minimum* local readers and
+  keep types compatible so a later merge is clean. Decide and note.
+- **Cardinality source for the aggregation ratio:** which cheap estimate is available
+  (`uniqCombined` on a sample vs. existing stats) without heavy scan? Pick and record.
+- **MV vs projection default:** confirm the repo/product preference (projections avoid a
+  second table but have their own constraints). Decide the tie-breaker rule and note it.
+- **query_log normalization:** is there an existing query-fingerprint/normalizer to group
+  similar aggregations? Reuse it; else implement a minimal GROUP-BY/agg-function normalizer. (verify)
+
+## STOP conditions & drift check
+
+Drift check (run first):
+`git diff --stat -- apps/dashboard/src/lib/ai/advisor apps/dashboard/src/lib/ai/agent/tools` — reconcile pointers if these changed.
+
+STOP and report (do NOT improvise) if:
+- Any recommendation would require an **execute/apply** path — recommend-only is absolute;
+  zero DDL-execution surface.
+- The size estimate cannot be produced without a heavy scan of user data (report the
+  query-load concern before shipping a scanner).
+- Metering can't be wired via the existing usage path without changing billing internals.
+- The work exceeds the listed files.
+
+## Verification
+
+```bash
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/ai/advisor/__tests__ --isolate
+cd apps/dashboard && bun run lint
+```
+
+## Done criteria
+
+ALL must hold:
+- [ ] From frequent aggregation queries, the designer proposes MV/projection DDL with the
+      correct engine (Summing/Aggregating) or a projection, a size estimate (within ~10%
+      on fixtures), impact, and an explicit risk/trade-off note; ≥60% of high-cost
+      aggregation shapes get a recommendation.
+- [ ] Exposed via the `recommend_materialized_view` agent tool (and `/advisor` if present),
+      copy-DDL only.
+- [ ] Metered as premium usage on paid tiers; fails open for self-host.
+- [ ] **Safety (load-bearing)**: RECOMMENDS DDL, NEVER auto-applies — no execute/apply
+      surface; recommendations are inert text; the added write-path/storage cost is stated,
+      never hidden; nothing changes existing query plans.
+- [ ] Size/impact numbers labeled as estimates; read-only vs `system.*`; graceful degrade.
+- [ ] `type-check`, `build`, `bun test src/lib/ai/advisor/__tests__ --isolate`, `lint`
+      all exit 0.
+- [ ] No files outside scope modified; `plans/README.md` row updated.
+
+---
+
+Priority **P0** · Effort **L** · Depth **E** · Wave **AI** · Lever **Revenue / AI-differentiation**

--- a/plans/49-query-cost-estimator.md
+++ b/plans/49-query-cost-estimator.md
@@ -1,0 +1,70 @@
+# 49 — Query cost estimator (EXPLAIN → rows / memory / time)
+
+## Kickoff prompt
+
+```text
+Execute plans/49-query-cost-estimator.md ALONE. Add a pre-flight query cost estimator that
+runs EXPLAIN (never executes the query) and estimates rows scanned, peak memory, and wall time.
+It powers runaway-query guardrails and the advisor's impact math (plan 46).
+Invariants: self-hosted stays whole (fail-open without Clerk); the estimator RUNS EXPLAIN ONLY —
+it must never execute the analyzed query and never mutate; AI recommends, never auto-applies;
+Postgres=NO for 2026 H2. Read the plan fully, honor STOP conditions, then run every Verification
+command and update your row in plans/README.md.
+Verify: cd apps/dashboard && bun run type-check && bun run build; bun test src/lib/ai/advisor --isolate; bun run lint.
+```
+
+## Current reality (audited)
+
+The agent has query tools (`apps/dashboard/src/lib/ai/agent/tools/query-tools.ts`) and an
+`explain_query` path, but **no cost estimate before execution** exists. There is no EXPLAIN
+parser and no cardinality propagation. The advisor (plan 46) needs this to rank recommendations
+by "granules/bytes saved," and operators need a guardrail against runaway queries.
+
+## Goal
+
+A read-only `estimate_query_cost(sql, hostId)` agent tool that returns
+`{ estRows, estBytesRead, estPeakMemoryBytes, estWallMs, confidence, warnings[] }` from EXPLAIN
+output only. No execution of the analyzed query.
+
+## Implement now (depth E — resolve open questions during discovery)
+
+- New `apps/dashboard/src/lib/ai/advisor/cost-estimator.ts`:
+  - `parseExplainPlan(explainJson)` — extract `ReadFromMergeTree` (granules/marks/bytes),
+    `Filter` (selectivity), `Join` (build side), `Aggregating` (group cardinality).
+  - `estimateRowsAndMemory(plan, columnStats)` — propagate cardinalities; memory ≈
+    max(build_side_rows × row_size, aggregation_state_size).
+  - `estimateWallMs(plan, throughputHint)` — bytes_read / bytes_per_sec + rows / rows_per_sec.
+- Extend `query-tools.ts` with `estimate_query_cost` — runs `EXPLAIN indexes = 1, json = 1` and
+  `EXPLAIN PLAN` with `readonly` transport; **must reject/guard** any attempt to run the raw SQL.
+- Pull per-column sizes/types from `system.columns` (already queried elsewhere; reuse a config).
+- Tests: `apps/dashboard/src/lib/ai/advisor/__tests__/cost-estimator.test.ts` with fixture EXPLAIN
+  JSON for a scan, a join, and an aggregation.
+- **Open questions to resolve:** exact EXPLAIN JSON shape across supported CH versions (use the
+  `since`/versioned-query mechanism); throughput hint source (static default vs. per-host from
+  `query_log`); how to express confidence.
+
+## STOP conditions & drift check
+
+- STOP if `query-tools.ts` moved or the readonly transport contract changed — re-confirm the
+  read-only guard before adding a tool that takes arbitrary SQL.
+- STOP if EXPLAIN JSON differs materially on the connected CH version; gate with `since` variants
+  rather than guessing.
+- Drift: if a cost estimator already exists, extend it instead of duplicating.
+
+## Verification
+
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/ai/advisor --isolate
+bun run lint
+```
+
+## Done criteria
+
+- `estimate_query_cost` returns rows/memory/time estimates from EXPLAIN only; never executes the
+  analyzed query (asserted by a test that fails if the raw SQL is sent).
+- Rows/memory within ~2× and time within ~30% on the fixture set.
+- Tool available to the agent and to plan 46's impact math.
+
+Priority: P1 · Effort: L · Depth: E · Wave: AI (Advisor) · Lever: AI-differentiation / Adoption

--- a/plans/52-proactive-weekly-health-report.md
+++ b/plans/52-proactive-weekly-health-report.md
@@ -1,0 +1,69 @@
+# 52 — Proactive weekly health report
+
+## Kickoff prompt
+
+```text
+Execute plans/52-proactive-weekly-health-report.md ALONE. Add a weekly cron that turns the
+insights engine + statistical baselines (plan 48) + capacity forecast (plan 50) into a shareable
+cluster-health narrative, delivered via the configured channels (email plan 25 / Slack plan 37).
+Invariants: self-hosted stays whole (fail-open without Clerk; opt-in per host); AI recommends,
+never auto-applies; honest content (no claims beyond what insights computed); Postgres=NO for
+2026 H2. Read the plan fully, honor STOP conditions, then run every Verification command and
+update your row in plans/README.md.
+Verify: cd apps/dashboard && bun run type-check && bun run build; bun test src/lib/insights --isolate; bun run lint.
+```
+
+## Current reality (audited)
+
+The insights engine (`apps/dashboard/src/lib/insights/generate-insights.ts` + `collectors.ts`)
+runs every ~5 min and persists findings, and there is a health-sweep cron
+(`routes/api/cron/health-sweep.ts`). But there is **no periodic digest** — nothing aggregates a
+week of findings into a narrative or delivers it. This is a retention + upsell surface.
+
+## Goal
+
+A weekly cron that composes a per-host health narrative (top findings, trend vs. baseline,
+capacity outlook, links to advisor recommendations) and delivers it via configured channels,
+opt-in per host.
+
+## Implement now (depth F)
+
+- New `apps/dashboard/src/lib/insights/weekly-report.ts`:
+  - `buildWeeklyReport(hostId)` — pull last 7d findings from the insights store, summarize by
+    category/severity, fold in baselines (plan 48) and capacity forecast (plan 50), and produce a
+    Markdown/HTML narrative + a compact summary object.
+- New `apps/dashboard/src/routes/api/cron/weekly-report.ts` — CRON_SECRET-gated (mirror
+  `health-sweep.ts`; fail-closed if secret unset), iterate opt-in hosts, build + deliver.
+- Delivery reuses the alert adapters: email (plan 25) and/or Slack (plan 37); if neither is
+  configured, persist the report only.
+- Persist reports in a small D1 table `weekly_reports` (host_id, week_start, summary_json,
+  delivered) mirroring the insights D1 store pattern; fail-open (swallow store errors).
+- Opt-in flag per host in settings; add a Cloudflare cron trigger entry (weekly) in
+  `wrangler.toml` `(verify)`.
+- Tests: `apps/dashboard/src/lib/insights/__tests__/weekly-report.test.ts` — builds a report from
+  fixture findings and asserts structure + that undelivered still persists.
+
+## STOP conditions & drift check
+
+- STOP if the insights store interface changed — reuse the existing store abstraction, don't add a
+  parallel one.
+- STOP if CRON_SECRET handling differs from `health-sweep.ts`; match it (fail-closed).
+- Drift: confirm adapter entry points (plans 25/37) before wiring delivery; if not yet merged,
+  gate delivery behind an adapter-present check and still persist.
+
+## Verification
+
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/insights --isolate
+bun run lint
+```
+
+## Done criteria
+
+- Weekly cron builds a per-host narrative from real insights + baselines + capacity.
+- Delivered via configured channel(s); persisted regardless of delivery.
+- CRON_SECRET fail-closed; opt-in per host; test covers build + persist.
+
+Priority: P1 · Effort: M · Depth: F · Wave: AI (Advisor) · Lever: Adoption / Revenue (retention surface)

--- a/plans/54-query-config-pack-registry.md
+++ b/plans/54-query-config-pack-registry.md
@@ -1,0 +1,65 @@
+# 54 — Community query-pack registry
+
+## Kickoff prompt
+
+```text
+Execute plans/54-query-config-pack-registry.md ALONE. Add a pack loader that fetches, validates,
+and merges community-authored YAML query packs into the declarative catalog, so self-hosters ship
+new queries without rebuilding. Depends on the declarative path (plan 53).
+Invariants: self-hosted stays whole; TS config path stays default; a malformed/unreachable pack
+must fail-closed to the built-in catalog (never crash); SSRF-guard the pack fetch; Postgres=NO for
+2026 H2. Read the plan fully, honor STOP conditions, then run every Verification command and update
+your row in plans/README.md.
+Verify: cd apps/dashboard && bun run type-check && bun run build; bun test src/lib/query-config --isolate; bun run lint.
+```
+
+## Current reality (audited)
+
+The declarative loader (`apps/dashboard/src/lib/query-config/declarative/loader.ts`) can compile a
+serializable config, but there is **no mechanism to load external packs** — the catalog is
+compiled-in. Self-hosters must fork to add queries. (Depends on plan 53 making the declarative path
+trustworthy.)
+
+## Goal
+
+`CHM_PACK_REGISTRY_URL` (HTTP or `file://`) points at one or more query packs; at startup they are
+fetched, validated against the declarative schema, and merged into the catalog. Bad packs are
+rejected with a clear error and the built-in catalog still serves.
+
+## Implement now (depth E — resolve open questions during discovery)
+
+- New `apps/dashboard/src/lib/query-config/declarative/pack-registry.ts`:
+  - Pack manifest schema `{ name, version, minChmVersion?, queries: DeclarativeQueryConfig[] }`.
+  - `loadPacks(urls)` — fetch (SSRF-guarded via the existing host-validation fetch), parse YAML,
+    validate each query with the declarative schema, dedupe by name, merge into the catalog.
+  - Cache with a version key; graceful degradation + structured logging on any failure.
+- Extend `loader.ts`/`index.ts` to consult loaded packs when `CHM_CONFIG_SOURCE=declarative`.
+- Env: `CHM_PACK_REGISTRY_URL` (comma-separated); document precedence (built-in < pack; last pack
+  wins on name collision, logged).
+- Tests: valid pack merges + appears in lookup; malformed pack is rejected and built-ins still
+  resolve; `file://` local pack loads.
+- **Open questions:** signature/verification of packs (defer or add a checksum), hot-reload vs.
+  startup-only (startup-only for v1), namespacing collisions.
+
+## STOP conditions & drift check
+
+- STOP if plan 53's declarative path isn't merged/trustworthy — land 53 first.
+- STOP before adding any un-guarded outbound fetch; reuse the SSRF-guarded fetch primitive.
+- Drift: confirm the declarative schema export used for validation.
+
+## Verification
+
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/query-config --isolate
+bun run lint
+```
+
+## Done criteria
+
+- A pack from an HTTP URL and a `file://` mount both load and appear in query lookups.
+- A malformed/unreachable pack fails closed to the built-in catalog (tested).
+- Pack fetch is SSRF-guarded; precedence + collisions documented.
+
+Priority: P0 · Effort: M · Depth: E · Wave: D (Dashboards/OSS) · Lever: OSS-extensibility / Adoption · Depends on: 53

--- a/plans/57-custom-dashboard-builder-grid.md
+++ b/plans/57-custom-dashboard-builder-grid.md
@@ -1,0 +1,60 @@
+# 57 — Custom dashboard builder (drag-drop grid)
+
+## Kickoff prompt
+
+```text
+Execute plans/57-custom-dashboard-builder-grid.md ALONE. Build a drag-drop dashboard grid with
+widget types (chart/table/stat/text) and a single shared time-range, persisted via plan 56.
+Invariants: self-hosted stays whole (works without D1 via localStorage); honest paywalls
+(custom-dashboard limits per plan, advertised⟺enforced or deferred); Postgres=NO for 2026 H2.
+Read the plan fully, honor STOP conditions, then run every Verification command and update your row
+in plans/README.md.
+Verify: cd apps/dashboard && bun run type-check && bun run build; bun test src/components/dashboard --isolate; bun run lint.
+```
+
+## Current reality (audited)
+
+`apps/dashboard/src/routes/(dashboard)/dashboard.tsx` supports selecting from built-in charts and
+saving a set, but the PRD's dynamic-dashboard vision (drag-drop grid, widget types, shared
+time-range) is only partial. `@dnd-kit` is already a dependency.
+
+## Goal
+
+Users add/move/resize widgets on a grid; all widgets share one time-range; layouts save/load via
+plan 56. Widget types: chart (from the registry), table, single-stat, text/markdown.
+
+## Implement now (depth E — resolve open questions during discovery)
+
+- New `apps/dashboard/src/components/dashboard/{grid.tsx, widget-frame.tsx, widget-chart.tsx,
+  widget-stat.tsx, widget-table.tsx, widget-text.tsx}` using `@dnd-kit` for drag/resize.
+- A shared `TimeRangeContext` that all widgets consume (single control drives every widget).
+- Layout model `{ widgets: [{id, type, chartName?, x, y, w, h, props}] }`; persist via plan 56
+  (D1 + localStorage fallback).
+- Integrate into `dashboard.tsx` (edit mode toggle: view ⇄ arrange).
+- Enforce custom-dashboard count per plan via `plan-enforcement` (or classify `deferred`).
+- Tests: layout serialize/deserialize round-trip; time-range change propagates to all widgets.
+- **Open questions:** grid lib specifics (dnd-kit sortable vs. a grid layout helper), responsive
+  breakpoints, chart-widget data wiring to existing chart components.
+
+## STOP conditions & drift check
+
+- STOP if plan 56 isn't merged — the builder needs its persistence; until then, localStorage-only.
+- STOP before adding a hard paywall in free beta — classify the limit explicitly.
+- Drift: confirm the chart registry API used to instantiate chart widgets.
+
+## Verification
+
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/components/dashboard --isolate
+bun run lint
+```
+
+## Done criteria
+
+- Add/move/resize widgets of all four types; one shared time-range drives all.
+- Layout persists + reloads via plan 56 (D1 or localStorage).
+- Custom-dashboard limit classified in `plan-enforcement`.
+
+Priority: P1 · Effort: L · Depth: E · Wave: D (Dashboards) · Lever: Adoption / Revenue · Depends on: 56

--- a/plans/58-declarative-chart-schema.md
+++ b/plans/58-declarative-chart-schema.md
@@ -1,0 +1,61 @@
+# 58 — Declarative chart schema
+
+## Kickoff prompt
+
+```text
+Execute plans/58-declarative-chart-schema.md ALONE. Define a declarative schema + loader for chart
+configs (mirroring the query-config declarative system) and port ~5 factory charts as templates,
+so charts can be authored as data (and later by the community/AI).
+Invariants: self-hosted stays whole; hand-rolled charts keep working (additive, no regression);
+Postgres=NO for 2026 H2. Read the plan fully, honor STOP conditions, then run every Verification
+command and update your row in plans/README.md.
+Verify: cd apps/dashboard && bun run type-check && bun run build; bun test src/components/charts --isolate; bun run lint.
+```
+
+## Current reality (audited)
+
+Charts are TypeScript: ~40 use the factory (`apps/dashboard/src/components/charts/factory/`), ~34
+are hand-rolled, and there is **no serializable chart schema**. Adding a chart requires code; the
+community/AI can't author visualizations without forking. The query-config declarative system
+(plans 53–54) is the model to mirror.
+
+## Goal
+
+A declarative chart schema + loader that maps a serializable chart definition to a `ChartFactory`
+call, with ≥5 factory charts ported as templates and identical rendering.
+
+## Implement now (depth E — resolve open questions during discovery)
+
+- New `apps/dashboard/src/components/charts/declarative/{schema.ts, loader.ts, catalog.ts}`
+  mirroring `lib/query-config/declarative/`.
+- Extract serializable fields from factory charts (chartName, index/query ref, categories,
+  defaultInterval, series/axis config); resolve `Icon` refs via lazy imports.
+- `loader` maps a declarative chart → existing `ChartFactory` call.
+- Port ≥5 factory charts (e.g. query-count, disk-size, memory-usage, merges, parts) into the
+  declarative catalog as templates; snapshot/visual-parity test vs the TS versions.
+- Document the authoring format for community contributions.
+- **Open questions:** how much interactivity is expressible declaratively (keep bespoke charts in
+  TS), icon resolution strategy, whether declarative charts join the chart registry directly.
+
+## STOP conditions & drift check
+
+- STOP if the factory API changed — align the loader to the current factory signature.
+- Keep hand-rolled charts untouched; this is additive.
+- Drift: confirm the chart registry + factory paths.
+
+## Verification
+
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/components/charts --isolate
+bun run lint
+```
+
+## Done criteria
+
+- ≥5 charts render identically from declarative definitions.
+- Schema + loader mirror the query-config declarative system; authoring documented.
+- Hand-rolled and factory charts unaffected.
+
+Priority: P2 · Effort: M · Depth: E · Wave: D (Dashboards) · Lever: OSS-extensibility / AI · Depends on: 53

--- a/plans/59-ai-generated-dashboards.md
+++ b/plans/59-ai-generated-dashboards.md
@@ -1,0 +1,63 @@
+# 59 — AI-generated dashboards
+
+## Kickoff prompt
+
+```text
+Execute plans/59-ai-generated-dashboards.md ALONE. Add an agent tool that turns a natural-language
+request ("show me everything about replication health") into a built dashboard assembled from the
+chart registry, applied via the dashboard builder (plans 56/57).
+Invariants: self-hosted stays whole; the agent proposes/builds dashboards from EXISTING registry
+charts only (no arbitrary code/DDL; recommends, never auto-applies destructive actions); honest
+paywalls (AI usage metered); Postgres=NO for 2026 H2. Read the plan fully, honor STOP conditions,
+then run every Verification command and update your row in plans/README.md.
+Verify: cd apps/dashboard && bun run type-check && bun run build; bun test src/lib/ai/agent --isolate; bun run lint.
+```
+
+## Current reality (audited)
+
+The agent has visualization/dashboard tool categories in the PRD, but there is **no working
+NL→dashboard builder** wired to real persistence. Dashboards are localStorage-only until plan 56;
+the grid builder arrives in plan 57. This plan composes those with the chart registry.
+
+## Goal
+
+`build_dashboard(request)` agent tool: maps NL + schema/query-history context to a set of registry
+charts, constructs a layout, and applies it via plans 56/57 in one click. Charts come only from the
+registry (safe, no code-gen).
+
+## Implement now (depth E — resolve open questions during discovery)
+
+- New agent tool in `apps/dashboard/src/lib/ai/agent/tools/` (e.g. `dashboard-tools.ts`):
+  `suggest_dashboard(request)` → list of registry chart names + a layout; `build_dashboard` applies
+  it via the plan-56 store / plan-57 layout model.
+- Ground the mapping in the chart registry (names + categories) + optional schema/query-history
+  context so suggestions are relevant; reject any chart not in the registry.
+- Meter as AI usage (ties to plan 14/agent budget).
+- Tests (golden-style, ties to plan 51): a request yields a valid layout of registry charts, no
+  unknown chart names, applied without reload.
+- **Open questions:** ranking/selection heuristic, how much query-history context to pass, preview
+  vs. auto-apply UX.
+
+## STOP conditions & drift check
+
+- STOP if plans 56/57 aren't merged — gate `build_dashboard` behind their presence; `suggest_` can
+  land first (read-only).
+- STOP if a suggested chart name isn't in the registry — filter it out, never invent.
+- Drift: confirm the chart registry export + the dashboard layout model.
+
+## Verification
+
+```
+cd apps/dashboard && bun run type-check
+cd apps/dashboard && bun run build
+cd apps/dashboard && bun test src/lib/ai/agent --isolate
+bun run lint
+```
+
+## Done criteria
+
+- NL request yields a valid dashboard of registry charts, applied without reload.
+- No non-registry chart names ever emitted (tested).
+- AI usage metered; golden test added.
+
+Priority: P2 · Effort: L · Depth: E · Wave: D (Dashboards) · Lever: AI-differentiation / Adoption · Depends on: 56, 57

--- a/plans/60-landing-hero-wedge-refresh.md
+++ b/plans/60-landing-hero-wedge-refresh.md
@@ -1,0 +1,69 @@
+# 60 — Landing hero: advisor + alerting + all-deployment wedge
+
+## Kickoff prompt
+
+```text
+Execute plans/60-landing-hero-wedge-refresh.md ALONE. Rewrite the landing hero (apps/landing) to
+lead with the wedge that beats Cloud-locked "Ask AI": a ClickHouse-specific ADVISOR (recommends
+projections/skip-indexes/partition keys/PREWHERE/MVs), ALERTING, and "works on every deployment"
+(self-host, Docker, K8s, Cloud). Reorder the hero gallery to lead with advisor/agent/alerts/topology.
+Invariants: self-hosted stays whole; MARKETING CLAIMS MUST MATCH SHIPPED + ENFORCED features — no
+overselling (verify each claim against apps/dashboard before publishing copy); Postgres=NO for 2026
+H2. Read the plan fully, honor STOP conditions, then run every Verification command and update your
+row in plans/README.md.
+Verify: cd apps/landing && bun install --frozen-lockfile && bun run build; bun run lint.
+```
+
+## Current reality (audited)
+
+`apps/landing` is Astro. Current hero headline: **"See every ClickHouse query. As it runs."** with
+a subhead centered on queries/merges/parts/replication + "an AI agent that answers questions." The
+advisor, alerting, and multi-deployment story are absent from the hero. Components exist:
+`Hero.astro`, `Features.astro`, `Capabilities.astro`, `Comparison.astro`, `FinalCta.astro`,
+`SocialProof.astro`, `Nav.astro`, `layouts/Base.astro`. (No `data/` or `scripts/` dir yet —
+`(verify)`.)
+
+## Goal
+
+A hero that names the advisor + alerting in the first two lines and states "works on every
+deployment," a reordered gallery leading with advisor/agent/alerts/topology, consistent accent on
+the key terms, and a secondary "See a live demo" CTA (ties to plan 65). Every claim matches shipped
+code.
+
+## Implement now (depth F)
+
+- `apps/landing/src/components/Hero.astro`:
+  - Rewrite headline to lead with the advisor+alerting wedge. Direction (pick/adapt, keep honest):
+    *"The ClickHouse cluster advisor — and everything you need to watch it."* Subhead names three
+    pillars: (1) live query/merge/replication visibility, (2) an AI advisor that recommends
+    projections, skip-indexes, partition keys, PREWHERE & MVs — **recommends, never auto-applies**,
+    (3) alerting to Slack/PagerDuty/email + Prometheus/Grafana — self-host, Docker, K8s, or Cloud.
+  - Reorder the gallery tabs so the first 4–5 are advisor/agent, alerts, topology, insights.
+  - Keep primary CTA "Open dashboard"; add secondary "See a live demo" (guard until plan 65 ships —
+    link to docs quickstart if demo not live yet).
+- Apply the brand accent consistently to "advisor" / "alerts".
+- Update `FinalCta.astro` to echo the new wedge.
+- Do NOT claim an unshipped capability. If a pillar item (e.g. advisor) isn't shipped yet, phrase
+  as the honest current state or gate the copy behind the feature landing (coordinate with plan 46).
+
+## STOP conditions & drift check
+
+- STOP and verify each hero claim against `apps/dashboard` shipped features before publishing (esp.
+  advisor recommendations — plan 46). If the advisor isn't merged, soften to "AI agent that
+  explains and advises" rather than "recommends DDL."
+- Drift: confirm the gallery/tab data source and screenshot asset names before reordering.
+
+## Verification
+
+```
+cd apps/landing && bun install --frozen-lockfile && bun run build
+bun run lint
+```
+
+## Done criteria
+
+- Hero names advisor + alerting in the first two lines and states multi-deployment support.
+- Gallery leads with advisor/agent/alerts/topology.
+- No claim exceeds shipped/enforced features (checked); build is green.
+
+Priority: P0 · Effort: L · Depth: F · Wave: G (Growth) · Lever: Adoption / SEO

--- a/plans/61-feature-sections-advisor-alerts-refresh.md
+++ b/plans/61-feature-sections-advisor-alerts-refresh.md
@@ -1,0 +1,63 @@
+# 61 — Feature/capability/comparison sections: advisor + alerting
+
+## Kickoff prompt
+
+```text
+Execute plans/61-feature-sections-advisor-alerts-refresh.md ALONE. Update the landing feature,
+capability, and comparison sections ("everywhere") to foreground the ClickHouse advisor and
+alerting, with real screenshots and an "Alert rules / channels" comparison row.
+Invariants: self-hosted stays whole; MARKETING CLAIMS MUST MATCH SHIPPED + ENFORCED features
+(verify each against apps/dashboard + packages/pricing before publishing); Postgres=NO for 2026 H2.
+Read the plan fully, honor STOP conditions, then run every Verification command and update your row
+in plans/README.md.
+Verify: cd apps/landing && bun install --frozen-lockfile && bun run build; bun run lint.
+```
+
+## Current reality (audited)
+
+`apps/landing` has `Features.astro` (AI Agent / Queries / Topology / Health), `Capabilities.astro`
+(6-card grid), and `Comparison.astro` (vs Grafana/Datadog/ClickHouse native). Advisor and alerting
+are under-represented; the comparison has no alerting row. Pricing/plan data comes from
+`@chm/pricing` (single source of truth) surfaced via the landing pricing data.
+
+## Goal
+
+Advisor + alerting appear as first-class in Features + Capabilities, with real screenshots, and the
+Comparison table gains an "Alert rules & channels" row — all claims verified against shipped code.
+
+## Implement now (depth F)
+
+- `apps/landing/src/components/Features.astro`: add an **Advisor** feature card (recommends
+  projections/skip-indexes/partition keys/PREWHERE/MVs — recommends, never auto-applies) and an
+  **Alerting** card (rules + channels: Slack/PagerDuty/Telegram/Discord/email + Prometheus). Use
+  real screenshots (add assets); badge AI-backed items.
+- `apps/landing/src/components/Capabilities.astro`: prepend "AI-backed" only where true; add an
+  alerting capability entry.
+- `apps/landing/src/components/Comparison.astro`: add an "Alert rules & channels" row; keep honest
+  framing (chmonitor vs generic tools).
+- Confirm each channel/feature claim exists in `apps/dashboard/src/lib/health/adapters/` and each
+  plan limit in `packages/pricing`; if a channel isn't shipped (e.g. email = plan 25), don't list
+  it until merged.
+
+## STOP conditions & drift check
+
+- STOP and verify each listed alert channel against `adapters/index.ts` (Slack/Discord/Telegram/
+  PagerDuty/generic exist today; email = plan 25, Opsgenie = plan 26 — omit until merged).
+- STOP if advisor isn't shipped (plan 46) — describe the AI agent's current advise/explain ability
+  honestly rather than claiming DDL recommendations.
+- Drift: confirm component names + the pricing data source.
+
+## Verification
+
+```
+cd apps/landing && bun install --frozen-lockfile && bun run build
+bun run lint
+```
+
+## Done criteria
+
+- Advisor + alerting are first-class in Features + Capabilities with real screenshots.
+- Comparison has an alerting row; every claim maps to shipped code (checked).
+- Build green.
+
+Priority: P1 · Effort: M · Depth: F · Wave: G (Growth) · Lever: Adoption / Revenue

--- a/plans/63-comparison-pages-vs-competitors.md
+++ b/plans/63-comparison-pages-vs-competitors.md
@@ -1,0 +1,65 @@
+# 63 — Comparison pages vs Grafana / Datadog / ClickHouse Cloud
+
+## Kickoff prompt
+
+```text
+Execute plans/63-comparison-pages-vs-competitors.md ALONE. Add honest, high-intent comparison
+pages: /vs-grafana, /vs-datadog, /vs-clickhouse-cloud, each a deep feature matrix + setup-time/TCO
+framing + CTA, linked from the main comparison section.
+Invariants: self-hosted stays whole; CLAIMS MUST BE HONEST + CURRENT — verify chmonitor rows
+against shipped code and competitor rows against their current public docs; no strawman; Postgres=NO
+for 2026 H2. Read the plan fully, honor STOP conditions, then run every Verification command and
+update your row in plans/README.md.
+Verify: cd apps/landing && bun install --frozen-lockfile && bun run build; bun run lint.
+```
+
+## Current reality (audited)
+
+The landing has a single on-page comparison matrix (`apps/landing/src/components/Comparison.astro`,
+vs Grafana/Datadog/ClickHouse native). There are **no dedicated /vs-* pages** (landing pages today
+are only index/pricing/changelog/brand/404). "vs" queries are high purchase-intent SEO traffic.
+Market context (verified 2026): ClickHouse Cloud has Cloud-locked Ask-AI + MCP + Agents; Grafana
+uses the Altinity plugin (16.6M downloads) / official datasource; Datadog has a ClickHouse
+integration; pganalyze charges $149/server.
+
+## Goal
+
+Three honest, keyword-targeted comparison pages with a shared reusable table, positioned around
+chmonitor's true differentiators (ClickHouse-specific advisor, alerting, works on every deployment,
+OSS, cost) — not strawmen — each with a CTA.
+
+## Implement now (depth E — resolve open questions during discovery)
+
+- New shared `apps/landing/src/components/ComparisonTable.astro` (reusable, data-driven rows).
+- New pages `apps/landing/src/pages/{vs-grafana,vs-datadog,vs-clickhouse-cloud}.astro`, each:
+  hero for the comparison, ≥10-row matrix, setup-time + TCO framing, honest disclaimers, CTA
+  ("Try chmonitor free" / "Open dashboard").
+- Position honestly: acknowledge Grafana/Altinity own raw-metrics dashboards and Datadog owns
+  full-stack APM; chmonitor wins on ClickHouse-specific advisor + alerting + self-host + cost +
+  MCP; ClickHouse Cloud's Ask-AI/Agents are Cloud-locked + analytics-first (not ops-advisor for
+  self-hosters).
+- Link from `Comparison.astro`; add schema.org markup + per-page meta (coordinate with plan 69).
+- **Open questions:** exact competitor rows/pricing to cite (re-verify at write time), TCO
+  calculator scope (static table vs interactive), how many rows.
+
+## STOP conditions & drift check
+
+- STOP and re-verify competitor capabilities/pricing against current public docs at write time
+  (they change); cite honestly, date the claims.
+- STOP if a chmonitor row overstates shipped features — verify against `apps/dashboard`.
+- Drift: confirm the landing pages dir + routing convention.
+
+## Verification
+
+```
+cd apps/landing && bun install --frozen-lockfile && bun run build
+bun run lint
+```
+
+## Done criteria
+
+- 3 /vs-* pages build, each with a ≥10-row honest matrix + CTA, linked from the main comparison.
+- chmonitor rows verified against shipped code; competitor rows dated + sourced.
+- Schema/meta present (or handed to plan 69).
+
+Priority: P1 · Effort: M · Depth: E · Wave: G (Growth) · Lever: SEO / Adoption

--- a/plans/64-seo-use-case-landing-pages.md
+++ b/plans/64-seo-use-case-landing-pages.md
@@ -1,0 +1,127 @@
+# 64 — SEO use-case landing pages
+
+## Kickoff prompt
+
+```text
+Execute plans/64-seo-use-case-landing-pages.md ALONE (do not read other plans).
+Goal: ship 4+ keyword-targeted use-case landing pages in apps/landing (queries,
+cluster-health, replication, performance) behind a shared LandingPage layout,
+internal-linked and in the sitemap.
+
+Invariants (do not violate):
+- Self-hosted/OSS stays WHOLE: these are marketing pages only; touch no app code,
+  no billing, no dashboard runtime.
+- Marketing claims MUST match shipped features: every capability named on a page
+  must exist in the product today (advisor recommends DDL / never auto-applies;
+  alerting = Slack/Discord/Telegram/PagerDuty/generic; works on self-host/Docker/
+  K8s/Cloud). No roadmap features stated as shipped. When unsure, cut the claim.
+- Analytics/DNT: reuse the existing analytics wrapper (plan 62) if present; do not
+  add a second tracker; respect Do-Not-Track; no PII.
+- Postgres/multi-DB: NO. ClickHouse-only positioning.
+
+When done, run the Verification block at the bottom and paste the output.
+```
+
+## Current reality (audited)
+
+Why (roadmap §4/64, P2/L/E): chmonitor's landing is a single funnel page (`index.astro`)
+plus `pricing`, `changelog`, `brand`, `404`. There are **no use-case / keyword-targeted
+pages**, so long-tail organic intent ("ClickHouse replication monitor", "ClickHouse query
+performance analyzer", "monitor ClickHouse cluster health") has no dedicated landing
+surface to rank for. Per strategy §1, the growth lever is widening the funnel mouth with an
+**honest, advisor-forward** presence — not competing with Grafana/Altinity on raw metrics.
+
+Pointers (verify at head):
+- Astro app: `apps/landing/` — `astro.config.mjs`, `src/pages/`, `src/components/`,
+  `src/layouts/Base.astro`. Existing pages: `index.astro`, `pricing.astro`,
+  `changelog.astro`, `brand.astro`, `404.astro`.
+- Reusable content blocks already exist: `components/Hero.astro`, `Features.astro`,
+  `Capabilities.astro`, `Comparison.astro`, `FinalCta.astro`, `Footer.astro`,
+  `SocialProof.astro`, `Nav.astro`.
+- No sitemap integration is confirmed — check `astro.config.mjs` for `@astrojs/sitemap`
+  `(verify)`; if absent, add it (this is the mechanism that gets new pages indexed).
+- Pricing/benefit copy is centralized — reuse the shared pricing data used by the
+  landing (`apps/landing/src/data/pricing.ts` `(verify path)`) rather than re-typing claims.
+
+## Goal
+
+Four or more crawlable use-case pages (`/monitor-queries`, `/cluster-health`,
+`/replication`, `/performance`) — each with a unique H1, unique title/description,
+use-case-specific hero + benefits + a real product screenshot + one CTA — sharing a
+`LandingPage.astro` layout, internally linked from the main page and footer, present in the
+sitemap, and carrying valid `SoftwareApplication` schema. Every claim maps to a shipped
+feature.
+
+## Implement now (depth E — approach + key files + open questions)
+
+### Approach
+1. **Shared layout** — `apps/landing/src/layouts/LandingPage.astro` (new). Wrap
+   `Base.astro` (which owns `<head>`/meta — see plan 69) and accept props: `title`,
+   `description`, `h1`, `subhead`, `heroImage`, `benefits[]`, `ctaHref`, `ctaLabel`,
+   `schema`. Compose existing `Nav`, `Footer`, `FinalCta`, `SocialProof` so pages stay
+   visually consistent with `index.astro`.
+2. **Page set** — one `.astro` per use case under `src/pages/`:
+   - `monitor-queries.astro` — live/running query visibility + kill (already shipped), then
+     the advisor angle ("see the slow query, get a recommended skip-index/PREWHERE — you
+     apply it"). Keyword: *monitor ClickHouse queries / query performance analyzer*.
+   - `cluster-health.astro` — health checks + alerting channels (Slack/Discord/Telegram/
+     PagerDuty/generic). Keyword: *ClickHouse cluster health monitoring*.
+   - `replication.astro` — replication-lag / read-only monitoring + alerting. Keyword:
+     *ClickHouse replication monitor*.
+   - `performance.astro` — query cost / advisor recommendations (recommend-only). Keyword:
+     *ClickHouse performance tuning / optimization*.
+3. **Screenshots** — reuse real product screenshots already used on the landing gallery;
+   do not mock up UI that does not exist.
+4. **Internal linking** — add a "Use cases" group to `Footer.astro` (and optionally a
+   nav/section on `index.astro`) linking all four pages; cross-link related pages to each
+   other.
+5. **Sitemap + schema** — ensure `@astrojs/sitemap` is configured so the new routes are
+   emitted; add `SoftwareApplication` JSON-LD per page via the layout.
+
+### Key files
+- New: `src/layouts/LandingPage.astro`; `src/pages/{monitor-queries,cluster-health,replication,performance}.astro`.
+- Edit: `src/components/Footer.astro` (use-case links); `astro.config.mjs` (sitemap
+  integration if missing); optionally `src/pages/index.astro` (link block).
+- Reuse: `Base.astro`, `Nav.astro`, `FinalCta.astro`, `SocialProof.astro`, shared pricing/
+  benefit data.
+
+### Open questions (resolve during discovery)
+- **Page set / keywords:** is the 4-page set above the right target, or should it track the
+  gallery tabs (advisor / agent / alerts / topology)? Confirm the keyword list with whatever
+  analytics/search-console signal exists; the layout must support 4–6 pages either way.
+- **Sitemap:** is `@astrojs/sitemap` already wired, or does a custom sitemap exist? Do not
+  double-emit.
+- **Claim audit:** which advisor/alerting capabilities are actually shipped at head vs. still
+  roadmap (plans 46/47 advisor, plan 25 email)? Only name shipped ones; leave a TODO comment
+  where a page would strengthen once a roadmap feature lands.
+
+## STOP conditions & drift check
+
+- STOP if any use-case page already exists — reconcile/extend instead of duplicating.
+- STOP and cut the claim if a capability a page would advertise is not shipped at head
+  (advisor auto-apply is FORBIDDEN to imply; email alerts may not exist yet).
+- DRIFT: if `Base.astro` does not centralize `<head>`/meta, coordinate with plan 69 rather
+  than hand-rolling per-page `<meta>` here (avoid two meta systems).
+- Do NOT add a second analytics library or any dashboard/runtime code.
+
+## Verification
+
+```
+cd apps/landing && bun install --frozen-lockfile && bun run build
+```
+
+- Confirm the build emits `monitor-queries`, `cluster-health`, `replication`, and
+  `performance` HTML pages and that each appears in the generated `sitemap*.xml`.
+- Grep the built output to confirm each page has a **unique** `<title>` and
+  `<h1>`, and that every advertised capability corresponds to a shipped feature.
+
+## Done criteria
+
+- ≥4 use-case pages build, each with a unique H1 + unique title/description and a real
+  screenshot.
+- Pages share `LandingPage.astro`; internal links exist (footer + cross-links); routes are
+  in the sitemap.
+- Valid `SoftwareApplication` schema per page; no unshipped-feature claims.
+- `bun run build` for `apps/landing` is green.
+
+Priority: P2 · Effort: L · Depth: E · Wave: G (Growth) · Lever: SEO / Adoption

--- a/plans/65-live-demo-embedded.md
+++ b/plans/65-live-demo-embedded.md
@@ -1,0 +1,119 @@
+# 65 — Live demo (embedded, public read-only)
+
+## Kickoff prompt
+
+```text
+Execute plans/65-live-demo-embedded.md ALONE (do not read other plans).
+Goal: stand up a public, read-only chmonitor demo (backed by a sample ClickHouse)
+and a "See a live demo" landing CTA + /demo page, with demo->signup tracked.
+
+Invariants (do not violate):
+- Self-hosted/OSS stays WHOLE: the demo is additive infra; it must not change the
+  self-host code path, billing, or default connection flow.
+- Marketing claims MUST match shipped features: the demo shows ONLY what the product
+  actually does (running queries, agent chat, topology, health) against real sample
+  data. No staged/fake panels. If a surface is not demo-safe, hide it, don't fake it.
+- Read-only + safe: the demo ClickHouse user is READ-ONLY; kill-query / control tools
+  and any DDL are DISABLED in the demo. AI still only RECOMMENDS, never auto-applies.
+- Analytics/DNT: reuse the existing analytics wrapper (plan 62); respect DNT; no PII.
+- Postgres/multi-DB: NO. ClickHouse-only.
+
+When done, run the Verification block at the bottom and paste the output.
+```
+
+## Current reality (audited)
+
+Why (roadmap §4/65, P1/M/E): there is **no public demo**. A prospect cannot see the product
+without connecting a cluster, which is the highest-friction step in the funnel. A live,
+read-only demo is the fastest proof-of-value and the natural target for the hero's secondary
+CTA (ties to plan 60's "See a live demo").
+
+Pointers (verify at head):
+- Landing Astro app: `apps/landing/src/pages/` (add `demo.astro`), `components/Hero.astro`
+  and `components/FinalCta.astro` (add/point the CTA), `layouts/Base.astro`.
+- The dashboard app (`apps/dashboard`) is what the demo actually renders; the demo needs a
+  **read-only chmonitor user/role + a sample ClickHouse endpoint** it can connect to. The
+  connection + control-tool surfaces live under `apps/dashboard/src/lib/` and the agent's
+  control tools are env-gated `(verify exact gates)` — the demo must run with them OFF.
+- Sample datasets: ClickHouse's public `Hits`/`Star Schema`/TPC-H are the conventional demo
+  corpora.
+
+## Goal
+
+A `/demo` entry point (page + hero CTA) that lands the visitor in a rate-limited, read-only
+chmonitor session over a sample ClickHouse — queries, agent chat, topology, and health are
+visible; nothing destructive is possible; the demo state resets periodically; and
+demo→signup conversion is tracked. Loads fast enough to be useful (<3s to first meaningful
+paint of the demo).
+
+## Implement now (depth E — approach + key files + open questions)
+
+### Approach
+1. **Demo cluster infra** — provision a public, read-only ClickHouse loaded with a sample
+   dataset (`Hits` or TPC-H). Create a chmonitor **read-only** user/role that: cannot run
+   control/kill tools, cannot execute DDL, and is scoped to the sample DB. This is the
+   load-bearing, mostly-infra part — see open questions.
+2. **Demo session** — a way to enter the dashboard in "demo mode": either (a) a pre-seeded,
+   shared read-only account the `/demo` page links into, or (b) an ephemeral demo session
+   the dashboard mints. Whichever is chosen, control tools/kill-query MUST be disabled and
+   rate limits applied. Prefer reusing existing edition/feature gates over new bespoke flags.
+3. **Landing surface** — `apps/landing/src/pages/demo.astro`: short framing + an embedded or
+   linked live dashboard + a prominent "Start free / connect your own cluster" CTA. Wire the
+   hero + `FinalCta` "See a live demo" button to `/demo` (coordinate with plan 60).
+4. **Reset** — a periodic reset (cron/scheduled) that restores the demo account's dashboards
+   and clears any accumulated agent conversations, so every visitor gets a clean demo.
+5. **Tracking** — fire `demo_viewed` and `demo_to_signup` via the existing analytics wrapper
+   (plan 62), so the demo's conversion contribution is measurable.
+
+### Key files
+- New: `apps/landing/src/pages/demo.astro`.
+- Edit: `apps/landing/src/components/Hero.astro` and/or `FinalCta.astro` (CTA target);
+  `layouts/Base.astro` (meta for `/demo` via plan 69).
+- Dashboard side (verify exact modules): demo/read-only role + control-tool gating; a demo
+  reset job.
+- Infra (not app code): the sample ClickHouse deployment + credentials (kept out of the repo;
+  configured via env/secrets).
+
+### Open questions (resolve during discovery)
+- **Demo cluster hosting:** where does the sample ClickHouse live (managed CH service, a
+  small self-hosted node, ClickHouse-provided public dataset endpoint), and who owns its
+  cost/uptime? This decision gates everything else — surface it before building UI.
+- **Session model:** shared read-only account vs. ephemeral per-visitor session — which does
+  the current auth/edition model support with the least new code, while still disabling
+  control tools?
+- **Embedding vs. linking:** can the dashboard be safely iframed on `/demo`, or should the
+  CTA open the dashboard in a new tab? (CSP/frame-ancestors + auth cookies decide this.)
+- **Abuse controls:** rate limiting + query timeouts on the demo endpoint so a visitor can't
+  hammer the sample cluster.
+
+## STOP conditions & drift check
+
+- STOP before exposing any demo session if control tools / kill-query / DDL are not provably
+  disabled for the demo role — a read-only guarantee is non-negotiable.
+- STOP if standing up the demo cluster requires committing credentials to the repo — keep
+  them in secrets/env only.
+- DRIFT: if there is no clean way to disable control tools per-session, do NOT weaken the
+  global gate; surface the gap and scope the demo to a deployment where controls are off.
+- Do NOT fake panels to fill the demo; hide surfaces that aren't demo-safe.
+
+## Verification
+
+```
+cd apps/landing && bun install --frozen-lockfile && bun run build
+```
+
+- Confirm `demo.astro` builds and the hero / final CTA link resolves to `/demo`.
+- Manually confirm (staging) the demo session is read-only: kill-query and any DDL/control
+  action are unavailable, and the agent only *recommends*.
+- Confirm `demo_viewed` / `demo_to_signup` events fire through the existing analytics wrapper
+  (and are suppressed under DNT).
+
+## Done criteria
+
+- `/demo` page + a "See a live demo" CTA in the hero/final CTA are live and build green.
+- The demo renders queries / agent / topology / health over real sample data, read-only, with
+  no destructive actions possible.
+- Demo state resets periodically; demo→signup conversion is tracked (DNT-respecting).
+- No fabricated UI; every visible capability is a shipped feature.
+
+Priority: P1 · Effort: M · Depth: E · Wave: G (Growth) · Lever: Adoption / Revenue

--- a/plans/67-docs-blog-content-engine.md
+++ b/plans/67-docs-blog-content-engine.md
@@ -1,0 +1,124 @@
+# 67 — Docs + blog content engine
+
+## Kickoff prompt
+
+```text
+Execute plans/67-docs-blog-content-engine.md ALONE (do not read other plans).
+Goal: stand up a repeatable docs+blog content engine — a 12-week editorial calendar,
+post templates, docs<->blog cross-links, an RSS feed, a GitHub-release->blog sync
+script, and a "latest posts" widget in the landing footer.
+
+Invariants (do not violate):
+- Self-hosted/OSS stays WHOLE: content + build tooling only; no app/runtime/billing
+  changes.
+- Marketing claims MUST match shipped features: release posts and how-tos describe
+  ONLY what actually shipped (advisor RECOMMENDS DDL / never auto-applies; alerting
+  channels as implemented; works on self-host/Docker/K8s/Cloud). Draft template must
+  include a "verify each claim against the code/changelog" checklist step.
+- Analytics/DNT: if posts embed any analytics, reuse the existing wrapper (plan 62)
+  and respect DNT; no PII.
+- Postgres/multi-DB: NO. ClickHouse-only positioning.
+
+When done, run the Verification block at the bottom and paste the output.
+```
+
+## Current reality (audited)
+
+Why (roadmap §4/67, P1/M/E): the blog has essentially one post and no cadence, so there is
+no SEO/nurture engine feeding the funnel. There is no release→content loop, no RSS, and the
+landing does not surface recent writing. Content is the cheapest durable growth lever for an
+open-core dev tool.
+
+Pointers (verify at head):
+- Blog app: `apps/blog/` — Astro content collection under `src/content/blog/`,
+  `astro.config.mjs`. (Round-2 plan 03 already touched blog surfaces, so the collection
+  exists.)
+- Docs app: `apps/docs/` — cross-linking target; confirm its build script name
+  (`bun run build:docs` per the task; `(verify)` in root `package.json`).
+- Landing footer: `apps/landing/src/components/Footer.astro` — where the "latest posts"
+  widget belongs.
+- Release source: GitHub releases for the repo — the sync script consumes these.
+
+## Goal
+
+A running content system: a documented 12-week calendar (mix of release notes, how-tos,
+troubleshooting, case studies), reusable post templates, bidirectional docs↔blog links, a
+working RSS feed, a script that turns a GitHub release into a draft blog post, and a landing
+footer widget listing the latest posts — such that a ≥2-posts/month cadence is
+operationally easy and every claim is verifiable.
+
+## Implement now (depth E — approach + key files + open questions)
+
+### Approach
+1. **Editorial calendar** — a committed `apps/blog/CONTENT-CALENDAR.md` (or similar) with 12
+   weeks of planned posts by type (release / how-to / troubleshooting / case-study), each
+   with target keyword and the docs page it should cross-link. This is the plan-of-record for
+   cadence.
+2. **Templates** — post templates (frontmatter + skeleton sections) per type under the blog
+   content dir, each ending with a **claim-verification checklist** ("does this feature ship
+   at the referenced version? link the changelog/PR"). Templates are how honesty is enforced
+   at authoring time.
+3. **Docs↔blog cross-linking** — establish the convention (how-to posts link the canonical
+   docs page; docs pages link the deeper blog write-up) and add the first links so the loop
+   is real, not just documented.
+4. **RSS** — add an RSS feed to the blog (`@astrojs/rss` or Astro's feed endpoint) so the
+   content is syndicable; link it from the footer widget.
+5. **Release→blog sync** — a script (`apps/blog/scripts/release-to-post.mjs` `(verify path)`)
+   that reads a GitHub release (tag, notes) and scaffolds a draft release post from the
+   release template, pre-filled and ready for the claim-verification pass. It **drafts**, it
+   does not auto-publish.
+6. **Landing "latest" widget** — a small block in `Footer.astro` (or a dedicated component it
+   imports) rendering the N most-recent posts (built from the blog content collection or its
+   RSS at build time).
+
+### Key files
+- New: blog content calendar doc; post templates; `apps/blog/scripts/release-to-post.mjs`;
+  RSS feed route/config in the blog.
+- Edit: `apps/blog/astro.config.mjs` (RSS/integration); `apps/landing/src/components/Footer.astro`
+  (latest-posts widget); the first docs pages + posts that form the cross-link loop.
+- Reuse: existing blog content-collection schema; docs build pipeline.
+
+### Open questions (resolve during discovery)
+- **Calendar ownership:** who authors on the cadence, and is 12 weeks / 2-per-month the right
+  target given available author time? The templates + sync script must make even a solo
+  cadence sustainable.
+- **Release-sync trigger:** does the script run manually, on a GitHub Actions `release`
+  event, or on demand? Decide before wiring; keep it draft-only regardless.
+- **Latest-posts data source:** does the landing build have access to the blog content
+  collection directly, or must it read the built RSS/JSON (separate Astro apps)? This
+  determines how the footer widget sources posts.
+- **Two markdown pipelines:** the repo already ships two markdown renderers (README DEP-02) —
+  reuse the blog's existing one; do not add a third.
+
+## STOP conditions & drift check
+
+- STOP if an RSS feed / release-sync / latest-posts widget already exists — reconcile instead
+  of duplicating.
+- STOP the release-sync script short of publishing — it drafts only; a human runs the
+  claim-verification checklist before anything goes live.
+- DRIFT: if templates would let an author state a roadmap feature as shipped, tighten the
+  checklist; honesty is enforced in the template, not left to the author's memory.
+- Do NOT add a new markdown/rendering pipeline; reuse the blog's.
+
+## Verification
+
+```
+bun run build:docs
+```
+
+Also build the blog (`cd apps/blog && bun install --frozen-lockfile && bun run build`
+`(verify script)`) and confirm: the RSS feed is emitted, at least two example/template posts
+render, the release-sync script produces a valid draft post from a sample release, and the
+landing footer's latest-posts widget builds (`cd apps/landing && bun run build`). Verify
+docs↔blog cross-links resolve.
+
+## Done criteria
+
+- A committed 12-week calendar + per-type templates (with a claim-verification checklist)
+  exist.
+- RSS feed builds; docs↔blog cross-links resolve; the landing footer shows latest posts.
+- The GitHub-release→blog sync script scaffolds a draft post (never auto-publishes).
+- `bun run build:docs` and the blog/landing builds are green; no unshipped-feature claims in
+  shipped templates/posts.
+
+Priority: P1 · Effort: M · Depth: E · Wave: G (Growth) · Lever: SEO / Adoption

--- a/plans/68-github-star-social-proof.md
+++ b/plans/68-github-star-social-proof.md
@@ -1,0 +1,97 @@
+# 68 — GitHub star social proof
+
+## Kickoff prompt
+
+```text
+Execute plans/68-github-star-social-proof.md ALONE (do not read other plans).
+Goal: add a prominent GitHub-star CTA to the landing — a star badge in the hero and
+a mid-page "building in public, star us" card — showing a live star count fetched at
+BUILD time, with click tracking and zero layout shift.
+
+Invariants (do not violate):
+- Self-hosted/OSS stays WHOLE: landing marketing only; no app/runtime/billing change.
+- Marketing claims MUST match reality: show the ACTUAL star count. If the build-time
+  fetch fails, fall back to the badge WITHOUT a fabricated number (or a static
+  "Star on GitHub" label) — never invent a count.
+- Analytics/DNT: track star-CTA clicks via the existing analytics wrapper (plan 62);
+  respect DNT; no PII.
+- Postgres/multi-DB: NO (not relevant here; keep the invariant visible).
+- No layout shift (CLS): reserve space for the count/badge so it does not reflow.
+
+When done, run the Verification block at the bottom and paste the output.
+```
+
+## Current reality (audited)
+
+Why (roadmap §4/68, P2/S/F): chmonitor is open-core, but the landing has **no prominent
+GitHub-star CTA**, forgoing cheap OSS social proof and discoverability. There is a
+`SocialProof.astro` component and an `OpenSource.astro` section, but no star badge/count or
+"star us" affordance in the hero or mid-page.
+
+Pointers (verify at head):
+- Hero: `apps/landing/src/components/Hero.astro` — badge placement (near the primary CTA).
+- Existing social-proof surfaces: `components/SocialProof.astro`, `components/OpenSource.astro`
+  — natural home / neighbor for the mid-page card.
+- Astro pages are static-built, so a **build-time** fetch of the GitHub star count is the
+  right mechanism (no client-side API call, no rate-limit exposure, no runtime dependency).
+- Analytics wrapper from plan 62 `(verify present)` for click tracking.
+
+## Implement now (depth F — file-level)
+
+### A. Build-time star count
+- Fetch the repo's stargazer count from the GitHub REST API at build time (inside the Astro
+  component frontmatter or an Astro config/data step), e.g. `GET /repos/{owner}/{repo}` →
+  `stargazers_count`. Read owner/repo from a shared constant/env, not hard-coded in two
+  places.
+- **Honest fallback:** wrap the fetch in try/catch; on failure render the star CTA with **no
+  number** (or a plain "Star on GitHub" label). Never render a placeholder/fake count.
+- Optionally format large counts (e.g. `1.2k`) but keep the raw number truthful.
+
+### B. Hero star badge — `components/Hero.astro`
+- Add a compact "★ Star on GitHub — {count}" badge/link near the hero CTAs, linking to the
+  repo. Keep it secondary to the primary product CTA (and to the "See a live demo" CTA from
+  plan 60 — don't crowd them).
+- **Reserve space** for the count so a slow/failed fetch does not shift layout (fixed min-width
+  or skeleton), satisfying the no-CLS invariant.
+
+### C. Mid-page star card
+- Add a mid-landing card ("We're building chmonitor in public — star the repo") either as a
+  new `components/StarCta.astro` placed in `index.astro`, or folded into `OpenSource.astro`
+  `(verify which is cleaner)`. Reuse the same build-time count value (compute once, pass
+  down) rather than fetching twice.
+
+### D. Click tracking
+- Fire a `github_star_cta_clicked` event (with a `placement: hero | midpage` property) via the
+  existing analytics wrapper on click; DNT-respecting, no PII.
+
+## STOP conditions & drift check
+
+- STOP if a star badge/count already exists — reconcile instead of duplicating.
+- STOP and use the honest fallback (no number) if the build-time fetch fails or is rate
+  limited; do NOT ship a hard-coded/fake count.
+- DRIFT: if `SocialProof.astro`/`OpenSource.astro` already fetch repo stats, reuse that data
+  path instead of adding a second GitHub fetch.
+- Fetch the count **once** at build and share it; do not fetch client-side at runtime.
+
+## Verification
+
+```
+cd apps/landing && bun install --frozen-lockfile && bun run build
+```
+
+- Confirm the build succeeds both when the GitHub fetch resolves and when it fails (simulate
+  by temporarily pointing at an invalid repo/offline) — the failing case must still build and
+  render the CTA with no fabricated number.
+- Inspect built HTML: the hero badge and mid-page card are present, link to the repo, and the
+  count area has reserved space (no reflow).
+- Confirm `github_star_cta_clicked` is wired through the existing analytics wrapper.
+
+## Done criteria
+
+- Star CTA appears in the hero **and** as a mid-landing card, linking to the repo.
+- The star count is fetched once at build time, shown truthfully, and falls back to a
+  number-free CTA on fetch failure.
+- Clicks are tracked with a `placement` property (DNT-respecting); no layout shift.
+- `apps/landing` `bun run build` is green.
+
+Priority: P2 · Effort: S · Depth: F · Wave: G (Growth) · Lever: Adoption / OSS

--- a/plans/OVERNIGHT-SWARM.md
+++ b/plans/OVERNIGHT-SWARM.md
@@ -1,0 +1,139 @@
+# Overnight swarm — kickoff prompts (Round 3, plans 14–70)
+
+Three ways to run the Round-3 backlog:
+1. **Master swarm prompt** — one prompt that dispatches parallel agents across the whole backlog,
+   auto-merges green PRs, and reports back.
+2. **Priority-wave prompts** — run a wave at a time (R → E/A/I/AI → D → G).
+3. **Per-plan prompts** — every `plans/NN-*.md` file has a `## Kickoff prompt` block to run that
+   one plan on demand.
+
+**Invariants every agent must hold (non-negotiable):**
+- Self-hosted/OSS stays whole; every plan/billing gate **fails open** without Clerk.
+- AI/advisor **recommends** DDL and **never auto-applies**; destructive actions stay ACK-gated.
+- **Honest paywalls & marketing**: advertised ⟺ enforced (or explicitly `deferred` in
+  `lib/billing/plan-enforcement.ts`); landing claims match shipped code.
+- Postgres/multi-DB: **NO** for 2026 H2.
+- Tests: **Bun test** for unit/logic, **Cypress** for component/e2e. Do **not** add Jest.
+
+**Verification baseline (every plan):** `bun run type-check` · `bun run build` · targeted
+`bun test … --isolate` · `bun run lint` (Biome). Landing plans: `cd apps/landing && bun install
+--frozen-lockfile && bun run build`.
+
+**Dependency edges to respect:** 54→53, 55→53, 58→53 · 57→56 · 59→56,57 · 34→30 · 47/48/49/50→
+build on 46's advisor dir but can start independently · 52→25/37 (deliver-or-persist) ·
+61/63→verify against shipped features · 65 gates 60's "live demo" CTA.
+
+---
+
+## 1. Master swarm prompt (auto-merge green)
+
+```text
+You are the overnight build swarm for the chmonitor monorepo (repo root: the chmonitor/ checkout).
+Goal: work the Round-3 feature backlog in plans/14–70 to green, merged PRs, unattended.
+
+Setup:
+1. Read plans/ROADMAP-2026H2.md (strategy + per-plan specs) and plans/README.md (status table +
+   conventions). Read CLAUDE.md and AGENTS.md for repo rules.
+2. Treat plans/README.md as the work queue: a plan is available if its row is TODO and its
+   "Depends on" plans are DONE. Respect the dependency edges in plans/OVERNIGHT-SWARM.md.
+
+Execution loop (run up to N plans in parallel, each in its own git worktree/branch):
+1. Claim a plan: set its README row to IN PROGRESS (your agent id) and commit that on your branch.
+2. Open plans/NN-*.md and implement EXACTLY what it scopes — nothing more. Honor its STOP
+   conditions and drift check. If the repo has drifted from the spec (a file moved/renamed), adapt
+   to reality; if the plan is no longer valid, set the row to BLOCKED (one-line reason) and stop.
+3. Hold the invariants (self-hosted whole / fail-open; advisor recommends-never-applies; honest
+   paywalls+marketing; Bun test not Jest; Postgres=NO).
+4. Run the plan's Verification block. All must pass: type-check, build, targeted bun test, lint.
+5. Open a PR titled `feat(<area>): <plan title> (plan NN)` with a body linking plans/NN-*.md and a
+   filled checklist of the plan's Done criteria.
+6. AUTO-MERGE if and only if: CI is green, no merge conflicts, and no invariant is touched
+   unsafely (any auth/billing/security-surface change → request human review instead of
+   auto-merging). Squash-merge. Then set the README row to DONE with the merge SHA.
+7. If anything fails: leave the row IN PROGRESS with a one-line blocker note, push the branch, and
+   continue to the next plan. Never force-push main. Never merge red.
+
+Ordering: prefer P0 → P1 → P2, and within that the owner's focus waves in order
+Revenue(14–20) → Alerting(25–34) → Integrations(35–45) → Advisor(46–52) → Enterprise(21–24) →
+Dashboards/OSS(53–59) → Growth(60–70). Test-only/additive plans (17, 51) may run anytime.
+
+Report at the end: a table of plan → status → PR/SHA → notes, and any BLOCKED plans with reasons.
+Do NOT touch secrets, do NOT deploy, do NOT change pricing numbers or remove any existing feature.
+```
+
+Tune `N` (parallelism) to your runner. Start conservative (N=4–6).
+
+---
+
+## 2. Priority-wave prompts
+
+Run one wave per night (or per runner). Each wave prompt is the master loop, scoped to a plan
+range. Paste the master prompt above, then append the wave scope:
+
+**Wave R — Revenue now (14–20)**
+```text
+SCOPE: only plans 14–20 (Revenue). These unblock the first paid dollar: AI-overage metering (14),
+paywall UX (15), billing dashboard card (16), checkout/webhook tests (17), per-host overage (18),
+downgrade protection (19), seat gate (20). Extra care on 14/18: never bill self-host, never
+double-charge; classify anything unshippable as `deferred` in plan-enforcement rather than faking
+revenue. Any billing-surface change → human review, do not auto-merge.
+```
+
+**Wave A — Alerting (25–34)** — *owner focus*
+```text
+SCOPE: only plans 25–34 (Alerting & Incident). Land 25 (email) and 27 (alert history) first; 28,
+29, 33 record into 27's alert_events (fall back gracefully if 27 not merged). 34 extends 30's
+alert_routes — land 30 before 34. Remediation (33) stays ACK-gated, never auto-executes DDL. All
+new outbound calls reuse the SSRF-guarded fetch.
+```
+
+**Wave I — Integrations (35–45)** — *owner focus*
+```text
+SCOPE: only plans 35–45 (Integrations). Adoption flywheels first: 35 (Prometheus /metrics), 41
+(ClickHouse Cloud connect), 43 (MCP registry), 44 (outbound webhook bus). 38 (Grafana plugin) and
+40 (Terraform provider) bootstrap NEW packages with their own toolchains — they must NOT break the
+monorepo `bun run build`; open them as separate PRs and request human review before merge. 36 adds
+a Cloudflare Queues binding to wrangler.toml with a self-host fail-open path.
+```
+
+**Wave AI — Advisor wedge (46–52)** — *highest strategic value*
+```text
+SCOPE: only plans 46–52 (Advisor). 46 (query-advisor-engine) is the wedge — build the advisor dir
++ tool; 47/49/50 extend it; 48 (baselines) and 51 (agent-eval goldens) are independently landable.
+ABSOLUTE invariant: the advisor OUTPUTS ranked DDL + risk + impact and NEVER executes/auto-applies.
+Every advisor PR must include a test asserting no execution/mutation of analyzed queries. Meter
+advisor calls as AI usage (ties to 14).
+```
+
+**Wave E — Enterprise (21–24)**
+```text
+SCOPE: only plans 21–24 (Enterprise: SSO/SAML, audit-log export, RBAC, multi-org pooling). All are
+edition-gated and must NOT degrade the OSS/community build (fail-open to community all-access).
+Auth/RBAC/audit changes → human review, do not auto-merge. Prefer Clerk enterprise connections for
+SSO rather than a bespoke SAML stack.
+```
+
+**Wave D — Dashboards & OSS de-hardcoding (53–59)**
+```text
+SCOPE: only plans 53–59. Land 53 (activate declarative queries) FIRST — 54, 55, 58 depend on it.
+Then 56 (dashboard D1) before 57/59. Keep the TS config path the DEFAULT; declarative + packs must
+fail closed to built-ins on any bad input. No feature removal.
+```
+
+**Wave G — Landing / Growth (60–70)** — *owner focus ("hero + everywhere")*
+```text
+SCOPE: only plans 60–70 (Landing/Marketing/Growth). 60 (hero wedge) + 61 (feature sections) + 62
+(analytics) + 69 (OG/SEO) are the core refresh; 70 (perf) gates conversion. HARD RULE: verify every
+marketing claim against shipped+enforced features before publishing copy — if the advisor (46) or a
+channel (email 25 / Opsgenie 26) isn't merged, describe the honest current state, don't oversell.
+Analytics (62) respects DNT and captures no PII/secrets. Landing verification:
+cd apps/landing && bun install --frozen-lockfile && bun run build.
+```
+
+---
+
+## 3. Per-plan prompts
+
+Every `plans/NN-*.md` opens with a `## Kickoff prompt` fenced block scoped to that single plan
+(with its invariants + verification commands). Paste it to run one plan on demand — ideal for
+spot-fixes or when a wave leaves a plan BLOCKED.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,8 +1,8 @@
 # Plans — cloud plan-benefits parity & follow-ups
 
 This directory holds implementation plans for making the cloud (SaaS) **plan
-benefits real, consistent, and tested**, plus two standalone follow-ups raised
-in review.
+benefits real, consistent, and tested**, plus the Round-2 audit fixes and the
+Round-3 feature backlog.
 
 ## North-star goal
 
@@ -15,13 +15,139 @@ in review.
 "Fail loud" applies: if a benefit can't be enforced yet, the plan says so and a
 test asserts the *current* contract so a future change can't regress it quietly.
 
-## Plans
+## How this queue works
+
+Treat this table as the **work queue**. A plan is available when its row is
+`⏳ TODO` and every plan it depends on is `✅ DONE`. Dependency edges and the
+per-wave kickoff prompts live in [OVERNIGHT-SWARM.md](OVERNIGHT-SWARM.md); the
+strategy + per-plan specs live in [ROADMAP-2026H2.md](ROADMAP-2026H2.md).
+
+Legend: **✅ DONE** merged to `main` · **🔶 HELD** PR open, needs a human
+decision (see reason) · **⏳ TODO** not started.
+
+## Round 1 — initial plans (01–03)
 
 | # | Plan | Type | Risk |
 |---|------|------|------|
 | 01 | [allow-private-hosts.md](01-allow-private-hosts.md) | feature (self-host) | low |
 | 02 | [plan-benefits-parity.md](02-plan-benefits-parity.md) | correctness + tests | medium |
 | 03 | [blog-stat-strip.md](03-blog-stat-strip.md) | copy | trivial |
+
+## Round 2 — audit fixes (04–13): all merged ✅
+
+Security / correctness / perf fixes surfaced by the code audit. Each shipped as
+its own squash-merged PR (code only; the spec files are archived here).
+
+| # | Plan | Status | PR |
+|---|------|--------|----|
+| 04 | [conversation-upsert-idor.md](04-conversation-upsert-idor.md) — scope upsert to owner (cross-tenant IDOR) | ✅ DONE | [#2203](https://github.com/chmonitor/chmonitor/pull/2203) |
+| 05 | [health-webhook-auth-gate.md](05-health-webhook-auth-gate.md) — write-auth on the SSRF proxy | ✅ DONE | [#2204](https://github.com/chmonitor/chmonitor/pull/2204) |
+| 06 | [alert-commit-after-delivery.md](06-alert-commit-after-delivery.md) — dedup state after delivery | ✅ DONE | [#2205](https://github.com/chmonitor/chmonitor/pull/2205) |
+| 07 | [parallel-connection-chart-queries.md](07-parallel-connection-chart-queries.md) — parallel chart queries | ✅ DONE | [#2206](https://github.com/chmonitor/chmonitor/pull/2206) |
+| 08 | [retention-prune-characterization-tests.md](08-retention-prune-characterization-tests.md) — cron prune tests | ✅ DONE | [#2207](https://github.com/chmonitor/chmonitor/pull/2207) |
+| 09 | [management-ddl-injection.md](09-management-ddl-injection.md) — escape/validate RBAC DDL | ✅ DONE | [#2208](https://github.com/chmonitor/chmonitor/pull/2208) |
+| 10 | [data-table-body-render-key.md](10-data-table-body-render-key.md) — cheap render key | ✅ DONE | [#2209](https://github.com/chmonitor/chmonitor/pull/2209) |
+| 11 | [clerk-webhook-handler-tests.md](11-clerk-webhook-handler-tests.md) — seat-enforcement tests | ✅ DONE | [#2210](https://github.com/chmonitor/chmonitor/pull/2210) |
+| 12 | [ai-agent-doc-tool-sync.md](12-ai-agent-doc-tool-sync.md) — docs↔tools sync + anti-drift test | ✅ DONE | [#2211](https://github.com/chmonitor/chmonitor/pull/2211) |
+| 13 | [ssrf-guard-ipv6-pinning-tests.md](13-ssrf-guard-ipv6-pinning-tests.md) — IPv6 + DNS-pinning tests | ✅ DONE | [#2202](https://github.com/chmonitor/chmonitor/pull/2202) |
+
+Supporting infra PRs: [#2212](https://github.com/chmonitor/chmonitor/pull/2212)
+(biome format drift) and
+[#2220](https://github.com/chmonitor/chmonitor/pull/2220) (break the plan-48
+baseline import cycle + clear round-3 format drift).
+
+## Round 3 — feature backlog (14–70)
+
+### Merged ✅ (9)
+
+| # | Plan | PR |
+|---|------|----|
+| 35 | [prometheus-metrics-exporter.md](35-prometheus-metrics-exporter.md) | [#2215](https://github.com/chmonitor/chmonitor/pull/2215) |
+| 48 | [statistical-anomaly-baselines.md](48-statistical-anomaly-baselines.md) | [#2217](https://github.com/chmonitor/chmonitor/pull/2217) |
+| 50 | [capacity-forecast-ttl-advisor.md](50-capacity-forecast-ttl-advisor.md) | [#2222](https://github.com/chmonitor/chmonitor/pull/2222) |
+| 51 | [agent-eval-golden-tests.md](51-agent-eval-golden-tests.md) | [#2216](https://github.com/chmonitor/chmonitor/pull/2216) |
+| 53 | [activate-declarative-queries.md](53-activate-declarative-queries.md) | [#2214](https://github.com/chmonitor/chmonitor/pull/2214) |
+| 55 | [self-hosted-local-config-override.md](55-self-hosted-local-config-override.md) | [#2221](https://github.com/chmonitor/chmonitor/pull/2221) |
+| 62 | [product-analytics-funnel.md](62-product-analytics-funnel.md) | [#2219](https://github.com/chmonitor/chmonitor/pull/2219) |
+| 69 | [og-images-seo-meta-audit.md](69-og-images-seo-meta-audit.md) | [#2223](https://github.com/chmonitor/chmonitor/pull/2223) |
+| 70 | [landing-perf-lighthouse.md](70-landing-perf-lighthouse.md) | [#2226](https://github.com/chmonitor/chmonitor/pull/2226) |
+
+### Held 🔶 — PR open, needs a human decision (4)
+
+Implemented and pushed, but deliberately **not auto-merged**: each touches a
+billing / security surface or failed live verification, so a person should make
+the call. The spec file for each held plan lives on its PR branch (kept off
+`main` until the PR merges).
+
+| # | Plan | PR | Why it's held |
+|---|------|----|---------------|
+| 14 | Wire AI overage spend metering | [#2213](https://github.com/chmonitor/chmonitor/pull/2213) | **Billing surface.** As written the Free monthly-USD cap is inert — usage is bounded only by the 5-messages/day limit, so real spend is never metered against a dollar cap. Confirm the intended cap semantics before enforcing. |
+| 25 | Email alert adapter | [#2218](https://github.com/chmonitor/chmonitor/pull/2218) | **No-op transport.** The SMTP path is a stub, and email only fires from the cron sweep when a webhook is *also* configured. Decide the real transport (Mailgun/SendGrid/SMTP) and the fire path. *(Branch is behind `main`; its only red is an inherited depcruise from before #2220 — update-branch clears it.)* |
+| 56 | Dashboard D1 persistence & sharing | [#2224](https://github.com/chmonitor/chmonitor/pull/2224) | **Public share endpoint + entitlement surface.** Adds an unauthenticated share route and a billing/entitlement gate. Needs a security review and a CI-build proof of client/server layering. *(Only red is `codecov/patch` — soft coverage, not a merge blocker.)* |
+| 66 | Onboarding sample-cluster preset | [#2225](https://github.com/chmonitor/chmonitor/pull/2225) | **Failed live verification.** The public demo endpoint (`play.clickhouse.com`) denies `query_log`/`parts`/`merges`/etc., so most monitoring pages render empty. Choose a demo endpoint that exposes the system tables before shipping the "Try with sample cluster" CTA. |
+
+### Not started ⏳ (44) — grouped by what unblocks each
+
+Each of these needs a **product/design decision**, **depends on a held PR**, or
+is **epic-scale** (new toolchain / package / enterprise auth) — i.e. not
+appropriate for blind autonomous execution. Grouped by the blocker:
+
+- **Revenue 15–20** (6) — build on the billing enforcement in held **#14**:
+  [15 upgrade-paywall-modal](15-upgrade-paywall-modal.md),
+  [16 billing-usage-dashboard-card](16-billing-usage-dashboard-card.md),
+  [17 checkout-webhook-e2e-tests](17-checkout-webhook-e2e-tests.md),
+  [18 per-host-overage-billing](18-per-host-overage-billing.md),
+  [19 downgrade-protection](19-downgrade-protection.md),
+  [20 seat-cap-invite-time-gate](20-seat-cap-invite-time-gate.md). **Unblock #14 first.**
+- **Enterprise 21–24** (4) — edition-gated enterprise auth; prefer Clerk
+  enterprise connections over a bespoke SAML stack. Product decision required:
+  [21 sso-saml-enterprise](21-sso-saml-enterprise.md),
+  [22 audit-log-export](22-audit-log-export.md),
+  [23 rbac-roles-enterprise](23-rbac-roles-enterprise.md),
+  [24 enterprise-multi-org-pooling](24-enterprise-multi-org-pooling.md).
+- **Alerting 26–34** (9) — interdependent cluster; land **#25** (held) and a
+  `27` alert_events store first, then the rest record into it:
+  [26 opsgenie-adapter](26-opsgenie-adapter.md),
+  [27 alert-history-audit-log](27-alert-history-audit-log.md),
+  [28 maintenance-windows-suppression](28-maintenance-windows-suppression.md),
+  [29 alert-ack-manual-resolution](29-alert-ack-manual-resolution.md),
+  [30 per-rule-alert-routing](30-per-rule-alert-routing.md),
+  [31 compound-alert-rules](31-compound-alert-rules.md),
+  [32 custom-alert-rule-builder](32-custom-alert-rule-builder.md),
+  [33 remediation-action-links](33-remediation-action-links.md) (ACK-gated, never auto-executes DDL),
+  [34 pagerduty-escalation-oncall](34-pagerduty-escalation-oncall.md) (extends 30).
+- **Integrations 36–47** (12) — new packages/toolchains (38 Grafana plugin, 40
+  Terraform provider, 39 OTel, 37 Slack OAuth) + security-adjacent proxies
+  (42/43/44); 46 is the advisor wedge (epic):
+  [36 inbound-event-bus-queues](36-inbound-event-bus-queues.md),
+  [37 slack-app-native-oauth](37-slack-app-native-oauth.md),
+  [38 grafana-datasource-plugin](38-grafana-datasource-plugin.md),
+  [39 otel-trace-export](39-otel-trace-export.md),
+  [40 terraform-provider](40-terraform-provider.md),
+  [41 clickhouse-cloud-connect-wizard](41-clickhouse-cloud-connect-wizard.md),
+  [42 kafka-consumer-control](42-kafka-consumer-control.md),
+  [43 mcp-custom-server-registry](43-mcp-custom-server-registry.md),
+  [44 webhook-event-bus-outbound](44-webhook-event-bus-outbound.md),
+  [45 github-deploy-correlation](45-github-deploy-correlation.md),
+  [46 query-advisor-engine](46-query-advisor-engine.md) (recommend-only, never auto-applies DDL),
+  [47 mv-projection-designer](47-mv-projection-designer.md) (recommend-only).
+- **Advisor 49, 52** (2) — [49 query-cost-estimator](49-query-cost-estimator.md)
+  (builds on 46), [52 proactive-weekly-health-report](52-proactive-weekly-health-report.md)
+  (depends on 25/37 delivery channels).
+- **Dashboards/OSS 54, 57–59** (4) — depend on held **#56** or are epic-scope:
+  [54 query-config-pack-registry](54-query-config-pack-registry.md),
+  [57 custom-dashboard-builder-grid](57-custom-dashboard-builder-grid.md) (needs 56),
+  [58 declarative-chart-schema](58-declarative-chart-schema.md),
+  [59 ai-generated-dashboards](59-ai-generated-dashboards.md) (needs 56/57).
+- **Growth 60–61, 63–65, 67–68** (7) — marketing copy must be verified against
+  shipped+enforced features first (60/61/63/64), and 65 depends on held **#66**:
+  [60 landing-hero-wedge-refresh](60-landing-hero-wedge-refresh.md),
+  [61 feature-sections-advisor-alerts-refresh](61-feature-sections-advisor-alerts-refresh.md),
+  [63 comparison-pages-vs-competitors](63-comparison-pages-vs-competitors.md),
+  [64 seo-use-case-landing-pages](64-seo-use-case-landing-pages.md),
+  [65 live-demo-embedded](65-live-demo-embedded.md) (needs 66),
+  [67 docs-blog-content-engine](67-docs-blog-content-engine.md),
+  [68 github-star-social-proof](68-github-star-social-proof.md).
 
 ## How "done" is judged (every plan)
 

--- a/plans/ROADMAP-2026H2.md
+++ b/plans/ROADMAP-2026H2.md
@@ -1,0 +1,602 @@
+# Round 3 — Feature Roadmap (2026 H2)
+
+> Generated 2026-07-03 at commit `c1668bb78`. Grounded in a full-repo audit (not PRD
+> claims). This is the **single source of truth** for the Round-3 plan set (plans
+> **14–70**). Each numbered plan below has a self-contained file `plans/NN-*.md`
+> written for a zero-context executor (house convention in `plans/README.md`).
+>
+> Rounds 1–2 (plans 01–13) were parity + audit fixes. **Round 3 is features**:
+> exhaustive, weighted to the owner's stated focus — **alerting, integrations, and
+> the landing/marketing refresh** — plus the revenue and AI-advisor levers.
+
+---
+
+## 1. Strategy (North Star: Revenue/MRR → Adoption → AI differentiation)
+
+**Positioning wedge — sharpened by 2026 market reality.** ClickHouse itself now ships
+"Ask AI", a remote MCP server, and Claude-powered "ClickHouse Agents" (Open House 2026,
+public beta) — but all three are **Cloud-locked and analytics-first**: they help data
+users write queries and build visualizations on *managed* ClickHouse. None is an
+**operational advisor for self-hosted clusters**. That is chmonitor's uncontested lane:
+
+> **"pganalyze for ClickHouse"** — a ClickHouse-specific ops advisor that reads
+> `system.*` and recommends **projections, skip-indexes, partition keys, PREWHERE,
+> and materialized views** (DDL it *recommends, never auto-applies*), with alerting and
+> integrations that work on **every** deployment (self-host, Docker, K8s, Cloud).
+
+**Pricing is validated.** pganalyze charges **$149/mo for one server**, +$100/extra
+server (replica ×0.5). chmonitor's **$29 Pro / $99 Max + $15–19 per-host overage**
+undercuts it decisively while the OSS core stays free — the open-core flywheel pganalyze
+never had.
+
+**Integrations are the adoption flywheel, not the moat.** Grafana (Altinity plugin: 16.6M
+downloads; official ClickHouse datasource), Datadog, and the Altinity K8s operator already
+own the *raw-metrics* lane. So chmonitor's Prometheus/Grafana/OTel work must **lead with
+the advisor + alerting** (things those tools don't do for ClickHouse), and meet teams where
+they are (export to their stack) rather than fight to replace it.
+
+**Three moves, in priority order:**
+1. **Turn on the money** (Wave R/E). Billing infra is live (Polar + Clerk + D1; host/seat/AI
+   daily/AI budget/retention all enforced). The gaps are *overage metering*, *paywall UX*,
+   and *enterprise (SSO/RBAC/audit)* — the difference between "can charge" and "converts."
+2. **Ship the wedge** (Wave AI). The advisor is the reason someone picks chmonitor over
+   `system.query_log` + Grafana. Today the product *collects and explains*; it does not yet
+   *recommend DDL*. Close that gap.
+3. **Widen the mouth of the funnel** (Waves A/I/G). Alerting + integrations + an honest,
+   advisor-forward landing page are what turn GitHub stars into connected clusters.
+
+**Invariants (never violate — enforced by every plan):**
+- Self-hosted/OSS stays **whole**; every plan/billing gate **fails open** without Clerk.
+- AI **recommends** DDL, **never auto-applies**. Destructive actions stay ACK-gated.
+- **Honest paywalls**: advertised ⟺ enforced (or explicitly `deferred`) in
+  `lib/billing/plan-enforcement.ts`; landing claims must match shipped code.
+- Postgres/multi-DB: **NO** for 2026 H2 (ADR carried in memory; revisit after $10k MRR).
+
+---
+
+## 2. Audit summary — real state vs. PRD claims
+
+The PRD over-states "shipped." Verified reality at `c1668bb78`:
+
+| Area | Real state (audited) |
+|---|---|
+| **Alerting** | Strong core: pluggable rule registry (15 builtin rules), dedup/cooldown state store, Slack/Discord/Telegram/PagerDuty/generic adapters, 5-min cron sweep, SSRF-guarded webhook proxy, insights engine. **Gaps:** no email adapter, no persisted alert history, no maintenance windows/ACK, host-level only, single global route, no escalation/on-call. |
+| **Integrations** | PeerDB (read-only), Kafka UI (read-only), OTel span *viewer*, Grafana *copy-paste recipe*, outbound alert webhooks, MCP server (built-in). **Missing:** Prometheus `/metrics` exporter, inbound event bus, native Slack app, Grafana plugin, Terraform, OTel *export*, ClickHouse-Cloud connect wizard, configurable outbound webhook bus. |
+| **AI advisor** | Tier-2 "collector + skill guide": 11 real tool groups, 18 skills (projection/index guidance in **prose only**), deterministic insights with static thresholds. **Missing the wedge:** no programmatic DDL recommender, no MV/projection designer, no statistical baselines, no cost estimator, no agent-eval harness. |
+| **Billing** | Live and enforcing: Polar checkout/portal/webhooks, Clerk orgs, D1 cache; host/seat/AI-daily/AI-budget/retention gates all wired and fail-open. **Gaps:** AI *overage* spend never accumulated, no in-app paywall/upgrade UX, no billing dashboard card, no SSO/RBAC/audit, per-host overage unplugged. |
+| **Dashboards / OSS** | Declarative query-config engine **built but dormant** (`CHM_CONFIG_SOURCE=ts` default); 40 factory / 34 hand-rolled charts; dashboards in localStorage only (D1 store exists, unwired). **The de-hardcoding lever is one flag + a pack loader away.** |
+| **Landing** | Astro; hero = "See every ClickHouse query. As it runs." Query-centric, AI-agent-second. No advisor/alerting/integrations wedge, **no product analytics**, no live demo, no sample cluster, no comparison sub-pages. |
+
+---
+
+## 3. Master plan table (Round 3 — plans 14–70)
+
+Priority P0–P3 · Effort S/M/L/XL · Depth **F**=full-executable, **E**=epic-brief · Wave.
+Full status table lives in `plans/README.md`. Depth "F" plans are audited to file-level and
+ready for an unattended overnight agent; "E" plans need light discovery first.
+
+### Wave R — Revenue Now (monetization)
+| # | Plan | P | Eff | Depth |
+|---|------|---|-----|-------|
+| 14 | wire-ai-overage-spend-metering | P0 | S | F |
+| 15 | upgrade-paywall-modal | P0 | M | F |
+| 16 | billing-usage-dashboard-card | P0 | M | F |
+| 17 | checkout-webhook-e2e-tests | P1 | M | F |
+| 18 | per-host-overage-billing | P1 | L | E |
+| 19 | downgrade-protection | P1 | S | F |
+| 20 | seat-cap-invite-time-gate | P1 | S | F |
+
+### Wave E — Enterprise (revenue / TAM)
+| # | Plan | P | Eff | Depth |
+|---|------|---|-----|-------|
+| 21 | sso-saml-enterprise | P2 | L | E |
+| 22 | audit-log-export | P2 | M | F |
+| 23 | rbac-roles-enterprise | P2 | L | E |
+| 24 | enterprise-multi-org-pooling | P2 | L | E |
+
+### Wave A — Alerting & Incident (focus)
+| # | Plan | P | Eff | Depth |
+|---|------|---|-----|-------|
+| 25 | email-alert-adapter | P0 | M | F |
+| 26 | opsgenie-adapter | P1 | M | F |
+| 27 | alert-history-audit-log | P1 | M | F |
+| 28 | maintenance-windows-suppression | P1 | M | F |
+| 29 | alert-ack-manual-resolution | P1 | M | F |
+| 30 | per-rule-alert-routing | P1 | L | E |
+| 31 | compound-alert-rules | P2 | L | E |
+| 32 | custom-alert-rule-builder | P2 | M | E |
+| 33 | remediation-action-links | P2 | M | F |
+| 34 | pagerduty-escalation-oncall | P1 | L | E |
+
+### Wave I — Integrations & Ecosystem (focus)
+| # | Plan | P | Eff | Depth |
+|---|------|---|-----|-------|
+| 35 | prometheus-metrics-exporter | P0 | M | F |
+| 36 | inbound-event-bus-queues | P1 | L | E |
+| 37 | slack-app-native-oauth | P1 | L | E |
+| 38 | grafana-datasource-plugin | P1 | L | E |
+| 39 | otel-trace-export | P2 | M | F |
+| 40 | terraform-provider | P2 | XL | E |
+| 41 | clickhouse-cloud-connect-wizard | P1 | M | F |
+| 42 | kafka-consumer-control | P2 | M | F |
+| 43 | mcp-custom-server-registry | P1 | M | F |
+| 44 | webhook-event-bus-outbound | P1 | M | F |
+| 45 | github-deploy-correlation | P2 | M | E |
+
+### Wave AI — Advisor Differentiation (the wedge)
+| # | Plan | P | Eff | Depth |
+|---|------|---|-----|-------|
+| 46 | query-advisor-engine | P0 | XL | E |
+| 47 | mv-projection-designer | P0 | L | E |
+| 48 | statistical-anomaly-baselines | P1 | M | F |
+| 49 | query-cost-estimator | P1 | L | E |
+| 50 | capacity-forecast-ttl-advisor | P2 | M | F |
+| 51 | agent-eval-golden-tests | P1 | L | F |
+| 52 | proactive-weekly-health-report | P1 | M | F |
+
+### Wave D — Dashboards & OSS de-hardcoding
+| # | Plan | P | Eff | Depth |
+|---|------|---|-----|-------|
+| 53 | activate-declarative-queries | P0 | S | F |
+| 54 | query-config-pack-registry | P0 | M | E |
+| 55 | self-hosted-local-config-override | P1 | M | F |
+| 56 | dashboard-d1-persistence-sharing | P1 | M | F |
+| 57 | custom-dashboard-builder-grid | P1 | L | E |
+| 58 | declarative-chart-schema | P2 | M | E |
+| 59 | ai-generated-dashboards | P2 | L | E |
+
+### Wave G — Landing / Marketing / Growth (focus)
+| # | Plan | P | Eff | Depth |
+|---|------|---|-----|-------|
+| 60 | landing-hero-wedge-refresh | P0 | L | F |
+| 61 | feature-sections-advisor-alerts-refresh | P1 | M | F |
+| 62 | product-analytics-funnel | P0 | M | F |
+| 63 | comparison-pages-vs-competitors | P1 | M | E |
+| 64 | seo-use-case-landing-pages | P2 | L | E |
+| 65 | live-demo-embedded | P1 | M | E |
+| 66 | onboarding-sample-cluster-preset | P1 | M | F |
+| 67 | docs-blog-content-engine | P1 | M | E |
+| 68 | github-star-social-proof | P2 | S | F |
+| 69 | og-images-seo-meta-audit | P1 | M | F |
+| 70 | landing-perf-lighthouse | P1 | S | F |
+
+**Deferred long-tail** (captured as backlog issues, not written as plan files this round):
+k8s-operator/CRD auto-discovery, dbt lineage, Aiven/Altinity cloud auto-discovery, S3 backup
+audit, PeerDB safe mutations, native mobile, marketplace, visual query builder. Promote to a
+numbered plan when a design-partner pulls.
+
+---
+
+## 4. Per-plan specs (writers expand these into `plans/NN-*.md`)
+
+Each block is the audited spec. Writers must expand into the house format (see
+`plans/README.md` + example `plans/02-plan-benefits-parity.md`): **Kickoff prompt**,
+Current reality (audited), Goal, Implement-now (files/APIs), STOP conditions/drift check,
+Verification commands, Done-criteria. Keep invariants. Verification baseline for every plan:
+`bun run type-check` · `bun run build` · targeted `bun test … --isolate` · `bun run lint`.
+
+### Wave R — Revenue Now
+
+**14 · wire-ai-overage-spend-metering · P0/S/F**
+- Why: overage revenue unplugged — `ai_usage_monthly` exists but per-request USD is never accumulated, so Pro/Max soft-caps bill $0 past the included allowance.
+- Files: `apps/dashboard/src/routes/api/v1/agent.ts` (post-generation hook), `src/lib/billing/ai-usage-store.ts` (`addAiSpend`), `src/routes/api/v1/billing/usage.ts` (surface `aiSpentThisMonth`).
+- Approach: after a successful generation, compute cost from real token usage × model price; if past the daily included allowance, `addAiSpend(owner.id, usd)`. Free hard-caps; Pro/Max meter overage; fail-open for self-host.
+- Accept: overage accumulates in D1; usage API returns `aiSpentThisMonth` vs `aiMonthlyUsdBudget`; test proves Free=hardcap / Pro=meter.
+- Lever: Revenue. Kickoff: "Accumulate AI overage USD via addAiSpend after each generation; Free hard-caps, Pro/Max meter, OSS untouched."
+
+**15 · upgrade-paywall-modal · P0/M/F**
+- Why: a 402 (host/seat/AI limit) returns raw JSON, not a paywall — the single biggest CVR leak.
+- Files: new `src/components/billing/paywall-modal.tsx`; `src/lib/api/error-handler.ts` (classify 402 → reason); reuse `src/lib/billing/entitlements.ts:limitMessage`; wire into app error boundary/toast.
+- Approach: intercept 402s, parse `reason` (host/seat/ai_daily/ai_budget), show modal with current vs next-tier caps + "Upgrade" → `POST /api/v1/billing/checkout`. Honest copy for `deferred` vs `enforced`.
+- Accept: 402 shows modal not error; upgrade opens Polar checkout; dismiss clean; test per reason.
+- Lever: Revenue/Adoption. Kickoff: "Add a PaywallModal that intercepts 402s and routes to Polar checkout with honest limit copy."
+
+**16 · billing-usage-dashboard-card · P0/M/F**
+- Why: no in-app surface for plan/usage/renewal — billing is invisible, so is the upgrade path.
+- Files: new `src/components/billing/{current-plan-card,usage-meters,renewal-banner}.tsx`; `src/routes/(dashboard)/billing.tsx`; reuse `routes/api/v1/billing/usage.ts`.
+- Approach: render plan + hosts/seats/AI-daily/AI-monthly meters (red >80%), renewal date, cancel-grace banner; CTAs → checkout / Polar portal.
+- Accept: card shows all meters + renewal; over-limit state warns; buttons route correctly; tests for Free/Pro/over-limit/cancel-grace.
+- Lever: Revenue/Adoption. Kickoff: "Build the in-app billing card (plan, usage meters, renewal, upgrade/manage CTAs) from /billing/usage."
+
+**17 · checkout-webhook-e2e-tests · P1/M/F**
+- Why: the checkout→webhook→D1→plan path is the revenue critical path and under-tested.
+- Files: `routes/api/v1/billing/checkout.test.ts` (new), `routes/api/v1/webhooks/polar.test.ts` (extend), `src/lib/billing/__tests__/checkout-e2e.test.ts` (new), runbook `docs/knowledge/billing-checkout-flow.md`.
+- Approach: unit + integration for checkout URL creation, webhook signature/idempotency/monotonic guard, D1 cache miss → Polar reconciliation; document recovery.
+- Accept: checkout returns valid URL; duplicate webhooks don't double-write; reconciliation covers cache miss; runbook committed.
+- Lever: Revenue. Kickoff: "Add e2e tests + runbook for checkout→Polar-webhook→D1→plan resolution incl. idempotency and reconciliation."
+
+**18 · per-host-overage-billing · P1/L/E**
+- Why: the advertised $15–19/host overage (GA pricing lever) has no code path; hosts hard-cap instead of expanding.
+- Files: `packages/pricing/src/plans.ts` (add `hostOverage`), `src/lib/billing/entitlements.ts` (soft-cap paid tiers), `routes/api/v1/user-connections.ts` (allow + meter), new `host_usage_monthly` D1 table, Polar usage-based reporting.
+- Approach: mirror the AI-overage model for hosts — soft-cap for paid, meter over-limit count × per-host price into monthly bill; keep Free hard-capped.
+- Accept: paid tier adds 4th+ host without 402; overage metered; monthly total = base + overage; tests for Pro/Max math.
+- Lever: Revenue (land-and-expand). Kickoff: "Soft-cap hosts for paid tiers and meter per-host overage into a monthly bill (mirror AI overage)."
+
+**19 · downgrade-protection · P1/S/F**
+- Why: users can downgrade below current usage and silently lose access to hosts/seats.
+- Files: new `routes/api/v1/billing/can-downgrade.ts`; `src/components/billing/` (confirm modal).
+- Approach: before portal link, compare current usage to target-plan limits; if over, warn with the exceeded limits and offer "stay" vs "downgrade anyway".
+- Accept: over-limit downgrade warns; confirm proceeds + logs; tests Free→Pro and Max→Pro.
+- Lever: Revenue (retention). Kickoff: "Add can-downgrade check + warning modal when current usage exceeds the target plan."
+
+**20 · seat-cap-invite-time-gate · P1/S/F**
+- Why: seat limit is enforced *post-hoc* via Clerk rollback — confusing UX; should pre-check at invite.
+- Files: org invite endpoint (locate), `src/lib/billing/entitlements.ts:checkSeatLimit`, keep `routes/api/v1/webhooks/clerk.ts` rollback as defense-in-depth.
+- Approach: pre-check `getPlanForOwner` + current member count before invite; 402 + paywall if over.
+- Accept: over-cap invite returns 402 pre-add; paywall shown; webhook fallback intact; test at seats and seats+1.
+- Lever: Adoption. Kickoff: "Pre-check seat limit at invite time and 402 with paywall instead of post-hoc Clerk rollback."
+
+### Wave E — Enterprise
+
+**21 · sso-saml-enterprise · P2/L/E**
+- Why: SSO/SAML is table-stakes for enterprise deals; `edition` flags it but nothing enforces it.
+- Files: new `src/lib/auth/sso/` (metadata + assertion validate), `routes/api/v1/auth/sso-callback.ts`, Clerk enterprise-connection integration, `src/lib/edition/edition.ts` (gate `sso`).
+- Approach: prefer Clerk's SAML/enterprise connections; admin configures IdP + verified domain → JIT-provision org+user on assertion; map IdP groups → roles (see 23).
+- Accept: SSO login provisions Clerk user+org scoped to domain; session resolves Enterprise; gated to enterprise edition.
+- Lever: Enterprise/Revenue. Kickoff: "Add SAML SSO (via Clerk enterprise connections) with domain-verified JIT org provisioning, enterprise-gated."
+
+**22 · audit-log-export · P2/M/F**
+- Why: SOC2/ISO buyers need an audit trail + export; none exists.
+- Files: new `audit_logs` D1 migration, `src/lib/audit/` (`logEvent`), `routes/api/v1/audit/export.ts` (CSV, date-filtered, org-scoped), wire into Clerk webhook + billing + connection mutations; enterprise-gated.
+- Approach: append-only event log (ts, user, org, event, resource, action, result, ip); GET export returns org-scoped CSV.
+- Accept: state-changing actions logged; CSV export filters by date + org only; tests for coverage + scoping.
+- Lever: Enterprise. Kickoff: "Add an append-only audit_logs table + org-scoped CSV export, enterprise-gated, wired to member/billing/connection mutations."
+
+**23 · rbac-roles-enterprise · P2/L/E**
+- Why: `rbac.ts` is community all-access; real teams need viewer/operator/admin scoping.
+- Files: `src/lib/rbac/rbac.ts` (real role→permission matrix), Clerk org roles sync, server gates on write routes (control tools, connections, alert rules), UI role management.
+- Approach: define roles (viewer/operator/admin) → permissions; map Clerk org roles; enforce on write paths; fail-open to community single-operator when edition≠enterprise.
+- Accept: viewer can't kill queries/edit connections; admin can; community unchanged; tests per role.
+- Lever: Enterprise. Kickoff: "Implement enterprise RBAC (viewer/operator/admin) mapped from Clerk org roles, gating write routes; community stays all-access."
+
+**24 · enterprise-multi-org-pooling · P2/L/E**
+- Why: large customers run multiple Clerk orgs but want one subscription + pooled limits.
+- Files: `src/lib/billing/billing-owner.ts` (parent resolution), `user-subscription.ts` (plan by parent), `org-host-count.ts` (pool), new `org_group` D1 table.
+- Approach: designate a parent org; bill + pool hosts/seats/AI/retention across children; unified usage in portal.
+- Accept: child orgs resolve parent plan; limits pool; one subscription; tests for pooling math.
+- Lever: Enterprise/TAM. Kickoff: "Add org-group parent/child so one subscription pools hosts/seats/AI across child orgs."
+
+### Wave A — Alerting & Incident (focus)
+
+**25 · email-alert-adapter · P0/M/F**
+- Why: email is the universal alert channel; adapters cover Slack/Discord/Telegram/PagerDuty but **not email** — an adoption blocker for teams without Slack.
+- Files: new `src/lib/health/adapters/email.ts`, register in `adapters/index.ts`, `server-alert-config.ts` (`HEALTH_ALERT_EMAIL_*`), `components/health/health-settings-dialog.tsx` (recipient config + test).
+- Approach: adapter renders HTML (host, check, value, thresholds, runbook link); provider via `mailgun://`/`sendgrid://`/SMTP; server reads recipients/from; test-send in settings.
+- Accept: valid MIME/HTML email dispatched; provider detected from URL/env; settings test works; passes adapter test parity.
+- Lever: Adoption. Kickoff: "Add an email alert adapter (Mailgun/SendGrid/SMTP) with HTML body + settings test, parity with existing adapters."
+
+**26 · opsgenie-adapter · P1/M/F**
+- Why: Opsgenie is a major on-call vendor with no adapter.
+- Files: new `src/lib/health/adapters/opsgenie.ts`, register in `adapters/index.ts`, `server-alert-config.ts` (`HEALTH_ALERT_OPSGENIE_API_KEY`).
+- Approach: POST Opsgenie Alert API; map severity→P1/P2, dedup key `chmonitor:{hostId}:{metric}`, tags (host/rule); detect `api.opsgenie.com`.
+- Accept: well-formed alert POST; dedup matches; settings test; adapter unit test.
+- Lever: Adoption/Revenue. Kickoff: "Add an Opsgenie alert adapter (Alert API, severity map, dedup key), settings test + unit test."
+
+**27 · alert-history-audit-log · P1/M/F**
+- Why: dedup state is in-memory only (lost on restart); no queryable record of dispatched alerts for audit/debugging.
+- Files: new `alert_events` D1 migration, `src/lib/health/alert-history-store.ts`, `routes/api/v1/health/history.ts` (GET filtered), history card in health settings; hook `evaluateAlert` on commit.
+- Approach: persist (event_time, host, rule, severity, prev_severity, decision_kind, delivered, error) after successful delivery; expose read API + UI.
+- Accept: events persist post-delivery; history API filters by host/day; UI shows recent; test coverage.
+- Lever: Adoption/Revenue (audit). Kickoff: "Persist dispatched alerts to a D1 alert_events log with a filtered history API + health UI card."
+
+**28 · maintenance-windows-suppression · P1/M/F**
+- Why: no way to suppress alerts during deploys/backups — a top alert-fatigue complaint.
+- Files: new `maintenance_windows` D1 migration, `src/lib/health/maintenance-windows.ts`, `routes/api/v1/health/maint-windows.ts` (CRUD), `components/health/maintenance-windows-dialog.tsx`; check in `evaluateAlert`.
+- Approach: window targets one/all hosts with start/end/reason; sweep suppresses (kind=`maintenance`) inside a window; record suppression in history (27).
+- Accept: window suppresses matching alerts; CRUD UI; suppressed events recorded; tests for in/out of window.
+- Lever: Adoption. Kickoff: "Add maintenance windows (D1 + CRUD + UI) that suppress alerts during planned work and record the suppression."
+
+**29 · alert-ack-manual-resolution · P1/M/F**
+- Why: an operator can't ACK/snooze a firing alert; it only clears when the condition clears.
+- Files: new `alert_acks` D1 migration, `src/lib/health/alert-ack-store.ts`, `routes/api/v1/health/ack.ts` (POST), `components/health/active-alerts-panel.tsx`; check in `evaluateAlert`.
+- Approach: ACK suppresses dispatch for a chosen duration (5/15/60/240m), records who/when; Active Alerts panel lists firing conditions + ACK controls.
+- Accept: ACK suppresses for duration; persisted with actor; panel shows firing + ACK state; sweep respects ACK; tests.
+- Lever: Adoption. Kickoff: "Add alert ACK/snooze (D1 + POST + Active Alerts panel) that suppresses dispatch for a chosen duration."
+
+**30 · per-rule-alert-routing · P1/L/E**
+- Why: one global webhook for all rules/hosts; teams need per-rule/per-host routing to channels.
+- Files: new `alert_routes` D1 migration, `src/lib/health/alert-routing.ts`, `routes/api/v1/health/routes.ts` (CRUD), `components/health/alert-routing-dialog.tsx`; dispatch in sweep.
+- Approach: route matches rule/host pattern → channel(s); sweep dispatches to all matches, records each; fallback to legacy global webhook when none match.
+- Accept: rule/host routing; multi-route fan-out recorded; back-compat with global URL; tests.
+- Lever: Revenue/Adoption. Kickoff: "Add per-rule/per-host alert routing (D1 + CRUD + UI) with multi-channel fan-out and legacy fallback."
+
+**31 · compound-alert-rules · P2/L/E**
+- Why: all rules are single-metric; false positives need AND/OR correlation (e.g. lag>60 AND readonly>0).
+- Files: `src/lib/alerting/compound-rules.ts` (new), `rule-registry.ts` (add `depends`), sweep evaluation order.
+- Approach: evaluate base rules, then compound rules over their outputs with custom predicate; own dedup/severity per compound rule; no cycles.
+- Accept: compound rules combine metrics; evaluated in dependency order; example rules ship; tests.
+- Lever: Adoption. Kickoff: "Add compound alert rules (AND/OR over base-rule outputs) with dependency-ordered evaluation and per-rule dedup."
+
+**32 · custom-alert-rule-builder · P2/M/E**
+- Why: users can't define rules without editing TS; blocks self-service alerting.
+- Files: new `components/health/rule-builder.tsx`, `src/lib/health/rule-builder-schema.ts`, `routes/api/v1/health/custom-rules.ts` (CRUD), register dynamically at sweep start.
+- Approach: "alert when [metric] [op] [threshold]" builder → safe whitelisted SQL; persist in `custom_alert_rules`; validate against injection.
+- Accept: builder covers numeric-threshold rules; generated SQL safe; custom rules appear in sweep; CRUD.
+- Lever: Adoption. Kickoff: "Add a safe custom-alert-rule builder (whitelisted metric/op/threshold → SQL) persisted in D1 and registered at sweep."
+
+**33 · remediation-action-links · P2/M/F**
+- Why: alerts carry no runbook/action affordance; MTTR suffers. (Advisor auto-exec stays out — invariant.)
+- Files: `src/lib/health/remediation-actions.ts` (new), `rule-registry.ts` (add `remediationActions`), `adapters/slack.ts` (buttons), `routes/api/v1/health/actions.ts` (execute, auth-gated, read-only or ACK-gated).
+- Approach: rules declare labeled actions (runbook link, "get diagnostics"); adapters render buttons/links; POST executes a **read-only** query or records intent; never auto-applies DDL.
+- Accept: rules define actions; Slack renders buttons; action endpoint auth-gated + recorded; no destructive auto-exec.
+- Lever: Adoption. Kickoff: "Add runbook/action links to alerts (Slack buttons + auth-gated read-only action endpoint); never auto-apply DDL."
+
+**34 · pagerduty-escalation-oncall · P1/L/E**
+- Why: PagerDuty adapter posts events but ignores escalation policies/on-call routing.
+- Files: new `src/lib/health/pagerduty-config.ts`, `pagerduty_routing` D1 migration, extend `alert-routing.ts`, `components/health/pagerduty-setup-dialog.tsx`.
+- Approach: map rule/host → PagerDuty service; PagerDuty handles escalation/on-call; one incident per (host,rule) via dedup key; API key from env.
+- Accept: service selection UI; escalation honored; dedup prevents dup incidents; test-alert path.
+- Lever: Revenue/Adoption. Kickoff: "Route alerts to PagerDuty services (escalation-policy aware) with per-(host,rule) dedup and setup UI."
+
+### Wave I — Integrations & Ecosystem (focus)
+
+**35 · prometheus-metrics-exporter · P0/M/F**
+- Why: no `/metrics` endpoint — the single biggest adoption flywheel (drops chmonitor into any Prometheus/Grafana/Alertmanager stack). Grafana/Altinity own raw metrics; meet teams there.
+- Files: new `routes/api/v1/metrics.ts` (or top-level `/metrics`), reuse `@chm/clickhouse-client`; gate `CHM_FEATURE_PROMETHEUS_ENABLED` (default on self-host, off in cloud).
+- Approach: query `system.metrics`+`system.asynchronous_metrics` (+ chmonitor alert counters), cache ~30s, emit Prometheus text (`# HELP/# TYPE`), labeled by host.
+- Accept: valid Prometheus format scrapeable at 30s; host labels; no surprise query load; test via client scrape.
+- Lever: Adoption/Ecosystem. Kickoff: "Expose a cached /metrics Prometheus exporter of system.metrics + async_metrics + alert counters, feature-gated."
+
+**36 · inbound-event-bus-queues · P1/L/E**
+- Why: alerting is outbound-only; no way to ingest Alertmanager/Datadog/generic events for correlation and fan-out.
+- Files: `apps/dashboard/wrangler.toml` (`[[queues.consumers]]`), new `routes/api/events/ingest.ts`, `event_log` D1, new "Inbound Events" page.
+- Approach: enqueue posted events, consume async, normalize (Alertmanager/Datadog/generic), dedup by hash, retain 30d, re-emit to outbound routes; read API with filters.
+- Accept: POST enqueues; consumer upserts + optional re-emit; events page lists/filter; dedup works.
+- Lever: Revenue/Ecosystem. Kickoff: "Add an inbound event bus (Cloudflare Queues) that normalizes Alertmanager/Datadog/generic events, stores 30d, and can re-emit."
+
+**37 · slack-app-native-oauth · P1/L/E**
+- Why: only outbound webhooks today; a native Slack app (OAuth + slash + ACK buttons) is a headline adoption + Pro lever.
+- Files: Slack manifest in `docs/slack/`, new `routes/api/v1/slack/{events,commands,interactions}.ts`, Bolt/HTTP handlers, D1 install store.
+- Approach: `/chmonitor status|query|alert` slash commands (rich blocks), home tab summary, alert → channel post with "Acknowledge" button updating D1 (ties to 29).
+- Accept: installs via OAuth; slash <3s; ACK button updates state; publish-ready manifest.
+- Lever: Adoption/Revenue. Kickoff: "Ship a native Slack app (OAuth, slash commands, home tab, ACK buttons) bridging alerts to chmonitor state."
+
+**38 · grafana-datasource-plugin · P1/L/E**
+- Why: the Grafana recipe is copy-paste; an official plugin that ships **ClickHouse-aware alert-rule templates + advisor panels** differentiates from generic datasources.
+- Files: new `apps/grafana-plugin/` (backend datasource), reuse `/api/v1/clickhouse/query`, bundle alert-rule queries; publish tarball.
+- Approach: wrap chmonitor CH client as a Grafana datasource with template vars + 10 prebuilt ClickHouse alert/advisor panels; enterprise features edition-gated.
+- Accept: installs via grafana-cli; queries render; alert rules import; <10-min setup; marketplace-ready.
+- Lever: Adoption/Ecosystem. Kickoff: "Build an official Grafana datasource plugin with ClickHouse-specific alert/advisor panel templates."
+
+**39 · otel-trace-export · P2/M/F**
+- Why: chmonitor reads OTel spans but can't export its own query traces to a collector for correlation.
+- Files: new `src/lib/otel/exporter.ts`, `@opentelemetry/exporter-trace-http`, env `CHM_OTEL_EXPORTER_URL` (opt-in).
+- Approach: wrap CH query execution to emit spans (dashboard-request → clickhouse-query → system-table-read) with query_id/user/read_bytes attrs; batch export.
+- Accept: spans appear in Jaeger/collector; durations match; opt-in via env; no measurable latency add.
+- Lever: Adoption/Enterprise. Kickoff: "Emit + export chmonitor's own query traces as OTel spans to an external collector (opt-in)."
+
+**40 · terraform-provider · P2/XL/E**
+- Why: enterprise GitOps for cloud resources (subscriptions, hosts, alert rules, MCP servers) — sticky, high-touch.
+- Files: new `terraform-provider-chmonitor/` (Go/Rust), CRUD for `chmonitor_{subscription,user,host,alert_rule}` via `chm_` API key; publish to registry.
+- Approach: scaffold provider; back resources with existing D1 stores/APIs; clean plan/apply/destroy; docs + examples.
+- Accept: registry publish; CRUD via TF; no refresh diffs; destroy cleans up.
+- Lever: Revenue/Enterprise. Kickoff: "Ship a Terraform provider for chmonitor Cloud resources (subscriptions/hosts/alert-rules/MCP) with registry publish."
+
+**41 · clickhouse-cloud-connect-wizard · P1/M/F**
+- Why: no Cloud-vs-self-host onboarding path; ClickHouse Cloud users are a prime paying segment.
+- Files: `components/connections/add-host-dialog.tsx` (Cloud preset: TLS, port 8443, host pattern hints), optional `src/lib/ch-cloud/billing-sync.ts` (usage/forecast), docs.
+- Approach: detect/guide ClickHouse Cloud connections (SSL required, service hostname), validate, optional Cloud billing sync for cost-aware alerts.
+- Accept: Cloud preset connects first-try; TLS defaults correct; optional billing sync populates cost card; test.
+- Lever: Revenue/Adoption. Kickoff: "Add a ClickHouse Cloud connection preset (TLS/8443/hostname hints) + optional Cloud cost sync to the connect wizard."
+
+**42 · kafka-consumer-control · P2/M/F**
+- Why: Kafka UI is read-only; ops want pause/resume/offset-reset (gated).
+- Files: extend `routes/(dashboard)/kafka-consumers.tsx`, new `routes/api/v1/kafka/consumers/$group.ts`, SSRF-guarded broker admin client; env `KAFKA_ADMIN_BROKER`.
+- Approach: show read-only state; conditional controls only when admin broker configured; proxy through chmonitor; audit each action.
+- Accept: controls appear only with admin env; pause/resume/offset work; 403 without; audited.
+- Lever: Adoption/Enterprise. Kickoff: "Add gated Kafka consumer controls (pause/resume/offset) via an SSRF-guarded broker admin proxy, audited."
+
+**43 · mcp-custom-server-registry · P1/M/F**
+- Why: placeholder UI exists but users can't register external MCP servers; agentic ecosystem play.
+- Files: new `routes/api/v1/mcp/{connect,servers}.ts`, extend `src/lib/ai/agent/mcp/connect-custom-servers.ts`, `mcp_server_registrations` D1, `routes/(dashboard)/agents/mcp-server-manager.tsx`.
+- Approach: register (URL, auth, transport), validate/cache capabilities, load per-user alongside built-ins at conversation start; template library (Slack/GitHub/Datadog).
+- Accept: register validates connectivity; custom tools usable in agent; per-user isolation; graceful degrade.
+- Lever: Adoption/Ecosystem. Kickoff: "Let users register external MCP servers (D1 + validate + per-user load) usable in the agent, with a template library."
+
+**44 · webhook-event-bus-outbound · P1/M/F**
+- Why: outbound webhooks fire only for alerts; a configurable bus (fire on any event) unlocks integrations without bespoke code.
+- Files: new `src/lib/events/outbound-bus.ts`, `webhook_subscriptions` D1, `routes/api/v1/webhooks/subscriptions.ts` (CRUD), emit hooks across findings/insights/alerts/connections; reuse SSRF guard.
+- Approach: subscribe URL + event-type filter + secret; sign payloads (HMAC); deliver with retry/backoff; dead-letter log.
+- Accept: subscribe to event types; signed delivery + retry; CRUD UI; SSRF-guarded; tests.
+- Lever: Ecosystem/Adoption. Kickoff: "Add a configurable outbound webhook bus (subscribe by event type, HMAC-signed, retried, SSRF-guarded)."
+
+**45 · github-deploy-correlation · P2/M/E**
+- Why: correlating query spikes/lag with releases is high-value SRE context.
+- Files: new `routes/api/v1/webhooks/github.ts`, `github_deployments` D1, timeline overlay in query-history charts.
+- Approach: verify GitHub deployment webhooks; store repo/env/version/ts; render deploy markers on query-volume timeline; filter by deploy.
+- Accept: signature verified; markers on timeline w/ hover; filter works; API lists recent.
+- Lever: Adoption/Ecosystem. Kickoff: "Ingest GitHub deployment webhooks and overlay deploy markers on the query-volume timeline."
+
+### Wave AI — Advisor Differentiation (the wedge)
+
+**46 · query-advisor-engine · P0/XL/E** — *the pganalyze-for-ClickHouse wedge; highest strategic priority*
+- Why: today the agent *collects + explains*; it does not *recommend DDL*. This is the reason to choose chmonitor over `query_log`+Grafana.
+- Files: new `src/lib/ai/advisor/{recommendation-engine,impact-estimator,sql-rewriter}.ts`, `src/lib/ai/agent/tools/advisor-tools.ts` (`get_optimization_recommendations`), `packages/mcp-server/src/tools/advisor.ts`, `routes/(dashboard)/advisor.tsx`, tests; optionally reuse `rust/monitor-core` WASM.
+- Approach: given a slow query (id or SQL) + EXPLAIN + schema, score candidate **skip-indexes** (selective predicate off PK prefix), **projections** (GROUP BY/ORDER BY mismatch), **partition keys** (range filter on non-partition col), **PREWHERE** (selective col), rank by estimated granules/bytes saved; emit ranked DDL + risk + effort; **never auto-apply**; meter as premium usage.
+- Accept: recommends `ALTER … ADD INDEX/PROJECTION`/PREWHERE for >70% of analyzed slow queries; validated safe (EXPLAIN before/after, no plan breakage); billing meters; golden tests (see 51).
+- Lever: **Revenue + AI-differentiation + Adoption**. Kickoff: "Build a ClickHouse DDL advisor: slow query → ranked skip-index/projection/partition/PREWHERE recommendations with impact + risk; recommend-only, metered, tested."
+
+**47 · mv-projection-designer · P0/L/E**
+- Why: extends the wedge to aggregation workloads — auto-design MV/projection DDL.
+- Files: new `src/lib/ai/advisor/mv-designer.ts`, agent tool `recommend_materialized_view`, tests.
+- Approach: mine top aggregation shapes from query_log (GROUP BY + aggfns); propose Summing/Aggregating MergeTree MV/projection; estimate size from `system.parts` × aggregation ratio; recommend-only.
+- Accept: recommends MV for >60% high-cost aggregations; size estimate within ~10%; premium-gated; tests.
+- Lever: Revenue/AI. Kickoff: "Design MV/projection DDL from frequent aggregation queries with size estimates; recommend-only, premium-gated."
+
+**48 · statistical-anomaly-baselines · P1/M/F**
+- Why: insights use static thresholds → false positives; per-cluster baselines cut them ~80%.
+- Files: new `src/lib/insights/statistical-baseline.ts`, refactor `insights/collectors.ts` to `scoreAnomaly`, `anomaly_baselines` store, agent tool `explain_anomaly_score`, tests.
+- Approach: fit per-host/per-metric distribution over 7d (MAD/IQR outlier reject), store (mean,σ), flag |z|>2; adapts to workload.
+- Accept: false-positive rate drops materially on test workloads; fit <100ms/host; tests.
+- Lever: Adoption/AI. Kickoff: "Replace static insight thresholds with per-cluster statistical baselines (z-score/MAD) + an explain tool."
+
+**49 · query-cost-estimator · P1/L/E**
+- Why: no pre-flight estimate of rows/memory/time; enables runaway-query guardrails + advisor impact math.
+- Files: new `src/lib/ai/advisor/cost-estimator.ts`, extend `agent/tools/query-tools.ts` (`estimate_query_cost` runs EXPLAIN, never executes), tests.
+- Approach: parse EXPLAIN INDEXES/PLAN → granules/bytes/selectivity/join build; combine with `system.columns` sizes; estimate rows/memory/time.
+- Accept: rows/memory within ~2×, time within ~30% on test queries; agent can warn before running; tests.
+- Lever: Adoption/AI. Kickoff: "Add a query cost estimator (EXPLAIN → rows/memory/time) used for guardrails and advisor impact scoring."
+
+**50 · capacity-forecast-ttl-advisor · P2/M/F**
+- Why: disk-full is a top incident; forecast + TTL suggestions prevent it.
+- Files: new `src/lib/ai/advisor/capacity-forecaster.ts`, extend `agent/tools/storage-tools.ts` (`forecast_disk_capacity`, `suggest_ttl_adjustment`), sample `system.part_log`, tests.
+- Approach: fit write-rate from part_log over 30d; forecast disk-full date; recommend TTL/partition drops that preserve required retention; recommend-only.
+- Accept: forecast within ~15% on historical data; TTL suggestions never violate retention; tests.
+- Lever: Adoption. Kickoff: "Forecast disk-full from part_log write rate and suggest safe TTL/partition changes (recommend-only)."
+
+**51 · agent-eval-golden-tests · P1/L/F**
+- Why: no end-to-end agent quality harness; advisor + tools need regression protection.
+- Files: new `src/lib/ai/agent/__tests__/scenarios.test.ts` + `fixtures/`; mock system tables/query_log; assert tool calls + recommendations.
+- Approach: 12–15 golden scenarios (slow query, disk-full, replication lag, fragmented table…); assert correct tools + safe, actionable recs; new features must extend goldens.
+- Accept: all goldens pass; recommendations safe (no destructive auto-exec); CI-wired.
+- Lever: Quality/AI. Kickoff: "Add a golden-scenario agent-eval suite asserting correct tool calls + safe recommendations, wired to CI."
+
+**52 · proactive-weekly-health-report · P1/M/F**
+- Why: turns insights into a recurring, shareable narrative (email/Slack) — retention + upsell surface.
+- Files: new `routes/api/cron/weekly-report.ts`, `src/lib/insights/weekly-report.ts`, reuse email (25)/Slack (37) adapters, D1 report store.
+- Approach: weekly cron aggregates findings + baselines (48) + capacity (50) into a narrative; deliver via configured channels; link to advisor recs.
+- Accept: weekly report generated + delivered; links to findings/advisor; opt-in per host; test.
+- Lever: Adoption/Revenue. Kickoff: "Generate + deliver a weekly cluster-health narrative (email/Slack) from insights, baselines, and capacity."
+
+### Wave D — Dashboards & OSS de-hardcoding
+
+**53 · activate-declarative-queries · P0/S/F**
+- Why: the declarative query-config engine + full catalog are **built but dormant** (`CHM_CONFIG_SOURCE=ts`); flipping it live is the keystone for "less hard-coded logic."
+- Files: `src/lib/query-config/index.ts` (`getConfigSource`), `declarative/catalog/*` (complete), new parity test.
+- Approach: add integration test loading representative declarative configs and asserting parity with TS; document `CHM_CONFIG_SOURCE=declarative`; keep TS default (back-compat).
+- Accept: declarative path routes all lookups; TS remains default; ≥10 configs match TS equivalents.
+- Lever: OSS/Adoption. Kickoff: "Prove + document the dormant declarative query-config path (parity test, env docs); keep TS default."
+
+**54 · query-config-pack-registry · P0/M/E**
+- Why: lets self-hosters ship new queries without rebuilds — the real OSS-extensibility unlock.
+- Files: new `src/lib/query-config/declarative/pack-registry.ts`, extend `loader.ts`, env `CHM_PACK_REGISTRY_URL`.
+- Approach: pack manifest (name/version/queries/deps); fetch+validate at startup (HTTP or `file://`), cache, merge into catalog; graceful degrade on bad packs.
+- Accept: Docker can load packs from URL/local mount; invalid packs rejected clearly; timeout + fallback.
+- Lever: OSS/Adoption. Kickoff: "Add a query-pack registry that fetches, validates, and merges community YAML query packs into the catalog."
+
+**55 · self-hosted-local-config-override · P1/M/F**
+- Why: self-hosted teams should drop YAML queries into a mounted dir without forking.
+- Files: new `src/lib/query-config/declarative/local-loader.ts`, extend `getQueryConfigByName`, Docker entrypoint (`CHM_CONFIG_DIRECTORY=/etc/chmonitor/queries.d`).
+- Approach: scan mounted dir at startup, validate each YAML, merge (or `local` namespace); clear errors on invalid.
+- Accept: mounted YAML appears in UI without rebuild; validation rejects bad configs; documented.
+- Lever: OSS/Adoption. Kickoff: "Load user YAML query configs from a mounted /etc/chmonitor/queries.d directory at startup."
+
+**56 · dashboard-d1-persistence-sharing · P1/M/F**
+- Why: dashboards are localStorage-only; the D1 store pattern exists (conversations) but isn't wired — blocks multi-device + sharing (a paid lever).
+- Files: `src/lib/dashboard-storage.ts` (add D1 backend), new `routes/api/dashboards/{list,save,delete,share}.ts`, migration.
+- Approach: mirror conversation D1 store for dashboards with owner + share ACL; localStorage fallback offline; optional org defaults.
+- Accept: dashboards persist across devices; optional share link; fallback works; tests.
+- Lever: Revenue/Adoption. Kickoff: "Persist + share dashboards via D1 (mirror the conversation store) with localStorage fallback."
+
+**57 · custom-dashboard-builder-grid · P1/L/E**
+- Why: PRD's dynamic-dashboard vision — drag-drop widgets + time-range sync — is only partially present.
+- Files: `routes/(dashboard)/dashboard.tsx`, new `components/dashboard/{grid,widget-*}.tsx` (`@dnd-kit` already a dep), shared time-range context, D1 (56).
+- Approach: widget types (chart/table/stat/text), drag-drop grid layout, one shared time range, save/load via 56.
+- Accept: add/move/resize widgets; single time-range drives all; layout persists.
+- Lever: Adoption/Revenue. Kickoff: "Build a drag-drop dashboard grid (widget types + shared time-range) persisted via D1."
+
+**58 · declarative-chart-schema · P2/M/E**
+- Why: charts are 40 factory / 34 hand-rolled TS; a declarative schema enables community/AI-authored charts.
+- Files: new `components/charts/declarative/{schema,loader,catalog}.ts` (mirror query-config declarative), migrate ~5 factory charts as templates.
+- Approach: extract serializable chart fields (name/index/categories/interval), Zod schema with icon resolution, loader → ChartFactory; document authoring.
+- Accept: ≥5 charts render identically from declarative defs; authoring documented.
+- Lever: OSS/AI. Kickoff: "Define a declarative chart schema + loader (mirror query-config) and port 5 factory charts as templates."
+
+**59 · ai-generated-dashboards · P2/L/E**
+- Why: "show me all queries scanning >1B rows" → auto-built dashboard is a marquee AI feature.
+- Files: new agent tool `suggest_dashboard`/`build_dashboard` in `agent/tools/`, chart-picker integration, reuse 57/58.
+- Approach: agent maps NL + schema/query-history → chart set (from registry) → constructs dashboard via 56/57; one-click apply.
+- Accept: NL request yields valid dashboard of registry charts applied without reload; tests for tool output.
+- Lever: AI/Adoption. Kickoff: "Add an agent tool that turns a natural-language request into a built dashboard from the chart registry."
+
+### Wave G — Landing / Marketing / Growth (focus — "hero + everywhere")
+
+**60 · landing-hero-wedge-refresh · P0/L/F**
+- Why: hero = "See every ClickHouse query. As it runs." — query-centric, advisor/alerting/integrations invisible; must lead with the wedge that beats Cloud-locked Ask-AI.
+- Files: `apps/landing/src/components/Hero.astro`, `src/data/pricing.ts`, gallery tab order, `FinalCta.astro`.
+- Approach: rewrite headline/subhead to advisor + alerts + "works on every deployment"; reorder gallery to lead with advisor/agent/alerts/topology; accent key terms; add "See a live demo" secondary CTA (ties to 65). **Honest claims only.**
+- Accept: hero names advisor + alerts in first two bullets; gallery leads with advisor/alerts; no unshipped claims; A/B-ready.
+- Lever: Adoption/SEO. Kickoff: "Rewrite the landing hero around the ClickHouse advisor + alerting + all-deployment wedge; reorder gallery; honest claims."
+
+**61 · feature-sections-advisor-alerts-refresh · P1/M/F**
+- Why: "update everywhere" — feature/capability/comparison sections under-sell advisor + alerting.
+- Files: `components/{Features,Capabilities,Comparison}.astro`, `src/data/pricing.ts`.
+- Approach: add advisor + alerting feature cards + screenshots; add "Alert rules / channels" comparison row; badge AI-backed capabilities; keep claims matched to shipped code.
+- Accept: advisor + alerting appear in features + comparison; screenshots real; claims honest.
+- Lever: Adoption/Revenue. Kickoff: "Refresh landing feature/capability/comparison sections to foreground the advisor + alerting, with real screenshots and honest claims."
+
+**62 · product-analytics-funnel · P0/M/F**
+- Why: **no product analytics anywhere** — flying blind on the conversion funnel that Revenue depends on.
+- Files: `apps/landing/src/layouts/Base.astro`, `apps/dashboard/src/root.tsx`, CTA/pricing components; PostHog (self-hostable) or Segment; respect DNT, exclude internal IPs.
+- Approach: instrument landing (pageview, CTA, pricing view, comparison) + dashboard (signup, cluster-connect, first-chart, agent message, upgrade); async, <50ms.
+- Accept: ≥5 funnels tracked; 7-day retention cohort visible; no PII; negligible page-load cost.
+- Lever: Revenue/Adoption. Kickoff: "Instrument landing + dashboard funnels with privacy-respecting product analytics (PostHog/Segment)."
+
+**63 · comparison-pages-vs-competitors · P1/M/E**
+- Why: high-intent "vs" search traffic; only a single on-page matrix today.
+- Files: new `apps/landing/src/pages/vs-{grafana,datadog,clickhouse-cloud}.astro`, shared `components/ComparisonTable.astro`.
+- Approach: per-competitor deep matrix + honest disclaimers + setup-time/TCO framing + CTA; link from main comparison; verified against shipped features.
+- Accept: ≥3 vs-pages; ≥10-row tables; honest positioning; schema markup.
+- Lever: SEO/Adoption. Kickoff: "Build honest /vs-grafana, /vs-datadog, /vs-clickhouse-cloud comparison pages with TCO framing and CTAs."
+
+**64 · seo-use-case-landing-pages · P2/L/E**
+- Why: long-tail organic ("ClickHouse replication monitor", "query performance analyzer").
+- Files: new `apps/landing/src/pages/{monitor-queries,cluster-health,replication,performance}.astro`, shared `LandingPage.astro`.
+- Approach: 4–6 keyword-targeted pages (unique hero/benefits/screens/CTA), internal-linked, sitemap submitted.
+- Accept: ≥4 use-case pages; unique metadata/H1; internal links; schema markup.
+- Lever: SEO/Adoption. Kickoff: "Ship 4+ SEO use-case landing pages (queries/health/replication/performance) with a shared layout."
+
+**65 · live-demo-embedded · P1/M/E**
+- Why: fastest proof-of-value; no public demo today.
+- Files: new `apps/landing/src/pages/demo.astro`, demo cluster infra, read-only chmonitor user/role, hero CTA.
+- Approach: public read-only ClickHouse (Hits/TPC-H) behind a rate-limited chmonitor dashboard; "See a live demo" CTA; track demo→signup.
+- Accept: demo loads <3s; queries/agent/topology visible; resets periodically; conversion tracked.
+- Lever: Adoption/Revenue. Kickoff: "Stand up a public read-only demo cluster + dashboard and a 'See a live demo' landing CTA with conversion tracking."
+
+**66 · onboarding-sample-cluster-preset · P1/M/F**
+- Why: "Try with sample data" removes the connect-a-cluster barrier at first run.
+- Files: `components/host/first-run-empty-state.tsx`, `components/connections/add-host-dialog.tsx`, sample-cluster preset creds.
+- Approach: add "Try with sample ClickHouse" that autofills a read-only demo endpoint; "connect your own" CTA after; track sample→real conversion.
+- Accept: sample button on /setup; autofills + connects; convert CTA; tracked.
+- Lever: Adoption/Revenue. Kickoff: "Add a 'Try with sample ClickHouse' one-click preset on first-run with a convert-to-your-own CTA."
+
+**67 · docs-blog-content-engine · P1/M/E**
+- Why: blog has one post; no SEO/nurture cadence.
+- Files: `apps/blog/src/content/blog/`, `astro.config.mjs`, `apps/landing/src/components/Footer.astro`, GitHub-release→blog sync script.
+- Approach: 12-week calendar (release/how-to/troubleshooting/case-study), templates, docs↔blog cross-links, RSS, landing "latest" widget.
+- Accept: ≥2 posts/month cadence; posts link docs/features; RSS active; archive categories.
+- Lever: SEO/Adoption. Kickoff: "Stand up a docs+blog content engine (calendar, templates, RSS, release sync, landing widget)."
+
+**68 · github-star-social-proof · P2/S/F**
+- Why: OSS social proof + discoverability; no prominent star CTA.
+- Files: `apps/landing/src/components/Hero.astro`, new `components/StarCta.astro` (build-time count), mid-page card.
+- Approach: star badge in hero + mid-landing card ("building in public — star us"); track clicks; live count at build.
+- Accept: star CTA in hero + mid-landing; count auto-updates; clicks tracked; no layout shift.
+- Lever: Adoption/OSS. Kickoff: "Add a prominent GitHub star CTA (hero badge + mid-page card, live count) with click tracking."
+
+**69 · og-images-seo-meta-audit · P1/M/F**
+- Why: social-share CTR + SERP CTR; OG images/meta not per-page.
+- Files: new `apps/landing/src/scripts/generate-og.mjs` (reuse docs' takumi/resvg), `layouts/Base.astro`, per-page meta + schema (FAQPage, SoftwareApplication+Offer, BreadcrumbList).
+- Approach: build-time per-page OG images; unique title/description (50–60 / 150–160); valid schema; test with validators.
+- Accept: unique OG per page (<100KB, readable); unique metas; schema valid; rich-result eligible.
+- Lever: SEO/Adoption. Kickoff: "Generate per-page OG images + audit titles/descriptions/schema across landing/blog for rich results."
+
+**70 · landing-perf-lighthouse · P1/S/F**
+- Why: faster landing = higher conversion + Core-Web-Vitals ranking.
+- Files: `apps/landing/astro.config.mjs`, `components/{Hero,Features}.astro`; CI Lighthouse check.
+- Approach: lazy-load gallery, defer hero shader until visible, code-split carousels, drop unused CSS; add CI warn <90.
+- Accept: Lighthouse ≥90 mobile+desktop; LCP <2.5s; CLS <0.1; JS <250KB gz; CI gate.
+- Lever: Adoption/SEO. Kickoff: "Optimize the landing to Lighthouse ≥90 / green CWV (lazy media, deferred shader, code-split) with a CI gate."
+
+---
+
+## 5. Findings carried from Round 2 (also get backlog issues)
+
+Deferred but real (see `plans/README.md` §"deferred / not planned"): **SEC-04** MCP custom-server
+transport unpinned · **SEC-05** raw ClickHouse errors leaked on ~20 server-defined-query routes
+· **BUG-03** custom MCP clients not closed on agent 402/pre-stream throw · **DEP-01** dev/build
+toolchain `bun audit` highs · **DEP-02** two markdown pipelines (measure before consolidating) ·
+**DEBT-01** two chart-authoring patterns (batch the 18 mechanical) · **DOC-01** stale
+"custom MCP not wired" comment. These become `finding`-labeled issues, not plan files.
+
+

--- a/plans/round3-issues.csv
+++ b/plans/round3-issues.csv
@@ -1,0 +1,65 @@
+number,title,priority,effort,depth,wave_label,plan_file
+14,14 — Wire AI overage spend metering,P0,S,F,wave:revenue,plans/14-wire-ai-overage-spend-metering.md
+15,15 — Upgrade paywall modal,P0,M,F,wave:revenue,plans/15-upgrade-paywall-modal.md
+16,16 — Billing usage dashboard card,P0,M,F,wave:revenue,plans/16-billing-usage-dashboard-card.md
+17,17 — Checkout → webhook → D1 → plan e2e tests + runbook,P1,M,F,wave:revenue,plans/17-checkout-webhook-e2e-tests.md
+18,18 — Per-host overage billing,P1,L,E,wave:revenue,plans/18-per-host-overage-billing.md
+19,19 — Downgrade protection,P1,S,F,wave:revenue,plans/19-downgrade-protection.md
+20,20 — Seat-cap invite-time gate,P1,S,F,wave:revenue,plans/20-seat-cap-invite-time-gate.md
+21,21 — SSO / SAML for Enterprise,P2,L,E,wave:enterprise,plans/21-sso-saml-enterprise.md
+22,22 — Audit log + org-scoped CSV export,P2,M,F,wave:enterprise,plans/22-audit-log-export.md
+23,23 — RBAC roles for Enterprise (viewer / operator / admin),P2,L,E,wave:enterprise,plans/23-rbac-roles-enterprise.md
+24,"24 — Enterprise multi-org pooling (one subscription, pooled limits)",P2,L,E,wave:enterprise,plans/24-enterprise-multi-org-pooling.md
+25,25 — Email alert adapter (Mailgun / SendGrid / SMTP),P0,M,F,wave:alerting,plans/25-email-alert-adapter.md
+26,26 — Opsgenie alert adapter,P1,M,F,wave:alerting,plans/26-opsgenie-adapter.md
+27,27 — Alert history (persisted alert_events + filtered API + UI card),P1,M,F,wave:alerting,plans/27-alert-history-audit-log.md
+28,28 — Maintenance windows (alert suppression),P1,M,F,wave:alerting,plans/28-maintenance-windows-suppression.md
+29,29 — Alert ACK / manual resolution (snooze),P1,M,F,wave:alerting,plans/29-alert-ack-manual-resolution.md
+30,30 — Per-rule / per-host alert routing,P1,L,E,wave:alerting,plans/30-per-rule-alert-routing.md
+31,31 — Compound alert rules (AND/OR correlation),P2,L,E,wave:alerting,plans/31-compound-alert-rules.md
+32,"32 — Custom alert rule builder (no-code, whitelisted)",P2,M,E,wave:alerting,plans/32-custom-alert-rule-builder.md
+33,33 — Remediation action links (runbook + read-only actions),P2,M,F,wave:alerting,plans/33-remediation-action-links.md
+34,34 — PagerDuty escalation & on-call routing,P1,L,E,wave:alerting,plans/34-pagerduty-escalation-oncall.md
+35,35 — Prometheus metrics exporter,P0,M,F,wave:integrations,plans/35-prometheus-metrics-exporter.md
+36,36 — Inbound event bus (Cloudflare Queues),P1,L,E,wave:integrations,plans/36-inbound-event-bus-queues.md
+37,37 — Native Slack app (OAuth + slash + ACK buttons),P1,L,E,wave:integrations,plans/37-slack-app-native-oauth.md
+38,38 — Grafana datasource plugin,P1,L,E,wave:integrations,plans/38-grafana-datasource-plugin.md
+39,39 — OTel trace export,P2,M,F,wave:integrations,plans/39-otel-trace-export.md
+40,40 — Terraform provider,P2,XL,E,wave:integrations,plans/40-terraform-provider.md
+41,41 — ClickHouse Cloud connect wizard,P1,M,F,wave:integrations,plans/41-clickhouse-cloud-connect-wizard.md
+42,42 — Kafka Consumer Control (gated pause/resume/offset via SSRF-guarded broker admin proxy),P2,M,F,wave:integrations,plans/42-kafka-consumer-control.md
+43,"43 — MCP Custom Server Registry (register external MCP servers, per-user, usable in the agent)",P1,M,F,wave:integrations,plans/43-mcp-custom-server-registry.md
+44,"44 — Outbound Webhook Event Bus (subscribe by event type, HMAC-signed, retried, SSRF-guarded)",P1,M,F,wave:integrations,plans/44-webhook-event-bus-outbound.md
+45,"45 — GitHub Deploy Correlation (ingest deployment webhooks, overlay deploy markers on the query-volume timeline)",P2,M,E,wave:integrations,plans/45-github-deploy-correlation.md
+46,"46 — Query Advisor Engine (slow query → ranked skip-index / projection / partition / PREWHERE DDL, recommend-only)",P0,XL,E,wave:advisor,plans/46-query-advisor-engine.md
+47,"47 — MV / Projection Designer (design MV/projection DDL from frequent aggregations, size-estimated, recommend-only)",P0,L,E,wave:advisor,plans/47-mv-projection-designer.md
+48,48 — Statistical Anomaly Baselines (replace static insight thresholds with per-cluster z-score/MAD baselines),P1,M,F,wave:advisor,plans/48-statistical-anomaly-baselines.md
+49,49 — Query cost estimator (EXPLAIN → rows / memory / time),P1,L,E,wave:advisor,plans/49-query-cost-estimator.md
+50,50 — Capacity forecast & TTL advisor,P2,M,F,wave:advisor,plans/50-capacity-forecast-ttl-advisor.md
+51,51 — Agent eval & golden-scenario tests,P1,L,F,wave:advisor,plans/51-agent-eval-golden-tests.md
+52,52 — Proactive weekly health report,P1,M,F,wave:advisor,plans/52-proactive-weekly-health-report.md
+53,53 — Activate the declarative query-config path,P0,S,F,wave:dashboards,plans/53-activate-declarative-queries.md
+54,54 — Community query-pack registry,P0,M,E,wave:dashboards,plans/54-query-config-pack-registry.md
+55,55 — Self-hosted local config override (queries.d),P1,M,F,wave:dashboards,plans/55-self-hosted-local-config-override.md
+56,56 — Dashboard D1 persistence & sharing,P1,M,F,wave:dashboards,plans/56-dashboard-d1-persistence-sharing.md
+57,57 — Custom dashboard builder (drag-drop grid),P1,L,E,wave:dashboards,plans/57-custom-dashboard-builder-grid.md
+58,58 — Declarative chart schema,P2,M,E,wave:dashboards,plans/58-declarative-chart-schema.md
+59,59 — AI-generated dashboards,P2,L,E,wave:dashboards,plans/59-ai-generated-dashboards.md
+60,60 — Landing hero: advisor + alerting + all-deployment wedge,P0,L,F,wave:growth,plans/60-landing-hero-wedge-refresh.md
+61,61 — Feature/capability/comparison sections: advisor + alerting,P1,M,F,wave:growth,plans/61-feature-sections-advisor-alerts-refresh.md
+62,62 — Product analytics & funnel instrumentation,P0,M,F,wave:growth,plans/62-product-analytics-funnel.md
+63,63 — Comparison pages vs Grafana / Datadog / ClickHouse Cloud,P1,M,E,wave:growth,plans/63-comparison-pages-vs-competitors.md
+64,64 — SEO use-case landing pages,P2,L,E,wave:growth,plans/64-seo-use-case-landing-pages.md
+65,"65 — Live demo (embedded, public read-only)",P1,M,E,wave:growth,plans/65-live-demo-embedded.md
+66,"66 — Onboarding: sample-cluster preset (""Try with sample ClickHouse"")",P1,M,F,wave:growth,plans/66-onboarding-sample-cluster-preset.md
+67,67 — Docs + blog content engine,P1,M,E,wave:growth,plans/67-docs-blog-content-engine.md
+68,68 — GitHub star social proof,P2,S,F,wave:growth,plans/68-github-star-social-proof.md
+69,69 — OG images + SEO meta/schema audit,P1,M,F,wave:growth,plans/69-og-images-seo-meta-audit.md
+70,70 — Landing performance (Lighthouse ≥90 / green Core Web Vitals),P1,S,F,wave:growth,plans/70-landing-perf-lighthouse.md
+,Finding SEC-04 — MCP custom-server transport unpinned (DNS-rebinding class),P2,,,type:finding,plans/README.md
+,Finding SEC-05 — Raw ClickHouse errors leaked on ~20 server-defined-query routes,P2,,,type:finding,plans/README.md
+,Finding BUG-03 — Custom MCP clients not closed on agent 402 / pre-stream throw,P3,,,type:finding,plans/README.md
+,Finding DEP-01 — bun audit highs in dev/build/deploy toolchain (bump wrangler/opennext/cypress),P3,,,type:finding,plans/README.md
+,Finding DEP-02 — Two markdown pipelines shipped (measure with bundle-size gate before consolidating),P3,,,type:finding,plans/README.md
+,Finding DEBT-01 — Two chart-authoring patterns (batch the 18 mechanically-convertible charts),P2,,,type:finding,plans/README.md
+,Finding DOC-01 — Stale 'custom MCP not wired' comment contradicted by agent.ts,P3,,,type:finding,plans/README.md


### PR DESCRIPTION
## What

Rewrites `plans/README.md` into an accurate **work queue** and persists the plan
spec files that existed only as untracked local files, so the backlog survives a
clean checkout.

### Status table (README)
- **Round 2 (04–13)** — all merged ✅, each linked to its PR (#2202–#2211) + the
  two infra PRs (#2212 format, #2220 baseline import-cycle).
- **Round 3 (14–70)**:
  - **Merged ✅ (9):** 35, 48, 50, 51, 53, 55, 62, 69, 70.
  - **Held 🔶 (4):** #2213 (14 billing), #2218 (25 email), #2224 (56 dashboard
    share), #2225 (66 onboarding) — each row states the specific decision it needs.
  - **Not started ⏳ (44):** grouped by blocker (revenue→#14, enterprise auth,
    alerting cluster, integrations toolchains, advisor wedge, dashboards→#56,
    growth copy verification).

### Persisted specs
- All 10 Round-2 specs (code merged, spec files never landed on `main`).
- All 44 not-started specs + `OVERNIGHT-SWARM.md`, `ROADMAP-2026H2.md`,
  `round3-issues.csv`.
- **Excluded:** specs for the 4 held plans (14/25/56/66) — they stay on their PR
  branches to avoid squash-merge collisions when those PRs land.

## Why

Only 12 of 70 plan specs were on `main`; the rest (including the entire
not-started backlog) lived as untracked local files at risk of loss. A stale
README also caused repeated re-derivation of what was already done. This makes
the queue authoritative and durable.

## Risk

Docs-only (`plans/**` markdown + one CSV). No code, no `src/` changes; lint-staged
matches nothing, so no quality gate is affected.

Co-Authored-By: duyetbot <bot@duyet.net>