### PR TITLE
feat(landing): hero GitHub star badge + shared build-time star fetch (plan 68)

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "test": "bun test",
     "preview": "astro preview",
     "build:og": "bun run scripts/build-og.ts",
     "cf:deploy": "wrangler deploy"

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -1,5 +1,12 @@
 ---
 import HeroHalftone from './HeroHalftone.tsx'
+import { formatCount, getGitHubStats } from '../lib/github-stars'
+
+// Build-time star count for the hero GitHub badge, shared with SocialProof so
+// the build makes one API call. Empty string when the fetch fails — the badge
+// then renders as a plain "Star on GitHub" with no fabricated number.
+const { stars } = await getGitHubStats()
+const starLabel = formatCount(stars)
 
 const galleryCards = [
   { tab: 'Overview', src: '/landing-assets/hero-overview.png', alt: 'chmonitor cluster overview' },
@@ -43,9 +50,17 @@ const galleryCards = [
           Quickstart
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/></svg>
         </a>
-        <a class="btn btn-ghost ehero-ghost" href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">
-          <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>
-          GitHub
+        <a
+          class="btn btn-ghost ehero-ghost ehero-star"
+          href="https://github.com/chmonitor/chmonitor"
+          target="_blank"
+          rel="noopener"
+          data-cta="github-star-hero"
+          aria-label={starLabel ? `Star chmonitor on GitHub — ${starLabel} stars` : 'Star chmonitor on GitHub'}
+        >
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2.5l2.9 6.1 6.6.9-4.8 4.6 1.2 6.6L12 18.6 6.1 21.3l1.2-6.6L2.5 9.5l6.6-.9z"/></svg>
+          Star
+          {starLabel && <span class="ehero-star-count">{starLabel}</span>}
         </a>
       </div>
     </div>
@@ -160,6 +175,16 @@ const galleryCards = [
     border: 1px solid rgba(255,255,255,.2); backdrop-filter: blur(10px);
   }
   .ehero-ghost:hover { background: rgba(18,18,24,.72); }
+  /* Star badge: the count sits behind a hairline divider with a reserved
+     min-width so a present vs. absent count never shifts the button width. */
+  .ehero-star { gap: 8px; }
+  .ehero-star-count {
+    min-width: 2.5ch; text-align: center;
+    padding-left: 8px; margin-left: 1px;
+    border-left: 1px solid rgba(255,255,255,.22);
+    font-weight: 600; font-variant-numeric: tabular-nums;
+  }
+  :global(html[data-theme='light']) .ehero-star-count { border-left-color: rgba(0,0,0,.14); }
 
   .ehero .gallery-strip { position: relative; z-index: 1; margin-top: 64px; }
 

--- a/apps/landing/src/components/SocialProof.astro
+++ b/apps/landing/src/components/SocialProof.astro
@@ -1,28 +1,10 @@
 ---
-// GitHub stats — fetched at build time and rendered as native, theme-aware chips
-// (the previous shields.io `?style=social` images were white pills that didn't
-// adapt to dark mode and rendered fuzzily). Fails open: if the API is
-// unreachable during the build, chips render without counts — never breaks CI.
-const REPO = 'chmonitor/chmonitor'
-let stars: number | null = null
-let forks: number | null = null
-let updated: string | null = null
-try {
-  const res = await fetch(`https://api.github.com/repos/${REPO}`, {
-    headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'chmonitor-landing' },
-  })
-  if (res.ok) {
-    const d = await res.json()
-    stars = typeof d.stargazers_count === 'number' ? d.stargazers_count : null
-    forks = typeof d.forks_count === 'number' ? d.forks_count : null
-    if (d.pushed_at) {
-      updated = new Date(d.pushed_at).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
-    }
-  }
-} catch {
-  // offline build — render chips without counts
-}
-const fmt = (n: number | null) => (n == null ? '' : n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n))
+// GitHub stats fetched once at build time via the shared helper (also used by
+// the hero star badge) so the static build makes a single API call. Fails open:
+// chips render without counts when the API is unreachable — never a fake number.
+import { GITHUB_REPO as REPO, formatCount as fmt, getGitHubStats } from '../lib/github-stars'
+
+const { stars, forks, updated } = await getGitHubStats()
 
 const starIcon = `<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2.5l2.9 6.1 6.6.9-4.8 4.6 1.2 6.6L12 18.6 6.1 21.3l1.2-6.6L2.5 9.5l6.6-.9z"/></svg>`
 const forkIcon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="6" cy="6" r="2.4"/><circle cx="18" cy="6" r="2.4"/><circle cx="12" cy="19" r="2.4"/><path d="M6 8.4v2.1a3 3 0 0 0 3 3h6a3 3 0 0 0 3-3V8.4M12 13.5v3.1"/></svg>`
@@ -35,7 +17,7 @@ const commitIcon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" s
       <h2>Open source, built in public</h2>
 
       <div class="stat-badges">
-        <a class="gh-stat" href={`https://github.com/${REPO}/stargazers`} target="_blank" rel="noopener" aria-label={`${fmt(stars)} GitHub stars`}>
+        <a class="gh-stat" href={`https://github.com/${REPO}/stargazers`} target="_blank" rel="noopener" data-cta="github-star-community" aria-label={`${fmt(stars)} GitHub stars`}>
           <span class="gh-ico" set:html={starIcon} />
           <span class="gh-label">Stars</span>
           {stars != null && <strong class="gh-num">{fmt(stars)}</strong>}

--- a/apps/landing/src/lib/github-stars.test.ts
+++ b/apps/landing/src/lib/github-stars.test.ts
@@ -1,0 +1,67 @@
+import { fetchGitHubStats, formatCount } from './github-stars'
+import { afterEach, describe, expect, test } from 'bun:test'
+
+const realFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+})
+
+describe('formatCount', () => {
+  test('returns empty string for null (never a fabricated number)', () => {
+    expect(formatCount(null)).toBe('')
+  })
+
+  test('passes small counts through verbatim', () => {
+    expect(formatCount(0)).toBe('0')
+    expect(formatCount(42)).toBe('42')
+    expect(formatCount(999)).toBe('999')
+  })
+
+  test('abbreviates thousands', () => {
+    expect(formatCount(1000)).toBe('1.0k')
+    expect(formatCount(1234)).toBe('1.2k')
+  })
+})
+
+describe('fetchGitHubStats fail-open', () => {
+  test('returns null counts when the API throws (offline build)', async () => {
+    globalThis.fetch = () => Promise.reject(new Error('offline'))
+    expect(await fetchGitHubStats('chmonitor/chmonitor')).toEqual({
+      stars: null,
+      forks: null,
+      updated: null,
+    })
+  })
+
+  test('returns null counts on a non-200 response (rate limited)', async () => {
+    globalThis.fetch = () =>
+      Promise.resolve(new Response('rate limited', { status: 403 }))
+    expect(await fetchGitHubStats('chmonitor/chmonitor')).toEqual({
+      stars: null,
+      forks: null,
+      updated: null,
+    })
+  })
+
+  test('parses counts on success', async () => {
+    globalThis.fetch = () =>
+      Promise.resolve(
+        Response.json({
+          stargazers_count: 1234,
+          forks_count: 56,
+          pushed_at: '2026-07-01T00:00:00Z',
+        })
+      )
+    const stats = await fetchGitHubStats('chmonitor/chmonitor')
+    expect(stats.stars).toBe(1234)
+    expect(stats.forks).toBe(56)
+    expect(stats.updated).toBeTypeOf('string')
+  })
+
+  test('ignores non-numeric fields rather than trusting them', async () => {
+    globalThis.fetch = () =>
+      Promise.resolve(Response.json({ stargazers_count: 'lots' }))
+    expect((await fetchGitHubStats('chmonitor/chmonitor')).stars).toBeNull()
+  })
+})

--- a/apps/landing/src/lib/github-stars.ts
+++ b/apps/landing/src/lib/github-stars.ts
@@ -1,0 +1,68 @@
+// Build-time GitHub repo stats, fetched ONCE and shared across landing
+// components (the hero star badge + the SocialProof community card) so the
+// static build makes a single API call instead of one per component.
+//
+// Fails open: on any error (offline build, rate limit, non-200) the counts are
+// `null` and callers render the CTA WITHOUT a fabricated number — never a
+// placeholder or invented count. See plans/68-github-star-social-proof.md.
+
+export const GITHUB_REPO = 'chmonitor/chmonitor'
+
+export interface GitHubStats {
+  stars: number | null
+  forks: number | null
+  /** Human month/year of the last push, e.g. "Jul 2026", or null on failure. */
+  updated: string | null
+}
+
+const EMPTY: GitHubStats = { stars: null, forks: null, updated: null }
+
+/**
+ * Fetch repo stats from the GitHub REST API. Pure (no module cache) so it is
+ * unit-testable; {@link getGitHubStats} adds the build-time memoization.
+ */
+export async function fetchGitHubStats(repo: string): Promise<GitHubStats> {
+  try {
+    const res = await fetch(`https://api.github.com/repos/${repo}`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'chmonitor-landing',
+      },
+    })
+    if (!res.ok) return { ...EMPTY }
+
+    const d = (await res.json()) as {
+      stargazers_count?: unknown
+      forks_count?: unknown
+      pushed_at?: unknown
+    }
+    return {
+      stars: typeof d.stargazers_count === 'number' ? d.stargazers_count : null,
+      forks: typeof d.forks_count === 'number' ? d.forks_count : null,
+      updated:
+        typeof d.pushed_at === 'string'
+          ? new Date(d.pushed_at).toLocaleDateString('en-US', {
+              month: 'short',
+              year: 'numeric',
+            })
+          : null,
+    }
+  } catch {
+    // Offline / rate-limited build — render without counts, never fabricate one.
+    return { ...EMPTY }
+  }
+}
+
+let cached: Promise<GitHubStats> | null = null
+
+/** Repo stats for the current build, fetched at most once and shared. */
+export function getGitHubStats(): Promise<GitHubStats> {
+  if (!cached) cached = fetchGitHubStats(GITHUB_REPO)
+  return cached
+}
+
+/** Compact count for display (e.g. `1.2k`); empty string when unknown. */
+export function formatCount(n: number | null): string {
+  if (n == null) return ''
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n)
+}


### PR DESCRIPTION
## What (plan 68 — GitHub star social proof)

Adds a **star-count CTA to the hero** and wires **click tracking** on the star CTAs, reconciling with the star fetch `SocialProof.astro` already does rather than duplicating it.

- **`lib/github-stars.ts` (new)** — extracts the build-time GitHub `stargazers_count` fetch into a shared, memoized helper so the static build makes **one** API call, consumed by both the hero badge and the community card. Fails open: on offline/rate-limited/non-200, counts are `null`.
- **Hero.astro** — the plain "GitHub" button becomes a "★ Star {count}" badge with a reserved-width count (`data-cta="github-star-hero"`). When the fetch returns no count it renders "Star" with **no fabricated number**.
- **SocialProof.astro** — now consumes the shared helper (removed its inline duplicate fetch); star chip gets `data-cta="github-star-community"`.
- Click tracking uses the **existing `data-cta` delegation** in `Base.astro` → allowlisted `cta_click` event (DNT-respecting) — no new analytics event type added.
- **`github-stars.test.ts` (new)** + a `test` script for the landing package: covers the fail-open invariant (throw/non-200 → null, never a fake count) and count formatting.

## Reconciliation note (STOP/DRIFT)

The plan's STOP condition says reconcile if a star count already exists — it did (`SocialProof.astro`). So this shares that one data path and adds only the missing hero badge + tracking, instead of a second fetch/duplicate card. `OpenSource.astro` is not mounted in `index.astro`, so the mid-page card stays in `SocialProof`.

## Verification

- `cd apps/landing && bun run build` — green (5 pages); built HTML contains both `github-star-hero` and `github-star-community` CTAs.
- `bun test apps/landing/src/lib/github-stars.test.ts` — 7 pass.
- `bun run check` (whole repo) — clean, no format drift. Pre-push (891 unit/package tests) green.

## Risk

Additive marketing-only; no app/runtime/billing/security change. Honest-marketing invariant held (real count or none).

Co-Authored-By: duyetbot <bot@duyet.net>