### PR TITLE
feat(query-config): community query-pack registry (plan 54)

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -261,3 +261,12 @@ AGENTSTATE_API_KEY=
 # (Docker volume / K8s ConfigMap — see docker-compose.yml and
 # deploy/kubernetes/README.md).
 # CHM_CONFIG_DIRECTORY=/etc/chmonitor/queries.d
+# Community query-pack registry (requires CHM_CONFIG_SOURCE=declarative).
+# Comma-separated HTTP(S) or file:// URLs, each a single YAML manifest
+# ({ name, version, queries: [...] }) fetched once at startup (no hot-reload).
+# HTTP(S) fetches are SSRF-guarded; file:// reads are a local, operator-chosen
+# path (same trust model as CHM_CONFIG_DIRECTORY). Precedence (highest to
+# lowest): CHM_CONFIG_DIRECTORY > packs > built-in declarative catalog > TS
+# configs; within packs, the last URL wins on a name collision (logged). An
+# unreachable/malformed pack is skipped — the built-in catalog always serves.
+# CHM_PACK_REGISTRY_URL=https://example.com/chmonitor-pack.yaml

--- a/apps/dashboard/src/lib/query-config/declarative/pack-registry.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/pack-registry.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for the community query-pack registry (Plan 54).
+ *
+ * `loadPacks` and `parsePackRegistryUrls` are the stable, directly-testable
+ * contracts — same rationale as `local-loader.test.ts` (plan 55): the
+ * memoized `ensurePacksLoaded` / `getPackCatalogSnapshot` singleton is wired
+ * through `getQueryConfigByName`'s `import.meta.env.SSR` branch, which isn't
+ * statically folded under plain `bun:test`, so asserting through that seam
+ * would test the wrong thing.
+ *
+ * HTTP fetches are stubbed (no real network/DNS) via an injected `fetchImpl`;
+ * `file://` cases use real temp files on disk, matching local-loader.test.ts.
+ */
+
+import { loadPacks, parsePackRegistryUrls } from './pack-registry'
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+function writeTempYaml(contents: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'chm-pack-registry-'))
+  const filePath = join(dir, 'pack.yaml')
+  writeFileSync(filePath, contents, 'utf-8')
+  return pathToFileURL(filePath).href
+}
+
+function okResponse(text: string): Response {
+  return new Response(text, { status: 200 })
+}
+
+const VALID_PACK = [
+  'name: community-pack',
+  'version: "1.0.0"',
+  'queries:',
+  '  - name: my-pack-query',
+  '    sql: "SELECT 1"',
+  '    columns:',
+  '      - value',
+].join('\n')
+
+// ---------------------------------------------------------------------------
+// parsePackRegistryUrls
+// ---------------------------------------------------------------------------
+
+describe('parsePackRegistryUrls', () => {
+  test('returns [] with no env set', () => {
+    expect(parsePackRegistryUrls({})).toEqual([])
+  })
+
+  test('returns [] for an empty string value', () => {
+    expect(parsePackRegistryUrls({ CHM_PACK_REGISTRY_URL: '' })).toEqual([])
+  })
+
+  test('parses a single URL', () => {
+    expect(
+      parsePackRegistryUrls({
+        CHM_PACK_REGISTRY_URL: 'https://example.com/pack.yaml',
+      })
+    ).toEqual(['https://example.com/pack.yaml'])
+  })
+
+  test('splits comma-separated URLs and trims whitespace', () => {
+    expect(
+      parsePackRegistryUrls({
+        CHM_PACK_REGISTRY_URL:
+          ' https://example.com/a.yaml , file:///etc/pack-b.yaml ,,',
+      })
+    ).toEqual(['https://example.com/a.yaml', 'file:///etc/pack-b.yaml'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadPacks — the plan's stated scenarios
+// ---------------------------------------------------------------------------
+
+describe('loadPacks', () => {
+  test('empty url list resolves to an empty catalog, no I/O', async () => {
+    const result = await loadPacks([], () => {
+      throw new Error('fetchImpl must not be called')
+    })
+    expect(result).toEqual({ catalog: {}, skipped: [] })
+  })
+
+  test('a valid HTTP pack merges and its query appears in the catalog', async () => {
+    const fetchImpl = (async () =>
+      okResponse(VALID_PACK)) as unknown as typeof fetch
+
+    const result = await loadPacks(
+      ['https://packs.example.com/pack.yaml'],
+      fetchImpl
+    )
+
+    expect(result.skipped).toEqual([])
+    expect(result.catalog['my-pack-query']).toBeDefined()
+    expect(result.catalog['my-pack-query'].sql).toBe('SELECT 1')
+  })
+
+  test('a valid file:// pack loads and its query appears in the catalog', async () => {
+    const url = writeTempYaml(VALID_PACK)
+    const dir = join(url.replace('file://', ''), '..')
+
+    try {
+      const result = await loadPacks([url])
+
+      expect(result.skipped).toEqual([])
+      expect(result.catalog['my-pack-query']).toBeDefined()
+      expect(result.catalog['my-pack-query'].columns).toEqual(['value'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('an unreachable pack (fetch throws) fails closed to an empty catalog', async () => {
+    const fetchImpl = (async () => {
+      throw new Error('ECONNREFUSED')
+    }) as unknown as typeof fetch
+
+    const result = await loadPacks(
+      ['https://down.example.com/pack.yaml'],
+      fetchImpl
+    )
+
+    expect(result.catalog).toEqual({})
+    expect(result.skipped).toHaveLength(1)
+    expect(result.skipped[0].source).toBe('https://down.example.com/pack.yaml')
+    expect(result.skipped[0].error).toContain('Could not fetch pack')
+  })
+
+  test('a non-2xx HTTP response is treated as unreachable', async () => {
+    const fetchImpl = (async () =>
+      new Response('not found', { status: 404 })) as unknown as typeof fetch
+
+    const result = await loadPacks(
+      ['https://example.com/missing.yaml'],
+      fetchImpl
+    )
+
+    expect(result.catalog).toEqual({})
+    expect(result.skipped).toHaveLength(1)
+    expect(result.skipped[0].error).toContain('404')
+  })
+
+  test('invalid YAML syntax rejects the whole pack, never throws', async () => {
+    const fetchImpl = (async () =>
+      okResponse('name: broken\n  sql: "SELECT 1')) as unknown as typeof fetch
+
+    let result: Awaited<ReturnType<typeof loadPacks>> | undefined
+    await expect(
+      (async () => {
+        result = await loadPacks(['https://example.com/broken.yaml'], fetchImpl)
+      })()
+    ).resolves.toBeUndefined()
+
+    expect(result!.catalog).toEqual({})
+    expect(result!.skipped).toHaveLength(1)
+    expect(result!.skipped[0].error).toContain('Invalid YAML')
+  })
+
+  test('a manifest missing required fields rejects the whole pack', async () => {
+    const fetchImpl = (async () =>
+      okResponse(
+        'description: "no name, version, or queries"'
+      )) as unknown as typeof fetch
+
+    const result = await loadPacks(
+      ['https://example.com/no-manifest.yaml'],
+      fetchImpl
+    )
+
+    expect(result.catalog).toEqual({})
+    expect(result.skipped).toHaveLength(1)
+    expect(result.skipped[0].error).toContain('Invalid pack manifest')
+  })
+
+  test('one invalid query in an otherwise-valid pack is skipped; valid entries still merge', async () => {
+    const mixedPack = [
+      'name: mixed-pack',
+      'version: "1.0.0"',
+      'queries:',
+      '  - name: good-query',
+      '    sql: "SELECT 1"',
+      '    columns:',
+      '      - value',
+      '  - name: bad-query',
+      '    sql: "SELECT 2"', // missing required `columns`
+    ].join('\n')
+    const fetchImpl = (async () =>
+      okResponse(mixedPack)) as unknown as typeof fetch
+
+    const result = await loadPacks(
+      ['https://example.com/mixed.yaml'],
+      fetchImpl
+    )
+
+    expect(result.catalog['good-query']).toBeDefined()
+    expect(result.catalog['bad-query']).toBeUndefined()
+    expect(result.skipped).toHaveLength(1)
+    expect(result.skipped[0].source).toContain('queries[1]')
+  })
+
+  test('a later URL wins on a name collision (last pack wins)', async () => {
+    const first = [
+      'name: pack-a',
+      'version: "1.0.0"',
+      'queries:',
+      '  - name: shared-query',
+      '    sql: "SELECT 1"',
+      '    columns:',
+      '      - value',
+    ].join('\n')
+    const second = [
+      'name: pack-b',
+      'version: "2.0.0"',
+      'queries:',
+      '  - name: shared-query',
+      '    sql: "SELECT 2"',
+      '    columns:',
+      '      - value',
+    ].join('\n')
+
+    let call = 0
+    const fetchImpl = (async () => {
+      call += 1
+      return okResponse(call === 1 ? first : second)
+    }) as unknown as typeof fetch
+
+    const result = await loadPacks(
+      ['https://example.com/a.yaml', 'https://example.com/b.yaml'],
+      fetchImpl
+    )
+
+    expect(result.catalog['shared-query'].sql).toBe('SELECT 2')
+  })
+
+  test('an unreachable pack among several does not block the others from loading', async () => {
+    const fetchImpl = (async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('down')) {
+        throw new Error('ECONNREFUSED')
+      }
+      return okResponse(VALID_PACK)
+    }) as unknown as typeof fetch
+
+    const result = await loadPacks(
+      [
+        'https://down.example.com/pack.yaml',
+        'https://up.example.com/pack.yaml',
+      ],
+      fetchImpl
+    )
+
+    expect(result.catalog['my-pack-query']).toBeDefined()
+    expect(result.skipped).toHaveLength(1)
+    expect(result.skipped[0].source).toBe('https://down.example.com/pack.yaml')
+  })
+})

--- a/apps/dashboard/src/lib/query-config/declarative/pack-registry.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/pack-registry.ts
@@ -1,0 +1,273 @@
+/**
+ * Community query-pack registry — Plan 54.
+ *
+ * `CHM_PACK_REGISTRY_URL` (comma-separated) points at one or more query packs
+ * — HTTP(S) URLs or `file://` mounts — each a single YAML document shaped
+ * like:
+ *
+ *   name: my-pack
+ *   version: "1.0.0"
+ *   minChmVersion: "0.3.0"   # optional; accepted, not yet enforced (v1)
+ *   queries:
+ *     - name: my-query
+ *       sql: "SELECT 1"
+ *       columns: [value]
+ *
+ * Packs are fetched once per process — startup-only, no hot-reload (v1; see
+ * plan 54's open questions). Loading is gated on `CHM_CONFIG_SOURCE=declarative`
+ * (packs extend the declarative catalog, same as the built-in one) and is a
+ * no-op with zero I/O when no URLs are configured — the common/default case.
+ *
+ * SSRF: HTTP(S) fetches go through the shared `createHostValidationFetch`
+ * (same primitive guarding ClickHouse Cloud connections, webhooks, and custom
+ * MCP servers). `file://` reads bypass it deliberately — SSRF is a *network*
+ * concern, and a `file://` pack is an operator-configured local path (same
+ * trust model as `CHM_CONFIG_DIRECTORY` / queries.d, plan 55), not
+ * attacker-controlled input.
+ *
+ * Fail-closed at every layer: an unreachable URL, invalid YAML, an invalid
+ * manifest, or an invalid query entry is skipped with a `warn` log — the pack
+ * (or just that entry) is dropped and the built-in catalog still serves. This
+ * module never throws.
+ *
+ * Precedence (highest to lowest): local queries.d (plan 55) > packs (this
+ * module) > built-in `DECLARATIVE_CATALOG` (plan 53) > TS `queries` array.
+ * Within packs, later URLs in `CHM_PACK_REGISTRY_URL` win on a name
+ * collision (logged); a later query within the same pack wins over an
+ * earlier one too (same merge step).
+ *
+ * SERVER-ONLY MODULE: statically imports `node:fs/promises` + `node:url` (for
+ * `file://`) and the `yaml` parser — none of which belong in the browser
+ * bundle. Every call site MUST gate on the build-time `import.meta.env.SSR`
+ * constant so Vite/Rollup dead-code-eliminates this whole module out of the
+ * client build. See `getQueryConfigByName` in `../index.ts`.
+ */
+
+import { z } from 'zod'
+
+import type { DeclarativeQueryConfig } from './schema'
+
+import { getConfigSource } from './loader'
+import { validateDeclarativeConfig } from './validate'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { error, warn } from '@chm/logger'
+import { parse as parseYaml } from 'yaml'
+import { createHostValidationFetch } from '@/lib/browser-connections/host-url'
+
+// ---------------------------------------------------------------------------
+// Env
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `CHM_PACK_REGISTRY_URL` into a trimmed URL list, or `[]` when unset.
+ * Pure — pass any env getter (mirrors `getConfigDirectory`'s runtimeEnv-first
+ * convention).
+ */
+export function parsePackRegistryUrls(
+  runtimeEnv?: Record<string, string | undefined>
+): string[] {
+  const source =
+    runtimeEnv ?? (typeof process !== 'undefined' ? process.env : {})
+  const raw = (source as Record<string, string | undefined>)
+    .CHM_PACK_REGISTRY_URL
+  if (!raw?.trim()) return []
+  return raw
+    .split(',')
+    .map((u) => u.trim())
+    .filter(Boolean)
+}
+
+// ---------------------------------------------------------------------------
+// Manifest schema
+// ---------------------------------------------------------------------------
+
+const packManifestSchema = z.object({
+  name: z.string().min(1, 'pack name is required'),
+  version: z.string().min(1, 'pack version is required'),
+  // Minimum chmonitor version required to use this pack. Accepted and
+  // schema-validated for forward-compatibility; not yet enforced against the
+  // running app version (deferred — see plan 54's open questions).
+  minChmVersion: z.string().min(1).optional(),
+  queries: z.array(z.unknown()).min(1, 'pack must declare at least one query'),
+})
+
+// ---------------------------------------------------------------------------
+// loadPacks — fetch, parse, validate, dedupe, merge
+// ---------------------------------------------------------------------------
+
+export interface LoadPacksResult {
+  /** Deduped, name-keyed catalog — last writer (by URL/queries order) wins. */
+  catalog: Record<string, DeclarativeQueryConfig>
+  /** Every whole-pack or per-query rejection, with a human-readable reason. */
+  skipped: Array<{ source: string; error: string }>
+}
+
+const PACK_FETCH_TIMEOUT_MS = 5000
+
+/** Read one pack's raw YAML text — `file://` via disk, else via `fetchImpl`. */
+async function readPackSource(
+  url: string,
+  fetchImpl: typeof fetch
+): Promise<string> {
+  if (url.startsWith('file://')) {
+    return readFile(fileURLToPath(url), 'utf-8')
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), PACK_FETCH_TIMEOUT_MS)
+  try {
+    const response = await fetchImpl(url, { signal: controller.signal })
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`.trim())
+    }
+    return await response.text()
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+/**
+ * Fetch + validate every pack URL, merging valid queries into a single
+ * name-keyed catalog. Never throws — every failure (fetch, YAML, manifest,
+ * or a single query) is caught, logged via `warn`, and recorded in `skipped`;
+ * the rest of the registry (and the built-in catalog) is unaffected.
+ *
+ * @param fetchImpl - SSRF-guarded by default (`createHostValidationFetch`).
+ *   Tests inject a stub to stay hermetic (no real network/DNS).
+ */
+export async function loadPacks(
+  urls: string[],
+  fetchImpl: typeof fetch = createHostValidationFetch()
+): Promise<LoadPacksResult> {
+  const catalog: Record<string, DeclarativeQueryConfig> = {}
+  const skipped: Array<{ source: string; error: string }> = []
+
+  for (const url of urls) {
+    let text: string
+    try {
+      text = await readPackSource(url, fetchImpl)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      skipped.push({ source: url, error: `Could not fetch pack: ${message}` })
+      warn(`[query-config] Skipping pack "${url}": unreachable`, {
+        error: message,
+      })
+      continue
+    }
+
+    let parsed: unknown
+    try {
+      parsed = parseYaml(text)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      skipped.push({ source: url, error: `Invalid YAML: ${message}` })
+      warn(`[query-config] Skipping pack "${url}": invalid YAML`, {
+        error: message,
+      })
+      continue
+    }
+
+    const manifestResult = packManifestSchema.safeParse(parsed)
+    if (!manifestResult.success) {
+      const message = manifestResult.error.issues
+        .map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+        .join('; ')
+      skipped.push({ source: url, error: `Invalid pack manifest: ${message}` })
+      warn(`[query-config] Skipping pack "${url}": invalid manifest`, {
+        error: message,
+      })
+      continue
+    }
+
+    const manifest = manifestResult.data
+    const packLabel = `${manifest.name}@${manifest.version}`
+
+    for (const [index, entry] of manifest.queries.entries()) {
+      const result = validateDeclarativeConfig(entry)
+      if (!result.ok) {
+        const message = result.errors.join('; ')
+        skipped.push({
+          source: `${url} (pack ${packLabel}, queries[${index}])`,
+          error: message,
+        })
+        warn(
+          `[query-config] Skipping queries[${index}] in pack "${packLabel}": schema validation failed`,
+          { url, error: message }
+        )
+        continue
+      }
+
+      if (catalog[result.config.name]) {
+        warn(
+          `[query-config] Pack "${packLabel}" overrides existing query "${result.config.name}"`,
+          { url }
+        )
+      }
+      catalog[result.config.name] = result.config
+    }
+  }
+
+  return { catalog, skipped }
+}
+
+// ---------------------------------------------------------------------------
+// Process-lifetime memo — startup-only (v1), matching getLocalConfigCatalog's
+// convention. Real callers (route handlers) `await ensurePacksLoaded` before
+// the synchronous `getQueryConfigByName` lookup, so the catalog is guaranteed
+// warm by the time it's read — no cold-start race.
+// ---------------------------------------------------------------------------
+
+let packCatalogSnapshot: Record<string, DeclarativeQueryConfig> = {}
+let warmupPromise: Promise<Record<string, DeclarativeQueryConfig>> | undefined
+
+/**
+ * Ensure the pack catalog has been loaded, and return it. Memoized for the
+ * process lifetime — the first call performs the fetch(es); every later call
+ * (regardless of `runtimeEnv`) resolves immediately to the same result.
+ *
+ * A no-op (no I/O at all) when the declarative path isn't active or no pack
+ * URLs are configured — keeps the OSS/`ts`-default path free.
+ */
+export function ensurePacksLoaded(
+  runtimeEnv?: Record<string, string | undefined>
+): Promise<Record<string, DeclarativeQueryConfig>> {
+  if (warmupPromise) return warmupPromise
+
+  if (getConfigSource(runtimeEnv) !== 'declarative') {
+    warmupPromise = Promise.resolve(packCatalogSnapshot)
+    return warmupPromise
+  }
+
+  const urls = parsePackRegistryUrls(runtimeEnv)
+  if (urls.length === 0) {
+    warmupPromise = Promise.resolve(packCatalogSnapshot)
+    return warmupPromise
+  }
+
+  warmupPromise = loadPacks(urls)
+    .then((result) => {
+      packCatalogSnapshot = result.catalog
+      return packCatalogSnapshot
+    })
+    .catch((err) => {
+      // loadPacks already catches every per-URL failure; this is an extra
+      // safety net so a truly unexpected throw can never surface as an
+      // unhandled rejection or block the built-in catalog.
+      error(
+        '[query-config] Unexpected pack-registry failure; using built-in catalog',
+        err
+      )
+      return packCatalogSnapshot
+    })
+
+  return warmupPromise
+}
+
+/** Synchronous read of whatever's currently cached (`{}` until warmed). */
+export function getPackCatalogSnapshot(): Record<
+  string,
+  DeclarativeQueryConfig
+> {
+  return packCatalogSnapshot
+}

--- a/apps/dashboard/src/lib/query-config/index.ts
+++ b/apps/dashboard/src/lib/query-config/index.ts
@@ -3,6 +3,7 @@ import type { QueryConfig } from '@/types/query-config'
 import { DECLARATIVE_CATALOG } from './declarative/catalog'
 import { getConfigSource, loadDeclarativeConfig } from './declarative/loader'
 import { getLocalConfigCatalog } from './declarative/local-loader'
+import { getPackCatalogSnapshot } from './declarative/pack-registry'
 import { error } from '@chm/logger'
 
 export type { QueryConfig } from './types'
@@ -281,6 +282,23 @@ export const getQueryConfigByName = (
           `[query-config] Malformed local config for "${name}"; falling back to built-in config`,
           err
         )
+      }
+    }
+
+    // Community query packs (plan 54) — extend the declarative catalog, so
+    // only consulted alongside it. Callers `await ensurePacksLoaded` before
+    // this synchronous lookup; the snapshot is `{}` (fail-closed) otherwise.
+    if (getConfigSource(runtimeEnv) === 'declarative') {
+      const pack = getPackCatalogSnapshot()[name]
+      if (pack) {
+        try {
+          return loadDeclarativeConfig(pack)
+        } catch (err) {
+          error(
+            `[query-config] Malformed pack config for "${name}"; falling back to built-in config`,
+            err
+          )
+        }
       }
     }
   }

--- a/apps/dashboard/src/routes/api/v1/browser-connections/tables/$name.ts
+++ b/apps/dashboard/src/routes/api/v1/browser-connections/tables/$name.ts
@@ -14,6 +14,7 @@ import { ApiErrorType } from '@/lib/api/types'
 import { executeConnectionTableConfig } from '@/lib/connection-query/execute-connection-table'
 import { resolveProxyCredentials } from '@/lib/connection-query/resolve-credentials'
 import { getQueryConfigByName } from '@/lib/query-config'
+import { ensurePacksLoaded } from '@/lib/query-config/declarative/pack-registry'
 
 const ROUTE_CONTEXT = {
   route: '/api/v1/browser-connections/tables/$name',
@@ -31,6 +32,9 @@ async function handlePost(
   request: Request,
   tableName: string
 ): Promise<Response> {
+  // Community query packs (plan 54) — warm before the sync lookup so a
+  // pack-only table name resolves deterministically (no cold-start race).
+  await ensurePacksLoaded()
   const queryConfig = getQueryConfigByName(tableName)
   if (!queryConfig) {
     return createErrorResponse(

--- a/apps/dashboard/src/routes/api/v1/user-connections/tables/$name.ts
+++ b/apps/dashboard/src/routes/api/v1/user-connections/tables/$name.ts
@@ -17,6 +17,7 @@ import { resolveConnectionUserId } from '@/lib/connection-store/auth'
 import { resolveConnectionStore } from '@/lib/connection-store/resolve-store'
 import { getUserConnectionsServerConfig } from '@/lib/connection-store/server-feature'
 import { getQueryConfigByName } from '@/lib/query-config'
+import { ensurePacksLoaded } from '@/lib/query-config/declarative/pack-registry'
 
 const ROUTE_CONTEXT = {
   route: '/api/v1/user-connections/tables/$name',
@@ -44,6 +45,9 @@ async function handlePost(
     )
   }
 
+  // Community query packs (plan 54) — warm before the sync lookup so a
+  // pack-only table name resolves deterministically (no cold-start race).
+  await ensurePacksLoaded()
   const queryConfig = getQueryConfigByName(tableName)
   if (!queryConfig) {
     return createErrorResponse(

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -461,6 +461,7 @@ Injected at build time for the About page.
 | Variable | Default | Purpose |
 |---|---|---|
 | `CHM_CONFIG_SOURCE` | `ts` | Query-config resolution path: `ts` (hand-written TypeScript configs, current default everywhere) or `declarative` (opt-in data-only catalog, validated against the same schema and kept at parity — see [Catalog contributing](/reference/catalog-contributing)). Any value other than the literal string `declarative` resolves to `ts`. A malformed declarative entry logs an error and falls back to the `ts` config rather than crashing. |
+| `CHM_PACK_REGISTRY_URL` | — | Comma-separated community query-pack URLs (HTTP(S) or `file://`), consulted when `CHM_CONFIG_SOURCE=declarative`. Each pack is a single YAML manifest (`{ name, version, queries: [...] }`) fetched once at startup (no hot-reload). HTTP(S) fetches are SSRF-guarded; `file://` reads a local, operator-chosen path. Precedence (highest to lowest): the self-hosted local `queries.d` override > packs > the built-in declarative catalog > `ts` configs. Within packs, the last URL wins on a name collision (logged). An unreachable or malformed pack — or a single bad query inside an otherwise-valid pack — is skipped with a warning; the built-in catalog always still serves. |
 
 ## Legacy / migration
 

--- a/docs/knowledge/declarative-config-catalog.md
+++ b/docs/knowledge/declarative-config-catalog.md
@@ -170,6 +170,35 @@ catalog-wide what the per-domain suites can't, gating the 02L default flip:
   documented allowlist (`keeper-presence`, `cluster-live-metrics-all`) consumed
   by direct import in `routes/api/v1/cluster-topology.ts`.
 
+## Community query packs (plan 54)
+
+`declarative/pack-registry.ts` lets self-hosters extend the catalog at runtime
+without rebuilding, via `CHM_PACK_REGISTRY_URL` (comma-separated HTTP(S) or
+`file://` URLs), consulted when `CHM_CONFIG_SOURCE=declarative`. Each pack is
+one YAML manifest — `{ name, version, minChmVersion?, queries: [...] }` — where
+every entry in `queries` is validated against the same
+`declarativeQueryConfigSchema` as the built-in catalog.
+
+- **`loadPacks(urls, fetchImpl?)`** — the directly-testable core (mirrors
+  `local-loader.ts`'s `loadLocalConfigs`): fetches each URL (SSRF-guarded via
+  `createHostValidationFetch`, with a 5s timeout; `file://` reads the local
+  path directly — not a network concern, same trust model as
+  `CHM_CONFIG_DIRECTORY`), parses YAML, validates the manifest shape, then
+  validates each query individually. A whole pack is rejected (fetch error,
+  invalid YAML, invalid manifest) on failure; a single bad query inside an
+  otherwise-valid pack is skipped without dropping its siblings. Every failure
+  is `warn`-logged and returned in `skipped` — this function never throws.
+- **Precedence**: local `queries.d` (plan 55) > packs > built-in
+  `DECLARATIVE_CATALOG` > TS `queries`. Within packs, a later
+  `CHM_PACK_REGISTRY_URL` entry wins on a name collision (logged).
+- **Startup-only (v1)** — `ensurePacksLoaded(runtimeEnv)` is memoized for the
+  process lifetime; no hot-reload. The two `tables/$name` route handlers
+  (`browser-connections`, `user-connections`) `await` it before the
+  synchronous `getQueryConfigByName` lookup so a pack-only query resolves
+  deterministically on first request, instead of racing a background fetch.
+- **`minChmVersion`** is schema-validated but not yet enforced against the
+  running app version — deferred, same as pack signing/verification.
+
 ## Status
 
 Foundation + opt-in wiring complete; `DECLARATIVE_CATALOG` has 93 entries — 91


### PR DESCRIPTION
## What (plan 54 — community query-pack registry)

Adds `CHM_PACK_REGISTRY_URL` — a community query-pack loader (HTTP(S) / `file://`, **SSRF-guarded, fail-closed**) wired into the declarative config path (`getQueryConfigByName` when `CHM_CONFIG_SOURCE=declarative`).

- **`lib/query-config/declarative/pack-registry.ts` (new)** — `parsePackRegistryUrls`, `loadPacks` (fetch/parse/validate/dedupe/merge with **per-URL and per-query granular fail-closed**), `ensurePacksLoaded`/`getPackCatalogSnapshot` (process-lifetime memo, startup-only).
- Precedence: local `queries.d` (plan 55) > packs > `DECLARATIVE_CATALOG` (plan 53) > TS `queries`. Kept `getQueryConfigByName` **synchronous** (unchanged contract); async fetch lives in `ensurePacksLoaded`, awaited by the two BYO-connection routes.
- Env var + precedence/collision docs in `.env.example`, `environment-variables.mdx`, `declarative-config-catalog.md`.

## Tests / verification

- **16 new tests**: URL parsing; empty-list zero-I/O no-op; valid HTTP + `file://` packs merge; unreachable/non-2xx fails closed (empty catalog); invalid YAML / missing manifest fields reject the whole pack without throwing; one bad query is skipped while siblings merge (granular fail-closed); later URL wins on collision; one down pack doesn't block others.
- `bun test src/lib/query-config --isolate` → **1042 pass, 0 fail** (zero regressions in plan 53/55 suites). `bun run check` / `lint` / `depcruise` clean.

## Reviewer note (pre-existing, not from this PR)

The primary env-host path (`lib/api/table-registry.ts`) seeds from the static bundled `queries` and does **not** call `getQueryConfigByName`, so packs (like the declarative catalog + `queries.d` before them) currently reach only the BYO-connection routes. Fully wiring the primary path is a larger `table-registry` restructure — out of this plan's scope, flagged for a follow-up.

## Risk

Additive-only, fail-closed by construction, no ripple into existing tests.

Co-Authored-By: duyetbot <bot@duyet.net>