### PR TITLE
feat(health): persist dispatched alerts to D1 alert_events + history API (plan 27)

### DIFF
--- a/apps/dashboard/src/components/health/health-settings-dialog.tsx
+++ b/apps/dashboard/src/components/health/health-settings-dialog.tsx
@@ -2,6 +2,7 @@ import { Settings } from 'lucide-react'
 import { toast } from 'sonner'
 
 import { HEALTH_CHECKS } from './health-checks'
+import { RecentAlertsCard } from './recent-alerts-card'
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
@@ -177,6 +178,7 @@ export function HealthSettingsDialog() {
           <TabsList>
             <TabsTrigger value="thresholds">Thresholds</TabsTrigger>
             <TabsTrigger value="alerts">Alerts</TabsTrigger>
+            <TabsTrigger value="history">History</TabsTrigger>
           </TabsList>
 
           <TabsContent value="thresholds">
@@ -358,6 +360,10 @@ export function HealthSettingsDialog() {
                 </button>
               </div>
             </div>
+          </TabsContent>
+
+          <TabsContent value="history">
+            <RecentAlertsCard />
           </TabsContent>
         </Tabs>
 

--- a/apps/dashboard/src/components/health/recent-alerts-card.tsx
+++ b/apps/dashboard/src/components/health/recent-alerts-card.tsx
@@ -1,0 +1,199 @@
+import { RefreshCw } from 'lucide-react'
+
+import type { AlertEventRecord } from '@/lib/health/alert-history-store'
+
+import { useAlertHistory } from './use-alert-history'
+import { useMemo, useState } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/ui/empty-state'
+import { Input } from '@/components/ui/input'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { useHostId } from '@/lib/swr/use-host'
+import { isServerHost, useMergedHosts } from '@/lib/swr/use-merged-hosts'
+import { cn } from '@/lib/utils'
+import { formatRelativeTime } from '@/lib/utils/format-relative-time'
+
+const ALL_HOSTS_VALUE = 'all'
+const HISTORY_LIMIT = 50
+
+/** Badge tint per event severity — 'recovery' reuses the brand's health/live emerald. */
+const SEVERITY_BADGE_CLASS: Record<AlertEventRecord['severity'], string> = {
+  critical:
+    'border-transparent bg-destructive/15 text-destructive dark:bg-destructive/25',
+  warning:
+    'border-transparent bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
+  recovery:
+    'border-transparent bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300',
+}
+
+/**
+ * "Recent alerts" card for the Health Settings dialog — lists dispatched
+ * sweep alerts from `GET /api/v1/health/history`, with an optional host/day
+ * filter. Persistence is best-effort (see `alert-history-store.ts`): on a
+ * deployment without D1 configured (self-hosted/OSS default) this simply
+ * shows the "no alerts recorded" empty state rather than an error.
+ */
+export function RecentAlertsCard() {
+  const currentHostId = useHostId()
+  const { hosts } = useMergedHosts()
+  // Alert history only ever covers env-configured hosts (the sweep reads
+  // CLICKHOUSE_* only, never per-user browser/database connections), so
+  // offering those in the filter would just always come back empty.
+  const serverHosts = useMemo(
+    () => hosts.filter((h) => isServerHost(h.source)),
+    [hosts]
+  )
+
+  const [hostFilter, setHostFilter] = useState<string>(String(currentHostId))
+  const [day, setDay] = useState('')
+
+  const hostId = hostFilter === ALL_HOSTS_VALUE ? undefined : Number(hostFilter)
+
+  const { events, isLoading, isFetching, error, refetch } = useAlertHistory({
+    hostId,
+    day: day || undefined,
+    limit: HISTORY_LIMIT,
+  })
+
+  let content: React.ReactNode
+  if (isLoading) {
+    content = (
+      <div className="py-8 text-center text-xs text-muted-foreground">
+        Loading recent alerts…
+      </div>
+    )
+  } else if (error) {
+    content = (
+      <EmptyState
+        variant="error"
+        title="Couldn't load alert history"
+        description={error.message}
+        onRefresh={refetch}
+        compact
+      />
+    )
+  } else if (events.length === 0) {
+    content = (
+      <EmptyState
+        variant="no-data"
+        title="No alerts recorded yet"
+        description="Dispatched alerts will show up here after the next health sweep."
+        compact
+      />
+    )
+  } else {
+    content = (
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Time</TableHead>
+            <TableHead>Host</TableHead>
+            <TableHead>Rule</TableHead>
+            <TableHead>Severity</TableHead>
+            <TableHead>Delivery</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {events.map((event) => (
+            <TableRow
+              key={
+                event.id ?? `${event.hostId}-${event.rule}-${event.eventTime}`
+              }
+            >
+              <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
+                {formatRelativeTime(new Date(event.eventTime).getTime())}
+              </TableCell>
+              <TableCell className="text-xs">
+                {event.hostLabel ?? event.hostId}
+              </TableCell>
+              <TableCell className="text-xs">{event.rule}</TableCell>
+              <TableCell>
+                <Badge
+                  className={cn(
+                    'text-[11px]',
+                    SEVERITY_BADGE_CLASS[event.severity]
+                  )}
+                >
+                  {event.severity}
+                </Badge>
+              </TableCell>
+              <TableCell className="text-xs">
+                {event.delivered ? (
+                  <span className="text-muted-foreground">Delivered</span>
+                ) : (
+                  <span
+                    className="text-destructive"
+                    title={event.error ?? undefined}
+                  >
+                    Failed
+                  </span>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Select value={hostFilter} onValueChange={setHostFilter}>
+          <SelectTrigger className="h-8 w-[160px] text-[13px]">
+            <SelectValue placeholder="All hosts" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_HOSTS_VALUE}>All hosts</SelectItem>
+            {serverHosts.map((h) => (
+              <SelectItem key={h.id} value={String(h.id)}>
+                {h.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Input
+          type="date"
+          value={day}
+          onChange={(e) => setDay(e.target.value)}
+          className="h-8 w-[160px] text-[13px]"
+          aria-label="Filter by day"
+        />
+        {day && (
+          <Button variant="ghost" size="sm" onClick={() => setDay('')}>
+            Clear day
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={refetch}
+          disabled={isFetching}
+          aria-label="Refresh"
+        >
+          <RefreshCw className={cn('size-3.5', isFetching && 'animate-spin')} />
+        </Button>
+      </div>
+
+      <ScrollArea className="h-[320px] rounded-md border">
+        <div className="p-1">{content}</div>
+      </ScrollArea>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/health/use-alert-history.ts
+++ b/apps/dashboard/src/components/health/use-alert-history.ts
@@ -1,0 +1,79 @@
+/**
+ * Data hook for the "Recent alerts" card (health-settings-dialog.tsx).
+ *
+ * Thin TanStack Query wrapper around GET /api/v1/health/history — mirrors the
+ * fetch/error conventions of `use-health-checks.ts` (apiFetch + throwIfNotOk)
+ * but for a single, simple query instead of a batch.
+ */
+import { useQuery } from '@tanstack/react-query'
+
+import type { AlertEventRecord } from '@/lib/health/alert-history-store'
+
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { throwIfNotOk } from '@/lib/swr/fetch-error'
+
+const REFRESH_INTERVAL_MS = 30_000
+
+interface HistoryResponse {
+  success: boolean
+  events: AlertEventRecord[]
+}
+
+export interface UseAlertHistoryParams {
+  /** Omit to show alerts across every host. */
+  hostId?: number
+  /** `YYYY-MM-DD`. Omit to show the most recent alerts regardless of date. */
+  day?: string
+  limit?: number
+}
+
+export interface UseAlertHistoryResult {
+  events: AlertEventRecord[]
+  isLoading: boolean
+  isFetching: boolean
+  error: Error | null
+  refetch: () => void
+}
+
+export function useAlertHistory({
+  hostId,
+  day,
+  limit,
+}: UseAlertHistoryParams): UseAlertHistoryResult {
+  const queryKey = ['/api/v1/health/history', hostId, day, limit] as const
+
+  const { data, error, isPending, isFetching, refetch } = useQuery<
+    HistoryResponse,
+    Error
+  >({
+    queryKey,
+    queryFn: async () => {
+      const params = new URLSearchParams()
+      if (hostId !== undefined) params.set('hostId', String(hostId))
+      if (day) params.set('day', day)
+      if (limit !== undefined) params.set('limit', String(limit))
+      const qs = params.toString()
+      const response = await apiFetch(
+        `/api/v1/health/history${qs ? `?${qs}` : ''}`
+      )
+      await throwIfNotOk(response, 'Failed to fetch alert history')
+      return response.json() as Promise<HistoryResponse>
+    },
+    staleTime: REFRESH_INTERVAL_MS * 0.9,
+    refetchInterval: () =>
+      typeof document !== 'undefined' && document.hidden
+        ? false
+        : REFRESH_INTERVAL_MS,
+    placeholderData: (prev) => prev,
+  })
+
+  return {
+    events: data?.events ?? [],
+    isLoading: isPending && isFetching,
+    isFetching,
+    error,
+    refetch: () => {
+      void refetch()
+    },
+  }
+}

--- a/apps/dashboard/src/db/conversations-migrations/0010_alert_events.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0010_alert_events.sql
@@ -1,0 +1,22 @@
+-- Persisted alert-dispatch audit log (plans/27-alert-history-audit-log.md).
+-- One row per attempted webhook delivery from the health sweep's dedup/notify
+-- decision (server-sweep.ts), whether the delivery succeeded or failed.
+-- host_id is a shared index into the operator's env-configured hosts
+-- (getClickHouseConfigs() reads CLICKHOUSE_* only — never per-user D1
+-- connections), so there is no owner_id/tenant column: every caller allowed to
+-- read /api/v1/health/* already sees the same host set.
+CREATE TABLE IF NOT EXISTS alert_events (
+  id             TEXT PRIMARY KEY,       -- crypto.randomUUID()
+  event_time     TEXT NOT NULL,          -- ISO-8601 UTC (payload.timestamp or now)
+  host_id        INTEGER NOT NULL,
+  host_label     TEXT,
+  rule           TEXT NOT NULL,          -- metric / rule id
+  severity       TEXT NOT NULL,          -- 'warning' | 'critical' | 'recovery'
+  prev_severity  TEXT,                   -- prior severity from the decision, if any
+  decision_kind  TEXT NOT NULL,          -- decision.kind (e.g. 'new' | 'escalated' | 'reminder' | 'recovery')
+  delivered      INTEGER NOT NULL,       -- 1 delivered, 0 attempted-but-failed
+  error          TEXT,                   -- delivery error message when delivered = 0
+  value          REAL,                   -- observed value (payload.value)
+  channel        TEXT                    -- adapter id ('slack'|'telegram'|'discord'|...), when known
+);
+CREATE INDEX IF NOT EXISTS idx_alert_events_host_time ON alert_events (host_id, event_time);

--- a/apps/dashboard/src/lib/health/alert-history-store.test.ts
+++ b/apps/dashboard/src/lib/health/alert-history-store.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for the D1-backed alert-history store.
+ *
+ * Uses a small behavioral fake of D1Database (prepare/bind/run/all) injected
+ * through a mocked @chm/platform, so we exercise the real SQL the store
+ * issues: the insert, the host_id/day-scoped reads (via a LIKE date-prefix
+ * match), the `limit` cap, and the best-effort degrade when no binding is
+ * present or the D1 call itself throws. Mirrors
+ * `insights/baseline-store.test.ts`'s fake-D1 pattern.
+ *
+ * WHY these matter: this store backs both the sweep's post-delivery audit
+ * write and the filtered read API — a bug here either silently drops history
+ * (round-trip) or, worse, throws into the sweep and could delay/drop a real
+ * alert (fail-open path).
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// --- behavioral D1 fake ------------------------------------------------------
+interface FakeRow {
+  id: string
+  event_time: string
+  host_id: number
+  host_label: string | null
+  rule: string
+  severity: string
+  prev_severity: string | null
+  decision_kind: string
+  delivered: number
+  error: string | null
+  value: number | null
+  channel: string | null
+}
+
+function makeFakeD1() {
+  const rows: FakeRow[] = []
+
+  function prepare(sql: string) {
+    const isInsert = /^\s*INSERT INTO/i.test(sql)
+    const hasHostFilter = /host_id = \?/.test(sql)
+    const hasDayFilter = /event_time LIKE \?/.test(sql)
+
+    return {
+      bind(...args: unknown[]) {
+        return {
+          async run(): Promise<{ meta: { changes: number } }> {
+            if (!isInsert)
+              throw new Error('fake D1: run() called on non-INSERT')
+            const [
+              id,
+              eventTime,
+              hostId,
+              hostLabel,
+              rule,
+              severity,
+              prevSeverity,
+              decisionKind,
+              delivered,
+              error,
+              value,
+              channel,
+            ] = args as [
+              string,
+              string,
+              number,
+              string | null,
+              string,
+              string,
+              string | null,
+              string,
+              number,
+              string | null,
+              number | null,
+              string | null,
+            ]
+            rows.push({
+              id,
+              event_time: eventTime,
+              host_id: hostId,
+              host_label: hostLabel,
+              rule,
+              severity,
+              prev_severity: prevSeverity,
+              decision_kind: decisionKind,
+              delivered,
+              error,
+              value,
+              channel,
+            })
+            return { meta: { changes: 1 } }
+          },
+          async all<T>(): Promise<{ results: T[] }> {
+            let idx = 0
+            let filtered = rows
+            if (hasHostFilter) {
+              const hostId = args[idx++] as number
+              filtered = filtered.filter((r) => r.host_id === hostId)
+            }
+            if (hasDayFilter) {
+              const dayLike = args[idx++] as string
+              const prefix = dayLike.replace(/%$/, '')
+              filtered = filtered.filter((r) => r.event_time.startsWith(prefix))
+            }
+            const limit = args[idx] as number
+            const sorted = [...filtered].sort((a, b) =>
+              b.event_time.localeCompare(a.event_time)
+            )
+            return { results: sorted.slice(0, limit) as unknown as T[] }
+          },
+        }
+      },
+    }
+  }
+
+  return { prepare, _rows: rows }
+}
+
+/** A D1 stand-in whose every call throws, to exercise the swallow-on-error path. */
+function makeThrowingD1() {
+  return {
+    prepare() {
+      throw new Error('boom: D1 unavailable')
+    },
+  }
+}
+
+// --- inject via mocked platform ---------------------------------------------
+let currentDb:
+  | ReturnType<typeof makeFakeD1>
+  | ReturnType<typeof makeThrowingD1>
+  | null = null
+
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({
+    getD1Database: () => currentDb,
+  }),
+}))
+
+const { recordAlertEvent, queryAlertEvents } = await import(
+  './alert-history-store'
+)
+
+import type { AlertEventRecord } from './alert-history-store'
+
+const event = (over: Partial<AlertEventRecord> = {}): AlertEventRecord => ({
+  eventTime: '2026-07-01T12:00:00.000Z',
+  hostId: 0,
+  hostLabel: 'prod-ch',
+  rule: 'disk-usage',
+  severity: 'critical',
+  prevSeverity: 'warning',
+  decisionKind: 'escalated',
+  delivered: true,
+  error: null,
+  value: 97.5,
+  channel: 'slack',
+  ...over,
+})
+
+beforeEach(() => {
+  currentDb = makeFakeD1()
+})
+
+describe('alert-history-store', () => {
+  test('recordAlertEvent then queryAlertEvents round-trips every field', async () => {
+    await recordAlertEvent(event())
+
+    const results = await queryAlertEvents({ hostId: 0 })
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject({
+      hostId: 0,
+      hostLabel: 'prod-ch',
+      rule: 'disk-usage',
+      severity: 'critical',
+      prevSeverity: 'warning',
+      decisionKind: 'escalated',
+      delivered: true,
+      error: null,
+      value: 97.5,
+      channel: 'slack',
+    })
+    expect(typeof results[0].id).toBe('string')
+    expect(results[0].id?.length).toBeGreaterThan(0)
+  })
+
+  test('delivered=false round-trips with an error message', async () => {
+    await recordAlertEvent(
+      event({ delivered: false, error: 'Webhook returned status 500' })
+    )
+
+    const [row] = await queryAlertEvents({ hostId: 0 })
+    expect(row.delivered).toBe(false)
+    expect(row.error).toBe('Webhook returned status 500')
+  })
+
+  test('queryAlertEvents filters by hostId', async () => {
+    await recordAlertEvent(event({ hostId: 0, rule: 'host-0-rule' }))
+    await recordAlertEvent(event({ hostId: 1, rule: 'host-1-rule' }))
+
+    expect((await queryAlertEvents({ hostId: 0 })).map((r) => r.rule)).toEqual([
+      'host-0-rule',
+    ])
+    expect((await queryAlertEvents({ hostId: 1 })).map((r) => r.rule)).toEqual([
+      'host-1-rule',
+    ])
+  })
+
+  test('queryAlertEvents filters by day (event_time date prefix)', async () => {
+    await recordAlertEvent(
+      event({ rule: 'day-1', eventTime: '2026-07-01T08:00:00.000Z' })
+    )
+    await recordAlertEvent(
+      event({ rule: 'day-2', eventTime: '2026-07-02T08:00:00.000Z' })
+    )
+
+    const results = await queryAlertEvents({ day: '2026-07-01' })
+    expect(results.map((r) => r.rule)).toEqual(['day-1'])
+  })
+
+  test('queryAlertEvents combines hostId + day filters', async () => {
+    await recordAlertEvent(
+      event({ hostId: 0, rule: 'match', eventTime: '2026-07-01T08:00:00.000Z' })
+    )
+    await recordAlertEvent(
+      event({
+        hostId: 1,
+        rule: 'wrong-host',
+        eventTime: '2026-07-01T08:00:00.000Z',
+      })
+    )
+    await recordAlertEvent(
+      event({
+        hostId: 0,
+        rule: 'wrong-day',
+        eventTime: '2026-07-02T08:00:00.000Z',
+      })
+    )
+
+    const results = await queryAlertEvents({ hostId: 0, day: '2026-07-01' })
+    expect(results.map((r) => r.rule)).toEqual(['match'])
+  })
+
+  test('queryAlertEvents orders newest first and honours limit', async () => {
+    await recordAlertEvent(
+      event({ rule: 'oldest', eventTime: '2026-07-01T08:00:00.000Z' })
+    )
+    await recordAlertEvent(
+      event({ rule: 'newest', eventTime: '2026-07-03T08:00:00.000Z' })
+    )
+    await recordAlertEvent(
+      event({ rule: 'middle', eventTime: '2026-07-02T08:00:00.000Z' })
+    )
+
+    const all = await queryAlertEvents({ hostId: 0 })
+    expect(all.map((r) => r.rule)).toEqual(['newest', 'middle', 'oldest'])
+
+    const capped = await queryAlertEvents({ hostId: 0, limit: 1 })
+    expect(capped.map((r) => r.rule)).toEqual(['newest'])
+  })
+
+  test('queryAlertEvents clamps an out-of-range limit to the max cap', async () => {
+    for (let i = 0; i < 5; i++) {
+      await recordAlertEvent(event({ rule: `r${i}` }))
+    }
+    // A limit above the hard cap must not blow past it (defense in depth —
+    // the route also validates, but the store enforces its own ceiling).
+    const results = await queryAlertEvents({ hostId: 0, limit: 100_000 })
+    expect(results.length).toBe(5)
+  })
+
+  test('degrades to void/[] (never throws) when no D1 binding is present', async () => {
+    currentDb = null
+
+    await recordAlertEvent(event()) // must resolve without throwing
+    expect(await queryAlertEvents({ hostId: 0 })).toEqual([])
+  })
+
+  test('degrades to void/[] (never throws) when the D1 call itself throws', async () => {
+    currentDb = makeThrowingD1()
+
+    await recordAlertEvent(event()) // must resolve without throwing
+    expect(await queryAlertEvents({ hostId: 0 })).toEqual([])
+  })
+})

--- a/apps/dashboard/src/lib/health/alert-history-store.ts
+++ b/apps/dashboard/src/lib/health/alert-history-store.ts
@@ -1,0 +1,183 @@
+/**
+ * D1-backed audit log of dispatched health-sweep alerts.
+ *
+ * Persists one row per attempted webhook delivery (`server-sweep.ts`, right
+ * after `postWebhook` resolves) so operators can see what fired, when, and
+ * whether delivery succeeded — the in-memory dedup state
+ * (`alert-state-store.ts`) only remembers the CURRENT condition per host/rule,
+ * not history. Reuses the same `CHM_CLOUD_D1` binding as the agent's
+ * conversation store and `insights/baseline-store.ts`; the table itself is
+ * created by the `alert_events` migration in `db/conversations-migrations`.
+ *
+ * Best-effort like every other insights/health backend: a missing binding, an
+ * unmigrated table, or any other D1 error is caught, logged, and resolved to
+ * `void` / `[]` rather than thrown — so a deployment with no D1 configured
+ * (the OSS/self-hosted default) simply never gets history, and the sweep's
+ * outbound alert delivery is completely unaffected either way (see
+ * plans/27-alert-history-audit-log.md).
+ *
+ * No owner/tenant column: `host_id` indexes the operator's env-configured
+ * hosts (`getClickHouseConfigs()` reads `CLICKHOUSE_*` only, never per-user D1
+ * connections), so every row is already scoped to whoever can reach
+ * `/api/v1/health/*` at all — there is no per-user data to leak.
+ */
+
+import { ErrorLogger } from '@chm/logger'
+import { getPlatformBindings } from '@chm/platform'
+
+const COMPONENT = 'alert-history-store'
+const warn = (msg: string) =>
+  ErrorLogger.logWarning(`[alert-history-store] ${msg}`, {
+    component: COMPONENT,
+  })
+
+const TABLE = 'alert_events'
+
+/** Sane caps so a runaway/unbounded query can't return unbounded rows. */
+const DEFAULT_LIMIT = 100
+const MAX_LIMIT = 200
+
+export interface AlertEventRecord {
+  id?: string
+  eventTime: string
+  hostId: number
+  hostLabel?: string | null
+  rule: string
+  severity: 'warning' | 'critical' | 'recovery'
+  prevSeverity?: 'warning' | 'critical' | 'recovery' | null
+  decisionKind: string
+  delivered: boolean
+  error?: string | null
+  value?: number | null
+  channel?: string | null
+}
+
+/** D1 row shape (snake_case columns, 0/1 delivered flag). */
+interface D1AlertEventRow {
+  id: string
+  event_time: string
+  host_id: number
+  host_label: string | null
+  rule: string
+  severity: string
+  prev_severity: string | null
+  decision_kind: string
+  delivered: number
+  error: string | null
+  value: number | null
+  channel: string | null
+}
+
+function getDb(): D1Database | null {
+  return getPlatformBindings().getD1Database('CHM_CLOUD_D1')
+}
+
+function rowToRecord(row: D1AlertEventRow): AlertEventRecord {
+  return {
+    id: row.id,
+    eventTime: row.event_time,
+    hostId: row.host_id,
+    hostLabel: row.host_label,
+    rule: row.rule,
+    severity: row.severity as AlertEventRecord['severity'],
+    prevSeverity: row.prev_severity as AlertEventRecord['prevSeverity'],
+    decisionKind: row.decision_kind,
+    delivered: row.delivered === 1,
+    error: row.error,
+    value: row.value,
+    channel: row.channel,
+  }
+}
+
+/**
+ * Best-effort append. NEVER throws — a D1 write failure (or a missing
+ * binding, i.e. self-hosted/OSS with no D1 configured) is caught, logged, and
+ * swallowed so the health sweep and its outbound alert delivery are never
+ * affected by an audit-log failure.
+ */
+export async function recordAlertEvent(e: AlertEventRecord): Promise<void> {
+  try {
+    const db = getDb()
+    if (!db) return
+
+    const id = e.id ?? crypto.randomUUID()
+
+    await db
+      .prepare(
+        `INSERT INTO ${TABLE}
+           (id, event_time, host_id, host_label, rule, severity, prev_severity, decision_kind, delivered, error, value, channel)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)`
+      )
+      .bind(
+        id,
+        e.eventTime,
+        e.hostId,
+        e.hostLabel ?? null,
+        e.rule,
+        e.severity,
+        e.prevSeverity ?? null,
+        e.decisionKind,
+        e.delivered ? 1 : 0,
+        e.error ?? null,
+        e.value ?? null,
+        e.channel ?? null
+      )
+      .run()
+  } catch (err) {
+    warn(
+      `failed to record alert event for host ${e.hostId} rule ${e.rule}: ${err}`
+    )
+  }
+}
+
+export interface AlertHistoryQuery {
+  hostId?: number
+  /** `YYYY-MM-DD` — matches the date prefix of `event_time`. */
+  day?: string
+  limit?: number
+}
+
+/**
+ * List recent alert events, optionally filtered by host and/or day, newest
+ * first. Best-effort — returns `[]` on any failure or when D1 is unavailable
+ * (never throws).
+ */
+export async function queryAlertEvents(
+  q: AlertHistoryQuery = {}
+): Promise<AlertEventRecord[]> {
+  try {
+    const db = getDb()
+    if (!db) return []
+
+    const limit = Math.min(Math.max(q.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT)
+    const conditions: string[] = []
+    const params: unknown[] = []
+
+    if (q.hostId !== undefined) {
+      params.push(q.hostId)
+      conditions.push(`host_id = ?${params.length}`)
+    }
+    if (q.day) {
+      params.push(`${q.day}%`)
+      conditions.push(`event_time LIKE ?${params.length}`)
+    }
+
+    const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : ''
+    params.push(limit)
+
+    const result = await db
+      .prepare(
+        `SELECT id, event_time, host_id, host_label, rule, severity, prev_severity, decision_kind, delivered, error, value, channel
+         FROM ${TABLE} ${where}
+         ORDER BY event_time DESC
+         LIMIT ?${params.length}`
+      )
+      .bind(...params)
+      .all<D1AlertEventRow>()
+
+    return (result.results ?? []).map(rowToRecord)
+  } catch (err) {
+    warn(`failed to query alert events: ${err}`)
+    return []
+  }
+}

--- a/apps/dashboard/src/lib/health/server-sweep.test.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Tests for the alert-history hook in the health sweep.
+ *
+ * Two layers:
+ *  1. `buildAlertEventRecord` — a pure decision→record mapping, unit-tested
+ *     directly (no mocking) to lock down the trickiest translation: recovery
+ *     carries its own 'recovery' severity (not the decision's 'ok'), and a
+ *     previousSeverity of 'ok' (no prior firing condition) maps to `null`.
+ *  2. `runHealthSweep` end-to-end — proves the hook is wired at the right
+ *     point in server-sweep.ts and fires exactly once per dispatched alert,
+ *     with the real decision + delivery outcome, on BOTH a successful and a
+ *     failed webhook delivery (`delivered`/`error` only mean something if
+ *     both paths are exercised).
+ *
+ * `@chm/clickhouse-client` is mocked so every rule's SQL resolves to a safe
+ * "ok" value EXCEPT a synthetic test-only rule (tagged with a unique SQL
+ * marker), which is the only one allowed to fire — this keeps the test
+ * independent of the real builtin rules' thresholds/SQL.
+ */
+
+import type { AlertDecision } from './alert-state-store'
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// --- fake D1 (captures INSERTs from recordAlertEvent) -----------------------
+interface FakeRow {
+  id: string
+  event_time: string
+  host_id: number
+  host_label: string | null
+  rule: string
+  severity: string
+  prev_severity: string | null
+  decision_kind: string
+  delivered: number
+  error: string | null
+  value: number | null
+  channel: string | null
+}
+
+function makeFakeD1() {
+  const rows: FakeRow[] = []
+  return {
+    rows,
+    prepare(_sql: string) {
+      return {
+        bind(...args: unknown[]) {
+          return {
+            async run(): Promise<{ meta: { changes: number } }> {
+              const [
+                id,
+                eventTime,
+                hostId,
+                hostLabel,
+                rule,
+                severity,
+                prevSeverity,
+                decisionKind,
+                delivered,
+                error,
+                value,
+                channel,
+              ] = args as [
+                string,
+                string,
+                number,
+                string | null,
+                string,
+                string,
+                string | null,
+                string,
+                number,
+                string | null,
+                number | null,
+                string | null,
+              ]
+              rows.push({
+                id,
+                event_time: eventTime,
+                host_id: hostId,
+                host_label: hostLabel,
+                rule,
+                severity,
+                prev_severity: prevSeverity,
+                decision_kind: decisionKind,
+                delivered,
+                error,
+                value,
+                channel,
+              })
+              return { meta: { changes: 1 } }
+            },
+          }
+        },
+      }
+    },
+  }
+}
+
+let fakeDb: ReturnType<typeof makeFakeD1>
+
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({
+    getD1Database: () => fakeDb,
+  }),
+}))
+
+// --- synthetic rule + ClickHouse stubs --------------------------------------
+const TEST_RULE_MARKER = '__TEST_SWEEP_MARKER__'
+const TEST_RULE_ID = 'test-sweep-rule'
+
+let testValue = 50
+
+const mockFetchData = mock(async ({ query }: { query: string }) => {
+  if (query.includes(TEST_RULE_MARKER)) {
+    return { data: [{ test_value: testValue }], error: null }
+  }
+  // Every builtin rule + the system.tables probe: an empty/zero-ish row,
+  // which classifies as 'ok' for every real rule's (>= 1) thresholds.
+  return { data: [{}], error: null }
+})
+
+mock.module('@chm/clickhouse-client', () => ({
+  fetchData: mockFetchData,
+  getClickHouseConfigs: () => [
+    { id: 0, host: 'test-host', user: 'default', password: '' },
+  ],
+}))
+
+mock.module('@/lib/insights/generate-insights', () => ({
+  generateInsights: async () => [],
+}))
+
+const { alertStateStore } = await import('./alert-state-store')
+const { ruleRegistry } = await import('@/lib/alerting/rule-registry')
+const { buildAlertEventRecord, runHealthSweep } = await import('./server-sweep')
+
+ruleRegistry.register({
+  id: TEST_RULE_ID,
+  type: 'custom',
+  title: 'Test Sweep Rule',
+  description: 'Synthetic rule for server-sweep.test.ts',
+  sql: `SELECT 1 /* ${TEST_RULE_MARKER} */`,
+  valueKey: 'test_value',
+  defaults: { warning: 10, critical: 20 },
+})
+
+const ENV_KEYS = [
+  'HEALTH_ALERT_ENABLED',
+  'HEALTH_ALERT_WEBHOOK_URL',
+  'HEALTH_ALERT_MIN_SEVERITY',
+] as const
+const savedEnv: Record<string, string | undefined> = {}
+
+let fetchCalls: { status: number }[] = []
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) savedEnv[key] = process.env[key]
+  process.env.HEALTH_ALERT_ENABLED = 'true'
+  process.env.HEALTH_ALERT_WEBHOOK_URL =
+    'https://hooks.slack.com/services/T000/B000/XXXX'
+  process.env.HEALTH_ALERT_MIN_SEVERITY = 'warning'
+
+  alertStateStore.clear()
+  fakeDb = makeFakeD1()
+  testValue = 50
+  fetchCalls = []
+})
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key]
+    else process.env[key] = savedEnv[key]
+  }
+})
+
+// ---------------------------------------------------------------------------
+// buildAlertEventRecord — pure mapping
+// ---------------------------------------------------------------------------
+describe('buildAlertEventRecord', () => {
+  const decision = (over: Partial<AlertDecision>): AlertDecision => ({
+    notify: true,
+    kind: 'new',
+    severity: 'critical',
+    previousSeverity: 'ok',
+    ...over,
+  })
+
+  test('a brand-new alert (ok -> critical): severity=critical, prevSeverity=null', () => {
+    const record = buildAlertEventRecord({
+      hostId: 0,
+      hostLabel: 'prod-ch',
+      ruleId: 'disk-usage',
+      decision: decision({
+        kind: 'new',
+        severity: 'critical',
+        previousSeverity: 'ok',
+      }),
+      value: 97,
+      delivered: true,
+      channel: 'slack',
+      now: 1_700_000_000_000,
+    })
+
+    expect(record.severity).toBe('critical')
+    expect(record.prevSeverity).toBeNull()
+    expect(record.decisionKind).toBe('new')
+    expect(record.delivered).toBe(true)
+    expect(record.error).toBeNull()
+    expect(record.value).toBe(97)
+    expect(record.channel).toBe('slack')
+    expect(record.eventTime).toBe(new Date(1_700_000_000_000).toISOString())
+  })
+
+  test('escalation (warning -> critical): prevSeverity carries the prior firing severity', () => {
+    const record = buildAlertEventRecord({
+      hostId: 0,
+      hostLabel: 'prod-ch',
+      ruleId: 'disk-usage',
+      decision: decision({
+        kind: 'escalated',
+        severity: 'critical',
+        previousSeverity: 'warning',
+      }),
+      value: 99,
+      delivered: true,
+      channel: 'slack',
+    })
+
+    expect(record.severity).toBe('critical')
+    expect(record.prevSeverity).toBe('warning')
+    expect(record.decisionKind).toBe('escalated')
+  })
+
+  test('recovery: severity is "recovery" (not the decision\'s "ok"), prevSeverity is the resolved condition', () => {
+    const record = buildAlertEventRecord({
+      hostId: 0,
+      hostLabel: 'prod-ch',
+      ruleId: 'disk-usage',
+      decision: decision({
+        kind: 'recovery',
+        severity: 'ok',
+        previousSeverity: 'critical',
+      }),
+      value: 10,
+      delivered: true,
+      channel: 'slack',
+    })
+
+    expect(record.severity).toBe('recovery')
+    expect(record.prevSeverity).toBe('critical')
+    expect(record.decisionKind).toBe('recovery')
+  })
+
+  test('a failed delivery carries delivered=false and the error message', () => {
+    const record = buildAlertEventRecord({
+      hostId: 0,
+      hostLabel: 'prod-ch',
+      ruleId: 'disk-usage',
+      decision: decision({
+        kind: 'new',
+        severity: 'warning',
+        previousSeverity: 'ok',
+      }),
+      value: 12,
+      delivered: false,
+      error: 'Webhook returned status 500',
+      channel: 'slack',
+    })
+
+    expect(record.delivered).toBe(false)
+    expect(record.error).toBe('Webhook returned status 500')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// runHealthSweep — end-to-end hook wiring
+// ---------------------------------------------------------------------------
+describe('runHealthSweep — alert-history hook', () => {
+  test('a dispatched (delivered) alert produces exactly one alert_events row', async () => {
+    globalThis.fetch = mock(async () => {
+      fetchCalls.push({ status: 200 })
+      return new Response(null, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const summary = await runHealthSweep()
+
+    expect(summary.alertsDispatched).toBe(1)
+    expect(fakeDb.rows).toHaveLength(1)
+
+    const [row] = fakeDb.rows
+    expect(row.host_id).toBe(0)
+    expect(row.host_label).toBe('test-host')
+    expect(row.rule).toBe(TEST_RULE_ID)
+    expect(row.severity).toBe('critical')
+    expect(row.prev_severity).toBeNull()
+    expect(row.decision_kind).toBe('new')
+    expect(row.delivered).toBe(1)
+    expect(row.error).toBeNull()
+    expect(row.value).toBe(50)
+    // detectAdapter() correctly identifies the slack webhook URL.
+    expect(row.channel).toBe('slack')
+  })
+
+  test('a failed delivery still produces one row, with delivered=0 and the error message', async () => {
+    globalThis.fetch = mock(async () => {
+      fetchCalls.push({ status: 500 })
+      return new Response(null, { status: 500 })
+    }) as unknown as typeof fetch
+
+    const summary = await runHealthSweep()
+
+    // Delivery failed, so the sweep does not count it as dispatched (retries
+    // next sweep instead of being suppressed by the dedup cooldown).
+    expect(summary.alertsDispatched).toBe(0)
+    expect(fakeDb.rows).toHaveLength(1)
+
+    const [row] = fakeDb.rows
+    expect(row.delivered).toBe(0)
+    expect(row.error).toBe('Webhook returned status 500')
+    expect(row.decision_kind).toBe('new')
+  })
+
+  test('a D1 write failure during recordAlertEvent never throws into the sweep', async () => {
+    // Simulate the store's own D1 call throwing (e.g. table not migrated
+    // yet) — the sweep must still complete and still count the delivery.
+    fakeDb = {
+      rows: [],
+      prepare() {
+        throw new Error('boom: D1 unavailable')
+      },
+    } as unknown as ReturnType<typeof makeFakeD1>
+
+    globalThis.fetch = mock(
+      async () => new Response(null, { status: 200 })
+    ) as unknown as typeof fetch
+
+    const summary = await runHealthSweep()
+
+    expect(summary.alertsDispatched).toBe(1)
+  })
+})

--- a/apps/dashboard/src/lib/health/server-sweep.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.ts
@@ -3,7 +3,11 @@ import type {
   AlertRuleDef,
   AlertRuleSeverity,
 } from '@/lib/alerting/rule-registry'
+import type { AlertEventRecord } from './alert-history-store'
+import type { AlertDecision } from './alert-state-store'
 
+import { detectAdapter } from './adapters'
+import { recordAlertEvent } from './alert-history-store'
 import { alertStateStore, evaluateAlert } from './alert-state-store'
 import {
   getServerAlertConfig,
@@ -140,13 +144,20 @@ function shouldRunRule(
   return tables.has(rule.tableCheck)
 }
 
+/** Result of a webhook delivery attempt, incl. the error text for the audit log. */
+interface WebhookResult {
+  ok: boolean
+  /** Present only when `ok` is false — recorded in the alert-history store. */
+  error?: string
+}
+
 /**
  * POST an alert to the configured webhook using the EXACT payload shape the
  * `/api/v1/health/webhook` proxy forwards upstream (`{ text, content: text }`),
  * so Slack (`text`) and Discord (`content`) both render it. Server-side, no CORS
  * proxy needed — we post directly to the operator-configured webhook URL.
  */
-async function postWebhook(url: string, text: string): Promise<boolean> {
+async function postWebhook(url: string, text: string): Promise<WebhookResult> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), 10_000)
   try {
@@ -157,17 +168,66 @@ async function postWebhook(url: string, text: string): Promise<boolean> {
       signal: controller.signal,
     })
     if (!res.ok) {
-      error(
-        '[health-sweep] Webhook returned non-OK status',
-        new Error(`Status ${res.status}`)
-      )
+      const message = `Webhook returned status ${res.status}`
+      error('[health-sweep] Webhook returned non-OK status', new Error(message))
+      return { ok: false, error: message }
     }
-    return res.ok
+    return { ok: true }
   } catch (err) {
     error('[health-sweep] Webhook POST failed', err as Error)
-    return false
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    }
   } finally {
     clearTimeout(timeout)
+  }
+}
+
+/**
+ * Map a notify decision + dispatch outcome into the shape the alert-history
+ * store persists. Pure — no I/O — so the decision→record translation (the
+ * trickiest part: `recovery` carries its own severity distinct from the
+ * underlying `AlertRuleSeverity`, and a fresh `new` alert has no meaningful
+ * previous severity) is unit-testable without mocking D1 or the sweep.
+ */
+export function buildAlertEventRecord(params: {
+  hostId: number
+  hostLabel: string
+  ruleId: string
+  decision: AlertDecision
+  value: number | null
+  delivered: boolean
+  error?: string
+  channel: string
+  /** Injectable clock for tests. Defaults to `Date.now()`. */
+  now?: number
+}): AlertEventRecord {
+  const { decision } = params
+  // Recovery is its own severity for audit purposes — the decision's
+  // `severity` field is 'ok' (the condition classifies healthy again), which
+  // isn't a useful thing to show in a log of *alert* events.
+  const severity: AlertEventRecord['severity'] =
+    decision.kind === 'recovery'
+      ? 'recovery'
+      : (decision.severity as 'warning' | 'critical')
+  // 'ok' means "no prior firing condition" (e.g. a brand-new alert) — no
+  // previous severity worth recording.
+  const prevSeverity: AlertEventRecord['prevSeverity'] =
+    decision.previousSeverity === 'ok' ? null : decision.previousSeverity
+
+  return {
+    eventTime: new Date(params.now ?? Date.now()).toISOString(),
+    hostId: params.hostId,
+    hostLabel: params.hostLabel,
+    rule: params.ruleId,
+    severity,
+    prevSeverity,
+    decisionKind: decision.kind,
+    delivered: params.delivered,
+    error: params.error ?? null,
+    value: params.value,
+    channel: params.channel,
   }
 }
 
@@ -256,13 +316,39 @@ export async function runHealthSweep(): Promise<SweepSummary> {
               decision.kind === 'recovery'
                 ? `[RECOVERY] ${rule.title} — resolved (host ${name})`
                 : `[${effective.toUpperCase()}] ${rule.title} — ${label} (host ${name})`
-            const ok = await postWebhook(settings.webhookUrl, text)
-            if (ok) {
+            const result = await postWebhook(settings.webhookUrl, text)
+            if (result.ok) {
               // Persist "notified" only now — a failed delivery leaves no
               // record, so the next sweep retries instead of suppressing.
               commit()
               alertsDispatched++
               if (decision.kind === 'recovery') recoveries++
+            }
+
+            // Best-effort audit trail — recorded AFTER the commit/counters
+            // above (on both success and failure) so a slow or failing D1
+            // write can never delay or drop the alert that was just
+            // dispatched. recordAlertEvent already never throws; the
+            // try/catch here is defense-in-depth, mirroring the
+            // generateInsights call below.
+            try {
+              await recordAlertEvent(
+                buildAlertEventRecord({
+                  hostId: config.id,
+                  hostLabel: name,
+                  ruleId: rule.id,
+                  decision,
+                  value,
+                  delivered: result.ok,
+                  error: result.error,
+                  channel: detectAdapter(settings.webhookUrl).id,
+                })
+              )
+            } catch (err) {
+              debug(
+                `[health-sweep] alert-history record failed for host ${config.id} rule ${rule.id}`,
+                err instanceof Error ? err.message : String(err)
+              )
             }
           } else {
             // Non-notify decisions (dedup/de-escalation/recovery-cleared

--- a/apps/dashboard/src/routes/api/v1/health/history.test.ts
+++ b/apps/dashboard/src/routes/api/v1/health/history.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Route test for GET /api/v1/health/history.
+ *
+ * Mocks `@/lib/health/alert-history-store` directly (the store's own SQL /
+ * fail-open semantics are covered by `alert-history-store.test.ts`) so this
+ * file proves the ROUTE's contract: hostId/day/limit are parsed from the
+ * query string and forwarded to `queryAlertEvents`, invalid params 400
+ * instead of reaching the store, and the response shapes `{ success, events
+ * }`. Mirrors the `Route.options.server.handlers` extraction pattern used by
+ * `routes/api/v1/__tests__/actions.test.ts`.
+ */
+
+import type { AlertEventRecord } from '@/lib/health/alert-history-store'
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+const mockQueryAlertEvents = mock(async () => [] as AlertEventRecord[])
+
+mock.module('@/lib/health/alert-history-store', () => ({
+  queryAlertEvents: mockQueryAlertEvents,
+}))
+
+const { Route } = await import('./history')
+
+type GetHandler = (ctx: { request: Request }) => Promise<Response>
+
+/**
+ * Extracts the GET handler from a TanStack Start server route. See
+ * `actions.test.ts`'s `getPostHandler` for why the cast is needed —
+ * `Route.options.server.handlers` is a union TypeScript can't narrow further.
+ */
+function getGetHandler(route: { options: { server?: unknown } }): GetHandler {
+  const handlers = (route.options.server as { handlers?: { GET?: GetHandler } })
+    ?.handlers
+  const fn = handlers?.GET
+  if (!fn) throw new Error('Route has no GET handler')
+  return fn
+}
+
+const handler = getGetHandler(Route)
+
+function makeRequest(query: string): Request {
+  return new Request(`http://localhost/api/v1/health/history${query}`)
+}
+
+const sampleEvent = (
+  over: Partial<AlertEventRecord> = {}
+): AlertEventRecord => ({
+  id: 'evt-1',
+  eventTime: '2026-07-01T12:00:00.000Z',
+  hostId: 0,
+  hostLabel: 'prod-ch',
+  rule: 'disk-usage',
+  severity: 'critical',
+  prevSeverity: 'warning',
+  decisionKind: 'escalated',
+  delivered: true,
+  error: null,
+  value: 97.5,
+  channel: 'slack',
+  ...over,
+})
+
+beforeEach(() => {
+  mockQueryAlertEvents.mockClear()
+  mockQueryAlertEvents.mockImplementation(async () => [])
+})
+
+describe('GET /api/v1/health/history', () => {
+  test('with no query params, forwards an all-undefined filter and returns events', async () => {
+    mockQueryAlertEvents.mockImplementation(async () => [sampleEvent()])
+
+    const response = await handler({ request: makeRequest('') })
+    expect(response.status).toBe(200)
+
+    const body = (await response.json()) as {
+      success: boolean
+      events: AlertEventRecord[]
+    }
+    expect(body.success).toBe(true)
+    expect(body.events).toEqual([sampleEvent()])
+    expect(mockQueryAlertEvents).toHaveBeenCalledWith({
+      hostId: undefined,
+      day: undefined,
+      limit: undefined,
+    })
+  })
+
+  test('parses hostId, day, and limit and forwards them to the store', async () => {
+    const response = await handler({
+      request: makeRequest('?hostId=2&day=2026-07-01&limit=25'),
+    })
+    expect(response.status).toBe(200)
+    expect(mockQueryAlertEvents).toHaveBeenCalledWith({
+      hostId: 2,
+      day: '2026-07-01',
+      limit: 25,
+    })
+  })
+
+  test('rejects a non-integer hostId with 400 without querying the store', async () => {
+    const response = await handler({ request: makeRequest('?hostId=abc') })
+    expect(response.status).toBe(400)
+    expect(mockQueryAlertEvents).not.toHaveBeenCalled()
+  })
+
+  test('rejects a negative hostId with 400', async () => {
+    const response = await handler({ request: makeRequest('?hostId=-1') })
+    expect(response.status).toBe(400)
+    expect(mockQueryAlertEvents).not.toHaveBeenCalled()
+  })
+
+  test('rejects a malformed day with 400 without querying the store', async () => {
+    const response = await handler({ request: makeRequest('?day=07-01-2026') })
+    expect(response.status).toBe(400)
+    expect(mockQueryAlertEvents).not.toHaveBeenCalled()
+  })
+
+  test('rejects a non-positive limit with 400', async () => {
+    const response = await handler({ request: makeRequest('?limit=0') })
+    expect(response.status).toBe(400)
+    expect(mockQueryAlertEvents).not.toHaveBeenCalled()
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/health/history.ts
+++ b/apps/dashboard/src/routes/api/v1/health/history.ts
@@ -1,0 +1,100 @@
+/**
+ * Alert history (audit log) endpoint
+ * GET /api/v1/health/history?hostId=0&day=2026-07-01&limit=50
+ *
+ * Returns recent rows from the `alert_events` D1 table — one row per attempted
+ * webhook delivery from the health sweep's notify decision (see
+ * `lib/health/server-sweep.ts` + `lib/health/alert-history-store.ts`). All
+ * query params are optional: omitting `hostId` returns events across every
+ * host, omitting `day` returns the most recent events regardless of date.
+ *
+ * Auth is centralized in middleware (#1397), same as the sibling
+ * /api/v1/health/* routes (checks.ts, snapshot.ts) — this handler only
+ * validates input and shapes the response. No per-row owner/tenant scoping:
+ * `host_id` indexes the operator's env-configured hosts only (the sweep never
+ * touches per-user D1 connections), so every caller allowed to reach this
+ * route already sees the same host set as the other health routes.
+ *
+ * The underlying store is best-effort — it degrades to `[]` rather than
+ * throwing when D1 isn't configured (self-hosted/OSS default), so this route
+ * always returns 200 with an (possibly empty) events array rather than a 5xx.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { queryAlertEvents } from '@/lib/health/alert-history-store'
+
+/** `YYYY-MM-DD` — matches the store's date-prefix filter contract exactly. */
+const DAY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+export const Route = createFileRoute('/api/v1/health/history')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const { searchParams } = new URL(request.url)
+
+        let hostId: number | undefined
+        const hostIdParam = searchParams.get('hostId')
+        if (hostIdParam !== null && hostIdParam !== '') {
+          const parsed = Number(hostIdParam)
+          if (!Number.isInteger(parsed) || parsed < 0) {
+            return Response.json(
+              {
+                success: false,
+                error: { type: 'validation', message: 'Invalid hostId' },
+              },
+              { status: 400 }
+            )
+          }
+          hostId = parsed
+        }
+
+        let day: string | undefined
+        const dayParam = searchParams.get('day')
+        if (dayParam !== null && dayParam !== '') {
+          if (!DAY_PATTERN.test(dayParam)) {
+            return Response.json(
+              {
+                success: false,
+                error: {
+                  type: 'validation',
+                  message: 'Invalid day: expected YYYY-MM-DD',
+                },
+              },
+              { status: 400 }
+            )
+          }
+          day = dayParam
+        }
+
+        let limit: number | undefined
+        const limitParam = searchParams.get('limit')
+        if (limitParam !== null && limitParam !== '') {
+          const parsed = Number(limitParam)
+          if (!Number.isInteger(parsed) || parsed <= 0) {
+            return Response.json(
+              {
+                success: false,
+                error: { type: 'validation', message: 'Invalid limit' },
+              },
+              { status: 400 }
+            )
+          }
+          limit = parsed
+        }
+
+        const events = await queryAlertEvents({ hostId, day, limit })
+
+        return Response.json(
+          { success: true, events },
+          {
+            status: 200,
+            headers: {
+              'Cache-Control': 'public, s-maxage=5, stale-while-revalidate=15',
+            },
+          }
+        )
+      },
+    },
+  },
+})


### PR DESCRIPTION
## What (plan 27 — alert history / audit log)

D1-backed `alert_events` audit log fed by the health sweep's **post-delivery** hook, a filtered read API, and a "Recent alerts" history tab in the settings dialog. Foundational for alerting plans 28–34.

- `db/conversations-migrations/0010_alert_events.sql` (new), `lib/health/alert-history-store.ts` (+ test), `routes/api/v1/health/history.ts` (+ test), `components/health/{use-alert-history,recent-alerts-card}.ts(x)`, "History" tab in `health-settings-dialog.tsx`.
- `server-sweep.ts`: `postWebhook` now returns `{ok, error?}`; the event is recorded **after** `commit()` so a D1 write can never delay or drop the outbound alert (fail-open, follows `insights/baseline-store.ts`).
- **22 new tests**; `bun test src/lib/health src/routes/api/v1/health src/lib/alerting src/components/health` → 275 pass, 0 fail. `bun run check` / `depcruise` clean.

## 🔶 Held for review — two reasons

1. **Alert-send path change.** It modifies `server-sweep.ts` (the delivery path). The recording is fail-open and post-delivery, but the critical path warrants a human read.
2. **Migration number collision.** This adds `0010_alert_events.sql`; held #2224 (plan 56) adds `0010_dashboards.sql`. Whichever merges second must be **renumbered** (→ `0011_…`). Not on `main` yet, so no conflict today, but must be resolved at merge time.

Auth note: the history route matches sibling `checks.ts`/`snapshot.ts` (global middleware); `getClickHouseConfigs()` only reads env `CLICKHOUSE_*`, so `host_id` has no per-tenant concept to leak (documented inline).

Co-Authored-By: duyetbot <bot@duyet.net>