### PR TITLE
feat(landing): SEO use-case landing pages (plan 64)

### DIFF
--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -1,3 +1,6 @@
+---
+import { useCases } from '../data/use-cases'
+---
   <footer>
     <div class="wrap">
       <div class="foot">
@@ -19,6 +22,12 @@
             <a href="https://dash.chmonitor.dev" target="_blank" rel="noopener">Dashboard</a>
             <a href="https://blog.chmonitor.dev" target="_blank" rel="noopener">Blog</a>
             <a href="/changelog">Changelog</a>
+          </div>
+          <div class="foot-col">
+            <h5>Use cases</h5>
+            {useCases.map((u) => (
+              <a href={`/${u.slug}`}>{u.eyebrow}</a>
+            ))}
           </div>
           <div class="foot-col">
             <h5>Open source</h5>

--- a/apps/landing/src/components/UseCaseLinks.astro
+++ b/apps/landing/src/components/UseCaseLinks.astro
@@ -1,0 +1,32 @@
+---
+// Shared cross-link cards for use-case pages — used both by LandingPage.astro
+// ("Related" — the other use cases) and index.astro ("Explore by use case" —
+// all four), so the two surfaces can never drift out of sync.
+import type { UseCase } from '../data/use-cases'
+
+interface Props {
+  items: UseCase[]
+  eyebrow: string
+  heading: string
+  soft?: boolean
+}
+
+const { items, eyebrow, heading, soft = false } = Astro.props
+---
+<section class={soft ? 'band band-soft' : 'band'}>
+  <div class="wrap">
+    <div class="sec-head reveal" style="text-align:center">
+      <span class="eyebrow">{eyebrow}</span>
+      <h2>{heading}</h2>
+    </div>
+    <div class="cap-grid">
+      {items.map((item) => (
+        <a class="cap reveal" href={`/${item.slug}`} data-cta={`usecase-link-${item.slug}`}>
+          <span class="cap-ico" set:html={`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">${item.benefits[0]?.icon ?? ''}</svg>`} />
+          <h4>{item.eyebrow}</h4>
+          <p>{item.cardBlurb}</p>
+        </a>
+      ))}
+    </div>
+  </div>
+</section>

--- a/apps/landing/src/data/use-cases.test.ts
+++ b/apps/landing/src/data/use-cases.test.ts
@@ -1,0 +1,64 @@
+import { useCases } from './use-cases'
+import { describe, expect, test } from 'bun:test'
+
+// Roadmap/unwired channel and feature names that must never appear as a
+// shipped-feature claim on a use-case page. See use-cases.ts's top comment
+// for the audit trail (Telegram/PagerDuty adapters exist as pure formatters
+// but are not consumed by the health-sweep dispatch — genuinely unwired).
+const DENYLIST = ['telegram', 'pagerduty', 'pager duty', 'opsgenie', 'email']
+
+// Structured copy fields to scan — NOT the raw source file text, which
+// legitimately mentions denylisted names in comments/docs.
+function copyFields(): string[] {
+  return useCases.flatMap((u) => [
+    u.title,
+    u.description,
+    u.eyebrow,
+    u.h1,
+    u.cardBlurb,
+    u.subhead,
+    u.heroImageAlt,
+    ...u.benefits.flatMap((b) => [b.title, b.body]),
+    ...u.featureList,
+  ])
+}
+
+describe('useCases content invariants', () => {
+  test('has at least 4 use cases (plan 64 done criteria)', () => {
+    expect(useCases.length).toBeGreaterThanOrEqual(4)
+  })
+
+  test('slugs are unique', () => {
+    const slugs = useCases.map((u) => u.slug)
+    expect(new Set(slugs).size).toBe(slugs.length)
+  })
+
+  test('titles are unique', () => {
+    const titles = useCases.map((u) => u.title)
+    expect(new Set(titles).size).toBe(titles.length)
+  })
+
+  test('descriptions are unique', () => {
+    const descriptions = useCases.map((u) => u.description)
+    expect(new Set(descriptions).size).toBe(descriptions.length)
+  })
+
+  test('h1s are unique', () => {
+    const h1s = useCases.map((u) => u.h1)
+    expect(new Set(h1s).size).toBe(h1s.length)
+  })
+
+  test('never names an unwired channel or roadmap feature', () => {
+    const haystack = copyFields().join('\n').toLowerCase()
+    for (const term of DENYLIST) {
+      expect(haystack).not.toContain(term)
+    }
+  })
+
+  test('every use case has at least one benefit and one feature-list entry', () => {
+    for (const u of useCases) {
+      expect(u.benefits.length).toBeGreaterThan(0)
+      expect(u.featureList.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/apps/landing/src/data/use-cases.ts
+++ b/apps/landing/src/data/use-cases.ts
@@ -1,0 +1,221 @@
+/**
+ * Use-case landing page content — the single source of truth for the four
+ * SEO landing pages (see plans/64-seo-use-case-landing-pages.md).
+ *
+ * Every claim here must map to a real, shipped chmonitor capability: this
+ * file IS the honesty-audit surface for those pages. `use-cases.test.ts`
+ * enforces the shape (unique slug/title/h1/description) and a denylist of
+ * roadmap-only feature names (PagerDuty, Telegram, OpsGenie, email alerts,
+ * DDL auto-apply) that are not wired to any UI today — see the alerting
+ * adapters audit trail in that file's comments.
+ */
+
+export interface UseCaseBenefit {
+  /** Inner SVG markup (paths/shapes only), viewBox 0 0 24 24, stroke style. */
+  icon: string
+  title: string
+  body: string
+}
+
+export interface UseCase {
+  /** Route slug — the page lives at /<slug>. */
+  slug: string
+  /** <title> tag — must stay unique across all use cases + existing pages. */
+  title: string
+  /** <meta description> — must stay unique across all use cases. */
+  description: string
+  /** Short label — page eyebrow, footer link, breadcrumb schema name. */
+  eyebrow: string
+  /** Page <h1> — must stay unique across all use cases. */
+  h1: string
+  /** One-line summary for compact cross-link cards (footer/homepage/related). */
+  cardBlurb: string
+  subhead: string
+  heroImage: string
+  heroImageAlt: string
+  /** Actual intrinsic pixel size of `heroImage` — reserves layout space (no CLS). */
+  heroImageWidth: number
+  heroImageHeight: number
+  benefits: UseCaseBenefit[]
+  /** SoftwareApplication JSON-LD featureList for this page. */
+  featureList: string[]
+}
+
+const SPARKLE_ICON =
+  '<path d="M12 2 13.5 9.5 21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5z"/>'
+const HEALTH_ICON =
+  '<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>'
+const TOPOLOGY_ICON =
+  '<rect x="3" y="3" width="6" height="6" rx="1.5"/><rect x="15" y="3" width="6" height="6" rx="1.5"/><rect x="9" y="15" width="6" height="6" rx="1.5"/><path d="M6 9v2a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V9"/><path d="M12 13v2"/>'
+const QUERY_GRID_ICON =
+  '<rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/>'
+const STOP_ICON = '<circle cx="12" cy="12" r="9"/><path d="m8 8 8 8"/>'
+const BELL_ICON =
+  '<path d="M6 8a6 6 0 1 1 12 0c0 4 1.5 6 2 6.5H4c.5-.5 2-2.5 2-6.5"/><path d="M9.5 18.5a2.5 2.5 0 0 0 5 0"/>'
+const ACTIVITY_ICON = '<path d="M3 12h4l3-8 4 16 3-8h4"/>'
+const QUEUE_ICON =
+  '<rect x="4" y="5" width="16" height="4" rx="1"/><rect x="4" y="11" width="16" height="4" rx="1"/><rect x="4" y="17" width="10" height="4" rx="1"/>'
+const BARS_ICON =
+  '<path d="M4 20V10"/><path d="M10 20V4"/><path d="M16 20v-7"/><path d="M22 20v-3"/>'
+const CAPACITY_ICON =
+  '<ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.7 3.6 3 8 3s8-1.3 8-3V5"/><path d="M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3"/>'
+
+export const useCases: UseCase[] = [
+  {
+    slug: 'monitor-queries',
+    title:
+      'chmonitor Query Monitoring — Live, Slow & Expensive ClickHouse Queries',
+    description:
+      'Monitor ClickHouse queries in real time: running, slow, failed and most expensive, with duration, memory and rows read. Kill runaway queries and review recommend-only EXPLAIN suggestions.',
+    eyebrow: 'Query monitoring',
+    h1: 'Monitor ClickHouse queries in real time',
+    cardBlurb:
+      'Running, slow, failed and expensive queries — with kill and recommend-only EXPLAIN suggestions.',
+    subhead:
+      "See every running, slow, failed and expensive query as it happens, with duration, memory and rows read, then act: kill a runaway query or review a recommend-only EXPLAIN suggestion for the one that's actually slow.",
+    heroImage: '/landing-assets/queries-running.png',
+    heroImageAlt:
+      'chmonitor running queries view with live charts and a detailed table',
+    heroImageWidth: 1024,
+    heroImageHeight: 570,
+    benefits: [
+      {
+        icon: QUERY_GRID_ICON,
+        title: 'Every query, live',
+        body: 'Running, history, failed, slowest and most expensive queries, each with duration, memory, rows read and the full statement. Filter by user and slice by time.',
+      },
+      {
+        icon: STOP_ICON,
+        title: 'Kill it from the table',
+        body: 'Stop a long-running or runaway query directly from the row — no separate SQL client or hand-written KILL QUERY needed.',
+      },
+      {
+        icon: SPARKLE_ICON,
+        title: 'Recommend-only EXPLAIN suggestions',
+        body: 'Run EXPLAIN and get heuristic suggestions — missing PREWHERE, unpruned partitions, unkeyed joins, missing index hints. chmonitor never rewrites or applies anything; you review and apply the fix.',
+      },
+    ],
+    featureList: [
+      'Live running query monitoring',
+      'Query history, slow, failed and most-expensive query views',
+      'Kill running queries from the table',
+      'Recommend-only EXPLAIN tuning suggestions',
+    ],
+  },
+  {
+    slug: 'cluster-health',
+    title: 'chmonitor Cluster Health — ClickHouse Health Checks & Alerts',
+    description:
+      'ClickHouse cluster health monitoring: replication lag, failed queries, disk, memory and stuck mutations on one board, with alerts to Slack or Discord when a check crosses your threshold.',
+    eyebrow: 'Cluster health',
+    h1: 'ClickHouse cluster health monitoring, at a glance',
+    cardBlurb:
+      'A color-coded health board with Slack/Discord alerts and recovery notifications.',
+    subhead:
+      'One board of color-coded health checks — replication lag, failed queries, disk, memory, stuck mutations — with alerts to Slack or Discord when something turns red, and again when it recovers.',
+    heroImage: '/landing-assets/health-summary.png',
+    heroImageAlt: 'chmonitor cluster health summary board',
+    heroImageWidth: 1024,
+    heroImageHeight: 564,
+    benefits: [
+      {
+        icon: HEALTH_ICON,
+        title: 'Every health signal in one board',
+        body: 'Green, warn or critical indicators for replication lag, readonly replicas, delayed inserts, failed queries, memory, disk, parts-per-partition and stuck mutations.',
+      },
+      {
+        icon: BELL_ICON,
+        title: 'Alerts to Slack or Discord',
+        body: 'Configure one webhook URL and chmonitor posts a message when a check crosses your threshold — and again when it recovers, so you know an incident actually cleared.',
+      },
+      {
+        icon: SPARKLE_ICON,
+        title: 'A ready audit prompt for your agent',
+        body: 'Turn any failing check into a structured prompt — the metric, raw data, relevant system tables and common causes — to paste into an AI agent for a tailored diagnosis.',
+      },
+    ],
+    featureList: [
+      'Color-coded cluster health board',
+      'Slack/Discord-compatible webhook alerts with recovery notifications',
+      'One-click audit prompt for AI agents',
+    ],
+  },
+  {
+    slug: 'replication',
+    title: 'chmonitor Replication Monitor — ClickHouse Replica Lag & Topology',
+    description:
+      'Monitor ClickHouse replication lag, read-only replicas and the replication queue across every shard, visualized on a live cluster topology map, with alerts when replication falls behind.',
+    eyebrow: 'Replication',
+    h1: 'Monitor ClickHouse replication lag and read-only replicas',
+    cardBlurb:
+      'Replica lag, read-only replicas and replication queues, on a live topology map.',
+    subhead:
+      'Track replica lag, read-only replicas, the replication queue and distributed DDL across every shard — visualized on a live cluster topology map, with alerts when replication falls behind.',
+    heroImage: '/landing-assets/topology.png',
+    heroImageAlt:
+      'chmonitor cluster topology: ClickHouse nodes, shards, replicas and the Keeper quorum with live replication links',
+    heroImageWidth: 1024,
+    heroImageHeight: 564,
+    benefits: [
+      {
+        icon: TOPOLOGY_ICON,
+        title: 'See the whole topology',
+        body: 'Nodes, shards, replicas and the Keeper quorum on one interactive map, with live replication and coordination links.',
+      },
+      {
+        icon: ACTIVITY_ICON,
+        title: 'Replication lag and read-only replicas',
+        body: 'Health checks flag lag and read-only replicas before they become an outage, with an optional alert to Slack or Discord when a replica falls behind your threshold.',
+      },
+      {
+        icon: QUEUE_ICON,
+        title: 'Replication & DDL queues',
+        body: 'Inspect the replication queue, replicated fetches and the distributed DDL queue to see exactly what is in flight or stuck on each replica.',
+      },
+    ],
+    featureList: [
+      'Cluster topology map with replicas and Keeper quorum',
+      'Replication lag and read-only replica health checks',
+      'Replication queue, replicated fetches and distributed DDL queue views',
+    ],
+  },
+  {
+    slug: 'performance',
+    title: 'chmonitor Performance — ClickHouse Query Tuning & Capacity Advisor',
+    description:
+      'Find the ClickHouse queries actually costing you time and memory, then get recommend-only tuning suggestions from EXPLAIN and a capacity/TTL advisor. Nothing is applied automatically.',
+    eyebrow: 'Performance',
+    h1: 'ClickHouse performance tuning, backed by real query data',
+    cardBlurb:
+      'Slowest/most-expensive queries plus a recommend-only tuning and capacity advisor.',
+    subhead:
+      'Find the queries actually costing you time and memory, then get recommend-only tuning suggestions from EXPLAIN and a capacity/TTL advisor — chmonitor never rewrites schema or executes DDL for you.',
+    heroImage: '/landing-assets/g-explain.png',
+    heroImageAlt:
+      'chmonitor EXPLAIN view with recommend-only tuning suggestions',
+    heroImageWidth: 1024,
+    heroImageHeight: 613,
+    benefits: [
+      {
+        icon: BARS_ICON,
+        title: 'Slowest and most expensive queries',
+        body: 'Ranked by duration, memory and rows read, so you know exactly where tuning effort will actually pay off.',
+      },
+      {
+        icon: SPARKLE_ICON,
+        title: 'EXPLAIN-based suggestions, recommend-only',
+        body: 'Missing PREWHERE, unpruned partitions, unkeyed joins and missing index hints, surfaced as suggestions you review and apply yourself.',
+      },
+      {
+        icon: CAPACITY_ICON,
+        title: 'Capacity & TTL advisor',
+        body: 'Ask the built-in AI agent to forecast disk-full dates from write growth and suggest a TTL change to stay under budget. It returns a suggested ALTER TABLE ... MODIFY TTL statement — it never runs one.',
+      },
+    ],
+    featureList: [
+      'Slowest and most-expensive query views',
+      'Recommend-only EXPLAIN tuning suggestions',
+      'AI-agent capacity and TTL advisor (suggests, never executes DDL)',
+    ],
+  },
+]

--- a/apps/landing/src/layouts/LandingPage.astro
+++ b/apps/landing/src/layouts/LandingPage.astro
@@ -1,0 +1,141 @@
+---
+// Shared layout for the SEO use-case pages (see
+// plans/64-seo-use-case-landing-pages.md): a page-specific hero (eyebrow/h1/
+// subhead/CTA + a real product screenshot), a benefits grid, social proof,
+// cross-links to the other use cases, and the standard closing CTA + footer.
+// Base.astro owns <head>/meta (title/description/canonical/OG/site-wide
+// Organization+SoftwareApplication schema) — this layout adds a page-specific
+// BreadcrumbList + a distinct per-page SoftwareApplication entity on top.
+import type { UseCase } from '../data/use-cases'
+
+import Base from './Base.astro'
+import Nav from '../components/Nav.astro'
+import Footer from '../components/Footer.astro'
+import FinalCta from '../components/FinalCta.astro'
+import SocialProof from '../components/SocialProof.astro'
+import UseCaseLinks from '../components/UseCaseLinks.astro'
+import { useCases } from '../data/use-cases'
+
+interface Props {
+  useCase: UseCase
+  ctaLabel?: string
+  ctaHref?: string
+}
+
+const {
+  useCase,
+  ctaLabel = 'Open dashboard',
+  ctaHref = 'https://dash.chmonitor.dev',
+} = Astro.props
+
+const {
+  slug,
+  title,
+  description,
+  eyebrow,
+  h1,
+  subhead,
+  heroImage,
+  heroImageAlt,
+  heroImageWidth,
+  heroImageHeight,
+  benefits,
+  featureList,
+} = useCase
+
+// The other three use cases, for the "Related" cross-link band.
+const related = useCases.filter((u) => u.slug !== slug)
+
+const canonical = new URL(Astro.url.pathname, Astro.site).toString()
+
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: new URL('/', Astro.site).toString() },
+    { '@type': 'ListItem', position: 2, name: eyebrow, item: canonical },
+  ],
+}
+
+// A distinct SoftwareApplication entity per page (own @id/name/description/
+// featureList) — not a duplicate of Base's site-wide entity. No aggregateRating
+// or review: chmonitor collects neither today, so both would be fabricated.
+const softwareJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  '@id': `${canonical}#software`,
+  name: `chmonitor — ${h1}`,
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'Linux, macOS, Windows',
+  license: 'https://github.com/chmonitor/chmonitor/blob/main/LICENSE',
+  url: canonical,
+  description,
+  featureList,
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+}
+---
+<Base title={title} description={description}>
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} is:inline />
+  <script type="application/ld+json" set:html={JSON.stringify(softwareJsonLd)} is:inline />
+  <Nav />
+  <main id="top">
+    <section class="band" style="padding-bottom:40px">
+      <div class="wrap">
+        <div class="feature" style="align-items:center">
+          <div class="reveal">
+            <div class="sec-head uc-head">
+              <span class="eyebrow">{eyebrow}</span>
+              <h1>{h1}</h1>
+              <p>{subhead}</p>
+            </div>
+            <div class="hero-actions" style="justify-content:flex-start;margin-top:6px">
+              <a class="btn btn-primary" href={ctaHref} target="_blank" rel="noopener" data-cta={`usecase-${slug}-primary`}>
+                {ctaLabel}
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+              </a>
+              <a class="btn btn-ghost" href="https://docs.chmonitor.dev" target="_blank" rel="noopener">
+                Docs
+              </a>
+            </div>
+          </div>
+          <div class="feat-shot reveal">
+            <div class="browser-bar"><span class="lights"><i></i><i></i><i></i></span></div>
+            <img src={heroImage} alt={heroImageAlt} width={heroImageWidth} height={heroImageHeight} loading="eager" decoding="async" />
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="band band-soft">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">What you get</span>
+          <h2>Built for this, not bolted on</h2>
+        </div>
+        <div class="cap-grid">
+          {benefits.map((b) => (
+            <div class="cap reveal">
+              <span class="cap-ico" set:html={`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">${b.icon}</svg>`} />
+              <h4>{b.title}</h4>
+              <p>{b.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <SocialProof />
+
+    <UseCaseLinks items={related} eyebrow="Related" heading="More ways to monitor ClickHouse" />
+
+    <FinalCta />
+  </main>
+  <Footer />
+
+  <style>
+    /* Promoted page title: match the global .sec-head h2 type scale, same
+       convention as pricing.astro / changelog.astro. */
+    .uc-head h1{font-size:clamp(28px,3.6vw,42px);line-height:1.1;letter-spacing:-.025em;font-weight:700;margin-top:14px;text-wrap:balance}
+    .uc-head p{margin-top:14px}
+  </style>
+</Base>

--- a/apps/landing/src/pages/cluster-health.astro
+++ b/apps/landing/src/pages/cluster-health.astro
@@ -1,0 +1,9 @@
+---
+// SEO use-case page — content lives in src/data/use-cases.ts (plans/64).
+import LandingPage from '../layouts/LandingPage.astro'
+import { useCases } from '../data/use-cases'
+
+const useCase = useCases.find((u) => u.slug === 'cluster-health')
+if (!useCase) throw new Error('use-cases.ts: missing "cluster-health" entry')
+---
+<LandingPage useCase={useCase} />

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -12,6 +12,8 @@ import Pricing from '../components/Pricing.astro'
 import FAQ from '../components/FAQ.astro'
 import FinalCta from '../components/FinalCta.astro'
 import Footer from '../components/Footer.astro'
+import UseCaseLinks from '../components/UseCaseLinks.astro'
+import { useCases } from '../data/use-cases'
 ---
 <Base>
   <Nav />
@@ -21,6 +23,7 @@ import Footer from '../components/Footer.astro'
     <DataExplorer />
     <Health />
     <Capabilities />
+    <UseCaseLinks items={useCases} eyebrow="Use cases" heading="Explore by use case" soft />
     <SocialProof />
     <Comparison />
     <Pricing />

--- a/apps/landing/src/pages/monitor-queries.astro
+++ b/apps/landing/src/pages/monitor-queries.astro
@@ -1,0 +1,9 @@
+---
+// SEO use-case page — content lives in src/data/use-cases.ts (plans/64).
+import LandingPage from '../layouts/LandingPage.astro'
+import { useCases } from '../data/use-cases'
+
+const useCase = useCases.find((u) => u.slug === 'monitor-queries')
+if (!useCase) throw new Error('use-cases.ts: missing "monitor-queries" entry')
+---
+<LandingPage useCase={useCase} />

--- a/apps/landing/src/pages/performance.astro
+++ b/apps/landing/src/pages/performance.astro
@@ -1,0 +1,9 @@
+---
+// SEO use-case page — content lives in src/data/use-cases.ts (plans/64).
+import LandingPage from '../layouts/LandingPage.astro'
+import { useCases } from '../data/use-cases'
+
+const useCase = useCases.find((u) => u.slug === 'performance')
+if (!useCase) throw new Error('use-cases.ts: missing "performance" entry')
+---
+<LandingPage useCase={useCase} />

--- a/apps/landing/src/pages/replication.astro
+++ b/apps/landing/src/pages/replication.astro
@@ -1,0 +1,9 @@
+---
+// SEO use-case page — content lives in src/data/use-cases.ts (plans/64).
+import LandingPage from '../layouts/LandingPage.astro'
+import { useCases } from '../data/use-cases'
+
+const useCase = useCases.find((u) => u.slug === 'replication')
+if (!useCase) throw new Error('use-cases.ts: missing "replication" entry')
+---
+<LandingPage useCase={useCase} />


### PR DESCRIPTION
Plan 64: four SEO use-case landing pages, honesty-audited against shipped/enforced features (per plans/README.md guidance).

- `use-cases.ts` — content for `/monitor-queries`, `/cluster-health`, `/replication`, `/performance`; every claim traced to shipped code (kill query, EXPLAIN heuristic suggestions recommend-only, health board + Slack/Discord alerts, cluster topology, replication queue/DDL queue, capacity/TTL advisor recommend-only). Telegram/PagerDuty/OpsGenie/email cut — verified as unwired dead code (pure formatters not consumed by the health-sweep dispatch, which only posts a Slack/Discord-shaped `{text, content}` payload).
- Shared `LandingPage.astro` layout — hero, benefits grid, social proof, related cross-links, `BreadcrumbList` + per-page `SoftwareApplication` JSON-LD.
- `UseCaseLinks.astro` — shared cross-link cards, used on each use-case page ("Related") and the homepage ("Explore by use case").
- Four page files (`src/pages/{monitor-queries,cluster-health,replication,performance}.astro`) — thin wrappers over the layout.
- Internal links: Footer "Use cases" column + homepage cross-link section.
- `use-cases.test.ts` — content invariants (unique slug/title/description/H1, denylist of unwired channel/feature names scanned over structured copy fields only).

Verified: `bun run build` in `apps/landing` emits all 4 pages with unique `<title>`/`<h1>`, all appear in the generated sitemap; `bun test` and `bun run lint` green.

Co-Authored-By: duyetbot <bot@duyet.net>