### PR TITLE
feat(landing): hero wedge refresh — advisor + real-time alerts (plan 60)

### DIFF
--- a/apps/landing/src/components/FinalCta.astro
+++ b/apps/landing/src/components/FinalCta.astro
@@ -10,8 +10,8 @@ import HeroHalftone from './HeroHalftone.tsx'
         <span class="mark mark-lg" aria-hidden="true" style="margin:0 auto 22px">
           <img src="/brand/logo-mark.svg" alt="chmonitor" />
         </span>
-        <h2>Start monitoring in minutes</h2>
-        <p>Open the hosted dashboard and connect a cluster, or grab the source and run it yourself. Self-hosting is always free.</p>
+        <h2>Start monitoring — with an <span class="wedge">advisor</span> and <span class="wedge">alerts</span> built in</h2>
+        <p>Open the hosted dashboard and connect a cluster, or self-host with Docker, Kubernetes, or from source. Self-hosting is always free.</p>
         <div class="hero-actions">
           <a class="btn btn-primary" href="https://dash.chmonitor.dev" target="_blank" rel="noopener" data-cta="final-primary">
             Open dashboard
@@ -52,6 +52,9 @@ import HeroHalftone from './HeroHalftone.tsx'
   /* Dark card ⇒ light copy. */
   .fcta .cta :global(h2) { color: #fff; text-shadow: 0 2px 40px rgba(0,0,0,.4); }
   .fcta .cta :global(p) { color: rgba(230,232,238,.9); }
+  /* Brand accent on the advisor/alerts wedge, same fixed orange as the hero
+     (stays orange in both themes — see Hero.astro .ch-hl/.accent). */
+  .fcta .cta :global(h2 .wedge) { color: #f97316; }
   .fcta-ghost {
     background: rgba(18,18,24,.55); color: #fff;
     border: 1px solid rgba(255,255,255,.2); backdrop-filter: blur(10px);

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -8,12 +8,14 @@ import { formatCount, getGitHubStats } from '../lib/github-stars'
 const { stars } = await getGitHubStats()
 const starLabel = formatCount(stars)
 
+// Leads with the advisor/agent + alerts + topology + insights wedge (plan 60);
+// the rest keep their prior relative order.
 const galleryCards = [
-  { tab: 'Overview', src: '/landing-assets/hero-overview.png', alt: 'chmonitor cluster overview' },
-  { tab: 'Cluster Topology', src: '/landing-assets/hero-topology.png', alt: 'chmonitor cluster topology' },
-  { tab: 'Health Summary', src: '/landing-assets/hero-health.png', alt: 'chmonitor health summary' },
   { tab: 'AI Agent', src: '/landing-assets/hero-agent.png', alt: 'chmonitor AI agent' },
+  { tab: 'Alerts', src: '/landing-assets/hero-health.png', alt: 'chmonitor health summary and alert thresholds' },
+  { tab: 'Cluster Topology', src: '/landing-assets/hero-topology.png', alt: 'chmonitor cluster topology' },
   { tab: 'Cluster Insights', src: '/landing-assets/g-insights.png', alt: 'chmonitor cluster insights' },
+  { tab: 'Overview', src: '/landing-assets/hero-overview.png', alt: 'chmonitor cluster overview' },
   { tab: 'Running Queries', src: '/landing-assets/g-running.png', alt: 'chmonitor running queries' },
   { tab: 'Explain Query', src: '/landing-assets/g-explain.png', alt: 'chmonitor explain query' },
   { tab: 'Most Expensive Queries', src: '/landing-assets/g-expensive.png', alt: 'chmonitor most expensive queries' },
@@ -34,17 +36,22 @@ const galleryCards = [
     <div class="ehero-content">
       <span class="ehero-eyebrow">Real-time ClickHouse observability</span>
       <h1 class="ehero-title">
-        <span class="l1">See every <span class="ch-hl">ClickHouse</span> query.</span><br /><span class="accent">As it runs.</span>
+        <span class="l1">The <span class="ch-hl">ClickHouse advisor</span>.</span><br /><span class="accent">Now with real-time alerts.</span>
       </h1>
       <p class="ehero-sub">
-        chmonitor turns your cluster's <strong>system tables</strong> into a fast, readable
-        dashboard — queries, merges, parts, replication and health, plus an AI agent that
-        answers questions about your data. <strong>Self-host it, or use the hosted dashboard.</strong>
+        chmonitor gives you live query, merge and replication visibility from your cluster's
+        <strong>system tables</strong>, an AI agent that recommends (never auto-applies) partition
+        keys, skip indexes, projections and PREWHERE rewrites, and threshold alerts to any webhook
+        or your Prometheus/Grafana stack. <strong>Self-host, Docker, K8s, or the hosted Cloud.</strong>
       </p>
       <div class="ehero-actions">
         <a class="btn btn-primary" href="https://dash.chmonitor.dev" target="_blank" rel="noopener" data-cta="hero-primary">
           Open dashboard
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+        </a>
+        <a class="btn btn-ghost ehero-ghost" href="https://docs.chmonitor.dev/guide/getting-started" target="_blank" rel="noopener" data-cta="hero-live-demo">
+          See a live demo
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16 10 8"/></svg>
         </a>
         <a class="btn btn-ghost ehero-ghost" href="https://docs.chmonitor.dev" target="_blank" rel="noopener">
           Quickstart

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -49,7 +49,7 @@ const galleryCards = [
           Open dashboard
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
         </a>
-        <a class="btn btn-ghost ehero-ghost" href="https://docs.chmonitor.dev/guide/getting-started" target="_blank" rel="noopener" data-cta="hero-live-demo">
+        <a class="btn btn-ghost ehero-ghost" href="https://dash.chmonitor.dev" target="_blank" rel="noopener" data-cta="hero-live-demo">
           See a live demo
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16 10 8"/></svg>
         </a>


### PR DESCRIPTION
## What (plan 60 — landing hero wedge)

Rewrites the hero to lead with the **advisor + real-time-alerts** wedge, reorders the gallery (AI Agent / Alerts / Topology / Insights first), adds a "See a live demo" CTA, and echoes the wedge in the final CTA. `Hero.astro` + `FinalCta.astro` only.

- **Landing build green** (5 pages); `bun run check` clean; 7 landing tests pass; plan 68's star badge preserved (no regression).

## Honesty audit (every claim → shipped evidence)

The agent verified each claim against the code and **softened** the plan's literal direction where the stronger claim wasn't shipped: "advisor" → the shipped `schema-design`/`query-tuning` agent skills (recommend-only); "real-time alerts" → `alert-dispatcher` + webhook route; monitoring/Prometheus/deployment matrix all shipped; "See a live demo" → verified the anonymous read-only demo is live (`/api/healthz` returned the demo host up). It did **not** name Slack/PagerDuty (adapters exist but have no dispatch caller).

Note: this branch was based a few commits behind current `main`, so the copy is conservative — it doesn't yet cite the newer merged advisor-engine/event-bus features (undersell, not oversell). A future pass can add them.

Co-Authored-By: duyetbot <bot@duyet.net>