### PR TITLE
fix(ci): bump unit-tests bun-version to 1.3.14 to fix coverage WriteFailed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,9 @@ jobs:
         with:
           # `bun test --isolate` (used by the test scripts to give each file a
           # fresh global, preventing cross-file mock.module leakage) needs a
-          # recent Bun.
-          bun-version: '1.3.13'
+          # recent Bun. 1.3.13's lcov coverage writer intermittently throws
+          # `WriteFailed` after all tests already passed; 1.3.14 fixes it.
+          bun-version: '1.3.14'
 
       - name: Bun Cache
         uses: actions/cache@v6


### PR DESCRIPTION
## Summary
Bun 1.3.13's lcov coverage writer intermittently throws `error: An internal error occurred (WriteFailed)` right after all tests finish (all tests pass beforehand, crash is in the writer). Reproduced on main's own recent Test workflow runs (e.g. run 28663719011 on commit db35d2def), not tied to any single PR's diff — this was blocking `unit-tests` CI on multiple unrelated open PRs (#2232, #2235, #2240) independently of their actual code changes.

## Change
Bump the `unit-tests` job's pinned `bun-version` from `1.3.13` to `1.3.14` in `.github/workflows/test.yml`.

## Verification
- `bun run test:coverage` passes clean locally under 1.3.14 (thousands of tests, 0 fail).
- No application code touched.

Co-Authored-By: duyetbot <bot@duyet.net>