### PR TITLE
feat(landing): honest /vs-* comparison pages (Grafana, Datadog, ClickHouse Cloud)

### DIFF
--- a/apps/landing/src/components/Comparison.astro
+++ b/apps/landing/src/components/Comparison.astro
@@ -78,5 +78,12 @@ const partialSvg = `<svg class="cmp-partial" viewBox="0 0 24 24" fill="none" str
       </div>
       <div class="cmp-note">Costs and features for third-party tools reflect publicly available information and may change. Always verify before purchasing.</div>
     </div>
+
+    <p class="cmp-deep-link reveal">Want the deep dive? <a href="/vs-grafana">chmonitor vs Grafana</a> · <a href="/vs-datadog">vs Datadog</a> · <a href="/vs-clickhouse-cloud">vs ClickHouse Cloud</a></p>
   </div>
 </section>
+
+<style>
+  .cmp-deep-link{margin-top:20px;text-align:center;font-size:14px;color:var(--muted-fg)}
+  .cmp-deep-link a{color:var(--orange);font-weight:600;text-decoration:underline;text-underline-offset:3px}
+</style>

--- a/apps/landing/src/components/ComparisonTable.astro
+++ b/apps/landing/src/components/ComparisonTable.astro
@@ -1,0 +1,73 @@
+---
+/**
+ * Shared, data-driven comparison matrix for the /vs-* pages. Renders chmonitor
+ * vs one named competitor across N rows. Reuses the same `.cmp-*` classes as
+ * the homepage `Comparison.astro` table (defined once, globally, in
+ * `layouts/Base.astro`) — no new CSS needed.
+ *
+ * Row cells are either a plain phrase (`kind: 'plain'`, e.g. "Setup time" or
+ * "Cost", where a check/cross would be meaningless) or a check/cross/partial
+ * icon plus a short explanation. Pass a `note` slot for the sourced,
+ * dated disclaimer under the table (mirrors `pricing.astro`'s `.cmp-note`).
+ */
+export type CellKind = 'yes' | 'no' | 'partial' | 'plain'
+
+export interface ComparisonCell {
+  kind: CellKind
+  text: string
+}
+
+export interface ComparisonRow {
+  label: string
+  chm: ComparisonCell
+  them: ComparisonCell
+}
+
+interface Props {
+  /** Header label for the competitor column, e.g. "Grafana + Altinity plugin". */
+  competitor: string
+  rows: ComparisonRow[]
+}
+
+const { competitor, rows } = Astro.props
+
+const ICON_YES = `<svg class="cmp-yes" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;display:inline-block;vertical-align:middle"><path d="m5 12 5 5L20 7"/></svg>`
+const ICON_NO = `<svg class="cmp-no" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;display:inline-block;vertical-align:middle"><path d="m18 6-12 12M6 6l12 12"/></svg>`
+const ICON_PARTIAL = `<svg class="cmp-partial" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;display:inline-block;vertical-align:middle"><path d="M5 12h14"/></svg>`
+
+function iconFor(kind: CellKind): string {
+  switch (kind) {
+    case 'yes':
+      return ICON_YES
+    case 'no':
+      return ICON_NO
+    case 'partial':
+      return ICON_PARTIAL
+    default:
+      return ''
+  }
+}
+---
+<div class="cmp-wrap reveal">
+  <div class="cmp-scroll">
+    <table class="cmp-table">
+      <thead>
+        <tr>
+          <th></th>
+          <th class="cmp-highlight">chmonitor</th>
+          <th>{competitor}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr>
+            <td>{row.label}</td>
+            <td class="cmp-highlight">{row.chm.kind !== 'plain' && <Fragment set:html={iconFor(row.chm.kind)} />} {row.chm.text}</td>
+            <td>{row.them.kind !== 'plain' && <Fragment set:html={iconFor(row.them.kind)} />} {row.them.text}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+  <div class="cmp-note"><slot name="note" /></div>
+</div>

--- a/apps/landing/src/data/comparisons.ts
+++ b/apps/landing/src/data/comparisons.ts
@@ -1,0 +1,393 @@
+/**
+ * Row data for the /vs-* comparison pages (`ComparisonTable.astro`).
+ *
+ * Every chmonitor cell maps to a shipped capability — verified against
+ * `apps/dashboard` source, not the pricing page's advertised entitlements
+ * (those are billing tiers, not a "what exists" test). Every competitor cell
+ * is sourced from that competitor's public docs/pricing pages as of July 2026
+ * (see each page's `note` slot for links) and is deliberately not a strawman:
+ * each table includes rows where the competitor legitimately wins.
+ */
+
+import type { ComparisonRow } from '../components/ComparisonTable.astro'
+
+export const grafanaRows: ComparisonRow[] = [
+  {
+    label: 'Setup time',
+    chm: {
+      kind: 'plain',
+      text: 'Point at your ClickHouse host — Docker, Helm, or Cloudflare Workers, ~5 min',
+    },
+    them: {
+      kind: 'plain',
+      text: 'Install Grafana, add the ClickHouse data source (Altinity or official plugin), then build panels',
+    },
+  },
+  {
+    label: 'Pre-built ClickHouse monitoring',
+    chm: {
+      kind: 'yes',
+      text: 'Queries, merges, parts, replication and health ship as complete pages — no query-writing',
+    },
+    them: {
+      kind: 'partial',
+      text: 'The plugin gives you a SQL editor and macros; you write or import the panel queries yourself',
+    },
+  },
+  {
+    label: 'Visualization flexibility & multi-datasource dashboards',
+    chm: {
+      kind: 'no',
+      text: 'Single-purpose: ClickHouse only, fixed page layouts',
+    },
+    them: {
+      kind: 'yes',
+      text: 'Best-in-class panel library and one pane of glass across dozens of data sources',
+    },
+  },
+  {
+    label: 'Plugin & panel ecosystem',
+    chm: { kind: 'no', text: 'No plugin marketplace' },
+    them: {
+      kind: 'yes',
+      text: 'A decade-deep plugin catalog for panels, data sources and alerting',
+    },
+  },
+  {
+    label: 'AI agent + MCP server for your cluster',
+    chm: {
+      kind: 'yes',
+      text: 'Built-in chat agent and an MCP server with ClickHouse-aware tools (query log, merges, replication)',
+    },
+    them: {
+      kind: 'no',
+      text: 'No built-in agent or MCP server scoped to ClickHouse system tables',
+    },
+  },
+  {
+    label: 'Query advisor (recommend-only)',
+    chm: {
+      kind: 'yes',
+      text: 'Ranked index/rewrite suggestions with EXPLAIN-based impact estimates; never auto-applies DDL',
+    },
+    them: {
+      kind: 'no',
+      text: 'No query advisor — you write and tune SQL yourself',
+    },
+  },
+  {
+    label: 'Materialized view / projection designer',
+    chm: {
+      kind: 'yes',
+      text: 'Recommend-only MV & projection suggestions derived from real query patterns',
+    },
+    them: {
+      kind: 'no',
+      text: 'Not a dashboarding concern — no schema-design tooling',
+    },
+  },
+  {
+    label: 'Anomaly detection on cluster metrics',
+    chm: {
+      kind: 'yes',
+      text: 'Statistical baselines per metric, built in',
+    },
+    them: {
+      kind: 'partial',
+      text: "Grafana's alerting supports threshold and anomaly-style rules, but you configure and tune each one",
+    },
+  },
+  {
+    label: 'Alerting & webhooks',
+    chm: {
+      kind: 'yes',
+      text: 'ClickHouse-native thresholds, inbound events and outbound webhooks run everywhere; alert history persists with a D1 binding (hosted cloud or a Cloudflare Workers self-host)',
+    },
+    them: {
+      kind: 'yes',
+      text: 'Mature unified alerting across every connected data source with broad notification routing',
+    },
+  },
+  {
+    label: 'Version-aware SQL across ClickHouse releases',
+    chm: {
+      kind: 'yes',
+      text: 'The query set adapts automatically to the connected ClickHouse version',
+    },
+    them: {
+      kind: 'no',
+      text: 'Panel queries are static SQL you maintain yourself across upgrades',
+    },
+  },
+  {
+    label: 'Cost',
+    chm: {
+      kind: 'plain',
+      text: 'Free self-hosted (GPL-3.0); hosted cloud in early access',
+    },
+    them: {
+      kind: 'plain',
+      text: 'Grafana OSS free; Grafana Cloud from $19/mo + usage (~$6.50 per 1K active series, ~$0.45/GB logs/traces), Enterprise from $25K/yr (2026 list pricing)',
+    },
+  },
+  {
+    label: 'Open source / self-host',
+    chm: {
+      kind: 'yes',
+      text: 'GPL-3.0 — Docker, Kubernetes (Helm), Cloudflare Workers',
+    },
+    them: { kind: 'yes', text: 'Grafana OSS is AGPL-3.0 and self-hostable' },
+  },
+]
+
+export const datadogRows: ComparisonRow[] = [
+  {
+    label: 'Setup time',
+    chm: {
+      kind: 'plain',
+      text: 'Point at your ClickHouse host — Docker, Helm, or Cloudflare Workers, ~5 min',
+    },
+    them: {
+      kind: 'plain',
+      text: 'Install the Datadog Agent and ClickHouse integration check on every node',
+    },
+  },
+  {
+    label: 'Agents required',
+    chm: {
+      kind: 'yes',
+      text: 'None — reads system tables directly over the ClickHouse protocol',
+    },
+    them: {
+      kind: 'no',
+      text: 'A Datadog Agent process runs on every monitored host',
+    },
+  },
+  {
+    label: 'ClickHouse-specific depth',
+    chm: {
+      kind: 'yes',
+      text: 'Purpose-built pages for query log, merges, parts, replication queue and Keeper quorum',
+    },
+    them: {
+      kind: 'partial',
+      text: 'A fixed ClickHouse integration metric set; no dedicated merge/part/replication drill-down UI',
+    },
+  },
+  {
+    label: 'Full-stack APM, distributed tracing & log management',
+    chm: { kind: 'no', text: 'ClickHouse monitoring only, by design' },
+    them: {
+      kind: 'yes',
+      text: 'Industry-leading APM, tracing and log management across your entire stack',
+    },
+  },
+  {
+    label: 'On-call, escalation & incident management',
+    chm: { kind: 'no', text: 'No on-call/escalation product' },
+    them: {
+      kind: 'yes',
+      text: 'Mature on-call routing, escalation policies and incident management',
+    },
+  },
+  {
+    label: 'AI agent for ClickHouse system tables',
+    chm: {
+      kind: 'yes',
+      text: "Chat agent + MCP server with tools scoped to ClickHouse's own system tables",
+    },
+    them: {
+      kind: 'partial',
+      text: "Datadog's AI features reason over Datadog telemetry, not ClickHouse system-table semantics specifically",
+    },
+  },
+  {
+    label: 'Query advisor (recommend-only)',
+    chm: {
+      kind: 'yes',
+      text: 'Ranked index/rewrite suggestions with EXPLAIN-based impact estimates; never auto-applies DDL',
+    },
+    them: {
+      kind: 'no',
+      text: 'Not part of a general infra-monitoring integration',
+    },
+  },
+  {
+    label: 'Materialized view / projection designer',
+    chm: {
+      kind: 'yes',
+      text: 'Recommend-only MV & projection suggestions derived from real query patterns',
+    },
+    them: { kind: 'no', text: 'Out of scope for the integration' },
+  },
+  {
+    label: 'Anomaly detection',
+    chm: {
+      kind: 'yes',
+      text: 'Statistical baselines scoped to ClickHouse cluster metrics, built in',
+    },
+    them: {
+      kind: 'yes',
+      text: 'Mature, general-purpose anomaly and forecast monitors across any metric you send it',
+    },
+  },
+  {
+    label: 'Alerting & webhooks',
+    chm: {
+      kind: 'yes',
+      text: 'ClickHouse-specific thresholds, inbound events and outbound webhooks run everywhere — narrower by design; alert history persists with a D1 binding (hosted cloud or a Cloudflare Workers self-host)',
+    },
+    them: {
+      kind: 'yes',
+      text: 'Broad monitor types, deep notification integrations and escalation across your whole stack',
+    },
+  },
+  {
+    label: 'Cost',
+    chm: {
+      kind: 'plain',
+      text: 'Free self-hosted (GPL-3.0); hosted cloud in early access',
+    },
+    them: {
+      kind: 'plain',
+      text: 'Infrastructure Monitoring ~$15–$23/host/month; APM adds ~$31/host/month; logs billed per GB (2026 list pricing, varies by commitment)',
+    },
+  },
+  {
+    label: 'Open source / self-host',
+    chm: {
+      kind: 'yes',
+      text: 'GPL-3.0 — Docker, Kubernetes (Helm), Cloudflare Workers',
+    },
+    them: { kind: 'no', text: 'SaaS only, no self-hosted option' },
+  },
+]
+
+export const clickhouseCloudRows: ComparisonRow[] = [
+  {
+    label: 'What it is',
+    chm: {
+      kind: 'plain',
+      text: 'An independent monitoring/ops layer you run alongside any ClickHouse deployment',
+    },
+    them: {
+      kind: 'plain',
+      text: "ClickHouse Inc's fully managed ClickHouse hosting service",
+    },
+  },
+  {
+    label: 'Fully managed hosting (no servers to run)',
+    chm: {
+      kind: 'no',
+      text: "Not a hosting product — it's an ops layer on top of whatever ClickHouse you run",
+    },
+    them: {
+      kind: 'yes',
+      text: 'Zero-ops managed service: autoscaling, backups and upgrades handled for you',
+    },
+  },
+  {
+    label: 'Works with self-managed / on-prem / any-cloud ClickHouse',
+    chm: {
+      kind: 'yes',
+      text: 'Any ClickHouse — OSS, Altinity, ClickHouse Cloud — on your infra or any cloud',
+    },
+    them: {
+      kind: 'no',
+      text: 'Monitors the ClickHouse Cloud service itself, not clusters you self-manage',
+    },
+  },
+  {
+    label: 'ClickHouse-specific ops depth',
+    chm: {
+      kind: 'yes',
+      text: 'Dedicated pages for the full merge/part/replication-queue/Keeper lifecycle',
+    },
+    them: {
+      kind: 'partial',
+      text: 'The Cloud console shows service-level metrics and Query Insights, with less part/merge/replication drill-down than a dedicated ops tool',
+    },
+  },
+  {
+    label: 'AI agent / natural-language assistant',
+    chm: {
+      kind: 'yes',
+      text: 'Built-in agent + MCP server, works against any connected ClickHouse — analytics and cluster ops',
+    },
+    them: {
+      kind: 'yes',
+      text: "Ask AI agent (public beta, March 2026) — natural-language analysis over your Cloud service's data; analytics-first, not a cluster-ops advisor",
+    },
+  },
+  {
+    label: 'MCP server for AI tools',
+    chm: {
+      kind: 'yes',
+      text: 'Ships with every deployment, self-hosted included',
+    },
+    them: {
+      kind: 'partial',
+      text: 'Remote MCP server in public beta (March 2026), Cloud-only, OAuth-gated, read-only SELECT scope',
+    },
+  },
+  {
+    label: 'Query advisor (recommend-only)',
+    chm: {
+      kind: 'yes',
+      text: 'Ranked index/rewrite suggestions with EXPLAIN-based impact estimates; never auto-applies DDL',
+    },
+    them: {
+      kind: 'no',
+      text: "Ask AI can write and run queries, but isn't a schema-optimization advisor",
+    },
+  },
+  {
+    label: 'Materialized view / projection designer',
+    chm: {
+      kind: 'yes',
+      text: 'Recommend-only MV & projection suggestions derived from real query patterns',
+    },
+    them: { kind: 'no', text: 'No dedicated MV/projection design tool' },
+  },
+  {
+    label: 'Anomaly detection on cluster health',
+    chm: {
+      kind: 'yes',
+      text: 'Statistical baselines on cluster/query metrics, built in',
+    },
+    them: {
+      kind: 'partial',
+      text: 'Console surfaces usage and service metrics; no dedicated statistical-baseline alerting product',
+    },
+  },
+  {
+    label: 'Alerting & webhooks',
+    chm: {
+      kind: 'yes',
+      text: 'Cluster-health thresholds, inbound events and outbound webhooks run everywhere; alert history persists with a D1 binding (hosted cloud or a Cloudflare Workers self-host)',
+    },
+    them: {
+      kind: 'partial',
+      text: 'Billing/usage and service notifications; not general cluster-health threshold alerting with webhook delivery',
+    },
+  },
+  {
+    label: 'Pricing model',
+    chm: {
+      kind: 'plain',
+      text: 'Free self-hosted (GPL-3.0); hosted cloud in early access',
+    },
+    them: {
+      kind: 'plain',
+      text: 'Usage-based: ~$0.22–$0.39 per compute-unit-hour plus ~$25/TB-month storage; no permanent free tier (30-day / $300-credit trial)',
+    },
+  },
+  {
+    label: 'Open source',
+    chm: { kind: 'yes', text: 'GPL-3.0, full source available' },
+    them: {
+      kind: 'no',
+      text: 'Proprietary managed service (built on the open-source ClickHouse core)',
+    },
+  },
+]

--- a/apps/landing/src/data/comparisons.ts
+++ b/apps/landing/src/data/comparisons.ts
@@ -101,7 +101,7 @@ export const grafanaRows: ComparisonRow[] = [
     label: 'Alerting & webhooks',
     chm: {
       kind: 'yes',
-      text: 'ClickHouse-native thresholds, inbound events and outbound webhooks run everywhere; alert history persists with a D1 binding (hosted cloud or a Cloudflare Workers self-host)',
+      text: 'ClickHouse-native thresholds and outbound webhooks run everywhere; alert history and inbound-event storage persist with a D1 binding (hosted cloud or a Cloudflare Workers self-host)',
     },
     them: {
       kind: 'yes',
@@ -235,7 +235,7 @@ export const datadogRows: ComparisonRow[] = [
     label: 'Alerting & webhooks',
     chm: {
       kind: 'yes',
-      text: 'ClickHouse-specific thresholds, inbound events and outbound webhooks run everywhere — narrower by design; alert history persists with a D1 binding (hosted cloud or a Cloudflare Workers self-host)',
+      text: 'ClickHouse-specific thresholds and outbound webhooks run everywhere — narrower by design; alert history and inbound-event storage persist with a D1 binding (hosted cloud or a Cloudflare Workers self-host)',
     },
     them: {
       kind: 'yes',
@@ -364,7 +364,7 @@ export const clickhouseCloudRows: ComparisonRow[] = [
     label: 'Alerting & webhooks',
     chm: {
       kind: 'yes',
-      text: 'Cluster-health thresholds, inbound events and outbound webhooks run everywhere; alert history persists with a D1 binding (hosted cloud or a Cloudflare Workers self-host)',
+      text: 'Cluster-health thresholds and outbound webhooks run everywhere; alert history and inbound-event storage persist with a D1 binding (hosted cloud or a Cloudflare Workers self-host)',
     },
     them: {
       kind: 'partial',

--- a/apps/landing/src/pages/vs-clickhouse-cloud.astro
+++ b/apps/landing/src/pages/vs-clickhouse-cloud.astro
@@ -1,0 +1,86 @@
+---
+import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import ComparisonTable from '../components/ComparisonTable.astro'
+import FinalCta from '../components/FinalCta.astro'
+import Footer from '../components/Footer.astro'
+import { clickhouseCloudRows } from '../data/comparisons'
+
+const canonical = new URL(Astro.url.pathname, Astro.site).toString()
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: new URL('/', Astro.site).toString() },
+    { '@type': 'ListItem', position: 2, name: 'chmonitor vs ClickHouse Cloud', item: canonical },
+  ],
+}
+---
+<Base
+  title="chmonitor vs ClickHouse Cloud's built-in monitoring — Honest 2026 Comparison"
+  description="chmonitor vs ClickHouse Cloud's console monitoring, Ask AI and remote MCP server: a dated, sourced feature matrix. Complementary, not exclusive — chmonitor also connects to ClickHouse Cloud."
+>
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} is:inline />
+  <Nav />
+  <main id="top">
+    <section class="band" style="padding-bottom:0">
+      <div class="wrap">
+        <div class="sec-head price-head reveal">
+          <span class="eyebrow">chmonitor vs ClickHouse Cloud</span>
+          <h1>An ops layer vs a managed hosting service</h1>
+          <p>ClickHouse Cloud is a genuinely zero-ops way to run ClickHouse — autoscaling, backups, upgrades handled for you, plus its own Ask AI agent and a remote MCP server in beta. chmonitor isn't a hosting product; it's an independent monitoring and advisor layer that works on any ClickHouse — including ClickHouse Cloud itself. They're not mutually exclusive.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="matrix" class="band band-soft">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">Feature matrix</span>
+          <h2>chmonitor vs ClickHouse Cloud's built-in tooling</h2>
+          <p>ClickHouse Cloud legitimately wins on zero-ops managed hosting — that's not something chmonitor does either.</p>
+        </div>
+        <ComparisonTable competitor="ClickHouse Cloud" rows={clickhouseCloudRows}>
+          <Fragment slot="note">
+            ClickHouse Cloud details reflect public docs and pricing as of July 2026 and may change — verify at <a href="https://clickhouse.com/pricing" target="_blank" rel="noopener">clickhouse.com/pricing</a> and the <a href="https://clickhouse.com/blog/agentic-analytics-ask-ai-agent-and-remote-mcp-server-beta-launch" target="_blank" rel="noopener">Ask AI / remote MCP server beta announcement</a>. chmonitor rows reflect the current self-hosted/OSS build.
+          </Fragment>
+        </ComparisonTable>
+      </div>
+    </section>
+
+    <section id="tco" class="band">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">Total cost of ownership</span>
+          <h2>Pick your hosting, keep the ops advisor</h2>
+          <p>chmonitor doesn't compete with ClickHouse Cloud's hosting — it adds the ops-focused advisor and alerting layer on top, wherever your ClickHouse runs.</p>
+        </div>
+        <div class="cap-grid">
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14 14 0 0 1 0 18M12 3a14 14 0 0 0 0 18"/></svg></span>
+            <h4>Not locked to one hosting vendor</h4>
+            <p>Works against self-managed ClickHouse, Altinity, or ClickHouse Cloud — connect any of them, switch hosting without losing your monitoring.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8Z"/></svg></span>
+            <h4>Built for cluster ops, not just queries</h4>
+            <p>A recommend-only query/MV advisor and statistical anomaly baselines built to run a cluster, not just analyze data in it.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="7" rx="1.5"/><rect x="3" y="13" width="18" height="7" rx="1.5"/><path d="M7 7.5h.01M7 16.5h.01"/></svg></span>
+            <h4>MCP server, every deployment</h4>
+            <p>Self-hosted chmonitor ships the same MCP server ClickHouse Cloud offers only in beta, and only to its own managed service.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1v22M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg></span>
+            <h4>Free self-hosted, period</h4>
+            <p>GPL-3.0, no usage-based bill. ClickHouse Cloud bills compute + storage with no permanent free tier.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <FinalCta />
+  </main>
+  <Footer />
+</Base>

--- a/apps/landing/src/pages/vs-datadog.astro
+++ b/apps/landing/src/pages/vs-datadog.astro
@@ -1,0 +1,86 @@
+---
+import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import ComparisonTable from '../components/ComparisonTable.astro'
+import FinalCta from '../components/FinalCta.astro'
+import Footer from '../components/Footer.astro'
+import { datadogRows } from '../data/comparisons'
+
+const canonical = new URL(Astro.url.pathname, Astro.site).toString()
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: new URL('/', Astro.site).toString() },
+    { '@type': 'ListItem', position: 2, name: 'chmonitor vs Datadog', item: canonical },
+  ],
+}
+---
+<Base
+  title="chmonitor vs Datadog for ClickHouse — Honest 2026 Comparison"
+  description="chmonitor vs Datadog's ClickHouse integration: a dated, sourced feature matrix, setup time and cost. Datadog wins on full-stack APM and on-call — we say so."
+>
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} is:inline />
+  <Nav />
+  <main id="top">
+    <section class="band" style="padding-bottom:0">
+      <div class="wrap">
+        <div class="sec-head price-head reveal">
+          <span class="eyebrow">chmonitor vs Datadog</span>
+          <h1>A ClickHouse specialist vs a full-stack observability platform</h1>
+          <p>Datadog is a mature, full-stack observability platform — APM, tracing, logs, on-call — with a ClickHouse integration bolted on. chmonitor only monitors ClickHouse, but goes far deeper: no agent to install, ClickHouse-native pages for merges/parts/replication, a recommend-only query/MV advisor, and a built-in AI agent. Neither replaces the other everywhere — here's the honest comparison.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="matrix" class="band band-soft">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">Feature matrix</span>
+          <h2>chmonitor vs Datadog</h2>
+          <p>Datadog legitimately wins on full-stack APM and on-call — that's not what chmonitor is for.</p>
+        </div>
+        <ComparisonTable competitor="Datadog" rows={datadogRows}>
+          <Fragment slot="note">
+            Datadog details reflect public pricing and docs as of July 2026 and may change — verify at <a href="https://www.datadoghq.com/pricing/" target="_blank" rel="noopener">datadoghq.com/pricing</a>. chmonitor rows reflect the current self-hosted/OSS build.
+          </Fragment>
+        </ComparisonTable>
+      </div>
+    </section>
+
+    <section id="tco" class="band">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">Total cost of ownership</span>
+          <h2>No agents, no per-host bill, for ClickHouse specifically</h2>
+          <p>If ClickHouse monitoring is the whole job, an agent-based, per-host-billed platform is a lot of surface area for one system.</p>
+        </div>
+        <div class="cap-grid">
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="7" rx="1.5"/><rect x="3" y="13" width="18" height="7" rx="1.5"/><path d="M7 7.5h.01M7 16.5h.01"/></svg></span>
+            <h4>Nothing to deploy per node</h4>
+            <p>chmonitor reads ClickHouse system tables directly. No Datadog Agent process to install, update or babysit on every host.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3 3 7l9 4 9-4-9-4Z"/><path d="m3 12 9 4 9-4"/><path d="m3 17 9 4 9-4"/></svg></span>
+            <h4>Merge/part/replication depth</h4>
+            <p>Dedicated pages for the parts of ClickHouse a general infra integration doesn't drill into.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8Z"/></svg></span>
+            <h4>Advisor + AI agent included</h4>
+            <p>A recommend-only query and MV/projection advisor plus a built-in AI agent, scoped to ClickHouse — not a general infra add-on.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1v22M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg></span>
+            <h4>Free self-hosted, period</h4>
+            <p>GPL-3.0, no per-host bill. Datadog Infrastructure Monitoring runs ~$15–$23/host/month before APM or logs.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <FinalCta />
+  </main>
+  <Footer />
+</Base>

--- a/apps/landing/src/pages/vs-grafana.astro
+++ b/apps/landing/src/pages/vs-grafana.astro
@@ -1,0 +1,86 @@
+---
+import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import ComparisonTable from '../components/ComparisonTable.astro'
+import FinalCta from '../components/FinalCta.astro'
+import Footer from '../components/Footer.astro'
+import { grafanaRows } from '../data/comparisons'
+
+const canonical = new URL(Astro.url.pathname, Astro.site).toString()
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: new URL('/', Astro.site).toString() },
+    { '@type': 'ListItem', position: 2, name: 'chmonitor vs Grafana', item: canonical },
+  ],
+}
+---
+<Base
+  title="chmonitor vs Grafana + ClickHouse plugin — Honest 2026 Comparison"
+  description="chmonitor vs Grafana with the Altinity/official ClickHouse data source plugin: a dated, sourced feature matrix, setup time and cost — no strawmen, just what each tool actually does."
+>
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} is:inline />
+  <Nav />
+  <main id="top">
+    <section class="band" style="padding-bottom:0">
+      <div class="wrap">
+        <div class="sec-head price-head reveal">
+          <span class="eyebrow">chmonitor vs Grafana</span>
+          <h1>ClickHouse-native monitoring vs a general-purpose dashboard</h1>
+          <p>Grafana with the Altinity or official ClickHouse plugin is a genuinely great, flexible dashboarding tool for any data source you wire up. chmonitor does one thing: it reads ClickHouse system tables directly and ships every page pre-built, plus an AI agent, a recommend-only query/MV advisor, and ClickHouse-aware alerting. Here's the honest, row-by-row comparison.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="matrix" class="band band-soft">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">Feature matrix</span>
+          <h2>chmonitor vs Grafana + ClickHouse plugin</h2>
+          <p>Where each tool actually wins — Grafana included.</p>
+        </div>
+        <ComparisonTable competitor="Grafana + ClickHouse plugin" rows={grafanaRows}>
+          <Fragment slot="note">
+            Grafana and Altinity/ClickHouse-plugin details reflect public docs and pricing pages as of July 2026 and may change — verify at <a href="https://grafana.com/pricing/" target="_blank" rel="noopener">grafana.com/pricing</a> and the <a href="https://github.com/Altinity/clickhouse-grafana" target="_blank" rel="noopener">Altinity ClickHouse plugin repo</a>. chmonitor rows reflect the current self-hosted/OSS build.
+          </Fragment>
+        </ComparisonTable>
+      </div>
+    </section>
+
+    <section id="tco" class="band">
+      <div class="wrap">
+        <div class="sec-head reveal" style="text-align:center">
+          <span class="eyebrow">Total cost of ownership</span>
+          <h2>Less to build, less to maintain</h2>
+          <p>Grafana's strength is being a flexible canvas. That flexibility is also the bill: someone has to build and maintain the ClickHouse panels.</p>
+        </div>
+        <div class="cap-grid">
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg></span>
+            <h4>Minutes, not a dashboard project</h4>
+            <p>chmonitor ships ClickHouse monitoring as complete pages. Grafana + the ClickHouse plugin gives you a SQL editor and a blank canvas.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3 3 7l9 4 9-4-9-4Z"/><path d="m3 12 9 4 9-4"/><path d="m3 17 9 4 9-4"/></svg></span>
+            <h4>Nothing to maintain across upgrades</h4>
+            <p>No panel JSON or hand-written SQL queries to keep in sync with your ClickHouse version — chmonitor's query set adapts on its own.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8Z"/></svg></span>
+            <h4>Advisor + AI agent included</h4>
+            <p>A recommend-only query and MV/projection advisor plus a built-in AI agent — Grafana has no ClickHouse-specific advisor at any price.</p>
+          </div>
+          <div class="cap reveal">
+            <span class="cap-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1v22M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg></span>
+            <h4>Free self-hosted, period</h4>
+            <p>GPL-3.0, no usage-based bill. Grafana Cloud starts free too, then bills per active series/user once you outgrow the free tier.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <FinalCta />
+  </main>
+  <Footer />
+</Base>


### PR DESCRIPTION
Implements **plan 63** — three comparison pages plus a reusable, data-driven `ComparisonTable.astro`.

## What
- `ComparisonTable.astro` — shared, data-driven table (reuses existing global `.cmp-*` CSS; no new styles).
- `/vs-grafana`, `/vs-datadog`, `/vs-clickhouse-cloud` — each with hero, ≥10-row honest feature matrix, TCO section, dated/sourced disclaimer, reused `<FinalCta />`.
- `data/comparisons.ts` — row data (12/12/11 rows).
- Additive link-back from the homepage `Comparison.astro`.

## Honesty guardrails
- Every chmonitor claim verified against **shipped `apps/dashboard` code** (not just pricing capability flags): MCP server (`/api/mcp`), AI agent, query advisor (recommend-only, EXPLAIN-based impact), MV/projection designer, anomaly baselines, alert dedup/cooldown + 5-min fleet-wide sweep, outbound alert webhooks (Slack/Discord/Telegram/PagerDuty/generic — no email adapter, correctly omitted), version-aware SQL, self-host (Docker/Helm/Cloudflare Workers, GPL-3.0).
- Each matrix includes 2–3 rows where the **competitor legitimately wins** — no strawmen (Grafana's plugin ecosystem/multi-datasource, Datadog's full-stack APM/on-call, ClickHouse Cloud's zero-ops hosting).
- Alert history + inbound-event storage explicitly scoped to "needs a D1 binding" (no fallback on bare Docker/K8s) — precision fix made mid-implementation.
- Competitor claims dated July 2026, each page links its primary source (grafana.com/pricing, Altinity plugin repo, Datadog pricing, ClickHouse Cloud pricing).

## Verification
- `bun run check` (Biome) clean across all commits.
- `cd apps/landing && bun run build` — now verified locally (the earlier self-referential `apps/landing/node_modules` symlink was a stale artifact of the shared checkout, not the PR; a clean `bun install` resolves it). All 8 pages build, including the 3 new `/vs-*` routes.
- The three CI failures (`build`, `landing`, `unit-tests`) are transient infra flakes — `ENOENT: could not open the "node_modules" directory` on `bun install --frozen-lockfile`, and an internal bun `WriteFailed` error on the dashboard's unrelated coverage run — not caused by this diff. Reran the failed jobs.

Co-Authored-By: duyetbot <bot@duyet.net>