### PR TITLE
feat(alerting): Opsgenie adapter (plan 26)

### DIFF
--- a/apps/dashboard/src/components/health/health-settings-dialog.tsx
+++ b/apps/dashboard/src/components/health/health-settings-dialog.tsx
@@ -6,6 +6,7 @@ import { HEALTH_CHECKS } from './health-checks'
 import { RecentAlertsCard } from './recent-alerts-card'
 import { WebhookSubscriptionsPanel } from './webhook-subscriptions-panel'
 import { useEffect, useState } from 'react'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -42,11 +43,23 @@ export function HealthSettingsDialog() {
   const [open, setOpen] = useState(false)
   const [thresholds, setThresholdsState] = useState<ThresholdsMap>({})
   const [alerts, setAlerts] = useState<AlertSettings>(DEFAULT_ALERT_SETTINGS)
+  const [opsgenieStatus, setOpsgenieStatus] = useState<{
+    configured: boolean
+    region: string | null
+  } | null>(null)
 
   useEffect(() => {
     if (!open) return
     setThresholdsState(loadThresholds())
     setAlerts(loadAlertSettings())
+    fetch('/api/v1/health/opsgenie-test')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) =>
+        setOpsgenieStatus(
+          data as { configured: boolean; region: string | null } | null
+        )
+      )
+      .catch(() => setOpsgenieStatus(null))
   }, [open])
 
   const handleThresholdChange = (
@@ -138,6 +151,25 @@ export function HealthSettingsDialog() {
     )
     if (ok) toast.success('Test alert sent')
     else toast.error('Webhook request failed')
+  }
+
+  const handleTestOpsgenie = async () => {
+    try {
+      const res = await fetch('/api/v1/health/opsgenie-test', {
+        method: 'POST',
+      })
+      if (res.ok) {
+        toast.success('Opsgenie test alert sent')
+      } else {
+        const body = await res.json().catch(() => null)
+        toast.error(
+          (body as { error?: { message?: string } } | null)?.error?.message ??
+            'Opsgenie test alert failed'
+        )
+      }
+    } catch {
+      toast.error('Opsgenie test alert failed')
+    }
   }
 
   const handleTestBrowser = () => {
@@ -324,6 +356,37 @@ export function HealthSettingsDialog() {
                   Send test
                 </Button>
               </div>
+            </div>
+
+            <Separator />
+
+            <div className="flex items-center justify-between rounded-md border p-3">
+              <div className="flex flex-col">
+                <div className="flex items-center gap-2">
+                  <Label className="text-sm font-medium">Opsgenie alerts</Label>
+                  <Badge
+                    variant={
+                      opsgenieStatus?.configured ? 'default' : 'secondary'
+                    }
+                  >
+                    {opsgenieStatus?.configured
+                      ? `Configured (${opsgenieStatus.region})`
+                      : 'Not configured'}
+                  </Badge>
+                </div>
+                <span className="text-xs text-muted-foreground">
+                  Set HEALTH_ALERT_OPSGENIE_API_KEY on the server to enable —
+                  the key is never exposed to the browser
+                </span>
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleTestOpsgenie}
+                disabled={!opsgenieStatus?.configured}
+              >
+                Send test
+              </Button>
             </div>
 
             <Separator />

--- a/apps/dashboard/src/lib/health/adapters/__tests__/__snapshots__/adapters.test.ts.snap
+++ b/apps/dashboard/src/lib/health/adapters/__tests__/__snapshots__/adapters.test.ts.snap
@@ -194,3 +194,29 @@ exports[`generic-json adapter snapshot 1`] = `
   "value": 7,
 }
 `;
+
+exports[`opsgenie adapter snapshot 1`] = `
+{
+  "alias": "chmonitor:2:failed-mutations",
+  "description": 
+"Runbooks:
+https://docs.example.com/runbook/mutations"
+,
+  "details": {
+    "critThreshold": "5",
+    "hostId": "2",
+    "metric": "failed-mutations",
+    "timestamp": "2026-07-02T10:00:00.000Z",
+    "value": "7",
+    "warnThreshold": "1",
+  },
+  "message": "Failed mutations — 7 failed mutations (host prod-1)",
+  "priority": "P1",
+  "source": "chmonitor",
+  "tags": [
+    "host:prod-1",
+    "metric:failed-mutations",
+    "chmonitor",
+  ],
+}
+`;

--- a/apps/dashboard/src/lib/health/adapters/__tests__/adapters.test.ts
+++ b/apps/dashboard/src/lib/health/adapters/__tests__/adapters.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   buildDiscordBody,
   buildGenericJsonBody,
+  buildOpsgenieBody,
   buildPagerDutyBody,
   buildSlackBody,
   buildTelegramBody,
@@ -24,6 +25,8 @@ import {
   discordAdapter,
   escapeMarkdownV2,
   genericJsonAdapter,
+  opsgenieAdapter,
+  opsgenieAlias,
   pagerDutyAdapter,
   pagerDutyDedupKey,
   slackAdapter,
@@ -272,6 +275,78 @@ describe('pagerduty adapter', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Opsgenie
+// ---------------------------------------------------------------------------
+
+describe('opsgenie adapter', () => {
+  test('critical maps to P1 priority with a stable alias', () => {
+    const body = buildOpsgenieBody(CRITICAL)
+    expect(body.priority).toBe('P1')
+    expect(body.alias).toBe('chmonitor:2:failed-mutations')
+    expect(body.alias).toBe(opsgenieAlias(CRITICAL))
+    expect(body.source).toBe('chmonitor')
+    expect(body.message).toBe(
+      'Failed mutations — 7 failed mutations (host prod-1)'
+    )
+  })
+
+  test('warning maps to P2, recovery maps to P3', () => {
+    expect(buildOpsgenieBody(WARNING).priority).toBe('P2')
+    expect(buildOpsgenieBody(RECOVERY).priority).toBe('P3')
+  })
+
+  test('repeated firings for the same host+metric share one alias', () => {
+    expect(opsgenieAlias(CRITICAL)).toBe(opsgenieAlias(WARNING))
+    expect(opsgenieAlias(CRITICAL)).toBe(opsgenieAlias(RECOVERY))
+  })
+
+  test('tags host + metric + chmonitor', () => {
+    expect(buildOpsgenieBody(CRITICAL).tags).toEqual([
+      'host:prod-1',
+      'metric:failed-mutations',
+      'chmonitor',
+    ])
+  })
+
+  test('details values are all strings', () => {
+    const details = buildOpsgenieBody(CRITICAL).details
+    for (const value of Object.values(details)) {
+      expect(typeof value).toBe('string')
+    }
+    expect(details.value).toBe('7')
+    expect(details.warnThreshold).toBe('1')
+    expect(details.critThreshold).toBe('5')
+  })
+
+  test('null value and missing thresholds render "n/a" strings', () => {
+    const details = buildOpsgenieBody({
+      ...CRITICAL,
+      value: null,
+      warnThreshold: null,
+      critThreshold: null,
+    }).details
+    expect(details.value).toBe('n/a')
+    expect(details.warnThreshold).toBe('n/a')
+    expect(details.critThreshold).toBe('n/a')
+  })
+
+  test('includes runbook urls in the description', () => {
+    expect(buildOpsgenieBody(CRITICAL).description).toContain(
+      'https://docs.example.com/runbook/mutations'
+    )
+  })
+
+  test('omits description when no runbook urls are present', () => {
+    const { runbookUrls: _runbookUrls, ...withoutRunbooks } = CRITICAL
+    expect(buildOpsgenieBody(withoutRunbooks).description).toBeUndefined()
+  })
+
+  test('snapshot', () => {
+    expect(buildOpsgenieBody(CRITICAL)).toMatchSnapshot()
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Generic JSON
 // ---------------------------------------------------------------------------
 
@@ -324,6 +399,12 @@ describe('detectAdapter', () => {
     expect(detectAdapter('https://events.pagerduty.com/v2/enqueue').id).toBe(
       'pagerduty'
     )
+    expect(detectAdapter('https://api.opsgenie.com/v2/alerts').id).toBe(
+      'opsgenie'
+    )
+    expect(detectAdapter('https://api.eu.opsgenie.com/v2/alerts').id).toBe(
+      'opsgenie'
+    )
   })
 
   test('falls back to generic-json for unknown urls', () => {
@@ -335,6 +416,7 @@ describe('detectAdapter', () => {
     expect(slackAdapter.id).toBe('slack')
     expect(discordAdapter.id).toBe('discord')
     expect(pagerDutyAdapter.id).toBe('pagerduty')
+    expect(opsgenieAdapter.id).toBe('opsgenie')
     expect(genericJsonAdapter.id).toBe('generic-json')
   })
 
@@ -344,6 +426,7 @@ describe('detectAdapter', () => {
       slackAdapter,
       discordAdapter,
       pagerDutyAdapter,
+      opsgenieAdapter,
       genericJsonAdapter,
     ]) {
       expect(adapter.buildBody(CRITICAL)).toBeDefined()

--- a/apps/dashboard/src/lib/health/adapters/index.ts
+++ b/apps/dashboard/src/lib/health/adapters/index.ts
@@ -12,6 +12,11 @@
 export type { DiscordWebhookBody } from './discord'
 export type { GenericJsonBody } from './generic-json'
 export type {
+  OpsgenieConfig,
+  OpsgenieCreateBody,
+  OpsgeniePriority,
+} from './opsgenie'
+export type {
   PagerDutyConfig,
   PagerDutyEventBody,
   PagerDutySeverity,
@@ -26,6 +31,7 @@ export type {
 
 export { buildDiscordBody, discordAdapter } from './discord'
 export { buildGenericJsonBody, genericJsonAdapter } from './generic-json'
+export { buildOpsgenieBody, opsgenieAdapter, opsgenieAlias } from './opsgenie'
 export {
   buildPagerDutyBody,
   pagerDutyAdapter,
@@ -43,6 +49,7 @@ import type { NotificationAdapter } from './types'
 
 import { discordAdapter } from './discord'
 import { genericJsonAdapter } from './generic-json'
+import { opsgenieAdapter } from './opsgenie'
 import { pagerDutyAdapter } from './pagerduty'
 import { slackAdapter } from './slack'
 import { telegramAdapter } from './telegram'
@@ -57,6 +64,7 @@ export const ADAPTERS: readonly NotificationAdapter[] = [
   slackAdapter,
   discordAdapter,
   pagerDutyAdapter,
+  opsgenieAdapter,
 ]
 
 /** All adapters including the generic-json fallback. */

--- a/apps/dashboard/src/lib/health/adapters/opsgenie.ts
+++ b/apps/dashboard/src/lib/health/adapters/opsgenie.ts
@@ -1,0 +1,98 @@
+/**
+ * Opsgenie notification adapter (pure formatter).
+ *
+ * Builds an Opsgenie Alert API v2 "Create Alert" body
+ * (`https://api.opsgenie.com/v2/alerts`, EU: `https://api.eu.opsgenie.com/v2/alerts`).
+ * Severity maps onto Opsgenie priorities (P1-P5), and a stable `alias` is
+ * derived from the payload so repeat firings collapse onto one alert — a
+ * `recovery` payload closes that alias instead of creating a new one.
+ *
+ * Auth (`Authorization: GenieKey <API_KEY>`) and the create-vs-close request
+ * routing are applied by the dispatch layer (`../opsgenie-dispatch.ts`), not
+ * this pure builder — mirrors `pagerduty.ts`.
+ */
+
+import type { AlertPayload, AlertSeverity, NotificationAdapter } from './types'
+
+/** Opsgenie Alert API v2 priorities. */
+export type OpsgeniePriority = 'P1' | 'P2' | 'P3' | 'P4' | 'P5'
+
+/** Map our severity onto Opsgenie's priority vocabulary. */
+const SEVERITY_MAP: Record<AlertSeverity, OpsgeniePriority> = {
+  critical: 'P1',
+  warning: 'P2',
+  // Not sent as a create priority — recovery closes the alias instead of
+  // creating an alert. Kept so the label always resolves to something sane.
+  recovery: 'P3',
+}
+
+/** Caller-supplied Opsgenie transport config (resolved by the dispatch layer). */
+export interface OpsgenieConfig {
+  apiKey: string
+}
+
+/** Opsgenie Alert API v2 "Create Alert" request body. */
+export interface OpsgenieCreateBody {
+  message: string
+  alias: string
+  priority: OpsgeniePriority
+  source: string
+  tags: string[]
+  /** Opsgenie requires detail values to be strings. */
+  details: Record<string, string>
+  description?: string
+}
+
+/** Stable alias so repeat firings collapse to one Opsgenie alert. */
+export function opsgenieAlias(payload: AlertPayload): string {
+  return `chmonitor:${payload.hostId}:${payload.metric}`
+}
+
+/**
+ * Build the Opsgenie Alert API v2 create-alert body for a payload.
+ *
+ * Used as-is for `warning`/`critical` (trigger) severities. For `recovery`,
+ * the dispatch layer reads `payload.severity` to route to the close-alias
+ * endpoint (`POST /v2/alerts/{alias}/close?identifierType=alias`) instead of
+ * creating a new alert; only this body's `.message` is reused there.
+ */
+export function buildOpsgenieBody(payload: AlertPayload): OpsgenieCreateBody {
+  const body: OpsgenieCreateBody = {
+    message: `${payload.title} — ${payload.label} (host ${payload.hostLabel})`,
+    alias: opsgenieAlias(payload),
+    priority: SEVERITY_MAP[payload.severity],
+    source: 'chmonitor',
+    tags: [
+      `host:${payload.hostLabel}`,
+      `metric:${payload.metric}`,
+      'chmonitor',
+    ],
+    details: {
+      hostId: String(payload.hostId),
+      metric: payload.metric,
+      value: payload.value === null ? 'n/a' : String(payload.value),
+      warnThreshold:
+        payload.warnThreshold == null ? 'n/a' : String(payload.warnThreshold),
+      critThreshold:
+        payload.critThreshold == null ? 'n/a' : String(payload.critThreshold),
+      timestamp: payload.timestamp,
+    },
+  }
+
+  if (payload.runbookUrls && payload.runbookUrls.length > 0) {
+    body.description = `Runbooks:\n${payload.runbookUrls.join('\n')}`
+  }
+
+  return body
+}
+
+/**
+ * Opsgenie adapter. `buildBody` needs no config — Opsgenie auth is a header
+ * (`GenieKey <API_KEY>`) applied by the dispatch layer, never part of the
+ * body.
+ */
+export const opsgenieAdapter: NotificationAdapter = {
+  id: 'opsgenie',
+  detect: (url: string) => /(?:^|\/\/)api(?:\.eu)?\.opsgenie\.com\//i.test(url),
+  buildBody: (payload: AlertPayload) => buildOpsgenieBody(payload),
+}

--- a/apps/dashboard/src/lib/health/opsgenie-dispatch.test.ts
+++ b/apps/dashboard/src/lib/health/opsgenie-dispatch.test.ts
@@ -1,0 +1,136 @@
+import type { AlertPayload } from './adapters/types'
+
+import { buildOpsgenieBody } from './adapters/opsgenie'
+import { dispatchOpsgenie } from './opsgenie-dispatch'
+import { describe, expect, test } from 'bun:test'
+
+// Injected DNS resolver so tests never hit the network — same pattern as
+// routes/api/v1/health/webhook.test.ts.
+const resolvePublic = async () => ['93.184.216.34']
+const resolvePrivate = async () => ['10.0.0.5']
+
+/** A fetch stub that records the request it was called with. */
+function stubFetch(response: Response = new Response('ok', { status: 200 })) {
+  const calls: { url: string; init: RequestInit }[] = []
+  const fetchImpl = (async (input: unknown, init?: RequestInit) => {
+    calls.push({ url: String(input), init: init ?? {} })
+    return response
+  }) as unknown as typeof fetch
+  return { calls, fetchImpl }
+}
+
+function throwingFetch(err: unknown) {
+  return (async () => {
+    throw err
+  }) as unknown as typeof fetch
+}
+
+const CRITICAL: AlertPayload = {
+  severity: 'critical',
+  hostLabel: 'prod-1',
+  hostId: 2,
+  metric: 'failed-mutations',
+  value: 7,
+  warnThreshold: 1,
+  critThreshold: 5,
+  title: 'Failed mutations',
+  label: '7 failed mutations',
+  timestamp: '2026-07-02T10:00:00.000Z',
+}
+
+const RECOVERY: AlertPayload = {
+  ...CRITICAL,
+  severity: 'recovery',
+  value: 0,
+  label: 'recovered',
+}
+
+describe('dispatchOpsgenie — create (trigger)', () => {
+  test('POSTs to the US base URL with the GenieKey header and the built body', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const ok = await dispatchOpsgenie(
+      CRITICAL,
+      { apiKey: 'test-key', region: 'us' },
+      { resolveHostAddresses: resolvePublic, fetchImpl }
+    )
+
+    expect(ok).toBe(true)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe('https://api.opsgenie.com/v2/alerts')
+    expect(calls[0].init.method).toBe('POST')
+    expect(
+      (calls[0].init.headers as Record<string, string>).Authorization
+    ).toBe('GenieKey test-key')
+    expect(JSON.parse(String(calls[0].init.body))).toEqual(
+      buildOpsgenieBody(CRITICAL)
+    )
+  })
+
+  test('uses the EU base URL when region is "eu"', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    await dispatchOpsgenie(
+      CRITICAL,
+      { apiKey: 'test-key', region: 'eu' },
+      { resolveHostAddresses: resolvePublic, fetchImpl }
+    )
+
+    expect(calls[0].url).toBe('https://api.eu.opsgenie.com/v2/alerts')
+  })
+
+  test('returns false when Opsgenie responds non-OK, without throwing', async () => {
+    const { fetchImpl } = stubFetch(new Response('nope', { status: 401 }))
+    const ok = await dispatchOpsgenie(
+      CRITICAL,
+      { apiKey: 'bad-key', region: 'us' },
+      { resolveHostAddresses: resolvePublic, fetchImpl }
+    )
+
+    expect(ok).toBe(false)
+  })
+})
+
+describe('dispatchOpsgenie — close (recovery)', () => {
+  test('POSTs to the alias close endpoint with identifierType=alias', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const ok = await dispatchOpsgenie(
+      RECOVERY,
+      { apiKey: 'test-key', region: 'us' },
+      { resolveHostAddresses: resolvePublic, fetchImpl }
+    )
+
+    expect(ok).toBe(true)
+    expect(calls[0].url).toBe(
+      'https://api.opsgenie.com/v2/alerts/chmonitor%3A2%3Afailed-mutations/close?identifierType=alias'
+    )
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({
+      source: 'chmonitor',
+      note: buildOpsgenieBody(RECOVERY).message,
+    })
+  })
+})
+
+describe('dispatchOpsgenie — fail-open', () => {
+  test('blocks an SSRF-unsafe resolution and returns false without fetching', async () => {
+    const { calls, fetchImpl } = stubFetch()
+    const ok = await dispatchOpsgenie(
+      CRITICAL,
+      { apiKey: 'test-key', region: 'us' },
+      { resolveHostAddresses: resolvePrivate, fetchImpl }
+    )
+
+    expect(ok).toBe(false)
+    expect(calls).toHaveLength(0)
+  })
+
+  test('returns false, never throws, when the fetch itself rejects', async () => {
+    const fetchImpl = throwingFetch(new Error('network down'))
+
+    await expect(
+      dispatchOpsgenie(
+        CRITICAL,
+        { apiKey: 'test-key', region: 'us' },
+        { resolveHostAddresses: resolvePublic, fetchImpl }
+      )
+    ).resolves.toBe(false)
+  })
+})

--- a/apps/dashboard/src/lib/health/opsgenie-dispatch.ts
+++ b/apps/dashboard/src/lib/health/opsgenie-dispatch.ts
@@ -1,0 +1,103 @@
+/**
+ * Opsgenie dispatch (transport layer).
+ *
+ * Applies the `Authorization: GenieKey <API_KEY>` header and the
+ * region-appropriate Alert API base URL, then POSTs a create request on
+ * trigger (`warning`/`critical`) or a close-alias request on `recovery`. The
+ * pure body builder (`adapters/opsgenie.ts`) stays network-free; this module
+ * is the only place that actually talks to Opsgenie — mirrors the
+ * separation PagerDuty documents (auth/transport belongs to the dispatch
+ * layer, not the adapter).
+ *
+ * Every outbound URL is checked with `validateHostUrl` first, the same SSRF
+ * guard every other outbound fetch in this repo goes through
+ * (`routes/api/v1/health/webhook.ts`, browser-connections) — even though the
+ * host here is fixed by `region`, not caller input.
+ *
+ * Never throws: a delivery failure must not abort the health sweep loop
+ * (fail-open, matching `postWebhook` in `server-sweep.ts`).
+ */
+
+import type { ResolveHostAddresses } from '@/lib/browser-connections/host-url'
+import type { AlertPayload } from './adapters/types'
+import type { OpsgenieRegion } from './server-alert-config'
+
+import { buildOpsgenieBody, opsgenieAlias } from './adapters/opsgenie'
+import { error } from '@chm/logger'
+import { validateHostUrl } from '@/lib/browser-connections/host-url'
+
+export interface OpsgenieDispatchConfig {
+  apiKey: string
+  region: OpsgenieRegion
+}
+
+/** Injectable dependencies (tests override DNS resolution + fetch). */
+export interface OpsgenieDispatchDeps {
+  resolveHostAddresses?: ResolveHostAddresses
+  fetchImpl?: typeof fetch
+}
+
+function opsgenieBaseUrl(region: OpsgenieRegion): string {
+  return region === 'eu'
+    ? 'https://api.eu.opsgenie.com/v2/alerts'
+    : 'https://api.opsgenie.com/v2/alerts'
+}
+
+/**
+ * Dispatch one alert to Opsgenie: creates an alert for `warning`/`critical`,
+ * closes the alias for `recovery`. Returns whether the request succeeded;
+ * never throws.
+ */
+export async function dispatchOpsgenie(
+  payload: AlertPayload,
+  config: OpsgenieDispatchConfig,
+  deps: OpsgenieDispatchDeps = {}
+): Promise<boolean> {
+  try {
+    const baseUrl = opsgenieBaseUrl(config.region)
+    const isClose = payload.severity === 'recovery'
+    const url = isClose
+      ? `${baseUrl}/${encodeURIComponent(opsgenieAlias(payload))}/close?identifierType=alias`
+      : baseUrl
+
+    const ssrfError = await validateHostUrl(url, deps.resolveHostAddresses)
+    if (ssrfError) {
+      error(
+        '[health] Opsgenie dispatch blocked an unsafe URL',
+        new Error(ssrfError)
+      )
+      return false
+    }
+
+    const body = isClose
+      ? { source: 'chmonitor', note: buildOpsgenieBody(payload).message }
+      : buildOpsgenieBody(payload)
+
+    const doFetch = deps.fetchImpl ?? fetch
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 10_000)
+    try {
+      const res = await doFetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `GenieKey ${config.apiKey}`,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      })
+      if (!res.ok) {
+        error(
+          '[health] Opsgenie dispatch returned non-OK status',
+          new Error(`Status ${res.status}`)
+        )
+      }
+      return res.ok
+    } finally {
+      clearTimeout(timeout)
+    }
+  } catch (err) {
+    error('[health] Opsgenie dispatch failed', err as Error)
+    return false
+  }
+}

--- a/apps/dashboard/src/lib/health/server-alert-config.test.ts
+++ b/apps/dashboard/src/lib/health/server-alert-config.test.ts
@@ -1,4 +1,7 @@
-import { getServerAlertConfig } from './server-alert-config'
+import {
+  getServerAlertConfig,
+  getServerOpsgenieConfig,
+} from './server-alert-config'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 
 const ENV_KEYS = [
@@ -141,5 +144,61 @@ describe('getServerAlertConfig', () => {
       minSeverity: 'critical',
       browserNotificationsEnabled: false,
     })
+  })
+})
+
+const OPSGENIE_ENV_KEYS = [
+  'HEALTH_ALERT_OPSGENIE_API_KEY',
+  'HEALTH_ALERT_OPSGENIE_REGION',
+] as const
+
+describe('getServerOpsgenieConfig', () => {
+  let saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const key of OPSGENIE_ENV_KEYS) {
+      saved[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    for (const key of OPSGENIE_ENV_KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = saved[key]
+      }
+    }
+    saved = {}
+  })
+
+  it('returns null when no API key is configured (fail-open)', () => {
+    expect(getServerOpsgenieConfig()).toBeNull()
+  })
+
+  it('returns null when the API key is only whitespace', () => {
+    process.env.HEALTH_ALERT_OPSGENIE_API_KEY = '   '
+    expect(getServerOpsgenieConfig()).toBeNull()
+  })
+
+  it('trims the API key and defaults region to "us"', () => {
+    process.env.HEALTH_ALERT_OPSGENIE_API_KEY = '  my-key  '
+    expect(getServerOpsgenieConfig()).toEqual({
+      apiKey: 'my-key',
+      region: 'us',
+    })
+  })
+
+  it('reads region "eu" case-insensitively', () => {
+    process.env.HEALTH_ALERT_OPSGENIE_API_KEY = 'my-key'
+    process.env.HEALTH_ALERT_OPSGENIE_REGION = 'EU'
+    expect(getServerOpsgenieConfig()?.region).toBe('eu')
+  })
+
+  it('falls back to "us" for an invalid region value', () => {
+    process.env.HEALTH_ALERT_OPSGENIE_API_KEY = 'my-key'
+    process.env.HEALTH_ALERT_OPSGENIE_REGION = 'apac'
+    expect(getServerOpsgenieConfig()?.region).toBe('us')
   })
 })

--- a/apps/dashboard/src/lib/health/server-alert-config.ts
+++ b/apps/dashboard/src/lib/health/server-alert-config.ts
@@ -103,6 +103,41 @@ export function getServerThresholdOverrides(
   return out
 }
 
+/** Opsgenie region — selects which Alert API base host the dispatch layer uses. */
+export type OpsgenieRegion = 'us' | 'eu'
+
+/** Resolved server-side Opsgenie config: the API key plus which region to target. */
+export interface ServerOpsgenieConfig {
+  apiKey: string
+  region: OpsgenieRegion
+}
+
+/**
+ * Server-side Opsgenie config, sourced from environment variables:
+ *
+ *   - HEALTH_ALERT_OPSGENIE_API_KEY → apiKey (default '')
+ *   - HEALTH_ALERT_OPSGENIE_REGION  → region ('us' | 'eu', default 'us')
+ *
+ * Returns null when no API key is configured — Opsgenie delivery is opt-in
+ * and fails open (no key ⇒ the sweep skips the Opsgenie dispatch entirely).
+ *
+ * NOTE: exposed as a companion function (matching
+ * {@link getServerThresholdOverrides}) rather than folded into
+ * {@link getServerAlertConfig}'s return value — that shape is shared with the
+ * client's localStorage settings and asserted deeply by its tests, and an
+ * Opsgenie API key is a server-only secret that must never round-trip
+ * through it.
+ */
+export function getServerOpsgenieConfig(): ServerOpsgenieConfig | null {
+  const apiKey = process.env.HEALTH_ALERT_OPSGENIE_API_KEY?.trim() || ''
+  if (!apiKey) return null
+  const region: OpsgenieRegion =
+    process.env.HEALTH_ALERT_OPSGENIE_REGION?.trim().toLowerCase() === 'eu'
+      ? 'eu'
+      : 'us'
+  return { apiKey, region }
+}
+
 /** Default cron re-notify cooldown, in minutes, when the env var is unset. */
 export const DEFAULT_ALERT_COOLDOWN_MINUTES = 60
 

--- a/apps/dashboard/src/lib/health/server-sweep.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.ts
@@ -8,6 +8,7 @@ import type {
   AlertRuleSeverity,
 } from '@/lib/alerting/rule-registry'
 import type { AlertPayload, PagerDutyEventBody } from './adapters'
+import type { AlertSeverity } from './adapters/types'
 import type { AlertEventRecord } from './alert-history-store'
 import type { AlertRoute } from './alert-routing'
 import type { AlertDecision } from './alert-state-store'
@@ -20,6 +21,7 @@ import {
   resolveTargets,
 } from './alert-routing'
 import { alertStateStore, evaluateAlert } from './alert-state-store'
+import { dispatchOpsgenie } from './opsgenie-dispatch'
 import {
   getPagerDutyFallbackRoutingKey,
   PAGERDUTY_EVENTS_API_URL,
@@ -27,6 +29,7 @@ import {
 import {
   getServerAlertConfig,
   getServerAlertCooldownMs,
+  getServerOpsgenieConfig,
   getServerThresholdOverrides,
 } from './server-alert-config'
 import { fetchData, getClickHouseConfigs } from '@chm/clickhouse-client'
@@ -338,9 +341,13 @@ export async function runHealthSweep(): Promise<SweepSummary> {
   const webhookConfigured = Boolean(settings.webhookUrl)
   const routes: AlertRoute[] = await listRoutes(SWEEP_ROUTING_OWNER_ID)
   const pagerDutyFallbackKey = getPagerDutyFallbackRoutingKey()
+  const opsgenieConfig = getServerOpsgenieConfig()
   const canDispatch =
     settings.webhookEnabled &&
-    (webhookConfigured || routes.length > 0 || Boolean(pagerDutyFallbackKey))
+    (webhookConfigured ||
+      routes.length > 0 ||
+      Boolean(pagerDutyFallbackKey) ||
+      Boolean(opsgenieConfig))
   const minRank = SEVERITY_ORDER[settings.minSeverity]
   const cooldownMs = getServerAlertCooldownMs()
 
@@ -390,6 +397,9 @@ export async function runHealthSweep(): Promise<SweepSummary> {
     severity: Severity
     value: number | null
     label: string
+    /** Thresholds that classified this finding, when known (base rules only). */
+    warnThreshold?: number | null
+    critThreshold?: number | null
   }): Promise<void> {
     const {
       hostId,
@@ -400,6 +410,8 @@ export async function runHealthSweep(): Promise<SweepSummary> {
       severity,
       value,
       label,
+      warnThreshold,
+      critThreshold,
     } = params
     const effective: Severity =
       SEVERITY_ORDER[severity] >= minRank ? severity : 'ok'
@@ -551,11 +563,62 @@ export async function runHealthSweep(): Promise<SweepSummary> {
         }
       }
 
+      // Opsgenie (plan 26): a single global env-configured destination (no
+      // per-route resolution yet, unlike webhook/PagerDuty targets above) —
+      // fires whenever `opsgenieConfig` is set. `dispatchOpsgenie` never
+      // throws (fails open), matching every other channel here.
+      if (opsgenieConfig) {
+        const alertSeverity: AlertSeverity =
+          decision.kind === 'recovery'
+            ? 'recovery'
+            : (effective as 'warning' | 'critical')
+        const ok = await dispatchOpsgenie(
+          {
+            severity: alertSeverity,
+            hostLabel: name,
+            hostId,
+            metric: ruleId,
+            value,
+            warnThreshold,
+            critThreshold,
+            title: ruleTitle,
+            label,
+            timestamp: new Date().toISOString(),
+          },
+          opsgenieConfig
+        )
+        if (ok) anyDelivered = true
+
+        try {
+          await recordAlertEvent(
+            buildAlertEventRecord({
+              hostId,
+              hostLabel: name,
+              ruleId,
+              decision,
+              value,
+              delivered: ok,
+              error: ok ? undefined : 'Opsgenie dispatch failed',
+              channel: 'opsgenie',
+            })
+          )
+        } catch (err) {
+          debug(
+            `[health-sweep] alert-history record failed for host ${hostId} rule ${ruleId}`,
+            err instanceof Error ? err.message : String(err)
+          )
+        }
+      }
+
       // Persist "notified" only when there was nothing to deliver (no
       // targets at all across every channel — not a failure) or at least one
       // channel succeeded. A failed delivery with no successes leaves no
       // record, so the next sweep retries instead of suppressing.
-      if (targets.length + pagerDutyTargets.length === 0 || anyDelivered) {
+      if (
+        targets.length + pagerDutyTargets.length + (opsgenieConfig ? 1 : 0) ===
+          0 ||
+        anyDelivered
+      ) {
         commit()
         if (anyDelivered) {
           alertsDispatched++
@@ -626,6 +689,8 @@ export async function runHealthSweep(): Promise<SweepSummary> {
             value,
             ruleType: rule.type,
             label: rule.formatLabel ? rule.formatLabel(value) : String(value),
+            warnThreshold: thresholds.warning,
+            critThreshold: thresholds.critical,
           })
         }
       } catch (err) {

--- a/apps/dashboard/src/routes/api/v1/health/opsgenie-test.test.ts
+++ b/apps/dashboard/src/routes/api/v1/health/opsgenie-test.test.ts
@@ -91,7 +91,10 @@ describe('POST /api/v1/health/opsgenie-test — dispatch', () => {
 
   test('sends a real test dispatch when configured', async () => {
     process.env.HEALTH_ALERT_OPSGENIE_API_KEY = 'my-key'
-    const fetchImpl = mock(async () => new Response('ok', { status: 202 }))
+    const fetchImpl = mock(
+      async (_url: string, _init?: RequestInit) =>
+        new Response('ok', { status: 202 })
+    )
     const res = await handlePost(makeRequest(), {
       fetchImpl: fetchImpl as unknown as typeof fetch,
       resolveHostAddresses: async () => ['93.184.216.34'],
@@ -99,9 +102,9 @@ describe('POST /api/v1/health/opsgenie-test — dispatch', () => {
 
     expect(res.status).toBe(200)
     expect(fetchImpl).toHaveBeenCalledTimes(1)
-    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
+    const [url, init] = fetchImpl.mock.calls[0]
     expect(url).toBe('https://api.opsgenie.com/v2/alerts')
-    expect((init.headers as Record<string, string>).Authorization).toBe(
+    expect((init?.headers as Record<string, string>).Authorization).toBe(
       'GenieKey my-key'
     )
   })

--- a/apps/dashboard/src/routes/api/v1/health/opsgenie-test.test.ts
+++ b/apps/dashboard/src/routes/api/v1/health/opsgenie-test.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// Same auth-gate mock pattern as webhook.test.ts — see that file's comment
+// for why this mocks the full export surface of feature-permissions/server.
+let authorizeFeatureRequest = mock(
+  async (
+    _permission: unknown,
+    _request: Request,
+    _options?: { allowAgentBearerToken?: boolean }
+  ): Promise<Response | null> => null
+)
+mock.module('@/lib/feature-permissions/server', () => ({
+  getAppConfig: () => ({ authProvider: 'none' as const, features: {} }),
+  _resetAppConfigCache: () => {},
+  publicReadEnabled: () => true,
+  authorizeFeatureRequest: (
+    permission: unknown,
+    request: Request,
+    options?: { allowAgentBearerToken?: boolean }
+  ) => authorizeFeatureRequest(permission, request, options),
+}))
+
+const OPSGENIE_ENV_KEYS = [
+  'HEALTH_ALERT_OPSGENIE_API_KEY',
+  'HEALTH_ALERT_OPSGENIE_REGION',
+] as const
+
+const { __handleGetForTests: handleGet, __handlePostForTests: handlePost } =
+  await import('./opsgenie-test')
+
+const originalEnv: Record<string, string | undefined> = {}
+for (const key of OPSGENIE_ENV_KEYS) originalEnv[key] = process.env[key]
+
+beforeEach(() => {
+  authorizeFeatureRequest = mock(async () => null)
+  for (const key of OPSGENIE_ENV_KEYS) delete process.env[key]
+})
+
+function makeRequest(): Request {
+  return new Request('https://dash.example.com/api/v1/health/opsgenie-test', {
+    method: 'POST',
+  })
+}
+
+describe('GET /api/v1/health/opsgenie-test', () => {
+  test('reports not configured when no API key is set', async () => {
+    const res = await handleGet()
+    const body = (await res.json()) as { configured: boolean; region: null }
+    expect(body).toEqual({ configured: false, region: null })
+  })
+
+  test('reports configured with region when an API key is set', async () => {
+    process.env.HEALTH_ALERT_OPSGENIE_API_KEY = 'my-key'
+    process.env.HEALTH_ALERT_OPSGENIE_REGION = 'eu'
+    const res = await handleGet()
+    const body = (await res.json()) as {
+      configured: boolean
+      region: string
+    }
+    expect(body).toEqual({ configured: true, region: 'eu' })
+  })
+})
+
+describe('POST /api/v1/health/opsgenie-test — auth gate', () => {
+  test('anonymous is blocked, no egress', async () => {
+    process.env.HEALTH_ALERT_OPSGENIE_API_KEY = 'my-key'
+    authorizeFeatureRequest = mock(
+      async () => new Response(null, { status: 401 })
+    )
+    const fetchImpl = mock(async () => new Response('ok', { status: 200 }))
+    const res = await handlePost(makeRequest(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    expect(res.status).toBe(401)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/v1/health/opsgenie-test — dispatch', () => {
+  test('400s when Opsgenie is not configured', async () => {
+    const fetchImpl = mock(async () => new Response('ok', { status: 200 }))
+    const res = await handlePost(makeRequest(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      resolveHostAddresses: async () => ['93.184.216.34'],
+    })
+
+    expect(res.status).toBe(400)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  test('sends a real test dispatch when configured', async () => {
+    process.env.HEALTH_ALERT_OPSGENIE_API_KEY = 'my-key'
+    const fetchImpl = mock(async () => new Response('ok', { status: 202 }))
+    const res = await handlePost(makeRequest(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      resolveHostAddresses: async () => ['93.184.216.34'],
+    })
+
+    expect(res.status).toBe(200)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://api.opsgenie.com/v2/alerts')
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      'GenieKey my-key'
+    )
+  })
+
+  test('502s when the Opsgenie request fails', async () => {
+    process.env.HEALTH_ALERT_OPSGENIE_API_KEY = 'my-key'
+    const fetchImpl = mock(async () => new Response('nope', { status: 500 }))
+    const res = await handlePost(makeRequest(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      resolveHostAddresses: async () => ['93.184.216.34'],
+    })
+
+    expect(res.status).toBe(502)
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/health/opsgenie-test.ts
+++ b/apps/dashboard/src/routes/api/v1/health/opsgenie-test.ts
@@ -1,0 +1,108 @@
+/**
+ * Opsgenie Test-Alert Endpoint
+ * GET  /api/v1/health/opsgenie-test  — is Opsgenie configured server-side?
+ * POST /api/v1/health/opsgenie-test  — send a synthetic test alert
+ *
+ * The Opsgenie API key (`HEALTH_ALERT_OPSGENIE_API_KEY`) is a server-only
+ * secret (see `server-alert-config.ts`) that must never round-trip to the
+ * browser — unlike the webhook URL (which the user types in and is proxied
+ * per-request via `/api/v1/health/webhook`), Opsgenie has no client-supplied
+ * credential. This endpoint lets the settings UI (a) show whether Opsgenie is
+ * configured and (b) fire a real test dispatch through the server's own
+ * config, without ever exposing the key.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { OpsgenieDispatchDeps } from '@/lib/health/opsgenie-dispatch'
+
+import { debug } from '@chm/logger'
+import { createErrorResponse } from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
+import { dispatchOpsgenie } from '@/lib/health/opsgenie-dispatch'
+import { getServerOpsgenieConfig } from '@/lib/health/server-alert-config'
+
+const ROUTE_CONTEXT = {
+  route: '/api/v1/health/opsgenie-test',
+  method: 'POST',
+} as const
+
+async function handleGet(): Promise<Response> {
+  const config = getServerOpsgenieConfig()
+  return Response.json({
+    configured: config !== null,
+    region: config?.region ?? null,
+  })
+}
+
+async function handlePost(
+  request: Request,
+  deps: OpsgenieDispatchDeps = {}
+): Promise<Response> {
+  // Write gate, same posture as /api/v1/health/webhook — this triggers a
+  // real outbound Opsgenie dispatch, so anonymous callers must not reach it.
+  const permissionResponse = await authorizeFeatureRequest(
+    { feature: 'settings', defaultAccess: 'authenticated', operation: 'write' },
+    request,
+    { allowAgentBearerToken: true }
+  )
+  if (permissionResponse) return permissionResponse
+
+  const config = getServerOpsgenieConfig()
+  if (!config) {
+    return createErrorResponse(
+      {
+        type: ApiErrorType.ValidationError,
+        message:
+          'Opsgenie is not configured. Set HEALTH_ALERT_OPSGENIE_API_KEY on the server.',
+      },
+      400,
+      ROUTE_CONTEXT
+    )
+  }
+
+  debug('[POST /api/v1/health/opsgenie-test] Sending test alert')
+
+  const ok = await dispatchOpsgenie(
+    {
+      severity: 'warning',
+      hostLabel: 'test-host',
+      hostId: 0,
+      metric: 'test',
+      value: 0,
+      warnThreshold: null,
+      critThreshold: null,
+      title: 'Test Alert',
+      label: 'This is a test alert from chmonitor',
+      timestamp: new Date().toISOString(),
+    },
+    config,
+    deps
+  )
+
+  if (!ok) {
+    return createErrorResponse(
+      {
+        type: ApiErrorType.NetworkError,
+        message: 'Opsgenie test alert failed. Check the server logs.',
+      },
+      502,
+      ROUTE_CONTEXT
+    )
+  }
+
+  return Response.json({ success: true }, { status: 200 })
+}
+
+export const Route = createFileRoute('/api/v1/health/opsgenie-test')({
+  server: {
+    handlers: {
+      GET: async () => handleGet(),
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})
+
+// Exported for unit tests only.
+export { handleGet as __handleGetForTests, handlePost as __handlePostForTests }


### PR DESCRIPTION
## Summary

Adds an Opsgenie notification adapter with parity to the existing Slack/Discord/Telegram/PagerDuty pattern (plan 26):

- **Pure adapter** (`apps/dashboard/src/lib/health/adapters/opsgenie.ts`): `buildOpsgenieBody(payload)` builds an Opsgenie Alert API v2 create-alert body — severity → priority (`critical→P1`, `warning→P2`), a stable `alias` (`chmonitor:{hostId}:{metric}`) so repeat firings collapse to one alert, host+metric tags, string-only `details`, runbook links in `description`. `opsgenieAdapter.detect` matches `api.opsgenie.com` / `api.eu.opsgenie.com`. No network/auth in this layer.
- **Registry**: `opsgenieAdapter` registered in `adapters/index.ts` (`ADAPTERS`, before the generic fallback); types/functions re-exported.
- **Server config**: `getServerOpsgenieConfig()` in `server-alert-config.ts` reads `HEALTH_ALERT_OPSGENIE_API_KEY` (empty ⇒ `null`, fail-open) and `HEALTH_ALERT_OPSGENIE_REGION` (`us`/`eu`, default `us`). `AlertSettings` shape unchanged.
- **Dispatch** (`opsgenie-dispatch.ts`): POSTs create on trigger / closes the alias on recovery, with the `GenieKey` auth header and region-correct base URL, through the same SSRF guard (`validateHostUrl`) other outbound fetches use. Never throws — fails open into the sweep.
- **Sweep wiring** (`server-sweep.ts`): the per-finding dedup decision now fans out to webhook *and* Opsgenie independently; each channel's failure is isolated, and "notified" is only persisted once at least one channel delivered (so a fully-failed sweep still retries).
- **Settings UI**: `health-settings-dialog.tsx` gets an Opsgenie section with a configured/region status badge and a "Send test" button, backed by a new `GET`/`POST /api/v1/health/opsgenie-test` route (POST write-gated like the webhook proxy).

### Note on the settings-UI interpretation

The plan's done-criteria says "Opsgenie **key field**." The Opsgenie API key
is documented (`server-alert-config.ts`) as a server-only secret that must
never round-trip to the browser — a localStorage-backed key input (like the
webhook URL field) would either be non-functional or a secret-leak path given
that design. Implemented instead as a read-only configured/region status +
a server-side test-send button that exercises the server's own env-configured
key. Flagging this explicitly rather than silently deviating from the
checklist wording.

### Note on `server-sweep.ts`

This branch also carries the (uncommitted, pre-existing) Opsgenie dispatch
wiring into `runHealthSweep` — split into its own commit since other agents
are working on `server-sweep.ts` / `server-alert-config.ts` in parallel for
plan 30's routing model. Expect a rebase.

### Known coverage gap

`runHealthSweep`'s new `if (opsgenieConfig)` fan-out branch isn't covered by
an integration test — `health-sweep.test.ts` only tests `CRON_SECRET` auth,
and the pre-existing webhook fan-out isn't integration-tested there either.
The Opsgenie dispatch *unit* itself is fully covered by `opsgenie-dispatch.test.ts`.

## Verification

```
$ cd apps/dashboard && bun run type-check
$ tsc --noEmit
EXIT:0

$ cd apps/dashboard && bun run build
... (prerender all routes) ...
EXIT:0

$ cd apps/dashboard && bun test src/lib/health/adapters --isolate
37 pass, 0 fail, 6 snapshots, 95 expect() calls

$ cd apps/dashboard && bun test src/lib/health/server-alert-config.test.ts --isolate
18 pass, 0 fail, 21 expect() calls

$ bun run lint   # (root — `cd apps/dashboard && bun run lint` has no such script;
                 #  root biome lint covers the whole monorepo including apps/dashboard)
Checked 1945 files in 1060ms. No fixes applied.
```

Additional tests run (not in the plan's block, covering the new UI/route + dispatch wiring):
- `bun test src/routes/api/v1/health/opsgenie-test.test.ts --isolate` — 6 pass
- `bun test src/lib/health/opsgenie-dispatch.test.ts src/routes/api/cron/__tests__/health-sweep.test.ts --isolate` — 18 pass

## Test plan
- [x] type-check, build, targeted unit tests, lint all green
- [x] `buildOpsgenieBody` snapshot + severity/alias/tags/details/description tests
- [x] `getServerOpsgenieConfig` env-reader tests (empty/whitespace/region normalization)
- [x] Opsgenie dispatch transport tests (create/close routing, SSRF guard, auth header, failure handling)
- [x] New settings-route tests (status GET, auth-gated test-send POST, 400/502 paths)
- [ ] Manual: set `HEALTH_ALERT_OPSGENIE_API_KEY` locally and confirm "Send test" creates a real Opsgenie alert (not run — no sandbox API key available)

https://claude.ai/code/session_01XpfaNdJZh4Rtr6cQm4DYqa