### PR TITLE
feat(docs): blog/content engine (plan 67)

### DIFF
--- a/apps/blog/CONTENT-CALENDAR.md
+++ b/apps/blog/CONTENT-CALENDAR.md
@@ -1,0 +1,64 @@
+# Content calendar
+
+The plan-of-record for `blog.chmonitor.dev` cadence: **2 posts/month minimum**,
+mixing four post types. This keeps a solo author sustainable — release posts and
+how-tos are the cheapest to produce (they document work that already shipped),
+troubleshooting and case-study posts are the highest-SEO-value but need more
+lead time.
+
+## How to use this file
+
+1. Pick the next unstarted week's row.
+2. Copy the matching template from `apps/blog/templates/` into
+   `apps/blog/src/content/blog/<slug>.md` with `draft: true`.
+3. Write the post. Every factual/feature claim must pass the template's
+   **claim-verification checklist** before `draft` flips to `false`.
+4. Add the docs cross-link in both directions (post → docs page it explains
+   deeper, docs page → post for the narrative version) per the convention in
+   `apps/blog/README.md`.
+5. Run `bun run sync-latest-posts` from `apps/blog/` (see
+   `scripts/sync-latest-posts.mjs`) to refresh the landing footer's "Latest
+   from the blog" widget, then commit both together.
+6. Mark the row below `done` and move on.
+
+Release posts are the exception to "pick the next row on schedule" — scaffold
+them on demand with `bun run release-to-post <tag>` (from `apps/blog/`) right
+after a GitHub release ships, then slot the draft into whichever week is next.
+
+## Status legend
+
+`planned` → not started · `drafting` → post exists as `draft: true` · `done` →
+published (`draft: false`, merged to main)
+
+## The 12 weeks
+
+| Week | Type | Working title | Target keyword | Cross-link (docs page) | Status |
+|---|---|---|---|---|---|
+| 1 | release | chmonitor v0.3 — a full rebuild | clickhouse monitoring dashboard | `/guide/getting-started` | done (`chmonitor-v0-3.md`, published 2026-06-29) |
+| 2 | how-to | Alerting to Slack and Discord | clickhouse alerting webhook | `/guide/features/health` | done (`alerting-to-slack-and-discord.md`) |
+| 3 | how-to | Ask your cluster anything: the AI agent over MCP | clickhouse ai agent mcp | `/guide/ai-agent` | planned |
+| 4 | troubleshooting | Why is my ClickHouse replication lagging? | clickhouse replication lag | `/guide/features` (replication section) | planned |
+| 5 | how-to | The query advisor: DDL recommendations you review, not that run themselves | clickhouse query optimization advisor | `/guide/ai-agent` (advisor tools) | planned |
+| 6 | case-study | Diagnosing a slow-query regression start to finish | clickhouse slow query diagnosis | `/guide/features` | planned |
+| 7 | troubleshooting | Reading `system.merges` when merges pile up | clickhouse merges stuck | `/guide/features` | planned |
+| 8 | how-to | Self-hosting chmonitor on Docker in five minutes | self-host clickhouse dashboard docker | `/operate/deploy/docker` | planned |
+| 9 | how-to | Self-hosting chmonitor on Kubernetes | clickhouse monitoring kubernetes | `/operate/deploy/k8s` | planned |
+| 10 | troubleshooting | Debugging `system.errors` spikes | clickhouse system errors | `/guide/features/health` | planned |
+| 11 | case-study | Capacity planning with the TTL and disk-growth advisor | clickhouse capacity planning ttl | `/guide/ai-agent` (advisor tools) | planned |
+| 12 | release | (scaffold from the next GitHub release when it ships) | — | `/reference/releases` | planned |
+
+## Post-type mix (per 12-week cycle)
+
+- Release: 2 (as releases actually ship — do not invent a cadence releases
+  don't have)
+- How-to: 5
+- Troubleshooting: 3
+- Case study: 2
+
+## Ownership
+
+One author, part-time. The templates + `release-to-post.mjs` exist specifically
+so this cadence survives without a dedicated content team — a release post
+should take under an hour once the release itself is done, because the script
+pre-fills tag/date/changelog links and the author only writes the "what it
+means for you" framing plus runs the verification checklist.

--- a/apps/blog/README.md
+++ b/apps/blog/README.md
@@ -49,6 +49,36 @@ Markdown (Astro renders raw HTML in `.md`):
 Launch films live in `chmonitor/launch/<version>/` and are copied into
 `public/posts/<version>/` for the release post.
 
+## Content engine
+
+- **Calendar**: `CONTENT-CALENDAR.md` is the plan-of-record for cadence (12
+  weeks, mixing release/how-to/troubleshooting/case-study posts). Update its
+  status column as posts move from planned → drafting → done.
+- **Templates**: `templates/*.md` (one per post type) live outside
+  `src/content/blog/` so the content-collection glob never picks them up as
+  posts. Each ends with a claim-verification checklist — every feature/config
+  claim in a post must be checked against merged code before `draft: false`.
+- **Docs↔blog cross-linking**: a how-to/troubleshooting/case-study post links
+  the canonical docs page it walks through (`https://docs.chmonitor.dev/<slug>`,
+  matching `docs/content/**` paths 1:1); the docs page links back with a
+  `[Post title](https://blog.chmonitor.dev/<slug>/)` reference. Bidirectional
+  by convention — see `alerting-to-slack-and-discord.md` ↔
+  `docs/content/guide/features/health.mdx` for the reference pair.
+- **RSS**: `src/pages/rss.xml.ts` (via `@astrojs/rss`) builds `/rss.xml` from
+  the same content collection as the post list; linked from `Base.astro`'s
+  `<head>` and the footer.
+- **Release → draft post**: `bun run release-to-post <tag>` (fetches via `gh
+  release view`, or `-- --from-file <json>` for offline/CI use) scaffolds a
+  `draft: true` post from `templates/release-post.md`. It never publishes —
+  a human still runs the claim-verification checklist and flips `draft` to
+  `false`.
+- **Landing footer widget**: `apps/landing` is a separate Astro app with its
+  own CI job, so it can't reach into this app's content collection at build
+  time. `bun run sync-latest-posts` regenerates a committed snapshot at
+  `apps/landing/src/data/latest-posts.json` (published, non-draft posts,
+  newest first) that `Footer.astro` renders as "Latest from the blog". Run it
+  after publishing and commit the snapshot alongside the post.
+
 ## Deploy
 
 ```bash

--- a/apps/blog/bun.lock
+++ b/apps/blog/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "blog",
       "dependencies": {
+        "@astrojs/rss": "^4.0.12",
         "@astrojs/sitemap": "^3.3.0",
         "astro": "^7.0.0",
       },
@@ -43,6 +44,8 @@
     "@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.3.2", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.0", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "satteri": "^0.9.1" } }, "sha512-feXuUPy41gVfeM7EHT1ciUim8ozGr+YHXab9uUBc1Hk8y60DQosO8ldL+AoPXnCAoGj1OChwHfvXmmJ6XVnY9A=="],
 
     "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
+
+    "@astrojs/rss": ["@astrojs/rss@4.0.19", "", { "dependencies": { "fast-xml-parser": "^5.5.7", "piccolore": "^0.1.3", "zod": "^4.3.6" } }, "sha512-e+z5wYeYtffQdHQO8c2tkSd2JEBdAuRXJV4ZEU5IxkYeE6e39woDd7nw1PH1Kk2tEYNCYuKdylnnbhGmt61awA=="],
 
     "@astrojs/sitemap": ["@astrojs/sitemap@3.7.3", "", { "dependencies": { "sitemap": "^9.0.0", "stream-replace-string": "^2.0.0", "zod": "^4.3.6" } }, "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA=="],
 
@@ -212,6 +215,8 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
+    "@nodable/entities": ["@nodable/entities@2.2.0", "", {}, "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg=="],
+
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
@@ -326,6 +331,8 @@
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
+    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
+
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
@@ -418,6 +425,10 @@
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.2.1", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.9.3", "", { "dependencies": { "@nodable/entities": "^2.2.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^1.0.1", "path-expression-matcher": "^1.5.0", "strnum": "^2.4.1", "xml-naming": "^0.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "flattie": ["flattie@1.1.1", "", {}, "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="],
@@ -459,6 +470,8 @@
     "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
+    "is-unsafe": ["is-unsafe@1.0.1", "", {}, "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA=="],
 
     "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
@@ -550,6 +563,8 @@
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.6.1", "", {}, "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ=="],
+
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
@@ -613,6 +628,8 @@
     "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "strnum": ["strnum@2.4.1", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg=="],
 
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
@@ -679,6 +696,8 @@
     "wrangler": ["wrangler@4.106.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260630.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260630.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260630.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-b6EVbsvbmAUY4bUQXT3+f8oFP8x+J5rEa5z3Akeh+6vyKiN4x8+PyZ53DPpnqdxhIihhq/a00Yq5chGJ19QXBQ=="],
 
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
 
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -9,9 +9,12 @@
     "build": "astro build",
     "preview": "astro preview",
     "build:og": "bun run scripts/build-og.ts",
+    "release-to-post": "bun run scripts/release-to-post.mjs",
+    "sync-latest-posts": "bun run scripts/sync-latest-posts.mjs",
     "cf:deploy": "wrangler deploy"
   },
   "dependencies": {
+    "@astrojs/rss": "^4.0.12",
     "@astrojs/sitemap": "^3.3.0",
     "astro": "^7.0.0"
   },

--- a/apps/blog/scripts/release-to-post.mjs
+++ b/apps/blog/scripts/release-to-post.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Scaffolds a DRAFT release blog post from a GitHub release.
+//
+// Usage (from apps/blog/):
+//   bun run release-to-post <tag>                        # fetch via `gh` CLI
+//   bun run release-to-post <tag> -- --from-file f.json   # offline/test input
+//
+// This never publishes anything — it writes src/content/blog/<slug>.md with
+// `draft: true` and leaves the claim-verification checklist comment intact,
+// exactly like copying templates/release-post.md by hand would. A human must
+// review, verify every claim against the code/changelog, remove the checklist
+// comment, and flip draft to false before it goes live.
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const APP_ROOT = join(__dirname, '..')
+const TEMPLATE_PATH = join(APP_ROOT, 'templates', 'release-post.md')
+const POSTS_DIR = join(APP_ROOT, 'src', 'content', 'blog')
+
+function parseArgs(argv) {
+  const tag = argv.find((a) => !a.startsWith('--'))
+  const fileFlagIndex = argv.indexOf('--from-file')
+  const fromFile = fileFlagIndex >= 0 ? argv[fileFlagIndex + 1] : null
+  if (!tag) {
+    console.error('Usage: bun run release-to-post <tag> [-- --from-file <path>]')
+    process.exit(1)
+  }
+  return { tag, fromFile }
+}
+
+/** Fetch release metadata: from a JSON file (offline/test) or the `gh` CLI. */
+function loadRelease(tag, fromFile) {
+  if (fromFile) {
+    return JSON.parse(readFileSync(fromFile, 'utf8'))
+  }
+  try {
+    const json = execFileSync(
+      'gh',
+      ['release', 'view', tag, '--json', 'tagName,name,body,publishedAt,url'],
+      { encoding: 'utf8' }
+    )
+    return JSON.parse(json)
+  } catch (err) {
+    console.error(
+      `Failed to fetch release "${tag}" via \`gh release view\`. ` +
+        `Pass --from-file <path> with {tagName, name, body, publishedAt, url} to run offline.\n${err.message}`
+    )
+    process.exit(1)
+  }
+}
+
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+/** First non-empty line of the release body, used as a rough description seed. */
+function firstLine(body) {
+  const line = (body ?? '').split('\n').find((l) => l.trim().length > 0)
+  return line ? line.trim().replace(/^#+\s*/, '') : ''
+}
+
+function toIsoDate(dateString) {
+  const d = dateString ? new Date(dateString) : new Date()
+  return d.toISOString().slice(0, 10)
+}
+
+function main() {
+  const { tag, fromFile } = parseArgs(process.argv.slice(2))
+  const release = loadRelease(tag, fromFile)
+
+  const version = release.tagName ?? tag
+  const title = release.name || `chmonitor ${version}`
+  const date = toIsoDate(release.publishedAt)
+  const description = firstLine(release.body) || `What's new in chmonitor ${version}.`
+  const releaseUrl =
+    release.url ?? `https://github.com/chmonitor/chmonitor/releases/tag/${version}`
+  const slug = slugify(title) || slugify(version)
+
+  let template = readFileSync(TEMPLATE_PATH, 'utf8')
+
+  // Strip the leading scaffold-instructions comment (the block starting with
+  // "Release post template." above the frontmatter) — it's for humans copying
+  // the file by hand, not for a generated draft.
+  template = template.replace(/^<!--[\s\S]*?-->\n/, '')
+
+  template = template
+    .replace('title: "chmonitor vX.Y — <one-line theme>"', `title: "${title.replace(/"/g, "'")}"`)
+    .replace(
+      'description: "<1-2 sentence summary of what shipped, written for a SERP snippet>"',
+      `description: "${description.replace(/"/g, "'")}"`
+    )
+    .replace('date: YYYY-MM-DD', `date: ${date}`)
+    .replace('tag: Release\nversion: vX.Y', `tag: Release\nversion: ${version}\ndraft: true`)
+    .replace(
+      '[GitHub release](https://github.com/chmonitor/chmonitor/releases/tag/vX.Y)',
+      `[GitHub release](${releaseUrl})`
+    )
+
+  if (!existsSync(POSTS_DIR)) mkdirSync(POSTS_DIR, { recursive: true })
+  const outPath = join(POSTS_DIR, `${slug}.md`)
+  if (existsSync(outPath)) {
+    console.error(`${outPath} already exists — refusing to overwrite. Delete it first if intended.`)
+    process.exit(1)
+  }
+  writeFileSync(outPath, template)
+  console.log(`Draft scaffolded: ${outPath}`)
+  console.log('draft: true — review, verify every claim, then flip to false before publishing.')
+}
+
+main()

--- a/apps/blog/scripts/sync-latest-posts.mjs
+++ b/apps/blog/scripts/sync-latest-posts.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Regenerates apps/landing/src/data/latest-posts.json from the blog's own
+// content collection, so the landing footer's "Latest from the blog" widget
+// stays in sync without landing needing a cross-app build-time fetch.
+//
+// apps/blog and apps/landing are independent Astro apps built and deployed
+// separately (see .github/workflows/blog.yml / landing.yml) — landing's CI
+// job never checks out a built blog, and a build-time network fetch to
+// blog.chmonitor.dev would make landing's build depend on a live external
+// service. A committed JSON snapshot avoids both problems: run this after
+// publishing a post and commit the snapshot alongside it.
+//
+// Usage: cd apps/blog && node scripts/sync-latest-posts.mjs [--limit N]
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const BLOG_DIR = join(__dirname, '..', 'src', 'content', 'blog')
+const OUT_PATH = join(__dirname, '..', '..', 'landing', 'src', 'data', 'latest-posts.json')
+const DEFAULT_LIMIT = 5
+
+function parseFrontmatter(raw) {
+  const match = raw.match(/^---\n([\s\S]*?)\n---/)
+  if (!match) return null
+  const fm = {}
+  for (const line of match[1].split('\n')) {
+    const m = line.match(/^(\w+):\s*(.*)$/)
+    if (!m) continue
+    let [, key, value] = m
+    value = value.trim().replace(/^"(.*)"$/, '$1')
+    fm[key] = value
+  }
+  return fm
+}
+
+function main() {
+  const limitFlagIndex = process.argv.indexOf('--limit')
+  const limit =
+    limitFlagIndex >= 0 ? Number(process.argv[limitFlagIndex + 1]) : DEFAULT_LIMIT
+
+  const files = readdirSync(BLOG_DIR).filter((f) => f.endsWith('.md'))
+  const posts = files
+    .map((file) => {
+      const raw = readFileSync(join(BLOG_DIR, file), 'utf8')
+      const fm = parseFrontmatter(raw)
+      if (!fm || fm.draft === 'true') return null
+      const slug = fm.version ?? file.replace(/\.md$/, '')
+      return {
+        title: fm.title,
+        date: fm.date,
+        tag: fm.tag ?? 'Release',
+        url: `https://blog.chmonitor.dev/${slug}/`,
+      }
+    })
+    .filter(Boolean)
+    .sort((a, b) => new Date(b.date).valueOf() - new Date(a.date).valueOf())
+    .slice(0, limit)
+
+  writeFileSync(OUT_PATH, `${JSON.stringify(posts, null, 2)}\n`)
+  console.log(`Wrote ${posts.length} posts to ${OUT_PATH}`)
+}
+
+main()

--- a/apps/blog/src/components/Footer.astro
+++ b/apps/blog/src/components/Footer.astro
@@ -18,6 +18,7 @@
           <a href="https://dash.chmonitor.dev" target="_blank" rel="noopener">Dashboard</a>
           <a href="https://chmonitor.dev/changelog">Changelog</a>
           <a href="/">Blog</a>
+          <a href="/rss.xml">RSS feed</a>
         </div>
         <div class="foot-col">
           <h5>Open source</h5>

--- a/apps/blog/src/content/blog/alerting-to-slack-and-discord.md
+++ b/apps/blog/src/content/blog/alerting-to-slack-and-discord.md
@@ -1,0 +1,86 @@
+---
+title: "Alerting to Slack and Discord"
+description: "Wire chmonitor's health sweep to a Slack or Discord webhook so your team gets notified the moment a check crosses a threshold — no polling the dashboard required."
+date: 2026-07-03
+tag: How-to
+---
+
+chmonitor's `/health` page checks replication lag, failed mutations, disk usage
+and a handful of other signals on a schedule you control. Left alone, that only
+helps the person who remembers to look at the page. The health-sweep cron
+endpoint closes that gap: point it at a Slack or Discord incoming webhook and
+it posts a message whenever a check meets or exceeds a severity threshold.
+
+## Prerequisites
+
+- A chmonitor instance already connected to at least one ClickHouse host.
+- A Slack **incoming webhook URL** (Slack app → Incoming Webhooks) or a
+  Discord **channel webhook URL** (Channel Settings → Integrations →
+  Webhooks).
+- The ability to set environment variables / secrets on your deployment
+  (Cloudflare Worker secret, Docker env, or K8s Secret).
+
+## Steps
+
+### 1. Set the required secrets
+
+The cron endpoint refuses to run unless `CRON_SECRET` is set — it guards
+`/api/cron/health-sweep`, and the same endpoint also runs `retention-prune`,
+which deletes old data, so it fails closed by design.
+
+```bash
+# Cloudflare Workers
+wrangler secret put CRON_SECRET
+wrangler secret put HEALTH_ALERT_WEBHOOK_URL
+```
+
+For Docker or Kubernetes, set the same names as regular environment variables
+(`CRON_SECRET`, `HEALTH_ALERT_WEBHOOK_URL`) via your `.env` file or Secret.
+
+### 2. Enable alert dispatch
+
+```bash
+HEALTH_ALERT_ENABLED=true
+HEALTH_ALERT_MIN_SEVERITY=warning   # or "critical" to only page on the worst checks
+HEALTH_ALERT_WEBHOOK_URL=https://hooks.slack.com/services/...
+CRON_SECRET=<random-secret>
+```
+
+The same `HEALTH_ALERT_WEBHOOK_URL` works for both Slack and Discord — the
+sweep posts `{"text": "...", "content": "..."}`, and each platform reads the
+field it understands.
+
+### 3. Schedule the sweep
+
+On Cloudflare Workers, add a cron trigger in `wrangler.toml`:
+
+```toml
+[triggers]
+crons = ["*/5 * * * *"]
+```
+
+Self-hosting on Docker or Kubernetes without a Workers Cron? Call the endpoint
+from any external scheduler (a system cron job, GitHub Actions schedule, etc.)
+with the same `Authorization` header shown below.
+
+### 4. Call it manually to test
+
+```bash
+curl -H "Authorization: Bearer $CRON_SECRET" \
+  https://your-chmonitor.example.com/api/cron/health-sweep
+```
+
+## Verifying it worked
+
+The endpoint always returns HTTP 200 with a JSON array of check results —
+dispatch happens server-side and doesn't block the response. The simplest way
+to confirm a message actually went out is to trip a threshold intentionally
+(temporarily lower `HEALTH_ALERT_MIN_SEVERITY` to `warning`) and watch the
+channel. If you're on Cloud with D1 configured, the `/health` page's alert
+history also records every dispatch attempt and whether delivery succeeded —
+that history isn't available on a self-hosted deployment without D1.
+
+## Related
+
+- Docs: [Health checks & alerting](https://docs.chmonitor.dev/guide/features/health)
+  — the full reference for every check, threshold, and environment variable.

--- a/apps/blog/src/layouts/Base.astro
+++ b/apps/blog/src/layouts/Base.astro
@@ -15,6 +15,7 @@ const ogImage = new URL(image, Astro.site).toString()
   <title>{title}</title>
   <meta name="description" content={description} />
   <link rel="canonical" href={canonical} />
+  <link rel="alternate" type="application/rss+xml" title="chmonitor blog" href="/rss.xml" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content={canonical} />
   <meta property="og:title" content={title} />

--- a/apps/blog/src/pages/rss.xml.ts
+++ b/apps/blog/src/pages/rss.xml.ts
@@ -1,0 +1,25 @@
+import rss from '@astrojs/rss'
+import { getCollection } from 'astro:content'
+import type { APIContext } from 'astro'
+import { postSlug } from '../lib/slug'
+
+export async function GET(context: APIContext) {
+  const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
+    (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
+  )
+
+  return rss({
+    title: "What's new in chmonitor",
+    description:
+      'Release notes, product updates and engineering notes from the team building the open-source ClickHouse monitoring dashboard.',
+    site: context.site ?? 'https://blog.chmonitor.dev',
+    items: posts.map((post) => ({
+      title: post.data.title,
+      description: post.data.description,
+      pubDate: post.data.date,
+      link: `/${postSlug(post)}/`,
+      categories: [post.data.tag],
+    })),
+    customData: '<language>en-us</language>',
+  })
+}

--- a/apps/blog/templates/case-study-post.md
+++ b/apps/blog/templates/case-study-post.md
@@ -1,0 +1,59 @@
+<!--
+Case-study post template.
+Copy to apps/blog/src/content/blog/<slug>.md and fill in. Keep draft: true
+until the claim-verification checklist at the bottom is fully checked.
+
+Case studies can be a real anonymized/de-identified scenario, or a realistic
+worked example built for this post — either is fine, but say which. Never
+present a hypothetical as a real customer story.
+-->
+---
+title: "<Outcome-oriented title, e.g. 'Diagnosing a slow-query regression start to finish'>"
+description: "<The problem, the tool, the outcome, in one sentence>"
+date: YYYY-MM-DD
+tag: Case study
+---
+
+<One paragraph: the situation, stated plainly. If this is a composite/worked
+example rather than a real incident, say so here explicitly.>
+
+## The problem
+
+<What broke or degraded, and how it was first noticed.>
+
+## Investigating
+
+<Walk through the actual chmonitor workflow used — pages visited, AI agent
+tools invoked, queries run. Screenshots or SQL are welcome. This is the part
+that should be reproducible by a reader with their own cluster.>
+
+## Root cause
+
+<What it turned out to be.>
+
+## Resolution
+
+<What was changed, and how the reader would confirm it worked (a chart
+returning to baseline, an advisor recommendation being applied, etc).>
+
+## Takeaway
+
+<One or two sentences: the generalizable lesson, and which chmonitor feature
+to reach for next time.>
+
+## Related
+
+- Docs: [<relevant docs page>](https://docs.chmonitor.dev/<slug>)
+
+<!--
+CLAIM-VERIFICATION CHECKLIST (delete this comment before setting draft: false)
+
+- [ ] State explicitly whether this is a real incident (anonymized) or a
+      worked/composite example — never blur the two.
+- [ ] Every chmonitor feature/page/AI-agent tool named is merged to `main`.
+- [ ] Any "the advisor recommended X" claim matches actual tool behavior —
+      e.g. the query/MV/TTL advisors recommend DDL, they do not auto-apply it.
+      Do not describe a recommend-only tool as having made a change itself.
+- [ ] SQL/metrics shown are either real output or clearly marked illustrative.
+- [ ] The docs cross-link resolves and the docs page agrees with this post.
+-->

--- a/apps/blog/templates/how-to-post.md
+++ b/apps/blog/templates/how-to-post.md
@@ -1,0 +1,58 @@
+<!--
+How-to post template.
+Copy to apps/blog/src/content/blog/<slug>.md and fill in. Keep draft: true
+until the claim-verification checklist at the bottom is fully checked.
+-->
+---
+title: "<Verb-first task, e.g. 'Alerting to Slack, Discord, Telegram, and PagerDuty'>"
+description: "<What the reader will be able to do after reading, in one sentence>"
+date: YYYY-MM-DD
+tag: How-to
+---
+
+<One paragraph: who this is for and what they'll have working by the end.>
+
+## Prerequisites
+
+- <e.g. a chmonitor instance already connected to a cluster>
+- <e.g. permission to set Cloudflare Worker secrets / env vars>
+
+## Steps
+
+### 1. <First concrete step>
+
+<Instructions. Prefer copy-pastable commands over prose.>
+
+```bash
+<command>
+```
+
+### 2. <Next step>
+
+...
+
+## Verifying it worked
+
+<How the reader confirms success — a curl command, a UI element that appears,
+a log line. Never end a how-to without a way to check the result.>
+
+## Related
+
+- Docs: [<canonical docs page for this feature>](https://docs.chmonitor.dev/<slug>)
+  — this post is the narrative walkthrough; the docs page is the reference.
+
+<!--
+CLAIM-VERIFICATION CHECKLIST (delete this comment before setting draft: false)
+
+- [ ] Every command/flag/env var was run/checked against the current codebase,
+      not remembered from an older version.
+- [ ] The feature described is merged to `main` (not a plan doc, not an open PR).
+- [ ] Self-hosted vs Cloud scope is accurate for each step (see CLAUDE.md
+      "One codebase" section) — call out explicitly if a step is Cloud-only.
+- [ ] The docs cross-link resolves, and the linked docs page agrees with this
+      post (if they conflict, fix the post to match the docs, not vice versa).
+- [ ] Add a reverse link from the docs page back to this post (docs<->blog
+      cross-linking is bidirectional by convention).
+- [ ] No feature named here is described as available on a platform it doesn't
+      ship on (e.g. don't claim a Cloud-only per-user feature works self-hosted).
+-->

--- a/apps/blog/templates/release-post.md
+++ b/apps/blog/templates/release-post.md
@@ -1,0 +1,62 @@
+<!--
+Release post template.
+Copy to apps/blog/src/content/blog/<slug>.md and fill in. Keep draft: true
+until the claim-verification checklist at the bottom is fully checked.
+
+Usually you won't start from this file by hand — run:
+  cd apps/blog && bun run scripts/release-to-post.mjs <tag>
+which scaffolds this template pre-filled from a real GitHub release.
+-->
+---
+title: "chmonitor vX.Y — <one-line theme>"
+description: "<1-2 sentence summary of what shipped, written for a SERP snippet>"
+date: YYYY-MM-DD
+tag: Release
+version: vX.Y
+---
+
+chmonitor **vX.Y** ships <N> new features and <N> fixes. <One paragraph on the
+headline change — the thing a returning user would notice first.>
+
+## What's new
+
+<div class="hl-grid">
+  <div class="hl"><b>&lt;Feature name&gt;</b><span>&lt;One sentence, plain language, no marketing adjectives.&gt;</span></div>
+  <!-- repeat one .hl block per headline feature -->
+</div>
+
+## <Headline feature, expanded>
+
+<2-4 paragraphs. Link the docs page that covers the feature in depth — this is
+half of the docs<->blog cross-link convention (see apps/blog/README.md). Link
+the GitHub issue/PR for anything a reader might want to verify further.>
+
+See [<docs page title>](https://docs.chmonitor.dev/<slug>) for the full
+reference.
+
+## Upgrading
+
+<What a self-hoster or Cloud user needs to do, if anything. Link the
+migration doc if one exists under docs/content/reference/migrating/.>
+
+## Full changelog
+
+See the [GitHub release](https://github.com/chmonitor/chmonitor/releases/tag/vX.Y)
+for the complete list of changes.
+
+<!--
+CLAIM-VERIFICATION CHECKLIST (delete this comment before setting draft: false)
+
+For every feature/claim named above:
+- [ ] The PR/commit that shipped it is merged to `main` (not just open, not a plan doc).
+- [ ] The version tag in frontmatter matches the tag the feature actually shipped in.
+- [ ] If the docs page linked above describes the feature differently, the docs page
+      is correct — this post matches it, not the other way around.
+- [ ] No roadmap/planned/future feature is described as shipped or "available now".
+- [ ] Self-hosted vs Cloud scope is accurate (don't claim Cloud-only behaviour ships
+      for self-hosted, or vice versa) — see CLAUDE.md "One codebase" section.
+- [ ] Any env var / config flag named is spelled exactly as in
+      docs/content/reference/environment-variables.mdx.
+- [ ] The docs<->blog cross-link resolves both ways (this post links the docs page;
+      the docs page links back to this post).
+-->

--- a/apps/blog/templates/troubleshooting-post.md
+++ b/apps/blog/templates/troubleshooting-post.md
@@ -1,0 +1,61 @@
+<!--
+Troubleshooting post template.
+Copy to apps/blog/src/content/blog/<slug>.md and fill in. Keep draft: true
+until the claim-verification checklist at the bottom is fully checked.
+-->
+---
+title: "<Symptom as a question, e.g. 'Why is my ClickHouse replication lagging?'>"
+description: "<What's causing it and how to fix it, in one sentence>"
+date: YYYY-MM-DD
+tag: Troubleshooting
+---
+
+<One paragraph: the symptom, when a reader would see it, why it matters.>
+
+## Symptoms
+
+- <What the reader observes — an error, a metric, a UI state>
+- <Where they'd see it in chmonitor: page name / chart / system table>
+
+## Common causes
+
+### <Cause 1>
+
+<Explanation. Include the `system.*` query a reader can run themselves to
+confirm this is their cause.>
+
+```sql
+<diagnostic query>
+```
+
+### <Cause 2>
+
+...
+
+## Fix
+
+<Concrete remediation steps, ordered by how likely they are to be the actual
+cause. Distinguish "safe to run yourself" from "requires ClickHouse-side
+config change" from "chmonitor can only surface this, not fix it".>
+
+## How chmonitor surfaces this
+
+<Which page/chart/AI-agent tool in chmonitor shows this, so the reader knows
+where to look next time. Link the docs page.>
+
+## Related
+
+- Docs: [<relevant docs page>](https://docs.chmonitor.dev/<slug>)
+
+<!--
+CLAIM-VERIFICATION CHECKLIST (delete this comment before setting draft: false)
+
+- [ ] Every diagnostic SQL query was actually run against a real ClickHouse
+      instance and returns the columns/shape shown.
+- [ ] The `system.*` tables referenced exist in the ClickHouse versions this
+      applies to (check docs/clickhouse-schemas/tables/*.md if version-specific).
+- [ ] The chmonitor feature/page cited as surfacing this is merged to `main`.
+- [ ] The docs cross-link resolves and the docs page agrees with this post.
+- [ ] Fix steps are marked correctly as chmonitor-side vs ClickHouse-side —
+      don't imply chmonitor auto-fixes something it only recommends.
+-->

--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -1,5 +1,10 @@
 ---
 import { useCases } from '../data/use-cases'
+import latestPosts from '../data/latest-posts.json'
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
 ---
   <footer>
     <div class="wrap">
@@ -42,6 +47,18 @@ import { useCases } from '../data/use-cases'
             <a href="https://github.com/chmonitor/chmonitor/security" target="_blank" rel="noopener">Security policy</a>
             <a href="/brand">Brand</a>
           </div>
+          {latestPosts.length > 0 && (
+            <div class="foot-col foot-col-posts">
+              <h5>Latest from the blog</h5>
+              {latestPosts.map((post) => (
+                <a href={post.url} target="_blank" rel="noopener">
+                  {post.title}
+                  <span class="foot-post-date">{fmtDate(post.date)}</span>
+                </a>
+              ))}
+              <a href="https://blog.chmonitor.dev/rss.xml" target="_blank" rel="noopener">RSS feed</a>
+            </div>
+          )}
         </div>
       </div>
       <div class="foot-bottom">

--- a/apps/landing/src/data/latest-posts.json
+++ b/apps/landing/src/data/latest-posts.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "Alerting to Slack and Discord",
+    "date": "2026-07-03",
+    "tag": "How-to",
+    "url": "https://blog.chmonitor.dev/alerting-to-slack-and-discord/"
+  },
+  {
+    "title": "chmonitor v0.3 — a full rebuild",
+    "date": "2026-06-29",
+    "tag": "Release",
+    "url": "https://blog.chmonitor.dev/v0.3/"
+  }
+]

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -457,6 +457,9 @@ const ogImage = new URL(image, Astro.site).toString()
     .foot-col h5{font-size:12px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--muted-fg);margin-bottom:14px}
     .foot-col a{display:block;font-size:14px;color:var(--fg-soft);margin-bottom:10px;transition:color .15s}
     .foot-col a:hover{color:var(--fg)}
+    .foot-col-posts{max-width:220px}
+    .foot-col-posts a{line-height:1.4}
+    .foot-post-date{display:block;font-size:12px;color:var(--muted-fg);margin-top:2px}
     .foot-bottom{margin-top:44px;padding-top:24px;border-top:1px solid var(--border-soft);
       display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap;font-size:13px;color:var(--muted-fg)}
 

--- a/docs/content/guide/features/health.mdx
+++ b/docs/content/guide/features/health.mdx
@@ -96,7 +96,7 @@ The health-sweep endpoint runs checks over all configured hosts and sends a webh
 |---|---|---|
 | `CRON_SECRET` | (unset = **endpoint disabled**) | **Required.** Guards `GET /api/cron/health-sweep` and `GET /api/cron/retention-prune`. Pass as `Authorization: Bearer <secret>` (or `?secret=<secret>`). When it is **unset/empty the endpoints fail closed and return HTTP 503** — they do not run. Note that `retention-prune` is **destructive** (it deletes conversation rows past each plan's retention window), which is why these routes refuse to run unauthenticated. |
 | `HEALTH_ALERT_ENABLED` | `false` | Set to `true` to enable webhook dispatch. |
-| `HEALTH_ALERT_WEBHOOK_URL` | (required if enabled) | Slack or Discord incoming webhook URL. Payload is a JSON object with a `text` field. |
+| `HEALTH_ALERT_WEBHOOK_URL` | (required if enabled) | Slack or Discord incoming webhook URL. Payload is `{"text": "...", "content": "..."}` so both render it. See [Alerting to Slack and Discord](https://blog.chmonitor.dev/alerting-to-slack-and-discord/) for setup examples. |
 | `HEALTH_ALERT_MIN_SEVERITY` | `warning` | Minimum severity that triggers a notification. Values: `warning` or `critical`. |
 
 <Callout type="warn" title="CRON_SECRET is required">
@@ -153,7 +153,7 @@ The Cloudflare scheduled trigger is routed to the route's `GET` handler. Because
 
 - `system.error_log` is checked separately by the Errors page (under Operations). The Health page uses `system.errors` (in-memory error counts), which resets on server restart.
 - If a system table is missing (e.g., no `system.replicas` on a standalone node), that check is skipped with an "unavailable" state rather than a false positive.
-- The webhook payload is a plain Slack/Discord-compatible JSON object (`{"text": "..."}`). Custom payload shapes are not supported in v1.
+- The webhook payload is a plain Slack/Discord-compatible JSON object (`{"text": "...", "content": "..."}`). Custom payload shapes are not supported in v1.
 - The health-sweep endpoint queries all configured `CLICKHOUSE_HOST` entries. High host counts increase sweep latency.
 
 ## Related


### PR DESCRIPTION
## Summary

Implements plan 67 — a repeatable docs+blog content engine.

- **`apps/blog/CONTENT-CALENDAR.md`** — 12-week editorial calendar (release / how-to / troubleshooting / case-study mix), target keyword + docs cross-link per row, status tracking.
- **`apps/blog/templates/*.md`** — one template per post type, living outside `src/content/blog/` so the content-collection glob never treats them as posts. Each ends with a claim-verification checklist ("does this feature ship at the referenced version? link the changelog/PR") — honesty enforced at authoring time, per the plan's invariant.
- **RSS** — `apps/blog/src/pages/rss.xml.ts` via `@astrojs/rss`, linked from `<head>` (`<link rel="alternate">`) and the blog footer.
- **Release → draft post** — `bun run release-to-post <tag>` (from `apps/blog/`) scaffolds a `draft: true` post from the release template via `gh release view` (or `-- --from-file <json>` for offline/testing). It never publishes; a human still runs the checklist and flips `draft: false`.
- **Landing footer widget** — `apps/blog` and `apps/landing` are independent Astro apps with separate CI jobs (`blog.yml` / `landing.yml`), so landing can't reach into blog's content collection at build time. `bun run sync-latest-posts` regenerates a committed snapshot (`apps/landing/src/data/latest-posts.json`) that `Footer.astro` renders as "Latest from the blog".
- **First real docs↔blog cross-link** — new how-to post `alerting-to-slack-and-discord.md` ↔ `docs/content/guide/features/health.mdx` (added a link both directions; also aligned a docs bullet that had drifted from the actual payload shape).

## Honesty/scope note (flagging per the plan's invariant)

The kickoff brief for this task said "alerting channels: Slack/Discord/Telegram/PagerDuty shipped." I verified against the code before writing the how-to post and found that's **not accurate for actual dispatch**: `postWebhook` in `apps/dashboard/src/lib/health/server-sweep.ts` hardcodes `body: JSON.stringify({ text, content: text })` — only Slack/Discord-shaped payloads are ever sent. Telegram/PagerDuty formatters exist in `apps/dashboard/src/lib/health/adapters/` but are pure, untested-against-delivery functions; `apps/landing/src/data/use-cases.test.ts` already documents this explicitly: "Telegram/PagerDuty adapters exist as pure formatters but are not consumed by the health-sweep dispatch — genuinely unwired." I scoped the new how-to post and docs link to **Slack + Discord only** to match what's actually shipped, rather than the brief's claim.

Also softened one verification step in the post: the `/health` page's alert-history log is D1-backed and unavailable on self-hosted deployments without D1 configured (see `alert-history-store.ts` comments), so the post now leads with the universal "trip a threshold" verification method and calls out the D1/Cloud-only history explicitly.

## Verification

```
$ bun run build:docs
...
✓ built in 3.08s
[prerender] Prerendered 1 pages: /

$ cd apps/blog && bun install --frozen-lockfile && bun run build
...
generating static routes
  ├─ /rss.xml
  ├─ /index.html
  ├─ /alerting-to-slack-and-discord/index.html
  ├─ /v0.3/index.html
✓ 3 page(s) built in 3.66s

$ cd apps/landing && bun install --frozen-lockfile && bun run build
...
generating static routes (9 pages) ✓
$ grep -o "Latest from the blog" dist/index.html  →  Latest from the blog (widget renders)

$ bun run lint
Checked 2042 files. No fixes applied.
```

Also manually verified: `bun run release-to-post v0.4 -- --from-file <sample.json>` scaffolds a correct `draft: true` post from the release template (deleted after the test — not committed); `bun run sync-latest-posts` regenerates `latest-posts.json` matching the two published posts; RSS feed (`dist/rss.xml`) contains both posts with correct titles/links/dates.

## Test plan

- [ ] CI green (blog / landing / docs workflows)
- [ ] Spot-check `blog.chmonitor.dev/rss.xml` after deploy
- [ ] Spot-check the landing footer's "Latest from the blog" column after deploy
- [ ] Confirm `docs.chmonitor.dev/guide/features/health` renders the new blog link