### PR TITLE
feat(advisor): proactive weekly health report, styled HTML narrative (plan 52)

### DIFF
--- a/apps/dashboard/src/db/conversations-migrations/0014_weekly_reports.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0014_weekly_reports.sql
@@ -1,0 +1,23 @@
+-- Persisted per-host weekly health report digests (narrative + baselines +
+-- capacity forecast summarized over a rolling 7-day window). See
+-- lib/insights/weekly-report-store.ts and
+-- plans/52-proactive-weekly-health-report.md.
+--
+-- The store also creates this table lazily (`CREATE TABLE IF NOT EXISTS`) on
+-- first use, mirroring the insights D1 store pattern (store/d1-store.ts) —
+-- this migration just gives the deployed CHM_CLOUD_D1 schema an explicit,
+-- tracked record. Both are safe together: IF NOT EXISTS is idempotent.
+--
+-- NOTE: numbered 0014 (not 0010) to leave headroom for other in-flight
+-- plans' migrations landing concurrently from sibling worktrees; the highest
+-- migration checked into this worktree at the time this was written was 0009.
+
+CREATE TABLE IF NOT EXISTS weekly_reports (
+  host_id TEXT NOT NULL,
+  week_start TEXT NOT NULL,
+  summary_json TEXT NOT NULL,
+  html TEXT NOT NULL DEFAULT '',
+  delivered INTEGER NOT NULL DEFAULT 0,
+  generated_at INTEGER NOT NULL,
+  PRIMARY KEY (host_id, week_start)
+);

--- a/apps/dashboard/src/lib/insights/__tests__/weekly-report.test.ts
+++ b/apps/dashboard/src/lib/insights/__tests__/weekly-report.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Weekly health report tests.
+ *
+ * Covers the three things the plan calls out: (1) `buildWeeklyReport` assembles
+ * a correct structured summary from fixture findings + baselines + capacity;
+ * (2) an undelivered report is still persisted (fail-open, no delivery channel);
+ * (3) `renderWeeklyReportHtml` emits valid, fully self-contained markup (no
+ * external assets) with the key sections and the honesty disclaimer, and
+ * escapes untrusted finding text.
+ *
+ * I/O boundaries are mocked so the test is hermetic: the capacity forecaster
+ * (ClickHouse) and the D1-backed weekly-report store are stubbed, while the
+ * findings come through the real pluggable insights store on its in-memory
+ * backend. mock.module calls precede the imports of the module under test so the
+ * stubs are registered before its module graph loads (same pattern as
+ * read-insights.store.test.ts).
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// Stub the virtual Worker env touched transitively via @chm/clickhouse-client.
+mock.module('cloudflare:workers', () => ({ env: {} }))
+
+// Stub the capacity forecaster (ClickHouse I/O) with a deterministic forecast.
+const FIXTURE_FORECAST = {
+  available: true as const,
+  hostId: 0,
+  horizonDays: 90,
+  sampleDays: 30,
+  dailyGrowthBytes: 5_000_000_000,
+  readableDailyGrowth: '4.66 GB',
+  daysToFull: 42,
+  fullDate: '2026-08-15T00:00:00.000Z',
+  willExceedHorizon: false,
+  confidence: 'high' as const,
+  freeBytes: 210_000_000_000,
+  totalBytes: 1_000_000_000_000,
+  topContributors: [],
+  caveat: 'Linear projection from 30 days of history.',
+  explanation:
+    'At the current write rate the disk fills in ~42 days. This is a projection, not a guarantee.',
+}
+mock.module('@/lib/ai/advisor/capacity-forecaster', () => ({
+  forecastDiskFull: async () => FIXTURE_FORECAST,
+}))
+
+// Stub the baseline store so baselinesFitted is deterministic.
+mock.module('../baseline-store', () => ({
+  listBaselines: async () => [{ metric: 'error_rate' }, { metric: 'qps' }],
+}))
+
+// Capture persistence in memory instead of hitting D1.
+const persisted: Array<{
+  weekStart: string
+  delivered: boolean
+  html: string
+}> = []
+mock.module('../weekly-report-store', () => ({
+  persistWeeklyReport: async (record: {
+    weekStart: string
+    delivered: boolean
+    html: string
+  }) => {
+    persisted.push({
+      weekStart: record.weekStart,
+      delivered: record.delivered,
+      html: record.html,
+    })
+    return true
+  },
+}))
+
+// Dynamic imports AFTER the mock.module calls above: static imports hoist above
+// mock.module, so the module-under-test's graph (which transitively imports the
+// virtual `cloudflare:workers` module via platform-native) must be loaded lazily
+// for the stubs to take effect. Mirrors retention-owner.test.ts.
+const { buildWeeklyReport, parseOptedInHosts, runWeeklyReportForHost } =
+  await import('../weekly-report')
+const { renderWeeklyReportHtml } = await import('../weekly-report-html')
+const { resetInsightsStoreCache, resolveInsightsStore } = await import(
+  '../store/resolve-store'
+)
+
+const savedBackend = process.env.INSIGHTS_STORE_BACKEND
+const savedWebhook = process.env.HEALTH_ALERT_WEBHOOK_URL
+
+beforeEach(async () => {
+  process.env.INSIGHTS_STORE_BACKEND = 'memory'
+  delete process.env.HEALTH_ALERT_WEBHOOK_URL
+  resetInsightsStoreCache()
+  persisted.length = 0
+
+  const store = await resolveInsightsStore()
+  await store.record(0, [
+    {
+      severity: 'critical',
+      category: 'reliability',
+      source: 'ai-insight',
+      title: 'replication queue backing up',
+      detail: 'replica is 1200 parts behind',
+      metric: 'replication_lag',
+      value: 1200,
+    },
+    {
+      severity: 'warning',
+      category: 'storage',
+      source: 'ai-insight',
+      title: 'table events is fragmented',
+      detail: 'active parts above baseline',
+      metric: 'max_active_parts',
+      value: 318,
+    },
+    {
+      severity: 'info',
+      category: 'performance',
+      source: 'ai-insight',
+      title: 'query latency nominal',
+      detail: 'p99 within baseline',
+      metric: 'p99_latency',
+      value: 120,
+    },
+  ])
+})
+
+afterAll(() => {
+  if (savedBackend === undefined) delete process.env.INSIGHTS_STORE_BACKEND
+  else process.env.INSIGHTS_STORE_BACKEND = savedBackend
+  if (savedWebhook === undefined) delete process.env.HEALTH_ALERT_WEBHOOK_URL
+  else process.env.HEALTH_ALERT_WEBHOOK_URL = savedWebhook
+  resetInsightsStoreCache()
+})
+
+describe('buildWeeklyReport', () => {
+  test('assembles a structured summary from findings + baselines + capacity', async () => {
+    const { summary, markdown, html } = await buildWeeklyReport(0, 'prod-eu')
+
+    expect(summary.hostId).toBe(0)
+    expect(summary.hostLabel).toBe('prod-eu')
+    expect(summary.totalFindings).toBe(3)
+    expect(summary.bySeverity).toEqual({ critical: 1, warning: 1, info: 1 })
+    expect(summary.byCategory).toEqual({
+      reliability: 1,
+      storage: 1,
+      performance: 1,
+    })
+
+    // Top findings ranked by severity (critical first).
+    expect(summary.topFindings[0]).toMatchObject({
+      severity: 'critical',
+      title: 'replication queue backing up',
+    })
+
+    // Baselines folded in (plan 48) + capacity forecast (plan 50).
+    expect(summary.baselinesFitted).toBe(2)
+    expect(summary.capacity).toMatchObject({ available: true, daysToFull: 42 })
+
+    expect(markdown).toContain('Weekly Health Report — prod-eu')
+    expect(html).toContain('<!doctype html>')
+  })
+})
+
+describe('runWeeklyReportForHost', () => {
+  test('persists the report even when no delivery channel is configured', async () => {
+    const result = await runWeeklyReportForHost(0, 'prod-eu')
+
+    expect(result.channelConfigured).toBe(false)
+    expect(result.delivered).toBe(false)
+    expect(result.persisted).toBe(true)
+
+    // Persisted exactly once, undelivered, with rendered HTML.
+    expect(persisted).toHaveLength(1)
+    expect(persisted[0].delivered).toBe(false)
+    expect(persisted[0].html).toContain('<!doctype html>')
+  })
+})
+
+describe('renderWeeklyReportHtml', () => {
+  test('produces valid, fully self-contained markup with the key sections', async () => {
+    const { summary } = await buildWeeklyReport(0, 'prod-eu')
+    const html = renderWeeklyReportHtml(summary)
+
+    // Self-contained: no external asset requests at all.
+    expect(html).not.toMatch(/<link\b/i)
+    expect(html).not.toMatch(/<script\b/i)
+    expect(html).not.toMatch(/src\s*=\s*["']https?:/i)
+    expect(html).not.toMatch(/@import/i)
+
+    // Structure + key sections.
+    expect(html).toContain('<!doctype html>')
+    expect(html).toContain('<style>')
+    expect(html).toContain('Top findings')
+    expect(html).toContain('Capacity outlook')
+    expect(html).toContain('Findings by category')
+
+    // Honesty invariant surfaced in the narrative.
+    expect(html).toContain('nothing here was applied automatically')
+
+    // Dark-mode aware + product OKLCH tokens.
+    expect(html).toContain('prefers-color-scheme: dark')
+    expect(html).toContain('oklch(')
+  })
+
+  test('escapes untrusted finding text to prevent markup injection', () => {
+    const html = renderWeeklyReportHtml({
+      hostId: 0,
+      hostLabel: 'prod',
+      weekStart: '2026-06-27',
+      weekEnd: '2026-07-04',
+      generatedAt: '2026-07-04T08:00:00.000Z',
+      totalFindings: 1,
+      bySeverity: { critical: 1, warning: 0, info: 0 },
+      byCategory: { reliability: 1 },
+      topFindings: [
+        {
+          severity: 'critical',
+          category: 'reliability',
+          title: '<script>alert(1)</script>',
+          detail: 'x & y < z',
+          metric: 'm',
+          generatedAt: '2026-07-04T08:00:00.000Z',
+        },
+      ],
+      baselinesFitted: 0,
+      capacity: {
+        available: false,
+        reason: 'error',
+        message: 'no forecast',
+      },
+    })
+
+    expect(html).not.toContain('<script>alert(1)</script>')
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(html).toContain('x &amp; y &lt; z')
+  })
+})
+
+describe('parseOptedInHosts', () => {
+  test('parses, de-dupes, sorts, and drops garbage; empty by default', () => {
+    expect(parseOptedInHosts(undefined)).toEqual([])
+    expect(parseOptedInHosts('')).toEqual([])
+    expect(parseOptedInHosts('2, 0, 2, x, -1, 1')).toEqual([0, 1, 2])
+  })
+})

--- a/apps/dashboard/src/lib/insights/weekly-report-html.ts
+++ b/apps/dashboard/src/lib/insights/weekly-report-html.ts
@@ -1,0 +1,342 @@
+/**
+ * Presentation-quality HTML renderer for the weekly health report.
+ *
+ * A PURE function of a {@link WeeklyReportSummary} — no I/O, no imports from the
+ * data-assembly path — so it is unit-testable in isolation and can be called
+ * both by `buildWeeklyReport` (to persist the rendered narrative) and by the
+ * view route (to re-render from a persisted summary).
+ *
+ * The output is a fully self-contained HTML document: all CSS is inlined in a
+ * single `<style>` block, there are NO external `<link>`/`<script src>`/font/
+ * image requests, so the document renders identically whether it is emailed,
+ * persisted in D1, or downloaded and opened standalone. Colors are the
+ * dashboard's own OKLCH design tokens (see `styles.css` / product-design.md) so
+ * the report reads as part of the same product, and it is dark-mode aware via
+ * `prefers-color-scheme`.
+ *
+ * HONESTY INVARIANT: this renderer only ever restates what the insights engine,
+ * statistical baselines, and capacity forecaster actually computed. It never
+ * claims any change was applied — chmonitor recommends, it does not act.
+ */
+
+import type {
+  WeeklyReportCapacity,
+  WeeklyReportSummary,
+  WeeklyTopFinding,
+} from './weekly-report'
+import type { InsightSeverity } from './types'
+
+/** Escape untrusted finding text before interpolating into markup. */
+function esc(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+const SEVERITY_LABEL: Record<InsightSeverity, string> = {
+  critical: 'Critical',
+  warning: 'Warning',
+  info: 'Info',
+}
+
+/** Percentage (0–100, rounded) of `part` out of `total`; 0 when total is 0. */
+function pct(part: number, total: number): number {
+  if (total <= 0) return 0
+  return Math.round((part / total) * 100)
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+  const i = Math.min(
+    units.length - 1,
+    Math.floor(Math.log(bytes) / Math.log(1024))
+  )
+  return `${(bytes / 1024 ** i).toFixed(i === 0 ? 0 : 1)} ${units[i]}`
+}
+
+/**
+ * The design tokens, inlined. Mirrors `apps/dashboard/src/styles.css` (light in
+ * `:root`, dark via `prefers-color-scheme`) so the report matches the product.
+ */
+const STYLE = `
+  :root {
+    --bg: oklch(0.985 0 0);
+    --surface: oklch(1 0 0);
+    --fg: oklch(0.205 0 0);
+    --muted-fg: oklch(0.556 0 0);
+    --border: oklch(0.922 0 0);
+    --subtle: oklch(0.97 0 0);
+    --primary: oklch(0.488 0.243 264.376);
+    --crit: oklch(0.577 0.245 27.325);
+    --warn: oklch(0.769 0.188 70.08);
+    --info: oklch(0.6 0.118 264);
+    --crit-bg: oklch(0.577 0.245 27.325 / 0.1);
+    --warn-bg: oklch(0.769 0.188 70.08 / 0.14);
+    --info-bg: oklch(0.6 0.118 264 / 0.1);
+    --shadow: 0 1px 2px oklch(0 0 0 / 0.04), 0 8px 24px oklch(0 0 0 / 0.05);
+    --radius: 12px;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: oklch(0.145 0 0);
+      --surface: oklch(0.205 0 0);
+      --fg: oklch(0.985 0 0);
+      --muted-fg: oklch(0.708 0 0);
+      --border: oklch(1 0 0 / 0.1);
+      --subtle: oklch(0.269 0 0);
+      --primary: oklch(0.62 0.19 265.638);
+      --crit: oklch(0.704 0.191 22.216);
+      --warn: oklch(0.828 0.189 84);
+      --info: oklch(0.7 0.13 264);
+      --crit-bg: oklch(0.704 0.191 22.216 / 0.16);
+      --warn-bg: oklch(0.828 0.189 84 / 0.16);
+      --info-bg: oklch(0.7 0.13 264 / 0.14);
+      --shadow: 0 1px 2px oklch(0 0 0 / 0.3), 0 8px 24px oklch(0 0 0 / 0.35);
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font: 15px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+      Helvetica, Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 720px; margin: 0 auto; padding: 32px 20px 56px; }
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    overflow: hidden;
+  }
+  .hero { padding: 28px 28px 24px; }
+  .eyebrow {
+    font-size: 11px; font-weight: 700; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--primary); margin: 0 0 6px;
+  }
+  h1 { font-size: 24px; font-weight: 700; letter-spacing: -0.01em; margin: 0 0 6px; }
+  .window { font-size: 13px; color: var(--muted-fg); margin: 0; }
+  .stat-row { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 22px; }
+  .stat {
+    flex: 1 1 120px; min-width: 110px; padding: 14px 16px;
+    border: 1px solid var(--border); border-radius: 10px; background: var(--bg);
+  }
+  .stat .num { font-size: 26px; font-weight: 700; line-height: 1.1; letter-spacing: -0.02em; }
+  .stat .lbl { font-size: 12px; color: var(--muted-fg); margin-top: 2px; }
+  .stat.crit .num { color: var(--crit); }
+  .stat.warn .num { color: var(--warn); }
+  .sevbar { display: flex; height: 8px; border-radius: 999px; overflow: hidden; margin-top: 22px; background: var(--subtle); }
+  .sevbar span { display: block; height: 100%; }
+  .sevbar .s-crit { background: var(--crit); }
+  .sevbar .s-warn { background: var(--warn); }
+  .sevbar .s-info { background: var(--info); }
+  .legend { display: flex; gap: 16px; margin-top: 10px; font-size: 12px; color: var(--muted-fg); }
+  .legend i { display: inline-block; width: 9px; height: 9px; border-radius: 3px; margin-right: 6px; vertical-align: middle; }
+  section { margin-top: 28px; }
+  .sec-title {
+    font-size: 12px; font-weight: 700; letter-spacing: 0.06em;
+    text-transform: uppercase; color: var(--muted-fg); margin: 0 0 12px;
+  }
+  .finding {
+    display: flex; gap: 14px; padding: 16px 18px; border: 1px solid var(--border);
+    border-left-width: 4px; border-radius: 10px; margin-bottom: 10px; background: var(--surface);
+  }
+  .finding.crit { border-left-color: var(--crit); }
+  .finding.warn { border-left-color: var(--warn); }
+  .finding.info { border-left-color: var(--info); }
+  .badge {
+    flex: 0 0 auto; align-self: flex-start; font-size: 10.5px; font-weight: 700;
+    letter-spacing: 0.04em; text-transform: uppercase; padding: 3px 9px;
+    border-radius: 999px; white-space: nowrap;
+  }
+  .badge.crit { color: var(--crit); background: var(--crit-bg); }
+  .badge.warn { color: var(--warn); background: var(--warn-bg); }
+  .badge.info { color: var(--info); background: var(--info-bg); }
+  .finding .body { min-width: 0; }
+  .finding .ttl { font-weight: 650; font-size: 14.5px; margin: 0 0 3px; }
+  .finding .dtl { font-size: 13px; color: var(--muted-fg); margin: 0; }
+  .finding .meta { font-size: 11.5px; color: var(--muted-fg); margin: 6px 0 0; opacity: 0.85; }
+  .empty { padding: 20px; text-align: center; color: var(--muted-fg); font-size: 13.5px; border: 1px dashed var(--border); border-radius: 10px; }
+  .cat { margin-bottom: 9px; }
+  .cat-head { display: flex; justify-content: space-between; font-size: 13px; margin-bottom: 5px; }
+  .cat-head .n { color: var(--muted-fg); font-variant-numeric: tabular-nums; }
+  .track { height: 7px; background: var(--subtle); border-radius: 999px; overflow: hidden; }
+  .track span { display: block; height: 100%; background: var(--primary); border-radius: 999px; }
+  .cap {
+    padding: 18px 20px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface);
+  }
+  .cap .headline { font-size: 15px; font-weight: 650; margin: 0 0 8px; }
+  .cap .prose { font-size: 13px; color: var(--muted-fg); margin: 0; }
+  .cap-metrics { display: flex; flex-wrap: wrap; gap: 18px; margin: 14px 0 4px; }
+  .cap-metrics div { font-size: 12px; color: var(--muted-fg); }
+  .cap-metrics strong { display: block; font-size: 17px; color: var(--fg); font-weight: 700; font-variant-numeric: tabular-nums; }
+  .util { margin-top: 14px; }
+  .util .track { height: 9px; }
+  .util .track span { background: var(--primary); }
+  .util.hot .track span { background: var(--crit); }
+  .footer {
+    margin-top: 26px; padding-top: 18px; border-top: 1px solid var(--border);
+    font-size: 12px; color: var(--muted-fg); line-height: 1.6;
+  }
+  .footer strong { color: var(--fg); font-weight: 650; }
+`
+
+function renderStatCards(s: WeeklyReportSummary): string {
+  return `
+    <div class="stat-row">
+      <div class="stat"><div class="num">${s.totalFindings}</div><div class="lbl">Findings this week</div></div>
+      <div class="stat crit"><div class="num">${s.bySeverity.critical}</div><div class="lbl">Critical</div></div>
+      <div class="stat warn"><div class="num">${s.bySeverity.warning}</div><div class="lbl">Warning</div></div>
+      <div class="stat"><div class="num">${s.baselinesFitted}</div><div class="lbl">Adaptive baselines</div></div>
+    </div>`
+}
+
+function renderSeverityBar(s: WeeklyReportSummary): string {
+  const { critical, warning, info } = s.bySeverity
+  const total = critical + warning + info
+  if (total === 0) return ''
+  return `
+    <div class="sevbar" role="img" aria-label="Severity distribution">
+      <span class="s-crit" style="width:${pct(critical, total)}%"></span>
+      <span class="s-warn" style="width:${pct(warning, total)}%"></span>
+      <span class="s-info" style="width:${pct(info, total)}%"></span>
+    </div>
+    <div class="legend">
+      <span><i style="background:var(--crit)"></i>${critical} critical</span>
+      <span><i style="background:var(--warn)"></i>${warning} warning</span>
+      <span><i style="background:var(--info)"></i>${info} info</span>
+    </div>`
+}
+
+function renderFinding(f: WeeklyTopFinding): string {
+  const sev = f.severity
+  const metric = f.metric ? ` · ${esc(f.metric)}` : ''
+  return `
+    <div class="finding ${sev}">
+      <span class="badge ${sev}">${SEVERITY_LABEL[sev]}</span>
+      <div class="body">
+        <p class="ttl">${esc(f.title)}</p>
+        <p class="dtl">${esc(f.detail)}</p>
+        <p class="meta">${esc(f.category)}${metric}</p>
+      </div>
+    </div>`
+}
+
+function renderTopFindings(s: WeeklyReportSummary): string {
+  if (s.topFindings.length === 0) {
+    return `<div class="empty">No notable findings this week — the cluster stayed within its baselines.</div>`
+  }
+  return s.topFindings.map(renderFinding).join('')
+}
+
+function renderCategories(s: WeeklyReportSummary): string {
+  const entries = Object.entries(s.byCategory).sort((a, b) => b[1] - a[1])
+  if (entries.length === 0) return ''
+  const max = entries[0][1]
+  const bars = entries
+    .slice(0, 6)
+    .map(
+      ([cat, n]) => `
+      <div class="cat">
+        <div class="cat-head"><span>${esc(cat)}</span><span class="n">${n}</span></div>
+        <div class="track"><span style="width:${pct(n, max)}%"></span></div>
+      </div>`
+    )
+    .join('')
+  return `
+    <section>
+      <p class="sec-title">Findings by category</p>
+      ${bars}
+    </section>`
+}
+
+function renderCapacity(cap: WeeklyReportCapacity): string {
+  if (!cap.available) {
+    return `
+      <div class="cap">
+        <p class="headline">Capacity outlook unavailable</p>
+        <p class="prose">${esc(cap.message)}</p>
+      </div>`
+  }
+
+  const usedBytes = Math.max(0, cap.totalBytes - cap.freeBytes)
+  const usedPct = pct(usedBytes, cap.totalBytes)
+  const hot = usedPct >= 80 || (cap.daysToFull !== null && cap.daysToFull <= 30)
+  const fullLine =
+    cap.daysToFull === null || cap.willExceedHorizon
+      ? `No disk-full date within the ${cap.horizonDays}-day horizon`
+      : `~${cap.daysToFull} day(s) to full${cap.fullDate ? ` (≈ ${esc(cap.fullDate.slice(0, 10))})` : ''}`
+
+  return `
+    <div class="cap">
+      <p class="headline">${esc(fullLine)}</p>
+      <div class="cap-metrics">
+        <div><strong>${esc(cap.readableDailyGrowth)}/day</strong>growth rate</div>
+        <div><strong>${formatBytes(cap.freeBytes)}</strong>free of ${formatBytes(cap.totalBytes)}</div>
+        <div><strong>${esc(cap.confidence)}</strong>confidence · ${cap.sampleDays}d history</div>
+      </div>
+      <div class="util ${hot ? 'hot' : ''}">
+        <div class="cat-head"><span>Disk utilization</span><span class="n">${usedPct}%</span></div>
+        <div class="track"><span style="width:${usedPct}%"></span></div>
+      </div>
+      <p class="prose" style="margin-top:14px">${esc(cap.explanation)}</p>
+    </div>`
+}
+
+/**
+ * Render a {@link WeeklyReportSummary} into a fully self-contained,
+ * presentation-quality HTML document. Pure and deterministic.
+ */
+export function renderWeeklyReportHtml(s: WeeklyReportSummary): string {
+  const title = `Weekly Health Report — ${esc(s.hostLabel)}`
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="color-scheme" content="light dark" />
+<title>${title}</title>
+<style>${STYLE}</style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="card">
+      <div class="hero">
+        <p class="eyebrow">chmonitor · Weekly digest</p>
+        <h1>${esc(s.hostLabel)}</h1>
+        <p class="window">${esc(s.weekStart)} → ${esc(s.weekEnd)} · generated ${esc(s.generatedAt.slice(0, 10))}</p>
+        ${renderStatCards(s)}
+        ${renderSeverityBar(s)}
+      </div>
+    </div>
+
+    <section>
+      <p class="sec-title">Top findings</p>
+      ${renderTopFindings(s)}
+    </section>
+
+    ${renderCategories(s)}
+
+    <section>
+      <p class="sec-title">Capacity outlook</p>
+      ${renderCapacity(s.capacity)}
+    </section>
+
+    <div class="footer">
+      <strong>How this report was built.</strong> Composed automatically from
+      chmonitor's AI insights engine, statistical baselines, and capacity
+      forecasting over the last 7 days. Every item above is a recommendation for
+      your review — <strong>nothing here was applied automatically</strong>.
+      chmonitor recommends; it does not change your cluster. Open the AI agent
+      (<code>/agents?host=${s.hostId}</code>) to investigate any finding.
+    </div>
+  </div>
+</body>
+</html>`
+}

--- a/apps/dashboard/src/lib/insights/weekly-report-store.ts
+++ b/apps/dashboard/src/lib/insights/weekly-report-store.ts
@@ -1,0 +1,207 @@
+/**
+ * D1-backed store for persisted weekly health reports.
+ *
+ * Mirrors the insights D1 store pattern (`store/d1-store.ts`): the table is
+ * created lazily (`CREATE TABLE IF NOT EXISTS`) on first use so persistence
+ * works even if the checked-in migration (`db/conversations-migrations/
+ * 0014_weekly_reports.sql`) hasn't run yet or a different D1 binding is used —
+ * `IF NOT EXISTS` makes the two idempotent together. Reuses the same
+ * `CHM_CLOUD_D1` binding as the agent's conversation store and the anomaly
+ * baseline store.
+ *
+ * Best-effort like every other insights backend: a missing binding or any D1
+ * error is caught, logged, and resolved to `false` / `null` / `[]` rather than
+ * thrown — so a deployment with no D1 configured (the OSS/self-hosted default)
+ * simply never persists a weekly report rather than crashing the cron. See
+ * plans/52-proactive-weekly-health-report.md.
+ */
+
+import { ErrorLogger } from '@chm/logger'
+import { getPlatformBindings } from '@chm/platform'
+
+const COMPONENT = 'weekly-report-store'
+const warn = (msg: string) =>
+  ErrorLogger.logWarning(`[weekly-report-store] ${msg}`, {
+    component: COMPONENT,
+  })
+
+const TABLE = 'weekly_reports'
+
+// Kept byte-for-byte in sync with db/conversations-migrations/0014_weekly_reports.sql.
+const MIGRATION_SQL = `
+  CREATE TABLE IF NOT EXISTS ${TABLE} (
+    host_id TEXT NOT NULL,
+    week_start TEXT NOT NULL,
+    summary_json TEXT NOT NULL,
+    html TEXT NOT NULL DEFAULT '',
+    delivered INTEGER NOT NULL DEFAULT 0,
+    generated_at INTEGER NOT NULL,
+    PRIMARY KEY (host_id, week_start)
+  )
+`
+
+/** A persisted weekly report row, keyed by (hostId, weekStart). */
+export interface WeeklyReportRecord {
+  readonly hostId: string
+  /** Start of the rolling 7-day window this report covers, `YYYY-MM-DD`. */
+  readonly weekStart: string
+  /** JSON-serialized `WeeklyReportSummary` (see `weekly-report.ts`). */
+  readonly summaryJson: string
+  /** Rendered, self-contained HTML narrative (see `weekly-report-html.ts`). */
+  readonly html: string
+  readonly delivered: boolean
+  /** Unix epoch milliseconds this report was generated. */
+  readonly generatedAt: number
+}
+
+interface D1WeeklyReportRow {
+  host_id: string
+  week_start: string
+  summary_json: string
+  html: string
+  delivered: number
+  generated_at: number
+}
+
+function rowToRecord(row: D1WeeklyReportRow): WeeklyReportRecord {
+  return {
+    hostId: row.host_id,
+    weekStart: row.week_start,
+    summaryJson: row.summary_json,
+    html: row.html ?? '',
+    delivered: row.delivered === 1,
+    generatedAt: row.generated_at,
+  }
+}
+
+function getDb(): D1Database | null {
+  return getPlatformBindings().getD1Database('CHM_CLOUD_D1')
+}
+
+// Single-flight migration: concurrent first calls share one promise so the
+// idempotent DDL runs at most once per process; a failure clears it so the
+// next call retries.
+let migration: Promise<void> | null = null
+
+function ensureMigrated(db: D1Database): Promise<void> {
+  if (!migration) {
+    migration = db
+      .prepare(MIGRATION_SQL)
+      .run()
+      .then(() => undefined)
+      .catch((err) => {
+        migration = null
+        throw err
+      })
+  }
+  return migration
+}
+
+/**
+ * Upsert a weekly report (keyed on host_id + week_start) — re-running the
+ * cron for the same host/week (e.g. a retry, or a later delivery-status
+ * update) overwrites the existing row instead of duplicating it.
+ * Best-effort: returns `false` on any failure, never throws.
+ */
+export async function persistWeeklyReport(
+  record: WeeklyReportRecord
+): Promise<boolean> {
+  try {
+    const db = getDb()
+    if (!db) {
+      warn('no D1 binding (CHM_CLOUD_D1) found — report not persisted')
+      return false
+    }
+    await ensureMigrated(db)
+
+    await db
+      .prepare(
+        `INSERT INTO ${TABLE}
+           (host_id, week_start, summary_json, html, delivered, generated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT (host_id, week_start) DO UPDATE SET
+           summary_json = excluded.summary_json,
+           html = excluded.html,
+           delivered = excluded.delivered,
+           generated_at = excluded.generated_at`
+      )
+      .bind(
+        record.hostId,
+        record.weekStart,
+        record.summaryJson,
+        record.html,
+        record.delivered ? 1 : 0,
+        record.generatedAt
+      )
+      .run()
+    return true
+  } catch (err) {
+    warn(
+      `failed to persist weekly report for ${record.hostId}/${record.weekStart}: ${err}`
+    )
+    return false
+  }
+}
+
+/**
+ * Read the persisted report for a host/week.
+ * Returns `null` when none exists yet, D1 is unavailable, or the read fails.
+ */
+export async function getWeeklyReport(
+  hostId: string,
+  weekStart: string
+): Promise<WeeklyReportRecord | null> {
+  try {
+    const db = getDb()
+    if (!db) return null
+    await ensureMigrated(db)
+
+    const row = await db
+      .prepare(
+        `SELECT host_id, week_start, summary_json, html, delivered, generated_at
+         FROM ${TABLE} WHERE host_id = ?1 AND week_start = ?2`
+      )
+      .bind(hostId, weekStart)
+      .first<D1WeeklyReportRow>()
+
+    return row ? rowToRecord(row) : null
+  } catch (err) {
+    warn(`failed to read weekly report for ${hostId}/${weekStart}: ${err}`)
+    return null
+  }
+}
+
+/**
+ * List recent persisted reports for a host, newest first.
+ * Best-effort — returns `[]` on any failure.
+ */
+export async function listWeeklyReports(
+  hostId: string,
+  limit = 12
+): Promise<WeeklyReportRecord[]> {
+  try {
+    const db = getDb()
+    if (!db) return []
+    await ensureMigrated(db)
+
+    const result = await db
+      .prepare(
+        `SELECT host_id, week_start, summary_json, html, delivered, generated_at
+         FROM ${TABLE} WHERE host_id = ?1
+         ORDER BY week_start DESC
+         LIMIT ?2`
+      )
+      .bind(hostId, Math.min(Math.max(Math.trunc(limit) || 0, 1), 100))
+      .all<D1WeeklyReportRow>()
+
+    return (result.results ?? []).map(rowToRecord)
+  } catch (err) {
+    warn(`failed to list weekly reports for ${hostId}: ${err}`)
+    return []
+  }
+}
+
+/** Test-only: clear the memoized migration promise so the next call retries. */
+export function resetWeeklyReportMigrationCache(): void {
+  migration = null
+}

--- a/apps/dashboard/src/lib/insights/weekly-report.ts
+++ b/apps/dashboard/src/lib/insights/weekly-report.ts
@@ -1,0 +1,430 @@
+/**
+ * Proactive weekly health report.
+ *
+ * Composes a per-host cluster-health narrative from a rolling 7-day window:
+ * top findings from the AI insights engine (`ai-insight` findings, which
+ * already fold in the statistical baselines from plan 48 — see
+ * `collectors.ts`'s baseline-backed detail strings), a count of adaptive
+ * baselines fitted for this host, and the disk-capacity outlook from the
+ * capacity forecaster (plan 50). Delivered best-effort via the existing
+ * outbound alert webhook (`HEALTH_ALERT_WEBHOOK_URL`) when configured — email
+ * (plan 25) and the native Slack app (plan 37) are not merged yet, so the
+ * webhook channel already used for regular alerts is the "configured channel"
+ * this reuses. The report is ALWAYS persisted regardless of delivery outcome
+ * (fail-open — see plans/52-proactive-weekly-health-report.md).
+ */
+
+import type { InsightSeverity } from './types'
+import type { ForecastResult } from '@/lib/ai/advisor/capacity-forecaster'
+
+import { debug, warn } from '@chm/logger'
+import { forecastDiskFull } from '@/lib/ai/advisor/capacity-forecaster'
+import { validateHostUrl } from '@/lib/browser-connections/host-url'
+import { listBaselines } from './baseline-store'
+import { resolveInsightsStore } from './store/resolve-store'
+import { INSIGHT_SOURCES, insightKey } from './types'
+import { renderWeeklyReportHtml } from './weekly-report-html'
+import { persistWeeklyReport } from './weekly-report-store'
+
+const WINDOW_SINCE = '7 DAY'
+const WINDOW_DAYS = 7
+const MAX_TOP_FINDINGS = 5
+const MAX_CATEGORY_BREAKDOWN = 6
+/** Discord's `content` field caps at 2000 chars; stay safely under it. */
+const MAX_WEBHOOK_TEXT_LENGTH = 1900
+
+const VALID_SEVERITY = new Set<InsightSeverity>(['info', 'warning', 'critical'])
+const SEVERITY_RANK: Record<InsightSeverity, number> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+}
+
+function toSeverity(value: string): InsightSeverity {
+  return VALID_SEVERITY.has(value as InsightSeverity)
+    ? (value as InsightSeverity)
+    : 'info'
+}
+
+/** A single highlighted finding surfaced in the "top findings" section. */
+export interface WeeklyTopFinding {
+  readonly severity: InsightSeverity
+  readonly category: string
+  readonly title: string
+  readonly detail: string
+  readonly metric: string
+  readonly generatedAt: string
+}
+
+/** Capacity section: the real forecast, or a degraded-but-honest fallback. */
+export type WeeklyReportCapacity =
+  | ForecastResult
+  | {
+      readonly available: false
+      readonly reason: 'error'
+      readonly message: string
+    }
+
+/** Compact, JSON-serializable summary of a host's weekly report. */
+export interface WeeklyReportSummary {
+  readonly hostId: number
+  readonly hostLabel: string
+  /** Start of the rolling 7-day window, `YYYY-MM-DD`. */
+  readonly weekStart: string
+  /** End of the window (today), `YYYY-MM-DD`. */
+  readonly weekEnd: string
+  readonly generatedAt: string
+  readonly totalFindings: number
+  readonly bySeverity: Record<InsightSeverity, number>
+  readonly byCategory: Record<string, number>
+  readonly topFindings: readonly WeeklyTopFinding[]
+  /** Count of metrics with a fitted statistical baseline (plan 48). */
+  readonly baselinesFitted: number
+  readonly capacity: WeeklyReportCapacity
+}
+
+export interface WeeklyReport {
+  readonly summary: WeeklyReportSummary
+  /** Markdown narrative — the full digest, before any delivery-channel truncation. */
+  readonly markdown: string
+  /** Presentation-quality, fully self-contained HTML document (see `weekly-report-html.ts`). */
+  readonly html: string
+}
+
+/**
+ * Parse the server-side per-host opt-in allowlist from
+ * `CHM_WEEKLY_REPORT_HOSTS` (comma-separated host indices, e.g. `"0,2"`).
+ *
+ * The opt-in is intentionally a Worker-readable env var, NOT the per-user
+ * localStorage `InsightsSettings` — the cron runs server-side and cannot read a
+ * browser's localStorage. Default (unset/empty) = an EMPTY set, so a
+ * self-hosted deployment that never sets it generates no weekly reports and
+ * stays quiet: opt-in, never opt-out. Garbage entries are dropped.
+ */
+export function parseOptedInHosts(raw: string | undefined | null): number[] {
+  if (!raw) return []
+  const seen = new Set<number>()
+  for (const part of raw.split(',')) {
+    const n = Number.parseInt(part.trim(), 10)
+    if (Number.isInteger(n) && n >= 0) seen.add(n)
+  }
+  return [...seen].sort((a, b) => a - b)
+}
+
+function dateNDaysAgo(n: number): string {
+  return new Date(Date.now() - n * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10)
+}
+
+/**
+ * Build the top-N findings list: dedupe by stable key (newest occurrence
+ * wins — `store.list()` returns newest-first) and rank by severity then
+ * recency, matching the overview panel's read-path ordering (`read-insights.ts`).
+ */
+function buildTopFindings(
+  hostId: number,
+  rows: ReadonlyArray<{
+    event_time: string
+    severity: string
+    category: string
+    title: string
+    detail: string
+    metric: string
+  }>
+): WeeklyTopFinding[] {
+  const byKey = new Map<string, WeeklyTopFinding>()
+  for (const row of rows) {
+    const key = insightKey(hostId, {
+      category: row.category,
+      metric: row.metric || undefined,
+      title: row.title,
+    })
+    if (byKey.has(key)) continue
+    byKey.set(key, {
+      severity: toSeverity(row.severity),
+      category: row.category,
+      title: row.title,
+      detail: row.detail,
+      metric: row.metric,
+      generatedAt: row.event_time,
+    })
+  }
+
+  return [...byKey.values()]
+    .sort((a, b) => {
+      const bySeverity = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]
+      if (bySeverity !== 0) return bySeverity
+      return b.generatedAt.localeCompare(a.generatedAt)
+    })
+    .slice(0, MAX_TOP_FINDINGS)
+}
+
+function formatCategoryBreakdown(byCategory: Record<string, number>): string {
+  const entries = Object.entries(byCategory).sort((a, b) => b[1] - a[1])
+  if (entries.length === 0) return 'No categories recorded.'
+  return entries
+    .slice(0, MAX_CATEGORY_BREAKDOWN)
+    .map(([category, count]) => `${category} (${count})`)
+    .join(', ')
+}
+
+function capacityLine(capacity: WeeklyReportCapacity): string {
+  if (!capacity.available) return capacity.message
+  return capacity.explanation
+}
+
+function buildMarkdown(summary: WeeklyReportSummary): string {
+  const { bySeverity } = summary
+  const lines: string[] = []
+
+  lines.push(`# Weekly Health Report — ${summary.hostLabel}`)
+  lines.push(
+    `**Window:** ${summary.weekStart} → ${summary.weekEnd} (last ${WINDOW_DAYS} days) · Generated ${summary.generatedAt}`
+  )
+  lines.push('')
+  lines.push('## Summary')
+  lines.push(
+    `- **${summary.totalFindings} findings** recorded (${bySeverity.critical} critical, ${bySeverity.warning} warning, ${bySeverity.info} info)`
+  )
+  lines.push(
+    `- **Top categories:** ${formatCategoryBreakdown(summary.byCategory)}`
+  )
+  lines.push(
+    `- **${summary.baselinesFitted} metrics** have adaptive statistical baselines fitted to this cluster (vs. fixed defaults)`
+  )
+  lines.push('')
+  lines.push('## Top findings')
+  if (summary.topFindings.length === 0) {
+    lines.push('No notable findings this week.')
+  } else {
+    summary.topFindings.forEach((f, i) => {
+      lines.push(
+        `${i + 1}. **[${f.severity.toUpperCase()}] ${f.title}** — ${f.detail}`
+      )
+    })
+  }
+  lines.push('')
+  lines.push('## Capacity outlook')
+  lines.push(capacityLine(summary.capacity))
+  lines.push('')
+  lines.push('## Recommendations')
+  lines.push(
+    `This report is generated automatically from chmonitor's AI insights engine, ` +
+      `statistical baselines, and capacity forecasting. Recommendations are advisory ` +
+      `only — nothing above was applied automatically. Open the AI agent ` +
+      `(\`/agents?host=${summary.hostId}\`) to dig deeper into any finding above.`
+  )
+
+  return lines.join('\n')
+}
+
+/**
+ * Build a host's weekly health report from real insights + baselines +
+ * capacity forecast. Never throws — a failure in any one input (ClickHouse,
+ * D1) degrades that section to an empty/unavailable state rather than
+ * aborting the whole report, so callers can always persist *something*.
+ */
+export async function buildWeeklyReport(
+  hostId: number,
+  hostLabel = `Host ${hostId}`
+): Promise<WeeklyReport> {
+  const weekStart = dateNDaysAgo(WINDOW_DAYS)
+  const weekEnd = dateNDaysAgo(0)
+  const generatedAt = new Date().toISOString()
+
+  let rows: Array<{
+    event_time: string
+    severity: string
+    category: string
+    title: string
+    detail: string
+    metric: string
+  }> = []
+  try {
+    const store = await resolveInsightsStore()
+    const listed = await store.list(hostId, {
+      since: WINDOW_SINCE,
+      limit: 1000,
+    })
+    rows = listed.filter((r) =>
+      INSIGHT_SOURCES.includes(r.source as (typeof INSIGHT_SOURCES)[number])
+    )
+  } catch (err) {
+    debug(
+      `[weekly-report] failed to read insights for host ${hostId}: ${err instanceof Error ? err.message : String(err)}`
+    )
+  }
+
+  const bySeverity: Record<InsightSeverity, number> = {
+    info: 0,
+    warning: 0,
+    critical: 0,
+  }
+  const byCategory: Record<string, number> = {}
+  for (const row of rows) {
+    bySeverity[toSeverity(row.severity)]++
+    byCategory[row.category] = (byCategory[row.category] ?? 0) + 1
+  }
+
+  const topFindings = buildTopFindings(hostId, rows)
+
+  let baselinesFitted = 0
+  try {
+    baselinesFitted = (await listBaselines(String(hostId))).length
+  } catch (err) {
+    debug(
+      `[weekly-report] failed to list baselines for host ${hostId}: ${err instanceof Error ? err.message : String(err)}`
+    )
+  }
+
+  let capacity: WeeklyReportCapacity
+  try {
+    capacity = await forecastDiskFull(hostId)
+  } catch (err) {
+    capacity = {
+      available: false,
+      reason: 'error',
+      message: `Capacity forecast unavailable: ${err instanceof Error ? err.message : String(err)}`,
+    }
+  }
+
+  const summary: WeeklyReportSummary = {
+    hostId,
+    hostLabel,
+    weekStart,
+    weekEnd,
+    generatedAt,
+    totalFindings: rows.length,
+    bySeverity,
+    byCategory,
+    topFindings,
+    baselinesFitted,
+    capacity,
+  }
+
+  return {
+    summary,
+    markdown: buildMarkdown(summary),
+    html: renderWeeklyReportHtml(summary),
+  }
+}
+
+function truncateForWebhook(markdown: string): string {
+  if (markdown.length <= MAX_WEBHOOK_TEXT_LENGTH) return markdown
+  return `${markdown.slice(0, MAX_WEBHOOK_TEXT_LENGTH - 15)}\n…(truncated)`
+}
+
+/**
+ * Best-effort delivery to the existing outbound alert webhook
+ * (`HEALTH_ALERT_WEBHOOK_URL`). SSRF-guarded: `validateHostUrl` rejects
+ * private/loopback/link-local/metadata destinations before the fetch, mirroring
+ * `/api/v1/health/webhook`'s proxy guard. Never throws — returns `false` on any
+ * failure (blocked URL, network error, non-2xx response) so a delivery problem
+ * never blocks persistence.
+ */
+async function deliverWeeklyReportWebhook(
+  url: string,
+  report: WeeklyReport
+): Promise<boolean> {
+  try {
+    const ssrfError = await validateHostUrl(url)
+    if (ssrfError) {
+      warn(`[weekly-report] blocked SSRF-unsafe webhook URL: ${ssrfError}`)
+      return false
+    }
+
+    const text = truncateForWebhook(report.markdown)
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 10_000)
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text, content: text }),
+        signal: controller.signal,
+      })
+      return res.ok
+    } finally {
+      clearTimeout(timeout)
+    }
+  } catch (err) {
+    warn(
+      `[weekly-report] webhook delivery failed for host ${report.summary.hostId}: ${err instanceof Error ? err.message : String(err)}`
+    )
+    return false
+  }
+}
+
+/** Outcome of running the weekly report pipeline for one host. */
+export interface WeeklyReportRunResult {
+  readonly hostId: number
+  /** Whether the report was successfully written to the weekly_reports store. */
+  readonly persisted: boolean
+  /** Whether a configured channel accepted the report. */
+  readonly delivered: boolean
+  /** Whether any delivery channel was configured at all (independent of success). */
+  readonly channelConfigured: boolean
+  readonly summary: WeeklyReportSummary
+}
+
+/**
+ * Build, persist, and best-effort deliver one host's weekly report.
+ *
+ * DELIVER-OR-PERSIST: persistence is attempted unconditionally (fail-open —
+ * plans 25/email and 37/Slack-native are not merged yet, so there may be no
+ * delivery channel at all). Delivery is attempted only when the existing
+ * outbound alert webhook (`HEALTH_ALERT_WEBHOOK_URL`) is configured, and a
+ * failed delivery never throws or blocks the already-persisted report.
+ */
+export async function runWeeklyReportForHost(
+  hostId: number,
+  hostLabel?: string
+): Promise<WeeklyReportRunResult> {
+  const report = await buildWeeklyReport(hostId, hostLabel)
+  const weekStart = report.summary.weekStart
+  const generatedAt = Date.now()
+
+  const persisted = await persistWeeklyReport({
+    hostId: String(hostId),
+    weekStart,
+    summaryJson: JSON.stringify(report.summary),
+    html: report.html,
+    delivered: false,
+    generatedAt,
+  })
+
+  const webhookUrl = (process.env.HEALTH_ALERT_WEBHOOK_URL ?? '').trim()
+  const channelConfigured = Boolean(webhookUrl)
+
+  let delivered = false
+  if (channelConfigured) {
+    try {
+      delivered = await deliverWeeklyReportWebhook(webhookUrl, report)
+    } catch {
+      delivered = false
+    }
+
+    if (delivered) {
+      // Update the SAME (host_id, week_start) row in place so the persisted
+      // record reflects delivery — never re-attempt persistence of the base
+      // report if this best-effort update fails.
+      await persistWeeklyReport({
+        hostId: String(hostId),
+        weekStart,
+        summaryJson: JSON.stringify(report.summary),
+        html: report.html,
+        delivered: true,
+        generatedAt,
+      })
+    }
+  }
+
+  return {
+    hostId,
+    persisted,
+    delivered,
+    channelConfigured,
+    summary: report.summary,
+  }
+}

--- a/apps/dashboard/src/routes/api/cron/weekly-report.ts
+++ b/apps/dashboard/src/routes/api/cron/weekly-report.ts
@@ -1,0 +1,127 @@
+/**
+ * Weekly Health Report Cron Endpoint — GET /api/cron/weekly-report
+ *
+ * Invoked on a weekly schedule (see wrangler.toml `[triggers] crons`, and the
+ * external-scheduler note in docs — like health-sweep and retention-prune, the
+ * secret-gated GET is triggered by a scheduler that forwards `CRON_SECRET`).
+ * For each host that has OPTED IN (via the `CHM_WEEKLY_REPORT_HOSTS`
+ * comma-separated allowlist of host indices), it builds a per-host 7-day health
+ * narrative from the insights engine + statistical baselines + capacity
+ * forecast, PERSISTS it to the `weekly_reports` D1 store, and best-effort
+ * delivers it via the configured outbound channel. Persistence happens
+ * regardless of delivery (fail-open), so a deployment with no delivery channel
+ * still accrues viewable reports (see GET /api/v1/insights/weekly-report).
+ *
+ * Opt-in, never opt-out: with `CHM_WEEKLY_REPORT_HOSTS` unset/empty NO reports
+ * are generated, so self-hosted stays quiet by default.
+ *
+ * Guarded by a shared secret (CRON_SECRET) via the `Authorization: Bearer
+ * <secret>` header or the `?secret=` query param — identical to health-sweep.
+ * When CRON_SECRET is unset/empty this endpoint FAILS CLOSED with HTTP 503; the
+ * platform routes scheduled events to the fetch handler as a plain GET with no
+ * trusted in-request signal, so an unauthenticated caller must not be able to
+ * trigger the sweep and its delivery fan-out.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { error, warn } from '@chm/logger'
+import { getClickHouseConfigsFromEnv } from '@/lib/api/clickhouse-config'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { secretsMatch } from '@/lib/auth/providers/constant-time'
+import { getHost } from '@/lib/utils'
+import {
+  parseOptedInHosts,
+  runWeeklyReportForHost,
+} from '@/lib/insights/weekly-report'
+
+/**
+ * Authorize a cron request. Returns a short-circuit `Response` when the request
+ * must be rejected, or `null` when it is authorized to proceed. Fail-closed:
+ * without a configured CRON_SECRET this endpoint returns 503. Mirrors
+ * health-sweep exactly.
+ */
+function authorizeCron(request: Request): Response | null {
+  const bindings = env as Record<string, string | undefined>
+  const secret = (bindings.CRON_SECRET ?? process.env.CRON_SECRET)?.trim()
+
+  if (!secret) {
+    warn(
+      '[GET /api/cron/weekly-report] CRON_SECRET not configured — refusing (503). Set CRON_SECRET to enable this endpoint.'
+    )
+    return Response.json(
+      { error: 'CRON_SECRET not configured' },
+      { status: 503 }
+    )
+  }
+
+  const authHeader = request.headers.get('authorization')
+  if (authHeader && secretsMatch(authHeader, `Bearer ${secret}`)) return null
+
+  const url = new URL(request.url)
+  const querySecret = url.searchParams.get('secret')
+  if (querySecret && secretsMatch(querySecret, secret)) return null
+
+  return Response.json({ error: 'Unauthorized' }, { status: 401 })
+}
+
+async function handler(request: Request): Promise<Response> {
+  const denied = authorizeCron(request)
+  if (denied) return denied
+
+  const bindings = env as Record<string, string | undefined>
+  bridgeClickHouseEnv(bindings)
+
+  try {
+    const optedIn = parseOptedInHosts(
+      bindings.CHM_WEEKLY_REPORT_HOSTS ?? process.env.CHM_WEEKLY_REPORT_HOSTS
+    )
+
+    // Resolve labels from the configured hosts; only report on opted-in indices
+    // that actually correspond to a configured host.
+    const configs = getClickHouseConfigsFromEnv(bindings)
+    const byId = new Map(configs.map((c) => [c.id, c]))
+
+    const results = []
+    for (const hostId of optedIn) {
+      const cfg = byId.get(hostId)
+      if (!cfg) {
+        warn(
+          `[GET /api/cron/weekly-report] opted-in host ${hostId} has no configured ClickHouse host — skipping`
+        )
+        continue
+      }
+      const label = cfg.customName || getHost(cfg.host) || `Host ${hostId}`
+      results.push(await runWeeklyReportForHost(hostId, label))
+    }
+
+    return Response.json(
+      {
+        optedInHosts: optedIn,
+        reported: results.length,
+        results,
+      },
+      { status: 200 }
+    )
+  } catch (err) {
+    error(
+      '[GET /api/cron/weekly-report] Weekly report run failed',
+      err as Error
+    )
+    return Response.json(
+      {
+        error: err instanceof Error ? err.message : 'Weekly report run failed',
+      },
+      { status: 500 }
+    )
+  }
+}
+
+export const Route = createFileRoute('/api/cron/weekly-report')({
+  server: {
+    handlers: {
+      GET: ({ request }) => handler(request),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/v1/insights/weekly-report.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/weekly-report.ts
@@ -1,0 +1,112 @@
+/**
+ * Weekly Health Report view/download endpoint — GET /api/v1/insights/weekly-report
+ *
+ * Returns a persisted weekly report so it can be viewed or downloaded even when
+ * NO delivery channel (email/Slack) is configured — the report is always
+ * persisted by the cron, and this route surfaces it. Reads from the
+ * `weekly_reports` D1 store (fail-open: returns 404 when D1 is unavailable or
+ * the report doesn't exist yet).
+ *
+ * Query parameters:
+ * - host (optional, default 0): host index to read the report for
+ * - week (optional): the report's `week_start` (`YYYY-MM-DD`); defaults to the
+ *   most recent persisted report for the host
+ * - format (optional): `html` (default) returns the self-contained HTML
+ *   document; `json` returns the parsed summary + metadata
+ *
+ * Auth posture mirrors GET /api/v1/insights — it inherits the deployment's auth
+ * posture (self-hosted `none`, cloud Clerk/public-read via middleware) rather
+ * than hard-gating on Clerk, so self-hosted stays whole.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { error, generateRequestId } from '@chm/logger'
+import {
+  getWeeklyReport,
+  listWeeklyReports,
+  type WeeklyReportRecord,
+} from '@/lib/insights/weekly-report-store'
+import type { WeeklyReportSummary } from '@/lib/insights/weekly-report'
+import { renderWeeklyReportHtml } from '@/lib/insights/weekly-report-html'
+
+/** Re-render HTML from the stored summary when the persisted `html` is empty. */
+function htmlFor(record: WeeklyReportRecord): string {
+  if (record.html) return record.html
+  try {
+    const summary = JSON.parse(record.summaryJson) as WeeklyReportSummary
+    return renderWeeklyReportHtml(summary)
+  } catch {
+    return '<!doctype html><meta charset="utf-8"><body>Report unavailable.</body>'
+  }
+}
+
+export const Route = createFileRoute('/api/v1/insights/weekly-report')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const requestId = generateRequestId()
+        try {
+          const params = new URL(request.url).searchParams
+
+          const hostId = Number.parseInt(params.get('host') ?? '0', 10)
+          if (!Number.isInteger(hostId) || hostId < 0) {
+            return Response.json(
+              {
+                error: 'Invalid host parameter: must be a non-negative integer',
+              },
+              { status: 400, headers: { 'X-Request-ID': requestId } }
+            )
+          }
+
+          const week = params.get('week')?.trim()
+          const record = week
+            ? await getWeeklyReport(String(hostId), week)
+            : (await listWeeklyReports(String(hostId), 1))[0]
+
+          if (!record) {
+            return Response.json(
+              { error: 'No weekly report found for this host/week' },
+              { status: 404, headers: { 'X-Request-ID': requestId } }
+            )
+          }
+
+          if (params.get('format') === 'json') {
+            let summary: unknown = null
+            try {
+              summary = JSON.parse(record.summaryJson)
+            } catch {
+              summary = null
+            }
+            return Response.json(
+              {
+                hostId: record.hostId,
+                weekStart: record.weekStart,
+                delivered: record.delivered,
+                generatedAt: record.generatedAt,
+                summary,
+              },
+              { headers: { 'X-Request-ID': requestId } }
+            )
+          }
+
+          return new Response(htmlFor(record), {
+            status: 200,
+            headers: {
+              'Content-Type': 'text/html; charset=utf-8',
+              'X-Request-ID': requestId,
+            },
+          })
+        } catch (err) {
+          error('[GET /api/v1/insights/weekly-report] Unexpected error:', err, {
+            requestId,
+          })
+          return Response.json(
+            { error: err instanceof Error ? err.message : 'Unknown error' },
+            { status: 500, headers: { 'X-Request-ID': requestId } }
+          )
+        }
+      },
+    },
+  },
+})

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -118,15 +118,19 @@ custom_domain = true
 # CHM_PROXY_AUTH_SECRET via: wrangler secret put CHM_PROXY_AUTH_SECRET
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Cron triggers. The @cloudflare/vite-plugin routes scheduled events to the
-# worker's fetch handler, which TanStack Start then dispatches to the matching
-# GET route (see src/routes/api/cron/). Each cron hits its corresponding route
-# via a synthetic GET request: retention-prune runs once daily at 03:00 UTC.
+# Cron triggers. These secret-gated GET routes (see src/routes/api/cron/) are
+# invoked by a scheduler that forwards CRON_SECRET as `Authorization: Bearer
+# <secret>` (an external scheduler, or a Cloudflare Cron that forwards the
+# secret to the route's URL — see docs/content/guide/features/health.mdx). The
+# schedules below document each cadence:
+#   - "0 3 * * *"  → retention-prune, daily at 03:00 UTC.
+#   - "0 8 * * 1"  → weekly-report, Mondays at 08:00 UTC (per-host opt-in via
+#     CHM_WEEKLY_REPORT_HOSTS; no-op when unset).
 # health-sweep (every 5 min) should be added here when that route is confirmed
 # working end-to-end.
 # ─────────────────────────────────────────────────────────────────────────────
 [triggers]
-crons = ["0 3 * * *"]
+crons = ["0 3 * * *", "0 8 * * 1"]
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Preview environment for PR deployments


### PR DESCRIPTION
Implements **plan 52 — proactive weekly health report** (depth F).

A weekly per-host cron composes a cluster-health narrative from the insights engine + statistical baselines (plan 48) + capacity forecaster (plan 50), and delivers it via the configured channel or persists-only when none is set. The **priority deliverable is the polished, self-contained HTML narrative** — it renders as a presentation-quality report (Anthropic-Artifact aesthetic), not a markdown dump.

## What's in it
- **`lib/insights/weekly-report.ts`** — `buildWeeklyReport(hostId)` pulls the last 7d `ai-insight` findings from the pluggable insights store, summarizes by category/severity, dedupes/ranks top findings, folds in the count of fitted baselines and the disk-capacity forecast, and returns a structured `WeeklyReportSummary` + Markdown + HTML. `parseOptedInHosts()` parses the server-side opt-in allowlist. Delivery + persistence in `runWeeklyReportForHost` (persist is unconditional/fail-open; delivery best-effort, SSRF-guarded).
- **`lib/insights/weekly-report-html.ts`** — `renderWeeklyReportHtml(summary)`: a **pure, independently-testable** HTML builder, cleanly separated from data assembly. Fully self-contained (inline `<style>`, **no external `<link>`/`<script src>`/fonts/images**), dark-mode aware via `prefers-color-scheme`, styled with the dashboard's own OKLCH design tokens (`styles.css`). Sections: header/eyebrow band, 4 severity stat cards, stacked severity distribution bar + legend, severity-colored finding cards (left-border accent + badge), category bars, and a capacity card with an inline disk-utilization bar that turns red in the ≥80% "hot" state. Untrusted finding text is HTML-escaped.
- **`routes/api/cron/weekly-report.ts`** — `GET /api/cron/weekly-report`, **CRON_SECRET-gated, fail-closed (503 when unset)**, mirroring `health-sweep.ts` exactly. Iterates opted-in hosts (`CHM_WEEKLY_REPORT_HOSTS`, comma-separated indices, **empty by default → no-op**), builds + delivers + persists each.
- **`routes/api/v1/insights/weekly-report.ts`** — `GET /api/v1/insights/weekly-report?host=&week=&format=` to view/download the persisted HTML (default) or JSON summary, so reports are viewable even with **zero delivery channels configured**. Auth posture mirrors `/api/v1/insights` (inherits deployment auth; self-hosted stays whole).
- **`lib/insights/weekly-report-store.ts` + `0014_weekly_reports.sql`** — D1 `weekly_reports` table (`host_id, week_start, summary_json, html, delivered, generated_at`) mirroring the insights D1 store pattern: lazy `CREATE TABLE IF NOT EXISTS`, single-flight migration, upsert on (host_id, week_start), **fail-open** (swallows store errors → self-hosted whole). DDL kept byte-for-byte in sync with the migration file.
- **`wrangler.toml`** — weekly cron entry `"0 8 * * 1"` (Mondays 08:00 UTC). *Note:* these secret-gated GET cron routes are invoked by an external scheduler / Worker-Cron that forwards `CRON_SECRET` (per `docs/.../health.mdx`); the comment documents cadence without claiming an auto per-path dispatcher that doesn't exist in-repo.

## Design decisions (per plan STOP/drift checks)
- **Opt-in source is a Worker-readable env allowlist**, not the per-user localStorage `InsightsSettings` — the cron runs server-side and can't read a browser's localStorage. Default empty = opt-in, never opt-out; self-hosted stays quiet.
- **Delivery adapters (email plan 25 / Slack plan 37) are not merged**, so per the plan's STOP condition delivery is gated behind an adapter-present check (reuses the existing outbound alert webhook when configured) and the report is **always persisted** regardless. Standalone view/download works with no channels.
- **Recommend-only / honest content**: the narrative only restates what insights/baselines/forecaster computed; the footer states "nothing here was applied automatically". Capacity `part_log`-unavailable case degrades gracefully.
- Built on prior in-progress work for this plan (store/data-assembly), extended with the HTML renderer, `html` column, view route, cron, opt-in, wrangler, and tests.

## Verification
```
cd apps/dashboard && bun run type-check   # exit 0
cd apps/dashboard && bun run build         # exit 0 (regenerates route tree)
cd apps/dashboard && bun test src/lib/insights --isolate   # 326 pass, 0 fail
bun run lint                               # exit 0 — Checked 2046 files, no fixes
```
Also rendered a rich fixture through `renderWeeklyReportHtml` and screenshotted it in-browser (dark) — reads as a genuinely polished report: severity stat cards, distribution bar, severity-accented finding cards, category bars, and a red disk-utilization bar in the hot state.

https://claude.ai/code/session_01XpfaNdJZh4Rtr6cQm4DYqa