### PR TITLE
feat(query-config): declarative chart schema (plan 58)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,7 @@ Developer-facing docs live in `docs/knowledge/` as a linked knowledge graph. Eac
 | Specs | [mcp-clerk-oauth.md](docs/knowledge/mcp-clerk-oauth.md) | MCP endpoint auth postures (open / HMAC API key / Clerk OAuth); either credential accepted when both set; REST token verification runs in both Worker and Next.js runtimes |
 | Specs | [agentstate-conversation-store.md](docs/knowledge/agentstate-conversation-store.md) | AgentState conversation backend: store priority, per-user external_id/tag isolation, append-only upsert, AI enrichment, backend/follow-ups routes |
 | Specs | [query-config-format.md](docs/knowledge/query-config-format.md) | QueryConfig type, versioned SQL, BackgroundBar |
+| Specs | [chart-config-format.md](docs/knowledge/chart-config-format.md) | Declarative chart schema/loader mirroring the query-config declarative system: area/bar factory config as data, chartName → chart-registry key, yAxisTickFormatterKey, lazy lucide-react icon resolution, ported chart templates (dormant, additive-only) |
 | Specs | [cluster-topology.md](docs/knowledge/cluster-topology.md) | Cluster topology SVG: layout pipeline, constant contracts, OKLCH `hsl(var())` gotcha, shared component, verification harness |
 | Development | [component-ci-stability.md](docs/knowledge/component-ci-stability.md) | Cypress component test fragility and fixes |
 | Development | [conventions.md](docs/knowledge/conventions.md) | Coding conventions, file org, component patterns |

--- a/apps/dashboard/src/components/charts/declarative/catalog/catalog.test.ts
+++ b/apps/dashboard/src/components/charts/declarative/catalog/catalog.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Catalog-wide sanity checks for DECLARATIVE_CHART_CATALOG
+ * (plans/58-declarative-chart-schema.md). Per-domain parity tests
+ * (query/query-catalog.test.ts, system/system-catalog.test.ts, …) prove each
+ * entry round-trips to its hand-authored factory config — but that comparison
+ * is against a *transcription* of the original factory call (the hand-authored
+ * chart files export only a rendered FC, not their config object, so there is
+ * no live reference to import and diff against; touching those files to
+ * export the config would violate the "additive only" constraint). The
+ * "resolves in the real chart-registry" test below is the one check here that
+ * verifies against a live source of truth rather than a transcription: it
+ * mirrors the orphan guard in
+ * `lib/query-config/declarative/catalog/flip-safety.test.ts`, catching a
+ * typo'd `chartName` that would otherwise 404 silently at
+ * `GET /api/v1/charts/$chartName` instead of failing a test.
+ */
+
+import { loadDeclarativeChart } from '../loader'
+import { DECLARATIVE_CHART_CATALOG } from './index'
+import { describe, expect, test } from 'bun:test'
+import { hasChart } from '@/lib/api/chart-registry'
+
+describe('DECLARATIVE_CHART_CATALOG', () => {
+  test('has at least 5 ported charts', () => {
+    expect(
+      Object.keys(DECLARATIVE_CHART_CATALOG).length
+    ).toBeGreaterThanOrEqual(5)
+  })
+
+  test('every entry is keyed by its own chartName', () => {
+    for (const [key, chart] of Object.entries(DECLARATIVE_CHART_CATALOG)) {
+      expect(chart.chartName).toBe(key)
+    }
+  })
+
+  test('every entry loads without error', () => {
+    for (const chart of Object.values(DECLARATIVE_CHART_CATALOG)) {
+      expect(() => loadDeclarativeChart(chart)).not.toThrow()
+    }
+  })
+
+  test('includes at least one area chart and one bar chart', () => {
+    const kinds = new Set(
+      Object.values(DECLARATIVE_CHART_CATALOG).map((c) => c.type)
+    )
+    expect(kinds.has('area')).toBe(true)
+    expect(kinds.has('bar')).toBe(true)
+  })
+
+  // Orphan guard: every chartName must resolve in the real, server-side
+  // chart-registry (lib/api/chart-registry.ts) — the declarative catalog
+  // describes presentation for a chart whose SQL is already registered there.
+  // A typo here would otherwise 404 silently at runtime instead of failing here.
+  test('every chartName resolves in the live chart-registry', () => {
+    for (const chartName of Object.keys(DECLARATIVE_CHART_CATALOG)) {
+      expect(hasChart(chartName)).toBe(true)
+    }
+  })
+})

--- a/apps/dashboard/src/components/charts/declarative/catalog/index.ts
+++ b/apps/dashboard/src/components/charts/declarative/catalog/index.ts
@@ -1,0 +1,52 @@
+/**
+ * DECLARATIVE_CHART_CATALOG — plans/58-declarative-chart-schema.md.
+ *
+ * Central registry of declarative chart definitions ported as templates,
+ * keyed by their `.chartName`. Mirrors
+ * `lib/query-config/declarative/catalog/index.ts`.
+ *
+ * DORMANT by design: nothing in the live app (routes, `chart-registry`)
+ * consumes this catalog yet — every hand-authored TS chart keeps rendering
+ * exactly as before. This is a template set + loader proof, not a cutover.
+ * See docs/knowledge/chart-config-format.md for the authoring format and the
+ * plan for how a future chart-picker / community catalog would consume it.
+ */
+
+import type { DeclarativeChart } from '../schema'
+
+import { errorRateOverTimeDeclarative } from './logs/error-rate-over-time'
+import { queryCountDeclarative } from './query/query-count'
+import { queryDurationDeclarative } from './query/query-duration'
+import { cpuUsageDeclarative } from './system/cpu-usage'
+import { memoryUsageDeclarative } from './system/memory-usage'
+import { zookeeperRequestsDeclarative } from './zookeeper/zookeeper-requests'
+
+const ALL_DECLARATIVE_CHARTS: DeclarativeChart[] = [
+  queryCountDeclarative,
+  queryDurationDeclarative,
+  memoryUsageDeclarative,
+  cpuUsageDeclarative,
+  zookeeperRequestsDeclarative,
+  errorRateOverTimeDeclarative,
+]
+
+// Assert no duplicate chartNames at module load time — two catalog entries
+// sharing a chartName would be an authoring bug and should fail loudly.
+const seen = new Set<string>()
+for (const chart of ALL_DECLARATIVE_CHARTS) {
+  if (seen.has(chart.chartName)) {
+    throw new Error(
+      `DECLARATIVE_CHART_CATALOG: duplicate chartName detected: '${chart.chartName}'. Each catalog entry must have a unique chartName.`
+    )
+  }
+  seen.add(chart.chartName)
+}
+
+export const DECLARATIVE_CHART_CATALOG: Record<string, DeclarativeChart> =
+  ALL_DECLARATIVE_CHARTS.reduce<Record<string, DeclarativeChart>>(
+    (acc, chart) => {
+      acc[chart.chartName] = chart
+      return acc
+    },
+    {}
+  )

--- a/apps/dashboard/src/components/charts/declarative/catalog/logs/error-rate-over-time.ts
+++ b/apps/dashboard/src/components/charts/declarative/catalog/logs/error-rate-over-time.ts
@@ -1,0 +1,29 @@
+import type { DeclarativeChart } from '../../schema'
+
+/**
+ * Declarative twin of `components/charts/logs/error-rate-over-time.tsx`
+ * (`ChartErrorRateOverTime`) — ported as a template for plans/58, and the
+ * catalog's multi-category + legend example.
+ */
+export const errorRateOverTimeDeclarative: DeclarativeChart = {
+  type: 'area',
+  chartName: 'error-rate-over-time',
+  icon: 'alert-triangle',
+  description: 'Error, warning, and info log volume over time',
+  index: 'event_time',
+  categories: ['error_count', 'warning_count', 'info_count'],
+  defaultTitle: 'Error Rate Over Time',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'error-rate-over-time-chart',
+  dateRangeConfig: 'realtime',
+  areaChartProps: {
+    readable: 'quantity',
+    stack: true,
+    showLegend: true,
+    showXAxis: true,
+    showCartesianGrid: true,
+    colors: ['--chart-red', '--chart-yellow', '--chart-blue'],
+    yAxisTickFormatterKey: 'count',
+  },
+}

--- a/apps/dashboard/src/components/charts/declarative/catalog/logs/logs-catalog.test.ts
+++ b/apps/dashboard/src/components/charts/declarative/catalog/logs/logs-catalog.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Parity test for the logs/ domain declarative chart catalog
+ * (plans/58-declarative-chart-schema.md). See
+ * ../query/query-catalog.test.ts for the parity-testing philosophy this
+ * mirrors. This is the catalog's multi-category + legend example.
+ */
+
+import { createChartFromDeclarative, loadDeclarativeChart } from '../../loader'
+import { errorRateOverTimeDeclarative } from './error-rate-over-time'
+import { describe, expect, test } from 'bun:test'
+import { chartTickFormatters } from '@/lib/utils'
+
+describe('error-rate-over-time declarative', () => {
+  test('loads without error', () => {
+    expect(() =>
+      loadDeclarativeChart(errorRateOverTimeDeclarative)
+    ).not.toThrow()
+  })
+
+  test('config matches the hand-authored createAreaChart call', () => {
+    const loaded = loadDeclarativeChart(errorRateOverTimeDeclarative)
+    expect(loaded.kind).toBe('area')
+    expect(loaded.config).toEqual({
+      chartName: 'error-rate-over-time',
+      index: 'event_time',
+      categories: ['error_count', 'warning_count', 'info_count'],
+      defaultTitle: 'Error Rate Over Time',
+      defaultInterval: 'toStartOfHour',
+      defaultLastHours: 24,
+      dataTestId: 'error-rate-over-time-chart',
+      dateRangeConfig: 'realtime',
+      areaChartProps: {
+        readable: 'quantity',
+        stack: true,
+        showLegend: true,
+        showXAxis: true,
+        showCartesianGrid: true,
+        colors: ['--chart-red', '--chart-yellow', '--chart-blue'],
+        yAxisTickFormatter: chartTickFormatters.count,
+      },
+    })
+  })
+
+  test('renders through createAreaChart without throwing', () => {
+    expect(() =>
+      createChartFromDeclarative(errorRateOverTimeDeclarative)
+    ).not.toThrow()
+  })
+})

--- a/apps/dashboard/src/components/charts/declarative/catalog/query/query-catalog.test.ts
+++ b/apps/dashboard/src/components/charts/declarative/catalog/query/query-catalog.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Parity tests for the query/ domain declarative chart catalog
+ * (plans/58-declarative-chart-schema.md).
+ *
+ * For each ported chart, assert that `loadDeclarativeChart(declarativeDef).config`
+ * deep-equals the exact config object literal the hand-authored TS chart
+ * passes to `createAreaChart`/`createBarChart` (transcribed here from
+ * `components/charts/query/query-count.tsx` / `query-duration.tsx`, which stay
+ * untouched — see the "Additive only" constraint in the plan). This is the
+ * same parity philosophy as
+ * `lib/query-config/declarative/catalog/merges/merges-catalog.test.ts`.
+ */
+
+import { createChartFromDeclarative, loadDeclarativeChart } from '../../loader'
+import { queryCountDeclarative } from './query-count'
+import { queryDurationDeclarative } from './query-duration'
+import { describe, expect, test } from 'bun:test'
+import { chartTickFormatters } from '@/lib/utils'
+
+describe('query-count declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeChart(queryCountDeclarative)).not.toThrow()
+  })
+
+  test('config matches the hand-authored createAreaChart call', () => {
+    const loaded = loadDeclarativeChart(queryCountDeclarative)
+    expect(loaded.kind).toBe('area')
+    expect(loaded.config).toEqual({
+      chartName: 'query-count',
+      index: 'event_time',
+      categories: ['query_count'],
+      defaultTitle: 'Query Count',
+      defaultInterval: 'toStartOfDay',
+      defaultLastHours: 24 * 14,
+      dataTestId: 'query-count-chart',
+      dateRangeConfig: 'query-activity',
+      showDeployments: true,
+      areaChartProps: {
+        readable: 'quantity',
+        stack: true,
+        showLegend: false,
+        showXAxis: true,
+        showCartesianGrid: true,
+        colors: ['--chart-yellow'],
+        breakdown: 'breakdown',
+        breakdownLabel: 'query_kind',
+        breakdownValue: 'count',
+        yAxisTickFormatter: chartTickFormatters.count,
+      },
+    })
+  })
+
+  test('renders through createAreaChart without throwing', () => {
+    expect(() =>
+      createChartFromDeclarative(queryCountDeclarative)
+    ).not.toThrow()
+  })
+})
+
+describe('query-duration declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeChart(queryDurationDeclarative)).not.toThrow()
+  })
+
+  test('config matches the hand-authored createAreaChart call', () => {
+    const loaded = loadDeclarativeChart(queryDurationDeclarative)
+    expect(loaded.kind).toBe('area')
+    expect(loaded.config).toEqual({
+      chartName: 'query-duration',
+      index: 'event_time',
+      categories: ['query_duration_s'],
+      defaultTitle: 'Query Duration',
+      defaultInterval: 'toStartOfDay',
+      defaultLastHours: 24 * 14,
+      dataTestId: 'query-duration-chart',
+      dateRangeConfig: 'query-duration',
+      areaChartProps: {
+        colors: ['--chart-rose-200'],
+        stack: true,
+        showLegend: false,
+        showXAxis: true,
+        showCartesianGrid: true,
+      },
+    })
+  })
+
+  test('renders through createAreaChart without throwing', () => {
+    expect(() =>
+      createChartFromDeclarative(queryDurationDeclarative)
+    ).not.toThrow()
+  })
+})

--- a/apps/dashboard/src/components/charts/declarative/catalog/query/query-count.ts
+++ b/apps/dashboard/src/components/charts/declarative/catalog/query/query-count.ts
@@ -1,0 +1,35 @@
+import type { DeclarativeChart } from '../../schema'
+
+/**
+ * Declarative twin of `components/charts/query/query-count.tsx`
+ * (`ChartQueryCount`) — ported as a template for plans/58. The hand-authored
+ * TS chart is untouched; this definition renders through the exact same
+ * `createAreaChart` factory call via `loadDeclarativeChart`/
+ * `createChartFromDeclarative`.
+ */
+export const queryCountDeclarative: DeclarativeChart = {
+  type: 'area',
+  chartName: 'query-count',
+  icon: 'bar-chart-3',
+  description: 'Query volume over time, broken down by query kind',
+  index: 'event_time',
+  categories: ['query_count'],
+  defaultTitle: 'Query Count',
+  defaultInterval: 'toStartOfDay',
+  defaultLastHours: 24 * 14,
+  dataTestId: 'query-count-chart',
+  dateRangeConfig: 'query-activity',
+  showDeployments: true,
+  areaChartProps: {
+    readable: 'quantity',
+    stack: true,
+    showLegend: false,
+    showXAxis: true,
+    showCartesianGrid: true,
+    colors: ['--chart-yellow'],
+    breakdown: 'breakdown',
+    breakdownLabel: 'query_kind',
+    breakdownValue: 'count',
+    yAxisTickFormatterKey: 'count',
+  },
+}

--- a/apps/dashboard/src/components/charts/declarative/catalog/query/query-duration.ts
+++ b/apps/dashboard/src/components/charts/declarative/catalog/query/query-duration.ts
@@ -1,0 +1,26 @@
+import type { DeclarativeChart } from '../../schema'
+
+/**
+ * Declarative twin of `components/charts/query/query-duration.tsx`
+ * (`ChartQueryDuration`) — ported as a template for plans/58.
+ */
+export const queryDurationDeclarative: DeclarativeChart = {
+  type: 'area',
+  chartName: 'query-duration',
+  icon: 'timer',
+  description: 'Average query duration over time',
+  index: 'event_time',
+  categories: ['query_duration_s'],
+  defaultTitle: 'Query Duration',
+  defaultInterval: 'toStartOfDay',
+  defaultLastHours: 24 * 14,
+  dataTestId: 'query-duration-chart',
+  dateRangeConfig: 'query-duration',
+  areaChartProps: {
+    colors: ['--chart-rose-200'],
+    stack: true,
+    showLegend: false,
+    showXAxis: true,
+    showCartesianGrid: true,
+  },
+}

--- a/apps/dashboard/src/components/charts/declarative/catalog/system/cpu-usage.ts
+++ b/apps/dashboard/src/components/charts/declarative/catalog/system/cpu-usage.ts
@@ -1,0 +1,22 @@
+import type { DeclarativeChart } from '../../schema'
+
+/**
+ * Declarative twin of `components/charts/system/cpu-usage.tsx`
+ * (`ChartCPUUsage`) — ported as a template for plans/58.
+ */
+export const cpuUsageDeclarative: DeclarativeChart = {
+  type: 'area',
+  chartName: 'cpu-usage',
+  icon: 'cpu',
+  description: 'Average CPU usage over time',
+  index: 'event_time',
+  categories: ['avg_cpu'],
+  defaultInterval: 'toStartOfTenMinutes',
+  defaultLastHours: 24,
+  dataTestId: 'cpu-usage-chart',
+  dateRangeConfig: 'system-metrics',
+  areaChartProps: {
+    colors: ['--chart-1'],
+    yAxisTickFormatterKey: 'duration',
+  },
+}

--- a/apps/dashboard/src/components/charts/declarative/catalog/system/memory-usage.ts
+++ b/apps/dashboard/src/components/charts/declarative/catalog/system/memory-usage.ts
@@ -1,0 +1,22 @@
+import type { DeclarativeChart } from '../../schema'
+
+/**
+ * Declarative twin of `components/charts/system/memory-usage.tsx`
+ * (`ChartMemoryUsage`) — ported as a template for plans/58.
+ */
+export const memoryUsageDeclarative: DeclarativeChart = {
+  type: 'area',
+  chartName: 'memory-usage',
+  icon: 'memory-stick',
+  description: 'Average memory usage over time',
+  index: 'event_time',
+  categories: ['avg_memory'],
+  defaultInterval: 'toStartOfTenMinutes',
+  defaultLastHours: 24,
+  dataTestId: 'memory-usage-chart',
+  dateRangeConfig: 'system-metrics',
+  areaChartProps: {
+    colors: ['--chart-12'],
+    yAxisTickFormatterKey: 'bytes',
+  },
+}

--- a/apps/dashboard/src/components/charts/declarative/catalog/system/system-catalog.test.ts
+++ b/apps/dashboard/src/components/charts/declarative/catalog/system/system-catalog.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Parity tests for the system/ domain declarative chart catalog
+ * (plans/58-declarative-chart-schema.md). See query-catalog.test.ts for the
+ * parity-testing philosophy this mirrors.
+ */
+
+import { createChartFromDeclarative, loadDeclarativeChart } from '../../loader'
+import { cpuUsageDeclarative } from './cpu-usage'
+import { memoryUsageDeclarative } from './memory-usage'
+import { describe, expect, test } from 'bun:test'
+import { chartTickFormatters } from '@/lib/utils'
+
+describe('memory-usage declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeChart(memoryUsageDeclarative)).not.toThrow()
+  })
+
+  test('config matches the hand-authored createAreaChart call', () => {
+    const loaded = loadDeclarativeChart(memoryUsageDeclarative)
+    expect(loaded.kind).toBe('area')
+    expect(loaded.config).toEqual({
+      chartName: 'memory-usage',
+      index: 'event_time',
+      categories: ['avg_memory'],
+      defaultInterval: 'toStartOfTenMinutes',
+      defaultLastHours: 24,
+      dataTestId: 'memory-usage-chart',
+      dateRangeConfig: 'system-metrics',
+      areaChartProps: {
+        colors: ['--chart-12'],
+        yAxisTickFormatter: chartTickFormatters.bytes,
+      },
+    })
+  })
+
+  test('renders through createAreaChart without throwing', () => {
+    expect(() =>
+      createChartFromDeclarative(memoryUsageDeclarative)
+    ).not.toThrow()
+  })
+})
+
+describe('cpu-usage declarative', () => {
+  test('loads without error', () => {
+    expect(() => loadDeclarativeChart(cpuUsageDeclarative)).not.toThrow()
+  })
+
+  test('config matches the hand-authored createAreaChart call', () => {
+    const loaded = loadDeclarativeChart(cpuUsageDeclarative)
+    expect(loaded.kind).toBe('area')
+    expect(loaded.config).toEqual({
+      chartName: 'cpu-usage',
+      index: 'event_time',
+      categories: ['avg_cpu'],
+      defaultInterval: 'toStartOfTenMinutes',
+      defaultLastHours: 24,
+      dataTestId: 'cpu-usage-chart',
+      dateRangeConfig: 'system-metrics',
+      areaChartProps: {
+        colors: ['--chart-1'],
+        yAxisTickFormatter: chartTickFormatters.duration,
+      },
+    })
+  })
+
+  test('renders through createAreaChart without throwing', () => {
+    expect(() => createChartFromDeclarative(cpuUsageDeclarative)).not.toThrow()
+  })
+})

--- a/apps/dashboard/src/components/charts/declarative/catalog/zookeeper/zookeeper-catalog.test.ts
+++ b/apps/dashboard/src/components/charts/declarative/catalog/zookeeper/zookeeper-catalog.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Parity test for the zookeeper/ domain declarative chart catalog
+ * (plans/58-declarative-chart-schema.md). See
+ * ../query/query-catalog.test.ts for the parity-testing philosophy this
+ * mirrors. This is the catalog's `type: 'bar'` (createBarChart) coverage.
+ */
+
+import { createChartFromDeclarative, loadDeclarativeChart } from '../../loader'
+import { zookeeperRequestsDeclarative } from './zookeeper-requests'
+import { describe, expect, test } from 'bun:test'
+import { chartTickFormatters } from '@/lib/utils'
+
+describe('zookeeper-requests declarative', () => {
+  test('loads without error', () => {
+    expect(() =>
+      loadDeclarativeChart(zookeeperRequestsDeclarative)
+    ).not.toThrow()
+  })
+
+  test('config matches the hand-authored createBarChart call', () => {
+    const loaded = loadDeclarativeChart(zookeeperRequestsDeclarative)
+    expect(loaded.kind).toBe('bar')
+    expect(loaded.config).toEqual({
+      chartName: 'zookeeper-requests',
+      index: 'event_time',
+      categories: ['ZookeeperRequests', 'ZooKeeperWatch'],
+      defaultTitle: 'ZooKeeper Requests',
+      defaultInterval: 'toStartOfHour',
+      defaultLastHours: 24 * 7,
+      dataTestId: 'zookeeper-requests-chart',
+      dateRangeConfig: 'health',
+      xAxisDateFormat: true,
+      barChartProps: {
+        showLegend: true,
+        stack: true,
+        yAxisTickFormatter: chartTickFormatters.count,
+      },
+    })
+  })
+
+  test('renders through createBarChart without throwing', () => {
+    expect(() =>
+      createChartFromDeclarative(zookeeperRequestsDeclarative)
+    ).not.toThrow()
+  })
+})

--- a/apps/dashboard/src/components/charts/declarative/catalog/zookeeper/zookeeper-requests.ts
+++ b/apps/dashboard/src/components/charts/declarative/catalog/zookeeper/zookeeper-requests.ts
@@ -1,0 +1,26 @@
+import type { DeclarativeChart } from '../../schema'
+
+/**
+ * Declarative twin of `components/charts/zookeeper/zookeeper-requests.tsx`
+ * (`ChartZookeeperRequests`) — ported as a template for plans/58, and the
+ * catalog's `type: 'bar'` example (`createBarChart`).
+ */
+export const zookeeperRequestsDeclarative: DeclarativeChart = {
+  type: 'bar',
+  chartName: 'zookeeper-requests',
+  icon: 'network',
+  description: 'ZooKeeper/Keeper request and watch volume over time',
+  index: 'event_time',
+  categories: ['ZookeeperRequests', 'ZooKeeperWatch'],
+  defaultTitle: 'ZooKeeper Requests',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24 * 7,
+  dataTestId: 'zookeeper-requests-chart',
+  dateRangeConfig: 'health',
+  xAxisDateFormat: true,
+  barChartProps: {
+    showLegend: true,
+    stack: true,
+    yAxisTickFormatterKey: 'count',
+  },
+}

--- a/apps/dashboard/src/components/charts/declarative/icon.test.ts
+++ b/apps/dashboard/src/components/charts/declarative/icon.test.ts
@@ -1,0 +1,18 @@
+import { isKnownChartIconName } from './icon'
+import { describe, expect, test } from 'bun:test'
+
+describe('isKnownChartIconName', () => {
+  test('accepts a real lucide-react icon name', () => {
+    expect(isKnownChartIconName('database')).toBe(true)
+    expect(isKnownChartIconName('cpu')).toBe(true)
+    expect(isKnownChartIconName('memory-stick')).toBe(true)
+  })
+
+  test('rejects an unknown icon name', () => {
+    expect(isKnownChartIconName('not-a-real-icon-xyz')).toBe(false)
+  })
+
+  test('rejects PascalCase (lucide-react/dynamic keys are kebab-case)', () => {
+    expect(isKnownChartIconName('Database')).toBe(false)
+  })
+})

--- a/apps/dashboard/src/components/charts/declarative/icon.tsx
+++ b/apps/dashboard/src/components/charts/declarative/icon.tsx
@@ -1,0 +1,42 @@
+/**
+ * Lazy icon resolution for declarative chart definitions.
+ *
+ * A declarative chart references its icon by a lucide-react icon name (a
+ * plain, kebab-case string, e.g. `'cpu'`, `'memory-stick'`, `'database'`) —
+ * not a live React component reference, so the catalog stays JSON-serializable
+ * and community/AI-authored definitions never need to `import` anything.
+ *
+ * Resolution goes through lucide-react's own `lucide-react/dynamic` entry
+ * point (`DynamicIcon` + `dynamicIconImports`), which code-splits every icon
+ * behind its own `import()` keyed by name. Only icons a `ChartIcon` actually
+ * renders are ever fetched — this module does NOT eagerly import the full
+ * lucide-react icon set.
+ */
+import type { ComponentProps } from 'react'
+
+import { DynamicIcon, iconNames } from 'lucide-react/dynamic'
+
+export type { IconName as ChartIconName } from 'lucide-react/dynamic'
+
+const KNOWN_ICON_NAMES = new Set<string>(iconNames)
+
+/** True when `name` is a real lucide-react icon name (kebab-case). */
+export function isKnownChartIconName(name: string): boolean {
+  return KNOWN_ICON_NAMES.has(name)
+}
+
+export interface ChartIconProps
+  extends Omit<ComponentProps<typeof DynamicIcon>, 'name'> {
+  /** lucide-react icon name, e.g. 'cpu', 'memory-stick', 'database'. */
+  name: string
+}
+
+/**
+ * Renders a declarative chart's `icon` string via lucide-react's lazy
+ * `DynamicIcon`. Unknown names fall through to `DynamicIcon`'s own
+ * fallback (renders nothing) rather than throwing, so a stale/typo'd icon
+ * degrades gracefully in a chart picker instead of crashing the page.
+ */
+export function ChartIcon({ name, ...props }: ChartIconProps) {
+  return <DynamicIcon name={name as never} {...props} />
+}

--- a/apps/dashboard/src/components/charts/declarative/index.ts
+++ b/apps/dashboard/src/components/charts/declarative/index.ts
@@ -1,0 +1,22 @@
+export { ChartIcon, type ChartIconProps, isKnownChartIconName } from './icon'
+export {
+  buildAreaChartConfig,
+  buildBarChartConfig,
+  createChartFromDeclarative,
+  type LoadedDeclarativeChart,
+  loadDeclarativeChart,
+} from './loader'
+export {
+  type DeclarativeAreaChart,
+  type DeclarativeAreaChartProps,
+  type DeclarativeBarChart,
+  type DeclarativeBarChartProps,
+  type DeclarativeChart,
+  declarativeAreaChartPropsSchema,
+  declarativeAreaChartSchema,
+  declarativeBarChartPropsSchema,
+  declarativeBarChartSchema,
+  declarativeChartSchema,
+  type TickFormatterKey,
+} from './schema'
+export { type ValidateChartResult, validateDeclarativeChart } from './validate'

--- a/apps/dashboard/src/components/charts/declarative/loader.test.ts
+++ b/apps/dashboard/src/components/charts/declarative/loader.test.ts
@@ -1,0 +1,143 @@
+import type { DeclarativeAreaChart, DeclarativeBarChart } from './schema'
+
+import {
+  buildAreaChartConfig,
+  buildBarChartConfig,
+  createChartFromDeclarative,
+  loadDeclarativeChart,
+} from './loader'
+import { describe, expect, test } from 'bun:test'
+import { chartTickFormatters } from '@/lib/utils'
+
+describe('buildAreaChartConfig', () => {
+  test('maps required fields', () => {
+    const d: DeclarativeAreaChart = {
+      type: 'area',
+      chartName: 'cpu-usage',
+      index: 'event_time',
+      categories: ['avg_cpu'],
+    }
+    const config = buildAreaChartConfig(d)
+    expect(config).toEqual({
+      chartName: 'cpu-usage',
+      index: 'event_time',
+      categories: ['avg_cpu'],
+    })
+  })
+
+  test('resolves yAxisTickFormatterKey to the matching chartTickFormatters fn', () => {
+    const d: DeclarativeAreaChart = {
+      type: 'area',
+      chartName: 'memory-usage',
+      index: 'event_time',
+      categories: ['avg_memory'],
+      areaChartProps: {
+        colors: ['--chart-12'],
+        yAxisTickFormatterKey: 'bytes',
+      },
+    }
+    const config = buildAreaChartConfig(d)
+    expect(config.areaChartProps?.yAxisTickFormatter).toBe(
+      chartTickFormatters.bytes
+    )
+    expect(config.areaChartProps?.colors).toEqual(['--chart-12'])
+    // yAxisTickFormatterKey itself must not leak onto the factory config —
+    // AreaChartFactoryConfig has no such field.
+    expect(
+      (config.areaChartProps as Record<string, unknown>).yAxisTickFormatterKey
+    ).toBeUndefined()
+  })
+
+  test('omits undefined optional fields entirely', () => {
+    const d: DeclarativeAreaChart = {
+      type: 'area',
+      chartName: 'minimal',
+      index: 'event_time',
+      categories: ['v'],
+    }
+    const config = buildAreaChartConfig(d)
+    expect('defaultTitle' in config).toBe(false)
+    expect('showDeployments' in config).toBe(false)
+    expect('areaChartProps' in config).toBe(false)
+  })
+})
+
+describe('buildBarChartConfig', () => {
+  test('maps required + optional fields', () => {
+    const d: DeclarativeBarChart = {
+      type: 'bar',
+      chartName: 'zookeeper-requests',
+      index: 'event_time',
+      categories: ['ZookeeperRequests', 'ZooKeeperWatch'],
+      defaultTitle: 'ZooKeeper Requests',
+      xAxisDateFormat: true,
+      barChartProps: {
+        showLegend: true,
+        stack: true,
+        yAxisTickFormatterKey: 'count',
+      },
+    }
+    const config = buildBarChartConfig(d)
+    expect(config.chartName).toBe('zookeeper-requests')
+    expect(config.xAxisDateFormat).toBe(true)
+    expect(config.barChartProps?.yAxisTickFormatter).toBe(
+      chartTickFormatters.count
+    )
+    expect(config.barChartProps?.showLegend).toBe(true)
+    expect(config.barChartProps?.stack).toBe(true)
+  })
+})
+
+describe('loadDeclarativeChart', () => {
+  test('tags area definitions with kind: area', () => {
+    const loaded = loadDeclarativeChart({
+      type: 'area',
+      chartName: 'query-count',
+      index: 'event_time',
+      categories: ['query_count'],
+    })
+    expect(loaded.kind).toBe('area')
+  })
+
+  test('tags bar definitions with kind: bar', () => {
+    const loaded = loadDeclarativeChart({
+      type: 'bar',
+      chartName: 'query-type',
+      index: 'query_type',
+      categories: ['count'],
+    })
+    expect(loaded.kind).toBe('bar')
+  })
+
+  test('throws with field-level errors on invalid input', () => {
+    expect(() => loadDeclarativeChart({ type: 'area' })).toThrow(
+      /Invalid declarative chart/
+    )
+  })
+})
+
+describe('createChartFromDeclarative', () => {
+  test('renders through the same factory as a hand-authored area chart', () => {
+    const Chart = createChartFromDeclarative({
+      type: 'area',
+      chartName: 'query-count',
+      index: 'event_time',
+      categories: ['query_count'],
+    })
+    expect(typeof Chart).toBe('object') // React.memo() returns an object, not a function
+  })
+
+  test('renders through the same factory as a hand-authored bar chart', () => {
+    const Chart = createChartFromDeclarative({
+      type: 'bar',
+      chartName: 'zookeeper-requests',
+      index: 'event_time',
+      categories: ['ZookeeperRequests'],
+    })
+    expect(typeof Chart).toBe('object')
+  })
+
+  test('throws on an invalid declarative definition instead of rendering nothing', () => {
+    expect(() => createChartFromDeclarative({ type: 'bar' })).toThrow()
+  })
+})

--- a/apps/dashboard/src/components/charts/declarative/loader.ts
+++ b/apps/dashboard/src/components/charts/declarative/loader.ts
@@ -1,0 +1,173 @@
+/**
+ * Declarative chart loader (plans/58-declarative-chart-schema.md).
+ *
+ * Converts a validated DeclarativeChart into the exact config object the
+ * existing chart factories (`createAreaChart` / `createBarChart`) accept, and
+ * — via `createChartFromDeclarative` — straight into a rendered chart
+ * component. There is no separate declarative rendering pipeline: a
+ * declarative chart is a data description of the SAME factory call a
+ * hand-authored chart file makes.
+ *
+ * RUNTIME-ONLY / CATALOG-ONLY FIELDS NOT PRESENT ON THE LOADED FACTORY CONFIG:
+ *   - description, icon — catalog metadata (docs / future chart-picker UI);
+ *     the factories have no such prop today. Read them off the declarative
+ *     definition directly (see `DeclarativeChart['description' | 'icon']`).
+ *
+ * Compiled fields (declarative spec → runtime value on the loaded config):
+ *   - areaChartProps.yAxisTickFormatterKey / barChartProps.yAxisTickFormatterKey
+ *     → the matching function from `lib/utils.ts#chartTickFormatters`.
+ */
+
+import type { FC } from 'react'
+import type { ChartProps } from '@/components/charts/chart-props'
+import type {
+  AreaChartFactoryConfig,
+  BarChartFactoryConfig,
+} from '@/components/charts/factory'
+import type {
+  DeclarativeAreaChart,
+  DeclarativeAreaChartProps,
+  DeclarativeBarChart,
+  DeclarativeBarChartProps,
+  TickFormatterKey,
+} from './schema'
+
+import { validateDeclarativeChart } from './validate'
+import { createAreaChart, createBarChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+function resolveTickFormatter(key: TickFormatterKey | undefined) {
+  return key === undefined ? undefined : chartTickFormatters[key]
+}
+
+function buildAreaChartProps(
+  props: DeclarativeAreaChartProps | undefined
+): AreaChartFactoryConfig['areaChartProps'] {
+  if (!props) return undefined
+
+  const { yAxisTickFormatterKey, ...rest } = props
+  const yAxisTickFormatter = resolveTickFormatter(yAxisTickFormatterKey)
+
+  return {
+    ...rest,
+    ...(yAxisTickFormatter !== undefined ? { yAxisTickFormatter } : {}),
+  }
+}
+
+function buildBarChartProps(
+  props: DeclarativeBarChartProps | undefined
+): BarChartFactoryConfig['barChartProps'] {
+  if (!props) return undefined
+
+  const { yAxisTickFormatterKey, ...rest } = props
+  const yAxisTickFormatter = resolveTickFormatter(yAxisTickFormatterKey)
+
+  return {
+    ...rest,
+    ...(yAxisTickFormatter !== undefined ? { yAxisTickFormatter } : {}),
+  }
+}
+
+/** Build an `AreaChartFactoryConfig` from a validated declarative area chart. */
+export function buildAreaChartConfig(
+  d: DeclarativeAreaChart
+): AreaChartFactoryConfig {
+  const config: AreaChartFactoryConfig = {
+    chartName: d.chartName,
+    index: d.index,
+    categories: d.categories,
+  }
+
+  if (d.defaultTitle !== undefined) config.defaultTitle = d.defaultTitle
+  if (d.defaultInterval !== undefined)
+    config.defaultInterval = d.defaultInterval
+  if (d.defaultLastHours !== undefined)
+    config.defaultLastHours = d.defaultLastHours
+  if (d.refreshInterval !== undefined)
+    config.refreshInterval = d.refreshInterval
+  if (d.dataTestId !== undefined) config.dataTestId = d.dataTestId
+  if (d.dateRangeConfig !== undefined)
+    config.dateRangeConfig = d.dateRangeConfig
+  if (d.enableScaleToggle !== undefined)
+    config.enableScaleToggle = d.enableScaleToggle
+  if (d.defaultChartClassName !== undefined)
+    config.defaultChartClassName = d.defaultChartClassName
+  if (d.showDeployments !== undefined)
+    config.showDeployments = d.showDeployments
+
+  const areaChartProps = buildAreaChartProps(d.areaChartProps)
+  if (areaChartProps !== undefined) config.areaChartProps = areaChartProps
+
+  return config
+}
+
+/** Build a `BarChartFactoryConfig` from a validated declarative bar chart. */
+export function buildBarChartConfig(
+  d: DeclarativeBarChart
+): BarChartFactoryConfig {
+  const config: BarChartFactoryConfig = {
+    chartName: d.chartName,
+    index: d.index,
+    categories: d.categories,
+  }
+
+  if (d.defaultTitle !== undefined) config.defaultTitle = d.defaultTitle
+  if (d.defaultInterval !== undefined)
+    config.defaultInterval = d.defaultInterval
+  if (d.defaultLastHours !== undefined)
+    config.defaultLastHours = d.defaultLastHours
+  if (d.refreshInterval !== undefined)
+    config.refreshInterval = d.refreshInterval
+  if (d.dataTestId !== undefined) config.dataTestId = d.dataTestId
+  if (d.dateRangeConfig !== undefined)
+    config.dateRangeConfig = d.dateRangeConfig
+  if (d.enableScaleToggle !== undefined)
+    config.enableScaleToggle = d.enableScaleToggle
+  if (d.defaultChartClassName !== undefined)
+    config.defaultChartClassName = d.defaultChartClassName
+  if (d.xAxisDateFormat !== undefined)
+    config.xAxisDateFormat = d.xAxisDateFormat
+
+  const barChartProps = buildBarChartProps(d.barChartProps)
+  if (barChartProps !== undefined) config.barChartProps = barChartProps
+
+  return config
+}
+
+export type LoadedDeclarativeChart =
+  | { kind: 'area'; config: AreaChartFactoryConfig }
+  | { kind: 'bar'; config: BarChartFactoryConfig }
+
+/**
+ * Validate `input` against the declarative chart schema (throws on invalid)
+ * and compile it into the matching `*ChartFactoryConfig`, tagged with which
+ * factory it targets.
+ *
+ * @throws Error when `input` fails schema validation (message includes all
+ *   field-level errors joined by '; ').
+ */
+export function loadDeclarativeChart(input: unknown): LoadedDeclarativeChart {
+  const result = validateDeclarativeChart(input)
+  if (!result.ok) {
+    throw new Error(`Invalid declarative chart: ${result.errors.join('; ')}`)
+  }
+
+  const d = result.chart
+  return d.type === 'area'
+    ? { kind: 'area', config: buildAreaChartConfig(d) }
+    : { kind: 'bar', config: buildBarChartConfig(d) }
+}
+
+/**
+ * Load a declarative chart definition and hand it straight to the matching
+ * factory (`createAreaChart` / `createBarChart`), returning the same
+ * `FC<ChartProps>` a hand-authored `createAreaChart({...})` call would — the
+ * declarative catalog renders through the exact same factory code path as
+ * every other chart, with zero rendering-pipeline duplication.
+ */
+export function createChartFromDeclarative(input: unknown): FC<ChartProps> {
+  const loaded = loadDeclarativeChart(input)
+  return loaded.kind === 'area'
+    ? createAreaChart(loaded.config)
+    : createBarChart(loaded.config)
+}

--- a/apps/dashboard/src/components/charts/declarative/schema.test.ts
+++ b/apps/dashboard/src/components/charts/declarative/schema.test.ts
@@ -1,0 +1,163 @@
+import { validateDeclarativeChart } from './validate'
+import { describe, expect, test } from 'bun:test'
+
+describe('minimal valid area chart', () => {
+  test('accepts chartName + type + index + categories', () => {
+    const result = validateDeclarativeChart({
+      type: 'area',
+      chartName: 'my-area-chart',
+      index: 'event_time',
+      categories: ['value'],
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.chart.chartName).toBe('my-area-chart')
+    expect(result.chart.type).toBe('area')
+  })
+})
+
+describe('minimal valid bar chart', () => {
+  test('accepts chartName + type + index + categories', () => {
+    const result = validateDeclarativeChart({
+      type: 'bar',
+      chartName: 'my-bar-chart',
+      index: 'query_type',
+      categories: ['count'],
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.chart.type).toBe('bar')
+  })
+})
+
+describe('full-featured area chart', () => {
+  test('accepts every serializable field', () => {
+    const result = validateDeclarativeChart({
+      type: 'area',
+      chartName: 'query-count',
+      description: 'Query volume over time',
+      icon: 'bar-chart-3',
+      index: 'event_time',
+      categories: ['query_count'],
+      defaultTitle: 'Query Count',
+      defaultInterval: 'toStartOfDay',
+      defaultLastHours: 336,
+      refreshInterval: 60000,
+      dataTestId: 'query-count-chart',
+      dateRangeConfig: 'query-activity',
+      enableScaleToggle: true,
+      defaultChartClassName: 'h-full',
+      showDeployments: true,
+      areaChartProps: {
+        colors: ['--chart-yellow'],
+        stack: true,
+        showLegend: false,
+        showXAxis: true,
+        showCartesianGrid: true,
+        readable: 'quantity',
+        breakdown: 'breakdown',
+        breakdownLabel: 'query_kind',
+        breakdownValue: 'count',
+        yAxisTickFormatterKey: 'count',
+      },
+    })
+
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('invalid configs', () => {
+  test('rejects missing chartName', () => {
+    const result = validateDeclarativeChart({
+      type: 'area',
+      index: 'event_time',
+      categories: ['value'],
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  test('rejects missing type discriminant', () => {
+    const result = validateDeclarativeChart({
+      chartName: 'no-type',
+      index: 'event_time',
+      categories: ['value'],
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  test('rejects empty categories', () => {
+    const result = validateDeclarativeChart({
+      type: 'area',
+      chartName: 'empty-categories',
+      index: 'event_time',
+      categories: [],
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  test('rejects missing index', () => {
+    const result = validateDeclarativeChart({
+      type: 'bar',
+      chartName: 'no-index',
+      categories: ['count'],
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  test('rejects unknown dateRangeConfig preset', () => {
+    const result = validateDeclarativeChart({
+      type: 'area',
+      chartName: 'bad-preset',
+      index: 'event_time',
+      categories: ['value'],
+      dateRangeConfig: 'not-a-real-preset',
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  test('rejects unknown ClickHouse interval', () => {
+    const result = validateDeclarativeChart({
+      type: 'area',
+      chartName: 'bad-interval',
+      index: 'event_time',
+      categories: ['value'],
+      defaultInterval: 'toStartOfDecade',
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  test('rejects an unknown lucide icon name', () => {
+    const result = validateDeclarativeChart({
+      type: 'area',
+      chartName: 'bad-icon',
+      index: 'event_time',
+      categories: ['value'],
+      icon: 'this-icon-does-not-exist-in-lucide',
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  test('accepts a real lucide icon name', () => {
+    const result = validateDeclarativeChart({
+      type: 'area',
+      chartName: 'good-icon',
+      index: 'event_time',
+      categories: ['value'],
+      icon: 'database',
+    })
+    expect(result.ok).toBe(true)
+  })
+
+  test('rejects an unknown yAxisTickFormatterKey', () => {
+    const result = validateDeclarativeChart({
+      type: 'bar',
+      chartName: 'bad-formatter',
+      index: 'event_time',
+      categories: ['value'],
+      barChartProps: { yAxisTickFormatterKey: 'not-a-formatter' },
+    })
+    expect(result.ok).toBe(false)
+  })
+})

--- a/apps/dashboard/src/components/charts/declarative/schema.ts
+++ b/apps/dashboard/src/components/charts/declarative/schema.ts
@@ -1,0 +1,266 @@
+/**
+ * Declarative chart schema — the catalog contract (plans/58-declarative-chart-schema.md).
+ *
+ * Mirrors `lib/query-config/declarative/schema.ts`: this module defines the
+ * SERIALIZABLE subset of a chart's factory config that can live in a JSON /
+ * YAML / TOML file and be authored by the community (or an AI agent) without
+ * writing TypeScript.
+ *
+ * A declarative chart definition maps 1:1 onto the config object the two
+ * "pure" chart factories already accept — `createAreaChart` and
+ * `createBarChart` (see `../factory/create-area-chart.tsx` /
+ * `../factory/create-bar-chart.tsx` / `../factory/types.ts`). The companion
+ * `loader.ts` compiles a validated definition into that exact config object
+ * (or, via `createChartFromDeclarative`, straight into a rendered chart
+ * component) — so a declarative chart renders through the SAME factory code
+ * path as a hand-authored one. No parallel rendering pipeline.
+ *
+ * `createCustomChart` (bespoke `render(data) => ReactNode` charts — progress
+ * bars, proportion lists, metric tiles, …) is intentionally NOT covered here:
+ * `render` is a function reference, not serializable. Charts that need that
+ * level of bespoke layout stay TS-only; this schema only expresses the
+ * data-describable area/bar chart shape. This mirrors the query-config
+ * declarative schema's philosophy of excluding runtime-only fields (functions,
+ * live component refs) rather than smuggling them in as opaque blobs.
+ *
+ * Serializable fields carried here:
+ *   identity:    chartName (chart-registry query key), description, icon
+ *   presentation: type ('area' | 'bar'), index, categories, defaultTitle
+ *   time:        defaultInterval, defaultLastHours, dateRangeConfig
+ *   behavior:    refreshInterval, enableScaleToggle, dataTestId
+ *   area-only:   showDeployments, areaChartProps (colors/stack/readable/…)
+ *   bar-only:    xAxisDateFormat, barChartProps (colors/stack/layout/…)
+ *
+ * Intentionally excluded (not serializable — require runtime code):
+ *   render               — CustomChartFactoryConfig's function (use a TS chart)
+ *   categories as fn     — BarChartFactoryConfig also allows
+ *                          `(data) => string[]`; the declarative form only
+ *                          supports a static string[]
+ *   tickFormatter / valueFormatter / customTooltip / onValueChange / chartConfig
+ *                        — function/JSX values on AreaChartProps/BarChartProps.
+ *                          `yAxisTickFormatterKey` covers the common case by
+ *                          referencing a named formatter from
+ *                          `lib/utils.ts#chartTickFormatters`.
+ *   dateRangeConfig as a literal DateRangeConfig object — only the named
+ *                          presets (`DateRangePresetName`) are supported
+ *                          declaratively; a bespoke options array stays TS-only.
+ */
+
+import { z } from 'zod'
+
+import { isKnownChartIconName } from './icon'
+
+// ---------------------------------------------------------------------------
+// ClickHouseInterval — mirrors VALID_INTERVALS from
+// @chm/types/clickhouse-interval. Hardcoded here (not imported) to keep the
+// declarative chart schema decoupled from app code, matching the
+// query-config declarative schema's convention (see featureIdSchema there).
+// ---------------------------------------------------------------------------
+
+const clickHouseIntervalValues = [
+  'toStartOfMinute',
+  'toStartOfFiveMinutes',
+  'toStartOfTenMinutes',
+  'toStartOfFifteenMinutes',
+  'toStartOfHour',
+  'toStartOfDay',
+  'toStartOfWeek',
+  'toStartOfMonth',
+] as const
+
+const clickHouseIntervalSchema = z.enum(clickHouseIntervalValues)
+
+// ---------------------------------------------------------------------------
+// DateRangePresetName — mirrors the keys of DATE_RANGE_PRESETS from
+// components/date-range/date-range-presets.ts. Hardcoded for the same reason
+// as clickHouseIntervalValues above.
+// ---------------------------------------------------------------------------
+
+const dateRangePresetNameValues = [
+  'standard',
+  'realtime',
+  'historical',
+  'disk-usage',
+  'query-activity',
+  'query-duration',
+  'system-metrics',
+  'operations',
+  'health',
+  'page-views',
+  'insights',
+] as const
+
+const dateRangePresetNameSchema = z.enum(dateRangePresetNameValues)
+
+// ---------------------------------------------------------------------------
+// yAxisTickFormatterKey — named reference into chartTickFormatters (lib/utils.ts)
+// ---------------------------------------------------------------------------
+
+const tickFormatterKeyValues = [
+  'bytes',
+  'percentage',
+  'count',
+  'duration',
+  'default',
+] as const
+
+export const tickFormatterKeySchema = z.enum(tickFormatterKeyValues)
+export type TickFormatterKey = z.infer<typeof tickFormatterKeySchema>
+
+// ---------------------------------------------------------------------------
+// readable / yAxisScale — small string enums shared by area + bar props
+// ---------------------------------------------------------------------------
+
+const readableFormatSchema = z.enum(['bytes', 'duration', 'number', 'quantity'])
+const yAxisScaleSchema = z.enum(['linear', 'log', 'auto'])
+
+// ---------------------------------------------------------------------------
+// icon — lucide-react icon name (kebab-case), resolved lazily by ../icon.tsx.
+// Not embedded into the factory config (the factory has no icon prop today);
+// this is catalog metadata for a future chart picker / docs / AI authoring
+// surface. Validated against lucide-react's own icon-name list so a typo'd
+// icon fails at catalog-validation time rather than silently rendering nothing.
+// ---------------------------------------------------------------------------
+
+const chartIconSchema = z
+  .string()
+  .min(1)
+  .refine(isKnownChartIconName, {
+    message: 'icon must be a valid lucide-react icon name (kebab-case)',
+  })
+  .optional()
+
+// ---------------------------------------------------------------------------
+// areaChartProps — serializable subset of AreaChartProps
+// (types/charts.ts) + the factory's yAxisTickFormatter extension.
+// ---------------------------------------------------------------------------
+
+export const declarativeAreaChartPropsSchema = z.object({
+  colors: z.array(z.string().min(1)).optional(),
+  stack: z.boolean().optional(),
+  relative: z.boolean().optional(),
+  opacity: z.number().optional(),
+  breakdown: z.string().optional(),
+  breakdownLabel: z.string().optional(),
+  breakdownValue: z.string().optional(),
+  breakdownHeading: z.string().optional(),
+  showLegend: z.boolean().optional(),
+  showXAxis: z.boolean().optional(),
+  showYAxis: z.boolean().optional(),
+  showTooltip: z.boolean().optional(),
+  showCartesianGrid: z.boolean().optional(),
+  showGridLines: z.boolean().optional(),
+  startEndOnly: z.boolean().optional(),
+  readable: readableFormatSchema.optional(),
+  readableColumn: z.string().optional(),
+  readableColumns: z.array(z.string()).optional(),
+  yAxisScale: yAxisScaleSchema.optional(),
+  yAxisWidth: z.number().optional(),
+  tickGap: z.number().optional(),
+  xAxisLabel: z.string().optional(),
+  yAxisLabel: z.string().optional(),
+  // Compiled by the loader into `areaChartProps.yAxisTickFormatter`.
+  yAxisTickFormatterKey: tickFormatterKeySchema.optional(),
+})
+
+export type DeclarativeAreaChartProps = z.infer<
+  typeof declarativeAreaChartPropsSchema
+>
+
+// ---------------------------------------------------------------------------
+// barChartProps — serializable subset of BarChartProps (types/charts.ts) +
+// the factory's yAxisTickFormatter extension.
+// ---------------------------------------------------------------------------
+
+export const declarativeBarChartPropsSchema = z.object({
+  colors: z.array(z.string().min(1)).optional(),
+  stack: z.boolean().optional(),
+  relative: z.boolean().optional(),
+  layout: z.enum(['vertical', 'horizontal']).optional(),
+  horizontal: z.boolean().optional(),
+  barCategoryGap: z.union([z.string(), z.number()]).optional(),
+  readableColumn: z.string().optional(),
+  tooltipTotal: z.boolean().optional(),
+  yAxisScale: yAxisScaleSchema.optional(),
+  showLegend: z.boolean().optional(),
+  showXAxis: z.boolean().optional(),
+  showYAxis: z.boolean().optional(),
+  showTooltip: z.boolean().optional(),
+  showGridLines: z.boolean().optional(),
+  // Compiled by the loader into `barChartProps.yAxisTickFormatter`.
+  yAxisTickFormatterKey: tickFormatterKeySchema.optional(),
+})
+
+export type DeclarativeBarChartProps = z.infer<
+  typeof declarativeBarChartPropsSchema
+>
+
+// ---------------------------------------------------------------------------
+// Shared base fields (BaseChartFactoryConfig subset)
+// ---------------------------------------------------------------------------
+
+const declarativeChartBaseSchema = z.object({
+  // Identity — the key this chart's data is fetched under, via
+  // GET /api/v1/charts/$chartName. Must already be registered in the
+  // server-side chart-registry (lib/api/chart-registry.ts); the declarative
+  // schema describes PRESENTATION only, not the SQL behind the chart.
+  chartName: z.string().min(1, 'chartName is required'),
+  description: z.string().optional(),
+  icon: chartIconSchema,
+
+  defaultTitle: z.string().optional(),
+  defaultInterval: clickHouseIntervalSchema.optional(),
+  defaultLastHours: z.number().positive().optional(),
+  refreshInterval: z.number().positive().optional(),
+  dataTestId: z.string().optional(),
+  dateRangeConfig: dateRangePresetNameSchema.optional(),
+  enableScaleToggle: z.boolean().optional(),
+})
+
+// ---------------------------------------------------------------------------
+// Area chart definition
+// ---------------------------------------------------------------------------
+
+export const declarativeAreaChartSchema = declarativeChartBaseSchema.extend({
+  type: z.literal('area'),
+  index: z.string().min(1, 'index is required'),
+  categories: z
+    .array(z.string().min(1))
+    .min(1, 'categories must have at least one entry'),
+  defaultChartClassName: z.string().optional(),
+  /** Opt-in GitHub deploy-marker overlay (plans/45-github-deploy-correlation.md). */
+  showDeployments: z.boolean().optional(),
+  areaChartProps: declarativeAreaChartPropsSchema.optional(),
+})
+
+export type DeclarativeAreaChart = z.infer<typeof declarativeAreaChartSchema>
+
+// ---------------------------------------------------------------------------
+// Bar chart definition
+// ---------------------------------------------------------------------------
+
+export const declarativeBarChartSchema = declarativeChartBaseSchema.extend({
+  type: z.literal('bar'),
+  index: z.string().min(1, 'index is required'),
+  // BarChartFactoryConfig also allows `categories: (data) => string[]` — not
+  // serializable, so the declarative form only supports a static list.
+  categories: z
+    .array(z.string().min(1))
+    .min(1, 'categories must have at least one entry'),
+  defaultChartClassName: z.string().optional(),
+  xAxisDateFormat: z.boolean().optional(),
+  barChartProps: declarativeBarChartPropsSchema.optional(),
+})
+
+export type DeclarativeBarChart = z.infer<typeof declarativeBarChartSchema>
+
+// ---------------------------------------------------------------------------
+// Main declarative schema — discriminated union on `type`
+// ---------------------------------------------------------------------------
+
+export const declarativeChartSchema = z.discriminatedUnion('type', [
+  declarativeAreaChartSchema,
+  declarativeBarChartSchema,
+])
+
+export type DeclarativeChart = z.infer<typeof declarativeChartSchema>

--- a/apps/dashboard/src/components/charts/declarative/validate.ts
+++ b/apps/dashboard/src/components/charts/declarative/validate.ts
@@ -1,0 +1,27 @@
+import { type DeclarativeChart, declarativeChartSchema } from './schema'
+
+export type ValidateChartResult =
+  | { ok: true; chart: DeclarativeChart }
+  | { ok: false; errors: string[] }
+
+/**
+ * Validate an unknown input against the declarative chart schema.
+ *
+ * Returns `{ ok: true, chart }` on success, or `{ ok: false, errors }` with a
+ * flat list of human-readable error strings that include the field path.
+ * Mirrors `lib/query-config/declarative/validate.ts`.
+ */
+export function validateDeclarativeChart(input: unknown): ValidateChartResult {
+  const result = declarativeChartSchema.safeParse(input)
+
+  if (result.success) {
+    return { ok: true, chart: result.data }
+  }
+
+  const errors = result.error.issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : '(root)'
+    return `${path}: ${issue.message}`
+  })
+
+  return { ok: false, errors }
+}

--- a/docs/knowledge/chart-config-format.md
+++ b/docs/knowledge/chart-config-format.md
@@ -1,0 +1,198 @@
+---
+id: chart-config-format
+title: Declarative Chart Config Format
+type: spec
+status: active
+updated: 2026-07-04
+tags:
+  - charts
+  - declarative
+  - catalog
+  - platform
+related:
+  - query-config-format
+  - declarative-config-catalog
+  - static-site-architecture
+  - product-design
+---
+
+# Declarative Chart Config Format
+
+The **declarative chart catalog** is the serializable subset of a factory
+chart's config expressed as plain data — objects with no JSX, no functions,
+and no live component imports. It mirrors the
+[[declarative-config-catalog|declarative QueryConfig catalog]] (plans 53-54),
+but for charts (plans/58-declarative-chart-schema.md): the goal is the same —
+let the community (or an AI agent) author a monitoring chart without writing
+TypeScript.
+
+## Specification
+
+Roughly 40 of chmonitor's ~74 charts are built via one of two "pure" chart
+factories — `createAreaChart` / `createBarChart`
+(`apps/dashboard/src/components/charts/factory/`) — that take a config object
+and return a fully-wired `FC<ChartProps>` (title, SQL toolbar, date range,
+loading/error/empty states all handled by `ChartCard`/`ChartContainer`). A
+declarative chart definition is a data description of **that exact config
+object** — `DeclarativeChart` is a discriminated union on `type`:
+
+```typescript
+type DeclarativeChart =
+  | { type: 'area'; chartName; index; categories; areaChartProps?; ... }
+  | { type: 'bar'; chartName; index; categories; barChartProps?; ... }
+```
+
+`chartName` is not a chart's own SQL — it's the key the chart is *fetched*
+under, `GET /api/v1/charts/$chartName`, which must already be registered in
+the server-side `lib/api/chart-registry.ts`. The declarative schema describes
+**presentation only** (which factory, which columns, axis/legend/color
+options), not the ClickHouse query behind it — that stays a normal
+chart-registry builder either way.
+
+The third factory, `createCustomChart` (bespoke `render(data) => ReactNode`
+charts — progress bars, proportion lists, metric tiles, …), is **not**
+declarative-capable: `render` is a function reference, not serializable.
+Charts that need that level of bespoke layout stay TS-only.
+
+## Where it lives
+
+```
+apps/dashboard/src/components/charts/declarative/
+├── schema.ts        # Zod schema — the catalog contract (DeclarativeChart)
+├── validate.ts       # validateDeclarativeChart() → {ok, chart|errors}
+├── loader.ts          # loadDeclarativeChart() → {kind, config}; createChartFromDeclarative()
+├── icon.tsx            # lazy lucide-react icon resolution (ChartIcon, isKnownChartIconName)
+└── catalog/
+    ├── index.ts        # DECLARATIVE_CHART_CATALOG: Record<chartName, DeclarativeChart>
+    └── <domain>/*.ts    # one file per ported chart, grouped by domain
+```
+
+## Pipeline
+
+```
+DeclarativeChart (data)
+  → validateDeclarativeChart (Zod)      # throws/returns errors on bad input
+  → loadDeclarativeChart                # maps serializable fields 1:1 to *ChartFactoryConfig
+  → { kind: 'area'|'bar', config }      # the exact AreaChartFactoryConfig / BarChartFactoryConfig
+  → createChartFromDeclarative          # calls createAreaChart(config) / createBarChart(config)
+  → FC<ChartProps>                       # same rendering path as a hand-authored chart
+```
+
+There is no parallel rendering pipeline — `createChartFromDeclarative` calls
+the SAME `createAreaChart`/`createBarChart` a hand-authored `.tsx` chart file
+calls. A declarative chart and its hand-authored twin produce byte-identical
+factory config objects (enforced by the parity tests below), so they render
+identically.
+
+## What the schema can express
+
+Shared (`BaseChartFactoryConfig` subset): `chartName`, `description` (catalog
+metadata), `icon` (catalog metadata, see below), `defaultTitle`,
+`defaultInterval` (`ClickHouseInterval`), `defaultLastHours`,
+`refreshInterval`, `dataTestId`, `dateRangeConfig` (a `DateRangePresetName`
+string — `'realtime' | 'query-activity' | 'system-metrics' | ...`; a bespoke
+`DateRangeConfig` options array is not serializable and stays TS-only),
+`enableScaleToggle`.
+
+- **`type: 'area'`** adds `index`, `categories: string[]`,
+  `defaultChartClassName`, `showDeployments` (GitHub deploy-marker overlay),
+  and `areaChartProps` — a serializable subset of `AreaChartProps`: `colors`,
+  `stack`, `relative`, `opacity`, `breakdown`/`breakdownLabel`/`breakdownValue`,
+  `showLegend`/`showXAxis`/`showYAxis`/`showTooltip`/`showCartesianGrid`,
+  `readable` (`'bytes'|'duration'|'number'|'quantity'`), `readableColumn(s)`,
+  `yAxisScale`, plus `yAxisTickFormatterKey` (see below).
+- **`type: 'bar'`** adds `index`, `categories: string[]` (the TS
+  `(data) => string[]` function form is not serializable — declarative bar
+  charts require a static category list), `defaultChartClassName`,
+  `xAxisDateFormat`, and `barChartProps` (`colors`, `stack`, `layout`,
+  `barCategoryGap`, `readableColumn`, `tooltipTotal`, `yAxisScale`,
+  `showLegend`/`showXAxis`/`showYAxis`/`showTooltip`, plus
+  `yAxisTickFormatterKey`).
+
+### yAxisTickFormatterKey — the tickFormatter replacement
+
+`AreaChartProps`/`BarChartProps.yAxisTickFormatter` is a function, so it isn't
+serializable directly. `yAxisTickFormatterKey` is a named reference into
+`lib/utils.ts#chartTickFormatters` (`'bytes' | 'percentage' | 'count' |
+'duration' | 'default'`); the loader resolves it to the matching function and
+sets it on `areaChartProps.yAxisTickFormatter` /
+`barChartProps.yAxisTickFormatter` — covering the common case without
+smuggling a function into the catalog.
+
+### icon — lazy lucide-react resolution
+
+`icon` is a plain lucide-react icon name string (kebab-case, e.g. `'cpu'`,
+`'memory-stick'`, `'database'`) — catalog metadata for a future chart-picker /
+docs surface, not consumed by the factories today (they have no icon prop).
+Validated at schema time against lucide-react's own icon-name list (a typo
+fails catalog validation, not a silent blank icon). Resolution goes through
+`lucide-react/dynamic`'s `DynamicIcon` + `dynamicIconImports` — lucide-react's
+own lazy-icon mechanism, which code-splits each icon behind its own
+`import()`. `icon.tsx` does **not** eagerly import the full lucide-react icon
+set; only an icon a `ChartIcon` actually renders is ever fetched.
+
+## What stays TS-only (and why)
+
+- **`createCustomChart` / `render`** — a function reference; any chart needing
+  bespoke JSX (progress bars, proportion lists, metric tiles) stays TS-only.
+- **`categories` as a function** (`BarChartFactoryConfig`'s
+  `(data) => string[]` form) — declarative bar charts require a static list.
+- **`tickFormatter` / `valueFormatter` / `customTooltip` / `onValueChange` /
+  `chartConfig`** — function/JSX-valued props on `AreaChartProps`/
+  `BarChartProps`. `yAxisTickFormatterKey` covers the common tick-formatting
+  case; anything more custom stays TS-only.
+- **A literal `DateRangeConfig` options array** — only the named presets
+  (`DateRangePresetName`) are declarative; a bespoke option set is TS-only.
+
+## Testing
+
+Each domain has a `<domain>-catalog.test.ts` parity suite
+(`catalog/query/query-catalog.test.ts`, `catalog/system/system-catalog.test.ts`,
+…) that runs `loadDeclarativeChart(decl).config` and **deep-equals** the result
+against the exact config object literal the hand-authored TS chart passes to
+`createAreaChart`/`createBarChart` — the same parity philosophy as the
+query-config catalog's `merges-catalog.test.ts`, with one difference worth
+being explicit about: the query-config version imports the *real* legacy
+config object and diffs against it, while the chart version diffs against a
+**transcription** of the hand-authored factory call (chart files export only
+the rendered `FC`, not their config object — exporting it would mean editing
+the "untouched" source file). A transcription can't catch a copy mistake or
+future drift in the original by itself, so `catalog/catalog.test.ts` adds one
+check against a live source of truth instead of a transcription: an orphan
+guard (mirroring `flip-safety.test.ts`'s) that asserts every catalog
+`chartName` resolves via `hasChart()` in the real
+`lib/api/chart-registry.ts` — catching a typo that would otherwise 404 silently
+at `GET /api/v1/charts/$chartName` instead of failing a test.
+`catalog/catalog.test.ts` also asserts the catalog has no duplicate
+`chartName`s and that every entry loads without throwing.
+`schema.test.ts` / `loader.test.ts` / `icon.test.ts` cover schema validation
+and the loader's field mapping (including `yAxisTickFormatterKey` resolution)
+directly.
+
+## Status
+
+Dormant by design — nothing in the live app (routes, `chart-registry`,
+`components/charts/registry/`) consumes `DECLARATIVE_CHART_CATALOG` yet; every
+hand-authored TS chart file keeps rendering exactly as before (additive only,
+no cutover). 6 charts are ported as templates across 4 domains: `query-count` /
+`query-duration` (area, `query/`), `memory-usage` / `cpu-usage` (area,
+`system/`), `error-rate-over-time` (area, multi-category + legend, `logs/`),
+`zookeeper-requests` (bar, `zookeeper/`) — covering both factory types and the
+common config shapes (breakdown, stack, multi-series, tick formatting).
+Whether/how declarative charts eventually join the chart registry or a
+dashboard-builder chart picker (plan 57) is an open question left for that
+follow-up plan; this catalog is the loader + template proof it would build on.
+
+## Key Files
+
+- `apps/dashboard/src/components/charts/declarative/schema.ts` — type definitions (Zod)
+- `apps/dashboard/src/components/charts/declarative/loader.ts` — declarative → factory config
+- `apps/dashboard/src/components/charts/declarative/catalog/` — ported chart templates
+- `apps/dashboard/src/components/charts/factory/` — the two pure factories this loader targets
+- `apps/dashboard/src/lib/api/chart-registry.ts` — the `chartName` → SQL registry declarative charts reference
+
+## See Also
+
+- [[query-config-format]] — the analogous format for table/query views
+- [[declarative-config-catalog]] — the query-config declarative system this mirrors
+- [[product-design]] — chart design tokens/conventions a new chart should follow


### PR DESCRIPTION
## Summary
- Adds a zod-validated declarative chart schema + loader (`apps/dashboard/src/components/charts/declarative/{schema,loader,validate,icon}.ts`) mirroring the existing query-config declarative system (`lib/query-config/declarative/`).
- `loadDeclarativeChart` / `createChartFromDeclarative` compile a serializable chart definition into the exact `AreaChartFactoryConfig`/`BarChartFactoryConfig` the existing `createAreaChart`/`createBarChart` factories accept — a declarative chart renders through the same factory code path as hand-authored TS charts, zero parallel rendering pipeline.
- Ports 6 factory charts as templates into a dormant catalog (`declarative/catalog/`): `query-count`, `query-duration`, `memory-usage`, `cpu-usage`, `error-rate-over-time`, `zookeeper-requests` — covering both area/bar types and common option shapes (breakdown, stack, colors, tick formatting).
- Icons are catalog-only metadata referenced by kebab-case lucide name, resolved lazily via `lucide-react/dynamic` (no eager bundling).
- New `docs/knowledge/chart-config-format.md` documents the authoring format for community/AI contributors; added to the Knowledge Graph table in root `CLAUDE.md`.
- Additive only: no existing hand-authored or factory chart file was touched, and nothing is wired into live routes — the catalog is fully dormant.

## Test plan
Ran the plan's own verification block exactly:
```
cd apps/dashboard && bun run type-check   → pass (tsc --noEmit, no errors)
cd apps/dashboard && bun run build        → pass (vite build + tsc --noEmit, 103 pages prerendered)
cd apps/dashboard && bun test src/components/charts --isolate → 91 pass, 0 fail (12 files, 260 expect() calls)
bun run lint (repo root)                  → pass (biome, 2060 files checked, no issues)
```

Note: the repo's `pre-push` hook additionally runs the full `bun test:unit` suite, which reports 2 pre-existing failures unrelated to this change (`cloudflare:workers` module resolution in `user-connections` route tests — a known bun-test-vs-workerd environment gap, not touched by this PR). Confirmed this also fails on latest `main` (59487abd5) — the `Test` GitHub Actions workflow is `failure` there too, and `unit-tests` is listed as a known non-required check in this repo's CLAUDE.md.

https://claude.ai/code/session_01XpfaNdJZh4Rtr6cQm4DYqa