### PR TITLE
feat(billing): AI monthly-spend meter + honest deferred labels on usage card (plan 16)

### DIFF
--- a/apps/dashboard/src/components/billing/usage-meter-utils.test.ts
+++ b/apps/dashboard/src/components/billing/usage-meter-utils.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  deferredNote,
+  formatUsd,
+  type Meter,
+  meterLevel,
+  meterPercent,
+  renewalBannerState,
+} from './usage-meter-utils'
+
+const meter = (used: number, limit: number | null): Meter => ({
+  used,
+  limit,
+  unlimited: limit == null,
+})
+
+describe('meterLevel — the paywall threshold (red past 80%)', () => {
+  test('normal below 60% of the cap', () => {
+    expect(meterLevel(meter(0, 1))).toBe('normal') // Free hosts, none used
+    expect(meterLevel(meter(1, 3))).toBe('normal') // 33%
+    expect(meterLevel(meter(59, 100))).toBe('normal')
+  })
+
+  test('amber from 60% up to (not including) 80%', () => {
+    expect(meterLevel(meter(60, 100))).toBe('amber')
+    expect(meterLevel(meter(2, 3))).toBe('amber') // 66%
+    expect(meterLevel(meter(79, 100))).toBe('amber')
+  })
+
+  test('red at or past 80% — including at/over the limit', () => {
+    expect(meterLevel(meter(80, 100))).toBe('red')
+    expect(meterLevel(meter(3, 3))).toBe('red') // at limit
+    expect(meterLevel(meter(5, 3))).toBe('red') // over limit
+  })
+
+  test('unlimited / uncapped meters never colour', () => {
+    expect(meterLevel(meter(9999, null))).toBe('normal') // Enterprise
+    expect(meterLevel({ used: 5, limit: 0, unlimited: false })).toBe('normal')
+  })
+
+  test('a store hiccup (NaN / negative used) degrades to normal, never over-limit', () => {
+    expect(meterLevel(meter(Number.NaN, 3))).toBe('normal')
+    expect(meterLevel(meter(-4, 3))).toBe('normal')
+  })
+})
+
+describe('meterPercent — bar fill', () => {
+  test('rounds the ratio and clamps to 100', () => {
+    expect(meterPercent(meter(1, 3))).toBe(33)
+    expect(meterPercent(meter(3, 3))).toBe(100)
+    expect(meterPercent(meter(9, 3))).toBe(100) // over-limit clamps
+  })
+
+  test('is 0 for unlimited / uncapped', () => {
+    expect(meterPercent(meter(50, null))).toBe(0)
+    expect(meterPercent({ used: 5, limit: 0, unlimited: false })).toBe(0)
+  })
+})
+
+describe('formatUsd — the AI monthly-spend meter', () => {
+  test('always two decimals', () => {
+    expect(formatUsd(0)).toBe('$0.00') // Free: $0.00 / $0.50
+    expect(formatUsd(0.5)).toBe('$0.50')
+    expect(formatUsd(5)).toBe('$5.00')
+    expect(formatUsd(12.34)).toBe('$12.34')
+  })
+
+  test('non-finite spend degrades to $0.00 rather than "NaN"', () => {
+    expect(formatUsd(Number.NaN)).toBe('$0.00')
+  })
+})
+
+describe('deferredNote — honest paywalls (advertised ⟺ enforced)', () => {
+  test('enforced limits read as real caps (no note)', () => {
+    // hosts / seats / AI daily / AI monthly-USD are all live gates today.
+    expect(deferredNote('hosts')).toBeNull()
+    expect(deferredNote('seats')).toBeNull()
+    expect(deferredNote('aiRequestsPerDay')).toBeNull()
+    expect(deferredNote('aiMonthlyUsdBudget')).toBeNull()
+  })
+
+  test('a deferred limit is labelled informational, not "upgrade to unlock"', () => {
+    // alertRules has no create-path yet → deferred → must be flagged.
+    expect(deferredNote('alertRules')).toBe('not billed in early access')
+  })
+})
+
+describe('renewalBannerState — Pro renewal + cancel-grace', () => {
+  test('Free / never subscribed shows nothing', () => {
+    expect(
+      renewalBannerState({
+        currentPeriodEnd: null,
+        cancelAtPeriodEnd: false,
+        status: 'none',
+      })
+    ).toBe('hidden')
+  })
+
+  test('active paid subscription shows the renewal date', () => {
+    expect(
+      renewalBannerState({
+        currentPeriodEnd: 1_800_000_000,
+        cancelAtPeriodEnd: false,
+        status: 'active',
+      })
+    ).toBe('renew')
+  })
+
+  test('cancel-at-period-end shows the grace banner', () => {
+    expect(
+      renewalBannerState({
+        currentPeriodEnd: 1_800_000_000,
+        cancelAtPeriodEnd: true,
+        status: 'active',
+      })
+    ).toBe('cancel')
+  })
+})

--- a/apps/dashboard/src/components/billing/usage-meter-utils.test.ts
+++ b/apps/dashboard/src/components/billing/usage-meter-utils.test.ts
@@ -1,5 +1,3 @@
-import { describe, expect, test } from 'bun:test'
-
 import {
   deferredNote,
   formatUsd,
@@ -8,6 +6,7 @@ import {
   meterPercent,
   renewalBannerState,
 } from './usage-meter-utils'
+import { describe, expect, test } from 'bun:test'
 
 const meter = (used: number, limit: number | null): Meter => ({
   used,

--- a/apps/dashboard/src/components/billing/usage-meter-utils.ts
+++ b/apps/dashboard/src/components/billing/usage-meter-utils.ts
@@ -1,0 +1,99 @@
+/**
+ * Pure presentation logic for the billing usage meters (see `usage-summary.tsx`).
+ *
+ * Extracted out of the React component so the threshold colours, USD formatting,
+ * "deferred limit" honesty note, and the renewal-banner decision can be asserted
+ * directly in Bun without rendering (see `usage-meter-utils.test.ts`). No React,
+ * no app-runtime imports — safe to pull into the client bundle.
+ */
+
+import {
+  LIMIT_ENFORCEMENT,
+  type LimitKey,
+} from '@/lib/billing/plan-enforcement'
+
+/** A used-vs-cap meter. `limit: null` (or `unlimited`) means no cap. */
+export interface Meter {
+  used: number
+  limit: number | null
+  unlimited: boolean
+}
+
+/** Severity band that drives a meter bar's colour. */
+export type MeterLevel = 'normal' | 'amber' | 'red'
+
+/** Amber once ≥ 60% of the cap is used; red once ≥ 80% (matches the paywall). */
+const AMBER_AT = 0.6
+const RED_AT = 0.8
+
+/** Non-negative, finite usage — a store hiccup can only ever under-count. */
+function safeUsed(used: number): number {
+  return Number.isFinite(used) && used > 0 ? used : 0
+}
+
+/** Fraction of the cap consumed (0 when there is no cap to fill toward). */
+function ratio(meter: Meter): number {
+  const { limit, unlimited } = meter
+  if (unlimited || limit == null || limit <= 0) return 0
+  return safeUsed(meter.used) / limit
+}
+
+/**
+ * Colour band for a meter. Unlimited / uncapped meters are always `normal`
+ * (there is nothing to run out of). Red subsumes at/over-limit (ratio ≥ 0.8),
+ * so a meter "turns red past 80%" as the plan requires.
+ */
+export function meterLevel(meter: Meter): MeterLevel {
+  const r = ratio(meter)
+  if (r >= RED_AT) return 'red'
+  if (r >= AMBER_AT) return 'amber'
+  return 'normal'
+}
+
+/** Bar fill 0–100 (clamped). 0 when the meter is unlimited / uncapped. */
+export function meterPercent(meter: Meter): number {
+  return Math.min(100, Math.round(ratio(meter) * 100))
+}
+
+const USD = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+})
+
+/** e.g. `$0.00`, `$0.50`, `$12.34`. Non-finite input formats as `$0.00`. */
+export function formatUsd(value: number): string {
+  return USD.format(Number.isFinite(value) ? value : 0)
+}
+
+/**
+ * Honesty note for a meter whose limit is advertised but not actually billed yet
+ * (`deferred` in the enforcement registry). Returns `null` for enforced limits so
+ * the meter reads as a real cap. Keeps the UI ⟺ enforcement in lockstep: flip a
+ * limit to `deferred` and the note appears automatically.
+ */
+export function deferredNote(key: LimitKey): string | null {
+  return LIMIT_ENFORCEMENT[key].status === 'deferred'
+    ? 'not billed in early access'
+    : null
+}
+
+/** What the renewal banner should render, or `hidden` when there's nothing to say. */
+export type RenewalBannerState = 'hidden' | 'cancel' | 'renew'
+
+/**
+ * Decide the renewal banner from the subscription's renewal metadata. Free / never
+ * subscribed (`status: 'none'` or no period end) is `hidden`; a pending
+ * cancellation shows the grace `cancel` banner; an active period shows `renew`.
+ */
+export function renewalBannerState(renewal: {
+  currentPeriodEnd: number | null
+  cancelAtPeriodEnd: boolean
+  status: string
+}): RenewalBannerState {
+  if (renewal.status === 'none' || renewal.currentPeriodEnd == null) {
+    return 'hidden'
+  }
+  return renewal.cancelAtPeriodEnd ? 'cancel' : 'renew'
+}

--- a/apps/dashboard/src/components/billing/usage-summary.tsx
+++ b/apps/dashboard/src/components/billing/usage-summary.tsx
@@ -1,10 +1,6 @@
 import { AlertTriangleIcon, CalendarClockIcon } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 
-import { Progress } from '@/components/ui/progress'
-import { Skeleton } from '@/components/ui/skeleton'
-import { apiFetch } from '@/lib/swr/api-fetch'
-import { cn } from '@/lib/utils'
 import {
   deferredNote,
   formatUsd,
@@ -13,6 +9,10 @@ import {
   meterPercent,
   renewalBannerState,
 } from './usage-meter-utils'
+import { Progress } from '@/components/ui/progress'
+import { Skeleton } from '@/components/ui/skeleton'
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { cn } from '@/lib/utils'
 
 /**
  * Current-plan usage summary — the used-vs-cap meters + renewal/cancel banner

--- a/apps/dashboard/src/components/billing/usage-summary.tsx
+++ b/apps/dashboard/src/components/billing/usage-summary.tsx
@@ -170,7 +170,7 @@ function UsageMeterBar({
           {formatValue(meter.used)}
           <span className="text-muted-foreground font-normal">
             {meter.unlimited || meter.limit == null
-              ? ' / ∞'
+              ? ' / Unlimited'
               : ` / ${formatValue(meter.limit)}`}
           </span>
         </span>
@@ -199,7 +199,7 @@ function UsageMeterBar({
  * AI overage spend this billing month ($ spent / $ budget). Degrades gracefully:
  * when `spent` is absent (metering not surfaced) the value renders "—" with no
  * bar — never a throw or a broken meter. `budget: null` is Enterprise BYOK /
- * unlimited and renders "/ ∞".
+ * unlimited and renders "/ Unlimited".
  */
 function AiSpendMeterBar({
   spent,

--- a/apps/dashboard/src/components/billing/usage-summary.tsx
+++ b/apps/dashboard/src/components/billing/usage-summary.tsx
@@ -5,6 +5,14 @@ import { Progress } from '@/components/ui/progress'
 import { Skeleton } from '@/components/ui/skeleton'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { cn } from '@/lib/utils'
+import {
+  deferredNote,
+  formatUsd,
+  type Meter,
+  meterLevel,
+  meterPercent,
+  renewalBannerState,
+} from './usage-meter-utils'
 
 /**
  * Current-plan usage summary — the used-vs-cap meters + renewal/cancel banner
@@ -27,6 +35,10 @@ interface BillingUsage {
   hosts: UsageMeter
   seats: UsageMeter
   aiMessages: UsageMeter
+  /** LLM overage $ spent this billing month. Absent until metering is surfaced. */
+  aiSpentThisMonth?: number
+  /** Monthly LLM spend cap in USD. `null` = Enterprise BYOK / unlimited. */
+  aiMonthlyUsdBudget?: number | null
   renewal: {
     currentPeriodEnd: number | null
     cancelAtPeriodEnd: boolean
@@ -94,29 +106,59 @@ export function UsageSummary() {
     )
   }
 
-  const { hosts, seats, aiMessages, renewal } = data
+  const {
+    hosts,
+    seats,
+    aiMessages,
+    aiSpentThisMonth,
+    aiMonthlyUsdBudget,
+    renewal,
+  } = data
 
   return (
     <div className="space-y-4 pt-2">
-      <div className="grid gap-4 sm:grid-cols-3">
-        <UsageMeterBar label="Hosts" meter={hosts} />
-        <UsageMeterBar label="Team seats" meter={seats} />
-        <UsageMeterBar label="AI messages today" meter={aiMessages} />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <UsageMeterBar
+          label="Hosts"
+          meter={hosts}
+          note={deferredNote('hosts')}
+        />
+        <UsageMeterBar
+          label="Team seats"
+          meter={seats}
+          note={deferredNote('seats')}
+        />
+        <UsageMeterBar
+          label="AI messages today"
+          meter={aiMessages}
+          note={deferredNote('aiRequestsPerDay')}
+        />
+        <AiSpendMeterBar
+          spent={aiSpentThisMonth}
+          budget={aiMonthlyUsdBudget}
+          note={deferredNote('aiMonthlyUsdBudget')}
+        />
       </div>
       <RenewalBanner renewal={renewal} />
     </div>
   )
 }
 
-function UsageMeterBar({ label, meter }: { label: string; meter: UsageMeter }) {
-  const { used, limit, unlimited } = meter
-  // Percentage of the cap consumed (0 when unlimited — nothing to fill toward).
-  const pct =
-    unlimited || limit == null || limit <= 0
-      ? 0
-      : Math.min(100, Math.round((used / limit) * 100))
-  const atLimit = !unlimited && limit != null && used >= limit
-  const nearLimit = !unlimited && pct >= 80
+function UsageMeterBar({
+  label,
+  meter,
+  formatValue = String,
+  note,
+}: {
+  label: string
+  meter: Meter
+  /** Renders `used` / `limit` (e.g. USD for the AI-spend meter). */
+  formatValue?: (value: number) => string
+  /** Honesty note for a `deferred` limit; omitted for enforced caps. */
+  note?: string | null
+}) {
+  const level = meterLevel(meter)
+  const pct = meterPercent(meter)
 
   return (
     <div className="space-y-1.5">
@@ -125,9 +167,11 @@ function UsageMeterBar({ label, meter }: { label: string; meter: UsageMeter }) {
           {label}
         </span>
         <span className="text-sm font-semibold tabular-nums">
-          {used}
+          {formatValue(meter.used)}
           <span className="text-muted-foreground font-normal">
-            {unlimited || limit == null ? ' / ∞' : ` / ${limit}`}
+            {meter.unlimited || meter.limit == null
+              ? ' / ∞'
+              : ` / ${formatValue(meter.limit)}`}
           </span>
         </span>
       </div>
@@ -135,26 +179,78 @@ function UsageMeterBar({ label, meter }: { label: string; meter: UsageMeter }) {
         value={pct}
         className={cn(
           '[&>div]:transition-all',
-          atLimit
+          level === 'red'
             ? '[&>div]:bg-destructive'
-            : nearLimit
+            : level === 'amber'
               ? '[&>div]:bg-amber-500'
               : undefined
         )}
       />
+      {note ? (
+        <p className="text-muted-foreground/70 text-[10px] leading-tight">
+          {note}
+        </p>
+      ) : null}
     </div>
   )
 }
 
+/**
+ * AI overage spend this billing month ($ spent / $ budget). Degrades gracefully:
+ * when `spent` is absent (metering not surfaced) the value renders "—" with no
+ * bar — never a throw or a broken meter. `budget: null` is Enterprise BYOK /
+ * unlimited and renders "/ ∞".
+ */
+function AiSpendMeterBar({
+  spent,
+  budget,
+  note,
+}: {
+  spent?: number
+  budget?: number | null
+  note?: string | null
+}) {
+  const label = 'AI spend this month'
+
+  if (spent === undefined) {
+    return (
+      <div className="space-y-1.5">
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="text-muted-foreground text-xs font-medium">
+            {label}
+          </span>
+          <span className="text-muted-foreground text-sm font-semibold tabular-nums">
+            —
+          </span>
+        </div>
+        {note ? (
+          <p className="text-muted-foreground/70 text-[10px] leading-tight">
+            {note}
+          </p>
+        ) : null}
+      </div>
+    )
+  }
+
+  return (
+    <UsageMeterBar
+      label={label}
+      meter={{ used: spent, limit: budget ?? null, unlimited: budget == null }}
+      formatValue={formatUsd}
+      note={note}
+    />
+  )
+}
+
 function RenewalBanner({ renewal }: { renewal: BillingUsage['renewal'] }) {
-  const { currentPeriodEnd, cancelAtPeriodEnd, status } = renewal
+  const state = renewalBannerState(renewal)
 
   // Nothing meaningful to show for the free tier (no period, never subscribed).
-  if (status === 'none' || currentPeriodEnd == null) return null
+  if (state === 'hidden' || renewal.currentPeriodEnd == null) return null
 
-  const dateLabel = formatRenewalDate(currentPeriodEnd)
+  const dateLabel = formatRenewalDate(renewal.currentPeriodEnd)
 
-  if (cancelAtPeriodEnd) {
+  if (state === 'cancel') {
     return (
       <div className="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
         <AlertTriangleIcon


### PR DESCRIPTION
## Plan 16 — Billing usage dashboard card

Fills the last gap on the in-app billing surface: the **4th usage meter (AI monthly spend)** and honest deferred-limit labeling.

> ⚠️ **HOLD FOR HUMAN REVIEW — do not auto-merge.** This is a billing surface. Auto-merge intentionally NOT armed.

### Plan drift → STOP condition triggered (extend, don't duplicate)
The plan's audited reality was stale — the billing route and most of plan 16 were **already implemented** since the plan was written:
- **`billing.tsx`** already renders the current-plan card, the Upgrade CTAs (plan grid → `startCheckout`), the "Manage billing" CTA (→ Polar `openBillingPortal`), and the plan comparison. (Plan file **C** `current-plan-card` and the CTAs of **E** already exist.)
- **`usage-summary.tsx`** already renders full meters (hosts, seats, AI-messages-today) **and** the renewal / cancel-grace banner. (Plan files **B** `usage-meters` and **D** `renewal-banner` already exist.)

The plan's own STOP condition covers exactly this: *"STOP if `usage-summary.tsx` already renders full meters — extend it and drop the duplicate `usage-meters.tsx`."* So this PR **extends** the existing component instead of creating `usage-meters.tsx` / `current-plan-card.tsx` / `renewal-banner.tsx` (which would duplicate shipped code). The next-tier helper is likewise unnecessary — the upgrade path already exists in the plan grid.

### What actually changed
- **New 4th meter — AI monthly spend** (`aiSpentThisMonth` / `aiMonthlyUsdBudget`), USD-formatted. Renders `/ Unlimited` for Enterprise BYOK (`budget: null`) and degrades to `—` with no bar if the field is ever absent — never throws. The API already surfaces both fields (plan 14 is merged), so this is **real** metering data (`getAiSpendThisMonth` → `ai_usage_monthly`).
- **Threshold** now `normal < 60% · amber ≥ 60% · red ≥ 80%`, so meters "turn red past 80%" per the plan's done-criterion. ⚠️ **Deviation flagged:** the previously shipped code was amber@80 / red@100, which failed that criterion at e.g. 85%. Applied the new bands uniformly to all four meters. If you prefer amber@80 / red@100, it's a one-line change in `usage-meter-utils.ts` (`RED_AT`/`AMBER_AT`).
- **"Unlimited" wording** — uncapped meters render `/ Unlimited` (not `∞`), matching the plan criterion **and** the existing `planHosts`/`planSeats` wording already shown in the plan-comparison matrix on the same page (previously the meter said `∞` while the matrix said "Unlimited").
- **Honest paywalls** — each meter shows a "not billed in early access" note whenever its limit is `deferred` in `plan-enforcement.ts`. All four metered limits are `enforced` today, so no note renders now, but the wiring keeps advertised ⟺ enforced automatically if a limit flips.
- **Grid** widened `sm:grid-cols-3` → `sm:grid-cols-2 lg:grid-cols-4` for the 4th meter.
- **Pure logic extracted** to `usage-meter-utils.ts` (thresholds, USD, deferred note, renewal-banner state) so it's Bun-testable without rendering. `usage-summary.tsx` and the renewal banner now consume it.
- OSS/self-host stays whole — the endpoint 401s and the component renders nothing (unchanged fail-open).

### Expected-but-worth-noting: Free shows `$0.00 / $0.50`
The AI-spend meter reads **real** spend, but the Free tier has `aiOverage: null`, so it **never accrues** metered spend — a Free account will always show `$0.00 / $0.50`. That's correct (genuinely zero), not a broken/empty meter. Paid tiers show actual accrued overage.

### Tests — `usage-meter-utils.test.ts` (Bun, 14 cases)
Covers the plan's F scenarios as pure logic: Free caps (normal), over-limit (red past 80%), Pro renewal (`renew`), cancel-grace (`cancel`), USD formatting incl. Free `$0.00 / $0.50`, and deferred-vs-enforced honesty. Chose Bun logic tests over Cypress render (non-required CI, historically flaky, no existing billing `.cy.tsx` pattern); the render itself is type-checked.

### Verification
- `bun test src/components/billing/` → **14 pass / 0 fail**
- `bun run lint` (biome, changed files) → clean
- `bun run type-check` / `type-check:test` → my files add **zero** errors (verified: identical 228→228 error count with vs. without the edit; all 228 are the pre-existing gitignored `routeTree.gen.ts` artifacts that CI's build step generates before type-check, per `cloudflare.yml:183-186`). Full `bun run build` intentionally skipped per worktree constraints.

Co-Authored-By: duyetbot <bot@duyet.net>
