### PR TITLE
fix(insights): break weekly-report/weekly-report-html circular import

### DIFF
--- a/apps/dashboard/src/lib/insights/types.ts
+++ b/apps/dashboard/src/lib/insights/types.ts
@@ -7,7 +7,46 @@
  * optionally polished by an LLM when a provider key is configured.
  */
 
+import type { ForecastResult } from '@/lib/ai/advisor/capacity-forecaster'
+
 export type InsightSeverity = 'info' | 'warning' | 'critical'
+
+/** A single highlighted finding surfaced in a weekly report's "top findings" section. */
+export interface WeeklyTopFinding {
+  readonly severity: InsightSeverity
+  readonly category: string
+  readonly title: string
+  readonly detail: string
+  readonly metric: string
+  readonly generatedAt: string
+}
+
+/** Weekly report capacity section: the real forecast, or a degraded-but-honest fallback. */
+export type WeeklyReportCapacity =
+  | ForecastResult
+  | {
+      readonly available: false
+      readonly reason: 'error'
+      readonly message: string
+    }
+
+/** Compact, JSON-serializable summary of a host's weekly report. */
+export interface WeeklyReportSummary {
+  readonly hostId: number
+  readonly hostLabel: string
+  /** Start of the rolling 7-day window, `YYYY-MM-DD`. */
+  readonly weekStart: string
+  /** End of the window (today), `YYYY-MM-DD`. */
+  readonly weekEnd: string
+  readonly generatedAt: string
+  readonly totalFindings: number
+  readonly bySeverity: Record<InsightSeverity, number>
+  readonly byCategory: Record<string, number>
+  readonly topFindings: readonly WeeklyTopFinding[]
+  /** Count of metrics with a fitted statistical baseline (plan 48). */
+  readonly baselinesFitted: number
+  readonly capacity: WeeklyReportCapacity
+}
 
 /** A recommended next step the operator can take for an insight. */
 export interface InsightAction {

--- a/apps/dashboard/src/lib/insights/weekly-report-html.ts
+++ b/apps/dashboard/src/lib/insights/weekly-report-html.ts
@@ -19,12 +19,12 @@
  * claims any change was applied — chmonitor recommends, it does not act.
  */
 
-import type { InsightSeverity } from './types'
 import type {
+  InsightSeverity,
   WeeklyReportCapacity,
   WeeklyReportSummary,
   WeeklyTopFinding,
-} from './weekly-report'
+} from './types'
 
 /** Escape untrusted finding text before interpolating into markup. */
 function esc(value: string): string {

--- a/apps/dashboard/src/lib/insights/weekly-report.ts
+++ b/apps/dashboard/src/lib/insights/weekly-report.ts
@@ -14,8 +14,12 @@
  * (fail-open — see plans/52-proactive-weekly-health-report.md).
  */
 
-import type { ForecastResult } from '@/lib/ai/advisor/capacity-forecaster'
-import type { InsightSeverity } from './types'
+import type {
+  InsightSeverity,
+  WeeklyReportCapacity,
+  WeeklyReportSummary,
+  WeeklyTopFinding,
+} from './types'
 
 import { listBaselines } from './baseline-store'
 import { resolveInsightsStore } from './store/resolve-store'
@@ -44,43 +48,6 @@ function toSeverity(value: string): InsightSeverity {
   return VALID_SEVERITY.has(value as InsightSeverity)
     ? (value as InsightSeverity)
     : 'info'
-}
-
-/** A single highlighted finding surfaced in the "top findings" section. */
-export interface WeeklyTopFinding {
-  readonly severity: InsightSeverity
-  readonly category: string
-  readonly title: string
-  readonly detail: string
-  readonly metric: string
-  readonly generatedAt: string
-}
-
-/** Capacity section: the real forecast, or a degraded-but-honest fallback. */
-export type WeeklyReportCapacity =
-  | ForecastResult
-  | {
-      readonly available: false
-      readonly reason: 'error'
-      readonly message: string
-    }
-
-/** Compact, JSON-serializable summary of a host's weekly report. */
-export interface WeeklyReportSummary {
-  readonly hostId: number
-  readonly hostLabel: string
-  /** Start of the rolling 7-day window, `YYYY-MM-DD`. */
-  readonly weekStart: string
-  /** End of the window (today), `YYYY-MM-DD`. */
-  readonly weekEnd: string
-  readonly generatedAt: string
-  readonly totalFindings: number
-  readonly bySeverity: Record<InsightSeverity, number>
-  readonly byCategory: Record<string, number>
-  readonly topFindings: readonly WeeklyTopFinding[]
-  /** Count of metrics with a fitted statistical baseline (plan 48). */
-  readonly baselinesFitted: number
-  readonly capacity: WeeklyReportCapacity
 }
 
 export interface WeeklyReport {

--- a/apps/dashboard/src/routes/api/v1/insights/weekly-report.ts
+++ b/apps/dashboard/src/routes/api/v1/insights/weekly-report.ts
@@ -21,7 +21,7 @@
 
 import { createFileRoute } from '@tanstack/react-router'
 
-import type { WeeklyReportSummary } from '@/lib/insights/weekly-report'
+import type { WeeklyReportSummary } from '@/lib/insights/types'
 
 import { error, generateRequestId } from '@chm/logger'
 import { renderWeeklyReportHtml } from '@/lib/insights/weekly-report-html'


### PR DESCRIPTION
## Summary
`weekly-report.ts` and `weekly-report-html.ts` (plan 52, merged) imported types from each other, tripping depcruise's `no-circular` rule on every PR downstream of this file — currently blocking plan 33 (#2255) and likely others. Root cause: the pure HTML renderer imported `WeeklyReportSummary`/`WeeklyReportCapacity`/`WeeklyTopFinding` from `weekly-report.ts`, which in turn imports `renderWeeklyReportHtml` from the renderer.

## Fix
Moved the three shared types into the existing `types.ts` (both files already depend on it). No behavior change — pure type relocation.

## Verification
- `bun run depcruise` → clean (was: 1 circular-dependency violation)
- `bunx tsc -p tsconfig.test.json --noEmit` → clean
- `bun run build` → succeeds
- `bun test src/lib/insights --isolate` → 326 pass, 0 fail
- `bun run lint` → clean

Co-Authored-By: duyetbot <bot@duyet.net>