### PR TITLE
feat(mcp): per-user external MCP server registry (register, validate, load) (plan 43)

### DIFF
--- a/apps/dashboard/src/components/agents/welcome/agent-mcp-panel.tsx
+++ b/apps/dashboard/src/components/agents/welcome/agent-mcp-panel.tsx
@@ -15,9 +15,11 @@
  * Follows the assistant-ui MCP config pattern:
  *   https://www.assistant-ui.com/docs/ui/mcp-config
  *
- * Note: custom servers are not yet wired to the agent runtime, so their
- * persisted enable/disable state is a stored user preference rather than a
- * live runtime binding.
+ * These custom servers ARE wired to the agent runtime: the runtime provider
+ * sends the enabled ones in each agent request body, and the agent connects
+ * them (SSRF-guarded) alongside the built-in tools for that conversation. For
+ * per-user servers that PERSIST server-side (D1) with auth + a template
+ * library, see the MCP Servers manager route (`/mcp-servers`).
  */
 
 import { PlusIcon, Trash2Icon, WrenchIcon } from 'lucide-react'

--- a/apps/dashboard/src/components/mcp/mcp-server-manager.tsx
+++ b/apps/dashboard/src/components/mcp/mcp-server-manager.tsx
@@ -1,0 +1,588 @@
+'use client'
+
+/**
+ * MCP Server Manager — per-user registry of external Model Context Protocol
+ * servers (plan 43). Backed by D1 through `/api/v1/mcp/servers`; each server is
+ * validated (SSRF-guarded) on save and loaded alongside the agent's built-in
+ * tools at conversation start.
+ *
+ * Distinct from the welcome-screen `AgentMcpPanel` (localStorage quick-config):
+ * this surface PERSISTS per-user, server-side, with auth + a template library.
+ */
+
+import {
+  CheckCircle2Icon,
+  Loader2Icon,
+  PlugZapIcon,
+  PlusIcon,
+  ServerIcon,
+  Trash2Icon,
+  XCircleIcon,
+} from 'lucide-react'
+
+import type {
+  McpAuthKind,
+  McpRegistrationDto,
+  McpTransport,
+  TestMcpConnectionResult,
+} from '@/lib/swr/use-mcp-registry'
+
+import { useState } from 'react'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { EmptyState } from '@/components/ui/empty-state'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Switch } from '@/components/ui/switch'
+import {
+  type CreateMcpServerInput,
+  McpRegistryRequestError,
+  testMcpConnection,
+  useCreateMcpServer,
+  useDeleteMcpServer,
+  useMcpRegistryServers,
+  usePatchMcpServer,
+} from '@/lib/swr/use-mcp-registry'
+import { cn } from '@/lib/utils'
+
+// ---------------------------------------------------------------------------
+// Template library — starter presets. The Test button is the source of truth;
+// confirm the exact endpoint/region for your account before saving.
+// ---------------------------------------------------------------------------
+
+interface ServerTemplate {
+  id: string
+  label: string
+  url: string
+  transport: McpTransport
+  authKind: McpAuthKind
+  authHeaderName?: string
+  hint: string
+}
+
+const TEMPLATES: ServerTemplate[] = [
+  {
+    id: 'github',
+    label: 'GitHub',
+    url: 'https://api.githubcopilot.com/mcp/',
+    transport: 'http',
+    authKind: 'bearer',
+    hint: 'Use a GitHub personal access token as the bearer token.',
+  },
+  {
+    id: 'slack',
+    label: 'Slack',
+    url: 'https://mcp.slack.com/mcp',
+    transport: 'http',
+    authKind: 'bearer',
+    hint: 'Provide your Slack MCP bearer token (verify your workspace URL).',
+  },
+  {
+    id: 'datadog',
+    label: 'Datadog',
+    url: 'https://mcp.datadoghq.com/api/unstable/mcp-server/mcp',
+    transport: 'http',
+    authKind: 'header',
+    authHeaderName: 'DD-API-KEY',
+    hint: 'Send your Datadog API key in the DD-API-KEY header.',
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Badges
+// ---------------------------------------------------------------------------
+
+function TransportBadge({ transport }: { transport: McpTransport }) {
+  return (
+    <Badge variant="outline" className="h-5 px-1.5 text-[10px] uppercase">
+      {transport}
+    </Badge>
+  )
+}
+
+function AuthBadge({
+  authKind,
+  headerName,
+}: {
+  authKind: McpAuthKind
+  headerName: string | null
+}) {
+  if (authKind === 'none') {
+    return <span className="text-muted-foreground text-[11px]">No auth</span>
+  }
+  return (
+    <Badge variant="secondary" className="h-5 px-1.5 text-[10px]">
+      {authKind === 'bearer' ? 'Bearer' : `Header: ${headerName ?? '—'}`}
+    </Badge>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Server row
+// ---------------------------------------------------------------------------
+
+function ServerRow({ server }: { server: McpRegistrationDto }) {
+  const patch = usePatchMcpServer()
+  const remove = useDeleteMcpServer()
+
+  const toolCount = server.capabilities?.length ?? 0
+  const validated = server.lastValidatedAt
+    ? new Date(server.lastValidatedAt).toLocaleDateString()
+    : null
+
+  return (
+    <div className="flex items-center gap-3 px-3 py-2.5">
+      <div className="bg-muted inline-flex size-8 shrink-0 items-center justify-center rounded-md">
+        <ServerIcon className="text-foreground size-4" strokeWidth={1.5} />
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-[13px] font-medium">
+            {server.name}
+          </span>
+          <TransportBadge transport={server.transport} />
+          <AuthBadge
+            authKind={server.authKind}
+            headerName={server.authHeaderName}
+          />
+        </div>
+        <div className="text-muted-foreground mt-0.5 flex items-center gap-1.5 truncate font-mono text-[11px]">
+          <span className="truncate">{server.url}</span>
+        </div>
+        <div className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-[10.5px] tabular-nums">
+          <span>{toolCount} tools</span>
+          {validated && (
+            <>
+              <span className="text-border">·</span>
+              <span>validated {validated}</span>
+            </>
+          )}
+          {!server.enabled && (
+            <>
+              <span className="text-border">·</span>
+              <span>disabled</span>
+            </>
+          )}
+        </div>
+      </div>
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="text-muted-foreground hover:text-destructive size-8 shrink-0"
+        disabled={remove.isPending}
+        onClick={() => remove.mutate(server.id)}
+        aria-label={`Remove ${server.name}`}
+      >
+        {remove.isPending ? (
+          <Loader2Icon className="size-4 animate-spin" />
+        ) : (
+          <Trash2Icon className="size-4" />
+        )}
+      </Button>
+
+      <Switch
+        checked={server.enabled}
+        disabled={patch.isPending}
+        onCheckedChange={(next) =>
+          patch.mutate({ id: server.id, enabled: next })
+        }
+        aria-label={
+          server.enabled ? `Disable ${server.name}` : `Enable ${server.name}`
+        }
+        className="shrink-0"
+      />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Add server form (name / url / transport / auth) with a Test button
+// ---------------------------------------------------------------------------
+
+const EMPTY_FORM: CreateMcpServerInput = {
+  name: '',
+  url: '',
+  transport: 'http',
+  authKind: 'none',
+  authSecret: '',
+  authHeaderName: '',
+}
+
+function AddServerForm({ onClose }: { onClose: () => void }) {
+  const [form, setForm] = useState<CreateMcpServerInput>(EMPTY_FORM)
+  const [testResult, setTestResult] = useState<TestMcpConnectionResult | null>(
+    null
+  )
+  const [testing, setTesting] = useState(false)
+  const [testError, setTestError] = useState<string | null>(null)
+
+  const create = useCreateMcpServer()
+
+  const set = (patch: Partial<CreateMcpServerInput>) => {
+    setForm((prev) => ({ ...prev, ...patch }))
+    setTestResult(null)
+    setTestError(null)
+  }
+
+  const applyTemplate = (t: ServerTemplate) => {
+    setForm({
+      name: t.label,
+      url: t.url,
+      transport: t.transport,
+      authKind: t.authKind,
+      authSecret: '',
+      authHeaderName: t.authHeaderName ?? '',
+    })
+    setTestResult(null)
+    setTestError(null)
+  }
+
+  const needsSecret = form.authKind !== 'none'
+  const needsHeaderName = form.authKind === 'header'
+  const canSubmit =
+    form.name.trim().length > 0 &&
+    form.url.trim().length > 0 &&
+    (!needsSecret || (form.authSecret ?? '').length > 0) &&
+    (!needsHeaderName || (form.authHeaderName ?? '').trim().length > 0)
+
+  const runTest = async () => {
+    setTesting(true)
+    setTestError(null)
+    setTestResult(null)
+    try {
+      const result = await testMcpConnection({
+        endpoint: form.url.trim(),
+        name: form.name.trim() || 'probe',
+        transport: form.transport,
+        authKind: form.authKind,
+        authSecret: form.authSecret,
+        authHeaderName: form.authHeaderName,
+      })
+      setTestResult(result)
+    } catch (e) {
+      setTestError(
+        e instanceof McpRegistryRequestError
+          ? e.message
+          : 'Test connection failed'
+      )
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  const submit = () => {
+    if (!canSubmit) return
+    create.mutate(
+      {
+        name: form.name.trim(),
+        url: form.url.trim(),
+        transport: form.transport,
+        authKind: form.authKind,
+        authSecret: needsSecret ? form.authSecret : undefined,
+        authHeaderName: needsHeaderName
+          ? form.authHeaderName?.trim()
+          : undefined,
+      },
+      { onSuccess: onClose }
+    )
+  }
+
+  return (
+    <Card className="rounded-xl border bg-card shadow-sm">
+      <CardContent className="space-y-3 p-4">
+        {/* Template library */}
+        <div className="space-y-1.5">
+          <Label className="text-muted-foreground text-[11px] uppercase tracking-wide">
+            Start from a template
+          </Label>
+          <div className="flex flex-wrap gap-1.5">
+            {TEMPLATES.map((t) => (
+              <Button
+                key={t.id}
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-7 text-[12px]"
+                onClick={() => applyTemplate(t)}
+              >
+                {t.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="mcp-name" className="text-[12px]">
+              Name
+            </Label>
+            <Input
+              id="mcp-name"
+              value={form.name}
+              placeholder="My MCP server"
+              onChange={(e) => set({ name: e.target.value })}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="mcp-transport" className="text-[12px]">
+              Transport
+            </Label>
+            <Select
+              value={form.transport}
+              onValueChange={(v) => set({ transport: v as McpTransport })}
+            >
+              <SelectTrigger id="mcp-transport">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="http">HTTP (streamable)</SelectItem>
+                <SelectItem value="sse">SSE</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="mcp-url" className="text-[12px]">
+            Endpoint URL
+          </Label>
+          <Input
+            id="mcp-url"
+            type="url"
+            value={form.url}
+            placeholder="https://…/mcp"
+            onChange={(e) => set({ url: e.target.value })}
+          />
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="mcp-auth" className="text-[12px]">
+              Authentication
+            </Label>
+            <Select
+              value={form.authKind}
+              onValueChange={(v) => set({ authKind: v as McpAuthKind })}
+            >
+              <SelectTrigger id="mcp-auth">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">None</SelectItem>
+                <SelectItem value="bearer">Bearer token</SelectItem>
+                <SelectItem value="header">Custom header</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          {needsHeaderName && (
+            <div className="space-y-1.5">
+              <Label htmlFor="mcp-header" className="text-[12px]">
+                Header name
+              </Label>
+              <Input
+                id="mcp-header"
+                value={form.authHeaderName ?? ''}
+                placeholder="Authorization"
+                onChange={(e) => set({ authHeaderName: e.target.value })}
+              />
+            </div>
+          )}
+        </div>
+
+        {needsSecret && (
+          <div className="space-y-1.5">
+            <Label htmlFor="mcp-secret" className="text-[12px]">
+              {form.authKind === 'bearer' ? 'Bearer token' : 'Header value'}
+            </Label>
+            <Input
+              id="mcp-secret"
+              type="password"
+              autoComplete="off"
+              value={form.authSecret ?? ''}
+              placeholder="Stored encrypted; never shown again"
+              onChange={(e) => set({ authSecret: e.target.value })}
+            />
+          </div>
+        )}
+
+        {/* Test result */}
+        {testResult?.status === 'connected' && (
+          <Alert className="border-emerald-500/40">
+            <CheckCircle2Icon className="size-4 text-emerald-600 dark:text-emerald-400" />
+            <AlertDescription>
+              Connected — {testResult.toolCount} tool
+              {testResult.toolCount === 1 ? '' : 's'} advertised
+              {testResult.tools.length > 0 && (
+                <span className="text-muted-foreground">
+                  {' '}
+                  ({testResult.tools.slice(0, 6).join(', ')}
+                  {testResult.tools.length > 6 ? '…' : ''})
+                </span>
+              )}
+            </AlertDescription>
+          </Alert>
+        )}
+        {(testResult?.status === 'error' || testError) && (
+          <Alert variant="destructive">
+            <XCircleIcon className="size-4" />
+            <AlertDescription>
+              {testError ?? testResult?.error ?? 'Could not connect'}
+            </AlertDescription>
+          </Alert>
+        )}
+        {create.error && (
+          <Alert variant="destructive">
+            <XCircleIcon className="size-4" />
+            <AlertDescription>
+              {create.error instanceof Error
+                ? create.error.message
+                : 'Failed to save server'}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <div className="flex items-center gap-2 pt-1">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5"
+            disabled={!form.url.trim() || testing}
+            onClick={runTest}
+          >
+            {testing ? (
+              <Loader2Icon className="size-3.5 animate-spin" />
+            ) : (
+              <PlugZapIcon className="size-3.5" />
+            )}
+            Test connection
+          </Button>
+          <div className="flex-1" />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8"
+            onClick={onClose}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            className="h-8"
+            disabled={!canSubmit || create.isPending}
+            onClick={submit}
+          >
+            {create.isPending && (
+              <Loader2Icon className="mr-1 size-3.5 animate-spin" />
+            )}
+            Save server
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+
+export function McpServerManager() {
+  const { servers, isLoading, error, notEnabled } = useMcpRegistryServers()
+  const [showAdd, setShowAdd] = useState(false)
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-16 w-full rounded-xl" />
+        <Skeleton className="h-16 w-full rounded-xl" />
+      </div>
+    )
+  }
+
+  if (notEnabled) {
+    return (
+      <EmptyState
+        variant="no-data"
+        icon={<ServerIcon className="size-6" strokeWidth={1.5} />}
+        title="MCP registry not enabled"
+        description="Registering external MCP servers per user requires the hosted (cloud) deployment with a signed-in account. On self-hosted, add custom servers from the agent's MCP panel instead."
+      />
+    )
+  }
+
+  if (error) {
+    return (
+      <EmptyState
+        variant="error"
+        title="Couldn’t load your MCP servers"
+        description={error.message}
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-muted-foreground text-[13px]">
+          {servers.length === 0
+            ? 'No servers registered yet.'
+            : `${servers.length} server${servers.length === 1 ? '' : 's'} · loaded with the agent’s built-in tools`}
+        </p>
+        {!showAdd && (
+          <Button
+            type="button"
+            size="sm"
+            className="h-8 gap-1.5"
+            onClick={() => setShowAdd(true)}
+          >
+            <PlusIcon className="size-3.5" />
+            Add server
+          </Button>
+        )}
+      </div>
+
+      {showAdd && <AddServerForm onClose={() => setShowAdd(false)} />}
+
+      {servers.length > 0 && (
+        <Card
+          className={cn('overflow-hidden rounded-xl border bg-card shadow-sm')}
+        >
+          <div className="divide-border divide-y">
+            {servers.map((server) => (
+              <ServerRow key={server.id} server={server} />
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {servers.length === 0 && !showAdd && (
+        <EmptyState
+          variant="no-data"
+          icon={<ServerIcon className="size-6" strokeWidth={1.5} />}
+          title="Register your first MCP server"
+          description="Connect an external Model Context Protocol server (Slack, GitHub, Datadog, or any HTTP/SSE endpoint). Its tools become available to the agent."
+          action={{
+            label: 'Add server',
+            onClick: () => setShowAdd(true),
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard/src/db/conversations-migrations/0015_mcp_server_registrations.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0015_mcp_server_registrations.sql
@@ -1,0 +1,39 @@
+-- Per-user external MCP server registrations (plan 43). Lets a signed-in user
+-- register external Model Context Protocol servers (URL + transport + optional
+-- auth) that are loaded alongside the built-in agent tools at conversation
+-- start. See lib/ai/agent/mcp/registration-store.ts and
+-- plans/43-mcp-custom-server-registry.md.
+--
+-- The store also creates this table lazily (`CREATE TABLE IF NOT EXISTS`) on
+-- first use, mirroring the weekly-report / insights D1 store pattern — this
+-- migration just gives the deployed CHM_CLOUD_D1 schema an explicit, tracked
+-- record. Both are safe together: IF NOT EXISTS is idempotent, and the store's
+-- DDL string is kept byte-for-byte in sync with this file.
+--
+-- Every row is scoped to user_id (the mandatory isolation key); reads and
+-- writes always filter `WHERE user_id = ?`. `auth_secret` holds the bearer
+-- token / header value ENCRYPTED at rest (AES-256-GCM, see registry-crypto.ts)
+-- — never a plaintext credential.
+--
+-- NOTE: numbered 0015 to sit above the highest migration checked in at the time
+-- this was written (0014_weekly_reports.sql). Wrangler applies migrations in
+-- filename order, not by the numeric prefix alone.
+
+CREATE TABLE IF NOT EXISTS mcp_server_registrations (
+  id                 TEXT PRIMARY KEY,             -- uuid / crypto.randomUUID()
+  user_id            TEXT NOT NULL,                -- Clerk user id (or 'guest' self-hosted); isolation key
+  name               TEXT NOT NULL,                -- display name; sanitised into the tool-key prefix
+  url                TEXT NOT NULL,                -- MCP endpoint URL (SSRF-guarded before every connect)
+  transport          TEXT NOT NULL DEFAULT 'http', -- 'http' | 'sse'
+  auth_kind          TEXT NOT NULL DEFAULT 'none', -- 'none' | 'bearer' | 'header'
+  auth_secret        TEXT,                         -- ENCRYPTED bearer token / header value (never plaintext); null for 'none'
+  auth_header_name   TEXT,                         -- custom header name when auth_kind = 'header'
+  enabled            INTEGER NOT NULL DEFAULT 1,   -- 1 = loaded at conversation start, 0 = registered but off
+  capabilities_json  TEXT,                         -- cached tool list from the last successful validate (JSON string)
+  last_validated_at  INTEGER,                      -- unix epoch ms of the last successful validate
+  created_at         INTEGER NOT NULL,
+  updated_at         INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_server_registrations_user_id
+  ON mcp_server_registrations (user_id);

--- a/apps/dashboard/src/lib/ai/agent/mcp/__tests__/connect-custom-servers.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/mcp/__tests__/connect-custom-servers.test.ts
@@ -1,10 +1,23 @@
 /**
- * Unit tests for the SSRF guard and name sanitiser in connect-custom-servers.
- * Network calls (createMCPClient) are not mocked — only pure functions are tested.
+ * Unit tests for connect-custom-servers.
+ *
+ * The SSRF guard + name sanitiser are tested as pure functions. The connect /
+ * validate / merge lifecycle is exercised through an INJECTED client factory
+ * (never the real `createMCPClient`), so no network call is made and the
+ * close-always / failure-isolation invariants can be asserted deterministically.
  */
 
-import { isAllowedMcpUrl, sanitizeServerName } from '../connect-custom-servers'
-import { describe, expect, test } from 'bun:test'
+import type { McpClientFactory } from '../connect-custom-servers'
+
+import {
+  connectCustomMcpServers,
+  isAllowedMcpUrl,
+  loadUserRegisteredServers,
+  mergeMcpServers,
+  sanitizeServerName,
+  validateServer,
+} from '../connect-custom-servers'
+import { describe, expect, mock, test } from 'bun:test'
 
 // ---------------------------------------------------------------------------
 // isAllowedMcpUrl
@@ -237,5 +250,175 @@ describe('sanitizeServerName', () => {
   test('returns "server" for empty or symbols-only input', () => {
     expect(sanitizeServerName('')).toBe('server')
     expect(sanitizeServerName('---')).toBe('server')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateServer — SSRF pre-check + close-always
+// ---------------------------------------------------------------------------
+
+const PUBLIC_ENDPOINT = 'https://mcp.example.com/mcp'
+
+describe('validateServer', () => {
+  test('rejects a private-host URL without opening a client', async () => {
+    const createClient = mock<McpClientFactory>(async () => ({
+      tools: async () => ({}),
+      close: async () => {},
+    }))
+    const res = await validateServer(
+      { id: '1', name: 'evil', endpoint: 'https://rebind.internal.test/mcp' },
+      { createClient, resolveHostAddresses: stubDns }
+    )
+    expect(res.ok).toBe(false)
+    expect(createClient).not.toHaveBeenCalled()
+  })
+
+  test('returns the advertised tool names and closes on success', async () => {
+    const close = mock(async () => {})
+    const createClient: McpClientFactory = async () => ({
+      tools: async () => ({ search: {}, fetch: {} }),
+      close,
+    })
+    const res = await validateServer(
+      { id: '1', name: 'ok', endpoint: PUBLIC_ENDPOINT },
+      { createClient, resolveHostAddresses: stubDns }
+    )
+    expect(res.ok).toBe(true)
+    expect(res.tools).toEqual(['search', 'fetch'])
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  test('closes the client even when tools() throws', async () => {
+    const close = mock(async () => {})
+    const createClient: McpClientFactory = async () => ({
+      tools: async () => {
+        throw new Error('listing failed: boom')
+      },
+      close,
+    })
+    const res = await validateServer(
+      { id: '1', name: 'flaky', endpoint: PUBLIC_ENDPOINT },
+      { createClient, resolveHostAddresses: stubDns }
+    )
+    expect(res.ok).toBe(false)
+    expect(res.error).toContain('boom')
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// connectCustomMcpServers — per-server isolation + SSRF
+// ---------------------------------------------------------------------------
+
+describe('connectCustomMcpServers', () => {
+  test('isolates a failing server; the others still return prefixed tools', async () => {
+    const closeGood = mock(async () => {})
+    const createClient: McpClientFactory = async ({ serverName }) => {
+      if (serverName === 'bad') {
+        return {
+          tools: async () => {
+            throw new Error('nope')
+          },
+          close: async () => {},
+        }
+      }
+      return { tools: async () => ({ ping: {} }), close: closeGood }
+    }
+
+    const result = await connectCustomMcpServers(
+      [
+        { id: 'g', name: 'good', endpoint: PUBLIC_ENDPOINT },
+        { id: 'b', name: 'bad', endpoint: 'https://api.acme.io/mcp' },
+      ],
+      { createClient, resolveHostAddresses: stubDns }
+    )
+
+    expect(Object.keys(result.tools)).toEqual(['mcp_good_ping'])
+    const statusById = Object.fromEntries(
+      result.statuses.map((s) => [s.id, s.status])
+    )
+    expect(statusById).toEqual({ g: 'connected', b: 'error' })
+
+    await result.closeAll()
+    expect(closeGood).toHaveBeenCalledTimes(1)
+  })
+
+  test('rejects a private-host server before connecting', async () => {
+    const createClient = mock<McpClientFactory>(async () => ({
+      tools: async () => ({}),
+      close: async () => {},
+    }))
+    const result = await connectCustomMcpServers(
+      [
+        {
+          id: 'x',
+          name: 'evil',
+          endpoint: 'https://metadata.internal.test/mcp',
+        },
+      ],
+      { createClient, resolveHostAddresses: stubDns }
+    )
+    expect(result.statuses[0]?.status).toBe('error')
+    expect(createClient).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// mergeMcpServers — dedupe across body + registry sources
+// ---------------------------------------------------------------------------
+
+describe('mergeMcpServers', () => {
+  test('de-duplicates by normalized endpoint, earlier lists win', () => {
+    const body = [
+      { id: 'a', name: 'body', endpoint: 'https://mcp.example.com/mcp/' },
+    ]
+    const registered = [
+      { id: 'b', name: 'reg', endpoint: 'https://MCP.example.com/mcp' },
+      { id: 'c', name: 'other', endpoint: 'https://api.acme.io/mcp' },
+    ]
+    const merged = mergeMcpServers(body, registered)
+    expect(merged.map((s) => s.id)).toEqual(['a', 'c'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadUserRegisteredServers — store mapping + best-effort
+// ---------------------------------------------------------------------------
+
+describe('loadUserRegisteredServers', () => {
+  test('maps a user’s enabled registrations into connect inputs', async () => {
+    const store = {
+      listEnabledConnectInputs: async (userId: string) => {
+        expect(userId).toBe('user-a')
+        return [
+          {
+            id: '1',
+            name: 'slack',
+            url: 'https://slack.example.com/mcp',
+            transport: 'http' as const,
+            auth: { kind: 'bearer' as const, token: 'tok' },
+          },
+        ]
+      },
+    }
+    const servers = await loadUserRegisteredServers('user-a', { store })
+    expect(servers).toEqual([
+      {
+        id: '1',
+        name: 'slack',
+        endpoint: 'https://slack.example.com/mcp',
+        transport: 'http',
+        auth: { kind: 'bearer', token: 'tok' },
+      },
+    ])
+  })
+
+  test('returns [] when the store throws (best-effort / OSS no D1)', async () => {
+    const store = {
+      listEnabledConnectInputs: async () => {
+        throw new Error('no D1 binding')
+      },
+    }
+    expect(await loadUserRegisteredServers('u', { store })).toEqual([])
   })
 })

--- a/apps/dashboard/src/lib/ai/agent/mcp/__tests__/registration-store.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/mcp/__tests__/registration-store.test.ts
@@ -11,8 +11,7 @@
  */
 
 import { Database } from 'bun:sqlite'
-import { beforeEach, describe, expect, test } from 'bun:test'
-import { mock } from 'bun:test'
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
 
 // One shared in-memory DB for the process: the store's lazy `CREATE TABLE IF
 // NOT EXISTS` migration is single-flight (cached per process), so a fresh DB

--- a/apps/dashboard/src/lib/ai/agent/mcp/__tests__/registration-store.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/mcp/__tests__/registration-store.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Proves the MCP registration store enforces per-user isolation and the
+ * ownership guard, and round-trips encrypted auth secrets.
+ *
+ * The store's SQL runs against `bun:sqlite` (D1's underlying engine) through a
+ * tiny D1-shaped shim, so the real `WHERE user_id = ?` scoping, the
+ * `ON CONFLICT ... WHERE user_id = excluded.user_id` guard, and the
+ * `changes === 0/1` semantics the `written`/`deleted` flags depend on are
+ * actually executed rather than re-derived. Mirrors
+ * `conversation-store/d1-store.sql.test.ts`.
+ */
+
+import { Database } from 'bun:sqlite'
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { mock } from 'bun:test'
+
+// One shared in-memory DB for the process: the store's lazy `CREATE TABLE IF
+// NOT EXISTS` migration is single-flight (cached per process), so a fresh DB
+// per test would not get re-migrated. We create the table up front and clear
+// rows between tests instead.
+const db = new Database(':memory:')
+db.run(`CREATE TABLE mcp_server_registrations (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  url TEXT NOT NULL,
+  transport TEXT NOT NULL DEFAULT 'http',
+  auth_kind TEXT NOT NULL DEFAULT 'none',
+  auth_secret TEXT,
+  auth_header_name TEXT,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  capabilities_json TEXT,
+  last_validated_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+)`)
+
+/** Minimal D1Database shim over bun:sqlite (prepare/bind/run/all/first). */
+function makeD1(): D1Database {
+  return {
+    prepare(sql: string) {
+      let params: unknown[] = []
+      const stmt = {
+        bind(...args: unknown[]) {
+          params = args
+          return stmt
+        },
+        run() {
+          const res = db.query(sql).run(...(params as never[]))
+          return Promise.resolve({ meta: { changes: res.changes } })
+        },
+        all<T>() {
+          return Promise.resolve({
+            results: db.query(sql).all(...(params as never[])) as T[],
+          })
+        },
+        first<T>() {
+          return Promise.resolve(
+            (db.query(sql).get(...(params as never[])) ?? null) as T | null
+          )
+        },
+      }
+      return stmt
+    },
+  } as unknown as D1Database
+}
+
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({ getD1Database: () => makeD1() }),
+}))
+
+// A dedicated encryption key so the secret round-trip test needs no Clerk env
+// (32 zero-bytes, base64). Set before importing the store/crypto.
+process.env.CHM_USER_CONNECTIONS_ENCRYPTION_KEY = btoa(
+  String.fromCharCode(...new Uint8Array(32))
+)
+
+const { McpRegistrationStore, D1_UPSERT_MCP_REGISTRATION_SQL } = await import(
+  '../registration-store'
+)
+
+const store = new McpRegistrationStore()
+
+function baseReg(over: Record<string, unknown> = {}) {
+  return {
+    id: 'r1',
+    userId: 'user-a',
+    name: 'server',
+    url: 'https://mcp.example.com/mcp',
+    transport: 'http' as const,
+    authKind: 'none' as const,
+    enabled: true,
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  db.run('DELETE FROM mcp_server_registrations')
+})
+
+describe('per-user isolation', () => {
+  test('user B cannot read user A’s registration', async () => {
+    await store.upsert(baseReg())
+    expect(await store.get('user-a', 'r1')).not.toBeNull()
+    expect(await store.get('user-b', 'r1')).toBeNull()
+    expect(await store.listForUser('user-b')).toEqual([])
+    expect((await store.listForUser('user-a')).map((r) => r.id)).toEqual(['r1'])
+  })
+
+  test('user B cannot delete user A’s registration', async () => {
+    await store.upsert(baseReg())
+    expect(await store.remove('user-b', 'r1')).toEqual({ deleted: false })
+    expect(await store.get('user-a', 'r1')).not.toBeNull()
+    expect(await store.remove('user-a', 'r1')).toEqual({ deleted: true })
+    expect(await store.get('user-a', 'r1')).toBeNull()
+  })
+
+  test('user B cannot rename/disable user A’s registration', async () => {
+    await store.upsert(baseReg({ name: 'orig' }))
+    expect(await store.patch('user-b', 'r1', { name: 'hijacked' })).toEqual({
+      updated: false,
+    })
+    const row = await store.get('user-a', 'r1')
+    expect(row?.name).toBe('orig')
+    expect(row?.enabled).toBe(true)
+  })
+})
+
+describe('owner-guarded upsert', () => {
+  test('returns { written: false } for a foreign id and leaves the row intact', async () => {
+    await store.upsert(baseReg({ name: 'orig' }))
+    const res = await store.upsert(
+      baseReg({ userId: 'user-b', name: 'hijacked' })
+    )
+    expect(res).toEqual({ written: false })
+    const row = await store.get('user-a', 'r1')
+    expect(row?.userId).toBe('user-a')
+    expect(row?.name).toBe('orig')
+  })
+
+  test('the owner can update; { written: true }', async () => {
+    await store.upsert(baseReg({ name: 'orig' }))
+    expect(await store.upsert(baseReg({ name: 'renamed' }))).toEqual({
+      written: true,
+    })
+    expect((await store.get('user-a', 'r1'))?.name).toBe('renamed')
+  })
+
+  test('a new id inserts; { written: true }', async () => {
+    expect(await store.upsert(baseReg({ id: 'r2' }))).toEqual({ written: true })
+  })
+
+  // The exact production SQL string, run raw — mirrors d1-store.sql.test.ts.
+  test('raw upsert SQL blocks a foreign owner (changes === 0)', () => {
+    db.run(
+      `INSERT INTO mcp_server_registrations
+       (id, user_id, name, url, transport, auth_kind, enabled, created_at, updated_at)
+       VALUES ('r1','user-a','orig','https://x/mcp','http','none',1,1,1)`
+    )
+    const res = db
+      .query(D1_UPSERT_MCP_REGISTRATION_SQL)
+      .run(
+        'r1',
+        'user-b',
+        'hijacked',
+        'https://y/mcp',
+        'http',
+        'none',
+        null,
+        null,
+        1,
+        null,
+        null,
+        2,
+        2
+      )
+    expect(res.changes).toBe(0)
+    const row = db
+      .query(`SELECT user_id, name FROM mcp_server_registrations WHERE id='r1'`)
+      .get() as { user_id: string; name: string }
+    expect(row.user_id).toBe('user-a')
+    expect(row.name).toBe('orig')
+  })
+})
+
+describe('secret hygiene + connect inputs', () => {
+  test('encrypts the token at rest; metadata omits it; loader decrypts it', async () => {
+    await store.upsert(
+      baseReg({ authKind: 'bearer', authSecret: 'super-secret-token' })
+    )
+
+    // Stored ciphertext is not the plaintext.
+    const raw = db
+      .query(`SELECT auth_secret FROM mcp_server_registrations WHERE id='r1'`)
+      .get() as { auth_secret: string }
+    expect(raw.auth_secret).not.toContain('super-secret-token')
+
+    // Metadata projection never carries the secret, only hasSecret.
+    const meta = await store.get('user-a', 'r1')
+    expect(meta?.hasSecret).toBe(true)
+    expect(JSON.stringify(meta)).not.toContain('super-secret-token')
+
+    // Loader decrypts for outbound use.
+    const inputs = await store.listEnabledConnectInputs('user-a')
+    expect(inputs).toEqual([
+      {
+        id: 'r1',
+        name: 'server',
+        url: 'https://mcp.example.com/mcp',
+        transport: 'http',
+        auth: { kind: 'bearer', token: 'super-secret-token' },
+      },
+    ])
+  })
+
+  test('disabled registrations are excluded from connect inputs', async () => {
+    await store.upsert(baseReg({ id: 'on', enabled: true }))
+    await store.upsert(baseReg({ id: 'off', enabled: false }))
+    const inputs = await store.listEnabledConnectInputs('user-a')
+    expect(inputs.map((i) => i.id)).toEqual(['on'])
+  })
+})

--- a/apps/dashboard/src/lib/ai/agent/mcp/connect-custom-servers.ts
+++ b/apps/dashboard/src/lib/ai/agent/mcp/connect-custom-servers.ts
@@ -14,12 +14,6 @@
  * permitted on loopback hosts (dev convenience).
  */
 
-import { createMCPClient } from '@ai-sdk/mcp'
-import {
-  createHostValidationFetch,
-  type ResolveHostAddresses,
-  validateHostUrl,
-} from '@/lib/browser-connections/host-url'
 import {
   type McpAuth,
   type McpConnectInput,
@@ -27,6 +21,12 @@ import {
   type McpTransport,
   mcpRegistrationStore,
 } from './registration-store'
+import { createMCPClient } from '@ai-sdk/mcp'
+import {
+  createHostValidationFetch,
+  type ResolveHostAddresses,
+  validateHostUrl,
+} from '@/lib/browser-connections/host-url'
 
 export interface CustomMcpServerInput {
   id: string

--- a/apps/dashboard/src/lib/ai/agent/mcp/connect-custom-servers.ts
+++ b/apps/dashboard/src/lib/ai/agent/mcp/connect-custom-servers.ts
@@ -16,14 +16,26 @@
 
 import { createMCPClient } from '@ai-sdk/mcp'
 import {
+  createHostValidationFetch,
   type ResolveHostAddresses,
   validateHostUrl,
 } from '@/lib/browser-connections/host-url'
+import {
+  type McpAuth,
+  type McpConnectInput,
+  type McpRegistrationStore,
+  type McpTransport,
+  mcpRegistrationStore,
+} from './registration-store'
 
 export interface CustomMcpServerInput {
   id: string
   name: string
   endpoint: string
+  /** Transport to open the client over. Defaults to 'http'. */
+  transport?: McpTransport
+  /** Structured auth; defaults to no auth. */
+  auth?: McpAuth
 }
 
 export interface McpConnectionResult {
@@ -35,6 +47,31 @@ export interface McpConnectionResult {
     toolCount: number
     error?: string
   }>
+}
+
+/** Minimal MCP client surface used here (subset of the AI SDK client). */
+interface McpClientLike {
+  tools: () => Promise<Record<string, unknown>>
+  close: () => Promise<void>
+}
+
+/**
+ * Factory for opening an MCP client. Injected in tests so the connect/close
+ * lifecycle (and failure paths) can be driven without a live network call —
+ * the default builds a real, SSRF-pinned AI SDK client (see
+ * {@link defaultCreateMcpClient}).
+ */
+export type McpClientFactory = (args: {
+  url: string
+  transport: McpTransport
+  headers?: Record<string, string>
+  serverName: string
+}) => Promise<McpClientLike>
+
+/** Options accepted across the connect helpers (test seams). */
+export interface ConnectOptions {
+  createClient?: McpClientFactory
+  resolveHostAddresses?: ResolveHostAddresses
 }
 
 /** Maximum number of custom servers to connect per request. */
@@ -188,8 +225,10 @@ export function sanitizeServerName(name: string): string {
  * Per-server failures are isolated — one bad server does not affect others.
  */
 export async function connectCustomMcpServers(
-  servers: CustomMcpServerInput[]
+  servers: CustomMcpServerInput[],
+  opts?: ConnectOptions
 ): Promise<McpConnectionResult> {
+  const createClient = opts?.createClient ?? defaultCreateMcpClient
   const clients: Array<{ close: () => Promise<void> }> = []
   const allTools: Record<string, unknown> = {}
   const statuses: McpConnectionResult['statuses'] = []
@@ -197,7 +236,7 @@ export async function connectCustomMcpServers(
   const toConnect = servers.slice(0, MAX_SERVERS)
 
   for (const server of toConnect) {
-    if (!(await isAllowedMcpUrl(server.endpoint))) {
+    if (!(await isAllowedMcpUrl(server.endpoint, opts?.resolveHostAddresses))) {
       statuses.push({
         id: server.id,
         status: 'error',
@@ -209,10 +248,7 @@ export async function connectCustomMcpServers(
     }
 
     try {
-      const { client, tools } = await connectWithTimeout(
-        server.endpoint,
-        server.name
-      )
+      const { client, tools } = await connectWithTimeout(server, createClient)
       clients.push(client)
 
       const prefix = `mcp_${sanitizeServerName(server.name)}_`
@@ -254,22 +290,159 @@ export async function connectCustomMcpServers(
 }
 
 // ---------------------------------------------------------------------------
+// Validate (test-before-save) + per-user loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Test-connect to a single MCP endpoint WITHOUT persisting: SSRF-guard the URL,
+ * open the (SSRF-pinned) client, list its advertised tools, and ALWAYS close
+ * the client — on success AND on throw (the BUG-03 close-always invariant).
+ * Returns the real advertised tool names on success, or a reason on failure.
+ */
+export async function validateServer(
+  input: CustomMcpServerInput,
+  opts?: ConnectOptions
+): Promise<{ ok: boolean; tools?: string[]; error?: string }> {
+  if (!(await isAllowedMcpUrl(input.endpoint, opts?.resolveHostAddresses))) {
+    return {
+      ok: false,
+      error:
+        'Endpoint URL not allowed (use https:, or http:// for localhost only)',
+    }
+  }
+
+  const createClient = opts?.createClient ?? defaultCreateMcpClient
+  let client: McpClientLike | null = null
+  try {
+    const result = await connectWithTimeout(input, createClient)
+    client = result.client
+    return { ok: true, tools: Object.keys(result.tools) }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    return { ok: false, error: msg.slice(0, 200) }
+  } finally {
+    // Close whether tools() succeeded or the connect threw after opening.
+    if (client) await client.close().catch(() => {})
+  }
+}
+
+/**
+ * Resolve a user's ENABLED, D1-persisted registrations into connect inputs
+ * (decrypted server-side). Best-effort: any failure (no D1 binding on
+ * self-hosted, decrypt error) resolves to `[]` so the conversation still runs
+ * with built-in tools — never throws into the agent request.
+ */
+export async function loadUserRegisteredServers(
+  userId: string,
+  opts?: { store?: Pick<McpRegistrationStore, 'listEnabledConnectInputs'> }
+): Promise<CustomMcpServerInput[]> {
+  try {
+    const store = opts?.store ?? mcpRegistrationStore
+    const inputs = await store.listEnabledConnectInputs(userId)
+    return inputs.map(connectInputToCustomServer)
+  } catch (e) {
+    console.error('[mcp-registry] loadUserRegisteredServers failed:', e)
+    return []
+  }
+}
+
+function connectInputToCustomServer(
+  input: McpConnectInput
+): CustomMcpServerInput {
+  return {
+    id: input.id,
+    name: input.name,
+    endpoint: input.url,
+    transport: input.transport,
+    auth: input.auth,
+  }
+}
+
+/**
+ * Merge multiple custom-server lists into one, de-duplicated by normalized
+ * endpoint (earlier lists win). Prevents connecting the same endpoint twice —
+ * and blowing past the per-call cap / colliding tool keys — when a user's
+ * request carries both request-body servers and their D1 registrations.
+ */
+export function mergeMcpServers(
+  ...lists: CustomMcpServerInput[][]
+): CustomMcpServerInput[] {
+  const seen = new Set<string>()
+  const merged: CustomMcpServerInput[] = []
+  for (const list of lists) {
+    for (const server of list) {
+      const key = normalizeEndpoint(server.endpoint)
+      if (seen.has(key)) continue
+      seen.add(key)
+      merged.push(server)
+    }
+  }
+  return merged
+}
+
+function normalizeEndpoint(endpoint: string): string {
+  const trimmed = endpoint.trim().toLowerCase()
+  return trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed
+}
+
+// ---------------------------------------------------------------------------
 // Internals
 // ---------------------------------------------------------------------------
 
 /**
+ * Build outbound auth headers from a registration's structured auth. Returns
+ * undefined for no auth so the transport sends none.
+ */
+function buildAuthHeaders(auth?: McpAuth): Record<string, string> | undefined {
+  if (!auth || auth.kind === 'none') return undefined
+  if (auth.kind === 'bearer') return { Authorization: `Bearer ${auth.token}` }
+  return { [auth.headerName]: auth.value }
+}
+
+/**
+ * Default MCP client factory: opens a real AI SDK client over the requested
+ * transport, PINNED behind the shared host-validation fetch. This closes SEC-04
+ * — the actual outbound connection is validated the same way the pre-check is,
+ * defeating the DNS-rebind TOCTOU (identical posture to `connection-client.ts`
+ * for user-supplied ClickHouse hosts: pins on Node, IP-literal-only on Workers).
+ */
+const defaultCreateMcpClient: McpClientFactory = async ({
+  url,
+  transport,
+  headers,
+  serverName,
+}) => {
+  const client = await createMCPClient({
+    transport: {
+      type: transport,
+      url,
+      ...(headers ? { headers } : {}),
+      fetch: createHostValidationFetch(),
+    },
+    onUncaughtError: (e) => {
+      console.error(`[MCP] Uncaught error from "${serverName}":`, e)
+    },
+  })
+  return {
+    tools: () => client.tools() as Promise<Record<string, unknown>>,
+    close: () => client.close(),
+  }
+}
+
+/**
  * Connect to an MCP endpoint and fetch its tools, with a hard timeout.
- * Cleans up the client if the timeout fires before connect completes.
+ * Cleans up the client if the timeout fires OR if tools() throws after the
+ * client opened, so a failed listing never leaks an open connection.
  */
 async function connectWithTimeout(
-  endpoint: string,
-  serverName: string
+  server: CustomMcpServerInput,
+  createClient: McpClientFactory
 ): Promise<{
-  client: { close: () => Promise<void> }
+  client: McpClientLike
   tools: Record<string, unknown>
 }> {
   let settled = false
-  let resolvedClient: { close: () => Promise<void> } | null = null
+  let resolvedClient: McpClientLike | null = null
 
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
@@ -284,11 +457,11 @@ async function connectWithTimeout(
 
     ;(async () => {
       try {
-        const client = await createMCPClient({
-          transport: { type: 'http', url: endpoint },
-          onUncaughtError: (e) => {
-            console.error(`[MCP] Uncaught error from "${serverName}":`, e)
-          },
+        const client = await createClient({
+          url: server.endpoint,
+          transport: server.transport ?? 'http',
+          headers: buildAuthHeaders(server.auth),
+          serverName: server.name,
         })
         resolvedClient = client
         const tools = await client.tools()
@@ -306,6 +479,11 @@ async function connectWithTimeout(
         if (settled) return
         settled = true
         clearTimeout(timer)
+        // If the client opened but tools() threw, close it before rejecting so
+        // a failed listing never leaks an open connection (BUG-03 class).
+        if (resolvedClient) {
+          resolvedClient.close().catch(() => {})
+        }
         reject(e)
       }
     })()

--- a/apps/dashboard/src/lib/ai/agent/mcp/connect-custom-servers.ts
+++ b/apps/dashboard/src/lib/ai/agent/mcp/connect-custom-servers.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  isMcpRegistryEnabled,
   type McpAuth,
   type McpConnectInput,
   type McpRegistrationStore,
@@ -336,6 +337,10 @@ export async function loadUserRegisteredServers(
   userId: string,
   opts?: { store?: Pick<McpRegistrationStore, 'listEnabledConnectInputs'> }
 ): Promise<CustomMcpServerInput[]> {
+  // Self-hosted/OSS without a D1 binding has no registry — skip silently. A
+  // missing registry is a normal condition, not an error worth logging on every
+  // agent conversation. Tests inject a store, so they bypass this gate.
+  if (!opts?.store && !isMcpRegistryEnabled()) return []
   try {
     const store = opts?.store ?? mcpRegistrationStore
     const inputs = await store.listEnabledConnectInputs(userId)

--- a/apps/dashboard/src/lib/ai/agent/mcp/registration-store.ts
+++ b/apps/dashboard/src/lib/ai/agent/mcp/registration-store.ts
@@ -84,8 +84,10 @@ export interface McpConnectInput {
 
 const TABLE = 'mcp_server_registrations'
 
-// Kept byte-for-byte in sync with
-// db/conversations-migrations/0015_mcp_server_registrations.sql.
+// Kept in sync with db/conversations-migrations/0015_mcp_server_registrations.sql
+// — identical columns / types / defaults (that file adds explanatory column
+// comments). `IF NOT EXISTS` makes the tracked migration and this lazy DDL
+// idempotent together.
 const MIGRATION_SQL = `CREATE TABLE IF NOT EXISTS ${TABLE} (
   id                 TEXT PRIMARY KEY,
   user_id            TEXT NOT NULL,

--- a/apps/dashboard/src/lib/ai/agent/mcp/registration-store.ts
+++ b/apps/dashboard/src/lib/ai/agent/mcp/registration-store.ts
@@ -21,12 +21,12 @@
  * (`db/conversations-migrations/0015_mcp_server_registrations.sql`) is applied.
  */
 
-import { getPlatformBindings } from '@chm/platform'
 import {
   decryptRegistrySecret,
   encryptRegistrySecret,
   isRegistryEncryptionConfigured,
 } from './registry-crypto'
+import { getPlatformBindings } from '@chm/platform'
 
 export type McpTransport = 'http' | 'sse'
 export type McpAuthKind = 'none' | 'bearer' | 'header'

--- a/apps/dashboard/src/lib/ai/agent/mcp/registration-store.ts
+++ b/apps/dashboard/src/lib/ai/agent/mcp/registration-store.ts
@@ -1,0 +1,424 @@
+/**
+ * D1-backed store for per-user external MCP server registrations (plan 43).
+ *
+ * Isolation: EVERY read and write is scoped `WHERE user_id = ?` — one user's
+ * servers and credentials are never visible to another. The owner-guarded
+ * upsert (mirroring `conversation-store/d1-store.ts` and plan 04) refuses to
+ * reassign a row owned by a different user.
+ *
+ * Secret hygiene: `auth_secret` is stored ENCRYPTED at rest (see
+ * `registry-crypto.ts`). The metadata projections (`listForUser` / `get`) NEVER
+ * include the secret — only `authKind` / `authHeaderName` / `hasSecret`. The
+ * plaintext token is decrypted in exactly one place — `listEnabledConnectInputs`
+ * — which runs server-side to build outbound auth headers and is never returned
+ * to a client.
+ *
+ * Best-effort like the other insights/cloud D1 stores: a missing `CHM_CLOUD_D1`
+ * binding (the OSS/self-hosted default) resolves to empty/`false` rather than
+ * throwing, so a deployment with no D1 simply has no registered servers and the
+ * agent runs with built-ins only. The table is created lazily on first use so
+ * persistence works even before the checked-in migration
+ * (`db/conversations-migrations/0015_mcp_server_registrations.sql`) is applied.
+ */
+
+import { getPlatformBindings } from '@chm/platform'
+import {
+  decryptRegistrySecret,
+  encryptRegistrySecret,
+  isRegistryEncryptionConfigured,
+} from './registry-crypto'
+
+export type McpTransport = 'http' | 'sse'
+export type McpAuthKind = 'none' | 'bearer' | 'header'
+
+/** Structured auth for an MCP registration (decrypted form). */
+export type McpAuth =
+  | { kind: 'none' }
+  | { kind: 'bearer'; token: string }
+  | { kind: 'header'; headerName: string; value: string }
+
+/** Safe registration metadata — NEVER carries the decrypted secret. */
+export interface McpRegistration {
+  id: string
+  userId: string
+  name: string
+  url: string
+  transport: McpTransport
+  authKind: McpAuthKind
+  authHeaderName: string | null
+  /** True when a secret is stored, so the UI can render state without it. */
+  hasSecret: boolean
+  enabled: boolean
+  /** Parsed cached tool names from the last successful validate (or null). */
+  capabilities: string[] | null
+  lastValidatedAt: number | null
+  createdAt: number
+  updatedAt: number
+}
+
+/** Input for {@link McpRegistrationStore.upsert} (create / full replace). */
+export interface McpRegistrationUpsert {
+  id: string
+  userId: string
+  name: string
+  url: string
+  transport: McpTransport
+  authKind: McpAuthKind
+  /** Plaintext secret; encrypted before write. Omit/undefined for `none`. */
+  authSecret?: string | null
+  authHeaderName?: string | null
+  enabled: boolean
+  /** Cached tool names from a successful validate. */
+  capabilities?: string[] | null
+  lastValidatedAt?: number | null
+}
+
+/** Decrypted connect input consumed by the agent loader. */
+export interface McpConnectInput {
+  id: string
+  name: string
+  url: string
+  transport: McpTransport
+  auth: McpAuth
+}
+
+const TABLE = 'mcp_server_registrations'
+
+// Kept byte-for-byte in sync with
+// db/conversations-migrations/0015_mcp_server_registrations.sql.
+const MIGRATION_SQL = `CREATE TABLE IF NOT EXISTS ${TABLE} (
+  id                 TEXT PRIMARY KEY,
+  user_id            TEXT NOT NULL,
+  name               TEXT NOT NULL,
+  url                TEXT NOT NULL,
+  transport          TEXT NOT NULL DEFAULT 'http',
+  auth_kind          TEXT NOT NULL DEFAULT 'none',
+  auth_secret        TEXT,
+  auth_header_name   TEXT,
+  enabled            INTEGER NOT NULL DEFAULT 1,
+  capabilities_json  TEXT,
+  last_validated_at  INTEGER,
+  created_at         INTEGER NOT NULL,
+  updated_at         INTEGER NOT NULL
+)`
+
+const INDEX_SQL = `CREATE INDEX IF NOT EXISTS idx_${TABLE}_user_id ON ${TABLE} (user_id)`
+
+/**
+ * Owner-guarded upsert. `ON CONFLICT (id) DO UPDATE ... WHERE user_id =
+ * excluded.user_id` leaves a row owned by a different user untouched (0
+ * `changes`) instead of reassigning it — the per-user isolation control.
+ * Exported so a `bun:sqlite` test can prove the guard without re-deriving it.
+ */
+export const D1_UPSERT_MCP_REGISTRATION_SQL = `INSERT INTO ${TABLE}
+   (id, user_id, name, url, transport, auth_kind, auth_secret, auth_header_name, enabled, capabilities_json, last_validated_at, created_at, updated_at)
+   VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+   ON CONFLICT (id) DO UPDATE SET
+     name = excluded.name,
+     url = excluded.url,
+     transport = excluded.transport,
+     auth_kind = excluded.auth_kind,
+     auth_secret = excluded.auth_secret,
+     auth_header_name = excluded.auth_header_name,
+     enabled = excluded.enabled,
+     capabilities_json = excluded.capabilities_json,
+     last_validated_at = excluded.last_validated_at,
+     updated_at = excluded.updated_at
+   WHERE ${TABLE}.user_id = excluded.user_id`
+
+interface D1McpRegistrationRow {
+  id: string
+  user_id: string
+  name: string
+  url: string
+  transport: string
+  auth_kind: string
+  auth_secret: string | null
+  auth_header_name: string | null
+  enabled: number
+  capabilities_json: string | null
+  last_validated_at: number | null
+  created_at: number
+  updated_at: number
+}
+
+function normalizeTransport(value: string): McpTransport {
+  return value === 'sse' ? 'sse' : 'http'
+}
+
+function normalizeAuthKind(value: string): McpAuthKind {
+  return value === 'bearer' || value === 'header' ? value : 'none'
+}
+
+function parseCapabilities(json: string | null): string[] | null {
+  if (!json) return null
+  try {
+    const parsed = JSON.parse(json)
+    return Array.isArray(parsed)
+      ? parsed.filter((t): t is string => typeof t === 'string')
+      : null
+  } catch {
+    return null
+  }
+}
+
+function rowToMeta(row: D1McpRegistrationRow): McpRegistration {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    name: row.name,
+    url: row.url,
+    transport: normalizeTransport(row.transport),
+    authKind: normalizeAuthKind(row.auth_kind),
+    authHeaderName: row.auth_header_name,
+    hasSecret: Boolean(row.auth_secret),
+    enabled: row.enabled === 1,
+    capabilities: parseCapabilities(row.capabilities_json),
+    lastValidatedAt: row.last_validated_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+function getDb(): D1Database | null {
+  try {
+    return getPlatformBindings().getD1Database('CHM_CLOUD_D1')
+  } catch {
+    return null
+  }
+}
+
+// Single-flight lazy migration: concurrent first calls share one promise so the
+// idempotent DDL runs at most once per process; a failure clears it to retry.
+let migration: Promise<void> | null = null
+
+async function ensureMigrated(db: D1Database): Promise<void> {
+  if (!migration) {
+    migration = (async () => {
+      await db.prepare(MIGRATION_SQL).run()
+      await db.prepare(INDEX_SQL).run()
+    })().catch((error) => {
+      migration = null
+      throw error
+    })
+  }
+  return migration
+}
+
+/**
+ * True when per-user MCP registration persistence is usable on this deployment
+ * (a D1 binding is present). OSS/self-hosted without D1 returns false and the
+ * registry API reports "not enabled" rather than crashing.
+ */
+export function isMcpRegistryEnabled(): boolean {
+  return getDb() !== null
+}
+
+export class McpRegistrationStore {
+  private requireDb(): D1Database {
+    const db = getDb()
+    if (!db) {
+      throw new McpRegistryError(
+        'MCP registration storage is not enabled (no CHM_CLOUD_D1 binding).',
+        'NOT_ENABLED'
+      )
+    }
+    return db
+  }
+
+  /** List a user's registrations (metadata only — no secrets). */
+  async listForUser(userId: string): Promise<McpRegistration[]> {
+    const db = this.requireDb()
+    await ensureMigrated(db)
+    const result = await db
+      .prepare(
+        `SELECT id, user_id, name, url, transport, auth_kind, auth_secret, auth_header_name, enabled, capabilities_json, last_validated_at, created_at, updated_at
+         FROM ${TABLE} WHERE user_id = ?1 ORDER BY created_at ASC`
+      )
+      .bind(userId)
+      .all<D1McpRegistrationRow>()
+    return (result.results ?? []).map(rowToMeta)
+  }
+
+  /** Get one registration by id, scoped to the user (metadata only). */
+  async get(userId: string, id: string): Promise<McpRegistration | null> {
+    const db = this.requireDb()
+    await ensureMigrated(db)
+    const row = await db
+      .prepare(
+        `SELECT id, user_id, name, url, transport, auth_kind, auth_secret, auth_header_name, enabled, capabilities_json, last_validated_at, created_at, updated_at
+         FROM ${TABLE} WHERE user_id = ?1 AND id = ?2`
+      )
+      .bind(userId, id)
+      .first<D1McpRegistrationRow>()
+    return row ? rowToMeta(row) : null
+  }
+
+  /**
+   * Create or fully replace a registration (owner-guarded). Encrypts the secret
+   * before write. Returns `written: false` when the id belongs to another user
+   * and the write was blocked by the ownership guard.
+   */
+  async upsert(input: McpRegistrationUpsert): Promise<{ written: boolean }> {
+    const db = this.requireDb()
+    await ensureMigrated(db)
+
+    let encryptedSecret: string | null = null
+    if (input.authKind !== 'none' && input.authSecret) {
+      if (!isRegistryEncryptionConfigured()) {
+        throw new McpRegistryError(
+          'Cannot store an MCP auth secret without encryption configured.',
+          'ENCRYPTION_UNAVAILABLE'
+        )
+      }
+      encryptedSecret = await encryptRegistrySecret(input.authSecret)
+    }
+
+    const now = Date.now()
+    const capabilitiesJson =
+      input.capabilities != null ? JSON.stringify(input.capabilities) : null
+
+    const res = await db
+      .prepare(D1_UPSERT_MCP_REGISTRATION_SQL)
+      .bind(
+        input.id,
+        input.userId,
+        input.name,
+        input.url,
+        input.transport,
+        input.authKind,
+        encryptedSecret,
+        input.authHeaderName ?? null,
+        input.enabled ? 1 : 0,
+        capabilitiesJson,
+        input.lastValidatedAt ?? null,
+        now,
+        now
+      )
+      .run()
+
+    return { written: (res.meta?.changes ?? 0) > 0 }
+  }
+
+  /**
+   * Targeted patch of name/enabled, scoped to the user. Never touches the
+   * secret or URL, so enable/disable/rename can't accidentally clear a token.
+   */
+  async patch(
+    userId: string,
+    id: string,
+    fields: { name?: string; enabled?: boolean }
+  ): Promise<{ updated: boolean }> {
+    const db = this.requireDb()
+    await ensureMigrated(db)
+
+    const existing = await this.get(userId, id)
+    if (!existing) return { updated: false }
+
+    const name = fields.name ?? existing.name
+    const enabled = fields.enabled ?? existing.enabled
+    const res = await db
+      .prepare(
+        `UPDATE ${TABLE} SET name = ?1, enabled = ?2, updated_at = ?3 WHERE user_id = ?4 AND id = ?5`
+      )
+      .bind(name, enabled ? 1 : 0, Date.now(), userId, id)
+      .run()
+    return { updated: (res.meta?.changes ?? 0) > 0 }
+  }
+
+  /** Cache the tool list from a successful validate (scoped to the user). */
+  async recordValidation(
+    userId: string,
+    id: string,
+    capabilities: string[]
+  ): Promise<void> {
+    const db = this.requireDb()
+    await ensureMigrated(db)
+    await db
+      .prepare(
+        `UPDATE ${TABLE} SET capabilities_json = ?1, last_validated_at = ?2, updated_at = ?2 WHERE user_id = ?3 AND id = ?4`
+      )
+      .bind(JSON.stringify(capabilities), Date.now(), userId, id)
+      .run()
+  }
+
+  /** Remove a registration, scoped to the user. */
+  async remove(userId: string, id: string): Promise<{ deleted: boolean }> {
+    const db = this.requireDb()
+    await ensureMigrated(db)
+    const res = await db
+      .prepare(`DELETE FROM ${TABLE} WHERE user_id = ?1 AND id = ?2`)
+      .bind(userId, id)
+      .run()
+    return { deleted: (res.meta?.changes ?? 0) > 0 }
+  }
+
+  /**
+   * Resolve a user's ENABLED registrations into decrypted connect inputs for
+   * the agent loader. This is the only path that decrypts secrets; the result
+   * is used solely to open outbound MCP clients server-side and is never
+   * returned to a client. A row whose secret fails to decrypt is skipped
+   * (logged) rather than aborting the whole load.
+   */
+  async listEnabledConnectInputs(userId: string): Promise<McpConnectInput[]> {
+    const db = this.requireDb()
+    await ensureMigrated(db)
+    const result = await db
+      .prepare(
+        `SELECT id, user_id, name, url, transport, auth_kind, auth_secret, auth_header_name, enabled, capabilities_json, last_validated_at, created_at, updated_at
+         FROM ${TABLE} WHERE user_id = ?1 AND enabled = 1 ORDER BY created_at ASC`
+      )
+      .bind(userId)
+      .all<D1McpRegistrationRow>()
+
+    const inputs: McpConnectInput[] = []
+    for (const row of result.results ?? []) {
+      try {
+        inputs.push({
+          id: row.id,
+          name: row.name,
+          url: row.url,
+          transport: normalizeTransport(row.transport),
+          auth: await toAuth(row),
+        })
+      } catch (error) {
+        console.error(
+          `[mcp-registry] Skipping registration ${row.id}: ${error instanceof Error ? error.message : String(error)}`
+        )
+      }
+    }
+    return inputs
+  }
+}
+
+async function toAuth(row: D1McpRegistrationRow): Promise<McpAuth> {
+  const kind = normalizeAuthKind(row.auth_kind)
+  if (kind === 'none' || !row.auth_secret) return { kind: 'none' }
+  const secret = await decryptRegistrySecret(row.auth_secret)
+  if (kind === 'bearer') return { kind: 'bearer', token: secret }
+  return {
+    kind: 'header',
+    headerName: row.auth_header_name || 'Authorization',
+    value: secret,
+  }
+}
+
+export type McpRegistryErrorCode =
+  | 'NOT_ENABLED'
+  | 'NOT_FOUND'
+  | 'ENCRYPTION_UNAVAILABLE'
+  | 'VALIDATION'
+
+export class McpRegistryError extends Error {
+  constructor(
+    message: string,
+    public readonly code: McpRegistryErrorCode,
+    public readonly cause?: unknown
+  ) {
+    super(message)
+    this.name = 'McpRegistryError'
+  }
+}
+
+/** Shared singleton — the store is stateless beyond the D1 binding lookup. */
+export const mcpRegistrationStore = new McpRegistrationStore()

--- a/apps/dashboard/src/lib/ai/agent/mcp/registry-crypto.ts
+++ b/apps/dashboard/src/lib/ai/agent/mcp/registry-crypto.ts
@@ -1,0 +1,118 @@
+/**
+ * Server-side AES-256-GCM encryption for external MCP server auth secrets
+ * (bearer tokens / custom-header values) stored in the D1 registration store.
+ *
+ * Mirrors the user-connection secret convention in
+ * `lib/connection-store/crypto.ts` (same VERSION byte + IV + ciphertext layout,
+ * same key material and priority) so operators never provision a second secret.
+ * The only difference is the plaintext here is a single opaque string rather
+ * than a structured credential object, and the key-derivation string is
+ * domain-separated (`chm:mcp-registry:v1:`) so the two features never share a
+ * derived key.
+ *
+ * A registered server's token is NEVER written to D1 in plaintext and NEVER
+ * returned to the client — the registry API projects non-secret columns only.
+ */
+
+const ALGORITHM = 'AES-GCM'
+const IV_LENGTH = 12
+const VERSION = 1
+
+function readEnv(key: string): string | undefined {
+  if (typeof process !== 'undefined' && process.env?.[key]) {
+    return process.env[key]
+  }
+  return undefined
+}
+
+// AES-256 key material, in priority order (identical to user-connections):
+//   1. CHM_USER_CONNECTIONS_ENCRYPTION_KEY — optional dedicated key (32 bytes,
+//      base64). Reused so both at-rest features share one operator-provided key.
+//   2. Derived from CLERK_SECRET_KEY via SHA-256. Per-user MCP registration is a
+//      cloud feature that already requires Clerk (D1 + signed-in scope), so the
+//      Clerk secret is present whenever this runs — no separate secret needed.
+async function deriveEncryptionKey(): Promise<CryptoKey | null> {
+  const explicit = readEnv('CHM_USER_CONNECTIONS_ENCRYPTION_KEY')
+  if (explicit) {
+    const raw = Uint8Array.from(atob(explicit.trim()), (c) => c.charCodeAt(0))
+    if (raw.length !== 32) {
+      throw new Error(
+        'CHM_USER_CONNECTIONS_ENCRYPTION_KEY must be 32 bytes (base64-encoded)'
+      )
+    }
+    return crypto.subtle.importKey('raw', raw, { name: ALGORITHM }, false, [
+      'encrypt',
+      'decrypt',
+    ])
+  }
+
+  const clerkSecret = readEnv('CLERK_SECRET_KEY')
+  if (!clerkSecret) return null
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(`chm:mcp-registry:v1:${clerkSecret}`)
+  )
+  return crypto.subtle.importKey('raw', digest, { name: ALGORITHM }, false, [
+    'encrypt',
+    'decrypt',
+  ])
+}
+
+/**
+ * True when a key is available to encrypt/decrypt MCP auth secrets — i.e. a
+ * dedicated key is set OR Clerk auth is configured. When false, callers must
+ * refuse to persist a secret (never store plaintext) rather than silently
+ * downgrading.
+ */
+export function isRegistryEncryptionConfigured(): boolean {
+  return Boolean(
+    readEnv('CHM_USER_CONNECTIONS_ENCRYPTION_KEY') ||
+      readEnv('CLERK_SECRET_KEY')
+  )
+}
+
+const KEY_UNAVAILABLE_ERROR =
+  'MCP registry secret encryption unavailable: set CLERK_SECRET_KEY (or CHM_USER_CONNECTIONS_ENCRYPTION_KEY)'
+
+export async function encryptRegistrySecret(secret: string): Promise<string> {
+  const key = await deriveEncryptionKey()
+  if (!key) throw new Error(KEY_UNAVAILABLE_ERROR)
+
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH))
+  const plaintext = new TextEncoder().encode(secret)
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: ALGORITHM, iv },
+    key,
+    plaintext
+  )
+
+  const payload = new Uint8Array(1 + IV_LENGTH + ciphertext.byteLength)
+  payload[0] = VERSION
+  payload.set(iv, 1)
+  payload.set(new Uint8Array(ciphertext), 1 + IV_LENGTH)
+
+  return btoa(String.fromCharCode(...payload))
+}
+
+export async function decryptRegistrySecret(
+  encrypted: string
+): Promise<string> {
+  const key = await deriveEncryptionKey()
+  if (!key) throw new Error(KEY_UNAVAILABLE_ERROR)
+
+  const payload = Uint8Array.from(atob(encrypted), (c) => c.charCodeAt(0))
+  if (payload[0] !== VERSION) {
+    throw new Error('Unsupported encryption version')
+  }
+
+  const iv = payload.slice(1, 1 + IV_LENGTH)
+  const ciphertext = payload.slice(1 + IV_LENGTH)
+
+  const plaintext = await crypto.subtle.decrypt(
+    { name: ALGORITHM, iv },
+    key,
+    ciphertext
+  )
+
+  return new TextDecoder().decode(plaintext)
+}

--- a/apps/dashboard/src/lib/ai/agent/mcp/registry-http.ts
+++ b/apps/dashboard/src/lib/ai/agent/mcp/registry-http.ts
@@ -1,0 +1,106 @@
+/**
+ * Shared auth + error mapping for the MCP registry HTTP routes
+ * (`/api/v1/mcp/servers` and the `/api/v1/mcp/probe` test-connection probe).
+ */
+
+import type { McpAuth, McpAuthKind, McpTransport } from './registration-store'
+
+import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import { ApiErrorType } from '@/lib/api/types'
+import { isClerkAuthProvider } from '@/lib/auth/provider'
+import { GUEST_USER_ID, resolveUserId } from '@/lib/conversation-store/auth'
+import { ConversationStoreError } from '@/lib/conversation-store/types'
+import { McpRegistryError } from './registration-store'
+
+interface RouteContext {
+  route: string
+  method: string
+}
+
+/**
+ * Resolve the user id the registry is scoped to.
+ *
+ * - Clerk configured + signed-in  → the Clerk user id (per-user isolation).
+ * - Clerk configured, no session  → throws UNAUTHORIZED (mapped to 401).
+ * - Clerk NOT configured (OSS)     → `'guest'` single-user scope, so a
+ *   self-hosted deployment still works without an auth provider.
+ */
+export async function resolveRegistryUserId(request: Request): Promise<string> {
+  if (!isClerkAuthProvider()) return GUEST_USER_ID
+  return resolveUserId(request)
+}
+
+/** Map registry / auth errors to the shared API error response shape. */
+export function mapRegistryError(
+  error: unknown,
+  context: RouteContext
+): Response {
+  if (error instanceof McpRegistryError) {
+    const status =
+      error.code === 'NOT_ENABLED'
+        ? 501
+        : error.code === 'NOT_FOUND'
+          ? 404
+          : error.code === 'VALIDATION'
+            ? 400
+            : error.code === 'ENCRYPTION_UNAVAILABLE'
+              ? 501
+              : 500
+    const type =
+      error.code === 'VALIDATION'
+        ? ApiErrorType.ValidationError
+        : ApiErrorType.PermissionError
+    return createApiErrorResponse(
+      { type, message: error.message },
+      status,
+      context
+    )
+  }
+
+  if (error instanceof ConversationStoreError) {
+    const status = error.code === 'UNAUTHORIZED' ? 401 : 500
+    return createApiErrorResponse(
+      { type: ApiErrorType.PermissionError, message: error.message },
+      status,
+      context
+    )
+  }
+
+  return createApiErrorResponse(
+    {
+      type: ApiErrorType.QueryError,
+      message: error instanceof Error ? error.message : 'Unknown error',
+    },
+    500,
+    context
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Request-body parsing (shared by servers.ts + probe.ts)
+// ---------------------------------------------------------------------------
+
+export function parseTransport(value: unknown): McpTransport {
+  return value === 'sse' ? 'sse' : 'http'
+}
+
+export function parseAuthKind(value: unknown): McpAuthKind {
+  return value === 'bearer' || value === 'header' ? value : 'none'
+}
+
+/** Build structured auth from raw request fields (no secret ⇒ no auth). */
+export function buildRegistryAuth(
+  kind: McpAuthKind,
+  secret: string | undefined,
+  headerName: string | undefined
+): McpAuth {
+  if (kind === 'bearer' && secret) return { kind: 'bearer', token: secret }
+  if (kind === 'header' && secret) {
+    return {
+      kind: 'header',
+      headerName: headerName || 'Authorization',
+      value: secret,
+    }
+  }
+  return { kind: 'none' }
+}

--- a/apps/dashboard/src/lib/ai/agent/mcp/registry-http.ts
+++ b/apps/dashboard/src/lib/ai/agent/mcp/registry-http.ts
@@ -5,12 +5,12 @@
 
 import type { McpAuth, McpAuthKind, McpTransport } from './registration-store'
 
+import { McpRegistryError } from './registration-store'
 import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
 import { ApiErrorType } from '@/lib/api/types'
 import { isClerkAuthProvider } from '@/lib/auth/provider'
 import { GUEST_USER_ID, resolveUserId } from '@/lib/conversation-store/auth'
 import { ConversationStoreError } from '@/lib/conversation-store/types'
-import { McpRegistryError } from './registration-store'
 
 interface RouteContext {
   route: string

--- a/apps/dashboard/src/lib/swr/use-mcp-registry.ts
+++ b/apps/dashboard/src/lib/swr/use-mcp-registry.ts
@@ -1,0 +1,185 @@
+/**
+ * TanStack Query hooks for the per-user MCP server registry
+ * (`/api/v1/mcp/servers`) plus the `/api/v1/mcp/probe` test-connection helper.
+ *
+ * Matches the codebase data-fetching pattern (apiFetch + useQuery/useMutation).
+ * The list query and every mutation share one query key so mutations invalidate
+ * the list. Secrets are write-only — they are POSTed but the server never
+ * returns them (the DTO carries only `authKind` / `hasSecret`).
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { apiFetch } from './api-fetch'
+
+export type McpTransport = 'http' | 'sse'
+export type McpAuthKind = 'none' | 'bearer' | 'header'
+
+export interface McpRegistrationDto {
+  id: string
+  name: string
+  url: string
+  transport: McpTransport
+  authKind: McpAuthKind
+  authHeaderName: string | null
+  hasSecret: boolean
+  enabled: boolean
+  capabilities: string[] | null
+  lastValidatedAt: number | null
+  createdAt: number
+  updatedAt: number
+}
+
+const REGISTRY_KEY = ['/api/v1/mcp/servers'] as const
+
+export class McpRegistryRequestError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number
+  ) {
+    super(message)
+    this.name = 'McpRegistryRequestError'
+  }
+}
+
+/** Parse the shared `{ success, data }` envelope; throw on non-2xx. */
+async function parseEnvelope<T>(res: Response): Promise<T> {
+  const body = (await res.json().catch(() => null)) as {
+    data?: T
+    error?: { message?: string }
+  } | null
+  if (!res.ok) {
+    throw new McpRegistryRequestError(
+      body?.error?.message ?? `Request failed (${res.status})`,
+      res.status
+    )
+  }
+  return (body?.data ?? null) as T
+}
+
+export interface UseMcpRegistryResult {
+  servers: McpRegistrationDto[]
+  isLoading: boolean
+  error: McpRegistryRequestError | null
+  /** True when the registry is not enabled on this deployment (501). */
+  notEnabled: boolean
+}
+
+export function useMcpRegistryServers(): UseMcpRegistryResult {
+  const { data, isLoading, error } = useQuery<McpRegistrationDto[]>({
+    queryKey: REGISTRY_KEY,
+    queryFn: async () => {
+      const res = await apiFetch('/api/v1/mcp/servers')
+      return (await parseEnvelope<McpRegistrationDto[]>(res)) ?? []
+    },
+    retry: false,
+    refetchOnWindowFocus: false,
+  })
+
+  const typedError = error instanceof McpRegistryRequestError ? error : null
+  return {
+    servers: data ?? [],
+    isLoading,
+    error: typedError,
+    notEnabled: typedError?.status === 501,
+  }
+}
+
+export interface CreateMcpServerInput {
+  name: string
+  url: string
+  transport: McpTransport
+  authKind: McpAuthKind
+  authSecret?: string
+  authHeaderName?: string
+}
+
+export function useCreateMcpServer() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: CreateMcpServerInput) => {
+      const res = await apiFetch('/api/v1/mcp/servers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+      return parseEnvelope<McpRegistrationDto & { validatedTools: string[] }>(
+        res
+      )
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: REGISTRY_KEY }),
+  })
+}
+
+export function usePatchMcpServer() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: {
+      id: string
+      name?: string
+      enabled?: boolean
+    }) => {
+      const res = await apiFetch('/api/v1/mcp/servers', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+      return parseEnvelope<McpRegistrationDto>(res)
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: REGISTRY_KEY }),
+  })
+}
+
+export function useDeleteMcpServer() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const res = await apiFetch(
+        `/api/v1/mcp/servers?id=${encodeURIComponent(id)}`,
+        { method: 'DELETE' }
+      )
+      await parseEnvelope<{ id: string; deleted: boolean }>(res)
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: REGISTRY_KEY }),
+  })
+}
+
+export interface TestMcpConnectionInput {
+  endpoint: string
+  name?: string
+  transport: McpTransport
+  authKind: McpAuthKind
+  authSecret?: string
+  authHeaderName?: string
+}
+
+export interface TestMcpConnectionResult {
+  status: 'connected' | 'error'
+  toolCount: number
+  tools: string[]
+  error?: string
+}
+
+/** Probe an endpoint (test-before-save). Returns the advertised tools. */
+export async function testMcpConnection(
+  input: TestMcpConnectionInput
+): Promise<TestMcpConnectionResult> {
+  const res = await apiFetch('/api/v1/mcp/probe', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  // The probe route returns the raw result shape (not the success envelope).
+  const body = (await res.json().catch(() => null)) as
+    | (TestMcpConnectionResult & { error?: string })
+    | { error?: string }
+    | null
+  if (!res.ok) {
+    const message =
+      body && typeof body.error === 'string'
+        ? body.error
+        : `Test failed (${res.status})`
+    throw new McpRegistryRequestError(message, res.status)
+  }
+  return body as TestMcpConnectionResult
+}

--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -75,6 +75,16 @@ export const menuItemsConfig: MenuItem[] = [
     permission: { feature: 'agent' },
   },
   {
+    title: 'MCP Servers',
+    href: '/mcp-servers',
+    description:
+      'Register external Model Context Protocol servers; their tools load with the agent at conversation start',
+    icon: WorkflowIcon,
+    section: 'main',
+    isNew: true,
+    permission: { feature: 'agent' },
+  },
+  {
     title: 'Insights',
     href: '/insights',
     icon: TrendingUpIcon,

--- a/apps/dashboard/src/routes/(dashboard)/mcp-servers.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/mcp-servers.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { PageHeader } from '@/components/layout/page-header'
+import { McpServerManager } from '@/components/mcp/mcp-server-manager'
+
+function McpServersPage() {
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6">
+      <PageHeader
+        title="MCP servers"
+        description="Register external Model Context Protocol servers. Their tools load alongside the agent's built-in tools at the start of every conversation."
+      />
+      <McpServerManager />
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/(dashboard)/mcp-servers')({
+  component: McpServersPage,
+})

--- a/apps/dashboard/src/routes/api/v1/agent.ts
+++ b/apps/dashboard/src/routes/api/v1/agent.ts
@@ -48,6 +48,8 @@ import { createJsonRenderPatchGuardStream } from '@/lib/ai/agent/json-render-pat
 import {
   type CustomMcpServerInput,
   connectCustomMcpServers,
+  loadUserRegisteredServers,
+  mergeMcpServers,
 } from '@/lib/ai/agent/mcp/connect-custom-servers'
 import { resolveDefaultAgentModel } from '@/lib/ai/agent-model-registry'
 import {
@@ -536,27 +538,11 @@ async function handlePost(request: Request): Promise<Response> {
     )
     .map((s) => ({ id: s.id, name: s.name, endpoint: s.endpoint }))
 
-  // Connect custom MCP servers (if any) before creating the agent.
-  // closeAll() is called in onEnd so connections are freed after streaming.
+  // Custom MCP servers are connected AFTER the billing gate below (which can
+  // return 402 before any stream exists) so a rejected request never opens —
+  // and then leaks — an MCP client. Declared here so onEnd can close them.
   let mcpCloseAll: (() => Promise<void>) | null = null
   let extraTools: Record<string, unknown> | undefined
-
-  if (validMcpServers.length > 0) {
-    const mcpResult = await connectCustomMcpServers(validMcpServers)
-    mcpCloseAll = mcpResult.closeAll
-    extraTools =
-      Object.keys(mcpResult.tools).length > 0 ? mcpResult.tools : undefined
-
-    const connected = mcpResult.statuses.filter(
-      (s) => s.status === 'connected'
-    ).length
-    const errored = mcpResult.statuses.filter(
-      (s) => s.status === 'error'
-    ).length
-    console.log(
-      `[Agent API] Custom MCP servers: ${connected} connected, ${errored} failed`
-    )
-  }
 
   // AI usage enforcement (cloud only): daily message meter + monthly USD budget.
   // resolveBillingOwner() throws when Clerk is not configured (self-hosted),
@@ -628,18 +614,52 @@ async function handlePost(request: Request): Promise<Response> {
     reservedDailyUsage = false
   }
 
+  // Now that all early (402 / validation) returns are behind us, connect the
+  // user's custom MCP servers: request-body servers PLUS their D1-persisted
+  // registrations (loaded per-user, best-effort — [] for guest / no D1). Merge
+  // and dedupe by endpoint so the same server is never connected twice (which
+  // would collide tool keys and bypass the per-call cap), then connect once.
+  // closeAll() runs in onEnd on the streaming path (and on a pre-stream throw
+  // just below).
+  const registeredServers = await loadUserRegisteredServers(userId)
+  const mergedMcpServers = mergeMcpServers(validMcpServers, registeredServers)
+  if (mergedMcpServers.length > 0) {
+    const mcpResult = await connectCustomMcpServers(mergedMcpServers)
+    mcpCloseAll = mcpResult.closeAll
+    extraTools =
+      Object.keys(mcpResult.tools).length > 0 ? mcpResult.tools : undefined
+
+    const connected = mcpResult.statuses.filter(
+      (s) => s.status === 'connected'
+    ).length
+    const errored = mcpResult.statuses.filter(
+      (s) => s.status === 'error'
+    ).length
+    console.log(
+      `[Agent API] Custom MCP servers: ${connected} connected, ${errored} failed`
+    )
+  }
+
   const requestOrigin = request.headers.get('origin') ?? undefined
-  const agent = createClickHouseAgent({
-    hostId,
-    model,
-    disabledTools,
-    systemPrompt: AGENT_JSON_RENDER_INLINE_PROMPT,
-    providerOptions: { openrouter: { user: openRouterUser } },
-    referer: requestOrigin,
-    includeControlTools,
-    sessionId,
-    extraTools,
-  })
+  let agent: ReturnType<typeof createClickHouseAgent>
+  try {
+    agent = createClickHouseAgent({
+      hostId,
+      model,
+      disabledTools,
+      systemPrompt: AGENT_JSON_RENDER_INLINE_PROMPT,
+      providerOptions: { openrouter: { user: openRouterUser } },
+      referer: requestOrigin,
+      includeControlTools,
+      sessionId,
+      extraTools,
+    })
+  } catch (error) {
+    // Pre-stream failure: close any MCP clients we just opened (onEnd won't run
+    // because no stream is created) before rethrowing to the outer boundary.
+    if (mcpCloseAll) await mcpCloseAll().catch(() => {})
+    throw error
+  }
 
   const uiMessages: Array<{
     id: string

--- a/apps/dashboard/src/routes/api/v1/mcp/probe.ts
+++ b/apps/dashboard/src/routes/api/v1/mcp/probe.ts
@@ -1,21 +1,37 @@
 /**
  * MCP probe endpoint — POST /api/v1/mcp/probe
  *
- * Validates and test-connects to a user-supplied MCP endpoint so the panel
- * can show real connection status and tool counts without waiting for a full
- * agent request.
+ * Validates and test-connects to a user-supplied MCP endpoint (the
+ * "Test connection" probe) so the UI can show real connection status and the
+ * server's advertised tools BEFORE saving a registration — without persisting
+ * anything. Optionally accepts `transport` + auth so the manager can test a
+ * server exactly as it will be loaded (bearer token / custom header).
+ *
+ * This is the single test-before-save implementation: it delegates to
+ * {@link validateServer} (shared with `/api/v1/mcp/servers` POST and the agent
+ * loader), which SSRF-guards the URL, opens the SSRF-pinned client, lists the
+ * real tools, and always closes the client.
  *
  * Auth: same as the agent route (authorizeAgentApiRequest).
  */
 
 import { createFileRoute } from '@tanstack/react-router'
 
-import { connectCustomMcpServers } from '@/lib/ai/agent/mcp/connect-custom-servers'
+import { validateServer } from '@/lib/ai/agent/mcp/connect-custom-servers'
+import {
+  buildRegistryAuth,
+  parseAuthKind,
+  parseTransport,
+} from '@/lib/ai/agent/mcp/registry-http'
 import { authorizeAgentApiRequest } from '@/lib/auth/agent-api-auth'
 
 interface ProbeRequestBody {
   endpoint: string
   name?: string
+  transport?: unknown
+  authKind?: unknown
+  authSecret?: unknown
+  authHeaderName?: unknown
 }
 
 interface ProbeResponse {
@@ -49,28 +65,34 @@ async function handlePost(request: Request): Promise<Response> {
 
   const endpoint = body.endpoint.trim()
   const name = typeof body.name === 'string' ? body.name.trim() : 'probe'
+  const transport = parseTransport(body.transport)
+  const authKind = parseAuthKind(body.authKind)
+  const authSecret =
+    typeof body.authSecret === 'string' ? body.authSecret : undefined
+  const authHeaderName =
+    typeof body.authHeaderName === 'string' ? body.authHeaderName : undefined
+  const auth = buildRegistryAuth(authKind, authSecret, authHeaderName)
 
-  let mcpResult
-  try {
-    mcpResult = await connectCustomMcpServers([
-      { id: 'probe', name: name || 'probe', endpoint },
-    ])
-  } finally {
-    // closeAll is called whether connect succeeded or not
-    if (mcpResult) {
-      await mcpResult.closeAll().catch(() => {})
-    }
-  }
+  const result = await validateServer({
+    id: 'probe',
+    name: name || 'probe',
+    endpoint,
+    transport,
+    auth,
+  })
 
-  const [status] = mcpResult.statuses
-  const toolNames = Object.keys(mcpResult.tools)
-
-  const responseBody: ProbeResponse = {
-    status: status?.status ?? 'error',
-    toolCount: status?.toolCount ?? 0,
-    tools: toolNames,
-    ...(status?.error !== undefined ? { error: status.error } : {}),
-  }
+  const responseBody: ProbeResponse = result.ok
+    ? {
+        status: 'connected',
+        toolCount: result.tools?.length ?? 0,
+        tools: result.tools ?? [],
+      }
+    : {
+        status: 'error',
+        toolCount: 0,
+        tools: [],
+        ...(result.error !== undefined ? { error: result.error } : {}),
+      }
 
   return Response.json(responseBody)
 }

--- a/apps/dashboard/src/routes/api/v1/mcp/servers.ts
+++ b/apps/dashboard/src/routes/api/v1/mcp/servers.ts
@@ -23,8 +23,8 @@ import type { McpRegistration } from '@/lib/ai/agent/mcp/registration-store'
 import { validateServer } from '@/lib/ai/agent/mcp/connect-custom-servers'
 import {
   isMcpRegistryEnabled,
-  mcpRegistrationStore,
   McpRegistryError,
+  mcpRegistrationStore,
 } from '@/lib/ai/agent/mcp/registration-store'
 import {
   buildRegistryAuth,

--- a/apps/dashboard/src/routes/api/v1/mcp/servers.ts
+++ b/apps/dashboard/src/routes/api/v1/mcp/servers.ts
@@ -1,0 +1,262 @@
+/**
+ * MCP server registry API — /api/v1/mcp/servers
+ *
+ *   GET    — list the signed-in user's registered MCP servers (metadata only,
+ *            never the stored secret).
+ *   POST   — validate connectivity + capabilities, then persist a new
+ *            registration (scoped to the user). Rejects an unreachable server
+ *            rather than storing a dishonest "connected" claim.
+ *   PATCH  — rename / enable / disable one of the user's registrations.
+ *   DELETE — remove one of the user's registrations (`?id=`).
+ *
+ * All operations are strictly user-scoped (see registration-store.ts) and reuse
+ * the shared API error/response builders. Requires the D1 registry to be
+ * enabled; otherwise returns 501 (like user-connections DB storage).
+ *
+ * See plans/43-mcp-custom-server-registry.md.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { McpRegistration } from '@/lib/ai/agent/mcp/registration-store'
+
+import { validateServer } from '@/lib/ai/agent/mcp/connect-custom-servers'
+import {
+  isMcpRegistryEnabled,
+  mcpRegistrationStore,
+  McpRegistryError,
+} from '@/lib/ai/agent/mcp/registration-store'
+import {
+  buildRegistryAuth,
+  mapRegistryError,
+  parseAuthKind,
+  parseTransport,
+  resolveRegistryUserId,
+} from '@/lib/ai/agent/mcp/registry-http'
+import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import { createSuccessResponse } from '@/lib/api/shared/response-builder'
+import { ApiErrorType } from '@/lib/api/types'
+
+const ROUTE = '/api/v1/mcp/servers'
+const CTX = (method: string) => ({ route: ROUTE, method })
+
+function notEnabledResponse(method: string): Response {
+  return createApiErrorResponse(
+    {
+      type: ApiErrorType.PermissionError,
+      message:
+        'MCP server registry is not enabled (no CHM_CLOUD_D1 binding on this deployment).',
+    },
+    501,
+    CTX(method)
+  )
+}
+
+function validationError(message: string, method: string): Response {
+  return createApiErrorResponse(
+    { type: ApiErrorType.ValidationError, message },
+    400,
+    CTX(method)
+  )
+}
+
+/** Public DTO — strips the owner id and NEVER carries the secret. */
+function toDto(reg: McpRegistration) {
+  return {
+    id: reg.id,
+    name: reg.name,
+    url: reg.url,
+    transport: reg.transport,
+    authKind: reg.authKind,
+    authHeaderName: reg.authHeaderName,
+    hasSecret: reg.hasSecret,
+    enabled: reg.enabled,
+    capabilities: reg.capabilities,
+    lastValidatedAt: reg.lastValidatedAt,
+    createdAt: reg.createdAt,
+    updatedAt: reg.updatedAt,
+  }
+}
+
+async function handleGet(request: Request): Promise<Response> {
+  if (!isMcpRegistryEnabled()) return notEnabledResponse('GET')
+  try {
+    const userId = await resolveRegistryUserId(request)
+    const servers = await mcpRegistrationStore.listForUser(userId)
+    return createSuccessResponse(servers.map(toDto))
+  } catch (error) {
+    return mapRegistryError(error, CTX('GET'))
+  }
+}
+
+interface CreateBody {
+  name?: unknown
+  url?: unknown
+  transport?: unknown
+  authKind?: unknown
+  authSecret?: unknown
+  authHeaderName?: unknown
+}
+
+async function handlePost(request: Request): Promise<Response> {
+  if (!isMcpRegistryEnabled()) return notEnabledResponse('POST')
+
+  let body: CreateBody
+  try {
+    body = (await request.json()) as CreateBody
+  } catch {
+    return validationError('Request body must be valid JSON', 'POST')
+  }
+
+  const name = typeof body.name === 'string' ? body.name.trim() : ''
+  const url = typeof body.url === 'string' ? body.url.trim() : ''
+  const transport = parseTransport(body.transport)
+  const authKind = parseAuthKind(body.authKind)
+  const authSecret =
+    typeof body.authSecret === 'string' ? body.authSecret : undefined
+  const authHeaderName =
+    typeof body.authHeaderName === 'string'
+      ? body.authHeaderName.trim()
+      : undefined
+
+  if (!name) return validationError('name is required', 'POST')
+  if (!url) return validationError('url is required', 'POST')
+  if (authKind !== 'none' && !authSecret) {
+    return validationError(
+      `authSecret is required for authKind "${authKind}"`,
+      'POST'
+    )
+  }
+  if (authKind === 'header' && !authHeaderName) {
+    return validationError(
+      'authHeaderName is required for authKind "header"',
+      'POST'
+    )
+  }
+
+  try {
+    const userId = await resolveRegistryUserId(request)
+
+    // Validate connectivity + capabilities BEFORE persisting — honest claims:
+    // an unreachable / SSRF-blocked server is rejected, not stored as "ok".
+    const auth = buildRegistryAuth(authKind, authSecret, authHeaderName)
+    const probe = await validateServer({
+      id: 'probe',
+      name,
+      endpoint: url,
+      transport,
+      auth,
+    })
+    if (!probe.ok) {
+      return validationError(
+        probe.error ?? 'Could not connect to the MCP server',
+        'POST'
+      )
+    }
+
+    const id = crypto.randomUUID()
+    const written = await mcpRegistrationStore.upsert({
+      id,
+      userId,
+      name,
+      url,
+      transport,
+      authKind,
+      authSecret,
+      authHeaderName: authKind === 'header' ? authHeaderName : null,
+      enabled: true,
+      capabilities: probe.tools ?? [],
+      lastValidatedAt: Date.now(),
+    })
+    if (!written.written) {
+      throw new McpRegistryError('Failed to persist registration', 'VALIDATION')
+    }
+
+    const created = await mcpRegistrationStore.get(userId, id)
+    return createSuccessResponse({
+      ...(created ? toDto(created) : { id, name, url }),
+      validatedTools: probe.tools ?? [],
+    })
+  } catch (error) {
+    return mapRegistryError(error, CTX('POST'))
+  }
+}
+
+interface PatchBody {
+  id?: unknown
+  name?: unknown
+  enabled?: unknown
+}
+
+async function handlePatch(request: Request): Promise<Response> {
+  if (!isMcpRegistryEnabled()) return notEnabledResponse('PATCH')
+
+  let body: PatchBody
+  try {
+    body = (await request.json()) as PatchBody
+  } catch {
+    return validationError('Request body must be valid JSON', 'PATCH')
+  }
+
+  const id = typeof body.id === 'string' ? body.id : ''
+  if (!id) return validationError('id is required', 'PATCH')
+
+  const name =
+    typeof body.name === 'string' && body.name.trim().length > 0
+      ? body.name.trim()
+      : undefined
+  const enabled = typeof body.enabled === 'boolean' ? body.enabled : undefined
+  if (name === undefined && enabled === undefined) {
+    return validationError(
+      'Nothing to update (name or enabled required)',
+      'PATCH'
+    )
+  }
+
+  try {
+    const userId = await resolveRegistryUserId(request)
+    const res = await mcpRegistrationStore.patch(userId, id, { name, enabled })
+    if (!res.updated) {
+      return mapRegistryError(
+        new McpRegistryError('Registration not found', 'NOT_FOUND'),
+        CTX('PATCH')
+      )
+    }
+    const updated = await mcpRegistrationStore.get(userId, id)
+    return createSuccessResponse(updated ? toDto(updated) : { id })
+  } catch (error) {
+    return mapRegistryError(error, CTX('PATCH'))
+  }
+}
+
+async function handleDelete(request: Request): Promise<Response> {
+  if (!isMcpRegistryEnabled()) return notEnabledResponse('DELETE')
+
+  const id = new URL(request.url).searchParams.get('id')?.trim() ?? ''
+  if (!id) return validationError('id query parameter is required', 'DELETE')
+
+  try {
+    const userId = await resolveRegistryUserId(request)
+    const res = await mcpRegistrationStore.remove(userId, id)
+    if (!res.deleted) {
+      return mapRegistryError(
+        new McpRegistryError('Registration not found', 'NOT_FOUND'),
+        CTX('DELETE')
+      )
+    }
+    return createSuccessResponse({ id, deleted: true })
+  } catch (error) {
+    return mapRegistryError(error, CTX('DELETE'))
+  }
+}
+
+export const Route = createFileRoute('/api/v1/mcp/servers')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => handleGet(request),
+      POST: async ({ request }) => handlePost(request),
+      PATCH: async ({ request }) => handlePatch(request),
+      DELETE: async ({ request }) => handleDelete(request),
+    },
+  },
+})

--- a/docs/content/guide/ai-agent.mdx
+++ b/docs/content/guide/ai-agent.mdx
@@ -222,6 +222,19 @@ You can connect additional MCP servers from the agent settings sidebar. Click **
 
 The panel probes each enabled server on load (`POST /api/v1/mcp/probe`) to show live connection status and tool count. Click a row to see the full tool list.
 
+### Persistent MCP server registry (per-user)
+
+The sidebar panel above stores servers in the browser (`localStorage`). For servers that **persist server-side per user** — with authentication and a template library — use the **MCP Servers** page (`/mcp-servers`, in the sidebar under *AI Agent*).
+
+- **Register** a server with a name, endpoint URL, transport (`http` streamable or `sse`), and optional auth (a **bearer token** or a **custom header**). Saving first runs a **Test connection** probe and stores the server only if it connects — so the tool count shown reflects what the server actually advertised.
+- **Template library** — one-click presets prefill the form for **Slack**, **GitHub**, and **Datadog** (endpoint + expected auth kind); you supply your own token.
+- **Enable / disable / remove** each server. Enabled registrations are loaded for that user at the start of every conversation, merged with any request-body (sidebar) servers and de-duplicated by endpoint.
+- **Storage** — registrations live in Cloudflare D1 (`mcp_server_registrations`), strictly scoped to the signed-in user; one user's servers are never loaded for another. Auth secrets are **encrypted at rest** (AES-256-GCM) and never returned by the API.
+- **SSRF-guarded transport** — the same private-range / DNS-rebind guard as above applies, and the actual outbound connection is pinned behind the host-validated fetch (not a raw fetch), so the validated address is the one connected to.
+- **Availability** — this page requires the hosted (cloud) deployment (a D1 binding + a signed-in account). Self-hosted deployments without D1 use the sidebar panel instead; the page shows an explanatory empty state.
+
+**API:** `GET/POST/PATCH/DELETE /api/v1/mcp/servers` (all user-scoped); `POST /api/v1/mcp/probe` for test-before-save.
+
 ### MCP tools
 
 The MCP server exposes a smaller, read-only-only subset of tools for external MCP

--- a/docs/knowledge/mcp-server.md
+++ b/docs/knowledge/mcp-server.md
@@ -85,3 +85,32 @@ exposure is visible in logs and cannot be silently forgotten.
 - `packages/mcp-server/src/http.ts` — auth gate (`defaultAuthenticator`)
 - `packages/mcp-server/src/auth/` — api-key + Clerk OAuth verifiers
 - Tests: `packages/mcp-server/src/__tests__/http.test.ts`
+
+## Consuming external MCP servers (per-user registry)
+
+The opposite direction: the in-app **agent** can also load tools from *external*
+MCP servers a user registers. This is a **cloud (D1) feature**, strictly
+per-user, and additive — self-hosted without D1 falls back to the browser
+(`localStorage`) sidebar panel and stays whole.
+
+- **Store / D1** — `apps/dashboard/src/lib/ai/agent/mcp/registration-store.ts`
+  (table `mcp_server_registrations`, migration
+  `db/conversations-migrations/0015_mcp_server_registrations.sql`). Every
+  read/write is `WHERE user_id = ?`; owner-guarded upsert
+  (`ON CONFLICT ... WHERE user_id = excluded.user_id`). Auth secrets encrypted at
+  rest via `registry-crypto.ts` (AES-256-GCM, same key material as
+  `connection-store/crypto.ts`), never returned by the API.
+- **Connect / SSRF (SEC-04)** — `connect-custom-servers.ts`: `validateServer`
+  (test-before-save, always closes the client) and `loadUserRegisteredServers`
+  (best-effort, `[]` when no D1). The transport is **pinned behind
+  `createHostValidationFetch()`** (same posture as `connection-query/
+  connection-client.ts` for ClickHouse hosts) so the actual outbound connection
+  is validated, not just a pre-check.
+- **Agent wiring** — `routes/api/v1/agent.ts` merges request-body servers +
+  D1 registrations (deduped by endpoint), connects once *below* the 402 billing
+  gate, and closes on the pre-stream throw path.
+- **Routes / UI** — `routes/api/v1/mcp/servers.ts` (CRUD) + `mcp/probe.ts`
+  (test), `routes/(dashboard)/mcp-servers.tsx` +
+  `components/mcp/mcp-server-manager.tsx` (manager with template library:
+  Slack / GitHub / Datadog). See `docs/content/guide/ai-agent.mdx` §"Persistent
+  MCP server registry".

--- a/plans/README.md
+++ b/plans/README.md
@@ -138,7 +138,7 @@ appropriate for blind autonomous execution. Grouped by the blocker:
   [39 otel-trace-export](39-otel-trace-export.md),
   [40 terraform-provider](40-terraform-provider.md),
   [42 kafka-consumer-control](42-kafka-consumer-control.md),
-  [43 mcp-custom-server-registry](43-mcp-custom-server-registry.md).
+  [43 mcp-custom-server-registry](43-mcp-custom-server-registry.md) — 🔷 **PR open** [#2271](https://github.com/chmonitor/chmonitor/pull/2271) (per-user D1 registry, SSRF-pinned transport, template library).
   (36, 41, 44, 45, 46, 47 already merged — the plumbing/advisor foundation this cluster builds on.)
 - **Advisor 52** (1) — [52 proactive-weekly-health-report](52-proactive-weekly-health-report.md)
   (depends on 25/37 delivery channels). (49 query-cost-estimator already merged, #2233.)


### PR DESCRIPTION
## Plan 43 — MCP Custom Server Registry

Lets a user register external MCP servers (URL + transport + optional auth),
persist them **per-user in D1**, validate connectivity/capabilities, and load
their tools alongside the agent's built-in tools at conversation start — with a
Slack/GitHub/Datadog template library. Also closes the audit's **SEC-04**
(unpinned custom-server transport) and **DOC-01** (stale "not yet wired" note).

### What's included
- **D1 store + migration** `0015_mcp_server_registrations.sql` +
  `registration-store.ts` — user-scoped (`WHERE user_id = ?`), owner-guarded
  upsert (`ON CONFLICT … WHERE user_id = excluded.user_id`), lazy
  `CREATE TABLE IF NOT EXISTS`, best-effort (missing D1 → empty, OSS stays whole).
- **Secrets encrypted at rest** `registry-crypto.ts` (AES-256-GCM, same key
  material as user-connections). The API projects non-secret columns only
  (`authKind`/`hasSecret`) — the token is decrypted in exactly one server-side
  path to build outbound headers, never returned.
- **SEC-04 fix** — the custom-server transport is now pinned behind
  `createHostValidationFetch()` (same posture as `connection-client.ts`),
  plus auth headers and `http`/`sse` support. New `validateServer` (close-always)
  and `loadUserRegisteredServers` (best-effort).
- **Agent wiring** — merges request-body + D1 servers (deduped by endpoint),
  connects once **below the 402 billing gate**, and closes on the pre-stream
  throw path (BUG-03).
- **Routes** — `GET/POST/PATCH/DELETE /api/v1/mcp/servers` (validate-then-store);
  `POST /api/v1/mcp/probe` extended for test-before-save (single shared impl —
  no duplicate `connect.ts`).
- **UI** — `/mcp-servers` manager page (list, add form + Test connection,
  template library, enable/disable/remove), registry hooks, nav entry. Fixed the
  DOC-01 note in the welcome panel.
- **Docs** — `guide/ai-agent.mdx` + `knowledge/mcp-server.md`.
- **Tests** — per-user isolation, owner-guarded upsert `{written:false}`,
  encrypt→decrypt round-trip, SSRF reject-without-connect, failing-server
  isolation, close-on-throw, merge dedupe (injected client factory; no network).

### Reconciliations vs the literal plan
- Much of the plan's "current reality" was stale — `connectCustomMcpServers` +
  SSRF guard + `/mcp/probe` + agent body-wiring + a localStorage panel already
  existed. This PR **adds** the D1 registry on top and keeps the localStorage
  panel intact.
- No `connect.ts` — the existing `probe.ts` already is the test-before-save
  endpoint; extended it instead of duplicating (DRY).
- Manager route is `/mcp-servers` (standalone) rather than
  `agents/mcp-server-manager` — `agents.tsx` is a leaf with no `<Outlet/>`, so a
  nested child would not render.
- Migration numbered **0015** (0014 was already taken on main).

### Safety
Additive and OSS-safe: no built-in tool set changed (tool-count guard test
untouched); the registry is a cloud/D1 feature that fails open to "not enabled"
without D1; per-user isolation enforced in SQL + tested. Touches the agent
request path and adds encrypted credential storage + an SSRF-guarded outbound —
please review the auth/SSRF/secret-handling with that in mind.

### Verification (from `apps/dashboard`)
- `bun run type-check` — clean
- `bun run type-check:test` — clean
- `bun test src/lib/ai/agent/mcp` — 57 pass / 0 fail
- `biome check` — clean
