### PR TITLE
refactor(slow-queries): premium table redesign, drop red row stripe, fix duration sizing

### DIFF
--- a/apps/dashboard/src/components/slow-queries/slow-queries-table.tsx
+++ b/apps/dashboard/src/components/slow-queries/slow-queries-table.tsx
@@ -144,12 +144,6 @@ const SORT_ACCESSOR: Record<SortKey, (d: DerivedQuery) => number> = {
 
 // ───────────────────────── cells ─────────────────────────
 
-const SEVERITY_ACCENT: Record<Severity, string> = {
-  critical: 'bg-rose-500',
-  warning: 'bg-amber-500',
-  normal: 'bg-blue-500',
-}
-
 const SEVERITY_DURATION: Record<Severity, string> = {
   critical: 'text-rose-600 dark:text-rose-400',
   warning: 'text-amber-600 dark:text-amber-400',
@@ -331,20 +325,9 @@ const QueryRow = memo(function QueryRow({
   return (
     <>
       <tr
-        className="group relative cursor-pointer border-b border-border align-middle hover:bg-muted/60"
+        className="group cursor-pointer border-b border-border/60 align-middle transition-colors hover:bg-muted/50"
         onClick={onToggle}
       >
-        {/* Severity accent stripe */}
-        <td className="relative w-0 p-0">
-          <span
-            className={cn(
-              'absolute inset-y-0 left-0 w-0.5',
-              SEVERITY_ACCENT[d.severity]
-            )}
-            aria-hidden
-          />
-        </td>
-
         {/* Rank + expand chevron */}
         <td className="px-2 py-2.5 sm:px-3">
           <div className="flex items-center gap-1.5 sm:gap-2">
@@ -432,7 +415,7 @@ const QueryRow = memo(function QueryRow({
       </tr>
       {expanded && (
         <tr className="border-b border-border">
-          <td colSpan={9} className="p-0">
+          <td colSpan={8} className="p-0">
             <ExpandedDetail d={d} />
           </td>
         </tr>
@@ -504,7 +487,6 @@ export function SlowQueriesTable({ rows }: SlowQueriesTableProps) {
         <table className="w-full border-collapse text-sm">
           <thead className="border-b border-border bg-muted/40">
             <tr>
-              <th className="w-0 p-0" aria-hidden />
               <SortableHeader width="64px">#</SortableHeader>
               <SortableHeader>Query</SortableHeader>
               <SortableHeader

--- a/apps/dashboard/src/components/slow-queries/slow-queries-table.tsx
+++ b/apps/dashboard/src/components/slow-queries/slow-queries-table.tsx
@@ -371,12 +371,12 @@ const QueryRow = memo(function QueryRow({
         <td className="px-2 py-2.5 text-right sm:px-3">
           <span
             className={cn(
-              'whitespace-nowrap font-semibold tabular-nums',
+              'whitespace-nowrap text-sm font-semibold tabular-nums',
               SEVERITY_DURATION[d.severity]
             )}
           >
             {dur.value}
-            <span className="ml-0.5 text-[11px] font-normal text-muted-foreground">
+            <span className="ml-0.5 font-normal text-muted-foreground">
               {dur.unit}
             </span>
           </span>

--- a/apps/dashboard/src/components/slow-queries/slow-queries-table.tsx
+++ b/apps/dashboard/src/components/slow-queries/slow-queries-table.tsx
@@ -150,21 +150,11 @@ const SEVERITY_DURATION: Record<Severity, string> = {
   normal: 'text-foreground',
 }
 
-const SEVERITY_RANK: Record<Severity, string> = {
-  critical: 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300',
-  warning:
-    'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
-  normal: 'bg-muted text-muted-foreground',
-}
-
-/** Rank badge — emphasises the slowest queries (1 = worst). */
-function RankBadge({ rank, severity }: { rank: number; severity: Severity }) {
+/** Rank indicator — a quiet monochrome ordinal (1 = slowest). */
+function RankBadge({ rank }: { rank: number }) {
   return (
     <span
-      className={cn(
-        'inline-flex size-6 shrink-0 items-center justify-center rounded-full text-[11px] font-bold tabular-nums',
-        SEVERITY_RANK[severity]
-      )}
+      className="inline-flex size-6 shrink-0 items-center justify-center rounded-md bg-muted font-mono text-[11px] font-semibold tabular-nums text-muted-foreground"
       title={`Rank #${rank} by duration`}
     >
       {rank}
@@ -192,12 +182,12 @@ function MetricBar({ label, pct }: { label: string; pct: number }) {
   const width = Math.max(Math.min(pct, 100), 2)
   return (
     <div className="flex min-w-[72px] flex-col gap-1">
-      <span className="truncate text-right text-[11.5px] font-medium tabular-nums">
+      <span className="truncate text-right text-xs font-medium tabular-nums">
         {label}
       </span>
       <div className="relative h-1.5 overflow-hidden rounded-full bg-muted">
         <div
-          className="absolute inset-y-0 left-0 rounded-full bg-blue-500/70 transition-all"
+          className="absolute inset-y-0 left-0 rounded-full bg-foreground/25 transition-all"
           style={{ width: `${width}%` }}
         />
       </div>
@@ -337,17 +327,17 @@ const QueryRow = memo(function QueryRow({
                 expanded && 'rotate-90'
               )}
             />
-            <RankBadge rank={rank} severity={d.severity} />
+            <RankBadge rank={rank} />
           </div>
         </td>
 
         {/* Query text */}
         <td className="max-w-0 px-2 py-2.5 sm:px-3">
-          <div className="truncate font-mono text-[12px] text-muted-foreground group-hover:text-foreground">
+          <div className="truncate font-mono text-sm text-muted-foreground group-hover:text-foreground">
             {d.query}
           </div>
           {/* Compact metric row on small viewports where columns collapse. */}
-          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[10.5px] text-muted-foreground md:hidden">
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground md:hidden">
             <span className="inline-flex items-center gap-1">
               <UserIcon className="size-3" />
               {d.user || 'anon'}
@@ -384,7 +374,7 @@ const QueryRow = memo(function QueryRow({
 
         {/* User — hidden on small screens (shown inline under query) */}
         <td className="hidden px-2 py-2.5 sm:px-3 lg:table-cell">
-          <span className="truncate text-[12px]">{d.user || 'anon'}</span>
+          <span className="truncate text-sm">{d.user || 'anon'}</span>
         </td>
 
         {/* Cache usage */}
@@ -482,7 +472,7 @@ export function SlowQueriesTable({ rows }: SlowQueriesTableProps) {
   }
 
   return (
-    <div className="overflow-hidden rounded-xl border border-border bg-card">
+    <div className="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
       <div className="overflow-x-auto">
         <table className="w-full border-collapse text-sm">
           <thead className="border-b border-border bg-muted/40">

--- a/apps/dashboard/src/components/slow-queries/slow-queries-view.tsx
+++ b/apps/dashboard/src/components/slow-queries/slow-queries-view.tsx
@@ -168,8 +168,11 @@ export function SlowQueriesView() {
             <div className="flex items-center gap-2">
               Slow Queries
               {rows.length > 0 && (
-                <span className="rounded-md bg-rose-100 px-2 py-0.5 text-xs font-medium tabular-nums text-rose-700 dark:bg-rose-900/40 dark:text-rose-300">
-                  slowest {slowest.toFixed(1)}s
+                <span className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/40 px-2 py-0.5 text-xs font-normal text-muted-foreground">
+                  slowest
+                  <span className="font-semibold tabular-nums text-foreground">
+                    {slowest.toFixed(1)}s
+                  </span>
                 </span>
               )}
             </div>


### PR DESCRIPTION
## Slow Queries page — redesign + two visual fixes

Redesigns the **Slow Queries** page for restraint (per the `product-design`
system) and fixes the two issues from the screenshot. Scoped to the bespoke
`SlowQueriesTable` + its page shell; no shared primitives touched.

### 1. Redesign — kill the "AI slop", make it intentional (#1)
The table leaned on a tricolor (rose / amber / blue) language repeated across a
left stripe, filled rank circles, and blue metric bars, with a zoo of one-off
font sizes. Now it uses **one** reserved colour channel and a consistent scale.

- **Rank**: monochrome muted ordinal chip (was a tricolor filled circle). Dropped the now-orphaned `SEVERITY_RANK` map.
- **Metric bars** (rows / bytes / memory): monochrome `bg-foreground/25` fill (was `bg-blue-500/70`).
- **Severity signal preserved** but confined to the single natural place — the **duration text** (`critical` = rose, `warning` = amber, `normal` = foreground). Nothing else is tinted.
- **Typography**: normalized `text-[10.5/11.5/12px]` → a consistent `text-sm` / `text-xs` scale; added `shadow-sm` to the card surface.
- **Header**: the loud rose `slowest 15.0s` pill → a quiet neutral stat chip with the number emphasized.

### 2. Remove the red left-border bar on every row (#2)
**Before:** every row drew a 2px colored vertical bar on its left edge
(`absolute inset-y-0 left-0 w-0.5`, colored rose/amber/blue by severity) via
`SEVERITY_ACCENT` — the "solid red vertical border" in the screenshot.
**After:** stripe removed (and its spacer column; `colSpan` 9→8). Rows are clean;
severity still reads from the duration text.

> Note: the source was the **bespoke table's stripe**, not the `rowClassName` in
> `slow-queries.ts` that the brief guessed at. That `rowClassName` returns
> `bg-red-50` row *backgrounds* (not a bar) and is **never consumed** by this
> page (the bespoke table ignores it). It IS a live field on the generic
> `DataTable` path, so I left it in place rather than risk regressing a subtle
> severity cue on generic surfaces the report wasn't about. Flagging for a
> follow-up if you want it gone everywhere.

### 3. Consistent duration value + unit sizing (#3)
**Before:** the Duration cell rendered the value at base size but the unit at
`text-[11px]` — `15.0` big + `m` small, mismatched baselines.
**After:** value + unit share one `text-sm` size/baseline; the unit keeps a
lighter weight + muted tone for contrast.

> **Conflict with the brief, surfaced honestly:** the report asked to fix
> `components/data-table/cells/duration-format.tsx` and expected it to also
> change other pages. It does **not**. That shared file uses `dayjs…humanize()`
> ("15 minutes", no big/small split) and is the renderer for the *generic*
> data-table (`ColumnFormat.Duration`) — it is **not** the renderer for this
> page and is not the source of the bug. The real source is the bespoke
> `slow-queries-table.tsx` (via `formatDuration`, which returns `{value, unit}`).
> So this fix is **page-local and affects no other page** — the inverse of the
> brief's prediction. `duration-format.tsx` was left untouched (it isn't broken).

### Verification
- `bun run type-check` and `bun run type-check:test`: **228 → 228**, i.e. **zero new** errors. All are the pre-existing `routeTree.gen.ts` cascade (missing `./routeTree.gen` module → the identical `createFileRoute` error in every route file). My two component files appear in zero errors.
- Biome lint clean on both files; no orphaned symbols left behind.
- Structure/behavior preserved: responsive column-collapse (`hidden md/lg/xl:table-cell`), the mobile inline-metric row, expand/collapse, sort, and rank-by-duration are unchanged — only colour/size/chrome moved.
- **Visual QA pending** — this environment can't browser-test; please eyeball light + dark.

### Follow-up (out of scope, noted)
The sibling bespoke tables `running-queries` and `expensive-queries` share the
same tricolor / blue-bar idiom. Restraining only Slow Queries makes the three
diverge slightly; propagating the same treatment is a good follow-up if desired.
