### PR TITLE
feat(billing): upgrade paywall modal (plan 15)

### DIFF
--- a/apps/dashboard/src/components/billing/paywall-host.tsx
+++ b/apps/dashboard/src/components/billing/paywall-host.tsx
@@ -1,0 +1,40 @@
+/**
+ * Renders the global `PaywallModal` once, driven by the paywall store
+ * (`lib/billing/paywall-store.ts`). Mounted in `DashboardShell` next to
+ * `<Toaster />` — same "singleton host at the shell" pattern.
+ */
+import { useSyncExternalStore } from 'react'
+
+import {
+  getPaywallServerSnapshot,
+  getPaywallSnapshot,
+  hidePaywall,
+  subscribePaywall,
+} from '@/lib/billing/paywall-store'
+import { PaywallModal } from './paywall-modal'
+
+export function usePaywall() {
+  return useSyncExternalStore(
+    subscribePaywall,
+    getPaywallSnapshot,
+    getPaywallServerSnapshot
+  )
+}
+
+export function PaywallHost() {
+  const state = usePaywall()
+  // `reason` stays populated after close (see paywall-store.ts hidePaywall) so
+  // the dialog's close animation doesn't flash empty content — this null
+  // check only skips the very first render, before any 402 has fired.
+  if (!state.reason) return null
+
+  return (
+    <PaywallModal
+      open={state.open}
+      reason={state.reason}
+      message={state.message}
+      currentPlanId={state.planId}
+      onClose={hidePaywall}
+    />
+  )
+}

--- a/apps/dashboard/src/components/billing/paywall-logic.ts
+++ b/apps/dashboard/src/components/billing/paywall-logic.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure decision logic for the PaywallModal — kept out of the React component
+ * so it's Bun-testable without rendering (see paywall-modal.test.tsx).
+ *
+ * Everything here derives from @chm/pricing plan data + the enforcement
+ * registry; nothing fetches. The modal component reads these as pure
+ * functions of its props.
+ */
+import type { BillingLimitReason } from '@/lib/api/error-handler/types'
+import type { Enforcement, LimitKey } from '@/lib/billing/plan-enforcement'
+import type { Plan, PlanId } from '@/lib/billing/plans'
+
+import { LIMIT_ENFORCEMENT } from '@/lib/billing/plan-enforcement'
+import { BILLING_PLAN_LIST, getPlan, PLAN_IDS } from '@/lib/billing/plans'
+
+/** Dialog title per reason. */
+export const REASON_TITLES: Record<BillingLimitReason, string> = {
+  host: 'Host limit reached',
+  seat: 'Seat limit reached',
+  ai_daily: 'Daily AI limit reached',
+  ai_budget: 'Monthly AI budget reached',
+}
+
+/** Which numeric `Plan` field each reason measures. */
+const REASON_FIELD: Record<
+  BillingLimitReason,
+  'hosts' | 'seats' | 'aiRequestsPerDay' | 'aiMonthlyUsdBudget'
+> = {
+  host: 'hosts',
+  seat: 'seats',
+  ai_daily: 'aiRequestsPerDay',
+  ai_budget: 'aiMonthlyUsdBudget',
+}
+
+/** Which `LIMIT_ENFORCEMENT` key governs each reason (same fields, named for the registry). */
+const REASON_LIMIT_KEY: Record<BillingLimitReason, LimitKey> = REASON_FIELD
+
+/**
+ * Whether this reason's limit is actually gated (`enforced`) or advertised but
+ * free during beta (`deferred`) — the honest-paywall source of truth. Never
+ * hardcode this per reason; always read the registry so it can't drift from
+ * the real gates.
+ */
+export function enforcementForReason(reason: BillingLimitReason): Enforcement {
+  return LIMIT_ENFORCEMENT[REASON_LIMIT_KEY[reason]]
+}
+
+function isPlanId(value: string): value is PlanId {
+  return (PLAN_IDS as readonly string[]).includes(value)
+}
+
+/** Resolves a plan id from a 402 body defensively — unknown ids fall back to Free. */
+export function resolveCurrentPlan(planId: string): Plan {
+  return getPlan(isPlanId(planId) ? planId : 'free')
+}
+
+/** Compact cap label for the current-vs-next mini table, e.g. "3", "$5/mo", "Unlimited". */
+export function formatReasonCap(
+  reason: BillingLimitReason,
+  plan: Plan
+): string {
+  const value = plan[REASON_FIELD[reason]]
+  if (value === null) return 'Unlimited'
+  return reason === 'ai_budget' ? `$${value}/mo` : String(value)
+}
+
+/**
+ * First plan after `currentPlanId` (in free -> pro -> max -> enterprise order)
+ * whose cap for `reason` exceeds the current plan's cap. Null when the
+ * current plan is already the top tier for that metric (shouldn't happen in
+ * practice — Enterprise caps are all unlimited, so it never trips a 402).
+ */
+export function findNextTier(
+  currentPlanId: string,
+  reason: BillingLimitReason
+): Plan | null {
+  const field = REASON_FIELD[reason]
+  const currentIndex = BILLING_PLAN_LIST.findIndex(
+    (p) => p.id === currentPlanId
+  )
+  const safeIndex = currentIndex === -1 ? 0 : currentIndex
+  const currentValue = BILLING_PLAN_LIST[safeIndex][field]
+
+  for (let i = safeIndex + 1; i < BILLING_PLAN_LIST.length; i++) {
+    const candidateValue = BILLING_PLAN_LIST[i][field]
+    if (
+      candidateValue === null ||
+      (currentValue !== null && candidateValue > currentValue)
+    ) {
+      return BILLING_PLAN_LIST[i]
+    }
+  }
+  return null
+}
+
+export type UpgradeAction =
+  | { kind: 'checkout'; planId: 'pro' | 'max' }
+  | { kind: 'portal' }
+  | { kind: 'contact' }
+  | { kind: 'none' }
+
+/**
+ * Mirrors the CTA branching already on the /billing page
+ * (routes/(dashboard)/billing.tsx onCheckout/onPortal/mailto), so the
+ * paywall's "Upgrade" button never offers an action that would fail:
+ * - No next tier (already top plan for this metric) -> nothing to offer.
+ * - Next tier is Enterprise -> no self-serve checkout; "Contact us" (mailto).
+ * - Caller already has a paid plan -> a fresh Polar checkout errors ("already
+ *   has an active subscription"); route to the customer portal instead, which
+ *   prorates the plan change.
+ * - Otherwise (Free -> Pro/Max) -> start a checkout for the next tier.
+ */
+export function resolveUpgradeAction(
+  currentPlanId: string,
+  nextTier: Plan | null
+): UpgradeAction {
+  if (!nextTier) return { kind: 'none' }
+  if (nextTier.id === 'enterprise') return { kind: 'contact' }
+  if (currentPlanId !== 'free') return { kind: 'portal' }
+  return { kind: 'checkout', planId: nextTier.id as 'pro' | 'max' }
+}

--- a/apps/dashboard/src/components/billing/paywall-modal.test.tsx
+++ b/apps/dashboard/src/components/billing/paywall-modal.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Logic-only Bun tests for the paywall surface (plan 15). The modal component
+ * itself is a thin render of these pure functions + `classifyBillingLimit`
+ * (see error-classifier.ts) — no DOM rendering here, per this repo's
+ * convention of Bun for logic / Cypress for interaction.
+ */
+import { describe, expect, test } from 'bun:test'
+
+import { classifyBillingLimit } from '@/lib/api/error-handler/error-classifier'
+import {
+  enforcementForReason,
+  findNextTier,
+  formatReasonCap,
+  REASON_TITLES,
+  resolveCurrentPlan,
+  resolveUpgradeAction,
+} from './paywall-logic'
+
+describe('classifyBillingLimit', () => {
+  test('classifies the nested error-response-builder 402 shape (host limit)', () => {
+    const body = {
+      success: false,
+      error: {
+        message: 'Host limit reached (1/1). Upgrade to add more hosts.',
+        details: { reason: 'host_limit', planId: 'free', limit: 1 },
+      },
+    }
+    expect(classifyBillingLimit(402, body)).toEqual({
+      reason: 'host',
+      message: 'Host limit reached (1/1). Upgrade to add more hosts.',
+      planId: 'free',
+    })
+  })
+
+  test('classifies the flat agent-route 402 shape (ai_daily / ai_budget)', () => {
+    const daily = {
+      error: 'Daily AI limit reached (5/5).',
+      details: { reason: 'ai_daily_limit', planId: 'free' },
+    }
+    expect(classifyBillingLimit(402, daily)).toEqual({
+      reason: 'ai_daily',
+      message: 'Daily AI limit reached (5/5).',
+      planId: 'free',
+    })
+
+    const budget = {
+      error: 'Monthly AI budget reached ($5.00/$5.00).',
+      details: { reason: 'ai_budget_limit', planId: 'pro' },
+    }
+    expect(classifyBillingLimit(402, budget)).toEqual({
+      reason: 'ai_budget',
+      message: 'Monthly AI budget reached ($5.00/$5.00).',
+      planId: 'pro',
+    })
+  })
+
+  test('classifies seat_limit', () => {
+    const body = {
+      error: {
+        message: 'Seat limit reached.',
+        details: { reason: 'seat_limit', planId: 'pro' },
+      },
+    }
+    expect(classifyBillingLimit(402, body)?.reason).toBe('seat')
+  })
+
+  test('returns null for a 402 with an unrecognized reason (e.g. alert_rule_limit)', () => {
+    const body = {
+      error: {
+        message: 'nope',
+        details: { reason: 'alert_rule_limit', planId: 'free' },
+      },
+    }
+    expect(classifyBillingLimit(402, body)).toBeNull()
+  })
+
+  test('returns null for non-402 statuses regardless of body shape', () => {
+    const body = {
+      error: {
+        message: 'Host limit reached.',
+        details: { reason: 'host_limit', planId: 'free' },
+      },
+    }
+    expect(classifyBillingLimit(200, body)).toBeNull()
+    expect(classifyBillingLimit(500, body)).toBeNull()
+  })
+
+  test('returns null for malformed / unrelated bodies', () => {
+    expect(classifyBillingLimit(402, null)).toBeNull()
+    expect(classifyBillingLimit(402, {})).toBeNull()
+    expect(classifyBillingLimit(402, { error: 'Internal error' })).toBeNull()
+  })
+})
+
+describe('paywall-logic — honest enforced/deferred copy', () => {
+  test('all four reasons resolve a title', () => {
+    for (const reason of ['host', 'seat', 'ai_daily', 'ai_budget'] as const) {
+      expect(REASON_TITLES[reason]).toBeTruthy()
+    }
+  })
+
+  test('host/seat/ai_daily/ai_budget are all `enforced` per plan-enforcement.ts (hard CTA)', () => {
+    for (const reason of ['host', 'seat', 'ai_daily', 'ai_budget'] as const) {
+      expect(enforcementForReason(reason).status).toBe('enforced')
+    }
+  })
+
+  test('formatReasonCap renders Unlimited for null caps and $/mo for ai_budget', () => {
+    const enterprise = resolveCurrentPlan('enterprise')
+    expect(formatReasonCap('host', enterprise)).toBe('Unlimited')
+    const free = resolveCurrentPlan('free')
+    expect(formatReasonCap('ai_budget', free)).toBe('$0.5/mo')
+    expect(formatReasonCap('host', free)).toBe('1')
+  })
+
+  test('findNextTier walks free -> pro -> max -> enterprise per metric', () => {
+    const next = findNextTier('free', 'host')
+    expect(next?.id).toBe('pro')
+  })
+
+  test('resolveCurrentPlan falls back to free for an unknown planId', () => {
+    expect(resolveCurrentPlan('not-a-real-plan').id).toBe('free')
+  })
+
+  test('resolveUpgradeAction: free -> checkout for the next paid tier', () => {
+    const next = findNextTier('free', 'host')
+    expect(resolveUpgradeAction('free', next)).toEqual({
+      kind: 'checkout',
+      planId: 'pro',
+    })
+  })
+
+  test('resolveUpgradeAction: already-paid owner -> portal (fresh checkout would 4xx)', () => {
+    const next = findNextTier('pro', 'host')
+    expect(resolveUpgradeAction('pro', next)).toEqual({ kind: 'portal' })
+  })
+
+  test('resolveUpgradeAction: next tier is enterprise -> contact (no self-serve checkout)', () => {
+    expect(
+      resolveUpgradeAction('max', resolveCurrentPlan('enterprise'))
+    ).toEqual({
+      kind: 'contact',
+    })
+  })
+
+  test('resolveUpgradeAction: no next tier -> none', () => {
+    expect(resolveUpgradeAction('enterprise', null)).toEqual({ kind: 'none' })
+  })
+})

--- a/apps/dashboard/src/components/billing/paywall-modal.tsx
+++ b/apps/dashboard/src/components/billing/paywall-modal.tsx
@@ -1,0 +1,150 @@
+/**
+ * The upgrade paywall — replaces a raw 402 error toast with a conversion
+ * surface. Mounted once at the app shell (`components/billing/paywall-host.tsx`
+ * inside `DashboardShell`) and driven by the global paywall store
+ * (`lib/billing/paywall-store.ts`), which `apiFetch` populates whenever a
+ * request comes back with a classified billing-limit 402
+ * (`classifyBillingLimit`).
+ *
+ * Honest paywalls: the hard "Upgrade" CTA only renders when
+ * `plan-enforcement.ts` says the hit limit is actually `enforced` server-side
+ * (see `paywall-logic.ts:enforcementForReason`). A `deferred` limit shows
+ * beta-friendly copy instead — never a false "you must upgrade" claim.
+ */
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import type { BillingLimitReason } from '@/lib/api/error-handler/types'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { trackEvent } from '@/lib/analytics/analytics'
+import { openBillingPortal, startCheckout } from '@/lib/billing/use-billing'
+import {
+  enforcementForReason,
+  findNextTier,
+  formatReasonCap,
+  REASON_TITLES,
+  resolveCurrentPlan,
+  resolveUpgradeAction,
+} from './paywall-logic'
+
+export interface PaywallModalProps {
+  open: boolean
+  reason: BillingLimitReason
+  /** Human-readable upgrade nudge, echoed from the server's `limitMessage()`. */
+  message: string
+  currentPlanId: string
+  onClose: () => void
+}
+
+export function PaywallModal({
+  open,
+  reason,
+  message,
+  currentPlanId,
+  onClose,
+}: PaywallModalProps) {
+  const [busy, setBusy] = useState(false)
+  const currentPlan = resolveCurrentPlan(currentPlanId)
+  const nextTier = findNextTier(currentPlan.id, reason)
+  const enforcement = enforcementForReason(reason)
+  const action = resolveUpgradeAction(currentPlan.id, nextTier)
+  const showHardCta =
+    enforcement.status === 'enforced' && action.kind !== 'none'
+
+  async function onUpgrade() {
+    setBusy(true)
+    trackEvent('upgrade_click', {
+      plan_id: nextTier?.id ?? 'unknown',
+      source: `paywall_${reason}`,
+    })
+    try {
+      if (action.kind === 'checkout') {
+        await startCheckout(action.planId, 'monthly')
+        return // navigating away — leave `busy` true through the redirect
+      }
+      if (action.kind === 'portal') {
+        await openBillingPortal()
+        return
+      }
+    } catch (err) {
+      setBusy(false)
+      toast.error(
+        err instanceof Error ? err.message : 'Could not start checkout'
+      )
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose()
+      }}
+    >
+      <DialogContent className="sm:max-w-md" data-testid="paywall-modal">
+        <DialogHeader>
+          <DialogTitle>{REASON_TITLES[reason]}</DialogTitle>
+          <DialogDescription>{message}</DialogDescription>
+        </DialogHeader>
+
+        {nextTier && (
+          <div className="grid grid-cols-2 gap-3 rounded-lg border p-3 text-sm">
+            <div className="space-y-1">
+              <div className="text-muted-foreground">
+                {currentPlan.name} (current)
+              </div>
+              <div className="font-medium">
+                {formatReasonCap(reason, currentPlan)}
+              </div>
+            </div>
+            <div className="space-y-1">
+              <div className="text-muted-foreground">{nextTier.name}</div>
+              <div className="font-medium">
+                {formatReasonCap(reason, nextTier)}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {enforcement.status === 'deferred' && (
+          <p
+            className="text-muted-foreground text-sm"
+            data-testid="paywall-deferred-copy"
+          >
+            This limit isn&apos;t billed during early access —{' '}
+            {enforcement.reason}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Dismiss
+          </Button>
+          {showHardCta &&
+            (action.kind === 'contact' ? (
+              <Button asChild>
+                <a href="mailto:hello@chmonitor.dev">Contact us</a>
+              </Button>
+            ) : (
+              <Button
+                onClick={onUpgrade}
+                disabled={busy}
+                data-testid="paywall-upgrade-cta"
+              >
+                {busy ? 'Redirecting…' : `Upgrade to ${nextTier?.name}`}
+              </Button>
+            ))}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/dashboard/src/components/layout/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/layout/dashboard-shell.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react'
 import { AppSidebar } from '@/components/app-sidebar'
 import { GlobalAssistantModal } from '@/components/assistant-ui/global-assistant-modal'
+import { PaywallHost } from '@/components/billing/paywall-host'
 import { KeyboardShortcuts } from '@/components/controls/keyboard-shortcuts'
 import { HeaderActions } from '@/components/header/header-actions'
 import { Breadcrumb } from '@/components/navigation/breadcrumb'
@@ -65,6 +66,7 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
         </SidebarInset>
       </ResizableSidebarProvider>
       <GlobalAssistantModal />
+      <PaywallHost />
       <Toaster />
     </>
   )

--- a/apps/dashboard/src/lib/api/error-handler/error-classifier.ts
+++ b/apps/dashboard/src/lib/api/error-handler/error-classifier.ts
@@ -5,7 +5,7 @@
  * for consistent error handling across the API layer.
  */
 
-import type { ErrorClassification } from './types'
+import type { BillingLimitClassification, ErrorClassification } from './types'
 
 import { ApiErrorType } from '@/lib/api/types'
 
@@ -141,4 +141,91 @@ function matchesAnyKeyword(
   keywords: ReadonlyArray<string>
 ): boolean {
   return keywords.some((keyword) => message.includes(keyword))
+}
+
+/**
+ * Maps the server-side `LimitReason` (`lib/billing/entitlements.ts`) to the
+ * short client reason the PaywallModal renders. `alert_rule_limit` is
+ * deliberately absent — no route emits a 402 for it yet (see
+ * `lib/billing/plan-enforcement.ts`), so it falls through to `null`.
+ */
+const LIMIT_REASON_MAP: Record<string, BillingLimitReason> = {
+  host_limit: 'host',
+  seat_limit: 'seat',
+  ai_daily_limit: 'ai_daily',
+  ai_budget_limit: 'ai_budget',
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+/**
+ * A billing 402 body has shipped in two shapes so far, and this reads either
+ * without requiring the routes to agree on one:
+ *  - `createApiErrorResponse` (routes/api/v1/user-connections.ts): nested
+ *    `{ error: { message, details: { reason, planId } } }`.
+ *  - the agent route's raw `Response` (routes/api/v1/agent.ts): flat
+ *    `{ error: <message string>, details: { reason, planId } }`.
+ * Returns the raw (long-form) reason string, unmapped — callers translate it.
+ */
+function extractLimitFields(
+  body: unknown
+): { rawReason: string; message?: string; planId?: string } | null {
+  if (!isRecord(body)) return null
+
+  // Nested shape: error is itself an object carrying message + details.
+  if (isRecord(body.error)) {
+    const details = body.error.details
+    const rawReason = isRecord(details) ? details.reason : undefined
+    if (typeof rawReason !== 'string') return null
+    return {
+      rawReason,
+      message:
+        typeof body.error.message === 'string' ? body.error.message : undefined,
+      planId:
+        isRecord(details) && typeof details.planId === 'string'
+          ? details.planId
+          : undefined,
+    }
+  }
+
+  // Flat shape: error is the message string itself; details sits at the top.
+  const details = body.details
+  const rawReason = isRecord(details) ? details.reason : undefined
+  if (typeof rawReason !== 'string') return null
+  return {
+    rawReason,
+    message: typeof body.error === 'string' ? body.error : undefined,
+    planId:
+      isRecord(details) && typeof details.planId === 'string'
+        ? details.planId
+        : undefined,
+  }
+}
+
+/**
+ * Classifies a fetch response's status + parsed JSON body as a billing-limit
+ * 402, for the global PaywallModal (see `components/billing/paywall-modal.tsx`).
+ * Returns `null` for anything else — non-402s, and 402s that aren't a
+ * recognized billing-limit shape (e.g. a future `alert_rule_limit`) — so the
+ * caller's existing error handling stays untouched for everything else.
+ */
+export function classifyBillingLimit(
+  status: number,
+  body: unknown
+): BillingLimitClassification | null {
+  if (status !== 402) return null
+
+  const fields = extractLimitFields(body)
+  if (!fields) return null
+
+  const reason = LIMIT_REASON_MAP[fields.rawReason]
+  if (!reason) return null
+
+  return {
+    reason,
+    message: fields.message || "You've hit a plan limit. Upgrade for more.",
+    planId: fields.planId || 'free',
+  }
 }

--- a/apps/dashboard/src/lib/api/error-handler/error-classifier.ts
+++ b/apps/dashboard/src/lib/api/error-handler/error-classifier.ts
@@ -5,7 +5,11 @@
  * for consistent error handling across the API layer.
  */
 
-import type { BillingLimitClassification, ErrorClassification } from './types'
+import type {
+  BillingLimitClassification,
+  BillingLimitReason,
+  ErrorClassification,
+} from './types'
 
 import { ApiErrorType } from '@/lib/api/types'
 

--- a/apps/dashboard/src/lib/api/error-handler/index.ts
+++ b/apps/dashboard/src/lib/api/error-handler/index.ts
@@ -24,6 +24,8 @@
 // Re-export all types
 export type {
   ApiHandler,
+  BillingLimitClassification,
+  BillingLimitReason,
   ErrorClassification,
   ErrorDetails,
   RouteContext,
@@ -31,7 +33,7 @@ export type {
 } from './types'
 
 // Export error classifier functions
-export { classifyError } from './error-classifier'
+export { classifyBillingLimit, classifyError } from './error-classifier'
 // Export error response builder functions
 export {
   createErrorResponse,

--- a/apps/dashboard/src/lib/api/error-handler/types.ts
+++ b/apps/dashboard/src/lib/api/error-handler/types.ts
@@ -67,6 +67,24 @@ export interface ErrorClassification {
 }
 
 /**
+ * Machine-readable reason for a billing-limit 402, surfaced to the
+ * PaywallModal. Short form of the server-side `LimitReason`
+ * (`lib/billing/entitlements.ts`) — `classifyBillingLimit` maps
+ * `host_limit`/`seat_limit`/`ai_daily_limit`/`ai_budget_limit` onto these four
+ * values. `alert_rule_limit` has no client reason (no 402 emits it yet).
+ */
+export type BillingLimitReason = 'host' | 'seat' | 'ai_daily' | 'ai_budget'
+
+/** Result of classifying a 402 response body as a billing-limit hit. */
+export interface BillingLimitClassification {
+  readonly reason: BillingLimitReason
+  /** Human-readable upgrade nudge (from the gate's `limitMessage()` call). */
+  readonly message: string
+  /** Billing owner's current plan id, e.g. 'free' — echoed by every gate. */
+  readonly planId: string
+}
+
+/**
  * HTTP status code mapping
  */
 export interface StatusCodeMap {

--- a/apps/dashboard/src/lib/billing/paywall-store.ts
+++ b/apps/dashboard/src/lib/billing/paywall-store.ts
@@ -1,0 +1,64 @@
+/**
+ * Paywall store — a tiny external store that lets `apiFetch` (a plain
+ * function, outside the React tree) trigger the global PaywallModal from
+ * anywhere a 402 billing-limit response is read.
+ *
+ * Same shape as other global singletons in this codebase (e.g. sonner's
+ * `toast()`): a module-level snapshot + listener set, read reactively via
+ * `useSyncExternalStore` in `usePaywall()` (components/billing/paywall-host.tsx).
+ *
+ * Fail-open by construction: this store only ever changes state when
+ * `showPaywall()` is called, which only happens when `apiFetch` classifies a
+ * real 402 billing-limit body (`classifyBillingLimit`). No 402 without Clerk
+ * (see `lib/billing/entitlements.ts`) means this never fires on OSS/self-host.
+ */
+import type { BillingLimitClassification } from '@/lib/api/error-handler/types'
+
+export interface PaywallState {
+  open: boolean
+  reason: BillingLimitClassification['reason'] | null
+  message: string
+  planId: string
+}
+
+const INITIAL_STATE: PaywallState = {
+  open: false,
+  reason: null,
+  message: '',
+  planId: 'free',
+}
+
+let state: PaywallState = INITIAL_STATE
+const listeners = new Set<() => void>()
+
+function emit(): void {
+  for (const listener of listeners) listener()
+}
+
+/** Opens the modal for a classified billing-limit hit. */
+export function showPaywall(classification: BillingLimitClassification): void {
+  state = { open: true, ...classification }
+  emit()
+}
+
+/** Closes the modal. The last reason/message/planId are kept (not reset) so
+ * the close animation doesn't flash empty content. */
+export function hidePaywall(): void {
+  if (!state.open) return
+  state = { ...state, open: false }
+  emit()
+}
+
+export function subscribePaywall(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function getPaywallSnapshot(): PaywallState {
+  return state
+}
+
+/** SSR/prerender snapshot — always closed; the store never mutates server-side. */
+export function getPaywallServerSnapshot(): PaywallState {
+  return INITIAL_STATE
+}

--- a/apps/dashboard/src/lib/swr/api-fetch.ts
+++ b/apps/dashboard/src/lib/swr/api-fetch.ts
@@ -1,3 +1,24 @@
+import { classifyBillingLimit } from '@/lib/api/error-handler/error-classifier'
+import { showPaywall } from '@/lib/billing/paywall-store'
+
+/**
+ * Reads a cloned 402 response body and, when it's a recognized billing-limit
+ * shape, opens the global PaywallModal. Best-effort and silent: a malformed
+ * body just means nothing to classify — the caller's own error handling
+ * (`throwIfNotOk` et al.) still runs unaffected since it reads the original,
+ * unconsumed response.
+ */
+async function maybeTriggerPaywall(response: Response): Promise<void> {
+  if (typeof window === 'undefined') return
+  try {
+    const body: unknown = await response.json()
+    const classification = classifyBillingLimit(response.status, body)
+    if (classification) showPaywall(classification)
+  } catch {
+    // Not JSON, or shape we don't recognize — nothing to classify.
+  }
+}
+
 /**
  * Fetch wrapper for first-party dashboard API calls (ported from the Next app).
  *
@@ -5,6 +26,12 @@
  * exceeded resource limits" page) so they surface as real errors rather than
  * being rendered as content. Framework-agnostic — used by the TanStack Query
  * hooks as the queryFn fetcher.
+ *
+ * Also the one chokepoint shared by every first-party request — plain
+ * TanStack Query hooks AND the AI agent's chat transport (which wraps this as
+ * its custom `fetch`, see agent-runtime-provider.tsx) — so it doubles as
+ * where a billing-limit 402 (host/seat/ai_daily/ai_budget) gets classified and
+ * routed to the global PaywallModal instead of surfacing as a raw error.
  */
 export async function apiFetch(
   input: RequestInfo | URL,
@@ -20,6 +47,14 @@ export async function apiFetch(
     contentType.includes('application/x-ndjson')
 
   if (response.ok && isStream) return response
+
+  if (
+    !response.ok &&
+    response.status === 402 &&
+    contentType.includes('application/json')
+  ) {
+    await maybeTriggerPaywall(response.clone())
+  }
 
   if (!response.ok && !isStream && contentType.includes('text/html')) {
     const bodyText = await response.clone().text()


### PR DESCRIPTION
## Summary

Implements plans/15-upgrade-paywall-modal.md. A 402 billing-limit response (host/seat/ai_daily/ai_budget) now opens a `PaywallModal` instead of surfacing as a raw error toast.

- **Classify** (`lib/api/error-handler/error-classifier.ts`): `classifyBillingLimit(status, body)` reads either 402 body shape in the app (nested `error.details.reason` from `createApiErrorResponse`, or the flat `error`/`details` shape from `agent.ts`) and maps the server's `LimitReason` (`host_limit`/`seat_limit`/`ai_daily_limit`/`ai_budget_limit`) onto a client `BillingLimitReason`. Unknown reasons (e.g. a future `alert_rule_limit`) and non-402s return `null`.
- **Wire** (`lib/swr/api-fetch.ts`): the one chokepoint shared by every first-party request (TanStack Query hooks + the AI agent's chat transport) classifies a 402 and calls `showPaywall()` on the new `lib/billing/paywall-store.ts` global store, instead of letting it fall through to the existing raw-error path.
- **Render** (`components/billing/paywall-modal.tsx` + `paywall-host.tsx`): title per reason, a current-vs-next-tier mini table for the hit metric (from `@chm/pricing` via `lib/billing/plans.ts`), and an Upgrade/Contact/Manage-billing CTA — mirroring the exact branching already used on `/billing` (fresh checkout for Free→paid, customer portal for an existing subscriber, mailto for Enterprise). Mounted once in `DashboardShell` next to `<Toaster />`.
- **Logic split** (`components/billing/paywall-logic.ts`): pure, Bun-testable functions — `enforcementForReason`, `findNextTier`, `formatReasonCap`, `resolveUpgradeAction`, `resolveCurrentPlan` — kept out of the component so behavior is testable without rendering.

### Honest-paywall invariant (evidence)

The hard "Upgrade" CTA only renders when `lib/billing/plan-enforcement.ts` marks the hit `LimitKey` as `enforced`. Current registry state for all four reasons this modal handles:

| Reason | `LIMIT_ENFORCEMENT` key | Status |
|---|---|---|
| host | `hosts` | `enforced` — `user-connections.ts handlePost → checkHostLimit` |
| seat | `seats` | `enforced` — `webhooks/clerk.ts organizationMembership.created → checkSeatLimit` |
| ai_daily | `aiRequestsPerDay` | `enforced` — `agent.ts handlePost → checkAiDailyLimit` |
| ai_budget | `aiMonthlyUsdBudget` | `enforced` — `agent.ts handlePost → checkAiBudget` + `meterAiOverage` |

All four are `enforced` today, so the modal always shows the hard CTA for them. If any of these ever flips to `deferred`, `enforcementForReason()` reads the registry live — the modal renders "This limit isn't billed during early access" copy instead, with no hard CTA. Nothing here changes what's gated; this is UX-only, per the plan's invariant.

### Self-hosted / OSS invariant

No new gates were added. The modal is purely reactive to 402s that `entitlements.ts` already produces, which only fire when Clerk is configured (cloud mode). On OSS/self-hosted (no Clerk), no 402 of this shape is ever emitted, so `PaywallHost` renders `null` — zero behavior change, fail-open by construction.

## Verification

```
$ cd apps/dashboard && bun run type-check
$ tsc --noEmit
(clean, no output)

$ cd apps/dashboard && bun run build
$ vite build && tsc --noEmit
[prerender] ... (all routes) ...
(clean, no errors)

$ cd apps/dashboard && bun test src/components/billing/paywall-modal.test.tsx --isolate
bun test v1.3.14 (0d9b296a)
 15 pass
 0 fail
 27 expect() calls
Ran 15 tests across 1 file. [95.00ms]

$ bun run lint
$ biome lint .
Checked 2087 files in 1069ms. No fixes applied.
```

Note: found and fixed a pre-existing missing `BillingLimitReason` type import in `error-classifier.ts` (left over from the earlier classify/wire commits already on this branch) as part of getting type-check green.

## Test plan
- [x] `bun run type-check` — clean
- [x] `bun run build` (vite build + tsc) — clean, all routes prerender
- [x] `bun test src/components/billing/paywall-modal.test.tsx --isolate` — 15/15 pass
- [x] `bun run lint` — clean
- [ ] Manual: trip a host/seat/ai_daily/ai_budget 402 in a cloud-mode Clerk session and confirm the modal (not a toast) opens with correct caps + CTA

https://claude.ai/code/session_01XpfaNdJZh4Rtr6cQm4DYqa