### PR TITLE
fix(agent): polish tool-call chat rendering — stable streaming + collapsible rows

### DIFF
--- a/apps/dashboard/src/components/agents/chat/tool-output.tsx
+++ b/apps/dashboard/src/components/agents/chat/tool-output.tsx
@@ -4,7 +4,6 @@ import {
   ChevronDownIcon,
   ChevronRightIcon,
   DownloadIcon,
-  Loader2Icon,
   Maximize2Icon,
 } from 'lucide-react'
 
@@ -15,7 +14,7 @@ import type { QueryConfig } from '@/types/query-config'
 import { QueryInsightsCard } from './query-insights-card'
 import { isCloudflareWorkers } from '@chm/clickhouse-client/runtime/cloudflare-workers'
 import { getToolMetadata } from '@chm/mcp-server/data'
-import { type ComponentProps, useEffect, useState } from 'react'
+import { type ComponentProps, type ReactNode, useEffect, useState } from 'react'
 import { AdvisorRecommendationsPanel } from '@/components/agents/advisor-recommendations-panel'
 import { AgentChartRenderer } from '@/components/agents/agent-chart-renderer'
 import { AgentDataSources } from '@/components/agents/agent-data-sources'
@@ -35,6 +34,11 @@ import {
 } from '@/components/agents/ask-user-widget'
 import { DataTable } from '@/components/data-table/data-table'
 import { Badge } from '@/components/ui/badge'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
 import {
   Dialog,
   DialogContent,
@@ -235,7 +239,7 @@ function ExpandTableButton({
   )
 }
 
-export function renderToolOutput(output: unknown) {
+function renderStructuredOutput(output: unknown): ReactNode {
   if (output == null) return null
 
   const outputObj = output as Record<string, unknown>
@@ -391,10 +395,111 @@ export function renderToolOutput(output: unknown) {
     return <ResultTable rows={outputObj.rows as unknown[]} maxRows={100} />
   }
 
+  // No structured renderer matched → let the caller decide (raw JSON is shown
+  // via renderRawOutput, kept behind a collapsed "Response" disclosure).
+  return null
+}
+
+/**
+ * Raw fallback: the tool output as a JSON / text blob. Rendered only when no
+ * structured renderer matches, and kept behind a collapsed disclosure so it
+ * never clutters the row.
+ */
+function renderRawOutput(output: unknown): ReactNode {
   return (
     <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all font-mono text-xs text-muted-foreground">
       {typeof output === 'string' ? output : JSON.stringify(output, null, 2)}
     </pre>
+  )
+}
+
+/**
+ * Renders a tool output. Structured shapes (charts, tables, insight /
+ * diagnostic cards) render richly; anything else falls back to the raw JSON
+ * blob. `renderStructuredOutput` is the SINGLE source of truth for "is there a
+ * rich render?" — callers that must distinguish rich vs. raw call it directly
+ * (non-null ⇒ rich), so the render path and the disclosure decision never drift.
+ */
+export function renderToolOutput(output: unknown): ReactNode {
+  return renderStructuredOutput(output) ?? renderRawOutput(output)
+}
+
+/**
+ * Animated ellipsis — the single "in progress" motion for a running tool.
+ * Three dots pulse in a staggered wave; `bg-current` inherits the label colour.
+ */
+function AnimatedDots() {
+  return (
+    <span className="inline-flex items-center gap-0.5" aria-hidden>
+      {[0, 200, 400].map((delay) => (
+        <span
+          key={delay}
+          className="size-1 shrink-0 animate-pulse rounded-full bg-current"
+          style={{ animationDelay: `${delay}ms` }}
+        />
+      ))}
+    </span>
+  )
+}
+
+/**
+ * The one, unmistakable "Running…" acknowledgement — replaces the old scattered
+ * label + "Executing…" badge + body spinner with a single animated indicator.
+ */
+function RunningIndicator() {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs font-medium text-amber-600 dark:text-amber-400">
+      Running
+      <AnimatedDots />
+    </span>
+  )
+}
+
+/**
+ * Collapsed-by-default subsection inside an expanded tool row (Parameters / raw
+ * Response). Matches the reasoning + tool-group chevron and collapse animation.
+ */
+function RowDisclosure({
+  label,
+  count,
+  defaultOpen = false,
+  children,
+}: {
+  readonly label: string
+  readonly count?: number
+  readonly defaultOpen?: boolean
+  readonly children: ReactNode
+}) {
+  return (
+    <Collapsible defaultOpen={defaultOpen} className="group/disclosure">
+      <CollapsibleTrigger className="flex w-full items-center gap-1 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground">
+        <ChevronRightIcon className="size-3 shrink-0 transition-transform duration-200 group-data-[state=open]/disclosure:rotate-90" />
+        <span>{label}</span>
+        {count != null ? (
+          <span className="tabular-nums tracking-normal text-muted-foreground/60">
+            {count}
+          </span>
+        ) : null}
+      </CollapsibleTrigger>
+      <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
+        <div className="pt-1 pb-1.5">{children}</div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+/**
+ * Non-promoted tool output. Rich structured renders (ResultTable, charts,
+ * advisor recommendations) stay visible; a raw JSON blob collapses behind a
+ * "Response" disclosure so the row stays clean by default.
+ */
+function ToolResponse({ output }: { readonly output: unknown }) {
+  const structured = renderStructuredOutput(output)
+  if (structured != null) {
+    return <div className="pb-1">{structured}</div>
+  }
+  return (
+    <RowDisclosure label="Response">{renderRawOutput(output)}</RowDisclosure>
   )
 }
 
@@ -410,13 +515,19 @@ export function ToolCallPart({
   const hasOutput = part.state === 'output-available'
   const hasError = part.state === 'output-error'
   const shouldAutoExpand = isStreaming || hasError || isStarting
+  // A tool is "active" while its input is streaming in or it is executing —
+  // the whole window that shows the single animated "Running…" indicator.
+  const isActive = isStarting || isStreaming
   const [isExpanded, setIsExpanded] = useState(shouldAutoExpand)
 
   useEffect(() => {
     if (shouldAutoExpand) setIsExpanded(true)
   }, [shouldAutoExpand])
 
-  // Auto-collapse when the message finishes streaming and tool has output
+  // Collapse a finished row into tidy history only once the WHOLE turn is done
+  // (`isMessageStreaming` is the message-level streaming flag, not this tool's).
+  // Staying expanded until then keeps the active row + its output visible right
+  // through the assistant's final text, instead of collapsing mid-stream.
   useEffect(() => {
     if (!isMessageStreaming && hasOutput && !hasError && isExpanded) {
       const timer = setTimeout(() => setIsExpanded(false), 800)
@@ -430,6 +541,12 @@ export function ToolCallPart({
       .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
       .join(', ')
   })()
+
+  const inputParamCount =
+    part.input && typeof part.input === 'object'
+      ? Object.keys(part.input as Record<string, unknown>).length
+      : 0
+  const hasInputParams = inputParamCount > 0
 
   const toolParams = (() => {
     const tool = getToolMetadata(toolName)
@@ -479,17 +596,20 @@ export function ToolCallPart({
           <div
             className={cn(
               'size-1.5 shrink-0 rounded-full',
-              isStarting && 'animate-pulse bg-yellow-500',
-              isStreaming && 'animate-ping bg-yellow-400',
+              isActive && 'animate-pulse bg-amber-500',
               hasOutput && 'bg-emerald-500',
               hasError && 'bg-red-500'
             )}
           />
 
           <div className="flex min-w-0 items-center gap-1.5">
-            <span className="text-muted-foreground text-xs">
-              {hasError ? 'Failed' : hasOutput ? 'Ran' : 'Running'}
-            </span>
+            {isActive ? (
+              <RunningIndicator />
+            ) : (
+              <span className="text-muted-foreground text-xs">
+                {hasError ? 'Failed' : 'Ran'}
+              </span>
+            )}
             <span className="font-mono text-xs font-medium">{toolName}</span>
             {inputParams && (
               <span className="text-muted-foreground/70 truncate font-mono text-xs">
@@ -499,18 +619,10 @@ export function ToolCallPart({
           </div>
 
           <div className="ml-auto flex items-center gap-1.5">
-            {isStreaming && (
-              <Badge
-                variant="outline"
-                className="shrink-0 text-[10px] text-yellow-600"
-              >
-                Executing…
-              </Badge>
-            )}
             {hasOutput && (
               <Badge
                 variant="outline"
-                className="shrink-0 text-[10px] text-green-600"
+                className="shrink-0 text-[10px] text-emerald-600 dark:text-emerald-400"
               >
                 ✓ Done
               </Badge>
@@ -518,7 +630,7 @@ export function ToolCallPart({
             {hasError && (
               <Badge
                 variant="outline"
-                className="shrink-0 text-[10px] text-red-600"
+                className="shrink-0 text-[10px] text-red-600 dark:text-red-400"
               >
                 ✗ Failed
               </Badge>
@@ -548,45 +660,37 @@ export function ToolCallPart({
         )}
       </div>
 
-      {/* Expanded body — indented under the accent bar, no extra background */}
+      {/* Expanded body — indented under the accent bar, no extra background.
+          Clean by default: rich output stays visible, while the raw params
+          dump and raw JSON response collapse into opt-in disclosures. */}
       {isExpanded ? (
         <div className="pl-4 pt-1">
-          {isStreaming ? (
-            <div className="py-1.5">
-              <div className="flex items-center gap-2">
-                <Loader2Icon className="size-4 animate-spin text-yellow-500" />
-                <span className="text-xs text-muted-foreground">
-                  Executing {toolName}…
-                </span>
-              </div>
+          {hasError && Boolean(part.errorText) ? (
+            <div className="pb-1.5 text-sm text-destructive">
+              {String(part.errorText)}
             </div>
           ) : null}
 
+          {/* Output: the interactive ask-user widget and rich structured
+              renders stay visible; a raw JSON blob collapses behind "Response".
+              Promoted outputs render outside this block (always visible). */}
           {hasOutput && part.output != null && !promotedOutput ? (
-            <div className="pb-1">
-              {isAskUserOutput(part.output) && onToolResult ? (
+            isAskUserOutput(part.output) && onToolResult ? (
+              <div className="pb-1">
                 <AskUserWidget
                   output={part.output}
                   toolCallId={part.toolCallId}
                   onSubmit={onToolResult}
                 />
-              ) : (
-                renderToolOutput(part.output)
-              )}
-            </div>
-          ) : null}
-
-          {hasError && Boolean(part.errorText) ? (
-            <div className="py-1.5 text-sm text-destructive">
-              {String(part.errorText)}
-            </div>
-          ) : null}
-
-          {part.input && typeof part.input === 'object' ? (
-            <div className="border-t border-border/40 pt-2 pb-1.5">
-              <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-                Parameters
               </div>
+            ) : (
+              <ToolResponse output={part.output} />
+            )
+          ) : null}
+
+          {/* Parameters — collapsed by default so the row reads clean */}
+          {hasInputParams ? (
+            <RowDisclosure label="Parameters" count={inputParamCount}>
               <div className="space-y-1">
                 {Object.entries(part.input as Record<string, unknown>).map(
                   ([key, value]) => {
@@ -621,7 +725,7 @@ export function ToolCallPart({
                   }
                 )}
               </div>
-            </div>
+            </RowDisclosure>
           ) : null}
         </div>
       ) : null}

--- a/apps/dashboard/src/components/assistant-ui/-thread/chain-of-thought.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/chain-of-thought.tsx
@@ -20,6 +20,7 @@ import type {
 } from '@assistant-ui/react'
 import type { ReactNode } from 'react'
 
+import { useMessage } from '@assistant-ui/react'
 import { MarkdownText } from '@/components/assistant-ui/markdown-text'
 import {
   Reasoning,
@@ -102,6 +103,35 @@ function renderLeafPart(part: EnrichedPartState) {
 }
 
 /**
+ * A run of adjacent tool calls. Stays expanded while ANY tool in the run is
+ * still executing OR the message is still streaming its final answer, so the
+ * group never collapses mid-turn (before the assistant's final text lands). It
+ * folds into tidy history only once the whole turn is done. The trigger's own
+ * spinner keeps tracking the tools' status, not the message's.
+ *
+ * Reads `useMessage` here (not inside `renderGroupedPart`) because that render
+ * function is called per group in a switch — hooks must live in a component.
+ */
+function ToolGroup({
+  count,
+  status,
+  children,
+}: {
+  readonly count: number
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus
+  readonly children: ReactNode
+}) {
+  const toolsRunning = status?.type === 'running'
+  const messageRunning = useMessage((m) => m.status?.type === 'running')
+  return (
+    <ToolGroupRoot isRunning={toolsRunning || messageRunning}>
+      <ToolGroupTrigger count={count} status={status} />
+      <ToolGroupContent>{children}</ToolGroupContent>
+    </ToolGroupRoot>
+  )
+}
+
+/**
  * Renderer function for MessagePrimitive.GroupedParts.
  * Reasoning and tool runs render as separate sibling collapsibles whose open
  * state follows the run's `running` status; leaf parts delegate to
@@ -119,13 +149,10 @@ export function renderGroupedPart({ part, children }: GroupedRenderInfo) {
       )
     }
     case 'group-tool': {
-      const isRunning = part.status?.type === 'running'
-      const count = part.indices.length
       return (
-        <ToolGroupRoot isRunning={isRunning}>
-          <ToolGroupTrigger count={count} status={part.status} />
-          <ToolGroupContent>{children}</ToolGroupContent>
-        </ToolGroupRoot>
+        <ToolGroup count={part.indices.length} status={part.status}>
+          {children}
+        </ToolGroup>
       )
     }
     default: {

--- a/apps/dashboard/src/components/assistant-ui/tool-fallback.tsx
+++ b/apps/dashboard/src/components/assistant-ui/tool-fallback.tsx
@@ -2,6 +2,7 @@
 
 import type { ToolCallMessagePartComponent } from '@assistant-ui/react'
 
+import { useMessage } from '@assistant-ui/react'
 import {
   type AgentToolPart,
   ToolCallPart,
@@ -27,6 +28,9 @@ export const ToolFallback: ToolCallMessagePartComponent = ({
 }) => {
   const hasResult = result !== undefined && result !== null
   const isRunning = status?.type === 'running'
+  // Whether the whole assistant turn is still streaming (NOT just this tool).
+  // Drives the row's collapse-into-history so it waits for the final text.
+  const isMessageStreaming = useMessage((m) => m.status?.type === 'running')
 
   const state: AgentToolPart['state'] = isError
     ? 'output-error'
@@ -53,7 +57,7 @@ export const ToolFallback: ToolCallMessagePartComponent = ({
   return (
     <ToolCallPart
       part={part}
-      isMessageStreaming={isRunning}
+      isMessageStreaming={isMessageStreaming}
       onToolResult={(_toolCallId, value) => addResult(value)}
     />
   )


### PR DESCRIPTION
Improves the AI-agent chat's tool-call rendering so a streaming run reads cleanly and never collapses mid-turn. Three fixes, following the design system (shadcn `Collapsible`, OKLCH semantic tokens, the reasoning/tool-group chevron + collapse-animation language; no `components/ui/*` edits).

## 1 · Keep the tool group + active row expanded until the turn ends

**Before:** both the "N tool calls" group and the tool rows keyed their auto-collapse off *tool-level* status. When the tools finished but the assistant was still streaming its **final text**, the group (and each finished row) collapsed early — jarring mid-stream.

Root cause: `ToolFallback` passed `isMessageStreaming={isRunning}` where `isRunning` was the individual tool's status (mislabeled), and `renderGroupedPart` drove the group off `part.status` (any tool running). Both go false the instant the last tool returns.

**After:** collapse is gated on the **whole turn**, not the tool.
- `ToolFallback` now reads the real message-streaming flag (`useMessage((m) => m.status?.type === 'running')`) and passes it as `isMessageStreaming` — so a finished row only folds into history once the turn is done. The prop name is now accurate; no signature change.
- A new `ToolGroup` component (in `chain-of-thought.tsx`) keeps the group open while **any tool runs OR the message is still streaming** (`toolsRunning || messageRunning`). It hosts the `useMessage` hook because `renderGroupedPart` is a per-group render function, not a component. `ToolGroupRoot`'s existing controlled logic is unchanged — it just gets the correct combined signal. The trigger spinner still tracks the tools' own status (no false "running" during the final-text phase).

Same `message.status` signal already relied on by `json-render-message.tsx`; `useMessage` is in the Cloudflare SSR-stub allowlist (`vite.config.ts`).

## 2 · Per-row Parameters + Response are collapsible, collapsed by default

**Before:** an expanded row always dumped the full `Parameters` block (every arg) plus the raw response.

**After:** an expanded row is clean; detail is opt-in.
- **Parameters** → a collapsed-by-default `RowDisclosure` (shows the arg count inline, e.g. `Parameters 3`).
- **Raw JSON/text response** → a collapsed-by-default **Response** disclosure.
- **Promoted / rich outputs stay visible as-is** — charts, `ResultTable`, `QueryInsightsCard`, advisor + diagnostics panels, and the interactive `AskUserWidget`. Only the raw params dump and raw JSON blob collapse.

To avoid drift, `renderToolOutput` is split into **`renderStructuredOutput`** (the single source of truth for "is there a rich render?" — returns `null` when nothing structured matches) + **`renderRawOutput`** (the `<pre>` blob). `renderToolOutput = renderStructuredOutput(x) ?? renderRawOutput(x)` — identical external behavior. The new `ToolResponse` uses `renderStructuredOutput` directly (non-null ⇒ render rich; null ⇒ raw goes behind the disclosure), so the render path and the disclosure decision can never disagree.

## 3 · One clear, animated "Running…" indicator

**Before:** three redundant running signals — the row label said `Running`, a badge said `Executing…`, and the expanded body said `Executing {tool}…` with a spinner.

**After:** a single animated `RunningIndicator` in the row header (amber status dot + "Running" + a staggered animated-dots ellipsis). The `Executing…` badge and the body spinner block are removed. The `✓ Done` / `✗ Failed` states are kept (aligned to emerald + dark-mode variants to match the status dot).

---

## Verification

- **Type-check delta: 0.** `bun run type-check` and `bun run type-check:test` (both part of the required `dashboard` check) each report **228 → 228** with the change. All 228 are pre-existing `routeTree.gen.ts` / route-id artifacts (that file is gitignored and generated by CI before type-check); none touch the changed files.
- Biome clean on all three files.
- **Visual QA is pending** — the agent chat needs a live authenticated streaming run, which can't be exercised here. Please eyeball the checklist below.

## UX decisions a reviewer should eyeball

- **Multi-group turns:** because the group stays open while the message streams, *earlier* tool groups in a turn also stay open until the whole turn ends (not just their own work). This matches the intent ("until the FINAL text response arrives") but is worth a look.
- **Multi-tool streams + non-promoted rich output:** a plain array → `ResultTable` renders directly (not behind the Response disclosure, per "keep rich output visible"), so during a multi-tool stream you may see **stacked tables**. If that reads heavy, the fallback is per-row collapse (tidy one-liners) with the group fix alone — a small follow-up, not this PR.
- **Running color:** amber (chosen over the tool-group's orange so it doesn't clash with the emerald `Done` / red `Failed` status dots); animated dots chosen over a spinner to avoid a generic look and match the dot-based status language.
- **Promoted outputs still collapse with the group at turn-end** — existing behavior this change *delays* (not introduces). Worth confirming the chart "fold" as the turn completes reads OK; moving promoted outputs outside the group would be a separate change.

## Suggested live QA checklist

1. Group + active row stay expanded through the assistant's **final text**, then collapse.
2. An **ask_user** widget stays visible while awaiting input (confirms `message.status` stays `running` through a tool-await pause).
3. Expanded rows read clean; Parameters/Response expand on click; charts/tables/insight cards remain visible without expanding.
4. Running state shows exactly one animated "Running…"; `✓ Done` / `✗ Failed` unchanged.

## Files

- `components/assistant-ui/tool-fallback.tsx` — pass real message-streaming status.
- `components/assistant-ui/-thread/chain-of-thought.tsx` — `ToolGroup` component (combined keep-open signal).
- `components/agents/chat/tool-output.tsx` — `RowDisclosure` / `ToolResponse` / `RunningIndicator` / `AnimatedDots`; `renderToolOutput` split.

`components/assistant-ui/tool-group.tsx` was reviewed but needs no change — its controlled `isRunning` logic just needed the correct signal.
