### PR TITLE
feat(slack): native Slack app with OAuth, slash commands, Home tab, ACK buttons (plan 37)

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -219,6 +219,22 @@ CHM_USER_CONNECTIONS_ENCRYPTION_KEY=
 # "Deployments") → Secret. Optional: unset means no deploy markers are
 # ingested/shown (see lib/deployments/, plans/45-github-deploy-correlation.md).
 # GITHUB_WEBHOOK_SECRET=
+# Native Slack app (OPTIONAL — plan 37, docs/content/guide/guides/slack-app.mdx).
+# Unset = the Slack app is off; every /api/v1/slack/* route fails closed and
+# nothing else changes. Create a Slack app from docs/slack/manifest.yml, then:
+#   SLACK_CLIENT_ID     — non-secret, from the app's Basic Information.
+#   SLACK_CLIENT_SECRET — SECRET, exchanges the OAuth code for a bot token.
+#   SLACK_SIGNING_SECRET — SECRET, verifies inbound requests + derives the
+#     at-rest bot-token encryption key. Required for the app to function.
+# OAuth redirect URL to register in Slack: <your-origin>/api/v1/slack/oauth
+# (override with SLACK_OAUTH_REDIRECT_URL if the derived origin is wrong).
+# SLACK_CLIENT_ID=
+# SLACK_CLIENT_SECRET=
+# SLACK_SIGNING_SECRET=
+# SLACK_OAUTH_REDIRECT_URL=
+# Optional dedicated 32-byte base64 key to encrypt stored bot tokens
+# independently of the signing secret (else derived from it).
+# SLACK_TOKEN_ENCRYPTION_KEY=
 # Bearer token guarding the server-to-server agent API (/api/v1/agent).
 AGENT_API_TOKEN=
 # Shared secrets for proxy / trusted-header auth (see above).

--- a/apps/dashboard/src/db/conversations-migrations/0015_slack_installations.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0015_slack_installations.sql
@@ -1,0 +1,45 @@
+-- Native Slack app (plans/37-slack-app-native-oauth.md).
+-- Lives in the shared CHM_CLOUD_D1 database alongside the other cloud/insights
+-- backends (conversations, alert_events, github_deployments). Both tables are
+-- optional: with no Slack app configured (the OSS/self-hosted default) they are
+-- simply never written to, and the feature stays off.
+
+-- One row per installed Slack workspace. The bot token is stored ENCRYPTED
+-- (AES-256-GCM, see lib/slack/token-crypto.ts) — never in the clear.
+CREATE TABLE IF NOT EXISTS slack_installations (
+  team_id         TEXT PRIMARY KEY,   -- Slack workspace id (T…)
+  team_name       TEXT,               -- workspace display name (for the UI)
+  bot_token_enc   TEXT NOT NULL,      -- encrypted xoxb- token (base64 envelope)
+  bot_user_id     TEXT,               -- the app's bot user id (U…)
+  scope           TEXT,               -- granted OAuth scopes (comma list)
+  authed_user_id  TEXT,               -- Slack user who performed the install
+  -- owner_ref binds the install to a chmonitor owner (Clerk user/org id in
+  -- cloud mode) or 'default' for single-tenant OSS installs — mirrors the
+  -- owner_scope precedent in github_deployments.
+  owner_ref       TEXT NOT NULL DEFAULT 'default',
+  installed_at    INTEGER NOT NULL,   -- unix ms
+  updated_at      INTEGER NOT NULL    -- unix ms
+);
+
+CREATE INDEX IF NOT EXISTS idx_slack_installations_owner
+  ON slack_installations (owner_ref);
+
+-- Minimal alert-acknowledgement store. An ACK button on a pushed alert writes
+-- one row here keyed by the alert's dedup key (host:rule[:severity]). This is a
+-- deliberately minimal, generic ACK primitive — roadmap 29 (alert ACK / manual
+-- resolution) owns the fuller state model; when it lands, its store should
+-- SUBSUME this table rather than the sweep growing a parallel one. Kept
+-- Slack-agnostic (actor + source) so it can be reused, not Slack-only.
+CREATE TABLE IF NOT EXISTS alert_acks (
+  ack_key       TEXT PRIMARY KEY,   -- alert dedup key, e.g. "0:failed-mutations:critical"
+  host_id       INTEGER,
+  rule_id       TEXT,
+  severity      TEXT,
+  acked_by      TEXT NOT NULL,      -- actor id (Slack user id, or a chmonitor user id)
+  acked_by_name TEXT,               -- display name, when known
+  source        TEXT NOT NULL,      -- where the ACK came from ('slack' | …)
+  acked_at      INTEGER NOT NULL    -- unix ms
+);
+
+CREATE INDEX IF NOT EXISTS idx_alert_acks_host
+  ON alert_acks (host_id, acked_at);

--- a/apps/dashboard/src/lib/health/alert-ack-store.ts
+++ b/apps/dashboard/src/lib/health/alert-ack-store.ts
@@ -1,0 +1,124 @@
+/**
+ * Minimal alert-acknowledgement store (D1).
+ *
+ * Records that a firing alert was acknowledged by an actor (initially: a Slack
+ * user clicking the "Acknowledge" button on a pushed alert — plans/37). One row
+ * per alert dedup key (`host:rule[:severity]`), in the shared `CHM_CLOUD_D1`
+ * database (`alert_acks` table, 0015 migration).
+ *
+ * DELIBERATELY MINIMAL. Roadmap 29 (alert ACK / manual resolution) owns the
+ * fuller ACK state model — including feeding back into the sweep's dedup so an
+ * acked condition suppresses reminders. This store does NOT touch
+ * `alert-state-store.ts`; wiring that coupling here would be inventing a
+ * parallel state store (explicitly called out as drift in the plan). When
+ * roadmap 29 lands it should SUBSUME this table. Kept source-agnostic (`source`
+ * column) so it is not Slack-only.
+ *
+ * Best-effort like the sibling health/insights D1 backends: a missing binding
+ * (OSS default with no D1) or any error is caught, logged, and resolved to
+ * false/null — never thrown.
+ */
+
+import { ErrorLogger } from '@chm/logger'
+import { getPlatformBindings } from '@chm/platform'
+
+const warn = (msg: string) =>
+  ErrorLogger.logWarning(`[alert-ack-store] ${msg}`, {
+    component: 'alert-ack-store',
+  })
+
+const TABLE = 'alert_acks'
+
+function getDb(): D1Database | null {
+  return getPlatformBindings().getD1Database('CHM_CLOUD_D1')
+}
+
+export interface AlertAck {
+  /** Stable dedup key for the alert, e.g. "0:failed-mutations:critical". */
+  ackKey: string
+  hostId?: number | null
+  ruleId?: string | null
+  severity?: string | null
+  /** Actor id (e.g. a Slack user id). */
+  ackedBy: string
+  ackedByName?: string | null
+  /** Where the ACK originated, e.g. 'slack'. */
+  source: string
+  /** Unix ms. */
+  ackedAt: number
+}
+
+interface D1AckRow {
+  ack_key: string
+  host_id: number | null
+  rule_id: string | null
+  severity: string | null
+  acked_by: string
+  acked_by_name: string | null
+  source: string
+  acked_at: number
+}
+
+/**
+ * Record an acknowledgement. Idempotent per `ack_key` (a repeated click / a
+ * re-ack updates the actor + timestamp in place). Returns false on any failure
+ * — never throws.
+ */
+export async function recordAlertAck(ack: AlertAck): Promise<boolean> {
+  try {
+    const db = getDb()
+    if (!db) return false
+    await db
+      .prepare(
+        `INSERT INTO ${TABLE}
+           (ack_key, host_id, rule_id, severity, acked_by, acked_by_name, source, acked_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+         ON CONFLICT (ack_key) DO UPDATE SET
+           acked_by = excluded.acked_by,
+           acked_by_name = excluded.acked_by_name,
+           source = excluded.source,
+           acked_at = excluded.acked_at`
+      )
+      .bind(
+        ack.ackKey,
+        ack.hostId ?? null,
+        ack.ruleId ?? null,
+        ack.severity ?? null,
+        ack.ackedBy,
+        ack.ackedByName ?? null,
+        ack.source,
+        ack.ackedAt
+      )
+      .run()
+    return true
+  } catch (err) {
+    warn(`failed to record ack ${ack.ackKey}: ${err}`)
+    return false
+  }
+}
+
+/** Look up an acknowledgement by key, or null if none / on failure. */
+export async function getAlertAck(ackKey: string): Promise<AlertAck | null> {
+  try {
+    const db = getDb()
+    if (!db) return null
+    const row = await db
+      .prepare(`SELECT * FROM ${TABLE} WHERE ack_key = ?1`)
+      .bind(ackKey)
+      .first<D1AckRow>()
+    if (!row) return null
+    return {
+      ackKey: row.ack_key,
+      hostId: row.host_id,
+      ruleId: row.rule_id,
+      severity: row.severity,
+      ackedBy: row.acked_by,
+      ackedByName: row.acked_by_name,
+      source: row.source,
+      ackedAt: row.acked_at,
+    }
+  } catch (err) {
+    warn(`failed to get ack ${ackKey}: ${err}`)
+    return null
+  }
+}

--- a/apps/dashboard/src/lib/health/server-sweep.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.ts
@@ -29,6 +29,8 @@ import {
 } from '@/lib/alerting/compound-rules'
 import { classifyValue, ruleRegistry } from '@/lib/alerting/rule-registry'
 import { generateInsights } from '@/lib/insights/generate-insights'
+import { buildAlertBlocksWithAck, type SlackBlock } from '@/lib/slack/blocks'
+import { isSlackAppConfigured } from '@/lib/slack/config'
 
 // Register pluggable alert rules into the global ruleRegistry once at module
 // load. The sweep drives itself from `ruleRegistry.getAll()`; the /health page
@@ -166,15 +168,28 @@ interface WebhookResult {
  * `/api/v1/health/webhook` proxy forwards upstream (`{ text, content: text }`),
  * so Slack (`text`) and Discord (`content`) both render it. Server-side, no CORS
  * proxy needed — we post directly to the operator-configured webhook URL.
+ *
+ * When `blocks` is provided (only for a Slack incoming webhook with the native
+ * Slack app configured — see the call site) it is added to the body so Slack
+ * renders the rich message with an "Acknowledge" button; `text` stays as the
+ * notification fallback and Discord/others ignore the extra field. Absent
+ * `blocks`, the body is byte-for-byte the original `{ text, content }` — the
+ * OSS/self-hosted path is unchanged.
  */
-async function postWebhook(url: string, text: string): Promise<WebhookResult> {
+async function postWebhook(
+  url: string,
+  text: string,
+  blocks?: unknown[]
+): Promise<WebhookResult> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), 10_000)
   try {
     const res = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text, content: text }),
+      body: JSON.stringify(
+        blocks ? { text, content: text, blocks } : { text, content: text }
+      ),
       signal: controller.signal,
     })
     if (!res.ok) {
@@ -363,7 +378,37 @@ export async function runHealthSweep(): Promise<SweepSummary> {
 
       let anyDelivered = false
       for (const url of targets) {
-        const result = await postWebhook(url, text)
+        const adapter = detectAdapter(url)
+
+        // Native Slack app bridge (plan 37): when the app is configured AND
+        // this target is a Slack incoming webhook, post rich blocks with an
+        // "Acknowledge" button (keyed by this alert's dedup key) instead of
+        // plain text. Gated so the OSS default (no Slack app) and non-Slack
+        // channels keep the exact plain-text payload. Recovery messages have
+        // nothing to acknowledge, so they stay plain text too.
+        let ackBlocks: SlackBlock[] | undefined
+        if (
+          decision.kind !== 'recovery' &&
+          (effective === 'warning' || effective === 'critical') &&
+          isSlackAppConfigured() &&
+          adapter.id === 'slack'
+        ) {
+          ackBlocks = buildAlertBlocksWithAck(
+            {
+              severity: effective,
+              hostLabel: name,
+              hostId,
+              metric: ruleId,
+              value,
+              title: ruleTitle,
+              label,
+              timestamp: new Date().toISOString(),
+            },
+            { hostId, ruleId, severity: effective }
+          )
+        }
+
+        const result = await postWebhook(url, text, ackBlocks)
         if (result.ok) anyDelivered = true
 
         // Best-effort audit trail per channel — recorded on both success and
@@ -383,7 +428,7 @@ export async function runHealthSweep(): Promise<SweepSummary> {
               value,
               delivered: result.ok,
               error: result.error,
-              channel: detectAdapter(url).id,
+              channel: adapter.id,
             })
           )
         } catch (err) {

--- a/apps/dashboard/src/lib/slack/api.ts
+++ b/apps/dashboard/src/lib/slack/api.ts
@@ -14,10 +14,11 @@
  * codes only, never request bodies or Authorization headers.
  */
 
+import type { SlackBlock, SlackHomeView } from './blocks'
+
+import { SLACK_API_BASE } from './config'
 import { error as logError } from '@chm/logger'
 import { validateHostUrl } from '@/lib/browser-connections/host-url'
-import { SLACK_API_BASE } from './config'
-import type { SlackBlock, SlackHomeView } from './blocks'
 
 const FETCH_TIMEOUT_MS = 10_000
 

--- a/apps/dashboard/src/lib/slack/api.ts
+++ b/apps/dashboard/src/lib/slack/api.ts
@@ -1,0 +1,183 @@
+/**
+ * Slack Web API transport (plans/37).
+ *
+ * The only outbound calls the Slack app makes. Two classes of destination:
+ *  - FIXED first-party hosts we construct ourselves (`slack.com/api/*`) for the
+ *    OAuth token exchange and `views.publish` — not attacker-influenced.
+ *  - The `response_url` carried IN a Slack interaction payload. That URL is
+ *    attacker-influenceable, so before fetching it we (1) require its host to be
+ *    Slack-owned (`hooks.slack.com`) and (2) additionally run it through the
+ *    shared SSRF guard (`validateHostUrl`) as belt-and-suspenders. This is the
+ *    plan's SSRF invariant.
+ *
+ * SECURITY: tokens are NEVER logged. Errors log status codes / Slack `error`
+ * codes only, never request bodies or Authorization headers.
+ */
+
+import { error as logError } from '@chm/logger'
+import { validateHostUrl } from '@/lib/browser-connections/host-url'
+import { SLACK_API_BASE } from './config'
+import type { SlackBlock, SlackHomeView } from './blocks'
+
+const FETCH_TIMEOUT_MS = 10_000
+
+/** Slack OAuth `oauth.v2.access` success shape (subset we persist). */
+export interface SlackOAuthAccessResult {
+  ok: boolean
+  error?: string
+  access_token?: string
+  token_type?: string
+  scope?: string
+  bot_user_id?: string
+  app_id?: string
+  team?: { id?: string; name?: string } | null
+  authed_user?: { id?: string } | null
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit
+): Promise<Response> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    return await fetch(url, { ...init, signal: controller.signal })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+/**
+ * Exchange an OAuth `code` for a workspace bot token via `oauth.v2.access`.
+ * Posts to the fixed `slack.com` host. Returns the parsed result; callers must
+ * check `.ok` before trusting `.access_token`. Never throws on a Slack-level
+ * error (returns `{ ok: false, error }`); only a network failure rejects.
+ */
+export async function exchangeOAuthCode(params: {
+  clientId: string
+  clientSecret: string
+  code: string
+  redirectUri: string
+}): Promise<SlackOAuthAccessResult> {
+  const body = new URLSearchParams({
+    client_id: params.clientId,
+    client_secret: params.clientSecret,
+    code: params.code,
+    redirect_uri: params.redirectUri,
+  })
+
+  const res = await fetchWithTimeout(`${SLACK_API_BASE}/oauth.v2.access`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  })
+
+  const json = (await res
+    .json()
+    .catch(() => null)) as SlackOAuthAccessResult | null
+  if (!json) return { ok: false, error: 'invalid_json_from_slack' }
+  return json
+}
+
+/**
+ * Publish a Home tab view for a user via `views.publish`. Uses the workspace
+ * bot token. Best-effort: logs and returns false on any failure.
+ */
+export async function publishHomeView(params: {
+  botToken: string
+  userId: string
+  view: SlackHomeView
+}): Promise<boolean> {
+  try {
+    const res = await fetchWithTimeout(`${SLACK_API_BASE}/views.publish`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        Authorization: `Bearer ${params.botToken}`,
+      },
+      body: JSON.stringify({ user_id: params.userId, view: params.view }),
+    })
+    const json = (await res.json().catch(() => null)) as {
+      ok?: boolean
+      error?: string
+    } | null
+    if (!json?.ok) {
+      logError(
+        '[slack-api] views.publish failed',
+        new Error(json?.error ?? `status ${res.status}`)
+      )
+      return false
+    }
+    return true
+  } catch (err) {
+    logError('[slack-api] views.publish exception', err)
+    return false
+  }
+}
+
+/**
+ * Assert a Slack `response_url` is genuinely Slack-owned before we fetch it.
+ * Slack always issues `response_url` values on `hooks.slack.com`. Rejecting
+ * anything else stops a forged interaction payload from turning this into an
+ * SSRF/arbitrary-POST primitive.
+ */
+export function isSlackResponseUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'https:') return false
+    return (
+      parsed.hostname === 'hooks.slack.com' ||
+      parsed.hostname.endsWith('.slack.com')
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * POST a message body to an interaction `response_url` (e.g. to replace the
+ * original alert message after an ACK). Double-guarded: Slack-host allowlist
+ * THEN the shared SSRF guard. Best-effort: logs and returns false on any
+ * failure or a non-Slack URL.
+ */
+export async function postToResponseUrl(
+  responseUrl: string,
+  body: { replace_original?: boolean; text?: string; blocks?: SlackBlock[] }
+): Promise<boolean> {
+  if (!isSlackResponseUrl(responseUrl)) {
+    logError(
+      '[slack-api] refusing non-Slack response_url',
+      new Error('response_url host is not Slack-owned')
+    )
+    return false
+  }
+  // Belt-and-suspenders: also run the shared SSRF guard (blocks private /
+  // metadata targets even if a *.slack.com name somehow resolved internally).
+  const ssrfError = await validateHostUrl(responseUrl)
+  if (ssrfError) {
+    logError(
+      '[slack-api] response_url blocked by SSRF guard',
+      new Error(ssrfError)
+    )
+    return false
+  }
+
+  try {
+    const res = await fetchWithTimeout(responseUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (!res.ok) {
+      logError(
+        '[slack-api] response_url POST failed',
+        new Error(`status ${res.status}`)
+      )
+      return false
+    }
+    return true
+  } catch (err) {
+    logError('[slack-api] response_url POST exception', err)
+    return false
+  }
+}

--- a/apps/dashboard/src/lib/slack/blocks.test.ts
+++ b/apps/dashboard/src/lib/slack/blocks.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for the pure Slack Block Kit builders (plans/37-slack-app-native-oauth).
+ *
+ * Asserts the slash-command and alert-ACK payloads are well-formed JSON blocks
+ * with the expected `action_id`, and that the ACK-value codec round-trips and
+ * rejects malformed input — the interactions route depends on both.
+ */
+
+import type { AlertPayload } from '@/lib/health/adapters/types'
+import type { IncidentSnapshot } from '@/lib/health/incident-snapshot'
+import {
+  ACK_ACTION_ID,
+  type AckKey,
+  buildAckedMessageBlocks,
+  buildAlertBlocksWithAck,
+  buildAlertListBlocks,
+  buildHomeTabView,
+  buildQueryResultBlocks,
+  buildStatusBlocks,
+  decodeAckValue,
+  encodeAckValue,
+} from './blocks'
+import { describe, expect, test } from 'bun:test'
+
+/** Every block must at minimum have a string `type`, and be JSON-serializable. */
+function assertWellFormed(blocks: unknown[]): void {
+  expect(Array.isArray(blocks)).toBe(true)
+  expect(blocks.length).toBeGreaterThan(0)
+  for (const block of blocks) {
+    expect(typeof block).toBe('object')
+    expect(typeof (block as { type: unknown }).type).toBe('string')
+  }
+  // Round-trips through JSON without throwing (no undefined/circular refs).
+  expect(() => JSON.parse(JSON.stringify(blocks))).not.toThrow()
+}
+
+const SNAPSHOT: IncidentSnapshot = {
+  hostId: 0,
+  capturedAt: '2026-07-04T00:00:00.000Z',
+  topQueries: [],
+  merges: { active: 2, stuck: 1, maxElapsed: 700 },
+  memoryUsagePct: 42.5,
+  diskUsagePct: 71.25,
+  replicationLagSeconds: 3,
+}
+
+const ALERT: AlertPayload = {
+  severity: 'critical',
+  hostLabel: 'prod-1',
+  hostId: 0,
+  metric: 'failed-mutations',
+  value: 3,
+  title: 'Failed mutations',
+  label: '3 failed mutations',
+  timestamp: '2026-07-04T00:00:00.000Z',
+}
+
+describe('encode/decodeAckValue', () => {
+  test('round-trips a key', () => {
+    const key: AckKey = {
+      hostId: 2,
+      ruleId: 'failed-mutations',
+      severity: 'critical',
+    }
+    const encoded = encodeAckValue(key)
+    expect(encoded.length).toBeLessThanOrEqual(2000)
+    expect(decodeAckValue(encoded)).toEqual(key)
+  })
+
+  test('rejects malformed / missing values', () => {
+    expect(decodeAckValue(null)).toBeNull()
+    expect(decodeAckValue('')).toBeNull()
+    expect(decodeAckValue('not json')).toBeNull()
+    expect(decodeAckValue('{}')).toBeNull()
+    expect(
+      decodeAckValue(JSON.stringify({ h: -1, r: 'x', s: 'critical' }))
+    ).toBeNull()
+    expect(
+      decodeAckValue(JSON.stringify({ h: 0, r: '', s: 'critical' }))
+    ).toBeNull()
+    expect(
+      decodeAckValue(JSON.stringify({ h: 0, r: 'x', s: 'bogus' }))
+    ).toBeNull()
+  })
+})
+
+describe('buildStatusBlocks', () => {
+  test('renders a well-formed status summary', () => {
+    const blocks = buildStatusBlocks('prod-1', SNAPSHOT)
+    assertWellFormed(blocks)
+    const json = JSON.stringify(blocks)
+    expect(json).toContain('prod-1')
+    expect(json).toContain('42.5%')
+    expect(json).toContain('stuck')
+  })
+})
+
+describe('buildQueryResultBlocks', () => {
+  test('renders a table for rows', () => {
+    const blocks = buildQueryResultBlocks(
+      'SELECT name, total FROM t',
+      [
+        { name: 'a', total: 1 },
+        { name: 'b', total: 2 },
+      ],
+      { rowCap: 20, durationMs: 12 }
+    )
+    assertWellFormed(blocks)
+    const json = JSON.stringify(blocks)
+    expect(json).toContain('name')
+    expect(json).toContain('2 row(s)')
+  })
+
+  test('handles an empty result set', () => {
+    const blocks = buildQueryResultBlocks('SELECT 1', [], { rowCap: 20 })
+    assertWellFormed(blocks)
+    expect(JSON.stringify(blocks)).toContain('No rows')
+  })
+})
+
+describe('buildAlertListBlocks', () => {
+  test('renders recent alerts', () => {
+    const blocks = buildAlertListBlocks([
+      {
+        eventTime: '2026-07-04T00:00:00.000Z',
+        hostId: 0,
+        hostLabel: 'prod-1',
+        rule: 'failed-mutations',
+        severity: 'critical',
+        decisionKind: 'new',
+        delivered: true,
+        value: 3,
+      },
+    ])
+    assertWellFormed(blocks)
+    expect(JSON.stringify(blocks)).toContain('failed-mutations')
+  })
+
+  test('shows an empty-state when there is no history', () => {
+    const blocks = buildAlertListBlocks([])
+    assertWellFormed(blocks)
+    expect(JSON.stringify(blocks)).toContain('No recent alerts')
+  })
+})
+
+describe('buildAlertBlocksWithAck', () => {
+  test('critical alert carries an Acknowledge button with the ACK action_id', () => {
+    const key: AckKey = {
+      hostId: 0,
+      ruleId: 'failed-mutations',
+      severity: 'critical',
+    }
+    const blocks = buildAlertBlocksWithAck(ALERT, key)
+    assertWellFormed(blocks)
+
+    const actions = blocks.find((b) => b.type === 'actions')
+    expect(actions).toBeDefined()
+    const button = actions?.elements?.[0] as
+      | { action_id?: string; value?: string; text?: { text?: string } }
+      | undefined
+    expect(button?.action_id).toBe(ACK_ACTION_ID)
+    expect(button?.text?.text).toBe('Acknowledge')
+    // The button value decodes back to the same alert identity.
+    expect(decodeAckValue(button?.value)).toEqual(key)
+  })
+
+  test('recovery alert has no Acknowledge button', () => {
+    const recovery: AlertPayload = { ...ALERT, severity: 'recovery' }
+    const key: AckKey = {
+      hostId: 0,
+      ruleId: 'failed-mutations',
+      severity: 'recovery',
+    }
+    const blocks = buildAlertBlocksWithAck(recovery, key)
+    assertWellFormed(blocks)
+    expect(blocks.find((b) => b.type === 'actions')).toBeUndefined()
+  })
+})
+
+describe('buildAckedMessageBlocks', () => {
+  test('removes the actions block and appends an acked-by context', () => {
+    const key: AckKey = {
+      hostId: 0,
+      ruleId: 'failed-mutations',
+      severity: 'critical',
+    }
+    const original = buildAlertBlocksWithAck(ALERT, key)
+    const updated = buildAckedMessageBlocks(
+      original,
+      'U123',
+      '2026-07-04T00:05:00.000Z'
+    )
+    assertWellFormed(updated)
+    expect(updated.find((b) => b.type === 'actions')).toBeUndefined()
+    expect(JSON.stringify(updated)).toContain('<@U123>')
+  })
+})
+
+describe('buildHomeTabView', () => {
+  test('publishes a home view with host summaries and a dashboard link', () => {
+    const view = buildHomeTabView(
+      [
+        {
+          hostId: 0,
+          label: 'prod-1',
+          memoryUsagePct: 40,
+          diskUsagePct: 55,
+          firing: 2,
+        },
+      ],
+      { dashboardUrl: 'https://dash.chmonitor.dev' }
+    )
+    expect(view.type).toBe('home')
+    assertWellFormed(view.blocks)
+    const json = JSON.stringify(view.blocks)
+    expect(json).toContain('prod-1')
+    expect(json).toContain('2 firing')
+    expect(json).toContain('https://dash.chmonitor.dev')
+  })
+
+  test('handles no hosts', () => {
+    const view = buildHomeTabView([])
+    assertWellFormed(view.blocks)
+    expect(JSON.stringify(view.blocks)).toContain('No ClickHouse hosts')
+  })
+})

--- a/apps/dashboard/src/lib/slack/blocks.test.ts
+++ b/apps/dashboard/src/lib/slack/blocks.test.ts
@@ -8,6 +8,7 @@
 
 import type { AlertPayload } from '@/lib/health/adapters/types'
 import type { IncidentSnapshot } from '@/lib/health/incident-snapshot'
+
 import {
   ACK_ACTION_ID,
   type AckKey,

--- a/apps/dashboard/src/lib/slack/blocks.ts
+++ b/apps/dashboard/src/lib/slack/blocks.ts
@@ -1,0 +1,396 @@
+/**
+ * Slack Block Kit builders for the native app (PURE — no network, no env).
+ *
+ * Every function here turns chmonitor data into the JSON block payloads Slack
+ * renders, and is trivially unit-testable. Transport (posting to Slack, tokens,
+ * response_url) lives in the route handlers / api.ts, never here — mirroring the
+ * pure-formatter split already used by lib/health/adapters/slack.ts.
+ *
+ * Type-only imports of the chmonitor data shapes keep this a leaf module with
+ * no runtime dependency on the Worker/D1 layers those shapes come from.
+ */
+
+import type { AlertPayload, AlertSeverity } from '@/lib/health/adapters/types'
+import type { AlertEventRecord } from '@/lib/health/alert-history-store'
+import type { IncidentSnapshot } from '@/lib/health/incident-snapshot'
+
+// ---------------------------------------------------------------------------
+// Block Kit types (only the subset this app emits).
+// ---------------------------------------------------------------------------
+
+export interface SlackTextObject {
+  type: 'plain_text' | 'mrkdwn'
+  text: string
+  emoji?: boolean
+}
+
+export interface SlackButtonElement {
+  type: 'button'
+  text: SlackTextObject
+  action_id: string
+  value?: string
+  url?: string
+  style?: 'primary' | 'danger'
+}
+
+export interface SlackBlock {
+  type: string
+  text?: SlackTextObject
+  fields?: SlackTextObject[]
+  elements?: (SlackTextObject | SlackButtonElement)[]
+  block_id?: string
+}
+
+/** A Home-tab view published via `views.publish`. */
+export interface SlackHomeView {
+  type: 'home'
+  blocks: SlackBlock[]
+}
+
+/**
+ * The `action_id` carried by the "Acknowledge" button on pushed alert
+ * messages. The interactions route matches on this exact id.
+ */
+export const ACK_ACTION_ID = 'chmonitor_ack_alert'
+
+/** Slack caps a button `value` at 2000 chars; our encoded key is far smaller. */
+const MAX_ACTION_VALUE = 2000
+
+const SEVERITY_EMOJI: Record<AlertSeverity, string> = {
+  critical: '🔴',
+  warning: '🟠',
+  recovery: '🟢',
+}
+
+// ---------------------------------------------------------------------------
+// ACK button value codec.
+// ---------------------------------------------------------------------------
+
+/** Structured identity of the alert an ACK button refers to. */
+export interface AckKey {
+  /** Numeric host id. */
+  hostId: number
+  /** Rule / metric id (the alert-state dedup key component). */
+  ruleId: string
+  /** Severity at the time the alert was posted. */
+  severity: AlertSeverity
+}
+
+/**
+ * Encode an {@link AckKey} into a compact JSON string for a button `value`.
+ * Throws if it would exceed Slack's 2000-char cap (impossible for real rule
+ * ids, but guarded so a pathological id fails loud instead of being silently
+ * truncated by Slack).
+ */
+export function encodeAckValue(key: AckKey): string {
+  const value = JSON.stringify({
+    h: key.hostId,
+    r: key.ruleId,
+    s: key.severity,
+  })
+  if (value.length > MAX_ACTION_VALUE) {
+    throw new Error('ACK button value exceeds Slack 2000-char limit')
+  }
+  return value
+}
+
+/** Decode a button `value` back into an {@link AckKey}, or null if malformed. */
+export function decodeAckValue(
+  value: string | undefined | null
+): AckKey | null {
+  if (!value) return null
+  try {
+    const parsed = JSON.parse(value) as {
+      h?: unknown
+      r?: unknown
+      s?: unknown
+    }
+    const hostId = Number(parsed.h)
+    const ruleId = typeof parsed.r === 'string' ? parsed.r : ''
+    const severity = parsed.s
+    if (!Number.isInteger(hostId) || hostId < 0 || !ruleId) return null
+    if (
+      severity !== 'warning' &&
+      severity !== 'critical' &&
+      severity !== 'recovery'
+    ) {
+      return null
+    }
+    return { hostId, ruleId, severity }
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared small helpers.
+// ---------------------------------------------------------------------------
+
+function header(text: string): SlackBlock {
+  return { type: 'header', text: { type: 'plain_text', text, emoji: true } }
+}
+
+function section(mrkdwn: string): SlackBlock {
+  return { type: 'section', text: { type: 'mrkdwn', text: mrkdwn } }
+}
+
+function context(mrkdwn: string): SlackBlock {
+  return { type: 'context', elements: [{ type: 'mrkdwn', text: mrkdwn }] }
+}
+
+const divider: SlackBlock = { type: 'divider' }
+
+function pct(value: number | null): string {
+  return value === null ? 'n/a' : `${value.toFixed(1)}%`
+}
+
+// ---------------------------------------------------------------------------
+// /chmonitor status
+// ---------------------------------------------------------------------------
+
+/**
+ * Cluster status summary blocks from an incident snapshot (running queries,
+ * merges, memory/disk pressure, replication lag). Individual fields may be
+ * null when their query failed — rendered as "n/a" rather than omitted.
+ */
+export function buildStatusBlocks(
+  hostLabel: string,
+  snapshot: IncidentSnapshot
+): SlackBlock[] {
+  const merges = snapshot.merges
+  const fields: SlackTextObject[] = [
+    { type: 'mrkdwn', text: `*Memory:*\n${pct(snapshot.memoryUsagePct)}` },
+    { type: 'mrkdwn', text: `*Disk:*\n${pct(snapshot.diskUsagePct)}` },
+    {
+      type: 'mrkdwn',
+      text: `*Running queries:*\n${snapshot.topQueries?.length ?? 'n/a'}`,
+    },
+    {
+      type: 'mrkdwn',
+      text: `*Active merges:*\n${merges ? `${merges.active}${merges.stuck > 0 ? ` (${merges.stuck} stuck)` : ''}` : 'n/a'}`,
+    },
+    {
+      type: 'mrkdwn',
+      text: `*Replication lag:*\n${snapshot.replicationLagSeconds === null ? 'n/a' : `${snapshot.replicationLagSeconds}s`}`,
+    },
+  ]
+
+  return [
+    header(`📊 Cluster status — ${hostLabel}`),
+    { type: 'section', fields },
+    context(`Captured ${snapshot.capturedAt}`),
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// /chmonitor query
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a capped result set as a fenced code block (a real Block Kit table
+ * type does not exist; a monospace preview is the idiomatic representation).
+ * The caller enforces the row/time caps at query time; `rowCap` here only
+ * controls how many are shown and whether a "+N more" note is appended.
+ */
+export function buildQueryResultBlocks(
+  sql: string,
+  rows: Array<Record<string, unknown>>,
+  opts: { rowCap: number; durationMs?: number; truncated?: boolean } = {
+    rowCap: 20,
+  }
+): SlackBlock[] {
+  const shown = rows.slice(0, opts.rowCap)
+  const blocks: SlackBlock[] = [header('🔎 Query result')]
+
+  if (shown.length === 0) {
+    blocks.push(section('_No rows returned._'))
+  } else {
+    const columns = Object.keys(shown[0])
+    const lines = shown.map((row) =>
+      columns.map((c) => formatCell(row[c])).join(' | ')
+    )
+    const table = [columns.join(' | '), ...lines].join('\n')
+    // Guard against Slack's 3000-char section text limit.
+    const body = table.length > 2800 ? `${table.slice(0, 2800)}\n…` : table
+    blocks.push(section('```' + body + '```'))
+  }
+
+  const noteParts: string[] = [`${shown.length} row(s)`]
+  if (opts.truncated) noteParts.push('result capped')
+  if (opts.durationMs !== undefined) noteParts.push(`${opts.durationMs}ms`)
+  blocks.push(context(noteParts.join(' · ')))
+  return blocks
+}
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return '∅'
+  const s = typeof value === 'object' ? JSON.stringify(value) : String(value)
+  return s.length > 60 ? `${s.slice(0, 57)}…` : s
+}
+
+// ---------------------------------------------------------------------------
+// /chmonitor alert
+// ---------------------------------------------------------------------------
+
+/**
+ * List recent firing alerts (from the D1 alert-history audit log). Recovery
+ * rows are excluded by the caller; this renders whatever it is given.
+ */
+export function buildAlertListBlocks(events: AlertEventRecord[]): SlackBlock[] {
+  if (events.length === 0) {
+    return [
+      header('🔔 Recent alerts'),
+      section('_No recent alerts._ Alert history requires `CHM_CLOUD_D1`.'),
+    ]
+  }
+
+  const blocks: SlackBlock[] = [header('🔔 Recent alerts')]
+  for (const e of events) {
+    const emoji = SEVERITY_EMOJI[e.severity] ?? '⚪'
+    const host = e.hostLabel || `host ${e.hostId}`
+    blocks.push(
+      section(
+        `${emoji} *${e.rule}* — ${host}\n${e.value === null || e.value === undefined ? '' : `value ${e.value} · `}${e.eventTime}`
+      )
+    )
+  }
+  return blocks
+}
+
+// ---------------------------------------------------------------------------
+// Alert message with an ACK button (the outbound "alert bridge").
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a rich alert message that carries an "Acknowledge" button. This is the
+ * ACK-enabled variant of lib/health/adapters/slack.ts's `buildSlackBody`: the
+ * `action_id` is {@link ACK_ACTION_ID} and the button `value` encodes the
+ * alert's dedup key so the interactions route can write the ACK + edit this
+ * message.
+ */
+export function buildAlertBlocksWithAck(
+  payload: AlertPayload,
+  ackKey: AckKey
+): SlackBlock[] {
+  const emoji = SEVERITY_EMOJI[payload.severity] ?? '⚪'
+  const heading =
+    payload.severity === 'recovery'
+      ? 'RECOVERY'
+      : payload.severity.toUpperCase()
+
+  const blocks: SlackBlock[] = [
+    header(`${emoji} ${heading}: ${payload.title}`),
+    {
+      type: 'section',
+      fields: [
+        {
+          type: 'mrkdwn',
+          text: `*Host:*\n${payload.hostLabel} (id ${payload.hostId})`,
+        },
+        { type: 'mrkdwn', text: `*Metric:*\n${payload.metric}` },
+        {
+          type: 'mrkdwn',
+          text: `*Value:*\n${payload.value === null ? 'n/a' : payload.value}`,
+        },
+        { type: 'mrkdwn', text: `*Detail:*\n${payload.label}` },
+      ],
+    },
+  ]
+
+  // Recovery messages don't need an ACK button — nothing to acknowledge.
+  if (payload.severity !== 'recovery') {
+    blocks.push({
+      type: 'actions',
+      block_id: 'chmonitor_ack',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: 'Acknowledge', emoji: true },
+          style: 'primary',
+          action_id: ACK_ACTION_ID,
+          value: encodeAckValue(ackKey),
+        },
+      ],
+    })
+  }
+
+  blocks.push(context(payload.timestamp))
+  return blocks
+}
+
+/**
+ * The same alert message after it has been acknowledged: the ACK button is
+ * replaced by a context line naming who acked it and when. Used by the
+ * interactions route's `chat.update` / response_url replacement.
+ */
+export function buildAckedMessageBlocks(
+  original: SlackBlock[],
+  ackedBy: string,
+  ackedAtIso: string
+): SlackBlock[] {
+  const withoutActions = original.filter((b) => b.type !== 'actions')
+  return [
+    ...withoutActions,
+    context(`✅ Acknowledged by <@${ackedBy}> · ${ackedAtIso}`),
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Home tab
+// ---------------------------------------------------------------------------
+
+/** A single host's compact line on the Home tab. */
+export interface HomeHostSummary {
+  hostId: number
+  label: string
+  memoryUsagePct: number | null
+  diskUsagePct: number | null
+  firing: number
+}
+
+/**
+ * Publish-ready Home tab view: a per-host health summary plus a hint on how to
+ * use the slash commands. `dashboardUrl`, when provided, becomes a link button.
+ */
+export function buildHomeTabView(
+  hosts: HomeHostSummary[],
+  opts: { dashboardUrl?: string } = {}
+): SlackHomeView {
+  const blocks: SlackBlock[] = [header('chmonitor')]
+
+  if (hosts.length === 0) {
+    blocks.push(section('_No ClickHouse hosts configured._'))
+  } else {
+    for (const h of hosts) {
+      const flame = h.firing > 0 ? `🔴 ${h.firing} firing` : '🟢 healthy'
+      blocks.push(
+        section(
+          `*${h.label}*  ${flame}\nMemory ${pct(h.memoryUsagePct)} · Disk ${pct(h.diskUsagePct)}`
+        )
+      )
+    }
+  }
+
+  blocks.push(divider)
+  blocks.push(
+    section(
+      'Use `/chmonitor status`, `/chmonitor query <SQL>`, or `/chmonitor alert` in any channel.'
+    )
+  )
+
+  if (opts.dashboardUrl) {
+    blocks.push({
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: 'Open dashboard', emoji: true },
+          action_id: 'chmonitor_open_dashboard',
+          url: opts.dashboardUrl,
+        },
+      ],
+    })
+  }
+
+  return { type: 'home', blocks }
+}

--- a/apps/dashboard/src/lib/slack/blocks.ts
+++ b/apps/dashboard/src/lib/slack/blocks.ts
@@ -200,7 +200,11 @@ export function buildQueryResultBlocks(
   }
 ): SlackBlock[] {
   const shown = rows.slice(0, opts.rowCap)
-  const blocks: SlackBlock[] = [header('🔎 Query result')]
+  const sqlPreview = sql.length > 150 ? `${sql.slice(0, 150)}…` : sql
+  const blocks: SlackBlock[] = [
+    header('🔎 Query result'),
+    context(`\`${sqlPreview}\``),
+  ]
 
   if (shown.length === 0) {
     blocks.push(section('_No rows returned._'))
@@ -212,7 +216,8 @@ export function buildQueryResultBlocks(
     const table = [columns.join(' | '), ...lines].join('\n')
     // Guard against Slack's 3000-char section text limit.
     const body = table.length > 2800 ? `${table.slice(0, 2800)}\n…` : table
-    blocks.push(section('```' + body + '```'))
+    const fence = '```'
+    blocks.push(section(`${fence}${body}${fence}`))
   }
 
   const noteParts: string[] = [`${shown.length} row(s)`]

--- a/apps/dashboard/src/lib/slack/config.ts
+++ b/apps/dashboard/src/lib/slack/config.ts
@@ -1,0 +1,91 @@
+/**
+ * Native Slack app — runtime configuration.
+ *
+ * The Slack app (OAuth install, /chmonitor slash commands, Home tab, ACK
+ * buttons) is entirely OPTIONAL. When its env is absent the feature is simply
+ * off: every inbound route fails closed (501/"not configured") and nothing
+ * else in the dashboard changes. This mirrors the fail-open posture of the
+ * GitHub deploy webhook (lib/deployments/config.ts) — the OSS/self-hosted
+ * default runs fine with none of these vars set.
+ *
+ * All values are read from `process.env`, which the Worker populates from its
+ * vars/secrets via the `nodejs_compat_populate_process_env` compat flag (see
+ * wrangler.toml) — the same source lib/deployments/config.ts reads. Secrets
+ * (`SLACK_CLIENT_SECRET`, `SLACK_SIGNING_SECRET`) must be provided as Worker
+ * secrets / `.env.local` and NEVER committed.
+ */
+
+function readEnv(key: string): string | undefined {
+  const v = typeof process !== 'undefined' ? process.env?.[key] : undefined
+  return v === undefined || v === '' ? undefined : v
+}
+
+/** OAuth client id (public — identifies the Slack app during install). */
+export function getSlackClientId(): string | undefined {
+  return readEnv('SLACK_CLIENT_ID')
+}
+
+/** OAuth client secret (SECRET — exchanges the install `code` for a token). */
+export function getSlackClientSecret(): string | undefined {
+  return readEnv('SLACK_CLIENT_SECRET')
+}
+
+/**
+ * Signing secret (SECRET) used to verify `X-Slack-Signature` on every inbound
+ * Slack request AND to derive the at-rest token-encryption key + the OAuth
+ * `state` CSRF signature. Its presence is the single gate for "is the Slack
+ * app configured", because no inbound request can be trusted without it.
+ */
+export function getSlackSigningSecret(): string | undefined {
+  return readEnv('SLACK_SIGNING_SECRET')
+}
+
+/**
+ * Optional dedicated 32-byte (base64) key for encrypting stored bot tokens,
+ * independent of the signing secret (set only if you want to rotate it
+ * separately). Mirrors CHM_USER_CONNECTIONS_ENCRYPTION_KEY.
+ */
+export function getSlackTokenEncryptionKey(): string | undefined {
+  return readEnv('SLACK_TOKEN_ENCRYPTION_KEY')
+}
+
+/**
+ * Whether the native Slack app is configured. Requires the three OAuth/verify
+ * credentials; anything less leaves the feature off (routes fail closed).
+ */
+export function isSlackAppConfigured(): boolean {
+  return Boolean(
+    getSlackClientId() && getSlackClientSecret() && getSlackSigningSecret()
+  )
+}
+
+/**
+ * OAuth scopes requested at install. Kept in sync with docs/slack/manifest.yml.
+ * Only scopes the app actually uses:
+ *  - commands       : receive the /chmonitor slash command
+ *  - chat:write     : post/update alert messages (ACK edit)
+ *  - app_mentions:read + the Home tab (`app_home`) come via event subscriptions
+ */
+export const SLACK_BOT_SCOPES = ['commands', 'chat:write'] as const
+
+/** Slack API base — a fixed, first-party host (not derived from any payload). */
+export const SLACK_API_BASE = 'https://slack.com/api'
+
+/** Slack OAuth authorize endpoint. */
+export const SLACK_AUTHORIZE_URL = 'https://slack.com/oauth/v2/authorize'
+
+/** Path of the OAuth redirect (callback) route — the app's registered redirect URI. */
+export const SLACK_OAUTH_CALLBACK_PATH = '/api/v1/slack/oauth'
+
+/**
+ * The OAuth redirect URI Slack calls back after the user approves the app.
+ * Prefer an explicit `SLACK_OAUTH_REDIRECT_URL` (so it exactly matches what is
+ * configured in the Slack app), otherwise derive it from the incoming request
+ * origin so a self-hoster gets a correct URL with zero extra config.
+ */
+export function getSlackOAuthRedirectUrl(request: Request): string {
+  const explicit = readEnv('SLACK_OAUTH_REDIRECT_URL')
+  if (explicit) return explicit
+  const origin = new URL(request.url).origin
+  return `${origin}${SLACK_OAUTH_CALLBACK_PATH}`
+}

--- a/apps/dashboard/src/lib/slack/inbound.ts
+++ b/apps/dashboard/src/lib/slack/inbound.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared inbound-request verification for the Slack routes (plans/37).
+ *
+ * Every inbound Slack request (slash commands, interactivity, events) is signed
+ * with the app signing secret. This helper centralizes the security-critical
+ * sequence used by all three routes:
+ *
+ *   1. Bail if the Slack app is not configured (feature off → caller 501s).
+ *   2. Read the RAW body ONCE (`request.text()`) — the signature is computed
+ *      over the raw bytes, so this MUST happen before any formData()/json()
+ *      parse (which would consume the stream and break verification).
+ *   3. Verify the `X-Slack-Signature` + `X-Slack-Request-Timestamp` headers
+ *      against the raw body (HMAC + freshness).
+ *
+ * Returns the raw body so the caller can parse it (URLSearchParams / JSON) only
+ * AFTER verification succeeds.
+ */
+
+import { getSlackSigningSecret, isSlackAppConfigured } from './config'
+import { verifySlackRequest } from './verify-signature'
+
+export interface InboundVerification {
+  /** Whether the Slack app is configured at all (false → caller returns 501). */
+  configured: boolean
+  /** Whether the signature + timestamp verified (false → caller returns 401). */
+  verified: boolean
+  /** The raw request body (empty string when unconfigured). */
+  rawBody: string
+}
+
+export async function readAndVerifySlackRequest(
+  request: Request
+): Promise<InboundVerification> {
+  if (!isSlackAppConfigured()) {
+    return { configured: false, verified: false, rawBody: '' }
+  }
+  const signingSecret = getSlackSigningSecret()
+  if (!signingSecret) {
+    return { configured: false, verified: false, rawBody: '' }
+  }
+
+  const rawBody = await request.text()
+  const verified = await verifySlackRequest({
+    signingSecret,
+    signature: request.headers.get('x-slack-signature'),
+    timestamp: request.headers.get('x-slack-request-timestamp'),
+    rawBody,
+  })
+
+  return { configured: true, verified, rawBody }
+}

--- a/apps/dashboard/src/lib/slack/install-store.ts
+++ b/apps/dashboard/src/lib/slack/install-store.ts
@@ -1,0 +1,167 @@
+/**
+ * D1-backed store for Slack workspace installations (plans/37).
+ *
+ * Reuses the same `CHM_CLOUD_D1` binding as the agent conversation store and
+ * the alert-history / github-deployments stores; the `slack_installations`
+ * table is created by the 0015 migration. The bot token is encrypted at rest
+ * (lib/slack/token-crypto.ts) — the plaintext token only ever exists in memory
+ * during a request.
+ *
+ * Best-effort like the sibling stores: a missing binding (the OSS default with
+ * no D1) or any D1 error is caught, logged, and resolved to false/null rather
+ * than thrown — so the dashboard never crashes over a Slack-store failure.
+ * `upsertInstallation` returns a boolean so the OAuth callback can tell the
+ * user when persistence genuinely failed (a stored-token-less install is
+ * useless), rather than silently claiming success.
+ */
+
+import { ErrorLogger } from '@chm/logger'
+import { getPlatformBindings } from '@chm/platform'
+import { decryptToken, encryptToken } from './token-crypto'
+
+const warn = (msg: string) =>
+  ErrorLogger.logWarning(`[slack-install-store] ${msg}`, {
+    component: 'slack-install-store',
+  })
+
+const TABLE = 'slack_installations'
+
+function getDb(): D1Database | null {
+  return getPlatformBindings().getD1Database('CHM_CLOUD_D1')
+}
+
+/** What we persist about an installed workspace (token in plaintext in memory). */
+export interface SlackInstallation {
+  teamId: string
+  teamName?: string | null
+  /** Raw `xoxb-` bot token — encrypted before it touches D1. */
+  botToken: string
+  botUserId?: string | null
+  scope?: string | null
+  authedUserId?: string | null
+  ownerRef: string
+  installedAt: number
+  updatedAt: number
+}
+
+interface D1InstallRow {
+  team_id: string
+  team_name: string | null
+  bot_token_enc: string
+  bot_user_id: string | null
+  scope: string | null
+  authed_user_id: string | null
+  owner_ref: string
+  installed_at: number
+  updated_at: number
+}
+
+/**
+ * Persist (or update) a workspace installation, keyed by `team_id` so a
+ * reinstall updates in place. Encrypts the bot token first. Returns false on
+ * any failure (missing D1, encryption misconfig, D1 error) — never throws.
+ */
+export async function upsertInstallation(
+  install: SlackInstallation
+): Promise<boolean> {
+  try {
+    const db = getDb()
+    if (!db) {
+      warn('no CHM_CLOUD_D1 binding — cannot persist Slack installation')
+      return false
+    }
+
+    const botTokenEnc = await encryptToken(install.botToken)
+
+    await db
+      .prepare(
+        `INSERT INTO ${TABLE}
+           (team_id, team_name, bot_token_enc, bot_user_id, scope, authed_user_id, owner_ref, installed_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+         ON CONFLICT (team_id) DO UPDATE SET
+           team_name = excluded.team_name,
+           bot_token_enc = excluded.bot_token_enc,
+           bot_user_id = excluded.bot_user_id,
+           scope = excluded.scope,
+           authed_user_id = excluded.authed_user_id,
+           owner_ref = excluded.owner_ref,
+           updated_at = excluded.updated_at`
+      )
+      .bind(
+        install.teamId,
+        install.teamName ?? null,
+        botTokenEnc,
+        install.botUserId ?? null,
+        install.scope ?? null,
+        install.authedUserId ?? null,
+        install.ownerRef,
+        install.installedAt,
+        install.updatedAt
+      )
+      .run()
+    return true
+  } catch (err) {
+    warn(`failed to upsert installation ${install.teamId}: ${err}`)
+    return false
+  }
+}
+
+async function rowToInstall(
+  row: D1InstallRow
+): Promise<SlackInstallation | null> {
+  try {
+    const botToken = await decryptToken(row.bot_token_enc)
+    return {
+      teamId: row.team_id,
+      teamName: row.team_name,
+      botToken,
+      botUserId: row.bot_user_id,
+      scope: row.scope,
+      authedUserId: row.authed_user_id,
+      ownerRef: row.owner_ref,
+      installedAt: row.installed_at,
+      updatedAt: row.updated_at,
+    }
+  } catch (err) {
+    // A decrypt failure (e.g. the signing secret was rotated) means the stored
+    // token is no longer usable — treat the workspace as not-installed rather
+    // than surfacing ciphertext or crashing. Reinstall re-keys it.
+    warn(`failed to decrypt token for ${row.team_id}: ${err}`)
+    return null
+  }
+}
+
+/** Fetch an installation by workspace id, with the decrypted token, or null. */
+export async function getInstallation(
+  teamId: string
+): Promise<SlackInstallation | null> {
+  try {
+    const db = getDb()
+    if (!db) return null
+    const row = await db
+      .prepare(`SELECT * FROM ${TABLE} WHERE team_id = ?1`)
+      .bind(teamId)
+      .first<D1InstallRow>()
+    if (!row) return null
+    return rowToInstall(row)
+  } catch (err) {
+    warn(`failed to get installation ${teamId}: ${err}`)
+    return null
+  }
+}
+
+/** Remove an installation (e.g. on app uninstall). Returns false on failure. */
+export async function deleteInstallation(teamId: string): Promise<boolean> {
+  try {
+    const db = getDb()
+    if (!db) return false
+    await db
+      .prepare(`DELETE FROM ${TABLE} WHERE team_id = ?1`)
+      .bind(teamId)
+      .run()
+    return true
+  } catch (err) {
+    warn(`failed to delete installation ${teamId}: ${err}`)
+    return false
+  }
+}

--- a/apps/dashboard/src/lib/slack/install-store.ts
+++ b/apps/dashboard/src/lib/slack/install-store.ts
@@ -15,9 +15,9 @@
  * useless), rather than silently claiming success.
  */
 
+import { decryptToken, encryptToken } from './token-crypto'
 import { ErrorLogger } from '@chm/logger'
 import { getPlatformBindings } from '@chm/platform'
-import { decryptToken, encryptToken } from './token-crypto'
 
 const warn = (msg: string) =>
   ErrorLogger.logWarning(`[slack-install-store] ${msg}`, {

--- a/apps/dashboard/src/lib/slack/oauth-state.test.ts
+++ b/apps/dashboard/src/lib/slack/oauth-state.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for the stateless OAuth `state` CSRF token (plans/37).
+ *
+ * Proves a freshly-signed state verifies and returns its bound ownerRef, and
+ * that a tampered payload, a wrong secret, and a stale token are all rejected —
+ * the CSRF properties the OAuth callback relies on.
+ */
+
+import {
+  signOAuthState,
+  STATE_MAX_AGE_SECONDS,
+  verifyOAuthState,
+} from './oauth-state'
+import { describe, expect, test } from 'bun:test'
+
+const SECRET = 'signing-secret'
+const NOW = 1_700_000_000_000
+
+describe('oauth-state', () => {
+  test('a freshly-signed state verifies and returns the bound ownerRef', async () => {
+    const state = await signOAuthState(SECRET, 'user_abc', NOW)
+    const result = await verifyOAuthState(SECRET, state, { nowMs: NOW })
+    expect(result).toEqual({ ownerRef: 'user_abc' })
+  })
+
+  test('a state signed with a different secret is rejected', async () => {
+    const state = await signOAuthState('other-secret', 'user_abc', NOW)
+    expect(await verifyOAuthState(SECRET, state, { nowMs: NOW })).toBeNull()
+  })
+
+  test('a tampered payload is rejected', async () => {
+    const state = await signOAuthState(SECRET, 'user_abc', NOW)
+    const [encoded, sig] = state.split('.')
+    // Flip a character in the payload, keep the old signature.
+    const tampered = `${encoded.slice(0, -1)}${encoded.slice(-1) === 'A' ? 'B' : 'A'}.${sig}`
+    expect(await verifyOAuthState(SECRET, tampered, { nowMs: NOW })).toBeNull()
+  })
+
+  test('a stale state (beyond the freshness window) is rejected', async () => {
+    const state = await signOAuthState(SECRET, 'user_abc', NOW)
+    const later = NOW + (STATE_MAX_AGE_SECONDS + 1) * 1000
+    expect(await verifyOAuthState(SECRET, state, { nowMs: later })).toBeNull()
+  })
+
+  test('missing / malformed state is rejected', async () => {
+    expect(await verifyOAuthState(SECRET, null, { nowMs: NOW })).toBeNull()
+    expect(await verifyOAuthState(SECRET, '', { nowMs: NOW })).toBeNull()
+    expect(await verifyOAuthState(SECRET, 'no-dot', { nowMs: NOW })).toBeNull()
+    expect(await verifyOAuthState('', 'x.y', { nowMs: NOW })).toBeNull()
+  })
+})

--- a/apps/dashboard/src/lib/slack/oauth-state.test.ts
+++ b/apps/dashboard/src/lib/slack/oauth-state.test.ts
@@ -7,8 +7,8 @@
  */
 
 import {
-  signOAuthState,
   STATE_MAX_AGE_SECONDS,
+  signOAuthState,
   verifyOAuthState,
 } from './oauth-state'
 import { describe, expect, test } from 'bun:test'

--- a/apps/dashboard/src/lib/slack/oauth-state.ts
+++ b/apps/dashboard/src/lib/slack/oauth-state.ts
@@ -1,0 +1,122 @@
+/**
+ * Stateless CSRF `state` for the Slack OAuth install flow (plans/37).
+ *
+ * Slack's OAuth redirect (`/api/v1/slack/oauth`) is a browser GET that Slack
+ * does NOT sign — so the `state` parameter is the CSRF defense. This app has no
+ * guaranteed server session store on Workers (and OSS must work without one), so
+ * `state` is a self-contained, HMAC-signed token instead of a stored nonce:
+ *
+ *   state = base64url(JSON payload) + '.' + hex(HMAC-SHA256(secret, payload))
+ *
+ * The callback recomputes the HMAC (constant-time compare) and rejects a
+ * tampered/forged token, and enforces a short freshness window so a leaked
+ * state can't be replayed indefinitely. The payload also carries `ownerRef` so
+ * the install is bound to whoever started it (a Clerk user in cloud mode, or
+ * 'default' for single-tenant OSS) without a server round-trip.
+ *
+ * Signed with the Slack signing secret (passed in, so this stays a pure,
+ * testable leaf with no env import).
+ */
+
+import { constantTimeEqual } from '@/lib/auth/providers/constant-time'
+
+/** Default freshness window for an install `state`: 10 minutes. */
+export const STATE_MAX_AGE_SECONDS = 60 * 10
+
+interface StatePayload {
+  /** Random nonce (defense in depth against fixed-token reuse). */
+  n: string
+  /** Issued-at, unix ms. */
+  t: number
+  /** chmonitor owner ref bound to this install. */
+  o: string
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+function fromBase64Url(s: string): Uint8Array {
+  const padded = s.replace(/-/g, '+').replace(/_/g, '/')
+  return Uint8Array.from(atob(padded), (c) => c.charCodeAt(0))
+}
+
+async function hmacHex(secret: string, message: string): Promise<string> {
+  const encoder = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+  const digest = await crypto.subtle.sign('HMAC', key, encoder.encode(message))
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/** Issue a signed `state` binding this install to `ownerRef`. */
+export async function signOAuthState(
+  secret: string,
+  ownerRef: string,
+  nowMs: number = Date.now()
+): Promise<string> {
+  const payload: StatePayload = {
+    n: crypto.randomUUID(),
+    t: nowMs,
+    o: ownerRef,
+  }
+  const encoded = toBase64Url(new TextEncoder().encode(JSON.stringify(payload)))
+  const sig = await hmacHex(secret, encoded)
+  return `${encoded}.${sig}`
+}
+
+/**
+ * Verify a `state` token: signature must match (constant-time) and it must be
+ * within the freshness window. Returns the bound `ownerRef` on success, or null
+ * on any tamper / stale / malformed input. Never throws.
+ */
+export async function verifyOAuthState(
+  secret: string,
+  state: string | null | undefined,
+  opts: { nowMs?: number; maxAgeSeconds?: number } = {}
+): Promise<{ ownerRef: string } | null> {
+  if (!secret || !state) return null
+  const dot = state.lastIndexOf('.')
+  if (dot <= 0) return null
+
+  const encoded = state.slice(0, dot)
+  const providedSig = state.slice(dot + 1)
+
+  const expectedSig = await hmacHex(secret, encoded)
+  const enc = new TextEncoder()
+  if (!constantTimeEqual(enc.encode(expectedSig), enc.encode(providedSig))) {
+    return null
+  }
+
+  let payload: StatePayload
+  try {
+    payload = JSON.parse(
+      new TextDecoder().decode(fromBase64Url(encoded))
+    ) as StatePayload
+  } catch {
+    return null
+  }
+
+  const nowMs = opts.nowMs ?? Date.now()
+  const maxAgeSeconds = opts.maxAgeSeconds ?? STATE_MAX_AGE_SECONDS
+  if (
+    typeof payload.t !== 'number' ||
+    !Number.isFinite(payload.t) ||
+    Math.abs(nowMs - payload.t) > maxAgeSeconds * 1000
+  ) {
+    return null
+  }
+  if (typeof payload.o !== 'string' || payload.o.length === 0) return null
+
+  return { ownerRef: payload.o }
+}

--- a/apps/dashboard/src/lib/slack/slash-parse.test.ts
+++ b/apps/dashboard/src/lib/slack/slash-parse.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for the pure `/chmonitor` subcommand parser (plans/37).
+ */
+
+import { parseSlashCommand } from './slash-parse'
+import { describe, expect, test } from 'bun:test'
+
+describe('parseSlashCommand', () => {
+  test('empty text → help', () => {
+    expect(parseSlashCommand('')).toEqual({ sub: 'help', arg: '', hostId: 0 })
+    expect(parseSlashCommand('   ')).toEqual({
+      sub: 'help',
+      arg: '',
+      hostId: 0,
+    })
+  })
+
+  test('unknown subcommand → help (never silently dropped)', () => {
+    expect(parseSlashCommand('frobnicate').sub).toBe('help')
+  })
+
+  test('status with no host defaults to host 0', () => {
+    expect(parseSlashCommand('status')).toEqual({
+      sub: 'status',
+      arg: '',
+      hostId: 0,
+    })
+  })
+
+  test('status with a numeric host selects it', () => {
+    expect(parseSlashCommand('status 2')).toEqual({
+      sub: 'status',
+      arg: '',
+      hostId: 2,
+    })
+  })
+
+  test('alert is recognized', () => {
+    expect(parseSlashCommand('alert').sub).toBe('alert')
+  })
+
+  test('query keeps the full remainder as SQL (never parsed as a host)', () => {
+    const parsed = parseSlashCommand('query SELECT 1 FROM system.tables')
+    expect(parsed.sub).toBe('query')
+    expect(parsed.arg).toBe('SELECT 1 FROM system.tables')
+    expect(parsed.hostId).toBe(0)
+  })
+
+  test('subcommand is case-insensitive', () => {
+    expect(parseSlashCommand('STATUS').sub).toBe('status')
+    expect(parseSlashCommand('Query SELECT 1').sub).toBe('query')
+  })
+})

--- a/apps/dashboard/src/lib/slack/slash-parse.ts
+++ b/apps/dashboard/src/lib/slack/slash-parse.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure parser for `/chmonitor <subcommand> [args]` (plans/37).
+ *
+ * Only the subcommands actually implemented this round are recognized
+ * (status | query | alert); anything else resolves to `help` so the command
+ * always responds with usage rather than silently doing nothing. Kept pure so
+ * the dispatch mapping is unit-testable without the route's Worker imports.
+ */
+
+export type SlashSub = 'status' | 'query' | 'alert' | 'help'
+
+export interface ParsedSlash {
+  sub: SlashSub
+  /** Remaining argument text after the subcommand (e.g. the SQL for `query`). */
+  arg: string
+  /** Host index for status/alert; defaults to 0. */
+  hostId: number
+}
+
+const KNOWN: ReadonlySet<string> = new Set(['status', 'query', 'alert'])
+
+export function parseSlashCommand(text: string): ParsedSlash {
+  const trimmed = (text ?? '').trim()
+  if (!trimmed) return { sub: 'help', arg: '', hostId: 0 }
+
+  const firstSpace = trimmed.indexOf(' ')
+  const word = (
+    firstSpace === -1 ? trimmed : trimmed.slice(0, firstSpace)
+  ).toLowerCase()
+  const rest = firstSpace === -1 ? '' : trimmed.slice(firstSpace + 1).trim()
+
+  if (!KNOWN.has(word)) return { sub: 'help', arg: trimmed, hostId: 0 }
+
+  const sub = word as Exclude<SlashSub, 'help'>
+
+  // For status/alert a bare trailing integer selects the host (e.g. "status 1").
+  // For query the whole remainder is SQL, so never treat it as a host index.
+  let hostId = 0
+  let arg = rest
+  if (sub !== 'query' && /^\d+$/.test(rest)) {
+    hostId = Number(rest)
+    arg = ''
+  }
+
+  return { sub, arg, hostId }
+}

--- a/apps/dashboard/src/lib/slack/token-crypto.test.ts
+++ b/apps/dashboard/src/lib/slack/token-crypto.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for at-rest Slack bot-token encryption (plans/37).
+ *
+ * Proves the AES-256-GCM envelope round-trips, that ciphertext is not the
+ * plaintext (token is not stored in the clear), and that decryption fails when
+ * the key material (signing secret) differs — the property that makes a rotated
+ * secret invalidate stored tokens rather than silently leaking them.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test'
+
+const ORIGINAL = process.env.SLACK_SIGNING_SECRET
+const ORIGINAL_KEY = process.env.SLACK_TOKEN_ENCRYPTION_KEY
+
+afterEach(() => {
+  // Restore env so tests stay isolated (config reads process.env live).
+  if (ORIGINAL === undefined) delete process.env.SLACK_SIGNING_SECRET
+  else process.env.SLACK_SIGNING_SECRET = ORIGINAL
+  if (ORIGINAL_KEY === undefined) delete process.env.SLACK_TOKEN_ENCRYPTION_KEY
+  else process.env.SLACK_TOKEN_ENCRYPTION_KEY = ORIGINAL_KEY
+})
+
+describe('token-crypto', () => {
+  test('round-trips a token and does not store it in the clear', async () => {
+    delete process.env.SLACK_TOKEN_ENCRYPTION_KEY
+    process.env.SLACK_SIGNING_SECRET = 'signing-secret-a'
+    const { encryptToken, decryptToken, isTokenEncryptionConfigured } =
+      await import('./token-crypto')
+
+    expect(isTokenEncryptionConfigured()).toBe(true)
+    // A structurally-obvious fake: real bot tokens are `xoxb-…`, but we avoid
+    // that exact shape so secret scanners don't flag this fixture. The crypto
+    // treats the token as an opaque string, so any value exercises the envelope.
+    const token = 'slack-bot-token-example-value-for-tests'
+    const enc = await encryptToken(token)
+    expect(enc).not.toContain(token)
+    expect(enc).not.toBe(token)
+    expect(await decryptToken(enc)).toBe(token)
+  })
+
+  test('a token encrypted under a different signing secret does not decrypt', async () => {
+    delete process.env.SLACK_TOKEN_ENCRYPTION_KEY
+    process.env.SLACK_SIGNING_SECRET = 'signing-secret-a'
+    const cryptoA = await import('./token-crypto')
+    const enc = await cryptoA.encryptToken('xoxb-secret')
+
+    // Rotate the secret; the same module now derives a different key.
+    process.env.SLACK_SIGNING_SECRET = 'signing-secret-b'
+    await expect(cryptoA.decryptToken(enc)).rejects.toThrow()
+  })
+
+  test('encryption is unavailable when no key material is present', async () => {
+    delete process.env.SLACK_TOKEN_ENCRYPTION_KEY
+    delete process.env.SLACK_SIGNING_SECRET
+    const { isTokenEncryptionConfigured, encryptToken } = await import(
+      './token-crypto'
+    )
+    expect(isTokenEncryptionConfigured()).toBe(false)
+    await expect(encryptToken('xoxb-secret')).rejects.toThrow()
+  })
+})

--- a/apps/dashboard/src/lib/slack/token-crypto.ts
+++ b/apps/dashboard/src/lib/slack/token-crypto.ts
@@ -1,0 +1,111 @@
+/**
+ * Server-side AES-256-GCM encryption for stored Slack bot tokens.
+ *
+ * A workspace bot token (`xoxb-…`) is a bearer credential that can post to the
+ * customer's Slack, so it is encrypted at rest in D1 rather than stored raw.
+ * Mirrors lib/connection-store/crypto.ts (which encrypts user ClickHouse
+ * credentials): same AES-256-GCM envelope (version byte + IV + ciphertext,
+ * base64), same "explicit key OR derive from an always-present secret" model.
+ *
+ * Key material, in priority order:
+ *   1. SLACK_TOKEN_ENCRYPTION_KEY — optional dedicated 32-byte base64 key, if
+ *      you want to rotate the data key independently of the signing secret.
+ *   2. Derived (SHA-256) from SLACK_SIGNING_SECRET. The Slack app REQUIRES the
+ *      signing secret to function (every inbound request is verified with it),
+ *      so it is always present when a token is being stored — no extra secret to
+ *      provision. Rotating the signing secret re-keys stored tokens, which means
+ *      workspaces must reinstall; acceptable and loud (decrypt fails → treated as
+ *      "not installed") rather than a silent security downgrade.
+ *
+ * Fail-closed: with no key material available, encryption/decryption throw, so
+ * the OAuth callback refuses to persist a token rather than storing it in the
+ * clear.
+ */
+
+import { getSlackSigningSecret, getSlackTokenEncryptionKey } from './config'
+
+const ALGORITHM = 'AES-GCM'
+const IV_LENGTH = 12
+const VERSION = 1
+
+async function deriveEncryptionKey(): Promise<CryptoKey | null> {
+  const explicit = getSlackTokenEncryptionKey()
+  if (explicit) {
+    const raw = Uint8Array.from(atob(explicit.trim()), (c) => c.charCodeAt(0))
+    if (raw.length !== 32) {
+      throw new Error(
+        'SLACK_TOKEN_ENCRYPTION_KEY must be 32 bytes (base64-encoded)'
+      )
+    }
+    return crypto.subtle.importKey('raw', raw, { name: ALGORITHM }, false, [
+      'encrypt',
+      'decrypt',
+    ])
+  }
+
+  const signingSecret = getSlackSigningSecret()
+  if (!signingSecret) return null
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(`chm:slack-token:v1:${signingSecret}`)
+  )
+  return crypto.subtle.importKey('raw', digest, { name: ALGORITHM }, false, [
+    'encrypt',
+    'decrypt',
+  ])
+}
+
+/** Whether token encryption is available (a dedicated key or the signing secret). */
+export function isTokenEncryptionConfigured(): boolean {
+  return Boolean(getSlackTokenEncryptionKey() || getSlackSigningSecret())
+}
+
+/** Encrypt a bot token to the versioned base64 envelope stored in D1. */
+export async function encryptToken(token: string): Promise<string> {
+  const key = await deriveEncryptionKey()
+  if (!key) {
+    throw new Error(
+      'Slack token encryption unavailable: set SLACK_SIGNING_SECRET (or SLACK_TOKEN_ENCRYPTION_KEY)'
+    )
+  }
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH))
+  const plaintext = new TextEncoder().encode(token)
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: ALGORITHM, iv },
+    key,
+    plaintext
+  )
+
+  const payload = new Uint8Array(1 + IV_LENGTH + ciphertext.byteLength)
+  payload[0] = VERSION
+  payload.set(iv, 1)
+  payload.set(new Uint8Array(ciphertext), 1 + IV_LENGTH)
+
+  return btoa(String.fromCharCode(...payload))
+}
+
+/** Decrypt a stored base64 envelope back to the raw bot token. */
+export async function decryptToken(encrypted: string): Promise<string> {
+  const key = await deriveEncryptionKey()
+  if (!key) {
+    throw new Error(
+      'Slack token encryption unavailable: set SLACK_SIGNING_SECRET (or SLACK_TOKEN_ENCRYPTION_KEY)'
+    )
+  }
+  const payload = Uint8Array.from(atob(encrypted), (c) => c.charCodeAt(0))
+
+  if (payload[0] !== VERSION) {
+    throw new Error('Unsupported encryption version')
+  }
+
+  const iv = payload.slice(1, 1 + IV_LENGTH)
+  const ciphertext = payload.slice(1 + IV_LENGTH)
+
+  const plaintext = await crypto.subtle.decrypt(
+    { name: ALGORITHM, iv },
+    key,
+    ciphertext
+  )
+
+  return new TextDecoder().decode(plaintext)
+}

--- a/apps/dashboard/src/lib/slack/verify-signature.test.ts
+++ b/apps/dashboard/src/lib/slack/verify-signature.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Real-crypto tests for the Slack request signature gate — the inbound-auth
+ * invariant of plans/37-slack-app-native-oauth.md: chmonitor never trusts a
+ * Slack payload it can't verify, and rejects replays. No mocks — this computes
+ * real HMAC-SHA256 signatures over the `v0:${ts}:${body}` basestring so the
+ * accept/reject paths are proven against the actual crypto.
+ *
+ * Covers the plan's required assertions: a correctly-signed request passes, a
+ * tampered body is rejected, and a stale timestamp is rejected.
+ */
+
+import {
+  computeSlackSignature,
+  MAX_TIMESTAMP_SKEW_SECONDS,
+  verifySlackRequest,
+} from './verify-signature'
+import { describe, expect, test } from 'bun:test'
+
+const SECRET = 'test-signing-secret'
+// A representative slash-command body (application/x-www-form-urlencoded).
+const BODY =
+  'token=xxx&team_id=T123&command=%2Fchmonitor&text=status&response_url=https%3A%2F%2Fhooks.slack.com%2Fx'
+const NOW = 1_700_000_000
+
+describe('verifySlackRequest', () => {
+  test('a correctly-signed, fresh request is accepted', async () => {
+    const ts = String(NOW)
+    const signature = await computeSlackSignature(SECRET, ts, BODY)
+    expect(
+      await verifySlackRequest({
+        signingSecret: SECRET,
+        signature,
+        timestamp: ts,
+        rawBody: BODY,
+        nowSeconds: NOW,
+      })
+    ).toBe(true)
+  })
+
+  test('a tampered body is rejected', async () => {
+    const ts = String(NOW)
+    const signature = await computeSlackSignature(SECRET, ts, BODY)
+    const tampered = BODY.replace('text=status', 'text=drop+table')
+    expect(
+      await verifySlackRequest({
+        signingSecret: SECRET,
+        signature,
+        timestamp: ts,
+        rawBody: tampered,
+        nowSeconds: NOW,
+      })
+    ).toBe(false)
+  })
+
+  test('a stale timestamp (beyond the skew window) is rejected even if signed', async () => {
+    const staleTs = String(NOW - MAX_TIMESTAMP_SKEW_SECONDS - 1)
+    // Signature is valid for the stale timestamp, but freshness must still fail.
+    const signature = await computeSlackSignature(SECRET, staleTs, BODY)
+    expect(
+      await verifySlackRequest({
+        signingSecret: SECRET,
+        signature,
+        timestamp: staleTs,
+        rawBody: BODY,
+        nowSeconds: NOW,
+      })
+    ).toBe(false)
+  })
+
+  test('a future timestamp beyond the skew window is rejected (replay/clock skew)', async () => {
+    const futureTs = String(NOW + MAX_TIMESTAMP_SKEW_SECONDS + 1)
+    const signature = await computeSlackSignature(SECRET, futureTs, BODY)
+    expect(
+      await verifySlackRequest({
+        signingSecret: SECRET,
+        signature,
+        timestamp: futureTs,
+        rawBody: BODY,
+        nowSeconds: NOW,
+      })
+    ).toBe(false)
+  })
+
+  test('a signature computed with the wrong secret is rejected', async () => {
+    const ts = String(NOW)
+    const signature = await computeSlackSignature(
+      'a-different-secret',
+      ts,
+      BODY
+    )
+    expect(
+      await verifySlackRequest({
+        signingSecret: SECRET,
+        signature,
+        timestamp: ts,
+        rawBody: BODY,
+        nowSeconds: NOW,
+      })
+    ).toBe(false)
+  })
+
+  test('missing signature / timestamp headers are rejected', async () => {
+    const ts = String(NOW)
+    const signature = await computeSlackSignature(SECRET, ts, BODY)
+    expect(
+      await verifySlackRequest({
+        signingSecret: SECRET,
+        signature: null,
+        timestamp: ts,
+        rawBody: BODY,
+        nowSeconds: NOW,
+      })
+    ).toBe(false)
+    expect(
+      await verifySlackRequest({
+        signingSecret: SECRET,
+        signature,
+        timestamp: null,
+        rawBody: BODY,
+        nowSeconds: NOW,
+      })
+    ).toBe(false)
+  })
+
+  test('a signature header missing the v0= prefix is rejected', async () => {
+    const ts = String(NOW)
+    const signature = await computeSlackSignature(SECRET, ts, BODY)
+    const rawHex = signature.replace('v0=', '')
+    expect(
+      await verifySlackRequest({
+        signingSecret: SECRET,
+        signature: rawHex,
+        timestamp: ts,
+        rawBody: BODY,
+        nowSeconds: NOW,
+      })
+    ).toBe(false)
+  })
+
+  test('a non-numeric timestamp is rejected', async () => {
+    const signature = await computeSlackSignature(SECRET, 'not-a-number', BODY)
+    expect(
+      await verifySlackRequest({
+        signingSecret: SECRET,
+        signature,
+        timestamp: 'not-a-number',
+        rawBody: BODY,
+        nowSeconds: NOW,
+      })
+    ).toBe(false)
+  })
+
+  test('an empty signing secret is rejected', async () => {
+    const ts = String(NOW)
+    const signature = await computeSlackSignature(SECRET, ts, BODY)
+    expect(
+      await verifySlackRequest({
+        signingSecret: '',
+        signature,
+        timestamp: ts,
+        rawBody: BODY,
+        nowSeconds: NOW,
+      })
+    ).toBe(false)
+  })
+})

--- a/apps/dashboard/src/lib/slack/verify-signature.ts
+++ b/apps/dashboard/src/lib/slack/verify-signature.ts
@@ -1,0 +1,112 @@
+/**
+ * Slack request signature verification (X-Slack-Signature).
+ *
+ * Slack signs every inbound request (slash commands, interactivity, events)
+ * with HMAC-SHA256 over the string `v0:${timestamp}:${rawBody}` using the app's
+ * signing secret, and sends the result as `X-Slack-Signature: v0=<hex>` plus the
+ * `X-Slack-Request-Timestamp` header. This is the ONLY auth for those inbound
+ * routes — an unsigned, mismatched, or stale request MUST be rejected before
+ * anything in the body is trusted or acted upon.
+ *
+ * CRITICAL: the signature is computed over the RAW request body, so the caller
+ * must read `await request.text()` and pass that exact string here BEFORE any
+ * `request.formData()` / `request.json()` parse (which would consume the body).
+ *
+ * Two independent checks, both required:
+ *  1. Timestamp freshness — reject if the request timestamp is more than
+ *     {@link MAX_TIMESTAMP_SKEW_SECONDS} away from now (replay protection).
+ *  2. Signature match — constant-time compare of the recomputed `v0=<hex>`
+ *     against the header.
+ *
+ * Uses the Web Crypto API (available in the Cloudflare Workers runtime and Bun,
+ * so this is directly unit-testable) and the shared constant-time comparator so
+ * this security-critical primitive isn't reimplemented. Mirrors the shape of
+ * lib/deployments/verify-signature.ts (GitHub) and the Polar/Clerk handlers.
+ */
+import { constantTimeEqual } from '@/lib/auth/providers/constant-time'
+
+const SIGNATURE_VERSION = 'v0'
+const SIGNATURE_PREFIX = `${SIGNATURE_VERSION}=`
+
+/** Reject requests whose timestamp is more than 5 minutes from now. */
+export const MAX_TIMESTAMP_SKEW_SECONDS = 60 * 5
+
+async function hmacSha256Hex(secret: string, message: string): Promise<string> {
+  const encoder = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+  const digest = await crypto.subtle.sign('HMAC', key, encoder.encode(message))
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/**
+ * Compute the `v0=<hex>` signature Slack sends in `X-Slack-Signature` for a
+ * given raw body + timestamp. Exported for tests (to forge a valid signature).
+ */
+export async function computeSlackSignature(
+  signingSecret: string,
+  timestamp: string,
+  rawBody: string
+): Promise<string> {
+  const basestring = `${SIGNATURE_VERSION}:${timestamp}:${rawBody}`
+  return `${SIGNATURE_PREFIX}${await hmacSha256Hex(signingSecret, basestring)}`
+}
+
+export interface VerifySlackRequestInput {
+  /** The app signing secret (`SLACK_SIGNING_SECRET`). */
+  signingSecret: string
+  /** The `X-Slack-Signature` header value (`v0=<hex>`). */
+  signature: string | null | undefined
+  /** The `X-Slack-Request-Timestamp` header value (unix seconds, as string). */
+  timestamp: string | null | undefined
+  /** The exact raw request body the signature was computed over. */
+  rawBody: string
+  /** Injectable clock (unix seconds) for tests. Defaults to `Date.now()/1000`. */
+  nowSeconds?: number
+  /** Override the max allowed skew (seconds). Defaults to 5 minutes. */
+  maxSkewSeconds?: number
+}
+
+/**
+ * Verify a Slack inbound request. Returns `true` only when the timestamp is
+ * fresh AND the signature matches (constant-time). Returns `false` for a
+ * missing/blank header, a non-`v0=` prefix, a non-numeric or stale timestamp,
+ * or a signature computed with a different secret and/or over a tampered body.
+ * Never throws.
+ */
+export async function verifySlackRequest(
+  input: VerifySlackRequestInput
+): Promise<boolean> {
+  const {
+    signingSecret,
+    signature,
+    timestamp,
+    rawBody,
+    nowSeconds = Math.floor(Date.now() / 1000),
+    maxSkewSeconds = MAX_TIMESTAMP_SKEW_SECONDS,
+  } = input
+
+  if (!signingSecret) return false
+  if (!signature || !signature.startsWith(SIGNATURE_PREFIX)) return false
+  if (!timestamp) return false
+
+  const ts = Number(timestamp)
+  if (!Number.isFinite(ts)) return false
+  if (Math.abs(nowSeconds - ts) > maxSkewSeconds) return false
+
+  const expected = await computeSlackSignature(
+    signingSecret,
+    timestamp,
+    rawBody
+  )
+
+  const encoder = new TextEncoder()
+  return constantTimeEqual(encoder.encode(expected), encoder.encode(signature))
+}

--- a/apps/dashboard/src/routes/api/v1/slack/commands.test.ts
+++ b/apps/dashboard/src/routes/api/v1/slack/commands.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Route-level tests for the /chmonitor slash command (plans/37).
+ *
+ * Exercises the real inbound auth path end-to-end (readAndVerifySlackRequest →
+ * verifySlackRequest with real HMAC) via the exported test handler, using real
+ * env (config reads process.env live) so no mocking of the security core is
+ * needed. Only the CH-free `help` path is driven so the test needs no
+ * ClickHouse — the query/status/alert data paths are covered by their own pure
+ * builders' tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+const SECRET = 'route-signing-secret'
+
+const saved = {
+  id: process.env.SLACK_CLIENT_ID,
+  secret: process.env.SLACK_CLIENT_SECRET,
+  signing: process.env.SLACK_SIGNING_SECRET,
+}
+
+function configure(on: boolean): void {
+  if (on) {
+    process.env.SLACK_CLIENT_ID = 'client-id'
+    process.env.SLACK_CLIENT_SECRET = 'client-secret'
+    process.env.SLACK_SIGNING_SECRET = SECRET
+  } else {
+    delete process.env.SLACK_CLIENT_ID
+    delete process.env.SLACK_CLIENT_SECRET
+    delete process.env.SLACK_SIGNING_SECRET
+  }
+}
+
+beforeEach(() => configure(true))
+afterEach(() => {
+  // Restore original env so other suites stay isolated.
+  for (const [k, v] of [
+    ['SLACK_CLIENT_ID', saved.id],
+    ['SLACK_CLIENT_SECRET', saved.secret],
+    ['SLACK_SIGNING_SECRET', saved.signing],
+  ] as const) {
+    if (v === undefined) delete process.env[k]
+    else process.env[k] = v
+  }
+})
+
+async function signedRequest(text: string): Promise<Request> {
+  const { computeSlackSignature } = await import('@/lib/slack/verify-signature')
+  const body = new URLSearchParams({ command: '/chmonitor', text }).toString()
+  const ts = String(Math.floor(Date.now() / 1000))
+  const signature = await computeSlackSignature(SECRET, ts, body)
+  return new Request('https://dash.example.dev/api/v1/slack/commands', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+      'x-slack-signature': signature,
+      'x-slack-request-timestamp': ts,
+    },
+    body,
+  })
+}
+
+describe('POST /api/v1/slack/commands', () => {
+  test('unconfigured → 501 (fail closed)', async () => {
+    configure(false)
+    const { __handlePostForTests } = await import('./commands')
+    const res = await __handlePostForTests(await signedRequest(''))
+    expect(res.status).toBe(501)
+  })
+
+  test('invalid signature → 401', async () => {
+    const { __handlePostForTests } = await import('./commands')
+    const body = new URLSearchParams({ text: 'help' }).toString()
+    const req = new Request('https://dash.example.dev/api/v1/slack/commands', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-slack-signature': 'v0=deadbeef',
+        'x-slack-request-timestamp': String(Math.floor(Date.now() / 1000)),
+      },
+      body,
+    })
+    const res = await __handlePostForTests(req)
+    expect(res.status).toBe(401)
+  })
+
+  test('validly-signed help command → 200 ephemeral blocks', async () => {
+    const { __handlePostForTests } = await import('./commands')
+    const res = await __handlePostForTests(await signedRequest(''))
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as {
+      response_type: string
+      blocks: unknown[]
+    }
+    expect(json.response_type).toBe('ephemeral')
+    expect(Array.isArray(json.blocks)).toBe(true)
+    expect(JSON.stringify(json.blocks)).toContain('/chmonitor status')
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/slack/commands.ts
+++ b/apps/dashboard/src/routes/api/v1/slack/commands.ts
@@ -121,11 +121,17 @@ async function runQuery(sql: string): Promise<SlackBlock[]> {
 
   // … plus hard read-only + row/time caps as defense-in-depth and to keep the
   // response within Slack's 3s budget. `result_overflow_mode: 'break'` stops at
-  // the row cap WITHOUT erroring (unlike the default 'throw'). Typed as a
-  // widened record (matching explorer/query.ts) since the per-key ClickHouse
-  // setting types want string values for readonly/max_result_rows.
+  // the row cap WITHOUT erroring (unlike the default 'throw').
+  //
+  // `readonly: 2` (NOT 1): level 1 forbids write queries AND changing any other
+  // setting in the same request, so pairing it with the caps below would throw
+  // "Cannot modify 'max_execution_time' setting in readonly mode". Level 2 still
+  // blocks writes (SELECT/SHOW only) but permits per-query settings — exactly
+  // what we need. `validateSqlQuery` already enforced SELECT-only above, so this
+  // is belt-and-suspenders. Typed as a widened record (matching explorer/query.ts)
+  // since the per-key ClickHouse setting types want string values here.
   const clickhouse_settings: Record<string, string | number> = {
-    readonly: 1,
+    readonly: 2,
     max_execution_time: QUERY_MAX_EXEC_SECONDS,
     max_result_rows: QUERY_ROW_CAP + 1,
     result_overflow_mode: 'break',

--- a/apps/dashboard/src/routes/api/v1/slack/commands.ts
+++ b/apps/dashboard/src/routes/api/v1/slack/commands.ts
@@ -1,0 +1,221 @@
+/**
+ * POST /api/v1/slack/commands — the `/chmonitor` slash command.
+ *
+ * Verifies the Slack signature over the RAW body, then dispatches the
+ * subcommand and responds SYNCHRONOUSLY with Block Kit blocks in the HTTP 200
+ * body (Slack renders the response body when it arrives within the 3s ack
+ * budget).
+ *
+ * Why synchronous (not the deferred `response_url` pattern): this app has no
+ * `ExecutionContext.waitUntil` plumbed through (see lib/events/outbound-bus.ts),
+ * so work kicked off after responding would be frozen with the isolate. We
+ * therefore keep each subcommand within budget and answer inline:
+ *   - status : one parallel incident snapshot (~1 CH round-trip).
+ *   - query  : ONE read-only SELECT, hard-capped `max_execution_time` +
+ *              `max_result_rows` so a slow/huge query fails within budget with
+ *              a helpful message instead of blowing the ack.
+ *   - alert  : a fast D1 read of recent alert history (no CH, no sweep — a
+ *              slash command must never trigger the webhook fan-out).
+ *
+ * Responses are `ephemeral` (only the invoking user sees them) so query output
+ * never leaks into a channel.
+ *
+ * Auth: the Slack signature IS the auth — this route never requires Clerk (it
+ * rides the same public/`publicRead` passthrough as the github/polar webhooks).
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+import type { DataFormat } from '@clickhouse/client'
+
+import { env } from 'cloudflare:workers'
+import { fetchData, getClickHouseConfigs } from '@chm/clickhouse-client'
+import { error as logError } from '@chm/logger'
+import { validateSqlQuery } from '@chm/sql-builder'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { queryAlertEvents } from '@/lib/health/alert-history-store'
+import { captureIncidentSnapshot } from '@/lib/health/incident-snapshot'
+import {
+  buildAlertListBlocks,
+  buildQueryResultBlocks,
+  buildStatusBlocks,
+  type SlackBlock,
+} from '@/lib/slack/blocks'
+import { readAndVerifySlackRequest } from '@/lib/slack/inbound'
+import { parseSlashCommand } from '@/lib/slack/slash-parse'
+
+/** Read-only query caps so `query` always answers within Slack's 3s budget. */
+const QUERY_MAX_EXEC_SECONDS = 3
+const QUERY_ROW_CAP = 20
+/** Recent alerts shown by `/chmonitor alert`. */
+const ALERT_LIST_LIMIT = 10
+
+/** Slack ephemeral response envelope. */
+function ephemeral(blocks: SlackBlock[]): Response {
+  return Response.json({ response_type: 'ephemeral', blocks })
+}
+
+function hostLabelFor(hostId: number): string {
+  try {
+    const configs = getClickHouseConfigs()
+    const cfg = configs[hostId]
+    if (!cfg) return `host ${hostId}`
+    return cfg.customName?.trim() || cfg.host
+  } catch {
+    return `host ${hostId}`
+  }
+}
+
+function helpBlocks(): SlackBlock[] {
+  return [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: 'chmonitor', emoji: true },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: [
+          'Usage:',
+          '• `/chmonitor status [hostId]` — cluster health summary',
+          '• `/chmonitor query <SQL>` — run a read-only SELECT (capped)',
+          '• `/chmonitor alert` — recent firing alerts',
+        ].join('\n'),
+      },
+    },
+  ]
+}
+
+async function runStatus(hostId: number): Promise<SlackBlock[]> {
+  const snapshot = await captureIncidentSnapshot(hostId)
+  return buildStatusBlocks(hostLabelFor(hostId), snapshot)
+}
+
+async function runQuery(sql: string): Promise<SlackBlock[]> {
+  if (!sql) {
+    return [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: 'Provide a query, e.g. `/chmonitor query SELECT count() FROM system.tables`',
+        },
+      },
+    ]
+  }
+
+  // SELECT-only guard (throws on DML/DDL/multi-statement) …
+  try {
+    validateSqlQuery(sql)
+  } catch (err) {
+    return [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `:x: ${err instanceof Error ? err.message : 'Only read-only SELECT queries are allowed.'}`,
+        },
+      },
+    ]
+  }
+
+  // … plus hard read-only + row/time caps as defense-in-depth and to keep the
+  // response within Slack's 3s budget. `result_overflow_mode: 'break'` stops at
+  // the row cap WITHOUT erroring (unlike the default 'throw'). Typed as a
+  // widened record (matching explorer/query.ts) since the per-key ClickHouse
+  // setting types want string values for readonly/max_result_rows.
+  const clickhouse_settings: Record<string, string | number> = {
+    readonly: 1,
+    max_execution_time: QUERY_MAX_EXEC_SECONDS,
+    max_result_rows: QUERY_ROW_CAP + 1,
+    result_overflow_mode: 'break',
+  }
+
+  const result = await fetchData<Array<Record<string, unknown>>>({
+    query: sql,
+    hostId: 0,
+    format: 'JSONEachRow' as DataFormat,
+    clickhouse_settings,
+  })
+
+  if (result.error) {
+    return [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `:x: Query failed: ${result.error.message}`,
+        },
+      },
+    ]
+  }
+
+  const rows = result.data ?? []
+  const truncated = rows.length > QUERY_ROW_CAP
+  return buildQueryResultBlocks(sql, rows, {
+    rowCap: QUERY_ROW_CAP,
+    durationMs: Number(result.metadata.duration ?? 0) || undefined,
+    truncated,
+  })
+}
+
+async function runAlert(): Promise<SlackBlock[]> {
+  const events = await queryAlertEvents({ limit: ALERT_LIST_LIMIT * 2 })
+  // "Firing" = the most recent non-recovery events.
+  const firing = events
+    .filter((e) => e.severity !== 'recovery')
+    .slice(0, ALERT_LIST_LIMIT)
+  return buildAlertListBlocks(firing)
+}
+
+async function handlePost(request: Request): Promise<Response> {
+  const { configured, verified, rawBody } =
+    await readAndVerifySlackRequest(request)
+  if (!configured) {
+    return Response.json({ error: 'Slack app not configured' }, { status: 501 })
+  }
+  if (!verified) {
+    return Response.json({ error: 'Invalid signature' }, { status: 401 })
+  }
+
+  // CH-querying subcommands need CLICKHOUSE_* on process.env (workerd binding).
+  bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+  const params = new URLSearchParams(rawBody)
+  const { sub, arg, hostId } = parseSlashCommand(params.get('text') ?? '')
+
+  try {
+    switch (sub) {
+      case 'status':
+        return ephemeral(await runStatus(hostId))
+      case 'query':
+        return ephemeral(await runQuery(arg))
+      case 'alert':
+        return ephemeral(await runAlert())
+      default:
+        return ephemeral(helpBlocks())
+    }
+  } catch (err) {
+    logError('[slack-commands] handler error', err)
+    return ephemeral([
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: ':x: Something went wrong handling that command. Please try again.',
+        },
+      },
+    ])
+  }
+}
+
+export const Route = createFileRoute('/api/v1/slack/commands')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})
+
+// Exported for unit tests only.
+export { handlePost as __handlePostForTests }

--- a/apps/dashboard/src/routes/api/v1/slack/events.ts
+++ b/apps/dashboard/src/routes/api/v1/slack/events.ts
@@ -26,8 +26,8 @@ import { queryAlertEvents } from '@/lib/health/alert-history-store'
 import { captureIncidentSnapshot } from '@/lib/health/incident-snapshot'
 import { publishHomeView } from '@/lib/slack/api'
 import { buildHomeTabView, type HomeHostSummary } from '@/lib/slack/blocks'
-import { getInstallation } from '@/lib/slack/install-store'
 import { readAndVerifySlackRequest } from '@/lib/slack/inbound'
+import { getInstallation } from '@/lib/slack/install-store'
 
 /** Cap how many hosts the Home tab summarizes so it stays within the ack budget. */
 const HOME_HOST_CAP = 5

--- a/apps/dashboard/src/routes/api/v1/slack/events.ts
+++ b/apps/dashboard/src/routes/api/v1/slack/events.ts
@@ -1,0 +1,143 @@
+/**
+ * POST /api/v1/slack/events — Slack Events API subscription endpoint.
+ *
+ * Verifies the Slack signature over the RAW body, then handles:
+ *   - `url_verification` — echo the one-time `challenge` (used when you set the
+ *     Events request URL in the Slack app config).
+ *   - `app_home_opened` — publish the chmonitor Home tab (per-host health
+ *     summary + how to use the slash commands + a dashboard link) for the
+ *     opening user, using the workspace's stored bot token.
+ *
+ * Publishing happens INLINE before the 200 (this app has no waitUntil): the
+ * Home view is built from a light, bounded set of parallel reads so it stays
+ * within Slack's ack budget, and `views.publish` is idempotent so a Slack retry
+ * simply republishes.
+ *
+ * Auth: the Slack signature IS the auth; never requires Clerk.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { getClickHouseConfigs } from '@chm/clickhouse-client'
+import { error as logError } from '@chm/logger'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import { queryAlertEvents } from '@/lib/health/alert-history-store'
+import { captureIncidentSnapshot } from '@/lib/health/incident-snapshot'
+import { publishHomeView } from '@/lib/slack/api'
+import { buildHomeTabView, type HomeHostSummary } from '@/lib/slack/blocks'
+import { getInstallation } from '@/lib/slack/install-store'
+import { readAndVerifySlackRequest } from '@/lib/slack/inbound'
+
+/** Cap how many hosts the Home tab summarizes so it stays within the ack budget. */
+const HOME_HOST_CAP = 5
+
+interface SlackEventEnvelope {
+  type?: string
+  challenge?: string
+  team_id?: string
+  event?: { type?: string; user?: string }
+}
+
+const OK = new Response(null, { status: 200 })
+
+async function buildHomeSummaries(): Promise<HomeHostSummary[]> {
+  bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+  let configs: ReturnType<typeof getClickHouseConfigs>
+  try {
+    configs = getClickHouseConfigs().slice(0, HOME_HOST_CAP)
+  } catch {
+    return []
+  }
+  if (configs.length === 0) return []
+
+  // Recent firing counts per host (fast D1 read; [] when no D1).
+  const events = await queryAlertEvents({ limit: 100 })
+  const firingByHost = new Map<number, number>()
+  for (const e of events) {
+    if (e.severity === 'recovery') continue
+    firingByHost.set(e.hostId, (firingByHost.get(e.hostId) ?? 0) + 1)
+  }
+
+  // Memory/disk snapshots in parallel (~1 CH round-trip total).
+  const snapshots = await Promise.all(
+    configs.map((c) => captureIncidentSnapshot(c.id).catch(() => null))
+  )
+
+  return configs.map((c, i) => ({
+    hostId: c.id,
+    label: c.customName?.trim() || c.host,
+    memoryUsagePct: snapshots[i]?.memoryUsagePct ?? null,
+    diskUsagePct: snapshots[i]?.diskUsagePct ?? null,
+    firing: firingByHost.get(c.id) ?? 0,
+  }))
+}
+
+async function handleAppHomeOpened(
+  teamId: string | undefined,
+  userId: string | undefined,
+  request: Request
+): Promise<void> {
+  if (!teamId || !userId) return
+  const install = await getInstallation(teamId)
+  if (!install) return // workspace not installed / token unusable
+
+  const summaries = await buildHomeSummaries()
+  const view = buildHomeTabView(summaries, {
+    dashboardUrl: new URL(request.url).origin,
+  })
+  await publishHomeView({ botToken: install.botToken, userId, view })
+}
+
+async function handlePost(request: Request): Promise<Response> {
+  const { configured, verified, rawBody } =
+    await readAndVerifySlackRequest(request)
+  if (!configured) {
+    return Response.json({ error: 'Slack app not configured' }, { status: 501 })
+  }
+  if (!verified) {
+    return Response.json({ error: 'Invalid signature' }, { status: 401 })
+  }
+
+  let envelope: SlackEventEnvelope
+  try {
+    envelope = JSON.parse(rawBody) as SlackEventEnvelope
+  } catch {
+    return Response.json({ error: 'Bad request' }, { status: 400 })
+  }
+
+  // URL verification handshake.
+  if (envelope.type === 'url_verification') {
+    return new Response(envelope.challenge ?? '', {
+      status: 200,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    })
+  }
+
+  if (
+    envelope.type === 'event_callback' &&
+    envelope.event?.type === 'app_home_opened'
+  ) {
+    try {
+      await handleAppHomeOpened(envelope.team_id, envelope.event.user, request)
+    } catch (err) {
+      // Never fail the event ack over a Home-tab publish error — Slack would
+      // just retry; log and 200 so it stops.
+      logError('[slack-events] app_home_opened publish failed', err)
+    }
+  }
+
+  return OK
+}
+
+export const Route = createFileRoute('/api/v1/slack/events')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})
+
+// Exported for unit tests only.
+export { handlePost as __handlePostForTests }

--- a/apps/dashboard/src/routes/api/v1/slack/install.ts
+++ b/apps/dashboard/src/routes/api/v1/slack/install.ts
@@ -1,0 +1,78 @@
+/**
+ * GET /api/v1/slack/install — begin the Slack app OAuth install.
+ *
+ * The "Add to chmonitor to Slack" entry point. Builds the Slack authorize URL
+ * with the configured scopes, this app's redirect URI, and a signed `state`
+ * (CSRF) that binds the install to the current chmonitor owner, then 302s the
+ * browser to Slack.
+ *
+ * Fails closed: with the Slack app unconfigured (OSS default) this returns 501
+ * and nothing happens. Does NOT require sign-in — owner binding is best-effort
+ * (a signed-in Clerk/proxy user is bound by subject; otherwise the install is
+ * single-tenant `default`), so the app works for self-hosted OSS with no auth.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { getAuthProvider } from '@/lib/auth/provider'
+import { resolveServerAuthProvider } from '@/lib/auth/providers'
+import {
+  getSlackClientId,
+  getSlackOAuthRedirectUrl,
+  getSlackSigningSecret,
+  isSlackAppConfigured,
+  SLACK_AUTHORIZE_URL,
+  SLACK_BOT_SCOPES,
+} from '@/lib/slack/config'
+import { signOAuthState } from '@/lib/slack/oauth-state'
+
+/** Best-effort chmonitor owner ref for this install. */
+async function resolveOwnerRef(request: Request): Promise<string> {
+  try {
+    const provider = getAuthProvider()
+    if (provider === 'none') return 'default'
+    const result =
+      await resolveServerAuthProvider(provider).authenticateRequest(request)
+    return result.authenticated && result.subject ? result.subject : 'default'
+  } catch {
+    return 'default'
+  }
+}
+
+async function handleGet(request: Request): Promise<Response> {
+  if (!isSlackAppConfigured()) {
+    return Response.json({ error: 'Slack app not configured' }, { status: 501 })
+  }
+
+  const clientId = getSlackClientId()
+  const signingSecret = getSlackSigningSecret()
+  // isSlackAppConfigured() guarantees both, but narrow for the type-checker.
+  if (!clientId || !signingSecret) {
+    return Response.json({ error: 'Slack app not configured' }, { status: 501 })
+  }
+
+  const ownerRef = await resolveOwnerRef(request)
+  const state = await signOAuthState(signingSecret, ownerRef)
+
+  const url = new URL(SLACK_AUTHORIZE_URL)
+  url.searchParams.set('client_id', clientId)
+  url.searchParams.set('scope', SLACK_BOT_SCOPES.join(','))
+  url.searchParams.set('redirect_uri', getSlackOAuthRedirectUrl(request))
+  url.searchParams.set('state', state)
+
+  return new Response(null, {
+    status: 302,
+    headers: { Location: url.toString() },
+  })
+}
+
+export const Route = createFileRoute('/api/v1/slack/install')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => handleGet(request),
+    },
+  },
+})
+
+// Exported for unit tests only.
+export { handleGet as __handleGetForTests }

--- a/apps/dashboard/src/routes/api/v1/slack/interactions.ts
+++ b/apps/dashboard/src/routes/api/v1/slack/interactions.ts
@@ -1,0 +1,120 @@
+/**
+ * POST /api/v1/slack/interactions — Slack interactivity (Block Kit actions).
+ *
+ * Handles the "Acknowledge" button on pushed alert messages: verify the Slack
+ * signature over the RAW body → decode the button `value` (the alert dedup key)
+ * → write an ACK to the alert-ack store (actor = the Slack user) → edit the
+ * original message via its `response_url` to show "Acknowledged by @user".
+ *
+ * The ACK write is intentionally minimal and does NOT feed back into the
+ * sweep's in-memory dedup (`alert-state-store.ts`) — that coupling is roadmap
+ * 29's job; adding it here would be inventing a parallel state store.
+ *
+ * SSRF: `response_url` comes from the (verified) Slack payload but is still
+ * checked against a Slack-host allowlist AND the shared SSRF guard before we
+ * POST to it (see lib/slack/api.ts).
+ *
+ * Auth: the Slack signature IS the auth; never requires Clerk.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { error as logError } from '@chm/logger'
+import { recordAlertAck } from '@/lib/health/alert-ack-store'
+import { postToResponseUrl } from '@/lib/slack/api'
+import {
+  ACK_ACTION_ID,
+  buildAckedMessageBlocks,
+  decodeAckValue,
+  type SlackBlock,
+} from '@/lib/slack/blocks'
+import { readAndVerifySlackRequest } from '@/lib/slack/inbound'
+
+interface SlackAction {
+  action_id?: string
+  value?: string
+  type?: string
+}
+
+interface SlackInteractionPayload {
+  type?: string
+  user?: { id?: string; username?: string; name?: string }
+  response_url?: string
+  message?: { blocks?: SlackBlock[] }
+  actions?: SlackAction[]
+}
+
+/** Empty 200 — acknowledges the interaction without posting a new message. */
+const OK = new Response(null, { status: 200 })
+
+async function handlePost(request: Request): Promise<Response> {
+  const { configured, verified, rawBody } =
+    await readAndVerifySlackRequest(request)
+  if (!configured) {
+    return Response.json({ error: 'Slack app not configured' }, { status: 501 })
+  }
+  if (!verified) {
+    return Response.json({ error: 'Invalid signature' }, { status: 401 })
+  }
+
+  // Interaction payloads arrive as a form field `payload` containing JSON.
+  const encoded = new URLSearchParams(rawBody).get('payload')
+  if (!encoded) return OK
+
+  let payload: SlackInteractionPayload
+  try {
+    payload = JSON.parse(encoded) as SlackInteractionPayload
+  } catch {
+    return OK
+  }
+
+  if (payload.type !== 'block_actions') return OK
+
+  const ackAction = payload.actions?.find((a) => a.action_id === ACK_ACTION_ID)
+  if (!ackAction) return OK
+
+  const ackKey = decodeAckValue(ackAction.value)
+  if (!ackKey) {
+    logError('[slack-interactions] ACK with malformed value')
+    return OK
+  }
+
+  const userId = payload.user?.id ?? 'unknown'
+  const userName = payload.user?.name ?? payload.user?.username ?? null
+  const nowIso = new Date().toISOString()
+
+  // Persist the ACK (best-effort; a failed write still edits the message so the
+  // user gets feedback — the store logs its own failures).
+  await recordAlertAck({
+    ackKey: `${ackKey.hostId}:${ackKey.ruleId}:${ackKey.severity}`,
+    hostId: ackKey.hostId,
+    ruleId: ackKey.ruleId,
+    severity: ackKey.severity,
+    ackedBy: userId,
+    ackedByName: userName,
+    source: 'slack',
+    ackedAt: Date.now(),
+  })
+
+  // Edit the original message: drop the button, append an "acked by" line.
+  const originalBlocks = payload.message?.blocks ?? []
+  if (payload.response_url) {
+    await postToResponseUrl(payload.response_url, {
+      replace_original: true,
+      blocks: buildAckedMessageBlocks(originalBlocks, userId, nowIso),
+    })
+  }
+
+  return OK
+}
+
+export const Route = createFileRoute('/api/v1/slack/interactions')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})
+
+// Exported for unit tests only.
+export { handlePost as __handlePostForTests }

--- a/apps/dashboard/src/routes/api/v1/slack/oauth.ts
+++ b/apps/dashboard/src/routes/api/v1/slack/oauth.ts
@@ -1,0 +1,158 @@
+/**
+ * GET /api/v1/slack/oauth — Slack OAuth redirect (callback) URI.
+ *
+ * The URL registered as the app's Redirect URL in the Slack app config. Slack
+ * sends the browser here after the user approves the install, with `?code` and
+ * the `?state` we issued at /api/v1/slack/install.
+ *
+ * Flow: verify `state` (CSRF — Slack does NOT sign this redirect, so state is
+ * the only defense) → exchange `code` for a workspace bot token via
+ * oauth.v2.access → persist the ENCRYPTED token in D1, bound to the owner ref
+ * carried in the (signed, tamper-proof) state. Never logs the code or token.
+ *
+ * Fails closed: 501 when the Slack app is unconfigured. A denied consent, a
+ * bad/expired state, or a failed exchange render a small self-contained result
+ * page (no dependency on a dashboard UI route) rather than leaking detail.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { error as logError } from '@chm/logger'
+import { exchangeOAuthCode } from '@/lib/slack/api'
+import {
+  getSlackClientId,
+  getSlackClientSecret,
+  getSlackOAuthRedirectUrl,
+  getSlackSigningSecret,
+  isSlackAppConfigured,
+} from '@/lib/slack/config'
+import { upsertInstallation } from '@/lib/slack/install-store'
+import { verifyOAuthState } from '@/lib/slack/oauth-state'
+
+/** Minimal self-contained result page (success or failure). */
+function resultPage(title: string, message: string, ok: boolean): Response {
+  const color = ok ? '#16a34a' : '#dc2626'
+  const html = `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>${title}</title></head><body style="font-family:system-ui,sans-serif;max-width:32rem;margin:4rem auto;padding:0 1rem;text-align:center"><h1 style="color:${color}">${title}</h1><p style="color:#475569">${message}</p></body></html>`
+  return new Response(html, {
+    status: ok ? 200 : 400,
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+  })
+}
+
+async function handleGet(request: Request): Promise<Response> {
+  if (!isSlackAppConfigured()) {
+    return Response.json({ error: 'Slack app not configured' }, { status: 501 })
+  }
+
+  const clientId = getSlackClientId()
+  const clientSecret = getSlackClientSecret()
+  const signingSecret = getSlackSigningSecret()
+  if (!clientId || !clientSecret || !signingSecret) {
+    return Response.json({ error: 'Slack app not configured' }, { status: 501 })
+  }
+
+  const { searchParams } = new URL(request.url)
+
+  // User denied consent (or Slack reported an error) — no code to exchange.
+  const oauthError = searchParams.get('error')
+  if (oauthError) {
+    return resultPage(
+      'Slack install cancelled',
+      'The installation was not completed. You can close this window.',
+      false
+    )
+  }
+
+  const code = searchParams.get('code')
+  const state = searchParams.get('state')
+
+  // CSRF: verify the signed state BEFORE doing anything with the code.
+  const verified = await verifyOAuthState(signingSecret, state)
+  if (!verified) {
+    logError('[slack-oauth] rejected: invalid/expired state')
+    return resultPage(
+      'Slack install failed',
+      'This install link is invalid or has expired. Please start again from chmonitor.',
+      false
+    )
+  }
+
+  if (!code) {
+    return resultPage(
+      'Slack install failed',
+      'Missing authorization code. Please start again from chmonitor.',
+      false
+    )
+  }
+
+  const redirectUri = getSlackOAuthRedirectUrl(request)
+  let access
+  try {
+    access = await exchangeOAuthCode({
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    })
+  } catch (err) {
+    logError('[slack-oauth] token exchange network failure', err)
+    return resultPage(
+      'Slack install failed',
+      'Could not reach Slack to complete the install. Please try again.',
+      false
+    )
+  }
+
+  if (!access.ok || !access.access_token || !access.team?.id) {
+    // Log Slack's error CODE only (never the code/token).
+    logError(
+      '[slack-oauth] token exchange rejected',
+      new Error(access.error ?? 'unknown_slack_error')
+    )
+    return resultPage(
+      'Slack install failed',
+      'Slack rejected the installation. Please try again.',
+      false
+    )
+  }
+
+  const now = Date.now()
+  const stored = await upsertInstallation({
+    teamId: access.team.id,
+    teamName: access.team.name ?? null,
+    botToken: access.access_token,
+    botUserId: access.bot_user_id ?? null,
+    scope: access.scope ?? null,
+    authedUserId: access.authed_user?.id ?? null,
+    ownerRef: verified.ownerRef,
+    installedAt: now,
+    updatedAt: now,
+  })
+
+  if (!stored) {
+    // Persistence failed (no D1, or encryption misconfigured) — an install we
+    // can't store is useless, so tell the user instead of faking success.
+    return resultPage(
+      'Slack install incomplete',
+      'chmonitor could not save the Slack connection. Ensure D1 storage is configured, then try again.',
+      false
+    )
+  }
+
+  return resultPage(
+    'chmonitor connected to Slack',
+    'You can now use /chmonitor in your workspace. You can close this window.',
+    true
+  )
+}
+
+export const Route = createFileRoute('/api/v1/slack/oauth')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => handleGet(request),
+    },
+  },
+})
+
+// Exported for unit tests only.
+export { handleGet as __handleGetForTests }

--- a/apps/docs/scripts/sync-docs.mjs
+++ b/apps/docs/scripts/sync-docs.mjs
@@ -98,7 +98,12 @@ const FOLDER_META = {
   'guide/guides': {
     title: 'Guides',
     icon: 'Compass',
-    pages: ['proxy-auth-setup', 'troubleshooting', 'upgrade-clickhouse'],
+    pages: [
+      'proxy-auth-setup',
+      'slack-app',
+      'troubleshooting',
+      'upgrade-clickhouse',
+    ],
   },
   // ── Tab 2: Deploy & Operate ────────────────────────────────────────────
   operate: {

--- a/docs/content/guide/guides/slack-app.mdx
+++ b/docs/content/guide/guides/slack-app.mdx
@@ -79,6 +79,18 @@ Slack app is configured, alert messages are posted as rich blocks with an
 and edits the message in place. Without the Slack app, alerts remain plain-text —
 nothing changes for existing setups.
 
+<Callout type="warn">
+Slack delivers a button click to the **interactivity URL of the app that owns
+the message**. So the **Acknowledge** button only reaches
+`/api/v1/slack/interactions` when the incoming webhook in
+`HEALTH_ALERT_WEBHOOK_URL` belongs to **this** chmonitor Slack app (the one whose
+interactivity URL you set in step 1). If the webhook was created by a different
+or legacy Slack app, the button still renders but the click is routed elsewhere
+and the acknowledgement is never recorded. A future release will post alerts via
+the stored bot token to a chosen channel so ACK works regardless of which app
+owns the webhook.
+</Callout>
+
 ## Security notes
 
 - Every inbound Slack request is verified against `X-Slack-Signature` +
@@ -87,5 +99,6 @@ nothing changes for existing setups.
   routes never require sign-in.
 - The OAuth `state` parameter is HMAC-signed (CSRF) and short-lived.
 - Bot tokens are AES-256-GCM encrypted at rest and never logged.
-- `/chmonitor query` is read-only (`readonly=1`, SELECT-only validation) and
-  row/time capped — it can never mutate your cluster.
+- `/chmonitor query` is read-only (`readonly=2` — write queries blocked while
+  per-query caps still apply — plus SELECT-only validation) and row/time capped,
+  so it can never mutate your cluster.

--- a/docs/content/guide/guides/slack-app.mdx
+++ b/docs/content/guide/guides/slack-app.mdx
@@ -1,0 +1,91 @@
+---
+title: Slack app
+description: Install the native chmonitor Slack app — OAuth setup, the /chmonitor slash command (status, read-only query, alerts), a Home tab, and Acknowledge buttons on alert messages.
+icon: MessageSquare
+---
+
+The **native Slack app** brings chmonitor into Slack: a `/chmonitor` slash
+command, a Home tab summary, and an **Acknowledge** button on alert messages —
+so on-call can triage from where they already are.
+
+The app is **optional** and **off by default**. With no Slack credentials set,
+every `/api/v1/slack/*` route is disabled and nothing else changes — self-hosted
+and OSS deployments are unaffected.
+
+## What you get
+
+- `/chmonitor status [hostId]` — a cluster health summary (memory, disk, running
+  queries, merges, replication lag).
+- `/chmonitor query <SQL>` — run **one read-only `SELECT`** and see the result as
+  a table. Queries are hard-capped (read-only, row limit, and a short execution
+  timeout) so they always answer within Slack's 3-second budget.
+- `/chmonitor alert` — the most recent firing alerts (from alert history).
+- A **Home tab** with a per-host health summary and a link to the dashboard.
+- An **Acknowledge** button on pushed alert messages that records who
+  acknowledged the alert and edits the message to show it.
+
+## 1. Create the Slack app from the manifest
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** →
+   **From a manifest**.
+2. Paste [`docs/slack/manifest.yml`](https://github.com/chmonitor/chmonitor/blob/main/docs/slack/manifest.yml)
+   from the repo.
+3. **Replace every `dash.chmonitor.dev`** in the manifest with your own
+   deployment host. The four request URLs must point at your running dashboard:
+
+   | Purpose | URL |
+   |---|---|
+   | Slash command | `https://<your-host>/api/v1/slack/commands` |
+   | Interactivity | `https://<your-host>/api/v1/slack/interactions` |
+   | Events | `https://<your-host>/api/v1/slack/events` |
+   | OAuth redirect | `https://<your-host>/api/v1/slack/oauth` |
+
+The bot requests only two scopes: `commands` and `chat:write`.
+
+## 2. Configure the environment
+
+From the app's **Basic Information → App Credentials**, set these on your
+dashboard deployment:
+
+| Variable | Secret? | Purpose |
+|---|---|---|
+| `SLACK_CLIENT_ID` | no | Identifies the app during OAuth install. |
+| `SLACK_CLIENT_SECRET` | **yes** | Exchanges the OAuth `code` for a bot token. |
+| `SLACK_SIGNING_SECRET` | **yes** | Verifies every inbound Slack request, and derives the at-rest bot-token encryption key. |
+| `SLACK_OAUTH_REDIRECT_URL` | no | Optional. Defaults to `<origin>/api/v1/slack/oauth`; set it if the derived origin is wrong (e.g. behind a proxy). |
+| `SLACK_TOKEN_ENCRYPTION_KEY` | **yes** | Optional. A dedicated 32-byte base64 key to encrypt stored bot tokens independently of the signing secret. |
+
+Set the secrets as Worker/container secrets — **never** commit them. On
+Cloudflare, `bun scripts/set-secrets.ts`; on Docker/K8s, your secret store.
+
+<Callout type="warn">
+Installations (workspace bot tokens) are stored in **Cloudflare D1**
+(`CHM_CLOUD_D1`), encrypted at rest. If your deployment has no D1 configured,
+the OAuth callback will report that it could not save the connection. D1 is the
+only supported install store.
+</Callout>
+
+## 3. Install into a workspace
+
+Visit `https://<your-host>/api/v1/slack/install` and approve the app. chmonitor
+redirects you to Slack, exchanges the code for a bot token, encrypts it, and
+stores it. You can now use `/chmonitor` in that workspace.
+
+## Acknowledge buttons
+
+When your health-alert webhook points at a **Slack incoming webhook** *and* the
+Slack app is configured, alert messages are posted as rich blocks with an
+**Acknowledge** button. Clicking it records the acknowledgement (who and when)
+and edits the message in place. Without the Slack app, alerts remain plain-text —
+nothing changes for existing setups.
+
+## Security notes
+
+- Every inbound Slack request is verified against `X-Slack-Signature` +
+  `X-Slack-Request-Timestamp` (HMAC-SHA256, constant-time, 5-minute replay
+  window) **before** the body is trusted. The signature is the auth — these
+  routes never require sign-in.
+- The OAuth `state` parameter is HMAC-signed (CSRF) and short-lived.
+- Bot tokens are AES-256-GCM encrypted at rest and never logged.
+- `/chmonitor query` is read-only (`readonly=1`, SELECT-only validation) and
+  row/time capped — it can never mutate your cluster.

--- a/docs/slack/manifest.yml
+++ b/docs/slack/manifest.yml
@@ -1,0 +1,58 @@
+# chmonitor — Slack app manifest (plan 37).
+#
+# Create the app at https://api.slack.com/apps → "Create New App" → "From a
+# manifest", paste this file, then replace EVERY `dash.chmonitor.dev` below with
+# your own deployment host (self-hosters use their own domain). The four request
+# URLs must all point at your running dashboard's /api/v1/slack/* routes.
+#
+# After creating the app, read its credentials into your environment:
+#   SLACK_CLIENT_ID, SLACK_CLIENT_SECRET  (Basic Information → App Credentials)
+#   SLACK_SIGNING_SECRET                  (Basic Information → App Credentials)
+# Then install via <your-origin>/api/v1/slack/install (the OAuth start route).
+#
+# Keep the bot scopes here IN SYNC with SLACK_BOT_SCOPES in
+# apps/dashboard/src/lib/slack/config.ts.
+
+display_information:
+  name: chmonitor
+  description: ClickHouse monitoring in Slack — cluster status, read-only queries, and alert acknowledgement.
+  background_color: "#0b0b0c"
+
+features:
+  bot_user:
+    display_name: chmonitor
+    always_online: true
+  app_home:
+    home_tab_enabled: true
+    messages_tab_enabled: false
+    home_tab_deep_link_enabled: false
+  slash_commands:
+    - command: /chmonitor
+      url: https://dash.chmonitor.dev/api/v1/slack/commands
+      description: ClickHouse status, a read-only query, or firing alerts
+      usage_hint: "status | query <SQL> | alert"
+      should_escape: false
+
+oauth_config:
+  redirect_urls:
+    - https://dash.chmonitor.dev/api/v1/slack/oauth
+  scopes:
+    bot:
+      # commands   — receive the /chmonitor slash command
+      # chat:write — post/update alert messages (the Acknowledge edit)
+      - commands
+      - chat:write
+
+settings:
+  event_subscriptions:
+    request_url: https://dash.chmonitor.dev/api/v1/slack/events
+    bot_events:
+      # Publish the Home tab when a user opens the app's Home.
+      - app_home_opened
+  interactivity:
+    is_enabled: true
+    # Receives the "Acknowledge" button clicks (block_actions).
+    request_url: https://dash.chmonitor.dev/api/v1/slack/interactions
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false


### PR DESCRIPTION
## Plan 37 — Native Slack app (OAuth + slash + ACK buttons)

Implements an installable Slack app: OAuth install persists a workspace bot token (encrypted) in D1; `/chmonitor status|query|alert` returns Block Kit within Slack's 3s budget; a Home tab cluster summary; and alert messages gain an **Acknowledge** button that records the ack and edits the message in place.

**Optional & fail-open for OSS/self-hosted.** With no `SLACK_*` env, every `/api/v1/slack/*` route returns 501 and nothing else changes — no Clerk required, and the existing plain-text alert path stays byte-for-byte identical.

### HELD FOR HUMAN REVIEW — do not auto-merge
This touches **auth and secret handling** (OAuth bot tokens), so auto-merge is intentionally **not** armed. Please review the security posture below before merging or enabling.

### Security posture
- **Signature-verify before parse.** Every inbound request is HMAC-SHA256 verified (`X-Slack-Signature` over `v0:ts:rawBody`, 5-minute replay window, constant-time compare) before the body is trusted. The signature is the auth — these routes never require sign-in (same public passthrough as the GitHub/Polar webhooks).
- **CSRF on OAuth.** The `state` param is a stateless HMAC-signed, 10-minute token bound to the owner ref; verified **before** the code exchange.
- **Tokens encrypted at rest.** Bot tokens are AES-256-GCM encrypted (key from `SLACK_TOKEN_ENCRYPTION_KEY`, else derived from `SLACK_SIGNING_SECRET`) before they touch D1, decrypted only in memory, never logged. A rotated secret invalidates stored tokens (fail-closed).
- **SSRF guard on `response_url`.** Outbound posts are restricted to a Slack-host allowlist AND pass `validateHostUrl`.
- **Minimal scopes:** `commands`, `chat:write` only.
- **Read-only query.** `/chmonitor query` runs `validateSqlQuery` (SELECT-only) + `readonly=2` + row/time/overflow caps, so it can never mutate the cluster.
- **Secrets never committed.** `.env.example` lists names only. A test fixture that matched Slack's `xoxb-` token shape was replaced with an obvious non-secret placeholder, and history was rewritten so **no commit** carries the token-shaped string (GitHub push protection is satisfied without a bypass).

### Storage
D1 only (`CHM_CLOUD_D1`), migration `0015_slack_installations.sql` creating `slack_installations` + `alert_acks`. Both stores are best-effort (never throw); OSS with no D1 degrades gracefully (OAuth callback reports it could not persist).

### Verified locally
- `tsc --noEmit` (tsconfig.json) — 0 errors
- `tsc -p tsconfig.test.json --noEmit` — 0 errors
- `bun test` Slack suites — 39 pass (signature verify, block builders, ACK codec, token-crypto, oauth-state, slash-parse, route-level auth)
- Biome — clean

### Not covered by CI — smoke-test before enabling in prod
The required `dashboard` check is **type-check only**; the CH-container tests cover query-configs, not these routes. **No route handler has run end-to-end against a live ClickHouse or Slack.** Before enabling the app in production, please smoke-test: the OAuth exchange + store, `/chmonitor status|query|alert`, the ACK write + message edit, and the Home-tab publish. In particular, confirm the `readonly=2` query path returns rows — I switched from `readonly=1`, which throws "Cannot modify setting in readonly mode" when paired with the exec-time/row caps (level 1 freezes all other settings; level 2 stays read-only but permits the caps, and `validateSqlQuery` already enforces SELECT-only).

### ACK-button routing caveat
Slack delivers a button click to the interactivity URL of the app that **owns the message**. The bridge adds the ACK button only when `HEALTH_ALERT_WEBHOOK_URL` is a Slack incoming webhook AND the app is configured — but the click only reaches `/api/v1/slack/interactions` when that webhook belongs to **this** chmonitor Slack app. If it belongs to a different/legacy Slack app, the button renders but the ack is never recorded. This is documented in the guide; a follow-up (post alerts via the stored bot token to a chosen channel) would make ACK work unconditionally with the current `chat:write` scope.

### Docs
- Setup guide: `docs/content/guide/guides/slack-app.mdx`
- Publish-ready manifest: `docs/slack/manifest.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
