### PR TITLE
feat(expensive-queries): adjustable window+duration filters, faster scan, fix empty-state

### DIFF
--- a/apps/dashboard/src/components/expensive-queries/expensive-queries-view.tsx
+++ b/apps/dashboard/src/components/expensive-queries/expensive-queries-view.tsx
@@ -1,9 +1,11 @@
 import {
   Flame,
+  Gauge,
   LayoutDashboardIcon,
   MinimizeIcon,
   RefreshCw,
   ScanSearch,
+  Timer,
 } from 'lucide-react'
 
 import type { ExpensiveQueryRow } from '@/components/expensive-queries/expensive-queries-table'
@@ -29,6 +31,7 @@ import {
 } from '@/lib/card-error-utils'
 import { useTimeRange } from '@/lib/context/time-range-context'
 import { truncateSql } from '@/lib/explain-heuristics'
+import { usePathname, useRouter, useSearchParams } from '@/lib/next-compat'
 import { useTableData } from '@/lib/query/use-table-data'
 import { expensiveQueriesConfig } from '@/lib/query-config/queries/expensive-queries'
 import { useHostId } from '@/lib/swr/use-host'
@@ -36,6 +39,67 @@ import { cn } from '@/lib/utils'
 
 // LoadingState is replaced by QueryPageSkeleton from @/components/query-tables/query-page-skeleton
 // HeaderButton is imported from @/components/query-tables/header-button
+
+const PRESETS = expensiveQueriesConfig.filterParamPresets ?? []
+const DEFAULTS = expensiveQueriesConfig.defaultParams ?? {}
+
+/** Group presets by the param key they drive (time window, min duration). */
+const PRESET_GROUPS: { key: string; icon: typeof Timer; label: string }[] = [
+  { key: 'last_hours', icon: Timer, label: 'Time window' },
+  { key: 'min_duration_s', icon: Gauge, label: 'Min duration' },
+]
+
+/** Format an hours count as a compact window label (1 → "1h", 168 → "7d"). */
+function formatHoursLabel(hours: number): string {
+  if (hours > 0 && hours % 24 === 0) return `${hours / 24}d`
+  return `${hours}h`
+}
+
+/** A single-select chip group bound to one filter param key. */
+function FilterGroup({
+  groupKey,
+  icon: Icon,
+  label,
+  active,
+  onSelect,
+}: {
+  groupKey: string
+  icon: typeof Timer
+  label: string
+  active: string
+  onSelect: (key: string, value: string) => void
+}) {
+  const options = PRESETS.filter((p) => p.key === groupKey)
+  if (options.length === 0) return null
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="inline-flex items-center gap-1 text-[11px] font-medium text-muted-foreground">
+        <Icon className="size-3.5" />
+        {label}
+      </span>
+      <div className="flex flex-wrap items-center gap-1">
+        {options.map((opt) => {
+          const selected = active === String(opt.value)
+          return (
+            <button
+              key={`${opt.key}-${opt.value}`}
+              type="button"
+              onClick={() => onSelect(opt.key, String(opt.value))}
+              className={cn(
+                'rounded-md border px-2 py-1 text-[11px] font-medium tabular-nums transition-colors',
+                selected
+                  ? 'border-primary bg-primary/10 text-primary'
+                  : 'border-border bg-card text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+              )}
+            >
+              {opt.name}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
 
 /**
  * ExpensiveQueriesView — the Most Expensive Queries page.
@@ -49,20 +113,41 @@ import { cn } from '@/lib/utils'
 export const ExpensiveQueriesView = function ExpensiveQueriesView() {
   const hostId = useHostId()
   const { timeRange } = useTimeRange()
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
   const [chartsOpen, setChartsOpen] = useState(true)
   const [explainOpen, setExplainOpen] = useState(false)
 
-  // Pass last_hours from global time-range context so the table respects the
-  // global picker. Falls back to the config default (24h) if context is absent.
-  const filterParams = useMemo(
-    () => ({ last_hours: String(timeRange.lastHours) }),
-    [timeRange.lastHours]
-  )
+  // Resolve the active value of each filter key:
+  //   URL param → global time-range context (for last_hours) → config default.
+  // The global picker seeds the initial window, but explicit URL params (a
+  // shared link or the filter chips below) take priority.
+  const filterParams = useMemo(() => {
+    const params: Record<string, string> = {}
+    for (const [key, value] of Object.entries(DEFAULTS)) {
+      const fromUrl = searchParams.get(key)
+      const resolved =
+        key === 'last_hours'
+          ? (fromUrl ?? String(timeRange.lastHours))
+          : (fromUrl ?? String(value))
+      if (resolved !== '') params[key] = resolved
+    }
+    return params
+  }, [searchParams, timeRange.lastHours])
 
   const { data, error, isLoading, isValidating, refresh } =
     useTableData<ExpensiveQueryRow>('expensive-queries', hostId, filterParams)
 
   const rows = data ?? []
+  // The hook always returns an array (never null), so the old `!data` guard was
+  // dead — the empty state flashed during the initial fetch. Gate the skeleton
+  // on the query state + emptiness instead. Using `isLoading && rows.length===0`
+  // (not `||`) keeps prior rows visible on chip/range changes via placeholderData.
+  const showSkeleton = isLoading && rows.length === 0
+  const windowLabel = formatHoursLabel(
+    Number(filterParams.last_hours ?? timeRange.lastHours)
+  )
 
   const explainItems = rows.slice(0, 20).map((r) => ({
     sql: String(r.query ?? ''),
@@ -70,6 +155,12 @@ export const ExpensiveQueriesView = function ExpensiveQueriesView() {
     readRows: Number(r.read_rows ?? 0),
     resultRows: Number(r.result_rows ?? 0),
   }))
+
+  const setFilter = (key: string, value: string) => {
+    const next = new URLSearchParams(searchParams)
+    next.set(key, value)
+    router.replace(`${pathname}?${next.toString()}`, { scroll: false })
+  }
 
   return (
     <TooltipProvider>
@@ -85,7 +176,7 @@ export const ExpensiveQueriesView = function ExpensiveQueriesView() {
               </span>
             </div>
           }
-          description={`Top query fingerprints by cost over the last ${timeRange.label} · aggregated from system.query_log`}
+          description={`Top query fingerprints by cost over the last ${windowLabel} · aggregated from system.query_log`}
           actions={
             <div className="flex flex-wrap items-center gap-1.5">
               {expensiveQueriesConfig.relatedCharts &&
@@ -116,10 +207,24 @@ export const ExpensiveQueriesView = function ExpensiveQueriesView() {
           }
         />
 
+        {/* Filter bar — time window + minimum per-query duration. */}
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-2 rounded-xl border border-border bg-card px-3 py-2.5">
+          {PRESET_GROUPS.map((group) => (
+            <FilterGroup
+              key={group.key}
+              groupKey={group.key}
+              icon={group.icon}
+              label={group.label}
+              active={filterParams[group.key] ?? ''}
+              onSelect={setFilter}
+            />
+          ))}
+        </div>
+
         {/* Body */}
-        {isLoading && !data ? (
+        {showSkeleton ? (
           <QueryPageSkeleton />
-        ) : error && !data ? (
+        ) : error && rows.length === 0 ? (
           <Card className="rounded-xl">
             <CardContent className="p-4">
               <EmptyState
@@ -176,7 +281,7 @@ export const ExpensiveQueriesView = function ExpensiveQueriesView() {
                   <EmptyState
                     variant="no-data"
                     title="No expensive queries"
-                    description={`No query activity recorded in the last ${timeRange.label} on this host.`}
+                    description={`Nothing matched in the last ${windowLabel} on this host. Try widening the time window or lowering the minimum duration.`}
                   />
                 </CardContent>
               </Card>

--- a/apps/dashboard/src/components/expensive-queries/expensive-queries-view.tsx
+++ b/apps/dashboard/src/components/expensive-queries/expensive-queries-view.tsx
@@ -8,6 +8,7 @@ import {
   Timer,
 } from 'lucide-react'
 
+import type { ChartProps } from '@/components/charts/chart-props'
 import type { ExpensiveQueryRow } from '@/components/expensive-queries/expensive-queries-table'
 import type { CardError } from '@/lib/card-error-utils'
 
@@ -29,7 +30,10 @@ import {
   getCardErrorTitle,
   toEmptyStateVariant,
 } from '@/lib/card-error-utils'
-import { useTimeRange } from '@/lib/context/time-range-context'
+import {
+  TIME_RANGE_PRESETS,
+  useTimeRange,
+} from '@/lib/context/time-range-context'
 import { truncateSql } from '@/lib/explain-heuristics'
 import { usePathname, useRouter, useSearchParams } from '@/lib/next-compat'
 import { useTableData } from '@/lib/query/use-table-data'
@@ -145,9 +149,32 @@ export const ExpensiveQueriesView = function ExpensiveQueriesView() {
   // on the query state + emptiness instead. Using `isLoading && rows.length===0`
   // (not `||`) keeps prior rows visible on chip/range changes via placeholderData.
   const showSkeleton = isLoading && rows.length === 0
-  const windowLabel = formatHoursLabel(
-    Number(filterParams.last_hours ?? timeRange.lastHours)
-  )
+  const activeHours = Number(filterParams.last_hours ?? timeRange.lastHours)
+  const windowLabel = formatHoursLabel(activeHours)
+
+  // Mirror the active window into the related chart so the fingerprint-occurrence
+  // chart tracks the same range as the table. The duration threshold is
+  // table-only — it has no meaning for an occurrences-over-time chart. Charts
+  // keep their own per-chart range override, which still wins if the user sets it.
+  const relatedChartsWithWindow = useMemo(() => {
+    const base = expensiveQueriesConfig.relatedCharts as
+      | (string | [string, Omit<ChartProps, 'hostId'>])[]
+      | undefined
+    if (!base) return base
+    const matched = TIME_RANGE_PRESETS.find((p) => p.lastHours === activeHours)
+    return base.map((c): string | [string, Omit<ChartProps, 'hostId'>] =>
+      Array.isArray(c)
+        ? [
+            c[0],
+            {
+              ...c[1],
+              lastHours: activeHours,
+              ...(matched ? { interval: matched.interval } : {}),
+            },
+          ]
+        : c
+    )
+  }, [activeHours])
 
   const explainItems = rows.slice(0, 20).map((r) => ({
     sql: String(r.query ?? ''),
@@ -255,9 +282,7 @@ export const ExpensiveQueriesView = function ExpensiveQueriesView() {
             {expensiveQueriesConfig.relatedCharts &&
               expensiveQueriesConfig.relatedCharts.length > 0 &&
               (chartsOpen ? (
-                <RelatedCharts
-                  relatedCharts={expensiveQueriesConfig.relatedCharts}
-                />
+                <RelatedCharts relatedCharts={relatedChartsWithWindow} />
               ) : (
                 <CollapsedChartsRow
                   labels={expensiveQueriesConfig.relatedCharts

--- a/apps/dashboard/src/lib/query-config/queries/expensive-queries-by-memory.ts
+++ b/apps/dashboard/src/lib/query-config/queries/expensive-queries-by-memory.ts
@@ -46,15 +46,30 @@ export const expensiveQueriesByMemoryConfig: QueryConfig = {
       ],
     }),
   },
-  description: 'Most expensive queries by memory finished over last 24 hours',
+  description: 'Most expensive queries by memory over the selected time window',
   docs: QUERY_LOG,
   tableCheck: 'system.query_log',
+  defaultParams: {
+    last_hours: '24',
+    // Minimum per-query memory floor (MiB). 0 keeps the default view unchanged.
+    min_memory_mb: '0',
+  },
+  filterParamPresets: [
+    { name: 'Last 1h', key: 'last_hours', value: '1' },
+    { name: 'Last 6h', key: 'last_hours', value: '6' },
+    { name: 'Last 24h', key: 'last_hours', value: '24' },
+    { name: 'Last 7d', key: 'last_hours', value: '168' },
+    { name: 'Any', key: 'min_memory_mb', value: '0' },
+    { name: '> 128 MB', key: 'min_memory_mb', value: '128' },
+    { name: '> 1 GB', key: 'min_memory_mb', value: '1024' },
+    { name: '> 4 GB', key: 'min_memory_mb', value: '4096' },
+  ],
   sql: [
     {
       since: '23.8',
       sql: `
       SELECT
-          query,
+          substr(query, 1, 500) AS query,
           user,
           count() as cnt,
           sum(memory_usage) AS sum_memory,
@@ -66,10 +81,10 @@ export const expensiveQueriesByMemoryConfig: QueryConfig = {
           round(100 * avg_memory / max(avg_memory) OVER ()) AS pct_avg_memory,
           normalized_query_hash
       FROM system.query_log
-      WHERE
-          (event_time >= (now() - toIntervalDay(1)))
-          AND query_kind = 'Select'
-          AND type = 'QueryFinish'
+      PREWHERE type = 'QueryFinish'
+          AND event_time > (now() - interval {last_hours:UInt64} hour)
+      WHERE query_kind = 'Select'
+          AND memory_usage >= {min_memory_mb:UInt64} * 1024 * 1024
       GROUP BY
           normalized_query_hash,
           query,
@@ -83,7 +98,7 @@ export const expensiveQueriesByMemoryConfig: QueryConfig = {
       since: '24.1',
       sql: `
       SELECT
-          query,
+          substr(query, 1, 500) AS query,
           query_cache_usage,
           user,
           count() as cnt,
@@ -96,10 +111,10 @@ export const expensiveQueriesByMemoryConfig: QueryConfig = {
           round(100 * avg_memory / max(avg_memory) OVER ()) AS pct_avg_memory,
           normalized_query_hash
       FROM system.query_log
-      WHERE
-          (event_time >= (now() - toIntervalDay(1)))
-          AND query_kind = 'Select'
-          AND type = 'QueryFinish'
+      PREWHERE type = 'QueryFinish'
+          AND event_time > (now() - interval {last_hours:UInt64} hour)
+      WHERE query_kind = 'Select'
+          AND memory_usage >= {min_memory_mb:UInt64} * 1024 * 1024
       GROUP BY
           normalized_query_hash,
           query,

--- a/apps/dashboard/src/lib/query-config/queries/expensive-queries.ts
+++ b/apps/dashboard/src/lib/query-config/queries/expensive-queries.ts
@@ -55,6 +55,10 @@ export const expensiveQueriesConfig: QueryConfig = {
   tableCheck: 'system.query_log',
   defaultParams: {
     last_hours: '24',
+    // Per-event duration floor (seconds). 0 keeps the default view unchanged —
+    // every finished/exception query counts — while letting the user narrow to
+    // individually-slow queries via the UI selector.
+    min_duration_s: '0',
   },
   filterParamPresets: [
     { name: 'Last 1h', key: 'last_hours', value: '1' },
@@ -62,6 +66,11 @@ export const expensiveQueriesConfig: QueryConfig = {
     { name: 'Last 24h', key: 'last_hours', value: '24' },
     { name: 'Last 7d', key: 'last_hours', value: '168' },
     { name: 'Last 30d', key: 'last_hours', value: '720' },
+    { name: 'Any', key: 'min_duration_s', value: '0' },
+    { name: '> 1s', key: 'min_duration_s', value: '1' },
+    { name: '> 5s', key: 'min_duration_s', value: '5' },
+    { name: '> 30s', key: 'min_duration_s', value: '30' },
+    { name: '> 60s', key: 'min_duration_s', value: '60' },
   ],
   sql: [
     {
@@ -102,7 +111,8 @@ export const expensiveQueriesConfig: QueryConfig = {
             formatReadableSize(sum(written_bytes)) AS written_bytes,
             formatReadableSize(sum(result_bytes)) AS result_bytes
         FROM merge('system', '^query_log')
-        WHERE (event_time > (now() - interval {last_hours:UInt64} hour)) AND (type IN (2, 4))
+        PREWHERE (type IN (2, 4)) AND (event_time > (now() - interval {last_hours:UInt64} hour))
+        WHERE query_duration_ms >= {min_duration_s:UInt64} * 1000
         GROUP BY normalized_query_hash
     )
     SELECT
@@ -162,7 +172,8 @@ export const expensiveQueriesConfig: QueryConfig = {
             formatReadableSize(sum(written_bytes)) AS written_bytes,
             formatReadableSize(sum(result_bytes)) AS result_bytes
         FROM merge('system', '^query_log')
-        WHERE (event_time > (now() - interval {last_hours:UInt64} hour)) AND (type IN (2, 4))
+        PREWHERE (type IN (2, 4)) AND (event_time > (now() - interval {last_hours:UInt64} hour))
+        WHERE query_duration_ms >= {min_duration_s:UInt64} * 1000
         GROUP BY normalized_query_hash
     )
     SELECT
@@ -223,7 +234,8 @@ export const expensiveQueriesConfig: QueryConfig = {
             formatReadableSize(sum(written_bytes)) AS written_bytes,
             formatReadableSize(sum(result_bytes)) AS result_bytes
         FROM merge('system', '^query_log')
-        WHERE (event_time > (now() - interval {last_hours:UInt64} hour)) AND (type IN (2, 4))
+        PREWHERE (type IN (2, 4)) AND (event_time > (now() - interval {last_hours:UInt64} hour))
+        WHERE query_duration_ms >= {min_duration_s:UInt64} * 1000
         GROUP BY normalized_query_hash
     )
     SELECT


### PR DESCRIPTION
Fixes three issues on the **Most Expensive Queries** page (`/expensive-queries`) and applies the matching perf/selector treatment to **Expensive Queries by Memory**.

## 1. Adjustable condition via a UI selector
A filter bar now lets the user control what counts as "expensive", mirroring the sibling **Slow Queries** view for consistency:

- **Time window** — `1h / 6h / 24h / 7d / 30d`
- **Min duration** — `Any / >1s / >5s / >30s / >60s` (new `min_duration_s` param)

Chip selections are written to the URL (shareable, survive reload) and seeded by the global time-range picker; explicit chips take priority. Both params flow into the table query via `filterParams`. The **time window also drives the related fingerprint chart** (injected via the existing `chartProps` channel, so the chart tracks the same range as the table); the duration threshold is table-only, since it has no meaning for an occurrences-over-time chart, and the chart keeps its own per-chart range override. **Expensive Queries by Memory** (generic table page) gets the same window selector plus a memory-appropriate **Min memory** floor (`Any / >128 MB / >1 GB / >4 GB`) surfaced automatically by the data-table toolbar.

Defaults are `min_duration_s: '0'` / `min_memory_mb: '0'`, so the **default view is unchanged** — the threshold only bites when the user opts in (this preserves the aggregate "death by a thousand cuts" fingerprints on first load).

## 2. Faster `system.query_log` scan
- Moved `type` + `event_time` filters into `PREWHERE` so granules are skipped before the wide `ProfileEvents` map / memory columns are read.
- Kept the threshold in `WHERE` (conservative `merge()` + `PREWHERE` split).
- by-memory: replaced the hard-coded 1-day window with the selectable `{last_hours}` bound and truncated the grouped query text to 500 chars to avoid materializing full multi-KB query blobs. Real `LIMIT` was already present (1000) and is retained.

## 3. Premature empty-state (skeleton-while-loading)
`useTableData` **always** returns an array (`data?.data ?? []`), so the old `isLoading && !data` guard was dead code — the empty array is truthy, the skeleton branch never ran, and **"No expensive queries" rendered during the initial fetch**. Fixed by gating on the query state + emptiness:

- Skeleton: `isLoading && rows.length === 0`
- Error card: `error && rows.length === 0`
- Empty state only once loading settles.

Using `&&` (not `||`) keeps prior rows visible across chip/range changes via `placeholderData`, so filter changes don't flash a skeleton. (The generic by-memory page already handles loading correctly via its Suspense/`TableSkeleton` path, so its empty-state needed no change.)

## Verification
- `bun run type-check` and `bun run type-check:test`: **228 → 228** (baseline captured on the clean branch; **zero new** errors — the 228 are the pre-existing `routeTree.gen.ts` route-registration errors, none in the edited files).
- Existing `sql-regressions.test.ts` guard (`selected_bytes` aliasing) preserved.

## QA pending
- **Browser QA** not run in this environment — needs a manual pass of the selector wiring + skeleton/empty transitions against a live host.
- **`PREWHERE` on `merge('system','^query_log')`** and the by-memory **GROUP BY on the truncated `query` alias** are only exercised by the query-config CI job (real ClickHouse container). Both use standard ClickHouse semantics but were not run locally.

Co-Authored-By: duyetbot <bot@duyet.net>
