### PR TITLE
feat(health): redesign health cards + generic per-check drill-down to affected rows

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -56,6 +56,11 @@ primary secondary accent destructive border input ring`. Charts:
 - **Spacing:** `gap-1.5` compact, `gap-2` standard, `gap-4` generous; card content `p-4 pt-0`.
 - **Pill/secondary button link:** `inline-flex h-8 items-center gap-1.5 rounded-md
   border border-border px-3 text-[13px] font-medium hover:bg-muted`.
+- **Clickable card → detail dialog:** whole card is the target (`role="button"` +
+  `tabIndex={0}` + `onKeyDown={activateOnEnterOrSpace(open)}`, never a nested
+  `<button>`); inner links `e.stopPropagation()` (not `preventDefault`) so they
+  still navigate. Drive drill-down from a per-item field, rendered via
+  `ResultTable`. See `components/health/{health-card-shell,health-detail-rows}.tsx`.
 
 ## Charts — always wrap state, never hand-roll it
 

--- a/apps/dashboard/src/components/health/health-card-shell.tsx
+++ b/apps/dashboard/src/components/health/health-card-shell.tsx
@@ -1,11 +1,12 @@
 import type { LucideIcon } from 'lucide-react'
-import { Maximize2 } from 'lucide-react'
+import { ArrowUpRight } from 'lucide-react'
 
 import type { HealthStatus } from '@/lib/health/health-status'
 import type { RelatedLink } from './health-checks'
 
 import { MiniAreaChart } from '@/components/charts/mini-charts'
 import { AppLink } from '@/components/ui/app-link'
+import { activateOnEnterOrSpace } from '@/lib/a11y'
 import { cn } from '@/lib/utils'
 
 /** Sparkline stroke color per severity (healthy → blue, matching KPI cards). */
@@ -17,6 +18,7 @@ const SPARK_COLOR: Record<HealthStatus, string> = {
   loading: 'hsl(0 0% 60%)',
 }
 
+/** Headline value color — accented only when there is something to look at. */
 const VALUE_COLOR: Record<HealthStatus, string> = {
   critical: 'text-red-600 dark:text-red-500',
   warning: 'text-amber-600 dark:text-amber-500',
@@ -25,44 +27,46 @@ const VALUE_COLOR: Record<HealthStatus, string> = {
   loading: 'text-foreground',
 }
 
-const ICON_COLOR: Record<HealthStatus, string> = {
-  critical: 'text-red-500',
-  warning: 'text-amber-500',
-  ok: 'text-green-500',
-  error: 'text-muted-foreground',
-  loading: 'text-muted-foreground',
+/** Tinted square behind the header icon — a restrained status cue. */
+const ICON_WRAP: Record<HealthStatus, string> = {
+  critical: 'bg-red-500/10 text-red-600 dark:text-red-400',
+  warning: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  ok: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  error: 'bg-muted text-muted-foreground',
+  loading: 'bg-muted text-muted-foreground',
 }
 
-function StatusDot({ status }: { status: HealthStatus }) {
+/**
+ * Status affordance: a labeled pill for issues (so severity reads at a glance),
+ * a quiet dot otherwise. Restrained on purpose — the card stays neutral until
+ * something actually needs attention.
+ */
+function StatusIndicator({ status }: { status: HealthStatus }) {
+  if (status === 'critical' || status === 'warning') {
+    return (
+      <span
+        className={cn(
+          'rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase leading-none tracking-wide',
+          status === 'critical'
+            ? 'bg-red-500/12 text-red-600 dark:text-red-400'
+            : 'bg-amber-500/12 text-amber-600 dark:text-amber-400'
+        )}
+      >
+        {status === 'critical' ? 'Critical' : 'Warning'}
+      </span>
+    )
+  }
   return (
     <span
       className={cn(
-        'inline-block h-2.5 w-2.5 rounded-full flex-shrink-0',
-        status === 'ok' && 'bg-green-500',
-        status === 'warning' && 'bg-amber-500',
-        status === 'critical' && 'bg-red-500',
-        status === 'loading' && 'bg-muted animate-pulse',
-        status === 'error' && 'bg-muted'
+        'inline-block size-2 rounded-full',
+        status === 'ok' && 'bg-emerald-500',
+        status === 'loading' && 'animate-pulse bg-muted-foreground/40',
+        status === 'error' && 'bg-muted-foreground/40'
       )}
       role="img"
       aria-label={`Status: ${status}`}
     />
-  )
-}
-
-function SeverityBadge({ status }: { status: HealthStatus }) {
-  if (status !== 'critical' && status !== 'warning') return null
-  return (
-    <span
-      className={cn(
-        'rounded-full px-2 py-0.5 text-[10px] font-semibold leading-none',
-        status === 'critical' && 'bg-red-500/15 text-red-600 dark:text-red-400',
-        status === 'warning' &&
-          'bg-amber-500/15 text-amber-600 dark:text-amber-400'
-      )}
-    >
-      {status === 'critical' ? 'Critical' : 'Warning'}
-    </span>
   )
 }
 
@@ -87,15 +91,19 @@ export interface HealthCardShellProps {
   links?: readonly RelatedLink[]
   /** Active host, used to append `?host=` to related links. */
   hostId: number
-  /** When provided, the value area opens details and a hover button appears. */
+  /** When provided, the WHOLE card opens details (keyboard + pointer). */
   onExpand?: () => void
 }
 
 /**
- * Shared visual chrome for every health card: severity-tinted surface, header
- * (icon + title + badge + status dot), headline value, trend sparkline, and a
- * footer of related-page chips. Purely presentational — all status/value
- * computation happens upstream in the grid.
+ * Shared visual chrome for every health card: a neutral card surface with a
+ * restrained status accent (a left rail + tinted icon only when there is an
+ * issue), a clear typographic hierarchy (title · headline value · sub-label),
+ * a trend sparkline, and a footer of related-page chips.
+ *
+ * The whole card is the click target when `onExpand` is provided — related-page
+ * links stop propagation so they still navigate without opening the dialog.
+ * Purely presentational: all status/value computation happens upstream.
  */
 export function HealthCardShell({
   icon: Icon,
@@ -112,78 +120,78 @@ export function HealthCardShell({
   const withHost = (href: string) =>
     `${href}${href.includes('?') ? '&' : '?'}host=${hostId}`
 
+  const isIssue = status === 'critical' || status === 'warning'
+
+  // Only make the card interactive when it can actually open something —
+  // avoids a role="button" with no handler. `onExpand` narrows to defined here.
+  const interactiveProps = onExpand
+    ? {
+        role: 'button' as const,
+        tabIndex: 0,
+        onClick: onExpand,
+        onKeyDown: activateOnEnterOrSpace(onExpand),
+        'aria-label': `Open ${title} details`,
+      }
+    : {}
+
   return (
     <div
+      {...interactiveProps}
       className={cn(
-        'group flex min-h-[200px] flex-col rounded-xl border bg-card p-4 shadow-sm transition-colors',
-        status === 'critical' && 'border-red-500/40 bg-red-500/[0.04]',
-        status === 'warning' && 'border-amber-500/40 bg-amber-500/[0.04]'
+        'group relative flex min-h-[200px] flex-col overflow-hidden rounded-xl border bg-card p-4 shadow-sm transition-all',
+        onExpand &&
+          'cursor-pointer hover:border-foreground/20 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+        status === 'critical' && 'border-red-500/25',
+        status === 'warning' && 'border-amber-500/25'
       )}
     >
-      {/* Header: icon + title · badge + status dot + (optional) expand */}
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex min-w-0 items-center gap-2">
+      {/* Restrained status accent: a thin left rail, issues only. */}
+      {isIssue && (
+        <span
+          aria-hidden
+          className={cn(
+            'absolute inset-y-0 left-0 w-[3px]',
+            status === 'critical' ? 'bg-red-500' : 'bg-amber-500'
+          )}
+        />
+      )}
+
+      {/* Header: tinted icon + title · status affordance */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2.5">
           {Icon && (
-            <Icon
-              className={cn('size-4 flex-shrink-0', ICON_COLOR[status])}
-              aria-hidden
-            />
+            <span
+              className={cn(
+                'grid size-8 flex-none place-items-center rounded-lg',
+                ICON_WRAP[status]
+              )}
+            >
+              <Icon className="size-4" strokeWidth={1.5} aria-hidden />
+            </span>
           )}
           <span className="truncate text-[13px] font-semibold leading-tight">
             {title}
           </span>
         </div>
-        <div className="flex flex-shrink-0 items-center gap-2">
-          <SeverityBadge status={status} />
-          <StatusDot status={status} />
-          {onExpand && (
-            <button
-              type="button"
-              onClick={onExpand}
-              aria-label={`Open ${title} details`}
-              className="rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
-            >
-              <Maximize2 className="size-3" />
-            </button>
-          )}
+        <div className="flex flex-none items-center pt-0.5">
+          <StatusIndicator status={status} />
         </div>
       </div>
 
       {/* Body: headline value + sub-label */}
-      {onExpand ? (
-        <button
-          type="button"
-          onClick={onExpand}
-          className="mt-3 text-left"
-          aria-label={`Open ${title} details`}
+      <div className="mt-4">
+        <div
+          className={cn(
+            'font-mono text-[32px] font-semibold leading-none tracking-tight tabular-nums',
+            VALUE_COLOR[status]
+          )}
         >
-          <div
-            className={cn(
-              'font-mono text-[34px] font-semibold leading-none tracking-tight tabular-nums',
-              VALUE_COLOR[status]
-            )}
-          >
-            {displayValue}
-          </div>
-          <div className="mt-2 text-[12.5px] leading-snug text-muted-foreground">
-            {sublabel}
-          </div>
-        </button>
-      ) : (
-        <div className="mt-3">
-          <div
-            className={cn(
-              'font-mono text-[34px] font-semibold leading-none tracking-tight tabular-nums',
-              VALUE_COLOR[status]
-            )}
-          >
-            {displayValue}
-          </div>
-          <div className="mt-2 text-[12.5px] leading-snug text-muted-foreground">
-            {sublabel}
-          </div>
+          {displayValue}
         </div>
-      )}
+        <div className="mt-2 text-[12.5px] leading-snug text-muted-foreground">
+          {sublabel}
+        </div>
+      </div>
 
       {/* Trend sparkline (real observed values, fills in over time) */}
       <div className="mt-3 h-[30px]">
@@ -196,25 +204,33 @@ export function HealthCardShell({
         )}
       </div>
 
-      {/* Footer: related-page chips */}
-      {links && links.length > 0 && (
-        <div className="mt-auto flex flex-wrap gap-1.5 pt-3.5">
-          {links.slice(0, 3).map((l) => (
-            <AppLink
-              key={l.href}
-              href={withHost(l.href)}
-              className={cn(
-                'inline-flex items-center rounded-md px-2 py-0.5',
-                'text-[11px] font-medium leading-none whitespace-nowrap',
-                'bg-muted/60 text-muted-foreground',
-                'transition-colors hover:bg-muted hover:text-foreground'
-              )}
-            >
-              {l.label}
-            </AppLink>
-          ))}
-        </div>
-      )}
+      {/* Footer: related-page chips + a hover hint that the card opens details */}
+      <div className="mt-auto flex flex-wrap items-center gap-1.5 pt-3.5">
+        {links?.slice(0, 3).map((l) => (
+          <AppLink
+            key={l.href}
+            href={withHost(l.href)}
+            onClick={(e) => e.stopPropagation()}
+            className={cn(
+              'inline-flex items-center rounded-md px-2 py-0.5',
+              'text-[11px] font-medium leading-none whitespace-nowrap',
+              'bg-muted/60 text-muted-foreground',
+              'transition-colors hover:bg-muted hover:text-foreground'
+            )}
+          >
+            {l.label}
+          </AppLink>
+        ))}
+        {onExpand && (
+          <span
+            aria-hidden
+            className="ml-auto inline-flex flex-none items-center gap-0.5 text-[11px] font-medium text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+          >
+            Details
+            <ArrowUpRight className="size-3" />
+          </span>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/dashboard/src/components/health/health-checks.ts
+++ b/apps/dashboard/src/components/health/health-checks.ts
@@ -58,6 +58,23 @@ export interface HealthCheckDef {
    * the chart registry here would cross a layering boundary depcruise enforces).
    */
   sql?: string
+  /**
+   * Chart name (in the registry) whose query returns the *affected rows* behind
+   * this check — the drill-down breakdown shown in the detail dialog (e.g. the
+   * individual lagging replicas, not just the max lag). Fetched on demand when
+   * the dialog opens. Omit for checks with no meaningful per-row breakdown.
+   */
+  detailChartName?: string
+  /**
+   * Heading for the breakdown table. Defaults to "Affected rows". Use a
+   * "Likely cause …" heading for checks whose metric is a global scalar with no
+   * true per-row source (so the rows are a diagnostic, not the flagged instances).
+   */
+  detailTitle?: string
+  /** One-line caption clarifying what the breakdown rows represent. */
+  detailDescription?: string
+  /** Message shown when the breakdown query returns no rows. */
+  detailEmptyMessage?: string
 }
 
 const fmtCount = (singular: string, plural?: string) => (v: number | null) => {
@@ -71,6 +88,9 @@ export const HEALTH_CHECKS: readonly HealthCheckDef[] = [
     title: 'Readonly Replicas',
     icon: ShieldAlert,
     chartName: 'health-readonly-replicas',
+    detailChartName: 'health-readonly-replicas-detail',
+    detailEmptyMessage:
+      'No readonly replicas — every replica is accepting writes.',
     valueKey: 'readonly_count',
     defaults: { warning: 1, critical: 3 },
     formatLabel: fmtCount('readonly replica'),
@@ -106,6 +126,10 @@ WHERE is_readonly = 1`,
     title: 'Delayed Inserts',
     icon: PauseCircle,
     chartName: 'health-delayed-inserts',
+    detailChartName: 'health-max-part-count-detail',
+    detailTitle: 'Likely cause: partitions with the most parts',
+    detailDescription:
+      '`DelayedInserts` is a global gauge with no per-row source. These partitions carry the most active parts — the pressure that makes the MergeTree throttle inserts.',
     valueKey: 'delayed_inserts',
     defaults: { warning: 1, critical: 5 },
     formatLabel: fmtCount('delayed insert'),
@@ -137,6 +161,9 @@ WHERE metric = 'DelayedInserts'`,
     title: 'Max Parts / Partition',
     icon: Layers,
     chartName: 'health-max-part-count',
+    detailChartName: 'health-max-part-count-detail',
+    detailTitle: 'Partitions by active part count',
+    detailEmptyMessage: 'No user partitions found.',
     valueKey: 'part_count',
     defaults: { warning: 150, critical: 300 },
     formatLabel: (v) => `${(v ?? 0).toLocaleString()} parts (max partition)`,
@@ -178,6 +205,8 @@ LIMIT 1`,
     title: 'Long-Running Queries',
     icon: Timer,
     chartName: 'health-long-running-queries',
+    detailChartName: 'health-long-running-queries-detail',
+    detailEmptyMessage: 'No initial queries have been running longer than 60s.',
     valueKey: 'long_running',
     defaults: { warning: 1, critical: 5 },
     formatLabel: (v) => `${(v ?? 0).toLocaleString()} queries > 60s`,
@@ -213,6 +242,8 @@ WHERE elapsed > 60 AND is_initial_query`,
     title: 'OOM-Killed Queries (1h)',
     icon: MemoryStick,
     chartName: 'health-oom-killed-recent',
+    detailChartName: 'health-oom-killed-recent-detail',
+    detailEmptyMessage: 'No OOM-killed queries in the last hour.',
     valueKey: 'oom_count',
     defaults: { warning: 1, critical: 10 },
     formatLabel: (v) => `${(v ?? 0).toLocaleString()} OOM kills in last hour`,
@@ -250,6 +281,8 @@ WHERE event_time > now() - INTERVAL 1 HOUR
     title: 'Failed Queries (1h)',
     icon: XCircle,
     chartName: 'health-failed-queries-recent',
+    detailChartName: 'health-failed-queries-recent-detail',
+    detailEmptyMessage: 'No failed queries in the last hour.',
     valueKey: 'failed_count',
     defaults: { warning: 10, critical: 100 },
     formatLabel: (v) =>
@@ -286,6 +319,9 @@ WHERE event_time > now() - INTERVAL 1 HOUR
     title: 'Replication Lag',
     icon: Clock,
     chartName: 'health-replication-lag',
+    detailChartName: 'health-replication-lag-detail',
+    detailTitle: 'Lagging replicas',
+    detailEmptyMessage: 'No replica is lagging — every table is caught up.',
     valueKey: 'max_lag',
     defaults: { warning: 30, critical: 300 },
     formatLabel: (v) => `${(v ?? 0).toLocaleString()}s max delay`,
@@ -320,6 +356,11 @@ FROM system.replicas`,
     title: 'Keeper Exceptions (1h)',
     icon: ServerCrash,
     chartName: 'health-keeper-exceptions-recent',
+    detailChartName: 'health-keeper-exceptions-detail',
+    detailTitle: 'Likely cause: KEEPER_EXCEPTION totals',
+    detailDescription:
+      '`system.errors` reports a cumulative count since server start (not the last hour) plus the most recent occurrence — Keeper has no per-incident row source.',
+    detailEmptyMessage: 'No KEEPER_EXCEPTION recorded on this server.',
     valueKey: 'exception_count',
     defaults: { warning: 1, critical: 20 },
     formatLabel: (v) => `${(v ?? 0).toLocaleString()} exceptions in last hour`,
@@ -351,6 +392,11 @@ WHERE error = 'KEEPER_EXCEPTION'
     title: 'Memory Usage',
     icon: MemoryStick,
     chartName: 'health-memory-percent',
+    detailChartName: 'health-memory-percent-detail',
+    detailTitle: 'Likely cause: top in-flight queries by memory',
+    detailDescription:
+      'OS memory is a host-level metric with no per-row source. These are the largest in-flight queries by memory — the biggest process-level consumers (they do not sum to OS memory).',
+    detailEmptyMessage: 'No queries are currently running.',
     valueKey: 'memory_percent',
     defaults: { warning: 80, critical: 95 },
     formatLabel: (v) => `${v ?? 0}% of OS memory`,
@@ -388,6 +434,9 @@ WHERE error = 'KEEPER_EXCEPTION'
     title: 'Disk Usage',
     icon: HardDrive,
     chartName: 'health-disk-percent',
+    detailChartName: 'health-disk-percent-detail',
+    detailTitle: 'Disks by utilization',
+    detailEmptyMessage: 'No disks reported.',
     valueKey: 'disk_percent',
     defaults: { warning: 80, critical: 95 },
     formatLabel: (v) => `${v ?? 0}% used (worst disk)`,
@@ -423,6 +472,8 @@ FROM system.disks`,
     title: 'Failed Mutations',
     icon: XCircle,
     chartName: 'health-failed-mutations',
+    detailChartName: 'health-failed-mutations-detail',
+    detailEmptyMessage: 'No failed mutations.',
     valueKey: 'failed_count',
     defaults: { warning: 1, critical: 5 },
     formatLabel: fmtCount('failed mutation'),
@@ -449,6 +500,8 @@ FROM system.mutations`,
     title: 'Stuck Merges (>10m)',
     icon: Timer,
     chartName: 'health-stuck-merges',
+    detailChartName: 'health-stuck-merges-detail',
+    detailEmptyMessage: 'No merges have been running longer than 10 minutes.',
     valueKey: 'stuck_count',
     defaults: { warning: 1, critical: 3 },
     formatLabel: fmtCount('stuck merge'),
@@ -476,6 +529,8 @@ WHERE elapsed > 600`,
     title: 'Query Timeout Breaches (1h)',
     icon: Clock,
     chartName: 'health-query-timeouts',
+    detailChartName: 'health-query-timeouts-detail',
+    detailEmptyMessage: 'No queries hit TIMEOUT_EXCEEDED in the last hour.',
     valueKey: 'timeout_count',
     defaults: { warning: 1, critical: 10 },
     formatLabel: (v) =>
@@ -509,6 +564,8 @@ WHERE event_time > now() - INTERVAL 1 HOUR
     title: 'Failed Backups (24h)',
     icon: HardDrive,
     chartName: 'health-failed-backups',
+    detailChartName: 'health-failed-backups-detail',
+    detailEmptyMessage: 'No failed backups in the last 24 hours.',
     valueKey: 'failed_count',
     defaults: { warning: 1, critical: 3 },
     formatLabel: fmtCount('failed backup'),
@@ -537,6 +594,8 @@ WHERE event_time > now() - INTERVAL 24 HOUR
     title: 'MV Refresh Failures',
     icon: ShieldAlert,
     chartName: 'health-mv-refresh-failures',
+    detailChartName: 'health-mv-refresh-failures-detail',
+    detailEmptyMessage: 'No materialized views have failed their last refresh.',
     valueKey: 'failed_count',
     defaults: { warning: 1, critical: 3 },
     formatLabel: fmtCount('failed MV refresh'),

--- a/apps/dashboard/src/components/health/health-detail-dialog.tsx
+++ b/apps/dashboard/src/components/health/health-detail-dialog.tsx
@@ -4,6 +4,7 @@ import type { AuditPromptInput } from '@/lib/health/audit-prompt'
 import type { HealthCheckDef } from './health-checks'
 
 import { HealthAuditPromptDialog } from './health-audit-prompt-dialog'
+import { HealthDetailRows } from './health-detail-rows'
 import { useState } from 'react'
 import { AppLink } from '@/components/ui/app-link'
 import { Badge } from '@/components/ui/badge'
@@ -91,7 +92,7 @@ export function HealthDetailDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-w-2xl">
+        <DialogContent className="max-w-3xl">
           <DialogHeader>
             <div className="flex items-center gap-2">
               <DialogTitle>{check.title}</DialogTitle>
@@ -132,7 +133,20 @@ export function HealthDetailDialog({
                 </div>
               </div>
 
-              {row && Object.keys(row).length > 0 && (
+              {check.detailChartName && (
+                <>
+                  <Separator />
+                  <HealthDetailRows
+                    chartName={check.detailChartName}
+                    hostId={hostId}
+                    title={check.detailTitle ?? 'Affected rows'}
+                    description={check.detailDescription}
+                    emptyMessage={check.detailEmptyMessage}
+                  />
+                </>
+              )}
+
+              {!check.detailChartName && row && Object.keys(row).length > 0 && (
                 <>
                   <Separator />
                   <div>

--- a/apps/dashboard/src/components/health/health-detail-rows.tsx
+++ b/apps/dashboard/src/components/health/health-detail-rows.tsx
@@ -1,0 +1,112 @@
+import { RefreshCw } from 'lucide-react'
+
+import { ResultTable } from '@/components/sql-console/result-table'
+import { EmptyState } from '@/components/ui/empty-state'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useChartData } from '@/lib/query/use-chart-data'
+
+interface HealthDetailRowsProps {
+  /** Registry chart name whose query returns the affected rows. */
+  chartName: string
+  hostId: number
+  /** Section heading, e.g. "Affected rows" or "Likely cause: …". */
+  title: string
+  /** Optional caption clarifying what the rows represent. */
+  description?: string
+  /** Message shown when the query returns no rows. */
+  emptyMessage?: string
+}
+
+const SKELETON_KEYS = ['a', 'b', 'c', 'd'] as const
+
+/**
+ * The drill-down breakdown for a health check: the actual rows behind the
+ * headline number (lagging replicas, failing queries, offending partitions, …).
+ *
+ * Rendered only while the detail dialog is open — Radix unmounts `DialogContent`
+ * when closed, so this component (and its `useChartData` fetch) mounts on open
+ * and unmounts on close. That keeps the /health page from fetching 17 breakdown
+ * queries up-front; each is fetched lazily the first time a card is opened.
+ *
+ * Generic by design: it renders whatever columns the check's detail query
+ * returns via the shared `ResultTable`, so a new check needs only a
+ * `detailChartName` — no per-card rendering code here.
+ */
+export function HealthDetailRows({
+  chartName,
+  hostId,
+  title,
+  description,
+  emptyMessage,
+}: HealthDetailRowsProps) {
+  const { data, isLoading, error, hasData, metadata, mutate } = useChartData({
+    chartName,
+    hostId,
+    // One-shot fetch on open — the dialog is not a live-refreshing surface.
+    refreshInterval: 0,
+  })
+
+  // An *optional* backing table that is absent returns 200 + a benign
+  // `metadata.unavailable` note (see /api/v1/charts/$name), not an error.
+  const unavailable = (
+    metadata as { unavailable?: { message?: string } } | undefined
+  )?.unavailable
+
+  const rowCount = data.length
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <h4 className="text-sm font-semibold">{title}</h4>
+        {hasData && (
+          <span className="rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
+            {rowCount}
+          </span>
+        )}
+      </div>
+      {description && (
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          {description}
+        </p>
+      )}
+
+      {unavailable ? (
+        <EmptyState
+          variant="table-missing"
+          compact
+          title="Not available on this server"
+          description={
+            unavailable.message ??
+            'The system table backing this check is not present.'
+          }
+        />
+      ) : isLoading ? (
+        <div className="flex flex-col gap-2" aria-busy="true">
+          {SKELETON_KEYS.map((k) => (
+            <Skeleton key={k} className="h-8 w-full" />
+          ))}
+        </div>
+      ) : error && !hasData ? (
+        <EmptyState
+          variant="error"
+          compact
+          description={error.message}
+          action={{
+            label: 'Retry',
+            onClick: () => void mutate(),
+            icon: <RefreshCw className="size-4" />,
+          }}
+        />
+      ) : !hasData ? (
+        <EmptyState
+          variant="no-data"
+          compact
+          title="No rows"
+          description={emptyMessage ?? 'This check has no affected rows.'}
+        />
+      ) : (
+        <ResultTable rows={data} emptyMessage={emptyMessage} />
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/health/health-grid.tsx
+++ b/apps/dashboard/src/components/health/health-grid.tsx
@@ -158,6 +158,7 @@ export function HealthGrid() {
           hostId={hostId}
           computed={stuck}
           spark={spark}
+          clickhouseVersion={results[STUCK_MUTATIONS_CHART]?.clickhouseVersion}
         />
       ),
     })
@@ -182,6 +183,9 @@ export function HealthGrid() {
           hostId={hostId}
           computed={running}
           spark={spark}
+          clickhouseVersion={
+            results[RUNNING_MUTATIONS_CHART]?.clickhouseVersion
+          }
         />
       ),
     })

--- a/apps/dashboard/src/components/health/mutations-cards.tsx
+++ b/apps/dashboard/src/components/health/mutations-cards.tsx
@@ -1,9 +1,11 @@
 import { GitMerge, Wrench } from 'lucide-react'
 
 import type { ComputedMutations } from '@/lib/health/health-status'
-import type { RelatedLink } from './health-checks'
+import type { HealthCheckDef, RelatedLink } from './health-checks'
 
 import { HealthCardShell } from './health-card-shell'
+import { HealthDetailDialog } from './health-detail-dialog'
+import { useState } from 'react'
 
 interface MutationsCardProps {
   hostId: number
@@ -11,52 +13,120 @@ interface MutationsCardProps {
   computed: ComputedMutations
   /** Observed values, oldest first, for the trend sparkline. */
   spark?: number[]
+  /** ClickHouse version, forwarded to the detail dialog. */
+  clickhouseVersion?: string
 }
 
-const STUCK_LINKS: readonly RelatedLink[] = [
+const MUTATIONS_LINKS: readonly RelatedLink[] = [
   { label: 'Mutations', href: '/mutations' },
   { label: 'Tables Overview', href: '/tables-overview' },
 ]
 
-const RUNNING_LINKS: readonly RelatedLink[] = [
-  { label: 'Mutations', href: '/mutations' },
-  { label: 'Tables Overview', href: '/tables-overview' },
-]
+const MUTATIONS_DOCS = [
+  {
+    label: 'system.mutations',
+    url: 'https://clickhouse.com/docs/en/operations/system-tables/mutations',
+  },
+  {
+    label: 'ALTER … UPDATE / DELETE',
+    url: 'https://clickhouse.com/docs/en/sql-reference/statements/alter/update',
+  },
+] as const
 
-export function StuckMutationsCard({
+// Minimal check definitions so the mutations cards reuse the same detail dialog
+// (and drill-down breakdown) as the standard checks — they are rendered outside
+// HEALTH_CHECKS because their status uses bespoke multi-field rules.
+const STUCK_MUTATIONS_DEF: HealthCheckDef = {
+  id: 'stuck-mutations',
+  title: 'Mutations',
+  icon: Wrench,
+  chartName: 'summary-stuck-mutations',
+  detailChartName: 'health-stuck-mutations-detail',
+  detailEmptyMessage: 'No in-progress or failed mutations.',
+  valueKey: 'stuck',
+  defaults: { warning: 1, critical: 1 },
+  description:
+    'In-progress and failed data mutations (ALTER … UPDATE / DELETE). Any stuck or failed mutation blocks later mutations on the same table.',
+  systemTables: ['system.mutations'],
+  commonCauses: [
+    'Mutation references a column that no longer exists',
+    'A replica is unreachable, so parts cannot be rewritten',
+    'Disk full or slow storage stalling the part rewrite',
+  ],
+  relatedLinks: MUTATIONS_LINKS,
+  docsLinks: MUTATIONS_DOCS,
+  sql: `SELECT
+  countIf(is_done = 0) AS active,
+  countIf(is_done = 0 AND isNotNull(latest_fail_time)) AS failed
+FROM system.mutations`,
+}
+
+const RUNNING_MUTATIONS_DEF: HealthCheckDef = {
+  id: 'running-mutations',
+  title: 'Running Mutations',
+  icon: GitMerge,
+  chartName: 'summary-used-by-mutations',
+  detailChartName: 'health-running-mutations-detail',
+  detailEmptyMessage: 'No mutations are currently running.',
+  valueKey: 'running_count',
+  defaults: { warning: 3, critical: 10 },
+  description:
+    'Mutations currently in progress. A large or growing count means mutations are queuing faster than the background pool can apply them.',
+  systemTables: ['system.mutations'],
+  commonCauses: [
+    'Many concurrent ALTER … UPDATE / DELETE statements',
+    'Background pool saturated by merges',
+    'Large parts making each mutation slow to apply',
+  ],
+  relatedLinks: MUTATIONS_LINKS,
+  docsLinks: MUTATIONS_DOCS,
+  sql: `SELECT count() AS running_count
+FROM system.mutations
+WHERE is_done = 0`,
+}
+
+function MutationsCard({
+  def,
   hostId,
   computed,
   spark,
-}: MutationsCardProps) {
+  clickhouseVersion,
+}: MutationsCardProps & { def: HealthCheckDef }) {
+  const [detailOpen, setDetailOpen] = useState(false)
+
   return (
-    <HealthCardShell
-      icon={Wrench}
-      title="Mutations"
-      status={computed.status}
-      displayValue={computed.value.toLocaleString()}
-      sublabel={computed.label}
-      spark={spark}
-      links={STUCK_LINKS}
-      hostId={hostId}
-    />
+    <>
+      <HealthCardShell
+        icon={def.icon}
+        title={def.title}
+        status={computed.status}
+        displayValue={computed.value.toLocaleString()}
+        sublabel={computed.label}
+        spark={spark}
+        links={def.relatedLinks}
+        hostId={hostId}
+        onExpand={() => setDetailOpen(true)}
+      />
+
+      <HealthDetailDialog
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
+        check={def}
+        hostId={hostId}
+        status={computed.status}
+        value={computed.value}
+        label={computed.label}
+        thresholds={def.defaults}
+        clickhouseVersion={clickhouseVersion}
+      />
+    </>
   )
 }
 
-export function RunningMutationsCard({
-  hostId,
-  computed,
-  spark,
-}: MutationsCardProps) {
-  return (
-    <HealthCardShell
-      icon={GitMerge}
-      title="Running Mutations"
-      status={computed.status}
-      displayValue={computed.value.toLocaleString()}
-      sublabel={computed.label}
-      spark={spark}
-      links={RUNNING_LINKS}
-      hostId={hostId}
-    />
-  )
+export function StuckMutationsCard(props: MutationsCardProps) {
+  return <MutationsCard def={STUCK_MUTATIONS_DEF} {...props} />
+}
+
+export function RunningMutationsCard(props: MutationsCardProps) {
+  return <MutationsCard def={RUNNING_MUTATIONS_DEF} {...props} />
 }

--- a/apps/dashboard/src/lib/api/charts/system-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/system-charts.ts
@@ -602,6 +602,288 @@ export const systemCharts: Record<string, ChartQueryBuilder> = {
     tableCheck: 'system.view_refreshes',
   }),
 
+  // ---------------------------------------------------------------------------
+  // Health drill-down charts. Each returns the *affected rows* behind a health
+  // check (the breakdown shown in the detail dialog), as opposed to the scalar
+  // aggregate the card headline reads. Fetched on demand when the dialog opens,
+  // via the standard /api/v1/charts/$name path (never the batched endpoint).
+  // Columns are pre-formatted + snake_case-aliased so the generic ResultTable
+  // renders them cleanly without per-card formatting code.
+  // ---------------------------------------------------------------------------
+
+  'health-readonly-replicas-detail': () => ({
+    query: `
+    SELECT
+      database,
+      table,
+      replica_name,
+      is_session_expired,
+      queue_size,
+      substring(zookeeper_exception, 1, 200) AS zookeeper_exception
+    FROM system.replicas
+    WHERE is_readonly = 1
+    ORDER BY database, table
+    LIMIT 50
+  `,
+    optional: true,
+    tableCheck: 'system.replicas',
+  }),
+
+  // Shared by both max-parts (breakdown) and delayed-inserts (diagnostic).
+  'health-max-part-count-detail': () => ({
+    query: `
+    SELECT
+      concat(database, '.', table) AS table_path,
+      partition,
+      count() AS parts,
+      formatReadableSize(sum(bytes_on_disk)) AS size_on_disk
+    FROM system.parts
+    WHERE active AND database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
+    GROUP BY database, table, partition
+    ORDER BY parts DESC
+    LIMIT 20
+  `,
+    optional: true,
+    tableCheck: 'system.parts',
+  }),
+
+  'health-long-running-queries-detail': () => ({
+    query: `
+    SELECT
+      query_id,
+      user,
+      round(elapsed, 1) AS elapsed_s,
+      formatReadableQuantity(read_rows) AS read_rows,
+      formatReadableSize(memory_usage) AS memory,
+      substring(replaceRegexpAll(query, '\\\\s+', ' '), 1, 160) AS query
+    FROM system.processes
+    WHERE elapsed > 60 AND is_initial_query
+    ORDER BY elapsed DESC
+    LIMIT 50
+  `,
+  }),
+
+  'health-oom-killed-recent-detail': () => ({
+    query: `
+    SELECT
+      event_time,
+      user,
+      query_id,
+      formatReadableSize(memory_usage) AS peak_memory,
+      substring(replaceRegexpAll(query, '\\\\s+', ' '), 1, 160) AS query
+    FROM system.query_log
+    WHERE event_time > now() - INTERVAL 1 HOUR
+      AND type IN ('ExceptionWhileProcessing', 'ExceptionBeforeStart')
+      AND (exception_code = 241 OR exception LIKE '%MEMORY_LIMIT_EXCEEDED%')
+    ORDER BY event_time DESC
+    LIMIT 50
+  `,
+    optional: true,
+    tableCheck: 'system.query_log',
+  }),
+
+  'health-failed-queries-recent-detail': () => ({
+    query: `
+    SELECT
+      event_time,
+      user,
+      exception_code,
+      substring(exception, 1, 160) AS exception,
+      substring(replaceRegexpAll(query, '\\\\s+', ' '), 1, 120) AS query
+    FROM system.query_log
+    WHERE event_time > now() - INTERVAL 1 HOUR
+      AND type IN ('ExceptionWhileProcessing', 'ExceptionBeforeStart')
+    ORDER BY event_time DESC
+    LIMIT 50
+  `,
+    optional: true,
+    tableCheck: 'system.query_log',
+  }),
+
+  'health-replication-lag-detail': () => ({
+    query: `
+    SELECT
+      database,
+      table,
+      replica_name,
+      absolute_delay AS delay_s,
+      queue_size,
+      (log_max_index - log_pointer) AS log_entries_behind
+    FROM system.replicas
+    WHERE absolute_delay > 0 OR queue_size > 0
+    ORDER BY absolute_delay DESC, queue_size DESC
+    LIMIT 50
+  `,
+    optional: true,
+    tableCheck: 'system.replicas',
+  }),
+
+  'health-keeper-exceptions-detail': () => ({
+    query: `
+    SELECT
+      name AS error,
+      value AS total_count,
+      last_error_time,
+      substring(last_error_message, 1, 300) AS last_error_message
+    FROM system.errors
+    WHERE name = 'KEEPER_EXCEPTION' AND value > 0
+  `,
+    optional: true,
+    tableCheck: 'system.errors',
+  }),
+
+  'health-memory-percent-detail': () => ({
+    query: `
+    SELECT
+      query_id,
+      user,
+      formatReadableSize(memory_usage) AS memory,
+      round(elapsed, 1) AS elapsed_s,
+      substring(replaceRegexpAll(query, '\\\\s+', ' '), 1, 140) AS query
+    FROM system.processes
+    WHERE is_initial_query
+    ORDER BY memory_usage DESC
+    LIMIT 20
+  `,
+  }),
+
+  'health-disk-percent-detail': () => ({
+    query: `
+    SELECT
+      name AS disk,
+      path,
+      formatReadableSize(total_space - free_space) AS used,
+      formatReadableSize(total_space) AS total,
+      round((total_space - free_space) * 100.0 / nullIf(total_space, 0), 1) AS used_pct
+    FROM system.disks
+    ORDER BY used_pct DESC
+    LIMIT 50
+  `,
+    optional: true,
+    tableCheck: 'system.disks',
+  }),
+
+  'health-failed-mutations-detail': () => ({
+    query: `
+    SELECT
+      database,
+      table,
+      mutation_id,
+      latest_fail_time,
+      parts_to_do,
+      substring(latest_fail_reason, 1, 240) AS latest_fail_reason
+    FROM system.mutations
+    WHERE is_done = 0 AND isNotNull(latest_fail_time)
+    ORDER BY latest_fail_time DESC
+    LIMIT 50
+  `,
+    optional: true,
+    tableCheck: 'system.mutations',
+  }),
+
+  'health-stuck-merges-detail': () => ({
+    query: `
+    SELECT
+      database,
+      table,
+      round(elapsed, 0) AS elapsed_s,
+      round(progress * 100, 1) AS progress_pct,
+      num_parts,
+      formatReadableSize(total_size_bytes_compressed) AS merge_size
+    FROM system.merges
+    WHERE elapsed > 600
+    ORDER BY elapsed DESC
+    LIMIT 50
+  `,
+    optional: true,
+    tableCheck: 'system.merges',
+  }),
+
+  'health-query-timeouts-detail': () => ({
+    query: `
+    SELECT
+      event_time,
+      user,
+      round(query_duration_ms / 1000, 1) AS duration_s,
+      substring(replaceRegexpAll(query, '\\\\s+', ' '), 1, 160) AS query
+    FROM system.query_log
+    WHERE event_time > now() - INTERVAL 1 HOUR
+      AND type IN ('ExceptionWhileProcessing', 'ExceptionBeforeStart')
+      AND (exception_code = 159 OR exception LIKE '%TIMEOUT_EXCEEDED%')
+    ORDER BY event_time DESC
+    LIMIT 50
+  `,
+    optional: true,
+    tableCheck: 'system.query_log',
+  }),
+
+  'health-failed-backups-detail': () => ({
+    query: `
+    SELECT
+      event_time,
+      name,
+      status,
+      substring(error, 1, 300) AS error
+    FROM system.backup_log
+    WHERE event_time > now() - INTERVAL 24 HOUR
+      AND status = 'FAILED'
+    ORDER BY event_time DESC
+    LIMIT 50
+  `,
+    optional: true,
+    tableCheck: 'system.backup_log',
+  }),
+
+  'health-mv-refresh-failures-detail': () => ({
+    query: `
+    SELECT
+      database,
+      view,
+      status,
+      substring(exception, 1, 300) AS exception
+    FROM system.view_refreshes
+    WHERE status IN ('Error', 'Failed')
+    LIMIT 50
+  `,
+    optional: true,
+    tableCheck: 'system.view_refreshes',
+  }),
+
+  'health-stuck-mutations-detail': () => ({
+    query: `
+    SELECT
+      database,
+      table,
+      mutation_id,
+      parts_to_do,
+      formatReadableTimeDelta(now() - create_time) AS age,
+      substring(latest_fail_reason, 1, 200) AS latest_fail_reason
+    FROM system.mutations
+    WHERE is_done = 0 OR isNotNull(latest_fail_time)
+    ORDER BY create_time DESC
+    LIMIT 50
+  `,
+    optional: true,
+    tableCheck: 'system.mutations',
+  }),
+
+  'health-running-mutations-detail': () => ({
+    query: `
+    SELECT
+      database,
+      table,
+      mutation_id,
+      parts_to_do,
+      formatReadableTimeDelta(now() - create_time) AS running_for
+    FROM system.mutations
+    WHERE is_done = 0
+    ORDER BY create_time ASC
+    LIMIT 50
+  `,
+    optional: true,
+    tableCheck: 'system.mutations',
+  }),
+
   'keeper-requests': ({
     interval = 'toStartOfFifteenMinutes',
     lastHours = 24,

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-06-29
+updated: 2026-07-04
 tags:
   - design-system
   - ui
@@ -82,6 +82,13 @@ sheet, sidebar, skeleton, tabs, tooltip (+ more).
 - `?host=N` routing; `useHostId()` (`lib/swr`); preserve params via
   `buildUrl(pathname, { host }, searchParams)`.
 - Hooks at deepest consumer — no `hostId` prop drilling.
+- **Clickable summary card → detail dialog:** make the WHOLE card the target
+  (`role="button"` + `tabIndex={0}` + `onClick` + `onKeyDown={activateOnEnterOrSpace(open)}`
+  from `lib/a11y.ts` — never a nested `<button>`); inner links call
+  `e.stopPropagation()` (NOT `preventDefault`) so they still navigate. Reveal a
+  hover/focus "Details" hint. Drive drill-down generically from a per-item field
+  (e.g. each health check's `detailChartName`) rendered via `ResultTable`, not
+  per-card code — see `components/health/{health-card-shell,health-detail-rows}.tsx`.
 - Graceful revalidation: keep data on `staleError`, show hover-revealed amber
   `ChartStaleIndicator`; only blank out on initial `error && !hasData`.
 - Icons: `lucide-react`, `size-4` / `size-3.5`, `strokeWidth={1.5}`.


### PR DESCRIPTION
## What & why

The **Health Summary** page had two problems (from a user screenshot):

1. Cards read like generic gradient tiles — a big number on a colored fill.
2. Drill-down was hidden behind a tiny ⤢ icon and only showed the check's
   description / SQL / causes — **never the actual affected rows**. The user's
   words: for "Replication Lag" they want to see *which tables* are lagging —
   "where do I click to get detailed info?" — "similar to all others."

This PR redesigns the cards and makes every card drill down to the rows behind
its number.

## Before → After

**Cards.** Full-bleed red/amber/green tint + big number → a calm, neutral
`bg-card` surface with a **restrained status accent**: a 3px left rail + a tinted
icon square **for issues only**, a labeled severity pill (`Critical` / `Warning`)
or a quiet status dot, and a clearer title · value · sub-label hierarchy. Healthy
cards stay neutral — color now means "look here."

**Drill-down.** The **whole card** is now the click target (keyboard + pointer)
that opens the detail dialog — related-page links `stopPropagation` so they still
navigate; a hover/focus **"Details ↗"** hint signals the affordance. The dialog
now leads with an **"Affected rows"** table showing the real breakdown, fetched
on open.

## How the generic drill-down works (no per-card special-casing)

- `HealthCheckDef` gains `detailChartName` / `detailTitle` / `detailDescription`
  / `detailEmptyMessage`.
- Each `detailChartName` is a normal entry in the chart registry
  (`system-charts.ts`) whose query returns **rows** (columns pre-formatted +
  snake_case-aliased in SQL, `LIMIT`ed, `optional`+`tableCheck` where the table
  can be absent).
- `HealthDetailRows` mounts **only while the dialog is open** (Radix unmounts
  `DialogContent` on close), calls the shared `useChartData({ detailChartName,
  hostId })`, and renders the rows with the existing `ResultTable` — with
  loading / empty / error / table-unavailable states. Because it's lazy, the
  grid still fetches **nothing extra** up-front; a breakdown is fetched the first
  time a card is opened.
- Works for **all host types** — env, per-user (D1), and browser connections all
  resolve the same registry via `hasChart`.

Adding a breakdown to a future check is now just: add a `*-detail` chart + set
`detailChartName`. Zero rendering code.

## Which checks now have detail rows

**True per-row breakdown** (each row *is* a flagged instance) — 14:
readonly replicas · max parts/partition · long-running queries · OOM-killed
queries · failed queries · **replication lag (the lagging replicas)** · disk
usage (per disk) · failed mutations · stuck merges · query-timeout breaches ·
failed backups · MV refresh failures · **Mutations** · **Running Mutations**
(the two mutations cards were previously *not* drillable — now wired through the
same dialog so every card behaves the same).

**Labeled diagnostic** (metric is a global scalar with **no** true per-row
source — surfaced honestly, not faked) — 3:
- **Delayed inserts** → "Likely cause: partitions with the most parts."
- **Memory usage** → "Likely cause: top in-flight queries by memory" (they don't
  sum to OS memory; labeled as such).
- **Keeper exceptions** → `system.errors` cumulative count + last message
  (labeled "cumulative since server start, not last hour").

These carry a `detailTitle`/`detailDescription` caption so the heading never
claims the rows are the flagged instances when they aren't. (Per the "fail loud"
instruction — I did not invent a per-row breakdown where none exists.)

## Type-check delta

Only required check is `dashboard` = `tsc --noEmit` on `tsconfig.json` +
`tsconfig.test.json`. Measured on the rebased tree:

| config | origin/main | this branch |
|---|---|---|
| `type-check` | 229 | 229 |
| `type-check:test` | 229 | 229 |

**0 new errors** (the ~229 are pre-existing `routeTree.gen.ts`-missing
artifacts; none reference my files). Branch is rebased onto current `origin/main`.

## Reviewer: please eyeball (no live ClickHouse here, so visual + query QA is pending)

1. **Card visuals** in light + dark: the severity rail / icon tint / pill, hover
   shadow, and the "Details" hint. Confirm healthy cards read as calm/neutral.
2. **Whole-card click** opens the dialog; **related-page chips still navigate**
   (stopPropagation) and don't also open the dialog; keyboard (Tab + Enter/Space)
   works.
3. **Breakdown queries against a real cluster** — I validated columns against
   `docs/clickhouse-schemas/` and used only long-stable columns, but could not
   run them. Worth a sanity check on an older CH (esp. `system.view_refreshes`,
   `system.errors.last_error_message`, `system.backup_log`) and that the
   `optional`+`tableCheck` degradation shows the friendly "Not available" note
   rather than an error.
4. The three **diagnostic** captions read honestly (not presented as literal
   "affected rows").

_Screenshots pending — cannot render without a live authenticated cluster._
