### PR TITLE
perf(failed-queries): PREWHERE + drop unused columns; fix loading-vs-empty state

### DIFF
--- a/apps/dashboard/src/components/tables/table-client.tsx
+++ b/apps/dashboard/src/components/tables/table-client.tsx
@@ -173,7 +173,7 @@ export const TableClient = function TableClient({
     [JSON.stringify(searchParams), hostId]
   )
 
-  const { data, metadata, error, isLoading, isValidating, refresh } =
+  const { data, metadata, error, isPending, isValidating, refresh } =
     useTableData<Record<string, unknown>>(
       queryConfig.name,
       hostId,
@@ -181,10 +181,14 @@ export const TableClient = function TableClient({
       refreshInterval
     )
 
-  // Show skeleton during initial load OR if validating with no existing data
-  // This prevents showing "no data" while waiting for the first response
+  // Keep the skeleton up until the query has actually settled. `isPending` is
+  // true whenever no successful response has loaded yet — including the brief
+  // dispatched-but-not-yet-fetching / paused / first-paint window where
+  // `isFetching` (and thus `isValidating`) is false. Without it the empty-state
+  // below would flash before the first result arrives. Also keep the skeleton
+  // while re-validating from an empty cache.
   const isInitialLoading =
-    isLoading || (isValidating && (!data || data.length === 0))
+    isPending || (isValidating && (!data || data.length === 0))
 
   if (isInitialLoading) {
     return <TableSkeleton />

--- a/apps/dashboard/src/lib/api/charts/query-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/query-charts.ts
@@ -229,7 +229,7 @@ export const queryCharts: Record<string, ChartQueryBuilder> = {
       SELECT ${applyInterval(interval, 'event_time')},
              COUNT() AS query_count
       FROM merge('system', '^query_log')
-      WHERE
+      PREWHERE
             type IN ['ExceptionBeforeStart', 'ExceptionWhileProcessing']
             ${timeFilter ? `AND ${timeFilter}` : ''}
       GROUP BY 1
@@ -240,7 +240,7 @@ export const queryCharts: Record<string, ChartQueryBuilder> = {
                type AS query_type,
                COUNT() AS count
         FROM merge('system', '^query_log')
-        WHERE
+        PREWHERE
               type IN ['ExceptionBeforeStart', 'ExceptionWhileProcessing']
               ${timeFilter ? `AND ${timeFilter}` : ''}
         GROUP BY 1, 2
@@ -292,7 +292,7 @@ export const queryCharts: Record<string, ChartQueryBuilder> = {
            user,
            countDistinct(query_id) AS count
     FROM merge('system', '^query_log')
-    WHERE
+    PREWHERE
           type IN ['ExceptionBeforeStart', 'ExceptionWhileProcessing']
           ${timeFilter ? `AND ${timeFilter}` : ''}
     GROUP BY 1, 2

--- a/apps/dashboard/src/lib/query-config/queries/failed-queries.ts
+++ b/apps/dashboard/src/lib/query-config/queries/failed-queries.ts
@@ -121,11 +121,12 @@ export const failedQueriesConfig: QueryConfig = {
             toString(used_functions) AS used_functions,
             toString(used_storages) AS used_storages,
             toString(used_table_functions) AS used_table_functions,
-            toString(thread_ids) AS thread_ids,
-            ProfileEvents,
-            Settings
+            toString(thread_ids) AS thread_ids
         FROM system.query_log
-        WHERE type IN ['ExceptionBeforeStart', 'ExceptionWhileProcessing']
+        -- PREWHERE reads the small type + event_time columns first and skips
+        -- granules with no exceptions, so the heavy query/stack_trace/toString
+        -- blobs are only read for the few rows that survive the filter.
+        PREWHERE type IN ['ExceptionBeforeStart', 'ExceptionWhileProcessing']
             AND ({type:String} = '' OR type = {type:String})
             AND event_time > now() - interval {last_hours:UInt64} hour
         ORDER BY query_start_time DESC
@@ -167,11 +168,12 @@ export const failedQueriesConfig: QueryConfig = {
             toString(used_functions) AS used_functions,
             toString(used_storages) AS used_storages,
             toString(used_table_functions) AS used_table_functions,
-            toString(thread_ids) AS thread_ids,
-            ProfileEvents,
-            Settings
+            toString(thread_ids) AS thread_ids
         FROM system.query_log
-        WHERE type IN ['ExceptionBeforeStart', 'ExceptionWhileProcessing']
+        -- PREWHERE reads the small type + event_time columns first and skips
+        -- granules with no exceptions, so the heavy query/stack_trace/toString
+        -- blobs are only read for the few rows that survive the filter.
+        PREWHERE type IN ['ExceptionBeforeStart', 'ExceptionWhileProcessing']
             AND ({type:String} = '' OR type = {type:String})
             AND event_time > now() - interval {last_hours:UInt64} hour
         ORDER BY query_start_time DESC

--- a/apps/dashboard/src/lib/query/use-table-data.ts
+++ b/apps/dashboard/src/lib/query/use-table-data.ts
@@ -144,6 +144,11 @@ export function useTableData<T = unknown>(
     metadata: data?.metadata,
     error: error ?? undefined,
     isLoading,
+    // `isPending` is true whenever no successful response has loaded yet for
+    // the current query key — including the dispatched-but-not-yet-fetching /
+    // paused / first-paint window where `isFetching` is false. Consumers use it
+    // to keep a skeleton up so the empty-state never flashes before data lands.
+    isPending,
     isValidating,
     refresh: () => refetch().then(() => undefined),
     hasData,


### PR DESCRIPTION
## Why

`/failed-queries?host=0` loads slowly, and the "No data" empty-state can flash
while the table query is still loading. This optimises the query path for the
page and fixes the premature empty-state.

## What changed

### 1. Table query — `failed-queries.ts` (the dominant cost)

The list query scans `system.query_log` over the range param (default 14 days)
and, for up to 1000 matched exception rows, pulls a very wide row: the full
`query` (via `normalizeQuery`), `stack_trace`, ~15 `toString(array)` columns, **plus
`ProfileEvents` and `Settings`** — two large `Map` columns.

**`ProfileEvents` and `Settings` were dead weight:** they were `SELECT`ed but appear
in neither `columns` nor `columnFormats`, so they were fetched for every row and
never rendered. Removed.

The exception-type + time filters moved from `WHERE` to **`PREWHERE`**, so ClickHouse
reads the tiny `type` (LowCardinality Enum8) and `event_time` (primary-key) columns
first, skips granules that hold no exceptions, and only reads the heavy blobs for
the few rows that survive the filter.

```sql
-- before
  ...
  toString(thread_ids) AS thread_ids,
  ProfileEvents,          -- unused
  Settings                -- unused
FROM system.query_log
WHERE type IN ['ExceptionBeforeStart','ExceptionWhileProcessing']
  AND ({type:String} = '' OR type = {type:String})
  AND event_time > now() - interval {last_hours:UInt64} hour
ORDER BY query_start_time DESC
LIMIT 1000

-- after
  ...
  toString(thread_ids) AS thread_ids
FROM system.query_log
PREWHERE type IN ['ExceptionBeforeStart','ExceptionWhileProcessing']
  AND ({type:String} = '' OR type = {type:String})
  AND event_time > now() - interval {last_hours:UInt64} hour
ORDER BY query_start_time DESC
LIMIT 1000
```

Results are unchanged: same rows (`PREWHERE`/`WHERE` combine with `AND`), same
displayed columns, same order, same `LIMIT`. Applied to both versioned SQL variants
(23.8 base and 24.1 `query_cache_usage`).

**Expected speedup:** dropping two per-row `Map` columns (`ProfileEvents` in query_log
commonly carries ~150–250 entries/row) cuts the read + network payload for up to
1000 rows substantially, and `PREWHERE` defers the remaining heavy blobs to the
exception rows only. The wide-row read was the page's dominant cost, so this is the
main win.

### 2. Related chart queries — `query-charts.ts` (investigated + tightened)

The `failed-query-count` and `failed-query-count-by-user` charts render **above** the
table and default to **expanded**, so both fire on initial page load, each scanning
`merge('system','^query_log')` over 14 days. Their exception-type + time filter is now
an explicit **`PREWHERE`** (matching the table), so the small `type`/`event_time`
columns filter first and `user`/`query_id` are read only for surviving rows.

### 3. Loading-vs-empty state — `table-client.tsx` + `use-table-data.ts`

The table's "No data" card rendered whenever data was empty and `isFetching` was
false. But TanStack Query reports `isPending=true` with `isFetching=false` during the
dispatched-but-not-yet-fetching / paused / first-paint window, so the empty card
could **flash before the first response settled**. `useTableData` now exposes
`isPending`, and `TableClient` keeps the skeleton up until the query has actually
resolved. The `TableSkeleton` still renders throughout the fetch.

This is additive (new `isPending` field; `isLoading` semantics unchanged), so the
other `useTableData` consumers (query-detail, slow/expensive queries, disks, keeper,
running, part-log) are untouched.

## Caveats / follow-ups (fail-loud)

- **Runtime QA pending** — I can't run against live ClickHouse, so numbers above are
  reasoning, not measured. Correctness is preserved by construction (column pruning +
  `PREWHERE`/`WHERE` are semantically equal).
- **Chart `PREWHERE` may duplicate `optimize_move_to_prewhere`.** ClickHouse likely
  already moves `type IN […]` to PREWHERE automatically; the explicit form is a
  guarantee + consistency with the table query. The charts are aggregation-only and
  capped at `max_execution_time = 25`, i.e. secondary to the table's wide-column read.
- **`failed-query-count` scans `query_log` twice** (an `event_count` CTE plus a
  `query_type` CTE). `event_count` is derivable from `query_type` (sum of per-type
  counts), but I did not restructure it here — collapsing the two CTEs risks changing
  `groupArray` breakdown ordering, which I can't verify without live ClickHouse. Noted
  as a follow-up.

## Verification

- `bun run type-check` and `bun run type-check:test`, baseline (origin/main) vs branch:
  **228 → 228, identical error set (0 new, 0 removed)**. The pre-existing ~207
  `routeTree.gen.ts` "not assignable to `undefined`" errors are unrelated (stale
  generated route tree in the worktree).
- Biome clean on all changed files; SQL validator corpus test (`shipped-sql-passes-validator`)
  covers the table config and accepts `PREWHERE`.
- No test asserts these queries' SQL text or the removed columns
  (`sql-regressions`, `version-compatibility`, `registry-completeness` all checked).

Co-Authored-By: duyetbot <bot@duyet.net>
