### PR TITLE
feat(running-queries): keep expanded queries as Done on finish + Explain link

### DIFF
--- a/apps/dashboard/src/components/running-queries/running-queries-table.tsx
+++ b/apps/dashboard/src/components/running-queries/running-queries-table.tsx
@@ -53,7 +53,23 @@ import { cn } from '@/lib/utils'
 export type { RunningQueryRow } from './table/types'
 
 interface RunningQueriesTableProps {
+  /** Live `system.processes` rows. Drives the toolbar/footer counts and CSV. */
   rows: RunningQueryRow[]
+  /**
+   * Retained "Done" rows — queries the user had expanded that have since left
+   * `system.processes`. Rendered pinned above the live rows in a finished
+   * state; excluded from the "active" counts and export.
+   */
+  doneRows: RunningQueryRow[]
+  /**
+   * Expanded row keys. Owned by the parent view so an expanded row survives as
+   * a Done row even when the live list (and this table) would otherwise unmount.
+   */
+  expanded: Set<string>
+  /** Toggle a row's expansion by its stable key. */
+  onToggle: (key: string) => void
+  /** Dismiss a retained Done row by query_id. */
+  onDismiss: (id: string) => void
 }
 
 /**
@@ -68,6 +84,10 @@ interface RunningQueriesTableProps {
  */
 export const RunningQueriesTable = memo(function RunningQueriesTable({
   rows,
+  doneRows,
+  expanded,
+  onToggle,
+  onDismiss,
 }: RunningQueriesTableProps) {
   const [search, setSearch] = useState('')
   const [filterKind, setFilterKind] = useState('all')
@@ -82,13 +102,16 @@ export const RunningQueriesTable = memo(function RunningQueriesTable({
   // Card view leads on phones (the wide metric table is unreadable in a scroll
   // box), table on desktop — with a toggle so either is reachable anywhere.
   const [view, setView] = useLayoutView()
-  // Expansion is keyed by a stable row key; `query_id` still drives actions.
-  // A row stays open across refreshes and re-sorts as long as that underlying
-  // identifier remains stable.
-  // sorting / filtering never reassigns the panel to a different query.
-  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+
+  // Expansion is owned by the parent view (keyed by the stable `query_id`), so
+  // an expanded row can be retained as a "Done" row when it finishes rather
+  // than vanishing with the live list. A row stays open across refreshes,
+  // re-sorts and filters as long as that identifier is stable.
 
   const derived = useMemo(() => rows.map(derive), [rows])
+  // Retained Done rows, pinned above the live rows and exempt from the live
+  // search / filter / sort so they stay put until dismissed.
+  const derivedDone = useMemo(() => doneRows.map(derive), [doneRows])
 
   // Filter options come from the values actually present in the data.
   const kindOptions = useMemo(() => {
@@ -144,15 +167,6 @@ export const RunningQueriesTable = memo(function RunningQueriesTable({
   const moreFiltersActive = filterInterface !== 'all' || longRunningOnly
   const totalColumns =
     BASE_COLUMN_COUNT + (OPTIONAL_COLUMNS.length - hiddenColumns.size)
-
-  const toggleRow = useCallback((id: string) => {
-    setExpanded((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }, [])
 
   const handleSort = useCallback((key: string) => {
     const k = key as SortKey
@@ -314,15 +328,25 @@ export const RunningQueriesTable = memo(function RunningQueriesTable({
           className="grid grid-cols-1 gap-3 p-3 sm:grid-cols-2 xl:grid-cols-3"
           data-testid="running-queries-cards"
         >
+          {derivedDone.map((d) => (
+            <QueryCard
+              key={d.key}
+              d={d}
+              done
+              expanded={expanded.has(d.key)}
+              onToggle={() => onToggle(d.key)}
+              onDismiss={() => onDismiss(d.id)}
+            />
+          ))}
           {visible.map((d) => (
             <QueryCard
               key={d.key}
               d={d}
               expanded={expanded.has(d.key)}
-              onToggle={() => toggleRow(d.key)}
+              onToggle={() => onToggle(d.key)}
             />
           ))}
-          {visible.length === 0 && <EmptyCards />}
+          {visible.length === 0 && derivedDone.length === 0 && <EmptyCards />}
         </div>
       ) : (
         /* Table — table-fixed so the Query column truncates instead of pushing
@@ -415,6 +439,18 @@ export const RunningQueriesTable = memo(function RunningQueriesTable({
               </tr>
             </thead>
             <tbody>
+              {/* Retained Done rows, pinned above the live rows. */}
+              {derivedDone.map((d) => (
+                <QueryRow
+                  key={d.key}
+                  d={d}
+                  done
+                  expanded={expanded.has(d.key)}
+                  onToggle={() => onToggle(d.key)}
+                  onDismiss={() => onDismiss(d.id)}
+                  hiddenColumns={hiddenColumns}
+                />
+              ))}
               {visible.map((d) => (
                 // Keyed by stable row key so each row keeps identity and
                 // component state through refreshes, sorts and filters.
@@ -422,11 +458,13 @@ export const RunningQueriesTable = memo(function RunningQueriesTable({
                   key={d.key}
                   d={d}
                   expanded={expanded.has(d.key)}
-                  onToggle={() => toggleRow(d.key)}
+                  onToggle={() => onToggle(d.key)}
                   hiddenColumns={hiddenColumns}
                 />
               ))}
-              {visible.length === 0 && <EmptyTableRow colSpan={totalColumns} />}
+              {visible.length === 0 && derivedDone.length === 0 && (
+                <EmptyTableRow colSpan={totalColumns} />
+              )}
             </tbody>
           </table>
         </div>

--- a/apps/dashboard/src/components/running-queries/running-queries-view.tsx
+++ b/apps/dashboard/src/components/running-queries/running-queries-view.tsx
@@ -4,7 +4,7 @@ import type { CompletedQueryRow } from '@/components/running-queries/completed-q
 import type { RunningQueryRow } from '@/components/running-queries/running-queries-table'
 import type { CardError } from '@/lib/card-error-utils'
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { PageHeader } from '@/components/layout'
 import { CollapsedChartsRow } from '@/components/layout/query-page/collapsed-charts-row'
 import { HeaderButton } from '@/components/query-tables/header-button'
@@ -12,6 +12,7 @@ import { QueryPageSkeleton } from '@/components/query-tables/query-page-skeleton
 import { CompletedQueriesTable } from '@/components/running-queries/completed-queries-table'
 import { RunningQueriesCharts } from '@/components/running-queries/running-queries-charts'
 import { RunningQueriesTable } from '@/components/running-queries/running-queries-table'
+import { reconcileDoneRows } from '@/components/running-queries/table/done-retention'
 import { Card, CardContent } from '@/components/ui/card'
 import { EmptyState } from '@/components/ui/empty-state'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -155,6 +156,43 @@ export const RunningQueriesView = function RunningQueriesView() {
   const [pendingFinished, setPendingFinished] = useState<CompletedQueryRow[]>(
     []
   )
+
+  // Row expansion is owned here rather than inside the table: the table unmounts
+  // when the live list empties, so a retained "Done" row must outlive it. Keyed
+  // by the stable `query_id` (the table's row key for identified rows).
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set())
+  const expandedRef = useRef(expanded)
+  expandedRef.current = expanded
+  const toggleExpanded = useCallback((key: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }, [])
+
+  // Finished queries the user had expanded, retained as Done rows (keyed by
+  // query_id) so an in-flight inspection is not lost when the query leaves
+  // `system.processes`. Cleared on dismiss or unmount (navigate away).
+  const [doneRows, setDoneRows] = useState<Map<string, RunningQueryRow>>(
+    () => new Map()
+  )
+  const dismissDone = useCallback((id: string) => {
+    setDoneRows((prev) => {
+      if (!prev.has(id)) return prev
+      const next = new Map(prev)
+      next.delete(id)
+      return next
+    })
+    setExpanded((prev) => {
+      if (!prev.has(id)) return prev
+      const next = new Set(prev)
+      next.delete(id)
+      return next
+    })
+  }, [])
+
   useEffect(() => {
     // Only diff once the running list has loaded; an undefined `data` means the
     // first fetch is still in flight, which must not count every id as gone.
@@ -169,6 +207,13 @@ export const RunningQueriesView = function RunningQueriesView() {
       if (!current.has(id)) finishedRows.push(row)
     }
     prevRunningRef.current = current
+    // Retain finished rows the user had expanded (the keep-Done behaviour).
+    // reconcileDoneRows returns the previous map unchanged when nothing was
+    // added or removed, so this setState bails out of a needless re-render.
+    const currentIds = new Set(current.keys())
+    setDoneRows((prev) =>
+      reconcileDoneRows(prev, finishedRows, currentIds, expandedRef.current)
+    )
     if (finishedRows.length > 0) {
       const finishedIds = finishedRows.map((r) => String(r.query_id))
       setJustFinishedIds((prev) => {
@@ -200,6 +245,12 @@ export const RunningQueriesView = function RunningQueriesView() {
   )
   const mergedCompleted =
     livePending.length > 0 ? [...livePending, ...completedRows] : completedRows
+
+  // Retained Done rows, newest-first (most recently finished at the top).
+  const doneRowsArr = useMemo(
+    () => Array.from(doneRows.values()).reverse(),
+    [doneRows]
+  )
 
   const errVariant = error
     ? detectCardErrorVariant(error as CardError)
@@ -305,7 +356,7 @@ export const RunningQueriesView = function RunningQueriesView() {
                 onExpand={() => setChartsOpen(true)}
               />
             )}
-            {rows.length === 0 ? (
+            {rows.length === 0 && doneRowsArr.length === 0 ? (
               <Card className="rounded-xl border-dashed">
                 <CardContent className="p-6">
                   <EmptyState
@@ -316,7 +367,13 @@ export const RunningQueriesView = function RunningQueriesView() {
                 </CardContent>
               </Card>
             ) : (
-              <RunningQueriesTable rows={rows} />
+              <RunningQueriesTable
+                rows={rows}
+                doneRows={doneRowsArr}
+                expanded={expanded}
+                onToggle={toggleExpanded}
+                onDismiss={dismissDone}
+              />
             )}
             <CompletedQueriesTable
               rows={mergedCompleted}

--- a/apps/dashboard/src/components/running-queries/table/cells.tsx
+++ b/apps/dashboard/src/components/running-queries/table/cells.tsx
@@ -1,33 +1,76 @@
+import { CheckCircle2 } from 'lucide-react'
+
 import type { DerivedQuery } from './types'
+
+import { cn } from '@/lib/utils'
+
+/** Emerald "Done" completion color, shared by the badge and progress bar. */
+const DONE_COLOR = 'hsl(158 64% 42%)'
+
+/**
+ * "Done" status pill for a query that finished while the user was inspecting
+ * it. Mirrors the emerald pill on the Recently-completed table so a retained
+ * row reads as intentionally finished, not as a live query.
+ */
+export function DoneBadge() {
+  return (
+    <span className="inline-flex items-center gap-1 rounded bg-emerald-100 px-1.5 py-0.5 text-[10.5px] font-semibold uppercase tracking-wide text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+      <CheckCircle2 className="size-3" />
+      Done
+    </span>
+  )
+}
 
 /**
  * Progress cell — a determinate bar with `read / total` rows when the query
  * reports progress, or an indeterminate shimmer when only the row count is
  * known. Bar color shifts blue → green as the scan completes.
+ *
+ * When `done`, the query has left `system.processes`: render a full emerald bar
+ * labelled "Done" as a completion marker (the `read / total` subtext stays the
+ * last-known counts — it is not a claim that every row was read).
  */
-export function ProgressCell({ d }: { d: DerivedQuery }) {
+export function ProgressCell({ d, done }: { d: DerivedQuery; done?: boolean }) {
   const { pct } = d
   const indeterminate = pct == null && d.readRows > 0
-  const label = pct != null ? `${pct}%` : indeterminate ? 'Reading…' : '—'
+  const label = done
+    ? 'Done'
+    : pct != null
+      ? `${pct}%`
+      : indeterminate
+        ? 'Reading…'
+        : '—'
   const denom =
     d.totalRows > 0 ? d.readableTotalRows : indeterminate ? '?' : '—'
   const color =
     pct == null
       ? 'hsl(38 92% 55%)'
       : pct >= 80
-        ? 'hsl(158 64% 42%)'
+        ? DONE_COLOR
         : 'hsl(217 91% 60%)'
 
   return (
     <div className="flex min-w-[88px] flex-col gap-1">
       <div className="flex items-center justify-between gap-2 text-[11px]">
-        <span className="font-medium tabular-nums">{label}</span>
+        <span
+          className={cn(
+            'font-medium tabular-nums',
+            done && 'text-emerald-600 dark:text-emerald-400'
+          )}
+        >
+          {label}
+        </span>
         <span className="truncate text-right tabular-nums text-muted-foreground">
           {d.readableReadRows} / {denom}
         </span>
       </div>
       <div className="relative h-1.5 overflow-hidden rounded-full bg-muted">
-        {pct != null ? (
+        {done ? (
+          <div
+            className="absolute inset-y-0 left-0 w-full rounded-full"
+            style={{ background: DONE_COLOR }}
+          />
+        ) : pct != null ? (
           <div
             className="absolute inset-y-0 left-0 rounded-full transition-all"
             style={{ width: `${Math.max(pct, 2)}%`, background: color }}

--- a/apps/dashboard/src/components/running-queries/table/done-retention.test.ts
+++ b/apps/dashboard/src/components/running-queries/table/done-retention.test.ts
@@ -1,0 +1,77 @@
+import type { RunningQueryRow } from './types'
+
+import { reconcileDoneRows } from './done-retention'
+import { describe, expect, test } from 'bun:test'
+
+const row = (
+  query_id: string,
+  extra: Partial<RunningQueryRow> = {}
+): RunningQueryRow => ({
+  query_id,
+  query: `SELECT ${query_id}`,
+  ...extra,
+})
+
+describe('reconcileDoneRows — retain expanded queries that just finished', () => {
+  test('retains a finished row the user had expanded', () => {
+    const next = reconcileDoneRows(
+      new Map(),
+      [row('a')],
+      new Set(),
+      new Set(['a'])
+    )
+    expect(next.has('a')).toBe(true)
+    expect(next.get('a')?.query).toBe('SELECT a')
+  })
+
+  test('ignores a finished row that was not expanded', () => {
+    const next = reconcileDoneRows(new Map(), [row('a')], new Set(), new Set())
+    expect(next.size).toBe(0)
+  })
+
+  test('ignores a "finished" row that is still present this poll', () => {
+    const next = reconcileDoneRows(
+      new Map(),
+      [row('a')],
+      new Set(['a']),
+      new Set(['a'])
+    )
+    expect(next.size).toBe(0)
+  })
+
+  test('drops a retained row that is running again', () => {
+    const prev = new Map([['a', row('a')]])
+    const next = reconcileDoneRows(prev, [], new Set(['a']), new Set(['a']))
+    expect(next.has('a')).toBe(false)
+  })
+
+  test('keeps an already-retained row that is still gone', () => {
+    const prev = new Map([['a', row('a')]])
+    const next = reconcileDoneRows(prev, [], new Set(), new Set(['a']))
+    expect(next.has('a')).toBe(true)
+    // No change → same reference so a state setter can bail out.
+    expect(next).toBe(prev)
+  })
+
+  test('returns the same reference when nothing changed', () => {
+    const prev = new Map<string, RunningQueryRow>()
+    // A finished-but-unexpanded row is a no-op.
+    expect(reconcileDoneRows(prev, [row('a')], new Set(), new Set())).toBe(prev)
+  })
+
+  test('does not mutate the previous map', () => {
+    const prev = new Map<string, RunningQueryRow>()
+    reconcileDoneRows(prev, [row('a')], new Set(), new Set(['a']))
+    expect(prev.size).toBe(0)
+  })
+
+  test('ignores finished rows without a query_id', () => {
+    const next = reconcileDoneRows(
+      new Map(),
+      [row('')],
+      new Set(),
+      new Set([''])
+    )
+    expect(next.size).toBe(0)
+  })
+})

--- a/apps/dashboard/src/components/running-queries/table/done-retention.ts
+++ b/apps/dashboard/src/components/running-queries/table/done-retention.ts
@@ -1,0 +1,59 @@
+import type { RunningQueryRow } from './types'
+
+/**
+ * Reconcile the set of "retained Done" rows after one running-queries poll.
+ *
+ * The Running Queries table lists live `system.processes` rows, so a query
+ * vanishes the instant it finishes. When the user has EXPANDED a row to inspect
+ * it, that mid-inspection disappearance is jarring — so we retain the row's
+ * last-known snapshot, flip it to a "Done" state, and keep it in the table
+ * until the user dismisses it (navigating away drops all state).
+ *
+ * This is the pure core of that lifecycle, kept side-effect free so it can be
+ * unit-tested:
+ *
+ * - A row present on the previous poll but absent now ("finished") is retained
+ *   ONLY if its query_id is currently expanded. Non-expanded finishes are left
+ *   to the separate "Recently completed" table, so the running table never
+ *   duplicates the whole completed log.
+ * - A retained id that shows up live again is dropped (it is running once more).
+ * - Explicit dismissal is handled by the caller (a plain map delete).
+ *
+ * Returns the SAME `prevDone` reference when nothing changed, so a React state
+ * setter fed with it bails out of a re-render.
+ *
+ * @param prevDone     Previously-retained Done rows, keyed by query_id.
+ * @param finishedRows Rows present on the previous poll but gone on this one.
+ * @param currentIds   query_ids present on this poll.
+ * @param expandedKeys Currently-expanded row keys (equal to query_id for keyed
+ *                     rows).
+ */
+export function reconcileDoneRows(
+  prevDone: Map<string, RunningQueryRow>,
+  finishedRows: RunningQueryRow[],
+  currentIds: Set<string>,
+  expandedKeys: Set<string>
+): Map<string, RunningQueryRow> {
+  const next = new Map(prevDone)
+  let changed = false
+
+  // A retained row that is running again drops back to the live list.
+  for (const id of prevDone.keys()) {
+    if (currentIds.has(id)) {
+      next.delete(id)
+      changed = true
+    }
+  }
+
+  // Newly-finished rows the user was inspecting become retained Done rows.
+  for (const row of finishedRows) {
+    const id = String(row.query_id ?? '')
+    if (!id || currentIds.has(id) || !expandedKeys.has(id)) continue
+    if (!next.has(id)) {
+      next.set(id, row)
+      changed = true
+    }
+  }
+
+  return changed ? next : prevDone
+}

--- a/apps/dashboard/src/components/running-queries/table/expanded-row.tsx
+++ b/apps/dashboard/src/components/running-queries/table/expanded-row.tsx
@@ -1,4 +1,11 @@
-import { CircleX, ExternalLink, Loader2, ScanSearch } from 'lucide-react'
+import {
+  CircleX,
+  ExternalLink,
+  Loader2,
+  ScanSearch,
+  Workflow,
+  X,
+} from 'lucide-react'
 
 import type { DerivedQuery } from './types'
 
@@ -8,22 +15,36 @@ import { Button } from '@/components/ui/button'
 import { buildExplorerQueryUrl } from '@/lib/explorer-url'
 import { formatReadableSize } from '@/lib/format-readable'
 import { useHostId } from '@/lib/swr/use-host'
+import { buildUrl } from '@/lib/url/url-builder'
 
 interface ExpandedRowProps {
   d: DerivedQuery
   onKill: () => void
   isKilling: boolean
+  /** Row has finished and is being retained; swaps Kill → Dismiss. */
+  done?: boolean
+  /** Drop this retained Done row from the table. */
+  onDismiss?: () => void
 }
 
 /**
  * Expanded row — an execution-details grid, the full query as a scrollable
  * code block, then row actions.
  */
-export function ExpandedRow({ d, onKill, isKilling }: ExpandedRowProps) {
+export function ExpandedRow({
+  d,
+  onKill,
+  isKilling,
+  done,
+  onDismiss,
+}: ExpandedRowProps) {
   const hostId = useHostId()
   const explorerUrl = buildExplorerQueryUrl(d.query, hostId)
   const detailUrl = d.id
     ? `/query?query_id=${encodeURIComponent(d.id)}&host=${hostId}`
+    : ''
+  const explainUrl = d.id
+    ? buildUrl('/explain', { query_id: d.id, host: hostId })
     : ''
   const lineCount = (d.query.match(/\n/g)?.length ?? 0) + 1
 
@@ -115,20 +136,40 @@ export function ExpandedRow({ d, onKill, isKilling }: ExpandedRowProps) {
             </span>
           )}
         </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="ml-auto h-7 gap-1.5 text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:hover:bg-rose-950/30"
-          onClick={onKill}
-          disabled={isKilling || !d.id}
-        >
-          {isKilling ? (
-            <Loader2 className="size-3.5 animate-spin" />
-          ) : (
-            <CircleX className="size-3.5" />
-          )}
-          Kill query
-        </Button>
+        {explainUrl && (
+          <Button variant="outline" size="sm" className="h-7 gap-1.5" asChild>
+            <Link href={explainUrl}>
+              <Workflow className="size-3.5" />
+              Explain
+            </Link>
+          </Button>
+        )}
+        {done ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="ml-auto h-7 gap-1.5 text-muted-foreground hover:text-foreground"
+            onClick={onDismiss}
+          >
+            <X className="size-3.5" />
+            Dismiss
+          </Button>
+        ) : (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="ml-auto h-7 gap-1.5 text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:hover:bg-rose-950/30"
+            onClick={onKill}
+            disabled={isKilling || !d.id}
+          >
+            {isKilling ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <CircleX className="size-3.5" />
+            )}
+            Kill query
+          </Button>
+        )}
       </div>
     </div>
   )

--- a/apps/dashboard/src/components/running-queries/table/query-card.tsx
+++ b/apps/dashboard/src/components/running-queries/table/query-card.tsx
@@ -10,18 +10,23 @@ import {
 
 import type { DerivedQuery } from './types'
 
-import { ProgressCell } from './cells'
+import { DoneBadge, ProgressCell } from './cells'
 import { ExpandedRow } from './expanded-row'
 import { useKillQuery } from './use-kill-query'
 import { memo } from 'react'
 import { formatDuration } from '@/components/query-tables/format-duration'
 import { KindBadge } from '@/components/query-tables/kind-badge'
 import { formatReadableSize } from '@/lib/format-readable'
+import { cn } from '@/lib/utils'
 
 interface QueryCardProps {
   d: DerivedQuery
   expanded: boolean
   onToggle: () => void
+  /** Query has finished and its card is retained in a "Done" state. */
+  done?: boolean
+  /** Drop this retained Done card from the list. */
+  onDismiss?: () => void
 }
 
 /**
@@ -33,6 +38,8 @@ export const QueryCard = memo(function QueryCard({
   d,
   expanded,
   onToggle,
+  done,
+  onDismiss,
 }: QueryCardProps) {
   const { isKilling, handleKill } = useKillQuery(d.id)
   const ExpandIcon = expanded ? ChevronDown : ChevronRight
@@ -42,7 +49,11 @@ export const QueryCard = memo(function QueryCard({
     <div
       data-testid="running-query-card"
       data-expanded={expanded || undefined}
-      className="overflow-hidden rounded-lg border border-border/60 bg-card/40"
+      className={cn(
+        'overflow-hidden rounded-lg border border-border/60 bg-card/40',
+        done &&
+          'border-emerald-300/60 bg-emerald-50/40 dark:border-emerald-900/50 dark:bg-emerald-950/20'
+      )}
     >
       <button
         type="button"
@@ -52,6 +63,7 @@ export const QueryCard = memo(function QueryCard({
       >
         {/* Header: kind badge + short id + expand affordance */}
         <div className="flex min-w-0 items-center gap-2">
+          {done && <DoneBadge />}
           <KindBadge kind={d.kind} />
           <span className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">
             #{d.id ? d.id.slice(0, 8) : 'n/a'}
@@ -92,11 +104,17 @@ export const QueryCard = memo(function QueryCard({
           </span>
         </div>
 
-        <ProgressCell d={d} />
+        <ProgressCell d={d} done={done} />
       </button>
 
       {expanded && (
-        <ExpandedRow d={d} onKill={handleKill} isKilling={isKilling} />
+        <ExpandedRow
+          d={d}
+          onKill={handleKill}
+          isKilling={isKilling}
+          done={done}
+          onDismiss={onDismiss}
+        />
       )}
     </div>
   )

--- a/apps/dashboard/src/components/running-queries/table/query-row.tsx
+++ b/apps/dashboard/src/components/running-queries/table/query-row.tsx
@@ -11,9 +11,11 @@ import {
   MemoryStick,
   ScanSearch,
   User as UserIcon,
+  Workflow,
+  X,
 } from 'lucide-react'
 
-import { CpuMeter, ProgressCell } from './cells'
+import { CpuMeter, DoneBadge, ProgressCell } from './cells'
 import { ExpandedRow } from './expanded-row'
 import {
   BASE_COLUMN_COUNT,
@@ -36,6 +38,7 @@ import {
 import { buildExplorerQueryUrl } from '@/lib/explorer-url'
 import { formatReadableSize } from '@/lib/format-readable'
 import { useHostId } from '@/lib/swr/use-host'
+import { buildUrl } from '@/lib/url/url-builder'
 import { cn } from '@/lib/utils'
 
 interface QueryRowProps {
@@ -43,6 +46,10 @@ interface QueryRowProps {
   expanded: boolean
   onToggle: () => void
   hiddenColumns: Set<OptionalColumn>
+  /** Query has finished and its row is retained in a "Done" state. */
+  done?: boolean
+  /** Drop this retained Done row from the table. */
+  onDismiss?: () => void
 }
 
 /** One running query rendered as a table row (collapsed) + detail row. */
@@ -51,11 +58,16 @@ export const QueryRow = memo(function QueryRow({
   expanded,
   onToggle,
   hiddenColumns,
+  done,
+  onDismiss,
 }: QueryRowProps) {
   const hostId = useHostId()
   const { isKilling, handleKill } = useKillQuery(d.id)
   const queryDetailUrl = d.id
     ? `/query?query_id=${encodeURIComponent(d.id)}&host=${hostId}`
+    : ''
+  const explainUrl = d.id
+    ? buildUrl('/explain', { query_id: d.id, host: hostId })
     : ''
 
   const dur = formatDuration(d.elapsed)
@@ -70,7 +82,11 @@ export const QueryRow = memo(function QueryRow({
   return (
     <>
       <tr
-        className="group animate-in cursor-pointer border-b border-border align-middle fade-in-0 slide-in-from-top-1 duration-300 hover:bg-muted/60"
+        className={cn(
+          'group animate-in cursor-pointer border-b border-border align-middle fade-in-0 slide-in-from-top-1 duration-300 hover:bg-muted/60',
+          done &&
+            'bg-emerald-50/60 hover:bg-emerald-50 dark:bg-emerald-950/20 dark:hover:bg-emerald-950/30'
+        )}
         onClick={onToggle}
       >
         {/* Type + expand chevron */}
@@ -82,6 +98,7 @@ export const QueryRow = memo(function QueryRow({
                 expanded && 'rotate-90'
               )}
             />
+            {done && <DoneBadge />}
             <KindBadge kind={d.kind} />
           </div>
         </td>
@@ -166,7 +183,7 @@ export const QueryRow = memo(function QueryRow({
 
         {/* Progress — always visible */}
         <td className="px-2 py-2.5 sm:px-3">
-          <ProgressCell d={d} />
+          <ProgressCell d={d} done={done} />
         </td>
 
         {/* Memory — md+ */}
@@ -204,7 +221,7 @@ export const QueryRow = memo(function QueryRow({
         {/* Duration — sm+ (lives in the meta line on xs) */}
         {showDuration && (
           <td className="hidden whitespace-nowrap px-2 py-2.5 text-right text-[12px] tabular-nums sm:table-cell sm:px-3">
-            <span className={SEVERITY_DURATION[d.severity]}>
+            <span className={cn(!done && SEVERITY_DURATION[d.severity])}>
               {dur.value}
               <span className="ml-0.5 text-[10.5px] text-muted-foreground">
                 {dur.unit}
@@ -219,25 +236,60 @@ export const QueryRow = memo(function QueryRow({
             className="flex items-center justify-end gap-0.5 opacity-60 transition-opacity group-hover:opacity-100"
             onClick={(e) => e.stopPropagation()}
           >
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="size-7 text-muted-foreground hover:text-rose-600"
-                  onClick={handleKill}
-                  disabled={isKilling || !d.id}
-                  aria-label="Kill query"
-                >
-                  {isKilling ? (
-                    <Loader2 className="size-3.5 animate-spin" />
-                  ) : (
-                    <CircleX className="size-3.5" />
-                  )}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Kill query</TooltipContent>
-            </Tooltip>
+            {done ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-7 text-muted-foreground hover:text-foreground"
+                    onClick={onDismiss}
+                    aria-label="Dismiss finished query"
+                  >
+                    <X className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Dismiss</TooltipContent>
+              </Tooltip>
+            ) : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-7 text-muted-foreground hover:text-rose-600"
+                    onClick={handleKill}
+                    disabled={isKilling || !d.id}
+                    aria-label="Kill query"
+                  >
+                    {isKilling ? (
+                      <Loader2 className="size-3.5 animate-spin" />
+                    ) : (
+                      <CircleX className="size-3.5" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Kill query</TooltipContent>
+              </Tooltip>
+            )}
+            {explainUrl && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="hidden size-7 text-muted-foreground hover:text-foreground md:inline-flex"
+                    aria-label="Explain query"
+                    asChild
+                  >
+                    <Link href={explainUrl}>
+                      <Workflow className="size-3.5" />
+                    </Link>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Explain query</TooltipContent>
+              </Tooltip>
+            )}
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
@@ -287,7 +339,13 @@ export const QueryRow = memo(function QueryRow({
       {expanded && (
         <tr>
           <td colSpan={colSpan} className="p-0">
-            <ExpandedRow d={d} onKill={handleKill} isKilling={isKilling} />
+            <ExpandedRow
+              d={d}
+              onKill={handleKill}
+              isKilling={isKilling}
+              done={done}
+              onDismiss={onDismiss}
+            />
           </td>
         </tr>
       )}


### PR DESCRIPTION
## Why

On **Running Queries**, the table lists live `system.processes` rows, so a query
vanishes the instant it finishes. If you had expanded its row to inspect it, it
disappears mid-inspection — the reported annoyance.

## What

Two improvements, folded into one branch (same running-queries files):

### 1. Keep an expanded query visible as **Done** when it finishes
- The **view** now owns row expansion and diffs each poll. When a query the user
  had **expanded** leaves the live list, its last-known snapshot is retained and
  rendered **pinned above the live rows** in a green **Done** state
  (`DoneBadge`, emerald tint, completed progress bar) with a **Dismiss** action
  replacing **Kill**. It stays until the user dismisses it or navigates away
  (state is component-local, so it clears on unmount).
- **Expanded-only** retention (the task's sanctioned minimum): non-expanded
  finishes are untouched — they still flow to the existing **Recently completed**
  table, so the running table never duplicates the whole completed log.
- The **table** is now presentational; **live counts, footer and CSV export stay
  on the live set only** — Done rows never inflate the "active" count.
- Expansion is keyed by the stable `query_id`, so an expanded row keeps its
  panel open across polls, re-sorts and filters (this half was already true;
  the fix is retaining the row after it finishes).

### 2. **Explain** link per query
- A small `Workflow` icon button on each row (and a labelled **Explain** button
  in the detail panel, shared by rows and cards) links to
  `/explain?query_id=<query_id>&host=<hostId>`, with `stopPropagation` so it
  never toggles row expansion. Rendered only when a `query_id` is present.

## Design notes
- **Retention lives in the view, not the table**, because the table unmounts
  when the live list empties; a retained Done row must outlive it. The core
  `reconcileDoneRows` reconciler is a **pure function with unit tests**.
- **Double-appearance is intentional**: an expanded-then-finished query shows as
  a preserved Done row in the running table *and* as a log entry in Recently
  completed. Suppression would need table→view coupling and a pop-in on dismiss;
  the emerald pill mirrors the completed table so the Done row reads as
  intentional.
- Done rows are **pinned at the top** and exempt from the live search/sort so
  they stay put until dismissed.

## Verification
- `bun test done-retention.test.ts` → **8 pass**.
- `bun run type-check` and `bun run type-check:test`: **228 errors on base
  `63aa030fc` → 228 on this branch — 0 new** (residual errors are pre-existing
  routeTree-class errors in route files this PR does not touch). **0 errors in
  any file this PR changes.**
- No full `bun run build` (per brief).

## Visual QA pending (no browser access here)
- Steady state (other live queries present): no unmount, clean in-place Done
  transition.
- Edge transition: when the **last** live query finishes **while expanded**,
  `doneRows` updates one render after the live list empties, so a one-frame
  empty-state flash + table remount (resetting the table's search/sort) is
  possible before the Done row paints. End state is correct; a raw
  `useLayoutEffect` preempt was declined because this view prerenders and there
  is no isomorphic shim (would risk an SSR warning). Flagged for visual QA.

Co-Authored-By: duyetbot <bot@duyet.net>
