### PR TITLE
feat(alerting): PagerDuty escalation / on-call routing (plan 34)

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -245,6 +245,13 @@ AGENTSTATE_API_KEY=
 # Health-sweep cron alerting.
 # CRON_SECRET= / HEALTH_ALERT_ENABLED=false / HEALTH_ALERT_MIN_SEVERITY=warning
 # HEALTH_ALERT_WEBHOOK_URL=
+# PagerDuty escalation / on-call routing (plan 34): HEALTH_ALERT_PAGERDUTY_ROUTING_KEY
+# is the legacy single-service Events API v2 routing key, used as a fallback
+# when no per-rule/per-host PagerDuty route is configured (Health settings >
+# Routing tab). HEALTH_ALERT_PAGERDUTY_API_KEY is a REST API token used ONLY to
+# list services for that tab's picker — never to create/modify PagerDuty config.
+# HEALTH_ALERT_PAGERDUTY_ROUTING_KEY=
+# HEALTH_ALERT_PAGERDUTY_API_KEY=
 # PeerDB monitoring.
 # PEERDB_API_URL= / PEERDB_PASSWORD=
 # User-connections / conversation store backend on non-Cloudflare targets

--- a/apps/dashboard/src/components/health/alert-routing-dialog.tsx
+++ b/apps/dashboard/src/components/health/alert-routing-dialog.tsx
@@ -1,29 +1,43 @@
 /**
- * Per-rule / per-host alert routing panel (plan 30).
+ * Per-rule / per-host alert routing panel (plan 30, extended by plan 34).
  *
  * Lets an operator define routes that match a rule id/type and/or host (glob
- * or `*`) to a channel webhook URL — the sweep fans out to every matching
- * route, falling back to the legacy global webhook (Alerts tab) when nothing
- * matches. Lives as a tab in `HealthSettingsDialog` alongside
- * Thresholds/Alerts/History/Webhooks (mirrors `WebhookSubscriptionsPanel`'s
- * structure), but — unlike the Clerk-gated webhook-subscriptions panel —
- * this works with zero auth on self-hosted deployments too (see
- * `lib/health/alert-routing-auth.ts`).
+ * or `*`) to a destination — either a channel webhook URL (`'webhook'`
+ * provider: Slack/Discord/generic JSON) or a PagerDuty service's Events API
+ * v2 routing key (`'pagerduty'` provider, plan 34), which lets PagerDuty's
+ * own escalation policy + on-call schedule take over. The sweep fans out to
+ * every matching route, falling back to the legacy global webhook / env
+ * PagerDuty routing key (Alerts tab) when nothing matches. Lives as a tab in
+ * `HealthSettingsDialog` alongside Thresholds/Alerts/History/Webhooks
+ * (mirrors `WebhookSubscriptionsPanel`'s structure), but — unlike the
+ * Clerk-gated webhook-subscriptions panel — this works with zero auth on
+ * self-hosted deployments too (see `lib/health/alert-routing-auth.ts`).
  */
 
 import { toast } from 'sonner'
 
-import type { AlertRouteInfo } from '@/lib/hooks/use-alert-routes'
+import type {
+  AlertRouteInfo,
+  AlertRouteProvider,
+} from '@/lib/hooks/use-alert-routes'
 
 import { useState } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { fireWebhook } from '@/lib/health/alert-dispatcher'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { firePagerDutyTest, fireWebhook } from '@/lib/health/alert-dispatcher'
 import {
   useAlertRoutes,
   useAlertRoutesMutations,
+  usePagerDutyServices,
 } from '@/lib/hooks/use-alert-routes'
 import { cn } from '@/lib/utils'
 
@@ -36,6 +50,7 @@ function RouteRow({
 }) {
   const [busy, setBusy] = useState(false)
   const { deleteRoute } = useAlertRoutesMutations()
+  const isPagerDuty = route.provider === 'pagerduty'
 
   const handleDelete = async () => {
     setBusy(true)
@@ -52,17 +67,28 @@ function RouteRow({
   const handleTest = async () => {
     setBusy(true)
     try {
-      const ok = await fireWebhook(
-        {
-          checkId: 'test',
-          title: 'Test Alert',
-          severity: 'warning',
-          value: 0,
-          label: 'This is a test alert from chmonitor',
-          hostId: 0,
-        },
-        route.channelUrl
-      )
+      const testAlert = {
+        checkId: 'test',
+        title: 'Test Alert',
+        severity: 'warning' as const,
+        value: 0,
+        label: 'This is a test alert from chmonitor',
+        hostId: 0,
+      }
+      // A PagerDuty route has no direct webhook URL to fire — its secret is
+      // the routing key, never returned by the API (masked), so a real test
+      // send must happen at creation time via `firePagerDutyTest` in the add
+      // form instead (see `handleSendTest` below). Existing PagerDuty routes
+      // can only be deleted + re-created to re-test, which is an acceptable
+      // tradeoff for never exposing the raw key back to the client after
+      // storage.
+      if (isPagerDuty) {
+        toast.info(
+          'Re-create the route to send another PagerDuty test event (the routing key is never re-shown once saved).'
+        )
+        return
+      }
+      const ok = await fireWebhook(testAlert, route.channelUrl)
       if (ok) toast.success('Test alert sent')
       else toast.error('Webhook request failed')
     } finally {
@@ -74,12 +100,15 @@ function RouteRow({
     <div className="flex items-center justify-between gap-2 rounded-md border p-3">
       <div className="flex min-w-0 flex-col gap-1">
         <div className="flex flex-wrap items-center gap-1.5">
+          {isPagerDuty && <Badge variant="default">PagerDuty</Badge>}
           <Badge variant="outline">rule: {route.matchRule}</Badge>
           <Badge variant="outline">host: {route.matchHost}</Badge>
           {!route.enabled && <Badge variant="secondary">disabled</Badge>}
         </div>
         <span className="truncate text-sm text-muted-foreground">
-          {route.channelUrl}
+          {isPagerDuty
+            ? `${route.serviceName || 'PagerDuty service'} — ${route.routingKeyMasked}`
+            : route.channelUrl}
         </span>
       </div>
       <div className="flex shrink-0 items-center gap-2">
@@ -102,26 +131,51 @@ function RouteRow({
 function AddRouteForm({ onCreated }: { onCreated: () => void }) {
   const [matchRule, setMatchRule] = useState('*')
   const [matchHost, setMatchHost] = useState('*')
+  const [provider, setProvider] = useState<AlertRouteProvider>('webhook')
   const [channelUrl, setChannelUrl] = useState('')
+  const [pdServiceId, setPdServiceId] = useState('')
+  const [pdServiceName, setPdServiceName] = useState('')
+  const [pdRoutingKey, setPdRoutingKey] = useState('')
   const [busy, setBusy] = useState(false)
   const { createRoute } = useAlertRoutesMutations()
+  const { services: pdServices, isLoading: pdServicesLoading } =
+    usePagerDutyServices(provider === 'pagerduty')
+
+  const reset = () => {
+    setMatchRule('*')
+    setMatchHost('*')
+    setChannelUrl('')
+    setPdServiceId('')
+    setPdServiceName('')
+    setPdRoutingKey('')
+  }
 
   const handleSubmit = async () => {
-    if (!channelUrl.trim()) {
+    if (provider === 'pagerduty') {
+      if (!pdRoutingKey.trim()) {
+        toast.error("Enter the service's PagerDuty routing/integration key")
+        return
+      }
+    } else if (!channelUrl.trim()) {
       toast.error('Enter a channel webhook URL')
       return
     }
+
     setBusy(true)
     try {
       await createRoute({
         matchRule: matchRule.trim() || '*',
         matchHost: matchHost.trim() || '*',
-        channelUrl: channelUrl.trim(),
+        ...(provider === 'pagerduty'
+          ? {
+              provider: 'pagerduty',
+              serviceName: pdServiceName.trim() || undefined,
+              routingKey: pdRoutingKey.trim(),
+            }
+          : { channelUrl: channelUrl.trim() }),
       })
       toast.success('Route created')
-      setMatchRule('*')
-      setMatchHost('*')
-      setChannelUrl('')
+      reset()
       onCreated()
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to create route')
@@ -130,9 +184,51 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
     }
   }
 
+  const handleSendTest = async () => {
+    if (!pdRoutingKey.trim()) {
+      toast.error("Enter the service's PagerDuty routing/integration key")
+      return
+    }
+    setBusy(true)
+    try {
+      const ok = await firePagerDutyTest(
+        {
+          checkId: 'test',
+          title: 'Test Alert',
+          severity: 'warning',
+          value: 0,
+          label: 'This is a test alert from chmonitor',
+          hostId: 0,
+        },
+        pdRoutingKey.trim()
+      )
+      if (ok) toast.success('Test event sent to PagerDuty')
+      else toast.error('PagerDuty Events API request failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
     <div className="flex flex-col gap-2 rounded-md border p-3">
       <Label className="text-sm font-medium">Add route</Label>
+      <div className="flex flex-col gap-1">
+        <Label className="text-xs text-muted-foreground">Destination</Label>
+        <Select
+          value={provider}
+          onValueChange={(v) => setProvider(v as AlertRouteProvider)}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="webhook">
+              Channel webhook (Slack/Discord/…)
+            </SelectItem>
+            <SelectItem value="pagerduty">PagerDuty service</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
       <div className="grid grid-cols-2 gap-2">
         <div className="flex flex-col gap-1">
           <Label
@@ -163,18 +259,70 @@ function AddRouteForm({ onCreated }: { onCreated: () => void }) {
           />
         </div>
       </div>
-      <Label
-        htmlFor="route-channel-url"
-        className="text-xs text-muted-foreground"
-      >
-        Channel webhook URL
-      </Label>
-      <Input
-        id="route-channel-url"
-        placeholder="https://hooks.slack.com/services/..."
-        value={channelUrl}
-        onChange={(e) => setChannelUrl(e.target.value)}
-      />
+
+      {provider === 'pagerduty' ? (
+        <>
+          <Label className="text-xs text-muted-foreground">
+            PagerDuty service {pdServicesLoading && '(loading…)'}
+          </Label>
+          {pdServices.length > 0 && (
+            <Select
+              value={pdServiceId}
+              onValueChange={(id) => {
+                setPdServiceId(id)
+                const svc = pdServices.find((s) => s.id === id)
+                setPdServiceName(svc?.name ?? '')
+              }}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Pick a listed service…" />
+              </SelectTrigger>
+              <SelectContent>
+                {pdServices.map((s) => (
+                  <SelectItem key={s.id} value={s.id}>
+                    {s.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          <Input
+            placeholder="Service display name (optional)"
+            value={pdServiceName}
+            onChange={(e) => setPdServiceName(e.target.value)}
+          />
+          <Input
+            placeholder="Service integration/routing key"
+            value={pdRoutingKey}
+            onChange={(e) => setPdRoutingKey(e.target.value)}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            className="self-start"
+            disabled={busy}
+            onClick={handleSendTest}
+          >
+            Send test event
+          </Button>
+        </>
+      ) : (
+        <>
+          <Label
+            htmlFor="route-channel-url"
+            className="text-xs text-muted-foreground"
+          >
+            Channel webhook URL
+          </Label>
+          <Input
+            id="route-channel-url"
+            placeholder="https://hooks.slack.com/services/..."
+            value={channelUrl}
+            onChange={(e) => setChannelUrl(e.target.value)}
+          />
+        </>
+      )}
+
       <Button
         size="sm"
         className="self-start"
@@ -193,10 +341,12 @@ export function AlertRoutingPanel({ className }: { className?: string }) {
   return (
     <div className={cn('flex flex-col gap-3', className)}>
       <p className="text-xs text-muted-foreground">
-        Route findings to different channels by rule or host — a finding
-        matching one or more routes fans out to every matched channel. When
-        nothing matches, the finding falls back to the global webhook configured
-        in the Alerts tab.
+        Route findings to different channels — or PagerDuty services — by rule
+        or host. A finding matching one or more routes fans out to every matched
+        destination, letting a PagerDuty route's service escalation policy +
+        on-call schedule take over. When nothing matches, the finding falls back
+        to the global webhook / PagerDuty routing key configured in the Alerts
+        tab.
       </p>
 
       {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}

--- a/apps/dashboard/src/db/conversations-migrations/0016_alert_routes_pagerduty.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0016_alert_routes_pagerduty.sql
@@ -1,0 +1,15 @@
+-- PagerDuty escalation / on-call routing (plan 34): extend the plan-30
+-- `alert_routes` table rather than shipping a second routing schema (open
+-- question 1 in the plan). A route now carries a `provider`: `'webhook'`
+-- (default, today's Slack/Discord/generic-JSON behavior via `channel_url`) or
+-- `'pagerduty'` (routes to a PagerDuty service's Events API v2 integration
+-- key via `routing_key`, with `service_name` as the display label). Existing
+-- rows default to `provider = 'webhook'` so plan-30 behavior is unchanged.
+--
+-- `routing_key` is the PagerDuty integration/routing key — a secret, stored
+-- at rest the same way channel_url already carries Slack/Discord webhook
+-- secrets in its path. Never used to call PagerDuty write/mutation endpoints;
+-- only the Events API v2 enqueue endpoint (trigger/resolve).
+ALTER TABLE alert_routes ADD COLUMN provider TEXT NOT NULL DEFAULT 'webhook';
+ALTER TABLE alert_routes ADD COLUMN service_name TEXT;
+ALTER TABLE alert_routes ADD COLUMN routing_key TEXT;

--- a/apps/dashboard/src/lib/health/alert-dispatcher.ts
+++ b/apps/dashboard/src/lib/health/alert-dispatcher.ts
@@ -1,4 +1,13 @@
+import { buildPagerDutyBody } from './adapters'
 import { loadAlertSettings } from './alert-settings-storage'
+
+// Duplicated (not imported) from `pagerduty-config.ts` on purpose: that
+// module reads server-only env vars (`process.env`), and this file is
+// client-side (browser `window`/`localStorage` checks below) — importing it
+// would pull a server-only module into the client bundle. The endpoint
+// itself is fixed and public (same for every PagerDuty service), so a
+// literal here carries no secret.
+const PAGERDUTY_EVENTS_API_URL = 'https://events.pagerduty.com/v2/enqueue'
 
 /** Actionable health severities used for escalation/recovery bookkeeping. */
 export type HealthAlertStatus = 'ok' | 'warning' | 'critical'
@@ -150,6 +159,50 @@ export async function fireWebhook(
     clearTimeout(timeout)
   }
 }
+/**
+ * Send a test PagerDuty event (trigger, immediately followed by resolve) to a
+ * specific service's routing key, via the `/api/v1/health/webhook` proxy's
+ * `provider`-hint path (verbatim body forward — see `webhook.ts`) so the
+ * setup dialog (plan 34) never needs a direct browser→PagerDuty fetch.
+ */
+export async function firePagerDutyTest(
+  alert: HealthAlertEvent,
+  routingKey: string
+): Promise<boolean> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 10_000)
+  try {
+    const body = buildPagerDutyBody(
+      {
+        severity: alert.severity,
+        hostLabel: `host ${alert.hostId}`,
+        hostId: alert.hostId,
+        metric: alert.checkId,
+        value: alert.value,
+        title: alert.title,
+        label: alert.label,
+        timestamp: new Date().toISOString(),
+      },
+      { routingKey }
+    )
+    const res = await fetch('/api/v1/health/webhook', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: PAGERDUTY_EVENTS_API_URL,
+        provider: 'pagerduty',
+        payload: body,
+      }),
+      signal: controller.signal,
+    })
+    return res.ok
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
 export async function dispatchAlert(alert: HealthAlertEvent): Promise<void> {
   try {
     const settings = loadAlertSettings()

--- a/apps/dashboard/src/lib/health/alert-routing.test.ts
+++ b/apps/dashboard/src/lib/health/alert-routing.test.ts
@@ -23,6 +23,9 @@ interface FakeRow {
   channel_url: string
   enabled: number
   created_at: number
+  provider: string
+  service_name: string | null
+  routing_key: string | null
 }
 
 function makeFakeD1() {
@@ -46,6 +49,9 @@ function makeFakeD1() {
                 channel_url,
                 enabled,
                 created_at,
+                provider,
+                service_name,
+                routing_key,
               ] = params as [
                 string,
                 string,
@@ -54,6 +60,9 @@ function makeFakeD1() {
                 string,
                 number,
                 number,
+                string,
+                string | null,
+                string | null,
               ]
               rows.push({
                 id,
@@ -63,6 +72,9 @@ function makeFakeD1() {
                 channel_url,
                 enabled,
                 created_at,
+                provider,
+                service_name,
+                routing_key,
               })
               return { meta: { changes: 1 } }
             }
@@ -116,8 +128,14 @@ mock.module('@chm/platform', () => ({
   }),
 }))
 
-const { createRoute, deleteRoute, listRoutes, matchRoutes, resolveTargets } =
-  await import('./alert-routing')
+const {
+  createRoute,
+  deleteRoute,
+  listRoutes,
+  matchRoutes,
+  resolvePagerDutyTargets,
+  resolveTargets,
+} = await import('./alert-routing')
 
 import type { AlertRoute, RouteMatchTarget } from './alert-routing'
 
@@ -130,6 +148,9 @@ function route(overrides: Partial<AlertRoute> = {}): AlertRoute {
     channelUrl: 'https://hooks.slack.com/services/x',
     enabled: true,
     createdAt: 0,
+    provider: 'webhook',
+    serviceName: null,
+    routingKey: null,
     ...overrides,
   }
 }
@@ -229,9 +250,117 @@ describe('resolveTargets (pure)', () => {
     ])
   })
 
+  test('a matched pagerduty route is excluded from the channel list AND suppresses the legacy webhook fallback (no double-fire)', () => {
+    // An operator who explicitly routed this rule/host to PagerDuty must not
+    // ALSO get the legacy global webhook — a match of either provider
+    // suppresses the OTHER provider's catch-all (plan 34).
+    const pd = route({
+      matchRule: 'disk-usage',
+      provider: 'pagerduty',
+      routingKey: 'R-key',
+    })
+    expect(resolveTargets([pd], TARGET, 'https://legacy.example/hook')).toEqual(
+      []
+    )
+  })
+
   test('no match and no legacy URL configured -> empty', () => {
     const r = route({ matchRule: 'replication-*' })
     expect(resolveTargets([r], TARGET, '')).toEqual([])
+  })
+})
+
+describe('resolvePagerDutyTargets (pure) — plan 34', () => {
+  test('matches a pagerduty route and returns its service + routing key', () => {
+    const r = route({
+      matchRule: 'disk-usage',
+      provider: 'pagerduty',
+      serviceName: 'DB On-call',
+      routingKey: 'R-abc',
+    })
+    expect(resolvePagerDutyTargets([r], TARGET, '')).toEqual([
+      { serviceName: 'DB On-call', routingKey: 'R-abc' },
+    ])
+  })
+
+  test('matches a pagerduty route via glob and the * host wildcard', () => {
+    const r = route({
+      matchRule: 'disk-*',
+      matchHost: '*',
+      provider: 'pagerduty',
+      serviceName: 'DB On-call',
+      routingKey: 'R-glob',
+    })
+    expect(resolvePagerDutyTargets([r], TARGET, '')).toEqual([
+      { serviceName: 'DB On-call', routingKey: 'R-glob' },
+    ])
+  })
+
+  test('ignores webhook-provider routes even if matched', () => {
+    const r = route({ matchRule: 'disk-usage', provider: 'webhook' })
+    expect(resolvePagerDutyTargets([r], TARGET, '')).toEqual([])
+  })
+
+  test('a matched webhook route suppresses the env PagerDuty fallback (no double-fire)', () => {
+    // An operator who explicitly routed this rule/host to Slack/Discord must
+    // not ALSO get it paged to the env-configured PagerDuty service (plan
+    // 34's cross-provider suppression, symmetric with resolveTargets above).
+    const webhook = route({ matchRule: 'disk-usage', provider: 'webhook' })
+    expect(
+      resolvePagerDutyTargets([webhook], TARGET, 'env-fallback-key')
+    ).toEqual([])
+  })
+
+  test('deduplicates matched routes sharing the same routing key', () => {
+    const r1 = route({
+      id: 'a',
+      matchRule: 'disk-usage',
+      provider: 'pagerduty',
+      serviceName: 'DB',
+      routingKey: 'R-shared',
+    })
+    const r2 = route({
+      id: 'b',
+      matchRule: '*',
+      provider: 'pagerduty',
+      serviceName: 'DB (dup)',
+      routingKey: 'R-shared',
+    })
+    expect(resolvePagerDutyTargets([r1, r2], TARGET, '')).toEqual([
+      { serviceName: 'DB', routingKey: 'R-shared' },
+    ])
+  })
+
+  test('a pagerduty route with no routing key never dispatches, and still suppresses the env fallback', () => {
+    // A route matched this finding (by rule/host) but is misconfigured (no
+    // routing key) — it counts as "this finding was explicitly routed" for
+    // the fallback-suppression decision, same as any other match, so the env
+    // key does NOT silently take over. This is a misconfiguration the
+    // operator should notice (an unmatched route commits with no delivery),
+    // not a shape the sweep should paper over by guessing a different key.
+    const r = route({
+      matchRule: 'disk-usage',
+      provider: 'pagerduty',
+      routingKey: null,
+    })
+    expect(resolvePagerDutyTargets([r], TARGET, 'env-fallback-key')).toEqual([])
+  })
+
+  test('falls back to the env routing key when nothing matches', () => {
+    const r = route({ matchRule: 'replication-*', provider: 'pagerduty' })
+    expect(resolvePagerDutyTargets([r], TARGET, 'env-fallback-key')).toEqual([
+      { serviceName: 'default', routingKey: 'env-fallback-key' },
+    ])
+  })
+
+  test('empty route list (no D1 / owner throw) falls back to the env key — STOP condition proof', () => {
+    expect(resolvePagerDutyTargets([], TARGET, 'env-fallback-key')).toEqual([
+      { serviceName: 'default', routingKey: 'env-fallback-key' },
+    ])
+  })
+
+  test('no match and no env key configured -> empty (no PagerDuty dispatch)', () => {
+    expect(resolvePagerDutyTargets([], TARGET, '')).toEqual([])
   })
 })
 
@@ -284,5 +413,49 @@ describe('D1-backed alert-routing CRUD', () => {
 
     expect(await deleteRoute('owner-1', created!.id)).toBe(true)
     expect(await listRoutes('owner-1')).toEqual([])
+  })
+
+  test('create -> list round-trip persists pagerduty provider fields', async () => {
+    const fakeDb = makeFakeD1()
+    currentDb = fakeDb
+
+    const created = await createRoute({
+      ownerId: 'owner-1',
+      matchRule: 'disk-*',
+      matchHost: '*',
+      channelUrl: 'https://events.pagerduty.com/v2/enqueue',
+      provider: 'pagerduty',
+      serviceName: 'DB On-call',
+      routingKey: 'R-abc',
+    })
+    expect(created?.provider).toBe('pagerduty')
+    expect(created?.serviceName).toBe('DB On-call')
+    expect(created?.routingKey).toBe('R-abc')
+
+    const [listed] = await listRoutes('owner-1')
+    expect(listed.provider).toBe('pagerduty')
+    expect(listed.serviceName).toBe('DB On-call')
+    expect(listed.routingKey).toBe('R-abc')
+  })
+
+  test('legacy row with no provider column value defaults to webhook', async () => {
+    const fakeDb = makeFakeD1()
+    currentDb = fakeDb
+    // Simulate a pre-migration row: provider/service_name/routing_key absent.
+    fakeDb._rows.push({
+      id: 'legacy-1',
+      owner_id: 'owner-1',
+      match_rule: '*',
+      match_host: '*',
+      channel_url: 'https://hooks.slack.com/services/x',
+      enabled: 1,
+      created_at: 0,
+      provider: '',
+      service_name: null,
+      routing_key: null,
+    })
+
+    const [listed] = await listRoutes('owner-1')
+    expect(listed.provider).toBe('webhook')
   })
 })

--- a/apps/dashboard/src/lib/health/alert-routing.ts
+++ b/apps/dashboard/src/lib/health/alert-routing.ts
@@ -32,6 +32,15 @@ const warn = (msg: string) =>
 
 const TABLE = 'alert_routes'
 
+/**
+ * Route destination provider. `'webhook'` (default) fans out to
+ * `channelUrl` exactly as plan 30 shipped — Slack/Discord/generic JSON.
+ * `'pagerduty'` (plan 34) routes to a PagerDuty service's Events API v2
+ * integration key (`routingKey`) instead, letting PagerDuty apply that
+ * service's own escalation policy + on-call schedule.
+ */
+export type AlertRouteProvider = 'webhook' | 'pagerduty'
+
 /** A configured alert route: match criteria → destination channel. */
 export interface AlertRoute {
   id: string
@@ -43,6 +52,12 @@ export interface AlertRoute {
   channelUrl: string
   enabled: boolean
   createdAt: number
+  /** Destination provider; defaults to `'webhook'` for plan-30 rows. */
+  provider: AlertRouteProvider
+  /** Display label for a PagerDuty service (provider `'pagerduty'` only). */
+  serviceName: string | null
+  /** PagerDuty Events API v2 integration/routing key (provider `'pagerduty'` only). */
+  routingKey: string | null
 }
 
 interface D1AlertRouteRow {
@@ -53,6 +68,9 @@ interface D1AlertRouteRow {
   channel_url: string
   enabled: number
   created_at: number
+  provider: string | null
+  service_name: string | null
+  routing_key: string | null
 }
 
 function getDb(): D1Database | null {
@@ -68,6 +86,12 @@ function rowToRoute(row: D1AlertRouteRow): AlertRoute {
     channelUrl: row.channel_url,
     enabled: row.enabled === 1,
     createdAt: row.created_at,
+    // Legacy plan-30 rows have no `provider` column value yet (pre-migration
+    // fake D1s in tests, or a row inserted before 0016 ran) — default to the
+    // webhook behavior they already have.
+    provider: row.provider === 'pagerduty' ? 'pagerduty' : 'webhook',
+    serviceName: row.service_name ?? null,
+    routingKey: row.routing_key ?? null,
   }
 }
 
@@ -84,7 +108,8 @@ export async function listRoutes(ownerId: string): Promise<AlertRoute[]> {
 
     const result = await db
       .prepare(
-        `SELECT id, owner_id, match_rule, match_host, channel_url, enabled, created_at
+        `SELECT id, owner_id, match_rule, match_host, channel_url, enabled, created_at,
+                provider, service_name, routing_key
          FROM ${TABLE}
          WHERE owner_id = ?1
          ORDER BY created_at DESC`
@@ -105,6 +130,12 @@ export interface CreateRouteInput {
   matchHost: string
   channelUrl: string
   enabled?: boolean
+  /** Defaults to `'webhook'` — plan-30 behavior unchanged. */
+  provider?: AlertRouteProvider
+  /** Display label for a PagerDuty service (provider `'pagerduty'` only). */
+  serviceName?: string | null
+  /** PagerDuty Events API v2 integration/routing key (provider `'pagerduty'` only). */
+  routingKey?: string | null
 }
 
 /**
@@ -127,13 +158,17 @@ export async function createRoute(
       channelUrl: input.channelUrl.trim(),
       enabled: input.enabled ?? true,
       createdAt: Date.now(),
+      provider: input.provider ?? 'webhook',
+      serviceName: input.serviceName?.trim() || null,
+      routingKey: input.routingKey?.trim() || null,
     }
 
     await db
       .prepare(
         `INSERT INTO ${TABLE}
-           (id, owner_id, match_rule, match_host, channel_url, enabled, created_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)`
+           (id, owner_id, match_rule, match_host, channel_url, enabled, created_at,
+            provider, service_name, routing_key)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)`
       )
       .bind(
         route.id,
@@ -142,7 +177,10 @@ export async function createRoute(
         route.matchHost,
         route.channelUrl,
         route.enabled ? 1 : 0,
-        route.createdAt
+        route.createdAt,
+        route.provider,
+        route.serviceName,
+        route.routingKey
       )
       .run()
 
@@ -234,10 +272,16 @@ export function matchRoutes(
 
 /**
  * Resolve the channel URLs a finding should be dispatched to: every matched
- * route's `channelUrl` (deduplicated), or `[legacyGlobalUrl]` when nothing
- * matches and a global URL is configured — preserving today's single-webhook
- * behavior for deployments that never configure a route. Returns `[]` only
- * when there is no match AND no legacy URL configured.
+ * `'webhook'`-provider route's `channelUrl` (deduplicated), or
+ * `[legacyGlobalUrl]` when NO route matched at all (any provider) and a
+ * global URL is configured — preserving today's single-webhook behavior for
+ * deployments that never configure a route. Returns `[]` when there is no
+ * legacy URL configured, OR when a `'pagerduty'` route matched instead: an
+ * explicit route (plan 30's precedent — "matched routes take precedence, the
+ * legacy URL is a fallback only when nothing matches") always suppresses the
+ * catch-all, even one belonging to the other provider — otherwise an
+ * operator who explicitly routed a rule to PagerDuty would ALSO get paged on
+ * the legacy Slack/Discord webhook for the same finding (plan 34).
  */
 export function resolveTargets(
   routes: readonly AlertRoute[],
@@ -245,8 +289,67 @@ export function resolveTargets(
   legacyGlobalUrl: string
 ): string[] {
   const matched = matchRoutes(routes, target)
-  if (matched.length > 0) {
-    return [...new Set(matched.map((r) => r.channelUrl))]
+  // 'pagerduty' routes (plan 34) are dispatched separately by
+  // {@link resolvePagerDutyTargets} with a PagerDuty-shaped body, never the
+  // generic `{ text, content }` wrapper this path sends — but a pagerduty
+  // match still counts toward "something matched" for the fallback decision
+  // below.
+  const webhookMatched = matched.filter((r) => r.provider === 'webhook')
+  if (webhookMatched.length > 0) {
+    return [...new Set(webhookMatched.map((r) => r.channelUrl))]
   }
+  if (matched.length > 0) return []
   return legacyGlobalUrl ? [legacyGlobalUrl] : []
+}
+
+/** One PagerDuty dispatch target: a service's display name + routing key. */
+export interface PagerDutyTarget {
+  serviceName: string
+  routingKey: string
+}
+
+/**
+ * Resolve the PagerDuty services a finding should page (plan 34 — extends
+ * plan 30's routing model rather than a parallel one): every ENABLED,
+ * matched route with `provider === 'pagerduty'` and a non-empty
+ * `routingKey`, deduplicated by routing key. When NO route matched at all
+ * (any provider), falls back to `[{ serviceName: 'default', routingKey:
+ * envFallbackKey }]` when `envFallbackKey` is configured — preserving
+ * today's single-integration-key behavior for deployments that never
+ * configure a PagerDuty route. Returns `[]` when there is no env key
+ * configured, OR when a `'webhook'` route matched instead — mirrors
+ * {@link resolveTargets}'s cross-provider suppression: an operator who
+ * explicitly routed a rule to Slack/Discord must not ALSO get it paged to
+ * the env-configured PagerDuty service. Pure — no I/O.
+ */
+export function resolvePagerDutyTargets(
+  routes: readonly AlertRoute[],
+  target: RouteMatchTarget,
+  envFallbackKey: string
+): PagerDutyTarget[] {
+  const matched = matchRoutes(routes, target)
+  const pagerDutyMatched = matched.filter(
+    (r): r is AlertRoute & { routingKey: string } =>
+      r.provider === 'pagerduty' && Boolean(r.routingKey)
+  )
+
+  if (pagerDutyMatched.length > 0) {
+    const seen = new Set<string>()
+    const out: PagerDutyTarget[] = []
+    for (const r of pagerDutyMatched) {
+      if (seen.has(r.routingKey)) continue
+      seen.add(r.routingKey)
+      out.push({
+        serviceName: r.serviceName || 'PagerDuty',
+        routingKey: r.routingKey,
+      })
+    }
+    return out
+  }
+
+  if (matched.length > 0) return []
+
+  return envFallbackKey
+    ? [{ serviceName: 'default', routingKey: envFallbackKey }]
+    : []
 }

--- a/apps/dashboard/src/lib/health/pagerduty-config.ts
+++ b/apps/dashboard/src/lib/health/pagerduty-config.ts
@@ -1,0 +1,91 @@
+/**
+ * PagerDuty escalation / on-call routing (plans/34-pagerduty-escalation-oncall.md).
+ *
+ * Two independent PagerDuty credentials, deliberately kept separate:
+ *
+ *   - `HEALTH_ALERT_PAGERDUTY_API_KEY` — an account-level REST API token used
+ *     ONLY to *list services* for the setup UI's picker
+ *     ({@link listPagerDutyServices}). NEVER used to create/update/delete
+ *     anything in PagerDuty — chmonitor pages humans, it does not manage
+ *     PagerDuty configuration (services/escalation policies/schedules stay
+ *     the operator's job in PagerDuty itself).
+ *   - `HEALTH_ALERT_PAGERDUTY_ROUTING_KEY` — the legacy single-service
+ *     Events API v2 integration/routing key, used as the fallback target
+ *     when no per-rule/per-host PagerDuty route matches (or when D1 isn't
+ *     configured) — see `resolvePagerDutyTargets` in `alert-routing.ts`.
+ *
+ * Fail-open guarantee: neither getter throws; an unset/blank env var simply
+ * disables that capability (no services listed / no fallback routing key).
+ */
+
+import { debug } from '@chm/logger'
+
+/** The fixed PagerDuty Events API v2 enqueue endpoint (same for every service). */
+export const PAGERDUTY_EVENTS_API_URL =
+  'https://events.pagerduty.com/v2/enqueue'
+
+/** REST API token for read-only "list services" calls, or '' when unset. */
+export function getPagerDutyRestApiKey(): string {
+  return process.env.HEALTH_ALERT_PAGERDUTY_API_KEY?.trim() || ''
+}
+
+/** Legacy single-service routing key fallback, or '' when unset. */
+export function getPagerDutyFallbackRoutingKey(): string {
+  return process.env.HEALTH_ALERT_PAGERDUTY_ROUTING_KEY?.trim() || ''
+}
+
+/** One PagerDuty service, as surfaced to the setup UI's picker. */
+export interface PagerDutyServiceOption {
+  id: string
+  name: string
+}
+
+interface PagerDutyServicesResponse {
+  services?: Array<{ id?: unknown; name?: unknown }>
+}
+
+/**
+ * List PagerDuty services via the REST API (read-only; `GET /services`).
+ * Best-effort — returns `[]` on any error (no token configured, network
+ * failure, non-2xx response, unexpected shape) rather than throwing, so a
+ * PagerDuty API hiccup can never break the setup dialog. Never calls a
+ * write/mutation PagerDuty endpoint.
+ */
+export async function listPagerDutyServices(
+  apiKey = getPagerDutyRestApiKey()
+): Promise<PagerDutyServiceOption[]> {
+  if (!apiKey) return []
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 10_000)
+  try {
+    const res = await fetch('https://api.pagerduty.com/services?limit=100', {
+      method: 'GET',
+      headers: {
+        Authorization: `Token token=${apiKey}`,
+        Accept: 'application/vnd.pagerduty+json;version=2',
+      },
+      signal: controller.signal,
+    })
+    if (!res.ok) {
+      debug(`[pagerduty-config] list services returned status ${res.status}`)
+      return []
+    }
+    const json = (await res.json()) as PagerDutyServicesResponse
+    if (!Array.isArray(json.services)) return []
+    return json.services
+      .filter(
+        (s): s is { id: string; name: string } =>
+          typeof s.id === 'string' && typeof s.name === 'string'
+      )
+      .map((s) => ({ id: s.id, name: s.name }))
+  } catch (err) {
+    debug(
+      '[pagerduty-config] list services failed',
+      err instanceof Error ? err.message : String(err)
+    )
+    return []
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/apps/dashboard/src/lib/health/server-sweep.test.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.test.ts
@@ -47,6 +47,10 @@ interface FakeRouteRow {
   channel_url: string
   enabled: number
   created_at: number
+  /** plan 34: defaults to 'webhook' when omitted, matching a pre-migration row. */
+  provider?: string
+  service_name?: string | null
+  routing_key?: string | null
 }
 
 /**
@@ -189,6 +193,7 @@ const ENV_KEYS = [
   'HEALTH_ALERT_ENABLED',
   'HEALTH_ALERT_WEBHOOK_URL',
   'HEALTH_ALERT_MIN_SEVERITY',
+  'HEALTH_ALERT_PAGERDUTY_ROUTING_KEY',
 ] as const
 const savedEnv: Record<string, string | undefined> = {}
 
@@ -200,6 +205,7 @@ beforeEach(() => {
   process.env.HEALTH_ALERT_WEBHOOK_URL =
     'https://hooks.slack.com/services/T000/B000/XXXX'
   process.env.HEALTH_ALERT_MIN_SEVERITY = 'warning'
+  delete process.env.HEALTH_ALERT_PAGERDUTY_ROUTING_KEY
 
   alertStateStore.clear()
   fakeDb = makeFakeD1()
@@ -501,6 +507,156 @@ describe('runHealthSweep — alert-history hook', () => {
     expect(posted).toHaveLength(0)
     expect(summary.alertsDispatched).toBe(0)
     expect(fakeDb.rows).toHaveLength(0)
+  })
+
+  // -------------------------------------------------------------------------
+  // PagerDuty escalation / on-call routing (plan 34)
+  // -------------------------------------------------------------------------
+
+  test('a matched pagerduty route posts a real Events API v2 body to the fixed enqueue endpoint', async () => {
+    // Isolate the PagerDuty-only delivery: no legacy global webhook so the
+    // 'webhook' fallback in resolveTargets contributes nothing here.
+    process.env.HEALTH_ALERT_WEBHOOK_URL = ''
+    fakeDb = makeFakeD1([
+      {
+        id: 'pd-route-1',
+        owner_id: '',
+        match_rule: TEST_RULE_ID,
+        match_host: '*',
+        channel_url: 'https://events.pagerduty.com/v2/enqueue',
+        enabled: 1,
+        created_at: 0,
+        provider: 'pagerduty',
+        service_name: 'DB On-call',
+        routing_key: 'R-service-key',
+      },
+    ])
+
+    const posted: { url: string; body: unknown }[] = []
+    globalThis.fetch = mock(async (url: string | URL | Request, init) => {
+      posted.push({
+        url: String(url),
+        body: init?.body ? JSON.parse(String(init.body)) : null,
+      })
+      return new Response(null, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const summary = await runHealthSweep()
+
+    expect(summary.alertsDispatched).toBe(1)
+    expect(posted).toHaveLength(1)
+    expect(posted[0].url).toBe('https://events.pagerduty.com/v2/enqueue')
+    const body = posted[0].body as {
+      routing_key: string
+      event_action: string
+      dedup_key: string
+    }
+    expect(body.routing_key).toBe('R-service-key')
+    expect(body.event_action).toBe('trigger')
+    expect(body.dedup_key).toBe(`chmonitor:0:${TEST_RULE_ID}`)
+    expect(fakeDb.rows).toHaveLength(1)
+    expect(fakeDb.rows[0].channel).toBe('pagerduty:DB On-call')
+  })
+
+  test('falls back to the env PagerDuty routing key when no route matches', async () => {
+    process.env.HEALTH_ALERT_WEBHOOK_URL = ''
+    process.env.HEALTH_ALERT_PAGERDUTY_ROUTING_KEY = 'R-env-fallback'
+
+    const posted: { url: string; body: unknown }[] = []
+    globalThis.fetch = mock(async (url: string | URL | Request, init) => {
+      posted.push({
+        url: String(url),
+        body: init?.body ? JSON.parse(String(init.body)) : null,
+      })
+      return new Response(null, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const summary = await runHealthSweep()
+
+    expect(summary.alertsDispatched).toBe(1)
+    expect(posted).toHaveLength(1)
+    expect(posted[0].url).toBe('https://events.pagerduty.com/v2/enqueue')
+    expect((posted[0].body as { routing_key: string }).routing_key).toBe(
+      'R-env-fallback'
+    )
+    expect(fakeDb.rows[0].channel).toBe('pagerduty:default')
+  })
+
+  test('no pagerduty route/env key configured -> no PagerDuty delivery (only the legacy webhook fires)', async () => {
+    const posted: string[] = []
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      posted.push(String(url))
+      return new Response(null, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const summary = await runHealthSweep()
+
+    expect(summary.alertsDispatched).toBe(1)
+    // Only the legacy global webhook (env HEALTH_ALERT_WEBHOOK_URL) fired —
+    // no PagerDuty Events API call since no route or env key is configured.
+    expect(posted).toEqual(['https://hooks.slack.com/services/T000/B000/XXXX'])
+  })
+
+  test('a matched pagerduty route suppresses the legacy webhook — no double-fire', async () => {
+    // Legacy global webhook stays configured (beforeEach default), AND a
+    // PagerDuty route matches this finding — the match must win exclusively:
+    // PagerDuty pages, the legacy Slack webhook must NOT also fire.
+    fakeDb = makeFakeD1([
+      {
+        id: 'pd-route-1',
+        owner_id: '',
+        match_rule: TEST_RULE_ID,
+        match_host: '*',
+        channel_url: 'https://events.pagerduty.com/v2/enqueue',
+        enabled: 1,
+        created_at: 0,
+        provider: 'pagerduty',
+        service_name: 'DB On-call',
+        routing_key: 'R-service-key',
+      },
+    ])
+
+    const posted: string[] = []
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      posted.push(String(url))
+      return new Response(null, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const summary = await runHealthSweep()
+
+    expect(summary.alertsDispatched).toBe(1)
+    expect(posted).toEqual(['https://events.pagerduty.com/v2/enqueue'])
+  })
+
+  test('a matched webhook route suppresses the env PagerDuty fallback — no double-fire', async () => {
+    // A catch-all webhook route matches AND an env PagerDuty routing key is
+    // configured — the explicit webhook route must win exclusively: no
+    // PagerDuty Events API call for this finding.
+    process.env.HEALTH_ALERT_PAGERDUTY_ROUTING_KEY = 'R-env-fallback'
+    fakeDb = makeFakeD1([
+      {
+        id: 'webhook-route-1',
+        owner_id: '',
+        match_rule: '*',
+        match_host: '*',
+        channel_url: 'https://hooks.slack.com/services/ROUTE/CHANNEL/AAA',
+        enabled: 1,
+        created_at: 0,
+      },
+    ])
+
+    const posted: string[] = []
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      posted.push(String(url))
+      return new Response(null, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const summary = await runHealthSweep()
+
+    expect(summary.alertsDispatched).toBe(1)
+    expect(posted).toEqual([
+      'https://hooks.slack.com/services/ROUTE/CHANNEL/AAA',
+    ])
   })
 })
 

--- a/apps/dashboard/src/lib/health/server-sweep.ts
+++ b/apps/dashboard/src/lib/health/server-sweep.ts
@@ -7,14 +7,23 @@ import type {
   AlertRuleDef,
   AlertRuleSeverity,
 } from '@/lib/alerting/rule-registry'
+import type { AlertPayload, PagerDutyEventBody } from './adapters'
 import type { AlertEventRecord } from './alert-history-store'
 import type { AlertRoute } from './alert-routing'
 import type { AlertDecision } from './alert-state-store'
 
-import { detectAdapter } from './adapters'
+import { buildPagerDutyBody, detectAdapter } from './adapters'
 import { recordAlertEvent } from './alert-history-store'
-import { listRoutes, resolveTargets } from './alert-routing'
+import {
+  listRoutes,
+  resolvePagerDutyTargets,
+  resolveTargets,
+} from './alert-routing'
 import { alertStateStore, evaluateAlert } from './alert-state-store'
+import {
+  getPagerDutyFallbackRoutingKey,
+  PAGERDUTY_EVENTS_API_URL,
+} from './pagerduty-config'
 import {
   getServerAlertConfig,
   getServerAlertCooldownMs,
@@ -195,6 +204,45 @@ async function postWebhook(url: string, text: string): Promise<WebhookResult> {
 }
 
 /**
+ * POST a PagerDuty Events API v2 body (`trigger` or `resolve`) to the fixed
+ * enqueue endpoint, using a specific service's routing key — plan 34. Mirrors
+ * {@link postWebhook}'s shape/timeout so the two dispatch paths behave the
+ * same for the caller; only the content-type target differs (a real PagerDuty
+ * body, not the generic `{ text, content }` wrapper).
+ */
+async function postPagerDutyEvent(
+  body: PagerDutyEventBody
+): Promise<WebhookResult> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 10_000)
+  try {
+    const res = await fetch(PAGERDUTY_EVENTS_API_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    })
+    if (!res.ok) {
+      const message = `PagerDuty Events API returned status ${res.status}`
+      error(
+        '[health-sweep] PagerDuty Events API returned non-OK status',
+        new Error(message)
+      )
+      return { ok: false, error: message }
+    }
+    return { ok: true }
+  } catch (err) {
+    error('[health-sweep] PagerDuty Events API POST failed', err as Error)
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+/**
  * Map a notify decision + dispatch outcome into the shape the alert-history
  * store persists. Pure — no I/O — so the decision→record translation (the
  * trickiest part: `recovery` carries its own severity distinct from the
@@ -274,8 +322,10 @@ export async function runHealthSweep(): Promise<SweepSummary> {
   const settings = getServerAlertConfig()
   const webhookConfigured = Boolean(settings.webhookUrl)
   const routes: AlertRoute[] = await listRoutes(SWEEP_ROUTING_OWNER_ID)
+  const pagerDutyFallbackKey = getPagerDutyFallbackRoutingKey()
   const canDispatch =
-    settings.webhookEnabled && (webhookConfigured || routes.length > 0)
+    settings.webhookEnabled &&
+    (webhookConfigured || routes.length > 0 || Boolean(pagerDutyFallbackKey))
   const minRank = SEVERITY_ORDER[settings.minSeverity]
   const cooldownMs = getServerAlertCooldownMs()
 
@@ -361,6 +411,19 @@ export async function runHealthSweep(): Promise<SweepSummary> {
         settings.webhookUrl
       )
 
+      // PagerDuty services (plan 34): resolved separately from the generic
+      // webhook fan-out above (`resolveTargets` already excludes
+      // provider === 'pagerduty' routes — see `alert-routing.ts`), because a
+      // PagerDuty target needs the real Events API v2 body/routing key
+      // rather than the generic `{ text, content }` wrapper. Falls back to
+      // the legacy env routing key when no route matches, same fail-open
+      // contract as the webhook path.
+      const pagerDutyTargets = resolvePagerDutyTargets(
+        routes,
+        { ruleId, ruleType, hostId, hostName: name },
+        pagerDutyFallbackKey
+      )
+
       let anyDelivered = false
       for (const url of targets) {
         const result = await postWebhook(url, text)
@@ -394,11 +457,60 @@ export async function runHealthSweep(): Promise<SweepSummary> {
         }
       }
 
+      if (pagerDutyTargets.length > 0) {
+        // `decision.kind === 'recovery'` maps to `event_action: 'resolve'`
+        // inside `buildPagerDutyBody`; the stable `chmonitor:{hostId}:{metric}`
+        // dedup key is what lets PagerDuty collapse repeat triggers into one
+        // open incident and auto-resolve it here. `metric` is the rule id, so
+        // this key aligns 1:1 with the sweep's own `hostId:ruleId` dedup.
+        const pagerDutyPayload: AlertPayload = {
+          severity:
+            decision.kind === 'recovery'
+              ? 'recovery'
+              : (effective as 'warning' | 'critical'),
+          hostLabel: name,
+          hostId,
+          metric: ruleId,
+          value,
+          title: ruleTitle,
+          label,
+          timestamp: new Date().toISOString(),
+        }
+
+        for (const target of pagerDutyTargets) {
+          const body = buildPagerDutyBody(pagerDutyPayload, {
+            routingKey: target.routingKey,
+          })
+          const result = await postPagerDutyEvent(body)
+          if (result.ok) anyDelivered = true
+
+          try {
+            await recordAlertEvent(
+              buildAlertEventRecord({
+                hostId,
+                hostLabel: name,
+                ruleId,
+                decision,
+                value,
+                delivered: result.ok,
+                error: result.error,
+                channel: `pagerduty:${target.serviceName}`,
+              })
+            )
+          } catch (err) {
+            debug(
+              `[health-sweep] alert-history record failed for host ${hostId} rule ${ruleId}`,
+              err instanceof Error ? err.message : String(err)
+            )
+          }
+        }
+      }
+
       // Persist "notified" only when there was nothing to deliver (no
-      // targets — not a failure) or at least one channel succeeded. A failed
-      // delivery with no successes leaves no record, so the next sweep retries
-      // instead of suppressing.
-      if (targets.length === 0 || anyDelivered) {
+      // targets at all across every channel — not a failure) or at least one
+      // channel succeeded. A failed delivery with no successes leaves no
+      // record, so the next sweep retries instead of suppressing.
+      if (targets.length + pagerDutyTargets.length === 0 || anyDelivered) {
         commit()
         if (anyDelivered) {
           alertsDispatched++

--- a/apps/dashboard/src/lib/hooks/use-alert-routes.ts
+++ b/apps/dashboard/src/lib/hooks/use-alert-routes.ts
@@ -12,6 +12,9 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { throwIfNotOk } from '@/lib/swr/fetch-error'
 
+/** Destination provider: `'webhook'` (plan 30) or `'pagerduty'` (plan 34). */
+export type AlertRouteProvider = 'webhook' | 'pagerduty'
+
 export interface AlertRouteInfo {
   id: string
   matchRule: string
@@ -19,6 +22,10 @@ export interface AlertRouteInfo {
   channelUrl: string
   enabled: boolean
   createdAt: number
+  provider: AlertRouteProvider
+  serviceName: string | null
+  /** Masked routing key (last 4 chars only) — never the raw secret. */
+  routingKeyMasked: string | null
 }
 
 export const ALERT_ROUTES_QUERY_KEY = ['/api/v1/health/routes'] as const
@@ -56,7 +63,10 @@ export function useAlertRoutesMutations() {
   const createRoute = async (input: {
     matchRule: string
     matchHost: string
-    channelUrl: string
+    channelUrl?: string
+    provider?: AlertRouteProvider
+    serviceName?: string
+    routingKey?: string
   }): Promise<AlertRouteInfo> => {
     const response = await apiFetch('/api/v1/health/routes', {
       method: 'POST',
@@ -82,4 +92,39 @@ export function useAlertRoutesMutations() {
   }
 
   return { createRoute, deleteRoute, invalidate }
+}
+
+/** One PagerDuty service, for the setup dialog's picker. */
+export interface PagerDutyServiceOption {
+  id: string
+  name: string
+}
+
+/**
+ * List PagerDuty services via the account's REST API token (plan 34) — used
+ * to populate the picker. Degrades to an empty list (never throws) when no
+ * token is configured, so the dialog always falls back to pasting a routing
+ * key by hand.
+ */
+export function usePagerDutyServices(enabled = true) {
+  const query = useQuery({
+    queryKey: ['/api/v1/health/pagerduty-services'],
+    queryFn: async () => {
+      const response = await apiFetch('/api/v1/health/pagerduty-services')
+      await throwIfNotOk(response, 'Failed to load PagerDuty services')
+      const json = (await response.json()) as {
+        success: boolean
+        services: PagerDutyServiceOption[]
+      }
+      return json.services ?? []
+    },
+    enabled,
+    staleTime: 60_000,
+  })
+
+  return {
+    services: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+  }
 }

--- a/apps/dashboard/src/routes/api/v1/health/pagerduty-services.ts
+++ b/apps/dashboard/src/routes/api/v1/health/pagerduty-services.ts
@@ -1,0 +1,51 @@
+/**
+ * PagerDuty service picker helper (plans/34-pagerduty-escalation-oncall.md).
+ *
+ *   GET /api/v1/health/pagerduty-services — list PagerDuty services via the
+ *   account-level REST API token (`HEALTH_ALERT_PAGERDUTY_API_KEY`), for the
+ *   alert-routing setup dialog's picker.
+ *
+ * READ-ONLY: this never calls a PagerDuty write/mutation endpoint — creating
+ * services/escalation policies/schedules stays the operator's job in
+ * PagerDuty itself (see `lib/health/pagerduty-config.ts`). Best-effort: an
+ * unset/invalid token or any PagerDuty API error resolves to an empty list
+ * rather than a 5xx, so the dialog can always fall back to pasting a routing
+ * key by hand.
+ *
+ * Gated like alert-routing writes (`requiresSignInForWrite`) rather than the
+ * routes GET: listing services reveals the operator's PagerDuty account
+ * structure, so cloud mode requires sign-in; self-hosted (no Clerk) stays
+ * open with zero auth, per "self-hosted stays whole".
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import {
+  requiresSignInForWrite,
+  resolveAlertRoutingOwnerId,
+} from '@/lib/health/alert-routing-auth'
+import { listPagerDutyServices } from '@/lib/health/pagerduty-config'
+
+async function handleGet(): Promise<Response> {
+  const ownerId = await resolveAlertRoutingOwnerId()
+  if (requiresSignInForWrite(ownerId)) {
+    return Response.json(
+      {
+        success: false,
+        error: { message: 'Sign in to list PagerDuty services.' },
+      },
+      { status: 401 }
+    )
+  }
+
+  const services = await listPagerDutyServices()
+  return Response.json({ success: true, services }, { status: 200 })
+}
+
+export const Route = createFileRoute('/api/v1/health/pagerduty-services')({
+  server: {
+    handlers: {
+      GET: async () => handleGet(),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/v1/health/routes.ts
+++ b/apps/dashboard/src/routes/api/v1/health/routes.ts
@@ -15,6 +15,8 @@
 
 import { createFileRoute } from '@tanstack/react-router'
 
+import type { AlertRouteProvider } from '@/lib/health/alert-routing'
+
 import { validateHostUrl } from '@/lib/browser-connections/host-url'
 import {
   createRoute,
@@ -25,9 +27,22 @@ import {
   requiresSignInForWrite,
   resolveAlertRoutingOwnerId,
 } from '@/lib/health/alert-routing-auth'
+import { PAGERDUTY_EVENTS_API_URL } from '@/lib/health/pagerduty-config'
 
 function jsonError(message: string, status: number): Response {
   return Response.json({ success: false, error: { message } }, { status })
+}
+
+/**
+ * Mask a PagerDuty routing key for API responses — unlike a Slack/Discord
+ * `channelUrl` (whose secret already lives openly in the URL path by
+ * convention), a routing key is a bare secret with no other identifying
+ * shape, so it is never returned in full once stored (plan 34's "secret at
+ * rest, like connection secrets"). Shows only the last 4 characters.
+ */
+function maskRoutingKey(key: string): string {
+  if (key.length <= 4) return '••••'
+  return `••••${key.slice(-4)}`
 }
 
 function toPublicRoute(route: Awaited<ReturnType<typeof listRoutes>>[number]) {
@@ -38,6 +53,11 @@ function toPublicRoute(route: Awaited<ReturnType<typeof listRoutes>>[number]) {
     channelUrl: route.channelUrl,
     enabled: route.enabled,
     createdAt: route.createdAt,
+    provider: route.provider,
+    serviceName: route.serviceName,
+    routingKeyMasked: route.routingKey
+      ? maskRoutingKey(route.routingKey)
+      : null,
   }
 }
 
@@ -55,6 +75,12 @@ interface CreateRouteBody {
   matchHost?: unknown
   channelUrl?: unknown
   enabled?: unknown
+  /** `'webhook'` (default) or `'pagerduty'` (plan 34). */
+  provider?: unknown
+  /** PagerDuty-only: display label for the service. */
+  serviceName?: unknown
+  /** PagerDuty-only: the service's Events API v2 integration/routing key. */
+  routingKey?: unknown
 }
 
 async function handlePost(request: Request): Promise<Response> {
@@ -68,6 +94,58 @@ async function handlePost(request: Request): Promise<Response> {
     body = (await request.json()) as CreateRouteBody
   } catch {
     return jsonError('Request body must be valid JSON', 400)
+  }
+
+  const provider: AlertRouteProvider =
+    body.provider === 'pagerduty' ? 'pagerduty' : 'webhook'
+
+  const matchRule =
+    typeof body.matchRule === 'string' && body.matchRule.trim()
+      ? body.matchRule.trim()
+      : '*'
+  const matchHost =
+    typeof body.matchHost === 'string' && body.matchHost.trim()
+      ? body.matchHost.trim()
+      : '*'
+  const enabled = body.enabled !== false
+
+  if (provider === 'pagerduty') {
+    const routingKey =
+      typeof body.routingKey === 'string' ? body.routingKey.trim() : ''
+    if (!routingKey) {
+      return jsonError(
+        'Missing required "routingKey": a PagerDuty service integration/routing key',
+        400
+      )
+    }
+    const serviceName =
+      typeof body.serviceName === 'string' ? body.serviceName.trim() : ''
+
+    // The Events API v2 endpoint is fixed for every PagerDuty service — not
+    // caller-supplied, so there is no new SSRF sink here (unlike the
+    // webhook path below, which fetches an arbitrary operator-supplied URL).
+    const created = await createRoute({
+      ownerId,
+      matchRule,
+      matchHost,
+      channelUrl: PAGERDUTY_EVENTS_API_URL,
+      enabled,
+      provider: 'pagerduty',
+      serviceName: serviceName || null,
+      routingKey,
+    })
+
+    if (!created) {
+      return jsonError(
+        'Alert routing storage is not configured (no D1 binding) or the write failed.',
+        501
+      )
+    }
+
+    return Response.json(
+      { success: true, route: toPublicRoute(created) },
+      { status: 201 }
+    )
   }
 
   const channelUrl =
@@ -88,22 +166,13 @@ async function handlePost(request: Request): Promise<Response> {
     return jsonError(ssrfError, 400)
   }
 
-  const matchRule =
-    typeof body.matchRule === 'string' && body.matchRule.trim()
-      ? body.matchRule.trim()
-      : '*'
-  const matchHost =
-    typeof body.matchHost === 'string' && body.matchHost.trim()
-      ? body.matchHost.trim()
-      : '*'
-  const enabled = body.enabled !== false
-
   const created = await createRoute({
     ownerId,
     matchRule,
     matchHost,
     channelUrl,
     enabled,
+    provider: 'webhook',
   })
 
   if (!created) {


### PR DESCRIPTION
## Summary

Implements plan 34: an operator maps rule/host patterns to a **PagerDuty service** (its Events API v2 integration/routing key), so a matching finding pages that service directly and lets PagerDuty's own escalation policy + on-call schedule take over — instead of every alert going to one flat integration key.

**Schema-overlap decision (plan open question 1):** extended plan 30's `alert_routes` table with `provider` / `service_name` / `routing_key` columns (migration `0016_alert_routes_pagerduty.sql`) rather than shipping a second routing table. Legacy rows default to `provider = 'webhook'`, so plan-30 behavior is byte-identical when no PagerDuty routes exist.

### What changed
- `lib/health/pagerduty-config.ts` (new): read-only REST API token (`HEALTH_ALERT_PAGERDUTY_API_KEY`) to *list services* for the setup picker — never a PagerDuty write/mutation call — plus the legacy single-key env fallback (`HEALTH_ALERT_PAGERDUTY_ROUTING_KEY`).
- `lib/health/alert-routing.ts`: `AlertRoute` gains `provider`/`serviceName`/`routingKey`; new pure `resolvePagerDutyTargets` (mirrors `resolveTargets`) resolves matched PagerDuty routes or falls back to the env key.
  - **Cross-provider suppression**: a route match of *either* provider now suppresses the *other* provider's catch-all fallback — an operator who explicitly routes a rule to PagerDuty must not also get paged on the legacy Slack/Discord webhook for the same finding, and vice versa (plan 30's own precedent: "matched routes take precedence, the legacy URL is a fallback only when nothing matches", extended across providers).
- `lib/health/server-sweep.ts`: dispatches a real PagerDuty Events API v2 `trigger`/`resolve` per matched service (`buildPagerDutyBody`), preserving the `chmonitor:{hostId}:{metric}` dedup key and running `evaluateAlert` exactly once per finding regardless of fan-out.
- `routes/api/v1/health/routes.ts`: CRUD extended for the `pagerduty` provider (routing key never returned raw — only a masked `routingKeyMasked`); `routes/api/v1/health/pagerduty-services.ts` (new): GET service list, owner-scoped, fail-open for self-hosted.
- `components/health/alert-routing-dialog.tsx`: routing panel gains a PagerDuty destination option (service picker from the REST token, or paste a routing key by hand; send-test-event).
- `.env.example`: documents the two new env vars.

### Invariants held
- Self-hosted stays whole: no D1 / owner throw → falls back to the single env routing key (or no PagerDuty dispatch if unset); proven by pure resolver tests.
- REST API token is read-only (list services only); Events API dispatch never calls a PagerDuty write/mutation endpoint — chmonitor pages humans, PagerDuty owns escalation.
- No Postgres — D1 only, mirroring the existing `alert_routes` pattern.
- Not gated behind a paywall (`alerting_advanced`/`webhook_integrations` are `deferred` in `plan-enforcement.ts`, so this ships free like the rest of alerting).

## Verification

Plan's verification block, run from a clean `bun install` in `apps/dashboard`:

```
$ cd apps/dashboard && bun run type-check
$ tsc --noEmit
(clean, no output)

$ cd apps/dashboard && bun run build
$ vite build && tsc --noEmit
... (prerenders 103 pages) ...
exit 0, no errors

$ cd apps/dashboard && bun test src/lib/health/adapters/ --isolate
 28 pass
 0 fail
 5 snapshots, 66 expect() calls

$ cd apps/dashboard && bun test src/lib/health/ --isolate
 213 pass
 0 fail
 5 snapshots, 450 expect() calls

$ cd apps/dashboard && bun run lint
error: Script not found "lint"
```

Note on the last command: `apps/dashboard/package.json` has no `lint` script (only `type-check`/`build`/`test`). Ran the repo-root lint instead as the closest equivalent:

```
$ bun run lint   # from repo root
$ biome lint .
Checked 2084 files in 722ms. No fixes applied.
```

The pre-push hook additionally ran the full dashboard + packages test suites (5307 + 896 tests, all passing) with no `--no-verify` needed.

## Test plan
- [x] `resolvePagerDutyTargets` pure tests: `*` match, glob match, dedup by routing key, no-match env fallback, no-D1/owner-throw fallback (STOP condition), cross-provider suppression (both directions)
- [x] `server-sweep.test.ts`: a matched PagerDuty route posts a real Events API v2 body to the fixed enqueue endpoint with the correct dedup key; env-key fallback when nothing matches; no PagerDuty route/env key configured → only the legacy webhook fires; matched PagerDuty route suppresses the legacy webhook (no double-fire) and vice versa
- [x] `bun run build` + `bun run type-check` clean
- [x] `bun run lint` (root) clean