### PR TITLE
perf(query): keep cached data on page revisits via 30s staleTime + keepPreviousData

### DIFF
--- a/apps/dashboard/src/lib/query/__tests__/provider.test.tsx
+++ b/apps/dashboard/src/lib/query/__tests__/provider.test.tsx
@@ -1,5 +1,6 @@
-import { QueryClient } from '@tanstack/react-query'
+import { keepPreviousData, QueryClient } from '@tanstack/react-query'
 
+import { createQueryClient } from '../query-client'
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
 
 describe('QueryProvider swr:revalidate integration', () => {
@@ -60,5 +61,34 @@ describe('QueryProvider swr:revalidate integration', () => {
 
   it('does not call invalidateQueries before the event fires', () => {
     expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('createQueryClient default query options', () => {
+  // These defaults are the mechanism behind "cached data on navigation":
+  // gcTime keeps a page's data alive between visits, staleTime avoids a
+  // refetch (and thus a possible loading state) on a quick revisit, and
+  // placeholderData keeps prior data on screen during in-place key changes.
+  // Assert the intent so a regression that reintroduces the revisit flash
+  // (e.g. resetting staleTime to a few seconds) fails here.
+
+  it('treats cached data as fresh for 30s so quick revisits skip the refetch', () => {
+    const queries = createQueryClient().getDefaultOptions().queries
+    expect(queries?.staleTime).toBe(30_000)
+  })
+
+  it('uses keepPreviousData so in-place key changes never blank to a skeleton', () => {
+    const queries = createQueryClient().getDefaultOptions().queries
+    expect(queries?.placeholderData).toBe(keepPreviousData)
+  })
+
+  it('retains inactive query data for 30 min so navigation revisits render from cache', () => {
+    const queries = createQueryClient().getDefaultOptions().queries
+    expect(queries?.gcTime).toBe(30 * 60_000)
+  })
+
+  it('does not refetch on window focus', () => {
+    const queries = createQueryClient().getDefaultOptions().queries
+    expect(queries?.refetchOnWindowFocus).toBe(false)
   })
 })

--- a/apps/dashboard/src/lib/query/provider.tsx
+++ b/apps/dashboard/src/lib/query/provider.tsx
@@ -1,7 +1,8 @@
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
 
+import { createQueryClient } from './query-client'
 import { useEffect, useState } from 'react'
 import { USER_CONNECTIONS_QUERY_PREFIX } from '@/lib/hooks/use-user-connections'
 
@@ -27,52 +28,6 @@ const PERSIST_MAX_AGE_MS = 24 * 60 * 60_000
 // data could render against a mismatched schema. The git SHA is inlined at
 // build time (see vite.config.ts CLIENT_ENV); 'dev' covers local builds.
 const PERSIST_BUSTER = import.meta.env.VITE_GIT_SHA || 'dev'
-
-function createQueryClient(): QueryClient {
-  return new QueryClient({
-    defaultOptions: {
-      queries: {
-        // SWR dedupingInterval: 5000ms
-        // Requests made within this window share the same in-flight fetch
-        // and the cached result is considered fresh for this long.
-        staleTime: 5_000,
-
-        // Keep inactive (unmounted) query data in cache for 30 min before
-        // garbage-collecting it. Orthogonal to staleTime: this does NOT
-        // affect freshness — data still revalidates per staleTime — it only
-        // controls how long a cached result survives after its last consumer
-        // unmounts. A monitoring dashboard hops between pages constantly;
-        // with the 5 min default, returning to a page after the GC window
-        // shows a loading skeleton. 30 min lets the user navigate back to an
-        // instant stale-while-revalidate render (cached data shown, refetch
-        // in background) instead of a blank skeleton. (TanStack Query
-        // default gcTime is 5 min.)
-        //
-        // gcTime also bounds what survives a persist round-trip: only queries
-        // whose gcTime has not elapsed are restored from localStorage on load.
-        gcTime: 30 * 60_000,
-
-        // SWR revalidateOnFocus: false
-        // Don't refetch when the browser tab regains focus.
-        refetchOnWindowFocus: false,
-
-        // SWR errorRetryCount: 3
-        // Retry failed queries up to 3 times before surfacing the error.
-        retry: 3,
-
-        // SWR onErrorRetry uses exponential backoff starting at 1 s (errorRetryInterval: 1000),
-        // doubling each attempt and capped at 30 s.
-        // attempt index is 0-based; match SWR's 2^n * 1000 formula.
-        retryDelay: (attempt) => Math.min(30_000, 1_000 * 2 ** attempt),
-
-        // SWR sets no global refreshInterval — polling is opt-in per query.
-        // TanStack Query default (false) matches: no background refetch unless
-        // the caller passes refetchInterval explicitly.
-        refetchInterval: false,
-      },
-    },
-  })
-}
 
 export function QueryProvider({ children }: QueryProviderProps) {
   const [queryClient] = useState(createQueryClient)

--- a/apps/dashboard/src/lib/query/query-client.ts
+++ b/apps/dashboard/src/lib/query/query-client.ts
@@ -1,0 +1,71 @@
+import { keepPreviousData, QueryClient } from '@tanstack/react-query'
+
+/**
+ * Build the app-wide TanStack QueryClient with our default query options.
+ *
+ * Extracted from provider.tsx (which wires the returned client into
+ * PersistQueryClientProvider) so these defaults can be unit-tested without
+ * pulling the React / persister / Clerk module graph into the test —
+ * see __tests__/provider.test.tsx.
+ */
+export function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        // Treat cached data as fresh for 30s so quick back-and-forth
+        // navigation between pages doesn't refetch at all — the previously
+        // rendered result stays on screen instead of dropping to a skeleton.
+        // This is only the DEFAULT: live views set a shorter per-query
+        // staleTime (the chart/table hooks derive it from their
+        // refreshInterval), and polling is driven by refetchInterval — which
+        // fires independently of staleTime — so live pages keep updating. The
+        // manual refresh button (swr:revalidate handler in provider.tsx)
+        // invalidates queries, which also bypasses staleTime.
+        staleTime: 30_000,
+
+        // Keep the previous/cached data visible while a query refetches or its
+        // key changes, instead of dropping to a pending state. Equivalent to
+        // SWR's keepPreviousData, applied globally so pages using the default
+        // client options (direct useQuery callers) get smooth in-place
+        // transitions; the chart/table hooks already set their own
+        // placeholderData and are unaffected. NOTE: this does not change
+        // unmount/remount revisits — those already render synchronously from
+        // the gcTime-retained cache — it only smooths in-place key changes.
+        placeholderData: keepPreviousData,
+
+        // Keep inactive (unmounted) query data in cache for 30 min before
+        // garbage-collecting it. Orthogonal to staleTime: this does NOT
+        // affect freshness — data still revalidates per staleTime — it only
+        // controls how long a cached result survives after its last consumer
+        // unmounts. A monitoring dashboard hops between pages constantly;
+        // with the 5 min default, returning to a page after the GC window
+        // shows a loading skeleton. 30 min lets the user navigate back to an
+        // instant stale-while-revalidate render (cached data shown, refetch
+        // in background) instead of a blank skeleton. (TanStack Query
+        // default gcTime is 5 min.)
+        //
+        // gcTime also bounds what survives a persist round-trip: only queries
+        // whose gcTime has not elapsed are restored from localStorage on load.
+        gcTime: 30 * 60_000,
+
+        // SWR revalidateOnFocus: false
+        // Don't refetch when the browser tab regains focus.
+        refetchOnWindowFocus: false,
+
+        // SWR errorRetryCount: 3
+        // Retry failed queries up to 3 times before surfacing the error.
+        retry: 3,
+
+        // SWR onErrorRetry uses exponential backoff starting at 1 s (errorRetryInterval: 1000),
+        // doubling each attempt and capped at 30 s.
+        // attempt index is 0-based; match SWR's 2^n * 1000 formula.
+        retryDelay: (attempt) => Math.min(30_000, 1_000 * 2 ** attempt),
+
+        // SWR sets no global refreshInterval — polling is opt-in per query.
+        // TanStack Query default (false) matches: no background refetch unless
+        // the caller passes refetchInterval explicitly.
+        refetchInterval: false,
+      },
+    },
+  })
+}


### PR DESCRIPTION
## What & why

> "all pages should support caching when navigating between pages."

Revisiting a dashboard page shouldn't flash a loading skeleton when the data
is already cached. This PR strengthens the **global** query-client defaults so
pages keep showing data across navigation instead of dropping to a pending
state.

**Changes (shared config only):**
- `staleTime` default **5s → 30s** — a quick back-and-forth between pages within
  30s is considered *fresh*, so `refetchOnMount` doesn't fire → no background
  refetch → nothing can flip a skeleton on during that window.
- Add `placeholderData: keepPreviousData` to the defaults — keeps the previous
  data on screen while a query's **key changes in place** (filter / host / range)
  instead of blanking.
- Extract `createQueryClient` into `lib/query/query-client.ts` (plain module,
  no React/persister imports) so the defaults are unit-testable, and assert them
  in `provider.test.tsx`.

## Honest scoping — what this does NOT do (read this)

While implementing I verified the current behavior, and the premise is **partly
already handled**:

- **Shared has-data pages already render cached data on revisit** and do *not*
  flash. `TableClient` and `ChartContainer` already gate their skeleton on
  `isLoading` (`isPending && isFetching`, i.e. only when there is no cached data)
  and rely on the existing `gcTime: 30min`. On revisit TanStack Query hydrates
  the cached rows synchronously (`isPending: false`) and refetches in the
  background. **This PR does not change that path and does not "make revisits
  instant" there — they already were.**
- This is **defense-in-depth for pages using the default client options**
  (direct `useQuery` callers: billing, alerts, explorer, sql-console, settings,
  etc.) plus smoother in-place key transitions app-wide.
- **`placeholderData` does not affect unmount/remount revisits** — those already
  render synchronously from the `gcTime`-retained cache. It only smooths in-place
  key changes. The quick-revisit lever here is the **staleTime** bump.
- **First-load slowness of never-visited pages is unchanged** — that's per-page
  query optimization (separate PRs). This PR only affects *revisits* / cached
  navigation.
- **Out of scope, deliberately untouched:** the empty-result table skeleton gate
  in `table-client.tsx` and the dedicated `slow-` / `expensive-` / `running-` /
  `failed-queries` views. Those are owned by separate in-flight work — notably
  `perf/failed-queries-page`, which is actively editing `table-client.tsx` and
  `use-table-data.ts`. I stayed out to avoid a merge conflict and per the task's
  scope. I also did **not** raise `use-table-data`'s staleTime floor, because it
  is consumed directly by those live views (e.g. `running-queries`) and would
  change their freshness-on-remount.

## Live polling is unaffected

The chart/table data hooks set their own shorter `staleTime`
(`Math.max(refreshInterval*0.9, 5s)`), and polling is driven by
`refetchInterval`, which fires **independently of staleTime**. Freshness-
sensitive direct queries (`use-host-status` 10s, `use-ai-quota`, billing,
notifications, health-checks) all set their own `staleTime`/`refetchInterval`,
so the default bump doesn't touch them. Manual refresh (`swr:revalidate` →
`invalidateQueries`) also bypasses `staleTime`.

Blast-radius check: of ~60 `useQuery` call sites, the ones inheriting the
default are schema/explorer/favorites/console/config queries — none are
fast live-metric pollers.

## Verification

- `bun test src/lib/query` → **1052 pass, 0 fail** (incl. 4 new default-option
  assertions + the existing `swr:revalidate` tests).
- `bun run type-check` and `bun run type-check:test` → **229 errors, identical to
  the `main` baseline (verified via stash)**. Zero new; all pre-existing
  `routeTree.gen` missing-module cascade + `next-compat.ts`. None in the touched
  files.
- `biome check` clean on all touched files.
- No full `bun run build` (per task).

UI behavior is validated by reasoning + the existing (non-required) component
tests, not a manual browser check (worktree has no dev server).

## Files
- `apps/dashboard/src/lib/query/query-client.ts` (new) — extracted `createQueryClient` with the updated defaults
- `apps/dashboard/src/lib/query/provider.tsx` — import the extracted factory
- `apps/dashboard/src/lib/query/__tests__/provider.test.tsx` — assert the defaults

Co-Authored-By: duyetbot <bot@duyet.net>
