### PR TITLE
feat(query-cache): redesign page with row expansion, hit-rate chart, cleaner columns

### DIFF
--- a/apps/dashboard/src/components/charts/registry/chart-categories.ts
+++ b/apps/dashboard/src/components/charts/registry/chart-categories.ts
@@ -39,6 +39,7 @@ export const CHARTS_BY_CATEGORY: Record<ChartCategory, string[]> = {
     'failed-query-count',
     'failed-query-count-by-user',
     'query-cache',
+    'query-cache-usage',
     'top-query-fingerprints',
     'cancelled-queries',
     'query-duration-percentiles',

--- a/apps/dashboard/src/components/charts/registry/imports/query-charts.ts
+++ b/apps/dashboard/src/components/charts/registry/imports/query-charts.ts
@@ -51,6 +51,11 @@ export const queryChartImports: ChartRegistryMap = {
       default: m.ChartQueryCache,
     }))
   ),
+  'query-cache-usage': lazy(() =>
+    import('@/components/charts/query/query-cache-usage').then((m) => ({
+      default: m.ChartQueryCacheUsage,
+    }))
+  ),
   'top-query-fingerprints': lazy(() =>
     import('@/components/charts/query/top-query-fingerprints').then((m) => ({
       default: m.ChartTopQueryFingerprints,

--- a/apps/dashboard/src/components/charts/registry/type-hints.ts
+++ b/apps/dashboard/src/components/charts/registry/type-hints.ts
@@ -21,6 +21,7 @@ export const CHART_TYPE_HINTS: Record<string, ChartSkeletonType> = {
   'failed-query-count': 'area',
   'failed-query-count-by-user': 'bar',
   'query-cache': 'metric',
+  'query-cache-usage': 'bar',
   'query-duration-percentiles': 'area',
   'slow-query-occurrences': 'bar',
 

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/queries/query-cache.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/queries/query-cache.ts
@@ -2,11 +2,14 @@ import type { DeclarativeQueryConfig } from '../../schema'
 
 export const queryCacheDeclarative: DeclarativeQueryConfig = {
   name: 'query-cache',
-  optional: false,
+  // system.query_cache only exists once the query cache is enabled (CH 23.5+).
+  // Optional so a missing table degrades to a graceful "table missing" empty
+  // state (via tableCheck) instead of a hard SQL error.
+  optional: true,
   defaultView: 'auto',
-  card: { primary: 'query', badges: ['stale', 'shared', 'compressed'] },
   description:
-    'https://clickhouse.com/blog/introduction-to-the-clickhouse-query-cache-and-design',
+    'Entries currently held in the ClickHouse query result cache — the cached SELECT, its result size, sharing/compression flags, and when each entry expires. Expand a row for the full query and its metadata.',
+  card: { primary: 'query', badges: ['stale', 'shared', 'compressed'] },
   suggestion: `Enable query cache with these settings:
 
 SET enable_query_result_cache = 1;
@@ -23,10 +26,13 @@ https://clickhouse.com/docs/en/operations/query-cache`,
           query,
           result_size,
           formatReadableSize(result_size) AS readable_result_size,
-          round(100 * result_size / max(result_size) OVER ()) AS pct_result_size,
+          round(100 * result_size / nullIf(max(result_size) OVER (), 0)) AS pct_result_size,
           stale,
           shared,
           compressed,
+          if(stale, 'Yes', 'No') AS readable_stale,
+          if(shared, 'Yes', 'No') AS readable_shared,
+          if(compressed, 'Yes', 'No') AS readable_compressed,
           expires_at,
           (expires_at - now()) AS expires_in,
           key_hash
@@ -42,15 +48,43 @@ https://clickhouse.com/docs/en/operations/query-cache`,
     'compressed',
     'expires_at',
     'expires_in',
-    'key_hash',
   ],
   columnFormats: {
-    query: 'code-dialog',
+    query: ['code-dialog', { max_truncate: 100, hide_query_comment: true }],
     readable_result_size: 'background-bar',
     stale: 'boolean',
     shared: 'boolean',
     compressed: 'boolean',
     expires_in: 'duration',
   },
-  relatedCharts: [['query-cache', {}]],
+  columnDescriptions: {
+    query: 'The SELECT statement whose result is stored in the query cache.',
+    readable_result_size: 'Size of the cached result set held in memory.',
+    stale: 'Whether the entry has passed its expiry and is awaiting refresh.',
+    shared: 'Whether the entry is shared across users rather than private.',
+    compressed: 'Whether the cached result is stored compressed.',
+    expires_at: 'Absolute time at which the entry becomes stale.',
+    expires_in: 'Time remaining until the entry becomes stale.',
+  },
+  // The active TS config (queries/query-cache.ts) renders a rich createExpandedPanel
+  // (result-size bar + metadata grid + full query code block). The declarative
+  // schema can only serialize the `config-details` auto-grid today (the richer
+  // "panel" variant is a documented follow-up in schema.ts). This keeps the flip
+  // to CHM_CONFIG_SOURCE=declarative from silently dropping row expansion.
+  expandable: {
+    type: 'config-details',
+    primaryColumns: [
+      'query',
+      'readable_result_size',
+      'stale',
+      'shared',
+      'compressed',
+      'expires_at',
+      'expires_in',
+    ],
+  },
+  relatedCharts: [
+    ['query-cache', {}],
+    ['query-cache-usage', {}],
+  ],
 }

--- a/apps/dashboard/src/lib/query-config/queries/query-cache.ts
+++ b/apps/dashboard/src/lib/query-config/queries/query-cache.ts
@@ -1,14 +1,15 @@
 import type { QueryConfig } from '@/types/query-config'
 
+import { createExpandedPanel } from '@/components/data-table/cells/expanded-panel'
 import { QUERY_CACHE } from '@/lib/table-notes'
 import { ColumnFormat } from '@/types/column-format'
 
 export const queryCacheConfig: QueryConfig = {
   name: 'query-cache',
   defaultView: 'auto',
-  card: { primary: 'query', badges: ['stale', 'shared', 'compressed'] },
   description:
-    'https://clickhouse.com/blog/introduction-to-the-clickhouse-query-cache-and-design',
+    'Entries currently held in the ClickHouse query result cache — the cached SELECT, its result size, sharing/compression flags, and when each entry expires. Expand a row for the full query and its metadata.',
+  card: { primary: 'query', badges: ['stale', 'shared', 'compressed'] },
   suggestion: `Enable query cache with these settings:
 
 SET enable_query_result_cache = 1;
@@ -18,16 +19,23 @@ SET query_cache_min_query_duration_ms = 1000;
 Learn more:
 https://clickhouse.com/docs/en/operations/query-cache`,
   docs: QUERY_CACHE,
+  // system.query_cache only exists once the query cache is enabled (CH 23.5+).
+  // Mark optional so a missing table degrades to a graceful "table missing"
+  // empty state (via tableCheck) instead of a hard SQL error.
+  optional: true,
   tableCheck: 'system.query_cache',
   sql: `
       SELECT
           query,
           result_size,
           formatReadableSize(result_size) AS readable_result_size,
-          round(100 * result_size / max(result_size) OVER ()) AS pct_result_size,
+          round(100 * result_size / nullIf(max(result_size) OVER (), 0)) AS pct_result_size,
           stale,
           shared,
           compressed,
+          if(stale, 'Yes', 'No') AS readable_stale,
+          if(shared, 'Yes', 'No') AS readable_shared,
+          if(compressed, 'Yes', 'No') AS readable_compressed,
           expires_at,
           (expires_at - now()) AS expires_in,
           key_hash
@@ -43,16 +51,59 @@ https://clickhouse.com/docs/en/operations/query-cache`,
     'compressed',
     'expires_at',
     'expires_in',
-    'key_hash',
   ],
   columnFormats: {
-    query: ColumnFormat.CodeDialog,
+    query: [
+      ColumnFormat.CodeDialog,
+      { max_truncate: 100, hide_query_comment: true },
+    ],
     readable_result_size: ColumnFormat.BackgroundBar,
     stale: ColumnFormat.Boolean,
     shared: ColumnFormat.Boolean,
     compressed: ColumnFormat.Boolean,
     expires_in: ColumnFormat.Duration,
   },
-
-  relatedCharts: [['query-cache', {}]],
+  columnDescriptions: {
+    query: 'The SELECT statement whose result is stored in the query cache.',
+    readable_result_size: 'Size of the cached result set held in memory.',
+    stale: 'Whether the entry has passed its expiry and is awaiting refresh.',
+    shared: 'Whether the entry is shared across users rather than private.',
+    compressed: 'Whether the cached result is stored compressed.',
+    expires_at: 'Absolute time at which the entry becomes stale.',
+    expires_in: 'Time remaining until the entry becomes stale.',
+  },
+  expandable: {
+    renderExpanded: createExpandedPanel({
+      sections: [
+        {
+          type: 'bars',
+          title: 'Result size',
+          columns: [
+            {
+              key: 'result_size',
+              label: 'Result size',
+              readableKey: 'readable_result_size',
+              pctKey: 'pct_result_size',
+            },
+          ],
+        },
+        {
+          type: 'fields',
+          title: 'Cache metadata',
+          columns: [
+            { key: 'stale', label: 'Stale' },
+            { key: 'shared', label: 'Shared' },
+            { key: 'compressed', label: 'Compressed' },
+            { key: 'expires_at', label: 'Expires at' },
+            { key: 'key_hash', label: 'Key hash' },
+          ],
+        },
+        { type: 'code', title: 'Cached query', column: 'query' },
+      ],
+    }),
+  },
+  relatedCharts: [
+    ['query-cache', {}],
+    ['query-cache-usage', {}],
+  ],
 }


### PR DESCRIPTION
## Summary

Reformat and enhance the **Query Cache** page (`/query-cache`). All work is
driven through the shared data-table `QueryConfig` — the generic
`DataTable`/`PageLayout` chrome is **not** forked.

### 1. De-slop the page
- **Description**: replaced the raw blog URL shown as the table description with
  a human summary of what the table holds.
- **Query column**: now truncated in the table (`CodeDialog` +
  `max_truncate: 100` + `hide_query_comment`) so long SELECTs no longer blow up
  row height — the full text lives in the expanded row.
- **`key_hash`**: dropped from the table columns (20-digit hash = scan noise);
  still selected in SQL and surfaced in the expanded panel.
- **Tooltips**: added `columnDescriptions` for every column.
- **Robustness**: `pct_result_size` now guards divide-by-zero with
  `nullIf(max(result_size) OVER (), 0)`.

### 2. Expandable rows (new)
Each row now expands (generic `createExpandedPanel` row-expand pattern) into:
- **Result size** — a proportion bar (reuses `readable_result_size` /
  `pct_result_size`).
- **Cache metadata** — grid of Stale / Shared / Compressed (rendered Yes/No via
  new `readable_*` SQL companions), Expires at, and Key hash.
- **Cached query** — the FULL query as a scrollable code block with char/line
  counts.

### 3. Chart card (new)
Surfaced the existing **Query Cache Hit Rate** chart (`query-cache-usage`,
Read/Write/None breakdown, CH 24.1+) as a related chart card next to the
existing cache-status card. It only existed in the overview gallery + API SQL
builder, so it had to be registered in the client chart registry (imports,
QUERY category, skeleton hint) to resolve through `<DynamicChart>`.

### 4. Fail loud on missing table
Marked the config `optional: true` so a missing `system.query_cache` (older CH /
cache never enabled) degrades to the graceful "table missing" empty state via
`tableCheck` instead of a hard SQL error.

## Before / After

| | Before | After |
|---|---|---|
| Description | raw `clickhouse.com/blog/...` URL | human summary |
| Long queries | untruncated, tall rows | truncated + full text on expand |
| Row detail | none | bar + metadata grid + full-query code block |
| Chart cards | cache status only | + hit-rate (Read/Write/None) |
| `key_hash` | noisy table column | moved to expanded panel |
| Missing table | hard SQL error | graceful "table missing" state |

## Parity / declarative catalog

The declarative catalog config (`declarative/catalog/queries/query-cache.ts`)
mirrors every serializable field **byte-for-byte** (SQL / columns /
columnFormats / columnDescriptions / relatedCharts / description / optional) so
`declarative-parity`, `flip-safety`, and `queries-catalog` stay green. Its
`expandable` uses the serializable `config-details` variant (the rich
`createExpandedPanel` "panel" variant isn't expressible in the declarative
schema yet — a documented follow-up), which keeps flip-safety's no-silent-drop
guard satisfied.

## SQL / version notes

- `system.query_cache` also gained `tag` / `query_id` / `is_subquery` in newer
  CH versions, but the docs give **no version boundaries** for them. Since this
  environment can't test against real ClickHouse and the required check is
  compile-only, they were intentionally **left out** rather than guessing a
  `since` that could break older versions. The SQL stays a plain string (no
  version-aware array needed).

## Verification

- `bun run type-check` → **229 errors, identical to baseline** (all pre-existing
  `routeTree.gen.ts` `createFileRoute` errors); **0 new**.
- `bun run type-check:test` → **230, identical to baseline**; **0 new**.
- Ran `flip-safety`, `declarative-parity`, `queries-catalog`,
  `registry-completeness`, `background-bar-companions`,
  `shipped-sql-passes-validator`, `version-compatibility` → **all green**.
- **Visual QA pending** — no browser available in this environment; the UI has
  not been rendered/screenshotted.

Co-Authored-By: duyetbot <bot@duyet.net>
