### PR TITLE
perf(tables-overview): cut per-part work in tables-overview query and nav badge

### DIFF
--- a/apps/dashboard/src/lib/api/menu-count-registry.ts
+++ b/apps/dashboard/src/lib/api/menu-count-registry.ts
@@ -26,7 +26,7 @@ export const menuCountRegistry: Record<string, MenuCountQuery> = {
     query: `SELECT COUNT() as count FROM system.tables WHERE lower(database) NOT IN ('system', 'information_schema') AND is_temporary = 0 AND engine LIKE '%MergeTree%'`,
   },
   'tables-overview': {
-    query: `SELECT countDistinct(database || table) as count FROM system.parts`,
+    query: `SELECT countDistinct(database, table) as count FROM system.parts WHERE active`,
   },
   'distributed-ddl-queue': {
     query: `SELECT COUNT() as count FROM system.distributed_ddl_queue WHERE status != 'Finished'`,

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/tables-overview.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/tables-overview.ts
@@ -10,17 +10,17 @@ export const tablesOverviewDeclarative: DeclarativeQueryConfig = {
         detached_parts AS
         (
             SELECT
-                format('{}.{}', database, \`table\`) AS \`table\`,
+                format('{}.{}', dp.database, dp.\`table\`) AS \`table\`,
                 count() AS detached_parts_count,
                 sum(bytes_on_disk) AS detached_bytes_on_disk,
                 formatReadableSize(detached_bytes_on_disk) AS readable_detached_bytes_on_disk
-            FROM system.detached_parts
-            GROUP BY 1
+            FROM system.detached_parts AS dp
+            GROUP BY dp.database, dp.\`table\`
         ),
         parts AS
         (
             SELECT
-                format('{}.{}', database, \`table\`) AS \`table\`,
+                format('{}.{}', parts.database, parts.\`table\`) AS \`table\`,
                 sum(rows) AS total_rows,
                 formatReadableQuantity(total_rows) AS readable_total_rows,
                 round((100 * total_rows) / nullIf(max(total_rows) OVER (), 0)) AS pct_total_rows,
@@ -57,8 +57,7 @@ export const tablesOverviewDeclarative: DeclarativeQueryConfig = {
                 round((100 * parts_count) / nullIf(max(parts_count) OVER (), 0)) AS pct_parts_count
             FROM system.parts AS parts
             WHERE active
-            GROUP BY 1
-            ORDER BY compressed DESC
+            GROUP BY parts.database, parts.\`table\`
         )
       SELECT
         parts.*,

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/tables-overview.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/tables-overview.ts
@@ -66,6 +66,7 @@ export const tablesOverviewDeclarative: DeclarativeQueryConfig = {
         splitByChar('.', parts.table)[2] AS _table
       FROM parts
       LEFT JOIN detached_parts USING (\`table\`)
+      ORDER BY compressed DESC
     `,
   columns: [
     'table',

--- a/apps/dashboard/src/lib/query-config/tables/tables-overview.ts
+++ b/apps/dashboard/src/lib/query-config/tables/tables-overview.ts
@@ -11,17 +11,17 @@ export const tablesOverviewConfig: QueryConfig = {
         detached_parts AS
         (
             SELECT
-                format('{}.{}', database, \`table\`) AS \`table\`,
+                format('{}.{}', dp.database, dp.\`table\`) AS \`table\`,
                 count() AS detached_parts_count,
                 sum(bytes_on_disk) AS detached_bytes_on_disk,
                 formatReadableSize(detached_bytes_on_disk) AS readable_detached_bytes_on_disk
-            FROM system.detached_parts
-            GROUP BY 1
+            FROM system.detached_parts AS dp
+            GROUP BY dp.database, dp.\`table\`
         ),
         parts AS
         (
             SELECT
-                format('{}.{}', database, \`table\`) AS \`table\`,
+                format('{}.{}', parts.database, parts.\`table\`) AS \`table\`,
                 sum(rows) AS total_rows,
                 formatReadableQuantity(total_rows) AS readable_total_rows,
                 round((100 * total_rows) / nullIf(max(total_rows) OVER (), 0)) AS pct_total_rows,
@@ -58,8 +58,7 @@ export const tablesOverviewConfig: QueryConfig = {
                 round((100 * parts_count) / nullIf(max(parts_count) OVER (), 0)) AS pct_parts_count
             FROM system.parts AS parts
             WHERE active
-            GROUP BY 1
-            ORDER BY compressed DESC
+            GROUP BY parts.database, parts.\`table\`
         )
       SELECT
         parts.*,

--- a/apps/dashboard/src/lib/query-config/tables/tables-overview.ts
+++ b/apps/dashboard/src/lib/query-config/tables/tables-overview.ts
@@ -67,6 +67,7 @@ export const tablesOverviewConfig: QueryConfig = {
         splitByChar('.', parts.table)[2] AS _table
       FROM parts
       LEFT JOIN detached_parts USING (\`table\`)
+      ORDER BY compressed DESC
     `,
   columns: [
     'table',


### PR DESCRIPTION
## Problem

`/tables-overview?host=0` loads slowly on clusters with many parts/tables — the
same class as the failed/expensive-queries slowness. The page is driven by one
query (it renders **no charts** — `relatedCharts` is empty), so the cost is the
SQL itself plus one nav-badge count query.

## What I found

Two independent `system.parts` scans feed this page:

1. **The page query** (`lib/query-config/tables/tables-overview.ts` + its
   declarative twin) aggregates `system.parts WHERE active` grouped **by a
   formatted string**: `GROUP BY format('{}.{}', database, table)`. ClickHouse
   builds that concatenated grouping key for **every active part row**
   (O(parts)). It also carried a dead `ORDER BY compressed DESC` inside the CTE.
2. **The nav badge** (`lib/api/menu-count-registry.ts`, key `tables-overview`)
   ran `SELECT countDistinct(database || table) FROM system.parts` — a scan of
   **every part, active _and_ inactive**, concatenating a string per row.

The `ORDER BY compressed DESC` also sat **inside** the parts CTE, where the
subsequent LEFT JOIN does not reliably preserve it — and the DataTable starts
with no default sort (`sorting` state `[]`, no `initialState` sort), so rows
render in **server order** on load.

## Changes

### 1. Page query — group by raw columns (per-table `format`, not per-part)

```diff
- FROM system.detached_parts
- GROUP BY 1                       -- key = format('{}.{}', database, table), built per part row
+ FROM system.detached_parts AS dp
+ GROUP BY dp.database, dp.`table` -- key = raw (database, table); format() moves to SELECT, per group
...
- FROM system.parts AS parts
- WHERE active
- GROUP BY 1
- ORDER BY compressed DESC         -- moved OUT of the CTE (see below)
+ FROM system.parts AS parts
+ WHERE active
+ GROUP BY parts.database, parts.`table`
...
  SELECT parts.*, detached_parts.*, …
  FROM parts
  LEFT JOIN detached_parts USING (`table`)
+ ORDER BY compressed DESC         -- runs once over grouped rows (O(tables)); deterministic largest-first
```

`format('{}.{}', …)` stays in the SELECT list, so it is now evaluated **once per
table** instead of once per active part. The `ORDER BY compressed DESC` moves to
the **outer** SELECT: it now sorts the already-grouped rows (O(tables),
negligible) and — because the DataTable applies no default sort — deterministically
preserves the largest-compressed-first default view the inner sort only produced
by luck of join internals. Grouping keys are **qualified**
(`parts.database`, `dp.table`) so the output alias `table` never shadows the
source column — the repo forces the old analyzer
(`allow_experimental_analyzer: 0`), where an unqualified `table` in `GROUP BY`
would bind to the alias and silently undo the optimization (same shadowing class
as #2200). Mirrors the proven idiom already used by `storage-economics.ts` /
`tablesListConfig` (group by raw `database, table`).

**Output columns, `columnFormats`, and the entire outer query are unchanged** —
all 14 UI columns preserved. The declarative catalog copy is kept byte-identical
(guarded by `declarative-parity.test.ts`).

### 2. Nav badge — scan only active parts, count a tuple

```diff
- SELECT countDistinct(database || table) as count FROM system.parts
+ SELECT countDistinct(database, table)  as count FROM system.parts WHERE active
```

Skips inactive parts, drops the per-row string concat, and makes the badge count
the **same set the page shows** (tables with >= 1 active part).

## Expected speedup & honest scope

- The wins are **proportional to part count** but bounded: they remove per-part
  **CPU** (string construction + the badge's inactive-part rows), not the
  unavoidable pass over active-part metadata. Expect a **noticeable but not
  order-of-magnitude** improvement on many-part clusters; small clusters were
  never slow here.
- **The floor is inherent, and not hidden:** 4 columns —
  `max_part_size_compressed/uncompressed`, `primary_keys_size`,
  `latest_modification` — are per-part aggregates that **cannot** come from
  `system.tables` at any version, so the active-parts scan must stay to keep
  those columns. The real order-of-magnitude win would be to **relocate those 4
  deep per-part columns to the `/table` and `/part-info` detail pages the
  overview already links to**, letting the overview run off `system.tables`
  (`total_bytes` / `total_rows` / `active_parts`, all cached). That removes UI
  from the overview, so it's a **product decision — flagging, not doing it
  here** (the task said keep the rendered columns).

## Loading / empty state (part 2)

**No code change needed.** This page uses the shared `createPage` -> `TableClient`
path, whose guard already shows the skeleton first and only renders the
empty-state after loading settles:
`isInitialLoading = isLoading || (isValidating && (!data || data.length === 0))`.
No premature empty-state, no page-specific override. The cross-visit
cached-data/global-caching work is explicitly a separate PR.

## Version compatibility

**None required.** Everything stays on `system.parts`; per
`docs/clickhouse-schemas/tables/parts.md` all referenced columns (`rows`,
`data_compressed_bytes`, `data_uncompressed_bytes`, `primary_key_bytes_in_memory`,
`modification_time`, `active`) exist since 19.x, so **no `since`-versioned SQL**
is introduced. (Staying on `system.parts` also sidesteps the newer, version-gated
`system.tables` aggregate columns — `total_bytes_uncompressed` ~ 24.1,
`parts`/`active_parts`/`total_marks` ~ 23.2.)

## Verification

- `bun test` on the guarding suites — **all green**: `declarative-parity`,
  `sql-regressions` (keeps the `uncompressed / nullIf(compressed, 0)` fragment),
  `background-bar-companions`, `shipped-sql-passes-validator`, `tables-catalog`,
  `flip-safety`, `menu-counts` route.
- `bun run type-check` **229 -> 229** and `type-check:test` **230 -> 230** (error
  sets byte-identical to the pre-change baseline; all pre-existing stale
  `routeTree.gen.ts` cascade). **Zero new errors.**
- No live ClickHouse available locally; relied on proven-in-repo SQL idioms + the
  query-config test suites. CI's query-config tests exercise the SQL against real
  ClickHouse across versions.

Co-Authored-By: duyetbot <bot@duyet.net>
