### PR TITLE
feat(explain): redesign page, add query picker and query_id prefill

### DIFF
--- a/apps/dashboard/src/components/explain/query-picker.tsx
+++ b/apps/dashboard/src/components/explain/query-picker.tsx
@@ -1,0 +1,230 @@
+import { ClockIcon, ListTreeIcon, TimerIcon, ZapIcon } from 'lucide-react'
+
+import { useState } from 'react'
+import { useQueryHistory } from '@/components/sql-console/hooks/use-query-history'
+import { Button } from '@/components/ui/button'
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import { useTableData } from '@/lib/query/use-table-data'
+
+/**
+ * What the picker hands back when a query is chosen.
+ *
+ * - `sql`: full, runnable SQL — used for sources that carry the complete query
+ *   text (the browser's recent history and `system.processes` running queries).
+ * - `queryId`: only an id — used for slow queries, whose stored `query` column
+ *   is truncated to 500 chars (`substr(query, 1, 500)`), so it is not reliably
+ *   runnable. The Explain page resolves the full SQL from `system.query_log` by
+ *   this id via its normal `query_id` prefill path.
+ */
+export type QueryPickSelection = { sql: string } | { queryId: string }
+
+interface QueryPickerProps {
+  hostId: number
+  onSelect: (selection: QueryPickSelection) => void
+}
+
+type Row = Record<string, unknown>
+
+/** Collapse whitespace and cap length for a single-line SQL preview. */
+function preview(sql: string, max = 140): string {
+  const flat = sql.replace(/\s+/g, ' ').trim()
+  return flat.length > max ? `${flat.slice(0, max)}…` : flat
+}
+
+function str(v: unknown): string {
+  return v == null ? '' : String(v)
+}
+
+/** Short relative time from an epoch-ms timestamp, e.g. "3m ago". */
+function timeAgo(ts: number): string {
+  const secs = Math.max(0, Math.round((Date.now() - ts) / 1000))
+  if (secs < 60) return `${secs}s ago`
+  const mins = Math.round(secs / 60)
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.round(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.round(hours / 24)}d ago`
+}
+
+/**
+ * One row in the picker. `value` is a unique, searchable string (cmdk lowercases
+ * it and filters against it) — but selection reads the closed-over `sql`/`queryId`
+ * rather than cmdk's normalized `onSelect` argument, so the real (case-preserving)
+ * SQL is never mangled.
+ */
+function PickItem({
+  value,
+  icon: Icon,
+  text,
+  meta,
+  onChoose,
+}: {
+  value: string
+  icon: React.ComponentType<{ className?: string }>
+  text: string
+  meta?: string
+  onChoose: () => void
+}) {
+  return (
+    <CommandItem value={value} onSelect={onChoose} className="gap-2">
+      <Icon className="size-3.5 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1 truncate font-mono text-[12px]">
+        {text}
+      </span>
+      {meta && (
+        <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+          {meta}
+        </span>
+      )}
+    </CommandItem>
+  )
+}
+
+/**
+ * Picker body. Split out so its data hooks only run while the dialog is open
+ * (the running/slow queries are fetched lazily, not on page load).
+ */
+function QueryPickerContent({
+  hostId,
+  onChoose,
+}: {
+  hostId: number
+  onChoose: (selection: QueryPickSelection) => void
+}) {
+  const { entries } = useQueryHistory()
+  const recent = entries.filter((e) => e.sql.trim()).slice(0, 10)
+
+  const running = useTableData<Row>('running-queries', hostId)
+  const slow = useTableData<Row>('slow-queries', hostId)
+
+  const runningRows = (running.data ?? [])
+    .filter((r) => str(r.query).trim())
+    .slice(0, 10)
+  const slowRows = (slow.data ?? [])
+    .filter((r) => str(r.query).trim() && str(r.query_id).trim())
+    .slice(0, 10)
+
+  const nothing =
+    recent.length === 0 &&
+    runningRows.length === 0 &&
+    slowRows.length === 0 &&
+    !running.isLoading &&
+    !slow.isLoading
+
+  return (
+    <>
+      <CommandInput placeholder="Search recent, running, or slow queries…" />
+      <CommandList>
+        {nothing && <CommandEmpty>No queries found.</CommandEmpty>}
+
+        {recent.length > 0 && (
+          <CommandGroup heading="Recent (this browser)">
+            {recent.map((e, i) => {
+              const p = preview(e.sql)
+              return (
+                <PickItem
+                  key={e.id}
+                  value={`recent-${i} ${p}`}
+                  icon={ClockIcon}
+                  text={p}
+                  meta={timeAgo(e.ts)}
+                  onChoose={() => onChoose({ sql: e.sql })}
+                />
+              )
+            })}
+          </CommandGroup>
+        )}
+
+        {runningRows.length > 0 && (
+          <CommandGroup heading="Running now">
+            {runningRows.map((r, i) => {
+              const sql = str(r.query)
+              const p = preview(sql)
+              const elapsed =
+                str(r.readable_elapsed) ||
+                (r.elapsed != null ? `${Number(r.elapsed).toFixed(1)}s` : '')
+              const user = str(r.user)
+              return (
+                <PickItem
+                  key={`${str(r.query_id)}-${i}`}
+                  value={`running-${i} ${p}`}
+                  icon={ZapIcon}
+                  text={p}
+                  meta={[elapsed, user].filter(Boolean).join(' · ')}
+                  onChoose={() => onChoose({ sql })}
+                />
+              )
+            })}
+          </CommandGroup>
+        )}
+
+        {slowRows.length > 0 && (
+          <CommandGroup heading="Slowest (last 24h)">
+            {slowRows.map((r, i) => {
+              const p = preview(str(r.query))
+              const dur =
+                str(r.readable_query_duration) ||
+                (r.query_duration != null
+                  ? `${Number(r.query_duration).toFixed(2)}s`
+                  : '')
+              const user = str(r.user)
+              return (
+                <PickItem
+                  key={`${str(r.query_id)}-${i}`}
+                  value={`slow-${i} ${p}`}
+                  icon={TimerIcon}
+                  text={p}
+                  meta={[dur, user].filter(Boolean).join(' · ')}
+                  onChoose={() => onChoose({ queryId: str(r.query_id) })}
+                />
+              )
+            })}
+          </CommandGroup>
+        )}
+      </CommandList>
+    </>
+  )
+}
+
+/**
+ * "Pick a query" button + command palette for choosing a query to explain,
+ * sourced from the browser's recent history, currently-running queries, and the
+ * slowest recent queries. Data is fetched lazily when the dialog opens.
+ */
+export function QueryPicker({ hostId, onSelect }: QueryPickerProps) {
+  const [open, setOpen] = useState(false)
+
+  const choose = (selection: QueryPickSelection) => {
+    onSelect(selection)
+    setOpen(false)
+  }
+
+  return (
+    <>
+      <Button
+        size="sm"
+        variant="outline"
+        className="gap-1.5"
+        onClick={() => setOpen(true)}
+      >
+        <ListTreeIcon className="size-3.5" strokeWidth={1.5} />
+        Pick a query
+      </Button>
+      <CommandDialog
+        open={open}
+        onOpenChange={setOpen}
+        title="Pick a query to explain"
+        description="Choose a recent, running, or slow query to load into the editor."
+      >
+        {open && <QueryPickerContent hostId={hostId} onChoose={choose} />}
+      </CommandDialog>
+    </>
+  )
+}

--- a/apps/dashboard/src/components/query-detail/query-detail-view.tsx
+++ b/apps/dashboard/src/components/query-detail/query-detail-view.tsx
@@ -6,6 +6,7 @@ import {
   Database,
   ExternalLink,
   HardDrive,
+  ListTree,
   MemoryStick,
   RowsIcon,
   Server,
@@ -21,6 +22,7 @@ import { buildExplorerQueryUrl } from '@/lib/explorer-url'
 import { formatReadableSize } from '@/lib/format-readable'
 import { useTableData } from '@/lib/query/use-table-data'
 import { useHostId } from '@/lib/swr/use-host'
+import { buildUrl } from '@/lib/url/url-builder'
 import { cn } from '@/lib/utils'
 
 // ──────────────────────────── types ────────────────────────────
@@ -430,14 +432,37 @@ export const QueryDetailView = function QueryDetailView({
             )}
           </div>
 
-          {/* Right: explorer link */}
+          {/* Right: actions */}
           {queryText && (
-            <Button variant="outline" size="sm" className="h-7 gap-1.5" asChild>
-              <Link href={explorerUrl}>
-                <ExternalLink className="size-3.5" />
-                Open in Explorer
-              </Link>
-            </Button>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1.5"
+                asChild
+              >
+                <Link
+                  href={buildUrl('/explain', {
+                    query_id: queryId,
+                    host: hostId,
+                  })}
+                >
+                  <ListTree className="size-3.5" />
+                  Explain query
+                </Link>
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1.5"
+                asChild
+              >
+                <Link href={explorerUrl}>
+                  <ExternalLink className="size-3.5" />
+                  Open in Explorer
+                </Link>
+              </Button>
+            </div>
           )}
         </div>
 

--- a/apps/dashboard/src/routes/(dashboard)/explain.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/explain.tsx
@@ -504,7 +504,9 @@ function ExplainContent() {
                 </code>
                 : {qlError.message}
               </span>
-            ) : (
+            ) : qlRow === null ? (
+              // Settled null = genuinely not found. A found row renders nothing
+              // here: the effect is about to fill the editor and strip the id.
               <span className="text-amber-600 dark:text-amber-400">
                 Query{' '}
                 <code className="bg-muted rounded px-1 text-[11px]">
@@ -516,7 +518,7 @@ function ExplainContent() {
                 </code>{' '}
                 yet — paste its SQL below to explain it.
               </span>
-            )}
+            ) : null}
           </div>
         )}
 
@@ -563,7 +565,7 @@ function ExplainContent() {
           planSettings={planSettings}
           treeRenderable={treeRenderable}
         />
-      ) : (
+      ) : prefillPending ? null : (
         <div className="rounded-xl border border-dashed bg-card/40 px-6 py-10">
           <EmptyState
             variant="no-data"

--- a/apps/dashboard/src/routes/(dashboard)/explain.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/explain.tsx
@@ -2,19 +2,23 @@ import {
   ChevronDownIcon,
   ChevronRightIcon,
   ExternalLinkIcon,
-  InfoCircledIcon,
 } from '@radix-ui/react-icons'
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 
 import { splitSqlStatements } from '@chm/sql-builder'
-import { lazy, Suspense, useMemo, useState } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
 import { ExplainResult } from '@/components/explain/explain-result'
+import {
+  QueryPicker,
+  type QueryPickSelection,
+} from '@/components/explain/query-picker'
 import { ErrorAlert } from '@/components/feedback'
 import { SaveFavoriteButton } from '@/components/query-favorites'
 import { TableSkeleton } from '@/components/skeletons'
+import { useQueryLog } from '@/components/sql-console/hooks/use-query-log'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Label } from '@/components/ui/label'
@@ -335,6 +339,42 @@ function ExplainContent() {
     useState<Record<string, number>>(buildDefaultSettings)
   const [activeQuery, setActiveQuery] = useState('0')
 
+  // ── query_id prefill (deep-link from a query row, or the query picker) ──
+  // Resolve the SQL for ?query_id=<id> from system.query_log and load it into
+  // the editor. Reuses the SQL-console query-log hook, whose lookup matches the
+  // spec: WHERE query_id = <id> AND type != 'QueryStart' ORDER BY event_time
+  // DESC LIMIT 1.
+  const queryIdFromUrl = searchParams.get('query_id')
+  const {
+    data: qlRow,
+    isLoading: qlLoading,
+    error: qlError,
+  } = useQueryLog(hostId, queryIdFromUrl, Boolean(queryIdFromUrl))
+  // Track the last id we prefilled from (not a boolean) so that re-picking a
+  // query after its id was stripped from the URL prefills again.
+  const lastPrefilledId = useRef<string | null>(null)
+
+  useEffect(() => {
+    // Reset the guard once query_id leaves the URL so the next pick re-runs.
+    if (!queryIdFromUrl) lastPrefilledId.current = null
+  }, [queryIdFromUrl])
+
+  useEffect(() => {
+    if (!queryIdFromUrl || lastPrefilledId.current === queryIdFromUrl) return
+    const sql = typeof qlRow?.query === 'string' ? qlRow.query : ''
+    if (!sql.trim()) return
+    lastPrefilledId.current = queryIdFromUrl
+    setQueryInput(sql)
+    setCommittedQuery(sql) // auto-run the current EXPLAIN tab
+    setActiveQuery('0')
+    // Strip query_id from the URL so a refresh — or later manual edits — isn't
+    // clobbered by re-fetching the original query. host / mode are preserved.
+    const params = new URLSearchParams(searchParams.toString())
+    params.delete('query_id')
+    const qs = params.toString()
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
+  }, [queryIdFromUrl, qlRow, pathname, router, searchParams])
+
   const setMode = (newMode: string) => {
     setModeState(newMode)
     const params = new URLSearchParams(searchParams.toString())
@@ -373,76 +413,128 @@ function ExplainContent() {
     setActiveQuery('0')
   }
 
+  // Query picker: recent/running queries carry full SQL (fill the editor
+  // directly); slow queries are stored truncated, so resolve them by query_id
+  // through the prefill path above.
+  const handlePick = (selection: QueryPickSelection) => {
+    if ('sql' in selection) {
+      setQueryInput(selection.sql)
+      setCommittedQuery(selection.sql)
+      setActiveQuery('0')
+      return
+    }
+    const params = new URLSearchParams(searchParams.toString())
+    params.set('query_id', selection.queryId)
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false })
+  }
+
+  // A ?query_id is still resolving to editor content (loading / not-found).
+  const prefillPending =
+    Boolean(queryIdFromUrl) && lastPrefilledId.current !== queryIdFromUrl
+
   return (
     <div className="flex flex-col gap-4">
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-lg">
-            <InfoCircledIcon className="size-5" />
-            Explain Query
-            <div className="ml-auto flex items-center gap-2">
-              <SaveFavoriteButton
-                sql={committedQuery}
-                hostId={hostId}
-                database={null}
-              />
-              <a
-                href="https://clickhouse.com/docs/sql-reference/statements/explain"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-muted-foreground hover:text-foreground text-xs font-normal"
-              >
-                Docs <ExternalLinkIcon className="inline size-3" />
-              </a>
-            </div>
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <Tabs value={mode} onValueChange={setMode}>
-            <div className="overflow-x-auto">
-              <TabsList>
-                {EXPLAIN_MODES.map((m) => (
-                  <TabsTrigger key={m.value} value={m.value}>
-                    {m.label}
-                  </TabsTrigger>
-                ))}
-              </TabsList>
-            </div>
-          </Tabs>
-
-          {!mode && (
-            <PlanSettingsPanel
-              settings={planSettings}
-              onToggle={toggleSetting}
-            />
-          )}
-
-          <div className="space-y-2">
-            <Suspense fallback={<EditorFallback />}>
-              <SqlEditor
-                value={queryInput}
-                onChange={setQueryInput}
-                onRun={handleExplain}
-                placeholder="Enter SQL query to explain..."
-              />
-            </Suspense>
-            <div className="flex items-center justify-between gap-2">
-              <p className="text-muted-foreground text-xs">
-                Press Cmd/Ctrl + Enter to explain. Separate multiple queries
-                with{' '}
-                <code className="bg-muted rounded px-1 text-[11px]">;</code>
-              </p>
-              <Button onClick={handleExplain} disabled={!queryInput.trim()}>
-                Explain
-              </Button>
-            </div>
+      {/* Toolbar: EXPLAIN modes on the left, query actions on the right. The
+          scroll wrapper pins overflow to the x-axis — a bare `overflow-x-auto`
+          also computes `overflow-y` to `auto` and paints a phantom vertical
+          scrollbar; `py-0.5` keeps the tab focus ring from being clipped. */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Tabs value={mode} onValueChange={setMode}>
+          <div className="overflow-x-auto overflow-y-hidden py-0.5">
+            <TabsList>
+              {EXPLAIN_MODES.map((m) => (
+                <TabsTrigger key={m.value} value={m.value}>
+                  {m.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
           </div>
-        </CardContent>
-      </Card>
+        </Tabs>
 
+        <div className="flex items-center gap-2">
+          <QueryPicker hostId={hostId} onSelect={handlePick} />
+          <SaveFavoriteButton
+            sql={committedQuery}
+            hostId={hostId}
+            database={null}
+          />
+          <a
+            href="https://clickhouse.com/docs/sql-reference/statements/explain"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs font-medium"
+          >
+            Docs <ExternalLinkIcon className="size-3" />
+          </a>
+        </div>
+      </div>
+
+      {/* Plan settings (EXPLAIN PLAN only) */}
+      {!mode && (
+        <PlanSettingsPanel settings={planSettings} onToggle={toggleSetting} />
+      )}
+
+      {/* Editor + run bar. The editor is its own bordered, focus-ring surface,
+          so there's no extra card wrapper and no nested-scroll "slop". */}
+      <div className="space-y-2">
+        <Suspense fallback={<EditorFallback />}>
+          <SqlEditor
+            value={queryInput}
+            onChange={setQueryInput}
+            onRun={handleExplain}
+            placeholder="Enter a SQL query to explain, or pick a recent, running, or slow query…"
+          />
+        </Suspense>
+
+        {prefillPending && (
+          <div className="text-xs">
+            {qlLoading ? (
+              <span className="text-muted-foreground">
+                Loading query{' '}
+                <code className="bg-muted rounded px-1 text-[11px]">
+                  {queryIdFromUrl}
+                </code>
+                …
+              </span>
+            ) : qlError ? (
+              <span className="text-amber-600 dark:text-amber-400">
+                Couldn't load query{' '}
+                <code className="bg-muted rounded px-1 text-[11px]">
+                  {queryIdFromUrl}
+                </code>
+                : {qlError.message}
+              </span>
+            ) : (
+              <span className="text-amber-600 dark:text-amber-400">
+                Query{' '}
+                <code className="bg-muted rounded px-1 text-[11px]">
+                  {queryIdFromUrl}
+                </code>{' '}
+                isn't in{' '}
+                <code className="bg-muted rounded px-1 text-[11px]">
+                  system.query_log
+                </code>{' '}
+                yet — paste its SQL below to explain it.
+              </span>
+            )}
+          </div>
+        )}
+
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-muted-foreground text-xs">
+            Press Cmd/Ctrl + Enter to explain. Separate multiple queries with{' '}
+            <code className="bg-muted rounded px-1 text-[11px]">;</code>
+          </p>
+          <Button onClick={handleExplain} disabled={!queryInput.trim()}>
+            Explain
+          </Button>
+        </div>
+      </div>
+
+      {/* Results */}
       {statements.length > 1 ? (
         <Tabs value={activeQuery} onValueChange={setActiveQuery}>
-          <div className="overflow-x-auto">
+          <div className="overflow-x-auto overflow-y-hidden py-0.5">
             <TabsList>
               {statements.map((_, i) => (
                 <TabsTrigger key={i} value={String(i)}>
@@ -471,7 +563,15 @@ function ExplainContent() {
           planSettings={planSettings}
           treeRenderable={treeRenderable}
         />
-      ) : null}
+      ) : (
+        <div className="rounded-xl border border-dashed bg-card/40 px-6 py-10">
+          <EmptyState
+            variant="no-data"
+            title="Nothing to explain yet"
+            description="Enter a SQL query above, or pick a recent, running, or slow query, then press Explain to see its execution plan."
+          />
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## What

Redesign the **Explain Query** page and its entry flow so arriving at a query's
plan is a first-class path, not a copy-paste chore.

### 1. De-slop the layout + fix the phantom scrollbar

**Before:** the whole tool (mode tabs, plan settings, editor, run button) was
wrapped in one big bordered `Card` with a `CardHeader`/`CardTitle`. The tab
strips used a bare `overflow-x-auto`, which — per CSS — also computes
`overflow-y` to `auto`, painting an odd thin **vertical** scrollbar on the right
of the tabs/settings area.

**After:** flat, intentional layout — a toolbar (EXPLAIN modes on the left;
`Pick a query` / Save / Docs on the right), plan settings, the editor as its own
focus-ring surface (no double border), then results. The page title already
lives in the breadcrumb, so the redundant in-card heading is gone. Both tab
strips now use `overflow-x-auto overflow-y-hidden py-0.5` — horizontal scroll on
narrow widths, no phantom vertical bar, focus ring preserved. Every existing
feature is kept: mode tabs, Plan Settings, Save-favorite, Docs link,
multi-statement tabs, and the tree/text toggle.

### 2. Consume `?query_id=<id>` and prefill (fully client-side)

Open `/explain?query_id=<id>&host=<h>` and the page fetches that query's SQL from
`system.query_log` (`WHERE query_id = <id> AND type != 'QueryStart' ORDER BY
event_time DESC LIMIT 1`, via the existing SQL-console query-log hook), prefills
the editor, and **auto-runs the current EXPLAIN tab**. It reads the param
client-side (TanStack Router search params + effects) — no SSR/middleware. After
a successful prefill it strips `query_id` from the URL so a refresh (or manual
edits) aren't clobbered by a re-fetch. Loading / not-found / error are handled
inline; the "not found" copy only shows on a settled miss (a resolved query
never flashes it). It also preserves the existing `?query=<sql>` prefill.

### 3. Pick a query from a list

New **"Pick a query"** command palette (`components/explain/query-picker.tsx`),
sourced lazily (only when opened) from:
- **Recent (this browser)** — local SQL history (full SQL) → fills the editor.
- **Running now** — `system.processes` (full SQL) → fills the editor.
- **Slowest (last 24h)** — `system.query_log`. These are stored **truncated**
  (`substr(query, 1, 500)`), so a slow pick hands back its `query_id` and reuses
  the prefill path above to load the full, runnable SQL.

Selection reads the closed-over row, not cmdk's normalized `onSelect` value, so
SQL casing is never mangled.

### 4. Entry point from a query row

The `/query` detail view gets an **"Explain query"** action next to "Open in
Explorer" that navigates to `/explain?query_id=<id>&host=<host>` — so you jump
from a logged query straight into its plan.

## Flow

`Query detail → "Explain query" → /explain?query_id=… → auto-prefill + run plan`,
or open Explain fresh → **Pick a query** (recent / running / slow) or paste SQL →
Explain.

## Type-check

Captured baseline first. `bun run type-check` and `type-check:test` both show
**zero new errors** vs. baseline (229 / 230 respectively — all pre-existing
`routeTree.gen.ts`/`createFileRoute` noise from the ungenerated route tree; the
one diff line is that same error on `explain.tsx`, shifted as the file grew).
Biome clean on all touched files. No full `bun run build` (per task).

## QA pending (no browser in this environment)

- [ ] No phantom scrollbar on either tab strip, in light + dark, at narrow width.
- [ ] Deep link `/explain?query_id=…&host=…` prefills + auto-runs; `query_id`
      is stripped from the URL afterward.
- [ ] Editing a prefilled query then refreshing does **not** revert it.
- [ ] Picker: recent/running fill instantly; a slow pick resolves full SQL.
- [ ] Bad/never-flushed `query_id` shows the inline "not found" hint (no crash).
- [ ] `/query` "Explain query" button lands on the plan.

> Note: pre-existing unrelated unit failure in `time-range-context.test.tsx`
> (missing `@happy-dom/global-registrator` in the worktree's symlinked
> `node_modules`; `bun install` disallowed here) — not touched by this PR; CI runs
> a real install. No test references the changed files.

Co-Authored-By: duyetbot <bot@duyet.net>
