### PR TITLE
feat(query-metric-log): expandable SQL rows, formatted metrics, sampled-memory chart

### DIFF
--- a/apps/dashboard/src/components/charts/query/query-metric-log-memory.tsx
+++ b/apps/dashboard/src/components/charts/query/query-metric-log-memory.tsx
@@ -1,0 +1,36 @@
+import type { ChartProps } from '@/components/charts/chart-props'
+
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+/**
+ * Sampled query memory from system.query_metric_log.
+ *
+ * Plots the bucketed max(memory_usage) and max(peak_memory_usage) across all
+ * queries over the window — the memory high-water mark as sampled by the metric
+ * log (distinct from `query-memory`, which averages query_log's per-query
+ * memory). Two overlapping, non-stacked byte series (peak >= current, so
+ * stacking would double-count). Defaults to a short 6h window because
+ * query_metric_log retention is typically short.
+ */
+export const ChartQueryMetricLogMemory = createAreaChart({
+  chartName: 'query-metric-log-memory',
+  index: 'event_time',
+  categories: ['memory_usage', 'peak_memory_usage'],
+  defaultTitle: 'Sampled Query Memory',
+  defaultInterval: 'toStartOfFiveMinutes',
+  defaultLastHours: 6,
+  dataTestId: 'query-metric-log-memory-chart',
+  areaChartProps: {
+    stack: false,
+    showLegend: true,
+    showXAxis: true,
+    showCartesianGrid: true,
+    readableColumns: ['readable_memory_usage', 'readable_peak_memory_usage'],
+    yAxisTickFormatter: chartTickFormatters.bytes,
+  },
+})
+
+export type ChartQueryMetricLogMemoryProps = ChartProps
+
+export default ChartQueryMetricLogMemory

--- a/apps/dashboard/src/components/charts/registry/chart-categories.ts
+++ b/apps/dashboard/src/components/charts/registry/chart-categories.ts
@@ -35,6 +35,7 @@ export const CHARTS_BY_CATEGORY: Record<ChartCategory, string[]> = {
     'query-count-by-user',
     'query-duration',
     'query-memory',
+    'query-metric-log-memory',
     'query-type',
     'failed-query-count',
     'failed-query-count-by-user',

--- a/apps/dashboard/src/components/charts/registry/imports/query-charts.ts
+++ b/apps/dashboard/src/components/charts/registry/imports/query-charts.ts
@@ -29,6 +29,11 @@ export const queryChartImports: ChartRegistryMap = {
       default: m.ChartQueryMemory,
     }))
   ),
+  'query-metric-log-memory': lazy(() =>
+    import('@/components/charts/query/query-metric-log-memory').then((m) => ({
+      default: m.ChartQueryMetricLogMemory,
+    }))
+  ),
   'query-type': lazy(() =>
     import('@/components/charts/query/query-type').then((m) => ({
       default: m.ChartQueryType,

--- a/apps/dashboard/src/components/charts/registry/type-hints.ts
+++ b/apps/dashboard/src/components/charts/registry/type-hints.ts
@@ -17,6 +17,7 @@ export const CHART_TYPE_HINTS: Record<string, ChartSkeletonType> = {
   'query-count-by-user': 'bar',
   'query-duration': 'area',
   'query-memory': 'area',
+  'query-metric-log-memory': 'area',
   'query-type': 'bar',
   'failed-query-count': 'area',
   'failed-query-count-by-user': 'bar',

--- a/apps/dashboard/src/components/data-table/cells/create-query-metric-log-expanded-details.tsx
+++ b/apps/dashboard/src/components/data-table/cells/create-query-metric-log-expanded-details.tsx
@@ -1,0 +1,30 @@
+// NOTE: intentionally NOT a 'use client' module and — crucially — free of any
+// static import of hook-using browser code. The query-config registry that
+// references this factory is eagerly imported by server/Worker API routes, so
+// pulling `useHostId`/`useQuery` in at module scope here would evaluate browser
+// code on the server. The real, hook-using panel is loaded with `React.lazy`,
+// so it is only ever fetched in the browser when a user expands a row.
+
+import type { ExpandedRenderer } from '@/types/query-config'
+
+import { lazy, Suspense } from 'react'
+
+const LazyPanel = lazy(() => import('./query-metric-log-expanded-details'))
+
+/**
+ * Factory returning an {@link ExpandedRenderer} for the Query Metric Log table.
+ * Lives in this `.tsx` module so the plain `.ts` query-config can opt into the
+ * bespoke, lazily-fetched row-expand panel without importing JSX (or the panel's
+ * client-only dependencies) itself.
+ */
+export function createQueryMetricLogExpandedDetails(): ExpandedRenderer {
+  return (row) => (
+    <Suspense
+      fallback={
+        <p className="text-xs text-muted-foreground">Loading details…</p>
+      }
+    >
+      <LazyPanel row={row as Record<string, unknown>} />
+    </Suspense>
+  )
+}

--- a/apps/dashboard/src/components/data-table/cells/query-metric-log-expanded-details.tsx
+++ b/apps/dashboard/src/components/data-table/cells/query-metric-log-expanded-details.tsx
@@ -1,0 +1,342 @@
+import {
+  Code2Icon,
+  CpuIcon,
+  DatabaseIcon,
+  GaugeIcon,
+  HardDriveDownloadIcon,
+  MemoryStickIcon,
+  TimerIcon,
+} from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+
+import type { ApiResponse } from '@/lib/api/types'
+
+import {
+  formatReadableQuantity,
+  formatReadableSize,
+} from '@/lib/format-readable'
+import { useHostId } from '@/lib/swr'
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { cn } from '@/lib/utils'
+
+/**
+ * Client-only implementation of the query-metric-log row-expand panel.
+ *
+ * This module uses hooks (`useHostId`, `useQuery`) and must NEVER be pulled
+ * into the server/Worker bundle that eagerly imports the query-config registry.
+ * It is loaded exclusively via `React.lazy` from
+ * `create-query-metric-log-expanded-details.tsx`, so it only ever evaluates in
+ * the browser when a user expands a row.
+ *
+ * `system.query_metric_log` samples per-query resource usage but carries no SQL
+ * text. On expand we look the query up by `query_id` in `system.query_log`
+ * (most-recent row) through the existing `/api/v1/explorer/query-log` endpoint
+ * to reveal the actual SQL plus the read/written/result counters the metric
+ * samples don't capture. query_log flushes asynchronously, so a `null` row means
+ * "not flushed yet" and we poll briefly until it appears.
+ */
+
+type QueryLogRow = Record<string, unknown> & {
+  query?: string
+  query_kind?: string
+  query_duration_ms?: number
+  read_rows?: number
+  read_bytes?: number
+  written_rows?: number
+  written_bytes?: number
+  result_rows?: number
+  result_bytes?: number
+  memory_usage?: number
+  exception?: string
+  databases?: string[]
+  tables?: string[]
+}
+
+interface Props {
+  row: Record<string, unknown>
+}
+
+function hasValue(value: unknown): boolean {
+  return value !== undefined && value !== null && String(value).trim() !== ''
+}
+
+function toStringSafe(value: unknown): string {
+  return hasValue(value) ? String(value) : ''
+}
+
+function toNumberOrNull(value: unknown): number | null {
+  if (!hasValue(value)) return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+/** Prefer a precomputed `readable_<key>` companion, else format the raw value. */
+function readable(
+  row: Record<string, unknown>,
+  key: string,
+  format: (n: number) => string
+): string {
+  const pre = toStringSafe(row[`readable_${key}`])
+  if (pre) return pre
+  const raw = toNumberOrNull(row[key])
+  return raw === null ? '' : format(raw)
+}
+
+/** Humanize a microsecond duration as "s / ms / us". */
+function formatMicros(us: number | null): string {
+  if (us === null) return ''
+  if (us >= 1_000_000) return `${(us / 1_000_000).toFixed(2)} s`
+  if (us >= 1_000) return `${(us / 1_000).toFixed(2)} ms`
+  return `${us} us`
+}
+
+function StatTile({
+  label,
+  value,
+  icon: Icon,
+  mono = false,
+}: {
+  label: string
+  value: string
+  icon?: React.ComponentType<{ className?: string }>
+  mono?: boolean
+}) {
+  if (!value) return null
+  return (
+    <div className="min-w-0 rounded-md border border-border/60 bg-background/60 px-3 py-2.5">
+      <div className="flex items-center gap-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        {Icon && <Icon className="size-3 shrink-0" aria-hidden="true" />}
+        <span className="truncate">{label}</span>
+      </div>
+      <div
+        className={cn(
+          'mt-1 truncate text-sm font-semibold leading-none tabular-nums text-foreground',
+          mono && 'font-mono'
+        )}
+        title={value}
+      >
+        {value}
+      </div>
+    </div>
+  )
+}
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+      {children}
+    </div>
+  )
+}
+
+export default function QueryMetricLogExpandedDetails({ row }: Props) {
+  const hostId = useHostId()
+  const queryId = toStringSafe(row.query_id)
+
+  // The lookup endpoint only serves env-configured hosts (hostId >= 0). Browser
+  // / per-user connections (negative hostId) aren't reachable here yet, so we
+  // skip the fetch and show a clear note instead of surfacing a raw 400.
+  const supported = hostId >= 0
+
+  const { data, isLoading, isError, error } = useQuery<
+    QueryLogRow | null,
+    Error
+  >({
+    queryKey: ['query-metric-log:query-log', hostId, queryId],
+    enabled: supported && Boolean(queryId),
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    retry: false,
+    // query_log is flushed asynchronously; poll until the row shows up.
+    refetchInterval: (q) => (q.state.data ? false : 3_000),
+    queryFn: async () => {
+      const params = new URLSearchParams({
+        hostId: String(hostId),
+        queryId,
+      })
+      const res = await apiFetch(
+        `/api/v1/explorer/query-log?${params.toString()}`
+      )
+      const json = (await res.json()) as ApiResponse<QueryLogRow | null>
+      if (!json.success) {
+        throw new Error(json.error?.message ?? 'Failed to load query')
+      }
+      return json.data ?? null
+    },
+  })
+
+  // ── Metric sample tiles (already in the row) ──────────────────────────────
+  const sampleTiles = (
+    <div>
+      <SectionTitle>Resource sample</SectionTitle>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
+        <StatTile
+          icon={MemoryStickIcon}
+          label="Memory"
+          value={readable(row, 'memory', formatReadableSize)}
+        />
+        <StatTile
+          icon={GaugeIcon}
+          label="Peak memory"
+          value={readable(row, 'peak_memory', formatReadableSize)}
+        />
+        <StatTile
+          icon={CpuIcon}
+          label="CPU time"
+          value={
+            toStringSafe(row.readable_cpu_time) ||
+            formatMicros(toNumberOrNull(row.cpu_time))
+          }
+        />
+        <StatTile
+          icon={TimerIcon}
+          label="Wall time"
+          value={
+            toStringSafe(row.readable_real_time) ||
+            formatMicros(toNumberOrNull(row.real_time))
+          }
+        />
+        <StatTile
+          icon={HardDriveDownloadIcon}
+          label="Selected rows"
+          value={readable(row, 'selected_rows', (n) =>
+            formatReadableQuantity(n)
+          )}
+        />
+      </div>
+    </div>
+  )
+
+  // ── query_log enrichment tiles (fetched) ──────────────────────────────────
+  const logTiles = (() => {
+    if (!data) return null
+    const tiles = [
+      {
+        label: 'Duration',
+        value:
+          data.query_duration_ms != null
+            ? `${(Number(data.query_duration_ms) / 1000).toFixed(2)} s`
+            : '',
+        icon: TimerIcon,
+      },
+      {
+        label: 'Read rows',
+        value:
+          data.read_rows != null
+            ? formatReadableQuantity(Number(data.read_rows))
+            : '',
+        icon: HardDriveDownloadIcon,
+      },
+      {
+        label: 'Read bytes',
+        value:
+          data.read_bytes != null
+            ? formatReadableSize(Number(data.read_bytes))
+            : '',
+        icon: HardDriveDownloadIcon,
+      },
+      {
+        label: 'Written rows',
+        value:
+          data.written_rows != null
+            ? formatReadableQuantity(Number(data.written_rows))
+            : '',
+        icon: DatabaseIcon,
+      },
+      {
+        label: 'Written bytes',
+        value:
+          data.written_bytes != null
+            ? formatReadableSize(Number(data.written_bytes))
+            : '',
+        icon: DatabaseIcon,
+      },
+      {
+        label: 'Result rows',
+        value:
+          data.result_rows != null
+            ? formatReadableQuantity(Number(data.result_rows))
+            : '',
+        icon: HardDriveDownloadIcon,
+      },
+    ].filter((t) => t.value)
+
+    if (tiles.length === 0) return null
+    return (
+      <div>
+        <SectionTitle>Query log</SectionTitle>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-6">
+          {tiles.map((t) => (
+            <StatTile
+              key={t.label}
+              icon={t.icon}
+              label={t.label}
+              value={t.value}
+            />
+          ))}
+        </div>
+      </div>
+    )
+  })()
+
+  // ── SQL section ───────────────────────────────────────────────────────────
+  const sql = toStringSafe(data?.query)
+  const kind = toStringSafe(data?.query_kind)
+  const exception = toStringSafe(data?.exception)
+
+  const sqlSection = (
+    <div>
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <span className="inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          <Code2Icon className="size-3 shrink-0" aria-hidden="true" />
+          Query
+          {kind && (
+            <span className="rounded bg-muted px-1 py-0.5 font-mono text-[9.5px] uppercase text-muted-foreground">
+              {kind}
+            </span>
+          )}
+        </span>
+        {sql && (
+          <span className="whitespace-nowrap text-[10.5px] tabular-nums text-muted-foreground">
+            {sql.length.toLocaleString()} chars
+          </span>
+        )}
+      </div>
+
+      {!supported ? (
+        <p className="text-xs text-muted-foreground">
+          SQL lookup isn't available for browser / per-user connections yet.
+        </p>
+      ) : isLoading ? (
+        <p className="text-xs text-muted-foreground">Loading query…</p>
+      ) : isError ? (
+        <p className="text-xs text-destructive">
+          {error?.message ?? 'Failed to load query.'}
+        </p>
+      ) : sql ? (
+        <pre className="max-h-[220px] overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/60 bg-background/60 px-3 py-2 font-mono text-[11.5px] leading-relaxed text-foreground">
+          {sql}
+        </pre>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          No query text found for this query_id yet — query_log is flushed
+          asynchronously, so it may appear shortly.
+        </p>
+      )}
+
+      {exception && (
+        <p className="mt-2 whitespace-pre-wrap break-words rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 font-mono text-[11px] text-destructive">
+          {exception}
+        </p>
+      )}
+    </div>
+  )
+
+  return (
+    <div data-slot="query-metric-log-expanded" className="space-y-3.5">
+      {sampleTiles}
+      {logTiles}
+      {sqlSection}
+    </div>
+  )
+}

--- a/apps/dashboard/src/lib/api/charts/query-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/query-charts.ts
@@ -116,6 +116,34 @@ export const queryCharts: Record<string, ChartQueryBuilder> = {
     }
   },
 
+  // Sampled memory envelope from system.query_metric_log (per-query samples,
+  // one row per query per sampling interval). Bucketed max(memory) + max(peak)
+  // over the window shows the memory high-water mark across all queries over
+  // time. optional + tableCheck: the table is opt-in and absent on many
+  // servers, so the executor skips it gracefully rather than erroring.
+  'query-metric-log-memory': ({
+    interval = 'toStartOfFiveMinutes',
+    lastHours = 6,
+  }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    return {
+      optional: true,
+      tableCheck: 'system.query_metric_log',
+      query: `
+    SELECT ${applyInterval(interval, 'event_time')},
+           max(memory_usage) AS memory_usage,
+           max(peak_memory_usage) AS peak_memory_usage,
+           formatReadableSize(max(memory_usage)) AS readable_memory_usage,
+           formatReadableSize(max(peak_memory_usage)) AS readable_peak_memory_usage
+    FROM system.query_metric_log
+    ${timeFilter ? `WHERE ${timeFilter}` : ''}
+    GROUP BY event_time
+    ORDER BY event_time ASC
+    SETTINGS max_execution_time = 25
+  `,
+    }
+  },
+
   'query-type': ({ lastHours = 24 }) => {
     const timeFilter = buildTimeFilter(lastHours)
     return {

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/system/query-metric-log.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/system/query-metric-log.ts
@@ -1,38 +1,16 @@
 import type { DeclarativeQueryConfig } from '../../schema'
 
-export const queryMetricLogDeclarative: DeclarativeQueryConfig = {
-  name: 'query-metric-log',
-  description:
-    'Per-query resource usage sampled over each query lifetime from system.query_metric_log',
-  docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_metric_log',
-  refreshInterval: 30_000,
-  // system.query_metric_log is opt-in and may not exist on every server / version
-  optional: true,
-  tableCheck: 'system.query_metric_log',
-  // Pre-aggregate one row per query instead of returning every raw per-interval
-  // sample. system.query_metric_log is high-cardinality (one row per query per
-  // sampling interval), so a raw SELECT can scan enough data to exceed Cloudflare
-  // Worker CPU/memory limits (HTTP 503). Aggregating server-side and bounding
-  // the time window keeps the result small and useful.
-  //
-  // When query_id is provided (e.g. from the "View Resource Timeline" action),
-  // the result is filtered to that single query.
-  defaultParams: {
-    query_id: '',
-    last_hours: '1',
-  },
-  filterParamPresets: [
-    { name: 'Last 1 hour', key: 'last_hours', value: '1' },
-    { name: 'Last 6 hours', key: 'last_hours', value: '6' },
-    { name: 'Last 24 hours', key: 'last_hours', value: '24' },
-  ],
-  sql: `
+// Declarative twin of lib/query-config/system/query-metric-log.ts. The catalog
+// snapshot test deep-equals the serializable fields (sql / columns /
+// columnFormats / sortingFns / relatedCharts) against the imperative config, so
+// this SQL string and those fields must stay byte-identical with it. The
+// imperative-only `expandable` (a bespoke React panel) is intentionally not
+// represented here — it's excluded from the comparison and cannot be expressed
+// declaratively.
+const QUERY_METRIC_LOG_SQL = `
       WITH per_query AS (
         SELECT
           query_id,
-          -- NOT "AS event_time": the new ClickHouse analyzer resolves the WHERE
-          -- column to this aggregate alias (it shadows the raw column) and rejects
-          -- "aggregate function in WHERE". Use a distinct name, re-alias below.
           max(event_time) AS last_event_time,
           max(memory_usage) AS memory_usage,
           max(peak_memory_usage) AS peak_memory_usage,
@@ -47,25 +25,59 @@ export const queryMetricLogDeclarative: DeclarativeQueryConfig = {
       SELECT
         query_id,
         last_event_time AS event_time,
+        memory_usage AS memory,
         formatReadableSize(memory_usage) AS readable_memory,
         round(memory_usage * 100.0 / nullIf(max(memory_usage) OVER (), 0), 2) AS pct_memory,
+        peak_memory_usage AS peak_memory,
         formatReadableSize(peak_memory_usage) AS readable_peak_memory,
         round(peak_memory_usage * 100.0 / nullIf(max(peak_memory_usage) OVER (), 0), 2) AS pct_peak_memory,
         selected_rows,
-        real_time_us,
-        cpu_time_us
+        real_time_us AS real_time,
+        multiIf(real_time_us >= 1000000, concat(toString(round(real_time_us / 1000000, 2)), ' s'),
+                real_time_us >= 1000, concat(toString(round(real_time_us / 1000, 2)), ' ms'),
+                concat(toString(real_time_us), ' us')) AS readable_real_time,
+        round(real_time_us * 100.0 / nullIf(max(real_time_us) OVER (), 0), 2) AS pct_real_time,
+        cpu_time_us AS cpu_time,
+        multiIf(cpu_time_us >= 1000000, concat(toString(round(cpu_time_us / 1000000, 2)), ' s'),
+                cpu_time_us >= 1000, concat(toString(round(cpu_time_us / 1000, 2)), ' ms'),
+                concat(toString(cpu_time_us), ' us')) AS readable_cpu_time,
+        round(cpu_time_us * 100.0 / nullIf(max(cpu_time_us) OVER (), 0), 2) AS pct_cpu_time
       FROM per_query
       ORDER BY event_time DESC
       LIMIT 100
-    `,
+    `
+
+export const queryMetricLogDeclarative: DeclarativeQueryConfig = {
+  name: 'query-metric-log',
+  description:
+    'Per-query resource usage sampled over each query lifetime from system.query_metric_log',
+  docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_metric_log',
+  refreshInterval: 30_000,
+  // system.query_metric_log is opt-in and may not exist on every server / version
+  optional: true,
+  tableCheck: 'system.query_metric_log',
+  defaultParams: {
+    query_id: '',
+    last_hours: '1',
+  },
+  filterParamPresets: [
+    { name: 'Last 1 hour', key: 'last_hours', value: '1' },
+    { name: 'Last 6 hours', key: 'last_hours', value: '6' },
+    { name: 'Last 24 hours', key: 'last_hours', value: '24' },
+  ],
+  // system.query_metric_log landed in ClickHouse 24.5; the columns used here are
+  // stable across every version that ships the table, so a single variant
+  // applies (the executor falls back to the oldest entry on older/unknown
+  // versions, where `optional` + `tableCheck` gate execution).
+  sql: [{ since: '24.5', sql: QUERY_METRIC_LOG_SQL }],
   columns: [
     'query_id',
     'event_time',
     'readable_memory',
     'readable_peak_memory',
     'selected_rows',
-    'real_time_us',
-    'cpu_time_us',
+    'readable_real_time',
+    'readable_cpu_time',
   ],
   columnFormats: {
     query_id: [
@@ -79,7 +91,22 @@ export const queryMetricLogDeclarative: DeclarativeQueryConfig = {
     readable_memory: 'background-bar',
     readable_peak_memory: 'background-bar',
     selected_rows: 'number-short',
-    real_time_us: 'number-short',
-    cpu_time_us: 'number-short',
+    readable_real_time: 'background-bar',
+    readable_cpu_time: 'background-bar',
   },
+  sortingFns: {
+    readable_memory: 'sort_column_using_actual_value',
+    readable_peak_memory: 'sort_column_using_actual_value',
+    readable_real_time: 'sort_column_using_actual_value',
+    readable_cpu_time: 'sort_column_using_actual_value',
+  },
+  relatedCharts: [
+    [
+      'query-metric-log-memory',
+      {
+        title: 'Sampled Query Memory',
+        colSpan: 10,
+      },
+    ],
+  ],
 }

--- a/apps/dashboard/src/lib/query-config/system/query-metric-log.ts
+++ b/apps/dashboard/src/lib/query-config/system/query-metric-log.ts
@@ -1,41 +1,32 @@
-import type { QueryConfig } from '@/types/query-config'
+import type { QueryConfig, VersionedSql } from '@/types/query-config'
 
+import { createQueryMetricLogExpandedDetails } from '@/components/data-table/cells/create-query-metric-log-expanded-details'
 import { ColumnFormat } from '@/types/column-format'
 
-export const queryMetricLogConfig: QueryConfig = {
-  name: 'query-metric-log',
-  description:
-    'Per-query resource usage sampled over each query lifetime from system.query_metric_log',
-  docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_metric_log',
-  refreshInterval: 30_000,
-  // system.query_metric_log is opt-in and may not exist on every server / version
-  optional: true,
-  tableCheck: 'system.query_metric_log',
-  // Pre-aggregate one row per query instead of returning every raw per-interval
-  // sample. system.query_metric_log is high-cardinality (one row per query per
-  // sampling interval), so a raw SELECT can scan enough data to exceed Cloudflare
-  // Worker CPU/memory limits (HTTP 503). Aggregating server-side and bounding
-  // the time window keeps the result small and useful.
-  //
-  // When query_id is provided (e.g. from the "View Resource Timeline" action
-  // on slow/history/expensive query rows), the result is filtered to that single
-  // query so callers see its max resource metrics at a glance.
-  defaultParams: {
-    query_id: '',
-    last_hours: '1',
-  },
-  filterParamPresets: [
-    { name: 'Last 1 hour', key: 'last_hours', value: '1' },
-    { name: 'Last 6 hours', key: 'last_hours', value: '6' },
-    { name: 'Last 24 hours', key: 'last_hours', value: '24' },
-  ],
-  sql: `
+// Shared SQL for the pre-aggregated one-row-per-query view. Kept in a const so
+// the imperative config here and its declarative catalog twin
+// (declarative/catalog/system/query-metric-log.ts) stay byte-identical — the
+// catalog snapshot test deep-equals their `sql` arrays.
+//
+// system.query_metric_log is high-cardinality (one row per query per sampling
+// interval), so a raw SELECT can scan enough data to exceed Cloudflare Worker
+// CPU/memory limits (HTTP 503). Aggregating server-side and bounding the time
+// window keeps the result small and useful. When query_id is provided (e.g.
+// from the "View Resource Timeline" action on slow/history/expensive query
+// rows) the result is filtered to that single query.
+//
+// Column notes:
+//  - `... AS last_event_time` (NOT `AS event_time`): the new analyzer resolves
+//    the WHERE column to an aggregate alias that shadows the raw column and
+//    rejects "aggregate function in WHERE". Use a distinct name, re-alias below.
+//  - each background-bar column ships its stripped base (`memory`, `peak_memory`,
+//    `real_time`, `cpu_time`) so the bar tooltip + magnitude sort read a real
+//    number, plus a `readable_*` display string and a `pct_*` bar width.
+//  - timing profile events are microseconds; humanize to s / ms / us.
+const QUERY_METRIC_LOG_SQL = `
       WITH per_query AS (
         SELECT
           query_id,
-          -- NOT "AS event_time": the new ClickHouse analyzer resolves the WHERE
-          -- column to this aggregate alias (it shadows the raw column) and rejects
-          -- "aggregate function in WHERE". Use a distinct name, re-alias below.
           max(event_time) AS last_event_time,
           max(memory_usage) AS memory_usage,
           max(peak_memory_usage) AS peak_memory_usage,
@@ -50,25 +41,59 @@ export const queryMetricLogConfig: QueryConfig = {
       SELECT
         query_id,
         last_event_time AS event_time,
+        memory_usage AS memory,
         formatReadableSize(memory_usage) AS readable_memory,
         round(memory_usage * 100.0 / nullIf(max(memory_usage) OVER (), 0), 2) AS pct_memory,
+        peak_memory_usage AS peak_memory,
         formatReadableSize(peak_memory_usage) AS readable_peak_memory,
         round(peak_memory_usage * 100.0 / nullIf(max(peak_memory_usage) OVER (), 0), 2) AS pct_peak_memory,
         selected_rows,
-        real_time_us,
-        cpu_time_us
+        real_time_us AS real_time,
+        multiIf(real_time_us >= 1000000, concat(toString(round(real_time_us / 1000000, 2)), ' s'),
+                real_time_us >= 1000, concat(toString(round(real_time_us / 1000, 2)), ' ms'),
+                concat(toString(real_time_us), ' us')) AS readable_real_time,
+        round(real_time_us * 100.0 / nullIf(max(real_time_us) OVER (), 0), 2) AS pct_real_time,
+        cpu_time_us AS cpu_time,
+        multiIf(cpu_time_us >= 1000000, concat(toString(round(cpu_time_us / 1000000, 2)), ' s'),
+                cpu_time_us >= 1000, concat(toString(round(cpu_time_us / 1000, 2)), ' ms'),
+                concat(toString(cpu_time_us), ' us')) AS readable_cpu_time,
+        round(cpu_time_us * 100.0 / nullIf(max(cpu_time_us) OVER (), 0), 2) AS pct_cpu_time
       FROM per_query
       ORDER BY event_time DESC
       LIMIT 100
-    `,
+    `
+
+export const queryMetricLogConfig: QueryConfig = {
+  name: 'query-metric-log',
+  description:
+    'Per-query resource usage sampled over each query lifetime from system.query_metric_log',
+  docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_metric_log',
+  refreshInterval: 30_000,
+  // system.query_metric_log is opt-in and may not exist on every server / version
+  optional: true,
+  tableCheck: 'system.query_metric_log',
+  defaultParams: {
+    query_id: '',
+    last_hours: '1',
+  },
+  filterParamPresets: [
+    { name: 'Last 1 hour', key: 'last_hours', value: '1' },
+    { name: 'Last 6 hours', key: 'last_hours', value: '6' },
+    { name: 'Last 24 hours', key: 'last_hours', value: '24' },
+  ],
+  // Version-aware form. system.query_metric_log landed in ClickHouse 24.5; the
+  // columns used here are stable across every version that ships the table, so a
+  // single variant applies (the executor falls back to the oldest entry on
+  // older/unknown versions, where `optional` + `tableCheck` gate execution).
+  sql: [{ since: '24.5', sql: QUERY_METRIC_LOG_SQL }] as VersionedSql[],
   columns: [
     'query_id',
     'event_time',
     'readable_memory',
     'readable_peak_memory',
     'selected_rows',
-    'real_time_us',
-    'cpu_time_us',
+    'readable_real_time',
+    'readable_cpu_time',
   ],
   columnFormats: {
     query_id: [
@@ -82,7 +107,31 @@ export const queryMetricLogConfig: QueryConfig = {
     readable_memory: ColumnFormat.BackgroundBar,
     readable_peak_memory: ColumnFormat.BackgroundBar,
     selected_rows: ColumnFormat.NumberShort,
-    real_time_us: ColumnFormat.NumberShort,
-    cpu_time_us: ColumnFormat.NumberShort,
+    readable_real_time: ColumnFormat.BackgroundBar,
+    readable_cpu_time: ColumnFormat.BackgroundBar,
   },
+  // Sort the readable/bar columns by their true numeric magnitude (the stripped
+  // base column) rather than the display string.
+  sortingFns: {
+    readable_memory: 'sort_column_using_actual_value',
+    readable_peak_memory: 'sort_column_using_actual_value',
+    readable_real_time: 'sort_column_using_actual_value',
+    readable_cpu_time: 'sort_column_using_actual_value',
+  },
+  // Click-to-expand: reveal the real SQL (looked up by query_id in
+  // system.query_log) plus the read/written/result counters the metric sample
+  // doesn't carry. Rendered by a lazily-loaded, client-only panel.
+  expandable: {
+    renderExpanded: createQueryMetricLogExpandedDetails(),
+  },
+  // Sampled memory envelope over the selected window (from query_metric_log).
+  relatedCharts: [
+    [
+      'query-metric-log-memory',
+      {
+        title: 'Sampled Query Memory',
+        colSpan: 10,
+      },
+    ],
+  ],
 }


### PR DESCRIPTION
## What

Enhances the **Query Metric Log** page (`/query-metric-log`) on three fronts.

### 1. Expandable rows that reveal the real SQL

`system.query_metric_log` rows are per-query resource samples keyed by `query_id` but carry **no SQL text**. Clicking a row now expands a detail panel that looks the query up by `query_id` in **`system.query_log`** (most-recent row) and shows the actual SQL plus the read/written/result counters the metric sample doesn't capture.

- **Join approach:** reuses the existing `GET /api/v1/explorer/query-log?hostId&queryId` endpoint (`ORDER BY event_time DESC LIMIT 1` by `query_id`), so no new API surface. Fetched **lazily** with TanStack Query only when a row is expanded (`ExpandedRow` mounts on expand), and polls until `query_log` flushes (async), then stops.
- **Server-bundle safety:** the query-config registry is eagerly imported by Worker API routes, so the hook-using panel (`useHostId`/`useQuery`) is loaded via `React.lazy` from a thin, hook-free factory — browser code never enters the server bundle.
- Panel shows the metric sample (memory, peak, CPU time, wall time, selected rows) + query_log enrichment (duration, read/written/result rows & bytes) + the SQL, with loading / not-found / error / exception states.

### 2. Formatted columns

Raw metric numbers now render with meaning via `ColumnFormat` in the `QueryConfig`:

| Column | Format |
|---|---|
| `readable_memory`, `readable_peak_memory` | `BackgroundBar` (readable bytes + magnitude bar) |
| `readable_real_time` (wall), `readable_cpu_time` | `BackgroundBar`; microseconds humanized to s / ms / us |
| `selected_rows` | `NumberShort` |
| `query_id` | `Link` to query detail |

Each bar column ships its stripped base + `pct_` companion in SQL and sorts by true numeric magnitude (`sort_column_using_actual_value`).

### 3. Chart

New **Sampled Query Memory** area chart (`query-metric-log-memory`): bucketed `max(memory_usage)` + `max(peak_memory_usage)` over the window from `system.query_metric_log` (the sampled memory high-water mark — distinct from `query-memory`, which averages query_log). Non-stacked byte series, wired via `relatedCharts`.

## Availability / correctness

- Config stays `optional: true` + `tableCheck: 'system.query_metric_log'`, and the chart is likewise `optional` + `tableCheck`, so both degrade gracefully when the opt-in table is absent. SQL is version-aware (`sql: [{ since: '24.5', … }]`).
- **Declarative parity:** the declarative catalog twin mirrors the serializable fields (`sql`/`columns`/`columnFormats`/`sortingFns`/`relatedCharts`) byte-for-byte; the bespoke expandable is imperative-only (excluded from the snapshot parity test by design).
- **Known limitation:** the query_log lookup endpoint only serves env-configured hosts (`hostId >= 0`). On cloud browser / per-user connections (negative hostId) the panel shows a clear note instead of erroring.

## Verification

- `type-check`: **0 new** errors (229 == baseline — all pre-existing stale `routeTree.gen.ts` route-registration errors).
- `type-check:test`: **0 new** errors (230 == baseline).
- `bun test` (structural, ran locally): catalog imperative≡declarative parity, `getQueryConfigByName`, chart-route name, **background-bar companions**, version-compatibility — all green. Biome clean.
- **CI-pending (no local ClickHouse):** `test:query-config` executes SQL against real CH containers. The SQL reuses the original config's proven table + columns plus standard scalar functions.
- **QA-pending:** no browser available — visual/interaction of the expand panel and chart tooltip not exercised.

Co-Authored-By: duyetbot <bot@duyet.net>
