### PR TITLE
feat(user-processes): enrich page with live + windowed per-user query_log activity

### DIFF
--- a/apps/dashboard/src/components/user-processes/index.ts
+++ b/apps/dashboard/src/components/user-processes/index.ts
@@ -1,0 +1,1 @@
+export { UserProcessesView } from './user-processes-view'

--- a/apps/dashboard/src/components/user-processes/user-processes-view.tsx
+++ b/apps/dashboard/src/components/user-processes/user-processes-view.tsx
@@ -1,0 +1,113 @@
+import { Timer } from 'lucide-react'
+
+import { useMemo } from 'react'
+import { PageLayout } from '@/components/layout/query-page'
+import { useTimeRange } from '@/lib/context/time-range-context'
+import { usePathname, useRouter, useSearchParams } from '@/lib/next-compat'
+import { userProcessesConfig } from '@/lib/query-config/tables/user-processes'
+import { cn } from '@/lib/utils'
+
+/** Presets that drive the dynamic `last_hours` window, from the query config. */
+const PRESETS = userProcessesConfig.filterParamPresets ?? []
+
+/**
+ * A single-select chip group bound to the `last_hours` filter param — the same
+ * pattern used by the slow-queries / expensive-queries views. Selecting a chip
+ * rewrites the URL, which re-fetches the table with the new window so the
+ * historical columns recompute.
+ */
+function FilterGroup({
+  groupKey,
+  active,
+  onSelect,
+}: {
+  groupKey: string
+  active: string
+  onSelect: (key: string, value: string) => void
+}) {
+  const options = PRESETS.filter((p) => p.key === groupKey)
+  if (options.length === 0) return null
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="inline-flex items-center gap-1 text-[11px] font-medium text-muted-foreground">
+        <Timer className="size-3.5" />
+        Time window
+      </span>
+      <div className="flex flex-wrap items-center gap-1">
+        {options.map((opt) => {
+          const selected = active === String(opt.value)
+          return (
+            <button
+              key={`${opt.key}-${opt.value}`}
+              type="button"
+              onClick={() => onSelect(opt.key, String(opt.value))}
+              className={cn(
+                'rounded-md border px-2 py-1 text-[11px] font-medium tabular-nums transition-colors',
+                selected
+                  ? 'border-primary bg-primary/10 text-primary'
+                  : 'border-border bg-card text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+              )}
+            >
+              {opt.name}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * UserProcessesView — the User Processes page.
+ *
+ * A dynamic time-window preset bar over the generic {@link PageLayout} table.
+ * The active window (URL `last_hours` param, seeded from the global time-range
+ * picker, default 24h) is passed to the table as a search param so the
+ * per-user `system.query_log` aggregate recomputes. The live `system.processes`
+ * columns are unaffected by the window.
+ */
+export function UserProcessesView() {
+  const { timeRange } = useTimeRange()
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  // URL param wins; otherwise seed from the global picker (defaults to 24h).
+  const lastHours =
+    searchParams.get('last_hours') ?? String(timeRange.lastHours)
+
+  const setFilter = (key: string, value: string) => {
+    const next = new URLSearchParams(searchParams)
+    next.set(key, value)
+    router.replace(`${pathname}?${next.toString()}`, { scroll: false })
+  }
+
+  const tableSearchParams = useMemo(
+    () => ({ last_hours: lastHours }),
+    [lastHours]
+  )
+
+  const activePreset = PRESETS.find((p) => String(p.value) === lastHours)
+  const windowLabel =
+    activePreset?.name.replace(/^Last /, '') ?? `${lastHours}h`
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2 rounded-xl border border-border bg-card px-3 py-2.5">
+        <FilterGroup
+          groupKey="last_hours"
+          active={lastHours}
+          onSelect={setFilter}
+        />
+      </div>
+
+      <PageLayout
+        queryConfig={userProcessesConfig}
+        title="User Processes"
+        description={`Per-user live queries and historical activity over the last ${windowLabel}`}
+        searchParams={tableSearchParams}
+      />
+    </div>
+  )
+}

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/tables/user-processes.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/tables/user-processes.ts
@@ -3,29 +3,133 @@ import type { DeclarativeQueryConfig } from '../../schema'
 export const userProcessesDeclarative: DeclarativeQueryConfig = {
   name: 'user-processes',
   defaultView: 'auto',
-  card: { primary: 'user' },
-  description: 'Per-user memory usage and resource summary',
+  card: {
+    primary: 'user',
+    metrics: [
+      'readable_queries',
+      'current_queries',
+      'readable_memory_usage',
+      'last_query_time',
+    ],
+  },
+  description:
+    'Per-user live queries plus historical activity over the selected window',
   refreshInterval: 30_000,
   optional: true,
-  tableCheck: 'system.user_processes',
+  tableCheck: 'system.query_log',
+  defaultParams: {
+    last_hours: '24',
+  },
+  filterParamPresets: [
+    { name: 'Last 1h', key: 'last_hours', value: '1' },
+    { name: 'Last 6h', key: 'last_hours', value: '6' },
+    { name: 'Last 24h', key: 'last_hours', value: '24' },
+    { name: 'Last 7d', key: 'last_hours', value: '168' },
+  ],
   sql: `
+    WITH
+      live AS (
+        SELECT
+          user,
+          count() AS current_queries,
+          sum(memory_usage) AS memory_usage,
+          max(peak_memory_usage) AS peak_memory_usage
+        FROM system.processes
+        GROUP BY user
+      ),
+      hist AS (
+        SELECT
+          user,
+          count() AS queries,
+          countIf(event_time > now() - interval 1 hour) AS queries_1h,
+          countIf(type IN (3, 4)) AS failed_queries,
+          sum(read_bytes) AS data_scanned,
+          sum(read_rows) AS rows_read,
+          sumIf(query_duration_ms, type = 2) / 1000 AS total_query_duration,
+          sumIf(query_duration_ms, type = 2) / 1000 / nullIf(countIf(type = 2), 0) AS avg_query_duration,
+          max(event_time) AS last_query_time
+        FROM system.query_log
+        WHERE type IN (2, 3, 4)
+          AND event_time > now() - interval {last_hours:UInt64} hour
+        GROUP BY user
+      )
     SELECT
       user,
+      current_queries,
       memory_usage,
       formatReadableSize(memory_usage) AS readable_memory_usage,
       round(memory_usage * 100.0 / nullIf(max(memory_usage) OVER (), 0), 2) AS pct_memory_usage,
       peak_memory_usage,
-      formatReadableSize(peak_memory_usage) AS readable_peak_memory_usage
-    FROM system.user_processes
-    ORDER BY memory_usage DESC
+      formatReadableSize(peak_memory_usage) AS readable_peak_memory_usage,
+      round(peak_memory_usage * 100.0 / nullIf(max(peak_memory_usage) OVER (), 0), 2) AS pct_peak_memory_usage,
+      queries,
+      formatReadableQuantity(queries) AS readable_queries,
+      round(queries * 100.0 / nullIf(max(queries) OVER (), 0), 2) AS pct_queries,
+      queries_1h,
+      failed_queries,
+      data_scanned,
+      formatReadableSize(data_scanned) AS readable_data_scanned,
+      round(data_scanned * 100.0 / nullIf(max(data_scanned) OVER (), 0), 2) AS pct_data_scanned,
+      rows_read,
+      formatReadableQuantity(rows_read) AS readable_rows_read,
+      round(rows_read * 100.0 / nullIf(max(rows_read) OVER (), 0), 2) AS pct_rows_read,
+      total_query_duration,
+      avg_query_duration,
+      last_query_time
+    FROM hist
+    LEFT JOIN live USING (user)
+    ORDER BY queries DESC, current_queries DESC
   `,
-  columns: ['user', 'readable_memory_usage', 'readable_peak_memory_usage'],
+  columns: [
+    'user',
+    'current_queries',
+    'readable_memory_usage',
+    'readable_peak_memory_usage',
+    'readable_queries',
+    'queries_1h',
+    'failed_queries',
+    'readable_data_scanned',
+    'readable_rows_read',
+    'avg_query_duration',
+    'total_query_duration',
+    'last_query_time',
+  ],
   columnFormats: {
     user: 'colored-badge',
+    current_queries: 'number',
     readable_memory_usage: 'background-bar',
+    readable_peak_memory_usage: 'background-bar',
+    readable_queries: 'background-bar',
+    queries_1h: 'number',
+    failed_queries: 'number',
+    readable_data_scanned: 'background-bar',
+    readable_rows_read: 'background-bar',
+    avg_query_duration: 'duration',
+    total_query_duration: 'duration',
+    last_query_time: 'related-time',
+  },
+  columnDescriptions: {
+    current_queries: 'In-flight queries right now (system.processes)',
+    readable_memory_usage:
+      'Live memory used by in-flight queries (system.processes)',
+    readable_peak_memory_usage:
+      'Peak memory across in-flight queries (system.processes)',
+    readable_queries:
+      'Finished + failed queries in the selected window (system.query_log)',
+    queries_1h: 'Queries in the last 1 hour',
+    failed_queries: 'Queries that ended in an exception in the selected window',
+    readable_data_scanned:
+      'Total bytes read from storage in the selected window',
+    readable_rows_read: 'Total rows read in the selected window',
+    avg_query_duration: 'Average duration of successful queries in the window',
+    total_query_duration: 'Total time of successful queries in the window',
+    last_query_time: 'Most recent query activity',
   },
   sortingFns: {
     readable_memory_usage: 'sort_column_using_actual_value',
     readable_peak_memory_usage: 'sort_column_using_actual_value',
+    readable_queries: 'sort_column_using_actual_value',
+    readable_data_scanned: 'sort_column_using_actual_value',
+    readable_rows_read: 'sort_column_using_actual_value',
   },
 }

--- a/apps/dashboard/src/lib/query-config/tables/user-processes.ts
+++ b/apps/dashboard/src/lib/query-config/tables/user-processes.ts
@@ -2,36 +2,160 @@ import type { QueryConfig } from '@/types/query-config'
 
 import { ColumnFormat } from '@/types/column-format'
 
+/**
+ * Per-user activity summary.
+ *
+ * The old version read only `system.processes` (momentary, live-only), so a
+ * user with no in-flight query showed `0.00 B` and the page was near-empty. This
+ * config keeps the live snapshot but drives the table from a per-user aggregate
+ * of `system.query_log`, so every user who ran queries in the selected window
+ * shows real numbers even when idle right now.
+ *
+ * Shape: `hist` (query_log, GROUP BY user) is the base of a LEFT JOIN to `live`
+ * (processes, GROUP BY user). LEFT-from-hist guarantees history-only users
+ * appear (the reported bug). A user whose *only* activity is an in-flight query
+ * with nothing finished in the window is omitted until it finishes — an
+ * acceptable, rare gap (FULL JOIN + USING key coalescing is version-fragile
+ * across 23.8→26.6, so we avoid it).
+ *
+ * The window is dynamic: `{last_hours}` (default 24h) is bound from the
+ * `last_hours` URL param via the preset bar in `user-processes-view.tsx`, so the
+ * historical columns recompute. All referenced query_log columns
+ * (`read_bytes`, `read_rows`, `query_duration_ms`, `type`, `event_time`, `user`,
+ * `memory_usage`) are schema-stable, so a single SQL string covers all versions.
+ */
 export const userProcessesConfig: QueryConfig = {
   name: 'user-processes',
   defaultView: 'auto',
-  card: { primary: 'user' },
-  description: 'Per-user memory usage and resource summary',
+  card: {
+    primary: 'user',
+    metrics: [
+      'readable_queries',
+      'current_queries',
+      'readable_memory_usage',
+      'last_query_time',
+    ],
+  },
+  description:
+    'Per-user live queries plus historical activity over the selected window',
   refreshInterval: 30_000,
-  // system.user_processes may not exist on every server / version
+  // Depends on system.query_log; degrade gracefully if query logging is off.
   optional: true,
-  tableCheck: 'system.user_processes',
-  // BackgroundBar requires base + readable_{column} + pct_{column}
+  tableCheck: 'system.query_log',
+  defaultParams: {
+    last_hours: '24',
+  },
+  filterParamPresets: [
+    { name: 'Last 1h', key: 'last_hours', value: '1' },
+    { name: 'Last 6h', key: 'last_hours', value: '6' },
+    { name: 'Last 24h', key: 'last_hours', value: '24' },
+    { name: 'Last 7d', key: 'last_hours', value: '168' },
+  ],
+  // BackgroundBar requires base + readable_{column} + pct_{column}.
   sql: `
+    WITH
+      live AS (
+        SELECT
+          user,
+          count() AS current_queries,
+          sum(memory_usage) AS memory_usage,
+          max(peak_memory_usage) AS peak_memory_usage
+        FROM system.processes
+        GROUP BY user
+      ),
+      hist AS (
+        SELECT
+          user,
+          count() AS queries,
+          countIf(event_time > now() - interval 1 hour) AS queries_1h,
+          countIf(type IN (3, 4)) AS failed_queries,
+          sum(read_bytes) AS data_scanned,
+          sum(read_rows) AS rows_read,
+          sumIf(query_duration_ms, type = 2) / 1000 AS total_query_duration,
+          sumIf(query_duration_ms, type = 2) / 1000 / nullIf(countIf(type = 2), 0) AS avg_query_duration,
+          max(event_time) AS last_query_time
+        FROM system.query_log
+        WHERE type IN (2, 3, 4)
+          AND event_time > now() - interval {last_hours:UInt64} hour
+        GROUP BY user
+      )
     SELECT
       user,
+      current_queries,
       memory_usage,
       formatReadableSize(memory_usage) AS readable_memory_usage,
       round(memory_usage * 100.0 / nullIf(max(memory_usage) OVER (), 0), 2) AS pct_memory_usage,
       peak_memory_usage,
-      formatReadableSize(peak_memory_usage) AS readable_peak_memory_usage
-    FROM system.user_processes
-    ORDER BY memory_usage DESC
+      formatReadableSize(peak_memory_usage) AS readable_peak_memory_usage,
+      round(peak_memory_usage * 100.0 / nullIf(max(peak_memory_usage) OVER (), 0), 2) AS pct_peak_memory_usage,
+      queries,
+      formatReadableQuantity(queries) AS readable_queries,
+      round(queries * 100.0 / nullIf(max(queries) OVER (), 0), 2) AS pct_queries,
+      queries_1h,
+      failed_queries,
+      data_scanned,
+      formatReadableSize(data_scanned) AS readable_data_scanned,
+      round(data_scanned * 100.0 / nullIf(max(data_scanned) OVER (), 0), 2) AS pct_data_scanned,
+      rows_read,
+      formatReadableQuantity(rows_read) AS readable_rows_read,
+      round(rows_read * 100.0 / nullIf(max(rows_read) OVER (), 0), 2) AS pct_rows_read,
+      total_query_duration,
+      avg_query_duration,
+      last_query_time
+    FROM hist
+    LEFT JOIN live USING (user)
+    ORDER BY queries DESC, current_queries DESC
   `,
-  columns: ['user', 'readable_memory_usage', 'readable_peak_memory_usage'],
+  columns: [
+    'user',
+    'current_queries',
+    'readable_memory_usage',
+    'readable_peak_memory_usage',
+    'readable_queries',
+    'queries_1h',
+    'failed_queries',
+    'readable_data_scanned',
+    'readable_rows_read',
+    'avg_query_duration',
+    'total_query_duration',
+    'last_query_time',
+  ],
   columnFormats: {
     user: ColumnFormat.ColoredBadge,
+    current_queries: ColumnFormat.Number,
     readable_memory_usage: ColumnFormat.BackgroundBar,
-    // readable_peak_memory_usage is already a human-readable string from
-    // formatReadableSize() in SQL, rendered as plain text
+    readable_peak_memory_usage: ColumnFormat.BackgroundBar,
+    readable_queries: ColumnFormat.BackgroundBar,
+    queries_1h: ColumnFormat.Number,
+    failed_queries: ColumnFormat.Number,
+    readable_data_scanned: ColumnFormat.BackgroundBar,
+    readable_rows_read: ColumnFormat.BackgroundBar,
+    avg_query_duration: ColumnFormat.Duration,
+    total_query_duration: ColumnFormat.Duration,
+    last_query_time: ColumnFormat.RelatedTime,
+  },
+  columnDescriptions: {
+    current_queries: 'In-flight queries right now (system.processes)',
+    readable_memory_usage:
+      'Live memory used by in-flight queries (system.processes)',
+    readable_peak_memory_usage:
+      'Peak memory across in-flight queries (system.processes)',
+    readable_queries:
+      'Finished + failed queries in the selected window (system.query_log)',
+    queries_1h: 'Queries in the last 1 hour',
+    failed_queries: 'Queries that ended in an exception in the selected window',
+    readable_data_scanned:
+      'Total bytes read from storage in the selected window',
+    readable_rows_read: 'Total rows read in the selected window',
+    avg_query_duration: 'Average duration of successful queries in the window',
+    total_query_duration: 'Total time of successful queries in the window',
+    last_query_time: 'Most recent query activity',
   },
   sortingFns: {
     readable_memory_usage: 'sort_column_using_actual_value',
     readable_peak_memory_usage: 'sort_column_using_actual_value',
+    readable_queries: 'sort_column_using_actual_value',
+    readable_data_scanned: 'sort_column_using_actual_value',
+    readable_rows_read: 'sort_column_using_actual_value',
   },
 }

--- a/apps/dashboard/src/routes/(dashboard)/user-processes.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/user-processes.tsx
@@ -1,20 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import { Suspense } from 'react'
-import { PageLayout } from '@/components/layout/query-page'
-import { PageSkeleton } from '@/components/skeletons'
-import { userProcessesConfig } from '@/lib/query-config/tables/user-processes'
-
-function UserProcessesPageContent() {
-  return <PageLayout queryConfig={userProcessesConfig} title="User Processes" />
-}
+import { UserProcessesView } from '@/components/user-processes'
 
 function UserProcessesPage() {
-  return (
-    <Suspense fallback={<PageSkeleton />}>
-      <UserProcessesPageContent />
-    </Suspense>
-  )
+  return <UserProcessesView />
 }
 
 export const Route = createFileRoute('/(dashboard)/user-processes')({


### PR DESCRIPTION
## Problem

The **User Processes** page ("Per-user memory usage and resource summary") read
only `system.user_processes` / `system.processes` — a momentary, live-only
snapshot. A user with no in-flight query (e.g. `healthcheck`) showed `0.00 B`,
so the page was near-empty and told you nothing about who actually uses the
cluster.

## What changed

The table is now driven by a **per-user `system.query_log` aggregate**
(`GROUP BY user`) `LEFT JOIN`ed to the live `system.processes` snapshot, so
every user who ran queries in the window shows real numbers even when idle right
now. LEFT-from-history guarantees history-only users appear (the reported bug);
we deliberately avoid `FULL JOIN … USING` because right-only key coalescing is
version-fragile across CH 23.8→26.6.

### Now tracked per user

| Source | Columns |
|--------|---------|
| Live (`system.processes`) | Current in-flight queries, live memory, peak memory |
| Historical (`system.query_log`, windowed) | Queries in window, queries in last 1h, failed (exception) queries, data scanned (`read_bytes`), rows read, avg + total query duration, last-seen time |

Every magnitude column is formatted via `ColumnFormat` — readable
bytes/quantity/duration, with **BackgroundBar** on memory, peak, queries, data
scanned and rows read so you can compare users at a glance. Durations use the
`Duration` format; last-seen uses `RelatedTime`.

### Dynamic time window

A **preset chip bar** (`1h / 6h / 24h / 7d`) sits above the table, reusing the
`FilterGroup` / `filterParamPresets` pattern from the slow-queries /
expensive-queries views. Selecting a window rewrites the `last_hours` URL param
and re-fetches, so the historical columns recompute. The window seeds from the
global time-range picker and defaults to **24h** (so the "Queries" column is the
last-24h count out of the box, with a dedicated last-1h sub-count alongside).
The live `system.processes` columns are unaffected by the window.

All referenced `query_log` columns (`read_bytes`, `read_rows`,
`query_duration_ms`, `type`, `event_time`, `user`, `memory_usage`) are
schema-stable, so a single SQL string covers every supported CH version — no
version variants needed.

## Files

- `lib/query-config/tables/user-processes.ts` — enriched config (+ declarative
  catalog mirror kept in flip-safety parity).
- `components/user-processes/user-processes-view.tsx` — bespoke view with the
  preset bar over the generic `PageLayout` table.
- `routes/(dashboard)/user-processes.tsx` — renders the new view.

## Load / cost note

The `query_log` scan is a low-cardinality `GROUP BY user` (streaming, bounded
memory) over the selected window — the **same cost profile as the existing
slow-queries / expensive-queries pages**, which already scan `query_log` over a
window. The join itself is between two tiny per-user aggregates, so it is not a
heavy join.

## Verification

- `bun run type-check` and `bun run type-check:test`: **zero new errors**.
  Pre-existing failures are all the `routeTree.gen`-absent cascade
  (`createFileRoute(...)` "not assignable to `undefined`") plus one pre-existing
  missing-dev-dep test — none in the changed/new files.
- Declarative parity: `tables-catalog.test.ts` (60 pass / 0 fail) and
  `flip-safety.test.ts` (276 pass / 0 fail) — the declarative variant
  deep-equals the imperative config on every serializable field.

## QA pending (couldn't browser-test in this environment)

- Visual check of the rendered page + preset-bar interaction.
- `readable_*` column header humanization (matches the existing slow-queries
  app-wide behavior for the same prefix).
- `test:query-config` runs this SQL against ClickHouse containers in CI — the
  first live execution of the query (non-blocking check).

Co-Authored-By: duyetbot <bot@duyet.net>
