### PR TITLE
feat(billing): seat-cap invite-time gate (plan 20)

### DIFF
--- a/apps/dashboard/src/components/billing/paywall-host.tsx
+++ b/apps/dashboard/src/components/billing/paywall-host.tsx
@@ -3,15 +3,15 @@
  * (`lib/billing/paywall-store.ts`). Mounted in `DashboardShell` next to
  * `<Toaster />` — same "singleton host at the shell" pattern.
  */
-import { useSyncExternalStore } from 'react'
 
+import { PaywallModal } from './paywall-modal'
+import { useSyncExternalStore } from 'react'
 import {
   getPaywallServerSnapshot,
   getPaywallSnapshot,
   hidePaywall,
   subscribePaywall,
 } from '@/lib/billing/paywall-store'
-import { PaywallModal } from './paywall-modal'
 
 export function usePaywall() {
   return useSyncExternalStore(

--- a/apps/dashboard/src/components/billing/paywall-modal.test.tsx
+++ b/apps/dashboard/src/components/billing/paywall-modal.test.tsx
@@ -4,9 +4,7 @@
  * (see error-classifier.ts) — no DOM rendering here, per this repo's
  * convention of Bun for logic / Cypress for interaction.
  */
-import { describe, expect, test } from 'bun:test'
 
-import { classifyBillingLimit } from '@/lib/api/error-handler/error-classifier'
 import {
   enforcementForReason,
   findNextTier,
@@ -15,6 +13,8 @@ import {
   resolveCurrentPlan,
   resolveUpgradeAction,
 } from './paywall-logic'
+import { describe, expect, test } from 'bun:test'
+import { classifyBillingLimit } from '@/lib/api/error-handler/error-classifier'
 
 describe('classifyBillingLimit', () => {
   test('classifies the nested error-response-builder 402 shape (host limit)', () => {

--- a/apps/dashboard/src/components/billing/paywall-modal.tsx
+++ b/apps/dashboard/src/components/billing/paywall-modal.tsx
@@ -11,11 +11,20 @@
  * (see `paywall-logic.ts:enforcementForReason`). A `deferred` limit shows
  * beta-friendly copy instead — never a false "you must upgrade" claim.
  */
-import { useState } from 'react'
+
 import { toast } from 'sonner'
 
 import type { BillingLimitReason } from '@/lib/api/error-handler/types'
 
+import {
+  enforcementForReason,
+  findNextTier,
+  formatReasonCap,
+  REASON_TITLES,
+  resolveCurrentPlan,
+  resolveUpgradeAction,
+} from './paywall-logic'
+import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -27,14 +36,6 @@ import {
 } from '@/components/ui/dialog'
 import { trackEvent } from '@/lib/analytics/analytics'
 import { openBillingPortal, startCheckout } from '@/lib/billing/use-billing'
-import {
-  enforcementForReason,
-  findNextTier,
-  formatReasonCap,
-  REASON_TITLES,
-  resolveCurrentPlan,
-  resolveUpgradeAction,
-} from './paywall-logic'
 
 export interface PaywallModalProps {
   open: boolean

--- a/apps/dashboard/src/lib/billing/plan-enforcement.ts
+++ b/apps/dashboard/src/lib/billing/plan-enforcement.ts
@@ -79,7 +79,7 @@ export const LIMIT_ENFORCEMENT: Record<LimitKey, Enforcement> = {
   },
   seats: {
     status: 'enforced',
-    gate: 'routes/api/v1/webhooks/clerk.ts organizationMembership.created → checkSeatLimit (rolls back over-limit member)',
+    gate: 'routes/api/v1/org/invite.ts handlePost → preCheckSeatLimit (pre-emptive 402 before the invite is created — the ONLY entry point today is a direct call to this route; the hosted Clerk <OrganizationProfile/> widget cannot be repointed at it, see components/clerk/organization-members.tsx, so its invites still rely solely on the fallback below); routes/api/v1/webhooks/clerk.ts organizationMembership.created → checkSeatLimit (rolls back over-limit member — defense-in-depth fallback, and the ONLY gate the widget invite path currently hits)',
   },
   alertRules: {
     status: 'deferred',

--- a/apps/dashboard/src/lib/billing/seat-enforcement.test.ts
+++ b/apps/dashboard/src/lib/billing/seat-enforcement.test.ts
@@ -1,12 +1,22 @@
 /**
- * Seat-enforcement unit tests — verifies that the `organizationMembership.created`
- * webhook handler correctly gates new members against the plan seat cap.
+ * Seat-enforcement unit tests.
  *
- * The webhook fires *after* Clerk creates the row, so `memberships.data.length`
- * (`count`) already includes the new member (post-addition total). The handler
- * passes the pre-addition count (`count - 1`) to `checkSeatLimit`, which uses
- * `used < limit` ("is there room for one more?"). `admit()` below mirrors that
- * exact call so the tests model the real webhook behaviour.
+ * Two admission points share `checkSeatLimit` but pass a DIFFERENT count,
+ * because they observe the roster at different times:
+ *
+ * - **Invite-time pre-check** (plan 20, `routes/api/v1/org/invite.ts`
+ *   `preCheckSeatLimit`, mirrored below as `preCheckAdmit`) runs BEFORE the
+ *   invite is created — the member does not exist yet, so it passes the LIVE
+ *   count straight through (no `-1`).
+ * - **Webhook rollback** (`routes/api/v1/webhooks/clerk.ts`, `admit` below)
+ *   fires AFTER Clerk has already added the member, so `memberships.data.length`
+ *   (`count`) already includes them (post-addition total) — the handler passes
+ *   the pre-addition count (`count - 1`) to ask the same "room for one more?"
+ *   question against the pre-addition roster.
+ *
+ * Both call `checkSeatLimit`, which uses `used < limit` ("is there room for
+ * one more?"). The functions below mirror each call site's exact arithmetic so
+ * these tests model real behaviour, not a reimplementation that could drift.
  */
 
 import type { Plan } from './plans'
@@ -20,6 +30,11 @@ const { free, pro, enterprise } = BILLING_PLANS
 // Mirrors the webhook: `count` is the post-addition membership total; admission
 // asks whether the pre-addition roster had room for one more.
 const admit = (plan: Plan, count: number) => checkSeatLimit(plan, count - 1)
+
+// Mirrors the invite-time pre-check (routes/api/v1/org/invite.ts
+// preCheckSeatLimit): `currentMembers` is the LIVE, pre-invite count — no `-1`.
+const preCheckAdmit = (plan: Plan, currentMembers: number) =>
+  checkSeatLimit(plan, currentMembers)
 
 describe('seat-enforcement — webhook admission (post-addition count)', () => {
   test('Free (seats=1): count=1 → allowed (first member fits)', () => {
@@ -48,5 +63,34 @@ describe('seat-enforcement — webhook admission (post-addition count)', () => {
     expect(check.unlimited).toBe(true)
     expect(check.limit).toBeNull()
     expect(check.remaining).toBeNull()
+  })
+})
+
+describe('seat-enforcement — invite-time pre-check (live, pre-addition count)', () => {
+  test('Free (seats=1): currentMembers=0 → allowed (room for the first invite)', () => {
+    expect(preCheckAdmit(free, 0).allowed).toBe(true)
+  })
+
+  test('Free (seats=1): currentMembers=1 (at cap) → denied — 402 before any invite is created', () => {
+    const check = preCheckAdmit(free, 1)
+    expect(check.allowed).toBe(false)
+    expect(check.limit).toBe(1)
+    expect(check.remaining).toBe(0)
+    expect(check.reason).toBe('seat_limit')
+  })
+
+  test('Pro (seats=3): currentMembers=2 (seats-1) → allowed — invite proceeds', () => {
+    expect(preCheckAdmit(pro, 2).allowed).toBe(true)
+  })
+
+  test('Pro (seats=3): currentMembers=3 (at cap) → denied — 402 before any invite is created', () => {
+    const check = preCheckAdmit(pro, 3)
+    expect(check.allowed).toBe(false)
+  })
+
+  test('Enterprise (seats=null): any currentMembers → always allowed (unlimited)', () => {
+    const check = preCheckAdmit(enterprise, 1_000)
+    expect(check.allowed).toBe(true)
+    expect(check.unlimited).toBe(true)
   })
 })

--- a/apps/dashboard/src/routes/api/v1/org/invite.test.ts
+++ b/apps/dashboard/src/routes/api/v1/org/invite.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for POST /api/v1/org/invite (plan 20) — the pre-emptive seat-cap gate
+ * that rejects an over-cap invite with a 402 BEFORE any Clerk invitation is
+ * created, plus the auth/role gates and the fail-open path (plan/member-count
+ * resolution throws → invite proceeds ungated, matching self-hosted/OSS
+ * "stays whole").
+ *
+ * mock.module style mirrors routes/api/v1/webhooks/clerk.test.ts: each mocked
+ * export is a stable wrapper delegating to a per-test `let` binding, and
+ * `@clerk/tanstack-react-start/server` is mocked with the full superset of
+ * methods used across the suite (this file adds
+ * `createOrganizationInvitation`) so registration stays order-independent when
+ * CI runs `bun test src/ --isolate`.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { BILLING_PLANS } from '@/lib/billing/plans'
+
+// --- @/lib/audit/logEvent (leaf specifier) ----------------------------------
+let logEventImpl = mock((_e: unknown) => Promise.resolve())
+mock.module('@/lib/audit/logEvent', () => ({
+  logEvent: (e: unknown) => logEventImpl(e),
+}))
+
+// --- @/lib/billing/billing-owner --------------------------------------------
+let resolveBillingOwner = mock(
+  async (): Promise<{ type: 'org' | 'user'; id: string }> => ({
+    type: 'org',
+    id: 'org_1',
+  })
+)
+mock.module('@/lib/billing/billing-owner', () => ({
+  resolveBillingOwner: () => resolveBillingOwner(),
+}))
+
+// --- @/lib/billing/user-subscription ----------------------------------------
+let getPlanForOwner = mock(async (_ownerId: string) => BILLING_PLANS.pro)
+mock.module('@/lib/billing/user-subscription', () => ({
+  isSubscriptionLive: () => true,
+  resolveOwnerSubscription: async () => null,
+  getPlanIdForOwner: async () => 'free' as const,
+  getPlanForOwner: (ownerId: string) => getPlanForOwner(ownerId),
+  getUserPlanId: async () => 'free' as const,
+  getUserPlan: async () => BILLING_PLANS.free,
+}))
+
+// --- @clerk/tanstack-react-start/server -------------------------------------
+let authImpl = mock(async () => ({
+  userId: 'user_admin',
+  orgId: 'org_1',
+  orgRole: 'org:admin' as string | null,
+}))
+let getOrganizationMembershipList = mock(
+  async (_args: { organizationId: string; limit: number }) => ({
+    data: [] as unknown[],
+  })
+)
+let deleteOrganizationMembership = mock(
+  async (_args: { organizationId: string; userId: string }) => ({})
+)
+let usersGetOrganizationMembershipList = mock(
+  async (_args: { userId: string }) => ({ data: [] as unknown[] })
+)
+let createOrganization = mock(
+  async (_args: { name: string; createdBy: string }) => ({ id: 'org_new' })
+)
+let createOrganizationInvitation = mock(
+  async (_args: {
+    organizationId: string
+    emailAddress: string
+    role: string
+    inviterUserId?: string
+  }) => ({ id: 'inv_1' })
+)
+mock.module('@clerk/tanstack-react-start/server', () => ({
+  auth: () => authImpl(),
+  clerkClient: () => ({
+    users: {
+      getOrganizationMembershipList: (args: { userId: string }) =>
+        usersGetOrganizationMembershipList(args),
+    },
+    organizations: {
+      getOrganizationMembershipList: (args: {
+        organizationId: string
+        limit: number
+      }) => getOrganizationMembershipList(args),
+      createOrganization: (args: { name: string; createdBy: string }) =>
+        createOrganization(args),
+      deleteOrganizationMembership: (args: {
+        organizationId: string
+        userId: string
+      }) => deleteOrganizationMembership(args),
+      createOrganizationInvitation: (args: {
+        organizationId: string
+        emailAddress: string
+        role: string
+        inviterUserId?: string
+      }) => createOrganizationInvitation(args),
+    },
+  }),
+}))
+
+const { __handlePostForTests: handlePost } = await import('./invite')
+
+function membershipsOfSize(count: number) {
+  return { data: Array.from({ length: count }) }
+}
+
+function makeRequest(body: unknown = { emailAddress: 'new@example.com' }) {
+  return new Request('https://dash.example.com/api/v1/org/invite', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  logEventImpl = mock(() => Promise.resolve())
+  resolveBillingOwner = mock(async () => ({ type: 'org', id: 'org_1' }))
+  getPlanForOwner = mock(async () => BILLING_PLANS.pro) // seats: 3
+  authImpl = mock(async () => ({
+    userId: 'user_admin',
+    orgId: 'org_1',
+    orgRole: 'org:admin',
+  }))
+  getOrganizationMembershipList = mock(async () => ({ data: [] }))
+  deleteOrganizationMembership = mock(async () => ({}))
+  usersGetOrganizationMembershipList = mock(async () => ({ data: [] }))
+  createOrganization = mock(async () => ({ id: 'org_new' }))
+  createOrganizationInvitation = mock(async () => ({ id: 'inv_1' }))
+})
+
+describe('POST /api/v1/org/invite — auth gates', () => {
+  test('401 when there is no signed-in billing owner', async () => {
+    resolveBillingOwner = mock(async () => {
+      throw new Error('unauthenticated')
+    })
+
+    const res = await handlePost(makeRequest())
+
+    expect(res.status).toBe(401)
+    expect(createOrganizationInvitation).not.toHaveBeenCalled()
+  })
+
+  test('403 when the billing owner is a user, not an org', async () => {
+    resolveBillingOwner = mock(async () => ({
+      type: 'user' as const,
+      id: 'user_solo',
+    }))
+
+    const res = await handlePost(makeRequest())
+
+    expect(res.status).toBe(403)
+    expect(createOrganizationInvitation).not.toHaveBeenCalled()
+  })
+
+  test('403 when the caller is not an org admin', async () => {
+    authImpl = mock(async () => ({
+      userId: 'user_member',
+      orgId: 'org_1',
+      orgRole: 'org:member',
+    }))
+
+    const res = await handlePost(makeRequest())
+
+    expect(res.status).toBe(403)
+    expect(createOrganizationInvitation).not.toHaveBeenCalled()
+  })
+
+  test('400 when emailAddress is missing', async () => {
+    const res = await handlePost(makeRequest({}))
+
+    expect(res.status).toBe(400)
+    expect(createOrganizationInvitation).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/v1/org/invite — pre-emptive seat gate', () => {
+  test('at cap (currentMembers === seats): 402 reason seat_limit BEFORE the invite is created', async () => {
+    getOrganizationMembershipList = mock(async () => membershipsOfSize(3)) // Pro: seats=3
+
+    const res = await handlePost(makeRequest())
+    const body = (await res.json()) as {
+      error: { details?: { reason?: string } }
+    }
+
+    expect(res.status).toBe(402)
+    expect(body.error.details?.reason).toBe('seat_limit')
+    expect(createOrganizationInvitation).not.toHaveBeenCalled()
+    expect(logEventImpl.mock.calls[0]?.[0]).toMatchObject({
+      orgId: 'org_1',
+      event: 'member.invited',
+      action: 'invite',
+      result: 'denied',
+    })
+  })
+
+  test('at seats-1: allowed — the Clerk invitation is created', async () => {
+    getOrganizationMembershipList = mock(async () => membershipsOfSize(2)) // Pro: seats=3
+
+    const res = await handlePost(makeRequest())
+
+    expect(res.status).toBe(200)
+    expect(createOrganizationInvitation).toHaveBeenCalledTimes(1)
+    expect(createOrganizationInvitation).toHaveBeenCalledWith({
+      organizationId: 'org_1',
+      emailAddress: 'new@example.com',
+      role: 'org:member',
+      inviterUserId: 'user_admin',
+    })
+    expect(logEventImpl.mock.calls[0]?.[0]).toMatchObject({
+      result: 'success',
+    })
+  })
+
+  test('enterprise plan (seats: null) bypasses the seat check entirely', async () => {
+    getPlanForOwner = mock(async () => BILLING_PLANS.enterprise)
+
+    const res = await handlePost(makeRequest())
+
+    expect(res.status).toBe(200)
+    expect(getOrganizationMembershipList).not.toHaveBeenCalled()
+    expect(createOrganizationInvitation).toHaveBeenCalledTimes(1)
+  })
+
+  test('fail-open: plan/member resolution throws (no Clerk) → invite proceeds, no 402', async () => {
+    getPlanForOwner = mock(async () => {
+      throw new Error('Clerk not configured')
+    })
+
+    const res = await handlePost(makeRequest())
+
+    expect(res.status).toBe(200)
+    expect(createOrganizationInvitation).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/org/invite.ts
+++ b/apps/dashboard/src/routes/api/v1/org/invite.ts
@@ -1,0 +1,222 @@
+/**
+ * POST /api/v1/org/invite — seat-cap invite-time gate (plan 20).
+ *
+ * Checks the org's seat cap BEFORE creating a Clerk organization invitation,
+ * so an over-cap invite is rejected with a 402 (`details.reason: 'seat_limit'`,
+ * classified client-side as `'seat'` by `classifyBillingLimit` — see
+ * lib/api/error-handler/error-classifier.ts) instead of admitting the member
+ * and rolling them back afterward.
+ *
+ * This is the PRIMARY, pre-emptive enforcement path. The
+ * `organizationMembership.created` webhook rollback
+ * (routes/api/v1/webhooks/clerk.ts) stays as defense-in-depth for any
+ * membership added via a path that bypasses this route (e.g. a direct Clerk
+ * Dashboard add, or a future invite surface that doesn't call this endpoint).
+ *
+ * KNOWN GAP: today NOTHING in the app calls this route yet. The org "Invite"
+ * UI is Clerk's hosted `<OrganizationProfile/>` widget
+ * (components/clerk/organization-members.tsx), which issues invitations
+ * directly from the browser via Clerk's own Frontend API and cannot be
+ * repointed at a custom endpoint (`customPages` on the widget only ADDS pages,
+ * it cannot replace the built-in Members-tab invite flow). So real UI invites
+ * still rely solely on the webhook rollback until the widget is replaced with
+ * a custom invite UI wired to this route — a separate, larger follow-up.
+ *
+ * Auth: requires a signed-in org admin. Mirrors
+ * routes/api/v1/audit/export.ts — no `member:manage` RBAC permission exists
+ * yet (lib/rbac/rbac.ts), so this composes the org-admin Clerk role directly.
+ * The org id is always session-derived via `resolveBillingOwner()`, never a
+ * request param, so a caller can only ever invite into their own org.
+ *
+ * Fail-open (self-hosted/OSS stays whole): plan resolution + member-count
+ * enumeration is wrapped in `preCheckSeatLimit`, which returns `null` — "skip
+ * the check" — on ANY failure there (Clerk not configured, Clerk API hiccup).
+ * A seat-check failure can never block an invite; it can only under-enforce,
+ * matching the fail-safe convention used by `countOwnerHosts`
+ * (lib/billing/org-host-count.ts).
+ */
+import { createFileRoute } from '@tanstack/react-router'
+
+import type { BillingOwner } from '@/lib/billing/billing-owner'
+import type { LimitCheck } from '@/lib/billing/entitlements'
+
+import { auth } from '@clerk/tanstack-react-start/server'
+import { createErrorResponse as createApiErrorResponse } from '@/lib/api/error-handler'
+import { ApiErrorType } from '@/lib/api/types'
+import { logEvent } from '@/lib/audit/logEvent'
+import { resolveBillingOwner } from '@/lib/billing/billing-owner'
+import { checkSeatLimit, limitMessage } from '@/lib/billing/entitlements'
+import { getPlanForOwner } from '@/lib/billing/user-subscription'
+
+const ROUTE = { route: '/api/v1/org/invite', method: 'POST' }
+
+interface InviteRequest {
+  emailAddress: string
+  role?: string
+}
+
+function unauthorized(message: string): Response {
+  return createApiErrorResponse(
+    { type: ApiErrorType.PermissionError, message },
+    401,
+    ROUTE
+  )
+}
+
+function forbidden(message: string): Response {
+  return createApiErrorResponse(
+    { type: ApiErrorType.PermissionError, message },
+    403,
+    ROUTE
+  )
+}
+
+function badRequest(message: string): Response {
+  return createApiErrorResponse(
+    { type: ApiErrorType.ValidationError, message },
+    400,
+    ROUTE
+  )
+}
+
+/** The 402 response shape the plan-15 `PaywallModal` classifies as `reason: 'seat'`. */
+function seatLimitResponse(check: LimitCheck): Response {
+  return createApiErrorResponse(
+    {
+      type: ApiErrorType.PermissionError,
+      message: limitMessage(check),
+      details: {
+        planId: check.planId,
+        limit: check.limit ?? undefined,
+        reason: check.reason,
+      },
+    },
+    402,
+    ROUTE
+  )
+}
+
+/**
+ * Pre-check the org's seat cap for one more invite. Returns `null` when the
+ * check should be SKIPPED — the plan is unlimited, or plan/member-count
+ * resolution threw (most commonly: Clerk isn't configured). Never throws.
+ *
+ * At invite time the new member has NOT been added yet, so this passes the
+ * LIVE member count to `checkSeatLimit` (no `-1`) — unlike the post-hoc
+ * webhook rollback in webhooks/clerk.ts, which fires after Clerk has already
+ * added the member and so subtracts one to ask the same "room for one more?"
+ * question against the pre-addition roster.
+ */
+async function preCheckSeatLimit(orgId: string): Promise<LimitCheck | null> {
+  try {
+    const plan = await getPlanForOwner(orgId)
+    if (plan.seats == null) return null // unlimited — nothing to check
+
+    const { clerkClient } = await import('@clerk/tanstack-react-start/server')
+    const memberships =
+      await clerkClient().organizations.getOrganizationMembershipList({
+        organizationId: orgId,
+        limit: 100,
+      })
+
+    return checkSeatLimit(plan, memberships.data.length)
+  } catch {
+    return null
+  }
+}
+
+async function handlePost(request: Request): Promise<Response> {
+  let owner: BillingOwner
+  try {
+    owner = await resolveBillingOwner()
+  } catch {
+    return unauthorized('Authentication is required to invite a teammate.')
+  }
+
+  if (owner.type !== 'org') {
+    return forbidden('An active organization is required to invite teammates.')
+  }
+
+  const authResult = await auth()
+  const orgRole = (authResult as { orgRole?: string | null } | null)?.orgRole
+  if (orgRole !== 'org:admin') {
+    return forbidden('Only organization admins can invite teammates.')
+  }
+
+  let body: Partial<InviteRequest>
+  try {
+    body = (await request.json()) as Partial<InviteRequest>
+  } catch {
+    return badRequest('Request body must be valid JSON')
+  }
+
+  const emailAddress = body.emailAddress?.trim()
+  if (!emailAddress) {
+    return badRequest('emailAddress is required')
+  }
+  const role = body.role?.trim() || 'org:member'
+
+  const orgId = owner.id
+  const userId = authResult?.userId ?? null
+
+  const check = await preCheckSeatLimit(orgId)
+  if (check && !check.allowed) {
+    await logEvent({
+      orgId,
+      userId,
+      event: 'member.invited',
+      resource: emailAddress,
+      action: 'invite',
+      result: 'denied',
+    })
+    return seatLimitResponse(check)
+  }
+
+  const { clerkClient } = await import('@clerk/tanstack-react-start/server')
+  let invitation: { id: string }
+  try {
+    invitation = await clerkClient().organizations.createOrganizationInvitation(
+      {
+        organizationId: orgId,
+        emailAddress,
+        role,
+        inviterUserId: userId ?? undefined,
+      }
+    )
+  } catch (err) {
+    return createApiErrorResponse(
+      {
+        type: ApiErrorType.QueryError,
+        message:
+          err instanceof Error ? err.message : 'Failed to create invitation',
+      },
+      500,
+      ROUTE
+    )
+  }
+
+  await logEvent({
+    orgId,
+    userId,
+    event: 'member.invited',
+    resource: emailAddress,
+    action: 'invite',
+    result: 'success',
+  })
+
+  return Response.json(
+    { success: true, invitationId: invitation.id },
+    { status: 200 }
+  )
+}
+
+export const Route = createFileRoute('/api/v1/org/invite')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})
+
+// Exported for unit tests only.
+export { handlePost as __handlePostForTests }

--- a/apps/dashboard/src/routes/api/v1/webhooks/clerk.test.ts
+++ b/apps/dashboard/src/routes/api/v1/webhooks/clerk.test.ts
@@ -89,8 +89,9 @@ mock.module('@/lib/billing/user-subscription', () => ({
 // adds organizations.deleteOrganizationMembership and keeps
 // organizations.getOrganizationMembershipList (org-host-count.test.ts) plus
 // users.getOrganizationMembershipList / organizations.createOrganization
-// (polar.test.ts) so registration for this shared specifier is
-// order-independent.
+// (polar.test.ts) plus auth / organizations.createOrganizationInvitation
+// (routes/api/v1/org/invite.test.ts) so registration for this shared
+// specifier is order-independent.
 let getOrganizationMembershipList = mock(
   async (_args: { organizationId: string; limit: number }) => ({
     data: [] as unknown[],
@@ -105,7 +106,16 @@ let usersGetOrganizationMembershipList = mock(
 let createOrganization = mock(
   async (_args: { name: string; createdBy: string }) => ({ id: 'org_new' })
 )
+const createOrganizationInvitation = mock(
+  async (_args: {
+    organizationId: string
+    emailAddress: string
+    role: string
+    inviterUserId?: string
+  }) => ({ id: 'inv_1' })
+)
 mock.module('@clerk/tanstack-react-start/server', () => ({
+  auth: async () => ({ userId: 'user_admin', orgId: 'org_1' }),
   clerkClient: () => ({
     users: {
       getOrganizationMembershipList: (args: { userId: string }) =>
@@ -122,6 +132,12 @@ mock.module('@clerk/tanstack-react-start/server', () => ({
         organizationId: string
         userId: string
       }) => deleteOrganizationMembership(args),
+      createOrganizationInvitation: (args: {
+        organizationId: string
+        emailAddress: string
+        role: string
+        inviterUserId?: string
+      }) => createOrganizationInvitation(args),
     },
   }),
 }))

--- a/apps/dashboard/src/routes/api/v1/webhooks/clerk.ts
+++ b/apps/dashboard/src/routes/api/v1/webhooks/clerk.ts
@@ -6,6 +6,13 @@
  * member would push the org over its plan's seat limit, the membership is
  * rolled back synchronously via Clerk's deleteOrganizationMembership API.
  *
+ * DEFENSE-IN-DEPTH, NOT THE PRIMARY GATE (plan 20): the primary, pre-emptive
+ * seat check now lives at invite time — routes/api/v1/org/invite.ts rejects an
+ * over-cap invite with a 402 BEFORE any member is created, so the normal invite
+ * flow never reaches this rollback. This handler stays wired for any path that
+ * bypasses that pre-check (e.g. a member added directly via the Clerk
+ * Dashboard) — do not remove it.
+ *
  * All other events are acknowledged (202) without action.
  * 501 when CLERK_WEBHOOK_SECRET is unset. 403 on bad signature.
  * 500 on unexpected handler errors (Clerk will retry with backoff).
@@ -13,7 +20,8 @@
  * Unauthenticated by design — the signature IS the auth.
  *
  * Registry gate: routes/api/v1/webhooks/clerk.ts
- *   organizationMembership.created → checkSeatLimit (rollback over-limit member)
+ *   organizationMembership.created → checkSeatLimit (rollback over-limit member;
+ *   fallback — see routes/api/v1/org/invite.ts for the primary pre-check)
  */
 import { createFileRoute } from '@tanstack/react-router'
 


### PR DESCRIPTION
## Summary

Executes `plans/20-seat-cap-invite-time-gate.md`: adds a server-side seat-cap **pre-check** that rejects an over-cap invite with a 402 (`details.reason: 'seat_limit'`, classified client-side as `'seat'` by the existing `classifyBillingLimit` — so the plan-15 `PaywallModal` renders it) **before** any Clerk organization invitation is created.

- New route `POST /api/v1/org/invite` (`apps/dashboard/src/routes/api/v1/org/invite.ts`):
  - Session-derived org id via `resolveBillingOwner()` (never a request param) + org-admin role check (mirrors `routes/api/v1/audit/export.ts`).
  - `preCheckSeatLimit(orgId)`: resolves plan + live member count, calls `checkSeatLimit(plan, currentMembers)` — **no `-1`**, since the invite hasn't been created yet (unlike the post-hoc webhook, which subtracts one because it fires after Clerk already added the member).
  - **Fail-open**: any failure resolving plan/members (Clerk not configured, API hiccup) skips the check entirely and lets the invite proceed — self-hosted/OSS stays whole.
  - On pass, calls Clerk's `createOrganizationInvitation` directly.
- `apps/dashboard/src/routes/api/v1/webhooks/clerk.ts`: **unchanged behavior** — added a comment marking the existing `organizationMembership.created` rollback as defense-in-depth now that the new route is primary.
- `apps/dashboard/src/lib/billing/plan-enforcement.ts`: updated the `seats` gate string to name both the new pre-check and the webhook fallback (and to be explicit about the current gap below).
- Tests: extended `seat-enforcement.test.ts` with invite-time (no `-1`) cases; new `invite.test.ts` covers auth/role gates, at-cap 402, at-`seats-1` success, unlimited-plan bypass, and the fail-open path.

## Known scope gap (please read before assuming this is "live")

**Nothing in the app calls this route yet.** The actual "Invite" UI is Clerk's hosted `<OrganizationProfile/>` widget (`components/clerk/organization-members.tsx`), which issues invitations directly from the browser via Clerk's Frontend API. I verified (`@clerk/shared` types) that the widget's `customPages` prop is **additive-only** — it cannot replace or intercept the built-in Members-tab invite flow. So real UI invites still go through Clerk directly and remain covered **solely** by the existing webhook rollback (add-then-remove), unchanged by this PR.

This is documented in the route's docblock and in the `plan-enforcement.ts` gate string, so "advertised ⟺ enforced" stays honest: `seats` is enforced (a real pre-check exists and is tested), but the pre-check's only entry point today is a direct call to this route. Fully closing the gap — paywall-on-invite-click in the actual UI — requires replacing the hosted widget with a custom invite UI wired to this endpoint. That's a larger follow-up, out of scope for this plan's Effort: S.

Two more minor honesty notes for the fallback path (both already true today, unchanged): `memberships.data.length` is capped at `limit: 100`, and pending-but-unaccepted invitations aren't counted toward either check.

## Verification (plan's block, run clean)

```
cd apps/dashboard && bun run type-check   # ✅ tsc --noEmit, no errors
cd apps/dashboard && bun run build        # ✅ vite build + tsc --noEmit, all routes prerendered
cd apps/dashboard && bun test src/lib/billing/seat-enforcement.test.ts --isolate
# ✅ 10 pass, 0 fail, 20 expect() calls
bun run lint                              # ✅ biome lint ., clean
```

Also ran (not in the plan's block, but relevant): `invite.test.ts` (8/8), `clerk.test.ts` (unchanged, 7/7 still pass), and the full pre-push hook (`bun run check` + `bun run test:unit` + `bun run test:packages` — 896 tests, 0 fail).

## Separate commit in this PR

`style(billing): fix pre-existing import-order drift in plan-15 paywall files` — mechanical `biome check --write` fix (import sort order only, no behavior change) for `paywall-modal.tsx` / `paywall-host.tsx` / `paywall-modal.test.tsx`. These were flagged by `bun run check` (the pre-push hook's stricter Biome pass, which includes `organizeImports`) but not by `bun run lint`; confirmed pre-existing on `origin/main` (byte-identical before the fix) and unrelated to plan 20, bundled here only because it was blocking the push.

## Test plan
- [x] `bun run type-check`
- [x] `bun run build`
- [x] `bun test src/lib/billing/seat-enforcement.test.ts --isolate`
- [x] `bun run lint`
- [x] `bun test src/routes/api/v1/org/invite.test.ts src/routes/api/v1/webhooks/clerk.test.ts --isolate`
- [x] Full pre-push hook (`bun run check`, `bun run test:unit`, `bun run test:packages`)