### PR TITLE
feat(agents): open MCP "Connect" entries in dialogs

### DIFF
--- a/apps/dashboard/src/components/agents/welcome/add-mcp-server-dialog.tsx
+++ b/apps/dashboard/src/components/agents/welcome/add-mcp-server-dialog.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+/**
+ * AddMcpServerDialog
+ *
+ * Hosts the "Connect new server" registration form in a shadcn Dialog.
+ * Previously this form rendered inline beneath the MCP server list in
+ * AgentMcpPanel; it now opens as a dialog so the panel stays compact and the
+ * flow matches the other "Connect" entries.
+ *
+ * The registered server is persisted to localStorage by useMcpConfig (via the
+ * caller's onAdd). As noted in AgentMcpPanel, custom servers are a stored user
+ * preference and are not yet wired to the agent runtime.
+ */
+
+import { PlugZapIcon } from 'lucide-react'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+
+/** A custom server the user is about to register. */
+export interface AddServerInput {
+  name: string
+  endpoint: string
+}
+
+interface AddMcpServerDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onAdd: (server: AddServerInput) => void
+}
+
+export function AddMcpServerDialog({
+  open,
+  onOpenChange,
+  onAdd,
+}: AddMcpServerDialogProps) {
+  const [name, setName] = useState('')
+  const [url, setUrl] = useState('')
+
+  const trimmedName = name.trim()
+  const trimmedUrl = url.trim()
+  const canSubmit = trimmedName.length > 0 && trimmedUrl.length > 0
+
+  const inputClass = cn(
+    'bg-background border-input h-9 w-full rounded-md border px-3 text-[13px]',
+    'placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring'
+  )
+
+  // Reset the fields whenever the dialog closes so a re-open starts clean.
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setName('')
+      setUrl('')
+    }
+    onOpenChange(next)
+  }
+
+  const handleSubmit = () => {
+    if (!canSubmit) return
+    onAdd({ name: trimmedName, endpoint: trimmedUrl })
+    handleOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-base">
+            <PlugZapIcon className="size-4" strokeWidth={1.6} />
+            Connect new server
+          </DialogTitle>
+          <DialogDescription className="text-[12.5px]">
+            Register a custom MCP server by name and endpoint URL.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form
+          className="space-y-3"
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleSubmit()
+          }}
+        >
+          <div className="space-y-1.5">
+            <label
+              htmlFor="mcp-server-name"
+              className="text-muted-foreground text-[11px] font-medium"
+            >
+              Server name
+            </label>
+            <input
+              id="mcp-server-name"
+              type="text"
+              placeholder="my-mcp-server"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className={inputClass}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label
+              htmlFor="mcp-server-url"
+              className="text-muted-foreground text-[11px] font-medium"
+            >
+              Endpoint URL
+            </label>
+            <input
+              id="mcp-server-url"
+              type="url"
+              placeholder="https://…"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              className={inputClass}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => handleOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={!canSubmit}>
+              Connect
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/dashboard/src/components/agents/welcome/agent-mcp-panel.tsx
+++ b/apps/dashboard/src/components/agents/welcome/agent-mcp-panel.tsx
@@ -24,6 +24,10 @@ import { PlusIcon, Trash2Icon, WrenchIcon } from 'lucide-react'
 
 import type { McpServer } from './mcp-types'
 
+import {
+  AddMcpServerDialog,
+  type AddServerInput,
+} from './add-mcp-server-dialog'
 import { McpToolsResourcesDialog } from './mcp-tools-resources-dialog'
 import { useState } from 'react'
 import { Badge } from '@/components/ui/badge'
@@ -32,7 +36,6 @@ import { Switch } from '@/components/ui/switch'
 import { toMcpServers, useMcpConfig } from '@/lib/hooks/use-mcp-config'
 import { useMcpProbe } from '@/lib/swr/use-mcp-probe'
 import { useMcpServerInfo } from '@/lib/swr/use-mcp-server-info'
-import { cn } from '@/lib/utils'
 
 // Re-exported for existing consumers; canonical definition lives in mcp-types.ts.
 export type { McpServer }
@@ -157,87 +160,6 @@ function McpServerRow({
 }
 
 // ---------------------------------------------------------------------------
-// "Connect new server" form
-// ---------------------------------------------------------------------------
-
-/** A custom server the user is about to register. */
-interface AddServerInput {
-  name: string
-  endpoint: string
-}
-
-interface AddServerFormProps {
-  onCancel: () => void
-  onAdd: (server: AddServerInput) => void
-}
-
-function AddServerForm({ onCancel, onAdd }: AddServerFormProps) {
-  const [name, setName] = useState('')
-  const [url, setUrl] = useState('')
-
-  const trimmedName = name.trim()
-  const trimmedUrl = url.trim()
-  const canSubmit = trimmedName.length > 0 && trimmedUrl.length > 0
-
-  const inputClass = cn(
-    'bg-background border-input h-8 w-full rounded-md border px-3 text-[12px]',
-    'placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring'
-  )
-
-  const handleSubmit = () => {
-    if (!canSubmit) return
-    onAdd({ name: trimmedName, endpoint: trimmedUrl })
-  }
-
-  return (
-    <form
-      className="border-border mt-2 space-y-2 rounded-md border p-2.5"
-      onSubmit={(e) => {
-        e.preventDefault()
-        handleSubmit()
-      }}
-    >
-      <p className="text-muted-foreground text-[10.5px] font-medium tracking-wide uppercase">
-        New server
-      </p>
-      <input
-        type="text"
-        placeholder="Server name"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        className={inputClass}
-      />
-      <input
-        type="url"
-        placeholder="Endpoint URL (https://…)"
-        value={url}
-        onChange={(e) => setUrl(e.target.value)}
-        className={inputClass}
-      />
-      <div className="flex items-center gap-2">
-        <Button
-          type="submit"
-          size="sm"
-          className="h-7 flex-1 text-[11.5px]"
-          disabled={!canSubmit}
-        >
-          Connect
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="h-7 flex-1 text-[11.5px]"
-          onClick={onCancel}
-        >
-          Cancel
-        </Button>
-      </div>
-    </form>
-  )
-}
-
-// ---------------------------------------------------------------------------
 // Custom server row — probes the endpoint to get live status + tool list
 // ---------------------------------------------------------------------------
 
@@ -291,7 +213,7 @@ export function AgentMcpPanel() {
     addServer,
     removeServer,
   } = useMcpConfig()
-  const [showAddForm, setShowAddForm] = useState(false)
+  const [addServerOpen, setAddServerOpen] = useState(false)
   const [selectedServer, setSelectedServer] = useState<McpServer | null>(null)
 
   // Derive real connection status for the built-in server from the
@@ -324,8 +246,8 @@ export function AgentMcpPanel() {
   }
 
   const handleAddServer = (server: AddServerInput) => {
+    // The dialog closes itself on submit; the panel only needs to persist.
     addServer(server)
-    setShowAddForm(false)
   }
 
   const panelStatus =
@@ -384,24 +306,23 @@ export function AgentMcpPanel() {
         )}
       </div>
 
-      {/* Add server form / button */}
-      {showAddForm ? (
-        <AddServerForm
-          onCancel={() => setShowAddForm(false)}
-          onAdd={handleAddServer}
-        />
-      ) : (
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="mt-1 h-8 w-full justify-center gap-1.5 text-[11.5px]"
-          onClick={() => setShowAddForm(true)}
-        >
-          <PlusIcon className="size-3" />
-          Connect new server
-        </Button>
-      )}
+      {/* Connect new server — opens a registration dialog */}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="mt-1 h-8 w-full justify-center gap-1.5 text-[11.5px]"
+        onClick={() => setAddServerOpen(true)}
+      >
+        <PlusIcon className="size-3" />
+        Connect new server
+      </Button>
+
+      <AddMcpServerDialog
+        open={addServerOpen}
+        onOpenChange={setAddServerOpen}
+        onAdd={handleAddServer}
+      />
     </div>
   )
 }

--- a/apps/dashboard/src/components/agents/welcome/agent-settings-sidebar.tsx
+++ b/apps/dashboard/src/components/agents/welcome/agent-settings-sidebar.tsx
@@ -25,6 +25,7 @@ import type { Skill } from '@/components/agents/welcome/skills-data'
 import { useEffect, useState } from 'react'
 import { AgentMcpPanel } from '@/components/agents/welcome/agent-mcp-panel'
 import { AgentModelPicker } from '@/components/agents/welcome/agent-model-picker'
+import { McpConnectAgentDialog } from '@/components/agents/welcome/mcp-connect-agent-dialog'
 import { SkillDetailDialog } from '@/components/agents/welcome/skill-detail-dialog'
 import { SkillsLibraryDialog } from '@/components/agents/welcome/skills-library-dialog'
 import { SUGGESTED_PROMPTS } from '@/components/agents/welcome/suggested-prompts'
@@ -45,7 +46,6 @@ import {
   CONVERSATION_BACKEND_LABELS,
   useConversationBackend,
 } from '@/lib/hooks/use-conversation-backend'
-import { useHostId } from '@/lib/swr/use-host'
 import { cn } from '@/lib/utils'
 
 interface AgentSettingsSidebarProps {
@@ -74,7 +74,7 @@ export function AgentSettingsSidebar({
   const topSkills = skills.slice(0, 3)
   const [skillDetail, setSkillDetail] = useState<Skill | null>(null)
   const [libraryOpen, setLibraryOpen] = useState(false)
-  const hostId = useHostId()
+  const [connectOpen, setConnectOpen] = useState(false)
 
   // The parent opens this sidebar via a post-mount effect (`!isMobile`), so the
   // very first commit on desktop transitions `open` false → true. Animating the
@@ -116,9 +116,10 @@ export function AgentSettingsSidebar({
         <AgentMcpPanel />
         {/* For users who run their own agent/IDE and want to point it at this
             cluster's MCP endpoint directly. */}
-        <a
-          href={`/mcp?host=${hostId}`}
-          className="text-muted-foreground hover:text-foreground hover:bg-muted/40 mt-1.5 flex items-center gap-2 rounded-md border border-dashed px-3 py-2 text-[11.5px] transition-colors"
+        <button
+          type="button"
+          onClick={() => setConnectOpen(true)}
+          className="text-muted-foreground hover:text-foreground hover:bg-muted/40 mt-1.5 flex w-full items-center gap-2 rounded-md border border-dashed px-3 py-2 text-left text-[11.5px] transition-colors"
         >
           <PlugZapIcon className="size-3.5 shrink-0" />
           <span className="min-w-0 flex-1">
@@ -130,7 +131,7 @@ export function AgentSettingsSidebar({
             </span>
           </span>
           <ArrowRightIcon className="size-3 shrink-0" />
-        </a>
+        </button>
       </SidebarSection>
 
       {/* SKILLS */}
@@ -237,6 +238,8 @@ export function AgentSettingsSidebar({
       />
 
       <SkillsLibraryDialog open={libraryOpen} onOpenChange={setLibraryOpen} />
+
+      <McpConnectAgentDialog open={connectOpen} onOpenChange={setConnectOpen} />
     </>
   )
 

--- a/apps/dashboard/src/components/agents/welcome/mcp-connect-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/welcome/mcp-connect-agent-dialog.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+/**
+ * McpConnectAgentDialog
+ *
+ * Shows how to point an external agent / IDE at THIS cluster's MCP endpoint:
+ * the endpoint URL, per-client setup guides, and example prompts. Opened from
+ * the "Connect your own agent" entry in the agent settings sidebar (previously
+ * a link that navigated away to the full /mcp page).
+ *
+ * Reuses the same building blocks as the standalone /mcp page — McpEndpointUrl,
+ * McpSetupGuides, McpExamplePrompts — so the two surfaces stay in sync. Layout
+ * mirrors mcp-tools-resources-dialog.tsx: p-0 content, muted header, plain
+ * ScrollArea body (the reused Cards sit on a neutral surface, not card-on-card).
+ */
+
+import { ArrowRightIcon, PlugZapIcon } from 'lucide-react'
+
+import { McpEndpointUrl } from '@/components/mcp/mcp-endpoint-url'
+import { McpExamplePrompts } from '@/components/mcp/mcp-example-prompts'
+import { McpSetupGuides } from '@/components/mcp/mcp-setup-guides'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { useHostId } from '@/lib/swr/use-host'
+
+interface McpConnectAgentDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function McpConnectAgentDialog({
+  open,
+  onOpenChange,
+}: McpConnectAgentDialogProps) {
+  // Hook at the deepest consumer: the dialog owns the host link itself rather
+  // than having the sidebar prop-drill it in.
+  const hostId = useHostId()
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl overflow-hidden p-0">
+        {/* Header — mirrors mcp-tools-resources-dialog muted header */}
+        <DialogHeader className="border-b bg-muted/30 px-5 py-4 text-left">
+          <div className="flex items-start gap-3">
+            <div className="bg-background border-border inline-flex size-10 shrink-0 items-center justify-center rounded-xl border">
+              <PlugZapIcon
+                className="text-foreground size-4"
+                strokeWidth={1.6}
+              />
+            </div>
+            <div className="min-w-0 flex-1 space-y-1">
+              <DialogTitle className="text-base">
+                Connect your own agent
+              </DialogTitle>
+              <DialogDescription className="text-left text-[12.5px] leading-snug">
+                Use this cluster&apos;s MCP endpoint in your IDE or tooling.
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        {/* Body */}
+        <ScrollArea className="max-h-[80dvh]">
+          <div className="space-y-5 p-5">
+            {/* Endpoint URL */}
+            <div className="space-y-1.5">
+              <p className="text-muted-foreground text-[10.5px] font-semibold tracking-wider uppercase">
+                Endpoint URL
+              </p>
+              <McpEndpointUrl />
+            </div>
+
+            {/* Per-client setup guides */}
+            <McpSetupGuides />
+
+            {/* Copy-to-clipboard example prompts */}
+            <McpExamplePrompts />
+
+            {/* Escape hatch to the full page for tool docs + live playground */}
+            <a
+              href={`/mcp?host=${hostId}`}
+              className="text-muted-foreground hover:text-foreground hover:bg-muted/40 flex items-center gap-2 rounded-md border border-dashed px-3 py-2 text-[11.5px] transition-colors"
+            >
+              <span className="min-w-0 flex-1">
+                Open the full MCP page for tool docs and a live playground.
+              </span>
+              <ArrowRightIcon className="size-3 shrink-0" />
+            </a>
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## What

The two **Connect** entries in the Agent settings → MCP Servers section now open **dialogs** instead of navigating away / rendering inline.

### 1. "Connect your own agent"
- **Before:** a sidebar link that navigated to the full `/mcp` page (`<a href="/mcp?host=…">`).
- **Now:** a button that opens `McpConnectAgentDialog` — a shadcn `Dialog` showing this cluster's **MCP endpoint URL + per-client setup guides + example prompts**, reusing the existing `McpEndpointUrl` / `McpSetupGuides` / `McpExamplePrompts` components (kept in sync with `/mcp`). Chrome mirrors `mcp-tools-resources-dialog.tsx` (`p-0` content, muted header, plain `ScrollArea` body so the reused Cards sit on a neutral surface). A footer link still reaches the full `/mcp` page for tool docs + a live playground. The dialog owns its host link via `useHostId()` (hooks-at-deepest-consumer), so the now-orphaned `hostId`/`useHostId` were removed from the sidebar.

### 2. "Connect new server"
- **Before:** the button toggled an **inline** registration form (`AddServerForm`) rendered under the server list.
- **Now:** the button opens `AddMcpServerDialog` — the same registration form hosted in a shadcn `Dialog` (name + endpoint URL → persisted to localStorage via `useMcpConfig`, unchanged).
- **Investigation (as requested):** there is **no** MCP-registry page/route on this branch (grepped `apps/dashboard/src/routes`, `components/mcp`, `components/agents` for `mcp-servers` / `registerServer` / `registry` — clean; `plans/43-mcp-custom-server-registry.md` is backlog only). So the form was **neither page-coupled nor missing** — the existing localStorage-backed form is simply moved into the dialog. Custom servers remain a stored user preference (not yet wired to the agent runtime), unchanged by this move.

## Verification
- **Type-check delta: 0 new errors.** Baseline `bun run type-check` = 230, `type-check:test` = 231 (all pre-existing `routes/*` / `routeTree.gen.ts` errors); post-change counts are identical, and none of the touched files appear in the error output.
- Followed the design system; **no `components/ui/*` edits**. New files: `mcp-connect-agent-dialog.tsx`, `add-mcp-server-dialog.tsx`.
- **QA pending:** could not browser-test in this environment — visual/interaction QA of both dialogs (incl. the mobile Drawer, where the dialogs render alongside the existing skill dialogs) is still to be done.

Co-Authored-By: duyetbot <bot@duyet.net>