### PR TITLE
feat(explorer): copy-friendly names, DDL beautify toggle, compact Indexes tab

### DIFF
--- a/apps/dashboard/src/components/explorer/explorer-breadcrumb.tsx
+++ b/apps/dashboard/src/components/explorer/explorer-breadcrumb.tsx
@@ -1,6 +1,7 @@
 import { Database, Server, Table as TableIcon } from 'lucide-react'
 
 import { useExplorerState } from './hooks/use-explorer-state'
+import { CopyButton } from '@/components/mcp/copy-button'
 import { AppLink as Link } from '@/components/ui/app-link'
 import {
   Breadcrumb,
@@ -10,6 +11,10 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb'
+
+/** Small, quiet copy affordance revealed on hover of its breadcrumb crumb. */
+const CRUMB_COPY_CLASS =
+  'size-6 p-0 text-muted-foreground opacity-0 transition-opacity group-hover/crumb:opacity-100 focus-visible:opacity-100'
 
 interface ExplorerBreadcrumbProps {
   hostName?: string
@@ -36,7 +41,7 @@ export function ExplorerBreadcrumb({ hostName }: ExplorerBreadcrumbProps) {
         {database && (
           <>
             <BreadcrumbSeparator />
-            <BreadcrumbItem>
+            <BreadcrumbItem className="group/crumb">
               {table ? (
                 <BreadcrumbLink asChild>
                   <Link
@@ -53,6 +58,7 @@ export function ExplorerBreadcrumb({ hostName }: ExplorerBreadcrumbProps) {
                   {database}
                 </BreadcrumbPage>
               )}
+              <CopyButton text={database} className={CRUMB_COPY_CLASS} />
             </BreadcrumbItem>
           </>
         )}
@@ -60,11 +66,12 @@ export function ExplorerBreadcrumb({ hostName }: ExplorerBreadcrumbProps) {
         {table && (
           <>
             <BreadcrumbSeparator />
-            <BreadcrumbItem>
+            <BreadcrumbItem className="group/crumb">
               <BreadcrumbPage className="flex items-center gap-1.5">
                 <TableIcon className="size-3.5" />
                 {table}
               </BreadcrumbPage>
+              <CopyButton text={table} className={CRUMB_COPY_CLASS} />
             </BreadcrumbItem>
           </>
         )}

--- a/apps/dashboard/src/components/explorer/explorer-content.tsx
+++ b/apps/dashboard/src/components/explorer/explorer-content.tsx
@@ -24,7 +24,7 @@ interface ExplorerContentProps {
 // Track which tabs have been visited for this table to enable pre-loading
 function useTabVisitTracker(tableKey: string | null, currentTab: ExplorerTab) {
   const [visitedTabs, setVisitedTabs] = useState<Set<ExplorerTab>>(
-    () => new Set<ExplorerTab>(['overview', 'data', currentTab])
+    () => new Set<ExplorerTab>(['overview', currentTab])
   )
   const prevTableKey = useRef<string | null>(null)
 
@@ -32,7 +32,7 @@ function useTabVisitTracker(tableKey: string | null, currentTab: ExplorerTab) {
   // biome-ignore lint/correctness/useExhaustiveDependencies: currentTab is only used to seed the set on table reset
   useEffect(() => {
     if (tableKey !== prevTableKey.current) {
-      setVisitedTabs(new Set<ExplorerTab>(['overview', 'data', currentTab]))
+      setVisitedTabs(new Set<ExplorerTab>(['overview', currentTab]))
       prevTableKey.current = tableKey
     }
   }, [tableKey])
@@ -130,13 +130,16 @@ export function ExplorerContent({ hostName }: ExplorerContentProps) {
           {visitedTabs.has('overview') && <OverviewTab />}
         </TabsContent>
 
-        {/* Data tab: always force-mounted to preserve pagination state */}
+        {/* Data tab: render only once visited so the first paint on the
+            default Overview tab doesn't fire a hidden `SELECT * ... LIMIT`
+            preview against the user's table. Once opened it stays force-mounted,
+            preserving pagination state when switching tabs. */}
         <TabsContent
           value="data"
           className={cn('mt-4', tab !== 'data' && 'hidden flex-none')}
           forceMount
         >
-          <DataTab />
+          {visitedTabs.has('data') && <DataTab />}
         </TabsContent>
 
         {/* Structure tab: don't force-mount due to complex filter state */}

--- a/apps/dashboard/src/components/explorer/explorer-empty-state.tsx
+++ b/apps/dashboard/src/components/explorer/explorer-empty-state.tsx
@@ -23,8 +23,16 @@ import { cn } from '@/lib/utils'
 interface Database {
   name: string
   engine: string
-  item_count: number
 }
+
+interface DatabaseCount {
+  name: string
+  item_count: number | string
+}
+
+// Schema shape changes rarely; skip refetching the database list on every
+// remount of the empty-state within this window.
+const SCHEMA_STALE_TIME = 5 * 60_000
 
 function getDatabaseIcon(engine: string): {
   icon: LucideIcon
@@ -79,28 +87,47 @@ interface ApiResponse<T> {
   metadata?: Record<string, unknown>
 }
 
-const fetcher = async (url: string): Promise<ApiResponse<Database[]>> => {
+const fetcher = async <T,>(url: string): Promise<ApiResponse<T>> => {
   const res = await apiFetch(url)
   if (!res.ok) {
     throw new Error(`Failed to fetch databases: ${res.statusText}`)
   }
-  return res.json() as Promise<ApiResponse<Database[]>>
+  return res.json() as Promise<ApiResponse<T>>
 }
 
 export function ExplorerEmptyState() {
   const hostId = useHostId()
   const { setDatabase, setTab } = useExplorerState()
-  const queryKey = [`/api/v1/explorer/databases?hostId=${hostId}`]
+  const databasesUrl = `/api/v1/explorer/databases?hostId=${hostId}`
   const {
     data: response,
     error,
     isLoading,
   } = useQuery<ApiResponse<Database[]>>({
-    queryKey,
-    queryFn: () => fetcher(`/api/v1/explorer/databases?hostId=${hostId}`),
+    queryKey: [databasesUrl],
+    queryFn: () => fetcher<Database[]>(databasesUrl),
+    staleTime: SCHEMA_STALE_TIME,
+  })
+
+  // Table counts stream in separately so the database cards can paint on names
+  // immediately instead of waiting on a cluster-wide system.tables enumeration.
+  const countsUrl = `/api/v1/tables/explorer-database-counts?hostId=${hostId}`
+  const { data: countsResponse, isLoading: countsLoading } = useQuery<
+    ApiResponse<DatabaseCount[]>
+  >({
+    queryKey: [countsUrl],
+    queryFn: () => fetcher<DatabaseCount[]>(countsUrl),
+    staleTime: SCHEMA_STALE_TIME,
   })
 
   const databases = response?.data
+
+  const countByName = new Map<string, number>(
+    (countsResponse?.data ?? []).map((row) => [
+      row.name,
+      Number(row.item_count),
+    ])
+  )
 
   return (
     <div className="flex h-full flex-col gap-6 p-8">
@@ -157,6 +184,7 @@ export function ExplorerEmptyState() {
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {databases.map((db) => {
               const { icon: Icon, color, bg } = getDatabaseIcon(db.engine)
+              const count = countByName.get(db.name)
               return (
                 <Card
                   key={db.name}
@@ -177,9 +205,13 @@ export function ExplorerEmptyState() {
                     </div>
                     <div className="flex-1 min-w-0">
                       <p className="font-medium truncate">{db.name}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {db.item_count} {db.item_count === 1 ? 'item' : 'items'}
-                      </p>
+                      {count === undefined && countsLoading ? (
+                        <Skeleton className="mt-1 h-3 w-12" />
+                      ) : (
+                        <p className="text-xs text-muted-foreground">
+                          {count ?? 0} {count === 1 ? 'item' : 'items'}
+                        </p>
+                      )}
                     </div>
                   </div>
                 </Card>

--- a/apps/dashboard/src/components/explorer/tabs/ddl-tab.tsx
+++ b/apps/dashboard/src/components/explorer/tabs/ddl-tab.tsx
@@ -1,13 +1,16 @@
-import { Check, Copy } from 'lucide-react'
+import { Check, Copy, SparklesIcon } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 
 import { useExplorerState } from '../hooks/use-explorer-state'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { Switch } from '@/components/ui/switch'
+import { formatSql } from '@/lib/sql-format'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { useHostId } from '@/lib/swr/use-host'
+import { dedent } from '@/lib/utils'
 
 interface DdlRow {
   create_table_query: string
@@ -26,60 +29,14 @@ const fetcher = async (url: string): Promise<ApiResponse<DdlRow[]>> => {
   return res.json()
 }
 
-/**
- * Simple SQL formatter for ClickHouse DDL statements.
- * Adds line breaks and indentation for readability.
- */
-function formatSql(sql: string): string {
-  if (!sql) return sql
-
-  // Keywords that should start on a new line (no indent)
-  const topLevelKeywords = [
-    'CREATE TABLE',
-    'CREATE MATERIALIZED VIEW',
-    'CREATE VIEW',
-    'CREATE DICTIONARY',
-    'ENGINE',
-    'ORDER BY',
-    'PARTITION BY',
-    'PRIMARY KEY',
-    'SAMPLE BY',
-    'TTL',
-    'SETTINGS',
-    'COMMENT',
-  ]
-
-  // Keywords that should start on a new line (with indent)
-  const indentedKeywords = ['TO', 'AS SELECT', 'AS']
-
-  let formatted = sql.trim()
-
-  // Add newline before top-level keywords
-  topLevelKeywords.forEach((keyword) => {
-    const regex = new RegExp(`\\s+(${keyword})\\b`, 'gi')
-    formatted = formatted.replace(regex, `\n$1`)
-  })
-
-  // Add newline and indent before certain keywords
-  indentedKeywords.forEach((keyword) => {
-    const regex = new RegExp(`\\s+(${keyword})\\b`, 'gi')
-    formatted = formatted.replace(regex, `\n  $1`)
-  })
-
-  // Format column definitions - add newline after opening paren in CREATE TABLE
-  formatted = formatted.replace(/\(\s*`/g, '(\n  `')
-  formatted = formatted.replace(/,\s*`/g, ',\n  `')
-
-  // Close the column list on its own line
-  formatted = formatted.replace(/`\s*\)\s*(ENGINE)/gi, '`\n)\n$1')
-
-  return formatted
-}
-
 export function DdlTab() {
   const hostId = useHostId()
   const { database, table } = useExplorerState()
   const [copied, setCopied] = useState(false)
+  // Pretty-format on by default — DDL is small, so formatting is cheap and the
+  // formatted form is what most people want to read. In-memory only (no shared
+  // preference) so it stays independent of the Request Info "Beautify" toggle.
+  const [isBeautified, setIsBeautified] = useState(true)
 
   const url =
     database && table
@@ -97,10 +54,29 @@ export function DdlTab() {
   })
 
   const ddl = response?.data?.[0]?.create_table_query
+  const raw = ddl ? dedent(ddl) : ''
+
+  // Lazily format the DDL when beautify is on. Show the raw DDL while the
+  // formatter chunk loads (no flash) and reset on table change so we never
+  // render a previous table's formatted SQL under the new header.
+  const [formatted, setFormatted] = useState<string | null>(null)
+  useEffect(() => {
+    setFormatted(null)
+    if (!isBeautified || !ddl) return
+    let cancelled = false
+    formatSql(ddl).then((result) => {
+      if (!cancelled) setFormatted(result)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [isBeautified, ddl])
+
+  const displaySql = isBeautified ? (formatted ?? raw) : raw
 
   const handleCopy = async () => {
-    if (ddl) {
-      await navigator.clipboard.writeText(ddl)
+    if (displaySql) {
+      await navigator.clipboard.writeText(displaySql)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     }
@@ -138,29 +114,39 @@ export function DdlTab() {
     )
   }
 
-  const formattedDdl = ddl ? formatSql(ddl) : ''
-
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
         <CardTitle>Table DDL</CardTitle>
-        <Button variant="outline" size="sm" onClick={handleCopy}>
-          {copied ? (
-            <>
-              <Check className="mr-2 size-4" />
-              Copied
-            </>
-          ) : (
-            <>
-              <Copy className="mr-2 size-4" />
-              Copy
-            </>
-          )}
-        </Button>
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1.5">
+            <SparklesIcon className="size-3 text-muted-foreground" />
+            <span className="text-xs text-muted-foreground">Beautify</span>
+            <Switch
+              size="sm"
+              checked={isBeautified}
+              onCheckedChange={setIsBeautified}
+              aria-label="Toggle SQL formatting"
+            />
+          </div>
+          <Button variant="outline" size="sm" onClick={handleCopy}>
+            {copied ? (
+              <>
+                <Check className="mr-2 size-4" />
+                Copied
+              </>
+            ) : (
+              <>
+                <Copy className="mr-2 size-4" />
+                Copy
+              </>
+            )}
+          </Button>
+        </div>
       </CardHeader>
       <CardContent>
-        <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-muted p-4 font-mono text-sm leading-relaxed">
-          <code>{formattedDdl}</code>
+        <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-muted p-4 font-mono text-xs leading-relaxed">
+          <code>{displaySql}</code>
         </pre>
       </CardContent>
     </Card>

--- a/apps/dashboard/src/components/explorer/tabs/indexes-tab.tsx
+++ b/apps/dashboard/src/components/explorer/tabs/indexes-tab.tsx
@@ -126,25 +126,25 @@ export function IndexesTab() {
 
   if (isLoading) {
     return (
-      <div className="flex flex-col gap-6">
-        <div className="grid gap-4 md:grid-cols-2">
+      <div className="flex flex-col gap-4">
+        <div className="grid gap-3 md:grid-cols-2">
           {Array.from({ length: 4 }).map((_, i) => (
-            <Card key={i}>
-              <CardHeader>
-                <Skeleton className="h-6 w-32" />
+            <Card key={i} className="gap-2 py-3">
+              <CardHeader className="px-4">
+                <Skeleton className="h-5 w-32" />
               </CardHeader>
-              <CardContent>
-                <Skeleton className="h-16 w-full" />
+              <CardContent className="px-4">
+                <Skeleton className="h-12 w-full" />
               </CardContent>
             </Card>
           ))}
         </div>
-        <Card>
-          <CardHeader>
-            <Skeleton className="h-6 w-24" />
+        <Card className="gap-3 py-4">
+          <CardHeader className="px-4">
+            <Skeleton className="h-5 w-24" />
           </CardHeader>
-          <CardContent>
-            <Skeleton className="h-32 w-full" />
+          <CardContent className="px-4">
+            <Skeleton className="h-24 w-full" />
           </CardContent>
         </Card>
       </div>
@@ -153,9 +153,9 @@ export function IndexesTab() {
 
   if (error) {
     return (
-      <Card>
-        <CardContent className="pt-6">
-          <div className="text-sm text-destructive">
+      <Card className="gap-3 py-4">
+        <CardContent className="px-4">
+          <div className="text-xs text-destructive">
             Failed to load data: {error.message}
           </div>
         </CardContent>
@@ -167,42 +167,46 @@ export function IndexesTab() {
     {
       label: 'Partition Key',
       value: indexData?.partition_key,
-      icon: <Database className="size-4" />,
+      icon: <Database className="size-3.5" />,
     },
     {
       label: 'Sorting Key',
       value: indexData?.sorting_key,
-      icon: <Key className="size-4" />,
+      icon: <Key className="size-3.5" />,
     },
     {
       label: 'Primary Key',
       value: indexData?.primary_key,
-      icon: <Key className="size-4" />,
+      icon: <Key className="size-3.5" />,
     },
     {
       label: 'Sampling Key',
       value: indexData?.sampling_key,
-      icon: <Settings className="size-4" />,
+      icon: <Settings className="size-3.5" />,
     },
   ]
 
+  // Dense table: shorter header row + tighter cell padding, applied at the call
+  // site so the shared shadcn Table primitive stays untouched.
+  const denseTable = 'text-xs [&_th]:h-8 [&_td]:py-1.5'
+
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-4">
       {/* Engine Info */}
       {indexData?.engine && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base">
-              <Settings className="size-4" />
+        <Card className="gap-3 py-4">
+          <CardHeader className="px-4">
+            <CardTitle className="flex items-center gap-2 text-sm">
+              <Settings className="size-3.5" />
               Engine
             </CardTitle>
           </CardHeader>
-          <CardContent>
-            <div className="space-y-2">
-              <div className="font-medium">{indexData.engine}</div>
+          <CardContent className="px-4">
+            <div className="space-y-1.5">
+              <div className="text-sm font-medium">{indexData.engine}</div>
               {indexData.engine_full &&
                 indexData.engine_full !== indexData.engine && (
-                  <pre className="overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted p-3 font-mono text-sm">
+                  <pre className="overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted p-2.5 font-mono text-xs">
                     <code>{formatEngineFull(indexData.engine_full)}</code>
                   </pre>
                 )}
@@ -212,22 +216,22 @@ export function IndexesTab() {
       )}
 
       {/* Keys Grid */}
-      <div className="grid gap-4 md:grid-cols-2">
+      <div className="grid gap-3 md:grid-cols-2">
         {keyFields.map(({ label, value, icon }) => (
-          <Card key={label}>
-            <CardHeader className="pb-2">
-              <CardTitle className="flex items-center gap-2 text-base">
+          <Card key={label} className="gap-2 py-3">
+            <CardHeader className="px-4">
+              <CardTitle className="flex items-center gap-2 text-sm">
                 {icon}
                 {label}
               </CardTitle>
             </CardHeader>
-            <CardContent>
+            <CardContent className="px-4">
               {value ? (
-                <pre className="overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted p-3 font-mono text-sm">
+                <pre className="overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted p-2.5 font-mono text-xs">
                   <code>{value}</code>
                 </pre>
               ) : (
-                <p className="text-sm text-muted-foreground">Not set</p>
+                <p className="text-xs text-muted-foreground">Not set</p>
               )}
             </CardContent>
           </Card>
@@ -235,31 +239,31 @@ export function IndexesTab() {
       </div>
 
       {/* Skip Indexes */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base">
-            <Filter className="size-4" />
+      <Card className="gap-3 py-4">
+        <CardHeader className="px-4">
+          <CardTitle className="flex items-center gap-2 text-sm">
+            <Filter className="size-3.5" />
             Skip Indexes
           </CardTitle>
         </CardHeader>
-        <CardContent>
+        <CardContent className="px-4">
           {skipIndexesLoading ? (
-            <Skeleton className="h-16 w-full" />
+            <Skeleton className="h-12 w-full" />
           ) : skipIndexesError ? (
-            <p className="text-sm text-muted-foreground">
+            <p className="text-xs text-muted-foreground">
               Skip indexes data unavailable
             </p>
           ) : skipIndexes.length > 0 ? (
-            <Table>
+            <Table className={denseTable}>
               <TableHeader>
                 <TableRow>
                   <TableHead>Name</TableHead>
                   <TableHead>Type</TableHead>
                   <TableHead>Expression</TableHead>
-                  <TableHead>Granularity</TableHead>
-                  <TableHead>Compressed</TableHead>
-                  <TableHead>Uncompressed</TableHead>
-                  <TableHead>Ratio</TableHead>
+                  <TableHead className="text-right">Granularity</TableHead>
+                  <TableHead className="text-right">Compressed</TableHead>
+                  <TableHead className="text-right">Uncompressed</TableHead>
+                  <TableHead className="text-right">Ratio</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -274,16 +278,24 @@ export function IndexesTab() {
                     <TableCell>
                       <code className="text-xs">{idx.expr}</code>
                     </TableCell>
-                    <TableCell>{idx.granularity}</TableCell>
-                    <TableCell>{idx.compressed_size}</TableCell>
-                    <TableCell>{idx.uncompressed_size}</TableCell>
-                    <TableCell>{idx.compression_ratio}x</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {idx.granularity}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {idx.compressed_size}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {idx.uncompressed_size}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {idx.compression_ratio}x
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>
             </Table>
           ) : (
-            <p className="text-sm text-muted-foreground">
+            <p className="text-xs text-muted-foreground">
               No skip indexes defined for this table
             </p>
           )}
@@ -291,41 +303,51 @@ export function IndexesTab() {
       </Card>
 
       {/* Projections */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base">
-            <Layers className="size-4" />
+      <Card className="gap-3 py-4">
+        <CardHeader className="px-4">
+          <CardTitle className="flex items-center gap-2 text-sm">
+            <Layers className="size-3.5" />
             Projections
           </CardTitle>
         </CardHeader>
-        <CardContent>
+        <CardContent className="px-4">
           {projections.length > 0 ? (
-            <Table>
+            <Table className={denseTable}>
               <TableHeader>
                 <TableRow>
                   <TableHead>Name</TableHead>
-                  <TableHead>Compressed</TableHead>
-                  <TableHead>Uncompressed</TableHead>
-                  <TableHead>Ratio</TableHead>
-                  <TableHead>Rows</TableHead>
-                  <TableHead>Parts</TableHead>
+                  <TableHead className="text-right">Compressed</TableHead>
+                  <TableHead className="text-right">Uncompressed</TableHead>
+                  <TableHead className="text-right">Ratio</TableHead>
+                  <TableHead className="text-right">Rows</TableHead>
+                  <TableHead className="text-right">Parts</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {projections.map((proj) => (
                   <TableRow key={proj.name}>
                     <TableCell className="font-medium">{proj.name}</TableCell>
-                    <TableCell>{proj.compressed_size}</TableCell>
-                    <TableCell>{proj.uncompressed_size}</TableCell>
-                    <TableCell>{proj.compression_ratio}x</TableCell>
-                    <TableCell>{proj.rows}</TableCell>
-                    <TableCell>{proj.parts}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {proj.compressed_size}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {proj.uncompressed_size}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {proj.compression_ratio}x
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {proj.rows}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {proj.parts}
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>
             </Table>
           ) : (
-            <p className="text-sm text-muted-foreground">
+            <p className="text-xs text-muted-foreground">
               No projections defined for this table
             </p>
           )}

--- a/apps/dashboard/src/components/explorer/tree/database-node.tsx
+++ b/apps/dashboard/src/components/explorer/tree/database-node.tsx
@@ -70,6 +70,8 @@ export const DatabaseNode = function DatabaseNode({
     queryKey: [url],
     queryFn: () => fetcher(url),
     enabled: shouldFetch,
+    // Table list per database changes rarely — cache across expand/collapse and remounts.
+    staleTime: 5 * 60_000,
   })
 
   const tables = response?.data

--- a/apps/dashboard/src/components/explorer/tree/database-tree.tsx
+++ b/apps/dashboard/src/components/explorer/tree/database-tree.tsx
@@ -44,6 +44,8 @@ export function DatabaseTree() {
   } = useQuery<ApiResponse<Database[]>>({
     queryKey: [queryKey],
     queryFn: () => fetcher(queryKey),
+    // Schema shape changes rarely — don't refetch the database list on every remount.
+    staleTime: 5 * 60_000,
   })
 
   const databases = response?.data

--- a/apps/dashboard/src/components/explorer/tree/table-node.tsx
+++ b/apps/dashboard/src/components/explorer/tree/table-node.tsx
@@ -127,6 +127,8 @@ export const TableNode = function TableNode({
         `/api/v1/explorer/columns?hostId=${hostId}&database=${encodeURIComponent(database)}&table=${encodeURIComponent(table)}`
       ),
     enabled: shouldFetch,
+    // Column schema changes rarely — cache across expand/collapse and remounts.
+    staleTime: 5 * 60_000,
   })
 
   const columns = response?.data

--- a/apps/dashboard/src/components/explorer/tree/tree-node.tsx
+++ b/apps/dashboard/src/components/explorer/tree/tree-node.tsx
@@ -135,7 +135,10 @@ export const TreeNode = function TreeNode({
                   )}
                 />
               ))}
-            <span className="truncate">{label}</span>
+            {/* `truncate` clips visually via CSS ellipsis while keeping the
+                full name in the DOM; `select-text` keeps it double-click
+                selectable + copyable even inside this clickable button. */}
+            <span className="truncate select-text">{label}</span>
             {badge && <div className="ml-auto">{badge}</div>}
           </SidebarMenuButton>
         </div>

--- a/apps/dashboard/src/components/mcp/copy-button.tsx
+++ b/apps/dashboard/src/components/mcp/copy-button.tsx
@@ -1,6 +1,6 @@
 import { Check, Copy } from 'lucide-react'
 
-import { useState } from 'react'
+import { type MouseEvent, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
@@ -13,7 +13,10 @@ interface CopyButtonProps {
 export function CopyButton({ text, className, label }: CopyButtonProps) {
   const [copied, setCopied] = useState(false)
 
-  const handleCopy = async () => {
+  const handleCopy = async (e: MouseEvent) => {
+    // Never let a copy click bubble to a clickable ancestor (breadcrumb link,
+    // tree row, table cell): copying should not also navigate or select.
+    e.stopPropagation()
     await navigator.clipboard.writeText(text)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/databases.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/databases.ts
@@ -1,21 +1,18 @@
 import type { DeclarativeQueryConfig } from '../../schema'
 
+// Mirrors explorerDatabasesConfig (TS). Table counts moved to a separate
+// streamed query (explorer-database-counts) so the sidebar / first paint no
+// longer joins system.tables. Keep this in lockstep with the TS config —
+// enforced by explorer-catalog.test.ts.
 export const explorerDatabasesDeclarative: DeclarativeQueryConfig = {
   name: 'explorer-databases',
-  description: 'List of ClickHouse databases with table counts',
+  description: 'List of ClickHouse databases',
   sql: `
-    SELECT
-      d.name,
-      d.engine,
-      d.data_path,
-      d.uuid,
-      count(t.name) AS item_count
-    FROM system.databases d
-    LEFT JOIN system.tables t ON d.name = t.database
-    WHERE d.name NOT IN ('INFORMATION_SCHEMA', 'information_schema')
-    GROUP BY d.name, d.engine, d.data_path, d.uuid
-    ORDER BY d.name
+    SELECT name, engine
+    FROM system.databases
+    WHERE name NOT IN ('INFORMATION_SCHEMA', 'information_schema')
+    ORDER BY name
   `,
-  columns: ['name', 'engine', 'data_path', 'uuid', 'item_count'],
+  columns: ['name', 'engine'],
   optional: false,
 }

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/tables.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/tables.ts
@@ -1,10 +1,13 @@
 import type { DeclarativeQueryConfig } from '../../schema'
 
+// Mirrors explorerTablesConfig (TS): only name/engine/total_rows are rendered,
+// so total_bytes / readable_size are no longer selected. Keep in lockstep with
+// the TS config — enforced by explorer-catalog.test.ts.
 export const explorerTablesDeclarative: DeclarativeQueryConfig = {
   name: 'explorer-tables',
   description: 'List of tables in a database',
-  sql: "SELECT name, engine, total_rows, total_bytes, formatReadableSize(total_bytes) as readable_size FROM system.tables WHERE database = {database:String} AND is_temporary = 0 AND name NOT LIKE '.inner_%' ORDER BY name",
-  columns: ['name', 'engine', 'total_rows', 'total_bytes', 'readable_size'],
+  sql: "SELECT name, engine, total_rows FROM system.tables WHERE database = {database:String} AND is_temporary = 0 AND name NOT LIKE '.inner_%' ORDER BY name",
+  columns: ['name', 'engine', 'total_rows'],
   optional: false,
   defaultParams: { database: 'default' },
 }

--- a/apps/dashboard/src/lib/query-config/explorer/databases.ts
+++ b/apps/dashboard/src/lib/query-config/explorer/databases.ts
@@ -1,20 +1,34 @@
 import type { QueryConfig } from '@/types/query-config'
 
+// Sidebar tree + empty-state gate. Deliberately does NOT join system.tables:
+// the tree renders only `name` and the empty-state renders `name` + `engine`,
+// so enumerating every table in the cluster to compute a per-database count
+// (the old `LEFT JOIN system.tables ... GROUP BY`) blocked the first paint for
+// a number nothing on this path uses. Table counts are now a separate,
+// streamed query (`explorer-database-counts`) consumed only by the empty-state.
 export const explorerDatabasesConfig: QueryConfig = {
   name: 'explorer-databases',
-  description: 'List of ClickHouse databases with table counts',
+  description: 'List of ClickHouse databases',
   sql: `
-    SELECT
-      d.name,
-      d.engine,
-      d.data_path,
-      d.uuid,
-      count(t.name) AS item_count
-    FROM system.databases d
-    LEFT JOIN system.tables t ON d.name = t.database
-    WHERE d.name NOT IN ('INFORMATION_SCHEMA', 'information_schema')
-    GROUP BY d.name, d.engine, d.data_path, d.uuid
-    ORDER BY d.name
+    SELECT name, engine
+    FROM system.databases
+    WHERE name NOT IN ('INFORMATION_SCHEMA', 'information_schema')
+    ORDER BY name
   `,
-  columns: ['name', 'engine', 'data_path', 'uuid', 'item_count'],
+  columns: ['name', 'engine'],
+}
+
+// Per-database table counts for the explorer empty-state, split out of
+// `explorer-databases` so the sidebar/first paint never waits on a
+// system.tables enumeration. Streamed in after the database names render.
+export const explorerDatabaseCountsConfig: QueryConfig = {
+  name: 'explorer-database-counts',
+  description: 'Per-database table counts for the explorer empty-state',
+  sql: `
+    SELECT database AS name, count() AS item_count
+    FROM system.tables
+    WHERE database NOT IN ('INFORMATION_SCHEMA', 'information_schema')
+    GROUP BY database
+  `,
+  columns: ['name', 'item_count'],
 }

--- a/apps/dashboard/src/lib/query-config/explorer/index.ts
+++ b/apps/dashboard/src/lib/query-config/explorer/index.ts
@@ -1,5 +1,8 @@
 export { explorerColumnsConfig } from './columns'
-export { explorerDatabasesConfig } from './databases'
+export {
+  explorerDatabaseCountsConfig,
+  explorerDatabasesConfig,
+} from './databases'
 export { explorerDdlConfig } from './ddl'
 export {
   explorerAllDependenciesConfig,

--- a/apps/dashboard/src/lib/query-config/explorer/tables.ts
+++ b/apps/dashboard/src/lib/query-config/explorer/tables.ts
@@ -1,9 +1,13 @@
 import type { QueryConfig } from '@/types/query-config'
 
+// Sidebar tree (and the SQL-console table picker) consume only name, engine and
+// total_rows. total_bytes / readable_size were selected but never rendered, so
+// they are dropped to keep this per-database system.tables read as light as the
+// sidebar needs. total_rows stays: it drives the row-count badge in the tree.
 export const explorerTablesConfig: QueryConfig = {
   name: 'explorer-tables',
   description: 'List of tables in a database',
-  sql: `SELECT name, engine, total_rows, total_bytes, formatReadableSize(total_bytes) as readable_size FROM system.tables WHERE database = {database:String} AND is_temporary = 0 AND name NOT LIKE '.inner_%' ORDER BY name`,
-  columns: ['name', 'engine', 'total_rows', 'total_bytes', 'readable_size'],
+  sql: `SELECT name, engine, total_rows FROM system.tables WHERE database = {database:String} AND is_temporary = 0 AND name NOT LIKE '.inner_%' ORDER BY name`,
+  columns: ['name', 'engine', 'total_rows'],
   defaultParams: { database: 'default' },
 }

--- a/apps/dashboard/src/lib/query-config/index.ts
+++ b/apps/dashboard/src/lib/query-config/index.ts
@@ -15,6 +15,7 @@ import { anomalyQueries } from './anomaly/anomaly-queries'
 import {
   explorerAllDependenciesConfig,
   explorerColumnsConfig,
+  explorerDatabaseCountsConfig,
   explorerDatabaseDependenciesConfig,
   explorerDatabasesConfig,
   explorerDdlConfig,
@@ -130,6 +131,7 @@ import { viewRefreshesConfig } from './tables/view-refreshes'
 export const queries: Array<QueryConfig> = [
   // Explorer
   explorerDatabasesConfig,
+  explorerDatabaseCountsConfig,
   explorerTablesConfig,
   explorerColumnsConfig,
   explorerDdlConfig,


### PR DESCRIPTION
**Stacked on #2286** (`perf/explorer-lazy-load`, not yet merged). This branch is
based on that PR, so the diff below will also show #2286's lazy-load changes
until it merges — only the three commits in this branch are new here.

Three small UX improvements to the `/explorer` page.

### 1. Copy-friendly database / table names
Truncated names in the breadcrumb and tree were hard to copy.
- Tree nodes already CSS-truncate (`truncate` = ellipsis, full name kept in the
  DOM); added `select-text` so the label stays double-click-selectable and
  Cmd+C-copyable even inside its clickable button. No JS substring is used for
  names anywhere (the only `.slice` in explorer is data-tab **cell values**,
  out of scope).
- The breadcrumb shows **full** (untruncated) names, so rather than truncating
  it, it now has a small, quiet, hover-revealed copy button (reusing the shared
  `CopyButton`) next to the database and table names.
- Hardened the shared `CopyButton` with `stopPropagation` so a copy click never
  also navigates/selects a clickable ancestor. Its only call sites are in
  `mcp/`, where this is a no-op improvement.
- `explorer-sidebar.tsx` renders names **through** the tree nodes, so it needs
  no change of its own.

### 2. Table DDL tab
- Renders the SQL at `text-xs` (mono).
- Adds a pretty-format toggle that is **on by default**, formatting
  `create_table_query` with the shared `lib/sql-format` formatter (lazy
  `sql-formatter`, raw-dedent fallback), replacing the old ad-hoc regex
  formatter. The toggle is in-memory only (independent of the Request Info
  "Beautify" preference); shows raw DDL while the formatter chunk loads and
  resets on table change. Copy now copies exactly what is displayed.

### 3. Indexes tab
- Compact, denser layout per the product design system: tighter card padding
  (`gap`/`py`/`px-4`), `text-sm` titles, `size-3.5` icons, `text-xs` mono
  blocks, and dense tables (shorter header row + tighter cells via
  `[&_th]:h-8 [&_td]:py-1.5`) with numeric columns right-aligned + `tabular-nums`.
  Pure call-site `className` overrides — shared `ui/*` primitives untouched.

### Verification
- `bun run type-check` + `bun run type-check:test` (from `apps/dashboard`):
  **0 new errors** vs this branch's baseline. Normalized set-diff of new error
  signatures is empty; all remaining errors are pre-existing stale route-tree /
  codegen artifacts (`routeTree.gen`, `next-compat.ts`, `@happy-dom`), and none
  of the 5 touched files report errors.
- Biome clean on every touched file.
- No `bun install` / no full build (worktree deps are symlinked).
- **QA pending**: static site — the three interactions (copy buttons, DDL
  toggle, compact tables) were not browser-tested.
