### PR TITLE
fix(agent-chat): clean starting state (hide Thinking text + just-now while running)

### DIFF
--- a/apps/dashboard/src/components/assistant-ui/-thread/message-stats.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/message-stats.tsx
@@ -241,6 +241,9 @@ export function MessageStatsFooter() {
   const timing = useMessageTiming()
   const metadata = useMessage((msg) => msg.metadata)
   const createdAt = useMessage((msg) => msg.createdAt)
+  // While the message is still streaming, its relative timestamp only ever reads
+  // "just now" — noisy next to the starting spinner. Hide it until completion.
+  const isRunning = useMessage((msg) => msg.status?.type === 'running')
   // assistant-ui exposes the AI SDK parts array as `message.content`
   const content = useMessage((msg) => msg.content) as readonly unknown[]
 
@@ -271,7 +274,7 @@ export function MessageStatsFooter() {
 
   const hasTokens = totalTokens > 0
   const hasDuration = timing?.totalStreamTime != null
-  const hasTimestamp = createdAt instanceof Date
+  const hasTimestamp = createdAt instanceof Date && !isRunning
   const hasModel = (usage?.resolvedModel ?? usage?.model) != null
 
   if (!hasTokens && !hasDuration && !hasTimestamp) return null

--- a/apps/dashboard/src/components/assistant-ui/thread.tsx
+++ b/apps/dashboard/src/components/assistant-ui/thread.tsx
@@ -67,7 +67,7 @@ import { useAgentAuthGate } from '@/components/assistant-ui/agent-auth-gate'
 import { JsonRenderMessage } from '@/components/assistant-ui/json-render-message'
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
 import { Bubble, BubbleContent } from '@/components/ui/bubble'
-import { Marker, MarkerContent, MarkerIcon } from '@/components/ui/marker'
+import { Marker, MarkerIcon } from '@/components/ui/marker'
 import { Message, MessageContent } from '@/components/ui/message'
 import {
   MessageScroller,
@@ -277,8 +277,9 @@ const EditComposer: FC = () => {
 // ---------------------------------------------------------------------------
 
 /**
- * Shows a subtle "Thinking…" pulse while the thread is running and the
- * current assistant message has no real parts yet.
+ * Shows a subtle spinner while the thread is running and the current assistant
+ * message has no real parts yet. The visible "Thinking…" label is intentionally
+ * dropped for a cleaner starting state; the text is kept screen-reader-only.
  */
 function LoadingIndicator() {
   const isRunning = useThread((thread) => thread.isRunning)
@@ -302,11 +303,11 @@ function LoadingIndicator() {
   if (!isRunning || hasError || !hasNoParts) return null
 
   return (
-    <Marker className="py-1">
+    <Marker className="py-1" role="status">
       <MarkerIcon>
         <LoaderCircleIcon className="animate-spin" />
       </MarkerIcon>
-      <MarkerContent className="shimmer text-xs">Thinking…</MarkerContent>
+      <span className="sr-only">Thinking…</span>
     </Marker>
   )
 }


### PR DESCRIPTION
## Summary

Cleans up the AI agent chat's "starting to respond" state and investigates the
dual-response-stream bug from the screenshots.

**Held for review — no auto-merge.**

## Ask 1 — cleaner agent starting state (shipped)

- **Dropped the visible "Thinking…" label**, kept the spinner. The starting
  state is now just the animated loader instead of loader + shimmering text.
  The label is preserved **screen-reader-only** (`role="status"` + `sr-only`
  span) so loading is still announced — a bare `aria-hidden` spinner would be a
  silent-loading a11y regression (the repo runs axe audits).
  `components/assistant-ui/thread.tsx` (`LoadingIndicator`).
- **Hid the per-message relative timestamp while the message is still
  streaming.** During streaming the relative time only ever reads "just now",
  which is noise next to the starting spinner. Gated on the message's own
  `status.type === 'running'`; the real timestamp ("2m ago", …) reappears the
  moment the message completes (the status→complete transition re-renders the
  footer via that selector).
  `components/assistant-ui/-thread/message-stats.tsx`.

`format.ts` was left untouched — changing the `"just now"` threshold there
wouldn't reliably flip to "5s ago" (the footer doesn't re-render on a timer),
so gating on run state is the robust fix.

## Ask 2 — dual response stream (QA-pending, no speculative fix)

I could **not** confirm the exact trigger from code alone (can't run the live
site), so per the task brief I am **not** shipping a speculative runtime change
that could make it worse. The investigation narrowed it to a single primary
hypothesis:

**Ruled out (evidence):**
- `apiFetch` (the agent transport's `fetch`, `lib/swr/api-fetch.ts`) has **no
  retry** path — it never re-issues a request.
- The agent route emits failures **in-stream**: on error it writes a
  `data-error` data part into the same HTTP-200 `createUIMessageStream`
  (`routes/api/v1/agent.ts:809-844`) instead of returning an HTTP error. So
  **one request = exactly one stream**, and the AI SDK has no HTTP failure to
  auto-retry. The dual stream is therefore a **client-side double submission**,
  not a server or SDK-retry artifact.
- Not a render keying/dedup bug: messages are keyed by runtime id
  (`MessageScrollerItem messageId={…}`), and two real assistant messages have
  distinct ids — matching "both left visible".
- **Not transport recreation** (in the common case): the chat transport
  `useMemo` is keyed on `[hostId, model, disabledTools, sessionId, mcpServers]`,
  and **all five are stable at send time** — `hostId` is the router search
  param, `model` is `useState(() => getSavedModel())`, and both
  `useToolConfig().disabledTools` and `useMcpConfig()` initialize synchronously
  via lazy `useState(() => readStorage())` (their `useEffect`s only write back,
  never re-hydrate). No async hydration swaps the transport mid-flight.

**Leading hypothesis (verify in QA):** double-submit on the **first message of a
new thread** via `useRemoteThreadListRuntime`
(`components/assistant-ui/agent-runtime-provider.tsx`). The optimistic "new"
thread runs `adapter.initialize()` then switches to the persisted thread; that
switch can replay the pending send. Attempt 1 is aborted → its stream carries a
`data-error` (the "first, failed" bubble); attempt 2 lands on the initialized
thread and succeeds. Two distinct-id assistant messages, both retained — which
matches the screenshots exactly.

**QA repro:** open the browser Network tab and send the **first** message in a
**brand-new** conversation. Two POSTs to `/api/v1/agent` for that single turn
(vs. one POST for a follow-up in an existing thread) confirms the new-thread
init race; the fix then belongs in the runtime / thread-list-adapter init flow
(e.g. ensure the pending send isn't replayed across the optimistic→persisted
thread switch), not in the transport or the route.

## Verification

From `apps/dashboard`:
- `bunx tsc --noEmit -p tsconfig.json` — **231 baseline → 231 after (0 new)**
- `bunx tsc --noEmit -p tsconfig.test.json` — **240 baseline → 240 after (0 new)**
  (measured against this checkout's pristine tree; the ~229/~230 figures in the
  brief predate recent `main` commits)
- `bunx biome check` on both touched files — clean; zero tsc errors in either file
- `bun run build` intentionally skipped (heavy; per worktree guidance)

Not runtime-verified against the live chat (no live-site access from the
worktree); Ask 1 is a pure presentational/logic change reasoned from the code.
