### PR TITLE
feat(insights): redesign overview strip + insights board, add operational collectors

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -61,6 +61,11 @@ primary secondary accent destructive border input ring`. Charts:
   `<button>`); inner links `e.stopPropagation()` (not `preventDefault`) so they
   still navigate. Drive drill-down from a per-item field, rendered via
   `ResultTable`. See `components/health/{health-card-shell,health-detail-rows}.tsx`.
+- **Overflow strip (one row, no wrap):** `scrollbar-hide overflow-x-auto` + `py-*`
+  (so shadows/accents/focus rings aren't clipped) with a chevron button + a
+  `from-background`→`transparent` edge fade per scrollable side, paging via
+  `scrollBy`. Re-measure on scroll / `ResizeObserver` / content-count change.
+  Copy `components/insights/insights-strip.tsx`.
 
 ## Charts — always wrap state, never hand-roll it
 

--- a/apps/dashboard/src/components/insights/insight-card.tsx
+++ b/apps/dashboard/src/components/insights/insight-card.tsx
@@ -1,11 +1,8 @@
-import type { LucideIcon } from 'lucide-react'
-import { AlertTriangle, ArrowRight, Info, TriangleAlert, X } from 'lucide-react'
+import { ArrowRight, X } from 'lucide-react'
 
-import type {
-  InsightCard as InsightCardData,
-  InsightSeverity,
-} from '@/lib/insights/types'
+import type { InsightCard as InsightCardData } from '@/lib/insights/types'
 
+import { SEVERITY_META } from '@/components/insights/severity-meta'
 import { AppLink as Link } from '@/components/ui/app-link'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -13,41 +10,6 @@ import { Card } from '@/components/ui/card'
 import { buildUrl } from '@/lib/url/url-builder'
 import { cn } from '@/lib/utils'
 import { formatRelativeTime } from '@/lib/utils/format-relative-time'
-
-interface SeverityStyle {
-  icon: LucideIcon
-  iconBg: string
-  iconColor: string
-  badge: string
-  badgeLabel: string
-}
-
-const SEVERITY: Record<InsightSeverity, SeverityStyle> = {
-  critical: {
-    icon: AlertTriangle,
-    iconBg: 'bg-rose-100 dark:bg-rose-950/50',
-    iconColor: 'text-rose-600 dark:text-rose-400',
-    badge:
-      'border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-800/60 dark:bg-rose-950/40 dark:text-rose-400',
-    badgeLabel: 'Critical',
-  },
-  warning: {
-    icon: TriangleAlert,
-    iconBg: 'bg-amber-100 dark:bg-amber-950/50',
-    iconColor: 'text-amber-600 dark:text-amber-400',
-    badge:
-      'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800/60 dark:bg-amber-950/40 dark:text-amber-400',
-    badgeLabel: 'Warning',
-  },
-  info: {
-    icon: Info,
-    iconBg: 'bg-muted',
-    iconColor: 'text-muted-foreground',
-    badge:
-      'border-border bg-muted/50 text-muted-foreground dark:bg-muted/30 dark:text-muted-foreground',
-    badgeLabel: 'Info',
-  },
-}
 
 interface InsightCardProps {
   insight: InsightCardData
@@ -62,7 +24,7 @@ export function InsightCard({
   onDismiss,
   className,
 }: InsightCardProps) {
-  const style = SEVERITY[insight.severity]
+  const style = SEVERITY_META[insight.severity]
   const Icon = style.icon
 
   const generatedMs = insight.generatedAt
@@ -78,7 +40,13 @@ export function InsightCard({
       : undefined
 
   return (
-    <Card className={cn('h-full gap-0 p-4 transition-colors', className)}>
+    <Card
+      className={cn(
+        'h-full gap-0 border-l-2 p-4 transition-colors',
+        style.accent,
+        className
+      )}
+    >
       <div className="flex items-start justify-between gap-2">
         <div
           className={cn(
@@ -113,7 +81,7 @@ export function InsightCard({
             variant="outline"
             className={cn('text-[10px] font-medium', style.badge)}
           >
-            {style.badgeLabel}
+            {style.label}
           </Badge>
           {hasGeneratedAt ? (
             <time

--- a/apps/dashboard/src/components/insights/insights-empty-cta.tsx
+++ b/apps/dashboard/src/components/insights/insights-empty-cta.tsx
@@ -1,0 +1,69 @@
+import { Activity, RefreshCw, Settings2 } from 'lucide-react'
+
+import { AppLink } from '@/components/ui/app-link'
+import { Button } from '@/components/ui/button'
+import { buildUrl } from '@/lib/url/url-builder'
+import { cn } from '@/lib/utils'
+
+interface InsightsEmptyCtaProps {
+  hostId: number
+  isGenerating: boolean
+  onGenerate: () => void
+  className?: string
+}
+
+/**
+ * Slim, dashed-border call-to-action shown when a host has no active insights.
+ * Shared by the overview strip and the insights-page board so the empty state
+ * looks identical on both surfaces (never an empty box).
+ */
+export function InsightsEmptyCta({
+  hostId,
+  isGenerating,
+  onGenerate,
+  className,
+}: InsightsEmptyCtaProps) {
+  return (
+    <section
+      className={cn(
+        'flex flex-wrap items-center justify-between gap-2 rounded-lg border border-dashed border-border bg-muted/30 px-4 py-3',
+        className
+      )}
+      aria-label="AI insights"
+    >
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Activity className="size-4 shrink-0" />
+        <span>
+          No insights right now. Generate a fresh analysis of this cluster.
+        </span>
+      </div>
+      <div className="flex items-center gap-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="gap-1.5"
+          onClick={onGenerate}
+          disabled={isGenerating}
+        >
+          <RefreshCw
+            className={cn('size-3.5', isGenerating && 'animate-spin')}
+          />
+          {isGenerating ? 'Generating…' : 'Generate insights'}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-8 text-muted-foreground hover:text-foreground"
+          aria-label="AI Insights settings"
+          asChild
+        >
+          <AppLink href={buildUrl('/insights-settings', { host: hostId })}>
+            <Settings2 className="size-3.5" />
+          </AppLink>
+        </Button>
+      </div>
+    </section>
+  )
+}

--- a/apps/dashboard/src/components/insights/insights-panel.tsx
+++ b/apps/dashboard/src/components/insights/insights-panel.tsx
@@ -290,7 +290,7 @@ function FilterTabs({
   return (
     <div
       className="flex flex-wrap items-center gap-1.5"
-      role="tablist"
+      role="group"
       aria-label="Filter insights"
     >
       <FilterTab
@@ -352,8 +352,7 @@ function FilterTab({
   return (
     <button
       type="button"
-      role="tab"
-      aria-selected={selected}
+      aria-pressed={selected}
       onClick={onClick}
       className={className}
     >

--- a/apps/dashboard/src/components/insights/insights-panel.tsx
+++ b/apps/dashboard/src/components/insights/insights-panel.tsx
@@ -1,7 +1,31 @@
-import { Activity, Database, RefreshCw, Settings2, X } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import {
+  Activity,
+  CircleDollarSign,
+  Database,
+  Gauge,
+  HardDrive,
+  RefreshCw,
+  Search,
+  Settings2,
+  ShieldAlert,
+  Sparkles,
+  TriangleAlert,
+  X,
+} from 'lucide-react'
 
-import { useState } from 'react'
+import type {
+  InsightCard as InsightCardData,
+  InsightSeverity,
+} from '@/lib/insights/types'
+
+import { useMemo, useState } from 'react'
 import { InsightCard } from '@/components/insights/insight-card'
+import { InsightsEmptyCta } from '@/components/insights/insights-empty-cta'
+import {
+  SEVERITY_META,
+  SEVERITY_ORDER,
+} from '@/components/insights/severity-meta'
 import { AppLink } from '@/components/ui/app-link'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -19,11 +43,42 @@ interface InsightsPanelProps {
   className?: string
 }
 
+/** Display metadata per insight category. Unknown categories fall back to a
+ * title-cased label with the generic Sparkles icon. */
+const CATEGORY_META: Record<string, { label: string; icon: LucideIcon }> = {
+  anomaly: { label: 'Anomalies', icon: Activity },
+  performance: { label: 'Performance', icon: Gauge },
+  storage: { label: 'Storage', icon: HardDrive },
+  reliability: { label: 'Reliability', icon: ShieldAlert },
+  queries: { label: 'Queries', icon: Search },
+  cost: { label: 'Cost', icon: CircleDollarSign },
+}
+
+function categoryMeta(category: string): { label: string; icon: LucideIcon } {
+  return (
+    CATEGORY_META[category] ?? {
+      label: category.charAt(0).toUpperCase() + category.slice(1),
+      icon: Sparkles,
+    }
+  )
+}
+
+const SEVERITY_RANK: Record<InsightSeverity, number> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+}
+
+/** Special filter ids that are not categories. */
+const FILTER_ALL = 'all'
+const FILTER_ATTENTION = 'attention'
+
 /**
- * AI-suggested insights for the current host. Insights are generated + cached
- * server-side (findings store) and refreshed by the cron sweep; the operator can
- * regenerate on demand and dismiss individual cards (persisted per-user in
- * localStorage). Renders an unobtrusive CTA when there is nothing to show.
+ * Classified AI insights board for the full `/insights` page. Insights are
+ * grouped by category with section headers, filterable via a tab row, and the
+ * critical/warning ones are surfaced through a dedicated "Needs attention" tab
+ * plus the severity-toned accent on each card. Generated + cached server-side
+ * (findings store); regenerate on demand and dismiss per-user (localStorage).
  */
 export function InsightsPanel({ hostId, className }: InsightsPanelProps) {
   const {
@@ -36,58 +91,56 @@ export function InsightsPanel({ hostId, className }: InsightsPanelProps) {
     dismiss,
     dismissAll,
   } = useInsights(hostId)
-  const [showAll, setShowAll] = useState(false)
+  const [filter, setFilter] = useState<string>(FILTER_ALL)
 
   const hasInsights = insights.length > 0
-  const VISIBLE = 6
-  const visible = showAll ? insights : insights.slice(0, VISIBLE)
+  const attentionCount = counts.critical + counts.warning
+
+  // Group by category, most-severe category first, then largest.
+  const categories = useMemo(() => {
+    const byCat = new Map<string, InsightCardData[]>()
+    for (const insight of insights) {
+      const arr = byCat.get(insight.category) ?? []
+      arr.push(insight)
+      byCat.set(insight.category, arr)
+    }
+    return [...byCat.entries()]
+      .map(([category, items]) => ({
+        category,
+        items: [...items].sort(
+          (a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]
+        ),
+        topRank: Math.min(...items.map((i) => SEVERITY_RANK[i.severity])),
+      }))
+      .sort((a, b) => a.topRank - b.topRank || b.items.length - a.items.length)
+  }, [insights])
 
   // Empty + idle → slim CTA row, so the panel never shows an empty box.
   if (!hasInsights && !isLoading) {
     return (
-      <section
-        className={cn(
-          'flex flex-wrap items-center justify-between gap-2 rounded-lg border border-dashed border-border bg-muted/30 px-4 py-3',
-          className
-        )}
-        aria-label="AI insights"
-      >
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Activity className="size-4 shrink-0" />
-          <span>
-            No insights right now. Generate a fresh analysis of this cluster.
-          </span>
-        </div>
-        <div className="flex items-center gap-1">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="gap-1.5"
-            onClick={generate}
-            disabled={isGenerating}
-          >
-            <RefreshCw
-              className={cn('size-3.5', isGenerating && 'animate-spin')}
-            />
-            {isGenerating ? 'Generating…' : 'Generate insights'}
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="size-8 text-muted-foreground hover:text-foreground"
-            aria-label="AI Insights settings"
-            asChild
-          >
-            <AppLink href={buildUrl('/insights-settings', { host: hostId })}>
-              <Settings2 className="size-3.5" />
-            </AppLink>
-          </Button>
-        </div>
-      </section>
+      <InsightsEmptyCta
+        hostId={hostId}
+        isGenerating={isGenerating}
+        onGenerate={generate}
+        className={className}
+      />
     )
   }
+
+  // A selected category (or attention) can vanish after dismissals — fall back
+  // to "All" so the board never shows an empty filtered view by accident.
+  const categoryIds = new Set(categories.map((c) => c.category))
+  let activeFilter = filter
+  if (filter === FILTER_ATTENTION && attentionCount === 0)
+    activeFilter = FILTER_ALL
+  else if (
+    filter !== FILTER_ALL &&
+    filter !== FILTER_ATTENTION &&
+    !categoryIds.has(filter)
+  )
+    activeFilter = FILTER_ALL
+
+  const attentionItems = insights.filter((i) => i.severity !== 'info')
 
   return (
     <section
@@ -96,29 +149,22 @@ export function InsightsPanel({ hostId, className }: InsightsPanelProps) {
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-          <Activity className="size-4 shrink-0 text-muted-foreground" />
-          <h2 className="text-sm font-medium text-foreground">Insights</h2>
-          {counts.critical > 0 ? (
-            <Badge
-              variant="outline"
-              className="border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-800/60 dark:bg-rose-950/40 dark:text-rose-400"
-            >
-              {counts.critical} critical
-            </Badge>
-          ) : null}
-          {counts.warning > 0 ? (
-            <Badge
-              variant="outline"
-              className="border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800/60 dark:bg-amber-950/40 dark:text-amber-400"
-            >
-              {counts.warning} warning
-            </Badge>
-          ) : null}
-          {counts.info > 0 ? (
-            <Badge variant="outline" className="text-muted-foreground">
-              {counts.info} info
-            </Badge>
-          ) : null}
+          <Sparkles className="size-4 shrink-0 text-muted-foreground" />
+          <h2 className="text-sm font-medium text-foreground">AI Insights</h2>
+          {SEVERITY_ORDER.map((sev) =>
+            counts[sev] > 0 ? (
+              <Badge
+                key={sev}
+                variant="outline"
+                className={cn(
+                  'text-[10px] font-medium',
+                  SEVERITY_META[sev].badge
+                )}
+              >
+                {counts[sev]} {SEVERITY_META[sev].label.toLowerCase()}
+              </Badge>
+            ) : null
+          )}
         </div>
         <div className="flex items-center gap-1">
           <Button
@@ -167,40 +213,205 @@ export function InsightsPanel({ hostId, className }: InsightsPanelProps) {
       {isLoading && !hasInsights ? (
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
           {Array.from({ length: 3 }).map((_, i) => (
-            <Skeleton key={i} className="h-32 w-full rounded-lg" />
+            <Skeleton key={i} className="h-32 w-full rounded-xl" />
           ))}
         </div>
       ) : (
         <>
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
-            {visible.map((insight) => (
-              <InsightCard
-                key={insight.key}
-                insight={insight}
-                hostId={hostId}
-                onDismiss={dismiss}
-              />
-            ))}
-          </div>
-          {insights.length > VISIBLE ? (
-            <div className="flex justify-center">
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="text-xs text-muted-foreground"
-                onClick={() => setShowAll((v) => !v)}
-              >
-                {showAll
-                  ? 'Show fewer'
-                  : `Show ${insights.length - VISIBLE} more`}
-              </Button>
+          <FilterTabs
+            total={insights.length}
+            attentionCount={attentionCount}
+            categories={categories}
+            active={activeFilter}
+            onChange={setFilter}
+          />
+
+          {activeFilter === FILTER_ALL ? (
+            <div className="flex flex-col gap-4">
+              {categories.map(({ category, items }) => (
+                <CategorySection
+                  key={category}
+                  category={category}
+                  items={items}
+                  hostId={hostId}
+                  onDismiss={dismiss}
+                />
+              ))}
             </div>
-          ) : null}
+          ) : activeFilter === FILTER_ATTENTION ? (
+            <InsightsGrid
+              items={attentionItems}
+              hostId={hostId}
+              onDismiss={dismiss}
+            />
+          ) : (
+            <InsightsGrid
+              items={
+                categories.find((c) => c.category === activeFilter)?.items ?? []
+              }
+              hostId={hostId}
+              onDismiss={dismiss}
+            />
+          )}
+
           <InsightsStorageFooter hostId={hostId} />
         </>
       )}
     </section>
+  )
+}
+
+interface CategoryGroup {
+  category: string
+  items: InsightCardData[]
+  topRank: number
+}
+
+/** Segmented filter row: All · Needs attention · one tab per category. */
+function FilterTabs({
+  total,
+  attentionCount,
+  categories,
+  active,
+  onChange,
+}: {
+  total: number
+  attentionCount: number
+  categories: CategoryGroup[]
+  active: string
+  onChange: (id: string) => void
+}) {
+  const base =
+    'inline-flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium transition-colors'
+  const activeCls = 'border-transparent bg-foreground text-background'
+  const inactiveCls =
+    'border-border bg-transparent text-muted-foreground hover:bg-muted hover:text-foreground'
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-1.5"
+      role="tablist"
+      aria-label="Filter insights"
+    >
+      <FilterTab
+        label="All"
+        count={total}
+        selected={active === FILTER_ALL}
+        onClick={() => onChange(FILTER_ALL)}
+        className={cn(base, active === FILTER_ALL ? activeCls : inactiveCls)}
+      />
+      {attentionCount > 0 ? (
+        <FilterTab
+          label="Needs attention"
+          count={attentionCount}
+          icon={<TriangleAlert className="size-3.5" />}
+          selected={active === FILTER_ATTENTION}
+          onClick={() => onChange(FILTER_ATTENTION)}
+          className={cn(
+            base,
+            active === FILTER_ATTENTION
+              ? 'border-transparent bg-amber-500 text-white dark:bg-amber-600'
+              : 'border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100 dark:border-amber-800/60 dark:bg-amber-950/40 dark:text-amber-400'
+          )}
+        />
+      ) : null}
+      {categories.map(({ category, items }) => {
+        const meta = categoryMeta(category)
+        const Icon = meta.icon
+        return (
+          <FilterTab
+            key={category}
+            label={meta.label}
+            count={items.length}
+            icon={<Icon className="size-3.5" strokeWidth={1.5} />}
+            selected={active === category}
+            onClick={() => onChange(category)}
+            className={cn(base, active === category ? activeCls : inactiveCls)}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+function FilterTab({
+  label,
+  count,
+  icon,
+  selected,
+  onClick,
+  className,
+}: {
+  label: string
+  count: number
+  icon?: React.ReactNode
+  selected: boolean
+  onClick: () => void
+  className?: string
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={selected}
+      onClick={onClick}
+      className={className}
+    >
+      {icon}
+      {label}
+      <span className="tabular-nums opacity-70">{count}</span>
+    </button>
+  )
+}
+
+/** One category's header + card grid, used in the grouped "All" view. */
+function CategorySection({
+  category,
+  items,
+  hostId,
+  onDismiss,
+}: {
+  category: string
+  items: InsightCardData[]
+  hostId: number
+  onDismiss: (insight: InsightCardData) => void
+}) {
+  const meta = categoryMeta(category)
+  const Icon = meta.icon
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        <Icon className="size-3.5" strokeWidth={1.5} />
+        {meta.label}
+        <span className="tabular-nums text-muted-foreground/70">
+          {items.length}
+        </span>
+      </div>
+      <InsightsGrid items={items} hostId={hostId} onDismiss={onDismiss} />
+    </div>
+  )
+}
+
+function InsightsGrid({
+  items,
+  hostId,
+  onDismiss,
+}: {
+  items: InsightCardData[]
+  hostId: number
+  onDismiss: (insight: InsightCardData) => void
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+      {items.map((insight) => (
+        <InsightCard
+          key={insight.key}
+          insight={insight}
+          hostId={hostId}
+          onDismiss={onDismiss}
+        />
+      ))}
+    </div>
   )
 }
 

--- a/apps/dashboard/src/components/insights/insights-strip.tsx
+++ b/apps/dashboard/src/components/insights/insights-strip.tsx
@@ -1,0 +1,291 @@
+import {
+  Activity,
+  ArrowRight,
+  ChevronLeft,
+  ChevronRight,
+  RefreshCw,
+  Settings2,
+} from 'lucide-react'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { InsightCard } from '@/components/insights/insight-card'
+import {
+  SEVERITY_META,
+  SEVERITY_ORDER,
+} from '@/components/insights/severity-meta'
+import { AppLink } from '@/components/ui/app-link'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useInsights } from '@/lib/query/use-insights'
+import { buildUrl } from '@/lib/url/url-builder'
+import { cn } from '@/lib/utils'
+
+interface InsightsStripProps {
+  hostId: number
+  className?: string
+}
+
+/**
+ * Compact one-row insights strip for the overview page.
+ *
+ * Renders every active insight in a single horizontally-scrollable row with the
+ * scrollbar hidden (`scrollbar-hide`). When the row overflows, a chevron button
+ * plus an edge fade appear on each scrollable side and page the row by ~one
+ * viewport (`scrollBy`). A "View all insights" header link deep-links to the
+ * full `/insights` board. Shares `useInsights` (and thus counts + dismissals)
+ * with the board and header popover.
+ */
+export function InsightsStrip({ hostId, className }: InsightsStripProps) {
+  const {
+    insights,
+    counts,
+    isLoading,
+    isGenerating,
+    refresh,
+    generate,
+    dismiss,
+  } = useInsights(hostId)
+
+  const hasInsights = insights.length > 0
+
+  // Empty + idle → slim CTA row, so the overview never shows an empty box.
+  if (!hasInsights && !isLoading) {
+    return (
+      <section
+        className={cn(
+          'flex flex-wrap items-center justify-between gap-2 rounded-lg border border-dashed border-border bg-muted/30 px-4 py-3',
+          className
+        )}
+        aria-label="AI insights"
+      >
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Activity className="size-4 shrink-0" />
+          <span>
+            No insights right now. Generate a fresh analysis of this cluster.
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={generate}
+            disabled={isGenerating}
+          >
+            <RefreshCw
+              className={cn('size-3.5', isGenerating && 'animate-spin')}
+            />
+            {isGenerating ? 'Generating…' : 'Generate insights'}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-8 text-muted-foreground hover:text-foreground"
+            aria-label="AI Insights settings"
+            asChild
+          >
+            <AppLink href={buildUrl('/insights-settings', { host: hostId })}>
+              <Settings2 className="size-3.5" />
+            </AppLink>
+          </Button>
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section
+      className={cn('flex flex-col gap-2', className)}
+      aria-label="AI insights"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Activity className="size-4 shrink-0 text-muted-foreground" />
+          <h2 className="text-sm font-medium text-foreground">Insights</h2>
+          {SEVERITY_ORDER.map((sev) =>
+            counts[sev] > 0 ? (
+              <Badge
+                key={sev}
+                variant="outline"
+                className={cn(
+                  'text-[10px] font-medium',
+                  SEVERITY_META[sev].badge
+                )}
+              >
+                {counts[sev]} {SEVERITY_META[sev].label.toLowerCase()}
+              </Badge>
+            ) : null
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+            asChild
+          >
+            <AppLink href={buildUrl('/insights', { host: hostId })}>
+              View all insights
+              <ArrowRight className="size-3.5" />
+            </AppLink>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => {
+              generate()
+              refresh()
+            }}
+            disabled={isGenerating}
+          >
+            <RefreshCw
+              className={cn('size-3.5', isGenerating && 'animate-spin')}
+            />
+            {isGenerating ? 'Refreshing…' : 'Refresh'}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-7 text-muted-foreground hover:text-foreground"
+            aria-label="AI Insights settings"
+            asChild
+          >
+            <AppLink href={buildUrl('/insights-settings', { host: hostId })}>
+              <Settings2 className="size-3.5" />
+            </AppLink>
+          </Button>
+        </div>
+      </div>
+
+      {isLoading && !hasInsights ? (
+        <div className="flex gap-3 overflow-hidden py-1.5">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton
+              key={i}
+              className="h-[132px] w-[19rem] shrink-0 rounded-xl"
+            />
+          ))}
+        </div>
+      ) : (
+        <InsightsScroller measureKey={insights.length}>
+          {insights.map((insight) => (
+            <div key={insight.key} className="w-[19rem] shrink-0">
+              <InsightCard
+                insight={insight}
+                hostId={hostId}
+                onDismiss={dismiss}
+              />
+            </div>
+          ))}
+        </InsightsScroller>
+      )}
+    </section>
+  )
+}
+
+/**
+ * A single-row horizontal scroller with a hidden scrollbar and, only when the
+ * content overflows, a chevron button + edge fade on each scrollable side.
+ * `key`-ing the recompute on the children count means adding/removing cards
+ * re-evaluates overflow (a ResizeObserver alone misses content-width changes).
+ */
+function InsightsScroller({
+  children,
+  measureKey,
+}: {
+  children: React.ReactNode
+  /** Bumps when the rendered card count changes, forcing an overflow re-measure. */
+  measureKey: number
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [canLeft, setCanLeft] = useState(false)
+  const [canRight, setCanRight] = useState(false)
+
+  const update = useCallback(() => {
+    const el = ref.current
+    if (!el) return
+    const max = el.scrollWidth - el.clientWidth
+    setCanLeft(el.scrollLeft > 1)
+    setCanRight(el.scrollLeft < max - 1)
+  }, [])
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    update()
+    el.addEventListener('scroll', update, { passive: true })
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => {
+      el.removeEventListener('scroll', update)
+      ro.disconnect()
+    }
+  }, [update])
+
+  // Content changes (insights loaded / dismissed) change scrollWidth without a
+  // container resize, so re-measure whenever the rendered card count changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: measureKey is the re-measure trigger
+  useEffect(update, [update, measureKey])
+
+  const page = (dir: 1 | -1) => {
+    const el = ref.current
+    if (!el) return
+    el.scrollBy({ left: dir * el.clientWidth * 0.85, behavior: 'smooth' })
+  }
+
+  return (
+    <div className="relative">
+      {canLeft ? (
+        <>
+          <div
+            className="pointer-events-none absolute inset-y-0 left-0 z-10 w-12 bg-gradient-to-r from-background to-transparent"
+            aria-hidden
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="absolute left-1 top-1/2 z-20 size-7 -translate-y-1/2 rounded-full bg-background/90 shadow-sm backdrop-blur"
+            aria-label="Scroll insights left"
+            onClick={() => page(-1)}
+          >
+            <ChevronLeft className="size-4" />
+          </Button>
+        </>
+      ) : null}
+
+      <div
+        ref={ref}
+        className="scrollbar-hide flex gap-3 overflow-x-auto py-1.5"
+      >
+        {children}
+      </div>
+
+      {canRight ? (
+        <>
+          <div
+            className="pointer-events-none absolute inset-y-0 right-0 z-10 w-12 bg-gradient-to-l from-background to-transparent"
+            aria-hidden
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="absolute right-1 top-1/2 z-20 size-7 -translate-y-1/2 rounded-full bg-background/90 shadow-sm backdrop-blur"
+            aria-label="Scroll insights right"
+            onClick={() => page(1)}
+          >
+            <ChevronRight className="size-4" />
+          </Button>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/insights/insights-strip.tsx
+++ b/apps/dashboard/src/components/insights/insights-strip.tsx
@@ -9,6 +9,7 @@ import {
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { InsightCard } from '@/components/insights/insight-card'
+import { InsightsEmptyCta } from '@/components/insights/insights-empty-cta'
 import {
   SEVERITY_META,
   SEVERITY_ORDER,
@@ -52,47 +53,12 @@ export function InsightsStrip({ hostId, className }: InsightsStripProps) {
   // Empty + idle → slim CTA row, so the overview never shows an empty box.
   if (!hasInsights && !isLoading) {
     return (
-      <section
-        className={cn(
-          'flex flex-wrap items-center justify-between gap-2 rounded-lg border border-dashed border-border bg-muted/30 px-4 py-3',
-          className
-        )}
-        aria-label="AI insights"
-      >
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Activity className="size-4 shrink-0" />
-          <span>
-            No insights right now. Generate a fresh analysis of this cluster.
-          </span>
-        </div>
-        <div className="flex items-center gap-1">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="gap-1.5"
-            onClick={generate}
-            disabled={isGenerating}
-          >
-            <RefreshCw
-              className={cn('size-3.5', isGenerating && 'animate-spin')}
-            />
-            {isGenerating ? 'Generating…' : 'Generate insights'}
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="size-8 text-muted-foreground hover:text-foreground"
-            aria-label="AI Insights settings"
-            asChild
-          >
-            <AppLink href={buildUrl('/insights-settings', { host: hostId })}>
-              <Settings2 className="size-3.5" />
-            </AppLink>
-          </Button>
-        </div>
-      </section>
+      <InsightsEmptyCta
+        hostId={hostId}
+        isGenerating={isGenerating}
+        onGenerate={generate}
+        className={className}
+      />
     )
   }
 

--- a/apps/dashboard/src/components/insights/insights-strip.tsx
+++ b/apps/dashboard/src/components/insights/insights-strip.tsx
@@ -1,10 +1,10 @@
 import {
-  Activity,
   ArrowRight,
   ChevronLeft,
   ChevronRight,
   RefreshCw,
   Settings2,
+  Sparkles,
 } from 'lucide-react'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -69,8 +69,8 @@ export function InsightsStrip({ hostId, className }: InsightsStripProps) {
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-          <Activity className="size-4 shrink-0 text-muted-foreground" />
-          <h2 className="text-sm font-medium text-foreground">Insights</h2>
+          <Sparkles className="size-4 shrink-0 text-muted-foreground" />
+          <h2 className="text-sm font-medium text-foreground">AI Insights</h2>
           {SEVERITY_ORDER.map((sev) =>
             counts[sev] > 0 ? (
               <Badge

--- a/apps/dashboard/src/components/insights/severity-meta.ts
+++ b/apps/dashboard/src/components/insights/severity-meta.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared visual metadata for insight severities.
+ *
+ * Single source of truth for the label, icon, and token classes used to render
+ * a severity across the insight surfaces (card, overview strip, insights-page
+ * board). Keeping it here avoids each surface re-deriving colors / labels and
+ * drifting — e.g. a card that says "Notice" next to a header that says "info".
+ */
+
+import type { LucideIcon } from 'lucide-react'
+import { AlertTriangle, Info, TriangleAlert } from 'lucide-react'
+
+import type { InsightSeverity } from '@/lib/insights/types'
+
+export interface SeverityMeta {
+  /** Human label shown on badges. Note: `info` reads as "Notice". */
+  readonly label: string
+  readonly icon: LucideIcon
+  /** Background token for the icon chip. */
+  readonly iconBg: string
+  /** Foreground token for the icon. */
+  readonly iconColor: string
+  /** Tinted outline-badge classes (also used for header count badges). */
+  readonly badge: string
+  /** Left-border accent color (paired with `border-l-2`) to surface severity. */
+  readonly accent: string
+}
+
+export const SEVERITY_META: Record<InsightSeverity, SeverityMeta> = {
+  critical: {
+    label: 'Critical',
+    icon: AlertTriangle,
+    iconBg: 'bg-rose-100 dark:bg-rose-950/50',
+    iconColor: 'text-rose-600 dark:text-rose-400',
+    badge:
+      'border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-800/60 dark:bg-rose-950/40 dark:text-rose-400',
+    accent: 'border-l-rose-400 dark:border-l-rose-500',
+  },
+  warning: {
+    label: 'Warning',
+    icon: TriangleAlert,
+    iconBg: 'bg-amber-100 dark:bg-amber-950/50',
+    iconColor: 'text-amber-600 dark:text-amber-400',
+    badge:
+      'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800/60 dark:bg-amber-950/40 dark:text-amber-400',
+    accent: 'border-l-amber-400 dark:border-l-amber-500',
+  },
+  info: {
+    label: 'Notice',
+    icon: Info,
+    iconBg: 'bg-muted',
+    iconColor: 'text-muted-foreground',
+    badge:
+      'border-border bg-muted/50 text-muted-foreground dark:bg-muted/30 dark:text-muted-foreground',
+    accent: 'border-l-border',
+  },
+}
+
+/** Severity display / sort order, most severe first. */
+export const SEVERITY_ORDER: readonly InsightSeverity[] = [
+  'critical',
+  'warning',
+  'info',
+]

--- a/apps/dashboard/src/lib/insights/collectors.ts
+++ b/apps/dashboard/src/lib/insights/collectors.ts
@@ -12,6 +12,12 @@ import type { Baseline } from './statistical-baseline'
 import type { InsightCandidate, InsightSeverity } from './types'
 
 import { readOnlyQuery } from '../ai/agent/tools/helpers'
+import {
+  checkDetachedParts,
+  checkFailedDictionaries,
+  checkLongRunningQuery,
+  checkStuckMutations,
+} from './operational-checks'
 import { refitBaselineIfStale, scoreAnomaly } from './statistical-baseline'
 
 function extractValue(result: unknown): number | null {
@@ -361,6 +367,63 @@ async function collectReliability(hostId: number): Promise<InsightCandidate[]> {
   return out
 }
 
+// ---------------------------------------------------------------------------
+// Operational collector — cheap point-in-time health checks across storage,
+// reliability and performance (each a single count/aggregate on a small system
+// table). Classification lives in ./operational-checks so it is unit-tested as
+// pure functions; this layer only owns the SQL.
+// ---------------------------------------------------------------------------
+
+async function collectOperational(hostId: number): Promise<InsightCandidate[]> {
+  const out: InsightCandidate[] = []
+
+  // Detached parts — leftovers from failed merges / DETACH; disk without value.
+  const detached = await firstRow(
+    `SELECT count() AS value FROM system.detached_parts`,
+    hostId
+  )
+  if (detached) {
+    const candidate = checkDetachedParts(Number(detached.value) || 0)
+    if (candidate) out.push(candidate)
+  }
+
+  // Stuck mutations — not done yet but already carrying a failure reason.
+  const mutations = await firstRow(
+    `SELECT count() AS value FROM system.mutations WHERE is_done = 0 AND latest_fail_reason != ''`,
+    hostId
+  )
+  if (mutations) {
+    const candidate = checkStuckMutations(Number(mutations.value) || 0)
+    if (candidate) out.push(candidate)
+  }
+
+  // Long-running live query — the single longest currently-executing query,
+  // excluding this collector's own probe of system.processes.
+  const longRunning = await firstRow(
+    `SELECT count() AS value, max(elapsed) AS max_elapsed FROM system.processes WHERE elapsed > 60 AND query NOT ILIKE '%system.processes%'`,
+    hostId
+  )
+  if (longRunning) {
+    const candidate = checkLongRunningQuery(
+      Number(longRunning.max_elapsed) || 0,
+      Number(longRunning.value) || 0
+    )
+    if (candidate) out.push(candidate)
+  }
+
+  // Dictionaries stuck in the FAILED state — every query using them errors.
+  const dictionaries = await firstRow(
+    `SELECT count() AS value FROM system.dictionaries WHERE status = 'FAILED'`,
+    hostId
+  )
+  if (dictionaries) {
+    const candidate = checkFailedDictionaries(Number(dictionaries.value) || 0)
+    if (candidate) out.push(candidate)
+  }
+
+  return out
+}
+
 /**
  * Run all collectors for a host and return de-duplicated candidates,
  * highest severity first.
@@ -372,6 +435,7 @@ export async function collectInsights(
     collectAnomalies(hostId).catch(() => []),
     collectStorage(hostId).catch(() => []),
     collectReliability(hostId).catch(() => []),
+    collectOperational(hostId).catch(() => []),
   ])
 
   const seen = new Set<string>()

--- a/apps/dashboard/src/lib/insights/operational-checks.test.ts
+++ b/apps/dashboard/src/lib/insights/operational-checks.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the operational insight classifiers.
+ *
+ * These are pure functions (no ClickHouse / store I/O), so they are exercised
+ * directly against boundary values — the same approach as `decideSeverity` in
+ * `collectors.test.ts`, but in a file that never mocks `./collectors`, so it is
+ * immune to the process-global `mock.module('./collectors')` used by the
+ * throttle test and stays green in the full `bun test src/lib/insights` run.
+ *
+ * Each `action.href` asserted here MUST match the corresponding `deriveAction`
+ * case in `read-insights.ts`: the inline action only survives the immediate
+ * generate() response, while a page reload re-derives it from the metric. If the
+ * two drift, insights silently lose their link after a reload.
+ */
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  checkDetachedParts,
+  checkFailedDictionaries,
+  checkLongRunningQuery,
+  checkStuckMutations,
+  DETACHED_PARTS_MIN,
+  DETACHED_PARTS_WARN,
+  LONG_QUERY_CRITICAL_SECONDS,
+  LONG_QUERY_WARN_SECONDS,
+  STUCK_MUTATIONS_CRITICAL,
+} from './operational-checks'
+
+describe('checkDetachedParts', () => {
+  test('below the minimum is suppressed', () => {
+    expect(checkDetachedParts(DETACHED_PARTS_MIN - 1)).toBeNull()
+    expect(checkDetachedParts(0)).toBeNull()
+  })
+
+  test('at the minimum surfaces as a notice (info)', () => {
+    const c = checkDetachedParts(DETACHED_PARTS_MIN)
+    expect(c?.severity).toBe('info')
+    expect(c?.category).toBe('storage')
+    expect(c?.metric).toBe('detached_parts')
+    expect(c?.value).toBe(DETACHED_PARTS_MIN)
+    expect(c?.action).toEqual({ label: 'View tables', href: '/tables' })
+  })
+
+  test('at/above the warn threshold escalates to warning', () => {
+    expect(checkDetachedParts(DETACHED_PARTS_WARN)?.severity).toBe('warning')
+    expect(checkDetachedParts(DETACHED_PARTS_WARN + 100)?.severity).toBe(
+      'warning'
+    )
+  })
+
+  test('non-finite input is ignored', () => {
+    expect(checkDetachedParts(Number.NaN)).toBeNull()
+  })
+})
+
+describe('checkStuckMutations', () => {
+  test('zero is suppressed', () => {
+    expect(checkStuckMutations(0)).toBeNull()
+  })
+
+  test('a single stuck mutation is a warning with singular copy', () => {
+    const c = checkStuckMutations(1)
+    expect(c?.severity).toBe('warning')
+    expect(c?.category).toBe('reliability')
+    expect(c?.metric).toBe('stuck_mutations')
+    expect(c?.title).toContain('1 mutation is')
+    expect(c?.action).toEqual({ label: 'View mutations', href: '/mutations' })
+  })
+
+  test('many stuck mutations escalate to critical with plural copy', () => {
+    const c = checkStuckMutations(STUCK_MUTATIONS_CRITICAL)
+    expect(c?.severity).toBe('critical')
+    expect(c?.title).toContain('mutations are')
+  })
+})
+
+describe('checkLongRunningQuery', () => {
+  test('below the warn runtime is suppressed even with many queries', () => {
+    expect(checkLongRunningQuery(LONG_QUERY_WARN_SECONDS - 1, 50)).toBeNull()
+  })
+
+  test('at the warn runtime is a performance warning', () => {
+    const c = checkLongRunningQuery(LONG_QUERY_WARN_SECONDS, 1)
+    expect(c?.severity).toBe('warning')
+    expect(c?.category).toBe('performance')
+    expect(c?.metric).toBe('longest_running_query')
+    expect(c?.action).toEqual({
+      label: 'Open running queries',
+      href: '/running-queries',
+    })
+  })
+
+  test('at/above the critical runtime is critical', () => {
+    expect(
+      checkLongRunningQuery(LONG_QUERY_CRITICAL_SECONDS, 1)?.severity
+    ).toBe('critical')
+  })
+
+  test('a second concurrent long query is mentioned in the detail', () => {
+    expect(checkLongRunningQuery(LONG_QUERY_WARN_SECONDS, 3)?.detail).toContain(
+      '3 queries over a minute'
+    )
+    // A single long query does not tack on the "(N queries...)" clause.
+    expect(
+      checkLongRunningQuery(LONG_QUERY_WARN_SECONDS, 1)?.detail
+    ).not.toContain('queries over a minute')
+  })
+})
+
+describe('checkFailedDictionaries', () => {
+  test('zero is suppressed', () => {
+    expect(checkFailedDictionaries(0)).toBeNull()
+  })
+
+  test('one failed dictionary is a reliability warning with singular copy', () => {
+    const c = checkFailedDictionaries(1)
+    expect(c?.severity).toBe('warning')
+    expect(c?.category).toBe('reliability')
+    expect(c?.metric).toBe('failed_dictionaries')
+    expect(c?.title).toContain('1 dictionary failed')
+    expect(c?.action).toEqual({
+      label: 'View dictionaries',
+      href: '/dictionaries',
+    })
+  })
+
+  test('several failures use plural copy', () => {
+    expect(checkFailedDictionaries(3)?.title).toContain('3 dictionaries failed')
+  })
+})

--- a/apps/dashboard/src/lib/insights/operational-checks.test.ts
+++ b/apps/dashboard/src/lib/insights/operational-checks.test.ts
@@ -13,8 +13,6 @@
  * two drift, insights silently lose their link after a reload.
  */
 
-import { describe, expect, test } from 'bun:test'
-
 import {
   checkDetachedParts,
   checkFailedDictionaries,
@@ -26,6 +24,7 @@ import {
   LONG_QUERY_WARN_SECONDS,
   STUCK_MUTATIONS_CRITICAL,
 } from './operational-checks'
+import { describe, expect, test } from 'bun:test'
 
 describe('checkDetachedParts', () => {
   test('below the minimum is suppressed', () => {

--- a/apps/dashboard/src/lib/insights/operational-checks.ts
+++ b/apps/dashboard/src/lib/insights/operational-checks.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure classifiers for the operational insight collectors.
+ *
+ * Each function maps a raw metric (already extracted from a ClickHouse system
+ * table) to an `InsightCandidate` or `null` when the reading is not worth
+ * surfacing. They are deliberately pure (no ClickHouse / store I/O) so they can
+ * be unit-tested directly against boundary values — the same split the anomaly
+ * collector uses for `decideSeverity`. `collectors.ts` owns the SQL and calls
+ * these; the thresholds live here as named constants so tests and collectors
+ * share one source of truth.
+ */
+
+import type { InsightCandidate } from './types'
+
+/** Detached parts: below this many, don't surface at all. */
+export const DETACHED_PARTS_MIN = 10
+/** At/above this many detached parts, escalate from notice to warning. */
+export const DETACHED_PARTS_WARN = 50
+
+/** At/above this many stuck+failing mutations, escalate warning → critical. */
+export const STUCK_MUTATIONS_CRITICAL = 10
+
+/** A live query must run at least this long (seconds) before we surface it. */
+export const LONG_QUERY_WARN_SECONDS = 300
+/** At/above this runtime (seconds) the long-running query is critical. */
+export const LONG_QUERY_CRITICAL_SECONDS = 1800
+
+/** Render a duration in seconds as a compact human string (`45s` / `12m` / `1.5h`). */
+function formatDuration(seconds: number): string {
+  if (seconds >= 3600) return `${Math.round((seconds / 3600) * 10) / 10}h`
+  if (seconds >= 60) return `${Math.round(seconds / 60)}m`
+  return `${Math.round(seconds)}s`
+}
+
+/**
+ * Detached parts accumulate from failed merges, ATTACH/DETACH operations, or
+ * corruption. They consume disk without being queryable, so a growing count is a
+ * cleanup signal.
+ */
+export function checkDetachedParts(count: number): InsightCandidate | null {
+  if (!Number.isFinite(count) || count < DETACHED_PARTS_MIN) return null
+  return {
+    severity: count >= DETACHED_PARTS_WARN ? 'warning' : 'info',
+    category: 'storage',
+    metric: 'detached_parts',
+    title: `${count} detached parts need review`,
+    detail: `This cluster has ${count} detached parts — usually leftovers from failed merges, ATTACH/DETACH operations, or corruption. They occupy disk without being queryable. Review them and DROP DETACHED PART once you have confirmed they are safe to remove.`,
+    value: count,
+    action: { label: 'View tables', href: '/tables' },
+  }
+}
+
+/**
+ * Mutations that are not done yet AND already carry a failure reason are stuck:
+ * they block subsequent ALTERs on the table and pile up until resolved.
+ */
+export function checkStuckMutations(count: number): InsightCandidate | null {
+  if (!Number.isFinite(count) || count < 1) return null
+  const plural = count > 1
+  return {
+    severity: count >= STUCK_MUTATIONS_CRITICAL ? 'critical' : 'warning',
+    category: 'reliability',
+    metric: 'stuck_mutations',
+    title: `${count} mutation${plural ? 's are' : ' is'} failing to complete`,
+    detail: `${count} mutation${plural ? 's' : ''} ${plural ? 'are' : 'is'} unfinished with a failure reason set. Stuck mutations block further ALTERs on the affected tables and keep retrying — inspect system.mutations for the latest_fail_reason and fix or KILL the mutation.`,
+    value: count,
+    action: { label: 'View mutations', href: '/mutations' },
+  }
+}
+
+/**
+ * A single very long-running live query holds locks and memory; surfacing the
+ * longest one flags a likely runaway scan or a query missing a filter.
+ */
+export function checkLongRunningQuery(
+  maxElapsedSeconds: number,
+  count: number
+): InsightCandidate | null {
+  if (
+    !Number.isFinite(maxElapsedSeconds) ||
+    maxElapsedSeconds < LONG_QUERY_WARN_SECONDS
+  )
+    return null
+  const others = Number.isFinite(count) && count > 1 ? count : 0
+  return {
+    severity:
+      maxElapsedSeconds >= LONG_QUERY_CRITICAL_SECONDS ? 'critical' : 'warning',
+    category: 'performance',
+    metric: 'longest_running_query',
+    title: `A query has been running for ${formatDuration(maxElapsedSeconds)}`,
+    detail: `The longest live query has been running for ${formatDuration(maxElapsedSeconds)}${others ? ` (${others} queries over a minute)` : ''}. Long-running queries hold locks and memory — check for a runaway scan or a missing filter, and cancel it if it is stuck.`,
+    value: Math.round(maxElapsedSeconds),
+    action: { label: 'Open running queries', href: '/running-queries' },
+  }
+}
+
+/**
+ * Dictionaries in the FAILED state error (or fall back) for every query that
+ * uses them — almost always a source-connectivity or definition problem.
+ */
+export function checkFailedDictionaries(
+  count: number
+): InsightCandidate | null {
+  if (!Number.isFinite(count) || count < 1) return null
+  const plural = count > 1
+  return {
+    severity: 'warning',
+    category: 'reliability',
+    metric: 'failed_dictionaries',
+    title: `${count} dictionar${plural ? 'ies' : 'y'} failed to load`,
+    detail: `${count} dictionar${plural ? 'ies are' : 'y is'} in the FAILED state. Queries that read ${plural ? 'these dictionaries' : 'this dictionary'} will error or fall back — check the source connectivity and last_exception in system.dictionaries.`,
+    value: count,
+    action: { label: 'View dictionaries', href: '/dictionaries' },
+  }
+}

--- a/apps/dashboard/src/lib/insights/read-insights.ts
+++ b/apps/dashboard/src/lib/insights/read-insights.ts
@@ -32,10 +32,17 @@ function deriveAction(
       return { label: 'Open running queries', href: '/running-queries' }
     case 'max_active_parts':
     case 'worst_compression_ratio':
+    case 'detached_parts':
       return { label: 'View tables', href: '/tables' }
     case 'readonly_replicas':
     case 'max_replication_delay':
       return { label: 'View replicas', href: '/replicas' }
+    case 'stuck_mutations':
+      return { label: 'View mutations', href: '/mutations' }
+    case 'longest_running_query':
+      return { label: 'Open running queries', href: '/running-queries' }
+    case 'failed_dictionaries':
+      return { label: 'View dictionaries', href: '/dictionaries' }
     default:
       if (category === 'storage')
         return { label: 'View tables', href: '/tables' }

--- a/apps/dashboard/src/routes/(dashboard)/overview.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/overview.tsx
@@ -5,7 +5,7 @@ import type { OverviewChartConfig } from './-charts-config'
 import { OVERVIEW_TABS } from './-charts-config'
 import { lazy, memo, Suspense, useMemo, useState } from 'react'
 import { ClientOnly } from '@/components/client-only'
-import { InsightsPanel } from '@/components/insights/insights-panel'
+import { InsightsStrip } from '@/components/insights/insights-strip'
 import { cardStyles } from '@/components/overview-charts/card-styles'
 import { OverviewCharts } from '@/components/overview-charts/overview-charts-client'
 import { OverviewStatusStrip } from '@/components/overview-charts/overview-status-strip'
@@ -227,7 +227,7 @@ function OverviewPageContent() {
       <OverviewCharts className="mb-4 sm:mb-6" />
 
       <ClientOnly fallback={null}>
-        <InsightsPanel hostId={hostId} className="mb-4 sm:mb-6" />
+        <InsightsStrip hostId={hostId} className="mb-4 sm:mb-6" />
       </ClientOnly>
 
       <ClientOnly

--- a/docs/knowledge/ai-insights.md
+++ b/docs/knowledge/ai-insights.md
@@ -3,7 +3,7 @@ id: ai-insights
 title: AI Insights Engine
 type: spec
 status: active
-updated: 2026-06-20
+updated: 2026-07-04
 tags:
   - insights
   - findings
@@ -32,6 +32,7 @@ is fragmented", "replication is lagging" — generated and **cached server-side*
 | Stage | Module |
 |-------|--------|
 | Collect (deterministic) | `src/lib/insights/collectors.ts` |
+| Operational classifiers (pure) | `src/lib/insights/operational-checks.ts` |
 | Enrich (optional LLM) | `src/lib/insights/llm-enrich.ts` |
 | Orchestrate + persist | `src/lib/insights/generate-insights.ts` |
 | Read + de-dupe | `src/lib/insights/read-insights.ts` |
@@ -42,6 +43,17 @@ is fragmented", "replication is lagging" — generated and **cached server-side*
   porting the SQL/severity heuristics from the agent's `anomaly-tools.ts` /
   `insights-tools.ts`. They **never throw** — any failure yields `[]` so the
   feature degrades on read-only clusters or missing system tables.
+- **Operational collectors** (`collectOperational` in `collectors.ts`) add cheap
+  point-in-time checks across categories — detached parts (`storage`), stuck /
+  failing mutations + FAILED dictionaries (`reliability`), and the longest
+  running live query (`performance`) — each a single count/aggregate on a small
+  system table. Their **classification is split into pure functions** in
+  `operational-checks.ts` (thresholds → `InsightCandidate | null`), mirroring the
+  anomaly collector's `decideSeverity`, so severity logic is unit-tested without
+  ClickHouse I/O (`operational-checks.test.ts`). Adding a metric here **must** be
+  paired with a `deriveAction` case in `read-insights.ts` — the findings store
+  keeps scalars only, so the action link is re-derived from `metric`/`category`
+  on every read; an unmatched metric silently loses its link after a reload.
 - **Enrichment is optional.** When a provider key resolves
   (`isProviderConfigured(resolveProvider(DEFAULT_MODEL).providerId)`), candidates
   pass through one `generateObject` call that tightens wording. With no key (or
@@ -208,11 +220,28 @@ validated server-side** — omitting them reproduces the original behavior.
 
 ## UI
 
-- `src/components/insights/insights-panel.tsx` — overview hero (status strip →
-  KPIs → **insights** → tabs). Renders a slim "Generate insights" CTA when empty.
+Two tailored surfaces share the same `useInsights` hook (so counts + dismissals
+stay in sync) and the same card + severity styling:
+
+- `src/components/insights/insights-strip.tsx` — **overview `/overview` strip**:
+  every active insight in a **single horizontally-scrollable row** with the
+  scrollbar hidden (`scrollbar-hide`). On overflow a chevron button + edge fade
+  appear per scrollable side and page by ~one viewport (`scrollBy`); overflow is
+  re-measured on scroll, container resize, and card-count change. Header carries
+  a **"View all insights"** deep link to `/insights`.
+- `src/components/insights/insights-panel.tsx` — **`/insights` page board**:
+  insights **grouped by category** (Anomalies / Performance / Storage /
+  Reliability, extensible to Queries / Cost) with section headers, a segmented
+  **filter row** (All · a tinted **"Needs attention"** tab for critical+warning ·
+  one tab per present category), and header severity count badges.
 - `src/components/insights/insight-card.tsx` — shadcn `Card` wrapper (never edits
-  `components/ui/`), severity-toned accent, dismiss `X`, and a derived action
-  link (e.g. View tables / Open running queries / Ask the agent).
+  `components/ui/`), a **severity-toned left-accent border**, dismiss `X`, and a
+  derived action link (e.g. View tables / Open running queries / Ask the agent).
+- `src/components/insights/severity-meta.ts` — **single source** for severity
+  label (`info` renders as **"Notice"**), icon, and token classes, shared by the
+  card, strip, and board so they never drift.
+- `src/components/insights/insights-empty-cta.tsx` — shared slim "Generate
+  insights" CTA rendered by both the strip and the board when a host has none.
 - `src/components/insights/insights-popover.tsx` — **global header popover**
   (mirrors `NotificationsPopover`), mounted in `header-actions.tsx` so insights
   surface on every page: severity-toned count badge, top insights with deep
@@ -227,4 +256,19 @@ validated server-side** — omitting them reproduces the original behavior.
 - Health-sweep findings are **not** written to the findings table (only webhook
   dispatch), so reading `source='ai-insight'` returns exactly engine output.
 - Tests: `src/lib/insights/insights.test.ts` (pure key + dismissal logic; shims
-  `window`/`localStorage`). Run with `bun test src/lib/insights`.
+  `window`/`localStorage`). Run with `bun test src/lib/insights`. Note the
+  operational classifiers are tested in `operational-checks.test.ts` (pure, no
+  I/O) rather than `collectors.test.ts`, which is poisoned in the full-suite run
+  by a process-global `mock.module('./collectors')` in
+  `generate-insights.throttle.test.ts` (pre-existing; those 6 collector tests
+  pass in isolation).
+
+## Follow-ups
+
+- **More detectors.** The operational collectors are a starter set. Natural next
+  detectors (each still a cheap single system-table read + a pure classifier in
+  `operational-checks.ts`): long-running merges (`system.merges`), high
+  `parts_to_throw_insert` pressure, growing `system.replication_queue`, dropped
+  connections / rejected inserts, and `cost`-category signals (e.g. cold-storage
+  candidates). Each new metric needs a matching `deriveAction` case and a
+  category in the board's `CATEGORY_META`.

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -107,6 +107,14 @@ sheet, sidebar, skeleton, tabs, tooltip (+ more).
 - Class idioms: card `rounded-xl border bg-card shadow-sm`; dense text
   `text-[13px]`; meta `text-xs text-muted-foreground`; hero title `text-xl
   font-semibold tracking-tight`.
+- Overflow strip: for a single-row scroller that must not wrap, use
+  `scrollbar-hide overflow-x-auto` (util in `styles.css`; also on the overview
+  tab bar) with `py-*` so card shadows/accents/focus rings aren't clipped
+  vertically. When it overflows, show a chevron button + a
+  `from-background`→`transparent` edge fade per scrollable side and page with
+  `scrollBy({ left: ±clientWidth*0.85, behavior: 'smooth' })`; re-measure on
+  scroll, `ResizeObserver`, and content-count change. Reference:
+  `components/insights/insights-strip.tsx`.
 
 ## Brand
 


### PR DESCRIPTION
## Summary

Redesigns both AI Insights surfaces in one PR and adds four new deterministic collectors.

### Overview strip (`/overview`)
- Replaced the multi-row `InsightsPanel` on the overview with a new **one-row** `InsightsStrip`.
- The row scrolls **horizontally with the scrollbar hidden** (`scrollbar-hide`). On overflow, a chevron button + a `from-background`->transparent **edge fade** appear on each scrollable side and page the row by ~one viewport (`scrollBy`). Overflow is re-measured on scroll, `ResizeObserver`, and card-count change.
- Header gains a **"View all insights"** link that deep-links to `/insights`, plus severity-count badges, Refresh, and the settings gear. Header now matches the board (Sparkles + "AI Insights").

### Insights board (`/insights`)
- `InsightsPanel` is now a **classified, filterable board**: insights are grouped into category sections (Anomalies, Performance, Storage, Reliability, Queries, Cost), most-severe category first.
- A segmented **filter row** (All, Needs attention, per-category) toggles views; the amber **"Needs attention"** filter surfaces every critical/warning insight. Filters use `aria-pressed` toggle-button semantics.
- Each card carries a **severity-toned left accent** + badge; severity `info` now reads **"Notice"**. Single source of truth in `severity-meta.ts`, shared by strip, board, and card.
- Falls back to "All" when a selected filter empties after dismissals.

### New operational collectors (`lib/insights/collectors.ts`)
Four cheap, deterministic detectors (each poison-proof: never throws, returns `[]` on failure), backed by new pure classifiers in `operational-checks.ts`:

| Metric | Category | Severity |
|--------|----------|----------|
| `detached_parts` (>= 10) | storage | warning >= 50, else info |
| `stuck_mutations` (failing) | reliability | critical >= 10, else warning |
| `longest_running_query` (> 60s) | performance | critical >= 1800s / warning >= 300s |
| `failed_dictionaries` | reliability | warning |

`deriveAction()` in `read-insights.ts` gains a case per metric (tables / mutations / running-queries / dictionaries) so action links survive reload + cron (the findings store persists only scalars, so the action is re-derived from metric + category).

## Testing / verification
- `bun test src/lib/insights`: **334 pass / 6 fail** (was 320 / 6 before this PR) -> **+14 new passing, zero new failures**. The 6 failures are pre-existing: `generate-insights.throttle.test.ts` calls `mock.module('./collectors')`, which is process-global + hoisted and poisons `collectors.test.ts` in the full-suite run (both pass in isolation). Not introduced here.
- `bun run type-check`: **230 = baseline** (all stale `routeTree.gen.ts` route-registration noise). **Zero new.**
- `bun run type-check:test`: **231 = baseline. Zero new.**
- Biome clean.

### Test-coverage note (deviation to call out)
New tests live in **`operational-checks.test.ts`** (pure classifiers), not `collectors.test.ts` as the task suggested -- `collectors.test.ts` is poisoned in the full-suite run by the throttle test's global `mock.module`, so a new test there would be unreliable. Tradeoff: the **classifier logic, severity thresholds, and `deriveAction` href pairing are fully unit-tested**, but the SQL wiring inside `collectOperational` (the four `firstRow` queries + `Number(row.value)` extraction) has **no end-to-end test**. The queries use only stable base columns (`system.detached_parts`; `system.mutations.is_done`/`latest_fail_reason`; `system.processes.elapsed`/`query`; `system.dictionaries.status`).

### QA pending
Could not run the browser -- **visual / interaction QA of the strip scroll affordances (chevrons, fades, hidden scrollbar) and the board filters is pending**. Type-check, unit tests, and lint are all verified above.

## Follow-ups
More detectors are scoped in `docs/knowledge/ai-insights.md` (Follow-ups) and intentionally kept out of this PR to keep it reviewable.
