### PR TITLE
fix(history-queries): enable row expand + share running-queries design

### DIFF
--- a/apps/dashboard/src/components/data-table/cells/code-dialog-format.tsx
+++ b/apps/dashboard/src/components/data-table/cells/code-dialog-format.tsx
@@ -422,7 +422,7 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
           'block min-w-0 truncate font-mono text-xs text-muted-foreground',
           options?.trigger_classname
         )}
-        title={formatted}
+        title={value}
       >
         {formatted}
       </code>

--- a/apps/dashboard/src/components/data-table/cells/code-dialog-format.tsx
+++ b/apps/dashboard/src/components/data-table/cells/code-dialog-format.tsx
@@ -53,6 +53,14 @@ export interface CodeDialogOptions {
   /** Force the dialog trigger for short content; defaults to false. */
   force_dialog?: boolean
   /**
+   * Render a plain, non-interactive truncated preview instead of a dialog
+   * trigger. Use when the cell lives inside a clickable/expandable row: a
+   * nested `<button>` would otherwise swallow the row click (see
+   * `shouldExpandOnRowClick`). The full content is expected to be surfaced
+   * elsewhere (e.g. an expanded detail panel). Defaults to false.
+   */
+  inline?: boolean
+  /**
    * Add a "Query Plan" tab that runs `EXPLAIN` for the SQL. Only takes effect
    * when the detected language is SQL. Defaults to false.
    */
@@ -404,6 +412,22 @@ export const CodeDialogFormat = memo(function CodeDialogFormat({
       /* noop */
     }
   }, [clearCopyTimer, content])
+
+  // Inline mode: a plain, non-interactive truncated preview so a clickable
+  // parent row (e.g. an expandable table row) is never blocked by this cell.
+  if (options?.inline) {
+    return (
+      <code
+        className={cn(
+          'block min-w-0 truncate font-mono text-xs text-muted-foreground',
+          options?.trigger_classname
+        )}
+        title={formatted}
+      >
+        {formatted}
+      </code>
+    )
+  }
 
   if (!options?.force_dialog && formatted.length < truncate_length) {
     return (

--- a/apps/dashboard/src/lib/query-config/declarative/schema.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/schema.ts
@@ -118,6 +118,7 @@ const codeDialogFormatArgsSchema = z.object({
   dialog_classname: z.string().optional(),
   show_explorer_link: z.boolean().optional(),
   force_dialog: z.boolean().optional(),
+  inline: z.boolean().optional(),
   show_query_plan: z.boolean().optional(),
 })
 

--- a/apps/dashboard/src/lib/query-config/queries/history-queries.ts
+++ b/apps/dashboard/src/lib/query-config/queries/history-queries.ts
@@ -501,14 +501,16 @@ ${historyQueryTail}
     query_duration: ColumnFormat.Duration,
     query_kind: ColumnFormat.ColoredBadge,
     query_cache_usage: ColumnFormat.ColoredBadge,
+    // Inline preview (not a dialog trigger): a nested button would swallow the
+    // row click and block inline expansion. The full SQL lives in the expanded
+    // row's "Full query" code section, mirroring the running-queries detail.
     query: [
       ColumnFormat.CodeDialog,
       {
         max_truncate: 100,
         hide_query_comment: true,
-        dialog_title: 'Query',
         trigger_classname: '!max-w-[280px] overflow-hidden',
-        force_dialog: true,
+        inline: true,
       },
     ],
     event_time: ColumnFormat.RelatedTime,


### PR DESCRIPTION
## The two asks
1. **Row-expand is broken** on `/history-queries?host=0` ("could not expand row").
2. **Share the running-queries design** — reuse the same expand/detail + visual language.

## Root cause of the expand bug (precise)
The history-queries `query` column was the **only** config in the repo setting `force_dialog: true` (`history-queries.ts`). In `code-dialog-format.tsx`, a `CodeDialog` cell renders a plain `<code>` preview for short content, **but with `force_dialog: true` it is _always_ a `<button>` dialog trigger** (regardless of length). The generic data-table's row-expand only fires when the click target is **not** inside an interactive element (`shouldExpandOnRowClick` rejects `button, a, input, …`). Because the query text is the widest / most natural thing to click and it was a permanent button, clicking it opened the SQL dialog and never expanded the row — perceived as "could not expand".

The expand *mechanism* itself was fully intact (chevron column, `getRowCanExpand`, `computeTableBodyRenderKey` includes `expanded`, `createExpandedPanel` is crash-safe). Every sibling query page omits `force_dialog`, so their short-query cells already fall through to the row and expand — only history opted out of that.

## The fix (surgical — no new table)
- Add an opt-in **`inline`** mode to the shared `CodeDialog` formatter: renders a plain, non-interactive truncated preview (reusing the existing comment-strip + truncation), so a nested button never swallows the parent row click. Opt-in → zero behavior change for every other `CodeDialog` usage.
- Switch the history `query` column to `inline: true` (drop `force_dialog`). The row now expands on click like **running-queries**; the full SQL is shown in the expanded row's **"Full query"** code section, and hovering the preview tooltips the full query (`title={value}`, matching running-queries' `title={d.query}`).

## Scope — what "share the design" means here (B, not A)
This PR delivers **interaction + detail-panel parity**: the row expands like running-queries and the expanded panel already renders in the running-queries visual language (see below). It does **not** restyle the page *chrome* (toolbar/header) into running-queries' bespoke `RunningQueriesView` — that would be a ~1500-line fork ("A"), which contradicts the "don't fork a parallel implementation / keep it surgical" constraint. If a full chrome restyle is wanted, that's a follow-up; the `inline` option and expand fix here survive into it unchanged.

## What is reused vs. new (why no fork)
There is **no shared expand/detail component** between the pages: running-queries' `ExpandedRow` is bespoke and coupled to `system.processes` (db / interface / address / **kill query**), none of which exist in `system.query_log`; each redesigned sibling (slow #2272, expensive #2276, running #2279) *forked* its own table, and failed-queries #2278 was improved while staying on the generic table. So rather than fork a parallel implementation, this leans on the existing shared pieces:
- history's expanded panel already uses `createExpandedPanel`, whose own docstring calls it *"the config-driven counterpart to the bespoke running-queries `ExpandedRow`"* — same OKLCH tokens, bordered cards, uppercase labels, `<pre>` code block. The only reason it didn't read as "matching" is that expansion was broken, so nobody could see it.
- **New code:** just the additive `inline` option on the shared formatter (+ the 1-line config switch + declarative-schema sync + full-query tooltip). No parallel table.

## Trade-off for the reviewer to sign off
`inline: true` **removes the inline rich-SQL dialog** (syntax highlight / beautify / copy / query-plan) that history previously had on its query cell. The full SQL is still one click away in the expanded detail panel, and the action column keeps Explorer/Explain. This matches running-queries' philosophy (plain query text in the row, detail on expand), but on a *history* page quick SQL inspection is arguably more valuable — flagging explicitly so it can be vetoed cheaply if you'd rather keep the dialog.

## Verification
- `bunx tsc --noEmit -p tsconfig.json` → **231** errors (baseline **231**, i.e. **0 new**).
- `bunx tsc --noEmit -p tsconfig.test.json` → **240** (baseline **240**, **0 new**). Touched files are absent from the error lists (the ~230 pre-existing `routeTree.gen`/route-typegen errors are unrelated).
- `biome check` clean on all touched files. Targeted unit tests green (schema 30 pass; registry-completeness + queries-catalog 25 pass).
- **QA pending — no browser in this environment.** The fix is verified by static analysis + the confirmed root cause, not an interactive click-to-expand run. Please spot-check `/history-queries?host=0`:
  - **Desktop table:** clicking a row (incl. the query text) should expand to the detail panel with the full SQL; long queries should no longer open the old dialog.
  - **Card view (narrow width):** history has `defaultView: 'auto'` + a `card` block with `primary: 'query'`, which renders through the same `CodeDialog` path — so `inline: true` also applies there (the card's query is no longer a dialog trigger). Confirm the card's own tap-to-expand still surfaces the query.

Held for review — **no auto-merge armed.**
