### PR TITLE
fix(query-config): keep query-metric-log flip-safe (bespoke expandable is TS-only)

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/flip-safety.test.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/flip-safety.test.ts
@@ -96,6 +96,17 @@ const BEHAVIOR_FIELDS = [
   'columnFilters',
 ] as const
 
+// Behavior fields a specific catalog config keeps TS-only ON PURPOSE because the
+// declarative schema cannot express them — declared here so the drop is explicit,
+// not silent (any UNLISTED drop still fails the check below). `query-metric-log`'s
+// `expandable` is a bespoke, lazily-loaded React panel
+// (createQueryMetricLogExpandedDetails); `compileExpandable` only supports the
+// serialisable `config-details` variant, so the panel stays authoritative in the
+// TS config while the mirror still validates the SQL/columns surface.
+const TS_ONLY_BEHAVIOR: Record<string, ReadonlySet<string>> = {
+  'query-metric-log': new Set(['expandable']),
+}
+
 // Catalog names with NO config of the same name in the central `queries`
 // registry. Both are real TS configs (`keeperPresenceConfig`,
 // `clusterLiveMetricsAllConfig`) consumed by DIRECT IMPORT in
@@ -183,7 +194,9 @@ describe('declarative catalog — flip-safety invariants', () => {
       test('flip preserves every behavior field the TS config defines', () => {
         const dropped = BEHAVIOR_FIELDS.filter(
           (field) =>
-            tsResolved[field] !== undefined && declResolved[field] === undefined
+            tsResolved[field] !== undefined &&
+            declResolved[field] === undefined &&
+            !TS_ONLY_BEHAVIOR[name]?.has(field)
         )
         expect(dropped).toEqual([])
       })


### PR DESCRIPTION
## Problem
Main's `Test` / `test:query-config` job is red: the declarative catalog **flip-safety** invariant reports `query-metric-log` dropping the `expandable` behavior field when resolved through its declarative mirror. Introduced by #2287, which added a bespoke expandable panel to the TS config.

## Root cause
`query-metric-log`'s expandable is `createQueryMetricLogExpandedDetails()` — a lazily-loaded `<Suspense><LazyPanel>` React panel. `compileExpandable` only supports the serialisable `type: 'config-details'` spec, so this panel **cannot** be expressed declaratively. The mirror's own comment already says expandable is *intentionally not represented / excluded from the comparison*, but the flip-safety `dropped` check never honored that exclusion.

## Fix
Add an explicit, documented per-config `TS_ONLY_BEHAVIOR` allowlist in `flip-safety.test.ts` (mirrors the existing `DIRECT_IMPORT_ONLY` pattern) marking `query-metric-log.expandable` as intentionally TS-only. The mirror still validates the SQL/columns surface; the bespoke panel stays authoritative in the TS config. **Any unlisted drop still fails** — the invariant stays protective for every other config.

## Verification
`bun test src/lib/query-config/declarative/` → **587 pass / 0 fail** (17 files). Not a global loosening of the check.