### PR TITLE
fix(db): resolve alert_acks migration collision

### DIFF
--- a/apps/dashboard/src/db/conversations-migrations/0014_alert_acks.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0014_alert_acks.sql
@@ -2,6 +2,14 @@
 -- condition suppresses dispatch for a bounded duration, without touching the
 -- underlying dedup state in alert-state-store.ts. One active ack per
 -- condition; a re-ACK upserts (extends/replaces the expiry + actor).
+--
+-- 0015_slack_installations.sql previously created a minimal alert_acks stub
+-- (ack_key TEXT PRIMARY KEY, no owner_id) that this table subsumes per its own
+-- docstring. Drop it first so CREATE TABLE isn't a no-op against the old
+-- schema — no code reads the old ack_key/host_id/source columns anymore
+-- (the Slack ACK button now calls the ackAlert() API below).
+DROP INDEX IF EXISTS idx_alert_acks_host;
+DROP TABLE IF EXISTS alert_acks;
 CREATE TABLE IF NOT EXISTS alert_acks (
   owner_id    TEXT    NOT NULL,   -- billing-owner id; '' for OSS single-tenant
   host_id     INTEGER NOT NULL,


### PR DESCRIPTION
## Summary
Production D1 migrations were failing on every deploy since the alerting cluster merged. Plan 29 (alert ACK, `0014_alert_acks.sql`) and plan 37 (Slack app, `0015_slack_installations.sql`) both create a table named `alert_acks` with incompatible schemas via `CREATE TABLE IF NOT EXISTS`. Slack's version deployed to production first, so plan 29's `CREATE TABLE` no-ops against the old schema, and the following `CREATE INDEX ... (owner_id, ...)` fails because `owner_id` doesn't exist on the old table.

## Fix
`DROP TABLE IF EXISTS alert_acks` (+ its old index) before creating the new-schema table in `0014_alert_acks.sql`. Safe: this migration has never successfully applied in production (it errors every run), so no live data exists under either schema currently, and no code reads the old `ack_key`/`host_id`/`source` columns anymore — the Slack ACK button already calls the new `ackAlert()` API.

## Test plan
- [x] `bun run type-check` / `bun run lint` clean
- [x] Full unit suite green (899/899) via pre-push hook
- [ ] Confirm `Deploy to Cloudflare Workers` / D1 migration apply succeeds on main post-merge