### PR TITLE
fix(ci): drop text coverage reporter to avoid Bun WriteFailed crash

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,10 +60,14 @@ jobs:
 
       - name: Run Bun tests with coverage
         working-directory: apps/dashboard
-        run: bun run test:coverage
+        # Uses the lcov-only CI script (drops --coverage-reporter=text) — the
+        # giant per-file text table appears to trip a large-stdout-write bug
+        # in Bun's coverage reporter (`error: An internal error occurred
+        # (WriteFailed)`) even on 1.3.14. lcov is all codecov-action needs.
+        run: bun run test:coverage:ci
 
       - name: Run workspace package tests with coverage
-        run: bun run test:packages
+        run: bun run test:packages:ci
 
       - name: Upload Bun coverage to Codecov
         uses: codecov/codecov-action@v7
@@ -209,4 +213,4 @@ jobs:
         run: bun run test:query-config
 
       - name: Run package integration tests
-        run: bun run test:packages
+        run: bun run test:packages:ci

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -29,6 +29,7 @@
     "test": "bun test src/ --isolate",
     "test:query-config": "bun test src/lib/query-config --isolate",
     "test:coverage": "bun test src/ --isolate --coverage --coverage-reporter=lcov --coverage-reporter=text",
+    "test:coverage:ci": "bun test src/ --isolate --coverage --coverage-reporter=lcov",
     "test:component": "cypress open --component",
     "test:component:headless": "cypress run --component",
     "test:e2e": "cypress open --e2e",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:query-config": "cd apps/dashboard && bun run test:query-config",
     "test:coverage": "(cd apps/dashboard && bun run test:coverage) && bun run test:packages",
     "test:packages": "bun test packages --isolate --coverage --coverage-reporter=lcov --coverage-reporter=text",
+    "test:packages:ci": "bun test packages --isolate --coverage --coverage-reporter=lcov",
     "test:component": "cd apps/dashboard && bun run test:component",
     "test:component:headless": "cd apps/dashboard && bun run test:component:headless",
     "test:e2e": "cd apps/dashboard && bun run test:e2e",


### PR DESCRIPTION
## Summary

Closes #2299.

**Issue 1 (the actual CI failure) — fixed:**
`.github/workflows/test.yml`'s `unit-tests` job ran `bun run test:coverage`,
which invokes bun's coverage reporter with both `--coverage-reporter=text`
(a giant per-file table) and `--coverage-reporter=lcov`. The huge stdout dump
appears to trip a large-write bug in Bun's coverage reporter
(`error: An internal error occurred (WriteFailed)`) even on the 1.3.14 pin
that was supposed to fix this exact class of bug.

Fix: added lcov-only `test:coverage:ci` (apps/dashboard) and
`test:packages:ci` (root) scripts, and switched all three coverage-producing
steps in `.github/workflows/test.yml` to use them:
- `unit-tests` job → `bun run test:coverage:ci` (apps/dashboard) +
  `bun run test:packages:ci` (root, feeds the codecov upload)
- `test-queries-config` job → `bun run test:packages:ci` (same
  `bun test packages --coverage` invocation, same crash risk)

The original `test:coverage` / `test:packages` scripts (text+lcov) are left
untouched for local human-readable dev use, and `.husky/pre-push` still uses
`test:packages` locally. `codecov-action`'s `files:` input
(`./apps/dashboard/coverage/lcov.info,./coverage/lcov.info`) is unaffected —
both lcov files are still produced by the `:ci` scripts (verified locally,
557k / 50k respectively).

**Issue 2 (pre-existing `URL is not defined` test pollution) — already fixed, no change needed:**
The issue suspected `time-range-context.test.tsx`'s `GlobalRegistrator.register()`
(from `@happy-dom/global-registrator`) wasn't calling `unregister()` in
`afterAll`, leaking a patched global `URL` into later test files
(`src/routes/api/v1/charts/**`). Checked the file — it already has
`afterAll(async () => { await GlobalRegistrator.unregister() })`, added in
#2265 alongside the test itself. Ran the full suite three times locally on
Bun 1.3.14 (the exact version CI pins): `bun test src/ --isolate` inside
`apps/dashboard` → **5724 pass, 0 fail** every time, including all
`charts/__tests__/*` files. The original ~250-failure repro in the issue was
observed on Bun 1.3.11 in a sandboxed environment that couldn't reach
1.3.14; it does not reproduce on the CI-pinned version, so no code change
was made for Issue 2.

## Test plan
- [x] `bun install` (root + apps/dashboard)
- [x] `bun run lint` — clean
- [x] `bun run build` (apps/dashboard) — exit 0, full prerender succeeds
- [x] `bun test src/ --isolate` (apps/dashboard) — 5724 pass, 0 fail, no WriteFailed
- [x] `bun run test:coverage:ci` (apps/dashboard) — same pass count, `coverage/lcov.info` produced (557k)
- [x] `bun run test:packages:ci` (root) — 899 pass, 0 fail, `coverage/lcov.info` produced (50k)
- [x] `.husky/pre-push` ran end-to-end on push (biome check, test:unit, test:packages) — all green