### PR TITLE
feat(insights): normalized slow-query-patterns table

### DIFF
--- a/apps/dashboard/src/lib/query-config/index.ts
+++ b/apps/dashboard/src/lib/query-config/index.ts
@@ -71,6 +71,7 @@ import { queryDetailConfig } from './queries/query-detail'
 import { queryViewsLogConfig } from './queries/query-views-log'
 import { runningQueriesConfig } from './queries/running-queries'
 import { slowQueriesConfig } from './queries/slow-queries'
+import { slowQueryPatternsConfig } from './queries/slow-query-patterns'
 // Thread Analysis
 import { threadAnalysisConfig } from './queries/thread-analysis'
 import { loginAttemptsConfig } from './security/login-attempts'
@@ -173,6 +174,7 @@ export const queries: Array<QueryConfig> = [
   expensiveQueriesConfig,
   expensiveQueriesByMemoryConfig,
   slowQueriesConfig,
+  slowQueryPatternsConfig,
   userProcessesConfig,
   queryMetricLogConfig,
 

--- a/apps/dashboard/src/lib/query-config/queries/slow-query-patterns.ts
+++ b/apps/dashboard/src/lib/query-config/queries/slow-query-patterns.ts
@@ -1,0 +1,323 @@
+import { ClockIcon, DatabaseIcon, LayersIcon, UserIcon } from 'lucide-react'
+
+import type { FilterSchema } from '@/lib/filters/types'
+import type { QueryConfig, VersionedSql } from '@/types/query-config'
+
+import { FILTER_PLACEHOLDER } from '@/lib/filters/where-builder'
+import { QUERY_LOG } from '@/lib/table-notes'
+import { ColumnFormat } from '@/types/column-format'
+
+/**
+ * Raw rows contributing to a normalized query pattern, before `GROUP BY
+ * normalized_query_hash`. Filters from {@link slowQueryPatternsFilterSchema}
+ * apply here (via {@link FILTER_PLACEHOLDER}) so "filter by user" narrows the
+ * executions that feed a pattern, not the pattern's representative values.
+ */
+const rawRowsSelect = `
+    SELECT
+        normalized_query_hash,
+        query,
+        user,
+        query_kind,
+        current_database,
+        event_time,
+        query_duration_ms,
+        memory_usage,
+        read_rows,
+        read_bytes,
+        written_bytes,
+        result_rows,
+        exception_code,
+        ProfileEvents`
+
+const queryLogDynamicOptions = (column: string) => ({
+  table: 'system.query_log',
+  column,
+  where: 'event_time > now() - toIntervalDay(7)',
+})
+
+/**
+ * Schema-driven filter definition for the Slow Query Patterns page.
+ * Time window defaults to the last 24 hours so the aggregation stays cheap;
+ * the user can widen or narrow it (and filter by user/query_kind/database)
+ * from the filter bar.
+ */
+export const slowQueryPatternsFilterSchema: FilterSchema = {
+  fields: [
+    {
+      key: 'event_time',
+      column: 'event_time',
+      label: 'Time',
+      type: 'datetime',
+      operators: ['withinHours', 'between', 'gte', 'lte'],
+      icon: ClockIcon,
+      options: [
+        { label: 'Last 1 hour', value: '1' },
+        { label: 'Last 6 hours', value: '6' },
+        { label: 'Last 24 hours', value: '24' },
+        { label: 'Last 7 days', value: '168' },
+        { label: 'Last 30 days', value: '720' },
+      ],
+      description: 'Relative window or an explicit date range.',
+      defaultValue: { operator: 'withinHours', value: '24' },
+    },
+    {
+      key: 'user',
+      column: 'user',
+      label: 'User',
+      type: 'select',
+      operators: ['in', 'notIn', 'eq', 'ne', 'contains'],
+      dynamicOptions: queryLogDynamicOptions('user'),
+      icon: UserIcon,
+      description: 'Restrict the underlying executions to this user.',
+    },
+    {
+      key: 'query_kind',
+      column: 'query_kind',
+      label: 'Query kind',
+      type: 'select',
+      operators: ['in', 'eq', 'ne'],
+      icon: LayersIcon,
+      options: [
+        { label: 'Select', value: 'Select' },
+        { label: 'Insert', value: 'Insert' },
+        { label: 'Create', value: 'Create' },
+        { label: 'Alter', value: 'Alter' },
+        { label: 'Drop', value: 'Drop' },
+        { label: 'Rename', value: 'Rename' },
+        { label: 'Optimize', value: 'Optimize' },
+        { label: 'System', value: 'System' },
+        { label: 'Show', value: 'Show' },
+        { label: 'Set', value: 'Set' },
+        { label: 'Backup', value: 'Backup' },
+      ],
+    },
+    {
+      key: 'database',
+      column: 'current_database',
+      label: 'Database',
+      type: 'select',
+      operators: ['in', 'eq', 'ne', 'contains'],
+      dynamicOptions: queryLogDynamicOptions('current_database'),
+      icon: DatabaseIcon,
+    },
+  ],
+  presets: [
+    {
+      name: 'Last hour',
+      icon: ClockIcon,
+      filters: [{ key: 'event_time', operator: 'withinHours', value: '1' }],
+    },
+    {
+      name: 'Selects only',
+      icon: LayersIcon,
+      filters: [{ key: 'query_kind', operator: 'in', value: 'Select' }],
+    },
+  ],
+}
+
+/**
+ * Normalized slow-query patterns: `system.query_log` aggregated by
+ * `normalized_query_hash`, mirroring ClickHouse Cloud's Query Insights
+ * "Slow Patterns" table. Foundation for the rest of the Query Insights epic
+ * (overview cards, detail flyout, insights API) — keep column names stable.
+ */
+export const slowQueryPatternsConfig: QueryConfig = {
+  name: 'slow-query-patterns',
+  description:
+    'Query patterns aggregated by normalized_query_hash — calls, duration percentiles, resource usage, and errors per pattern',
+  docs: QUERY_LOG,
+  tableCheck: 'system.query_log',
+  filterSchema: slowQueryPatternsFilterSchema,
+  sql: [
+    {
+      since: '19.1',
+      description: 'Base query without query_cache_usage',
+      sql: `
+    WITH filtered AS (
+      SELECT q.* FROM (
+${rawRowsSelect}
+        FROM system.query_log
+        WHERE type IN ('QueryFinish', 'ExceptionWhileProcessing')
+      ) AS q
+      ${FILTER_PLACEHOLDER}
+    ),
+    base_metrics AS (
+      SELECT
+          normalized_query_hash,
+          any(query) AS normalized_query,
+          any(user) AS user,
+          any(query_kind) AS query_kind,
+          any(current_database) AS database,
+          count() AS calls,
+          sum(query_duration_ms) / 1000 AS total_duration,
+          avg(query_duration_ms) / 1000 AS avg_duration,
+          quantile(0.5)(query_duration_ms) / 1000 AS p50_duration,
+          quantile(0.95)(query_duration_ms) / 1000 AS p95_duration,
+          quantile(0.99)(query_duration_ms) / 1000 AS p99_duration,
+          max(query_duration_ms) / 1000 AS max_duration,
+          sum(ProfileEvents['OSCPUVirtualTimeMicroseconds']) / 1000000 AS cpu_time,
+          max(memory_usage) AS peak_memory,
+          formatReadableSize(max(memory_usage)) AS readable_peak_memory,
+          sum(read_rows) AS read_rows,
+          formatReadableQuantity(sum(read_rows)) AS readable_read_rows,
+          sum(read_bytes) AS read_bytes,
+          formatReadableSize(sum(read_bytes)) AS readable_read_bytes,
+          sum(result_rows) AS result_rows,
+          formatReadableQuantity(sum(result_rows)) AS readable_result_rows,
+          sum(written_bytes) AS written_bytes,
+          formatReadableSize(sum(written_bytes)) AS readable_written_bytes,
+          countIf(exception_code != 0) AS errors,
+          0 AS cache_hit_ratio
+      FROM filtered
+      GROUP BY normalized_query_hash
+    )
+    SELECT
+        *,
+        round(100 * calls / nullIf(max(calls) OVER (), 0), 2) AS pct_calls,
+        round(100 * peak_memory / nullIf(max(peak_memory) OVER (), 0), 2) AS pct_peak_memory,
+        round(100 * read_rows / nullIf(max(read_rows) OVER (), 0), 2) AS pct_read_rows,
+        round(100 * read_bytes / nullIf(max(read_bytes) OVER (), 0), 2) AS pct_read_bytes,
+        round(100 * result_rows / nullIf(max(result_rows) OVER (), 0), 2) AS pct_result_rows,
+        round(100 * written_bytes / nullIf(max(written_bytes) OVER (), 0), 2) AS pct_written_bytes,
+        round(100 * cache_hit_ratio / nullIf(max(cache_hit_ratio) OVER (), 0), 2) AS pct_cache_hit_ratio
+    FROM base_metrics
+    ORDER BY total_duration DESC
+    LIMIT 1000
+  `,
+    },
+    {
+      since: '24.1',
+      description:
+        'Added query_cache_usage-derived cache_hit_ratio (query_cache_usage requires CH 24.1+)',
+      sql: `
+    WITH filtered AS (
+      SELECT q.* FROM (
+${rawRowsSelect},
+        query_cache_usage
+        FROM system.query_log
+        WHERE type IN ('QueryFinish', 'ExceptionWhileProcessing')
+      ) AS q
+      ${FILTER_PLACEHOLDER}
+    ),
+    base_metrics AS (
+      SELECT
+          normalized_query_hash,
+          any(query) AS normalized_query,
+          any(user) AS user,
+          any(query_kind) AS query_kind,
+          any(current_database) AS database,
+          count() AS calls,
+          sum(query_duration_ms) / 1000 AS total_duration,
+          avg(query_duration_ms) / 1000 AS avg_duration,
+          quantile(0.5)(query_duration_ms) / 1000 AS p50_duration,
+          quantile(0.95)(query_duration_ms) / 1000 AS p95_duration,
+          quantile(0.99)(query_duration_ms) / 1000 AS p99_duration,
+          max(query_duration_ms) / 1000 AS max_duration,
+          sum(ProfileEvents['OSCPUVirtualTimeMicroseconds']) / 1000000 AS cpu_time,
+          max(memory_usage) AS peak_memory,
+          formatReadableSize(max(memory_usage)) AS readable_peak_memory,
+          sum(read_rows) AS read_rows,
+          formatReadableQuantity(sum(read_rows)) AS readable_read_rows,
+          sum(read_bytes) AS read_bytes,
+          formatReadableSize(sum(read_bytes)) AS readable_read_bytes,
+          sum(result_rows) AS result_rows,
+          formatReadableQuantity(sum(result_rows)) AS readable_result_rows,
+          sum(written_bytes) AS written_bytes,
+          formatReadableSize(sum(written_bytes)) AS readable_written_bytes,
+          countIf(exception_code != 0) AS errors,
+          round(100 * countIf(query_cache_usage = 'Read') / count(), 2) AS cache_hit_ratio
+      FROM filtered
+      GROUP BY normalized_query_hash
+    )
+    SELECT
+        *,
+        round(100 * calls / nullIf(max(calls) OVER (), 0), 2) AS pct_calls,
+        round(100 * peak_memory / nullIf(max(peak_memory) OVER (), 0), 2) AS pct_peak_memory,
+        round(100 * read_rows / nullIf(max(read_rows) OVER (), 0), 2) AS pct_read_rows,
+        round(100 * read_bytes / nullIf(max(read_bytes) OVER (), 0), 2) AS pct_read_bytes,
+        round(100 * result_rows / nullIf(max(result_rows) OVER (), 0), 2) AS pct_result_rows,
+        round(100 * written_bytes / nullIf(max(written_bytes) OVER (), 0), 2) AS pct_written_bytes,
+        round(100 * cache_hit_ratio / nullIf(max(cache_hit_ratio) OVER (), 0), 2) AS pct_cache_hit_ratio
+    FROM base_metrics
+    ORDER BY total_duration DESC
+    LIMIT 1000
+  `,
+    },
+  ] as VersionedSql[],
+
+  rowClassName: (row) => {
+    const totalDuration = Number(row.total_duration || 0)
+    if (totalDuration > 60) return 'bg-red-50 dark:bg-red-950/20'
+    if (totalDuration > 10) return 'bg-amber-50 dark:bg-amber-950/20'
+    return undefined
+  },
+
+  columns: [
+    'action',
+    'normalized_query',
+    'calls',
+    'total_duration',
+    'avg_duration',
+    'p50_duration',
+    'p95_duration',
+    'p99_duration',
+    'max_duration',
+    'cpu_time',
+    'readable_peak_memory',
+    'readable_read_rows',
+    'readable_read_bytes',
+    'readable_result_rows',
+    'readable_written_bytes',
+    'errors',
+    'cache_hit_ratio',
+    'user',
+    'query_kind',
+    'database',
+  ],
+  columnIcons: {
+    user: UserIcon,
+    query_kind: LayersIcon,
+    database: DatabaseIcon,
+    total_duration: ClockIcon,
+  },
+  columnFormats: {
+    action: [ColumnFormat.Action, ['open-in-explorer', 'analyze-with-ai']],
+    normalized_query: [
+      ColumnFormat.CodeDialog,
+      { max_truncate: 100, hide_query_comment: true },
+    ],
+    calls: [ColumnFormat.BackgroundBar, { numberFormat: true }],
+    total_duration: ColumnFormat.Duration,
+    avg_duration: ColumnFormat.Duration,
+    p50_duration: ColumnFormat.Duration,
+    p95_duration: ColumnFormat.Duration,
+    p99_duration: ColumnFormat.Duration,
+    max_duration: ColumnFormat.Duration,
+    cpu_time: ColumnFormat.Duration,
+    readable_peak_memory: ColumnFormat.BackgroundBar,
+    readable_read_rows: ColumnFormat.BackgroundBar,
+    readable_read_bytes: ColumnFormat.BackgroundBar,
+    readable_result_rows: ColumnFormat.BackgroundBar,
+    readable_written_bytes: ColumnFormat.BackgroundBar,
+    errors: ColumnFormat.Number,
+    cache_hit_ratio: ColumnFormat.BackgroundBar,
+    user: ColumnFormat.ColoredBadge,
+    query_kind: ColumnFormat.ColoredBadge,
+    database: ColumnFormat.Badge,
+  },
+  columnDescriptions: {
+    normalized_query: 'Representative query text for this pattern',
+    calls: 'Number of executions matching this normalized query',
+    total_duration: 'Sum of query_duration_ms across all calls (seconds)',
+    avg_duration: 'Average query_duration_ms per call (seconds)',
+    p50_duration: 'Median query duration (seconds)',
+    p95_duration: '95th percentile query duration (seconds)',
+    p99_duration: '99th percentile query duration (seconds)',
+    max_duration: 'Slowest single execution (seconds)',
+    cpu_time: "Sum of ProfileEvents['OSCPUVirtualTimeMicroseconds'] (seconds)",
+    cache_hit_ratio:
+      'Share of calls served from the query cache (CH 24.1+; 0 on older versions)',
+    errors: 'Count of calls with a non-zero exception_code',
+  },
+}

--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -164,6 +164,15 @@ export const menuItemsConfig: MenuItem[] = [
         tableCheck: 'system.query_log',
       },
       {
+        title: 'Slow Query Patterns',
+        href: '/slow-query-patterns',
+        description:
+          'Normalized query patterns aggregated by hash — calls, duration percentiles, and resource usage per pattern',
+        icon: LayersIcon,
+        docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_log',
+        tableCheck: 'system.query_log',
+      },
+      {
         title: 'Explain',
         href: '/explain',
         description: 'Query execution plan analysis for performance tuning',

--- a/apps/dashboard/src/routes/(dashboard)/slow-query-patterns.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/slow-query-patterns.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { createPage } from '@/lib/create-page'
+import { slowQueryPatternsConfig } from '@/lib/query-config/queries/slow-query-patterns'
+
+const SlowQueryPatternsPage = createPage({
+  queryConfig: slowQueryPatternsConfig,
+  title: 'Slow Query Patterns',
+})
+
+export const Route = createFileRoute('/(dashboard)/slow-query-patterns')({
+  component: SlowQueryPatternsPage,
+})


### PR DESCRIPTION
## Summary
- Adds `slowQueryPatternsConfig` (`apps/dashboard/src/lib/query-config/queries/slow-query-patterns.ts`): aggregates `system.query_log` `GROUP BY normalized_query_hash`, mirroring ClickHouse Cloud's Query Insights "Slow Patterns" table.
- 19 data columns: `normalized_query` (representative, via `any()`), `calls`, `total_duration`/`avg_duration`/`p50_duration`/`p95_duration`/`p99_duration`/`max_duration`, `cpu_time` (`ProfileEvents['OSCPUVirtualTimeMicroseconds']`), peak memory, read rows/bytes, result rows, written bytes, `errors` (`countIf(exception_code != 0)`), `cache_hit_ratio`, plus representative `user`/`query_kind`/`database`.
- Version-aware SQL (`since: '19.1'` / `since: '24.1'`) — `cache_hit_ratio` derives from `query_cache_usage`, which only exists on CH 24.1+; older versions report `0`.
- Sortable by every metric (plain numeric/duration columns); BackgroundBar formatting (with `pct_*` companions) on `calls`, peak memory, read rows/bytes, result rows, written bytes, and `cache_hit_ratio`.
- Filterable by user / query_kind / database (+ time window) via the existing schema-driven `filterSchema` + `FILTER_PLACEHOLDER` mechanism — filters apply to the raw `query_log` rows *before* aggregation, so "filter by user" narrows which executions feed a pattern.
- Registered in `lib/query-config/index.ts`, wired to a new route `src/routes/(dashboard)/slow-query-patterns.tsx` (`createPage` + `PageLayout`, same minimal pattern as `expensive-queries-by-memory.tsx`), and added to `menu.ts` under "Slow Query Patterns".

Closes #2261

## For the rest of the Query Insights epic (#2260, #2262, #2263, #2266)
- Exported config: `slowQueryPatternsConfig` (name: `'slow-query-patterns'`).
- Exported filter schema: `slowQueryPatternsFilterSchema`.
- Stable column names to build on: `normalized_query_hash`, `normalized_query`, `calls`, `total_duration`, `avg_duration`, `p50_duration`, `p95_duration`, `p99_duration`, `max_duration`, `cpu_time`, `peak_memory`/`readable_peak_memory`/`pct_peak_memory`, `read_rows`/`readable_read_rows`/`pct_read_rows`, `read_bytes`/`readable_read_bytes`/`pct_read_bytes`, `result_rows`/`readable_result_rows`/`pct_result_rows`, `written_bytes`/`readable_written_bytes`/`pct_written_bytes`, `errors`, `cache_hit_ratio`/`pct_cache_hit_ratio`, `user`, `query_kind`, `database`.

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run build` (vite build + `tsc --noEmit`, run from `apps/dashboard`) — clean, `/slow-query-patterns` prerenders 200 OK
- [x] `bun run test:query-config` — 1044 pass / 0 fail (includes the corpus-wide `validateSqlQuery` check over every shipped config, which now covers this one)
- [x] `bun run test` — 5724 pass / 0 fail
- [ ] Sanity-check against a live/dockerized ClickHouse (not available in this environment — no Docker daemon running here)