### PR TITLE
feat(platform): add lib/target module for platform detection (PR1 of #2187)

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -54,6 +54,34 @@ module.exports = {
       },
     },
 
+    // ── lib/target must stay a platform-detection leaf (issue #2187) ──────
+    // Orthogonal to deployment-mode (oss|cloud), edition, cloud, and any store.
+    // It only detects the deploy platform and exposes bindings/env — it must
+    // never reach "up" into product/config layers.
+    {
+      name: 'target-module-is-leaf',
+      severity: 'error',
+      comment:
+        'lib/target must not import deployment-mode / edition / cloud / any store — it is a pure platform-detection leaf (issue #2187).',
+      from: { path: '^apps/dashboard/src/lib/target/' },
+      to: {
+        // Match both resolved paths and the raw `@/` alias specifier
+        // (depcruise has no alias resolver configured, so aliased imports keep
+        // their `@/…` source string).
+        path: [
+          '^apps/dashboard/src/lib/cloud/',
+          '^apps/dashboard/src/lib/config/deployment-mode',
+          '^apps/dashboard/src/lib/edition/',
+          '^apps/dashboard/src/lib/stores/',
+          '^@/lib/cloud/',
+          '^@/lib/config/deployment-mode',
+          '^@/lib/edition/',
+          '^@/lib/stores/',
+          '/(zustand|redux|@reduxjs)/',
+        ],
+      },
+    },
+
     // ── @chm/clickhouse-client must not depend on @chm/mcp-server ────────
     {
       name: 'clickhouse-client-layer',

--- a/apps/dashboard/src/lib/platform-native.ts
+++ b/apps/dashboard/src/lib/platform-native.ts
@@ -7,12 +7,21 @@
  * not exist in a TanStack Start worker (and `@opennextjs/cloudflare` is not a
  * dependency here). This shim instead reads bindings straight from the
  * `cloudflare:workers` env — which is the real Worker env on workerd and a
- * `process.env` shim on the Node/Docker build target. D1/Queue access therefore
- * works on Cloudflare and degrades to `null` everywhere else (the conversation
- * store and the inbound event ingest route both fall back to their non-binding
- * path when the binding is absent).
+ * `process.env` shim on the Node/Docker build target. D1/Queue/DO access
+ * therefore works on Cloudflare and degrades to `null` everywhere else (the
+ * conversation store and the inbound event ingest route both fall back to their
+ * non-binding path when the binding is absent).
+ *
+ * As of issue #2187 (PR1) this is a thin re-implementation on top of the unified
+ * deploy-target module (`lib/target`): `getD1Database` / `getDurableObjectNamespace`
+ * delegate to the resolved `target()` adapter, and `getQueue` uses the same
+ * shared binding probe. This is a ZERO-BEHAVIOR-CHANGE refactor — the probe logic
+ * (read the `cloudflare:workers` env, return the value only when it is an object)
+ * is identical to the previous inline implementation on every runtime.
+ * `getDurableObjectNamespace` is a NEW capability added here; existing callers of
+ * `getD1Database` / `getQueue` see the same behavior and return shape.
  */
-import { env } from 'cloudflare:workers'
+import { readBinding, target } from '@/lib/target'
 
 export interface PlatformBindings {
   getD1Database(bindingName: string): D1Database | null
@@ -23,30 +32,29 @@ export interface PlatformBindings {
    * queue configured" and fall back to an inline path rather than throwing.
    */
   getQueue(bindingName: string): Queue | null
+  /**
+   * Get a Durable Object namespace binding by name, or null when unbound.
+   * Added in issue #2187 (PR1) as a new capability on top of `lib/target`.
+   */
+  getDurableObjectNamespace(bindingName: string): DurableObjectNamespace | null
 }
 
 export function getPlatformBindings(): PlatformBindings {
+  const adapter = target()
   return {
     getD1Database(bindingName: string): D1Database | null {
-      const binding = (env as Record<string, unknown> | undefined)?.[
-        bindingName
-      ]
-      // A real D1Database is an object on workerd; on the Node shim the value is
-      // absent or a plain string, so we return null and let callers degrade.
-      return binding && typeof binding === 'object'
-        ? (binding as unknown as D1Database)
-        : null
+      return adapter.d1(bindingName)
     },
+    // Queue is not part of the `TargetAdapter` contract (kept faithful to the
+    // issue's d1/kv/durableObject interface), so use the shared binding probe
+    // directly — identical behavior to the previous inline implementation.
     getQueue(bindingName: string): Queue | null {
-      const binding = (env as Record<string, unknown> | undefined)?.[
-        bindingName
-      ]
-      // A real Queue producer is an object on workerd; absent everywhere else
-      // (no binding declared, Node/Docker target) — return null so callers
-      // degrade to their synchronous inline path.
-      return binding && typeof binding === 'object'
-        ? (binding as unknown as Queue)
-        : null
+      return readBinding<Queue>(bindingName)
+    },
+    getDurableObjectNamespace(
+      bindingName: string
+    ): DurableObjectNamespace | null {
+      return adapter.durableObject(bindingName)
     },
   }
 }

--- a/apps/dashboard/src/lib/target/cloudflare-adapter.ts
+++ b/apps/dashboard/src/lib/target/cloudflare-adapter.ts
@@ -1,0 +1,41 @@
+/**
+ * Cloudflare Workers target adapter (issue #2187, PR1).
+ *
+ * Selected when `VITE_DEPLOY_TARGET === 'cf'`. Bindings and env strings come
+ * from the `cloudflare:workers` `env` via the shared, target-agnostic probes in
+ * `env-access.ts`.
+ */
+import type { EnvSource, TargetAdapter, TargetCapabilities } from './types'
+
+import { readBinding, readTargetEnv } from './env-access'
+
+export class CloudflareAdapter implements TargetAdapter {
+  readonly name = 'cloudflare' as const
+
+  readonly capabilities: TargetCapabilities = {
+    d1: true,
+    kv: true,
+    durableObject: true,
+    queue: true,
+  }
+
+  env(key: string): string | undefined {
+    return readTargetEnv(key)
+  }
+
+  envSource(): EnvSource {
+    return 'cloudflare'
+  }
+
+  d1(bindingName: string): D1Database | null {
+    return readBinding<D1Database>(bindingName)
+  }
+
+  kv(bindingName: string): KVNamespace | null {
+    return readBinding<KVNamespace>(bindingName)
+  }
+
+  durableObject(bindingName: string): DurableObjectNamespace | null {
+    return readBinding<DurableObjectNamespace>(bindingName)
+  }
+}

--- a/apps/dashboard/src/lib/target/env-access.ts
+++ b/apps/dashboard/src/lib/target/env-access.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared, target-agnostic env + binding access for `lib/target` (issue #2187).
+ *
+ * Both adapters delegate binding access here. This is intentional and is what
+ * makes the `getPlatformBindings()` re-implementation a genuine ZERO-BEHAVIOR
+ * CHANGE: the current `lib/platform-native.ts` shim already reads bindings from
+ * the `cloudflare:workers` `env` and returns the value only when it is an
+ * object. That import is build-target-aliased by `vite.config.ts`:
+ *   - workerd build → the real Worker `env` (bindings are objects),
+ *   - Node build    → `cloudflare-workers-shim.ts` (`env` = `process.env`, so
+ *                     bindings are strings/undefined → probe returns `null`),
+ *   - bun test      → the same shim, mocked via the test preload.
+ * So the probe is already independent of `VITE_DEPLOY_TARGET`; keeping it shared
+ * preserves behavior on every runtime (including `vite dev` on workerd, where
+ * `VITE_DEPLOY_TARGET` is unset yet a real D1 binding exists).
+ */
+import { env as workerEnv } from 'cloudflare:workers'
+
+/**
+ * Read an env string: Cloudflare Worker binding `env` first (real bindings
+ * object on workerd; the `process.env` shim on the Node build), then
+ * `process.env`. Empty strings are treated as unset. Never throws.
+ *
+ * Identical to `lib/feature-permissions/server.ts::readEnv` — the single reader
+ * that PR2 will route the ~55 scattered route env reads through.
+ */
+export function readTargetEnv(key: string): string | undefined {
+  try {
+    const fromBinding = (workerEnv as Record<string, string | undefined>)?.[key]
+    if (fromBinding !== undefined && fromBinding !== '') return fromBinding
+  } catch {
+    // cloudflare:workers env not available in this context — fall through.
+  }
+  if (typeof process !== 'undefined' && process.env) {
+    const fromProcess = process.env[key]
+    if (fromProcess !== undefined && fromProcess !== '') return fromProcess
+  }
+  return undefined
+}
+
+/**
+ * Probe a platform binding by name. Returns the binding only when it is a real
+ * object (workerd); on the Node build the aliased `env` yields a string/
+ * undefined, so this returns `null` and callers degrade to their non-binding
+ * path. Matches the exact semantics of the previous `lib/platform-native.ts`.
+ */
+export function readBinding<T>(bindingName: string): T | null {
+  const binding = (workerEnv as Record<string, unknown> | undefined)?.[
+    bindingName
+  ]
+  return binding && typeof binding === 'object' ? (binding as T) : null
+}

--- a/apps/dashboard/src/lib/target/index.ts
+++ b/apps/dashboard/src/lib/target/index.ts
@@ -1,0 +1,51 @@
+/**
+ * Public entry point for the deploy-target module (issue #2187, PR1).
+ *
+ * `target()` returns the process-wide adapter, resolved ONCE from
+ * `VITE_DEPLOY_TARGET` (fail-closed to `node`) and cached. Server-only — the
+ * adapters import `cloudflare:workers`; do not reach this from a client bundle.
+ *
+ * PR1 scope: only `lib/platform-native.ts` consumes this. Later PRs route the
+ * route env reads (PR2) and the version/KV cache (PR3) through it.
+ */
+import type { TargetAdapter, TargetName } from './types'
+
+import { CloudflareAdapter } from './cloudflare-adapter'
+import { NodeAdapter } from './node-adapter'
+import { parseTarget } from './resolve'
+
+let _adapter: TargetAdapter | null = null
+
+function createAdapter(name: TargetName): TargetAdapter {
+  return name === 'cloudflare' ? new CloudflareAdapter() : new NodeAdapter()
+}
+
+/**
+ * The resolved deploy-target adapter for this process. Resolved once from
+ * `import.meta.env.VITE_DEPLOY_TARGET` and cached for the process lifetime.
+ */
+export function target(): TargetAdapter {
+  if (_adapter) return _adapter
+  _adapter = createAdapter(parseTarget(import.meta.env.VITE_DEPLOY_TARGET))
+  return _adapter
+}
+
+/**
+ * Reset the cached adapter — tests only. Lets a test drive `target()` after
+ * swapping the adapter that `parseTarget` would pick (via injection helpers).
+ */
+export function _resetTargetCache(): void {
+  _adapter = null
+}
+
+export type {
+  EnvSource,
+  TargetAdapter,
+  TargetCapabilities,
+  TargetName,
+} from './types'
+
+export { CloudflareAdapter } from './cloudflare-adapter'
+export { readBinding, readTargetEnv } from './env-access'
+export { NodeAdapter } from './node-adapter'
+export { parseTarget } from './resolve'

--- a/apps/dashboard/src/lib/target/node-adapter.ts
+++ b/apps/dashboard/src/lib/target/node-adapter.ts
@@ -1,0 +1,49 @@
+/**
+ * Node / Docker / Kubernetes target adapter (issue #2187, PR1).
+ *
+ * The fail-closed default — selected for every `VITE_DEPLOY_TARGET` that is not
+ * `cf` (including unset/junk). Env strings come from `process.env` (via the
+ * shared reader, which also tolerates the `cloudflare:workers` shim).
+ *
+ * `capabilities` report the platform's PRODUCTION reality: a Node/Docker/K8s
+ * deploy has no Cloudflare bindings. The binding accessors still delegate to the
+ * shared, target-agnostic probe rather than hard-returning `null` — this is
+ * deliberate: it keeps `getPlatformBindings()` byte-for-byte identical to the
+ * previous shim on EVERY runtime, notably `vite dev` (which runs on workerd with
+ * `VITE_DEPLOY_TARGET` unset yet a real D1 binding present). On a genuine Node
+ * build the shimmed `env` holds only strings, so the probe returns `null`.
+ */
+import type { EnvSource, TargetAdapter, TargetCapabilities } from './types'
+
+import { readBinding, readTargetEnv } from './env-access'
+
+export class NodeAdapter implements TargetAdapter {
+  readonly name = 'node' as const
+
+  readonly capabilities: TargetCapabilities = {
+    d1: false,
+    kv: false,
+    durableObject: false,
+    queue: false,
+  }
+
+  env(key: string): string | undefined {
+    return readTargetEnv(key)
+  }
+
+  envSource(): EnvSource {
+    return 'process'
+  }
+
+  d1(bindingName: string): D1Database | null {
+    return readBinding<D1Database>(bindingName)
+  }
+
+  kv(bindingName: string): KVNamespace | null {
+    return readBinding<KVNamespace>(bindingName)
+  }
+
+  durableObject(bindingName: string): DurableObjectNamespace | null {
+    return readBinding<DurableObjectNamespace>(bindingName)
+  }
+}

--- a/apps/dashboard/src/lib/target/resolve.ts
+++ b/apps/dashboard/src/lib/target/resolve.ts
@@ -1,0 +1,18 @@
+/**
+ * Adapter resolution from `VITE_DEPLOY_TARGET` (issue #2187, PR1).
+ *
+ * Fail-closed to `node`: only the exact string `cf` selects Cloudflare;
+ * everything else — `docker`, `helm`, `dev`, `unknown`, empty, whitespace, junk,
+ * `undefined` — resolves to `node`. This NEVER silently assumes Cloudflare from
+ * an unset/garbage value, mirroring `parseCloudMode` / `parseDeploymentMode`.
+ */
+import type { TargetName } from './types'
+
+/**
+ * Pure parse of a raw `VITE_DEPLOY_TARGET` value into a target name. Never
+ * throws. Kept pure (no `import.meta.env` access) so it is directly unit-testable
+ * — `VITE_DEPLOY_TARGET` is build-inlined and cannot be mutated at test runtime.
+ */
+export function parseTarget(value: string | null | undefined): TargetName {
+  return value?.trim().toLowerCase() === 'cf' ? 'cloudflare' : 'node'
+}

--- a/apps/dashboard/src/lib/target/target.test.ts
+++ b/apps/dashboard/src/lib/target/target.test.ts
@@ -1,0 +1,116 @@
+import type { TargetAdapter } from './types'
+
+import { CloudflareAdapter } from './cloudflare-adapter'
+import { _resetTargetCache, target } from './index'
+import { NodeAdapter } from './node-adapter'
+import { parseTarget } from './resolve'
+import { describe, expect, test } from 'bun:test'
+
+describe('parseTarget — fail-closed adapter resolution', () => {
+  test("only 'cf' selects Cloudflare (case/space-insensitive)", () => {
+    expect(parseTarget('cf')).toBe('cloudflare')
+    expect(parseTarget('CF')).toBe('cloudflare')
+    expect(parseTarget('  cf  ')).toBe('cloudflare')
+    expect(parseTarget('Cf')).toBe('cloudflare')
+  })
+
+  test('unset / empty / whitespace fails closed to node', () => {
+    expect(parseTarget(undefined)).toBe('node')
+    expect(parseTarget(null)).toBe('node')
+    expect(parseTarget('')).toBe('node')
+    expect(parseTarget('   ')).toBe('node')
+  })
+
+  test('every other known and junk value fails closed to node', () => {
+    for (const value of [
+      'docker',
+      'helm',
+      'dev',
+      'unknown',
+      'cloudflare', // NOT 'cf' — must not match
+      'true',
+      'CFF',
+      'garbage',
+    ]) {
+      expect(parseTarget(value)).toBe('node')
+    }
+  })
+})
+
+// Compile-time assertion that both classes satisfy TargetAdapter. If either
+// drifts from the interface this file fails to type-check (part of `bun run build`).
+const _cfContract: TargetAdapter = new CloudflareAdapter()
+const _nodeContract: TargetAdapter = new NodeAdapter()
+void _cfContract
+void _nodeContract
+
+describe('CloudflareAdapter contract', () => {
+  const a = new CloudflareAdapter()
+
+  test('identity + capabilities', () => {
+    expect(a.name).toBe('cloudflare')
+    expect(a.envSource()).toBe('cloudflare')
+    expect(a.capabilities).toEqual({
+      d1: true,
+      kv: true,
+      durableObject: true,
+      queue: true,
+    })
+  })
+
+  test('binding accessors return null when no real binding is present', () => {
+    // Under bun test `cloudflare:workers` env is the process.env shim, so a
+    // non-object value probes to null.
+    expect(a.d1('CHM_CLOUD_D1')).toBeNull()
+    expect(a.kv('VERSION_CACHE_KV')).toBeNull()
+    expect(a.durableObject('SOME_DO')).toBeNull()
+  })
+
+  test('env() reads string vars', () => {
+    const key = 'CHM_TARGET_TEST_ENV_CF'
+    process.env[key] = 'hello'
+    expect(a.env(key)).toBe('hello')
+    delete process.env[key]
+    expect(a.env(key)).toBeUndefined()
+  })
+})
+
+describe('NodeAdapter contract', () => {
+  const a = new NodeAdapter()
+
+  test('identity + capabilities (no Cloudflare bindings in production)', () => {
+    expect(a.name).toBe('node')
+    expect(a.envSource()).toBe('process')
+    expect(a.capabilities).toEqual({
+      d1: false,
+      kv: false,
+      durableObject: false,
+      queue: false,
+    })
+  })
+
+  test('binding accessors return null on Node', () => {
+    expect(a.d1('CHM_CLOUD_D1')).toBeNull()
+    expect(a.kv('VERSION_CACHE_KV')).toBeNull()
+    expect(a.durableObject('SOME_DO')).toBeNull()
+  })
+
+  test('env() reads string vars', () => {
+    const key = 'CHM_TARGET_TEST_ENV_NODE'
+    process.env[key] = 'world'
+    expect(a.env(key)).toBe('world')
+    delete process.env[key]
+  })
+})
+
+describe('target() singleton', () => {
+  test('resolves to node under bun test (VITE_DEPLOY_TARGET unset) and caches', () => {
+    _resetTargetCache()
+    const first = target()
+    expect(first.name).toBe('node')
+    // Cached: same instance on repeated calls.
+    expect(target()).toBe(first)
+    _resetTargetCache()
+    expect(target()).not.toBe(first)
+  })
+})

--- a/apps/dashboard/src/lib/target/types.ts
+++ b/apps/dashboard/src/lib/target/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Deploy-target adapter contract (issue #2187, PR1).
+ *
+ * ONE seam for "where is this code running and what platform primitives can it
+ * reach". Consolidates the three previously-disconnected platform seams:
+ *   - `@chm/platform` (D1/DO bindings — aliased to `lib/platform-native.ts`),
+ *   - `lib/feature-permissions/server.ts::readEnv()` (env-string reads), and
+ *   - `lib/version-cache.ts` (the globalThis KV probe).
+ *
+ * The adapter is resolved ONCE at startup from `VITE_DEPLOY_TARGET`
+ * (`lib/target/resolve.ts`), fail-closed to `node` — an unset/junk value NEVER
+ * silently assumes Cloudflare. Mirrors the fail-closed philosophy of
+ * `lib/cloud/cloud-mode.ts` and `lib/config/deployment-mode.ts`.
+ *
+ * DESIGN INVARIANT: this module is orthogonal to deployment-mode (oss|cloud) and
+ * edition. It must not import from `lib/cloud`, `lib/config/deployment-mode`,
+ * `lib/edition`, or any store (enforced by a depcruise leaf rule).
+ *
+ * Cloudflare primitive types (`D1Database`, `KVNamespace`,
+ * `DurableObjectNamespace`) are provided globally by `@cloudflare/workers-types`.
+ */
+
+/** Resolved target platform. */
+export type TargetName = 'cloudflare' | 'node'
+
+/** Where the adapter reads env strings from (advisory metadata). */
+export type EnvSource = 'cloudflare' | 'process'
+
+/**
+ * Static capability flags for the resolved target. Advisory: consumed by later
+ * PRs (e.g. PR4 `selfScheduling`); not wired into binding access, which always
+ * probes safely regardless of these flags.
+ */
+export interface TargetCapabilities {
+  readonly d1: boolean
+  readonly kv: boolean
+  readonly durableObject: boolean
+  readonly queue: boolean
+}
+
+/**
+ * A resolved deploy-target adapter. Binding accessors return `null` when the
+ * binding is absent (self-host / Node / local dev without the binding) — callers
+ * MUST treat `null` as "not configured" and degrade to their non-binding path.
+ */
+export interface TargetAdapter {
+  /** Resolved target name. */
+  readonly name: TargetName
+  /** Read an env string (Worker binding env first, then `process.env`). */
+  env(key: string): string | undefined
+  /** Which env source this adapter prefers. */
+  envSource(): EnvSource
+  /** Get a D1 database binding by name, or `null` when unbound. */
+  d1(bindingName: string): D1Database | null
+  /** Get a KV namespace binding by name, or `null` when unbound. */
+  kv(bindingName: string): KVNamespace | null
+  /** Get a Durable Object namespace binding by name, or `null` when unbound. */
+  durableObject(bindingName: string): DurableObjectNamespace | null
+  /** Static capability flags for this target. */
+  readonly capabilities: TargetCapabilities
+}


### PR DESCRIPTION
## Summary

PR1 (zero-behavior-change foundation) of the deploy-target adapter effort. Consolidates the three previously-disconnected platform-detection seams behind one `apps/dashboard/src/lib/target/` module:

- **`types.ts`** — `TargetAdapter` interface: `name`, `env()`, `envSource()`, `d1()`/`kv()`/`durableObject()`, `capabilities`.
- **`resolve.ts`** — pure `parseTarget(value)` resolving the adapter from `VITE_DEPLOY_TARGET`. **Fail-closed to `node`**: only the exact string `cf` selects Cloudflare; unset/junk/`docker`/`helm`/`dev`/`unknown` all resolve to `node`, never silently assuming Cloudflare. Mirrors `parseCloudMode` / `parseDeploymentMode`.
- **`cloudflare-adapter.ts` / `node-adapter.ts`** — the two `TargetAdapter` implementations.
- **`env-access.ts`** — shared, target-agnostic env + binding probes (the piece that guarantees zero behavior change).
- **`index.ts`** — `target()` accessor (resolved once, cached) + re-exports.

### platform-native re-implementation (zero behavior change)
`lib/platform-native.ts::getPlatformBindings()` is re-implemented on top of `target()`:
- `getD1Database` / `getDurableObjectNamespace` delegate to the resolved adapter; `getQueue` uses the shared binding probe (Queue is intentionally not part of the `d1/kv/durableObject` interface).
- Adds **`getDurableObjectNamespace`** as a new capability.
- Binding access still probes the build-target-aliased `cloudflare:workers` env with the same `typeof === 'object'` guard, so every runtime — Cloudflare, Docker/Node, **and `vite dev` on workerd (where `VITE_DEPLOY_TARGET` is unset yet a real D1 binding exists)** — behaves exactly as before. Existing `getD1Database` / `getQueue` return shapes are unchanged.

### Dependency-cruiser rule
New `target-module-is-leaf` rule forbids `lib/target/**` from importing deployment-mode / edition / cloud / any store. Verified it actually fires for both relative and `@/`-alias imports.

### Tests
`lib/target/target.test.ts`: `parseTarget` fail-closed matrix, both adapters' `TargetAdapter` contract (identity, capabilities, env, null bindings), and singleton caching. 10/10 pass.

No call sites outside `platform-native.ts` were touched.

## Verification
| Command | Result |
|---|---|
| `bun run test` (target module) | ✅ 10/10 pass |
| `bun run test` (full suite) | 5638 pass; 8 fail + 6 errors, **all** from pre-existing missing private deps (`@agentstate/sdk`, `@ai-sdk/mcp`, `@anyr/ai-sdk-provider`, `@polar-sh/sdk`, `@happy-dom`) — none reference `target`/`platform-native` |
| `bun run depcruise` | ✅ green; new leaf rule confirmed firing |
| `tsc --noEmit` | my files type-clean (no error references `lib/target`/`platform-native`) |
| `bun run build` / `build:node` / `cf dry-run` | ⚠️ UNVERIFIED locally — blocked by missing sandbox devDep `@sentry/vite-plugin` (unresolved in `vite.config.ts`); CI is the authoritative gate |

Closes #2187

**Follow-up work remains open (NOT addressed here):** PR2 (route ~55 env reads through `target().env`), PR3 (`version-cache.ts` + `lib/cache` via `target().kv()`), PR4 (`capabilities.selfScheduling` + Helm cronjob). These were tracked on #2187; consider re-filing as fresh issues since `Closes #2187` will close the tracker on merge.