### PR TITLE
feat(insights): add Query Insights overview page

### DIFF
--- a/apps/dashboard/src/components/charts/query-performance/query-insights-cache-hit-ratio.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-cache-hit-ratio.tsx
@@ -1,0 +1,45 @@
+import { createCustomChart } from '@/components/charts/factory'
+import { ProportionList } from '@/components/charts/primitives/proportion-list'
+
+interface CacheHitRatioData {
+  hits: number
+  misses: number
+}
+
+/**
+ * Tile 5 of the Query Insights overview: MarkCache/UncompressedCache hits
+ * vs. misses from `ProfileEvents`. Distinct from the Slow Query Patterns
+ * `cache_hit_ratio` column, which is derived from `query_cache_usage`
+ * (the query result cache, CH 24.1+).
+ */
+export const ChartQueryInsightsCacheHitRatio = createCustomChart({
+  chartName: 'query-insights-cache-hit-ratio',
+  defaultTitle: 'Cache Hit Ratio',
+  defaultLastHours: 24,
+  dataTestId: 'query-insights-cache-hit-ratio-chart',
+  dateRangeConfig: 'query-activity',
+  render: (dataArray) => {
+    const data = dataArray as CacheHitRatioData[]
+    const row = data[0]
+
+    return (
+      <ProportionList
+        items={[
+          {
+            label: 'Hits',
+            value: row?.hits ?? 0,
+            colorClass: 'bg-emerald-500',
+          },
+          {
+            label: 'Misses',
+            value: row?.misses ?? 0,
+            colorClass: 'bg-red-500',
+          },
+        ]}
+        emptyMessage="No cache activity recorded"
+      />
+    )
+  },
+})
+
+export default ChartQueryInsightsCacheHitRatio

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-errors.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-errors.tsx
@@ -1,0 +1,25 @@
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+/** Tile 6 of the Query Insights overview: errors (exception_code != 0) over time. */
+export const ChartQueryInsightsErrors = createAreaChart({
+  chartName: 'query-insights-errors',
+  index: 'event_time',
+  categories: ['errors'],
+  defaultTitle: 'Errors Over Time',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'query-insights-errors-chart',
+  dateRangeConfig: 'query-activity',
+  areaChartProps: {
+    readable: 'number',
+    stack: false,
+    showLegend: false,
+    showXAxis: true,
+    showCartesianGrid: true,
+    colors: ['--chart-orange-600'],
+    yAxisTickFormatter: chartTickFormatters.count,
+  },
+})
+
+export default ChartQueryInsightsErrors

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-latency.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-latency.tsx
@@ -1,0 +1,30 @@
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+/** Tile 2 of the Query Insights overview: mean + p50/p95/p99 duration. */
+export const ChartQueryInsightsLatency = createAreaChart({
+  chartName: 'query-insights-latency',
+  index: 'event_time',
+  categories: [
+    'avg_duration_ms',
+    'p50_duration_ms',
+    'p95_duration_ms',
+    'p99_duration_ms',
+  ],
+  defaultTitle: 'Query Latency',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'query-insights-latency-chart',
+  dateRangeConfig: 'query-activity',
+  areaChartProps: {
+    readable: 'duration',
+    stack: false,
+    showLegend: true,
+    showXAxis: true,
+    showCartesianGrid: true,
+    colors: ['--chart-1', '--chart-2', '--chart-3', '--chart-4'],
+    yAxisTickFormatter: chartTickFormatters.duration,
+  },
+})
+
+export default ChartQueryInsightsLatency

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-operations.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-operations.tsx
@@ -1,0 +1,44 @@
+import { createCustomChart } from '@/components/charts/factory'
+import { ProportionList } from '@/components/charts/primitives/proportion-list'
+
+interface OperationsData {
+  query_kind: string
+  query_count: number
+}
+
+const queryKindColors: Record<string, string> = {
+  Select: 'bg-emerald-500',
+  Insert: 'bg-blue-500',
+  Create: 'bg-indigo-500',
+  Alter: 'bg-amber-500',
+  Drop: 'bg-red-500',
+  Rename: 'bg-purple-500',
+  Optimize: 'bg-cyan-500',
+  System: 'bg-gray-500',
+}
+
+/** Tile 3 of the Query Insights overview: operations breakdown by query_kind. */
+export const ChartQueryInsightsOperations = createCustomChart({
+  chartName: 'query-insights-operations',
+  defaultTitle: 'Operations Breakdown',
+  defaultLastHours: 24,
+  dataTestId: 'query-insights-operations-chart',
+  dateRangeConfig: 'query-activity',
+  render: (dataArray) => {
+    const data = dataArray as OperationsData[]
+
+    return (
+      <ProportionList
+        items={data.map((d, index) => ({
+          label: d.query_kind || 'Unknown',
+          value: d.query_count,
+          colorClass:
+            queryKindColors[d.query_kind] ?? `bg-chart-${(index % 5) + 1}`,
+        }))}
+        emptyMessage="No query operations recorded"
+      />
+    )
+  },
+})
+
+export default ChartQueryInsightsOperations

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-qps.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-qps.tsx
@@ -1,0 +1,25 @@
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+/** Tile 1 of the Query Insights overview: query volume as a rate (QPS). */
+export const ChartQueryInsightsQps = createAreaChart({
+  chartName: 'query-insights-qps',
+  index: 'event_time',
+  categories: ['qps'],
+  defaultTitle: 'Queries / sec',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'query-insights-qps-chart',
+  dateRangeConfig: 'query-activity',
+  areaChartProps: {
+    readable: 'number',
+    stack: false,
+    showLegend: false,
+    showXAxis: true,
+    showCartesianGrid: true,
+    colors: ['--chart-1'],
+    yAxisTickFormatter: chartTickFormatters.count,
+  },
+})
+
+export default ChartQueryInsightsQps

--- a/apps/dashboard/src/components/charts/query-performance/query-insights-rows.tsx
+++ b/apps/dashboard/src/components/charts/query-performance/query-insights-rows.tsx
@@ -1,0 +1,25 @@
+import { createAreaChart } from '@/components/charts/factory'
+import { chartTickFormatters } from '@/lib/utils'
+
+/** Tile 4 of the Query Insights overview: rows read vs. rows returned. */
+export const ChartQueryInsightsRows = createAreaChart({
+  chartName: 'query-insights-rows',
+  index: 'event_time',
+  categories: ['read_rows', 'result_rows'],
+  defaultTitle: 'Rows Read / Returned',
+  defaultInterval: 'toStartOfHour',
+  defaultLastHours: 24,
+  dataTestId: 'query-insights-rows-chart',
+  dateRangeConfig: 'query-activity',
+  areaChartProps: {
+    readable: 'quantity',
+    stack: false,
+    showLegend: true,
+    showXAxis: true,
+    showCartesianGrid: true,
+    colors: ['--chart-blue-300', '--chart-orange-300'],
+    yAxisTickFormatter: chartTickFormatters.count,
+  },
+})
+
+export default ChartQueryInsightsRows

--- a/apps/dashboard/src/components/charts/registry/imports/query-perf-charts.ts
+++ b/apps/dashboard/src/components/charts/registry/imports/query-perf-charts.ts
@@ -35,4 +35,46 @@ export const queryPerfChartImports: ChartRegistryMap = {
       })
     )
   ),
+  'query-insights-qps': lazy(() =>
+    import('@/components/charts/query-performance/query-insights-qps').then(
+      (m) => ({
+        default: m.ChartQueryInsightsQps,
+      })
+    )
+  ),
+  'query-insights-latency': lazy(() =>
+    import('@/components/charts/query-performance/query-insights-latency').then(
+      (m) => ({
+        default: m.ChartQueryInsightsLatency,
+      })
+    )
+  ),
+  'query-insights-operations': lazy(() =>
+    import(
+      '@/components/charts/query-performance/query-insights-operations'
+    ).then((m) => ({
+      default: m.ChartQueryInsightsOperations,
+    }))
+  ),
+  'query-insights-rows': lazy(() =>
+    import('@/components/charts/query-performance/query-insights-rows').then(
+      (m) => ({
+        default: m.ChartQueryInsightsRows,
+      })
+    )
+  ),
+  'query-insights-cache-hit-ratio': lazy(() =>
+    import(
+      '@/components/charts/query-performance/query-insights-cache-hit-ratio'
+    ).then((m) => ({
+      default: m.ChartQueryInsightsCacheHitRatio,
+    }))
+  ),
+  'query-insights-errors': lazy(() =>
+    import('@/components/charts/query-performance/query-insights-errors').then(
+      (m) => ({
+        default: m.ChartQueryInsightsErrors,
+      })
+    )
+  ),
 }

--- a/apps/dashboard/src/components/charts/registry/type-hints.ts
+++ b/apps/dashboard/src/components/charts/registry/type-hints.ts
@@ -26,6 +26,14 @@ export const CHART_TYPE_HINTS: Record<string, ChartSkeletonType> = {
   'query-duration-percentiles': 'area',
   'slow-query-occurrences': 'bar',
 
+  // Query Insights overview (parity with ClickHouse Cloud Query Insights)
+  'query-insights-qps': 'area',
+  'query-insights-latency': 'area',
+  'query-insights-operations': 'bar',
+  'query-insights-rows': 'area',
+  'query-insights-cache-hit-ratio': 'bar',
+  'query-insights-errors': 'area',
+
   // Merge Charts - area and metric
   'merge-count': 'area',
   'summary-used-by-merges': 'table',

--- a/apps/dashboard/src/lib/api/__tests__/charts/query-insights-charts.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/charts/query-insights-charts.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test'
+import { queryInsightsCharts } from '@/lib/api/charts/query-insights-charts'
+
+const defaultParams = { interval: 'toStartOfHour' as const, lastHours: 24 }
+
+describe('queryInsightsCharts', () => {
+  const entries = Object.entries(queryInsightsCharts)
+
+  test('map is non-empty', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  test('known chart names are present', () => {
+    const names = Object.keys(queryInsightsCharts)
+    expect(names).toContain('query-insights-qps')
+    expect(names).toContain('query-insights-latency')
+    expect(names).toContain('query-insights-operations')
+    expect(names).toContain('query-insights-rows')
+    expect(names).toContain('query-insights-cache-hit-ratio')
+    expect(names).toContain('query-insights-errors')
+  })
+
+  test.each(
+    entries
+  )('"%s" builder returns valid, version-aware query result', (_name, builder) => {
+    const result = builder(defaultParams) as any
+
+    expect(result).toHaveProperty('query')
+    expect(typeof result.query).toBe('string')
+    expect(result.query.length).toBeGreaterThan(0)
+    expect(result.query).toMatch(/SELECT/i)
+    expect(result.query).toMatch(/query_log/)
+
+    // Version-aware sql: [{ since, sql }] array per repo convention.
+    expect(Array.isArray(result.sql)).toBe(true)
+    expect(result.sql.length).toBeGreaterThan(0)
+    for (const variant of result.sql) {
+      expect(typeof variant.since).toBe('string')
+      expect(typeof variant.sql).toBe('string')
+      expect(variant.sql).toMatch(/SELECT/i)
+    }
+  })
+
+  test('errors tile filters on exception_code != 0', () => {
+    const result = queryInsightsCharts['query-insights-errors'](
+      defaultParams
+    ) as any
+    expect(result.query).toMatch(/exception_code\s*!=\s*0/)
+  })
+
+  test('cache hit ratio tile reads MarkCache/UncompressedCache ProfileEvents', () => {
+    const result = queryInsightsCharts['query-insights-cache-hit-ratio'](
+      defaultParams
+    ) as any
+    expect(result.query).toMatch(/MarkCacheHits/)
+    expect(result.query).toMatch(/UncompressedCacheHits/)
+  })
+
+  test('operations tile groups by query_kind', () => {
+    const result = queryInsightsCharts['query-insights-operations'](
+      defaultParams
+    ) as any
+    expect(result.query).toMatch(/GROUP BY query_kind/)
+  })
+
+  test('latency tile includes mean and p50/p95/p99', () => {
+    const result = queryInsightsCharts['query-insights-latency'](
+      defaultParams
+    ) as any
+    expect(result.query).toMatch(/avg\(query_duration_ms\)/)
+    expect(result.query).toMatch(/quantile\(0\.50\)/)
+    expect(result.query).toMatch(/quantile\(0\.95\)/)
+    expect(result.query).toMatch(/quantile\(0\.99\)/)
+  })
+})

--- a/apps/dashboard/src/lib/api/chart-registry.ts
+++ b/apps/dashboard/src/lib/api/chart-registry.ts
@@ -27,6 +27,7 @@ import { mergeCharts } from './charts/merge-charts'
 import { overviewCharts } from './charts/overview-charts'
 import { pageViewCharts } from './charts/page-view-charts'
 import { queryCharts } from './charts/query-charts'
+import { queryInsightsCharts } from './charts/query-insights-charts'
 import { queryPerfCharts } from './charts/query-perf-charts'
 import { replicationCharts } from './charts/replication-charts'
 import { securityCharts } from './charts/security-charts'
@@ -153,4 +154,5 @@ registerChartQueries({
   ...dictionaryCharts,
   ...queryPerfCharts,
   ...insightCharts,
+  ...queryInsightsCharts,
 })

--- a/apps/dashboard/src/lib/api/charts/query-insights-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/query-insights-charts.ts
@@ -1,0 +1,137 @@
+/**
+ * Query Insights Overview Charts
+ *
+ * Backs the `/queries/insights` overview grid (parity with ClickHouse
+ * Cloud's Query Insights): QPS, latency percentiles, operations breakdown,
+ * rows read/returned, cache hit ratio, and errors over time — all derived
+ * from `system.query_log`.
+ */
+
+import type { ChartQueryBuilder } from './types'
+
+import { applyInterval, buildTimeFilter, fillStep, nowOrToday } from './types'
+
+/** Bucket width in seconds per interval, used to derive a queries/sec rate. */
+const INTERVAL_SECONDS: Record<string, number> = {
+  toStartOfMinute: 60,
+  toStartOfFiveMinutes: 300,
+  toStartOfTenMinutes: 600,
+  toStartOfFifteenMinutes: 900,
+  toStartOfHour: 3600,
+  toStartOfDay: 86400,
+  toStartOfWeek: 604800,
+  toStartOfMonth: 2629746, // average month length
+}
+
+export const queryInsightsCharts: Record<string, ChartQueryBuilder> = {
+  // Tile 1: Queries / sec — query volume as a rate over the range.
+  'query-insights-qps': ({ interval = 'toStartOfHour', lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    const bucketSeconds = INTERVAL_SECONDS[interval] ?? 3600
+    const query = `
+    SELECT ${applyInterval(interval, 'event_time')},
+           round(COUNT() / ${bucketSeconds}, 3) AS qps
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+          ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY event_time
+    ORDER BY event_time ASC
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+    SETTINGS max_execution_time = 25
+  `
+    return { query, sql: [{ since: '19.1', sql: query }] }
+  },
+
+  // Tile 2: Query latency — mean + p50/p95/p99 on one chart.
+  'query-insights-latency': ({
+    interval = 'toStartOfHour',
+    lastHours = 24,
+  }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    const query = `
+    SELECT ${applyInterval(interval, 'event_time')},
+           round(avg(query_duration_ms), 2) AS avg_duration_ms,
+           round(quantile(0.50)(query_duration_ms), 2) AS p50_duration_ms,
+           round(quantile(0.95)(query_duration_ms), 2) AS p95_duration_ms,
+           round(quantile(0.99)(query_duration_ms), 2) AS p99_duration_ms
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+          ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY event_time
+    ORDER BY event_time ASC
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+    SETTINGS max_execution_time = 25
+  `
+    return { query, sql: [{ since: '19.1', sql: query }] }
+  },
+
+  // Tile 3: Operations breakdown — donut by query_kind (Select/Insert/…).
+  'query-insights-operations': ({ lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    const query = `
+    SELECT
+      query_kind,
+      COUNT() AS query_count,
+      round(100 * query_count / sum(query_count) OVER (), 2) AS percentage
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+          ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY query_kind
+    ORDER BY query_count DESC
+    SETTINGS max_execution_time = 25
+  `
+    return { query, sql: [{ since: '19.1', sql: query }] }
+  },
+
+  // Tile 4: Rows read / returned.
+  'query-insights-rows': ({ interval = 'toStartOfHour', lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    const query = `
+    SELECT ${applyInterval(interval, 'event_time')},
+           sum(read_rows) AS read_rows,
+           sum(result_rows) AS result_rows
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+          ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY event_time
+    ORDER BY event_time ASC
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+    SETTINGS max_execution_time = 25
+  `
+    return { query, sql: [{ since: '19.1', sql: query }] }
+  },
+
+  // Tile 5: Cache hit ratio — ProfileEvents MarkCache/UncompressedCache hits
+  // vs misses (different from `query-cache-usage`, which is the
+  // query-result-cache `query_cache_usage` ratio used on Slow Query Patterns).
+  'query-insights-cache-hit-ratio': ({ lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    const query = `
+    SELECT
+      sum(ProfileEvents['MarkCacheHits']) + sum(ProfileEvents['UncompressedCacheHits']) AS hits,
+      sum(ProfileEvents['MarkCacheMisses']) + sum(ProfileEvents['UncompressedCacheMisses']) AS misses
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+          ${timeFilter ? `AND ${timeFilter}` : ''}
+    SETTINGS max_execution_time = 25
+  `
+    return { query, sql: [{ since: '19.1', sql: query }] }
+  },
+
+  // Tile 6: Errors over time — exception_code != 0.
+  'query-insights-errors': ({ interval = 'toStartOfHour', lastHours = 24 }) => {
+    const timeFilter = buildTimeFilter(lastHours)
+    const query = `
+    SELECT ${applyInterval(interval, 'event_time')},
+           COUNT() AS errors
+    FROM system.query_log
+    WHERE exception_code != 0
+          ${timeFilter ? `AND ${timeFilter}` : ''}
+    GROUP BY event_time
+    ORDER BY event_time ASC
+    WITH FILL TO ${nowOrToday(interval)} STEP ${fillStep(interval)}
+    SETTINGS max_execution_time = 25
+  `
+    return { query, sql: [{ since: '19.1', sql: query }] }
+  },
+}

--- a/apps/dashboard/src/menu.ts
+++ b/apps/dashboard/src/menu.ts
@@ -138,6 +138,16 @@ export const menuItemsConfig: MenuItem[] = [
         tableCheck: 'system.query_log',
       },
       {
+        title: 'Query Insights',
+        href: '/queries/insights',
+        description:
+          'QPS, latency percentiles, operations breakdown, rows read/returned, cache hit ratio, and errors over time',
+        icon: ActivityIcon,
+        isNew: true,
+        docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_log',
+        tableCheck: 'system.query_log',
+      },
+      {
         title: 'Failed Queries',
         href: '/failed-queries',
         description:

--- a/apps/dashboard/src/routes/(dashboard)/queries/insights.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/queries/insights.tsx
@@ -1,0 +1,37 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { ChartQueryInsightsCacheHitRatio } from '@/components/charts/query-performance/query-insights-cache-hit-ratio'
+import { ChartQueryInsightsErrors } from '@/components/charts/query-performance/query-insights-errors'
+import { ChartQueryInsightsLatency } from '@/components/charts/query-performance/query-insights-latency'
+import { ChartQueryInsightsOperations } from '@/components/charts/query-performance/query-insights-operations'
+import { ChartQueryInsightsQps } from '@/components/charts/query-performance/query-insights-qps'
+import { ChartQueryInsightsRows } from '@/components/charts/query-performance/query-insights-rows'
+
+function QueryInsightsPage() {
+  return (
+    <div className="flex flex-col gap-4 sm:gap-4">
+      <div>
+        <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
+          Query Insights
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Query volume, latency, operations, resource usage, cache
+          effectiveness, and errors from system.query_log
+        </p>
+      </div>
+
+      <div className="grid auto-rows-[320px] grid-cols-1 gap-3 lg:grid-cols-2 xl:grid-cols-3">
+        <ChartQueryInsightsQps />
+        <ChartQueryInsightsLatency />
+        <ChartQueryInsightsOperations />
+        <ChartQueryInsightsRows />
+        <ChartQueryInsightsCacheHitRatio />
+        <ChartQueryInsightsErrors />
+      </div>
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/(dashboard)/queries/insights')({
+  component: QueryInsightsPage,
+})


### PR DESCRIPTION
## Summary

Adds a `/queries/insights` overview grid (parity with ClickHouse Cloud's Query Insights) built from `system.query_log`. Six tiles:

1. **Queries / sec** — query volume as a rate over the range
2. **Query latency** — mean + p50/p95/p99 on one chart
3. **Operations breakdown** — donut by `query_kind` (Select/Insert/…)
4. **Rows read / returned** — `read_rows` vs `result_rows`
5. **Cache hit ratio** — `ProfileEvents` MarkCache/UncompressedCache hits vs misses (distinct from Slow Query Patterns' `query_cache_usage`-based ratio)
6. **Errors over time** — `exception_code != 0`

Implementation notes:
- New chart-query builders in `lib/api/charts/query-insights-charts.ts`, registered in `lib/api/chart-registry.ts`, each with a version-aware `sql: [{ since, sql }]` array.
- New chart components under `components/charts/query-performance/query-insights-*.tsx`, using the existing `createAreaChart`/`createCustomChart` factories — so `ChartCard`/`ChartContainer`, the shared `DateRangeSelector`, and graceful stale-error handling are inherited for free.
- `hostId` is resolved via `useHostId()` inside each chart factory (no prop drilling), so `?host` routing works automatically.
- Registered the client-side lazy import + skeleton type hint, and added a "Query Insights" nav entry under Queries in `menu.ts`.
- No `components/ui/*` files touched.

Closes #2260

## Test plan
- [x] `bun run lint` — passes
- [x] `bun run build` (Vite build + `tsc --noEmit`) — passes; `/queries/insights` prerenders successfully
- [x] New unit tests for the 6 chart-query builders (`lib/api/__tests__/charts/query-insights-charts.test.ts`) — 12/12 pass
- [x] `bun run test:query-config` — 1044/1044 pass (no regressions)
- [x] Full `lib/api/__tests__/charts` suite — 317/317 pass