### PR TITLE
perf(auth): skip Clerk verify on the anonymous public-read fast path

### DIFF
--- a/apps/dashboard/src/lib/auth/__tests__/api-guard-public-read-short-circuit.test.ts
+++ b/apps/dashboard/src/lib/auth/__tests__/api-guard-public-read-short-circuit.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression test for #2186: on the anonymous public-read fast path, the
+ * `/api/v1/*` guard (`getApiKeyAuthFailure` / `enforceAuth`) must never invoke
+ * the Clerk provider's `authenticateRequest` — that call does a full JWT
+ * verify (+ cold-start JWKS fetch) that is destined to be discarded anyway,
+ * since `provider === 'clerk' && publicReadEnabled()` always resolves to
+ * "pass" regardless of the caller's actual auth state (see api-guard.ts).
+ *
+ * `@/lib/auth/providers` is mocked at its barrel so we can assert
+ * `resolveServerAuthProvider` — the only entry point to the Clerk provider
+ * used by the guard — is never called when the short-circuit applies, while
+ * confirming it's still consulted (and still gates) everywhere else.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+const resolveServerAuthProviderImpl = mock(() => ({
+  authenticateRequest: mock(async () => ({ authenticated: false })),
+}))
+
+mock.module('@/lib/auth/providers', () => ({
+  resolveServerAuthProvider: resolveServerAuthProviderImpl,
+}))
+
+const { getApiKeyAuthFailure, enforceAuth } = await import('../api-guard')
+
+const ENV_KEYS = [
+  'CHM_AUTH_PROVIDER',
+  'VITE_AUTH_PROVIDER',
+  'CHM_API_KEY_SECRET',
+  'CHM_CLERK_PUBLIC_READ',
+  'CLERK_SECRET_KEY',
+] as const
+
+function apiV1Req(
+  method: 'GET' | 'POST' = 'GET',
+  path = '/api/v1/hosts'
+): Request {
+  return new Request(`https://dash.example.com${path}`, { method })
+}
+
+describe('#2186 public-read short-circuit skips the Clerk provider call', () => {
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k]
+      delete process.env[k]
+    }
+    resolveServerAuthProviderImpl.mockClear()
+  })
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k]
+      else process.env[k] = saved[k]
+    }
+  })
+
+  it('getApiKeyAuthFailure: anonymous read passes WITHOUT calling the provider', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'clerk'
+    process.env.CHM_CLERK_PUBLIC_READ = 'true'
+
+    const result = await getApiKeyAuthFailure(apiV1Req('GET'))
+
+    expect(result).toBeNull()
+    expect(resolveServerAuthProviderImpl).not.toHaveBeenCalled()
+  })
+
+  it('enforceAuth: anonymous read passes WITHOUT calling the provider', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'clerk'
+    process.env.CHM_CLERK_PUBLIC_READ = 'true'
+
+    const result = await enforceAuth(apiV1Req('GET'))
+
+    expect(result).toBeNull()
+    expect(resolveServerAuthProviderImpl).not.toHaveBeenCalled()
+  })
+
+  it('still calls the provider (and still 401s) for clerk WITHOUT public-read', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'clerk'
+    // CHM_CLERK_PUBLIC_READ intentionally unset — private deployment.
+
+    const result = await getApiKeyAuthFailure(apiV1Req('GET'))
+
+    expect(resolveServerAuthProviderImpl).toHaveBeenCalled()
+    expect(result?.status).toBe(401)
+  })
+
+  it('still calls the provider for a clerk WRITE even when public-read is enabled', async () => {
+    // The guard itself is not method-aware — under public-read it passes
+    // every /api/v1/* request, by design, deferring write-vs-read enforcement
+    // entirely to the per-route `authorizeFeatureRequest()` (see
+    // lib/feature-permissions/server.ts: writes never qualify for the
+    // anonymous-read baseline there). This test locks that this guard's
+    // short-circuit doesn't accidentally start distinguishing methods itself,
+    // which would be a behavior change requiring its own review.
+    process.env.CHM_AUTH_PROVIDER = 'clerk'
+    process.env.CHM_CLERK_PUBLIC_READ = 'true'
+
+    const result = await getApiKeyAuthFailure(apiV1Req('POST'))
+
+    expect(result).toBeNull()
+    expect(resolveServerAuthProviderImpl).not.toHaveBeenCalled()
+  })
+})

--- a/apps/dashboard/src/lib/auth/api-guard.ts
+++ b/apps/dashboard/src/lib/auth/api-guard.ts
@@ -150,7 +150,23 @@ export async function getApiKeyAuthFailure(
     // Authorization header may carry a Clerk/proxy token rather than a chm_ key.
   }
 
-  // 2. The active auth provider (clerk session, proxy identity, …). Browser
+  // 2. Opt-in public read-only mode (clerk only): let ALL /api/v1/* requests
+  //    through without ever invoking the Clerk provider, and defer to each
+  //    route's authorizeFeatureRequest() for fine-grained enforcement. Public
+  //    features serve data to anonymous visitors; agent/actions and any write
+  //    are `authenticated`/non-`read` and still 401 at the route (writes never
+  //    qualify for the anonymous baseline there — see
+  //    lib/feature-permissions/server.ts).
+  //
+  //    Checked BEFORE the provider call below: whether or not the caller is
+  //    actually signed in, this guard's outcome is the same (`null` = pass) in
+  //    this config, so verifying the Clerk session here first is pure wasted
+  //    work — a full JWT verify (+ cold-start JWKS fetch) on every anonymous
+  //    read on the highest-volume path (#2186).
+  const provider = getAuthProvider()
+  if (provider === 'clerk' && publicReadEnabled()) return null
+
+  // 3. The active auth provider (clerk session, proxy identity, …). Browser
   //    clients send a Clerk `__session` cookie; proxy deployments send a
   //    Cloudflare Access JWT or a trusted identity header.
   //
@@ -159,7 +175,6 @@ export async function getApiKeyAuthFailure(
   //    `none` + no key), so the API key is the ONLY accepted credential. The
   //    `none` provider authenticates everyone, so consulting it here would let
   //    keyless requests through and silently defeat API-key auth.
-  const provider = getAuthProvider()
   if (
     provider !== 'none' &&
     (await resolveServerAuthProvider(provider).authenticateRequest(request))
@@ -167,11 +182,6 @@ export async function getApiKeyAuthFailure(
   ) {
     return null
   }
-
-  // Opt-in public read-only mode (clerk only): let anonymous requests through
-  // and defer to each route's authorizeFeatureRequest(). Public features serve
-  // data; agent/actions are `authenticated` and still 401 at the route.
-  if (provider === 'clerk' && publicReadEnabled()) return null
 
   return jsonError('Authentication required', 401)
 }
@@ -202,8 +212,14 @@ export async function enforceAuth(request: Request): Promise<Response | null> {
     if (result.valid) return null
   }
 
-  // 2. The active auth provider (clerk session, proxy identity, …).
+  // 2. Opt-in public read-only mode (clerk only) — checked BEFORE the provider
+  //    call below so an anonymous-read config never pays for a Clerk verify
+  //    it doesn't need (#2186); see the matching comment in
+  //    `getApiKeyAuthFailure`.
   const provider = getAuthProvider()
+  if (provider === 'clerk' && publicReadEnabled()) return null
+
+  // 3. The active auth provider (clerk session, proxy identity, …).
   if (
     provider !== 'none' &&
     (await resolveServerAuthProvider(provider).authenticateRequest(request))
@@ -211,9 +227,6 @@ export async function enforceAuth(request: Request): Promise<Response | null> {
   ) {
     return null
   }
-
-  // Opt-in public read-only mode (clerk only).
-  if (provider === 'clerk' && publicReadEnabled()) return null
 
   return jsonError('Authentication required', 401)
 }


### PR DESCRIPTION
## Summary

Closes #2186.

`getApiKeyAuthFailure` / `enforceAuth` in `apps/dashboard/src/lib/auth/api-guard.ts` always called the active auth provider's `authenticateRequest()` (for Clerk: a full JWT verify with a possible cold-start JWKS fetch) *before* checking `publicReadEnabled()`. On a cloud deployment with `CHM_CLERK_PUBLIC_READ=true`, every anonymous `/api/v1/*` read — the highest-volume path — paid for that verification even though the outcome is identical either way.

**Fix:** move the `provider === 'clerk' && publicReadEnabled()` check to run *before* the `resolveServerAuthProvider(provider).authenticateRequest(request)` call, in both `getApiKeyAuthFailure` and `enforceAuth`.

This is a pure reorder, not a logic change: in the `clerk + publicReadEnabled()` config, both branches already returned `null` (pass) — authenticated or not — so moving the check earlier changes *when* the decision is made, not *what* it is. Nothing about who is allowed to do what changes.

## What is NOT touched

- **Write / authenticated-feature gating** lives entirely downstream in `authorizeFeatureRequest()` (`apps/dashboard/src/lib/feature-permissions/server.ts`), which this PR does not modify. It only grants the anonymous baseline for `operation === 'read'` + `state.access === 'public'`; writes and `authenticated`-access features (agent, actions) always fall through to its own `isAuthenticatedRequest()` check. Existing tests lock this: `src/lib/feature-permissions/__tests__/permissions.test.ts`.
- `isAuthenticatedRequest()` in `api-guard.ts` (used to gate exposure of deployment/security metadata, e.g. `/api/health`) is untouched — it deliberately never honors `publicReadEnabled()` (see #1768), and its existing regression tests (`src/lib/auth/__tests__/api-guard.test.ts`) still pass unmodified.
- Non-`clerk` providers (`none`, `proxy`, `trusted`) take the exact same code path as before.

## Code path changed

- `apps/dashboard/src/lib/auth/api-guard.ts` — `getApiKeyAuthFailure()` and `enforceAuth()`.

## Test plan

- [x] `bun run lint` — clean
- [x] `cd apps/dashboard && bun run build` (Vite build + `tsc --noEmit`) — clean
- [x] `cd apps/dashboard && bun run test` (full isolated suite, 5738 tests) — all pass
- [x] Existing `src/lib/auth/__tests__/api-guard.test.ts` (the `isAuthenticatedRequest` / `enforceAuth` #1768 divergence tests) — pass unmodified, proving the metadata-exposure boundary is untouched
- [x] Existing `packages/mcp-server/src/__tests__/http-clerk.test.ts` — pass unmodified (different module, unaffected)
- [x] New `src/lib/auth/__tests__/api-guard-public-read-short-circuit.test.ts`:
  - anonymous read under `clerk` + public-read passes **without** the guard ever calling `resolveServerAuthProvider` (proves the short-circuit)
  - `clerk` **without** public-read still calls the provider and still 401s an anonymous request (proves private deployments are unaffected)
  - documents that this guard is not method-aware by design (writes are still blanket-passed here, exactly as before — the real write gate is `authorizeFeatureRequest`)
- [x] Existing `src/lib/feature-permissions/__tests__/permissions.test.ts` (write-operation classification, public/read-write capability matrix) — pass unmodified