### PR TITLE
perf(api): KV-back the /api/v1/data dashboard-query allowlist cache

### DIFF
--- a/apps/dashboard/src/lib/api/data/dashboard-query-kv-cache.test.ts
+++ b/apps/dashboard/src/lib/api/data/dashboard-query-kv-cache.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for dashboard-query-kv-cache.ts (L2 KV cache for the dashboard-query
+ * allowlist, #2185).
+ *
+ * Core invariant: `getKVCachedDashboardQueries` must return `null` — never
+ * throw, never return an empty/allow-everything value — on any miss, read
+ * error, or absent binding, so callers always fall back to the authoritative
+ * ClickHouse check (fail-closed).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+mock.module('@chm/logger', () => ({
+  error: () => {},
+  warn: () => {},
+  debug: () => {},
+}))
+
+import {
+  getKVCachedDashboardQueries,
+  setKVCachedDashboardQueries,
+} from './dashboard-query-kv-cache'
+
+interface FakeKV {
+  get: (key: string, opts?: unknown) => Promise<unknown>
+  put: (key: string, value: string, opts?: unknown) => Promise<void>
+}
+
+function installKV(kv: FakeKV) {
+  ;(
+    globalThis as unknown as { DASHBOARD_QUERY_KV: FakeKV }
+  ).DASHBOARD_QUERY_KV = kv
+}
+
+function removeKV() {
+  delete (globalThis as unknown as { DASHBOARD_QUERY_KV?: FakeKV })
+    .DASHBOARD_QUERY_KV
+}
+
+beforeEach(() => {
+  removeKV()
+})
+
+afterEach(() => {
+  removeKV()
+})
+
+describe('getKVCachedDashboardQueries', () => {
+  test('returns null when no KV binding is present (self-hosted/Node)', async () => {
+    const result = await getKVCachedDashboardQueries(0)
+    expect(result).toBeNull()
+  })
+
+  test('returns null on a KV miss (get resolves null)', async () => {
+    installKV({ get: async () => null, put: async () => {} })
+    const result = await getKVCachedDashboardQueries(0)
+    expect(result).toBeNull()
+  })
+
+  test('returns null when the KV get() call throws (fail-closed)', async () => {
+    installKV({
+      get: async () => {
+        throw new Error('boom')
+      },
+      put: async () => {},
+    })
+    const result = await getKVCachedDashboardQueries(0)
+    expect(result).toBeNull()
+  })
+
+  test('returns null for a malformed (non-array) cached value', async () => {
+    installKV({ get: async () => ({ not: 'an array' }), put: async () => {} })
+    const result = await getKVCachedDashboardQueries(0)
+    expect(result).toBeNull()
+  })
+
+  test('returns a Set of queries on a well-formed hit', async () => {
+    installKV({
+      get: async () => ['SELECT 1', 'SELECT 2'],
+      put: async () => {},
+    })
+    const result = await getKVCachedDashboardQueries(0)
+    expect(result).toEqual(new Set(['SELECT 1', 'SELECT 2']))
+  })
+
+  test('uses a per-host cache key', async () => {
+    const seenKeys: string[] = []
+    installKV({
+      get: async (key: string) => {
+        seenKeys.push(key)
+        return null
+      },
+      put: async () => {},
+    })
+    await getKVCachedDashboardQueries(5)
+    expect(seenKeys).toEqual(['dashboard-queries:5'])
+  })
+})
+
+describe('setKVCachedDashboardQueries', () => {
+  test('is a no-op when no KV binding is present', async () => {
+    // Must not throw even though there is no binding to write to.
+    await expect(
+      setKVCachedDashboardQueries(0, new Set(['q']))
+    ).resolves.toBeUndefined()
+  })
+
+  test('writes the serialized query set with an expirationTtl', async () => {
+    let putArgs: [string, string, unknown] | undefined
+    installKV({
+      get: async () => null,
+      put: async (key: string, value: string, opts?: unknown) => {
+        putArgs = [key, value, opts]
+      },
+    })
+
+    await setKVCachedDashboardQueries(3, new Set(['SELECT 1']))
+
+    expect(putArgs).toBeDefined()
+    expect(putArgs![0]).toBe('dashboard-queries:3')
+    expect(JSON.parse(putArgs![1])).toEqual(['SELECT 1'])
+    expect(
+      (putArgs![2] as { expirationTtl: number }).expirationTtl
+    ).toBeGreaterThan(0)
+  })
+
+  test('swallows a KV put() error without throwing', async () => {
+    installKV({
+      get: async () => null,
+      put: async () => {
+        throw new Error('write failed')
+      },
+    })
+
+    await expect(
+      setKVCachedDashboardQueries(0, new Set(['q']))
+    ).resolves.toBeUndefined()
+  })
+})

--- a/apps/dashboard/src/lib/api/data/dashboard-query-kv-cache.ts
+++ b/apps/dashboard/src/lib/api/data/dashboard-query-kv-cache.ts
@@ -1,0 +1,106 @@
+/**
+ * Dashboard Query KV Cache (L2)
+ *
+ * Backs the in-memory per-isolate allowlist cache (`cache-manager.ts`, L1)
+ * with an optional Cloudflare Workers KV layer that survives isolate churn
+ * (cold starts, isolate eviction). Zero-config, same pattern as
+ * `lib/version-cache.ts`'s `VERSION_CACHE_KV`: the code auto-detects the
+ * `DASHBOARD_QUERY_KV` binding via `globalThis` and is a silent no-op when
+ * it's absent — self-hosted Docker/K8s deploys (no Cloudflare KV) are
+ * unaffected and keep working exactly as before.
+ *
+ * SECURITY (fail-closed): a KV miss, a KV read error, or a missing binding
+ * ALWAYS returns `null`/no-op. Callers must treat that as "no cached
+ * answer" and fall through to the authoritative ClickHouse allowlist query
+ * in `dashboard-query-validator.ts` — never as permission to allow a query.
+ * This module only ever *shortcuts an allow* on a positive, well-formed
+ * cache hit; it never shortcuts a reject.
+ *
+ * @module lib/api/data/dashboard-query-kv-cache
+ */
+
+import { debug, warn } from '@chm/logger'
+
+/** Minimal Cloudflare KV Namespace surface used here. */
+interface KVNamespace {
+  get(
+    key: string,
+    options?: { type?: 'text' | 'json' | 'arrayBuffer' | 'stream' }
+  ): Promise<unknown>
+  put(
+    key: string,
+    value: string,
+    options?: { expirationTtl?: number }
+  ): Promise<void>
+}
+
+/** KV entry TTL: 15 minutes (longer than the 5-min in-memory L1, since KV
+ * already survives isolate churn — this just bounds allowlist staleness). */
+const KV_TTL_SECONDS = 15 * 60
+
+function getKeyName(hostId: number): string {
+  return `dashboard-queries:${hostId}`
+}
+
+/** Resolve the `DASHBOARD_QUERY_KV` binding if the runtime provides one. */
+function getKV(): KVNamespace | undefined {
+  if (typeof globalThis !== 'undefined' && 'DASHBOARD_QUERY_KV' in globalThis) {
+    return (globalThis as unknown as { DASHBOARD_QUERY_KV: KVNamespace })
+      .DASHBOARD_QUERY_KV
+  }
+  return undefined
+}
+
+/**
+ * Read the cached dashboard query allowlist for a host from KV.
+ *
+ * @returns The cached `Set` of queries, or `null` on any miss/error/absent
+ * binding. `null` MUST be treated as "unknown" (fall through to the
+ * authoritative ClickHouse check), never as "allowed" or "denied".
+ */
+export async function getKVCachedDashboardQueries(
+  hostId: number
+): Promise<Set<string> | null> {
+  const kv = getKV()
+  if (!kv) return null
+
+  try {
+    const value = await kv.get(getKeyName(hostId), { type: 'json' })
+    if (!Array.isArray(value)) return null
+
+    debug(`[dashboard-query-kv-cache] KV cache hit for host ${hostId}`)
+    return new Set(value as string[])
+  } catch (err) {
+    // Fail closed: a KV read error is a cache miss, not an allow.
+    warn(
+      '[dashboard-query-kv-cache] KV get error (treated as cache miss):',
+      err
+    )
+    return null
+  }
+}
+
+/**
+ * Write-through the freshly validated allowlist to KV. Best-effort: a write
+ * failure is logged and swallowed — the caller already has its answer from
+ * the authoritative ClickHouse query, so a KV write failure must never
+ * affect the current request's result.
+ */
+export async function setKVCachedDashboardQueries(
+  hostId: number,
+  queries: Set<string>
+): Promise<void> {
+  const kv = getKV()
+  if (!kv) return
+
+  try {
+    await kv.put(getKeyName(hostId), JSON.stringify(Array.from(queries)), {
+      expirationTtl: KV_TTL_SECONDS,
+    })
+    debug(
+      `[dashboard-query-kv-cache] KV cached ${queries.size} queries for host ${hostId}`
+    )
+  } catch (err) {
+    warn('[dashboard-query-kv-cache] KV put error (non-fatal):', err)
+  }
+}

--- a/apps/dashboard/src/lib/api/data/dashboard-query-validator.test.ts
+++ b/apps/dashboard/src/lib/api/data/dashboard-query-validator.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for dashboard-query-validator.ts — specifically the KV (L2) cache
+ * layer added in #2185 on top of the existing in-memory (L1) cache.
+ *
+ * The single invariant under test: a KV miss, a KV read error, or a missing
+ * `DASHBOARD_QUERY_KV` binding (self-hosted/Node) must NEVER be treated as
+ * "allow" — it must always fall through to the authoritative ClickHouse
+ * allowlist query, preserving the fail-closed behavior of the validator.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from 'bun:test'
+
+// ── Stub external I/O before importing the module under test. ─────────────
+
+type FetchDataResult = {
+  data?: Array<{ query: string }>
+  error?: unknown
+}
+
+let fetchDataImpl: (...args: unknown[]) => Promise<FetchDataResult> =
+  async () => ({ data: [], error: null })
+let fetchDataCallCount = 0
+
+mock.module('@chm/clickhouse-client', () => ({
+  fetchData: (...args: unknown[]) => {
+    fetchDataCallCount++
+    return fetchDataImpl(...args)
+  },
+}))
+
+mock.module('@chm/logger', () => ({
+  error: () => {},
+  warn: () => {},
+  debug: () => {},
+}))
+
+mock.module('@/lib/app-tables', () => ({
+  DASHBOARD_CHARTS_TABLE: 'clickhouse_monitoring_custom_dashboard',
+}))
+
+// ── Import AFTER mocks are registered ──────────────────────────────────────
+
+import { clearHostCache } from './cache-manager'
+import { validateDashboardQuery } from './dashboard-query-validator'
+
+// Fake KV namespace installed on globalThis to simulate the Cloudflare
+// binding. `getKV()` (dashboard-query-kv-cache.ts) auto-detects it there.
+interface FakeKV {
+  get: (key: string, opts?: unknown) => Promise<unknown>
+  put: (key: string, value: string, opts?: unknown) => Promise<void>
+}
+
+function installKV(kv: FakeKV) {
+  ;(
+    globalThis as unknown as { DASHBOARD_QUERY_KV: FakeKV }
+  ).DASHBOARD_QUERY_KV = kv
+}
+
+function removeKV() {
+  delete (globalThis as unknown as { DASHBOARD_QUERY_KV?: FakeKV })
+    .DASHBOARD_QUERY_KV
+}
+
+let hostCounter = 1000
+function nextHost(): number {
+  // Distinct hostId per test avoids cross-test pollution of the module-level
+  // in-memory L1 cache (cache-manager.ts) between assertions.
+  hostCounter++
+  return hostCounter
+}
+
+// `cache-manager.ts` (the L1 in-memory cache) is a module-level singleton
+// shared with `cache-manager.test.ts`, which drives it via a fixed fake
+// epoch starting at 1_700_000_000_000. Pin the clock here to a fixed point
+// safely below that (well outside its TTL window) for the whole file so
+// `validateDashboardQuery`'s L1 writes never leave a real wall-clock
+// timestamp behind that could desync that other suite's TTL-expiry math,
+// regardless of which test file bun runs first.
+const FAKE_NOW = 1_600_000_000_000
+
+beforeAll(() => {
+  setSystemTime(FAKE_NOW)
+})
+
+afterAll(() => {
+  setSystemTime() // restore the real clock
+})
+
+beforeEach(() => {
+  fetchDataCallCount = 0
+  fetchDataImpl = async () => ({ data: [], error: null })
+})
+
+afterEach(() => {
+  removeKV()
+})
+
+describe('validateDashboardQuery — KV (L2) cache, fail-closed semantics', () => {
+  test('KV cache hit containing the query short-circuits without querying ClickHouse', async () => {
+    const hostId = nextHost()
+    const query = 'SELECT count() FROM system.tables'
+
+    installKV({
+      get: async () => [query],
+      put: async () => {},
+    })
+    fetchDataImpl = async () => {
+      throw new Error('fetchData must not be called on a KV hit')
+    }
+
+    const result = await validateDashboardQuery(query, hostId)
+
+    expect(result.valid).toBe(true)
+    expect(fetchDataCallCount).toBe(0)
+  })
+
+  test('fail-closed: KV get() throwing falls through to ClickHouse, and rejects when the table is inaccessible', async () => {
+    const hostId = nextHost()
+    const query = 'SELECT count() FROM system.tables'
+
+    installKV({
+      get: async () => {
+        throw new Error('KV is unavailable')
+      },
+      put: async () => {},
+    })
+    fetchDataImpl = async () => ({
+      data: [],
+      error: 'Table does not exist',
+    })
+
+    const result = await validateDashboardQuery(query, hostId)
+
+    // The KV failure must NOT be treated as an allow — the authoritative
+    // ClickHouse check ran and (because the table errored) the request is
+    // rejected, exactly as it would be with no KV layer at all.
+    expect(result.valid).toBe(false)
+    expect(result.error?.type).toBe('permission_error')
+    expect(fetchDataCallCount).toBe(1)
+  })
+
+  test('fail-closed: KV miss (null) falls through to ClickHouse, and rejects when the query is not allow-listed', async () => {
+    const hostId = nextHost()
+    const query = 'SELECT count() FROM system.tables'
+
+    installKV({
+      get: async () => null,
+      put: async () => {},
+    })
+    fetchDataImpl = async () => ({
+      data: [{ query: 'SELECT 1' }], // allow-list exists, but not our query
+      error: null,
+    })
+
+    const result = await validateDashboardQuery(query, hostId)
+
+    expect(result.valid).toBe(false)
+    expect(result.error?.type).toBe('permission_error')
+    expect(fetchDataCallCount).toBe(1)
+  })
+
+  test('fail-closed: KV snapshot present but missing this query falls through and can still be rejected', async () => {
+    const hostId = nextHost()
+    const query = 'SELECT count() FROM system.tables'
+
+    installKV({
+      get: async () => ['SELECT 1', 'SELECT 2'], // stale snapshot, no match
+      put: async () => {},
+    })
+    fetchDataImpl = async () => ({
+      data: [{ query: 'SELECT 1' }, { query: 'SELECT 2' }], // still not allow-listed
+      error: null,
+    })
+
+    const result = await validateDashboardQuery(query, hostId)
+
+    expect(result.valid).toBe(false)
+    expect(fetchDataCallCount).toBe(1)
+  })
+
+  test('no KV binding (self-hosted/Node): behaves exactly like the pre-existing in-memory-only path', async () => {
+    const hostId = nextHost()
+    const query = 'SELECT count() FROM system.tables'
+
+    removeKV()
+    fetchDataImpl = async () => ({
+      data: [{ query }],
+      error: null,
+    })
+
+    const result = await validateDashboardQuery(query, hostId)
+
+    expect(result.valid).toBe(true)
+    expect(fetchDataCallCount).toBe(1)
+  })
+
+  test('a successful ClickHouse validation writes through to KV', async () => {
+    const hostId = nextHost()
+    const query = 'SELECT count() FROM system.tables'
+    const putCalls: Array<{ key: string; value: string }> = []
+
+    installKV({
+      get: async () => null,
+      put: async (key: string, value: string) => {
+        putCalls.push({ key, value })
+      },
+    })
+    fetchDataImpl = async () => ({
+      data: [{ query }],
+      error: null,
+    })
+
+    const result = await validateDashboardQuery(query, hostId)
+
+    expect(result.valid).toBe(true)
+    expect(putCalls).toHaveLength(1)
+    expect(putCalls[0]!.key).toBe(`dashboard-queries:${hostId}`)
+    expect(JSON.parse(putCalls[0]!.value)).toContain(query)
+  })
+
+  test('an unexpected error during KV write-through does not fail the (already-valid) request', async () => {
+    const hostId = nextHost()
+    const query = 'SELECT count() FROM system.tables'
+
+    installKV({
+      get: async () => null,
+      put: async () => {
+        throw new Error('KV put failed')
+      },
+    })
+    fetchDataImpl = async () => ({
+      data: [{ query }],
+      error: null,
+    })
+
+    const result = await validateDashboardQuery(query, hostId)
+
+    expect(result.valid).toBe(true)
+  })
+})
+
+describe('validateDashboardQuery — L1 in-memory cache still short-circuits (regression guard)', () => {
+  test('a query already cached in L1 never touches KV or ClickHouse', async () => {
+    const hostId = nextHost()
+    const query = 'SELECT count() FROM system.tables'
+
+    let kvGetCallCount = 0
+    installKV({
+      get: async () => {
+        kvGetCallCount++
+        return null // cold KV too, first call falls through to ClickHouse
+      },
+      put: async () => {},
+    })
+    fetchDataImpl = async () => ({
+      data: [{ query }],
+      error: null,
+    })
+
+    // Warm L1 via a first successful validation (this call does consult KV).
+    const first = await validateDashboardQuery(query, hostId)
+    expect(first.valid).toBe(true)
+    expect(fetchDataCallCount).toBe(1)
+    expect(kvGetCallCount).toBe(1)
+
+    // Second call must hit L1 only — no KV, no ClickHouse.
+    const second = await validateDashboardQuery(query, hostId)
+    expect(second.valid).toBe(true)
+    expect(fetchDataCallCount).toBe(1)
+    expect(kvGetCallCount).toBe(1)
+
+    clearHostCache(hostId)
+  })
+})

--- a/apps/dashboard/src/lib/api/data/dashboard-query-validator.ts
+++ b/apps/dashboard/src/lib/api/data/dashboard-query-validator.ts
@@ -15,6 +15,10 @@
  */
 
 import { getCachedDashboardQueries } from './cache-manager'
+import {
+  getKVCachedDashboardQueries,
+  setKVCachedDashboardQueries,
+} from './dashboard-query-kv-cache'
 import { fetchData } from '@chm/clickhouse-client'
 import { error } from '@chm/logger'
 import { DASHBOARD_CHARTS_TABLE } from '@/lib/app-tables'
@@ -57,10 +61,26 @@ export async function validateDashboardQuery(
   hostId: number
 ): Promise<DashboardQueryValidationResult> {
   try {
-    // Check cache first to avoid repeated database queries
+    // Check the in-memory L1 cache first to avoid repeated database queries
     const cachedQueries = getCachedDashboardQueries(hostId)
     if (cachedQueries?.has(query)) {
       return { valid: true }
+    }
+
+    // L2: Cloudflare KV cache — survives Worker isolate churn (cold starts,
+    // L1 TTL expiry). A miss/error/absent-binding here is NOT a security
+    // decision: it always falls through to the authoritative ClickHouse
+    // lookup below, so fail-closed semantics hold regardless of KV state.
+    const kvCachedQueries = await getKVCachedDashboardQueries(hostId)
+    if (kvCachedQueries) {
+      // Warm L1 from L2 so subsequent requests on this isolate skip KV too.
+      const { updateDashboardQueryCache } = await import('./cache-manager')
+      updateDashboardQueryCache(hostId, kvCachedQueries)
+      if (kvCachedQueries.has(query)) {
+        return { valid: true }
+      }
+      // Not found in the KV snapshot — fall through to the authoritative
+      // ClickHouse check below (the allowlist may have changed since caching).
     }
 
     // Query the dashboard table to verify this query exists
@@ -89,9 +109,10 @@ export async function validateDashboardQuery(
       queries.add(row.query)
     }
 
-    // Update cache with new queries
+    // Update caches with the freshly validated allowlist (L1 in-memory + L2 KV)
     const { updateDashboardQueryCache } = await import('./cache-manager')
     updateDashboardQueryCache(hostId, queries)
+    await setKVCachedDashboardQueries(hostId, queries)
 
     // Check if the query exists in the table
     if (!queries.has(query)) {

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -22,6 +22,19 @@ database_name = "chm-cloud"
 database_id = "cca247b6-9b25-41bd-b9ca-727b35bc6039"
 migrations_dir = "./src/db/conversations-migrations"
 
+# KV cache for the /api/v1/data dashboard-query allowlist (issue #2185). Backs
+# the in-memory L1 (cache-manager.ts, 5-min TTL) with an L2 that survives
+# Worker isolate churn on cold starts. Optional/zero-config: code auto-detects
+# this binding (see lib/api/data/dashboard-query-kv-cache.ts, same pattern as
+# lib/version-cache.ts's VERSION_CACHE_KV) and falls back to in-memory-only
+# when absent, so self-hosted/Docker/K8s deploys (no KV binding) are unaffected.
+# A KV miss or read error is always treated as a cache miss (fail-closed) —
+# never as an implicit allow.
+[[kv_namespaces]]
+binding = "DASHBOARD_QUERY_KV"
+id = "98b43d2d6fcf438cbd91e18e38b4212d"
+preview_id = "44390b843ada46d8beb47c99bcf24115"
+
 # Durable Object migrations.
 # The legacy Next.js worker (same name, chmonitor-dash) registered two SQLite
 # Durable Objects: DOQueueHandler (OpenNext queue) and AgentConversationDurableObject
@@ -155,6 +168,14 @@ binding = "CHM_CLOUD_D1"
 database_name = "chm-cloud"
 database_id = "cca247b6-9b25-41bd-b9ca-727b35bc6039"
 migrations_dir = "./src/db/conversations-migrations"
+
+# Reuse the same dashboard-query allowlist KV namespace (shared preview/prod
+# for now, same pattern as CHM_CLOUD_D1 above). Cached entries are non-secret
+# (they mirror rows already readable from the dashboard's own charts table).
+[[env.preview.kv_namespaces]]
+binding = "DASHBOARD_QUERY_KV"
+id = "98b43d2d6fcf438cbd91e18e38b4212d"
+preview_id = "44390b843ada46d8beb47c99bcf24115"
 
 # DO migrations are not inherited by named environments — repeat the chain that
 # drops the legacy preview worker's Durable Objects (see top-level note).


### PR DESCRIPTION
## Summary

- Backs the per-isolate 5-minute in-memory allowlist cache (`dashboard-query-validator.ts` / `cache-manager.ts`) with a Cloudflare KV L2 (`DASHBOARD_QUERY_KV`) so cold Worker isolates and post-TTL requests no longer pay a serial ClickHouse round-trip before the real `/api/v1/data` query runs.
- Zero-config, same pattern as `lib/version-cache.ts`'s `VERSION_CACHE_KV`: the code auto-detects the `DASHBOARD_QUERY_KV` binding via `globalThis` and is a silent no-op when absent, so self-hosted Docker/K8s deploys (no Cloudflare KV) are unaffected and behave exactly as before.
- Provisioned the actual `DASHBOARD_QUERY_KV` namespace (prod + preview ids) and wired the binding into `wrangler.toml` (top-level worker + `[env.preview]`, reusing the same namespace id for now — same "shared preview/prod" pattern already used for `CHM_CLOUD_D1`).

## Security — fail-closed semantics preserved

This is the single most important invariant of the change: **a KV miss, a KV read error, or a missing binding must never be treated as an allow.**

- `getKVCachedDashboardQueries` (`dashboard-query-kv-cache.ts`) returns `null` on any miss/error/absent-binding — callers must (and do) treat `null` as "unknown", not "allowed".
- In `validateDashboardQuery`, a KV lookup only ever *shortcuts an allow* on a positive, well-formed cache hit that contains the exact query string. Any other outcome (miss, error, stale snapshot without the query) falls straight through to the existing authoritative `SELECT query FROM <table>` ClickHouse check, unchanged.
- `setKVCachedDashboardQueries` write-through is best-effort: a write failure is logged and swallowed, never affecting the current request's (already-determined) result.

## Test plan

- [x] `bun test src/lib/api/data src/routes/api/v1/data` — 39 + 8 tests pass, including the pre-existing structural `sql-validation.test.ts` / `readonly.test.ts`.
- [x] New `dashboard-query-kv-cache.test.ts` — unit tests for the KV adapter (miss/error/malformed-value/absent-binding all resolve to `null`; put swallows errors).
- [x] New `dashboard-query-validator.test.ts`, including the required fail-closed assertions:
  - KV `get()` throwing still falls through to ClickHouse and rejects when the table errors (`fetchDataCallCount` = 1, `result.valid === false`).
  - KV miss (`null`) or a stale KV snapshot missing the query still falls through and rejects when ClickHouse says the query isn't allow-listed.
  - No KV binding (self-hosted) behaves identically to the pre-existing in-memory-only path.
  - A KV hit *containing* the query short-circuits without calling ClickHouse (the actual perf win).
  - A successful ClickHouse validation writes through to KV; a KV write failure doesn't fail the request.
  - Regression guard: the existing in-memory L1 cache still short-circuits before KV/ClickHouse are consulted.
- [x] `bun run lint` — clean.
- [x] `bun run build` (`vite build && tsc --noEmit` in `apps/dashboard`) — clean, prerenders all 105 static pages.
- [x] Full `bun test` run confirmed identical to `main` (174 pre-existing unrelated failures/27 errors on both, from `URL is not defined` / other environment issues in this worktree — verified via `git stash`).

Closes #2185